### PR TITLE
feat: complete phase 9 review workbench core

### DIFF
--- a/docs/plans/2026-04-14-phase9-review-workbench-completion.md
+++ b/docs/plans/2026-04-14-phase9-review-workbench-completion.md
@@ -1,0 +1,87 @@
+# Phase 9: Review Workbench Completion
+
+**Goal:** Turn the current provenance-aware truth UI into a real local operator console for knowledge maintenance. Phase 8 made the system browseable and minimally actionable. Phase 9 finishes the review loop by making queue membership explainable, review actions auditable, and maintenance entry points visible from the surfaces where users already work.
+
+## Current Gap
+
+The system already has:
+
+- contradiction resolution in the UI,
+- stale summary rebuild in the UI,
+- batch actions,
+- provenance on object/topic/event/note surfaces,
+- dashboard queue visibility.
+
+But the workbench still feels partial:
+
+- a contradiction row can be resolved without showing the exact claim pair that triggered it,
+- a stale summary row can be rebuilt without showing why it was flagged,
+- review actions are not visible as a history trail inside the UI,
+- object/topic/event pages show review context counts but not the recent maintenance activity behind those counts.
+
+## Scope
+
+### Slice A: Review History And Audit Trail
+
+Expose recent review actions in the truth UI:
+
+- contradiction resolution history
+- stale summary rebuild history
+- object-scoped history on object/topic/event pages
+- dashboard preview of recent review activity
+
+The history should come from persisted audit data, not ad-hoc in-memory state.
+
+### Slice B: Contradiction Evidence Drill-Down
+
+For each contradiction item, show:
+
+- positive claim texts
+- negative claim texts
+- affected object titles
+- recent resolution history when available
+
+This should make it obvious why a contradiction exists and what was previously done about it.
+
+### Slice C: Stale Summary Rationale Drill-Down
+
+For each stale summary item, show deterministic reason codes and human-readable explanations such as:
+
+- no outgoing relations
+- summary too short
+- summary repeats title
+- summary missing
+
+This should make rebuild decisions explainable instead of opaque.
+
+### Slice D: Review Entry Points From Existing Pages
+
+Strengthen the current object/topic/event pages by surfacing:
+
+- recent review history
+- direct links to the contradiction and stale-summary queues
+- queue-specific context for the current object scope
+
+## Non-Goals
+
+- no new hosted service or background worker,
+- no LLM-driven contradiction detection rewrite,
+- no event ontology rebuild,
+- no full queue prioritization engine yet.
+
+## Milestone Definition
+
+Phase 9 reaches its first stable checkpoint when:
+
+1. users can see why contradiction and stale summary rows exist,
+2. users can see what review actions were recently taken,
+3. object/topic/event pages expose enough maintenance context that queue actions feel connected to the rest of the workbench,
+4. the normal maintenance path does not require dropping to CLI for explanation.
+
+## Execution Order
+
+1. Add failing tests for review history and rationale payloads.
+2. Persist UI review actions into the audit layer.
+3. Add truth API helpers for review history and rationale-rich queue payloads.
+4. Render history and drill-down context in contradiction/stale-summary/object/topic/event views.
+5. Re-run targeted UI suites and then the full pytest suite.

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -629,6 +629,12 @@ def _render_dashboard(payload: dict) -> str:
         f"<span class='muted'>({escape(item['summary_text'])})</span></li>"
         for item in payload["stale_summaries"]["items"]
     ) or "<li>None</li>"
+    priority_items = "".join(
+        f'<li><span class="pill">{escape(item["kind"].replace("_", " "))}</span> '
+        f'<a href="{escape(item["path"])}">{escape(item["label"])}</a>'
+        f"<div class='muted'>{escape(item['detail'])}</div></li>"
+        for item in payload["priorities"]
+    ) or "<li class='muted'>No urgent maintenance items surfaced.</li>"
     return _layout(
         "OpenClaw Truth UI",
         (
@@ -648,11 +654,15 @@ def _render_dashboard(payload: dict) -> str:
             "</section>"
             "<section class='grid two-col'>"
             "<div class='section-stack'>"
+            f"<section class='card'><h2>Needs Attention Now</h2><ul class='list-tight'>{priority_items}</ul></section>"
             f"<section class='card'><h2>Recent Objects</h2><ul class='list-tight'>{object_items}</ul></section>"
             f"<section class='card'><h2>Recent Events</h2><ul class='list-tight'>{event_items}</ul></section>"
             f"<section class='card'><h2><a href='/summaries'>Stale Summaries</a></h2><ul class='list-tight'>{stale_summary_items}</ul></section>"
             "</div>"
+            "<div class='section-stack'>"
             f"<section class='card'><h2>Contradiction Queue</h2><ul class='list-tight'>{contradiction_items}</ul></section>"
+            f"{_render_review_history(payload['recent_review_actions'], title='Recent Review Actions')}"
+            "</div>"
             "</section>"
         ),
     )
@@ -720,6 +730,33 @@ def _render_object_page(payload: dict) -> str:
     section_nav = "".join(
         f'<a href="{escape(item["href"])}">{escape(item["label"])}</a>' for item in payload["section_nav"]
     )
