### PR TITLE
feat: unify discovery and concept evidence flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,13 @@
 > - LLM 是程序员 —— AutoPilot 自动完成编译、链接、维护
 > - Wiki 是代码库 —— 持续编译、自动维护的结构化知识
 
+## 当前平台边界
+
+- 当前内置标准 pack 是 `default-knowledge`
+- 主流程可显式选择 `--pack default-knowledge --profile full`
+- AutoPilot 可显式选择 `--pack default-knowledge --profile autopilot`
+- 第三方领域包通过 Pack API 接入，文档见 `docs/pack-api/`
+
 ---
 schema_version: "1.0.0"
 note_id: claude-0db92ed6
@@ -159,7 +166,7 @@ ovp --full
 
 # 或分步执行
 ovp --step articles       # L1 → L2: 生成深度解读
-ovp-evergreen --recent 7  # L2 → L3: 提取 Evergreen
+ovp-absorb --recent 7     # L2 → L3: 提取/吸收 Evergreen 生命周期动作
 ovp-moc --scan           # 更新 MOC 索引
 ```
 
@@ -175,9 +182,10 @@ mv article.md 50-Inbox/01-Raw/
 # 全自动发生:
 # 1. 检测新文件 → 加入队列
 # 2. 生成深度解读 (6维度质量评分)
-# 3. 质量达标 → 提取 Evergreen
+# 3. 质量达标 → absorb
 # 4. 更新 MOC
-# 5. 自动 git commit
+# 5. 刷新 knowledge.db
+# 6. 自动 git commit
 ```
 
 ### 3.3 完整数据流
@@ -190,7 +198,7 @@ ovp-article --process     # L1 → L2
 20-Areas/AI-Research/     # L2: 深度解读
 Topics/2026-04/
     ↓
-ovp-evergreen --recent 7  # L2 → L3
+ovp-absorb --recent 7     # L2 → L3
     ↓
 10-Knowledge/Evergreen/   # L3: 原子概念
     ↓

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -437,25 +437,24 @@ Ingest → Query → Output → 回写 wiki → 下次 Query 可用
 处理后: ![图](attachments/2026-04/img-hash.png)
 ```
 
-### 7.2 可选：qmd 搜索引擎
+### 7.2 可选：QMD 外部发现适配器
 
-对于大型 wiki，建议使用 [qmd](https://github.com/jzaki/qmd) 作为本地搜索引擎：
-- 混合 BM25/向量搜索
-- LLM 重排序
-- 支持 CLI 和 MCP Server
+当前默认 discovery 已经统一到 `knowledge.db`：
+- `ovp-query` 默认走 `knowledge.db`
+- 关键词检索使用 FTS5 BM25
+- 语义检索使用本地 deterministic embeddings
+
+QMD 现在只是**显式可选**的外部发现适配器，不再是默认 runtime 依赖，也不会参与自动链接或 canonical identity 决策。
 
 ```bash
-# 安装 qmd
-pip install qmd
+# 默认：knowledge.db
+ovp-query "AI Agent 架构"
 
-# 索引知识库
-qmd index /path/to/vault
-
-# 搜索
-qmd search "AI Agent 架构"
+# 显式改用 qmd
+ovp-query --engine qmd "AI Agent 架构"
 ```
 
-使用 qmd 时，在 `ovp-query` 中添加 `--search-engine qmd` 参数。
+如果需要保留 QMD 做人工探索或对照检索，可以单独安装并维护它，但不要把 QMD 结果当成自动 link resolution 的依据。
 
 ```bash
 # .env

--- a/README.md
+++ b/README.md
@@ -40,6 +40,121 @@ Ingest → Interpret → Absorb → Refine → Canonical → Derived
 - `ovp-autopilot` 默认实时跑 `absorb -> moc -> knowledge_index`
 - `ovp-autopilot --with-refine` 会在实时链路里追加 `refine`
 
+## 为什么会变成现在这套架构
+
+这个项目最早是围绕 Obsidian Vault 的自动化整理脚本发展起来的，但随着能力增加，出现了三个典型问题：
+
+- 运行时主流程和单个脚本各自演化，难以保证契约一致
+- 概念、链接、Atlas、graph、检索索引彼此耦合，但真相边界不清楚
+- 一旦要支持媒体、医疗、工程研究这类不同领域，原来的 concept-only 模型会失真
+
+现在这套设计的目标就是把这些问题拆开：
+
+- 用六层运行模型明确“什么是编排层、什么是真相层、什么是派生层”
+- 用 `default-knowledge` 固化当前默认领域，而不是把它散落在 core 里
+- 用 Pack API 让不同领域通过 pack 接入，而不是继续往 core 里硬编码特例
+
+这意味着当前仓库已经不只是一个 Vault 自动化项目，而是一个：
+
+> 面向 Obsidian/Vault 工作流的可扩展知识编排平台
+
+其中 `default-knowledge` 是第一个内置标准 pack，不是唯一领域模型。
+
+## Domain Packs
+
+当前 core 已经开始 pack 化。
+
+- 内置标准 pack：`default-knowledge`
+- 运行时可通过 `--pack` 和 `--profile` 选择 workflow
+- 第三方 pack 可以通过 `openclaw_pipeline.packs` entry point 或 `OPENCLAW_PACK_MANIFESTS` manifest 列表接入
+
+示例：
+
+```bash
+ovp --pack default-knowledge --profile full
+ovp-autopilot --pack default-knowledge --profile autopilot --yes
+```
+
+面向第三方 pack 作者的 API 文档在：
+
+- `docs/pack-api/README.md`
+- `docs/pack-api/manifest-and-hooks.md`
+- `docs/pack-api/dogfooding-with-media-pack.md`
+
+## 平台架构
+
+从平台视角看，当前系统分成三层：
+
+1. **Core Platform**
+2. **Domain Pack**
+3. **Workflow Profile**
+
+### 1. Core Platform
+
+core 负责通用且必须稳定的部分：
+
+- runtime / vault layout
+- CLI orchestration
+- autopilot / queue / watcher
+- canonical identity helper
+- registry framework
+- derived `knowledge.db`
+- graph / lint / audit 基础设施
+- plugin / pack loader
+- evidence schema 基础契约
+
+### 2. Domain Pack
+
+pack 负责领域语义，而不是只放几段 prompt。它定义：
+
+- object kinds
+- workflow profile
+- discovery boundary
+- absorb / refine / lint 规则
+- schema / template / prompt 资源
+
+当前内置的是 `default-knowledge`。未来媒体、医疗、工程研究这类领域，应该各自作为外部 pack 工程接入。
+
+### 3. Workflow Profile
+
+profile 是某个 pack 下的一条可执行 DAG。
+
+当前已经实现的标准 profile：
+
+- `default-knowledge/full`
+- `default-knowledge/autopilot`
+
+这也是为什么现在可以显式运行：
+
+```bash
+ovp --pack default-knowledge --profile full
+ovp-autopilot --pack default-knowledge --profile autopilot --yes
+```
+
+## 插件设计
+
+当前插件/pack 接入面已经有最小闭环，不再只是设计稿。
+
+支持两种发现方式：
+
+1. Python entry point 组：`openclaw_pipeline.packs`
+2. 显式 manifest 列表：`OPENCLAW_PACK_MANIFESTS=/path/a.yaml:/path/b.yaml`
+
+最小接入链路是：
+
+1. 第三方 pack 提供 manifest
+2. manifest 声明 `entrypoints.pack`
+3. entrypoint 返回 `BaseDomainPack`
+4. core 校验 `api_version`
+5. 用户通过 `--pack/--profile` 运行
+
+当前已经实现的硬边界：
+
+- pack 不能把 semantic retrieval 直接升级成 canonical identity
+- pack 不能把 `knowledge.db` 当 source of truth
+- pack 不能绕过 audit/logging
+- 所有 derived state 都必须可重建
+
 ## 真实运行模型
 
 ### Source of Truth

--- a/README.md
+++ b/README.md
@@ -250,6 +250,13 @@ vault/
 - 审计事件浏览
 - 工具发现与只读服务
 
+默认 discovery 也已经统一到这里：
+
+- `ovp-query` 默认走 `knowledge.db`
+- 关键词检索使用 FTS5 BM25
+- 语义检索使用本地 deterministic embeddings
+- QMD 不再是默认检索依赖，只能通过显式 `--engine qmd` 启用
+
 ## 快速开始
 
 ```bash

--- a/README_EN.md
+++ b/README_EN.md
@@ -250,6 +250,13 @@ It exists to power:
 - audit browsing
 - tool discovery and read-only serving
 
+Default discovery now routes through this layer:
+
+- `ovp-query` uses `knowledge.db` by default
+- keyword retrieval uses FTS5 BM25
+- semantic retrieval uses local deterministic embeddings
+- QMD is no longer the default runtime dependency; it is opt-in via `--engine qmd`
+
 ## Quick Start
 
 ```bash

--- a/README_EN.md
+++ b/README_EN.md
@@ -40,6 +40,121 @@ The current release wires those layers into the actual runtime:
 - `ovp-autopilot` runs real-time `absorb -> moc -> knowledge_index`
 - `ovp-autopilot --with-refine` adds `refine` to that path
 
+## Why The Architecture Looks Like This
+
+This repository started as a set of Obsidian automation scripts, but that model stopped scaling once the system grew:
+
+- the main runtime and individual scripts drifted apart
+- concepts, links, Atlas, graph, and retrieval indexes were tightly coupled without a clean truth boundary
+- new domains like media, medical, or engineering research could not be modeled safely with a concept-only core
+
+The current architecture is the direct answer to those failures:
+
+- the six-layer runtime makes orchestration, canonical state, and derived state explicit
+- `default-knowledge` freezes the current default domain semantics as a pack instead of scattering them through core
+- Pack API turns future domains into installable packs rather than more hardcoded branches inside the runtime
+
+So the project is no longer just a Vault automation repo. It is now:
+
+> an extensible knowledge orchestration platform for Obsidian-style vault workflows
+
+with `default-knowledge` as the first built-in standard pack.
+
+## Domain Packs
+
+The core runtime is now being formalized as a pack-aware platform.
+
+- Built-in standard pack: `default-knowledge`
+- Runtime selection is exposed through `--pack` and `--profile`
+- Third-party packs can be discovered through the `openclaw_pipeline.packs` entry point group or the `OPENCLAW_PACK_MANIFESTS` manifest list
+
+Examples:
+
+```bash
+ovp --pack default-knowledge --profile full
+ovp-autopilot --pack default-knowledge --profile autopilot --yes
+```
+
+Pack API documentation for third-party developers lives in:
+
+- `docs/pack-api/README.md`
+- `docs/pack-api/manifest-and-hooks.md`
+- `docs/pack-api/dogfooding-with-media-pack.md`
+
+## Platform Architecture
+
+From a platform perspective, the system now has three layers:
+
+1. **Core Platform**
+2. **Domain Pack**
+3. **Workflow Profile**
+
+### 1. Core Platform
+
+Core owns the cross-domain pieces that must remain stable:
+
+- runtime / vault layout
+- CLI orchestration
+- autopilot / queue / watcher
+- canonical identity helpers
+- registry framework
+- derived `knowledge.db`
+- graph / lint / audit infrastructure
+- plugin / pack loading
+- base evidence schema contracts
+
+### 2. Domain Pack
+
+A pack is not just a prompt bundle. It defines domain semantics:
+
+- object kinds
+- workflow profiles
+- discovery boundaries
+- absorb / refine / lint rules
+- schemas / templates / prompt resources
+
+The built-in pack is `default-knowledge`. Future domains such as media, medical, or engineering research should arrive as external pack projects.
+
+### 3. Workflow Profile
+
+A workflow profile is an executable DAG under a pack.
+
+The built-in profiles currently shipped are:
+
+- `default-knowledge/full`
+- `default-knowledge/autopilot`
+
+That is why these are now first-class runtime invocations:
+
+```bash
+ovp --pack default-knowledge --profile full
+ovp-autopilot --pack default-knowledge --profile autopilot --yes
+```
+
+## Plugin Design
+
+The plugin / pack surface is no longer only a design memo. There is now a minimal working integration path.
+
+Two discovery modes are supported:
+
+1. Python entry point group: `openclaw_pipeline.packs`
+2. Explicit manifest list: `OPENCLAW_PACK_MANIFESTS=/path/a.yaml:/path/b.yaml`
+
+The minimum third-party loading chain is:
+
+1. provide a manifest
+2. declare `entrypoints.pack`
+3. return a `BaseDomainPack`
+4. pass `api_version` validation
+5. select it through `--pack/--profile`
+
+Hard boundaries currently enforced by core:
+
+- a pack cannot turn semantic retrieval into canonical identity
+- a pack cannot treat `knowledge.db` as source of truth
+- a pack cannot bypass audit/logging
+- all derived state must remain rebuildable
+
 ## Runtime Model
 
 ### Source of Truth

--- a/docs/pack-api/README.md
+++ b/docs/pack-api/README.md
@@ -1,0 +1,217 @@
+# Pack API v1
+
+面向第三方开发者的 Domain Pack 开发文档。
+
+当前状态：
+
+- 这不是纯设计稿了，core 已经实现了最小 pack runtime
+- 内置 `default-knowledge` 已经按 pack 运行
+- `ovp` / `ovp-autopilot` 已经支持 `--pack` / `--profile`
+- core 已支持 entry point 和 manifest 两种 pack 发现路径
+
+这套 API 的目标不是让外部开发者“改 core”，而是让他们在 **不破坏 core 运行时契约** 的前提下，开发自己的领域包：
+
+- `default-knowledge`
+- `media-editorial`
+- `medical-evidence`
+- `engineering-research`
+- 未来其他领域
+
+## 1. 平台结构
+
+OpenClaw 平台分成三层：
+
+1. **Core Platform**
+2. **Domain Pack**
+3. **Workflow Profile**
+
+### Core Platform 负责什么
+
+Core 负责通用运行时，不负责某个领域的知识定义。
+
+Core 拥有：
+
+- runtime / vault layout
+- pipeline orchestration
+- autopilot / queue / watcher
+- identity helpers
+- registry framework
+- derived `knowledge.db`
+- graph / lint / audit 基础设施
+- plugin loader
+- evidence schema 基础契约
+
+### Domain Pack 负责什么
+
+Pack 负责领域语义。
+
+Pack 定义：
+
+- 对象类型
+- schema
+- discovery 规则
+- absorb / refine 规则
+- lint 规则
+- prompts / templates
+- workflow profiles
+
+### Workflow Profile 负责什么
+
+Profile 是某个 pack 下的一条可执行 DAG。
+
+例如：
+
+- `default-knowledge/full`
+- `default-knowledge/autopilot`
+- `media-editorial/daily-desk`
+- `media-editorial/weibo-fastlane`
+
+当前 core 已落地的是：
+
+- `default-knowledge/full`
+- `default-knowledge/autopilot`
+
+---
+
+## 2. 第一个标准 Pack
+
+平台的第一个标准 pack 是：
+
+```text
+default-knowledge
+```
+
+它就是当前仓库现有的偏技术/知识管理工作流，被正式包装成默认领域包。
+
+这意味着：
+
+- 媒体不是 core 的特例
+- 媒体也不是 seed ontology
+- 媒体、医疗等都应该作为独立 pack 来接入
+
+这样 core 才能保持稳定。
+
+---
+
+## 3. Pack 的最小职责
+
+一个可安装 pack 至少要提供：
+
+1. manifest
+2. pack entrypoint
+3. object kind 定义
+4. workflow profile 定义
+5. schema / template / prompt 资源
+
+推荐目录：
+
+```text
+openclaw-pack-<name>/
+├── README.md
+├── pyproject.toml
+├── src/openclaw_pack_<name>/
+│   ├── __init__.py
+│   ├── plugin.py
+│   ├── manifest.yaml
+│   ├── schemas/
+│   ├── templates/
+│   ├── prompts/
+│   ├── workflows.py
+│   ├── discovery.py
+│   ├── absorb.py
+│   ├── refine.py
+│   └── lint.py
+└── tests/
+```
+
+---
+
+## 4. Pack 生命周期
+
+一个 pack 的接入流程应该是：
+
+1. 开发者编写 pack
+2. pack 暴露 manifest 和 Python entrypoint
+3. core 通过 plugin loader 发现并加载它
+4. 用户通过 `--pack` 和 `--profile` 选择运行
+
+示例：
+
+```bash
+ovp --pack default-knowledge --profile full
+ovp --pack media-editorial --profile daily-desk
+ovp-autopilot --pack default-knowledge --profile autopilot
+```
+
+当前 core 已支持两种发现方式：
+
+- Python entry point 组：`openclaw_pipeline.packs`
+- 显式 manifest 路径：环境变量 `OPENCLAW_PACK_MANIFESTS=/path/a.yaml:/path/b.yaml`
+
+对第三方 pack 来说，推荐优先提供 entry point；manifest 适合开发期和未安装场景。
+
+---
+
+## 5. 重要边界
+
+Pack 可以定义领域逻辑，但不能破坏 core 的硬边界。
+
+### Pack 不能做的事
+
+- 绕过 audit / pipeline logging
+- 绕过 canonical identity framework
+- 把 semantic retrieval 直接变成 canonical identity
+- 直接把 `knowledge.db` 当成 source of truth
+- 偷偷改 core runtime contract
+
+### Pack 必须服从的事
+
+- ID 必须 deterministic
+- 写入必须经过 core 的可审计路径
+- derived state 必须可重建
+- workflow 的副作用必须可追踪
+- abstain 必须是合法结果
+
+---
+
+## 6. Pack 开发顺序建议
+
+不要一上来做全自动。
+
+推荐顺序：
+
+1. 定义对象模型
+2. 定义 schema
+3. 定义 workflow profiles
+4. 定义 discovery / absorb / refine 规则
+5. 定义 lint / evaluation
+6. 最后再做 autopilot
+
+这条顺序尤其适合媒体和医疗。
+
+---
+
+## 7. 文档组成
+
+本目录当前包含：
+
+- `README.md`
+  面向 pack 作者的总览
+- `manifest-and-hooks.md`
+  pack manifest、hook、entrypoint 和运行时接口
+- `dogfooding-with-media-pack.md`
+  如何用媒体 pack 吃自己的狗粮
+
+---
+
+## 8. 设计原则
+
+这套 Pack API 的目标有两件事：
+
+1. 建立 OpenClaw 自己的领域扩展体系
+2. 让我们自己的媒体项目先按这套体系落地，逼出真实接口
+
+也就是说：
+
+> 这不是写给“未来某个抽象第三方”的空文档。
+> 这是我们自己要先拿来做媒体 pack、再给别人用的开发文档。

