### PR TITLE
feat: bridge truth UI to atlas and deep dives

### DIFF
--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -10,7 +10,9 @@ from urllib.parse import parse_qs, urlparse
 
 from ..runtime import resolve_vault_dir
 from ..ui.view_models import (
+    build_atlas_browser_payload,
     build_contradiction_browser_payload,
+    build_derivation_browser_payload,
     build_event_dossier_payload,
     build_object_page_payload,
     build_objects_index_payload,
@@ -80,6 +82,8 @@ def _layout(title: str, body: str) -> str:
           <nav>
             <a href="/">Home</a>
             <a href="/objects">Objects</a>
+            <a href="/atlas">Atlas</a>
+            <a href="/deep-dives">Deep Dives</a>
             <a href="/events">Event Dossier</a>
             <a href="/contradictions">Contradictions</a>
           </nav>
@@ -166,6 +170,14 @@ def _render_object_page(payload: dict) -> str:
         f'<li><span class="pill">{escape(item["status"])}</span>{escape(item["subject_key"])}</li>'
         for item in payload["contradictions"]
     ) or "<li>None</li>"
+    source_notes = "".join(
+        f"<li>{escape(item['title'])} <span class='muted'>({escape(item['note_type'])})</span></li>"
+        for item in payload["provenance"]["source_notes"]
+    ) or "<li>None</li>"
+    mocs = "".join(
+        f"<li>{escape(item['title'])}</li>"
+        for item in payload["provenance"]["mocs"]
+    ) or "<li>None</li>"
     summary_text = payload["summary"]["summary_text"] if payload["summary"] else ""
     section_nav = "".join(
         f'<a href="{escape(item["href"])}">{escape(item["label"])}</a>' for item in payload["section_nav"]
@@ -179,6 +191,8 @@ def _render_object_page(payload: dict) -> str:
             f"<a href='{escape(payload['links']['topic_path'])}'>Explore topic</a>"
             f"<a href='{escape(payload['links']['events_path'])}'>Related events</a>"
             f"<a href='{escape(payload['links']['contradictions_path'])}'>Contradictions</a>"
+            f"<a href='/deep-dives?q={escape(payload['object']['object_id'])}'>Source deep dives</a>"
+            f"<a href='/atlas?q={escape(payload['object']['object_id'])}'>Atlas / MOC</a>"
             "</div></section>"
             f"<nav class='subnav'>{section_nav}</nav>"
             "<section class='grid stats'>"
@@ -196,6 +210,11 @@ def _render_object_page(payload: dict) -> str:
             f"<div><dt>Object Kind</dt><dd>{escape(payload['context']['object_kind'])}</dd></div>"
             f"<div><dt>Source Slug</dt><dd>{escape(payload['context']['source_slug'])}</dd></div>"
             f"<div><dt>Canonical Path</dt><dd>{escape(payload['context']['canonical_path'])}</dd></div>"
+            "</dl></section>"
+            "<section class='card'><h2>Provenance</h2><dl class='meta-list'>"
+            f"<div><dt>Evergreen Markdown</dt><dd>{escape(payload['provenance']['evergreen_path'])}</dd></div>"
+            f"<div><dt>Source Notes</dt><dd><ul class='list-tight'>{source_notes}</ul></dd></div>"
+            f"<div><dt>Atlas / MOC</dt><dd><ul class='list-tight'>{mocs}</ul></dd></div>"
             "</dl></section>"
             f"<section id='relations' class='card'><h2>Relations</h2><ul class='list-tight'>{relations}</ul></section>"
             f"<section id='contradictions' class='card'><h2>Contradictions</h2><ul class='list-tight'>{contradictions}</ul></section>"
@@ -219,10 +238,13 @@ def _render_topic_page(payload: dict) -> str:
             f"<a href='{escape(payload['links']['center_object_path'])}'>Open center object</a>"
             f"<a href='{escape(payload['links']['events_path'])}'>Related events</a>"
             f"<a href='{escape(payload['links']['contradictions_path'])}'>Contradictions</a>"
+            f"<a href='/deep-dives?q={escape(payload['center']['object_id'])}'>Source deep dives</a>"
+            f"<a href='/atlas?q={escape(payload['center']['object_id'])}'>Atlas / MOC</a>"
             "</div></section>"
             "<section class='grid two-col'>"
             f"<section class='card'><h2>Center Summary</h2><p>{escape(payload['center_summary'])}</p></section>"
             f"<section class='card'><h2>Neighbors</h2><ul class='list-tight'>{neighbors}</ul></section>"
+            f"<section class='card'><h2>Atlas / MOC</h2><ul class='list-tight'>{''.join(f'<li>{escape(item['title'])}</li>' for item in payload['provenance']['mocs']) or '<li>None</li>'}</ul></section>"
             "</section>"
         ),
     )
@@ -237,8 +259,12 @@ def _render_events_page(payload: dict) -> str:
     events = "".join(
         f'<section id="date-{escape(section["date"])}" class="card"><h2>{escape(section["date"])}</h2><ul class="list-tight">'
         + "".join(
-            f"<li>{escape(item['event_type'])} - "
-            f'<a href="/object?id={escape(item["object_id"])}">{escape(item["title"])}</a></li>'
+            (
+                f"<li>{escape(item['event_type'])} - "
+                f'<a href="/object?id={escape(item["object_id"])}">{escape(item["title"])}</a></li>'
+                if item["event_type"] != "page_date"
+                else f'<li><a href="/object?id={escape(item["object_id"])}">{escape(item["title"])}</a></li>'
+            )
             for item in section["events"]
         )
         + "</ul></section>"
@@ -248,6 +274,7 @@ def _render_events_page(payload: dict) -> str:
         "Event Dossier",
         (
             "<h1>Event Dossier</h1>"
+            "<p class='muted'>A timeline-oriented view over dated truth objects, not a separate event object model.</p>"
             "<form method='get' action='/events'>"
             f"<input type='text' name='q' value='{escape(query)}' placeholder='Filter events' /> "
             "<button type='submit'>Search</button>"
@@ -255,6 +282,66 @@ def _render_events_page(payload: dict) -> str:
             f"<p class='muted'>{payload['event_count']} events across {len(payload['dates'])} dates.</p>"
             f"<nav class='subnav'>{date_nav}</nav>"
             f"{events}"
+        ),
+    )
+
+
+def _render_atlas_page(payload: dict) -> str:
+    query = payload.get("query", "")
+    items = "".join(
+        "<li>"
+        f"{escape(item['title'])}"
+        + (
+            " <span class='muted'>"
+            + ", ".join(
+                f'<a href="/object?id={escape(member["object_id"])}">{escape(member["title"])}</a>'
+                for member in item["members"]
+            )
+            + "</span>"
+        )
+        + "</li>"
+        for item in payload["items"]
+    ) or "<li>None</li>"
+    return _layout(
+        "Atlas / MOC Browser",
+        (
+            "<h1>Atlas / MOC Browser</h1>"
+            "<form method='get' action='/atlas'>"
+            f"<input type='text' name='q' value='{escape(query)}' placeholder='Filter MOCs or objects' /> "
+            "<button type='submit'>Search</button>"
+            "</form>"
+            f"<p class='muted'>{payload['count']} atlas/moc pages linked to indexed objects.</p>"
+            f"<section class='card'><ul class='list-tight'>{items}</ul></section>"
+        ),
+    )
+
+
+def _render_derivations_page(payload: dict) -> str:
+    query = payload.get("query", "")
+    items = "".join(
+        "<li>"
+        f"{escape(item['title'])}"
+        + (
+            " <span class='muted'>"
+            + ", ".join(
+                f'<a href="/object?id={escape(member["object_id"])}">{escape(member["title"])}</a>'
+                for member in item["derived_objects"]
+            )
+            + "</span>"
+        )
+        + "</li>"
+        for item in payload["items"]
+    ) or "<li>None</li>"
+    return _layout(
+        "Deep Dive Derivations",
+        (
+            "<h1>Deep Dive Derivations</h1>"
+            "<form method='get' action='/deep-dives'>"
+            f"<input type='text' name='q' value='{escape(query)}' placeholder='Filter deep dives or objects' /> "
+            "<button type='submit'>Search</button>"
+            "</form>"
+            f"<p class='muted'>{payload['count']} deep dive notes linked to indexed objects.</p>"
+            f"<section class='card'><ul class='list-tight'>{items}</ul></section>"
         ),
     )
 
@@ -356,6 +443,24 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
                     q = query.get("q", [""])[0]
                     payload = build_event_dossier_payload(resolved_vault, query=q)
                     self._write_html(_render_events_page(payload))
