### PR TITLE
test: harden internal pack e2e coverage

### DIFF
--- a/docs/plans/2026-04-11-phase5-internal-pack-e2e-hardening.md
+++ b/docs/plans/2026-04-11-phase5-internal-pack-e2e-hardening.md
@@ -1,0 +1,168 @@
+# Phase 5: Internal Pack E2E Hardening
+
+## Why This Phase Exists
+
+Phase 4 finished the internal pack split:
+
+- `research-tech` is the primary built-in pack
+- `default-knowledge` is the compatibility pack
+- workflow / query / review / materialize / docs are pack-aware
+
+What is still missing is stronger runtime confidence.
+
+The current repo had broad unit/integration coverage, but it did not yet have a
+single pack-level end-to-end test that proves the internal pack loop actually
+works as one coherent runtime.
+
+That gap matters more than any external pack work.
+
+## Goal
+
+Before validating any external pack, prove that the internal pack runtime is
+stable end-to-end.
+
+The target is not “more tests” in the abstract. The target is:
+
+- `research-tech` can run a realistic pack loop end-to-end
+- `default-knowledge` still works as a compatibility layer
+- core pack contracts can be changed without silently breaking derived surfaces
+
+## Scope
+
+### 1. Add Pack-Level E2E Coverage
+
+Introduce explicit tests that run a small but real pack lifecycle:
+
+- extraction
+- extraction preview/dashboard
+- truth/index rebuild
+- materialized views
+- review queue generation
+- maintenance loop
+- query surface
+
+The first version should cover:
+
+- `research-tech`
+- `default-knowledge` compatibility regression
+
+### 2. Keep Broad Regression Green
+
+Pack e2e tests should run alongside the existing broad suite:
+
+- `PYTHONPATH=src python3.13 -m pytest -q --ignore=tests/test_autopilot_contracts.py`
+
+The current `watchdog` environment issue is still out of scope for this slice.
+
+### 3. Defer External Pack Work
+
+Explicitly do **not** start media/medical/external pack validation until this
+internal e2e line is in place and stable.
+
+## Done In Slice 1
+
+Added `tests/test_pack_e2e.py` with two pack-level tests:
+
+1. `research-tech` end-to-end runtime
+   - extract
+   - preview/dashboard
+   - knowledge index / truth store
+   - object/topic/event/contradiction materializers
+   - contradiction/stale-summary review queues
+   - contradiction resolution + summary rebuild
+   - knowledge query surface
+
+2. `default-knowledge` compatibility regression
+   - extract
+   - preview/dashboard
+   - object/materialized view
+   - review queue
+
+## Done In Slice 2
+
+Added `tests/test_pack_runtime_e2e.py` to validate orchestrated runtime behavior:
+
+1. `research-tech/full` runtime orchestration
+   - real pack profile stages are used as the execution sequence
+   - `quality -> absorb` file-level gating is passed through the pipeline
+   - the runtime completes the full ordered chain for the primary pack
+
+2. `default-knowledge/full` compatibility orchestration
+   - compatibility pack still slices and resumes correctly
+   - `quality -> absorb` propagation still works under the compatibility path
+
+## Verification
+
+Focused:
+
+```bash
+PYTHONPATH=src python3.13 -m pytest -q tests/test_pack_e2e.py
+PYTHONPATH=src python3.13 -m pytest -q tests/test_pack_runtime_e2e.py tests/test_pack_e2e.py
+PYTHONPATH=src python3.13 -m pytest -q \
+  tests/test_runtime_paths.py \
+  tests/test_pack_runtime_e2e.py \
+  tests/test_pack_e2e.py \
+  tests/test_default_pack_compat.py \
+  tests/test_query_tool.py \
+  tests/test_build_views_command.py \
+  tests/test_review_queue_command.py \
+  tests/test_truth_store.py \
+  tests/test_knowledge_index.py
+```
+
+Broad:
+
+```bash
+PYTHONPATH=src python3.13 -m pytest -q --ignore=tests/test_autopilot_contracts.py
+```
+
+Compile:
+
+```bash
+python3.13 -m compileall src/openclaw_pipeline
+```
+
+Autopilot environment recovery:
+
+```bash
+PYTHONPATH=src python3.13 -m pytest -q tests/test_autopilot_contracts.py
+PYTHONPATH=src python3.13 -m pytest -q
+```
+
+## Milestone Status
+
+- Phase 1 `Make Extraction Visible`: complete
+- Phase 2 `Add Truth Store`: complete
+- Phase 3 `Materialize + Review`: complete
+- Phase 4 `Split Domain Packs`: complete
+- Phase 5 `Internal Pack E2E Hardening`: started
+
+This phase now has two solid slices:
+
+- command-surface pack e2e
+- orchestrated runtime pack e2e
+
+That is enough to say the phase is materially underway, and the most important
+runtime/testing gap is now closed:
+
+- pack-level command/runtime e2e exists
+- `autopilot` no longer breaks test collection when `watchdog` is absent
+- the default `python3.13` full test run now passes
+
+## What Still Remains In Phase 5
+
+1. Add pack-level regression checks for future default-pack switching, if that
+   decision is revisited later.
+2. Optionally add a higher-fidelity subprocess-backed e2e for `ovp --pack research-tech --profile full`
+   if the command-runtime contract becomes more complex than the current in-process orchestration tests.
+
+## Commit / PR Boundary
+
+This is now a good **commit** boundary and a good **PR** boundary.
+
+The original Phase 5 blocker was internal pack confidence. That blocker is now
+substantially addressed:
+
+- internal pack command/runtime e2e exists
+- compatibility pack regression exists
+- full `python3.13` pytest is green again

