### PR TITLE
Finish Phase 14 queue hardening

### DIFF
--- a/docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
+++ b/docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
@@ -441,7 +441,7 @@ Exit condition:
 
 Reference plan:
 
-- [2026-04-15-phase14-orchestration-integration-plan.md](/Users/chris/Documents/openclaw-template/docs/plans/2026-04-15-phase14-orchestration-integration-plan.md)
+- [2026-04-15-phase14-orchestration-integration-plan.md](2026-04-15-phase14-orchestration-integration-plan.md)
 
 ### Milestone 10: Graph Intelligence And Synthesis
 

--- a/docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
+++ b/docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
@@ -348,7 +348,7 @@ Current slice:
 
 ### Milestone 8: Knowledge Evolution Layer
 
-Status: **Not Started**
+Status: **Complete**
 
 Goal:
 
@@ -369,9 +369,21 @@ Exit condition:
 
 - users can trace how a topic evolved across notes and reviews, not just detect isolated conflicts.
 
+Current progress:
+
+- deterministic evolution candidates now exist for:
+  - `replaces`
+  - `enriches`
+  - `confirms`
+  - `challenges`
+- `/evolution` and `/api/evolution` expose candidate plus reviewed evolution links,
+- object and topic pages render `Evolution` sections,
+- evolution review actions persist accepted and rejected links,
+- the layer is reviewable without pretending candidate links are already truth.
+
 ### Milestone 9: Background Intelligence
 
-Status: **Not Started**
+Status: **In Progress**
 
 Goal:
 
@@ -391,6 +403,45 @@ Core deliverables:
 Exit condition:
 
 - the system can surface at least one relevant contradiction, one useful synthesis, or one actionable priority the user likely would not have found unaided.
+
+Current progress:
+
+- `/briefing` is no longer a raw snapshot page; it now surfaces:
+  - `First Useful Sign`
+  - `Insights`
+  - `Priority Items`
+- `signals` and `briefing` now attach explicit `Recommended Action` metadata,
+- deterministic briefing intelligence is grounded in existing signals and evolution links,
+- UI cold-start no longer blocks on full evolution recomputation because caches are prewarmed at startup.
+
+### Milestone 9A: Background Intelligence Orchestration Integration
+
+Status: **Planned**
+
+Goal:
+
+Keep `signals`, `briefing`, and `recommended actions` as observation and prioritization surfaces while unifying all execution behind one action queue plus worker layer that dispatches into the existing `ovp` runtime.
+
+Core deliverables:
+
+- one execution surface:
+  - action queue
+  - worker
+  - workflow handler registry
+- explicit relationship between focused queue actions and broad batch execution through `ovp --full`,
+- policy-driven auto-queue for low-risk deterministic actions:
+  - `source_needs_deep_dive`
+  - `deep_dive_needs_objects`
+- queue state surfaced back into `signals` and `briefing`,
+- worker-side precondition checks and idempotent dedupe.
+
+Exit condition:
+
+- the product has many observation surfaces but only one execution surface, and `ovp --full` remains the batch reconciler instead of competing with a second workflow engine.
+
+Reference plan:
+
+- [2026-04-15-phase14-orchestration-integration-plan.md](/Users/chris/Documents/openclaw-template/docs/plans/2026-04-15-phase14-orchestration-integration-plan.md)
 
 ### Milestone 10: Graph Intelligence And Synthesis
 

--- a/docs/plans/2026-04-15-phase14-orchestration-integration-plan.md
+++ b/docs/plans/2026-04-15-phase14-orchestration-integration-plan.md
@@ -1,0 +1,370 @@
+# Phase 14 Orchestration Integration Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Unify `signals`, `briefing`, `recommended actions`, and existing `ovp` workflows behind one action-queue control plane so the product has many observation surfaces but only one execution surface.
+
+**Architecture:** Keep `ovp --full` and existing pipeline/profile commands as the execution engine. Add an action queue ledger plus a thin worker/dispatcher that maps `recommended_action.kind` to existing workflow handlers. UI pages enqueue or review actions; they do not execute workflows directly.
+
+**Tech Stack:** Python 3.13, existing `truth_api`, `ui_server`, `unified_pipeline_enhanced.py`, JSONL/audit logs, pytest.
+
+## Current State
+
+The repo already has two partially overlapping systems:
+
+1. **Execution surfaces**
+   - `ovp --full --pack ...`
+   - individual pipeline steps in `unified_pipeline_enhanced.py`
+   - existing UI maintenance actions:
+     - contradiction resolution
+     - summary rebuild
+     - evolution review
+
+2. **Detection/intelligence surfaces**
+   - `signals`
+   - `briefing`
+   - `recommended_action`
+   - `production gaps`
+   - `evolution candidates`
+
+The risk is obvious: if every page learns how to launch workflows directly, the product ends up with many conflicting entrypoints, no single state machine, and poor auditability.
+
+## Design Decision
+
+There must be:
+
+- **many observation surfaces**
+  - dashboard
+  - briefing
+  - signals
+  - contradictions
+  - summaries
+  - production
+
+and exactly **one execution surface**
+
+- action queue
+- worker
+- workflow handler registry
+
+That means:
+
+- `signals` detect
+- `briefing` prioritizes
+- `recommended_action` proposes
+- `action queue` decides what will run
+- `worker` executes
+- existing `ovp` runtime performs the actual work
+
+## System Model
+
+```text
+truth state
+  -> signal sync
+  -> policy
+  -> action queue
+  -> worker
+  -> existing ovp workflow handlers
+  -> truth state refresh
+```
+
+This makes the new product layer a control plane, not a second workflow system.
+
+## Role Of `ovp --full`
+
+`ovp --full` should remain the bulk reconciler and profile executor.
+
+It should not be replaced by the queue system.
+
+Instead:
+
+1. **`ovp --full` remains the best entrypoint for broad batch runs**
+   - full pack/profile execution
+   - large inbox refreshes
+   - overnight or operator-triggered reconciliation
+
+2. **Queue/worker becomes the best entrypoint for targeted follow-up actions**
+   - create a deep dive for one processed source note
+   - extract evergreen objects for one deep dive
+   - rebuild one object summary
+   - later: repair one production-chain gap
+
+3. **Both converge on the same truth state**
+   - after execution, truth/index refresh happens
+   - signals are re-synced
+   - briefing/dashboard see the new state
+
+So the relationship is:
+
+- `ovp --full` = broad scheduled or manual batch execution
+- `action queue` = focused incremental execution
+
+They are complementary, not competing.
+
+## Required New Layer
+
+### Action Queue Ledger
+
+Create a dedicated action ledger separate from `signals`.
+
+Minimum fields:
+
+- `action_id`
+- `action_kind`
+- `source_signal_id`
+- `title`
+- `target_ref`
+- `object_ids`
+- `note_paths`
+- `status`
+  - `queued`
+  - `running`
+  - `succeeded`
+  - `failed`
+  - `dismissed`
+  - `obsolete`
+- `created_at`
+- `started_at`
+- `finished_at`
+- `error`
+- `payload`
+
+This must be separate from the signal ledger because:
+
+- a signal is a detected state
+- an action is a chosen response to that state
+
+One signal can produce zero, one, or multiple actions over time.
+
+### Worker / Dispatcher
+
+Create a thin worker that:
+
+1. reads queued actions
+2. marks one as `running`
+3. resolves `action_kind` to a workflow handler
+4. executes
+5. updates status
+6. records audit output
+
+The worker must never encode domain logic directly. It should only dispatch.
+
+## Workflow Handler Registry
+
+Recommended action kinds should map to existing workflow handlers.
+
+Initial mappings:
+
+- `review_contradiction`
+  - already handled by existing contradiction review UI
+  - keep manual for now
+
+- `rebuild_summary`
+  - map to existing `rebuild_compiled_summaries(...)`
+
+- `deep_dive_workflow`
+  - target: one processed source note
+  - should call a focused execution path, not `ovp --full`
+
+- `object_extraction_workflow`
+  - target: one deep dive note
+  - should call a focused absorb/object extraction path
+
+- `inspect_production_gap`
+  - review-only for now
+
+## Policy Model
+
+Do not force the user to enqueue every signal manually.
+
+Signals should be split into three policy classes:
+
+### Auto-queue
+
+Use for deterministic, low-risk follow-up steps:
+
+- `source_needs_deep_dive`
+- `deep_dive_needs_objects`
+
+### Needs Review
+
+Use for semantically riskier tasks:
+
+- `contradiction_open`
+- many `production_gap` cases
+- later, complex evolution actions
+
+### Ignore / Dismiss
+
+Used for low-value or intentionally skipped states.
+
+This lets the product avoid the “click every signal one by one” trap.
+
+## Idempotency Rules
+
+### Signal idempotency
+
+Keep current deterministic `signal_id`.
+
+Signals continue to represent the current active state, not a user-triggered event.
+
+### Action idempotency
+
+Create actions with a deterministic uniqueness rule:
+
+- `signal_id`
+- `action_kind`
+- `target_ref`
+- `payload_hash`
+
+If the same active signal is seen again, do not enqueue a duplicate action.
+
+### Worker precondition checks
+
+Before running any queued action, the worker must re-check that the signal condition still holds.
+
+If the condition is already satisfied:
+
+- do not execute
+- mark the action `obsolete` or `already_satisfied`
+
+This is mandatory for safe retries and restarts.
+
+## History Model
+
+The current signal ledger behaves like an active snapshot.
+
+To support queue semantics properly, the system should distinguish:
+
+1. **active signals**
+2. **signal history**
+3. **action queue**
+4. **action execution history**
+
+Phase 14 does not need the full historical model immediately, but the queue design must not block it.
+
+## Recommended Phase 14 Execution Order
+
+### Task 1: Lock orchestration contract in docs and tests
+
+**Files:**
+- Create: `docs/plans/2026-04-15-phase14-orchestration-integration-plan.md`
+- Modify later: `docs/plans/2026-04-14-local-knowledge-workbench-milestone.md`
+
+**Step 1: Document one execution surface**
+
+Write the orchestration contract:
+- observation surfaces vs execution surface
+- `ovp --full` role
+- action queue role
+- worker role
+
+**Step 2: Commit**
+
+```bash
+git add docs/plans/2026-04-15-phase14-orchestration-integration-plan.md
+git commit -m "docs: define phase14 orchestration integration"
+```
+
+### Task 2: Introduce action queue ledger
+
+**Files:**
+- Modify: `src/openclaw_pipeline/truth_api.py`
+- Test: `tests/test_truth_api.py`
+
+**Step 1: Write failing tests**
+
+Cover:
+- queue insertion
+- deterministic dedupe
+- state transitions
+
+**Step 2: Implement minimal queue storage**
+
+Use the existing JSONL/audit style first. Do not introduce a new DB abstraction yet.
+
+**Step 3: Verify**
+
+Run focused tests, then full tests.
+
+### Task 3: Add a worker/dispatcher
+
+**Files:**
+- Modify: `src/openclaw_pipeline/commands/*.py`
+- Modify: `src/openclaw_pipeline/truth_api.py`
+- Test: `tests/test_ui_server.py`, `tests/test_truth_api.py`
+
+**Step 1: Add worker contract**
+
+The worker should:
+- fetch queued action
+- re-check preconditions
+- dispatch by `action_kind`
+- record outcome
+
+**Step 2: Keep handlers thin**
+
+Do not duplicate pipeline logic in the worker.
+
+### Task 4: Wire the first two actionable workflow bridges
+
+**Files:**
+- Modify: `src/openclaw_pipeline/unified_pipeline_enhanced.py`
+- Modify: `src/openclaw_pipeline/truth_api.py`
+- Modify: `src/openclaw_pipeline/commands/ui_server.py`
+- Test: `tests/test_runtime_paths.py`, `tests/test_truth_api.py`, `tests/test_ui_smoke.py`
+
+**Step 1: Add focused workflow entrypoints**
+
+Needed handlers:
+- one source note -> deep dive
+- one deep dive -> evergreen/object extraction
+
+These should reuse existing workflow primitives as much as possible.
+
+**Step 2: Queue auto-policy**
+
+Auto-queue:
+- `source_needs_deep_dive`
+- `deep_dive_needs_objects`
+
+### Task 5: Surface queue state in UI
+
+**Files:**
+- Modify: `src/openclaw_pipeline/ui/view_models.py`
+- Modify: `src/openclaw_pipeline/commands/ui_server.py`
+- Test: `tests/test_ui_smoke.py`
+
+Show:
+- queued
+- running
+- succeeded
+- failed
+- obsolete
+
+`signals` and `briefing` should explain whether the recommended action is:
+- already queued
+- manual only
+- completed
+
+## Non-Goals For This Slice
+
+Do not do these yet:
+
+- full background daemon orchestration
+- multi-worker concurrency
+- speculative auto-run for contradictions
+- a second workflow engine
+- replacing `ovp --full`
+- heavy graph intelligence work
+
+## Exit Criteria
+
+Phase 14 orchestration integration is good enough when:
+
+1. `signals` and `briefing` surface recommended actions.
+2. There is a real action queue ledger.
+3. At least one worker path executes queued actions.
+4. `source_needs_deep_dive` and `deep_dive_needs_objects` can auto-queue safely.
+5. The worker re-checks preconditions and avoids duplicate execution.
+6. `ovp --full` remains the batch reconciler instead of being bypassed or duplicated.

--- a/src/openclaw_pipeline/commands/resolve_contradictions.py
+++ b/src/openclaw_pipeline/commands/resolve_contradictions.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from ..knowledge_index import contradiction_object_ids, rebuild_compiled_summaries, resolve_contradictions
 from ..runtime import VaultLayout, resolve_vault_dir
+from ..truth_api import record_review_action
 
 
 def _load_contradiction_ids_from_queue(layout: VaultLayout, queue_name: str) -> tuple[list[str], dict[str, list[Path]]]:
@@ -57,14 +58,31 @@ def main(argv: list[str] | None = None) -> int:
     contradiction_ids = list(dict.fromkeys(contradiction_ids))
 
     payload = resolve_contradictions(vault_dir, contradiction_ids, status=args.status, note=args.note)
+    affected_object_ids = contradiction_object_ids(vault_dir, payload["contradiction_ids"])
     if payload["resolved_count"] and args.rebuild_summaries:
-        affected_object_ids = contradiction_object_ids(vault_dir, payload["contradiction_ids"])
         rebuild_payload = rebuild_compiled_summaries(vault_dir, object_ids=affected_object_ids)
         payload["rebuilt_summary_count"] = rebuild_payload["objects_rebuilt"]
         payload["rebuilt_object_ids"] = rebuild_payload["object_ids"]
     else:
         payload["rebuilt_summary_count"] = 0
         payload["rebuilt_object_ids"] = []
+    if payload["resolved_count"]:
+        payload["object_ids"] = affected_object_ids
+        record_review_action(
+            vault_dir,
+            event_type="ui_contradictions_resolved",
+            slug=affected_object_ids[0] if affected_object_ids else "",
+            payload={
+                "object_ids": affected_object_ids,
+                "contradiction_ids": payload["contradiction_ids"],
+                "status": args.status,
+                "note": args.note,
+                "rebuilt_object_ids": payload["rebuilt_object_ids"],
+            },
+            session_id="resolve-contradictions-cli",
+        )
+    else:
+        payload["object_ids"] = []
 
     cleared_queue_files: list[str] = []
     if payload["resolved_count"] and queue_files_by_id:

--- a/src/openclaw_pipeline/commands/run_actions.py
+++ b/src/openclaw_pipeline/commands/run_actions.py
@@ -2,20 +2,62 @@ from __future__ import annotations
 
 import argparse
 import json
+import time
 from pathlib import Path
 
-from ..runtime import resolve_vault_dir
+from ..runtime import VaultLayout, advisory_file_lock, resolve_vault_dir
 from ..truth_api import run_next_action_queue_item
+
+
+def run_action_worker_loop(
+    vault_dir: Path | str,
+    *,
+    interval_seconds: float = 2.0,
+    max_runs: int | None = None,
+) -> dict[str, object]:
+    resolved_vault = resolve_vault_dir(vault_dir)
+    iterations = 0
+    last_result: dict[str, object] = {"ran": False, "reason": "not_started"}
+
+    while max_runs is None or iterations < max_runs:
+        last_result = run_next_action_queue_item(resolved_vault)
+        iterations += 1
+        if max_runs is not None and iterations >= max_runs:
+            break
+        time.sleep(max(0.0, interval_seconds))
+
+    return {
+        "loop": True,
+        "iterations": iterations,
+        "interval_seconds": max(0.0, interval_seconds),
+        "last_result": last_result,
+    }
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Run queued action workers")
     parser.add_argument("--vault-dir", type=Path, default=None, help="Vault directory")
-    parser.add_argument("--once", action="store_true", help="Run at most one queued action")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--once", action="store_true", help="Run at most one queued action")
+    mode.add_argument("--loop", action="store_true", help="Run as a dedicated action worker loop")
+    parser.add_argument("--interval", type=float, default=2.0, help="Polling interval for loop mode")
+    parser.add_argument("--max-runs", type=int, default=None, help="Maximum iterations in loop mode")
     args = parser.parse_args(argv)
 
     resolved_vault = resolve_vault_dir(args.vault_dir)
-    payload = run_next_action_queue_item(resolved_vault)
+    if args.loop:
+        layout = VaultLayout.from_vault(resolved_vault)
+        try:
+            with advisory_file_lock(layout.action_worker_lock, timeout_seconds=0.0):
+                payload = run_action_worker_loop(
+                    resolved_vault,
+                    interval_seconds=args.interval,
+                    max_runs=args.max_runs,
+                )
+        except TimeoutError:
+            payload = {"loop": True, "started": False, "reason": "worker_already_running"}
+    else:
+        payload = run_next_action_queue_item(resolved_vault)
     print(json.dumps(payload, ensure_ascii=False), flush=True)
     return 0
 

--- a/src/openclaw_pipeline/commands/run_actions.py
+++ b/src/openclaw_pipeline/commands/run_actions.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from ..runtime import resolve_vault_dir
+from ..truth_api import run_next_action_queue_item
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run queued action workers")
+    parser.add_argument("--vault-dir", type=Path, default=None, help="Vault directory")
+    parser.add_argument("--once", action="store_true", help="Run at most one queued action")
+    args = parser.parse_args(argv)
+
+    resolved_vault = resolve_vault_dir(args.vault_dir)
+    payload = run_next_action_queue_item(resolved_vault)
+    print(json.dumps(payload, ensure_ascii=False), flush=True)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/openclaw_pipeline/commands/run_actions.py
+++ b/src/openclaw_pipeline/commands/run_actions.py
@@ -14,13 +14,14 @@ def run_action_worker_loop(
     *,
     interval_seconds: float = 2.0,
     max_runs: int | None = None,
+    safe_only: bool = False,
 ) -> dict[str, object]:
     resolved_vault = resolve_vault_dir(vault_dir)
     iterations = 0
     last_result: dict[str, object] = {"ran": False, "reason": "not_started"}
 
     while max_runs is None or iterations < max_runs:
-        last_result = run_next_action_queue_item(resolved_vault)
+        last_result = run_next_action_queue_item(resolved_vault, safe_only=safe_only)
         iterations += 1
         if max_runs is not None and iterations >= max_runs:
             break
@@ -30,6 +31,7 @@ def run_action_worker_loop(
         "loop": True,
         "iterations": iterations,
         "interval_seconds": max(0.0, interval_seconds),
+        "safe_only": safe_only,
         "last_result": last_result,
     }
 
@@ -42,6 +44,7 @@ def main(argv: list[str] | None = None) -> int:
     mode.add_argument("--loop", action="store_true", help="Run as a dedicated action worker loop")
     parser.add_argument("--interval", type=float, default=2.0, help="Polling interval for loop mode")
     parser.add_argument("--max-runs", type=int, default=None, help="Maximum iterations in loop mode")
+    parser.add_argument("--safe-only", action="store_true", help="Only run actions marked safe_to_run")
     args = parser.parse_args(argv)
 
     resolved_vault = resolve_vault_dir(args.vault_dir)
@@ -53,11 +56,12 @@ def main(argv: list[str] | None = None) -> int:
                     resolved_vault,
                     interval_seconds=args.interval,
                     max_runs=args.max_runs,
+                    safe_only=args.safe_only,
                 )
         except TimeoutError:
             payload = {"loop": True, "started": False, "reason": "worker_already_running"}
     else:
-        payload = run_next_action_queue_item(resolved_vault)
+        payload = run_next_action_queue_item(resolved_vault, safe_only=args.safe_only)
     print(json.dumps(payload, ensure_ascii=False), flush=True)
     return 0
 

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -6,6 +6,7 @@ import mimetypes
 import sqlite3
 import re
 import sys
+import threading
 from html import escape
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -1547,6 +1548,7 @@ def _render_actions_page(payload: dict) -> str:
         "Action Queue",
         (
             "<h1>Action Queue</h1>"
+            "<p class='muted'>Asynchronous queue consumption is opt-in. Start the UI with <code>--with-action-worker</code> to let a background dispatcher run queued actions outside the request thread.</p>"
             "<form method='post' action='/actions/run-next' class='link-row'>"
             "<button type='submit'>Run next queued action</button>"
             "</form>"
@@ -2163,6 +2165,46 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
     return ThreadingHTTPServer((host, port), Handler)
 
 
+def _action_dispatcher_loop(vault_dir: Path | str, *, stop_event: threading.Event, interval_seconds: float) -> None:
+    while not stop_event.is_set():
+        try:
+            run_next_action_queue_item(vault_dir)
+        except Exception:
+            pass
+        stop_event.wait(interval_seconds)
+
+
+def _start_action_dispatcher(
+    vault_dir: Path | str,
+    *,
+    interval_seconds: float = 2.0,
+) -> dict[str, Any]:
+    stop_event = threading.Event()
+    thread = threading.Thread(
+        target=_action_dispatcher_loop,
+        kwargs={
+            "vault_dir": resolve_vault_dir(vault_dir),
+            "stop_event": stop_event,
+            "interval_seconds": interval_seconds,
+        },
+        daemon=True,
+        name="ovp-action-dispatcher",
+    )
+    thread.start()
+    return {"thread": thread, "stop_event": stop_event, "interval_seconds": interval_seconds}
+
+
+def _stop_action_dispatcher(dispatcher: dict[str, Any] | None) -> None:
+    if not dispatcher:
+        return
+    stop_event = dispatcher.get("stop_event")
+    thread = dispatcher.get("thread")
+    if isinstance(stop_event, threading.Event):
+        stop_event.set()
+    if isinstance(thread, threading.Thread):
+        thread.join(timeout=5)
+
+
 def _prewarm_ui_caches(vault_dir: Path | str) -> None:
     try:
         build_evolution_browser_payload(vault_dir, status="all")
@@ -2179,16 +2221,25 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--vault-dir", type=Path, default=None, help="Vault directory")
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8787)
+    parser.add_argument("--with-action-worker", action="store_true", help="Run a background action dispatcher in this UI process")
+    parser.add_argument("--action-worker-interval", type=float, default=2.0, help="Polling interval for the optional background action dispatcher")
     args = parser.parse_args(argv)
 
     resolved_vault = resolve_vault_dir(args.vault_dir)
     server = create_server(resolved_vault, host=args.host, port=args.port)
+    dispatcher = None
     try:
         build_objects_index_payload(resolved_vault, limit=1, offset=0)
         ensure_signal_ledger_synced(resolved_vault)
         _start_ui_prewarm(resolved_vault)
+        if args.with_action_worker:
+            dispatcher = _start_action_dispatcher(
+                resolved_vault,
+                interval_seconds=args.action_worker_interval,
+            )
     except Exception as exc:
         print(f"ui server preflight failed: {exc}", file=sys.stderr)
+        _stop_action_dispatcher(dispatcher)
         server.server_close()
         return 1
 
@@ -2198,6 +2249,7 @@ def main(argv: list[str] | None = None) -> int:
     except KeyboardInterrupt:  # pragma: no cover
         pass
     finally:
+        _stop_action_dispatcher(dispatcher)
         server.server_close()
     return 0
 

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -1386,6 +1386,42 @@ def _render_signals_page(payload: dict) -> str:
 
 
 def _render_briefing_page(payload: dict) -> str:
+    first_useful_sign = payload.get("first_useful_sign")
+    first_useful_sign_html = (
+        "<li>"
+        + f"<span class='pill'>{escape(str(first_useful_sign['kind']))}</span> "
+        + f"<a href=\"{escape(str(first_useful_sign['path']))}\">{escape(str(first_useful_sign['title']))}</a>"
+        + f"<div class='muted'>{escape(str(first_useful_sign['detail']))}</div>"
+        + (
+            f"<div class='muted'>Sources: {escape(', '.join(first_useful_sign.get('source_paths', [])))}</div>"
+            if first_useful_sign.get("source_paths")
+            else ""
+        )
+        + "</li>"
+        if first_useful_sign
+        else "<li class='muted'>No useful sign surfaced yet.</li>"
+    )
+    insights = "".join(
+        "<li>"
+        + f"<span class='pill'>{escape(str(item['link_type']))}</span> "
+        + f"<a href=\"{escape(str(item['path']))}\">{escape(str(item['title']))}</a>"
+        + f"<div class='muted'>{escape(str(item['detail']))}</div>"
+        + (
+            f"<div class='muted'>Sources: {escape(', '.join(item.get('source_paths', [])))}</div>"
+            if item.get("source_paths")
+            else ""
+        )
+        + "</li>"
+        for item in payload["insights"]
+    ) or "<li class='muted'>No evolution insights surfaced.</li>"
+    priority_items = "".join(
+        "<li>"
+        + f"<span class='pill'>{escape(str(item['kind']))}</span> "
+        + f"<a href=\"{escape(str(item['path']))}\">{escape(str(item['title']))}</a>"
+        + f"<div class='muted'>{escape(str(item['detail']))}</div>"
+        + "</li>"
+        for item in payload["priority_items"]
+    ) or "<li class='muted'>No priority items surfaced.</li>"
     recent_signals = "".join(
         f'<li><span class="pill">{escape(item["signal_type"])}</span> '
         f'<a href="{escape(item["source_path"])}">{escape(item["title"])}</a>'
@@ -1411,6 +1447,9 @@ def _render_briefing_page(payload: dict) -> str:
         (
             "<h1>Working Memory Snapshot</h1>"
             f"<p class='muted'>Generated at {escape(payload['generated_at'])}. {payload['recent_signal_count']} recent signals, {payload['unresolved_issue_count']} unresolved issues.</p>"
+            f"<section class='card'><h2>First Useful Sign</h2><ul class='list-tight'>{first_useful_sign_html}</ul></section>"
+            f"<section class='card'><h2>Insights</h2><ul class='list-tight'>{insights}</ul></section>"
+            f"<section class='card'><h2>Priority Items</h2><ul class='list-tight'>{priority_items}</ul></section>"
             f"<section class='card'><h2>Recent Signals</h2><ul class='list-tight'>{recent_signals}</ul></section>"
             f"<section class='card'><h2>Unresolved Issues</h2><ul class='list-tight'>{unresolved}</ul></section>"
             f"<section class='card'><h2>Changed Objects</h2><ul class='list-tight'>{changed_objects}</ul></section>"
@@ -1988,6 +2027,17 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
     return ThreadingHTTPServer((host, port), Handler)
 
 
+def _prewarm_ui_caches(vault_dir: Path | str) -> None:
+    try:
+        build_evolution_browser_payload(vault_dir, status="all")
+    except Exception:
+        return
+
+
+def _start_ui_prewarm(vault_dir: Path | str) -> None:
+    _prewarm_ui_caches(vault_dir)
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Run a minimal local UI over knowledge.db")
     parser.add_argument("--vault-dir", type=Path, default=None, help="Vault directory")
@@ -2000,6 +2050,7 @@ def main(argv: list[str] | None = None) -> int:
     try:
         build_objects_index_payload(resolved_vault, limit=1, offset=0)
         ensure_signal_ledger_synced(resolved_vault)
+        _start_ui_prewarm(resolved_vault)
     except Exception as exc:
         print(f"ui server preflight failed: {exc}", file=sys.stderr)
         server.server_close()

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -2287,7 +2287,8 @@ def _spawn_action_worker_process(vault_dir: Path | str, *, interval_seconds: flo
 def _prewarm_ui_caches(vault_dir: Path | str) -> None:
     try:
         build_evolution_browser_payload(vault_dir, status="all")
-    except Exception:
+    except Exception as exc:
+        print(f"ui server cache pre-warming failed: {exc}", file=sys.stderr)
         return
 
 

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -1353,6 +1353,18 @@ def _render_signals_page(payload: dict) -> str:
         f'<a href="{escape(item["source_path"])}">{escape(item["title"])}</a>'
         f"<div class='muted'>{escape(item['detail'])}</div>"
         + (
+            "<div class='muted'>Recommended Action: "
+            + f'<a href="{escape(item["recommended_action"]["path"])}">{escape(item["recommended_action"]["label"])}</a>'
+            + (
+                " <span class='pill'>executable</span>"
+                if item["recommended_action"].get("executable")
+                else " <span class='pill'>manual</span>"
+            )
+            + "</div>"
+            if item.get("recommended_action")
+            else ""
+        )
+        + (
             "<div class='muted'>Downstream: "
             + ", ".join(
                 f'<a href="{escape(effect["path"])}">{escape(effect["label"])}</a>'
@@ -1419,6 +1431,18 @@ def _render_briefing_page(payload: dict) -> str:
         + f"<span class='pill'>{escape(str(item['kind']))}</span> "
         + f"<a href=\"{escape(str(item['path']))}\">{escape(str(item['title']))}</a>"
         + f"<div class='muted'>{escape(str(item['detail']))}</div>"
+        + (
+            "<div class='muted'>Recommended Action: "
+            + f'<a href="{escape(str(item["recommended_action"]["path"]))}">{escape(str(item["recommended_action"]["label"]))}</a>'
+            + (
+                " <span class='pill'>executable</span>"
+                if item["recommended_action"].get("executable")
+                else " <span class='pill'>manual</span>"
+            )
+            + "</div>"
+            if item.get("recommended_action")
+            else ""
+        )
         + "</li>"
         for item in payload["priority_items"]
     ) or "<li class='muted'>No priority items surfaced.</li>"

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -5,6 +5,7 @@ import json
 import mimetypes
 import sqlite3
 import re
+import subprocess
 import sys
 import threading
 from html import escape
@@ -2168,7 +2169,19 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
 def _action_dispatcher_loop(vault_dir: Path | str, *, stop_event: threading.Event, interval_seconds: float) -> None:
     while not stop_event.is_set():
         try:
-            run_next_action_queue_item(vault_dir)
+            subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "openclaw_pipeline.commands.run_actions",
+                    "--vault-dir",
+                    str(resolve_vault_dir(vault_dir)),
+                    "--once",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=1800,
+            )
         except Exception:
             pass
         stop_event.wait(interval_seconds)

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -38,10 +38,13 @@ from ..ui.view_models import (
     build_topic_overview_payload,
 )
 from ..truth_api import (
+    dismiss_action_queue_item,
     enqueue_signal_action,
     ensure_signal_ledger_synced,
     record_review_action,
+    retry_action_queue_item,
     review_evolution_candidate,
+    run_action_queue,
     run_next_action_queue_item,
 )
 
@@ -1542,6 +1545,22 @@ def _render_actions_page(payload: dict) -> str:
             if item.get("created_at")
             else ""
         )
+        + (
+            "<form method='post' action='/actions/retry' class='link-row'>"
+            + f"<input type='hidden' name='action_id' value='{escape(str(item['action_id']))}' />"
+            + "<button type='submit'>Retry</button>"
+            + "</form>"
+            if item.get("status") in {"failed", "obsolete"}
+            else ""
+        )
+        + (
+            "<form method='post' action='/actions/dismiss' class='link-row'>"
+            + f"<input type='hidden' name='action_id' value='{escape(str(item['action_id']))}' />"
+            + "<button type='submit'>Dismiss</button>"
+            + "</form>"
+            if item.get("status") in {"queued", "failed", "obsolete", "running"}
+            else ""
+        )
         + "</li>"
         for item in payload["items"]
     ) or "<li class='muted'>No queued actions yet.</li>"
@@ -1552,6 +1571,10 @@ def _render_actions_page(payload: dict) -> str:
             "<p class='muted'>Asynchronous queue consumption is opt-in. Start the UI with <code>--with-action-worker</code> to let a background dispatcher run queued actions outside the request thread.</p>"
             "<form method='post' action='/actions/run-next' class='link-row'>"
             "<button type='submit'>Run next queued action</button>"
+            "</form>"
+            "<form method='post' action='/actions/run-batch' class='link-row'>"
+            "<input type='hidden' name='limit' value='5' />"
+            "<button type='submit'>Run 5 queued actions</button>"
             "</form>"
             "<form method='get' action='/actions' class='link-row'>"
             f"<input type='text' name='q' value='{escape(query)}' placeholder='Search actions' />"
@@ -2029,6 +2052,29 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
                     run_next_action_queue_item(resolved_vault)
                     self._redirect("/actions")
                     return
+                if path == "/api/actions/run-batch":
+                    limit = int(self._form_first(form, "limit").strip() or "5")
+                    self._write_json(run_action_queue(resolved_vault, limit=limit))
+                    return
+                if path == "/actions/run-batch":
+                    limit = int(self._form_first(form, "limit").strip() or "5")
+                    run_action_queue(resolved_vault, limit=limit)
+                    self._redirect("/actions")
+                    return
+                if path == "/api/actions/retry":
+                    self._write_json(self._retry_action(form))
+                    return
+                if path == "/actions/retry":
+                    self._retry_action(form)
+                    self._redirect("/actions")
+                    return
+                if path == "/api/actions/dismiss":
+                    self._write_json(self._dismiss_action(form))
+                    return
+                if path == "/actions/dismiss":
+                    self._dismiss_action(form)
+                    self._redirect("/actions")
+                    return
                 self.send_error(404, "Not Found")
             except ValueError as exc:
                 self.send_error(400, str(exc))
@@ -2133,6 +2179,18 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
             payload = enqueue_signal_action(resolved_vault, signal_id=signal_id)
             payload["next_path"] = self._form_first(form, "next").strip() or "/actions"
             return payload
+
+        def _retry_action(self, form: dict[str, list[str]]) -> dict[str, object]:
+            action_id = self._form_first(form, "action_id").strip()
+            if not action_id:
+                raise ValueError("missing action_id")
+            return retry_action_queue_item(resolved_vault, action_id=action_id)
+
+        def _dismiss_action(self, form: dict[str, list[str]]) -> dict[str, object]:
+            action_id = self._form_first(form, "action_id").strip()
+            if not action_id:
+                raise ValueError("missing action_id")
+            return dismiss_action_queue_item(resolved_vault, action_id=action_id)
 
         def _write_json(self, payload: dict) -> None:
             body = json.dumps(payload, ensure_ascii=False).encode("utf-8")

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -18,6 +18,7 @@ from ..identity import canonicalize_note_id
 from ..knowledge_index import contradiction_object_ids, rebuild_compiled_summaries, resolve_contradictions
 from ..runtime import VaultLayout, resolve_vault_dir
 from ..ui.view_models import (
+    build_action_queue_payload,
     build_atlas_browser_payload,
     build_briefing_payload,
     build_contradiction_browser_payload,
@@ -34,7 +35,12 @@ from ..ui.view_models import (
     build_truth_dashboard_payload,
     build_topic_overview_payload,
 )
-from ..truth_api import ensure_signal_ledger_synced, record_review_action, review_evolution_candidate
+from ..truth_api import (
+    enqueue_signal_action,
+    ensure_signal_ledger_synced,
+    record_review_action,
+    review_evolution_candidate,
+)
 
 _MARKDOWN_RENDERER = MarkdownIt("commonmark", {"breaks": True, "html": False}).enable("table")
 _FENCED_FRONTMATTER_RE = re.compile(r"^```ya?ml\s*\n---\n(.*?)\n---\n```\s*\n?", re.DOTALL)
@@ -107,6 +113,7 @@ def _layout(title: str, body: str) -> str:
             <a href="/search">Search</a>
             <a href="/signals">Signals</a>
             <a href="/briefing">Briefing</a>
+            <a href="/actions">Actions</a>
             <a href="/evolution">Evolution</a>
             <a href="/production">Production</a>
             <a href="/atlas">Atlas</a>
@@ -1356,12 +1363,25 @@ def _render_signals_page(payload: dict) -> str:
             "<div class='muted'>Recommended Action: "
             + f'<a href="{escape(item["recommended_action"]["path"])}">{escape(item["recommended_action"]["label"])}</a>'
             + (
-                " <span class='pill'>executable</span>"
-                if item["recommended_action"].get("executable")
-                else " <span class='pill'>manual</span>"
+                f" <span class='pill'>{escape(str(item['recommended_action']['queue_status']))}</span>"
+                if item["recommended_action"].get("queue_status")
+                else (
+                    " <span class='pill'>executable</span>"
+                    if item["recommended_action"].get("executable")
+                    else " <span class='pill'>manual</span>"
+                )
             )
             + "</div>"
             if item.get("recommended_action")
+            else ""
+        )
+        + (
+            "<form method='post' action='/actions/enqueue' class='link-row'>"
+            + f"<input type='hidden' name='signal_id' value='{escape(item['signal_id'])}' />"
+            + "<input type='hidden' name='next' value='/signals' />"
+            + "<button type='submit'>Queue action</button>"
+            + "</form>"
+            if item.get("recommended_action") and not item["recommended_action"].get("queue_status")
             else ""
         )
         + (
@@ -1435,12 +1455,25 @@ def _render_briefing_page(payload: dict) -> str:
             "<div class='muted'>Recommended Action: "
             + f'<a href="{escape(str(item["recommended_action"]["path"]))}">{escape(str(item["recommended_action"]["label"]))}</a>'
             + (
-                " <span class='pill'>executable</span>"
-                if item["recommended_action"].get("executable")
-                else " <span class='pill'>manual</span>"
+                f" <span class='pill'>{escape(str(item['recommended_action']['queue_status']))}</span>"
+                if item["recommended_action"].get("queue_status")
+                else (
+                    " <span class='pill'>executable</span>"
+                    if item["recommended_action"].get("executable")
+                    else " <span class='pill'>manual</span>"
+                )
             )
             + "</div>"
             if item.get("recommended_action")
+            else ""
+        )
+        + (
+            "<form method='post' action='/actions/enqueue' class='link-row'>"
+            + f"<input type='hidden' name='signal_id' value='{escape(str(item['signal_id']))}' />"
+            + "<input type='hidden' name='next' value='/briefing' />"
+            + "<button type='submit'>Queue action</button>"
+            + "</form>"
+            if item.get("signal_id") and item.get("recommended_action") and not item["recommended_action"].get("queue_status")
             else ""
         )
         + "</li>"
@@ -1478,6 +1511,48 @@ def _render_briefing_page(payload: dict) -> str:
             f"<section class='card'><h2>Unresolved Issues</h2><ul class='list-tight'>{unresolved}</ul></section>"
             f"<section class='card'><h2>Changed Objects</h2><ul class='list-tight'>{changed_objects}</ul></section>"
             f"<section class='card'><h2>Active Topics</h2><ul class='list-tight'>{active_topics}</ul></section>"
+        ),
+    )
+
+
+def _render_actions_page(payload: dict) -> str:
+    query = payload.get("query", "")
+    selected_status = payload.get("status", "")
+    options = ["", "queued", "running", "succeeded", "failed", "dismissed", "obsolete"]
+    option_html = "".join(
+        f"<option value='{escape(option)}' {'selected' if option == selected_status else ''}>"
+        f"{escape(option or 'all statuses')}</option>"
+        for option in options
+    )
+    items = "".join(
+        "<li>"
+        f"<span class='pill'>{escape(str(item['status']))}</span> "
+        f"<span class='pill'>{escape(str(item['action_kind']))}</span> "
+        f"{escape(str(item['title']))}"
+        + (
+            f"<div class='muted'>Target: {escape(str(item['target_ref']))}</div>"
+            if item.get("target_ref")
+            else ""
+        )
+        + (
+            f"<div class='muted'>Created at {escape(str(item['created_at']))}</div>"
+            if item.get("created_at")
+            else ""
+        )
+        + "</li>"
+        for item in payload["items"]
+    ) or "<li class='muted'>No queued actions yet.</li>"
+    return _layout(
+        "Action Queue",
+        (
+            "<h1>Action Queue</h1>"
+            "<form method='get' action='/actions' class='link-row'>"
+            f"<input type='text' name='q' value='{escape(query)}' placeholder='Search actions' />"
+            f"<select name='status'>{option_html}</select>"
+            "<button type='submit'>Filter</button>"
+            "</form>"
+            f"<p class='muted'>{payload['count']} actions in the current execution surface.</p>"
+            f"<section class='card'><ul class='list-tight'>{items}</ul></section>"
         ),
     )
 
@@ -1859,6 +1934,17 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
                     payload = build_production_browser_payload(resolved_vault, query=q)
                     self._write_html(_render_production_browser_page(payload))
                     return
+                if path == "/api/actions":
+                    status = query.get("status", [""])[0] or None
+                    q = query.get("q", [""])[0]
+                    self._write_json(build_action_queue_payload(resolved_vault, status=status, query=q))
+                    return
+                if path == "/actions":
+                    status = query.get("status", [""])[0] or None
+                    q = query.get("q", [""])[0]
+                    payload = build_action_queue_payload(resolved_vault, status=status, query=q)
+                    self._write_html(_render_actions_page(payload))
+                    return
                 if path == "/api/summaries":
                     q = query.get("q", [""])[0]
                     self._write_json(build_stale_summary_browser_payload(resolved_vault, query=q))
@@ -1921,6 +2007,13 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
                 if path == "/evolution/review":
                     self._review_evolution_action(form)
                     self._redirect("/evolution")
+                    return
+                if path == "/api/actions/enqueue":
+                    self._write_json(self._enqueue_signal_action(form))
+                    return
+                if path == "/actions/enqueue":
+                    payload = self._enqueue_signal_action(form)
+                    self._redirect(str(payload["next_path"]))
                     return
                 self.send_error(404, "Not Found")
             except ValueError as exc:
@@ -2018,6 +2111,14 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
                 note=note,
                 link_type=link_type,
             )
+
+        def _enqueue_signal_action(self, form: dict[str, list[str]]) -> dict[str, object]:
+            signal_id = self._form_first(form, "signal_id").strip()
+            if not signal_id:
+                raise ValueError("missing signal_id")
+            payload = enqueue_signal_action(resolved_vault, signal_id=signal_id)
+            payload["next_path"] = self._form_first(form, "next").strip() or "/actions"
+            return payload
 
         def _write_json(self, payload: dict) -> None:
             body = json.dumps(payload, ensure_ascii=False).encode("utf-8")

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -1504,6 +1504,11 @@ def _render_briefing_page(payload: dict) -> str:
         f"<span class='muted'>({item['signal_count']} signals)</span></li>"
         for item in payload["active_topics"]
     ) or "<li class='muted'>No active topics surfaced.</li>"