--- a/docs/pack-api/dogfooding-with-media-pack.md
+++ b/docs/pack-api/dogfooding-with-media-pack.md
@@ -1,0 +1,103 @@
+# Dogfooding With A Media Pack
+
+这份文档解释为什么媒体 pack 要严格按 Pack API 来做，而不是在 core 仓库里硬编码。
+
+## 1. 为什么要吃自己的狗粮
+
+如果 Pack API 只是对外文档，而我们自己做媒体项目时不用它，这套 API 很快就会变成空壳。
+
+真正能把接口做对的方法只有一个：
+
+> 我们自己先按这套接口做第一个强需求外部 pack。
+
+媒体领域正适合承担这个角色，因为它和 `default-knowledge` 的差异足够大：
+
+- 对象模型不同
+- workflow DAG 不同
+- lint 规则不同
+- 反馈闭环不同
+
+这会逼 core 把边界做实。
+
+## 2. 媒体 Pack 不应该直接进 Core
+
+媒体项目应该单独一个工程，例如：
+
+```text
+openclaw-pack-media-editorial
+```
+
+原因：
+
+- 它的对象模型不是 core 默认对象模型
+- 它的 prompts / schemas 更新速度更快
+- 它的评估标准更依赖编辑部实际反馈
+- 它的发布节奏不该和 core 绑定
+
+## 3. 媒体 Pack 如何验证 Pack API 是否可用
+
+媒体 pack 应该至少覆盖下面这些对象：
+
+- `raw_source`
+- `evidence_packet`
+- `event`
+- `angle`
+- `writing_sheet`
+- `topic_card`
+- `research_brief`
+- `draft`
+- `feedback`
+
+如果 Pack API 能把这些对象接进来，说明平台边界基本是成立的。
+
+## 4. 媒体 Pack 应该优先验证什么
+
+不是先验证“能不能自动写出爆款稿”，而是先验证：
+
+1. 能不能定义对象模型
+2. 能不能注册 workflow profiles
+3. 能不能通过 discovery hooks 找到事件/角度/历史相似稿
+4. 能不能通过 lint hooks 执行事实与风格门禁
+5. 能不能把编辑反馈写回 pack 自己的规则系统
+
+## 5. 建议的媒体 Pack 落地顺序
+
+### Phase 1
+
+- `daily-desk` profile
+- Topic Card
+- Research Brief
+- Fact Lint
+- Style Lint
+
+### Phase 2
+
+- Outline
+- Neutral Draft
+- Style Pass
+
+### Phase 3
+
+- Publish feedback
+- Writing Sheet 自动更新
+- Topic scoring 更新
+
+## 6. 这样做的收益
+
+这样做的好处正是你刚才说的两点：
+
+1. 我们建立自己的 Pack API 文档和开发体系
+2. 媒体项目直接套用这套体系，逼着我们把接口、流程、边界都跑通
+
+结果是：
+
+- 我们不是“先写一套文档，再希望别人用”
+- 而是“先自己按文档做出真实 pack，再把这套文档变成真正可复用的开发体系”
+
+## 7. 最终原则
+
+core 应该服务 pack，pack 不应该污染 core。
+
+`default-knowledge` 作为第一个标准 pack，负责稳定平台基线。  
+`media-editorial` 作为第一个强验证外部 pack，负责验证平台是否真的可扩展。  
+其他领域包以后都沿着同一条路开发。

--- a/docs/pack-api/manifest-and-hooks.md
+++ b/docs/pack-api/manifest-and-hooks.md
@@ -1,0 +1,318 @@
+# Pack Manifest And Hooks
+
+本文件定义 Pack API v1 的建议接口。
+
+注意：
+
+- 当前仓库已经实现了最小 pack runtime、profile 选择和 plugin loader
+- 这里既描述 **当前已支持的接口**，也描述 Pack API v1 的目标接口
+- pack 作者应该优先按“已支持部分”接入，再逐步使用更完整的 hooks 面
+
+当前已支持的最小能力：
+
+- manifest 校验
+- `entrypoints.pack`
+- `BaseDomainPack`
+- `--pack / --profile`
+- entry point / manifest 两种发现方式
+- `api_version` 兼容性检查
+
+## 1. Manifest
+
+每个 pack 应提供一个 manifest。
+
+推荐 YAML：
+
+```yaml
+name: media-editorial
+version: 0.1.0
+api_version: 1
+display_name: Media Editorial Pack
+description: Editorial workflow pack for finance/media production
+
+object_kinds:
+  - raw_source
+  - evidence_packet
+  - event
+  - angle
+  - writing_sheet
+  - topic_card
+  - research_brief
+  - draft
+  - feedback
+
+workflow_profiles:
+  - daily-desk
+  - weibo-fastlane
+
+resources:
+  schemas:
+    - schemas/event.yaml
+    - schemas/topic_card.yaml
+  templates:
+    - templates/topic-card.md
+    - templates/research-brief.md
+  prompts:
+    - prompts/topic-card-generator.md
+    - prompts/research-brief.md
+
+entrypoints:
+  pack: openclaw_pack_media.plugin:get_pack
+```
+
+## 2. Python Entrypoint
+
+Pack 必须暴露一个 entrypoint：
+
+```python
+def get_pack() -> BaseDomainPack:
+    ...
+```
+
+core 通过它拿到 pack 对象。
+
+当前实现支持两种加载路径：
+
+1. 通过 Python entry point 组 `openclaw_pipeline.packs`
+2. 通过 manifest 文件列表 `OPENCLAW_PACK_MANIFESTS`
+
+manifest 的 `entrypoints.pack` 仍然是最终入口。
+
+## 3. BaseDomainPack 建议接口
+
+```python
+class BaseDomainPack:
+    name: str
+    version: str
+    api_version: int
+
+    def object_kinds(self) -> list[ObjectKindSpec]:
+        ...
+
+    def workflow_profiles(self) -> list[WorkflowProfile]:
+        ...
+
+    def discovery_hooks(self) -> DiscoveryHooks:
+        ...
+
+    def absorb_hooks(self) -> AbsorbHooks:
+        ...
+
+    def refine_hooks(self) -> RefineHooks:
+        ...
+
+    def lint_hooks(self) -> LintHooks:
+        ...
+
+    def templates_dir(self) -> Path:
+        ...
+
+    def prompts_dir(self) -> Path:
+        ...
+```
+
+## 4. Object Kind Spec
+
+Pack 可以注册新的 object kinds。
+
+```python
+@dataclass
+class ObjectKindSpec:
+    kind: str
+    display_name: str
+    description: str
+    canonical: bool
+    schema_ref: str | None = None
+```
+
+示例：
+
+- `concept`
+- `entity`
+- `event`
+- `angle`
+- `claim`
+- `writing_sheet`
+
+## 5. Workflow Profile
+
+每个 pack 可以注册一个或多个 profile。
+
+```python
+@dataclass
+class WorkflowProfile:
+    name: str
+    description: str
+    stages: list[str]
+    supports_autopilot: bool = False
+```
+
+例如：
+
+```python
+WorkflowProfile(
+    name="daily-desk",
+    description="Daily editorial desk workflow",
+    stages=[
+        "ingest",
+        "normalize",
+        "event_cluster",
+        "topic_card",
+        "desk_review",
+        "research_brief",
+        "outline",
+        "neutral_draft",
+        "style_pass",
+        "fact_lint",
+        "style_lint",
+        "editor_review",
+        "derive",
+    ],
+)
+```
+
+## 6. Discovery Hooks
+
+Pack 不能改变 core 的 identity 原则，但可以改变“发现什么对象”。
+
+建议：
+
+```python
+class DiscoveryHooks(Protocol):
+    def discover_object_candidates(
+        self,
+        *,
+        vault_dir: Path,
+        query: str,
+        retrieval_evidence: list[dict[str, object]],
+        limit: int = 10,
+    ) -> list[dict[str, object]]:
+        ...
+```
+
+输出应该是结构化对象候选，而不是随便一段文本。
+
+## 7. Absorb Hooks
+
+Absorb hook 负责把 interpret 层产物编入该领域知识体系。
+
+```python
+class AbsorbHooks(Protocol):
+    def absorb(
+        self,
+        *,
+        source_note: Path,
+        evidence: dict[str, object],
+    ) -> dict[str, object]:
+        ...
+```
+
+输出必须结构化，至少包含：
+
+- `decision_type`
+- `action`
+- `target_kind`
+- `target_id`
+- `confidence`
+- `requires_review`
+
+## 8. Refine Hooks
+
+Refine hook 负责整理已有对象。
+
+```python
+class RefineHooks(Protocol):
+    def propose_cleanup(...): ...
+    def propose_breakdown(...): ...
+    def execute_mutation(...): ...
+```
+
+媒体 pack 可以把它扩展成：
+
+- `topic_card`
+- `research_brief`
+- `outline`
+- `style_pass`
+
+但执行副作用仍要经过 core 审计。
+
+## 9. Lint Hooks
+
+不同领域的质量门槛不同，lint 必须 pack 化。
+
+```python
+class LintHooks(Protocol):
+    def run_fact_lint(...): ...
+    def run_style_lint(...): ...
+    def run_domain_lint(...): ...
+```
+
+示例：
+
+- 媒体：事实漂移、标题正文不一致、AI 腔、低可信来源
+- 医疗：证据等级、危险建议、禁忌症遗漏
+- 编程：过时信息、错误 API、性能/安全误导
+
+## 10. Evidence Schema
+
+所有 pack 都应消费同一套 core evidence buckets：
+
+- `identity_evidence`
+- `retrieval_evidence`
+- `graph_evidence`
+- `audit_evidence`
+
+Pack 可以追加领域 evidence，但不能删除 core evidence。
+
+示例：
+
+```python
+{
+  "identity_evidence": [...],
+  "retrieval_evidence": [...],
+  "graph_evidence": [...],
+  "audit_evidence": [...],
+  "domain_evidence": {
+    "topic_fit": [...],
+    "writing_sheet_matches": [...],
+  }
+}
+```
+
+## 11. Versioning
+
+Pack 需要双版本：
+
+- `version`
+  pack 自己的版本
+- `api_version`
+  对应 core Pack API 的版本
+
+core 应只加载兼容 `api_version` 的 pack。
+
+## 12. 测试要求
+
+每个 pack 至少要有：
+
+- manifest validation tests
+- workflow profile tests
+- discovery hook tests
+- absorb/refine contract tests
+- lint rule tests
+
+如果 pack 要接 autopilot，还要有：
+
+- idempotency tests
+- retry safety tests
+- audit log tests
+
+## 13. Pack 作者检查清单
+
+- 对象模型是否独立清楚
+- schema 是否完整
+- workflow 是否不是“一键全自动乱写”
+- 重大判断是否输出结构化结果
+- 是否复用了 core evidence schema
+- 是否服从 core identity / audit / derived 规则
+
+如果这些做不到，这个 pack 还不应该发布。

--- a/docs/plans/2026-04-07-discovery-and-concept-unification.md
+++ b/docs/plans/2026-04-07-discovery-and-concept-unification.md
@@ -1,0 +1,332 @@
+# Discovery And Concept Unification Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Unify search, concept discovery, and LLM retrieval context so the system has one default discovery stack, one canonical identity resolver, and one evidence contract for downstream model decisions.
+
+**Architecture:** Keep canonical identity resolution deterministic and registry-first. Move default discovery to `knowledge.db` (FTS + embeddings), demote QMD to an optional external discovery adapter, and expose a shared evidence schema with separate identity, retrieval, graph, and audit channels for LLM workflows.
+
+**Tech Stack:** Python CLI, SQLite FTS5, local deterministic embeddings, optional QMD adapter, pytest.
+
+---
+
+## Why This Plan Exists
+
+The repository currently has three overlapping retrieval systems:
+
+1. `ConceptRegistry.resolve_mention()` and `search()` for deterministic registry resolution.
+2. `query_tool.py`, which prefers `qmd search` and otherwise falls back to a weak built-in lexical scorer.
+3. `knowledge_index.py`, which already implements local FTS5 BM25 retrieval plus deterministic chunk embeddings in `knowledge.db`.
+
+These systems are not aligned:
+
+- automatic link resolution correctly avoids semantic retrieval
+- user-facing discovery still routes through QMD or a legacy fallback
+- LLM workflows receive mixed result types without a stable evidence schema
+
+The result is inconsistent ranking, duplicated logic, and avoidable drift between search, concept discovery, and downstream LLM reasoning.
+
+---
+
+## Target State
+
+### 1. Canonical Resolution
+
+**Single rule:** automatic mention resolution remains registry-first and deterministic.
+
+- `ConceptRegistry.resolve_mention()` stays authoritative
+- QMD and vector similarity never auto-link notes
+- abstain remains valid behavior
+
+### 2. Default Discovery
+
+**Single default runtime:** `knowledge.db`
+
+- lexical discovery: `search_knowledge_index()`
+- semantic discovery: `query_knowledge_index()`
+- future hybrid discovery: combine the two in one local reranker
+
+QMD becomes an explicit optional engine, not the default.
+
+### 3. Concept Discovery
+
+There should be one shared “related concept discovery” entry point used by:
+
+- candidate generation
+- ambiguous concept review
+- surface conflict review
+- query-time “related notes”
+- refine-time context expansion
+
+This entry point should return typed evidence, not ad hoc result lists.
+
+### 4. LLM Evidence Schema
+
+LLM-facing workflows should receive four separate evidence buckets:
+
+- `identity_evidence`: registry matches / abstains / ambiguities
+- `retrieval_evidence`: knowledge.db lexical/semantic results
+- `graph_evidence`: graph neighbors / Atlas / MOC context
+- `audit_evidence`: recency, mutations, pipeline or refine events
+
+No workflow should infer identity from retrieval alone.
+
+---
+
+## Recommended Product Decisions
+
+### A. Usage Scenarios
+
+| Scenario | Default engine | QMD allowed? | Notes |
+|---|---|---|---|
+| Auto-linking / note resolution | Registry only | No | Deterministic only |
+| Candidate creation | Registry + discovery helper | Yes, as auxiliary only | Retrieval may suggest related context |
+| Query / search | knowledge.db | Yes, explicit engine switch only | knowledge.db should be the platform default |
+| Conflict review / duplicate review | Registry + discovery helper | Yes | QMD can remain a reviewer signal |
+| Refine (`cleanup` / `breakdown`) | knowledge.db + graph | Yes, optional | Retrieval should inform rewrite/split context |
+
+### B. Knowledge Discovery
+
+`ovp-query` should no longer prefer QMD automatically.
+
+Default behavior:
+
+- `ovp-query --engine knowledge` or no engine flag: use `knowledge.db`
+- `ovp-query --engine qmd`: use QMD explicitly
+- if `knowledge.db` missing: rebuild on demand
+- if QMD missing and explicitly requested: fail clearly, do not silently change ranking semantics
+
+### C. LLM Handling
+
+Major LLM workflows must consume structured evidence rather than flat search results.
+
+Examples:
+
+- `absorb`: identity evidence first, then retrieval evidence for enrichment context
+- `promote/merge/reject`: identity + retrieval + graph evidence
+- `cleanup/breakdown`: retrieval + graph + audit evidence
+- `query`: retrieval + graph evidence, optionally identity hits if concept mentions are recognized
+
+---
+
+## Concrete Refactor Plan
+
+### Task 1: Introduce a unified discovery contract
+
+**Files:**
+- Create: `src/openclaw_pipeline/discovery.py`
+- Modify: `src/openclaw_pipeline/knowledge_index.py`
+- Test: `tests/test_discovery.py`
+
+**Step 1: Write the failing test**
+
+Add tests for:
+
+- `discover_related()` returning typed results from `knowledge.db`
+- stable result shape with `engine`, `kind`, `slug`, `title`, `score`, `snippet`
+- default engine being `knowledge`
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest -q tests/test_discovery.py`
+
+Expected: missing module / helper failures.
+
+**Step 3: Write minimal implementation**
+
+Create a small discovery facade:
+
+- `discover_related(vault_dir, query, *, engine="knowledge", limit=10)`
+- `discover_identity_context(registry, mention)`
+- `discover_query_context(vault_dir, query, *, limit=10)`
+
+Back it with:
+
+- `search_knowledge_index()`
+- `query_knowledge_index()`
+- optional `qmd` adapter
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest -q tests/test_discovery.py`
+
+Expected: PASS
+
+### Task 2: Make `ovp-query` knowledge.db-first
+
+**Files:**
+- Modify: `src/openclaw_pipeline/query_tool.py`
+- Test: `tests/test_query_tool.py`
+
+**Step 1: Write the failing test**
+
+Add tests asserting:
+
+- default search engine uses `knowledge.db`
+- `--engine qmd` is explicit
+- missing QMD does not silently override an explicit `qmd` request
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest -q tests/test_query_tool.py`
+
+Expected: default engine behavior mismatch.
+
+**Step 3: Write minimal implementation**
+
+- add `--engine {knowledge,qmd}` if not already present
+- default to `knowledge`
+- use discovery helpers instead of direct `qmd` subprocess fallback
+- only use the old builtin lexical scorer as a final internal emergency fallback, or remove it entirely
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest -q tests/test_query_tool.py`
+
+Expected: PASS
+
+### Task 3: Unify concept discovery hooks
+
+**Files:**
+- Modify: `src/openclaw_pipeline/concept_registry.py`
+- Modify: `src/openclaw_pipeline/concept_resolver.py`
+- Test: `tests/test_concept_discovery.py`
+
+**Step 1: Write the failing test**
+
+Add tests asserting:
+
+- candidate creation receives typed related context from the discovery facade
+- `fix_surface_conflicts()` uses discovery evidence only for review signals, not as the sole automatic merge trigger
+- registry `search()` remains lexical/deterministic for compatibility
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest -q tests/test_concept_discovery.py`
+
+Expected: current QMD-only auxiliary behavior mismatch.
+
+**Step 3: Write minimal implementation**
+
+- replace direct `_qmd_related_context()` calls in candidate/review paths with a shared discovery helper
+- keep `_qmd_related_context()` only as a provider implementation, not the public concept-discovery API
+- revise conflict analysis so QMD/semantic similarity contributes to `review_needed`, while automatic merge still requires deterministic overlap or explicit review execution
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest -q tests/test_concept_discovery.py`
+
+Expected: PASS
+
+### Task 4: Add LLM evidence schema
+
+**Files:**
+- Create: `src/openclaw_pipeline/evidence.py`
+- Modify: `src/openclaw_pipeline/commands/absorb.py`
+- Modify: `src/openclaw_pipeline/refine.py`
+- Modify: `src/openclaw_pipeline/query_tool.py`
+- Test: `tests/test_evidence_schema.py`
+
+**Step 1: Write the failing test**
+
+Add tests asserting:
+
+- evidence payloads contain separate `identity_evidence`, `retrieval_evidence`, `graph_evidence`, `audit_evidence`
+- no retrieval-only payload is labeled as identity
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest -q tests/test_evidence_schema.py`
+
+Expected: missing schema failures.
+
+**Step 3: Write minimal implementation**
+
+Create helpers such as:
+
+- `build_identity_evidence()`
+- `build_retrieval_evidence()`
+- `build_graph_evidence()`
+- `build_audit_evidence()`
+
+Use them where structured LLM-facing payloads are assembled.
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest -q tests/test_evidence_schema.py`
+
+Expected: PASS
+
+### Task 5: Rationalize docs and CLI guidance
+
+**Files:**
+- Modify: `README.md`
+- Modify: `README_EN.md`
+- Modify: `CLAUDE.md`
+- Modify: `skills/daily-ingestion.md`
+
+**Step 1: Write the failing doc checklist**
+
+Create a checklist:
+
+- QMD is documented as optional, not default
+- `knowledge.db` is documented as the default retrieval layer
+- registry remains canonical for identity
+- concept discovery is documented as distinct from automatic linking
+
+**Step 2: Update docs**
+
+- remove stale wording that suggests “use qmd by default”
+- explain explicit `--engine qmd`
+- explain the new discovery contract
+
+**Step 3: Verify docs and help**
+
+Run:
+
+- `ovp-query --help`
+- `ovp-knowledge-index --help`
+- `rg -n "qmd|knowledge.db|source of truth|engine" README.md README_EN.md CLAUDE.md skills/daily-ingestion.md`
+
+Expected: docs align with the new contract.
+
+### Task 6: Full verification
+
+**Files:**
+- Modify: tests as needed
+
+**Step 1: Run full verification**
+
+Run:
+
+- `python3 -m compileall src/openclaw_pipeline`
+- `pytest -q`
+
+Expected: all pass.
+
+**Step 2: Commit**
+
+```bash
+git add src/openclaw_pipeline/discovery.py src/openclaw_pipeline/evidence.py src/openclaw_pipeline/query_tool.py src/openclaw_pipeline/concept_registry.py src/openclaw_pipeline/concept_resolver.py tests/test_discovery.py tests/test_query_tool.py tests/test_concept_discovery.py tests/test_evidence_schema.py README.md README_EN.md CLAUDE.md skills/daily-ingestion.md
+git commit -m "feat: unify discovery and concept retrieval contracts"
+```
+
+---
+
+## Recommended Implementation Order
+
+1. Discovery facade
+2. `ovp-query` default engine change
+3. Concept discovery hook unification
+4. LLM evidence schema
+5. Docs
+6. Full verification
+
+---
+
+## Non-Goals
+
+- Do not let QMD decide automatic wikilinks
+- Do not make `knowledge.db` a second source of truth
+- Do not replace registry lexical search with semantic matching
+- Do not add freeform LLM rewriting to the resolver

