### PR TITLE
[codex] phase19: add orientation entry products

### DIFF
--- a/docs/pack-api/README.md
+++ b/docs/pack-api/README.md
@@ -53,6 +53,7 @@ Pack 定义：
 - artifact families
 - assembly recipes
 - governance contracts
+- compiled page contracts and entry products
 - schema
 - discovery 规则
 - absorb / refine 规则
@@ -186,6 +187,7 @@ ovp-packs --json
 ```bash
 ovp-doctor --pack research-tech --json
 ovp-export --pack research-tech --target topic-overview --output-path /tmp/topic.md
+ovp-export --pack research-tech --target orientation-brief --output-path /tmp/orientation.json
 ```
 
 这些命令不是 Pack API 本身，但它们定义了 pack 在真实运行时应该具备的 operator surface：
@@ -210,6 +212,7 @@ ovp-export --pack research-tech --target topic-overview --output-path /tmp/topic
 
 同一套 assembly contract 现在也开始进入 UI access layer：
 
+- `/`
 - `object/page`
 - `overview/topic`
 - `event/dossier`
@@ -218,6 +221,21 @@ ovp-export --pack research-tech --target topic-overview --output-path /tmp/topic
 
 这些 payload 当前都会暴露 `assembly_contract`，shared shell 页面也会直接渲染 recipe provider、source contract、output mode。
 
+从 `Phase 19` 开始，pack 还需要把 access contract 花在真正的 entry products 上，而不只是“能导出一个页面”：
+
+- `/briefing` 现在应该被视为 orientation product，而不是 operator-only snapshot
+- `/` workbench home 现在应该回答：
+  - what changed recently
+  - what is important right now
+  - what deserves review
+  - what the system recommends next
+- object/topic/event/contradiction pages 现在应该暴露稳定的 `compiled_sections`
+  - `current_state`
+  - `why_it_matters`
+  - `evidence_traceability`
+  - `open_tensions`
+  - `where_to_go_next`
+
 `ovp-doctor` 现在也会展示同一条链：
 
 - recipe provider
@@ -225,6 +243,13 @@ ovp-export --pack research-tech --target topic-overview --output-path /tmp/topic
 - source contract provider
 
 对第三方 pack 来说，推荐优先提供 entry point；manifest 适合开发期和未安装场景。
+
+如果 pack 要支持 orientation-style entry products，推荐至少做到：
+
+- 声明一个 `orientation_brief` assembly recipe
+- 让 `ovp-export --target orientation-brief` 能导出编译后的 JSON 产物
+- 让 shared shell 的 `/briefing` 和 `/` 使用同一套 contract 解释自己
+- 让 compiled page payload 暴露稳定的 `compiled_sections` / `section_nav`
 
 ---
 

--- a/docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
+++ b/docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
@@ -499,32 +499,38 @@ The historical Phase 10 -> Phase 15 ordering below is now complete and should be
 
 Use the `Architecture follow-up` closeout above as completed platform history. Do not reopen it unless a new pack/runtime ownership bug appears.
 
-The next-step order after that closeout starts at the next product phase rather than repeating:
+The just-finished sequence was:
 
 1. `Phase 17`
 2. `Phase 18`
+3. `Phase 19`
 
-Reference plan:
+Completed references:
 
 - [[2026-04-16-phase17-research-graph-visualization-plan]]
 - [[2026-04-17-phase18-knowledge-compiler-contract-consolidation-plan]]
+- [[2026-04-17-phase19-orientation-and-compiled-knowledge-products]]
 
-Relationship between them:
+What those phases accomplished:
 
-- `Phase 17` is the graph-product follow-up on top of the completed graph substrate
-- `Phase 18` is the contract-consolidation follow-up that turns the current runtime pieces into explicit knowledge-compiler contracts
-  - current status: complete / ready to close
+- `Phase 17` made the research graph explorable as a real bounded product surface
+- `Phase 18` made the current runtime legible as explicit knowledge-compiler contracts
+- `Phase 19` turned those contracts into entry products: orientation brief, compiled-page sections, and a real workbench home
+
+What this sequence closed:
+
+- graph exploration is no longer the missing piece
+- contract boundaries are no longer the missing piece
+- orientation on entry is no longer the obvious missing piece
+- the current product surface now has a clearer default entry path and stronger compiled pages
 
 Sequence rule:
 
-- do not reopen `Phase 16` runtime hardening inside `Phase 17`
-- let `Phase 17` finish the graph exploration surface
-- then let `Phase 18` consolidate:
-  - artifact contracts
-  - assembly contracts
-  - governance contracts
+- do not reopen `Phase 17` graph-canvas internals unless a real product gap appears
+- do not reopen `Phase 18` contract plumbing unless a new contract family ambiguity appears
+- do not reopen `Phase 19` product-semantic work unless a new entry-surface/product-contract gap appears
 
-This keeps product exploration and architecture consolidation from getting mixed into one oversized phase.
+This keeps the roadmap moving from substrate -> contracts -> entry products, instead of looping back into infrastructure.
 
 Closeout:
 
@@ -544,7 +550,7 @@ Do **not** prioritize these before Milestones 3-5:
 
 Also do **not** treat every externally borrowed module as an immediate build track.
 
-Before `Phase 18` is complete, defer:
+After `Phase 19`, still defer:
 
 - full temporal truth modeling,
 - harness/session memory backends,

--- a/docs/plans/2026-04-17-phase19-orientation-and-compiled-knowledge-products.md
+++ b/docs/plans/2026-04-17-phase19-orientation-and-compiled-knowledge-products.md
@@ -1,0 +1,262 @@
+# Phase 19: Orientation And Compiled Knowledge Products
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Status:** complete / ready to close
+
+**Goal:** Turn the now-explicit knowledge-compiler contracts into user-facing entry products so OVP feels like an active knowledge system, not just a powerful local console.
+
+**Architecture:** `Phase 17` delivered graph exploration. `Phase 18` delivered explicit artifact, assembly, and governance contracts. `Phase 19` should spend those contracts on product semantics: better orientation, stronger compiled pages, and clearer “where do I go next?” loops. This phase should stay inside the existing `research-tech` pack and reuse the contract stack rather than opening new infrastructure tracks.
+
+**Tech Stack:** Existing `AssemblyRecipeSpec` / `GovernanceSpec`, `research-tech` assembly recipes, `ovp-ui`, `ovp-export`, `ui/view_models.py`, `ui_server.py`, pack-owned wiki views and observation surfaces.
+
+## Why This Is The Right Next Phase
+
+The current architecture is now in a good state:
+
+- graph exploration exists,
+- contract boundaries are explicit,
+- review and runtime provenance are visible,
+- export/UI/doctor all speak the same pack language.
+
+But the product still has a real gap:
+
+- a new or returning user still has to infer where to start,
+- object/topic/event pages are useful but not yet strong “knowledge entry products,”
+- the workbench still behaves more like a capable operator console than a system that orients you immediately.
+
+So the next move should **not** be:
+
+- temporal truth hardening,
+- harness/session memory,
+- benchmark infrastructure,
+- or another backend-heavy subsystem.
+
+The next move should be:
+
+- make the current knowledge state easier to enter,
+- make compiled products feel deliberate,
+- and make the next useful action obvious.
+
+## Product Thesis
+
+After `Phase 19`, a user should be able to land in OVP and answer three questions quickly:
+
+1. What does the system currently know that matters?
+2. Where should I start reading?
+3. What should I do next?
+
+That means the primary output of this phase is not a new database or runtime abstraction.
+It is a set of **entry products**:
+
+- an orientation brief,
+- stronger object/topic/event/contradiction pages,
+- and a workbench home that explains the current state of the vault in one screen.
+
+## What Phase 19 Must Deliver
+
+### 1. Orientation Brief v1
+
+Add a first-class entry artifact that compiles:
+
+- active topics
+- recent changes
+- unresolved issues
+- recommended next reads
+- recommended next actions
+
+This should be the productized version of what the current `/briefing` route hints at, not a second parallel dashboard.
+
+### 2. Compiled Page Contracts v1
+
+Strengthen the product shape of:
+
+- object pages
+- topic overviews
+- event dossiers
+- contradiction views
+
+Each of these should feel like a deliberate compiled page with stable sections, not only a raw data surface.
+
+Minimum page-contract expectations:
+
+- current state
+- why it matters
+- evidence / traceability
+- open issues or tensions
+- where to go next
+
+### 3. Workbench Home / Entry Screen
+
+Add a clear default product entry surface that answers:
+
+- what changed recently
+- what is important right now
+- what deserves review
+- what the system recommends next
+
+This should use the same assembly/governance contract stack rather than bypassing it.
+
+### 4. Cross-Surface Next-Step Links
+
+Pages should explicitly route users between:
+
+- orientation -> topic
+- topic -> object
+- object -> event / contradiction / deep dive
+- contradiction -> review
+- signals/actions -> relevant compiled page
+
+The goal is not more links. The goal is better **navigation intent**.
+
+### 5. Exportable Entry Products
+
+The new orientation artifact and strengthened compiled pages should be exportable through `ovp-export`, not trapped inside the local UI.
+
+## What Phase 19 Should Not Do
+
+Explicit deferrals:
+
+- full temporal truth semantics
+- pack-agnostic memory backend work
+- graph workspaces / pinning / route bookmarking
+- benchmark platform work
+- multi-user or hosted product shell
+- external domain pack expansion
+
+Those can all be valid later.
+They are not the highest-leverage next move.
+
+## Recommended Implementation Shape
+
+### Task 1: Add Orientation Recipe To Research-Tech
+
+**Files:**
+- Modify: `src/openclaw_pipeline/packs/research_tech/assembly_recipes.py`
+- Modify: `src/openclaw_pipeline/packs/research_tech/pack.py`
+- Modify: `src/openclaw_pipeline/commands/export_artifact.py`
+- Test: `tests/test_export_command.py`
+
+Deliverable:
+
+- a new `orientation_brief` assembly recipe
+- export target support for the orientation artifact
+
+Status:
+
+- complete
+
+### Task 2: Strengthen Briefing Payload Into Orientation Product
+
+**Files:**
+- Modify: `src/openclaw_pipeline/ui/view_models.py`
+- Modify: `src/openclaw_pipeline/commands/ui_server.py`
+- Test: `tests/test_ui_view_models.py`
+- Test: `tests/test_ui_server.py`
+
+Deliverable:
+
+- `/briefing` evolves into a true orientation page
+- stable sections for:
+  - what changed
+  - what matters
+  - what needs review
+  - what to read / do next
+
+Status:
+
+- complete
+
+### Task 3: Add Compiled Page Section Contracts
+
+**Files:**
+- Modify: `src/openclaw_pipeline/ui/view_models.py`
+- Modify: `src/openclaw_pipeline/commands/ui_server.py`
+- Reference: existing page builders and contract cards
+- Test: `tests/test_ui_view_models.py`
+- Test: `tests/test_ui_server.py`
+
+Deliverable:
+
+- object/topic/event/contradiction pages expose stable compiled sections
+- each page explicitly answers:
+  - what is this
+  - why does it matter
+  - what evidence anchors it
+  - what tensions remain
+  - what should the user open next
+
+Status:
+
+- complete
+
+### Task 4: Add Workbench Home Entry Surface
+
+**Files:**
+- Modify: `src/openclaw_pipeline/commands/ui_server.py`
+- Modify: `src/openclaw_pipeline/ui/view_models.py`
+- Test: `tests/test_ui_server.py`
+
+Deliverable:
+
+- the root/home experience becomes a real workbench entry point
+- it routes clearly into orientation, production, review, graph, and compiled pages
+
+Status:
+
+- complete
+
+### Task 5: Verification And Pack Docs
+
+**Files:**
+- Modify: `docs/pack-api/README.md`
+- Modify: `docs/research-tech/RESEARCH_TECH_SKILLPACK.md`
+- Modify: `docs/research-tech/RESEARCH_TECH_VERIFY.md`
+
+Deliverable:
+
+- docs explain the new orientation product and page contract expectations
+- verify docs include export + UI checks for the new entry products
+
+Status:
+
+- complete
+
+## Implementation Notes
+
+What shipped in this phase:
+
+- `research-tech` now declares a first-class `orientation_brief` assembly recipe
+- `ovp-export --target orientation-brief` exports a compiled JSON entry product
+- `/briefing` now resolves through the same contract stack and behaves as an orientation page
+- `/` workbench home now exposes entry sections and routes users into the orientation surface
+- object/topic/event/contradiction payloads now expose stable `compiled_sections` and `section_nav`
+- shared UI pages render those compiled sections instead of relying on raw list surfaces alone
+- docs and verify checklists now treat orientation and compiled-page sections as part of the pack contract
+
+## Exit Condition
+
+`Phase 19` is complete when all of the following are true:
+
+1. OVP has a clear orientation artifact.
+2. `/briefing` behaves like a real knowledge entry product.
+3. object/topic/event/contradiction pages expose stable compiled sections.
+4. the home/workbench entry clearly routes the user into the most useful next surfaces.
+5. export and UI both surface the new entry products through the same contract stack.
+
+## What Comes After Phase 19
+
+Only after `Phase 19` should OVP seriously consider:
+
+1. saved graph workspaces and route bookmarking
+2. richer synthesis overlays on graph surfaces
+3. temporal truth hardening
+4. deeper signal capture / session memory
+5. benchmark and evaluation framing
+
+That keeps the system growing in the right order:
+
+- first graph,
+- then explicit contracts,
+- then entry products,
+- then deeper intelligence and automation.

