### PR TITLE
feat: add phase 8 truth review workbench

### DIFF
--- a/docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
+++ b/docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
@@ -1,0 +1,524 @@
+# Local Knowledge Workbench Milestone Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Define the remaining product and engineering milestones from the current OVP state to a real local knowledge workbench.
+
+**Architecture:** Keep the existing architecture intact: vault Markdown remains the authoring and export surface, `knowledge.db` remains the truth-aware runtime store, and `ovp-ui` becomes the primary local inspection and review surface. The next work should deepen the bridge between these three layers instead of replacing any of them.
+
+**Tech Stack:** Python 3.13, SQLite via stdlib `sqlite3`, current `knowledge_index.py`, `truth_api.py`, `ui/view_models.py`, `commands/ui_server.py`, pytest, lightweight local HTTP UI.
+
+---
+
+## Product Definition
+
+“本地知识工作台” at this project stage means a local-first system where a user can:
+
+1. ingest and process source material into deep dives and evergreen notes,
+2. inspect the truth layer directly from `knowledge.db`,
+3. move from DB rows back to the originating Markdown notes without guessing,
+4. review and maintain contradictions / stale summaries from one UI,
+5. understand how source notes, deep dives, evergreen objects, Atlas/MOC pages, and timeline entries connect.
+
+This does **not** require:
+
+- multi-user collaboration,
+- a hosted web product,
+- replacing Obsidian as the authoring surface,
+- replacing SQLite,
+- or a complete ontology for every future domain.
+
+## Current State
+
+### What already exists
+
+- `research-tech` is the default workflow pack.
+- Pipeline is stable end-to-end for the current vault.
+- `knowledge.db` contains:
+  - `objects`
+  - `claims`
+  - `relations`
+  - `compiled_summaries`
+  - `timeline_events`
+  - `contradictions`
+  - `pages_index / page_links`
+- Local product surfaces already exist:
+  - `ovp-truth`
+  - `ovp-ui`
+  - `ovp-doctor`
+  - `ovp-export`
+- `ovp-ui` already supports:
+  - objects browser
+  - unified search
+  - note rendering
+  - Atlas / MOC browser
+  - Deep Dive derivation browser
+  - event browser
+  - contradiction browser
+  - stale summary browser
+  - contradiction resolution actions
+  - summary rebuild actions
+  - batch operations for contradictions and stale summaries
+
+### What this means in product terms
+
+The system is already past “debugging UI for the DB.” It is now a working local browser + maintenance tool over the truth layer.
+
+But it is **not yet** a full local knowledge workbench, because key product loops are still incomplete or weak.
+
+## Gap Analysis
+
+### Gap 1: Review workbench is partial
+
+Current status:
+
+- contradictions can be reviewed,
+- stale summaries can be rebuilt,
+- review context is visible on object/topic/event pages.
+
+Missing:
+
+- richer evidence for why an item is in queue,
+- review history and audit visibility in the UI,
+- direct review entry points from more surfaces,
+- queue-level operator ergonomics beyond the current minimal forms.
+
+### Gap 2: Event model is still shallow
+
+Current status:
+
+- `Event Dossier` is usable,
+- provenance is visible,
+- users can jump from events back to object / deep dive / Atlas.
+
+Missing:
+
+- stronger distinction between “dated note” and “event entity,”
+- better grouping and filtering semantics,
+- better summary context for why an item appears on the timeline,
+- less ambiguity around whether `/events` is a note timeline or an event system.
+
+### Gap 3: Contradiction model is weak
+
+Current status:
+
+- contradiction queue exists,
+- UI can resolve contradictions,
+- zero-result explanations are visible.
+
+Missing:
+
+- stronger detection quality,
+- better evidence display,
+- clearer subject/object scope,
+- confidence that an empty contradiction queue means something useful.
+
+### Gap 4: Knowledge production traceability is still thin
+
+Current status:
+
+- source note <-> deep dive bridge exists,
+- deep dive -> derived object browser exists,
+- object -> evergreen/source note/Atlas bridge exists.
+
+Missing:
+
+- a clear end-to-end production chain view:
+  - source -> processed -> deep dive -> evergreen -> Atlas
+- per-note and per-object “what did this produce / what produced this” explanations,
+- better aggregate views for editorial or knowledge operations.
+
+### Gap 5: Product shell is still utilitarian
+
+Current status:
+
+- UI is usable,
+- search works,
+- review queues are visible.
+
+Missing:
+
+- stronger navigation IA,
+- denser dashboards,
+- better page-level context summaries,
+- stronger operator affordances,
+- a clearer “start here / next action” experience.
+
+## Milestone Map
+
+### Milestone 0: Knowledge Runtime Foundation
+
+Status: **Complete**
+
+Includes:
+
+- Phase 1: extraction visibility
+- Phase 2: truth store
+- Phase 3: materializers + review loops
+- Phase 4: pack split
+- Phase 5: pack E2E hardening
+- Phase 6: operationalization and engine decision
+
+Exit condition:
+
+- `research-tech` is the default pack
+- runtime is stable
+- full pytest suite is green
+
+### Milestone 1: DB Surface And Local Browsing
+
+Status: **Complete**
+
+Includes:
+
+- Phase 7
+- `truth_api`
+- `ovp-truth`
+- DB-backed view models
+- `ovp-ui`
+- object/topic/event/contradiction browsing
+
+Exit condition:
+
+- user can inspect truth rows from the DB without raw SQL
+
+### Milestone 2: Provenance-Aware Review Workbench
+
+Status: **In Progress**
+
+Includes:
+
+- Phase 8
+- provenance-aware events
+- provenance-aware contradictions
+- Atlas / Deep Dive bridge pages
+- note rendering and asset serving
+- unified search
+- contradiction and stale-summary actions
+- batch review operations
+
+Exit condition:
+
+1. Every major truth surface can point back to Markdown provenance.
+2. The user can perform the two current truth maintenance loops from the UI.
+3. The UI no longer feels like a raw DB viewer.
+
+Remaining work inside this milestone:
+
+- tighten queue evidence and review explanation
+- expose review history / audit visibility
+- improve dashboard and page-level next-action context
+
+### Milestone 3: Review Workbench Completion
+
+Status: **Not Started**
+
+Goal:
+
+Make the current UI feel like a real operator console for knowledge maintenance.
+
+Core deliverables:
+
+- contradiction evidence drill-down
+- stale summary rationale drill-down
+- review history / audit trail in UI
+- queue actions reachable from object/topic/event pages
+- better dashboard guidance:
+  - what is urgent,
+  - what is noisy,
+  - what changed recently
+
+Exit condition:
+
+- an operator can use `ovp-ui` to review and maintain the current truth queues without dropping back to CLI for normal flows
+
+### Milestone 4: Event And Contradiction Model Hardening
+
+Status: **Not Started**
+
+Goal:
+
+Improve the underlying semantic quality of `events` and `contradictions`, not just the UI.
+
+Core deliverables:
+
+- clearer timeline row semantics
+- better event grouping
+- stronger contradiction evidence / polarity rules
+- better empty-state semantics
+- fewer false-positive and false-negative workbench items
+
+Exit condition:
+
+- users can trust that these surfaces are semantically meaningful, not just technically present
+
+### Milestone 5: Knowledge Production Traceability
+
+Status: **Not Started**
+
+Goal:
+
+Make the full production chain legible:
+
+- source
+- processed note
+- deep dive
+- evergreen object
+- Atlas/MOC placement
+
+Core deliverables:
+
+- source-centric provenance views
+- deep-dive production summaries
+- object derivation summaries
+- Atlas/topic rollups that explain knowledge contribution, not just membership
+
+Exit condition:
+
+- users can answer “where did this knowledge come from?” and “what did this note produce?” from the product itself
+
+### Milestone 6: Product Shell And Operator UX
+
+Status: **Not Started**
+
+Goal:
+
+Turn the current local UI into a clearer product surface.
+
+Core deliverables:
+
+- better homepage / dashboard IA
+- stronger navigation between object/topic/event/review/search
+- more intentional layout and information density
+- improved affordances for common workflows
+
+Exit condition:
+
+- first-time users can understand how to navigate and operate the system without reading code or plan docs
+
+## Recommended Next Sequence
+
+### Phase 9: Review Workbench Completion
+
+Do next.
+
+Reason:
+
+- it deepens the surfaces that already exist,
+- it improves user trust immediately,
+- and it avoids moving to more speculative model work too early.
+
+Recommended scope:
+
+1. review history / audit panels,
+2. contradiction evidence context,
+3. stale summary explanation panels,
+4. action entry points from object/topic/event pages,
+5. dashboard prioritization for review work.
+
+### Phase 10: Event + Contradiction Hardening
+
+Do after Phase 9.
+
+Reason:
+
+- once the workbench is operational, semantic weaknesses become more visible,
+- then it is worth hardening the underlying model.
+
+### Phase 11: Knowledge Production Traceability
+
+Do after Phase 10 or in parallel if product pressure is stronger than model pressure.
+
+Reason:
+
+- this is the most legible “value surface” for users,
+- but it depends on the earlier provenance and review foundation being stable.
+
+## Non-Recommended Paths Right Now
+
+Do **not** prioritize these before Milestones 3-5:
+
+- external domain packs,
+- PGlite migration,
+- hosted product shell,
+- multi-user features,
+- heavy frontend rewrite,
+- speculative graph visualization for its own sake.
+
+Those are downstream, not current blockers.
+
+## Milestone Exit Criteria For “Real Local Knowledge Workbench”
+
+The project can claim that label when all of the following are true:
+
+1. Users can browse truth rows directly.
+2. Users can trace truth rows back to source Markdown.
+3. Users can perform routine knowledge maintenance from the UI.
+4. Users can understand why an item appears in events / contradictions / stale summaries.
+5. Users can inspect the full production chain from source to evergreen organization.
+6. The local UI feels like the primary operational surface, not a debug sidecar.
+
+## Current Assessment
+
+As of this plan:
+
+- Milestone 0: complete
+- Milestone 1: complete
+- Milestone 2: mostly complete, but not fully closed
+- Milestone 3+: not started
+
+So the honest product statement is:
+
+> OVP is already a usable local truth browser and partial review workbench, but it is not yet a fully mature local knowledge workbench.
+
+That remaining gap is now specific and manageable. It is no longer architectural uncertainty; it is milestone execution.
+
+## External Reference Projects And What To Borrow
+
+This milestone should stay grounded in concrete product references instead of inventing abstract architecture in isolation.
+
+### GBrain
+
+Reference:
+
+- `gbrain` repository
+
+What matters:
+
+- knowledge system framed as an operator workflow, not just a storage engine,
+- strong maintenance / recipe / skillpack story,
+- clear “the system keeps working after you save” mental model.
+
+What OVP should borrow:
+
+- stronger operator protocol for recurring maintenance,
+- clearer ongoing maintenance narratives beyond one-shot commands,
+- more productized workflows around curation and upkeep.
+
+### Nia Vault
+
+Reference:
+
+- `Nia Vault` docs
+
+What matters:
+
+- stronger page contract,
+- clearer distinction between compiled truth and ongoing timeline/history,
+- product-level graph and workflow center concepts.
+
+What OVP should borrow:
+
+- object/topic/event pages should feel more like stable knowledge pages, not generic data views,
+- stronger workflow-center experience for lint / maintenance / sync operations,
+- eventually a more explicit graph surface for typed relation browsing.
+
+### agentmemory
+
+Reference:
+
+- `agentmemory` repository
+
+What matters:
+
+- excellent runtime observability story,
+- clear integration packaging for many agent hosts,
+- benchmark / measurable-value framing.
+
+What OVP should borrow:
+
+- better visibility into what the system captured, indexed, and changed,
+- clearer integration health surfaces,
+- stronger quality and maintenance metrics over time.
+
+### Nowledge Mem
+
+Reference:
+
+- `Nowledge Mem` docs
+
+What matters:
+
+- very strong first-loop product framing:
+  - save one thing,
+  - find it again,
+  - let one real tool use it,
+- explicit “how to know it is working” verification language,
+- background intelligence framed as:
+  - contradictions,
+  - clusters,
+  - briefings,
+  - graph connections,
+- search described as a ranking pipeline, not just a textbox,
+- browse / automation tools packaged as part of the product surface, not hidden implementation detail.
+
+What OVP should borrow:
+
+- a stronger “first useful loop” for local workbench onboarding,
+- explicit verification surfaces that prove:
+  - this came from my vault,
+  - this object came from my source chain,
+  - this review queue reflects real system state,
+- a more productized explanation of background maintenance:
+  - why an item is stale,
+  - why a contradiction exists,
+  - what changed since last run,
+- eventually a richer ranking / relevance story for unified search instead of raw matching alone.
+
+## Cross-Project Product Principles
+
+Across `gbrain`, `Nia Vault`, `agentmemory`, and `Nowledge Mem`, the consistent lessons are:
+
+1. The product must prove one useful loop quickly.
+2. The system must expose why it knows something, not just what it knows.
+3. Maintenance and background processing must feel like first-class product behavior.
+4. Search and browsing are not enough by themselves; the user must also see what changed and why.
+5. Integration quality must be visible and testable from the product surface.
+
+OVP should treat these as milestone guardrails, not optional polish.
+
+## Milestone Adjustments From External References
+
+### Milestone 3: Review Workbench Completion
+
+Add:
+
+- “How to know this queue is working” operator checks,
+- explicit queue rationale and evidence panels,
+- dashboard surfacing of recent maintenance effects.
+
+This is directly reinforced by Nowledge Mem’s verification model and GBrain’s operator framing.
+
+### Milestone 4: Event And Contradiction Model Hardening
+
+Add:
+
+- contradiction explanation quality as a first-class product requirement,
+- clearer event semantics and reason-for-appearance messaging,
+- better graph-aware relation context where appropriate.
+
+This is reinforced by Nia’s page contract and Nowledge Mem’s background-intelligence framing.
+
+### Milestone 5: Knowledge Production Traceability
+
+Add:
+
+- explicit “first useful loop” surfaces:
+  - source saved,
+  - deep dive generated,
+  - evergreen derived,
+  - Atlas placement updated,
+- verification views that let users prove the pipeline really produced the knowledge they are seeing.
+
+This is reinforced by Nowledge Mem’s “save / find / use” loop and verification framing.
+
+### Milestone 6: Product Shell And Operator UX
+
+Add:
+
+- better onboarding / “start here” paths,
+- “how to know it is working” checks inside the product,
+- observability panels for indexing, search, maintenance, and review state,
+- more explicit product-level integration and automation surfaces.
+
+This is reinforced by agentmemory’s observability and Nowledge Mem’s onboarding / browse-now packaging.

--- a/docs/plans/2026-04-14-phase8-provenance-review-workbench.md
+++ b/docs/plans/2026-04-14-phase8-provenance-review-workbench.md
@@ -1,0 +1,81 @@
+# Phase 8: Provenance Review Workbench
+
+**Goal:** Turn the current DB browser into a provenance-aware knowledge workbench. Users should be able to move from truth rows to the originating Markdown world without guessing, and the review surfaces should expose enough context to act on contradictions and timeline entries.
+
+## Current Gap
+
+The system already has:
+
+- DB-backed object/topic/event/contradiction views
+- Atlas / Deep Dive bridge pages
+- Markdown note rendering with smart wikilinks
+
+But the product still feels split:
+
+- `/events` shows dated objects, but not where they came from
+- `/contradictions` shows conflict rows, but not the source notes or MOCs that contextualize them
+- Atlas and Deep Dive pages list links, but do not yet summarize what each source page is contributing
+- The user still has to manually connect DB rows back to Evergreen, deep dives, and Atlas notes
+
+## Scope
+
+### Slice A: Provenance-Aware Events
+
+Make `/events` and `/api/events` carry provenance:
+
+- object page link
+- Evergreen markdown link
+- source deep dive links
+- Atlas / MOC links
+
+The page should make it obvious that events are timeline entries over objects, and give a direct path back to source notes.
+
+### Slice B: Provenance-Aware Contradictions
+
+Make `/contradictions` and `/api/contradictions` carry workbench context:
+
+- related object links
+- source deep dive links
+- Atlas / MOC links
+- resolution metadata when present
+
+This is still read-only, but it should feel like a review queue, not just a table dump.
+
+### Slice C: Richer Atlas / Deep Dive Browsers
+
+Upgrade `/atlas` and `/deep-dives` from flat membership lists into source summaries:
+
+- note title + note link
+- object count
+- first derived/member objects inline
+- short summary of “what this page contributes”
+
+### Slice D: Model Hardening
+
+Clarify and harden:
+
+- event rows vs event objects
+- contradiction detection limits
+- UI copy so users understand why contradiction counts may be zero
+
+## Non-Goals
+
+- No write actions from the UI yet
+- No full event ontology rebuild
+- No LLM-driven contradiction detection changes in this slice
+
+## Milestone Definition
+
+Phase 8 reaches its first stable checkpoint when:
+
+1. `/events` and `/contradictions` expose provenance that links back to Markdown sources.
+2. Atlas and Deep Dive pages show enough summary context to explain how they relate to indexed objects.
+3. Users can navigate DB truth rows back to Evergreen, source notes, and Atlas pages without manual filesystem lookup.
+
+## Execution Order
+
+1. Add failing tests for provenance-aware event and contradiction payloads.
+2. Implement truth/view-model support for provenance batching.
+3. Render richer event and contradiction cards in `ovp-ui`.
+4. Enrich Atlas / Deep Dive browsers with counts and summary context.
+5. Re-run targeted UI suites and then the full pytest suite.

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import mimetypes
 import sqlite3
 import re
 import sys
@@ -118,6 +119,10 @@ def _note_href(path: str) -> str:
     return f"/note?path={quote(path, safe='')}"
 
 
+def _asset_href(path: str) -> str:
+    return f"/asset?path={quote(path, safe='')}"
+
+
 def _search_href(query: str) -> str:
     return f"/search?q={quote(query, safe='')}"
 
@@ -131,6 +136,17 @@ def _read_vault_note(vault_dir: Path, relative_path: str) -> tuple[Path, str]:
     if not candidate.is_file():
         raise ValueError(f"note not found: {relative_path}")
     return candidate, candidate.read_text(encoding="utf-8")
+
+
+def _read_vault_asset(vault_dir: Path, relative_path: str) -> tuple[bytes, str]:
+    candidate = (vault_dir / relative_path).resolve()
+    try:
+        candidate.relative_to(vault_dir.resolve())
+    except ValueError as exc:
+        raise ValueError("invalid asset path") from exc
+    if not candidate.is_file():
+        raise ValueError(f"asset not found: {relative_path}")
+    return candidate.read_bytes(), mimetypes.guess_type(candidate.name)[0] or "application/octet-stream"
 
 
 def _lookup_wikilink_target(vault_dir: Path, target: str) -> tuple[str, str] | None:
@@ -323,6 +339,24 @@ def _smart_markdown_link(label: str, href: str) -> str:
     return f"[{safe_label}]({href})"
 
 
+def _rewrite_local_image_links(vault_dir: Path, markdown: str) -> str:
+    def replace_match(match: re.Match[str]) -> str:
+        alt_text = match.group(1)
+        raw_target = match.group(2).strip()
+        if raw_target.startswith(("http://", "https://", "data:", "/asset?")):
+            return match.group(0)
+        candidate = (vault_dir / raw_target).resolve()
+        try:
+            relative_path = str(candidate.relative_to(vault_dir.resolve()))
+        except ValueError:
+            return match.group(0)
+        if not candidate.is_file():
+            return match.group(0)
+        return f"![{alt_text}]({_asset_href(relative_path)})"
+
+    return re.sub(r"!\[([^\]]*)\]\(([^)]+)\)", replace_match, markdown)
+
+
 def _convert_box_table_fences(markdown: str, *, github_repo_base: str | None) -> str:
     lines = markdown.splitlines()
     output: list[str] = []
@@ -414,6 +448,7 @@ def _render_markdown_note(vault_dir: Path, markdown: str) -> tuple[str, str]:
     frontmatter, body = _parse_frontmatter(markdown)
     github_repo_base = _infer_github_repo_base(frontmatter, body)
     rendered_body = _convert_box_table_fences(body, github_repo_base=github_repo_base)
+    rendered_body = _rewrite_local_image_links(vault_dir, rendered_body)
     rendered_body = _replace_wikilinks_with_markdown_links(vault_dir, rendered_body)
     rendered_body = _linkify_related_knowledge_section(vault_dir, rendered_body)
     rendered_body = _linkify_keywords(rendered_body).strip()
@@ -427,8 +462,10 @@ def _render_markdown_note(vault_dir: Path, markdown: str) -> tuple[str, str]:
 def _render_note_page(vault_dir: Path, relative_path: str, markdown: str, payload: dict | None = None) -> str:
     frontmatter_html, note_html = _render_markdown_note(vault_dir, markdown)
     source_note = None
+    derived_notes: list[dict[str, str]] = []
     if payload:
         source_note = payload.get("provenance", {}).get("original_source_note")
