### PR TITLE
feat: operationalize research-tech pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ pack 负责领域语义，而不是只放几段 prompt。它定义：
 
 当前内置的是：
 
-- `research-tech`：当前技术研究知识流的显式 pack
-- `default-knowledge`：默认兼容层
+- `research-tech`：当前技术研究知识流的显式 pack，也是默认 workflow pack
+- `default-knowledge`：兼容层
 
 未来媒体、医疗这类领域，应该各自作为外部 pack 工程接入。
 
@@ -138,7 +138,14 @@ profile 是某个 pack 下的一条可执行 DAG。
 - `default-knowledge/full`
 - `default-knowledge/autopilot`
 
-这也是为什么现在可以显式运行：
+这也是为什么现在默认就会跑：
+
+```bash
+ovp --full
+ovp-autopilot --yes
+```
+
+也可以显式指定：
 
 ```bash
 ovp --pack research-tech --profile full

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Ingest → Interpret → Absorb → Refine → Canonical → Derived
 
 ```bash
 ovp-packs
+ovp-doctor --pack research-tech --json
 ovp --pack research-tech --profile full
 ovp-autopilot --pack research-tech --profile autopilot --yes
 ovp --pack default-knowledge --profile full
@@ -137,6 +138,29 @@ profile 是某个 pack 下的一条可执行 DAG。
 - `research-tech/autopilot`
 - `default-knowledge/full`
 - `default-knowledge/autopilot`
+
+## 研究技术 Pack 的运营面
+
+`research-tech` 现在不只是一个内部 pack，也已经有最小运营面：
+
+- `ovp-doctor`
+  检查默认 workflow pack、pack 角色、operator docs、recipes，以及可选的 vault 健康状态
+- `ovp-export`
+  导出最小 compiled artifacts：
+  - `object-page`
+  - `topic-overview`
+  - `event-dossier`
+  - `contradictions`
+- `docs/research-tech/RESEARCH_TECH_SKILLPACK.md`
+- `docs/research-tech/RESEARCH_TECH_VERIFY.md`
+- `docs/recipes/research-tech/*.md`
+
+示例：
+
+```bash
+ovp-doctor --pack research-tech --json
+ovp-export --pack research-tech --target topic-overview --output-path /tmp/topic.md
+```
 
 这也是为什么现在默认就会跑：
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -124,8 +124,8 @@ A pack is not just a prompt bundle. It defines domain semantics:
 
 The built-in packs are:
 
-- `research-tech`: the explicit technical research pack
-- `default-knowledge`: the default compatibility layer
+- `research-tech`: the explicit technical research pack and the default workflow pack
+- `default-knowledge`: the compatibility layer
 
 Future domains such as media or medical should arrive as external pack projects.
 
@@ -140,7 +140,14 @@ The built-in profiles currently shipped are:
 - `default-knowledge/full`
 - `default-knowledge/autopilot`
 
-That is why these are now first-class runtime invocations:
+That is why the default workflow path now runs:
+
+```bash
+ovp --full
+ovp-autopilot --yes
+```
+
+You can still select packs explicitly:
 
 ```bash
 ovp --pack research-tech --profile full

--- a/README_EN.md
+++ b/README_EN.md
@@ -79,6 +79,7 @@ Examples:
 
 ```bash
 ovp-packs
+ovp-doctor --pack research-tech --json
 ovp --pack research-tech --profile full
 ovp-autopilot --pack research-tech --profile autopilot --yes
 ovp --pack default-knowledge --profile full
@@ -138,6 +139,29 @@ The built-in profiles currently shipped are:
 - `research-tech/full`
 - `research-tech/autopilot`
 - `default-knowledge/full`
+
+## Research-Tech Operational Surface
+
+`research-tech` is no longer only an internal pack. It now has a minimal operational surface:
+
+- `ovp-doctor`
+  reports default workflow pack, pack roles, operator docs, recipes, and optional vault health
+- `ovp-export`
+  exports minimal compiled artifacts:
+  - `object-page`
+  - `topic-overview`
+  - `event-dossier`
+  - `contradictions`
+- `docs/research-tech/RESEARCH_TECH_SKILLPACK.md`
+- `docs/research-tech/RESEARCH_TECH_VERIFY.md`
+- `docs/recipes/research-tech/*.md`
+
+Examples:
+
+```bash
+ovp-doctor --pack research-tech --json
+ovp-export --pack research-tech --target topic-overview --output-path /tmp/topic.md
+```
 - `default-knowledge/autopilot`
 
 That is why the default workflow path now runs:

--- a/docs/pack-api/README.md
+++ b/docs/pack-api/README.md
@@ -178,6 +178,19 @@ ovp-packs --json
 
 查看当前运行时可见的 builtin/external packs、角色、兼容基底和 profiles。
 
+对于内置标准 pack 的运营验证，当前也已经有最小命令面：
+
+```bash
+ovp-doctor --pack research-tech --json
+ovp-export --pack research-tech --target topic-overview --output-path /tmp/topic.md
+```
+
+这些命令不是 Pack API 本身，但它们定义了 pack 在真实运行时应该具备的 operator surface：
+
+- doctor / verify
+- recipes
+- exportable compiled artifacts
+
 对第三方 pack 来说，推荐优先提供 entry point；manifest 适合开发期和未安装场景。
 
 ---

--- a/docs/pack-api/README.md
+++ b/docs/pack-api/README.md
@@ -77,6 +77,11 @@ Profile 是某个 pack 下的一条可执行 DAG。
 - `default-knowledge/full`
 - `default-knowledge/autopilot`
 
+当前默认 workflow 入口走的是：
+
+- `ovp --full` -> `research-tech/full`
+- `ovp-autopilot` -> `research-tech/autopilot`
+
 ---
 
 ## 2. 第一个标准 Pack