--- a/docs/research-tech/RESEARCH_TECH_SKILLPACK.md
+++ b/docs/research-tech/RESEARCH_TECH_SKILLPACK.md
@@ -14,7 +14,7 @@
   - compiled overviews
   - review items
 - explicit assembly recipes for:
-  - operator briefing
+  - orientation brief
   - topic overview
   - object brief
   - event dossier
@@ -24,10 +24,18 @@
   - signal rules
   - resolver rules
 - materialized views:
+  - workbench home / entry surface
+  - orientation brief
   - object pages
   - topic overviews
   - event dossiers
   - contradiction views
+- compiled page sections for:
+  - current state
+  - why it matters
+  - evidence traceability
+  - open tensions
+  - where to go next
 - review and maintenance loops:
   - contradiction review / resolution
   - stale summary review / rebuild
@@ -41,6 +49,7 @@
 - `ovp-extraction-dashboard --pack research-tech`
 - `ovp-ops --pack research-tech --profile vault/review_queue`
 - `ovp-build-views --pack research-tech --view overview/topic`
+- `ovp-export --pack research-tech --target orientation-brief --output-path out/orientation.json`
 - `ovp-export --pack research-tech --target topic-overview --output-path out/topic.md`
 - `ovp-doctor --pack research-tech --json`
 - `ovp-truth objects --vault-dir /path/to/vault`
@@ -52,8 +61,12 @@
   - 看 `declared` / `effective` contract families
   - 看 shared shell 解析到的 `governance_contract`
 - `ovp-ui --vault-dir /path/to/vault --port 8787`
+  - 看 `/` workbench home 的 entry sections
+  - 看 `/briefing` 的 orientation sections
   - 看页面级 `Assembly Contract` / `Governance Contract`
   - 看 signals / actions / briefing 上的 item-level provenance
+- `ovp-export --pack research-tech --target orientation-brief --output-path out/orientation.json`
+  - 看 orientation product 走到的 `assembly recipe -> source contract -> source provider` 链路
 - `ovp-export --pack research-tech --target topic-overview --output-path out/topic.md`
   - 看 export target 走到的 `assembly recipe -> source contract -> source provider` 链路
 

--- a/docs/research-tech/RESEARCH_TECH_VERIFY.md
+++ b/docs/research-tech/RESEARCH_TECH_VERIFY.md
@@ -52,16 +52,22 @@ Inspect:
 
 ```bash
 ovp-export --pack research-tech --vault-dir /path/to/vault --target topic-overview --output-path /tmp/topic.md
+ovp-export --pack research-tech --vault-dir /path/to/vault --target orientation-brief --output-path /tmp/orientation.json
 ```
 
 Expected:
 
-- export completes
-- output file exists
-- content is a compiled markdown artifact, not a raw database dump
-- JSON payload includes both:
+- both exports complete
+- both output files exist
+- `topic-overview` is a compiled markdown artifact, not a raw database dump
+- `orientation-brief` is a compiled JSON artifact, not a raw observation snapshot
+- orientation JSON includes:
+  - `assembly_contract`
+  - stable `compiled_sections`
+  - `section_nav`
+- export metadata includes both:
   - the resolved assembly recipe name/provider pack
-  - the resolved wiki view name/provider pack
+  - the resolved source contract name/provider pack
 
 ## UI Contract Checks
 
@@ -71,6 +77,7 @@ ovp-ui --pack default-knowledge --vault-dir /path/to/vault --port 8787
 
 Inspect:
 
+- `/?pack=default-knowledge`
 - `/object?id=<object-id>&pack=default-knowledge`
 - `/topic?id=<object-id>&pack=default-knowledge`
 - `/events?pack=default-knowledge`
@@ -81,9 +88,20 @@ Inspect:
 
 Expected:
 
+- `/` renders a workbench entry surface with:
+  - `Where To Start`
+  - `Orientation Brief`
+  - `entry_sections`
 - shared shell pages keep the requested pack scope in links/forms
 - assembly contract card is visible on each page
 - governance contract card is visible on runtime/operator pages
+- `/briefing` behaves as an orientation product rather than a raw operator snapshot
+- object/topic/event/contradiction pages expose compiled sections for:
+  - current state
+  - why it matters
+  - evidence traceability
+  - open tensions
+  - where to go next
 - compatibility-pack pages show assembly recipe inheritance from `research-tech`
 - compatibility-pack pages also show when the source contract provider resolves to `default-knowledge`
 - compatibility-pack runtime pages show governance inheritance from `research-tech`
@@ -116,7 +134,7 @@ Expected:
 
 - `provider_pack` can stay `research-tech`
 - `source_provider_pack` can differ and resolve to `default-knowledge`
-- `operator_briefing` keeps both recipe provider and source provider on `research-tech`
+- `orientation_brief` keeps both recipe provider and source provider on `research-tech`
 - effective `governance_specs` stay inherited from `research-tech` for `default-knowledge`
 - shell governance summary also resolves as inherited from `research-tech`
 
@@ -133,6 +151,8 @@ Expected:
 - `/api/briefing` includes:
   - `assembly_contract`
   - `governance_contract`
+  - stable `compiled_sections`
+  - `section_nav`
   - item-level `recommended_action.resolver_rule_name`
   - item-level `recommended_action.governance_provider_*`
 - `/api/signals` includes:

--- a/progress.md
+++ b/progress.md
@@ -2,6 +2,32 @@
 
 ## Session: 2026-04-17
 
+### Phase 19: Orientation And Compiled Knowledge Products
+- **Status:** complete
+- Actions taken:
+  - Added a first-class `orientation_brief` assembly recipe to `research-tech`
+  - Extended `ovp-export` with an `orientation-brief` target that emits a compiled JSON entry product
+  - Turned `/briefing` into an orientation page with stable compiled sections and section navigation
+  - Added stable compiled-page sections to object/topic/event/contradiction payload builders
+  - Upgraded the workbench home `/` into an entry surface with `Where To Start`, `Orientation Brief`, and explicit entry sections
+  - Updated the shared UI shell to render compiled sections and section navigation across the new entry products
+  - Closed out `Phase 19` docs and verify checklists for orientation and compiled-page contracts
+- Files created/modified:
+  - docs/plans/2026-04-17-phase19-orientation-and-compiled-knowledge-products.md
+  - docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
+  - docs/pack-api/README.md
+  - docs/research-tech/RESEARCH_TECH_SKILLPACK.md
+  - docs/research-tech/RESEARCH_TECH_VERIFY.md
+  - progress.md
+  - task_plan.md
+  - src/openclaw_pipeline/packs/research_tech/assembly_recipes.py
+  - src/openclaw_pipeline/commands/export_artifact.py
+  - src/openclaw_pipeline/ui/view_models.py
+  - src/openclaw_pipeline/commands/ui_server.py
+  - tests/test_export_command.py
+  - tests/test_ui_view_models.py
+  - tests/test_ui_server.py
+
 ### Phase 1: Local Project Context
 - **Status:** complete
 - **Started:** 2026-04-17 America/Los_Angeles
@@ -165,6 +191,17 @@
     - `governance_contract`
     - item-level resolver/governance provenance
   - Marked `Phase 18` as complete / ready to close in the phase plan and the milestone sequencing doc
+  - Researched `HKUDS/DeepTutor` and added Round 20, classifying it as a tutoring-oriented context-assembly and compiled-learning-product system rather than a knowledge compiler
+  - Verified in code that DeepTutor’s KB path is conventional llamaindex indexing:
+    - `raw/` staging
+    - PDF/text parsing
+    - fixed chunking
+    - embeddings
+    - persisted vector index in `llamaindex_storage/`
+  - Verified that the older “numbered item” extraction path for definitions/theorems/equations is now explicitly deprecated/no-op in the active llamaindex-only route
+  - Identified the strongest transferable idea in `services/session/turn_runtime.py`: one turn composes notebook context, history context, lightweight memory, conversation history, attachments, and selected KBs into a single `UnifiedContext`
+  - Verified that notebook references are not injected raw; they are first compressed by `NotebookAnalysisAgent` into a question-targeted observation note
+  - Verified that notebook records and deep research outputs are treated as reusable work artifacts rather than canonical truth objects
 - Files created/modified:
   - docs/plans/2026-04-17-external-project-discovery-log.md
   - docs/plans/2026-04-17-ovp-architecture-mapping.md

--- a/src/openclaw_pipeline/commands/export_artifact.py
+++ b/src/openclaw_pipeline/commands/export_artifact.py
@@ -6,12 +6,14 @@ import shutil
 from pathlib import Path
 
 from ..assembly_recipe_registry import resolve_assembly_recipe_spec, resolve_assembly_source_contract