+        derived_notes = payload.get("provenance", {}).get("derived_deep_dives", [])
     provenance_html = ""
     if source_note:
         provenance_html = (
@@ -440,6 +477,18 @@ def _render_note_page(vault_dir: Path, relative_path: str, markdown: str, payloa
             f"<div class='muted'>{escape(source_note['path'])}</div>"
             "</dd></div>"
             "</dl>"
+            "</section>"
+        )
+    if derived_notes:
+        derived_list = "".join(
+            f'<li><a href="{escape(_note_href(item["path"]))}">{escape(item["title"])}</a>'
+            f"<div class='muted'>{escape(item['path'])}</div></li>"
+            for item in derived_notes
+        )
+        provenance_html += (
+            "<section class='card'>"
+            "<h2>Derived Deep Dives</h2>"
+            f"<ul class='list-tight'>{derived_list}</ul>"
             "</section>"
         )
     return _layout(
@@ -989,6 +1038,11 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
                     payload = build_note_page_payload(resolved_vault, note_path=relative_path)
                     self._write_html(_render_note_page(resolved_vault, relative_path, markdown, payload))
                     return
+                if path == "/asset":
+                    relative_path = self._required(query, "path")
+                    body, content_type = _read_vault_asset(resolved_vault, relative_path)
+                    self._write_bytes(body, content_type)
+                    return
                 if path == "/api/contradictions":
                     status = query.get("status", [""])[0] or None
                     q = query.get("q", [""])[0]
@@ -1088,6 +1142,13 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
             body = html.encode("utf-8")
             self.send_response(200)
             self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def _write_bytes(self, body: bytes, content_type: str) -> None:
+            self.send_response(200)
+            self.send_header("Content-Type", content_type)
             self.send_header("Content-Length", str(len(body)))
             self.end_headers()
             self.wfile.write(body)

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -21,8 +21,10 @@ from ..ui.view_models import (
     build_contradiction_browser_payload,
     build_derivation_browser_payload,
     build_event_dossier_payload,
+    build_note_page_payload,
     build_object_page_payload,
     build_objects_index_payload,
+    build_search_payload,
     build_stale_summary_browser_payload,
     build_truth_dashboard_payload,
     build_topic_overview_payload,
@@ -94,6 +96,7 @@ def _layout(title: str, body: str) -> str:
           <nav>
             <a href="/">Home</a>
             <a href="/objects">Objects</a>
+            <a href="/search">Search</a>
             <a href="/atlas">Atlas</a>
             <a href="/deep-dives">Deep Dives</a>
             <a href="/events">Event Dossier</a>
@@ -115,8 +118,8 @@ def _note_href(path: str) -> str:
     return f"/note?path={quote(path, safe='')}"
 
 
-def _objects_search_href(query: str) -> str:
-    return f"/objects?q={quote(query, safe='')}"
+def _search_href(query: str) -> str:
+    return f"/search?q={quote(query, safe='')}"
 
 
 def _read_vault_note(vault_dir: Path, relative_path: str) -> tuple[Path, str]:
@@ -209,7 +212,7 @@ def _lookup_wikilink_target(vault_dir: Path, target: str) -> tuple[str, str] | N
 
 
 def _is_search_href(href: str) -> bool:
-    return href.startswith("/objects?q=")
+    return href.startswith("/search?q=")
 
 
 def _strip_frontmatter(markdown: str) -> str:
@@ -280,7 +283,7 @@ def _replace_wikilinks_with_markdown_links(vault_dir: Path, markdown: str) -> st
         target_part, _, label_part = raw_inner.partition("|")
         label = label_part.strip() or target_part.split("#", 1)[0].strip()
         resolved = _lookup_wikilink_target(vault_dir, target_part)
-        href = resolved[0] if resolved else _objects_search_href(target_part.split("#", 1)[0].strip() or label)
+        href = resolved[0] if resolved else _search_href(target_part.split("#", 1)[0].strip() or label)
         emoji = "🔍" if _is_search_href(href) else "🎯"
         safe_label = label.replace("[", "\\[").replace("]", "\\]")
         return f"[{emoji} {safe_label}]({href})"
@@ -379,7 +382,7 @@ def _linkify_keywords(markdown: str) -> str:
             keyword = raw.strip()
             if not keyword:
                 continue
-            rendered.append(_smart_markdown_link(keyword, _objects_search_href(keyword)))
+            rendered.append(_smart_markdown_link(keyword, _search_href(keyword)))
         output.append(f"{prefix}：{'，'.join(rendered)}")
     return "\n".join(output)
 
@@ -398,7 +401,7 @@ def _linkify_related_knowledge_section(vault_dir: Path, markdown: str) -> str:
             concept, sep, remainder = stripped[2:].partition(" — ")
             concept = concept.strip()
             resolved = _lookup_wikilink_target(vault_dir, concept)
-            href = resolved[0] if resolved else _objects_search_href(concept)
+            href = resolved[0] if resolved else _search_href(concept)
             emoji = "🔍" if _is_search_href(href) else "🎯"
             output_lines.append(f'- [{emoji} {concept}]({href}) — {remainder}')
             continue
@@ -421,8 +424,24 @@ def _render_markdown_note(vault_dir: Path, markdown: str) -> tuple[str, str]:
     return _render_frontmatter(frontmatter), html_body
 
 
-def _render_note_page(vault_dir: Path, relative_path: str, markdown: str) -> str:
+def _render_note_page(vault_dir: Path, relative_path: str, markdown: str, payload: dict | None = None) -> str:
     frontmatter_html, note_html = _render_markdown_note(vault_dir, markdown)
+    source_note = None
+    if payload:
+        source_note = payload.get("provenance", {}).get("original_source_note")
+    provenance_html = ""
+    if source_note:
+        provenance_html = (
+            "<section class='card'>"
+            "<h2>Provenance</h2>"
+            "<dl class='meta-list'>"
+            "<div><dt>Original Source Note</dt><dd>"
+            f'<a href="{escape(_note_href(source_note["path"]))}">{escape(source_note["title"])}</a>'
+            f"<div class='muted'>{escape(source_note['path'])}</div>"
+            "</dd></div>"
+            "</dl>"
+            "</section>"
+        )
     return _layout(
         f"Markdown Note: {relative_path}",
         (
@@ -431,7 +450,37 @@ def _render_note_page(vault_dir: Path, relative_path: str, markdown: str) -> str
             f"<p class='muted'>{escape(relative_path)}</p>"
             "</section>"
             f"{frontmatter_html}"
+            f"{provenance_html}"
             f"<section class='card'>{note_html}</section>"
+        ),
+    )
+
+
+def _render_search_page(payload: dict) -> str:
+    query = payload["query"]
+    object_items = "".join(
+        f'<li><a href="/object?id={escape(item["object_id"])}">{escape(item["title"])}</a> '
+        f'<span class="muted">({escape(item["object_id"])})</span></li>'
+        for item in payload["objects"]
+    ) or "<li class='muted'>No object hits.</li>"
+    note_items = "".join(
+        f'<li><a href="{escape(_note_href(item["path"]))}">{escape(item["title"])}</a> '
+        f'<span class="pill">{escape(item["note_type"])}</span></li>'
+        for item in payload["notes"]
+    ) or "<li class='muted'>No note hits.</li>"
+    return _layout(
+        f"Search: {query}",
+        (
+            "<h1>Search</h1>"
+            "<form method='get' action='/search'>"
+            f"<input type='text' name='q' value='{escape(query)}' placeholder='Search vault' /> "
+            "<button type='submit'>Search</button>"
+            "</form>"
+            f"<p class='muted'>{payload['object_count']} object hits, {payload['note_count']} note hits.</p>"
+            "<section class='grid two-col'>"
+            f"<section class='card'><h2>Objects</h2><ul class='list-tight'>{object_items}</ul></section>"
+            f"<section class='card'><h2>Notes</h2><ul class='list-tight'>{note_items}</ul></section>"
+            "</section>"
         ),
     )
 
@@ -871,6 +920,15 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
                     )
                     self._write_html(_render_objects_index(payload))
                     return
+                if path == "/api/search":
+                    q = query.get("q", [""])[0]
+                    self._write_json(build_search_payload(resolved_vault, query=q))
+                    return
+                if path == "/search":
+                    q = query.get("q", [""])[0]
+                    payload = build_search_payload(resolved_vault, query=q)
+                    self._write_html(_render_search_page(payload))
+                    return
                 if path == "/api/object":
                     object_id = self._required(query, "id")
                     self._write_json(build_object_page_payload(resolved_vault, object_id))
@@ -928,7 +986,8 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
                 if path == "/note":
                     relative_path = self._required(query, "path")
                     _, markdown = _read_vault_note(resolved_vault, relative_path)
-                    self._write_html(_render_note_page(resolved_vault, relative_path, markdown))
+                    payload = build_note_page_payload(resolved_vault, note_path=relative_path)
+                    self._write_html(_render_note_page(resolved_vault, relative_path, markdown, payload))
                     return
                 if path == "/api/contradictions":
                     status = query.get("status", [""])[0] or None

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -63,6 +63,7 @@ def _layout(title: str, body: str) -> str:
       h1, h2, h3 {{ margin-bottom: 0.5rem; line-height: 1.2; }}
       ul {{ padding-left: 1.2rem; }}
       pre {{ background: #f4f4f5; padding: 1rem; border-radius: 8px; overflow-x: auto; }}
+      img {{ max-width: 100%; height: auto; display: block; border-radius: 12px; }}
       input, select, button {{ font: inherit; }}
       input, select {{ padding: 0.55rem 0.7rem; border: 1px solid var(--border); border-radius: 10px; background: var(--surface); }}
       button {{ padding: 0.55rem 0.8rem; border-radius: 10px; border: 1px solid var(--accent); background: var(--accent); color: white; cursor: pointer; }}

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -433,6 +433,14 @@ def _render_note_page(vault_dir: Path, relative_path: str, markdown: str) -> str
     )
 
 
+def _render_named_note_links(items: list[dict[str, str]]) -> str:
+    if not items:
+        return "<span class='muted'>None</span>"
+    return ", ".join(
+        f'<a href="{escape(_note_href(item["path"]))}">{escape(item["title"])}</a>' for item in items
+    )
+
+
 def _render_dashboard(payload: dict) -> str:
     object_items = "".join(
         f'<li><a href="/object?id={escape(item["object_id"])}">{escape(item["title"])}</a></li>'
@@ -611,10 +619,17 @@ def _render_events_page(payload: dict) -> str:
         f'<section id="date-{escape(section["date"])}" class="card"><h2>{escape(section["date"])}</h2><ul class="list-tight">'
         + "".join(
             (
-                f"<li>{escape(item['event_type'])} - "
-                f'<a href="/object?id={escape(item["object_id"])}">{escape(item["title"])}</a></li>'
-                if item["event_type"] != "page_date"
-                else f'<li><a href="/object?id={escape(item["object_id"])}">{escape(item["title"])}</a></li>'
+                "<li>"
+                + (
+                    f"{escape(item['event_type'])} - "
+                    if item["event_type"] != "page_date"
+                    else ""
+                )
+                + f'<a href="{escape(item["object_path"])}">{escape(item["title"])}</a>'
+                + f"<div class='muted'>Evergreen: <a href=\"{escape(_note_href(item['provenance']['evergreen_path']))}\">{escape(item['provenance']['evergreen_path'])}</a></div>"
+                + f"<div class='muted'>Source Notes: {_render_named_note_links(item['provenance']['source_notes'])}</div>"
+                + f"<div class='muted'>Atlas / MOC: {_render_named_note_links(item['provenance']['mocs'])}</div>"
+                + "</li>"
             )
             for item in section["events"]
         )
@@ -642,6 +657,7 @@ def _render_atlas_page(payload: dict) -> str:
     items = "".join(
         "<li>"
         f'<a href="{escape(_note_href(item["path"]))}">{escape(item["title"])}</a>'
+        + f" <span class='pill'>{item['member_count']} objects</span>"
         + (
             " <span class='muted'>"
             + ", ".join(
@@ -649,6 +665,11 @@ def _render_atlas_page(payload: dict) -> str:
                 for member in item["members"]
             )
             + "</span>"
+        )
+        + (
+            f"<div class='muted'>Preview: {escape(', '.join(item['preview_titles']))}</div>"
+            if item["preview_titles"]
+            else ""
         )
         + "</li>"
         for item in payload["items"]
@@ -672,6 +693,7 @@ def _render_derivations_page(payload: dict) -> str:
     items = "".join(
         "<li>"
         f'<a href="{escape(_note_href(item["path"]))}">{escape(item["title"])}</a>'
+        + f" <span class='pill'>{item['derived_object_count']} derived objects</span>"
         + (
             " <span class='muted'>"
             + ", ".join(
@@ -679,6 +701,11 @@ def _render_derivations_page(payload: dict) -> str:
                 for member in item["derived_objects"]
             )
             + "</span>"
+        )
+        + (
+            f"<div class='muted'>Preview: {escape(', '.join(item['preview_titles']))}</div>"
+            if item["preview_titles"]
+            else ""
         )
         + "</li>"
         for item in payload["items"]
@@ -706,12 +733,15 @@ def _render_contradictions_page(payload: dict) -> str:
         + (
             " <span class='muted'>"
             + ", ".join(
-                f'<a href="{escape(link["path"])}">{escape(link["object_id"])}</a>' for link in item["object_links"]
+                f'<a href="{escape(link["path"])}">{escape(item["object_titles"].get(link["object_id"], link["object_id"]))}</a>'
+                for link in item["object_links"]
             )
             + "</span>"
             if item["object_links"]
             else ""
         )
+        + f"<div class='muted'>Source Notes: {_render_named_note_links(item['provenance']['source_notes'])}</div>"
+        + f"<div class='muted'>Atlas / MOC: {_render_named_note_links(item['provenance']['mocs'])}</div>"
         + "</li>"
         for item in payload["items"]
     ) or "<li>None</li>"

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -458,6 +458,11 @@ def _render_dashboard(payload: dict) -> str:
         f'<a href="/object?id={escape(item["object_id"])}">{escape(item["title"])}</a></li>'
         for item in payload["events"]["items"]
     ) or "<li>None</li>"
+    stale_summary_items = "".join(
+        f'<li><a href="/object?id={escape(item["object_id"])}">{escape(item["title"])}</a> '
+        f"<span class='muted'>({escape(item['summary_text'])})</span></li>"
+        for item in payload["stale_summaries"]["items"]
+    ) or "<li>None</li>"
     return _layout(
         "OpenClaw Truth UI",
         (
@@ -472,11 +477,14 @@ def _render_dashboard(payload: dict) -> str:
             f"<p>{payload['contradictions']['open_count']}</p></div>"
             "<div class='card'><h2>Recent Events</h2>"
             f"<p>{payload['events']['count']}</p></div>"
+            "<div class='card'><h2>Stale Summaries</h2>"
+            f"<p>{payload['stale_summaries']['count']}</p></div>"
             "</section>"
             "<section class='grid two-col'>"
             "<div class='section-stack'>"
             f"<section class='card'><h2>Recent Objects</h2><ul class='list-tight'>{object_items}</ul></section>"
             f"<section class='card'><h2>Recent Events</h2><ul class='list-tight'>{event_items}</ul></section>"
+            f"<section class='card'><h2><a href='/summaries'>Stale Summaries</a></h2><ul class='list-tight'>{stale_summary_items}</ul></section>"
             "</div>"
             f"<section class='card'><h2>Contradiction Queue</h2><ul class='list-tight'>{contradiction_items}</ul></section>"
             "</section>"

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -23,6 +23,7 @@ from ..ui.view_models import (
     build_event_dossier_payload,
     build_object_page_payload,
     build_objects_index_payload,
+    build_stale_summary_browser_payload,
     build_truth_dashboard_payload,
     build_topic_overview_payload,
 )
@@ -97,6 +98,7 @@ def _layout(title: str, body: str) -> str:
             <a href="/deep-dives">Deep Dives</a>
             <a href="/events">Event Dossier</a>
             <a href="/contradictions">Contradictions</a>
+            <a href="/summaries">Stale Summaries</a>
           </nav>
         </div>
         <div class="shell-body">
@@ -796,6 +798,37 @@ def _render_contradictions_page(payload: dict) -> str:
     )
 
 
+def _render_stale_summaries_page(payload: dict) -> str:
+    query = payload.get("query", "")
+    detection_notes = "".join(f"<li>{escape(note)}</li>" for note in payload["detection_notes"])
+    items = "".join(
+        "<li>"
+        f'<a href="{escape(item["object_path"])}">{escape(item["title"])}</a> '
+        f"<span class='muted'>({escape(item['object_id'])})</span>"
+        f"<div class='muted'>Summary: {escape(item['summary_text'])}</div>"
+        f"<div class='muted'>Outgoing relations: {item['outgoing_relation_count']}</div>"
+        "<form method='post' action='/summaries/rebuild' class='link-row'>"
+        f"<input type='hidden' name='object_id' value='{escape(item['object_id'])}' />"
+        "<button type='submit'>Rebuild Summary</button>"
+        "</form>"
+        "</li>"
+        for item in payload["items"]
+    ) or "<li class='muted'>No stale summaries detected.</li>"
+    return _layout(
+        "Stale Summaries",
+        (
+            "<h1>Stale Summaries</h1>"
+            "<form method='get' action='/summaries'>"
+            f"<input type='text' name='q' value='{escape(query)}' placeholder='Filter stale summaries' /> "
+            "<button type='submit'>Filter</button>"
+            "</form>"
+            f"<p class='muted'>{payload['count']} stale summary candidates.</p>"
+            f"<section class='card'><h2>Detection Notes</h2><ul class='list-tight'>{detection_notes}</ul></section>"
+            f"<section class='card'><ul class='list-tight'>{items}</ul></section>"
+        ),
+    )
+
+
 def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int = 8787) -> ThreadingHTTPServer:
     resolved_vault = resolve_vault_dir(vault_dir)
 
@@ -875,6 +908,15 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
                     payload = build_derivation_browser_payload(resolved_vault, query=q)
                     self._write_html(_render_derivations_page(payload))
                     return
+                if path == "/api/summaries":
+                    q = query.get("q", [""])[0]
+                    self._write_json(build_stale_summary_browser_payload(resolved_vault, query=q))
+                    return
+                if path == "/summaries":
+                    q = query.get("q", [""])[0]
+                    payload = build_stale_summary_browser_payload(resolved_vault, query=q)
+                    self._write_html(_render_stale_summaries_page(payload))
+                    return
                 if path == "/note":
                     relative_path = self._required(query, "path")
                     _, markdown = _read_vault_note(resolved_vault, relative_path)
@@ -908,6 +950,13 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
                 if path == "/contradictions/resolve":
                     self._resolve_contradiction_action(form)
                     self._redirect("/contradictions?status=resolved")
+                    return
+                if path == "/api/summaries/rebuild":
+                    self._write_json(self._rebuild_summary_action(form))
+                    return
+                if path == "/summaries/rebuild":
+                    self._rebuild_summary_action(form)
+                    self._redirect("/summaries")
                     return
                 self.send_error(404, "Not Found")
             except ValueError as exc:
@@ -953,6 +1002,12 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
                 payload["rebuilt_summary_count"] = 0
                 payload["rebuilt_object_ids"] = []
             return payload
+
+        def _rebuild_summary_action(self, form: dict[str, str]) -> dict[str, object]:
+            object_id = form.get("object_id", "").strip()
+            if not object_id:
+                raise ValueError("missing object_id")
+            return rebuild_compiled_summaries(resolved_vault, object_ids=[object_id])
 
         def _write_json(self, payload: dict) -> None:
             body = json.dumps(payload, ensure_ascii=False).encode("utf-8")

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -14,6 +14,7 @@ import yaml
 from markdown_it import MarkdownIt
 
 from ..identity import canonicalize_note_id
+from ..knowledge_index import contradiction_object_ids, rebuild_compiled_summaries, resolve_contradictions
 from ..runtime import VaultLayout, resolve_vault_dir
 from ..ui.view_models import (
     build_atlas_browser_payload,
@@ -746,6 +747,32 @@ def _render_contradictions_page(payload: dict) -> str:
         )
         + f"<div class='muted'>Source Notes: {_render_named_note_links(item['provenance']['source_notes'])}</div>"
         + f"<div class='muted'>Atlas / MOC: {_render_named_note_links(item['provenance']['mocs'])}</div>"
+        + (
+            f"<div class='muted'>Resolution Note: {escape(item['resolution_note'])}</div>"
+            if item.get("resolution_note")
+            else ""
+        )
+        + (
+            f"<div class='muted'>Resolved At: {escape(item['resolved_at'])}</div>"
+            if item.get("resolved_at")
+            else ""
+        )
+        + (
+            "<form method='post' action='/contradictions/resolve' class='link-row'>"
+            f"<input type='hidden' name='contradiction_id' value='{escape(item['contradiction_id'])}' />"
+            "<select name='status'>"
+            "<option value='resolved_keep_positive'>resolved_keep_positive</option>"
+            "<option value='resolved_keep_negative'>resolved_keep_negative</option>"
+            "<option value='dismissed'>dismissed</option>"
+            "<option value='needs_human'>needs_human</option>"
+            "</select>"
+            "<input type='text' name='note' placeholder='Resolution note' />"
+            "<label><input type='checkbox' name='rebuild_summaries' value='1' /> rebuild summaries</label>"
+            "<button type='submit'>Resolve</button>"
+            "</form>"
+            if item["status"] == "open"
+            else ""
+        )
         + "</li>"
         for item in payload["items"]
     ) or f"<li>{escape(payload['empty_state'])}</li>"
@@ -870,11 +897,62 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
             except ValueError as exc:
                 self.send_error(400, str(exc))
 
+        def do_POST(self) -> None:  # noqa: N802
+            parsed = urlparse(self.path)
+            path = parsed.path
+            try:
+                form = self._read_form()
+                if path == "/api/contradictions/resolve":
+                    self._write_json(self._resolve_contradiction_action(form))
+                    return
+                if path == "/contradictions/resolve":
+                    self._resolve_contradiction_action(form)
+                    self._redirect("/contradictions?status=resolved")
+                    return
+                self.send_error(404, "Not Found")
+            except ValueError as exc:
+                self.send_error(400, str(exc))
+
         def _required(self, query: dict[str, list[str]], key: str) -> str:
             values = query.get(key)
             if not values or not values[0]:
                 raise ValueError(f"missing required query param: {key}")
             return values[0]
+
+        def _read_form(self) -> dict[str, str]:
+            length = int(self.headers.get("Content-Length", "0"))
+            raw = self.rfile.read(length).decode("utf-8")
+            parsed = parse_qs(raw, keep_blank_values=True)
+            return {key: values[0] for key, values in parsed.items()}
+
+        def _resolve_contradiction_action(self, form: dict[str, str]) -> dict[str, object]:
+            contradiction_id = form.get("contradiction_id", "").strip()
+            status = form.get("status", "").strip()
+            note = form.get("note", "").strip()
+            if not contradiction_id:
+                raise ValueError("missing contradiction_id")
+            if status not in {
+                "resolved_keep_positive",
+                "resolved_keep_negative",
+                "dismissed",
+                "needs_human",
+            }:
+                raise ValueError("invalid contradiction status")
+            payload = resolve_contradictions(
+                resolved_vault,
+                [contradiction_id],
+                status=status,
+                note=note,
+            )
+            if payload["resolved_count"] and form.get("rebuild_summaries") == "1":
+                affected_object_ids = contradiction_object_ids(resolved_vault, payload["contradiction_ids"])
+                rebuild_payload = rebuild_compiled_summaries(resolved_vault, object_ids=affected_object_ids)
+                payload["rebuilt_summary_count"] = rebuild_payload["objects_rebuilt"]
+                payload["rebuilt_object_ids"] = rebuild_payload["object_ids"]
+            else:
+                payload["rebuilt_summary_count"] = 0
+                payload["rebuilt_object_ids"] = []
+            return payload
 
         def _write_json(self, payload: dict) -> None:
             body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
@@ -891,6 +969,12 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
             self.send_header("Content-Length", str(len(body)))
             self.end_headers()
             self.wfile.write(body)
+
+        def _redirect(self, location: str) -> None:
+            self.send_response(303)
+            self.send_header("Location", location)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
 
     return ThreadingHTTPServer((host, port), Handler)
 

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -611,6 +611,11 @@ def _render_topic_page(payload: dict) -> str:
 
 def _render_events_page(payload: dict) -> str:
     query = payload.get("query", "")
+    type_breakdown = "".join(
+        f"<span class='pill'>{escape(kind.replace('_', ' '))}: {count}</span>"
+        for kind, count in payload["event_type_counts"].items()
+    )
+    model_notes = "".join(f"<li>{escape(note)}</li>" for note in payload["model_notes"])
     date_nav = "".join(
         f"<a href='#date-{escape(section['date'])}'>{escape(section['date'])}</a>"
         for section in payload["date_sections"]
@@ -620,11 +625,7 @@ def _render_events_page(payload: dict) -> str:
         + "".join(
             (
                 "<li>"
-                + (
-                    f"{escape(item['event_type'])} - "
-                    if item["event_type"] != "page_date"
-                    else ""
-                )
+                + f"<span class='pill'>{escape(item['event_label'])}</span> "
                 + f'<a href="{escape(item["object_path"])}">{escape(item["title"])}</a>'
                 + f"<div class='muted'>Evergreen: <a href=\"{escape(_note_href(item['provenance']['evergreen_path']))}\">{escape(item['provenance']['evergreen_path'])}</a></div>"
                 + f"<div class='muted'>Source Notes: {_render_named_note_links(item['provenance']['source_notes'])}</div>"
@@ -646,6 +647,8 @@ def _render_events_page(payload: dict) -> str:
             "<button type='submit'>Search</button>"
             "</form>"
             f"<p class='muted'>{payload['event_count']} events across {len(payload['dates'])} dates.</p>"
+            f"<div class='link-row'>{type_breakdown}</div>"
+            f"<section class='card'><h2>Model Notes</h2><ul class='list-tight'>{model_notes}</ul></section>"
             f"<nav class='subnav'>{date_nav}</nav>"
             f"{events}"
         ),
@@ -727,6 +730,7 @@ def _render_derivations_page(payload: dict) -> str:
 def _render_contradictions_page(payload: dict) -> str:
     status = payload.get("status", "")
     query = payload.get("query", "")
+    detection_notes = "".join(f"<li>{escape(note)}</li>" for note in payload["detection_notes"])
     items = "".join(
         "<li>"
         f"<span class='pill'>{escape(item['status'])}</span>{escape(item['subject_key'])}"
@@ -744,7 +748,7 @@ def _render_contradictions_page(payload: dict) -> str:
         + f"<div class='muted'>Atlas / MOC: {_render_named_note_links(item['provenance']['mocs'])}</div>"
         + "</li>"
         for item in payload["items"]
-    ) or "<li>None</li>"
+    ) or f"<li>{escape(payload['empty_state'])}</li>"
     return _layout(
         "Contradictions",
         (
@@ -759,6 +763,7 @@ def _render_contradictions_page(payload: dict) -> str:
             "<button type='submit'>Filter</button>"
             "</form>"
             f"<p class='muted'>{payload['count']} records, {payload['open_count']} open.</p>"
+            f"<section class='card'><h2>Detection Notes</h2><ul class='list-tight'>{detection_notes}</ul></section>"
             f"<section class='card'><ul class='list-tight'>{items}</ul></section>"
         ),
     )

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -543,6 +543,29 @@ def _render_named_note_links(items: list[dict[str, str]]) -> str:
     )
 
 
+def _render_review_context_card(context: dict[str, object], *, title: str = "Review Context") -> str:
+    latest_event_date = str(context.get("latest_event_date") or "")
+    latest_event_html = escape(latest_event_date) if latest_event_date else "<span class='muted'>None</span>"
+    stale_summary_ids = ", ".join(str(item) for item in context.get("stale_summary_object_ids", [])) or "None"
+    contradiction_object_ids = ", ".join(str(item) for item in context.get("contradiction_object_ids", [])) or "None"
+    return (
+        "<section class='card'>"
+        f"<h2>{escape(title)}</h2>"
+        "<dl class='meta-list'>"
+        f"<div><dt>Objects in scope</dt><dd>{int(context.get('object_count', 0))}</dd></div>"
+        f"<div><dt>Source notes</dt><dd>{int(context.get('source_note_count', 0))}</dd></div>"
+        f"<div><dt>Atlas / MOC pages</dt><dd>{int(context.get('moc_count', 0))}</dd></div>"
+        f"<div><dt>Open contradictions</dt><dd>{int(context.get('open_contradiction_count', 0))}</dd></div>"
+        f"<div><dt>Total contradictions</dt><dd>{int(context.get('contradiction_count', 0))}</dd></div>"
+        f"<div><dt>Stale summaries</dt><dd>{int(context.get('stale_summary_count', 0))}</dd></div>"
+        f"<div><dt>Latest event date</dt><dd>{latest_event_html}</dd></div>"
+        f"<div><dt>Contradiction objects</dt><dd>{escape(contradiction_object_ids)}</dd></div>"
+        f"<div><dt>Stale summary objects</dt><dd>{escape(stale_summary_ids)}</dd></div>"
+        "</dl>"
+        "</section>"
+    )
+
+
 def _render_dashboard(payload: dict) -> str:
     object_items = "".join(
         f'<li><a href="/object?id={escape(item["object_id"])}">{escape(item["title"])}</a></li>'
@@ -657,6 +680,7 @@ def _render_object_page(payload: dict) -> str:
             f"<a href='{escape(payload['links']['topic_path'])}'>Explore topic</a>"
             f"<a href='{escape(payload['links']['events_path'])}'>Related events</a>"
             f"<a href='{escape(payload['links']['contradictions_path'])}'>Contradictions</a>"
+            f"<a href='{escape(payload['links']['summaries_path'])}'>Stale summaries</a>"
             f"<a href='/deep-dives?q={escape(payload['object']['object_id'])}'>Source deep dives</a>"
             f"<a href='/atlas?q={escape(payload['object']['object_id'])}'>Atlas / MOC</a>"
             "</div></section>"
@@ -672,6 +696,7 @@ def _render_object_page(payload: dict) -> str:
             f"<section id='claims' class='card'><h2>Claims</h2><ul class='list-tight'>{claims}</ul></section>"
             "</div>"
             "<div class='section-stack'>"
+            f"{_render_review_context_card(payload['review_context'])}"
             "<section class='card'><h2>Context</h2><dl class='meta-list'>"
             f"<div><dt>Object Kind</dt><dd>{escape(payload['context']['object_kind'])}</dd></div>"
             f"<div><dt>Source Slug</dt><dd>{escape(payload['context']['source_slug'])}</dd></div>"
@@ -707,6 +732,7 @@ def _render_topic_page(payload: dict) -> str:
             f"<a href='{escape(payload['links']['center_object_path'])}'>Open center object</a>"
             f"<a href='{escape(payload['links']['events_path'])}'>Related events</a>"
             f"<a href='{escape(payload['links']['contradictions_path'])}'>Contradictions</a>"
+            f"<a href='{escape(payload['links']['summaries_path'])}'>Stale summaries</a>"
             f"<a href='/deep-dives?q={escape(payload['center']['object_id'])}'>Source deep dives</a>"
             f"<a href='/atlas?q={escape(payload['center']['object_id'])}'>Atlas / MOC</a>"
             "</div></section>"
@@ -714,6 +740,7 @@ def _render_topic_page(payload: dict) -> str:
             f"<section class='card'><h2>Center Summary</h2><p>{escape(payload['center_summary'])}</p></section>"
             f"<section class='card'><h2>Neighbors</h2><ul class='list-tight'>{neighbors}</ul></section>"
             f"<section class='card'><h2>Atlas / MOC</h2><ul class='list-tight'>{mocs}</ul></section>"
+            f"{_render_review_context_card(payload['review_context'])}"
             "</section>"
         ),
     )
@@ -740,6 +767,11 @@ def _render_events_page(payload: dict) -> str:
                 + f"<div class='muted'>Evergreen: <a href=\"{escape(_note_href(item['provenance']['evergreen_path']))}\">{escape(item['provenance']['evergreen_path'])}</a></div>"
                 + f"<div class='muted'>Source Notes: {_render_named_note_links(item['provenance']['source_notes'])}</div>"
                 + f"<div class='muted'>Atlas / MOC: {_render_named_note_links(item['provenance']['mocs'])}</div>"
+                + "<div class='link-row'>"
+                + f"<a href='{escape(item['review_links']['topic_path'])}'>Topic</a>"
+                + f"<a href='{escape(item['review_links']['contradictions_path'])}'>Contradictions</a>"
+                + f"<a href='{escape(item['review_links']['summaries_path'])}'>Stale summaries</a>"
+                + "</div>"
                 + "</li>"
             )
             for item in section["events"]
@@ -758,6 +790,7 @@ def _render_events_page(payload: dict) -> str:
             "</form>"
             f"<p class='muted'>{payload['event_count']} events across {len(payload['dates'])} dates.</p>"
             f"<div class='link-row'>{type_breakdown}</div>"
+            f"{_render_review_context_card(payload['review_context'])}"
             f"<section class='card'><h2>Model Notes</h2><ul class='list-tight'>{model_notes}</ul></section>"
             f"<nav class='subnav'>{date_nav}</nav>"
             f"{events}"
@@ -843,7 +876,12 @@ def _render_contradictions_page(payload: dict) -> str:
     detection_notes = "".join(f"<li>{escape(note)}</li>" for note in payload["detection_notes"])
     items = "".join(
         "<li>"
-        f"<span class='pill'>{escape(item['status'])}</span>{escape(item['subject_key'])}"
+        + (
+            f"<label><input type='checkbox' form='contradiction-batch-form' name='contradiction_id' value='{escape(item['contradiction_id'])}' /> batch</label> "
+            if item["status"] == "open"
+            else ""
+        )
+        + f"<span class='pill'>{escape(item['status'])}</span>{escape(item['subject_key'])}"
         + (
             " <span class='muted'>"
             + ", ".join(
@@ -900,6 +938,20 @@ def _render_contradictions_page(payload: dict) -> str:
             "</form>"
             f"<p class='muted'>{payload['count']} records, {payload['open_count']} open.</p>"
             f"<section class='card'><h2>Detection Notes</h2><ul class='list-tight'>{detection_notes}</ul></section>"
+            "<section class='card'>"
+            "<h2>Batch Resolve</h2>"
+            "<form id='contradiction-batch-form' method='post' action='/contradictions/resolve' class='link-row'>"
+            "<select name='status'>"
+            "<option value='resolved_keep_positive'>resolved_keep_positive</option>"
+            "<option value='resolved_keep_negative'>resolved_keep_negative</option>"
+            "<option value='dismissed'>dismissed</option>"
+            "<option value='needs_human'>needs_human</option>"
+            "</select>"
+            "<input type='text' name='note' placeholder='Resolution note for selected rows' />"
+            "<label><input type='checkbox' name='rebuild_summaries' value='1' /> rebuild summaries</label>"
+            "<button type='submit'>Resolve Selected</button>"
+            "</form>"
+            "</section>"
             f"<section class='card'><ul class='list-tight'>{items}</ul></section>"
         ),
     )
@@ -910,6 +962,7 @@ def _render_stale_summaries_page(payload: dict) -> str:
     detection_notes = "".join(f"<li>{escape(note)}</li>" for note in payload["detection_notes"])
     items = "".join(
         "<li>"
+        f"<label><input type='checkbox' form='summary-batch-form' name='object_id' value='{escape(item['object_id'])}' /> batch</label> "
         f'<a href="{escape(item["object_path"])}">{escape(item["title"])}</a> '
         f"<span class='muted'>({escape(item['object_id'])})</span>"
         f"<div class='muted'>Summary: {escape(item['summary_text'])}</div>"
@@ -930,7 +983,14 @@ def _render_stale_summaries_page(payload: dict) -> str:
             "<button type='submit'>Filter</button>"
             "</form>"
             f"<p class='muted'>{payload['count']} stale summary candidates.</p>"
+            f"{_render_review_context_card(payload['review_context'])}"
             f"<section class='card'><h2>Detection Notes</h2><ul class='list-tight'>{detection_notes}</ul></section>"
+            "<section class='card'>"
+            "<h2>Batch Rebuild</h2>"
+            "<form id='summary-batch-form' method='post' action='/summaries/rebuild' class='link-row'>"
+            "<button type='submit'>Rebuild Selected</button>"
+            "</form>"
+            "</section>"
             f"<section class='card'><ul class='list-tight'>{items}</ul></section>"
         ),
     )
@@ -1090,17 +1150,23 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
                 raise ValueError(f"missing required query param: {key}")
             return values[0]
 
-        def _read_form(self) -> dict[str, str]:
+        def _read_form(self) -> dict[str, list[str]]:
             length = int(self.headers.get("Content-Length", "0"))
             raw = self.rfile.read(length).decode("utf-8")
-            parsed = parse_qs(raw, keep_blank_values=True)
-            return {key: values[0] for key, values in parsed.items()}
+            return parse_qs(raw, keep_blank_values=True)
 
-        def _resolve_contradiction_action(self, form: dict[str, str]) -> dict[str, object]:
-            contradiction_id = form.get("contradiction_id", "").strip()
-            status = form.get("status", "").strip()
-            note = form.get("note", "").strip()
-            if not contradiction_id:
+        def _form_first(self, form: dict[str, list[str]], key: str) -> str:
+            values = form.get(key, [])
+            return values[0] if values else ""
+
+        def _form_all(self, form: dict[str, list[str]], key: str) -> list[str]:
+            return form.get(key, [])
+
+        def _resolve_contradiction_action(self, form: dict[str, list[str]]) -> dict[str, object]:
+            contradiction_ids = [item.strip() for item in self._form_all(form, "contradiction_id") if item.strip()]
+            status = self._form_first(form, "status").strip()
+            note = self._form_first(form, "note").strip()
+            if not contradiction_ids:
                 raise ValueError("missing contradiction_id")
             if status not in {
                 "resolved_keep_positive",
@@ -1111,11 +1177,11 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
                 raise ValueError("invalid contradiction status")
             payload = resolve_contradictions(
                 resolved_vault,
-                [contradiction_id],
+                contradiction_ids,
                 status=status,
                 note=note,
             )
-            if payload["resolved_count"] and form.get("rebuild_summaries") == "1":
+            if payload["resolved_count"] and self._form_first(form, "rebuild_summaries") == "1":
                 affected_object_ids = contradiction_object_ids(resolved_vault, payload["contradiction_ids"])
                 rebuild_payload = rebuild_compiled_summaries(resolved_vault, object_ids=affected_object_ids)
                 payload["rebuilt_summary_count"] = rebuild_payload["objects_rebuilt"]
@@ -1125,11 +1191,11 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
                 payload["rebuilt_object_ids"] = []
             return payload
 
-        def _rebuild_summary_action(self, form: dict[str, str]) -> dict[str, object]:
-            object_id = form.get("object_id", "").strip()
-            if not object_id:
+        def _rebuild_summary_action(self, form: dict[str, list[str]]) -> dict[str, object]:
+            object_ids = [item.strip() for item in self._form_all(form, "object_id") if item.strip()]
+            if not object_ids:
                 raise ValueError("missing object_id")
-            return rebuild_compiled_summaries(resolved_vault, object_ids=[object_id])
+            return rebuild_compiled_summaries(resolved_vault, object_ids=object_ids)
 
         def _write_json(self, payload: dict) -> None:
             body = json.dumps(payload, ensure_ascii=False).encode("utf-8")

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -764,7 +764,11 @@ def _render_events_page(payload: dict) -> str:
                 "<li>"
                 + f"<span class='pill'>{escape(item['event_label'])}</span> "
                 + f'<a href="{escape(item["object_path"])}">{escape(item["title"])}</a>'
-                + f"<div class='muted'>Evergreen: <a href=\"{escape(_note_href(item['provenance']['evergreen_path']))}\">{escape(item['provenance']['evergreen_path'])}</a></div>"
+                + (
+                    f"<div class='muted'>Evergreen: <a href=\"{escape(_note_href(item['provenance']['evergreen_path']))}\">{escape(item['provenance']['evergreen_path'])}</a></div>"
+                    if item["provenance"]["evergreen_path"]
+                    else "<div class='muted'>Evergreen: <span class='muted'>None</span></div>"
+                )
                 + f"<div class='muted'>Source Notes: {_render_named_note_links(item['provenance']['source_notes'])}</div>"
                 + f"<div class='muted'>Atlas / MOC: {_render_named_note_links(item['provenance']['mocs'])}</div>"
                 + "<div class='link-row'>"

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -38,6 +38,82 @@ def _escape_like(value: str) -> str:
     return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
+def _is_moc_row(note_type: str, path: str) -> bool:
+    return note_type == "moc" or "/10-Knowledge/Atlas/" in path or Path(path).name.startswith("MOC")
+
+
+def _batch_object_rows(vault_dir: Path | str, object_ids: list[str]) -> dict[str, dict[str, Any]]:
+    if not object_ids:
+        return {}
+    db_path = _db_path(vault_dir)
+    resolved_vault = resolve_vault_dir(vault_dir)
+    placeholders = ",".join("?" for _ in object_ids)
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            f"""
+            SELECT object_id, object_kind, title, canonical_path, source_slug
+            FROM objects
+            WHERE object_id IN ({placeholders})
+            ORDER BY object_id
+            """,
+            tuple(object_ids),
+        ).fetchall()
+    return {
+        row[0]: {
+            "object_id": row[0],
+            "object_kind": row[1],
+            "title": row[2],
+            "canonical_path": _vault_relative_path(resolved_vault, row[3]),
+            "source_slug": row[4],
+        }
+        for row in rows
+    }
+
+
+def get_object_provenance_map(vault_dir: Path | str, object_ids: list[str]) -> dict[str, dict[str, Any]]:
+    if not object_ids:
+        return {}
+    db_path = _db_path(vault_dir)
+    resolved_vault = resolve_vault_dir(vault_dir)
+    ordered_object_ids = list(dict.fromkeys(object_ids))
+    object_rows = _batch_object_rows(vault_dir, ordered_object_ids)
+    placeholders = ",".join("?" for _ in ordered_object_ids)
+    with sqlite3.connect(db_path) as conn:
+        mention_rows = conn.execute(
+            f"""
+            SELECT page_links.target_slug, pages_index.slug, pages_index.title, pages_index.note_type, pages_index.path
+            FROM page_links
+            JOIN pages_index ON pages_index.slug = page_links.source_slug
+            WHERE page_links.target_slug IN ({placeholders})
+              AND pages_index.slug != page_links.target_slug
+            ORDER BY page_links.target_slug, pages_index.slug
+            """,
+            tuple(ordered_object_ids),
+        ).fetchall()
+
+    provenance = {
+        object_id: {
+            "title": object_rows.get(object_id, {}).get("title", object_id),
+            "evergreen_path": object_rows.get(object_id, {}).get("canonical_path", ""),
+            "source_notes": [],
+            "mocs": [],
+        }
+        for object_id in ordered_object_ids
+    }
+    for target_slug, slug, title, note_type, path in mention_rows:
+        item = {
+            "slug": slug,
+            "title": title,
+            "note_type": note_type,
+            "path": _vault_relative_path(resolved_vault, path),
+        }
+        if _is_moc_row(note_type, path):
+            provenance[target_slug]["mocs"].append(item)
+        elif note_type != "evergreen":
+            provenance[target_slug]["source_notes"].append(item)
+    return provenance
+
+
 def list_objects(
     vault_dir: Path | str,
     *,
@@ -272,7 +348,7 @@ def get_object_detail(vault_dir: Path | str, object_id: str) -> dict[str, Any]:
             "note_type": note_type,
             "path": _vault_relative_path(resolved_vault, path),
         }
-        if note_type == "moc" or "/10-Knowledge/Atlas/" in path or Path(path).name.startswith("MOC"):
+        if _is_moc_row(note_type, path):
             mocs.append(item)
             continue
         if slug == object_id:

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -437,8 +437,12 @@ def list_contradictions(
     params: list[Any] = []
     where_clauses: list[str] = []
     if status:
-        where_clauses.append("status = ?")
-        params.append(status)
+        if status == "resolved":
+            where_clauses.append("status != ?")
+            params.append("open")
+        else:
+            where_clauses.append("status = ?")
+            params.append(status)
     if normalized_query:
         where_clauses.append("lower(subject_key) LIKE ? ESCAPE '\\'")
         params.append(f"%{normalized_query}%")

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
 import json
+import re
 import sqlite3
 from pathlib import Path
 from typing import Any
 
+import yaml
+
 from .runtime import VaultLayout, resolve_vault_dir
 
 MAX_PAGE_SIZE = 500
+_FENCED_FRONTMATTER_RE = re.compile(r"^```ya?ml\s*\n---\n(.*?)\n---\n```\s*\n?", re.DOTALL)
 
 
 def _db_path(vault_dir: Path | str) -> Path:
@@ -36,6 +40,40 @@ def _validate_page_args(*, limit: int, offset: int = 0) -> tuple[int, int]:
 
 def _escape_like(value: str) -> str:
     return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def _parse_frontmatter(markdown: str) -> dict[str, Any]:
+    fenced_match = _FENCED_FRONTMATTER_RE.match(markdown)
+    if fenced_match:
+        raw_frontmatter = fenced_match.group(1)
+        try:
+            parsed = yaml.safe_load(raw_frontmatter) or {}
+        except yaml.YAMLError:
+            parsed = {}
+        return parsed if isinstance(parsed, dict) else {}
+    if not markdown.startswith("---\n"):
+        return {}
+    end = markdown.find("\n---\n", 4)
+    if end == -1:
+        return {}
+    raw_frontmatter = markdown[4:end]
+    try:
+        parsed = yaml.safe_load(raw_frontmatter) or {}
+    except yaml.YAMLError:
+        parsed = {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _read_note_frontmatter(vault_dir: Path | str, relative_path: str) -> dict[str, Any]:
+    resolved = resolve_vault_dir(vault_dir)
+    note_path = (resolved / relative_path).resolve()
+    try:
+        note_path.relative_to(resolved.resolve())
+    except ValueError:
+        return {}
+    if not note_path.is_file():
+        return {}
+    return _parse_frontmatter(note_path.read_text(encoding="utf-8"))
 
 
 def _is_moc_row(note_type: str, path: str) -> bool:
@@ -158,6 +196,102 @@ def list_objects(
         }
         for row in rows
     ]
+
+
+def search_vault_surface(
+    vault_dir: Path | str,
+    *,
+    query: str,
+    object_limit: int = 25,
+    note_limit: int = 25,
+) -> dict[str, Any]:
+    normalized_query = query.strip()
+    object_limit, _ = _validate_page_args(limit=object_limit, offset=0)
+    note_limit, _ = _validate_page_args(limit=note_limit, offset=0)
+    if not normalized_query:
+        return {
+            "query": "",
+            "objects": [],
+            "notes": [],
+        }
+    db_path = _db_path(vault_dir)
+    resolved_vault = resolve_vault_dir(vault_dir)
+    escaped_query = _escape_like(normalized_query.lower())
+    with sqlite3.connect(db_path) as conn:
+        object_rows = conn.execute(
+            """
+            SELECT DISTINCT objects.object_id, objects.object_kind, objects.title, objects.canonical_path, objects.source_slug
+            FROM objects
+            LEFT JOIN compiled_summaries ON compiled_summaries.object_id = objects.object_id
+            LEFT JOIN claims ON claims.object_id = objects.object_id
+            WHERE lower(objects.object_id) LIKE ? ESCAPE '\\'
+               OR lower(objects.title) LIKE ? ESCAPE '\\'
+               OR lower(objects.source_slug) LIKE ? ESCAPE '\\'
+               OR lower(compiled_summaries.summary_text) LIKE ? ESCAPE '\\'
+               OR lower(claims.claim_text) LIKE ? ESCAPE '\\'
+            ORDER BY objects.object_id
+            LIMIT ?
+            """,
+            (
+                f"%{escaped_query}%",
+                f"%{escaped_query}%",
+                f"%{escaped_query}%",
+                f"%{escaped_query}%",
+                f"%{escaped_query}%",
+                object_limit,
+            ),
+        ).fetchall()
+        note_rows = conn.execute(
+            """
+            SELECT slug, title, note_type, path
+            FROM pages_index
+            WHERE lower(slug) LIKE ? ESCAPE '\\'
+               OR lower(title) LIKE ? ESCAPE '\\'
+               OR lower(path) LIKE ? ESCAPE '\\'
+               OR lower(body) LIKE ? ESCAPE '\\'
+            ORDER BY
+              CASE note_type
+                WHEN 'evergreen' THEN 0
+                WHEN 'deep_dive' THEN 1
+                WHEN 'moc' THEN 2
+                ELSE 3
+              END,
+              slug
+            LIMIT ?
+            """,
+            (
+                f"%{escaped_query}%",
+                f"%{escaped_query}%",
+                f"%{escaped_query}%",
+                f"%{escaped_query}%",
+                note_limit,
+            ),
+        ).fetchall()
+
+    objects = [
+        {
+            "object_id": row[0],
+            "object_kind": row[1],
+            "title": row[2],
+            "canonical_path": _vault_relative_path(resolved_vault, row[3]),
+            "source_slug": row[4],
+        }
+        for row in object_rows
+    ]
+    notes = [
+        {
+            "slug": row[0],
+            "title": row[1],
+            "note_type": row[2],
+            "path": _vault_relative_path(resolved_vault, row[3]),
+        }
+        for row in note_rows
+    ]
+    return {
+        "query": normalized_query,
+        "objects": objects,
+        "notes": notes,
+    }
 
 
 def count_objects(vault_dir: Path | str, *, query: str | None = None) -> int:
@@ -417,6 +551,87 @@ def get_object_detail(vault_dir: Path | str, object_id: str) -> dict[str, Any]:
             "source_notes": source_notes,
             "mocs": mocs,
         },
+    }
+
+
+def _find_note_by_source(vault_dir: Path, *, source_url: str, exclude_path: str) -> dict[str, str] | None:
+    search_roots = [
+        vault_dir / "50-Inbox" / "03-Processed",
+        vault_dir / "50-Inbox" / "02-Processing",
+        vault_dir / "50-Inbox" / "01-Raw",
+    ]
+    resolved_exclude = str((vault_dir / exclude_path).resolve())
+    for root in search_roots:
+        if not root.exists():
+            continue
+        for candidate in sorted(root.rglob("*.md")):
+            if str(candidate.resolve()) == resolved_exclude:
+                continue
+            frontmatter = _parse_frontmatter(candidate.read_text(encoding="utf-8"))
+            if str(frontmatter.get("source", "")).strip() != source_url:
+                continue
+            title = str(frontmatter.get("title") or candidate.stem).strip()
+            return {
+                "title": title,
+                "path": str(candidate.resolve().relative_to(vault_dir.resolve())),
+            }
+    return None
+
+
+def _find_note_from_pipeline_log(vault_dir: Path, *, note_path: str) -> dict[str, str] | None:
+    log_path = VaultLayout.from_vault(vault_dir).logs_dir / "pipeline.jsonl"
+    if not log_path.exists():
+        return None
+    article_file: str | None = None
+    archived_path: str | None = None
+    target_absolute = str((vault_dir / note_path).resolve())
+    for raw_line in log_path.read_text(encoding="utf-8").splitlines():
+        if not raw_line.strip():
+            continue
+        try:
+            event = json.loads(raw_line)
+        except json.JSONDecodeError:
+            continue
+        if event.get("event_type") == "article_processed":
+            output = str(event.get("output", "")).strip()
+            if output == target_absolute or output.endswith(note_path):
+                article_file = str(event.get("file", "")).strip()
+                continue
+        if event.get("event_type") == "source_archived_to_processed":
+            archived = str(event.get("archived", "")).strip()
+            source = str(event.get("source", "")).strip()
+            if article_file and (archived.endswith(article_file) or source.endswith(article_file)):
+                archived_path = archived
+    if not archived_path:
+        return None
+    candidate = Path(archived_path)
+    if not candidate.is_absolute():
+        candidate = (vault_dir / archived_path).resolve()
+    if not candidate.is_file():
+        return None
+    frontmatter = _parse_frontmatter(candidate.read_text(encoding="utf-8"))
+    return {
+        "title": str(frontmatter.get("title") or candidate.stem).strip(),
+        "path": str(candidate.resolve().relative_to(vault_dir.resolve())),
+    }
+
+
+def get_note_provenance(vault_dir: Path | str, *, note_path: str) -> dict[str, Any]:
+    resolved_vault = resolve_vault_dir(vault_dir)
+    frontmatter = _read_note_frontmatter(resolved_vault, note_path)
+    source_url = str(frontmatter.get("source", "")).strip()
+    original_source_note = None
+    if source_url:
+        original_source_note = _find_note_by_source(
+            resolved_vault,
+            source_url=source_url,
+            exclude_path=note_path,
+        )
+    if original_source_note is None:
+        original_source_note = _find_note_from_pipeline_log(resolved_vault, note_path=note_path)
+    return {
+        "note_path": note_path,
+        "original_source_note": original_source_note,
     }
 
 

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -587,3 +587,56 @@ def list_deep_dive_derivations(
         }
         for item in items
     ]
