### PR TITLE
feat: list external entrypoint packs

### DIFF
--- a/src/openclaw_pipeline/commands/list_packs.py
+++ b/src/openclaw_pipeline/commands/list_packs.py
@@ -41,13 +41,14 @@ def main(argv: list[str] | None = None) -> int:
         for pack in discover_entrypoint_packs().values()
         if pack.name not in builtin_names
     ]
+    entrypoint_names = {item["name"] for item in entrypoint}
 
     manifest_env = os.environ.get("OPENCLAW_PACK_MANIFESTS", "")
     manifest_paths = [Path(item) for item in manifest_env.split(os.pathsep) if item]
     manifests = []
     if manifest_paths:
         for manifest in discover_plugin_manifests(manifest_paths).values():
-            if manifest.name in builtin_names or any(item["name"] == manifest.name for item in entrypoint):
+            if manifest.name in builtin_names or manifest.name in entrypoint_names:
                 continue
             manifests.append(
                 {

--- a/src/openclaw_pipeline/commands/list_packs.py
+++ b/src/openclaw_pipeline/commands/list_packs.py
@@ -6,7 +6,7 @@ import os
 from pathlib import Path
 
 from ..packs.loader import list_builtin_packs
-from ..plugins import discover_plugin_manifests
+from ..plugins import discover_entrypoint_packs, discover_plugin_manifests
 
 
 def _serialize_pack(pack: object, *, source: str) -> dict[str, object]:
@@ -34,12 +34,21 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     builtin = [_serialize_pack(pack, source="builtin") for pack in list_builtin_packs()]
+    builtin_names = {item["name"] for item in builtin}
+
+    entrypoint = [
+        _serialize_pack(pack, source="entrypoint")
+        for pack in discover_entrypoint_packs().values()
+        if pack.name not in builtin_names
+    ]
 
     manifest_env = os.environ.get("OPENCLAW_PACK_MANIFESTS", "")
     manifest_paths = [Path(item) for item in manifest_env.split(os.pathsep) if item]
     manifests = []
     if manifest_paths:
         for manifest in discover_plugin_manifests(manifest_paths).values():
+            if manifest.name in builtin_names or any(item["name"] == manifest.name for item in entrypoint):
+                continue
             manifests.append(
                 {
                     "name": manifest.name,
@@ -53,7 +62,7 @@ def main(argv: list[str] | None = None) -> int:
                 }
             )
 
-    payload = {"builtin": builtin, "external": manifests}
+    payload = {"builtin": builtin, "external": entrypoint + manifests}
     if args.json:
         print(json.dumps(payload, ensure_ascii=False))
         return 0
@@ -63,6 +72,12 @@ def main(argv: list[str] | None = None) -> int:
         if item["compatibility_base"]:
             line += f" -> {item['compatibility_base']}"
         line += f" profiles={','.join(item['profiles'])}"
+        print(line)
+    for item in entrypoint:
+        line = f"{item['name']} [{item['role']}]"
+        if item["compatibility_base"]:
+            line += f" -> {item['compatibility_base']}"
+        line += f" profiles={','.join(item['profiles'])} source=entrypoint"
         print(line)
     for item in manifests:
         print(f"{item['name']} [external] manifest={item['manifest_path']}")

--- a/tests/test_list_packs_command.py
+++ b/tests/test_list_packs_command.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+from types import SimpleNamespace
 
 
 def test_list_packs_command_outputs_builtin_roles(capsys):
@@ -29,6 +30,31 @@ def test_list_packs_command_help_mentions_domain_packs(capsys):
     assert "domain packs" in output.lower()
 
 
+def test_list_packs_command_lists_entrypoint_packs(monkeypatch, capsys):
+    from openclaw_pipeline.commands import list_packs
+
+    class FakePack:
+        name = "media"
+        role = "domain"
+        compatibility_base = None
+        version = "0.1.0"
+        api_version = 1
+
+        @staticmethod
+        def workflow_profiles():
+            return [SimpleNamespace(name="daily-desk"), SimpleNamespace(name="feature-dossier")]
+
+    monkeypatch.setattr(list_packs, "discover_entrypoint_packs", lambda: {"media": FakePack()})
+
+    exit_code = list_packs.main(["--json"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    external = {item["name"]: item for item in payload["external"]}
+    assert external["media"]["source"] == "entrypoint"
+    assert external["media"]["profiles"] == ["daily-desk", "feature-dossier"]
+
+
 def test_list_packs_command_reads_manifest_paths_from_os_pathsep(tmp_path, monkeypatch, capsys):
     from openclaw_pipeline.commands.list_packs import main
 
@@ -53,6 +79,10 @@ entrypoints:
   pack: external.two:get_pack
 """.strip(),
         encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "openclaw_pipeline.commands.list_packs.discover_entrypoint_packs",
+        lambda: {},
     )
     monkeypatch.setenv("OPENCLAW_PACK_MANIFESTS", f"{first}{os.pathsep}{second}")
 


### PR DESCRIPTION
## Summary
- expose built-in and external entrypoint packs from the `list-packs` command
- include manifest-discovered external packs from `OPENCLAW_PACK_MANIFESTS`
- add coverage for built-in roles, entrypoint pack discovery, and manifest path parsing

## Validation
- `python3 -m py_compile src/openclaw_pipeline/commands/list_packs.py tests/test_list_packs_command.py`
- `uv run python - <<'PY' ... main(['--json']) ... PY`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/30" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