--- a/docs/plans/2026-04-07-domain-pack-platform-design.md
+++ b/docs/plans/2026-04-07-domain-pack-platform-design.md
@@ -1,0 +1,540 @@
+# Domain Pack Platform Design
+
+## Goal
+
+Turn the current repository from a single knowledge-pipeline product into a platform with three explicit layers:
+
+1. **Core platform**
+2. **Default domain pack**
+3. **Workflow profiles**
+
+The first standard pack is **not** media. It is the current repository's existing technical/knowledge workflow, formalized as `default-knowledge`.
+
+Media, medical, and other specialized domains should become **separate plugin-pack projects** that can be installed into the core platform rather than hard-coded into it.
+
+---
+
+## Executive Decision
+
+The correct platform shape is:
+
+```text
+openclaw-core
+  + default-knowledge pack
+  + workflow profiles
+  + plugin loader
+  + derived runtime / audit / registry infra
+
+external packs
+  + media-editorial pack
+  + engineering-research pack
+  + medical-evidence pack
+  + future domain packs
+```
+
+This means:
+
+- the repository stops assuming one universal ontology
+- `concept` stops being the only first-class semantic object
+- domain-specific extraction, absorb, refine, lint, and scoring rules move into packs
+- the core remains responsible for runtime integrity, identity, auditing, orchestration, and derived indexes
+
+---
+
+## Why This Refactor Is Necessary
+
+The current codebase has already evolved beyond a simple “evergreen note pipeline”.
+
+It now contains:
+
+- a six-layer architecture
+- canonical identity rules
+- absorb and refine workflows
+- a derived `knowledge.db`
+- graph, lint, and audit infrastructure
+
+But it still carries one hidden assumption:
+
+> the dominant semantic unit is a concept-like evergreen note
+
+That assumption works for the current technical knowledge workflow, but it does not generalize cleanly to:
+
+- media editorial systems
+- medical evidence systems
+- legal or regulatory knowledge systems
+- research or analyst desks
+
+In those domains, the meaningful objects differ:
+
+- media cares about events, evidence packets, angles, writing sheets, briefs, drafts, feedback
+- medicine cares about claims, evidence grades, contraindications, protocols, safety summaries
+- engineering research cares about repos, patterns, tradeoffs, benchmarks, failure modes, design memos
+
+So the right move is not “insert media into the current concept model”.
+
+The right move is:
+
+> make the ontology pluggable, while keeping execution integrity in the core.
+
+---
+
+## Platform Model
+
+### 1. Core Platform
+
+The core platform owns infrastructure that should remain domain-agnostic.
+
+It includes:
+
+- runtime layout resolution
+- pipeline execution engine
+- autopilot / watcher / queue
+- identity helpers
+- registry framework
+- derived `knowledge.db`
+- graph and lint infrastructure
+- audit/event logging
+- plugin discovery and loading
+- base evidence schema contract
+
+The core does **not** decide:
+
+- which object kinds a domain uses
+- what “high quality” means inside a domain
+- which extraction prompts or writing rules apply
+- which workflow stages are required for a domain
+
+### 2. Domain Pack
+
+A domain pack defines domain semantics.
+
+Each pack should declare:
+
+- supported object kinds
+- frontmatter schemas
+- extraction policies
+- absorb policies
+- refine policies
+- lint rules
+- templates
+- prompts
+- scoring heuristics
+- workflow stages or stage presets
+
+Examples:
+
+- `default-knowledge`
+- `media-editorial`
+- `engineering-research`
+- `medical-evidence`
+
+### 3. Workflow Profile
+
+A workflow profile is the operational DAG for a domain.
+
+Examples:
+
+- `default-full`
+- `default-autopilot`
+- `media-daily-desk`
+- `media-weibo-fastlane`
+- `medical-briefing`
+- `engineering-weekly-research`
+
+Workflow profiles are allowed to be pack-specific.
+
+The core only guarantees that profiles execute through a stable orchestration contract.
+
+---
+
+## The First Standard Pack: `default-knowledge`
+
+The current repository should be formalized as the first standard pack, named:
+
+```text
+default-knowledge
+```
+
+This pack preserves current semantics:
+
+- raw input
+- deep-dive interpretation
+- concept / entity / evergreen-oriented absorb
+- cleanup / breakdown refine
+- registry / alias / Atlas canonical state
+- derived `knowledge.db`, graph, lint, daily delta
+
+### Why `default-knowledge` should be the first pack
+
+1. It already exists in code.
+2. It is the only pack we can fully validate today.
+3. It provides the reference contract for future external packs.
+4. It prevents media from distorting core abstractions too early.
+
+This is important:
+
+> media should be the first strong external validation pack, not the seed pack that defines the platform.
+
+---
+
+## External Pack Model
+
+Media and medical should be separate engineering projects.
+
+Recommended repo pattern:
+
+```text
+openclaw-core                    # current repo evolved into platform
+openclaw-pack-default-knowledge  # may live in-tree first, then optionally split
+openclaw-pack-media-editorial
+openclaw-pack-medical-evidence
+openclaw-pack-engineering-research
+```
+
+### Why separate repos are preferable for specialized packs
+
+- domain cadence differs from core cadence
+- prompts and schemas will churn faster than runtime infra
+- domain evaluation datasets and fixtures are pack-specific
+- domain packs may have different governance and owners
+- pack release cycles should not force core releases
+
+The installation model should be plugin-based:
+
+```bash
+ovp-plugin install openclaw-pack-media-editorial
+ovp --pack media-editorial --profile daily-desk
+```
+
+---
+
+## Object System
+
+The current concept registry needs to evolve into an **object system**.
+
+This does **not** mean deleting concept logic.
+
+It means promoting it into a more general model:
+
+```text
+KnowledgeObject
+  - id
+  - kind
+  - title
+  - aliases
+  - status
+  - pack
+  - schema_version
+  - canonical_path
+  - metadata
+```
+
+### Core object kinds
+
+The core should only know a small stable base:
+
+- `entity`
+- `concept`
+- `evergreen`
+- `note`
+- `document`
+
+### Pack-defined object kinds
+
+Packs can add their own kinds.
+
+For example media:
+
+- `raw_source`
+- `evidence_packet`
+- `event`
+- `angle`
+- `analogue`
+- `writing_sheet`
+- `topic_card`
+- `research_brief`
+- `outline`
+- `draft`
+- `feedback`
+
+For medical:
+
+- `claim`
+- `guideline`
+- `protocol`
+- `evidence_grade`
+- `contraindication`
+- `patient_summary`
+
+### Registry implication
+
+The current `concept_registry.py` should eventually become:
+
+```text
+object_registry.py
+```
+
+With `concept_registry.py` surviving as a compatibility wrapper or a pack-local adapter for `default-knowledge`.
+
+---
+
+## Discovery Model
+
+The current discovery work should also be generalized.
+
+Today we have already separated:
+
+- canonical identity resolution
+- retrieval discovery
+- evidence buckets
+
+The next step is to move from:
+
+```text
+concept discovery
+```
+
+to:
+
+```text
+object discovery
+```
+
+### Core discovery responsibilities
+
+The core should provide:
+
+- deterministic identity lookup
+- shared retrieval layer (`knowledge.db`)
+- evidence schema
+- shared discovery facade
+
+### Pack discovery responsibilities
+
+Each pack decides:
+
+- what kinds of objects can be discovered
+- which discovery outputs are valid
+- what abstain means in that domain
+- how retrieval evidence influences review
+- how object candidates are promoted, merged, split, or rejected
+
+For example:
+
+- `default-knowledge` may discover concepts and evergreen enrich targets
+- `media-editorial` may discover events, angles, analogues, and writing sheets
+- `medical-evidence` may discover claims, evidence conflicts, and protocol candidates
+
+---
+
+## Workflow Architecture
+
+### Core stages
+
+The core should expose generic stage categories:
+
+- ingest
+- normalize
+- interpret
+- absorb
+- refine
+- canonicalize
+- derive
+- review
+- publish
+- feedback
+
+Not every profile uses every stage.
+
+### `default-knowledge` profile
+
+Maps approximately to the current six-layer runtime:
+
+```text
+ingest -> interpret -> absorb -> refine(optional) -> canonicalize -> derive
+```
+
+### `media-editorial` profile
+
+Would map to:
+
+```text
+ingest
+-> normalize
+-> event_cluster
+-> topic_card
+-> desk_review
+-> research_brief
+-> outline
+-> neutral_draft
+-> style_pass
+-> fact_lint
+-> style_lint
+-> editor_review
+-> publish
+-> feedback
+```
+
+The important point:
+
+> these stages are profile-defined, not hard-coded into core.
+
+---
+
+## Plugin Contract
+
+Each pack plugin should export a manifest plus Python entrypoints.
+
+Example conceptual manifest:
+
+```yaml
+name: media-editorial
+version: 0.1.0
+api_version: 1
+object_kinds:
+  - event
+  - angle
+  - writing_sheet
+workflow_profiles:
+  - daily-desk
+  - weibo-fastlane
+schemas:
+  - schemas/event.yaml
+  - schemas/topic_card.yaml
+templates:
+  - templates/topic-card.md
+prompts:
+  - prompts/topic-card-generator.md
+entrypoints:
+  pack: openclaw_pack_media.plugin:get_pack
+```
+
+And the runtime-facing Python object should supply:
+
+- pack metadata
+- object kind definitions
+- schema validators
+- stage handlers
+- lint hooks
+- discovery hooks
+- evidence enrichers
+
+---
+
+## Pack Boundaries
+
+### Core owns
+
+- runtime correctness
+- stable plugin API
+- state/audit durability
+- canonical identity framework
+- retrieval substrate
+- cross-pack orchestration and safety
+
+### Packs own
+
+- ontology
+- templates and prompts
+- domain lint rules
+- workflow DAGs
+- scorecards and domain gates
+- object lifecycle semantics
+
+### Packs must not do
+
+- bypass audit logging
+- write arbitrary derived state without core hooks
+- invent their own incompatible identity model
+- directly replace the core runtime contract
+
+---
+
+## Identity Rules
+
+This is a hard boundary.
+
+Even after packs exist:
+
+- canonical IDs must still be deterministic
+- derived retrieval must not become identity truth
+- semantic similarity must never silently become canonical linking
+
+Pack-specific logic can influence:
+
+- review
+- candidate generation
+- enrichment suggestions
+- editorial proposals
+
+But not:
+
+- silent auto-identity assignment without deterministic rules
+
+---
+
+## Recommended Migration Path
+
+### Phase 1: Platform extraction inside current repo
+
+- define plugin/pack interfaces
+- formalize `default-knowledge` as the first pack
+- move current prompts/templates/rules under pack-aware structure
+- keep behavior unchanged
+
+### Phase 2: Registry and discovery generalization
+
+- introduce object registry abstractions
+- keep concept registry compatibility
+- generalize discovery and evidence hooks to pack-aware interfaces
+
+### Phase 3: Workflow profile system
+
+- let packs register profiles
+- make `ovp --pack ... --profile ...` first-class
+- keep legacy command aliases for default pack
+
+### Phase 4: External pack extraction
+
+- create `media-editorial` as a separate repo
+- install it back into core via plugin loading
+- validate that the platform really supports a non-default ontology
+
+### Phase 5: Second external pack
+
+- build another domain pack, ideally different enough to stress the model
+- `medical-evidence` or `engineering-research`
+
+If the second external pack works cleanly, the platform model is real.
+
+---
+
+## Non-Goals
+
+This design does not propose:
+
+- turning the current repo into a media product
+- making media the core ontology
+- replacing Obsidian markdown as the durable store
+- replacing `knowledge.db` with domain-specific databases as canonical truth
+- building all future packs now
+
+---
+
+## Final Recommendation
+
+The correct strategic move is:
+
+1. turn this repository into a **knowledge workflow platform**
+2. formalize the current semantics as `default-knowledge`
+3. define a real plugin-pack interface
+4. build media as the first serious **external** validation pack
+
+That gives us:
+
+- a stable core
+- a clean default pack
+- real extensibility
+- no pressure to force every domain into a concept-only model
+
+This is the architecture that can support media, medicine, engineering, and future domains without collapsing into one giant special-case codebase.

--- a/docs/plans/2026-04-07-domain-pack-platform-implementation.md
+++ b/docs/plans/2026-04-07-domain-pack-platform-implementation.md
@@ -1,0 +1,363 @@
+# Domain Pack Platform Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Refactor the current repository into a platform with a first-class `default-knowledge` pack, pack-aware workflow profiles, and a plugin interface that allows external domain packs such as media or medical systems.
+
+**Architecture:** Keep the current runtime, registry, audit, and derived layers in core. Extract the current domain semantics into an in-repo `default-knowledge` pack, then add pack manifests, plugin loading, and workflow-profile registration without breaking existing CLI aliases.
+
+**Tech Stack:** Python CLI, setuptools entry points or plugin manifest loading, Markdown templates/prompts, pytest.
+
+---
+
+## Phase 0: Freeze Current Semantics As Baseline
+
+### Task 1: Write baseline contract tests for current default behavior
+
+**Files:**
+- Create: `tests/test_default_pack_compat.py`
+- Reference: `src/openclaw_pipeline/unified_pipeline_enhanced.py`
+- Reference: `src/openclaw_pipeline/autopilot/daemon.py`
+
+**Step 1: Write the failing test**
+
+Add tests asserting:
+
+- default pipeline still resolves to the current `absorb -> canonical -> derive` semantics
+- current CLI aliases still map to the same pack behavior
+- no pack selection still behaves like current `default-knowledge`
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest -q tests/test_default_pack_compat.py`
+
+Expected: missing pack abstraction failures.
+
+**Step 3: Write minimal implementation**
+
+Do not change behavior yet. Only add the compatibility scaffolding needed for the tests to pass.
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest -q tests/test_default_pack_compat.py`
+
+Expected: PASS
+
+---
+
+## Phase 1: Introduce Core Pack Interfaces
+
+### Task 2: Create pack manifests and runtime interfaces
+
+**Files:**
+- Create: `src/openclaw_pipeline/packs/__init__.py`
+- Create: `src/openclaw_pipeline/packs/base.py`
+- Create: `src/openclaw_pipeline/packs/loader.py`
+- Test: `tests/test_pack_loader.py`
+
+**Step 1: Write the failing test**
+
+Add tests asserting:
+
+- a pack has `name`, `version`, `object_kinds`, `workflow_profiles`
+- the loader can load the in-repo default pack
+- invalid pack objects fail clearly
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest -q tests/test_pack_loader.py`
+
+Expected: import / loader failures.
+
+**Step 3: Write minimal implementation**
+
+Create:
+
+- `BaseDomainPack`
+- `WorkflowProfile`
+- `StageHandlerSpec`
+- `load_pack(name)`
+- `load_default_pack()`
+
+Keep this deliberately small. Do not implement external installation yet.
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest -q tests/test_pack_loader.py`
+
+Expected: PASS
+
+---
+
+## Phase 2: Formalize `default-knowledge` As The First Pack
+
+### Task 3: Move current domain metadata into `default-knowledge`
+
+**Files:**
+- Create: `src/openclaw_pipeline/packs/default_knowledge/__init__.py`
+- Create: `src/openclaw_pipeline/packs/default_knowledge/pack.py`
+- Create: `src/openclaw_pipeline/packs/default_knowledge/schemas.py`
+- Create: `src/openclaw_pipeline/packs/default_knowledge/profiles.py`
+- Test: `tests/test_default_knowledge_pack.py`
+
+**Step 1: Write the failing test**
+
+Add tests asserting:
+
+- `default-knowledge` exposes object kinds compatible with current behavior
+- it registers at least `full` and `autopilot` profiles
+- it declares current core stages in the expected order
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest -q tests/test_default_knowledge_pack.py`
+
+Expected: missing pack failures.
+
+**Step 3: Write minimal implementation**
+
+Do not move all logic yet. Only formalize metadata and profile declarations.
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest -q tests/test_default_knowledge_pack.py`
+
+Expected: PASS
+
+---
+
+## Phase 3: Make Workflow Resolution Pack-Aware
+
+### Task 4: Add `--pack` and `--profile` runtime selection
+
+**Files:**
+- Modify: `src/openclaw_pipeline/unified_pipeline_enhanced.py`
+- Modify: `src/openclaw_pipeline/autopilot/daemon.py`
+- Test: `tests/test_pack_profiles.py`
+
+**Step 1: Write the failing test**
+
+Add tests asserting:
+
+- `ovp --pack default-knowledge --profile full` resolves to current full plan
+- `ovp-autopilot --pack default-knowledge --profile autopilot` resolves to current autopilot plan
+- omitting pack/profile preserves old behavior
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest -q tests/test_pack_profiles.py`
+
+Expected: argument parsing / execution-plan mismatch.
+
+**Step 3: Write minimal implementation**
+
+Wire workflow resolution through pack profiles, but preserve:
+
+- existing default behavior
+- existing legacy aliases
+- `--with-refine`
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest -q tests/test_pack_profiles.py`
+
+Expected: PASS
+
+---
+
+## Phase 4: Generalize Registry Toward Object Registry
+
+### Task 5: Introduce pack-aware object metadata without breaking concept registry
+
+**Files:**
+- Create: `src/openclaw_pipeline/object_registry.py`
+- Modify: `src/openclaw_pipeline/concept_registry.py`
+- Test: `tests/test_object_registry.py`
+
+**Step 1: Write the failing test**
+
+Add tests asserting:
+
+- core object records have `id`, `kind`, `pack`, `title`, `status`
+- `concept_registry` can project into the object registry model
+- current concept behavior still works unchanged
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest -q tests/test_object_registry.py tests/test_concept_registry.py`
+
+Expected: missing object registry failures.
+
+**Step 3: Write minimal implementation**
+
+Keep `concept_registry.py` as compatibility surface.
+Do not yet migrate all storage.
+Only add the abstraction layer needed for pack-aware object kinds.
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest -q tests/test_object_registry.py tests/test_concept_registry.py`
+
+Expected: PASS
+
+---
+
+## Phase 5: Pack-Aware Discovery And Evidence
+
+### Task 6: Make discovery hooks pack-aware
+
+**Files:**
+- Modify: `src/openclaw_pipeline/discovery.py`
+- Modify: `src/openclaw_pipeline/evidence.py`
+- Modify: `src/openclaw_pipeline/concept_registry.py`
+- Test: `tests/test_pack_discovery_hooks.py`
+
+**Step 1: Write the failing test**
+
+Add tests asserting:
+
+- the default pack still returns current discovery behavior
+- pack hooks can alter which object kinds are discoverable
+- evidence payloads carry `pack` and `object_kind` context
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest -q tests/test_pack_discovery_hooks.py`
+
+Expected: no pack hook failures.
+
+**Step 3: Write minimal implementation**
+
+Extend discovery/evidence contracts with pack awareness without changing default ranking semantics.
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest -q tests/test_pack_discovery_hooks.py`
+
+Expected: PASS
+
+---
+
+## Phase 6: Plugin Installation Surface
+
+### Task 7: Add plugin manifest discovery and installation hooks
+
+**Files:**
+- Create: `src/openclaw_pipeline/plugins.py`
+- Modify: `pyproject.toml`
+- Modify: `src/openclaw_pipeline/commands/...` as needed
+- Test: `tests/test_plugin_installation.py`
+
+**Step 1: Write the failing test**
+
+Add tests asserting:
+
+- external packs can be discovered through a manifest or entry point
+- plugin metadata is validated
+- missing or incompatible API versions fail clearly
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest -q tests/test_plugin_installation.py`
+
+Expected: plugin discovery failures.
+
+**Step 3: Write minimal implementation**
+
+Start with read-only plugin discovery and loading.
+Do not build a full marketplace.
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest -q tests/test_plugin_installation.py`
+
+Expected: PASS
+
+---
+
+## Phase 7: Documentation And Migration Notes
+
+### Task 8: Rewrite docs around platform/core/pack/profile model
+
+**Files:**
+- Modify: `README.md`
+- Modify: `README_EN.md`
+- Modify: `CLAUDE.md`
+- Create: `docs/architecture/domain-packs.md` or keep under `docs/plans/`
+
+**Step 1: Write doc checklist**
+
+Document:
+
+- what core owns
+- what a pack owns
+- why `default-knowledge` is first
+- why media is external
+- how plugin installation is intended to work
+
+**Step 2: Update docs**
+
+Replace single-domain framing with platform framing while keeping examples grounded in current behavior.
+
+**Step 3: Verify docs reference real commands**
+
+Run:
+
+```bash
+rg "pack|profile|default-knowledge|plugin" README.md README_EN.md CLAUDE.md
+```
+
+Expected: docs reflect the new model consistently.
+
+---
+
+## Phase 8: Full Verification
+
+### Task 9: Run full platform verification
+
+**Files:**
+- Test: full suite
+
+**Step 1: Run focused tests**
+
+```bash
+pytest -q tests/test_default_pack_compat.py tests/test_pack_loader.py tests/test_default_knowledge_pack.py tests/test_pack_profiles.py tests/test_object_registry.py tests/test_pack_discovery_hooks.py tests/test_plugin_installation.py
+```
+
+Expected: PASS
+
+**Step 2: Run full suite**
+
+```bash
+pytest -q
+```
+
+Expected: PASS
+
+**Step 3: Run compile verification**
+
+```bash
+python3 -m compileall src/openclaw_pipeline
+```
+
+Expected: exit 0
+
+**Step 4: Commit**
+
+```bash
+git add .
+git commit -m "feat: introduce domain pack platform architecture"
+```
+
+---
+
+## Notes For The Implementer
+
+- Do not build media support in this repo during the first platform extraction.
+- Do not let plugin packs bypass audit/runtime hooks.
+- Do not break existing CLI semantics while introducing `--pack` and `--profile`.
+- Keep `default-knowledge` behavior identical before generalizing further.
+- The success criterion is not “media works”.
+- The success criterion is:
+
+> the current system works unchanged as `default-knowledge`, and the core is now structurally ready to host external packs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,9 @@ ovp-cleanup = "openclaw_pipeline.commands.cleanup:main"
 ovp-breakdown = "openclaw_pipeline.commands.breakdown:main"
 ovp-knowledge-index = "openclaw_pipeline.commands.knowledge_index:main"
 