+
+
+def list_stale_summaries(
+    vault_dir: Path | str,
+    *,
+    query: str | None = None,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    limit, _ = _validate_page_args(limit=limit, offset=0)
+    db_path = _db_path(vault_dir)
+    normalized_query = _escape_like(query.strip().lower()) if query else ""
+    sql = """
+        SELECT objects.object_id, objects.title, compiled_summaries.summary_text,
+               COALESCE(rel.outgoing_count, 0) AS outgoing_count
+        FROM objects
+        LEFT JOIN compiled_summaries ON compiled_summaries.object_id = objects.object_id
+        LEFT JOIN (
+            SELECT source_object_id, COUNT(*) AS outgoing_count
+            FROM relations
+            GROUP BY source_object_id
+        ) AS rel ON rel.source_object_id = objects.object_id
+    """
+    params: list[Any] = []
+    if normalized_query:
+        sql += """
+            WHERE lower(objects.object_id) LIKE ? ESCAPE '\\'
+               OR lower(objects.title) LIKE ? ESCAPE '\\'
+               OR lower(compiled_summaries.summary_text) LIKE ? ESCAPE '\\'
+        """
+        params.extend([f"%{normalized_query}%"] * 3)
+    sql += " ORDER BY objects.object_id LIMIT ?"
+    params.append(limit)
+
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(sql, tuple(params)).fetchall()
+
+    items: list[dict[str, Any]] = []
+    for object_id, title, summary_text, outgoing_count in rows:
+        summary = str(summary_text or "").strip()
+        if outgoing_count > 0:
+            continue
+        if len(summary) >= 40 and summary.lower() != str(title).strip().lower():
+            continue
+        items.append(
+            {
+                "object_id": str(object_id),
+                "title": str(title),
+                "summary_text": summary,
+                "outgoing_relation_count": int(outgoing_count or 0),
+                "object_path": f"/object?id={object_id}",
+            }
+        )
+    return items

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -616,6 +616,47 @@ def _find_note_from_pipeline_log(vault_dir: Path, *, note_path: str) -> dict[str
     }
 
 
+def _find_derived_notes_from_pipeline_log(vault_dir: Path, *, note_path: str) -> list[dict[str, str]]:
+    log_path = VaultLayout.from_vault(vault_dir).logs_dir / "pipeline.jsonl"
+    if not log_path.exists():
+        return []
+    target_name = Path(note_path).name
+    derived: list[dict[str, str]] = []
+    seen_paths: set[str] = set()
+    for raw_line in log_path.read_text(encoding="utf-8").splitlines():
+        if not raw_line.strip():
+            continue
+        try:
+            event = json.loads(raw_line)
+        except json.JSONDecodeError:
+            continue
+        if event.get("event_type") != "article_processed":
+            continue
+        file_name = str(event.get("file", "")).strip()
+        if file_name != target_name:
+            continue
+        output = str(event.get("output", "")).strip()
+        if not output:
+            continue
+        candidate = Path(output)
+        if not candidate.is_absolute():
+            candidate = (vault_dir / output).resolve()
+        if not candidate.is_file():
+            continue
+        relative_path = str(candidate.resolve().relative_to(vault_dir.resolve()))
+        if relative_path in seen_paths:
+            continue
+        seen_paths.add(relative_path)
+        frontmatter = _parse_frontmatter(candidate.read_text(encoding="utf-8"))
+        derived.append(
+            {
+                "title": str(frontmatter.get("title") or candidate.stem).strip(),
+                "path": relative_path,
+            }
+        )
+    return derived
+
+
 def get_note_provenance(vault_dir: Path | str, *, note_path: str) -> dict[str, Any]:
     resolved_vault = resolve_vault_dir(vault_dir)
     frontmatter = _read_note_frontmatter(resolved_vault, note_path)
@@ -629,9 +670,11 @@ def get_note_provenance(vault_dir: Path | str, *, note_path: str) -> dict[str, A
         )
     if original_source_note is None:
         original_source_note = _find_note_from_pipeline_log(resolved_vault, note_path=note_path)
+    derived_deep_dives = _find_derived_notes_from_pipeline_log(resolved_vault, note_path=note_path)
     return {
         "note_path": note_path,
         "original_source_note": original_source_note,
+        "derived_deep_dives": derived_deep_dives,
     }
 
 

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -152,6 +152,118 @@ def get_object_provenance_map(vault_dir: Path | str, object_ids: list[str]) -> d
     return provenance
 
 
+def get_review_context(vault_dir: Path | str, object_ids: list[str]) -> dict[str, Any]:
+    normalized_object_ids = list(dict.fromkeys(object_id for object_id in object_ids if object_id))
+    if not normalized_object_ids:
+        return {
+            "object_count": 0,
+            "source_note_count": 0,
+            "moc_count": 0,
+            "contradiction_count": 0,
+            "open_contradiction_count": 0,
+            "stale_summary_count": 0,
+            "latest_event_date": "",
+            "source_notes": [],
+            "mocs": [],
+            "stale_summary_object_ids": [],
+            "contradiction_object_ids": [],
+        }
+
+    provenance_map = get_object_provenance_map(vault_dir, normalized_object_ids)
+    source_notes: dict[str, dict[str, Any]] = {}
+    mocs: dict[str, dict[str, Any]] = {}
+    for provenance in provenance_map.values():
+        for note in provenance["source_notes"]:
+            source_notes.setdefault(note["slug"], note)
+        for moc in provenance["mocs"]:
+            mocs.setdefault(moc["slug"], moc)
+
+    db_path = _db_path(vault_dir)
+    placeholders = ",".join("?" for _ in normalized_object_ids)
+    with sqlite3.connect(db_path) as conn:
+        stale_rows = conn.execute(
+            f"""
+            SELECT objects.object_id, objects.title, compiled_summaries.summary_text,
+                   COALESCE(rel.outgoing_count, 0) AS outgoing_count
+            FROM objects
+            LEFT JOIN compiled_summaries ON compiled_summaries.object_id = objects.object_id
+            LEFT JOIN (
+                SELECT source_object_id, COUNT(*) AS outgoing_count
+                FROM relations
+                GROUP BY source_object_id
+            ) AS rel ON rel.source_object_id = objects.object_id
+            WHERE objects.object_id IN ({placeholders})
+            ORDER BY objects.object_id
+            """,
+            tuple(normalized_object_ids),
+        ).fetchall()
+        event_row = conn.execute(
+            f"""
+            SELECT MAX(event_date)
+            FROM timeline_events
+            WHERE slug IN ({placeholders})
+            """,
+            tuple(normalized_object_ids),
+        ).fetchone()
+        contradiction_rows = conn.execute(
+            """
+            SELECT contradiction_id, positive_claim_ids_json, negative_claim_ids_json, status
+            FROM contradictions
+            ORDER BY contradiction_id
+            """
+        ).fetchall()
+
+    stale_summaries: list[dict[str, Any]] = []
+    for object_id, title, summary_text, outgoing_count in stale_rows:
+        summary = str(summary_text or "").strip()
+        if outgoing_count > 0:
+            continue
+        if len(summary) >= 40 and summary.lower() != str(title).strip().lower():
+            continue
+        stale_summaries.append(
+            {
+                "object_id": str(object_id),
+                "title": str(title),
+                "summary_text": summary,
+                "outgoing_relation_count": int(outgoing_count or 0),
+                "object_path": f"/object?id={object_id}",
+            }
+        )
+    stale_summary_object_ids = [item["object_id"] for item in stale_summaries]
+
+    contradiction_ids: list[str] = []
+    open_contradiction_ids: list[str] = []
+    contradiction_object_ids: set[str] = set()
+    object_id_set = set(normalized_object_ids)
+    for contradiction_id, positive_json, negative_json, status in contradiction_rows:
+        claim_ids = json.loads(positive_json) + json.loads(negative_json)
+        matched_object_ids = {
+            claim_id.split("::", 1)[0]
+            for claim_id in claim_ids
+            if claim_id.split("::", 1)[0] in object_id_set
+        }
+        if not matched_object_ids:
+            continue
+        contradiction_ids.append(str(contradiction_id))
+        contradiction_object_ids.update(matched_object_ids)
+        if status == "open":
+            open_contradiction_ids.append(str(contradiction_id))
+
+    return {
+        "object_count": len(normalized_object_ids),
+        "source_note_count": len(source_notes),
+        "moc_count": len(mocs),
+        "contradiction_count": len(contradiction_ids),
+        "open_contradiction_count": len(open_contradiction_ids),
+        "stale_summary_count": len(stale_summaries),
+        "latest_event_date": str(event_row[0] or ""),
+        "source_notes": list(source_notes.values()),
+        "mocs": list(mocs.values()),
+        "stale_summary_object_ids": stale_summary_object_ids,
+        "contradiction_object_ids": sorted(contradiction_object_ids),
+    }
+
+
 def list_objects(
     vault_dir: Path | str,
     *,
@@ -910,6 +1022,7 @@ def list_stale_summaries(
     vault_dir: Path | str,
     *,
     query: str | None = None,
+    object_ids: list[str] | None = None,
     limit: int = 100,
 ) -> list[dict[str, Any]]:
     limit, _ = _validate_page_args(limit=limit, offset=0)
@@ -927,13 +1040,27 @@ def list_stale_summaries(
         ) AS rel ON rel.source_object_id = objects.object_id
     """
     params: list[Any] = []
+    where_clauses: list[str] = []
+    if object_ids:
+        normalized_object_ids = list(dict.fromkeys(object_id for object_id in object_ids if object_id))
+        if not normalized_object_ids:
+            return []
+        placeholders = ",".join("?" for _ in normalized_object_ids)
+        where_clauses.append(f"objects.object_id IN ({placeholders})")
+        params.extend(normalized_object_ids)
     if normalized_query:
-        sql += """
-            WHERE lower(objects.object_id) LIKE ? ESCAPE '\\'
-               OR lower(objects.title) LIKE ? ESCAPE '\\'
-               OR lower(compiled_summaries.summary_text) LIKE ? ESCAPE '\\'
-        """
+        where_clauses.append(
+            """
+            (
+                lower(objects.object_id) LIKE ? ESCAPE '\\'
+                OR lower(objects.title) LIKE ? ESCAPE '\\'
+                OR lower(compiled_summaries.summary_text) LIKE ? ESCAPE '\\'
+            )
+            """.strip()
+        )
         params.extend([f"%{normalized_query}%"] * 3)
+    if where_clauses:
+        sql += " WHERE " + " AND ".join(where_clauses)
     sql += " ORDER BY objects.object_id LIMIT ?"
     params.append(limit)
 

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -828,23 +828,82 @@ def list_deep_dive_derivations(
     query: str | None = None,
     limit: int = 100,
 ) -> list[dict[str, Any]]:
-    items = _list_surface_groups(
-        vault_dir,
-        note_type="deep_dive",
-        query=query,
-        limit=limit,
-        object_list_key="derived_objects",
-    )
-    return [
-        {
-            "slug": item["slug"],
-            "title": item["title"],
-            "note_type": item["note_type"],
-            "path": item["path"],
-            "derived_objects": item["derived_objects"],
+    limit, _ = _validate_page_args(limit=limit, offset=0)
+    db_path = _db_path(vault_dir)
+    resolved_vault = resolve_vault_dir(vault_dir)
+    normalized_query = (query or "").strip().lower()
+
+    with sqlite3.connect(db_path) as conn:
+        deep_dive_rows = conn.execute(
+            """
+            SELECT slug, title, note_type, path
+            FROM pages_index
+            WHERE note_type = 'deep_dive'
+            ORDER BY slug
+            """
+        ).fetchall()
+        object_rows = conn.execute(
+            """
+            SELECT object_id, title
+            FROM objects
+            ORDER BY object_id
+            """
+        ).fetchall()
+        audit_rows = conn.execute(
+            """
+            SELECT payload_json
+            FROM audit_events
+            WHERE event_type = 'evergreen_auto_promoted'
+            """
+        ).fetchall()
+
+    object_titles = {row[0]: row[1] for row in object_rows}
+    grouped_promotions: dict[str, dict[str, dict[str, str]]] = {}
+    for (payload_json,) in audit_rows:
+        try:
+            payload = json.loads(payload_json)
+        except json.JSONDecodeError:
+            continue
+        source_name = str(payload.get("source") or "").strip()
+        object_id = str(payload.get("mutation", {}).get("target_slug") or payload.get("concept") or "").strip()
+        if not source_name or not object_id:
+            continue
+        title = object_titles.get(object_id, object_id)
+        grouped_promotions.setdefault(source_name, {})[object_id] = {
+            "object_id": object_id,
+            "title": title,
         }
-        for item in items
-    ]
+
+    items: list[dict[str, Any]] = []
+    for slug, title, note_type, path in deep_dive_rows:
+        relative_path = _vault_relative_path(resolved_vault, path)
+        source_name = Path(relative_path).name
+        derived_objects = list(grouped_promotions.get(source_name, {}).values())
+        if normalized_query:
+            haystacks = [
+                slug.lower(),
+                title.lower(),
+                relative_path.lower(),
+                *(
+                    value.lower()
+                    for item in derived_objects
+                    for value in (item["object_id"], item["title"])
+                ),
+            ]
+            if not any(normalized_query in haystack for haystack in haystacks):
+                continue
+        items.append(
+            {
+                "slug": slug,
+                "title": title,
+                "note_type": note_type,
+                "path": relative_path,
+                "derived_objects": sorted(derived_objects, key=lambda item: item["object_id"]),
+            }
+        )
+        if len(items) >= limit:
+            break
+    return items
 
 
 def list_stale_summaries(

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -239,6 +239,7 @@ def build_truth_dashboard_payload(vault_dir: Path | str) -> dict[str, Any]:
     objects = build_objects_index_payload(vault_dir, limit=12, offset=0)
     contradictions = build_contradiction_browser_payload(vault_dir)
     events = build_event_dossier_payload(vault_dir, limit=8)
+    stale_summaries = build_stale_summary_browser_payload(vault_dir)
     return {
         "screen": "truth/dashboard",
         "objects": {
@@ -254,6 +255,10 @@ def build_truth_dashboard_payload(vault_dir: Path | str) -> dict[str, Any]:
             "count": events["event_count"],
             "items": events["events"][:8],
             "dates": events["dates"],
+        },
+        "stale_summaries": {
+            "count": stale_summaries["count"],
+            "items": stale_summaries["items"][:8],
         },
     }
 

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -9,6 +9,7 @@ from ..runtime import VaultLayout, resolve_vault_dir
 from ..truth_api import (
     count_objects,
     get_object_detail,
+    get_object_provenance_map,
     get_topic_neighborhood,
     list_atlas_memberships,
     list_contradictions,
@@ -140,6 +141,13 @@ def build_event_dossier_payload(
         }
         for row in rows
     ]
+    provenance_map = get_object_provenance_map(vault_dir, [event["object_id"] for event in events])
+    for event in events:
+        event["object_path"] = f"/object?id={event['object_id']}"
+        event["provenance"] = provenance_map.get(
+            event["object_id"],
+            {"evergreen_path": "", "source_notes": [], "mocs": []},
+        )
     dates = sorted({event["event_date"] for event in events})
     grouped: dict[str, list[dict[str, Any]]] = {}
     for event in events:
@@ -162,16 +170,43 @@ def build_contradiction_browser_payload(
     query: str | None = None,
 ) -> dict[str, Any]:
     raw_items = list_contradictions(vault_dir, status=status, query=query)
+    provenance_map = get_object_provenance_map(
+        vault_dir,
+        _object_ids_from_claim_ids(
+            *(
+                item["positive_claim_ids"] + item["negative_claim_ids"]
+                for item in raw_items
+            )
+        ),
+    )
     items = []
     for item in raw_items:
         object_ids = _object_ids_from_claim_ids(item["positive_claim_ids"], item["negative_claim_ids"])
+        source_notes: dict[str, dict[str, Any]] = {}
+        mocs: dict[str, dict[str, Any]] = {}
+        object_titles: dict[str, str] = {}
+        for object_id in object_ids:
+            provenance = provenance_map.get(
+                object_id,
+                {"title": object_id, "evergreen_path": "", "source_notes": [], "mocs": []},
+            )
+            object_titles[object_id] = provenance["title"]
+            for note in provenance["source_notes"]:
+                source_notes.setdefault(note["slug"], note)
+            for moc in provenance["mocs"]:
+                mocs.setdefault(moc["slug"], moc)
         items.append(
             {
                 **item,
                 "object_ids": object_ids,
+                "object_titles": object_titles,
                 "object_links": [
                     {"object_id": object_id, "path": f"/object?id={object_id}"} for object_id in object_ids
                 ],
+                "provenance": {
+                    "source_notes": list(source_notes.values()),
+                    "mocs": list(mocs.values()),
+                },
             }
         )
     status_counts = Counter(item["status"] for item in items)
@@ -231,19 +266,39 @@ def build_objects_index_payload(
 
 def build_atlas_browser_payload(vault_dir: Path | str, *, query: str | None = None) -> dict[str, Any]:
     items = list_atlas_memberships(vault_dir, query=query)
+    enriched_items = []
+    for item in items:
+        preview_titles = [member["title"] for member in item["members"][:5]]
+        enriched_items.append(
+            {
+                **item,
+                "member_count": len(item["members"]),
+                "preview_titles": preview_titles,
+            }
+        )
     return {
         "screen": "atlas/browser",
-        "items": items,
-        "count": len(items),
+        "items": enriched_items,
+        "count": len(enriched_items),
         "query": query or "",
     }
 
 
 def build_derivation_browser_payload(vault_dir: Path | str, *, query: str | None = None) -> dict[str, Any]:
     items = list_deep_dive_derivations(vault_dir, query=query)
+    enriched_items = []
+    for item in items:
+        preview_titles = [member["title"] for member in item["derived_objects"][:5]]
+        enriched_items.append(
+            {
+                **item,
+                "derived_object_count": len(item["derived_objects"]),
+                "preview_titles": preview_titles,
+            }
+        )
     return {
         "screen": "derivations/browser",
-        "items": items,
-        "count": len(items),
+        "items": enriched_items,
+        "count": len(enriched_items),
         "query": query or "",
     }

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -15,6 +15,7 @@ from ..truth_api import (
     list_contradictions,
     list_deep_dive_derivations,
     list_objects,
+    list_stale_summaries,
 )
 
 
@@ -314,4 +315,18 @@ def build_derivation_browser_payload(vault_dir: Path | str, *, query: str | None
         "items": enriched_items,
         "count": len(enriched_items),
         "query": query or "",
+    }
+
+
+def build_stale_summary_browser_payload(vault_dir: Path | str, *, query: str | None = None) -> dict[str, Any]:
+    items = list_stale_summaries(vault_dir, query=query)
+    return {
+        "screen": "truth/stale-summaries",
+        "items": items,
+        "count": len(items),
+        "query": query or "",
+        "detection_notes": [
+            "Stale summary review flags compiled summaries that are weak and have no outgoing supporting relations.",
+            "This queue is deterministic and favors false negatives over false positives.",
+        ],
     }

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -9,6 +9,7 @@ from ..runtime import VaultLayout, resolve_vault_dir
 from ..truth_api import (
     count_objects,
     get_object_detail,
+    get_note_provenance,
     get_object_provenance_map,
     get_topic_neighborhood,
     list_atlas_memberships,
@@ -16,6 +17,7 @@ from ..truth_api import (
     list_deep_dive_derivations,
     list_objects,
     list_stale_summaries,
+    search_vault_surface,
 )
 
 
@@ -334,4 +336,23 @@ def build_stale_summary_browser_payload(vault_dir: Path | str, *, query: str | N
             "Stale summary review flags compiled summaries that are weak and have no outgoing supporting relations.",
             "This queue is deterministic and favors false negatives over false positives.",
         ],
+    }
+
+
+def build_search_payload(vault_dir: Path | str, *, query: str) -> dict[str, Any]:
+    results = search_vault_surface(vault_dir, query=query)
+    return {
+        "screen": "search/results",
+        **results,
+        "object_count": len(results["objects"]),
+        "note_count": len(results["notes"]),
+    }
+
+
+def build_note_page_payload(vault_dir: Path | str, *, note_path: str) -> dict[str, Any]:
+    provenance = get_note_provenance(vault_dir, note_path=note_path)
+    return {
+        "screen": "note/page",
+        "note_path": note_path,
+        "provenance": provenance,
     }

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -135,6 +135,8 @@ def build_event_dossier_payload(
         {
             "event_date": row[0],
             "event_type": row[1],
+            "event_kind": "dated_note" if row[1] == "page_date" else "dated_heading",
+            "event_label": "Dated Note" if row[1] == "page_date" else "Dated Heading",
             "object_id": row[2],
             "title": row[3],
             "summary_text": row[4] or "",
@@ -153,12 +155,18 @@ def build_event_dossier_payload(
     for event in events:
         grouped.setdefault(event["event_date"], []).append(event)
     date_sections = [{"date": date, "events": grouped[date]} for date in dates]
+    event_type_counts = Counter(event["event_kind"] for event in events)
     return {
         "screen": "event/dossier",
         "events": events,
         "event_count": len(events),
         "dates": dates,
         "date_sections": date_sections,
+        "event_type_counts": dict(event_type_counts),
+        "model_notes": [
+            "Event Dossier is a timeline over dated notes projected from indexed pages, not a separate event entity system.",
+            "page_date rows come from note-level dates; heading_date rows come from dated section headings.",
+        ],
         "query": query or "",
     }
 
@@ -216,6 +224,11 @@ def build_contradiction_browser_payload(
         "count": len(items),
         "open_count": status_counts.get("open", 0),
         "resolved_count": sum(count for status, count in status_counts.items() if status != "open"),
+        "detection_notes": [
+            "Contradictions are currently detected from page_summary claim polarity, not from full semantic contradiction analysis.",
+            "Zero results do not prove consistency; they usually mean the current heuristic did not detect a conflict.",
+        ],
+        "empty_state": "Zero results usually means the current heuristic did not detect a conflict, not that the vault is globally contradiction-free.",
         "status": status or "",
         "query": query or "",
     }

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -11,6 +11,7 @@ from ..truth_api import (
     get_object_detail,
     get_note_provenance,
     get_object_provenance_map,
+    get_review_context,
     get_topic_neighborhood,
     list_atlas_memberships,
     list_contradictions,
@@ -41,6 +42,7 @@ def _object_ids_from_claim_ids(*claim_id_lists: list[str]) -> list[str]:
 def build_object_page_payload(vault_dir: Path | str, object_id: str) -> dict[str, Any]:
     detail = get_object_detail(vault_dir, object_id)
     neighborhood = get_topic_neighborhood(vault_dir, object_id)
+    review_context = get_review_context(vault_dir, [object_id])
     neighbor_titles = {item["object_id"]: item["title"] for item in neighborhood["neighbors"]}
     relations = [
         {
@@ -63,10 +65,12 @@ def build_object_page_payload(vault_dir: Path | str, object_id: str) -> dict[str
             "canonical_path": detail["object"]["canonical_path"],
         },
         "provenance": detail["provenance"],
+        "review_context": review_context,
         "links": {
             "topic_path": f"/topic?id={object_id}",
             "events_path": f"/events?q={object_id}",
             "contradictions_path": f"/contradictions?q={object_id}",
+            "summaries_path": f"/summaries?q={object_id}",
         },
         "section_nav": [
             {"href": "#summary", "label": "Summary"},
@@ -80,6 +84,10 @@ def build_object_page_payload(vault_dir: Path | str, object_id: str) -> dict[str
 def build_topic_overview_payload(vault_dir: Path | str, object_id: str) -> dict[str, Any]:
     neighborhood = get_topic_neighborhood(vault_dir, object_id)
     detail = get_object_detail(vault_dir, object_id)
+    review_context = get_review_context(
+        vault_dir,
+        [object_id, *[item["object_id"] for item in neighborhood["neighbors"]]],
+    )
     return {
         "screen": "overview/topic",
         **neighborhood,
@@ -87,10 +95,12 @@ def build_topic_overview_payload(vault_dir: Path | str, object_id: str) -> dict[
         "neighbor_count": len(neighborhood["neighbors"]),
         "center_summary": detail["summary"]["summary_text"] if detail["summary"] else "",
         "provenance": detail["provenance"],
+        "review_context": review_context,
         "links": {
             "center_object_path": f"/object?id={object_id}",
             "events_path": f"/events?q={object_id}",
             "contradictions_path": f"/contradictions?q={object_id}",
+            "summaries_path": f"/summaries?q={object_id}",
         },
     }
 
@@ -147,8 +157,15 @@ def build_event_dossier_payload(
         for row in rows
     ]
     provenance_map = get_object_provenance_map(vault_dir, [event["object_id"] for event in events])
+    review_context = get_review_context(vault_dir, [event["object_id"] for event in events])
     for event in events:
         event["object_path"] = f"/object?id={event['object_id']}"
+        event["review_links"] = {
+            "object_path": event["object_path"],
+            "topic_path": f"/topic?id={event['object_id']}",
+            "contradictions_path": f"/contradictions?q={event['object_id']}",
+            "summaries_path": f"/summaries?q={event['object_id']}",
+        }
         event["provenance"] = provenance_map.get(
             event["object_id"],
             {"evergreen_path": "", "source_notes": [], "mocs": []},
@@ -166,6 +183,7 @@ def build_event_dossier_payload(
         "dates": dates,
         "date_sections": date_sections,
         "event_type_counts": dict(event_type_counts),
+        "review_context": review_context,
         "model_notes": [
             "Event Dossier is a timeline over dated notes projected from indexed pages, not a separate event entity system.",
             "page_date rows come from note-level dates; heading_date rows come from dated section headings.",
@@ -327,11 +345,13 @@ def build_derivation_browser_payload(vault_dir: Path | str, *, query: str | None
 
 def build_stale_summary_browser_payload(vault_dir: Path | str, *, query: str | None = None) -> dict[str, Any]:
     items = list_stale_summaries(vault_dir, query=query)
+    review_context = get_review_context(vault_dir, [item["object_id"] for item in items])
     return {
         "screen": "truth/stale-summaries",
         "items": items,
         "count": len(items),
         "query": query or "",
+        "review_context": review_context,
         "detection_notes": [
             "Stale summary review flags compiled summaries that are weak and have no outgoing supporting relations.",
             "This queue is deterministic and favors false negatives over false positives.",

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
 
 
@@ -257,6 +260,108 @@ Alpha one does not support local-first execution.
     detail = get_object_detail(temp_vault, "alpha")
 
     assert detail["contradictions"] == []
+
+
+def test_truth_api_searches_objects_and_notes(temp_vault):
+    from openclaw_pipeline.truth_api import search_vault_surface
+
+    vault = _seed_truth_vault(temp_vault)
+    deep_dive = vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "Agent Harness_深度解读.md"
+    deep_dive.parent.mkdir(parents=True, exist_ok=True)
+    deep_dive.write_text(
+        """---
+title: Agent Harness Deep Dive
+source: https://example.com/agent-harness
+date: 2026-04-13
+type: deep_dive
+---
+
+# Agent Harness Deep Dive
+
+Mentions [[source-note]].
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(vault)
+
+    payload = search_vault_surface(vault, query="agent harness")
+
+    assert payload["query"] == "agent harness"
+    assert {item["object_id"] for item in payload["objects"]} == {"negative-note", "source-note"}
+    assert any(item["note_type"] == "deep_dive" for item in payload["notes"])
+    assert any(
+        item["path"] == "20-Areas/AI-Research/Topics/2026-04/Agent Harness_深度解读.md"
+        for item in payload["notes"]
+    )
+
+
+def test_truth_api_resolves_deep_dive_source_note_from_frontmatter_and_logs(temp_vault):
+    from openclaw_pipeline.truth_api import get_note_provenance
+
+    processed = temp_vault / "50-Inbox" / "03-Processed" / "2026-04" / "2026-04-01_The_Harness_Wars_Begin.md"
+    processed.parent.mkdir(parents=True, exist_ok=True)
+    processed.write_text(
+        """---
+title: "The Harness Wars Begin"
+source: "https://x.com/0xJsum/status/2039198679815565508"
+---
+
+Processed source note.
+""",
+        encoding="utf-8",
+    )
+    deep_dive = temp_vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "2026-04-09_The Harness Wars Begin_深度解读.md"
+    deep_dive.parent.mkdir(parents=True, exist_ok=True)
+    deep_dive.write_text(
+        """```yaml
+---
+title: "The Harness Wars Begin"
+source: "https://x.com/0xJsum/status/2039198679815565508"
+date: "2026-04-09"
+type: "ai"
+---
+```
+
+# One-liner
+""",
+        encoding="utf-8",
+    )
+    logs_dir = temp_vault / "60-Logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    (logs_dir / "pipeline.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "event_type": "article_processed",
+                        "file": "2026-04-01_The_Harness_Wars_Begin.md",
+                        "output": str(deep_dive),
+                    },
+                    ensure_ascii=False,
+                ),
+                json.dumps(
+                    {
+                        "event_type": "source_archived_to_processed",
+                        "source": str(temp_vault / "50-Inbox" / "02-Processing" / "2026-04-01_The_Harness_Wars_Begin.md"),
+                        "archived": str(processed),
+                    },
+                    ensure_ascii=False,
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    provenance = get_note_provenance(
+        temp_vault,
+        note_path="20-Areas/AI-Research/Topics/2026-04/2026-04-09_The Harness Wars Begin_深度解读.md",
+    )
+
+    assert provenance["original_source_note"] == {
+        "title": "The Harness Wars Begin",
+        "path": "50-Inbox/03-Processed/2026-04/2026-04-01_The_Harness_Wars_Begin.md",
+    }
 
 
 def test_truth_api_returns_object_provenance_and_moc_membership(temp_vault):

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -364,6 +364,65 @@ type: "ai"
     }
 
 