--- a/docs/plans/2026-04-13-phase6-operationalization-and-engine-evaluation.md
+++ b/docs/plans/2026-04-13-phase6-operationalization-and-engine-evaluation.md
@@ -1,0 +1,186 @@
+# Phase 6: Operationalization And Engine Evaluation
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Turn `research-tech` from an internally-correct pack into an operationally-usable standard pack, while making an explicit storage-engine decision for the truth/index layer.
+
+**Architecture:** Keep the current Python-native `knowledge.db` path on SQLite as the authoritative derived/truth store implementation for now. Add operational surfaces around `research-tech` (`doctor`, `SKILLPACK`, `VERIFY`, `recipes`, `export`) so the pack can be installed, verified, operated, and audited as a real runtime surface. Revisit PGlite only if the truth layer becomes cross-runtime, browser-embedded, or Postgres-specific semantics become a hard product requirement.
+
+**Tech Stack:** Python 3.13, stdlib `sqlite3`, current command/runtime surfaces, pytest, markdown docs under `docs/`.
+
+## 1. Engine Decision: PGlite vs SQLite
+
+### Current Repo Reality
+
+The current store is:
+
+- Python-native
+- rebuilt by `knowledge_index.py`
+- read by Python materializers, review runtime, query tooling, and derived maintenance
+- explicitly a **derived / truth-aware index**, not the canonical authoring store
+
+That matters because engine choice is downstream of runtime shape.
+
+### What PGlite Is Good At
+
+PGlite is stronger than SQLite when all of the following matter:
+
+- browser or JS-first embedding is a first-order requirement
+- Postgres SQL semantics/extensions are required across environments
+- you need one engine family that can later scale to remote Postgres/Supabase with lower conceptual drift
+- local/edge/browser runtimes are part of the core product
+
+### What SQLite Is Still Better At Here
+
+For this repo today, SQLite is the better engine because:
+
+- the current system is Python-native, not JS-native
+- stdlib `sqlite3` is zero-dependency and already integrated across runtime surfaces
+- the current truth/index layer is rebuilt in-process and is not yet a cross-runtime sync substrate
+- migration to PGlite would introduce a bridge/sidecar/WASM runtime boundary before there is a product need for it
+- we already paid the integration cost to stabilize indexing, truth projection, and maintenance on SQLite
+
+### Decision
+
+Do **not** migrate to PGlite in this phase.
+
+Instead:
+
+- keep SQLite as the current engine
+- make the engine choice explicit in docs and doctor output
+- define the triggers that would justify a future PGlite migration
+
+### Revisit Triggers
+
+Only reopen PGlite migration if at least one of these becomes true:
+
+1. The truth store must run in browser/edge/JS runtimes directly.
+2. The same pack runtime must support both embedded local mode and remote Postgres mode with near-identical SQL behavior.
+3. The store stops being a rebuildable derived layer and becomes a long-lived transactional system with stronger relational semantics than SQLite is comfortably providing.
+
+## 2. Scope For This Phase
+
+### Slice A: Research-Tech Operational Surface
+
+Add:
+
+- `ovp-doctor`
+- `docs/research-tech/RESEARCH_TECH_SKILLPACK.md`
+- `docs/research-tech/RESEARCH_TECH_VERIFY.md`
+
+The command should report:
+
+- primary/compatibility pack roles
+- default workflow pack
+- installed pack surfaces for a selected pack
+- operational docs/recipes presence
+- optional vault health basics when `--vault-dir` is provided
+- current storage engine choice and rationale summary
+
+### Slice B: Research-Tech Recipes
+
+Add a first recipe layer for the real source paths we already support:
+
+- pinboard
+- clippings
+- github/repo
+- paper/pdf
+- web article
+
+These recipes are not codegen; they are operator-facing runbooks that make ingestion reproducible.
+
+### Slice C: Minimal Publish / Export Contract
+
+Add an explicit export surface so `research-tech` can publish compiled artifacts without pretending to have a full publishing platform.
+
+Start with a single command:
+
+- `ovp-export`
+
+Support minimal targets:
+
+- `object-page`
+- `topic-overview`
+- `event-dossier`
+- `contradictions`
+
+This should reuse the existing view/materializer runtime and write explicit exported artifacts to a caller-selected output path.
+
+## 3. Implementation Tasks
+
+### Task 1: Add failing tests for doctor
+
+**Files:**
+- Create: `tests/test_doctor_command.py`
+- Modify: `pyproject.toml`
+
+Write failing tests for:
+
+- reporting `research-tech` as primary and `default-knowledge` as compatibility
+- showing default workflow pack
+- JSON output shape
+- optional vault structure checks
+
+### Task 2: Implement `ovp-doctor`
+
+**Files:**
+- Create: `src/openclaw_pipeline/commands/doctor.py`
+- Modify: `src/openclaw_pipeline/packs/loader.py`
+- Modify: `src/openclaw_pipeline/runtime.py` if shared helpers are needed
+
+Implement the minimal command to satisfy the tests and print deterministic JSON/text output.
+
+### Task 3: Add failing tests for export contract
+
+**Files:**
+- Create: `tests/test_export_command.py`
+- Modify: `pyproject.toml`
+
+Write failing tests for:
+
+- `ovp-export --target object-page --object-id ...`
+- `ovp-export --target topic-overview`
+- `ovp-export --target event-dossier`
+- `ovp-export --target contradictions`
+
+### Task 4: Implement `ovp-export`
+
+**Files:**
+- Create: `src/openclaw_pipeline/commands/export_artifact.py`
+- Modify: `src/openclaw_pipeline/wiki_views/runtime.py` only if a small helper improves reuse
+
+Use existing view builders/materializers. The export command should be a thin operational wrapper, not a second rendering pipeline.
+
+### Task 5: Add operational docs and recipes
+
+**Files:**
+- Create: `docs/research-tech/RESEARCH_TECH_SKILLPACK.md`
+- Create: `docs/research-tech/RESEARCH_TECH_VERIFY.md`
+- Create: `docs/recipes/research-tech/pinboard.md`
+- Create: `docs/recipes/research-tech/clippings.md`
+- Create: `docs/recipes/research-tech/github-repo.md`
+- Create: `docs/recipes/research-tech/paper-pdf.md`
+- Create: `docs/recipes/research-tech/web-article.md`
+- Modify: `README.md`
+- Modify: `README_EN.md`
+
+Keep these docs concrete and operator-facing.
+
+### Task 6: Verification
+
+Run:
+
+```bash
+PYTHONPATH=src python3.13 -m pytest -q tests/test_doctor_command.py tests/test_export_command.py
+PYTHONPATH=src python3.13 -m pytest -q
+python3.13 -m compileall src/openclaw_pipeline
+```
+
+## 4. Milestone Outcome
+
+If this phase lands successfully, `research-tech` becomes:
+
+- not just a correct internal pack
+- but an installable, operable, verifiable, exportable standard pack
+
+That is the right boundary before any external pack work or any serious PGlite migration debate.

--- a/docs/recipes/research-tech/clippings.md
+++ b/docs/recipes/research-tech/clippings.md
@@ -1,0 +1,19 @@
+# Recipe: Clippings
+
+## Goal
+
+Move new clipping sources into the normal `research-tech` interpretation and absorb pipeline.
+
+## Command
+
+```bash
+ovp --full --pack research-tech --from-step clippings --batch-size 25
+```
+
+## Verify
+
+Check that:
+
+- `Clippings/` decreases
+- `50-Inbox/01-Raw` and `50-Inbox/03-Processed/YYYY-MM` update
+- new deep-dive notes land under `20-Areas/.../Topics/YYYY-MM`

--- a/docs/recipes/research-tech/github-repo.md
+++ b/docs/recipes/research-tech/github-repo.md
@@ -1,0 +1,19 @@
+# Recipe: GitHub Repo
+
+## Goal
+
+Run a repo/document style source through the `research-tech` interpretation path.
+
+## Command Surface
+
+```bash
+ovp --full --pack research-tech
+```
+
+The GitHub processor is invoked by the workflow when the source is classified as a repository/document-style item.
+
+## Verify
+
+- deep-dive note exists
+- extraction preview can show `tech/doc_structure`
+- knowledge index rebuild succeeds

--- a/docs/recipes/research-tech/paper-pdf.md
+++ b/docs/recipes/research-tech/paper-pdf.md
@@ -1,0 +1,17 @@
+# Recipe: Paper / PDF
+
+## Goal
+
+Run paper/PDF sources through the `research-tech` pack and preserve evidence into the truth layer.
+
+## Command
+
+```bash
+ovp --full --pack research-tech
+```
+
+## Verify
+
+- paper processor resolves and reads the PDF
+- deep-dive note is produced
+- `ovp-build-views --pack research-tech --view event/dossier` still compiles after indexing

--- a/docs/recipes/research-tech/pinboard.md
+++ b/docs/recipes/research-tech/pinboard.md
@@ -1,0 +1,18 @@
+# Recipe: Pinboard
+
+## Goal
+
+Run the `research-tech` pack from fresh Pinboard source items through the full workflow.
+
+## Command
+
+```bash
+ovp --full --pack research-tech --batch-size 25
+```
+
+## Verify
+
+```bash
+ovp-doctor --pack research-tech --vault-dir /path/to/vault --json
+tail -f /path/to/vault/60-Logs/pipeline.jsonl
+```

--- a/docs/recipes/research-tech/web-article.md
+++ b/docs/recipes/research-tech/web-article.md
@@ -1,0 +1,17 @@
+# Recipe: Web Article
+
+## Goal
+
+Run a normal web article source through the `research-tech` workflow without fabricating missing content.
+
+## Command
+
+```bash
+ovp --full --pack research-tech
+```
+
+## Verify
+
+- thin/metadata-only sources abstain instead of hallucinating
+- successful article sources produce deep-dive notes
+- `ovp-query --pack research-tech "..."` can retrieve the new material after indexing

