### PR TITLE
feat: expand truth UI browsing surfaces

### DIFF
--- a/src/openclaw_pipeline/commands/truth_api.py
+++ b/src/openclaw_pipeline/commands/truth_api.py
@@ -22,6 +22,7 @@ def main(argv: list[str] | None = None) -> int:
     objects_parser.add_argument("--vault-dir", type=Path, default=None, help="Vault directory")
     objects_parser.add_argument("--limit", type=int, default=100)
     objects_parser.add_argument("--offset", type=int, default=0)
+    objects_parser.add_argument("--query", default=None, help="Case-insensitive object search")
 
     object_parser = subparsers.add_parser("object", help="Fetch object detail")
     object_parser.add_argument("--vault-dir", type=Path, default=None, help="Vault directory")
@@ -45,7 +46,9 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         if args.command == "objects":
-            payload = {"items": list_objects(vault_dir, limit=args.limit, offset=args.offset)}
+            payload = {
+                "items": list_objects(vault_dir, limit=args.limit, offset=args.offset, query=args.query)
+            }
         elif args.command == "object":
             payload = get_object_detail(vault_dir, args.id)
         elif args.command == "contradictions":

--- a/src/openclaw_pipeline/commands/truth_api.py
+++ b/src/openclaw_pipeline/commands/truth_api.py
@@ -32,6 +32,7 @@ def main(argv: list[str] | None = None) -> int:
     contradictions_parser.add_argument("--vault-dir", type=Path, default=None, help="Vault directory")
     contradictions_parser.add_argument("--limit", type=int, default=100)
     contradictions_parser.add_argument("--status", default=None)
+    contradictions_parser.add_argument("--query", default=None, help="Case-insensitive contradiction search")
 
     neighborhood_parser = subparsers.add_parser("neighborhood", help="Fetch topic neighborhood")
     neighborhood_parser.add_argument("--vault-dir", type=Path, default=None, help="Vault directory")
@@ -52,7 +53,14 @@ def main(argv: list[str] | None = None) -> int:
         elif args.command == "object":
             payload = get_object_detail(vault_dir, args.id)
         elif args.command == "contradictions":
-            payload = {"items": list_contradictions(vault_dir, limit=args.limit, status=args.status)}
+            payload = {
+                "items": list_contradictions(
+                    vault_dir,
+                    limit=args.limit,
+                    status=args.status,
+                    query=args.query,
+                )
+            }
         elif args.command == "neighborhood":
             payload = get_topic_neighborhood(vault_dir, args.id, depth=args.depth)
         else:  # pragma: no cover - argparse enforces commands

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -62,8 +62,14 @@ def _layout(title: str, body: str) -> str:
       .pill {{ display: inline-block; padding: 0.15rem 0.5rem; border-radius: 999px; background: var(--accent-soft); color: var(--accent); margin-right: 0.5rem; }}
       .link-row {{ display: flex; gap: 0.75rem; flex-wrap: wrap; margin-top: 0.9rem; }}
       .link-row a {{ color: var(--accent); text-decoration: none; font-weight: 600; }}
+      .subnav {{ display: flex; gap: 0.6rem; flex-wrap: wrap; margin-top: 0.9rem; margin-bottom: 1rem; }}
+      .subnav a {{ color: var(--muted); text-decoration: none; padding: 0.35rem 0.6rem; border: 1px solid var(--border); border-radius: 999px; background: var(--surface); }}
+      .subnav a:hover {{ color: var(--accent); border-color: var(--accent-soft); }}
       .list-tight li {{ margin-bottom: 0.4rem; }}
       .section-stack {{ display: grid; gap: 1rem; }}
+      .meta-list {{ display: grid; gap: 0.6rem; margin: 0; }}
+      .meta-list dt {{ font-weight: 700; }}
+      .meta-list dd {{ margin: 0; color: var(--muted); }}
       @media (max-width: 780px) {{ .two-col {{ grid-template-columns: 1fr; }} main {{ padding: 1rem 1rem 2rem; }} }}
     </style>
   </head>
@@ -161,6 +167,9 @@ def _render_object_page(payload: dict) -> str:
         for item in payload["contradictions"]
     ) or "<li>None</li>"
     summary_text = payload["summary"]["summary_text"] if payload["summary"] else ""
+    section_nav = "".join(
+        f'<a href="{escape(item["href"])}">{escape(item["label"])}</a>' for item in payload["section_nav"]
+    )
     return _layout(
         f"Object: {payload['object']['title']}",
         (
@@ -171,6 +180,7 @@ def _render_object_page(payload: dict) -> str:
             f"<a href='{escape(payload['links']['events_path'])}'>Related events</a>"
             f"<a href='{escape(payload['links']['contradictions_path'])}'>Contradictions</a>"
             "</div></section>"
+            f"<nav class='subnav'>{section_nav}</nav>"
             "<section class='grid stats'>"
             f"<div class='card'><h2>Claims</h2><p>{payload['claim_count']}</p></div>"
             f"<div class='card'><h2>Relations</h2><p>{payload['relation_count']}</p></div>"
@@ -178,12 +188,17 @@ def _render_object_page(payload: dict) -> str:
             "</section>"
             "<section class='grid two-col'>"
             "<div class='section-stack'>"
-            f"<section class='card'><h2>Compiled Summary</h2><p>{escape(summary_text)}</p></section>"
-            f"<section class='card'><h2>Claims</h2><ul class='list-tight'>{claims}</ul></section>"
+            f"<section id='summary' class='card'><h2>Compiled Summary</h2><p>{escape(summary_text)}</p></section>"
+            f"<section id='claims' class='card'><h2>Claims</h2><ul class='list-tight'>{claims}</ul></section>"
             "</div>"
             "<div class='section-stack'>"
-            f"<section class='card'><h2>Relations</h2><ul class='list-tight'>{relations}</ul></section>"
-            f"<section class='card'><h2>Contradictions</h2><ul class='list-tight'>{contradictions}</ul></section>"
+            "<section class='card'><h2>Context</h2><dl class='meta-list'>"
+            f"<div><dt>Object Kind</dt><dd>{escape(payload['context']['object_kind'])}</dd></div>"
+            f"<div><dt>Source Slug</dt><dd>{escape(payload['context']['source_slug'])}</dd></div>"
+            f"<div><dt>Canonical Path</dt><dd>{escape(payload['context']['canonical_path'])}</dd></div>"
+            "</dl></section>"
+            f"<section id='relations' class='card'><h2>Relations</h2><ul class='list-tight'>{relations}</ul></section>"
+            f"<section id='contradictions' class='card'><h2>Contradictions</h2><ul class='list-tight'>{contradictions}</ul></section>"
             "</div>"
             "</section>"
         ),
@@ -205,17 +220,29 @@ def _render_topic_page(payload: dict) -> str:
             f"<a href='{escape(payload['links']['events_path'])}'>Related events</a>"
             f"<a href='{escape(payload['links']['contradictions_path'])}'>Contradictions</a>"
             "</div></section>"
+            "<section class='grid two-col'>"
+            f"<section class='card'><h2>Center Summary</h2><p>{escape(payload['center_summary'])}</p></section>"
             f"<section class='card'><h2>Neighbors</h2><ul class='list-tight'>{neighbors}</ul></section>"
+            "</section>"
         ),
     )
 
 
 def _render_events_page(payload: dict) -> str:
     query = payload.get("query", "")
+    date_nav = "".join(
+        f"<a href='#date-{escape(section['date'])}'>{escape(section['date'])}</a>"
+        for section in payload["date_sections"]
+    )
     events = "".join(
-        f"<li>{escape(item['event_date'])} - "
-        f'<a href="/object?id={escape(item["object_id"])}">{escape(item["title"])}</a></li>'
-        for item in payload["events"]
+        f'<section id="date-{escape(section["date"])}" class="card"><h2>{escape(section["date"])}</h2><ul class="list-tight">'
+        + "".join(
+            f"<li>{escape(item['event_type'])} - "
+            f'<a href="/object?id={escape(item["object_id"])}">{escape(item["title"])}</a></li>'
+            for item in section["events"]
+        )
+        + "</ul></section>"
+        for section in payload["date_sections"]
     ) or "<li>None</li>"
     return _layout(
         "Event Dossier",
@@ -226,7 +253,8 @@ def _render_events_page(payload: dict) -> str:
             "<button type='submit'>Search</button>"
             "</form>"
             f"<p class='muted'>{payload['event_count']} events across {len(payload['dates'])} dates.</p>"
-            f"<section class='card'><ul class='list-tight'>{events}</ul></section>"
+            f"<nav class='subnav'>{date_nav}</nav>"
+            f"{events}"
         ),
     )
 
