### PR TITLE
feat: add knowledge evolution review workbench

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -14,6 +14,8 @@ jobs:
     environment:
       name: pypi
       url: https://pypi.org/p/obsidian-vault-pipeline
+    permissions:
+      id-token: write  # OIDC token for trusted publishing
 
     steps:
     - name: Checkout code
@@ -25,20 +27,10 @@ jobs:
         python-version: '3.11'
 
     - name: Install build dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install build twine
+      run: pip install build
 
     - name: Build package
       run: python -m build
 
-    - name: Check package
-      run: |
-        twine check dist/*
-        ls -la dist/
-
     - name: Publish to PyPI
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-      run: twine upload dist/* --skip-existing
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "obsidian-vault-pipeline"
-version = "0.8.5"
+version = "0.8.6"
 description = "全自动Obsidian知识管理Pipeline - 生产级知识管理流水线"
 readme = "README.md"
 license = "MIT"

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -22,6 +22,7 @@ from ..ui.view_models import (
     build_briefing_payload,
     build_contradiction_browser_payload,
     build_derivation_browser_payload,
+    build_evolution_browser_payload,
     build_event_dossier_payload,
     build_note_page_payload,
     build_object_page_payload,
@@ -33,11 +34,12 @@ from ..ui.view_models import (
     build_truth_dashboard_payload,
     build_topic_overview_payload,
 )
-from ..truth_api import ensure_signal_ledger_synced, record_review_action
+from ..truth_api import ensure_signal_ledger_synced, record_review_action, review_evolution_candidate
 
 _MARKDOWN_RENDERER = MarkdownIt("commonmark", {"breaks": True, "html": False}).enable("table")
 _FENCED_FRONTMATTER_RE = re.compile(r"^```ya?ml\s*\n---\n(.*?)\n---\n```\s*\n?", re.DOTALL)
 _GITHUB_REPO_RE = re.compile(r"https://github\.com/([^/\s]+)/([^/\s#]+)")
+_EVOLUTION_LINK_TYPES = ["challenges", "replaces", "enriches", "confirms"]
 
 
 def _layout(title: str, body: str) -> str:
@@ -105,6 +107,7 @@ def _layout(title: str, body: str) -> str:
             <a href="/search">Search</a>
             <a href="/signals">Signals</a>
             <a href="/briefing">Briefing</a>
+            <a href="/evolution">Evolution</a>
             <a href="/production">Production</a>
             <a href="/atlas">Atlas</a>
             <a href="/deep-dives">Deep Dives</a>
@@ -576,6 +579,79 @@ def _render_object_links(items: list[dict[str, str]]) -> str:
     )
 
 
+def _render_evolution_link_type_select(selected: str) -> str:
+    return "<select name='link_type'>" + "".join(
+        f"<option value='{escape(option)}' {'selected' if option == selected else ''}>{escape(option)}</option>"
+        for option in _EVOLUTION_LINK_TYPES
+    ) + "</select>"
+
+
+def _render_evolution_review_form(item: dict[str, object]) -> str:
+    link_type = str(item.get("link_type") or "")
+    return (
+        "<form method='post' action='/evolution/review' class='link-row'>"
+        f"<input type='hidden' name='evolution_id' value='{escape(str(item['evolution_id']))}' />"
+        f"{_render_evolution_link_type_select(link_type)}"
+        "<input type='text' name='note' placeholder='Review note' />"
+        "<button type='submit' name='status' value='accepted'>Accept</button>"
+        "<button type='submit' name='status' value='rejected'>Reject</button>"
+        "</form>"
+    )
+
+
+def _render_evolution_links(items: list[dict[str, object]], *, empty_text: str) -> str:
+    if not items:
+        return f"<p class='muted'>{escape(empty_text)}</p>"
+    rows = []
+    for item in items:
+        rows.append(
+            "<li>"
+            f"<span class='pill'>{escape(str(item.get('link_type') or 'evolution'))}</span> "
+            f"{escape(str(item.get('subject_kind') or 'subject'))}: {escape(str(item.get('subject_id') or ''))}"
+            f"<div class='muted'>Earlier: {escape(str(item.get('earlier_ref') or ''))} | Later: {escape(str(item.get('later_ref') or ''))}</div>"
+            + (
+                f"<div class='muted'>Note: {escape(str(item.get('note') or ''))}</div>"
+                if item.get("note")
+                else ""
+            )
+            + (
+                f"<div class='muted'>Reviewed at: {escape(str(item.get('timestamp') or ''))}</div>"
+                if item.get("timestamp")
+                else ""
+            )
+            + "</li>"
+        )
+    return "<ul class='list-tight'>" + "".join(rows) + "</ul>"
+
+
+def _render_evolution_candidates(items: list[dict[str, object]], *, compact: bool = False, reviewable: bool = False) -> str:
+    if not items:
+        return "<p class='muted'>No evolution candidates surfaced for this scope.</p>"
+    rows = []
+    for item in items[: 3 if compact else len(items)]:
+        source_paths = ", ".join(
+            f'<a href="{escape(_note_href(path))}">{escape(path)}</a>'
+            for path in item["source_paths"]
+        ) or "<span class='muted'>None</span>"
+        evidence = ", ".join(
+            escape(str(entry.get("source_slug") or entry.get("path") or entry.get("title") or ""))
+            for entry in item["evidence"][:2]
+            if isinstance(entry, dict)
+        )
+        rows.append(
+            "<li>"
+            f"<span class='pill'>{escape(str(item['link_type']))}</span> "
+            f"{escape(str(item['subject_kind']))}: {escape(str(item['subject_id']))}"
+            f"<div class='muted'>Earlier: {escape(str(item['earlier_ref']))} | Later: {escape(str(item['later_ref']))}</div>"
+            f"<div class='muted'>Reasons: {escape(', '.join(str(code) for code in item['reason_codes']))}</div>"
+            f"<div class='muted'>Sources: {source_paths}</div>"
+            + (f"<div class='muted'>Evidence: {evidence}</div>" if evidence else "")
+            + (_render_evolution_review_form(item) if reviewable else "")
+            + "</li>"
+        )
+    return "<ul class='list-tight'>" + "".join(rows) + "</ul>"
+
+
 def _render_review_context_card(context: dict[str, object], *, title: str = "Review Context") -> str:
     latest_event_date = str(context.get("latest_event_date") or "")
     latest_event_html = escape(latest_event_date) if latest_event_date else "<span class='muted'>None</span>"
@@ -688,6 +764,7 @@ def _render_dashboard(payload: dict) -> str:
         f"<span class='muted'>({escape(item['summary_text'])})</span></li>"
         for item in payload["stale_summaries"]["items"]
     ) or "<li>None</li>"
+    evolution_items = _render_evolution_candidates(payload["evolution"]["items"], compact=False)
     production_gap_items = "".join(
         f'<li><span class="pill">{escape(item["stage_label"].replace("_", " "))}</span> '
         f'<a href="{escape(_note_href(item["note_path"]))}">{escape(item["title"])}</a>'
@@ -722,12 +799,15 @@ def _render_dashboard(payload: dict) -> str:
             f"<p>{payload['events']['count']}</p></div>"
             "<div class='card'><h2>Stale Summaries</h2>"
             f"<p>{payload['stale_summaries']['count']}</p></div>"
+            "<div class='card'><h2>Evolution Candidates</h2>"
+            f"<p>{payload['evolution']['candidate_count']}</p></div>"
             "<div class='card'><h2>Signals</h2>"
             f"<p>{payload['signals']['count']}</p></div>"
             "</section>"
             "<section class='grid two-col'>"
             "<div class='section-stack'>"
             f"<section class='card'><h2>Needs Attention Now</h2><ul class='list-tight'>{priority_items}</ul></section>"
+            f"<section class='card'><h2><a href='/evolution'>Evolution</a></h2>{evolution_items}</section>"
             f"<section class='card'><h2>Recent Objects</h2><ul class='list-tight'>{object_items}</ul></section>"
             f"<section class='card'><h2>Recent Events</h2><ul class='list-tight'>{event_items}</ul></section>"
             f"<section class='card'><h2><a href='/summaries'>Stale Summaries</a></h2><ul class='list-tight'>{stale_summary_items}</ul></section>"
@@ -802,6 +882,10 @@ def _render_object_page(payload: dict) -> str:
         for item in payload["provenance"]["mocs"]
     ) or "<li>None</li>"
     summary_text = payload["summary"]["summary_text"] if payload["summary"] else ""
+    evolution = payload.get(
+        "evolution",
+        {"candidate_items": [], "accepted_links": [], "accepted_count": 0, "candidate_count": 0, "link_types": []},
+    )
     section_nav = "".join(
         f'<a href="{escape(item["href"])}">{escape(item["label"])}</a>' for item in payload["section_nav"]
     )
@@ -873,6 +957,17 @@ def _render_object_page(payload: dict) -> str:
             f"<div><dt>Source Notes</dt><dd><ul class='list-tight'>{source_notes}</ul></dd></div>"
             f"<div><dt>Atlas / MOC</dt><dd><ul class='list-tight'>{mocs}</ul></dd></div>"
             "</dl></section>"
+            "<section class='card'><h2>Evolution</h2>"
+            f"<p class='muted'>{evolution['accepted_count']} accepted links and {evolution['candidate_count']} candidate links in scope."
+            + (
+                f" Link types: {escape(', '.join(evolution['link_types']))}."
+                if evolution["link_types"]
+                else ""
+            )
+            + "</p>"
+            f"<h3>Accepted Links</h3>{_render_evolution_links(evolution['accepted_links'], empty_text='No accepted evolution links yet.')}"
+            f"<h3>Candidate Links</h3>{_render_evolution_candidates(evolution['candidate_items'], compact=True, reviewable=True)}"
+            "</section>"
             "<section class='card'><h2>Production Chain</h2><dl class='meta-list'>"
             f"<div><dt>Source Notes</dt><dd>{_render_named_note_links(payload['production_chain']['source_notes'])}</dd></div>"
             f"<div><dt>Source Deep Dives</dt><dd>{_render_named_note_links(payload['production_chain']['deep_dives'])}</dd></div>"
@@ -896,6 +991,10 @@ def _render_topic_page(payload: dict) -> str:
     mocs = "".join(
         f"<li>{escape(item['title'])}</li>" for item in payload["provenance"]["mocs"]
     ) or "<li>None</li>"
+    evolution = payload.get(
+        "evolution",
+        {"candidate_items": [], "accepted_links": [], "accepted_count": 0, "candidate_count": 0, "link_types": []},
+    )
     summary_form = (
         "<form method='post' action='/summaries/rebuild' class='link-row'>"
         + "".join(
@@ -931,6 +1030,17 @@ def _render_topic_page(payload: dict) -> str:
             f"<section class='card'><h2>Center Summary</h2><p>{escape(payload['center_summary'])}</p></section>"
             f"<section class='card'><h2>Neighbors</h2><ul class='list-tight'>{neighbors}</ul></section>"
             f"<section class='card'><h2>Atlas / MOC</h2><ul class='list-tight'>{mocs}</ul></section>"
+            "<section class='card'><h2>Evolution</h2>"
+            f"<p class='muted'>{evolution['accepted_count']} accepted links and {evolution['candidate_count']} candidate links in scope."
+            + (
+                f" Link types: {escape(', '.join(evolution['link_types']))}."
+                if evolution["link_types"]
+                else ""
+            )
+            + "</p>"
+            f"<h3>Accepted Links</h3>{_render_evolution_links(evolution['accepted_links'], empty_text='No accepted evolution links yet.')}"
+            f"<h3>Candidate Links</h3>{_render_evolution_candidates(evolution['candidate_items'], compact=True, reviewable=True)}"
+            "</section>"
             f"{_render_production_summary_card(payload['production_summary'])}"
             f"{_render_review_context_card(payload['review_context'])}"
             f"{_render_review_history(payload['review_history'])}"
@@ -1186,6 +1296,44 @@ def _render_production_browser_page(payload: dict) -> str:
             "<section class='card'><h2>Chain Model</h2><p class='muted'>This browser shows the current upstream/downstream chain from traceable notes into deep dives, evergreen objects, and Atlas placement.</p></section>"
             f"<section class='card'><h2>Weak Points</h2><ul class='list-tight'>{weak_points}</ul></section>"
             f"<section class='card'><ul class='list-tight'>{items}</ul></section>"
+        ),
+    )
+
+
+def _render_evolution_browser_page(payload: dict) -> str:
+    query = payload.get("query", "")
+    status = payload.get("status", "all")
+    selected_link_type = payload.get("link_type", "")
+    type_counts = "".join(
+        f"<span class='pill'>{escape(link_type)}: {count}</span>"
+        for link_type, count in payload["type_counts"].items()
+    ) or "<span class='muted'>None</span>"
+    return _layout(
+        "Evolution Browser",
+        (
+            "<h1>Evolution Browser</h1>"
+            "<form method='get' action='/evolution' class='link-row'>"
+            f"<input type='text' name='q' value='{escape(query)}' placeholder='Filter evolution links' />"
+            "<select name='status'>"
+            + "".join(
+                f"<option value='{escape(option)}' {'selected' if status == option else ''}>{escape(option)}</option>"
+                for option in ("all", "candidate", "accepted", "rejected")
+            )
+            + "</select>"
+            "<select name='link_type'>"
+            "<option value=''>all link types</option>"
+            + "".join(
+                f"<option value='{escape(option)}' {'selected' if selected_link_type == option else ''}>{escape(option)}</option>"
+                for option in _EVOLUTION_LINK_TYPES
+            )
+            + "</select>"
+            "<button type='submit'>Search</button>"
+            "</form>"
+            f"<p class='muted'>{payload['count']} evolution records in the current view.</p>"
+            f"<section class='card'><h2>Link Types</h2><div class='link-row'>{type_counts}</div></section>"
+            f"<section class='card'><h2>Accepted Links</h2>{_render_evolution_links(payload['accepted_links'], empty_text='No accepted evolution links yet.')}</section>"
+            f"<section class='card'><h2>Rejected Links</h2>{_render_evolution_links(payload['rejected_links'], empty_text='No rejected evolution links yet.')}</section>"
+            f"<section class='card'><h2>Candidate Links</h2>{_render_evolution_candidates(payload['candidate_items'], reviewable=True)}</section>"
         ),
     )
 
@@ -1581,6 +1729,19 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
                     payload = build_signal_browser_payload(resolved_vault, signal_type=signal_type, query=q)
                     self._write_html(_render_signals_page(payload))
                     return
+                if path == "/api/evolution":
+                    q = query.get("q", [""])[0]
+                    status = query.get("status", ["all"])[0] or "all"
+                    link_type = query.get("link_type", [""])[0] or None
+                    self._write_json(build_evolution_browser_payload(resolved_vault, query=q, status=status, link_type=link_type))
+                    return
+                if path == "/evolution":
+                    q = query.get("q", [""])[0]
+                    status = query.get("status", ["all"])[0] or "all"
+                    link_type = query.get("link_type", [""])[0] or None
+                    payload = build_evolution_browser_payload(resolved_vault, query=q, status=status, link_type=link_type)
+                    self._write_html(_render_evolution_browser_page(payload))
+                    return
                 if path == "/api/object":
                     object_id = self._required(query, "id")
                     self._write_json(build_object_page_payload(resolved_vault, object_id))
@@ -1691,6 +1852,13 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
                     self._rebuild_summary_action(form)
                     self._redirect("/summaries")
                     return
+                if path == "/api/evolution/review":
+                    self._write_json(self._review_evolution_action(form))
+                    return
+                if path == "/evolution/review":
+                    self._review_evolution_action(form)
+                    self._redirect("/evolution")
+                    return
                 self.send_error(404, "Not Found")
             except ValueError as exc:
                 self.send_error(400, str(exc))
@@ -1774,6 +1942,19 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
                     },
                 )
             return payload
+
+        def _review_evolution_action(self, form: dict[str, list[str]]) -> dict[str, object]:
+            evolution_id = self._form_first(form, "evolution_id").strip()
+            status = self._form_first(form, "status").strip()
+            note = self._form_first(form, "note").strip()
+            link_type = self._form_first(form, "link_type").strip() or None
+            return review_evolution_candidate(
+                resolved_vault,
+                evolution_id=evolution_id,
+                status=status,
+                note=note,
+                link_type=link_type,
+            )
 
         def _write_json(self, payload: dict) -> None:
             body = json.dumps(payload, ensure_ascii=False).encode("utf-8")

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -459,6 +459,129 @@ def _rank_contradiction_evidence(item: dict[str, Any]) -> list[dict[str, Any]]:
     return ranked
 
 
+def _parse_iso_datetime(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        return datetime.fromisoformat(text)
+    except ValueError:
+        return None
+
+
+def _candidate_evolution_id(
+    *,
+    link_type: str,
+    subject_kind: str,
+    subject_id: str,
+    earlier_ref: str,
+    later_ref: str,
+) -> str:
+    fingerprint = "::".join([link_type, subject_kind, subject_id, earlier_ref, later_ref])
+    return hashlib.sha1(fingerprint.encode("utf-8")).hexdigest()[:16]
+
+
+def _page_paths_for_slugs(vault_dir: Path | str, slugs: list[str]) -> dict[str, str]:
+    normalized_slugs = list(dict.fromkeys(slug for slug in slugs if slug))
+    if not normalized_slugs:
+        return {}
+    db_path = _db_path(vault_dir)
+    resolved_vault = resolve_vault_dir(vault_dir)
+    placeholders = ",".join("?" for _ in normalized_slugs)
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            f"""
+            SELECT slug, path
+            FROM pages_index
+            WHERE slug IN ({placeholders})
+            """,
+            tuple(normalized_slugs),
+        ).fetchall()
+    return {
+        str(slug): _vault_relative_path(resolved_vault, path)
+        for slug, path in rows
+    }
+
+
+def _note_date_text(vault_dir: Path | str, note_path: str) -> str:
+    frontmatter = _read_note_frontmatter(vault_dir, note_path)
+    date_value = frontmatter.get("date")
+    return str(date_value).strip()
+
+
+def _note_date_sort_key(date_text: str) -> tuple[int, float, str]:
+    parsed = _parse_iso_datetime(date_text)
+    if parsed is None:
+        return (0, 0.0, date_text)
+    return (1, parsed.timestamp(), date_text)
+
+
+def _read_note_text(vault_dir: Path | str, relative_path: str) -> str:
+    resolved = resolve_vault_dir(vault_dir)
+    note_path = (resolved / relative_path).resolve()
+    try:
+        note_path.relative_to(resolved.resolve())
+    except ValueError:
+        return ""
+    if not note_path.is_file():
+        return ""
+    return note_path.read_text(encoding="utf-8")
+
+
+_SUPERSESSION_CUE_RE = re.compile(
+    r"\b(supersed(?:e|es|ed|ing)|replace(?:s|d|ment|ments)?|obsolete|deprecated|no longer|instead)\b",
+    re.IGNORECASE,
+)
+_CONFIRMATION_CUE_RE = re.compile(
+    r"\b(confirm(?:s|ed|ing)?|corroborat(?:e|es|ed|ing)|validated?|agrees?\s+with|supports?)\b",
+    re.IGNORECASE,
+)
+
+
+def _has_cue(
+    vault_dir: Path | str,
+    note_path: str,
+    pattern: re.Pattern[str],
+) -> bool:
+    text = _read_note_text(vault_dir, note_path).lower()
+    for match in pattern.finditer(text):
+        prefix = text[max(0, match.start() - 24) : match.start()]
+        if re.search(r"(?:\bnot\s+|\bwithout\s+|n't\s+)$", prefix):
+            continue
+        return True
+    return False
+
+
+def _has_supersession_cue(vault_dir: Path | str, note_path: str) -> bool:
+    return _has_cue(vault_dir, note_path, _SUPERSESSION_CUE_RE)
+
+
+def _has_confirmation_cue(vault_dir: Path | str, note_path: str) -> bool:
+    return _has_cue(vault_dir, note_path, _CONFIRMATION_CUE_RE)
+
+
+def _evolution_candidate_matches_query(item: dict[str, Any], normalized_query: str) -> bool:
+    haystacks = [
+        str(item.get("link_type") or "").lower(),
+        str(item.get("subject_kind") or "").lower(),
+        str(item.get("subject_id") or "").lower(),
+        str(item.get("earlier_ref") or "").lower(),
+        str(item.get("later_ref") or "").lower(),
+        *(str(path).lower() for path in item.get("source_paths", [])),
+        *(str(code).lower() for code in item.get("reason_codes", [])),
+        *(
+            str(entry.get("source_slug") or entry.get("path") or entry.get("title") or "").lower()
+            for entry in item.get("evidence", [])
+            if isinstance(entry, dict)
+        ),
+    ]
+    return any(normalized_query in haystack for haystack in haystacks if haystack)
+
+
 def list_objects(
     vault_dir: Path | str,
     *,
@@ -919,8 +1042,8 @@ def list_review_actions(
     limit: int = 20,
 ) -> list[dict[str, Any]]:
     limit, _ = _validate_page_args(limit=limit, offset=0)
-    db_path = _db_path(vault_dir)
     normalized_object_ids = set(object_id for object_id in (object_ids or []) if object_id)
+    db_path = _db_path(vault_dir)
     with sqlite3.connect(db_path) as conn:
         rows = conn.execute(
             """
@@ -932,6 +1055,15 @@ def list_review_actions(
             """,
             (_REVIEW_AUDIT_LOG_NAME,),
         ).fetchall()
+    return _review_action_items(rows, normalized_object_ids=normalized_object_ids, limit=limit)
+
+
+def _review_action_items(
+    rows: list[tuple[Any, ...]],
+    *,
+    normalized_object_ids: set[str],
+    limit: int | None,
+) -> list[dict[str, Any]]:
     items: list[dict[str, Any]] = []
     for source_log, event_type, slug, session_id, timestamp, payload_json in rows:
         try:
@@ -953,6 +1085,13 @@ def list_review_actions(
                 "session_id": session_id,
                 "timestamp": timestamp,
                 "object_ids": action_object_ids,
+                "evolution_id": str(payload.get("evolution_id") or ""),
+                "subject_kind": str(payload.get("subject_kind") or ""),
+                "subject_id": str(payload.get("subject_id") or ""),
+                "earlier_ref": str(payload.get("earlier_ref") or ""),
+                "later_ref": str(payload.get("later_ref") or ""),
+                "link_type": str(payload.get("link_type") or ""),
+                "candidate_link_type": str(payload.get("candidate_link_type") or ""),
                 "contradiction_ids": [
                     str(value)
                     for value in payload.get("contradiction_ids", [])
@@ -968,9 +1107,29 @@ def list_review_actions(
                 "objects_rebuilt": int(payload.get("objects_rebuilt") or 0),
             }
         )
-        if len(items) >= limit:
+        if limit is not None and len(items) >= limit:
             break
     return items
+
+
+def list_evolution_review_actions(
+    vault_dir: Path | str,
+    *,
+    object_ids: list[str] | None = None,
+) -> list[dict[str, Any]]:
+    normalized_object_ids = set(object_id for object_id in (object_ids or []) if object_id)
+    db_path = _db_path(vault_dir)
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT source_log, event_type, slug, session_id, timestamp, payload_json
+            FROM audit_events
+            WHERE source_log = ? AND event_type = ?
+            ORDER BY timestamp DESC
+            """,
+            (_REVIEW_AUDIT_LOG_NAME, "ui_evolution_reviewed"),
+        ).fetchall()
+    return _review_action_items(rows, normalized_object_ids=normalized_object_ids, limit=None)
 
 
 def _signal_id(signal_type: str, key: str) -> str:
@@ -1905,6 +2064,362 @@ def list_contradictions(
         item["ranked_evidence"] = _rank_contradiction_evidence(item)
         item["review_history"] = list_review_actions(vault_dir, object_ids=object_ids, limit=5)
     return items
+
+
+def _all_evolution_candidates(
+    vault_dir: Path | str,
+    *,
+    query: str | None = None,
+    link_type: str | None = None,
+) -> list[dict[str, Any]]:
+    normalized_query = (query or "").strip().lower()
+    candidates: list[dict[str, Any]] = []
+
+    open_contradictions = list_contradictions(vault_dir, limit=MAX_PAGE_SIZE, status="open")
+    contradiction_object_ids = sorted(
+        {
+            claim["object_id"]
+            for item in open_contradictions
+            for claim in (item["positive_claims"] + item["negative_claims"])
+        }
+    )
+    contradiction_object_paths = _batch_object_rows(vault_dir, contradiction_object_ids)
+    contradiction_source_paths = _page_paths_for_slugs(
+        vault_dir,
+        [
+            evidence["source_slug"]
+            for item in open_contradictions
+            for claim in (item["positive_claims"] + item["negative_claims"])
+            for evidence in claim["evidence"]
+            if evidence.get("source_slug")
+        ],
+    )
+
+    for item in open_contradictions:
+        positive_claims = list(item["positive_claims"])
+        negative_claims = list(item["negative_claims"])
+        if not positive_claims or not negative_claims:
+            continue
+        contradiction_item_object_ids = sorted(
+            {
+                claim["object_id"]
+                for claim in (positive_claims + negative_claims)
+            }
+        )
+
+        claim_dates: dict[str, tuple[tuple[int, float, str], str]] = {}
+        for claim in positive_claims + negative_claims:
+            canonical_path = contradiction_object_paths.get(claim["object_id"], {}).get("canonical_path", "")
+            date_text = _note_date_text(vault_dir, canonical_path) if canonical_path else ""
+            claim_dates[claim["claim_id"]] = (_note_date_sort_key(date_text), date_text)
+
+        positive_claim = positive_claims[0]
+        negative_claim = negative_claims[0]
+        best_pair_score: tuple[int, float, str, str] | None = None
+        for positive_candidate in positive_claims:
+            positive_key, _positive_date = claim_dates[positive_candidate["claim_id"]]
+            for negative_candidate in negative_claims:
+                negative_key, _negative_date = claim_dates[negative_candidate["claim_id"]]
+                both_valid = 1 if positive_key[0] and negative_key[0] else 0
+                distance = abs(positive_key[1] - negative_key[1]) if both_valid else 0.0
+                pair_score = (
+                    both_valid,
+                    distance,
+                    positive_candidate["claim_id"],
+                    negative_candidate["claim_id"],
+                )
+                if best_pair_score is None or pair_score > best_pair_score:
+                    best_pair_score = pair_score
+                    positive_claim = positive_candidate
+                    negative_claim = negative_candidate
+
+        positive_key, positive_date = claim_dates[positive_claim["claim_id"]]
+        negative_key, negative_date = claim_dates[negative_claim["claim_id"]]
+        if positive_key > negative_key:
+            earlier_claim, later_claim = negative_claim, positive_claim
+            earlier_date, later_date = negative_date, positive_date
+        else:
+            earlier_claim, later_claim = positive_claim, negative_claim
+            earlier_date, later_date = positive_date, negative_date
+
+        record = {
+            "evolution_id": _candidate_evolution_id(
+                link_type="challenges",
+                subject_kind="topic",
+                subject_id=item["subject_key"],
+                earlier_ref=f"claim://{earlier_claim['claim_id']}",
+                later_ref=f"claim://{later_claim['claim_id']}",
+            ),
+            "status": "candidate",
+            "link_type": "challenges",
+            "subject_kind": "topic",
+            "subject_id": item["subject_key"],
+            "object_ids": contradiction_item_object_ids,
+            "earlier_ref": f"claim://{earlier_claim['claim_id']}",
+            "later_ref": f"claim://{later_claim['claim_id']}",
+            "earlier_date": earlier_date,
+            "later_date": later_date,
+            "reason_codes": ["open_contradiction", "claim_polarity_divergence"],
+            "confidence": 0.9,
+            "evidence": item["ranked_evidence"][:4],
+            "source_paths": [
+                path
+                for path in dict.fromkeys(
+                    [
+                        *(
+                            contradiction_source_paths.get(evidence["source_slug"], "")
+                            for claim in (item["positive_claims"] + item["negative_claims"])
+                            for evidence in claim["evidence"]
+                            if evidence.get("source_slug")
+                        ),
+                        *(
+                            contradiction_object_paths.get(object_id, {}).get("canonical_path", "")
+                            for object_id in contradiction_item_object_ids
+                        ),
+                    ]
+                )
+                if path
+            ],
+        }
+        if link_type and record["link_type"] != link_type:
+            continue
+        if normalized_query and not _evolution_candidate_matches_query(record, normalized_query):
+            continue
+        candidates.append(record)
+
+    stale_summaries = list_stale_summaries(vault_dir, limit=MAX_PAGE_SIZE)
+    for item in stale_summaries:
+        traceability = get_object_traceability(vault_dir, item["object_id"])
+        earlier_path = traceability["object"]["canonical_path"]
+        earlier_date = _note_date_text(vault_dir, earlier_path)
+        earlier_key = _note_date_sort_key(earlier_date)
+        later_choice: dict[str, str] | None = None
+        later_choice_key: tuple[int, float, str] | None = None
+        for note in [*traceability["deep_dives"], *traceability["source_notes"]]:
+            if not _has_supersession_cue(vault_dir, note["path"]):
+                continue
+            candidate_date = _note_date_text(vault_dir, note["path"])
+            candidate_key = _note_date_sort_key(candidate_date)
+            if candidate_key <= earlier_key:
+                continue
+            if later_choice_key is None or candidate_key > later_choice_key:
+                later_choice = note
+                later_choice_key = candidate_key
+        if later_choice is None:
+            continue
+        later_ref = f"{later_choice.get('note_type') or 'note'}://{later_choice['path']}"
+        later_date = _note_date_text(vault_dir, later_choice["path"])
+        record = {
+            "evolution_id": _candidate_evolution_id(
+                link_type="replaces",
+                subject_kind="object",
+                subject_id=item["object_id"],
+                earlier_ref=f"object://{item['object_id']}",
+                later_ref=later_ref,
+            ),
+            "status": "candidate",
+            "link_type": "replaces",
+            "subject_kind": "object",
+            "subject_id": item["object_id"],
+            "object_ids": [item["object_id"]],
+            "earlier_ref": f"object://{item['object_id']}",
+            "later_ref": later_ref,
+            "earlier_date": earlier_date,
+            "later_date": later_date,
+            "reason_codes": ["stale_summary", "later_traceability_neighbor"],
+            "confidence": 0.8,
+            "evidence": [
+                *[
+                    {"kind": "stale_summary_reason", "code": code, "text": text}
+                    for code, text in zip(item["reason_codes"], item["reason_texts"], strict=False)
+                ],
+                {
+                    "kind": "later_traceability_neighbor",
+                    "title": later_choice["title"],
+                    "path": later_choice["path"],
+                    "date": later_date,
+                },
+            ],
+            "source_paths": [
+                path
+                for path in dict.fromkeys(
+                    [
+                        earlier_path,
+                        *[note["path"] for note in traceability["deep_dives"]],
+                        *[note["path"] for note in traceability["source_notes"]],
+                    ]
+                )
+                if path
+            ],
+        }
+        if link_type and record["link_type"] != link_type:
+            continue
+        if normalized_query and not _evolution_candidate_matches_query(record, normalized_query):
+            continue
+        candidates.append(record)
+
+    for item in list_objects(vault_dir, limit=MAX_PAGE_SIZE):
+        traceability = get_object_traceability(vault_dir, item["object_id"])
+        earlier_path = traceability["object"]["canonical_path"]
+        earlier_date = _note_date_text(vault_dir, earlier_path)
+        earlier_key = _note_date_sort_key(earlier_date)
+        for note in [*traceability["deep_dives"], *traceability["source_notes"]]:
+            later_date = _note_date_text(vault_dir, note["path"])
+            later_key = _note_date_sort_key(later_date)
+            if later_key <= earlier_key:
+                continue
+            if _has_supersession_cue(vault_dir, note["path"]):
+                continue
+            inferred_link_type = "confirms" if _has_confirmation_cue(vault_dir, note["path"]) else "enriches"
+            record = {
+                "evolution_id": _candidate_evolution_id(
+                    link_type=inferred_link_type,
+                    subject_kind="object",
+                    subject_id=item["object_id"],
+                    earlier_ref=f"object://{item['object_id']}",
+                    later_ref=f"{note.get('note_type') or 'note'}://{note['path']}",
+                ),
+                "status": "candidate",
+                "link_type": inferred_link_type,
+                "subject_kind": "object",
+                "subject_id": item["object_id"],
+                "object_ids": [item["object_id"]],
+                "earlier_ref": f"object://{item['object_id']}",
+                "later_ref": f"{note.get('note_type') or 'note'}://{note['path']}",
+                "earlier_date": earlier_date,
+                "later_date": later_date,
+                "reason_codes": ["later_traceability_neighbor", f"lexical_{inferred_link_type}" if inferred_link_type == "confirms" else "later_context"],
+                "confidence": 0.7 if inferred_link_type == "confirms" else 0.6,
+                "evidence": [
+                    {
+                        "kind": "later_traceability_neighbor",
+                        "title": note["title"],
+                        "path": note["path"],
+                        "date": later_date,
+                    }
+                ],
+                "source_paths": [path for path in dict.fromkeys([earlier_path, note["path"]]) if path],
+            }
+            if link_type and record["link_type"] != link_type:
+                continue
+            if normalized_query and not _evolution_candidate_matches_query(record, normalized_query):
+                continue
+            candidates.append(record)
+
+    candidates.sort(
+        key=lambda item: (
+            str(item["later_date"]),
+            str(item["subject_id"]),
+            str(item["link_type"]),
+            str(item["evolution_id"]),
+        ),
+        reverse=True,
+    )
+    unique_candidates: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    for item in candidates:
+        if item["evolution_id"] in seen_ids:
+            continue
+        seen_ids.add(item["evolution_id"])
+        unique_candidates.append(item)
+    return unique_candidates
+
+
+def list_evolution_candidates(
+    vault_dir: Path | str,
+    *,
+    query: str | None = None,
+    link_type: str | None = None,
+    status: str = "candidate",
+    limit: int = 100,
+    offset: int = 0,
+) -> list[dict[str, Any]]:
+    limit, offset = _validate_page_args(limit=limit, offset=offset)
+    if status != "candidate":
+        return []
+    unique_candidates = _all_evolution_candidates(vault_dir, query=query, link_type=link_type)
+    return unique_candidates[offset : offset + limit]
+
+
+def list_evolution_links(
+    vault_dir: Path | str,
+    *,
+    object_ids: list[str] | None = None,
+    query: str | None = None,
+    link_type: str | None = None,
+    status: str | None = None,
+    limit: int | None = None,
+) -> list[dict[str, Any]]:
+    normalized_query = (query or "").strip().lower()
+    latest_by_evolution_id: dict[str, dict[str, Any]] = {}
+    for action in list_evolution_review_actions(vault_dir, object_ids=object_ids):
+        evolution_id = str(action.get("evolution_id") or "")
+        if not evolution_id or evolution_id in latest_by_evolution_id:
+            continue
+        latest_by_evolution_id[evolution_id] = action
+    items = list(latest_by_evolution_id.values())
+    filtered: list[dict[str, Any]] = []
+    for item in items:
+        if status and item.get("status") != status:
+            continue
+        if link_type and item.get("link_type") != link_type:
+            continue
+        if normalized_query and not _evolution_candidate_matches_query(item, normalized_query):
+            continue
+        filtered.append(item)
+    if limit is not None:
+        limit, _ = _validate_page_args(limit=limit, offset=0)
+        return filtered[:limit]
+    return filtered
+
+
+def review_evolution_candidate(
+    vault_dir: Path | str,
+    *,
+    evolution_id: str,
+    status: str,
+    note: str = "",
+    link_type: str | None = None,
+) -> dict[str, Any]:
+    if not evolution_id:
+        raise ValueError("missing evolution_id")
+    if status not in {"accepted", "rejected"}:
+        raise ValueError("invalid evolution status")
+    if link_type and link_type not in {"replaces", "enriches", "confirms", "challenges"}:
+        raise ValueError("invalid evolution link_type")
+    candidate = next(
+        (item for item in _all_evolution_candidates(vault_dir) if item["evolution_id"] == evolution_id),
+        None,
+    )
+    if candidate is None:
+        raise ValueError("unknown evolution candidate")
+    final_link_type = link_type or str(candidate["link_type"])
+    payload = {
+        "object_ids": list(candidate.get("object_ids", [])),
+        "evolution_id": candidate["evolution_id"],
+        "status": status,
+        "note": note,
+        "link_type": final_link_type,
+        "candidate_link_type": candidate["link_type"],
+        "subject_kind": candidate["subject_kind"],
+        "subject_id": candidate["subject_id"],
+        "earlier_ref": candidate["earlier_ref"],
+        "later_ref": candidate["later_ref"],
+    }
+    record_review_action(
+        vault_dir,
+        event_type="ui_evolution_reviewed",
+        slug=str(candidate["subject_id"]),
+        payload=payload,
+    )
+    return {
+        "reviewed_count": 1,
+        "accepted_count": 1 if status == "accepted" else 0,
+        "rejected_count": 1 if status == "rejected" else 0,
+        "evolution_ids": [candidate["evolution_id"]],
+        "candidate_count": 1,
+        "status": status,
+    }
 
 
 def get_topic_neighborhood(vault_dir: Path | str, object_id: str, *, depth: int = 1) -> dict[str, Any]:

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -510,7 +510,7 @@ def _page_paths_for_slugs(vault_dir: Path | str, slugs: list[str]) -> dict[str, 
 def _note_date_text(vault_dir: Path | str, note_path: str) -> str:
     frontmatter = _read_note_frontmatter(vault_dir, note_path)
     date_value = frontmatter.get("date")
-    return str(date_value).strip()
+    return str(date_value).strip() if date_value is not None else ""
 
 
 def _note_date_sort_key(date_text: str) -> tuple[int, float, str]:

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -21,6 +21,8 @@ from ..truth_api import (
     get_object_provenance_map,
     get_review_context,
     get_topic_neighborhood,
+    list_evolution_candidates,
+    list_evolution_links,
     list_review_actions,
     list_atlas_memberships,
     list_contradictions,
@@ -58,6 +60,24 @@ def _existing_object_rows(vault_dir: Path | str, object_ids: list[str]) -> dict[
             tuple(normalized_object_ids),
         ).fetchall()
     return {str(object_id): str(title) for object_id, title in rows}
+
+
+def _object_scope_paths(vault_dir: Path | str, object_ids: list[str]) -> dict[str, str]:
+    normalized_object_ids = list(dict.fromkeys(object_id for object_id in object_ids if object_id))
+    if not normalized_object_ids:
+        return {}
+    db_path = _db_path(vault_dir)
+    placeholders = ",".join("?" for _ in normalized_object_ids)
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            f"""
+            SELECT object_id, canonical_path
+            FROM objects
+            WHERE object_id IN ({placeholders})
+            """,
+            tuple(normalized_object_ids),
+        ).fetchall()
+    return {str(object_id): str(path or "") for object_id, path in rows}
 
 
 def _object_ids_from_claim_ids(*claim_id_lists: list[str]) -> list[str]:
@@ -172,6 +192,83 @@ def _build_production_weak_points(
     return list_production_gaps(vault_dir, query=query, limit=limit)
 
 
+def _build_evolution_section(
+    vault_dir: Path | str,
+    *,
+    query: str | None = None,
+    link_type: str | None = None,
+    status: str = "candidate",
+    scoped_object_ids: list[str] | None = None,
+) -> dict[str, Any]:
+    normalized_object_ids = list(dict.fromkeys(object_id for object_id in (scoped_object_ids or []) if object_id))
+    canonical_paths = {path for path in _object_scope_paths(vault_dir, normalized_object_ids).values() if path}
+    reviewed_links = list_evolution_links(
+        vault_dir,
+        object_ids=normalized_object_ids or None,
+        query=query,
+        link_type=link_type,
+    )
+    reviewed_evolution_ids = {str(item["evolution_id"]) for item in reviewed_links}
+    accepted_links = [item for item in reviewed_links if item["status"] == "accepted"]
+    rejected_links = [item for item in reviewed_links if item["status"] == "rejected"]
+    candidate_items = [
+        item
+        for item in list_evolution_candidates(vault_dir, query=query, link_type=link_type, status="candidate")
+        if item["evolution_id"] not in reviewed_evolution_ids
+    ]
+    if normalized_object_ids:
+        filtered_items: list[dict[str, Any]] = []
+        for item in candidate_items:
+            refs = (str(item["earlier_ref"]), str(item["later_ref"]))
+            if item["subject_kind"] == "object" and item["subject_id"] in normalized_object_ids:
+                filtered_items.append(item)
+                continue
+            if any(
+                ref.startswith(f"claim://{object_id}::") or ref == f"object://{object_id}"
+                for object_id in normalized_object_ids
+                for ref in refs
+            ):
+                filtered_items.append(item)
+                continue
+            if any(path in canonical_paths for path in item["source_paths"]):
+                filtered_items.append(item)
+        candidate_items = filtered_items
+        accepted_links = [
+            item for item in accepted_links
+            if set(item.get("object_ids", [])).intersection(normalized_object_ids)
+        ]
+        rejected_links = [
+            item for item in rejected_links
+            if set(item.get("object_ids", [])).intersection(normalized_object_ids)
+        ]
+    if status == "accepted":
+        candidate_items = []
+    elif status == "rejected":
+        candidate_items = []
+        accepted_links = []
+    elif status == "candidate":
+        pass
+    else:
+        # keep all sections visible on the default "all" view
+        status = "all"
+    return {
+        "accepted_links": accepted_links,
+        "rejected_links": rejected_links,
+        "candidate_items": candidate_items,
+        "candidate_count": len(candidate_items),
+        "accepted_count": len(accepted_links),
+        "rejected_count": len(rejected_links),
+        "link_types": sorted(
+            {
+                *(item["link_type"] for item in candidate_items),
+                *(str(item.get("link_type") or "") for item in accepted_links),
+                *(str(item.get("link_type") or "") for item in rejected_links),
+            }
+        ),
+        "status": status,
+    }
+
+
 def build_signal_browser_payload(
     vault_dir: Path | str,
     *,
@@ -226,6 +323,7 @@ def build_object_page_payload(vault_dir: Path | str, object_id: str) -> dict[str
         "provenance": detail["provenance"],
         "review_context": review_context,
         "review_history": list_review_actions(vault_dir, object_ids=[object_id], limit=8),
+        "evolution": _build_evolution_section(vault_dir, status="all", scoped_object_ids=[object_id]),
         "stale_summary_details": list_stale_summaries(vault_dir, object_ids=[object_id], limit=10),
         "open_contradiction_ids": [
             item["contradiction_id"] for item in detail["contradictions"] if item["status"] == "open"
@@ -275,6 +373,7 @@ def build_topic_overview_payload(vault_dir: Path | str, object_id: str) -> dict[
             object_ids=scoped_object_ids,
             limit=8,
         ),
+        "evolution": _build_evolution_section(vault_dir, status="all", scoped_object_ids=scoped_object_ids),
         "scoped_object_ids": scoped_object_ids,
         "scoped_stale_summary_ids": [item["object_id"] for item in scoped_stale_summaries],
         "scoped_open_contradiction_ids": [item["contradiction_id"] for item in scoped_contradictions],
@@ -394,6 +493,40 @@ def build_event_dossier_payload(
             "page_date rows come from note-level dates; heading_date rows come from dated section headings.",
         ],
         "query": query or "",
+    }
+
+
+def build_evolution_browser_payload(
+    vault_dir: Path | str,
+    *,
+    query: str | None = None,
+    status: str = "all",
+    link_type: str | None = None,
+) -> dict[str, Any]:
+    evolution = _build_evolution_section(vault_dir, query=query, link_type=link_type, status=status)
+    type_counts = Counter(
+        item["link_type"]
+        for item in [
+            *evolution["candidate_items"],
+            *evolution["accepted_links"],
+            *evolution["rejected_links"],
+        ]
+    )
+    return {
+        "screen": "evolution/browser",
+        "query": query or "",
+        "status": status,
+        "link_type": link_type or "",
+        "items": evolution["candidate_items"],
+        "candidate_items": evolution["candidate_items"],
+        "accepted_links": evolution["accepted_links"],
+        "rejected_links": evolution["rejected_links"],
+        "candidate_count": evolution["candidate_count"],
+        "accepted_count": evolution["accepted_count"],
+        "rejected_count": evolution["rejected_count"],
+        "count": evolution["candidate_count"] + evolution["accepted_count"] + evolution["rejected_count"],
+        "type_counts": dict(type_counts),
+        "link_types": evolution["link_types"],
     }
 
 
@@ -554,6 +687,7 @@ def build_truth_dashboard_payload(vault_dir: Path | str) -> dict[str, Any]:
     contradictions = build_contradiction_browser_payload(vault_dir)
     events = build_event_dossier_payload(vault_dir, limit=8)
     stale_summaries = build_stale_summary_browser_payload(vault_dir)
+    evolution = build_evolution_browser_payload(vault_dir, status="all")
     signals = build_signal_browser_payload(vault_dir)
     production_weak_points = _build_production_weak_points(vault_dir)
     priorities: list[dict[str, Any]] = []
@@ -603,6 +737,11 @@ def build_truth_dashboard_payload(vault_dir: Path | str) -> dict[str, Any]:
         "stale_summaries": {
             "count": stale_summaries["count"],
             "items": stale_summaries["items"][:8],
+        },
+        "evolution": {
+            "candidate_count": evolution["candidate_count"],
+            "accepted_count": evolution["accepted_count"],
+            "items": evolution["candidate_items"][:6],
         },
         "production": {
             "weak_points": production_weak_points,

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -121,6 +121,204 @@ def test_truth_api_filters_contradictions_by_query(temp_vault):
     assert items[0]["subject_key"] == "agent harness"
 
 
+def test_truth_api_lists_evolution_candidates_from_open_contradictions(temp_vault):
+    from openclaw_pipeline.truth_api import list_evolution_candidates
+
+    vault = _seed_truth_vault(temp_vault)
+
+    items = list_evolution_candidates(vault)
+
+    assert items
+    challenge = next(item for item in items if item["link_type"] == "challenges")
+    assert challenge["status"] == "candidate"
+    assert challenge["subject_kind"] == "topic"
+    assert challenge["subject_id"] == "agent harness"
+    assert set(challenge["object_ids"]) == {"negative-note", "source-note"}
+    assert challenge["reason_codes"] == ["open_contradiction", "claim_polarity_divergence"]
+
+
+def test_truth_api_lists_replaces_and_enriches_candidates(temp_vault):
+    from openclaw_pipeline.truth_api import list_evolution_candidates
+
+    vault = _seed_truth_vault(temp_vault)
+    legacy = vault / "10-Knowledge" / "Evergreen" / "Legacy.md"
+    legacy.write_text(
+        """---
+note_id: legacy-note
+title: Legacy Note
+type: evergreen
+date: 2026-04-01
+---
+
+# Legacy Note
+
+Legacy note.
+""",
+        encoding="utf-8",
+    )
+    deep_dive = vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "Legacy Dive_深度解读.md"
+    deep_dive.parent.mkdir(parents=True, exist_ok=True)
+    deep_dive.write_text(
+        """---
+note_id: legacy-dive
+title: Legacy Dive
+type: deep_dive
+date: 2026-04-10
+---
+
+# Legacy Dive
+
+This note supersedes [[legacy-note]] and confirms the migration path.
+""",
+        encoding="utf-8",
+    )
+    (vault / "60-Logs").mkdir(parents=True, exist_ok=True)
+    (vault / "60-Logs" / "pipeline.jsonl").write_text(
+        json.dumps(
+            {
+                "event_type": "evergreen_auto_promoted",
+                "concept": "legacy-note",
+                "source": "Legacy Dive_深度解读.md",
+                "mutation": {"target_slug": "legacy-note"},
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(vault)
+
+    items = list_evolution_candidates(vault, query="legacy")
+
+    assert any(item["link_type"] == "replaces" and item["subject_id"] == "legacy-note" for item in items)
+
+    enrich_dive = vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "Source Enrichment_深度解读.md"
+    enrich_dive.parent.mkdir(parents=True, exist_ok=True)
+    enrich_dive.write_text(
+        """---
+note_id: source-enrichment
+title: Source Enrichment
+type: deep_dive
+date: 2026-04-20
+---
+
+Source note builds on [[source-note]] with more deployment detail.
+""",
+        encoding="utf-8",
+    )
+    (vault / "60-Logs" / "pipeline.jsonl").write_text(
+        (vault / "60-Logs" / "pipeline.jsonl").read_text(encoding="utf-8")
+        + json.dumps(
+            {
+                "event_type": "evergreen_auto_promoted",
+                "concept": "source-note",
+                "source": "Source Enrichment_深度解读.md",
+                "mutation": {"target_slug": "source-note"},
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(vault)
+
+    items = list_evolution_candidates(vault, query="source-note")
+
+    assert any(item["link_type"] in {"enriches", "confirms"} and item["subject_id"] == "source-note" for item in items)
+
+
+def test_truth_api_reviews_evolution_candidate_and_lists_links(temp_vault):
+    from openclaw_pipeline.truth_api import list_evolution_candidates, list_evolution_links, review_evolution_candidate
+
+    vault = _seed_truth_vault(temp_vault)
+    candidate = next(item for item in list_evolution_candidates(vault) if item["link_type"] == "challenges")
+
+    payload = review_evolution_candidate(
+        vault,
+        evolution_id=candidate["evolution_id"],
+        status="accepted",
+        note="Accepted in review",
+        link_type="challenges",
+    )
+    links = list_evolution_links(vault, status="accepted")
+
+    assert payload["accepted_count"] == 1
+    assert links
+    assert links[0]["evolution_id"] == candidate["evolution_id"]
+    assert links[0]["status"] == "accepted"
+
+
+def test_truth_api_reviews_evolution_candidate_beyond_page_limit(temp_vault, monkeypatch):
+    from openclaw_pipeline import truth_api
+
+    vault = _seed_truth_vault(temp_vault)
+    legacy = vault / "10-Knowledge" / "Evergreen" / "Legacy.md"
+    legacy.write_text(
+        """---
+note_id: legacy-note
+title: Legacy Note
+type: evergreen
+date: 2026-04-01
+---
+
+# Legacy Note
+
+Legacy note.
+""",
+        encoding="utf-8",
+    )
+    deep_dive = vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "Legacy Dive_深度解读.md"
+    deep_dive.parent.mkdir(parents=True, exist_ok=True)
+    deep_dive.write_text(
+        """---
+note_id: legacy-dive
+title: Legacy Dive
+type: deep_dive
+date: 2026-04-10
+---
+
+# Legacy Dive
+
+This note supersedes [[legacy-note]] and confirms the migration path.
+""",
+        encoding="utf-8",
+    )
+    (vault / "60-Logs").mkdir(parents=True, exist_ok=True)
+    (vault / "60-Logs" / "pipeline.jsonl").write_text(
+        json.dumps(
+            {
+                "event_type": "evergreen_auto_promoted",
+                "concept": "legacy-note",
+                "source": "Legacy Dive_深度解读.md",
+                "mutation": {"target_slug": "legacy-note"},
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(vault)
+
+    items = truth_api.list_evolution_candidates(vault)
+    assert len(items) >= 2
+    target = items[-1]
+    original = truth_api.list_evolution_candidates
+
+    def capped_list_evolution_candidates(vault_dir, *, limit=100, offset=0, **kwargs):
+        effective_limit = 1 if limit is not None else limit
+        return original(vault_dir, limit=effective_limit, offset=offset, **kwargs)
+
+    monkeypatch.setattr(truth_api, "list_evolution_candidates", capped_list_evolution_candidates)
+
+    payload = truth_api.review_evolution_candidate(
+        vault,
+        evolution_id=target["evolution_id"],
+        status="accepted",
+    )
+
+    assert payload["evolution_ids"] == [target["evolution_id"]]
+
+
 def test_truth_api_builds_topic_neighborhood(temp_vault):
     from openclaw_pipeline.truth_api import get_topic_neighborhood
 

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -76,6 +76,25 @@ def test_truth_api_lists_objects(temp_vault):
     assert objects[1]["object_kind"] == "evergreen"
 
 
+def test_note_date_text_returns_empty_string_when_frontmatter_date_missing(temp_vault):
+    from openclaw_pipeline.truth_api import _note_date_text
+
+    note = temp_vault / "10-Knowledge" / "Evergreen" / "NoDate.md"
+    note.write_text(
+        """---
+note_id: no-date
+title: No Date
+type: evergreen
+---
+
+# No Date
+""",
+        encoding="utf-8",
+    )
+
+    assert _note_date_text(temp_vault, "10-Knowledge/Evergreen/NoDate.md") == ""
+
+
 def test_truth_api_returns_object_detail_with_claims_relations_and_summary(temp_vault):
     from openclaw_pipeline.truth_api import get_object_detail
 

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -227,6 +227,111 @@ Source note builds on [[source-note]] with more deployment detail.
     assert any(item["link_type"] in {"enriches", "confirms"} and item["subject_id"] == "source-note" for item in items)
 
 
+def test_truth_api_expresses_all_four_evolution_link_types(temp_vault):
+    from openclaw_pipeline.truth_api import list_evolution_candidates
+
+    vault = _seed_truth_vault(temp_vault)
+    legacy = vault / "10-Knowledge" / "Evergreen" / "Legacy.md"
+    legacy.write_text(
+        """---
+note_id: legacy-note
+title: Legacy Note
+type: evergreen
+date: 2026-04-01
+---
+
+# Legacy Note
+
+Legacy note.
+""",
+        encoding="utf-8",
+    )
+    replace_dive = vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "Legacy Replace_深度解读.md"
+    replace_dive.parent.mkdir(parents=True, exist_ok=True)
+    replace_dive.write_text(
+        """---
+note_id: legacy-replace
+title: Legacy Replace
+type: deep_dive
+date: 2026-04-10
+---
+
+# Legacy Replace
+
+This note supersedes [[legacy-note]] and instead recommends the new path.
+""",
+        encoding="utf-8",
+    )
+    enrich_dive = vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "Source Enrichment_深度解读.md"
+    enrich_dive.write_text(
+        """---
+note_id: source-enrichment
+title: Source Enrichment
+type: deep_dive
+date: 2026-04-20
+---
+
+Source note builds on [[source-note]] with more deployment detail.
+""",
+        encoding="utf-8",
+    )
+    confirm_dive = vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "Source Confirmation_深度解读.md"
+    confirm_dive.write_text(
+        """---
+note_id: source-confirmation
+title: Source Confirmation
+type: deep_dive
+date: 2026-04-22
+---
+
+Source note confirms the local-first rollout guidance from independent testing.
+""",
+        encoding="utf-8",
+    )
+    (vault / "60-Logs").mkdir(parents=True, exist_ok=True)
+    (vault / "60-Logs" / "pipeline.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "event_type": "evergreen_auto_promoted",
+                        "concept": "legacy-note",
+                        "source": "Legacy Replace_深度解读.md",
+                        "mutation": {"target_slug": "legacy-note"},
+                    },
+                    ensure_ascii=False,
+                ),
+                json.dumps(
+                    {
+                        "event_type": "evergreen_auto_promoted",
+                        "concept": "source-note",
+                        "source": "Source Enrichment_深度解读.md",
+                        "mutation": {"target_slug": "source-note"},
+                    },
+                    ensure_ascii=False,
+                ),
+                json.dumps(
+                    {
+                        "event_type": "evergreen_auto_promoted",
+                        "concept": "source-note",
+                        "source": "Source Confirmation_深度解读.md",
+                        "mutation": {"target_slug": "source-note"},
+                    },
+                    ensure_ascii=False,
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(vault)
+
+    items = list_evolution_candidates(vault)
+    link_types = {item["link_type"] for item in items}
+
+    assert {"replaces", "enriches", "confirms", "challenges"}.issubset(link_types)
+
+
 def test_truth_api_reviews_evolution_candidate_and_lists_links(temp_vault):
     from openclaw_pipeline.truth_api import list_evolution_candidates, list_evolution_links, review_evolution_candidate
 

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -229,6 +229,66 @@ Processed source note without downstream chain.
     assert "contradiction_open" in payload["type_counts"]
 
 
+def test_ui_server_evolution_endpoint_returns_payload(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+
+    _seed_truth_store(temp_vault)
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("GET", "/api/evolution")
+        response = conn.getresponse()
+        payload = json.loads(response.read().decode("utf-8"))
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 200
+    assert payload["screen"] == "evolution/browser"
+    assert payload["count"] >= 1
+
+
+def test_ui_server_can_accept_evolution_candidate_via_api(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+    from openclaw_pipeline.truth_api import list_evolution_candidates
+
+    _seed_truth_store(temp_vault)
+    candidate = next(item for item in list_evolution_candidates(temp_vault) if item["link_type"] == "challenges")
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        body = urlencode(
+            {
+                "evolution_id": candidate["evolution_id"],
+                "status": "accepted",
+                "note": "Accepted in UI",
+                "link_type": "challenges",
+            }
+        )
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request(
+            "POST",
+            "/api/evolution/review",
+            body=body,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        response = conn.getresponse()
+        payload = json.loads(response.read().decode("utf-8"))
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 200
+    assert payload["accepted_count"] == 1
+
+
 def test_ui_server_briefing_endpoint_returns_payload(temp_vault):
     from openclaw_pipeline.commands.ui_server import create_server
     from openclaw_pipeline.truth_api import record_review_action

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -140,6 +140,7 @@ date: 2026-04-13
         events_status, events_body = _get(port, "/events")
         atlas_status, atlas_body = _get(port, "/atlas")
         deep_dives_status, deep_dives_body = _get(port, "/deep-dives")
+        evolution_status, evolution_body = _get(port, "/evolution")
         production_status, production_body = _get(port, "/production")
         contradictions_status, contradictions_body = _get(port, "/contradictions")
     finally:
@@ -165,6 +166,7 @@ date: 2026-04-13
     assert "/private/" not in object_body
     assert "Source Deep Dive" in object_body
     assert "Atlas Index" in object_body
+    assert "Evolution" in object_body
     assert "Review Context" in object_body
     assert "Open contradictions" in object_body
     assert "/summaries?q=alpha" in object_body
@@ -181,6 +183,7 @@ date: 2026-04-13
     assert '/events?q=alpha' in topic_body
     assert "Center Summary" in topic_body
     assert "Atlas / MOC" in topic_body
+    assert "Evolution" in topic_body
     assert "Review Context" in topic_body
     assert "Production Contribution" in topic_body
     assert "Missing source notes" in topic_body
@@ -218,6 +221,11 @@ date: 2026-04-13
     assert deep_dives_status == 200
     assert "Deep Dive Derivations" in deep_dives_body
     assert "Contribution Summary" in deep_dives_body
+
+    assert evolution_status == 200
+    assert "Evolution Browser" in evolution_body
+    assert "Candidate Links" in evolution_body
+    assert "/evolution/review" in evolution_body
     assert "Showing the most recent 50 deep dives" in deep_dives_body
     assert "Source Deep Dive" in deep_dives_body
 
@@ -985,10 +993,12 @@ Thin note.
     assert "Contradictions Open" in root_body
     assert "Recent Events" in root_body
     assert "Stale Summaries" in root_body
+    assert "Evolution Candidates" in root_body
     assert "Needs Attention Now" in root_body
     assert "Alpha" in root_body
     assert "Thin Note" in root_body
     assert "/summaries" in root_body
+    assert "/evolution" in root_body
     assert "Production Weak Points" in root_body
     assert "Signals" in root_body
 

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -598,6 +598,97 @@ def test_build_briefing_payload(temp_vault):
     assert payload["active_topics"]
 
 
+def test_build_evolution_browser_payload(temp_vault):
+    from openclaw_pipeline.ui.view_models import build_evolution_browser_payload
+
+    _seed_truth_store(temp_vault)
+
+    payload = build_evolution_browser_payload(temp_vault)
+
+    assert payload["screen"] == "evolution/browser"
+    assert payload["count"] >= 1
+    assert payload["candidate_items"]
+    assert payload["type_counts"]
+
+
+def test_build_evolution_browser_payload_filters_reviewed_links_by_link_type(temp_vault):
+    from openclaw_pipeline.truth_api import list_evolution_candidates, review_evolution_candidate
+    from openclaw_pipeline.ui.view_models import build_evolution_browser_payload
+
+    _seed_truth_store(temp_vault)
+    legacy = temp_vault / "10-Knowledge" / "Evergreen" / "Legacy.md"
+    legacy.write_text(
+        """---
+note_id: legacy-note
+title: Legacy Note
+type: evergreen
+date: 2026-04-01
+---
+
+# Legacy Note
+
+Legacy note.
+""",
+        encoding="utf-8",
+    )
+    deep_dive = temp_vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "Legacy Dive_深度解读.md"
+    deep_dive.parent.mkdir(parents=True, exist_ok=True)
+    deep_dive.write_text(
+        """---
+note_id: legacy-dive
+title: Legacy Dive
+type: deep_dive
+date: 2026-04-10
+---
+
+# Legacy Dive
+
+This note supersedes [[legacy-note]] and confirms the migration path.
+""",
+        encoding="utf-8",
+    )
+    (temp_vault / "60-Logs").mkdir(parents=True, exist_ok=True)
+    (temp_vault / "60-Logs" / "pipeline.jsonl").write_text(
+        """{"event_type":"evergreen_auto_promoted","concept":"legacy-note","source":"Legacy Dive_深度解读.md","mutation":{"target_slug":"legacy-note"}}
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    items = list_evolution_candidates(temp_vault)
+    challenge = next(item for item in items if item["link_type"] == "challenges")
+    replace_item = next(item for item in items if item["link_type"] == "replaces")
+    review_evolution_candidate(temp_vault, evolution_id=challenge["evolution_id"], status="accepted")
+    review_evolution_candidate(temp_vault, evolution_id=replace_item["evolution_id"], status="accepted")
+
+    payload = build_evolution_browser_payload(temp_vault, status="all", link_type="challenges")
+
+    assert payload["accepted_links"]
+    assert {item["link_type"] for item in payload["accepted_links"]} == {"challenges"}
+
+
+def test_build_object_page_payload_includes_evolution_section(temp_vault):
+    from openclaw_pipeline.ui.view_models import build_object_page_payload
+
+    _seed_truth_store(temp_vault)
+
+    payload = build_object_page_payload(temp_vault, "alpha")
+
+    assert "evolution" in payload
+    assert payload["evolution"]["candidate_count"] >= 1
+
+
+def test_build_topic_overview_payload_includes_evolution_section(temp_vault):
+    from openclaw_pipeline.ui.view_models import build_topic_overview_payload
+
+    _seed_truth_store(temp_vault)
+
+    payload = build_topic_overview_payload(temp_vault, "alpha")
+
+    assert "evolution" in payload
+    assert payload["evolution"]["candidate_count"] >= 1
+
+
 def test_build_event_dossier_payload_filters_by_query(temp_vault):
     from openclaw_pipeline.ui.view_models import build_event_dossier_payload
 


### PR DESCRIPTION
## Summary
- add a deterministic evolution review workbench with typed `replaces`, `enriches`, `confirms`, and `challenges` candidates
- expose evolution queue and object/topic evolution sections in the local UI
- persist evolution review outcomes, fix filtered reviewed-link consistency, and remove review lookup dependence on paged candidate windows
- add acceptance coverage proving all four evolution link semantics are expressible

## Verification
- `PYTHONPATH=src python3.13 -m pytest -q tests/test_truth_api.py tests/test_ui_view_models.py tests/test_ui_server.py tests/test_ui_smoke.py`
- `PYTHONPATH=src python3.13 -m pytest -q`
- `python3.13 -m compileall src/openclaw_pipeline`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/21" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Evolution system for identifying and reviewing knowledge evolution across claims, including candidate discovery, status tracking (accepted/rejected/candidate), and full review workflows.
  * Integrated Evolution views across dashboard, object pages, topic pages, and dedicated Evolution browser.

* **Chores**
  * Version bumped to 0.8.6.
  * Modernized CI/CD pipeline with OIDC-based trusted publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->