--- a/docs/research-tech/RESEARCH_TECH_SKILLPACK.md
+++ b/docs/research-tech/RESEARCH_TECH_SKILLPACK.md
@@ -1,0 +1,37 @@
+# Research-Tech Skillpack
+
+`research-tech` is the primary built-in pack for technical research workflows.
+
+## What It Covers
+
+- source ingestion from pinboard, clippings, repos, papers, and articles
+- interpretation into deep-dive notes
+- truth-aware indexing and compiled summaries
+- materialized views:
+  - object pages
+  - topic overviews
+  - event dossiers
+  - contradiction views
+- review and maintenance loops:
+  - contradiction review / resolution
+  - stale summary review / rebuild
+
+## Operator Commands
+
+- `ovp --full --pack research-tech`
+- `ovp-autopilot --pack research-tech --profile autopilot`
+- `ovp-extract --pack research-tech --profile tech/doc_structure`
+- `ovp-extract-preview --pack research-tech --profile tech/doc_structure`
+- `ovp-extraction-dashboard --pack research-tech`
+- `ovp-ops --pack research-tech --profile vault/review_queue`
+- `ovp-build-views --pack research-tech --view overview/topic`
+- `ovp-export --pack research-tech --target topic-overview --output-path out/topic.md`
+- `ovp-doctor --pack research-tech --json`
+
+## What This Pack Is Not
+
+- not the compatibility layer
+- not media/editorial specific
+- not a generic demo pack
+
+`default-knowledge` remains available only for compatibility.

--- a/docs/research-tech/RESEARCH_TECH_VERIFY.md
+++ b/docs/research-tech/RESEARCH_TECH_VERIFY.md
@@ -1,0 +1,57 @@
+# Research-Tech Verify
+
+Use this checklist when validating the primary `research-tech` pack.
+
+## Quick Runtime Checks
+
+```bash
+ovp-packs --json
+ovp-doctor --pack research-tech --json
+ovp --help
+ovp-autopilot --help
+```
+
+Expected:
+
+- `research-tech` is `role=primary`
+- `default-knowledge` is `role=compatibility`
+- default workflow pack is `research-tech`
+
+## Test Checks
+
+```bash
+PYTHONPATH=src python3.13 -m pytest -q tests/test_pack_e2e.py tests/test_pack_runtime_e2e.py tests/test_autopilot_contracts.py
+PYTHONPATH=src python3.13 -m pytest -q
+python3.13 -m compileall src/openclaw_pipeline
+```
+
+Expected:
+
+- pack-level e2e stays green
+- orchestrated runtime e2e stays green
+- full suite stays green under Python 3.13
+
+## Vault Checks
+
+```bash
+ovp-doctor --pack research-tech --vault-dir /path/to/vault --json
+```
+
+Inspect:
+
+- inbox counts
+- processed counts
+- whether `knowledge.db` exists
+- operator docs/recipes are present
+
+## Export Checks
+
+```bash
+ovp-export --pack research-tech --vault-dir /path/to/vault --target topic-overview --output-path /tmp/topic.md
+```
+
+Expected:
+
+- export completes
+- output file exists
+- content is a compiled markdown artifact, not a raw database dump

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,9 @@ ovp-ops = "openclaw_pipeline.commands.run_operations:main"
 ovp-build-views = "openclaw_pipeline.commands.build_views:main"
 ovp-resolve-contradictions = "openclaw_pipeline.commands.resolve_contradictions:main"
 ovp-packs = "openclaw_pipeline.commands.list_packs:main"
+ovp-migrate-pack-provenance = "openclaw_pipeline.commands.migrate_pack_provenance:main"
+ovp-doctor = "openclaw_pipeline.commands.doctor:main"
+ovp-export = "openclaw_pipeline.commands.export_artifact:main"
 
 [project.entry-points."openclaw_pipeline.packs"]
 default-knowledge = "openclaw_pipeline.packs.default_knowledge:get_pack"

--- a/src/openclaw_pipeline/autopilot/daemon.py
+++ b/src/openclaw_pipeline/autopilot/daemon.py
@@ -25,7 +25,7 @@ from threading import Lock
 from .queue import TaskQueue, Task
 from ..llm_defaults import DEFAULT_MINIMAX_API_BASE, DEFAULT_MINIMAX_MODEL, normalize_model_for_api_base, resolve_api_base, resolve_api_key
 from ..runtime import resolve_vault_dir
-from ..packs.loader import DEFAULT_PACK_NAME, PRIMARY_PACK_NAME, resolve_workflow_profile
+from ..packs.loader import DEFAULT_PACK_NAME, DEFAULT_WORKFLOW_PACK_NAME, PRIMARY_PACK_NAME, resolve_workflow_profile
 from .watcher import MultiSourceWatcher
 
 