@@ -235,7 +263,18 @@ def _render_contradictions_page(payload: dict) -> str:
     status = payload.get("status", "")
     query = payload.get("query", "")
     items = "".join(
-        f"<li><span class='pill'>{escape(item['status'])}</span>{escape(item['subject_key'])}</li>"
+        "<li>"
+        f"<span class='pill'>{escape(item['status'])}</span>{escape(item['subject_key'])}"
+        + (
+            " <span class='muted'>"
+            + ", ".join(
+                f'<a href="{escape(link["path"])}">{escape(link["object_id"])}</a>' for link in item["object_links"]
+            )
+            + "</span>"
+            if item["object_links"]
+            else ""
+        )
+        + "</li>"
         for item in payload["items"]
     ) or "<li>None</li>"
     return _layout(

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -90,6 +90,7 @@ def _render_dashboard(payload: dict) -> str:
 
 
 def _render_objects_index(payload: dict) -> str:
+    query = payload.get("query", "")
     items = "".join(
         f'<li><a href="/object?id={escape(item["object_id"])}">{escape(item["title"])}</a> '
         f'<span class="muted">({escape(item["object_id"])})</span></li>'
@@ -97,7 +98,15 @@ def _render_objects_index(payload: dict) -> str:
     )
     return _layout(
         "Objects",
-        f"<h1>Objects</h1><p class='muted'>{payload['count']} objects in current page.</p><ul>{items}</ul>",
+        (
+            "<h1>Objects</h1>"
+            "<form method='get' action='/objects'>"
+            f"<input type='text' name='q' value='{escape(query)}' placeholder='Search objects' /> "
+            "<button type='submit'>Search</button>"
+            "</form>"
+            f"<p class='muted'>{payload['count']} objects in current page.</p>"
+            f"<ul>{items}</ul>"
+        ),
     )
 
 
@@ -192,12 +201,18 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
                 if path == "/api/objects":
                     limit = int(query.get("limit", ["100"])[0])
                     offset = int(query.get("offset", ["0"])[0])
-                    self._write_json(build_objects_index_payload(resolved_vault, limit=limit, offset=offset))
+                    q = query.get("q", [""])[0]
+                    self._write_json(
+                        build_objects_index_payload(resolved_vault, limit=limit, offset=offset, query=q)
+                    )
                     return
                 if path == "/objects":
                     limit = int(query.get("limit", ["100"])[0])
                     offset = int(query.get("offset", ["0"])[0])
-                    payload = build_objects_index_payload(resolved_vault, limit=limit, offset=offset)
+                    q = query.get("q", [""])[0]
+                    payload = build_objects_index_payload(
+                        resolved_vault, limit=limit, offset=offset, query=q
+                    )
                     self._write_html(_render_objects_index(payload))
                     return
                 if path == "/api/object":

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -14,38 +14,9 @@ from ..ui.view_models import (
     build_event_dossier_payload,
     build_object_page_payload,
     build_objects_index_payload,
+    build_truth_dashboard_payload,
     build_topic_overview_payload,
 )
-
-
-HTML_SHELL = """<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>OpenClaw Truth UI</title>
-    <style>
-      body { font-family: ui-sans-serif, system-ui, sans-serif; margin: 2rem; line-height: 1.5; max-width: 980px; }
-      code { background: #f4f4f5; padding: 0.1rem 0.3rem; border-radius: 4px; }
-      ul { padding-left: 1.2rem; }
-      nav { margin-bottom: 1.5rem; }
-      nav a { margin-right: 1rem; }
-      section { margin-top: 1.5rem; }
-      .muted { color: #52525b; }
-    </style>
-  </head>
-  <body>
-    <h1>OpenClaw Truth UI</h1>
-    <p>Minimal read-only shell over <code>knowledge.db</code>.</p>
-    <nav>
-      <a href="/objects">Objects</a>
-      <a href="/events">Event Dossier</a>
-      <a href="/contradictions">Contradictions</a>
-    </nav>
-    <p class="muted">JSON APIs remain available at <code>/api/*</code>, including <code>/api/objects</code>.</p>
-  </body>
-</html>
-"""
 
 
 def _layout(title: str, body: str) -> str:
@@ -78,6 +49,44 @@ def _layout(title: str, body: str) -> str:
   </body>
 </html>
 """
+
+
+def _render_dashboard(payload: dict) -> str:
+    object_items = "".join(
+        f'<li><a href="/object?id={escape(item["object_id"])}">{escape(item["title"])}</a></li>'
+        for item in payload["objects"]["items"]
+    ) or "<li>None</li>"
+    contradiction_items = "".join(
+        f'<li><span class="pill">{escape(item["status"])}</span>{escape(item["subject_key"])}</li>'
+        for item in payload["contradictions"]["items"]
+    ) or "<li>None</li>"
+    event_items = "".join(
+        f"<li>{escape(item['event_date'])} - "
+        f'<a href="/object?id={escape(item["object_id"])}">{escape(item["title"])}</a></li>'
+        for item in payload["events"]["items"]
+    ) or "<li>None</li>"
+    return _layout(
+        "OpenClaw Truth UI",
+        (
+            "<h1>OpenClaw Truth UI</h1>"
+            "<p class='muted'>Read-only browser over <code>knowledge.db</code>. JSON APIs remain available at <code>/api/*</code>, including <code>/api/objects</code>.</p>"
+            "<section class='card'>"
+            "<h2>Objects Indexed</h2>"
+            f"<p>{payload['objects']['count']}</p>"
+            f"<ul>{object_items}</ul>"
+            "</section>"
+            "<section class='card'>"
+            "<h2>Contradictions Open</h2>"
+            f"<p>{payload['contradictions']['open_count']}</p>"
+            f"<ul>{contradiction_items}</ul>"
+            "</section>"
+            "<section class='card'>"
+            "<h2>Recent Events</h2>"
+            f"<p>{payload['events']['count']}</p>"
+            f"<ul>{event_items}</ul>"
+            "</section>"
+        ),
+    )
 
 
 def _render_objects_index(payload: dict) -> str:
@@ -177,7 +186,8 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
 
             try:
                 if path == "/":
-                    self._write_html(HTML_SHELL)
+                    payload = build_truth_dashboard_payload(resolved_vault)
+                    self._write_html(_render_dashboard(payload))
                     return
                 if path == "/api/objects":
                     limit = int(query.get("limit", ["100"])[0])

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -151,6 +151,7 @@ def _render_topic_page(payload: dict) -> str:
 
 
 def _render_events_page(payload: dict) -> str:
+    query = payload.get("query", "")
     events = "".join(
         f"<li>{escape(item['event_date'])} - "
         f'<a href="/object?id={escape(item["object_id"])}">{escape(item["title"])}</a></li>'
@@ -159,7 +160,11 @@ def _render_events_page(payload: dict) -> str:
     return _layout(
         "Event Dossier",
         (
-            f"<h1>Event Dossier</h1>"
+            "<h1>Event Dossier</h1>"
+            "<form method='get' action='/events'>"
+            f"<input type='text' name='q' value='{escape(query)}' placeholder='Filter events' /> "
+            "<button type='submit'>Search</button>"
+            "</form>"
             f"<p class='muted'>{payload['event_count']} events across {len(payload['dates'])} dates.</p>"
             f"<section class='card'><ul>{events}</ul></section>"
         ),
@@ -167,6 +172,7 @@ def _render_events_page(payload: dict) -> str:
 
 
 def _render_contradictions_page(payload: dict) -> str:
+    status = payload.get("status", "")
     items = "".join(
         f"<li><span class='pill'>{escape(item['status'])}</span>{escape(item['subject_key'])}</li>"
         for item in payload["items"]
@@ -174,7 +180,15 @@ def _render_contradictions_page(payload: dict) -> str:
     return _layout(
         "Contradictions",
         (
-            f"<h1>Contradictions</h1>"
+            "<h1>Contradictions</h1>"
+            "<form method='get' action='/contradictions'>"
+            "<select name='status'>"
+            f"<option value=''{' selected' if not status else ''}>all</option>"
+            f"<option value='open'{' selected' if status == 'open' else ''}>open</option>"
+            f"<option value='resolved'{' selected' if status == 'resolved' else ''}>resolved</option>"
+            "</select> "
+            "<button type='submit'>Filter</button>"
+            "</form>"
             f"<p class='muted'>{payload['count']} records, {payload['open_count']} open.</p>"
             f"<section class='card'><ul>{items}</ul></section>"
         ),
@@ -234,17 +248,21 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
                     self._write_html(_render_topic_page(payload))
                     return
                 if path == "/api/events":
-                    self._write_json(build_event_dossier_payload(resolved_vault))
+                    q = query.get("q", [""])[0]
+                    self._write_json(build_event_dossier_payload(resolved_vault, query=q))
                     return
                 if path == "/events":
-                    payload = build_event_dossier_payload(resolved_vault)
+                    q = query.get("q", [""])[0]
+                    payload = build_event_dossier_payload(resolved_vault, query=q)
                     self._write_html(_render_events_page(payload))
                     return
                 if path == "/api/contradictions":
-                    self._write_json(build_contradiction_browser_payload(resolved_vault))
+                    status = query.get("status", [""])[0] or None
+                    self._write_json(build_contradiction_browser_payload(resolved_vault, status=status))
                     return
                 if path == "/contradictions":
-                    payload = build_contradiction_browser_payload(resolved_vault)
+                    status = query.get("status", [""])[0] or None
+                    payload = build_contradiction_browser_payload(resolved_vault, status=status)
                     self._write_html(_render_contradictions_page(payload))
                     return
                 self.send_error(404, "Not Found")

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -27,25 +27,62 @@ def _layout(title: str, body: str) -> str:
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{escape(title)}</title>
     <style>
-      body {{ font-family: ui-sans-serif, system-ui, sans-serif; margin: 2rem; line-height: 1.5; max-width: 980px; }}
-      nav {{ margin-bottom: 1.5rem; }}
-      nav a {{ margin-right: 1rem; }}
-      h1, h2 {{ margin-bottom: 0.5rem; }}
+      :root {{
+        color-scheme: light;
+        --bg: #f7f6f2;
+        --surface: #fffdfa;
+        --border: #e7e1d8;
+        --text: #1f1a17;
+        --muted: #71675d;
+        --accent: #9f4f24;
+        --accent-soft: #f4dfd2;
+      }}
+      * {{ box-sizing: border-box; }}
+      body {{ font-family: ui-sans-serif, system-ui, sans-serif; margin: 0; line-height: 1.5; background: var(--bg); color: var(--text); }}
+      main {{ max-width: 1180px; margin: 0 auto; padding: 1.5rem 1.5rem 3rem; }}
+      nav {{ margin-bottom: 1.5rem; display: flex; gap: 0.9rem; flex-wrap: wrap; }}
+      nav a {{ color: var(--accent); text-decoration: none; font-weight: 600; }}
+      nav a:hover {{ text-decoration: underline; }}
+      h1, h2, h3 {{ margin-bottom: 0.5rem; line-height: 1.2; }}
       ul {{ padding-left: 1.2rem; }}
       pre {{ background: #f4f4f5; padding: 1rem; border-radius: 8px; overflow-x: auto; }}
-      .muted {{ color: #52525b; }}
-      .card {{ border: 1px solid #e4e4e7; border-radius: 10px; padding: 1rem; margin-bottom: 1rem; }}
-      .pill {{ display: inline-block; padding: 0.15rem 0.5rem; border-radius: 999px; background: #eef2ff; margin-right: 0.5rem; }}
+      input, select, button {{ font: inherit; }}
+      input, select {{ padding: 0.55rem 0.7rem; border: 1px solid var(--border); border-radius: 10px; background: var(--surface); }}
+      button {{ padding: 0.55rem 0.8rem; border-radius: 10px; border: 1px solid var(--accent); background: var(--accent); color: white; cursor: pointer; }}
+      button:hover {{ opacity: 0.92; }}
+      .muted {{ color: var(--muted); }}
+      .hero {{ margin-bottom: 1.5rem; }}
+      .shell {{ background: var(--surface); border: 1px solid var(--border); border-radius: 20px; box-shadow: 0 12px 36px rgba(31, 26, 23, 0.06); }}
+      .shell-head {{ padding: 1.1rem 1.25rem 0; }}
+      .shell-body {{ padding: 0 1.25rem 1.25rem; }}
+      .card {{ border: 1px solid var(--border); background: var(--surface); border-radius: 16px; padding: 1rem; margin-bottom: 1rem; }}
+      .grid {{ display: grid; gap: 1rem; }}
+      .stats {{ grid-template-columns: repeat(auto-fit, minmax(190px, 1fr)); }}
+      .two-col {{ grid-template-columns: minmax(0, 2.1fr) minmax(280px, 1fr); align-items: start; }}
+      .pill {{ display: inline-block; padding: 0.15rem 0.5rem; border-radius: 999px; background: var(--accent-soft); color: var(--accent); margin-right: 0.5rem; }}
+      .link-row {{ display: flex; gap: 0.75rem; flex-wrap: wrap; margin-top: 0.9rem; }}
+      .link-row a {{ color: var(--accent); text-decoration: none; font-weight: 600; }}
+      .list-tight li {{ margin-bottom: 0.4rem; }}
+      .section-stack {{ display: grid; gap: 1rem; }}
+      @media (max-width: 780px) {{ .two-col {{ grid-template-columns: 1fr; }} main {{ padding: 1rem 1rem 2rem; }} }}
     </style>
   </head>
   <body>
-    <nav>
-      <a href="/">Home</a>
-      <a href="/objects">Objects</a>
-      <a href="/events">Event Dossier</a>
-      <a href="/contradictions">Contradictions</a>
-    </nav>
-    {body}
+    <main>
+      <div class="shell">
+        <div class="shell-head">
+          <nav>
+            <a href="/">Home</a>
+            <a href="/objects">Objects</a>
+            <a href="/events">Event Dossier</a>
+            <a href="/contradictions">Contradictions</a>
+          </nav>
+        </div>
+        <div class="shell-body">
+          {body}
+        </div>
+      </div>
+    </main>
   </body>
 </html>
 """
@@ -68,22 +105,24 @@ def _render_dashboard(payload: dict) -> str:
     return _layout(
         "OpenClaw Truth UI",
         (
+            "<section class='hero'>"
             "<h1>OpenClaw Truth UI</h1>"
             "<p class='muted'>Read-only browser over <code>knowledge.db</code>. JSON APIs remain available at <code>/api/*</code>, including <code>/api/objects</code>.</p>"
-            "<section class='card'>"
-            "<h2>Objects Indexed</h2>"
-            f"<p>{payload['objects']['count']}</p>"
-            f"<ul>{object_items}</ul>"
             "</section>"
-            "<section class='card'>"
-            "<h2>Contradictions Open</h2>"
-            f"<p>{payload['contradictions']['open_count']}</p>"
-            f"<ul>{contradiction_items}</ul>"
+            "<section class='grid stats'>"
+            "<div class='card'><h2>Objects Indexed</h2>"
+            f"<p>{payload['objects']['count']}</p></div>"
+            "<div class='card'><h2>Contradictions Open</h2>"
+            f"<p>{payload['contradictions']['open_count']}</p></div>"
+            "<div class='card'><h2>Recent Events</h2>"
+            f"<p>{payload['events']['count']}</p></div>"
             "</section>"
-            "<section class='card'>"
-            "<h2>Recent Events</h2>"
-            f"<p>{payload['events']['count']}</p>"
-            f"<ul>{event_items}</ul>"
+            "<section class='grid two-col'>"
+            "<div class='section-stack'>"
+            f"<section class='card'><h2>Recent Objects</h2><ul class='list-tight'>{object_items}</ul></section>"
+            f"<section class='card'><h2>Recent Events</h2><ul class='list-tight'>{event_items}</ul></section>"
+            "</div>"
+            f"<section class='card'><h2>Contradiction Queue</h2><ul class='list-tight'>{contradiction_items}</ul></section>"
             "</section>"
         ),
     )
@@ -105,7 +144,7 @@ def _render_objects_index(payload: dict) -> str:
             "<button type='submit'>Search</button>"
             "</form>"
             f"<p class='muted'>{payload['count']} objects in current page.</p>"
-            f"<ul>{items}</ul>"
+            f"<section class='card'><ul class='list-tight'>{items}</ul></section>"
         ),
     )
 
