### PR TITLE
Implement unified knowledge architecture foundations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ node_modules/
 *.tar.gz
 .gstack/
 .worktrees/
+
+.supervisor/runtime/

--- a/.gitignore
+++ b/.gitignore
@@ -73,4 +73,4 @@ node_modules/
 .gstack/
 .worktrees/
 
-.supervisor/runtime/
+.supervisor/

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ node_modules/
 *.zip
 *.tar.gz
 .gstack/
+.worktrees/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ ovp-absorb = "openclaw_pipeline.commands.absorb:main"
 ovp-cleanup = "openclaw_pipeline.commands.cleanup:main"
 ovp-breakdown = "openclaw_pipeline.commands.breakdown:main"
 ovp-knowledge-index = "openclaw_pipeline.commands.knowledge_index:main"
+ovp-extract = "openclaw_pipeline.commands.extract_profiles:main"
 
 [project.entry-points."openclaw_pipeline.packs"]
 default-knowledge = "openclaw_pipeline.packs.default_knowledge:get_pack"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,8 @@ ovp-cleanup = "openclaw_pipeline.commands.cleanup:main"
 ovp-breakdown = "openclaw_pipeline.commands.breakdown:main"
 ovp-knowledge-index = "openclaw_pipeline.commands.knowledge_index:main"
 ovp-extract = "openclaw_pipeline.commands.extract_profiles:main"
+ovp-ops = "openclaw_pipeline.commands.run_operations:main"
+ovp-build-views = "openclaw_pipeline.commands.build_views:main"
 
 [project.entry-points."openclaw_pipeline.packs"]
 default-knowledge = "openclaw_pipeline.packs.default_knowledge:get_pack"

--- a/src/openclaw_pipeline/commands/build_views.py
+++ b/src/openclaw_pipeline/commands/build_views.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from ..packs.loader import load_pack
+from ..runtime import resolve_vault_dir
+from ..wiki_views.runtime import build_view
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build a compiled wiki view from a pack-defined view spec.")
+    parser.add_argument("--vault-dir", type=Path, default=None, help="Vault directory")
+    parser.add_argument("--pack", default="default-knowledge", help="Pack name")
+    parser.add_argument("--view", required=True, help="Wiki view name")
+    args = parser.parse_args(argv)
+
+    vault_dir = resolve_vault_dir(args.vault_dir)
+    pack = load_pack(args.pack)
+    view = pack.wiki_view(args.view)
+    output_path = build_view(vault_dir, view)
+    print(json.dumps({"output_path": str(output_path)}, ensure_ascii=False))
+    return 0

--- a/src/openclaw_pipeline/commands/extract_profiles.py
+++ b/src/openclaw_pipeline/commands/extract_profiles.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from ..extraction.artifacts import write_run_result
+from ..extraction.runtime import ExtractionRuntime
+from ..packs.loader import load_pack
+from ..runtime import VaultLayout, resolve_vault_dir
+
+
+class NoopExtractor:
+    def extract(self, chunk_text, *, chunk_index, source_path, profile):  # noqa: ANN001, ARG002
+        return []
+
+
+def build_extractor() -> object:
+    return NoopExtractor()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run a pack extraction profile and emit derived artifacts.")
+    parser.add_argument("--vault-dir", type=Path, default=None, help="Vault directory")
+    parser.add_argument("--pack", default="default-knowledge", help="Pack name")
+    parser.add_argument("--profile", required=True, help="Extraction profile name")
+    parser.add_argument("--source", type=Path, required=True, help="Source markdown/text file")
+    args = parser.parse_args(argv)
+
+    vault_dir = resolve_vault_dir(args.vault_dir)
+    pack = load_pack(args.pack)
+    profile = pack.extraction_profile(args.profile)
+    source_path = args.source.resolve()
+    text = source_path.read_text(encoding="utf-8")
+
+    runtime = ExtractionRuntime(extractor=build_extractor())
+    result = runtime.run_text(profile=profile, text=text, source_path=source_path)
+    artifact_path = write_run_result(VaultLayout.from_vault(vault_dir), result)
+
+    print(json.dumps({"artifact_path": str(artifact_path), "profile_name": result.profile_name}, ensure_ascii=False))
+    return 0

--- a/src/openclaw_pipeline/commands/run_operations.py
+++ b/src/openclaw_pipeline/commands/run_operations.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from ..operations.runtime import run_operation_profile
+from ..packs.loader import load_pack
+from ..runtime import resolve_vault_dir
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run a pack-defined knowledge operation profile.")
+    parser.add_argument("--vault-dir", type=Path, default=None, help="Vault directory")
+    parser.add_argument("--pack", default="default-knowledge", help="Pack name")
+    parser.add_argument("--profile", required=True, help="Operation profile name")
+    args = parser.parse_args(argv)
+
+    vault_dir = resolve_vault_dir(args.vault_dir)
+    pack = load_pack(args.pack)
+    profile = pack.operation_profile(args.profile)
+    written = run_operation_profile(vault_dir, profile)
+    print(json.dumps({"written": [str(path) for path in written]}, ensure_ascii=False))
+    return 0

--- a/src/openclaw_pipeline/derived/__init__.py
+++ b/src/openclaw_pipeline/derived/__init__.py
@@ -1,0 +1,3 @@
+from .paths import compiled_view_path, extraction_run_path, review_queue_path
+
+__all__ = ["compiled_view_path", "extraction_run_path", "review_queue_path"]

--- a/src/openclaw_pipeline/derived/paths.py
+++ b/src/openclaw_pipeline/derived/paths.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from hashlib import sha1
+from pathlib import Path
+
+from ..runtime import VaultLayout
+
+
+def _normalize_name(value: str) -> str:
+    normalized = value.strip().replace("/", "__").replace("\\", "__")
+    return normalized.replace(" ", "-")
+
+
+def extraction_run_path(
+    layout: VaultLayout,
+    *,
+    pack_name: str,
+    profile_name: str,
+    source_path: Path,
+) -> Path:
+    profile_dir = layout.extraction_runs_dir / pack_name / _normalize_name(profile_name)
+    source_key = sha1(source_path.as_posix().encode("utf-8")).hexdigest()[:12]
+    return profile_dir / f"{source_key}.json"
+
+
+def review_queue_path(
+    layout: VaultLayout,
+    *,
+    queue_name: str,
+    subject: str,
+) -> Path:
+    return layout.review_queue_dir / _normalize_name(queue_name) / f"{_normalize_name(subject)}.json"
+
+
+def compiled_view_path(
+    layout: VaultLayout,
+    *,
+    pack_name: str,
+    view_name: str,
+) -> Path:
+    return layout.compiled_views_dir / pack_name / f"{_normalize_name(view_name)}.md"

--- a/src/openclaw_pipeline/derived/paths.py
+++ b/src/openclaw_pipeline/derived/paths.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from ..runtime import VaultLayout
 
 
-def _normalize_name(value: str) -> str:
+def normalize_derived_name(value: str) -> str:
     normalized = value.strip().replace("/", "__").replace("\\", "__")
     return normalized.replace(" ", "-")
 
@@ -18,7 +18,7 @@ def extraction_run_path(
     profile_name: str,
     source_path: Path,
 ) -> Path:
-    profile_dir = layout.extraction_runs_dir / pack_name / _normalize_name(profile_name)
+    profile_dir = layout.extraction_runs_dir / pack_name / normalize_derived_name(profile_name)
     source_key = sha1(source_path.as_posix().encode("utf-8")).hexdigest()[:12]
     return profile_dir / f"{source_key}.json"
 
@@ -29,7 +29,7 @@ def review_queue_path(
     queue_name: str,
     subject: str,
 ) -> Path:
-    return layout.review_queue_dir / _normalize_name(queue_name) / f"{_normalize_name(subject)}.json"
+    return layout.review_queue_dir / normalize_derived_name(queue_name) / f"{normalize_derived_name(subject)}.json"
 
 
 def compiled_view_path(
@@ -38,4 +38,4 @@ def compiled_view_path(
     pack_name: str,
     view_name: str,
 ) -> Path:
-    return layout.compiled_views_dir / pack_name / f"{_normalize_name(view_name)}.md"
+    return layout.compiled_views_dir / pack_name / f"{normalize_derived_name(view_name)}.md"

--- a/src/openclaw_pipeline/discovery.py
+++ b/src/openclaw_pipeline/discovery.py
@@ -5,7 +5,7 @@ import sqlite3
 import subprocess
 from pathlib import Path
 
-from .extraction.artifacts import load_run_results
+from .extraction.artifacts import iter_run_results
 from .packs.base import BaseDomainPack
 from .packs.loader import load_pack
 from .runtime import VaultLayout, resolve_vault_dir
@@ -141,7 +141,7 @@ def _discover_with_extraction(
     normalized_query = query.lower().strip()
     rows: list[dict[str, object]] = []
     layout = VaultLayout.from_vault(vault_dir)
-    for result in load_run_results(layout, pack_name=pack.name, profile_name=extraction_profile):
+    for result in iter_run_results(layout, pack_name=pack.name, profile_name=extraction_profile):
         for record in result.records:
             search_blob = " ".join(str(value) for value in record.values.values()).lower()
             if normalized_query and normalized_query not in search_blob:

--- a/src/openclaw_pipeline/discovery.py
+++ b/src/openclaw_pipeline/discovery.py
@@ -5,9 +5,10 @@ import sqlite3
 import subprocess
 from pathlib import Path
 
+from .extraction.artifacts import load_run_results
 from .packs.base import BaseDomainPack
 from .packs.loader import load_pack
-from .runtime import resolve_vault_dir
+from .runtime import VaultLayout, resolve_vault_dir
 
 
 def _snippet_from_page(page: dict[str, object] | None, fallback: str = "") -> str:
@@ -129,6 +130,46 @@ def _discover_with_qmd(vault_dir: Path, query: str, limit: int) -> list[dict[str
     return rows[:limit]
 
 
+def _discover_with_extraction(
+    vault_dir: Path,
+    query: str,
+    limit: int,
+    *,
+    pack: BaseDomainPack,
+    extraction_profile: str | None,
+) -> list[dict[str, object]]:
+    normalized_query = query.lower().strip()
+    rows: list[dict[str, object]] = []
+    layout = VaultLayout.from_vault(vault_dir)
+    for result in load_run_results(layout, pack_name=pack.name, profile_name=extraction_profile):
+        for record in result.records:
+            search_blob = " ".join(str(value) for value in record.values.values()).lower()
+            if normalized_query and normalized_query not in search_blob:
+                continue
+            title = str(
+                record.values.get("section_title")
+                or record.values.get("claim")
+                or record.values.get("subject")
+                or record.values.get("step_name")
+                or result.profile_name
+            )
+            rows.append(
+                {
+                    "engine": "extraction",
+                    "kind": "derived",
+                    "slug": "",
+                    "title": title,
+                    "score": 1.0,
+                    "snippet": " ".join(str(value) for value in record.values.values())[:180],
+                    "path": result.source_path,
+                    "profile": result.profile_name,
+                }
+            )
+            if len(rows) >= limit:
+                return rows
+    return rows
+
+
 def _resolve_pack(pack: str | BaseDomainPack | None) -> BaseDomainPack:
     if isinstance(pack, BaseDomainPack):
         return pack
@@ -170,15 +211,24 @@ def discover_related(
     engine: str = "knowledge",
     limit: int = 10,
     pack: str | BaseDomainPack | None = None,
+    include_extraction: bool = False,
+    extraction_profile: str | None = None,
 ) -> list[dict[str, object]]:
     resolved_vault = resolve_vault_dir(vault_dir)
     resolved_pack = _resolve_pack(pack)
     if engine == "knowledge":
-        return _annotate_discovery_rows(
-            resolved_vault,
-            _discover_with_knowledge(resolved_vault, query, limit),
-            resolved_pack,
-        )
+        rows = _discover_with_knowledge(resolved_vault, query, limit)
+        if include_extraction and len(rows) < limit:
+            rows.extend(
+                _discover_with_extraction(
+                    resolved_vault,
+                    query,
+                    limit - len(rows),
+                    pack=resolved_pack,
+                    extraction_profile=extraction_profile,
+                )
+            )
+        return _annotate_discovery_rows(resolved_vault, rows, resolved_pack)
     if engine == "qmd":
         return _annotate_discovery_rows(
             resolved_vault,

--- a/src/openclaw_pipeline/evidence.py
+++ b/src/openclaw_pipeline/evidence.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from .discovery import discover_related
-from .extraction.artifacts import load_run_results
+from .extraction.artifacts import iter_run_results
 from .knowledge_index import knowledge_index_stats, recent_audit_events
 from .packs.base import BaseDomainPack
 from .packs.loader import load_pack
@@ -167,8 +167,10 @@ def _build_extraction_evidence(
     extraction_profile: str | None,
 ) -> list[dict[str, object]]:
     evidence: list[dict[str, object]] = []
-    for result in load_run_results(VaultLayout.from_vault(vault_dir), pack_name=pack.name, profile_name=extraction_profile):
+    for result in iter_run_results(VaultLayout.from_vault(vault_dir), pack_name=pack.name, profile_name=extraction_profile):
         for record in result.records:
+            if len(evidence) >= limit:
+                return evidence
             span = record.spans[0] if record.spans else None
             evidence.append(
                 {

--- a/src/openclaw_pipeline/evidence.py
+++ b/src/openclaw_pipeline/evidence.py
@@ -220,7 +220,7 @@ def build_evidence_payload(
     graph_targets = list(dict.fromkeys([*(slugs or []), *derived_slugs]))
     slug_kinds = _slug_object_kinds(resolved_vault, registry=registry)
 
-    return {
+    payload = {
         "identity_evidence": identity_evidence,
         "retrieval_evidence": retrieval_evidence,
         "graph_evidence": _build_graph_evidence(
@@ -237,10 +237,12 @@ def build_evidence_payload(
             pack=resolved_pack,
             slug_kinds=slug_kinds,
         ),
-        "extraction_evidence": _build_extraction_evidence(
+    }
+    if include_extraction:
+        payload["extraction_evidence"] = _build_extraction_evidence(
             resolved_vault,
             limit=limit,
             pack=resolved_pack,
             extraction_profile=extraction_profile,
-        ) if include_extraction else [],
-    }
+        )
+    return payload

--- a/src/openclaw_pipeline/evidence.py
+++ b/src/openclaw_pipeline/evidence.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import sqlite3
+from itertools import islice
 from pathlib import Path
 from typing import Any
 
 from .discovery import discover_related
+from .extraction.artifacts import load_run_results
 from .knowledge_index import knowledge_index_stats, recent_audit_events
 from .packs.base import BaseDomainPack
 from .packs.loader import load_pack
@@ -157,6 +159,34 @@ def _build_audit_evidence(
     ]
 
 
+def _build_extraction_evidence(
+    vault_dir: Path,
+    limit: int,
+    *,
+    pack: BaseDomainPack,
+    extraction_profile: str | None,
+) -> list[dict[str, object]]:
+    evidence: list[dict[str, object]] = []
+    for result in load_run_results(VaultLayout.from_vault(vault_dir), pack_name=pack.name, profile_name=extraction_profile):
+        for record in result.records:
+            span = record.spans[0] if record.spans else None
+            evidence.append(
+                {
+                    "channel": "extraction",
+                    "pack": pack.name,
+                    "profile": result.profile_name,
+                    "object_kind": "document",
+                    "source_path": result.source_path,
+                    "quote": span.quote if span else "",
+                    "char_start": span.char_start if span else 0,
+                    "char_end": span.char_end if span else 0,
+                    "section_title": span.section_title if span else "",
+                    "values": record.values,
+                }
+            )
+    return list(islice(evidence, limit))
+
+
 def build_evidence_payload(
     vault_dir: Path,
     *,
@@ -166,6 +196,8 @@ def build_evidence_payload(
     limit: int = 5,
     registry: Any | None = None,
     pack: str | BaseDomainPack | None = None,
+    include_extraction: bool = False,
+    extraction_profile: str | None = None,
 ) -> dict[str, list[dict[str, object]]]:
     resolved_vault = resolve_vault_dir(vault_dir)
     resolved_pack = _resolve_pack(pack)
@@ -205,4 +237,10 @@ def build_evidence_payload(
             pack=resolved_pack,
             slug_kinds=slug_kinds,
         ),
+        "extraction_evidence": _build_extraction_evidence(
+            resolved_vault,
+            limit=limit,
+            pack=resolved_pack,
+            extraction_profile=extraction_profile,
+        ) if include_extraction else [],
     }

--- a/src/openclaw_pipeline/extraction/__init__.py
+++ b/src/openclaw_pipeline/extraction/__init__.py
@@ -1,0 +1,24 @@
+from .specs import (
+    ExtractionFieldSpec,
+    ExtractionProfileSpec,
+    ExtractionRelationSpec,
+    GroundingPolicy,
+    MergePolicy,
+    ProjectionTarget,
+)
+from .results import ExtractionRecord, ExtractionRelation, ExtractionRunResult, ExtractionSpan
+from .runtime import ExtractionRuntime
+
+__all__ = [
+    "ExtractionFieldSpec",
+    "ExtractionProfileSpec",
+    "ExtractionRelationSpec",
+    "ExtractionRecord",
+    "ExtractionRelation",
+    "ExtractionRunResult",
+    "ExtractionRuntime",
+    "ExtractionSpan",
+    "GroundingPolicy",
+    "MergePolicy",
+    "ProjectionTarget",
+]

--- a/src/openclaw_pipeline/extraction/artifacts.py
+++ b/src/openclaw_pipeline/extraction/artifacts.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ..derived.paths import extraction_run_path
+from ..runtime import VaultLayout
+from .results import ExtractionRunResult
+
+
+def write_run_result(layout: VaultLayout, result: ExtractionRunResult) -> Path:
+    path = extraction_run_path(
+        layout,
+        pack_name=result.pack_name,
+        profile_name=result.profile_name,
+        source_path=Path(result.source_path),
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(result.to_dict(), ensure_ascii=False, indent=2), encoding="utf-8")
+    return path
+
+
+def load_run_results(
+    layout: VaultLayout,
+    *,
+    pack_name: str,
+    profile_name: str | None = None,
+) -> list[ExtractionRunResult]:
+    base_dir = layout.extraction_runs_dir / pack_name
+    if profile_name:
+        base_dir = base_dir / profile_name.replace("/", "__").replace("\\", "__")
+    if not base_dir.exists():
+        return []
+
+    results: list[ExtractionRunResult] = []
+    for artifact in sorted(base_dir.rglob("*.json")):
+        results.append(ExtractionRunResult.from_dict(json.loads(artifact.read_text(encoding="utf-8"))))
+    return results

--- a/src/openclaw_pipeline/extraction/artifacts.py
+++ b/src/openclaw_pipeline/extraction/artifacts.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Iterator
 
-from ..derived.paths import extraction_run_path
+from ..derived.paths import extraction_run_path, normalize_derived_name
 from ..runtime import VaultLayout
 from .results import ExtractionRunResult
 
@@ -26,13 +27,20 @@ def load_run_results(
     pack_name: str,
     profile_name: str | None = None,
 ) -> list[ExtractionRunResult]:
+    return list(iter_run_results(layout, pack_name=pack_name, profile_name=profile_name))
+
+
+def iter_run_results(
+    layout: VaultLayout,
+    *,
+    pack_name: str,
+    profile_name: str | None = None,
+) -> Iterator[ExtractionRunResult]:
     base_dir = layout.extraction_runs_dir / pack_name
     if profile_name:
-        base_dir = base_dir / profile_name.replace("/", "__").replace("\\", "__")
+        base_dir = base_dir / normalize_derived_name(profile_name)
     if not base_dir.exists():
-        return []
+        return
 
-    results: list[ExtractionRunResult] = []
     for artifact in sorted(base_dir.rglob("*.json")):
-        results.append(ExtractionRunResult.from_dict(json.loads(artifact.read_text(encoding="utf-8"))))
-    return results
+        yield ExtractionRunResult.from_dict(json.loads(artifact.read_text(encoding="utf-8")))

--- a/src/openclaw_pipeline/extraction/results.py
+++ b/src/openclaw_pipeline/extraction/results.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class ExtractionSpan:
+    source_path: str
+    section_title: str
+    char_start: int
+    char_end: int
+    quote: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "source_path": self.source_path,
+            "section_title": self.section_title,
+            "char_start": self.char_start,
+            "char_end": self.char_end,
+            "quote": self.quote,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> "ExtractionSpan":
+        return cls(
+            source_path=str(data.get("source_path") or ""),
+            section_title=str(data.get("section_title") or ""),
+            char_start=int(data.get("char_start") or 0),
+            char_end=int(data.get("char_end") or 0),
+            quote=str(data.get("quote") or ""),
+        )
+
+
+@dataclass
+class ExtractionRecord:
+    values: dict[str, object]
+    spans: list[ExtractionSpan] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "values": self.values,
+            "spans": [span.to_dict() for span in self.spans],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> "ExtractionRecord":
+        return cls(
+            values=dict(data.get("values") or {}),
+            spans=[ExtractionSpan.from_dict(item) for item in data.get("spans", [])],
+        )
+
+
+@dataclass
+class ExtractionRelation:
+    relation_type: str
+    source_id: str
+    target_id: str
+    spans: list[ExtractionSpan] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "relation_type": self.relation_type,
+            "source_id": self.source_id,
+            "target_id": self.target_id,
+            "spans": [span.to_dict() for span in self.spans],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> "ExtractionRelation":
+        return cls(
+            relation_type=str(data.get("relation_type") or ""),
+            source_id=str(data.get("source_id") or ""),
+            target_id=str(data.get("target_id") or ""),
+            spans=[ExtractionSpan.from_dict(item) for item in data.get("spans", [])],
+        )
+
+
+@dataclass
+class ExtractionRunResult:
+    pack_name: str
+    profile_name: str
+    source_path: str
+    records: list[ExtractionRecord] = field(default_factory=list)
+    relations: list[ExtractionRelation] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "pack_name": self.pack_name,
+            "profile_name": self.profile_name,
+            "source_path": self.source_path,
+            "records": [record.to_dict() for record in self.records],
+            "relations": [relation.to_dict() for relation in self.relations],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> "ExtractionRunResult":
+        return cls(
+            pack_name=str(data.get("pack_name") or ""),
+            profile_name=str(data.get("profile_name") or ""),
+            source_path=str(data.get("source_path") or ""),
+            records=[ExtractionRecord.from_dict(item) for item in data.get("records", [])],
+            relations=[ExtractionRelation.from_dict(item) for item in data.get("relations", [])],
+        )

--- a/src/openclaw_pipeline/extraction/runtime.py
+++ b/src/openclaw_pipeline/extraction/runtime.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+
+from .results import ExtractionRecord, ExtractionRunResult
+from .specs import ExtractionProfileSpec
+
+
+class ExtractionRuntime:
+    def __init__(self, *, extractor: object, chunk_size: int = 2048, overlap: int = 256):
+        self.extractor = extractor
+        self.chunk_size = chunk_size
+        self.overlap = overlap
+
+    def run_text(
+        self,
+        *,
+        profile: ExtractionProfileSpec,
+        text: str,
+        source_path: Path,
+    ) -> ExtractionRunResult:
+        records: list[ExtractionRecord] = []
+        for chunk_index, chunk_text in enumerate(self._chunk_text(text)):
+            records.extend(
+                self.extractor.extract(
+                    chunk_text,
+                    chunk_index=chunk_index,
+                    source_path=source_path,
+                    profile=profile,
+                )
+            )
+        return ExtractionRunResult(
+            pack_name=profile.pack,
+            profile_name=profile.name,
+            source_path=str(source_path),
+            records=self._merge_records(records, profile),
+        )
+
+    def _chunk_text(self, text: str) -> Iterable[str]:
+        if len(text) <= self.chunk_size:
+            yield text
+            return
+
+        step = max(self.chunk_size - self.overlap, 1)
+        for start in range(0, len(text), step):
+            chunk = text[start:start + self.chunk_size]
+            if chunk:
+                yield chunk
+
+    def _merge_records(
+        self,
+        records: list[ExtractionRecord],
+        profile: ExtractionProfileSpec,
+    ) -> list[ExtractionRecord]:
+        if not profile.identifier_fields:
+            return records
+
+        merged: dict[tuple[object, ...], ExtractionRecord] = {}
+        ordered_keys: list[tuple[object, ...]] = []
+
+        for record in records:
+            key = tuple(record.values.get(field) for field in profile.identifier_fields)
+            if key not in merged:
+                merged[key] = ExtractionRecord(values=dict(record.values), spans=list(record.spans))
+                ordered_keys.append(key)
+                continue
+
+            current = merged[key]
+            for field_name, value in record.values.items():
+                if value not in (None, "", [], {}):
+                    current.values[field_name] = value
+            current.spans.extend(record.spans)
+
+        return [merged[key] for key in ordered_keys]

--- a/src/openclaw_pipeline/extraction/specs.py
+++ b/src/openclaw_pipeline/extraction/specs.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class ExtractionFieldSpec:
+    name: str
+    field_type: str
+    description: str
+    required: bool = False
+
+
+@dataclass(frozen=True)
+class ExtractionRelationSpec:
+    name: str
+    source_field: str
+    target_field: str
+    description: str = ""
+
+
+@dataclass(frozen=True)
+class GroundingPolicy:
+    require_quote: bool = True
+    include_char_offsets: bool = True
+    include_section_title: bool = True
+
+
+@dataclass(frozen=True)
+class MergePolicy:
+    strategy: str = "by_identifier"
+    allow_partial_updates: bool = True
+
+
+@dataclass(frozen=True)
+class ProjectionTarget:
+    object_kind: str
+    channel: str
+    target_name: str | None = None
+
+
+@dataclass(frozen=True)
+class ExtractionProfileSpec:
+    name: str
+    pack: str
+    input_object_kinds: list[str]
+    output_mode: str
+    fields: list[ExtractionFieldSpec]
+    relations: list[ExtractionRelationSpec] = field(default_factory=list)
+    grounding_policy: GroundingPolicy = field(default_factory=GroundingPolicy)
+    identifier_fields: list[str] = field(default_factory=list)
+    merge_policy: MergePolicy = field(default_factory=MergePolicy)
+    projection_target: ProjectionTarget = field(
+        default_factory=lambda: ProjectionTarget(object_kind="document", channel="extraction")
+    )
+    display_fields: list[str] = field(default_factory=list)
+    notes: str = ""

--- a/src/openclaw_pipeline/lint_checker.py
+++ b/src/openclaw_pipeline/lint_checker.py
@@ -48,6 +48,19 @@ class LintIssue:
     auto_fixable: bool = False
 
 
+def issue_to_operation_proposal(issue: LintIssue) -> dict[str, object]:
+    queue_name = "frontmatter" if "frontmatter" in issue.type else "review"
+    return {
+        "proposal_type": "lint_issue",
+        "queue_name": queue_name,
+        "review_required": True,
+        "file": issue.file,
+        "message": issue.message,
+        "suggestion": issue.suggestion,
+        "level": issue.level,
+    }
+
+
 class KnowledgeLinter:
     """知识库健康检查器"""
 

--- a/src/openclaw_pipeline/operations/__init__.py
+++ b/src/openclaw_pipeline/operations/__init__.py
@@ -1,0 +1,4 @@
+from .runtime import run_operation_profile
+from .specs import OperationCheckSpec, OperationProfileSpec, OperationProposalSpec
+
+__all__ = ["OperationCheckSpec", "OperationProfileSpec", "OperationProposalSpec", "run_operation_profile"]

--- a/src/openclaw_pipeline/operations/runtime.py
+++ b/src/openclaw_pipeline/operations/runtime.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+from ..derived.paths import review_queue_path
+from ..runtime import VaultLayout, iter_markdown_files, resolve_vault_dir
+from .specs import OperationProfileSpec
+
+
+def _frontmatter_for(path: Path) -> dict[str, object]:
+    content = path.read_text(encoding="utf-8")
+    if not content.startswith("---"):
+        return {}
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        return {}
+    return yaml.safe_load(parts[1]) or {}
+
+
+def _frontmatter_audit_items(vault_dir: Path) -> list[dict[str, object]]:
+    items: list[dict[str, object]] = []
+    for md_file in iter_markdown_files(vault_dir):
+        frontmatter = _frontmatter_for(md_file)
+        if frontmatter.get("title"):
+            continue
+        items.append(
+            {
+                "queue_name": "frontmatter",
+                "issue_type": "missing-title",
+                "file": str(md_file.relative_to(vault_dir)),
+                "message": "Missing title field in frontmatter",
+                "review_required": True,
+            }
+        )
+    return items
+
+
+def run_operation_profile(vault_dir: Path, profile: OperationProfileSpec) -> list[Path]:
+    resolved_vault = resolve_vault_dir(vault_dir)
+    layout = VaultLayout.from_vault(resolved_vault)
+
+    if profile.name == "vault/frontmatter_audit":
+        items = _frontmatter_audit_items(resolved_vault)
+    else:
+        items = []
+
+    written: list[Path] = []
+    for item in items:
+        artifact_path = review_queue_path(
+            layout,
+            queue_name=str(item["queue_name"]),
+            subject=Path(str(item["file"])).stem,
+        )
+        artifact_path.parent.mkdir(parents=True, exist_ok=True)
+        artifact_path.write_text(json.dumps(item, ensure_ascii=False, indent=2), encoding="utf-8")
+        written.append(artifact_path)
+    return written

--- a/src/openclaw_pipeline/operations/runtime.py
+++ b/src/openclaw_pipeline/operations/runtime.py
@@ -1,29 +1,18 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from pathlib import Path
 
-import yaml
-
 from ..derived.paths import review_queue_path
-from ..runtime import VaultLayout, iter_markdown_files, resolve_vault_dir
+from ..runtime import VaultLayout, iter_markdown_files, read_markdown_frontmatter, resolve_vault_dir
 from .specs import OperationProfileSpec
-
-
-def _frontmatter_for(path: Path) -> dict[str, object]:
-    content = path.read_text(encoding="utf-8")
-    if not content.startswith("---"):
-        return {}
-    parts = content.split("---", 2)
-    if len(parts) < 3:
-        return {}
-    return yaml.safe_load(parts[1]) or {}
 
 
 def _frontmatter_audit_items(vault_dir: Path) -> list[dict[str, object]]:
     items: list[dict[str, object]] = []
     for md_file in iter_markdown_files(vault_dir):
-        frontmatter = _frontmatter_for(md_file)
+        frontmatter = read_markdown_frontmatter(md_file)
         if frontmatter.get("title"):
             continue
         items.append(
@@ -38,14 +27,22 @@ def _frontmatter_audit_items(vault_dir: Path) -> list[dict[str, object]]:
     return items
 
 
+def _noop_items(_: Path) -> list[dict[str, object]]:
+    return []
+
+
+_OPERATION_BUILDERS: dict[str, Callable[[Path], list[dict[str, object]]]] = {
+    "vault/frontmatter_audit": _frontmatter_audit_items,
+    "vault/review_queue": _noop_items,
+    "vault/bridge_recommendations": _noop_items,
+}
+
+
 def run_operation_profile(vault_dir: Path, profile: OperationProfileSpec) -> list[Path]:
     resolved_vault = resolve_vault_dir(vault_dir)
     layout = VaultLayout.from_vault(resolved_vault)
-
-    if profile.name == "vault/frontmatter_audit":
-        items = _frontmatter_audit_items(resolved_vault)
-    else:
-        items = []
+    builder = _OPERATION_BUILDERS.get(profile.name, _noop_items)
+    items = builder(resolved_vault)
 
     written: list[Path] = []
     for item in items:

--- a/src/openclaw_pipeline/operations/specs.py
+++ b/src/openclaw_pipeline/operations/specs.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class OperationCheckSpec:
+    name: str
+    description: str
+
+
+@dataclass(frozen=True)
+class OperationProposalSpec:
+    proposal_type: str
+    queue_name: str
+    description: str = ""
+
+
+@dataclass(frozen=True)
+class OperationProfileSpec:
+    name: str
+    pack: str
+    scope: str
+    triggers: list[str] = field(default_factory=list)
+    checks: list[OperationCheckSpec] = field(default_factory=list)
+    proposal_types: list[OperationProposalSpec] = field(default_factory=list)
+    auto_fix_policy: str = "manual"
+    review_required: bool = True

--- a/src/openclaw_pipeline/packs/base.py
+++ b/src/openclaw_pipeline/packs/base.py
@@ -34,6 +34,9 @@ class BaseDomainPack:
     _object_kinds: list[ObjectKindSpec] = field(default_factory=list)
     _workflow_profiles: list[WorkflowProfile] = field(default_factory=list)
     _discoverable_object_kinds: list[str] = field(default_factory=list)
+    _extraction_profiles: list[object] = field(default_factory=list)
+    _operation_profiles: list[object] = field(default_factory=list)
+    _wiki_views: list[object] = field(default_factory=list)
 
     def object_kinds(self) -> list[ObjectKindSpec]:
         return list(self._object_kinds)
@@ -51,3 +54,30 @@ class BaseDomainPack:
             if profile.name == name:
                 return profile
         raise ValueError(f"Unknown workflow profile '{name}' for pack '{self.name}'")
+
+    def extraction_profiles(self) -> list[object]:
+        return list(self._extraction_profiles)
+
+    def extraction_profile(self, name: str) -> object:
+        for profile in self._extraction_profiles:
+            if getattr(profile, "name", None) == name:
+                return profile
+        raise ValueError(f"Unknown extraction profile '{name}' for pack '{self.name}'")
+
+    def operation_profiles(self) -> list[object]:
+        return list(self._operation_profiles)
+
+    def operation_profile(self, name: str) -> object:
+        for profile in self._operation_profiles:
+            if getattr(profile, "name", None) == name:
+                return profile
+        raise ValueError(f"Unknown operation profile '{name}' for pack '{self.name}'")
+
+    def wiki_views(self) -> list[object]:
+        return list(self._wiki_views)
+
+    def wiki_view(self, name: str) -> object:
+        for view in self._wiki_views:
+            if getattr(view, "name", None) == name:
+                return view
+        raise ValueError(f"Unknown wiki view '{name}' for pack '{self.name}'")

--- a/src/openclaw_pipeline/packs/default_knowledge/extraction_profiles.py
+++ b/src/openclaw_pipeline/packs/default_knowledge/extraction_profiles.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from ...extraction.specs import (
+    ExtractionFieldSpec,
+    ExtractionProfileSpec,
+    GroundingPolicy,
+    MergePolicy,
+    ProjectionTarget,
+)
+
+
+DEFAULT_EXTRACTION_PROFILES = [
+    ExtractionProfileSpec(
+        name="media/news_timeline",
+        pack="default-knowledge",
+        input_object_kinds=["document"],
+        output_mode="record_list",
+        fields=[
+            ExtractionFieldSpec("event_type", "string", "Type of event"),
+            ExtractionFieldSpec("actors", "string_list", "People or organizations involved"),
+            ExtractionFieldSpec("when", "string", "When the event happened"),
+            ExtractionFieldSpec("claim", "string", "Core event statement", required=True),
+            ExtractionFieldSpec("impact", "string", "Why it matters"),
+        ],
+        identifier_fields=["claim", "when"],
+        grounding_policy=GroundingPolicy(require_quote=True, include_char_offsets=True),
+        merge_policy=MergePolicy(strategy="by_identifier", allow_partial_updates=True),
+        projection_target=ProjectionTarget(object_kind="document", channel="extraction"),
+        display_fields=["event_type", "when", "claim"],
+        notes="Loosely adapted from Hyper-Extract event timeline ideas.",
+    ),
+    ExtractionProfileSpec(
+        name="media/commentary_sentiment",
+        pack="default-knowledge",
+        input_object_kinds=["document"],
+        output_mode="record_list",
+        fields=[
+            ExtractionFieldSpec("subject", "string", "Primary subject of commentary", required=True),
+            ExtractionFieldSpec("stance", "string", "Overall stance or tone"),
+            ExtractionFieldSpec("sentiment_score", "number", "Normalized sentiment score"),
+            ExtractionFieldSpec("thesis", "string", "Main opinion or framing"),
+        ],
+        identifier_fields=["subject", "thesis"],
+        grounding_policy=GroundingPolicy(require_quote=True, include_char_offsets=True),
+        merge_policy=MergePolicy(strategy="by_identifier", allow_partial_updates=True),
+        projection_target=ProjectionTarget(object_kind="document", channel="extraction"),
+        display_fields=["subject", "stance", "sentiment_score"],
+        notes="Moderately adapted from Hyper-Extract sentiment model ideas.",
+    ),
+    ExtractionProfileSpec(
+        name="tech/doc_structure",
+        pack="default-knowledge",
+        input_object_kinds=["document"],
+        output_mode="record_list",
+        fields=[
+            ExtractionFieldSpec("section_title", "string", "Heading text", required=True),
+            ExtractionFieldSpec("section_kind", "string", "Body, appendix, code, table, figure"),
+            ExtractionFieldSpec("summary", "string", "Short summary of section content"),
+            ExtractionFieldSpec("references", "string_list", "Cross references found in the section"),
+        ],
+        identifier_fields=["section_title"],
+        grounding_policy=GroundingPolicy(require_quote=True, include_char_offsets=True),
+        merge_policy=MergePolicy(strategy="by_identifier", allow_partial_updates=True),
+        projection_target=ProjectionTarget(object_kind="document", channel="extraction"),
+        display_fields=["section_title", "section_kind", "summary"],
+        notes="Heavily inspired by Hyper-Extract general/doc_structure.",
+    ),
+    ExtractionProfileSpec(
+        name="tech/workflow_graph",
+        pack="default-knowledge",
+        input_object_kinds=["document"],
+        output_mode="graph",
+        fields=[
+            ExtractionFieldSpec("step_name", "string", "Workflow step name", required=True),
+            ExtractionFieldSpec("step_kind", "string", "Action, decision, input, output"),
+            ExtractionFieldSpec("depends_on", "string_list", "Prerequisite step names"),
+            ExtractionFieldSpec("produces", "string_list", "Artifacts or outputs produced"),
+        ],
+        identifier_fields=["step_name"],
+        grounding_policy=GroundingPolicy(require_quote=True, include_char_offsets=True),
+        merge_policy=MergePolicy(strategy="by_identifier", allow_partial_updates=True),
+        projection_target=ProjectionTarget(object_kind="document", channel="extraction"),
+        display_fields=["step_name", "step_kind"],
+        notes="Heavily inspired by Hyper-Extract general/workflow_graph.",
+    ),
+]

--- a/src/openclaw_pipeline/packs/default_knowledge/operation_profiles.py
+++ b/src/openclaw_pipeline/packs/default_knowledge/operation_profiles.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from ...operations.specs import OperationCheckSpec, OperationProfileSpec, OperationProposalSpec
+
+
+DEFAULT_OPERATION_PROFILES = [
+    OperationProfileSpec(
+        name="vault/frontmatter_audit",
+        pack="default-knowledge",
+        scope="vault",
+        triggers=["manual", "pre-refine"],
+        checks=[OperationCheckSpec(name="required-frontmatter", description="Ensure title and note metadata exist")],
+        proposal_types=[OperationProposalSpec(proposal_type="frontmatter_fix", queue_name="frontmatter")],
+        auto_fix_policy="manual",
+        review_required=True,
+    ),
+    OperationProfileSpec(
+        name="vault/review_queue",
+        pack="default-knowledge",
+        scope="vault",
+        triggers=["manual"],
+        checks=[OperationCheckSpec(name="queue-health", description="Inspect pending review items")],
+        proposal_types=[OperationProposalSpec(proposal_type="queue_review", queue_name="review")],
+        auto_fix_policy="manual",
+        review_required=True,
+    ),
+    OperationProfileSpec(
+        name="vault/bridge_recommendations",
+        pack="default-knowledge",
+        scope="vault",
+        triggers=["manual", "post-absorb"],
+        checks=[OperationCheckSpec(name="bridge-gaps", description="Suggest cross-note bridge candidates")],
+        proposal_types=[OperationProposalSpec(proposal_type="bridge_note", queue_name="bridges")],
+        auto_fix_policy="manual",
+        review_required=True,
+    ),
+]

--- a/src/openclaw_pipeline/packs/default_knowledge/pack.py
+++ b/src/openclaw_pipeline/packs/default_knowledge/pack.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from ..base import BaseDomainPack
+from .extraction_profiles import DEFAULT_EXTRACTION_PROFILES
 from .profiles import DEFAULT_KNOWLEDGE_AUTOPILOT_PROFILE, DEFAULT_KNOWLEDGE_FULL_PROFILE
 from .schemas import DEFAULT_KNOWLEDGE_OBJECT_KINDS
 
@@ -15,4 +16,5 @@ def get_pack() -> BaseDomainPack:
             DEFAULT_KNOWLEDGE_FULL_PROFILE,
             DEFAULT_KNOWLEDGE_AUTOPILOT_PROFILE,
         ],
+        _extraction_profiles=list(DEFAULT_EXTRACTION_PROFILES),
     )

--- a/src/openclaw_pipeline/packs/default_knowledge/pack.py
+++ b/src/openclaw_pipeline/packs/default_knowledge/pack.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from ..base import BaseDomainPack
 from .extraction_profiles import DEFAULT_EXTRACTION_PROFILES
+from .operation_profiles import DEFAULT_OPERATION_PROFILES
 from .profiles import DEFAULT_KNOWLEDGE_AUTOPILOT_PROFILE, DEFAULT_KNOWLEDGE_FULL_PROFILE
 from .schemas import DEFAULT_KNOWLEDGE_OBJECT_KINDS
+from .wiki_views import DEFAULT_WIKI_VIEWS
 
 
 def get_pack() -> BaseDomainPack:
@@ -17,4 +19,6 @@ def get_pack() -> BaseDomainPack:
             DEFAULT_KNOWLEDGE_AUTOPILOT_PROFILE,
         ],
         _extraction_profiles=list(DEFAULT_EXTRACTION_PROFILES),
+        _operation_profiles=list(DEFAULT_OPERATION_PROFILES),
+        _wiki_views=list(DEFAULT_WIKI_VIEWS),
     )

--- a/src/openclaw_pipeline/packs/default_knowledge/wiki_views.py
+++ b/src/openclaw_pipeline/packs/default_knowledge/wiki_views.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from ...wiki_views.specs import TraceabilityPolicy, WikiViewInputSpec, WikiViewSpec
+
+
+DEFAULT_WIKI_VIEWS = [
+    WikiViewSpec(
+        name="overview/domain",
+        pack="default-knowledge",
+        purpose_path="90-Templates/purpose/domain.md",
+        schema_path="90-Templates/schema/domain.md",
+        input_sources=[WikiViewInputSpec(source_kind="evergreen", description="Canonical evergreen notes")],
+        traceability_policy=TraceabilityPolicy(include_sources=True, include_generated_from=True),
+        publish_target="compiled_markdown",
+    ),
+    WikiViewSpec(
+        name="overview/topic",
+        pack="default-knowledge",
+        purpose_path="90-Templates/purpose/topic.md",
+        schema_path="90-Templates/schema/topic.md",
+        input_sources=[WikiViewInputSpec(source_kind="evergreen", description="Topic-level evergreen notes")],
+        traceability_policy=TraceabilityPolicy(include_sources=True, include_generated_from=True),
+        publish_target="compiled_markdown",
+    ),
+    WikiViewSpec(
+        name="saved_answer/query",
+        pack="default-knowledge",
+        purpose_path="90-Templates/purpose/saved-answer.md",
+        schema_path="90-Templates/schema/saved-answer.md",
+        input_sources=[WikiViewInputSpec(source_kind="query", description="Saved query outputs")],
+        traceability_policy=TraceabilityPolicy(include_sources=True, include_generated_from=True),
+        publish_target="compiled_markdown",
+    ),
+]

--- a/src/openclaw_pipeline/query_to_wiki.py
+++ b/src/openclaw_pipeline/query_to_wiki.py
@@ -52,7 +52,12 @@ type: evergreen
 date: {date_str}
 tags: [evergreen, auto-generated]
 aliases: ["{title}", "{slug}"]
----
+"""
+    if sources:
+        md_content += "sources:\n"
+        for source in sources:
+            md_content += f'  - "{source}"\n'
+    md_content += f"""---
 
 # {title}
 

--- a/src/openclaw_pipeline/runtime.py
+++ b/src/openclaw_pipeline/runtime.py
@@ -5,6 +5,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Iterator
 
+import yaml
+
 
 def resolve_vault_dir(vault_dir: Path | str | None = None) -> Path:
     """Resolve the vault directory once and use the absolute path everywhere."""
@@ -24,6 +26,24 @@ def iter_markdown_files(directory: Path, recursive: bool = True) -> Iterator[Pat
         if is_hidden_path(md_file):
             continue
         yield md_file
+
+
+def read_markdown_frontmatter(path: Path) -> dict[str, object]:
+    """Return parsed YAML frontmatter for a markdown file, if present."""
+    content = path.read_text(encoding="utf-8")
+    if not content.startswith("---"):
+        return {}
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        return {}
+    return yaml.safe_load(parts[1]) or {}
+
+
+def markdown_title(path: Path) -> str:
+    """Return a markdown file title from frontmatter, falling back to the stem."""
+    metadata = read_markdown_frontmatter(path)
+    title = metadata.get("title")
+    return str(title) if title else path.stem
 
 
 @dataclass(frozen=True)
@@ -113,6 +133,10 @@ class VaultLayout:
     @property
     def papers_dir(self) -> Path:
         return self.vault_dir / "20-Areas" / "AI-Research" / "Papers"
+
+    @property
+    def queries_dir(self) -> Path:
+        return self.vault_dir / "20-Areas" / "Queries"
 
     @property
     def pinboard_archive_dir(self) -> Path:

--- a/src/openclaw_pipeline/runtime.py
+++ b/src/openclaw_pipeline/runtime.py
@@ -95,6 +95,10 @@ class VaultLayout:
         return self.vault_dir / "50-Inbox" / "02-Pinboard"
 
     @property
+    def processing_dir(self) -> Path:
+        return self.vault_dir / "50-Inbox" / "02-Processing"
+
+    @property
     def processed_dir(self) -> Path:
         return self.vault_dir / "50-Inbox" / "03-Processed"
 

--- a/src/openclaw_pipeline/runtime.py
+++ b/src/openclaw_pipeline/runtime.py
@@ -51,6 +51,22 @@ class VaultLayout:
         return self.logs_dir / "transactions"
 
     @property
+    def derived_dir(self) -> Path:
+        return self.logs_dir / "derived"
+
+    @property
+    def extraction_runs_dir(self) -> Path:
+        return self.derived_dir / "extraction-runs"
+
+    @property
+    def review_queue_dir(self) -> Path:
+        return self.derived_dir / "review-queue"
+
+    @property
+    def compiled_views_dir(self) -> Path:
+        return self.derived_dir / "compiled-views"
+
+    @property
     def pipeline_reports_dir(self) -> Path:
         return self.logs_dir / "pipeline-reports"
 

--- a/src/openclaw_pipeline/wiki_views/__init__.py
+++ b/src/openclaw_pipeline/wiki_views/__init__.py
@@ -1,0 +1,4 @@
+from .runtime import build_view
+from .specs import TraceabilityPolicy, WikiViewInputSpec, WikiViewSpec
+
+__all__ = ["TraceabilityPolicy", "WikiViewInputSpec", "WikiViewSpec", "build_view"]

--- a/src/openclaw_pipeline/wiki_views/runtime.py
+++ b/src/openclaw_pipeline/wiki_views/runtime.py
@@ -2,22 +2,37 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import yaml
-
 from ..derived.paths import compiled_view_path
-from ..runtime import VaultLayout, resolve_vault_dir
+from ..runtime import VaultLayout, iter_markdown_files, markdown_title, resolve_vault_dir
 from .specs import WikiViewSpec
 
 
-def _load_title(path: Path) -> str:
-    content = path.read_text(encoding="utf-8")
-    if content.startswith("---"):
-        parts = content.split("---", 2)
-        if len(parts) >= 3:
-            metadata = yaml.safe_load(parts[1]) or {}
-            if metadata.get("title"):
-                return str(metadata["title"])
-    return path.stem
+def _paths_for_source_kind(layout: VaultLayout, source_kind: str) -> list[Path]:
+    source_roots = {
+        "evergreen": layout.evergreen_dir,
+        "query": layout.queries_dir,
+        "atlas": layout.atlas_dir,
+        "raw": layout.raw_dir,
+    }
+    root = source_roots.get(source_kind)
+    if root is None or not root.exists():
+        return []
+    return sorted(iter_markdown_files(root))
+
+
+def _resolve_view_inputs(layout: VaultLayout, spec: WikiViewSpec) -> list[Path]:
+    if not spec.input_sources:
+        return _paths_for_source_kind(layout, "evergreen")
+
+    seen: set[Path] = set()
+    resolved: list[Path] = []
+    for input_spec in spec.input_sources:
+        for path in _paths_for_source_kind(layout, input_spec.source_kind):
+            if path in seen:
+                continue
+            seen.add(path)
+            resolved.append(path)
+    return resolved
 
 
 def build_view(vault_dir: Path, spec: WikiViewSpec) -> Path:
@@ -27,9 +42,8 @@ def build_view(vault_dir: Path, spec: WikiViewSpec) -> Path:
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
     titles: list[str] = []
-    if layout.evergreen_dir.exists():
-        for note in sorted(layout.evergreen_dir.glob("*.md")):
-            titles.append(_load_title(note))
+    for note in _resolve_view_inputs(layout, spec):
+        titles.append(markdown_title(note))
 
     lines = [
         f"# {spec.name}",

--- a/src/openclaw_pipeline/wiki_views/runtime.py
+++ b/src/openclaw_pipeline/wiki_views/runtime.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from ..derived.paths import compiled_view_path
+from ..runtime import VaultLayout, resolve_vault_dir
+from .specs import WikiViewSpec
+
+
+def _load_title(path: Path) -> str:
+    content = path.read_text(encoding="utf-8")
+    if content.startswith("---"):
+        parts = content.split("---", 2)
+        if len(parts) >= 3:
+            metadata = yaml.safe_load(parts[1]) or {}
+            if metadata.get("title"):
+                return str(metadata["title"])
+    return path.stem
+
+
+def build_view(vault_dir: Path, spec: WikiViewSpec) -> Path:
+    resolved_vault = resolve_vault_dir(vault_dir)
+    layout = VaultLayout.from_vault(resolved_vault)
+    output_path = compiled_view_path(layout, pack_name=spec.pack, view_name=spec.name)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    titles: list[str] = []
+    if layout.evergreen_dir.exists():
+        for note in sorted(layout.evergreen_dir.glob("*.md")):
+            titles.append(_load_title(note))
+
+    lines = [
+        f"# {spec.name}",
+        "",
+        f"- pack: {spec.pack}",
+        f"- publish_target: {spec.publish_target}",
+        "",
+        "## Included Notes",
+        "",
+    ]
+    if titles:
+        lines.extend(f"- {title}" for title in titles)
+    else:
+        lines.append("- (none)")
+
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return output_path

--- a/src/openclaw_pipeline/wiki_views/specs.py
+++ b/src/openclaw_pipeline/wiki_views/specs.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class TraceabilityPolicy:
+    include_sources: bool = True
+    include_generated_from: bool = True
+
+
+@dataclass(frozen=True)
+class WikiViewInputSpec:
+    source_kind: str
+    description: str
+
+
+@dataclass(frozen=True)
+class WikiViewSpec:
+    name: str
+    pack: str
+    purpose_path: str
+    schema_path: str
+    input_sources: list[WikiViewInputSpec] = field(default_factory=list)
+    builder: str = "compiled_markdown"
+    traceability_policy: TraceabilityPolicy = field(default_factory=TraceabilityPolicy)
+    publish_target: str = "compiled_markdown"

--- a/tests/test_build_views_command.py
+++ b/tests/test_build_views_command.py
@@ -39,3 +39,50 @@ date: 2026-04-10
     content = artifacts[0].read_text(encoding="utf-8")
     assert "# overview/domain" in content
     assert "Agent Harness" in content
+
+
+def test_build_views_command_respects_input_source_kinds(temp_vault):
+    from openclaw_pipeline.commands.build_views import main
+    from openclaw_pipeline.runtime import VaultLayout
+
+    evergreen = temp_vault / "10-Knowledge" / "Evergreen" / "Evergreen-Only.md"
+    evergreen.parent.mkdir(parents=True, exist_ok=True)
+    evergreen.write_text(
+        """---
+title: Evergreen Only
+type: evergreen
+---
+""",
+        encoding="utf-8",
+    )
+
+    query = temp_vault / "20-Areas" / "Queries" / "Saved-Answer.md"
+    query.parent.mkdir(parents=True, exist_ok=True)
+    query.write_text(
+        """---
+title: Saved Answer
+type: query
+---
+""",
+        encoding="utf-8",
+    )
+
+    result = main(
+        [
+            "--vault-dir",
+            str(temp_vault),
+            "--pack",
+            "default-knowledge",
+            "--view",
+            "saved_answer/query",
+        ]
+    )
+
+    layout = VaultLayout.from_vault(temp_vault)
+    artifacts = sorted(layout.compiled_views_dir.rglob("*.md"))
+
+    assert result == 0
+    assert artifacts
+    content = artifacts[-1].read_text(encoding="utf-8")
+    assert "Saved Answer" in content
+    assert "Evergreen Only" not in content

--- a/tests/test_build_views_command.py
+++ b/tests/test_build_views_command.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+
+def test_build_views_command_writes_compiled_markdown(temp_vault):
+    from openclaw_pipeline.commands.build_views import main
+    from openclaw_pipeline.runtime import VaultLayout
+
+    note = temp_vault / "10-Knowledge" / "Evergreen" / "Agent-Harness.md"
+    note.parent.mkdir(parents=True, exist_ok=True)
+    note.write_text(
+        """---
+note_id: agent-harness
+title: Agent Harness
+type: evergreen
+date: 2026-04-10
+---
+
+# Agent Harness
+""",
+        encoding="utf-8",
+    )
+
+    result = main(
+        [
+            "--vault-dir",
+            str(temp_vault),
+            "--pack",
+            "default-knowledge",
+            "--view",
+            "overview/domain",
+        ]
+    )
+
+    layout = VaultLayout.from_vault(temp_vault)
+    artifacts = sorted(layout.compiled_views_dir.rglob("*.md"))
+
+    assert result == 0
+    assert artifacts
+    content = artifacts[0].read_text(encoding="utf-8")
+    assert "# overview/domain" in content
+    assert "Agent Harness" in content

--- a/tests/test_default_pack_extraction_profiles.py
+++ b/tests/test_default_pack_extraction_profiles.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+
+def test_default_pack_registers_first_wave_extraction_profiles():
+    from openclaw_pipeline.packs.loader import load_default_pack
+
+    pack = load_default_pack()
+    profiles = {profile.name: profile for profile in pack.extraction_profiles()}
+
+    assert {
+        "media/news_timeline",
+        "media/commentary_sentiment",
+        "tech/doc_structure",
+        "tech/workflow_graph",
+    } <= set(profiles)
+
+    assert profiles["tech/doc_structure"].identifier_fields == ["section_title"]
+    assert profiles["tech/workflow_graph"].projection_target.channel == "extraction"
+    assert profiles["media/news_timeline"].grounding_policy.require_quote is True
+    assert profiles["media/commentary_sentiment"].projection_target.object_kind == "document"

--- a/tests/test_derived_paths.py
+++ b/tests/test_derived_paths.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from openclaw_pipeline.derived.paths import compiled_view_path, extraction_run_path, review_queue_path
+from openclaw_pipeline.derived.paths import (
+    compiled_view_path,
+    extraction_run_path,
+    normalize_derived_name,
+    review_queue_path,
+)
 from openclaw_pipeline.runtime import VaultLayout
 
 
@@ -34,3 +39,7 @@ def test_compiled_view_path_stays_under_compiled_view_directory(tmp_path):
 
     assert path.parent == layout.compiled_views_dir / "default-knowledge"
     assert path.name == "overview__domain.md"
+
+
+def test_normalize_derived_name_handles_spaces_and_separators():
+    assert normalize_derived_name("  tech / doc structure  ") == "tech-__-doc-structure"

--- a/tests/test_derived_paths.py
+++ b/tests/test_derived_paths.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from openclaw_pipeline.derived.paths import compiled_view_path, extraction_run_path, review_queue_path
+from openclaw_pipeline.runtime import VaultLayout
+
+
+def test_extraction_run_path_is_stable_for_same_inputs(tmp_path):
+    layout = VaultLayout.from_vault(tmp_path / "vault")
+    source = Path("50-Inbox/01-Raw/example.md")
+
+    first = extraction_run_path(layout, pack_name="default-knowledge", profile_name="tech/doc_structure", source_path=source)
+    second = extraction_run_path(layout, pack_name="default-knowledge", profile_name="tech/doc_structure", source_path=source)
+
+    assert first == second
+    assert first.parent == layout.extraction_runs_dir / "default-knowledge" / "tech__doc_structure"
+    assert first.suffix == ".json"
+
+
+def test_review_queue_path_stays_under_review_queue_directory(tmp_path):
+    layout = VaultLayout.from_vault(tmp_path / "vault")
+
+    path = review_queue_path(layout, queue_name="frontmatter", subject="missing-title")
+
+    assert path.parent == layout.review_queue_dir / "frontmatter"
+    assert path.name == "missing-title.json"
+
+
+def test_compiled_view_path_stays_under_compiled_view_directory(tmp_path):
+    layout = VaultLayout.from_vault(tmp_path / "vault")
+
+    path = compiled_view_path(layout, pack_name="default-knowledge", view_name="overview/domain")
+
+    assert path.parent == layout.compiled_views_dir / "default-knowledge"
+    assert path.name == "overview__domain.md"

--- a/tests/test_discovery_extraction_projection.py
+++ b/tests/test_discovery_extraction_projection.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def test_discover_related_can_include_projected_extraction_rows(temp_vault):
+    from openclaw_pipeline.derived.paths import extraction_run_path
+    from openclaw_pipeline.discovery import discover_related
+    from openclaw_pipeline.extraction.results import ExtractionRecord, ExtractionRunResult, ExtractionSpan
+    from openclaw_pipeline.runtime import VaultLayout
+
+    layout = VaultLayout.from_vault(temp_vault)
+    source_path = Path("50-Inbox/01-Raw/example.md")
+    artifact_path = extraction_run_path(
+        layout,
+        pack_name="default-knowledge",
+        profile_name="tech/doc_structure",
+        source_path=source_path,
+    )
+    artifact_path.parent.mkdir(parents=True, exist_ok=True)
+    artifact_path.write_text(
+        json.dumps(
+            ExtractionRunResult(
+                pack_name="default-knowledge",
+                profile_name="tech/doc_structure",
+                source_path=str(source_path),
+                records=[
+                    ExtractionRecord(
+                        values={"section_title": "Architecture", "summary": "Tool orchestration"},
+                        spans=[
+                            ExtractionSpan(
+                                source_path=str(source_path),
+                                section_title="Architecture",
+                                char_start=0,
+                                char_end=20,
+                                quote="Tool orchestration",
+                            )
+                        ],
+                    )
+                ],
+            ).to_dict(),
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    results = discover_related(
+        temp_vault,
+        "architecture",
+        limit=5,
+        include_extraction=True,
+        extraction_profile="tech/doc_structure",
+    )
+
+    assert results
+    assert results[0]["engine"] == "extraction"
+    assert results[0]["pack"] == "default-knowledge"
+    assert results[0]["object_kind"] == "document"
+    assert results[0]["title"] == "Architecture"
+

--- a/tests/test_evidence_extraction_channel.py
+++ b/tests/test_evidence_extraction_channel.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def test_build_evidence_payload_can_include_extraction_evidence(temp_vault):
+    from openclaw_pipeline.derived.paths import extraction_run_path
+    from openclaw_pipeline.evidence import build_evidence_payload
+    from openclaw_pipeline.extraction.results import ExtractionRecord, ExtractionRunResult, ExtractionSpan
+    from openclaw_pipeline.runtime import VaultLayout
+
+    layout = VaultLayout.from_vault(temp_vault)
+    source_path = Path("50-Inbox/01-Raw/example.md")
+    artifact_path = extraction_run_path(
+        layout,
+        pack_name="default-knowledge",
+        profile_name="tech/doc_structure",
+        source_path=source_path,
+    )
+    artifact_path.parent.mkdir(parents=True, exist_ok=True)
+
+    result = ExtractionRunResult(
+        pack_name="default-knowledge",
+        profile_name="tech/doc_structure",
+        source_path=str(source_path),
+        records=[
+            ExtractionRecord(
+                values={"section_title": "Architecture", "summary": "Overview"},
+                spans=[
+                    ExtractionSpan(
+                        source_path=str(source_path),
+                        section_title="Architecture",
+                        char_start=0,
+                        char_end=20,
+                        quote="Architecture overview",
+                    )
+                ],
+            )
+        ],
+    )
+    artifact_path.write_text(json.dumps(result.to_dict(), ensure_ascii=False), encoding="utf-8")
+
+    payload = build_evidence_payload(
+        temp_vault,
+        extraction_profile="tech/doc_structure",
+        include_extraction=True,
+    )
+
+    assert "extraction_evidence" in payload
+    assert payload["extraction_evidence"][0]["channel"] == "extraction"
+    assert payload["extraction_evidence"][0]["profile"] == "tech/doc_structure"
+    assert payload["extraction_evidence"][0]["quote"] == "Architecture overview"
+

--- a/tests/test_evidence_extraction_channel.py
+++ b/tests/test_evidence_extraction_channel.py
@@ -52,3 +52,36 @@ def test_build_evidence_payload_can_include_extraction_evidence(temp_vault):
     assert payload["extraction_evidence"][0]["profile"] == "tech/doc_structure"
     assert payload["extraction_evidence"][0]["quote"] == "Architecture overview"
 
+
+def test_build_evidence_payload_limits_extraction_evidence(temp_vault):
+    from openclaw_pipeline.derived.paths import extraction_run_path
+    from openclaw_pipeline.evidence import build_evidence_payload
+    from openclaw_pipeline.extraction.results import ExtractionRecord, ExtractionRunResult
+    from openclaw_pipeline.runtime import VaultLayout
+
+    layout = VaultLayout.from_vault(temp_vault)
+    for index in range(2):
+        source_path = Path(f"50-Inbox/01-Raw/example-{index}.md")
+        artifact_path = extraction_run_path(
+            layout,
+            pack_name="default-knowledge",
+            profile_name="tech/doc_structure",
+            source_path=source_path,
+        )
+        artifact_path.parent.mkdir(parents=True, exist_ok=True)
+        result = ExtractionRunResult(
+            pack_name="default-knowledge",
+            profile_name="tech/doc_structure",
+            source_path=str(source_path),
+            records=[ExtractionRecord(values={"section_title": f"Section {index}"}, spans=[])],
+        )
+        artifact_path.write_text(json.dumps(result.to_dict(), ensure_ascii=False), encoding="utf-8")
+
+    payload = build_evidence_payload(
+        temp_vault,
+        extraction_profile="tech/doc_structure",
+        include_extraction=True,
+        limit=1,
+    )
+
+    assert len(payload["extraction_evidence"]) == 1

--- a/tests/test_extract_profiles_command.py
+++ b/tests/test_extract_profiles_command.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import json
+
+
+class FakeCommandExtractor:
+    def extract(self, chunk_text, *, chunk_index, source_path, profile):  # noqa: ANN001
+        from openclaw_pipeline.extraction.results import ExtractionRecord, ExtractionSpan
+
+        return [
+            ExtractionRecord(
+                values={"section_title": "Architecture", "summary": chunk_text[:20]},
+                spans=[
+                    ExtractionSpan(
+                        source_path=str(source_path),
+                        section_title="Architecture",
+                        char_start=chunk_index,
+                        char_end=chunk_index + 20,
+                        quote="Architecture quote",
+                    )
+                ],
+            )
+        ]
+
+
+def test_extract_profiles_command_writes_derived_json(temp_vault, monkeypatch):
+    from openclaw_pipeline.commands import extract_profiles
+    from openclaw_pipeline.runtime import VaultLayout
+
+    source = temp_vault / "50-Inbox" / "01-Raw" / "example.md"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text("# Architecture\n\nRuntime tools.\n", encoding="utf-8")
+
+    monkeypatch.setattr(extract_profiles, "build_extractor", lambda: FakeCommandExtractor())
+
+    result = extract_profiles.main(
+        [
+            "--vault-dir",
+            str(temp_vault),
+            "--pack",
+            "default-knowledge",
+            "--profile",
+            "tech/doc_structure",
+            "--source",
+            str(source),
+        ]
+    )
+
+    layout = VaultLayout.from_vault(temp_vault)
+    artifacts = sorted(layout.extraction_runs_dir.rglob("*.json"))
+
+    assert result == 0
+    assert artifacts
+    payload = json.loads(artifacts[0].read_text(encoding="utf-8"))
+    assert payload["profile_name"] == "tech/doc_structure"
+    assert payload["records"][0]["values"]["section_title"] == "Architecture"
+    assert not list((temp_vault / "10-Knowledge" / "Evergreen").glob("*.md"))

--- a/tests/test_extraction_results.py
+++ b/tests/test_extraction_results.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+
+def test_extraction_span_preserves_grounding_metadata():
+    from openclaw_pipeline.extraction.results import ExtractionRecord, ExtractionSpan
+
+    span = ExtractionSpan(
+        source_path="50-Inbox/01-Raw/example.md",
+        section_title="Introduction",
+        char_start=10,
+        char_end=42,
+        quote="Grounded evidence quote",
+    )
+    record = ExtractionRecord(
+        values={"section_title": "Introduction", "summary": "Overview"},
+        spans=[span],
+    )
+
+    assert record.values["section_title"] == "Introduction"
+    assert record.spans[0].section_title == "Introduction"
+    assert record.spans[0].quote == "Grounded evidence quote"
+

--- a/tests/test_extraction_runtime_merge.py
+++ b/tests/test_extraction_runtime_merge.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from openclaw_pipeline.extraction.specs import (
+    ExtractionFieldSpec,
+    ExtractionProfileSpec,
+    GroundingPolicy,
+    MergePolicy,
+    ProjectionTarget,
+)
+
+
+class FakeExtractor:
+    def extract(self, chunk_text, *, chunk_index, source_path, profile):  # noqa: ANN001
+        from openclaw_pipeline.extraction.results import ExtractionRecord, ExtractionSpan
+
+        quote = "first quote" if chunk_index == 0 else "second quote"
+        summary = "first summary" if chunk_index == 0 else "refined summary"
+        return [
+            ExtractionRecord(
+                values={"section_title": "Architecture", "summary": summary},
+                spans=[
+                    ExtractionSpan(
+                        source_path=str(source_path),
+                        section_title="Architecture",
+                        char_start=chunk_index * 10,
+                        char_end=chunk_index * 10 + 10,
+                        quote=quote,
+                    )
+                ],
+            )
+        ]
+
+
+def test_runtime_merges_records_by_identifier_fields(tmp_path):
+    from openclaw_pipeline.extraction.runtime import ExtractionRuntime
+
+    profile = ExtractionProfileSpec(
+        name="tech/doc_structure",
+        pack="default-knowledge",
+        input_object_kinds=["document"],
+        output_mode="record_list",
+        fields=[
+            ExtractionFieldSpec("section_title", "string", "Heading text", required=True),
+            ExtractionFieldSpec("summary", "string", "Section summary"),
+        ],
+        grounding_policy=GroundingPolicy(require_quote=True, include_char_offsets=True),
+        identifier_fields=["section_title"],
+        merge_policy=MergePolicy(strategy="by_identifier", allow_partial_updates=True),
+        projection_target=ProjectionTarget(object_kind="document", channel="extraction"),
+        display_fields=["section_title", "summary"],
+    )
+
+    runtime = ExtractionRuntime(extractor=FakeExtractor(), chunk_size=24, overlap=0)
+
+    result = runtime.run_text(
+        profile=profile,
+        text="Architecture chunk one. Architecture chunk two.",
+        source_path=tmp_path / "example.md",
+    )
+
+    assert len(result.records) == 1
+    assert result.records[0].values["section_title"] == "Architecture"
+    assert result.records[0].values["summary"] == "refined summary"
+    assert [span.quote for span in result.records[0].spans] == ["first quote", "second quote"]

--- a/tests/test_extraction_specs.py
+++ b/tests/test_extraction_specs.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+
+def test_extraction_profile_spec_declares_grounded_projection_contract():
+    from openclaw_pipeline.extraction.specs import (
+        ExtractionFieldSpec,
+        ExtractionProfileSpec,
+        GroundingPolicy,
+        MergePolicy,
+        ProjectionTarget,
+    )
+
+    profile = ExtractionProfileSpec(
+        name="tech/doc_structure",
+        pack="default-knowledge",
+        input_object_kinds=["document"],
+        output_mode="record_list",
+        fields=[
+            ExtractionFieldSpec(name="section_title", field_type="string", description="Heading text"),
+            ExtractionFieldSpec(name="section_kind", field_type="string", description="Section category"),
+        ],
+        relations=[],
+        grounding_policy=GroundingPolicy(require_quote=True, include_char_offsets=True),
+        identifier_fields=["section_title"],
+        merge_policy=MergePolicy(strategy="by_identifier", allow_partial_updates=True),
+        projection_target=ProjectionTarget(object_kind="document", channel="extraction"),
+        display_fields=["section_title", "section_kind"],
+        notes="Inspired by technical document structure extraction",
+    )
+
+    assert profile.name == "tech/doc_structure"
+    assert profile.grounding_policy.require_quote is True
+    assert profile.merge_policy.strategy == "by_identifier"
+    assert profile.projection_target.channel == "extraction"
+    assert [field.name for field in profile.fields] == ["section_title", "section_kind"]

--- a/tests/test_lint_operation_profiles.py
+++ b/tests/test_lint_operation_profiles.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+
+def test_lint_issue_can_be_mapped_to_operation_proposal():
+    from openclaw_pipeline.lint_checker import LintIssue, issue_to_operation_proposal
+
+    proposal = issue_to_operation_proposal(
+        LintIssue(
+            layer="L2",
+            level="warning",
+            type="frontmatter-missing-title",
+            file="10-Knowledge/Evergreen/Example.md",
+            message="Missing title",
+            suggestion="Add a title field",
+            auto_fixable=False,
+        )
+    )
+
+    assert proposal["queue_name"] == "frontmatter"
+    assert proposal["proposal_type"] == "lint_issue"
+    assert proposal["review_required"] is True
+    assert proposal["file"] == "10-Knowledge/Evergreen/Example.md"
+

--- a/tests/test_operation_profiles.py
+++ b/tests/test_operation_profiles.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+
+def test_default_pack_exposes_first_wave_operation_profiles():
+    from openclaw_pipeline.packs.loader import load_default_pack
+
+    pack = load_default_pack()
+    profiles = {profile.name: profile for profile in pack.operation_profiles()}
+
+    assert {
+        "vault/frontmatter_audit",
+        "vault/review_queue",
+        "vault/bridge_recommendations",
+    } <= set(profiles)
+
+    assert profiles["vault/frontmatter_audit"].review_required is True
+    assert profiles["vault/frontmatter_audit"].proposal_types[0].queue_name == "frontmatter"
+    assert profiles["vault/review_queue"].scope == "vault"
+

--- a/tests/test_pack_extension_points.py
+++ b/tests/test_pack_extension_points.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import pytest
+
+
+def test_default_pack_exposes_new_derived_extension_points():
+    from openclaw_pipeline.packs.loader import load_default_pack
+
+    pack = load_default_pack()
+
+    assert pack.extraction_profiles() == []
+    assert pack.operation_profiles() == []
+    assert pack.wiki_views() == []
+
+
+def test_base_pack_lookup_methods_raise_for_unknown_extension_names():
+    from openclaw_pipeline.packs.loader import load_default_pack
+
+    pack = load_default_pack()
+
+    with pytest.raises(ValueError, match="Unknown extraction profile"):
+        pack.extraction_profile("missing")
+
+    with pytest.raises(ValueError, match="Unknown operation profile"):
+        pack.operation_profile("missing")
+
+    with pytest.raises(ValueError, match="Unknown wiki view"):
+        pack.wiki_view("missing")

--- a/tests/test_pack_extension_points.py
+++ b/tests/test_pack_extension_points.py
@@ -9,8 +9,8 @@ def test_default_pack_exposes_new_derived_extension_points():
     pack = load_default_pack()
 
     assert pack.extraction_profiles()
-    assert pack.operation_profiles() == []
-    assert pack.wiki_views() == []
+    assert pack.operation_profiles()
+    assert pack.wiki_views()
 
 
 def test_base_pack_lookup_methods_raise_for_unknown_extension_names():

--- a/tests/test_pack_extension_points.py
+++ b/tests/test_pack_extension_points.py
@@ -8,7 +8,7 @@ def test_default_pack_exposes_new_derived_extension_points():
 
     pack = load_default_pack()
 
-    assert pack.extraction_profiles() == []
+    assert pack.extraction_profiles()
     assert pack.operation_profiles() == []
     assert pack.wiki_views() == []
 

--- a/tests/test_query_to_wiki_traceability.py
+++ b/tests/test_query_to_wiki_traceability.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+
+def test_create_evergreen_writes_source_traceability_to_frontmatter(tmp_path):
+    from openclaw_pipeline.query_to_wiki import create_evergreen
+
+    vault = tmp_path / "vault"
+    (vault / "10-Knowledge" / "Evergreen").mkdir(parents=True, exist_ok=True)
+
+    path, slug = create_evergreen(
+        vault,
+        title="Architecture View",
+        definition="A saved answer",
+        content="Body",
+        sources=["50-Inbox/01-Raw/example.md"],
+    )
+
+    content = path.read_text(encoding="utf-8")
+
+    assert slug == "architecture-view"
+    assert "sources:" in content
+    assert "- \"50-Inbox/01-Raw/example.md\"" in content
+

--- a/tests/test_review_queue_command.py
+++ b/tests/test_review_queue_command.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+
+
+def test_run_operations_command_writes_frontmatter_review_items(temp_vault):
+    from openclaw_pipeline.commands.run_operations import main
+    from openclaw_pipeline.runtime import VaultLayout
+
+    note = temp_vault / "10-Knowledge" / "Evergreen" / "Broken.md"
+    note.parent.mkdir(parents=True, exist_ok=True)
+    note.write_text(
+        """---
+note_id: broken
+type: evergreen
+date: 2026-04-10
+---
+
+# Broken
+""",
+        encoding="utf-8",
+    )
+
+    result = main(
+        [
+            "--vault-dir",
+            str(temp_vault),
+            "--pack",
+            "default-knowledge",
+            "--profile",
+            "vault/frontmatter_audit",
+        ]
+    )
+
+    layout = VaultLayout.from_vault(temp_vault)
+    artifacts = sorted(layout.review_queue_dir.rglob("*.json"))
+
+    assert result == 0
+    assert artifacts
+    payload = json.loads(artifacts[0].read_text(encoding="utf-8"))
+    assert payload["queue_name"] == "frontmatter"
+    assert payload["issue_type"] == "missing-title"

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -30,6 +30,11 @@ def test_vault_layout_uses_resolved_vault_dir(tmp_path):
     assert layout.pipeline_log == (tmp_path / "vault" / "60-Logs" / "pipeline.jsonl").resolve()
     assert layout.knowledge_db == (tmp_path / "vault" / "60-Logs" / "knowledge.db").resolve()
     assert layout.transactions_dir == (tmp_path / "vault" / "60-Logs" / "transactions").resolve()
+    assert layout.derived_dir == (tmp_path / "vault" / "60-Logs" / "derived").resolve()
+    assert layout.extraction_runs_dir == (tmp_path / "vault" / "60-Logs" / "derived" / "extraction-runs").resolve()
+    assert layout.review_queue_dir == (tmp_path / "vault" / "60-Logs" / "derived" / "review-queue").resolve()
+    assert layout.compiled_views_dir == (tmp_path / "vault" / "60-Logs" / "derived" / "compiled-views").resolve()
+    assert layout.processing_dir == (tmp_path / "vault" / "50-Inbox" / "02-Processing").resolve()
     assert layout.classification_output_dir("tools").parts[-3:-1] == ("Tools", "Topics")
     assert layout.papers_dir == (tmp_path / "vault" / "20-Areas" / "AI-Research" / "Papers").resolve()
 

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -7,7 +7,13 @@ import pytest
 
 from openclaw_pipeline.auto_github_processor import build_default_output_dir as github_output_dir
 from openclaw_pipeline.auto_paper_processor import build_default_output_dir as paper_output_dir
-from openclaw_pipeline.runtime import VaultLayout, iter_markdown_files, resolve_vault_dir
+from openclaw_pipeline.runtime import (
+    VaultLayout,
+    iter_markdown_files,
+    markdown_title,
+    read_markdown_frontmatter,
+    resolve_vault_dir,
+)
 from openclaw_pipeline.unified_pipeline_enhanced import EnhancedPipeline, build_execution_plan
 
 
@@ -37,6 +43,7 @@ def test_vault_layout_uses_resolved_vault_dir(tmp_path):
     assert layout.processing_dir == (tmp_path / "vault" / "50-Inbox" / "02-Processing").resolve()
     assert layout.classification_output_dir("tools").parts[-3:-1] == ("Tools", "Topics")
     assert layout.papers_dir == (tmp_path / "vault" / "20-Areas" / "AI-Research" / "Papers").resolve()
+    assert layout.queries_dir == (tmp_path / "vault" / "20-Areas" / "Queries").resolve()
 
 
 def test_specialized_processors_derive_default_outputs_from_vault(tmp_path):
@@ -191,3 +198,22 @@ def test_iter_markdown_files_does_not_drop_parent_relative_paths(tmp_path, monke
 
     assert len(files) == 1
     assert files[0].name == "Example.md"
+
+
+def test_markdown_helpers_read_frontmatter_and_title(tmp_path):
+    note = tmp_path / "Example.md"
+    note.write_text(
+        """---
+title: Runtime Helpers
+type: evergreen
+---
+
+# Runtime Helpers
+""",
+        encoding="utf-8",
+    )
+
+    metadata = read_markdown_frontmatter(note)
+
+    assert metadata["title"] == "Runtime Helpers"
+    assert markdown_title(note) == "Runtime Helpers"

--- a/tests/test_wiki_view_specs.py
+++ b/tests/test_wiki_view_specs.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+
+def test_default_pack_exposes_first_wave_wiki_views():
+    from openclaw_pipeline.packs.loader import load_default_pack
+
+    pack = load_default_pack()
+    views = {view.name: view for view in pack.wiki_views()}
+
+    assert {
+        "overview/domain",
+        "overview/topic",
+        "saved_answer/query",
+    } <= set(views)
+
+    assert views["overview/domain"].traceability_policy.include_sources is True
+    assert views["saved_answer/query"].publish_target == "compiled_markdown"
+


### PR DESCRIPTION
## Summary
- add derived artifact foundations and pack extension points
- add extraction profile specs, default profiles, runtime, evidence hooks, discovery projection, and CLI
- add knowledge operations, review queue runtime, compiled wiki views, and query-to-wiki traceability
- restore the vault processing directory path contract after rebasing onto latest `main`

## Verification
- `/tmp/openclaw-knowledge-venv/bin/pytest -q`

## Notes
- this PR intentionally reimplements ideas from external research projects inside OpenClaw-native contracts
- no external extraction or wiki framework was added as a runtime dependency
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/2" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Three CLI commands: extraction, operations (review queue), and build-views for compiling wiki views.
  * Extraction pipeline with default profiles and runtime for chunking/merging; operations for frontmatter audits and review-item generation.
  * Discovery/evidence now can include extraction-derived results; compiled wiki views and derived artifact paths supported; markdown frontmatter/title helpers added.

* **Chores**
  * Updated ignore patterns to exclude local worktree and supervisor dirs.

* **Tests**
  * Extensive new test coverage for extraction, operations, wiki views, paths, and runtimes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->