### PR TITLE
Fix truth ledger review blockers

### DIFF
--- a/src/openclaw_pipeline/runtime.py
+++ b/src/openclaw_pipeline/runtime.py
@@ -74,6 +74,22 @@ class VaultLayout:
         return self.logs_dir / "knowledge.db.lock"
 
     @property
+    def signals_log(self) -> Path:
+        return self.logs_dir / "signals.jsonl"
+
+    @property
+    def signals_log_lock(self) -> Path:
+        return self.logs_dir / "signals.jsonl.lock"
+
+    @property
+    def actions_log(self) -> Path:
+        return self.logs_dir / "actions.jsonl"
+
+    @property
+    def actions_log_lock(self) -> Path:
+        return self.logs_dir / "actions.jsonl.lock"
+
+    @property
     def action_worker_lock(self) -> Path:
         return self.logs_dir / "action-worker.lock"
 
@@ -204,4 +220,26 @@ def knowledge_db_write_lock(
 ) -> Iterator[None]:
     layout = VaultLayout.from_vault(vault_dir)
     with advisory_file_lock(layout.knowledge_db_lock, timeout_seconds=timeout_seconds):
+        yield
+
+
+@contextmanager
+def signal_ledger_write_lock(
+    vault_dir: Path | str | None = None,
+    *,
+    timeout_seconds: float | None = 300.0,
+) -> Iterator[None]:
+    layout = VaultLayout.from_vault(vault_dir)
+    with advisory_file_lock(layout.signals_log_lock, timeout_seconds=timeout_seconds):
+        yield
+
+
+@contextmanager
+def action_queue_write_lock(
+    vault_dir: Path | str | None = None,
+    *,
+    timeout_seconds: float | None = 300.0,
+) -> Iterator[None]:
+    layout = VaultLayout.from_vault(vault_dir)
+    with advisory_file_lock(layout.actions_log_lock, timeout_seconds=timeout_seconds):
         yield

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -1530,7 +1530,7 @@ def dismiss_action_queue_item(vault_dir: Path | str, *, action_id: str) -> dict[
         action = _action_by_id_unlocked(vault_dir, action_id)
         if action is None:
             raise ValueError("unknown action_id")
-        if str(action.get("status") or "") in {"succeeded", "dismissed"}:
+        if str(action.get("status") or "") in {"running", "succeeded", "dismissed"}:
             raise ValueError("action is not dismissible")
         action["status"] = "dismissed"
         action["finished_at"] = _utc_now_text()

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from collections import Counter
 import hashlib
 import json
@@ -12,7 +12,13 @@ from urllib.parse import quote
 
 import yaml
 
-from .runtime import VaultLayout, knowledge_db_write_lock, resolve_vault_dir
+from .runtime import (
+    VaultLayout,
+    action_queue_write_lock,
+    knowledge_db_write_lock,
+    resolve_vault_dir,
+    signal_ledger_write_lock,
+)
 
 MAX_PAGE_SIZE = 500
 _FENCED_FRONTMATTER_RE = re.compile(r"^```ya?ml\s*\n---\n(.*?)\n---\n```\s*\n?", re.DOTALL)
@@ -70,6 +76,20 @@ _BRIEFING_EVOLUTION_PRIORITY = {
 def _db_path(vault_dir: Path | str) -> Path:
     resolved = resolve_vault_dir(vault_dir)
     return VaultLayout.from_vault(resolved).knowledge_db
+
+
+def _utc_now_text() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _action_queue_path(vault_dir: Path | str) -> Path:
+    resolved = resolve_vault_dir(vault_dir)
+    return VaultLayout.from_vault(resolved).actions_log
+
+
+def _signal_ledger_path(vault_dir: Path | str) -> Path:
+    resolved = resolve_vault_dir(vault_dir)
+    return VaultLayout.from_vault(resolved).signals_log
 
 
 def _read_jsonl_items(path: Path) -> list[dict[str, Any]]:
@@ -224,7 +244,7 @@ def record_review_action(
 ) -> dict[str, Any]:
     resolved_vault = resolve_vault_dir(vault_dir)
     layout = VaultLayout.from_vault(resolved_vault)
-    timestamp = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    timestamp = _utc_now_text()
     event = {
         "timestamp": timestamp,
         "session_id": session_id,
@@ -1278,16 +1298,12 @@ def _classify_action_error(error: str) -> str:
     return "workflow_failed"
 
 
-def _read_action_queue_rows(vault_dir: Path | str) -> list[dict[str, Any]]:
-    resolved_vault = resolve_vault_dir(vault_dir)
-    layout = VaultLayout.from_vault(resolved_vault)
-    return _read_jsonl_items(layout.logs_dir / f"{_ACTION_LOG_NAME}.jsonl")
+def _read_action_queue_rows_unlocked(vault_dir: Path | str) -> list[dict[str, Any]]:
+    return _read_jsonl_items(_action_queue_path(vault_dir))
 
 
-def _write_action_queue_rows(vault_dir: Path | str, actions: list[dict[str, Any]]) -> None:
-    resolved_vault = resolve_vault_dir(vault_dir)
-    layout = VaultLayout.from_vault(resolved_vault)
-    _rewrite_jsonl(layout.logs_dir / f"{_ACTION_LOG_NAME}.jsonl", actions)
+def _write_action_queue_rows_unlocked(vault_dir: Path | str, actions: list[dict[str, Any]]) -> None:
+    _rewrite_jsonl(_action_queue_path(vault_dir), actions)
 
 
 def list_action_queue(
@@ -1300,31 +1316,32 @@ def list_action_queue(
     limit, _ = _validate_page_args(limit=limit, offset=0)
     normalized_query = (query or "").strip().lower()
     items: list[dict[str, Any]] = []
-    for item in _read_action_queue_rows(vault_dir):
-        if status and item.get("status") != status:
-            continue
-        if normalized_query:
-            haystacks = [
-                str(item.get("title") or "").lower(),
-                str(item.get("action_kind") or "").lower(),
-                str(item.get("target_ref") or "").lower(),
-            ]
-            if not any(normalized_query in haystack for haystack in haystacks):
+    with action_queue_write_lock(vault_dir):
+        for item in _read_action_queue_rows_unlocked(vault_dir):
+            if status and item.get("status") != status:
                 continue
-        items.append(item)
-        if len(items) >= limit:
-            break
+            if normalized_query:
+                haystacks = [
+                    str(item.get("title") or "").lower(),
+                    str(item.get("action_kind") or "").lower(),
+                    str(item.get("target_ref") or "").lower(),
+                ]
+                if not any(normalized_query in haystack for haystack in haystacks):
+                    continue
+            items.append(item)
+            if len(items) >= limit:
+                break
     return items
 
 
 def _signal_by_id(vault_dir: Path | str, signal_id: str) -> dict[str, Any] | None:
-    layout = VaultLayout.from_vault(resolve_vault_dir(vault_dir))
-    ledger_path = layout.logs_dir / f"{_SIGNAL_LOG_NAME}.jsonl"
+    ledger_path = _signal_ledger_path(vault_dir)
     if not ledger_path.exists():
         ensure_signal_ledger_synced(vault_dir)
-    for item in _read_jsonl_items(ledger_path):
-        if item.get("signal_id") == signal_id:
-            return item
+    with signal_ledger_write_lock(vault_dir):
+        for item in _read_jsonl_items(ledger_path):
+            if item.get("signal_id") == signal_id:
+                return item
     return None
 
 
@@ -1337,19 +1354,20 @@ def enqueue_signal_action(
     signal = _signal_by_id(vault_dir, signal_id)
     if signal is None:
         raise ValueError("unknown signal_id")
-    existing_actions = _read_action_queue_rows(vault_dir)
-    created, action = _enqueue_action_from_signal(
-        signal,
-        existing_actions=existing_actions,
-        session_id=session_id,
-    )
-    if created:
-        existing_actions.append(action)
-        existing_actions.sort(
-            key=lambda item: (str(item.get("created_at", "")), str(item.get("action_id", ""))),
-            reverse=True,
+    with action_queue_write_lock(vault_dir):
+        existing_actions = _read_action_queue_rows_unlocked(vault_dir)
+        created, action = _enqueue_action_from_signal(
+            signal,
+            existing_actions=existing_actions,
+            session_id=session_id,
         )
-        _write_action_queue_rows(vault_dir, existing_actions)
+        if created:
+            existing_actions.append(action)
+            existing_actions.sort(
+                key=lambda item: (str(item.get("created_at", "")), str(item.get("action_id", ""))),
+                reverse=True,
+            )
+            _write_action_queue_rows_unlocked(vault_dir, existing_actions)
     return {"created": created, "action": action}
 
 
@@ -1380,7 +1398,7 @@ def _enqueue_action_from_signal(
     existing = next((item for item in existing_actions if item.get("action_id") == action_id), None)
     if existing is not None:
         return False, existing
-    timestamp = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    timestamp = _utc_now_text()
     action = {
         "action_id": action_id,
         "action_kind": str(recommended_action["kind"]),
@@ -1416,31 +1434,32 @@ def _backfill_auto_queue_actions(
     ]
     if not candidates:
         return {"created_count": 0, "created_action_ids": []}
-    existing_actions = _read_action_queue_rows(vault_dir)
-    created_actions: list[dict[str, Any]] = []
-    for item in candidates:
-        created, action = _enqueue_action_from_signal(
-            item,
-            existing_actions=existing_actions,
-            session_id="action-backfill",
-        )
-        if created:
-            existing_actions.append(action)
-            created_actions.append(action)
-    if created_actions:
-        existing_actions.sort(
-            key=lambda item: (str(item.get("created_at", "")), str(item.get("action_id", ""))),
-            reverse=True,
-        )
-        _write_action_queue_rows(vault_dir, existing_actions)
+    with action_queue_write_lock(vault_dir):
+        existing_actions = _read_action_queue_rows_unlocked(vault_dir)
+        created_actions: list[dict[str, Any]] = []
+        for item in candidates:
+            created, action = _enqueue_action_from_signal(
+                item,
+                existing_actions=existing_actions,
+                session_id="action-backfill",
+            )
+            if created:
+                existing_actions.append(action)
+                created_actions.append(action)
+        if created_actions:
+            existing_actions.sort(
+                key=lambda item: (str(item.get("created_at", "")), str(item.get("action_id", ""))),
+                reverse=True,
+            )
+            _write_action_queue_rows_unlocked(vault_dir, existing_actions)
     return {
         "created_count": len(created_actions),
         "created_action_ids": [item["action_id"] for item in created_actions],
     }
 
 
-def _replace_action_queue_item(vault_dir: Path | str, action: dict[str, Any]) -> dict[str, Any]:
-    existing_actions = _read_action_queue_rows(vault_dir)
+def _replace_action_queue_item_unlocked(vault_dir: Path | str, action: dict[str, Any]) -> dict[str, Any]:
+    existing_actions = _read_action_queue_rows_unlocked(vault_dir)
     replaced = False
     for index, item in enumerate(existing_actions):
         if item.get("action_id") == action.get("action_id"):
@@ -1453,29 +1472,34 @@ def _replace_action_queue_item(vault_dir: Path | str, action: dict[str, Any]) ->
         key=lambda item: (str(item.get("created_at", "")), str(item.get("action_id", ""))),
         reverse=True,
     )
-    _write_action_queue_rows(vault_dir, existing_actions)
+    _write_action_queue_rows_unlocked(vault_dir, existing_actions)
     return action
 
 
-def _action_by_id(vault_dir: Path | str, action_id: str) -> dict[str, Any] | None:
-    for item in _read_action_queue_rows(vault_dir):
+def _action_by_id_unlocked(vault_dir: Path | str, action_id: str) -> dict[str, Any] | None:
+    for item in _read_action_queue_rows_unlocked(vault_dir):
         if item.get("action_id") == action_id:
             return dict(item)
     return None
 
 
-def _next_queued_action(vault_dir: Path | str) -> dict[str, Any] | None:
-    queued = [item for item in _read_action_queue_rows(vault_dir) if item.get("status") == "queued"]
+def _action_by_id(vault_dir: Path | str, action_id: str) -> dict[str, Any] | None:
+    with action_queue_write_lock(vault_dir):
+        return _action_by_id_unlocked(vault_dir, action_id)
+
+
+def _next_queued_action_unlocked(vault_dir: Path | str) -> dict[str, Any] | None:
+    queued = [item for item in _read_action_queue_rows_unlocked(vault_dir) if item.get("status") == "queued"]
     if not queued:
         return None
     queued.sort(key=lambda item: (str(item.get("created_at", "")), str(item.get("action_id", ""))))
     return dict(queued[0])
 
 
-def _next_safe_queued_action(vault_dir: Path | str) -> dict[str, Any] | None:
+def _next_safe_queued_action_unlocked(vault_dir: Path | str) -> dict[str, Any] | None:
     queued = [
         item
-        for item in _read_action_queue_rows(vault_dir)
+        for item in _read_action_queue_rows_unlocked(vault_dir)
         if item.get("status") == "queued" and bool(item.get("safe_to_run"))
     ]
     if not queued:
@@ -1485,30 +1509,32 @@ def _next_safe_queued_action(vault_dir: Path | str) -> dict[str, Any] | None:
 
 
 def retry_action_queue_item(vault_dir: Path | str, *, action_id: str) -> dict[str, Any]:
-    action = _action_by_id(vault_dir, action_id)
-    if action is None:
-        raise ValueError("unknown action_id")
-    if str(action.get("status") or "") not in {"failed", "obsolete"}:
-        raise ValueError("action is not retryable")
-    action["status"] = "queued"
-    action["started_at"] = ""
-    action["finished_at"] = ""
-    action["error"] = ""
-    action["failure_bucket"] = ""
-    action["result"] = {}
-    _replace_action_queue_item(vault_dir, action)
+    with action_queue_write_lock(vault_dir):
+        action = _action_by_id_unlocked(vault_dir, action_id)
+        if action is None:
+            raise ValueError("unknown action_id")
+        if str(action.get("status") or "") not in {"failed", "obsolete"}:
+            raise ValueError("action is not retryable")
+        action["status"] = "queued"
+        action["started_at"] = ""
+        action["finished_at"] = ""
+        action["error"] = ""
+        action["failure_bucket"] = ""
+        action["result"] = {}
+        _replace_action_queue_item_unlocked(vault_dir, action)
     return {"retried": True, "action": action}
 
 
 def dismiss_action_queue_item(vault_dir: Path | str, *, action_id: str) -> dict[str, Any]:
-    action = _action_by_id(vault_dir, action_id)
-    if action is None:
-        raise ValueError("unknown action_id")
-    if str(action.get("status") or "") in {"succeeded", "dismissed"}:
-        raise ValueError("action is not dismissible")
-    action["status"] = "dismissed"
-    action["finished_at"] = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-    _replace_action_queue_item(vault_dir, action)
+    with action_queue_write_lock(vault_dir):
+        action = _action_by_id_unlocked(vault_dir, action_id)
+        if action is None:
+            raise ValueError("unknown action_id")
+        if str(action.get("status") or "") in {"succeeded", "dismissed"}:
+            raise ValueError("action is not dismissible")
+        action["status"] = "dismissed"
+        action["finished_at"] = _utc_now_text()
+        _replace_action_queue_item_unlocked(vault_dir, action)
     return {"dismissed": True, "action": action}
 
 
@@ -1560,22 +1586,28 @@ def _refresh_truth_after_action(vault_dir: Path | str) -> None:
 
 
 def run_next_action_queue_item(vault_dir: Path | str, *, safe_only: bool = False) -> dict[str, Any]:
-    action = _next_safe_queued_action(vault_dir) if safe_only else _next_queued_action(vault_dir)
-    if action is None:
-        return {"ran": False, "reason": "no_queued_actions", "safe_only": safe_only}
+    with action_queue_write_lock(vault_dir):
+        action = (
+            _next_safe_queued_action_unlocked(vault_dir)
+            if safe_only
+            else _next_queued_action_unlocked(vault_dir)
+        )
+        if action is None:
+            return {"ran": False, "reason": "no_queued_actions", "safe_only": safe_only}
 
-    started_at = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-    action["status"] = "running"
-    action["started_at"] = started_at
-    action["error"] = ""
-    action["failure_bucket"] = ""
-    _replace_action_queue_item(vault_dir, action)
+        started_at = _utc_now_text()
+        action["status"] = "running"
+        action["started_at"] = started_at
+        action["error"] = ""
+        action["failure_bucket"] = ""
+        _replace_action_queue_item_unlocked(vault_dir, action)
 
     if _signal_by_id(vault_dir, str(action.get("source_signal_id") or "")) is None:
-        action["status"] = "obsolete"
-        action["finished_at"] = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-        action["failure_bucket"] = "obsolete_signal"
-        _replace_action_queue_item(vault_dir, action)
+        with action_queue_write_lock(vault_dir):
+            action["status"] = "obsolete"
+            action["finished_at"] = _utc_now_text()
+            action["failure_bucket"] = "obsolete_signal"
+            _replace_action_queue_item_unlocked(vault_dir, action)
         return {"ran": False, "reason": "obsolete_signal", "action": action, "safe_only": safe_only}
 
     handlers = {
@@ -1584,29 +1616,32 @@ def run_next_action_queue_item(vault_dir: Path | str, *, safe_only: bool = False
     }
     handler = handlers.get(str(action.get("action_kind") or ""))
     if handler is None:
-        action["status"] = "failed"
-        action["error"] = f"unsupported_action_kind:{action.get('action_kind')}"
-        action["failure_bucket"] = "unsupported_action_kind"
-        action["retry_count"] = int(action.get("retry_count") or 0) + 1
-        action["finished_at"] = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-        _replace_action_queue_item(vault_dir, action)
+        with action_queue_write_lock(vault_dir):
+            action["status"] = "failed"
+            action["error"] = f"unsupported_action_kind:{action.get('action_kind')}"
+            action["failure_bucket"] = "unsupported_action_kind"
+            action["retry_count"] = int(action.get("retry_count") or 0) + 1
+            action["finished_at"] = _utc_now_text()
+            _replace_action_queue_item_unlocked(vault_dir, action)
         return {"ran": False, "reason": "unsupported_action_kind", "action": action, "safe_only": safe_only}
 
     try:
         result = handler(vault_dir, action)
         _refresh_truth_after_action(vault_dir)
-        action["status"] = "succeeded"
-        action["finished_at"] = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-        action["result"] = result
-        _replace_action_queue_item(vault_dir, action)
+        with action_queue_write_lock(vault_dir):
+            action["status"] = "succeeded"
+            action["finished_at"] = _utc_now_text()
+            action["result"] = result
+            _replace_action_queue_item_unlocked(vault_dir, action)
         return {"ran": True, "action": action, "safe_only": safe_only}
     except Exception as exc:
-        action["status"] = "failed"
-        action["error"] = str(exc)
-        action["failure_bucket"] = _classify_action_error(str(exc))
-        action["retry_count"] = int(action.get("retry_count") or 0) + 1
-        action["finished_at"] = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-        _replace_action_queue_item(vault_dir, action)
+        with action_queue_write_lock(vault_dir):
+            action["status"] = "failed"
+            action["error"] = str(exc)
+            action["failure_bucket"] = _classify_action_error(str(exc))
+            action["retry_count"] = int(action.get("retry_count") or 0) + 1
+            action["finished_at"] = _utc_now_text()
+            _replace_action_queue_item_unlocked(vault_dir, action)
         return {"ran": False, "reason": "execution_failed", "action": action, "safe_only": safe_only}
 
 
@@ -1666,6 +1701,14 @@ def list_production_gaps(
     limit, _ = _validate_page_args(limit=limit, offset=0)
     candidate_limit = min(MAX_PAGE_SIZE, max(limit * 5, limit))
     items = list_production_chains(vault_dir, query=query, limit=candidate_limit)
+    return _production_gap_items_from_chains(items, limit=limit)
+
+
+def _production_gap_items_from_chains(
+    items: list[dict[str, Any]],
+    *,
+    limit: int,
+) -> list[dict[str, Any]]:
     weak_points: list[dict[str, Any]] = []
     for item in items:
         traceability = item["traceability"]
@@ -1705,7 +1748,7 @@ def list_production_gaps(
 
 def _compute_signal_entries(vault_dir: Path | str) -> list[dict[str, Any]]:
     resolved_vault = resolve_vault_dir(vault_dir)
-    timestamp = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    timestamp = _utc_now_text()
     signals: list[dict[str, Any]] = []
 
     for item in list_contradictions(resolved_vault, status="open", limit=MAX_PAGE_SIZE):
@@ -1783,7 +1826,8 @@ def _compute_signal_entries(vault_dir: Path | str) -> list[dict[str, Any]]:
             }
         )
 
-    for item in list_production_gaps(resolved_vault, limit=MAX_PAGE_SIZE):
+    production_chains = list_production_chains(resolved_vault, limit=MAX_PAGE_SIZE)
+    for item in _production_gap_items_from_chains(production_chains, limit=MAX_PAGE_SIZE):
         object_ids = [entry["object_id"] for entry in item["traceability"]["objects"]]
         signals.append(
             {
@@ -1816,7 +1860,7 @@ def _compute_signal_entries(vault_dir: Path | str) -> list[dict[str, Any]]:
             }
         )
 
-    for item in list_production_chains(resolved_vault, limit=MAX_PAGE_SIZE):
+    for item in production_chains:
         traceability = item["traceability"]
         if item["stage_label"] == "source_note" and not traceability["deep_dives"]:
             signals.append(
@@ -1958,9 +2002,9 @@ def _compute_signal_entries(vault_dir: Path | str) -> list[dict[str, Any]]:
 
 def sync_signal_ledger(vault_dir: Path | str) -> dict[str, Any]:
     resolved_vault = resolve_vault_dir(vault_dir)
-    layout = VaultLayout.from_vault(resolved_vault)
     signals = _compute_signal_entries(resolved_vault)
-    _rewrite_jsonl(layout.logs_dir / f"{_SIGNAL_LOG_NAME}.jsonl", signals)
+    with signal_ledger_write_lock(resolved_vault):
+        _rewrite_jsonl(_signal_ledger_path(resolved_vault), signals)
     type_counts = Counter(item["signal_type"] for item in signals)
     result = {
         "signal_count": len(signals),
@@ -1995,25 +2039,26 @@ def list_signals(
 ) -> list[dict[str, Any]]:
     limit, _ = _validate_page_args(limit=limit, offset=0)
     resolved_vault = resolve_vault_dir(vault_dir)
-    ledger_path = VaultLayout.from_vault(resolved_vault).logs_dir / f"{_SIGNAL_LOG_NAME}.jsonl"
+    ledger_path = _signal_ledger_path(resolved_vault)
     if not ledger_path.exists():
         ensure_signal_ledger_synced(resolved_vault)
     normalized_query = (query or "").strip().lower()
     items: list[dict[str, Any]] = []
-    for item in _read_jsonl_items(ledger_path):
-        if signal_type and item.get("signal_type") != signal_type:
-            continue
-        if normalized_query:
-            haystacks = [
-                str(item.get("title") or "").lower(),
-                str(item.get("detail") or "").lower(),
-                str(item.get("source_label") or "").lower(),
-            ]
-            if not any(normalized_query in haystack for haystack in haystacks):
+    with signal_ledger_write_lock(resolved_vault):
+        for item in _read_jsonl_items(ledger_path):
+            if signal_type and item.get("signal_type") != signal_type:
                 continue
-        items.append(item)
-        if len(items) >= limit:
-            break
+            if normalized_query:
+                haystacks = [
+                    str(item.get("title") or "").lower(),
+                    str(item.get("detail") or "").lower(),
+                    str(item.get("source_label") or "").lower(),
+                ]
+                if not any(normalized_query in haystack for haystack in haystacks):
+                    continue
+            items.append(item)
+            if len(items) >= limit:
+                break
     return _attach_action_queue_state(vault_dir, items)
 
 
@@ -2050,7 +2095,15 @@ def get_briefing_snapshot(vault_dir: Path | str, *, limit: int = 8) -> dict[str,
             if object_id
         )
     )
-    object_rows = _batch_object_rows(vault_dir, changed_object_ids)
+    topic_counts: Counter[str] = Counter()
+    for item in recent_signals:
+        for object_id in item.get("object_ids", []):
+            topic_counts[object_id] += 1
+    active_topic_ids = [object_id for object_id, _ in topic_counts.most_common(limit)]
+    object_rows = _batch_object_rows(
+        vault_dir,
+        list(dict.fromkeys([*changed_object_ids, *active_topic_ids])),
+    )
     changed_objects = [
         {
             "object_id": object_id,
@@ -2059,17 +2112,10 @@ def get_briefing_snapshot(vault_dir: Path | str, *, limit: int = 8) -> dict[str,
         }
         for object_id in changed_object_ids[:limit]
     ]
-
-    topic_counts: Counter[str] = Counter()
-    for item in recent_signals:
-        for object_id in item.get("object_ids", []):
-            topic_counts[object_id] += 1
     active_topics = [
         {
             "object_id": object_id,
-            "title": object_rows.get(object_id, {}).get("title")
-            or _batch_object_rows(vault_dir, [object_id]).get(object_id, {}).get("title")
-            or object_id,
+            "title": object_rows.get(object_id, {}).get("title") or object_id,
             "signal_count": count,
             "path": f"/topic?id={object_id}",
         }
@@ -2182,7 +2228,7 @@ def get_briefing_snapshot(vault_dir: Path | str, *, limit: int = 8) -> dict[str,
     }
 
     return {
-        "generated_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "generated_at": _utc_now_text(),
         "recent_signal_count": len(recent_signals),
         "unresolved_issue_count": len(unresolved_issues),
         "changed_object_count": len(changed_objects),

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -132,6 +132,18 @@ def test_truth_api_reads_signal_and_action_ledgers_without_knowledge_db(temp_vau
     assert actions[0]["action_id"] == "action::demo"
 
 
+def test_truth_api_avoids_datetime_utc_import_for_python_310_compatibility():
+    source = (
+        Path(__file__).resolve().parents[1]
+        / "src"
+        / "openclaw_pipeline"
+        / "truth_api.py"
+    ).read_text(encoding="utf-8")
+
+    assert "from datetime import UTC" not in source
+    assert "datetime.now(UTC)" not in source
+
+
 def test_truth_api_reads_review_actions_from_jsonl_without_knowledge_db(temp_vault):
     from openclaw_pipeline.truth_api import list_evolution_review_actions, list_review_actions
 
@@ -2246,6 +2258,31 @@ Processed source note without any derived deep dive.
     assert refreshed_signal["recommended_action"]["action_id"] == actions[0]["action_id"]
 
 
+def test_truth_api_enqueue_signal_action_uses_action_queue_lock(temp_vault, monkeypatch):
+    import openclaw_pipeline.truth_api as truth_api
+
+    vault = _seed_truth_vault(temp_vault)
+    rebuild_knowledge_index(vault)
+    truth_api.sync_signal_ledger(vault)
+    contradiction_signal = next(
+        item for item in truth_api.list_signals(vault) if item["signal_type"] == "contradiction_open"
+    )
+    calls: list[str] = []
+
+    @contextmanager
+    def fake_lock(vault_dir, *, timeout_seconds=300.0):
+        calls.append(f"enter:{vault_dir == vault}")
+        yield
+        calls.append("exit")
+
+    monkeypatch.setattr(truth_api, "action_queue_write_lock", fake_lock, raising=False)
+
+    payload = truth_api.enqueue_signal_action(vault, signal_id=contradiction_signal["signal_id"])
+
+    assert payload["created"] is True
+    assert calls == [f"enter:{True}", "exit"]
+
+
 def test_truth_api_includes_review_action_signals(temp_vault):
     from openclaw_pipeline.truth_api import list_signals, record_review_action, sync_signal_ledger
 
@@ -2303,6 +2340,201 @@ def test_truth_api_sync_signal_ledger_writes_jsonl_without_db_lock(temp_vault, m
     signals_path = vault / "60-Logs" / "signals.jsonl"
     assert signals_path.exists()
     assert summary["signal_count"] >= 1
+
+
+def test_truth_api_sync_signal_ledger_uses_signal_ledger_lock(temp_vault, monkeypatch):
+    from openclaw_pipeline import truth_api
+
+    vault = _seed_truth_vault(temp_vault)
+    calls: list[str] = []
+
+    @contextmanager
+    def fake_lock(vault_dir, *, timeout_seconds=300.0):
+        calls.append(f"enter:{vault_dir == vault}")
+        yield
+        calls.append("exit")
+
+    monkeypatch.setattr(truth_api, "signal_ledger_write_lock", fake_lock, raising=False)
+    monkeypatch.setattr(
+        truth_api,
+        "_backfill_auto_queue_actions",
+        lambda vault_dir, *, signals=None: {"created_count": 0, "created_action_ids": []},
+    )
+
+    truth_api.sync_signal_ledger(vault)
+
+    assert calls == [f"enter:{True}", "exit"]
+
+
+def test_truth_api_run_next_action_queue_item_uses_action_queue_lock(temp_vault, monkeypatch):
+    import openclaw_pipeline.truth_api as truth_api
+
+    logs_dir = temp_vault / "60-Logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    (logs_dir / "actions.jsonl").write_text(
+        json.dumps(
+            {
+                "action_id": "action::safe",
+                "action_kind": "deep_dive_workflow",
+                "source_signal_id": "signal::safe",
+                "title": "Safe action",
+                "target_ref": "50-Inbox/03-Processed/Harness.md",
+                "status": "queued",
+                "created_at": "2026-04-15T00:00:01Z",
+                "retry_count": 0,
+                "failure_bucket": "",
+                "safe_to_run": True,
+                "payload": {},
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    calls: list[str] = []
+
+    @contextmanager
+    def fake_lock(vault_dir, *, timeout_seconds=300.0):
+        calls.append(f"enter:{vault_dir == temp_vault}")
+        yield
+        calls.append("exit")
+
+    monkeypatch.setattr(truth_api, "action_queue_write_lock", fake_lock, raising=False)
+    monkeypatch.setattr(truth_api, "_signal_by_id", lambda vault_dir, signal_id: {"signal_id": signal_id})
+    monkeypatch.setattr(truth_api, "_run_deep_dive_workflow_action", lambda vault_dir, action: {"ok": True})
+    monkeypatch.setattr(truth_api, "_refresh_truth_after_action", lambda vault_dir: None)
+
+    payload = truth_api.run_next_action_queue_item(temp_vault, safe_only=True)
+
+    assert payload["ran"] is True
+    assert calls == [f"enter:{True}", "exit", f"enter:{True}", "exit"]
+
+
+def test_truth_api_compute_signal_entries_reuses_production_chains(temp_vault, monkeypatch):
+    import openclaw_pipeline.truth_api as truth_api
+
+    calls = {"chains": 0}
+
+    monkeypatch.setattr(truth_api, "list_contradictions", lambda *args, **kwargs: [])
+    monkeypatch.setattr(truth_api, "list_stale_summaries", lambda *args, **kwargs: [])
+    monkeypatch.setattr(truth_api, "list_review_actions", lambda *args, **kwargs: [])
+
+    def fake_chains(vault_dir, *, query=None, limit=100):
+        calls["chains"] += 1
+        return [
+            {
+                "title": "Loose Source",
+                "path": "50-Inbox/03-Processed/2026-04/Loose Source.md",
+                "stage_label": "source_note",
+                "traceability": {
+                    "deep_dives": [],
+                    "objects": [],
+                    "atlas_pages": [],
+                    "source_notes": [],
+                    "counts": {
+                        "source_notes": 0,
+                        "deep_dives": 0,
+                        "objects": 0,
+                        "atlas_pages": 0,
+                    },
+                },
+            },
+            {
+                "title": "Loose Deep Dive",
+                "path": "20-Areas/AI-Research/Topics/2026-04/Loose Deep Dive_深度解读.md",
+                "stage_label": "deep_dive",
+                "traceability": {
+                    "deep_dives": [],
+                    "objects": [],
+                    "atlas_pages": [],
+                    "source_notes": [{"path": "50-Inbox/03-Processed/2026-04/Loose Source.md"}],
+                    "counts": {
+                        "source_notes": 1,
+                        "deep_dives": 0,
+                        "objects": 0,
+                        "atlas_pages": 0,
+                    },
+                },
+            },
+        ]
+
+    monkeypatch.setattr(truth_api, "list_production_chains", fake_chains)
+    monkeypatch.setattr(
+        truth_api,
+        "list_production_gaps",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("should not call list_production_gaps")),
+    )
+
+    items = truth_api._compute_signal_entries(temp_vault)
+
+    assert calls["chains"] == 1
+    assert {item["signal_type"] for item in items} >= {
+        "production_gap",
+        "source_needs_deep_dive",
+        "deep_dive_needs_objects",
+    }
+
+
+def test_truth_api_briefing_batches_topic_title_lookups(temp_vault, monkeypatch):
+    import openclaw_pipeline.truth_api as truth_api
+
+    calls: list[tuple[str, ...]] = []
+    monkeypatch.setattr(
+        truth_api,
+        "list_signals",
+        lambda vault_dir, limit=8: [
+            {
+                "signal_id": "signal::a",
+                "signal_type": "source_needs_deep_dive",
+                "title": "Topic A",
+                "detail": "Needs work.",
+                "source_path": "/note?path=a",
+                "note_paths": ["a"],
+                "object_ids": ["source-note"],
+                "recommended_action": None,
+            },
+            {
+                "signal_id": "signal::b",
+                "signal_type": "deep_dive_needs_objects",
+                "title": "Topic B",
+                "detail": "Needs objects.",
+                "source_path": "/note?path=b",
+                "note_paths": ["b"],
+                "object_ids": ["target-note"],
+                "recommended_action": None,
+            },
+        ],
+    )
+    monkeypatch.setattr(truth_api, "list_evolution_candidates", lambda vault_dir, limit=24: [])
+    monkeypatch.setattr(truth_api, "list_action_queue", lambda vault_dir, limit=100: [])
+
+    def fake_batch(vault_dir, object_ids):
+        calls.append(tuple(object_ids))
+        return {
+            object_id: {"title": f"title:{object_id}"}
+            for object_id in object_ids
+        }
+
+    monkeypatch.setattr(truth_api, "_batch_object_rows", fake_batch)
+
+    payload = truth_api.get_briefing_snapshot(temp_vault, limit=8)
+
+    assert payload["active_topics"] == [
+        {
+            "object_id": "source-note",
+            "title": "title:source-note",
+            "signal_count": 1,
+            "path": "/topic?id=source-note",
+        },
+        {
+            "object_id": "target-note",
+            "title": "title:target-note",
+            "signal_count": 1,
+            "path": "/topic?id=target-note",
+        },
+    ]
+    non_empty_calls = [set(call) for call in calls if call]
+    assert non_empty_calls == [{"source-note", "target-note"}]
 
 
 def test_truth_api_record_review_action_writes_jsonl_without_db_lock(temp_vault, monkeypatch):

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -142,6 +142,7 @@ def test_truth_api_avoids_datetime_utc_import_for_python_310_compatibility():
 
     assert "from datetime import UTC" not in source
     assert "datetime.now(UTC)" not in source
+    assert "datetime.UTC" not in source
 
 
 def test_truth_api_reads_review_actions_from_jsonl_without_knowledge_db(temp_vault):
@@ -1956,6 +1957,38 @@ Processed source note without any derived deep dive.
     assert payload["action"]["status"] == "dismissed"
     assert payload["action"]["finished_at"]
     assert dismissed_action["status"] == "dismissed"
+
+
+def test_truth_api_cannot_dismiss_running_action_queue_item(temp_vault):
+    import pytest
+    import openclaw_pipeline.truth_api as truth_api
+
+    logs_dir = temp_vault / "60-Logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    (logs_dir / "actions.jsonl").write_text(
+        json.dumps(
+            {
+                "action_id": "action::running",
+                "action_kind": "deep_dive_workflow",
+                "source_signal_id": "signal::running",
+                "title": "Running action",
+                "target_ref": "50-Inbox/03-Processed/Harness.md",
+                "status": "running",
+                "created_at": "2026-04-15T00:00:01Z",
+                "started_at": "2026-04-15T00:00:02Z",
+                "retry_count": 0,
+                "failure_bucket": "",
+                "safe_to_run": True,
+                "payload": {},
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="action is not dismissible"):
+        truth_api.dismiss_action_queue_item(temp_vault, action_id="action::running")
 
 
 def test_truth_api_run_action_queue_processes_multiple_queued_items(temp_vault, monkeypatch):


### PR DESCRIPTION
## Summary
- replace `datetime.UTC` usage in `truth_api` so the package stays compatible with Python 3.10
- serialize JSONL action queue and signal ledger access with dedicated file locks
- reuse one production-chain pass during signal computation and batch topic title lookups in briefing
- add regression coverage for lock usage, signal computation reuse, and Python-version compatibility

## Verification
- `PYTHONPATH=src python3.13 -m pytest -q tests/test_truth_api.py tests/test_ui_server.py tests/test_run_actions_command.py`
- `PYTHONPATH=src python3.13 -m pytest -q`
- `python3.13 -m compileall src/openclaw_pipeline`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/23" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved timestamp handling consistency across signals, actions, and briefings.
  * Enhanced concurrency control for action queue and signal ledger operations to prevent conflicts during simultaneous access.

* **Improvements**
  * Optimized briefing snapshot generation with more efficient data retrieval.

* **Tests**
  * Added comprehensive test coverage for concurrency controls and Python 3.10 compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->