@@ -125,12 +164,28 @@ def _render_object_page(payload: dict) -> str:
     return _layout(
         f"Object: {payload['object']['title']}",
         (
-            f"<h1>Object: {escape(payload['object']['title'])}</h1>"
+            f"<section class='hero'><h1>Object: {escape(payload['object']['title'])}</h1>"
             f"<p class='muted'>{escape(payload['object']['object_id'])}</p>"
+            "<div class='link-row'>"
+            f"<a href='{escape(payload['links']['topic_path'])}'>Explore topic</a>"
+            f"<a href='{escape(payload['links']['events_path'])}'>Related events</a>"
+            f"<a href='{escape(payload['links']['contradictions_path'])}'>Contradictions</a>"
+            "</div></section>"
+            "<section class='grid stats'>"
+            f"<div class='card'><h2>Claims</h2><p>{payload['claim_count']}</p></div>"
+            f"<div class='card'><h2>Relations</h2><p>{payload['relation_count']}</p></div>"
+            f"<div class='card'><h2>Contradictions</h2><p>{payload['contradiction_count']}</p></div>"
+            "</section>"
+            "<section class='grid two-col'>"
+            "<div class='section-stack'>"
             f"<section class='card'><h2>Compiled Summary</h2><p>{escape(summary_text)}</p></section>"
-            f"<section class='card'><h2>Claims</h2><ul>{claims}</ul></section>"
-            f"<section class='card'><h2>Relations</h2><ul>{relations}</ul></section>"
-            f"<section class='card'><h2>Contradictions</h2><ul>{contradictions}</ul></section>"
+            f"<section class='card'><h2>Claims</h2><ul class='list-tight'>{claims}</ul></section>"
+            "</div>"
+            "<div class='section-stack'>"
+            f"<section class='card'><h2>Relations</h2><ul class='list-tight'>{relations}</ul></section>"
+            f"<section class='card'><h2>Contradictions</h2><ul class='list-tight'>{contradictions}</ul></section>"
+            "</div>"
+            "</section>"
         ),
     )
 
