### PR TITLE
feat: add db truth surface and local UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ profile 是某个 pack 下的一条可执行 DAG。
   - `topic-overview`
   - `event-dossier`
   - `contradictions`
+- `ovp-truth`
+  直接读取 `knowledge.db` 中的 object / contradiction / neighborhood truth rows
+- `ovp-ui`
+  启动一个本地只读 DB 浏览面，直接查看 object / topic / event / contradiction
 - `docs/research-tech/RESEARCH_TECH_SKILLPACK.md`
 - `docs/research-tech/RESEARCH_TECH_VERIFY.md`
 - `docs/recipes/research-tech/*.md`
@@ -159,6 +163,8 @@ profile 是某个 pack 下的一条可执行 DAG。
 
 ```bash
 ovp-doctor --pack research-tech --json
+ovp-truth objects --vault-dir /path/to/vault
+ovp-ui --vault-dir /path/to/vault --port 8787
 ovp-export --pack research-tech --target topic-overview --output-path /tmp/topic.md
 ```
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -152,6 +152,10 @@ The built-in profiles currently shipped are:
   - `topic-overview`
   - `event-dossier`
   - `contradictions`
+- `ovp-truth`
+  reads object / contradiction / neighborhood truth rows directly from `knowledge.db`
+- `ovp-ui`
+  launches a local read-only DB browser for object / topic / event / contradiction views
 - `docs/research-tech/RESEARCH_TECH_SKILLPACK.md`
 - `docs/research-tech/RESEARCH_TECH_VERIFY.md`
 - `docs/recipes/research-tech/*.md`
@@ -160,6 +164,8 @@ Examples:
 
 ```bash
 ovp-doctor --pack research-tech --json
+ovp-truth objects --vault-dir /path/to/vault
+ovp-ui --vault-dir /path/to/vault --port 8787
 ovp-export --pack research-tech --target topic-overview --output-path /tmp/topic.md
 ```
 - `default-knowledge/autopilot`

--- a/docs/plans/2026-04-13-phase7-db-surface-and-ui-access.md
+++ b/docs/plans/2026-04-13-phase7-db-surface-and-ui-access.md
@@ -1,0 +1,414 @@
+# Phase 7: DB Surface And UI Access Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Let users directly feel and inspect the truth/data layer in `knowledge.db`, instead of only seeing generated Markdown in the vault.
+
+**Architecture:** Keep SQLite/`knowledge.db` as the authoritative derived/truth-aware runtime store. Add a thin read-only surface above it in three steps: queryable JSON endpoints/commands, browsable compiled DB views, and then a small local UI for object/topic/event/contradiction exploration. Do not replace Markdown views; make DB-backed views the primary inspection surface and Markdown the export/materialization surface.
+
+**Tech Stack:** Python 3.13, stdlib `sqlite3`, existing `knowledge_index.py`, existing materializers, existing pack runtime, pytest, lightweight local server/UI (prefer stdlib/very small dependency footprint).
+
+## Problem Statement
+
+Today the user can mainly feel the system through:
+
+- vault Markdown
+- materialized views exported back into Markdown
+- CLI summaries (`ovp-doctor`, `ovp-export`, `ovp-query`)
+
+This is enough for operators, but not enough for product feeling. The DB already contains:
+
+- `objects`
+- `claims`
+- `relations`
+- `compiled_summaries`
+- `contradictions`
+- `timeline_events`
+
+But users still cannot easily:
+
+- browse objects directly from the DB
+- inspect relation neighborhoods interactively
+- review contradiction/state changes in one place
+- compare “truth rows” vs materialized Markdown outputs
+
+That is the next product gap.
+
+## Phase 7 Scope
+
+### Slice A: Readable DB Surface
+
+Add a first-class read/query layer above `knowledge.db`:
+
+- list objects
+- fetch object detail
+- fetch relations for object
+- fetch claims/evidence for object
+- list contradictions
+- fetch timeline/event dossier inputs
+
+This should not require raw SQL from users.
+
+### Slice B: Compiled DB Views
+
+Add derived read-model builders that turn DB truth into structured JSON/markdown payloads suitable for UI:
+
+- object detail payload
+- topic neighborhood payload
+- event dossier payload
+- contradiction queue payload
+
+These are not exports for publication; they are UI/view-model payloads.
+
+### Slice C: Local UI
+
+Add a minimal local UI/server for inspection:
+
+- object browser
+- topic graph/neighborhood browser
+- contradiction review browser
+- event dossier browser
+
+This should be read-only in the first cut. Review actions can stay CLI-driven initially.
+
+## Non-Goals
+
+- No full multi-user web app
+- No remote DB
+- No PGlite migration
+- No rewriting pack/materializer architecture
+- No replacing vault Markdown as the authoring/export surface
+
+## Milestone Definition
+
+Phase 7 is complete when:
+
+1. A user can run one local command and inspect DB-backed object/topic/event/contradiction views.
+2. The UI is reading from `knowledge.db`, not re-parsing Markdown.
+3. The same truth rows can still be materialized to Markdown/export through existing flows.
+4. `research-tech` pack remains the default workflow pack.
+
+## Task 1: Add failing tests for DB read surface
+
+**Files:**
+- Create: `tests/test_truth_api.py`
+- Reference: `src/openclaw_pipeline/truth_store.py`
+- Reference: `src/openclaw_pipeline/knowledge_index.py`
+
+**Step 1: Write the failing tests**
+
+Cover:
+
+- listing objects
+- fetching object detail with summary/claims/relations
+- listing contradictions
+- listing topic neighborhood by object/topic id
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+PYTHONPATH=src python3.13 -m pytest -q tests/test_truth_api.py
+```
+
+Expected:
+- import failure or missing function failures
+
+**Step 3: Implement minimal DB read API**
+
+Create a new module:
+
+- `src/openclaw_pipeline/truth_api.py`
+
+Add pure read helpers, e.g.:
+
+- `list_objects(db_path, limit, offset)`
+- `get_object_detail(db_path, object_id)`
+- `list_contradictions(db_path, status="open")`
+- `get_topic_neighborhood(db_path, object_id, depth=1)`
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+PYTHONPATH=src python3.13 -m pytest -q tests/test_truth_api.py
+```
+
+Expected:
+- PASS
+
+**Step 5: Commit**
+
+```bash
+git add tests/test_truth_api.py src/openclaw_pipeline/truth_api.py
+git commit -m "feat: add truth api read surface"
+```
+
+## Task 2: Add CLI access to DB truth surface
+
+**Files:**
+- Create: `src/openclaw_pipeline/commands/truth_api.py`
+- Modify: `pyproject.toml`
+- Test: `tests/test_truth_api_command.py`
+
+**Step 1: Write the failing test**
+
+Cover:
+
+- `ovp-truth objects`
+- `ovp-truth object --id ...`
+- `ovp-truth contradictions`
+- `ovp-truth neighborhood --id ...`
+
+Require JSON output.
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+PYTHONPATH=src python3.13 -m pytest -q tests/test_truth_api_command.py
+```
+
+**Step 3: Implement minimal command**
+
+Add a read-only command:
+
+- `ovp-truth`
+
+Requirements:
+
+- accepts `--vault-dir`
+- resolves `knowledge.db`
+- outputs JSON
+- no write actions in this slice
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+PYTHONPATH=src python3.13 -m pytest -q tests/test_truth_api_command.py
+```
+
+**Step 5: Commit**
+
+```bash
+git add tests/test_truth_api_command.py src/openclaw_pipeline/commands/truth_api.py pyproject.toml
+git commit -m "feat: add truth api cli"
+```
+
+## Task 3: Build UI view-model payloads
+
+**Files:**
+- Create: `src/openclaw_pipeline/ui/view_models.py`
+- Test: `tests/test_ui_view_models.py`
+
+**Step 1: Write the failing test**
+
+Cover:
+
+- object page payload shape
+- topic neighborhood payload shape
+- event dossier payload shape
+- contradiction browser payload shape
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+PYTHONPATH=src python3.13 -m pytest -q tests/test_ui_view_models.py
+```
+
+**Step 3: Implement minimal view-model builders**
+
+Translate truth rows into UI-shaped payloads:
+
+- labels
+- summaries
+- relation lists
+- evidence snippets
+- contradiction statuses
+
+Do not render HTML here.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+PYTHONPATH=src python3.13 -m pytest -q tests/test_ui_view_models.py
+```
+
+**Step 5: Commit**
+
+```bash
+git add tests/test_ui_view_models.py src/openclaw_pipeline/ui/view_models.py
+git commit -m "feat: add db-backed ui view models"
+```
+
+## Task 4: Add minimal local UI server
+
+**Files:**
+- Create: `src/openclaw_pipeline/commands/ui_server.py`
+- Create: `tests/test_ui_server.py`
+
+**Step 1: Write the failing test**
+
+Cover:
+
+- route registration
+- object route returns payload
+- contradiction route returns payload
+- topic route returns payload
+
+Prefer response contract tests over browser tests in the first cut.
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+PYTHONPATH=src python3.13 -m pytest -q tests/test_ui_server.py
+```
+
+**Step 3: Implement minimal server**
+
+Start with a simple local HTTP server:
+
+- stdlib `http.server` or similarly light approach
+- read-only JSON endpoints first
+- optional static HTML shell that fetches JSON and renders lists/detail panes
+
+Expose command:
+
+- `ovp-ui --vault-dir ...`
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+PYTHONPATH=src python3.13 -m pytest -q tests/test_ui_server.py
+```
+
+**Step 5: Commit**
+
+```bash
+git add tests/test_ui_server.py src/openclaw_pipeline/commands/ui_server.py
+git commit -m "feat: add local db ui server"
+```
+
+## Task 5: Add browser-level smoke tests
+
+**Files:**
+- Create: `tests/test_ui_smoke.py`
+
+**Step 1: Write the failing test**
+
+Smoke-check:
+
+- object page loads
+- contradictions page loads
+- topic page loads
+- event page loads
+
+Use sample `knowledge.db` fixtures.
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+PYTHONPATH=src python3.13 -m pytest -q tests/test_ui_smoke.py
+```
+
+**Step 3: Implement only what is needed to pass**
+
+Do not expand into a design system or multi-page app. Keep first cut small and readable.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+PYTHONPATH=src python3.13 -m pytest -q tests/test_ui_smoke.py
+```
+
+**Step 5: Commit**
+
+```bash
+git add tests/test_ui_smoke.py
+git commit -m "test: add db ui smoke coverage"
+```
+
+## Task 6: Wire the UI into operator docs
+
+**Files:**
+- Modify: `README.md`
+- Modify: `README_EN.md`
+- Modify: `docs/research-tech/RESEARCH_TECH_VERIFY.md`
+- Modify: `docs/research-tech/RESEARCH_TECH_SKILLPACK.md`
+
+**Step 1: Write docs updates**
+
+Document:
+
+- what DB-backed UI is for
+- how it differs from Markdown materialization
+- how to launch it
+- what routes/screens exist
+
+**Step 2: Verify commands/examples**
+
+Run:
+
+```bash
+ovp-doctor --pack research-tech --json
+ovp-truth objects --vault-dir /path/to/vault
+ovp-ui --vault-dir /path/to/vault
+```
+
+**Step 3: Commit**
+
+```bash
+git add README.md README_EN.md docs/research-tech/RESEARCH_TECH_VERIFY.md docs/research-tech/RESEARCH_TECH_SKILLPACK.md
+git commit -m "docs: add db ui operating guide"
+```
+
+## Recommended Execution Order
+
+1. Task 1
+2. Task 2
+3. Task 3
+4. Task 4
+5. Task 5
+6. Task 6
+
+This order is deliberate:
+
+- first make DB truth readable
+- then make it scriptable
+- then make it renderable
+- then expose it via UI
+- then smoke-test it
+- finally document it
+
+## Product Interpretation
+
+Relative to GBrain, this phase intentionally focuses on:
+
+- **feeling the system through the DB**
+- **operational inspection**
+- **compiled knowledge browsing**
+
+It does **not** yet try to match:
+
+- full publish layer
+- richer multi-tenant product shell
+- installable recipe runtime
+
+Those can come later. The immediate gap is simpler: users need to see and navigate the truth store directly.