+def test_truth_api_resolves_processed_note_to_derived_deep_dives(temp_vault):
+    from openclaw_pipeline.truth_api import get_note_provenance
+
+    processed = temp_vault / "50-Inbox" / "03-Processed" / "2026-04" / "2026-04-01_The_Harness_Wars_Begin.md"
+    processed.parent.mkdir(parents=True, exist_ok=True)
+    processed.write_text(
+        """---
+title: "The Harness Wars Begin"
+source: "https://x.com/0xJsum/status/2039198679815565508"
+---
+
+Processed source note.
+""",
+        encoding="utf-8",
+    )
+    deep_dive = temp_vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "2026-04-09_The Harness Wars Begin_深度解读.md"
+    deep_dive.parent.mkdir(parents=True, exist_ok=True)
+    deep_dive.write_text(
+        """```yaml
+---
+title: "The Harness Wars Begin"
+source: "https://x.com/0xJsum/status/2039198679815565508"
+date: "2026-04-09"
+type: "ai"
+---
+```
+
+# One-liner
+""",
+        encoding="utf-8",
+    )
+    logs_dir = temp_vault / "60-Logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    (logs_dir / "pipeline.jsonl").write_text(
+        json.dumps(
+            {
+                "event_type": "article_processed",
+                "file": "2026-04-01_The_Harness_Wars_Begin.md",
+                "output": str(deep_dive),
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    provenance = get_note_provenance(
+        temp_vault,
+        note_path="50-Inbox/03-Processed/2026-04/2026-04-01_The_Harness_Wars_Begin.md",
+    )
+
+    assert provenance["derived_deep_dives"] == [
+        {
+            "title": "The Harness Wars Begin",
+            "path": "20-Areas/AI-Research/Topics/2026-04/2026-04-09_The Harness Wars Begin_深度解读.md",
+        }
+    ]
+
+
 def test_truth_api_returns_object_provenance_and_moc_membership(temp_vault):
     from openclaw_pipeline.truth_api import get_object_detail
 

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -620,11 +620,44 @@ date: 2026-04-13
 ---
 
 # Deep Dive
-
-- [[alpha]]
-- [[beta]]
-- [[gamma]]
 """,
+        encoding="utf-8",
+    )
+    logs_dir = temp_vault / "60-Logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    (logs_dir / "pipeline.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "event_type": "evergreen_auto_promoted",
+                        "concept": "alpha",
+                        "source": "Deep Dive_深度解读.md",
+                        "mutation": {"target_slug": "alpha"},
+                    },
+                    ensure_ascii=False,
+                ),
+                json.dumps(
+                    {
+                        "event_type": "evergreen_auto_promoted",
+                        "concept": "beta",
+                        "source": "Deep Dive_深度解读.md",
+                        "mutation": {"target_slug": "beta"},
+                    },
+                    ensure_ascii=False,
+                ),
+                json.dumps(
+                    {
+                        "event_type": "evergreen_auto_promoted",
+                        "concept": "gamma",
+                        "source": "Deep Dive_深度解读.md",
+                        "mutation": {"target_slug": "gamma"},
+                    },
+                    ensure_ascii=False,
+                ),
+            ]
+        )
+        + "\n",
         encoding="utf-8",
     )
 

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -201,6 +201,59 @@ def test_ui_server_can_resolve_contradiction_via_api(temp_vault):
     assert row == ("resolved_keep_positive", "Reviewed in UI")
 
 
+def test_ui_server_can_rebuild_stale_summary_via_api(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+    from openclaw_pipeline.runtime import VaultLayout
+
+    note = temp_vault / "10-Knowledge" / "Evergreen" / "Thin.md"
+    note.write_text(
+        """---
+note_id: thin-note
+title: Thin Note
+type: evergreen
+date: 2026-04-10
+---
+
+# Thin Note
+
+Thin note.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+    layout = VaultLayout.from_vault(temp_vault)
+    with sqlite3.connect(layout.knowledge_db) as conn:
+        conn.execute(
+            "UPDATE compiled_summaries SET summary_text = ? WHERE object_id = ?",
+            ("Thin.", "thin-note"),
+        )
+        conn.commit()
+
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        body = urlencode({"object_id": "thin-note"})
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request(
+            "POST",
+            "/api/summaries/rebuild",
+            body=body,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        response = conn.getresponse()
+        payload = json.loads(response.read().decode("utf-8"))
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 200
+    assert payload["objects_rebuilt"] == 1
+    assert payload["object_ids"] == ["thin-note"]
+
+
 def test_ui_server_topic_and_events_endpoints_return_payloads(temp_vault):
     from openclaw_pipeline.commands.ui_server import create_server
 

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -242,6 +242,71 @@ def test_ui_server_can_resolve_contradiction_via_api(temp_vault):
     assert row == ("resolved_keep_positive", "Reviewed in UI")
 
 
+def test_ui_server_can_bulk_resolve_contradictions_via_api(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+    from openclaw_pipeline.runtime import VaultLayout
+
+    _seed_truth_store(temp_vault)
+    delta = temp_vault / "10-Knowledge" / "Evergreen" / "Delta.md"
+    delta.write_text(
+        """---
+note_id: delta
+title: Delta
+type: evergreen
+date: 2026-04-13
+---
+
+# Delta
+
+Delta supports local-first execution.
+""",
+        encoding="utf-8",
+    )
+    delta_conflict = temp_vault / "10-Knowledge" / "Evergreen" / "Delta Conflict.md"
+    delta_conflict.write_text(
+        """---
+note_id: delta-conflict
+title: Delta Conflict
+type: evergreen
+date: 2026-04-13
+---
+
+# Delta Conflict
+
+Delta does not support local-first execution.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+    layout = VaultLayout.from_vault(temp_vault)
+    with sqlite3.connect(layout.knowledge_db) as conn:
+        contradiction_ids = [row[0] for row in conn.execute("SELECT contradiction_id FROM contradictions ORDER BY contradiction_id").fetchall()]
+
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        body = "contradiction_id=" + "&contradiction_id=".join(contradiction_ids) + "&status=dismissed&note=Batch+reviewed"
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request(
+            "POST",
+            "/api/contradictions/resolve",
+            body=body,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        response = conn.getresponse()
+        payload = json.loads(response.read().decode("utf-8"))
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 200
+    assert payload["resolved_count"] == 2
+    assert sorted(payload["contradiction_ids"]) == contradiction_ids
+
+
 def test_ui_server_can_rebuild_stale_summary_via_api(temp_vault):
     from openclaw_pipeline.commands.ui_server import create_server
     from openclaw_pipeline.runtime import VaultLayout
@@ -293,6 +358,52 @@ Thin note.
     assert response.status == 200
     assert payload["objects_rebuilt"] == 1
     assert payload["object_ids"] == ["thin-note"]
+
+
+def test_ui_server_can_bulk_rebuild_summaries_via_api(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+
+    for object_id, title in (("thin-note", "Thin Note"), ("fragile-note", "Fragile Note")):
+        note = temp_vault / "10-Knowledge" / "Evergreen" / f"{title}.md"
+        note.write_text(
+            f"""---
+note_id: {object_id}
+title: {title}
+type: evergreen
+date: 2026-04-10
+---
+
+# {title}
+
+Thin note.
+""",
+            encoding="utf-8",
+        )
+    rebuild_knowledge_index(temp_vault)
+
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        body = "object_id=thin-note&object_id=fragile-note"
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request(
+            "POST",
+            "/api/summaries/rebuild",
+            body=body,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        response = conn.getresponse()
+        payload = json.loads(response.read().decode("utf-8"))
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 200
+    assert payload["objects_rebuilt"] == 2
+    assert payload["object_ids"] == ["fragile-note", "thin-note"]
 
 
 def test_ui_server_topic_and_events_endpoints_return_payloads(temp_vault):

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 import subprocess
 import threading
 from http.client import HTTPConnection
 from pathlib import Path
+from urllib.parse import urlencode
 
 from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
 
@@ -148,6 +150,55 @@ def test_ui_server_contradictions_endpoint_returns_payload(temp_vault):
     assert response.status == 200
     assert payload["count"] == 1
     assert payload["items"][0]["subject_key"] == "alpha"
+
+
+def test_ui_server_can_resolve_contradiction_via_api(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+    from openclaw_pipeline.runtime import VaultLayout
+
+    _seed_truth_store(temp_vault)
+    layout = VaultLayout.from_vault(temp_vault)
+    with sqlite3.connect(layout.knowledge_db) as conn:
+        contradiction_id = conn.execute("SELECT contradiction_id FROM contradictions").fetchone()[0]
+
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        body = urlencode(
+            {
+                "contradiction_id": contradiction_id,
+                "status": "resolved_keep_positive",
+                "note": "Reviewed in UI",
+                "rebuild_summaries": "1",
+            }
+        )
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request(
+            "POST",
+            "/api/contradictions/resolve",
+            body=body,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        response = conn.getresponse()
+        payload = json.loads(response.read().decode("utf-8"))
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 200
+    assert payload["resolved_count"] == 1
+    assert payload["contradiction_ids"] == [contradiction_id]
+    assert payload["rebuilt_summary_count"] == 2
+
+    with sqlite3.connect(layout.knowledge_db) as conn:
+        row = conn.execute(
+            "SELECT status, resolution_note FROM contradictions WHERE contradiction_id = ?",
+            (contradiction_id,),
+        ).fetchone()
+    assert row == ("resolved_keep_positive", "Reviewed in UI")
 
 
 def test_ui_server_topic_and_events_endpoints_return_payloads(temp_vault):

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -106,6 +106,47 @@ def test_ui_server_objects_endpoint_returns_json(temp_vault):
     assert [item["object_id"] for item in payload["items"]] == ["alpha", "beta", "conflict"]
 
 
+def test_ui_server_search_endpoint_returns_objects_and_notes(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+
+    _seed_truth_store(temp_vault)
+    deep_dive = temp_vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "Agent Harness_深度解读.md"
+    deep_dive.parent.mkdir(parents=True, exist_ok=True)
+    deep_dive.write_text(
+        """---
+title: Agent Harness Deep Dive
+source: https://example.com/agent-harness
+date: 2026-04-13
+type: deep_dive
+---
+
+# Agent Harness Deep Dive
+
+Mentions [[alpha]].
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("GET", "/api/search?q=alpha")
+        response = conn.getresponse()
+        payload = json.loads(response.read().decode("utf-8"))
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 200
+    assert payload["objects"]
+    assert payload["notes"]
+    assert any(item["note_type"] == "deep_dive" for item in payload["notes"])
+
+
 def test_ui_server_object_endpoint_returns_detail_payload(temp_vault):
     from openclaw_pipeline.commands.ui_server import create_server
 

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -611,6 +611,58 @@ def test_ui_note_page_rewrites_local_images_to_asset_route(temp_vault):
     assert asset_body.startswith(b"\x89PNG")
 
 
+def test_ui_deep_dive_browser_uses_promoted_objects_not_incidental_mentions(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+
+    prompt = temp_vault / "10-Knowledge" / "Evergreen" / "Prompt Engineering.md"
+    prompt.parent.mkdir(parents=True, exist_ok=True)
+    prompt.write_text(
+        """---
+note_id: prompt-engineering
+title: Prompt Engineering
+type: evergreen
+date: 2026-04-13
+---
+
+# Prompt Engineering
+""",
+        encoding="utf-8",
+    )
+    deep_dive = temp_vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "Weekly Build_深度解读.md"
+    deep_dive.parent.mkdir(parents=True, exist_ok=True)
+    deep_dive.write_text(
+        """---
+note_id: weekly-build
+title: Weekly Build
+type: deep_dive
+date: 2026-04-13
+---
+
+# Weekly Build
+
+- [[prompt-engineering]] — mentioned as related knowledge
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        status, body = _get(port, "/deep-dives")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert status == 200
+    assert "Weekly Build" in body
+    assert "0 derived objects" in body
+    assert "Prompt Engineering" not in body
+
+
 def test_ui_search_page_combines_objects_and_notes(temp_vault):
     from openclaw_pipeline.commands.ui_server import create_server
 
@@ -931,6 +983,12 @@ date: 2026-04-13
 
 Mentions [[alpha]].
 """,
+        encoding="utf-8",
+    )
+    logs_dir = temp_vault / "60-Logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    (logs_dir / "pipeline.jsonl").write_text(
+        '{"event_type":"evergreen_auto_promoted","concept":"alpha","source":"Deep Dive_深度解读.md","mutation":{"target_slug":"alpha"}}\n',
         encoding="utf-8",
     )
     atlas = temp_vault / "10-Knowledge" / "Atlas" / "Atlas-Index.md"

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -165,6 +165,8 @@ date: 2026-04-13
     assert "2026-04-13" in events_body
     assert 'id="date-2026-04-13"' in events_body
     assert "timeline-oriented" in events_body
+    assert "Dated Note" in events_body
+    assert "Model Notes" in events_body
     assert "page_date -" not in events_body
     assert "Source Deep Dive" in events_body
     assert "Atlas Index" in events_body
@@ -177,6 +179,7 @@ date: 2026-04-13
     assert '/object?id=alpha' in contradictions_body
     assert "Source Deep Dive" in contradictions_body
     assert "Atlas Index" in contradictions_body
+    assert "Detection Notes" in contradictions_body
 
 
 def test_ui_note_page_renders_markdown_note(temp_vault):
@@ -480,6 +483,40 @@ def test_ui_contradictions_page_filters_by_status(temp_vault):
     assert "resolved" in body
     assert "<span class='pill'>resolved</span>" in body
     assert "<span class='pill'>open</span>" not in body
+
+
+def test_ui_contradictions_empty_state_explains_heuristic_limit(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+
+    alpha = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
+    alpha.write_text(
+        """---
+note_id: alpha
+title: Alpha
+type: evergreen
+date: 2026-04-13
+---
+
+# Alpha
+
+Alpha supports local-first execution.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        status, body = _get(port, "/contradictions")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert status == 200
+    assert "Zero results usually means the current heuristic did not detect a conflict" in body
 
 
 def test_ui_contradictions_page_filters_by_query(temp_vault):

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -162,6 +162,9 @@ date: 2026-04-13
     assert "/private/" not in object_body
     assert "Source Deep Dive" in object_body
     assert "Atlas Index" in object_body
+    assert "Review Context" in object_body
+    assert "Open contradictions" in object_body
+    assert "/summaries?q=alpha" in object_body
     assert f"/note?path={quote('10-Knowledge/Evergreen/Alpha.md', safe='')}" in object_body
     assert f"/note?path={quote('20-Areas/Tools/Topics/2026-04/Source Deep Dive_深度解读.md', safe='')}" in object_body
     assert f"/note?path={quote('10-Knowledge/Atlas/Atlas-Index.md', safe='')}" in object_body
@@ -173,6 +176,8 @@ date: 2026-04-13
     assert '/events?q=alpha' in topic_body
     assert "Center Summary" in topic_body
     assert "Atlas / MOC" in topic_body
+    assert "Review Context" in topic_body
+    assert "/summaries?q=alpha" in topic_body
 
     assert events_status == 200
     assert "Event Dossier" in events_body
@@ -181,6 +186,8 @@ date: 2026-04-13
     assert "timeline-oriented" in events_body
     assert "Dated Note" in events_body
     assert "Model Notes" in events_body
+    assert "Review Context" in events_body
+    assert "/summaries?q=alpha" in events_body
     assert "page_date -" not in events_body
     assert "Source Deep Dive" in events_body
     assert "Atlas Index" in events_body
@@ -191,6 +198,7 @@ date: 2026-04-13
     assert "Contradictions" in contradictions_body
     assert "alpha" in contradictions_body
     assert '/object?id=alpha' in contradictions_body
+    assert "Resolve Selected" in contradictions_body
     assert "Source Deep Dive" in contradictions_body
     assert "Atlas Index" in contradictions_body
     assert "Detection Notes" in contradictions_body
@@ -743,6 +751,46 @@ Thin note.
     assert "Alpha" in root_body
     assert "Thin Note" in root_body
     assert "/summaries" in root_body
+
+
+def test_ui_contradictions_and_summaries_support_batch_actions(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+
+    _seed_truth_store(temp_vault)
+    thin = temp_vault / "10-Knowledge" / "Evergreen" / "Thin.md"
+    thin.write_text(
+        """---
+note_id: thin-note
+title: Thin Note
+type: evergreen
+date: 2026-04-10
+---
+
+# Thin Note
+
+Thin note.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        contradictions_status, contradictions_body = _get(port, "/contradictions")
+        summaries_status, summaries_body = _get(port, "/summaries")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert contradictions_status == 200
+    assert "Resolve Selected" in contradictions_body
+    assert "name='contradiction_id'" in contradictions_body
+    assert summaries_status == 200
+    assert "Rebuild Selected" in summaries_body
+    assert "name='object_id'" in summaries_body
 
 
 def test_ui_objects_page_filters_by_query(temp_vault):

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -166,11 +166,17 @@ date: 2026-04-13
     assert 'id="date-2026-04-13"' in events_body
     assert "timeline-oriented" in events_body
     assert "page_date -" not in events_body
+    assert "Source Deep Dive" in events_body
+    assert "Atlas Index" in events_body
+    assert f"/note?path={quote('20-Areas/Tools/Topics/2026-04/Source Deep Dive_深度解读.md', safe='')}" in events_body
+    assert f"/note?path={quote('10-Knowledge/Atlas/Atlas-Index.md', safe='')}" in events_body
 
     assert contradictions_status == 200
     assert "Contradictions" in contradictions_body
     assert "alpha" in contradictions_body
     assert '/object?id=alpha' in contradictions_body
+    assert "Source Deep Dive" in contradictions_body
+    assert "Atlas Index" in contradictions_body
 
 
 def test_ui_note_page_renders_markdown_note(temp_vault):
@@ -582,12 +588,14 @@ date: 2026-04-13
     assert "Atlas / MOC Browser" in atlas_body
     assert "Atlas Index" in atlas_body
     assert "Alpha" in atlas_body
+    assert "1 objects" in atlas_body
     assert f"/note?path={quote('10-Knowledge/Atlas/Atlas-Index.md', safe='')}" in atlas_body
 
     assert derivations_status == 200
     assert "Deep Dive Derivations" in derivations_body
     assert "Deep Dive" in derivations_body
     assert "Alpha" in derivations_body
+    assert "1 derived objects" in derivations_body
     assert (
         f"/note?path={quote('20-Areas/Tools/Topics/2026-04/Deep Dive_深度解读.md', safe='')}"
         in derivations_body

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -999,6 +999,32 @@ def test_ui_events_page_filters_by_query(temp_vault):
     assert "Alpha" not in body
 
 
+def test_ui_events_page_handles_missing_evergreen_path(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+    from openclaw_pipeline.runtime import VaultLayout
+
+    _seed_truth_store(temp_vault)
+    db_path = VaultLayout.from_vault(temp_vault).knowledge_db
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("UPDATE objects SET canonical_path = '' WHERE object_id = ?", ("alpha",))
+        conn.commit()
+
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        status, body = _get(port, "/events?q=alpha")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert status == 200
+    assert "Evergreen: <span class='muted'>None</span>" in body
+    assert 'href="/note?path="' not in body
+
+
 def test_ui_smoke_atlas_and_deep_dive_pages_render_bridge_views(temp_vault):
     from openclaw_pipeline.commands.ui_server import create_server
 

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -589,6 +589,60 @@ def test_ui_contradictions_page_can_resolve_item(temp_vault):
     assert "Reviewed in browser" in page_body
 
 
+def test_ui_summaries_page_can_rebuild_item(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+    from openclaw_pipeline.runtime import VaultLayout
+
+    note = temp_vault / "10-Knowledge" / "Evergreen" / "Thin.md"
+    note.write_text(
+        """---
+note_id: thin-note
+title: Thin Note
+type: evergreen
+date: 2026-04-10
+---
+
+# Thin Note
+
+Thin note.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+    layout = VaultLayout.from_vault(temp_vault)
+    with sqlite3.connect(layout.knowledge_db) as conn:
+        conn.execute(
+            "UPDATE compiled_summaries SET summary_text = ? WHERE object_id = ?",
+            ("Thin.", "thin-note"),
+        )
+        conn.commit()
+
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        status, before_body = _get(port, "/summaries")
+        rebuild_status, _body, headers = _post(
+            port,
+            "/summaries/rebuild",
+            {"object_id": "thin-note"},
+        )
+        after_status, after_body = _get(port, "/summaries")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert status == 200
+    assert "Stale Summaries" in before_body
+    assert "thin-note" in before_body
+    assert rebuild_status == 303
+    assert headers["location"] == "/summaries"
+    assert after_status == 200
+    assert "Thin note." in after_body
+
+
 def test_ui_events_page_filters_by_query(temp_vault):
     from openclaw_pipeline.commands.ui_server import create_server
 

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -505,6 +505,112 @@ type: "ai"
     assert f'/note?path={quote("50-Inbox/03-Processed/2026-04/2026-04-01_The_Harness_Wars_Begin.md", safe="")}' in body
 
 
+def test_ui_note_page_shows_derived_deep_dive_for_processed_source(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+
+    processed = temp_vault / "50-Inbox" / "03-Processed" / "2026-04" / "2026-04-01_The_Harness_Wars_Begin.md"
+    processed.parent.mkdir(parents=True, exist_ok=True)
+    processed.write_text(
+        """---
+title: "The Harness Wars Begin"
+source: "https://x.com/0xJsum/status/2039198679815565508"
+---
+
+Processed source note.
+""",
+        encoding="utf-8",
+    )
+    note = temp_vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "2026-04-09_The Harness Wars Begin_深度解读.md"
+    note.parent.mkdir(parents=True, exist_ok=True)
+    note.write_text(
+        """```yaml
+---
+title: "The Harness Wars Begin"
+source: "https://x.com/0xJsum/status/2039198679815565508"
+date: "2026-04-09"
+type: "ai"
+---
+```
+
+# One-liner
+""",
+        encoding="utf-8",
+    )
+    logs_dir = temp_vault / "60-Logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    (logs_dir / "pipeline.jsonl").write_text(
+        '{"event_type":"article_processed","file":"2026-04-01_The_Harness_Wars_Begin.md","output":"'
+        + str(note)
+        + '"}\n',
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        status, body = _get(
+            port,
+            f"/note?path={quote('50-Inbox/03-Processed/2026-04/2026-04-01_The_Harness_Wars_Begin.md', safe='')}",
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert status == 200
+    assert "Derived Deep Dives" in body
+    assert f'/note?path={quote("20-Areas/AI-Research/Topics/2026-04/2026-04-09_The Harness Wars Begin_深度解读.md", safe="")}' in body
+
+
+def test_ui_note_page_rewrites_local_images_to_asset_route(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+
+    asset = temp_vault / "50-Inbox" / "01-Raw" / "attachments" / "2026-04" / "sample.png"
+    asset.parent.mkdir(parents=True, exist_ok=True)
+    asset.write_bytes(
+        bytes.fromhex(
+            "89504E470D0A1A0A0000000D4948445200000001000000010802000000907753DE0000000C49444154789C6360000000020001E221BC330000000049454E44AE426082"
+        )
+    )
+    note = temp_vault / "50-Inbox" / "03-Processed" / "2026-04" / "Images.md"
+    note.parent.mkdir(parents=True, exist_ok=True)
+    note.write_text(
+        "![Image](50-Inbox/01-Raw/attachments/2026-04/sample.png)\n",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        status, body = _get(
+            port,
+            f"/note?path={quote('50-Inbox/03-Processed/2026-04/Images.md', safe='')}",
+        )
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request(
+            "GET",
+            f"/asset?path={quote('50-Inbox/01-Raw/attachments/2026-04/sample.png', safe='')}",
+        )
+        response = conn.getresponse()
+        asset_status = response.status
+        asset_body = response.read()
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert status == 200
+    assert "/asset?path=50-Inbox%2F01-Raw%2Fattachments%2F2026-04%2Fsample.png" in body
+    assert asset_status == 200
+    assert asset_body.startswith(b"\x89PNG")
+
+
 def test_ui_search_page_combines_objects_and_notes(temp_vault):
     from openclaw_pipeline.commands.ui_server import create_server
 

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -439,6 +439,22 @@ def test_ui_root_dashboard_renders_db_summary(temp_vault):
     from openclaw_pipeline.commands.ui_server import create_server
 
     _seed_truth_store(temp_vault)
+    thin = temp_vault / "10-Knowledge" / "Evergreen" / "Thin.md"
+    thin.write_text(
+        """---
+note_id: thin-note
+title: Thin Note
+type: evergreen
+date: 2026-04-10
+---
+
+# Thin Note
+
+Thin note.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
     server = create_server(temp_vault, host="127.0.0.1", port=0)
     port = server.server_address[1]
     thread = threading.Thread(target=server.serve_forever, daemon=True)
@@ -454,7 +470,10 @@ def test_ui_root_dashboard_renders_db_summary(temp_vault):
     assert "Objects Indexed" in root_body
     assert "Contradictions Open" in root_body
     assert "Recent Events" in root_body
+    assert "Stale Summaries" in root_body
     assert "Alpha" in root_body
+    assert "Thin Note" in root_body
+    assert "/summaries" in root_body
 
 
 def test_ui_objects_page_filters_by_query(temp_vault):

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -379,9 +379,9 @@ date: 2026-04-13
     assert '🔍 AI-Agent' in body
     assert '🎯 Prompt-Engineering' in body
     assert '🔍 AI-Workflow' in body
-    assert '/objects?q=ai-agent' in body
+    assert '/search?q=ai-agent' in body
     assert '/object?id=prompt-engineering' in body
-    assert '/objects?q=AI-Workflow' in body
+    assert '/search?q=AI-Workflow' in body
 
 
 def test_ui_note_page_smart_renders_reference_tables_and_keywords(temp_vault):
@@ -431,8 +431,119 @@ github: "https://github.com/example/repo"
     assert '<table>' in body
     assert 'href="https://github.com/example/repo"' in body
     assert 'href="https://github.com/example/repo/blob/main/docs/RELEASING.md"' in body
-    assert '/objects?q=OpenCove' in body
-    assert '/objects?q=Claude%20Code' in body
+    assert '/search?q=OpenCove' in body
+    assert '/search?q=Claude%20Code' in body
+
+
+def test_ui_note_page_shows_original_source_note_for_deep_dive(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+
+    processed = temp_vault / "50-Inbox" / "03-Processed" / "2026-04" / "2026-04-01_The_Harness_Wars_Begin.md"
+    processed.parent.mkdir(parents=True, exist_ok=True)
+    processed.write_text(
+        """---
+title: "The Harness Wars Begin"
+source: "https://x.com/0xJsum/status/2039198679815565508"
+---
+
+Processed source note.
+""",
+        encoding="utf-8",
+    )
+    note = temp_vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "2026-04-09_The Harness Wars Begin_深度解读.md"
+    note.parent.mkdir(parents=True, exist_ok=True)
+    note.write_text(
+        """```yaml
+---
+title: "The Harness Wars Begin"
+source: "https://x.com/0xJsum/status/2039198679815565508"
+date: "2026-04-09"
+type: "ai"
+---
+```
+
+# One-liner
+""",
+        encoding="utf-8",
+    )
+    logs_dir = temp_vault / "60-Logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    (logs_dir / "pipeline.jsonl").write_text(
+        '\n'.join(
+            [
+                '{"event_type":"article_processed","file":"2026-04-01_The_Harness_Wars_Begin.md","output":"'
+                + str(note)
+                + '"}',
+                '{"event_type":"source_archived_to_processed","source":"'
+                + str(temp_vault / "50-Inbox" / "02-Processing" / "2026-04-01_The_Harness_Wars_Begin.md")
+                + '","archived":"'
+                + str(processed)
+                + '"}',
+            ]
+        )
+        + '\n',
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        status, body = _get(
+            port,
+            f"/note?path={quote('20-Areas/AI-Research/Topics/2026-04/2026-04-09_The Harness Wars Begin_深度解读.md', safe='')}",
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert status == 200
+    assert "Original Source Note" in body
+    assert f'/note?path={quote("50-Inbox/03-Processed/2026-04/2026-04-01_The_Harness_Wars_Begin.md", safe="")}' in body
+
+
+def test_ui_search_page_combines_objects_and_notes(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+
+    _seed_truth_store(temp_vault)
+    deep_dive = temp_vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "Agent Harness_深度解读.md"
+    deep_dive.parent.mkdir(parents=True, exist_ok=True)
+    deep_dive.write_text(
+        """---
+title: Agent Harness Deep Dive
+source: https://example.com/agent-harness
+date: 2026-04-13
+type: deep_dive
+---
+
+# Agent Harness Deep Dive
+
+Mentions [[alpha]].
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        status, body = _get(port, "/search?q=alpha")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert status == 200
+    assert "Search" in body
+    assert "Objects" in body
+    assert "Notes" in body
+    assert "/object?id=alpha" in body
+    assert f'/note?path={quote("20-Areas/AI-Research/Topics/2026-04/Agent Harness_深度解读.md", safe="")}' in body
 
 
 def test_ui_root_dashboard_renders_db_summary(temp_vault):

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sqlite3
 import threading
 from http.client import HTTPConnection
-from urllib.parse import quote
+from urllib.parse import quote, urlencode
 
 from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
 from openclaw_pipeline.runtime import VaultLayout
@@ -78,6 +78,20 @@ def _get(port: int, path: str) -> tuple[int, str]:
     conn.request("GET", path)
     response = conn.getresponse()
     return response.status, response.read().decode("utf-8")
+
+
+def _post(port: int, path: str, fields: dict[str, str]) -> tuple[int, str, dict[str, str]]:
+    conn = HTTPConnection("127.0.0.1", port, timeout=5)
+    body = urlencode(fields)
+    conn.request(
+        "POST",
+        path,
+        body=body,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    response = conn.getresponse()
+    headers = {key.lower(): value for key, value in response.getheaders()}
+    return response.status, response.read().decode("utf-8"), headers
 
 
 def test_ui_smoke_pages_render_truth_views(temp_vault):
@@ -536,6 +550,43 @@ def test_ui_contradictions_page_filters_by_query(temp_vault):
 
     assert status == 200
     assert "alpha" in body
+
+
+def test_ui_contradictions_page_can_resolve_item(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+    from openclaw_pipeline.runtime import VaultLayout
+
+    _seed_truth_store(temp_vault)
+    layout = VaultLayout.from_vault(temp_vault)
+    with sqlite3.connect(layout.knowledge_db) as conn:
+        contradiction_id = conn.execute("SELECT contradiction_id FROM contradictions").fetchone()[0]
+
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        status, _body, headers = _post(
+            port,
+            "/contradictions/resolve",
+            {
+                "contradiction_id": contradiction_id,
+                "status": "resolved_keep_positive",
+                "note": "Reviewed in browser",
+                "rebuild_summaries": "1",
+            },
+        )
+        page_status, page_body = _get(port, "/contradictions?status=resolved")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert status == 303
+    assert headers["location"] == "/contradictions?status=resolved"
+    assert page_status == 200
+    assert "resolved_keep_positive" in page_body
+    assert "Reviewed in browser" in page_body
 
 
 def test_ui_events_page_filters_by_query(temp_vault):

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -178,7 +178,11 @@ def test_build_event_dossier_payload(temp_vault):
     assert payload["event_count"] == 3
     assert payload["dates"] == ["2026-04-13"]
     assert payload["events"][0]["object_id"] == "alpha"
+    assert payload["events"][0]["event_kind"] == "dated_note"
+    assert payload["events"][0]["event_label"] == "Dated Note"
     assert payload["date_sections"][0]["date"] == "2026-04-13"
+    assert payload["event_type_counts"] == {"dated_note": 3}
+    assert "dated notes projected from indexed pages" in payload["model_notes"][0]
 
 
 def test_build_event_dossier_payload_includes_provenance(temp_vault):
@@ -238,6 +242,33 @@ def test_build_contradiction_browser_payload(temp_vault):
     assert payload["items"][0]["subject_key"] == "alpha"
     assert payload["open_count"] == 1
     assert payload["items"][0]["object_ids"] == ["alpha", "conflict"]
+    assert "page_summary claim polarity" in payload["detection_notes"][0]
+
+
+def test_build_contradiction_browser_payload_empty_state_explains_zero(temp_vault):
+    from openclaw_pipeline.ui.view_models import build_contradiction_browser_payload
+
+    alpha = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
+    alpha.write_text(
+        """---
+note_id: alpha
+title: Alpha
+type: evergreen
+date: 2026-04-13
+---
+
+# Alpha
+
+Alpha supports local-first execution.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    payload = build_contradiction_browser_payload(temp_vault)
+
+    assert payload["count"] == 0
+    assert "Zero results usually means the current heuristic did not detect a conflict" in payload["empty_state"]
 
 
 def test_build_contradiction_browser_payload_filters_by_status(temp_vault):

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -89,8 +89,12 @@ def test_build_object_page_payload(temp_vault):
     assert payload["links"]["topic_path"] == "/topic?id=alpha"
     assert payload["links"]["events_path"] == "/events?q=alpha"
     assert payload["links"]["contradictions_path"] == "/contradictions?q=alpha"
+    assert payload["links"]["summaries_path"] == "/summaries?q=alpha"
     assert payload["context"]["source_slug"] == "alpha"
     assert payload["section_nav"][0]["href"] == "#summary"
+    assert payload["review_context"]["object_count"] == 1
+    assert payload["review_context"]["open_contradiction_count"] == 1
+    assert payload["review_context"]["latest_event_date"] == "2026-04-13"
 
 
 def test_build_object_page_payload_includes_provenance(temp_vault):
@@ -165,6 +169,9 @@ def test_build_topic_overview_payload(temp_vault):
     assert payload["links"]["center_object_path"] == "/object?id=alpha"
     assert payload["links"]["events_path"] == "/events?q=alpha"
     assert payload["center_summary"] == "Alpha supports local-first execution."
+    assert payload["links"]["summaries_path"] == "/summaries?q=alpha"
+    assert payload["review_context"]["object_count"] == 2
+    assert payload["review_context"]["open_contradiction_count"] == 1
 
 
 def test_build_event_dossier_payload(temp_vault):
@@ -183,6 +190,10 @@ def test_build_event_dossier_payload(temp_vault):
     assert payload["date_sections"][0]["date"] == "2026-04-13"
     assert payload["event_type_counts"] == {"dated_note": 3}
     assert "dated notes projected from indexed pages" in payload["model_notes"][0]
+    assert payload["review_context"]["object_count"] == 3
+    assert payload["review_context"]["open_contradiction_count"] == 1
+    assert payload["events"][0]["review_links"]["contradictions_path"] == "/contradictions?q=alpha"
+    assert payload["events"][0]["review_links"]["summaries_path"] == "/summaries?q=alpha"
 
 
 def test_build_event_dossier_payload_includes_provenance(temp_vault):
@@ -534,6 +545,32 @@ Thin note.
     assert payload["items"][0]["object_id"] == "thin-note"
     assert payload["items"][0]["summary_text"] == "Thin note."
     assert "compiled summaries that are weak" in payload["detection_notes"][0]
+
+
+def test_build_stale_summary_browser_payload_includes_review_context(temp_vault):
+    from openclaw_pipeline.ui.view_models import build_stale_summary_browser_payload
+
+    note = temp_vault / "10-Knowledge" / "Evergreen" / "Thin.md"
+    note.write_text(
+        """---
+note_id: thin-note
+title: Thin Note
+type: evergreen
+date: 2026-04-10
+---
+
+# Thin Note
+
+Thin note.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    payload = build_stale_summary_browser_payload(temp_vault)
+
+    assert payload["review_context"]["object_count"] == 1
+    assert payload["review_context"]["stale_summary_count"] == 1
 
 
 def test_build_event_dossier_payload_applies_limit_before_materializing(temp_vault):

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -489,6 +489,12 @@ Mentions [[alpha]].
 """,
         encoding="utf-8",
     )
+    logs_dir = temp_vault / "60-Logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    (logs_dir / "pipeline.jsonl").write_text(
+        '{"event_type":"evergreen_auto_promoted","concept":"alpha","source":"Deep Dive_深度解读.md","mutation":{"target_slug":"alpha"}}\n',
+        encoding="utf-8",
+    )
     rebuild_knowledge_index(temp_vault)
 
     payload = build_derivation_browser_payload(temp_vault)

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -181,6 +181,51 @@ def test_build_event_dossier_payload(temp_vault):
     assert payload["date_sections"][0]["date"] == "2026-04-13"
 
 
+def test_build_event_dossier_payload_includes_provenance(temp_vault):
+    from openclaw_pipeline.ui.view_models import build_event_dossier_payload
+
+    source = temp_vault / "20-Areas" / "Tools" / "Topics" / "2026-04" / "Source Deep Dive_深度解读.md"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text(
+        """---
+note_id: source-deep-dive
+title: Source Deep Dive
+type: deep_dive
+date: 2026-04-13
+---
+
+# Source Deep Dive
+
+Mentions [[alpha]].
+""",
+        encoding="utf-8",
+    )
+    atlas = temp_vault / "10-Knowledge" / "Atlas" / "Atlas-Index.md"
+    atlas.write_text(
+        """---
+note_id: atlas-index
+title: Atlas Index
+type: moc
+date: 2026-04-13
+---
+
+# Atlas Index
+
+- [[alpha]]
+""",
+        encoding="utf-8",
+    )
+    _seed_truth_store(temp_vault)
+
+    payload = build_event_dossier_payload(temp_vault, query="alpha")
+
+    event = next(item for item in payload["events"] if item["object_id"] == "alpha")
+    assert event["object_path"] == "/object?id=alpha"
+    assert event["provenance"]["evergreen_path"] == "10-Knowledge/Evergreen/Alpha.md"
+    assert event["provenance"]["source_notes"][0]["slug"] == "source-deep-dive"
+    assert event["provenance"]["mocs"][0]["slug"] == "atlas-index"
+
+
 def test_build_contradiction_browser_payload(temp_vault):
     from openclaw_pipeline.ui.view_models import build_contradiction_browser_payload
 
@@ -217,6 +262,50 @@ def test_build_contradiction_browser_payload_filters_by_query(temp_vault):
 
     assert payload["count"] == 1
     assert payload["items"][0]["subject_key"] == "alpha"
+
+
+def test_build_contradiction_browser_payload_includes_provenance(temp_vault):
+    from openclaw_pipeline.ui.view_models import build_contradiction_browser_payload
+
+    source = temp_vault / "20-Areas" / "Tools" / "Topics" / "2026-04" / "Source Deep Dive_深度解读.md"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text(
+        """---
+note_id: source-deep-dive
+title: Source Deep Dive
+type: deep_dive
+date: 2026-04-13
+---
+
+# Source Deep Dive
+
+Mentions [[alpha]].
+""",
+        encoding="utf-8",
+    )
+    atlas = temp_vault / "10-Knowledge" / "Atlas" / "Atlas-Index.md"
+    atlas.write_text(
+        """---
+note_id: atlas-index
+title: Atlas Index
+type: moc
+date: 2026-04-13
+---
+
+# Atlas Index
+
+- [[alpha]]
+""",
+        encoding="utf-8",
+    )
+    _seed_truth_store(temp_vault)
+
+    payload = build_contradiction_browser_payload(temp_vault)
+
+    item = payload["items"][0]
+    assert item["object_titles"] == {"alpha": "Alpha", "conflict": "Conflict"}
+    assert item["provenance"]["source_notes"][0]["slug"] == "source-deep-dive"
+    assert item["provenance"]["mocs"][0]["slug"] == "atlas-index"
 
 
 def test_build_truth_dashboard_payload(temp_vault):
@@ -313,6 +402,8 @@ date: 2026-04-13
     assert payload["count"] == 1
     assert payload["items"][0]["slug"] == "atlas-index"
     assert payload["items"][0]["members"][0]["object_id"] == "alpha"
+    assert payload["items"][0]["member_count"] == 1
+    assert payload["items"][0]["preview_titles"] == ["Alpha"]
 
 
 def test_build_derivation_browser_payload(temp_vault):
@@ -357,6 +448,8 @@ Mentions [[alpha]].
     assert payload["count"] == 1
     assert payload["items"][0]["slug"] == "deep-dive"
     assert payload["items"][0]["derived_objects"][0]["object_id"] == "alpha"
+    assert payload["items"][0]["derived_object_count"] == 1
+    assert payload["items"][0]["preview_titles"] == ["Alpha"]
 
 
 def test_build_event_dossier_payload_applies_limit_before_materializing(temp_vault):

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -343,13 +343,31 @@ def test_build_truth_dashboard_payload(temp_vault):
     from openclaw_pipeline.ui.view_models import build_truth_dashboard_payload
 
     _seed_truth_store(temp_vault)
+    thin = temp_vault / "10-Knowledge" / "Evergreen" / "Thin.md"
+    thin.write_text(
+        """---
+note_id: thin-note
+title: Thin Note
+type: evergreen
+date: 2026-04-10
+---
+
+# Thin Note
+
+Thin note.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
 
     payload = build_truth_dashboard_payload(temp_vault)
 
     assert payload["screen"] == "truth/dashboard"
-    assert payload["objects"]["count"] == 3
+    assert payload["objects"]["count"] == 4
     assert payload["contradictions"]["count"] == 1
-    assert payload["events"]["count"] == 3
+    assert payload["events"]["count"] == 4
+    assert payload["stale_summaries"]["count"] >= 1
+    assert "thin-note" in [item["object_id"] for item in payload["stale_summaries"]["items"]]
     assert payload["objects"]["items"][0]["object_id"] == "alpha"
 
 

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -483,6 +483,35 @@ Mentions [[alpha]].
     assert payload["items"][0]["preview_titles"] == ["Alpha"]
 
 
+def test_build_stale_summary_browser_payload(temp_vault):
+    from openclaw_pipeline.ui.view_models import build_stale_summary_browser_payload
+
+    note = temp_vault / "10-Knowledge" / "Evergreen" / "Thin.md"
+    note.write_text(
+        """---
+note_id: thin-note
+title: Thin Note
+type: evergreen
+date: 2026-04-10
+---
+
+# Thin Note
+
+Thin note.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    payload = build_stale_summary_browser_payload(temp_vault)
+
+    assert payload["screen"] == "truth/stale-summaries"
+    assert payload["count"] == 1
+    assert payload["items"][0]["object_id"] == "thin-note"
+    assert payload["items"][0]["summary_text"] == "Thin note."
+    assert "compiled summaries that are weak" in payload["detection_notes"][0]
+
+
 def test_build_event_dossier_payload_applies_limit_before_materializing(temp_vault):
     from openclaw_pipeline.ui.view_models import build_event_dossier_payload
 


### PR DESCRIPTION
## Summary
- add batch contradiction resolution and stale summary rebuild actions to the truth UI
- add review-context payloads and UI cards on object, topic, event, and stale summary surfaces
- harden real vault browsing paths so event review context works on large object sets

## Verification
- PYTHONPATH=src python3.13 -m pytest -q tests/test_ui_view_models.py tests/test_ui_server.py tests/test_ui_smoke.py
- PYTHONPATH=src python3.13 -m pytest -q
- python3.13 -m compileall src/openclaw_pipeline
- real local smoke on 127.0.0.1:8787 for /object, /topic, /events, /contradictions, /summaries
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/15" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added search functionality across objects and notes
  * Implemented asset serving for markdown images
  * Enhanced pages with provenance and traceability information (events, notes, pages)
  * Added stale summaries detection with batch rebuild capability
  * Introduced contradiction resolution with batch controls
  * Added review context metrics across pages

* **Documentation**
  * Added planning documents for Local Knowledge Workbench milestone and Phase 8

* **Tests**
  * Added comprehensive test coverage for search, assets, provenance, and batch actions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->