@@ -143,9 +198,14 @@ def _render_topic_page(payload: dict) -> str:
     return _layout(
         f"Topic: {payload['center']['title']}",
         (
-            f"<h1>Topic: {escape(payload['center']['title'])}</h1>"
+            f"<section class='hero'><h1>Topic: {escape(payload['center']['title'])}</h1>"
             f"<p class='muted'>{payload['neighbor_count']} neighbors, {payload['edge_count']} edges.</p>"
-            f"<section class='card'><h2>Neighbors</h2><ul>{neighbors}</ul></section>"
+            "<div class='link-row'>"
+            f"<a href='{escape(payload['links']['center_object_path'])}'>Open center object</a>"
+            f"<a href='{escape(payload['links']['events_path'])}'>Related events</a>"
+            f"<a href='{escape(payload['links']['contradictions_path'])}'>Contradictions</a>"
+            "</div></section>"
+            f"<section class='card'><h2>Neighbors</h2><ul class='list-tight'>{neighbors}</ul></section>"
         ),
     )
 
@@ -166,13 +226,14 @@ def _render_events_page(payload: dict) -> str:
             "<button type='submit'>Search</button>"
             "</form>"
             f"<p class='muted'>{payload['event_count']} events across {len(payload['dates'])} dates.</p>"
-            f"<section class='card'><ul>{events}</ul></section>"
+            f"<section class='card'><ul class='list-tight'>{events}</ul></section>"
         ),
     )
 
 
 def _render_contradictions_page(payload: dict) -> str:
     status = payload.get("status", "")
+    query = payload.get("query", "")
     items = "".join(
         f"<li><span class='pill'>{escape(item['status'])}</span>{escape(item['subject_key'])}</li>"
         for item in payload["items"]
@@ -187,10 +248,11 @@ def _render_contradictions_page(payload: dict) -> str:
             f"<option value='open'{' selected' if status == 'open' else ''}>open</option>"
             f"<option value='resolved'{' selected' if status == 'resolved' else ''}>resolved</option>"
             "</select> "
+            f"<input type='text' name='q' value='{escape(query)}' placeholder='Filter contradictions' /> "
             "<button type='submit'>Filter</button>"
             "</form>"
             f"<p class='muted'>{payload['count']} records, {payload['open_count']} open.</p>"
-            f"<section class='card'><ul>{items}</ul></section>"
+            f"<section class='card'><ul class='list-tight'>{items}</ul></section>"
         ),
     )
 
@@ -258,11 +320,15 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
                     return
                 if path == "/api/contradictions":
                     status = query.get("status", [""])[0] or None
-                    self._write_json(build_contradiction_browser_payload(resolved_vault, status=status))
+                    q = query.get("q", [""])[0]
+                    self._write_json(
+                        build_contradiction_browser_payload(resolved_vault, status=status, query=q)
+                    )
                     return
                 if path == "/contradictions":
                     status = query.get("status", [""])[0] or None
-                    payload = build_contradiction_browser_payload(resolved_vault, status=status)
+                    q = query.get("q", [""])[0]
+                    payload = build_contradiction_browser_payload(resolved_vault, status=status, query=q)
                     self._write_html(_render_contradictions_page(payload))
                     return
                 self.send_error(404, "Not Found")

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -23,19 +23,44 @@ def _validate_page_args(*, limit: int, offset: int = 0) -> tuple[int, int]:
     return limit, offset
 
 
-def list_objects(vault_dir: Path | str, *, limit: int = 100, offset: int = 0) -> list[dict[str, Any]]:
+def list_objects(
+    vault_dir: Path | str,
+    *,
+    limit: int = 100,
+    offset: int = 0,
+    query: str | None = None,
+) -> list[dict[str, Any]]:
     limit, offset = _validate_page_args(limit=limit, offset=offset)
     db_path = _db_path(vault_dir)
+    normalized_query = query.strip().lower() if query else ""
     with sqlite3.connect(db_path) as conn:
-        rows = conn.execute(
-            """
-            SELECT object_id, object_kind, title, canonical_path, source_slug
-            FROM objects
-            ORDER BY object_id
-            LIMIT ? OFFSET ?
-            """,
-            (limit, offset),
-        ).fetchall()
+        if normalized_query:
+            rows = conn.execute(
+                """
+                SELECT object_id, object_kind, title, canonical_path, source_slug
+                FROM objects
+                WHERE lower(object_id) LIKE ? OR lower(title) LIKE ? OR lower(source_slug) LIKE ?
+                ORDER BY object_id
+                LIMIT ? OFFSET ?
+                """,
+                (
+                    f"%{normalized_query}%",
+                    f"%{normalized_query}%",
+                    f"%{normalized_query}%",
+                    limit,
+                    offset,
+                ),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                """
+                SELECT object_id, object_kind, title, canonical_path, source_slug
+                FROM objects
+                ORDER BY object_id
+                LIMIT ? OFFSET ?
+                """,
+                (limit, offset),
+            ).fetchall()
 
     return [
         {

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -23,6 +23,10 @@ def _validate_page_args(*, limit: int, offset: int = 0) -> tuple[int, int]:
     return limit, offset
 
 
+def _escape_like(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
 def list_objects(
     vault_dir: Path | str,
     *,
@@ -32,35 +36,29 @@ def list_objects(
 ) -> list[dict[str, Any]]:
     limit, offset = _validate_page_args(limit=limit, offset=offset)
     db_path = _db_path(vault_dir)
-    normalized_query = query.strip().lower() if query else ""
+    normalized_query = _escape_like(query.strip().lower()) if query else ""
     with sqlite3.connect(db_path) as conn:
+        sql = """
+            SELECT object_id, object_kind, title, canonical_path, source_slug
+            FROM objects
+        """
+        params: list[Any] = []
         if normalized_query:
-            rows = conn.execute(
-                """
-                SELECT object_id, object_kind, title, canonical_path, source_slug
-                FROM objects
-                WHERE lower(object_id) LIKE ? OR lower(title) LIKE ? OR lower(source_slug) LIKE ?
-                ORDER BY object_id
-                LIMIT ? OFFSET ?
-                """,
-                (
+            sql += """
+                WHERE lower(object_id) LIKE ? ESCAPE '\\'
+                   OR lower(title) LIKE ? ESCAPE '\\'
+                   OR lower(source_slug) LIKE ? ESCAPE '\\'
+            """
+            params.extend(
+                [
                     f"%{normalized_query}%",
                     f"%{normalized_query}%",
                     f"%{normalized_query}%",
-                    limit,
-                    offset,
-                ),
-            ).fetchall()
-        else:
-            rows = conn.execute(
-                """
-                SELECT object_id, object_kind, title, canonical_path, source_slug
-                FROM objects
-                ORDER BY object_id
-                LIMIT ? OFFSET ?
-                """,
-                (limit, offset),
-            ).fetchall()
+                ]
+            )
+        sql += " ORDER BY object_id LIMIT ? OFFSET ?"
+        params.extend([limit, offset])
+        rows = conn.execute(sql, tuple(params)).fetchall()
 
     return [
         {
@@ -74,9 +72,33 @@ def list_objects(
     ]
 
 
+def count_objects(vault_dir: Path | str, *, query: str | None = None) -> int:
+    db_path = _db_path(vault_dir)
+    normalized_query = _escape_like(query.strip().lower()) if query else ""
+    sql = "SELECT COUNT(*) FROM objects"
+    params: list[Any] = []
+    if normalized_query:
+        sql += """
+            WHERE lower(object_id) LIKE ? ESCAPE '\\'
+               OR lower(title) LIKE ? ESCAPE '\\'
+               OR lower(source_slug) LIKE ? ESCAPE '\\'
+        """
+        params.extend(
+            [
+                f"%{normalized_query}%",
+                f"%{normalized_query}%",
+                f"%{normalized_query}%",
+            ]
+        )
+
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(sql, tuple(params)).fetchone()
+    return int(row[0]) if row else 0
+
+
 def get_object_detail(vault_dir: Path | str, object_id: str) -> dict[str, Any]:
     db_path = _db_path(vault_dir)
-    escaped = object_id.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    escaped = _escape_like(object_id)
 
     with sqlite3.connect(db_path) as conn:
         object_row = conn.execute(
@@ -205,7 +227,7 @@ def list_contradictions(
 ) -> list[dict[str, Any]]:
     limit, _ = _validate_page_args(limit=limit, offset=0)
     db_path = _db_path(vault_dir)
-    normalized_query = query.strip().lower() if query else ""
+    normalized_query = _escape_like(query.strip().lower()) if query else ""
     query = """
         SELECT contradiction_id, subject_key, positive_claim_ids_json, negative_claim_ids_json, status, resolution_note, resolved_at
         FROM contradictions
@@ -216,7 +238,7 @@ def list_contradictions(
         where_clauses.append("status = ?")
         params.append(status)
     if normalized_query:
-        where_clauses.append("lower(subject_key) LIKE ?")
+        where_clauses.append("lower(subject_key) LIKE ? ESCAPE '\\'")
         params.append(f"%{normalized_query}%")
     if where_clauses:
         query += " WHERE " + " AND ".join(where_clauses)

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -196,17 +196,30 @@ def get_object_detail(vault_dir: Path | str, object_id: str) -> dict[str, Any]:
     }
 
 
-def list_contradictions(vault_dir: Path | str, *, limit: int = 100, status: str | None = None) -> list[dict[str, Any]]:
+def list_contradictions(
+    vault_dir: Path | str,
+    *,
+    limit: int = 100,
+    status: str | None = None,
+    query: str | None = None,
+) -> list[dict[str, Any]]:
     limit, _ = _validate_page_args(limit=limit, offset=0)
     db_path = _db_path(vault_dir)
+    normalized_query = query.strip().lower() if query else ""
     query = """
         SELECT contradiction_id, subject_key, positive_claim_ids_json, negative_claim_ids_json, status, resolution_note, resolved_at
         FROM contradictions
     """
     params: list[Any] = []
+    where_clauses: list[str] = []
     if status:
-        query += " WHERE status = ?"
+        where_clauses.append("status = ?")
         params.append(status)
+    if normalized_query:
+        where_clauses.append("lower(subject_key) LIKE ?")
+        params.append(f"%{normalized_query}%")
+    if where_clauses:
+        query += " WHERE " + " AND ".join(where_clauses)
     query += " ORDER BY subject_key LIMIT ?"
     params.append(limit)
 

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -113,12 +113,19 @@ def build_truth_dashboard_payload(vault_dir: Path | str) -> dict[str, Any]:
     }
 
 
-def build_objects_index_payload(vault_dir: Path | str, *, limit: int = 100, offset: int = 0) -> dict[str, Any]:
-    items = list_objects(vault_dir, limit=limit, offset=offset)
+def build_objects_index_payload(
+    vault_dir: Path | str,
+    *,
+    limit: int = 100,
+    offset: int = 0,
+    query: str | None = None,
+) -> dict[str, Any]:
+    items = list_objects(vault_dir, limit=limit, offset=offset, query=query)
     return {
         "screen": "objects/index",
         "items": items,
         "count": len(items),
         "limit": limit,
         "offset": offset,
+        "query": query or "",
     }

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -14,6 +14,18 @@ def _db_path(vault_dir: Path | str) -> Path:
     return VaultLayout.from_vault(resolved).knowledge_db
 
 
+def _object_ids_from_claim_ids(*claim_id_lists: list[str]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for claim_ids in claim_id_lists:
+        for claim_id in claim_ids:
+            object_id = claim_id.split("::", 1)[0]
+            if object_id and object_id not in seen:
+                seen.add(object_id)
+                ordered.append(object_id)
+    return ordered
+
+
 def build_object_page_payload(vault_dir: Path | str, object_id: str) -> dict[str, Any]:
     detail = get_object_detail(vault_dir, object_id)
     neighborhood = get_topic_neighborhood(vault_dir, object_id)
@@ -33,21 +45,34 @@ def build_object_page_payload(vault_dir: Path | str, object_id: str) -> dict[str
         "relation_count": len(relations),
         "contradiction_count": len(detail["contradictions"]),
         "evidence_count": len(detail["evidence"]),
+        "context": {
+            "object_kind": detail["object"]["object_kind"],
+            "source_slug": detail["object"]["source_slug"],
+            "canonical_path": detail["object"]["canonical_path"],
+        },
         "links": {
             "topic_path": f"/topic?id={object_id}",
             "events_path": f"/events?q={object_id}",
             "contradictions_path": f"/contradictions?q={object_id}",
         },
+        "section_nav": [
+            {"href": "#summary", "label": "Summary"},
+            {"href": "#claims", "label": "Claims"},
+            {"href": "#relations", "label": "Relations"},
+            {"href": "#contradictions", "label": "Contradictions"},
+        ],
     }
 
 
 def build_topic_overview_payload(vault_dir: Path | str, object_id: str) -> dict[str, Any]:
     neighborhood = get_topic_neighborhood(vault_dir, object_id)
+    detail = get_object_detail(vault_dir, object_id)
     return {
         "screen": "overview/topic",
         **neighborhood,
         "edge_count": len(neighborhood["edges"]),
         "neighbor_count": len(neighborhood["neighbors"]),
+        "center_summary": detail["summary"]["summary_text"] if detail["summary"] else "",
         "links": {
             "center_object_path": f"/object?id={object_id}",
             "events_path": f"/events?q={object_id}",
@@ -98,11 +123,16 @@ def build_event_dossier_payload(vault_dir: Path | str, *, query: str | None = No
         for row in rows
     ]
     dates = sorted({event["event_date"] for event in events})
+    date_sections = [
+        {"date": date, "events": [event for event in events if event["event_date"] == date]}
+        for date in dates
+    ]
     return {
         "screen": "event/dossier",
         "events": events,
         "event_count": len(events),
         "dates": dates,
+        "date_sections": date_sections,
         "query": query or "",
     }
 
@@ -113,7 +143,19 @@ def build_contradiction_browser_payload(
     status: str | None = None,
     query: str | None = None,
 ) -> dict[str, Any]:
-    items = list_contradictions(vault_dir, status=status, query=query)
+    raw_items = list_contradictions(vault_dir, status=status, query=query)
+    items = []
+    for item in raw_items:
+        object_ids = _object_ids_from_claim_ids(item["positive_claim_ids"], item["negative_claim_ids"])
+        items.append(
+            {
+                **item,
+                "object_ids": object_ids,
+                "object_links": [
+                    {"object_id": object_id, "path": f"/object?id={object_id}"} for object_id in object_ids
+                ],
+            }
+        )
     status_counts = Counter(item["status"] for item in items)
     return {
         "screen": "truth/contradictions",

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from ..runtime import VaultLayout, resolve_vault_dir
-from ..truth_api import get_object_detail, get_topic_neighborhood, list_contradictions, list_objects
+from ..truth_api import count_objects, get_object_detail, get_topic_neighborhood, list_contradictions, list_objects
 
 
 def _db_path(vault_dir: Path | str) -> Path:
@@ -81,36 +81,44 @@ def build_topic_overview_payload(vault_dir: Path | str, object_id: str) -> dict[
     }
 
 
-def build_event_dossier_payload(vault_dir: Path | str, *, query: str | None = None) -> dict[str, Any]:
+def _escape_like(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def build_event_dossier_payload(
+    vault_dir: Path | str,
+    *,
+    query: str | None = None,
+    limit: int | None = None,
+) -> dict[str, Any]:
     db_path = _db_path(vault_dir)
-    normalized_query = query.strip().lower() if query else ""
+    normalized_query = _escape_like(query.strip().lower()) if query else ""
     with sqlite3.connect(db_path) as conn:
+        sql = """
+            SELECT timeline_events.event_date, timeline_events.event_type, objects.object_id, objects.title, compiled_summaries.summary_text
+            FROM timeline_events
+            JOIN objects ON objects.object_id = timeline_events.slug
+            LEFT JOIN compiled_summaries ON compiled_summaries.object_id = objects.object_id
+        """
+        params: list[Any] = []
         if normalized_query:
-            rows = conn.execute(
-                """
-                SELECT timeline_events.event_date, timeline_events.event_type, objects.object_id, objects.title, compiled_summaries.summary_text
-                FROM timeline_events
-                JOIN objects ON objects.object_id = timeline_events.slug
-                LEFT JOIN compiled_summaries ON compiled_summaries.object_id = objects.object_id
-                WHERE lower(objects.object_id) LIKE ? OR lower(objects.title) LIKE ? OR lower(compiled_summaries.summary_text) LIKE ?
-                ORDER BY timeline_events.event_date, objects.object_id
-                """,
-                (
+            sql += """
+                WHERE lower(objects.object_id) LIKE ? ESCAPE '\\'
+                   OR lower(objects.title) LIKE ? ESCAPE '\\'
+                   OR lower(compiled_summaries.summary_text) LIKE ? ESCAPE '\\'
+            """
+            params.extend(
+                [
                     f"%{normalized_query}%",
                     f"%{normalized_query}%",
                     f"%{normalized_query}%",
-                ),
-            ).fetchall()
-        else:
-            rows = conn.execute(
-                """
-                SELECT timeline_events.event_date, timeline_events.event_type, objects.object_id, objects.title, compiled_summaries.summary_text
-                FROM timeline_events
-                JOIN objects ON objects.object_id = timeline_events.slug
-                LEFT JOIN compiled_summaries ON compiled_summaries.object_id = objects.object_id
-                ORDER BY timeline_events.event_date, objects.object_id
-                """
-            ).fetchall()
+                ]
+            )
+        sql += " ORDER BY timeline_events.event_date, objects.object_id"
+        if limit is not None:
+            sql += " LIMIT ?"
+            params.append(limit)
+        rows = conn.execute(sql, tuple(params)).fetchall()
 
     events = [
         {
@@ -123,10 +131,10 @@ def build_event_dossier_payload(vault_dir: Path | str, *, query: str | None = No
         for row in rows
     ]
     dates = sorted({event["event_date"] for event in events})
-    date_sections = [
-        {"date": date, "events": [event for event in events if event["event_date"] == date]}
-        for date in dates
-    ]
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for event in events:
+        grouped.setdefault(event["event_date"], []).append(event)
+    date_sections = [{"date": date, "events": grouped[date]} for date in dates]
     return {
         "screen": "event/dossier",
         "events": events,
@@ -171,11 +179,11 @@ def build_contradiction_browser_payload(
 def build_truth_dashboard_payload(vault_dir: Path | str) -> dict[str, Any]:
     objects = build_objects_index_payload(vault_dir, limit=12, offset=0)
     contradictions = build_contradiction_browser_payload(vault_dir)
-    events = build_event_dossier_payload(vault_dir)
+    events = build_event_dossier_payload(vault_dir, limit=8)
     return {
         "screen": "truth/dashboard",
         "objects": {
-            "count": objects["count"],
+            "count": objects["total_count"],
             "items": objects["items"],
         },
         "contradictions": {
@@ -199,10 +207,12 @@ def build_objects_index_payload(
     query: str | None = None,
 ) -> dict[str, Any]:
     items = list_objects(vault_dir, limit=limit, offset=offset, query=query)
+    total_count = count_objects(vault_dir, query=query)
     return {
         "screen": "objects/index",
         "items": items,
         "count": len(items),
+        "total_count": total_count,
         "limit": limit,
         "offset": offset,
         "query": query or "",

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -90,6 +90,29 @@ def build_contradiction_browser_payload(vault_dir: Path | str) -> dict[str, Any]
     }
 
 
+def build_truth_dashboard_payload(vault_dir: Path | str) -> dict[str, Any]:
+    objects = build_objects_index_payload(vault_dir, limit=12, offset=0)
+    contradictions = build_contradiction_browser_payload(vault_dir)
+    events = build_event_dossier_payload(vault_dir)
+    return {
+        "screen": "truth/dashboard",
+        "objects": {
+            "count": objects["count"],
+            "items": objects["items"],
+        },
+        "contradictions": {
+            "count": contradictions["count"],
+            "open_count": contradictions["open_count"],
+            "items": contradictions["items"][:8],
+        },
+        "events": {
+            "count": events["event_count"],
+            "items": events["events"][:8],
+            "dates": events["dates"],
+        },
+    }
+
+
 def build_objects_index_payload(vault_dir: Path | str, *, limit: int = 100, offset: int = 0) -> dict[str, Any]:
     items = list_objects(vault_dir, limit=limit, offset=offset)
     return {

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -33,6 +33,11 @@ def build_object_page_payload(vault_dir: Path | str, object_id: str) -> dict[str
         "relation_count": len(relations),
         "contradiction_count": len(detail["contradictions"]),
         "evidence_count": len(detail["evidence"]),
+        "links": {
+            "topic_path": f"/topic?id={object_id}",
+            "events_path": f"/events?q={object_id}",
+            "contradictions_path": f"/contradictions?q={object_id}",
+        },
     }
 
 
@@ -43,6 +48,11 @@ def build_topic_overview_payload(vault_dir: Path | str, object_id: str) -> dict[
         **neighborhood,
         "edge_count": len(neighborhood["edges"]),
         "neighbor_count": len(neighborhood["neighbors"]),
+        "links": {
+            "center_object_path": f"/object?id={object_id}",
+            "events_path": f"/events?q={object_id}",
+            "contradictions_path": f"/contradictions?q={object_id}",
+        },
     }
 
 
@@ -97,8 +107,13 @@ def build_event_dossier_payload(vault_dir: Path | str, *, query: str | None = No
     }
 
 
-def build_contradiction_browser_payload(vault_dir: Path | str, *, status: str | None = None) -> dict[str, Any]:
-    items = list_contradictions(vault_dir, status=status)
+def build_contradiction_browser_payload(
+    vault_dir: Path | str,
+    *,
+    status: str | None = None,
+    query: str | None = None,
+) -> dict[str, Any]:
+    items = list_contradictions(vault_dir, status=status, query=query)
     status_counts = Counter(item["status"] for item in items)
     return {
         "screen": "truth/contradictions",
@@ -107,6 +122,7 @@ def build_contradiction_browser_payload(vault_dir: Path | str, *, status: str | 
         "open_count": status_counts.get("open", 0),
         "resolved_count": sum(count for status, count in status_counts.items() if status != "open"),
         "status": status or "",
+        "query": query or "",
     }
 
 

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -46,18 +46,36 @@ def build_topic_overview_payload(vault_dir: Path | str, object_id: str) -> dict[
     }
 
 
-def build_event_dossier_payload(vault_dir: Path | str) -> dict[str, Any]:
+def build_event_dossier_payload(vault_dir: Path | str, *, query: str | None = None) -> dict[str, Any]:
     db_path = _db_path(vault_dir)
+    normalized_query = query.strip().lower() if query else ""
     with sqlite3.connect(db_path) as conn:
-        rows = conn.execute(
-            """
-            SELECT timeline_events.event_date, timeline_events.event_type, objects.object_id, objects.title, compiled_summaries.summary_text
-            FROM timeline_events
-            JOIN objects ON objects.object_id = timeline_events.slug
-            LEFT JOIN compiled_summaries ON compiled_summaries.object_id = objects.object_id
-            ORDER BY timeline_events.event_date, objects.object_id
-            """
-        ).fetchall()
+        if normalized_query:
+            rows = conn.execute(
+                """
+                SELECT timeline_events.event_date, timeline_events.event_type, objects.object_id, objects.title, compiled_summaries.summary_text
+                FROM timeline_events
+                JOIN objects ON objects.object_id = timeline_events.slug
+                LEFT JOIN compiled_summaries ON compiled_summaries.object_id = objects.object_id
+                WHERE lower(objects.object_id) LIKE ? OR lower(objects.title) LIKE ? OR lower(compiled_summaries.summary_text) LIKE ?
+                ORDER BY timeline_events.event_date, objects.object_id
+                """,
+                (
+                    f"%{normalized_query}%",
+                    f"%{normalized_query}%",
+                    f"%{normalized_query}%",
+                ),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                """
+                SELECT timeline_events.event_date, timeline_events.event_type, objects.object_id, objects.title, compiled_summaries.summary_text
+                FROM timeline_events
+                JOIN objects ON objects.object_id = timeline_events.slug
+                LEFT JOIN compiled_summaries ON compiled_summaries.object_id = objects.object_id
+                ORDER BY timeline_events.event_date, objects.object_id
+                """
+            ).fetchall()
 
     events = [
         {
@@ -75,11 +93,12 @@ def build_event_dossier_payload(vault_dir: Path | str) -> dict[str, Any]:
         "events": events,
         "event_count": len(events),
         "dates": dates,
+        "query": query or "",
     }
 
 
-def build_contradiction_browser_payload(vault_dir: Path | str) -> dict[str, Any]:
-    items = list_contradictions(vault_dir)
+def build_contradiction_browser_payload(vault_dir: Path | str, *, status: str | None = None) -> dict[str, Any]:
+    items = list_contradictions(vault_dir, status=status)
     status_counts = Counter(item["status"] for item in items)
     return {
         "screen": "truth/contradictions",
@@ -87,6 +106,7 @@ def build_contradiction_browser_payload(vault_dir: Path | str) -> dict[str, Any]
         "count": len(items),
         "open_count": status_counts.get("open", 0),
         "resolved_count": sum(count for status, count in status_counts.items() if status != "open"),
+        "status": status or "",
     }
 
 

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -142,6 +142,16 @@ def test_truth_api_rejects_negative_pagination_inputs(temp_vault):
         raise AssertionError("Expected ValueError for negative contradiction limit")
 
 
+def test_truth_api_filters_objects_by_query(temp_vault):
+    from openclaw_pipeline.truth_api import list_objects
+
+    vault = _seed_truth_vault(temp_vault)
+
+    objects = list_objects(vault, query="target")
+
+    assert [item["object_id"] for item in objects] == ["target-note"]
+
+
 def test_truth_api_matches_contradictions_by_exact_object_id_prefix(temp_vault):
     from openclaw_pipeline.truth_api import get_object_detail
 

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -163,6 +163,46 @@ def test_truth_api_filters_objects_by_query(temp_vault):
     assert [item["object_id"] for item in objects] == ["target-note"]
 
 
+def test_truth_api_escapes_like_wildcards_in_object_queries(temp_vault):
+    from openclaw_pipeline.truth_api import list_objects
+
+    percent = temp_vault / "10-Knowledge" / "Evergreen" / "Percent.md"
+    alpha = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
+    percent.write_text(
+        """---
+note_id: percent%note
+title: Percent % Note
+type: evergreen
+date: 2026-04-13
+---
+
+# Percent % Note
+
+Literal percent id.
+""",
+        encoding="utf-8",
+    )
+    alpha.write_text(
+        """---
+note_id: alpha-note
+title: Alpha Note
+type: evergreen
+date: 2026-04-13
+---
+
+# Alpha Note
+
+Regular note.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    objects = list_objects(temp_vault, query="%")
+
+    assert [item["title"] for item in objects] == ["Percent % Note"]
+
+
 def test_truth_api_matches_contradictions_by_exact_object_id_prefix(temp_vault):
     from openclaw_pipeline.truth_api import get_object_detail
 

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -102,6 +102,17 @@ def test_truth_api_lists_contradictions(temp_vault):
     assert items[0]["negative_claim_ids"]
 
 
+def test_truth_api_filters_contradictions_by_query(temp_vault):
+    from openclaw_pipeline.truth_api import list_contradictions
+
+    vault = _seed_truth_vault(temp_vault)
+
+    items = list_contradictions(vault, query="agent")
+
+    assert len(items) == 1
+    assert items[0]["subject_key"] == "agent harness"
+
+
 def test_truth_api_builds_topic_neighborhood(temp_vault):
     from openclaw_pipeline.truth_api import get_topic_neighborhood
 

--- a/tests/test_truth_api_command.py
+++ b/tests/test_truth_api_command.py
@@ -108,6 +108,19 @@ def test_truth_api_command_lists_contradictions(temp_vault, capsys):
     assert payload["items"][0]["subject_key"] == "alpha"
 
 
+def test_truth_api_command_filters_contradictions_by_query(temp_vault, capsys):
+    from openclaw_pipeline.commands.truth_api import main
+
+    _seed_truth_store(temp_vault)
+
+    exit_code = main(["contradictions", "--vault-dir", str(temp_vault), "--query", "alp"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert len(payload["items"]) == 1
+    assert payload["items"][0]["subject_key"] == "alpha"
+
+
 def test_truth_api_command_returns_neighborhood(temp_vault, capsys):
     from openclaw_pipeline.commands.truth_api import main
 

--- a/tests/test_truth_api_command.py
+++ b/tests/test_truth_api_command.py
@@ -70,6 +70,18 @@ def test_truth_api_command_lists_objects(temp_vault, capsys):
     assert [item["object_id"] for item in payload["items"]] == ["alpha", "beta", "conflict"]
 
 
+def test_truth_api_command_filters_objects_by_query(temp_vault, capsys):
+    from openclaw_pipeline.commands.truth_api import main
+
+    _seed_truth_store(temp_vault)
+
+    exit_code = main(["objects", "--vault-dir", str(temp_vault), "--query", "bet"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert [item["object_id"] for item in payload["items"]] == ["beta"]
+
+
 def test_truth_api_command_returns_object_detail(temp_vault, capsys):
     from openclaw_pipeline.commands.truth_api import main
 

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import sqlite3
 import threading
 from http.client import HTTPConnection
 
 from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
+from openclaw_pipeline.runtime import VaultLayout
 
 
 def _seed_truth_store(temp_vault):
@@ -56,6 +58,20 @@ Alpha does not support local-first execution.
         encoding="utf-8",
     )
     rebuild_knowledge_index(temp_vault)
+
+
+def _resolve_all_contradictions(temp_vault):
+    db_path = VaultLayout.from_vault(temp_vault).knowledge_db
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            UPDATE contradictions
+            SET status = 'resolved',
+                resolution_note = 'reviewed',
+                resolved_at = '2026-04-14T00:00:00Z'
+            """
+        )
+        conn.commit()
 def _get(port: int, path: str) -> tuple[int, str]:
     conn = HTTPConnection("127.0.0.1", port, timeout=5)
     conn.request("GET", path)
@@ -136,6 +152,48 @@ def test_ui_objects_page_filters_by_query(temp_vault):
     thread.start()
     try:
         status, body = _get(port, "/objects?q=bet")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert status == 200
+    assert "Beta" in body
+    assert "Alpha" not in body
+
+
+def test_ui_contradictions_page_filters_by_status(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+
+    _seed_truth_store(temp_vault)
+    _resolve_all_contradictions(temp_vault)
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        status, body = _get(port, "/contradictions?status=resolved")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert status == 200
+    assert "resolved" in body
+    assert "<span class='pill'>resolved</span>" in body
+    assert "<span class='pill'>open</span>" not in body
+
+
+def test_ui_events_page_filters_by_query(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+
+    _seed_truth_store(temp_vault)
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        status, body = _get(port, "/events?q=beta")
     finally:
         server.shutdown()
         server.server_close()

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -109,20 +109,25 @@ def test_ui_smoke_pages_render_truth_views(temp_vault):
     assert '/topic?id=alpha' in object_body
     assert '/events?q=alpha' in object_body
     assert '/contradictions?q=alpha' in object_body
+    assert 'href="#claims"' in object_body
+    assert "Source Slug" in object_body
 
     assert topic_status == 200
     assert "Topic: Alpha" in topic_body
     assert "Neighbors" in topic_body
     assert '/object?id=alpha' in topic_body
     assert '/events?q=alpha' in topic_body
+    assert "Center Summary" in topic_body
 
     assert events_status == 200
     assert "Event Dossier" in events_body
     assert "2026-04-13" in events_body
+    assert 'id="date-2026-04-13"' in events_body
 
     assert contradictions_status == 200
     assert "Contradictions" in contradictions_body
     assert "alpha" in contradictions_body
+    assert '/object?id=alpha' in contradictions_body
 
 
 def test_ui_root_dashboard_renders_db_summary(temp_vault):

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -124,3 +124,23 @@ def test_ui_root_dashboard_renders_db_summary(temp_vault):
     assert "Contradictions Open" in root_body
     assert "Recent Events" in root_body
     assert "Alpha" in root_body
+
+
+def test_ui_objects_page_filters_by_query(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+
+    _seed_truth_store(temp_vault)
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        status, body = _get(port, "/objects?q=bet")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert status == 200
+    assert "Beta" in body
+    assert "Alpha" not in body

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -102,3 +102,25 @@ def test_ui_smoke_pages_render_truth_views(temp_vault):
     assert contradictions_status == 200
     assert "Contradictions" in contradictions_body
     assert "alpha" in contradictions_body
+
+
+def test_ui_root_dashboard_renders_db_summary(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+
+    _seed_truth_store(temp_vault)
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        root_status, root_body = _get(port, "/")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert root_status == 200
+    assert "Objects Indexed" in root_body
+    assert "Contradictions Open" in root_body
+    assert "Recent Events" in root_body
+    assert "Alpha" in root_body

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -106,10 +106,15 @@ def test_ui_smoke_pages_render_truth_views(temp_vault):
     assert "Object: Alpha" in object_body
     assert "Relations" in object_body
     assert "Beta" in object_body
+    assert '/topic?id=alpha' in object_body
+    assert '/events?q=alpha' in object_body
+    assert '/contradictions?q=alpha' in object_body
 
     assert topic_status == 200
     assert "Topic: Alpha" in topic_body
     assert "Neighbors" in topic_body
+    assert '/object?id=alpha' in topic_body
+    assert '/events?q=alpha' in topic_body
 
     assert events_status == 200
     assert "Event Dossier" in events_body
@@ -182,6 +187,25 @@ def test_ui_contradictions_page_filters_by_status(temp_vault):
     assert "resolved" in body
     assert "<span class='pill'>resolved</span>" in body
     assert "<span class='pill'>open</span>" not in body
+
+
+def test_ui_contradictions_page_filters_by_query(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+
+    _seed_truth_store(temp_vault)
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        status, body = _get(port, "/contradictions?q=alp")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert status == 200
+    assert "alpha" in body
 
 
 def test_ui_events_page_filters_by_query(temp_vault):

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -57,6 +57,22 @@ Alpha does not support local-first execution.
     rebuild_knowledge_index(temp_vault)
 
 
+def _resolve_all_contradictions(temp_vault):
+    from openclaw_pipeline.runtime import VaultLayout
+
+    db_path = VaultLayout.from_vault(temp_vault).knowledge_db
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            UPDATE contradictions
+            SET status = 'resolved',
+                resolution_note = 'reviewed',
+                resolved_at = '2026-04-14T00:00:00Z'
+            """
+        )
+        conn.commit()
+
+
 def test_build_object_page_payload(temp_vault):
     from openclaw_pipeline.ui.view_models import build_object_page_payload
 
@@ -111,6 +127,19 @@ def test_build_contradiction_browser_payload(temp_vault):
     assert payload["open_count"] == 1
 
 
+def test_build_contradiction_browser_payload_filters_by_status(temp_vault):
+    from openclaw_pipeline.ui.view_models import build_contradiction_browser_payload
+
+    _seed_truth_store(temp_vault)
+    _resolve_all_contradictions(temp_vault)
+
+    payload = build_contradiction_browser_payload(temp_vault, status="resolved")
+
+    assert payload["count"] == 1
+    assert payload["open_count"] == 0
+    assert payload["items"][0]["status"] == "resolved"
+
+
 def test_build_truth_dashboard_payload(temp_vault):
     from openclaw_pipeline.ui.view_models import build_truth_dashboard_payload
 
@@ -123,6 +152,17 @@ def test_build_truth_dashboard_payload(temp_vault):
     assert payload["contradictions"]["count"] == 1
     assert payload["events"]["count"] == 3
     assert payload["objects"]["items"][0]["object_id"] == "alpha"
+
+
+def test_build_event_dossier_payload_filters_by_query(temp_vault):
+    from openclaw_pipeline.ui.view_models import build_event_dossier_payload
+
+    _seed_truth_store(temp_vault)
+
+    payload = build_event_dossier_payload(temp_vault, query="beta")
+
+    assert payload["event_count"] == 1
+    assert [item["object_id"] for item in payload["events"]] == ["beta"]
 
 
 def test_build_object_page_payload_handles_missing_summary(temp_vault):

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -86,6 +86,9 @@ def test_build_object_page_payload(temp_vault):
     assert payload["claim_count"] == 1
     assert payload["relation_count"] == 1
     assert payload["contradiction_count"] == 1
+    assert payload["links"]["topic_path"] == "/topic?id=alpha"
+    assert payload["links"]["events_path"] == "/events?q=alpha"
+    assert payload["links"]["contradictions_path"] == "/contradictions?q=alpha"
 
 
 def test_build_topic_overview_payload(temp_vault):
@@ -99,6 +102,8 @@ def test_build_topic_overview_payload(temp_vault):
     assert payload["center"]["object_id"] == "alpha"
     assert [item["object_id"] for item in payload["neighbors"]] == ["beta"]
     assert payload["edge_count"] == 1
+    assert payload["links"]["center_object_path"] == "/object?id=alpha"
+    assert payload["links"]["events_path"] == "/events?q=alpha"
 
 
 def test_build_event_dossier_payload(temp_vault):
@@ -138,6 +143,17 @@ def test_build_contradiction_browser_payload_filters_by_status(temp_vault):
     assert payload["count"] == 1
     assert payload["open_count"] == 0
     assert payload["items"][0]["status"] == "resolved"
+
+
+def test_build_contradiction_browser_payload_filters_by_query(temp_vault):
+    from openclaw_pipeline.ui.view_models import build_contradiction_browser_payload
+
+    _seed_truth_store(temp_vault)
+
+    payload = build_contradiction_browser_payload(temp_vault, query="alp")
+
+    assert payload["count"] == 1
+    assert payload["items"][0]["subject_key"] == "alpha"
 
 
 def test_build_truth_dashboard_payload(temp_vault):

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -89,6 +89,8 @@ def test_build_object_page_payload(temp_vault):
     assert payload["links"]["topic_path"] == "/topic?id=alpha"
     assert payload["links"]["events_path"] == "/events?q=alpha"
     assert payload["links"]["contradictions_path"] == "/contradictions?q=alpha"
+    assert payload["context"]["source_slug"] == "alpha"
+    assert payload["section_nav"][0]["href"] == "#summary"
 
 
 def test_build_topic_overview_payload(temp_vault):
@@ -104,6 +106,7 @@ def test_build_topic_overview_payload(temp_vault):
     assert payload["edge_count"] == 1
     assert payload["links"]["center_object_path"] == "/object?id=alpha"
     assert payload["links"]["events_path"] == "/events?q=alpha"
+    assert payload["center_summary"] == "Alpha supports local-first execution."
 
 
 def test_build_event_dossier_payload(temp_vault):
@@ -117,6 +120,7 @@ def test_build_event_dossier_payload(temp_vault):
     assert payload["event_count"] == 3
     assert payload["dates"] == ["2026-04-13"]
     assert payload["events"][0]["object_id"] == "alpha"
+    assert payload["date_sections"][0]["date"] == "2026-04-13"
 
 
 def test_build_contradiction_browser_payload(temp_vault):
@@ -130,6 +134,7 @@ def test_build_contradiction_browser_payload(temp_vault):
     assert payload["count"] == 1
     assert payload["items"][0]["subject_key"] == "alpha"
     assert payload["open_count"] == 1
+    assert payload["items"][0]["object_ids"] == ["alpha", "conflict"]
 
 
 def test_build_contradiction_browser_payload_filters_by_status(temp_vault):

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -175,6 +175,34 @@ def test_build_truth_dashboard_payload(temp_vault):
     assert payload["objects"]["items"][0]["object_id"] == "alpha"
 
 
+def test_build_truth_dashboard_payload_uses_total_object_count(temp_vault):
+    from openclaw_pipeline.ui.view_models import build_truth_dashboard_payload
+
+    _seed_truth_store(temp_vault)
+    for index in range(20):
+        extra = temp_vault / "10-Knowledge" / "Evergreen" / f"Extra-{index}.md"
+        extra.write_text(
+            f"""---
+note_id: extra-{index}
+title: Extra {index}
+type: evergreen
+date: 2026-04-13
+---
+
+# Extra {index}
+
+Filler note.
+""",
+            encoding="utf-8",
+        )
+    rebuild_knowledge_index(temp_vault)
+
+    payload = build_truth_dashboard_payload(temp_vault)
+
+    assert payload["objects"]["count"] == 23
+    assert len(payload["objects"]["items"]) == 12
+
+
 def test_build_event_dossier_payload_filters_by_query(temp_vault):
     from openclaw_pipeline.ui.view_models import build_event_dossier_payload
 
@@ -184,6 +212,17 @@ def test_build_event_dossier_payload_filters_by_query(temp_vault):
 
     assert payload["event_count"] == 1
     assert [item["object_id"] for item in payload["events"]] == ["beta"]
+
+
+def test_build_event_dossier_payload_applies_limit_before_materializing(temp_vault):
+    from openclaw_pipeline.ui.view_models import build_event_dossier_payload
+
+    _seed_truth_store(temp_vault)
+
+    payload = build_event_dossier_payload(temp_vault, limit=2)
+
+    assert payload["event_count"] == 2
+    assert len(payload["events"]) == 2
 
 
 def test_build_object_page_payload_handles_missing_summary(temp_vault):

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -111,6 +111,20 @@ def test_build_contradiction_browser_payload(temp_vault):
     assert payload["open_count"] == 1
 
 
+def test_build_truth_dashboard_payload(temp_vault):
+    from openclaw_pipeline.ui.view_models import build_truth_dashboard_payload
+
+    _seed_truth_store(temp_vault)
+
+    payload = build_truth_dashboard_payload(temp_vault)
+
+    assert payload["screen"] == "truth/dashboard"
+    assert payload["objects"]["count"] == 3
+    assert payload["contradictions"]["count"] == 1
+    assert payload["events"]["count"] == 3
+    assert payload["objects"]["items"][0]["object_id"] == "alpha"
+
+
 def test_build_object_page_payload_handles_missing_summary(temp_vault):
     from openclaw_pipeline.ui.view_models import build_object_page_payload
     from openclaw_pipeline.runtime import VaultLayout


### PR DESCRIPTION
## Summary
- add a DB-backed truth dashboard home and object search to `ovp-ui`
- add contradiction and event filters, plus pack-aware contradiction query support in `ovp-truth`
- enrich object/topic/event/contradiction pages with cross-navigation, context summaries, grouped event sections, and linked contradiction objects

## Verification
- `PYTHONPATH=src python3.13 -m pytest -q`
- `python3.13 -m compileall src/openclaw_pipeline`
- real smoke against `/Users/chris/Documents/openclaw-vault` for `/`, `/object?id=context-engineering`, `/topic?id=context-engineering`, `/events?q=agent`, `/contradictions?status=open&q=agent`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/10" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