--- a/docs/research-tech/RESEARCH_TECH_SKILLPACK.md
+++ b/docs/research-tech/RESEARCH_TECH_SKILLPACK.md
@@ -27,6 +27,8 @@
 - `ovp-build-views --pack research-tech --view overview/topic`
 - `ovp-export --pack research-tech --target topic-overview --output-path out/topic.md`
 - `ovp-doctor --pack research-tech --json`
+- `ovp-truth objects --vault-dir /path/to/vault`
+- `ovp-ui --vault-dir /path/to/vault --port 8787`
 
 ## What This Pack Is Not
 

--- a/docs/research-tech/RESEARCH_TECH_VERIFY.md
+++ b/docs/research-tech/RESEARCH_TECH_VERIFY.md
@@ -7,6 +7,8 @@ Use this checklist when validating the primary `research-tech` pack.
 ```bash
 ovp-packs --json
 ovp-doctor --pack research-tech --json
+ovp-truth objects --vault-dir /path/to/vault
+ovp-ui --vault-dir /path/to/vault --port 8787
 ovp --help
 ovp-autopilot --help
 ```
@@ -16,6 +18,8 @@ Expected:
 - `research-tech` is `role=primary`
 - `default-knowledge` is `role=compatibility`
 - default workflow pack is `research-tech`
+- `ovp-truth` can read object rows directly from `knowledge.db`
+- `ovp-ui` starts a local DB-backed browser surface
 
 ## Test Checks
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ ovp-packs = "openclaw_pipeline.commands.list_packs:main"
 ovp-migrate-pack-provenance = "openclaw_pipeline.commands.migrate_pack_provenance:main"
 ovp-doctor = "openclaw_pipeline.commands.doctor:main"
 ovp-export = "openclaw_pipeline.commands.export_artifact:main"
+ovp-truth = "openclaw_pipeline.commands.truth_api:main"
 
 [project.entry-points."openclaw_pipeline.packs"]
 default-knowledge = "openclaw_pipeline.packs.default_knowledge:get_pack"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ ovp-migrate-pack-provenance = "openclaw_pipeline.commands.migrate_pack_provenanc
 ovp-doctor = "openclaw_pipeline.commands.doctor:main"
 ovp-export = "openclaw_pipeline.commands.export_artifact:main"
 ovp-truth = "openclaw_pipeline.commands.truth_api:main"
+ovp-ui = "openclaw_pipeline.commands.ui_server:main"
 
 [project.entry-points."openclaw_pipeline.packs"]
 default-knowledge = "openclaw_pipeline.packs.default_knowledge:get_pack"

--- a/src/openclaw_pipeline/commands/truth_api.py
+++ b/src/openclaw_pipeline/commands/truth_api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path
 
 from ..runtime import resolve_vault_dir
@@ -39,16 +40,23 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     vault_dir = resolve_vault_dir(getattr(args, "vault_dir", None))
 
-    if args.command == "objects":
-        payload = {"items": list_objects(vault_dir, limit=args.limit, offset=args.offset)}
-    elif args.command == "object":
-        payload = get_object_detail(vault_dir, args.id)
-    elif args.command == "contradictions":
-        payload = {"items": list_contradictions(vault_dir, limit=args.limit, status=args.status)}
-    elif args.command == "neighborhood":
-        payload = get_topic_neighborhood(vault_dir, args.id, depth=args.depth)
-    else:  # pragma: no cover - argparse enforces commands
-        parser.error(f"unknown command: {args.command}")
+    if args.command == "neighborhood" and args.depth != 1:
+        parser.error("Only depth=1 is currently supported")
+
+    try:
+        if args.command == "objects":
+            payload = {"items": list_objects(vault_dir, limit=args.limit, offset=args.offset)}
+        elif args.command == "object":
+            payload = get_object_detail(vault_dir, args.id)
+        elif args.command == "contradictions":
+            payload = {"items": list_contradictions(vault_dir, limit=args.limit, status=args.status)}
+        elif args.command == "neighborhood":
+            payload = get_topic_neighborhood(vault_dir, args.id, depth=args.depth)
+        else:  # pragma: no cover - argparse enforces commands
+            parser.error(f"unknown command: {args.command}")
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        raise SystemExit(2) from exc
 
     print(json.dumps(payload, ensure_ascii=False))
     return 0

