### PR TITLE
feat: add active signal loop surfaces

### DIFF
--- a/docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
+++ b/docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
@@ -318,7 +318,7 @@ That transition should stay constrained by a few hard product rules:
 
 ### Milestone 7: Active Signal Loop
 
-Status: **Not Started**
+Status: **In Progress**
 
 Goal:
 
@@ -335,6 +335,16 @@ Core deliverables:
 Exit condition:
 
 - saving or updating a note can improve future retrieval and navigation without requiring a manual full pipeline run every time.
+
+Current slice:
+
+- deterministic signal ledger over existing trusted maintenance surfaces,
+- signal browser in `ovp-ui`,
+- dashboard signal surfacing,
+- persisted signal rows in logs plus mirrored `audit_events`,
+- review-action-derived change signals for contradiction resolution and summary rebuild,
+- extraction-trigger signals for missing deep dives and missing downstream objects,
+- briefing-ready snapshot payloads over recent signals, unresolved issues, changed objects, and active topics.
 
 ### Milestone 8: Knowledge Evolution Layer
 
@@ -493,7 +503,8 @@ As of this plan:
 - Milestone 4: in progress
 - Milestone 5: in progress
 - Milestone 6: not started
-- Milestone 7+: not started
+- Milestone 7: in progress
+- Milestone 8+: not started
 
 So the honest product statement is:
 