+[project.entry-points."openclaw_pipeline.packs"]
+default-knowledge = "openclaw_pipeline.packs.default_knowledge:get_pack"
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/openclaw_pipeline"]
 

--- a/skills/daily-ingestion.md
+++ b/skills/daily-ingestion.md
@@ -25,22 +25,23 @@ git checkout main && git pull origin main
 git status
 ```
 
-## QMD 配置
+## 检索配置
 
-**重要**：必须用 npm/node 运行，不能用 bunx：
+默认不需要 QMD。
+
+当前日常流程的默认 discovery 已经统一到 `knowledge.db`：
+- `ovp-query` 默认使用 `knowledge.db`
+- 关键词检索使用 FTS5 BM25
+- 语义检索使用本地 deterministic embeddings
+
+只有在你需要额外的外部 discovery 对照时，才显式使用 QMD：
 
 ```bash
-# 安装（用 npm，不用 bunx）
-npm install -g @tobilu/qmd
-
-# 初始化 collection
-qmd collection add openclaw ${WIGS_VAULT_DIR:-~/openclaw-vault}
-
-# 生成向量嵌入（首次或更新后）
-node ~/.nvm/versions/node/v22.20.0/lib/node_modules/@tobilu/qmd/dist/cli/qmd.js embed --collection openclaw -f
-
-# 注意：bunx 会导致 sqlite-vec 加载失败（Bun 的 SQLite 不支持扩展加载）
+ovp-query "AI Agent 架构"
+ovp-query --engine qmd "AI Agent 架构"
 ```
+
+QMD 是可选 adapter，不参与自动链接和 canonical 概念决策。
 
 ---
 

--- a/src/openclaw_pipeline/autopilot/daemon.py
+++ b/src/openclaw_pipeline/autopilot/daemon.py
@@ -24,6 +24,7 @@ from threading import Lock
 
 from .queue import TaskQueue, Task
 from ..runtime import resolve_vault_dir
+from ..packs.loader import resolve_workflow_profile
 from .watcher import MultiSourceWatcher
 
 
@@ -161,6 +162,8 @@ class AutoPilotDaemon:
         quality_threshold: float = 3.0,
         auto_commit: bool = True,
         with_refine: bool = False,
+        pack: str | None = None,
+        profile: str | None = None,
     ):
         self.vault_dir = Path(vault_dir)
         self.watch_sources = watch_sources
@@ -169,6 +172,12 @@ class AutoPilotDaemon:
         self.quality_threshold = quality_threshold
         self.auto_commit = auto_commit
         self.with_refine = with_refine
+        self.pack, self.workflow_profile = resolve_workflow_profile(
+            pack_name=pack,
+            profile_name=profile,
+            default_profile="autopilot",
+            require_autopilot=True,
+        )
 
         # 组件初始化
         self.queue = TaskQueue(self.vault_dir / "60-Logs" / "autopilot.db")
@@ -187,6 +196,9 @@ class AutoPilotDaemon:
         # 信号处理
         signal.signal(signal.SIGINT, self._signal_handler)
         signal.signal(signal.SIGTERM, self._signal_handler)
+
+    def _profile_has_stage(self, stage: str) -> bool:
+        return stage in self.workflow_profile.stages
 
     def _signal_handler(self, signum, frame):
         """优雅关闭"""
@@ -308,22 +320,21 @@ class AutoPilotDaemon:
                 result['quality'] = quality
 
             if quality >= self.quality_threshold:
-                # Stage 3: absorb 到知识层
-                self._run_absorb()
-                result['stages'].append('absorb')
+                if self._profile_has_stage('absorb'):
+                    self._run_absorb()
+                    result['stages'].append('absorb')
 
-                # Stage 4: 更新 MOC
-                self._run_moc_update()
-                result['stages'].append('moc')
+                if self._profile_has_stage('moc'):
+                    self._run_moc_update()
+                    result['stages'].append('moc')
 
-                # Stage 5: 可选 Refine
                 if self.with_refine:
                     self._run_refine()
                     result['stages'].append('refine')
 
-                # Stage 6: 刷新 derived knowledge index
-                self._run_knowledge_index_refresh()
-                result['stages'].append('knowledge_index')
+                if self._profile_has_stage('knowledge_index'):
+                    self._run_knowledge_index_refresh()
+                    result['stages'].append('knowledge_index')
 
                 # Stage 7: 自动提交
                 if self.auto_commit:
@@ -698,6 +709,16 @@ def main():
         action="store_true",
         help="在 absorb/moc 之后追加 cleanup + breakdown 批处理"
     )
+    parser.add_argument(
+        "--pack",
+        default=None,
+        help="Domain pack 名称（默认: default-knowledge）",
+    )
+    parser.add_argument(
+        "--profile",
+        default=None,
+        help="Workflow profile 名称（默认: autopilot）",
+    )
 
     args = parser.parse_args()
 
@@ -719,6 +740,8 @@ def main():
         quality_threshold=args.quality,
         auto_commit=not args.no_commit,
         with_refine=args.with_refine,
+        pack=args.pack,
+        profile=args.profile,
     )
 
     daemon.run()

--- a/src/openclaw_pipeline/commands/absorb.py
+++ b/src/openclaw_pipeline/commands/absorb.py
@@ -5,6 +5,7 @@ import json
 from pathlib import Path
 
 from ..auto_evergreen_extractor import run_absorb_workflow
+from ..evidence import build_evidence_payload
 from ..runtime import resolve_vault_dir
 
 
@@ -47,6 +48,17 @@ def main(argv: list[str] | None = None) -> int:
         dry_run=False,
         auto_promote=args.auto_promote,
         promote_threshold=args.promote_threshold,
+    )
+    mentions = [
+        str(concept.get("name") or "")
+        for result in workflow_payload.get("results", [])
+        for concept in result.get("concepts", [])
+        if concept.get("name")
+    ]
+    workflow_payload["evidence"] = build_evidence_payload(
+        vault_dir,
+        mentions=mentions[:10],
+        limit=5,
     )
 
     if args.json:

--- a/src/openclaw_pipeline/commands/breakdown.py
+++ b/src/openclaw_pipeline/commands/breakdown.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from ..refine import (
     analyze_breakdown,
+    attach_proposal_evidence,
     execute_breakdown,
     load_note_targets,
     record_refine_run,
@@ -26,7 +27,7 @@ def main(argv: list[str] | None = None) -> int:
 
     vault_dir = resolve_vault_dir(args.vault_dir)
     targets = load_note_targets(vault_dir, slug=args.slug, all_notes=args.all)
-    proposals = [analyze_breakdown(target) for target in targets]
+    proposals = [attach_proposal_evidence(vault_dir, analyze_breakdown(target)) for target in targets]
     mutations = []
     canonical_refresh = None
     if args.write:

--- a/src/openclaw_pipeline/commands/cleanup.py
+++ b/src/openclaw_pipeline/commands/cleanup.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from ..refine import (
     analyze_cleanup,
+    attach_proposal_evidence,
     execute_cleanup,
     load_note_targets,
     record_refine_run,
@@ -26,7 +27,7 @@ def main(argv: list[str] | None = None) -> int:
 
     vault_dir = resolve_vault_dir(args.vault_dir)
     targets = load_note_targets(vault_dir, slug=args.slug, all_notes=args.all)
-    proposals = [analyze_cleanup(target) for target in targets]
+    proposals = [attach_proposal_evidence(vault_dir, analyze_cleanup(target)) for target in targets]
     mutations = []
     canonical_refresh = None
     if args.write:

--- a/src/openclaw_pipeline/concept_registry.py
+++ b/src/openclaw_pipeline/concept_registry.py
@@ -496,6 +496,12 @@ class ConceptRegistry:
             return results
         return self._legacy_surface_search(query, area=area, topk=topk)
 
+    def to_object_records(self) -> list[Any]:
+        """Project legacy concept entries into pack-aware object records."""
+        from .object_registry import record_from_concept_entry
+
+        return [record_from_concept_entry(entry) for entry in self._entries]
+
     # ========== New Resolution API ==========
 
     def resolve_mention(self, mention: str, area: str | None = None) -> ResolutionResult:

--- a/src/openclaw_pipeline/concept_registry.py
+++ b/src/openclaw_pipeline/concept_registry.py
@@ -38,6 +38,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Iterable
 
+from .discovery import discover_related
+
 try:
     import jieba
     JIEBA_AVAILABLE = True
@@ -95,6 +97,8 @@ class RelatedContext:
     slug: str
     title: str
     score: float
+    engine: str = "knowledge"
+    kind: str = "semantic"
     snippet: str | None = None
 
 
@@ -560,7 +564,7 @@ class ConceptRegistry:
                     normalized_query=norm,
                     matched_surface=norm,
                 )],
-                related_context=self._qmd_related_context(mention),
+                related_context=self._discover_related_context(mention),
             )
 
         # Step 3: Safe near match
@@ -594,7 +598,7 @@ class ConceptRegistry:
                 normalized_query=norm,
                 matched_surface=norm,
             )],
-            related_context=self._qmd_related_context(mention),
+            related_context=self._discover_related_context(mention),
         )
 
     def _dedupe_entries(self, records: list[SurfaceRecord]) -> list[RegistryEntry]:
@@ -864,6 +868,25 @@ class ConceptRegistry:
         except (subprocess.SubprocessError, json.JSONDecodeError, ValueError, TimeoutError):
             return []
 
+    def _discover_related_context(self, mention: str, topk: int = 5) -> list[RelatedContext]:
+        """
+        Shared related-context discovery for candidate/review flows.
+
+        This is auxiliary only. It never determines canonical identity.
+        """
+        rows = discover_related(self.vault_dir, mention, engine="knowledge", limit=topk)
+        return [
+            RelatedContext(
+                slug=str(row["slug"]),
+                title=str(row["title"]),
+                score=float(row["score"]),
+                engine=str(row.get("engine") or "knowledge"),
+                kind=str(row.get("kind") or "semantic"),
+                snippet=str(row.get("snippet") or "") or None,
+            )
+            for row in rows
+        ]
+
     # ========== Legacy Search Methods (Deprecated) ==========
 
     def _search_via_qmd(self, query: str, area: str | None, topk: int) -> list[tuple[ConceptEntry, float]]:
@@ -1118,7 +1141,7 @@ class ConceptRegistry:
         maps to multiple different slugs (e.g., "MCP" and "MCP-Protocol").
 
         Resolution logic:
-        - If QMD similarity between entries > similarity_threshold -> merge_as_alias
+        - QMD similarity is a review signal, not an automatic merge trigger
         - If QMD similarity between entries > min_similarity_for_merge -> review_needed
         - If QMD similarity < min_similarity_for_merge -> separate (remove conflict aliases)
 
@@ -1200,10 +1223,6 @@ class ConceptRegistry:
             if sentence_like_entries:
                 conflict_info["action"] = "review_title"
                 results["review_needed"].append(conflict_info)
-            elif avg_similarity >= similarity_threshold:
-                conflict_info["action"] = "merge"
-                conflict_info["target_slug"] = unique_slugs[0]  # Keep first as canonical
-                results["merge_candidates"].append(conflict_info)
             elif avg_similarity >= min_similarity_for_merge:
                 conflict_info["action"] = "review"
                 results["review_needed"].append(conflict_info)

--- a/src/openclaw_pipeline/discovery.py
+++ b/src/openclaw_pipeline/discovery.py
@@ -5,6 +5,8 @@ import sqlite3
 import subprocess
 from pathlib import Path
 
+from .packs.base import BaseDomainPack
+from .packs.loader import load_pack
 from .runtime import resolve_vault_dir
 
 
@@ -122,32 +124,90 @@ def _discover_with_qmd(vault_dir: Path, query: str, limit: int) -> list[dict[str
     return rows[:limit]
 
 
+def _resolve_pack(pack: str | BaseDomainPack | None) -> BaseDomainPack:
+    if isinstance(pack, BaseDomainPack):
+        return pack
+    return load_pack(pack or "default-knowledge")
+
+
+def _slug_object_kinds(vault_dir: Path) -> dict[str, str]:
+    from .concept_registry import ConceptRegistry
+
+    registry = ConceptRegistry(vault_dir).load()
+    return {entry.slug: entry.kind for entry in registry.entries}
+
+
+def _annotate_discovery_rows(
+    vault_dir: Path,
+    rows: list[dict[str, object]],
+    pack: BaseDomainPack,
+) -> list[dict[str, object]]:
+    slug_kinds = _slug_object_kinds(vault_dir)
+    allowed_kinds = set(pack.discoverable_object_kinds())
+
+    annotated: list[dict[str, object]] = []
+    for row in rows:
+        slug = str(row.get("slug") or "")
+        object_kind = slug_kinds.get(slug, "document")
+        if allowed_kinds and object_kind not in allowed_kinds:
+            continue
+        normalized = dict(row)
+        normalized["pack"] = pack.name
+        normalized["object_kind"] = object_kind
+        annotated.append(normalized)
+    return annotated
+
+
 def discover_related(
     vault_dir: Path,
     query: str,
     *,
     engine: str = "knowledge",
     limit: int = 10,
+    pack: str | BaseDomainPack | None = None,
 ) -> list[dict[str, object]]:
     resolved_vault = resolve_vault_dir(vault_dir)
+    resolved_pack = _resolve_pack(pack)
     if engine == "knowledge":
-        return _discover_with_knowledge(resolved_vault, query, limit)
+        return _annotate_discovery_rows(
+            resolved_vault,
+            _discover_with_knowledge(resolved_vault, query, limit),
+            resolved_pack,
+        )
     if engine == "qmd":
-        return _discover_with_qmd(resolved_vault, query, limit)
+        return _annotate_discovery_rows(
+            resolved_vault,
+            _discover_with_qmd(resolved_vault, query, limit),
+            resolved_pack,
+        )
     raise ValueError(f"Unsupported discovery engine: {engine}")
 
 
-def discover_identity_context(registry: object, mention: str) -> dict[str, object]:
+def discover_identity_context(
+    registry: object,
+    mention: str,
+    *,
+    pack: str | BaseDomainPack | None = None,
+) -> dict[str, object]:
+    resolved_pack = _resolve_pack(pack)
     resolution = registry.resolve_mention(mention)
     return {
         "action": resolution.action.value if hasattr(resolution.action, "value") else str(resolution.action),
         "mention": resolution.mention,
         "normalized_mention": resolution.normalized_mention,
         "entry_slug": resolution.entry.slug if resolution.entry else "",
+        "pack": resolved_pack.name,
+        "object_kind": getattr(registry.find_by_slug(resolution.entry.slug), "kind", "document") if resolution.entry else "",
         "confidence": resolution.confidence,
         "ambiguous_slugs": [entry.slug for entry in resolution.ambiguous_entries],
     }
 
 
-def discover_query_context(vault_dir: Path, query: str, *, limit: int = 10) -> list[dict[str, object]]:
-    return discover_related(vault_dir, query, engine="knowledge", limit=limit)
+def discover_query_context(
+    vault_dir: Path,
+    query: str,
+    *,
+    limit: int = 10,
+    pack: str | BaseDomainPack | None = None,
+) -> list[dict[str, object]]:
+    return discover_related(vault_dir, query, engine="knowledge", limit=limit, pack=pack)

--- a/src/openclaw_pipeline/discovery.py
+++ b/src/openclaw_pipeline/discovery.py
@@ -37,13 +37,15 @@ def _discover_with_knowledge(vault_dir: Path, query: str, limit: int) -> list[di
     from .knowledge_index import get_knowledge_page, query_knowledge_index
 
     lexical_rows = [row for row in _safe_search_knowledge(vault_dir, query, limit=limit) if float(row.get("score", 0.0)) > 0.0]
-    semantic_rows = query_knowledge_index(vault_dir, query, limit=limit)
 
     results: list[dict[str, object]] = []
-    seen: set[tuple[str, str]] = set()
+    seen_slugs: set[str] = set()
 
     for row in lexical_rows:
         slug = str(row["slug"])
+        if slug in seen_slugs:
+            continue
+        seen_slugs.add(slug)
         page = get_knowledge_page(vault_dir, slug)
         entry = {
             "engine": "knowledge",
@@ -54,32 +56,35 @@ def _discover_with_knowledge(vault_dir: Path, query: str, limit: int) -> list[di
             "snippet": _snippet_from_page(page),
             "path": str(page["path"]) if page else "",
         }
-        key = (entry["kind"], slug)
-        if key not in seen:
-            seen.add(key)
-            results.append(entry)
+        results.append(entry)
 
+    if len(results) >= limit:
+        return results[:limit]
+
+    semantic_rows = query_knowledge_index(vault_dir, query, limit=limit)
     for row in semantic_rows:
         slug = str(row["slug"])
+        if slug in seen_slugs:
+            continue
+        seen_slugs.add(slug)
         page = get_knowledge_page(vault_dir, slug)
         title = str(page["title"]) if page else slug
         snippet = str(row.get("chunk_text") or "")[:180]
-        entry = {
-            "engine": "knowledge",
-            "kind": "semantic",
-            "slug": slug,
-            "title": title,
-            "score": float(row["score"]),
-            "snippet": snippet,
-            "path": str(page["path"]) if page else "",
-            "section_title": str(row.get("section_title") or ""),
-        }
-        key = (entry["kind"], slug)
-        if key not in seen:
-            seen.add(key)
-            results.append(entry)
+        results.append(
+            {
+                "engine": "knowledge",
+                "kind": "semantic",
+                "slug": slug,
+                "title": title,
+                "score": float(row["score"]),
+                "snippet": snippet,
+                "path": str(page["path"]) if page else "",
+                "section_title": str(row.get("section_title") or ""),
+            }
+        )
+        if len(results) >= limit:
+            break
 
-    results.sort(key=lambda item: (item["kind"] != "lexical", -float(item["score"])))
     return results[:limit]
 
 

--- a/src/openclaw_pipeline/discovery.py
+++ b/src/openclaw_pipeline/discovery.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import re
+import sqlite3
+import subprocess
+from pathlib import Path
+
+from .runtime import resolve_vault_dir
+
+
+def _snippet_from_page(page: dict[str, object] | None, fallback: str = "") -> str:
+    if page is None:
+        return fallback
+    body = str(page.get("body") or "").strip()
+    if not body:
+        return fallback
+    normalized = " ".join(body.split())
+    return normalized[:180]
+
+
+def _safe_search_knowledge(vault_dir: Path, query: str, limit: int) -> list[dict[str, object]]:
+    from .knowledge_index import search_knowledge_index
+
+    try:
+        return search_knowledge_index(vault_dir, query, limit=limit)
+    except sqlite3.OperationalError:
+        normalized_terms = re.findall(r"[A-Za-z0-9]+", query)
+        if not normalized_terms:
+            return []
+        safe_query = " ".join(f'"{term}"' for term in normalized_terms)
+        return search_knowledge_index(vault_dir, safe_query, limit=limit)
+
+
+def _discover_with_knowledge(vault_dir: Path, query: str, limit: int) -> list[dict[str, object]]:
+    from .knowledge_index import get_knowledge_page, query_knowledge_index
+
+    lexical_rows = [row for row in _safe_search_knowledge(vault_dir, query, limit=limit) if float(row.get("score", 0.0)) > 0.0]
+    semantic_rows = query_knowledge_index(vault_dir, query, limit=limit)
+
+    results: list[dict[str, object]] = []
+    seen: set[tuple[str, str]] = set()
+
+    for row in lexical_rows:
+        slug = str(row["slug"])
+        page = get_knowledge_page(vault_dir, slug)
+        entry = {
+            "engine": "knowledge",
+            "kind": "lexical",
+            "slug": slug,
+            "title": str(row["title"]),
+            "score": float(row["score"]),
+            "snippet": _snippet_from_page(page),
+            "path": str(page["path"]) if page else "",
+        }
+        key = (entry["kind"], slug)
+        if key not in seen:
+            seen.add(key)
+            results.append(entry)
+
+    for row in semantic_rows:
+        slug = str(row["slug"])
+        page = get_knowledge_page(vault_dir, slug)
+        title = str(page["title"]) if page else slug
+        snippet = str(row.get("chunk_text") or "")[:180]
+        entry = {
+            "engine": "knowledge",
+            "kind": "semantic",
+            "slug": slug,
+            "title": title,
+            "score": float(row["score"]),
+            "snippet": snippet,
+            "path": str(page["path"]) if page else "",
+            "section_title": str(row.get("section_title") or ""),
+        }
+        key = (entry["kind"], slug)
+        if key not in seen:
+            seen.add(key)
+            results.append(entry)
+
+    results.sort(key=lambda item: (item["kind"] != "lexical", -float(item["score"])))
+    return results[:limit]
+
+
+def _discover_with_qmd(vault_dir: Path, query: str, limit: int) -> list[dict[str, object]]:  # noqa: ARG001
+    try:
+        result = subprocess.run(
+            ["qmd", "search", query, "--limit", str(limit)],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError) as exc:
+        raise RuntimeError("QMD engine requested but qmd is not available") from exc
+
+    if result.returncode != 0:
+        raise RuntimeError("QMD engine requested but qmd is not available")
+
+    rows: list[dict[str, object]] = []
+    for line in result.stdout.strip().splitlines():
+        if "|" not in line:
+            continue
+        parts = [part.strip() for part in line.split("|")]
+        if len(parts) < 3:
+            continue
+        file_path, score_text, title = parts[:3]
+        slug = Path(file_path).stem
+        try:
+            score = float(score_text)
+        except ValueError:
+            score = 0.0
+        rows.append(
+            {
+                "engine": "qmd",
+                "kind": "semantic",
+                "slug": slug,
+                "title": title,
+                "score": score,
+                "snippet": "",
+                "path": file_path,
+            }
+        )
+    return rows[:limit]
+
+
+def discover_related(
+    vault_dir: Path,
+    query: str,
+    *,
+    engine: str = "knowledge",
+    limit: int = 10,
+) -> list[dict[str, object]]:
+    resolved_vault = resolve_vault_dir(vault_dir)
+    if engine == "knowledge":
+        return _discover_with_knowledge(resolved_vault, query, limit)
+    if engine == "qmd":
+        return _discover_with_qmd(resolved_vault, query, limit)
+    raise ValueError(f"Unsupported discovery engine: {engine}")
+
+
+def discover_identity_context(registry: object, mention: str) -> dict[str, object]:
+    resolution = registry.resolve_mention(mention)
+    return {
+        "action": resolution.action.value if hasattr(resolution.action, "value") else str(resolution.action),
+        "mention": resolution.mention,
+        "normalized_mention": resolution.normalized_mention,
+        "entry_slug": resolution.entry.slug if resolution.entry else "",
+        "confidence": resolution.confidence,
+        "ambiguous_slugs": [entry.slug for entry in resolution.ambiguous_entries],
+    }
+
+
+def discover_query_context(vault_dir: Path, query: str, *, limit: int = 10) -> list[dict[str, object]]:
+    return discover_related(vault_dir, query, engine="knowledge", limit=limit)

--- a/src/openclaw_pipeline/evidence.py
+++ b/src/openclaw_pipeline/evidence.py
@@ -6,10 +6,32 @@ from typing import Any
 
 from .discovery import discover_related
 from .knowledge_index import knowledge_index_stats, recent_audit_events
+from .packs.base import BaseDomainPack
+from .packs.loader import load_pack
 from .runtime import VaultLayout, resolve_vault_dir
 
 
-def _build_identity_evidence(vault_dir: Path, mentions: list[str], registry: Any | None = None) -> list[dict[str, object]]:
+def _resolve_pack(pack: str | BaseDomainPack | None) -> BaseDomainPack:
+    if isinstance(pack, BaseDomainPack):
+        return pack
+    return load_pack(pack or "default-knowledge")
+
+
+def _slug_object_kinds(vault_dir: Path, registry: Any | None = None) -> dict[str, str]:
+    if registry is None:
+        from .concept_registry import ConceptRegistry
+
+        registry = ConceptRegistry(vault_dir).load()
+    return {entry.slug: entry.kind for entry in registry.entries}
+
+
+def _build_identity_evidence(
+    vault_dir: Path,
+    mentions: list[str],
+    registry: Any | None = None,
+    *,
+    pack: BaseDomainPack,
+) -> list[dict[str, object]]:
     if not mentions:
         return []
     if registry is None:
@@ -27,13 +49,22 @@ def _build_identity_evidence(vault_dir: Path, mentions: list[str], registry: Any
                 "action": result.action.value if hasattr(result.action, "value") else str(result.action),
                 "confidence": result.confidence,
                 "entry_slug": result.entry.slug if result.entry else "",
+                "pack": pack.name,
+                "object_kind": getattr(registry.find_by_slug(result.entry.slug), "kind", "document") if result.entry else "",
                 "ambiguous_slugs": [entry.slug for entry in result.ambiguous_entries],
             }
         )
     return evidence
 
 
-def _build_retrieval_evidence(vault_dir: Path, query: str | None, mentions: list[str], limit: int) -> list[dict[str, object]]:
+def _build_retrieval_evidence(
+    vault_dir: Path,
+    query: str | None,
+    mentions: list[str],
+    limit: int,
+    *,
+    pack: BaseDomainPack,
+) -> list[dict[str, object]]:
     retrieval_queries = []
     if query:
         retrieval_queries.append(query)
@@ -42,7 +73,7 @@ def _build_retrieval_evidence(vault_dir: Path, query: str | None, mentions: list
     results: list[dict[str, object]] = []
     seen: set[tuple[str, str, str]] = set()
     for item_query in retrieval_queries[:3]:
-        for row in discover_related(vault_dir, item_query, engine="knowledge", limit=limit):
+        for row in discover_related(vault_dir, item_query, engine="knowledge", limit=limit, pack=pack):
             normalized = {
                 "channel": "retrieval",
                 "query": item_query,
@@ -50,6 +81,8 @@ def _build_retrieval_evidence(vault_dir: Path, query: str | None, mentions: list
                 "kind": row.get("kind", "semantic"),
                 "slug": row.get("slug", ""),
                 "title": row.get("title", ""),
+                "pack": row.get("pack", pack.name),
+                "object_kind": row.get("object_kind", "document"),
                 "score": float(row.get("score") or 0.0),
                 "snippet": row.get("snippet", ""),
                 "path": row.get("path", ""),
@@ -62,7 +95,14 @@ def _build_retrieval_evidence(vault_dir: Path, query: str | None, mentions: list
     return results[:limit]
 
 
-def _build_graph_evidence(vault_dir: Path, slugs: list[str], limit: int) -> list[dict[str, object]]:
+def _build_graph_evidence(
+    vault_dir: Path,
+    slugs: list[str],
+    limit: int,
+    *,
+    pack: BaseDomainPack,
+    slug_kinds: dict[str, str],
+) -> list[dict[str, object]]:
     if not slugs:
         return []
 
@@ -81,24 +121,36 @@ def _build_graph_evidence(vault_dir: Path, slugs: list[str], limit: int) -> list
     return [
         {
             "channel": "graph",
+            "pack": pack.name,
             "source_slug": source_slug,
             "target_slug": target_slug,
+            "source_kind": slug_kinds.get(source_slug, "document"),
+            "target_kind": slug_kinds.get(target_slug, "document"),
             "link_type": link_type,
         }
         for source_slug, target_slug, link_type in rows
     ]
 
 
-def _build_audit_evidence(vault_dir: Path, slugs: list[str], limit: int) -> list[dict[str, object]]:
+def _build_audit_evidence(
+    vault_dir: Path,
+    slugs: list[str],
+    limit: int,
+    *,
+    pack: BaseDomainPack,
+    slug_kinds: dict[str, str],
+) -> list[dict[str, object]]:
     rows = recent_audit_events(vault_dir, limit=max(limit * 5, 10))
     if slugs:
         rows = [row for row in rows if row.get("slug") in slugs]
     return [
         {
             "channel": "audit",
+            "pack": pack.name,
             "source_log": row.get("source_log", ""),
             "event_type": row.get("event_type", ""),
             "slug": row.get("slug", ""),
+            "object_kind": slug_kinds.get(str(row.get("slug") or ""), "document"),
             "timestamp": row.get("timestamp", ""),
         }
         for row in rows[:limit]
@@ -113,18 +165,44 @@ def build_evidence_payload(
     slugs: list[str] | None = None,
     limit: int = 5,
     registry: Any | None = None,
+    pack: str | BaseDomainPack | None = None,
 ) -> dict[str, list[dict[str, object]]]:
     resolved_vault = resolve_vault_dir(vault_dir)
+    resolved_pack = _resolve_pack(pack)
     mentions = [mention for mention in (mentions or []) if mention]
-    identity_evidence = _build_identity_evidence(resolved_vault, mentions or ([query] if query else []), registry=registry)
-    retrieval_evidence = _build_retrieval_evidence(resolved_vault, query, mentions, limit=limit)
+    identity_evidence = _build_identity_evidence(
+        resolved_vault,
+        mentions or ([query] if query else []),
+        registry=registry,
+        pack=resolved_pack,
+    )
+    retrieval_evidence = _build_retrieval_evidence(
+        resolved_vault,
+        query,
+        mentions,
+        limit=limit,
+        pack=resolved_pack,
+    )
 
     derived_slugs = [str(row.get("slug") or "") for row in retrieval_evidence if row.get("slug")]
     graph_targets = list(dict.fromkeys([*(slugs or []), *derived_slugs]))
+    slug_kinds = _slug_object_kinds(resolved_vault, registry=registry)
 
     return {
         "identity_evidence": identity_evidence,
         "retrieval_evidence": retrieval_evidence,
-        "graph_evidence": _build_graph_evidence(resolved_vault, graph_targets, limit=limit),
-        "audit_evidence": _build_audit_evidence(resolved_vault, graph_targets, limit=limit),
+        "graph_evidence": _build_graph_evidence(
+            resolved_vault,
+            graph_targets,
+            limit=limit,
+            pack=resolved_pack,
+            slug_kinds=slug_kinds,
+        ),
+        "audit_evidence": _build_audit_evidence(
+            resolved_vault,
+            graph_targets,
+            limit=limit,
+            pack=resolved_pack,
+            slug_kinds=slug_kinds,
+        ),
     }

--- a/src/openclaw_pipeline/evidence.py
+++ b/src/openclaw_pipeline/evidence.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from .discovery import discover_related
+from .knowledge_index import knowledge_index_stats, recent_audit_events
+from .runtime import VaultLayout, resolve_vault_dir
+
+
+def _build_identity_evidence(vault_dir: Path, mentions: list[str], registry: Any | None = None) -> list[dict[str, object]]:
+    if not mentions:
+        return []
+    if registry is None:
+        from .concept_registry import ConceptRegistry
+
+        registry = ConceptRegistry(vault_dir).load()
+
+    evidence = []
+    for mention in mentions:
+        result = registry.resolve_mention(mention)
+        evidence.append(
+            {
+                "channel": "identity",
+                "mention": mention,
+                "action": result.action.value if hasattr(result.action, "value") else str(result.action),
+                "confidence": result.confidence,
+                "entry_slug": result.entry.slug if result.entry else "",
+                "ambiguous_slugs": [entry.slug for entry in result.ambiguous_entries],
+            }
+        )
+    return evidence
+
+
+def _build_retrieval_evidence(vault_dir: Path, query: str | None, mentions: list[str], limit: int) -> list[dict[str, object]]:
+    retrieval_queries = []
+    if query:
+        retrieval_queries.append(query)
+    retrieval_queries.extend(mention for mention in mentions if mention and mention not in retrieval_queries)
+
+    results: list[dict[str, object]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for item_query in retrieval_queries[:3]:
+        for row in discover_related(vault_dir, item_query, engine="knowledge", limit=limit):
+            normalized = {
+                "channel": "retrieval",
+                "query": item_query,
+                "engine": row.get("engine", "knowledge"),
+                "kind": row.get("kind", "semantic"),
+                "slug": row.get("slug", ""),
+                "title": row.get("title", ""),
+                "score": float(row.get("score") or 0.0),
+                "snippet": row.get("snippet", ""),
+                "path": row.get("path", ""),
+            }
+            key = (str(normalized["query"]), str(normalized["kind"]), str(normalized["slug"]))
+            if key in seen:
+                continue
+            seen.add(key)
+            results.append(normalized)
+    return results[:limit]
+
+
+def _build_graph_evidence(vault_dir: Path, slugs: list[str], limit: int) -> list[dict[str, object]]:
+    if not slugs:
+        return []
+
+    knowledge_index_stats(vault_dir)
+    layout = VaultLayout.from_vault(vault_dir)
+    placeholders = ",".join("?" for _ in slugs)
+    query = f"""
+        SELECT source_slug, target_slug, link_type
+        FROM page_links
+        WHERE source_slug IN ({placeholders}) OR target_slug IN ({placeholders})
+        LIMIT ?
+    """
+    with sqlite3.connect(layout.knowledge_db) as conn:
+        rows = conn.execute(query, (*slugs, *slugs, limit)).fetchall()
+
+    return [
+        {
+            "channel": "graph",
+            "source_slug": source_slug,
+            "target_slug": target_slug,
+            "link_type": link_type,
+        }
+        for source_slug, target_slug, link_type in rows
+    ]
+
+
+def _build_audit_evidence(vault_dir: Path, slugs: list[str], limit: int) -> list[dict[str, object]]:
+    rows = recent_audit_events(vault_dir, limit=max(limit * 5, 10))
+    if slugs:
+        rows = [row for row in rows if row.get("slug") in slugs]
+    return [
+        {
+            "channel": "audit",
+            "source_log": row.get("source_log", ""),
+            "event_type": row.get("event_type", ""),
+            "slug": row.get("slug", ""),
+            "timestamp": row.get("timestamp", ""),
+        }
+        for row in rows[:limit]
+    ]
+
+
+def build_evidence_payload(
+    vault_dir: Path,
+    *,
+    query: str | None = None,
+    mentions: list[str] | None = None,
+    slugs: list[str] | None = None,
+    limit: int = 5,
+    registry: Any | None = None,
+) -> dict[str, list[dict[str, object]]]:
+    resolved_vault = resolve_vault_dir(vault_dir)
+    mentions = [mention for mention in (mentions or []) if mention]
+    identity_evidence = _build_identity_evidence(resolved_vault, mentions or ([query] if query else []), registry=registry)
+    retrieval_evidence = _build_retrieval_evidence(resolved_vault, query, mentions, limit=limit)
+
+    derived_slugs = [str(row.get("slug") or "") for row in retrieval_evidence if row.get("slug")]
+    graph_targets = list(dict.fromkeys([*(slugs or []), *derived_slugs]))
+
+    return {
+        "identity_evidence": identity_evidence,
+        "retrieval_evidence": retrieval_evidence,
+        "graph_evidence": _build_graph_evidence(resolved_vault, graph_targets, limit=limit),
+        "audit_evidence": _build_audit_evidence(resolved_vault, graph_targets, limit=limit),
+    }

--- a/src/openclaw_pipeline/object_registry.py
+++ b/src/openclaw_pipeline/object_registry.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .concept_registry import ConceptEntry, ConceptRegistry
+
+
+DEFAULT_OBJECT_PACK = "default-knowledge"
+
+
+@dataclass(frozen=True)
+class ObjectRecord:
+    id: str
+    kind: str
+    pack: str
+    title: str
+    status: str
+    aliases: tuple[str, ...] = ()
+    area: str | None = None
+    canonical_ref: str | None = None
+    meta: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass
+class ObjectRegistry:
+    _records: list[ObjectRecord]
+
+    def records(self) -> list[ObjectRecord]:
+        return list(self._records)
+
+    def find_by_id(self, object_id: str) -> ObjectRecord | None:
+        for record in self._records:
+            if record.id == object_id:
+                return record
+        return None
+
+    @classmethod
+    def from_concept_registry(cls, registry: ConceptRegistry) -> ObjectRegistry:
+        return cls([record_from_concept_entry(entry) for entry in registry.entries])
+
+
+def record_from_concept_entry(entry: ConceptEntry) -> ObjectRecord:
+    return ObjectRecord(
+        id=entry.slug,
+        kind=entry.kind,
+        pack=DEFAULT_OBJECT_PACK,
+        title=entry.title,
+        status=entry.status,
+        aliases=tuple(entry.aliases),
+        area=entry.area,
+        canonical_ref=entry.slug,
+        meta={
+            "resolver_enabled": entry.resolver_enabled,
+            "source_count": entry.source_count,
+            "evidence_count": entry.evidence_count,
+        },
+    )

--- a/src/openclaw_pipeline/packs/__init__.py
+++ b/src/openclaw_pipeline/packs/__init__.py
@@ -1,0 +1,11 @@
+from .base import BaseDomainPack, ObjectKindSpec, StageHandlerSpec, WorkflowProfile
+from .loader import load_default_pack, load_pack
+
+__all__ = [
+    "BaseDomainPack",
+    "ObjectKindSpec",
+    "StageHandlerSpec",
+    "WorkflowProfile",
+    "load_default_pack",
+    "load_pack",
+]

--- a/src/openclaw_pipeline/packs/base.py
+++ b/src/openclaw_pipeline/packs/base.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class ObjectKindSpec:
+    kind: str
+    display_name: str
+    description: str
+    canonical: bool = True
+    schema_ref: str | None = None
+
+
+@dataclass(frozen=True)
+class WorkflowProfile:
+    name: str
+    description: str
+    stages: list[str]
+    supports_autopilot: bool = False
+
+
+@dataclass(frozen=True)
+class StageHandlerSpec:
+    stage: str
+    description: str = ""
+
+
+@dataclass
+class BaseDomainPack:
+    name: str
+    version: str
+    api_version: int
+    _object_kinds: list[ObjectKindSpec] = field(default_factory=list)
+    _workflow_profiles: list[WorkflowProfile] = field(default_factory=list)
+    _discoverable_object_kinds: list[str] = field(default_factory=list)
+
+    def object_kinds(self) -> list[ObjectKindSpec]:
+        return list(self._object_kinds)
+
+    def workflow_profiles(self) -> list[WorkflowProfile]:
+        return list(self._workflow_profiles)
+
+    def discoverable_object_kinds(self) -> list[str]:
+        if self._discoverable_object_kinds:
+            return list(self._discoverable_object_kinds)
+        return [item.kind for item in self._object_kinds]
+
+    def profile(self, name: str) -> WorkflowProfile:
+        for profile in self._workflow_profiles:
+            if profile.name == name:
+                return profile
+        raise ValueError(f"Unknown workflow profile '{name}' for pack '{self.name}'")

--- a/src/openclaw_pipeline/packs/default_knowledge/__init__.py
+++ b/src/openclaw_pipeline/packs/default_knowledge/__init__.py
@@ -1,0 +1,3 @@
+from .pack import get_pack
+
+__all__ = ["get_pack"]

--- a/src/openclaw_pipeline/packs/default_knowledge/pack.py
+++ b/src/openclaw_pipeline/packs/default_knowledge/pack.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from ..base import BaseDomainPack
+from .profiles import DEFAULT_KNOWLEDGE_AUTOPILOT_PROFILE, DEFAULT_KNOWLEDGE_FULL_PROFILE
+from .schemas import DEFAULT_KNOWLEDGE_OBJECT_KINDS
+
+
+def get_pack() -> BaseDomainPack:
+    return BaseDomainPack(
+        name="default-knowledge",
+        version="0.1.0",
+        api_version=1,
+        _object_kinds=list(DEFAULT_KNOWLEDGE_OBJECT_KINDS),
+        _workflow_profiles=[
+            DEFAULT_KNOWLEDGE_FULL_PROFILE,
+            DEFAULT_KNOWLEDGE_AUTOPILOT_PROFILE,
+        ],
+    )

--- a/src/openclaw_pipeline/packs/default_knowledge/profiles.py
+++ b/src/openclaw_pipeline/packs/default_knowledge/profiles.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from ..base import WorkflowProfile
+
+
+DEFAULT_KNOWLEDGE_FULL_PROFILE = WorkflowProfile(
+    name="full",
+    description="Default knowledge full pipeline",
+    stages=[
+        "pinboard",
+        "pinboard_process",
+        "clippings",
+        "articles",
+        "quality",
+        "fix_links",
+        "absorb",
+        "registry_sync",
+        "moc",
+        "knowledge_index",
+    ],
+)
+
+DEFAULT_KNOWLEDGE_AUTOPILOT_PROFILE = WorkflowProfile(
+    name="autopilot",
+    description="Default knowledge autopilot runtime",
+    stages=[
+        "interpretation",
+        "quality",
+        "absorb",
+        "moc",
+        "knowledge_index",
+    ],
+    supports_autopilot=True,
+)

--- a/src/openclaw_pipeline/packs/default_knowledge/schemas.py
+++ b/src/openclaw_pipeline/packs/default_knowledge/schemas.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from ..base import ObjectKindSpec
+
+
+DEFAULT_KNOWLEDGE_OBJECT_KINDS = [
+    ObjectKindSpec(
+        kind="concept",
+        display_name="Concept",
+        description="Canonical concept-like knowledge object",
+        canonical=True,
+    ),
+    ObjectKindSpec(
+        kind="entity",
+        display_name="Entity",
+        description="Named people, organizations, tools, or products",
+        canonical=True,
+    ),
+    ObjectKindSpec(
+        kind="evergreen",
+        display_name="Evergreen",
+        description="Reusable evergreen note in the default knowledge pack",
+        canonical=True,
+    ),
+    ObjectKindSpec(
+        kind="document",
+        display_name="Document",
+        description="Interpreted or raw document artifact tracked by the pack",
+        canonical=False,
+    ),
+]

--- a/src/openclaw_pipeline/packs/loader.py
+++ b/src/openclaw_pipeline/packs/loader.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from .base import BaseDomainPack, WorkflowProfile
+
+
+DEFAULT_PACK_NAME = "default-knowledge"
+
+
+def load_default_pack() -> BaseDomainPack:
+    from .default_knowledge import get_pack
+
+    pack = get_pack()
+    if not isinstance(pack, BaseDomainPack):
+        raise TypeError("default pack entrypoint did not return a BaseDomainPack")
+    return pack
+
+
+def load_pack(name: str) -> BaseDomainPack:
+    if name == DEFAULT_PACK_NAME:
+        return load_default_pack()
+    from ..plugins import discover_entrypoint_packs, discover_plugin_manifests, load_manifest_pack
+
+    entrypoint_packs = discover_entrypoint_packs()
+    if name in entrypoint_packs:
+        return entrypoint_packs[name]
+
+    manifest_env = os.environ.get("OPENCLAW_PACK_MANIFESTS", "")
+    manifest_paths = [Path(item) for item in manifest_env.split(":") if item]
+    if manifest_paths:
+        manifests = discover_plugin_manifests(manifest_paths)
+        if name in manifests:
+            return load_manifest_pack(manifests[name])
+    raise ValueError(f"Unknown pack: {name}")
+
+
+def resolve_workflow_profile(
+    *,
+    pack_name: str | None = None,
+    profile_name: str | None = None,
+    default_profile: str,
+    require_autopilot: bool = False,
+) -> tuple[BaseDomainPack, WorkflowProfile]:
+    """Resolve a pack/profile pair with stable defaults."""
+
+    resolved_pack_name = pack_name or DEFAULT_PACK_NAME
+    resolved_profile_name = profile_name or default_profile
+
+    pack = load_pack(resolved_pack_name)
+    profile = pack.profile(resolved_profile_name)
+
+    if require_autopilot and not profile.supports_autopilot:
+        raise ValueError(
+            f"Workflow profile '{resolved_profile_name}' for pack '{resolved_pack_name}' "
+            "does not support autopilot"
+        )
+
+    return pack, profile

--- a/src/openclaw_pipeline/plugins.py
+++ b/src/openclaw_pipeline/plugins.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib import import_module, metadata
+from pathlib import Path
+from typing import Iterable
+
+import yaml
+
+from .packs.base import BaseDomainPack
+
+
+PACK_API_VERSION = 1
+ENTRYPOINT_GROUP = "openclaw_pipeline.packs"
+
+
+@dataclass(frozen=True)
+class PluginManifest:
+    name: str
+    version: str
+    api_version: int
+    pack_entrypoint: str
+    manifest_path: Path
+
+
+def _validate_manifest_data(data: dict[str, object], manifest_path: Path) -> PluginManifest:
+    for field_name in ("name", "version", "api_version", "entrypoints"):
+        if field_name not in data:
+            raise ValueError(f"Plugin manifest {manifest_path} missing required field: {field_name}")
+
+    entrypoints = data["entrypoints"]
+    if not isinstance(entrypoints, dict) or "pack" not in entrypoints:
+        raise ValueError(f"Plugin manifest {manifest_path} missing required field: entrypoints.pack")
+
+    return PluginManifest(
+        name=str(data["name"]),
+        version=str(data["version"]),
+        api_version=int(data["api_version"]),
+        pack_entrypoint=str(entrypoints["pack"]),
+        manifest_path=manifest_path,
+    )
+
+
+def discover_plugin_manifests(manifest_paths: Iterable[Path]) -> dict[str, PluginManifest]:
+    manifests: dict[str, PluginManifest] = {}
+    for manifest_path in manifest_paths:
+        with open(manifest_path, "r", encoding="utf-8") as handle:
+            raw = yaml.safe_load(handle) or {}
+        manifest = _validate_manifest_data(raw, Path(manifest_path))
+        manifests[manifest.name] = manifest
+    return manifests
+
+
+def _load_pack_entrypoint(entrypoint: str) -> BaseDomainPack:
+    module_name, attr_name = entrypoint.split(":", 1)
+    target = getattr(import_module(module_name), attr_name)
+    pack = target() if callable(target) else target
+    if not isinstance(pack, BaseDomainPack):
+        raise TypeError(f"Pack entrypoint {entrypoint} did not return BaseDomainPack")
+    if pack.api_version != PACK_API_VERSION:
+        raise ValueError(
+            f"Pack {pack.name} api_version {pack.api_version} is incompatible with core api_version {PACK_API_VERSION}"
+        )
+    return pack
+
+
+def load_manifest_pack(manifest: PluginManifest) -> BaseDomainPack:
+    if manifest.api_version != PACK_API_VERSION:
+        raise ValueError(
+            f"Plugin manifest {manifest.manifest_path} api_version {manifest.api_version} "
+            f"is incompatible with core api_version {PACK_API_VERSION}"
+        )
+    return _load_pack_entrypoint(manifest.pack_entrypoint)
+
+
+def discover_entrypoint_packs() -> dict[str, BaseDomainPack]:
+    discovered: dict[str, BaseDomainPack] = {}
+    entry_points = metadata.entry_points()
+    if hasattr(entry_points, "select"):
+        candidates = entry_points.select(group=ENTRYPOINT_GROUP)
+    else:
+        candidates = entry_points.get(ENTRYPOINT_GROUP, [])
+
+    for entry_point in candidates:
+        loaded = entry_point.load()
+        pack = loaded() if callable(loaded) else loaded
+        if not isinstance(pack, BaseDomainPack):
+            raise TypeError(f"Entry point {entry_point.value} did not return BaseDomainPack")
+        if pack.api_version != PACK_API_VERSION:
+            raise ValueError(
+                f"Pack {pack.name} api_version {pack.api_version} is incompatible with core api_version {PACK_API_VERSION}"
+            )
+        discovered[pack.name] = pack
+
+    return discovered

--- a/src/openclaw_pipeline/query_tool.py
+++ b/src/openclaw_pipeline/query_tool.py
@@ -16,8 +16,18 @@ import json
 import argparse
 from pathlib import Path
 from datetime import datetime
-from typing import List, Dict, Set, Optional
+from typing import List, Dict
 from dataclasses import dataclass
+
+try:
+    from .discovery import discover_related
+except ImportError:
+    from discovery import discover_related  # type: ignore
+
+try:
+    from .evidence import build_evidence_payload
+except ImportError:
+    from evidence import build_evidence_payload  # type: ignore
 
 try:
     from .runtime import resolve_vault_dir
@@ -129,109 +139,22 @@ class VaultQuerier:
 
         return text[:max_len] + "..." if len(text) > max_len else text
 
-    def search(self, query: str, top_k: int = 10) -> List[SearchResult]:
+    def search(self, query: str, top_k: int = 10, engine: str = "knowledge") -> List[SearchResult]:
         """
         搜索知识库
-        优先使用 qmd（如果安装并配置），否则使用内置 BM25 近似搜索
+        默认使用 knowledge.db；QMD 仅作为显式引擎
         """
-        # 尝试使用 qmd（如果可用）
-        qmd_results = self._search_with_qmd(query, top_k)
-        if qmd_results:
-            return qmd_results
-
-        # 回退到内置搜索
-        return self._search_builtin(query, top_k)
-
-    def _search_with_qmd(self, query: str, top_k: int) -> Optional[List[SearchResult]]:
-        """尝试使用 qmd 搜索引擎"""
-        try:
-            # 检查 qmd 是否可用
-            import subprocess
-            result = subprocess.run(
-                ["qmd", "search", query, "--limit", str(top_k)],
-                capture_output=True,
-                text=True,
-                timeout=10
-            )
-
-            if result.returncode != 0:
-                return None
-
-            # 解析 qmd 输出
-            results = []
-            for line in result.stdout.strip().split('\n'):
-                if '|' in line:
-                    parts = line.split('|')
-                    if len(parts) >= 3:
-                        file_path = parts[0].strip()
-                        score = float(parts[1].strip())
-                        title = parts[2].strip()
-
-                        # 获取摘录
-                        page = self.all_pages.get(file_path, {})
-                        excerpt = page.get('excerpt', '')
-
-                        results.append(SearchResult(
-                            file=file_path,
-                            title=title,
-                            relevance=score,
-                            excerpt=excerpt
-                        ))
-
-            if results:
-                self.log(f"使用 qmd 搜索引擎，找到 {len(results)} 个结果")
-                return results
-
-        except (subprocess.SubprocessError, FileNotFoundError, ValueError):
-            pass
-
-        return None
-
-    def _search_builtin(self, query: str, top_k: int = 10) -> List[SearchResult]:
-        """
-        内置 BM25 近似搜索（qmd 不可用时回退）
-        """
-        self.log("使用内置搜索引擎 (qmd 未配置或不可用)")
-
-        query_terms = set(query.lower().split())
-        scores = []
-
-        for path, page in self.all_pages.items():
-            score = 0.0
-
-            # 标题匹配（高权重）
-            title_lower = page['title'].lower()
-            for term in query_terms:
-                if term in title_lower:
-                    score += 10.0
-
-            # 内容匹配
-            content_lower = page['content'].lower()
-            for term in query_terms:
-                count = content_lower.count(term)
-                score += count * 1.0
-
-            # 标签匹配
-            for tag in page.get('tags', []):
-                for term in query_terms:
-                    if term in tag.lower():
-                        score += 5.0
-
-            if score > 0:
-                scores.append((path, score, page))
-
-        # 排序取 top_k
-        scores.sort(key=lambda x: x[1], reverse=True)
-
         results = []
-        for path, score, page in scores[:top_k]:
+        for row in discover_related(self.vault_dir, query, engine=engine, limit=top_k):
+            path = str(row.get("path") or row.get("slug") or "")
+            title = str(row.get("title") or row.get("slug") or path)
+            excerpt = str(row.get("snippet") or "")
             results.append(SearchResult(
                 file=path,
-                title=page['title'],
-                relevance=score,
-                excerpt=page['excerpt']
+                title=title,
+                relevance=float(row.get("score") or 0.0),
+                excerpt=excerpt,
             ))
-
         return results
 
     def query(self, question: str, search_results: List[SearchResult]) -> dict:
@@ -485,7 +408,7 @@ type: moc
         self.log(f"已更新 MOC-Queries.md")
 
 
-def main():
+def main(argv: list[str] | None = None):
     parser = argparse.ArgumentParser(
         description="ovp-query: 查询知识库并归档回写 (Karpathy LLM Wiki Pattern)"
     )
@@ -518,8 +441,14 @@ def main():
         default=10,
         help="搜索返回的相关页面数量 (默认: 10)"
     )
+    parser.add_argument(
+        "--engine",
+        choices=["knowledge", "qmd"],
+        default="knowledge",
+        help="检索引擎: knowledge(默认) 或 qmd",
+    )
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     vault_dir = resolve_vault_dir(args.vault_dir)
 
@@ -544,7 +473,11 @@ def main():
 
     # 搜索
     querier.log(f"搜索: {question}")
-    results = querier.search(question, top_k=args.top_k)
+    try:
+        results = querier.search(question, top_k=args.top_k, engine=args.engine)
+    except RuntimeError as exc:
+        print(f"❌ {exc}")
+        return 1
 
     if not results:
         print("❌ 未找到相关内容")
@@ -558,6 +491,13 @@ def main():
     # 查询
     querier.log("使用 LLM 生成回答...")
     answer = querier.query(question, results)
+    answer["evidence"] = build_evidence_payload(
+        vault_dir,
+        query=question,
+        mentions=[result.title for result in results[:3]],
+        slugs=[Path(result.file).stem for result in results[:5] if result.file],
+        limit=min(args.top_k, 5),
+    )
 
     print(f"\n💡 回答:\n")
     print(answer['answer'])

--- a/src/openclaw_pipeline/refine.py
+++ b/src/openclaw_pipeline/refine.py
@@ -180,6 +180,20 @@ def record_refine_run(
     )
 
 
+def attach_proposal_evidence(vault_dir: Path, proposal: dict[str, Any]) -> dict[str, Any]:
+    from .evidence import build_evidence_payload
+
+    enriched = dict(proposal)
+    enriched["evidence"] = build_evidence_payload(
+        vault_dir,
+        query=str(proposal.get("slug") or ""),
+        mentions=[str(proposal.get("slug") or "")],
+        slugs=[str(proposal.get("slug") or "")],
+        limit=5,
+    )
+    return enriched
+
+
 def _rewrite_cleanup_body(body: str) -> str:
     lines = body.splitlines()
     rewritten: list[str] = []

--- a/src/openclaw_pipeline/unified_pipeline_enhanced.py
+++ b/src/openclaw_pipeline/unified_pipeline_enhanced.py
@@ -41,8 +41,10 @@ from typing import Any
 
 try:
     from .runtime import VaultLayout, resolve_vault_dir
+    from .packs.loader import resolve_workflow_profile
 except ImportError:  # pragma: no cover - script mode fallback
     from runtime import VaultLayout, resolve_vault_dir
+    from packs.loader import resolve_workflow_profile
 
 # ========== 环境初始化 ==========
 # 加载 .env 文件（从 Vault 根目录或 auto_vault 目录）
@@ -297,8 +299,11 @@ def normalize_step_name(step: str | None) -> str | None:
     return STEP_ALIASES.get(step, step)
 
 
-def pipeline_steps(include_refine: bool = False) -> list[str]:
-    steps = list(BASE_PIPELINE_STEPS)
+def pipeline_steps(
+    include_refine: bool = False,
+    base_steps: list[str] | None = None,
+) -> list[str]:
+    steps = list(base_steps or BASE_PIPELINE_STEPS)
     if include_refine and "refine" not in steps:
         steps.insert(-1, "refine")
     return steps
@@ -307,86 +312,78 @@ def pipeline_steps(include_refine: bool = False) -> list[str]:
 def build_execution_plan(args: argparse.Namespace) -> dict[str, Any]:
     """Build the requested execution plan from CLI args."""
     include_refine = bool(getattr(args, "with_refine", False))
+    pack_name = getattr(args, "pack", None)
+    profile_name = getattr(args, "profile", None)
+    pack, profile = resolve_workflow_profile(
+        pack_name=pack_name,
+        profile_name=profile_name,
+        default_profile="full",
+    )
+    selected_steps = pipeline_steps(include_refine=include_refine, base_steps=profile.stages)
+    pinboard_selected_steps = [step for step in selected_steps if step != "clippings"]
+
+    def plan_dict(steps: list[str], description: str, pinboard_days: int | None, pinboard_start: str | None, pinboard_end: str | None) -> dict[str, Any]:
+        return {
+            "pack": pack.name,
+            "profile": profile.name,
+            "steps": steps,
+            "pinboard_days": pinboard_days,
+            "pinboard_start": pinboard_start,
+            "pinboard_end": pinboard_end,
+            "description": description,
+        }
 
     if args.full:
-        return {
-            "steps": pipeline_steps(include_refine=include_refine),
-            "pinboard_days": args.pinboard_days or 7,
-            "pinboard_start": None,
-            "pinboard_end": None,
-            "description": "Full pipeline (Pinboard+Clippings+Absorb+Derived)"
-        }
+        return plan_dict(
+            selected_steps,
+            f"Full pipeline ({pack.name}/{profile.name})",
+            args.pinboard_days or 7,
+            None,
+            None,
+        )
 
     if args.pinboard_new:
-        return {
-            "steps": ["pinboard", "pinboard_process"],
-            "pinboard_days": 7,
-            "pinboard_start": None,
-            "pinboard_end": None,
-            "description": "New Pinboard bookmarks only",
-        }
+        return plan_dict(["pinboard", "pinboard_process"], "New Pinboard bookmarks only", 7, None, None)
 
     if args.pinboard_history:
         pinboard_start, pinboard_end = args.pinboard_history
-        return {
-            "steps": [
-                "pinboard",
-                "pinboard_process",
-                "articles",
-                "quality",
-                "fix_links",
-                "absorb",
-                "registry_sync",
-                "moc",
-                *(["refine"] if include_refine else []),
-                "knowledge_index",
-            ],
-            "pinboard_days": None,
-            "pinboard_start": pinboard_start,
-            "pinboard_end": pinboard_end,
-            "description": f"Historical Pinboard {pinboard_start} to {pinboard_end}",
-        }
+        return plan_dict(
+            pinboard_selected_steps,
+            f"Historical Pinboard {pinboard_start} to {pinboard_end}",
+            None,
+            pinboard_start,
+            pinboard_end,
+        )
 
     if args.pinboard_days:
-        return {
-            "steps": [
-                "pinboard",
-                "pinboard_process",
-                "articles",
-                "quality",
-                "fix_links",
-                "absorb",
-                "registry_sync",
-                "moc",
-                *(["refine"] if include_refine else []),
-                "knowledge_index",
-            ],
-            "pinboard_days": args.pinboard_days,
-            "pinboard_start": None,
-            "pinboard_end": None,
-            "description": f"Pinboard last {args.pinboard_days} days + full pipeline",
-        }
+        return plan_dict(
+            pinboard_selected_steps,
+            f"Pinboard last {args.pinboard_days} days + full pipeline",
+            args.pinboard_days,
+            None,
+            None,
+        )
 
     if args.step:
-        return {
-            "steps": [normalize_step_name(args.step)],
-            "pinboard_days": args.pinboard_days,
-            "pinboard_start": None,
-            "pinboard_end": None,
-            "description": f"Single step: {normalize_step_name(args.step)}",
-        }
+        return plan_dict(
+            [normalize_step_name(args.step)],
+            f"Single step: {normalize_step_name(args.step)}",
+            args.pinboard_days,
+            None,
+            None,
+        )
 
     if args.from_step:
-        requested_steps = pipeline_steps(include_refine=include_refine)
+        requested_steps = selected_steps
         normalized_from_step = normalize_step_name(args.from_step)
         start_idx = requested_steps.index(normalized_from_step) if normalized_from_step in requested_steps else 0
-        return {
-            "steps": requested_steps[start_idx:],
-            "pinboard_days": args.pinboard_days or 7,
-            "pinboard_start": None,
-            "pinboard_end": None,
-            "description": f"From step: {normalized_from_step}",
-        }
+        return plan_dict(
+            requested_steps[start_idx:],
+            f"From step: {normalized_from_step}",
+            args.pinboard_days or 7,
+            None,
+            None,
+        )
 
     return {}
 
@@ -1339,6 +1336,8 @@ def main():
     parser.add_argument("--batch-size", type=int, help="批次大小（用于articles/clippings）")
     parser.add_argument("--dry-run", action="store_true", help="预览模式")
     parser.add_argument("--with-refine", action="store_true", help="在 absorb/moc 之后执行 cleanup + breakdown 批处理")
+    parser.add_argument("--pack", default=None, help="Domain pack 名称（默认: default-knowledge）")
+    parser.add_argument("--profile", default=None, help="Workflow profile 名称（默认: full）")
     parser.add_argument("--vault-dir", type=Path, default=VAULT_DIR, help="Vault根目录")
 
     args = parser.parse_args()

--- a/tests/test_autopilot_contracts.py
+++ b/tests/test_autopilot_contracts.py
@@ -71,6 +71,23 @@ def test_autopilot_success_path_runs_absorb_and_knowledge_index_after_moc(tmp_pa
     assert order == ["absorb", "moc", "knowledge_index"]
 
 
+def test_autopilot_accepts_explicit_default_pack_profile(tmp_path):
+    vault = tmp_path / "vault"
+    (vault / "60-Logs").mkdir(parents=True)
+
+    daemon = AutoPilotDaemon(
+        vault,
+        watch_sources=["inbox"],
+        auto_commit=False,
+        pack="default-knowledge",
+        profile="autopilot",
+    )
+
+    assert daemon.pack.name == "default-knowledge"
+    assert daemon.workflow_profile.name == "autopilot"
+    assert daemon.workflow_profile.stages == ["interpretation", "quality", "absorb", "moc", "knowledge_index"]
+
+
 def test_autopilot_with_refine_runs_refine_before_knowledge_index(tmp_path, monkeypatch):
     vault = tmp_path / "vault"
     (vault / "60-Logs").mkdir(parents=True)

--- a/tests/test_concept_discovery.py
+++ b/tests/test_concept_discovery.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+
+def test_resolve_mention_uses_shared_discovery_related_context(temp_vault, monkeypatch):
+    from openclaw_pipeline import concept_registry as registry_module
+    from openclaw_pipeline.concept_registry import ConceptRegistry, ResolutionAction
+
+    def fake_discover(vault_dir, query, engine="knowledge", limit=5):  # noqa: ARG001
+        return [
+            {
+                "engine": engine,
+                "kind": "semantic",
+                "slug": "agent-runtime",
+                "title": "Agent Runtime",
+                "score": 0.88,
+                "snippet": "runtime orchestration",
+            }
+        ]
+
+    monkeypatch.setattr(registry_module, "discover_related", fake_discover)
+
+    registry = ConceptRegistry(temp_vault)
+    result = registry.resolve_mention("Unknown Runtime Concept")
+
+    assert result.action == ResolutionAction.CREATE_CANDIDATE
+    assert len(result.related_context) == 1
+    assert result.related_context[0].slug == "agent-runtime"
+    assert result.related_context[0].engine == "knowledge"
+    assert result.related_context[0].kind == "semantic"
+
+
+def test_fix_surface_conflicts_uses_similarity_as_review_signal_only(temp_vault, monkeypatch):
+    from openclaw_pipeline.concept_registry import ConceptEntry, ConceptRegistry
+
+    registry = ConceptRegistry(temp_vault)
+    registry.add_entry(
+        ConceptEntry(
+            slug="agent-harness",
+            title="Agent Harness",
+            aliases=["Agent Runtime"],
+            definition="Harness.",
+            area="AI",
+        )
+    )
+    registry.add_entry(
+        ConceptEntry(
+            slug="agent-runtime",
+            title="Agent Runtime",
+            aliases=["Agent Runtime"],
+            definition="Runtime.",
+            area="AI",
+        )
+    )
+
+    monkeypatch.setattr(ConceptRegistry, "get_bidirectional_similarity", lambda self, t1, s1, t2, s2: 0.95)
+
+    results = registry.fix_surface_conflicts(dry_run=True)
+
+    assert results["merge_candidates"] == []
+    assert results["review_needed"]
+    assert results["review_needed"][0]["action"] == "review"

--- a/tests/test_default_knowledge_pack.py
+++ b/tests/test_default_knowledge_pack.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+
+def test_default_knowledge_pack_exposes_expected_object_kinds():
+    from openclaw_pipeline.packs.loader import load_default_pack
+
+    pack = load_default_pack()
+    kinds = {kind.kind for kind in pack.object_kinds()}
+
+    assert {"concept", "entity", "evergreen", "document"} <= kinds
+
+
+def test_default_knowledge_pack_registers_full_and_autopilot_profiles():
+    from openclaw_pipeline.packs.loader import load_default_pack
+
+    pack = load_default_pack()
+    profiles = {profile.name: profile for profile in pack.workflow_profiles()}
+
+    assert "full" in profiles
+    assert "autopilot" in profiles
+
+
+def test_default_knowledge_full_profile_matches_current_stage_order():
+    from openclaw_pipeline.packs.loader import load_default_pack
+
+    pack = load_default_pack()
+    profile = pack.profile("full")
+
+    assert profile.stages == [
+        "pinboard",
+        "pinboard_process",
+        "clippings",
+        "articles",
+        "quality",
+        "fix_links",
+        "absorb",
+        "registry_sync",
+        "moc",
+        "knowledge_index",
+    ]

--- a/tests/test_default_pack_compat.py
+++ b/tests/test_default_pack_compat.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from argparse import Namespace
+
+
+def test_no_pack_selection_matches_default_full_profile():
+    from openclaw_pipeline.packs.loader import load_default_pack
+    from openclaw_pipeline.unified_pipeline_enhanced import build_execution_plan
+
+    args = Namespace(
+        full=True,
+        with_refine=False,
+        pinboard_new=False,
+        pinboard_history=None,
+        pinboard_days=None,
+        step=None,
+        from_step=None,
+        pack=None,
+        profile=None,
+    )
+
+    plan = build_execution_plan(args)
+    default_pack = load_default_pack()
+    full_profile = default_pack.profile("full")
+
+    assert plan["steps"] == full_profile.stages
+
+
+def test_explicit_default_pack_profile_matches_default_full_profile():
+    from openclaw_pipeline.packs.loader import load_default_pack
+    from openclaw_pipeline.unified_pipeline_enhanced import build_execution_plan
+
+    args = Namespace(
+        full=True,
+        with_refine=False,
+        pinboard_new=False,
+        pinboard_history=None,
+        pinboard_days=None,
+        step=None,
+        from_step=None,
+        pack="default-knowledge",
+        profile="full",
+    )
+
+    plan = build_execution_plan(args)
+    default_pack = load_default_pack()
+
+    assert plan["pack"] == "default-knowledge"
+    assert plan["profile"] == "full"
+    assert plan["steps"] == default_pack.profile("full").stages
+
+
+def test_step_aliases_remain_compatible_with_default_pack():
+    from openclaw_pipeline.packs.loader import load_default_pack
+    from openclaw_pipeline.unified_pipeline_enhanced import STEP_ALIASES
+
+    default_pack = load_default_pack()
+
+    assert STEP_ALIASES["evergreen"] == "absorb"
+    assert "absorb" in default_pack.profile("full").stages

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+
+
+def test_discover_related_defaults_to_knowledge_engine(temp_vault):
+    from openclaw_pipeline.discovery import discover_related
+    from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
+
+    note = temp_vault / "10-Knowledge" / "Evergreen" / "Agent-Harness.md"
+    note.write_text(
+        """---
+note_id: agent-harness
+title: Agent Harness
+type: evergreen
+date: 2026-04-07
+aliases: [Harness Runtime]
+---
+
+# Agent Harness
+
+## Architecture
+
+The harness coordinates architecture, execution, and tools.
+""",
+        encoding="utf-8",
+    )
+
+    rebuild_knowledge_index(temp_vault)
+    results = discover_related(temp_vault, "architecture tools", limit=3)
+
+    assert results
+    assert results[0]["engine"] == "knowledge"
+    assert results[0]["slug"] == "agent-harness"
+    assert results[0]["kind"] in {"lexical", "semantic"}
+    assert "title" in results[0]
+    assert "snippet" in results[0]
+
+
+def test_discover_related_qmd_engine_is_explicit_and_typed(temp_vault, monkeypatch):
+    from openclaw_pipeline import discovery
+
+    def fake_qmd(vault_dir, query, limit):  # noqa: ARG001
+        return [
+            {
+                "engine": "qmd",
+                "kind": "semantic",
+                "slug": "agent-runtime",
+                "title": "Agent Runtime",
+                "score": 0.91,
+                "snippet": "runtime orchestration",
+            }
+        ]
+
+    monkeypatch.setattr(discovery, "_discover_with_qmd", fake_qmd)
+    results = discovery.discover_related(temp_vault, "runtime orchestration", engine="qmd", limit=2)
+
+    assert results == [
+        {
+            "engine": "qmd",
+            "kind": "semantic",
+            "slug": "agent-runtime",
+            "title": "Agent Runtime",
+            "score": 0.91,
+            "snippet": "runtime orchestration",
+        }
+    ]
+

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -33,6 +33,8 @@ The harness coordinates architecture, execution, and tools.
     assert results[0]["engine"] == "knowledge"
     assert results[0]["slug"] == "agent-harness"
     assert results[0]["kind"] in {"lexical", "semantic"}
+    assert results[0]["pack"] == "default-knowledge"
+    assert results[0]["object_kind"] == "document"
     assert "title" in results[0]
     assert "snippet" in results[0]
 
@@ -63,6 +65,7 @@ def test_discover_related_qmd_engine_is_explicit_and_typed(temp_vault, monkeypat
             "title": "Agent Runtime",
             "score": 0.91,
             "snippet": "runtime orchestration",
+            "pack": "default-knowledge",
+            "object_kind": "document",
         }
     ]
-

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -69,3 +69,33 @@ def test_discover_related_qmd_engine_is_explicit_and_typed(temp_vault, monkeypat
             "object_kind": "document",
         }
     ]
+
+
+def test_discover_with_knowledge_deduplicates_by_slug_and_skips_semantic_when_lexical_is_enough(
+    temp_vault,
+    monkeypatch,
+):
+    from openclaw_pipeline import discovery
+
+    monkeypatch.setattr(
+        discovery,
+        "_safe_search_knowledge",
+        lambda vault_dir, query, limit: [  # noqa: ARG005
+            {"slug": "agent-harness", "title": "Agent Harness", "score": 12.0},
+            {"slug": "agent-runtime", "title": "Agent Runtime", "score": 11.0},
+        ],
+    )
+
+    def fail_semantic(vault_dir, query, limit):  # noqa: ARG001
+        raise AssertionError("semantic search should not run when lexical already satisfies the limit")
+
+    monkeypatch.setattr(
+        "openclaw_pipeline.knowledge_index.get_knowledge_page",
+        lambda vault_dir, slug: {"title": slug.replace("-", " ").title(), "path": f"{slug}.md", "body": slug},
+    )
+    monkeypatch.setattr("openclaw_pipeline.knowledge_index.query_knowledge_index", fail_semantic)
+
+    results = discovery._discover_with_knowledge(temp_vault, "agent runtime", limit=2)
+
+    assert [row["slug"] for row in results] == ["agent-harness", "agent-runtime"]
+    assert {row["kind"] for row in results} == {"lexical"}

--- a/tests/test_evidence_schema.py
+++ b/tests/test_evidence_schema.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import json
+
+
+def test_build_evidence_payload_separates_identity_retrieval_graph_and_audit(temp_vault):
+    from openclaw_pipeline.concept_registry import ConceptEntry, ConceptRegistry
+    from openclaw_pipeline.evidence import build_evidence_payload
+    from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
+    from openclaw_pipeline.runtime import VaultLayout
+
+    source = temp_vault / "10-Knowledge" / "Evergreen" / "Source.md"
+    target = temp_vault / "10-Knowledge" / "Evergreen" / "Target.md"
+
+    source.write_text(
+        """---
+note_id: agent-harness
+title: Agent Harness
+type: evergreen
+date: 2026-04-07
+aliases: [Harness Runtime]
+---
+
+# Agent Harness
+
+## Architecture
+
+The harness coordinates architecture and tools.
+
+Links to [[agent-runtime]].
+""",
+        encoding="utf-8",
+    )
+    target.write_text(
+        """---
+note_id: agent-runtime
+title: Agent Runtime
+type: evergreen
+date: 2026-04-07
+---
+
+# Agent Runtime
+""",
+        encoding="utf-8",
+    )
+
+    registry = ConceptRegistry(temp_vault)
+    registry.add_entry(
+        ConceptEntry(
+            slug="agent-harness",
+            title="Agent Harness",
+            aliases=["Harness Runtime"],
+            definition="Harness.",
+            area="AI",
+        )
+    )
+    registry.save()
+
+    rebuild_knowledge_index(temp_vault)
+    layout = VaultLayout.from_vault(temp_vault)
+    layout.pipeline_log.write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-04-07T12:00:00Z",
+                "session_id": "pipe-1",
+                "event_type": "pipeline_stage_completed",
+                "targets": ["agent-harness"],
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    payload = build_evidence_payload(
+        temp_vault,
+        query="architecture tools",
+        mentions=["Agent Harness"],
+        slugs=["agent-harness"],
+        limit=3,
+    )
+
+    assert set(payload) == {
+        "identity_evidence",
+        "retrieval_evidence",
+        "graph_evidence",
+        "audit_evidence",
+    }
+    assert payload["identity_evidence"]
+    assert payload["identity_evidence"][0]["channel"] == "identity"
+    assert payload["identity_evidence"][0]["entry_slug"] == "agent-harness"
+    assert payload["retrieval_evidence"]
+    assert all(item["channel"] == "retrieval" for item in payload["retrieval_evidence"])
+    assert payload["graph_evidence"]
+    assert all(item["channel"] == "graph" for item in payload["graph_evidence"])
+    assert payload["audit_evidence"]
+    assert all(item["channel"] == "audit" for item in payload["audit_evidence"])
+
+
+def test_query_tool_attaches_structured_evidence_to_saved_answer(temp_vault, monkeypatch):
+    from openclaw_pipeline import query_tool
+
+    source = temp_vault / "10-Knowledge" / "Evergreen" / "Agent-Harness.md"
+    source.write_text(
+        """---
+note_id: agent-harness
+title: Agent Harness
+type: evergreen
+date: 2026-04-07
+---
+
+# Agent Harness
+""",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        query_tool.VaultQuerier,
+        "search",
+        lambda self, query, top_k=10, engine="knowledge": [
+            query_tool.SearchResult(
+                file="10-Knowledge/Evergreen/Agent-Harness.md",
+                title="Agent Harness",
+                relevance=1.0,
+                excerpt="architecture",
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        query_tool.VaultQuerier,
+        "query",
+        lambda self, q, r: {"answer": "ok", "sources": [], "related_concepts": []},
+    )
+
+    captured = {}
+
+    def fake_save(self, question, result, output_dir, output_format="markdown"):  # noqa: ARG001
+        captured["result"] = result
+        return output_dir / "saved.md"
+
+    monkeypatch.setattr(query_tool.VaultQuerier, "save_to_wiki", fake_save)
+    monkeypatch.setattr(
+        query_tool,
+        "build_evidence_payload",
+        lambda vault_dir, **kwargs: {
+            "identity_evidence": [{"channel": "identity"}],
+            "retrieval_evidence": [{"channel": "retrieval"}],
+            "graph_evidence": [{"channel": "graph"}],
+            "audit_evidence": [{"channel": "audit"}],
+        },
+    )
+
+    result = query_tool.main(["--vault-dir", str(temp_vault), "architecture tools"])
+
+    assert result == 0
+    assert "evidence" in captured["result"]
+    assert captured["result"]["evidence"]["identity_evidence"][0]["channel"] == "identity"
+
+
+def test_cleanup_proposal_includes_structured_evidence(temp_vault, capsys):
+    from openclaw_pipeline.commands.cleanup import main
+
+    note = temp_vault / "10-Knowledge" / "Evergreen" / "Agent-Harness.md"
+    note.write_text(
+        """---
+note_id: agent-harness
+title: Agent Harness
+type: evergreen
+date: 2026-04-07
+---
+
+# Agent Harness
+
+## 2026-04
+
+Old notes.
+""",
+        encoding="utf-8",
+    )
+
+    result = main(["--vault-dir", str(temp_vault), "--all", "--json"])
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert result == 0
+    assert payload["proposals"]
+    assert "evidence" in payload["proposals"][0]
+    assert set(payload["proposals"][0]["evidence"]) == {
+        "identity_evidence",
+        "retrieval_evidence",
+        "graph_evidence",
+        "audit_evidence",
+    }

--- a/tests/test_object_registry.py
+++ b/tests/test_object_registry.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from openclaw_pipeline.concept_registry import ConceptEntry, ConceptRegistry, STATUS_ACTIVE
+
+
+def test_object_record_contains_core_pack_fields():
+    from openclaw_pipeline.object_registry import ObjectRecord
+
+    record = ObjectRecord(
+        id="agent-harness",
+        kind="concept",
+        pack="default-knowledge",
+        title="Agent Harness",
+        status=STATUS_ACTIVE,
+    )
+
+    assert record.id == "agent-harness"
+    assert record.kind == "concept"
+    assert record.pack == "default-knowledge"
+    assert record.title == "Agent Harness"
+    assert record.status == STATUS_ACTIVE
+
+
+def test_concept_registry_projects_entries_into_object_registry(temp_vault):
+    from openclaw_pipeline.object_registry import ObjectRegistry
+
+    registry = ConceptRegistry(temp_vault)
+    registry.add_entry(
+        ConceptEntry(
+            slug="agent-harness",
+            title="Agent Harness",
+            aliases=["Harness"],
+            definition="A repeatable agent runtime harness.",
+            area="AI",
+            status=STATUS_ACTIVE,
+        )
+    )
+
+    object_registry = ObjectRegistry.from_concept_registry(registry)
+    records = object_registry.records()
+
+    assert len(records) == 1
+    assert records[0].id == "agent-harness"
+    assert records[0].kind == "concept"
+    assert records[0].pack == "default-knowledge"
+    assert records[0].status == STATUS_ACTIVE
+
+
+def test_concept_registry_exposes_object_records_without_changing_legacy_behavior(temp_vault):
+    registry = ConceptRegistry(temp_vault)
+    entry = ConceptEntry(
+        slug="deep-research",
+        title="Deep Research",
+        aliases=["Research Loop"],
+        definition="A structured research workflow.",
+        area="AI",
+        status=STATUS_ACTIVE,
+    )
+    registry.add_entry(entry)
+
+    records = registry.to_object_records()
+
+    assert registry.find_by_slug("deep-research") is entry
+    assert len(registry.entries) == 1
+    assert len(records) == 1
+    assert records[0].id == "deep-research"
+    assert records[0].title == "Deep Research"

--- a/tests/test_pack_discovery_hooks.py
+++ b/tests/test_pack_discovery_hooks.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import json
+
+
+def test_default_pack_discovery_preserves_knowledge_behavior_with_context(temp_vault):
+    from openclaw_pipeline.concept_registry import ConceptEntry, ConceptRegistry
+    from openclaw_pipeline.discovery import discover_related
+    from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
+
+    note = temp_vault / "10-Knowledge" / "Evergreen" / "Agent-Harness.md"
+    note.write_text(
+        """---
+note_id: agent-harness
+title: Agent Harness
+type: evergreen
+date: 2026-04-07
+---
+
+# Agent Harness
+
+## Architecture
+
+The harness coordinates architecture, execution, and tools.
+""",
+        encoding="utf-8",
+    )
+
+    registry = ConceptRegistry(temp_vault)
+    registry.add_entry(
+        ConceptEntry(
+            slug="agent-harness",
+            title="Agent Harness",
+            aliases=[],
+            definition="Harness.",
+            area="AI",
+            kind="concept",
+        )
+    )
+    registry.save()
+
+    rebuild_knowledge_index(temp_vault)
+    results = discover_related(temp_vault, "architecture tools", limit=3, pack="default-knowledge")
+
+    assert results
+    assert results[0]["engine"] == "knowledge"
+    assert results[0]["slug"] == "agent-harness"
+    assert results[0]["pack"] == "default-knowledge"
+    assert results[0]["object_kind"] == "concept"
+
+
+def test_pack_discovery_hooks_can_filter_discoverable_object_kinds(temp_vault):
+    from openclaw_pipeline.concept_registry import ConceptEntry, ConceptRegistry
+    from openclaw_pipeline.discovery import discover_related
+    from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
+    from openclaw_pipeline.packs.base import BaseDomainPack
+
+    concept_note = temp_vault / "10-Knowledge" / "Evergreen" / "Agent-Harness.md"
+    concept_note.write_text(
+        """---
+note_id: agent-harness
+title: Agent Harness
+type: evergreen
+date: 2026-04-07
+---
+
+# Agent Harness
+
+Entity and orchestration reference.
+""",
+        encoding="utf-8",
+    )
+    entity_note = temp_vault / "10-Knowledge" / "Evergreen" / "Anthropic.md"
+    entity_note.write_text(
+        """---
+note_id: anthropic
+title: Anthropic
+type: evergreen
+date: 2026-04-07
+---
+
+# Anthropic
+
+Entity and orchestration reference.
+""",
+        encoding="utf-8",
+    )
+
+    registry = ConceptRegistry(temp_vault)
+    registry.add_entry(
+        ConceptEntry(
+            slug="agent-harness",
+            title="Agent Harness",
+            aliases=[],
+            definition="Harness.",
+            area="AI",
+            kind="concept",
+        )
+    )
+    registry.add_entry(
+        ConceptEntry(
+            slug="anthropic",
+            title="Anthropic",
+            aliases=[],
+            definition="Company.",
+            area="AI",
+            kind="entity",
+        )
+    )
+    registry.save()
+
+    rebuild_knowledge_index(temp_vault)
+
+    entity_only_pack = BaseDomainPack(
+        name="entity-only",
+        version="0.1.0",
+        api_version=1,
+        _discoverable_object_kinds=["entity"],
+    )
+
+    results = discover_related(temp_vault, "entity orchestration reference", limit=5, pack=entity_only_pack)
+
+    assert results
+    assert {row["object_kind"] for row in results} == {"entity"}
+    assert {row["slug"] for row in results} == {"anthropic"}
+
+
+def test_pack_evidence_payload_carries_pack_and_object_kind_context(temp_vault):
+    from openclaw_pipeline.concept_registry import ConceptEntry, ConceptRegistry
+    from openclaw_pipeline.evidence import build_evidence_payload
+    from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
+    from openclaw_pipeline.runtime import VaultLayout
+
+    note = temp_vault / "10-Knowledge" / "Evergreen" / "Agent-Harness.md"
+    note.write_text(
+        """---
+note_id: agent-harness
+title: Agent Harness
+type: evergreen
+date: 2026-04-07
+---
+
+# Agent Harness
+
+Links to [[agent-runtime]].
+""",
+        encoding="utf-8",
+    )
+
+    registry = ConceptRegistry(temp_vault)
+    registry.add_entry(
+        ConceptEntry(
+            slug="agent-harness",
+            title="Agent Harness",
+            aliases=[],
+            definition="Harness.",
+            area="AI",
+            kind="concept",
+        )
+    )
+    registry.save()
+
+    rebuild_knowledge_index(temp_vault)
+    layout = VaultLayout.from_vault(temp_vault)
+    layout.pipeline_log.write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-04-07T12:00:00Z",
+                "session_id": "pipe-1",
+                "event_type": "pipeline_stage_completed",
+                "targets": ["agent-harness"],
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    payload = build_evidence_payload(
+        temp_vault,
+        query="agent harness",
+        mentions=["Agent Harness"],
+        slugs=["agent-harness"],
+        limit=3,
+        pack="default-knowledge",
+    )
+
+    assert payload["identity_evidence"][0]["pack"] == "default-knowledge"
+    assert payload["identity_evidence"][0]["object_kind"] == "concept"
+    assert payload["retrieval_evidence"][0]["pack"] == "default-knowledge"
+    assert payload["retrieval_evidence"][0]["object_kind"] == "concept"

--- a/tests/test_pack_loader.py
+++ b/tests/test_pack_loader.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import pytest
+
+
+def test_load_default_pack_returns_pack_contract():
+    from openclaw_pipeline.packs.base import BaseDomainPack
+    from openclaw_pipeline.packs.loader import load_default_pack
+
+    pack = load_default_pack()
+
+    assert isinstance(pack, BaseDomainPack)
+    assert pack.name == "default-knowledge"
+    assert pack.version
+    assert pack.object_kinds()
+    assert pack.workflow_profiles()
+
+
+def test_load_pack_by_name_returns_default_knowledge():
+    from openclaw_pipeline.packs.loader import load_pack
+
+    pack = load_pack("default-knowledge")
+
+    assert pack.name == "default-knowledge"
+
+
+def test_load_pack_rejects_unknown_pack():
+    from openclaw_pipeline.packs.loader import load_pack
+
+    with pytest.raises(ValueError):
+        load_pack("unknown-pack")
+

--- a/tests/test_plugin_installation.py
+++ b/tests/test_plugin_installation.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def test_external_pack_can_be_discovered_via_manifest(tmp_path, monkeypatch):
+    from openclaw_pipeline.plugins import discover_plugin_manifests, load_manifest_pack
+
+    package_root = tmp_path / "fake_pack"
+    package_root.mkdir()
+    (package_root / "__init__.py").write_text("", encoding="utf-8")
+    (package_root / "plugin.py").write_text(
+        """
+from openclaw_pipeline.packs.base import BaseDomainPack
+
+def get_pack():
+    return BaseDomainPack(name="media-editorial", version="0.1.0", api_version=1)
+""",
+        encoding="utf-8",
+    )
+    manifest = tmp_path / "manifest.yaml"
+    manifest.write_text(
+        """
+name: media-editorial
+version: 0.1.0
+api_version: 1
+entrypoints:
+  pack: fake_pack.plugin:get_pack
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    manifests = discover_plugin_manifests([manifest])
+    pack = load_manifest_pack(manifests["media-editorial"])
+
+    assert "media-editorial" in manifests
+    assert pack.name == "media-editorial"
+
+
+def test_plugin_manifest_validation_fails_clearly_on_missing_fields(tmp_path):
+    from openclaw_pipeline.plugins import discover_plugin_manifests
+
+    manifest = tmp_path / "broken.yaml"
+    manifest.write_text("version: 0.1.0\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="missing required field"):
+        discover_plugin_manifests([manifest])
+
+
+def test_incompatible_api_versions_fail_clearly(tmp_path, monkeypatch):
+    from openclaw_pipeline.plugins import discover_plugin_manifests, load_manifest_pack
+
+    package_root = tmp_path / "bad_pack"
+    package_root.mkdir()
+    (package_root / "__init__.py").write_text("", encoding="utf-8")
+    (package_root / "plugin.py").write_text(
+        """
+from openclaw_pipeline.packs.base import BaseDomainPack
+
+def get_pack():
+    return BaseDomainPack(name="medical-evidence", version="0.1.0", api_version=2)
+""",
+        encoding="utf-8",
+    )
+    manifest = tmp_path / "medical.yaml"
+    manifest.write_text(
+        """
+name: medical-evidence
+version: 0.1.0
+api_version: 2
+entrypoints:
+  pack: bad_pack.plugin:get_pack
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    manifests = discover_plugin_manifests([manifest])
+
+    with pytest.raises(ValueError, match="api_version"):
+        load_manifest_pack(manifests["medical-evidence"])
+
+
+def test_entrypoint_discovery_can_load_external_pack(monkeypatch):
+    from openclaw_pipeline.packs.base import BaseDomainPack
+    from openclaw_pipeline.plugins import discover_entrypoint_packs
+
+    class FakeEntryPoint:
+        name = "engineering-research"
+        value = "fake.plugin:get_pack"
+        group = "openclaw_pipeline.packs"
+
+        def load(self):
+            return lambda: BaseDomainPack(name="engineering-research", version="0.1.0", api_version=1)
+
+    monkeypatch.setattr(
+        "openclaw_pipeline.plugins.metadata.entry_points",
+        lambda: {"openclaw_pipeline.packs": [FakeEntryPoint()]},
+    )
+
+    packs = discover_entrypoint_packs()
+
+    assert "engineering-research" in packs
+    assert packs["engineering-research"].name == "engineering-research"

--- a/tests/test_query_tool.py
+++ b/tests/test_query_tool.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+def test_vault_querier_search_defaults_to_knowledge_engine(temp_vault, monkeypatch):
+    from openclaw_pipeline import query_tool
+
+    queried = {}
+
+    def fake_discover(vault_dir, query, engine, limit):
+        queried["vault_dir"] = vault_dir
+        queried["query"] = query
+        queried["engine"] = engine
+        queried["limit"] = limit
+        return [
+            {
+                "engine": "knowledge",
+                "kind": "lexical",
+                "slug": "agent-harness",
+                "title": "Agent Harness",
+                "score": 12.3,
+                "snippet": "architecture and tools",
+                "path": "10-Knowledge/Evergreen/Agent-Harness.md",
+            }
+        ]
+
+    monkeypatch.setattr(query_tool, "discover_related", fake_discover)
+    querier = query_tool.VaultQuerier(temp_vault)
+    results = querier.search("architecture tools", top_k=5)
+
+    assert queried["engine"] == "knowledge"
+    assert len(results) == 1
+    assert results[0].file == "10-Knowledge/Evergreen/Agent-Harness.md"
+    assert results[0].title == "Agent Harness"
+
+
+def test_query_cli_explicit_qmd_engine_is_passed(temp_vault, monkeypatch, capsys):
+    from openclaw_pipeline import query_tool
+
+    source = temp_vault / "10-Knowledge" / "Evergreen" / "Agent-Harness.md"
+    source.write_text(
+        """---
+note_id: agent-harness
+title: Agent Harness
+type: evergreen
+date: 2026-04-07
+---
+
+# Agent Harness
+""",
+        encoding="utf-8",
+    )
+
+    captured = {}
+
+    def fake_search(self, query, top_k=10, engine="knowledge"):
+        captured["engine"] = engine
+        return [
+            query_tool.SearchResult(
+                file="10-Knowledge/Evergreen/Agent-Harness.md",
+                title="Agent Harness",
+                relevance=1.0,
+                excerpt="architecture",
+            )
+        ]
+
+    monkeypatch.setattr(query_tool.VaultQuerier, "search", fake_search)
+    monkeypatch.setattr(query_tool.VaultQuerier, "query", lambda self, q, r: {"answer": "ok", "sources": [], "related_concepts": []})
+    monkeypatch.setattr(query_tool.VaultQuerier, "save_to_wiki", lambda self, q, a, d, output_format="markdown": d / "saved.md")
+
+    result = query_tool.main([
+        "--vault-dir", str(temp_vault),
+        "--engine", "qmd",
+        "--top-k", "3",
+        "runtime architecture",
+    ])
+    capsys.readouterr()
+
+    assert result == 0
+    assert captured["engine"] == "qmd"
+
+
+def test_query_cli_explicit_qmd_engine_fails_clearly_when_unavailable(temp_vault, monkeypatch, capsys):
+    from openclaw_pipeline import query_tool
+
+    source = temp_vault / "10-Knowledge" / "Evergreen" / "Agent-Harness.md"
+    source.write_text(
+        """---
+note_id: agent-harness
+title: Agent Harness
+type: evergreen
+date: 2026-04-07
+---
+
+# Agent Harness
+""",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(query_tool.VaultQuerier, "search", lambda self, query, top_k=10, engine="knowledge": (_ for _ in ()).throw(RuntimeError("QMD engine requested but qmd is not available")))
+
+    result = query_tool.main([
+        "--vault-dir", str(temp_vault),
+        "--engine", "qmd",
+        "runtime architecture",
+    ])
+    captured = capsys.readouterr()
+
+    assert result == 1
+    assert "qmd is not available" in captured.out.lower()
+


### PR DESCRIPTION
## Summary
- move default discovery to `knowledge.db` via a shared `discovery.py` facade and make `ovp-query` explicit about `knowledge` vs `qmd`
- unify concept review and candidate related-context lookup, and downgrade QMD similarity from an auto-merge trigger to a review-only signal
- add a shared `evidence.py` schema for identity, retrieval, graph, and audit evidence and wire it into absorb, query, and refine proposals
- rewrite CN/EN docs and workflow notes so QMD is documented as an optional adapter instead of the default runtime dependency

## Test Plan
- [x] `pytest -q`
- [x] `python3 -m compileall src/openclaw_pipeline`
- [x] `python3 -m openclaw_pipeline.query_tool --help`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added pack and workflow profile system enabling runtime customization via `--pack` and `--profile` CLI flags
  * New structured evidence payload providing identity, retrieval, graph, and audit context in query and refine outputs
  * QMD now available as optional discovery engine via `--engine qmd`

* **Changes**
  * Default discovery unified to `knowledge.db` using FTS5 for keyword search and local embeddings for semantic search
  * `ovp-absorb` command (replaces `ovp-evergreen`) integrated into default workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->