+    contradiction_form = (
+        "<form method='post' action='/contradictions/resolve' class='link-row'>"
+        + "".join(
+            f"<input type='hidden' name='contradiction_id' value='{escape(contradiction_id)}' />"
+            for contradiction_id in payload["open_contradiction_ids"]
+        )
+        + "<select name='status'>"
+        + "<option value='resolved_keep_positive'>resolved_keep_positive</option>"
+        + "<option value='resolved_keep_negative'>resolved_keep_negative</option>"
+        + "<option value='dismissed'>dismissed</option>"
+        + "<option value='needs_human'>needs_human</option>"
+        + "</select>"
+        + "<input type='text' name='note' placeholder='Resolution note' />"
+        + "<label><input type='checkbox' name='rebuild_summaries' value='1' /> rebuild summaries</label>"
+        + "<button type='submit'>Resolve Open Contradictions</button>"
+        + "</form>"
+        if payload["open_contradiction_ids"]
+        else "<p class='muted'>No open contradictions on this object.</p>"
+    )
+    summary_form = (
+        "<form method='post' action='/summaries/rebuild' class='link-row'>"
+        + f"<input type='hidden' name='object_id' value='{escape(payload['object']['object_id'])}' />"
+        + "<button type='submit'>Rebuild This Summary</button>"
+        + "</form>"
+        if payload["stale_summary_details"]
+        else "<p class='muted'>No stale summary action needed for this object.</p>"
+    )
     return _layout(
         f"Object: {payload['object']['title']}",
         (
@@ -747,6 +784,10 @@ def _render_object_page(payload: dict) -> str:
             "<div class='section-stack'>"
             f"{_render_review_context_card(payload['review_context'])}"
             f"{_render_review_history(payload['review_history'])}"
+            "<section class='card'><h2>Quick Maintenance</h2>"
+            f"{contradiction_form}"
+            f"{summary_form}"
+            "</section>"
             "<section class='card'><h2>Context</h2><dl class='meta-list'>"
             f"<div><dt>Object Kind</dt><dd>{escape(payload['context']['object_kind'])}</dd></div>"
             f"<div><dt>Source Slug</dt><dd>{escape(payload['context']['source_slug'])}</dd></div>"
@@ -774,6 +815,24 @@ def _render_topic_page(payload: dict) -> str:
     mocs = "".join(
         f"<li>{escape(item['title'])}</li>" for item in payload["provenance"]["mocs"]
     ) or "<li>None</li>"
+    summary_form = (
+        "<form method='post' action='/summaries/rebuild' class='link-row'>"
+        + "".join(
+            f"<input type='hidden' name='object_id' value='{escape(object_id)}' />"
+            for object_id in payload["scoped_stale_summary_ids"]
+        )
+        + "<button type='submit'>Rebuild Scoped Summaries</button>"
+        + "</form>"
+        if payload["scoped_stale_summary_ids"]
+        else "<p class='muted'>No stale summaries in this topic scope.</p>"
+    )
+    contradiction_entry = (
+        "<div class='link-row'>"
+        + f"<a href='{escape(payload['links']['contradictions_path'])}'>Review scoped contradictions</a>"
+        + "</div>"
+        if payload["scoped_open_contradiction_ids"]
+        else "<p class='muted'>No open contradictions in this topic scope.</p>"
+    )
     return _layout(
         f"Topic: {payload['center']['title']}",
         (
@@ -793,6 +852,10 @@ def _render_topic_page(payload: dict) -> str:
             f"<section class='card'><h2>Atlas / MOC</h2><ul class='list-tight'>{mocs}</ul></section>"
             f"{_render_review_context_card(payload['review_context'])}"
             f"{_render_review_history(payload['review_history'])}"
+            "<section class='card'><h2>Quick Maintenance</h2>"
+            f"{contradiction_entry}"
+            f"{summary_form}"
+            "</section>"
             "</section>"
         ),
     )
@@ -835,6 +898,26 @@ def _render_events_page(payload: dict) -> str:
         + "</ul></section>"
         for section in payload["date_sections"]
     ) or "<li>None</li>"
+    summary_form = (
+        "<form method='post' action='/summaries/rebuild' class='link-row'>"
+        + "".join(
+            f"<input type='hidden' name='object_id' value='{escape(object_id)}' />"
+            for object_id in payload["scoped_stale_summary_ids"]
+        )
+        + "<button type='submit'>Rebuild Visible Summaries</button>"
+        + "</form>"
+        if payload["scoped_stale_summary_ids"]
+        else "<p class='muted'>No stale summaries in the visible event scope.</p>"
+    )
+    contradiction_entry = (
+        f"<div class='link-row'><a href='/contradictions?q={escape(query)}'>Review visible contradictions</a></div>"
+        if payload["scoped_open_contradiction_ids"] and query
+        else (
+            "<div class='link-row'><a href='/contradictions'>Review visible contradictions</a></div>"
+            if payload["scoped_open_contradiction_ids"]
+            else "<p class='muted'>No open contradictions in the visible event scope.</p>"
+        )
+    )
     return _layout(
         "Event Dossier",
         (
@@ -848,6 +931,10 @@ def _render_events_page(payload: dict) -> str:
             f"<div class='link-row'>{type_breakdown}</div>"
             f"{_render_review_context_card(payload['review_context'])}"
             f"{_render_review_history(payload['review_history'])}"
+            "<section class='card'><h2>Quick Maintenance</h2>"
+            f"{contradiction_entry}"
+            f"{summary_form}"
+            "</section>"
             f"<section class='card'><h2>Model Notes</h2><ul class='list-tight'>{model_notes}</ul></section>"
             f"<nav class='subnav'>{date_nav}</nav>"
             f"{events}"

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -1041,11 +1041,35 @@ def _render_contradictions_page(payload: dict) -> str:
         + (
             "<details><summary>Claim Evidence</summary><ul class='list-tight'>"
             + "".join(
-                f"<li>Positive: {escape(claim['claim_text'])} <span class='muted'>({escape(claim['object_title'])})</span></li>"
+                "<li>Positive: "
+                + f"{escape(claim['claim_text'])} <span class='muted'>({escape(claim['object_title'])})</span>"
+                + (
+                    "<ul class='list-tight'>"
+                    + "".join(
+                        f"<li>{escape(evidence['evidence_kind'])}: {escape(evidence['quote_text'])} <span class='muted'>({escape(evidence['source_slug'])})</span></li>"
+                        for evidence in claim["evidence"]
+                    )
+                    + "</ul>"
+                    if claim["evidence"]
+                    else ""
+                )
+                + "</li>"
                 for claim in item["positive_claims"]
             )
             + "".join(
-                f"<li>Negative: {escape(claim['claim_text'])} <span class='muted'>({escape(claim['object_title'])})</span></li>"
+                "<li>Negative: "
+                + f"{escape(claim['claim_text'])} <span class='muted'>({escape(claim['object_title'])})</span>"
+                + (
+                    "<ul class='list-tight'>"
+                    + "".join(
+                        f"<li>{escape(evidence['evidence_kind'])}: {escape(evidence['quote_text'])} <span class='muted'>({escape(evidence['source_slug'])})</span></li>"
+                        for evidence in claim["evidence"]
+                    )
+                    + "</ul>"
+                    if claim["evidence"]
+                    else ""
+                )
+                + "</li>"
                 for claim in item["negative_claims"]
             )
             + "</ul></details>"
@@ -1144,6 +1168,11 @@ def _render_stale_summaries_page(payload: dict) -> str:
         f"<span class='muted'>({escape(item['object_id'])})</span>"
         f"<div class='muted'>Summary: {escape(item['summary_text'])}</div>"
         f"<div class='muted'>Outgoing relations: {item['outgoing_relation_count']}</div>"
+        + (
+            f"<div class='muted'>Latest event date: {escape(item['latest_event_date'])}</div>"
+            if item["latest_event_date"]
+            else ""
+        )
         + "<ul class='list-tight'>"
         + "".join(f"<li>{escape(reason)}</li>" for reason in item["reason_texts"])
         + "</ul>"

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -30,6 +30,7 @@ from ..ui.view_models import (
     build_truth_dashboard_payload,
     build_topic_overview_payload,
 )
+from ..truth_api import record_review_action
 
 _MARKDOWN_RENDERER = MarkdownIt("commonmark", {"breaks": True, "html": False}).enable("table")
 _FENCED_FRONTMATTER_RE = re.compile(r"^```ya?ml\s*\n---\n(.*?)\n---\n```\s*\n?", re.DOTALL)
@@ -566,6 +567,49 @@ def _render_review_context_card(context: dict[str, object], *, title: str = "Rev
     )
 
 
+def _render_review_history(items: list[dict[str, object]], *, title: str = "Review History") -> str:
+    if not items:
+        return (
+            "<section class='card'>"
+            f"<h2>{escape(title)}</h2>"
+            "<p class='muted'>No recent review actions recorded for this scope.</p>"
+            "</section>"
+        )
+    rows = "".join(
+        "<li>"
+        f"<span class='pill'>{escape(str(item['event_type']))}</span> "
+        f"{escape(str(item['timestamp']))}"
+        + (
+            f"<div class='muted'>Status: {escape(str(item['status']))}</div>"
+            if item.get("status")
+            else ""
+        )
+        + (
+            f"<div class='muted'>Note: {escape(str(item['note']))}</div>"
+            if item.get("note")
+            else ""
+        )
+        + (
+            f"<div class='muted'>Objects: {escape(', '.join(str(v) for v in item['object_ids']))}</div>"
+            if item.get("object_ids")
+            else ""
+        )
+        + (
+            f"<div class='muted'>Rebuilt: {escape(', '.join(str(v) for v in item['rebuilt_object_ids']))}</div>"
+            if item.get("rebuilt_object_ids")
+            else ""
+        )
+        + "</li>"
+        for item in items
+    )
+    return (
+        "<section class='card'>"
+        f"<h2>{escape(title)}</h2>"
+        f"<ul class='list-tight'>{rows}</ul>"
+        "</section>"
+    )
+
+
 def _render_dashboard(payload: dict) -> str:
     object_items = "".join(
         f'<li><a href="/object?id={escape(item["object_id"])}">{escape(item["title"])}</a></li>'
@@ -658,6 +702,11 @@ def _render_object_page(payload: dict) -> str:
         f'<li><span class="pill">{escape(item["status"])}</span>{escape(item["subject_key"])}</li>'
         for item in payload["contradictions"]
     ) or "<li>None</li>"
+    stale_summary_signals = "".join(
+        f"<li>{escape(reason)}</li>"
+        for item in payload["stale_summary_details"]
+        for reason in item["reason_texts"]
+    ) or "<li class='muted'>No stale summary signals for this object.</li>"
     source_notes = "".join(
         f'<li><a href="{escape(_note_href(item["path"]))}">{escape(item["title"])}</a> '
         f"<span class='muted'>({escape(item['note_type'])})</span></li>"
@@ -697,6 +746,7 @@ def _render_object_page(payload: dict) -> str:
             "</div>"
             "<div class='section-stack'>"
             f"{_render_review_context_card(payload['review_context'])}"
+            f"{_render_review_history(payload['review_history'])}"
             "<section class='card'><h2>Context</h2><dl class='meta-list'>"
             f"<div><dt>Object Kind</dt><dd>{escape(payload['context']['object_kind'])}</dd></div>"
             f"<div><dt>Source Slug</dt><dd>{escape(payload['context']['source_slug'])}</dd></div>"
@@ -709,6 +759,7 @@ def _render_object_page(payload: dict) -> str:
             "</dl></section>"
             f"<section id='relations' class='card'><h2>Relations</h2><ul class='list-tight'>{relations}</ul></section>"
             f"<section id='contradictions' class='card'><h2>Contradictions</h2><ul class='list-tight'>{contradictions}</ul></section>"
+            f"<section class='card'><h2>Stale Summary Signals</h2><ul class='list-tight'>{stale_summary_signals}</ul></section>"
             "</div>"
             "</section>"
         ),
@@ -741,6 +792,7 @@ def _render_topic_page(payload: dict) -> str:
             f"<section class='card'><h2>Neighbors</h2><ul class='list-tight'>{neighbors}</ul></section>"
             f"<section class='card'><h2>Atlas / MOC</h2><ul class='list-tight'>{mocs}</ul></section>"
             f"{_render_review_context_card(payload['review_context'])}"
+            f"{_render_review_history(payload['review_history'])}"
             "</section>"
         ),
     )
@@ -795,6 +847,7 @@ def _render_events_page(payload: dict) -> str:
             f"<p class='muted'>{payload['event_count']} events across {len(payload['dates'])} dates.</p>"
             f"<div class='link-row'>{type_breakdown}</div>"
             f"{_render_review_context_card(payload['review_context'])}"
+            f"{_render_review_history(payload['review_history'])}"
             f"<section class='card'><h2>Model Notes</h2><ul class='list-tight'>{model_notes}</ul></section>"
             f"<nav class='subnav'>{date_nav}</nav>"
             f"{events}"
@@ -899,6 +952,39 @@ def _render_contradictions_page(payload: dict) -> str:
         + f"<div class='muted'>Source Notes: {_render_named_note_links(item['provenance']['source_notes'])}</div>"
         + f"<div class='muted'>Atlas / MOC: {_render_named_note_links(item['provenance']['mocs'])}</div>"
         + (
+            "<details><summary>Claim Evidence</summary><ul class='list-tight'>"
+            + "".join(
+                f"<li>Positive: {escape(claim['claim_text'])} <span class='muted'>({escape(claim['object_title'])})</span></li>"
+                for claim in item["positive_claims"]
+            )
+            + "".join(
+                f"<li>Negative: {escape(claim['claim_text'])} <span class='muted'>({escape(claim['object_title'])})</span></li>"
+                for claim in item["negative_claims"]
+            )
+            + "</ul></details>"
+        )
+        + (
+            "<details><summary>Review History</summary><ul class='list-tight'>"
+            + "".join(
+                f"<li>{escape(str(history['timestamp']))} <span class='pill'>{escape(str(history['event_type']))}</span>"
+                + (
+                    f"<div class='muted'>Status: {escape(str(history['status']))}</div>"
+                    if history.get("status")
+                    else ""
+                )
+                + (
+                    f"<div class='muted'>Note: {escape(str(history['note']))}</div>"
+                    if history.get("note")
+                    else ""
+                )
+                + "</li>"
+                for history in item["review_history"]
+            )
+            + "</ul></details>"
+            if item["review_history"]
+            else ""
+        )
+        + (
             f"<div class='muted'>Resolution Note: {escape(item['resolution_note'])}</div>"
             if item.get("resolution_note")
             else ""
@@ -971,11 +1057,30 @@ def _render_stale_summaries_page(payload: dict) -> str:
         f"<span class='muted'>({escape(item['object_id'])})</span>"
         f"<div class='muted'>Summary: {escape(item['summary_text'])}</div>"
         f"<div class='muted'>Outgoing relations: {item['outgoing_relation_count']}</div>"
-        "<form method='post' action='/summaries/rebuild' class='link-row'>"
-        f"<input type='hidden' name='object_id' value='{escape(item['object_id'])}' />"
-        "<button type='submit'>Rebuild Summary</button>"
-        "</form>"
-        "</li>"
+        + "<ul class='list-tight'>"
+        + "".join(f"<li>{escape(reason)}</li>" for reason in item["reason_texts"])
+        + "</ul>"
+        + (
+            "<details><summary>Review History</summary><ul class='list-tight'>"
+            + "".join(
+                f"<li>{escape(str(history['timestamp']))} <span class='pill'>{escape(str(history['event_type']))}</span>"
+                + (
+                    f"<div class='muted'>Rebuilt: {escape(', '.join(str(v) for v in history['rebuilt_object_ids']))}</div>"
+                    if history.get("rebuilt_object_ids")
+                    else ""
+                )
+                + "</li>"
+                for history in item["review_history"]
+            )
+            + "</ul></details>"
+            if item["review_history"]
+            else ""
+        )
+        + "<form method='post' action='/summaries/rebuild' class='link-row'>"
+        + f"<input type='hidden' name='object_id' value='{escape(item['object_id'])}' />"
+        + "<button type='submit'>Rebuild Summary</button>"
+        + "</form>"
+        + "</li>"
         for item in payload["items"]
     ) or "<li class='muted'>No stale summaries detected.</li>"
     return _layout(
@@ -988,6 +1093,7 @@ def _render_stale_summaries_page(payload: dict) -> str:
             "</form>"
             f"<p class='muted'>{payload['count']} stale summary candidates.</p>"
             f"{_render_review_context_card(payload['review_context'])}"
+            f"{_render_review_history(payload['review_history'])}"
             f"<section class='card'><h2>Detection Notes</h2><ul class='list-tight'>{detection_notes}</ul></section>"
             "<section class='card'>"
             "<h2>Batch Rebuild</h2>"
@@ -1191,15 +1297,42 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
                 payload["rebuilt_summary_count"] = rebuild_payload["objects_rebuilt"]
                 payload["rebuilt_object_ids"] = rebuild_payload["object_ids"]
             else:
+                affected_object_ids = contradiction_object_ids(resolved_vault, payload["contradiction_ids"])
                 payload["rebuilt_summary_count"] = 0
                 payload["rebuilt_object_ids"] = []
+            if payload["resolved_count"]:
+                payload["object_ids"] = affected_object_ids
+                record_review_action(
+                    resolved_vault,
+                    event_type="ui_contradictions_resolved",
+                    slug=affected_object_ids[0] if affected_object_ids else "",
+                    payload={
+                        "object_ids": affected_object_ids,
+                        "contradiction_ids": payload["contradiction_ids"],
+                        "status": status,
+                        "note": note,
+                        "rebuilt_object_ids": payload["rebuilt_object_ids"],
+                    },
+                )
             return payload
 
         def _rebuild_summary_action(self, form: dict[str, list[str]]) -> dict[str, object]:
             object_ids = [item.strip() for item in self._form_all(form, "object_id") if item.strip()]
             if not object_ids:
                 raise ValueError("missing object_id")
-            return rebuild_compiled_summaries(resolved_vault, object_ids=object_ids)
+            payload = rebuild_compiled_summaries(resolved_vault, object_ids=object_ids)
+            if payload["objects_rebuilt"]:
+                record_review_action(
+                    resolved_vault,
+                    event_type="ui_summaries_rebuilt",
+                    slug=payload["object_ids"][0] if payload["object_ids"] else "",
+                    payload={
+                        "object_ids": payload["object_ids"],
+                        "objects_rebuilt": payload["objects_rebuilt"],
+                        "rebuilt_object_ids": payload["object_ids"],
+                    },
+                )
+            return payload
 
         def _write_json(self, payload: dict) -> None:
             body = json.dumps(payload, ensure_ascii=False).encode("utf-8")

--- a/src/openclaw_pipeline/knowledge_index.py
+++ b/src/openclaw_pipeline/knowledge_index.py
@@ -201,6 +201,7 @@ def _collect_audit_rows(layout: VaultLayout) -> list[tuple[str, str, str, str, s
     log_specs = [
         ("pipeline", layout.pipeline_log),
         ("refine", layout.logs_dir / "refine-mutations.jsonl"),
+        ("review-actions", layout.logs_dir / "review-actions.jsonl"),
     ]
     for source_log, path in log_specs:
         if not path.exists():

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -343,6 +343,34 @@ def _claim_details_map(vault_dir: Path | str, claim_ids: list[str]) -> dict[str,
     }
 
 
+def _claim_evidence_map(vault_dir: Path | str, claim_ids: list[str]) -> dict[str, list[dict[str, Any]]]:
+    normalized_claim_ids = list(dict.fromkeys(claim_id for claim_id in claim_ids if claim_id))
+    if not normalized_claim_ids:
+        return {}
+    db_path = _db_path(vault_dir)
+    placeholders = ",".join("?" for _ in normalized_claim_ids)
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            f"""
+            SELECT claim_id, source_slug, evidence_kind, quote_text
+            FROM claim_evidence
+            WHERE claim_id IN ({placeholders})
+            ORDER BY claim_id, source_slug, evidence_kind
+            """,
+            tuple(normalized_claim_ids),
+        ).fetchall()
+    evidence_map: dict[str, list[dict[str, Any]]] = {}
+    for claim_id, source_slug, evidence_kind, quote_text in rows:
+        evidence_map.setdefault(claim_id, []).append(
+            {
+                "source_slug": source_slug,
+                "evidence_kind": evidence_kind,
+                "quote_text": quote_text or "",
+            }
+        )
+    return evidence_map
+
+
 def list_objects(
     vault_dir: Path | str,
     *,
@@ -984,6 +1012,14 @@ def list_contradictions(
             for claim_id in (item["positive_claim_ids"] + item["negative_claim_ids"])
         ],
     )
+    evidence_map = _claim_evidence_map(
+        vault_dir,
+        [
+            claim_id
+            for item in items
+            for claim_id in (item["positive_claim_ids"] + item["negative_claim_ids"])
+        ],
+    )
     for item in items:
         object_ids = list(
             dict.fromkeys(
@@ -991,8 +1027,22 @@ def list_contradictions(
                 for claim_id in (item["positive_claim_ids"] + item["negative_claim_ids"])
             )
         )
-        item["positive_claims"] = [claim_map[claim_id] for claim_id in item["positive_claim_ids"] if claim_id in claim_map]
-        item["negative_claims"] = [claim_map[claim_id] for claim_id in item["negative_claim_ids"] if claim_id in claim_map]
+        item["positive_claims"] = [
+            {
+                **claim_map[claim_id],
+                "evidence": evidence_map.get(claim_id, []),
+            }
+            for claim_id in item["positive_claim_ids"]
+            if claim_id in claim_map
+        ]
+        item["negative_claims"] = [
+            {
+                **claim_map[claim_id],
+                "evidence": evidence_map.get(claim_id, []),
+            }
+            for claim_id in item["negative_claim_ids"]
+            if claim_id in claim_map
+        ]
         item["review_history"] = list_review_actions(vault_dir, object_ids=object_ids, limit=5)
     return items
 
@@ -1225,6 +1275,14 @@ def list_stale_summaries(
 
     with sqlite3.connect(db_path) as conn:
         rows = conn.execute(sql, tuple(params)).fetchall()
+        latest_event_rows = conn.execute(
+            """
+            SELECT slug, MAX(event_date)
+            FROM timeline_events
+            GROUP BY slug
+            """
+        ).fetchall()
+    latest_event_map = {str(slug): str(event_date or "") for slug, event_date in latest_event_rows}
 
     items: list[dict[str, Any]] = []
     for object_id, title, summary_text, outgoing_count in rows:
@@ -1254,6 +1312,7 @@ def list_stale_summaries(
                 "reason_codes": reason_codes,
                 "reason_texts": reason_texts,
                 "review_history": list_review_actions(vault_dir, object_ids=[str(object_id)], limit=5),
+                "latest_event_date": latest_event_map.get(str(object_id), ""),
             }
         )
     return items

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime
 import json
 import re
 import sqlite3
@@ -12,6 +13,7 @@ from .runtime import VaultLayout, resolve_vault_dir
 
 MAX_PAGE_SIZE = 500
 _FENCED_FRONTMATTER_RE = re.compile(r"^```ya?ml\s*\n---\n(.*?)\n---\n```\s*\n?", re.DOTALL)
+_REVIEW_AUDIT_LOG_NAME = "review-actions"
 
 
 def _db_path(vault_dir: Path | str) -> Path:
@@ -74,6 +76,51 @@ def _read_note_frontmatter(vault_dir: Path | str, relative_path: str) -> dict[st
     if not note_path.is_file():
         return {}
     return _parse_frontmatter(note_path.read_text(encoding="utf-8"))
+
+
+def _append_jsonl(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, ensure_ascii=False) + "\n")
+
+
+def record_review_action(
+    vault_dir: Path | str,
+    *,
+    event_type: str,
+    payload: dict[str, Any],
+    slug: str = "",
+    session_id: str = "ovp-ui",
+) -> dict[str, Any]:
+    resolved_vault = resolve_vault_dir(vault_dir)
+    layout = VaultLayout.from_vault(resolved_vault)
+    timestamp = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    event = {
+        "timestamp": timestamp,
+        "session_id": session_id,
+        "event_type": event_type,
+        "slug": slug,
+        **payload,
+    }
+    _append_jsonl(layout.logs_dir / f"{_REVIEW_AUDIT_LOG_NAME}.jsonl", event)
+    if layout.knowledge_db.exists():
+        with sqlite3.connect(layout.knowledge_db) as conn:
+            conn.execute(
+                """
+                INSERT INTO audit_events (source_log, event_type, slug, session_id, timestamp, payload_json)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    _REVIEW_AUDIT_LOG_NAME,
+                    event_type,
+                    slug,
+                    session_id,
+                    timestamp,
+                    json.dumps(event, ensure_ascii=False),
+                ),
+            )
+            conn.commit()
+    return event
 
 
 def _is_moc_row(note_type: str, path: str) -> bool:
@@ -167,6 +214,7 @@ def get_review_context(vault_dir: Path | str, object_ids: list[str]) -> dict[str
             "mocs": [],
             "stale_summary_object_ids": [],
             "contradiction_object_ids": [],
+            "recent_review_actions": [],
         }
 
     provenance_map = get_object_provenance_map(vault_dir, normalized_object_ids)
@@ -261,6 +309,37 @@ def get_review_context(vault_dir: Path | str, object_ids: list[str]) -> dict[str
         "mocs": list(mocs.values()),
         "stale_summary_object_ids": stale_summary_object_ids,
         "contradiction_object_ids": sorted(contradiction_object_ids),
+        "recent_review_actions": list_review_actions(vault_dir, object_ids=normalized_object_ids, limit=5),
+    }
+
+
+def _claim_details_map(vault_dir: Path | str, claim_ids: list[str]) -> dict[str, dict[str, Any]]:
+    normalized_claim_ids = list(dict.fromkeys(claim_id for claim_id in claim_ids if claim_id))
+    if not normalized_claim_ids:
+        return {}
+    db_path = _db_path(vault_dir)
+    placeholders = ",".join("?" for _ in normalized_claim_ids)
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            f"""
+            SELECT claims.claim_id, claims.object_id, objects.title, claims.claim_kind, claims.claim_text, claims.confidence
+            FROM claims
+            JOIN objects ON objects.object_id = claims.object_id
+            WHERE claims.claim_id IN ({placeholders})
+            ORDER BY claims.claim_id
+            """,
+            tuple(normalized_claim_ids),
+        ).fetchall()
+    return {
+        row[0]: {
+            "claim_id": row[0],
+            "object_id": row[1],
+            "object_title": row[2],
+            "claim_kind": row[3],
+            "claim_text": row[4],
+            "confidence": row[5],
+        }
+        for row in rows
     }
 
 
@@ -769,6 +848,67 @@ def _find_derived_notes_from_pipeline_log(vault_dir: Path, *, note_path: str) ->
     return derived
 
 
+def list_review_actions(
+    vault_dir: Path | str,
+    *,
+    object_ids: list[str] | None = None,
+    limit: int = 20,
+) -> list[dict[str, Any]]:
+    limit, _ = _validate_page_args(limit=limit, offset=0)
+    db_path = _db_path(vault_dir)
+    normalized_object_ids = set(object_id for object_id in (object_ids or []) if object_id)
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT source_log, event_type, slug, session_id, timestamp, payload_json
+            FROM audit_events
+            WHERE source_log = ?
+            ORDER BY timestamp DESC
+            LIMIT 200
+            """,
+            (_REVIEW_AUDIT_LOG_NAME,),
+        ).fetchall()
+    items: list[dict[str, Any]] = []
+    for source_log, event_type, slug, session_id, timestamp, payload_json in rows:
+        try:
+            payload = json.loads(payload_json)
+        except json.JSONDecodeError:
+            payload = {}
+        action_object_ids = [
+            str(value)
+            for value in payload.get("object_ids", [])
+            if isinstance(value, str) and value
+        ]
+        if normalized_object_ids and not normalized_object_ids.intersection(action_object_ids):
+            continue
+        items.append(
+            {
+                "source_log": source_log,
+                "event_type": event_type,
+                "slug": slug,
+                "session_id": session_id,
+                "timestamp": timestamp,
+                "object_ids": action_object_ids,
+                "contradiction_ids": [
+                    str(value)
+                    for value in payload.get("contradiction_ids", [])
+                    if isinstance(value, str) and value
+                ],
+                "status": str(payload.get("status") or ""),
+                "note": str(payload.get("note") or ""),
+                "rebuilt_object_ids": [
+                    str(value)
+                    for value in payload.get("rebuilt_object_ids", [])
+                    if isinstance(value, str) and value
+                ],
+                "objects_rebuilt": int(payload.get("objects_rebuilt") or 0),
+            }
+        )
+        if len(items) >= limit:
+            break
+    return items
+
+
 def get_note_provenance(vault_dir: Path | str, *, note_path: str) -> dict[str, Any]:
     resolved_vault = resolve_vault_dir(vault_dir)
     frontmatter = _read_note_frontmatter(resolved_vault, note_path)
@@ -824,7 +964,7 @@ def list_contradictions(
     with sqlite3.connect(db_path) as conn:
         rows = conn.execute(query, tuple(params)).fetchall()
 
-    return [
+    items = [
         {
             "contradiction_id": row[0],
             "subject_key": row[1],
@@ -836,6 +976,25 @@ def list_contradictions(
         }
         for row in rows
     ]
+    claim_map = _claim_details_map(
+        vault_dir,
+        [
+            claim_id
+            for item in items
+            for claim_id in (item["positive_claim_ids"] + item["negative_claim_ids"])
+        ],
+    )
+    for item in items:
+        object_ids = list(
+            dict.fromkeys(
+                claim_id.split("::", 1)[0]
+                for claim_id in (item["positive_claim_ids"] + item["negative_claim_ids"])
+            )
+        )
+        item["positive_claims"] = [claim_map[claim_id] for claim_id in item["positive_claim_ids"] if claim_id in claim_map]
+        item["negative_claims"] = [claim_map[claim_id] for claim_id in item["negative_claim_ids"] if claim_id in claim_map]
+        item["review_history"] = list_review_actions(vault_dir, object_ids=object_ids, limit=5)
+    return items
 
 
 def get_topic_neighborhood(vault_dir: Path | str, object_id: str, *, depth: int = 1) -> dict[str, Any]:
@@ -1074,6 +1233,17 @@ def list_stale_summaries(
             continue
         if len(summary) >= 40 and summary.lower() != str(title).strip().lower():
             continue
+        reason_codes: list[str] = ["no_outgoing_relations"]
+        reason_texts: list[str] = ["No outgoing relations currently support this summary."]
+        if not summary:
+            reason_codes.append("summary_missing")
+            reason_texts.append("Compiled summary is empty.")
+        elif len(summary) < 40:
+            reason_codes.append("summary_too_short")
+            reason_texts.append("Compiled summary is too short to stand on its own.")
+        if summary and summary.lower() == str(title).strip().lower():
+            reason_codes.append("summary_repeats_title")
+            reason_texts.append("Compiled summary repeats the title instead of adding substance.")
         items.append(
             {
                 "object_id": str(object_id),
@@ -1081,6 +1251,9 @@ def list_stale_summaries(
                 "summary_text": summary,
                 "outgoing_relation_count": int(outgoing_count or 0),
                 "object_path": f"/object?id={object_id}",
+                "reason_codes": reason_codes,
+                "reason_texts": reason_texts,
+                "review_history": list_review_actions(vault_dir, object_ids=[str(object_id)], limit=5),
             }
         )
     return items

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -69,6 +69,9 @@ def build_object_page_payload(vault_dir: Path | str, object_id: str) -> dict[str
         "review_context": review_context,
         "review_history": list_review_actions(vault_dir, object_ids=[object_id], limit=8),
         "stale_summary_details": list_stale_summaries(vault_dir, object_ids=[object_id], limit=10),
+        "open_contradiction_ids": [
+            item["contradiction_id"] for item in detail["contradictions"] if item["status"] == "open"
+        ],
         "links": {
             "topic_path": f"/topic?id={object_id}",
             "events_path": f"/events?q={object_id}",
@@ -87,10 +90,19 @@ def build_object_page_payload(vault_dir: Path | str, object_id: str) -> dict[str
 def build_topic_overview_payload(vault_dir: Path | str, object_id: str) -> dict[str, Any]:
     neighborhood = get_topic_neighborhood(vault_dir, object_id)
     detail = get_object_detail(vault_dir, object_id)
+    scoped_object_ids = [object_id, *[item["object_id"] for item in neighborhood["neighbors"]]]
     review_context = get_review_context(
         vault_dir,
-        [object_id, *[item["object_id"] for item in neighborhood["neighbors"]]],
+        scoped_object_ids,
     )
+    scoped_stale_summaries = list_stale_summaries(vault_dir, object_ids=scoped_object_ids, limit=50)
+    scoped_contradictions = [
+        item
+        for item in list_contradictions(vault_dir, limit=100)
+        if set(item["positive_claim_ids"] + item["negative_claim_ids"])
+        and any(claim_id.split("::", 1)[0] in set(scoped_object_ids) for claim_id in item["positive_claim_ids"] + item["negative_claim_ids"])
+        and item["status"] == "open"
+    ]
     return {
         "screen": "overview/topic",
         **neighborhood,
@@ -101,9 +113,12 @@ def build_topic_overview_payload(vault_dir: Path | str, object_id: str) -> dict[
         "review_context": review_context,
         "review_history": list_review_actions(
             vault_dir,
-            object_ids=[object_id, *[item["object_id"] for item in neighborhood["neighbors"]]],
+            object_ids=scoped_object_ids,
             limit=8,
         ),
+        "scoped_object_ids": scoped_object_ids,
+        "scoped_stale_summary_ids": [item["object_id"] for item in scoped_stale_summaries],
+        "scoped_open_contradiction_ids": [item["contradiction_id"] for item in scoped_contradictions],
         "links": {
             "center_object_path": f"/object?id={object_id}",
             "events_path": f"/events?q={object_id}",
@@ -165,7 +180,15 @@ def build_event_dossier_payload(
         for row in rows
     ]
     provenance_map = get_object_provenance_map(vault_dir, [event["object_id"] for event in events])
-    review_context = get_review_context(vault_dir, [event["object_id"] for event in events])
+    scoped_object_ids = [event["object_id"] for event in events]
+    review_context = get_review_context(vault_dir, scoped_object_ids)
+    scoped_stale_summaries = list_stale_summaries(vault_dir, object_ids=scoped_object_ids, limit=100)
+    scoped_contradictions = [
+        item
+        for item in list_contradictions(vault_dir, limit=200)
+        if any(claim_id.split("::", 1)[0] in set(scoped_object_ids) for claim_id in item["positive_claim_ids"] + item["negative_claim_ids"])
+        and item["status"] == "open"
+    ]
     for event in events:
         event["object_path"] = f"/object?id={event['object_id']}"
         event["review_links"] = {
@@ -192,7 +215,10 @@ def build_event_dossier_payload(
         "date_sections": date_sections,
         "event_type_counts": dict(event_type_counts),
         "review_context": review_context,
-        "review_history": list_review_actions(vault_dir, object_ids=[event["object_id"] for event in events], limit=8),
+        "review_history": list_review_actions(vault_dir, object_ids=scoped_object_ids, limit=8),
+        "scoped_object_ids": list(dict.fromkeys(scoped_object_ids)),
+        "scoped_stale_summary_ids": [item["object_id"] for item in scoped_stale_summaries],
+        "scoped_open_contradiction_ids": [item["contradiction_id"] for item in scoped_contradictions],
         "model_notes": [
             "Event Dossier is a timeline over dated notes projected from indexed pages, not a separate event entity system.",
             "page_date rows come from note-level dates; heading_date rows come from dated section headings.",
@@ -269,6 +295,25 @@ def build_truth_dashboard_payload(vault_dir: Path | str) -> dict[str, Any]:
     contradictions = build_contradiction_browser_payload(vault_dir)
     events = build_event_dossier_payload(vault_dir, limit=8)
     stale_summaries = build_stale_summary_browser_payload(vault_dir)
+    priorities: list[dict[str, Any]] = []
+    for item in contradictions["items"][:4]:
+        priorities.append(
+            {
+                "kind": "contradiction",
+                "label": item["subject_key"],
+                "path": f"/contradictions?q={item['subject_key']}",
+                "detail": f"{len(item['object_ids'])} objects in scope",
+            }
+        )
+    for item in stale_summaries["items"][:4]:
+        priorities.append(
+            {
+                "kind": "stale_summary",
+                "label": item["title"],
+                "path": item["object_path"],
+                "detail": ", ".join(item["reason_codes"]),
+            }
+        )
     return {
         "screen": "truth/dashboard",
         "objects": {
@@ -289,6 +334,8 @@ def build_truth_dashboard_payload(vault_dir: Path | str) -> dict[str, Any]:
             "count": stale_summaries["count"],
             "items": stale_summaries["items"][:8],
         },
+        "recent_review_actions": list_review_actions(vault_dir, limit=8),
+        "priorities": priorities[:8],
     }
 
 

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -13,6 +13,7 @@ from ..truth_api import (
     get_object_provenance_map,
     get_review_context,
     get_topic_neighborhood,
+    list_review_actions,
     list_atlas_memberships,
     list_contradictions,
     list_deep_dive_derivations,
@@ -66,6 +67,8 @@ def build_object_page_payload(vault_dir: Path | str, object_id: str) -> dict[str
         },
         "provenance": detail["provenance"],
         "review_context": review_context,
+        "review_history": list_review_actions(vault_dir, object_ids=[object_id], limit=8),
+        "stale_summary_details": list_stale_summaries(vault_dir, object_ids=[object_id], limit=10),
         "links": {
             "topic_path": f"/topic?id={object_id}",
             "events_path": f"/events?q={object_id}",
@@ -96,6 +99,11 @@ def build_topic_overview_payload(vault_dir: Path | str, object_id: str) -> dict[
         "center_summary": detail["summary"]["summary_text"] if detail["summary"] else "",
         "provenance": detail["provenance"],
         "review_context": review_context,
+        "review_history": list_review_actions(
+            vault_dir,
+            object_ids=[object_id, *[item["object_id"] for item in neighborhood["neighbors"]]],
+            limit=8,
+        ),
         "links": {
             "center_object_path": f"/object?id={object_id}",
             "events_path": f"/events?q={object_id}",
@@ -184,6 +192,7 @@ def build_event_dossier_payload(
         "date_sections": date_sections,
         "event_type_counts": dict(event_type_counts),
         "review_context": review_context,
+        "review_history": list_review_actions(vault_dir, object_ids=[event["object_id"] for event in events], limit=8),
         "model_notes": [
             "Event Dossier is a timeline over dated notes projected from indexed pages, not a separate event entity system.",
             "page_date rows come from note-level dates; heading_date rows come from dated section headings.",
@@ -352,6 +361,7 @@ def build_stale_summary_browser_payload(vault_dir: Path | str, *, query: str | N
         "count": len(items),
         "query": query or "",
         "review_context": review_context,
+        "review_history": list_review_actions(vault_dir, object_ids=[item["object_id"] for item in items], limit=8),
         "detection_notes": [
             "Stale summary review flags compiled summaries that are weak and have no outgoing supporting relations.",
             "This queue is deterministic and favors false negatives over false positives.",

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -239,7 +239,18 @@ def test_ui_server_can_resolve_contradiction_via_api(temp_vault):
             "SELECT status, resolution_note FROM contradictions WHERE contradiction_id = ?",
             (contradiction_id,),
         ).fetchone()
+        audit_row = conn.execute(
+            """
+            SELECT event_type, payload_json
+            FROM audit_events
+            WHERE source_log = 'review-actions'
+            ORDER BY timestamp DESC
+            LIMIT 1
+            """
+        ).fetchone()
     assert row == ("resolved_keep_positive", "Reviewed in UI")
+    assert audit_row is not None
+    assert audit_row[0] == "ui_contradictions_resolved"
 
 
 def test_ui_server_can_bulk_resolve_contradictions_via_api(temp_vault):
@@ -358,6 +369,18 @@ Thin note.
     assert response.status == 200
     assert payload["objects_rebuilt"] == 1
     assert payload["object_ids"] == ["thin-note"]
+    with sqlite3.connect(VaultLayout.from_vault(temp_vault).knowledge_db) as conn:
+        audit_row = conn.execute(
+            """
+            SELECT event_type, payload_json
+            FROM audit_events
+            WHERE source_log = 'review-actions'
+            ORDER BY timestamp DESC
+            LIMIT 1
+            """
+        ).fetchone()
+    assert audit_row is not None
+    assert audit_row[0] == "ui_summaries_rebuilt"
 
 
 def test_ui_server_can_bulk_rebuild_summaries_via_api(temp_vault):

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -208,6 +208,7 @@ date: 2026-04-13
     assert "Source Deep Dive" in contradictions_body
     assert "Atlas Index" in contradictions_body
     assert "Detection Notes" in contradictions_body
+    assert "Claim Evidence" in contradictions_body
 
 
 def test_ui_note_page_renders_markdown_note(temp_vault):

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -913,6 +913,7 @@ def test_ui_contradictions_page_can_resolve_item(temp_vault):
             },
         )
         page_status, page_body = _get(port, "/contradictions?status=resolved")
+        object_status, object_body = _get(port, "/object?id=alpha")
     finally:
         server.shutdown()
         server.server_close()
@@ -923,6 +924,9 @@ def test_ui_contradictions_page_can_resolve_item(temp_vault):
     assert page_status == 200
     assert "resolved_keep_positive" in page_body
     assert "Reviewed in browser" in page_body
+    assert object_status == 200
+    assert "Review History" in object_body
+    assert "ui_contradictions_resolved" in object_body
 
 
 def test_ui_summaries_page_can_rebuild_item(temp_vault):
@@ -965,6 +969,7 @@ Thin note.
             {"object_id": "thin-note"},
         )
         after_status, after_body = _get(port, "/summaries")
+        object_status, object_body = _get(port, "/object?id=thin-note")
     finally:
         server.shutdown()
         server.server_close()
@@ -977,6 +982,10 @@ Thin note.
     assert headers["location"] == "/summaries"
     assert after_status == 200
     assert "Thin note." in after_body
+    assert "No outgoing relations currently support this summary." in before_body
+    assert object_status == 200
+    assert "Review History" in object_body
+    assert "ui_summaries_rebuilt" in object_body
 
 
 def test_ui_events_page_filters_by_query(temp_vault):

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -165,6 +165,8 @@ date: 2026-04-13
     assert "Review Context" in object_body
     assert "Open contradictions" in object_body
     assert "/summaries?q=alpha" in object_body
+    assert "Quick Maintenance" in object_body
+    assert "Resolve Open Contradictions" in object_body
     assert f"/note?path={quote('10-Knowledge/Evergreen/Alpha.md', safe='')}" in object_body
     assert f"/note?path={quote('20-Areas/Tools/Topics/2026-04/Source Deep Dive_深度解读.md', safe='')}" in object_body
     assert f"/note?path={quote('10-Knowledge/Atlas/Atlas-Index.md', safe='')}" in object_body
@@ -178,6 +180,8 @@ date: 2026-04-13
     assert "Atlas / MOC" in topic_body
     assert "Review Context" in topic_body
     assert "/summaries?q=alpha" in topic_body
+    assert "Quick Maintenance" in topic_body
+    assert "Review scoped contradictions" in topic_body
 
     assert events_status == 200
     assert "Event Dossier" in events_body
@@ -188,6 +192,8 @@ date: 2026-04-13
     assert "Model Notes" in events_body
     assert "Review Context" in events_body
     assert "/summaries?q=alpha" in events_body
+    assert "Quick Maintenance" in events_body
+    assert "Review visible contradictions" in events_body
     assert "page_date -" not in events_body
     assert "Source Deep Dive" in events_body
     assert "Atlas Index" in events_body
@@ -748,6 +754,7 @@ Thin note.
     assert "Contradictions Open" in root_body
     assert "Recent Events" in root_body
     assert "Stale Summaries" in root_body
+    assert "Needs Attention Now" in root_body
     assert "Alpha" in root_body
     assert "Thin Note" in root_body
     assert "/summaries" in root_body

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -95,6 +95,8 @@ def test_build_object_page_payload(temp_vault):
     assert payload["review_context"]["object_count"] == 1
     assert payload["review_context"]["open_contradiction_count"] == 1
     assert payload["review_context"]["latest_event_date"] == "2026-04-13"
+    assert payload["review_history"] == []
+    assert payload["stale_summary_details"] == []
 
 
 def test_build_object_page_payload_includes_provenance(temp_vault):
@@ -172,6 +174,7 @@ def test_build_topic_overview_payload(temp_vault):
     assert payload["links"]["summaries_path"] == "/summaries?q=alpha"
     assert payload["review_context"]["object_count"] == 2
     assert payload["review_context"]["open_contradiction_count"] == 1
+    assert payload["review_history"] == []
 
 
 def test_build_event_dossier_payload(temp_vault):
@@ -194,6 +197,7 @@ def test_build_event_dossier_payload(temp_vault):
     assert payload["review_context"]["open_contradiction_count"] == 1
     assert payload["events"][0]["review_links"]["contradictions_path"] == "/contradictions?q=alpha"
     assert payload["events"][0]["review_links"]["summaries_path"] == "/summaries?q=alpha"
+    assert payload["review_history"] == []
 
 
 def test_build_event_dossier_payload_includes_provenance(temp_vault):
@@ -543,8 +547,32 @@ Thin note.
     assert payload["screen"] == "truth/stale-summaries"
     assert payload["count"] == 1
     assert payload["items"][0]["object_id"] == "thin-note"
-    assert payload["items"][0]["summary_text"] == "Thin note."
-    assert "compiled summaries that are weak" in payload["detection_notes"][0]
+    assert "summary_too_short" in payload["items"][0]["reason_codes"]
+    assert payload["review_history"] == []
+
+
+def test_build_object_page_payload_includes_review_history(temp_vault):
+    from openclaw_pipeline.truth_api import record_review_action
+    from openclaw_pipeline.ui.view_models import build_object_page_payload
+
+    _seed_truth_store(temp_vault)
+    record_review_action(
+        temp_vault,
+        event_type="ui_contradictions_resolved",
+        slug="alpha",
+        payload={
+            "object_ids": ["alpha"],
+            "contradiction_ids": ["contradiction::alpha"],
+            "status": "resolved_keep_positive",
+            "note": "Reviewed in UI",
+            "rebuilt_object_ids": ["alpha"],
+        },
+    )
+
+    payload = build_object_page_payload(temp_vault, "alpha")
+
+    assert payload["review_history"][0]["event_type"] == "ui_contradictions_resolved"
+    assert payload["review_history"][0]["note"] == "Reviewed in UI"
 
 
 def test_build_stale_summary_browser_payload_includes_review_context(temp_vault):

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -355,6 +355,7 @@ date: 2026-04-13
     assert item["object_titles"] == {"alpha": "Alpha", "conflict": "Conflict"}
     assert item["provenance"]["source_notes"][0]["slug"] == "source-deep-dive"
     assert item["provenance"]["mocs"][0]["slug"] == "atlas-index"
+    assert item["positive_claims"][0]["evidence"]
 
 
 def test_build_truth_dashboard_payload(temp_vault):
@@ -553,6 +554,7 @@ Thin note.
     assert payload["count"] == 1
     assert payload["items"][0]["object_id"] == "thin-note"
     assert "summary_too_short" in payload["items"][0]["reason_codes"]
+    assert payload["items"][0]["latest_event_date"] == "2026-04-10"
     assert payload["review_history"] == []
 
 

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -175,6 +175,8 @@ def test_build_topic_overview_payload(temp_vault):
     assert payload["review_context"]["object_count"] == 2
     assert payload["review_context"]["open_contradiction_count"] == 1
     assert payload["review_history"] == []
+    assert payload["scoped_open_contradiction_ids"]
+    assert payload["scoped_stale_summary_ids"] == ["beta"]
 
 
 def test_build_event_dossier_payload(temp_vault):
@@ -198,6 +200,7 @@ def test_build_event_dossier_payload(temp_vault):
     assert payload["events"][0]["review_links"]["contradictions_path"] == "/contradictions?q=alpha"
     assert payload["events"][0]["review_links"]["summaries_path"] == "/summaries?q=alpha"
     assert payload["review_history"] == []
+    assert payload["scoped_open_contradiction_ids"]
 
 
 def test_build_event_dossier_payload_includes_provenance(temp_vault):
@@ -384,6 +387,8 @@ Thin note.
     assert payload["stale_summaries"]["count"] >= 1
     assert "thin-note" in [item["object_id"] for item in payload["stale_summaries"]["items"]]
     assert payload["objects"]["items"][0]["object_id"] == "alpha"
+    assert payload["priorities"]
+    assert payload["recent_review_actions"] == []
 
 
 def test_build_truth_dashboard_payload_uses_total_object_count(temp_vault):
@@ -573,6 +578,17 @@ def test_build_object_page_payload_includes_review_history(temp_vault):
 
     assert payload["review_history"][0]["event_type"] == "ui_contradictions_resolved"
     assert payload["review_history"][0]["note"] == "Reviewed in UI"
+
+
+def test_build_object_page_payload_exposes_quick_maintenance_state(temp_vault):
+    from openclaw_pipeline.ui.view_models import build_object_page_payload
+
+    _seed_truth_store(temp_vault)
+
+    payload = build_object_page_payload(temp_vault, "alpha")
+
+    assert payload["open_contradiction_ids"]
+    assert payload["stale_summary_details"] == []
 
 
 def test_build_stale_summary_browser_payload_includes_review_context(temp_vault):


### PR DESCRIPTION
## Summary
- add review audit trail persistence and render review history across truth UI surfaces
- add scoped maintenance entry points on object, topic, and event pages plus dashboard prioritization
- enrich contradiction evidence trails and stale-summary rationale/timing context

## Verification
- `PYTHONPATH=src python3.13 -m pytest -q tests/test_ui_view_models.py tests/test_ui_server.py tests/test_ui_smoke.py`
- `PYTHONPATH=src python3.13 -m pytest -q`
- `python3.13 -m compileall src/openclaw_pipeline`

## Scope
This PR contains exactly these three commits:
- `35a93f7` `feat: add phase 9 review audit trail`
- `79238cd` `feat: add scoped review actions and priorities`
- `33c993f` `feat: enrich review evidence trails`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/16" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Recent Review Actions" audit trail sections to dashboard and detail pages
  * Added "Quick Maintenance" sections on object, topic, and event pages for direct access to contradiction resolution and summary rebuild actions
  * Added "Needs Attention Now" priority items to the dashboard
  * Enhanced contradictions page with detailed claim evidence display and review history
  * Enhanced stale summaries page with reason codes and review history

<!-- end of auto-generated comment: release notes by coderabbit.ai -->