### PR TITLE
feat: expose pack contract metadata

### DIFF
--- a/docs/plans/2026-04-16-media-pack-phase16-contract-note.md
+++ b/docs/plans/2026-04-16-media-pack-phase16-contract-note.md
@@ -1,0 +1,106 @@
+# Media Pack: Phase 16 Contract Note
+
+Status: Active guidance
+
+## Why This Exists
+
+`Phase 16` is the platform-hardening pass after `Phase 15`.
+
+The goal is to let a pack such as media reuse:
+
+- queue and worker lifecycle
+- audit and rebuild discipline
+- local UI shell
+- derived SQLite container
+
+without patching core runtime modules.
+
+## What Media Pack Should Assume Now
+
+Media Pack should treat these as the supported pack-owned insertion points:
+
+1. `stage handlers`
+   - batch/profile execution
+   - autopilot stage execution
+   - focused queue actions
+
+2. `truth projection`
+   - `objects`
+   - `claims`
+   - `claim_evidence`
+   - `relations`
+   - `compiled_summaries`
+   - `contradictions`
+   - optional `graph_edges`
+   - optional `graph_clusters`
+
+3. `observation surfaces`
+   - `signals`
+   - `briefing`
+   - `production_chains`
+   - later domain-specific surfaces
+
+## What Media Pack Should Not Do
+
+Do not patch:
+
+- `knowledge_index.py`
+- `truth_api.py`
+- `ui_server.py`
+- queue worker internals
+
+Do not assume that media should inherit `research-tech` semantics such as:
+
+- evergreen-centric object meaning
+- current contradiction semantics
+- current event dossier semantics
+- current production-chain semantics
+
+Core owns the container, queue, audit, rebuild lifecycle, and UI shell.
+Media Pack should own domain meaning.
+
+## Compatibility Behavior
+
+Compatibility fallback is intentionally narrow.
+
+If a compatibility pack does **not** declare its own:
+
+- stage handlers
+- truth projection
+- observation surfaces
+
+then OVP may resolve those contracts from `compatibility_base`.
+
+Once a pack declares its own contract, OVP should treat that contract as authoritative.
+
+## What Phase 16 Will Tighten
+
+Phase 16 should make these rules more explicit, not less:
+
+1. execution dispatch resolves through pack-owned handlers
+2. truth projection resolves through pack-owned builders
+3. observation surfaces resolve through pack-owned builders
+4. core stops carrying `research-tech` defaults in disguise
+
+## Immediate Guidance For Media Pack
+
+If media work has already started:
+
+- keep pack code inside the media pack
+- implement pack-owned handlers instead of adding core branches
+- implement a media truth projection builder instead of reusing research object semantics
+- implement media observation surfaces only where media has real product meaning
+
+If media needs to inspect the current runtime contract, use:
+
+```bash
+PYTHONPATH=src python3.13 -m openclaw_pipeline.commands.doctor --pack <pack-name> --json
+```
+
+This now exposes:
+
+- declared handlers
+- effective handlers after compatibility fallback
+- declared truth projection
+- effective truth projection
+- declared/effective observation surfaces

--- a/src/openclaw_pipeline/commands/doctor.py
+++ b/src/openclaw_pipeline/commands/doctor.py
@@ -4,6 +4,7 @@ import argparse
 import json
 from pathlib import Path
 
+from ..pack_resolution import iter_compatible_packs
 from ..packs.loader import (
     DEFAULT_PACK_NAME,
     DEFAULT_WORKFLOW_PACK_NAME,
@@ -11,6 +12,7 @@ from ..packs.loader import (
     load_pack,
 )
 from ..runtime import VaultLayout, iter_markdown_files, resolve_vault_dir
+from ..truth_projection_registry import resolve_truth_projection_builder
 
 
 def _repo_root() -> Path:
@@ -69,6 +71,102 @@ def _vault_payload(vault_dir: Path | None) -> dict[str, object] | None:
     }
 
 
