### PR TITLE
docs: define OVP layer contract and stage handler registry plan

### DIFF
--- a/docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
+++ b/docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
@@ -442,6 +442,7 @@ Exit condition:
 Reference plan:
 
 - [2026-04-15-phase14-orchestration-integration-plan.md](2026-04-15-phase14-orchestration-integration-plan.md)
+- [2026-04-15-stage-handler-registry-design.md](2026-04-15-stage-handler-registry-design.md)
 
 Architecture follow-up:
 
@@ -449,6 +450,18 @@ Architecture follow-up:
   OVP now needs a deeper separation between core runtime, pack surfaces, domain execution hooks,
   domain truth projection, and domain UI semantics so the product does not remain implicitly bound
   to `research-tech` while it grows beyond the first in-repo pack.
+
+Implementation sequence:
+
+1. `Stage Handler Registry`
+   Extract execution dispatch from current in-repo handler coupling so profile execution,
+   autopilot, and queue actions share one handler contract.
+2. `Pack-Aware Truth Projection`
+   Move truth-building semantics behind domain-aware contracts instead of keeping them implicitly
+   bound to `research-tech`.
+3. `Pack-Aware Observation Surfaces`
+   Generalize `signals`, `briefing`, `production`, and related product semantics after execution
+   and truth layers are no longer hard-coded.
 
 ### Milestone 10: Graph Intelligence And Synthesis
 

--- a/docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
+++ b/docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
@@ -443,6 +443,13 @@ Reference plan:
 
 - [2026-04-15-phase14-orchestration-integration-plan.md](2026-04-15-phase14-orchestration-integration-plan.md)
 
+Architecture follow-up:
+
+- [2026-04-15-ovp-layer-contract.md](2026-04-15-ovp-layer-contract.md)
+  OVP now needs a deeper separation between core runtime, pack surfaces, domain execution hooks,
+  domain truth projection, and domain UI semantics so the product does not remain implicitly bound
+  to `research-tech` while it grows beyond the first in-repo pack.
+
 ### Milestone 10: Graph Intelligence And Synthesis
 
 Status: **Not Started**

--- a/docs/plans/2026-04-15-ovp-layer-contract.md
+++ b/docs/plans/2026-04-15-ovp-layer-contract.md
@@ -275,6 +275,10 @@ OVP does not need a big-bang rewrite. It needs a second platform extraction pass
 
 ### Refactor A: Stage Handler Registry
 
+Detailed design:
+
+- [2026-04-15-stage-handler-registry-design.md](2026-04-15-stage-handler-registry-design.md)
+
 Introduce a first-class handler registry between:
 
 - action queue worker