+    queue_summary = payload.get("queue_summary", {})
+    failure_buckets = "".join(
+        f"<li><span class='pill'>{escape(bucket)}</span> {count}</li>"
+        for bucket, count in queue_summary.get("failure_buckets", {}).items()
+    ) or "<li class='muted'>No failed actions.</li>"
     return _layout(
         "Working Memory Snapshot",
         (
@@ -1512,6 +1517,18 @@ def _render_briefing_page(payload: dict) -> str:
             f"<section class='card'><h2>First Useful Sign</h2><ul class='list-tight'>{first_useful_sign_html}</ul></section>"
             f"<section class='card'><h2>Insights</h2><ul class='list-tight'>{insights}</ul></section>"
             f"<section class='card'><h2>Priority Items</h2><ul class='list-tight'>{priority_items}</ul></section>"
+            "<section class='card'><h2>Execution Surface</h2>"
+            f"<p class='muted'>{queue_summary.get('queued_count', 0)} queued, "
+            f"{queue_summary.get('safe_queued_count', 0)} safe to auto-run, "
+            f"{queue_summary.get('running_count', 0)} running, "
+            f"{queue_summary.get('failed_count', 0)} failed.</p>"
+            "<form method='post' action='/actions/run-batch' class='link-row'>"
+            "<input type='hidden' name='limit' value='5' />"
+            "<input type='hidden' name='safe_only' value='1' />"
+            "<input type='hidden' name='next' value='/briefing' />"
+            "<button type='submit'>Run 5 safe queued actions</button>"
+            "</form>"
+            f"<ul class='list-tight'>{failure_buckets}</ul></section>"
             f"<section class='card'><h2>Recent Signals</h2><ul class='list-tight'>{recent_signals}</ul></section>"
             f"<section class='card'><h2>Unresolved Issues</h2><ul class='list-tight'>{unresolved}</ul></section>"
             f"<section class='card'><h2>Changed Objects</h2><ul class='list-tight'>{changed_objects}</ul></section>"
@@ -1533,7 +1550,13 @@ def _render_actions_page(payload: dict) -> str:
         "<li>"
         f"<span class='pill'>{escape(str(item['status']))}</span> "
         f"<span class='pill'>{escape(str(item['action_kind']))}</span> "
-        f"{escape(str(item['title']))}"
+        + (
+            " <span class='pill'>safe</span>"
+            if item.get("safe_to_run")
+            else " <span class='pill'>manual</span>"
+        )
+        + " "
+        + f"{escape(str(item['title']))}"
         + (
             f"<div class='muted'>Target: {escape(str(item['target_ref']))}</div>"
             if item.get("target_ref")
@@ -1542,6 +1565,16 @@ def _render_actions_page(payload: dict) -> str:
         + (
             f"<div class='muted'>Created at {escape(str(item['created_at']))}</div>"
             if item.get("created_at")
+            else ""
+        )
+        + (
+            f"<div class='muted'>Retry count: {int(item.get('retry_count') or 0)}</div>"
+            if item.get("retry_count") is not None
+            else ""
+        )
+        + (
+            f"<div class='muted'>Failure bucket: {escape(str(item['failure_bucket']))}</div>"
+            if item.get("failure_bucket")
             else ""
         )
         + (
@@ -1575,12 +1608,19 @@ def _render_actions_page(payload: dict) -> str:
             "<input type='hidden' name='limit' value='5' />"
             "<button type='submit'>Run 5 queued actions</button>"
             "</form>"
+            "<form method='post' action='/actions/run-batch' class='link-row'>"
+            "<input type='hidden' name='limit' value='5' />"
+            "<input type='hidden' name='safe_only' value='1' />"
+            "<button type='submit'>Run 5 safe queued actions</button>"
+            "</form>"
             "<form method='get' action='/actions' class='link-row'>"
             f"<input type='text' name='q' value='{escape(query)}' placeholder='Search actions' />"
             f"<select name='status'>{option_html}</select>"
             "<button type='submit'>Filter</button>"
             "</form>"
-            f"<p class='muted'>{payload['count']} actions in the current execution surface.</p>"
+            f"<p class='muted'>{payload['count']} actions in the current execution surface. "
+            f"{payload.get('queued_safe_count', 0)} queued safe actions. "
+            f"{payload.get('failed_count', 0)} failed actions.</p>"
             f"<section class='card'><ul class='list-tight'>{items}</ul></section>"
         ),
     )
@@ -2045,20 +2085,24 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
                     self._redirect(str(payload["next_path"]))
                     return
                 if path == "/api/actions/run-next":
-                    self._write_json(run_next_action_queue_item(resolved_vault))
+                    safe_only = self._form_first(form, "safe_only").strip() == "1"
+                    self._write_json(run_next_action_queue_item(resolved_vault, safe_only=safe_only))
                     return
                 if path == "/actions/run-next":
-                    run_next_action_queue_item(resolved_vault)
-                    self._redirect("/actions")
+                    safe_only = self._form_first(form, "safe_only").strip() == "1"
+                    run_next_action_queue_item(resolved_vault, safe_only=safe_only)
+                    self._redirect(self._form_first(form, "next").strip() or "/actions")
                     return
                 if path == "/api/actions/run-batch":
                     limit = int(self._form_first(form, "limit").strip() or "5")
-                    self._write_json(run_action_queue(resolved_vault, limit=limit))
+                    safe_only = self._form_first(form, "safe_only").strip() == "1"
+                    self._write_json(run_action_queue(resolved_vault, limit=limit, safe_only=safe_only))
                     return
                 if path == "/actions/run-batch":
                     limit = int(self._form_first(form, "limit").strip() or "5")
-                    run_action_queue(resolved_vault, limit=limit)
-                    self._redirect("/actions")
+                    safe_only = self._form_first(form, "safe_only").strip() == "1"
+                    run_action_queue(resolved_vault, limit=limit, safe_only=safe_only)
+                    self._redirect(self._form_first(form, "next").strip() or "/actions")
                     return
                 if path == "/api/actions/retry":
                     self._write_json(self._retry_action(form))

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -40,6 +40,7 @@ from ..truth_api import (
     ensure_signal_ledger_synced,
     record_review_action,
     review_evolution_candidate,
+    run_next_action_queue_item,
 )
 
 _MARKDOWN_RENDERER = MarkdownIt("commonmark", {"breaks": True, "html": False}).enable("table")
@@ -1546,6 +1547,9 @@ def _render_actions_page(payload: dict) -> str:
         "Action Queue",
         (
             "<h1>Action Queue</h1>"
+            "<form method='post' action='/actions/run-next' class='link-row'>"
+            "<button type='submit'>Run next queued action</button>"
+            "</form>"
             "<form method='get' action='/actions' class='link-row'>"
             f"<input type='text' name='q' value='{escape(query)}' placeholder='Search actions' />"
             f"<select name='status'>{option_html}</select>"
@@ -2014,6 +2018,13 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
                 if path == "/actions/enqueue":
                     payload = self._enqueue_signal_action(form)
                     self._redirect(str(payload["next_path"]))
+                    return
+                if path == "/api/actions/run-next":
+                    self._write_json(run_next_action_queue_item(resolved_vault))
+                    return
+                if path == "/actions/run-next":
+                    run_next_action_queue_item(resolved_vault)
+                    self._redirect("/actions")
                     return
                 self.send_error(404, "Not Found")
             except ValueError as exc:

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -7,7 +7,6 @@ import sqlite3
 import re
 import subprocess
 import sys
-import threading
 from html import escape
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -1568,7 +1567,7 @@ def _render_actions_page(payload: dict) -> str:
         "Action Queue",
         (
             "<h1>Action Queue</h1>"
-            "<p class='muted'>Asynchronous queue consumption is opt-in. Start the UI with <code>--with-action-worker</code> to let a background dispatcher run queued actions outside the request thread.</p>"
+            "<p class='muted'>Asynchronous queue consumption is opt-in. Run <code>python -m openclaw_pipeline.commands.run_actions --vault-dir &lt;vault&gt; --loop</code> or start the UI with <code>--with-action-worker</code> to spawn a detached worker process.</p>"
             "<form method='post' action='/actions/run-next' class='link-row'>"
             "<button type='submit'>Run next queued action</button>"
             "</form>"
@@ -2223,57 +2222,22 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
 
     return ThreadingHTTPServer((host, port), Handler)
 
-
-def _action_dispatcher_loop(vault_dir: Path | str, *, stop_event: threading.Event, interval_seconds: float) -> None:
-    while not stop_event.is_set():
-        try:
-            subprocess.run(
-                [
-                    sys.executable,
-                    "-m",
-                    "openclaw_pipeline.commands.run_actions",
-                    "--vault-dir",
-                    str(resolve_vault_dir(vault_dir)),
-                    "--once",
-                ],
-                capture_output=True,
-                text=True,
-                timeout=1800,
-            )
-        except Exception:
-            pass
-        stop_event.wait(interval_seconds)
-
-
-def _start_action_dispatcher(
-    vault_dir: Path | str,
-    *,
-    interval_seconds: float = 2.0,
-) -> dict[str, Any]:
-    stop_event = threading.Event()
-    thread = threading.Thread(
-        target=_action_dispatcher_loop,
-        kwargs={
-            "vault_dir": resolve_vault_dir(vault_dir),
-            "stop_event": stop_event,
-            "interval_seconds": interval_seconds,
-        },
-        daemon=True,
-        name="ovp-action-dispatcher",
+def _spawn_action_worker_process(vault_dir: Path | str, *, interval_seconds: float = 2.0) -> None:
+    subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "openclaw_pipeline.commands.run_actions",
+            "--vault-dir",
+            str(resolve_vault_dir(vault_dir)),
+            "--loop",
+            "--interval",
+            str(max(0.1, interval_seconds)),
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
     )
-    thread.start()
-    return {"thread": thread, "stop_event": stop_event, "interval_seconds": interval_seconds}
-
-
-def _stop_action_dispatcher(dispatcher: dict[str, Any] | None) -> None:
-    if not dispatcher:
-        return
-    stop_event = dispatcher.get("stop_event")
-    thread = dispatcher.get("thread")
-    if isinstance(stop_event, threading.Event):
-        stop_event.set()
-    if isinstance(thread, threading.Thread):
-        thread.join(timeout=5)
 
 
 def _prewarm_ui_caches(vault_dir: Path | str) -> None:
@@ -2292,25 +2256,23 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--vault-dir", type=Path, default=None, help="Vault directory")
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8787)
-    parser.add_argument("--with-action-worker", action="store_true", help="Run a background action dispatcher in this UI process")
-    parser.add_argument("--action-worker-interval", type=float, default=2.0, help="Polling interval for the optional background action dispatcher")
+    parser.add_argument("--with-action-worker", action="store_true", help="Spawn a detached action worker process")
+    parser.add_argument("--action-worker-interval", type=float, default=2.0, help="Polling interval for the detached action worker")
     args = parser.parse_args(argv)
 
     resolved_vault = resolve_vault_dir(args.vault_dir)
     server = create_server(resolved_vault, host=args.host, port=args.port)
-    dispatcher = None
     try:
         build_objects_index_payload(resolved_vault, limit=1, offset=0)
         ensure_signal_ledger_synced(resolved_vault)
         _start_ui_prewarm(resolved_vault)
         if args.with_action_worker:
-            dispatcher = _start_action_dispatcher(
+            _spawn_action_worker_process(
                 resolved_vault,
                 interval_seconds=args.action_worker_interval,
             )
     except Exception as exc:
         print(f"ui server preflight failed: {exc}", file=sys.stderr)
-        _stop_action_dispatcher(dispatcher)
         server.server_close()
         return 1
 
@@ -2320,7 +2282,6 @@ def main(argv: list[str] | None = None) -> int:
     except KeyboardInterrupt:  # pragma: no cover
         pass
     finally:
-        _stop_action_dispatcher(dispatcher)
         server.server_close()
     return 0
 

--- a/src/openclaw_pipeline/knowledge_index.py
+++ b/src/openclaw_pipeline/knowledge_index.py
@@ -306,6 +306,48 @@ def _ensure_knowledge_db(vault_dir: Path) -> tuple[Path, VaultLayout]:
     return resolved_vault, layout
 
 
+def _read_jsonl_items(path: Path) -> list[dict[str, object]]:
+    if not path.exists():
+        return []
+    items: list[dict[str, object]] = []
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        if not raw_line.strip():
+            continue
+        try:
+            payload = json.loads(raw_line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            items.append(payload)
+    return items
+
+
+def _latest_contradiction_review_overrides(vault_dir: Path) -> dict[str, dict[str, str]]:
+    layout = VaultLayout.from_vault(vault_dir)
+    items = sorted(
+        [
+            item
+            for item in _read_jsonl_items(layout.logs_dir / "review-actions.jsonl")
+            if item.get("event_type") == "ui_contradictions_resolved"
+        ],
+        key=lambda item: str(item.get("timestamp") or ""),
+    )
+    overrides: dict[str, dict[str, str]] = {}
+    for item in items:
+        status = str(item.get("status") or "")
+        note = str(item.get("note") or "")
+        resolved_at = str(item.get("timestamp") or "")
+        for contradiction_id in item.get("contradiction_ids", []) or []:
+            contradiction_key = str(contradiction_id or "")
+            if contradiction_key:
+                overrides[contradiction_key] = {
+                    "status": status,
+                    "resolution_note": note,
+                    "resolved_at": resolved_at,
+                }
+    return overrides
+
+
 def rebuild_knowledge_index(vault_dir: Path) -> dict[str, int | str]:
     resolved_vault = resolve_vault_dir(vault_dir)
     layout = VaultLayout.from_vault(resolved_vault)
@@ -511,6 +553,7 @@ def rebuild_knowledge_index(vault_dir: Path) -> dict[str, int | str]:
         else:
             assert conn is not None
             conn.close()
+            _remove_sqlite_artifacts(layout.knowledge_db)
             temp_db_path.replace(layout.knowledge_db)
 
         return {
@@ -659,12 +702,19 @@ def list_contradictions(vault_dir: Path, limit: int = 20, subject: str | None = 
         params = (limit,)
     query += " ORDER BY subject_key LIMIT ?"
 
-    with sqlite3.connect(layout.knowledge_db) as conn:
-        rows = conn.execute(query, params).fetchall()
-
-    return [
-        {
-            "contradiction_id": row[0],
+    try:
+        with sqlite3.connect(layout.knowledge_db) as conn:
+            rows = conn.execute(query, params).fetchall()
+    except sqlite3.OperationalError as exc:
+        if "no such table" in str(exc).lower():
+            return []
+        raise
+    overrides = _latest_contradiction_review_overrides(vault_dir)
+    items = []
+    for row in rows:
+        contradiction_id = str(row[0])
+        item = {
+            "contradiction_id": contradiction_id,
             "subject_key": row[1],
             "positive_claim_ids": json.loads(row[2]),
             "negative_claim_ids": json.loads(row[3]),
@@ -672,8 +722,13 @@ def list_contradictions(vault_dir: Path, limit: int = 20, subject: str | None = 
             "resolution_note": row[5] or "",
             "resolved_at": row[6] or "",
         }
-        for row in rows
-    ]
+        override = overrides.get(contradiction_id)
+        if override:
+            item["status"] = override["status"]
+            item["resolution_note"] = override["resolution_note"]
+            item["resolved_at"] = override["resolved_at"]
+        items.append(item)
+    return items
 
 
 def resolve_contradictions(
@@ -695,30 +750,17 @@ def resolve_contradictions(
         }
 
     placeholders = ",".join("?" for _ in resolved_ids)
-    with knowledge_db_write_lock(vault_dir):
-        with sqlite3.connect(layout.knowledge_db) as conn:
-            existing = conn.execute(
-                f"""
-                SELECT contradiction_id
-                FROM contradictions
-                WHERE contradiction_id IN ({placeholders})
-                ORDER BY contradiction_id
-                """,
-                tuple(resolved_ids),
-            ).fetchall()
-            found_ids = [row[0] for row in existing]
-            if found_ids:
-                now_value = conn.execute("SELECT strftime('%Y-%m-%dT%H:%M:%SZ', 'now')").fetchone()[0]
-                found_placeholders = ",".join("?" for _ in found_ids)
-                conn.execute(
-                    f"""
-                    UPDATE contradictions
-                    SET status = ?, resolution_note = ?, resolved_at = ?
-                    WHERE contradiction_id IN ({found_placeholders})
-                    """,
-                    (status, note, now_value, *found_ids),
-                )
-                conn.commit()
+    with sqlite3.connect(layout.knowledge_db) as conn:
+        existing = conn.execute(
+            f"""
+            SELECT contradiction_id
+            FROM contradictions
+            WHERE contradiction_id IN ({placeholders})
+            ORDER BY contradiction_id
+            """,
+            tuple(resolved_ids),
+        ).fetchall()
+        found_ids = [row[0] for row in existing]
 
     return {
         "resolved_count": len(found_ids),
@@ -770,80 +812,29 @@ def contradiction_object_ids(vault_dir: Path, contradiction_ids: list[str]) -> l
 
 def rebuild_compiled_summaries(vault_dir: Path, object_ids: list[str] | None = None) -> dict[str, object]:
     _, layout = _ensure_knowledge_db(vault_dir)
-    with knowledge_db_write_lock(vault_dir):
-        with sqlite3.connect(layout.knowledge_db) as conn:
-            if object_ids:
-                placeholders = ",".join("?" for _ in object_ids)
-                object_rows = conn.execute(
-                    f"""
-                    SELECT objects.object_id, objects.title,
-                           COALESCE(rel.outgoing_count, 0) AS outgoing_count
-                    FROM objects
-                    LEFT JOIN (
-                        SELECT source_object_id, COUNT(*) AS outgoing_count
-                        FROM relations
-                        GROUP BY source_object_id
-                    ) AS rel ON rel.source_object_id = objects.object_id
-                    WHERE objects.object_id IN ({placeholders})
-                    ORDER BY objects.object_id
-                    """,
-                    tuple(object_ids),
-                ).fetchall()
-            else:
-                object_rows = conn.execute(
-                    """
-                    SELECT objects.object_id, objects.title,
-                           COALESCE(rel.outgoing_count, 0) AS outgoing_count
-                    FROM objects
-                    LEFT JOIN (
-                        SELECT source_object_id, COUNT(*) AS outgoing_count
-                        FROM relations
-                        GROUP BY source_object_id
-                    ) AS rel ON rel.source_object_id = objects.object_id
-                    ORDER BY objects.object_id
-                    """
-                ).fetchall()
+    with sqlite3.connect(layout.knowledge_db) as conn:
+        if object_ids:
+            placeholders = ",".join("?" for _ in object_ids)
+            object_rows = conn.execute(
+                f"""
+                SELECT object_id
+                FROM objects
+                WHERE object_id IN ({placeholders})
+                ORDER BY object_id
+                """,
+                tuple(object_ids),
+            ).fetchall()
+        else:
+            object_rows = conn.execute(
+                """
+                SELECT object_id
+                FROM objects
+                ORDER BY object_id
+                """
+            ).fetchall()
 
-            rebuilt_ids: list[str] = []
-            for object_id, title, _outgoing_count in object_rows:
-                claim_rows = conn.execute(
-                    """
-                    SELECT claim_text
-                    FROM claims
-                    WHERE object_id = ? AND claim_kind = 'page_summary'
-                    ORDER BY claim_id
-                    """,
-                    (object_id,),
-                ).fetchall()
-                base_summary = str(claim_rows[0][0]) if claim_rows else str(title)
-                related_rows = conn.execute(
-                    """
-                    SELECT target_object_id
-                    FROM relations
-                    WHERE source_object_id = ?
-                    ORDER BY target_object_id
-                    LIMIT ?
-                    """,
-                    (object_id, SUMMARY_RELATED_LIMIT),
-                ).fetchall()
-                related_ids = [row[0] for row in related_rows]
-                summary = base_summary
-                if related_ids:
-                    summary = f"{base_summary} Related: {', '.join(related_ids)}."
-                if len(summary) > SUMMARY_MAX_LEN:
-                    summary = summary[: SUMMARY_MAX_LEN - 3].rstrip() + "..."
-
-                conn.execute(
-                    """
-                    INSERT INTO compiled_summaries (object_id, summary_text, source_slug)
-                    VALUES (?, ?, ?)
-                    ON CONFLICT(object_id) DO UPDATE SET summary_text = excluded.summary_text, source_slug = excluded.source_slug
-                    """,
-                    (object_id, summary, object_id),
-                )
-                rebuilt_ids.append(str(object_id))
-
-            conn.commit()
+    rebuilt_ids = [str(row[0]) for row in object_rows]
+    rebuild_knowledge_index(vault_dir)
 
     return {
         "objects_rebuilt": len(rebuilt_ids),

--- a/src/openclaw_pipeline/knowledge_index.py
+++ b/src/openclaw_pipeline/knowledge_index.py
@@ -13,7 +13,7 @@ from .concept_registry import ConceptRegistry, ResolutionAction
 from .graph.frontmatter import FrontmatterParser, NoteMetadata
 from .graph.link_parser import LinkParser
 from .identity import canonicalize_note_id
-from .runtime import VaultLayout, resolve_vault_dir
+from .runtime import VaultLayout, knowledge_db_write_lock, resolve_vault_dir
 from .truth_store import TRUTH_STORE_SCHEMA, build_truth_store_projection
 
 SUMMARY_MAX_LEN = 320
@@ -309,223 +309,224 @@ def _ensure_knowledge_db(vault_dir: Path) -> tuple[Path, VaultLayout]:
 def rebuild_knowledge_index(vault_dir: Path) -> dict[str, int | str]:
     resolved_vault = resolve_vault_dir(vault_dir)
     layout = VaultLayout.from_vault(resolved_vault)
-    evergreen_dir = layout.evergreen_dir
-    atlas_dir = layout.atlas_dir
-    areas_dir = resolved_vault / "20-Areas"
-    parser = FrontmatterParser(resolved_vault)
-    link_parser = LinkParser(resolved_vault)
-    registry = ConceptRegistry(resolved_vault).load()
+    with knowledge_db_write_lock(resolved_vault):
+        evergreen_dir = layout.evergreen_dir
+        atlas_dir = layout.atlas_dir
+        areas_dir = resolved_vault / "20-Areas"
+        parser = FrontmatterParser(resolved_vault)
+        link_parser = LinkParser(resolved_vault)
+        registry = ConceptRegistry(resolved_vault).load()
 
-    object_metadata_items = [
-        meta
-        for meta in parser.parse_directory(evergreen_dir, recursive=True)
-        if "_Candidates" not in Path(meta.path).parts
-    ]
-    page_metadata_items = list(object_metadata_items)
-    for extra_dir in (atlas_dir, areas_dir):
-        if not extra_dir.exists():
-            continue
-        for meta in parser.parse_directory(extra_dir, recursive=True):
-            if "_Candidates" in Path(meta.path).parts:
+        object_metadata_items = [
+            meta
+            for meta in parser.parse_directory(evergreen_dir, recursive=True)
+            if "_Candidates" not in Path(meta.path).parts
+        ]
+        page_metadata_items = list(object_metadata_items)
+        for extra_dir in (atlas_dir, areas_dir):
+            if not extra_dir.exists():
                 continue
-            page_metadata_items.append(meta)
+            for meta in parser.parse_directory(extra_dir, recursive=True):
+                if "_Candidates" in Path(meta.path).parts:
+                    continue
+                page_metadata_items.append(meta)
 
-    deduped_page_metadata_items: list[NoteMetadata] = []
-    seen_page_keys: set[str] = set()
-    for meta in page_metadata_items:
-        key = meta.note_id
-        if key in seen_page_keys:
-            continue
-        seen_page_keys.add(key)
-        deduped_page_metadata_items.append(meta)
+        deduped_page_metadata_items: list[NoteMetadata] = []
+        seen_page_keys: set[str] = set()
+        for meta in page_metadata_items:
+            key = meta.note_id
+            if key in seen_page_keys:
+                continue
+            seen_page_keys.add(key)
+            deduped_page_metadata_items.append(meta)
 
-    surface_map = _build_surface_map(object_metadata_items)
-    known_slugs = {meta.note_id for meta in object_metadata_items}
+        surface_map = _build_surface_map(object_metadata_items)
+        known_slugs = {meta.note_id for meta in object_metadata_items}
 
-    temp_db_path = layout.knowledge_db.with_name(f"{layout.knowledge_db.name}.tmp")
-    _remove_sqlite_artifacts(temp_db_path)
+        temp_db_path = layout.knowledge_db.with_name(f"{layout.knowledge_db.name}.tmp")
+        _remove_sqlite_artifacts(temp_db_path)
 
-    conn = None
-    try:
-        conn = _initialize_database(temp_db_path)
-        page_rows = []
-        timeline_rows = []
-        embedding_rows = []
-        for meta in deduped_page_metadata_items:
-            file_path = Path(meta.path)
-            body = _split_frontmatter_body(file_path.read_text(encoding="utf-8"))
-            page_rows.append(
-                (
-                    meta.note_id,
-                    meta.title,
-                    meta.note_type,
-                    str(file_path),
-                    meta.day_id,
-                    json.dumps(meta.to_dict(), ensure_ascii=False),
-                    body,
-                )
-            )
-            timeline_rows.extend(_extract_timeline_events(meta, body))
-            for chunk_index, (section_title, chunk_text) in enumerate(_chunk_page_body(body, meta.title)):
-                embedding_rows.append(
+        conn = None
+        try:
+            conn = _initialize_database(temp_db_path)
+            page_rows = []
+            timeline_rows = []
+            embedding_rows = []
+            for meta in deduped_page_metadata_items:
+                file_path = Path(meta.path)
+                body = _split_frontmatter_body(file_path.read_text(encoding="utf-8"))
+                page_rows.append(
                     (
                         meta.note_id,
-                        chunk_index,
-                        section_title,
-                        chunk_text,
-                        _embed_text(f"{section_title}\n{chunk_text}"),
-                        EMBEDDING_MODEL,
+                        meta.title,
+                        meta.note_type,
+                        str(file_path),
+                        meta.day_id,
+                        json.dumps(meta.to_dict(), ensure_ascii=False),
+                        body,
                     )
                 )
-
-        conn.executemany(
-            """
-            INSERT INTO pages_index (slug, title, note_type, path, day_id, frontmatter_json, body)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
-            """,
-            page_rows,
-        )
-        conn.executemany(
-            "INSERT INTO page_fts (slug, title, body) VALUES (?, ?, ?)",
-            [(slug, title, body) for slug, title, _, _, _, _, body in page_rows],
-        )
-
-        link_rows = []
-        for meta in deduped_page_metadata_items:
-            file_path = Path(meta.path)
-            for link in link_parser.parse_file(file_path):
-                target_slug = _resolve_target_slug(link.target_raw or link.target, registry, surface_map)
-                if not target_slug or target_slug not in known_slugs:
-                    continue
-                link_rows.append(
-                    (
-                        link.source,
-                        target_slug,
-                        link.target_raw,
-                        link.link_type,
-                        link.line_number,
+                timeline_rows.extend(_extract_timeline_events(meta, body))
+                for chunk_index, (section_title, chunk_text) in enumerate(_chunk_page_body(body, meta.title)):
+                    embedding_rows.append(
+                        (
+                            meta.note_id,
+                            chunk_index,
+                            section_title,
+                            chunk_text,
+                            _embed_text(f"{section_title}\n{chunk_text}"),
+                            EMBEDDING_MODEL,
+                        )
                     )
-                )
 
-        conn.executemany(
-            """
-            INSERT INTO page_links (source_slug, target_slug, target_raw, link_type, line_number)
-            VALUES (?, ?, ?, ?, ?)
-            """,
-            link_rows,
-        )
-
-        object_page_rows = [row for row in page_rows if row[0] in known_slugs]
-        object_link_rows = [row for row in link_rows if row[0] in known_slugs]
-        truth_projection = build_truth_store_projection(object_page_rows, object_link_rows)
-        conn.executemany(
-            """
-            INSERT INTO objects (object_id, object_kind, title, canonical_path, source_slug)
-            VALUES (?, ?, ?, ?, ?)
-            """,
-            truth_projection.objects,
-        )
-        conn.executemany(
-            """
-            INSERT INTO claims (claim_id, object_id, claim_kind, claim_text, confidence)
-            VALUES (?, ?, ?, ?, ?)
-            """,
-            truth_projection.claims,
-        )
-        conn.executemany(
-            """
-            INSERT INTO claim_evidence (claim_id, source_slug, evidence_kind, quote_text)
-            VALUES (?, ?, ?, ?)
-            """,
-            truth_projection.claim_evidence,
-        )
-        conn.executemany(
-            """
-            INSERT INTO relations (source_object_id, target_object_id, relation_type, evidence_source_slug)
-            VALUES (?, ?, ?, ?)
-            """,
-            truth_projection.relations,
-        )
-        conn.executemany(
-            """
-            INSERT INTO compiled_summaries (object_id, summary_text, source_slug)
-            VALUES (?, ?, ?)
-            """,
-            truth_projection.compiled_summaries,
-        )
-        conn.executemany(
-            """
-            INSERT INTO contradictions (
-                contradiction_id,
-                subject_key,
-                positive_claim_ids_json,
-                negative_claim_ids_json,
-                status,
-                resolution_note,
-                resolved_at
+            conn.executemany(
+                """
+                INSERT INTO pages_index (slug, title, note_type, path, day_id, frontmatter_json, body)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                page_rows,
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?)
-            """,
-            truth_projection.contradictions,
-        )
+            conn.executemany(
+                "INSERT INTO page_fts (slug, title, body) VALUES (?, ?, ?)",
+                [(slug, title, body) for slug, title, _, _, _, _, body in page_rows],
+            )
 
-        raw_rows = _collect_raw_rows(layout)
-        conn.executemany(
-            """
-            INSERT INTO raw_data (slug, source_name, payload_json, source_path)
-            VALUES (?, ?, ?, ?)
-            """,
-            raw_rows,
-        )
+            link_rows = []
+            for meta in deduped_page_metadata_items:
+                file_path = Path(meta.path)
+                for link in link_parser.parse_file(file_path):
+                    target_slug = _resolve_target_slug(link.target_raw or link.target, registry, surface_map)
+                    if not target_slug or target_slug not in known_slugs:
+                        continue
+                    link_rows.append(
+                        (
+                            link.source,
+                            target_slug,
+                            link.target_raw,
+                            link.link_type,
+                            link.line_number,
+                        )
+                    )
 
-        conn.executemany(
-            """
-            INSERT INTO timeline_events (slug, event_date, event_type, heading, payload_json)
-            VALUES (?, ?, ?, ?, ?)
-            """,
-            timeline_rows,
-        )
+            conn.executemany(
+                """
+                INSERT INTO page_links (source_slug, target_slug, target_raw, link_type, line_number)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                link_rows,
+            )
 
-        audit_rows = _collect_audit_rows(layout)
-        conn.executemany(
-            """
-            INSERT INTO audit_events (source_log, event_type, slug, session_id, timestamp, payload_json)
-            VALUES (?, ?, ?, ?, ?, ?)
-            """,
-            audit_rows,
-        )
-        conn.executemany(
-            """
-            INSERT INTO page_embeddings (slug, chunk_index, section_title, chunk_text, embedding_blob, embedding_model)
-            VALUES (?, ?, ?, ?, ?, ?)
-            """,
-            embedding_rows,
-        )
-        conn.commit()
-    except Exception:
-        if conn is not None:
+            object_page_rows = [row for row in page_rows if row[0] in known_slugs]
+            object_link_rows = [row for row in link_rows if row[0] in known_slugs]
+            truth_projection = build_truth_store_projection(object_page_rows, object_link_rows)
+            conn.executemany(
+                """
+                INSERT INTO objects (object_id, object_kind, title, canonical_path, source_slug)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                truth_projection.objects,
+            )
+            conn.executemany(
+                """
+                INSERT INTO claims (claim_id, object_id, claim_kind, claim_text, confidence)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                truth_projection.claims,
+            )
+            conn.executemany(
+                """
+                INSERT INTO claim_evidence (claim_id, source_slug, evidence_kind, quote_text)
+                VALUES (?, ?, ?, ?)
+                """,
+                truth_projection.claim_evidence,
+            )
+            conn.executemany(
+                """
+                INSERT INTO relations (source_object_id, target_object_id, relation_type, evidence_source_slug)
+                VALUES (?, ?, ?, ?)
+                """,
+                truth_projection.relations,
+            )
+            conn.executemany(
+                """
+                INSERT INTO compiled_summaries (object_id, summary_text, source_slug)
+                VALUES (?, ?, ?)
+                """,
+                truth_projection.compiled_summaries,
+            )
+            conn.executemany(
+                """
+                INSERT INTO contradictions (
+                    contradiction_id,
+                    subject_key,
+                    positive_claim_ids_json,
+                    negative_claim_ids_json,
+                    status,
+                    resolution_note,
+                    resolved_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                truth_projection.contradictions,
+            )
+
+            raw_rows = _collect_raw_rows(layout)
+            conn.executemany(
+                """
+                INSERT INTO raw_data (slug, source_name, payload_json, source_path)
+                VALUES (?, ?, ?, ?)
+                """,
+                raw_rows,
+            )
+
+            conn.executemany(
+                """
+                INSERT INTO timeline_events (slug, event_date, event_type, heading, payload_json)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                timeline_rows,
+            )
+
+            audit_rows = _collect_audit_rows(layout)
+            conn.executemany(
+                """
+                INSERT INTO audit_events (source_log, event_type, slug, session_id, timestamp, payload_json)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                audit_rows,
+            )
+            conn.executemany(
+                """
+                INSERT INTO page_embeddings (slug, chunk_index, section_title, chunk_text, embedding_blob, embedding_model)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                embedding_rows,
+            )
+            conn.commit()
+        except Exception:
+            if conn is not None:
+                conn.close()
+            _remove_sqlite_artifacts(temp_db_path)
+            raise
+        else:
+            assert conn is not None
             conn.close()
-        _remove_sqlite_artifacts(temp_db_path)
-        raise
-    else:
-        assert conn is not None
-        conn.close()
-        temp_db_path.replace(layout.knowledge_db)
+            temp_db_path.replace(layout.knowledge_db)
 
-    return {
-        "db_path": str(layout.knowledge_db),
-        "pages_indexed": len(page_rows),
-        "links_indexed": len(link_rows),
-        "raw_records_indexed": len(raw_rows),
-        "timeline_events_indexed": len(timeline_rows),
-        "audit_events_indexed": len(audit_rows),
-        "embedding_chunks_indexed": len(embedding_rows),
-        "objects_indexed": len(truth_projection.objects),
-        "claims_indexed": len(truth_projection.claims),
-        "relations_indexed": len(truth_projection.relations),
-        "compiled_summaries_indexed": len(truth_projection.compiled_summaries),
-        "contradictions_indexed": len(truth_projection.contradictions),
-    }
+        return {
+            "db_path": str(layout.knowledge_db),
+            "pages_indexed": len(page_rows),
+            "links_indexed": len(link_rows),
+            "raw_records_indexed": len(raw_rows),
+            "timeline_events_indexed": len(timeline_rows),
+            "audit_events_indexed": len(audit_rows),
+            "embedding_chunks_indexed": len(embedding_rows),
+            "objects_indexed": len(truth_projection.objects),
+            "claims_indexed": len(truth_projection.claims),
+            "relations_indexed": len(truth_projection.relations),
+            "compiled_summaries_indexed": len(truth_projection.compiled_summaries),
+            "contradictions_indexed": len(truth_projection.contradictions),
+        }
 
 
 def query_knowledge_index(vault_dir: Path, query: str, limit: int = 5) -> list[dict[str, str | int | float]]:
@@ -694,29 +695,30 @@ def resolve_contradictions(
         }
 
     placeholders = ",".join("?" for _ in resolved_ids)
-    with sqlite3.connect(layout.knowledge_db) as conn:
-        existing = conn.execute(
-            f"""
-            SELECT contradiction_id
-            FROM contradictions
-            WHERE contradiction_id IN ({placeholders})
-            ORDER BY contradiction_id
-            """,
-            tuple(resolved_ids),
-        ).fetchall()
-        found_ids = [row[0] for row in existing]
-        if found_ids:
-            now_value = conn.execute("SELECT strftime('%Y-%m-%dT%H:%M:%SZ', 'now')").fetchone()[0]
-            found_placeholders = ",".join("?" for _ in found_ids)
-            conn.execute(
+    with knowledge_db_write_lock(vault_dir):
+        with sqlite3.connect(layout.knowledge_db) as conn:
+            existing = conn.execute(
                 f"""
-                UPDATE contradictions
-                SET status = ?, resolution_note = ?, resolved_at = ?
-                WHERE contradiction_id IN ({found_placeholders})
+                SELECT contradiction_id
+                FROM contradictions
+                WHERE contradiction_id IN ({placeholders})
+                ORDER BY contradiction_id
                 """,
-                (status, note, now_value, *found_ids),
-            )
-            conn.commit()
+                tuple(resolved_ids),
+            ).fetchall()
+            found_ids = [row[0] for row in existing]
+            if found_ids:
+                now_value = conn.execute("SELECT strftime('%Y-%m-%dT%H:%M:%SZ', 'now')").fetchone()[0]
+                found_placeholders = ",".join("?" for _ in found_ids)
+                conn.execute(
+                    f"""
+                    UPDATE contradictions
+                    SET status = ?, resolution_note = ?, resolved_at = ?
+                    WHERE contradiction_id IN ({found_placeholders})
+                    """,
+                    (status, note, now_value, *found_ids),
+                )
+                conn.commit()
 
     return {
         "resolved_count": len(found_ids),
@@ -768,79 +770,80 @@ def contradiction_object_ids(vault_dir: Path, contradiction_ids: list[str]) -> l
 
 def rebuild_compiled_summaries(vault_dir: Path, object_ids: list[str] | None = None) -> dict[str, object]:
     _, layout = _ensure_knowledge_db(vault_dir)
-    with sqlite3.connect(layout.knowledge_db) as conn:
-        if object_ids:
-            placeholders = ",".join("?" for _ in object_ids)
-            object_rows = conn.execute(
-                f"""
-                SELECT objects.object_id, objects.title,
-                       COALESCE(rel.outgoing_count, 0) AS outgoing_count
-                FROM objects
-                LEFT JOIN (
-                    SELECT source_object_id, COUNT(*) AS outgoing_count
+    with knowledge_db_write_lock(vault_dir):
+        with sqlite3.connect(layout.knowledge_db) as conn:
+            if object_ids:
+                placeholders = ",".join("?" for _ in object_ids)
+                object_rows = conn.execute(
+                    f"""
+                    SELECT objects.object_id, objects.title,
+                           COALESCE(rel.outgoing_count, 0) AS outgoing_count
+                    FROM objects
+                    LEFT JOIN (
+                        SELECT source_object_id, COUNT(*) AS outgoing_count
+                        FROM relations
+                        GROUP BY source_object_id
+                    ) AS rel ON rel.source_object_id = objects.object_id
+                    WHERE objects.object_id IN ({placeholders})
+                    ORDER BY objects.object_id
+                    """,
+                    tuple(object_ids),
+                ).fetchall()
+            else:
+                object_rows = conn.execute(
+                    """
+                    SELECT objects.object_id, objects.title,
+                           COALESCE(rel.outgoing_count, 0) AS outgoing_count
+                    FROM objects
+                    LEFT JOIN (
+                        SELECT source_object_id, COUNT(*) AS outgoing_count
+                        FROM relations
+                        GROUP BY source_object_id
+                    ) AS rel ON rel.source_object_id = objects.object_id
+                    ORDER BY objects.object_id
+                    """
+                ).fetchall()
+
+            rebuilt_ids: list[str] = []
+            for object_id, title, _outgoing_count in object_rows:
+                claim_rows = conn.execute(
+                    """
+                    SELECT claim_text
+                    FROM claims
+                    WHERE object_id = ? AND claim_kind = 'page_summary'
+                    ORDER BY claim_id
+                    """,
+                    (object_id,),
+                ).fetchall()
+                base_summary = str(claim_rows[0][0]) if claim_rows else str(title)
+                related_rows = conn.execute(
+                    """
+                    SELECT target_object_id
                     FROM relations
-                    GROUP BY source_object_id
-                ) AS rel ON rel.source_object_id = objects.object_id
-                WHERE objects.object_id IN ({placeholders})
-                ORDER BY objects.object_id
-                """,
-                tuple(object_ids),
-            ).fetchall()
-        else:
-            object_rows = conn.execute(
-                """
-                SELECT objects.object_id, objects.title,
-                       COALESCE(rel.outgoing_count, 0) AS outgoing_count
-                FROM objects
-                LEFT JOIN (
-                    SELECT source_object_id, COUNT(*) AS outgoing_count
-                    FROM relations
-                    GROUP BY source_object_id
-                ) AS rel ON rel.source_object_id = objects.object_id
-                ORDER BY objects.object_id
-                """
-            ).fetchall()
+                    WHERE source_object_id = ?
+                    ORDER BY target_object_id
+                    LIMIT ?
+                    """,
+                    (object_id, SUMMARY_RELATED_LIMIT),
+                ).fetchall()
+                related_ids = [row[0] for row in related_rows]
+                summary = base_summary
+                if related_ids:
+                    summary = f"{base_summary} Related: {', '.join(related_ids)}."
+                if len(summary) > SUMMARY_MAX_LEN:
+                    summary = summary[: SUMMARY_MAX_LEN - 3].rstrip() + "..."
 
-        rebuilt_ids: list[str] = []
-        for object_id, title, _outgoing_count in object_rows:
-            claim_rows = conn.execute(
-                """
-                SELECT claim_text
-                FROM claims
-                WHERE object_id = ? AND claim_kind = 'page_summary'
-                ORDER BY claim_id
-                """,
-                (object_id,),
-            ).fetchall()
-            base_summary = str(claim_rows[0][0]) if claim_rows else str(title)
-            related_rows = conn.execute(
-                """
-                SELECT target_object_id
-                FROM relations
-                WHERE source_object_id = ?
-                ORDER BY target_object_id
-                LIMIT ?
-                """,
-                (object_id, SUMMARY_RELATED_LIMIT),
-            ).fetchall()
-            related_ids = [row[0] for row in related_rows]
-            summary = base_summary
-            if related_ids:
-                summary = f"{base_summary} Related: {', '.join(related_ids)}."
-            if len(summary) > SUMMARY_MAX_LEN:
-                summary = summary[: SUMMARY_MAX_LEN - 3].rstrip() + "..."
+                conn.execute(
+                    """
+                    INSERT INTO compiled_summaries (object_id, summary_text, source_slug)
+                    VALUES (?, ?, ?)
+                    ON CONFLICT(object_id) DO UPDATE SET summary_text = excluded.summary_text, source_slug = excluded.source_slug
+                    """,
+                    (object_id, summary, object_id),
+                )
+                rebuilt_ids.append(str(object_id))
 
-            conn.execute(
-                """
-                INSERT INTO compiled_summaries (object_id, summary_text, source_slug)
-                VALUES (?, ?, ?)
-                ON CONFLICT(object_id) DO UPDATE SET summary_text = excluded.summary_text, source_slug = excluded.source_slug
-                """,
-                (object_id, summary, object_id),
-            )
-            rebuilt_ids.append(str(object_id))
-
-        conn.commit()
+            conn.commit()
 
     return {
         "objects_rebuilt": len(rebuilt_ids),

--- a/src/openclaw_pipeline/materializers/contradiction_view.py
+++ b/src/openclaw_pipeline/materializers/contradiction_view.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import sqlite3
 from pathlib import Path
 
 from ..derived.paths import compiled_view_path
+from ..knowledge_index import list_contradictions
 from ..runtime import VaultLayout, resolve_vault_dir
 
 
@@ -13,19 +13,7 @@ def materialize_contradiction_view(vault_dir: Path, *, pack_name: str, view_name
     output_path = compiled_view_path(layout, pack_name=pack_name, view_name=view_name)
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    with sqlite3.connect(layout.knowledge_db) as conn:
-        try:
-            rows = conn.execute(
-                """
-                SELECT contradiction_id, subject_key, status, resolution_note, resolved_at
-                FROM contradictions
-                ORDER BY subject_key
-                """
-            ).fetchall()
-        except sqlite3.OperationalError as exc:
-            if "no such table: contradictions" not in str(exc):
-                raise
-            rows = []
+    rows = list_contradictions(resolved_vault, limit=500)
 
     lines = [
         f"# {view_name}",
@@ -40,15 +28,15 @@ def materialize_contradiction_view(vault_dir: Path, *, pack_name: str, view_name
     if not rows:
         lines.append("- (none)")
     else:
-        for contradiction_id, subject_key, status, resolution_note, resolved_at in rows:
+        for row in rows:
             lines.extend(
                 [
-                    f"### {subject_key}",
+                    f"### {row['subject_key']}",
                     "",
-                    f"- contradiction_id: {contradiction_id}",
-                    f"- status: {status}",
-                    f"- resolved_at: {resolved_at or '(open)'}",
-                    f"- resolution_note: {resolution_note or '(none)'}",
+                    f"- contradiction_id: {row['contradiction_id']}",
+                    f"- status: {row['status']}",
+                    f"- resolved_at: {row['resolved_at'] or '(open)'}",
+                    f"- resolution_note: {row['resolution_note'] or '(none)'}",
                     "",
                 ]
             )

--- a/src/openclaw_pipeline/materializers/object_page.py
+++ b/src/openclaw_pipeline/materializers/object_page.py
@@ -1,13 +1,9 @@
 from __future__ import annotations
 
-import sqlite3
 from pathlib import Path
 
 from ..runtime import VaultLayout, resolve_vault_dir
-
-
-def _escape_like(value: str) -> str:
-    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+from ..truth_api import get_object_detail
 
 
 def materialize_object_page(vault_dir: Path, *, pack_name: str, object_id: str) -> Path:
@@ -15,54 +11,13 @@ def materialize_object_page(vault_dir: Path, *, pack_name: str, object_id: str) 
     layout = VaultLayout.from_vault(resolved_vault)
     output_path = layout.compiled_views_dir / pack_name / "objects" / f"{object_id}.md"
     output_path.parent.mkdir(parents=True, exist_ok=True)
-
-    escaped_object_id = _escape_like(object_id)
-    with sqlite3.connect(layout.knowledge_db) as conn:
-        object_row = conn.execute(
-            """
-            SELECT object_id, object_kind, title, canonical_path, source_slug
-            FROM objects
-            WHERE object_id = ?
-            """,
-            (object_id,),
-        ).fetchone()
-        if object_row is None:
-            raise ValueError(f"Unknown object_id: {object_id}")
-
-        summary_row = conn.execute(
-            "SELECT summary_text FROM compiled_summaries WHERE object_id = ?",
-            (object_id,),
-        ).fetchone()
-        claim_rows = conn.execute(
-            """
-            SELECT claim_kind, claim_text
-            FROM claims
-            WHERE object_id = ?
-            ORDER BY claim_id
-            """,
-            (object_id,),
-        ).fetchall()
-        relation_rows = conn.execute(
-            """
-            SELECT target_object_id, relation_type
-            FROM relations
-            WHERE source_object_id = ?
-            ORDER BY target_object_id
-            """,
-            (object_id,),
-        ).fetchall()
-        contradiction_rows = conn.execute(
-            """
-            SELECT contradiction_id, subject_key, status, resolution_note
-            FROM contradictions
-            WHERE positive_claim_ids_json LIKE ? ESCAPE '\\' OR negative_claim_ids_json LIKE ? ESCAPE '\\'
-            ORDER BY subject_key
-            """,
-            (f"%{escaped_object_id}::%", f"%{escaped_object_id}::%"),
-        ).fetchall()
-
-    _object_id, object_kind, title, canonical_path, source_slug = object_row
-    summary_text = summary_row[0] if summary_row else ""
+    detail = get_object_detail(resolved_vault, object_id)
+    object_row = detail["object"]
+    object_kind = object_row["object_kind"]
+    title = object_row["title"]
+    canonical_path = object_row["canonical_path"]
+    source_slug = object_row["source_slug"]
+    summary_text = detail.get("summary", {}).get("summary_text", "")
 
     lines = [
         f"# {title}",
@@ -79,8 +34,8 @@ def materialize_object_page(vault_dir: Path, *, pack_name: str, object_id: str) 
         "## Claims",
         "",
     ]
-    if claim_rows:
-        lines.extend(f"- [{claim_kind}] {claim_text}" for claim_kind, claim_text in claim_rows)
+    if detail["claims"]:
+        lines.extend(f"- [{item['claim_kind']}] {item['claim_text']}" for item in detail["claims"])
     else:
         lines.append("- (none)")
 
@@ -91,8 +46,10 @@ def materialize_object_page(vault_dir: Path, *, pack_name: str, object_id: str) 
             "",
         ]
     )
-    if relation_rows:
-        lines.extend(f"- [[{target_object_id}]] ({relation_type})" for target_object_id, relation_type in relation_rows)
+    if detail["relations"]:
+        lines.extend(
+            f"- [[{item['target_object_id']}]] ({item['relation_type']})" for item in detail["relations"]
+        )
     else:
         lines.append("- (none)")
 
@@ -103,11 +60,11 @@ def materialize_object_page(vault_dir: Path, *, pack_name: str, object_id: str) 
             "",
         ]
     )
-    if contradiction_rows:
-        for contradiction_id, subject_key, status, resolution_note in contradiction_rows:
-            lines.append(f"- {subject_key} [{status}] ({contradiction_id})")
-            if resolution_note:
-                lines.append(f"  - note: {resolution_note}")
+    if detail["contradictions"]:
+        for item in detail["contradictions"]:
+            lines.append(f"- {item['subject_key']} [{item['status']}] ({item['contradiction_id']})")
+            if item["resolution_note"]:
+                lines.append(f"  - note: {item['resolution_note']}")
     else:
         lines.append("- (none)")
 

--- a/src/openclaw_pipeline/runtime.py
+++ b/src/openclaw_pipeline/runtime.py
@@ -74,6 +74,10 @@ class VaultLayout:
         return self.logs_dir / "knowledge.db.lock"
 
     @property
+    def action_worker_lock(self) -> Path:
+        return self.logs_dir / "action-worker.lock"
+
+    @property
     def transactions_dir(self) -> Path:
         return self.logs_dir / "transactions"
 

--- a/src/openclaw_pipeline/runtime.py
+++ b/src/openclaw_pipeline/runtime.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
+from contextlib import contextmanager
+import fcntl
+import time
 from typing import Iterator
 
 import yaml
@@ -65,6 +68,10 @@ class VaultLayout:
     @property
     def knowledge_db(self) -> Path:
         return self.logs_dir / "knowledge.db"
+
+    @property
+    def knowledge_db_lock(self) -> Path:
+        return self.logs_dir / "knowledge.db.lock"
 
     @property
     def transactions_dir(self) -> Path:
@@ -159,3 +166,38 @@ class VaultLayout:
         }
         area = mapping.get(classification, "AI-Research")
         return self.month_topics_dir(area, when=when)
+
+
+@contextmanager
+def advisory_file_lock(
+    path: Path,
+    *,
+    timeout_seconds: float | None = 300.0,
+    poll_interval_seconds: float = 0.1,
+) -> Iterator[None]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    deadline = None if timeout_seconds is None else time.monotonic() + timeout_seconds
+    with path.open("a+", encoding="utf-8") as handle:
+        while True:
+            try:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except BlockingIOError:
+                if deadline is not None and time.monotonic() >= deadline:
+                    raise TimeoutError(f"Timed out waiting for lock: {path}")
+                time.sleep(poll_interval_seconds)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+@contextmanager
+def knowledge_db_write_lock(
+    vault_dir: Path | str | None = None,
+    *,
+    timeout_seconds: float | None = 300.0,
+) -> Iterator[None]:
+    layout = VaultLayout.from_vault(vault_dir)
+    with advisory_file_lock(layout.knowledge_db_lock, timeout_seconds=timeout_seconds):
+        yield

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -1401,12 +1401,46 @@ def _replace_action_queue_item(vault_dir: Path | str, action: dict[str, Any]) ->
     return action
 
 
+def _action_by_id(vault_dir: Path | str, action_id: str) -> dict[str, Any] | None:
+    for item in _read_action_queue_rows(vault_dir):
+        if item.get("action_id") == action_id:
+            return dict(item)
+    return None
+
+
 def _next_queued_action(vault_dir: Path | str) -> dict[str, Any] | None:
     queued = [item for item in _read_action_queue_rows(vault_dir) if item.get("status") == "queued"]
     if not queued:
         return None
     queued.sort(key=lambda item: (str(item.get("created_at", "")), str(item.get("action_id", ""))))
     return dict(queued[0])
+
+
+def retry_action_queue_item(vault_dir: Path | str, *, action_id: str) -> dict[str, Any]:
+    action = _action_by_id(vault_dir, action_id)
+    if action is None:
+        raise ValueError("unknown action_id")
+    if str(action.get("status") or "") not in {"failed", "obsolete"}:
+        raise ValueError("action is not retryable")
+    action["status"] = "queued"
+    action["started_at"] = ""
+    action["finished_at"] = ""
+    action["error"] = ""
+    action["result"] = {}
+    _replace_action_queue_item(vault_dir, action)
+    return {"retried": True, "action": action}
+
+
+def dismiss_action_queue_item(vault_dir: Path | str, *, action_id: str) -> dict[str, Any]:
+    action = _action_by_id(vault_dir, action_id)
+    if action is None:
+        raise ValueError("unknown action_id")
+    if str(action.get("status") or "") in {"succeeded", "dismissed"}:
+        raise ValueError("action is not dismissible")
+    action["status"] = "dismissed"
+    action["finished_at"] = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    _replace_action_queue_item(vault_dir, action)
+    return {"dismissed": True, "action": action}
 
 
 def _run_deep_dive_workflow_action(vault_dir: Path | str, action: dict[str, Any]) -> dict[str, Any]:
@@ -1499,6 +1533,24 @@ def run_next_action_queue_item(vault_dir: Path | str) -> dict[str, Any]:
         action["finished_at"] = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
         _replace_action_queue_item(vault_dir, action)
         return {"ran": False, "reason": "execution_failed", "action": action}
+
+
+def run_action_queue(vault_dir: Path | str, *, limit: int = 5) -> dict[str, Any]:
+    limit = max(1, min(int(limit), MAX_PAGE_SIZE))
+    results: list[dict[str, Any]] = []
+    stopped_reason = "limit_reached"
+    for _ in range(limit):
+        payload = run_next_action_queue_item(vault_dir)
+        results.append(payload)
+        if not payload.get("ran"):
+            stopped_reason = str(payload.get("reason") or "stopped")
+            break
+    return {
+        "limit": limit,
+        "ran_count": sum(1 for item in results if item.get("ran")),
+        "stopped_reason": stopped_reason,
+        "results": results,
+    }
 
 
 def _action_queue_state_map(vault_dir: Path | str) -> dict[str, dict[str, Any]]:

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -50,11 +50,43 @@ EVOLUTION_LINK_EXPLANATIONS = {
     "confirms": "Independent evidence is reinforcing the current interpretation.",
     "enriches": "Newer material is adding depth without overturning the core idea.",
 }
+_BRIEFING_SIGNAL_PRIORITY = {
+    "contradiction_open": 100,
+    "stale_summary": 90,
+    "production_gap": 80,
+    "source_needs_deep_dive": 70,
+    "deep_dive_needs_objects": 60,
+    "contradiction_reviewed": 40,
+    "summary_rebuilt": 30,
+}
+_BRIEFING_EVOLUTION_PRIORITY = {
+    "challenges": 100,
+    "replaces": 90,
+    "confirms": 70,
+    "enriches": 60,
+}
 
 
 def _db_path(vault_dir: Path | str) -> Path:
     resolved = resolve_vault_dir(vault_dir)
     return VaultLayout.from_vault(resolved).knowledge_db
+
+
+def _briefing_priority_score(item: dict[str, Any]) -> tuple[int, int, int]:
+    signal_type = str(item.get("signal_type") or item.get("kind") or "")
+    recommended_action = item.get("recommended_action")
+    executable = 0
+    if isinstance(recommended_action, dict) and recommended_action.get("executable"):
+        executable = 1
+    object_count = len([value for value in item.get("object_ids", []) if value])
+    return (_BRIEFING_SIGNAL_PRIORITY.get(signal_type, 0), executable, object_count)
+
+
+def _briefing_evolution_score(item: dict[str, Any]) -> tuple[int, int]:
+    return (
+        _BRIEFING_EVOLUTION_PRIORITY.get(str(item.get("link_type") or ""), 0),
+        len([value for value in item.get("object_ids", []) if value]),
+    )
 
 
 def _path_signature(path: Path) -> tuple[str, int, int]:
@@ -1984,7 +2016,16 @@ def get_briefing_snapshot(vault_dir: Path | str, *, limit: int = 8) -> dict[str,
         "source_needs_deep_dive",
         "deep_dive_needs_objects",
     }
-    unresolved_issues = [item for item in recent_signals if item["signal_type"] in unresolved_signal_types][:limit]
+    unresolved_issues = [item for item in recent_signals if item["signal_type"] in unresolved_signal_types]
+    unresolved_issues.sort(
+        key=lambda item: (
+            _briefing_priority_score(item),
+            str(item.get("title") or "").lower(),
+            str(item.get("signal_id") or ""),
+        ),
+        reverse=True,
+    )
+    unresolved_issues = unresolved_issues[:limit]
     changed_signals = [
         item
         for item in recent_signals
@@ -2033,7 +2074,7 @@ def get_briefing_snapshot(vault_dir: Path | str, *, limit: int = 8) -> dict[str,
         )
     )
     evolution_rows = _batch_object_rows(vault_dir, evolution_object_ids)
-    insights: list[dict[str, Any]] = []
+    merged_insights: dict[tuple[str, str, str], dict[str, Any]] = {}
     for item in evolution_candidates:
         primary_object_id = next((object_id for object_id in item.get("object_ids", []) if object_id), "")
         primary_title = (
@@ -2041,33 +2082,50 @@ def get_briefing_snapshot(vault_dir: Path | str, *, limit: int = 8) -> dict[str,
             or object_rows.get(primary_object_id, {}).get("title")
             or str(item.get("subject_id") or primary_object_id)
         )
-        insights.append(
-            {
-                "kind": f"evolution_{item['link_type']}",
-                "link_type": item["link_type"],
-                "title": str(primary_title),
-                "detail": EVOLUTION_LINK_EXPLANATIONS.get(
-                    item["link_type"], "Knowledge evolution was detected."
-                ),
-                "path": "/evolution?link_type="
-                + quote(str(item["link_type"]), safe="")
-                + "&q="
-                + quote(str(primary_title), safe=""),
-                "source_paths": [path for path in item.get("source_paths", []) if path][:3],
-                "object_ids": list(item.get("object_ids", [])),
-                "recommended_action": _recommended_action(
-                    kind="review_evolution",
-                    label="Review evolution",
-                    path="/evolution?link_type="
-                    + quote(str(item["link_type"]), safe="")
-                    + "&q="
-                    + quote(str(primary_title), safe=""),
-                    executable=True,
-                ),
-            }
+        path = (
+            "/evolution?link_type="
+            + quote(str(item["link_type"]), safe="")
+            + "&q="
+            + quote(str(primary_title), safe="")
         )
-        if len(insights) >= limit:
-            break
+        insight = {
+            "kind": f"evolution_{item['link_type']}",
+            "link_type": item["link_type"],
+            "title": str(primary_title),
+            "detail": EVOLUTION_LINK_EXPLANATIONS.get(
+                item["link_type"], "Knowledge evolution was detected."
+            ),
+            "path": path,
+            "source_paths": [path for path in item.get("source_paths", []) if path][:3],
+            "object_ids": list(item.get("object_ids", [])),
+            "recommended_action": _recommended_action(
+                kind="review_evolution",
+                label="Review evolution",
+                path=path,
+                executable=True,
+            ),
+        }
+        key = (str(insight["kind"]), str(insight["title"]), str(insight["path"]))
+        existing = merged_insights.get(key)
+        if existing is None:
+            merged_insights[key] = insight
+        else:
+            existing["source_paths"] = list(
+                dict.fromkeys([*existing.get("source_paths", []), *insight.get("source_paths", [])])
+            )[:3]
+            existing["object_ids"] = list(
+                dict.fromkeys([*existing.get("object_ids", []), *insight.get("object_ids", [])])
+            )
+    insights = list(merged_insights.values())
+    insights.sort(
+        key=lambda item: (
+            _briefing_evolution_score(item),
+            str(item.get("title") or "").lower(),
+            str(item.get("path") or ""),
+        ),
+        reverse=True,
+    )
+    insights = insights[:limit]
 
     priority_items: list[dict[str, Any]] = []
     for item in unresolved_issues:

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -40,6 +40,10 @@ SIGNAL_TYPE_EXPLANATIONS = {
     "source_needs_deep_dive": "A processed source note exists without any derived deep dive, so the next extraction step is still missing.",
     "deep_dive_needs_objects": "A deep dive exists without any derived evergreen objects, so absorb-style extraction has not completed yet.",
 }
+AUTO_QUEUE_SIGNAL_TYPES = {
+    "source_needs_deep_dive",
+    "deep_dive_needs_objects",
+}
 EVOLUTION_LINK_EXPLANATIONS = {
     "challenges": "Newer evidence is challenging the current interpretation.",
     "replaces": "A newer interpretation appears to supersede the older one.",
@@ -1278,6 +1282,31 @@ def enqueue_signal_action(
     signal = _signal_by_id(vault_dir, signal_id)
     if signal is None:
         raise ValueError("unknown signal_id")
+    existing_actions = _read_action_queue_rows(vault_dir)
+    created, action = _enqueue_action_from_signal(
+        signal,
+        existing_actions=existing_actions,
+        session_id=session_id,
+    )
+    if created:
+        existing_actions.append(action)
+        existing_actions.sort(
+            key=lambda item: (str(item.get("created_at", "")), str(item.get("action_id", ""))),
+            reverse=True,
+        )
+        _write_action_queue_rows(vault_dir, existing_actions)
+    return {"created": created, "action": action}
+
+
+def _enqueue_action_from_signal(
+    signal: dict[str, Any],
+    *,
+    existing_actions: list[dict[str, Any]],
+    session_id: str,
+) -> tuple[bool, dict[str, Any]]:
+    signal_id = str(signal.get("signal_id") or "")
+    if not signal_id:
+        raise ValueError("signal is missing signal_id")
     recommended_action = signal.get("recommended_action")
     if not isinstance(recommended_action, dict) or not recommended_action.get("kind"):
         raise ValueError("signal has no recommended action")
@@ -1293,10 +1322,9 @@ def enqueue_signal_action(
         "object_ids": list(signal.get("object_ids", [])),
     }
     action_id = _action_id(signal_id, str(recommended_action["kind"]), target_ref, payload)
-    existing_actions = _read_action_queue_rows(vault_dir)
     existing = next((item for item in existing_actions if item.get("action_id") == action_id), None)
     if existing is not None:
-        return {"created": False, "action": existing}
+        return False, existing
     timestamp = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
     action = {
         "action_id": action_id,
@@ -1314,10 +1342,43 @@ def enqueue_signal_action(
         "payload": payload,
         "session_id": session_id,
     }
-    existing_actions.append(action)
-    existing_actions.sort(key=lambda item: (str(item.get("created_at", "")), str(item.get("action_id", ""))), reverse=True)
-    _write_action_queue_rows(vault_dir, existing_actions)
-    return {"created": True, "action": action}
+    return True, action
+
+
+def _backfill_auto_queue_actions(
+    vault_dir: Path | str,
+    *,
+    signals: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    active_signals = signals if signals is not None else list_signals(vault_dir, limit=MAX_PAGE_SIZE)
+    candidates = [
+        item
+        for item in active_signals
+        if str(item.get("signal_type") or "") in AUTO_QUEUE_SIGNAL_TYPES
+    ]
+    if not candidates:
+        return {"created_count": 0, "created_action_ids": []}
+    existing_actions = _read_action_queue_rows(vault_dir)
+    created_actions: list[dict[str, Any]] = []
+    for item in candidates:
+        created, action = _enqueue_action_from_signal(
+            item,
+            existing_actions=existing_actions,
+            session_id="action-backfill",
+        )
+        if created:
+            existing_actions.append(action)
+            created_actions.append(action)
+    if created_actions:
+        existing_actions.sort(
+            key=lambda item: (str(item.get("created_at", "")), str(item.get("action_id", ""))),
+            reverse=True,
+        )
+        _write_action_queue_rows(vault_dir, existing_actions)
+    return {
+        "created_count": len(created_actions),
+        "created_action_ids": [item["action_id"] for item in created_actions],
+    }
 
 
 def _action_queue_state_map(vault_dir: Path | str) -> dict[str, dict[str, Any]]:
@@ -1677,6 +1738,8 @@ def sync_signal_ledger(vault_dir: Path | str) -> dict[str, Any]:
         "signal_count": len(signals),
         "type_counts": dict(type_counts),
     }
+    backfill = _backfill_auto_queue_actions(resolved_vault, signals=signals)
+    result["auto_queued_action_count"] = backfill["created_count"]
     cache_key = (str(resolved_vault.resolve()), _signal_dependency_signature(resolved_vault))
     _SIGNAL_LEDGER_SYNC_CACHE.clear()
     _SIGNAL_LEDGER_SYNC_CACHE[cache_key] = result

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -2619,7 +2619,7 @@ def list_contradictions(
     limit, _ = _validate_page_args(limit=limit, offset=0)
     db_path = _db_path(vault_dir)
     normalized_query = _escape_like(query.strip().lower()) if query else ""
-    query = """
+    sql = """
         SELECT contradiction_id, subject_key, positive_claim_ids_json, negative_claim_ids_json, status, resolution_note, resolved_at
         FROM contradictions
     """
@@ -2629,13 +2629,15 @@ def list_contradictions(
         where_clauses.append("lower(subject_key) LIKE ? ESCAPE '\\'")
         params.append(f"%{normalized_query}%")
     if where_clauses:
-        query += " WHERE " + " AND ".join(where_clauses)
-    query += " ORDER BY subject_key LIMIT ?"
-    params.append(limit)
+        sql += " WHERE " + " AND ".join(where_clauses)
+    sql += " ORDER BY subject_key"
+    if status is None:
+        sql += " LIMIT ?"
+        params.append(limit)
 
     try:
         with sqlite3.connect(db_path) as conn:
-            rows = conn.execute(query, tuple(params)).fetchall()
+            rows = conn.execute(sql, tuple(params)).fetchall()
     except sqlite3.OperationalError as exc:
         if "no such table" in str(exc).lower():
             return []
@@ -2666,6 +2668,7 @@ def list_contradictions(
             items = [item for item in items if item["status"] != "open"]
         else:
             items = [item for item in items if item["status"] == status]
+    items = items[:limit]
     claim_map = _claim_details_map(
         vault_dir,
         [

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -1251,6 +1251,33 @@ def _recommended_action(*, kind: str, label: str, path: str, executable: bool) -
     }
 
 
+SAFE_AUTO_RUN_ACTION_KINDS = {
+    "deep_dive_workflow",
+    "object_extraction_workflow",
+}
+
+
+def _is_safe_action_kind(action_kind: str) -> bool:
+    return action_kind in SAFE_AUTO_RUN_ACTION_KINDS
+
+
+def _classify_action_error(error: str) -> str:
+    normalized = (error or "").strip().lower()
+    if not normalized:
+        return ""
+    if normalized.startswith("unsupported_action_kind:"):
+        return "unsupported_action_kind"
+    if "not found" in normalized or "missing" in normalized:
+        return "missing_target"
+    if "timed out" in normalized or "timeout" in normalized:
+        return "timeout"
+    if "integrity" in normalized or "database" in normalized or "sqlite" in normalized:
+        return "storage_error"
+    if "refresh" in normalized or "knowledge_index" in normalized:
+        return "refresh_failed"
+    return "workflow_failed"
+
+
 def _read_action_queue_rows(vault_dir: Path | str) -> list[dict[str, Any]]:
     resolved_vault = resolve_vault_dir(vault_dir)
     layout = VaultLayout.from_vault(resolved_vault)
@@ -1367,6 +1394,9 @@ def _enqueue_action_from_signal(
         "started_at": "",
         "finished_at": "",
         "error": "",
+        "failure_bucket": "",
+        "retry_count": 0,
+        "safe_to_run": _is_safe_action_kind(str(recommended_action["kind"])),
         "payload": payload,
         "session_id": session_id,
     }
@@ -1442,6 +1472,18 @@ def _next_queued_action(vault_dir: Path | str) -> dict[str, Any] | None:
     return dict(queued[0])
 
 
+def _next_safe_queued_action(vault_dir: Path | str) -> dict[str, Any] | None:
+    queued = [
+        item
+        for item in _read_action_queue_rows(vault_dir)
+        if item.get("status") == "queued" and bool(item.get("safe_to_run"))
+    ]
+    if not queued:
+        return None
+    queued.sort(key=lambda item: (str(item.get("created_at", "")), str(item.get("action_id", ""))))
+    return dict(queued[0])
+
+
 def retry_action_queue_item(vault_dir: Path | str, *, action_id: str) -> dict[str, Any]:
     action = _action_by_id(vault_dir, action_id)
     if action is None:
@@ -1452,6 +1494,7 @@ def retry_action_queue_item(vault_dir: Path | str, *, action_id: str) -> dict[st
     action["started_at"] = ""
     action["finished_at"] = ""
     action["error"] = ""
+    action["failure_bucket"] = ""
     action["result"] = {}
     _replace_action_queue_item(vault_dir, action)
     return {"retried": True, "action": action}
@@ -1516,22 +1559,24 @@ def _refresh_truth_after_action(vault_dir: Path | str) -> None:
     sync_signal_ledger(vault_dir)
 
 
-def run_next_action_queue_item(vault_dir: Path | str) -> dict[str, Any]:
-    action = _next_queued_action(vault_dir)
+def run_next_action_queue_item(vault_dir: Path | str, *, safe_only: bool = False) -> dict[str, Any]:
+    action = _next_safe_queued_action(vault_dir) if safe_only else _next_queued_action(vault_dir)
     if action is None:
-        return {"ran": False, "reason": "no_queued_actions"}
+        return {"ran": False, "reason": "no_queued_actions", "safe_only": safe_only}
 
     started_at = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
     action["status"] = "running"
     action["started_at"] = started_at
     action["error"] = ""
+    action["failure_bucket"] = ""
     _replace_action_queue_item(vault_dir, action)
 
     if _signal_by_id(vault_dir, str(action.get("source_signal_id") or "")) is None:
         action["status"] = "obsolete"
         action["finished_at"] = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+        action["failure_bucket"] = "obsolete_signal"
         _replace_action_queue_item(vault_dir, action)
-        return {"ran": False, "reason": "obsolete_signal", "action": action}
+        return {"ran": False, "reason": "obsolete_signal", "action": action, "safe_only": safe_only}
 
     handlers = {
         "deep_dive_workflow": _run_deep_dive_workflow_action,
@@ -1541,9 +1586,11 @@ def run_next_action_queue_item(vault_dir: Path | str) -> dict[str, Any]:
     if handler is None:
         action["status"] = "failed"
         action["error"] = f"unsupported_action_kind:{action.get('action_kind')}"
+        action["failure_bucket"] = "unsupported_action_kind"
+        action["retry_count"] = int(action.get("retry_count") or 0) + 1
         action["finished_at"] = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
         _replace_action_queue_item(vault_dir, action)
-        return {"ran": False, "reason": "unsupported_action_kind", "action": action}
+        return {"ran": False, "reason": "unsupported_action_kind", "action": action, "safe_only": safe_only}
 
     try:
         result = handler(vault_dir, action)
@@ -1552,27 +1599,30 @@ def run_next_action_queue_item(vault_dir: Path | str) -> dict[str, Any]:
         action["finished_at"] = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
         action["result"] = result
         _replace_action_queue_item(vault_dir, action)
-        return {"ran": True, "action": action}
+        return {"ran": True, "action": action, "safe_only": safe_only}
     except Exception as exc:
         action["status"] = "failed"
         action["error"] = str(exc)
+        action["failure_bucket"] = _classify_action_error(str(exc))
+        action["retry_count"] = int(action.get("retry_count") or 0) + 1
         action["finished_at"] = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
         _replace_action_queue_item(vault_dir, action)
-        return {"ran": False, "reason": "execution_failed", "action": action}
+        return {"ran": False, "reason": "execution_failed", "action": action, "safe_only": safe_only}
 
 
-def run_action_queue(vault_dir: Path | str, *, limit: int = 5) -> dict[str, Any]:
+def run_action_queue(vault_dir: Path | str, *, limit: int = 5, safe_only: bool = False) -> dict[str, Any]:
     limit = max(1, min(int(limit), MAX_PAGE_SIZE))
     results: list[dict[str, Any]] = []
     stopped_reason = "limit_reached"
     for _ in range(limit):
-        payload = run_next_action_queue_item(vault_dir)
+        payload = run_next_action_queue_item(vault_dir, safe_only=safe_only)
         results.append(payload)
         if not payload.get("ran"):
             stopped_reason = str(payload.get("reason") or "stopped")
             break
     return {
         "limit": limit,
+        "safe_only": safe_only,
         "ran_count": sum(1 for item in results if item.get("ran")),
         "stopped_reason": stopped_reason,
         "results": results,
@@ -1601,6 +1651,7 @@ def _attach_action_queue_state(vault_dir: Path | str, items: list[dict[str, Any]
                 recommended["queue_status"] = action.get("status", "")
                 recommended["action_id"] = action.get("action_id", "")
                 recommended["queue_path"] = "/actions"
+                recommended["safe_to_run"] = bool(action.get("safe_to_run"))
             enriched["recommended_action"] = recommended
         annotated.append(enriched)
     return annotated
@@ -2113,6 +2164,22 @@ def get_briefing_snapshot(vault_dir: Path | str, *, limit: int = 8) -> dict[str,
         if len(priority_items) >= limit:
             break
     first_useful_sign = insights[0] if insights else (priority_items[0] if priority_items else None)
+    action_items = list_action_queue(vault_dir, limit=MAX_PAGE_SIZE)
+    queue_summary = {
+        "queued_count": sum(1 for item in action_items if item.get("status") == "queued"),
+        "safe_queued_count": sum(
+            1 for item in action_items if item.get("status") == "queued" and bool(item.get("safe_to_run"))
+        ),
+        "running_count": sum(1 for item in action_items if item.get("status") == "running"),
+        "failed_count": sum(1 for item in action_items if item.get("status") == "failed"),
+        "failure_buckets": dict(
+            Counter(
+                str(item.get("failure_bucket") or "")
+                for item in action_items
+                if item.get("status") == "failed" and str(item.get("failure_bucket") or "")
+            )
+        ),
+    }
 
     return {
         "generated_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -2129,6 +2196,7 @@ def get_briefing_snapshot(vault_dir: Path | str, *, limit: int = 8) -> dict[str,
         "insights": insights,
         "priority_items": priority_items,
         "first_useful_sign": first_useful_sign,
+        "queue_summary": queue_summary,
     }
 
 

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -1147,6 +1147,15 @@ def _signal_id(signal_type: str, key: str) -> str:
     return f"{signal_type}::{hashlib.sha1(key.encode('utf-8')).hexdigest()[:12]}"
 
 
+def _recommended_action(*, kind: str, label: str, path: str, executable: bool) -> dict[str, Any]:
+    return {
+        "kind": kind,
+        "label": label,
+        "path": path,
+        "executable": executable,
+    }
+
+
 def list_production_gaps(
     vault_dir: Path | str,
     *,
@@ -1228,6 +1237,12 @@ def _compute_signal_entries(vault_dir: Path | str) -> list[dict[str, Any]]:
                         for claim in item["positive_claims"][:1] + item["negative_claims"][:1]
                     ],
                 ],
+                "recommended_action": _recommended_action(
+                    kind="review_contradiction",
+                    label="Review contradiction",
+                    path=f"/contradictions?q={quote(item['subject_key'], safe='')}",
+                    executable=True,
+                ),
                 "payload": {
                     "contradiction_id": item["contradiction_id"],
                     "scope_summary": item["scope_summary"],
@@ -1254,6 +1269,12 @@ def _compute_signal_entries(vault_dir: Path | str) -> list[dict[str, Any]]:
                     {"label": "Open object", "path": item["object_path"]},
                     {"label": "Review stale summary", "path": f"/summaries?q={quote(item['object_id'], safe='')}"},
                 ],
+                "recommended_action": _recommended_action(
+                    kind="rebuild_summary",
+                    label="Rebuild summary",
+                    path=f"/summaries?q={quote(item['object_id'], safe='')}",
+                    executable=True,
+                ),
                 "payload": {
                     "reason_codes": item["reason_codes"],
                     "latest_event_date": item["latest_event_date"],
@@ -1280,6 +1301,12 @@ def _compute_signal_entries(vault_dir: Path | str) -> list[dict[str, Any]]:
                     {"label": "Open note", "path": f"/note?path={quote(item['note_path'], safe='')}"},
                     {"label": "Inspect production chain", "path": f"/production?q={quote(item['title'], safe='')}"},
                 ],
+                "recommended_action": _recommended_action(
+                    kind="inspect_production_gap",
+                    label="Inspect production gap",
+                    path=f"/production?q={quote(item['title'], safe='')}",
+                    executable=False,
+                ),
                 "payload": {
                     "stage_label": item["stage_label"],
                     "missing": item["missing"],
@@ -1308,6 +1335,12 @@ def _compute_signal_entries(vault_dir: Path | str) -> list[dict[str, Any]]:
                         {"label": "Open source note", "path": f"/note?path={quote(item['path'], safe='')}"},
                         {"label": "Inspect production chain", "path": f"/production?q={quote(item['title'], safe='')}"},
                     ],
+                    "recommended_action": _recommended_action(
+                        kind="deep_dive_workflow",
+                        label="Create deep dive",
+                        path=f"/note?path={quote(item['path'], safe='')}",
+                        executable=False,
+                    ),
                     "payload": {
                         "stage_label": item["stage_label"],
                         "traceability_counts": traceability["counts"],
@@ -1332,6 +1365,12 @@ def _compute_signal_entries(vault_dir: Path | str) -> list[dict[str, Any]]:
                         {"label": "Open deep dive", "path": f"/note?path={quote(item['path'], safe='')}"},
                         {"label": "Inspect production chain", "path": f"/production?q={quote(item['title'], safe='')}"},
                     ],
+                    "recommended_action": _recommended_action(
+                        kind="object_extraction_workflow",
+                        label="Extract evergreen objects",
+                        path=f"/note?path={quote(item['path'], safe='')}",
+                        executable=False,
+                    ),
                     "payload": {
                         "stage_label": item["stage_label"],
                         "traceability_counts": traceability["counts"],
@@ -1362,6 +1401,12 @@ def _compute_signal_entries(vault_dir: Path | str) -> list[dict[str, Any]]:
                             for object_id in item["object_ids"][:2]
                         ],
                     ],
+                    "recommended_action": _recommended_action(
+                        kind="review_resolution",
+                        label="Inspect resolved contradictions",
+                        path="/contradictions?status=resolved",
+                        executable=False,
+                    ),
                     "payload": {
                         "event_type": item["event_type"],
                         "contradiction_ids": item["contradiction_ids"],
@@ -1392,6 +1437,12 @@ def _compute_signal_entries(vault_dir: Path | str) -> list[dict[str, Any]]:
                             for object_id in item["rebuilt_object_ids"][:2]
                         ],
                     ],
+                    "recommended_action": _recommended_action(
+                        kind="review_rebuilt_summary",
+                        label="Inspect rebuilt summaries",
+                        path="/summaries",
+                        executable=False,
+                    ),
                     "payload": {
                         "event_type": item["event_type"],
                         "objects_rebuilt": rebuilt_count,
@@ -1577,6 +1628,15 @@ def get_briefing_snapshot(vault_dir: Path | str, *, limit: int = 8) -> dict[str,
                 + quote(str(primary_title), safe=""),
                 "source_paths": [path for path in item.get("source_paths", []) if path][:3],
                 "object_ids": list(item.get("object_ids", [])),
+                "recommended_action": _recommended_action(
+                    kind="review_evolution",
+                    label="Review evolution",
+                    path="/evolution?link_type="
+                    + quote(str(item["link_type"]), safe="")
+                    + "&q="
+                    + quote(str(primary_title), safe=""),
+                    executable=True,
+                ),
             }
         )
         if len(insights) >= limit:
@@ -1592,6 +1652,7 @@ def get_briefing_snapshot(vault_dir: Path | str, *, limit: int = 8) -> dict[str,
                 "path": item["source_path"],
                 "source_paths": list(item.get("note_paths", [])),
                 "object_ids": list(item.get("object_ids", [])),
+                "recommended_action": item.get("recommended_action"),
             }
         )
         if len(priority_items) >= limit:

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -12,7 +12,7 @@ from urllib.parse import quote
 
 import yaml
 
-from .runtime import VaultLayout, resolve_vault_dir
+from .runtime import VaultLayout, knowledge_db_write_lock, resolve_vault_dir
 
 MAX_PAGE_SIZE = 500
 _FENCED_FRONTMATTER_RE = re.compile(r"^```ya?ml\s*\n---\n(.*?)\n---\n```\s*\n?", re.DOTALL)
@@ -186,22 +186,23 @@ def record_review_action(
     }
     _append_jsonl(layout.logs_dir / f"{_REVIEW_AUDIT_LOG_NAME}.jsonl", event)
     if layout.knowledge_db.exists():
-        with sqlite3.connect(layout.knowledge_db) as conn:
-            conn.execute(
-                """
-                INSERT INTO audit_events (source_log, event_type, slug, session_id, timestamp, payload_json)
-                VALUES (?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    _REVIEW_AUDIT_LOG_NAME,
-                    event_type,
-                    slug,
-                    session_id,
-                    timestamp,
-                    json.dumps(event, ensure_ascii=False),
-                ),
-            )
-            conn.commit()
+        with knowledge_db_write_lock(resolved_vault):
+            with sqlite3.connect(layout.knowledge_db) as conn:
+                conn.execute(
+                    """
+                    INSERT INTO audit_events (source_log, event_type, slug, session_id, timestamp, payload_json)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        _REVIEW_AUDIT_LOG_NAME,
+                        event_type,
+                        slug,
+                        session_id,
+                        timestamp,
+                        json.dumps(event, ensure_ascii=False),
+                    ),
+                )
+                conn.commit()
     return event
 
 
@@ -1202,26 +1203,27 @@ def _write_action_queue_rows(vault_dir: Path | str, actions: list[dict[str, Any]
     layout = VaultLayout.from_vault(resolved_vault)
     _rewrite_jsonl(layout.logs_dir / f"{_ACTION_LOG_NAME}.jsonl", actions)
     if layout.knowledge_db.exists():
-        with sqlite3.connect(layout.knowledge_db) as conn:
-            conn.execute("DELETE FROM audit_events WHERE source_log = ?", (_ACTION_LOG_NAME,))
-            conn.executemany(
-                """
-                INSERT INTO audit_events (source_log, event_type, slug, session_id, timestamp, payload_json)
-                VALUES (?, ?, ?, ?, ?, ?)
-                """,
-                [
-                    (
-                        _ACTION_LOG_NAME,
-                        action["action_kind"],
-                        action["action_id"],
-                        action.get("session_id", "action-queue"),
-                        action["created_at"],
-                        json.dumps(action, ensure_ascii=False),
-                    )
-                    for action in actions
-                ],
-            )
-            conn.commit()
+        with knowledge_db_write_lock(resolved_vault):
+            with sqlite3.connect(layout.knowledge_db) as conn:
+                conn.execute("DELETE FROM audit_events WHERE source_log = ?", (_ACTION_LOG_NAME,))
+                conn.executemany(
+                    """
+                    INSERT INTO audit_events (source_log, event_type, slug, session_id, timestamp, payload_json)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    [
+                        (
+                            _ACTION_LOG_NAME,
+                            action["action_kind"],
+                            action["action_id"],
+                            action.get("session_id", "action-queue"),
+                            action["created_at"],
+                            json.dumps(action, ensure_ascii=False),
+                        )
+                        for action in actions
+                    ],
+                )
+                conn.commit()
 
 
 def list_action_queue(
@@ -1831,26 +1833,27 @@ def sync_signal_ledger(vault_dir: Path | str) -> dict[str, Any]:
     signals = _compute_signal_entries(resolved_vault)
     _rewrite_jsonl(layout.logs_dir / f"{_SIGNAL_LOG_NAME}.jsonl", signals)
     if layout.knowledge_db.exists():
-        with sqlite3.connect(layout.knowledge_db) as conn:
-            conn.execute("DELETE FROM audit_events WHERE source_log = ?", (_SIGNAL_LOG_NAME,))
-            conn.executemany(
-                """
-                INSERT INTO audit_events (source_log, event_type, slug, session_id, timestamp, payload_json)
-                VALUES (?, ?, ?, ?, ?, ?)
-                """,
-                [
-                    (
-                        _SIGNAL_LOG_NAME,
-                        item["signal_type"],
-                        item["signal_id"],
-                        "signal-ledger",
-                        item["detected_at"],
-                        json.dumps(item, ensure_ascii=False),
-                    )
-                    for item in signals
-                ],
-            )
-            conn.commit()
+        with knowledge_db_write_lock(resolved_vault):
+            with sqlite3.connect(layout.knowledge_db) as conn:
+                conn.execute("DELETE FROM audit_events WHERE source_log = ?", (_SIGNAL_LOG_NAME,))
+                conn.executemany(
+                    """
+                    INSERT INTO audit_events (source_log, event_type, slug, session_id, timestamp, payload_json)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    [
+                        (
+                            _SIGNAL_LOG_NAME,
+                            item["signal_type"],
+                            item["signal_id"],
+                            "signal-ledger",
+                            item["detected_at"],
+                            json.dumps(item, ensure_ascii=False),
+                        )
+                        for item in signals
+                    ],
+                )
+                conn.commit()
     type_counts = Counter(item["signal_type"] for item in signals)
     result = {
         "signal_count": len(signals),

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -72,6 +72,22 @@ def _db_path(vault_dir: Path | str) -> Path:
     return VaultLayout.from_vault(resolved).knowledge_db
 
 
+def _read_jsonl_items(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    items: list[dict[str, Any]] = []
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        if not raw_line.strip():
+            continue
+        try:
+            payload = json.loads(raw_line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            items.append(payload)
+    return items
+
+
 def _briefing_priority_score(item: dict[str, Any]) -> tuple[int, int, int]:
     signal_type = str(item.get("signal_type") or item.get("kind") or "")
     recommended_action = item.get("recommended_action")
@@ -217,24 +233,6 @@ def record_review_action(
         **payload,
     }
     _append_jsonl(layout.logs_dir / f"{_REVIEW_AUDIT_LOG_NAME}.jsonl", event)
-    if layout.knowledge_db.exists():
-        with knowledge_db_write_lock(resolved_vault):
-            with sqlite3.connect(layout.knowledge_db) as conn:
-                conn.execute(
-                    """
-                    INSERT INTO audit_events (source_log, event_type, slug, session_id, timestamp, payload_json)
-                    VALUES (?, ?, ?, ?, ?, ?)
-                    """,
-                    (
-                        _REVIEW_AUDIT_LOG_NAME,
-                        event_type,
-                        slug,
-                        session_id,
-                        timestamp,
-                        json.dumps(event, ensure_ascii=False),
-                    ),
-                )
-                conn.commit()
     return event
 
 
@@ -969,6 +967,27 @@ def get_object_detail(vault_dir: Path | str, object_id: str) -> dict[str, Any]:
         if note_type != "evergreen":
             source_notes.append(item)
 
+    contradiction_items = [
+        {
+            "contradiction_id": row[0],
+            "subject_key": row[1],
+            "positive_claim_ids": json.loads(row[2]),
+            "negative_claim_ids": json.loads(row[3]),
+            "status": row[4],
+            "resolution_note": row[5] or "",
+            "resolved_at": row[6] or "",
+        }
+        for row in contradiction_rows
+    ]
+    contradiction_overrides = _latest_contradiction_review_overrides(resolved_vault)
+    for item in contradiction_items:
+        override = contradiction_overrides.get(str(item["contradiction_id"]))
+        if not override:
+            continue
+        item["status"] = override["status"]
+        item["resolution_note"] = override["resolution_note"]
+        item["resolved_at"] = override["resolved_at"]
+
     return {
         "object": {
             "object_id": object_row[0],
@@ -1013,18 +1032,7 @@ def get_object_detail(vault_dir: Path | str, object_id: str) -> dict[str, Any]:
             }
             for row in relation_rows
         ],
-        "contradictions": [
-            {
-                "contradiction_id": row[0],
-                "subject_key": row[1],
-                "positive_claim_ids": json.loads(row[2]),
-                "negative_claim_ids": json.loads(row[3]),
-                "status": row[4],
-                "resolution_note": row[5] or "",
-                "resolved_at": row[6] or "",
-            }
-            for row in contradiction_rows
-        ],
+        "contradictions": contradiction_items,
         "provenance": {
             "evergreen_path": _vault_relative_path(resolved_vault, object_row[3]),
             "source_notes": source_notes,
@@ -1092,18 +1100,22 @@ def list_review_actions(
 ) -> list[dict[str, Any]]:
     limit, _ = _validate_page_args(limit=limit, offset=0)
     normalized_object_ids = set(object_id for object_id in (object_ids or []) if object_id)
-    db_path = _db_path(vault_dir)
-    with sqlite3.connect(db_path) as conn:
-        rows = conn.execute(
-            """
-            SELECT source_log, event_type, slug, session_id, timestamp, payload_json
-            FROM audit_events
-            WHERE source_log = ?
-            ORDER BY timestamp DESC
-            LIMIT 200
-            """,
-            (_REVIEW_AUDIT_LOG_NAME,),
-        ).fetchall()
+    resolved_vault = resolve_vault_dir(vault_dir)
+    rows = [
+        (
+            _REVIEW_AUDIT_LOG_NAME,
+            item.get("event_type", ""),
+            item.get("slug", ""),
+            item.get("session_id", ""),
+            item.get("timestamp", ""),
+            json.dumps(item, ensure_ascii=False),
+        )
+        for item in sorted(
+            _read_jsonl_items(VaultLayout.from_vault(resolved_vault).logs_dir / f"{_REVIEW_AUDIT_LOG_NAME}.jsonl"),
+            key=lambda item: str(item.get("timestamp") or ""),
+            reverse=True,
+        )[:200]
+    ]
     return _review_action_items(rows, normalized_object_ids=normalized_object_ids, limit=limit)
 
 
@@ -1161,23 +1173,62 @@ def _review_action_items(
     return items
 
 
+def _latest_contradiction_review_overrides(vault_dir: Path | str) -> dict[str, dict[str, str]]:
+    resolved_vault = resolve_vault_dir(vault_dir)
+    items = sorted(
+        [
+            item
+            for item in _read_jsonl_items(
+                VaultLayout.from_vault(resolved_vault).logs_dir / f"{_REVIEW_AUDIT_LOG_NAME}.jsonl"
+            )
+            if item.get("event_type") == "ui_contradictions_resolved"
+        ],
+        key=lambda item: str(item.get("timestamp") or ""),
+    )
+    overrides: dict[str, dict[str, str]] = {}
+    for item in items:
+        status = str(item.get("status") or "")
+        note = str(item.get("note") or "")
+        resolved_at = str(item.get("timestamp") or "")
+        for contradiction_id in item.get("contradiction_ids", []) or []:
+            contradiction_key = str(contradiction_id or "")
+            if contradiction_key:
+                overrides[contradiction_key] = {
+                    "status": status,
+                    "resolution_note": note,
+                    "resolved_at": resolved_at,
+                }
+    return overrides
+
+
 def list_evolution_review_actions(
     vault_dir: Path | str,
     *,
     object_ids: list[str] | None = None,
 ) -> list[dict[str, Any]]:
     normalized_object_ids = set(object_id for object_id in (object_ids or []) if object_id)
-    db_path = _db_path(vault_dir)
-    with sqlite3.connect(db_path) as conn:
-        rows = conn.execute(
-            """
-            SELECT source_log, event_type, slug, session_id, timestamp, payload_json
-            FROM audit_events
-            WHERE source_log = ? AND event_type = ?
-            ORDER BY timestamp DESC
-            """,
-            (_REVIEW_AUDIT_LOG_NAME, "ui_evolution_reviewed"),
-        ).fetchall()
+    resolved_vault = resolve_vault_dir(vault_dir)
+    rows = [
+        (
+            _REVIEW_AUDIT_LOG_NAME,
+            item.get("event_type", ""),
+            item.get("slug", ""),
+            item.get("session_id", ""),
+            item.get("timestamp", ""),
+            json.dumps(item, ensure_ascii=False),
+        )
+        for item in sorted(
+            [
+                item
+                for item in _read_jsonl_items(
+                    VaultLayout.from_vault(resolved_vault).logs_dir / f"{_REVIEW_AUDIT_LOG_NAME}.jsonl"
+                )
+                if item.get("event_type") == "ui_evolution_reviewed"
+            ],
+            key=lambda item: str(item.get("timestamp") or ""),
+            reverse=True,
+        )
+    ]
     return _review_action_items(rows, normalized_object_ids=normalized_object_ids, limit=None)
 
 
@@ -1203,59 +1254,13 @@ def _recommended_action(*, kind: str, label: str, path: str, executable: bool) -
 def _read_action_queue_rows(vault_dir: Path | str) -> list[dict[str, Any]]:
     resolved_vault = resolve_vault_dir(vault_dir)
     layout = VaultLayout.from_vault(resolved_vault)
-    rows: list[tuple[str]] = []
-    if layout.knowledge_db.exists():
-        with sqlite3.connect(layout.knowledge_db) as conn:
-            rows = conn.execute(
-                """
-                SELECT payload_json
-                FROM audit_events
-                WHERE source_log = ?
-                ORDER BY timestamp DESC, slug
-                """,
-                (_ACTION_LOG_NAME,),
-            ).fetchall()
-    elif (layout.logs_dir / f"{_ACTION_LOG_NAME}.jsonl").exists():
-        rows = [
-            (line,)
-            for line in (layout.logs_dir / f"{_ACTION_LOG_NAME}.jsonl").read_text(encoding="utf-8").splitlines()
-            if line.strip()
-        ]
-    items: list[dict[str, Any]] = []
-    for (payload_json,) in rows:
-        try:
-            items.append(json.loads(payload_json))
-        except json.JSONDecodeError:
-            continue
-    return items
+    return _read_jsonl_items(layout.logs_dir / f"{_ACTION_LOG_NAME}.jsonl")
 
 
 def _write_action_queue_rows(vault_dir: Path | str, actions: list[dict[str, Any]]) -> None:
     resolved_vault = resolve_vault_dir(vault_dir)
     layout = VaultLayout.from_vault(resolved_vault)
     _rewrite_jsonl(layout.logs_dir / f"{_ACTION_LOG_NAME}.jsonl", actions)
-    if layout.knowledge_db.exists():
-        with knowledge_db_write_lock(resolved_vault):
-            with sqlite3.connect(layout.knowledge_db) as conn:
-                conn.execute("DELETE FROM audit_events WHERE source_log = ?", (_ACTION_LOG_NAME,))
-                conn.executemany(
-                    """
-                    INSERT INTO audit_events (source_log, event_type, slug, session_id, timestamp, payload_json)
-                    VALUES (?, ?, ?, ?, ?, ?)
-                    """,
-                    [
-                        (
-                            _ACTION_LOG_NAME,
-                            action["action_kind"],
-                            action["action_id"],
-                            action.get("session_id", "action-queue"),
-                            action["created_at"],
-                            json.dumps(action, ensure_ascii=False),
-                        )
-                        for action in actions
-                    ],
-                )
-                conn.commit()
 
 
 def list_action_queue(
@@ -1286,25 +1291,14 @@ def list_action_queue(
 
 
 def _signal_by_id(vault_dir: Path | str, signal_id: str) -> dict[str, Any] | None:
-    ensure_signal_ledger_synced(vault_dir)
-    db_path = _db_path(vault_dir)
-    with sqlite3.connect(db_path) as conn:
-        row = conn.execute(
-            """
-            SELECT payload_json
-            FROM audit_events
-            WHERE source_log = ? AND slug = ?
-            ORDER BY timestamp DESC
-            LIMIT 1
-            """,
-            (_SIGNAL_LOG_NAME, signal_id),
-        ).fetchone()
-    if not row:
-        return None
-    try:
-        return json.loads(row[0])
-    except json.JSONDecodeError:
-        return None
+    layout = VaultLayout.from_vault(resolve_vault_dir(vault_dir))
+    ledger_path = layout.logs_dir / f"{_SIGNAL_LOG_NAME}.jsonl"
+    if not ledger_path.exists():
+        ensure_signal_ledger_synced(vault_dir)
+    for item in _read_jsonl_items(ledger_path):
+        if item.get("signal_id") == signal_id:
+            return item
+    return None
 
 
 def enqueue_signal_action(
@@ -1916,28 +1910,6 @@ def sync_signal_ledger(vault_dir: Path | str) -> dict[str, Any]:
     layout = VaultLayout.from_vault(resolved_vault)
     signals = _compute_signal_entries(resolved_vault)
     _rewrite_jsonl(layout.logs_dir / f"{_SIGNAL_LOG_NAME}.jsonl", signals)
-    if layout.knowledge_db.exists():
-        with knowledge_db_write_lock(resolved_vault):
-            with sqlite3.connect(layout.knowledge_db) as conn:
-                conn.execute("DELETE FROM audit_events WHERE source_log = ?", (_SIGNAL_LOG_NAME,))
-                conn.executemany(
-                    """
-                    INSERT INTO audit_events (source_log, event_type, slug, session_id, timestamp, payload_json)
-                    VALUES (?, ?, ?, ?, ?, ?)
-                    """,
-                    [
-                        (
-                            _SIGNAL_LOG_NAME,
-                            item["signal_type"],
-                            item["signal_id"],
-                            "signal-ledger",
-                            item["detected_at"],
-                            json.dumps(item, ensure_ascii=False),
-                        )
-                        for item in signals
-                    ],
-                )
-                conn.commit()
     type_counts = Counter(item["signal_type"] for item in signals)
     result = {
         "signal_count": len(signals),
@@ -1971,25 +1943,13 @@ def list_signals(
     limit: int = 100,
 ) -> list[dict[str, Any]]:
     limit, _ = _validate_page_args(limit=limit, offset=0)
-    ensure_signal_ledger_synced(vault_dir)
-    db_path = _db_path(vault_dir)
+    resolved_vault = resolve_vault_dir(vault_dir)
+    ledger_path = VaultLayout.from_vault(resolved_vault).logs_dir / f"{_SIGNAL_LOG_NAME}.jsonl"
+    if not ledger_path.exists():
+        ensure_signal_ledger_synced(resolved_vault)
     normalized_query = (query or "").strip().lower()
-    with sqlite3.connect(db_path) as conn:
-        rows = conn.execute(
-            """
-            SELECT payload_json
-            FROM audit_events
-            WHERE source_log = ?
-            ORDER BY timestamp DESC, slug
-            """,
-            (_SIGNAL_LOG_NAME,),
-        ).fetchall()
     items: list[dict[str, Any]] = []
-    for (payload_json,) in rows:
-        try:
-            item = json.loads(payload_json)
-        except json.JSONDecodeError:
-            continue
+    for item in _read_jsonl_items(ledger_path):
         if signal_type and item.get("signal_type") != signal_type:
             continue
         if normalized_query:
@@ -2597,13 +2557,6 @@ def list_contradictions(
     """
     params: list[Any] = []
     where_clauses: list[str] = []
-    if status:
-        if status == "resolved":
-            where_clauses.append("status != ?")
-            params.append("open")
-        else:
-            where_clauses.append("status = ?")
-            params.append(status)
     if normalized_query:
         where_clauses.append("lower(subject_key) LIKE ? ESCAPE '\\'")
         params.append(f"%{normalized_query}%")
@@ -2612,8 +2565,13 @@ def list_contradictions(
     query += " ORDER BY subject_key LIMIT ?"
     params.append(limit)
 
-    with sqlite3.connect(db_path) as conn:
-        rows = conn.execute(query, tuple(params)).fetchall()
+    try:
+        with sqlite3.connect(db_path) as conn:
+            rows = conn.execute(query, tuple(params)).fetchall()
+    except sqlite3.OperationalError as exc:
+        if "no such table" in str(exc).lower():
+            return []
+        raise
 
     items = [
         {
@@ -2627,6 +2585,19 @@ def list_contradictions(
         }
         for row in rows
     ]
+    contradiction_overrides = _latest_contradiction_review_overrides(vault_dir)
+    for item in items:
+        override = contradiction_overrides.get(str(item["contradiction_id"]))
+        if not override:
+            continue
+        item["status"] = override["status"]
+        item["resolution_note"] = override["resolution_note"]
+        item["resolved_at"] = override["resolved_at"]
+    if status:
+        if status == "resolved":
+            items = [item for item in items if item["status"] != "open"]
+        else:
+            items = [item for item in items if item["status"] == status]
     claim_map = _claim_details_map(
         vault_dir,
         [

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -18,6 +18,7 @@ MAX_PAGE_SIZE = 500
 _FENCED_FRONTMATTER_RE = re.compile(r"^```ya?ml\s*\n---\n(.*?)\n---\n```\s*\n?", re.DOTALL)
 _REVIEW_AUDIT_LOG_NAME = "review-actions"
 _SIGNAL_LOG_NAME = "signals"
+_ACTION_LOG_NAME = "actions"
 _SOURCE_NOTE_INDEX_CACHE: dict[tuple[str, tuple[tuple[str, int, int], ...]], dict[str, list[dict[str, str]]]] = {}
 _PIPELINE_LOG_INDEX_CACHE: dict[tuple[str, int, int], dict[str, Any]] = {}
 _DEEP_DIVE_OBJECT_MAP_CACHE: dict[tuple[str, int, int], dict[str, list[dict[str, str]]]] = {}
@@ -1147,6 +1148,12 @@ def _signal_id(signal_type: str, key: str) -> str:
     return f"{signal_type}::{hashlib.sha1(key.encode('utf-8')).hexdigest()[:12]}"
 
 
+def _action_id(signal_id: str, action_kind: str, target_ref: str, payload: dict[str, Any]) -> str:
+    payload_key = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    key = f"{signal_id}::{action_kind}::{target_ref}::{payload_key}"
+    return f"action::{hashlib.sha1(key.encode('utf-8')).hexdigest()[:12]}"
+
+
 def _recommended_action(*, kind: str, label: str, path: str, executable: bool) -> dict[str, Any]:
     return {
         "kind": kind,
@@ -1154,6 +1161,190 @@ def _recommended_action(*, kind: str, label: str, path: str, executable: bool) -
         "path": path,
         "executable": executable,
     }
+
+
+def _read_action_queue_rows(vault_dir: Path | str) -> list[dict[str, Any]]:
+    resolved_vault = resolve_vault_dir(vault_dir)
+    layout = VaultLayout.from_vault(resolved_vault)
+    rows: list[tuple[str]] = []
+    if layout.knowledge_db.exists():
+        with sqlite3.connect(layout.knowledge_db) as conn:
+            rows = conn.execute(
+                """
+                SELECT payload_json
+                FROM audit_events
+                WHERE source_log = ?
+                ORDER BY timestamp DESC, slug
+                """,
+                (_ACTION_LOG_NAME,),
+            ).fetchall()
+    elif (layout.logs_dir / f"{_ACTION_LOG_NAME}.jsonl").exists():
+        rows = [
+            (line,)
+            for line in (layout.logs_dir / f"{_ACTION_LOG_NAME}.jsonl").read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+    items: list[dict[str, Any]] = []
+    for (payload_json,) in rows:
+        try:
+            items.append(json.loads(payload_json))
+        except json.JSONDecodeError:
+            continue
+    return items
+
+
+def _write_action_queue_rows(vault_dir: Path | str, actions: list[dict[str, Any]]) -> None:
+    resolved_vault = resolve_vault_dir(vault_dir)
+    layout = VaultLayout.from_vault(resolved_vault)
+    _rewrite_jsonl(layout.logs_dir / f"{_ACTION_LOG_NAME}.jsonl", actions)
+    if layout.knowledge_db.exists():
+        with sqlite3.connect(layout.knowledge_db) as conn:
+            conn.execute("DELETE FROM audit_events WHERE source_log = ?", (_ACTION_LOG_NAME,))
+            conn.executemany(
+                """
+                INSERT INTO audit_events (source_log, event_type, slug, session_id, timestamp, payload_json)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                [
+                    (
+                        _ACTION_LOG_NAME,
+                        action["action_kind"],
+                        action["action_id"],
+                        action.get("session_id", "action-queue"),
+                        action["created_at"],
+                        json.dumps(action, ensure_ascii=False),
+                    )
+                    for action in actions
+                ],
+            )
+            conn.commit()
+
+
+def list_action_queue(
+    vault_dir: Path | str,
+    *,
+    status: str | None = None,
+    query: str | None = None,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    limit, _ = _validate_page_args(limit=limit, offset=0)
+    normalized_query = (query or "").strip().lower()
+    items: list[dict[str, Any]] = []
+    for item in _read_action_queue_rows(vault_dir):
+        if status and item.get("status") != status:
+            continue
+        if normalized_query:
+            haystacks = [
+                str(item.get("title") or "").lower(),
+                str(item.get("action_kind") or "").lower(),
+                str(item.get("target_ref") or "").lower(),
+            ]
+            if not any(normalized_query in haystack for haystack in haystacks):
+                continue
+        items.append(item)
+        if len(items) >= limit:
+            break
+    return items
+
+
+def _signal_by_id(vault_dir: Path | str, signal_id: str) -> dict[str, Any] | None:
+    ensure_signal_ledger_synced(vault_dir)
+    db_path = _db_path(vault_dir)
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            """
+            SELECT payload_json
+            FROM audit_events
+            WHERE source_log = ? AND slug = ?
+            ORDER BY timestamp DESC
+            LIMIT 1
+            """,
+            (_SIGNAL_LOG_NAME, signal_id),
+        ).fetchone()
+    if not row:
+        return None
+    try:
+        return json.loads(row[0])
+    except json.JSONDecodeError:
+        return None
+
+
+def enqueue_signal_action(
+    vault_dir: Path | str,
+    *,
+    signal_id: str,
+    session_id: str = "ovp-ui",
+) -> dict[str, Any]:
+    signal = _signal_by_id(vault_dir, signal_id)
+    if signal is None:
+        raise ValueError("unknown signal_id")
+    recommended_action = signal.get("recommended_action")
+    if not isinstance(recommended_action, dict) or not recommended_action.get("kind"):
+        raise ValueError("signal has no recommended action")
+    target_ref = (
+        next((path for path in signal.get("note_paths", []) if path), "")
+        or next((object_id for object_id in signal.get("object_ids", []) if object_id), "")
+        or str(signal.get("source_path") or "")
+    )
+    payload = {
+        "recommended_action": recommended_action,
+        "source_path": signal.get("source_path", ""),
+        "note_paths": list(signal.get("note_paths", [])),
+        "object_ids": list(signal.get("object_ids", [])),
+    }
+    action_id = _action_id(signal_id, str(recommended_action["kind"]), target_ref, payload)
+    existing_actions = _read_action_queue_rows(vault_dir)
+    existing = next((item for item in existing_actions if item.get("action_id") == action_id), None)
+    if existing is not None:
+        return {"created": False, "action": existing}
+    timestamp = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    action = {
+        "action_id": action_id,
+        "action_kind": str(recommended_action["kind"]),
+        "source_signal_id": signal_id,
+        "title": str(recommended_action.get("label") or signal.get("title") or signal_id),
+        "target_ref": target_ref,
+        "object_ids": list(signal.get("object_ids", [])),
+        "note_paths": list(signal.get("note_paths", [])),
+        "status": "queued",
+        "created_at": timestamp,
+        "started_at": "",
+        "finished_at": "",
+        "error": "",
+        "payload": payload,
+        "session_id": session_id,
+    }
+    existing_actions.append(action)
+    existing_actions.sort(key=lambda item: (str(item.get("created_at", "")), str(item.get("action_id", ""))), reverse=True)
+    _write_action_queue_rows(vault_dir, existing_actions)
+    return {"created": True, "action": action}
+
+
+def _action_queue_state_map(vault_dir: Path | str) -> dict[str, dict[str, Any]]:
+    state_map: dict[str, dict[str, Any]] = {}
+    for item in list_action_queue(vault_dir, limit=MAX_PAGE_SIZE):
+        signal_id = str(item.get("source_signal_id") or "")
+        if signal_id and signal_id not in state_map:
+            state_map[signal_id] = item
+    return state_map
+
+
+def _attach_action_queue_state(vault_dir: Path | str, items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    queue_state = _action_queue_state_map(vault_dir)
+    annotated: list[dict[str, Any]] = []
+    for item in items:
+        enriched = dict(item)
+        recommended_action = item.get("recommended_action")
+        if isinstance(recommended_action, dict):
+            action = queue_state.get(str(item.get("signal_id") or ""))
+            recommended = dict(recommended_action)
+            if action is not None:
+                recommended["queue_status"] = action.get("status", "")
+                recommended["action_id"] = action.get("action_id", "")
+                recommended["queue_path"] = "/actions"
+            enriched["recommended_action"] = recommended
+        annotated.append(enriched)
+    return annotated
 
 
 def list_production_gaps(
@@ -1544,7 +1735,7 @@ def list_signals(
         items.append(item)
         if len(items) >= limit:
             break
-    return items
+    return _attach_action_queue_state(vault_dir, items)
 
 
 def get_briefing_snapshot(vault_dir: Path | str, *, limit: int = 8) -> dict[str, Any]:
@@ -1646,6 +1837,7 @@ def get_briefing_snapshot(vault_dir: Path | str, *, limit: int = 8) -> dict[str,
     for item in unresolved_issues:
         priority_items.append(
             {
+                "signal_id": item["signal_id"],
                 "kind": item["signal_type"],
                 "title": item["title"],
                 "detail": item["detail"],

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -1381,6 +1381,124 @@ def _backfill_auto_queue_actions(
     }
 
 
+def _replace_action_queue_item(vault_dir: Path | str, action: dict[str, Any]) -> dict[str, Any]:
+    existing_actions = _read_action_queue_rows(vault_dir)
+    replaced = False
+    for index, item in enumerate(existing_actions):
+        if item.get("action_id") == action.get("action_id"):
+            existing_actions[index] = action
+            replaced = True
+            break
+    if not replaced:
+        existing_actions.append(action)
+    existing_actions.sort(
+        key=lambda item: (str(item.get("created_at", "")), str(item.get("action_id", ""))),
+        reverse=True,
+    )
+    _write_action_queue_rows(vault_dir, existing_actions)
+    return action
+
+
+def _next_queued_action(vault_dir: Path | str) -> dict[str, Any] | None:
+    queued = [item for item in _read_action_queue_rows(vault_dir) if item.get("status") == "queued"]
+    if not queued:
+        return None
+    queued.sort(key=lambda item: (str(item.get("created_at", "")), str(item.get("action_id", ""))))
+    return dict(queued[0])
+
+
+def _run_deep_dive_workflow_action(vault_dir: Path | str, action: dict[str, Any]) -> dict[str, Any]:
+    from .auto_article_processor import AutoArticleProcessor, PipelineLogger, TransactionManager
+
+    resolved_vault = resolve_vault_dir(vault_dir)
+    note_paths = [path for path in action.get("note_paths", []) if path]
+    if not note_paths:
+        raise ValueError("deep_dive_workflow action missing note_paths")
+    source_path = resolved_vault / note_paths[0]
+    if not source_path.exists():
+        raise FileNotFoundError(f"source note not found: {note_paths[0]}")
+    layout = VaultLayout.from_vault(resolved_vault)
+    logger = PipelineLogger(layout.pipeline_log)
+    txn = TransactionManager(layout.transactions_dir)
+    processor = AutoArticleProcessor(resolved_vault, logger, txn)
+    processor.init_llm()
+    result = processor.process_single_file(source_path, dry_run=False)
+    if result.get("status") != "completed":
+        raise RuntimeError(str(result.get("error") or "deep_dive_workflow_failed"))
+    return result
+
+
+def _run_object_extraction_workflow_action(vault_dir: Path | str, action: dict[str, Any]) -> dict[str, Any]:
+    from .auto_evergreen_extractor import run_absorb_workflow
+
+    resolved_vault = resolve_vault_dir(vault_dir)
+    note_paths = [path for path in action.get("note_paths", []) if path]
+    if not note_paths:
+        raise ValueError("object_extraction_workflow action missing note_paths")
+    deep_dive_path = resolved_vault / note_paths[0]
+    if not deep_dive_path.exists():
+        raise FileNotFoundError(f"deep dive not found: {note_paths[0]}")
+    return run_absorb_workflow(
+        resolved_vault,
+        file_path=deep_dive_path,
+        dry_run=False,
+        auto_promote=True,
+        promote_threshold=1,
+    )
+
+
+def _refresh_truth_after_action(vault_dir: Path | str) -> None:
+    from .knowledge_index import rebuild_knowledge_index
+
+    rebuild_knowledge_index(resolve_vault_dir(vault_dir))
+    sync_signal_ledger(vault_dir)
+
+
+def run_next_action_queue_item(vault_dir: Path | str) -> dict[str, Any]:
+    action = _next_queued_action(vault_dir)
+    if action is None:
+        return {"ran": False, "reason": "no_queued_actions"}
+
+    started_at = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    action["status"] = "running"
+    action["started_at"] = started_at
+    action["error"] = ""
+    _replace_action_queue_item(vault_dir, action)
+
+    if _signal_by_id(vault_dir, str(action.get("source_signal_id") or "")) is None:
+        action["status"] = "obsolete"
+        action["finished_at"] = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+        _replace_action_queue_item(vault_dir, action)
+        return {"ran": False, "reason": "obsolete_signal", "action": action}
+
+    handlers = {
+        "deep_dive_workflow": _run_deep_dive_workflow_action,
+        "object_extraction_workflow": _run_object_extraction_workflow_action,
+    }
+    handler = handlers.get(str(action.get("action_kind") or ""))
+    if handler is None:
+        action["status"] = "failed"
+        action["error"] = f"unsupported_action_kind:{action.get('action_kind')}"
+        action["finished_at"] = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+        _replace_action_queue_item(vault_dir, action)
+        return {"ran": False, "reason": "unsupported_action_kind", "action": action}
+
+    try:
+        result = handler(vault_dir, action)
+        _refresh_truth_after_action(vault_dir)
+        action["status"] = "succeeded"
+        action["finished_at"] = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+        action["result"] = result
+        _replace_action_queue_item(vault_dir, action)
+        return {"ran": True, "action": action}
+    except Exception as exc:
+        action["status"] = "failed"
+        action["error"] = str(exc)
+        action["finished_at"] = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+        _replace_action_queue_item(vault_dir, action)
+        return {"ran": False, "reason": "execution_failed", "action": action}
+
+
 def _action_queue_state_map(vault_dir: Path | str) -> dict[str, dict[str, Any]]:
     state_map: dict[str, dict[str, Any]] = {}
     for item in list_action_queue(vault_dir, limit=MAX_PAGE_SIZE):

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -22,6 +22,7 @@ _SOURCE_NOTE_INDEX_CACHE: dict[tuple[str, tuple[tuple[str, int, int], ...]], dic
 _PIPELINE_LOG_INDEX_CACHE: dict[tuple[str, int, int], dict[str, Any]] = {}
 _DEEP_DIVE_OBJECT_MAP_CACHE: dict[tuple[str, int, int], dict[str, list[dict[str, str]]]] = {}
 _SIGNAL_LEDGER_SYNC_CACHE: dict[tuple[str, tuple[tuple[str, int, int], ...]], dict[str, Any]] = {}
+_EVOLUTION_CANDIDATE_CACHE: dict[tuple[str, tuple[tuple[str, int, int], ...], tuple[str, ...]], list[dict[str, Any]]] = {}
 CONTRADICTION_STATUS_EXPLANATIONS = {
     "open": "Active contradiction awaiting review.",
     "resolved_keep_positive": "Reviewed and the positive claim set remains the preferred interpretation.",
@@ -37,6 +38,12 @@ SIGNAL_TYPE_EXPLANATIONS = {
     "summary_rebuilt": "A summary rebuild action recently refreshed one or more compiled summaries.",
     "source_needs_deep_dive": "A processed source note exists without any derived deep dive, so the next extraction step is still missing.",
     "deep_dive_needs_objects": "A deep dive exists without any derived evergreen objects, so absorb-style extraction has not completed yet.",
+}
+EVOLUTION_LINK_EXPLANATIONS = {
+    "challenges": "Newer evidence is challenging the current interpretation.",
+    "replaces": "A newer interpretation appears to supersede the older one.",
+    "confirms": "Independent evidence is reinforcing the current interpretation.",
+    "enriches": "Newer material is adding depth without overturning the core idea.",
 }
 
 
@@ -78,6 +85,10 @@ def _signal_dependency_signature(vault_dir: Path) -> tuple[tuple[str, int, int],
     ]
     signatures.extend(_search_root_signatures(vault_dir))
     return tuple(signatures)
+
+
+def _evolution_dependency_signature(vault_dir: Path) -> tuple[tuple[str, int, int], ...]:
+    return _signal_dependency_signature(vault_dir)
 
 
 def _vault_relative_path(vault_dir: Path | str, path: str) -> str:
@@ -1534,6 +1545,67 @@ def get_briefing_snapshot(vault_dir: Path | str, *, limit: int = 8) -> dict[str,
         }
         for object_id, count in topic_counts.most_common(limit)
     ]
+    evolution_candidates = list_evolution_candidates(vault_dir, limit=min(MAX_PAGE_SIZE, limit * 3))
+    evolution_object_ids = list(
+        dict.fromkeys(
+            object_id
+            for item in evolution_candidates
+            for object_id in item.get("object_ids", [])
+            if object_id
+        )
+    )
+    evolution_rows = _batch_object_rows(vault_dir, evolution_object_ids)
+    insights: list[dict[str, Any]] = []
+    for item in evolution_candidates:
+        primary_object_id = next((object_id for object_id in item.get("object_ids", []) if object_id), "")
+        primary_title = (
+            evolution_rows.get(primary_object_id, {}).get("title")
+            or object_rows.get(primary_object_id, {}).get("title")
+            or str(item.get("subject_id") or primary_object_id)
+        )
+        insights.append(
+            {
+                "kind": f"evolution_{item['link_type']}",
+                "link_type": item["link_type"],
+                "title": str(primary_title),
+                "detail": EVOLUTION_LINK_EXPLANATIONS.get(
+                    item["link_type"], "Knowledge evolution was detected."
+                ),
+                "path": "/evolution?link_type="
+                + quote(str(item["link_type"]), safe="")
+                + "&q="
+                + quote(str(primary_title), safe=""),
+                "source_paths": [path for path in item.get("source_paths", []) if path][:3],
+                "object_ids": list(item.get("object_ids", [])),
+            }
+        )
+        if len(insights) >= limit:
+            break
+
+    priority_items: list[dict[str, Any]] = []
+    for item in unresolved_issues:
+        priority_items.append(
+            {
+                "kind": item["signal_type"],
+                "title": item["title"],
+                "detail": item["detail"],
+                "path": item["source_path"],
+                "source_paths": list(item.get("note_paths", [])),
+                "object_ids": list(item.get("object_ids", [])),
+            }
+        )
+        if len(priority_items) >= limit:
+            break
+    seen_priority_keys = {(item["kind"], item["title"], item["path"]) for item in priority_items}
+    for item in insights:
+        key = (item["kind"], item["title"], item["path"])
+        if key in seen_priority_keys:
+            continue
+        priority_items.append(item)
+        seen_priority_keys.add(key)
+        if len(priority_items) >= limit:
+            break
+    first_useful_sign = insights[0] if insights else (priority_items[0] if priority_items else None)
 
     return {
         "generated_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -1545,6 +1617,11 @@ def get_briefing_snapshot(vault_dir: Path | str, *, limit: int = 8) -> dict[str,
         "unresolved_issues": unresolved_issues,
         "changed_objects": changed_objects,
         "active_topics": active_topics,
+        "insight_count": len(insights),
+        "priority_item_count": len(priority_items),
+        "insights": insights,
+        "priority_items": priority_items,
+        "first_useful_sign": first_useful_sign,
     }
 
 
@@ -2066,16 +2143,36 @@ def list_contradictions(
     return items
 
 
-def _all_evolution_candidates(
+def _eligible_evolution_object_ids(vault_dir: Path | str) -> list[str]:
+    promoted_object_ids = {
+        item["object_id"]
+        for objects in _deep_dive_object_map(vault_dir).values()
+        for item in objects
+        if item.get("object_id")
+    }
+    existing_object_ids = {item["object_id"] for item in list_objects(vault_dir, limit=MAX_PAGE_SIZE)}
+    return sorted(promoted_object_ids.intersection(existing_object_ids))
+
+
+def _compute_evolution_candidates(
     vault_dir: Path | str,
     *,
-    query: str | None = None,
-    link_type: str | None = None,
+    object_ids: list[str] | None = None,
 ) -> list[dict[str, Any]]:
-    normalized_query = (query or "").strip().lower()
     candidates: list[dict[str, Any]] = []
+    normalized_object_ids = list(dict.fromkeys(object_id for object_id in (object_ids or []) if object_id))
+    scoped_object_id_set = set(normalized_object_ids)
 
     open_contradictions = list_contradictions(vault_dir, limit=MAX_PAGE_SIZE, status="open")
+    if scoped_object_id_set:
+        open_contradictions = [
+            item
+            for item in open_contradictions
+            if scoped_object_id_set.intersection(
+                claim["object_id"]
+                for claim in (item["positive_claims"] + item["negative_claims"])
+            )
+        ]
     contradiction_object_ids = sorted(
         {
             claim["object_id"]
@@ -2181,13 +2278,13 @@ def _all_evolution_candidates(
                 if path
             ],
         }
-        if link_type and record["link_type"] != link_type:
-            continue
-        if normalized_query and not _evolution_candidate_matches_query(record, normalized_query):
-            continue
         candidates.append(record)
 
-    stale_summaries = list_stale_summaries(vault_dir, limit=MAX_PAGE_SIZE)
+    stale_summaries = list_stale_summaries(
+        vault_dir,
+        object_ids=normalized_object_ids or None,
+        limit=MAX_PAGE_SIZE,
+    )
     for item in stale_summaries:
         traceability = get_object_traceability(vault_dir, item["object_id"])
         earlier_path = traceability["object"]["canonical_path"]
@@ -2252,14 +2349,11 @@ def _all_evolution_candidates(
                 if path
             ],
         }
-        if link_type and record["link_type"] != link_type:
-            continue
-        if normalized_query and not _evolution_candidate_matches_query(record, normalized_query):
-            continue
         candidates.append(record)
 
-    for item in list_objects(vault_dir, limit=MAX_PAGE_SIZE):
-        traceability = get_object_traceability(vault_dir, item["object_id"])
+    candidate_object_ids = normalized_object_ids or _eligible_evolution_object_ids(vault_dir)
+    for object_id in candidate_object_ids:
+        traceability = get_object_traceability(vault_dir, object_id)
         earlier_path = traceability["object"]["canonical_path"]
         earlier_date = _note_date_text(vault_dir, earlier_path)
         earlier_key = _note_date_sort_key(earlier_date)
@@ -2275,16 +2369,16 @@ def _all_evolution_candidates(
                 "evolution_id": _candidate_evolution_id(
                     link_type=inferred_link_type,
                     subject_kind="object",
-                    subject_id=item["object_id"],
-                    earlier_ref=f"object://{item['object_id']}",
+                    subject_id=object_id,
+                    earlier_ref=f"object://{object_id}",
                     later_ref=f"{note.get('note_type') or 'note'}://{note['path']}",
                 ),
                 "status": "candidate",
                 "link_type": inferred_link_type,
                 "subject_kind": "object",
-                "subject_id": item["object_id"],
-                "object_ids": [item["object_id"]],
-                "earlier_ref": f"object://{item['object_id']}",
+                "subject_id": object_id,
+                "object_ids": [object_id],
+                "earlier_ref": f"object://{object_id}",
                 "later_ref": f"{note.get('note_type') or 'note'}://{note['path']}",
                 "earlier_date": earlier_date,
                 "later_date": later_date,
@@ -2300,10 +2394,6 @@ def _all_evolution_candidates(
                 ],
                 "source_paths": [path for path in dict.fromkeys([earlier_path, note["path"]]) if path],
             }
-            if link_type and record["link_type"] != link_type:
-                continue
-            if normalized_query and not _evolution_candidate_matches_query(record, normalized_query):
-                continue
             candidates.append(record)
 
     candidates.sort(
@@ -2325,9 +2415,30 @@ def _all_evolution_candidates(
     return unique_candidates
 
 
+def _all_evolution_candidates(
+    vault_dir: Path | str,
+    *,
+    object_ids: list[str] | None = None,
+) -> list[dict[str, Any]]:
+    resolved_vault = resolve_vault_dir(vault_dir)
+    normalized_object_ids = tuple(dict.fromkeys(object_id for object_id in (object_ids or []) if object_id))
+    cache_key = (
+        str(resolved_vault.resolve()),
+        _evolution_dependency_signature(resolved_vault),
+        normalized_object_ids,
+    )
+    cached = _EVOLUTION_CANDIDATE_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+    result = _compute_evolution_candidates(resolved_vault, object_ids=list(normalized_object_ids))
+    _EVOLUTION_CANDIDATE_CACHE[cache_key] = result
+    return result
+
+
 def list_evolution_candidates(
     vault_dir: Path | str,
     *,
+    object_ids: list[str] | None = None,
     query: str | None = None,
     link_type: str | None = None,
     status: str = "candidate",
@@ -2337,7 +2448,13 @@ def list_evolution_candidates(
     limit, offset = _validate_page_args(limit=limit, offset=offset)
     if status != "candidate":
         return []
-    unique_candidates = _all_evolution_candidates(vault_dir, query=query, link_type=link_type)
+    normalized_query = (query or "").strip().lower()
+    unique_candidates = [
+        item
+        for item in _all_evolution_candidates(vault_dir, object_ids=object_ids)
+        if (not link_type or item["link_type"] == link_type)
+        and (not normalized_query or _evolution_candidate_matches_query(item, normalized_query))
+    ]
     return unique_candidates[offset : offset + limit]
 
 

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -25,6 +25,7 @@ from ..truth_api import (
     list_evolution_links,
     list_review_actions,
     list_atlas_memberships,
+    list_action_queue,
     list_contradictions,
     list_deep_dive_derivations,
     list_objects,
@@ -290,6 +291,23 @@ def build_signal_browser_payload(
         "signal_type": signal_type or "",
         "type_counts": dict(Counter(item["signal_type"] for item in items)),
         "signal_type_explanations": SIGNAL_TYPE_EXPLANATIONS,
+    }
+
+
+def build_action_queue_payload(
+    vault_dir: Path | str,
+    *,
+    status: str | None = None,
+    query: str | None = None,
+) -> dict[str, Any]:
+    items = list_action_queue(vault_dir, status=status, query=query)
+    return {
+        "screen": "actions/browser",
+        "items": items,
+        "count": len(items),
+        "query": query or "",
+        "status": status or "",
+        "status_counts": dict(Counter(str(item["status"]) for item in items)),
     }
 
 

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -308,6 +308,15 @@ def build_action_queue_payload(
         "query": query or "",
         "status": status or "",
         "status_counts": dict(Counter(str(item["status"]) for item in items)),
+        "queued_safe_count": sum(1 for item in items if item.get("status") == "queued" and item.get("safe_to_run")),
+        "failed_count": sum(1 for item in items if item.get("status") == "failed"),
+        "failure_buckets": dict(
+            Counter(
+                str(item.get("failure_bucket") or "")
+                for item in items
+                if item.get("status") == "failed" and str(item.get("failure_bucket") or "")
+            )
+        ),
     }
 
 

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -213,7 +213,13 @@ def _build_evolution_section(
     rejected_links = [item for item in reviewed_links if item["status"] == "rejected"]
     candidate_items = [
         item
-        for item in list_evolution_candidates(vault_dir, query=query, link_type=link_type, status="candidate")
+        for item in list_evolution_candidates(
+            vault_dir,
+            object_ids=normalized_object_ids or None,
+            query=query,
+            link_type=link_type,
+            status="candidate",
+        )
         if item["evolution_id"] not in reviewed_evolution_ids
     ]
     if normalized_object_ids:
@@ -289,7 +295,7 @@ def build_signal_browser_payload(
 
 def build_briefing_payload(vault_dir: Path | str) -> dict[str, Any]:
     return {
-        "screen": "briefing/snapshot",
+        "screen": "briefing/intelligence",
         **get_briefing_snapshot(vault_dir),
     }
 

--- a/tests/test_build_views_command.py
+++ b/tests/test_build_views_command.py
@@ -226,6 +226,7 @@ def test_build_views_command_can_materialize_object_page_from_truth_store(temp_v
     from openclaw_pipeline.commands.build_views import main
     from openclaw_pipeline.knowledge_index import list_contradictions, rebuild_knowledge_index, resolve_contradictions
     from openclaw_pipeline.runtime import VaultLayout
+    from openclaw_pipeline.truth_api import record_review_action
 
     source = temp_vault / "10-Knowledge" / "Evergreen" / "Source.md"
     target = temp_vault / "10-Knowledge" / "Evergreen" / "Target.md"
@@ -283,6 +284,18 @@ Source note does not support the runtime architecture.
         [contradiction_id],
         status="needs_human",
         note="Needs editorial review.",
+    )
+    record_review_action(
+        temp_vault,
+        event_type="ui_contradictions_resolved",
+        slug="source-note",
+        payload={
+            "object_ids": ["source-note", "conflict-note"],
+            "contradiction_ids": [contradiction_id],
+            "status": "needs_human",
+            "note": "Needs editorial review.",
+            "rebuilt_object_ids": [],
+        },
     )
 
     result = main(
@@ -504,6 +517,7 @@ def test_build_views_command_can_materialize_contradictions_overview(temp_vault)
     from openclaw_pipeline.commands.build_views import main
     from openclaw_pipeline.knowledge_index import list_contradictions, rebuild_knowledge_index, resolve_contradictions
     from openclaw_pipeline.runtime import VaultLayout
+    from openclaw_pipeline.truth_api import record_review_action
 
     one = temp_vault / "10-Knowledge" / "Evergreen" / "One.md"
     two = temp_vault / "10-Knowledge" / "Evergreen" / "Two.md"
@@ -543,6 +557,18 @@ Agent harness does not support local-first execution for operators.
         [contradiction_id],
         status="dismissed",
         note="False conflict after claim review.",
+    )
+    record_review_action(
+        temp_vault,
+        event_type="ui_contradictions_resolved",
+        slug="harness-positive",
+        payload={
+            "object_ids": ["harness-positive", "harness-negative"],
+            "contradiction_ids": [contradiction_id],
+            "status": "dismissed",
+            "note": "False conflict after claim review.",
+            "rebuilt_object_ids": [],
+        },
     )
 
     result = main(

--- a/tests/test_knowledge_index.py
+++ b/tests/test_knowledge_index.py
@@ -925,3 +925,38 @@ aliases: [Target Note]
 
     assert result["pages_indexed"] == 2
     assert result["links_indexed"] == 1
+
+
+def test_rebuild_knowledge_index_acquires_single_writer_lock(temp_vault, monkeypatch):
+    from contextlib import contextmanager
+
+    from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
+
+    evergreen = temp_vault / "10-Knowledge" / "Evergreen" / "Source.md"
+    evergreen.write_text(
+        """---
+note_id: source-note
+title: Source Note
+type: evergreen
+date: 2026-04-10
+---
+
+# Source Note
+""",
+        encoding="utf-8",
+    )
+
+    calls: list[str] = []
+
+    @contextmanager
+    def fake_lock(vault_dir, *, timeout_seconds=300.0):
+        calls.append(f"enter:{temp_vault == vault_dir}")
+        yield
+        calls.append("exit")
+
+    monkeypatch.setattr("openclaw_pipeline.knowledge_index.knowledge_db_write_lock", fake_lock)
+
+    result = rebuild_knowledge_index(temp_vault)
+
+    assert result["pages_indexed"] == 1
+    assert calls == ["enter:True", "exit"]

--- a/tests/test_resolve_contradictions_command.py
+++ b/tests/test_resolve_contradictions_command.py
@@ -49,7 +49,7 @@ Agent harness does not support local-first execution for operators.
 
 def test_resolve_contradictions_command_updates_truth_store_status(temp_vault, capsys):
     from openclaw_pipeline.commands.resolve_contradictions import main
-    from openclaw_pipeline.runtime import VaultLayout
+    from openclaw_pipeline.truth_api import list_contradictions, list_review_actions
 
     contradiction_id, _one, _two = _build_contradiction(temp_vault)
 
@@ -72,25 +72,19 @@ def test_resolve_contradictions_command_updates_truth_store_status(temp_vault, c
     assert payload["resolved_count"] == 1
     assert payload["contradiction_ids"] == [contradiction_id]
 
-    db_path = VaultLayout.from_vault(temp_vault).knowledge_db
-    with sqlite3.connect(db_path) as conn:
-        row = conn.execute(
-            """
-            SELECT status, resolution_note
-            FROM contradictions
-            WHERE contradiction_id = ?
-            """,
-            (contradiction_id,),
-        ).fetchone()
-
-    assert row == ("resolved_keep_positive", "Confirmed the positive claim after review.")
+    row = next(item for item in list_contradictions(temp_vault, limit=10) if item["contradiction_id"] == contradiction_id)
+    assert row["status"] == "resolved_keep_positive"
+    assert row["resolution_note"] == "Confirmed the positive claim after review."
+    review = list_review_actions(temp_vault, limit=5)[0]
+    assert review["event_type"] == "ui_contradictions_resolved"
+    assert review["status"] == "resolved_keep_positive"
 
 
 def test_resolve_contradictions_command_can_apply_review_queue(temp_vault, capsys):
     from openclaw_pipeline.commands.resolve_contradictions import main
     from openclaw_pipeline.operations.runtime import run_operation_profile
     from openclaw_pipeline.packs.loader import load_pack
-    from openclaw_pipeline.runtime import VaultLayout
+    from openclaw_pipeline.truth_api import list_contradictions
 
     contradiction_id, _one, _two = _build_contradiction(temp_vault)
     pack = load_pack("default-knowledge")
@@ -119,18 +113,9 @@ def test_resolve_contradictions_command_can_apply_review_queue(temp_vault, capsy
     assert payload["cleared_queue_files"] == [str(queue_file)]
     assert not queue_file.exists()
 
-    db_path = VaultLayout.from_vault(temp_vault).knowledge_db
-    with sqlite3.connect(db_path) as conn:
-        row = conn.execute(
-            """
-            SELECT status, resolution_note
-            FROM contradictions
-            WHERE contradiction_id = ?
-            """,
-            (contradiction_id,),
-        ).fetchone()
-
-    assert row == ("dismissed", "")
+    row = next(item for item in list_contradictions(temp_vault, limit=10) if item["contradiction_id"] == contradiction_id)
+    assert row["status"] == "dismissed"
+    assert row["resolution_note"] == ""
 
 
 def test_resolve_contradictions_command_can_rebuild_affected_summaries(temp_vault, capsys):

--- a/tests/test_run_actions_command.py
+++ b/tests/test_run_actions_command.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+
+
+def test_run_actions_main_runs_once_and_prints_payload(temp_vault, capsys, monkeypatch):
+    from openclaw_pipeline.commands.run_actions import main
+
+    monkeypatch.setattr(
+        "openclaw_pipeline.commands.run_actions.run_next_action_queue_item",
+        lambda vault_dir: {"ran": True, "action": {"action_id": "action::demo"}},
+    )
+
+    exit_code = main(["--vault-dir", str(temp_vault), "--once"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["ran"] is True
+    assert payload["action"]["action_id"] == "action::demo"
+
+
+def test_run_actions_main_can_loop_for_multiple_iterations(temp_vault, capsys, monkeypatch):
+    from openclaw_pipeline.commands.run_actions import main
+
+    calls = {"count": 0}
+
+    def fake_run_next(vault_dir):
+        calls["count"] += 1
+        return {"ran": False, "action": None, "iteration": calls["count"]}
+
+    monkeypatch.setattr(
+        "openclaw_pipeline.commands.run_actions.run_next_action_queue_item",
+        fake_run_next,
+    )
+
+    exit_code = main(
+        [
+            "--vault-dir",
+            str(temp_vault),
+            "--loop",
+            "--interval",
+            "0",
+            "--max-runs",
+            "2",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert calls["count"] == 2
+    assert payload["loop"] is True
+    assert payload["iterations"] == 2

--- a/tests/test_run_actions_command.py
+++ b/tests/test_run_actions_command.py
@@ -8,7 +8,11 @@ def test_run_actions_main_runs_once_and_prints_payload(temp_vault, capsys, monke
 
     monkeypatch.setattr(
         "openclaw_pipeline.commands.run_actions.run_next_action_queue_item",
-        lambda vault_dir: {"ran": True, "action": {"action_id": "action::demo"}},
+        lambda vault_dir, *, safe_only=False: {
+            "ran": True,
+            "safe_only": safe_only,
+            "action": {"action_id": "action::demo"},
+        },
     )
 
     exit_code = main(["--vault-dir", str(temp_vault), "--once"])
@@ -24,9 +28,9 @@ def test_run_actions_main_can_loop_for_multiple_iterations(temp_vault, capsys, m
 
     calls = {"count": 0}
 
-    def fake_run_next(vault_dir):
+    def fake_run_next(vault_dir, *, safe_only=False):
         calls["count"] += 1
-        return {"ran": False, "action": None, "iteration": calls["count"]}
+        return {"ran": False, "safe_only": safe_only, "action": None, "iteration": calls["count"]}
 
     monkeypatch.setattr(
         "openclaw_pipeline.commands.run_actions.run_next_action_queue_item",
@@ -50,3 +54,4 @@ def test_run_actions_main_can_loop_for_multiple_iterations(temp_vault, capsys, m
     assert calls["count"] == 2
     assert payload["loop"] is True
     assert payload["iterations"] == 2
+    assert payload["last_result"]["iteration"] == 2

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -1880,6 +1880,83 @@ Thin.
     assert any(item.get("recommended_action") for item in payload["priority_items"])
 
 
+def test_truth_api_briefing_dedupes_equivalent_evolution_insights(temp_vault, monkeypatch):
+    import openclaw_pipeline.truth_api as truth_api
+
+    vault = _seed_truth_vault(temp_vault)
+    monkeypatch.setattr(truth_api, "list_signals", lambda vault_dir, limit=8: [])
+    monkeypatch.setattr(
+        truth_api,
+        "list_evolution_candidates",
+        lambda vault_dir, limit=24: [
+            {
+                "link_type": "challenges",
+                "subject_id": "agent harness",
+                "object_ids": ["source-note"],
+                "source_paths": ["10-Knowledge/Evergreen/Source.md"],
+            },
+            {
+                "link_type": "challenges",
+                "subject_id": "agent harness",
+                "object_ids": ["source-note"],
+                "source_paths": ["10-Knowledge/Evergreen/Source.md"],
+            },
+        ],
+    )
+
+    payload = truth_api.get_briefing_snapshot(vault, limit=8)
+
+    assert len(payload["insights"]) == 1
+    assert len(payload["priority_items"]) == 1
+
+
+def test_truth_api_briefing_prioritizes_actionable_unresolved_issues(temp_vault, monkeypatch):
+    import openclaw_pipeline.truth_api as truth_api
+
+    vault = _seed_truth_vault(temp_vault)
+    monkeypatch.setattr(
+        truth_api,
+        "list_signals",
+        lambda vault_dir, limit=8: [
+            {
+                "signal_id": "signal::source",
+                "signal_type": "source_needs_deep_dive",
+                "title": "Manual extraction gap",
+                "detail": "Needs deep dive.",
+                "source_path": "/note?path=50-Inbox/03-Processed/2026-04/Manual.md",
+                "note_paths": ["50-Inbox/03-Processed/2026-04/Manual.md"],
+                "object_ids": [],
+                "recommended_action": {
+                    "kind": "deep_dive_workflow",
+                    "label": "Create deep dive",
+                    "path": "/note?path=50-Inbox/03-Processed/2026-04/Manual.md",
+                    "executable": False,
+                },
+            },
+            {
+                "signal_id": "signal::contradiction",
+                "signal_type": "contradiction_open",
+                "title": "Agent harness contradiction",
+                "detail": "Open contradiction.",
+                "source_path": "/contradictions?q=agent%20harness",
+                "note_paths": [],
+                "object_ids": ["source-note"],
+                "recommended_action": {
+                    "kind": "review_contradiction",
+                    "label": "Review contradiction",
+                    "path": "/contradictions?q=agent%20harness",
+                    "executable": True,
+                },
+            },
+        ],
+    )
+    monkeypatch.setattr(truth_api, "list_evolution_candidates", lambda vault_dir, limit=24: [])
+
+    payload = truth_api.get_briefing_snapshot(vault, limit=8)
+
+    assert payload["priority_items"][0]["kind"] == "contradiction_open"
+
+
 def test_truth_api_enqueues_signal_actions_idempotently(temp_vault):
     from openclaw_pipeline.truth_api import enqueue_signal_action, list_action_queue, list_signals, sync_signal_ledger
 

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -77,6 +77,109 @@ def test_truth_api_lists_objects(temp_vault):
     assert objects[1]["object_kind"] == "evergreen"
 
 
+def test_truth_api_reads_signal_and_action_ledgers_without_knowledge_db(temp_vault):
+    from openclaw_pipeline.truth_api import list_action_queue, list_signals
+
+    logs_dir = temp_vault / "60-Logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    (logs_dir / "knowledge.db").write_bytes(b"not-a-real-sqlite-db")
+    (logs_dir / "signals.jsonl").write_text(
+        json.dumps(
+            {
+                "signal_id": "source_needs_deep_dive::demo",
+                "signal_type": "source_needs_deep_dive",
+                "detected_at": "2026-04-15T00:00:00Z",
+                "status": "active",
+                "title": "Create deep dive for Demo Source",
+                "detail": "Demo source is missing a deep dive.",
+                "source_path": "/note?path=50-Inbox%2F03-Processed%2FDemo.md",
+                "object_ids": [],
+                "note_paths": ["50-Inbox/03-Processed/Demo.md"],
+                "recommended_action": {
+                    "kind": "deep_dive_workflow",
+                    "label": "Create deep dive",
+                    "path": "/note?path=50-Inbox%2F03-Processed%2FDemo.md",
+                    "executable": False,
+                },
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (logs_dir / "actions.jsonl").write_text(
+        json.dumps(
+            {
+                "action_id": "action::demo",
+                "action_kind": "deep_dive_workflow",
+                "source_signal_id": "source_needs_deep_dive::demo",
+                "title": "Create deep dive for Demo Source",
+                "target_ref": "50-Inbox/03-Processed/Demo.md",
+                "status": "queued",
+                "created_at": "2026-04-15T00:00:01Z",
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    signals = list_signals(temp_vault)
+    actions = list_action_queue(temp_vault)
+
+    assert signals[0]["signal_id"] == "source_needs_deep_dive::demo"
+    assert signals[0]["recommended_action"]["queue_status"] == "queued"
+    assert actions[0]["action_id"] == "action::demo"
+
+
+def test_truth_api_reads_review_actions_from_jsonl_without_knowledge_db(temp_vault):
+    from openclaw_pipeline.truth_api import list_evolution_review_actions, list_review_actions
+
+    logs_dir = temp_vault / "60-Logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    (logs_dir / "knowledge.db").write_bytes(b"not-a-real-sqlite-db")
+    (logs_dir / "review-actions.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "timestamp": "2026-04-15T00:00:00Z",
+                        "session_id": "ovp-ui",
+                        "event_type": "ui_evolution_reviewed",
+                        "slug": "agent-harness",
+                        "object_ids": ["source-note"],
+                        "evolution_id": "evolution::demo",
+                        "link_type": "challenges",
+                        "status": "accepted",
+                        "note": "accepted",
+                    },
+                    ensure_ascii=False,
+                ),
+                json.dumps(
+                    {
+                        "timestamp": "2026-04-15T00:00:10Z",
+                        "session_id": "ovp-ui",
+                        "event_type": "ui_summaries_rebuilt",
+                        "slug": "source-note",
+                        "object_ids": ["source-note"],
+                        "rebuilt_object_ids": ["source-note"],
+                        "objects_rebuilt": 1,
+                    },
+                    ensure_ascii=False,
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    review_actions = list_review_actions(temp_vault)
+    evolution_actions = list_evolution_review_actions(temp_vault)
+
+    assert review_actions[0]["event_type"] == "ui_summaries_rebuilt"
+    assert evolution_actions[0]["evolution_id"] == "evolution::demo"
+
+
 def test_note_date_text_returns_empty_string_when_frontmatter_date_missing(temp_vault):
     from openclaw_pipeline.truth_api import _note_date_text
 
@@ -2028,7 +2131,7 @@ def test_truth_api_includes_review_action_signals(temp_vault):
     assert reviewed["source_path"] == "/contradictions?status=resolved"
 
 
-def test_truth_api_sync_signal_ledger_acquires_single_writer_lock(temp_vault, monkeypatch):
+def test_truth_api_sync_signal_ledger_writes_jsonl_without_db_lock(temp_vault, monkeypatch):
     from openclaw_pipeline import truth_api
 
     vault = _seed_truth_vault(temp_vault)
@@ -2042,12 +2145,15 @@ def test_truth_api_sync_signal_ledger_acquires_single_writer_lock(temp_vault, mo
 
     monkeypatch.setattr(truth_api, "knowledge_db_write_lock", fake_lock)
 
-    truth_api.sync_signal_ledger(vault)
+    summary = truth_api.sync_signal_ledger(vault)
 
-    assert calls == ["enter:True", "exit"]
+    assert calls == []
+    signals_path = vault / "60-Logs" / "signals.jsonl"
+    assert signals_path.exists()
+    assert summary["signal_count"] >= 1
 
 
-def test_truth_api_record_review_action_acquires_single_writer_lock(temp_vault, monkeypatch):
+def test_truth_api_record_review_action_writes_jsonl_without_db_lock(temp_vault, monkeypatch):
     from openclaw_pipeline import truth_api
 
     vault = _seed_truth_vault(temp_vault)
@@ -2072,4 +2178,8 @@ def test_truth_api_record_review_action_acquires_single_writer_lock(temp_vault, 
         },
     )
 
-    assert calls == ["enter:True", "exit"]
+    assert calls == []
+    review_log = vault / "60-Logs" / "review-actions.jsonl"
+    assert review_log.exists()
+    lines = [line for line in review_log.read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert len(lines) == 1

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -1650,6 +1650,74 @@ Mentions [[source-note]] but has not produced any evergreen objects yet.
     )
 
 
+def test_truth_api_run_next_action_queue_item_executes_deep_dive_workflow(temp_vault, monkeypatch):
+    import openclaw_pipeline.truth_api as truth_api
+
+    vault = _seed_truth_vault(temp_vault)
+    processed = vault / "50-Inbox" / "03-Processed" / "2026-04" / "Harness Source.md"
+    processed.parent.mkdir(parents=True, exist_ok=True)
+    processed.write_text(
+        """---
+title: Harness Source
+source: https://example.com/harness
+---
+
+Processed source note without any derived deep dive.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(vault)
+    truth_api.sync_signal_ledger(vault)
+
+    calls: list[str] = []
+
+    def fake_run_deep_dive(vault_dir, action):
+        calls.append(action["action_kind"])
+        return {"output_path": "20-Areas/AI-Research/Topics/2026-04/Harness Source_深度解读.md"}
+
+    monkeypatch.setattr(truth_api, "_run_deep_dive_workflow_action", fake_run_deep_dive)
+    monkeypatch.setattr(truth_api, "_refresh_truth_after_action", lambda vault_dir: None)
+
+    payload = truth_api.run_next_action_queue_item(vault)
+    actions = truth_api.list_action_queue(vault)
+
+    assert payload["ran"] is True
+    assert payload["action"]["status"] == "succeeded"
+    assert payload["action"]["finished_at"]
+    assert calls == ["deep_dive_workflow"]
+    assert actions[0]["status"] == "succeeded"
+
+
+def test_truth_api_run_next_action_queue_item_marks_obsolete_when_signal_is_gone(temp_vault, monkeypatch):
+    import openclaw_pipeline.truth_api as truth_api
+
+    vault = _seed_truth_vault(temp_vault)
+    processed = vault / "50-Inbox" / "03-Processed" / "2026-04" / "Harness Source.md"
+    processed.parent.mkdir(parents=True, exist_ok=True)
+    processed.write_text(
+        """---
+title: Harness Source
+source: https://example.com/harness
+---
+
+Processed source note without any derived deep dive.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(vault)
+    truth_api.sync_signal_ledger(vault)
+
+    monkeypatch.setattr(truth_api, "_signal_by_id", lambda vault_dir, signal_id: None)
+
+    payload = truth_api.run_next_action_queue_item(vault)
+    actions = truth_api.list_action_queue(vault)
+
+    assert payload["ran"] is False
+    assert payload["reason"] == "obsolete_signal"
+    assert payload["action"]["status"] == "obsolete"
+    assert actions[0]["status"] == "obsolete"
+
+
 def test_truth_api_builds_briefing_snapshot(temp_vault):
     from openclaw_pipeline.truth_api import get_briefing_snapshot, record_review_action, sync_signal_ledger
 

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -1582,18 +1582,72 @@ Mentions [[source-note]] but has not produced any evergreen objects yet.
     deep_dive_signal = next(item for item in items if item["signal_type"] == "deep_dive_needs_objects")
     assert source_signal["note_paths"] == ["50-Inbox/03-Processed/2026-04/Harness Source.md"]
     assert deep_dive_signal["note_paths"] == ["20-Areas/AI-Research/Topics/2026-04/Harness Deep Dive_深度解读.md"]
-    assert source_signal["recommended_action"] == {
-        "kind": "deep_dive_workflow",
-        "label": "Create deep dive",
-        "path": "/note?path=50-Inbox%2F03-Processed%2F2026-04%2FHarness%20Source.md",
-        "executable": False,
+    assert source_signal["recommended_action"]["kind"] == "deep_dive_workflow"
+    assert source_signal["recommended_action"]["label"] == "Create deep dive"
+    assert source_signal["recommended_action"]["executable"] is False
+    assert source_signal["recommended_action"]["queue_status"] == "queued"
+    assert source_signal["recommended_action"]["action_id"]
+    assert deep_dive_signal["recommended_action"]["kind"] == "object_extraction_workflow"
+    assert deep_dive_signal["recommended_action"]["label"] == "Extract evergreen objects"
+    assert deep_dive_signal["recommended_action"]["executable"] is False
+    assert deep_dive_signal["recommended_action"]["queue_status"] == "queued"
+    assert deep_dive_signal["recommended_action"]["action_id"]
+
+
+def test_truth_api_backfills_active_auto_queue_signals_without_duplicates(temp_vault):
+    from openclaw_pipeline.truth_api import list_action_queue, list_signals, sync_signal_ledger
+
+    vault = _seed_truth_vault(temp_vault)
+    processed = vault / "50-Inbox" / "03-Processed" / "2026-04" / "Harness Source.md"
+    processed.parent.mkdir(parents=True, exist_ok=True)
+    processed.write_text(
+        """---
+title: Harness Source
+source: https://example.com/harness
+---
+
+Processed source note without any derived deep dive.
+""",
+        encoding="utf-8",
+    )
+    deep_dive = vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "Harness Deep Dive_深度解读.md"
+    deep_dive.parent.mkdir(parents=True, exist_ok=True)
+    deep_dive.write_text(
+        """---
+note_id: harness-deep-dive
+title: Harness Deep Dive
+type: deep_dive
+source: https://example.com/another-harness
+date: 2026-04-13
+---
+
+# Harness Deep Dive
+
+Mentions [[source-note]] but has not produced any evergreen objects yet.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(vault)
+
+    sync_signal_ledger(vault)
+    first_actions = list_action_queue(vault)
+    sync_signal_ledger(vault)
+    second_actions = list_action_queue(vault)
+    items = list_signals(vault)
+
+    assert len(first_actions) == 2
+    assert len(second_actions) == 2
+    assert {item["action_kind"] for item in second_actions} == {
+        "deep_dive_workflow",
+        "object_extraction_workflow",
     }
-    assert deep_dive_signal["recommended_action"] == {
-        "kind": "object_extraction_workflow",
-        "label": "Extract evergreen objects",
-        "path": "/note?path=20-Areas%2FAI-Research%2FTopics%2F2026-04%2FHarness%20Deep%20Dive_%E6%B7%B1%E5%BA%A6%E8%A7%A3%E8%AF%BB.md",
-        "executable": False,
-    }
+    assert {item["status"] for item in second_actions} == {"queued"}
+    assert not any(item["action_kind"] == "review_contradiction" for item in second_actions)
+    assert all(
+        item["recommended_action"].get("queue_status") == "queued"
+        for item in items
+        if item["signal_type"] in {"source_needs_deep_dive", "deep_dive_needs_objects"}
+    )
 
 
 def test_truth_api_builds_briefing_snapshot(temp_vault):
@@ -1667,7 +1721,7 @@ Processed source note without any derived deep dive.
     actions = list_action_queue(vault)
     refreshed_signal = next(item for item in list_signals(vault) if item["signal_id"] == source_signal["signal_id"])
 
-    assert first["created"] is True
+    assert first["created"] is False
     assert second["created"] is False
     assert first["action"]["action_id"] == second["action"]["action_id"]
     assert len(actions) == 1

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -1479,9 +1479,11 @@ Processed source note with no downstream chain.
     contradiction = next(item for item in items if item["signal_type"] == "contradiction_open")
     assert contradiction["source_path"] == "/contradictions"
     assert contradiction["downstream_effects"]
+    assert contradiction["recommended_action"]["executable"] is True
     stale = next(item for item in items if item["signal_type"] == "stale_summary")
     assert stale["object_ids"] == ["thin-note"]
     assert stale["source_path"] == "/summaries?q=thin-note"
+    assert stale["recommended_action"]["executable"] is True
 
 
 def test_truth_api_filters_signal_ledger_by_type_and_query(temp_vault):
@@ -1580,6 +1582,18 @@ Mentions [[source-note]] but has not produced any evergreen objects yet.
     deep_dive_signal = next(item for item in items if item["signal_type"] == "deep_dive_needs_objects")
     assert source_signal["note_paths"] == ["50-Inbox/03-Processed/2026-04/Harness Source.md"]
     assert deep_dive_signal["note_paths"] == ["20-Areas/AI-Research/Topics/2026-04/Harness Deep Dive_深度解读.md"]
+    assert source_signal["recommended_action"] == {
+        "kind": "deep_dive_workflow",
+        "label": "Create deep dive",
+        "path": "/note?path=50-Inbox%2F03-Processed%2F2026-04%2FHarness%20Source.md",
+        "executable": False,
+    }
+    assert deep_dive_signal["recommended_action"] == {
+        "kind": "object_extraction_workflow",
+        "label": "Extract evergreen objects",
+        "path": "/note?path=20-Areas%2FAI-Research%2FTopics%2F2026-04%2FHarness%20Deep%20Dive_%E6%B7%B1%E5%BA%A6%E8%A7%A3%E8%AF%BB.md",
+        "executable": False,
+    }
 
 
 def test_truth_api_builds_briefing_snapshot(temp_vault):
@@ -1625,6 +1639,7 @@ Thin.
     assert payload["insights"]
     assert payload["priority_items"]
     assert payload["first_useful_sign"] in payload["insights"]
+    assert any(item.get("recommended_action") for item in payload["priority_items"])
 
 
 def test_truth_api_includes_review_action_signals(temp_vault):

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -1719,6 +1719,121 @@ Processed source note without any derived deep dive.
     assert actions[0]["status"] == "obsolete"
 
 
+def test_truth_api_can_retry_failed_action_queue_item(temp_vault, monkeypatch):
+    import openclaw_pipeline.truth_api as truth_api
+
+    vault = _seed_truth_vault(temp_vault)
+    processed = vault / "50-Inbox" / "03-Processed" / "2026-04" / "Harness Source.md"
+    processed.parent.mkdir(parents=True, exist_ok=True)
+    processed.write_text(
+        """---
+title: Harness Source
+source: https://example.com/harness
+---
+
+Processed source note without any derived deep dive.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(vault)
+    truth_api.sync_signal_ledger(vault)
+
+    monkeypatch.setattr(
+        truth_api,
+        "_run_deep_dive_workflow_action",
+        lambda vault_dir, action: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    truth_api.run_next_action_queue_item(vault)
+    failed_action = truth_api.list_action_queue(vault)[0]
+
+    payload = truth_api.retry_action_queue_item(vault, action_id=failed_action["action_id"])
+    retried_action = truth_api.list_action_queue(vault)[0]
+
+    assert payload["retried"] is True
+    assert payload["action"]["status"] == "queued"
+    assert payload["action"]["error"] == ""
+    assert payload["action"]["started_at"] == ""
+    assert payload["action"]["finished_at"] == ""
+    assert retried_action["status"] == "queued"
+
+
+def test_truth_api_can_dismiss_queued_action_queue_item(temp_vault):
+    import openclaw_pipeline.truth_api as truth_api
+
+    vault = _seed_truth_vault(temp_vault)
+    processed = vault / "50-Inbox" / "03-Processed" / "2026-04" / "Harness Source.md"
+    processed.parent.mkdir(parents=True, exist_ok=True)
+    processed.write_text(
+        """---
+title: Harness Source
+source: https://example.com/harness
+---
+
+Processed source note without any derived deep dive.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(vault)
+    truth_api.sync_signal_ledger(vault)
+    queued_action = truth_api.list_action_queue(vault)[0]
+
+    payload = truth_api.dismiss_action_queue_item(vault, action_id=queued_action["action_id"])
+    dismissed_action = truth_api.list_action_queue(vault)[0]
+
+    assert payload["dismissed"] is True
+    assert payload["action"]["status"] == "dismissed"
+    assert payload["action"]["finished_at"]
+    assert dismissed_action["status"] == "dismissed"
+
+
+def test_truth_api_run_action_queue_processes_multiple_queued_items(temp_vault, monkeypatch):
+    import openclaw_pipeline.truth_api as truth_api
+
+    vault = _seed_truth_vault(temp_vault)
+    processed = vault / "50-Inbox" / "03-Processed" / "2026-04" / "Harness Source.md"
+    processed.parent.mkdir(parents=True, exist_ok=True)
+    processed.write_text(
+        """---
+title: Harness Source
+source: https://example.com/harness
+---
+
+Processed source note without any derived deep dive.
+""",
+        encoding="utf-8",
+    )
+    deep_dive = vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "Harness Deep Dive_深度解读.md"
+    deep_dive.parent.mkdir(parents=True, exist_ok=True)
+    deep_dive.write_text(
+        """---
+note_id: harness-deep-dive
+title: Harness Deep Dive
+type: deep_dive
+source: https://example.com/another-harness
+date: 2026-04-13
+---
+
+# Harness Deep Dive
+
+Mentions [[source-note]] but has not produced any evergreen objects yet.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(vault)
+    truth_api.sync_signal_ledger(vault)
+
+    monkeypatch.setattr(truth_api, "_run_deep_dive_workflow_action", lambda vault_dir, action: {"ok": "deep_dive"})
+    monkeypatch.setattr(truth_api, "_run_object_extraction_workflow_action", lambda vault_dir, action: {"ok": "objects"})
+    monkeypatch.setattr(truth_api, "_refresh_truth_after_action", lambda vault_dir: None)
+
+    payload = truth_api.run_action_queue(vault, limit=5)
+    actions = truth_api.list_action_queue(vault)
+
+    assert payload["ran_count"] == 2
+    assert payload["stopped_reason"] == "no_queued_actions"
+    assert {item["status"] for item in actions} == {"succeeded"}
+
+
 def test_truth_api_builds_briefing_snapshot(temp_vault):
     from openclaw_pipeline.truth_api import get_briefing_snapshot, record_review_action, sync_signal_ledger
 

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import contextmanager
 import json
 from pathlib import Path
 
@@ -1833,3 +1834,50 @@ def test_truth_api_includes_review_action_signals(temp_vault):
     reviewed = next(item for item in items if item["signal_type"] == "contradiction_reviewed")
     assert reviewed["object_ids"] == ["source-note"]
     assert reviewed["source_path"] == "/contradictions?status=resolved"
+
+
+def test_truth_api_sync_signal_ledger_acquires_single_writer_lock(temp_vault, monkeypatch):
+    from openclaw_pipeline import truth_api
+
+    vault = _seed_truth_vault(temp_vault)
+    calls: list[str] = []
+
+    @contextmanager
+    def fake_lock(vault_dir, *, timeout_seconds=300.0):
+        calls.append(f"enter:{vault_dir == vault}")
+        yield
+        calls.append("exit")
+
+    monkeypatch.setattr(truth_api, "knowledge_db_write_lock", fake_lock)
+
+    truth_api.sync_signal_ledger(vault)
+
+    assert calls == ["enter:True", "exit"]
+
+
+def test_truth_api_record_review_action_acquires_single_writer_lock(temp_vault, monkeypatch):
+    from openclaw_pipeline import truth_api
+
+    vault = _seed_truth_vault(temp_vault)
+    calls: list[str] = []
+
+    @contextmanager
+    def fake_lock(vault_dir, *, timeout_seconds=300.0):
+        calls.append(f"enter:{vault_dir == vault}")
+        yield
+        calls.append("exit")
+
+    monkeypatch.setattr(truth_api, "knowledge_db_write_lock", fake_lock)
+
+    truth_api.record_review_action(
+        vault,
+        event_type="ui_summaries_rebuilt",
+        slug="source-note",
+        payload={
+            "object_ids": ["source-note"],
+            "objects_rebuilt": 1,
+            "rebuilt_object_ids": ["source-note"],
+        },
+    )
+
+    assert calls == ["enter:True", "exit"]

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -351,6 +351,65 @@ Source note confirms the local-first rollout guidance from independent testing.
     assert {"replaces", "enriches", "confirms", "challenges"}.issubset(link_types)
 
 
+def test_truth_api_scopes_evolution_candidate_traceability_to_requested_objects(temp_vault, monkeypatch):
+    from openclaw_pipeline import truth_api
+
+    vault = _seed_truth_vault(temp_vault)
+    observed_object_ids: list[str] = []
+    original = truth_api.get_object_traceability
+
+    def counted_get_object_traceability(vault_dir, object_id):
+        observed_object_ids.append(object_id)
+        return original(vault_dir, object_id)
+
+    monkeypatch.setattr(truth_api, "get_object_traceability", counted_get_object_traceability)
+
+    items = truth_api.list_evolution_candidates(vault, object_ids=["source-note"])
+
+    assert items
+    assert set(observed_object_ids) == {"source-note"}
+    assert all("source-note" in item["object_ids"] for item in items)
+
+
+def test_truth_api_ignores_missing_objects_in_evolution_object_pool(temp_vault):
+    from openclaw_pipeline.truth_api import list_evolution_candidates
+
+    vault = _seed_truth_vault(temp_vault)
+    deep_dive = vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "Ghost Dive_深度解读.md"
+    deep_dive.parent.mkdir(parents=True, exist_ok=True)
+    deep_dive.write_text(
+        """---
+note_id: ghost-dive
+title: Ghost Dive
+type: deep_dive
+date: 2026-04-14
+---
+
+# Ghost Dive
+""",
+        encoding="utf-8",
+    )
+    (vault / "60-Logs").mkdir(parents=True, exist_ok=True)
+    (vault / "60-Logs" / "pipeline.jsonl").write_text(
+        json.dumps(
+            {
+                "event_type": "evergreen_auto_promoted",
+                "concept": "ghost-object",
+                "source": "Ghost Dive_深度解读.md",
+                "mutation": {"target_slug": "ghost-object"},
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(vault)
+
+    items = list_evolution_candidates(vault)
+
+    assert all("ghost-object" not in item["object_ids"] for item in items)
+
+
 def test_truth_api_reviews_evolution_candidate_and_lists_links(temp_vault):
     from openclaw_pipeline.truth_api import list_evolution_candidates, list_evolution_links, review_evolution_candidate
 
@@ -1563,6 +1622,9 @@ Thin.
     assert payload["unresolved_issues"]
     assert any(item["object_id"] == "source-note" for item in payload["changed_objects"])
     assert payload["active_topics"]
+    assert payload["insights"]
+    assert payload["priority_items"]
+    assert payload["first_useful_sign"] in payload["insights"]
 
 
 def test_truth_api_includes_review_action_signals(temp_vault):

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -244,6 +244,62 @@ def test_truth_api_filters_contradictions_by_query(temp_vault):
     assert items[0]["subject_key"] == "agent harness"
 
 
+def test_truth_api_filters_contradictions_by_resolved_status_after_overrides(temp_vault):
+    from openclaw_pipeline.truth_api import list_contradictions, record_review_action
+
+    vault = _seed_truth_vault(temp_vault)
+    positive = vault / "10-Knowledge" / "Evergreen" / "Zeta Positive.md"
+    negative = vault / "10-Knowledge" / "Evergreen" / "Zeta Negative.md"
+    positive.write_text(
+        """---
+note_id: zeta-positive
+title: Zeta Positive
+type: evergreen
+date: 2026-04-13
+---
+
+# Zeta Positive
+
+Zeta platform supports high-trust execution for operators.
+""",
+        encoding="utf-8",
+    )
+    negative.write_text(
+        """---
+note_id: zeta-negative
+title: Zeta Negative
+type: evergreen
+date: 2026-04-13
+---
+
+# Zeta Negative
+
+Zeta platform does not support high-trust execution for operators.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(vault)
+    contradiction = next(item for item in list_contradictions(vault, limit=10) if item["subject_key"] == "zeta platform")
+    record_review_action(
+        vault,
+        event_type="ui_contradictions_resolved",
+        slug="zeta-positive",
+        payload={
+            "object_ids": ["zeta-negative", "zeta-positive"],
+            "contradiction_ids": [contradiction["contradiction_id"]],
+            "status": "dismissed",
+            "note": "",
+            "rebuilt_object_ids": [],
+        },
+    )
+
+    items = list_contradictions(vault, status="resolved", limit=1)
+
+    assert len(items) == 1
+    assert items[0]["subject_key"] == "zeta platform"
+    assert items[0]["status"] == "dismissed"
+
+
 def test_truth_api_lists_evolution_candidates_from_open_contradictions(temp_vault):
     from openclaw_pipeline.truth_api import list_evolution_candidates
 

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -1642,6 +1642,40 @@ Thin.
     assert any(item.get("recommended_action") for item in payload["priority_items"])
 
 
+def test_truth_api_enqueues_signal_actions_idempotently(temp_vault):
+    from openclaw_pipeline.truth_api import enqueue_signal_action, list_action_queue, list_signals, sync_signal_ledger
+
+    vault = _seed_truth_vault(temp_vault)
+    processed = vault / "50-Inbox" / "03-Processed" / "2026-04" / "Harness Source.md"
+    processed.parent.mkdir(parents=True, exist_ok=True)
+    processed.write_text(
+        """---
+title: Harness Source
+source: https://example.com/harness
+---
+
+Processed source note without any derived deep dive.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(vault)
+    sync_signal_ledger(vault)
+    source_signal = next(item for item in list_signals(vault) if item["signal_type"] == "source_needs_deep_dive")
+
+    first = enqueue_signal_action(vault, signal_id=source_signal["signal_id"])
+    second = enqueue_signal_action(vault, signal_id=source_signal["signal_id"])
+    actions = list_action_queue(vault)
+    refreshed_signal = next(item for item in list_signals(vault) if item["signal_id"] == source_signal["signal_id"])
+
+    assert first["created"] is True
+    assert second["created"] is False
+    assert first["action"]["action_id"] == second["action"]["action_id"]
+    assert len(actions) == 1
+    assert actions[0]["status"] == "queued"
+    assert refreshed_signal["recommended_action"]["queue_status"] == "queued"
+    assert refreshed_signal["recommended_action"]["action_id"] == actions[0]["action_id"]
+
+
 def test_truth_api_includes_review_action_signals(temp_vault):
     from openclaw_pipeline.truth_api import list_signals, record_review_action, sync_signal_ledger
 

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -1855,6 +1855,7 @@ Processed source note without any derived deep dive.
     assert payload["retried"] is True
     assert payload["action"]["status"] == "queued"
     assert payload["action"]["error"] == ""
+    assert payload["action"]["failure_bucket"] == ""
     assert payload["action"]["started_at"] == ""
     assert payload["action"]["finished_at"] == ""
     assert retried_action["status"] == "queued"
@@ -1933,8 +1934,103 @@ Mentions [[source-note]] but has not produced any evergreen objects yet.
     actions = truth_api.list_action_queue(vault)
 
     assert payload["ran_count"] == 2
+    assert payload["safe_only"] is False
     assert payload["stopped_reason"] == "no_queued_actions"
     assert {item["status"] for item in actions} == {"succeeded"}
+
+
+def test_truth_api_failed_action_tracks_retry_count_and_failure_bucket(temp_vault, monkeypatch):
+    import openclaw_pipeline.truth_api as truth_api
+
+    vault = _seed_truth_vault(temp_vault)
+    processed = vault / "50-Inbox" / "03-Processed" / "2026-04" / "Harness Source.md"
+    processed.parent.mkdir(parents=True, exist_ok=True)
+    processed.write_text(
+        """---
+title: Harness Source
+source: https://example.com/harness
+---
+
+Processed source note without any derived deep dive.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(vault)
+    truth_api.sync_signal_ledger(vault)
+
+    monkeypatch.setattr(
+        truth_api,
+        "_run_deep_dive_workflow_action",
+        lambda vault_dir, action: (_ for _ in ()).throw(FileNotFoundError("source note not found")),
+    )
+
+    payload = truth_api.run_next_action_queue_item(vault, safe_only=True)
+    failed_action = truth_api.list_action_queue(vault)[0]
+
+    assert payload["ran"] is False
+    assert payload["safe_only"] is True
+    assert failed_action["status"] == "failed"
+    assert failed_action["retry_count"] == 1
+    assert failed_action["failure_bucket"] == "missing_target"
+
+
+def test_truth_api_run_action_queue_can_limit_to_safe_actions(temp_vault, monkeypatch):
+    import openclaw_pipeline.truth_api as truth_api
+
+    logs_dir = temp_vault / "60-Logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    (logs_dir / "actions.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "action_id": "action::manual",
+                        "action_kind": "review_contradiction",
+                        "source_signal_id": "signal::manual",
+                        "title": "Manual review",
+                        "target_ref": "/contradictions",
+                        "status": "queued",
+                        "created_at": "2026-04-15T00:00:00Z",
+                        "retry_count": 0,
+                        "failure_bucket": "",
+                        "safe_to_run": False,
+                    },
+                    ensure_ascii=False,
+                ),
+                json.dumps(
+                    {
+                        "action_id": "action::safe",
+                        "action_kind": "deep_dive_workflow",
+                        "source_signal_id": "signal::safe",
+                        "title": "Safe action",
+                        "target_ref": "50-Inbox/03-Processed/Harness.md",
+                        "status": "queued",
+                        "created_at": "2026-04-15T00:00:01Z",
+                        "retry_count": 0,
+                        "failure_bucket": "",
+                        "safe_to_run": True,
+                    },
+                    ensure_ascii=False,
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(truth_api, "_signal_by_id", lambda vault_dir, signal_id: {"signal_id": signal_id})
+    monkeypatch.setattr(truth_api, "_run_deep_dive_workflow_action", lambda vault_dir, action: {"ok": True})
+    monkeypatch.setattr(truth_api, "_refresh_truth_after_action", lambda vault_dir: None)
+
+    payload = truth_api.run_action_queue(temp_vault, limit=1, safe_only=True)
+    actions = truth_api.list_action_queue(temp_vault)
+    safe = next(item for item in actions if item["action_id"] == "action::safe")
+    manual = next(item for item in actions if item["action_id"] == "action::manual")
+
+    assert payload["safe_only"] is True
+    assert payload["ran_count"] == 1
+    assert safe["status"] == "succeeded"
+    assert manual["status"] == "queued"
 
 
 def test_truth_api_builds_briefing_snapshot(temp_vault):

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -370,6 +370,47 @@ Processed source note without downstream chain.
     assert payload["action"]["status"] == "queued"
 
 
+def test_ui_server_can_run_next_action_via_api(temp_vault, monkeypatch):
+    import openclaw_pipeline.commands.ui_server as ui_server
+    from openclaw_pipeline.commands.ui_server import create_server
+
+    monkeypatch.setattr(
+        ui_server,
+        "run_next_action_queue_item",
+        lambda vault_dir: {
+            "ran": True,
+            "action": {
+                "action_id": "action::demo",
+                "action_kind": "deep_dive_workflow",
+                "status": "succeeded",
+            },
+        },
+    )
+
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request(
+            "POST",
+            "/api/actions/run-next",
+            body="",
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        response = conn.getresponse()
+        payload = json.loads(response.read().decode("utf-8"))
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 200
+    assert payload["ran"] is True
+    assert payload["action"]["status"] == "succeeded"
+
+
 def test_ui_server_can_resolve_contradiction_via_api(temp_vault):
     from openclaw_pipeline.commands.ui_server import create_server
     from openclaw_pipeline.runtime import VaultLayout

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -377,8 +377,9 @@ def test_ui_server_can_run_next_action_via_api(temp_vault, monkeypatch):
     monkeypatch.setattr(
         ui_server,
         "run_next_action_queue_item",
-        lambda vault_dir: {
+        lambda vault_dir, *, safe_only=False: {
             "ran": True,
+            "safe_only": safe_only,
             "action": {
                 "action_id": "action::demo",
                 "action_kind": "deep_dive_workflow",
@@ -418,11 +419,12 @@ def test_ui_server_can_run_action_batch_via_api(temp_vault, monkeypatch):
     monkeypatch.setattr(
         ui_server,
         "run_action_queue",
-        lambda vault_dir, *, limit: {
+        lambda vault_dir, *, limit, safe_only=False: {
             "ran_count": 2,
             "stopped_reason": "no_queued_actions",
             "results": [],
             "limit": limit,
+            "safe_only": safe_only,
         },
     )
 
@@ -449,6 +451,44 @@ def test_ui_server_can_run_action_batch_via_api(temp_vault, monkeypatch):
     assert response.status == 200
     assert payload["ran_count"] == 2
     assert payload["limit"] == 5
+
+
+def test_ui_server_can_run_safe_action_batch_via_api(temp_vault, monkeypatch):
+    import openclaw_pipeline.commands.ui_server as ui_server
+    from openclaw_pipeline.commands.ui_server import create_server
+
+    monkeypatch.setattr(
+        ui_server,
+        "run_action_queue",
+        lambda vault_dir, *, limit, safe_only=False: {
+            "ran_count": 1,
+            "limit": limit,
+            "safe_only": safe_only,
+        },
+    )
+
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        body = urlencode({"limit": "5", "safe_only": "1"})
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request(
+            "POST",
+            "/api/actions/run-batch",
+            body=body,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        response = conn.getresponse()
+        payload = json.loads(response.read().decode("utf-8"))
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 200
+    assert payload["safe_only"] is True
 
 
 def test_ui_server_can_retry_action_via_api(temp_vault, monkeypatch):

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -707,6 +707,16 @@ def test_ui_server_main_starts_server_with_requested_bind(temp_vault, capsys, mo
         "openclaw_pipeline.commands.ui_server._start_ui_prewarm",
         lambda vault_dir: calls.setdefault("prewarm_vault_dir", str(vault_dir)),
     )
+    monkeypatch.setattr(
+        "openclaw_pipeline.commands.ui_server._start_action_dispatcher",
+        lambda vault_dir, *, interval_seconds: calls.setdefault(
+            "dispatcher", {"vault_dir": str(vault_dir), "interval_seconds": interval_seconds}
+        ),
+    )
+    monkeypatch.setattr(
+        "openclaw_pipeline.commands.ui_server._stop_action_dispatcher",
+        lambda dispatcher: calls.setdefault("dispatcher_stopped", dispatcher is None or True),
+    )
 
     exit_code = main(["--vault-dir", str(temp_vault), "--host", "127.0.0.1", "--port", "9999"])
     payload = json.loads(capsys.readouterr().out)
@@ -718,8 +728,67 @@ def test_ui_server_main_starts_server_with_requested_bind(temp_vault, capsys, mo
         "host": "127.0.0.1",
         "port": 9999,
         "prewarm_vault_dir": str(temp_vault),
+        "dispatcher_stopped": True,
         "closed": True,
     }
+
+
+def test_ui_server_main_can_start_action_dispatcher_when_enabled(temp_vault, capsys, monkeypatch):
+    from openclaw_pipeline.commands.ui_server import main
+
+    calls = {}
+
+    class FakeServer:
+        def serve_forever(self):
+            raise KeyboardInterrupt
+
+        def server_close(self):
+            calls["closed"] = True
+
+    def fake_create_server(vault_dir, *, host, port):
+        calls["vault_dir"] = str(vault_dir)
+        calls["host"] = host
+        calls["port"] = port
+        return FakeServer()
+
+    monkeypatch.setattr("openclaw_pipeline.commands.ui_server.create_server", fake_create_server)
+    monkeypatch.setattr(
+        "openclaw_pipeline.commands.ui_server.build_objects_index_payload",
+        lambda vault_dir, *, limit, offset: {"items": []},
+    )
+    monkeypatch.setattr(
+        "openclaw_pipeline.commands.ui_server.ensure_signal_ledger_synced",
+        lambda vault_dir: {"signal_count": 0, "type_counts": {}},
+    )
+    monkeypatch.setattr(
+        "openclaw_pipeline.commands.ui_server._start_ui_prewarm",
+        lambda vault_dir: None,
+    )
+    monkeypatch.setattr(
+        "openclaw_pipeline.commands.ui_server._start_action_dispatcher",
+        lambda vault_dir, *, interval_seconds: {"worker": True, "interval_seconds": interval_seconds},
+    )
+    monkeypatch.setattr(
+        "openclaw_pipeline.commands.ui_server._stop_action_dispatcher",
+        lambda dispatcher: calls.setdefault("dispatcher_stopped", dispatcher["worker"]),
+    )
+
+    exit_code = main(
+        [
+            "--vault-dir",
+            str(temp_vault),
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "9999",
+            "--with-action-worker",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload == {"host": "127.0.0.1", "port": 9999, "vault_dir": str(temp_vault)}
+    assert calls["dispatcher_stopped"] is True
 
 
 def test_ui_server_main_exits_nonzero_when_preflight_fails(temp_vault, capsys, monkeypatch):

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -791,6 +791,52 @@ def test_ui_server_main_can_start_action_dispatcher_when_enabled(temp_vault, cap
     assert calls["dispatcher_stopped"] is True
 
 
+def test_ui_server_action_dispatcher_runs_actions_in_subprocess(temp_vault, monkeypatch):
+    from openclaw_pipeline.commands import ui_server
+
+    calls = {}
+
+    class FakeStopEvent:
+        def __init__(self):
+            self._is_set = False
+
+        def is_set(self):
+            return self._is_set
+
+        def wait(self, timeout):
+            calls["wait_timeout"] = timeout
+            self._is_set = True
+            return True
+
+    def fake_run(cmd, *, capture_output, text, timeout):
+        calls["cmd"] = cmd
+        calls["capture_output"] = capture_output
+        calls["text"] = text
+        calls["timeout"] = timeout
+
+        class Result:
+            returncode = 0
+            stdout = '{"status":"idle"}'
+            stderr = ""
+
+        return Result()
+
+    monkeypatch.setattr(ui_server.subprocess, "run", fake_run)
+
+    ui_server._action_dispatcher_loop(
+        temp_vault,
+        stop_event=FakeStopEvent(),
+        interval_seconds=3.5,
+    )
+
+    assert calls["cmd"][1:4] == ["-m", "openclaw_pipeline.commands.run_actions", "--vault-dir"]
+    assert calls["cmd"][-1] == "--once"
+    assert calls["capture_output"] is True
+    assert calls["text"] is True
+    assert calls["timeout"] == 1800
+    assert calls["wait_timeout"] == 3.5
+
+
 def test_ui_server_main_exits_nonzero_when_preflight_fails(temp_vault, capsys, monkeypatch):
     from openclaw_pipeline.commands.ui_server import main
 

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -530,6 +530,7 @@ def test_ui_server_can_dismiss_action_via_api(temp_vault, monkeypatch):
 def test_ui_server_can_resolve_contradiction_via_api(temp_vault):
     from openclaw_pipeline.commands.ui_server import create_server
     from openclaw_pipeline.runtime import VaultLayout
+    from openclaw_pipeline.truth_api import list_contradictions
 
     _seed_truth_store(temp_vault)
     layout = VaultLayout.from_vault(temp_vault)
@@ -568,23 +569,12 @@ def test_ui_server_can_resolve_contradiction_via_api(temp_vault):
     assert payload["contradiction_ids"] == [contradiction_id]
     assert payload["rebuilt_summary_count"] == 2
 
-    with sqlite3.connect(layout.knowledge_db) as conn:
-        row = conn.execute(
-            "SELECT status, resolution_note FROM contradictions WHERE contradiction_id = ?",
-            (contradiction_id,),
-        ).fetchone()
-        audit_row = conn.execute(
-            """
-            SELECT event_type, payload_json
-            FROM audit_events
-            WHERE source_log = 'review-actions'
-            ORDER BY timestamp DESC
-            LIMIT 1
-            """
-        ).fetchone()
-    assert row == ("resolved_keep_positive", "Reviewed in UI")
-    assert audit_row is not None
-    assert audit_row[0] == "ui_contradictions_resolved"
+    review_log = (layout.logs_dir / "review-actions.jsonl").read_text(encoding="utf-8").splitlines()
+    latest_review = json.loads(review_log[-1])
+    contradiction = next(item for item in list_contradictions(temp_vault, status="resolved") if item["contradiction_id"] == contradiction_id)
+    assert contradiction["status"] == "resolved_keep_positive"
+    assert contradiction["resolution_note"] == "Reviewed in UI"
+    assert latest_review["event_type"] == "ui_contradictions_resolved"
 
 
 def test_ui_server_can_bulk_resolve_contradictions_via_api(temp_vault):
@@ -703,18 +693,11 @@ Thin note.
     assert response.status == 200
     assert payload["objects_rebuilt"] == 1
     assert payload["object_ids"] == ["thin-note"]
-    with sqlite3.connect(VaultLayout.from_vault(temp_vault).knowledge_db) as conn:
-        audit_row = conn.execute(
-            """
-            SELECT event_type, payload_json
-            FROM audit_events
-            WHERE source_log = 'review-actions'
-            ORDER BY timestamp DESC
-            LIMIT 1
-            """
-        ).fetchone()
-    assert audit_row is not None
-    assert audit_row[0] == "ui_summaries_rebuilt"
+    review_log = (
+        VaultLayout.from_vault(temp_vault).logs_dir / "review-actions.jsonl"
+    ).read_text(encoding="utf-8").splitlines()
+    latest_review = json.loads(review_log[-1])
+    assert latest_review["event_type"] == "ui_summaries_rebuilt"
 
 
 def test_ui_server_can_bulk_rebuild_summaries_via_api(temp_vault):
@@ -823,16 +806,6 @@ def test_ui_server_main_starts_server_with_requested_bind(temp_vault, capsys, mo
         "openclaw_pipeline.commands.ui_server._start_ui_prewarm",
         lambda vault_dir: calls.setdefault("prewarm_vault_dir", str(vault_dir)),
     )
-    monkeypatch.setattr(
-        "openclaw_pipeline.commands.ui_server._start_action_dispatcher",
-        lambda vault_dir, *, interval_seconds: calls.setdefault(
-            "dispatcher", {"vault_dir": str(vault_dir), "interval_seconds": interval_seconds}
-        ),
-    )
-    monkeypatch.setattr(
-        "openclaw_pipeline.commands.ui_server._stop_action_dispatcher",
-        lambda dispatcher: calls.setdefault("dispatcher_stopped", dispatcher is None or True),
-    )
 
     exit_code = main(["--vault-dir", str(temp_vault), "--host", "127.0.0.1", "--port", "9999"])
     payload = json.loads(capsys.readouterr().out)
@@ -844,12 +817,11 @@ def test_ui_server_main_starts_server_with_requested_bind(temp_vault, capsys, mo
         "host": "127.0.0.1",
         "port": 9999,
         "prewarm_vault_dir": str(temp_vault),
-        "dispatcher_stopped": True,
         "closed": True,
     }
 
 
-def test_ui_server_main_can_start_action_dispatcher_when_enabled(temp_vault, capsys, monkeypatch):
+def test_ui_server_main_can_spawn_detached_action_worker_when_enabled(temp_vault, capsys, monkeypatch):
     from openclaw_pipeline.commands.ui_server import main
 
     calls = {}
@@ -881,12 +853,8 @@ def test_ui_server_main_can_start_action_dispatcher_when_enabled(temp_vault, cap
         lambda vault_dir: None,
     )
     monkeypatch.setattr(
-        "openclaw_pipeline.commands.ui_server._start_action_dispatcher",
-        lambda vault_dir, *, interval_seconds: {"worker": True, "interval_seconds": interval_seconds},
-    )
-    monkeypatch.setattr(
-        "openclaw_pipeline.commands.ui_server._stop_action_dispatcher",
-        lambda dispatcher: calls.setdefault("dispatcher_stopped", dispatcher["worker"]),
+        "openclaw_pipeline.commands.ui_server.subprocess.Popen",
+        lambda cmd, **kwargs: calls.setdefault("worker_process", {"cmd": cmd, "kwargs": kwargs}),
     )
 
     exit_code = main(
@@ -904,53 +872,9 @@ def test_ui_server_main_can_start_action_dispatcher_when_enabled(temp_vault, cap
 
     assert exit_code == 0
     assert payload == {"host": "127.0.0.1", "port": 9999, "vault_dir": str(temp_vault)}
-    assert calls["dispatcher_stopped"] is True
-
-
-def test_ui_server_action_dispatcher_runs_actions_in_subprocess(temp_vault, monkeypatch):
-    from openclaw_pipeline.commands import ui_server
-
-    calls = {}
-
-    class FakeStopEvent:
-        def __init__(self):
-            self._is_set = False
-
-        def is_set(self):
-            return self._is_set
-
-        def wait(self, timeout):
-            calls["wait_timeout"] = timeout
-            self._is_set = True
-            return True
-
-    def fake_run(cmd, *, capture_output, text, timeout):
-        calls["cmd"] = cmd
-        calls["capture_output"] = capture_output
-        calls["text"] = text
-        calls["timeout"] = timeout
-
-        class Result:
-            returncode = 0
-            stdout = '{"status":"idle"}'
-            stderr = ""
-
-        return Result()
-
-    monkeypatch.setattr(ui_server.subprocess, "run", fake_run)
-
-    ui_server._action_dispatcher_loop(
-        temp_vault,
-        stop_event=FakeStopEvent(),
-        interval_seconds=3.5,
-    )
-
-    assert calls["cmd"][1:4] == ["-m", "openclaw_pipeline.commands.run_actions", "--vault-dir"]
-    assert calls["cmd"][-1] == "--once"
-    assert calls["capture_output"] is True
-    assert calls["text"] is True
-    assert calls["timeout"] == 1800
-    assert calls["wait_timeout"] == 3.5
+    assert calls["worker_process"]["cmd"][1:4] == ["-m", "openclaw_pipeline.commands.run_actions", "--vault-dir"]
+    assert "--loop" in calls["worker_process"]["cmd"]
+    assert calls["worker_process"]["kwargs"]["start_new_session"] is True
 
 
 def test_ui_server_main_exits_nonzero_when_preflight_fails(temp_vault, capsys, monkeypatch):

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -411,6 +411,122 @@ def test_ui_server_can_run_next_action_via_api(temp_vault, monkeypatch):
     assert payload["action"]["status"] == "succeeded"
 
 
+def test_ui_server_can_run_action_batch_via_api(temp_vault, monkeypatch):
+    import openclaw_pipeline.commands.ui_server as ui_server
+    from openclaw_pipeline.commands.ui_server import create_server
+
+    monkeypatch.setattr(
+        ui_server,
+        "run_action_queue",
+        lambda vault_dir, *, limit: {
+            "ran_count": 2,
+            "stopped_reason": "no_queued_actions",
+            "results": [],
+            "limit": limit,
+        },
+    )
+
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        body = urlencode({"limit": "5"})
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request(
+            "POST",
+            "/api/actions/run-batch",
+            body=body,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        response = conn.getresponse()
+        payload = json.loads(response.read().decode("utf-8"))
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 200
+    assert payload["ran_count"] == 2
+    assert payload["limit"] == 5
+
+
+def test_ui_server_can_retry_action_via_api(temp_vault, monkeypatch):
+    import openclaw_pipeline.commands.ui_server as ui_server
+    from openclaw_pipeline.commands.ui_server import create_server
+
+    monkeypatch.setattr(
+        ui_server,
+        "retry_action_queue_item",
+        lambda vault_dir, *, action_id: {
+            "retried": True,
+            "action": {"action_id": action_id, "status": "queued"},
+        },
+    )
+
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        body = urlencode({"action_id": "action::demo"})
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request(
+            "POST",
+            "/api/actions/retry",
+            body=body,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        response = conn.getresponse()
+        payload = json.loads(response.read().decode("utf-8"))
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 200
+    assert payload["retried"] is True
+    assert payload["action"]["status"] == "queued"
+
+
+def test_ui_server_can_dismiss_action_via_api(temp_vault, monkeypatch):
+    import openclaw_pipeline.commands.ui_server as ui_server
+    from openclaw_pipeline.commands.ui_server import create_server
+
+    monkeypatch.setattr(
+        ui_server,
+        "dismiss_action_queue_item",
+        lambda vault_dir, *, action_id: {
+            "dismissed": True,
+            "action": {"action_id": action_id, "status": "dismissed"},
+        },
+    )
+
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        body = urlencode({"action_id": "action::demo"})
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request(
+            "POST",
+            "/api/actions/dismiss",
+            body=body,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        response = conn.getresponse()
+        payload = json.loads(response.read().decode("utf-8"))
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 200
+    assert payload["dismissed"] is True
+    assert payload["action"]["status"] == "dismissed"
+
+
 def test_ui_server_can_resolve_contradiction_via_api(temp_vault):
     from openclaw_pipeline.commands.ui_server import create_server
     from openclaw_pipeline.runtime import VaultLayout

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -324,6 +324,52 @@ def test_ui_server_briefing_endpoint_returns_payload(temp_vault):
     assert payload["active_topics"]
 
 
+def test_ui_server_can_enqueue_signal_action_via_api(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+    from openclaw_pipeline.truth_api import list_signals
+
+    _seed_truth_store(temp_vault)
+    loose_source = temp_vault / "50-Inbox" / "03-Processed" / "2026-04" / "Loose Source.md"
+    loose_source.parent.mkdir(parents=True, exist_ok=True)
+    loose_source.write_text(
+        """---
+title: Loose Source
+source: https://example.com/loose
+---
+
+Processed source note without downstream chain.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+    source_signal = next(
+        item for item in list_signals(temp_vault) if item["signal_type"] == "source_needs_deep_dive"
+    )
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        body = urlencode({"signal_id": source_signal["signal_id"]})
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request(
+            "POST",
+            "/api/actions/enqueue",
+            body=body,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        response = conn.getresponse()
+        payload = json.loads(response.read().decode("utf-8"))
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 200
+    assert payload["created"] is True
+    assert payload["action"]["status"] == "queued"
+
+
 def test_ui_server_can_resolve_contradiction_via_api(temp_vault):
     from openclaw_pipeline.commands.ui_server import create_server
     from openclaw_pipeline.runtime import VaultLayout

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -616,6 +616,10 @@ def test_ui_server_main_starts_server_with_requested_bind(temp_vault, capsys, mo
         "openclaw_pipeline.commands.ui_server.ensure_signal_ledger_synced",
         lambda vault_dir: {"signal_count": 0, "type_counts": {}},
     )
+    monkeypatch.setattr(
+        "openclaw_pipeline.commands.ui_server._start_ui_prewarm",
+        lambda vault_dir: calls.setdefault("prewarm_vault_dir", str(vault_dir)),
+    )
 
     exit_code = main(["--vault-dir", str(temp_vault), "--host", "127.0.0.1", "--port", "9999"])
     payload = json.loads(capsys.readouterr().out)
@@ -626,6 +630,7 @@ def test_ui_server_main_starts_server_with_requested_bind(temp_vault, capsys, mo
         "vault_dir": str(temp_vault),
         "host": "127.0.0.1",
         "port": 9999,
+        "prewarm_vault_dir": str(temp_vault),
         "closed": True,
     }
 

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -366,7 +366,7 @@ Processed source note without downstream chain.
         thread.join(timeout=5)
 
     assert response.status == 200
-    assert payload["created"] is True
+    assert payload["created"] is False
     assert payload["action"]["status"] == "queued"
 
 

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -1047,6 +1047,7 @@ Processed source note without downstream chain.
     assert "contradiction_open" in body
     assert "production_gap" in body
     assert "summary_rebuilt" in body
+    assert "Recommended Action" in body
 
 
 def test_ui_signals_page_renders_extraction_trigger_signals(temp_vault):
@@ -1095,6 +1096,8 @@ date: 2026-04-13
     assert status == 200
     assert "source_needs_deep_dive" in body
     assert "deep_dive_needs_objects" in body
+    assert "Create deep dive" in body
+    assert "Extract evergreen objects" in body
 
 
 def test_ui_briefing_page_renders_briefing_snapshot(temp_vault):
@@ -1129,6 +1132,7 @@ def test_ui_briefing_page_renders_briefing_snapshot(temp_vault):
     assert "First Useful Sign" in body
     assert "Insights" in body
     assert "Priority Items" in body
+    assert "Recommended Action" in body
     assert "Recent Signals" in body
     assert "Active Topics" in body
 

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -1133,8 +1133,46 @@ def test_ui_briefing_page_renders_briefing_snapshot(temp_vault):
     assert "Insights" in body
     assert "Priority Items" in body
     assert "Recommended Action" in body
-    assert "Recent Signals" in body
-    assert "Active Topics" in body
+
+
+def test_ui_actions_page_renders_queued_signal_actions(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+    from openclaw_pipeline.truth_api import enqueue_signal_action, list_signals
+
+    _seed_truth_store(temp_vault)
+    loose_source = temp_vault / "50-Inbox" / "03-Processed" / "2026-04" / "Loose Source.md"
+    loose_source.parent.mkdir(parents=True, exist_ok=True)
+    loose_source.write_text(
+        """---
+title: Loose Source
+source: https://example.com/loose
+---
+
+Processed source note without downstream chain.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+    source_signal = next(
+        item for item in list_signals(temp_vault) if item["signal_type"] == "source_needs_deep_dive"
+    )
+    enqueue_signal_action(temp_vault, signal_id=source_signal["signal_id"])
+
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        status, body = _get(port, "/actions")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert status == 200
+    assert "Action Queue" in body
+    assert "Create deep dive" in body
+    assert "queued" in body
 
 
 def test_ui_contradictions_and_summaries_support_batch_actions(temp_vault):

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -1174,6 +1174,7 @@ Processed source note without downstream chain.
     assert "Create deep dive" in body
     assert "queued" in body
     assert "Run next queued action" in body
+    assert "Run 5 queued actions" in body
 
 
 def test_ui_contradictions_and_summaries_support_batch_actions(temp_vault):

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -1126,6 +1126,9 @@ def test_ui_briefing_page_renders_briefing_snapshot(temp_vault):
 
     assert status == 200
     assert "Working Memory Snapshot" in body
+    assert "First Useful Sign" in body
+    assert "Insights" in body
+    assert "Priority Items" in body
     assert "Recent Signals" in body
     assert "Active Topics" in body
 

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -1173,6 +1173,7 @@ Processed source note without downstream chain.
     assert "Action Queue" in body
     assert "Create deep dive" in body
     assert "queued" in body
+    assert "Run next queued action" in body
 
 
 def test_ui_contradictions_and_summaries_support_batch_actions(temp_vault):

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -598,6 +598,7 @@ def test_build_briefing_payload(temp_vault):
     assert payload["active_topics"]
     assert payload["insights"]
     assert payload["priority_items"]
+    assert payload["queue_summary"]["queued_count"] >= 0
 
 
 def test_build_evolution_browser_payload(temp_vault):

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -592,10 +592,12 @@ def test_build_briefing_payload(temp_vault):
 
     payload = build_briefing_payload(temp_vault)
 
-    assert payload["screen"] == "briefing/snapshot"
+    assert payload["screen"] == "briefing/intelligence"
     assert payload["recent_signal_count"] >= 1
     assert payload["recent_signals"]
     assert payload["active_topics"]
+    assert payload["insights"]
+    assert payload["priority_items"]
 
 
 def test_build_evolution_browser_payload(temp_vault):


### PR DESCRIPTION
## Summary
- harden the action queue execution surface with safe-only execution and richer failure state
- expose queue execution summary in briefing and action surfaces
- carry retry counts and failure buckets through queue processing and UI

## What Changed
- added `safe_only` support to `run_next_action_queue_item`, batch queue execution, and the action worker CLI
- marked queue items with `safe_to_run`, `retry_count`, and `failure_bucket`
- surfaced queue summary data in briefing and richer action metadata in `/actions`
- added UI support for running safe-only batches from `/actions` and `/briefing`
- extended tests for failure classification, safe-only execution, and updated command/UI signatures

## Verification
- `PYTHONPATH=src python3.13 -m pytest -q` -> `454 passed`
- `python3.13 -m compileall src/openclaw_pipeline` -> passed

## Context
This lands the remaining Phase 14 execution-surface work after the earlier derived-db hardening changes. The queue now has a clearer lifecycle for safe automation versus manual follow-up, and briefing reflects that execution state directly.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/22" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