+from ..observation_surface_registry import execute_observation_surface_builder
 from ..packs.loader import PRIMARY_PACK_NAME, load_pack
 from ..runtime import resolve_vault_dir
 from ..wiki_views.runtime import build_view
 
 
 TARGET_TO_RECIPE = {
+    "orientation-brief": "orientation_brief",
     "object-page": "object_brief",
     "topic-overview": "topic_overview",
     "event-dossier": "event_dossier",
@@ -43,6 +45,10 @@ def _resolve_export_view(pack, recipe_provider_pack, recipe) -> tuple[object, ob
     return provider_pack, provider_pack.wiki_view(view_name)
 
 
+def _write_json_export(output_path: Path, payload: object) -> None:
+    output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Export pack-backed compiled artifacts to an explicit output path."
@@ -60,41 +66,82 @@ def main(argv: list[str] | None = None) -> int:
         recipe_provider_pack, recipe = _resolve_export_recipe(pack, args.target)
     except Exception as exc:
         parser.error(f"failed to resolve export recipe for target '{args.target}' and pack '{pack.name}': {exc}")
-    try:
-        view_provider_pack, view = _resolve_export_view(pack, recipe_provider_pack, recipe)
-    except Exception as exc:
-        parser.error(
-            f"failed to resolve export view '{getattr(recipe, 'source_contract_name', None)}' "
-            f"for target '{args.target}' and pack '{pack.name}': {exc}"
-        )
-
     if args.target == "object-page" and not args.object_id:
         parser.error("the --object-id argument is required for object-page exports")
 
-    try:
-        source_path = build_view(vault_dir, view, object_id=args.object_id)
-    except Exception as exc:
-        parser.error(
-            f"failed to build export target '{args.target}' for view '{getattr(view, 'name', None)}' "
-            f"and object_id={args.object_id!r}: {exc}"
-        )
     output_path = args.output_path.expanduser().resolve()
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copyfile(source_path, output_path)
 
-    print(
-        json.dumps(
-            {
-                "target": args.target,
-                "pack": pack.name,
-                "recipe_name": getattr(recipe, "name", ""),
-                "recipe_provider_pack": getattr(recipe_provider_pack, "name", ""),
-                "view_name": getattr(view, "name", ""),
-                "view_provider_pack": getattr(view_provider_pack, "name", ""),
-                "source_path": str(source_path),
-                "output_path": str(output_path),
-            },
-            ensure_ascii=False,
+    source = resolve_assembly_source_contract(pack_name=pack, recipe=recipe)
+    if getattr(recipe, "source_contract_kind", "") == "wiki_view":
+        try:
+            view_provider_pack, view = _resolve_export_view(pack, recipe_provider_pack, recipe)
+        except Exception as exc:
+            parser.error(
+                f"failed to resolve export view '{getattr(recipe, 'source_contract_name', None)}' "
+                f"for target '{args.target}' and pack '{pack.name}': {exc}"
+            )
+        try:
+            source_path = build_view(vault_dir, view, object_id=args.object_id)
+        except Exception as exc:
+            parser.error(
+                f"failed to build export target '{args.target}' for view '{getattr(view, 'name', None)}' "
+                f"and object_id={args.object_id!r}: {exc}"
+            )
+        shutil.copyfile(source_path, output_path)
+        print(
+            json.dumps(
+                {
+                    "target": args.target,
+                    "pack": pack.name,
+                    "recipe_name": getattr(recipe, "name", ""),
+                    "recipe_provider_pack": getattr(recipe_provider_pack, "name", ""),
+                    "view_name": getattr(view, "name", ""),
+                    "view_provider_pack": getattr(view_provider_pack, "name", ""),
+                    "source_path": str(source_path),
+                    "output_path": str(output_path),
+                },
+                ensure_ascii=False,
+            )
         )
+        return 0
+
+    if getattr(recipe, "source_contract_kind", "") == "observation_surface":
+        try:
+            spec, payload = execute_observation_surface_builder(
+                surface_kind=str(getattr(recipe, "source_contract_name", "")),
+                vault_dir=vault_dir,
+                pack_name=pack.name,
+            )
+        except Exception as exc:
+            parser.error(
+                f"failed to build export target '{args.target}' for observation surface "
+                f"'{getattr(recipe, 'source_contract_name', None)}': {exc}"
+            )
+        if getattr(recipe, "name", "") == "orientation_brief":
+            from ..ui.view_models import build_briefing_payload
+
+            payload = build_briefing_payload(vault_dir, pack_name=pack.name)
+        _write_json_export(output_path, payload)
+        print(
+            json.dumps(
+                {
+                    "target": args.target,
+                    "pack": pack.name,
+                    "recipe_name": getattr(recipe, "name", ""),
+                    "recipe_provider_pack": getattr(recipe_provider_pack, "name", ""),
+                    "source_name": getattr(recipe, "source_contract_name", ""),
+                    "source_provider_pack": str(source.get("source_provider_pack") or getattr(spec, "pack", "")),
+                    "source_provider_name": str(source.get("source_provider_name") or getattr(spec, "name", "")),
+                    "output_path": str(output_path),
+                },
+                ensure_ascii=False,
+            )
+        )
+        return 0
+
+    parser.error(
+        f"assembly recipe '{getattr(recipe, 'name', '')}' uses unsupported source contract kind "
+        f"'{getattr(recipe, 'source_contract_kind', '')}'"
     )
     return 0

--- a/src/openclaw_pipeline/commands/export_artifact.py
+++ b/src/openclaw_pipeline/commands/export_artifact.py
@@ -21,6 +21,17 @@ TARGET_TO_RECIPE = {
 }
 
 
+def _build_compiled_briefing_export(vault_dir: Path, *, pack_name: str) -> object:
+    from ..ui.view_models import build_briefing_payload
+
+    return build_briefing_payload(vault_dir, pack_name=pack_name)
+
+
+OBSERVATION_SURFACE_EXPORT_BUILDERS = {
+    "briefing": _build_compiled_briefing_export,
+}
+
+
 def _resolve_export_recipe(pack, target: str) -> tuple[object, object]:
     recipe_name = TARGET_TO_RECIPE[target]
     recipe = resolve_assembly_recipe_spec(pack_name=pack, recipe_name=recipe_name)
@@ -47,6 +58,18 @@ def _resolve_export_view(pack, recipe_provider_pack, recipe) -> tuple[object, ob
 
 def _write_json_export(output_path: Path, payload: object) -> None:
     output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _build_observation_surface_export(*, vault_dir: Path, pack_name: str, recipe) -> tuple[object | None, object]:
+    surface_kind = str(getattr(recipe, "source_contract_name", ""))
+    compiled_builder = OBSERVATION_SURFACE_EXPORT_BUILDERS.get(surface_kind)
+    if compiled_builder is not None:
+        return None, compiled_builder(vault_dir, pack_name=pack_name)
+    return execute_observation_surface_builder(
+        surface_kind=surface_kind,
+        vault_dir=vault_dir,
+        pack_name=pack_name,
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -108,20 +131,16 @@ def main(argv: list[str] | None = None) -> int:
 
     if getattr(recipe, "source_contract_kind", "") == "observation_surface":
         try:
-            spec, payload = execute_observation_surface_builder(
-                surface_kind=str(getattr(recipe, "source_contract_name", "")),
+            spec, payload = _build_observation_surface_export(
                 vault_dir=vault_dir,
                 pack_name=pack.name,
+                recipe=recipe,
             )
         except Exception as exc:
             parser.error(
                 f"failed to build export target '{args.target}' for observation surface "
                 f"'{getattr(recipe, 'source_contract_name', None)}': {exc}"
             )
-        if getattr(recipe, "name", "") == "orientation_brief":
-            from ..ui.view_models import build_briefing_payload
-
-            payload = build_briefing_payload(vault_dir, pack_name=pack.name)
         _write_json_export(output_path, payload)
         print(
             json.dumps(

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -317,6 +317,42 @@ def _render_governance_contract_card(payload: dict) -> str:
     )
 
 
+def _render_compiled_sections(sections: list[dict[str, object]]) -> str:
+    if not sections:
+        return ""
+    rendered_sections: list[str] = []
+    for section in sections:
+        label = str(section.get("label") or section.get("id") or "")
+        anchor = str(section.get("anchor") or str(section.get("id") or "").replace("_", "-"))
+        summary = str(section.get("summary") or "")
+        items = section.get("items") or []
+        item_html = "".join(
+            "<li>"
+            + (
+                f'<a href="{escape(str(item.get("path") or ""))}">{escape(str(item.get("label") or ""))}</a>'
+                if str(item.get("path") or "")
+                else escape(str(item.get("label") or ""))
+            )
+            + (
+                f"<div class='muted'>{escape(str(item.get('detail') or ''))}</div>"
+                if str(item.get("detail") or "")
+                else ""
+            )
+            + "</li>"
+            for item in items
+            if isinstance(item, dict)
+        ) or "<li class='muted'>No items surfaced.</li>"
+        summary_html = f"<p class='muted'>{escape(summary)}</p>" if summary else ""
+        rendered_sections.append(
+            f"<section id='{escape(anchor)}' class='card'>"
+            f"<h2>{escape(label)}</h2>"
+            f"{summary_html}"
+            f"<ul class='list-tight'>{item_html}</ul>"
+            "</section>"
+        )
+    return "".join(rendered_sections)
+
+
 def _unsupported_route_payload(route_path: str, requested_pack: str = "") -> dict[str, str]:
     normalized_pack = requested_pack.strip()
     return {
@@ -1019,8 +1055,12 @@ def _render_dashboard(payload: dict) -> str:
     requested_pack = payload.get("requested_pack", "")
     research_overview = payload.get("research_overview", {})
     research_overview_supported = research_overview.get("status") == "supported"
+    orientation = payload.get("orientation", {})
     signals_surface_contract = _render_surface_contract_card(payload["signals"])
     production_surface_contract = _render_surface_contract_card(payload["production"])
+    orientation_assembly_contract = _render_assembly_contract_card(orientation) if isinstance(orientation, dict) else ""
+    orientation_governance_contract = _render_governance_contract_card(orientation) if isinstance(orientation, dict) else ""
+    entry_sections_html = _render_compiled_sections(payload.get("entry_sections", []))
     object_items = "".join(
         f'<li><a href="{escape(_object_href(item["object_id"], item.get("object_path", "")))}">{escape(item["title"])}</a></li>'
         for item in payload["objects"]["items"]
@@ -1122,9 +1162,16 @@ def _render_dashboard(payload: dict) -> str:
             "<h1>OpenClaw Truth UI</h1>",
             "<p class='muted'>Read-only browser over <code>knowledge.db</code>. JSON APIs remain available at <code>/api/*</code>, including <code>/api/objects</code>.",
             f"{' Pack scope: ' + escape(requested_pack) + '.' if requested_pack else ''}</p>",
+            f"<div class='link-row'><a href='{escape(_shell_href('/briefing', requested_pack))}'>Orientation Brief</a></div>",
             "</section>",
             "<section class='grid stats'>",
             "".join(stats_cards),
+            "</section>",
+            "<section class='section-stack'>",
+            "<section class='card'><h2>Where To Start</h2><p class='muted'>Use the orientation brief and the compiled entry sections below to decide what to read, review, or do next.</p></section>",
+            orientation_assembly_contract,
+            orientation_governance_contract,
+            entry_sections_html,
             "</section>",
             "<section class='grid two-col'>",
             "<div class='section-stack'>",
@@ -1341,6 +1388,7 @@ def _render_object_page(payload: dict) -> str:
             "<section class='grid two-col'>"
             "<div class='section-stack'>"
             f"<section id='summary' class='card'><h2>Compiled Summary</h2><p>{escape(summary_text)}</p></section>"
+            f"{_render_compiled_sections(payload.get('compiled_sections', []))}"
             f"<section id='claims' class='card'><h2>Claims</h2><ul class='list-tight'>{claims}</ul></section>"
             "</div>"
             "<div class='section-stack'>"
@@ -1368,6 +1416,10 @@ def _render_topic_page(payload: dict) -> str:
     evolution = payload.get(
         "evolution",
         {"candidate_items": [], "accepted_links": [], "accepted_count": 0, "candidate_count": 0, "link_types": []},
+    )
+    section_nav = "".join(
+        f'<a href="{escape(str(item["href"]))}">{escape(str(item["label"]))}</a>'
+        for item in payload.get("section_nav", [])
     )
     summary_form = (
         "<form method='post' action='/summaries/rebuild' class='link-row'>"
@@ -1438,7 +1490,9 @@ def _render_topic_page(payload: dict) -> str:
             + "</p>"
             + f"<div class='link-row'>{''.join(hero_links)}</div></section>"
             + assembly_contract_card
+            + (f"<nav class='subnav'>{section_nav}</nav>" if section_nav else "")
             + "<section class='grid two-col'>"
+            f"{_render_compiled_sections(payload.get('compiled_sections', []))}"
             f"<section class='card'><h2>Center Summary</h2><p>{escape(payload['center_summary'])}</p></section>"
             f"<section class='card'><h2>Neighbors</h2><ul class='list-tight'>{neighbors}</ul></section>"
             f"{''.join(right_sections)}"
@@ -1477,6 +1531,10 @@ def _render_events_page(payload: dict) -> str:
     date_nav = "".join(
         f"<a href='#date-{escape(section['date'])}'>{escape(section['date'])}</a>"
         for section in payload["cluster_sections"]
+    )
+    section_nav = "".join(
+        f'<a href="{escape(str(item["href"]))}">{escape(str(item["label"]))}</a>'
+        for item in payload.get("section_nav", [])
     )
     events = "".join(
         f'<section id="date-{escape(section["date"])}" class="card"><h2>{escape(section["date"])}</h2><ul class="list-tight">'
@@ -1555,6 +1613,8 @@ def _render_events_page(payload: dict) -> str:
                 f" Pack scope: {escape(requested_pack)}." if requested_pack else "",
                 f"{escape(limit_note)}</p>",
                 assembly_contract_card,
+                (f"<nav class='subnav'>{section_nav}</nav>" if section_nav else ""),
+                _render_compiled_sections(payload.get("compiled_sections", [])),
                 f"<div class='link-row'>{type_breakdown}</div>",
                 f"{_render_production_summary_card(payload['production_summary'], requested_pack=requested_pack)}",
                 f"{_render_review_context_card(payload['review_context'])}",
@@ -2597,6 +2657,10 @@ def _render_briefing_page(payload: dict) -> str:
         f"<span class='muted'>({item['signal_count']} signals)</span></li>"
         for item in payload["active_topics"]
     ) or "<li class='muted'>No active topics surfaced.</li>"
+    section_nav = "".join(
+        f'<a href="{escape(str(item["href"]))}">{escape(str(item["label"]))}</a>'
+        for item in payload.get("section_nav", [])
+    )
     queue_summary = payload.get("queue_summary", {})
     failure_buckets = "".join(
         f"<li><span class='pill'>{escape(bucket)}</span> {count}</li>"
@@ -2606,13 +2670,15 @@ def _render_briefing_page(payload: dict) -> str:
         "Working Memory Snapshot",
         "".join(
             [
-                "<h1>Working Memory Snapshot</h1>",
+                "<h1>Orientation Brief</h1>",
                 f"<p class='muted'>Generated at {escape(payload['generated_at'])}. {payload['recent_signal_count']} recent signals, {payload['unresolved_issue_count']} unresolved issues.",
                 f" Pack scope: {escape(requested_pack)}." if requested_pack else "",
                 "</p>",
                 surface_contract_card,
                 assembly_contract_card,
                 governance_contract_card,
+                f"<nav class='subnav'>{section_nav}</nav>" if section_nav else "",
+                _render_compiled_sections(payload.get("compiled_sections", [])),
                 f"<section class='card'><h2>First Useful Sign</h2><ul class='list-tight'>{first_useful_sign_html}</ul></section>",
                 f"<section class='card'><h2>Insights</h2><ul class='list-tight'>{insights}</ul></section>",
                 f"<section class='card'><h2>Priority Items</h2><ul class='list-tight'>{priority_items}</ul></section>",
@@ -2823,6 +2889,10 @@ def _render_contradictions_page(payload: dict) -> str:
             for status_name, text in detection_contract["status_explanations"].items()
         )
     )
+    section_nav = "".join(
+        f'<a href="{escape(str(item["href"]))}">{escape(str(item["label"]))}</a>'
+        for item in payload.get("section_nav", [])
+    )
     items = "".join(
         "<li>"
         + (
@@ -2974,6 +3044,8 @@ def _render_contradictions_page(payload: dict) -> str:
                 f" Pack scope: {escape(requested_pack)}." if requested_pack else "",
                 "</p>",
                 assembly_contract_card,
+                f"<nav class='subnav'>{section_nav}</nav>" if section_nav else "",
+                _render_compiled_sections(payload.get("compiled_sections", [])),
                 f"<section class='card'><h2>Detection Notes</h2><ul class='list-tight'>{detection_notes}</ul></section>",
                 "<section class='card'>",
                 "<h2>Batch Resolve</h2>",

--- a/src/openclaw_pipeline/packs/research_tech/assembly_recipes.py
+++ b/src/openclaw_pipeline/packs/research_tech/assembly_recipes.py
@@ -32,6 +32,26 @@ def build_assembly_recipes(pack_name: str = "research-tech") -> list[AssemblyRec
             output=AssemblyOutputSpec(output_mode="json", publish_target="ui_payload"),
         ),
         AssemblyRecipeSpec(
+            name="orientation_brief",
+            pack=pack_name,
+            recipe_kind="orientation_brief",
+            description="User-facing orientation brief over current knowledge state, changes, and next steps.",
+            source_contract_kind="observation_surface",
+            source_contract_name="briefing",
+            inputs=[
+                AssemblyInputSpec(
+                    source_kind="signals",
+                    description="Current signal ledger and briefing prioritization state",
+                )
+            ],
+            audience=AssemblyAudienceSpec(audience="operator", interaction_mode="read_only"),
+            freshness_policy=AssemblyFreshnessPolicy(
+                cache_mode="derived_cache",
+                invalidation_signals=["signals", "actions", "review_queue"],
+            ),
+            output=AssemblyOutputSpec(output_mode="json", publish_target="compiled_json"),
+        ),
+        AssemblyRecipeSpec(
             name="topic_overview",
             pack=pack_name,
             recipe_kind="topic_overview",

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -99,6 +99,27 @@ def _section_nav_from_compiled_sections(sections: list[dict[str, Any]]) -> list[
     ]
 
 
+def _compiled_section_by_id(
+    sections: list[dict[str, Any]],
+    section_id: str,
+) -> dict[str, Any]:
+    return next((section for section in sections if str(section.get("id") or "") == section_id), {})
+
+
+def _remap_compiled_section(
+    section: dict[str, Any],
+    *,
+    section_id: str,
+    label: str,
+    summary: str,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    items = list(section.get("items") or [])
+    if limit is not None:
+        items = items[:limit]
+    return _compiled_section(section_id, label, summary=summary, items=items)
+
+
 def _db_path(vault_dir: Path | str) -> Path:
     resolved = resolve_vault_dir(vault_dir)
     return VaultLayout.from_vault(resolved).knowledge_db
@@ -2996,67 +3017,28 @@ def build_truth_dashboard_payload(
             }
         )
     orientation = build_briefing_payload(vault_dir, pack_name=pack_name)
+    orientation_sections = list(orientation.get("compiled_sections") or [])
     entry_sections = [
-        _compiled_section(
-            "what_changed_recently",
-            "What Changed Recently",
+        _remap_compiled_section(
+            _compiled_section_by_id(orientation_sections, "what_changed"),
+            section_id="what_changed_recently",
+            label="What Changed Recently",
             summary=f"{orientation.get('changed_object_count', 0)} changed objects and {orientation.get('recent_signal_count', 0)} recent signals surfaced.",
-            items=[
-                *[
-                    {
-                        "kind": "changed_object",
-                        "label": item["title"],
-                        "path": item["path"],
-                        "detail": f"Changed object · {item['object_id']}",
-                    }
-                    for item in orientation.get("changed_objects", [])[:4]
-                ]
-            ],
+            limit=4,
         ),
-        _compiled_section(
-            "important_right_now",
-            "Important Right Now",
+        _remap_compiled_section(
+            _compiled_section_by_id(orientation_sections, "next_actions"),
+            section_id="important_right_now",
+            label="Important Right Now",
             summary=f"{len(orientation.get('priority_items', []))} priority items are currently surfaced.",
-            items=[
-                *[
-                    {
-                        "kind": str(item["kind"]),
-                        "label": str(item["title"]),
-                        "path": str(item["path"]),
-                        "detail": str(item["detail"]),
-                    }
-                    for item in orientation.get("priority_items", [])[:4]
-                ]
-            ],
+            limit=4,
         ),
-        _compiled_section(
-            "deserves_review",
-            "Deserves Review",
-            summary=f"{contradictions['open_count'] if research_overview_supported else signals['count']} review-oriented items are currently in scope.",
-            items=(
-                [
-                    {
-                        "kind": "contradiction",
-                        "label": item["subject_key"],
-                        "path": _scoped_path(
-                            f"/contradictions?q={quote(str(item['subject_key']), safe='')}",
-                            pack_name=requested_pack,
-                        ),
-                        "detail": f"{len(item['object_ids'])} objects in scope",
-                    }
-                    for item in contradictions["items"][:4]
-                ]
-                if research_overview_supported
-                else [
-                    {
-                        "kind": str(item["signal_type"]),
-                        "label": str(item["title"]),
-                        "path": str(item["source_path"]),
-                        "detail": str(item["detail"]),
-                    }
-                    for item in signals["items"][:4]
-                ]
-            ),
+        _remap_compiled_section(
+            _compiled_section_by_id(orientation_sections, "needs_review"),
+            section_id="deserves_review",
+            label="Deserves Review",
+            summary=f"{orientation.get('unresolved_issue_count', 0)} review-oriented items are currently in scope.",
+            limit=4,
         ),
         _compiled_section(
             "recommended_next_steps",

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -71,6 +71,34 @@ def _assembly_contract(recipe_name: str, *, pack_name: str | None = None) -> dic
     return describe_assembly_recipe_contract(pack_name=pack_name, recipe_name=recipe_name)
 
 
+def _compiled_section(
+    section_id: str,
+    label: str,
+    *,
+    summary: str,
+    items: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    normalized_items = list(items or [])
+    return {
+        "id": section_id,
+        "label": label,
+        "anchor": section_id.replace("_", "-"),
+        "summary": summary,
+        "item_count": len(normalized_items),
+        "items": normalized_items,
+    }
+
+
+def _section_nav_from_compiled_sections(sections: list[dict[str, Any]]) -> list[dict[str, str]]:
+    return [
+        {
+            "href": f"#{str(section.get('anchor') or str(section.get('id') or '').replace('_', '-'))}",
+            "label": str(section.get("label") or section.get("id") or ""),
+        }
+        for section in sections
+    ]
+
+
 def _db_path(vault_dir: Path | str) -> Path:
     resolved = resolve_vault_dir(vault_dir)
     return VaultLayout.from_vault(resolved).knowledge_db
@@ -890,7 +918,7 @@ def build_briefing_payload(vault_dir: Path | str, *, pack_name: str | None = Non
         pack_name=pack_name,
         surface_kind="briefing",
     )
-    assembly_contract = _assembly_contract("operator_briefing", pack_name=pack_name)
+    assembly_contract = _assembly_contract("orientation_brief", pack_name=pack_name)
     governance_contract = describe_governance_contract(pack_name=pack_name)
     if surface_contract["status"] == "missing":
         return {
@@ -916,6 +944,8 @@ def build_briefing_payload(vault_dir: Path | str, *, pack_name: str | None = Non
             "priority_item_count": 0,
             "insights": [],
             "priority_items": [],
+            "compiled_sections": [],
+            "section_nav": [],
             "first_useful_sign": None,
             "queue_summary": {
                 "queued_count": 0,
@@ -925,13 +955,93 @@ def build_briefing_payload(vault_dir: Path | str, *, pack_name: str | None = Non
                 "failure_buckets": {},
             },
         }
+    snapshot = get_briefing_snapshot(vault_dir, pack_name=pack_name)
+    changed_items = [
+        {
+            "kind": "changed_object",
+            "label": str(item["title"]),
+            "path": str(item["path"]),
+            "detail": f"Changed object · {item['object_id']}",
+        }
+        for item in snapshot.get("changed_objects", [])[:5]
+    ]
+    what_matters_items = [
+        {
+            "kind": "active_topic",
+            "label": str(item["title"]),
+            "path": str(item["path"]),
+            "detail": f"{int(item['signal_count'])} signals in scope",
+        }
+        for item in snapshot.get("active_topics", [])[:5]
+    ]
+    needs_review_items = [
+        {
+            "kind": str(item["signal_type"]),
+            "label": str(item["title"]),
+            "path": str(item["source_path"]),
+            "detail": str(item["detail"]),
+        }
+        for item in snapshot.get("unresolved_issues", [])[:5]
+    ]
+    next_read_items = [
+        {
+            "kind": str(item["kind"]),
+            "label": str(item["title"]),
+            "path": str(item["path"]),
+            "detail": str(item["detail"]),
+        }
+        for item in snapshot.get("insights", [])[:5]
+    ]
+    next_action_items = [
+        {
+            "kind": str(item["kind"]),
+            "label": str(item["title"]),
+            "path": str(((item.get("recommended_action") or {}).get("path")) or item.get("path") or ""),
+            "detail": str(((item.get("recommended_action") or {}).get("label")) or item.get("detail") or ""),
+        }
+        for item in snapshot.get("priority_items", [])[:5]
+    ]
+    compiled_sections = [
+        _compiled_section(
+            "what_changed",
+            "What Changed",
+            summary=f"{len(changed_items)} changed objects surfaced recently.",
+            items=changed_items,
+        ),
+        _compiled_section(
+            "what_matters",
+            "What Matters",
+            summary=f"{len(what_matters_items)} active topics currently dominate the signal surface.",
+            items=what_matters_items,
+        ),
+        _compiled_section(
+            "needs_review",
+            "Needs Review",
+            summary=f"{len(needs_review_items)} unresolved issues currently deserve attention.",
+            items=needs_review_items,
+        ),
+        _compiled_section(
+            "next_reads",
+            "Next Reads",
+            summary=f"{len(next_read_items)} compiled next-read routes were surfaced from current evidence.",
+            items=next_read_items,
+        ),
+        _compiled_section(
+            "next_actions",
+            "Next Actions",
+            summary=f"{len(next_action_items)} next actions are currently available from the queue and briefing logic.",
+            items=next_action_items,
+        ),
+    ]
     return {
         "screen": "briefing/intelligence",
         "requested_pack": requested_pack,
         "surface_contract": surface_contract,
         "assembly_contract": assembly_contract,
         "governance_contract": governance_contract,
-        **get_briefing_snapshot(vault_dir, pack_name=pack_name),
+        **snapshot,
+        "compiled_sections": compiled_sections,
+        "section_nav": _section_nav_from_compiled_sections(compiled_sections),
     }
 
 def build_object_page_payload(
@@ -998,6 +1108,142 @@ def build_object_page_payload(
             "status": "all",
         }
     )
+    summary_text = detail["summary"]["summary_text"] if detail["summary"] else ""
+    stale_summary_details = (
+        list_stale_summaries(
+            vault_dir,
+            pack_name=pack_name,
+            object_ids=[object_id],
+            limit=10,
+        )
+        if research_shell_enabled
+        else []
+    )
+    compiled_sections = [
+        _compiled_section(
+            "current_state",
+            "Current State",
+            summary=summary_text or "No compiled summary yet.",
+            items=[
+                {
+                    "kind": "summary",
+                    "label": detail["object"]["title"],
+                    "path": "",
+                    "detail": summary_text or "No compiled summary yet.",
+                },
+                {"kind": "claims", "label": "Claims", "path": "", "detail": f"{len(detail['claims'])} claims"},
+                {"kind": "relations", "label": "Relations", "path": "", "detail": f"{len(relations)} relations"},
+            ],
+        ),
+        _compiled_section(
+            "why_it_matters",
+            "Why It Matters",
+            summary=f"{len(detail['contradictions']) if research_shell_enabled else 0} contradictions and {review_context.get('stale_summary_count', 0)} stale summaries shape current maintenance urgency.",
+            items=[
+                {
+                    "kind": "topic",
+                    "label": "Explore topic",
+                    "path": _scoped_path(f"/topic?id={quote(object_id, safe='')}", pack_name=requested_pack),
+                    "detail": "Open the surrounding topic neighborhood.",
+                },
+                *(
+                    [
+                        {
+                            "kind": "events",
+                            "label": "Related events",
+                            "path": research_links["events_path"],
+                            "detail": "See timeline context for this object.",
+                        }
+                    ]
+                    if research_shell_enabled
+                    else []
+                ),
+            ],
+        ),
+        _compiled_section(
+            "evidence_traceability",
+            "Evidence Traceability",
+            summary=f"{len(detail['evidence'])} evidence rows, {len(detail['provenance']['source_notes'])} source notes, {len(detail['provenance']['mocs'])} atlas pages.",
+            items=[
+                {
+                    "kind": "evergreen",
+                    "label": "Evergreen note",
+                    "path": _scoped_path(
+                        f"/note?path={quote(detail['provenance']['evergreen_path'], safe='')}",
+                        pack_name=requested_pack,
+                    )
+                    if detail["provenance"]["evergreen_path"]
+                    else "",
+                    "detail": detail["provenance"]["evergreen_path"] or "No evergreen markdown path",
+                },
+                *[
+                    {
+                        "kind": "source_note",
+                        "label": item["title"],
+                        "path": _scoped_path(f"/note?path={quote(item['path'], safe='')}", pack_name=requested_pack),
+                        "detail": item["note_type"],
+                    }
+                    for item in detail["provenance"]["source_notes"][:3]
+                ],
+            ],
+        ),
+        _compiled_section(
+            "open_tensions",
+            "Open Tensions",
+            summary=f"{len(detail['contradictions']) if research_shell_enabled else 0} contradictions and {len(stale_summary_details) if research_shell_enabled else 0} stale-summary signals remain.",
+            items=[
+                *[
+                    {
+                        "kind": "contradiction",
+                        "label": item["subject_key"],
+                        "path": research_links["contradictions_path"],
+                        "detail": item["status"],
+                    }
+                    for item in detail["contradictions"][:3]
+                ],
+                *[
+                    {
+                        "kind": "stale_summary",
+                        "label": item["title"],
+                        "path": research_links["summaries_path"],
+                        "detail": ", ".join(item["reason_texts"]),
+                    }
+                    for item in stale_summary_details[:2]
+                ],
+            ],
+        ),
+        _compiled_section(
+            "where_to_go_next",
+            "Where To Go Next",
+            summary="Use the surrounding compiled products to continue reading or review.",
+            items=[
+                {
+                    "kind": "topic",
+                    "label": "Topic overview",
+                    "path": _scoped_path(f"/topic?id={quote(object_id, safe='')}", pack_name=requested_pack),
+                    "detail": "Open the surrounding topic page.",
+                },
+                *(
+                    [
+                        {
+                            "kind": "events",
+                            "label": "Event dossier",
+                            "path": research_links["events_path"],
+                            "detail": "See event and time context.",
+                        },
+                        {
+                            "kind": "contradictions",
+                            "label": "Contradiction review",
+                            "path": research_links["contradictions_path"],
+                            "detail": "Inspect open conflicts.",
+                        },
+                    ]
+                    if research_shell_enabled
+                    else []
+                ),
+            ],
+        ),
+    ]
     return {
         "screen": "object/page",
         "requested_pack": requested_pack,
@@ -1019,16 +1265,7 @@ def build_object_page_payload(
         "review_context": review_context,
         "review_history": list_review_actions(vault_dir, object_ids=[object_id], limit=8) if research_shell_enabled else [],
         "evolution": evolution_section,
-        "stale_summary_details": (
-            list_stale_summaries(
-                vault_dir,
-                pack_name=pack_name,
-                object_ids=[object_id],
-                limit=10,
-            )
-            if research_shell_enabled
-            else []
-        ),
+        "stale_summary_details": stale_summary_details,
         "open_contradiction_ids": (
             [item["contradiction_id"] for item in detail["contradictions"] if item["status"] == "open"]
             if research_shell_enabled
@@ -1039,20 +1276,8 @@ def build_object_page_payload(
             "graph_path": _graph_path(pack_name=requested_pack, object_id=object_id),
             **research_links,
         },
-        "section_nav": (
-            [
-                {"href": "#summary", "label": "Summary"},
-                {"href": "#claims", "label": "Claims"},
-                {"href": "#relations", "label": "Relations"},
-                {"href": "#contradictions", "label": "Contradictions"},
-            ]
-            if research_shell_enabled
-            else [
-                {"href": "#summary", "label": "Summary"},
-                {"href": "#claims", "label": "Claims"},
-                {"href": "#relations", "label": "Relations"},
-            ]
-        ),
+        "compiled_sections": compiled_sections,
+        "section_nav": [{"href": "#summary", "label": "Summary"}, *_section_nav_from_compiled_sections(compiled_sections)],
     }
 
 
@@ -1131,6 +1356,136 @@ def build_topic_overview_payload(
         "atlas_path": "",
         "graph_path": _graph_path(pack_name=requested_pack, object_id=object_id),
     }
+    compiled_sections = [
+        _compiled_section(
+            "current_state",
+            "Current State",
+            summary=f"{len(neighbors)} neighbors and {len(neighborhood['edges'])} edges define this topic view.",
+            items=[
+                {
+                    "kind": "center_object",
+                    "label": detail["object"]["title"],
+                    "path": _scoped_path(f"/object?id={quote(object_id, safe='')}", pack_name=requested_pack),
+                    "detail": detail["summary"]["summary_text"] if detail["summary"] else "No compiled summary yet.",
+                },
+                *[
+                    {
+                        "kind": "neighbor",
+                        "label": item["title"],
+                        "path": item["object_path"],
+                        "detail": "Neighbor in current topic scope",
+                    }
+                    for item in neighbors[:3]
+                ],
+            ],
+        ),
+        _compiled_section(
+            "why_it_matters",
+            "Why It Matters",
+            summary=f"{review_context.get('open_contradiction_count', 0)} contradictions and {review_context.get('stale_summary_count', 0)} stale summaries currently shape this topic.",
+            items=[
+                *(
+                    [
+                        {
+                            "kind": "events",
+                            "label": "Event dossier",
+                            "path": research_links["events_path"],
+                            "detail": "See time-bounded activity around this topic.",
+                        },
+                        {
+                            "kind": "deep_dives",
+                            "label": "Source deep dives",
+                            "path": research_links["deep_dives_path"],
+                            "detail": "Inspect supporting analysis.",
+                        },
+                    ]
+                    if research_shell_enabled
+                    else []
+                ),
+            ],
+        ),
+        _compiled_section(
+            "evidence_traceability",
+            "Evidence Traceability",
+            summary=f"{len(detail['provenance']['source_notes'])} source notes and {len(detail['provenance']['mocs'])} atlas pages anchor this topic.",
+            items=[
+                *[
+                    {
+                        "kind": "source_note",
+                        "label": item["title"],
+                        "path": _scoped_path(f"/note?path={quote(item['path'], safe='')}", pack_name=requested_pack),
+                        "detail": item["note_type"],
+                    }
+                    for item in detail["provenance"]["source_notes"][:3]
+                ],
+                *[
+                    {
+                        "kind": "atlas_page",
+                        "label": item["title"],
+                        "path": _scoped_path(f"/note?path={quote(item['path'], safe='')}", pack_name=requested_pack),
+                        "detail": "Atlas / MOC",
+                    }
+                    for item in detail["provenance"]["mocs"][:3]
+                ],
+            ],
+        ),
+        _compiled_section(
+            "open_tensions",
+            "Open Tensions",
+            summary=f"{len(scoped_contradictions)} open contradictions and {len(scoped_stale_summaries)} stale summaries remain in this topic scope.",
+            items=[
+                *[
+                    {
+                        "kind": "contradiction",
+                        "label": item["subject_key"],
+                        "path": research_links["contradictions_path"],
+                        "detail": item["status"],
+                    }
+                    for item in scoped_contradictions[:3]
+                ],
+                *[
+                    {
+                        "kind": "stale_summary",
+                        "label": item["title"],
+                        "path": research_links["summaries_path"],
+                        "detail": ", ".join(item["reason_texts"]),
+                    }
+                    for item in scoped_stale_summaries[:2]
+                ],
+            ],
+        ),
+        _compiled_section(
+            "where_to_go_next",
+            "Where To Go Next",
+            summary="Jump from the topic hub into the most useful next compiled products.",
+            items=[
+                {
+                    "kind": "center_object",
+                    "label": "Center object",
+                    "path": _scoped_path(f"/object?id={quote(object_id, safe='')}", pack_name=requested_pack),
+                    "detail": "Open the canonical object page.",
+                },
+                *(
+                    [
+                        {
+                            "kind": "contradictions",
+                            "label": "Contradictions",
+                            "path": research_links["contradictions_path"],
+                            "detail": "Review open tensions.",
+                        },
+                        {
+                            "kind": "atlas",
+                            "label": "Atlas / MOC",
+                            "path": research_links["atlas_path"],
+                            "detail": "Open atlas reach.",
+                        },
+                    ]
+                    if research_shell_enabled
+                    else []
+                ),
+            ],
+        ),
+    ]
     return {
         "screen": "overview/topic",
         "requested_pack": requested_pack,
@@ -1187,6 +1542,8 @@ def build_topic_overview_payload(
             "graph_path": _graph_path(pack_name=requested_pack, object_id=object_id),
             **research_links,
         },
+        "compiled_sections": compiled_sections,
+        "section_nav": _section_nav_from_compiled_sections(compiled_sections),
     }
 
 
@@ -1269,6 +1626,97 @@ def build_event_dossier_payload(
     event_type_counts = Counter(event["event_kind"] for event in events)
     row_type_counts = Counter(event["row_type"] for event in events)
     semantic_roles = Counter(event["semantic_role"] for event in events)
+    compiled_sections = [
+        _compiled_section(
+            "current_state",
+            "Current State",
+            summary=f"{len(events)} timeline rows grouped into {sum(len(section['clusters']) for section in cluster_sections)} visible event clusters.",
+            items=[
+                *[
+                    {
+                        "kind": "event_cluster",
+                        "label": item["title"],
+                        "path": item["review_links"]["topic_path"],
+                        "detail": f"{item['row_count']} timeline rows",
+                    }
+                    for section in cluster_sections[:2]
+                    for item in section["clusters"][:2]
+                ]
+            ],
+        ),
+        _compiled_section(
+            "why_it_matters",
+            "Why It Matters",
+            summary=f"{review_context.get('open_contradiction_count', 0)} contradictions and {review_context.get('stale_summary_count', 0)} stale summaries appear in the visible event scope.",
+            items=[
+                {"kind": "query", "label": query or "All events", "path": "", "detail": "Current dossier filter scope."},
+                {
+                    "kind": "contradictions",
+                    "label": "Contradiction review",
+                    "path": _scoped_path(f"/contradictions?q={quote(query or '', safe='')}", pack_name=requested_pack) if query else _scoped_path("/contradictions", pack_name=requested_pack),
+                    "detail": "Inspect tensions in the visible event scope.",
+                },
+            ],
+        ),
+        _compiled_section(
+            "evidence_traceability",
+            "Evidence Traceability",
+            summary=f"{len({note['slug'] for event in events for note in event['provenance']['source_notes']})} source notes and {len({moc['slug'] for event in events for moc in event['provenance']['mocs']})} atlas pages anchor the visible event scope.",
+            items=[
+                *[
+                    {
+                        "kind": "source_note",
+                        "label": note["title"],
+                        "path": _scoped_path(f"/note?path={quote(note['path'], safe='')}", pack_name=requested_pack),
+                        "detail": note["note_type"],
+                    }
+                    for event in events[:3]
+                    for note in event["provenance"]["source_notes"][:1]
+                ]
+            ],
+        ),
+        _compiled_section(
+            "open_tensions",
+            "Open Tensions",
+            summary=f"{len(scoped_contradictions)} contradictions and {len(scoped_stale_summaries)} stale summaries remain visible in this dossier.",
+            items=[
+                *[
+                    {
+                        "kind": "contradiction",
+                        "label": item["subject_key"],
+                        "path": _scoped_path(f"/contradictions?q={quote(item['subject_key'], safe='')}", pack_name=requested_pack),
+                        "detail": item["status"],
+                    }
+                    for item in scoped_contradictions[:3]
+                ],
+                *[
+                    {
+                        "kind": "stale_summary",
+                        "label": item["title"],
+                        "path": item["object_path"],
+                        "detail": ", ".join(item["reason_texts"]),
+                    }
+                    for item in scoped_stale_summaries[:2]
+                ],
+            ],
+        ),
+        _compiled_section(
+            "where_to_go_next",
+            "Where To Go Next",
+            summary="Continue from the timeline into object, contradiction, and summary review surfaces.",
+            items=[
+                *[
+                    {
+                        "kind": "topic",
+                        "label": item["title"],
+                        "path": item["review_links"]["topic_path"],
+                        "detail": "Open topic context for this event cluster.",
+                    }
+                    for item in events[:3]
+                ]
+            ],
+        ),
+    ]
     return {
         "screen": "event/dossier",
         "requested_pack": requested_pack,
@@ -1301,6 +1749,8 @@ def build_event_dossier_payload(
             "page_date rows come from note-level dates; heading_date rows come from dated section headings.",
         ],
         "query": query or "",
+        "compiled_sections": compiled_sections,
+        "section_nav": _section_nav_from_compiled_sections(compiled_sections),
     }
 
 
@@ -2257,8 +2707,86 @@ def build_contradiction_browser_payload(
                     "mocs": list(mocs.values()),
                 },
             }
-        )
+    )
     status_counts = Counter(item["status"] for item in items)
+    compiled_sections = [
+        _compiled_section(
+            "current_state",
+            "Current State",
+            summary=f"{len(items)} contradiction rows are currently visible, with {status_counts.get('open', 0)} still open.",
+            items=[
+                *[
+                    {
+                        "kind": "contradiction",
+                        "label": item["subject_key"],
+                        "path": _scoped_path(f"/contradictions?q={quote(item['subject_key'], safe='')}", pack_name=requested_pack),
+                        "detail": item["status"],
+                    }
+                    for item in items[:4]
+                ]
+            ],
+        ),
+        _compiled_section(
+            "why_it_matters",
+            "Why It Matters",
+            summary=f"{len({object_id for item in items for object_id in item['object_ids']})} objects and {len({note['slug'] for item in items for note in item['provenance']['source_notes']})} source notes are affected by the visible contradiction scope.",
+            items=[
+                {"kind": "filter", "label": status or "all", "path": "", "detail": "Current contradiction filter."},
+                {"kind": "query", "label": query or "all", "path": "", "detail": "Current query scope."},
+            ],
+        ),
+        _compiled_section(
+            "evidence_traceability",
+            "Evidence Traceability",
+            summary="Contradictions are anchored by ranked evidence and provenance across source notes and atlas pages.",
+            items=[
+                *[
+                    {
+                        "kind": "source_note",
+                        "label": note["title"],
+                        "path": _scoped_path(f"/note?path={quote(note['path'], safe='')}", pack_name=requested_pack),
+                        "detail": note["note_type"],
+                    }
+                    for item in items[:3]
+                    for note in item["provenance"]["source_notes"][:1]
+                ]
+            ],
+        ),
+        _compiled_section(
+            "open_tensions",
+            "Open Tensions",
+            summary=f"{status_counts.get('open', 0)} open rows still require review or dismissal.",
+            items=[
+                *[
+                    {
+                        "kind": "open_contradiction",
+                        "label": item["subject_key"],
+                        "path": _scoped_path(f"/contradictions?q={quote(item['subject_key'], safe='')}", pack_name=requested_pack),
+                        "detail": item["status_explanation"],
+                    }
+                    for item in items[:4]
+                    if item["status"] == "open"
+                ]
+            ],
+        ),
+        _compiled_section(
+            "where_to_go_next",
+            "Where To Go Next",
+            summary="Route from contradiction review into object pages and downstream maintenance.",
+            items=[
+                *[
+                    {
+                        "kind": "object",
+                        "label": item["object_titles"].get(link["object_id"], link["object_id"]),
+                        "path": link["path"],
+                        "detail": "Open affected object page.",
+                    }
+                    for item in items[:2]
+                    for link in item["object_links"][:2]
+                ]
+            ],
+        ),
+    ]
     return {
         "screen": "truth/contradictions",
         "requested_pack": requested_pack,
@@ -2295,6 +2823,8 @@ def build_contradiction_browser_payload(
         "empty_state": "Zero results usually means the current heuristic did not detect a conflict, not that the vault is globally contradiction-free.",
         "status": status or "",
         "query": query or "",
+        "compiled_sections": compiled_sections,
+        "section_nav": _section_nav_from_compiled_sections(compiled_sections),
     }
 
 
@@ -2465,6 +2995,107 @@ def build_truth_dashboard_payload(
                 "detail": item["detail"],
             }
         )
+    orientation = build_briefing_payload(vault_dir, pack_name=pack_name)
+    entry_sections = [
+        _compiled_section(
+            "what_changed_recently",
+            "What Changed Recently",
+            summary=f"{orientation.get('changed_object_count', 0)} changed objects and {orientation.get('recent_signal_count', 0)} recent signals surfaced.",
+            items=[
+                *[
+                    {
+                        "kind": "changed_object",
+                        "label": item["title"],
+                        "path": item["path"],
+                        "detail": f"Changed object · {item['object_id']}",
+                    }
+                    for item in orientation.get("changed_objects", [])[:4]
+                ]
+            ],
+        ),
+        _compiled_section(
+            "important_right_now",
+            "Important Right Now",
+            summary=f"{len(orientation.get('priority_items', []))} priority items are currently surfaced.",
+            items=[
+                *[
+                    {
+                        "kind": str(item["kind"]),
+                        "label": str(item["title"]),
+                        "path": str(item["path"]),
+                        "detail": str(item["detail"]),
+                    }
+                    for item in orientation.get("priority_items", [])[:4]
+                ]
+            ],
+        ),
+        _compiled_section(
+            "deserves_review",
+            "Deserves Review",
+            summary=f"{contradictions['open_count'] if research_overview_supported else signals['count']} review-oriented items are currently in scope.",
+            items=(
+                [
+                    {
+                        "kind": "contradiction",
+                        "label": item["subject_key"],
+                        "path": _scoped_path(
+                            f"/contradictions?q={quote(str(item['subject_key']), safe='')}",
+                            pack_name=requested_pack,
+                        ),
+                        "detail": f"{len(item['object_ids'])} objects in scope",
+                    }
+                    for item in contradictions["items"][:4]
+                ]
+                if research_overview_supported
+                else [
+                    {
+                        "kind": str(item["signal_type"]),
+                        "label": str(item["title"]),
+                        "path": str(item["source_path"]),
+                        "detail": str(item["detail"]),
+                    }
+                    for item in signals["items"][:4]
+                ]
+            ),
+        ),
+        _compiled_section(
+            "recommended_next_steps",
+            "Recommended Next Steps",
+            summary="Start with the orientation brief, then move into the highest-signal compiled surfaces.",
+            items=[
+                {
+                    "kind": "orientation",
+                    "label": "Orientation Brief",
+                    "path": _scoped_path("/briefing", pack_name=requested_pack),
+                    "detail": "Open the current knowledge entry product.",
+                },
+                {
+                    "kind": "signals",
+                    "label": "Signals",
+                    "path": _scoped_path("/signals", pack_name=requested_pack),
+                    "detail": "Review current active signals.",
+                },
+                {
+                    "kind": "production",
+                    "label": "Production",
+                    "path": _scoped_path("/production", pack_name=requested_pack),
+                    "detail": "Inspect production weak points.",
+                },
+                *(
+                    [
+                        {
+                            "kind": "graph",
+                            "label": "Clusters",
+                            "path": _scoped_path("/clusters", pack_name=requested_pack),
+                            "detail": "Explore graph clusters.",
+                        }
+                    ]
+                    if research_overview_supported
+                    else []
+                ),
+            ],
+        ),
+    ]
     return {
         "screen": "truth/dashboard",
         "requested_pack": requested_pack,
@@ -2512,6 +3143,8 @@ def build_truth_dashboard_payload(
             "items": signals["items"][:8],
             "browser_path": _scoped_path("/signals", pack_name=requested_pack),
         },
+        "orientation": orientation,
+        "entry_sections": entry_sections,
         "recent_review_actions": list_review_actions(vault_dir, limit=8),
         "priorities": priorities[:8],
     }

--- a/task_plan.md
+++ b/task_plan.md
@@ -76,3 +76,10 @@ Phase 4
   - registry-backed effective assembly/governance enumeration in `ovp-doctor`
   - explicit `/api/briefing`, `/api/signals`, and `/api/actions` endpoint assertions for contract provenance
   - closeout docs marking `Phase 18` complete / ready to close
+- `Phase 19` implementation is now complete:
+  - `orientation_brief` exists as a first-class assembly recipe
+  - `ovp-export --target orientation-brief` exports a compiled JSON entry product
+  - `/briefing` is now the orientation page
+  - `/` workbench home now exposes entry sections and routes into orientation
+  - object/topic/event/contradiction pages now expose stable compiled sections
+  - docs and verify checklists now treat orientation and compiled-page contracts as pack-level product semantics

--- a/tests/test_export_command.py
+++ b/tests/test_export_command.py
@@ -150,6 +150,38 @@ def test_export_command_can_export_orientation_brief(temp_vault, tmp_path, capsy
     ]
 
 
+def test_export_command_orientation_brief_uses_compiled_export_builder(
+    temp_vault, tmp_path, monkeypatch, capsys
+):
+    from openclaw_pipeline.commands import export_artifact
+
+    _seed_truth_store(temp_vault)
+    output_path = tmp_path / "orientation-brief.json"
+
+    monkeypatch.setattr(
+        export_artifact,
+        "execute_observation_surface_builder",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("raw observation builder should not run")),
+    )
+
+    exit_code = export_artifact.main(
+        [
+            "--vault-dir",
+            str(temp_vault),
+            "--target",
+            "orientation-brief",
+            "--output-path",
+            str(output_path),
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    exported = json.loads(output_path.read_text(encoding="utf-8"))
+    assert exit_code == 0
+    assert payload["source_name"] == "briefing"
+    assert exported["assembly_contract"]["recipe_name"] == "orientation_brief"
+
+
 def test_export_command_can_use_inherited_assembly_recipe_for_compatibility_pack(
     temp_vault, tmp_path, capsys
 ):

--- a/tests/test_export_command.py
+++ b/tests/test_export_command.py
@@ -112,6 +112,44 @@ def test_export_command_can_export_topic_overview(temp_vault, tmp_path, capsys):
     assert "# overview/topic" in output_path.read_text(encoding="utf-8")
 
 
+def test_export_command_can_export_orientation_brief(temp_vault, tmp_path, capsys):
+    from openclaw_pipeline.commands.export_artifact import main
+
+    _seed_truth_store(temp_vault)
+    output_path = tmp_path / "orientation-brief.json"
+
+    exit_code = main(
+        [
+            "--vault-dir",
+            str(temp_vault),
+            "--target",
+            "orientation-brief",
+            "--output-path",
+            str(output_path),
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    exported = json.loads(output_path.read_text(encoding="utf-8"))
+    assert exit_code == 0
+    assert payload["target"] == "orientation-brief"
+    assert payload["recipe_name"] == "orientation_brief"
+    assert payload["recipe_provider_pack"] == "research-tech"
+    assert payload["source_name"] == "briefing"
+    assert payload["source_provider_pack"] == "research-tech"
+    assert payload["source_provider_name"] == "research-tech-briefing"
+    assert output_path.exists()
+    assert exported["screen"] == "briefing/intelligence"
+    assert exported["assembly_contract"]["recipe_name"] == "orientation_brief"
+    assert [section["id"] for section in exported["compiled_sections"]] == [
+        "what_changed",
+        "what_matters",
+        "needs_review",
+        "next_reads",
+        "next_actions",
+    ]
+
+
 def test_export_command_can_use_inherited_assembly_recipe_for_compatibility_pack(
     temp_vault, tmp_path, capsys
 ):

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -81,6 +81,8 @@ def test_ui_server_root_serves_html_shell(temp_vault):
 
     assert response.status == 200
     assert "OpenClaw Truth UI" in body
+    assert "Where To Start" in body
+    assert "Orientation Brief" in body
     assert "/api/objects" in body
 
 
@@ -312,6 +314,8 @@ def test_ui_server_object_page_preserves_pack_scope_in_shell_nav(temp_vault):
     assert "inherited from object_brief in research-tech" in body
     assert "Source contract: wiki_view · object/page" in body
     assert "Source provider: default-knowledge · object/page" in body
+    assert "Why It Matters" in body
+    assert "Where To Go Next" in body
     assert "Source contract: wiki_view · object/page" in body
 
 
@@ -483,6 +487,8 @@ def test_ui_server_contradictions_page_renders_assembly_contract(temp_vault):
     assert "inherited from contradiction_view in research-tech" in body
     assert "Source contract: wiki_view · truth/contradictions" in body
     assert "Source provider: default-knowledge · truth/contradictions" in body
+    assert "Why It Matters" in body
+    assert "Where To Go Next" in body
 
 
 def test_ui_server_signals_endpoint_returns_payload(temp_vault):
@@ -1405,6 +1411,14 @@ def test_ui_server_briefing_endpoint_returns_payload(temp_vault):
     assert response.status == 200
     assert payload["recent_signal_count"] >= 1
     assert payload["active_topics"]
+    assert payload["assembly_contract"]["recipe_name"] == "orientation_brief"
+    assert [section["id"] for section in payload["compiled_sections"]] == [
+        "what_changed",
+        "what_matters",
+        "needs_review",
+        "next_reads",
+        "next_actions",
+    ]
 
 
 def test_ui_server_briefing_endpoint_accepts_pack_scope(temp_vault):
@@ -1456,11 +1470,13 @@ def test_ui_server_briefing_page_preserves_pack_scope_in_shell_nav(temp_vault):
     assert 'href="/signals?pack=default-knowledge"' in body
     assert 'href="/clusters?pack=default-knowledge"' in body
     assert "inherited from research-tech-briefing" in body
-    assert "inherited from operator_briefing in research-tech" in body
+    assert "inherited from orientation_brief in research-tech" in body
     assert "Source contract: observation_surface · briefing" in body
     assert "Source provider: research-tech · research-tech-briefing" in body
     assert "Governance Contract" in body
     assert "inherited from research_governance in research-tech" in body
+    assert "What Changed" in body
+    assert "Next Actions" in body
 
 
 def test_ui_server_briefing_page_renders_governance_resolver_metadata(temp_vault, monkeypatch):
@@ -1920,13 +1936,13 @@ def test_ui_server_briefing_endpoint_preserves_contract_metadata(temp_vault, mon
                 "description": "Briefing surface",
             },
             "assembly_contract": {
-                "recipe_name": "operator_briefing",
+                "recipe_name": "orientation_brief",
                 "requested_pack": pack_name or "",
                 "status": "inherited",
                 "provider_pack": "research-tech",
-                "provider_name": "operator_briefing",
-                "recipe_kind": "operator_briefing",
-                "description": "Operator briefing recipe",
+                "provider_name": "orientation_brief",
+                "recipe_kind": "orientation_brief",
+                "description": "Orientation briefing recipe",
                 "source_contract_kind": "observation_surface",
                 "source_contract_name": "briefing",
                 "source_provider_pack": "research-tech",
@@ -2698,12 +2714,11 @@ def test_ui_server_topic_page_preserves_pack_scope_in_shell_nav(temp_vault):
 
 def test_render_object_page_hides_research_affordances_when_pack_lacks_research_semantics(temp_vault, monkeypatch):
     import openclaw_pipeline.commands.ui_server as ui_server
-    from openclaw_pipeline.ui.view_models import build_object_page_payload
+    import openclaw_pipeline.ui.view_models as view_models
 
     _seed_truth_store(temp_vault)
-    payload = build_object_page_payload(temp_vault, "alpha")
-    payload["requested_pack"] = "media-editorial"
-    payload["research_shell_enabled"] = False
+    monkeypatch.setattr(view_models, "_supports_research_shell", lambda pack_name=None: False, raising=False)
+    payload = view_models.build_object_page_payload(temp_vault, "alpha", pack_name="default-knowledge")
     monkeypatch.setattr(ui_server, "_shell_supports_research_nav", lambda requested_pack="": False)
 
     body = ui_server._render_object_page(payload)

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -1185,6 +1185,11 @@ Thin note.
     production_gap = next(item for item in payload["priorities"] if item["kind"] == "production_gap")
     assert production_gap["path"].startswith("/note?path=50-Inbox%2F03-Processed%2F2026-04%2FLoose%20Source.md")
     assert payload["recent_review_actions"] == []
+    orientation_sections = {section["id"]: section for section in payload["orientation"]["compiled_sections"]}
+    entry_sections = {section["id"]: section for section in payload["entry_sections"]}
+    assert entry_sections["what_changed_recently"]["items"] == orientation_sections["what_changed"]["items"][:4]
+    assert entry_sections["important_right_now"]["items"] == orientation_sections["next_actions"]["items"][:4]
+    assert entry_sections["deserves_review"]["items"] == orientation_sections["needs_review"]["items"][:4]
 
 
 def test_build_truth_dashboard_payload_preserves_requested_pack(temp_vault):

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -97,6 +97,13 @@ def test_build_object_page_payload(temp_vault):
     assert payload["assembly_contract"]["source_contract_name"] == "object/page"
     assert payload["assembly_contract"]["source_provider_pack"] == "research-tech"
     assert payload["assembly_contract"]["source_provider_name"] == "object/page"
+    assert [section["id"] for section in payload["compiled_sections"]] == [
+        "current_state",
+        "why_it_matters",
+        "evidence_traceability",
+        "open_tensions",
+        "where_to_go_next",
+    ]
     assert payload["section_nav"][0]["href"] == "#summary"
     assert payload["review_context"]["object_count"] == 1
     assert payload["review_context"]["open_contradiction_count"] == 1
@@ -142,10 +149,13 @@ def test_build_object_page_payload_hides_research_affordances_when_research_shel
     assert payload["review_history"] == []
     assert payload["stale_summary_details"] == []
     assert payload["open_contradiction_ids"] == []
-    assert payload["section_nav"] == [
-        {"href": "#summary", "label": "Summary"},
-        {"href": "#claims", "label": "Claims"},
-        {"href": "#relations", "label": "Relations"},
+    assert [item["label"] for item in payload["section_nav"]] == [
+        "Summary",
+        "Current State",
+        "Why It Matters",
+        "Evidence Traceability",
+        "Open Tensions",
+        "Where To Go Next",
     ]
     assert payload["evolution"]["candidate_count"] == 0
     assert payload["evolution"]["accepted_count"] == 0
@@ -225,6 +235,13 @@ def test_build_topic_overview_payload(temp_vault):
     assert payload["assembly_contract"]["source_contract_name"] == "overview/topic"
     assert payload["assembly_contract"]["source_provider_pack"] == "research-tech"
     assert payload["assembly_contract"]["source_provider_name"] == "overview/topic"
+    assert [section["id"] for section in payload["compiled_sections"]] == [
+        "current_state",
+        "why_it_matters",
+        "evidence_traceability",
+        "open_tensions",
+        "where_to_go_next",
+    ]
     assert payload["links"]["center_object_path"] == "/object?id=alpha"
     assert payload["links"]["events_path"] == "/events?q=alpha"
     assert payload["center_summary"] == "Alpha supports local-first execution."
@@ -335,6 +352,13 @@ def test_build_event_dossier_payload(temp_vault):
     assert payload["assembly_contract"]["source_contract_name"] == "event/dossier"
     assert payload["assembly_contract"]["source_provider_pack"] == "research-tech"
     assert payload["assembly_contract"]["source_provider_name"] == "event/dossier"
+    assert [section["id"] for section in payload["compiled_sections"]] == [
+        "current_state",
+        "why_it_matters",
+        "evidence_traceability",
+        "open_tensions",
+        "where_to_go_next",
+    ]
     assert payload["event_count"] == 3
     assert payload["dates"] == ["2026-04-13"]
     assert payload["events"][0]["object_id"] == "alpha"
@@ -974,6 +998,13 @@ def test_build_contradiction_browser_payload(temp_vault):
     assert payload["assembly_contract"]["source_contract_name"] == "truth/contradictions"
     assert payload["assembly_contract"]["source_provider_pack"] == "research-tech"
     assert payload["assembly_contract"]["source_provider_name"] == "truth/contradictions"
+    assert [section["id"] for section in payload["compiled_sections"]] == [
+        "current_state",
+        "why_it_matters",
+        "evidence_traceability",
+        "open_tensions",
+        "where_to_go_next",
+    ]
     assert payload["count"] == 1
     assert payload["items"][0]["subject_key"] == "alpha"
     assert payload["open_count"] == 1
@@ -1135,6 +1166,13 @@ Thin note.
     payload = build_truth_dashboard_payload(temp_vault)
 
     assert payload["screen"] == "truth/dashboard"
+    assert payload["orientation"]["assembly_contract"]["recipe_name"] == "orientation_brief"
+    assert [section["id"] for section in payload["entry_sections"]] == [
+        "what_changed_recently",
+        "important_right_now",
+        "deserves_review",
+        "recommended_next_steps",
+    ]
     assert payload["objects"]["count"] == 4
     assert payload["contradictions"]["count"] == 1
     assert payload["events"]["count"] == 4
@@ -1418,7 +1456,7 @@ def test_build_briefing_payload(temp_vault):
     payload = build_briefing_payload(temp_vault)
 
     assert payload["screen"] == "briefing/intelligence"
-    assert payload["assembly_contract"]["recipe_name"] == "operator_briefing"
+    assert payload["assembly_contract"]["recipe_name"] == "orientation_brief"
     assert payload["assembly_contract"]["status"] == "declared"
     assert payload["assembly_contract"]["source_contract_kind"] == "observation_surface"
     assert payload["assembly_contract"]["source_contract_name"] == "briefing"
@@ -1433,6 +1471,20 @@ def test_build_briefing_payload(temp_vault):
     assert payload["active_topics"]
     assert payload["insights"]
     assert payload["priority_items"]
+    assert [section["id"] for section in payload["compiled_sections"]] == [
+        "what_changed",
+        "what_matters",
+        "needs_review",
+        "next_reads",
+        "next_actions",
+    ]
+    assert [item["href"] for item in payload["section_nav"]] == [
+        "#what-changed",
+        "#what-matters",
+        "#needs-review",
+        "#next-reads",
+        "#next-actions",
+    ]
     assert payload["queue_summary"]["queued_count"] >= 0
 
 
@@ -1447,6 +1499,7 @@ def test_build_briefing_payload_preserves_requested_pack(temp_vault):
     assert payload["screen"] == "briefing/intelligence"
     assert payload["assembly_contract"]["status"] == "inherited"
     assert payload["assembly_contract"]["provider_pack"] == "research-tech"
+    assert payload["assembly_contract"]["recipe_name"] == "orientation_brief"
     assert payload["assembly_contract"]["source_provider_pack"] == "research-tech"
     assert payload["assembly_contract"]["source_provider_name"] == "research-tech-briefing"
     assert payload["surface_contract"]["surface_kind"] == "briefing"


### PR DESCRIPTION
## Summary

This PR completes `Phase 19` by turning the contract stack from Phase 18 into user-facing entry products.

It adds a first-class `orientation_brief`, upgrades `/briefing` into an orientation surface, gives object/topic/event/contradiction pages stable compiled sections, and makes `/` a real workbench entry screen.

## What Changed

- added `orientation_brief` to `research-tech` assembly recipes
- added `ovp-export --target orientation-brief` for compiled JSON entry products
- upgraded briefing payloads into orientation products with stable `compiled_sections` and `section_nav`
- added compiled page sections and navigation to object/topic/event/contradiction payloads
- upgraded the shared UI shell root page with `Where To Start`, `Orientation Brief`, and entry sections
- closed out the Phase 19 plan and updated pack/operator docs

## Why

Phase 17 solved graph exploration and Phase 18 solved explicit runtime contracts, but OVP still lacked a strong entry surface. The product still made users infer where to start.

This PR spends the contract stack on product semantics so the system answers:

- what matters now
- where to start reading
- what to do next

## Validation

```bash
python3.11 -m py_compile .worktrees/phase19-pr-clean/src/openclaw_pipeline/commands/export_artifact.py .worktrees/phase19-pr-clean/src/openclaw_pipeline/ui/view_models.py .worktrees/phase19-pr-clean/src/openclaw_pipeline/commands/ui_server.py .worktrees/phase19-pr-clean/src/openclaw_pipeline/packs/research_tech/assembly_recipes.py
PYTHONPATH=.worktrees/phase19-pr-clean/src pytest -q .worktrees/phase19-pr-clean/tests/test_export_command.py .worktrees/phase19-pr-clean/tests/test_ui_view_models.py .worktrees/phase19-pr-clean/tests/test_ui_server.py .worktrees/phase19-pr-clean/tests/test_doctor_command.py .worktrees/phase19-pr-clean/tests/test_truth_api.py .worktrees/phase19-pr-clean/tests/test_pack_loader.py .worktrees/phase19-pr-clean/tests/test_execution_contract_registry.py .worktrees/phase19-pr-clean/tests/test_processor_contract_registry.py
```

Result: `262 passed in 40.72s`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Orientation Brief" as a first-class entry product with compiled knowledge summary
  * Extended object/topic/event/contradiction pages with stable compiled sections (current state, why it matters, evidence traceability, open tensions, where to go next)
  * Enhanced workbench home with "Where To Start" entry sections and orientation access
  * Added section navigation across briefing and page views
  * Enabled `ovp-export --target orientation-brief` to export compiled entry products

* **Documentation**
  * Updated API documentation and verification guides for orientation and compiled-page contracts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->