--- a/docs/plans/2026-04-15-ovp-layer-contract.md
+++ b/docs/plans/2026-04-15-ovp-layer-contract.md
@@ -1,0 +1,342 @@
+# OVP Layer Contract
+
+**Goal:** Clarify which OVP layers are truly core, which must become pack-aware, and which current `research-tech` semantics must be moved out of the generic runtime.
+
+**Why this document exists:** OVP has already extracted pack metadata, workflow profile selection, and several operator surfaces. But deeper runtime layers are still partially coupled to `research-tech` assumptions. That is acceptable for the first in-repo pack, but it is not sufficient for external domain systems such as media or medical workflows.
+
+## 1. Current Diagnosis
+
+OVP is no longer a single-domain vault script bundle. It is already operating as:
+
+- a local-first runtime,
+- a derived SQLite truth and retrieval layer,
+- a review and maintenance shell,
+- a pack-capable workflow platform.
+
+However, the current separation stops too early.
+
+### What is already platform-like
+
+- runtime and vault layout
+- audit and logging
+- pack loading and profile selection
+- extraction / operation / wiki view specs
+- queue and worker direction
+- UI shell and local HTTP product surface
+
+### What is still implicitly `research-tech`
+
+- `knowledge.db` rebuild source assumptions
+- truth projection rules
+- contradiction detection semantics
+- event / timeline semantics
+- focused workflow handlers behind the action queue
+- several UI payloads that look generic but actually encode current knowledge-pack assumptions
+
+## 2. The Current Leakage
+
+The following modules are still more domain-bound than their current names suggest.
+
+### Leakage A: `knowledge_index.py` is not yet pack-aware
+
+Current behavior:
+
+- rebuild scans current evergreen, Atlas, and area directories
+- rows are projected from page-centric Markdown assumptions
+- truth rows are derived from current note layout and current registry semantics
+
+This means OVP currently has a generic DB container but a non-generic rebuild contract.
+
+### Leakage B: `truth_store.py` encodes one provisional knowledge model
+
+Current behavior:
+
+- one page becomes one object row
+- one page summary becomes one main claim
+- contradiction detection is built on page-summary polarity heuristics
+
+This is a useful first truth layer, but it is not a domain-neutral truth projection contract.
+
+### Leakage C: several UI surfaces are generic in name, specific in meaning
+
+Examples:
+
+- `Event Dossier` is currently a dated-note projection, not a domain event system
+- `Production` means source note -> deep dive -> evergreen -> Atlas
+- `Briefing` currently prioritizes maintenance and evolution over domain-specific desk work
+
+These are valid product surfaces, but they are not yet generic pack surfaces.
+
+### Leakage D: action handlers still dispatch into current knowledge workflows
+
+The queue design is correct:
+
+- many observation surfaces
+- one execution surface
+
+But the handler layer is still coupled to current deep-dive and evergreen extraction flows.
+
+## 3. Target Layer Contract
+
+OVP should be treated as six layers.
+
+## Layer 1. Core Runtime
+
+Owns:
+
+- vault layout
+- CLI entrypoints
+- logging and audit
+- queue and worker lifecycle
+- plugin loading
+- DB file lifecycle and rebuild orchestration
+- UI shell, routing, auth-free local server
+
+Must remain generic.
+
+Must not know:
+
+- media object semantics
+- medical evidence semantics
+- research-tech-only object semantics
+
+## Layer 2. Pack Surface
+
+Owns:
+
+- object kind declarations
+- workflow profiles
+- extraction profiles
+- operation profiles
+- wiki view declarations
+
+This is the layer OVP already has in usable form.
+
+Constraint:
+
+- this layer describes domain surfaces
+- it does not itself execute domain logic
+
+## Layer 3. Domain Execution Hooks
+
+Owns:
+
+- stage handler registry
+- focused workflow handlers
+- processor mode metadata
+- processor input/output contracts
+- quality and evaluation hooks
+
+This layer decides:
+
+- which stages are rule-based
+- which are LLM-structured
+- which are hybrid
+- which require human review
+
+Core should only orchestrate this layer. Core should not encode domain processor logic directly.
+
+## Layer 4. Domain Truth Projection
+
+Owns:
+
+- which domain objects can be projected into the truth layer
+- how claims, relations, evidence, summaries, and contradictions are derived
+- which projections are deterministic vs review-gated
+
+Core should own:
+
+- the SQLite container
+- rebuild transaction discipline
+- read/query interfaces
+
+Packs should own:
+
+- projection rules
+- projection validation
+- truth-specific review semantics
+
+Constraint:
+
+- `knowledge.db` remains derived, never canonical
+- but its truth projection cannot stay hard-coded to one in-repo pack forever
+
+## Layer 5. Domain Product Surfaces
+
+Owns:
+
+- screen-level payload contracts
+- domain browser semantics
+- domain queue semantics
+- domain dashboards and briefing semantics
+
+Core should own:
+
+- shell layout
+- common widgets
+- query plumbing
+- review action mechanics
+
+Packs or domain systems should own:
+
+- what an event browser means
+- what a briefing means
+- what a production chain means
+- what a stale object means
+
+## Layer 6. Materialization And Exports
+
+Owns:
+
+- compiled Markdown exports
+- object pages
+- dossiers
+- overview pages
+- external operator artifacts
+
+Constraint:
+
+- materializers must read from canonical and derived state through stable contracts
+- they must not become a second hidden execution engine
+
+## 4. What Stays In Core
+
+The following should stay centralized and become stricter over time:
+
+- audit and logging contracts
+- queue state machine
+- idempotency rules
+- plugin discovery
+- deterministic IDs where core guarantees them
+- rebuild discipline for derived stores
+- navigation shell and generic review affordances
+- search and query infrastructure
+
+## 5. What Must Become Pack-Aware
+
+The following should not remain `research-tech` defaults in disguise:
+
+- truth projection builders
+- contradiction builders
+- event projection builders
+- production-chain builders
+- signal builders
+- briefing builders
+- action handler registry
+- domain browser payload builders
+
+If these remain core-owned and research-tech-shaped, external packs will only be able to register names while reimplementing the real system elsewhere.
+
+## 6. What Should Move Out Of The Generic Runtime
+
+The following semantics should be treated as `research-tech` defaults, not core truths:
+
+- `source note -> deep dive -> evergreen -> Atlas` as the only production-chain model
+- page-summary polarity as the default contradiction model
+- dated-note projection as the default event model
+- current object browser assumptions over evergreen-centric objects
+- maintenance-first briefing as the only briefing model
+
+These can remain the default in-repo implementation, but they should move behind pack-aware contracts.
+
+## 7. Relationship To `research-tech`
+
+`research-tech` should become:
+
+- the first complete in-repo domain implementation
+- the default compatibility baseline for current vaults
+- the reference implementation of pack-aware truth, UI, and queue integration
+
+It should not remain:
+
+- the implicit meaning of core runtime concepts
+
+In other words:
+
+- `research-tech` should prove the contracts
+- it should not define the platform boundary by accident
+
+## 8. Relationship To External Media Systems
+
+For an external media domain system:
+
+- collection and normalization can stay fully outside OVP
+- an external media pack can use OVP pack surfaces and execution shell
+- domain truth projection and domain product surfaces should plug into OVP through contracts, not by patching core
+
+This is the critical design outcome:
+
+- OVP should host external domain systems
+- it should not force them to pretend they are `research-tech`
+
+## 9. Required Next Refactors
+
+OVP does not need a big-bang rewrite. It needs a second platform extraction pass.
+
+### Refactor A: Stage Handler Registry
+
+Introduce a first-class handler registry between:
+
+- action queue worker
+- focused workflow execution
+- pack/domain-specific handlers
+
+The worker should dispatch by contract, not by importing current knowledge processors directly.
+
+### Refactor B: Pack-Aware Truth Projection
+
+Split:
+
+- DB container and rebuild orchestration
+- domain truth projection rules
+
+`knowledge_index.py` should remain core-owned for rebuild lifecycle, but should stop owning every domain projection rule.
+
+### Refactor C: Pack-Aware UI Payload Builders
+
+Split:
+
+- common shell and transport
+- domain payload semantics
+
+OVP can keep one UI process while still allowing pack-aware page semantics.
+
+### Refactor D: Processor Control Plane
+
+Promote a configuration layer that declares:
+
+- processor name
+- stage
+- mode
+- input and output objects
+- implementation entry
+- quality hooks
+
+This is the missing bridge between pack metadata and real execution.
+
+### Refactor E: Signal / Briefing / Production Builders
+
+Generalize these from:
+
+- current knowledge-maintenance signals
+
+to:
+
+- pack-aware observation surfaces built on domain truth and domain policy
+
+## 10. Migration Principle
+
+OVP should evolve under this rule:
+
+1. keep current `research-tech` behavior working,
+2. move one deeper layer at a time behind an explicit contract,
+3. do not let external packs bypass audit, queue, or rebuild discipline,
+4. do not let core keep domain semantics just because the first pack needed them.
+
+## 11. Success Condition
+
+This effort is successful when all three statements are true:
+
+1. `research-tech` still works as the default in-repo knowledge pack.
+2. OVP core no longer assumes that every useful domain has `evergreen`, `Event Dossier`, and current contradiction semantics.
+3. An external domain system such as media can reuse the runtime, queue, audit, and UI shell without reimplementing the whole platform.

