### PR TITLE
feat: close out phase15 graph intelligence

### DIFF
--- a/docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
+++ b/docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
@@ -485,63 +485,17 @@ Exit condition:
 
 Closeout:
 
-- [2026-04-15-phase15-graph-intelligence-closeout.md](2026-04-15-phase15-graph-intelligence-closeout.md)
+- [[2026-04-15-phase15-graph-intelligence-closeout]]
 
 ## Recommended Next Sequence
 
-### Finish Phase 10: Event + Contradiction Hardening
+The historical Phase 10 -> Phase 15 ordering below is now complete and should be treated as archived milestone history, not as the active follow-up plan.
 
-Do first.
+Use the `Architecture follow-up` and `Implementation sequence` sections above as the current next-step order:
 
-Reason:
-
-- the review workbench is now strong enough that model weaknesses are visible,
-- event and contradiction semantics need to become trustworthy before we add more intelligence on top.
-
-### Phase 11: Knowledge Production Traceability
-
-Do next.
-
-Reason:
-
-- this is still the most legible product-value surface,
-- it closes the source -> deep dive -> evergreen -> Atlas chain,
-- it prepares the evidence trail required for later active intelligence.
-
-### Phase 12: Active Signal Loop
-
-Do after Phase 11.
-
-Reason:
-
-- once production traceability is strong, asynchronous signal capture can safely create backlinks, entities, and updates,
-- this is the first real step from “workbench” to “active system.”
-
-### Phase 13: Knowledge Evolution Layer
-
-Do after Phase 12.
-
-Reason:
-
-- evolution links depend on better signal capture and graph linking,
-- they turn the current maintenance model into a more complete model of changing understanding.
-
-### Phase 14: Background Intelligence
-
-Do after Phase 13.
-
-Reason:
-
-- briefings, insights, and proactive flags should sit on top of a stable evolution layer,
-- otherwise they become noisy product theater instead of useful intelligence.
-
-### Phase 15: Graph Intelligence And Synthesis
-
-Do after Phase 14.
-
-Reason:
-
-- community detection, clusters, and crystal-like synthesis become much more useful once the graph and evolution layers are already trustworthy.
+1. `Stage Handler Registry`
+2. `Pack-Aware Truth Projection`
+3. `Pack-Aware Observation Surfaces`
 
 ## Non-Recommended Paths Right Now
 

--- a/docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
+++ b/docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
@@ -465,7 +465,7 @@ Implementation sequence:
 
 ### Milestone 10: Graph Intelligence And Synthesis
 
-Status: **Not Started**
+Status: **Implemented**
 
 Goal:
 
@@ -482,6 +482,10 @@ Core deliverables:
 Exit condition:
 
 - users can see coherent topic clusters, cross-domain links, and evolving synthesized references grounded in source-cited knowledge.
+
+Closeout:
+
+- [2026-04-15-phase15-graph-intelligence-closeout.md](2026-04-15-phase15-graph-intelligence-closeout.md)
 
 ## Recommended Next Sequence
 

--- a/docs/plans/2026-04-15-phase15-graph-intelligence-closeout.md
+++ b/docs/plans/2026-04-15-phase15-graph-intelligence-closeout.md
@@ -1,0 +1,71 @@
+# Phase 15: Graph Intelligence And Synthesis Closeout
+
+Status: Implemented
+
+## Goal
+
+Use the pack-aware truth graph as a substrate for cluster discovery, local graph drill-down, and deterministic synthesized research reading surfaces.
+
+## Delivered
+
+- pack-aware truth substrate for graph projections inside a shared `knowledge.db`
+- multi-pack truth projection coexistence without `research-tech` overwriting other pack rows
+- graph cluster browser surface
+- graph cluster detail surface
+- deterministic cluster synthesis summaries
+- compiled cluster overview pages
+- compiled cluster crystal pages
+- structural cluster labels
+- relation pattern summaries
+- review pressure drill-down:
+  - open contradictions
+  - stale summaries
+- related cluster neighborhood surfacing
+- bridge kinds and bridge bands for cluster-to-cluster explanation
+- neighborhood grouping by bridge kind
+- deterministic next-read routing
+- deterministic reading routes with:
+  - route rank
+  - route score
+  - route reason
+- browser-level surfacing of:
+  - top reading route
+  - route availability
+  - reading intent count / preview
+
+## Exit Condition Check
+
+Milestone 10 required:
+
+- community detection over objects and relations
+- cluster labels and topic maps
+- cross-domain connection surfacing
+- crystal-like synthesized reference views
+- visual/query surfaces that explain why items belong together
+
+This is now satisfied for the current `research-tech` pack because:
+
+- graph clusters are materialized from pack-owned graph seed projections
+- `/clusters` and `/cluster` provide live graph browsing and local subgraph drill-down
+- `overview/clusters` and `cluster/crystal` provide compiled synthesis artifacts
+- related clusters, bridge kinds, neighborhood groups, and reading routes explain why clusters belong together
+- all synthesis stays source-cited through existing provenance, review pressure, source-note coverage, and atlas-page coverage
+
+## Explicit Deferrals
+
+These are not Phase 15 blockers:
+
+- global infinite-canvas graph UI
+- model-generated cluster narratives
+- multi-hop route planning across more than one neighbor step
+- generalized cross-pack graph semantics shared across domains
+- richer graph semantics beyond the current pack-owned seed model
+
+## Phase 16 Entry
+
+Phase 16 should start from a closed assumption:
+
+- Phase 15 already delivered a usable deterministic graph intelligence layer for `research-tech`
+- further graph work is optional enhancement, not a prerequisite for the next phase
+
+If Phase 16 needs graph data, it should consume the existing pack-aware cluster and crystal surfaces instead of reopening Phase 15 scope.

--- a/src/openclaw_pipeline/commands/build_views.py
+++ b/src/openclaw_pipeline/commands/build_views.py
@@ -19,6 +19,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--view", required=True, help="Wiki view name")
     parser.add_argument("--object-id", help="Object ID for object-specific materializers")
+    parser.add_argument("--cluster-id", help="Cluster ID for cluster-specific materializers")
     args = parser.parse_args(argv)
 
     vault_dir = resolve_vault_dir(args.vault_dir)
@@ -26,6 +27,8 @@ def main(argv: list[str] | None = None) -> int:
     view = pack.wiki_view(args.view)
     if view.builder == "object_page" and not args.object_id:
         parser.error("the --object-id argument is required for object/page views")
-    output_path = build_view(vault_dir, view, object_id=args.object_id)
+    if view.builder == "cluster_crystal" and not args.cluster_id:
+        parser.error("the --cluster-id argument is required for cluster/crystal views")
+    output_path = build_view(vault_dir, view, object_id=args.object_id, cluster_id=args.cluster_id)
     print(json.dumps({"output_path": str(output_path)}, ensure_ascii=False))
     return 0

--- a/src/openclaw_pipeline/commands/truth_api.py
+++ b/src/openclaw_pipeline/commands/truth_api.py
@@ -10,6 +10,7 @@ from ..truth_api import (
     get_object_detail,
     get_topic_neighborhood,
     list_contradictions,
+    list_graph_clusters,
     list_objects,
 )
 
@@ -33,6 +34,11 @@ def main(argv: list[str] | None = None) -> int:
     contradictions_parser.add_argument("--limit", type=int, default=100)
     contradictions_parser.add_argument("--status", default=None)
     contradictions_parser.add_argument("--query", default=None, help="Case-insensitive contradiction search")
+
+    clusters_parser = subparsers.add_parser("clusters", help="List graph clusters")
+    clusters_parser.add_argument("--vault-dir", type=Path, default=None, help="Vault directory")
+    clusters_parser.add_argument("--limit", type=int, default=100)
+    clusters_parser.add_argument("--query", default=None, help="Case-insensitive cluster search")
 
     neighborhood_parser = subparsers.add_parser("neighborhood", help="Fetch topic neighborhood")
     neighborhood_parser.add_argument("--vault-dir", type=Path, default=None, help="Vault directory")
@@ -58,6 +64,14 @@ def main(argv: list[str] | None = None) -> int:
                     vault_dir,
                     limit=args.limit,
                     status=args.status,
+                    query=args.query,
+                )
+            }
+        elif args.command == "clusters":
+            payload = {
+                "items": list_graph_clusters(
+                    vault_dir,
+                    limit=args.limit,
                     query=args.query,
                 )
             }

--- a/src/openclaw_pipeline/commands/truth_api.py
+++ b/src/openclaw_pipeline/commands/truth_api.py
@@ -38,6 +38,7 @@ def main(argv: list[str] | None = None) -> int:
 
     clusters_parser = subparsers.add_parser("clusters", help="List graph clusters")
     clusters_parser.add_argument("--vault-dir", type=Path, default=None, help="Vault directory")
+    clusters_parser.add_argument("--pack", default=None, help="Pack namespace for the cluster list")
     clusters_parser.add_argument("--limit", type=int, default=100)
     clusters_parser.add_argument("--query", default=None, help="Case-insensitive cluster search")
 
@@ -77,6 +78,7 @@ def main(argv: list[str] | None = None) -> int:
             payload = {
                 "items": list_graph_clusters(
                     vault_dir,
+                    pack_name=args.pack,
                     limit=args.limit,
                     query=args.query,
                 )

--- a/src/openclaw_pipeline/commands/truth_api.py
+++ b/src/openclaw_pipeline/commands/truth_api.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from ..runtime import resolve_vault_dir
 from ..truth_api import (
+    get_graph_cluster_detail,
     get_object_detail,
     get_topic_neighborhood,
     list_contradictions,
@@ -39,6 +40,11 @@ def main(argv: list[str] | None = None) -> int:
     clusters_parser.add_argument("--vault-dir", type=Path, default=None, help="Vault directory")
     clusters_parser.add_argument("--limit", type=int, default=100)
     clusters_parser.add_argument("--query", default=None, help="Case-insensitive cluster search")
+
+    cluster_parser = subparsers.add_parser("cluster", help="Fetch graph cluster detail")
+    cluster_parser.add_argument("--vault-dir", type=Path, default=None, help="Vault directory")
+    cluster_parser.add_argument("--id", required=True, help="Cluster id")
+    cluster_parser.add_argument("--pack", default=None, help="Pack namespace for the cluster")
 
     neighborhood_parser = subparsers.add_parser("neighborhood", help="Fetch topic neighborhood")
     neighborhood_parser.add_argument("--vault-dir", type=Path, default=None, help="Vault directory")
@@ -75,6 +81,8 @@ def main(argv: list[str] | None = None) -> int:
                     query=args.query,
                 )
             }
+        elif args.command == "cluster":
+            payload = get_graph_cluster_detail(vault_dir, args.id, pack_name=args.pack)
         elif args.command == "neighborhood":
             payload = get_topic_neighborhood(vault_dir, args.id, depth=args.depth)
         else:  # pragma: no cover - argparse enforces commands

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -1422,6 +1422,14 @@ def _render_cluster_detail_page(payload: dict) -> str:
         f"<li>{escape(item['title'])} <span class='pill'>{item['object_count']} objects</span></li>"
         for item in payload["top_mocs"]
     ) or "<li class='muted'>No atlas coverage.</li>"
+    open_contradictions = "".join(
+        f"<li><a href=\"{escape(item['path'])}\">{escape(item['subject_key'])}</a> <span class='pill'>{len(item['object_ids'])} objects</span></li>"
+        for item in payload["open_contradictions"]
+    ) or "<li class='muted'>No open contradictions in this cluster.</li>"
+    stale_summaries = "".join(
+        f"<li><a href=\"{escape(item['object_path'])}\">{escape(item['title'])}</a> <span class='pill'>{', '.join(escape(code) for code in item['reason_codes'])}</span></li>"
+        for item in payload["stale_summaries"]
+    ) or "<li class='muted'>No stale summaries in this cluster.</li>"
     relation_patterns = "".join(
         f"<li>{escape(item['display_name'])} <span class='pill'>{item['count']}</span></li>"
         for item in payload["relation_pattern_items"]
@@ -1442,6 +1450,7 @@ def _render_cluster_detail_page(payload: dict) -> str:
             f"<section class='card'><h2>Cluster Synthesis</h2><ul class='list-tight'>{summary_bullets}</ul></section>"
             f"<section class='card'><h2>Structural Label</h2><p><strong>{escape(payload['structural_label']['title'])}</strong></p><p class='muted'>{escape(payload['structural_label']['reason'])}</p></section>"
             f"<section class='card'><h2>Relation Patterns</h2><ul class='list-tight'>{relation_patterns}</ul></section>"
+            f"<section class='card'><h2>Review Pressure</h2><h3>Open Contradictions</h3><ul class='list-tight'>{open_contradictions}</ul><h3>Stale Summaries</h3><ul class='list-tight'>{stale_summaries}</ul></section>"
             f"<section class='card'><h2>Edge Kinds</h2><div class='link-row'>{edge_kind_counts}</div></section>"
             f"<section class='card'><h2>Object Kinds</h2><div class='link-row'>{object_kind_counts}</div></section>"
             f"<section class='card'><h2>Coverage</h2><p class='muted'>"

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -1330,6 +1330,7 @@ def _render_clusters_page(payload: dict) -> str:
         "<li>"
         f'<a href="{escape(item["detail_path"])}">{escape(item["label"])}</a>'
         + f" <span class='pill'>{escape(item['cluster_kind'])}</span>"
+        + f" <span class='pill'>{escape(item['priority_band'])}</span>"
         + f" <span class='pill'>{item['member_count']} objects</span>"
         + (
             " <span class='muted'>"
@@ -1340,6 +1341,12 @@ def _render_clusters_page(payload: dict) -> str:
             + "</span>"
         )
         + f"<div class='muted'>Center: <a href='{escape(item['center_object_path'])}'>{escape(item['center_title'])}</a></div>"
+        + f"<div class='muted'>Priority: {escape(item['priority_reason'])}</div>"
+        + (
+            f"<div class='muted'>{escape(item['top_summary_bullet'])}</div>"
+            if item.get("top_summary_bullet")
+            else ""
+        )
         + "</li>"
         for item in payload["items"]
     ) or "<li class='muted'>No graph clusters found.</li>"

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -1476,11 +1476,13 @@ def _render_cluster_detail_page(payload: dict) -> str:
     ) or "<li class='muted'>No neighborhood groups surfaced for this cluster.</li>"
     reading_routes = "".join(
         "<li>"
+        f"<span class='pill'>#{item['route_rank']}</span> "
         f"{escape(item['display_name'])}: "
         f"<a href=\"{escape(item['detail_path'])}\">{escape(item['display_title'])}</a> "
         f"<span class='pill'>{escape(item['bridge_kind'])}</span> "
         f"<span class='pill'>{escape(item['bridge_band'])}</span>"
-        f"<div class='muted'>{escape(item['reason'])}</div>"
+        f"<div class='muted'>Score: {item['route_score']} · {escape(item['route_reason'])}</div>"
+        f"<div class='muted'>Bridge evidence: {escape(item['reason'])}</div>"
         "</li>"
         for item in payload["reading_routes"]
     ) or "<li class='muted'>No reading routes derived for this cluster.</li>"

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -1464,6 +1464,16 @@ def _render_cluster_detail_page(payload: dict) -> str:
         + "</li>"
         for item in payload["related_clusters"]
     ) or "<li class='muted'>No related clusters surfaced for this scope.</li>"
+    related_cluster_groups = "".join(
+        f"<li>{escape(item['display_name'])} <span class='pill'>{item['count']}</span>"
+        + (
+            f"<div class='muted'>{escape(', '.join(item['cluster_titles'][:3]))}</div>"
+            if item["cluster_titles"]
+            else ""
+        )
+        + "</li>"
+        for item in payload["related_cluster_groups"]
+    ) or "<li class='muted'>No neighborhood groups surfaced for this cluster.</li>"
     next_read_cluster = payload.get("next_read_cluster")
     next_read_route = (
         "<p>"
@@ -1505,6 +1515,7 @@ def _render_cluster_detail_page(payload: dict) -> str:
             f"<section class='card'><h2>Relation Patterns</h2><ul class='list-tight'>{relation_patterns}</ul></section>"
             f"<section class='card'><h2>Review Pressure</h2><h3>Open Contradictions</h3><ul class='list-tight'>{open_contradictions}</ul><h3>Stale Summaries</h3><ul class='list-tight'>{stale_summaries}</ul></section>"
             f"<section class='card'><h2>Next Reading Route</h2>{next_read_route}</section>"
+            f"<section class='card'><h2>Neighborhood Groups</h2><ul class='list-tight'>{related_cluster_groups}</ul></section>"
             f"<section class='card'><h2>Related Clusters</h2><ul class='list-tight'>{related_clusters}</ul></section>"
             f"<section class='card'><h2>Edge Kinds</h2><div class='link-row'>{edge_kind_counts}</div></section>"
             f"<section class='card'><h2>Object Kinds</h2><div class='link-row'>{object_kind_counts}</div></section>"

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -1355,6 +1355,11 @@ def _render_clusters_page(payload: dict) -> str:
             else ""
         )
         + (
+            f"<div class='muted'>Neighborhood: {escape(item['neighborhood_band'])} · {escape(item['neighborhood_reason'])}</div>"
+            if item.get("neighborhood_score")
+            else ""
+        )
+        + (
             f"<div class='muted'>{escape(item['top_summary_bullet'])}</div>"
             if item.get("top_summary_bullet")
             else ""

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -1355,7 +1355,7 @@ def _render_clusters_page(payload: dict) -> str:
             else ""
         )
         + (
-            f"<div class='muted'>Neighborhood: {escape(item['neighborhood_band'])} · {escape(item['neighborhood_reason'])}</div>"
+            f"<div class='muted'>Neighborhood: {escape(item['neighborhood_band'])} · {escape(item['neighborhood_bridge_kind'])} · {escape(item['neighborhood_reason'])}</div>"
             if item.get("neighborhood_score")
             else ""
         )
@@ -1449,6 +1449,7 @@ def _render_cluster_detail_page(payload: dict) -> str:
         "<li>"
         f"<a href=\"{escape(item['detail_path'])}\">{escape(item['display_title'])}</a> "
         f"<span class='pill'>{item['member_count']} objects</span> "