+def _stage_handler_payload(spec: object) -> dict[str, object]:
+    return {
+        "name": getattr(spec, "name", ""),
+        "pack": getattr(spec, "pack", ""),
+        "handler_kind": getattr(spec, "handler_kind", ""),
+        "runtime_adapter": getattr(spec, "runtime_adapter", ""),
+        "stage": getattr(spec, "stage", None),
+        "action_kind": getattr(spec, "action_kind", None),
+        "target_mode": getattr(spec, "target_mode", ""),
+        "supports_autopilot": bool(getattr(spec, "supports_autopilot", False)),
+        "safe_to_run": bool(getattr(spec, "safe_to_run", False)),
+        "requires_truth_refresh": bool(getattr(spec, "requires_truth_refresh", False)),
+        "requires_signal_resync": bool(getattr(spec, "requires_signal_resync", False)),
+        "entrypoint": getattr(spec, "entrypoint", ""),
+        "description": getattr(spec, "description", ""),
+    }
+
+
+def _truth_projection_payload(spec: object | None) -> dict[str, object] | None:
+    if spec is None:
+        return None
+    return {
+        "name": getattr(spec, "name", ""),
+        "pack": getattr(spec, "pack", ""),
+        "entrypoint": getattr(spec, "entrypoint", ""),
+        "description": getattr(spec, "description", ""),
+    }
+
+
+def _observation_surface_payload(spec: object) -> dict[str, object]:
+    return {
+        "name": getattr(spec, "name", ""),
+        "pack": getattr(spec, "pack", ""),
+        "surface_kind": getattr(spec, "surface_kind", ""),
+        "entrypoint": getattr(spec, "entrypoint", ""),
+        "description": getattr(spec, "description", ""),
+    }
+
+
+def _contracts_payload(pack_name: str) -> dict[str, object]:
+    pack = load_pack(pack_name)
+    compatible_packs = iter_compatible_packs(pack)
+    declared_stage_handlers = [_stage_handler_payload(spec) for spec in pack.stage_handlers()]
+    declared_truth_projection = _truth_projection_payload(pack.truth_projection())
+    declared_surfaces = [_observation_surface_payload(spec) for spec in pack.observation_surfaces()]
+
+    effective_stage_handlers: list[dict[str, object]] = []
+    seen_stage_keys: set[tuple[str, str, str]] = set()
+    for compatible_pack in compatible_packs:
+        for spec in compatible_pack.stage_handlers():
+            key = (
+                str(getattr(spec, "handler_kind", "")),
+                str(getattr(spec, "runtime_adapter", "")),
+                str(getattr(spec, "stage", "") or getattr(spec, "action_kind", "")),
+            )
+            if key in seen_stage_keys:
+                continue
+            seen_stage_keys.add(key)
+            effective_stage_handlers.append(_stage_handler_payload(spec))
+
+    effective_surfaces: list[dict[str, object]] = []
+    seen_surface_kinds: set[str] = set()
+    for compatible_pack in compatible_packs:
+        for spec in compatible_pack.observation_surfaces():
+            surface_kind = str(getattr(spec, "surface_kind", ""))
+            if surface_kind in seen_surface_kinds:
+                continue
+            seen_surface_kinds.add(surface_kind)
+            effective_surfaces.append(_observation_surface_payload(spec))
+
+    return {
+        "declared": {
+            "stage_handlers": declared_stage_handlers,
+            "truth_projection": declared_truth_projection,
+            "observation_surfaces": declared_surfaces,
+        },
+        "effective": {
+            "stage_handlers": effective_stage_handlers,
+            "truth_projection": _truth_projection_payload(
+                resolve_truth_projection_builder(pack_name=pack_name)
+            ),
+            "observation_surfaces": effective_surfaces,
+        },
+        "contract_notes": {
+            "compatibility_behavior": (
+                "Compatibility packs inherit stage handlers, truth projection, and observation "
+                "surfaces from compatibility_base only when they do not declare their own contract."
+            ),
+            "media_pack_guidance": (
+                "External packs should implement stage handlers, a truth projection builder, and "
+                "observation surfaces inside the pack rather than patching core runtime modules."
+            ),
+        },
+    }
+
+
 def _payload(pack_name: str, vault_dir: Path | None) -> dict[str, object]:
     repo_root = _repo_root()
     pack = load_pack(pack_name)
@@ -98,6 +196,7 @@ def _payload(pack_name: str, vault_dir: Path | None) -> dict[str, object]:
         },
         "docs": _docs_payload(repo_root, pack_name=pack_name),
         "vault": _vault_payload(vault_dir),
+        "contracts": _contracts_payload(pack_name),
     }
 
 

--- a/tests/test_doctor_command.py
+++ b/tests/test_doctor_command.py
@@ -18,6 +18,14 @@ def test_doctor_command_reports_primary_and_compatibility_roles(capsys):
     assert payload["pack"]["role"] == "primary"
     assert payload["docs"]["skillpack"]["exists"] is True
     assert payload["docs"]["verify"]["exists"] is True
+    assert payload["contracts"]["declared"]["truth_projection"]["pack"] == "research-tech"
+    assert any(
+        item["action_kind"] == "deep_dive_workflow"
+        for item in payload["contracts"]["effective"]["stage_handlers"]
+    )
+    assert {
+        item["surface_kind"] for item in payload["contracts"]["effective"]["observation_surfaces"]
+    } >= {"signals", "briefing", "production_chains"}
 
 
 def test_doctor_command_reports_compatibility_pack_metadata(capsys):
@@ -32,6 +40,13 @@ def test_doctor_command_reports_compatibility_pack_metadata(capsys):
     assert payload["pack"]["compatibility_base"] == "research-tech"
     assert payload["docs"]["skillpack"]["exists"] is False
     assert payload["docs"]["verify"]["exists"] is False
+    assert payload["contracts"]["declared"]["truth_projection"] is None
+    assert payload["contracts"]["effective"]["truth_projection"]["pack"] == "research-tech"
+    assert any(
+        item["runtime_adapter"] == "focused_action"
+        for item in payload["contracts"]["effective"]["stage_handlers"]
+    )
+    assert "compatibility packs inherit" in payload["contracts"]["contract_notes"]["compatibility_behavior"].lower()
 
 
 def test_doctor_command_reports_vault_health(temp_vault, capsys):


### PR DESCRIPTION
## Summary
- expose declared vs effective pack contracts in doctor output
- add media-pack Phase 16 contract note
- add coverage for compatibility/effective contract reporting

## Verification
- PYTHONPATH=src python3.13 -m pytest -q tests/test_doctor_command.py
- python3.13 -m compileall src/openclaw_pipeline

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/27" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Phase 16 media pack guidance document defining the phase as a post-Phase 15 platform-hardening pass. Specifies supported pack-owned insertion points including stage handlers, truth projection components, and observation surfaces. Documents explicit core module restrictions and compatibility inheritance rules.

* **New Features**
  * Enhanced doctor CLI command with new contract introspection capabilities. Displays declared and effective pack contracts including stage handlers, truth projections, and observation surfaces to support pack validation and ensure implementation compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->