### PR TITLE
feat: add product installer for ovp commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ vault/
 ## 快速开始
 
 ```bash
-pip install obsidian-vault-pipeline
+curl -fsSL https://raw.githubusercontent.com/fakechris/obsidian_vault_pipeline/main/scripts/install-user.sh | bash
 
 mkdir -p my-vault
 cd my-vault
@@ -436,6 +436,15 @@ cd my-vault
 ovp --check
 ovp --full
 ```
+
+如果你更偏好显式的 PyPI 两步安装：
+
+```bash
+python3 -m pip install --user obsidian-vault-pipeline
+python3 -m openclaw_pipeline.installer
+```
+
+安装器会优先把 `ovp*` 命令写入当前 `PATH` 里可写的安全 bin 目录；如果找不到，则退回 `~/.local/bin`，不会修改你的 shell 配置。
 
 如果你要显式看到整形层：
 

--- a/README.md
+++ b/README.md
@@ -428,7 +428,9 @@ vault/
 ## 快速开始
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/fakechris/obsidian_vault_pipeline/main/scripts/install-user.sh | bash
+curl -fsSLO https://raw.githubusercontent.com/fakechris/obsidian_vault_pipeline/main/scripts/install-user.sh
+less install-user.sh
+bash install-user.sh
 
 mkdir -p my-vault
 cd my-vault
@@ -442,6 +444,12 @@ ovp --full
 ```bash
 python3 -m pip install --user obsidian-vault-pipeline
 python3 -m openclaw_pipeline.installer
+```
+
+如果你的 Python 环境启用了 PEP 668，优先使用：
+
+```bash
+pipx install obsidian-vault-pipeline
 ```
 
 安装器会优先把 `ovp*` 命令写入当前 `PATH` 里可写的安全 bin 目录；如果找不到，则退回 `~/.local/bin`，不会修改你的 shell 配置。

--- a/README_EN.md
+++ b/README_EN.md
@@ -430,7 +430,7 @@ Default discovery now routes through this layer:
 ## Quick Start
 
 ```bash
-pip install obsidian-vault-pipeline
+curl -fsSL https://raw.githubusercontent.com/fakechris/obsidian_vault_pipeline/main/scripts/install-user.sh | bash
 
 mkdir -p my-vault
 cd my-vault
@@ -438,6 +438,15 @@ cd my-vault
 ovp --check
 ovp --full
 ```
+
+If you prefer the explicit PyPI two-step flow:
+
+```bash
+python3 -m pip install --user obsidian-vault-pipeline
+python3 -m openclaw_pipeline.installer
+```
+
+The installer prefers a writable, safe bin directory that is already on `PATH`; if none is available, it falls back to `~/.local/bin`. It does not edit your shell configuration.
 
 If you want to see the refine layer explicitly:
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -430,7 +430,9 @@ Default discovery now routes through this layer:
 ## Quick Start
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/fakechris/obsidian_vault_pipeline/main/scripts/install-user.sh | bash
+curl -fsSLO https://raw.githubusercontent.com/fakechris/obsidian_vault_pipeline/main/scripts/install-user.sh
+less install-user.sh
+bash install-user.sh
 
 mkdir -p my-vault
 cd my-vault
@@ -444,6 +446,12 @@ If you prefer the explicit PyPI two-step flow:
 ```bash
 python3 -m pip install --user obsidian-vault-pipeline
 python3 -m openclaw_pipeline.installer
+```
+
+If your Python installation enforces PEP 668, prefer:
+
+```bash
+pipx install obsidian-vault-pipeline
 ```
 
 The installer prefers a writable, safe bin directory that is already on `PATH`; if none is available, it falls back to `~/.local/bin`. It does not edit your shell configuration.