+        f"<span class='pill'>{escape(item['bridge_kind'])}</span> "
         f"<span class='pill'>{escape(item['reason'])}</span>"
         + (
             f"<div class='muted'>Shared source notes: {escape(', '.join(item['shared_source_titles']))}</div>"
@@ -1467,6 +1468,7 @@ def _render_cluster_detail_page(payload: dict) -> str:
     next_read_route = (
         "<p>"
         f"<a href=\"{escape(next_read_cluster['detail_path'])}\">{escape(next_read_cluster['display_title'])}</a> "
+        f"<span class='pill'>{escape(next_read_cluster['bridge_kind'])}</span> "
         f"<span class='pill'>{escape(next_read_cluster['bridge_band'])}</span>"
         "</p>"
         f"<p class='muted'>{escape(next_read_cluster['reason'])}</p>"

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -23,6 +23,7 @@ from ..ui.view_models import (
     build_atlas_browser_payload,
     build_briefing_payload,
     build_cluster_browser_payload,
+    build_cluster_detail_payload,
     build_contradiction_browser_payload,
     build_derivation_browser_payload,
     build_evolution_browser_payload,
@@ -1327,7 +1328,7 @@ def _render_clusters_page(payload: dict) -> str:
     ) or "<span class='muted'>None</span>"
     items = "".join(
         "<li>"
-        f'<a href="{escape(item["center_object_path"])}">{escape(item["label"])}</a>'
+        f'<a href="{escape(item["detail_path"])}">{escape(item["label"])}</a>'
         + f" <span class='pill'>{escape(item['cluster_kind'])}</span>"
         + f" <span class='pill'>{item['member_count']} objects</span>"
         + (
@@ -1355,6 +1356,48 @@ def _render_clusters_page(payload: dict) -> str:
             f"<section class='card'><h2>Cluster Kinds</h2><div class='link-row'>{kind_counts}</div></section>"
             f"<section class='card'><h2>Model Notes</h2><ul class='list-tight'>{model_notes}</ul></section>"
             f"<section class='card'><ul class='list-tight'>{items}</ul></section>"
+        ),
+    )
+
+
+def _render_cluster_detail_page(payload: dict) -> str:
+    cluster = payload["cluster"]
+    edge_kind_counts = "".join(
+        f"<span class='pill'>{escape(edge_kind)}: {count}</span>"
+        for edge_kind, count in payload["edge_kind_counts"].items()
+    ) or "<span class='muted'>None</span>"
+    members = "".join(
+        f'<li><a href="{escape(member["path"])}">{escape(member["title"])}</a></li>'
+        for member in cluster["member_links"]
+    ) or "<li class='muted'>No members.</li>"
+    edges = "".join(
+        "<li>"
+        f'<a href="{escape(edge["source_path"])}">{escape(edge["source_title"])}</a>'
+        f" <span class='pill'>{escape(edge['edge_kind'])}</span> "
+        f'<a href="{escape(edge["target_path"])}">{escape(edge["target_title"])}</a>'
+        + (
+            f" <span class='muted'>source: {escape(edge['evidence_source_slug'])}</span>"
+            if edge["evidence_source_slug"]
+            else ""
+        )
+        + "</li>"
+        for edge in payload["edges"]
+    ) or "<li class='muted'>No internal edges for this cluster.</li>"
+    model_notes = "".join(f"<li>{escape(note)}</li>" for note in payload["model_notes"])
+    return _layout(
+        "Graph Cluster",
+        (
+            "<h1>Graph Cluster</h1>"
+            f"<p><a href='/clusters'>Back to clusters</a></p>"
+            f"<section class='card'><h2>{escape(cluster['label'])}</h2>"
+            f"<p class='muted'>Pack: {escape(cluster['pack'])} · Kind: {escape(cluster['cluster_kind'])} · Score: {cluster['score']:.1f}</p>"
+            f"<p>Center: <a href='{escape(cluster['center_object_path'])}'>{escape(cluster['center_title'])}</a></p>"
+            f"<p class='muted'>{cluster['member_count']} member objects.</p>"
+            "</section>"
+            f"<section class='card'><h2>Edge Kinds</h2><div class='link-row'>{edge_kind_counts}</div></section>"
+            f"<section class='card'><h2>Members</h2><ul class='list-tight'>{members}</ul></section>"
+            f"<section class='card'><h2>Internal Edges</h2><ul class='list-tight'>{edges}</ul></section>"
+            f"<section class='card'><h2>Model Notes</h2><ul class='list-tight'>{model_notes}</ul></section>"
         ),
     )
 
@@ -2058,6 +2101,17 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
                     q = query.get("q", [""])[0]
                     payload = build_cluster_browser_payload(resolved_vault, query=q)
                     self._write_html(_render_clusters_page(payload))
+                    return
+                if path == "/api/cluster":
+                    cluster_id = self._required(query, "id")
+                    pack_name = query.get("pack", [""])[0] or None
+                    self._write_json(build_cluster_detail_payload(resolved_vault, cluster_id=cluster_id, pack_name=pack_name))
+                    return
+                if path == "/cluster":
+                    cluster_id = self._required(query, "id")
+                    pack_name = query.get("pack", [""])[0] or None
+                    payload = build_cluster_detail_payload(resolved_vault, cluster_id=cluster_id, pack_name=pack_name)
+                    self._write_html(_render_cluster_detail_page(payload))
                     return
                 if path == "/api/actions":
                     status = query.get("status", [""])[0] or None

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -22,6 +22,7 @@ from ..ui.view_models import (
     build_action_queue_payload,
     build_atlas_browser_payload,
     build_briefing_payload,
+    build_cluster_browser_payload,
     build_contradiction_browser_payload,
     build_derivation_browser_payload,
     build_evolution_browser_payload,
@@ -121,6 +122,7 @@ def _layout(title: str, body: str) -> str:
             <a href="/actions">Actions</a>
             <a href="/evolution">Evolution</a>
             <a href="/production">Production</a>
+            <a href="/clusters">Clusters</a>
             <a href="/atlas">Atlas</a>
             <a href="/deep-dives">Deep Dives</a>
             <a href="/events">Event Dossier</a>
@@ -1312,6 +1314,51 @@ def _render_production_browser_page(payload: dict) -> str:
     )
 
 
+def _render_clusters_page(payload: dict) -> str:
+    query = payload.get("query", "")
+    limit_note = (
+        f" Showing the first {payload['limit']} graph clusters in this browser window."
+        if payload.get("is_limited")
+        else ""
+    )
+    kind_counts = "".join(
+        f"<span class='pill'>{escape(cluster_kind)}: {count}</span>"
+        for cluster_kind, count in payload["cluster_kind_counts"].items()
+    ) or "<span class='muted'>None</span>"
+    items = "".join(
+        "<li>"
+        f'<a href="{escape(item["center_object_path"])}">{escape(item["label"])}</a>'
+        + f" <span class='pill'>{escape(item['cluster_kind'])}</span>"
+        + f" <span class='pill'>{item['member_count']} objects</span>"
+        + (
+            " <span class='muted'>"
+            + ", ".join(
+                f'<a href="{escape(member["path"])}">{escape(member["title"])}</a>'
+                for member in item["member_links"]
+            )
+            + "</span>"
+        )
+        + f"<div class='muted'>Center: <a href='{escape(item['center_object_path'])}'>{escape(item['center_title'])}</a></div>"
+        + "</li>"
+        for item in payload["items"]
+    ) or "<li class='muted'>No graph clusters found.</li>"
+    model_notes = "".join(f"<li>{escape(note)}</li>" for note in payload["model_notes"])
+    return _layout(
+        "Graph Clusters",
+        (
+            "<h1>Graph Clusters</h1>"
+            "<form method='get' action='/clusters'>"
+            f"<input type='text' name='q' value='{escape(query)}' placeholder='Filter clusters or members' /> "
+            "<button type='submit'>Search</button>"
+            "</form>"
+            f"<p class='muted'>{payload['count']} graph clusters. Largest cluster has {payload['largest_cluster_size']} objects.{escape(limit_note)}</p>"
+            f"<section class='card'><h2>Cluster Kinds</h2><div class='link-row'>{kind_counts}</div></section>"
+            f"<section class='card'><h2>Model Notes</h2><ul class='list-tight'>{model_notes}</ul></section>"
+            f"<section class='card'><ul class='list-tight'>{items}</ul></section>"
+        ),
+    )
+
+
 def _render_evolution_browser_page(payload: dict) -> str:
     query = payload.get("query", "")
     status = payload.get("status", "all")
@@ -2002,6 +2049,15 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
                     q = query.get("q", [""])[0]
                     payload = build_production_browser_payload(resolved_vault, query=q)
                     self._write_html(_render_production_browser_page(payload))
+                    return
+                if path == "/api/clusters":
+                    q = query.get("q", [""])[0]
+                    self._write_json(build_cluster_browser_payload(resolved_vault, query=q))
+                    return
+                if path == "/clusters":
+                    q = query.get("q", [""])[0]
+                    payload = build_cluster_browser_payload(resolved_vault, query=q)
+                    self._write_html(_render_clusters_page(payload))
                     return
                 if path == "/api/actions":
                     status = query.get("status", [""])[0] or None

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -1317,6 +1317,7 @@ def _render_production_browser_page(payload: dict) -> str:
 
 def _render_clusters_page(payload: dict) -> str:
     query = payload.get("query", "")
+    requested_pack = payload.get("requested_pack", "")
     limit_note = (
         f" Showing the first {payload['limit']} graph clusters in this browser window."
         if payload.get("is_limited")
@@ -1359,16 +1360,25 @@ def _render_clusters_page(payload: dict) -> str:
     model_notes = "".join(f"<li>{escape(note)}</li>" for note in payload["model_notes"])
     return _layout(
         "Graph Clusters",
-        (
-            "<h1>Graph Clusters</h1>"
-            "<form method='get' action='/clusters'>"
-            f"<input type='text' name='q' value='{escape(query)}' placeholder='Filter clusters or members' /> "
-            "<button type='submit'>Search</button>"
-            "</form>"
-            f"<p class='muted'>{payload['count']} graph clusters. Largest cluster has {payload['largest_cluster_size']} objects.{escape(limit_note)}</p>"
-            f"<section class='card'><h2>Cluster Kinds</h2><div class='link-row'>{kind_counts}</div></section>"
-            f"<section class='card'><h2>Model Notes</h2><ul class='list-tight'>{model_notes}</ul></section>"
-            f"<section class='card'><ul class='list-tight'>{items}</ul></section>"
+        "".join(
+            [
+                "<h1>Graph Clusters</h1>",
+                "<form method='get' action='/clusters'>",
+                (
+                    f"<input type='hidden' name='pack' value='{escape(requested_pack)}' />"
+                    if requested_pack
+                    else ""
+                ),
+                f"<input type='text' name='q' value='{escape(query)}' placeholder='Filter clusters or members' /> ",
+                "<button type='submit'>Search</button>",
+                "</form>",
+                f"<p class='muted'>{payload['count']} graph clusters. Largest cluster has {payload['largest_cluster_size']} objects.",
+                f" Pack scope: {escape(requested_pack)}." if requested_pack else "",
+                f"{escape(limit_note)}</p>",
+                f"<section class='card'><h2>Cluster Kinds</h2><div class='link-row'>{kind_counts}</div></section>",
+                f"<section class='card'><h2>Model Notes</h2><ul class='list-tight'>{model_notes}</ul></section>",
+                f"<section class='card'><ul class='list-tight'>{items}</ul></section>",
+            ]
         ),
     )
 
@@ -1422,7 +1432,7 @@ def _render_cluster_detail_page(payload: dict) -> str:
         "Graph Cluster",
         (
             "<h1>Graph Cluster</h1>"
-            f"<p><a href='/clusters'>Back to clusters</a></p>"
+            f"<p><a href='{escape(payload['browser_path'])}'>Back to clusters</a></p>"
             f"<section class='card'><h2>{escape(payload.get('display_title') or cluster['label'])}</h2>"
             f"<p class='muted'>Pack: {escape(cluster['pack'])} · Kind: {escape(cluster['cluster_kind'])} · Score: {cluster['score']:.1f}</p>"
             f"<p class='muted'>Canonical cluster id: {escape(cluster['label'])}</p>"
@@ -2142,11 +2152,13 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
                     return
                 if path == "/api/clusters":
                     q = query.get("q", [""])[0]
-                    self._write_json(build_cluster_browser_payload(resolved_vault, query=q))
+                    pack_name = query.get("pack", [""])[0] or None
+                    self._write_json(build_cluster_browser_payload(resolved_vault, pack_name=pack_name, query=q))
                     return
                 if path == "/clusters":
                     q = query.get("q", [""])[0]
-                    payload = build_cluster_browser_payload(resolved_vault, query=q)
+                    pack_name = query.get("pack", [""])[0] or None
+                    payload = build_cluster_browser_payload(resolved_vault, pack_name=pack_name, query=q)
                     self._write_html(_render_clusters_page(payload))
                     return
                 if path == "/api/cluster":

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -1350,6 +1350,11 @@ def _render_clusters_page(payload: dict) -> str:
             else ""
         )
         + (
+            f"<div class='muted'>Related clusters: {item['related_cluster_count']} · {escape(item['related_cluster_preview'])}</div>"
+            if item.get("related_cluster_count")
+            else ""
+        )
+        + (
             f"<div class='muted'>{escape(item['top_summary_bullet'])}</div>"
             if item.get("top_summary_bullet")
             else ""

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -1528,7 +1528,7 @@ def _render_cluster_detail_page(payload: dict) -> str:
             f"<p><a href='{escape(payload['browser_path'])}'>Back to clusters</a></p>"
             f"<section class='card'><h2>{escape(payload.get('display_title') or cluster['label'])}</h2>"
             f"<p class='muted'>Pack: {escape(cluster['pack'])} · Kind: {escape(cluster['cluster_kind'])} · Score: {cluster['score']:.1f}</p>"
-            f"<p class='muted'>Canonical cluster id: {escape(cluster['label'])}</p>"
+            f"<p class='muted'>Canonical cluster id: {escape(cluster['cluster_id'])}</p>"
             f"<p>Center: <a href='{escape(cluster['center_object_path'])}'>{escape(cluster['center_title'])}</a></p>"
             f"<p class='muted'>{cluster['member_count']} member objects.</p>"
             "</section>"

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -1360,6 +1360,11 @@ def _render_clusters_page(payload: dict) -> str:
             else ""
         )
         + (
+            f"<div class='muted'>Next read: <a href='{escape(item['next_read_path'])}'>{escape(item['next_read_title'])}</a> · {escape(item['next_read_reason'])}</div>"
+            if item.get("next_read_title")
+            else ""
+        )
+        + (
             f"<div class='muted'>{escape(item['top_summary_bullet'])}</div>"
             if item.get("top_summary_bullet")
             else ""
@@ -1458,6 +1463,24 @@ def _render_cluster_detail_page(payload: dict) -> str:
         + "</li>"
         for item in payload["related_clusters"]
     ) or "<li class='muted'>No related clusters surfaced for this scope.</li>"
+    next_read_cluster = payload.get("next_read_cluster")
+    next_read_route = (
+        "<p>"
+        f"<a href=\"{escape(next_read_cluster['detail_path'])}\">{escape(next_read_cluster['display_title'])}</a> "
+        f"<span class='pill'>{escape(next_read_cluster['bridge_band'])}</span>"
+        "</p>"
+        f"<p class='muted'>{escape(next_read_cluster['reason'])}</p>"
+        + (
+            f"<p class='muted'>Shared source notes: {escape(', '.join(next_read_cluster['shared_source_titles']))}</p>"
+            if next_read_cluster["shared_source_titles"]
+            else ""
+        )
+        + (
+            f"<p class='muted'>Shared atlas pages: {escape(', '.join(next_read_cluster['shared_moc_titles']))}</p>"
+            if next_read_cluster["shared_moc_titles"]
+            else ""
+        )
+    ) if next_read_cluster else "<p class='muted'>No next reading route surfaced for this cluster.</p>"
     relation_patterns = "".join(
         f"<li>{escape(item['display_name'])} <span class='pill'>{item['count']}</span></li>"
         for item in payload["relation_pattern_items"]
@@ -1479,6 +1502,7 @@ def _render_cluster_detail_page(payload: dict) -> str:
             f"<section class='card'><h2>Structural Label</h2><p><strong>{escape(payload['structural_label']['title'])}</strong></p><p class='muted'>{escape(payload['structural_label']['reason'])}</p></section>"
             f"<section class='card'><h2>Relation Patterns</h2><ul class='list-tight'>{relation_patterns}</ul></section>"
             f"<section class='card'><h2>Review Pressure</h2><h3>Open Contradictions</h3><ul class='list-tight'>{open_contradictions}</ul><h3>Stale Summaries</h3><ul class='list-tight'>{stale_summaries}</ul></section>"
+            f"<section class='card'><h2>Next Reading Route</h2>{next_read_route}</section>"
             f"<section class='card'><h2>Related Clusters</h2><ul class='list-tight'>{related_clusters}</ul></section>"
             f"<section class='card'><h2>Edge Kinds</h2><div class='link-row'>{edge_kind_counts}</div></section>"
             f"<section class='card'><h2>Object Kinds</h2><div class='link-row'>{object_kind_counts}</div></section>"

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -1365,6 +1365,11 @@ def _render_clusters_page(payload: dict) -> str:
             else ""
         )
         + (
+            f"<div class='muted'>Top route: {escape(item['top_reading_route_kind'])} · {escape(item['top_reading_route_title'])} · {escape(item['top_reading_route_reason'])}</div>"
+            if item.get("top_reading_route_kind")
+            else ""
+        )
+        + (
             f"<div class='muted'>{escape(item['top_summary_bullet'])}</div>"
             if item.get("top_summary_bullet")
             else ""

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -1366,6 +1366,14 @@ def _render_cluster_detail_page(payload: dict) -> str:
         f"<span class='pill'>{escape(edge_kind)}: {count}</span>"
         for edge_kind, count in payload["edge_kind_counts"].items()
     ) or "<span class='muted'>None</span>"
+    object_kind_counts = "".join(
+        f"<span class='pill'>{escape(object_kind)}: {count}</span>"
+        for object_kind, count in payload["object_kind_counts"].items()
+    ) or "<span class='muted'>None</span>"
+    summary_bullets = "".join(
+        f"<li>{escape(item)}</li>"
+        for item in payload["summary_bullets"]
+    ) or "<li class='muted'>No cluster summary available.</li>"
     members = "".join(
         f'<li><a href="{escape(member["path"])}">{escape(member["title"])}</a></li>'
         for member in cluster["member_links"]
@@ -1383,6 +1391,15 @@ def _render_cluster_detail_page(payload: dict) -> str:
         + "</li>"
         for edge in payload["edges"]
     ) or "<li class='muted'>No internal edges for this cluster.</li>"
+    top_source_notes = "".join(
+        f"<li>{escape(item['title'])} <span class='pill'>{item['object_count']} objects</span></li>"
+        for item in payload["top_source_notes"]
+    ) or "<li class='muted'>No source-note coverage.</li>"
+    top_mocs = "".join(
+        f"<li>{escape(item['title'])} <span class='pill'>{item['object_count']} objects</span></li>"
+        for item in payload["top_mocs"]
+    ) or "<li class='muted'>No atlas coverage.</li>"
+    review_context = payload["review_context"]
     model_notes = "".join(f"<li>{escape(note)}</li>" for note in payload["model_notes"])
     return _layout(
         "Graph Cluster",
@@ -1394,7 +1411,17 @@ def _render_cluster_detail_page(payload: dict) -> str:
             f"<p>Center: <a href='{escape(cluster['center_object_path'])}'>{escape(cluster['center_title'])}</a></p>"
             f"<p class='muted'>{cluster['member_count']} member objects.</p>"
             "</section>"
+            f"<section class='card'><h2>Cluster Synthesis</h2><ul class='list-tight'>{summary_bullets}</ul></section>"
             f"<section class='card'><h2>Edge Kinds</h2><div class='link-row'>{edge_kind_counts}</div></section>"
+            f"<section class='card'><h2>Object Kinds</h2><div class='link-row'>{object_kind_counts}</div></section>"
+            f"<section class='card'><h2>Coverage</h2><p class='muted'>"
+            f"{review_context['source_note_count']} source/deep-dive notes · "
+            f"{review_context['moc_count']} atlas pages · "
+            f"{review_context['open_contradiction_count']} open contradictions · "
+            f"{review_context['stale_summary_count']} stale summaries"
+            "</p></section>"
+            f"<section class='card'><h2>Top Source Notes</h2><ul class='list-tight'>{top_source_notes}</ul></section>"
+            f"<section class='card'><h2>Top Atlas Pages</h2><ul class='list-tight'>{top_mocs}</ul></section>"
             f"<section class='card'><h2>Members</h2><ul class='list-tight'>{members}</ul></section>"
             f"<section class='card'><h2>Internal Edges</h2><ul class='list-tight'>{edges}</ul></section>"
             f"<section class='card'><h2>Model Notes</h2><ul class='list-tight'>{model_notes}</ul></section>"

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -1328,7 +1328,7 @@ def _render_clusters_page(payload: dict) -> str:
     ) or "<span class='muted'>None</span>"
     items = "".join(
         "<li>"
-        f'<a href="{escape(item["detail_path"])}">{escape(item["label"])}</a>'
+        f'<a href="{escape(item["detail_path"])}">{escape(item.get("display_title") or item["label"])}</a>'
         + f" <span class='pill'>{escape(item['cluster_kind'])}</span>"
         + f" <span class='pill'>{escape(item['priority_band'])}</span>"
         + f" <span class='pill'>{item['member_count']} objects</span>"
@@ -1340,8 +1340,14 @@ def _render_clusters_page(payload: dict) -> str:
             )
             + "</span>"
         )
+        + f"<div class='muted'>Canonical cluster: {escape(item['label'])}</div>"
         + f"<div class='muted'>Center: <a href='{escape(item['center_object_path'])}'>{escape(item['center_title'])}</a></div>"
         + f"<div class='muted'>Priority: {escape(item['priority_reason'])}</div>"
+        + (
+            f"<div class='muted'>Relation patterns: {escape(item['relation_pattern_preview'])}</div>"
+            if item.get("relation_pattern_preview")
+            else ""
+        )
         + (
             f"<div class='muted'>{escape(item['top_summary_bullet'])}</div>"
             if item.get("top_summary_bullet")
@@ -1406,6 +1412,10 @@ def _render_cluster_detail_page(payload: dict) -> str:
         f"<li>{escape(item['title'])} <span class='pill'>{item['object_count']} objects</span></li>"
         for item in payload["top_mocs"]
     ) or "<li class='muted'>No atlas coverage.</li>"
+    relation_patterns = "".join(
+        f"<li>{escape(item['display_name'])} <span class='pill'>{item['count']}</span></li>"
+        for item in payload["relation_pattern_items"]
+    ) or "<li class='muted'>No relation patterns in this cluster.</li>"
     review_context = payload["review_context"]
     model_notes = "".join(f"<li>{escape(note)}</li>" for note in payload["model_notes"])
     return _layout(
@@ -1413,12 +1423,15 @@ def _render_cluster_detail_page(payload: dict) -> str:
         (
             "<h1>Graph Cluster</h1>"
             f"<p><a href='/clusters'>Back to clusters</a></p>"
-            f"<section class='card'><h2>{escape(cluster['label'])}</h2>"
+            f"<section class='card'><h2>{escape(payload.get('display_title') or cluster['label'])}</h2>"
             f"<p class='muted'>Pack: {escape(cluster['pack'])} · Kind: {escape(cluster['cluster_kind'])} · Score: {cluster['score']:.1f}</p>"
+            f"<p class='muted'>Canonical cluster id: {escape(cluster['label'])}</p>"
             f"<p>Center: <a href='{escape(cluster['center_object_path'])}'>{escape(cluster['center_title'])}</a></p>"
             f"<p class='muted'>{cluster['member_count']} member objects.</p>"
             "</section>"
             f"<section class='card'><h2>Cluster Synthesis</h2><ul class='list-tight'>{summary_bullets}</ul></section>"
+            f"<section class='card'><h2>Structural Label</h2><p><strong>{escape(payload['structural_label']['title'])}</strong></p><p class='muted'>{escape(payload['structural_label']['reason'])}</p></section>"
+            f"<section class='card'><h2>Relation Patterns</h2><ul class='list-tight'>{relation_patterns}</ul></section>"
             f"<section class='card'><h2>Edge Kinds</h2><div class='link-row'>{edge_kind_counts}</div></section>"
             f"<section class='card'><h2>Object Kinds</h2><div class='link-row'>{object_kind_counts}</div></section>"
             f"<section class='card'><h2>Coverage</h2><p class='muted'>"

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -1370,6 +1370,11 @@ def _render_clusters_page(payload: dict) -> str:
             else ""
         )
         + (
+            f"<div class='muted'>Reading intents: {item['reading_intent_count']} · {escape(item['reading_intent_preview'])}</div>"
+            if item.get("reading_intent_count")
+            else ""
+        )
+        + (
             f"<div class='muted'>{escape(item['top_summary_bullet'])}</div>"
             if item.get("top_summary_bullet")
             else ""

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -1430,6 +1430,24 @@ def _render_cluster_detail_page(payload: dict) -> str:
         f"<li><a href=\"{escape(item['object_path'])}\">{escape(item['title'])}</a> <span class='pill'>{', '.join(escape(code) for code in item['reason_codes'])}</span></li>"
         for item in payload["stale_summaries"]
     ) or "<li class='muted'>No stale summaries in this cluster.</li>"
+    related_clusters = "".join(
+        "<li>"
+        f"<a href=\"{escape(item['detail_path'])}\">{escape(item['display_title'])}</a> "
+        f"<span class='pill'>{item['member_count']} objects</span> "
+        f"<span class='pill'>{escape(item['reason'])}</span>"
+        + (
+            f"<div class='muted'>Shared source notes: {escape(', '.join(item['shared_source_titles']))}</div>"
+            if item["shared_source_titles"]
+            else ""
+        )
+        + (
+            f"<div class='muted'>Shared atlas pages: {escape(', '.join(item['shared_moc_titles']))}</div>"
+            if item["shared_moc_titles"]
+            else ""
+        )
+        + "</li>"
+        for item in payload["related_clusters"]
+    ) or "<li class='muted'>No related clusters surfaced for this scope.</li>"
     relation_patterns = "".join(
         f"<li>{escape(item['display_name'])} <span class='pill'>{item['count']}</span></li>"
         for item in payload["relation_pattern_items"]
@@ -1451,6 +1469,7 @@ def _render_cluster_detail_page(payload: dict) -> str:
             f"<section class='card'><h2>Structural Label</h2><p><strong>{escape(payload['structural_label']['title'])}</strong></p><p class='muted'>{escape(payload['structural_label']['reason'])}</p></section>"
             f"<section class='card'><h2>Relation Patterns</h2><ul class='list-tight'>{relation_patterns}</ul></section>"
             f"<section class='card'><h2>Review Pressure</h2><h3>Open Contradictions</h3><ul class='list-tight'>{open_contradictions}</ul><h3>Stale Summaries</h3><ul class='list-tight'>{stale_summaries}</ul></section>"
+            f"<section class='card'><h2>Related Clusters</h2><ul class='list-tight'>{related_clusters}</ul></section>"
             f"<section class='card'><h2>Edge Kinds</h2><div class='link-row'>{edge_kind_counts}</div></section>"
             f"<section class='card'><h2>Object Kinds</h2><div class='link-row'>{object_kind_counts}</div></section>"
             f"<section class='card'><h2>Coverage</h2><p class='muted'>"

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -1474,6 +1474,16 @@ def _render_cluster_detail_page(payload: dict) -> str:
         + "</li>"
         for item in payload["related_cluster_groups"]
     ) or "<li class='muted'>No neighborhood groups surfaced for this cluster.</li>"
+    reading_routes = "".join(
+        "<li>"
+        f"{escape(item['display_name'])}: "
+        f"<a href=\"{escape(item['detail_path'])}\">{escape(item['display_title'])}</a> "
+        f"<span class='pill'>{escape(item['bridge_kind'])}</span> "
+        f"<span class='pill'>{escape(item['bridge_band'])}</span>"
+        f"<div class='muted'>{escape(item['reason'])}</div>"
+        "</li>"
+        for item in payload["reading_routes"]
+    ) or "<li class='muted'>No reading routes derived for this cluster.</li>"
     next_read_cluster = payload.get("next_read_cluster")
     next_read_route = (
         "<p>"
@@ -1514,6 +1524,7 @@ def _render_cluster_detail_page(payload: dict) -> str:
             f"<section class='card'><h2>Structural Label</h2><p><strong>{escape(payload['structural_label']['title'])}</strong></p><p class='muted'>{escape(payload['structural_label']['reason'])}</p></section>"
             f"<section class='card'><h2>Relation Patterns</h2><ul class='list-tight'>{relation_patterns}</ul></section>"
             f"<section class='card'><h2>Review Pressure</h2><h3>Open Contradictions</h3><ul class='list-tight'>{open_contradictions}</ul><h3>Stale Summaries</h3><ul class='list-tight'>{stale_summaries}</ul></section>"
+            f"<section class='card'><h2>Reading Routes</h2><ul class='list-tight'>{reading_routes}</ul></section>"
             f"<section class='card'><h2>Next Reading Route</h2>{next_read_route}</section>"
             f"<section class='card'><h2>Neighborhood Groups</h2><ul class='list-tight'>{related_cluster_groups}</ul></section>"
             f"<section class='card'><h2>Related Clusters</h2><ul class='list-tight'>{related_clusters}</ul></section>"

--- a/src/openclaw_pipeline/knowledge_index.py
+++ b/src/openclaw_pipeline/knowledge_index.py
@@ -13,6 +13,7 @@ from .concept_registry import ConceptRegistry, ResolutionAction
 from .graph.frontmatter import FrontmatterParser, NoteMetadata
 from .graph.link_parser import LinkParser
 from .identity import canonicalize_note_id
+from .packs.loader import DEFAULT_WORKFLOW_PACK_NAME
 from .runtime import VaultLayout, knowledge_db_write_lock, resolve_vault_dir
 from .truth_projection_registry import execute_truth_projection_builder
 from .truth_store import TRUTH_STORE_SCHEMA
@@ -100,6 +101,10 @@ SCHEMA += "\n" + TRUTH_STORE_SCHEMA
 
 EMBEDDING_DIMENSIONS = 128
 EMBEDDING_MODEL = "local-hash-v1"
+
+
+def _truth_pack_name(pack_name: str | None = None) -> str:
+    return str(pack_name or DEFAULT_WORKFLOW_PACK_NAME)
 
 
 def _split_frontmatter_body(content: str) -> str:
@@ -473,42 +478,43 @@ def rebuild_knowledge_index(
             )
             conn.executemany(
                 """
-                INSERT INTO objects (object_id, object_kind, title, canonical_path, source_slug)
-                VALUES (?, ?, ?, ?, ?)
+                INSERT INTO objects (pack, object_id, object_kind, title, canonical_path, source_slug)
+                VALUES (?, ?, ?, ?, ?, ?)
                 """,
                 truth_projection.objects,
             )
             conn.executemany(
                 """
-                INSERT INTO claims (claim_id, object_id, claim_kind, claim_text, confidence)
-                VALUES (?, ?, ?, ?, ?)
+                INSERT INTO claims (pack, claim_id, object_id, claim_kind, claim_text, confidence)
+                VALUES (?, ?, ?, ?, ?, ?)
                 """,
                 truth_projection.claims,
             )
             conn.executemany(
                 """
-                INSERT INTO claim_evidence (claim_id, source_slug, evidence_kind, quote_text)
-                VALUES (?, ?, ?, ?)
+                INSERT INTO claim_evidence (pack, claim_id, source_slug, evidence_kind, quote_text)
+                VALUES (?, ?, ?, ?, ?)
                 """,
                 truth_projection.claim_evidence,
             )
             conn.executemany(
                 """
-                INSERT INTO relations (source_object_id, target_object_id, relation_type, evidence_source_slug)
-                VALUES (?, ?, ?, ?)
+                INSERT INTO relations (pack, source_object_id, target_object_id, relation_type, evidence_source_slug)
+                VALUES (?, ?, ?, ?, ?)
                 """,
                 truth_projection.relations,
             )
             conn.executemany(
                 """
-                INSERT INTO compiled_summaries (object_id, summary_text, source_slug)
-                VALUES (?, ?, ?)
+                INSERT INTO compiled_summaries (pack, object_id, summary_text, source_slug)
+                VALUES (?, ?, ?, ?)
                 """,
                 truth_projection.compiled_summaries,
             )
             conn.executemany(
                 """
                 INSERT INTO contradictions (
+                    pack,
                     contradiction_id,
                     subject_key,
                     positive_claim_ids_json,
@@ -517,9 +523,39 @@ def rebuild_knowledge_index(
                     resolution_note,
                     resolved_at
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 truth_projection.contradictions,
+            )
+            conn.executemany(
+                """
+                INSERT INTO graph_edges (
+                    pack,
+                    edge_id,
+                    source_object_id,
+                    target_object_id,
+                    edge_kind,
+                    weight,
+                    evidence_source_slug
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                truth_projection.graph_edges,
+            )
+            conn.executemany(
+                """
+                INSERT INTO graph_clusters (
+                    pack,
+                    cluster_id,
+                    cluster_kind,
+                    label,
+                    center_object_id,
+                    member_object_ids_json,
+                    score
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                truth_projection.graph_clusters,
             )
 
             raw_rows = _collect_raw_rows(layout)
@@ -568,7 +604,7 @@ def rebuild_knowledge_index(
 
             return {
                 "db_path": str(layout.knowledge_db),
-                "projection_pack": projection_spec.pack,
+                "projection_pack": _truth_pack_name(pack_name),
                 "pages_indexed": len(page_rows),
                 "links_indexed": len(link_rows),
                 "raw_records_indexed": len(raw_rows),
@@ -580,6 +616,8 @@ def rebuild_knowledge_index(
                 "relations_indexed": len(truth_projection.relations),
                 "compiled_summaries_indexed": len(truth_projection.compiled_summaries),
                 "contradictions_indexed": len(truth_projection.contradictions),
+                "graph_edges_indexed": len(truth_projection.graph_edges),
+                "graph_clusters_indexed": len(truth_projection.graph_clusters),
             }
 
 
@@ -670,21 +708,31 @@ def search_knowledge_index(vault_dir: Path, query: str, limit: int = 10) -> list
     return results
 
 
-def search_truth_store(vault_dir: Path, query: str, limit: int = 10) -> list[dict[str, object]]:
+def search_truth_store(
+    vault_dir: Path,
+    query: str,
+    limit: int = 10,
+    *,
+    pack_name: str | None = None,
+) -> list[dict[str, object]]:
     _, layout = _ensure_knowledge_db(vault_dir)
+    truth_pack = _truth_pack_name(pack_name)
     like_query = f"%{query.strip()}%"
     with sqlite3.connect(layout.knowledge_db) as conn:
         rows = conn.execute(
             """
             SELECT claims.object_id, objects.title, claims.claim_kind, claims.claim_text, compiled_summaries.summary_text
             FROM claims
-            JOIN objects ON objects.object_id = claims.object_id
-            LEFT JOIN compiled_summaries ON compiled_summaries.object_id = claims.object_id
-            WHERE claims.claim_text LIKE ? OR compiled_summaries.summary_text LIKE ? OR objects.title LIKE ?
+            JOIN objects ON objects.pack = claims.pack AND objects.object_id = claims.object_id
+            LEFT JOIN compiled_summaries
+              ON compiled_summaries.pack = claims.pack
+             AND compiled_summaries.object_id = claims.object_id
+            WHERE claims.pack = ?
+              AND (claims.claim_text LIKE ? OR compiled_summaries.summary_text LIKE ? OR objects.title LIKE ?)
             ORDER BY claims.object_id
             LIMIT ?
             """,
-            (like_query, like_query, like_query, limit),
+            (truth_pack, like_query, like_query, like_query, limit),
         ).fetchall()
 
     return [
@@ -699,18 +747,26 @@ def search_truth_store(vault_dir: Path, query: str, limit: int = 10) -> list[dic
     ]
 
 
-def list_contradictions(vault_dir: Path, limit: int = 20, subject: str | None = None) -> list[dict[str, object]]:
+def list_contradictions(
+    vault_dir: Path,
+    limit: int = 20,
+    subject: str | None = None,
+    *,
+    pack_name: str | None = None,
+) -> list[dict[str, object]]:
     _, layout = _ensure_knowledge_db(vault_dir)
+    truth_pack = _truth_pack_name(pack_name)
     query = """
         SELECT contradiction_id, subject_key, positive_claim_ids_json, negative_claim_ids_json, status, resolution_note, resolved_at
         FROM contradictions
     """
     params: tuple[object, ...]
     if subject:
-        query += " WHERE subject_key LIKE ?"
-        params = (f"%{subject}%", limit)
+        query += " WHERE pack = ? AND subject_key LIKE ?"
+        params = (truth_pack, f"%{subject}%", limit)
     else:
-        params = (limit,)
+        query += " WHERE pack = ?"
+        params = (truth_pack, limit)
     query += " ORDER BY subject_key LIMIT ?"
 
     try:
@@ -748,8 +804,10 @@ def resolve_contradictions(
     *,
     status: str,
     note: str = "",
+    pack_name: str | None = None,
 ) -> dict[str, object]:
     _, layout = _ensure_knowledge_db(vault_dir)
+    truth_pack = _truth_pack_name(pack_name)
     resolved_ids = list(dict.fromkeys(contradiction_ids))
     if not resolved_ids:
         return {
@@ -766,10 +824,10 @@ def resolve_contradictions(
             f"""
             SELECT contradiction_id
             FROM contradictions
-            WHERE contradiction_id IN ({placeholders})
+            WHERE pack = ? AND contradiction_id IN ({placeholders})
             ORDER BY contradiction_id
             """,
-            tuple(resolved_ids),
+            (truth_pack, *resolved_ids),
         ).fetchall()
         found_ids = [row[0] for row in existing]
 
@@ -782,8 +840,14 @@ def resolve_contradictions(
     }
 
 
-def contradiction_object_ids(vault_dir: Path, contradiction_ids: list[str]) -> list[str]:
+def contradiction_object_ids(
+    vault_dir: Path,
+    contradiction_ids: list[str],
+    *,
+    pack_name: str | None = None,
+) -> list[str]:
     _, layout = _ensure_knowledge_db(vault_dir)
+    truth_pack = _truth_pack_name(pack_name)
     resolved_ids = list(dict.fromkeys(contradiction_ids))
     if not resolved_ids:
         return []
@@ -794,9 +858,9 @@ def contradiction_object_ids(vault_dir: Path, contradiction_ids: list[str]) -> l
             f"""
             SELECT positive_claim_ids_json, negative_claim_ids_json
             FROM contradictions
-            WHERE contradiction_id IN ({placeholders})
+            WHERE pack = ? AND contradiction_id IN ({placeholders})
             """,
-            tuple(resolved_ids),
+            (truth_pack, *resolved_ids),
         ).fetchall()
 
         claim_ids: list[str] = []
@@ -812,17 +876,23 @@ def contradiction_object_ids(vault_dir: Path, contradiction_ids: list[str]) -> l
             f"""
             SELECT DISTINCT object_id
             FROM claims
-            WHERE claim_id IN ({claim_placeholders})
+            WHERE pack = ? AND claim_id IN ({claim_placeholders})
             ORDER BY object_id
             """,
-            tuple(claim_ids),
+            (truth_pack, *claim_ids),
         ).fetchall()
 
     return [row[0] for row in object_rows]
 
 
-def rebuild_compiled_summaries(vault_dir: Path, object_ids: list[str] | None = None) -> dict[str, object]:
+def rebuild_compiled_summaries(
+    vault_dir: Path,
+    object_ids: list[str] | None = None,
+    *,
+    pack_name: str | None = None,
+) -> dict[str, object]:
     _, layout = _ensure_knowledge_db(vault_dir)
+    truth_pack = _truth_pack_name(pack_name)
     with sqlite3.connect(layout.knowledge_db) as conn:
         if object_ids:
             placeholders = ",".join("?" for _ in object_ids)
@@ -830,22 +900,25 @@ def rebuild_compiled_summaries(vault_dir: Path, object_ids: list[str] | None = N
                 f"""
                 SELECT object_id
                 FROM objects
-                WHERE object_id IN ({placeholders})
+                WHERE pack = ? AND object_id IN ({placeholders})
                 ORDER BY object_id
                 """,
-                tuple(object_ids),
+                (truth_pack, *object_ids),
             ).fetchall()
         else:
             object_rows = conn.execute(
                 """
                 SELECT object_id
                 FROM objects
+                WHERE pack = ?
                 ORDER BY object_id
                 """
+                ,
+                (truth_pack,),
             ).fetchall()
 
     rebuilt_ids = [str(row[0]) for row in object_rows]
-    rebuild_knowledge_index(vault_dir)
+    rebuild_knowledge_index(vault_dir, pack_name=truth_pack)
 
     return {
         "objects_rebuilt": len(rebuilt_ids),
@@ -880,8 +953,9 @@ def get_knowledge_page(vault_dir: Path, slug: str) -> dict[str, object] | None:
     }
 
 
-def knowledge_index_stats(vault_dir: Path) -> dict[str, object]:
+def knowledge_index_stats(vault_dir: Path, *, pack_name: str | None = None) -> dict[str, object]:
     _, layout = _ensure_knowledge_db(vault_dir)
+    truth_pack = _truth_pack_name(pack_name)
     queries = {
         "pages": "SELECT COUNT(*) FROM pages_index",
         "links": "SELECT COUNT(*) FROM page_links",
@@ -889,16 +963,18 @@ def knowledge_index_stats(vault_dir: Path) -> dict[str, object]:
         "timeline_events": "SELECT COUNT(*) FROM timeline_events",
         "audit_events": "SELECT COUNT(*) FROM audit_events",
         "embedding_chunks": "SELECT COUNT(*) FROM page_embeddings",
-        "objects": "SELECT COUNT(*) FROM objects",
-        "claims": "SELECT COUNT(*) FROM claims",
-        "relations": "SELECT COUNT(*) FROM relations",
-        "compiled_summaries": "SELECT COUNT(*) FROM compiled_summaries",
-        "contradictions": "SELECT COUNT(*) FROM contradictions",
+        "objects": "SELECT COUNT(*) FROM objects WHERE pack = ?",
+        "claims": "SELECT COUNT(*) FROM claims WHERE pack = ?",
+        "relations": "SELECT COUNT(*) FROM relations WHERE pack = ?",
+        "compiled_summaries": "SELECT COUNT(*) FROM compiled_summaries WHERE pack = ?",
+        "contradictions": "SELECT COUNT(*) FROM contradictions WHERE pack = ?",
+        "graph_edges": "SELECT COUNT(*) FROM graph_edges WHERE pack = ?",
+        "graph_clusters": "SELECT COUNT(*) FROM graph_clusters WHERE pack = ?",
     }
     stats: dict[str, object] = {"db_path": str(layout.knowledge_db)}
     with sqlite3.connect(layout.knowledge_db) as conn:
         for key, query in queries.items():
-            stats[key] = int(conn.execute(query).fetchone()[0])
+            stats[key] = int(conn.execute(query, (truth_pack,)).fetchone()[0]) if "pack = ?" in query else int(conn.execute(query).fetchone()[0])
     return stats
 
 

--- a/src/openclaw_pipeline/knowledge_index.py
+++ b/src/openclaw_pipeline/knowledge_index.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from array import array
+from datetime import datetime, timezone
 import hashlib
 from io import TextIOBase
 import json
@@ -15,7 +16,7 @@ from .graph.link_parser import LinkParser
 from .identity import canonicalize_note_id
 from .packs.loader import DEFAULT_WORKFLOW_PACK_NAME
 from .runtime import VaultLayout, knowledge_db_write_lock, resolve_vault_dir
-from .truth_projection_registry import execute_truth_projection_builder
+from .truth_projection_registry import execute_truth_projection_builder, resolve_truth_projection_builder
 from .truth_store import TRUTH_STORE_SCHEMA
 
 SUMMARY_MAX_LEN = 320
@@ -101,10 +102,126 @@ SCHEMA += "\n" + TRUTH_STORE_SCHEMA
 
 EMBEDDING_DIMENSIONS = 128
 EMBEDDING_MODEL = "local-hash-v1"
+TRUTH_PROJECTION_TABLE_COLUMNS: dict[str, tuple[str, ...]] = {
+    "objects": ("pack", "object_id", "object_kind", "title", "canonical_path", "source_slug"),
+    "claims": ("pack", "claim_id", "object_id", "claim_kind", "claim_text", "confidence"),
+    "claim_evidence": ("pack", "claim_id", "source_slug", "evidence_kind", "quote_text"),
+    "relations": ("pack", "source_object_id", "target_object_id", "relation_type", "evidence_source_slug"),
+    "compiled_summaries": ("pack", "object_id", "summary_text", "source_slug"),
+    "contradictions": (
+        "pack",
+        "contradiction_id",
+        "subject_key",
+        "positive_claim_ids_json",
+        "negative_claim_ids_json",
+        "status",
+        "resolution_note",
+        "resolved_at",
+    ),
+    "graph_edges": (
+        "pack",
+        "edge_id",
+        "source_object_id",
+        "target_object_id",
+        "edge_kind",
+        "weight",
+        "evidence_source_slug",
+    ),
+    "graph_clusters": (
+        "pack",
+        "cluster_id",
+        "cluster_kind",
+        "label",
+        "center_object_id",
+        "member_object_ids_json",
+        "score",
+    ),
+}
 
 
 def _truth_pack_name(pack_name: str | None = None) -> str:
     return str(pack_name or DEFAULT_WORKFLOW_PACK_NAME)
+
+
+def _utc_now_text() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _projection_metadata(pack_name: str) -> tuple[str, str]:
+    try:
+        spec = resolve_truth_projection_builder(pack_name=pack_name)
+    except Exception:
+        return pack_name, ""
+    return spec.pack, getattr(spec, "name", "")
+
+
+def _preserve_existing_truth_rows(
+    source_db_path: Path,
+    dest_conn: sqlite3.Connection,
+    *,
+    exclude_pack: str,
+) -> None:
+    if not source_db_path.exists():
+        return
+    preserved_packs: set[str] = set()
+    preserved_metadata_packs: set[str] = set()
+    try:
+        with sqlite3.connect(source_db_path) as source_conn:
+            for table_name, columns in TRUTH_PROJECTION_TABLE_COLUMNS.items():
+                column_sql = ", ".join(columns)
+                rows = source_conn.execute(
+                    f"SELECT {column_sql} FROM {table_name} WHERE pack != ? ORDER BY pack",
+                    (exclude_pack,),
+                ).fetchall()
+                if not rows:
+                    continue
+                placeholders = ", ".join("?" for _ in columns)
+                dest_conn.executemany(
+                    f"INSERT INTO {table_name} ({column_sql}) VALUES ({placeholders})",
+                    rows,
+                )
+                preserved_packs.update(str(row[0]) for row in rows if row and row[0])
+
+            metadata_rows = source_conn.execute(
+                """
+                SELECT pack, owner_pack, builder_name, built_at
+                FROM truth_projections
+                WHERE pack != ?
+                ORDER BY pack
+                """,
+                (exclude_pack,),
+            ).fetchall()
+    except sqlite3.OperationalError as exc:
+        if "no such table" not in str(exc).lower():
+            raise
+        metadata_rows = []
+    except sqlite3.DatabaseError:
+        return
+
+    if metadata_rows:
+        dest_conn.executemany(
+            """
+            INSERT INTO truth_projections (pack, owner_pack, builder_name, built_at)
+            VALUES (?, ?, ?, ?)
+            """,
+            metadata_rows,
+        )
+        preserved_metadata_packs.update(str(row[0]) for row in metadata_rows if row and row[0])
+
+    missing_metadata_packs = sorted(preserved_packs - preserved_metadata_packs)
+    if not missing_metadata_packs:
+        return
+
+    built_at = _utc_now_text()
+    for pack in missing_metadata_packs:
+        owner_pack, builder_name = _projection_metadata(pack)
+        dest_conn.execute(
+            """
+            INSERT INTO truth_projections (pack, owner_pack, builder_name, built_at)
+            VALUES (?, ?, ?, ?)
+            """,
+            (pack, owner_pack, builder_name, built_at),
+        )
 
 
 def _split_frontmatter_body(content: str) -> str:
@@ -361,6 +478,7 @@ def rebuild_knowledge_index(
 ) -> dict[str, int | str]:
     resolved_vault = resolve_vault_dir(vault_dir)
     layout = VaultLayout.from_vault(resolved_vault)
+    truth_pack = _truth_pack_name(pack_name)
     with knowledge_db_write_lock(resolved_vault):
         evergreen_dir = layout.evergreen_dir
         atlas_dir = layout.atlas_dir
@@ -401,6 +519,7 @@ def rebuild_knowledge_index(
         conn = None
         try:
             conn = _initialize_database(temp_db_path)
+            _preserve_existing_truth_rows(layout.knowledge_db, conn, exclude_pack=truth_pack)
             page_rows = []
             timeline_rows = []
             embedding_rows = []
@@ -557,6 +676,18 @@ def rebuild_knowledge_index(
                 """,
                 truth_projection.graph_clusters,
             )
+            conn.execute(
+                """
+                INSERT INTO truth_projections (pack, owner_pack, builder_name, built_at)
+                VALUES (?, ?, ?, ?)
+                """,
+                (
+                    truth_pack,
+                    projection_spec.pack,
+                    getattr(projection_spec, "name", ""),
+                    _utc_now_text(),
+                ),
+            )
 
             raw_rows = _collect_raw_rows(layout)
             conn.executemany(
@@ -604,7 +735,7 @@ def rebuild_knowledge_index(
 
             return {
                 "db_path": str(layout.knowledge_db),
-                "projection_pack": _truth_pack_name(pack_name),
+                "projection_pack": truth_pack,
                 "pages_indexed": len(page_rows),
                 "links_indexed": len(link_rows),
                 "raw_records_indexed": len(raw_rows),
@@ -975,6 +1106,27 @@ def knowledge_index_stats(vault_dir: Path, *, pack_name: str | None = None) -> d
     with sqlite3.connect(layout.knowledge_db) as conn:
         for key, query in queries.items():
             stats[key] = int(conn.execute(query, (truth_pack,)).fetchone()[0]) if "pack = ?" in query else int(conn.execute(query).fetchone()[0])
+        try:
+            rows = conn.execute(
+                """
+                SELECT pack, owner_pack, builder_name, built_at
+                FROM truth_projections
+                ORDER BY pack
+                """
+            ).fetchall()
+        except sqlite3.OperationalError as exc:
+            if "no such table" not in str(exc).lower():
+                raise
+            rows = []
+        stats["materialized_truth_packs"] = [
+            {
+                "pack": str(pack),
+                "owner_pack": str(owner_pack),
+                "builder_name": str(builder_name or ""),
+                "built_at": str(built_at or ""),
+            }
+            for pack, owner_pack, builder_name, built_at in rows
+        ]
     return stats
 
 

--- a/src/openclaw_pipeline/materializers/cluster_crystal.py
+++ b/src/openclaw_pipeline/materializers/cluster_crystal.py
@@ -99,6 +99,25 @@ def materialize_cluster_crystal(vault_dir: Path, *, pack_name: str, cluster_id: 
     lines.extend(
         [
             "",
+            "## Related Clusters",
+            "",
+        ]
+    )
+    if payload["related_clusters"]:
+        for item in payload["related_clusters"]:
+            lines.append(
+                f"- {item['display_title']} [{item['reason']}]"
+            )
+            if item["shared_source_titles"]:
+                lines.append(f"  - shared source notes: {', '.join(item['shared_source_titles'])}")
+            if item["shared_moc_titles"]:
+                lines.append(f"  - shared atlas pages: {', '.join(item['shared_moc_titles'])}")
+    else:
+        lines.append("- (none)")
+
+    lines.extend(
+        [
+            "",
             "## Coverage",
             "",
             f"- source_note_count: {payload['review_context']['source_note_count']}",

--- a/src/openclaw_pipeline/materializers/cluster_crystal.py
+++ b/src/openclaw_pipeline/materializers/cluster_crystal.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from urllib.parse import quote
 
 from ..runtime import VaultLayout, resolve_vault_dir
 from ..ui.view_models import build_cluster_detail_payload
@@ -9,7 +10,11 @@ from ..ui.view_models import build_cluster_detail_payload
 def materialize_cluster_crystal(vault_dir: Path, *, pack_name: str, cluster_id: str) -> Path:
     resolved_vault = resolve_vault_dir(vault_dir)
     layout = VaultLayout.from_vault(resolved_vault)
-    output_path = layout.compiled_views_dir / pack_name / "clusters" / f"{cluster_id}.md"
+    output_dir = (layout.compiled_views_dir / pack_name / "clusters").resolve()
+    safe_cluster_id = quote(cluster_id, safe="")
+    output_path = (output_dir / f"{safe_cluster_id}.md").resolve()
+    if output_dir not in output_path.parents:
+        raise ValueError("cluster_id must not escape the clusters output directory")
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
     payload = build_cluster_detail_payload(resolved_vault, cluster_id=cluster_id, pack_name=pack_name)

--- a/src/openclaw_pipeline/materializers/cluster_crystal.py
+++ b/src/openclaw_pipeline/materializers/cluster_crystal.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..runtime import VaultLayout, resolve_vault_dir
+from ..ui.view_models import build_cluster_detail_payload
+
+
+def materialize_cluster_crystal(vault_dir: Path, *, pack_name: str, cluster_id: str) -> Path:
+    resolved_vault = resolve_vault_dir(vault_dir)
+    layout = VaultLayout.from_vault(resolved_vault)
+    output_path = layout.compiled_views_dir / pack_name / "clusters" / f"{cluster_id}.md"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    payload = build_cluster_detail_payload(resolved_vault, cluster_id=cluster_id, pack_name=pack_name)
+    cluster = payload["cluster"]
+
+    lines = [
+        f"# cluster/{cluster_id}",
+        "",
+        f"- pack: {pack_name}",
+        "- builder: cluster_crystal",
+        f"- cluster_kind: {cluster['cluster_kind']}",
+        f"- center: [[{cluster['center_object_id']}]]",
+        f"- member_count: {cluster['member_count']}",
+        f"- score: {cluster['score']}",
+        "",
+        "## Cluster Synthesis",
+        "",
+    ]
+
+    if payload["summary_bullets"]:
+        lines.extend(f"- {bullet}" for bullet in payload["summary_bullets"])
+    else:
+        lines.append("- (none)")
+
+    lines.extend(
+        [
+            "",
+            "## Coverage",
+            "",
+            f"- source_note_count: {payload['review_context']['source_note_count']}",
+            f"- moc_count: {payload['review_context']['moc_count']}",
+            f"- open_contradiction_count: {payload['review_context']['open_contradiction_count']}",
+            f"- stale_summary_count: {payload['review_context']['stale_summary_count']}",
+            "",
+            "## Members",
+            "",
+        ]
+    )
+    if cluster["member_links"]:
+        for member in cluster["member_links"]:
+            lines.append(f"- [[{member['object_id']}]] ({member['title']})")
+    else:
+        lines.append("- (none)")
+
+    lines.extend(
+        [
+            "",
+            "## Internal Edges",
+            "",
+        ]
+    )
+    if payload["edges"]:
+        for edge in payload["edges"]:
+            lines.append(
+                f"- [[{edge['source_object_id']}]] -[{edge['edge_kind']}]-> "
+                f"[[{edge['target_object_id']}]]"
+            )
+    else:
+        lines.append("- (none)")
+
+    lines.extend(
+        [
+            "",
+            "## Top Source Notes",
+            "",
+        ]
+    )
+    if payload["top_source_notes"]:
+        for item in payload["top_source_notes"]:
+            lines.append(f"- {item['title']} ({item['object_count']} objects)")
+    else:
+        lines.append("- (none)")
+
+    lines.extend(
+        [
+            "",
+            "## Top Atlas Pages",
+            "",
+        ]
+    )
+    if payload["top_mocs"]:
+        for item in payload["top_mocs"]:
+            lines.append(f"- {item['title']} ({item['object_count']} objects)")
+    else:
+        lines.append("- (none)")
+
+    output_path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+    return output_path

--- a/src/openclaw_pipeline/materializers/cluster_crystal.py
+++ b/src/openclaw_pipeline/materializers/cluster_crystal.py
@@ -37,6 +37,27 @@ def materialize_cluster_crystal(vault_dir: Path, *, pack_name: str, cluster_id: 
     lines.extend(
         [
             "",
+            "## Structural Label",
+            "",
+            f"- kind: {payload['structural_label']['kind']}",
+            f"- title: {payload['structural_label']['title']}",
+            f"- reason: {payload['structural_label']['reason']}",
+            "",
+            "## Edge Summary",
+            "",
+        ]
+    )
+    if payload["edge_summary_items"]:
+        for item in payload["edge_summary_items"]:
+            lines.append(
+                f"- {item['edge_kind']} ({item['edge_family']}) = {item['count']} [{item['display_name']}]"
+            )
+    else:
+        lines.append("- (none)")
+
+    lines.extend(
+        [
+            "",
             "## Coverage",
             "",
             f"- source_note_count: {payload['review_context']['source_note_count']}",

--- a/src/openclaw_pipeline/materializers/cluster_crystal.py
+++ b/src/openclaw_pipeline/materializers/cluster_crystal.py
@@ -108,8 +108,11 @@ def materialize_cluster_crystal(vault_dir: Path, *, pack_name: str, cluster_id: 
             lines.extend(
                 [
                     f"- {item['display_name']}: {item['display_title']}",
+                    f"  - route_rank: {item['route_rank']}",
+                    f"  - route_score: {item['route_score']}",
                     f"  - bridge_kind: {item['bridge_kind']}",
                     f"  - bridge_band: {item['bridge_band']}",
+                    f"  - route_reason: {item['route_reason']}",
                     f"  - reason: {item['reason']}",
                 ]
             )

--- a/src/openclaw_pipeline/materializers/cluster_crystal.py
+++ b/src/openclaw_pipeline/materializers/cluster_crystal.py
@@ -99,6 +99,32 @@ def materialize_cluster_crystal(vault_dir: Path, *, pack_name: str, cluster_id: 
     lines.extend(
         [
             "",
+            "## Next Reading Route",
+            "",
+        ]
+    )
+    if payload["next_read_cluster"]:
+        lines.extend(
+            [
+                f"- title: {payload['next_read_cluster']['display_title']}",
+                f"- bridge_band: {payload['next_read_cluster']['bridge_band']}",
+                f"- reason: {payload['next_read_cluster']['reason']}",
+            ]
+        )
+        if payload["next_read_cluster"]["shared_source_titles"]:
+            lines.append(
+                f"- shared source notes: {', '.join(payload['next_read_cluster']['shared_source_titles'])}"
+            )
+        if payload["next_read_cluster"]["shared_moc_titles"]:
+            lines.append(
+                f"- shared atlas pages: {', '.join(payload['next_read_cluster']['shared_moc_titles'])}"
+            )
+    else:
+        lines.append("- (none)")
+
+    lines.extend(
+        [
+            "",
             "## Related Clusters",
             "",
         ]

--- a/src/openclaw_pipeline/materializers/cluster_crystal.py
+++ b/src/openclaw_pipeline/materializers/cluster_crystal.py
@@ -107,6 +107,7 @@ def materialize_cluster_crystal(vault_dir: Path, *, pack_name: str, cluster_id: 
         lines.extend(
             [
                 f"- title: {payload['next_read_cluster']['display_title']}",
+                f"- bridge_kind: {payload['next_read_cluster']['bridge_kind']}",
                 f"- bridge_band: {payload['next_read_cluster']['bridge_band']}",
                 f"- reason: {payload['next_read_cluster']['reason']}",
             ]
@@ -132,7 +133,7 @@ def materialize_cluster_crystal(vault_dir: Path, *, pack_name: str, cluster_id: 
     if payload["related_clusters"]:
         for item in payload["related_clusters"]:
             lines.append(
-                f"- {item['display_title']} [{item['reason']}]"
+                f"- {item['display_title']} [{item['bridge_kind']} / {item['bridge_band']}: {item['reason']}]"
             )
             if item["shared_source_titles"]:
                 lines.append(f"  - shared source notes: {', '.join(item['shared_source_titles'])}")

--- a/src/openclaw_pipeline/materializers/cluster_crystal.py
+++ b/src/openclaw_pipeline/materializers/cluster_crystal.py
@@ -126,6 +126,19 @@ def materialize_cluster_crystal(vault_dir: Path, *, pack_name: str, cluster_id: 
     lines.extend(
         [
             "",
+            "## Neighborhood Groups",
+            "",
+        ]
+    )
+    if payload["related_cluster_groups"]:
+        for item in payload["related_cluster_groups"]:
+            lines.append(f"- {item['bridge_kind']} ({item['count']})")
+    else:
+        lines.append("- (none)")
+
+    lines.extend(
+        [
+            "",
             "## Related Clusters",
             "",
         ]

--- a/src/openclaw_pipeline/materializers/cluster_crystal.py
+++ b/src/openclaw_pipeline/materializers/cluster_crystal.py
@@ -99,6 +99,26 @@ def materialize_cluster_crystal(vault_dir: Path, *, pack_name: str, cluster_id: 
     lines.extend(
         [
             "",
+            "## Reading Routes",
+            "",
+        ]
+    )
+    if payload["reading_routes"]:
+        for item in payload["reading_routes"]:
+            lines.extend(
+                [
+                    f"- {item['display_name']}: {item['display_title']}",
+                    f"  - bridge_kind: {item['bridge_kind']}",
+                    f"  - bridge_band: {item['bridge_band']}",
+                    f"  - reason: {item['reason']}",
+                ]
+            )
+    else:
+        lines.append("- (none)")
+
+    lines.extend(
+        [
+            "",
             "## Next Reading Route",
             "",
         ]

--- a/src/openclaw_pipeline/materializers/cluster_crystal.py
+++ b/src/openclaw_pipeline/materializers/cluster_crystal.py
@@ -72,6 +72,33 @@ def materialize_cluster_crystal(vault_dir: Path, *, pack_name: str, cluster_id: 
     lines.extend(
         [
             "",
+            "## Review Pressure",
+            "",
+            "### Open Contradictions",
+            "",
+        ]
+    )
+    if payload["open_contradictions"]:
+        for item in payload["open_contradictions"]:
+            lines.append(f"- {item['subject_key']} ({len(item['object_ids'])} objects)")
+    else:
+        lines.append("- (none)")
+    lines.extend(
+        [
+            "",
+            "### Stale Summaries",
+            "",
+        ]
+    )
+    if payload["stale_summaries"]:
+        for item in payload["stale_summaries"]:
+            lines.append(f"- {item['title']} [{', '.join(item['reason_codes'])}]")
+    else:
+        lines.append("- (none)")
+
+    lines.extend(
+        [
+            "",
             "## Coverage",
             "",
             f"- source_note_count: {payload['review_context']['source_note_count']}",

--- a/src/openclaw_pipeline/materializers/cluster_crystal.py
+++ b/src/openclaw_pipeline/materializers/cluster_crystal.py
@@ -24,6 +24,7 @@ def materialize_cluster_crystal(vault_dir: Path, *, pack_name: str, cluster_id: 
         f"- center: [[{cluster['center_object_id']}]]",
         f"- member_count: {cluster['member_count']}",
         f"- score: {cluster['score']}",
+        f"- display_title: {payload['display_title']}",
         "",
         "## Cluster Synthesis",
         "",
@@ -52,6 +53,19 @@ def materialize_cluster_crystal(vault_dir: Path, *, pack_name: str, cluster_id: 
             lines.append(
                 f"- {item['edge_kind']} ({item['edge_family']}) = {item['count']} [{item['display_name']}]"
             )
+    else:
+        lines.append("- (none)")
+
+    lines.extend(
+        [
+            "",
+            "## Relation Patterns",
+            "",
+        ]
+    )
+    if payload["relation_pattern_items"]:
+        for item in payload["relation_pattern_items"]:
+            lines.append(f"- {item['display_name']} = {item['count']}")
     else:
         lines.append("- (none)")
 

--- a/src/openclaw_pipeline/materializers/cluster_view.py
+++ b/src/openclaw_pipeline/materializers/cluster_view.py
@@ -110,6 +110,18 @@ def materialize_cluster_view(vault_dir: Path, *, pack_name: str, view_name: str)
             lines.extend(
                 [
                     "",
+                    "#### Neighborhood Groups",
+                    "",
+                ]
+            )
+            if detail["related_cluster_groups"]:
+                for item in detail["related_cluster_groups"]:
+                    lines.append(f"- {item['bridge_kind']} ({item['count']})")
+            else:
+                lines.append("- (none)")
+            lines.extend(
+                [
+                    "",
                     "#### Related Clusters",
                     "",
                 ]

--- a/src/openclaw_pipeline/materializers/cluster_view.py
+++ b/src/openclaw_pipeline/materializers/cluster_view.py
@@ -52,6 +52,8 @@ def materialize_cluster_view(vault_dir: Path, *, pack_name: str, view_name: str)
                     f"- neighborhood_band: {row['neighborhood_band']}",
                     f"- neighborhood_bridge_kind: {row['neighborhood_bridge_kind']}",
                     f"- neighborhood_reason: {row['neighborhood_reason']}",
+                    f"- top_reading_route_kind: {row['top_reading_route_kind']}",
+                    f"- top_reading_route_title: {row['top_reading_route_title']}",
                     "",
                     "#### Members",
                     "",

--- a/src/openclaw_pipeline/materializers/cluster_view.py
+++ b/src/openclaw_pipeline/materializers/cluster_view.py
@@ -55,6 +55,8 @@ def materialize_cluster_view(vault_dir: Path, *, pack_name: str, view_name: str)
                     f"- top_reading_route_kind: {row['top_reading_route_kind']}",
                     f"- top_reading_route_title: {row['top_reading_route_title']}",
                     f"- has_reading_route: {row['has_reading_route']}",
+                    f"- reading_intent_count: {row['reading_intent_count']}",
+                    f"- reading_intent_preview: {row['reading_intent_preview']}",
                     "",
                     "#### Members",
                     "",

--- a/src/openclaw_pipeline/materializers/cluster_view.py
+++ b/src/openclaw_pipeline/materializers/cluster_view.py
@@ -47,6 +47,7 @@ def materialize_cluster_view(vault_dir: Path, *, pack_name: str, view_name: str)
                     f"- score: {row['score']}",
                     f"- priority_band: {row['priority_band']}",
                     f"- priority_reason: {row['priority_reason']}",
+                    f"- related_cluster_count: {row['related_cluster_count']}",
                     "",
                     "#### Members",
                     "",
@@ -82,6 +83,18 @@ def materialize_cluster_view(vault_dir: Path, *, pack_name: str, view_name: str)
             if detail["relation_pattern_items"]:
                 for item in detail["relation_pattern_items"]:
                     lines.append(f"- {item['display_name']} ({item['count']})")
+            else:
+                lines.append("- (none)")
+            lines.extend(
+                [
+                    "",
+                    "#### Related Clusters",
+                    "",
+                ]
+            )
+            if detail["related_clusters"]:
+                for item in detail["related_clusters"]:
+                    lines.append(f"- {item['display_title']} [{item['reason']}]")
             else:
                 lines.append("- (none)")
             lines.extend(

--- a/src/openclaw_pipeline/materializers/cluster_view.py
+++ b/src/openclaw_pipeline/materializers/cluster_view.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from ..derived.paths import compiled_view_path
 from ..runtime import VaultLayout, resolve_vault_dir
-from ..ui.view_models import build_cluster_browser_payload, build_cluster_detail_payload
+from ..ui.view_models import build_cluster_browser_payload
 
 
 def materialize_cluster_view(vault_dir: Path, *, pack_name: str, view_name: str) -> Path:
@@ -30,11 +30,6 @@ def materialize_cluster_view(vault_dir: Path, *, pack_name: str, view_name: str)
         lines.append("- (none)")
     else:
         for row in rows:
-            detail = build_cluster_detail_payload(
-                resolved_vault,
-                cluster_id=str(row["cluster_id"]),
-                pack_name=pack_name,
-            )
             lines.extend(
                 [
                     f"### {row.get('display_title') or row['label']}",
@@ -74,23 +69,23 @@ def materialize_cluster_view(vault_dir: Path, *, pack_name: str, view_name: str)
                     "",
                 ]
             )
-            for bullet in detail["summary_bullets"]:
+            for bullet in row["summary_bullets"]:
                 lines.append(f"- {bullet}")
             lines.extend(
                 [
                     "",
                     "#### Structural Label",
                     "",
-                    f"- kind: {detail['structural_label']['kind']}",
-                    f"- title: {detail['structural_label']['title']}",
-                    f"- reason: {detail['structural_label']['reason']}",
+                    f"- kind: {row['structural_label']['kind']}",
+                    f"- title: {row['structural_label']['title']}",
+                    f"- reason: {row['structural_label']['reason']}",
                     "",
                     "#### Relation Patterns",
                     "",
                 ]
             )
-            if detail["relation_pattern_items"]:
-                for item in detail["relation_pattern_items"]:
+            if row["relation_pattern_items"]:
+                for item in row["relation_pattern_items"]:
                     lines.append(f"- {item['display_name']} ({item['count']})")
             else:
                 lines.append("- (none)")
@@ -101,13 +96,13 @@ def materialize_cluster_view(vault_dir: Path, *, pack_name: str, view_name: str)
                     "",
                 ]
             )
-            if detail["next_read_cluster"]:
+            if row["next_read_cluster"]:
                 lines.extend(
                     [
-                        f"- title: {detail['next_read_cluster']['display_title']}",
-                        f"- bridge_kind: {detail['next_read_cluster']['bridge_kind']}",
-                        f"- bridge_band: {detail['next_read_cluster']['bridge_band']}",
-                        f"- reason: {detail['next_read_cluster']['reason']}",
+                        f"- title: {row['next_read_cluster']['display_title']}",
+                        f"- bridge_kind: {row['next_read_cluster']['bridge_kind']}",
+                        f"- bridge_band: {row['next_read_cluster']['bridge_band']}",
+                        f"- reason: {row['next_read_cluster']['reason']}",
                     ]
                 )
             else:
@@ -119,8 +114,8 @@ def materialize_cluster_view(vault_dir: Path, *, pack_name: str, view_name: str)
                     "",
                 ]
             )
-            if detail["related_cluster_groups"]:
-                for item in detail["related_cluster_groups"]:
+            if row["related_cluster_groups"]:
+                for item in row["related_cluster_groups"]:
                     lines.append(f"- {item['bridge_kind']} ({item['count']})")
             else:
                 lines.append("- (none)")
@@ -131,8 +126,8 @@ def materialize_cluster_view(vault_dir: Path, *, pack_name: str, view_name: str)
                     "",
                 ]
             )
-            if detail["related_clusters"]:
-                for item in detail["related_clusters"]:
+            if row["related_clusters"]:
+                for item in row["related_clusters"]:
                     lines.append(
                         f"- {item['display_title']} [{item['bridge_kind']} / {item['bridge_band']}: {item['reason']}]"
                     )
@@ -143,17 +138,17 @@ def materialize_cluster_view(vault_dir: Path, *, pack_name: str, view_name: str)
                     "",
                     "#### Coverage",
                     "",
-                    f"- source_note_count: {detail['review_context']['source_note_count']}",
-                    f"- moc_count: {detail['review_context']['moc_count']}",
-                    f"- open_contradiction_count: {detail['review_context']['open_contradiction_count']}",
-                    f"- stale_summary_count: {detail['review_context']['stale_summary_count']}",
+                    f"- source_note_count: {row['review_context']['source_note_count']}",
+                    f"- moc_count: {row['review_context']['moc_count']}",
+                    f"- open_contradiction_count: {row['review_context']['open_contradiction_count']}",
+                    f"- stale_summary_count: {row['review_context']['stale_summary_count']}",
                     "",
                     "#### Top Source Notes",
                     "",
                 ]
             )
-            if detail["top_source_notes"]:
-                for item in detail["top_source_notes"]:
+            if row["top_source_notes"]:
+                for item in row["top_source_notes"]:
                     lines.append(f"- {item['title']} ({item['object_count']} objects)")
             else:
                 lines.append("- (none)")
@@ -164,8 +159,8 @@ def materialize_cluster_view(vault_dir: Path, *, pack_name: str, view_name: str)
                     "",
                 ]
             )
-            if detail["top_mocs"]:
-                for item in detail["top_mocs"]:
+            if row["top_mocs"]:
+                for item in row["top_mocs"]:
                     lines.append(f"- {item['title']} ({item['object_count']} objects)")
             else:
                 lines.append("- (none)")

--- a/src/openclaw_pipeline/materializers/cluster_view.py
+++ b/src/openclaw_pipeline/materializers/cluster_view.py
@@ -91,6 +91,23 @@ def materialize_cluster_view(vault_dir: Path, *, pack_name: str, view_name: str)
             lines.extend(
                 [
                     "",
+                    "#### Next Reading Route",
+                    "",
+                ]
+            )
+            if detail["next_read_cluster"]:
+                lines.extend(
+                    [
+                        f"- title: {detail['next_read_cluster']['display_title']}",
+                        f"- bridge_band: {detail['next_read_cluster']['bridge_band']}",
+                        f"- reason: {detail['next_read_cluster']['reason']}",
+                    ]
+                )
+            else:
+                lines.append("- (none)")
+            lines.extend(
+                [
+                    "",
                     "#### Related Clusters",
                     "",
                 ]

--- a/src/openclaw_pipeline/materializers/cluster_view.py
+++ b/src/openclaw_pipeline/materializers/cluster_view.py
@@ -48,6 +48,9 @@ def materialize_cluster_view(vault_dir: Path, *, pack_name: str, view_name: str)
                     f"- priority_band: {row['priority_band']}",
                     f"- priority_reason: {row['priority_reason']}",
                     f"- related_cluster_count: {row['related_cluster_count']}",
+                    f"- neighborhood_score: {row['neighborhood_score']}",
+                    f"- neighborhood_band: {row['neighborhood_band']}",
+                    f"- neighborhood_reason: {row['neighborhood_reason']}",
                     "",
                     "#### Members",
                     "",
@@ -94,7 +97,7 @@ def materialize_cluster_view(vault_dir: Path, *, pack_name: str, view_name: str)
             )
             if detail["related_clusters"]:
                 for item in detail["related_clusters"]:
-                    lines.append(f"- {item['display_title']} [{item['reason']}]")
+                    lines.append(f"- {item['display_title']} [{item['bridge_band']}: {item['reason']}]")
             else:
                 lines.append("- (none)")
             lines.extend(

--- a/src/openclaw_pipeline/materializers/cluster_view.py
+++ b/src/openclaw_pipeline/materializers/cluster_view.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from ..derived.paths import compiled_view_path
 from ..runtime import VaultLayout, resolve_vault_dir
 from ..truth_api import list_graph_clusters
+from ..ui.view_models import build_cluster_detail_payload
 
 
 def materialize_cluster_view(vault_dir: Path, *, pack_name: str, view_name: str) -> Path:
@@ -29,6 +30,11 @@ def materialize_cluster_view(vault_dir: Path, *, pack_name: str, view_name: str)
         lines.append("- (none)")
     else:
         for row in rows:
+            detail = build_cluster_detail_payload(
+                resolved_vault,
+                cluster_id=str(row["cluster_id"]),
+                pack_name=pack_name,
+            )
             lines.extend(
                 [
                     f"### {row['label']}",
@@ -46,6 +52,46 @@ def materialize_cluster_view(vault_dir: Path, *, pack_name: str, view_name: str)
             if row["members"]:
                 for member in row["members"]:
                     lines.append(f"- [[{member['object_id']}]] ({member['title']})")
+            else:
+                lines.append("- (none)")
+            lines.extend(
+                [
+                    "",
+                    "#### Cluster Synthesis",
+                    "",
+                ]
+            )
+            for bullet in detail["summary_bullets"]:
+                lines.append(f"- {bullet}")
+            lines.extend(
+                [
+                    "",
+                    "#### Coverage",
+                    "",
+                    f"- source_note_count: {detail['review_context']['source_note_count']}",
+                    f"- moc_count: {detail['review_context']['moc_count']}",
+                    f"- open_contradiction_count: {detail['review_context']['open_contradiction_count']}",
+                    f"- stale_summary_count: {detail['review_context']['stale_summary_count']}",
+                    "",
+                    "#### Top Source Notes",
+                    "",
+                ]
+            )
+            if detail["top_source_notes"]:
+                for item in detail["top_source_notes"]:
+                    lines.append(f"- {item['title']} ({item['object_count']} objects)")
+            else:
+                lines.append("- (none)")
+            lines.extend(
+                [
+                    "",
+                    "#### Top Atlas Pages",
+                    "",
+                ]
+            )
+            if detail["top_mocs"]:
+                for item in detail["top_mocs"]:
+                    lines.append(f"- {item['title']} ({item['object_count']} objects)")
             else:
                 lines.append("- (none)")
             lines.append("")

--- a/src/openclaw_pipeline/materializers/cluster_view.py
+++ b/src/openclaw_pipeline/materializers/cluster_view.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..derived.paths import compiled_view_path
+from ..runtime import VaultLayout, resolve_vault_dir
+from ..truth_api import list_graph_clusters
+
+
+def materialize_cluster_view(vault_dir: Path, *, pack_name: str, view_name: str) -> Path:
+    resolved_vault = resolve_vault_dir(vault_dir)
+    layout = VaultLayout.from_vault(resolved_vault)
+    output_path = compiled_view_path(layout, pack_name=pack_name, view_name=view_name)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    rows = list_graph_clusters(resolved_vault, pack_name=pack_name, limit=200)
+
+    lines = [
+        f"# {view_name}",
+        "",
+        f"- pack: {pack_name}",
+        "- builder: cluster_view",
+        "",
+        "## Graph Clusters",
+        "",
+    ]
+
+    if not rows:
+        lines.append("- (none)")
+    else:
+        for row in rows:
+            lines.extend(
+                [
+                    f"### {row['label']}",
+                    "",
+                    f"- cluster_id: {row['cluster_id']}",
+                    f"- cluster_kind: {row['cluster_kind']}",
+                    f"- center: [[{row['center_object_id']}]]",
+                    f"- member_count: {row['member_count']}",
+                    f"- score: {row['score']}",
+                    "",
+                    "#### Members",
+                    "",
+                ]
+            )
+            if row["members"]:
+                for member in row["members"]:
+                    lines.append(f"- [[{member['object_id']}]] ({member['title']})")
+            else:
+                lines.append("- (none)")
+            lines.append("")
+
+    output_path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+    return output_path

--- a/src/openclaw_pipeline/materializers/cluster_view.py
+++ b/src/openclaw_pipeline/materializers/cluster_view.py
@@ -50,6 +50,7 @@ def materialize_cluster_view(vault_dir: Path, *, pack_name: str, view_name: str)
                     f"- related_cluster_count: {row['related_cluster_count']}",
                     f"- neighborhood_score: {row['neighborhood_score']}",
                     f"- neighborhood_band: {row['neighborhood_band']}",
+                    f"- neighborhood_bridge_kind: {row['neighborhood_bridge_kind']}",
                     f"- neighborhood_reason: {row['neighborhood_reason']}",
                     "",
                     "#### Members",
@@ -99,6 +100,7 @@ def materialize_cluster_view(vault_dir: Path, *, pack_name: str, view_name: str)
                 lines.extend(
                     [
                         f"- title: {detail['next_read_cluster']['display_title']}",
+                        f"- bridge_kind: {detail['next_read_cluster']['bridge_kind']}",
                         f"- bridge_band: {detail['next_read_cluster']['bridge_band']}",
                         f"- reason: {detail['next_read_cluster']['reason']}",
                     ]
@@ -114,7 +116,9 @@ def materialize_cluster_view(vault_dir: Path, *, pack_name: str, view_name: str)
             )
             if detail["related_clusters"]:
                 for item in detail["related_clusters"]:
-                    lines.append(f"- {item['display_title']} [{item['bridge_band']}: {item['reason']}]")
+                    lines.append(
+                        f"- {item['display_title']} [{item['bridge_kind']} / {item['bridge_band']}: {item['reason']}]"
+                    )
             else:
                 lines.append("- (none)")
             lines.extend(

--- a/src/openclaw_pipeline/materializers/cluster_view.py
+++ b/src/openclaw_pipeline/materializers/cluster_view.py
@@ -4,8 +4,7 @@ from pathlib import Path
 
 from ..derived.paths import compiled_view_path
 from ..runtime import VaultLayout, resolve_vault_dir
-from ..truth_api import list_graph_clusters
-from ..ui.view_models import build_cluster_detail_payload
+from ..ui.view_models import build_cluster_browser_payload, build_cluster_detail_payload
 
 
 def materialize_cluster_view(vault_dir: Path, *, pack_name: str, view_name: str) -> Path:
@@ -14,7 +13,8 @@ def materialize_cluster_view(vault_dir: Path, *, pack_name: str, view_name: str)
     output_path = compiled_view_path(layout, pack_name=pack_name, view_name=view_name)
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    rows = list_graph_clusters(resolved_vault, pack_name=pack_name, limit=200)
+    browser_payload = build_cluster_browser_payload(resolved_vault, pack_name=pack_name, limit=200)
+    rows = browser_payload["items"]
 
     lines = [
         f"# {view_name}",
@@ -37,13 +37,16 @@ def materialize_cluster_view(vault_dir: Path, *, pack_name: str, view_name: str)
             )
             lines.extend(
                 [
-                    f"### {row['label']}",
+                    f"### {row.get('display_title') or row['label']}",
                     "",
                     f"- cluster_id: {row['cluster_id']}",
+                    f"- canonical_label: {row['label']}",
                     f"- cluster_kind: {row['cluster_kind']}",
                     f"- center: [[{row['center_object_id']}]]",
                     f"- member_count: {row['member_count']}",
                     f"- score: {row['score']}",
+                    f"- priority_band: {row['priority_band']}",
+                    f"- priority_reason: {row['priority_reason']}",
                     "",
                     "#### Members",
                     "",
@@ -63,6 +66,24 @@ def materialize_cluster_view(vault_dir: Path, *, pack_name: str, view_name: str)
             )
             for bullet in detail["summary_bullets"]:
                 lines.append(f"- {bullet}")
+            lines.extend(
+                [
+                    "",
+                    "#### Structural Label",
+                    "",
+                    f"- kind: {detail['structural_label']['kind']}",
+                    f"- title: {detail['structural_label']['title']}",
+                    f"- reason: {detail['structural_label']['reason']}",
+                    "",
+                    "#### Relation Patterns",
+                    "",
+                ]
+            )
+            if detail["relation_pattern_items"]:
+                for item in detail["relation_pattern_items"]:
+                    lines.append(f"- {item['display_name']} ({item['count']})")
+            else:
+                lines.append("- (none)")
             lines.extend(
                 [
                     "",

--- a/src/openclaw_pipeline/materializers/cluster_view.py
+++ b/src/openclaw_pipeline/materializers/cluster_view.py
@@ -54,6 +54,7 @@ def materialize_cluster_view(vault_dir: Path, *, pack_name: str, view_name: str)
                     f"- neighborhood_reason: {row['neighborhood_reason']}",
                     f"- top_reading_route_kind: {row['top_reading_route_kind']}",
                     f"- top_reading_route_title: {row['top_reading_route_title']}",
+                    f"- has_reading_route: {row['has_reading_route']}",
                     "",
                     "#### Members",
                     "",

--- a/src/openclaw_pipeline/materializers/object_page.py
+++ b/src/openclaw_pipeline/materializers/object_page.py
@@ -11,7 +11,7 @@ def materialize_object_page(vault_dir: Path, *, pack_name: str, object_id: str) 
     layout = VaultLayout.from_vault(resolved_vault)
     output_path = layout.compiled_views_dir / pack_name / "objects" / f"{object_id}.md"
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    detail = get_object_detail(resolved_vault, object_id)
+    detail = get_object_detail(resolved_vault, object_id, pack_name=pack_name)
     object_row = detail["object"]
     object_kind = object_row["object_kind"]
     title = object_row["title"]

--- a/src/openclaw_pipeline/packs/research_tech/shared.py
+++ b/src/openclaw_pipeline/packs/research_tech/shared.py
@@ -212,6 +212,16 @@ def build_wiki_views(pack_name: str) -> list[WikiViewSpec]:
             publish_target="compiled_markdown",
         ),
         WikiViewSpec(
+            name="cluster/crystal",
+            pack=pack_name,
+            purpose_path="90-Templates/purpose/topic.md",
+            schema_path="90-Templates/schema/topic.md",
+            input_sources=[],
+            builder="cluster_crystal",
+            traceability_policy=TraceabilityPolicy(include_sources=True, include_generated_from=True),
+            publish_target="compiled_markdown",
+        ),
+        WikiViewSpec(
             name="saved_answer/query",
             pack=pack_name,
             purpose_path="90-Templates/purpose/saved-answer.md",

--- a/src/openclaw_pipeline/packs/research_tech/shared.py
+++ b/src/openclaw_pipeline/packs/research_tech/shared.py
@@ -202,6 +202,16 @@ def build_wiki_views(pack_name: str) -> list[WikiViewSpec]:
             publish_target="compiled_markdown",
         ),
         WikiViewSpec(
+            name="overview/clusters",
+            pack=pack_name,
+            purpose_path="90-Templates/purpose/topic.md",
+            schema_path="90-Templates/schema/topic.md",
+            input_sources=[],
+            builder="cluster_view",
+            traceability_policy=TraceabilityPolicy(include_sources=True, include_generated_from=True),
+            publish_target="compiled_markdown",
+        ),
+        WikiViewSpec(
             name="saved_answer/query",
             pack=pack_name,
             purpose_path="90-Templates/purpose/saved-answer.md",

--- a/src/openclaw_pipeline/packs/research_tech/truth_projection.py
+++ b/src/openclaw_pipeline/packs/research_tech/truth_projection.py
@@ -47,8 +47,9 @@ def _subject_key(claim_text: str) -> str:
     return lowered.split(".", 1)[0].strip()
 
 
-def _contradiction_id_for_subject(subject: str) -> str:
-    return f"contradiction::{hashlib.sha1(subject.encode('utf-8')).hexdigest()[:12]}"
+def _contradiction_id_for_subject(pack_name: str, subject: str) -> str:
+    fingerprint = f"{pack_name}:{subject}"
+    return f"contradiction::{hashlib.sha1(fingerprint.encode('utf-8')).hexdigest()[:12]}"
 
 
 def _is_negative_claim(claim_text: str) -> bool:
@@ -77,7 +78,7 @@ def _detect_contradictions(
         negatives = [claim_id for claim_id, text in rows if _is_negative_claim(text)]
         if not positives or not negatives:
             continue
-        contradiction_id = _contradiction_id_for_subject(subject)
+        contradiction_id = _contradiction_id_for_subject(pack_name, subject)
         contradictions.append(
             (
                 pack_name,

--- a/src/openclaw_pipeline/packs/research_tech/truth_projection.py
+++ b/src/openclaw_pipeline/packs/research_tech/truth_projection.py
@@ -1,8 +1,197 @@
 from __future__ import annotations
 
+from collections import defaultdict
+import hashlib
+import json
+import re
 from pathlib import Path
 
-from ...truth_store import TruthStoreProjection, build_truth_store_projection
+from ...truth_store import TruthStoreProjection
+
+_NEGATION_RE = re.compile(
+    r"\b(?:does not|doesn't|do not|is not|isn't|are not|aren't|has not|hasn't|have not|haven't|cannot|can't|not)\b"
+)
+_NEGATION_EXCLUSIONS = (
+    "not only",
+    "not necessarily",
+    "not merely",
+    "not just",
+)
+
+
+def _claim_id(object_id: str, claim_text: str) -> str:
+    digest = hashlib.sha1(f"{object_id}:{claim_text}".encode("utf-8")).hexdigest()[:12]
+    return f"{object_id}::{digest}"
+
+
+def _page_summary(body: str, *, fallback: str) -> str:
+    content = body.strip()
+    if not content:
+        return fallback
+    lines = [line.strip() for line in content.splitlines() if line.strip() and not line.strip().startswith("#")]
+    text = " ".join(lines)
+    if not text:
+        return fallback
+    for marker in (". ", "! ", "? ", "。", "！", "？"):
+        if marker in text:
+            return text.split(marker, 1)[0].strip() + (marker.strip() if marker.strip() in "。！？" else ".")
+    return text[:220]
+
+
+def _subject_key(claim_text: str) -> str:
+    lowered = claim_text.strip().lower()
+    lowered = re.sub(r"\s+", " ", lowered)
+    for marker in (" supports ", " does not support ", " is ", " are ", " has ", " have "):
+        if marker in lowered:
+            return lowered.split(marker, 1)[0].strip()
+    return lowered.split(".", 1)[0].strip()
+
+
+def _contradiction_id_for_subject(subject: str) -> str:
+    return f"contradiction::{hashlib.sha1(subject.encode('utf-8')).hexdigest()[:12]}"
+
+
+def _is_negative_claim(claim_text: str) -> bool:
+    lowered = claim_text.strip().lower()
+    if any(exclusion in lowered for exclusion in _NEGATION_EXCLUSIONS):
+        return False
+    return bool(_NEGATION_RE.search(lowered))
+
+
+def _detect_contradictions(
+    pack_name: str,
+    claims: list[tuple[str, str, str, str, str, float]],
+) -> list[tuple[str, str, str, str, str, str, str, str]]:
+    grouped: dict[str, list[tuple[str, str]]] = {}
+    for _pack, claim_id, _object_id, claim_kind, claim_text, _confidence in claims:
+        if claim_kind != "page_summary":
+            continue
+        subject = _subject_key(claim_text)
+        if not subject:
+            continue
+        grouped.setdefault(subject, []).append((claim_id, claim_text))
+
+    contradictions: list[tuple[str, str, str, str, str, str, str, str]] = []
+    for subject, rows in grouped.items():
+        positives = [claim_id for claim_id, text in rows if not _is_negative_claim(text)]
+        negatives = [claim_id for claim_id, text in rows if _is_negative_claim(text)]
+        if not positives or not negatives:
+            continue
+        contradiction_id = _contradiction_id_for_subject(subject)
+        contradictions.append(
+            (
+                pack_name,
+                contradiction_id,
+                subject,
+                json.dumps(positives, ensure_ascii=False),
+                json.dumps(negatives, ensure_ascii=False),
+                "open",
+                "",
+                "",
+            )
+        )
+    return contradictions
+
+
+def _graph_edge_id(source_object_id: str, target_object_id: str, edge_kind: str) -> str:
+    fingerprint = f"{source_object_id}:{target_object_id}:{edge_kind}"
+    return hashlib.sha1(fingerprint.encode("utf-8")).hexdigest()[:16]
+
+
+def _graph_cluster_id(member_object_ids: list[str]) -> str:
+    fingerprint = "::".join(member_object_ids)
+    return f"cluster::{hashlib.sha1(fingerprint.encode('utf-8')).hexdigest()[:12]}"
+
+
+def _build_graph_seeds(
+    pack_name: str,
+    *,
+    objects: list[tuple[str, str, str, str, str, str]],
+    relations: list[tuple[str, str, str, str, str]],
+    contradictions: list[tuple[str, str, str, str, str, str, str, str]],
+) -> tuple[
+    list[tuple[str, str, str, str, str, float, str]],
+    list[tuple[str, str, str, str, str, str, float]],
+]:
+    edge_rows: dict[str, tuple[str, str, str, str, str, float, str]] = {}
+    adjacency: dict[str, set[str]] = defaultdict(set)
+    object_titles = {object_id: title for _pack, object_id, _kind, title, _path, _source in objects}
+
+    for _pack, source_object_id, target_object_id, relation_type, evidence_source_slug in relations:
+        edge_kind = f"relation:{relation_type}"
+        edge_id = _graph_edge_id(source_object_id, target_object_id, edge_kind)
+        edge_rows[edge_id] = (
+            pack_name,
+            edge_id,
+            source_object_id,
+            target_object_id,
+            edge_kind,
+            1.0,
+            evidence_source_slug,
+        )
+        adjacency[source_object_id].add(target_object_id)
+        adjacency[target_object_id].add(source_object_id)
+
+    for _pack, _contradiction_id, _subject_key, positive_json, negative_json, _status, _note, _resolved_at in contradictions:
+        positive_ids = {claim_id.split("::", 1)[0] for claim_id in json.loads(positive_json)}
+        negative_ids = {claim_id.split("::", 1)[0] for claim_id in json.loads(negative_json)}
+        for source_object_id in sorted(positive_ids):
+            for target_object_id in sorted(negative_ids):
+                if source_object_id == target_object_id:
+                    continue
+                ordered = tuple(sorted([source_object_id, target_object_id]))
+                edge_kind = "contradiction:subject"
+                edge_id = _graph_edge_id(ordered[0], ordered[1], edge_kind)
+                edge_rows[edge_id] = (
+                    pack_name,
+                    edge_id,
+                    ordered[0],
+                    ordered[1],
+                    edge_kind,
+                    0.8,
+                    "",
+                )
+                adjacency[ordered[0]].add(ordered[1])
+                adjacency[ordered[1]].add(ordered[0])
+
+    visited: set[str] = set()
+    cluster_rows: list[tuple[str, str, str, str, str, str, float]] = []
+    for object_id in sorted(object_titles):
+        if object_id in visited:
+            continue
+        stack = [object_id]
+        component: list[str] = []
+        while stack:
+            current = stack.pop()
+            if current in visited:
+                continue
+            visited.add(current)
+            component.append(current)
+            stack.extend(sorted(adjacency.get(current, set()) - visited))
+        component = sorted(component)
+        if len(component) < 2:
+            continue
+        center_object_id = max(
+            component,
+            key=lambda candidate: (
+                len(adjacency.get(candidate, set())),
+                object_titles.get(candidate, ""),
+                candidate,
+            ),
+        )
+        cluster_rows.append(
+            (
+                pack_name,
+                _graph_cluster_id(component),
+                "relation_component",
+                object_titles.get(center_object_id, center_object_id),
+                center_object_id,
+                json.dumps(component, ensure_ascii=False),
+                float(len(component)),
+            )
+        )
+
+    return list(edge_rows.values()), cluster_rows
 
 
 def build_truth_projection(
@@ -10,7 +199,44 @@ def build_truth_projection(
     vault_dir: Path,
     page_rows: list[tuple[str, str, str, str, str, str, str]],
     link_rows: list[tuple[str, str, str, str, int]],
+    pack_name: str | None = None,
     spec: object | None = None,
 ) -> TruthStoreProjection:
     _ = vault_dir, spec
-    return build_truth_store_projection(page_rows, link_rows)
+    resolved_pack_name = str(pack_name or "research-tech")
+
+    objects: list[tuple[str, str, str, str, str, str]] = []
+    claims: list[tuple[str, str, str, str, str, float]] = []
+    claim_evidence: list[tuple[str, str, str, str, str]] = []
+    compiled_summaries: list[tuple[str, str, str, str]] = []
+
+    for slug, title, note_type, path, _day_id, _frontmatter_json, body in page_rows:
+        objects.append((resolved_pack_name, slug, note_type, title, path, slug))
+        summary = _page_summary(body, fallback=title)
+        claim_id = _claim_id(slug, summary)
+        claims.append((resolved_pack_name, claim_id, slug, "page_summary", summary, 1.0))
+        claim_evidence.append((resolved_pack_name, claim_id, slug, "body_summary", summary))
+        compiled_summaries.append((resolved_pack_name, slug, summary, slug))
+
+    relations = [
+        (resolved_pack_name, source_slug, target_slug, relation_type, source_slug)
+        for source_slug, target_slug, _target_raw, relation_type, _line_number in link_rows
+    ]
+    contradictions = _detect_contradictions(resolved_pack_name, claims)
+    graph_edges, graph_clusters = _build_graph_seeds(
+        resolved_pack_name,
+        objects=objects,
+        relations=relations,
+        contradictions=contradictions,
+    )
+
+    return TruthStoreProjection(
+        objects=objects,
+        claims=claims,
+        claim_evidence=claim_evidence,
+        relations=relations,
+        compiled_summaries=compiled_summaries,
+        contradictions=contradictions,
+        graph_edges=graph_edges,
+        graph_clusters=graph_clusters,
+    )

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -1249,6 +1249,85 @@ def list_graph_clusters(
     return items
 
 
+def get_graph_cluster_detail(
+    vault_dir: Path | str,
+    cluster_id: str,
+    *,
+    pack_name: str | None = None,
+) -> dict[str, Any]:
+    db_path = _db_path(vault_dir)
+    pack_candidates = _materialized_truth_packs(vault_dir, pack_name=pack_name, table_name="graph_clusters")
+
+    truth_pack = ""
+    cluster_row = None
+    with sqlite3.connect(db_path) as conn:
+        for candidate_pack in pack_candidates:
+            cluster_row = conn.execute(
+                """
+                SELECT cluster_id, cluster_kind, label, center_object_id, member_object_ids_json, score
+                FROM graph_clusters
+                WHERE pack = ? AND cluster_id = ?
+                """,
+                (candidate_pack, cluster_id),
+            ).fetchone()
+            if cluster_row is not None:
+                truth_pack = candidate_pack
+                break
+        if cluster_row is None:
+            raise ValueError(f"Unknown cluster_id: {cluster_id}")
+
+        member_object_ids = [str(value) for value in json.loads(cluster_row[4])]
+        if member_object_ids:
+            placeholders = ",".join("?" for _ in member_object_ids)
+            edge_rows = conn.execute(
+                f"""
+                SELECT edge_id, source_object_id, target_object_id, edge_kind, weight, evidence_source_slug
+                FROM graph_edges
+                WHERE pack = ?
+                  AND source_object_id IN ({placeholders})
+                  AND target_object_id IN ({placeholders})
+                ORDER BY weight DESC, edge_kind, source_object_id, target_object_id
+                """,
+                (truth_pack, *member_object_ids, *member_object_ids),
+            ).fetchall()
+        else:
+            edge_rows = []
+
+    object_rows = _batch_object_rows(vault_dir, member_object_ids, pack_name=truth_pack)
+    center_object_id = str(cluster_row[3])
+    return {
+        "cluster": {
+            "cluster_id": str(cluster_row[0]),
+            "cluster_kind": str(cluster_row[1]),
+            "label": str(cluster_row[2]),
+            "center_object_id": center_object_id,
+            "center_title": object_rows.get(center_object_id, {}).get("title", center_object_id),
+            "member_object_ids": member_object_ids,
+            "member_count": len(member_object_ids),
+            "members": [
+                object_rows.get(
+                    object_id,
+                    {"object_id": object_id, "title": object_id, "pack": truth_pack},
+                )
+                for object_id in member_object_ids
+            ],
+            "score": float(cluster_row[5] or 0.0),
+            "pack": truth_pack,
+        },
+        "edges": [
+            {
+                "edge_id": str(row[0]),
+                "source_object_id": str(row[1]),
+                "target_object_id": str(row[2]),
+                "edge_kind": str(row[3]),
+                "weight": float(row[4] or 0.0),
+                "evidence_source_slug": str(row[5] or ""),
+            }
+            for row in edge_rows
+        ],
+    }
+
+
 def _find_note_by_source(vault_dir: Path, *, source_url: str, exclude_path: str) -> dict[str, str] | None:
     cache_key = (str(vault_dir.resolve()), _search_root_signatures(vault_dir))
     source_index = _SOURCE_NOTE_INDEX_CACHE.get(cache_key)

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -1175,6 +1175,7 @@ def list_graph_clusters(
     limit, _ = _validate_page_args(limit=limit, offset=0)
     db_path = _db_path(vault_dir)
     pack_candidates = _materialized_truth_packs(vault_dir, pack_name=pack_name, table_name="graph_clusters")
+    requested_pack = pack_name or pack_candidates[0]
     normalized_query = _escape_like(query.strip().lower()) if query else ""
 
     sql = """
@@ -1241,7 +1242,8 @@ def list_graph_clusters(
                     for object_id in member_object_ids
                 ],
                 "score": float(score or 0.0),
-                "pack": cluster_pack,
+                "pack": requested_pack,
+                "row_pack": cluster_pack,
             }
         )
         if len(items) >= limit:
@@ -1257,6 +1259,7 @@ def get_graph_cluster_detail(
 ) -> dict[str, Any]:
     db_path = _db_path(vault_dir)
     pack_candidates = _materialized_truth_packs(vault_dir, pack_name=pack_name, table_name="graph_clusters")
+    requested_pack = pack_name or pack_candidates[0]
 
     truth_pack = ""
     cluster_row = None
@@ -1312,7 +1315,8 @@ def get_graph_cluster_detail(
                 for object_id in member_object_ids
             ],
             "score": float(cluster_row[5] or 0.0),
-            "pack": truth_pack,
+            "pack": requested_pack,
+            "row_pack": truth_pack,
         },
         "edges": [
             {

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -99,11 +99,26 @@ def _materialized_truth_packs(
     candidates = _truth_pack_candidates(pack_name)
     requested_pack = candidates[0]
     db_path = _db_path(vault_dir)
-    with sqlite3.connect(db_path) as conn:
-        row = conn.execute(
-            f"SELECT 1 FROM {table_name} WHERE pack = ? LIMIT 1",
-            (requested_pack,),
-        ).fetchone()
+    row = None
+    try:
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                "SELECT 1 FROM truth_projections WHERE pack = ? LIMIT 1",
+                (requested_pack,),
+            ).fetchone()
+            if row is None:
+                row = conn.execute(
+                    f"SELECT 1 FROM {table_name} WHERE pack = ? LIMIT 1",
+                    (requested_pack,),
+                ).fetchone()
+    except sqlite3.OperationalError as exc:
+        if "no such table" not in str(exc).lower():
+            raise
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                f"SELECT 1 FROM {table_name} WHERE pack = ? LIMIT 1",
+                (requested_pack,),
+            ).fetchone()
     if row is not None:
         return [requested_pack]
     return candidates
@@ -979,7 +994,7 @@ def get_object_detail(
     db_path = _db_path(vault_dir)
     resolved_vault = resolve_vault_dir(vault_dir)
     escaped = _escape_like(object_id)
-    pack_candidates = _materialized_truth_packs(vault_dir, pack_name=pack_name, table_name="graph_clusters")
+    pack_candidates = _materialized_truth_packs(vault_dir, pack_name=pack_name, table_name="objects")
 
     truth_pack = ""
     with sqlite3.connect(db_path) as conn:
@@ -1159,7 +1174,7 @@ def list_graph_clusters(
 ) -> list[dict[str, Any]]:
     limit, _ = _validate_page_args(limit=limit, offset=0)
     db_path = _db_path(vault_dir)
-    pack_candidates = _truth_pack_candidates(pack_name)
+    pack_candidates = _materialized_truth_packs(vault_dir, pack_name=pack_name, table_name="graph_clusters")
     normalized_query = _escape_like(query.strip().lower()) if query else ""
 
     sql = """

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -14,6 +14,7 @@ import yaml
 
 from .handler_registry import execute_focused_action_handler, resolve_focused_action_handler
 from .observation_surface_registry import execute_observation_surface_builder
+from .pack_resolution import iter_compatible_packs
 from .packs.loader import DEFAULT_WORKFLOW_PACK_NAME
 from .runtime import (
     VaultLayout,
@@ -79,6 +80,33 @@ _BRIEFING_EVOLUTION_PRIORITY = {
 def _db_path(vault_dir: Path | str) -> Path:
     resolved = resolve_vault_dir(vault_dir)
     return VaultLayout.from_vault(resolved).knowledge_db
+
+
+def _truth_pack_name(pack_name: str | None = None) -> str:
+    return str(pack_name or DEFAULT_WORKFLOW_PACK_NAME)
+
+
+def _truth_pack_candidates(pack_name: str | None = None) -> list[str]:
+    return [pack.name for pack in iter_compatible_packs(pack_name or DEFAULT_WORKFLOW_PACK_NAME)]
+
+
+def _materialized_truth_packs(
+    vault_dir: Path | str,
+    *,
+    pack_name: str | None,
+    table_name: str,
+) -> list[str]:
+    candidates = _truth_pack_candidates(pack_name)
+    requested_pack = candidates[0]
+    db_path = _db_path(vault_dir)
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            f"SELECT 1 FROM {table_name} WHERE pack = ? LIMIT 1",
+            (requested_pack,),
+        ).fetchone()
+    if row is not None:
+        return [requested_pack]
+    return candidates
 
 
 def _utc_now_text() -> str:
@@ -268,32 +296,45 @@ def _is_moc_row(note_type: str, path: str) -> bool:
     return note_type == "moc" or "/10-Knowledge/Atlas/" in path or Path(path).name.startswith("MOC")
 
 
-def _batch_object_rows(vault_dir: Path | str, object_ids: list[str]) -> dict[str, dict[str, Any]]:
+def _batch_object_rows(
+    vault_dir: Path | str,
+    object_ids: list[str],
+    *,
+    pack_name: str | None = None,
+) -> dict[str, dict[str, Any]]:
     if not object_ids:
         return {}
     db_path = _db_path(vault_dir)
     resolved_vault = resolve_vault_dir(vault_dir)
+    pack_candidates = _materialized_truth_packs(vault_dir, pack_name=pack_name, table_name="objects")
     placeholders = ",".join("?" for _ in object_ids)
+    pack_placeholders = ",".join("?" for _ in pack_candidates)
     with sqlite3.connect(db_path) as conn:
         rows = conn.execute(
             f"""
-            SELECT object_id, object_kind, title, canonical_path, source_slug
+            SELECT pack, object_id, object_kind, title, canonical_path, source_slug
             FROM objects
-            WHERE object_id IN ({placeholders})
-            ORDER BY object_id
+            WHERE pack IN ({pack_placeholders}) AND object_id IN ({placeholders})
+            ORDER BY CASE pack
+              {''.join(f"WHEN ? THEN {index} " for index, _ in enumerate(pack_candidates))}
+              ELSE {len(pack_candidates)}
+            END, object_id
             """,
-            tuple(object_ids),
+            (*pack_candidates, *object_ids, *pack_candidates),
         ).fetchall()
-    return {
-        row[0]: {
-            "object_id": row[0],
-            "object_kind": row[1],
-            "title": row[2],
-            "canonical_path": _vault_relative_path(resolved_vault, row[3]),
-            "source_slug": row[4],
+    items: dict[str, dict[str, Any]] = {}
+    for pack, object_id, object_kind, title, canonical_path, source_slug in rows:
+        if object_id in items:
+            continue
+        items[object_id] = {
+            "object_id": object_id,
+            "object_kind": object_kind,
+            "title": title,
+            "canonical_path": _vault_relative_path(resolved_vault, canonical_path),
+            "source_slug": source_slug,
+            "pack": pack,
         }
-        for row in rows
-    }
+    return items
 
 
 def get_object_provenance_map(vault_dir: Path | str, object_ids: list[str]) -> dict[str, dict[str, Any]]:
@@ -663,22 +704,27 @@ def list_objects(
     limit: int = 100,
     offset: int = 0,
     query: str | None = None,
+    pack_name: str | None = None,
 ) -> list[dict[str, Any]]:
     limit, offset = _validate_page_args(limit=limit, offset=offset)
     db_path = _db_path(vault_dir)
     resolved_vault = resolve_vault_dir(vault_dir)
+    pack_candidates = _materialized_truth_packs(vault_dir, pack_name=pack_name, table_name="objects")
     normalized_query = _escape_like(query.strip().lower()) if query else ""
     with sqlite3.connect(db_path) as conn:
         sql = """
-            SELECT object_id, object_kind, title, canonical_path, source_slug
+            SELECT pack, object_id, object_kind, title, canonical_path, source_slug
             FROM objects
         """
-        params: list[Any] = []
+        params: list[Any] = [*pack_candidates]
+        sql += f" WHERE pack IN ({','.join('?' for _ in pack_candidates)})"
         if normalized_query:
             sql += """
-                WHERE lower(object_id) LIKE ? ESCAPE '\\'
-                   OR lower(title) LIKE ? ESCAPE '\\'
-                   OR lower(source_slug) LIKE ? ESCAPE '\\'
+                AND (
+                  lower(object_id) LIKE ? ESCAPE '\\'
+                  OR lower(title) LIKE ? ESCAPE '\\'
+                  OR lower(source_slug) LIKE ? ESCAPE '\\'
+                )
             """
             params.extend(
                 [
@@ -687,20 +733,34 @@ def list_objects(
                     f"%{normalized_query}%",
                 ]
             )
-        sql += " ORDER BY object_id LIMIT ? OFFSET ?"
-        params.extend([limit, offset])
+        sql += """
+            ORDER BY CASE pack
+              {pack_order}
+              ELSE {fallback_order}
+            END, object_id
+        """.format(
+            pack_order=" ".join(f"WHEN ? THEN {index}" for index, _ in enumerate(pack_candidates)),
+            fallback_order=len(pack_candidates),
+        )
+        params.extend(pack_candidates)
         rows = conn.execute(sql, tuple(params)).fetchall()
-
-    return [
-        {
-            "object_id": row[0],
-            "object_kind": row[1],
-            "title": row[2],
-            "canonical_path": _vault_relative_path(resolved_vault, row[3]),
-            "source_slug": row[4],
-        }
-        for row in rows
-    ]
+    items: list[dict[str, Any]] = []
+    seen_object_ids: set[str] = set()
+    for pack, object_id, object_kind, title, canonical_path, source_slug in rows:
+        if object_id in seen_object_ids:
+            continue
+        seen_object_ids.add(object_id)
+        items.append(
+            {
+                "object_id": object_id,
+                "object_kind": object_kind,
+                "title": title,
+                "canonical_path": _vault_relative_path(resolved_vault, canonical_path),
+                "source_slug": source_slug,
+                "pack": pack,
+            }
+        )
+    return items[offset : offset + limit]
 
 
 def search_vault_surface(
@@ -709,6 +769,7 @@ def search_vault_surface(
     query: str,
     object_limit: int = 25,
     note_limit: int = 25,
+    pack_name: str | None = None,
 ) -> dict[str, Any]:
     normalized_query = query.strip()
     object_limit, _ = _validate_page_args(limit=object_limit, offset=0)
@@ -721,23 +782,32 @@ def search_vault_surface(
         }
     db_path = _db_path(vault_dir)
     resolved_vault = resolve_vault_dir(vault_dir)
+    truth_pack = _truth_pack_name(pack_name)
     escaped_query = _escape_like(normalized_query.lower())
     with sqlite3.connect(db_path) as conn:
         object_rows = conn.execute(
             """
             SELECT DISTINCT objects.object_id, objects.object_kind, objects.title, objects.canonical_path, objects.source_slug
             FROM objects
-            LEFT JOIN compiled_summaries ON compiled_summaries.object_id = objects.object_id
-            LEFT JOIN claims ON claims.object_id = objects.object_id
-            WHERE lower(objects.object_id) LIKE ? ESCAPE '\\'
-               OR lower(objects.title) LIKE ? ESCAPE '\\'
-               OR lower(objects.source_slug) LIKE ? ESCAPE '\\'
-               OR lower(compiled_summaries.summary_text) LIKE ? ESCAPE '\\'
-               OR lower(claims.claim_text) LIKE ? ESCAPE '\\'
+            LEFT JOIN compiled_summaries
+              ON compiled_summaries.pack = objects.pack
+             AND compiled_summaries.object_id = objects.object_id
+            LEFT JOIN claims
+              ON claims.pack = objects.pack
+             AND claims.object_id = objects.object_id
+            WHERE objects.pack = ?
+              AND (
+                lower(objects.object_id) LIKE ? ESCAPE '\\'
+                OR lower(objects.title) LIKE ? ESCAPE '\\'
+                OR lower(objects.source_slug) LIKE ? ESCAPE '\\'
+                OR lower(compiled_summaries.summary_text) LIKE ? ESCAPE '\\'
+                OR lower(claims.claim_text) LIKE ? ESCAPE '\\'
+              )
             ORDER BY objects.object_id
             LIMIT ?
             """,
             (
+                truth_pack,
                 f"%{escaped_query}%",
                 f"%{escaped_query}%",
                 f"%{escaped_query}%",
@@ -780,6 +850,7 @@ def search_vault_surface(
             "title": row[2],
             "canonical_path": _vault_relative_path(resolved_vault, row[3]),
             "source_slug": row[4],
+            "pack": truth_pack,
         }
         for row in object_rows
     ]
@@ -799,25 +870,21 @@ def search_vault_surface(
     }
 
 
-def count_objects(vault_dir: Path | str, *, query: str | None = None) -> int:
+def count_objects(vault_dir: Path | str, *, query: str | None = None, pack_name: str | None = None) -> int:
     db_path = _db_path(vault_dir)
+    pack_candidates = _materialized_truth_packs(vault_dir, pack_name=pack_name, table_name="objects")
     normalized_query = _escape_like(query.strip().lower()) if query else ""
-    sql = "SELECT COUNT(*) FROM objects"
-    params: list[Any] = []
+    sql = f"SELECT COUNT(DISTINCT object_id) FROM objects WHERE pack IN ({','.join('?' for _ in pack_candidates)})"
+    params: list[Any] = [*pack_candidates]
     if normalized_query:
         sql += """
-            WHERE lower(object_id) LIKE ? ESCAPE '\\'
-               OR lower(title) LIKE ? ESCAPE '\\'
-               OR lower(source_slug) LIKE ? ESCAPE '\\'
+            AND (
+              lower(object_id) LIKE ? ESCAPE '\\'
+              OR lower(title) LIKE ? ESCAPE '\\'
+              OR lower(source_slug) LIKE ? ESCAPE '\\'
+            )
         """
-        params.extend(
-            [
-                f"%{normalized_query}%",
-                f"%{normalized_query}%",
-                f"%{normalized_query}%",
-            ]
-        )
-
+        params.extend([f"%{normalized_query}%"] * 3)
     with sqlite3.connect(db_path) as conn:
         row = conn.execute(sql, tuple(params)).fetchone()
     return int(row[0]) if row else 0
@@ -903,20 +970,32 @@ def _list_surface_groups(
     return list(grouped.values())
 
 
-def get_object_detail(vault_dir: Path | str, object_id: str) -> dict[str, Any]:
+def get_object_detail(
+    vault_dir: Path | str,
+    object_id: str,
+    *,
+    pack_name: str | None = None,
+) -> dict[str, Any]:
     db_path = _db_path(vault_dir)
     resolved_vault = resolve_vault_dir(vault_dir)
     escaped = _escape_like(object_id)
+    pack_candidates = _materialized_truth_packs(vault_dir, pack_name=pack_name, table_name="graph_clusters")
 
+    truth_pack = ""
     with sqlite3.connect(db_path) as conn:
-        object_row = conn.execute(
-            """
-            SELECT object_id, object_kind, title, canonical_path, source_slug
-            FROM objects
-            WHERE object_id = ?
-            """,
-            (object_id,),
-        ).fetchone()
+        object_row = None
+        for candidate_pack in pack_candidates:
+            object_row = conn.execute(
+                """
+                SELECT object_id, object_kind, title, canonical_path, source_slug
+                FROM objects
+                WHERE pack = ? AND object_id = ?
+                """,
+                (candidate_pack, object_id),
+            ).fetchone()
+            if object_row is not None:
+                truth_pack = candidate_pack
+                break
         if object_row is None:
             raise ValueError(f"Unknown object_id: {object_id}")
 
@@ -924,47 +1003,48 @@ def get_object_detail(vault_dir: Path | str, object_id: str) -> dict[str, Any]:
             """
             SELECT object_id, summary_text, source_slug
             FROM compiled_summaries
-            WHERE object_id = ?
+            WHERE pack = ? AND object_id = ?
             """,
-            (object_id,),
+            (truth_pack, object_id),
         ).fetchone()
         claim_rows = conn.execute(
             """
             SELECT claim_id, claim_kind, claim_text, confidence
             FROM claims
-            WHERE object_id = ?
+            WHERE pack = ? AND object_id = ?
             ORDER BY claim_id
             """,
-            (object_id,),
+            (truth_pack, object_id),
         ).fetchall()
         evidence_rows = conn.execute(
             """
             SELECT claim_id, source_slug, evidence_kind, quote_text
             FROM claim_evidence
             WHERE claim_id IN (
-                SELECT claim_id FROM claims WHERE object_id = ?
+                SELECT claim_id FROM claims WHERE pack = ? AND object_id = ?
             )
             ORDER BY claim_id, evidence_kind
             """,
-            (object_id,),
+            (truth_pack, object_id),
         ).fetchall()
         relation_rows = conn.execute(
             """
             SELECT source_object_id, target_object_id, relation_type, evidence_source_slug
             FROM relations
-            WHERE source_object_id = ?
+            WHERE pack = ? AND source_object_id = ?
             ORDER BY target_object_id
             """,
-            (object_id,),
+            (truth_pack, object_id),
         ).fetchall()
         contradiction_rows = conn.execute(
             """
             SELECT contradiction_id, subject_key, positive_claim_ids_json, negative_claim_ids_json, status, resolution_note, resolved_at
             FROM contradictions
-            WHERE positive_claim_ids_json LIKE ? ESCAPE '\\' OR negative_claim_ids_json LIKE ? ESCAPE '\\'
+            WHERE pack = ?
+              AND (positive_claim_ids_json LIKE ? ESCAPE '\\' OR negative_claim_ids_json LIKE ? ESCAPE '\\')
             ORDER BY subject_key
             """,
-            (f'%"{escaped}::%', f'%"{escaped}::%'),
+            (truth_pack, f'%"{escaped}::%', f'%"{escaped}::%'),
         ).fetchall()
         mention_rows = conn.execute(
             """
@@ -1023,6 +1103,7 @@ def get_object_detail(vault_dir: Path | str, object_id: str) -> dict[str, Any]:
             "title": object_row[2],
             "canonical_path": _vault_relative_path(resolved_vault, object_row[3]),
             "source_slug": object_row[4],
+            "pack": truth_pack,
         },
         "summary": (
             {
@@ -1067,6 +1148,90 @@ def get_object_detail(vault_dir: Path | str, object_id: str) -> dict[str, Any]:
             "mocs": mocs,
         },
     }
+
+
+def list_graph_clusters(
+    vault_dir: Path | str,
+    *,
+    pack_name: str | None = None,
+    query: str | None = None,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    limit, _ = _validate_page_args(limit=limit, offset=0)
+    db_path = _db_path(vault_dir)
+    pack_candidates = _truth_pack_candidates(pack_name)
+    normalized_query = _escape_like(query.strip().lower()) if query else ""
+
+    sql = """
+        SELECT pack, cluster_id, cluster_kind, label, center_object_id, member_object_ids_json, score
+        FROM graph_clusters
+        WHERE pack IN ({pack_placeholders})
+    """
+    sql = sql.format(pack_placeholders=",".join("?" for _ in pack_candidates))
+    params: list[Any] = [*pack_candidates]
+    if normalized_query:
+        sql += """
+          AND (
+            lower(pack) LIKE ? ESCAPE '\\'
+            OR
+            lower(cluster_kind) LIKE ? ESCAPE '\\'
+            OR lower(label) LIKE ? ESCAPE '\\'
+            OR lower(center_object_id) LIKE ? ESCAPE '\\'
+            OR lower(member_object_ids_json) LIKE ? ESCAPE '\\'
+          )
+        """
+        params.extend([f"%{normalized_query}%"] * 5)
+    sql += """
+      ORDER BY CASE pack
+        {pack_order}
+        ELSE {fallback_order}
+      END, score DESC, cluster_id
+    """.format(
+        pack_order=" ".join(f"WHEN ? THEN {index}" for index, _ in enumerate(pack_candidates)),
+        fallback_order=len(pack_candidates),
+    )
+    params.extend(pack_candidates)
+
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(sql, tuple(params)).fetchall()
+
+    all_member_ids = [
+        object_id
+        for _pack, _cluster_id, _cluster_kind, _label, _center_object_id, member_json, _score in rows
+        for object_id in json.loads(member_json)
+    ]
+    object_rows = _batch_object_rows(vault_dir, all_member_ids, pack_name=pack_name)
+
+    items: list[dict[str, Any]] = []
+    seen_cluster_ids: set[str] = set()
+    for cluster_pack, cluster_id, cluster_kind, label, center_object_id, member_json, score in rows:
+        if cluster_id in seen_cluster_ids:
+            continue
+        seen_cluster_ids.add(cluster_id)
+        member_object_ids = json.loads(member_json)
+        items.append(
+            {
+                "cluster_id": str(cluster_id),
+                "cluster_kind": str(cluster_kind),
+                "label": str(label),
+                "center_object_id": str(center_object_id),
+                "center_title": object_rows.get(str(center_object_id), {}).get("title", str(center_object_id)),
+                "member_object_ids": member_object_ids,
+                "member_count": len(member_object_ids),
+                "members": [
+                    object_rows.get(
+                        str(object_id),
+                        {"object_id": str(object_id), "title": str(object_id), "pack": cluster_pack},
+                    )
+                    for object_id in member_object_ids
+                ],
+                "score": float(score or 0.0),
+                "pack": cluster_pack,
+            }
+        )
+        if len(items) >= limit:
+            break
+    return items
 
 
 def _find_note_by_source(vault_dir: Path, *, source_url: str, exclude_path: str) -> dict[str, str] | None:

--- a/src/openclaw_pipeline/truth_projection_registry.py
+++ b/src/openclaw_pipeline/truth_projection_registry.py
@@ -32,6 +32,7 @@ def execute_truth_projection_builder(
         vault_dir=vault_dir,
         page_rows=page_rows,
         link_rows=link_rows,
+        pack_name=str(getattr(coerce_pack(pack_name), "name", "")),
         spec=spec,
     )
     return spec, projection

--- a/src/openclaw_pipeline/truth_store.py
+++ b/src/openclaw_pipeline/truth_store.py
@@ -98,6 +98,13 @@ CREATE TABLE graph_clusters (
 );
 
 CREATE INDEX idx_graph_clusters_pack_kind ON graph_clusters(pack, cluster_kind);
+
+CREATE TABLE truth_projections (
+  pack TEXT PRIMARY KEY,
+  owner_pack TEXT NOT NULL,
+  builder_name TEXT NOT NULL DEFAULT '',
+  built_at TEXT NOT NULL DEFAULT ''
+);
 """
 
 CONTRADICTION_HEURISTIC_NOTE = (

--- a/src/openclaw_pipeline/truth_store.py
+++ b/src/openclaw_pipeline/truth_store.py
@@ -1,139 +1,120 @@
 from __future__ import annotations
 
-import json
+from dataclasses import dataclass, field
 import hashlib
+import json
 import re
-from dataclasses import dataclass
 
 
 TRUTH_STORE_SCHEMA = """
 CREATE TABLE objects (
-  object_id TEXT PRIMARY KEY,
+  pack TEXT NOT NULL DEFAULT 'research-tech',
+  object_id TEXT NOT NULL,
   object_kind TEXT NOT NULL,
   title TEXT NOT NULL,
   canonical_path TEXT NOT NULL,
-  source_slug TEXT NOT NULL
+  source_slug TEXT NOT NULL,
+  PRIMARY KEY (pack, object_id)
 );
 
 CREATE TABLE claims (
-  claim_id TEXT PRIMARY KEY,
+  pack TEXT NOT NULL DEFAULT 'research-tech',
+  claim_id TEXT NOT NULL,
   object_id TEXT NOT NULL,
   claim_kind TEXT NOT NULL,
   claim_text TEXT NOT NULL,
-  confidence REAL NOT NULL DEFAULT 1.0
+  confidence REAL NOT NULL DEFAULT 1.0,
+  PRIMARY KEY (pack, claim_id)
 );
 
-CREATE INDEX idx_claims_object ON claims(object_id);
+CREATE INDEX idx_claims_pack_object ON claims(pack, object_id);
 
 CREATE TABLE claim_evidence (
+  pack TEXT NOT NULL DEFAULT 'research-tech',
   claim_id TEXT NOT NULL,
   source_slug TEXT NOT NULL,
   evidence_kind TEXT NOT NULL,
   quote_text TEXT NOT NULL DEFAULT ''
 );
 
-CREATE INDEX idx_claim_evidence_claim ON claim_evidence(claim_id);
+CREATE INDEX idx_claim_evidence_pack_claim ON claim_evidence(pack, claim_id);
 
 CREATE TABLE relations (
+  pack TEXT NOT NULL DEFAULT 'research-tech',
   source_object_id TEXT NOT NULL,
   target_object_id TEXT NOT NULL,
   relation_type TEXT NOT NULL,
   evidence_source_slug TEXT NOT NULL DEFAULT ''
 );
 
-CREATE INDEX idx_relations_source ON relations(source_object_id);
-CREATE INDEX idx_relations_target ON relations(target_object_id);
+CREATE INDEX idx_relations_pack_source ON relations(pack, source_object_id);
+CREATE INDEX idx_relations_pack_target ON relations(pack, target_object_id);
 
 CREATE TABLE compiled_summaries (
-  object_id TEXT PRIMARY KEY,
+  pack TEXT NOT NULL DEFAULT 'research-tech',
+  object_id TEXT NOT NULL,
   summary_text TEXT NOT NULL,
-  source_slug TEXT NOT NULL
+  source_slug TEXT NOT NULL,
+  PRIMARY KEY (pack, object_id)
 );
 
 CREATE TABLE contradictions (
-  contradiction_id TEXT PRIMARY KEY,
+  pack TEXT NOT NULL DEFAULT 'research-tech',
+  contradiction_id TEXT NOT NULL,
   subject_key TEXT NOT NULL,
   positive_claim_ids_json TEXT NOT NULL,
   negative_claim_ids_json TEXT NOT NULL,
   status TEXT NOT NULL DEFAULT 'open',
   resolution_note TEXT NOT NULL DEFAULT '',
-  resolved_at TEXT NOT NULL DEFAULT ''
+  resolved_at TEXT NOT NULL DEFAULT '',
+  PRIMARY KEY (pack, contradiction_id)
 );
+
+CREATE INDEX idx_contradictions_pack_subject ON contradictions(pack, subject_key);
+
+CREATE TABLE graph_edges (
+  pack TEXT NOT NULL DEFAULT 'research-tech',
+  edge_id TEXT NOT NULL,
+  source_object_id TEXT NOT NULL,
+  target_object_id TEXT NOT NULL,
+  edge_kind TEXT NOT NULL,
+  weight REAL NOT NULL DEFAULT 1.0,
+  evidence_source_slug TEXT NOT NULL DEFAULT '',
+  PRIMARY KEY (pack, edge_id)
+);
+
+CREATE INDEX idx_graph_edges_pack_source ON graph_edges(pack, source_object_id);
+CREATE INDEX idx_graph_edges_pack_target ON graph_edges(pack, target_object_id);
+
+CREATE TABLE graph_clusters (
+  pack TEXT NOT NULL DEFAULT 'research-tech',
+  cluster_id TEXT NOT NULL,
+  cluster_kind TEXT NOT NULL,
+  label TEXT NOT NULL,
+  center_object_id TEXT NOT NULL,
+  member_object_ids_json TEXT NOT NULL,
+  score REAL NOT NULL DEFAULT 0.0,
+  PRIMARY KEY (pack, cluster_id)
+);
+
+CREATE INDEX idx_graph_clusters_pack_kind ON graph_clusters(pack, cluster_kind);
 """
 
-_NEGATION_RE = re.compile(r"\b(?:does not|doesn't|do not|is not|isn't|are not|aren't|has not|hasn't|have not|haven't|cannot|can't|not)\b")
+CONTRADICTION_HEURISTIC_NOTE = (
+    "TODO: current contradiction rows are pack-owned heuristics, not core truth. "
+    "If contradiction quality is noisy, tighten the active pack's subject normalization, "
+    "claim grouping, and review semantics instead of teaching core one more domain rule."
+)
+
+_NEGATION_RE = re.compile(
+    r"\b(?:does not|doesn't|do not|is not|isn't|are not|aren't|has not|hasn't|have not|haven't|cannot|can't|not)\b"
+)
 _NEGATION_EXCLUSIONS = (
     "not only",
     "not necessarily",
     "not merely",
     "not just",
 )
-CONTRADICTION_HEURISTIC_NOTE = (
-    "TODO: _detect_contradictions uses a regex-based negation heuristic with exclusions. "
-    "If it still produces noisy rows, tighten subject_key() normalization and contradiction_id_for_subject() grouping."
-)
-
-
-@dataclass(frozen=True)
-class TruthStoreProjection:
-    objects: list[tuple[str, str, str, str, str]]
-    claims: list[tuple[str, str, str, str, float]]
-    claim_evidence: list[tuple[str, str, str, str]]
-    relations: list[tuple[str, str, str, str]]
-    compiled_summaries: list[tuple[str, str, str]]
-    contradictions: list[tuple[str, str, str, str, str, str, str]]
-
-
-def build_truth_store_projection(
-    page_rows: list[tuple[str, str, str, str, str, str, str]],
-    link_rows: list[tuple[str, str, str, str, int]],
-) -> TruthStoreProjection:
-    objects: list[tuple[str, str, str, str, str]] = []
-    claims: list[tuple[str, str, str, str, float]] = []
-    claim_evidence: list[tuple[str, str, str, str]] = []
-    compiled_summaries: list[tuple[str, str, str]] = []
-
-    for slug, title, note_type, path, _day_id, _frontmatter_json, body in page_rows:
-        objects.append((slug, note_type, title, path, slug))
-        summary = _page_summary(body, fallback=title)
-        claim_id = _claim_id(slug, summary)
-        claims.append((claim_id, slug, "page_summary", summary, 1.0))
-        claim_evidence.append((claim_id, slug, "body_summary", summary))
-        compiled_summaries.append((slug, summary, slug))
-
-    relations = [
-        (source_slug, target_slug, relation_type, source_slug)
-        for source_slug, target_slug, _target_raw, relation_type, _line_number in link_rows
-    ]
-    contradictions = _detect_contradictions(claims)
-
-    return TruthStoreProjection(
-        objects=objects,
-        claims=claims,
-        claim_evidence=claim_evidence,
-        relations=relations,
-        compiled_summaries=compiled_summaries,
-        contradictions=contradictions,
-    )
-
-
-def _claim_id(object_id: str, claim_text: str) -> str:
-    digest = hashlib.sha1(f"{object_id}:{claim_text}".encode("utf-8")).hexdigest()[:12]
-    return f"{object_id}::{digest}"
-
-
-def _page_summary(body: str, *, fallback: str) -> str:
-    content = body.strip()
-    if not content:
-        return fallback
-    lines = [line.strip() for line in content.splitlines() if line.strip() and not line.strip().startswith("#")]
-    text = " ".join(lines)
-    if not text:
-        return fallback
-    for marker in (". ", "! ", "? ", "。", "！", "？"):
-        if marker in text:
-            return text.split(marker, 1)[0].strip() + (marker.strip() if marker.strip() in "。！？" else ".")
-    return text[:220]
 
 
 def subject_key(claim_text: str) -> str:
@@ -145,12 +126,15 @@ def subject_key(claim_text: str) -> str:
     return lowered.split(".", 1)[0].strip()
 
 
-def contradiction_id_for_subject(subject: str) -> str:
-    return f"contradiction::{hashlib.sha1(subject.encode('utf-8')).hexdigest()[:12]}"
+def _is_negative_claim(claim_text: str) -> bool:
+    lowered = claim_text.strip().lower()
+    if any(exclusion in lowered for exclusion in _NEGATION_EXCLUSIONS):
+        return False
+    return bool(_NEGATION_RE.search(lowered))
 
 
 def _detect_contradictions(
-    claims: list[tuple[str, str, str, str, float]]
+    claims: list[tuple[str, str, str, str, float]],
 ) -> list[tuple[str, str, str, str, str, str, str]]:
     grouped: dict[str, list[tuple[str, str]]] = {}
     for claim_id, _object_id, claim_kind, claim_text, _confidence in claims:
@@ -167,7 +151,8 @@ def _detect_contradictions(
         negatives = [claim_id for claim_id, text in rows if _is_negative_claim(text)]
         if not positives or not negatives:
             continue
-        contradiction_id = contradiction_id_for_subject(subject)
+        fingerprint = re.sub(r"\s+", " ", subject.strip().lower())
+        contradiction_id = f"contradiction::{hashlib.sha1(fingerprint.encode('utf-8')).hexdigest()[:12]}"
         contradictions.append(
             (
                 contradiction_id,
@@ -182,8 +167,13 @@ def _detect_contradictions(
     return contradictions
 
 
-def _is_negative_claim(claim_text: str) -> bool:
-    lowered = claim_text.strip().lower()
-    if any(exclusion in lowered for exclusion in _NEGATION_EXCLUSIONS):
-        return False
-    return bool(_NEGATION_RE.search(lowered))
+@dataclass(frozen=True)
+class TruthStoreProjection:
+    objects: list[tuple[str, str, str, str, str, str]] = field(default_factory=list)
+    claims: list[tuple[str, str, str, str, str, float]] = field(default_factory=list)
+    claim_evidence: list[tuple[str, str, str, str, str]] = field(default_factory=list)
+    relations: list[tuple[str, str, str, str, str]] = field(default_factory=list)
+    compiled_summaries: list[tuple[str, str, str, str]] = field(default_factory=list)
+    contradictions: list[tuple[str, str, str, str, str, str, str, str]] = field(default_factory=list)
+    graph_edges: list[tuple[str, str, str, str, str, float, str]] = field(default_factory=list)
+    graph_clusters: list[tuple[str, str, str, str, str, str, float]] = field(default_factory=list)

--- a/src/openclaw_pipeline/truth_store.py
+++ b/src/openclaw_pipeline/truth_store.py
@@ -8,7 +8,7 @@ import re
 
 TRUTH_STORE_SCHEMA = """
 CREATE TABLE objects (
-  pack TEXT NOT NULL DEFAULT 'research-tech',
+  pack TEXT NOT NULL,
   object_id TEXT NOT NULL,
   object_kind TEXT NOT NULL,
   title TEXT NOT NULL,
@@ -18,7 +18,7 @@ CREATE TABLE objects (
 );
 
 CREATE TABLE claims (
-  pack TEXT NOT NULL DEFAULT 'research-tech',
+  pack TEXT NOT NULL,
   claim_id TEXT NOT NULL,
   object_id TEXT NOT NULL,
   claim_kind TEXT NOT NULL,
@@ -30,7 +30,7 @@ CREATE TABLE claims (
 CREATE INDEX idx_claims_pack_object ON claims(pack, object_id);
 
 CREATE TABLE claim_evidence (
-  pack TEXT NOT NULL DEFAULT 'research-tech',
+  pack TEXT NOT NULL,
   claim_id TEXT NOT NULL,
   source_slug TEXT NOT NULL,
   evidence_kind TEXT NOT NULL,
@@ -40,7 +40,7 @@ CREATE TABLE claim_evidence (
 CREATE INDEX idx_claim_evidence_pack_claim ON claim_evidence(pack, claim_id);
 
 CREATE TABLE relations (
-  pack TEXT NOT NULL DEFAULT 'research-tech',
+  pack TEXT NOT NULL,
   source_object_id TEXT NOT NULL,
   target_object_id TEXT NOT NULL,
   relation_type TEXT NOT NULL,
@@ -51,7 +51,7 @@ CREATE INDEX idx_relations_pack_source ON relations(pack, source_object_id);
 CREATE INDEX idx_relations_pack_target ON relations(pack, target_object_id);
 
 CREATE TABLE compiled_summaries (
-  pack TEXT NOT NULL DEFAULT 'research-tech',
+  pack TEXT NOT NULL,
   object_id TEXT NOT NULL,
   summary_text TEXT NOT NULL,
   source_slug TEXT NOT NULL,
@@ -59,7 +59,7 @@ CREATE TABLE compiled_summaries (
 );
 
 CREATE TABLE contradictions (
-  pack TEXT NOT NULL DEFAULT 'research-tech',
+  pack TEXT NOT NULL,
   contradiction_id TEXT NOT NULL,
   subject_key TEXT NOT NULL,
   positive_claim_ids_json TEXT NOT NULL,
@@ -73,7 +73,7 @@ CREATE TABLE contradictions (
 CREATE INDEX idx_contradictions_pack_subject ON contradictions(pack, subject_key);
 
 CREATE TABLE graph_edges (
-  pack TEXT NOT NULL DEFAULT 'research-tech',
+  pack TEXT NOT NULL,
   edge_id TEXT NOT NULL,
   source_object_id TEXT NOT NULL,
   target_object_id TEXT NOT NULL,
@@ -87,7 +87,7 @@ CREATE INDEX idx_graph_edges_pack_source ON graph_edges(pack, source_object_id);
 CREATE INDEX idx_graph_edges_pack_target ON graph_edges(pack, target_object_id);
 
 CREATE TABLE graph_clusters (
-  pack TEXT NOT NULL DEFAULT 'research-tech',
+  pack TEXT NOT NULL,
   cluster_id TEXT NOT NULL,
   cluster_kind TEXT NOT NULL,
   label TEXT NOT NULL,

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -11,6 +11,7 @@ from ..runtime import VaultLayout, resolve_vault_dir
 from ..truth_store import CONTRADICTION_HEURISTIC_NOTE
 from ..truth_api import (
     CONTRADICTION_STATUS_EXPLANATIONS,
+    MAX_PAGE_SIZE,
     SIGNAL_TYPE_EXPLANATIONS,
     count_objects,
     get_briefing_snapshot,
@@ -196,6 +197,19 @@ def _collect_cluster_provenance(
     }
 
 
+def _build_cluster_provenance_index(
+    vault_dir: Path | str,
+    cluster_rows: list[dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    return {
+        str(row["cluster_id"]): _collect_cluster_provenance(
+            vault_dir,
+            [str(member["object_id"]) for member in row["members"]],
+        )
+        for row in cluster_rows
+    }
+
+
 def _build_related_cluster_items(
     vault_dir: Path | str,
     *,
@@ -203,17 +217,24 @@ def _build_related_cluster_items(
     requested_pack: str,
     current_source_note_items: dict[str, dict[str, Any]],
     current_moc_items: dict[str, dict[str, Any]],
+    cluster_rows: list[dict[str, Any]] | None = None,
+    cluster_provenance_index: dict[str, dict[str, Any]] | None = None,
 ) -> list[dict[str, Any]]:
     current_source_slugs = set(current_source_note_items)
     current_moc_slugs = set(current_moc_items)
     if not current_source_slugs and not current_moc_slugs:
         return []
     related_items: list[dict[str, Any]] = []
-    for row in list_graph_clusters(vault_dir, pack_name=requested_pack, limit=200):
+    rows = cluster_rows if cluster_rows is not None else list_graph_clusters(vault_dir, pack_name=requested_pack, limit=200)
+    for row in rows:
         if str(row["cluster_id"]) == cluster_id:
             continue
-        member_object_ids = [str(member["object_id"]) for member in row["members"]]
-        provenance = _collect_cluster_provenance(vault_dir, member_object_ids)
+        provenance = None
+        if cluster_provenance_index is not None:
+            provenance = cluster_provenance_index.get(str(row["cluster_id"]))
+        if provenance is None:
+            member_object_ids = [str(member["object_id"]) for member in row["members"]]
+            provenance = _collect_cluster_provenance(vault_dir, member_object_ids)
         shared_source_slugs = sorted(current_source_slugs & set(provenance["source_note_items"]))
         shared_moc_slugs = sorted(current_moc_slugs & set(provenance["moc_items"]))
         if not shared_source_slugs and not shared_moc_slugs:
@@ -351,6 +372,185 @@ def _build_reading_routes(related_clusters: list[dict[str, Any]]) -> list[dict[s
             }
         )
     return routes
+
+
+def _build_cluster_surface_sections(
+    vault_dir: Path | str,
+    *,
+    cluster: dict[str, Any],
+    edges: list[dict[str, Any]],
+    requested_pack: str,
+    cluster_rows: list[dict[str, Any]] | None = None,
+    cluster_provenance_index: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    member_object_ids = [str(member["object_id"]) for member in cluster["members"]]
+    edge_kind_counts = Counter(edge["edge_kind"] for edge in edges)
+    edge_summary_items = [
+        {
+            "edge_kind": edge_kind,
+            "edge_family": _edge_kind_parts(edge_kind)[0],
+            "edge_subtype": _edge_kind_parts(edge_kind)[1],
+            "display_name": (
+                "contradiction links"
+                if _edge_kind_parts(edge_kind)[0] == "contradiction"
+                else (
+                    f"{_edge_kind_parts(edge_kind)[1].replace('_', ' ')} links"
+                    if _edge_kind_parts(edge_kind)[0] == "relation" and _edge_kind_parts(edge_kind)[1]
+                    else edge_kind.replace(":", " ")
+                )
+            ),
+            "count": count,
+        }
+        for edge_kind, count in sorted(edge_kind_counts.items(), key=lambda item: (-item[1], item[0]))
+    ]
+    object_kind_counts = Counter(
+        str(member["object_kind"])
+        for member in cluster["members"]
+        if member.get("object_kind")
+    )
+    review_context = get_review_context(vault_dir, member_object_ids)
+    open_contradictions = [
+        {
+            "contradiction_id": item["contradiction_id"],
+            "subject_key": item["subject_key"],
+            "object_ids": _object_ids_from_claim_ids(item["positive_claim_ids"], item["negative_claim_ids"]),
+            "path": f"/contradictions?q={quote(str(item['subject_key']), safe='')}",
+        }
+        for item in list_contradictions(vault_dir, status="open", limit=MAX_PAGE_SIZE)
+        if set(_object_ids_from_claim_ids(item["positive_claim_ids"], item["negative_claim_ids"])) & set(member_object_ids)
+    ][:5]
+    stale_summaries = list_stale_summaries(vault_dir, object_ids=member_object_ids, limit=5)
+    provenance = (
+        cluster_provenance_index.get(str(cluster["cluster_id"]))
+        if cluster_provenance_index is not None and str(cluster["cluster_id"]) in cluster_provenance_index
+        else _collect_cluster_provenance(vault_dir, member_object_ids)
+    )
+    source_note_counts = provenance["source_note_counts"]
+    source_note_items = provenance["source_note_items"]
+    moc_counts = provenance["moc_counts"]
+    moc_items = provenance["moc_items"]
+
+    top_edge_kind = next(iter(sorted(edge_kind_counts.items(), key=lambda item: (-item[1], item[0]))), None)
+    kind_summary = ", ".join(
+        f"{kind} {count}"
+        for kind, count in sorted(object_kind_counts.items(), key=lambda item: (-item[1], item[0]))
+    )
+    summary_bullets = [
+        f"{cluster['member_count']} objects in a {cluster['cluster_kind']} cluster centered on {cluster['center_title']}.",
+    ]
+    if top_edge_kind:
+        summary_bullets.append(
+            f"{len(edges)} internal edges across {len(edge_kind_counts)} edge kinds; dominant edge kind is {top_edge_kind[0]} ({top_edge_kind[1]})."
+        )
+    if kind_summary:
+        summary_bullets.append(f"Object kinds in scope: {kind_summary}.")
+    if review_context["source_note_count"] or review_context["moc_count"]:
+        summary_bullets.append(
+            f"Coverage currently includes {review_context['source_note_count']} source/deep-dive notes and {review_context['moc_count']} atlas pages."
+        )
+    if review_context["open_contradiction_count"] or review_context["stale_summary_count"]:
+        summary_bullets.append(
+            f"Review pressure: {review_context['open_contradiction_count']} open contradictions and {review_context['stale_summary_count']} stale summaries in this cluster scope."
+        )
+    structural_label = _derive_cluster_structural_label(
+        center_title=str(cluster["center_title"]),
+        edge_summary_items=edge_summary_items,
+    )
+    relation_pattern_items = _build_relation_pattern_items(edge_summary_items)
+    relation_pattern_preview = _relation_pattern_preview(relation_pattern_items)
+    related_clusters = _build_related_cluster_items(
+        vault_dir,
+        cluster_id=str(cluster["cluster_id"]),
+        requested_pack=requested_pack,
+        current_source_note_items=source_note_items,
+        current_moc_items=moc_items,
+        cluster_rows=cluster_rows,
+        cluster_provenance_index=cluster_provenance_index,
+    )
+    related_cluster_groups = _build_related_cluster_groups(related_clusters)
+    reading_routes = _build_reading_routes(related_clusters)
+    next_read_cluster = related_clusters[0] if related_clusters else None
+
+    return {
+        "display_title": structural_label["title"],
+        "edge_count": len(edges),
+        "edge_kind_counts": dict(edge_kind_counts),
+        "edge_summary_items": edge_summary_items,
+        "relation_pattern_items": relation_pattern_items,
+        "relation_pattern_preview": relation_pattern_preview,
+        "object_kind_counts": dict(object_kind_counts),
+        "structural_label": structural_label,
+        "review_context": review_context,
+        "open_contradictions": open_contradictions,
+        "stale_summaries": stale_summaries,
+        "related_clusters": related_clusters,
+        "related_cluster_groups": related_cluster_groups,
+        "reading_routes": reading_routes,
+        "next_read_cluster": next_read_cluster,
+        "top_source_notes": _top_counter_items(source_note_counts, source_note_items),
+        "top_mocs": _top_counter_items(moc_counts, moc_items),
+        "summary_bullets": summary_bullets,
+    }
+
+
+def build_cluster_summary_payload(
+    vault_dir: Path | str,
+    *,
+    cluster_id: str,
+    pack_name: str | None = None,
+    cluster_rows: list[dict[str, Any]] | None = None,
+    cluster_provenance_index: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    detail = get_graph_cluster_detail(vault_dir, cluster_id, pack_name=pack_name)
+    cluster = detail["cluster"]
+    requested_pack = pack_name or str(cluster["pack"])
+    member_index = {str(member["object_id"]): member for member in cluster["members"]}
+    detail_path = (
+        f"/cluster?id={quote(str(cluster['cluster_id']), safe='')}"
+        f"&pack={quote(requested_pack, safe='')}"
+    )
+    enriched_cluster = {
+        **cluster,
+        "detail_path": detail_path,
+        "center_object_path": f"/object?id={quote(str(cluster['center_object_id']), safe='')}",
+        "member_links": [
+            {
+                **member,
+                "path": f"/object?id={quote(str(member['object_id']), safe='')}",
+            }
+            for member in cluster["members"]
+        ],
+    }
+    enriched_edges = [
+        {
+            **edge,
+            "source_title": member_index.get(str(edge["source_object_id"]), {}).get(
+                "title",
+                str(edge["source_object_id"]),
+            ),
+            "target_title": member_index.get(str(edge["target_object_id"]), {}).get(
+                "title",
+                str(edge["target_object_id"]),
+            ),
+            "source_path": f"/object?id={quote(str(edge['source_object_id']), safe='')}",
+            "target_path": f"/object?id={quote(str(edge['target_object_id']), safe='')}",
+        }
+        for edge in detail["edges"]
+    ]
+    sections = _build_cluster_surface_sections(
+        vault_dir,
+        cluster=enriched_cluster,
+        edges=enriched_edges,
+        requested_pack=requested_pack,
+        cluster_rows=cluster_rows,
+        cluster_provenance_index=cluster_provenance_index,
+    )
+    return {
+        "requested_pack": requested_pack,
+        "cluster": enriched_cluster,
+        "edges": enriched_edges,
+        **sections,
+    }
 
 
 def _build_production_summary(vault_dir: Path | str, object_ids: list[str]) -> dict[str, Any]:
@@ -831,21 +1031,24 @@ def build_cluster_browser_payload(
     limit: int = DEFAULT_TRACEABILITY_BROWSER_LIMIT,
 ) -> dict[str, Any]:
     items = list_graph_clusters(vault_dir, pack_name=pack_name, query=query, limit=limit)
+    cluster_provenance_index = _build_cluster_provenance_index(vault_dir, items)
     cluster_kind_counts = Counter(item["cluster_kind"] for item in items)
     largest_cluster_size = max((int(item["member_count"]) for item in items), default=0)
     enriched_items = []
     for item in items:
         requested_pack = pack_name or str(item["pack"])
-        detail = build_cluster_detail_payload(
+        summary = build_cluster_summary_payload(
             vault_dir,
             cluster_id=str(item["cluster_id"]),
             pack_name=requested_pack,
+            cluster_rows=items,
+            cluster_provenance_index=cluster_provenance_index,
         )
-        review_context = detail["review_context"]
+        review_context = summary["review_context"]
         dominant_edge_kind = next(
             iter(
                 sorted(
-                    detail["edge_kind_counts"].items(),
+                    summary["edge_kind_counts"].items(),
                     key=lambda pair: (-pair[1], pair[0]),
                 )
             ),
@@ -855,11 +1058,11 @@ def build_cluster_browser_payload(
             review_context["open_contradiction_count"] * 100
             + review_context["stale_summary_count"] * 40
             + int(item["member_count"]) * 10
-            + len(detail["edges"]) * 3
+            + int(summary["edge_count"]) * 3
             + review_context["source_note_count"]
             + review_context["moc_count"]
         )
-        if detail["reading_routes"]:
+        if summary["reading_routes"]:
             priority_score += 15
         if review_context["open_contradiction_count"] > 0 or review_context["stale_summary_count"] > 0:
             priority_band = "attention"
@@ -873,21 +1076,21 @@ def build_cluster_browser_payload(
         else:
             priority_band = "reference"
             priority_reason = f"{review_context['source_note_count']} source notes in scope"
-        strongest_related = detail["related_clusters"][0] if detail["related_clusters"] else None
-        top_reading_route = detail["reading_routes"][0] if detail["reading_routes"] else None
+        strongest_related = summary["related_clusters"][0] if summary["related_clusters"] else None
+        top_reading_route = summary["reading_routes"][0] if summary["reading_routes"] else None
         enriched_items.append(
             {
                 **item,
-                "row_pack": str(item["pack"]),
+                "row_pack": str(item.get("row_pack") or item["pack"]),
                 "pack": requested_pack,
-                "detail_path": detail["cluster"]["detail_path"],
-                "center_object_path": detail["cluster"]["center_object_path"],
-                "member_links": detail["cluster"]["member_links"],
-                "display_title": detail["display_title"],
-                "relation_pattern_preview": detail["relation_pattern_preview"],
-                "related_cluster_count": len(detail["related_clusters"]),
+                "detail_path": summary["cluster"]["detail_path"],
+                "center_object_path": summary["cluster"]["center_object_path"],
+                "member_links": summary["cluster"]["member_links"],
+                "display_title": summary["display_title"],
+                "relation_pattern_preview": summary["relation_pattern_preview"],
+                "related_cluster_count": len(summary["related_clusters"]),
                 "related_cluster_preview": ", ".join(
-                    related["display_title"] for related in detail["related_clusters"][:2]
+                    related["display_title"] for related in summary["related_clusters"][:2]
                 ),
                 "neighborhood_score": strongest_related["score"] if strongest_related else 0,
                 "neighborhood_reason": strongest_related["reason"] if strongest_related else "",
@@ -900,14 +1103,30 @@ def build_cluster_browser_payload(
                 "top_reading_route_title": top_reading_route["display_title"] if top_reading_route else "",
                 "top_reading_route_reason": top_reading_route["route_reason"] if top_reading_route else "",
                 "has_reading_route": bool(top_reading_route),
-                "reading_intent_count": len(detail["reading_routes"]),
+                "reading_intent_count": len(summary["reading_routes"]),
                 "reading_intent_preview": ", ".join(
-                    route["display_name"] for route in detail["reading_routes"]
+                    route["display_name"] for route in summary["reading_routes"]
                 ),
+                "summary_bullets": summary["summary_bullets"],
+                "structural_label": summary["structural_label"],
+                "edge_kind_counts": summary["edge_kind_counts"],
+                "edge_summary_items": summary["edge_summary_items"],
+                "edge_count": summary["edge_count"],
+                "relation_pattern_items": summary["relation_pattern_items"],
+                "review_context": summary["review_context"],
+                "open_contradictions": summary["open_contradictions"],
+                "stale_summaries": summary["stale_summaries"],
+                "related_clusters": summary["related_clusters"],
+                "related_cluster_groups": summary["related_cluster_groups"],
+                "reading_routes": summary["reading_routes"],
+                "next_read_cluster": summary["next_read_cluster"],
+                "top_source_notes": summary["top_source_notes"],
+                "top_mocs": summary["top_mocs"],
+                "object_kind_counts": summary["object_kind_counts"],
                 "priority_score": priority_score,
                 "priority_band": priority_band,
                 "priority_reason": priority_reason,
-                "top_summary_bullet": detail["summary_bullets"][0] if detail["summary_bullets"] else "",
+                "top_summary_bullet": summary["summary_bullets"][0] if summary["summary_bullets"] else "",
                 "dominant_edge_kind": dominant_edge_kind[0] if dominant_edge_kind is not None else "",
             }
         )
@@ -940,6 +1159,8 @@ def build_cluster_detail_payload(
     *,
     cluster_id: str,
     pack_name: str | None = None,
+    cluster_rows: list[dict[str, Any]] | None = None,
+    cluster_provenance_index: dict[str, dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     detail = get_graph_cluster_detail(vault_dir, cluster_id, pack_name=pack_name)
     cluster = detail["cluster"]
@@ -978,110 +1199,22 @@ def build_cluster_detail_payload(
         }
         for edge in detail["edges"]
     ]
-    edge_kind_counts = Counter(edge["edge_kind"] for edge in enriched_edges)
-    edge_summary_items = [
-        {
-            "edge_kind": edge_kind,
-            "edge_family": _edge_kind_parts(edge_kind)[0],
-            "edge_subtype": _edge_kind_parts(edge_kind)[1],
-            "display_name": (
-                "contradiction links"
-                if _edge_kind_parts(edge_kind)[0] == "contradiction"
-                else (
-                    f"{_edge_kind_parts(edge_kind)[1].replace('_', ' ')} links"
-                    if _edge_kind_parts(edge_kind)[0] == "relation" and _edge_kind_parts(edge_kind)[1]
-                    else edge_kind.replace(":", " ")
-                )
-            ),
-            "count": count,
-        }
-        for edge_kind, count in sorted(edge_kind_counts.items(), key=lambda item: (-item[1], item[0]))
-    ]
-    object_kind_counts = Counter(
-        str(member["object_kind"])
-        for member in cluster["members"]
-        if member.get("object_kind")
-    )
-    review_context = get_review_context(vault_dir, member_object_ids)
-    open_contradictions = [
-        {
-            "contradiction_id": item["contradiction_id"],
-            "subject_key": item["subject_key"],
-            "object_ids": _object_ids_from_claim_ids(item["positive_claim_ids"], item["negative_claim_ids"]),
-            "path": f"/contradictions?q={quote(str(item['subject_key']), safe='')}",
-        }
-        for item in list_contradictions(vault_dir, status="open", limit=20)
-        if set(_object_ids_from_claim_ids(item["positive_claim_ids"], item["negative_claim_ids"])) & set(member_object_ids)
-    ][:5]
-    stale_summaries = list_stale_summaries(vault_dir, object_ids=member_object_ids, limit=5)
-    provenance = _collect_cluster_provenance(vault_dir, member_object_ids)
-    source_note_counts = provenance["source_note_counts"]
-    source_note_items = provenance["source_note_items"]
-    moc_counts = provenance["moc_counts"]
-    moc_items = provenance["moc_items"]
-
-    top_edge_kind = next(iter(sorted(edge_kind_counts.items(), key=lambda item: (-item[1], item[0]))), None)
-    kind_summary = ", ".join(
-        f"{kind} {count}"
-        for kind, count in sorted(object_kind_counts.items(), key=lambda item: (-item[1], item[0]))
-    )
-    summary_bullets = [
-        f"{cluster['member_count']} objects in a {cluster['cluster_kind']} cluster centered on {cluster['center_title']}.",
-    ]
-    if top_edge_kind:
-        summary_bullets.append(
-            f"{len(enriched_edges)} internal edges across {len(edge_kind_counts)} edge kinds; dominant edge kind is {top_edge_kind[0]} ({top_edge_kind[1]})."
-        )
-    if kind_summary:
-        summary_bullets.append(f"Object kinds in scope: {kind_summary}.")
-    if review_context["source_note_count"] or review_context["moc_count"]:
-        summary_bullets.append(
-            f"Coverage currently includes {review_context['source_note_count']} source/deep-dive notes and {review_context['moc_count']} atlas pages."
-        )
-    if review_context["open_contradiction_count"] or review_context["stale_summary_count"]:
-        summary_bullets.append(
-            f"Review pressure: {review_context['open_contradiction_count']} open contradictions and {review_context['stale_summary_count']} stale summaries in this cluster scope."
-        )
-    structural_label = _derive_cluster_structural_label(
-        center_title=str(cluster["center_title"]),
-        edge_summary_items=edge_summary_items,
-    )
-    relation_pattern_items = _build_relation_pattern_items(edge_summary_items)
-    relation_pattern_preview = _relation_pattern_preview(relation_pattern_items)
-    related_clusters = _build_related_cluster_items(
+    sections = _build_cluster_surface_sections(
         vault_dir,
-        cluster_id=str(cluster["cluster_id"]),
+        cluster=enriched_cluster,
+        edges=enriched_edges,
         requested_pack=requested_pack,
-        current_source_note_items=source_note_items,
-        current_moc_items=moc_items,
+        cluster_rows=cluster_rows,
+        cluster_provenance_index=cluster_provenance_index,
     )
-    related_cluster_groups = _build_related_cluster_groups(related_clusters)
-    reading_routes = _build_reading_routes(related_clusters)
-    next_read_cluster = related_clusters[0] if related_clusters else None
 
     return {
         "screen": "graph/cluster-detail",
         "requested_pack": requested_pack,
         "cluster": enriched_cluster,
         "browser_path": f"/clusters?pack={quote(requested_pack, safe='')}",
-        "display_title": structural_label["title"],
         "edges": enriched_edges,
-        "edge_kind_counts": dict(edge_kind_counts),
-        "edge_summary_items": edge_summary_items,
-        "relation_pattern_items": relation_pattern_items,
-        "relation_pattern_preview": relation_pattern_preview,
-        "object_kind_counts": dict(object_kind_counts),
-        "structural_label": structural_label,
-        "review_context": review_context,
-        "open_contradictions": open_contradictions,
-        "stale_summaries": stale_summaries,
-        "related_clusters": related_clusters,
-        "related_cluster_groups": related_cluster_groups,
-        "reading_routes": reading_routes,
-        "next_read_cluster": next_read_cluster,
-        "top_source_notes": _top_counter_items(source_note_counts, source_note_items),
-        "top_mocs": _top_counter_items(moc_counts, moc_items),
-        "summary_bullets": summary_bullets,
+        **sections,
         "model_notes": [
             "Cluster detail currently reflects pack-owned graph seed structure, not a final semantic subgraph model.",
             "Edges are filtered to the cluster's own member set inside the requested pack projection.",

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -317,16 +317,29 @@ def _build_reading_routes(related_clusters: list[dict[str, Any]]) -> list[dict[s
         ),
     ]
     routes: list[dict[str, Any]] = []
-    for route_kind, display_name, allowed_bridge_kinds in route_specs:
+    for index, (route_kind, display_name, allowed_bridge_kinds) in enumerate(route_specs, start=1):
         candidate = next(
             (item for item in related_clusters if str(item["bridge_kind"]) in allowed_bridge_kinds),
             None,
         )
         if candidate is None:
             continue
+        if route_kind == "full_context_route":
+            route_reason = (
+                "Best first if you want both evidence continuity and atlas continuity across clusters."
+            )
+            route_score = int(candidate["score"]) + 30
+        elif route_kind == "source_continuity_route":
+            route_reason = "Best if you want to keep reading along shared source-note coverage."
+            route_score = int(candidate["score"]) + 20
+        else:
+            route_reason = "Best if you want to keep reading along shared atlas-page coverage."
+            route_score = int(candidate["score"]) + 10
         routes.append(
             {
                 "route_kind": route_kind,
+                "route_rank": index,
+                "route_score": route_score,
                 "display_name": display_name,
                 "cluster_id": candidate["cluster_id"],
                 "display_title": candidate["display_title"],
@@ -334,6 +347,7 @@ def _build_reading_routes(related_clusters: list[dict[str, Any]]) -> list[dict[s
                 "bridge_kind": candidate["bridge_kind"],
                 "bridge_band": candidate["bridge_band"],
                 "reason": candidate["reason"],
+                "route_reason": route_reason,
             }
         )
     return routes

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -630,18 +630,20 @@ def build_evolution_browser_payload(
 def build_cluster_browser_payload(
     vault_dir: Path | str,
     *,
+    pack_name: str | None = None,
     query: str | None = None,
     limit: int = DEFAULT_TRACEABILITY_BROWSER_LIMIT,
 ) -> dict[str, Any]:
-    items = list_graph_clusters(vault_dir, query=query, limit=limit)
+    items = list_graph_clusters(vault_dir, pack_name=pack_name, query=query, limit=limit)
     cluster_kind_counts = Counter(item["cluster_kind"] for item in items)
     largest_cluster_size = max((int(item["member_count"]) for item in items), default=0)
     enriched_items = []
     for item in items:
+        requested_pack = pack_name or str(item["pack"])
         detail = build_cluster_detail_payload(
             vault_dir,
             cluster_id=str(item["cluster_id"]),
-            pack_name=str(item["pack"]),
+            pack_name=requested_pack,
         )
         review_context = detail["review_context"]
         dominant_edge_kind = next(
@@ -676,6 +678,8 @@ def build_cluster_browser_payload(
         enriched_items.append(
             {
                 **item,
+                "row_pack": str(item["pack"]),
+                "pack": requested_pack,
                 "detail_path": detail["cluster"]["detail_path"],
                 "center_object_path": detail["cluster"]["center_object_path"],
                 "member_links": detail["cluster"]["member_links"],
@@ -697,6 +701,7 @@ def build_cluster_browser_payload(
     )
     return {
         "screen": "graph/clusters",
+        "requested_pack": pack_name or "",
         "query": query or "",
         "limit": limit,
         "is_limited": True,
@@ -719,11 +724,12 @@ def build_cluster_detail_payload(
 ) -> dict[str, Any]:
     detail = get_graph_cluster_detail(vault_dir, cluster_id, pack_name=pack_name)
     cluster = detail["cluster"]
+    requested_pack = pack_name or str(cluster["pack"])
     member_index = {str(member["object_id"]): member for member in cluster["members"]}
     member_object_ids = [str(member["object_id"]) for member in cluster["members"]]
     detail_path = (
         f"/cluster?id={quote(str(cluster['cluster_id']), safe='')}"
-        f"&pack={quote(str(cluster['pack']), safe='')}"
+        f"&pack={quote(requested_pack, safe='')}"
     )
     enriched_cluster = {
         **cluster,
@@ -834,7 +840,9 @@ def build_cluster_detail_payload(
 
     return {
         "screen": "graph/cluster-detail",
+        "requested_pack": requested_pack,
         "cluster": enriched_cluster,
+        "browser_path": f"/clusters?pack={quote(requested_pack, safe='')}",
         "display_title": structural_label["title"],
         "edges": enriched_edges,
         "edge_kind_counts": dict(edge_kind_counts),

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -224,6 +224,12 @@ def _build_related_cluster_items(
         if shared_moc_slugs:
             reason_parts.append(f"{len(shared_moc_slugs)} shared atlas pages")
         score = len(shared_source_slugs) * 10 + len(shared_moc_slugs) * 5 + int(row["member_count"])
+        if len(shared_source_slugs) >= 1 and len(shared_moc_slugs) >= 1:
+            bridge_band = "strong"
+        elif len(shared_source_slugs) >= 1 or len(shared_moc_slugs) >= 2:
+            bridge_band = "medium"
+        else:
+            bridge_band = "light"
         related_items.append(
             {
                 "cluster_id": str(row["cluster_id"]),
@@ -245,6 +251,7 @@ def _build_related_cluster_items(
                     str(current_moc_items.get(slug, provenance["moc_items"].get(slug, {})).get("title", slug))
                     for slug in shared_moc_slugs
                 ][:3],
+                "bridge_band": bridge_band,
                 "reason": ", ".join(reason_parts),
                 "score": score,
             }
@@ -771,6 +778,7 @@ def build_cluster_browser_payload(
         else:
             priority_band = "reference"
             priority_reason = f"{review_context['source_note_count']} source notes in scope"
+        strongest_related = detail["related_clusters"][0] if detail["related_clusters"] else None
         enriched_items.append(
             {
                 **item,
@@ -785,6 +793,9 @@ def build_cluster_browser_payload(
                 "related_cluster_preview": ", ".join(
                     related["display_title"] for related in detail["related_clusters"][:2]
                 ),
+                "neighborhood_score": strongest_related["score"] if strongest_related else 0,
+                "neighborhood_reason": strongest_related["reason"] if strongest_related else "",
+                "neighborhood_band": strongest_related["bridge_band"] if strongest_related else "",
                 "priority_score": priority_score,
                 "priority_band": priority_band,
                 "priority_reason": priority_reason,

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -900,6 +900,10 @@ def build_cluster_browser_payload(
                 "top_reading_route_title": top_reading_route["display_title"] if top_reading_route else "",
                 "top_reading_route_reason": top_reading_route["route_reason"] if top_reading_route else "",
                 "has_reading_route": bool(top_reading_route),
+                "reading_intent_count": len(detail["reading_routes"]),
+                "reading_intent_preview": ", ".join(
+                    route["display_name"] for route in detail["reading_routes"]
+                ),
                 "priority_score": priority_score,
                 "priority_band": priority_band,
                 "priority_reason": priority_reason,

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -14,6 +14,7 @@ from ..truth_api import (
     SIGNAL_TYPE_EXPLANATIONS,
     count_objects,
     get_briefing_snapshot,
+    get_graph_cluster_detail,
     get_object_detail,
     get_object_traceability,
     get_note_provenance,
@@ -576,6 +577,10 @@ def build_cluster_browser_payload(
     enriched_items = [
         {
             **item,
+            "detail_path": (
+                f"/cluster?id={quote(str(item['cluster_id']), safe='')}"
+                f"&pack={quote(str(item['pack']), safe='')}"
+            ),
             "center_object_path": f"/object?id={quote(str(item['center_object_id']), safe='')}",
             "member_links": [
                 {
@@ -599,6 +604,59 @@ def build_cluster_browser_payload(
         "model_notes": [
             "Graph clusters currently come from pack-owned graph seed projections, not from a final semantic clustering model.",
             "Current research-tech clusters are relation/contradiction connected components over pack-scoped truth rows.",
+        ],
+    }
+
+
+def build_cluster_detail_payload(
+    vault_dir: Path | str,
+    *,
+    cluster_id: str,
+    pack_name: str | None = None,
+) -> dict[str, Any]:
+    detail = get_graph_cluster_detail(vault_dir, cluster_id, pack_name=pack_name)
+    cluster = detail["cluster"]
+    member_index = {str(member["object_id"]): member for member in cluster["members"]}
+    detail_path = (
+        f"/cluster?id={quote(str(cluster['cluster_id']), safe='')}"
+        f"&pack={quote(str(cluster['pack']), safe='')}"
+    )
+    enriched_cluster = {
+        **cluster,
+        "detail_path": detail_path,
+        "center_object_path": f"/object?id={quote(str(cluster['center_object_id']), safe='')}",
+        "member_links": [
+            {
+                **member,
+                "path": f"/object?id={quote(str(member['object_id']), safe='')}",
+            }
+            for member in cluster["members"]
+        ],
+    }
+    enriched_edges = [
+        {
+            **edge,
+            "source_title": member_index.get(str(edge["source_object_id"]), {}).get(
+                "title",
+                str(edge["source_object_id"]),
+            ),
+            "target_title": member_index.get(str(edge["target_object_id"]), {}).get(
+                "title",
+                str(edge["target_object_id"]),
+            ),
+            "source_path": f"/object?id={quote(str(edge['source_object_id']), safe='')}",
+            "target_path": f"/object?id={quote(str(edge['target_object_id']), safe='')}",
+        }
+        for edge in detail["edges"]
+    ]
+    return {
+        "screen": "graph/cluster-detail",
+        "cluster": enriched_cluster,
+        "edges": enriched_edges,
+        "edge_kind_counts": dict(Counter(edge["edge_kind"] for edge in enriched_edges)),
+        "model_notes": [
+            "Cluster detail currently reflects pack-owned graph seed structure, not a final semantic subgraph model.",
+            "Edges are filtered to the cluster's own member set inside the requested pack projection.",
         ],
     }
 

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -781,6 +781,10 @@ def build_cluster_browser_payload(
                 "member_links": detail["cluster"]["member_links"],
                 "display_title": detail["display_title"],
                 "relation_pattern_preview": detail["relation_pattern_preview"],
+                "related_cluster_count": len(detail["related_clusters"]),
+                "related_cluster_preview": ", ".join(
+                    related["display_title"] for related in detail["related_clusters"][:2]
+                ),
                 "priority_score": priority_score,
                 "priority_band": priority_band,
                 "priority_reason": priority_reason,

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -574,24 +574,63 @@ def build_cluster_browser_payload(
     items = list_graph_clusters(vault_dir, query=query, limit=limit)
     cluster_kind_counts = Counter(item["cluster_kind"] for item in items)
     largest_cluster_size = max((int(item["member_count"]) for item in items), default=0)
-    enriched_items = [
-        {
-            **item,
-            "detail_path": (
-                f"/cluster?id={quote(str(item['cluster_id']), safe='')}"
-                f"&pack={quote(str(item['pack']), safe='')}"
+    enriched_items = []
+    for item in items:
+        detail = build_cluster_detail_payload(
+            vault_dir,
+            cluster_id=str(item["cluster_id"]),
+            pack_name=str(item["pack"]),
+        )
+        review_context = detail["review_context"]
+        dominant_edge_kind = next(
+            iter(
+                sorted(
+                    detail["edge_kind_counts"].items(),
+                    key=lambda pair: (-pair[1], pair[0]),
+                )
             ),
-            "center_object_path": f"/object?id={quote(str(item['center_object_id']), safe='')}",
-            "member_links": [
-                {
-                    **member,
-                    "path": f"/object?id={quote(str(member['object_id']), safe='')}",
-                }
-                for member in item["members"]
-            ],
-        }
-        for item in items
-    ]
+            None,
+        )
+        priority_score = (
+            review_context["open_contradiction_count"] * 100
+            + review_context["stale_summary_count"] * 40
+            + int(item["member_count"]) * 10
+            + len(detail["edges"]) * 3
+            + review_context["source_note_count"]
+            + review_context["moc_count"]
+        )
+        if review_context["open_contradiction_count"] > 0 or review_context["stale_summary_count"] > 0:
+            priority_band = "attention"
+            priority_reason = (
+                f"{review_context['open_contradiction_count']} open contradictions, "
+                f"{review_context['stale_summary_count']} stale summaries"
+            )
+        elif dominant_edge_kind is not None:
+            priority_band = "active"
+            priority_reason = f"dominant edge kind {dominant_edge_kind[0]} ({dominant_edge_kind[1]})"
+        else:
+            priority_band = "reference"
+            priority_reason = f"{review_context['source_note_count']} source notes in scope"
+        enriched_items.append(
+            {
+                **item,
+                "detail_path": detail["cluster"]["detail_path"],
+                "center_object_path": detail["cluster"]["center_object_path"],
+                "member_links": detail["cluster"]["member_links"],
+                "priority_score": priority_score,
+                "priority_band": priority_band,
+                "priority_reason": priority_reason,
+                "top_summary_bullet": detail["summary_bullets"][0] if detail["summary_bullets"] else "",
+                "dominant_edge_kind": dominant_edge_kind[0] if dominant_edge_kind is not None else "",
+            }
+        )
+    enriched_items.sort(
+        key=lambda item: (
+            -int(item["priority_score"]),
+            str(item["label"]).lower(),
+            str(item["cluster_id"]),
+        )
+    )
     return {
         "screen": "graph/clusters",
         "query": query or "",

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -28,6 +28,7 @@ from ..truth_api import (
     list_action_queue,
     list_contradictions,
     list_deep_dive_derivations,
+    list_graph_clusters,
     list_objects,
     list_production_gaps,
     list_production_chains,
@@ -560,6 +561,45 @@ def build_evolution_browser_payload(
         "count": evolution["candidate_count"] + evolution["accepted_count"] + evolution["rejected_count"],
         "type_counts": dict(type_counts),
         "link_types": evolution["link_types"],
+    }
+
+
+def build_cluster_browser_payload(
+    vault_dir: Path | str,
+    *,
+    query: str | None = None,
+    limit: int = DEFAULT_TRACEABILITY_BROWSER_LIMIT,
+) -> dict[str, Any]:
+    items = list_graph_clusters(vault_dir, query=query, limit=limit)
+    cluster_kind_counts = Counter(item["cluster_kind"] for item in items)
+    largest_cluster_size = max((int(item["member_count"]) for item in items), default=0)
+    enriched_items = [
+        {
+            **item,
+            "center_object_path": f"/object?id={quote(str(item['center_object_id']), safe='')}",
+            "member_links": [
+                {
+                    **member,
+                    "path": f"/object?id={quote(str(member['object_id']), safe='')}",
+                }
+                for member in item["members"]
+            ],
+        }
+        for item in items
+    ]
+    return {
+        "screen": "graph/clusters",
+        "query": query or "",
+        "limit": limit,
+        "is_limited": True,
+        "items": enriched_items,
+        "count": len(enriched_items),
+        "cluster_kind_counts": dict(cluster_kind_counts),
+        "largest_cluster_size": largest_cluster_size,
+        "model_notes": [
+            "Graph clusters currently come from pack-owned graph seed projections, not from a final semantic clustering model.",
+            "Current research-tech clusters are relation/contradiction connected components over pack-scoped truth rows.",
+        ],
     }
 
 

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -796,6 +796,9 @@ def build_cluster_browser_payload(
                 "neighborhood_score": strongest_related["score"] if strongest_related else 0,
                 "neighborhood_reason": strongest_related["reason"] if strongest_related else "",
                 "neighborhood_band": strongest_related["bridge_band"] if strongest_related else "",
+                "next_read_title": strongest_related["display_title"] if strongest_related else "",
+                "next_read_path": strongest_related["detail_path"] if strongest_related else "",
+                "next_read_reason": strongest_related["reason"] if strongest_related else "",
                 "priority_score": priority_score,
                 "priority_band": priority_band,
                 "priority_reason": priority_reason,
@@ -947,6 +950,7 @@ def build_cluster_detail_payload(
         current_source_note_items=source_note_items,
         current_moc_items=moc_items,
     )
+    next_read_cluster = related_clusters[0] if related_clusters else None
 
     return {
         "screen": "graph/cluster-detail",
@@ -965,6 +969,7 @@ def build_cluster_detail_payload(
         "open_contradictions": open_contradictions,
         "stale_summaries": stale_summaries,
         "related_clusters": related_clusters,
+        "next_read_cluster": next_read_cluster,
         "top_source_notes": _top_counter_items(source_note_counts, source_note_items),
         "top_mocs": _top_counter_items(moc_counts, moc_items),
         "summary_bullets": summary_bullets,

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -267,6 +267,37 @@ def _build_related_cluster_items(
     return related_items[:5]
 
 
+def _bridge_kind_display_name(bridge_kind: str) -> str:
+    if bridge_kind == "source_and_atlas_overlap":
+        return "Source + Atlas Overlap"
+    if bridge_kind == "source_overlap":
+        return "Source Overlap"
+    if bridge_kind == "atlas_overlap":
+        return "Atlas Overlap"
+    return bridge_kind.replace("_", " ").title()
+
+
+def _build_related_cluster_groups(related_clusters: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    grouped: dict[str, dict[str, Any]] = {}
+    for item in related_clusters:
+        group = grouped.setdefault(
+            str(item["bridge_kind"]),
+            {
+                "bridge_kind": str(item["bridge_kind"]),
+                "display_name": _bridge_kind_display_name(str(item["bridge_kind"])),
+                "count": 0,
+                "cluster_titles": [],
+            },
+        )
+        group["count"] += 1
+        if item["display_title"] not in group["cluster_titles"]:
+            group["cluster_titles"].append(item["display_title"])
+    return sorted(
+        grouped.values(),
+        key=lambda item: (-int(item["count"]), str(item["bridge_kind"])),
+    )
+
+
 def _build_production_summary(vault_dir: Path | str, object_ids: list[str]) -> dict[str, Any]:
     normalized_object_ids = list(dict.fromkeys(object_id for object_id in object_ids if object_id))
     object_traceability = [get_object_traceability(vault_dir, object_id) for object_id in normalized_object_ids]
@@ -958,6 +989,7 @@ def build_cluster_detail_payload(
         current_source_note_items=source_note_items,
         current_moc_items=moc_items,
     )
+    related_cluster_groups = _build_related_cluster_groups(related_clusters)
     next_read_cluster = related_clusters[0] if related_clusters else None
 
     return {
@@ -977,6 +1009,7 @@ def build_cluster_detail_payload(
         "open_contradictions": open_contradictions,
         "stale_summaries": stale_summaries,
         "related_clusters": related_clusters,
+        "related_cluster_groups": related_cluster_groups,
         "next_read_cluster": next_read_cluster,
         "top_source_notes": _top_counter_items(source_note_counts, source_note_items),
         "top_mocs": _top_counter_items(moc_counts, moc_items),

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -95,6 +95,45 @@ def _object_ids_from_claim_ids(*claim_id_lists: list[str]) -> list[str]:
     return ordered
 
 
+def _edge_kind_parts(edge_kind: str) -> tuple[str, str]:
+    family, sep, subtype = str(edge_kind).partition(":")
+    if not sep:
+        return (family, "")
+    return (family, subtype)
+
+
+def _derive_cluster_structural_label(
+    *,
+    center_title: str,
+    edge_summary_items: list[dict[str, Any]],
+) -> dict[str, str]:
+    contradiction_item = next((item for item in edge_summary_items if item["edge_family"] == "contradiction"), None)
+    if contradiction_item is not None:
+        return {
+            "kind": "contradiction_cluster",
+            "title": f"Contradiction cluster around {center_title}",
+            "reason": f"{contradiction_item['count']} contradiction edges are present in the local graph.",
+        }
+    dominant = edge_summary_items[0] if edge_summary_items else None
+    if dominant is None:
+        return {
+            "kind": "reference_cluster",
+            "title": f"Reference cluster around {center_title}",
+            "reason": "No internal edge structure has been materialized yet.",
+        }
+    if dominant["edge_family"] == "relation":
+        return {
+            "kind": "relation_cluster",
+            "title": f"Relation cluster around {center_title}",
+            "reason": f"{dominant['count']} {dominant['display_name']} dominate the local graph.",
+        }
+    return {
+        "kind": "mixed_cluster",
+        "title": f"Mixed graph cluster around {center_title}",
+        "reason": f"Dominant edge family is {dominant['edge_family']}.",
+    }
+
+
 def _build_production_summary(vault_dir: Path | str, object_ids: list[str]) -> dict[str, Any]:
     normalized_object_ids = list(dict.fromkeys(object_id for object_id in object_ids if object_id))
     object_traceability = [get_object_traceability(vault_dir, object_id) for object_id in normalized_object_ids]
@@ -690,6 +729,24 @@ def build_cluster_detail_payload(
         for edge in detail["edges"]
     ]
     edge_kind_counts = Counter(edge["edge_kind"] for edge in enriched_edges)
+    edge_summary_items = [
+        {
+            "edge_kind": edge_kind,
+            "edge_family": _edge_kind_parts(edge_kind)[0],
+            "edge_subtype": _edge_kind_parts(edge_kind)[1],
+            "display_name": (
+                "contradiction links"
+                if _edge_kind_parts(edge_kind)[0] == "contradiction"
+                else (
+                    f"{_edge_kind_parts(edge_kind)[1].replace('_', ' ')} links"
+                    if _edge_kind_parts(edge_kind)[0] == "relation" and _edge_kind_parts(edge_kind)[1]
+                    else edge_kind.replace(":", " ")
+                )
+            ),
+            "count": count,
+        }
+        for edge_kind, count in sorted(edge_kind_counts.items(), key=lambda item: (-item[1], item[0]))
+    ]
     object_kind_counts = Counter(
         str(member["object_kind"])
         for member in cluster["members"]
@@ -743,13 +800,19 @@ def build_cluster_detail_payload(
         summary_bullets.append(
             f"Review pressure: {review_context['open_contradiction_count']} open contradictions and {review_context['stale_summary_count']} stale summaries in this cluster scope."
         )
+    structural_label = _derive_cluster_structural_label(
+        center_title=str(cluster["center_title"]),
+        edge_summary_items=edge_summary_items,
+    )
 
     return {
         "screen": "graph/cluster-detail",
         "cluster": enriched_cluster,
         "edges": enriched_edges,
         "edge_kind_counts": dict(edge_kind_counts),
+        "edge_summary_items": edge_summary_items,
         "object_kind_counts": dict(object_kind_counts),
+        "structural_label": structural_label,
         "review_context": review_context,
         "top_source_notes": _top_counter_items(source_note_counts, source_note_items),
         "top_mocs": _top_counter_items(moc_counts, moc_items),

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -872,6 +872,7 @@ def build_cluster_browser_payload(
             priority_band = "reference"
             priority_reason = f"{review_context['source_note_count']} source notes in scope"
         strongest_related = detail["related_clusters"][0] if detail["related_clusters"] else None
+        top_reading_route = detail["reading_routes"][0] if detail["reading_routes"] else None
         enriched_items.append(
             {
                 **item,
@@ -893,6 +894,9 @@ def build_cluster_browser_payload(
                 "next_read_title": strongest_related["display_title"] if strongest_related else "",
                 "next_read_path": strongest_related["detail_path"] if strongest_related else "",
                 "next_read_reason": strongest_related["reason"] if strongest_related else "",
+                "top_reading_route_kind": top_reading_route["route_kind"] if top_reading_route else "",
+                "top_reading_route_title": top_reading_route["display_title"] if top_reading_route else "",
+                "top_reading_route_reason": top_reading_route["route_reason"] if top_reading_route else "",
                 "priority_score": priority_score,
                 "priority_band": priority_band,
                 "priority_reason": priority_reason,

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -617,6 +617,7 @@ def build_cluster_detail_payload(
     detail = get_graph_cluster_detail(vault_dir, cluster_id, pack_name=pack_name)
     cluster = detail["cluster"]
     member_index = {str(member["object_id"]): member for member in cluster["members"]}
+    member_object_ids = [str(member["object_id"]) for member in cluster["members"]]
     detail_path = (
         f"/cluster?id={quote(str(cluster['cluster_id']), safe='')}"
         f"&pack={quote(str(cluster['pack']), safe='')}"
@@ -649,11 +650,71 @@ def build_cluster_detail_payload(
         }
         for edge in detail["edges"]
     ]
+    edge_kind_counts = Counter(edge["edge_kind"] for edge in enriched_edges)
+    object_kind_counts = Counter(
+        str(member["object_kind"])
+        for member in cluster["members"]
+        if member.get("object_kind")
+    )
+    review_context = get_review_context(vault_dir, member_object_ids)
+    provenance_map = get_object_provenance_map(vault_dir, member_object_ids)
+    source_note_counts: Counter[str] = Counter()
+    source_note_items: dict[str, dict[str, Any]] = {}
+    moc_counts: Counter[str] = Counter()
+    moc_items: dict[str, dict[str, Any]] = {}
+    for provenance in provenance_map.values():
+        for note in provenance["source_notes"]:
+            slug = str(note["slug"])
+            source_note_items.setdefault(slug, note)
+            source_note_counts[slug] += 1
+        for moc in provenance["mocs"]:
+            slug = str(moc["slug"])
+            moc_items.setdefault(slug, moc)
+            moc_counts[slug] += 1
+
+    def _top_counter_items(
+        counts: Counter[str],
+        item_map: dict[str, dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        return [
+            {**item_map[key], "object_count": count}
+            for key, count in sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+            if key in item_map
+        ][:5]
+
+    top_edge_kind = next(iter(sorted(edge_kind_counts.items(), key=lambda item: (-item[1], item[0]))), None)
+    kind_summary = ", ".join(
+        f"{kind} {count}"
+        for kind, count in sorted(object_kind_counts.items(), key=lambda item: (-item[1], item[0]))
+    )
+    summary_bullets = [
+        f"{cluster['member_count']} objects in a {cluster['cluster_kind']} cluster centered on {cluster['center_title']}.",
+    ]
+    if top_edge_kind:
+        summary_bullets.append(
+            f"{len(enriched_edges)} internal edges across {len(edge_kind_counts)} edge kinds; dominant edge kind is {top_edge_kind[0]} ({top_edge_kind[1]})."
+        )
+    if kind_summary:
+        summary_bullets.append(f"Object kinds in scope: {kind_summary}.")
+    if review_context["source_note_count"] or review_context["moc_count"]:
+        summary_bullets.append(
+            f"Coverage currently includes {review_context['source_note_count']} source/deep-dive notes and {review_context['moc_count']} atlas pages."
+        )
+    if review_context["open_contradiction_count"] or review_context["stale_summary_count"]:
+        summary_bullets.append(
+            f"Review pressure: {review_context['open_contradiction_count']} open contradictions and {review_context['stale_summary_count']} stale summaries in this cluster scope."
+        )
+
     return {
         "screen": "graph/cluster-detail",
         "cluster": enriched_cluster,
         "edges": enriched_edges,
-        "edge_kind_counts": dict(Counter(edge["edge_kind"] for edge in enriched_edges)),
+        "edge_kind_counts": dict(edge_kind_counts),
+        "object_kind_counts": dict(object_kind_counts),
+        "review_context": review_context,
+        "top_source_notes": _top_counter_items(source_note_counts, source_note_items),
+        "top_mocs": _top_counter_items(moc_counts, moc_items),
+        "summary_bullets": summary_bullets,
         "model_notes": [
             "Cluster detail currently reflects pack-owned graph seed structure, not a final semantic subgraph model.",
             "Edges are filtered to the cluster's own member set inside the requested pack projection.",

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -157,6 +157,102 @@ def _relation_pattern_preview(relation_pattern_items: list[dict[str, Any]]) -> s
     return preview
 
 
+def _top_counter_items(
+    counts: Counter[str],
+    item_map: dict[str, dict[str, Any]],
+    *,
+    limit: int = 5,
+) -> list[dict[str, Any]]:
+    return [
+        {**item_map[key], "object_count": count}
+        for key, count in sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+        if key in item_map
+    ][:limit]
+
+
+def _collect_cluster_provenance(
+    vault_dir: Path | str,
+    member_object_ids: list[str],
+) -> dict[str, Any]:
+    provenance_map = get_object_provenance_map(vault_dir, member_object_ids)
+    source_note_counts: Counter[str] = Counter()
+    source_note_items: dict[str, dict[str, Any]] = {}
+    moc_counts: Counter[str] = Counter()
+    moc_items: dict[str, dict[str, Any]] = {}
+    for provenance in provenance_map.values():
+        for note in provenance["source_notes"]:
+            slug = str(note["slug"])
+            source_note_items.setdefault(slug, note)
+            source_note_counts[slug] += 1
+        for moc in provenance["mocs"]:
+            slug = str(moc["slug"])
+            moc_items.setdefault(slug, moc)
+            moc_counts[slug] += 1
+    return {
+        "source_note_counts": source_note_counts,
+        "source_note_items": source_note_items,
+        "moc_counts": moc_counts,
+        "moc_items": moc_items,
+    }
+
+
+def _build_related_cluster_items(
+    vault_dir: Path | str,
+    *,
+    cluster_id: str,
+    requested_pack: str,
+    current_source_note_items: dict[str, dict[str, Any]],
+    current_moc_items: dict[str, dict[str, Any]],
+) -> list[dict[str, Any]]:
+    current_source_slugs = set(current_source_note_items)
+    current_moc_slugs = set(current_moc_items)
+    if not current_source_slugs and not current_moc_slugs:
+        return []
+    related_items: list[dict[str, Any]] = []
+    for row in list_graph_clusters(vault_dir, pack_name=requested_pack, limit=200):
+        if str(row["cluster_id"]) == cluster_id:
+            continue
+        member_object_ids = [str(member["object_id"]) for member in row["members"]]
+        provenance = _collect_cluster_provenance(vault_dir, member_object_ids)
+        shared_source_slugs = sorted(current_source_slugs & set(provenance["source_note_items"]))
+        shared_moc_slugs = sorted(current_moc_slugs & set(provenance["moc_items"]))
+        if not shared_source_slugs and not shared_moc_slugs:
+            continue
+        reason_parts: list[str] = []
+        if shared_source_slugs:
+            reason_parts.append(f"{len(shared_source_slugs)} shared source notes")
+        if shared_moc_slugs:
+            reason_parts.append(f"{len(shared_moc_slugs)} shared atlas pages")
+        score = len(shared_source_slugs) * 10 + len(shared_moc_slugs) * 5 + int(row["member_count"])
+        related_items.append(
+            {
+                "cluster_id": str(row["cluster_id"]),
+                "pack": requested_pack,
+                "label": str(row["label"]),
+                "display_title": f"Cluster around {row['center_title']}",
+                "detail_path": (
+                    f"/cluster?id={quote(str(row['cluster_id']), safe='')}"
+                    f"&pack={quote(requested_pack, safe='')}"
+                ),
+                "member_count": int(row["member_count"]),
+                "shared_source_count": len(shared_source_slugs),
+                "shared_moc_count": len(shared_moc_slugs),
+                "shared_source_titles": [
+                    str(current_source_note_items.get(slug, provenance["source_note_items"].get(slug, {})).get("title", slug))
+                    for slug in shared_source_slugs
+                ][:3],
+                "shared_moc_titles": [
+                    str(current_moc_items.get(slug, provenance["moc_items"].get(slug, {})).get("title", slug))
+                    for slug in shared_moc_slugs
+                ][:3],
+                "reason": ", ".join(reason_parts),
+                "score": score,
+            }
+        )
+    related_items.sort(key=lambda item: (-item["score"], item["label"].lower(), item["cluster_id"]))
+    return related_items[:5]
+
+
 def _build_production_summary(vault_dir: Path | str, object_ids: list[str]) -> dict[str, Any]:
     normalized_object_ids = list(dict.fromkeys(object_id for object_id in object_ids if object_id))
     object_traceability = [get_object_traceability(vault_dir, object_id) for object_id in normalized_object_ids]
@@ -795,30 +891,11 @@ def build_cluster_detail_payload(
         if set(_object_ids_from_claim_ids(item["positive_claim_ids"], item["negative_claim_ids"])) & set(member_object_ids)
     ][:5]
     stale_summaries = list_stale_summaries(vault_dir, object_ids=member_object_ids, limit=5)
-    provenance_map = get_object_provenance_map(vault_dir, member_object_ids)
-    source_note_counts: Counter[str] = Counter()
-    source_note_items: dict[str, dict[str, Any]] = {}
-    moc_counts: Counter[str] = Counter()
-    moc_items: dict[str, dict[str, Any]] = {}
-    for provenance in provenance_map.values():
-        for note in provenance["source_notes"]:
-            slug = str(note["slug"])
-            source_note_items.setdefault(slug, note)
-            source_note_counts[slug] += 1
-        for moc in provenance["mocs"]:
-            slug = str(moc["slug"])
-            moc_items.setdefault(slug, moc)
-            moc_counts[slug] += 1
-
-    def _top_counter_items(
-        counts: Counter[str],
-        item_map: dict[str, dict[str, Any]],
-    ) -> list[dict[str, Any]]:
-        return [
-            {**item_map[key], "object_count": count}
-            for key, count in sorted(counts.items(), key=lambda item: (-item[1], item[0]))
-            if key in item_map
-        ][:5]
+    provenance = _collect_cluster_provenance(vault_dir, member_object_ids)
+    source_note_counts = provenance["source_note_counts"]
+    source_note_items = provenance["source_note_items"]
+    moc_counts = provenance["moc_counts"]
+    moc_items = provenance["moc_items"]
 
     top_edge_kind = next(iter(sorted(edge_kind_counts.items(), key=lambda item: (-item[1], item[0]))), None)
     kind_summary = ", ".join(
@@ -848,6 +925,13 @@ def build_cluster_detail_payload(
     )
     relation_pattern_items = _build_relation_pattern_items(edge_summary_items)
     relation_pattern_preview = _relation_pattern_preview(relation_pattern_items)
+    related_clusters = _build_related_cluster_items(
+        vault_dir,
+        cluster_id=str(cluster["cluster_id"]),
+        requested_pack=requested_pack,
+        current_source_note_items=source_note_items,
+        current_moc_items=moc_items,
+    )
 
     return {
         "screen": "graph/cluster-detail",
@@ -865,6 +949,7 @@ def build_cluster_detail_payload(
         "review_context": review_context,
         "open_contradictions": open_contradictions,
         "stale_summaries": stale_summaries,
+        "related_clusters": related_clusters,
         "top_source_notes": _top_counter_items(source_note_counts, source_note_items),
         "top_mocs": _top_counter_items(moc_counts, moc_items),
         "summary_bullets": summary_bullets,

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -298,6 +298,47 @@ def _build_related_cluster_groups(related_clusters: list[dict[str, Any]]) -> lis
     )
 
 
+def _build_reading_routes(related_clusters: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    route_specs = [
+        (
+            "full_context_route",
+            "Full Context Route",
+            {"source_and_atlas_overlap"},
+        ),
+        (
+            "source_continuity_route",
+            "Source Continuity Route",
+            {"source_and_atlas_overlap", "source_overlap"},
+        ),
+        (
+            "atlas_continuity_route",
+            "Atlas Continuity Route",
+            {"source_and_atlas_overlap", "atlas_overlap"},
+        ),
+    ]
+    routes: list[dict[str, Any]] = []
+    for route_kind, display_name, allowed_bridge_kinds in route_specs:
+        candidate = next(
+            (item for item in related_clusters if str(item["bridge_kind"]) in allowed_bridge_kinds),
+            None,
+        )
+        if candidate is None:
+            continue
+        routes.append(
+            {
+                "route_kind": route_kind,
+                "display_name": display_name,
+                "cluster_id": candidate["cluster_id"],
+                "display_title": candidate["display_title"],
+                "detail_path": candidate["detail_path"],
+                "bridge_kind": candidate["bridge_kind"],
+                "bridge_band": candidate["bridge_band"],
+                "reason": candidate["reason"],
+            }
+        )
+    return routes
+
+
 def _build_production_summary(vault_dir: Path | str, object_ids: list[str]) -> dict[str, Any]:
     normalized_object_ids = list(dict.fromkeys(object_id for object_id in object_ids if object_id))
     object_traceability = [get_object_traceability(vault_dir, object_id) for object_id in normalized_object_ids]
@@ -990,6 +1031,7 @@ def build_cluster_detail_payload(
         current_moc_items=moc_items,
     )
     related_cluster_groups = _build_related_cluster_groups(related_clusters)
+    reading_routes = _build_reading_routes(related_clusters)
     next_read_cluster = related_clusters[0] if related_clusters else None
 
     return {
@@ -1010,6 +1052,7 @@ def build_cluster_detail_payload(
         "stale_summaries": stale_summaries,
         "related_clusters": related_clusters,
         "related_cluster_groups": related_cluster_groups,
+        "reading_routes": reading_routes,
         "next_read_cluster": next_read_cluster,
         "top_source_notes": _top_counter_items(source_note_counts, source_note_items),
         "top_mocs": _top_counter_items(moc_counts, moc_items),

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -224,6 +224,12 @@ def _build_related_cluster_items(
         if shared_moc_slugs:
             reason_parts.append(f"{len(shared_moc_slugs)} shared atlas pages")
         score = len(shared_source_slugs) * 10 + len(shared_moc_slugs) * 5 + int(row["member_count"])
+        if shared_source_slugs and shared_moc_slugs:
+            bridge_kind = "source_and_atlas_overlap"
+        elif shared_source_slugs:
+            bridge_kind = "source_overlap"
+        else:
+            bridge_kind = "atlas_overlap"
         if len(shared_source_slugs) >= 1 and len(shared_moc_slugs) >= 1:
             bridge_band = "strong"
         elif len(shared_source_slugs) >= 1 or len(shared_moc_slugs) >= 2:
@@ -251,6 +257,7 @@ def _build_related_cluster_items(
                     str(current_moc_items.get(slug, provenance["moc_items"].get(slug, {})).get("title", slug))
                     for slug in shared_moc_slugs
                 ][:3],
+                "bridge_kind": bridge_kind,
                 "bridge_band": bridge_band,
                 "reason": ", ".join(reason_parts),
                 "score": score,
@@ -796,6 +803,7 @@ def build_cluster_browser_payload(
                 "neighborhood_score": strongest_related["score"] if strongest_related else 0,
                 "neighborhood_reason": strongest_related["reason"] if strongest_related else "",
                 "neighborhood_band": strongest_related["bridge_band"] if strongest_related else "",
+                "neighborhood_bridge_kind": strongest_related["bridge_kind"] if strongest_related else "",
                 "next_read_title": strongest_related["display_title"] if strongest_related else "",
                 "next_read_path": strongest_related["detail_path"] if strongest_related else "",
                 "next_read_reason": strongest_related["reason"] if strongest_related else "",

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -784,6 +784,17 @@ def build_cluster_detail_payload(
         if member.get("object_kind")
     )
     review_context = get_review_context(vault_dir, member_object_ids)
+    open_contradictions = [
+        {
+            "contradiction_id": item["contradiction_id"],
+            "subject_key": item["subject_key"],
+            "object_ids": _object_ids_from_claim_ids(item["positive_claim_ids"], item["negative_claim_ids"]),
+            "path": f"/contradictions?q={quote(str(item['subject_key']), safe='')}",
+        }
+        for item in list_contradictions(vault_dir, status="open", limit=20)
+        if set(_object_ids_from_claim_ids(item["positive_claim_ids"], item["negative_claim_ids"])) & set(member_object_ids)
+    ][:5]
+    stale_summaries = list_stale_summaries(vault_dir, object_ids=member_object_ids, limit=5)
     provenance_map = get_object_provenance_map(vault_dir, member_object_ids)
     source_note_counts: Counter[str] = Counter()
     source_note_items: dict[str, dict[str, Any]] = {}
@@ -852,6 +863,8 @@ def build_cluster_detail_payload(
         "object_kind_counts": dict(object_kind_counts),
         "structural_label": structural_label,
         "review_context": review_context,
+        "open_contradictions": open_contradictions,
+        "stale_summaries": stale_summaries,
         "top_source_notes": _top_counter_items(source_note_counts, source_note_items),
         "top_mocs": _top_counter_items(moc_counts, moc_items),
         "summary_bullets": summary_bullets,

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -859,6 +859,8 @@ def build_cluster_browser_payload(
             + review_context["source_note_count"]
             + review_context["moc_count"]
         )
+        if detail["reading_routes"]:
+            priority_score += 15
         if review_context["open_contradiction_count"] > 0 or review_context["stale_summary_count"] > 0:
             priority_band = "attention"
             priority_reason = (
@@ -897,6 +899,7 @@ def build_cluster_browser_payload(
                 "top_reading_route_kind": top_reading_route["route_kind"] if top_reading_route else "",
                 "top_reading_route_title": top_reading_route["display_title"] if top_reading_route else "",
                 "top_reading_route_reason": top_reading_route["route_reason"] if top_reading_route else "",
+                "has_reading_route": bool(top_reading_route),
                 "priority_score": priority_score,
                 "priority_band": priority_band,
                 "priority_reason": priority_reason,

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -134,6 +134,29 @@ def _derive_cluster_structural_label(
     }
 
 
+def _build_relation_pattern_items(edge_summary_items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {
+            "edge_kind": item["edge_kind"],
+            "subtype": item["edge_subtype"],
+            "display_name": item["display_name"],
+            "count": item["count"],
+        }
+        for item in edge_summary_items
+        if item["edge_family"] == "relation"
+    ]
+
+
+def _relation_pattern_preview(relation_pattern_items: list[dict[str, Any]]) -> str:
+    if not relation_pattern_items:
+        return ""
+    preview_items = relation_pattern_items[:2]
+    preview = ", ".join(f"{item['display_name']} ({item['count']})" for item in preview_items)
+    if len(relation_pattern_items) > 2:
+        return f"{preview}, +{len(relation_pattern_items) - 2} more"
+    return preview
+
+
 def _build_production_summary(vault_dir: Path | str, object_ids: list[str]) -> dict[str, Any]:
     normalized_object_ids = list(dict.fromkeys(object_id for object_id in object_ids if object_id))
     object_traceability = [get_object_traceability(vault_dir, object_id) for object_id in normalized_object_ids]
@@ -656,6 +679,8 @@ def build_cluster_browser_payload(
                 "detail_path": detail["cluster"]["detail_path"],
                 "center_object_path": detail["cluster"]["center_object_path"],
                 "member_links": detail["cluster"]["member_links"],
+                "display_title": detail["display_title"],
+                "relation_pattern_preview": detail["relation_pattern_preview"],
                 "priority_score": priority_score,
                 "priority_band": priority_band,
                 "priority_reason": priority_reason,
@@ -804,13 +829,18 @@ def build_cluster_detail_payload(
         center_title=str(cluster["center_title"]),
         edge_summary_items=edge_summary_items,
     )
+    relation_pattern_items = _build_relation_pattern_items(edge_summary_items)
+    relation_pattern_preview = _relation_pattern_preview(relation_pattern_items)
 
     return {
         "screen": "graph/cluster-detail",
         "cluster": enriched_cluster,
+        "display_title": structural_label["title"],
         "edges": enriched_edges,
         "edge_kind_counts": dict(edge_kind_counts),
         "edge_summary_items": edge_summary_items,
+        "relation_pattern_items": relation_pattern_items,
+        "relation_pattern_preview": relation_pattern_preview,
         "object_kind_counts": dict(object_kind_counts),
         "structural_label": structural_label,
         "review_context": review_context,

--- a/src/openclaw_pipeline/wiki_views/runtime.py
+++ b/src/openclaw_pipeline/wiki_views/runtime.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from ..derived.paths import compiled_view_path
 from ..extraction.artifacts import iter_run_results
+from ..materializers.cluster_view import materialize_cluster_view
 from ..materializers.contradiction_view import materialize_contradiction_view
 from ..materializers.event_dossier import materialize_event_dossier
 from ..materializers.object_page import materialize_object_page
@@ -63,6 +64,8 @@ def build_view(vault_dir: Path, spec: WikiViewSpec, *, object_id: str | None = N
         return materialize_event_dossier(resolved_vault, pack_name=spec.pack, view_name=spec.name)
     if spec.builder == "contradiction_view":
         return materialize_contradiction_view(resolved_vault, pack_name=spec.pack, view_name=spec.name)
+    if spec.builder == "cluster_view":
+        return materialize_cluster_view(resolved_vault, pack_name=spec.pack, view_name=spec.name)
 
     output_path = compiled_view_path(layout, pack_name=spec.pack, view_name=spec.name)
     output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/openclaw_pipeline/wiki_views/runtime.py
+++ b/src/openclaw_pipeline/wiki_views/runtime.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from ..derived.paths import compiled_view_path
 from ..extraction.artifacts import iter_run_results
+from ..materializers.cluster_crystal import materialize_cluster_crystal
 from ..materializers.cluster_view import materialize_cluster_view
 from ..materializers.contradiction_view import materialize_contradiction_view
 from ..materializers.event_dossier import materialize_event_dossier
@@ -50,7 +51,13 @@ def _resolve_view_inputs(layout: VaultLayout, spec: WikiViewSpec) -> list[Path]:
     return resolved
 
 
-def build_view(vault_dir: Path, spec: WikiViewSpec, *, object_id: str | None = None) -> Path:
+def build_view(
+    vault_dir: Path,
+    spec: WikiViewSpec,
+    *,
+    object_id: str | None = None,
+    cluster_id: str | None = None,
+) -> Path:
     resolved_vault = resolve_vault_dir(vault_dir)
     layout = VaultLayout.from_vault(resolved_vault)
 
@@ -58,6 +65,10 @@ def build_view(vault_dir: Path, spec: WikiViewSpec, *, object_id: str | None = N
         if not object_id:
             raise ValueError("object_id is required for object_page views")
         return materialize_object_page(resolved_vault, pack_name=spec.pack, object_id=object_id)
+    if spec.builder == "cluster_crystal":
+        if not cluster_id:
+            raise ValueError("cluster_id is required for cluster_crystal views")
+        return materialize_cluster_crystal(resolved_vault, pack_name=spec.pack, cluster_id=cluster_id)
     if spec.builder == "topic_view":
         return materialize_topic_view(resolved_vault, pack_name=spec.pack, view_name=spec.name)
     if spec.builder == "event_dossier":

--- a/tests/test_build_views_command.py
+++ b/tests/test_build_views_command.py
@@ -551,6 +551,38 @@ Target note captures downstream effects.
 """,
         encoding="utf-8",
     )
+    source = temp_vault / "20-Areas" / "Tools" / "Topics" / "2026-04" / "Source Deep Dive_深度解读.md"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text(
+        """---
+note_id: source-deep-dive
+title: Source Deep Dive
+type: deep_dive
+date: 2026-04-10
+---
+
+# Source Deep Dive
+
+Mentions [[source-note]] and [[target-note]].
+""",
+        encoding="utf-8",
+    )
+    atlas = temp_vault / "10-Knowledge" / "Atlas" / "Atlas-Index.md"
+    atlas.write_text(
+        """---
+note_id: atlas-index
+title: Atlas Index
+type: moc
+date: 2026-04-10
+---
+
+# Atlas Index
+
+- [[source-note]]
+- [[target-note]]
+""",
+        encoding="utf-8",
+    )
 
     rebuild_knowledge_index(temp_vault)
 
@@ -573,6 +605,10 @@ Target note captures downstream effects.
     assert "## Graph Clusters" in content
     assert "Source Note" in content
     assert "Target Note" in content
+    assert "#### Cluster Synthesis" in content
+    assert "#### Coverage" in content
+    assert "Source Deep Dive" in content
+    assert "Atlas Index" in content
 
 
 def test_build_views_command_can_materialize_contradictions_overview(temp_vault):

--- a/tests/test_build_views_command.py
+++ b/tests/test_build_views_command.py
@@ -693,6 +693,8 @@ Target note captures downstream effects.
     assert result == 0
     assert f"# cluster/{cluster['cluster_id']}" in content
     assert "## Cluster Synthesis" in content
+    assert "## Structural Label" in content
+    assert "## Edge Summary" in content
     assert "## Members" in content
     assert "## Internal Edges" in content
     assert "Source Note" in content

--- a/tests/test_build_views_command.py
+++ b/tests/test_build_views_command.py
@@ -630,6 +630,7 @@ date: 2026-04-10
     assert "#### Relation Patterns" in content
     assert "#### Related Clusters" in content
     assert "- priority_band:" in content
+    assert "- neighborhood_score:" in content
     assert "#### Coverage" in content
     assert "Source Deep Dive" in content
     assert "Atlas Index" in content

--- a/tests/test_build_views_command.py
+++ b/tests/test_build_views_command.py
@@ -628,6 +628,7 @@ date: 2026-04-10
     assert "#### Cluster Synthesis" in content
     assert "#### Structural Label" in content
     assert "#### Relation Patterns" in content
+    assert "#### Related Clusters" in content
     assert "- priority_band:" in content
     assert "#### Coverage" in content
     assert "Source Deep Dive" in content

--- a/tests/test_build_views_command.py
+++ b/tests/test_build_views_command.py
@@ -513,6 +513,68 @@ The system launched publicly for operators.
     assert "Launch note explains the system launch details." in content
 
 
+def test_build_views_command_can_materialize_cluster_overview(temp_vault):
+    from openclaw_pipeline.commands.build_views import main
+    from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
+    from openclaw_pipeline.runtime import VaultLayout
+
+    source = temp_vault / "10-Knowledge" / "Evergreen" / "Source.md"
+    target = temp_vault / "10-Knowledge" / "Evergreen" / "Target.md"
+
+    source.write_text(
+        """---
+note_id: source-note
+title: Source Note
+type: evergreen
+date: 2026-04-10
+---
+
+# Source Note
+
+Source note explains the runtime architecture.
+
+Links to [[target-note]].
+""",
+        encoding="utf-8",
+    )
+    target.write_text(
+        """---
+note_id: target-note
+title: Target Note
+type: evergreen
+date: 2026-04-10
+---
+
+# Target Note
+
+Target note captures downstream effects.
+""",
+        encoding="utf-8",
+    )
+
+    rebuild_knowledge_index(temp_vault)
+
+    result = main(
+        [
+            "--vault-dir",
+            str(temp_vault),
+            "--pack",
+            "default-knowledge",
+            "--view",
+            "overview/clusters",
+        ]
+    )
+
+    layout = VaultLayout.from_vault(temp_vault)
+    content = (layout.compiled_views_dir / "default-knowledge" / "overview__clusters.md").read_text(encoding="utf-8")
+
+    assert result == 0
+    assert "# overview/clusters" in content
+    assert "## Graph Clusters" in content
+    assert "Source Note" in content
+    assert "Target Note" in content
+
+
 def test_build_views_command_can_materialize_contradictions_overview(temp_vault):
     from openclaw_pipeline.commands.build_views import main
     from openclaw_pipeline.knowledge_index import list_contradictions, rebuild_knowledge_index, resolve_contradictions

--- a/tests/test_build_views_command.py
+++ b/tests/test_build_views_command.py
@@ -631,6 +631,7 @@ date: 2026-04-10
     assert "#### Related Clusters" in content
     assert "#### Next Reading Route" in content
     assert "- top_reading_route_kind:" in content
+    assert "- has_reading_route:" in content
     assert "- priority_band:" in content
     assert "- neighborhood_score:" in content
     assert "#### Coverage" in content

--- a/tests/test_build_views_command.py
+++ b/tests/test_build_views_command.py
@@ -837,6 +837,8 @@ date: 2026-04-10
 
     assert result == 0
     assert "## Reading Routes" in content
+    assert "route_rank:" in content
+    assert "route_reason:" in content
     assert "## Related Clusters" in content
     assert "## Neighborhood Groups" in content
     assert "source_and_atlas_overlap" in content

--- a/tests/test_build_views_command.py
+++ b/tests/test_build_views_command.py
@@ -695,8 +695,11 @@ Target note captures downstream effects.
     assert "## Cluster Synthesis" in content
     assert "## Structural Label" in content
     assert "## Edge Summary" in content
+    assert "## Relation Patterns" in content
     assert "## Members" in content
     assert "## Internal Edges" in content
+    assert "- display_title: " in content
+    assert "cluster around" in content
     assert "Source Note" in content
     assert "Target Note" in content
 

--- a/tests/test_build_views_command.py
+++ b/tests/test_build_views_command.py
@@ -629,6 +629,7 @@ date: 2026-04-10
     assert "#### Structural Label" in content
     assert "#### Relation Patterns" in content
     assert "#### Related Clusters" in content
+    assert "#### Next Reading Route" in content
     assert "- priority_band:" in content
     assert "- neighborhood_score:" in content
     assert "#### Coverage" in content
@@ -702,6 +703,7 @@ Target note captures downstream effects.
     assert "## Edge Summary" in content
     assert "## Relation Patterns" in content
     assert "## Review Pressure" in content
+    assert "## Next Reading Route" in content
     assert "## Members" in content
     assert "## Internal Edges" in content
     assert "- display_title: " in content

--- a/tests/test_build_views_command.py
+++ b/tests/test_build_views_command.py
@@ -837,6 +837,7 @@ date: 2026-04-10
 
     assert result == 0
     assert "## Related Clusters" in content
+    assert "source_and_atlas_overlap" in content
     assert "Shared Atlas" in content or "Shared Deep Dive" in content
 
 

--- a/tests/test_build_views_command.py
+++ b/tests/test_build_views_command.py
@@ -836,6 +836,7 @@ date: 2026-04-10
     ).read_text(encoding="utf-8")
 
     assert result == 0
+    assert "## Reading Routes" in content
     assert "## Related Clusters" in content
     assert "## Neighborhood Groups" in content
     assert "source_and_atlas_overlap" in content

--- a/tests/test_build_views_command.py
+++ b/tests/test_build_views_command.py
@@ -632,6 +632,7 @@ date: 2026-04-10
     assert "#### Next Reading Route" in content
     assert "- top_reading_route_kind:" in content
     assert "- has_reading_route:" in content
+    assert "- reading_intent_count:" in content
     assert "- priority_band:" in content
     assert "- neighborhood_score:" in content
     assert "#### Coverage" in content

--- a/tests/test_build_views_command.py
+++ b/tests/test_build_views_command.py
@@ -626,6 +626,9 @@ date: 2026-04-10
     assert "Source Note" in content
     assert "Target Note" in content
     assert "#### Cluster Synthesis" in content
+    assert "#### Structural Label" in content
+    assert "#### Relation Patterns" in content
+    assert "- priority_band:" in content
     assert "#### Coverage" in content
     assert "Source Deep Dive" in content
     assert "Atlas Index" in content

--- a/tests/test_build_views_command.py
+++ b/tests/test_build_views_command.py
@@ -699,6 +699,7 @@ Target note captures downstream effects.
     assert "## Structural Label" in content
     assert "## Edge Summary" in content
     assert "## Relation Patterns" in content
+    assert "## Review Pressure" in content
     assert "## Members" in content
     assert "## Internal Edges" in content
     assert "- display_title: " in content

--- a/tests/test_build_views_command.py
+++ b/tests/test_build_views_command.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 
 def test_build_views_help_mentions_primary_pack(capsys):
     from openclaw_pipeline.commands.build_views import main
@@ -32,6 +34,24 @@ def test_build_views_command_requires_object_id_for_object_page(temp_vault):
         assert exc.code == 2
     else:
         raise AssertionError("expected object/page to require --object-id")
+
+
+def test_build_views_command_requires_cluster_id_for_cluster_crystal(temp_vault):
+    from openclaw_pipeline.commands.build_views import main
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(
+            [
+                "--vault-dir",
+                str(temp_vault),
+                "--pack",
+                "default-knowledge",
+                "--view",
+                "cluster/crystal",
+            ]
+        )
+
+    assert exc_info.value.code == 2
 
 
 def test_build_views_command_writes_compiled_markdown(temp_vault):
@@ -609,6 +629,74 @@ date: 2026-04-10
     assert "#### Coverage" in content
     assert "Source Deep Dive" in content
     assert "Atlas Index" in content
+
+
+def test_build_views_command_can_materialize_cluster_crystal(temp_vault):
+    from openclaw_pipeline.commands.build_views import main
+    from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
+    from openclaw_pipeline.runtime import VaultLayout
+    from openclaw_pipeline.truth_api import list_graph_clusters
+
+    source = temp_vault / "10-Knowledge" / "Evergreen" / "Source.md"
+    target = temp_vault / "10-Knowledge" / "Evergreen" / "Target.md"
+    source.write_text(
+        """---
+note_id: source-note
+title: Source Note
+type: evergreen
+date: 2026-04-10
+---
+
+# Source Note
+
+Source note explains the runtime architecture.
+
+Links to [[target-note]].
+""",
+        encoding="utf-8",
+    )
+    target.write_text(
+        """---
+note_id: target-note
+title: Target Note
+type: evergreen
+date: 2026-04-10
+---
+
+# Target Note
+
+Target note captures downstream effects.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+    cluster = list_graph_clusters(temp_vault, pack_name="default-knowledge")[0]
+
+    result = main(
+        [
+            "--vault-dir",
+            str(temp_vault),
+            "--pack",
+            "default-knowledge",
+            "--view",
+            "cluster/crystal",
+            "--cluster-id",
+            cluster["cluster_id"],
+        ]
+    )
+
+    layout = VaultLayout.from_vault(temp_vault)
+    content = (
+        layout.compiled_views_dir / "default-knowledge" / "clusters" / f"{cluster['cluster_id']}.md"
+    ).read_text(encoding="utf-8")
+
+    assert result == 0
+    assert f"# cluster/{cluster['cluster_id']}" in content
+    assert "## Cluster Synthesis" in content
+    assert "## Members" in content
+    assert "## Internal Edges" in content
+    assert "Source Note" in content
+    assert "Target Note" in content
 
 
 def test_build_views_command_can_materialize_contradictions_overview(temp_vault):

--- a/tests/test_build_views_command.py
+++ b/tests/test_build_views_command.py
@@ -708,6 +708,134 @@ Target note captures downstream effects.
     assert "Target Note" in content
 
 
+def test_build_views_command_cluster_crystal_includes_related_clusters(temp_vault):
+    from openclaw_pipeline.commands.build_views import main
+    from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
+    from openclaw_pipeline.runtime import VaultLayout
+    from openclaw_pipeline.truth_api import list_graph_clusters
+
+    alpha = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
+    beta = temp_vault / "10-Knowledge" / "Evergreen" / "Beta.md"
+    gamma = temp_vault / "10-Knowledge" / "Evergreen" / "Gamma.md"
+    delta = temp_vault / "10-Knowledge" / "Evergreen" / "Delta.md"
+    alpha.write_text(
+        """---
+note_id: alpha
+title: Alpha
+type: evergreen
+date: 2026-04-10
+---
+
+# Alpha
+
+Alpha links to [[beta]].
+""",
+        encoding="utf-8",
+    )
+    beta.write_text(
+        """---
+note_id: beta
+title: Beta
+type: evergreen
+date: 2026-04-10
+---
+
+# Beta
+
+Alpha does not support local-first execution.
+""",
+        encoding="utf-8",
+    )
+    gamma.write_text(
+        """---
+note_id: gamma
+title: Gamma
+type: evergreen
+date: 2026-04-10
+---
+
+# Gamma
+
+Gamma links to [[delta]].
+""",
+        encoding="utf-8",
+    )
+    delta.write_text(
+        """---
+note_id: delta
+title: Delta
+type: evergreen
+date: 2026-04-10
+---
+
+# Delta
+""",
+        encoding="utf-8",
+    )
+    shared_source = temp_vault / "20-Areas" / "Tools" / "Topics" / "2026-04" / "Shared Deep Dive_深度解读.md"
+    shared_source.parent.mkdir(parents=True, exist_ok=True)
+    shared_source.write_text(
+        """---
+note_id: shared-deep-dive
+title: Shared Deep Dive
+type: deep_dive
+date: 2026-04-10
+---
+
+# Shared Deep Dive
+
+Mentions [[alpha]], [[beta]], [[gamma]], and [[delta]].
+""",
+        encoding="utf-8",
+    )
+    atlas = temp_vault / "10-Knowledge" / "Atlas" / "Shared-Atlas.md"
+    atlas.write_text(
+        """---
+note_id: shared-atlas
+title: Shared Atlas
+type: moc
+date: 2026-04-10
+---
+
+# Shared Atlas
+
+- [[alpha]]
+- [[beta]]
+- [[gamma]]
+- [[delta]]
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+    cluster = next(
+        item
+        for item in list_graph_clusters(temp_vault, pack_name="default-knowledge")
+        if "alpha" in {member["object_id"] for member in item["members"]}
+    )
+
+    result = main(
+        [
+            "--vault-dir",
+            str(temp_vault),
+            "--pack",
+            "default-knowledge",
+            "--view",
+            "cluster/crystal",
+            "--cluster-id",
+            cluster["cluster_id"],
+        ]
+    )
+
+    layout = VaultLayout.from_vault(temp_vault)
+    content = (
+        layout.compiled_views_dir / "default-knowledge" / "clusters" / f"{cluster['cluster_id']}.md"
+    ).read_text(encoding="utf-8")
+
+    assert result == 0
+    assert "## Related Clusters" in content
+    assert "Shared Atlas" in content or "Shared Deep Dive" in content
+
+
 def test_build_views_command_can_materialize_contradictions_overview(temp_vault):
     from openclaw_pipeline.commands.build_views import main
     from openclaw_pipeline.knowledge_index import list_contradictions, rebuild_knowledge_index, resolve_contradictions

--- a/tests/test_build_views_command.py
+++ b/tests/test_build_views_command.py
@@ -837,6 +837,7 @@ date: 2026-04-10
 
     assert result == 0
     assert "## Related Clusters" in content
+    assert "## Neighborhood Groups" in content
     assert "source_and_atlas_overlap" in content
     assert "Shared Atlas" in content or "Shared Deep Dive" in content
 

--- a/tests/test_build_views_command.py
+++ b/tests/test_build_views_command.py
@@ -630,6 +630,7 @@ date: 2026-04-10
     assert "#### Relation Patterns" in content
     assert "#### Related Clusters" in content
     assert "#### Next Reading Route" in content
+    assert "- top_reading_route_kind:" in content
     assert "- priority_band:" in content
     assert "- neighborhood_score:" in content
     assert "#### Coverage" in content

--- a/tests/test_build_views_command.py
+++ b/tests/test_build_views_command.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from urllib.parse import quote
+
 import pytest
 
 
@@ -374,21 +376,22 @@ Baseline note.
     with sqlite3.connect(layout.knowledge_db) as conn:
         conn.execute(
             """
-            INSERT INTO objects (object_id, object_kind, title, canonical_path, source_slug)
-            VALUES ('agent_note', 'evergreen', 'Agent Note', '10-Knowledge/Evergreen/Agent Note.md', 'agent_note')
+            INSERT INTO objects (pack, object_id, object_kind, title, canonical_path, source_slug)
+            VALUES ('research-tech', 'agent_note', 'evergreen', 'Agent Note', '10-Knowledge/Evergreen/Agent Note.md', 'agent_note')
             """
         )
         conn.execute(
             """
-            INSERT INTO compiled_summaries (object_id, summary_text, source_slug)
-            VALUES ('agent_note', 'Agent note documents an unrelated system.', 'agent_note')
+            INSERT INTO compiled_summaries (pack, object_id, summary_text, source_slug)
+            VALUES ('research-tech', 'agent_note', 'Agent note documents an unrelated system.', 'agent_note')
             """
         )
         conn.execute(
             """
             INSERT INTO contradictions (
-              contradiction_id, subject_key, positive_claim_ids_json, negative_claim_ids_json, status, resolution_note, resolved_at
+              pack, contradiction_id, subject_key, positive_claim_ids_json, negative_claim_ids_json, status, resolution_note, resolved_at
             ) VALUES (
+              'research-tech',
               'contradiction::underscore',
               'agent platform',
               '[\"agentXnote::positive\"]',
@@ -696,7 +699,10 @@ Target note captures downstream effects.
 
     layout = VaultLayout.from_vault(temp_vault)
     content = (
-        layout.compiled_views_dir / "default-knowledge" / "clusters" / f"{cluster['cluster_id']}.md"
+        layout.compiled_views_dir
+        / "default-knowledge"
+        / "clusters"
+        / f"{quote(cluster['cluster_id'], safe='')}.md"
     ).read_text(encoding="utf-8")
 
     assert result == 0
@@ -713,6 +719,69 @@ Target note captures downstream effects.
     assert "cluster around" in content
     assert "Source Note" in content
     assert "Target Note" in content
+
+
+def test_build_views_command_materializes_cluster_crystal_to_safe_path(temp_vault):
+    from openclaw_pipeline.commands.build_views import main
+    from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
+    from openclaw_pipeline.runtime import VaultLayout
+    from openclaw_pipeline.truth_api import list_graph_clusters
+
+    source = temp_vault / "10-Knowledge" / "Evergreen" / "Source.md"
+    target = temp_vault / "10-Knowledge" / "Evergreen" / "Target.md"
+    source.write_text(
+        """---
+note_id: source-note
+title: Source Note
+type: evergreen
+date: 2026-04-10
+---
+
+# Source Note
+
+Links to [[target-note]].
+""",
+        encoding="utf-8",
+    )
+    target.write_text(
+        """---
+note_id: target-note
+title: Target Note
+type: evergreen
+date: 2026-04-10
+---
+
+# Target Note
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+    cluster = list_graph_clusters(temp_vault, pack_name="default-knowledge")[0]
+
+    result = main(
+        [
+            "--vault-dir",
+            str(temp_vault),
+            "--pack",
+            "default-knowledge",
+            "--view",
+            "cluster/crystal",
+            "--cluster-id",
+            cluster["cluster_id"],
+        ]
+    )
+
+    layout = VaultLayout.from_vault(temp_vault)
+    output_path = (
+        layout.compiled_views_dir
+        / "default-knowledge"
+        / "clusters"
+        / f"{quote(cluster['cluster_id'], safe='')}.md"
+    )
+
+    assert result == 0
+    assert ":" not in output_path.name
+    assert output_path.exists()
 
 
 def test_build_views_command_cluster_crystal_includes_related_clusters(temp_vault):
@@ -835,7 +904,10 @@ date: 2026-04-10
 
     layout = VaultLayout.from_vault(temp_vault)
     content = (
-        layout.compiled_views_dir / "default-knowledge" / "clusters" / f"{cluster['cluster_id']}.md"
+        layout.compiled_views_dir
+        / "default-knowledge"
+        / "clusters"
+        / f"{quote(cluster['cluster_id'], safe='')}.md"
     ).read_text(encoding="utf-8")
 
     assert result == 0

--- a/tests/test_knowledge_index.py
+++ b/tests/test_knowledge_index.py
@@ -233,6 +233,59 @@ date: 2026-04-07
     assert rows == [("alpha", "Alpha Evergreen", "evergreen", str(evergreen))]
 
 
+def test_rebuild_knowledge_index_scopes_truth_rows_and_graph_seeds_to_selected_pack(temp_vault):
+    from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
+    from openclaw_pipeline.runtime import VaultLayout
+
+    source = temp_vault / "10-Knowledge" / "Evergreen" / "Source.md"
+    target = temp_vault / "10-Knowledge" / "Evergreen" / "Target.md"
+
+    source.write_text(
+        """---
+note_id: source-note
+title: Source Note
+type: evergreen
+date: 2026-04-15
+---
+
+# Source Note
+
+Links to [[target-note]].
+""",
+        encoding="utf-8",
+    )
+    target.write_text(
+        """---
+note_id: target-note
+title: Target Note
+type: evergreen
+date: 2026-04-15
+---
+
+# Target Note
+""",
+        encoding="utf-8",
+    )
+
+    result = rebuild_knowledge_index(temp_vault, pack_name="default-knowledge")
+    db_path = VaultLayout.from_vault(temp_vault).knowledge_db
+
+    assert result["projection_pack"] == "default-knowledge"
+    assert result["graph_edges_indexed"] >= 1
+    assert result["graph_clusters_indexed"] >= 1
+
+    with sqlite3.connect(db_path) as conn:
+        object_packs = conn.execute(
+            "SELECT DISTINCT pack FROM objects ORDER BY pack"
+        ).fetchall()
+        graph_packs = conn.execute(
+            "SELECT DISTINCT pack FROM graph_edges ORDER BY pack"
+        ).fetchall()
+
+    assert object_packs == [("default-knowledge",)]
+    assert graph_packs == [("default-knowledge",)]
+
+
 def test_knowledge_index_help_includes_expected_arguments(capsys):
     from openclaw_pipeline.commands.knowledge_index import main
 
@@ -358,6 +411,8 @@ date: 2026-04-07
                 relations=[],
                 compiled_summaries=[],
                 contradictions=[],
+                graph_edges=[],
+                graph_clusters=[],
             ),
         )
 

--- a/tests/test_knowledge_index.py
+++ b/tests/test_knowledge_index.py
@@ -286,6 +286,69 @@ date: 2026-04-15
     assert graph_packs == [("default-knowledge",)]
 
 
+def test_rebuild_knowledge_index_preserves_other_materialized_pack_projections(temp_vault):
+    from openclaw_pipeline.knowledge_index import knowledge_index_stats, rebuild_knowledge_index
+    from openclaw_pipeline.runtime import VaultLayout
+
+    source = temp_vault / "10-Knowledge" / "Evergreen" / "Source.md"
+    target = temp_vault / "10-Knowledge" / "Evergreen" / "Target.md"
+
+    source.write_text(
+        """---
+note_id: source-note
+title: Source Note
+type: evergreen
+date: 2026-04-15
+---
+
+# Source Note
+
+Links to [[target-note]].
+""",
+        encoding="utf-8",
+    )
+    target.write_text(
+        """---
+note_id: target-note
+title: Target Note
+type: evergreen
+date: 2026-04-15
+---
+
+# Target Note
+""",
+        encoding="utf-8",
+    )
+
+    rebuild_knowledge_index(temp_vault, pack_name="research-tech")
+    rebuild_knowledge_index(temp_vault, pack_name="default-knowledge")
+
+    db_path = VaultLayout.from_vault(temp_vault).knowledge_db
+    with sqlite3.connect(db_path) as conn:
+        object_packs = conn.execute(
+            "SELECT DISTINCT pack FROM objects ORDER BY pack"
+        ).fetchall()
+        graph_packs = conn.execute(
+            "SELECT DISTINCT pack FROM graph_clusters ORDER BY pack"
+        ).fetchall()
+        projection_packs = conn.execute(
+            "SELECT pack, owner_pack FROM truth_projections ORDER BY pack"
+        ).fetchall()
+
+    assert object_packs == [("default-knowledge",), ("research-tech",)]
+    assert graph_packs == [("default-knowledge",), ("research-tech",)]
+    assert projection_packs == [
+        ("default-knowledge", "research-tech"),
+        ("research-tech", "research-tech"),
+    ]
+
+    research_stats = knowledge_index_stats(temp_vault, pack_name="research-tech")
+    default_stats = knowledge_index_stats(temp_vault, pack_name="default-knowledge")
+
+    assert research_stats["objects"] == 2
+    assert default_stats["objects"] == 2
+
+
 def test_knowledge_index_help_includes_expected_arguments(capsys):
     from openclaw_pipeline.commands.knowledge_index import main
 

--- a/tests/test_knowledge_index.py
+++ b/tests/test_knowledge_index.py
@@ -349,6 +349,55 @@ date: 2026-04-15
     assert default_stats["objects"] == 2
 
 
+def test_rebuild_knowledge_index_makes_contradiction_ids_distinct_per_pack(temp_vault):
+    from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
+    from openclaw_pipeline.runtime import VaultLayout
+
+    source = temp_vault / "10-Knowledge" / "Evergreen" / "Source.md"
+    negative = temp_vault / "10-Knowledge" / "Evergreen" / "Negative.md"
+
+    source.write_text(
+        """---
+note_id: source-note
+title: Source Note
+type: evergreen
+date: 2026-04-15
+---
+
+# Source Note
+
+Agent harness supports local-first execution.
+""",
+        encoding="utf-8",
+    )
+    negative.write_text(
+        """---
+note_id: negative-note
+title: Negative Note
+type: evergreen
+date: 2026-04-15
+---
+
+# Negative Note
+
+Agent harness does not support local-first execution.
+""",
+        encoding="utf-8",
+    )
+
+    rebuild_knowledge_index(temp_vault, pack_name="research-tech")
+    rebuild_knowledge_index(temp_vault, pack_name="default-knowledge")
+
+    db_path = VaultLayout.from_vault(temp_vault).knowledge_db
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            "SELECT pack, contradiction_id FROM contradictions ORDER BY pack"
+        ).fetchall()
+
+    assert [row[0] for row in rows] == ["default-knowledge", "research-tech"]
+    assert rows[0][1] != rows[1][1]
+
+
 def test_knowledge_index_help_includes_expected_arguments(capsys):
     from openclaw_pipeline.commands.knowledge_index import main
 

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -5,6 +5,8 @@ import json
 from pathlib import Path
 import sqlite3
 
+import pytest
+
 from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
 
 
@@ -144,6 +146,24 @@ def test_truth_api_avoids_datetime_utc_import_for_python_310_compatibility():
     assert "from datetime import UTC" not in source
     assert "datetime.now(UTC)" not in source
     assert "datetime.UTC" not in source
+
+
+def test_truth_store_schema_requires_explicit_pack():
+    from openclaw_pipeline.truth_store import TRUTH_STORE_SCHEMA
+
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.executescript(TRUTH_STORE_SCHEMA)
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                """
+                INSERT INTO objects (object_id, object_kind, title, canonical_path, source_slug)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                ("alpha", "evergreen", "Alpha", "10-Knowledge/Evergreen/Alpha.md", "alpha"),
+            )
+    finally:
+        conn.close()
 
 
 def test_truth_api_reads_review_actions_from_jsonl_without_knowledge_db(temp_vault):

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from contextlib import contextmanager
 import json
 from pathlib import Path
+import sqlite3
 
 from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
 
@@ -225,6 +226,90 @@ def test_truth_api_returns_object_detail_with_claims_relations_and_summary(temp_
     assert detail["relations"][0]["target_object_id"] == "target-note"
     assert detail["evidence"][0]["evidence_kind"] == "body_summary"
     assert detail["contradictions"][0]["subject_key"] == "agent harness"
+
+
+def test_truth_api_filters_truth_rows_by_pack_name(temp_vault):
+    from openclaw_pipeline.truth_api import get_object_detail, list_objects
+
+    vault = _seed_truth_vault(temp_vault)
+    db_path = vault / "60-Logs" / "knowledge.db"
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO objects (pack, object_id, object_kind, title, canonical_path, source_slug)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "default-knowledge",
+                "source-note",
+                "evergreen",
+                "Default Source Note",
+                "10-Knowledge/Evergreen/Source.md",
+                "source-note",
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO claims (pack, claim_id, object_id, claim_kind, claim_text, confidence)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "default-knowledge",
+                "source-note::default-pack",
+                "source-note",
+                "page_summary",
+                "Default-knowledge source summary.",
+                1.0,
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO compiled_summaries (pack, object_id, summary_text, source_slug)
+            VALUES (?, ?, ?, ?)
+            """,
+            (
+                "default-knowledge",
+                "source-note",
+                "Default-knowledge source summary.",
+                "source-note",
+            ),
+        )
+        conn.commit()
+
+    research_objects = list_objects(vault, pack_name="research-tech")
+    default_objects = list_objects(vault, pack_name="default-knowledge")
+    research_detail = get_object_detail(vault, "source-note", pack_name="research-tech")
+    default_detail = get_object_detail(vault, "source-note", pack_name="default-knowledge")
+
+    assert research_objects[1]["title"] == "Source Note"
+    assert default_objects == [
+        {
+            "object_id": "source-note",
+            "object_kind": "evergreen",
+            "title": "Default Source Note",
+            "canonical_path": "10-Knowledge/Evergreen/Source.md",
+            "source_slug": "source-note",
+            "pack": "default-knowledge",
+        }
+    ]
+    assert research_detail["object"]["title"] == "Source Note"
+    assert default_detail["object"]["title"] == "Default Source Note"
+    assert default_detail["summary"]["summary_text"] == "Default-knowledge source summary."
+
+
+def test_truth_api_lists_research_graph_clusters(temp_vault):
+    from openclaw_pipeline.truth_api import list_graph_clusters
+
+    vault = _seed_truth_vault(temp_vault)
+
+    clusters = list_graph_clusters(vault, pack_name="research-tech")
+
+    assert len(clusters) >= 1
+    assert clusters[0]["pack"] == "research-tech"
+    assert clusters[0]["cluster_kind"] == "relation_component"
+    assert "source-note" in clusters[0]["member_object_ids"]
+    assert "target-note" in clusters[0]["member_object_ids"]
 
 
 def test_truth_api_lists_contradictions(temp_vault):

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -312,6 +312,71 @@ def test_truth_api_lists_research_graph_clusters(temp_vault):
     assert "target-note" in clusters[0]["member_object_ids"]
 
 
+def test_truth_api_does_not_fallback_when_requested_pack_is_materialized(temp_vault, monkeypatch):
+    from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
+    from openclaw_pipeline.truth_api import get_object_detail, list_graph_clusters, list_objects
+    from openclaw_pipeline.truth_store import TruthStoreProjection
+
+    vault = _seed_truth_vault(temp_vault)
+
+    class Spec:
+        pack = "research-tech"
+        name = "research-tech-default"
+
+    def fake_execute_truth_projection_builder(*, vault_dir, page_rows, link_rows, pack_name=None):
+        assert vault_dir == vault
+        assert pack_name == "default-knowledge"
+        return (
+            Spec(),
+            TruthStoreProjection(
+                objects=[
+                    (
+                        "default-knowledge",
+                        "source-note",
+                        "evergreen",
+                        "Default Source Note",
+                        "10-Knowledge/Evergreen/Source.md",
+                        "source-note",
+                    )
+                ],
+                claims=[],
+                claim_evidence=[],
+                relations=[],
+                compiled_summaries=[],
+                contradictions=[],
+                graph_edges=[],
+                graph_clusters=[],
+            ),
+        )
+
+    monkeypatch.setattr(
+        "openclaw_pipeline.knowledge_index.execute_truth_projection_builder",
+        fake_execute_truth_projection_builder,
+    )
+
+    rebuild_knowledge_index(vault, pack_name="default-knowledge")
+
+    research_clusters = list_graph_clusters(vault, pack_name="research-tech")
+    default_clusters = list_graph_clusters(vault, pack_name="default-knowledge")
+    default_objects = list_objects(vault, pack_name="default-knowledge")
+    default_detail = get_object_detail(vault, "source-note", pack_name="default-knowledge")
+
+    assert research_clusters
+    assert default_clusters == []
+    assert default_objects == [
+        {
+            "object_id": "source-note",
+            "object_kind": "evergreen",
+            "title": "Default Source Note",
+            "canonical_path": "10-Knowledge/Evergreen/Source.md",
+            "source_slug": "source-note",
+            "pack": "default-knowledge",
+        }
+    ]
+    assert default_detail["object"]["title"] == "Default Source Note"
+    assert default_detail["object"]["pack"] == "default-knowledge"
+
+
 def test_truth_api_lists_contradictions(temp_vault):
     from openclaw_pipeline.truth_api import list_contradictions
 

--- a/tests/test_truth_api_command.py
+++ b/tests/test_truth_api_command.py
@@ -122,6 +122,19 @@ def test_truth_api_command_lists_graph_clusters(temp_vault, capsys):
     assert "alpha" in payload["items"][0]["member_object_ids"]
 
 
+def test_truth_api_command_lists_graph_clusters_for_requested_pack(temp_vault, capsys):
+    from openclaw_pipeline.commands.truth_api import main
+
+    _seed_truth_store(temp_vault)
+
+    exit_code = main(["clusters", "--vault-dir", str(temp_vault), "--pack", "default-knowledge"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["items"]
+    assert all(item["pack"] == "default-knowledge" for item in payload["items"])
+
+
 def test_truth_api_command_returns_graph_cluster_detail(temp_vault, capsys):
     from openclaw_pipeline.commands.truth_api import main
     from openclaw_pipeline.truth_api import list_graph_clusters

--- a/tests/test_truth_api_command.py
+++ b/tests/test_truth_api_command.py
@@ -108,6 +108,20 @@ def test_truth_api_command_lists_contradictions(temp_vault, capsys):
     assert payload["items"][0]["subject_key"] == "alpha"
 
 
+def test_truth_api_command_lists_graph_clusters(temp_vault, capsys):
+    from openclaw_pipeline.commands.truth_api import main
+
+    _seed_truth_store(temp_vault)
+
+    exit_code = main(["clusters", "--vault-dir", str(temp_vault)])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert len(payload["items"]) >= 1
+    assert payload["items"][0]["cluster_kind"] == "relation_component"
+    assert "alpha" in payload["items"][0]["member_object_ids"]
+
+
 def test_truth_api_command_filters_contradictions_by_query(temp_vault, capsys):
     from openclaw_pipeline.commands.truth_api import main
 

--- a/tests/test_truth_api_command.py
+++ b/tests/test_truth_api_command.py
@@ -122,6 +122,34 @@ def test_truth_api_command_lists_graph_clusters(temp_vault, capsys):
     assert "alpha" in payload["items"][0]["member_object_ids"]
 
 
+def test_truth_api_command_returns_graph_cluster_detail(temp_vault, capsys):
+    from openclaw_pipeline.commands.truth_api import main
+    from openclaw_pipeline.truth_api import list_graph_clusters
+
+    _seed_truth_store(temp_vault)
+    cluster = list_graph_clusters(temp_vault)[0]
+
+    exit_code = main(
+        [
+            "cluster",
+            "--vault-dir",
+            str(temp_vault),
+            "--id",
+            cluster["cluster_id"],
+            "--pack",
+            cluster["pack"],
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["cluster"]["cluster_id"] == cluster["cluster_id"]
+    assert payload["cluster"]["pack"] == cluster["pack"]
+    assert payload["edges"]
+    assert payload["edges"][0]["source_object_id"]
+    assert payload["edges"][0]["target_object_id"]
+
+
 def test_truth_api_command_filters_contradictions_by_query(temp_vault, capsys):
     from openclaw_pipeline.commands.truth_api import main
 

--- a/tests/test_truth_projection_registry.py
+++ b/tests/test_truth_projection_registry.py
@@ -34,3 +34,31 @@ def test_compatibility_pack_falls_back_to_base_truth_projection_builder(monkeypa
 
     assert spec.pack == "base-pack"
     assert spec.entrypoint == "tests.fake_truth_projection:build"
+
+
+def test_execute_truth_projection_builder_namespaces_rows_to_requested_pack(temp_vault):
+    from openclaw_pipeline.truth_projection_registry import execute_truth_projection_builder
+
+    page_rows = [
+        (
+            "source-note",
+            "Source Note",
+            "evergreen",
+            str(temp_vault / "10-Knowledge" / "Evergreen" / "Source.md"),
+            "2026-04-15",
+            "{}",
+            "Source body.",
+        )
+    ]
+
+    spec, projection = execute_truth_projection_builder(
+        vault_dir=temp_vault,
+        page_rows=page_rows,
+        link_rows=[],
+        pack_name="default-knowledge",
+    )
+
+    assert spec.pack == "research-tech"
+    assert projection.objects[0][0] == "default-knowledge"
+    assert projection.claims[0][0] == "default-knowledge"
+    assert projection.compiled_summaries[0][0] == "default-knowledge"

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -506,6 +506,8 @@ date: 2026-04-13
     assert item["top_reading_route_kind"] == "full_context_route"
     assert item["top_reading_route_title"]
     assert item["has_reading_route"] is True
+    assert item["reading_intent_count"] >= 1
+    assert "Full Context Route" in item["reading_intent_preview"]
 
 
 def test_ui_server_can_accept_evolution_candidate_via_api(temp_vault):

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -492,6 +492,8 @@ date: 2026-04-13
     assert response.status == 200
     assert item["related_cluster_count"] >= 1
     assert item["related_cluster_preview"]
+    assert item["neighborhood_score"] > 0
+    assert item["neighborhood_reason"]
 
 
 def test_ui_server_can_accept_evolution_candidate_via_api(temp_vault):

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -405,6 +405,8 @@ date: 2026-04-13
     assert payload["related_clusters"]
     assert payload["related_clusters"][0]["shared_source_count"] >= 1
     assert payload["related_clusters"][0]["shared_moc_count"] >= 1
+    assert payload["related_cluster_groups"]
+    assert payload["related_cluster_groups"][0]["bridge_kind"] == "source_and_atlas_overlap"
 
 
 def test_ui_server_clusters_endpoint_includes_related_cluster_summary(temp_vault):

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -409,6 +409,8 @@ date: 2026-04-13
     assert payload["related_cluster_groups"][0]["bridge_kind"] == "source_and_atlas_overlap"
     assert payload["reading_routes"]
     assert payload["reading_routes"][0]["route_kind"] == "full_context_route"
+    assert payload["reading_routes"][0]["route_rank"] == 1
+    assert payload["reading_routes"][0]["route_reason"]
 
 
 def test_ui_server_clusters_endpoint_includes_related_cluster_summary(temp_vault):

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -505,6 +505,7 @@ date: 2026-04-13
     assert item["next_read_path"].startswith("/cluster?id=")
     assert item["top_reading_route_kind"] == "full_context_route"
     assert item["top_reading_route_title"]
+    assert item["has_reading_route"] is True
 
 
 def test_ui_server_can_accept_evolution_candidate_via_api(temp_vault):

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -407,6 +407,8 @@ date: 2026-04-13
     assert payload["related_clusters"][0]["shared_moc_count"] >= 1
     assert payload["related_cluster_groups"]
     assert payload["related_cluster_groups"][0]["bridge_kind"] == "source_and_atlas_overlap"
+    assert payload["reading_routes"]
+    assert payload["reading_routes"][0]["route_kind"] == "full_context_route"
 
 
 def test_ui_server_clusters_endpoint_includes_related_cluster_summary(temp_vault):

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -314,6 +314,99 @@ def test_ui_server_cluster_detail_endpoint_returns_payload(temp_vault):
     assert payload["stale_summaries"]
 
 
+def test_ui_server_cluster_detail_endpoint_includes_related_clusters(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+    from openclaw_pipeline.truth_api import list_graph_clusters
+
+    _seed_truth_store(temp_vault)
+    gamma = temp_vault / "10-Knowledge" / "Evergreen" / "Gamma.md"
+    delta = temp_vault / "10-Knowledge" / "Evergreen" / "Delta.md"
+    gamma.write_text(
+        """---
+note_id: gamma
+title: Gamma
+type: evergreen
+date: 2026-04-13
+---
+
+# Gamma
+
+Gamma links to [[delta]].
+""",
+        encoding="utf-8",
+    )
+    delta.write_text(
+        """---
+note_id: delta
+title: Delta
+type: evergreen
+date: 2026-04-13
+---
+
+# Delta
+""",
+        encoding="utf-8",
+    )
+    shared_source = temp_vault / "20-Areas" / "Tools" / "Topics" / "2026-04" / "Shared Deep Dive_深度解读.md"
+    shared_source.parent.mkdir(parents=True, exist_ok=True)
+    shared_source.write_text(
+        """---
+note_id: shared-deep-dive
+title: Shared Deep Dive
+type: deep_dive
+date: 2026-04-13
+---
+
+# Shared Deep Dive
+
+Mentions [[alpha]], [[beta]], [[gamma]], and [[delta]].
+""",
+        encoding="utf-8",
+    )
+    atlas = temp_vault / "10-Knowledge" / "Atlas" / "Shared-Atlas.md"
+    atlas.write_text(
+        """---
+note_id: shared-atlas
+title: Shared Atlas
+type: moc
+date: 2026-04-13
+---
+
+# Shared Atlas
+
+- [[alpha]]
+- [[beta]]
+- [[gamma]]
+- [[delta]]
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+    cluster = next(
+        item
+        for item in list_graph_clusters(temp_vault)
+        if "alpha" in {member["object_id"] for member in item["members"]}
+    )
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("GET", f"/api/cluster?id={cluster['cluster_id']}&pack={cluster['pack']}")
+        response = conn.getresponse()
+        payload = json.loads(response.read().decode("utf-8"))
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 200
+    assert payload["related_clusters"]
+    assert payload["related_clusters"][0]["shared_source_count"] >= 1
+    assert payload["related_clusters"][0]["shared_moc_count"] >= 1
+
+
 def test_ui_server_can_accept_evolution_candidate_via_api(temp_vault):
     from openclaw_pipeline.commands.ui_server import create_server
     from openclaw_pipeline.truth_api import list_evolution_candidates

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -276,6 +276,33 @@ def test_ui_server_clusters_endpoint_returns_payload(temp_vault):
     assert payload["items"][0]["cluster_kind"] == "relation_component"
 
 
+def test_ui_server_cluster_detail_endpoint_returns_payload(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+    from openclaw_pipeline.truth_api import list_graph_clusters
+
+    _seed_truth_store(temp_vault)
+    cluster = list_graph_clusters(temp_vault)[0]
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("GET", f"/api/cluster?id={cluster['cluster_id']}&pack={cluster['pack']}")
+        response = conn.getresponse()
+        payload = json.loads(response.read().decode("utf-8"))
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 200
+    assert payload["screen"] == "graph/cluster-detail"
+    assert payload["cluster"]["cluster_id"] == cluster["cluster_id"]
+    assert payload["cluster"]["pack"] == cluster["pack"]
+    assert payload["edges"]
+
+
 def test_ui_server_can_accept_evolution_candidate_via_api(temp_vault):
     from openclaw_pipeline.commands.ui_server import create_server
     from openclaw_pipeline.truth_api import list_evolution_candidates

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -413,6 +413,30 @@ date: 2026-04-13
     assert payload["reading_routes"][0]["route_reason"]
 
 
+def test_ui_server_cluster_detail_page_shows_canonical_cluster_id(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+    from openclaw_pipeline.truth_api import list_graph_clusters
+
+    _seed_truth_store(temp_vault)
+    cluster = list_graph_clusters(temp_vault)[0]
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("GET", f"/cluster?id={cluster['cluster_id']}&pack={cluster['pack']}")
+        response = conn.getresponse()
+        body = response.read().decode("utf-8")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 200
+    assert f"Canonical cluster id: {cluster['cluster_id']}" in body
+
+
 def test_ui_server_clusters_endpoint_includes_related_cluster_summary(temp_vault):
     from openclaw_pipeline.commands.ui_server import create_server
 

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -301,6 +301,7 @@ def test_ui_server_cluster_detail_endpoint_returns_payload(temp_vault):
     assert payload["cluster"]["cluster_id"] == cluster["cluster_id"]
     assert payload["cluster"]["pack"] == cluster["pack"]
     assert payload["edges"]
+    assert payload["summary_bullets"]
 
 
 def test_ui_server_can_accept_evolution_candidate_via_api(temp_vault):

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -274,6 +274,8 @@ def test_ui_server_clusters_endpoint_returns_payload(temp_vault):
     assert payload["screen"] == "graph/clusters"
     assert payload["count"] >= 1
     assert payload["items"][0]["cluster_kind"] == "relation_component"
+    assert payload["items"][0]["priority_band"]
+    assert payload["items"][0]["priority_reason"]
 
 
 def test_ui_server_cluster_detail_endpoint_returns_payload(temp_vault):

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -262,7 +262,7 @@ def test_ui_server_clusters_endpoint_returns_payload(temp_vault):
     thread.start()
     try:
         conn = HTTPConnection("127.0.0.1", port, timeout=5)
-        conn.request("GET", "/api/clusters")
+        conn.request("GET", "/api/clusters?pack=default-knowledge")
         response = conn.getresponse()
         payload = json.loads(response.read().decode("utf-8"))
     finally:
@@ -272,6 +272,7 @@ def test_ui_server_clusters_endpoint_returns_payload(temp_vault):
 
     assert response.status == 200
     assert payload["screen"] == "graph/clusters"
+    assert payload["requested_pack"] == "default-knowledge"
     assert payload["count"] >= 1
     assert payload["items"][0]["cluster_kind"] == "relation_component"
     assert payload["items"][0]["priority_band"]
@@ -304,6 +305,7 @@ def test_ui_server_cluster_detail_endpoint_returns_payload(temp_vault):
     assert payload["screen"] == "graph/cluster-detail"
     assert payload["cluster"]["cluster_id"] == cluster["cluster_id"]
     assert payload["cluster"]["pack"] == cluster["pack"]
+    assert payload["browser_path"].startswith("/clusters?pack=")
     assert payload["edges"]
     assert payload["summary_bullets"]
     assert payload["structural_label"]["title"]

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -494,6 +494,7 @@ date: 2026-04-13
     assert item["related_cluster_preview"]
     assert item["neighborhood_score"] > 0
     assert item["neighborhood_reason"]
+    assert item["neighborhood_bridge_kind"] == "source_and_atlas_overlap"
     assert item["next_read_title"]
     assert item["next_read_path"].startswith("/cluster?id=")
 

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -407,6 +407,93 @@ date: 2026-04-13
     assert payload["related_clusters"][0]["shared_moc_count"] >= 1
 
 
+def test_ui_server_clusters_endpoint_includes_related_cluster_summary(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+
+    _seed_truth_store(temp_vault)
+    gamma = temp_vault / "10-Knowledge" / "Evergreen" / "Gamma.md"
+    delta = temp_vault / "10-Knowledge" / "Evergreen" / "Delta.md"
+    gamma.write_text(
+        """---
+note_id: gamma
+title: Gamma
+type: evergreen
+date: 2026-04-13
+---
+
+# Gamma
+
+Gamma links to [[delta]].
+""",
+        encoding="utf-8",
+    )
+    delta.write_text(
+        """---
+note_id: delta
+title: Delta
+type: evergreen
+date: 2026-04-13
+---
+
+# Delta
+""",
+        encoding="utf-8",
+    )
+    shared_source = temp_vault / "20-Areas" / "Tools" / "Topics" / "2026-04" / "Shared Deep Dive_深度解读.md"
+    shared_source.parent.mkdir(parents=True, exist_ok=True)
+    shared_source.write_text(
+        """---
+note_id: shared-deep-dive
+title: Shared Deep Dive
+type: deep_dive
+date: 2026-04-13
+---
+
+# Shared Deep Dive
+
+Mentions [[alpha]], [[beta]], [[gamma]], and [[delta]].
+""",
+        encoding="utf-8",
+    )
+    shared_atlas = temp_vault / "10-Knowledge" / "Atlas" / "Shared-Atlas.md"
+    shared_atlas.write_text(
+        """---
+note_id: shared-atlas
+title: Shared Atlas
+type: moc
+date: 2026-04-13
+---
+
+# Shared Atlas
+
+- [[alpha]]
+- [[beta]]
+- [[gamma]]
+- [[delta]]
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("GET", "/api/clusters")
+        response = conn.getresponse()
+        payload = json.loads(response.read().decode("utf-8"))
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    item = next(entry for entry in payload["items"] if "alpha" in entry["member_object_ids"])
+    assert response.status == 200
+    assert item["related_cluster_count"] >= 1
+    assert item["related_cluster_preview"]
+
+
 def test_ui_server_can_accept_evolution_candidate_via_api(temp_vault):
     from openclaw_pipeline.commands.ui_server import create_server
     from openclaw_pipeline.truth_api import list_evolution_candidates

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -252,6 +252,30 @@ def test_ui_server_evolution_endpoint_returns_payload(temp_vault):
     assert payload["count"] >= 1
 
 
+def test_ui_server_clusters_endpoint_returns_payload(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+
+    _seed_truth_store(temp_vault)
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("GET", "/api/clusters")
+        response = conn.getresponse()
+        payload = json.loads(response.read().decode("utf-8"))
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 200
+    assert payload["screen"] == "graph/clusters"
+    assert payload["count"] >= 1
+    assert payload["items"][0]["cluster_kind"] == "relation_component"
+
+
 def test_ui_server_can_accept_evolution_candidate_via_api(temp_vault):
     from openclaw_pipeline.commands.ui_server import create_server
     from openclaw_pipeline.truth_api import list_evolution_candidates

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -503,6 +503,8 @@ date: 2026-04-13
     assert item["neighborhood_bridge_kind"] == "source_and_atlas_overlap"
     assert item["next_read_title"]
     assert item["next_read_path"].startswith("/cluster?id=")
+    assert item["top_reading_route_kind"] == "full_context_route"
+    assert item["top_reading_route_title"]
 
 
 def test_ui_server_can_accept_evolution_candidate_via_api(temp_vault):

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -276,6 +276,8 @@ def test_ui_server_clusters_endpoint_returns_payload(temp_vault):
     assert payload["items"][0]["cluster_kind"] == "relation_component"
     assert payload["items"][0]["priority_band"]
     assert payload["items"][0]["priority_reason"]
+    assert payload["items"][0]["display_title"]
+    assert payload["items"][0]["relation_pattern_preview"]
 
 
 def test_ui_server_cluster_detail_endpoint_returns_payload(temp_vault):
@@ -304,6 +306,8 @@ def test_ui_server_cluster_detail_endpoint_returns_payload(temp_vault):
     assert payload["cluster"]["pack"] == cluster["pack"]
     assert payload["edges"]
     assert payload["summary_bullets"]
+    assert payload["structural_label"]["title"]
+    assert payload["relation_pattern_items"]
 
 
 def test_ui_server_can_accept_evolution_candidate_via_api(temp_vault):

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -494,6 +494,8 @@ date: 2026-04-13
     assert item["related_cluster_preview"]
     assert item["neighborhood_score"] > 0
     assert item["neighborhood_reason"]
+    assert item["next_read_title"]
+    assert item["next_read_path"].startswith("/cluster?id=")
 
 
 def test_ui_server_can_accept_evolution_candidate_via_api(temp_vault):

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -310,6 +310,8 @@ def test_ui_server_cluster_detail_endpoint_returns_payload(temp_vault):
     assert payload["summary_bullets"]
     assert payload["structural_label"]["title"]
     assert payload["relation_pattern_items"]
+    assert payload["open_contradictions"]
+    assert payload["stale_summaries"]
 
 
 def test_ui_server_can_accept_evolution_candidate_via_api(temp_vault):

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -585,6 +585,9 @@ date: 2026-04-13
     assert payload["next_read_cluster"]["detail_path"] == payload["related_clusters"][0]["detail_path"]
     assert payload["next_read_cluster"]["display_title"]
     assert payload["next_read_cluster"]["bridge_kind"] == "source_and_atlas_overlap"
+    assert payload["related_cluster_groups"]
+    assert payload["related_cluster_groups"][0]["bridge_kind"] == "source_and_atlas_overlap"
+    assert payload["related_cluster_groups"][0]["count"] >= 1
 
 
 def test_build_event_dossier_payload_includes_provenance(temp_vault):

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -258,6 +258,21 @@ def test_build_event_dossier_payload(temp_vault):
     assert payload["scoped_open_contradiction_ids"]
 
 
+def test_build_cluster_browser_payload(temp_vault):
+    from openclaw_pipeline.ui.view_models import build_cluster_browser_payload
+
+    _seed_truth_store(temp_vault)
+
+    payload = build_cluster_browser_payload(temp_vault)
+
+    assert payload["screen"] == "graph/clusters"
+    assert payload["count"] >= 1
+    assert payload["cluster_kind_counts"] == {"relation_component": payload["count"]}
+    assert payload["items"][0]["center_object_path"].startswith("/object?id=")
+    assert payload["items"][0]["member_count"] >= 2
+    assert payload["items"][0]["members"][0]["object_id"]
+
+
 def test_build_event_dossier_payload_includes_provenance(temp_vault):
     from openclaw_pipeline.ui.view_models import build_event_dossier_payload
 

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -434,6 +434,7 @@ date: 2026-04-13
     assert item["top_reading_route_kind"] == "full_context_route"
     assert item["top_reading_route_title"]
     assert item["top_reading_route_reason"]
+    assert item["has_reading_route"] is True
 
 
 def test_build_cluster_detail_payload(temp_vault):

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -311,6 +311,47 @@ Delta extends Gamma.
     assert "alpha" in payload["items"][0]["member_object_ids"]
 
 
+def test_build_cluster_browser_payload_respects_requested_pack(temp_vault):
+    from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
+    from openclaw_pipeline.ui.view_models import build_cluster_browser_payload
+
+    source = temp_vault / "10-Knowledge" / "Evergreen" / "Source.md"
+    target = temp_vault / "10-Knowledge" / "Evergreen" / "Target.md"
+    source.write_text(
+        """---
+note_id: source-note
+title: Source Note
+type: evergreen
+date: 2026-04-10
+---
+
+# Source Note
+
+Links to [[target-note]].
+""",
+        encoding="utf-8",
+    )
+    target.write_text(
+        """---
+note_id: target-note
+title: Target Note
+type: evergreen
+date: 2026-04-10
+---
+
+# Target Note
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    payload = build_cluster_browser_payload(temp_vault, pack_name="default-knowledge")
+
+    assert payload["requested_pack"] == "default-knowledge"
+    assert payload["items"]
+    assert all(item["pack"] == "default-knowledge" for item in payload["items"])
+
+
 def test_build_cluster_detail_payload(temp_vault):
     from openclaw_pipeline.truth_api import list_graph_clusters
     from openclaw_pipeline.ui.view_models import build_cluster_detail_payload
@@ -355,6 +396,7 @@ date: 2026-04-13
     assert payload["screen"] == "graph/cluster-detail"
     assert payload["cluster"]["cluster_id"] == cluster["cluster_id"]
     assert payload["cluster"]["detail_path"].startswith("/cluster?id=")
+    assert "pack=" in payload["browser_path"]
     assert payload["cluster"]["center_object_path"].startswith("/object?id=")
     assert payload["cluster"]["member_links"][0]["path"].startswith("/object?id=")
     assert payload["edges"]

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -259,18 +259,54 @@ def test_build_event_dossier_payload(temp_vault):
 
 
 def test_build_cluster_browser_payload(temp_vault):
+    from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
     from openclaw_pipeline.ui.view_models import build_cluster_browser_payload
 
     _seed_truth_store(temp_vault)
+    gamma = temp_vault / "10-Knowledge" / "Evergreen" / "Gamma.md"
+    delta = temp_vault / "10-Knowledge" / "Evergreen" / "Delta.md"
+    gamma.write_text(
+        """---
+note_id: gamma
+title: Gamma
+type: evergreen
+date: 2026-04-13
+---
+
+# Gamma
+
+Links to [[delta]].
+""",
+        encoding="utf-8",
+    )
+    delta.write_text(
+        """---
+note_id: delta
+title: Delta
+type: evergreen
+date: 2026-04-13
+---
+
+# Delta
+
+Delta extends Gamma.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
 
     payload = build_cluster_browser_payload(temp_vault)
 
     assert payload["screen"] == "graph/clusters"
-    assert payload["count"] >= 1
+    assert payload["count"] >= 2
     assert payload["cluster_kind_counts"] == {"relation_component": payload["count"]}
     assert payload["items"][0]["center_object_path"].startswith("/object?id=")
     assert payload["items"][0]["member_count"] >= 2
     assert payload["items"][0]["members"][0]["object_id"]
+    assert payload["items"][0]["priority_band"] == "attention"
+    assert payload["items"][0]["priority_reason"]
+    assert payload["items"][0]["priority_score"] > payload["items"][1]["priority_score"]
+    assert "alpha" in payload["items"][0]["member_object_ids"]
 
 
 def test_build_cluster_detail_payload(temp_vault):

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -439,6 +439,21 @@ date: 2026-04-13
     assert "Full Context Route" in item["reading_intent_preview"]
 
 
+def test_build_cluster_browser_payload_does_not_call_full_detail_builder(temp_vault, monkeypatch):
+    from openclaw_pipeline.ui import view_models
+
+    _seed_truth_store(temp_vault)
+
+    def _explode(*args, **kwargs):
+        raise AssertionError("cluster browser should not call full detail builder")
+
+    monkeypatch.setattr(view_models, "build_cluster_detail_payload", _explode)
+
+    payload = view_models.build_cluster_browser_payload(temp_vault)
+
+    assert payload["items"]
+
+
 def test_build_cluster_detail_payload(temp_vault):
     from openclaw_pipeline.truth_api import list_graph_clusters
     from openclaw_pipeline.ui.view_models import build_cluster_detail_payload
@@ -503,6 +518,49 @@ date: 2026-04-13
     assert payload["stale_summaries"]
     assert payload["top_source_notes"][0]["slug"] == "source-deep-dive"
     assert payload["top_mocs"][0]["slug"] == "atlas-index"
+
+
+def test_build_cluster_detail_payload_filters_relevant_contradictions_before_slicing(
+    temp_vault,
+    monkeypatch,
+):
+    from openclaw_pipeline.truth_api import list_graph_clusters
+    from openclaw_pipeline.ui import view_models
+
+    _seed_truth_store(temp_vault)
+    cluster = list_graph_clusters(temp_vault)[0]
+
+    relevant = {
+        "contradiction_id": "contradiction::relevant",
+        "subject_key": "alpha",
+        "positive_claim_ids": ["alpha::p"],
+        "negative_claim_ids": ["conflict::n"],
+    }
+    unrelated = [
+        {
+            "contradiction_id": f"contradiction::other::{index}",
+            "subject_key": f"other-{index}",
+            "positive_claim_ids": [f"other-{index}::p"],
+            "negative_claim_ids": [f"other-{index}::n"],
+        }
+        for index in range(20)
+    ]
+
+    def _fake_list_contradictions(_vault_dir, *, status=None, query=None, limit=100, **kwargs):
+        assert status == "open"
+        rows = [*unrelated, relevant]
+        return rows if limit is None else rows[:limit]
+
+    monkeypatch.setattr(view_models, "list_contradictions", _fake_list_contradictions)
+
+    payload = view_models.build_cluster_detail_payload(
+        temp_vault,
+        cluster_id=cluster["cluster_id"],
+        pack_name=cluster["pack"],
+    )
+
+    assert payload["open_contradictions"]
+    assert payload["open_contradictions"][0]["contradiction_id"] == "contradiction::relevant"
 
 
 def test_build_cluster_detail_payload_includes_related_clusters(temp_vault):

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -305,6 +305,8 @@ Delta extends Gamma.
     assert payload["items"][0]["members"][0]["object_id"]
     assert payload["items"][0]["priority_band"] == "attention"
     assert payload["items"][0]["priority_reason"]
+    assert payload["items"][0]["display_title"].startswith("Contradiction cluster around")
+    assert payload["items"][0]["relation_pattern_preview"]
     assert payload["items"][0]["priority_score"] > payload["items"][1]["priority_score"]
     assert "alpha" in payload["items"][0]["member_object_ids"]
 
@@ -362,6 +364,8 @@ date: 2026-04-13
     assert "Alpha" in payload["structural_label"]["title"]
     assert payload["edge_summary_items"]
     assert payload["edge_summary_items"][0]["edge_family"] == "contradiction"
+    assert payload["relation_pattern_items"]
+    assert payload["relation_pattern_items"][0]["display_name"].endswith("links")
     assert payload["summary_bullets"]
     assert payload["object_kind_counts"]["evergreen"] == payload["cluster"]["member_count"]
     assert payload["review_context"]["source_note_count"] >= 1

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -590,6 +590,9 @@ date: 2026-04-13
     assert payload["related_cluster_groups"][0]["count"] >= 1
     assert payload["reading_routes"]
     assert payload["reading_routes"][0]["route_kind"] == "full_context_route"
+    assert payload["reading_routes"][0]["route_rank"] == 1
+    assert payload["reading_routes"][0]["route_score"] >= payload["reading_routes"][-1]["route_score"]
+    assert payload["reading_routes"][0]["route_reason"]
     assert payload["reading_routes"][0]["detail_path"].startswith("/cluster?id=")
 
 

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -418,6 +418,89 @@ date: 2026-04-13
     assert payload["top_mocs"][0]["slug"] == "atlas-index"
 
 
+def test_build_cluster_detail_payload_includes_related_clusters(temp_vault):
+    from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
+    from openclaw_pipeline.truth_api import list_graph_clusters
+    from openclaw_pipeline.ui.view_models import build_cluster_detail_payload
+
+    _seed_truth_store(temp_vault)
+    gamma = temp_vault / "10-Knowledge" / "Evergreen" / "Gamma.md"
+    delta = temp_vault / "10-Knowledge" / "Evergreen" / "Delta.md"
+    gamma.write_text(
+        """---
+note_id: gamma
+title: Gamma
+type: evergreen
+date: 2026-04-13
+---
+
+# Gamma
+
+Gamma links to [[delta]].
+""",
+        encoding="utf-8",
+    )
+    delta.write_text(
+        """---
+note_id: delta
+title: Delta
+type: evergreen
+date: 2026-04-13
+---
+
+# Delta
+""",
+        encoding="utf-8",
+    )
+    source = temp_vault / "20-Areas" / "Tools" / "Topics" / "2026-04" / "Shared Deep Dive_深度解读.md"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text(
+        """---
+note_id: shared-deep-dive
+title: Shared Deep Dive
+type: deep_dive
+date: 2026-04-13
+---
+
+# Shared Deep Dive
+
+Mentions [[alpha]], [[beta]], [[gamma]], and [[delta]].
+""",
+        encoding="utf-8",
+    )
+    atlas = temp_vault / "10-Knowledge" / "Atlas" / "Shared-Atlas.md"
+    atlas.write_text(
+        """---
+note_id: shared-atlas
+title: Shared Atlas
+type: moc
+date: 2026-04-13
+---
+
+# Shared Atlas
+
+- [[alpha]]
+- [[beta]]
+- [[gamma]]
+- [[delta]]
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    cluster = next(
+        item
+        for item in list_graph_clusters(temp_vault)
+        if "alpha" in {member["object_id"] for member in item["members"]}
+    )
+    payload = build_cluster_detail_payload(temp_vault, cluster_id=cluster["cluster_id"], pack_name=cluster["pack"])
+
+    assert payload["related_clusters"]
+    assert payload["related_clusters"][0]["shared_source_count"] >= 1
+    assert payload["related_clusters"][0]["shared_moc_count"] >= 1
+    assert payload["related_clusters"][0]["detail_path"].startswith("/cluster?id=")
+
+
 def test_build_event_dossier_payload_includes_provenance(temp_vault):
     from openclaw_pipeline.ui.view_models import build_event_dossier_payload
 

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -588,6 +588,9 @@ date: 2026-04-13
     assert payload["related_cluster_groups"]
     assert payload["related_cluster_groups"][0]["bridge_kind"] == "source_and_atlas_overlap"
     assert payload["related_cluster_groups"][0]["count"] >= 1
+    assert payload["reading_routes"]
+    assert payload["reading_routes"][0]["route_kind"] == "full_context_route"
+    assert payload["reading_routes"][0]["detail_path"].startswith("/cluster?id=")
 
 
 def test_build_event_dossier_payload_includes_provenance(temp_vault):

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -428,6 +428,7 @@ date: 2026-04-13
     assert item["related_cluster_preview"]
     assert item["neighborhood_score"] > 0
     assert item["neighborhood_reason"]
+    assert item["neighborhood_bridge_kind"] == "source_and_atlas_overlap"
     assert item["next_read_title"]
     assert item["next_read_path"].startswith("/cluster?id=")
 
@@ -577,11 +578,13 @@ date: 2026-04-13
 
     assert payload["related_clusters"]
     assert payload["related_clusters"][0]["bridge_band"]
+    assert payload["related_clusters"][0]["bridge_kind"] == "source_and_atlas_overlap"
     assert payload["related_clusters"][0]["shared_source_count"] >= 1
     assert payload["related_clusters"][0]["shared_moc_count"] >= 1
     assert payload["related_clusters"][0]["detail_path"].startswith("/cluster?id=")
     assert payload["next_read_cluster"]["detail_path"] == payload["related_clusters"][0]["detail_path"]
     assert payload["next_read_cluster"]["display_title"]
+    assert payload["next_read_cluster"]["bridge_kind"] == "source_and_atlas_overlap"
 
 
 def test_build_event_dossier_payload_includes_provenance(temp_vault):

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -435,6 +435,8 @@ date: 2026-04-13
     assert item["top_reading_route_title"]
     assert item["top_reading_route_reason"]
     assert item["has_reading_route"] is True
+    assert item["reading_intent_count"] >= 1
+    assert "Full Context Route" in item["reading_intent_preview"]
 
 
 def test_build_cluster_detail_payload(temp_vault):

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -273,6 +273,25 @@ def test_build_cluster_browser_payload(temp_vault):
     assert payload["items"][0]["members"][0]["object_id"]
 
 
+def test_build_cluster_detail_payload(temp_vault):
+    from openclaw_pipeline.truth_api import list_graph_clusters
+    from openclaw_pipeline.ui.view_models import build_cluster_detail_payload
+
+    _seed_truth_store(temp_vault)
+    cluster = list_graph_clusters(temp_vault)[0]
+
+    payload = build_cluster_detail_payload(temp_vault, cluster_id=cluster["cluster_id"], pack_name=cluster["pack"])
+
+    assert payload["screen"] == "graph/cluster-detail"
+    assert payload["cluster"]["cluster_id"] == cluster["cluster_id"]
+    assert payload["cluster"]["detail_path"].startswith("/cluster?id=")
+    assert payload["cluster"]["center_object_path"].startswith("/object?id=")
+    assert payload["cluster"]["member_links"][0]["path"].startswith("/object?id=")
+    assert payload["edges"]
+    assert payload["edges"][0]["source_path"].startswith("/object?id=")
+    assert payload["edges"][0]["target_path"].startswith("/object?id=")
+
+
 def test_build_event_dossier_payload_includes_provenance(temp_vault):
     from openclaw_pipeline.ui.view_models import build_event_dossier_payload
 

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -426,6 +426,8 @@ date: 2026-04-13
 
     assert item["related_cluster_count"] >= 1
     assert item["related_cluster_preview"]
+    assert item["neighborhood_score"] > 0
+    assert item["neighborhood_reason"]
 
 
 def test_build_cluster_detail_payload(temp_vault):
@@ -572,6 +574,7 @@ date: 2026-04-13
     payload = build_cluster_detail_payload(temp_vault, cluster_id=cluster["cluster_id"], pack_name=cluster["pack"])
 
     assert payload["related_clusters"]
+    assert payload["related_clusters"][0]["bridge_band"]
     assert payload["related_clusters"][0]["shared_source_count"] >= 1
     assert payload["related_clusters"][0]["shared_moc_count"] >= 1
     assert payload["related_clusters"][0]["detail_path"].startswith("/cluster?id=")

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -412,6 +412,8 @@ date: 2026-04-13
     assert payload["object_kind_counts"]["evergreen"] == payload["cluster"]["member_count"]
     assert payload["review_context"]["source_note_count"] >= 1
     assert payload["review_context"]["moc_count"] >= 1
+    assert payload["open_contradictions"]
+    assert payload["stale_summaries"]
     assert payload["top_source_notes"][0]["slug"] == "source-deep-dive"
     assert payload["top_mocs"][0]["slug"] == "atlas-index"
 

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -358,6 +358,10 @@ date: 2026-04-13
     assert payload["edges"]
     assert payload["edges"][0]["source_path"].startswith("/object?id=")
     assert payload["edges"][0]["target_path"].startswith("/object?id=")
+    assert payload["structural_label"]["kind"] == "contradiction_cluster"
+    assert "Alpha" in payload["structural_label"]["title"]
+    assert payload["edge_summary_items"]
+    assert payload["edge_summary_items"][0]["edge_family"] == "contradiction"
     assert payload["summary_bullets"]
     assert payload["object_kind_counts"]["evergreen"] == payload["cluster"]["member_count"]
     assert payload["review_context"]["source_note_count"] >= 1

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -431,6 +431,9 @@ date: 2026-04-13
     assert item["neighborhood_bridge_kind"] == "source_and_atlas_overlap"
     assert item["next_read_title"]
     assert item["next_read_path"].startswith("/cluster?id=")
+    assert item["top_reading_route_kind"] == "full_context_route"
+    assert item["top_reading_route_title"]
+    assert item["top_reading_route_reason"]
 
 
 def test_build_cluster_detail_payload(temp_vault):

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -352,6 +352,82 @@ date: 2026-04-10
     assert all(item["pack"] == "default-knowledge" for item in payload["items"])
 
 
+def test_build_cluster_browser_payload_includes_related_cluster_summary(temp_vault):
+    from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
+    from openclaw_pipeline.ui.view_models import build_cluster_browser_payload
+
+    _seed_truth_store(temp_vault)
+    gamma = temp_vault / "10-Knowledge" / "Evergreen" / "Gamma.md"
+    delta = temp_vault / "10-Knowledge" / "Evergreen" / "Delta.md"
+    gamma.write_text(
+        """---
+note_id: gamma
+title: Gamma
+type: evergreen
+date: 2026-04-13
+---
+
+# Gamma
+
+Gamma links to [[delta]].
+""",
+        encoding="utf-8",
+    )
+    delta.write_text(
+        """---
+note_id: delta
+title: Delta
+type: evergreen
+date: 2026-04-13
+---
+
+# Delta
+""",
+        encoding="utf-8",
+    )
+    shared_source = temp_vault / "20-Areas" / "Tools" / "Topics" / "2026-04" / "Shared Deep Dive_深度解读.md"
+    shared_source.parent.mkdir(parents=True, exist_ok=True)
+    shared_source.write_text(
+        """---
+note_id: shared-deep-dive
+title: Shared Deep Dive
+type: deep_dive
+date: 2026-04-13
+---
+
+# Shared Deep Dive
+
+Mentions [[alpha]], [[beta]], [[gamma]], and [[delta]].
+""",
+        encoding="utf-8",
+    )
+    shared_atlas = temp_vault / "10-Knowledge" / "Atlas" / "Shared-Atlas.md"
+    shared_atlas.write_text(
+        """---
+note_id: shared-atlas
+title: Shared Atlas
+type: moc
+date: 2026-04-13
+---
+
+# Shared Atlas
+
+- [[alpha]]
+- [[beta]]
+- [[gamma]]
+- [[delta]]
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    payload = build_cluster_browser_payload(temp_vault)
+    item = next(entry for entry in payload["items"] if "alpha" in entry["member_object_ids"])
+
+    assert item["related_cluster_count"] >= 1
+    assert item["related_cluster_preview"]
+
+
 def test_build_cluster_detail_payload(temp_vault):
     from openclaw_pipeline.truth_api import list_graph_clusters
     from openclaw_pipeline.ui.view_models import build_cluster_detail_payload

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -277,6 +277,38 @@ def test_build_cluster_detail_payload(temp_vault):
     from openclaw_pipeline.truth_api import list_graph_clusters
     from openclaw_pipeline.ui.view_models import build_cluster_detail_payload
 
+    source = temp_vault / "20-Areas" / "Tools" / "Topics" / "2026-04" / "Source Deep Dive_深度解读.md"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text(
+        """---
+note_id: source-deep-dive
+title: Source Deep Dive
+type: deep_dive
+date: 2026-04-13
+---
+
+# Source Deep Dive
+
+Mentions [[alpha]] and [[beta]].
+""",
+        encoding="utf-8",
+    )
+    atlas = temp_vault / "10-Knowledge" / "Atlas" / "Atlas-Index.md"
+    atlas.write_text(
+        """---
+note_id: atlas-index
+title: Atlas Index
+type: moc
+date: 2026-04-13
+---
+
+# Atlas Index
+
+- [[alpha]]
+- [[beta]]
+""",
+        encoding="utf-8",
+    )
     _seed_truth_store(temp_vault)
     cluster = list_graph_clusters(temp_vault)[0]
 
@@ -290,6 +322,12 @@ def test_build_cluster_detail_payload(temp_vault):
     assert payload["edges"]
     assert payload["edges"][0]["source_path"].startswith("/object?id=")
     assert payload["edges"][0]["target_path"].startswith("/object?id=")
+    assert payload["summary_bullets"]
+    assert payload["object_kind_counts"]["evergreen"] == payload["cluster"]["member_count"]
+    assert payload["review_context"]["source_note_count"] >= 1
+    assert payload["review_context"]["moc_count"] >= 1
+    assert payload["top_source_notes"][0]["slug"] == "source-deep-dive"
+    assert payload["top_mocs"][0]["slug"] == "atlas-index"
 
 
 def test_build_event_dossier_payload_includes_provenance(temp_vault):

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -428,6 +428,8 @@ date: 2026-04-13
     assert item["related_cluster_preview"]
     assert item["neighborhood_score"] > 0
     assert item["neighborhood_reason"]
+    assert item["next_read_title"]
+    assert item["next_read_path"].startswith("/cluster?id=")
 
 
 def test_build_cluster_detail_payload(temp_vault):
@@ -578,6 +580,8 @@ date: 2026-04-13
     assert payload["related_clusters"][0]["shared_source_count"] >= 1
     assert payload["related_clusters"][0]["shared_moc_count"] >= 1
     assert payload["related_clusters"][0]["detail_path"].startswith("/cluster?id=")
+    assert payload["next_read_cluster"]["detail_path"] == payload["related_clusters"][0]["detail_path"]
+    assert payload["next_read_cluster"]["display_title"]
 
 
 def test_build_event_dossier_payload_includes_provenance(temp_vault):


### PR DESCRIPTION
## Summary
- close out Phase 15 graph intelligence and synthesis with pack-aware cluster browsing, detail, crystal, neighborhood, and reading-route surfaces
- add deterministic cluster explainability layers including structural labels, relation patterns, bridge kinds, neighborhood groups, and route-aware browser prioritization
- record Phase 15 completion in the milestone plan and add a dedicated closeout document with explicit deferrals

## Test Plan
- `PYTHONPATH=src python3.13 -m pytest -q tests/test_truth_api.py tests/test_truth_api_command.py tests/test_build_views_command.py tests/test_ui_view_models.py tests/test_ui_server.py`
- `PYTHONPATH=src python3.13 -m pytest -q`
- `python3.13 -m compileall src/openclaw_pipeline`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/26" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Graph cluster browser—browse and search knowledge graph clusters with member details and relationship summaries.
  * Cluster detail pages—view comprehensive cluster analysis including edges, contradictions, summaries, and related clusters.
  * Multi-pack knowledge support—manage knowledge across multiple packs simultaneously without data overwrites.
  * New cluster API endpoints—access cluster browsing and detail views programmatically.

* **Documentation**
  * Phase 15 "Graph Intelligence And Synthesis" completed with phase closeout documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->