--- a/src/openclaw_pipeline/autopilot/daemon.py
+++ b/src/openclaw_pipeline/autopilot/daemon.py
@@ -187,7 +187,7 @@ class AutoPilotDaemon:
 
         # 组件初始化
         self.queue = TaskQueue(self.vault_dir / "60-Logs" / "autopilot.db")
-        self.watcher: Optional[PollingWatcher] = None
+        self.watcher: Optional[MultiSourceWatcher] = None
         self.executor: Optional[ThreadPoolExecutor] = None
 
         # 质量检查器

--- a/src/openclaw_pipeline/autopilot/watcher.py
+++ b/src/openclaw_pipeline/autopilot/watcher.py
@@ -9,9 +9,19 @@
 
 import time
 from pathlib import Path
-from typing import Callable, List, Set, Optional, Dict
-from watchdog.observers import Observer
-from watchdog.events import FileSystemEventHandler, FileCreatedEvent, FileModifiedEvent
+from typing import Any, Callable, Dict, List, Optional, Set
+
+try:  # pragma: no cover - exercised via import contract tests
+    from watchdog.events import FileSystemEventHandler
+    from watchdog.observers import Observer
+    WATCHDOG_AVAILABLE = True
+except ModuleNotFoundError:  # pragma: no cover - environment-dependent
+    WATCHDOG_AVAILABLE = False
+
+    class FileSystemEventHandler:  # type: ignore[override]
+        pass
+
+    Observer = None  # type: ignore[assignment]
 
 
 class VaultEventHandler(FileSystemEventHandler):
@@ -33,13 +43,13 @@ class VaultEventHandler(FileSystemEventHandler):
                 return source
         return None
 
-    def on_created(self, event):
+    def on_created(self, event: Any):
         if not event.is_directory and event.src_path.endswith('.md'):
             source = self._get_source(event.src_path)
             if source:
                 self.callback(source, event.src_path)
 
-    def on_modified(self, event):
+    def on_modified(self, event: Any):
         pass
 
 
@@ -118,6 +128,11 @@ class MultiSourceWatcher:
         """启动实时监控（使用 watchdog）"""
         if self.observer:
             return  # 已启动
+        if not WATCHDOG_AVAILABLE:
+            raise RuntimeError(
+                "watchdog is required for realtime autopilot watching; "
+                "install watchdog or use polling mode"
+            )
 
         handler = VaultEventHandler(self.source_map, self.callback)
         self.observer = Observer()