--- a/docs/plans/2026-04-15-phase14-orchestration-integration-plan.md
+++ b/docs/plans/2026-04-15-phase14-orchestration-integration-plan.md
@@ -8,6 +8,11 @@
 
 **Tech Stack:** Python 3.13, existing `truth_api`, `ui_server`, `unified_pipeline_enhanced.py`, JSONL/audit logs, pytest.
 
+**Architecture follow-up:** This orchestration plan now depends on a deeper runtime split captured in:
+
+- [2026-04-15-ovp-layer-contract.md](2026-04-15-ovp-layer-contract.md)
+- [2026-04-15-stage-handler-registry-design.md](2026-04-15-stage-handler-registry-design.md)
+
 ## Current State
 
 The repo already has two partially overlapping systems:
@@ -302,6 +307,10 @@ The worker should:
 - dispatch by `action_kind`
 - record outcome
 
+This dispatch should not be implemented as another local dict of hard-coded handlers.
+It should be extracted through the Stage Handler Registry design so queue execution,
+profile execution, and autopilot all converge on the same handler contract.
+
 **Step 2: Keep handlers thin**
 
 Do not duplicate pipeline logic in the worker.
@@ -321,6 +330,7 @@ Needed handlers:
 - one deep dive -> evergreen/object extraction
 
 These should reuse existing workflow primitives as much as possible.
