### PR TITLE
feat: add knowledge production traceability surfaces

### DIFF
--- a/docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
+++ b/docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
@@ -267,6 +267,12 @@ Core deliverables:
 - object derivation summaries
 - Atlas/topic rollups that explain knowledge contribution, not just membership
 
+Current progress:
+
+- `Production Chain` is visible on `note` and `object` pages
+- `/atlas` and `/deep-dives` show contribution summaries
+- `/production` exists as a provenance-first aggregate browser over source notes and deep dives
+
 Exit condition:
 
 - users can answer “where did this knowledge come from?” and “what did this note produce?” from the product itself

--- a/docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
+++ b/docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
@@ -248,7 +248,7 @@ Exit condition:
 
 ### Milestone 5: Knowledge Production Traceability
 
-Status: **Not Started**
+Status: **In Progress**
 
 Goal:
 
@@ -485,7 +485,7 @@ As of this plan:
 - Milestone 2: complete
 - Milestone 3: complete
 - Milestone 4: in progress
-- Milestone 5: not started
+- Milestone 5: in progress
 - Milestone 6: not started
 - Milestone 7+: not started
 

--- a/docs/plans/2026-04-14-phase11-knowledge-production-traceability.md
+++ b/docs/plans/2026-04-14-phase11-knowledge-production-traceability.md
@@ -107,8 +107,8 @@ Completed so far:
 - a new `/production` browser for source/deep-dive chain traversal,
 - `Production Contribution` summaries on `/topic` and `/events`,
 - aggregate chain-gap signals such as missing source notes, missing deep dives, and missing Atlas reach.
+- dashboard and `/production` now surface vault-wide production weak points so users can prioritize which chains to repair first.
 
 Remaining work in Phase 11:
 
-- stronger prioritization around which chains are incomplete or weak across the whole vault,
 - eventual promotion from traceability browser to full production intelligence.

--- a/docs/plans/2026-04-14-phase11-knowledge-production-traceability.md
+++ b/docs/plans/2026-04-14-phase11-knowledge-production-traceability.md
@@ -58,9 +58,17 @@ The user should not need to learn a new route before they can understand product
 
 ### Slice C: Traceability Browser Follow-Up
 
-After stable payloads exist on note/object pages, add a dedicated traceability browser only if the embedded views prove insufficient.
+After stable payloads exist on note/object pages, add dedicated aggregate browsers where they materially improve operator understanding:
 
-This is explicitly later. The first job is to make the production chain visible where users already are.
+- Atlas contribution summaries
+- Deep-dive contribution summaries
+- a production browser spanning:
+  - source note
+  - deep dive
+  - downstream objects
+  - downstream Atlas/MOC reach
+
+This browser should stay provenance-first. It is not a graph view and it should not invent links from loose mentions.
 
 ## Non-Goals
 
@@ -85,5 +93,21 @@ Phase 11 reaches its first checkpoint when:
 1. Add failing tests for note/object production-chain payloads.
 2. Implement minimal `truth_api` helpers over current data sources.
 3. Surface the chain on `/note` and `/object`.
-4. Run focused UI tests.
-5. Run full `pytest` and `compileall`.
+4. Add aggregate browsers for `/atlas`, `/deep-dives`, and `/production`.
+5. Run focused UI tests.
+6. Run full `pytest` and `compileall`.
+
+## Current Checkpoint
+
+Completed so far:
+
+- stable `get_note_traceability()` and `get_object_traceability()` payloads,
+- `Production Chain` sections on `/note` and `/object`,
+- contribution summaries on `/atlas` and `/deep-dives`,
+- a new `/production` browser for source/deep-dive chain traversal.
+
+Remaining work in Phase 11:
+
+- richer chain summaries on topic/event surfaces,
+- stronger prioritization around which chains are incomplete or weak,
+- eventual promotion from traceability browser to full production intelligence.

--- a/docs/plans/2026-04-14-phase11-knowledge-production-traceability.md
+++ b/docs/plans/2026-04-14-phase11-knowledge-production-traceability.md
@@ -1,0 +1,89 @@
+# Phase 11: Knowledge Production Traceability
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make the full knowledge production chain legible from the product itself: source note -> processed note -> deep dive -> evergreen object -> Atlas/MOC placement.
+
+**Architecture:** Reuse the current vault-first architecture. Do not introduce a separate provenance database or new ontology layer. Instead, compute stable production-chain payloads from existing sources: `pages_index`, `page_links`, `objects`, `audit_events`, and the current note/object provenance helpers. Surface those payloads first on existing `note` and `object` pages before adding any new dedicated browser.
+
+**Tech Stack:** Python 3.13, SQLite via stdlib `sqlite3`, `truth_api.py`, `ui/view_models.py`, `commands/ui_server.py`, `knowledge_index.py`, pytest.
+
+## Problem
+
+The product already lets users move between notes, deep dives, objects, and Atlas pages, but it still makes them mentally reconstruct the production chain themselves.
+
+Today a user can often answer:
+
+- “what is this object?”
+- “which deep dives mention it?”
+- “which MOC links to it?”
+
+But the product still makes it too hard to answer:
+
+- “what did this source note actually produce?”
+- “which deep dive promoted this object?”
+- “which Atlas pages are downstream of this note?”
+- “where in the chain am I right now?”
+
+That is the next major gap between a good local browser and a real knowledge workbench.
+
+## Scope
+
+### Slice A: Stable Production Chain Payloads
+
+Add explicit production-chain payloads for the most important surfaces:
+
+- `get_note_traceability()`
+- `get_object_traceability()`
+
+They should expose, in stable fields:
+
+- current artifact
+- upstream source notes
+- deep dives
+- derived objects
+- downstream Atlas/MOC reach
+- simple counts for each stage
+
+This slice is about trustworthy chain shape, not yet richer ranking.
+
+### Slice B: Product Rendering On Existing Pages
+
+Render the new traceability payloads directly on:
+
+- `/note`
+- `/object`
+
+The user should not need to learn a new route before they can understand production flow.
+
+### Slice C: Traceability Browser Follow-Up
+
+After stable payloads exist on note/object pages, add a dedicated traceability browser only if the embedded views prove insufficient.
+
+This is explicitly later. The first job is to make the production chain visible where users already are.
+
+## Non-Goals
+
+- no new graph visualization,
+- no hosted product shell,
+- no new extraction algorithm,
+- no background briefing system,
+- no evolution links yet,
+- no rewrite of `knowledge_index`.
+
+## Exit Criteria
+
+Phase 11 reaches its first checkpoint when:
+
+1. source notes and deep dives can show what they produced,
+2. objects can show which source notes and deep dives produced them,
+3. downstream Atlas/MOC reach is visible from the same surface,
+4. users no longer have to manually infer the chain from multiple disconnected pages.
+
+## Execution Order
+
+1. Add failing tests for note/object production-chain payloads.
+2. Implement minimal `truth_api` helpers over current data sources.
+3. Surface the chain on `/note` and `/object`.
+4. Run focused UI tests.
+5. Run full `pytest` and `compileall`.

--- a/docs/plans/2026-04-14-phase11-knowledge-production-traceability.md
+++ b/docs/plans/2026-04-14-phase11-knowledge-production-traceability.md
@@ -104,10 +104,11 @@ Completed so far:
 - stable `get_note_traceability()` and `get_object_traceability()` payloads,
 - `Production Chain` sections on `/note` and `/object`,
 - contribution summaries on `/atlas` and `/deep-dives`,
-- a new `/production` browser for source/deep-dive chain traversal.
+- a new `/production` browser for source/deep-dive chain traversal,
+- `Production Contribution` summaries on `/topic` and `/events`,
+- aggregate chain-gap signals such as missing source notes, missing deep dives, and missing Atlas reach.
 
 Remaining work in Phase 11:
 
-- richer chain summaries on topic/event surfaces,
-- stronger prioritization around which chains are incomplete or weak,
+- stronger prioritization around which chains are incomplete or weak across the whole vault,
 - eventual promotion from traceability browser to full production intelligence.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "obsidian-vault-pipeline"
