### PR TITLE
[codex] fix briefing page title

### DIFF
--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -2667,7 +2667,7 @@ def _render_briefing_page(payload: dict) -> str:
         for bucket, count in queue_summary.get("failure_buckets", {}).items()
     ) or "<li class='muted'>No failed actions.</li>"
     return _layout(
-        "Working Memory Snapshot",
+        "Orientation Brief",
         "".join(
             [
                 "<h1>Orientation Brief</h1>",

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -111,6 +111,29 @@ def test_ui_server_root_accepts_pack_scope(temp_vault):
     assert "inherited from research-tech-production-chains" in body
 
 
+def test_ui_server_briefing_page_uses_orientation_title(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+
+    _seed_truth_store(temp_vault)
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("GET", "/briefing")
+        response = conn.getresponse()
+        body = response.read().decode("utf-8")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 200
+    assert "<title>Orientation Brief</title>" in body
+    assert "<h1>Orientation Brief</h1>" in body
+
+
 def test_ui_server_objects_endpoint_returns_json(temp_vault):
     from openclaw_pipeline.commands.ui_server import create_server
 


### PR DESCRIPTION
## Summary

Follow-up fix for merged PR #33.

The Phase 19 rename changed the visible briefing heading to `Orientation Brief`, but the page-level HTML `<title>` still said `Working Memory Snapshot`. This PR aligns the document title with the rendered page heading and adds a regression test so the mismatch cannot reappear silently.

## What Changed

- changed the briefing page `_layout()` title from `Working Memory Snapshot` to `Orientation Brief`
- added a UI server regression test that asserts both the `<title>` and `<h1>` match

## Why

After #33 merged, review surfaced a real UI inconsistency: browser tab/window title and page heading diverged for `/briefing`.

## Validation

```bash
python3.11 -m py_compile .worktrees/briefing-title-fix/src/openclaw_pipeline/commands/ui_server.py
PYTHONPATH=.worktrees/briefing-title-fix/src pytest -q .worktrees/briefing-title-fix/tests/test_ui_server.py
```

Result: `71 passed in 35.52s`