+They should be registered as focused handlers, not hidden behind `truth_api.py` imports.
 
 **Step 2: Queue auto-policy**
 

--- a/docs/plans/2026-04-15-stage-handler-registry-design.md
+++ b/docs/plans/2026-04-15-stage-handler-registry-design.md
@@ -1,0 +1,373 @@
+# Stage Handler Registry Design
+
+**Goal:** Define the first concrete runtime extraction step needed after pack metadata extraction: make OVP execution paths resolve through an explicit handler registry instead of directly importing current `research-tech` workflow implementations.
+
+**Status:** Design only. No code contract is changed by this document.
+
+## 1. Background
+
+OVP already completed an important first platform split:
+
+- packs can declare object kinds,
+- packs can declare workflow profiles,
+- packs can declare extraction, operation, and wiki view surfaces,
+- runtime selection can choose `--pack` and `--profile`.
+
+That was the correct first step.
+
+But it only extracted the **descriptive layer**.
+
+Below that layer, execution still relies on direct knowledge-pack assumptions:
+
+- workflow stage strings are executed by core `if/elif` branching,
+- focused action handlers import current deep-dive and evergreen workflows directly,
+- the queue worker does not resolve handlers through a pack-aware contract,
+- autopilot still assumes the current stage implementation graph.
+
+This creates an illusion of full pack generality while preserving a deeper coupling to the first in-repo domain system.
+
+## 2. Why This Design Is Needed Now
+
+The immediate trigger is not abstract architecture work. It is external domain pressure.
+
+### What the media pack exercise exposed
+
+The media domain effort is already pushing on a different set of needs:
+
+- different object model
+- different workflow DAG
+- different review gates
+- different truth projection requirements
+- different product surfaces
+
+That is expected and desirable.
+
+However, the current runtime does not fail at the metadata level. It fails one level deeper.
+
+The current problems exposed by media are:
+
+1. an external pack can declare stages, but cannot yet declare how those stages execute in a first-class way,
+2. the action queue can enqueue generic actions, but execution still resolves to current knowledge handlers,
+3. there is no stable contract for saying:
+   - this stage is batch-oriented,
+   - this action is focused,
+   - this handler is safe for autopilot,
+   - this handler belongs to this pack,
+4. processor mode and quality evaluation are still outside the core runtime contract.
+
+This means an external media system can currently reuse:
+
+- pack metadata
+- queue direction
+- shell direction
+
+but cannot yet cleanly reuse:
+
+- execution dispatch
+- focused follow-up workflows
+- stage-level handler ownership
+
+Without this layer, external packs will keep drifting toward “register surfaces here, implement the real system elsewhere.”
+
+## 3. Problem Statement
+
+OVP currently has three execution paths that should converge, but do not yet share an explicit dispatch contract.
+
+### Path A: profile execution
+
+`WorkflowProfile.stages` is declared in pack metadata, but core still executes stage names through direct branching.
+
+### Path B: autopilot execution
+
+Autopilot checks whether a profile includes stages such as `absorb`, `moc`, and `knowledge_index`, but still calls the current in-repo handlers directly.
+
+### Path C: action queue execution
+
+The queue system already has the correct product direction:
+
+- many observation surfaces
+- one execution surface
+
+But queue dispatch still resolves `action_kind` to concrete `research-tech` flow imports inside `truth_api.py`.
+
+These three paths should converge on one handler contract.
+
+## 4. Design Goal
+
+Introduce a **Stage Handler Registry** that becomes the execution bridge between:
+
+- pack/profile declarations,
+- queue actions,
+- focused workflow handlers,
+- broad batch runtime entrypoints.
+
+The registry should answer:
+
+- what handler executes a given stage,
+- what handler executes a given focused action,
+- which pack owns that handler,
+- whether it is safe for autopilot or safe-only queue execution,
+- what target scope it expects,
+- how core should call it.
+
+## 5. Non-Goals
+
+This slice is intentionally narrow.
+
+It does **not** fully solve:
+
+- pack-aware truth projection,
+- pack-aware UI payload builders,
+- pack-aware signal semantics,
+- media truth/object integration,
+- full processor control-plane implementation,
+- full LLM/rule mode orchestration.
+
+It only extracts the execution dispatch layer.
+
+## 6. Target Contract
+
+The runtime should distinguish two handler families.
+
+### A. Stage handlers
+
+Used for:
+
+- profile execution
+- broad or profile-scoped pipeline runs
+- autopilot stage resolution
+
+Examples:
+
+- `articles`
+- `quality`
+- `absorb`
+- `moc`
+- `knowledge_index`
+
+### B. Focused action handlers
+
+Used for:
+
+- queue worker execution
+- single-note or single-object follow-up actions
+
+Examples:
+
+- `deep_dive_workflow`
+- `object_extraction_workflow`
+- later:
+  - `topic_refresh_workflow`
+  - `brief_rebuild_workflow`
+  - `repair_production_gap`
+
+Both families should be resolved from one registry contract.
+
+## 7. Proposed Data Model
+
+Current `StageHandlerSpec` is too thin to carry real runtime meaning.
+
+It should evolve into a richer execution descriptor with fields equivalent to:
+
+- `name`
+- `pack`
+- `handler_kind`
+  - `profile_stage`
+  - `focused_action`
+- `stage`
+- `action_kind`
+- `description`
+- `entrypoint`
+- `target_mode`
+  - `batch`
+  - `single_note`
+  - `single_object`
+  - `pack_scope`
+- `supports_autopilot`
+- `safe_to_run`
+- `requires_truth_refresh`
+- `requires_signal_resync`
+
+Not every field must ship in the first code slice, but the design should target this shape.
+
+## 8. Runtime Behavior
+
+### Profile execution path
+
+Current flow:
+
+- resolve pack
+- resolve profile
+- iterate stage names
+- core decides how to execute each string
+
+Target flow:
+
+- resolve pack
+- resolve profile
+- for each stage:
+  - resolve handler from registry
+  - execute through a common runtime adapter
+  - collect result and audit
+
+### Autopilot path
+
+Current flow:
+
+- check whether profile includes stage names
+- call current in-repo helper methods directly
+
+Target flow:
+
+- resolve handlers for supported stages
+- execute only handlers marked compatible with autopilot
+
+### Action queue path
+
+Current flow:
+
+- load queued action
+- map `action_kind` via an in-function dict
+- call direct imports
+
+Target flow:
+
+- load queued action
+- resolve focused action handler from registry
+- re-check preconditions
+- execute through common runtime adapter
+- apply refresh policy
+
+## 9. Common Runtime Adapter
+
+Core still needs one thin adapter around handlers.
+
+That adapter should own:
+
+- uniform call signature normalization
+- audit/logging
+- result normalization
+- error classification
+- optional truth refresh
+- optional signal resync
+
+This keeps handler code domain-owned while preserving one execution discipline.
+
+## 10. Research-Tech First Migration
+
+The first implementation should not try to support every hypothetical domain.
+
+It should migrate current `research-tech` execution first.
+
+### First handlers to register
+
+Stage handlers:
+
+- `articles`
+- `quality`
+- `absorb`
+- `moc`
+- `refine`
+- `knowledge_index`
+
+Focused action handlers:
+
+- `deep_dive_workflow`
+- `object_extraction_workflow`
+
+The success condition for the first code slice is:
+
+- current behavior remains the same,
+- but dispatch no longer relies on hard-coded stage/action branches in the core runtime.
+
+## 11. Relationship To The Processor Control Plane
+
+The handler registry is not the full processor control plane.
+
+It is the execution bridge that must exist before processor metadata becomes truly operational.
+
+Relationship:
+
+- handler registry says **who executes what**
+- processor control plane says **how that processor is shaped**
+  - mode
+  - inputs
+  - outputs
+  - quality hooks
+
+The media project already exposed the need for the second layer, but OVP should extract the first one first.
+
+## 12. Relationship To Media
+
+This design does not implement media support directly.
+
+What it does is remove the first blocking illusion:
+
+- before: external media packs could declare workflow surfaces but not participate cleanly in execution dispatch
+- after this slice: external packs can at least plug focused and staged execution into the same runtime shell
+
+What remains unsolved after this slice:
+
+- media truth projection
+- media event semantics
+- media topic and briefing surfaces
+- media-specific UI payload builders
+
+That is acceptable.
+
+The objective of this slice is not “make media work.”
+
+The objective is:
+
+> make OVP execution no longer accidentally synonymous with `research-tech`.
+
+## 13. Milestone Adjustment
+
+This design implies a small but important update to the current milestone narrative.
+
+### Milestone 9A should be split conceptually into three sub-slices
+
+#### Slice 9A-1: Stage Handler Registry
+
+Extract execution dispatch from current in-repo handler coupling.
+
+#### Slice 9A-2: Pack-Aware Truth Projection
+
+Move domain truth building behind contracts.
+
+#### Slice 9A-3: Pack-Aware Observation Surfaces
+
+Move `signals`, `briefing`, `production`, and related payload builders behind pack/domain-aware contracts.
+
+This is a sequencing adjustment, not a strategy reversal.
+
+## 14. Expected Code Scope For The First Implementation Slice
+
+This should be a medium-sized runtime refactor, not a major rewrite.
+
+Likely touched areas:
+
+- `packs/base.py`
+- `packs/loader.py`
+- new execution/registry module
+- `unified_pipeline_enhanced.py`
+- `autopilot/daemon.py`
+- `truth_api.py`
+- `research-tech` pack registration
+- focused tests for dispatch and queue behavior
+
+This should remain a focused execution-layer change.
+
+It should not simultaneously rewrite:
+
+- truth store projection
+- DB schema semantics
+- UI semantics
+
+## 15. Success Condition
+
+This design is successful when:
+
+1. current `research-tech` batch and focused flows still work,
+2. queue dispatch no longer directly hard-codes current knowledge handlers,
+3. future external packs have a real runtime insertion point below metadata and above truth projection.


### PR DESCRIPTION
## Summary
This is a docs-only PR.

It clarifies the next platform extraction step for OVP so the runtime does not remain implicitly bound to `research-tech` while external domain systems such as media continue to pressure the deeper layers.

## What Changed
- add an explicit OVP layer contract
- add a detailed Stage Handler Registry design doc
- connect the design back into the phase14 orchestration plan
- adjust the main milestone plan to sequence the next extraction work as:
  1. Stage Handler Registry
  2. Pack-Aware Truth Projection
  3. Pack-Aware Observation Surfaces

## Why
The media pack exercise exposed that OVP already extracted pack metadata, but deeper execution dispatch is still hard-wired to current knowledge-pack handlers. This PR documents the intended separation before code changes begin.

## Scope
Docs only.

No runtime code, DB schema, queue behavior, or handler implementation changed in this PR.

## Merge Guidance
Safe to merge directly as a planning/documentation PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/24" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