+                    return
+                if path == "/api/atlas":
+                    q = query.get("q", [""])[0]
+                    self._write_json(build_atlas_browser_payload(resolved_vault, query=q))
+                    return
+                if path == "/atlas":
+                    q = query.get("q", [""])[0]
+                    payload = build_atlas_browser_payload(resolved_vault, query=q)
+                    self._write_html(_render_atlas_page(payload))
+                    return
+                if path == "/api/deep-dives":
+                    q = query.get("q", [""])[0]
+                    self._write_json(build_derivation_browser_payload(resolved_vault, query=q))
+                    return
+                if path == "/deep-dives":
+                    q = query.get("q", [""])[0]
+                    payload = build_derivation_browser_payload(resolved_vault, query=q)
+                    self._write_html(_render_derivations_page(payload))
                     return
                 if path == "/api/contradictions":
                     status = query.get("status", [""])[0] or None

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -641,7 +641,7 @@ def _render_atlas_page(payload: dict) -> str:
     query = payload.get("query", "")
     items = "".join(
         "<li>"
-        f"{escape(item['title'])}"
+        f'<a href="{escape(_note_href(item["path"]))}">{escape(item["title"])}</a>'
         + (
             " <span class='muted'>"
             + ", ".join(
@@ -671,7 +671,7 @@ def _render_derivations_page(payload: dict) -> str:
     query = payload.get("query", "")
     items = "".join(
         "<li>"
-        f"{escape(item['title'])}"
+        f'<a href="{escape(_note_href(item["path"]))}">{escape(item["title"])}</a>'
         + (
             " <span class='muted'>"
             + ", ".join(

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -2,13 +2,19 @@ from __future__ import annotations
 
 import argparse
 import json
+import sqlite3
+import re
 import sys
 from html import escape
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from urllib.parse import parse_qs, quote, urlparse
 
-from ..runtime import resolve_vault_dir
+import yaml
+from markdown_it import MarkdownIt
+
+from ..identity import canonicalize_note_id
+from ..runtime import VaultLayout, resolve_vault_dir
 from ..ui.view_models import (
     build_atlas_browser_payload,
     build_contradiction_browser_payload,
@@ -19,6 +25,9 @@ from ..ui.view_models import (
     build_truth_dashboard_payload,
     build_topic_overview_payload,
 )
+
+_MARKDOWN_RENDERER = MarkdownIt("commonmark", {"breaks": True, "html": False}).enable("table")
+_FENCED_FRONTMATTER_RE = re.compile(r"^```ya?ml\s*\n---\n(.*?)\n---\n```\s*\n?", re.DOTALL)
 
 
 def _layout(title: str, body: str) -> str:
@@ -113,6 +122,84 @@ def _read_vault_note(vault_dir: Path, relative_path: str) -> tuple[Path, str]:
     return candidate, candidate.read_text(encoding="utf-8")
 
 
+def _lookup_wikilink_target(vault_dir: Path, target: str) -> tuple[str, str] | None:
+    db_path = VaultLayout.from_vault(vault_dir).knowledge_db
+    if not db_path.exists():
+        return None
+
+    raw_target = target.split("|", 1)[0].split("#", 1)[0].strip()
+    if not raw_target:
+        return None
+
+    exact_path = raw_target
+    stem = Path(raw_target).stem
+    normalized = canonicalize_note_id(raw_target)
+    normalized_stem = canonicalize_note_id(stem)
+    suffixes = [f"%/{stem.lower()}.md"]
+    if raw_target.lower().endswith(".md"):
+        suffixes.append(f"%/{raw_target.lower()}")
+
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT slug, title, note_type, path
+            FROM pages_index
+            WHERE lower(slug) = ?
+               OR lower(title) = ?
+               OR lower(path) = ?
+               OR lower(path) LIKE ?
+               OR lower(path) LIKE ?
+            LIMIT 25
+            """,
+            (
+                normalized,
+                raw_target.lower(),
+                exact_path.lower(),
+                suffixes[0],
+                suffixes[-1],
+            ),
+        ).fetchall()
+
+    def rank(row: tuple[str, str, str, str]) -> tuple[int, str]:
+        slug, title, _note_type, path = row
+        path_lower = path.lower()
+        title_lower = title.lower()
+        if slug == normalized:
+            return (0, path)
+        if normalized_stem and slug == normalized_stem:
+            return (1, path)
+        if title_lower == raw_target.lower():
+            return (2, path)
+        if path_lower.endswith(f"/{raw_target.lower()}"):
+            return (3, path)
+        if path_lower.endswith(f"/{stem.lower()}.md"):
+            return (4, path)
+        return (10, path)
+
+    if not rows:
+        for candidate in vault_dir.rglob("*.md"):
+            if candidate.stem.lower() != stem.lower():
+                continue
+            relative_path = str(candidate.resolve().relative_to(vault_dir.resolve()))
+            if "10-Knowledge/Evergreen/" in relative_path:
+                return (f"/object?id={quote(canonicalize_note_id(stem), safe='')}", canonicalize_note_id(stem))
+            return (_note_href(relative_path), relative_path)
+        return None
+
+    slug, _title, note_type, path = sorted(rows, key=rank)[0]
+    relative_path = path
+    candidate = Path(path)
+    if candidate.is_absolute():
+        try:
+            relative_path = str(candidate.resolve().relative_to(vault_dir.resolve()))
+        except ValueError:
+            relative_path = path
+
+    if note_type == "evergreen":
+        return (f"/object?id={quote(slug, safe='')}", slug)
+    return (_note_href(relative_path), relative_path)
+
+
 def _strip_frontmatter(markdown: str) -> str:
     if not markdown.startswith("---\n"):
         return markdown
@@ -122,55 +209,89 @@ def _strip_frontmatter(markdown: str) -> str:
     return markdown[end + 5 :]
 
 
-def _render_markdown_note(markdown: str) -> str:
-    body = _strip_frontmatter(markdown).strip()
-    if not body:
-        return "<p class='muted'>Empty note.</p>"
+def _parse_frontmatter(markdown: str) -> tuple[dict[str, object], str]:
+    fenced_match = _FENCED_FRONTMATTER_RE.match(markdown)
+    if fenced_match:
+        raw_frontmatter = fenced_match.group(1)
+        body = markdown[fenced_match.end() :]
+        try:
+            parsed = yaml.safe_load(raw_frontmatter) or {}
+        except yaml.YAMLError:
+            parsed = {}
+        return parsed if isinstance(parsed, dict) else {}, body
+    if not markdown.startswith("---\n"):
+        return {}, markdown
+    end = markdown.find("\n---\n", 4)
+    if end == -1:
+        return {}, markdown
+    raw_frontmatter = markdown[4:end]
+    body = markdown[end + 5 :]
+    try:
+        parsed = yaml.safe_load(raw_frontmatter) or {}
+    except yaml.YAMLError:
+        parsed = {}
+    return parsed if isinstance(parsed, dict) else {}, body
 
-    chunks: list[str] = []
-    paragraph_lines: list[str] = []
-    list_items: list[str] = []
 
-    def flush_paragraph() -> None:
-        nonlocal paragraph_lines
-        if paragraph_lines:
-            text = " ".join(line.strip() for line in paragraph_lines if line.strip())
-            chunks.append(f"<p>{escape(text)}</p>")
-            paragraph_lines = []
+def _render_frontmatter(frontmatter: dict[str, object]) -> str:
+    if not frontmatter:
+        return ""
+    rows = "".join(
+        "<tr>"
+        f"<th>{escape(str(key))}</th>"
+        f"<td>{escape(json.dumps(value, ensure_ascii=False) if isinstance(value, (list, dict)) else str(value))}</td>"
+        "</tr>"
+        for key, value in frontmatter.items()
+    )
+    return (
+        "<section class='card'>"
+        "<h2>Frontmatter</h2>"
+        "<table><tbody>"
+        f"{rows}"
+        "</tbody></table>"
+        "</section>"
+    )
 
-    def flush_list() -> None:
-        nonlocal list_items
-        if list_items:
-            chunks.append("<ul>" + "".join(f"<li>{escape(item)}</li>" for item in list_items) + "</ul>")
-            list_items = []
 
-    for raw_line in body.splitlines():
-        line = raw_line.rstrip()
-        stripped = line.strip()
-        if not stripped:
-            flush_paragraph()
-            flush_list()
+def _replace_wikilinks_with_markdown_links(vault_dir: Path, markdown: str) -> str:
+    def replace_match(match: re.Match[str]) -> str:
+        raw_inner = match.group(1)
+        target_part, _, label_part = raw_inner.partition("|")
+        label = label_part.strip() or target_part.split("#", 1)[0].strip()
+        resolved = _lookup_wikilink_target(vault_dir, target_part)
+        if not resolved:
+            return match.group(0)
+        href, _resolved_target = resolved
+        safe_label = label.replace("[", "\\[").replace("]", "\\]")
+        return f"[{safe_label}]({href})"
+
+    output_lines: list[str] = []
+    in_fence = False
+    for line in markdown.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("```"):
+            in_fence = not in_fence
+            output_lines.append(line)
             continue
-        if stripped.startswith("#"):
-            flush_paragraph()
-            flush_list()
-            level = min(len(stripped) - len(stripped.lstrip("#")), 6)
-            heading = stripped[level:].strip()
-            chunks.append(f"<h{level}>{escape(heading)}</h{level}>")
+        if in_fence:
+            output_lines.append(line)
             continue
-        if stripped.startswith("- "):
-            flush_paragraph()
-            list_items.append(stripped[2:].strip())
-            continue
-        flush_list()
-        paragraph_lines.append(stripped)
-
-    flush_paragraph()
-    flush_list()
-    return "".join(chunks)
+        output_lines.append(re.sub(r"\[\[([^\]]+)\]\]", replace_match, line))
+    return "\n".join(output_lines)
 
 
-def _render_note_page(relative_path: str, markdown: str) -> str:
+def _render_markdown_note(vault_dir: Path, markdown: str) -> tuple[str, str]:
+    frontmatter, body = _parse_frontmatter(markdown)
+    rendered_body = _replace_wikilinks_with_markdown_links(vault_dir, body).strip()
+    if not rendered_body:
+        html_body = "<p class='muted'>Empty note.</p>"
+    else:
+        html_body = _MARKDOWN_RENDERER.render(rendered_body)
+    return _render_frontmatter(frontmatter), html_body
+
+
+def _render_note_page(vault_dir: Path, relative_path: str, markdown: str) -> str:
+    frontmatter_html, note_html = _render_markdown_note(vault_dir, markdown)
     return _layout(
         f"Markdown Note: {relative_path}",
         (
@@ -178,7 +299,8 @@ def _render_note_page(relative_path: str, markdown: str) -> str:
             "<h1>Markdown Note</h1>"
             f"<p class='muted'>{escape(relative_path)}</p>"
             "</section>"
-            f"<section class='card'>{_render_markdown_note(markdown)}</section>"
+            f"{frontmatter_html}"
+            f"<section class='card'>{note_html}</section>"
         ),
     )
 
@@ -557,7 +679,7 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
                 if path == "/note":
                     relative_path = self._required(query, "path")
                     _, markdown = _read_vault_note(resolved_vault, relative_path)
-                    self._write_html(_render_note_page(relative_path, markdown))
+                    self._write_html(_render_note_page(resolved_vault, relative_path, markdown))
                     return
                 if path == "/api/contradictions":
                     status = query.get("status", [""])[0] or None

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -28,6 +28,7 @@ from ..ui.view_models import (
 
 _MARKDOWN_RENDERER = MarkdownIt("commonmark", {"breaks": True, "html": False}).enable("table")
 _FENCED_FRONTMATTER_RE = re.compile(r"^```ya?ml\s*\n---\n(.*?)\n---\n```\s*\n?", re.DOTALL)
+_GITHUB_REPO_RE = re.compile(r"https://github\.com/([^/\s]+)/([^/\s#]+)")
 
 
 def _layout(title: str, body: str) -> str:
@@ -109,6 +110,10 @@ def _layout(title: str, body: str) -> str:
 
 def _note_href(path: str) -> str:
     return f"/note?path={quote(path, safe='')}"
+
+
+def _objects_search_href(query: str) -> str:
+    return f"/objects?q={quote(query, safe='')}"
 
 
 def _read_vault_note(vault_dir: Path, relative_path: str) -> tuple[Path, str]:
@@ -200,6 +205,10 @@ def _lookup_wikilink_target(vault_dir: Path, target: str) -> tuple[str, str] | N
     return (_note_href(relative_path), relative_path)
 
 
+def _is_search_href(href: str) -> bool:
+    return href.startswith("/objects?q=")
+
+
 def _strip_frontmatter(markdown: str) -> str:
     if not markdown.startswith("---\n"):
         return markdown
@@ -234,12 +243,21 @@ def _parse_frontmatter(markdown: str) -> tuple[dict[str, object], str]:
 
 
 def _render_frontmatter(frontmatter: dict[str, object]) -> str:
+    def render_value(value: object) -> str:
+        if isinstance(value, str) and value.startswith(("http://", "https://")):
+            return (
+                f'<a href="{escape(value)}" target="_blank" rel="noopener noreferrer">{escape(value)}</a>'
+            )
+        if isinstance(value, (list, dict)):
+            return escape(json.dumps(value, ensure_ascii=False))
+        return escape(str(value))
+
     if not frontmatter:
         return ""
     rows = "".join(
         "<tr>"
         f"<th>{escape(str(key))}</th>"
-        f"<td>{escape(json.dumps(value, ensure_ascii=False) if isinstance(value, (list, dict)) else str(value))}</td>"
+        f"<td>{render_value(value)}</td>"
         "</tr>"
         for key, value in frontmatter.items()
     )
@@ -259,11 +277,10 @@ def _replace_wikilinks_with_markdown_links(vault_dir: Path, markdown: str) -> st
         target_part, _, label_part = raw_inner.partition("|")
         label = label_part.strip() or target_part.split("#", 1)[0].strip()
         resolved = _lookup_wikilink_target(vault_dir, target_part)
-        if not resolved:
-            return match.group(0)
-        href, _resolved_target = resolved
+        href = resolved[0] if resolved else _objects_search_href(target_part.split("#", 1)[0].strip() or label)
+        emoji = "🔍" if _is_search_href(href) else "🎯"
         safe_label = label.replace("[", "\\[").replace("]", "\\]")
-        return f"[{safe_label}]({href})"
+        return f"[{emoji} {safe_label}]({href})"
 
     output_lines: list[str] = []
     in_fence = False
@@ -280,9 +297,120 @@ def _replace_wikilinks_with_markdown_links(vault_dir: Path, markdown: str) -> st
     return "\n".join(output_lines)
 
 
+def _infer_github_repo_base(frontmatter: dict[str, object], markdown: str) -> str | None:
+    candidates: list[str] = []
+    for value in frontmatter.values():
+        if isinstance(value, str):
+            candidates.append(value)
+    candidates.append(markdown)
+    for candidate in candidates:
+        match = _GITHUB_REPO_RE.search(candidate)
+        if not match:
+            continue
+        owner, repo = match.groups()
+        return f"https://github.com/{owner}/{repo.removesuffix('.git')}"
+    return None
+
+
+def _smart_markdown_link(label: str, href: str) -> str:
+    safe_label = label.replace("[", "\\[").replace("]", "\\]")
+    return f"[{safe_label}]({href})"
+
+
+def _convert_box_table_fences(markdown: str, *, github_repo_base: str | None) -> str:
+    lines = markdown.splitlines()
+    output: list[str] = []
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        if line.strip().startswith("```"):
+            fence = [line]
+            index += 1
+            while index < len(lines):
+                fence.append(lines[index])
+                if lines[index].strip().startswith("```"):
+                    index += 1
+                    break
+                index += 1
+            body = fence[1:-1]
+            if body and any("│" in row for row in body) and any("┌" in row or "├" in row or "└" in row for row in body):
+                rows: list[tuple[str, str]] = []
+                for row in body:
+                    if "│" not in row:
+                        continue
+                    parts = [part.strip() for part in row.strip().strip("│").split("│")]
+                    if len(parts) != 2:
+                        continue
+                    left, right = parts
+                    if not left or left == "参考链接":
+                        continue
+                    if right.startswith(("http://", "https://")):
+                        right = _smart_markdown_link(right, right)
+                    elif github_repo_base and right.endswith(".md") and not right.startswith("/"):
+                        right = _smart_markdown_link(right, f"{github_repo_base}/blob/main/{right}")
+                    rows.append((left, right))
+                if rows:
+                    output.append("| 名称 | 值 |")
+                    output.append("| --- | --- |")
+                    for left, right in rows:
+                        output.append(f"| {left} | {right} |")
+                    continue
+            output.extend(fence)
+            continue
+        output.append(line)
+        index += 1
+    return "\n".join(output)
+
+
+def _linkify_keywords(markdown: str) -> str:
+    output: list[str] = []
+    keyword_re = re.compile(r"^(\*\*关键词\*\*|关键词)\s*[：:]\s*(.+)$")
+    for line in markdown.splitlines():
+        match = keyword_re.match(line.strip())
+        if not match:
+            output.append(line)
+            continue
+        prefix, values = match.groups()
+        rendered = []
+        for raw in values.split(","):
+            keyword = raw.strip()
+            if not keyword:
+                continue
+            rendered.append(_smart_markdown_link(keyword, _objects_search_href(keyword)))
+        output.append(f"{prefix}：{'，'.join(rendered)}")
+    return "\n".join(output)
+
+
+def _linkify_related_knowledge_section(vault_dir: Path, markdown: str) -> str:
+    output_lines: list[str] = []
+    in_related = False
+
+    for line in markdown.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            in_related = stripped.lstrip("#").strip() == "关联知识"
+            output_lines.append(line)
+            continue
+        if in_related and re.match(r"^- [^\[][^—]+ — ", stripped):
+            concept, sep, remainder = stripped[2:].partition(" — ")
+            concept = concept.strip()
+            resolved = _lookup_wikilink_target(vault_dir, concept)
+            href = resolved[0] if resolved else _objects_search_href(concept)
+            emoji = "🔍" if _is_search_href(href) else "🎯"
+            output_lines.append(f'- [{emoji} {concept}]({href}) — {remainder}')
+            continue
+        output_lines.append(line)
+
+    return "\n".join(output_lines)
+
+
 def _render_markdown_note(vault_dir: Path, markdown: str) -> tuple[str, str]:
     frontmatter, body = _parse_frontmatter(markdown)
-    rendered_body = _replace_wikilinks_with_markdown_links(vault_dir, body).strip()
+    github_repo_base = _infer_github_repo_base(frontmatter, body)
+    rendered_body = _convert_box_table_fences(body, github_repo_base=github_repo_base)
+    rendered_body = _replace_wikilinks_with_markdown_links(vault_dir, rendered_body)
+    rendered_body = _linkify_related_knowledge_section(vault_dir, rendered_body)
+    rendered_body = _linkify_keywords(rendered_body).strip()
     if not rendered_body:
         html_body = "<p class='muted'>Empty note.</p>"
     else:
@@ -373,6 +501,12 @@ def _render_object_page(payload: dict) -> str:
         if evergreen_path
         else "<span class='muted'>None</span>"
     )
+    canonical_path = payload["context"]["canonical_path"]
+    canonical_path_html = (
+        f'<a href="{escape(_note_href(canonical_path))}">{escape(canonical_path)}</a>'
+        if canonical_path
+        else "<span class='muted'>None</span>"
+    )
     claims = "".join(f"<li>{escape(item['claim_text'])}</li>" for item in payload["claims"]) or "<li>None</li>"
     relations = "".join(
         f'<li><a href="/object?id={escape(item["target_object_id"])}">{escape(item.get("target_title", item["target_object_id"]))}</a>'
@@ -423,7 +557,7 @@ def _render_object_page(payload: dict) -> str:
             "<section class='card'><h2>Context</h2><dl class='meta-list'>"
             f"<div><dt>Object Kind</dt><dd>{escape(payload['context']['object_kind'])}</dd></div>"
             f"<div><dt>Source Slug</dt><dd>{escape(payload['context']['source_slug'])}</dd></div>"
-            f"<div><dt>Canonical Path</dt><dd>{escape(payload['context']['canonical_path'])}</dd></div>"
+            f"<div><dt>Canonical Path</dt><dd>{canonical_path_html}</dd></div>"
             "</dl></section>"
             "<section class='card'><h2>Provenance</h2><dl class='meta-list'>"
             f"<div><dt>Evergreen Markdown</dt><dd>{evergreen_html}</dd></div>"

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -6,7 +6,7 @@ import sys
 from html import escape
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, quote, urlparse
 
 from ..runtime import resolve_vault_dir
 from ..ui.view_models import (
@@ -98,6 +98,91 @@ def _layout(title: str, body: str) -> str:
 """
 
 
+def _note_href(path: str) -> str:
+    return f"/note?path={quote(path, safe='')}"
+
+
+def _read_vault_note(vault_dir: Path, relative_path: str) -> tuple[Path, str]:
+    candidate = (vault_dir / relative_path).resolve()
+    try:
+        candidate.relative_to(vault_dir.resolve())
+    except ValueError as exc:
+        raise ValueError("invalid note path") from exc
+    if not candidate.is_file():
+        raise ValueError(f"note not found: {relative_path}")
+    return candidate, candidate.read_text(encoding="utf-8")
+
+
+def _strip_frontmatter(markdown: str) -> str:
+    if not markdown.startswith("---\n"):
+        return markdown
+    end = markdown.find("\n---\n", 4)
+    if end == -1:
+        return markdown
+    return markdown[end + 5 :]
+
+
+def _render_markdown_note(markdown: str) -> str:
+    body = _strip_frontmatter(markdown).strip()
+    if not body:
+        return "<p class='muted'>Empty note.</p>"
+
+    chunks: list[str] = []
+    paragraph_lines: list[str] = []
+    list_items: list[str] = []
+
+    def flush_paragraph() -> None:
+        nonlocal paragraph_lines
+        if paragraph_lines:
+            text = " ".join(line.strip() for line in paragraph_lines if line.strip())
+            chunks.append(f"<p>{escape(text)}</p>")
+            paragraph_lines = []
+
+    def flush_list() -> None:
+        nonlocal list_items
+        if list_items:
+            chunks.append("<ul>" + "".join(f"<li>{escape(item)}</li>" for item in list_items) + "</ul>")
+            list_items = []
+
+    for raw_line in body.splitlines():
+        line = raw_line.rstrip()
+        stripped = line.strip()
+        if not stripped:
+            flush_paragraph()
+            flush_list()
+            continue
+        if stripped.startswith("#"):
+            flush_paragraph()
+            flush_list()
+            level = min(len(stripped) - len(stripped.lstrip("#")), 6)
+            heading = stripped[level:].strip()
+            chunks.append(f"<h{level}>{escape(heading)}</h{level}>")
+            continue
+        if stripped.startswith("- "):
+            flush_paragraph()
+            list_items.append(stripped[2:].strip())
+            continue
+        flush_list()
+        paragraph_lines.append(stripped)
+
+    flush_paragraph()
+    flush_list()
+    return "".join(chunks)
+
+
+def _render_note_page(relative_path: str, markdown: str) -> str:
+    return _layout(
+        f"Markdown Note: {relative_path}",
+        (
+            "<section class='hero'>"
+            "<h1>Markdown Note</h1>"
+            f"<p class='muted'>{escape(relative_path)}</p>"
+            "</section>"
+            f"<section class='card'>{_render_markdown_note(markdown)}</section>"
+        ),
+    )
+
+
 def _render_dashboard(payload: dict) -> str:
     object_items = "".join(
         f'<li><a href="/object?id={escape(item["object_id"])}">{escape(item["title"])}</a></li>'
@@ -160,6 +245,12 @@ def _render_objects_index(payload: dict) -> str:
 
 
 def _render_object_page(payload: dict) -> str:
+    evergreen_path = payload["provenance"]["evergreen_path"]
+    evergreen_html = (
+        f'<a href="{escape(_note_href(evergreen_path))}">{escape(evergreen_path)}</a>'
+        if evergreen_path
+        else "<span class='muted'>None</span>"
+    )
     claims = "".join(f"<li>{escape(item['claim_text'])}</li>" for item in payload["claims"]) or "<li>None</li>"
     relations = "".join(
         f'<li><a href="/object?id={escape(item["target_object_id"])}">{escape(item.get("target_title", item["target_object_id"]))}</a>'
@@ -171,11 +262,12 @@ def _render_object_page(payload: dict) -> str:
         for item in payload["contradictions"]
     ) or "<li>None</li>"
     source_notes = "".join(
-        f"<li>{escape(item['title'])} <span class='muted'>({escape(item['note_type'])})</span></li>"
+        f'<li><a href="{escape(_note_href(item["path"]))}">{escape(item["title"])}</a> '
+        f"<span class='muted'>({escape(item['note_type'])})</span></li>"
         for item in payload["provenance"]["source_notes"]
     ) or "<li>None</li>"
     mocs = "".join(
-        f"<li>{escape(item['title'])}</li>"
+        f'<li><a href="{escape(_note_href(item["path"]))}">{escape(item["title"])}</a></li>'
         for item in payload["provenance"]["mocs"]
     ) or "<li>None</li>"
     summary_text = payload["summary"]["summary_text"] if payload["summary"] else ""
@@ -212,7 +304,7 @@ def _render_object_page(payload: dict) -> str:
             f"<div><dt>Canonical Path</dt><dd>{escape(payload['context']['canonical_path'])}</dd></div>"
             "</dl></section>"
             "<section class='card'><h2>Provenance</h2><dl class='meta-list'>"
-            f"<div><dt>Evergreen Markdown</dt><dd>{escape(payload['provenance']['evergreen_path'])}</dd></div>"
+            f"<div><dt>Evergreen Markdown</dt><dd>{evergreen_html}</dd></div>"
             f"<div><dt>Source Notes</dt><dd><ul class='list-tight'>{source_notes}</ul></dd></div>"
             f"<div><dt>Atlas / MOC</dt><dd><ul class='list-tight'>{mocs}</ul></dd></div>"
             "</dl></section>"
@@ -461,6 +553,11 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
                     q = query.get("q", [""])[0]
                     payload = build_derivation_browser_payload(resolved_vault, query=q)
                     self._write_html(_render_derivations_page(payload))
+                    return
+                if path == "/note":
+                    relative_path = self._required(query, "path")
+                    _, markdown = _read_vault_note(resolved_vault, relative_path)
+                    self._write_html(_render_note_page(relative_path, markdown))
                     return
                 if path == "/api/contradictions":
                     status = query.get("status", [""])[0] or None

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -577,6 +577,9 @@ def _render_topic_page(payload: dict) -> str:
         f'<li><a href="/object?id={escape(item["object_id"])}">{escape(item["title"])}</a></li>'
         for item in payload["neighbors"]
     ) or "<li>None</li>"
+    mocs = "".join(
+        f"<li>{escape(item['title'])}</li>" for item in payload["provenance"]["mocs"]
+    ) or "<li>None</li>"
     return _layout(
         f"Topic: {payload['center']['title']}",
         (
@@ -592,7 +595,7 @@ def _render_topic_page(payload: dict) -> str:
             "<section class='grid two-col'>"
             f"<section class='card'><h2>Center Summary</h2><p>{escape(payload['center_summary'])}</p></section>"
             f"<section class='card'><h2>Neighbors</h2><ul class='list-tight'>{neighbors}</ul></section>"
-            f"<section class='card'><h2>Atlas / MOC</h2><ul class='list-tight'>{''.join(f'<li>{escape(item['title'])}</li>' for item in payload['provenance']['mocs']) or '<li>None</li>'}</ul></section>"
+            f"<section class='card'><h2>Atlas / MOC</h2><ul class='list-tight'>{mocs}</ul></section>"
             "</section>"
         ),
     )

--- a/src/openclaw_pipeline/knowledge_index.py
+++ b/src/openclaw_pipeline/knowledge_index.py
@@ -309,17 +309,37 @@ def rebuild_knowledge_index(vault_dir: Path) -> dict[str, int | str]:
     resolved_vault = resolve_vault_dir(vault_dir)
     layout = VaultLayout.from_vault(resolved_vault)
     evergreen_dir = layout.evergreen_dir
+    atlas_dir = layout.atlas_dir
+    areas_dir = resolved_vault / "20-Areas"
     parser = FrontmatterParser(resolved_vault)
     link_parser = LinkParser(resolved_vault)
     registry = ConceptRegistry(resolved_vault).load()
 
-    metadata_items = [
+    object_metadata_items = [
         meta
         for meta in parser.parse_directory(evergreen_dir, recursive=True)
         if "_Candidates" not in Path(meta.path).parts
     ]
-    surface_map = _build_surface_map(metadata_items)
-    known_slugs = {meta.note_id for meta in metadata_items}
+    page_metadata_items = list(object_metadata_items)
+    for extra_dir in (atlas_dir, areas_dir):
+        if not extra_dir.exists():
+            continue
+        for meta in parser.parse_directory(extra_dir, recursive=True):
+            if "_Candidates" in Path(meta.path).parts:
+                continue
+            page_metadata_items.append(meta)
+
+    deduped_page_metadata_items: list[NoteMetadata] = []
+    seen_page_keys: set[tuple[str, str]] = set()
+    for meta in page_metadata_items:
+        key = (meta.note_id, meta.path)
+        if key in seen_page_keys:
+            continue
+        seen_page_keys.add(key)
+        deduped_page_metadata_items.append(meta)
+
+    surface_map = _build_surface_map(object_metadata_items)
+    known_slugs = {meta.note_id for meta in object_metadata_items}
 
     temp_db_path = layout.knowledge_db.with_name(f"{layout.knowledge_db.name}.tmp")
     _remove_sqlite_artifacts(temp_db_path)
@@ -330,7 +350,7 @@ def rebuild_knowledge_index(vault_dir: Path) -> dict[str, int | str]:
         page_rows = []
         timeline_rows = []
         embedding_rows = []
-        for meta in metadata_items:
+        for meta in deduped_page_metadata_items:
             file_path = Path(meta.path)
             body = _split_frontmatter_body(file_path.read_text(encoding="utf-8"))
             page_rows.append(
@@ -370,9 +390,8 @@ def rebuild_knowledge_index(vault_dir: Path) -> dict[str, int | str]:
         )
 
         link_rows = []
-        for file_path in sorted(evergreen_dir.rglob("*.md")):
-            if "_Candidates" in file_path.parts:
-                continue
+        for meta in deduped_page_metadata_items:
+            file_path = Path(meta.path)
             for link in link_parser.parse_file(file_path):
                 target_slug = _resolve_target_slug(link.target_raw or link.target, registry, surface_map)
                 if not target_slug or target_slug not in known_slugs:
@@ -395,7 +414,9 @@ def rebuild_knowledge_index(vault_dir: Path) -> dict[str, int | str]:
             link_rows,
         )
 
-        truth_projection = build_truth_store_projection(page_rows, link_rows)
+        object_page_rows = [row for row in page_rows if row[0] in known_slugs]
+        object_link_rows = [row for row in link_rows if row[0] in known_slugs]
+        truth_projection = build_truth_store_projection(object_page_rows, object_link_rows)
         conn.executemany(
             """
             INSERT INTO objects (object_id, object_kind, title, canonical_path, source_slug)

--- a/src/openclaw_pipeline/knowledge_index.py
+++ b/src/openclaw_pipeline/knowledge_index.py
@@ -330,9 +330,9 @@ def rebuild_knowledge_index(vault_dir: Path) -> dict[str, int | str]:
             page_metadata_items.append(meta)
 
     deduped_page_metadata_items: list[NoteMetadata] = []
-    seen_page_keys: set[tuple[str, str]] = set()
+    seen_page_keys: set[str] = set()
     for meta in page_metadata_items:
-        key = (meta.note_id, meta.path)
+        key = meta.note_id
         if key in seen_page_keys:
             continue
         seen_page_keys.add(key)

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -158,6 +158,42 @@ def get_object_detail(vault_dir: Path | str, object_id: str) -> dict[str, Any]:
             """,
             (f'%"{escaped}::%', f'%"{escaped}::%'),
         ).fetchall()
+        mention_rows = conn.execute(
+            """
+            SELECT slug, title, note_type, path
+            FROM pages_index
+            WHERE slug != ?
+              AND (
+                body LIKE ?
+                OR body LIKE ?
+                OR body LIKE ?
+              )
+            ORDER BY slug
+            """,
+            (
+                object_id,
+                f"%[[{object_id}]]%",
+                f"%[[{object_id}|%",
+                f"%[[{object_id}#%",
+            ),
+        ).fetchall()
+
+    mocs: list[dict[str, Any]] = []
+    source_notes: list[dict[str, Any]] = []
+    for slug, title, note_type, path in mention_rows:
+        item = {
+            "slug": slug,
+            "title": title,
+            "note_type": note_type,
+            "path": path,
+        }
+        if note_type == "moc" or "/10-Knowledge/Atlas/" in path or Path(path).name.startswith("MOC"):
+            mocs.append(item)
+            continue
+        if slug == object_id:
+            continue
+        if note_type != "evergreen":
+            source_notes.append(item)
 
     return {
         "object": {
@@ -215,6 +251,11 @@ def get_object_detail(vault_dir: Path | str, object_id: str) -> dict[str, Any]:
             }
             for row in contradiction_rows
         ],
+        "provenance": {
+            "evergreen_path": object_row[3],
+            "source_notes": source_notes,
+            "mocs": mocs,
+        },
     }
 
 
@@ -331,3 +372,100 @@ def get_topic_neighborhood(vault_dir: Path | str, object_id: str, *, depth: int 
             for row in edge_rows
         ],
     }
+
+
+def list_atlas_memberships(
+    vault_dir: Path | str,
+    *,
+    query: str | None = None,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    limit, _ = _validate_page_args(limit=limit, offset=0)
+    db_path = _db_path(vault_dir)
+    normalized_query = _escape_like(query.strip().lower()) if query else ""
+    sql = """
+        SELECT pages_index.slug, pages_index.title, pages_index.path, objects.object_id, objects.title
+        FROM pages_index
+        JOIN page_links ON page_links.source_slug = pages_index.slug
+        JOIN objects ON objects.object_id = page_links.target_slug
+        WHERE pages_index.note_type = 'moc'
+    """
+    params: list[Any] = []
+    if normalized_query:
+        sql += """
+          AND (
+            lower(pages_index.slug) LIKE ? ESCAPE '\\'
+            OR lower(pages_index.title) LIKE ? ESCAPE '\\'
+            OR lower(objects.object_id) LIKE ? ESCAPE '\\'
+            OR lower(objects.title) LIKE ? ESCAPE '\\'
+          )
+        """
+        params.extend([f"%{normalized_query}%"] * 4)
+    sql += " ORDER BY pages_index.slug, objects.object_id LIMIT ?"
+    params.append(limit)
+
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(sql, tuple(params)).fetchall()
+
+    grouped: dict[str, dict[str, Any]] = {}
+    for slug, title, path, object_id, object_title in rows:
+        item = grouped.setdefault(
+            slug,
+            {
+                "slug": slug,
+                "title": title,
+                "path": path,
+                "members": [],
+            },
+        )
+        item["members"].append({"object_id": object_id, "title": object_title})
+    return list(grouped.values())
+
+
+def list_deep_dive_derivations(
+    vault_dir: Path | str,
+    *,
+    query: str | None = None,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    limit, _ = _validate_page_args(limit=limit, offset=0)
+    db_path = _db_path(vault_dir)
+    normalized_query = _escape_like(query.strip().lower()) if query else ""
+    sql = """
+        SELECT pages_index.slug, pages_index.title, pages_index.note_type, pages_index.path, objects.object_id, objects.title
+        FROM pages_index
+        JOIN page_links ON page_links.source_slug = pages_index.slug
+        JOIN objects ON objects.object_id = page_links.target_slug
+        WHERE pages_index.note_type = 'deep_dive'
+    """
+    params: list[Any] = []
+    if normalized_query:
+        sql += """
+          AND (
+            lower(pages_index.slug) LIKE ? ESCAPE '\\'
+            OR lower(pages_index.title) LIKE ? ESCAPE '\\'
+            OR lower(objects.object_id) LIKE ? ESCAPE '\\'
+            OR lower(objects.title) LIKE ? ESCAPE '\\'
+          )
+        """
+        params.extend([f"%{normalized_query}%"] * 4)
+    sql += " ORDER BY pages_index.slug, objects.object_id LIMIT ?"
+    params.append(limit)
+
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(sql, tuple(params)).fetchall()
+
+    grouped: dict[str, dict[str, Any]] = {}
+    for slug, title, note_type, path, object_id, object_title in rows:
+        item = grouped.setdefault(
+            slug,
+            {
+                "slug": slug,
+                "title": title,
+                "note_type": note_type,
+                "path": path,
+                "derived_objects": [],
+            },
+        )
+        item["derived_objects"].append({"object_id": object_id, "title": object_title})
+    return list(grouped.values())

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -108,6 +108,86 @@ def count_objects(vault_dir: Path | str, *, query: str | None = None) -> int:
     return int(row[0]) if row else 0
 
 
+def _surface_page_query_clauses(*, note_type: str, normalized_query: str) -> tuple[str, list[Any]]:
+    where = [f"pages_index.note_type = '{note_type}'"]
+    params: list[Any] = []
+    if normalized_query:
+        where.append(
+            """
+            (
+              lower(pages_index.slug) LIKE ? ESCAPE '\\'
+              OR lower(pages_index.title) LIKE ? ESCAPE '\\'
+              OR lower(objects.object_id) LIKE ? ESCAPE '\\'
+              OR lower(objects.title) LIKE ? ESCAPE '\\'
+            )
+            """.strip()
+        )
+        params.extend([f"%{normalized_query}%"] * 4)
+    return " AND ".join(where), params
+
+
+def _list_surface_groups(
+    vault_dir: Path | str,
+    *,
+    note_type: str,
+    query: str | None,
+    limit: int,
+    object_list_key: str,
+) -> list[dict[str, Any]]:
+    limit, _ = _validate_page_args(limit=limit, offset=0)
+    db_path = _db_path(vault_dir)
+    resolved_vault = resolve_vault_dir(vault_dir)
+    normalized_query = _escape_like(query.strip().lower()) if query else ""
+    where_sql, base_params = _surface_page_query_clauses(
+        note_type=note_type,
+        normalized_query=normalized_query,
+    )
+
+    with sqlite3.connect(db_path) as conn:
+        selected_rows = conn.execute(
+            f"""
+            SELECT DISTINCT pages_index.slug
+            FROM pages_index
+            JOIN page_links ON page_links.source_slug = pages_index.slug
+            JOIN objects ON objects.object_id = page_links.target_slug
+            WHERE {where_sql}
+            ORDER BY pages_index.slug
+            LIMIT ?
+            """,
+            tuple([*base_params, limit]),
+        ).fetchall()
+        selected_slugs = [row[0] for row in selected_rows]
+        if not selected_slugs:
+            return []
+        placeholders = ",".join("?" for _ in selected_slugs)
+        rows = conn.execute(
+            f"""
+            SELECT pages_index.slug, pages_index.title, pages_index.note_type, pages_index.path, objects.object_id, objects.title
+            FROM pages_index
+            JOIN page_links ON page_links.source_slug = pages_index.slug
+            JOIN objects ON objects.object_id = page_links.target_slug
+            WHERE pages_index.slug IN ({placeholders})
+            ORDER BY pages_index.slug, objects.object_id
+            """,
+            tuple(selected_slugs),
+        ).fetchall()
+
+    grouped: dict[str, dict[str, Any]] = {}
+    for slug, title, row_note_type, path, object_id, object_title in rows:
+        item = grouped.setdefault(
+            slug,
+            {
+                "slug": slug,
+                "title": title,
+                "note_type": row_note_type,
+                "path": _vault_relative_path(resolved_vault, path),
+                object_list_key: [],
+            },
+        )
+        item[object_list_key].append({"object_id": object_id, "title": object_title})
+    return list(grouped.values())
+
+
 def get_object_detail(vault_dir: Path | str, object_id: str) -> dict[str, Any]:
     db_path = _db_path(vault_dir)
     resolved_vault = resolve_vault_dir(vault_dir)
@@ -173,22 +253,14 @@ def get_object_detail(vault_dir: Path | str, object_id: str) -> dict[str, Any]:
         ).fetchall()
         mention_rows = conn.execute(
             """
-            SELECT slug, title, note_type, path
-            FROM pages_index
-            WHERE slug != ?
-              AND (
-                body LIKE ?
-                OR body LIKE ?
-                OR body LIKE ?
-              )
-            ORDER BY slug
+            SELECT DISTINCT pages_index.slug, pages_index.title, pages_index.note_type, pages_index.path
+            FROM page_links
+            JOIN pages_index ON pages_index.slug = page_links.source_slug
+            WHERE page_links.target_slug = ?
+              AND pages_index.slug != ?
+            ORDER BY pages_index.slug
             """,
-            (
-                object_id,
-                f"%[[{object_id}]]%",
-                f"%[[{object_id}|%",
-                f"%[[{object_id}#%",
-            ),
+            (object_id, object_id),
         ).fetchall()
 
     mocs: list[dict[str, Any]] = []
@@ -394,47 +466,22 @@ def list_atlas_memberships(
     query: str | None = None,
     limit: int = 100,
 ) -> list[dict[str, Any]]:
-    limit, _ = _validate_page_args(limit=limit, offset=0)
-    db_path = _db_path(vault_dir)
-    resolved_vault = resolve_vault_dir(vault_dir)
-    normalized_query = _escape_like(query.strip().lower()) if query else ""
-    sql = """
-        SELECT pages_index.slug, pages_index.title, pages_index.path, objects.object_id, objects.title
-        FROM pages_index
-        JOIN page_links ON page_links.source_slug = pages_index.slug
-        JOIN objects ON objects.object_id = page_links.target_slug
-        WHERE pages_index.note_type = 'moc'
-    """
-    params: list[Any] = []
-    if normalized_query:
-        sql += """
-          AND (
-            lower(pages_index.slug) LIKE ? ESCAPE '\\'
-            OR lower(pages_index.title) LIKE ? ESCAPE '\\'
-            OR lower(objects.object_id) LIKE ? ESCAPE '\\'
-            OR lower(objects.title) LIKE ? ESCAPE '\\'
-          )
-        """
-        params.extend([f"%{normalized_query}%"] * 4)
-    sql += " ORDER BY pages_index.slug, objects.object_id LIMIT ?"
-    params.append(limit)
-
-    with sqlite3.connect(db_path) as conn:
-        rows = conn.execute(sql, tuple(params)).fetchall()
-
-    grouped: dict[str, dict[str, Any]] = {}
-    for slug, title, path, object_id, object_title in rows:
-        item = grouped.setdefault(
-            slug,
-            {
-                "slug": slug,
-                "title": title,
-                "path": _vault_relative_path(resolved_vault, path),
-                "members": [],
-            },
-        )
-        item["members"].append({"object_id": object_id, "title": object_title})
-    return list(grouped.values())
+    items = _list_surface_groups(
+        vault_dir,
+        note_type="moc",
+        query=query,
+        limit=limit,
+        object_list_key="members",
+    )
+    return [
+        {
+            "slug": item["slug"],
+            "title": item["title"],
+            "path": item["path"],
+            "members": item["members"],
+        }
+        for item in items
+    ]
 
 
 def list_deep_dive_derivations(
@@ -443,45 +490,20 @@ def list_deep_dive_derivations(
     query: str | None = None,
     limit: int = 100,
 ) -> list[dict[str, Any]]:
-    limit, _ = _validate_page_args(limit=limit, offset=0)
-    db_path = _db_path(vault_dir)
-    resolved_vault = resolve_vault_dir(vault_dir)
-    normalized_query = _escape_like(query.strip().lower()) if query else ""
-    sql = """
-        SELECT pages_index.slug, pages_index.title, pages_index.note_type, pages_index.path, objects.object_id, objects.title
-        FROM pages_index
-        JOIN page_links ON page_links.source_slug = pages_index.slug
-        JOIN objects ON objects.object_id = page_links.target_slug
-        WHERE pages_index.note_type = 'deep_dive'
-    """
-    params: list[Any] = []
-    if normalized_query:
-        sql += """
-          AND (
-            lower(pages_index.slug) LIKE ? ESCAPE '\\'
-            OR lower(pages_index.title) LIKE ? ESCAPE '\\'
-            OR lower(objects.object_id) LIKE ? ESCAPE '\\'
-            OR lower(objects.title) LIKE ? ESCAPE '\\'
-          )
-        """
-        params.extend([f"%{normalized_query}%"] * 4)
-    sql += " ORDER BY pages_index.slug, objects.object_id LIMIT ?"
-    params.append(limit)
-
-    with sqlite3.connect(db_path) as conn:
-        rows = conn.execute(sql, tuple(params)).fetchall()
-
-    grouped: dict[str, dict[str, Any]] = {}
-    for slug, title, note_type, path, object_id, object_title in rows:
-        item = grouped.setdefault(
-            slug,
-            {
-                "slug": slug,
-                "title": title,
-                "note_type": note_type,
-                "path": _vault_relative_path(resolved_vault, path),
-                "derived_objects": [],
-            },
-        )
-        item["derived_objects"].append({"object_id": object_id, "title": object_title})
-    return list(grouped.values())
+    items = _list_surface_groups(
+        vault_dir,
+        note_type="deep_dive",
+        query=query,
+        limit=limit,
+        object_list_key="derived_objects",
+    )
+    return [
+        {
+            "slug": item["slug"],
+            "title": item["title"],
+            "note_type": item["note_type"],
+            "path": item["path"],
+            "derived_objects": item["derived_objects"],
+        }
+        for item in items
+    ]

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -47,6 +47,7 @@ def list_objects(
 ) -> list[dict[str, Any]]:
     limit, offset = _validate_page_args(limit=limit, offset=offset)
     db_path = _db_path(vault_dir)
+    resolved_vault = resolve_vault_dir(vault_dir)
     normalized_query = _escape_like(query.strip().lower()) if query else ""
     with sqlite3.connect(db_path) as conn:
         sql = """
@@ -76,7 +77,7 @@ def list_objects(
             "object_id": row[0],
             "object_kind": row[1],
             "title": row[2],
-            "canonical_path": row[3],
+            "canonical_path": _vault_relative_path(resolved_vault, row[3]),
             "source_slug": row[4],
         }
         for row in rows
@@ -212,7 +213,7 @@ def get_object_detail(vault_dir: Path | str, object_id: str) -> dict[str, Any]:
             "object_id": object_row[0],
             "object_kind": object_row[1],
             "title": object_row[2],
-            "canonical_path": object_row[3],
+            "canonical_path": _vault_relative_path(resolved_vault, object_row[3]),
             "source_slug": object_row[4],
         },
         "summary": (
@@ -320,6 +321,7 @@ def get_topic_neighborhood(vault_dir: Path | str, object_id: str, *, depth: int 
         raise ValueError("Only depth=1 is currently supported")
 
     db_path = _db_path(vault_dir)
+    resolved_vault = resolve_vault_dir(vault_dir)
     with sqlite3.connect(db_path) as conn:
         center = conn.execute(
             """
@@ -361,7 +363,7 @@ def get_topic_neighborhood(vault_dir: Path | str, object_id: str, *, depth: int 
             "object_id": center[0],
             "object_kind": center[1],
             "title": center[2],
-            "canonical_path": center[3],
+            "canonical_path": _vault_relative_path(resolved_vault, center[3]),
             "source_slug": center[4],
         },
         "neighbors": [
@@ -369,7 +371,7 @@ def get_topic_neighborhood(vault_dir: Path | str, object_id: str, *, depth: int 
                 "object_id": row[0],
                 "object_kind": row[1],
                 "title": row[2],
-                "canonical_path": row[3],
+                "canonical_path": _vault_relative_path(resolved_vault, row[3]),
                 "source_slug": row[4],
             }
             for row in neighbor_rows
@@ -394,6 +396,7 @@ def list_atlas_memberships(
 ) -> list[dict[str, Any]]:
     limit, _ = _validate_page_args(limit=limit, offset=0)
     db_path = _db_path(vault_dir)
+    resolved_vault = resolve_vault_dir(vault_dir)
     normalized_query = _escape_like(query.strip().lower()) if query else ""
     sql = """
         SELECT pages_index.slug, pages_index.title, pages_index.path, objects.object_id, objects.title
@@ -426,7 +429,7 @@ def list_atlas_memberships(
             {
                 "slug": slug,
                 "title": title,
-                "path": path,
+                "path": _vault_relative_path(resolved_vault, path),
                 "members": [],
             },
         )
@@ -442,6 +445,7 @@ def list_deep_dive_derivations(
 ) -> list[dict[str, Any]]:
     limit, _ = _validate_page_args(limit=limit, offset=0)
     db_path = _db_path(vault_dir)
+    resolved_vault = resolve_vault_dir(vault_dir)
     normalized_query = _escape_like(query.strip().lower()) if query else ""
     sql = """
         SELECT pages_index.slug, pages_index.title, pages_index.note_type, pages_index.path, objects.object_id, objects.title
@@ -475,7 +479,7 @@ def list_deep_dive_derivations(
                 "slug": slug,
                 "title": title,
                 "note_type": note_type,
-                "path": path,
+                "path": _vault_relative_path(resolved_vault, path),
                 "derived_objects": [],
             },
         )

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -109,8 +109,8 @@ def count_objects(vault_dir: Path | str, *, query: str | None = None) -> int:
 
 
 def _surface_page_query_clauses(*, note_type: str, normalized_query: str) -> tuple[str, list[Any]]:
-    where = [f"pages_index.note_type = '{note_type}'"]
-    params: list[Any] = []
+    where = ["pages_index.note_type = ?"]
+    params: list[Any] = [note_type]
     if normalized_query:
         where.append(
             """

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -15,6 +15,17 @@ def _db_path(vault_dir: Path | str) -> Path:
     return VaultLayout.from_vault(resolved).knowledge_db
 
 
+def _vault_relative_path(vault_dir: Path | str, path: str) -> str:
+    resolved = resolve_vault_dir(vault_dir).resolve()
+    candidate = Path(path)
+    if not candidate.is_absolute():
+        return path
+    try:
+        return str(candidate.resolve().relative_to(resolved))
+    except ValueError:
+        return path
+
+
 def _validate_page_args(*, limit: int, offset: int = 0) -> tuple[int, int]:
     if limit < 0 or offset < 0:
         raise ValueError("limit and offset must be >= 0")
@@ -98,6 +109,7 @@ def count_objects(vault_dir: Path | str, *, query: str | None = None) -> int:
 
 def get_object_detail(vault_dir: Path | str, object_id: str) -> dict[str, Any]:
     db_path = _db_path(vault_dir)
+    resolved_vault = resolve_vault_dir(vault_dir)
     escaped = _escape_like(object_id)
 
     with sqlite3.connect(db_path) as conn:
@@ -185,7 +197,7 @@ def get_object_detail(vault_dir: Path | str, object_id: str) -> dict[str, Any]:
             "slug": slug,
             "title": title,
             "note_type": note_type,
-            "path": path,
+            "path": _vault_relative_path(resolved_vault, path),
         }
         if note_type == "moc" or "/10-Knowledge/Atlas/" in path or Path(path).name.startswith("MOC"):
             mocs.append(item)
@@ -252,7 +264,7 @@ def get_object_detail(vault_dir: Path | str, object_id: str) -> dict[str, Any]:
             for row in contradiction_rows
         ],
         "provenance": {
-            "evergreen_path": object_row[3],
+            "evergreen_path": _vault_relative_path(resolved_vault, object_row[3]),
             "source_notes": source_notes,
             "mocs": mocs,
         },

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -6,7 +6,15 @@ from pathlib import Path
 from typing import Any
 
 from ..runtime import VaultLayout, resolve_vault_dir
-from ..truth_api import count_objects, get_object_detail, get_topic_neighborhood, list_contradictions, list_objects
+from ..truth_api import (
+    count_objects,
+    get_object_detail,
+    get_topic_neighborhood,
+    list_atlas_memberships,
+    list_contradictions,
+    list_deep_dive_derivations,
+    list_objects,
+)
 
 
 def _db_path(vault_dir: Path | str) -> Path:
@@ -50,6 +58,7 @@ def build_object_page_payload(vault_dir: Path | str, object_id: str) -> dict[str
             "source_slug": detail["object"]["source_slug"],
             "canonical_path": detail["object"]["canonical_path"],
         },
+        "provenance": detail["provenance"],
         "links": {
             "topic_path": f"/topic?id={object_id}",
             "events_path": f"/events?q={object_id}",
@@ -73,6 +82,7 @@ def build_topic_overview_payload(vault_dir: Path | str, object_id: str) -> dict[
         "edge_count": len(neighborhood["edges"]),
         "neighbor_count": len(neighborhood["neighbors"]),
         "center_summary": detail["summary"]["summary_text"] if detail["summary"] else "",
+        "provenance": detail["provenance"],
         "links": {
             "center_object_path": f"/object?id={object_id}",
             "events_path": f"/events?q={object_id}",
@@ -215,5 +225,25 @@ def build_objects_index_payload(
         "total_count": total_count,
         "limit": limit,
         "offset": offset,
+        "query": query or "",
+    }
+
+
+def build_atlas_browser_payload(vault_dir: Path | str, *, query: str | None = None) -> dict[str, Any]:
+    items = list_atlas_memberships(vault_dir, query=query)
+    return {
+        "screen": "atlas/browser",
+        "items": items,
+        "count": len(items),
+        "query": query or "",
+    }
+
+
+def build_derivation_browser_payload(vault_dir: Path | str, *, query: str | None = None) -> dict[str, Any]:
+    items = list_deep_dive_derivations(vault_dir, query=query)
+    return {
+        "screen": "derivations/browser",
+        "items": items,
+        "count": len(items),
         "query": query or "",
     }

--- a/tests/test_knowledge_index.py
+++ b/tests/test_knowledge_index.py
@@ -114,6 +114,82 @@ aliases: [Linked Note]
     assert links == [("source-note", "linked-note", "wikilink")]
 
 
+def test_rebuild_knowledge_index_indexes_atlas_and_deep_dive_pages_for_bridge_queries(temp_vault):
+    from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
+    from openclaw_pipeline.runtime import VaultLayout
+
+    evergreen = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
+    evergreen.write_text(
+        """---
+note_id: alpha
+title: Alpha
+type: evergreen
+date: 2026-04-07
+---
+
+# Alpha
+
+Alpha body.
+""",
+        encoding="utf-8",
+    )
+    deep_dive = temp_vault / "20-Areas" / "Tools" / "Topics" / "2026-04" / "Deep Dive_深度解读.md"
+    deep_dive.parent.mkdir(parents=True, exist_ok=True)
+    deep_dive.write_text(
+        """---
+note_id: deep-dive
+title: Deep Dive
+type: deep_dive
+date: 2026-04-07
+---
+
+# Deep Dive
+
+Mentions [[alpha]].
+""",
+        encoding="utf-8",
+    )
+    atlas = temp_vault / "10-Knowledge" / "Atlas" / "Atlas-Index.md"
+    atlas.write_text(
+        """---
+note_id: atlas-index
+title: Atlas Index
+type: moc
+date: 2026-04-07
+---
+
+# Atlas Index
+
+- [[alpha]]
+""",
+        encoding="utf-8",
+    )
+
+    result = rebuild_knowledge_index(temp_vault)
+    db_path = VaultLayout.from_vault(temp_vault).knowledge_db
+
+    assert result["pages_indexed"] == 3
+    assert result["objects_indexed"] == 1
+
+    with sqlite3.connect(db_path) as conn:
+        pages = conn.execute(
+            "SELECT slug, note_type FROM pages_index ORDER BY slug"
+        ).fetchall()
+        links = conn.execute(
+            "SELECT source_slug, target_slug, link_type FROM page_links ORDER BY source_slug"
+        ).fetchall()
+
+    assert pages == [
+        ("alpha", "evergreen"),
+        ("atlas-index", "moc"),
+        ("deep-dive", "deep_dive"),
+    ]
+    assert links == [
+        ("atlas-index", "alpha", "wikilink"),
+        ("deep-dive", "alpha", "wikilink"),
+    ]
+
+
 def test_knowledge_index_help_includes_expected_arguments(capsys):
     from openclaw_pipeline.commands.knowledge_index import main
 

--- a/tests/test_knowledge_index.py
+++ b/tests/test_knowledge_index.py
@@ -190,6 +190,49 @@ date: 2026-04-07
     ]
 
 
+def test_rebuild_knowledge_index_dedupes_duplicate_slugs_across_surfaces(temp_vault):
+    from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
+    from openclaw_pipeline.runtime import VaultLayout
+
+    evergreen = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
+    evergreen.write_text(
+        """---
+note_id: alpha
+title: Alpha Evergreen
+type: evergreen
+date: 2026-04-07
+---
+
+# Alpha Evergreen
+""",
+        encoding="utf-8",
+    )
+    atlas = temp_vault / "10-Knowledge" / "Atlas" / "Alpha.md"
+    atlas.write_text(
+        """---
+note_id: alpha
+title: Alpha Atlas
+type: moc
+date: 2026-04-07
+---
+
+# Alpha Atlas
+""",
+        encoding="utf-8",
+    )
+
+    result = rebuild_knowledge_index(temp_vault)
+    db_path = VaultLayout.from_vault(temp_vault).knowledge_db
+
+    assert result["pages_indexed"] == 1
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            "SELECT slug, title, note_type, path FROM pages_index ORDER BY slug"
+        ).fetchall()
+
+    assert rows == [("alpha", "Alpha Evergreen", "evergreen", str(evergreen))]
+
+
 def test_knowledge_index_help_includes_expected_arguments(capsys):
     from openclaw_pipeline.commands.knowledge_index import main
 

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -321,3 +321,157 @@ date: 2026-04-13
     assert detail["provenance"]["source_notes"][0]["note_type"] == "deep_dive"
     assert detail["provenance"]["mocs"][0]["slug"] == "atlas-index"
     assert detail["provenance"]["mocs"][0]["title"] == "Atlas Index"
+
+
+def test_truth_api_uses_page_links_for_provenance_resolution(temp_vault):
+    from openclaw_pipeline.truth_api import get_object_detail
+
+    source = temp_vault / "20-Areas" / "Tools" / "Topics" / "2026-04" / "Alias Deep Dive_深度解读.md"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text(
+        """---
+note_id: alias-deep-dive
+title: Alias Deep Dive
+type: deep_dive
+date: 2026-04-13
+---
+
+# Alias Deep Dive
+
+Mentions [[Alpha Concept]].
+""",
+        encoding="utf-8",
+    )
+    evergreen = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
+    evergreen.write_text(
+        """---
+note_id: alpha
+title: Alpha
+type: evergreen
+date: 2026-04-13
+aliases: [Alpha Concept]
+---
+
+# Alpha
+
+Alpha supports local-first execution.
+""",
+        encoding="utf-8",
+    )
+    atlas = temp_vault / "10-Knowledge" / "Atlas" / "Alias Atlas.md"
+    atlas.write_text(
+        """---
+note_id: alias-atlas
+title: Alias Atlas
+type: moc
+date: 2026-04-13
+---
+
+# Alias Atlas
+
+- [[Alpha Concept]]
+""",
+        encoding="utf-8",
+    )
+
+    rebuild_knowledge_index(temp_vault)
+
+    detail = get_object_detail(temp_vault, "alpha")
+
+    assert [item["slug"] for item in detail["provenance"]["source_notes"]] == ["alias-deep-dive"]
+    assert [item["slug"] for item in detail["provenance"]["mocs"]] == ["alias-atlas"]
+
+
+def test_truth_api_limits_atlas_memberships_by_page_not_join_rows(temp_vault):
+    from openclaw_pipeline.truth_api import list_atlas_memberships
+
+    for note_id, title in (("alpha", "Alpha"), ("beta", "Beta"), ("gamma", "Gamma")):
+        note = temp_vault / "10-Knowledge" / "Evergreen" / f"{title}.md"
+        note.write_text(
+            f"""---
+note_id: {note_id}
+title: {title}
+type: evergreen
+date: 2026-04-13
+---
+
+# {title}
+""",
+            encoding="utf-8",
+        )
+
+    atlas = temp_vault / "10-Knowledge" / "Atlas" / "Atlas Index.md"
+    atlas.write_text(
+        """---
+note_id: atlas-index
+title: Atlas Index
+type: moc
+date: 2026-04-13
+---
+
+# Atlas Index
+
+- [[alpha]]
+- [[beta]]
+- [[gamma]]
+""",
+        encoding="utf-8",
+    )
+
+    rebuild_knowledge_index(temp_vault)
+
+    items = list_atlas_memberships(temp_vault, limit=1)
+
+    assert len(items) == 1
+    assert items[0]["slug"] == "atlas-index"
+    assert [member["object_id"] for member in items[0]["members"]] == ["alpha", "beta", "gamma"]
+
+
+def test_truth_api_limits_deep_dive_derivations_by_page_not_join_rows(temp_vault):
+    from openclaw_pipeline.truth_api import list_deep_dive_derivations
+
+    for note_id, title in (("alpha", "Alpha"), ("beta", "Beta"), ("gamma", "Gamma")):
+        note = temp_vault / "10-Knowledge" / "Evergreen" / f"{title}.md"
+        note.write_text(
+            f"""---
+note_id: {note_id}
+title: {title}
+type: evergreen
+date: 2026-04-13
+---
+
+# {title}
+""",
+            encoding="utf-8",
+        )
+
+    deep_dive = temp_vault / "20-Areas" / "Tools" / "Topics" / "2026-04" / "Deep Dive_深度解读.md"
+    deep_dive.parent.mkdir(parents=True, exist_ok=True)
+    deep_dive.write_text(
+        """---
+note_id: deep-dive
+title: Deep Dive
+type: deep_dive
+date: 2026-04-13
+---
+
+# Deep Dive
+
+- [[alpha]]
+- [[beta]]
+- [[gamma]]
+""",
+        encoding="utf-8",
+    )
+
+    rebuild_knowledge_index(temp_vault)
+
+    items = list_deep_dive_derivations(temp_vault, limit=1)
+
+    assert len(items) == 1
+    assert items[0]["slug"] == "deep-dive"
+    assert [member["object_id"] for member in items[0]["derived_objects"]] == [
+        "alpha",
+        "beta",
+        "gamma",
+    ]

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -315,8 +315,8 @@ date: 2026-04-13
 
     detail = get_object_detail(temp_vault, "alpha")
 
-    assert detail["object"]["canonical_path"].endswith("10-Knowledge/Evergreen/Alpha.md")
-    assert detail["provenance"]["evergreen_path"].endswith("10-Knowledge/Evergreen/Alpha.md")
+    assert detail["object"]["canonical_path"] == "10-Knowledge/Evergreen/Alpha.md"
+    assert detail["provenance"]["evergreen_path"] == "10-Knowledge/Evergreen/Alpha.md"
     assert detail["provenance"]["source_notes"][0]["slug"] == "source-deep-dive"
     assert detail["provenance"]["source_notes"][0]["note_type"] == "deep_dive"
     assert detail["provenance"]["mocs"][0]["slug"] == "atlas-index"

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -475,3 +475,15 @@ date: 2026-04-13
         "beta",
         "gamma",
     ]
+
+
+def test_surface_page_query_clauses_parameterizes_note_type():
+    from openclaw_pipeline.truth_api import _surface_page_query_clauses
+
+    where_sql, params = _surface_page_query_clauses(
+        note_type="moc",
+        normalized_query="alpha",
+    )
+
+    assert "pages_index.note_type = ?" in where_sql
+    assert params[0] == "moc"

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -257,3 +257,67 @@ Alpha one does not support local-first execution.
     detail = get_object_detail(temp_vault, "alpha")
 
     assert detail["contradictions"] == []
+
+
+def test_truth_api_returns_object_provenance_and_moc_membership(temp_vault):
+    from openclaw_pipeline.truth_api import get_object_detail
+
+    source = temp_vault / "20-Areas" / "Tools" / "Topics" / "2026-04" / "Source Deep Dive_深度解读.md"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text(
+        """---
+note_id: source-deep-dive
+title: Source Deep Dive
+type: deep_dive
+date: 2026-04-13
+---
+
+# Source Deep Dive
+
+Mentions [[alpha]].
+""",
+        encoding="utf-8",
+    )
+
+    evergreen = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
+    evergreen.write_text(
+        """---
+note_id: alpha
+title: Alpha
+type: evergreen
+date: 2026-04-13
+---
+
+# Alpha
+
+Alpha supports local-first execution.
+""",
+        encoding="utf-8",
+    )
+
+    atlas = temp_vault / "10-Knowledge" / "Atlas" / "Atlas-Index.md"
+    atlas.write_text(
+        """---
+note_id: atlas-index
+title: Atlas Index
+type: moc
+date: 2026-04-13
+---
+
+# Atlas Index
+
+- [[alpha]]
+""",
+        encoding="utf-8",
+    )
+
+    rebuild_knowledge_index(temp_vault)
+
+    detail = get_object_detail(temp_vault, "alpha")
+
+    assert detail["object"]["canonical_path"].endswith("10-Knowledge/Evergreen/Alpha.md")
+    assert detail["provenance"]["evergreen_path"].endswith("10-Knowledge/Evergreen/Alpha.md")
+    assert detail["provenance"]["source_notes"][0]["slug"] == "source-deep-dive"
+    assert detail["provenance"]["source_notes"][0]["note_type"] == "deep_dive"
+    assert detail["provenance"]["mocs"][0]["slug"] == "atlas-index"
+    assert detail["provenance"]["mocs"][0]["title"] == "Atlas Index"

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import threading
 from http.client import HTTPConnection
+from pathlib import Path
 
 from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
 
@@ -240,3 +242,15 @@ def test_ui_server_main_exits_nonzero_when_preflight_fails(temp_vault, capsys, m
     assert exit_code == 1
     assert captured.out == ""
     assert "broken knowledge db" in captured.err
+
+
+def test_ui_server_module_compiles_on_python311():
+    module_path = Path("src/openclaw_pipeline/commands/ui_server.py")
+    result = subprocess.run(
+        ["python3.11", "-m", "py_compile", str(module_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sqlite3
 import threading
 from http.client import HTTPConnection
+from urllib.parse import quote
 
 from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
 from openclaw_pipeline.runtime import VaultLayout
@@ -145,6 +146,9 @@ date: 2026-04-13
     assert "Evergreen Markdown" in object_body
     assert "Source Deep Dive" in object_body
     assert "Atlas Index" in object_body
+    assert f"/note?path={quote('10-Knowledge/Evergreen/Alpha.md', safe='')}" in object_body
+    assert f"/note?path={quote('20-Areas/Tools/Topics/2026-04/Source Deep Dive_深度解读.md', safe='')}" in object_body
+    assert f"/note?path={quote('10-Knowledge/Atlas/Atlas-Index.md', safe='')}" in object_body
 
     assert topic_status == 200
     assert "Topic: Alpha" in topic_body
@@ -165,6 +169,46 @@ date: 2026-04-13
     assert "Contradictions" in contradictions_body
     assert "alpha" in contradictions_body
     assert '/object?id=alpha' in contradictions_body
+
+
+def test_ui_note_page_renders_markdown_note(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+
+    note = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
+    note.write_text(
+        """---
+note_id: alpha
+title: Alpha
+type: evergreen
+date: 2026-04-13
+---
+
+# Alpha
+
+Alpha supports local-first execution.
+
+- First point
+- Second point
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        status, body = _get(port, f"/note?path={quote('10-Knowledge/Evergreen/Alpha.md', safe='')}")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert status == 200
+    assert "Markdown Note" in body
+    assert "Alpha supports local-first execution." in body
+    assert "<li>First point</li>" in body
 
 
 def test_ui_root_dashboard_renders_db_summary(temp_vault):

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -144,6 +144,8 @@ date: 2026-04-13
     assert 'href="#claims"' in object_body
     assert "Source Slug" in object_body
     assert "Evergreen Markdown" in object_body
+    assert "10-Knowledge/Evergreen/Alpha.md" in object_body
+    assert "/private/" not in object_body
     assert "Source Deep Dive" in object_body
     assert "Atlas Index" in object_body
     assert f"/note?path={quote('10-Knowledge/Evergreen/Alpha.md', safe='')}" in object_body
@@ -302,9 +304,112 @@ Body paragraph.
     assert status == 200
     assert "Frontmatter" in body
     assert "https://example.com/post" in body
+    assert 'href="https://example.com/post"' in body
     assert "published" in body
     assert "```yaml" not in body
     assert "Body paragraph." in body
+
+
+def test_ui_note_page_normalizes_related_knowledge_links(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+
+    prompt = temp_vault / "10-Knowledge" / "Evergreen" / "Prompt Engineering.md"
+    prompt.parent.mkdir(parents=True, exist_ok=True)
+    prompt.write_text(
+        """---
+note_id: prompt-engineering
+title: Prompt Engineering
+type: evergreen
+date: 2026-04-13
+---
+
+# Prompt Engineering
+""",
+        encoding="utf-8",
+    )
+    note = temp_vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "Related Links_深度解读.md"
+    note.parent.mkdir(parents=True, exist_ok=True)
+    note.write_text(
+        """## 关联知识
+
+- [[ai-agent|AI-Agent]] — explanation
+- Prompt-Engineering — explanation
+- AI-Workflow — explanation
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        status, body = _get(port, f"/note?path={quote('20-Areas/AI-Research/Topics/2026-04/Related Links_深度解读.md', safe='')}")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert status == 200
+    assert "[[ai-agent|AI-Agent]]" not in body
+    assert '🔍 AI-Agent' in body
+    assert '🎯 Prompt-Engineering' in body
+    assert '🔍 AI-Workflow' in body
+    assert '/objects?q=ai-agent' in body
+    assert '/object?id=prompt-engineering' in body
+    assert '/objects?q=AI-Workflow' in body
+
+
+def test_ui_note_page_smart_renders_reference_tables_and_keywords(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+
+    note = temp_vault / "20-Areas" / "Tools" / "Topics" / "2026-04" / "Repo Links_深度解读.md"
+    note.parent.mkdir(parents=True, exist_ok=True)
+    note.write_text(
+        """```yaml
+---
+title: "Repo Links"
+source: "https://github.com/example/repo"
+github: "https://github.com/example/repo"
+---
+```
+
+## 13. 页脚
+
+```
+┌────────────────────────────────────┐
+│ 参考链接                           │
+├────────────────────────────────────┤
+│ GitHub 仓库 │ https://github.com/example/repo │
+├────────────────────────────────────┤
+│ 打包文档 │ docs/RELEASING.md │
+└────────────────────────────────────┘
+```
+
+**关键词**：OpenCove, Claude Code
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        status, body = _get(port, f"/note?path={quote('20-Areas/Tools/Topics/2026-04/Repo Links_深度解读.md', safe='')}")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert status == 200
+    assert '<table>' in body
+    assert 'href="https://github.com/example/repo"' in body
+    assert 'href="https://github.com/example/repo/blob/main/docs/RELEASING.md"' in body
+    assert '/objects?q=OpenCove' in body
+    assert '/objects?q=Claude%20Code' in body
 
 
 def test_ui_root_dashboard_renders_db_summary(temp_vault):

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -174,6 +174,35 @@ date: 2026-04-13
 def test_ui_note_page_renders_markdown_note(temp_vault):
     from openclaw_pipeline.commands.ui_server import create_server
 
+    source = temp_vault / "20-Areas" / "Tools" / "Topics" / "2026-04" / "Source Deep Dive_深度解读.md"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text(
+        """---
+note_id: source-deep-dive
+title: Source Deep Dive
+type: deep_dive
+date: 2026-04-13
+---
+
+# Source Deep Dive
+
+Mentions [[alpha]].
+""",
+        encoding="utf-8",
+    )
+    beta = temp_vault / "10-Knowledge" / "Evergreen" / "Beta.md"
+    beta.write_text(
+        """---
+note_id: beta
+title: Beta
+type: evergreen
+date: 2026-04-13
+---
+
+# Beta
+""",
+        encoding="utf-8",
+    )
     note = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
     note.write_text(
         """---
@@ -189,6 +218,21 @@ Alpha supports local-first execution.
 
 - First point
 - Second point
+
+## 关联概念
+
+[[beta]]
+
+📚 来源
+[[Source Deep Dive_深度解读]]
+
+| Name | Value |
+| --- | --- |
+| mode | local-first |
+
+```text
+raw block
+```
 """,
         encoding="utf-8",
     )
@@ -207,8 +251,60 @@ Alpha supports local-first execution.
 
     assert status == 200
     assert "Markdown Note" in body
+    assert "Frontmatter" in body
+    assert "published" not in body
     assert "Alpha supports local-first execution." in body
     assert "<li>First point</li>" in body
+    assert '/object?id=beta' in body
+    assert f'/note?path={quote("20-Areas/Tools/Topics/2026-04/Source Deep Dive_深度解读.md", safe="")}' in body
+    assert "<table>" in body
+    assert "raw block" in body
+    assert "language-text" in body
+
+
+def test_ui_note_page_formats_fenced_yaml_frontmatter(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+
+    note = temp_vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "Fenced Source_深度解读.md"
+    note.parent.mkdir(parents=True, exist_ok=True)
+    note.write_text(
+        """```yaml
+---
+title: "Fenced Source"
+source: "https://example.com/post"
+author: "@author"
+date: "2026-01-28"
+type: "tutorial"
+tags: ["AI-Agent", "workflow"]
+status: "published"
+---
+```
+
+## Summary
+
+Body paragraph.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        status, body = _get(port, f"/note?path={quote('20-Areas/AI-Research/Topics/2026-04/Fenced Source_深度解读.md', safe='')}")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert status == 200
+    assert "Frontmatter" in body
+    assert "https://example.com/post" in body
+    assert "published" in body
+    assert "```yaml" not in body
+    assert "Body paragraph." in body
 
 
 def test_ui_root_dashboard_renders_db_summary(temp_vault):

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -582,8 +582,13 @@ date: 2026-04-13
     assert "Atlas / MOC Browser" in atlas_body
     assert "Atlas Index" in atlas_body
     assert "Alpha" in atlas_body
+    assert f"/note?path={quote('10-Knowledge/Atlas/Atlas-Index.md', safe='')}" in atlas_body
 
     assert derivations_status == 200
     assert "Deep Dive Derivations" in derivations_body
     assert "Deep Dive" in derivations_body
     assert "Alpha" in derivations_body
+    assert (
+        f"/note?path={quote('20-Areas/Tools/Topics/2026-04/Deep Dive_深度解读.md', safe='')}"
+        in derivations_body
+    )

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -82,6 +82,37 @@ def _get(port: int, path: str) -> tuple[int, str]:
 def test_ui_smoke_pages_render_truth_views(temp_vault):
     from openclaw_pipeline.commands.ui_server import create_server
 
+    source = temp_vault / "20-Areas" / "Tools" / "Topics" / "2026-04" / "Source Deep Dive_深度解读.md"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text(
+        """---
+note_id: source-deep-dive
+title: Source Deep Dive
+type: deep_dive
+date: 2026-04-13
+---
+
+# Source Deep Dive
+
+Mentions [[alpha]].
+""",
+        encoding="utf-8",
+    )
+    atlas = temp_vault / "10-Knowledge" / "Atlas" / "Atlas-Index.md"
+    atlas.write_text(
+        """---
+note_id: atlas-index
+title: Atlas Index
+type: moc
+date: 2026-04-13
+---
+
+# Atlas Index
+
+- [[alpha]]
+""",
+        encoding="utf-8",
+    )
     _seed_truth_store(temp_vault)
     server = create_server(temp_vault, host="127.0.0.1", port=0)
     port = server.server_address[1]
@@ -111,6 +142,9 @@ def test_ui_smoke_pages_render_truth_views(temp_vault):
     assert '/contradictions?q=alpha' in object_body
     assert 'href="#claims"' in object_body
     assert "Source Slug" in object_body
+    assert "Evergreen Markdown" in object_body
+    assert "Source Deep Dive" in object_body
+    assert "Atlas Index" in object_body
 
     assert topic_status == 200
     assert "Topic: Alpha" in topic_body
@@ -118,11 +152,14 @@ def test_ui_smoke_pages_render_truth_views(temp_vault):
     assert '/object?id=alpha' in topic_body
     assert '/events?q=alpha' in topic_body
     assert "Center Summary" in topic_body
+    assert "Atlas / MOC" in topic_body
 
     assert events_status == 200
     assert "Event Dossier" in events_body
     assert "2026-04-13" in events_body
     assert 'id="date-2026-04-13"' in events_body
+    assert "timeline-oriented" in events_body
+    assert "page_date -" not in events_body
 
     assert contradictions_status == 200
     assert "Contradictions" in contradictions_body
@@ -231,3 +268,77 @@ def test_ui_events_page_filters_by_query(temp_vault):
     assert status == 200
     assert "Beta" in body
     assert "Alpha" not in body
+
+
+def test_ui_smoke_atlas_and_deep_dive_pages_render_bridge_views(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+
+    alpha = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
+    alpha.write_text(
+        """---
+note_id: alpha
+title: Alpha
+type: evergreen
+date: 2026-04-13
+---
+
+# Alpha
+
+Alpha supports local-first execution.
+""",
+        encoding="utf-8",
+    )
+    deep_dive = temp_vault / "20-Areas" / "Tools" / "Topics" / "2026-04" / "Deep Dive_深度解读.md"
+    deep_dive.parent.mkdir(parents=True, exist_ok=True)
+    deep_dive.write_text(
+        """---
+note_id: deep-dive
+title: Deep Dive
+type: deep_dive
+date: 2026-04-13
+---
+
+# Deep Dive
+
+Mentions [[alpha]].
+""",
+        encoding="utf-8",
+    )
+    atlas = temp_vault / "10-Knowledge" / "Atlas" / "Atlas-Index.md"
+    atlas.write_text(
+        """---
+note_id: atlas-index
+title: Atlas Index
+type: moc
+date: 2026-04-13
+---
+
+# Atlas Index
+
+- [[alpha]]
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        atlas_status, atlas_body = _get(port, "/atlas")
+        derivations_status, derivations_body = _get(port, "/deep-dives")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert atlas_status == 200
+    assert "Atlas / MOC Browser" in atlas_body
+    assert "Atlas Index" in atlas_body
+    assert "Alpha" in atlas_body
+
+    assert derivations_status == 200
+    assert "Deep Dive Derivations" in derivations_body
+    assert "Deep Dive" in derivations_body
+    assert "Alpha" in derivations_body

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -93,6 +93,64 @@ def test_build_object_page_payload(temp_vault):
     assert payload["section_nav"][0]["href"] == "#summary"
 
 
+def test_build_object_page_payload_includes_provenance(temp_vault):
+    from openclaw_pipeline.ui.view_models import build_object_page_payload
+
+    source = temp_vault / "20-Areas" / "Tools" / "Topics" / "2026-04" / "Source Deep Dive_深度解读.md"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text(
+        """---
+note_id: source-deep-dive
+title: Source Deep Dive
+type: deep_dive
+date: 2026-04-13
+---
+
+# Source Deep Dive
+
+Mentions [[alpha]].
+""",
+        encoding="utf-8",
+    )
+    atlas = temp_vault / "10-Knowledge" / "Atlas" / "Atlas-Index.md"
+    atlas.write_text(
+        """---
+note_id: atlas-index
+title: Atlas Index
+type: moc
+date: 2026-04-13
+---
+
+# Atlas Index
+
+- [[alpha]]
+""",
+        encoding="utf-8",
+    )
+    alpha = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
+    alpha.write_text(
+        """---
+note_id: alpha
+title: Alpha
+type: evergreen
+date: 2026-04-13
+---
+
+# Alpha
+
+Alpha supports local-first execution.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    payload = build_object_page_payload(temp_vault, "alpha")
+
+    assert payload["provenance"]["evergreen_path"].endswith("10-Knowledge/Evergreen/Alpha.md")
+    assert payload["provenance"]["source_notes"][0]["slug"] == "source-deep-dive"
+    assert payload["provenance"]["mocs"][0]["slug"] == "atlas-index"
+
+
 def test_build_topic_overview_payload(temp_vault):
     from openclaw_pipeline.ui.view_models import build_topic_overview_payload
 
@@ -212,6 +270,93 @@ def test_build_event_dossier_payload_filters_by_query(temp_vault):
 
     assert payload["event_count"] == 1
     assert [item["object_id"] for item in payload["events"]] == ["beta"]
+
+
+def test_build_atlas_browser_payload(temp_vault):
+    from openclaw_pipeline.ui.view_models import build_atlas_browser_payload
+
+    alpha = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
+    alpha.write_text(
+        """---
+note_id: alpha
+title: Alpha
+type: evergreen
+date: 2026-04-13
+---
+
+# Alpha
+
+Alpha supports local-first execution.
+""",
+        encoding="utf-8",
+    )
+    atlas = temp_vault / "10-Knowledge" / "Atlas" / "Atlas-Index.md"
+    atlas.write_text(
+        """---
+note_id: atlas-index
+title: Atlas Index
+type: moc
+date: 2026-04-13
+---
+
+# Atlas Index
+
+- [[alpha]]
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    payload = build_atlas_browser_payload(temp_vault)
+
+    assert payload["screen"] == "atlas/browser"
+    assert payload["count"] == 1
+    assert payload["items"][0]["slug"] == "atlas-index"
+    assert payload["items"][0]["members"][0]["object_id"] == "alpha"
+
+
+def test_build_derivation_browser_payload(temp_vault):
+    from openclaw_pipeline.ui.view_models import build_derivation_browser_payload
+
+    alpha = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
+    alpha.write_text(
+        """---
+note_id: alpha
+title: Alpha
+type: evergreen
+date: 2026-04-13
+---
+
+# Alpha
+
+Alpha supports local-first execution.
+""",
+        encoding="utf-8",
+    )
+    deep_dive = temp_vault / "20-Areas" / "Tools" / "Topics" / "2026-04" / "Deep Dive_深度解读.md"
+    deep_dive.parent.mkdir(parents=True, exist_ok=True)
+    deep_dive.write_text(
+        """---
+note_id: deep-dive
+title: Deep Dive
+type: deep_dive
+date: 2026-04-13
+---
+
+# Deep Dive
+
+Mentions [[alpha]].
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    payload = build_derivation_browser_payload(temp_vault)
+
+    assert payload["screen"] == "derivations/browser"
+    assert payload["count"] == 1
+    assert payload["items"][0]["slug"] == "deep-dive"
+    assert payload["items"][0]["derived_objects"][0]["object_id"] == "alpha"
 
 
 def test_build_event_dossier_payload_applies_limit_before_materializing(temp_vault):


### PR DESCRIPTION
## Summary
- expand knowledge indexing so Atlas and 20-Areas pages participate in `pages_index`/`page_links` while keeping truth objects Evergreen-backed
- expose provenance on object/topic payloads and add Atlas / Deep Dive browser views in `ovp-ui`
- hide meaningless `page_date` labels from the Event Dossier UI

## Verification
- `PYTHONPATH=src python3.13 -m pytest -q tests/test_knowledge_index.py tests/test_truth_api.py tests/test_ui_view_models.py tests/test_ui_server.py tests/test_ui_smoke.py`
- `PYTHONPATH=src python3.13 -m pytest -q`
- `python3.13 -m py_compile src/openclaw_pipeline/knowledge_index.py src/openclaw_pipeline/truth_api.py src/openclaw_pipeline/ui/view_models.py src/openclaw_pipeline/commands/ui_server.py`
- local `ovp-ui` smoke on `/events`, `/atlas`, `/deep-dives`, `/object?id=context-engineering`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/13" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Atlas / MOC" and "Deep Dives" browser views with search/filter and nav links.
  * Enhanced object/topic pages with a Provanance section (evergreen path, source notes, atlas membership).
  * Added a markdown-backed note view with frontmatter, wikilink resolution, and related-note linking.
  * Cleaner event display for timeline-oriented entries.

* **Tests**
  * Expanded UI and API tests covering atlas/deep-dive views, note rendering, and provenance payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->