@@ -719,8 +719,8 @@ def main():
         "--pack",
         default=None,
         help=(
-            f"Domain pack 名称 (默认兼容 pack: {DEFAULT_PACK_NAME}; "
-            f"第一标准 pack: {PRIMARY_PACK_NAME})"
+            f"Domain pack 名称 (默认 workflow pack: {DEFAULT_WORKFLOW_PACK_NAME}; "
+            f"兼容 pack: {DEFAULT_PACK_NAME}; 第一标准 pack: {PRIMARY_PACK_NAME})"
         ),
     )
     parser.add_argument(

--- a/src/openclaw_pipeline/commands/doctor.py
+++ b/src/openclaw_pipeline/commands/doctor.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from ..packs.loader import (
+    DEFAULT_PACK_NAME,
+    DEFAULT_WORKFLOW_PACK_NAME,
+    PRIMARY_PACK_NAME,
+    load_pack,
+)
+from ..runtime import VaultLayout, iter_markdown_files, resolve_vault_dir
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _docs_payload(repo_root: Path, *, pack_name: str) -> dict[str, object]:
+    pack_slug = pack_name.replace("_", "-")
+    docs_root = repo_root / "docs"
+    research_root = docs_root / "research-tech"
+    recipes_root = docs_root / "recipes" / pack_slug
+
+    skillpack = research_root / "RESEARCH_TECH_SKILLPACK.md"
+    verify = research_root / "RESEARCH_TECH_VERIFY.md"
+    recipe_files = sorted(recipes_root.glob("*.md")) if recipes_root.exists() else []
+    return {
+        "skillpack": {"path": str(skillpack), "exists": skillpack.exists()},
+        "verify": {"path": str(verify), "exists": verify.exists()},
+        "recipes": {
+            "path": str(recipes_root),
+            "exists": recipes_root.exists(),
+            "count": len(recipe_files),
+            "files": [item.name for item in recipe_files],
+        },
+    }
+
+
+def _vault_payload(vault_dir: Path | None) -> dict[str, object] | None:
+    if vault_dir is None:
+        return None
+    layout = VaultLayout.from_vault(vault_dir)
+    return {
+        "vault_dir": str(layout.vault_dir),
+        "raw_count": len(list(iter_markdown_files(layout.raw_dir))) if layout.raw_dir.exists() else 0,
+        "clippings_count": len(list(iter_markdown_files(layout.clippings_dir))) if layout.clippings_dir.exists() else 0,
+        "pinboard_count": len(list(iter_markdown_files(layout.pinboard_dir))) if layout.pinboard_dir.exists() else 0,
+        "processing_count": len(list(iter_markdown_files(layout.processing_dir))) if layout.processing_dir.exists() else 0,
+        "processed_count": len(list(iter_markdown_files(layout.processed_dir))) if layout.processed_dir.exists() else 0,
+        "evergreen_count": len(list(iter_markdown_files(layout.evergreen_dir))) if layout.evergreen_dir.exists() else 0,
+        "knowledge_db_exists": layout.knowledge_db.exists(),
+    }
+
+
+def _payload(pack_name: str, vault_dir: Path | None) -> dict[str, object]:
+    repo_root = _repo_root()
+    pack = load_pack(pack_name)
+    return {
+        "defaults": {
+            "workflow_pack": DEFAULT_WORKFLOW_PACK_NAME,
+            "compatibility_pack": DEFAULT_PACK_NAME,
+            "primary_pack": PRIMARY_PACK_NAME,
+        },
+        "pack": {
+            "name": pack.name,
+            "role": getattr(pack, "role", "domain"),
+            "compatibility_base": getattr(pack, "compatibility_base", None),
+            "workflow_profiles": [profile.name for profile in pack.workflow_profiles()],
+            "extraction_profiles": [profile.name for profile in pack.extraction_profiles()],
+            "operation_profiles": [profile.name for profile in pack.operation_profiles()],
+            "wiki_views": [view.name for view in pack.wiki_views()],
+        },
+        "storage": {
+            "selected_engine": "sqlite",
+            "pglite_migration": "defer",
+            "reason": (
+                "knowledge.db is currently a Python-native derived/truth-aware store; "
+                "PGlite should only be revisited if browser/JS-native or remote-Postgres "
+                "parity becomes a hard requirement."
+            ),
+        },
+        "docs": _docs_payload(repo_root, pack_name=pack_name),
+        "vault": _vault_payload(vault_dir),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Inspect pack/runtime operational health and explain why SQLite remains the "
+            "selected engine while PGlite migration is deferred."
+        )
+    )
+    parser.add_argument("--vault-dir", type=Path, default=None, help="Optional vault directory for health checks")
+    parser.add_argument(
+        "--pack",
+        default=PRIMARY_PACK_NAME,
+        help=(
+            f"Pack name to inspect (primary pack: {PRIMARY_PACK_NAME}; "
+            f"compatibility pack: {DEFAULT_PACK_NAME})"
+        ),
+    )
+    parser.add_argument("--json", action="store_true", help="Emit structured JSON")
+    args = parser.parse_args(argv)
+
+    payload = _payload(args.pack, resolve_vault_dir(args.vault_dir) if args.vault_dir else None)
+    if args.json:
+        print(json.dumps(payload, ensure_ascii=False))
+        return 0
+
+    print(f"Pack: {payload['pack']['name']} [{payload['pack']['role']}]")
+    print(f"Defaults: workflow={DEFAULT_WORKFLOW_PACK_NAME} compatibility={DEFAULT_PACK_NAME}")
+    print("Storage: sqlite (PGlite migration deferred)")
+    print(f"Skillpack doc: {payload['docs']['skillpack']['path']}")
+    print(f"Verify doc: {payload['docs']['verify']['path']}")
+    if payload["vault"]:
+        vault = payload["vault"]
+        print(
+            "Vault: "
+            f"raw={vault['raw_count']} clippings={vault['clippings_count']} "
+            f"pinboard={vault['pinboard_count']} processed={vault['processed_count']} "
+            f"evergreen={vault['evergreen_count']} knowledge_db_exists={vault['knowledge_db_exists']}"
+        )
+    return 0

--- a/src/openclaw_pipeline/commands/doctor.py
+++ b/src/openclaw_pipeline/commands/doctor.py
@@ -14,17 +14,32 @@ from ..runtime import VaultLayout, iter_markdown_files, resolve_vault_dir
 
 
 def _repo_root() -> Path:
-    return Path(__file__).resolve().parents[3]
+    current = Path(__file__).resolve()
+    for candidate in [current.parent, *current.parents]:
+        if (candidate / "pyproject.toml").exists():
+            return candidate
+    return current.parents[3]
+
+
+def _doc_stem(pack_name: str, suffix: str) -> str:
+    normalized = pack_name.replace("-", "_").upper()
+    return f"{normalized}_{suffix}"
+
+
+def _count_markdown(directory: Path) -> int:
+    if not directory.exists():
+        return 0
+    return sum(1 for _ in iter_markdown_files(directory))
 
 
 def _docs_payload(repo_root: Path, *, pack_name: str) -> dict[str, object]:
     pack_slug = pack_name.replace("_", "-")
     docs_root = repo_root / "docs"
-    research_root = docs_root / "research-tech"
+    pack_docs_root = docs_root / pack_slug
     recipes_root = docs_root / "recipes" / pack_slug
 
-    skillpack = research_root / "RESEARCH_TECH_SKILLPACK.md"
-    verify = research_root / "RESEARCH_TECH_VERIFY.md"
+    skillpack = pack_docs_root / f"{_doc_stem(pack_name, 'SKILLPACK')}.md"
+    verify = pack_docs_root / f"{_doc_stem(pack_name, 'VERIFY')}.md"
     recipe_files = sorted(recipes_root.glob("*.md")) if recipes_root.exists() else []
     return {
         "skillpack": {"path": str(skillpack), "exists": skillpack.exists()},
@@ -44,12 +59,12 @@ def _vault_payload(vault_dir: Path | None) -> dict[str, object] | None:
     layout = VaultLayout.from_vault(vault_dir)
     return {
         "vault_dir": str(layout.vault_dir),
-        "raw_count": len(list(iter_markdown_files(layout.raw_dir))) if layout.raw_dir.exists() else 0,
-        "clippings_count": len(list(iter_markdown_files(layout.clippings_dir))) if layout.clippings_dir.exists() else 0,
-        "pinboard_count": len(list(iter_markdown_files(layout.pinboard_dir))) if layout.pinboard_dir.exists() else 0,
-        "processing_count": len(list(iter_markdown_files(layout.processing_dir))) if layout.processing_dir.exists() else 0,
-        "processed_count": len(list(iter_markdown_files(layout.processed_dir))) if layout.processed_dir.exists() else 0,
-        "evergreen_count": len(list(iter_markdown_files(layout.evergreen_dir))) if layout.evergreen_dir.exists() else 0,
+        "raw_count": _count_markdown(layout.raw_dir),
+        "clippings_count": _count_markdown(layout.clippings_dir),
+        "pinboard_count": _count_markdown(layout.pinboard_dir),
+        "processing_count": _count_markdown(layout.processing_dir),
+        "processed_count": _count_markdown(layout.processed_dir),
+        "evergreen_count": _count_markdown(layout.evergreen_dir),
         "knowledge_db_exists": layout.knowledge_db.exists(),
     }
 
@@ -120,7 +135,8 @@ def main(argv: list[str] | None = None) -> int:
         print(
             "Vault: "
             f"raw={vault['raw_count']} clippings={vault['clippings_count']} "
-            f"pinboard={vault['pinboard_count']} processed={vault['processed_count']} "
+            f"pinboard={vault['pinboard_count']} processing={vault['processing_count']} "
+            f"processed={vault['processed_count']} "
             f"evergreen={vault['evergreen_count']} knowledge_db_exists={vault['knowledge_db_exists']}"
         )
     return 0

--- a/src/openclaw_pipeline/commands/export_artifact.py
+++ b/src/openclaw_pipeline/commands/export_artifact.py
@@ -32,12 +32,21 @@ def main(argv: list[str] | None = None) -> int:
     vault_dir = resolve_vault_dir(args.vault_dir)
     pack = load_pack(args.pack)
     view_name = TARGET_TO_VIEW[args.target]
-    view = pack.wiki_view(view_name)
+    try:
+        view = pack.wiki_view(view_name)
+    except Exception as exc:
+        parser.error(f"failed to resolve view '{view_name}' for pack '{pack.name}': {exc}")
 
     if args.target == "object-page" and not args.object_id:
         parser.error("the --object-id argument is required for object-page exports")
 
-    source_path = build_view(vault_dir, view, object_id=args.object_id)
+    try:
+        source_path = build_view(vault_dir, view, object_id=args.object_id)
+    except Exception as exc:
+        parser.error(
+            f"failed to build export target '{args.target}' for view '{view_name}' "
+            f"and object_id={args.object_id!r}: {exc}"
+        )
     output_path = args.output_path.expanduser().resolve()
     output_path.parent.mkdir(parents=True, exist_ok=True)
     shutil.copyfile(source_path, output_path)

--- a/src/openclaw_pipeline/commands/export_artifact.py
+++ b/src/openclaw_pipeline/commands/export_artifact.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from pathlib import Path
+
+from ..packs.loader import PRIMARY_PACK_NAME, load_pack
+from ..runtime import resolve_vault_dir
+from ..wiki_views.runtime import build_view
+
+
+TARGET_TO_VIEW = {
+    "object-page": "object/page",
+    "topic-overview": "overview/topic",
+    "event-dossier": "event/dossier",
+    "contradictions": "truth/contradictions",
+}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Export pack-backed compiled artifacts to an explicit output path."
+    )
+    parser.add_argument("--vault-dir", type=Path, default=None, help="Vault directory")
+    parser.add_argument("--pack", default=PRIMARY_PACK_NAME, help=f"Pack name (default: {PRIMARY_PACK_NAME})")
+    parser.add_argument("--target", required=True, choices=sorted(TARGET_TO_VIEW), help="Export target")
+    parser.add_argument("--object-id", help="Required for object-page exports")
+    parser.add_argument("--output-path", type=Path, required=True, help="Where to write the exported artifact")
+    args = parser.parse_args(argv)
+
+    vault_dir = resolve_vault_dir(args.vault_dir)
+    pack = load_pack(args.pack)
+    view_name = TARGET_TO_VIEW[args.target]
+    view = pack.wiki_view(view_name)
+
+    if args.target == "object-page" and not args.object_id:
+        parser.error("the --object-id argument is required for object-page exports")
+
+    source_path = build_view(vault_dir, view, object_id=args.object_id)
+    output_path = args.output_path.expanduser().resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(source_path, output_path)
+
+    print(
+        json.dumps(
+            {
+                "target": args.target,
+                "pack": pack.name,
+                "source_path": str(source_path),
+                "output_path": str(output_path),
+            },
+            ensure_ascii=False,
+        )
+    )
+    return 0