--- a/tests/test_autopilot_contracts.py
+++ b/tests/test_autopilot_contracts.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from openclaw_pipeline.autopilot.queue import Task, TaskQueue
 from openclaw_pipeline.autopilot.daemon import AutoPilotDaemon
 from openclaw_pipeline.commands.repair import repair_autopilot
+from openclaw_pipeline.autopilot.watcher import MultiSourceWatcher, WATCHDOG_AVAILABLE
 
 
 def test_task_queue_deduplicates_active_file_tasks(tmp_path):
@@ -128,3 +129,28 @@ def test_autopilot_with_refine_runs_refine_before_knowledge_index(tmp_path, monk
     assert result["success"] is True
     assert result["stages"] == ["interpretation", "absorb", "moc", "refine", "knowledge_index"]
     assert order == ["absorb", "moc", "refine", "knowledge_index"]
+
+
+def test_autopilot_watcher_import_does_not_require_watchdog(tmp_path):
+    watcher = MultiSourceWatcher({"inbox": tmp_path}, lambda source, path: None)
+
+    assert watcher.source_map["inbox"] == tmp_path
+    assert watcher.observer is None
+
+
+def test_autopilot_realtime_watcher_behaves_cleanly_without_watchdog(tmp_path):
+    watcher = MultiSourceWatcher({"inbox": tmp_path}, lambda source, path: None)
+
+    if WATCHDOG_AVAILABLE:
+        watcher.start_realtime()
+        assert watcher.running is True
+        watcher.stop_realtime()
+        assert watcher.observer is None
+        return
+
+    try:
+        watcher.start_realtime()
+    except RuntimeError as exc:
+        assert "watchdog" in str(exc)
+    else:
+        raise AssertionError("expected realtime watcher to require watchdog")

--- a/tests/test_pack_e2e.py
+++ b/tests/test_pack_e2e.py
@@ -1,0 +1,422 @@
+from __future__ import annotations
+
+import json
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+
+
+def _capture_json(main_fn, argv: list[str]) -> dict[str, object]:
+    buffer = StringIO()
+    with redirect_stdout(buffer):
+        result = main_fn(argv)
+    assert result == 0
+    return json.loads(buffer.getvalue())
+
+
+def _write_note(path: Path, content: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _seed_truth_notes(vault: Path) -> None:
+    evergreen_dir = vault / "10-Knowledge" / "Evergreen"
+    _write_note(
+        evergreen_dir / "Harness-Positive.md",
+        """---
+note_id: harness-positive
+title: Harness Positive
+type: evergreen
+date: 2026-04-10
+---
+
+# Harness Positive
+
+Agent harness supports local-first execution for operators.
+
+Links to [[runtime-target]].
+""",
+    )
+    _write_note(
+        evergreen_dir / "Harness-Negative.md",
+        """---
+note_id: harness-negative
+title: Harness Negative
+type: evergreen
+date: 2026-04-10
+---
+
+# Harness Negative
+
+Agent harness does not support local-first execution for operators.
+""",
+    )
+    _write_note(
+        evergreen_dir / "Runtime-Target.md",
+        """---
+note_id: runtime-target
+title: Runtime Target
+type: evergreen
+date: 2026-04-10
+---
+
+# Runtime Target
+
+Runtime target captures downstream execution effects.
+""",
+    )
+    _write_note(
+        evergreen_dir / "Thin-Summary.md",
+        """---
+note_id: thin-summary
+title: Thin Summary
+type: evergreen
+date: 2026-04-10
+---
+
+# Thin Summary
+
+Tiny note.
+""",
+    )
+
+
+def _seed_raw_source(vault: Path, *, name: str = "runtime-graph.md") -> Path:
+    return _write_note(
+        vault / "50-Inbox" / "01-Raw" / name,
+        """---
+title: Runtime Graph
+type: raw
+date: 2026-04-10
+---
+
+# Runtime Graph
+
+## Architecture
+
+The runtime architecture coordinates [[harness-positive]] and [[runtime-target]].
+
+## Workflow
+
+- Load source material
+- Build derived truth artifacts
+- Materialize knowledge surfaces
+""",
+    )
+
+
+def test_research_tech_pack_e2e_runtime(temp_vault):
+    from openclaw_pipeline.commands.build_views import main as build_views_main
+    from openclaw_pipeline.commands.extract_preview import main as extract_preview_main
+    from openclaw_pipeline.commands.extract_profiles import main as extract_main
+    from openclaw_pipeline.commands.extraction_dashboard import main as dashboard_main
+    from openclaw_pipeline.commands.rebuild_summaries import main as rebuild_summaries_main
+    from openclaw_pipeline.commands.resolve_contradictions import main as resolve_contradictions_main
+    from openclaw_pipeline.commands.run_operations import main as run_operations_main
+    from openclaw_pipeline.knowledge_index import knowledge_index_stats, rebuild_knowledge_index, search_truth_store
+    from openclaw_pipeline.query_tool import VaultQuerier
+    from openclaw_pipeline.runtime import VaultLayout
+
+    _seed_truth_notes(temp_vault)
+    source = _seed_raw_source(temp_vault)
+    layout = VaultLayout.from_vault(temp_vault)
+
+    extract_payload = _capture_json(
+        extract_main,
+        [
+            "--vault-dir",
+            str(temp_vault),
+            "--pack",
+            "research-tech",
+            "--profile",
+            "tech/workflow_graph",
+            "--source",
+            str(source),
+        ],
+    )
+    artifact_path = Path(str(extract_payload["artifact_path"]))
+    assert artifact_path.exists()
+
+    preview_payload = _capture_json(
+        extract_preview_main,
+        [
+            "--vault-dir",
+            str(temp_vault),
+            "--pack",
+            "research-tech",
+            "--profile",
+            "tech/workflow_graph",
+            "--source",
+            str(source),
+        ],
+    )
+    assert preview_payload["pack"] == "research-tech"
+    assert preview_payload["run_count"] == 1
+    assert preview_payload["record_count"] >= 3
+
+    dashboard_payload = _capture_json(
+        dashboard_main,
+        ["--vault-dir", str(temp_vault), "--pack", "research-tech"],
+    )
+    assert dashboard_payload["pack"] == "research-tech"
+    assert dashboard_payload["total_runs"] == 1
+    assert "tech/workflow_graph" in dashboard_payload["profiles"]
+
+    rebuild_knowledge_index(temp_vault)
+    stats = knowledge_index_stats(temp_vault)
+    assert stats["objects"] == 4
+    assert stats["relations"] == 1
+    assert stats["contradictions"] == 1
+
+    extract_view_payload = _capture_json(
+        build_views_main,
+        [
+            "--vault-dir",
+            str(temp_vault),
+            "--pack",
+            "research-tech",
+            "--view",
+            "overview/extraction",
+        ],
+    )
+    object_view_payload = _capture_json(
+        build_views_main,
+        [
+            "--vault-dir",
+            str(temp_vault),
+            "--pack",
+            "research-tech",
+            "--view",
+            "object/page",
+            "--object-id",
+            "harness-positive",
+        ],
+    )
+    topic_view_payload = _capture_json(
+        build_views_main,
+        [
+            "--vault-dir",
+            str(temp_vault),
+            "--pack",
+            "research-tech",
+            "--view",
+            "overview/topic",
+        ],
+    )
+    event_view_payload = _capture_json(
+        build_views_main,
+        [
+            "--vault-dir",
+            str(temp_vault),
+            "--pack",
+            "research-tech",
+            "--view",
+            "event/dossier",
+        ],
+    )
+    contradiction_view_payload = _capture_json(
+        build_views_main,
+        [
+            "--vault-dir",
+            str(temp_vault),
+            "--pack",
+            "research-tech",
+            "--view",
+            "truth/contradictions",
+        ],
+    )
+
+    assert Path(str(extract_view_payload["output_path"])).exists()
+    object_view = Path(str(object_view_payload["output_path"]))
+    assert object_view.exists()
+    assert "Contradictions" in object_view.read_text(encoding="utf-8")
+    assert Path(str(topic_view_payload["output_path"])).exists()
+    assert Path(str(event_view_payload["output_path"])).exists()
+    contradiction_view = Path(str(contradiction_view_payload["output_path"]))
+    assert contradiction_view.exists()
+    assert "agent harness" in contradiction_view.read_text(encoding="utf-8")
+
+    contradiction_queue = _capture_json(
+        run_operations_main,
+        [
+            "--vault-dir",
+            str(temp_vault),
+            "--pack",
+            "research-tech",
+            "--profile",
+            "truth/contradiction_review",
+        ],
+    )
+    stale_queue = _capture_json(
+        run_operations_main,
+        [
+            "--vault-dir",
+            str(temp_vault),
+            "--pack",
+            "research-tech",
+            "--profile",
+            "truth/stale_summary_review",
+        ],
+    )
+
+    assert contradiction_queue["written"]
+    assert stale_queue["written"]
+    contradiction_artifact = Path(str(contradiction_queue["written"][0]))
+    stale_artifact = Path(str(stale_queue["written"][0]))
+    assert contradiction_artifact.exists()
+    assert stale_artifact.exists()
+    assert contradiction_artifact.parent == layout.review_queue_dir / "contradictions"
+    assert stale_artifact.parent == layout.review_queue_dir / "stale-summaries"
+
+    resolve_payload = _capture_json(
+        resolve_contradictions_main,
+        [
+            "--vault-dir",
+            str(temp_vault),
+            "--from-queue",
+            "contradictions",
+            "--status",
+            "resolved_keep_positive",
+            "--note",
+            "Keep positive research-tech claim.",
+            "--rebuild-summaries",
+            "--json",
+        ],
+    )
+    assert resolve_payload["resolved_count"] == 1
+    assert resolve_payload["rebuilt_summary_count"] >= 2
+    assert resolve_payload["cleared_queue_files"]
+    assert not contradiction_artifact.exists()
+
+    rebuilt_object_view_payload = _capture_json(
+        build_views_main,
+        [
+            "--vault-dir",
+            str(temp_vault),
+            "--pack",
+            "research-tech",
+            "--view",
+            "object/page",
+            "--object-id",
+            "harness-positive",
+        ],
+    )
+    rebuilt_object_view = Path(str(rebuilt_object_view_payload["output_path"]))
+    rebuilt_object_content = rebuilt_object_view.read_text(encoding="utf-8")
+    assert "[resolved_keep_positive]" in rebuilt_object_content
+    assert "Keep positive research-tech claim." in rebuilt_object_content
+
+    stale_rebuild_payload = _capture_json(
+        rebuild_summaries_main,
+        [
+            "--vault-dir",
+            str(temp_vault),
+            "--from-queue",
+            "stale-summaries",
+            "--json",
+        ],
+    )
+    assert stale_rebuild_payload["objects_rebuilt"] >= 1
+    assert "thin-summary" in stale_rebuild_payload["object_ids"]
+
+    truth_hits = search_truth_store(temp_vault, "local-first", limit=5)
+    assert any(hit["object_id"] == "harness-positive" for hit in truth_hits)
+
+    results = VaultQuerier(temp_vault, pack="research-tech").search("runtime architecture", top_k=5, engine="knowledge")
+    assert results
+    assert any(result.title in {"Harness Positive", "Runtime Target"} for result in results)
+
+
+def test_default_knowledge_pack_e2e_compatibility(temp_vault):
+    from openclaw_pipeline.commands.build_views import main as build_views_main
+    from openclaw_pipeline.commands.extract_preview import main as extract_preview_main
+    from openclaw_pipeline.commands.extract_profiles import main as extract_main
+    from openclaw_pipeline.commands.extraction_dashboard import main as dashboard_main
+    from openclaw_pipeline.commands.run_operations import main as run_operations_main
+    from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
+    from openclaw_pipeline.runtime import VaultLayout
+
+    _seed_truth_notes(temp_vault)
+    source = _seed_raw_source(temp_vault, name="compat-graph.md")
+    layout = VaultLayout.from_vault(temp_vault)
+
+    extract_payload = _capture_json(
+        extract_main,
+        [
+            "--vault-dir",
+            str(temp_vault),
+            "--pack",
+            "default-knowledge",
+            "--profile",
+            "tech/doc_structure",
+            "--source",
+            str(source),
+        ],
+    )
+    assert Path(str(extract_payload["artifact_path"])).exists()
+
+    preview_payload = _capture_json(
+        extract_preview_main,
+        [
+            "--vault-dir",
+            str(temp_vault),
+            "--pack",
+            "default-knowledge",
+            "--profile",
+            "tech/doc_structure",
+            "--source",
+            str(source),
+        ],
+    )
+    dashboard_payload = _capture_json(
+        dashboard_main,
+        ["--vault-dir", str(temp_vault), "--pack", "default-knowledge"],
+    )
+    assert preview_payload["pack"] == "default-knowledge"
+    assert dashboard_payload["pack"] == "default-knowledge"
+
+    rebuild_knowledge_index(temp_vault)
+
+    extract_view_payload = _capture_json(
+        build_views_main,
+        [
+            "--vault-dir",
+            str(temp_vault),
+            "--pack",
+            "default-knowledge",
+            "--view",
+            "overview/extraction",
+        ],
+    )
+    object_view_payload = _capture_json(
+        build_views_main,
+        [
+            "--vault-dir",
+            str(temp_vault),
+            "--pack",
+            "default-knowledge",
+            "--view",
+            "object/page",
+            "--object-id",
+            "harness-positive",
+        ],
+    )
+    queue_payload = _capture_json(
+        run_operations_main,
+        [
+            "--vault-dir",
+            str(temp_vault),
+            "--pack",
+            "default-knowledge",
+            "--profile",
+            "vault/review_queue",
+        ],
+    )
+
+    assert Path(str(extract_view_payload["output_path"])).exists()
+    assert Path(str(object_view_payload["output_path"])).exists()
+    assert queue_payload["written"]
+    assert Path(str(queue_payload["written"][0])).exists()
+    assert (layout.compiled_views_dir / "default-knowledge").exists()
+    assert (layout.extraction_runs_dir / "default-knowledge").exists()

--- a/tests/test_pack_runtime_e2e.py
+++ b/tests/test_pack_runtime_e2e.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _make_pipeline(tmp_path: Path):
+    from openclaw_pipeline.unified_pipeline_enhanced import EnhancedPipeline, PipelineLogger, TransactionManager
+
+    vault = tmp_path / "vault"
+    (vault / "60-Logs").mkdir(parents=True, exist_ok=True)
+    logger = PipelineLogger(vault / "60-Logs" / "pipeline.jsonl")
+    txn = TransactionManager(vault / "60-Logs" / "transactions")
+    pipeline = EnhancedPipeline(vault, logger, txn)
+    pipeline.txn_id = txn.start("test-pipeline", "pack runtime e2e")
+    return vault, pipeline
+
+
+def _bind_success_step(pipeline, step_name: str, calls: list[str], **payload):
+    def _step(*args, **kwargs):
+        calls.append(step_name)
+        result = {"success": True}
+        result.update(payload)
+        return result
+
+    setattr(pipeline, f"step_{step_name}", _step)
+
+
+def test_research_tech_full_profile_runtime_e2e(tmp_path):
+    from openclaw_pipeline.packs.loader import load_pack
+
+    _vault, pipeline = _make_pipeline(tmp_path)
+    calls: list[str] = []
+    captured_absorb: dict[str, object] = {}
+
+    _bind_success_step(pipeline, "pinboard", calls)
+    _bind_success_step(pipeline, "pinboard_process", calls)
+    _bind_success_step(pipeline, "clippings", calls)
+    _bind_success_step(pipeline, "articles", calls)
+    _bind_success_step(
+        pipeline,
+        "quality",
+        calls,
+        quality_score=4.25,
+        quality_checked=3,
+        quality_qualified=2,
+        quality_qualified_files=["/tmp/qualified-a.md", "/tmp/qualified-b.md"],
+    )
+    _bind_success_step(pipeline, "fix_links", calls)
+
+    def fake_absorb(recent_days=7, dry_run=False, quality_score=-1.0, qualified_files=None, batch_size=None):
+        calls.append("absorb")
+        captured_absorb["recent_days"] = recent_days
+        captured_absorb["dry_run"] = dry_run
+        captured_absorb["quality_score"] = quality_score
+        captured_absorb["qualified_files"] = list(qualified_files or [])
+        captured_absorb["batch_size"] = batch_size
+        return {"success": True, "produced": 2}
+
+    pipeline.step_absorb = fake_absorb
+    _bind_success_step(pipeline, "registry_sync", calls)
+    _bind_success_step(pipeline, "moc", calls)
+    _bind_success_step(pipeline, "knowledge_index", calls)
+
+    steps = load_pack("research-tech").profile("full").stages
+    results = pipeline.run_pipeline(steps=steps, batch_size=25, dry_run=False)
+
+    assert list(results) == steps
+    assert calls == steps
+    assert all(result["success"] is True for result in results.values())
+    assert captured_absorb == {
+        "recent_days": 7,
+        "dry_run": False,
+        "quality_score": 4.25,
+        "qualified_files": ["/tmp/qualified-a.md", "/tmp/qualified-b.md"],
+        "batch_size": 25,
+    }
+
+
+def test_default_knowledge_compatibility_runtime_from_step_e2e(tmp_path):
+    from openclaw_pipeline.packs.loader import load_pack
+
+    _vault, pipeline = _make_pipeline(tmp_path)
+    calls: list[str] = []
+    captured_absorb: dict[str, object] = {}
+
+    _bind_success_step(
+        pipeline,
+        "quality",
+        calls,
+        quality_score=3.5,
+        quality_checked=2,
+        quality_qualified=1,
+        quality_qualified_files=["/tmp/compat-qualified.md"],
+    )
+    _bind_success_step(pipeline, "fix_links", calls)
+
+    def fake_absorb(recent_days=7, dry_run=False, quality_score=-1.0, qualified_files=None, batch_size=None):
+        calls.append("absorb")
+        captured_absorb["quality_score"] = quality_score
+        captured_absorb["qualified_files"] = list(qualified_files or [])
+        return {"success": True, "produced": 1}
+
+    pipeline.step_absorb = fake_absorb
+    _bind_success_step(pipeline, "registry_sync", calls)
+    _bind_success_step(pipeline, "moc", calls)
+    _bind_success_step(pipeline, "knowledge_index", calls)
+
+    full_steps = load_pack("default-knowledge").profile("full").stages
+    sliced_steps = full_steps[full_steps.index("quality") :]
+    results = pipeline.run_pipeline(steps=sliced_steps, batch_size=10, dry_run=False)
+
+    assert list(results) == sliced_steps
+    assert calls == sliced_steps
+    assert captured_absorb["quality_score"] == 3.5
+    assert captured_absorb["qualified_files"] == ["/tmp/compat-qualified.md"]


### PR DESCRIPTION
## Summary
- add pack-level e2e coverage for `research-tech` and `default-knowledge`
- add runtime orchestration e2e coverage for pack-aware full-profile execution
- make `autopilot` import/test contracts work without a hard `watchdog` dependency at collection time
- record Phase 5 internal pack hardening status in repo docs

## Why
Phase 4 proved the internal pack split. The next risk was runtime confidence: there was broad unit/integration coverage, but no true pack-level e2e, and `tests/test_autopilot_contracts.py` was still excluded from the default Python 3.13 run because `watchdog` was imported too early.

This PR closes that gap before any external pack work.

## Verification
- `PYTHONPATH=src python3.13 -m pytest -q tests/test_autopilot_contracts.py tests/test_pack_e2e.py tests/test_pack_runtime_e2e.py`
- `PYTHONPATH=src python3.13 -m pytest -q`
- `python3.13 -m compileall src/openclaw_pipeline`