-version = "0.8.4"
+version = "0.8.5"
 description = "全自动Obsidian知识管理Pipeline - 生产级知识管理流水线"
 readme = "README.md"
 license = "MIT"

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -465,9 +465,11 @@ def _render_note_page(vault_dir: Path, relative_path: str, markdown: str, payloa
     frontmatter_html, note_html = _render_markdown_note(vault_dir, markdown)
     source_note = None
     derived_notes: list[dict[str, str]] = []
+    production_chain = None
     if payload:
         source_note = payload.get("provenance", {}).get("original_source_note")
         derived_notes = payload.get("provenance", {}).get("derived_deep_dives", [])
+        production_chain = payload.get("production_chain")
     provenance_html = ""
     if source_note:
         provenance_html = (
@@ -493,6 +495,20 @@ def _render_note_page(vault_dir: Path, relative_path: str, markdown: str, payloa
             f"<ul class='list-tight'>{derived_list}</ul>"
             "</section>"
         )
+    production_chain_html = ""
+    if production_chain:
+        production_chain_html = (
+            "<section class='card'>"
+            "<h2>Production Chain</h2>"
+            "<dl class='meta-list'>"
+            f"<div><dt>Current Note</dt><dd>{escape(production_chain['note']['title'])}<div class='muted'>{escape(production_chain['note']['path'])}</div></dd></div>"
+            f"<div><dt>Source Notes</dt><dd>{_render_named_note_links(production_chain['source_notes'])}</dd></div>"
+            f"<div><dt>Deep Dives</dt><dd>{_render_named_note_links(production_chain['deep_dives'])}</dd></div>"
+            f"<div><dt>Derived Objects</dt><dd>{_render_object_links(production_chain['objects'])}</dd></div>"
+            f"<div><dt>Atlas / MOC Reach</dt><dd>{_render_named_note_links(production_chain['atlas_pages'])}</dd></div>"
+            "</dl>"
+            "</section>"
+        )
     return _layout(
         f"Markdown Note: {relative_path}",
         (
@@ -502,6 +518,7 @@ def _render_note_page(vault_dir: Path, relative_path: str, markdown: str, payloa
             "</section>"
             f"{frontmatter_html}"
             f"{provenance_html}"
+            f"{production_chain_html}"
             f"<section class='card'>{note_html}</section>"
         ),
     )
@@ -541,6 +558,15 @@ def _render_named_note_links(items: list[dict[str, str]]) -> str:
         return "<span class='muted'>None</span>"
     return ", ".join(
         f'<a href="{escape(_note_href(item["path"]))}">{escape(item["title"])}</a>' for item in items
+    )
+
+
+def _render_object_links(items: list[dict[str, str]]) -> str:
+    if not items:
+        return "<span class='muted'>None</span>"
+    return ", ".join(
+        f'<a href="/object?id={escape(item["object_id"])}">{escape(item["title"])}</a>'
+        for item in items
     )
 
 
@@ -797,6 +823,12 @@ def _render_object_page(payload: dict) -> str:
             f"<div><dt>Evergreen Markdown</dt><dd>{evergreen_html}</dd></div>"
             f"<div><dt>Source Notes</dt><dd><ul class='list-tight'>{source_notes}</ul></dd></div>"
             f"<div><dt>Atlas / MOC</dt><dd><ul class='list-tight'>{mocs}</ul></dd></div>"
+            "</dl></section>"
+            "<section class='card'><h2>Production Chain</h2><dl class='meta-list'>"
+            f"<div><dt>Source Notes</dt><dd>{_render_named_note_links(payload['production_chain']['source_notes'])}</dd></div>"
+            f"<div><dt>Source Deep Dives</dt><dd>{_render_named_note_links(payload['production_chain']['deep_dives'])}</dd></div>"
+            f"<div><dt>Evergreen Note</dt><dd>{evergreen_html}</dd></div>"
+            f"<div><dt>Atlas / MOC Reach</dt><dd>{_render_named_note_links(payload['production_chain']['atlas_pages'])}</dd></div>"
             "</dl></section>"
             f"<section id='relations' class='card'><h2>Relations</h2><ul class='list-tight'>{relations}</ul></section>"
             f"<section id='contradictions' class='card'><h2>Contradictions</h2><ul class='list-tight'>{contradictions}</ul></section>"

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -684,6 +684,12 @@ def _render_dashboard(payload: dict) -> str:
         f"<span class='muted'>({escape(item['summary_text'])})</span></li>"
         for item in payload["stale_summaries"]["items"]
     ) or "<li>None</li>"
+    production_gap_items = "".join(
+        f'<li><span class="pill">{escape(item["stage_label"].replace("_", " "))}</span> '
+        f'<a href="{escape(_note_href(item["note_path"]))}">{escape(item["title"])}</a>'
+        f"<div class='muted'>Missing: {escape(item['detail'])}</div></li>"
+        for item in payload["production"]["weak_points"]
+    ) or "<li class='muted'>No production-chain weak points surfaced.</li>"
     priority_items = "".join(
         f'<li><span class="pill">{escape(item["kind"].replace("_", " "))}</span> '
         f'<a href="{escape(item["path"])}">{escape(item["label"])}</a>'
@@ -715,6 +721,7 @@ def _render_dashboard(payload: dict) -> str:
             f"<section class='card'><h2><a href='/summaries'>Stale Summaries</a></h2><ul class='list-tight'>{stale_summary_items}</ul></section>"
             "</div>"
             "<div class='section-stack'>"
+            f"<section class='card'><h2><a href='/production'>Production Weak Points</a></h2><ul class='list-tight'>{production_gap_items}</ul></section>"
             f"<section class='card'><h2>Contradiction Queue</h2><ul class='list-tight'>{contradiction_items}</ul></section>"
             f"{_render_review_history(payload['recent_review_actions'], title='Recent Review Actions')}"
             "</div>"
@@ -1126,6 +1133,14 @@ def _render_production_browser_page(payload: dict) -> str:
         + "</li>"
         for item in payload["items"]
     ) or "<li class='muted'>No production chains found.</li>"
+    weak_points = "".join(
+        "<li>"
+        f'<span class="pill">{escape(item["stage_label"].replace("_", " "))}</span> '
+        f'<a href="{escape(_note_href(item["note_path"]))}">{escape(item["title"])}</a>'
+        f"<div class='muted'>Missing: {escape(item['detail'])}</div>"
+        "</li>"
+        for item in payload["weak_points"]
+    ) or "<li class='muted'>No production-chain weak points surfaced.</li>"
     return _layout(
         "Production Browser",
         (
@@ -1136,6 +1151,7 @@ def _render_production_browser_page(payload: dict) -> str:
             "</form>"
             f"<p class='muted'>{payload['count']} production-chain entries. {payload['counts']['source_notes']} source notes and {payload['counts']['deep_dives']} deep dives.</p>"
             "<section class='card'><h2>Chain Model</h2><p class='muted'>This browser shows the current upstream/downstream chain from traceable notes into deep dives, evergreen objects, and Atlas placement.</p></section>"
+            f"<section class='card'><h2>Weak Points</h2><ul class='list-tight'>{weak_points}</ul></section>"
             f"<section class='card'><ul class='list-tight'>{items}</ul></section>"
         ),
     )

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -638,6 +638,33 @@ def _render_review_history(items: list[dict[str, object]], *, title: str = "Revi
     )
 
 
+def _render_production_summary_card(summary: dict[str, object], *, title: str = "Production Contribution") -> str:
+    signal_items = "".join(
+        f"<li>{escape(str(signal['label']))}: {int(signal['count'])}</li>"
+        for signal in summary["signals"]
+    ) or "<li class='muted'>No production-chain gaps surfaced for this scope.</li>"
+    count_items = "".join(
+        f"<li>{escape(label)}: {int(summary['counts'][key])}</li>"
+        for key, label in (
+            ("source_notes", "Source notes"),
+            ("deep_dives", "Deep dives"),
+            ("atlas_pages", "Atlas / MOC pages"),
+        )
+    )
+    return (
+        "<section class='card'>"
+        f"<h2>{escape(title)}</h2>"
+        "<dl class='meta-list'>"
+        f"<div><dt>Objects in scope</dt><dd>{int(summary['object_count'])}</dd></div>"
+        f"<div><dt>Top Source Notes</dt><dd>{_render_named_note_links(summary['top_source_notes'])}</dd></div>"
+        f"<div><dt>Top Deep Dives</dt><dd>{_render_named_note_links(summary['top_deep_dives'])}</dd></div>"
+        f"<div><dt>Atlas / MOC Reach</dt><dd>{_render_named_note_links(summary['top_atlas_pages'])}</dd></div>"
+        "</dl>"
+        f"<ul class='list-tight'>{count_items}{signal_items}</ul>"
+        "</section>"
+    )
+
+
 def _render_dashboard(payload: dict) -> str:
     object_items = "".join(
         f'<li><a href="/object?id={escape(item["object_id"])}">{escape(item["title"])}</a></li>'
@@ -884,6 +911,7 @@ def _render_topic_page(payload: dict) -> str:
             f"<section class='card'><h2>Center Summary</h2><p>{escape(payload['center_summary'])}</p></section>"
             f"<section class='card'><h2>Neighbors</h2><ul class='list-tight'>{neighbors}</ul></section>"
             f"<section class='card'><h2>Atlas / MOC</h2><ul class='list-tight'>{mocs}</ul></section>"
+            f"{_render_production_summary_card(payload['production_summary'])}"
             f"{_render_review_context_card(payload['review_context'])}"
             f"{_render_review_history(payload['review_history'])}"
             "<section class='card'><h2>Quick Maintenance</h2>"
@@ -985,6 +1013,7 @@ def _render_events_page(payload: dict) -> str:
             "</form>"
             f"<p class='muted'>{payload['cluster_count']} event clusters from {payload['event_count']} timeline rows across {len(payload['dates'])} dates.</p>"
             f"<div class='link-row'>{type_breakdown}</div>"
+            f"{_render_production_summary_card(payload['production_summary'])}"
             f"{_render_review_context_card(payload['review_context'])}"
             f"{_render_review_history(payload['review_history'])}"
             "<section class='card'><h2>Quick Maintenance</h2>"

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -25,6 +25,7 @@ from ..ui.view_models import (
     build_note_page_payload,
     build_object_page_payload,
     build_objects_index_payload,
+    build_production_browser_payload,
     build_search_payload,
     build_stale_summary_browser_payload,
     build_truth_dashboard_payload,
@@ -100,6 +101,7 @@ def _layout(title: str, body: str) -> str:
             <a href="/">Home</a>
             <a href="/objects">Objects</a>
             <a href="/search">Search</a>
+            <a href="/production">Production</a>
             <a href="/atlas">Atlas</a>
             <a href="/deep-dives">Deep Dives</a>
             <a href="/events">Event Dossier</a>
@@ -1004,6 +1006,8 @@ def _render_atlas_page(payload: dict) -> str:
         "<li>"
         f'<a href="{escape(_note_href(item["path"]))}">{escape(item["title"])}</a>'
         + f" <span class='pill'>{item['member_count']} objects</span>"
+        + f" <span class='pill'>{len(item['deep_dives'])} deep dives</span>"
+        + f" <span class='pill'>{len(item['source_notes'])} source notes</span>"
         + (
             " <span class='muted'>"
             + ", ".join(
@@ -1017,6 +1021,8 @@ def _render_atlas_page(payload: dict) -> str:
             if item["preview_titles"]
             else ""
         )
+        + f"<div class='muted'>Source Notes: {_render_named_note_links(item['source_notes'])}</div>"
+        + f"<div class='muted'>Deep Dives: {_render_named_note_links(item['deep_dives'])}</div>"
         + "</li>"
         for item in payload["items"]
     ) or "<li>None</li>"
@@ -1029,6 +1035,7 @@ def _render_atlas_page(payload: dict) -> str:
             "<button type='submit'>Search</button>"
             "</form>"
             f"<p class='muted'>{payload['count']} atlas/moc pages linked to indexed objects.</p>"
+            "<section class='card'><h2>Contribution Summary</h2><p class='muted'>Each Atlas page now shows the source notes and deep dives that feed the objects it organizes.</p></section>"
             f"<section class='card'><ul class='list-tight'>{items}</ul></section>"
         ),
     )
@@ -1040,6 +1047,8 @@ def _render_derivations_page(payload: dict) -> str:
         "<li>"
         f'<a href="{escape(_note_href(item["path"]))}">{escape(item["title"])}</a>'
         + f" <span class='pill'>{item['derived_object_count']} derived objects</span>"
+        + f" <span class='pill'>{len(item['source_notes'])} source notes</span>"
+        + f" <span class='pill'>{len(item['atlas_pages'])} atlas pages</span>"
         + (
             " <span class='muted'>"
             + ", ".join(
@@ -1053,6 +1062,8 @@ def _render_derivations_page(payload: dict) -> str:
             if item["preview_titles"]
             else ""
         )
+        + f"<div class='muted'>Source Notes: {_render_named_note_links(item['source_notes'])}</div>"
+        + f"<div class='muted'>Atlas / MOC Reach: {_render_named_note_links(item['atlas_pages'])}</div>"
         + "</li>"
         for item in payload["items"]
     ) or "<li>None</li>"
@@ -1065,6 +1076,37 @@ def _render_derivations_page(payload: dict) -> str:
             "<button type='submit'>Search</button>"
             "</form>"
             f"<p class='muted'>{payload['count']} deep dive notes linked to indexed objects.</p>"
+            "<section class='card'><h2>Contribution Summary</h2><p class='muted'>Each deep dive now shows upstream source notes and downstream Atlas reach, not just derived objects.</p></section>"
+            f"<section class='card'><ul class='list-tight'>{items}</ul></section>"
+        ),
+    )
+
+
+def _render_production_browser_page(payload: dict) -> str:
+    query = payload.get("query", "")
+    items = "".join(
+        "<li>"
+        f'<a href="{escape(_note_href(item["path"]))}">{escape(item["title"])}</a>'
+        + f" <span class='pill'>{escape(item['stage_label'].replace('_', ' '))}</span>"
+        + f" <span class='pill'>{item['traceability']['counts']['deep_dives']} deep dives</span>"
+        + f" <span class='pill'>{item['traceability']['counts']['objects']} objects</span>"
+        + f" <span class='pill'>{item['traceability']['counts']['atlas_pages']} atlas pages</span>"
+        + f"<div class='muted'>Deep Dives: {_render_named_note_links(item['traceability']['deep_dives'])}</div>"
+        + f"<div class='muted'>Objects: {_render_object_links(item['traceability']['objects'])}</div>"
+        + f"<div class='muted'>Atlas / MOC Reach: {_render_named_note_links(item['traceability']['atlas_pages'])}</div>"
+        + "</li>"
+        for item in payload["items"]
+    ) or "<li class='muted'>No production chains found.</li>"
+    return _layout(
+        "Production Browser",
+        (
+            "<h1>Production Browser</h1>"
+            "<form method='get' action='/production'>"
+            f"<input type='text' name='q' value='{escape(query)}' placeholder='Filter source notes, deep dives, objects, or atlas' /> "
+            "<button type='submit'>Search</button>"
+            "</form>"
+            f"<p class='muted'>{payload['count']} production-chain entries. {payload['counts']['source_notes']} source notes and {payload['counts']['deep_dives']} deep dives.</p>"
+            "<section class='card'><h2>Chain Model</h2><p class='muted'>This browser shows the current upstream/downstream chain from traceable notes into deep dives, evergreen objects, and Atlas placement.</p></section>"
             f"<section class='card'><ul class='list-tight'>{items}</ul></section>"
         ),
     )