--- a/src/openclaw_pipeline/commands/migrate_pack_provenance.py
+++ b/src/openclaw_pipeline/commands/migrate_pack_provenance.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import argparse
+import json
+
+from ..migrate_pack_provenance import migrate_pack_provenance
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Rewrite historical log provenance from a compatibility pack to its primary base."
+    )
+    parser.add_argument("--vault-dir", default=".", help="Vault directory to update")
+    parser.add_argument(
+        "--from-pack",
+        default="default-knowledge",
+        help="Source pack name to rewrite from",
+    )
+    parser.add_argument(
+        "--to-pack",
+        default=None,
+        help="Explicit target pack name. Defaults to the source pack's compatibility base.",
+    )
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Apply the rewrite in-place. Without this flag the command is a dry run.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit structured JSON output.",
+    )
+    args = parser.parse_args(argv)
+
+    result = migrate_pack_provenance(
+        args.vault_dir,
+        from_pack=args.from_pack,
+        to_pack=args.to_pack,
+        write=args.write,
+    )
+
+    if args.json:
+        print(json.dumps(result, ensure_ascii=False))
+        return 0
+
+    mode = "write" if args.write else "dry-run"
+    print(
+        f"[{mode}] migrated {result['files_changed']} files "
+        f"({result['replacements']} replacements): "
+        f"{result['from_pack']} -> {result['to_pack']}"
+    )
+    for path in result["changed_paths"]:
+        print(path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/openclaw_pipeline/materializers/contradiction_view.py
+++ b/src/openclaw_pipeline/materializers/contradiction_view.py
@@ -14,13 +14,18 @@ def materialize_contradiction_view(vault_dir: Path, *, pack_name: str, view_name
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
     with sqlite3.connect(layout.knowledge_db) as conn:
-        rows = conn.execute(
-            """
-            SELECT contradiction_id, subject_key, status, resolution_note, resolved_at
-            FROM contradictions
-            ORDER BY subject_key
-            """
-        ).fetchall()
+        try:
+            rows = conn.execute(
+                """
+                SELECT contradiction_id, subject_key, status, resolution_note, resolved_at
+                FROM contradictions
+                ORDER BY subject_key
+                """
+            ).fetchall()
+        except sqlite3.OperationalError as exc:
+            if "no such table: contradictions" not in str(exc):
+                raise
+            rows = []
 
     lines = [
         f"# {view_name}",

--- a/src/openclaw_pipeline/migrate_pack_provenance.py
+++ b/src/openclaw_pipeline/migrate_pack_provenance.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from .packs.loader import load_pack
+from .runtime import VaultLayout, resolve_vault_dir
+
+TEXT_SUFFIXES = {".json", ".jsonl", ".md"}
+
+
+def default_target_pack(from_pack: str) -> str:
+    pack = load_pack(from_pack)
+    compatibility_base = getattr(pack, "compatibility_base", None)
+    if compatibility_base:
+        return str(compatibility_base)
+    return from_pack
+
+
+def iter_provenance_files(layout: VaultLayout) -> list[Path]:
+    if not layout.logs_dir.exists():
+        return []
+    return sorted(
+        path
+        for path in layout.logs_dir.rglob("*")
+        if path.is_file() and path.suffix in TEXT_SUFFIXES
+    )
+
+
+def migrate_pack_provenance(
+    vault_dir: Path | str | None = None,
+    *,
+    from_pack: str,
+    to_pack: str | None = None,
+    write: bool = False,
+) -> dict[str, object]:
+    resolved_vault = resolve_vault_dir(vault_dir)
+    layout = VaultLayout.from_vault(resolved_vault)
+    target_pack = to_pack or default_target_pack(from_pack)
+
+    files_scanned = 0
+    files_changed = 0
+    replacements = 0
+    changed_paths: list[str] = []
+
+    if from_pack == target_pack:
+        return {
+            "vault_dir": str(resolved_vault),
+            "logs_dir": str(layout.logs_dir),
+            "from_pack": from_pack,
+            "to_pack": target_pack,
+            "files_scanned": 0,
+            "files_changed": 0,
+            "replacements": 0,
+            "changed_paths": [],
+            "write": write,
+        }
+
+    for path in iter_provenance_files(layout):
+        files_scanned += 1
+        original = path.read_text(encoding="utf-8")
+        count = original.count(from_pack)
+        if count <= 0:
+            continue
+        updated = original.replace(from_pack, target_pack)
+        files_changed += 1
+        replacements += count
+        changed_paths.append(str(path))
+        if write:
+            path.write_text(updated, encoding="utf-8")
+
+    return {
+        "vault_dir": str(resolved_vault),
+        "logs_dir": str(layout.logs_dir),
+        "from_pack": from_pack,
+        "to_pack": target_pack,
+        "files_scanned": files_scanned,
+        "files_changed": files_changed,
+        "replacements": replacements,
+        "changed_paths": changed_paths,
+        "write": write,
+    }

--- a/src/openclaw_pipeline/migrate_pack_provenance.py
+++ b/src/openclaw_pipeline/migrate_pack_provenance.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from .packs.loader import load_pack
@@ -26,6 +27,11 @@ def iter_provenance_files(layout: VaultLayout) -> list[Path]:
     )
 
 
+def _token_pattern(pack_name: str) -> re.Pattern[str]:
+    escaped = re.escape(pack_name)
+    return re.compile(rf"(?<![A-Za-z0-9_]){escaped}(?![A-Za-z0-9_])")
+
+
 def migrate_pack_provenance(
     vault_dir: Path | str | None = None,
     *,
@@ -41,6 +47,7 @@ def migrate_pack_provenance(
     files_changed = 0
     replacements = 0
     changed_paths: list[str] = []
+    errors: list[dict[str, str]] = []
 
     if from_pack == target_pack:
         return {
@@ -52,21 +59,28 @@ def migrate_pack_provenance(
             "files_changed": 0,
             "replacements": 0,
             "changed_paths": [],
+            "errors": [],
             "write": write,
         }
 
+    pattern = _token_pattern(from_pack)
     for path in iter_provenance_files(layout):
         files_scanned += 1
-        original = path.read_text(encoding="utf-8")
-        count = original.count(from_pack)
-        if count <= 0:
+        try:
+            original = path.read_text(encoding="utf-8")
+            matches = list(pattern.finditer(original))
+            count = len(matches)
+            if count <= 0:
+                continue
+            updated = pattern.sub(target_pack, original)
+            files_changed += 1
+            replacements += count
+            changed_paths.append(str(path))
+            if write:
+                path.write_text(updated, encoding="utf-8")
+        except (UnicodeDecodeError, OSError) as exc:
+            errors.append({"path": str(path), "error": str(exc)})
             continue
-        updated = original.replace(from_pack, target_pack)
-        files_changed += 1
-        replacements += count
-        changed_paths.append(str(path))
-        if write:
-            path.write_text(updated, encoding="utf-8")
 
     return {
         "vault_dir": str(resolved_vault),
@@ -77,5 +91,6 @@ def migrate_pack_provenance(
         "files_changed": files_changed,
         "replacements": replacements,
         "changed_paths": changed_paths,
+        "errors": errors,
         "write": write,
     }

--- a/src/openclaw_pipeline/packs/loader.py
+++ b/src/openclaw_pipeline/packs/loader.py
@@ -8,6 +8,7 @@ from .base import BaseDomainPack, WorkflowProfile
 
 DEFAULT_PACK_NAME = "default-knowledge"
 PRIMARY_PACK_NAME = "research-tech"
+DEFAULT_WORKFLOW_PACK_NAME = PRIMARY_PACK_NAME
 BUILTIN_PACK_LOADERS = {
     "default-knowledge": ("openclaw_pipeline.packs.default_knowledge", "get_pack"),
     "research-tech": ("openclaw_pipeline.packs.research_tech", "get_pack"),
@@ -65,7 +66,7 @@ def resolve_workflow_profile(
 ) -> tuple[BaseDomainPack, WorkflowProfile]:
     """Resolve a pack/profile pair with stable defaults."""
 
-    resolved_pack_name = pack_name or DEFAULT_PACK_NAME
+    resolved_pack_name = pack_name or DEFAULT_WORKFLOW_PACK_NAME
     resolved_profile_name = profile_name or default_profile
 
     pack = load_pack(resolved_pack_name)

--- a/src/openclaw_pipeline/unified_pipeline_enhanced.py
+++ b/src/openclaw_pipeline/unified_pipeline_enhanced.py
@@ -43,11 +43,11 @@ from typing import Any
 
 try:
     from .runtime import VaultLayout, resolve_vault_dir
-    from .packs.loader import DEFAULT_PACK_NAME, PRIMARY_PACK_NAME, resolve_workflow_profile
+    from .packs.loader import DEFAULT_PACK_NAME, DEFAULT_WORKFLOW_PACK_NAME, PRIMARY_PACK_NAME, resolve_workflow_profile
     from .batch_quality_checker import collect_quality_files
 except ImportError:  # pragma: no cover - script mode fallback
     from runtime import VaultLayout, resolve_vault_dir
-    from packs.loader import DEFAULT_PACK_NAME, PRIMARY_PACK_NAME, resolve_workflow_profile
+    from packs.loader import DEFAULT_PACK_NAME, DEFAULT_WORKFLOW_PACK_NAME, PRIMARY_PACK_NAME, resolve_workflow_profile
     from batch_quality_checker import collect_quality_files
 
 # ========== 环境初始化 ==========
@@ -1753,8 +1753,8 @@ def main():
         "--pack",
         default=None,
         help=(
-            f"Domain pack 名称 (默认兼容 pack: {DEFAULT_PACK_NAME}; "
-            f"第一标准 pack: {PRIMARY_PACK_NAME})"
+            f"Domain pack 名称 (默认 workflow pack: {DEFAULT_WORKFLOW_PACK_NAME}; "
+            f"兼容 pack: {DEFAULT_PACK_NAME}; 第一标准 pack: {PRIMARY_PACK_NAME})"
         ),
     )
     parser.add_argument("--profile", default=None, help="Workflow profile 名称（默认: full）")

--- a/tests/test_default_pack_compat.py
+++ b/tests/test_default_pack_compat.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from argparse import Namespace
 
 
-def test_no_pack_selection_matches_default_full_profile():
-    from openclaw_pipeline.packs.loader import load_default_pack
+def test_no_pack_selection_matches_primary_full_profile():
+    from openclaw_pipeline.packs.loader import load_primary_pack
     from openclaw_pipeline.unified_pipeline_enhanced import build_execution_plan
 
     args = Namespace(
@@ -20,9 +20,11 @@ def test_no_pack_selection_matches_default_full_profile():
     )
 
     plan = build_execution_plan(args)
-    default_pack = load_default_pack()
-    full_profile = default_pack.profile("full")
+    primary_pack = load_primary_pack()
+    full_profile = primary_pack.profile("full")
 
+    assert plan["pack"] == "research-tech"
+    assert plan["profile"] == "full"
     assert plan["steps"] == full_profile.stages
 
 

--- a/tests/test_doctor_command.py
+++ b/tests/test_doctor_command.py
@@ -30,6 +30,8 @@ def test_doctor_command_reports_compatibility_pack_metadata(capsys):
     assert payload["pack"]["name"] == "default-knowledge"
     assert payload["pack"]["role"] == "compatibility"
     assert payload["pack"]["compatibility_base"] == "research-tech"
+    assert payload["docs"]["skillpack"]["exists"] is False
+    assert payload["docs"]["verify"]["exists"] is False
 
 
 def test_doctor_command_reports_vault_health(temp_vault, capsys):
@@ -48,6 +50,20 @@ def test_doctor_command_reports_vault_health(temp_vault, capsys):
     assert payload["vault"]["raw_count"] == 1
     assert payload["vault"]["clippings_count"] == 1
     assert payload["vault"]["knowledge_db_exists"] is False
+
+
+def test_doctor_command_text_output_includes_processing_count(temp_vault, capsys):
+    from openclaw_pipeline.commands.doctor import main
+
+    processing = temp_vault / "50-Inbox" / "02-Processing"
+    processing.mkdir(parents=True, exist_ok=True)
+    (processing / "processing.md").write_text("# Processing\n", encoding="utf-8")
+
+    exit_code = main(["--vault-dir", str(temp_vault)])
+    output = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "processing=1" in output
 
 
 def test_doctor_help_mentions_pglite(capsys):

--- a/tests/test_doctor_command.py
+++ b/tests/test_doctor_command.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import json
+
+
+def test_doctor_command_reports_primary_and_compatibility_roles(capsys):
+    from openclaw_pipeline.commands.doctor import main
+
+    exit_code = main(["--json"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["defaults"]["workflow_pack"] == "research-tech"
+    assert payload["defaults"]["compatibility_pack"] == "default-knowledge"
+    assert payload["storage"]["selected_engine"] == "sqlite"
+    assert payload["storage"]["pglite_migration"] == "defer"
+    assert payload["pack"]["name"] == "research-tech"
+    assert payload["pack"]["role"] == "primary"
+    assert payload["docs"]["skillpack"]["exists"] is True
+    assert payload["docs"]["verify"]["exists"] is True
+
+
+def test_doctor_command_reports_compatibility_pack_metadata(capsys):
+    from openclaw_pipeline.commands.doctor import main
+
+    exit_code = main(["--pack", "default-knowledge", "--json"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["pack"]["name"] == "default-knowledge"
+    assert payload["pack"]["role"] == "compatibility"
+    assert payload["pack"]["compatibility_base"] == "research-tech"
+
+
+def test_doctor_command_reports_vault_health(temp_vault, capsys):
+    from openclaw_pipeline.commands.doctor import main
+
+    raw = temp_vault / "50-Inbox" / "01-Raw"
+    raw.mkdir(parents=True, exist_ok=True)
+    (raw / "sample.md").write_text("# Sample\n", encoding="utf-8")
+    (temp_vault / "Clippings").mkdir(parents=True, exist_ok=True)
+    (temp_vault / "Clippings" / "clip.md").write_text("# Clip\n", encoding="utf-8")
+
+    exit_code = main(["--vault-dir", str(temp_vault), "--json"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["vault"]["raw_count"] == 1
+    assert payload["vault"]["clippings_count"] == 1
+    assert payload["vault"]["knowledge_db_exists"] is False
+
+
+def test_doctor_help_mentions_pglite(capsys):
+    from openclaw_pipeline.commands.doctor import main
+
+    try:
+        main(["--help"])
+    except SystemExit as exc:
+        assert exc.code == 0
+
+    output = capsys.readouterr().out
+    assert "PGlite" in output

--- a/tests/test_export_command.py
+++ b/tests/test_export_command.py
@@ -209,3 +209,31 @@ def test_export_command_handles_missing_contradictions_table(temp_vault, tmp_pat
     content = output_path.read_text(encoding="utf-8")
     assert "# truth/contradictions" in content
     assert "(none)" in content
+
+
+def test_export_command_surfaces_build_errors_as_cli_errors(temp_vault, tmp_path, monkeypatch):
+    from openclaw_pipeline.commands import export_artifact
+
+    _seed_truth_store(temp_vault)
+    output_path = tmp_path / "topic.md"
+
+    def raise_error(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(export_artifact, "build_view", raise_error)
+
+    try:
+        export_artifact.main(
+            [
+                "--vault-dir",
+                str(temp_vault),
+                "--target",
+                "topic-overview",
+                "--output-path",
+                str(output_path),
+            ]
+        )
+    except SystemExit as exc:
+        assert exc.code == 2
+    else:
+        raise AssertionError("expected export command to convert build errors into parser failures")

--- a/tests/test_export_command.py
+++ b/tests/test_export_command.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import json
+
+
+def _seed_truth_store(temp_vault):
+    from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
+
+    alpha = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
+    beta = temp_vault / "10-Knowledge" / "Evergreen" / "Beta.md"
+    conflict = temp_vault / "10-Knowledge" / "Evergreen" / "Conflict.md"
+
+    alpha.write_text(
+        """---
+note_id: alpha
+title: Alpha
+type: evergreen
+date: 2026-04-10
+---
+
+# Alpha
+
+Alpha connects to [[Beta]].
+Alpha is always reliable.
+""",
+        encoding="utf-8",
+    )
+    beta.write_text(
+        """---
+note_id: beta
+title: Beta
+type: evergreen
+date: 2026-04-10
+---
+
+# Beta
+
+Beta extends Alpha.
+""",
+        encoding="utf-8",
+    )
+    conflict.write_text(
+        """---
+note_id: conflict
+title: Conflict
+type: evergreen
+date: 2026-04-11
+---
+
+# Conflict
+
+Alpha is not reliable.
+""",
+        encoding="utf-8",
+    )
+
+    rebuild_knowledge_index(temp_vault)
+
+
+def test_export_command_can_export_object_page(temp_vault, tmp_path, capsys):
+    from openclaw_pipeline.commands.export_artifact import main
+
+    _seed_truth_store(temp_vault)
+    output_path = tmp_path / "alpha-object.md"
+
+    exit_code = main(
+        [
+            "--vault-dir",
+            str(temp_vault),
+            "--target",
+            "object-page",
+            "--object-id",
+            "alpha",
+            "--output-path",
+            str(output_path),
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert payload["target"] == "object-page"
+    assert output_path.exists()
+    assert "Alpha" in output_path.read_text(encoding="utf-8")
+
+
+def test_export_command_can_export_topic_overview(temp_vault, tmp_path, capsys):
+    from openclaw_pipeline.commands.export_artifact import main
+
+    _seed_truth_store(temp_vault)
+    output_path = tmp_path / "topic.md"
+
+    exit_code = main(
+        [
+            "--vault-dir",
+            str(temp_vault),
+            "--target",
+            "topic-overview",
+            "--output-path",
+            str(output_path),
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert payload["target"] == "topic-overview"
+    assert output_path.exists()
+    assert "# overview/topic" in output_path.read_text(encoding="utf-8")
+
+
+def test_export_command_can_export_event_dossier(temp_vault, tmp_path, capsys):
+    from openclaw_pipeline.commands.export_artifact import main
+
+    _seed_truth_store(temp_vault)
+    output_path = tmp_path / "events.md"
+
+    exit_code = main(
+        [
+            "--vault-dir",
+            str(temp_vault),
+            "--target",
+            "event-dossier",
+            "--output-path",
+            str(output_path),
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert payload["target"] == "event-dossier"
+    assert output_path.exists()
+    assert "# event/dossier" in output_path.read_text(encoding="utf-8")
+
+
+def test_export_command_can_export_contradictions(temp_vault, tmp_path, capsys):
+    from openclaw_pipeline.commands.export_artifact import main
+
+    _seed_truth_store(temp_vault)
+    output_path = tmp_path / "contradictions.md"
+
+    exit_code = main(
+        [
+            "--vault-dir",
+            str(temp_vault),
+            "--target",
+            "contradictions",
+            "--output-path",
+            str(output_path),
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert payload["target"] == "contradictions"
+    assert output_path.exists()
+    assert "# truth/contradictions" in output_path.read_text(encoding="utf-8")
+
+
+def test_export_command_requires_object_id_for_object_page(temp_vault, tmp_path):
+    from openclaw_pipeline.commands.export_artifact import main
+
+    _seed_truth_store(temp_vault)
+    output_path = tmp_path / "missing-object-id.md"
+
+    try:
+        main(
+            [
+                "--vault-dir",
+                str(temp_vault),
+                "--target",
+                "object-page",
+                "--output-path",
+                str(output_path),
+            ]
+        )
+    except SystemExit as exc:
+        assert exc.code == 2
+    else:
+        raise AssertionError("expected object-page export to require --object-id")
+
+
+def test_export_command_handles_missing_contradictions_table(temp_vault, tmp_path, capsys):
+    import sqlite3
+
+    from openclaw_pipeline.commands.export_artifact import main
+    from openclaw_pipeline.runtime import VaultLayout
+
+    layout = VaultLayout.from_vault(temp_vault)
+    layout.logs_dir.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(layout.knowledge_db) as conn:
+        conn.execute("CREATE TABLE compiled_summaries (object_id TEXT, summary TEXT)")
+        conn.commit()
+
+    output_path = tmp_path / "contradictions-empty.md"
+    exit_code = main(
+        [
+            "--vault-dir",
+            str(temp_vault),
+            "--target",
+            "contradictions",
+            "--output-path",
+            str(output_path),
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert payload["target"] == "contradictions"
+    assert output_path.exists()
+    content = output_path.read_text(encoding="utf-8")
+    assert "# truth/contradictions" in content
+    assert "(none)" in content

--- a/tests/test_migrate_pack_provenance.py
+++ b/tests/test_migrate_pack_provenance.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 
 def test_migrate_pack_provenance_dry_run_reports_log_only_changes(temp_vault, sample_evergreen_files):
@@ -94,3 +95,47 @@ def test_migrate_pack_provenance_command_emits_json(temp_vault, capsys):
     assert exit_code == 0
     assert payload["to_pack"] == "research-tech"
     assert payload["files_changed"] == 1
+
+
+def test_migrate_pack_provenance_replaces_only_token_bound_occurrences(temp_vault):
+    logs_dir = temp_vault / "60-Logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    sample = logs_dir / "sample.md"
+    sample.write_text(
+        "default-knowledge default-knowledge/full xdefault-knowledgey\n",
+        encoding="utf-8",
+    )
+
+    from openclaw_pipeline.migrate_pack_provenance import migrate_pack_provenance
+
+    result = migrate_pack_provenance(temp_vault, from_pack="default-knowledge", write=True)
+    content = sample.read_text(encoding="utf-8")
+
+    assert result["files_changed"] == 1
+    assert result["replacements"] == 2
+    assert "research-tech/full" in content
+    assert "xdefault-knowledgey" in content
+
+
+def test_migrate_pack_provenance_skips_unreadable_files(temp_vault, monkeypatch):
+    logs_dir = temp_vault / "60-Logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    broken = logs_dir / "broken.json"
+    broken.write_text('{"pack":"default-knowledge"}', encoding="utf-8")
+
+    original_read_text = Path.read_text
+
+    def patched_read_text(self, *args, **kwargs):
+        if self == broken:
+            raise UnicodeDecodeError("utf-8", b"", 0, 1, "broken")
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", patched_read_text)
+
+    from openclaw_pipeline.migrate_pack_provenance import migrate_pack_provenance
+
+    result = migrate_pack_provenance(temp_vault, from_pack="default-knowledge", write=True)
+
+    assert result["files_changed"] == 0
+    assert len(result["errors"]) == 1
+    assert result["errors"][0]["path"].endswith("broken.json")

--- a/tests/test_migrate_pack_provenance.py
+++ b/tests/test_migrate_pack_provenance.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+
+
+def test_migrate_pack_provenance_dry_run_reports_log_only_changes(temp_vault, sample_evergreen_files):
+    logs_dir = temp_vault / "60-Logs"
+    transactions_dir = logs_dir / "transactions"
+    transactions_dir.mkdir(parents=True, exist_ok=True)
+
+    transaction_path = transactions_dir / "txn.json"
+    transaction_path.write_text(
+        json.dumps(
+            {
+                "id": "txn-1",
+                "description": "Full pipeline (default-knowledge/full)",
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    pipeline_log = logs_dir / "pipeline.jsonl"
+    pipeline_log.write_text(
+        json.dumps({"event_type": "graph", "pack": "default-knowledge"}, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+    from openclaw_pipeline.migrate_pack_provenance import migrate_pack_provenance
+
+    result = migrate_pack_provenance(temp_vault, from_pack="default-knowledge", write=False)
+
+    assert result["from_pack"] == "default-knowledge"
+    assert result["to_pack"] == "research-tech"
+    assert result["files_changed"] == 2
+    assert result["replacements"] >= 2
+    assert "default-knowledge" in transaction_path.read_text(encoding="utf-8")
+    assert "default-knowledge" in pipeline_log.read_text(encoding="utf-8")
+    evergreen_path = temp_vault / "10-Knowledge" / "Evergreen" / "DCF-Valuation.md"
+    assert "default-knowledge" not in evergreen_path.read_text(encoding="utf-8")
+
+
+def test_migrate_pack_provenance_write_updates_logs_without_touching_notes(temp_vault, sample_evergreen_files):
+    logs_dir = temp_vault / "60-Logs"
+    transactions_dir = logs_dir / "transactions"
+    transactions_dir.mkdir(parents=True, exist_ok=True)
+
+    transaction_path = transactions_dir / "txn.json"
+    transaction_path.write_text(
+        json.dumps(
+            {
+                "id": "txn-1",
+                "description": "Full pipeline (default-knowledge/full)",
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    report_path = logs_dir / "pipeline-reports" / "pipeline-report-demo.md"
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text("pack=default-knowledge\n", encoding="utf-8")
+    pipeline_log = logs_dir / "pipeline.jsonl"
+    pipeline_log.write_text(
+        json.dumps({"event_type": "graph", "pack": "default-knowledge"}, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    evergreen_path = temp_vault / "10-Knowledge" / "Evergreen" / "DCF-Valuation.md"
+    original_evergreen = evergreen_path.read_text(encoding="utf-8")
+
+    from openclaw_pipeline.migrate_pack_provenance import migrate_pack_provenance
+
+    result = migrate_pack_provenance(temp_vault, from_pack="default-knowledge", write=True)
+
+    assert result["files_changed"] == 3
+    assert "research-tech/full" in transaction_path.read_text(encoding="utf-8")
+    assert "research-tech" in pipeline_log.read_text(encoding="utf-8")
+    assert "research-tech" in report_path.read_text(encoding="utf-8")
+    assert evergreen_path.read_text(encoding="utf-8") == original_evergreen
+
+
+def test_migrate_pack_provenance_command_emits_json(temp_vault, capsys):
+    logs_dir = temp_vault / "60-Logs"
+    transactions_dir = logs_dir / "transactions"
+    transactions_dir.mkdir(parents=True, exist_ok=True)
+    (transactions_dir / "txn.json").write_text(
+        json.dumps({"description": "Full pipeline (default-knowledge/full)"}, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+    from openclaw_pipeline.commands.migrate_pack_provenance import main
+
+    exit_code = main(["--vault-dir", str(temp_vault), "--json"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["to_pack"] == "research-tech"
+    assert payload["files_changed"] == 1


### PR DESCRIPTION
## Summary
- add `ovp-doctor` and `ovp-export` as operational surfaces for `research-tech`
- add `research-tech` skillpack/verify docs plus source recipes and Phase 6 plan
- add pack provenance migration tooling and make contradiction export tolerate older knowledge.db schemas

## Why
`research-tech` is now the default workflow pack, but it still needed an operator-facing surface. This PR makes the pack inspectable, verifiable, exportable, and safer to migrate in real vaults.

## Validation
- `PYTHONPATH=src python3.13 -m pytest -q tests/test_doctor_command.py tests/test_export_command.py tests/test_migrate_pack_provenance.py tests/test_pack_e2e.py tests/test_pack_runtime_e2e.py`
- `PYTHONPATH=src python3.13 -m pytest -q`
- `python3.13 -m compileall src/openclaw_pipeline`
- real smoke: `ovp-doctor --pack research-tech --vault-dir /Users/chris/Documents/openclaw-vault --json`
- real smoke: `ovp-export --pack research-tech --target contradictions --output-path /tmp/openclaw-contradictions.md`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/7" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New CLI tools: pack diagnostics, artifact export, and pack-provenance migration.
  * Research-tech promoted as the default workflow pack.

* **Documentation**
  * New Research-Tech skillpack, operational surface, and verification checklist.
  * Multiple new recipes for pinboard, clippings, repos, papers, and web articles.
  * Phase‑6 operationalization plan and operator runbooks.

* **Tests**
  * Added comprehensive tests for diagnostics, export, and migration workflows.

* **Bug Fixes**
  * Exports now tolerate a missing contradictions table gracefully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->