--- a/src/openclaw_pipeline/commands/truth_api.py
+++ b/src/openclaw_pipeline/commands/truth_api.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from ..runtime import resolve_vault_dir
+from ..truth_api import (
+    get_object_detail,
+    get_topic_neighborhood,
+    list_contradictions,
+    list_objects,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Read truth-store data from knowledge.db")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    objects_parser = subparsers.add_parser("objects", help="List objects")
+    objects_parser.add_argument("--vault-dir", type=Path, default=None, help="Vault directory")
+    objects_parser.add_argument("--limit", type=int, default=100)
+    objects_parser.add_argument("--offset", type=int, default=0)
+
+    object_parser = subparsers.add_parser("object", help="Fetch object detail")
+    object_parser.add_argument("--vault-dir", type=Path, default=None, help="Vault directory")
+    object_parser.add_argument("--id", required=True, help="Object id")
+
+    contradictions_parser = subparsers.add_parser("contradictions", help="List contradictions")
+    contradictions_parser.add_argument("--vault-dir", type=Path, default=None, help="Vault directory")
+    contradictions_parser.add_argument("--limit", type=int, default=100)
+    contradictions_parser.add_argument("--status", default=None)
+
+    neighborhood_parser = subparsers.add_parser("neighborhood", help="Fetch topic neighborhood")
+    neighborhood_parser.add_argument("--vault-dir", type=Path, default=None, help="Vault directory")
+    neighborhood_parser.add_argument("--id", required=True, help="Center object id")
+    neighborhood_parser.add_argument("--depth", type=int, default=1)
+
+    args = parser.parse_args(argv)
+    vault_dir = resolve_vault_dir(getattr(args, "vault_dir", None))
+
+    if args.command == "objects":
+        payload = {"items": list_objects(vault_dir, limit=args.limit, offset=args.offset)}
+    elif args.command == "object":
+        payload = get_object_detail(vault_dir, args.id)
+    elif args.command == "contradictions":
+        payload = {"items": list_contradictions(vault_dir, limit=args.limit, status=args.status)}
+    elif args.command == "neighborhood":
+        payload = get_topic_neighborhood(vault_dir, args.id, depth=args.depth)
+    else:  # pragma: no cover - argparse enforces commands
+        parser.error(f"unknown command: {args.command}")
+
+    print(json.dumps(payload, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -103,12 +103,13 @@ def _render_object_page(payload: dict) -> str:
         f'<li><span class="pill">{escape(item["status"])}</span>{escape(item["subject_key"])}</li>'
         for item in payload["contradictions"]
     ) or "<li>None</li>"
+    summary_text = payload["summary"]["summary_text"] if payload["summary"] else ""
     return _layout(
         f"Object: {payload['object']['title']}",
         (
             f"<h1>Object: {escape(payload['object']['title'])}</h1>"
             f"<p class='muted'>{escape(payload['object']['object_id'])}</p>"
-            f"<section class='card'><h2>Compiled Summary</h2><p>{escape(payload['summary']['summary_text'])}</p></section>"
+            f"<section class='card'><h2>Compiled Summary</h2><p>{escape(summary_text)}</p></section>"
             f"<section class='card'><h2>Claims</h2><ul>{claims}</ul></section>"
             f"<section class='card'><h2>Relations</h2><ul>{relations}</ul></section>"
             f"<section class='card'><h2>Contradictions</h2><ul>{contradictions}</ul></section>"

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import argparse
+import json
+from html import escape
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+from ..runtime import resolve_vault_dir
+from ..ui.view_models import (
+    build_contradiction_browser_payload,
+    build_event_dossier_payload,
+    build_object_page_payload,
+    build_objects_index_payload,
+    build_topic_overview_payload,
+)
+
+
+HTML_SHELL = """<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>OpenClaw Truth UI</title>
+    <style>
+      body { font-family: ui-sans-serif, system-ui, sans-serif; margin: 2rem; line-height: 1.5; max-width: 980px; }
+      code { background: #f4f4f5; padding: 0.1rem 0.3rem; border-radius: 4px; }
+      ul { padding-left: 1.2rem; }
+      nav { margin-bottom: 1.5rem; }
+      nav a { margin-right: 1rem; }
+      section { margin-top: 1.5rem; }
+      .muted { color: #52525b; }
+    </style>
+  </head>
+  <body>
+    <h1>OpenClaw Truth UI</h1>
+    <p>Minimal read-only shell over <code>knowledge.db</code>.</p>
+    <nav>
+      <a href="/objects">Objects</a>
+      <a href="/events">Event Dossier</a>
+      <a href="/contradictions">Contradictions</a>
+    </nav>
+    <p class="muted">JSON APIs remain available at <code>/api/*</code>, including <code>/api/objects</code>.</p>
+  </body>
+</html>
+"""
+
+
+def _layout(title: str, body: str) -> str:
+    return f"""<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{escape(title)}</title>
+    <style>
+      body {{ font-family: ui-sans-serif, system-ui, sans-serif; margin: 2rem; line-height: 1.5; max-width: 980px; }}
+      nav {{ margin-bottom: 1.5rem; }}
+      nav a {{ margin-right: 1rem; }}
+      h1, h2 {{ margin-bottom: 0.5rem; }}
+      ul {{ padding-left: 1.2rem; }}
+      pre {{ background: #f4f4f5; padding: 1rem; border-radius: 8px; overflow-x: auto; }}
+      .muted {{ color: #52525b; }}
+      .card {{ border: 1px solid #e4e4e7; border-radius: 10px; padding: 1rem; margin-bottom: 1rem; }}
+      .pill {{ display: inline-block; padding: 0.15rem 0.5rem; border-radius: 999px; background: #eef2ff; margin-right: 0.5rem; }}
+    </style>
+  </head>
+  <body>
+    <nav>
+      <a href="/">Home</a>
+      <a href="/objects">Objects</a>
+      <a href="/events">Event Dossier</a>
+      <a href="/contradictions">Contradictions</a>
+    </nav>
+    {body}
+  </body>
+</html>
+"""
+
+
+def _render_objects_index(payload: dict) -> str:
+    items = "".join(
+        f'<li><a href="/object?id={escape(item["object_id"])}">{escape(item["title"])}</a> '
+        f'<span class="muted">({escape(item["object_id"])})</span></li>'
+        for item in payload["items"]
+    )
+    return _layout(
+        "Objects",
+        f"<h1>Objects</h1><p class='muted'>{payload['count']} objects in current page.</p><ul>{items}</ul>",
+    )
+
+
+def _render_object_page(payload: dict) -> str:
+    claims = "".join(f"<li>{escape(item['claim_text'])}</li>" for item in payload["claims"]) or "<li>None</li>"
+    relations = "".join(
+        f'<li><a href="/object?id={escape(item["target_object_id"])}">{escape(item.get("target_title", item["target_object_id"]))}</a>'
+        f' <span class="muted">({escape(item["relation_type"])})</span></li>'
+        for item in payload["relations"]
+    ) or "<li>None</li>"
+    contradictions = "".join(
+        f'<li><span class="pill">{escape(item["status"])}</span>{escape(item["subject_key"])}</li>'
+        for item in payload["contradictions"]
+    ) or "<li>None</li>"
+    return _layout(
+        f"Object: {payload['object']['title']}",
+        (
+            f"<h1>Object: {escape(payload['object']['title'])}</h1>"
+            f"<p class='muted'>{escape(payload['object']['object_id'])}</p>"
+            f"<section class='card'><h2>Compiled Summary</h2><p>{escape(payload['summary']['summary_text'])}</p></section>"
+            f"<section class='card'><h2>Claims</h2><ul>{claims}</ul></section>"
+            f"<section class='card'><h2>Relations</h2><ul>{relations}</ul></section>"
+            f"<section class='card'><h2>Contradictions</h2><ul>{contradictions}</ul></section>"
+        ),
+    )
+
+
+def _render_topic_page(payload: dict) -> str:
+    neighbors = "".join(
+        f'<li><a href="/object?id={escape(item["object_id"])}">{escape(item["title"])}</a></li>'
+        for item in payload["neighbors"]
+    ) or "<li>None</li>"
+    return _layout(
+        f"Topic: {payload['center']['title']}",
+        (
+            f"<h1>Topic: {escape(payload['center']['title'])}</h1>"
+            f"<p class='muted'>{payload['neighbor_count']} neighbors, {payload['edge_count']} edges.</p>"
+            f"<section class='card'><h2>Neighbors</h2><ul>{neighbors}</ul></section>"
+        ),
+    )
+
+
+def _render_events_page(payload: dict) -> str:
+    events = "".join(
+        f"<li>{escape(item['event_date'])} - "
+        f'<a href="/object?id={escape(item["object_id"])}">{escape(item["title"])}</a></li>'
+        for item in payload["events"]
+    ) or "<li>None</li>"
+    return _layout(
+        "Event Dossier",
+        (
+            f"<h1>Event Dossier</h1>"
+            f"<p class='muted'>{payload['event_count']} events across {len(payload['dates'])} dates.</p>"
+            f"<section class='card'><ul>{events}</ul></section>"
+        ),
+    )
+
+
+def _render_contradictions_page(payload: dict) -> str:
+    items = "".join(
+        f"<li><span class='pill'>{escape(item['status'])}</span>{escape(item['subject_key'])}</li>"
+        for item in payload["items"]
+    ) or "<li>None</li>"
+    return _layout(
+        "Contradictions",
+        (
+            f"<h1>Contradictions</h1>"
+            f"<p class='muted'>{payload['count']} records, {payload['open_count']} open.</p>"
+            f"<section class='card'><ul>{items}</ul></section>"
+        ),
+    )
+
+
+def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int = 8787) -> ThreadingHTTPServer:
+    resolved_vault = resolve_vault_dir(vault_dir)
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, format: str, *args) -> None:  # pragma: no cover
+            return
+
+        def do_GET(self) -> None:  # noqa: N802
+            parsed = urlparse(self.path)
+            path = parsed.path
+            query = parse_qs(parsed.query)
+
+            try:
+                if path == "/":
+                    self._write_html(HTML_SHELL)
+                    return
+                if path == "/api/objects":
+                    limit = int(query.get("limit", ["100"])[0])
+                    offset = int(query.get("offset", ["0"])[0])
+                    self._write_json(build_objects_index_payload(resolved_vault, limit=limit, offset=offset))
+                    return
+                if path == "/objects":
+                    limit = int(query.get("limit", ["100"])[0])
+                    offset = int(query.get("offset", ["0"])[0])
+                    payload = build_objects_index_payload(resolved_vault, limit=limit, offset=offset)
+                    self._write_html(_render_objects_index(payload))
+                    return
+                if path == "/api/object":
+                    object_id = self._required(query, "id")
+                    self._write_json(build_object_page_payload(resolved_vault, object_id))
+                    return
+                if path == "/object":
+                    object_id = self._required(query, "id")
+                    payload = build_object_page_payload(resolved_vault, object_id)
+                    self._write_html(_render_object_page(payload))
+                    return
+                if path == "/api/topic":
+                    object_id = self._required(query, "id")
+                    self._write_json(build_topic_overview_payload(resolved_vault, object_id))
+                    return
+                if path == "/topic":
+                    object_id = self._required(query, "id")
+                    payload = build_topic_overview_payload(resolved_vault, object_id)
+                    self._write_html(_render_topic_page(payload))
+                    return
+                if path == "/api/events":
+                    self._write_json(build_event_dossier_payload(resolved_vault))
+                    return
+                if path == "/events":
+                    payload = build_event_dossier_payload(resolved_vault)
+                    self._write_html(_render_events_page(payload))
+                    return
+                if path == "/api/contradictions":
+                    self._write_json(build_contradiction_browser_payload(resolved_vault))
+                    return
+                if path == "/contradictions":
+                    payload = build_contradiction_browser_payload(resolved_vault)
+                    self._write_html(_render_contradictions_page(payload))
+                    return
+                self.send_error(404, "Not Found")
+            except ValueError as exc:
+                self.send_error(400, str(exc))
+
+        def _required(self, query: dict[str, list[str]], key: str) -> str:
+            values = query.get(key)
+            if not values or not values[0]:
+                raise ValueError(f"missing required query param: {key}")
+            return values[0]
+
+        def _write_json(self, payload: dict) -> None:
+            body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def _write_html(self, html: str) -> None:
+            body = html.encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    return ThreadingHTTPServer((host, port), Handler)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run a minimal local UI over knowledge.db")
+    parser.add_argument("--vault-dir", type=Path, default=None, help="Vault directory")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8787)
+    args = parser.parse_args(argv)
+
+    server = create_server(resolve_vault_dir(args.vault_dir), host=args.host, port=args.port)
+    print(json.dumps({"host": args.host, "port": args.port, "vault_dir": str(resolve_vault_dir(args.vault_dir))}))
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:  # pragma: no cover
+        pass
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from html import escape
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -256,8 +257,16 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--port", type=int, default=8787)
     args = parser.parse_args(argv)
 
-    server = create_server(resolve_vault_dir(args.vault_dir), host=args.host, port=args.port)
-    print(json.dumps({"host": args.host, "port": args.port, "vault_dir": str(resolve_vault_dir(args.vault_dir))}))
+    resolved_vault = resolve_vault_dir(args.vault_dir)
+    server = create_server(resolved_vault, host=args.host, port=args.port)
+    try:
+        build_objects_index_payload(resolved_vault, limit=1, offset=0)
+    except Exception as exc:
+        print(f"ui server preflight failed: {exc}", file=sys.stderr)
+        server.server_close()
+        return 1
+
+    print(json.dumps({"host": args.host, "port": args.port, "vault_dir": str(resolved_vault)}), flush=True)
     try:
         server.serve_forever()
     except KeyboardInterrupt:  # pragma: no cover

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -7,13 +7,24 @@ from typing import Any
 
 from .runtime import VaultLayout, resolve_vault_dir
 
+MAX_PAGE_SIZE = 500
+
 
 def _db_path(vault_dir: Path | str) -> Path:
     resolved = resolve_vault_dir(vault_dir)
     return VaultLayout.from_vault(resolved).knowledge_db
 
 
+def _validate_page_args(*, limit: int, offset: int = 0) -> tuple[int, int]:
+    if limit < 0 or offset < 0:
+        raise ValueError("limit and offset must be >= 0")
+    if limit > MAX_PAGE_SIZE:
+        raise ValueError(f"limit must be <= {MAX_PAGE_SIZE}")
+    return limit, offset
+
+
 def list_objects(vault_dir: Path | str, *, limit: int = 100, offset: int = 0) -> list[dict[str, Any]]:
+    limit, offset = _validate_page_args(limit=limit, offset=offset)
     db_path = _db_path(vault_dir)
     with sqlite3.connect(db_path) as conn:
         rows = conn.execute(
@@ -98,7 +109,7 @@ def get_object_detail(vault_dir: Path | str, object_id: str) -> dict[str, Any]:
             WHERE positive_claim_ids_json LIKE ? ESCAPE '\\' OR negative_claim_ids_json LIKE ? ESCAPE '\\'
             ORDER BY subject_key
             """,
-            (f"%{escaped}::%", f"%{escaped}::%"),
+            (f'%"{escaped}::%', f'%"{escaped}::%'),
         ).fetchall()
 
     return {
@@ -161,6 +172,7 @@ def get_object_detail(vault_dir: Path | str, object_id: str) -> dict[str, Any]:
 
 
 def list_contradictions(vault_dir: Path | str, *, limit: int = 100, status: str | None = None) -> list[dict[str, Any]]:
+    limit, _ = _validate_page_args(limit=limit, offset=0)
     db_path = _db_path(vault_dir)
     query = """
         SELECT contradiction_id, subject_key, positive_claim_ids_json, negative_claim_ids_json, status, resolution_note, resolved_at

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from .runtime import VaultLayout, resolve_vault_dir
+
+
+def _db_path(vault_dir: Path | str) -> Path:
+    resolved = resolve_vault_dir(vault_dir)
+    return VaultLayout.from_vault(resolved).knowledge_db
+
+
+def list_objects(vault_dir: Path | str, *, limit: int = 100, offset: int = 0) -> list[dict[str, Any]]:
+    db_path = _db_path(vault_dir)
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT object_id, object_kind, title, canonical_path, source_slug
+            FROM objects
+            ORDER BY object_id
+            LIMIT ? OFFSET ?
+            """,
+            (limit, offset),
+        ).fetchall()
+
+    return [
+        {
+            "object_id": row[0],
+            "object_kind": row[1],
+            "title": row[2],
+            "canonical_path": row[3],
+            "source_slug": row[4],
+        }
+        for row in rows
+    ]
+
+
+def get_object_detail(vault_dir: Path | str, object_id: str) -> dict[str, Any]:
+    db_path = _db_path(vault_dir)
+    escaped = object_id.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+    with sqlite3.connect(db_path) as conn:
+        object_row = conn.execute(
+            """
+            SELECT object_id, object_kind, title, canonical_path, source_slug
+            FROM objects
+            WHERE object_id = ?
+            """,
+            (object_id,),
+        ).fetchone()
+        if object_row is None:
+            raise ValueError(f"Unknown object_id: {object_id}")
+
+        summary_row = conn.execute(
+            """
+            SELECT object_id, summary_text, source_slug
+            FROM compiled_summaries
+            WHERE object_id = ?
+            """,
+            (object_id,),
+        ).fetchone()
+        claim_rows = conn.execute(
+            """
+            SELECT claim_id, claim_kind, claim_text, confidence
+            FROM claims
+            WHERE object_id = ?
+            ORDER BY claim_id
+            """,
+            (object_id,),
+        ).fetchall()
+        evidence_rows = conn.execute(
+            """
+            SELECT claim_id, source_slug, evidence_kind, quote_text
+            FROM claim_evidence
+            WHERE claim_id IN (
+                SELECT claim_id FROM claims WHERE object_id = ?
+            )
+            ORDER BY claim_id, evidence_kind
+            """,
+            (object_id,),
+        ).fetchall()
+        relation_rows = conn.execute(
+            """
+            SELECT source_object_id, target_object_id, relation_type, evidence_source_slug
+            FROM relations
+            WHERE source_object_id = ?
+            ORDER BY target_object_id
+            """,
+            (object_id,),
+        ).fetchall()
+        contradiction_rows = conn.execute(
+            """
+            SELECT contradiction_id, subject_key, positive_claim_ids_json, negative_claim_ids_json, status, resolution_note, resolved_at
+            FROM contradictions
+            WHERE positive_claim_ids_json LIKE ? ESCAPE '\\' OR negative_claim_ids_json LIKE ? ESCAPE '\\'
+            ORDER BY subject_key
+            """,
+            (f"%{escaped}::%", f"%{escaped}::%"),
+        ).fetchall()
+
+    return {
+        "object": {
+            "object_id": object_row[0],
+            "object_kind": object_row[1],
+            "title": object_row[2],
+            "canonical_path": object_row[3],
+            "source_slug": object_row[4],
+        },
+        "summary": (
+            {
+                "object_id": summary_row[0],
+                "summary_text": summary_row[1],
+                "source_slug": summary_row[2],
+            }
+            if summary_row
+            else None
+        ),
+        "claims": [
+            {
+                "claim_id": row[0],
+                "claim_kind": row[1],
+                "claim_text": row[2],
+                "confidence": row[3],
+            }
+            for row in claim_rows
+        ],
+        "evidence": [
+            {
+                "claim_id": row[0],
+                "source_slug": row[1],
+                "evidence_kind": row[2],
+                "quote_text": row[3],
+            }
+            for row in evidence_rows
+        ],
+        "relations": [
+            {
+                "source_object_id": row[0],
+                "target_object_id": row[1],
+                "relation_type": row[2],
+                "evidence_source_slug": row[3],
+            }
+            for row in relation_rows
+        ],
+        "contradictions": [
+            {
+                "contradiction_id": row[0],
+                "subject_key": row[1],
+                "positive_claim_ids": json.loads(row[2]),
+                "negative_claim_ids": json.loads(row[3]),
+                "status": row[4],
+                "resolution_note": row[5] or "",
+                "resolved_at": row[6] or "",
+            }
+            for row in contradiction_rows
+        ],
+    }
+
+
+def list_contradictions(vault_dir: Path | str, *, limit: int = 100, status: str | None = None) -> list[dict[str, Any]]:
+    db_path = _db_path(vault_dir)
+    query = """
+        SELECT contradiction_id, subject_key, positive_claim_ids_json, negative_claim_ids_json, status, resolution_note, resolved_at
+        FROM contradictions
+    """
+    params: list[Any] = []
+    if status:
+        query += " WHERE status = ?"
+        params.append(status)
+    query += " ORDER BY subject_key LIMIT ?"
+    params.append(limit)
+
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(query, tuple(params)).fetchall()
+
+    return [
+        {
+            "contradiction_id": row[0],
+            "subject_key": row[1],
+            "positive_claim_ids": json.loads(row[2]),
+            "negative_claim_ids": json.loads(row[3]),
+            "status": row[4],
+            "resolution_note": row[5] or "",
+            "resolved_at": row[6] or "",
+        }
+        for row in rows
+    ]
+
+
+def get_topic_neighborhood(vault_dir: Path | str, object_id: str, *, depth: int = 1) -> dict[str, Any]:
+    if depth != 1:
+        raise ValueError("Only depth=1 is currently supported")
+
+    db_path = _db_path(vault_dir)
+    with sqlite3.connect(db_path) as conn:
+        center = conn.execute(
+            """
+            SELECT object_id, object_kind, title, canonical_path, source_slug
+            FROM objects
+            WHERE object_id = ?
+            """,
+            (object_id,),
+        ).fetchone()
+        if center is None:
+            raise ValueError(f"Unknown object_id: {object_id}")
+
+        edge_rows = conn.execute(
+            """
+            SELECT source_object_id, target_object_id, relation_type, evidence_source_slug
+            FROM relations
+            WHERE source_object_id = ?
+            ORDER BY target_object_id
+            """,
+            (object_id,),
+        ).fetchall()
+        neighbor_ids = [row[1] for row in edge_rows]
+        if neighbor_ids:
+            placeholders = ",".join("?" for _ in neighbor_ids)
+            neighbor_rows = conn.execute(
+                f"""
+                SELECT object_id, object_kind, title, canonical_path, source_slug
+                FROM objects
+                WHERE object_id IN ({placeholders})
+                ORDER BY object_id
+                """,
+                tuple(neighbor_ids),
+            ).fetchall()
+        else:
+            neighbor_rows = []
+
+    return {
+        "center": {
+            "object_id": center[0],
+            "object_kind": center[1],
+            "title": center[2],
+            "canonical_path": center[3],
+            "source_slug": center[4],
+        },
+        "neighbors": [
+            {
+                "object_id": row[0],
+                "object_kind": row[1],
+                "title": row[2],
+                "canonical_path": row[3],
+                "source_slug": row[4],
+            }
+            for row in neighbor_rows
+        ],
+        "edges": [
+            {
+                "source_object_id": row[0],
+                "target_object_id": row[1],
+                "relation_type": row[2],
+                "evidence_source_slug": row[3],
+            }
+            for row in edge_rows
+        ],
+    }

--- a/src/openclaw_pipeline/ui/__init__.py
+++ b/src/openclaw_pipeline/ui/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -16,11 +16,21 @@ def _db_path(vault_dir: Path | str) -> Path:
 
 def build_object_page_payload(vault_dir: Path | str, object_id: str) -> dict[str, Any]:
     detail = get_object_detail(vault_dir, object_id)
+    neighborhood = get_topic_neighborhood(vault_dir, object_id)
+    neighbor_titles = {item["object_id"]: item["title"] for item in neighborhood["neighbors"]}
+    relations = [
+        {
+            **item,
+            "target_title": neighbor_titles.get(item["target_object_id"], item["target_object_id"]),
+        }
+        for item in detail["relations"]
+    ]
     return {
         "screen": "object/page",
         **detail,
+        "relations": relations,
         "claim_count": len(detail["claims"]),
-        "relation_count": len(detail["relations"]),
+        "relation_count": len(relations),
         "contradiction_count": len(detail["contradictions"]),
         "evidence_count": len(detail["evidence"]),
     }

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import sqlite3
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from ..runtime import VaultLayout, resolve_vault_dir
+from ..truth_api import get_object_detail, get_topic_neighborhood, list_contradictions, list_objects
+
+
+def _db_path(vault_dir: Path | str) -> Path:
+    resolved = resolve_vault_dir(vault_dir)
+    return VaultLayout.from_vault(resolved).knowledge_db
+
+
+def build_object_page_payload(vault_dir: Path | str, object_id: str) -> dict[str, Any]:
+    detail = get_object_detail(vault_dir, object_id)
+    return {
+        "screen": "object/page",
+        **detail,
+        "claim_count": len(detail["claims"]),
+        "relation_count": len(detail["relations"]),
+        "contradiction_count": len(detail["contradictions"]),
+        "evidence_count": len(detail["evidence"]),
+    }
+
+
+def build_topic_overview_payload(vault_dir: Path | str, object_id: str) -> dict[str, Any]:
+    neighborhood = get_topic_neighborhood(vault_dir, object_id)
+    return {
+        "screen": "overview/topic",
+        **neighborhood,
+        "edge_count": len(neighborhood["edges"]),
+        "neighbor_count": len(neighborhood["neighbors"]),
+    }
+
+
+def build_event_dossier_payload(vault_dir: Path | str) -> dict[str, Any]:
+    db_path = _db_path(vault_dir)
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT timeline_events.event_date, timeline_events.event_type, objects.object_id, objects.title, compiled_summaries.summary_text
+            FROM timeline_events
+            JOIN objects ON objects.object_id = timeline_events.slug
+            LEFT JOIN compiled_summaries ON compiled_summaries.object_id = objects.object_id
+            ORDER BY timeline_events.event_date, objects.object_id
+            """
+        ).fetchall()
+
+    events = [
+        {
+            "event_date": row[0],
+            "event_type": row[1],
+            "object_id": row[2],
+            "title": row[3],
+            "summary_text": row[4] or "",
+        }
+        for row in rows
+    ]
+    dates = sorted({event["event_date"] for event in events})
+    return {
+        "screen": "event/dossier",
+        "events": events,
+        "event_count": len(events),
+        "dates": dates,
+    }
+
+
+def build_contradiction_browser_payload(vault_dir: Path | str) -> dict[str, Any]:
+    items = list_contradictions(vault_dir)
+    status_counts = Counter(item["status"] for item in items)
+    return {
+        "screen": "truth/contradictions",
+        "items": items,
+        "count": len(items),
+        "open_count": status_counts.get("open", 0),
+        "resolved_count": sum(count for status, count in status_counts.items() if status != "open"),
+    }
+
+
+def build_objects_index_payload(vault_dir: Path | str, *, limit: int = 100, offset: int = 0) -> dict[str, Any]:
+    items = list_objects(vault_dir, limit=limit, offset=offset)
+    return {
+        "screen": "objects/index",
+        "items": items,
+        "count": len(items),
+        "limit": limit,
+        "offset": offset,
+    }

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
+
+
+def _seed_truth_vault(temp_vault):
+    source = temp_vault / "10-Knowledge" / "Evergreen" / "Source.md"
+    target = temp_vault / "10-Knowledge" / "Evergreen" / "Target.md"
+    negative = temp_vault / "10-Knowledge" / "Evergreen" / "Negative.md"
+
+    source.write_text(
+        """---
+note_id: source-note
+title: Source Note
+type: evergreen
+date: 2026-04-13
+---
+
+# Source Note
+
+Agent harness supports local-first execution for operators.
+
+Links to [[target-note]].
+""",
+        encoding="utf-8",
+    )
+    target.write_text(
+        """---
+note_id: target-note
+title: Target Note
+type: evergreen
+date: 2026-04-13
+---
+
+# Target Note
+
+Target note captures downstream effects.
+""",
+        encoding="utf-8",
+    )
+    negative.write_text(
+        """---
+note_id: negative-note
+title: Negative Note
+type: evergreen
+date: 2026-04-13
+---
+
+# Negative Note
+
+Agent harness does not support local-first execution for operators.
+""",
+        encoding="utf-8",
+    )
+
+    rebuild_knowledge_index(temp_vault)
+    return temp_vault
+
+
+def test_truth_api_lists_objects(temp_vault):
+    from openclaw_pipeline.truth_api import list_objects
+
+    vault = _seed_truth_vault(temp_vault)
+
+    objects = list_objects(vault)
+
+    assert [item["object_id"] for item in objects] == [
+        "negative-note",
+        "source-note",
+        "target-note",
+    ]
+    assert objects[1]["title"] == "Source Note"
+    assert objects[1]["object_kind"] == "evergreen"
+
+
+def test_truth_api_returns_object_detail_with_claims_relations_and_summary(temp_vault):
+    from openclaw_pipeline.truth_api import get_object_detail
+
+    vault = _seed_truth_vault(temp_vault)
+
+    detail = get_object_detail(vault, "source-note")
+
+    assert detail["object"]["object_id"] == "source-note"
+    assert detail["summary"]["summary_text"] == "Agent harness supports local-first execution for operators."
+    assert detail["claims"][0]["claim_kind"] == "page_summary"
+    assert detail["relations"][0]["target_object_id"] == "target-note"
+    assert detail["evidence"][0]["evidence_kind"] == "body_summary"
+    assert detail["contradictions"][0]["subject_key"] == "agent harness"
+
+
+def test_truth_api_lists_contradictions(temp_vault):
+    from openclaw_pipeline.truth_api import list_contradictions
+
+    vault = _seed_truth_vault(temp_vault)
+
+    items = list_contradictions(vault)
+
+    assert len(items) == 1
+    assert items[0]["subject_key"] == "agent harness"
+    assert items[0]["status"] == "open"
+    assert items[0]["positive_claim_ids"]
+    assert items[0]["negative_claim_ids"]
+
+
+def test_truth_api_builds_topic_neighborhood(temp_vault):
+    from openclaw_pipeline.truth_api import get_topic_neighborhood
+
+    vault = _seed_truth_vault(temp_vault)
+
+    neighborhood = get_topic_neighborhood(vault, "source-note")
+
+    assert neighborhood["center"]["object_id"] == "source-note"
+    assert [item["object_id"] for item in neighborhood["neighbors"]] == ["target-note"]
+    assert neighborhood["edges"] == [
+        {
+            "source_object_id": "source-note",
+            "target_object_id": "target-note",
+            "relation_type": "wikilink",
+            "evidence_source_slug": "source-note",
+        }
+    ]

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -119,3 +119,80 @@ def test_truth_api_builds_topic_neighborhood(temp_vault):
             "evidence_source_slug": "source-note",
         }
     ]
