### PR TITLE
chore: enable trusted publisher for PyPI

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -14,6 +14,8 @@ jobs:
     environment:
       name: pypi
       url: https://pypi.org/p/obsidian-vault-pipeline
+    permissions:
+      id-token: write  # OIDC token for trusted publishing
 
     steps:
     - name: Checkout code
@@ -25,20 +27,10 @@ jobs:
         python-version: '3.11'
 
     - name: Install build dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install build twine
+      run: pip install build
 
     - name: Build package
       run: python -m build
 
-    - name: Check package
-      run: |
-        twine check dist/*
-        ls -la dist/
-
     - name: Publish to PyPI
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-      run: twine upload dist/* --skip-existing
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "obsidian-vault-pipeline"
-version = "0.8.5"
+version = "0.8.6"
 description = "全自动Obsidian知识管理Pipeline - 生产级知识管理流水线"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Switch PyPI publishing from API token to Trusted Publisher (OIDC)
- Update `publish-pypi.yml` to use `pypa/gh-action-pypi-publish@release/v1`
- Bump version to 0.8.6

## Test plan
- [x] Tag `v0.8.6` pushed, workflow triggered
- [ ] Verify PyPI publish succeeds via Trusted Publisher
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/20" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.8.6
  * Enhanced CI/CD publishing workflow with improved security and simplified deployment process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->