--- a/scripts/install-user.sh
+++ b/scripts/install-user.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+OVP_PACKAGE_SPEC="${OVP_PACKAGE_SPEC:-obsidian-vault-pipeline}"
+OVP_DISTRIBUTION_NAME="${OVP_DISTRIBUTION_NAME:-obsidian-vault-pipeline}"
+
+if ! RESOLVED_PYTHON_BIN="$(command -v "$PYTHON_BIN")"; then
+  echo "Could not find Python interpreter: $PYTHON_BIN" >&2
+  exit 1
+fi
+PYTHON_BIN="$RESOLVED_PYTHON_BIN"
+
+install_package() {
+  if "$PYTHON_BIN" -m pip install --user "$1"; then
+    return 0
+  fi
+  "$PYTHON_BIN" -m pip install --user --break-system-packages "$1"
+}
+
+install_package "$OVP_PACKAGE_SPEC"
+
+installer_args=(
+  -m
+  openclaw_pipeline.installer
+  --distribution
+  "$OVP_DISTRIBUTION_NAME"
+  --python-executable
+  "$PYTHON_BIN"
+)
+
+if [ -n "${OVP_BIN_DIR:-}" ]; then
+  installer_args+=(--bin-dir "$OVP_BIN_DIR")
+fi
+
+"$PYTHON_BIN" "${installer_args[@]}"

--- a/scripts/install-user.sh
+++ b/scripts/install-user.sh
@@ -15,7 +15,22 @@ install_package() {
   if "$PYTHON_BIN" -m pip install --user "$1"; then
     return 0
   fi
-  "$PYTHON_BIN" -m pip install --user --break-system-packages "$1"
+  if [ "${OVP_ALLOW_BREAK_SYSTEM_PACKAGES:-0}" = "1" ]; then
+    "$PYTHON_BIN" -m pip install --user --break-system-packages "$1"
+    return 0
+  fi
+  cat >&2 <<EOF
+User-scoped pip install failed for $1.
+
+Recommended options:
+  1. Use pipx:
+     pipx install $1
+  2. Re-run this installer with explicit opt-in:
+     OVP_ALLOW_BREAK_SYSTEM_PACKAGES=1 ./scripts/install-user.sh
+
+This script does not force --break-system-packages by default.
+EOF
+  return 1
 }
 
 install_package "$OVP_PACKAGE_SPEC"