--- a/docs/plans/2026-04-14-phase12-active-signal-loop.md
+++ b/docs/plans/2026-04-14-phase12-active-signal-loop.md
@@ -1,0 +1,146 @@
+# Phase 12 Active Signal Loop Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Turn current maintenance findings into first-class active signals that can be inspected, prioritized, and later extended into note-save and background-intelligence triggers.
+
+**Architecture:** Start with a deterministic signal ledger built from existing trusted surfaces: open contradictions, stale summaries, and production-chain gaps. Persist those signals into a dedicated log and mirrored `audit_events` rows, then expose them through `truth_api`, `ovp-ui`, and the dashboard before attempting richer asynchronous extraction.
+
+**Tech Stack:** Python 3.13, SQLite via stdlib `sqlite3`, existing `truth_api.py`, `ui/view_models.py`, `commands/ui_server.py`, pytest.
+
+---
+
+## Scope
+
+This first slice of Phase 12 does **not** try to ship full asynchronous intelligence. It establishes the minimum product contract:
+
+1. signals are first-class records,
+2. signals have stable IDs and types,
+3. signals can be listed and filtered from the truth layer,
+4. the local UI can show them as a distinct operator surface,
+5. the dashboard can surface them as a new active-system layer.
+
+The second slice extends that contract so the ledger is not only a snapshot of current queue-worthy state. It must also capture recent maintenance transitions:
+
+- contradiction review actions,
+- summary rebuild actions.
+
+The third slice adds extraction-trigger signals that answer “what should happen next?” for the current production chain:
+
+- source note exists but still needs a deep dive,
+- deep dive exists but still needs downstream objects.
+
+The fourth slice adds a briefing-ready snapshot so later daily or session-start intelligence can reuse one stable summary surface instead of rebuilding ad hoc summaries everywhere.
+
+## Signal Types In Scope
+
+- `contradiction_open`
+- `stale_summary`
+- `production_gap`
+- `contradiction_reviewed`
+- `summary_rebuilt`
+- `source_needs_deep_dive`
+- `deep_dive_needs_objects`
+
+These are chosen because they already come from deterministic system state. This avoids pretending we have richer intelligence before the substrate is ready.
+The first three are state signals. The next two are change signals derived from review actions. The last two are extraction-trigger signals derived from the current production chain.
+
+## Files
+
+- Modify: `src/openclaw_pipeline/truth_api.py`
+- Modify: `src/openclaw_pipeline/ui/view_models.py`
+- Modify: `src/openclaw_pipeline/commands/ui_server.py`
+- Modify: `docs/plans/2026-04-14-local-knowledge-workbench-milestone.md`
+- Test: `tests/test_truth_api.py`
+- Test: `tests/test_ui_view_models.py`
+- Test: `tests/test_ui_server.py`
+- Test: `tests/test_ui_smoke.py`
+
+## Task 1: Signal Ledger API
+
+Add deterministic signal computation and persistence:
+
+- `sync_signal_ledger(vault_dir)`
+- `list_signals(vault_dir, signal_type=None, query=None, limit=...)`
+- `list_production_gaps(...)`
+
+Persist the current ledger to:
+
+- `60-Logs/signals.jsonl`
+- mirrored `audit_events` rows with `source_log='signals'`
+
+Each signal row should include:
+
+- `signal_id`
+- `signal_type`
+- `detected_at`
+- `status`
+- `title`
+- `detail`
+- `source_path`
+- `source_label`
+- `object_ids`
+- `note_paths`
+- `downstream_effects`
+- a typed `payload`
+
+## Task 2: Signal Browser View Models
+
+Add `build_signal_browser_payload(...)` and wire dashboard signal summaries through it.
+
+The browser payload should provide:
+
+- current count
+- type counts
+- type explanations
+- filtered items
+
+The dashboard should show:
+
+- signal count
+- sample signal items
+- signals as a first-class section, not buried inside review queues
+
+## Task 3: Signal Browser UI
+
+Add:
+
+- `/signals`
+- `/api/signals`
+
+The HTML page should support:
+
+- search by text
+- filter by signal type
+- visible signal-type explanations
+- links back to the originating maintenance surface or source note
+- downstream links where they exist
+
+## Task 4: Milestone Update
+
+Update the master milestone doc so `Milestone 7: Active Signal Loop` is no longer “not started.” It should be marked `In Progress` and describe this first slice as:
+
+- deterministic signal ledger
+- operator-visible signal browser
+- dashboard signal surfacing
+
+## Verification
+
+Run:
+
+```bash
+PYTHONPATH=src python3.13 -m pytest -q tests/test_truth_api.py -k signal
+PYTHONPATH=src python3.13 -m pytest -q tests/test_ui_view_models.py -k 'signal or dashboard'
+PYTHONPATH=src python3.13 -m pytest -q tests/test_ui_server.py -k signals tests/test_ui_smoke.py -k 'signals or dashboard'
+PYTHONPATH=src python3.13 -m pytest -q
+python3.13 -m compileall src/openclaw_pipeline
+```
+
+## Exit Condition
+
+Phase 12 first slice is done when:
+
+1. signals exist as stable persisted rows,
+2. users can browse them directly in the UI,
+3. the dashboard surfaces them alongside review queues,
+4. this is implemented without inventing speculative heuristics beyond the current trusted sources.

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -19,6 +19,7 @@ from ..knowledge_index import contradiction_object_ids, rebuild_compiled_summari
 from ..runtime import VaultLayout, resolve_vault_dir
 from ..ui.view_models import (
     build_atlas_browser_payload,
+    build_briefing_payload,
     build_contradiction_browser_payload,
     build_derivation_browser_payload,
     build_event_dossier_payload,
@@ -27,6 +28,7 @@ from ..ui.view_models import (
     build_objects_index_payload,
     build_production_browser_payload,
     build_search_payload,
+    build_signal_browser_payload,
     build_stale_summary_browser_payload,
     build_truth_dashboard_payload,
     build_topic_overview_payload,
@@ -101,6 +103,8 @@ def _layout(title: str, body: str) -> str:
             <a href="/">Home</a>
             <a href="/objects">Objects</a>
             <a href="/search">Search</a>
+            <a href="/signals">Signals</a>
+            <a href="/briefing">Briefing</a>
             <a href="/production">Production</a>
             <a href="/atlas">Atlas</a>
             <a href="/deep-dives">Deep Dives</a>
@@ -690,6 +694,12 @@ def _render_dashboard(payload: dict) -> str:
         f"<div class='muted'>Missing: {escape(item['detail'])}</div></li>"
         for item in payload["production"]["weak_points"]
     ) or "<li class='muted'>No production-chain weak points surfaced.</li>"
+    signal_items = "".join(
+        f'<li><span class="pill">{escape(item["signal_type"])}</span> '
+        f'<a href="{escape(item["source_path"])}">{escape(item["title"])}</a>'
+        f"<div class='muted'>{escape(item['detail'])}</div></li>"
+        for item in payload["signals"]["items"]
+    ) or "<li class='muted'>No active signals surfaced.</li>"
     priority_items = "".join(
         f'<li><span class="pill">{escape(item["kind"].replace("_", " "))}</span> '
         f'<a href="{escape(item["path"])}">{escape(item["label"])}</a>'
@@ -712,6 +722,8 @@ def _render_dashboard(payload: dict) -> str:
             f"<p>{payload['events']['count']}</p></div>"
             "<div class='card'><h2>Stale Summaries</h2>"
             f"<p>{payload['stale_summaries']['count']}</p></div>"
+            "<div class='card'><h2>Signals</h2>"
+            f"<p>{payload['signals']['count']}</p></div>"
             "</section>"
             "<section class='grid two-col'>"
             "<div class='section-stack'>"
@@ -721,6 +733,7 @@ def _render_dashboard(payload: dict) -> str:
             f"<section class='card'><h2><a href='/summaries'>Stale Summaries</a></h2><ul class='list-tight'>{stale_summary_items}</ul></section>"
             "</div>"
             "<div class='section-stack'>"
+            f"<section class='card'><h2><a href='/signals'>Signals</a></h2><ul class='list-tight'>{signal_items}</ul></section>"
             f"<section class='card'><h2><a href='/production'>Production Weak Points</a></h2><ul class='list-tight'>{production_gap_items}</ul></section>"
             f"<section class='card'><h2>Contradiction Queue</h2><ul class='list-tight'>{contradiction_items}</ul></section>"
             f"{_render_review_history(payload['recent_review_actions'], title='Recent Review Actions')}"
@@ -1157,6 +1170,87 @@ def _render_production_browser_page(payload: dict) -> str:
     )
 
 
+def _render_signals_page(payload: dict) -> str:
+    query = payload.get("query", "")
+    selected_type = payload.get("signal_type", "")
+    options = ["", *sorted(payload["signal_type_explanations"].keys())]
+    option_html = "".join(
+        f"<option value='{escape(option)}' {'selected' if option == selected_type else ''}>"
+        f"{escape(option or 'all signal types')}</option>"
+        for option in options
+    )
+    items = "".join(
+        "<li>"
+        f'<span class="pill">{escape(item["signal_type"])}</span> '
+        f'<a href="{escape(item["source_path"])}">{escape(item["title"])}</a>'
+        f"<div class='muted'>{escape(item['detail'])}</div>"
+        + (
+            "<div class='muted'>Downstream: "
+            + ", ".join(
+                f'<a href="{escape(effect["path"])}">{escape(effect["label"])}</a>'
+                for effect in item["downstream_effects"]
+            )
+            + "</div>"
+            if item["downstream_effects"]
+            else ""
+        )
+        + "</li>"
+        for item in payload["items"]
+    ) or "<li class='muted'>No active signals found.</li>"
+    explanations = "".join(
+        f"<li><span class='pill'>{escape(signal_type)}</span> {escape(text)}</li>"
+        for signal_type, text in payload["signal_type_explanations"].items()
+    )
+    return _layout(
+        "Active Signals",
+        (
+            "<h1>Active Signals</h1>"
+            "<form method='get' action='/signals' class='link-row'>"
+            f"<input type='text' name='q' value='{escape(query)}' placeholder='Search signals' />"
+            f"<select name='type'>{option_html}</select>"
+            "<button type='submit'>Filter</button>"
+            "</form>"
+            f"<p class='muted'>{payload['count']} active signals.</p>"
+            f"<section class='card'><h2>Signal Types</h2><ul class='list-tight'>{explanations}</ul></section>"
+            f"<section class='card'><ul class='list-tight'>{items}</ul></section>"
+        ),
+    )
+
+
+def _render_briefing_page(payload: dict) -> str:
+    recent_signals = "".join(
+        f'<li><span class="pill">{escape(item["signal_type"])}</span> '
+        f'<a href="{escape(item["source_path"])}">{escape(item["title"])}</a>'
+        f"<div class='muted'>{escape(item['detail'])}</div></li>"
+        for item in payload["recent_signals"]
+    ) or "<li class='muted'>No recent signals.</li>"
+    unresolved = "".join(
+        f'<li><span class="pill">{escape(item["signal_type"])}</span> '
+        f'<a href="{escape(item["source_path"])}">{escape(item["title"])}</a></li>'
+        for item in payload["unresolved_issues"]
+    ) or "<li class='muted'>No unresolved issues.</li>"
+    changed_objects = "".join(
+        f'<li><a href="{escape(item["path"])}">{escape(item["title"])}</a></li>'
+        for item in payload["changed_objects"]
+    ) or "<li class='muted'>No recent changed objects.</li>"
+    active_topics = "".join(
+        f'<li><a href="{escape(item["path"])}">{escape(item["title"])}</a> '
+        f"<span class='muted'>({item['signal_count']} signals)</span></li>"
+        for item in payload["active_topics"]
+    ) or "<li class='muted'>No active topics surfaced.</li>"
+    return _layout(
+        "Working Memory Snapshot",
+        (
+            "<h1>Working Memory Snapshot</h1>"
+            f"<p class='muted'>Generated at {escape(payload['generated_at'])}. {payload['recent_signal_count']} recent signals, {payload['unresolved_issue_count']} unresolved issues.</p>"
+            f"<section class='card'><h2>Recent Signals</h2><ul class='list-tight'>{recent_signals}</ul></section>"
+            f"<section class='card'><h2>Unresolved Issues</h2><ul class='list-tight'>{unresolved}</ul></section>"
+            f"<section class='card'><h2>Changed Objects</h2><ul class='list-tight'>{changed_objects}</ul></section>"
+            f"<section class='card'><h2>Active Topics</h2><ul class='list-tight'>{active_topics}</ul></section>"
+        ),
+    )
+
+
 def _render_contradictions_page(payload: dict) -> str:
     status = payload.get("status", "")
     query = payload.get("query", "")
@@ -1449,6 +1543,23 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
                     q = query.get("q", [""])[0]
                     payload = build_search_payload(resolved_vault, query=q)
                     self._write_html(_render_search_page(payload))
+                    return
+                if path == "/api/briefing":
+                    self._write_json(build_briefing_payload(resolved_vault))
+                    return
+                if path == "/briefing":
+                    self._write_html(_render_briefing_page(build_briefing_payload(resolved_vault)))
+                    return
+                if path == "/api/signals":
+                    q = query.get("q", [""])[0]
+                    signal_type = query.get("type", [""])[0] or None
+                    self._write_json(build_signal_browser_payload(resolved_vault, signal_type=signal_type, query=q))
+                    return
+                if path == "/signals":
+                    q = query.get("q", [""])[0]
+                    signal_type = query.get("type", [""])[0] or None
+                    payload = build_signal_browser_payload(resolved_vault, signal_type=signal_type, query=q)
+                    self._write_html(_render_signals_page(payload))
                     return
                 if path == "/api/object":
                     object_id = self._required(query, "id")

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -1821,8 +1821,3 @@ def main(argv: list[str] | None = None) -> int:
 
 if __name__ == "__main__":  # pragma: no cover
     raise SystemExit(main())
-    limit_note = (
-        f" Showing the most recent {payload['limit']} timeline rows in this dossier window."
-        if payload.get("is_limited")
-        else ""
-    )

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -945,6 +945,11 @@ def _render_topic_page(payload: dict) -> str:
 
 def _render_events_page(payload: dict) -> str:
     query = payload.get("query", "")
+    limit_note = (
+        f" Showing the most recent {payload['limit']} timeline rows in this dossier window."
+        if payload.get("is_limited")
+        else ""
+    )
     type_breakdown = "".join(
         f"<span class='pill'>{escape(kind.replace('_', ' '))}: {count}</span>"
         for kind, count in payload["event_type_counts"].items()
@@ -1031,7 +1036,7 @@ def _render_events_page(payload: dict) -> str:
             f"<input type='text' name='q' value='{escape(query)}' placeholder='Filter events' /> "
             "<button type='submit'>Search</button>"
             "</form>"
-            f"<p class='muted'>{payload['cluster_count']} event clusters from {payload['event_count']} timeline rows across {len(payload['dates'])} dates.</p>"
+            f"<p class='muted'>{payload['cluster_count']} event clusters from {payload['event_count']} timeline rows across {len(payload['dates'])} dates.{escape(limit_note)}</p>"
             f"<div class='link-row'>{type_breakdown}</div>"
             f"{_render_production_summary_card(payload['production_summary'])}"
             f"{_render_review_context_card(payload['review_context'])}"
@@ -1816,3 +1821,8 @@ def main(argv: list[str] | None = None) -> int:
 
 if __name__ == "__main__":  # pragma: no cover
     raise SystemExit(main())
+    limit_note = (
+        f" Showing the most recent {payload['limit']} timeline rows in this dossier window."
+        if payload.get("is_limited")
+        else ""
+    )

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -33,7 +33,7 @@ from ..ui.view_models import (
     build_truth_dashboard_payload,
     build_topic_overview_payload,
 )
-from ..truth_api import record_review_action
+from ..truth_api import ensure_signal_ledger_synced, record_review_action
 
 _MARKDOWN_RENDERER = MarkdownIt("commonmark", {"breaks": True, "html": False}).enable("table")
 _FENCED_FRONTMATTER_RE = re.compile(r"^```ya?ml\s*\n---\n(.*?)\n---\n```\s*\n?", re.DOTALL)
@@ -1798,6 +1798,7 @@ def main(argv: list[str] | None = None) -> int:
     server = create_server(resolved_vault, host=args.host, port=args.port)
     try:
         build_objects_index_payload(resolved_vault, limit=1, offset=0)
+        ensure_signal_ledger_synced(resolved_vault)
     except Exception as exc:
         print(f"ui server preflight failed: {exc}", file=sys.stderr)
         server.server_close()

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -1056,6 +1056,11 @@ def _render_events_page(payload: dict) -> str:
 
 def _render_atlas_page(payload: dict) -> str:
     query = payload.get("query", "")
+    limit_note = (
+        f" Showing the most recent {payload['limit']} atlas pages in this browser window."
+        if payload.get("is_limited")
+        else ""
+    )
     items = "".join(
         "<li>"
         f'<a href="{escape(_note_href(item["path"]))}">{escape(item["title"])}</a>'
@@ -1088,7 +1093,7 @@ def _render_atlas_page(payload: dict) -> str:
             f"<input type='text' name='q' value='{escape(query)}' placeholder='Filter MOCs or objects' /> "
             "<button type='submit'>Search</button>"
             "</form>"
-            f"<p class='muted'>{payload['count']} atlas/moc pages linked to indexed objects.</p>"
+            f"<p class='muted'>{payload['count']} atlas/moc pages linked to indexed objects.{escape(limit_note)}</p>"
             "<section class='card'><h2>Contribution Summary</h2><p class='muted'>Each Atlas page now shows the source notes and deep dives that feed the objects it organizes.</p></section>"
             f"<section class='card'><ul class='list-tight'>{items}</ul></section>"
         ),
@@ -1097,6 +1102,11 @@ def _render_atlas_page(payload: dict) -> str:
 
 def _render_derivations_page(payload: dict) -> str:
     query = payload.get("query", "")
+    limit_note = (
+        f" Showing the most recent {payload['limit']} deep dives in this browser window."
+        if payload.get("is_limited")
+        else ""
+    )
     items = "".join(
         "<li>"
         f'<a href="{escape(_note_href(item["path"]))}">{escape(item["title"])}</a>'
@@ -1129,7 +1139,7 @@ def _render_derivations_page(payload: dict) -> str:
             f"<input type='text' name='q' value='{escape(query)}' placeholder='Filter deep dives or objects' /> "
             "<button type='submit'>Search</button>"
             "</form>"
-            f"<p class='muted'>{payload['count']} deep dive notes linked to indexed objects.</p>"
+            f"<p class='muted'>{payload['count']} deep dive notes linked to indexed objects.{escape(limit_note)}</p>"
             "<section class='card'><h2>Contribution Summary</h2><p class='muted'>Each deep dive now shows upstream source notes and downstream Atlas reach, not just derived objects.</p></section>"
             f"<section class='card'><ul class='list-tight'>{items}</ul></section>"
         ),
@@ -1138,6 +1148,11 @@ def _render_derivations_page(payload: dict) -> str:
 
 def _render_production_browser_page(payload: dict) -> str:
     query = payload.get("query", "")
+    limit_note = (
+        f" Showing the most recent {payload['limit']} production-chain entries in this browser window."
+        if payload.get("is_limited")
+        else ""
+    )
     items = "".join(
         "<li>"
         f'<a href="{escape(_note_href(item["path"]))}">{escape(item["title"])}</a>'
@@ -1167,7 +1182,7 @@ def _render_production_browser_page(payload: dict) -> str:
             f"<input type='text' name='q' value='{escape(query)}' placeholder='Filter source notes, deep dives, objects, or atlas' /> "
             "<button type='submit'>Search</button>"
             "</form>"
-            f"<p class='muted'>{payload['count']} production-chain entries. {payload['counts']['source_notes']} source notes and {payload['counts']['deep_dives']} deep dives.</p>"
+            f"<p class='muted'>{payload['count']} production-chain entries. {payload['counts']['source_notes']} source notes and {payload['counts']['deep_dives']} deep dives.{escape(limit_note)}</p>"
             "<section class='card'><h2>Chain Model</h2><p class='muted'>This browser shows the current upstream/downstream chain from traceable notes into deep dives, evergreen objects, and Atlas placement.</p></section>"
             f"<section class='card'><h2>Weak Points</h2><ul class='list-tight'>{weak_points}</ul></section>"
             f"<section class='card'><ul class='list-tight'>{items}</ul></section>"

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -1081,7 +1081,7 @@ def _compute_signal_entries(vault_dir: Path | str) -> list[dict[str, Any]]:
                 "note_paths": [],
                 "downstream_effects": [
                     {"label": "Open object", "path": item["object_path"]},
-                    {"label": "Review stale summary", "path": f"/summaries?q={item['object_id']}"},
+                    {"label": "Review stale summary", "path": f"/summaries?q={quote(item['object_id'], safe='')}"},
                 ],
                 "payload": {
                     "reason_codes": item["reason_codes"],

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -18,6 +18,10 @@ MAX_PAGE_SIZE = 500
 _FENCED_FRONTMATTER_RE = re.compile(r"^```ya?ml\s*\n---\n(.*?)\n---\n```\s*\n?", re.DOTALL)
 _REVIEW_AUDIT_LOG_NAME = "review-actions"
 _SIGNAL_LOG_NAME = "signals"
+_SOURCE_NOTE_INDEX_CACHE: dict[tuple[str, tuple[tuple[str, int, int], ...]], dict[str, list[dict[str, str]]]] = {}
+_PIPELINE_LOG_INDEX_CACHE: dict[tuple[str, int, int], dict[str, Any]] = {}
+_DEEP_DIVE_OBJECT_MAP_CACHE: dict[tuple[str, int, int], dict[str, list[dict[str, str]]]] = {}
+_SIGNAL_LEDGER_SYNC_CACHE: dict[tuple[str, tuple[tuple[str, int, int], ...]], dict[str, Any]] = {}
 CONTRADICTION_STATUS_EXPLANATIONS = {
     "open": "Active contradiction awaiting review.",
     "resolved_keep_positive": "Reviewed and the positive claim set remains the preferred interpretation.",
@@ -39,6 +43,41 @@ SIGNAL_TYPE_EXPLANATIONS = {
 def _db_path(vault_dir: Path | str) -> Path:
     resolved = resolve_vault_dir(vault_dir)
     return VaultLayout.from_vault(resolved).knowledge_db
+
+
+def _path_signature(path: Path) -> tuple[str, int, int]:
+    try:
+        stat = path.stat()
+    except FileNotFoundError:
+        return (str(path), -1, -1)
+    return (str(path), stat.st_mtime_ns, stat.st_size)
+
+
+def _search_root_signatures(vault_dir: Path) -> tuple[tuple[str, int, int], ...]:
+    roots = [
+        vault_dir / "50-Inbox" / "03-Processed",
+        vault_dir / "50-Inbox" / "02-Processing",
+        vault_dir / "50-Inbox" / "01-Raw",
+    ]
+    signatures: list[tuple[str, int, int]] = []
+    for root in roots:
+        signatures.append(_path_signature(root))
+        if not root.exists():
+            continue
+        for child in sorted(root.iterdir(), key=lambda item: item.name):
+            signatures.append(_path_signature(child))
+    return tuple(signatures)
+
+
+def _signal_dependency_signature(vault_dir: Path) -> tuple[tuple[str, int, int], ...]:
+    layout = VaultLayout.from_vault(vault_dir)
+    signatures = [
+        _path_signature(layout.knowledge_db),
+        _path_signature(layout.logs_dir / f"{_REVIEW_AUDIT_LOG_NAME}.jsonl"),
+        _path_signature(layout.logs_dir / "pipeline.jsonl"),
+    ]
+    signatures.extend(_search_root_signatures(vault_dir))
+    return tuple(signatures)
 
 
 def _vault_relative_path(vault_dir: Path | str, path: str) -> str:
@@ -823,26 +862,38 @@ def get_object_detail(vault_dir: Path | str, object_id: str) -> dict[str, Any]:
 
 
 def _find_note_by_source(vault_dir: Path, *, source_url: str, exclude_path: str) -> dict[str, str] | None:
-    search_roots = [
-        vault_dir / "50-Inbox" / "03-Processed",
-        vault_dir / "50-Inbox" / "02-Processing",
-        vault_dir / "50-Inbox" / "01-Raw",
-    ]
-    resolved_exclude = str((vault_dir / exclude_path).resolve())
-    for root in search_roots:
-        if not root.exists():
+    cache_key = (str(vault_dir.resolve()), _search_root_signatures(vault_dir))
+    source_index = _SOURCE_NOTE_INDEX_CACHE.get(cache_key)
+    if source_index is None:
+        search_roots = [
+            vault_dir / "50-Inbox" / "03-Processed",
+            vault_dir / "50-Inbox" / "02-Processing",
+            vault_dir / "50-Inbox" / "01-Raw",
+        ]
+        source_index = {}
+        for root in search_roots:
+            if not root.exists():
+                continue
+            for candidate in sorted(root.rglob("*.md")):
+                frontmatter = _parse_frontmatter(candidate.read_text(encoding="utf-8"))
+                candidate_source = str(frontmatter.get("source", "")).strip()
+                if not candidate_source:
+                    continue
+                title = str(frontmatter.get("title") or candidate.stem).strip()
+                source_index.setdefault(candidate_source, []).append(
+                    {
+                        "title": title,
+                        "path": str(candidate.resolve().relative_to(vault_dir.resolve())),
+                    }
+                )
+        _SOURCE_NOTE_INDEX_CACHE.clear()
+        _SOURCE_NOTE_INDEX_CACHE[cache_key] = source_index
+
+    resolved_exclude = str((vault_dir / exclude_path).resolve().relative_to(vault_dir.resolve()))
+    for item in source_index.get(source_url, []):
+        if item["path"] == resolved_exclude:
             continue
-        for candidate in sorted(root.rglob("*.md")):
-            if str(candidate.resolve()) == resolved_exclude:
-                continue
-            frontmatter = _parse_frontmatter(candidate.read_text(encoding="utf-8"))
-            if str(frontmatter.get("source", "")).strip() != source_url:
-                continue
-            title = str(frontmatter.get("title") or candidate.stem).strip()
-            return {
-                "title": title,
-                "path": str(candidate.resolve().relative_to(vault_dir.resolve())),
-            }
+        return item
     return None
 
 
@@ -850,79 +901,15 @@ def _find_note_from_pipeline_log(vault_dir: Path, *, note_path: str) -> dict[str
     log_path = VaultLayout.from_vault(vault_dir).logs_dir / "pipeline.jsonl"
     if not log_path.exists():
         return None
-    article_file: str | None = None
-    archived_path: str | None = None
-    target_absolute = str((vault_dir / note_path).resolve())
-    for raw_line in log_path.read_text(encoding="utf-8").splitlines():
-        if not raw_line.strip():
-            continue
-        try:
-            event = json.loads(raw_line)
-        except json.JSONDecodeError:
-            continue
-        if event.get("event_type") == "article_processed":
-            output = str(event.get("output", "")).strip()
-            if output == target_absolute or output.endswith(note_path):
-                article_file = str(event.get("file", "")).strip()
-                continue
-        if event.get("event_type") == "source_archived_to_processed":
-            archived = str(event.get("archived", "")).strip()
-            source = str(event.get("source", "")).strip()
-            if article_file and (archived.endswith(article_file) or source.endswith(article_file)):
-                archived_path = archived
-    if not archived_path:
-        return None
-    candidate = Path(archived_path)
-    if not candidate.is_absolute():
-        candidate = (vault_dir / archived_path).resolve()
-    if not candidate.is_file():
-        return None
-    frontmatter = _parse_frontmatter(candidate.read_text(encoding="utf-8"))
-    return {
-        "title": str(frontmatter.get("title") or candidate.stem).strip(),
-        "path": str(candidate.resolve().relative_to(vault_dir.resolve())),
-    }
+    index = _pipeline_log_index(vault_dir)
+    return index["original_source_by_output"].get(str((vault_dir / note_path).resolve().relative_to(vault_dir.resolve())))
 
 
 def _find_derived_notes_from_pipeline_log(vault_dir: Path, *, note_path: str) -> list[dict[str, str]]:
     log_path = VaultLayout.from_vault(vault_dir).logs_dir / "pipeline.jsonl"
     if not log_path.exists():
         return []
-    target_name = Path(note_path).name
-    derived: list[dict[str, str]] = []
-    seen_paths: set[str] = set()
-    for raw_line in log_path.read_text(encoding="utf-8").splitlines():
-        if not raw_line.strip():
-            continue
-        try:
-            event = json.loads(raw_line)
-        except json.JSONDecodeError:
-            continue
-        if event.get("event_type") != "article_processed":
-            continue
-        file_name = str(event.get("file", "")).strip()
-        if file_name != target_name:
-            continue
-        output = str(event.get("output", "")).strip()
-        if not output:
-            continue
-        candidate = Path(output)
-        if not candidate.is_absolute():
-            candidate = (vault_dir / output).resolve()
-        if not candidate.is_file():
-            continue
-        relative_path = str(candidate.resolve().relative_to(vault_dir.resolve()))
-        if relative_path in seen_paths:
-            continue
-        seen_paths.add(relative_path)
-        frontmatter = _parse_frontmatter(candidate.read_text(encoding="utf-8"))
-        derived.append(
-            {
-                "title": str(frontmatter.get("title") or candidate.stem).strip(),
-                "path": relative_path,
-            }
-        )
-    return derived
+    return list(_pipeline_log_index(vault_dir)["derived_by_source_file"].get(Path(note_path).name, []))
 
 
 def list_review_actions(
@@ -1273,10 +1260,26 @@ def sync_signal_ledger(vault_dir: Path | str) -> dict[str, Any]:
             )
             conn.commit()
     type_counts = Counter(item["signal_type"] for item in signals)
-    return {
+    result = {
         "signal_count": len(signals),
         "type_counts": dict(type_counts),
     }
+    cache_key = (str(resolved_vault.resolve()), _signal_dependency_signature(resolved_vault))
+    _SIGNAL_LEDGER_SYNC_CACHE.clear()
+    _SIGNAL_LEDGER_SYNC_CACHE[cache_key] = result
+    return result
+
+
+def ensure_signal_ledger_synced(vault_dir: Path | str) -> dict[str, Any]:
+    resolved_vault = resolve_vault_dir(vault_dir)
+    cache_key = (str(resolved_vault.resolve()), _signal_dependency_signature(resolved_vault))
+    cached = _SIGNAL_LEDGER_SYNC_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+    result = sync_signal_ledger(resolved_vault)
+    _SIGNAL_LEDGER_SYNC_CACHE.clear()
+    _SIGNAL_LEDGER_SYNC_CACHE[cache_key] = result
+    return result
 
 
 def list_signals(
@@ -1287,7 +1290,7 @@ def list_signals(
     limit: int = 100,
 ) -> list[dict[str, Any]]:
     limit, _ = _validate_page_args(limit=limit, offset=0)
-    sync_signal_ledger(vault_dir)
+    ensure_signal_ledger_synced(vault_dir)
     db_path = _db_path(vault_dir)
     normalized_query = (query or "").strip().lower()
     with sqlite3.connect(db_path) as conn:
@@ -1436,13 +1439,8 @@ def _page_row_by_path(vault_dir: Path | str, note_path: str) -> dict[str, str]:
 
 def _deep_dive_objects_for_path(vault_dir: Path | str, note_path: str) -> list[dict[str, str]]:
     resolved_vault = resolve_vault_dir(vault_dir)
-    normalized_target = (resolved_vault / note_path).resolve().as_posix()
-    items = list_deep_dive_derivations(vault_dir, limit=MAX_PAGE_SIZE)
-    for item in items:
-        candidate_path = (resolved_vault / item["path"]).resolve().as_posix()
-        if candidate_path == normalized_target:
-            return item["derived_objects"]
-    return []
+    normalized_target = str((resolved_vault / note_path).resolve().relative_to(resolved_vault.resolve()))
+    return list(_deep_dive_object_map(vault_dir).get(normalized_target, []))
 
 
 def _atlas_pages_for_object_ids(vault_dir: Path | str, object_ids: list[str]) -> list[dict[str, str]]:
@@ -1451,6 +1449,142 @@ def _atlas_pages_for_object_ids(vault_dir: Path | str, object_ids: list[str]) ->
         for item in provenance["mocs"]:
             atlas_pages.setdefault(item["slug"], item)
     return list(atlas_pages.values())
+
+
+def _pipeline_log_index(vault_dir: Path) -> dict[str, Any]:
+    log_path = VaultLayout.from_vault(vault_dir).logs_dir / "pipeline.jsonl"
+    cache_key = (str(vault_dir.resolve()), *(_path_signature(log_path)[1:]))
+    cached = _PIPELINE_LOG_INDEX_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
+    article_outputs: dict[str, str] = {}
+    derived_by_source_file: dict[str, list[dict[str, str]]] = {}
+    archived_by_article_file: dict[str, str] = {}
+    if log_path.exists():
+        for raw_line in log_path.read_text(encoding="utf-8").splitlines():
+            if not raw_line.strip():
+                continue
+            try:
+                event = json.loads(raw_line)
+            except json.JSONDecodeError:
+                continue
+            if event.get("event_type") == "article_processed":
+                file_name = str(event.get("file", "")).strip()
+                output = str(event.get("output", "")).strip()
+                if not file_name or not output:
+                    continue
+                candidate = Path(output)
+                if not candidate.is_absolute():
+                    candidate = (vault_dir / output).resolve()
+                if not candidate.is_file():
+                    continue
+                relative_path = str(candidate.resolve().relative_to(vault_dir.resolve()))
+                article_outputs[relative_path] = file_name
+                frontmatter = _parse_frontmatter(candidate.read_text(encoding="utf-8"))
+                derived_by_source_file.setdefault(file_name, [])
+                if not any(item["path"] == relative_path for item in derived_by_source_file[file_name]):
+                    derived_by_source_file[file_name].append(
+                        {
+                            "title": str(frontmatter.get("title") or candidate.stem).strip(),
+                            "path": relative_path,
+                        }
+                    )
+            elif event.get("event_type") == "source_archived_to_processed":
+                archived = str(event.get("archived", "")).strip()
+                source = str(event.get("source", "")).strip()
+                if not archived and not source:
+                    continue
+                target = archived or source
+                article_file = Path(target).name
+                candidate = Path(target)
+                if not candidate.is_absolute():
+                    candidate = (vault_dir / target).resolve()
+                if candidate.is_file():
+                    archived_by_article_file[article_file] = str(candidate.resolve().relative_to(vault_dir.resolve()))
+
+    original_source_by_output: dict[str, dict[str, str]] = {}
+    for output_path, article_file in article_outputs.items():
+        archived_path = archived_by_article_file.get(article_file)
+        if not archived_path:
+            continue
+        candidate = (vault_dir / archived_path).resolve()
+        if not candidate.is_file():
+            continue
+        frontmatter = _parse_frontmatter(candidate.read_text(encoding="utf-8"))
+        original_source_by_output[output_path] = {
+            "title": str(frontmatter.get("title") or candidate.stem).strip(),
+            "path": archived_path,
+        }
+
+    result = {
+        "original_source_by_output": original_source_by_output,
+        "derived_by_source_file": derived_by_source_file,
+    }
+    _PIPELINE_LOG_INDEX_CACHE.clear()
+    _PIPELINE_LOG_INDEX_CACHE[cache_key] = result
+    return result
+
+
+def _deep_dive_object_map(vault_dir: Path | str) -> dict[str, list[dict[str, str]]]:
+    db_path = _db_path(vault_dir)
+    resolved_vault = resolve_vault_dir(vault_dir)
+    cache_key = (str(resolved_vault.resolve()), *(_path_signature(db_path)[1:]))
+    cached = _DEEP_DIVE_OBJECT_MAP_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
+    with sqlite3.connect(db_path) as conn:
+        deep_dive_rows = conn.execute(
+            """
+            SELECT path
+            FROM pages_index
+            WHERE note_type = 'deep_dive'
+            ORDER BY slug
+            """
+        ).fetchall()
+        object_rows = conn.execute(
+            """
+            SELECT object_id, title
+            FROM objects
+            ORDER BY object_id
+            """
+        ).fetchall()
+        audit_rows = conn.execute(
+            """
+            SELECT payload_json
+            FROM audit_events
+            WHERE event_type = 'evergreen_auto_promoted'
+            """
+        ).fetchall()
+
+    object_titles = {row[0]: row[1] for row in object_rows}
+    grouped_promotions: dict[str, dict[str, dict[str, str]]] = {}
+    for (payload_json,) in audit_rows:
+        try:
+            payload = json.loads(payload_json)
+        except json.JSONDecodeError:
+            continue
+        source_name = str(payload.get("source") or "").strip()
+        object_id = str(payload.get("mutation", {}).get("target_slug") or payload.get("concept") or "").strip()
+        if not source_name or not object_id:
+            continue
+        grouped_promotions.setdefault(source_name, {})[object_id] = {
+            "object_id": object_id,
+            "title": object_titles.get(object_id, object_id),
+        }
+
+    result: dict[str, list[dict[str, str]]] = {}
+    for (path,) in deep_dive_rows:
+        relative_path = _vault_relative_path(resolved_vault, path)
+        result[relative_path] = sorted(
+            grouped_promotions.get(Path(relative_path).name, {}).values(),
+            key=lambda item: item["object_id"],
+        )
+
+    _DEEP_DIVE_OBJECT_MAP_CACHE.clear()
+    _DEEP_DIVE_OBJECT_MAP_CACHE[cache_key] = result
+    return result
 
 
 def _promoted_deep_dives_for_object(vault_dir: Path | str, object_id: str) -> list[dict[str, str]]:
@@ -1888,43 +2022,13 @@ def list_deep_dive_derivations(
             ORDER BY slug
             """
         ).fetchall()
-        object_rows = conn.execute(
-            """
-            SELECT object_id, title
-            FROM objects
-            ORDER BY object_id
-            """
-        ).fetchall()
-        audit_rows = conn.execute(
-            """
-            SELECT payload_json
-            FROM audit_events
-            WHERE event_type = 'evergreen_auto_promoted'
-            """
-        ).fetchall()
 
-    object_titles = {row[0]: row[1] for row in object_rows}
-    grouped_promotions: dict[str, dict[str, dict[str, str]]] = {}
-    for (payload_json,) in audit_rows:
-        try:
-            payload = json.loads(payload_json)
-        except json.JSONDecodeError:
-            continue
-        source_name = str(payload.get("source") or "").strip()
-        object_id = str(payload.get("mutation", {}).get("target_slug") or payload.get("concept") or "").strip()
-        if not source_name or not object_id:
-            continue
-        title = object_titles.get(object_id, object_id)
-        grouped_promotions.setdefault(source_name, {})[object_id] = {
-            "object_id": object_id,
-            "title": title,
-        }
+    derivation_map = _deep_dive_object_map(vault_dir)
 
     items: list[dict[str, Any]] = []
     for slug, title, note_type, path in deep_dive_rows:
         relative_path = _vault_relative_path(resolved_vault, path)
-        source_name = Path(relative_path).name
-        derived_objects = list(grouped_promotions.get(source_name, {}).values())
+        derived_objects = list(derivation_map.get(relative_path, []))
         if normalized_query:
             haystacks = [
                 slug.lower(),

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -984,7 +984,8 @@ def list_production_gaps(
     limit: int = 100,
 ) -> list[dict[str, Any]]:
     limit, _ = _validate_page_args(limit=limit, offset=0)
-    items = list_production_chains(vault_dir, query=query, limit=MAX_PAGE_SIZE)
+    candidate_limit = min(MAX_PAGE_SIZE, max(limit * 5, limit))
+    items = list_production_chains(vault_dir, query=query, limit=candidate_limit)
     weak_points: list[dict[str, Any]] = []
     for item in items:
         traceability = item["traceability"]

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from collections import Counter
+import hashlib
 import json
 import re
 import sqlite3
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
 import yaml
 
@@ -14,12 +17,22 @@ from .runtime import VaultLayout, resolve_vault_dir
 MAX_PAGE_SIZE = 500
 _FENCED_FRONTMATTER_RE = re.compile(r"^```ya?ml\s*\n---\n(.*?)\n---\n```\s*\n?", re.DOTALL)
 _REVIEW_AUDIT_LOG_NAME = "review-actions"
+_SIGNAL_LOG_NAME = "signals"
 CONTRADICTION_STATUS_EXPLANATIONS = {
     "open": "Active contradiction awaiting review.",
     "resolved_keep_positive": "Reviewed and the positive claim set remains the preferred interpretation.",
     "resolved_keep_negative": "Reviewed and the negative claim set remains the preferred interpretation.",
     "dismissed": "Reviewed and dismissed as not worth keeping in the active contradiction queue.",
     "needs_human": "Requires deeper human judgment before the contradiction can be considered closed.",
+}
+SIGNAL_TYPE_EXPLANATIONS = {
+    "contradiction_open": "Open contradiction detected from the current truth store and awaiting review.",
+    "stale_summary": "Compiled summary is currently weak enough to justify targeted rebuild review.",
+    "production_gap": "Knowledge production chain is missing an expected downstream stage or reach surface.",
+    "contradiction_reviewed": "A contradiction review action recently changed the maintenance state for one or more objects.",
+    "summary_rebuilt": "A summary rebuild action recently refreshed one or more compiled summaries.",
+    "source_needs_deep_dive": "A processed source note exists without any derived deep dive, so the next extraction step is still missing.",
+    "deep_dive_needs_objects": "A deep dive exists without any derived evergreen objects, so absorb-style extraction has not completed yet.",
 }
 
 
@@ -89,6 +102,13 @@ def _append_jsonl(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a", encoding="utf-8") as handle:
         handle.write(json.dumps(payload, ensure_ascii=False) + "\n")
+
+
+def _rewrite_jsonl(path: Path, payloads: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for payload in payloads:
+            handle.write(json.dumps(payload, ensure_ascii=False) + "\n")
 
 
 def record_review_action(
@@ -964,6 +984,405 @@ def list_review_actions(
         if len(items) >= limit:
             break
     return items
+
+
+def _signal_id(signal_type: str, key: str) -> str:
+    return f"{signal_type}::{hashlib.sha1(key.encode('utf-8')).hexdigest()[:12]}"
+
+
+def list_production_gaps(
+    vault_dir: Path | str,
+    *,
+    query: str | None = None,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    limit, _ = _validate_page_args(limit=limit, offset=0)
+    items = list_production_chains(vault_dir, query=query, limit=MAX_PAGE_SIZE)
+    weak_points: list[dict[str, Any]] = []
+    for item in items:
+        traceability = item["traceability"]
+        missing: list[str] = []
+        if item["stage_label"] == "source_note":
+            if not traceability["deep_dives"]:
+                missing.append("deep dives")
+            if not traceability["objects"]:
+                missing.append("objects")
+            if not traceability["atlas_pages"]:
+                missing.append("Atlas / MOC reach")
+        else:
+            if not traceability["source_notes"]:
+                missing.append("source notes")
+            if not traceability["objects"]:
+                missing.append("objects")
+            if not traceability["atlas_pages"]:
+                missing.append("Atlas / MOC reach")
+        if not missing:
+            continue
+        weak_points.append(
+            {
+                "signal_id": _signal_id("production_gap", item["path"]),
+                "signal_type": "production_gap",
+                "title": item["title"],
+                "detail": ", ".join(missing),
+                "stage_label": item["stage_label"],
+                "note_path": item["path"],
+                "missing": missing,
+                "severity": len(missing),
+                "traceability": item["traceability"],
+            }
+        )
+    weak_points.sort(key=lambda item: (-item["severity"], item["stage_label"], item["title"].lower()))
+    return weak_points[:limit]
+
+
+def _compute_signal_entries(vault_dir: Path | str) -> list[dict[str, Any]]:
+    resolved_vault = resolve_vault_dir(vault_dir)
+    timestamp = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    signals: list[dict[str, Any]] = []
+
+    for item in list_contradictions(resolved_vault, status="open", limit=MAX_PAGE_SIZE):
+        object_ids = list(
+            dict.fromkeys(
+                claim_id.split("::", 1)[0]
+                for claim_id in (item["positive_claim_ids"] + item["negative_claim_ids"])
+            )
+        )
+        signals.append(
+            {
+                "signal_id": _signal_id("contradiction_open", item["contradiction_id"]),
+                "signal_type": "contradiction_open",
+                "detected_at": timestamp,
+                "status": "active",
+                "title": item["subject_key"],
+                "detail": (
+                    f"{item['scope_summary']['object_count']} objects, "
+                    f"{len(item['ranked_evidence'])} ranked evidence rows"
+                ),
+                "explanation": SIGNAL_TYPE_EXPLANATIONS["contradiction_open"],
+                "source_path": "/contradictions",
+                "source_label": "Contradictions",
+                "object_ids": object_ids,
+                "note_paths": [],
+                "downstream_effects": [
+                    {"label": "Review contradiction", "path": f"/contradictions?q={quote(item['subject_key'], safe='')}"},
+                    *[
+                        {"label": f"Object: {claim['object_title']}", "path": f"/object?id={claim['object_id']}"}
+                        for claim in item["positive_claims"][:1] + item["negative_claims"][:1]
+                    ],
+                ],
+                "payload": {
+                    "contradiction_id": item["contradiction_id"],
+                    "scope_summary": item["scope_summary"],
+                    "status_bucket": item["status_bucket"],
+                },
+            }
+        )
+
+    for item in list_stale_summaries(resolved_vault, limit=MAX_PAGE_SIZE):
+        signals.append(
+            {
+                "signal_id": _signal_id("stale_summary", item["object_id"]),
+                "signal_type": "stale_summary",
+                "detected_at": timestamp,
+                "status": "active",
+                "title": item["title"],
+                "detail": ", ".join(item["reason_texts"]),
+                "explanation": SIGNAL_TYPE_EXPLANATIONS["stale_summary"],
+                "source_path": f"/summaries?q={quote(item['object_id'], safe='')}",
+                "source_label": "Stale Summaries",
+                "object_ids": [item["object_id"]],
+                "note_paths": [],
+                "downstream_effects": [
+                    {"label": "Open object", "path": item["object_path"]},
+                    {"label": "Review stale summary", "path": f"/summaries?q={item['object_id']}"},
+                ],
+                "payload": {
+                    "reason_codes": item["reason_codes"],
+                    "latest_event_date": item["latest_event_date"],
+                },
+            }
+        )
+
+    for item in list_production_gaps(resolved_vault, limit=MAX_PAGE_SIZE):
+        object_ids = [entry["object_id"] for entry in item["traceability"]["objects"]]
+        signals.append(
+            {
+                "signal_id": item["signal_id"],
+                "signal_type": "production_gap",
+                "detected_at": timestamp,
+                "status": "active",
+                "title": item["title"],
+                "detail": item["detail"],
+                "explanation": SIGNAL_TYPE_EXPLANATIONS["production_gap"],
+                "source_path": f"/note?path={quote(item['note_path'], safe='')}",
+                "source_label": "Production",
+                "object_ids": object_ids,
+                "note_paths": [item["note_path"]],
+                "downstream_effects": [
+                    {"label": "Open note", "path": f"/note?path={quote(item['note_path'], safe='')}"},
+                    {"label": "Inspect production chain", "path": f"/production?q={quote(item['title'], safe='')}"},
+                ],
+                "payload": {
+                    "stage_label": item["stage_label"],
+                    "missing": item["missing"],
+                    "traceability_counts": item["traceability"]["counts"],
+                },
+            }
+        )
+
+    for item in list_production_chains(resolved_vault, limit=MAX_PAGE_SIZE):
+        traceability = item["traceability"]
+        if item["stage_label"] == "source_note" and not traceability["deep_dives"]:
+            signals.append(
+                {
+                    "signal_id": _signal_id("source_needs_deep_dive", item["path"]),
+                    "signal_type": "source_needs_deep_dive",
+                    "detected_at": timestamp,
+                    "status": "active",
+                    "title": item["title"],
+                    "detail": "Processed source note has no derived deep dive yet.",
+                    "explanation": SIGNAL_TYPE_EXPLANATIONS["source_needs_deep_dive"],
+                    "source_path": f"/note?path={quote(item['path'], safe='')}",
+                    "source_label": "Production",
+                    "object_ids": [],
+                    "note_paths": [item["path"]],
+                    "downstream_effects": [
+                        {"label": "Open source note", "path": f"/note?path={quote(item['path'], safe='')}"},
+                        {"label": "Inspect production chain", "path": f"/production?q={quote(item['title'], safe='')}"},
+                    ],
+                    "payload": {
+                        "stage_label": item["stage_label"],
+                        "traceability_counts": traceability["counts"],
+                    },
+                }
+            )
+        if item["stage_label"] == "deep_dive" and not traceability["objects"]:
+            signals.append(
+                {
+                    "signal_id": _signal_id("deep_dive_needs_objects", item["path"]),
+                    "signal_type": "deep_dive_needs_objects",
+                    "detected_at": timestamp,
+                    "status": "active",
+                    "title": item["title"],
+                    "detail": "Deep dive has not produced any evergreen objects yet.",
+                    "explanation": SIGNAL_TYPE_EXPLANATIONS["deep_dive_needs_objects"],
+                    "source_path": f"/note?path={quote(item['path'], safe='')}",
+                    "source_label": "Production",
+                    "object_ids": [],
+                    "note_paths": [item["path"]],
+                    "downstream_effects": [
+                        {"label": "Open deep dive", "path": f"/note?path={quote(item['path'], safe='')}"},
+                        {"label": "Inspect production chain", "path": f"/production?q={quote(item['title'], safe='')}"},
+                    ],
+                    "payload": {
+                        "stage_label": item["stage_label"],
+                        "traceability_counts": traceability["counts"],
+                    },
+                }
+            )
+
+    for item in list_review_actions(resolved_vault, limit=MAX_PAGE_SIZE):
+        if item["event_type"] == "ui_contradictions_resolved":
+            status = item["status"] or "reviewed"
+            signals.append(
+                {
+                    "signal_id": _signal_id("contradiction_reviewed", f"{item['timestamp']}::{','.join(item['contradiction_ids'])}"),
+                    "signal_type": "contradiction_reviewed",
+                    "detected_at": item["timestamp"],
+                    "status": "active",
+                    "title": "Contradiction reviewed",
+                    "detail": f"{len(item['contradiction_ids'])} contradictions moved to {status}.",
+                    "explanation": SIGNAL_TYPE_EXPLANATIONS["contradiction_reviewed"],
+                    "source_path": "/contradictions?status=resolved",
+                    "source_label": "Review Actions",
+                    "object_ids": item["object_ids"],
+                    "note_paths": [],
+                    "downstream_effects": [
+                        {"label": "Open resolved contradictions", "path": "/contradictions?status=resolved"},
+                        *[
+                            {"label": f"Object: {object_id}", "path": f"/object?id={object_id}"}
+                            for object_id in item["object_ids"][:2]
+                        ],
+                    ],
+                    "payload": {
+                        "event_type": item["event_type"],
+                        "contradiction_ids": item["contradiction_ids"],
+                        "status": status,
+                        "rebuilt_object_ids": item["rebuilt_object_ids"],
+                    },
+                }
+            )
+        elif item["event_type"] == "ui_summaries_rebuilt":
+            rebuilt_count = item["objects_rebuilt"] or len(item["rebuilt_object_ids"])
+            signals.append(
+                {
+                    "signal_id": _signal_id("summary_rebuilt", f"{item['timestamp']}::{','.join(item['rebuilt_object_ids'])}"),
+                    "signal_type": "summary_rebuilt",
+                    "detected_at": item["timestamp"],
+                    "status": "active",
+                    "title": "Summary rebuilt",
+                    "detail": f"{rebuilt_count} summaries rebuilt.",
+                    "explanation": SIGNAL_TYPE_EXPLANATIONS["summary_rebuilt"],
+                    "source_path": "/summaries",
+                    "source_label": "Review Actions",
+                    "object_ids": item["object_ids"],
+                    "note_paths": [],
+                    "downstream_effects": [
+                        {"label": "Open stale summaries", "path": "/summaries"},
+                        *[
+                            {"label": f"Object: {object_id}", "path": f"/object?id={object_id}"}
+                            for object_id in item["rebuilt_object_ids"][:2]
+                        ],
+                    ],
+                    "payload": {
+                        "event_type": item["event_type"],
+                        "objects_rebuilt": rebuilt_count,
+                        "rebuilt_object_ids": item["rebuilt_object_ids"],
+                    },
+                }
+            )
+
+    signals.sort(key=lambda item: (item["signal_type"], item["title"].lower(), item["signal_id"]))
+    return signals
+
+
+def sync_signal_ledger(vault_dir: Path | str) -> dict[str, Any]:
+    resolved_vault = resolve_vault_dir(vault_dir)
+    layout = VaultLayout.from_vault(resolved_vault)
+    signals = _compute_signal_entries(resolved_vault)
+    _rewrite_jsonl(layout.logs_dir / f"{_SIGNAL_LOG_NAME}.jsonl", signals)
+    if layout.knowledge_db.exists():
+        with sqlite3.connect(layout.knowledge_db) as conn:
+            conn.execute("DELETE FROM audit_events WHERE source_log = ?", (_SIGNAL_LOG_NAME,))
+            conn.executemany(
+                """
+                INSERT INTO audit_events (source_log, event_type, slug, session_id, timestamp, payload_json)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                [
+                    (
+                        _SIGNAL_LOG_NAME,
+                        item["signal_type"],
+                        item["signal_id"],
+                        "signal-ledger",
+                        item["detected_at"],
+                        json.dumps(item, ensure_ascii=False),
+                    )
+                    for item in signals
+                ],
+            )
+            conn.commit()
+    type_counts = Counter(item["signal_type"] for item in signals)
+    return {
+        "signal_count": len(signals),
+        "type_counts": dict(type_counts),
+    }
+
+
+def list_signals(
+    vault_dir: Path | str,
+    *,
+    signal_type: str | None = None,
+    query: str | None = None,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    limit, _ = _validate_page_args(limit=limit, offset=0)
+    sync_signal_ledger(vault_dir)
+    db_path = _db_path(vault_dir)
+    normalized_query = (query or "").strip().lower()
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT payload_json
+            FROM audit_events
+            WHERE source_log = ?
+            ORDER BY timestamp DESC, slug
+            """,
+            (_SIGNAL_LOG_NAME,),
+        ).fetchall()
+    items: list[dict[str, Any]] = []
+    for (payload_json,) in rows:
+        try:
+            item = json.loads(payload_json)
+        except json.JSONDecodeError:
+            continue
+        if signal_type and item.get("signal_type") != signal_type:
+            continue
+        if normalized_query:
+            haystacks = [
+                str(item.get("title") or "").lower(),
+                str(item.get("detail") or "").lower(),
+                str(item.get("source_label") or "").lower(),
+            ]
+            if not any(normalized_query in haystack for haystack in haystacks):
+                continue
+        items.append(item)
+        if len(items) >= limit:
+            break
+    return items
+
+
+def get_briefing_snapshot(vault_dir: Path | str, *, limit: int = 8) -> dict[str, Any]:
+    limit, _ = _validate_page_args(limit=limit, offset=0)
+    recent_signals = list_signals(vault_dir, limit=limit)
+    unresolved_signal_types = {
+        "contradiction_open",
+        "stale_summary",
+        "production_gap",
+        "source_needs_deep_dive",
+        "deep_dive_needs_objects",
+    }
+    unresolved_issues = [item for item in recent_signals if item["signal_type"] in unresolved_signal_types][:limit]
+    changed_signals = [
+        item
+        for item in recent_signals
+        if item["signal_type"] in {"contradiction_reviewed", "summary_rebuilt"}
+    ]
+    changed_object_ids = list(
+        dict.fromkeys(
+            object_id
+            for item in changed_signals
+            for object_id in item.get("object_ids", [])
+            if object_id
+        )
+    )
+    object_rows = _batch_object_rows(vault_dir, changed_object_ids)
+    changed_objects = [
+        {
+            "object_id": object_id,
+            "title": object_rows.get(object_id, {}).get("title", object_id),
+            "path": f"/object?id={object_id}",
+        }
+        for object_id in changed_object_ids[:limit]
+    ]
+
+    topic_counts: Counter[str] = Counter()
+    for item in recent_signals:
+        for object_id in item.get("object_ids", []):
+            topic_counts[object_id] += 1
+    active_topics = [
+        {
+            "object_id": object_id,
+            "title": object_rows.get(object_id, {}).get("title")
+            or _batch_object_rows(vault_dir, [object_id]).get(object_id, {}).get("title")
+            or object_id,
+            "signal_count": count,
+            "path": f"/topic?id={object_id}",
+        }
+        for object_id, count in topic_counts.most_common(limit)
+    ]
+
+    return {
+        "generated_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "recent_signal_count": len(recent_signals),
+        "unresolved_issue_count": len(unresolved_issues),
+        "changed_object_count": len(changed_objects),
+        "active_topic_count": len(active_topics),
+        "recent_signals": recent_signals,
+        "unresolved_issues": unresolved_issues,
+        "changed_objects": changed_objects,
+        "active_topics": active_topics,
+    }
 
 
 def get_note_provenance(vault_dir: Path | str, *, note_path: str) -> dict[str, Any]:

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -34,11 +34,30 @@ from ..truth_api import (
 )
 
 DEFAULT_EVENT_DOSSIER_LIMIT = 50
+DEFAULT_TRACEABILITY_BROWSER_LIMIT = 50
 
 
 def _db_path(vault_dir: Path | str) -> Path:
     resolved = resolve_vault_dir(vault_dir)
     return VaultLayout.from_vault(resolved).knowledge_db
+
+
+def _existing_object_rows(vault_dir: Path | str, object_ids: list[str]) -> dict[str, str]:
+    normalized_object_ids = list(dict.fromkeys(object_id for object_id in object_ids if object_id))
+    if not normalized_object_ids:
+        return {}
+    db_path = _db_path(vault_dir)
+    placeholders = ",".join("?" for _ in normalized_object_ids)
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            f"""
+            SELECT object_id, title
+            FROM objects
+            WHERE object_id IN ({placeholders})
+            """,
+            tuple(normalized_object_ids),
+        ).fetchall()
+    return {str(object_id): str(title) for object_id, title in rows}
 
 
 def _object_ids_from_claim_ids(*claim_id_lists: list[str]) -> list[str]:
@@ -620,19 +639,32 @@ def build_objects_index_payload(
 
 
 def build_atlas_browser_payload(vault_dir: Path | str, *, query: str | None = None) -> dict[str, Any]:
-    items = list_atlas_memberships(vault_dir, query=query)
+    items = list_atlas_memberships(vault_dir, query=query, limit=DEFAULT_TRACEABILITY_BROWSER_LIMIT)
+    derivations = list_deep_dive_derivations(vault_dir, limit=DEFAULT_TRACEABILITY_BROWSER_LIMIT)
+    object_to_deep_dives: dict[str, dict[str, dict[str, str]]] = {}
+    object_to_source_notes: dict[str, dict[str, dict[str, str]]] = {}
+    for item in derivations:
+        source_notes = get_note_traceability(vault_dir, note_path=item["path"])["source_notes"]
+        for derived in item["derived_objects"]:
+            object_to_deep_dives.setdefault(derived["object_id"], {})[item["slug"]] = {
+                "slug": item["slug"],
+                "title": item["title"],
+                "note_type": "deep_dive",
+                "path": item["path"],
+            }
+            object_to_source_notes.setdefault(derived["object_id"], {})
+            for source in source_notes:
+                object_to_source_notes[derived["object_id"]][source["path"]] = source
     enriched_items = []
     for item in items:
         preview_titles = [member["title"] for member in item["members"][:5]]
         member_object_ids = [member["object_id"] for member in item["members"]]
-        review_context = get_review_context(vault_dir, member_object_ids)
         source_note_map: dict[str, dict[str, str]] = {}
         deep_dive_map: dict[str, dict[str, str]] = {}
         for member_object_id in member_object_ids:
-            traceability = get_object_traceability(vault_dir, member_object_id)
-            for source in traceability["source_notes"]:
+            for source in object_to_source_notes.get(member_object_id, {}).values():
                 source_note_map.setdefault(source["path"], source)
-            for deep_dive in traceability["deep_dives"]:
+            for deep_dive in object_to_deep_dives.get(member_object_id, {}).values():
                 deep_dive_map.setdefault(deep_dive["slug"], deep_dive)
         enriched_items.append(
             {
@@ -641,7 +673,6 @@ def build_atlas_browser_payload(vault_dir: Path | str, *, query: str | None = No
                 "preview_titles": preview_titles,
                 "source_notes": list(source_note_map.values()),
                 "deep_dives": list(deep_dive_map.values()),
-                "review_context": review_context,
             }
         )
     return {
@@ -649,30 +680,42 @@ def build_atlas_browser_payload(vault_dir: Path | str, *, query: str | None = No
         "items": enriched_items,
         "count": len(enriched_items),
         "query": query or "",
+        "limit": DEFAULT_TRACEABILITY_BROWSER_LIMIT,
+        "is_limited": True,
     }
 
 
 def build_derivation_browser_payload(vault_dir: Path | str, *, query: str | None = None) -> dict[str, Any]:
-    items = list_deep_dive_derivations(vault_dir, query=query)
+    items = list_deep_dive_derivations(vault_dir, query=query, limit=DEFAULT_TRACEABILITY_BROWSER_LIMIT)
     enriched_items = []
     for item in items:
-        preview_titles = [member["title"] for member in item["derived_objects"][:5]]
-        object_ids = [member["object_id"] for member in item["derived_objects"]]
-        review_context = get_review_context(vault_dir, object_ids)
+        existing_object_rows = _existing_object_rows(
+            vault_dir,
+            [member["object_id"] for member in item["derived_objects"]],
+        )
+        derived_objects = [
+            {
+                "object_id": member["object_id"],
+                "title": existing_object_rows.get(member["object_id"], member["title"]),
+            }
+            for member in item["derived_objects"]
+            if member["object_id"] in existing_object_rows
+        ]
+        preview_titles = [member["title"] for member in derived_objects[:5]]
+        provenance_map = get_object_provenance_map(vault_dir, [member["object_id"] for member in derived_objects])
         atlas_page_map: dict[str, dict[str, str]] = {}
-        for member_object_id in object_ids:
-            traceability = get_object_traceability(vault_dir, member_object_id)
-            for atlas_page in traceability["atlas_pages"]:
+        for provenance in provenance_map.values():
+            for atlas_page in provenance["mocs"]:
                 atlas_page_map.setdefault(atlas_page["slug"], atlas_page)
         source_notes = get_note_traceability(vault_dir, note_path=item["path"])["source_notes"]
         enriched_items.append(
             {
                 **item,
-                "derived_object_count": len(item["derived_objects"]),
+                "derived_objects": derived_objects,
+                "derived_object_count": len(derived_objects),
                 "preview_titles": preview_titles,
                 "atlas_pages": list(atlas_page_map.values()),
                 "source_notes": source_notes,
-                "review_context": review_context,
             }
         )
     return {
@@ -680,11 +723,13 @@ def build_derivation_browser_payload(vault_dir: Path | str, *, query: str | None
         "items": enriched_items,
         "count": len(enriched_items),
         "query": query or "",
+        "limit": DEFAULT_TRACEABILITY_BROWSER_LIMIT,
+        "is_limited": True,
     }
 
 
 def build_production_browser_payload(vault_dir: Path | str, *, query: str | None = None) -> dict[str, Any]:
-    items = list_production_chains(vault_dir, query=query)
+    items = list_production_chains(vault_dir, query=query, limit=DEFAULT_TRACEABILITY_BROWSER_LIMIT)
     source_items = [item for item in items if item["stage_label"] == "source_note"]
     deep_dive_items = [item for item in items if item["stage_label"] == "deep_dive"]
     weak_points = _build_production_weak_points(vault_dir, query=query)
@@ -696,6 +741,8 @@ def build_production_browser_payload(vault_dir: Path | str, *, query: str | None
         "weak_points": weak_points,
         "count": len(items),
         "query": query or "",
+        "limit": DEFAULT_TRACEABILITY_BROWSER_LIMIT,
+        "is_limited": True,
         "counts": {
             "source_notes": len(source_items),
             "deep_dives": len(deep_dive_items),

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -11,7 +11,9 @@ from ..runtime import VaultLayout, resolve_vault_dir
 from ..truth_store import CONTRADICTION_HEURISTIC_NOTE
 from ..truth_api import (
     CONTRADICTION_STATUS_EXPLANATIONS,
+    SIGNAL_TYPE_EXPLANATIONS,
     count_objects,
+    get_briefing_snapshot,
     get_object_detail,
     get_object_traceability,
     get_note_provenance,
@@ -24,7 +26,9 @@ from ..truth_api import (
     list_contradictions,
     list_deep_dive_derivations,
     list_objects,
+    list_production_gaps,
     list_production_chains,
+    list_signals,
     list_stale_summaries,
     search_vault_surface,
 )
@@ -144,39 +148,32 @@ def _build_production_weak_points(
     query: str | None = None,
     limit: int = 12,
 ) -> list[dict[str, Any]]:
-    items = list_production_chains(vault_dir, query=query, limit=200)
-    weak_points: list[dict[str, Any]] = []
-    for item in items:
-        traceability = item["traceability"]
-        missing: list[str] = []
-        if item["stage_label"] == "source_note":
-            if not traceability["deep_dives"]:
-                missing.append("deep dives")
-            if not traceability["objects"]:
-                missing.append("objects")
-            if not traceability["atlas_pages"]:
-                missing.append("Atlas / MOC reach")
-        else:
-            if not traceability["source_notes"]:
-                missing.append("source notes")
-            if not traceability["objects"]:
-                missing.append("objects")
-            if not traceability["atlas_pages"]:
-                missing.append("Atlas / MOC reach")
-        if not missing:
-            continue
-        weak_points.append(
-            {
-                "title": item["title"],
-                "note_path": item["path"],
-                "stage_label": item["stage_label"],
-                "missing": missing,
-                "severity": len(missing),
-                "detail": ", ".join(missing),
-            }
-        )
-    weak_points.sort(key=lambda item: (-item["severity"], item["stage_label"], item["title"].lower()))
-    return weak_points[:limit]
+    return list_production_gaps(vault_dir, query=query, limit=limit)
+
+
+def build_signal_browser_payload(
+    vault_dir: Path | str,
+    *,
+    signal_type: str | None = None,
+    query: str | None = None,
+) -> dict[str, Any]:
+    items = list_signals(vault_dir, signal_type=signal_type, query=query)
+    return {
+        "screen": "signals/browser",
+        "items": items,
+        "count": len(items),
+        "query": query or "",
+        "signal_type": signal_type or "",
+        "type_counts": dict(Counter(item["signal_type"] for item in items)),
+        "signal_type_explanations": SIGNAL_TYPE_EXPLANATIONS,
+    }
+
+
+def build_briefing_payload(vault_dir: Path | str) -> dict[str, Any]:
+    return {
+        "screen": "briefing/snapshot",
+        **get_briefing_snapshot(vault_dir),
+    }
 
 
 def build_object_page_payload(vault_dir: Path | str, object_id: str) -> dict[str, Any]:
@@ -533,6 +530,7 @@ def build_truth_dashboard_payload(vault_dir: Path | str) -> dict[str, Any]:
     contradictions = build_contradiction_browser_payload(vault_dir)
     events = build_event_dossier_payload(vault_dir, limit=8)
     stale_summaries = build_stale_summary_browser_payload(vault_dir)
+    signals = build_signal_browser_payload(vault_dir)
     production_weak_points = _build_production_weak_points(vault_dir)
     priorities: list[dict[str, Any]] = []
     for item in contradictions["items"][:4]:
@@ -585,6 +583,11 @@ def build_truth_dashboard_payload(vault_dir: Path | str) -> dict[str, Any]:
         "production": {
             "weak_points": production_weak_points,
             "weak_point_count": len(production_weak_points),
+        },
+        "signals": {
+            "count": signals["count"],
+            "items": signals["items"][:8],
+            "type_counts": signals["type_counts"],
         },
         "recent_review_actions": list_review_actions(vault_dir, limit=8),
         "priorities": priorities[:8],

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -33,6 +33,8 @@ from ..truth_api import (
     search_vault_surface,
 )
 
+DEFAULT_EVENT_DOSSIER_LIMIT = 50
+
 
 def _db_path(vault_dir: Path | str) -> Path:
     resolved = resolve_vault_dir(vault_dir)
@@ -278,6 +280,7 @@ def build_event_dossier_payload(
 ) -> dict[str, Any]:
     db_path = _db_path(vault_dir)
     normalized_query = _escape_like(query.strip().lower()) if query else ""
+    effective_limit = DEFAULT_EVENT_DOSSIER_LIMIT if limit is None else limit
     with sqlite3.connect(db_path) as conn:
         sql = """
             SELECT timeline_events.event_date, timeline_events.event_type, timeline_events.heading,
@@ -300,10 +303,10 @@ def build_event_dossier_payload(
                     f"%{normalized_query}%",
                 ]
             )
-        sql += " ORDER BY timeline_events.event_date, objects.object_id"
-        if limit is not None:
+        sql += " ORDER BY timeline_events.event_date DESC, objects.object_id"
+        if effective_limit is not None:
             sql += " LIMIT ?"
-            params.append(limit)
+            params.append(effective_limit)
         rows = conn.execute(sql, tuple(params)).fetchall()
 
     events = [
@@ -332,7 +335,7 @@ def build_event_dossier_payload(
             event["object_id"],
             {"evergreen_path": "", "source_notes": [], "mocs": []},
         )
-    dates = sorted({event["event_date"] for event in events})
+    dates = sorted({event["event_date"] for event in events}, reverse=True)
     grouped: dict[str, list[dict[str, Any]]] = {}
     for event in events:
         grouped.setdefault(event["event_date"], []).append(event)
@@ -354,6 +357,8 @@ def build_event_dossier_payload(
         "dates": dates,
         "cluster_sections": cluster_sections,
         "event_type_counts": dict(event_type_counts),
+        "limit": effective_limit,
+        "is_limited": effective_limit is not None,
         "timeline_contract": {
             "timeline_kind": "dated_note_projection",
             "row_type_counts": dict(row_type_counts),

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -1053,3 +1053,205 @@ def test_surface_page_query_clauses_parameterizes_note_type():
 
     assert "pages_index.note_type = ?" in where_sql
     assert params[0] == "moc"
+
+
+def test_truth_api_syncs_and_lists_active_signals(temp_vault):
+    from openclaw_pipeline.truth_api import list_signals, sync_signal_ledger
+
+    vault = _seed_truth_vault(temp_vault)
+    thin = vault / "10-Knowledge" / "Evergreen" / "Thin.md"
+    thin.write_text(
+        """---
+note_id: thin-note
+title: Thin Note
+type: evergreen
+date: 2026-04-13
+---
+
+# Thin Note
+
+Thin.
+""",
+        encoding="utf-8",
+    )
+    loose_source = vault / "50-Inbox" / "03-Processed" / "2026-04" / "Loose Source.md"
+    loose_source.parent.mkdir(parents=True, exist_ok=True)
+    loose_source.write_text(
+        """---
+title: Loose Source
+source: https://example.com/loose
+---
+
+Processed source note with no downstream chain.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(vault)
+
+    summary = sync_signal_ledger(vault)
+    items = list_signals(vault)
+
+    assert summary["signal_count"] >= 3
+    assert any(item["signal_type"] == "contradiction_open" for item in items)
+    assert any(item["signal_type"] == "stale_summary" for item in items)
+    assert any(item["signal_type"] == "production_gap" for item in items)
+    contradiction = next(item for item in items if item["signal_type"] == "contradiction_open")
+    assert contradiction["source_path"] == "/contradictions"
+    assert contradiction["downstream_effects"]
+    stale = next(item for item in items if item["signal_type"] == "stale_summary")
+    assert stale["object_ids"] == ["thin-note"]
+    assert stale["source_path"] == "/summaries?q=thin-note"
+
+
+def test_truth_api_filters_signal_ledger_by_type_and_query(temp_vault):
+    from openclaw_pipeline.truth_api import list_signals, sync_signal_ledger
+
+    vault = _seed_truth_vault(temp_vault)
+    loose_source = vault / "50-Inbox" / "03-Processed" / "2026-04" / "Loose Source.md"
+    loose_source.parent.mkdir(parents=True, exist_ok=True)
+    loose_source.write_text(
+        """---
+title: Loose Source
+source: https://example.com/loose
+---
+
+Processed source note with no downstream chain.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(vault)
+
+    sync_signal_ledger(vault)
+
+    production_only = list_signals(vault, signal_type="production_gap")
+    searched = list_signals(vault, query="agent harness")
+
+    assert production_only
+    assert {item["signal_type"] for item in production_only} == {"production_gap"}
+    assert searched
+    assert all("agent harness" in f"{item['title']} {item['detail']}".lower() for item in searched)
+
+
+def test_truth_api_includes_extraction_trigger_signals(temp_vault):
+    from openclaw_pipeline.truth_api import list_signals, sync_signal_ledger
+
+    vault = _seed_truth_vault(temp_vault)
+    processed = vault / "50-Inbox" / "03-Processed" / "2026-04" / "Harness Source.md"
+    processed.parent.mkdir(parents=True, exist_ok=True)
+    processed.write_text(
+        """---
+title: Harness Source
+source: https://example.com/harness
+---
+
+Processed source note without any derived deep dive.
+""",
+        encoding="utf-8",
+    )
+    deep_dive = vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "Harness Deep Dive_深度解读.md"
+    deep_dive.parent.mkdir(parents=True, exist_ok=True)
+    deep_dive.write_text(
+        """---
+note_id: harness-deep-dive
+title: Harness Deep Dive
+type: deep_dive
+source: https://example.com/another-harness
+date: 2026-04-13
+---
+
+# Harness Deep Dive
+
+Mentions [[source-note]] but has not produced any evergreen objects yet.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(vault)
+
+    sync_signal_ledger(vault)
+    items = list_signals(vault)
+
+    assert any(item["signal_type"] == "source_needs_deep_dive" for item in items)
+    assert any(item["signal_type"] == "deep_dive_needs_objects" for item in items)
+    source_signal = next(item for item in items if item["signal_type"] == "source_needs_deep_dive")
+    deep_dive_signal = next(item for item in items if item["signal_type"] == "deep_dive_needs_objects")
+    assert source_signal["note_paths"] == ["50-Inbox/03-Processed/2026-04/Harness Source.md"]
+    assert deep_dive_signal["note_paths"] == ["20-Areas/AI-Research/Topics/2026-04/Harness Deep Dive_深度解读.md"]
+
+
+def test_truth_api_builds_briefing_snapshot(temp_vault):
+    from openclaw_pipeline.truth_api import get_briefing_snapshot, record_review_action, sync_signal_ledger
+
+    vault = _seed_truth_vault(temp_vault)
+    thin = vault / "10-Knowledge" / "Evergreen" / "Thin.md"
+    thin.write_text(
+        """---
+note_id: thin-note
+title: Thin Note
+type: evergreen
+date: 2026-04-13
+---
+
+# Thin Note
+
+Thin.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(vault)
+    record_review_action(
+        vault,
+        event_type="ui_summaries_rebuilt",
+        slug="source-note",
+        payload={
+            "object_ids": ["source-note"],
+            "objects_rebuilt": 1,
+            "rebuilt_object_ids": ["source-note"],
+        },
+    )
+    sync_signal_ledger(vault)
+
+    payload = get_briefing_snapshot(vault)
+
+    assert payload["recent_signal_count"] >= 1
+    assert payload["unresolved_issue_count"] >= 1
+    assert payload["recent_signals"]
+    assert payload["unresolved_issues"]
+    assert any(item["object_id"] == "source-note" for item in payload["changed_objects"])
+    assert payload["active_topics"]
+
+
+def test_truth_api_includes_review_action_signals(temp_vault):
+    from openclaw_pipeline.truth_api import list_signals, record_review_action, sync_signal_ledger
+
+    vault = _seed_truth_vault(temp_vault)
+    record_review_action(
+        vault,
+        event_type="ui_contradictions_resolved",
+        slug="source-note",
+        payload={
+            "object_ids": ["source-note"],
+            "contradiction_ids": ["contradiction::alpha"],
+            "status": "dismissed",
+            "note": "Reviewed",
+            "rebuilt_object_ids": ["source-note"],
+        },
+    )
+    record_review_action(
+        vault,
+        event_type="ui_summaries_rebuilt",
+        slug="source-note",
+        payload={
+            "object_ids": ["source-note"],
+            "objects_rebuilt": 1,
+            "rebuilt_object_ids": ["source-note"],
+        },
+    )
+
+    sync_signal_ledger(vault)
+    items = list_signals(vault)
+
+    assert any(item["signal_type"] == "contradiction_reviewed" for item in items)
+    assert any(item["signal_type"] == "summary_rebuilt" for item in items)
+    reviewed = next(item for item in items if item["signal_type"] == "contradiction_reviewed")
+    assert reviewed["object_ids"] == ["source-note"]
+    assert reviewed["source_path"] == "/contradictions?status=resolved"

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -1132,6 +1132,29 @@ Processed source note with no downstream chain.
     assert all("agent harness" in f"{item['title']} {item['detail']}".lower() for item in searched)
 
 
+def test_truth_api_reuses_signal_ledger_when_dependencies_unchanged(temp_vault, monkeypatch):
+    import openclaw_pipeline.truth_api as truth_api
+
+    vault = _seed_truth_vault(temp_vault)
+    truth_api.sync_signal_ledger(vault)
+
+    calls = 0
+    original = truth_api._compute_signal_entries
+
+    def counted(vault_dir):
+        nonlocal calls
+        calls += 1
+        return original(vault_dir)
+
+    monkeypatch.setattr(truth_api, "_compute_signal_entries", counted)
+
+    first = truth_api.list_signals(vault)
+    second = truth_api.list_signals(vault)
+
+    assert first == second
+    assert calls == 0
+
+
 def test_truth_api_includes_extraction_trigger_signals(temp_vault):
     from openclaw_pipeline.truth_api import list_signals, sync_signal_ledger
 

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -552,6 +552,10 @@ def test_ui_server_main_starts_server_with_requested_bind(temp_vault, capsys, mo
         "openclaw_pipeline.commands.ui_server.build_objects_index_payload",
         lambda vault_dir, *, limit, offset: {"items": []},
     )
+    monkeypatch.setattr(
+        "openclaw_pipeline.commands.ui_server.ensure_signal_ledger_synced",
+        lambda vault_dir: {"signal_count": 0, "type_counts": {}},
+    )
 
     exit_code = main(["--vault-dir", str(temp_vault), "--host", "127.0.0.1", "--port", "9999"])
     payload = json.loads(capsys.readouterr().out)

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -193,6 +193,77 @@ def test_ui_server_contradictions_endpoint_returns_payload(temp_vault):
     assert payload["items"][0]["subject_key"] == "alpha"
 
 
+def test_ui_server_signals_endpoint_returns_payload(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+
+    _seed_truth_store(temp_vault)
+    loose_source = temp_vault / "50-Inbox" / "03-Processed" / "2026-04" / "Loose Source.md"
+    loose_source.parent.mkdir(parents=True, exist_ok=True)
+    loose_source.write_text(
+        """---
+title: Loose Source
+source: https://example.com/loose
+---
+
+Processed source note without downstream chain.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("GET", "/api/signals")
+        response = conn.getresponse()
+        payload = json.loads(response.read().decode("utf-8"))
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 200
+    assert payload["count"] >= 2
+    assert "contradiction_open" in payload["type_counts"]
+
+
+def test_ui_server_briefing_endpoint_returns_payload(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+    from openclaw_pipeline.truth_api import record_review_action
+
+    _seed_truth_store(temp_vault)
+    record_review_action(
+        temp_vault,
+        event_type="ui_summaries_rebuilt",
+        slug="alpha",
+        payload={
+            "object_ids": ["alpha"],
+            "objects_rebuilt": 1,
+            "rebuilt_object_ids": ["alpha"],
+        },
+    )
+    rebuild_knowledge_index(temp_vault)
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("GET", "/api/briefing")
+        response = conn.getresponse()
+        payload = json.loads(response.read().decode("utf-8"))
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 200
+    assert payload["recent_signal_count"] >= 1
+    assert payload["active_topics"]
+
+
 def test_ui_server_can_resolve_contradiction_via_api(temp_vault):
     from openclaw_pipeline.commands.ui_server import create_server
     from openclaw_pipeline.runtime import VaultLayout

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -213,15 +213,18 @@ date: 2026-04-13
     assert atlas_status == 200
     assert "Atlas / MOC Browser" in atlas_body
     assert "Contribution Summary" in atlas_body
+    assert "Showing the most recent 50 atlas pages" in atlas_body
 
     assert deep_dives_status == 200
     assert "Deep Dive Derivations" in deep_dives_body
     assert "Contribution Summary" in deep_dives_body
+    assert "Showing the most recent 50 deep dives" in deep_dives_body
     assert "Source Deep Dive" in deep_dives_body
 
     assert production_status == 200
     assert "Production Browser" in production_body
     assert "Chain Model" in production_body
+    assert "Showing the most recent 50 production-chain entries" in production_body
     assert "Weak Points" in production_body
     assert "Source Deep Dive" in production_body
     assert "deep dive" in production_body

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -937,6 +937,18 @@ def test_ui_root_dashboard_renders_db_summary(temp_vault):
     from openclaw_pipeline.commands.ui_server import create_server
 
     _seed_truth_store(temp_vault)
+    loose_source = temp_vault / "50-Inbox" / "03-Processed" / "2026-04" / "Loose Source.md"
+    loose_source.parent.mkdir(parents=True, exist_ok=True)
+    loose_source.write_text(
+        """---
+title: Loose Source
+source: https://example.com/loose
+---
+
+Processed source note without downstream chain.
+""",
+        encoding="utf-8",
+    )
     thin = temp_vault / "10-Knowledge" / "Evergreen" / "Thin.md"
     thin.write_text(
         """---
@@ -974,6 +986,134 @@ Thin note.
     assert "Thin Note" in root_body
     assert "/summaries" in root_body
     assert "Production Weak Points" in root_body
+    assert "Signals" in root_body
+
+
+def test_ui_signals_page_renders_active_signal_ledger(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+    from openclaw_pipeline.truth_api import record_review_action
+
+    _seed_truth_store(temp_vault)
+    loose_source = temp_vault / "50-Inbox" / "03-Processed" / "2026-04" / "Loose Source.md"
+    loose_source.parent.mkdir(parents=True, exist_ok=True)
+    loose_source.write_text(
+        """---
+title: Loose Source
+source: https://example.com/loose
+---
+
+Processed source note without downstream chain.
+""",
+        encoding="utf-8",
+    )
+    record_review_action(
+        temp_vault,
+        event_type="ui_summaries_rebuilt",
+        slug="alpha",
+        payload={
+            "object_ids": ["alpha"],
+            "objects_rebuilt": 1,
+            "rebuilt_object_ids": ["alpha"],
+        },
+    )
+    rebuild_knowledge_index(temp_vault)
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        status, body = _get(port, "/signals")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert status == 200
+    assert "Active Signals" in body
+    assert "contradiction_open" in body
+    assert "production_gap" in body
+    assert "summary_rebuilt" in body
+
+
+def test_ui_signals_page_renders_extraction_trigger_signals(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+
+    _seed_truth_store(temp_vault)
+    processed = temp_vault / "50-Inbox" / "03-Processed" / "2026-04" / "Harness Source.md"
+    processed.parent.mkdir(parents=True, exist_ok=True)
+    processed.write_text(
+        """---
+title: Harness Source
+source: https://example.com/harness
+---
+
+Processed source note without any derived deep dive.
+""",
+        encoding="utf-8",
+    )
+    deep_dive = temp_vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "Harness Deep Dive_深度解读.md"
+    deep_dive.parent.mkdir(parents=True, exist_ok=True)
+    deep_dive.write_text(
+        """---
+note_id: harness-deep-dive
+title: Harness Deep Dive
+type: deep_dive
+source: https://example.com/another-harness
+date: 2026-04-13
+---
+
+# Harness Deep Dive
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        status, body = _get(port, "/signals")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert status == 200
+    assert "source_needs_deep_dive" in body
+    assert "deep_dive_needs_objects" in body
+
+
+def test_ui_briefing_page_renders_briefing_snapshot(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+    from openclaw_pipeline.truth_api import record_review_action
+
+    _seed_truth_store(temp_vault)
+    record_review_action(
+        temp_vault,
+        event_type="ui_summaries_rebuilt",
+        slug="alpha",
+        payload={
+            "object_ids": ["alpha"],
+            "objects_rebuilt": 1,
+            "rebuilt_object_ids": ["alpha"],
+        },
+    )
+    rebuild_knowledge_index(temp_vault)
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        status, body = _get(port, "/briefing")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert status == 200
+    assert "Working Memory Snapshot" in body
+    assert "Recent Signals" in body
+    assert "Active Topics" in body
 
 
 def test_ui_contradictions_and_summaries_support_batch_actions(temp_vault):

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -199,6 +199,7 @@ date: 2026-04-13
     assert "Event Clusters" in events_body
     assert "Review Context" in events_body
     assert "Production Contribution" in events_body
+    assert "Showing the most recent 50 timeline rows" in events_body
     assert "Top Source Notes" in events_body
     assert "/summaries?q=alpha" in events_body
     assert "Quick Maintenance" in events_body

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -545,6 +545,57 @@ Filler note.
     assert len(payload["objects"]["items"]) == 12
 
 
+def test_build_signal_browser_payload(temp_vault):
+    from openclaw_pipeline.ui.view_models import build_signal_browser_payload
+
+    _seed_truth_store(temp_vault)
+    loose_source = temp_vault / "50-Inbox" / "03-Processed" / "2026-04" / "Loose Source.md"
+    loose_source.parent.mkdir(parents=True, exist_ok=True)
+    loose_source.write_text(
+        """---
+title: Loose Source
+source: https://example.com/loose
+---
+
+Processed source note without downstream chain.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    payload = build_signal_browser_payload(temp_vault)
+
+    assert payload["screen"] == "signals/browser"
+    assert payload["count"] >= 2
+    assert payload["type_counts"]["contradiction_open"] >= 1
+    assert any(item["signal_type"] == "production_gap" for item in payload["items"])
+
+
+def test_build_briefing_payload(temp_vault):
+    from openclaw_pipeline.ui.view_models import build_briefing_payload
+    from openclaw_pipeline.truth_api import record_review_action
+
+    _seed_truth_store(temp_vault)
+    record_review_action(
+        temp_vault,
+        event_type="ui_summaries_rebuilt",
+        slug="alpha",
+        payload={
+            "object_ids": ["alpha"],
+            "objects_rebuilt": 1,
+            "rebuilt_object_ids": ["alpha"],
+        },
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    payload = build_briefing_payload(temp_vault)
+
+    assert payload["screen"] == "briefing/snapshot"
+    assert payload["recent_signal_count"] >= 1
+    assert payload["recent_signals"]
+    assert payload["active_topics"]
+
+
 def test_build_event_dossier_payload_filters_by_query(temp_vault):
     from openclaw_pipeline.ui.view_models import build_event_dossier_payload
 

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -244,6 +244,8 @@ def test_build_event_dossier_payload(temp_vault):
     assert payload["events"][0]["semantic_role"] == "note_date_projection"
     assert payload["cluster_sections"][0]["date"] == "2026-04-13"
     assert payload["event_type_counts"] == {"dated_note": 3}
+    assert payload["limit"] == 50
+    assert payload["is_limited"] is True
     assert payload["timeline_contract"]["timeline_kind"] == "dated_note_projection"
     assert payload["timeline_contract"]["row_type_counts"] == {"page_date": 3}
     assert payload["timeline_contract"]["semantic_roles"] == {"note_date_projection": 3}
@@ -1095,6 +1097,47 @@ def test_build_event_dossier_payload_applies_limit_before_materializing(temp_vau
 
     assert payload["event_count"] == 2
     assert len(payload["events"]) == 2
+
+
+def test_build_event_dossier_payload_orders_latest_first(temp_vault):
+    from openclaw_pipeline.ui.view_models import build_event_dossier_payload
+
+    older = temp_vault / "10-Knowledge" / "Evergreen" / "Older.md"
+    newer = temp_vault / "10-Knowledge" / "Evergreen" / "Newer.md"
+    older.write_text(
+        """---
+note_id: older
+title: Older
+type: evergreen
+date: 2026-04-10
+---
+
+# Older
+
+Older event.
+""",
+        encoding="utf-8",
+    )
+    newer.write_text(
+        """---
+note_id: newer
+title: Newer
+type: evergreen
+date: 2026-04-13
+---
+
+# Newer
+
+Newer event.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    payload = build_event_dossier_payload(temp_vault)
+
+    assert payload["dates"][0] == "2026-04-13"
+    assert payload["events"][0]["object_id"] == "newer"
 
 
 def test_build_object_page_payload_handles_missing_summary(temp_vault):

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -685,6 +685,8 @@ date: 2026-04-13
     assert payload["items"][0]["members"][0]["object_id"] == "alpha"
     assert payload["items"][0]["member_count"] == 1
     assert payload["items"][0]["preview_titles"] == ["Alpha"]
+    assert payload["limit"] == 50
+    assert payload["is_limited"] is True
 
 
 def test_build_derivation_browser_payload(temp_vault):
@@ -738,6 +740,8 @@ Mentions [[alpha]].
     assert payload["items"][0]["derived_object_count"] == 1
     assert payload["items"][0]["preview_titles"] == ["Alpha"]
     assert payload["items"][0]["source_notes"] == []
+    assert payload["limit"] == 50
+    assert payload["is_limited"] is True
 
 
 def test_build_derivation_browser_payload_includes_chain_context(temp_vault):
@@ -971,6 +975,8 @@ Mentions [[alpha]].
     assert payload["counts"]["deep_dives"] == 1
     assert any(item["stage_label"] == "source_note" for item in payload["items"])
     assert any(item["stage_label"] == "deep_dive" for item in payload["items"])
+    assert payload["limit"] == 50
+    assert payload["is_limited"] is True
 
 
 def test_build_production_browser_payload_surfaces_weak_points(temp_vault):
@@ -995,6 +1001,60 @@ Processed source note without downstream chain.
     assert payload["weak_points"]
     assert payload["weak_points"][0]["title"] == "Loose Source"
     assert "deep dives" in payload["weak_points"][0]["missing"]
+
+
+def test_build_derivation_browser_payload_filters_stale_object_ids(temp_vault):
+    from openclaw_pipeline.ui.view_models import build_derivation_browser_payload
+    from openclaw_pipeline.runtime import VaultLayout
+
+    alpha = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
+    alpha.write_text(
+        """---
+note_id: alpha
+title: Alpha
+type: evergreen
+date: 2026-04-13
+---
+
+# Alpha
+
+Alpha supports local-first execution.
+""",
+        encoding="utf-8",
+    )
+    deep_dive = temp_vault / "20-Areas" / "Tools" / "Topics" / "2026-04" / "Deep Dive_深度解读.md"
+    deep_dive.parent.mkdir(parents=True, exist_ok=True)
+    deep_dive.write_text(
+        """---
+note_id: deep-dive
+title: Deep Dive
+type: deep_dive
+date: 2026-04-13
+---
+
+# Deep Dive
+
+Mentions [[alpha]].
+""",
+        encoding="utf-8",
+    )
+    logs_dir = temp_vault / "60-Logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    (logs_dir / "pipeline.jsonl").write_text(
+        "\n".join(
+            [
+                '{"event_type":"evergreen_auto_promoted","concept":"alpha","source":"Deep Dive_深度解读.md","mutation":{"target_slug":"alpha"}}',
+                '{"event_type":"evergreen_auto_promoted","concept":"stale-object","source":"Deep Dive_深度解读.md","mutation":{"target_slug":"stale-object"}}',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    payload = build_derivation_browser_payload(temp_vault)
+
+    assert [item["object_id"] for item in payload["items"][0]["derived_objects"]] == ["alpha"]
 
 
 def test_build_stale_summary_browser_payload(temp_vault):


### PR DESCRIPTION
## Summary
- add Phase 12 active signal loop surfaces with persisted signal ledger and `/signals`
- add change and extraction-trigger signals plus briefing-ready snapshot payloads
- update milestone and Phase 12 planning docs to reflect the current active-system transition

## Test Plan
- [x] `PYTHONPATH=src python3.13 -m pytest -q`
- [x] `python3.13 -m compileall src/openclaw_pipeline`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/19" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Signals" page to browse, search, and filter active signals by type (contradictions, gaps, stale summaries, etc.)
  * Added "Briefing" page displaying a working memory snapshot with recent signals, unresolved issues, changed objects, and active topics
  * Extended dashboard navigation and statistics with new Signals section

<!-- end of auto-generated comment: release notes by coderabbit.ai -->