@@ -1407,6 +1449,15 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
                     q = query.get("q", [""])[0]
                     payload = build_derivation_browser_payload(resolved_vault, query=q)
                     self._write_html(_render_derivations_page(payload))
+                    return
+                if path == "/api/production":
+                    q = query.get("q", [""])[0]
+                    self._write_json(build_production_browser_payload(resolved_vault, query=q))
+                    return
+                if path == "/production":
+                    q = query.get("q", [""])[0]
+                    payload = build_production_browser_payload(resolved_vault, query=q)
+                    self._write_html(_render_production_browser_page(payload))
                     return
                 if path == "/api/summaries":
                     q = query.get("q", [""])[0]

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -1016,10 +1016,12 @@ def _page_row_by_path(vault_dir: Path | str, note_path: str) -> dict[str, str]:
 
 
 def _deep_dive_objects_for_path(vault_dir: Path | str, note_path: str) -> list[dict[str, str]]:
-    source_name = Path(note_path).name
+    resolved_vault = resolve_vault_dir(vault_dir)
+    normalized_target = (resolved_vault / note_path).resolve().as_posix()
     items = list_deep_dive_derivations(vault_dir, limit=MAX_PAGE_SIZE)
     for item in items:
-        if Path(item["path"]).name == source_name:
+        candidate_path = (resolved_vault / item["path"]).resolve().as_posix()
+        if candidate_path == normalized_target:
             return item["derived_objects"]
     return []
 
@@ -1032,27 +1034,93 @@ def _atlas_pages_for_object_ids(vault_dir: Path | str, object_ids: list[str]) ->
     return list(atlas_pages.values())
 
 
+def _promoted_deep_dives_for_object(vault_dir: Path | str, object_id: str) -> list[dict[str, str]]:
+    db_path = _db_path(vault_dir)
+    resolved_vault = resolve_vault_dir(vault_dir)
+    with sqlite3.connect(db_path) as conn:
+        deep_dive_rows = conn.execute(
+            """
+            SELECT slug, title, note_type, path
+            FROM pages_index
+            WHERE note_type = 'deep_dive'
+            ORDER BY slug
+            """
+        ).fetchall()
+        audit_rows = conn.execute(
+            """
+            SELECT payload_json
+            FROM audit_events
+            WHERE event_type = 'evergreen_auto_promoted'
+            """
+        ).fetchall()
+
+    promoted_source_names: set[str] = set()
+    for (payload_json,) in audit_rows:
+        try:
+            payload = json.loads(payload_json)
+        except json.JSONDecodeError:
+            continue
+        target_slug = str(payload.get("mutation", {}).get("target_slug") or payload.get("concept") or "").strip()
+        source_name = str(payload.get("source") or "").strip()
+        if target_slug == object_id and source_name:
+            promoted_source_names.add(source_name)
+
+    items: list[dict[str, str]] = []
+    seen_slugs: set[str] = set()
+    for slug, title, _note_type, path in deep_dive_rows:
+        relative_path = _vault_relative_path(resolved_vault, path)
+        if Path(relative_path).name not in promoted_source_names:
+            continue
+        if slug in seen_slugs:
+            continue
+        seen_slugs.add(slug)
+        items.append(
+            {
+                "slug": str(slug),
+                "title": str(title),
+                "note_type": "deep_dive",
+                "path": relative_path,
+            }
+        )
+    return items
+
+
 def get_note_traceability(vault_dir: Path | str, *, note_path: str) -> dict[str, Any]:
     note = _page_row_by_path(vault_dir, note_path)
     provenance = get_note_provenance(vault_dir, note_path=note_path)
     deep_dives: list[dict[str, str]] = []
     source_notes: list[dict[str, str]] = []
+    objects: list[dict[str, str]] = []
+    atlas_pages: list[dict[str, str]] = []
 
     if note["note_type"] == "deep_dive":
         deep_dives = [note]
         if provenance["original_source_note"]:
             source_notes = [provenance["original_source_note"]]
+    elif note["note_type"] == "evergreen":
+        object_traceability = get_object_traceability(vault_dir, note["slug"])
+        deep_dives = object_traceability["deep_dives"]
+        source_notes = object_traceability["source_notes"]
+        objects = [
+            {
+                "object_id": object_traceability["object"]["object_id"],
+                "title": object_traceability["object"]["title"],
+            }
+        ]
+        atlas_pages = object_traceability["atlas_pages"]
     else:
         deep_dives = provenance["derived_deep_dives"]
         if provenance["original_source_note"]:
             source_notes = [provenance["original_source_note"]]
 