+
+
+def test_truth_api_rejects_negative_pagination_inputs(temp_vault):
+    from openclaw_pipeline.truth_api import list_contradictions, list_objects
+
+    vault = _seed_truth_vault(temp_vault)
+
+    for kwargs in ({"limit": -1}, {"offset": -1}, {"limit": -1, "offset": -1}):
+        try:
+            list_objects(vault, **kwargs)
+        except ValueError as exc:
+            assert "must be >= 0" in str(exc)
+        else:
+            raise AssertionError(f"Expected ValueError for {kwargs}")
+
+    try:
+        list_contradictions(vault, limit=-1)
+    except ValueError as exc:
+        assert "must be >= 0" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError for negative contradiction limit")
+
+
+def test_truth_api_matches_contradictions_by_exact_object_id_prefix(temp_vault):
+    from openclaw_pipeline.truth_api import get_object_detail
+
+    alpha = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
+    alpha_one = temp_vault / "10-Knowledge" / "Evergreen" / "AlphaOne.md"
+    alpha_neg = temp_vault / "10-Knowledge" / "Evergreen" / "AlphaNeg.md"
+
+    alpha.write_text(
+        """---
+note_id: alpha
+title: Alpha
+type: evergreen
+date: 2026-04-13
+---
+
+# Alpha
+
+Alpha supports local-first execution.
+""",
+        encoding="utf-8",
+    )
+    alpha_one.write_text(
+        """---
+note_id: alpha-one
+title: Alpha One
+type: evergreen
+date: 2026-04-13
+---
+
+# Alpha One
+
+Alpha one supports local-first execution.
+""",
+        encoding="utf-8",
+    )
+    alpha_neg.write_text(
+        """---
+note_id: alpha-one-negative
+title: Alpha One Negative
+type: evergreen
+date: 2026-04-13
+---
+
+# Alpha One Negative
+
+Alpha one does not support local-first execution.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    detail = get_object_detail(temp_vault, "alpha")
+
+    assert detail["contradictions"] == []

--- a/tests/test_truth_api_command.py
+++ b/tests/test_truth_api_command.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import pytest
 
 from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
 
@@ -106,3 +107,29 @@ def test_truth_api_command_returns_neighborhood(temp_vault, capsys):
     assert exit_code == 0
     assert payload["center"]["object_id"] == "alpha"
     assert [item["object_id"] for item in payload["neighbors"]] == ["beta"]
+
+
+def test_truth_api_command_reports_unknown_object_as_cli_error(temp_vault, capsys):
+    from openclaw_pipeline.commands.truth_api import main
+
+    _seed_truth_store(temp_vault)
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(["object", "--vault-dir", str(temp_vault), "--id", "missing"])
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 2
+    assert "Unknown object_id: missing" in captured.err
+
+
+def test_truth_api_command_rejects_unsupported_depth(temp_vault, capsys):
+    from openclaw_pipeline.commands.truth_api import main
+
+    _seed_truth_store(temp_vault)
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(["neighborhood", "--vault-dir", str(temp_vault), "--id", "alpha", "--depth", "2"])
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 2
+    assert "Only depth=1 is currently supported" in captured.err

--- a/tests/test_truth_api_command.py
+++ b/tests/test_truth_api_command.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+
+from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
+
+
+def _seed_truth_store(temp_vault):
+    alpha = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
+    beta = temp_vault / "10-Knowledge" / "Evergreen" / "Beta.md"
+    conflict = temp_vault / "10-Knowledge" / "Evergreen" / "Conflict.md"
+
+    alpha.write_text(
+        """---
+note_id: alpha
+title: Alpha
+type: evergreen
+date: 2026-04-13
+---
+
+# Alpha
+
+Alpha supports local-first execution.
+
+Links to [[beta]].
+""",
+        encoding="utf-8",
+    )
+    beta.write_text(
+        """---
+note_id: beta
+title: Beta
+type: evergreen
+date: 2026-04-13
+---
+
+# Beta
+
+Beta extends Alpha.
+""",
+        encoding="utf-8",
+    )
+    conflict.write_text(
+        """---
+note_id: conflict
+title: Conflict
+type: evergreen
+date: 2026-04-13
+---
+
+# Conflict
+
+Alpha does not support local-first execution.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+
+def test_truth_api_command_lists_objects(temp_vault, capsys):
+    from openclaw_pipeline.commands.truth_api import main
+
+    _seed_truth_store(temp_vault)
+
+    exit_code = main(["objects", "--vault-dir", str(temp_vault)])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert [item["object_id"] for item in payload["items"]] == ["alpha", "beta", "conflict"]
+
+
+def test_truth_api_command_returns_object_detail(temp_vault, capsys):
+    from openclaw_pipeline.commands.truth_api import main
+
+    _seed_truth_store(temp_vault)
+
+    exit_code = main(["object", "--vault-dir", str(temp_vault), "--id", "alpha"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["object"]["object_id"] == "alpha"
+    assert payload["relations"][0]["target_object_id"] == "beta"
+
+
+def test_truth_api_command_lists_contradictions(temp_vault, capsys):
+    from openclaw_pipeline.commands.truth_api import main
+
+    _seed_truth_store(temp_vault)
+
+    exit_code = main(["contradictions", "--vault-dir", str(temp_vault)])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert len(payload["items"]) == 1
+    assert payload["items"][0]["subject_key"] == "alpha"
+
+
+def test_truth_api_command_returns_neighborhood(temp_vault, capsys):
+    from openclaw_pipeline.commands.truth_api import main
+
+    _seed_truth_store(temp_vault)
+
+    exit_code = main(["neighborhood", "--vault-dir", str(temp_vault), "--id", "alpha"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["center"]["object_id"] == "alpha"
+    assert [item["object_id"] for item in payload["neighbors"]] == ["beta"]

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import json
+import threading
+from contextlib import closing
+from http.client import HTTPConnection
+from socket import socket
+
+from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
+
+
+def _seed_truth_store(temp_vault):
+    alpha = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
+    beta = temp_vault / "10-Knowledge" / "Evergreen" / "Beta.md"
+    conflict = temp_vault / "10-Knowledge" / "Evergreen" / "Conflict.md"
+
+    alpha.write_text(
+        """---
+note_id: alpha
+title: Alpha
+type: evergreen
+date: 2026-04-13
+---
+
+# Alpha
+
+Alpha supports local-first execution.
+
+Links to [[beta]].
+""",
+        encoding="utf-8",
+    )
+    beta.write_text(
+        """---
+note_id: beta
+title: Beta
+type: evergreen
+date: 2026-04-13
+---
+
+# Beta
+
+Beta extends Alpha.
+""",
+        encoding="utf-8",
+    )
+    conflict.write_text(
+        """---
+note_id: conflict
+title: Conflict
+type: evergreen
+date: 2026-04-13
+---
+
+# Conflict
+
+Alpha does not support local-first execution.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+
+def _free_port() -> int:
+    with closing(socket()) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def test_ui_server_root_serves_html_shell(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+
+    _seed_truth_store(temp_vault)
+    port = _free_port()
+    server = create_server(temp_vault, host="127.0.0.1", port=port)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("GET", "/")
+        response = conn.getresponse()
+        body = response.read().decode("utf-8")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 200
+    assert "OpenClaw Truth UI" in body
+    assert "/api/objects" in body
+
+
+def test_ui_server_objects_endpoint_returns_json(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+
+    _seed_truth_store(temp_vault)
+    port = _free_port()
+    server = create_server(temp_vault, host="127.0.0.1", port=port)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("GET", "/api/objects")
+        response = conn.getresponse()
+        payload = json.loads(response.read().decode("utf-8"))
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 200
+    assert [item["object_id"] for item in payload["items"]] == ["alpha", "beta", "conflict"]
+
+
+def test_ui_server_object_endpoint_returns_detail_payload(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+
+    _seed_truth_store(temp_vault)
+    port = _free_port()
+    server = create_server(temp_vault, host="127.0.0.1", port=port)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("GET", "/api/object?id=alpha")
+        response = conn.getresponse()
+        payload = json.loads(response.read().decode("utf-8"))
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 200
+    assert payload["object"]["object_id"] == "alpha"
+    assert payload["relation_count"] == 1
+
+
+def test_ui_server_contradictions_endpoint_returns_payload(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+
+    _seed_truth_store(temp_vault)
+    port = _free_port()
+    server = create_server(temp_vault, host="127.0.0.1", port=port)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("GET", "/api/contradictions")
+        response = conn.getresponse()
+        payload = json.loads(response.read().decode("utf-8"))
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 200
+    assert payload["count"] == 1
+    assert payload["items"][0]["subject_key"] == "alpha"
+
+
+def test_ui_server_topic_and_events_endpoints_return_payloads(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+
+    _seed_truth_store(temp_vault)
+    port = _free_port()
+    server = create_server(temp_vault, host="127.0.0.1", port=port)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("GET", "/api/topic?id=alpha")
+        topic_response = conn.getresponse()
+        topic_payload = json.loads(topic_response.read().decode("utf-8"))
+
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("GET", "/api/events")
+        event_response = conn.getresponse()
+        event_payload = json.loads(event_response.read().decode("utf-8"))
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert topic_response.status == 200
+    assert topic_payload["center"]["object_id"] == "alpha"
+    assert event_response.status == 200
+    assert event_payload["event_count"] == 3
+
+
+def test_ui_server_main_starts_server_with_requested_bind(temp_vault, capsys, monkeypatch):
+    from openclaw_pipeline.commands.ui_server import main
+
+    calls = {}
+
+    class FakeServer:
+        def serve_forever(self):
+            raise KeyboardInterrupt
+
+        def server_close(self):
+            calls["closed"] = True
+
+    def fake_create_server(vault_dir, *, host, port):
+        calls["vault_dir"] = str(vault_dir)
+        calls["host"] = host
+        calls["port"] = port
+        return FakeServer()
+
+    monkeypatch.setattr("openclaw_pipeline.commands.ui_server.create_server", fake_create_server)
+
+    exit_code = main(["--vault-dir", str(temp_vault), "--host", "127.0.0.1", "--port", "9999"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload == {"host": "127.0.0.1", "port": 9999, "vault_dir": str(temp_vault)}
+    assert calls == {
+        "vault_dir": str(temp_vault),
+        "host": "127.0.0.1",
+        "port": 9999,
+        "closed": True,
+    }

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 import json
 import threading
-from contextlib import closing
 from http.client import HTTPConnection
-from socket import socket
 
 from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
 
@@ -59,20 +57,12 @@ Alpha does not support local-first execution.
         encoding="utf-8",
     )
     rebuild_knowledge_index(temp_vault)
-
-
-def _free_port() -> int:
-    with closing(socket()) as sock:
-        sock.bind(("127.0.0.1", 0))
-        return sock.getsockname()[1]
-
-
 def test_ui_server_root_serves_html_shell(temp_vault):
     from openclaw_pipeline.commands.ui_server import create_server
 
     _seed_truth_store(temp_vault)
-    port = _free_port()
-    server = create_server(temp_vault, host="127.0.0.1", port=port)
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
@@ -94,8 +84,8 @@ def test_ui_server_objects_endpoint_returns_json(temp_vault):
     from openclaw_pipeline.commands.ui_server import create_server
 
     _seed_truth_store(temp_vault)
-    port = _free_port()
-    server = create_server(temp_vault, host="127.0.0.1", port=port)
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
@@ -116,8 +106,8 @@ def test_ui_server_object_endpoint_returns_detail_payload(temp_vault):
     from openclaw_pipeline.commands.ui_server import create_server
 
     _seed_truth_store(temp_vault)
-    port = _free_port()
-    server = create_server(temp_vault, host="127.0.0.1", port=port)
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
@@ -139,8 +129,8 @@ def test_ui_server_contradictions_endpoint_returns_payload(temp_vault):
     from openclaw_pipeline.commands.ui_server import create_server
 
     _seed_truth_store(temp_vault)
-    port = _free_port()
-    server = create_server(temp_vault, host="127.0.0.1", port=port)
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
@@ -162,8 +152,8 @@ def test_ui_server_topic_and_events_endpoints_return_payloads(temp_vault):
     from openclaw_pipeline.commands.ui_server import create_server
 
     _seed_truth_store(temp_vault)
-    port = _free_port()
-    server = create_server(temp_vault, host="127.0.0.1", port=port)
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
@@ -206,6 +196,10 @@ def test_ui_server_main_starts_server_with_requested_bind(temp_vault, capsys, mo
         return FakeServer()
 
     monkeypatch.setattr("openclaw_pipeline.commands.ui_server.create_server", fake_create_server)
+    monkeypatch.setattr(
+        "openclaw_pipeline.commands.ui_server.build_objects_index_payload",
+        lambda vault_dir, *, limit, offset: {"items": []},
+    )
 
     exit_code = main(["--vault-dir", str(temp_vault), "--host", "127.0.0.1", "--port", "9999"])
     payload = json.loads(capsys.readouterr().out)
@@ -218,3 +212,31 @@ def test_ui_server_main_starts_server_with_requested_bind(temp_vault, capsys, mo
         "port": 9999,
         "closed": True,
     }
+
+
+def test_ui_server_main_exits_nonzero_when_preflight_fails(temp_vault, capsys, monkeypatch):
+    from openclaw_pipeline.commands.ui_server import main
+
+    class FakeServer:
+        def serve_forever(self):
+            raise AssertionError("serve_forever should not run when preflight fails")
+
+        def server_close(self):
+            return None
+
+    monkeypatch.setattr(
+        "openclaw_pipeline.commands.ui_server.create_server",
+        lambda vault_dir, *, host, port: FakeServer(),
+    )
+
+    def boom(vault_dir, *, limit, offset):
+        raise ValueError("broken knowledge db")
+
+    monkeypatch.setattr("openclaw_pipeline.commands.ui_server.build_objects_index_payload", boom)
+
+    exit_code = main(["--vault-dir", str(temp_vault)])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert captured.out == ""
+    assert "broken knowledge db" in captured.err

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import threading
+from contextlib import closing
+from http.client import HTTPConnection
+from socket import socket
+
+from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
+
+
+def _seed_truth_store(temp_vault):
+    alpha = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
+    beta = temp_vault / "10-Knowledge" / "Evergreen" / "Beta.md"
+    conflict = temp_vault / "10-Knowledge" / "Evergreen" / "Conflict.md"
+
+    alpha.write_text(
+        """---
+note_id: alpha
+title: Alpha
+type: evergreen
+date: 2026-04-13
+---
+
+# Alpha
+
+Alpha supports local-first execution.
+
+Links to [[beta]].
+""",
+        encoding="utf-8",
+    )
+    beta.write_text(
+        """---
+note_id: beta
+title: Beta
+type: evergreen
+date: 2026-04-13
+---
+
+# Beta
+
+Beta extends Alpha.
+""",
+        encoding="utf-8",
+    )
+    conflict.write_text(
+        """---
+note_id: conflict
+title: Conflict
+type: evergreen
+date: 2026-04-13
+---
+
+# Conflict
+
+Alpha does not support local-first execution.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+
+def _free_port() -> int:
+    with closing(socket()) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _get(port: int, path: str) -> tuple[int, str]:
+    conn = HTTPConnection("127.0.0.1", port, timeout=5)
+    conn.request("GET", path)
+    response = conn.getresponse()
+    return response.status, response.read().decode("utf-8")
+
+
+def test_ui_smoke_pages_render_truth_views(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+
+    _seed_truth_store(temp_vault)
+    port = _free_port()
+    server = create_server(temp_vault, host="127.0.0.1", port=port)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        objects_status, objects_body = _get(port, "/objects")
+        object_status, object_body = _get(port, "/object?id=alpha")
+        topic_status, topic_body = _get(port, "/topic?id=alpha")
+        events_status, events_body = _get(port, "/events")
+        contradictions_status, contradictions_body = _get(port, "/contradictions")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert objects_status == 200
+    assert "Objects" in objects_body
+    assert "Alpha" in objects_body
+
+    assert object_status == 200
+    assert "Object: Alpha" in object_body
+    assert "Relations" in object_body
+    assert "Beta" in object_body
+
+    assert topic_status == 200
+    assert "Topic: Alpha" in topic_body
+    assert "Neighbors" in topic_body
+
+    assert events_status == 200
+    assert "Event Dossier" in events_body
+    assert "2026-04-13" in events_body
+
+    assert contradictions_status == 200
+    assert "Contradictions" in contradictions_body
+    assert "alpha" in contradictions_body

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 import threading
-from contextlib import closing
 from http.client import HTTPConnection
-from socket import socket
 
 from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
 
@@ -58,14 +56,6 @@ Alpha does not support local-first execution.
         encoding="utf-8",
     )
     rebuild_knowledge_index(temp_vault)
-
-
-def _free_port() -> int:
-    with closing(socket()) as sock:
-        sock.bind(("127.0.0.1", 0))
-        return sock.getsockname()[1]
-
-
 def _get(port: int, path: str) -> tuple[int, str]:
     conn = HTTPConnection("127.0.0.1", port, timeout=5)
     conn.request("GET", path)
@@ -77,8 +67,8 @@ def test_ui_smoke_pages_render_truth_views(temp_vault):
     from openclaw_pipeline.commands.ui_server import create_server
 
     _seed_truth_store(temp_vault)
-    port = _free_port()
-    server = create_server(temp_vault, host="127.0.0.1", port=port)
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
+
+
+def _seed_truth_store(temp_vault):
+    alpha = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
+    beta = temp_vault / "10-Knowledge" / "Evergreen" / "Beta.md"
+    conflict = temp_vault / "10-Knowledge" / "Evergreen" / "Conflict.md"
+
+    alpha.write_text(
+        """---
+note_id: alpha
+title: Alpha
+type: evergreen
+date: 2026-04-13
+---
+
+# Alpha
+
+Alpha supports local-first execution.
+
+Links to [[beta]].
+""",
+        encoding="utf-8",
+    )
+    beta.write_text(
+        """---
+note_id: beta
+title: Beta
+type: evergreen
+date: 2026-04-13
+---
+
+# Beta
+
+Beta extends Alpha.
+""",
+        encoding="utf-8",
+    )
+    conflict.write_text(
+        """---
+note_id: conflict
+title: Conflict
+type: evergreen
+date: 2026-04-13
+---
+
+# Conflict
+
+Alpha does not support local-first execution.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+
+def test_build_object_page_payload(temp_vault):
+    from openclaw_pipeline.ui.view_models import build_object_page_payload
+
+    _seed_truth_store(temp_vault)
+
+    payload = build_object_page_payload(temp_vault, "alpha")
+
+    assert payload["screen"] == "object/page"
+    assert payload["object"]["object_id"] == "alpha"
+    assert payload["summary"]["summary_text"] == "Alpha supports local-first execution."
+    assert payload["claim_count"] == 1
+    assert payload["relation_count"] == 1
+    assert payload["contradiction_count"] == 1
+
+
+def test_build_topic_overview_payload(temp_vault):
+    from openclaw_pipeline.ui.view_models import build_topic_overview_payload
+
+    _seed_truth_store(temp_vault)
+
+    payload = build_topic_overview_payload(temp_vault, "alpha")
+
+    assert payload["screen"] == "overview/topic"
+    assert payload["center"]["object_id"] == "alpha"
+    assert [item["object_id"] for item in payload["neighbors"]] == ["beta"]
+    assert payload["edge_count"] == 1
+
+
+def test_build_event_dossier_payload(temp_vault):
+    from openclaw_pipeline.ui.view_models import build_event_dossier_payload
+
+    _seed_truth_store(temp_vault)
+
+    payload = build_event_dossier_payload(temp_vault)
+
+    assert payload["screen"] == "event/dossier"
+    assert payload["event_count"] == 3
+    assert payload["dates"] == ["2026-04-13"]
+    assert payload["events"][0]["object_id"] == "alpha"
+
+
+def test_build_contradiction_browser_payload(temp_vault):
+    from openclaw_pipeline.ui.view_models import build_contradiction_browser_payload
+
+    _seed_truth_store(temp_vault)
+
+    payload = build_contradiction_browser_payload(temp_vault)
+
+    assert payload["screen"] == "truth/contradictions"
+    assert payload["count"] == 1
+    assert payload["items"][0]["subject_key"] == "alpha"
+    assert payload["open_count"] == 1

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sqlite3
+
 from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
 
 
@@ -107,3 +109,19 @@ def test_build_contradiction_browser_payload(temp_vault):
     assert payload["count"] == 1
     assert payload["items"][0]["subject_key"] == "alpha"
     assert payload["open_count"] == 1
+
+
+def test_build_object_page_payload_handles_missing_summary(temp_vault):
+    from openclaw_pipeline.ui.view_models import build_object_page_payload
+    from openclaw_pipeline.runtime import VaultLayout
+
+    _seed_truth_store(temp_vault)
+    db_path = VaultLayout.from_vault(temp_vault).knowledge_db
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("DELETE FROM compiled_summaries WHERE object_id = ?", ("alpha",))
+        conn.commit()
+
+    payload = build_object_page_payload(temp_vault, "alpha")
+
+    assert payload["summary"] is None
+    assert payload["claim_count"] == 1


### PR DESCRIPTION
## Summary
- add a read-only truth API over `knowledge.db` and expose it via `ovp-truth`
- add DB-backed UI view-models and a local `ovp-ui` server for object/topic/event/contradiction browsing
- document the new DB inspection surface in research-tech operator docs

## What Changed
- added `truth_api.py` for object, contradiction, and neighborhood reads
- added `commands/truth_api.py` and `commands/ui_server.py`
- added `ui/view_models.py` to shape DB rows into UI-friendly payloads
- added browser/smoke coverage for the local UI routes
- updated README, verify docs, and skillpack docs to include `ovp-truth` and `ovp-ui`

## Verification
- `PYTHONPATH=src python3.13 -m pytest -q tests/test_ui_server.py tests/test_ui_smoke.py tests/test_ui_view_models.py tests/test_truth_api.py tests/test_truth_api_command.py tests/test_truth_store.py tests/test_knowledge_index.py tests/test_build_views_command.py`
- `PYTHONPATH=src python3.13 -m pytest -q`
- `python3.13 -m compileall src/openclaw_pipeline`
- real smoke: `/Users/chris/Library/Python/3.13/bin/ovp-ui --help`

## Notes
- this stays read-only on purpose; review and write actions remain CLI-driven for now
- existing Markdown materialization is preserved; this PR adds a DB-first inspection surface rather than replacing vault views
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/9" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `ovp-truth` command to query and inspect objects, contradictions, and neighborhood relationships from the knowledge database
  * Added `ovp-ui` command to launch a local read-only web interface for exploring objects, topics, events, and contradictions

* **Documentation**
  * Updated guides with new command documentation and usage examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->