--- a/src/openclaw_pipeline/installer.py
+++ b/src/openclaw_pipeline/installer.py
@@ -67,6 +67,7 @@ def write_shims(
         module_name, func_name = _split_entry_point(entry_point)
         wrapper_path = target_dir / script_name
         wrapper_body = _build_wrapper(
+            script_name=script_name,
             python_executable=python_executable,
             module_name=module_name,
             func_name=func_name,
@@ -120,7 +121,10 @@ def main(argv: list[str] | None = None) -> int:
         python_executable=args.python_executable,
     )
     print(f"Installed {len(created)} OVP command shims into {target_dir}")
-    if str(target_dir) not in os.environ.get("PATH", "").split(os.pathsep):
+    path_entries = _parse_path_entries(os.environ.get("PATH", ""))
+    if target_dir.resolve(strict=False) not in {
+        entry.resolve(strict=False) for entry in path_entries
+    }:
         print(f"Note: {target_dir} is not currently on PATH.")
     return 0
 
@@ -159,8 +163,6 @@ def _curated_path_candidates(path_entries: list[Path], home_dir: Path) -> list[P
         if home_dir in resolved.parents and candidate.name == "bin":
             candidates.append(candidate)
             continue
-        if candidate in preferred_system_bins:
-            candidates.append(candidate)
     return candidates
 
 
@@ -181,15 +183,21 @@ def _split_entry_point(entry_point: str) -> tuple[str, str]:
     return module_name, func_name
 
 
-def _build_wrapper(python_executable: str, module_name: str, func_name: str) -> str:
+def _build_wrapper(
+    script_name: str,
+    python_executable: str,
+    module_name: str,
+    func_name: str,
+) -> str:
     python_code = (
+        f"import sys; sys.argv[0] = {script_name!r}; "
         f"from {module_name} import {func_name} as _entry; "
         "raise SystemExit(_entry())"
     )
     return (
         "#!/usr/bin/env bash\n"
         "set -euo pipefail\n"
-        f'exec "{python_executable}" -c {shlex.quote(python_code)} "$@"\n'
+        f'exec {shlex.quote(python_executable)} -c {shlex.quote(python_code)} "$@"\n'
     )
 
 

--- a/src/openclaw_pipeline/installer.py
+++ b/src/openclaw_pipeline/installer.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import stat
+import sys
+from importlib.metadata import PackageNotFoundError, distribution
+from pathlib import Path
+
+PACKAGE_NAME = "obsidian-vault-pipeline"
+
+
+def load_project_scripts(project_root: Path) -> dict[str, str]:
+    toml_module = _load_toml_module()
+    pyproject_path = project_root / "pyproject.toml"
+    with pyproject_path.open("rb") as fh:
+        data = toml_module.load(fh)
+    scripts = data.get("project", {}).get("scripts", {})
+    return {
+        name: entry_point
+        for name, entry_point in scripts.items()
+        if name.startswith("ovp")
+    }
+
+
+def load_distribution_scripts(distribution_name: str = PACKAGE_NAME) -> dict[str, str]:
+    dist = distribution(distribution_name)
+    scripts: dict[str, str] = {}
+    for entry_point in dist.entry_points:
+        if entry_point.group == "console_scripts" and entry_point.name.startswith("ovp"):
+            scripts[entry_point.name] = entry_point.value
+    return scripts
+
+
+def choose_install_bin_dir(path_env: str | None = None, home_dir: Path | None = None) -> Path:
+    home = home_dir or Path.home()
+    path_value = path_env if path_env is not None else os.environ.get("PATH", "")
+    path_entries = _parse_path_entries(path_value)
+
+    preferred_bins = [
+        home / ".local" / "bin",
+        home / "bin",
+    ]
+    preferred_lookup = {path.resolve(strict=False) for path in preferred_bins}
+    path_lookup = {path.resolve(strict=False) for path in path_entries}
+
+    for preferred in preferred_bins:
+        if preferred.resolve(strict=False) in path_lookup and _is_writable_dir(preferred):
+            return preferred
+
+    for candidate in _curated_path_candidates(path_entries, home):
+        if _is_writable_dir(candidate):
+            return candidate
+
+    return preferred_bins[0]
+
+
+def write_shims(
+    target_dir: Path,
+    scripts: dict[str, str],
+    python_executable: str,
+) -> list[Path]:
+    target_dir.mkdir(parents=True, exist_ok=True)
+    created: list[Path] = []
+    for script_name, entry_point in sorted(scripts.items()):
+        module_name, func_name = _split_entry_point(entry_point)
+        wrapper_path = target_dir / script_name
+        wrapper_body = _build_wrapper(
+            python_executable=python_executable,
+            module_name=module_name,
+            func_name=func_name,
+        )
+        wrapper_path.write_text(wrapper_body, encoding="utf-8")
+        current_mode = wrapper_path.stat().st_mode
+        wrapper_path.chmod(current_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        created.append(wrapper_path)
+    return created
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Install OVP command shims into a user-visible bin directory.",
+    )
+    parser.add_argument(
+        "--project-root",
+        type=Path,
+        help="Repository root containing pyproject.toml. Used as a fallback when distribution metadata is unavailable.",
+    )
+    parser.add_argument(
+        "--distribution",
+        default=PACKAGE_NAME,
+        help=f"Installed distribution name to inspect. Defaults to {PACKAGE_NAME}.",
+    )
+    parser.add_argument(
+        "--bin-dir",
+        type=Path,
+        help="Explicit directory to place command shims into.",
+    )
+    parser.add_argument(
+        "--python-executable",
+        default=sys.executable,
+        help="Python executable used inside generated shims.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        scripts = load_distribution_scripts(args.distribution)
+    except PackageNotFoundError:
+        if args.project_root is None:
+            parser.error(
+                f"Distribution {args.distribution!r} is not installed and --project-root was not provided."
+            )
+        scripts = load_project_scripts(args.project_root)
+
+    target_dir = args.bin_dir or choose_install_bin_dir()
+    created = write_shims(
+        target_dir=target_dir,
+        scripts=scripts,
+        python_executable=args.python_executable,
+    )
+    print(f"Installed {len(created)} OVP command shims into {target_dir}")
+    if str(target_dir) not in os.environ.get("PATH", "").split(os.pathsep):
+        print(f"Note: {target_dir} is not currently on PATH.")
+    return 0
+
+
+def _parse_path_entries(path_env: str) -> list[Path]:
+    entries: list[Path] = []
+    seen: set[Path] = set()
+    for raw_entry in path_env.split(os.pathsep):
+        if not raw_entry:
+            continue
+        path = Path(raw_entry).expanduser()
+        resolved = path.resolve(strict=False)
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        entries.append(path)
+    return entries
+
+
+def _curated_path_candidates(path_entries: list[Path], home_dir: Path) -> list[Path]:
+    candidates: list[Path] = []
+    preferred_system_bins = [
+        Path("/usr/local/bin"),
+        Path("/opt/homebrew/bin"),
+    ]
+    for candidate in preferred_system_bins:
+        if candidate in path_entries:
+            candidates.append(candidate)
+
+    for candidate in path_entries:
+        if candidate in candidates:
+            continue
+        resolved = candidate.resolve(strict=False)
+        if _looks_like_virtualenv_bin(candidate):
+            continue
+        if home_dir in resolved.parents and candidate.name == "bin":
+            candidates.append(candidate)
+            continue
+        if candidate in preferred_system_bins:
+            candidates.append(candidate)
+    return candidates
+
+
+def _looks_like_virtualenv_bin(path: Path) -> bool:
+    text = str(path)
+    markers = (".venv/", "virtualenv", "conda", "miniconda", "/envs/")
+    return any(marker in text for marker in markers)
+
+
+def _is_writable_dir(path: Path) -> bool:
+    return path.is_dir() and os.access(path, os.W_OK | os.X_OK)
+
+
+def _split_entry_point(entry_point: str) -> tuple[str, str]:
+    module_name, _, func_name = entry_point.partition(":")
+    if not module_name or not func_name:
+        raise ValueError(f"Unsupported entry point: {entry_point!r}")
+    return module_name, func_name
+
+
+def _build_wrapper(python_executable: str, module_name: str, func_name: str) -> str:
+    python_code = (
+        f"from {module_name} import {func_name} as _entry; "
+        "raise SystemExit(_entry())"
+    )
+    return (
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        f'exec "{python_executable}" -c {shlex.quote(python_code)} "$@"\n'
+    )
+
+
+def _load_toml_module():
+    try:
+        import tomllib
+
+        return tomllib
+    except ModuleNotFoundError:
+        try:
+            import tomli
+
+            return tomli
+        except ModuleNotFoundError as exc:
+            raise RuntimeError(
+                "Reading pyproject.toml requires tomllib (Python 3.11+) or tomli."
+            ) from exc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -34,9 +34,28 @@ def test_installer_writes_executable_shims(tmp_path):
     wrapper = target_dir / "ovp-ui"
     body = wrapper.read_text(encoding="utf-8")
     assert body.startswith("#!/usr/bin/env bash")
-    assert 'exec "/opt/homebrew/opt/python@3.13/bin/python3.13"' in body
+    assert "sys.argv[0]" in body
+    assert "ovp-ui" in body
+    assert "exec /opt/homebrew/opt/python@3.13/bin/python3.13" in body
     assert "from openclaw_pipeline.commands.ui_server import main" in body
     assert os.access(wrapper, os.X_OK)
+
+
+def test_installer_shell_escapes_python_executable(tmp_path):
+    from openclaw_pipeline.installer import write_shims
+
+    target_dir = tmp_path / "bin"
+    scripts = {"ovp-ui": "openclaw_pipeline.commands.ui_server:main"}
+
+    created = write_shims(
+        target_dir=target_dir,
+        scripts=scripts,
+        python_executable="/tmp/python $HOME/bin/python3",
+    )
+
+    assert len(created) == 1
+    body = (target_dir / "ovp-ui").read_text(encoding="utf-8")
+    assert "exec '/tmp/python $HOME/bin/python3'" in body
 
 
 def test_choose_install_bin_dir_prefers_user_path_entry(tmp_path):

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def test_installer_loads_ovp_scripts_from_pyproject():
+    from openclaw_pipeline.installer import load_project_scripts
+
+    scripts = load_project_scripts(Path(__file__).resolve().parents[1])
+
+    assert scripts["ovp"] == "openclaw_pipeline.unified_pipeline_enhanced:main"
+    assert scripts["ovp-ui"] == "openclaw_pipeline.commands.ui_server:main"
+    assert scripts["ovp-truth"] == "openclaw_pipeline.commands.truth_api:main"
+
+
+def test_installer_writes_executable_shims(tmp_path):
+    from openclaw_pipeline.installer import write_shims
+
+    target_dir = tmp_path / "bin"
+    scripts = {
+        "ovp-ui": "openclaw_pipeline.commands.ui_server:main",
+        "ovp-truth": "openclaw_pipeline.commands.truth_api:main",
+    }
+
+    created = write_shims(
+        target_dir=target_dir,
+        scripts=scripts,
+        python_executable="/opt/homebrew/opt/python@3.13/bin/python3.13",
+    )
+
+    assert [path.name for path in created] == ["ovp-truth", "ovp-ui"]
+
+    wrapper = target_dir / "ovp-ui"
+    body = wrapper.read_text(encoding="utf-8")
+    assert body.startswith("#!/usr/bin/env bash")
+    assert 'exec "/opt/homebrew/opt/python@3.13/bin/python3.13"' in body
+    assert "from openclaw_pipeline.commands.ui_server import main" in body
+    assert os.access(wrapper, os.X_OK)
+
+
+def test_choose_install_bin_dir_prefers_user_path_entry(tmp_path):
+    from openclaw_pipeline.installer import choose_install_bin_dir
+
+    home = tmp_path / "home"
+    user_local_bin = home / ".local" / "bin"
+    user_local_bin.mkdir(parents=True)
+    external_bin = tmp_path / "external-bin"
+    external_bin.mkdir()
+
+    selected = choose_install_bin_dir(
+        path_env=os.pathsep.join([str(external_bin), str(user_local_bin)]),
+        home_dir=home,
+    )
+
+    assert selected == user_local_bin
+
+
+def test_choose_install_bin_dir_falls_back_to_user_local_bin(tmp_path):
+    from openclaw_pipeline.installer import choose_install_bin_dir
+
+    home = tmp_path / "home"
+    selected = choose_install_bin_dir(path_env="", home_dir=home)
+
+    assert selected == home / ".local" / "bin"


### PR DESCRIPTION
## Summary
- add a productized installer module that discovers OVP console scripts and writes shims into a safe user bin directory
- add `scripts/install-user.sh` so users can install from PyPI/source without editing shell config
- document the installer flow in the README and cover it with installer-specific tests

## Verification
- `PYTHONPATH=src python3.13 -m pytest -q`
- `python3.13 -m compileall src/openclaw_pipeline`
- user-shell smoke: run `./scripts/install-user.sh` from `zsh -lc`, then verify `ovp-ui --help`, `ovp --help`, and `ovp-truth --help` resolve directly from `PATH`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/11" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