-    object_map: dict[str, dict[str, str]] = {}
-    for deep_dive in deep_dives:
-        for item in _deep_dive_objects_for_path(vault_dir, deep_dive["path"]):
-            object_map.setdefault(item["object_id"], item)
-    objects = list(object_map.values())
-    atlas_pages = _atlas_pages_for_object_ids(vault_dir, [item["object_id"] for item in objects])
+    if not objects:
+        object_map: dict[str, dict[str, str]] = {}
+        for deep_dive in deep_dives:
+            for item in _deep_dive_objects_for_path(vault_dir, deep_dive["path"]):
+                object_map.setdefault(item["object_id"], item)
+        objects = list(object_map.values())
+    if not atlas_pages:
+        atlas_pages = _atlas_pages_for_object_ids(vault_dir, [item["object_id"] for item in objects])
     return {
         "note": note,
         "source_notes": source_notes,
@@ -1070,7 +1138,7 @@ def get_note_traceability(vault_dir: Path | str, *, note_path: str) -> dict[str,
 
 def get_object_traceability(vault_dir: Path | str, object_id: str) -> dict[str, Any]:
     detail = get_object_detail(vault_dir, object_id)
-    deep_dives = [item for item in detail["provenance"]["source_notes"] if item["note_type"] == "deep_dive"]
+    deep_dives = _promoted_deep_dives_for_object(vault_dir, object_id)
     source_note_map: dict[str, dict[str, str]] = {}
     for deep_dive in deep_dives:
         original = get_note_provenance(vault_dir, note_path=deep_dive["path"])["original_source_note"]

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -987,6 +987,112 @@ def get_note_provenance(vault_dir: Path | str, *, note_path: str) -> dict[str, A
     }
 
 
+def _page_row_by_path(vault_dir: Path | str, note_path: str) -> dict[str, str]:
+    db_path = _db_path(vault_dir)
+    resolved_vault = resolve_vault_dir(vault_dir)
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            """
+            SELECT slug, title, note_type, path
+            FROM pages_index
+            WHERE path = ?
+            LIMIT 1
+            """,
+            (str((resolved_vault / note_path).resolve()),),
+        ).fetchone()
+    if row:
+        return {
+            "slug": row[0],
+            "title": row[1],
+            "note_type": row[2],
+            "path": _vault_relative_path(resolved_vault, row[3]),
+        }
+    return {
+        "slug": Path(note_path).stem,
+        "title": Path(note_path).stem,
+        "note_type": "note",
+        "path": note_path,
+    }
+
+
+def _deep_dive_objects_for_path(vault_dir: Path | str, note_path: str) -> list[dict[str, str]]:
+    source_name = Path(note_path).name
+    items = list_deep_dive_derivations(vault_dir, limit=MAX_PAGE_SIZE)
+    for item in items:
+        if Path(item["path"]).name == source_name:
+            return item["derived_objects"]
+    return []
+
+
+def _atlas_pages_for_object_ids(vault_dir: Path | str, object_ids: list[str]) -> list[dict[str, str]]:
+    atlas_pages: dict[str, dict[str, str]] = {}
+    for provenance in get_object_provenance_map(vault_dir, object_ids).values():
+        for item in provenance["mocs"]:
+            atlas_pages.setdefault(item["slug"], item)
+    return list(atlas_pages.values())
+
+
+def get_note_traceability(vault_dir: Path | str, *, note_path: str) -> dict[str, Any]:
+    note = _page_row_by_path(vault_dir, note_path)
+    provenance = get_note_provenance(vault_dir, note_path=note_path)
+    deep_dives: list[dict[str, str]] = []
+    source_notes: list[dict[str, str]] = []
+
+    if note["note_type"] == "deep_dive":
+        deep_dives = [note]
+        if provenance["original_source_note"]:
+            source_notes = [provenance["original_source_note"]]
+    else:
+        deep_dives = provenance["derived_deep_dives"]
+        if provenance["original_source_note"]:
+            source_notes = [provenance["original_source_note"]]
+
+    object_map: dict[str, dict[str, str]] = {}
+    for deep_dive in deep_dives:
+        for item in _deep_dive_objects_for_path(vault_dir, deep_dive["path"]):
+            object_map.setdefault(item["object_id"], item)
+    objects = list(object_map.values())
+    atlas_pages = _atlas_pages_for_object_ids(vault_dir, [item["object_id"] for item in objects])
+    return {
+        "note": note,
+        "source_notes": source_notes,
+        "deep_dives": deep_dives,
+        "objects": objects,
+        "atlas_pages": atlas_pages,
+        "counts": {
+            "source_notes": len(source_notes),
+            "deep_dives": len(deep_dives),
+            "objects": len(objects),
+            "atlas_pages": len(atlas_pages),
+        },
+    }
+
+
+def get_object_traceability(vault_dir: Path | str, object_id: str) -> dict[str, Any]:
+    detail = get_object_detail(vault_dir, object_id)
+    deep_dives = [item for item in detail["provenance"]["source_notes"] if item["note_type"] == "deep_dive"]
+    source_note_map: dict[str, dict[str, str]] = {}
+    for deep_dive in deep_dives:
+        original = get_note_provenance(vault_dir, note_path=deep_dive["path"])["original_source_note"]
+        if original:
+            source_note_map.setdefault(original["path"], original)
+    return {
+        "object": detail["object"],
+        "evergreen_note": {
+            "title": detail["object"]["title"],
+            "path": detail["provenance"]["evergreen_path"],
+        },
+        "source_notes": list(source_note_map.values()),
+        "deep_dives": deep_dives,
+        "atlas_pages": detail["provenance"]["mocs"],
+        "counts": {
+            "source_notes": len(source_note_map),
+            "deep_dives": len(deep_dives),
+            "atlas_pages": len(detail["provenance"]["mocs"]),
+        },
+    }
+
+
 def list_contradictions(
     vault_dir: Path | str,
     *,

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -1093,6 +1093,89 @@ def get_object_traceability(vault_dir: Path | str, object_id: str) -> dict[str, 
     }
 
 
+def list_production_chains(
+    vault_dir: Path | str,
+    *,
+    query: str | None = None,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    limit, _ = _validate_page_args(limit=limit, offset=0)
+    db_path = _db_path(vault_dir)
+    resolved_vault = resolve_vault_dir(vault_dir)
+    normalized_query = (query or "").strip().lower()
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT slug, title, note_type, path
+            FROM pages_index
+            WHERE note_type = 'deep_dive'
+            ORDER BY note_type, slug
+            """
+        ).fetchall()
+
+    candidates: list[dict[str, str]] = []
+    seen_paths: set[str] = set()
+    for slug, title, note_type, path in rows:
+        relative_path = _vault_relative_path(resolved_vault, path)
+        seen_paths.add(relative_path)
+        candidates.append(
+            {
+                "slug": str(slug),
+                "title": str(title),
+                "note_type": str(note_type),
+                "path": relative_path,
+                "stage_label": "deep_dive",
+            }
+        )
+
+    processed_root = resolved_vault / "50-Inbox" / "03-Processed"
+    if processed_root.exists():
+        for candidate in sorted(processed_root.rglob("*.md")):
+            relative_path = str(candidate.resolve().relative_to(resolved_vault.resolve()))
+            if relative_path in seen_paths:
+                continue
+            frontmatter = _parse_frontmatter(candidate.read_text(encoding="utf-8"))
+            candidates.append(
+                {
+                    "slug": candidate.stem,
+                    "title": str(frontmatter.get("title") or candidate.stem).strip(),
+                    "note_type": "note",
+                    "path": relative_path,
+                    "stage_label": "source_note",
+                }
+            )
+
+    items: list[dict[str, Any]] = []
+    for candidate in candidates:
+        relative_path = candidate["path"]
+        chain = get_note_traceability(vault_dir, note_path=relative_path)
+        if normalized_query:
+            haystacks = [
+                str(candidate["title"]).lower(),
+                str(candidate["slug"]).lower(),
+                relative_path.lower(),
+                *(item["title"].lower() for item in chain["deep_dives"]),
+                *(item["title"].lower() for item in chain["objects"]),
+                *(item["title"].lower() for item in chain["atlas_pages"]),
+                *(item["title"].lower() for item in chain["source_notes"]),
+            ]
+            if not any(normalized_query in haystack for haystack in haystacks):
+                continue
+        items.append(
+            {
+                "slug": candidate["slug"],
+                "title": candidate["title"],
+                "note_type": candidate["note_type"],
+                "path": relative_path,
+                "stage_label": candidate["stage_label"],
+                "traceability": chain,
+            }
+        )
+        if len(items) >= limit:
+            break
+    return items
+
+
 def list_contradictions(
     vault_dir: Path | str,
     *,

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -23,6 +23,7 @@ from ..truth_api import (
     list_contradictions,
     list_deep_dive_derivations,
     list_objects,
+    list_production_chains,
     list_stale_summaries,
     search_vault_surface,
 )
@@ -466,11 +467,24 @@ def build_atlas_browser_payload(vault_dir: Path | str, *, query: str | None = No
     enriched_items = []
     for item in items:
         preview_titles = [member["title"] for member in item["members"][:5]]
+        member_object_ids = [member["object_id"] for member in item["members"]]
+        review_context = get_review_context(vault_dir, member_object_ids)
+        source_note_map: dict[str, dict[str, str]] = {}
+        deep_dive_map: dict[str, dict[str, str]] = {}
+        for member_object_id in member_object_ids:
+            traceability = get_object_traceability(vault_dir, member_object_id)
+            for source in traceability["source_notes"]:
+                source_note_map.setdefault(source["path"], source)
+            for deep_dive in traceability["deep_dives"]:
+                deep_dive_map.setdefault(deep_dive["slug"], deep_dive)
         enriched_items.append(
             {
                 **item,
                 "member_count": len(item["members"]),
                 "preview_titles": preview_titles,
+                "source_notes": list(source_note_map.values()),
+                "deep_dives": list(deep_dive_map.values()),
+                "review_context": review_context,
             }
         )
     return {
@@ -486,11 +500,22 @@ def build_derivation_browser_payload(vault_dir: Path | str, *, query: str | None
     enriched_items = []
     for item in items:
         preview_titles = [member["title"] for member in item["derived_objects"][:5]]
+        object_ids = [member["object_id"] for member in item["derived_objects"]]
+        review_context = get_review_context(vault_dir, object_ids)
+        atlas_page_map: dict[str, dict[str, str]] = {}
+        for member_object_id in object_ids:
+            traceability = get_object_traceability(vault_dir, member_object_id)
+            for atlas_page in traceability["atlas_pages"]:
+                atlas_page_map.setdefault(atlas_page["slug"], atlas_page)
+        source_notes = get_note_traceability(vault_dir, note_path=item["path"])["source_notes"]
         enriched_items.append(
             {
                 **item,
                 "derived_object_count": len(item["derived_objects"]),
                 "preview_titles": preview_titles,
+                "atlas_pages": list(atlas_page_map.values()),
+                "source_notes": source_notes,
+                "review_context": review_context,
             }
         )
     return {
@@ -498,6 +523,24 @@ def build_derivation_browser_payload(vault_dir: Path | str, *, query: str | None
         "items": enriched_items,
         "count": len(enriched_items),
         "query": query or "",
+    }
+
+
+def build_production_browser_payload(vault_dir: Path | str, *, query: str | None = None) -> dict[str, Any]:
+    items = list_production_chains(vault_dir, query=query)
+    source_items = [item for item in items if item["stage_label"] == "source_note"]
+    deep_dive_items = [item for item in items if item["stage_label"] == "deep_dive"]
+    return {
+        "screen": "production/browser",
+        "items": items,
+        "source_items": source_items,
+        "deep_dive_items": deep_dive_items,
+        "count": len(items),
+        "query": query or "",
+        "counts": {
+            "source_notes": len(source_items),
+            "deep_dives": len(deep_dive_items),
+        },
     }
 
 

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -12,7 +12,9 @@ from ..truth_api import (
     CONTRADICTION_STATUS_EXPLANATIONS,
     count_objects,
     get_object_detail,
+    get_object_traceability,
     get_note_provenance,
+    get_note_traceability,
     get_object_provenance_map,
     get_review_context,
     get_topic_neighborhood,
@@ -58,6 +60,7 @@ def build_object_page_payload(vault_dir: Path | str, object_id: str) -> dict[str
     return {
         "screen": "object/page",
         **detail,
+        "production_chain": get_object_traceability(vault_dir, object_id),
         "relations": relations,
         "claim_count": len(detail["claims"]),
         "relation_count": len(relations),
@@ -531,4 +534,5 @@ def build_note_page_payload(vault_dir: Path | str, *, note_path: str) -> dict[st
         "screen": "note/page",
         "note_path": note_path,
         "provenance": provenance,
+        "production_chain": get_note_traceability(vault_dir, note_path=note_path),
     }

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -5,6 +5,7 @@ import sqlite3
 from collections import Counter
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
 from ..runtime import VaultLayout, resolve_vault_dir
 from ..truth_store import CONTRADICTION_HEURISTIC_NOTE
@@ -557,7 +558,7 @@ def build_truth_dashboard_payload(vault_dir: Path | str) -> dict[str, Any]:
             {
                 "kind": "production_gap",
                 "label": item["title"],
-                "path": f"/note?path={item['note_path']}",
+                "path": f"/note?path={quote(item['note_path'], safe='')}",
                 "detail": item["detail"],
             }
         )

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -137,6 +137,47 @@ def _build_production_summary(vault_dir: Path | str, object_ids: list[str]) -> d
     }
 
 
+def _build_production_weak_points(
+    vault_dir: Path | str,
+    *,
+    query: str | None = None,
+    limit: int = 12,
+) -> list[dict[str, Any]]:
+    items = list_production_chains(vault_dir, query=query, limit=200)
+    weak_points: list[dict[str, Any]] = []
+    for item in items:
+        traceability = item["traceability"]
+        missing: list[str] = []
+        if item["stage_label"] == "source_note":
+            if not traceability["deep_dives"]:
+                missing.append("deep dives")
+            if not traceability["objects"]:
+                missing.append("objects")
+            if not traceability["atlas_pages"]:
+                missing.append("Atlas / MOC reach")
+        else:
+            if not traceability["source_notes"]:
+                missing.append("source notes")
+            if not traceability["objects"]:
+                missing.append("objects")
+            if not traceability["atlas_pages"]:
+                missing.append("Atlas / MOC reach")
+        if not missing:
+            continue
+        weak_points.append(
+            {
+                "title": item["title"],
+                "note_path": item["path"],
+                "stage_label": item["stage_label"],
+                "missing": missing,
+                "severity": len(missing),
+                "detail": ", ".join(missing),
+            }
+        )
+    weak_points.sort(key=lambda item: (-item["severity"], item["stage_label"], item["title"].lower()))
+    return weak_points[:limit]
+
+
 def build_object_page_payload(vault_dir: Path | str, object_id: str) -> dict[str, Any]:
     detail = get_object_detail(vault_dir, object_id)
     neighborhood = get_topic_neighborhood(vault_dir, object_id)
@@ -491,6 +532,7 @@ def build_truth_dashboard_payload(vault_dir: Path | str) -> dict[str, Any]:
     contradictions = build_contradiction_browser_payload(vault_dir)
     events = build_event_dossier_payload(vault_dir, limit=8)
     stale_summaries = build_stale_summary_browser_payload(vault_dir)
+    production_weak_points = _build_production_weak_points(vault_dir)
     priorities: list[dict[str, Any]] = []
     for item in contradictions["items"][:4]:
         priorities.append(
@@ -508,6 +550,15 @@ def build_truth_dashboard_payload(vault_dir: Path | str) -> dict[str, Any]:
                 "label": item["title"],
                 "path": item["object_path"],
                 "detail": ", ".join(item["reason_codes"]),
+            }
+        )
+    for item in production_weak_points[:4]:
+        priorities.append(
+            {
+                "kind": "production_gap",
+                "label": item["title"],
+                "path": f"/note?path={item['note_path']}",
+                "detail": item["detail"],
             }
         )
     return {
@@ -529,6 +580,10 @@ def build_truth_dashboard_payload(vault_dir: Path | str) -> dict[str, Any]:
         "stale_summaries": {
             "count": stale_summaries["count"],
             "items": stale_summaries["items"][:8],
+        },
+        "production": {
+            "weak_points": production_weak_points,
+            "weak_point_count": len(production_weak_points),
         },
         "recent_review_actions": list_review_actions(vault_dir, limit=8),
         "priorities": priorities[:8],
@@ -623,11 +678,13 @@ def build_production_browser_payload(vault_dir: Path | str, *, query: str | None
     items = list_production_chains(vault_dir, query=query)
     source_items = [item for item in items if item["stage_label"] == "source_note"]
     deep_dive_items = [item for item in items if item["stage_label"] == "deep_dive"]
+    weak_points = _build_production_weak_points(vault_dir, query=query)
     return {
         "screen": "production/browser",
         "items": items,
         "source_items": source_items,
         "deep_dive_items": deep_dive_items,
+        "weak_points": weak_points,
         "count": len(items),
         "query": query or "",
         "counts": {

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -46,6 +46,97 @@ def _object_ids_from_claim_ids(*claim_id_lists: list[str]) -> list[str]:
     return ordered
 
 
+def _build_production_summary(vault_dir: Path | str, object_ids: list[str]) -> dict[str, Any]:
+    normalized_object_ids = list(dict.fromkeys(object_id for object_id in object_ids if object_id))
+    object_traceability = [get_object_traceability(vault_dir, object_id) for object_id in normalized_object_ids]
+    source_note_counts: Counter[str] = Counter()
+    deep_dive_counts: Counter[str] = Counter()
+    atlas_page_counts: Counter[str] = Counter()
+    source_note_items: dict[str, dict[str, str]] = {}
+    deep_dive_items: dict[str, dict[str, str]] = {}
+    atlas_page_items: dict[str, dict[str, str]] = {}
+    missing_source_object_ids: list[str] = []
+    missing_deep_dive_object_ids: list[str] = []
+    missing_atlas_object_ids: list[str] = []
+
+    for traceability in object_traceability:
+        object_id = traceability["object"]["object_id"]
+        if not traceability["source_notes"]:
+            missing_source_object_ids.append(object_id)
+        if not traceability["deep_dives"]:
+            missing_deep_dive_object_ids.append(object_id)
+        if not traceability["atlas_pages"]:
+            missing_atlas_object_ids.append(object_id)
+        for item in traceability["source_notes"]:
+            source_note_items.setdefault(item["path"], item)
+            source_note_counts[item["path"]] += 1
+        for item in traceability["deep_dives"]:
+            deep_dive_items.setdefault(item["slug"], item)
+            deep_dive_counts[item["slug"]] += 1
+        for item in traceability["atlas_pages"]:
+            atlas_page_items.setdefault(item["slug"], item)
+            atlas_page_counts[item["slug"]] += 1
+
+    def _top_items(
+        counts: Counter[str],
+        item_map: dict[str, dict[str, str]],
+    ) -> list[dict[str, Any]]:
+        ordered = sorted(
+            counts.items(),
+            key=lambda item: (-item[1], item[0]),
+        )
+        return [
+            {
+                **item_map[key],
+                "object_count": count,
+            }
+            for key, count in ordered
+            if key in item_map
+        ][:5]
+
+    signals: list[dict[str, Any]] = []
+    if missing_source_object_ids:
+        signals.append(
+            {
+                "code": "missing_source_notes",
+                "count": len(missing_source_object_ids),
+                "label": "Missing source notes",
+                "object_ids": missing_source_object_ids,
+            }
+        )
+    if missing_deep_dive_object_ids:
+        signals.append(
+            {
+                "code": "missing_deep_dives",
+                "count": len(missing_deep_dive_object_ids),
+                "label": "Missing deep dives",
+                "object_ids": missing_deep_dive_object_ids,
+            }
+        )
+    if missing_atlas_object_ids:
+        signals.append(
+            {
+                "code": "missing_atlas_reach",
+                "count": len(missing_atlas_object_ids),
+                "label": "Missing Atlas / MOC reach",
+                "object_ids": missing_atlas_object_ids,
+            }
+        )
+
+    return {
+        "object_count": len(normalized_object_ids),
+        "counts": {
+            "source_notes": len(source_note_items),
+            "deep_dives": len(deep_dive_items),
+            "atlas_pages": len(atlas_page_items),
+        },
+        "top_source_notes": _top_items(source_note_counts, source_note_items),
+        "top_deep_dives": _top_items(deep_dive_counts, deep_dive_items),
+        "top_atlas_pages": _top_items(atlas_page_counts, atlas_page_items),
+        "signals": signals,
+    }
+
+
 def build_object_page_payload(vault_dir: Path | str, object_id: str) -> dict[str, Any]:
     detail = get_object_detail(vault_dir, object_id)
     neighborhood = get_topic_neighborhood(vault_dir, object_id)
@@ -117,6 +208,7 @@ def build_topic_overview_payload(vault_dir: Path | str, object_id: str) -> dict[
         "neighbor_count": len(neighborhood["neighbors"]),
         "center_summary": detail["summary"]["summary_text"] if detail["summary"] else "",
         "provenance": detail["provenance"],
+        "production_summary": _build_production_summary(vault_dir, scoped_object_ids),
         "review_context": review_context,
         "review_history": list_review_actions(
             vault_dir,
@@ -228,6 +320,7 @@ def build_event_dossier_payload(
             "row_type_counts": dict(row_type_counts),
             "semantic_roles": dict(semantic_roles),
         },
+        "production_summary": _build_production_summary(vault_dir, scoped_object_ids),
         "review_context": review_context,
         "review_history": list_review_actions(vault_dir, object_ids=scoped_object_ids, limit=8),
         "scoped_object_ids": list(dict.fromkeys(scoped_object_ids)),

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -740,6 +740,181 @@ date: 2026-04-13
     assert [item["slug"] for item in traceability["atlas_pages"]] == ["atlas-index"]
 
 
+def test_truth_api_object_traceability_excludes_incidental_deep_dive_mentions(temp_vault):
+    from openclaw_pipeline.truth_api import get_object_traceability
+
+    processed = temp_vault / "50-Inbox" / "03-Processed" / "2026-04" / "Harness.md"
+    processed.parent.mkdir(parents=True, exist_ok=True)
+    processed.write_text(
+        """---
+title: Harness
+source: https://example.com/harness
+---
+
+Processed source note.
+""",
+        encoding="utf-8",
+    )
+    promoted = temp_vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "Harness_深度解读.md"
+    promoted.parent.mkdir(parents=True, exist_ok=True)
+    promoted.write_text(
+        """---
+note_id: harness-deep-dive
+title: Harness Deep Dive
+type: deep_dive
+source: https://example.com/harness
+date: 2026-04-13
+---
+
+# Harness Deep Dive
+
+Mentions [[alpha]].
+""",
+        encoding="utf-8",
+    )
+    incidental = temp_vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "Incidental_深度解读.md"
+    incidental.write_text(
+        """---
+note_id: incidental-deep-dive
+title: Incidental Deep Dive
+type: deep_dive
+date: 2026-04-13
+---
+
+# Incidental Deep Dive
+
+Also mentions [[alpha]] but did not promote it.
+""",
+        encoding="utf-8",
+    )
+    evergreen = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
+    evergreen.parent.mkdir(parents=True, exist_ok=True)
+    evergreen.write_text(
+        """---
+note_id: alpha
+title: Alpha
+type: evergreen
+date: 2026-04-13
+---
+
+# Alpha
+""",
+        encoding="utf-8",
+    )
+    logs_dir = temp_vault / "60-Logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    (logs_dir / "pipeline.jsonl").write_text(
+        json.dumps(
+            {
+                "event_type": "evergreen_auto_promoted",
+                "concept": "alpha",
+                "source": "Harness_深度解读.md",
+                "mutation": {"target_slug": "alpha"},
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    rebuild_knowledge_index(temp_vault)
+
+    traceability = get_object_traceability(temp_vault, "alpha")
+
+    assert [item["slug"] for item in traceability["deep_dives"]] == ["harness-deep-dive"]
+
+
+def test_truth_api_returns_note_traceability_for_evergreen_note(temp_vault):
+    from openclaw_pipeline.truth_api import get_note_traceability
+
+    processed = temp_vault / "50-Inbox" / "03-Processed" / "2026-04" / "Harness.md"
+    processed.parent.mkdir(parents=True, exist_ok=True)
+    processed.write_text(
+        """---
+title: Harness
+source: https://example.com/harness
+---
+
+Processed source note.
+""",
+        encoding="utf-8",
+    )
+    deep_dive = temp_vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "Harness_深度解读.md"
+    deep_dive.parent.mkdir(parents=True, exist_ok=True)
+    deep_dive.write_text(
+        """---
+note_id: harness-deep-dive
+title: Harness Deep Dive
+type: deep_dive
+source: https://example.com/harness
+date: 2026-04-13
+---
+
+# Harness Deep Dive
+
+Mentions [[alpha]].
+""",
+        encoding="utf-8",
+    )
+    evergreen = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
+    evergreen.parent.mkdir(parents=True, exist_ok=True)
+    evergreen.write_text(
+        """---
+note_id: alpha
+title: Alpha
+type: evergreen
+date: 2026-04-13
+---
+
+# Alpha
+""",
+        encoding="utf-8",
+    )
+    atlas = temp_vault / "10-Knowledge" / "Atlas" / "Atlas Index.md"
+    atlas.write_text(
+        """---
+note_id: atlas-index
+title: Atlas Index
+type: moc
+date: 2026-04-13
+---
+
+# Atlas Index
+
+- [[alpha]]
+""",
+        encoding="utf-8",
+    )
+    logs_dir = temp_vault / "60-Logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    (logs_dir / "pipeline.jsonl").write_text(
+        json.dumps(
+            {
+                "event_type": "evergreen_auto_promoted",
+                "concept": "alpha",
+                "source": "Harness_深度解读.md",
+                "mutation": {"target_slug": "alpha"},
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    rebuild_knowledge_index(temp_vault)
+
+    traceability = get_note_traceability(
+        temp_vault,
+        note_path="10-Knowledge/Evergreen/Alpha.md",
+    )
+
+    assert traceability["note"]["note_type"] == "evergreen"
+    assert [item["slug"] for item in traceability["deep_dives"]] == ["harness-deep-dive"]
+    assert [item["path"] for item in traceability["source_notes"]] == ["50-Inbox/03-Processed/2026-04/Harness.md"]
+    assert [item["object_id"] for item in traceability["objects"]] == ["alpha"]
+    assert [item["slug"] for item in traceability["atlas_pages"]] == ["atlas-index"]
+
+
 def test_truth_api_limits_atlas_memberships_by_page_not_join_rows(temp_vault):
     from openclaw_pipeline.truth_api import list_atlas_memberships
 

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -551,6 +551,195 @@ date: 2026-04-13
     assert [item["slug"] for item in detail["provenance"]["mocs"]] == ["alias-atlas"]
 
 
+def test_truth_api_returns_note_traceability_for_processed_source(temp_vault):
+    from openclaw_pipeline.truth_api import get_note_traceability
+
+    processed = temp_vault / "50-Inbox" / "03-Processed" / "2026-04" / "Harness.md"
+    processed.parent.mkdir(parents=True, exist_ok=True)
+    processed.write_text(
+        """---
+title: Harness
+source: https://example.com/harness
+---
+
+Processed source note.
+""",
+        encoding="utf-8",
+    )
+    deep_dive = temp_vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "Harness_深度解读.md"
+    deep_dive.parent.mkdir(parents=True, exist_ok=True)
+    deep_dive.write_text(
+        """---
+note_id: harness-deep-dive
+title: Harness Deep Dive
+type: deep_dive
+source: https://example.com/harness
+date: 2026-04-13
+---
+
+# Harness Deep Dive
+
+Mentions [[alpha]].
+""",
+        encoding="utf-8",
+    )
+    evergreen = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
+    evergreen.parent.mkdir(parents=True, exist_ok=True)
+    evergreen.write_text(
+        """---
+note_id: alpha
+title: Alpha
+type: evergreen
+date: 2026-04-13
+---
+
+# Alpha
+""",
+        encoding="utf-8",
+    )
+    atlas = temp_vault / "10-Knowledge" / "Atlas" / "Atlas Index.md"
+    atlas.write_text(
+        """---
+note_id: atlas-index
+title: Atlas Index
+type: moc
+date: 2026-04-13
+---
+
+# Atlas Index
+
+- [[alpha]]
+""",
+        encoding="utf-8",
+    )
+    logs_dir = temp_vault / "60-Logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    (logs_dir / "pipeline.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "event_type": "article_processed",
+                        "file": "Harness.md",
+                        "output": str(deep_dive),
+                    },
+                    ensure_ascii=False,
+                ),
+                json.dumps(
+                    {
+                        "event_type": "evergreen_auto_promoted",
+                        "concept": "alpha",
+                        "source": "Harness_深度解读.md",
+                        "mutation": {"target_slug": "alpha"},
+                    },
+                    ensure_ascii=False,
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    rebuild_knowledge_index(temp_vault)
+
+    traceability = get_note_traceability(
+        temp_vault,
+        note_path="50-Inbox/03-Processed/2026-04/Harness.md",
+    )
+
+    assert traceability["note"]["path"] == "50-Inbox/03-Processed/2026-04/Harness.md"
+    assert [item["title"] for item in traceability["deep_dives"]] == ["Harness Deep Dive"]
+    assert [item["object_id"] for item in traceability["objects"]] == ["alpha"]
+    assert [item["slug"] for item in traceability["atlas_pages"]] == ["atlas-index"]
+
+
+def test_truth_api_returns_object_traceability(temp_vault):
+    from openclaw_pipeline.truth_api import get_object_traceability
+
+    processed = temp_vault / "50-Inbox" / "03-Processed" / "2026-04" / "Harness.md"
+    processed.parent.mkdir(parents=True, exist_ok=True)
+    processed.write_text(
+        """---
+title: Harness
+source: https://example.com/harness
+---
+
+Processed source note.
+""",
+        encoding="utf-8",
+    )
+    deep_dive = temp_vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "Harness_深度解读.md"
+    deep_dive.parent.mkdir(parents=True, exist_ok=True)
+    deep_dive.write_text(
+        """---
+note_id: harness-deep-dive
+title: Harness Deep Dive
+type: deep_dive
+source: https://example.com/harness
+date: 2026-04-13
+---
+
+# Harness Deep Dive
+
+Mentions [[alpha]].
+""",
+        encoding="utf-8",
+    )
+    evergreen = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
+    evergreen.parent.mkdir(parents=True, exist_ok=True)
+    evergreen.write_text(
+        """---
+note_id: alpha
+title: Alpha
+type: evergreen
+date: 2026-04-13
+---
+
+# Alpha
+""",
+        encoding="utf-8",
+    )
+    atlas = temp_vault / "10-Knowledge" / "Atlas" / "Atlas Index.md"
+    atlas.write_text(
+        """---
+note_id: atlas-index
+title: Atlas Index
+type: moc
+date: 2026-04-13
+---
+
+# Atlas Index
+
+- [[alpha]]
+""",
+        encoding="utf-8",
+    )
+    logs_dir = temp_vault / "60-Logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    (logs_dir / "pipeline.jsonl").write_text(
+        json.dumps(
+            {
+                "event_type": "evergreen_auto_promoted",
+                "concept": "alpha",
+                "source": "Harness_深度解读.md",
+                "mutation": {"target_slug": "alpha"},
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    rebuild_knowledge_index(temp_vault)
+
+    traceability = get_object_traceability(temp_vault, "alpha")
+
+    assert traceability["object"]["object_id"] == "alpha"
+    assert [item["slug"] for item in traceability["deep_dives"]] == ["harness-deep-dive"]
+    assert [item["path"] for item in traceability["source_notes"]] == ["50-Inbox/03-Processed/2026-04/Harness.md"]
+    assert [item["slug"] for item in traceability["atlas_pages"]] == ["atlas-index"]
+
+
 def test_truth_api_limits_atlas_memberships_by_page_not_join_rows(temp_vault):
     from openclaw_pipeline.truth_api import list_atlas_memberships
 

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -138,6 +138,9 @@ date: 2026-04-13
         object_status, object_body = _get(port, "/object?id=alpha")
         topic_status, topic_body = _get(port, "/topic?id=alpha")
         events_status, events_body = _get(port, "/events")
+        atlas_status, atlas_body = _get(port, "/atlas")
+        deep_dives_status, deep_dives_body = _get(port, "/deep-dives")
+        production_status, production_body = _get(port, "/production")
         contradictions_status, contradictions_body = _get(port, "/contradictions")
     finally:
         server.shutdown()
@@ -201,6 +204,22 @@ date: 2026-04-13
     assert "Atlas Index" in events_body
     assert f"/note?path={quote('20-Areas/Tools/Topics/2026-04/Source Deep Dive_深度解读.md', safe='')}" in events_body
     assert f"/note?path={quote('10-Knowledge/Atlas/Atlas-Index.md', safe='')}" in events_body
+
+    assert atlas_status == 200
+    assert "Atlas / MOC Browser" in atlas_body
+    assert "Contribution Summary" in atlas_body
+    assert "Source Deep Dive" in atlas_body
+
+    assert deep_dives_status == 200
+    assert "Deep Dive Derivations" in deep_dives_body
+    assert "Contribution Summary" in deep_dives_body
+    assert "Source Deep Dive" in deep_dives_body
+
+    assert production_status == 200
+    assert "Production Browser" in production_body
+    assert "Chain Model" in production_body
+    assert "Source Deep Dive" in production_body
+    assert "deep dive" in production_body
 
     assert contradictions_status == 200
     assert "Contradictions" in contradictions_body

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -586,6 +586,191 @@ type: "ai"
     assert f'/note?path={quote("20-Areas/AI-Research/Topics/2026-04/2026-04-09_The Harness Wars Begin_深度解读.md", safe="")}' in body
 
 
+def test_ui_note_page_shows_production_chain(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+
+    processed = temp_vault / "50-Inbox" / "03-Processed" / "2026-04" / "Harness.md"
+    processed.parent.mkdir(parents=True, exist_ok=True)
+    processed.write_text(
+        """---
+title: Harness
+source: https://example.com/harness
+---
+
+Processed source note.
+""",
+        encoding="utf-8",
+    )
+    deep_dive = temp_vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "Harness_深度解读.md"
+    deep_dive.parent.mkdir(parents=True, exist_ok=True)
+    deep_dive.write_text(
+        """---
+note_id: harness-deep-dive
+title: Harness Deep Dive
+type: deep_dive
+source: https://example.com/harness
+date: 2026-04-13
+---
+
+# Harness Deep Dive
+
+Mentions [[alpha]].
+""",
+        encoding="utf-8",
+    )
+    evergreen = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
+    evergreen.parent.mkdir(parents=True, exist_ok=True)
+    evergreen.write_text(
+        """---
+note_id: alpha
+title: Alpha
+type: evergreen
+date: 2026-04-13
+---
+
+# Alpha
+""",
+        encoding="utf-8",
+    )
+    atlas = temp_vault / "10-Knowledge" / "Atlas" / "Atlas Index.md"
+    atlas.write_text(
+        """---
+note_id: atlas-index
+title: Atlas Index
+type: moc
+date: 2026-04-13
+---
+
+# Atlas Index
+
+- [[alpha]]
+""",
+        encoding="utf-8",
+    )
+    logs_dir = temp_vault / "60-Logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    (logs_dir / "pipeline.jsonl").write_text(
+        "\n".join(
+            [
+                '{"event_type":"article_processed","file":"Harness.md","output":"'
+                + str(deep_dive)
+                + '"}',
+                '{"event_type":"evergreen_auto_promoted","concept":"alpha","source":"Harness_深度解读.md","mutation":{"target_slug":"alpha"}}',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        status, body = _get(
+            port,
+            f"/note?path={quote('50-Inbox/03-Processed/2026-04/Harness.md', safe='')}",
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert status == 200
+    assert "Production Chain" in body
+    assert "Derived Objects" in body
+    assert "Atlas / MOC Reach" in body
+    assert "/object?id=alpha" in body
+
+
+def test_ui_object_page_shows_production_chain(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+
+    processed = temp_vault / "50-Inbox" / "03-Processed" / "2026-04" / "Harness.md"
+    processed.parent.mkdir(parents=True, exist_ok=True)
+    processed.write_text(
+        """---
+title: Harness
+source: https://example.com/harness
+---
+
+Processed source note.
+""",
+        encoding="utf-8",
+    )
+    deep_dive = temp_vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "Harness_深度解读.md"
+    deep_dive.parent.mkdir(parents=True, exist_ok=True)
+    deep_dive.write_text(
+        """---
+note_id: harness-deep-dive
+title: Harness Deep Dive
+type: deep_dive
+source: https://example.com/harness
+date: 2026-04-13
+---
+
+# Harness Deep Dive
+
+Mentions [[alpha]].
+""",
+        encoding="utf-8",
+    )
+    evergreen = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
+    evergreen.parent.mkdir(parents=True, exist_ok=True)
+    evergreen.write_text(
+        """---
+note_id: alpha
+title: Alpha
+type: evergreen
+date: 2026-04-13
+---
+
+# Alpha
+""",
+        encoding="utf-8",
+    )
+    atlas = temp_vault / "10-Knowledge" / "Atlas" / "Atlas Index.md"
+    atlas.write_text(
+        """---
+note_id: atlas-index
+title: Atlas Index
+type: moc
+date: 2026-04-13
+---
+
+# Atlas Index
+
+- [[alpha]]
+""",
+        encoding="utf-8",
+    )
+    logs_dir = temp_vault / "60-Logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    (logs_dir / "pipeline.jsonl").write_text(
+        '{"event_type":"evergreen_auto_promoted","concept":"alpha","source":"Harness_深度解读.md","mutation":{"target_slug":"alpha"}}\n',
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        status, body = _get(port, "/object?id=alpha")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert status == 200
+    assert "Production Chain" in body
+    assert "Source Notes" in body
+    assert "Source Deep Dives" in body
+    assert "Atlas / MOC Reach" in body
+
+
 def test_ui_note_page_rewrites_local_images_to_asset_route(temp_vault):
     from openclaw_pipeline.commands.ui_server import create_server
 

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -212,7 +212,6 @@ date: 2026-04-13
     assert atlas_status == 200
     assert "Atlas / MOC Browser" in atlas_body
     assert "Contribution Summary" in atlas_body
-    assert "Source Deep Dive" in atlas_body
 
     assert deep_dives_status == 200
     assert "Deep Dive Derivations" in deep_dives_body

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -222,6 +222,7 @@ date: 2026-04-13
     assert production_status == 200
     assert "Production Browser" in production_body
     assert "Chain Model" in production_body
+    assert "Weak Points" in production_body
     assert "Source Deep Dive" in production_body
     assert "deep dive" in production_body
 
@@ -973,6 +974,7 @@ Thin note.
     assert "Alpha" in root_body
     assert "Thin Note" in root_body
     assert "/summaries" in root_body
+    assert "Production Weak Points" in root_body
 
 
 def test_ui_contradictions_and_summaries_support_batch_actions(temp_vault):

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -182,6 +182,8 @@ date: 2026-04-13
     assert "Center Summary" in topic_body
     assert "Atlas / MOC" in topic_body
     assert "Review Context" in topic_body
+    assert "Production Contribution" in topic_body
+    assert "Missing source notes" in topic_body
     assert "/summaries?q=alpha" in topic_body
     assert "Quick Maintenance" in topic_body
     assert "Review scoped contradictions" in topic_body
@@ -196,6 +198,8 @@ date: 2026-04-13
     assert "Timeline Contract" in events_body
     assert "Event Clusters" in events_body
     assert "Review Context" in events_body
+    assert "Production Contribution" in events_body
+    assert "Top Source Notes" in events_body
     assert "/summaries?q=alpha" in events_body
     assert "Quick Maintenance" in events_body
     assert "Review visible contradictions" in events_body

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -469,6 +469,18 @@ def test_build_truth_dashboard_payload(temp_vault):
     from openclaw_pipeline.ui.view_models import build_truth_dashboard_payload
 
     _seed_truth_store(temp_vault)
+    loose_source = temp_vault / "50-Inbox" / "03-Processed" / "2026-04" / "Loose Source.md"
+    loose_source.parent.mkdir(parents=True, exist_ok=True)
+    loose_source.write_text(
+        """---
+title: Loose Source
+source: https://example.com/loose
+---
+
+Processed source note without downstream chain.
+""",
+        encoding="utf-8",
+    )
     thin = temp_vault / "10-Knowledge" / "Evergreen" / "Thin.md"
     thin.write_text(
         """---
@@ -496,6 +508,8 @@ Thin note.
     assert "thin-note" in [item["object_id"] for item in payload["stale_summaries"]["items"]]
     assert payload["objects"]["items"][0]["object_id"] == "alpha"
     assert payload["priorities"]
+    assert payload["production"]["weak_point_count"] >= 1
+    assert any(item["kind"] == "production_gap" for item in payload["priorities"])
     assert payload["recent_review_actions"] == []
 
 
@@ -900,6 +914,30 @@ Mentions [[alpha]].
     assert payload["counts"]["deep_dives"] == 1
     assert any(item["stage_label"] == "source_note" for item in payload["items"])
     assert any(item["stage_label"] == "deep_dive" for item in payload["items"])
+
+
+def test_build_production_browser_payload_surfaces_weak_points(temp_vault):
+    from openclaw_pipeline.ui.view_models import build_production_browser_payload
+
+    processed = temp_vault / "50-Inbox" / "03-Processed" / "2026-04" / "Loose Source.md"
+    processed.parent.mkdir(parents=True, exist_ok=True)
+    processed.write_text(
+        """---
+title: Loose Source
+source: https://example.com/loose
+---
+
+Processed source note without downstream chain.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    payload = build_production_browser_payload(temp_vault)
+
+    assert payload["weak_points"]
+    assert payload["weak_points"][0]["title"] == "Loose Source"
+    assert "deep dives" in payload["weak_points"][0]["missing"]
 
 
 def test_build_stale_summary_browser_payload(temp_vault):

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -692,3 +692,167 @@ def test_build_object_page_payload_handles_missing_summary(temp_vault):
 
     assert payload["summary"] is None
     assert payload["claim_count"] == 1
+
+
+def test_build_note_page_payload_includes_production_chain(temp_vault):
+    from openclaw_pipeline.ui.view_models import build_note_page_payload
+
+    processed = temp_vault / "50-Inbox" / "03-Processed" / "2026-04" / "Harness.md"
+    processed.parent.mkdir(parents=True, exist_ok=True)
+    processed.write_text(
+        """---
+title: Harness
+source: https://example.com/harness
+---
+
+Processed source note.
+""",
+        encoding="utf-8",
+    )
+    deep_dive = temp_vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "Harness_深度解读.md"
+    deep_dive.parent.mkdir(parents=True, exist_ok=True)
+    deep_dive.write_text(
+        """---
+note_id: harness-deep-dive
+title: Harness Deep Dive
+type: deep_dive
+source: https://example.com/harness
+date: 2026-04-13
+---
+
+# Harness Deep Dive
+
+Mentions [[alpha]].
+""",
+        encoding="utf-8",
+    )
+    evergreen = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
+    evergreen.parent.mkdir(parents=True, exist_ok=True)
+    evergreen.write_text(
+        """---
+note_id: alpha
+title: Alpha
+type: evergreen
+date: 2026-04-13
+---
+
+# Alpha
+""",
+        encoding="utf-8",
+    )
+    atlas = temp_vault / "10-Knowledge" / "Atlas" / "Atlas Index.md"
+    atlas.write_text(
+        """---
+note_id: atlas-index
+title: Atlas Index
+type: moc
+date: 2026-04-13
+---
+
+# Atlas Index
+
+- [[alpha]]
+""",
+        encoding="utf-8",
+    )
+    logs_dir = temp_vault / "60-Logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    (logs_dir / "pipeline.jsonl").write_text(
+        "\n".join(
+            [
+                '{"event_type":"article_processed","file":"Harness.md","output":"'
+                + str(deep_dive)
+                + '"}',
+                '{"event_type":"evergreen_auto_promoted","concept":"alpha","source":"Harness_深度解读.md","mutation":{"target_slug":"alpha"}}',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    payload = build_note_page_payload(
+        temp_vault,
+        note_path="50-Inbox/03-Processed/2026-04/Harness.md",
+    )
+
+    assert payload["production_chain"]["note"]["path"] == "50-Inbox/03-Processed/2026-04/Harness.md"
+    assert [item["title"] for item in payload["production_chain"]["deep_dives"]] == ["Harness Deep Dive"]
+    assert [item["object_id"] for item in payload["production_chain"]["objects"]] == ["alpha"]
+    assert [item["slug"] for item in payload["production_chain"]["atlas_pages"]] == ["atlas-index"]
+
+
+def test_build_object_page_payload_includes_production_chain(temp_vault):
+    from openclaw_pipeline.ui.view_models import build_object_page_payload
+
+    processed = temp_vault / "50-Inbox" / "03-Processed" / "2026-04" / "Harness.md"
+    processed.parent.mkdir(parents=True, exist_ok=True)
+    processed.write_text(
+        """---
+title: Harness
+source: https://example.com/harness
+---
+
+Processed source note.
+""",
+        encoding="utf-8",
+    )
+    deep_dive = temp_vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "Harness_深度解读.md"
+    deep_dive.parent.mkdir(parents=True, exist_ok=True)
+    deep_dive.write_text(
+        """---
+note_id: harness-deep-dive
+title: Harness Deep Dive
+type: deep_dive
+source: https://example.com/harness
+date: 2026-04-13
+---
+
+# Harness Deep Dive
+
+Mentions [[alpha]].
+""",
+        encoding="utf-8",
+    )
+    evergreen = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
+    evergreen.parent.mkdir(parents=True, exist_ok=True)
+    evergreen.write_text(
+        """---
+note_id: alpha
+title: Alpha
+type: evergreen
+date: 2026-04-13
+---
+
+# Alpha
+""",
+        encoding="utf-8",
+    )
+    atlas = temp_vault / "10-Knowledge" / "Atlas" / "Atlas Index.md"
+    atlas.write_text(
+        """---
+note_id: atlas-index
+title: Atlas Index
+type: moc
+date: 2026-04-13
+---
+
+# Atlas Index
+
+- [[alpha]]
+""",
+        encoding="utf-8",
+    )
+    logs_dir = temp_vault / "60-Logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    (logs_dir / "pipeline.jsonl").write_text(
+        '{"event_type":"evergreen_auto_promoted","concept":"alpha","source":"Harness_深度解读.md","mutation":{"target_slug":"alpha"}}\n',
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    payload = build_object_page_payload(temp_vault, "alpha")
+
+    assert [item["slug"] for item in payload["production_chain"]["deep_dives"]] == ["harness-deep-dive"]
+    assert [item["path"] for item in payload["production_chain"]["source_notes"]] == ["50-Inbox/03-Processed/2026-04/Harness.md"]
+    assert [item["slug"] for item in payload["production_chain"]["atlas_pages"]] == ["atlas-index"]

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -179,6 +179,52 @@ def test_build_topic_overview_payload(temp_vault):
     assert payload["scoped_stale_summary_ids"] == ["beta"]
 
 
+def test_build_topic_overview_payload_includes_production_summary(temp_vault):
+    from openclaw_pipeline.ui.view_models import build_topic_overview_payload
+
+    source = temp_vault / "20-Areas" / "Tools" / "Topics" / "2026-04" / "Source Deep Dive_深度解读.md"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text(
+        """---
+note_id: source-deep-dive
+title: Source Deep Dive
+type: deep_dive
+date: 2026-04-13
+---
+
+# Source Deep Dive
+
+Mentions [[alpha]].
+""",
+        encoding="utf-8",
+    )
+    atlas = temp_vault / "10-Knowledge" / "Atlas" / "Atlas-Index.md"
+    atlas.write_text(
+        """---
+note_id: atlas-index
+title: Atlas Index
+type: moc
+date: 2026-04-13
+---
+
+# Atlas Index
+
+- [[alpha]]
+""",
+        encoding="utf-8",
+    )
+    _seed_truth_store(temp_vault)
+
+    payload = build_topic_overview_payload(temp_vault, "alpha")
+
+    assert payload["production_summary"]["object_count"] == 2
+    assert payload["production_summary"]["counts"]["deep_dives"] == 1
+    assert payload["production_summary"]["counts"]["atlas_pages"] == 1
+    assert payload["production_summary"]["counts"]["source_notes"] == 0
+    assert payload["production_summary"]["top_deep_dives"][0]["title"] == "Source Deep Dive"
+    assert any(signal["code"] == "missing_source_notes" for signal in payload["production_summary"]["signals"])
+
+
 def test_build_event_dossier_payload(temp_vault):
     from openclaw_pipeline.ui.view_models import build_event_dossier_payload
 
@@ -252,6 +298,52 @@ date: 2026-04-13
     assert event["provenance"]["evergreen_path"] == "10-Knowledge/Evergreen/Alpha.md"
     assert event["provenance"]["source_notes"][0]["slug"] == "source-deep-dive"
     assert event["provenance"]["mocs"][0]["slug"] == "atlas-index"
+
+
+def test_build_event_dossier_payload_includes_production_summary(temp_vault):
+    from openclaw_pipeline.ui.view_models import build_event_dossier_payload
+
+    source = temp_vault / "20-Areas" / "Tools" / "Topics" / "2026-04" / "Source Deep Dive_深度解读.md"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text(
+        """---
+note_id: source-deep-dive
+title: Source Deep Dive
+type: deep_dive
+date: 2026-04-13
+---
+
+# Source Deep Dive
+
+Mentions [[alpha]].
+""",
+        encoding="utf-8",
+    )
+    atlas = temp_vault / "10-Knowledge" / "Atlas" / "Atlas-Index.md"
+    atlas.write_text(
+        """---
+note_id: atlas-index
+title: Atlas Index
+type: moc
+date: 2026-04-13
+---
+
+# Atlas Index
+
+- [[alpha]]
+""",
+        encoding="utf-8",
+    )
+    _seed_truth_store(temp_vault)
+
+    payload = build_event_dossier_payload(temp_vault)
+
+    assert payload["production_summary"]["object_count"] == 3
+    assert payload["production_summary"]["counts"]["deep_dives"] == 1
+    assert payload["production_summary"]["counts"]["atlas_pages"] == 1
+    assert payload["production_summary"]["counts"]["source_notes"] == 0
+    assert payload["production_summary"]["top_deep_dives"][0]["title"] == "Source Deep Dive"
+    assert any(signal["code"] == "missing_source_notes" for signal in payload["production_summary"]["signals"])
 
 
 def test_build_contradiction_browser_payload(temp_vault):

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -574,6 +574,240 @@ Mentions [[alpha]].
     assert payload["items"][0]["derived_objects"][0]["object_id"] == "alpha"
     assert payload["items"][0]["derived_object_count"] == 1
     assert payload["items"][0]["preview_titles"] == ["Alpha"]
+    assert payload["items"][0]["source_notes"] == []
+
+
+def test_build_derivation_browser_payload_includes_chain_context(temp_vault):
+    from openclaw_pipeline.ui.view_models import build_derivation_browser_payload
+
+    processed = temp_vault / "50-Inbox" / "03-Processed" / "2026-04" / "Harness.md"
+    processed.parent.mkdir(parents=True, exist_ok=True)
+    processed.write_text(
+        """---
+title: Harness
+source: https://example.com/harness
+---
+
+Processed source note.
+""",
+        encoding="utf-8",
+    )
+    alpha = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
+    alpha.write_text(
+        """---
+note_id: alpha
+title: Alpha
+type: evergreen
+date: 2026-04-13
+---
+
+# Alpha
+""",
+        encoding="utf-8",
+    )
+    atlas = temp_vault / "10-Knowledge" / "Atlas" / "Atlas Index.md"
+    atlas.write_text(
+        """---
+note_id: atlas-index
+title: Atlas Index
+type: moc
+date: 2026-04-13
+---
+
+# Atlas Index
+
+- [[alpha]]
+""",
+        encoding="utf-8",
+    )
+    deep_dive = temp_vault / "20-Areas" / "Tools" / "Topics" / "2026-04" / "Deep Dive_深度解读.md"
+    deep_dive.parent.mkdir(parents=True, exist_ok=True)
+    deep_dive.write_text(
+        """---
+note_id: deep-dive
+title: Deep Dive
+type: deep_dive
+source: https://example.com/harness
+date: 2026-04-13
+---
+
+# Deep Dive
+
+Mentions [[alpha]].
+""",
+        encoding="utf-8",
+    )
+    logs_dir = temp_vault / "60-Logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    (logs_dir / "pipeline.jsonl").write_text(
+        '{"event_type":"evergreen_auto_promoted","concept":"alpha","source":"Deep Dive_深度解读.md","mutation":{"target_slug":"alpha"}}\n',
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    payload = build_derivation_browser_payload(temp_vault)
+
+    assert payload["items"][0]["source_notes"][0]["path"] == "50-Inbox/03-Processed/2026-04/Harness.md"
+    assert payload["items"][0]["atlas_pages"][0]["slug"] == "atlas-index"
+
+
+def test_build_atlas_browser_payload_includes_chain_context(temp_vault):
+    from openclaw_pipeline.ui.view_models import build_atlas_browser_payload
+
+    processed = temp_vault / "50-Inbox" / "03-Processed" / "2026-04" / "Harness.md"
+    processed.parent.mkdir(parents=True, exist_ok=True)
+    processed.write_text(
+        """---
+title: Harness
+source: https://example.com/harness
+---
+
+Processed source note.
+""",
+        encoding="utf-8",
+    )
+    alpha = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
+    alpha.write_text(
+        """---
+note_id: alpha
+title: Alpha
+type: evergreen
+date: 2026-04-13
+---
+
+# Alpha
+""",
+        encoding="utf-8",
+    )
+    deep_dive = temp_vault / "20-Areas" / "Tools" / "Topics" / "2026-04" / "Deep Dive_深度解读.md"
+    deep_dive.parent.mkdir(parents=True, exist_ok=True)
+    deep_dive.write_text(
+        """---
+note_id: deep-dive
+title: Deep Dive
+type: deep_dive
+source: https://example.com/harness
+date: 2026-04-13
+---
+
+# Deep Dive
+
+Mentions [[alpha]].
+""",
+        encoding="utf-8",
+    )
+    atlas = temp_vault / "10-Knowledge" / "Atlas" / "Atlas Index.md"
+    atlas.write_text(
+        """---
+note_id: atlas-index
+title: Atlas Index
+type: moc
+date: 2026-04-13
+---
+
+# Atlas Index
+
+- [[alpha]]
+""",
+        encoding="utf-8",
+    )
+    logs_dir = temp_vault / "60-Logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    (logs_dir / "pipeline.jsonl").write_text(
+        '{"event_type":"evergreen_auto_promoted","concept":"alpha","source":"Deep Dive_深度解读.md","mutation":{"target_slug":"alpha"}}\n',
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    payload = build_atlas_browser_payload(temp_vault)
+
+    assert payload["items"][0]["source_notes"][0]["path"] == "50-Inbox/03-Processed/2026-04/Harness.md"
+    assert payload["items"][0]["deep_dives"][0]["slug"] == "deep-dive"
+
+
+def test_build_production_browser_payload(temp_vault):
+    from openclaw_pipeline.ui.view_models import build_production_browser_payload
+
+    processed = temp_vault / "50-Inbox" / "03-Processed" / "2026-04" / "Harness.md"
+    processed.parent.mkdir(parents=True, exist_ok=True)
+    processed.write_text(
+        """---
+title: Harness
+source: https://example.com/harness
+---
+
+Processed source note.
+""",
+        encoding="utf-8",
+    )
+    alpha = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
+    alpha.write_text(
+        """---
+note_id: alpha
+title: Alpha
+type: evergreen
+date: 2026-04-13
+---
+
+# Alpha
+""",
+        encoding="utf-8",
+    )
+    atlas = temp_vault / "10-Knowledge" / "Atlas" / "Atlas Index.md"
+    atlas.write_text(
+        """---
+note_id: atlas-index
+title: Atlas Index
+type: moc
+date: 2026-04-13
+---
+
+# Atlas Index
+
+- [[alpha]]
+""",
+        encoding="utf-8",
+    )
+    deep_dive = temp_vault / "20-Areas" / "Tools" / "Topics" / "2026-04" / "Deep Dive_深度解读.md"
+    deep_dive.parent.mkdir(parents=True, exist_ok=True)
+    deep_dive.write_text(
+        """---
+note_id: deep-dive
+title: Deep Dive
+type: deep_dive
+source: https://example.com/harness
+date: 2026-04-13
+---
+
+# Deep Dive
+
+Mentions [[alpha]].
+""",
+        encoding="utf-8",
+    )
+    logs_dir = temp_vault / "60-Logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    (logs_dir / "pipeline.jsonl").write_text(
+        "\n".join(
+            [
+                '{"event_type":"article_processed","file":"Harness.md","output":"'
+                + str(deep_dive)
+                + '"}',
+                '{"event_type":"evergreen_auto_promoted","concept":"alpha","source":"Deep Dive_深度解读.md","mutation":{"target_slug":"alpha"}}',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    payload = build_production_browser_payload(temp_vault)
+
+    assert payload["screen"] == "production/browser"
+    assert payload["counts"]["source_notes"] == 1
+    assert payload["counts"]["deep_dives"] == 1
+    assert any(item["stage_label"] == "source_note" for item in payload["items"])
+    assert any(item["stage_label"] == "deep_dive" for item in payload["items"])
 
 
 def test_build_stale_summary_browser_payload(temp_vault):

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -218,11 +218,12 @@ date: 2026-04-13
     payload = build_topic_overview_payload(temp_vault, "alpha")
 
     assert payload["production_summary"]["object_count"] == 2
-    assert payload["production_summary"]["counts"]["deep_dives"] == 1
+    assert payload["production_summary"]["counts"]["deep_dives"] == 0
     assert payload["production_summary"]["counts"]["atlas_pages"] == 1
     assert payload["production_summary"]["counts"]["source_notes"] == 0
-    assert payload["production_summary"]["top_deep_dives"][0]["title"] == "Source Deep Dive"
+    assert payload["production_summary"]["top_deep_dives"] == []
     assert any(signal["code"] == "missing_source_notes" for signal in payload["production_summary"]["signals"])
+    assert any(signal["code"] == "missing_deep_dives" for signal in payload["production_summary"]["signals"])
 
 
 def test_build_event_dossier_payload(temp_vault):
@@ -339,11 +340,12 @@ date: 2026-04-13
     payload = build_event_dossier_payload(temp_vault)
 
     assert payload["production_summary"]["object_count"] == 3
-    assert payload["production_summary"]["counts"]["deep_dives"] == 1
+    assert payload["production_summary"]["counts"]["deep_dives"] == 0
     assert payload["production_summary"]["counts"]["atlas_pages"] == 1
     assert payload["production_summary"]["counts"]["source_notes"] == 0
-    assert payload["production_summary"]["top_deep_dives"][0]["title"] == "Source Deep Dive"
+    assert payload["production_summary"]["top_deep_dives"] == []
     assert any(signal["code"] == "missing_source_notes" for signal in payload["production_summary"]["signals"])
+    assert any(signal["code"] == "missing_deep_dives" for signal in payload["production_summary"]["signals"])
 
 
 def test_build_contradiction_browser_payload(temp_vault):
@@ -510,6 +512,8 @@ Thin note.
     assert payload["priorities"]
     assert payload["production"]["weak_point_count"] >= 1
     assert any(item["kind"] == "production_gap" for item in payload["priorities"])
+    production_gap = next(item for item in payload["priorities"] if item["kind"] == "production_gap")
+    assert production_gap["path"].startswith("/note?path=50-Inbox%2F03-Processed%2F2026-04%2FLoose%20Source.md")
     assert payload["recent_review_actions"] == []
 
 


### PR DESCRIPTION
## Summary
This PR completes the first full pass of Phase 11: Knowledge Production Traceability.

It makes the production chain legible from the product itself instead of forcing users to mentally reconstruct it across disconnected pages.

Included commits:
- `83bcbd8` `feat: add production chain traceability views`
- `913bd88` `feat: add production traceability browsers`
- `531fdc4` `feat: add production contribution summaries`
- `d5bdb1e` `feat: surface production weak points`

## What shipped
- `note` and `object` pages now expose explicit `Production Chain` sections.
- `/atlas` and `/deep-dives` now show contribution summaries instead of only flat membership/derivation lists.
- `/production` is a provenance-first aggregate browser over source notes and deep dives.
- `topic` and `events` now show `Production Contribution` summaries.
- dashboard and `/production` now surface vault-wide production weak points:
  - missing source notes
  - missing deep dives
  - missing Atlas / MOC reach
- `Needs Attention Now` now includes production-gap items.

## Important semantic choice
This PR stays provenance-first and does **not** invent downstream links from loose mentions. Production surfaces only reflect traceable chain edges.

## Verification
Fresh verification run before opening PR:
- `PYTHONPATH=src python3.13 -m pytest -q` -> `397 passed`
- `python3.13 -m compileall src/openclaw_pipeline` -> passed

## Review gate
Do not merge immediately after a single check. Wait for review/comments to settle, then address any blocking feedback before merge.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/18" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Production Chain sections to note and object pages, displaying source notes, deep dives, derived objects, and Atlas/MOC reach
  * Launched new `/production` browser for viewing production chains with filtering capabilities and weak point identification
  * Added Production Contribution summaries to topic overview and event pages
  * Enhanced `/atlas` and `/deep-dives` pages with aggregated contribution context
  * Added Production Weak Points section to dashboard to highlight missing chain links

<!-- end of auto-generated comment: release notes by coderabbit.ai -->