### PR TITLE
[codex] close phase20-23 semantic trust and signal loop slices

### DIFF
--- a/docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
+++ b/docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
@@ -228,7 +228,7 @@ Exit condition:
 
 ### Milestone 4: Event And Contradiction Model Hardening
 
-Status: **In Progress**
+Status: **Complete**
 
 Goal:
 
@@ -248,7 +248,7 @@ Exit condition:
 
 ### Milestone 5: Knowledge Production Traceability
 
-Status: **In Progress**
+Status: **Complete**
 
 Goal:
 
@@ -279,7 +279,7 @@ Exit condition:
 
 ### Milestone 6: Product Shell And Operator UX
 
-Status: **Not Started**
+Status: **Complete**
 
 Goal:
 
@@ -504,18 +504,34 @@ The just-finished sequence was:
 1. `Phase 17`
 2. `Phase 18`
 3. `Phase 19`
+4. `Phase 20`
+5. `Phase 21`
+6. `Phase 22`
+7. `Phase 23`
 
 Completed references:
 
 - [[2026-04-16-phase17-research-graph-visualization-plan]]
 - [[2026-04-17-phase18-knowledge-compiler-contract-consolidation-plan]]
 - [[2026-04-17-phase19-orientation-and-compiled-knowledge-products]]
+- [[2026-04-17-phase20-semantic-trust-and-production-traceability]]
+- [[2026-04-17-phase21-product-shell-and-operator-ux]]
+- [[2026-04-17-phase22-active-signal-impact-accounting]]
+- [[2026-04-18-phase23-inbound-capture-audit-visibility]]
+
+Active next reference:
+
+- `Milestone 7: Active Signal Loop` (next execution slice should focus on brain-first lookup + backlink legibility)
 
 What those phases accomplished:
 
 - `Phase 17` made the research graph explorable as a real bounded product surface
 - `Phase 18` made the current runtime legible as explicit knowledge-compiler contracts
 - `Phase 19` turned those contracts into entry products: orientation brief, compiled-page sections, and a real workbench home
+- `Phase 20` turned event/contradiction surfaces and production-chain views into semantically trustworthy, traceable products
+- `Phase 21` turned the trustworthy workbench into a clearer operator shell with workflow IA, next-step rails, and denser page ordering
+- `Phase 22` turned passive signal surfaces into a first active loop by making signal/action/result impact legible from the product itself
+- `Phase 23` made inbound note capture legible by turning existing pipeline/refine audit into note, signal, and briefing products
 
 What this sequence closed:
 
@@ -523,19 +539,27 @@ What this sequence closed:
 - contract boundaries are no longer the missing piece
 - orientation on entry is no longer the obvious missing piece
 - the current product surface now has a clearer default entry path and stronger compiled pages
+- the signal loop no longer stops at passive visibility; it now shows whether execution was productive, stalled, failed, or still waiting
+- the signal loop now also shows what recent inbound note capture actually did before queue execution became relevant
+
+What the next phase should close:
+
+- the next phase should tighten brain-first lookup before object/link creation
+- newly created downstream objects should make backlink expectations more explicit
+- the operator should be able to see when capture created candidate vs canonical downstream knowledge without widening into opaque background automation
 
 Sequence rule:
 
 - do not reopen `Phase 17` graph-canvas internals unless a real product gap appears
 - do not reopen `Phase 18` contract plumbing unless a new contract family ambiguity appears
 - do not reopen `Phase 19` product-semantic work unless a new entry-surface/product-contract gap appears
+- treat `Phase 20` as the closeout for Milestones 4 and 5 instead of reopening the archived `Phase 10` / `Phase 11` slices independently
+- treat `Phase 21` as the closeout for Milestone 6
+- treat `Phase 22` as the first closeout slice for Milestone 7
+- treat `Phase 23` as the second closeout slice for Milestone 7
+- use the next Milestone 7 slice for brain-first lookup + backlink legibility instead of reopening shell UX or widening immediately into background intelligence
 
 This keeps the roadmap moving from substrate -> contracts -> entry products, instead of looping back into infrastructure.
-
-Closeout:
-
-- [[2026-04-16-phase17-research-graph-visualization-plan]]
-- [[2026-04-16-phase17-research-graph-visualization-closeout]]
 
 ## Non-Recommended Paths Right Now
 
@@ -578,9 +602,9 @@ As of this plan:
 - Milestone 1: complete
 - Milestone 2: complete
 - Milestone 3: complete
-- Milestone 4: in progress
-- Milestone 5: in progress
-- Milestone 6: not started
+- Milestone 4: complete
+- Milestone 5: complete
+- Milestone 6: complete
 - Milestone 7: in progress
 - Milestone 8+: not started
 

--- a/docs/plans/2026-04-17-phase20-semantic-trust-and-production-traceability.md
+++ b/docs/plans/2026-04-17-phase20-semantic-trust-and-production-traceability.md
@@ -1,0 +1,253 @@
+# Phase 20: Semantic Trust And Production Traceability
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Status:** complete
+
+**Goal:** Make the post-Phase-19 workbench trustworthy in its two weakest places: event/contradiction semantics and end-to-end knowledge production traceability.
+
+**Architecture:** `Phase 19` made the workbench easy to enter. `Phase 20` should make it easier to trust. Do not introduce a new ontology store, hosted service, or memory backend. Reuse the existing truth store, compiled-page contract stack, and `research-tech` pack surfaces. Harden the payload contracts that leave `truth_api.py`, then spend those contracts on stronger compiled pages and provenance-first aggregate views. This phase intentionally supersedes the remaining product work implied by the older `Phase 10` and `Phase 11` docs, because the current contract/UI architecture is now materially different.
+
+**Tech Stack:** Python 3.13, SQLite via stdlib `sqlite3`, `truth_api.py`, `ui/view_models.py`, `commands/ui_server.py`, `knowledge_index.py`, current `research-tech` pack contracts, pytest.
+
+## Why This Is The Right Next Phase
+
+`Phase 17` solved graph exploration.  
+`Phase 18` solved contract legibility.  
+`Phase 19` solved entry products.
+
+What is still weak is not “where do I click?” but:
+
+- can I trust what `/events` means?
+- can I trust what a contradiction row actually claims?
+- can I tell what knowledge a source note or deep dive really produced?
+- can I move through the production chain without reconstructing it in my head?
+
+That is why the next move should **not** be:
+
+- temporal truth modeling,
+- harness/session memory,
+- benchmark infrastructure,
+- graph workspaces,
+- or a wider shell redesign.
+
+The next move should be to make the current workbench semantically harder and production-legible.
+
+## Product Thesis
+
+After `Phase 20`, a user should be able to answer five questions from the product itself:
+
+1. What kind of timeline row am I looking at?
+2. Why is this item treated as an event rather than only a dated note?
+3. Why is this contradiction open, and what evidence anchors it?
+4. What did this source note or deep dive actually produce?
+5. Where in the production chain am I right now?
+
+This phase is therefore about two things:
+
+- **semantic trust**
+- **production-chain legibility**
+
+## Relationship To Earlier Plans
+
+This phase should be treated as the active successor to the older plans:
+
+- [[2026-04-14-phase10-event-contradiction-hardening]]
+- [[2026-04-14-phase11-knowledge-production-traceability]]
+
+Those plans remain useful historical slices, but they were written before:
+
+- the current contract stack existed,
+- `ovp-export` and `ovp-ui` shared assembly/governance explanations,
+- `Phase 19` turned the workbench into an entry-product surface.
+
+`Phase 20` should therefore **supersede their remaining work**, not compete with them.
+
+## What Phase 20 Must Deliver
+
+### 1. Event Semantics Contract v1
+
+Add explicit event/timeline semantics to the product contract:
+
+- row type
+- semantic role
+- anchor kind
+- grouping kind
+- event-vs-note explanation
+
+Users should be able to tell whether they are looking at:
+
+- a note-date projection,
+- a heading-date projection,
+- or a stronger grouped event summary.
+
+### 2. Contradiction Semantics Contract v1
+
+Add explicit contradiction semantics to the product contract:
+
+- detection model
+- confidence semantics
+- polarity / tension explanation
+- evidence summary
+- status bucket semantics
+
+This does **not** mean “replace the detector.”
+It means the current detector must stop hiding behind prose.
+
+### 3. Production Traceability Contract v2
+
+Strengthen the stable production-chain contract for:
+
+- notes
+- deep dives
+- objects
+- topics
+- Atlas/MOC pages
+
+Users should be able to see:
+
+- upstream source material
+- intermediate deep dives / processed notes
+- downstream objects
+- downstream Atlas/topic reach
+- missing links or weak spots in the chain
+
+### 4. Compiled Trust Sections On Key Pages
+
+Spend the stronger contracts on the pages that matter most:
+
+- `/events`
+- `/contradictions`
+- `/note`
+- `/object`
+- `/topic`
+- `/production`
+
+These pages should answer:
+
+- what this surface means
+- what evidence anchors it
+- what is ambiguous
+- what this item produced
+- where the user should go next
+
+### 5. Provenance-First Aggregate Views
+
+Upgrade aggregate surfaces so they explain contribution, not only membership:
+
+- event grouping summaries
+- contradiction queue summaries
+- production-chain summaries
+- Atlas/topic contribution summaries
+
+This phase should make aggregate browsing feel like a compiled editorial surface, not a pile of filtered rows.
+
+## What Phase 20 Should Not Do
+
+Explicit deferrals:
+
+- full temporal truth modeling (`valid_at / invalid_at / expired_at`)
+- LLM-heavy contradiction rewrites
+- session/harness memory capture
+- graph workspaces or saved routes
+- backend migration or new runtime store
+- benchmark platform work
+- external domain-pack expansion
+
+Those all remain valid later. They are not the next highest-leverage move.
+
+## Recommended Implementation Shape
+
+### Task 1: Harden Event Payload Semantics
+
+**Files:**
+- Modify: `src/openclaw_pipeline/truth_api.py`
+- Modify: `src/openclaw_pipeline/ui/view_models.py`
+- Modify: `src/openclaw_pipeline/commands/ui_server.py`
+- Test: `tests/test_truth_api.py`
+- Test: `tests/test_ui_view_models.py`
+- Test: `tests/test_ui_server.py`
+
+**Deliverable:**
+
+- stable timeline/event contract fields
+- explicit grouping semantics
+- clearer event-level summaries on `/events` and event dossiers
+
+### Task 2: Harden Contradiction Payload Semantics
+
+**Files:**
+- Modify: `src/openclaw_pipeline/truth_api.py`
+- Modify: `src/openclaw_pipeline/ui/view_models.py`
+- Modify: `src/openclaw_pipeline/commands/ui_server.py`
+- Test: `tests/test_truth_api.py`
+- Test: `tests/test_ui_view_models.py`
+- Test: `tests/test_ui_server.py`
+
+**Deliverable:**
+
+- stable contradiction contract fields
+- explicit evidence and polarity summaries
+- better zero/open/reviewed semantics on `/contradictions`
+
+### Task 3: Upgrade Production Traceability Contracts
+
+**Files:**
+- Modify: `src/openclaw_pipeline/truth_api.py`
+- Modify: `src/openclaw_pipeline/ui/view_models.py`
+- Modify: `src/openclaw_pipeline/commands/ui_server.py`
+- Reference: existing note/object/topic/production builders
+- Test: `tests/test_truth_api.py`
+- Test: `tests/test_ui_view_models.py`
+- Test: `tests/test_ui_server.py`
+
+**Deliverable:**
+
+- stronger note/object/topic/deep-dive production summaries
+- explicit chain counts and gap semantics
+- easier chain navigation from compiled pages
+
+### Task 4: Spend The Contracts On Product Surfaces
+
+**Files:**
+- Modify: `src/openclaw_pipeline/ui/view_models.py`
+- Modify: `src/openclaw_pipeline/commands/ui_server.py`
+- Test: `tests/test_ui_view_models.py`
+- Test: `tests/test_ui_server.py`
+
+**Deliverable:**
+
+- `compiled_sections` for semantic trust and production traceability land on the key pages
+- pages surface “why this appears” and “what this produced” without requiring CLI or DB inference
+
+### Task 5: Verification And Plan Closeout
+
+**Files:**
+- Modify: `docs/plans/2026-04-14-local-knowledge-workbench-milestone.md`
+- Modify: `docs/research-tech/RESEARCH_TECH_VERIFY.md`
+- Modify: `progress.md`
+- Modify: `task_plan.md`
+
+**Deliverable:**
+
+- verify docs cover the upgraded trust/traceability pages
+- milestone sequencing clearly points at `Phase 20` as the active next execution target
+- the new phase is ready to hand off into implementation
+
+## Exit Condition
+
+`Phase 20` is complete when all of the following are true:
+
+1. `/events` explains stable row and grouping semantics instead of relying on interpretation alone.
+2. `/contradictions` explains stable detection/evidence/polarity semantics instead of relying on prose alone.
+3. note/object/topic/production pages make the full knowledge production chain legible from the product itself.
+4. users can answer “why is this here?” and “what did this produce?” without reconstructing the chain manually.
+5. focused tests lock the payload contracts so later heuristic changes cannot silently weaken product meaning.
+
+## Recommended Follow-Up Ordering
+
+After `Phase 20`, the most plausible next options are:
+
+1. finish the remaining product-shell/operator UX work only if real navigation gaps remain,
+2. deepen the active signal loop where it materially improves traceability and review quality,
+3. defer temporal truth and harness-memory work until the current workbench semantics are clearly strong enough to justify a harder model.

--- a/docs/plans/2026-04-17-phase21-product-shell-and-operator-ux.md
+++ b/docs/plans/2026-04-17-phase21-product-shell-and-operator-ux.md
@@ -1,0 +1,191 @@
+# Phase 21: Product Shell And Operator UX
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Turn the current post-Phase-20 workbench into a clearer operator product where first-time users can see the main workflows, move between surfaces intentionally, and act without reconstructing the shell in their head.
+
+**Architecture:** Keep the existing truth/runtime/contracts intact. Do not introduce a frontend rewrite, new routing framework, or new product shell backend. Spend the current `truth_api.py` + `ui/view_models.py` + `commands/ui_server.py` stack on clearer shell-level workflow grouping, stronger cross-surface affordances, and denser page-level operator context.
+
+**Tech Stack:** Python 3.13, stdlib HTTP UI shell, `ui/view_models.py`, `commands/ui_server.py`, existing payload contracts, pytest.
+
+**Status:** Complete
+
+## Why This Is The Right Next Phase
+
+`Phase 19` solved entry products.  
+`Phase 20` solved semantic trust and production-chain legibility.
+
+What is still weak is the shell itself:
+
+- the home/dashboard still reads like a pile of useful cards, not a clear workflow map,
+- cross-surface navigation still depends too much on remembering which route to open,
+- operator actions exist, but the UI does not yet make the common flows feel explicit,
+- the product is trustworthy now, but not yet obviously easy to operate.
+
+That makes `Milestone 6` the highest-leverage next step.
+
+## Product Thesis
+
+After `Phase 21`, a first-time user should be able to answer four questions without reading docs:
+
+1. Where should I start?
+2. Which route should I open to inspect, review, trace, or search?
+3. What should I do next from this page?
+4. Which surfaces are shared-shell surfaces vs research-only surfaces?
+
+This phase is therefore about:
+
+- **workflow-first navigation**
+- **operator affordance density**
+- **page-level next-step clarity**
+
+## What Phase 21 Must Deliver
+
+### 1. Dashboard Workflow IA
+
+The home/dashboard should expose the main workbench workflows as named groups, not only as raw cards:
+
+- orient
+- inspect
+- review
+- trace
+- explore
+
+This should be a stable payload contract plus a visible UI block near the top of `/`.
+
+### 2. Cross-Surface Operator Affordances
+
+Key pages should expose a consistent “what to do next from here” strip, not only local card links:
+
+- object
+- topic
+- events
+- contradictions
+- signals
+- production
+
+The goal is not more links. The goal is more legible actions.
+
+### 3. Clearer Shared-Shell vs Research-Shell Semantics
+
+The shell should make it more obvious when a page is:
+
+- shared-shell available
+- inherited from `research-tech`
+- research-specific / hidden for compatibility packs
+
+This should remain driven by existing contracts, not by new ad-hoc booleans.
+
+### 4. Denser, Better Ordered Page Context
+
+The shell should favor:
+
+- immediate state summary,
+- next-step affordances,
+- then detailed evidence/review blocks.
+
+This is ordering and grouping work, not a visual redesign phase.
+
+## What Phase 21 Should Not Do
+
+Do not:
+
+- reopen event/contradiction semantics,
+- reopen production-chain modeling,
+- add temporal truth,
+- build a new UI stack,
+- redesign the graph experience,
+- or widen into background intelligence / signal automation.
+
+## Recommended Implementation Shape
+
+### Task 1: Add Dashboard Workflow Groups
+
+**Files:**
+- Modify: `src/openclaw_pipeline/ui/view_models.py`
+- Modify: `src/openclaw_pipeline/commands/ui_server.py`
+- Test: `tests/test_ui_view_models.py`
+- Test: `tests/test_ui_server.py`
+
+**Deliverable:**
+
+- stable dashboard `workflow_groups`
+- visible “workflow map” block on `/`
+- workflow links preserve pack scope
+
+### Task 2: Add Consistent Operator Action Rails
+
+**Files:**
+- Modify: `src/openclaw_pipeline/ui/view_models.py`
+- Modify: `src/openclaw_pipeline/commands/ui_server.py`
+- Test: `tests/test_ui_view_models.py`
+- Test: `tests/test_ui_server.py`
+
+**Deliverable:**
+
+- note/object/topic/event/contradiction/signal/production pages expose a small, consistent action rail
+- rails are contract-driven or payload-driven, not stringly scattered in templates
+
+### Task 3: Reorder And Tighten Page Shells
+
+**Files:**
+- Modify: `src/openclaw_pipeline/commands/ui_server.py`
+- Test: `tests/test_ui_server.py`
+
+**Deliverable:**
+
+- shell pages lead with current-state + next-step context
+- operator sections become easier to scan
+- shared-shell/research-shell status remains explicit
+
+### Task 4: Verify And Close Out
+
+**Files:**
+- Modify: `docs/plans/2026-04-14-local-knowledge-workbench-milestone.md`
+- Modify: `docs/research-tech/RESEARCH_TECH_VERIFY.md`
+- Modify: `progress.md`
+- Modify: `task_plan.md`
+
+**Deliverable:**
+
+- verify docs cover workflow IA and operator rails
+- milestone sequencing points to the next real gap after shell UX
+- `Phase 21` is ready to close cleanly
+
+## Exit Condition
+
+`Phase 21` is complete when all of the following are true:
+
+1. `/` exposes clear workflow groups instead of only a pile of cards.
+2. Key workbench pages expose explicit next-step/operator rails.
+3. Shared-shell vs research-shell availability remains clear from the product surface.
+4. A first-time user can navigate the main workflows without reading plan docs.
+
+## Closeout
+
+`Phase 21` is complete.
+
+What landed:
+
+- dashboard `workflow_groups` and a visible `Workflow Map` on `/`
+- consistent `Next Actions` operator rails on:
+  - note
+  - object
+  - topic
+  - events
+  - contradictions
+  - signals
+  - production
+- page-shell ordering that now leads with:
+  - a lead compiled section
+  - explicit next actions
+  - then contract/status and deeper detail blocks
+
+Verification basis:
+
+- focused red/green tests for workflow groups, operator rails, and shell ordering
+- full `tests/test_ui_view_models.py` and `tests/test_ui_server.py` suite green
+
+Next real gap after shell UX:
+
+- `Milestone 7: Active Signal Loop`

--- a/docs/plans/2026-04-17-phase22-active-signal-impact-accounting.md
+++ b/docs/plans/2026-04-17-phase22-active-signal-impact-accounting.md
@@ -1,0 +1,228 @@
+# Phase 22: Active Signal Impact Accounting
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Turn the current passive signal surfaces into an active, trustworthy loop by making each signal explain what execution it triggered, where it currently sits, and whether it produced visible downstream knowledge changes.
+
+**Architecture:** Keep the existing signal ledger, action queue, focused-action contracts, and UI shell. Do not widen into background note hooks, asynchronous entity detection, or temporal memory infrastructure. This phase should spend the current `signal -> recommended_action -> action_queue -> focused_action result -> truth refresh` pipeline on impact accounting and lifecycle legibility, so operators can see which signals actually improved the system and which ones stalled.
+
+**Tech Stack:** Python 3.13, stdlib JSON/SQLite runtime, `truth_api.py`, `ui/view_models.py`, `commands/ui_server.py`, current `research-tech` observation surfaces, pytest.
+
+**Status:** Complete
+
+## Why This Is The Right Next Phase
+
+`Phase 21` made the shell easier to operate.
+
+What is still weak is the active loop itself:
+
+- signals can recommend actions, but they do not clearly explain whether execution ever happened,
+- queued/running/failed/succeeded state exists, but it is not yet shaped into a product-level impact summary,
+- action results are stored, but users cannot quickly tell whether a signal led to visible downstream change,
+- the workbench can show current signals, but not yet whether those signals were productive.
+
+That makes the first slice of `Milestone 7` a traceable signal loop, not broader automation.
+
+## Product Thesis
+
+After `Phase 22`, an operator should be able to answer five questions from `/signals`, `/briefing`, and `/actions` without reading logs:
+
+1. Did this signal create an action or not?
+2. If it created one, what lifecycle state is it in now?
+3. If execution finished, did it produce any visible downstream artifact or knowledge change?
+4. Which signals are productive, stalled, failed, or still waiting?
+5. What is the first useful sign that the signal loop is improving the workbench?
+
+This phase is therefore about:
+
+- **signal lifecycle legibility**
+- **action/result impact accounting**
+- **briefing-level visibility into productive vs stalled work**
+
+## What Phase 22 Must Deliver
+
+### 1. Signal Impact Contract v1
+
+Each signal should expose an explicit `impact_summary` derived from:
+
+- recommended action metadata
+- action queue state
+- action result payloads
+
+The contract should cover at least:
+
+- `impact_status`
+- `lifecycle_stage`
+- `action_kind`
+- `action_status`
+- `impact_label`
+- `impact_detail`
+- a small set of stable counts or artifacts when available
+
+This should stay deterministic and be computed from existing runtime state.
+
+### 2. Signal Browser Upgrade
+
+`/signals` should surface the signal impact contract directly:
+
+- productive signals should look different from merely queued ones,
+- failed/stalled signals should be clearly legible,
+- the page should explain the active loop instead of only listing signals.
+
+This should remain a product-layer improvement over existing payloads, not a new signal engine.
+
+### 3. Briefing Upgrade
+
+`/briefing` should stop treating all signals equally.
+
+It should summarize the active loop with categories such as:
+
+- productive recently
+- waiting in queue
+- blocked / failed
+- review-only / no execution path
+
+The first useful sign of `Milestone 7` is that the orientation layer can tell whether the signal loop is producing downstream value.
+
+### 4. Action Queue Legibility
+
+`/actions` should explain action results in terms that line up with the signal impact contract, so the queue page and the signal page are describing the same lifecycle.
+
+Do not introduce a second interpretation model on the action page.
+
+### 5. Phase Closeout Without Widening Scope
+
+This phase should end once impact accounting is visible and stable.
+
+Do not widen into:
+
+- note save/update hooks,
+- generalized inbound signal capture,
+- background enrichment workers,
+- entity evolution,
+- or benchmark infrastructure.
+
+Those remain later slices of `Milestone 7`.
+
+## What Phase 22 Should Not Do
+
+Explicit deferrals:
+
+- automatic capture on every note save/update
+- new signal types unrelated to current trusted surfaces
+- opaque “AI decided this matters” background processing
+- temporal truth modeling
+- harness/session memory capture
+- graph synthesis or graph-triggered automation
+
+## Recommended Implementation Shape
+
+### Task 1: Write The Failing Impact-Contract Tests
+
+**Files:**
+- Modify: `tests/test_truth_api.py`
+- Modify: `tests/test_ui_view_models.py`
+- Modify: `tests/test_ui_server.py`
+
+**Deliverable:**
+
+- failing tests for signal impact summaries
+- failing tests for briefing/action payload exposure
+- failing tests for UI rendering of impact status
+
+### Task 2: Implement Signal Impact Accounting In `truth_api.py`
+
+**Files:**
+- Modify: `src/openclaw_pipeline/truth_api.py`
+- Test: `tests/test_truth_api.py`
+
+**Deliverable:**
+
+- stable, deterministic impact summary attached to signals
+- queue/result-derived lifecycle status
+- minimal artifact/count extraction from focused action results
+
+### Task 3: Spend The Contract In View Models
+
+**Files:**
+- Modify: `src/openclaw_pipeline/ui/view_models.py`
+- Test: `tests/test_ui_view_models.py`
+
+**Deliverable:**
+
+- `/signals` payloads expose impact-aware counts and summaries
+- `/briefing` compiled sections distinguish productive vs stalled loop outcomes
+- `/actions` payload aligns with the same impact vocabulary
+
+### Task 4: Render The Impact Loop In The Shell
+
+**Files:**
+- Modify: `src/openclaw_pipeline/commands/ui_server.py`
+- Test: `tests/test_ui_server.py`
+
+**Deliverable:**
+
+- signals, briefing, and actions pages render the new impact/lifecycle summaries
+- the shell explains what happened, not only what exists
+
+### Task 5: Verify And Close Out
+
+**Files:**
+- Modify: `docs/plans/2026-04-14-local-knowledge-workbench-milestone.md`
+- Modify: `docs/research-tech/RESEARCH_TECH_VERIFY.md`
+- Modify: `progress.md`
+- Modify: `task_plan.md`
+
+**Deliverable:**
+
+- verify docs cover the new impact-accounting surfaces
+- milestone plan points to the next real `Milestone 7` slice after this one
+- `Phase 22` is ready to close cleanly
+
+## Exit Condition
+
+`Phase 22` is complete when all of the following are true:
+
+1. signals expose a stable impact/lifecycle summary grounded in current queue/result state,
+2. `/signals` makes productive vs stalled vs failed signal outcomes legible,
+3. `/briefing` summarizes signal-loop productivity instead of only recent signal presence,
+4. `/actions` and `/signals` describe execution using the same lifecycle language,
+5. focused tests lock the contract so future signal heuristics cannot silently erase impact visibility.
+
+## Closeout
+
+`Phase 22` is complete.
+
+What landed:
+
+- `truth_api.py` now attaches deterministic `impact_summary` contracts to:
+  - signal rows
+  - action queue rows
+- the impact contract currently distinguishes:
+  - `review_only`
+  - `ready`
+  - `waiting`
+  - `running`
+  - `productive`
+  - `completed`
+  - `failed`
+  - `stalled`
+- `/signals` now exposes impact-aware counts and item-level lifecycle explanations instead of only queue badges
+- `/actions` now uses the same lifecycle vocabulary as `/signals`
+- `/briefing` now exposes:
+  - `loop_summary`
+  - a leading `signal_loop` compiled section
+  - a more useful `first_useful_sign` when a productive signal exists
+
+What this phase intentionally did **not** do:
+
+- add note-save hooks
+- widen signal detection
+- introduce background entity intelligence
+- reopen temporal truth or harness memory
+
+Next real gap inside `Milestone 7`:
+
+- selected inbound signal capture on save/update
+- stronger audit visibility for what changed, linked, or was skipped
+- still without widening into opaque background automation

--- a/docs/plans/2026-04-18-phase23-inbound-capture-audit-visibility.md
+++ b/docs/plans/2026-04-18-phase23-inbound-capture-audit-visibility.md
@@ -1,0 +1,159 @@
+# Phase 23: Inbound Capture Audit Visibility
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Extend the active signal loop from lifecycle visibility into deterministic inbound-capture visibility, so operators can tell what a newly saved or updated note actually triggered, what downstream artifacts appeared, and what was only surfaced as a candidate or left untouched.
+
+**Architecture:** Keep the current signal ledger, action queue, shared shell, and pipeline/refine logs. Do not add file-save hooks, background entity workers, temporal memory, or opaque capture intelligence. This phase should spend existing `pipeline.jsonl` and `refine-mutations.jsonl` audit data on three product surfaces only: `note/page`, `signals/browser`, and `briefing/intelligence`.
+
+**Tech Stack:** Python 3.13, stdlib JSON/runtime, `truth_api.py`, `ui/view_models.py`, `commands/ui_server.py`, existing pipeline/refine logs, pytest.
+
+**Status:** Complete
+
+## Why This Was The Right Next Phase
+
+`Phase 22` answered:
+
+- did a signal queue anything,
+- what lifecycle state is it in,
+- did the queue ever produce visible downstream change.
+
+What still stayed hidden was the inbound side:
+
+- did the note get picked up at all,
+- did it only stage/archive,
+- did it create a deep dive,
+- did it surface candidates,
+- did it auto-promote an evergreen object,
+- or did it stop before any downstream artifact appeared.
+
+That gap matters because `Milestone 7` is not only about action execution. It is about making note/save/update activity legible as an improving knowledge loop.
+
+## Product Thesis
+
+After `Phase 23`, an operator should be able to answer three additional questions without opening raw logs:
+
+1. Was this note actually captured by the inbound pipeline?
+2. What downstream artifacts or candidates did that capture produce?
+3. Did the signal surface inherit any concrete inbound evidence from its source note?
+
+This phase is therefore about:
+
+- **note-level inbound capture summaries**
+- **signal-level audit legibility**
+- **briefing-level visibility into recent captured input**
+
+## What Phase 23 Delivered
+
+### 1. Note Inbound Capture Contract v1
+
+`truth_api.py` now exposes a deterministic `get_note_inbound_capture_summary(...)` contract derived from existing logs.
+
+The contract currently includes:
+
+- `status`
+- `captured_event_count`
+- `produced_artifact_count`
+- `candidate_count`
+- `error_count`
+- `skipped_count`
+- `latest_timestamp`
+- `summary`
+- `items`
+
+The v1 event set is intentionally narrow and deterministic:
+
+- `source_staged_for_processing`
+- `source_archived_to_processed`
+- `source_restored_to_raw`
+- `article_processed`
+- `article_abstained`
+- `article_error`
+- `candidates_upserted`
+- `candidate_upsert_error`
+- `evergreen_auto_promoted`
+- `evergreen_created`
+- `evergreen_error`
+- `refine_mutation_applied`
+
+### 2. Signal-Level Capture Summary
+
+`list_signals(...)` now attaches `capture_summary` derived from the signal’s backing `note_paths`.
+
+This makes the signal browser able to distinguish:
+
+- signals with observed inbound capture but no downstream artifact yet,
+- signals with productive capture history,
+- signals with no capture audit attached at all.
+
+### 3. Note Page Upgrade
+
+`note/page` now includes a first-class `Inbound Capture` compiled section.
+
+This section sits alongside:
+
+- `Current State`
+- `Evidence Traceability`
+- `Production Chain`
+- `Where To Go Next`
+
+and turns previously implicit pipeline activity into a readable page-level product artifact.
+
+### 4. Briefing Upgrade
+
+`/briefing` now includes an `Inbound Capture` compiled section built from recent signals that actually carry capture audit.
+
+This keeps the orientation layer grounded in concrete note activity rather than only queue state.
+
+### 5. Signal Browser Upgrade
+
+`/signals` now renders item-level inbound capture summaries directly.
+
+The page can now explain both:
+
+- what the signal is asking for next,
+- what has already happened on the inbound side.
+
+## What Phase 23 Intentionally Did Not Do
+
+Explicit deferrals:
+
+- automatic file-save hooks
+- generalized capture on every edit event
+- background entity extraction workers
+- temporal truth or memory infrastructure
+- benchmark/evaluation layers
+
+## Exit Condition
+
+`Phase 23` is complete when all of the following are true:
+
+1. note pages expose stable inbound capture summaries from existing logs,
+2. signals expose inherited inbound capture summaries from their backing notes,
+3. `/briefing` surfaces recent capture audit as a compiled section,
+4. `/signals` renders capture visibility directly instead of forcing log inspection,
+5. focused tests lock the new contract and rendering behavior.
+
+## Closeout
+
+`Phase 23` is complete.
+
+What landed:
+
+- `truth_api.py` now exposes `get_note_inbound_capture_summary(...)`
+- signal rows now carry `capture_summary`
+- note pages now expose an `Inbound Capture` compiled section
+- briefing pages now expose an `Inbound Capture` compiled section
+- signals pages now render item-level inbound capture summaries
+
+What this phase intentionally did **not** do:
+
+- add save hooks
+- widen capture detection into a new background engine
+- reopen shell UX or temporal-truth work
+
+Next real gap inside `Milestone 7`:
+
+- tighten brain-first lookup before object creation/link creation
+- make backlink enforcement more explicit when new downstream objects are created
+- keep the loop deterministic and operator-legible

--- a/docs/research-tech/RESEARCH_TECH_VERIFY.md
+++ b/docs/research-tech/RESEARCH_TECH_VERIFY.md
@@ -89,19 +89,55 @@ Inspect:
 Expected:
 
 - `/` renders a workbench entry surface with:
+  - `Workflow Map`
+  - `Orient`
+  - `Inspect`
+  - `Review`
+  - `Trace`
+  - `Explore`
   - `Where To Start`
   - `Orientation Brief`
   - `entry_sections`
 - shared shell pages keep the requested pack scope in links/forms
+- key operator pages render `Next Actions`
 - assembly contract card is visible on each page
 - governance contract card is visible on runtime/operator pages
 - `/briefing` behaves as an orientation product rather than a raw operator snapshot
+- `/briefing` includes a leading `Signal Loop` compiled section
+- `/briefing` also includes an `Inbound Capture` compiled section when recent signals carry note-level capture audit
+- note/object/briefing/production pages lead with:
+  - a lead compiled section
+  - then `Next Actions`
+  - then deeper evidence/review sections
+- note pages expose an `Inbound Capture` compiled section when pipeline/refine audit exists for the note
+- `/signals` exposes:
+  - impact counts
+  - item-level `Impact`
+  - item-level `Inbound capture`
+  - the same lifecycle language as `/actions`
+- `/actions` exposes:
+  - impact counts
+  - item-level `Impact`
+  - queue/result lifecycle phrased the same way as `/signals`
 - object/topic/event/contradiction pages expose compiled sections for:
   - current state
   - why it matters
   - evidence traceability
+  - production chain
   - open tensions
   - where to go next
+- note/object/topic/production pages make chain state visible without CLI/DB inspection:
+  - `chain_status`
+  - `missing_stages`
+  - `chain_summary`
+- `/events` explains:
+  - grouping kind
+  - anchor kind counts
+  - why grouped rows are events instead of only dated-note projections
+- `/contradictions` explains:
+  - polarity semantics
+  - evidence semantics
+  - per-row tension summary
 - compatibility-pack pages show assembly recipe inheritance from `research-tech`
 - compatibility-pack pages also show when the source contract provider resolves to `default-knowledge`
 - compatibility-pack runtime pages show governance inheritance from `research-tech`
@@ -153,13 +189,20 @@ Expected:
   - `governance_contract`
   - stable `compiled_sections`
   - `section_nav`
+  - `loop_summary`
+  - an `inbound_capture` compiled section when recent signals carry capture audit
   - item-level `recommended_action.resolver_rule_name`
   - item-level `recommended_action.governance_provider_*`
 - `/api/signals` includes:
   - `governance_contract`
+  - `impact_counts`
+  - item-level `impact_summary`
+  - item-level `capture_summary`
   - item-level `recommended_action.resolver_rule_name`
   - item-level `recommended_action.governance_provider_*`
 - `/api/actions` includes:
   - `governance_contract`
+  - `impact_counts`
+  - item-level `impact_summary`
   - item-level `resolver_rule_name`
   - item-level `governance_provider_*`

--- a/progress.md
+++ b/progress.md
@@ -1,6 +1,215 @@
 # Progress Log
 
+## Session: 2026-04-18
+
+### Phase 23: Inbound Capture Audit Visibility
+- **Status:** complete
+- Actions taken:
+  - Defined `Phase 23` as the second active execution slice for `Milestone 7`, scoped narrowly to inbound-capture legibility rather than hooks or background automation
+  - Added deterministic `get_note_inbound_capture_summary(...)` in `truth_api.py`, derived from existing `pipeline.jsonl` and `refine-mutations.jsonl`
+  - Kept the v1 event set intentionally narrow and explicit:
+    - `source_staged_for_processing`
+    - `source_archived_to_processed`
+    - `source_restored_to_raw`
+    - `article_processed`
+    - `article_abstained`
+    - `article_error`
+    - `candidates_upserted`
+    - `candidate_upsert_error`
+    - `evergreen_auto_promoted`
+    - `evergreen_created`
+    - `evergreen_error`
+    - `refine_mutation_applied`
+  - Attached `capture_summary` to signal rows based on their backing `note_paths`
+  - Upgraded note pages with a first-class `Inbound Capture` compiled section
+  - Upgraded `/briefing` with an `Inbound Capture` compiled section derived from recent signals carrying note-level capture audit
+  - Upgraded `/signals` to render item-level inbound capture summaries directly
+  - Closed out `Phase 23` docs and moved the roadmap to the next Milestone 7 slice:
+    - brain-first lookup + backlink legibility
+- Files created/modified:
+  - docs/plans/2026-04-18-phase23-inbound-capture-audit-visibility.md
+  - docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
+  - docs/research-tech/RESEARCH_TECH_VERIFY.md
+  - src/openclaw_pipeline/truth_api.py
+  - src/openclaw_pipeline/ui/view_models.py
+  - src/openclaw_pipeline/commands/ui_server.py
+  - tests/test_truth_api.py
+  - tests/test_ui_view_models.py
+  - tests/test_ui_server.py
+  - progress.md
+  - task_plan.md
+
 ## Session: 2026-04-17
+
+### Phase 22: Active Signal Impact Accounting
+- **Status:** complete
+- Actions taken:
+  - Defined `Phase 22` as the first active execution slice for `Milestone 7`, scoped narrowly to signal impact accounting rather than inbound hooks or background intelligence
+  - Wrote a dedicated phase plan focused on:
+    - deterministic signal/action impact summaries
+    - signal/browser and action/browser lifecycle legibility
+    - briefing-level loop productivity visibility
+  - Added deterministic `impact_summary` contracts in `truth_api.py` for:
+    - signal rows
+    - action queue rows
+  - Introduced stable lifecycle/impact buckets:
+    - `review_only`
+    - `ready`
+    - `waiting`
+    - `running`
+    - `productive`
+    - `completed`
+    - `failed`
+    - `stalled`
+  - Kept the implementation grounded in existing runtime state only:
+    - signal ledger
+    - action queue state
+    - focused-action result payloads
+    - processor output metadata
+  - Upgraded `build_signal_browser_payload` and `build_action_queue_payload` with `impact_counts`
+  - Upgraded `build_briefing_payload` with:
+    - `loop_summary`
+    - leading `signal_loop` compiled section
+    - more useful `first_useful_sign` selection when a productive signal exists
+  - Updated the UI shell so `/signals`, `/actions`, and `/briefing` render the new impact/lifecycle language directly instead of only queue badges
+  - Closed out `Phase 22` docs and moved the roadmap to the next Milestone 7 slice:
+    - selected inbound capture + audit visibility
+- Files created/modified:
+  - docs/plans/2026-04-17-phase22-active-signal-impact-accounting.md
+  - docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
+  - docs/research-tech/RESEARCH_TECH_VERIFY.md
+  - src/openclaw_pipeline/truth_api.py
+  - src/openclaw_pipeline/ui/view_models.py
+  - src/openclaw_pipeline/commands/ui_server.py
+  - tests/test_truth_api.py
+  - tests/test_ui_view_models.py
+  - tests/test_ui_server.py
+  - progress.md
+  - task_plan.md
+
+### Phase 21: Product Shell And Operator UX
+- **Status:** complete
+- Actions taken:
+  - Defined `Phase 21` as the active successor to `Phase 20`, scoped narrowly to shell IA and operator affordances rather than signal automation or new intelligence layers
+  - Added a dedicated implementation plan for `Phase 21` focused on:
+    - dashboard workflow IA
+    - cross-surface operator rails
+    - page-shell ordering and affordance density
+  - Updated the main milestone roadmap so `Phase 21` is now the active next reference for `Milestone 6`
+  - Started `Task 1` with red-first tests for dashboard workflow groups and root-shell rendering
+  - Added stable dashboard `workflow_groups` with five workflow buckets:
+    - orient
+    - inspect
+    - review
+    - trace
+    - explore
+  - Updated the root UI shell to render a visible `Workflow Map` block above `Where To Start`
+  - Kept all workflow links pack-scoped through the existing shared-shell path helpers
+  - Started `Task 2` with red-first payload and UI assertions for a shared `operator_rail` / `Next Actions` affordance across:
+    - note pages
+    - object pages
+    - topic pages
+    - event dossier
+    - contradictions browser
+    - signals browser
+    - production browser
+  - Added stable `operator_rail` payloads to the page builders that need cross-surface operator affordances
+  - Added a shared UI renderer for `Next Actions` so those rails now render as a consistent card instead of ad hoc link rows
+  - Fixed two real regressions caught by the wider suite while landing the rail:
+    - restored a missing `operator_rail` declaration in `build_object_page_payload`
+    - replaced an accidental object-scoped rail copy in `build_briefing_payload` with a briefing-scoped rail
+  - Re-ran the full `ui_view_models` and `ui_server` suites to green after the focused red/green cycle passed
+  - Completed `Task 3` by reordering shell pages so they now lead with:
+    - a lead compiled section
+    - then `Next Actions`
+    - then contract/status and deeper evidence/review blocks
+  - Closed out `Phase 21` docs:
+    - marked the phase plan complete
+    - marked `Milestone 6` complete
+    - updated verify guidance for workflow IA and operator rails
+    - pointed the roadmap at `Milestone 7: Active Signal Loop` as the next real gap
+- Files created/modified:
+  - docs/plans/2026-04-17-phase21-product-shell-and-operator-ux.md
+  - docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
+  - docs/research-tech/RESEARCH_TECH_VERIFY.md
+  - progress.md
+  - task_plan.md
+  - src/openclaw_pipeline/ui/view_models.py
+  - src/openclaw_pipeline/commands/ui_server.py
+  - tests/test_ui_view_models.py
+  - tests/test_ui_server.py
+
+### Phase 20: Semantic Trust And Production Traceability
+- **Status:** complete
+- Actions taken:
+  - Started the first execution batch for `Phase 20`, focused on event semantics, contradiction semantics, and production-chain traceability contracts
+  - Hardened `Event Dossier` semantics with explicit:
+    - `grouping_kind`
+    - `anchor_kind_counts`
+    - `event_vs_note_explanation`
+  - Hardened contradiction rows with explicit:
+    - `polarity_summary`
+    - `evidence_summary`
+    - `tension_summary`
+  - Hardened contradiction browser contract with explicit:
+    - `polarity_semantics`
+    - `evidence_semantics`
+  - Upgraded note/object traceability payloads with:
+    - `stage_label`
+    - `stage_presence`
+    - `missing_stages`
+    - `chain_status`
+    - `chain_summary`
+  - Spent the new trust/traceability fields on the current UI surfaces:
+    - `/events`
+    - `/contradictions`
+    - `/note`
+    - `/object`
+    - `/production`
+  - Added and ran red-first tests covering the new contract fields and page rendering
+  - Completed a second execution batch for `Phase 20`, focused on spending those contracts on compiled trust sections across the production-chain surfaces
+  - Upgraded `/note` and `/production` payloads/pages so their compiled sections now make chain state explicit via:
+    - `current_state`
+    - `evidence_traceability`
+    - `production_chain`
+    - `chain_gaps`
+    - `where_to_go_next`
+  - Added explicit `Production Chain` compiled sections to:
+    - object pages
+    - topic pages
+  - Topic pages now spend `production_summary` on a stable compiled section instead of only a side-card summary, including:
+    - top deep-dive contribution
+    - Atlas/MOC reach
+    - gap signals
+  - Re-ran the trust/UI suite to green after locking the new note/object/topic/production expectations with focused tests first
+  - Closed out `Phase 20` in the phase plan and the main milestone roadmap after the new trust/traceability contracts and compiled sections satisfied the phase exit conditions
+- Files created/modified:
+  - docs/plans/2026-04-17-phase20-semantic-trust-and-production-traceability.md
+  - docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
+  - docs/research-tech/RESEARCH_TECH_VERIFY.md
+  - src/openclaw_pipeline/truth_api.py
+  - src/openclaw_pipeline/ui/view_models.py
+  - src/openclaw_pipeline/commands/ui_server.py
+  - tests/test_truth_api.py
+  - tests/test_ui_view_models.py
+  - tests/test_ui_server.py
+  - progress.md
+
+### Phase 20: Semantic Trust And Production Traceability Planning
+- **Status:** planned
+- Actions taken:
+  - Reviewed the post-`Phase 19` roadmap state in the main milestone doc
+  - Re-read the archived `Phase 10` and `Phase 11` plans to avoid duplicating or reopening stale execution slices
+  - Defined a new `Phase 20` as the active successor plan for the remaining Milestone 4 + 5 work
+  - Scoped `Phase 20` around two product gaps only:
+    - semantic trust for events and contradictions
+    - production-chain legibility across notes, deep dives, objects, and Atlas/topic pages
+  - Explicitly deferred temporal truth, harness/session memory, graph workspaces, and benchmark-platform work
+- Files created/modified:
+  - docs/plans/2026-04-17-phase20-semantic-trust-and-production-traceability.md
+  - docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
+  - task_plan.md
+  - progress.md
 
 ### Phase 19: Orientation And Compiled Knowledge Products
 - **Status:** complete

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -30,7 +30,6 @@ from ..ui.view_models import (
     build_derivation_browser_payload,
     build_evolution_browser_payload,
     build_event_dossier_payload,
-    build_graph_canvas_payload,
     build_note_page_payload,
     build_object_page_payload,
     build_objects_index_payload,
@@ -87,7 +86,6 @@ def _shell_nav_items(requested_pack: str = "") -> list[tuple[str, str]]:
             [
                 ("Evolution", "/evolution"),
                 ("Clusters", "/clusters"),
-                ("Graph", "/graph"),
                 ("Atlas", "/atlas"),
                 ("Deep Dives", "/deep-dives"),
                 ("Event Dossier", "/events"),
@@ -315,6 +313,38 @@ def _render_governance_contract_card(payload: dict) -> str:
         f"<section class='card'><h2>Governance Contract</h2><p class='muted'>{detail}</p>"
         f"{description_html}{facts_html}</section>"
     )
+
+
+def _render_operator_rail(payload: dict) -> str:
+    items = payload.get("operator_rail")
+    if not isinstance(items, list) or not items:
+        return ""
+    rendered_items: list[str] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        label = str(item.get("label") or "").strip()
+        path = str(item.get("path") or "").strip()
+        detail = str(item.get("detail") or "").strip()
+        if not label:
+            continue
+        label_html = f'<a href="{escape(path)}">{escape(label)}</a>' if path else escape(label)
+        detail_html = f"<div class='muted'>{escape(detail)}</div>" if detail else ""
+        rendered_items.append(f"<li>{label_html}{detail_html}</li>")
+    if not rendered_items:
+        return ""
+    return (
+        "<section class='card'><h2>Next Actions</h2>"
+        f"<ul class='list-tight'>{''.join(rendered_items)}</ul>"
+        "</section>"
+    )
+
+
+def _split_lead_compiled_sections(sections: list[dict[str, object]] | None) -> tuple[list[dict[str, object]], list[dict[str, object]]]:
+    normalized = [section for section in (sections or []) if isinstance(section, dict)]
+    if not normalized:
+        return [], []
+    return [normalized[0]], normalized[1:]
 
 
 def _render_compiled_sections(sections: list[dict[str, object]]) -> str:
@@ -733,10 +763,15 @@ def _render_note_page(vault_dir: Path, relative_path: str, markdown: str, payloa
     source_note = None
     derived_notes: list[dict[str, str]] = []
     production_chain = None
+    compiled_sections: list[dict[str, object]] = []
+    section_nav_items: list[dict[str, str]] = []
     if payload:
         source_note = payload.get("provenance", {}).get("original_source_note")
         derived_notes = payload.get("provenance", {}).get("derived_deep_dives", [])
         production_chain = payload.get("production_chain")
+        compiled_sections = list(payload.get("compiled_sections") or [])
+        section_nav_items = list(payload.get("section_nav") or [])
+    lead_sections, remaining_sections = _split_lead_compiled_sections(compiled_sections)
     provenance_html = ""
     if source_note:
         provenance_html = (
@@ -764,11 +799,15 @@ def _render_note_page(vault_dir: Path, relative_path: str, markdown: str, payloa
         )
     production_chain_html = ""
     if production_chain:
+        missing_stages = ", ".join(str(item).replace("_", " ") for item in production_chain.get("missing_stages", [])) or "None"
         production_chain_html = (
             "<section class='card'>"
             "<h2>Production Chain</h2>"
             "<dl class='meta-list'>"
             f"<div><dt>Current Note</dt><dd>{escape(production_chain['note']['title'])}<div class='muted'>{escape(production_chain['note']['path'])}</div></dd></div>"
+            f"<div><dt>Chain Status</dt><dd>{escape(str(production_chain.get('chain_status') or ''))}</dd></div>"
+            f"<div><dt>Missing Stages</dt><dd>{escape(missing_stages)}</dd></div>"
+            f"<div><dt>Chain Summary</dt><dd>{escape(str(production_chain.get('chain_summary') or ''))}</dd></div>"
             f"<div><dt>Source Notes</dt><dd>{_render_named_note_links(production_chain['source_notes'], requested_pack=requested_pack)}</dd></div>"
             f"<div><dt>Deep Dives</dt><dd>{_render_named_note_links(production_chain['deep_dives'], requested_pack=requested_pack)}</dd></div>"
             f"<div><dt>Derived Objects</dt><dd>{_render_object_links(production_chain['objects'], requested_pack=requested_pack)}</dd></div>"
@@ -776,6 +815,11 @@ def _render_note_page(vault_dir: Path, relative_path: str, markdown: str, payloa
             "</dl>"
             "</section>"
         )
+    section_nav = "".join(
+        f'<a href="{escape(str(item["href"]))}">{escape(str(item["label"]))}</a>'
+        for item in section_nav_items
+    )
+    operator_rail_card = _render_operator_rail(payload or {})
     return _layout(
         f"Markdown Note: {relative_path}",
         (
@@ -783,10 +827,14 @@ def _render_note_page(vault_dir: Path, relative_path: str, markdown: str, payloa
             "<h1>Markdown Note</h1>"
             f"<p class='muted'>{escape(relative_path)}</p>"
             "</section>"
-            f"{frontmatter_html}"
-            f"{provenance_html}"
-            f"{production_chain_html}"
-            f"<section class='card'>{note_html}</section>"
+            + _render_compiled_sections(lead_sections)
+            + operator_rail_card
+            + (f"<nav class='subnav'>{section_nav}</nav>" if section_nav else "")
+            + f"{frontmatter_html}"
+            + f"{provenance_html}"
+            + f"{production_chain_html}"
+            + f"{_render_compiled_sections(remaining_sections)}"
+            + f"<section class='card'>{note_html}</section>"
         ),
         requested_pack=requested_pack,
     )
@@ -1051,6 +1099,35 @@ def _render_production_summary_card(
     )
 
 
+def _render_workflow_groups(groups: list[dict[str, object]]) -> str:
+    if not groups:
+        return ""
+    return "".join(
+        "<section class='card'>"
+        f"<h2>{escape(str(group.get('title') or ''))}</h2>"
+        f"<p class='muted'>{escape(str(group.get('summary') or ''))}</p>"
+        "<ul class='list-tight'>"
+        + "".join(
+            "<li>"
+            + (
+                f'<a href="{escape(str(item.get("path") or ""))}">{escape(str(item.get("label") or ""))}</a>'
+                if item.get("path")
+                else escape(str(item.get("label") or ""))
+            )
+            + (
+                f"<div class='muted'>{escape(str(item.get('detail') or ''))}</div>"
+                if item.get("detail")
+                else ""
+            )
+            + "</li>"
+            for item in (group.get("items") or [])
+        )
+        + "</ul>"
+        "</section>"
+        for group in groups
+    )
+
+
 def _render_dashboard(payload: dict) -> str:
     requested_pack = payload.get("requested_pack", "")
     research_overview = payload.get("research_overview", {})
@@ -1061,6 +1138,7 @@ def _render_dashboard(payload: dict) -> str:
     orientation_assembly_contract = _render_assembly_contract_card(orientation) if isinstance(orientation, dict) else ""
     orientation_governance_contract = _render_governance_contract_card(orientation) if isinstance(orientation, dict) else ""
     entry_sections_html = _render_compiled_sections(payload.get("entry_sections", []))
+    workflow_groups_html = _render_workflow_groups(payload.get("workflow_groups", []))
     object_items = "".join(
         f'<li><a href="{escape(_object_href(item["object_id"], item.get("object_path", "")))}">{escape(item["title"])}</a></li>'
         for item in payload["objects"]["items"]
@@ -1168,6 +1246,8 @@ def _render_dashboard(payload: dict) -> str:
             "".join(stats_cards),
             "</section>",
             "<section class='section-stack'>",
+            "<section class='card'><h2>Workflow Map</h2><p class='muted'>Start here if you do not yet know which route to open. Each group maps one common operator workflow onto the current shell.</p></section>",
+            workflow_groups_html,
             "<section class='card'><h2>Where To Start</h2><p class='muted'>Use the orientation brief and the compiled entry sections below to decide what to read, review, or do next.</p></section>",
             orientation_assembly_contract,
             orientation_governance_contract,
@@ -1225,6 +1305,7 @@ def _render_object_page(payload: dict) -> str:
     research_shell_enabled = bool(payload.get("research_shell_enabled", _shell_supports_research_nav(requested_pack)))
     next_path = _shell_href(f"/object?id={quote(str(payload['object']['object_id']), safe='')}", requested_pack)
     assembly_contract_card = _render_assembly_contract_card(payload)
+    operator_rail_card = _render_operator_rail(payload)
     evergreen_path = payload["provenance"]["evergreen_path"]
     evergreen_html = (
         f'<a href="{escape(_note_href(evergreen_path, requested_pack))}">{escape(evergreen_path)}</a>'
@@ -1266,6 +1347,7 @@ def _render_object_page(payload: dict) -> str:
         "evolution",
         {"candidate_items": [], "accepted_links": [], "accepted_count": 0, "candidate_count": 0, "link_types": []},
     )
+    lead_sections, remaining_sections = _split_lead_compiled_sections(payload.get("compiled_sections", []))
     section_nav_items = [
         item for item in payload["section_nav"] if research_shell_enabled or item["href"] != "#contradictions"
     ]
@@ -1303,7 +1385,6 @@ def _render_object_page(payload: dict) -> str:
     )
     hero_links = [
         f"<a href='{escape(payload['links']['topic_path'])}'>Explore topic</a>",
-        f"<a href='{escape(payload['links']['graph_path'])}'>Open in graph</a>",
     ]
     if research_shell_enabled:
         hero_links.extend(
@@ -1359,6 +1440,9 @@ def _render_object_page(payload: dict) -> str:
             f"<div><dt>Atlas / MOC</dt><dd><ul class='list-tight'>{mocs}</ul></dd></div>"
             "</dl></section>",
             "<section class='card'><h2>Production Chain</h2><dl class='meta-list'>"
+            f"<div><dt>Chain Status</dt><dd>{escape(str(payload['production_chain'].get('chain_status') or ''))}</dd></div>"
+            f"<div><dt>Missing Stages</dt><dd>{escape(', '.join(str(item).replace('_', ' ') for item in payload['production_chain'].get('missing_stages', [])) or 'None')}</dd></div>"
+            f"<div><dt>Chain Summary</dt><dd>{escape(str(payload['production_chain'].get('chain_summary') or ''))}</dd></div>"
             f"<div><dt>Source Notes</dt><dd>{_render_named_note_links(payload['production_chain']['source_notes'], requested_pack=requested_pack)}</dd></div>"
             f"<div><dt>Source Deep Dives</dt><dd>{_render_named_note_links(payload['production_chain']['deep_dives'], requested_pack=requested_pack)}</dd></div>"
             f"<div><dt>Evergreen Note</dt><dd>{evergreen_html}</dd></div>"
@@ -1382,13 +1466,15 @@ def _render_object_page(payload: dict) -> str:
             + (f" Pack scope: {escape(requested_pack)}." if requested_pack else "")
             + "</p>"
             + f"<div class='link-row'>{''.join(hero_links)}</div></section>"
+            + _render_compiled_sections(lead_sections)
+            + operator_rail_card
             + assembly_contract_card
             + f"<nav class='subnav'>{section_nav}</nav>"
             + f"<section class='grid stats'>{''.join(stats_cards)}</section>"
             "<section class='grid two-col'>"
             "<div class='section-stack'>"
             f"<section id='summary' class='card'><h2>Compiled Summary</h2><p>{escape(summary_text)}</p></section>"
-            f"{_render_compiled_sections(payload.get('compiled_sections', []))}"
+            f"{_render_compiled_sections(remaining_sections)}"
             f"<section id='claims' class='card'><h2>Claims</h2><ul class='list-tight'>{claims}</ul></section>"
             "</div>"
             "<div class='section-stack'>"
@@ -1405,6 +1491,7 @@ def _render_topic_page(payload: dict) -> str:
     research_shell_enabled = bool(payload.get("research_shell_enabled", _shell_supports_research_nav(requested_pack)))
     next_path = _shell_href(f"/topic?id={quote(str(payload['center']['object_id']), safe='')}", requested_pack)
     assembly_contract_card = _render_assembly_contract_card(payload)
+    operator_rail_card = _render_operator_rail(payload)
     neighbors = "".join(
         f'<li><a href="{escape(_object_href(item["object_id"], item.get("object_path", ""), requested_pack=requested_pack))}">{escape(item["title"])}</a></li>'
         for item in payload["neighbors"]
@@ -1417,6 +1504,7 @@ def _render_topic_page(payload: dict) -> str:
         "evolution",
         {"candidate_items": [], "accepted_links": [], "accepted_count": 0, "candidate_count": 0, "link_types": []},
     )
+    lead_sections, remaining_sections = _split_lead_compiled_sections(payload.get("compiled_sections", []))
     section_nav = "".join(
         f'<a href="{escape(str(item["href"]))}">{escape(str(item["label"]))}</a>'
         for item in payload.get("section_nav", [])
@@ -1442,7 +1530,6 @@ def _render_topic_page(payload: dict) -> str:
     )
     hero_links = [
         f"<a href='{escape(payload['links']['center_object_path'])}'>Open center object</a>",
-        f"<a href='{escape(payload['links']['graph_path'])}'>Open in graph</a>",
     ]
     if research_shell_enabled:
         hero_links.extend(
@@ -1489,10 +1576,12 @@ def _render_topic_page(payload: dict) -> str:
             + (f" Pack scope: {escape(requested_pack)}." if requested_pack else "")
             + "</p>"
             + f"<div class='link-row'>{''.join(hero_links)}</div></section>"
+            + _render_compiled_sections(lead_sections)
+            + operator_rail_card
             + assembly_contract_card
             + (f"<nav class='subnav'>{section_nav}</nav>" if section_nav else "")
             + "<section class='grid two-col'>"
-            f"{_render_compiled_sections(payload.get('compiled_sections', []))}"
+            f"{_render_compiled_sections(remaining_sections)}"
             f"<section class='card'><h2>Center Summary</h2><p>{escape(payload['center_summary'])}</p></section>"
             f"<section class='card'><h2>Neighbors</h2><ul class='list-tight'>{neighbors}</ul></section>"
             f"{''.join(right_sections)}"
@@ -1506,6 +1595,8 @@ def _render_events_page(payload: dict) -> str:
     query = payload.get("query", "")
     requested_pack = payload.get("requested_pack", "")
     assembly_contract_card = _render_assembly_contract_card(payload)
+    operator_rail_card = _render_operator_rail(payload)
+    lead_sections, remaining_sections = _split_lead_compiled_sections(payload.get("compiled_sections", []))
     limit_note = (
         f" Showing the most recent {payload['limit']} timeline rows in this dossier window."
         if payload.get("is_limited")
@@ -1518,14 +1609,20 @@ def _render_events_page(payload: dict) -> str:
     timeline_contract = payload["timeline_contract"]
     timeline_contract_items = (
         f"<li>Timeline kind: {escape(timeline_contract['timeline_kind'])}</li>"
+        + f"<li>Grouping kind: {escape(str(timeline_contract.get('grouping_kind') or ''))}</li>"
         + "".join(
             f"<li>Row type {escape(str(row_type))}: {count}</li>"
             for row_type, count in timeline_contract["row_type_counts"].items()
         )
         + "".join(
+            f"<li>Anchor kind {escape(str(anchor_kind))}: {count}</li>"
+            for anchor_kind, count in timeline_contract.get("anchor_kind_counts", {}).items()
+        )
+        + "".join(
             f"<li>Semantic role {escape(str(role))}: {count}</li>"
             for role, count in timeline_contract["semantic_roles"].items()
         )
+        + f"<li>Semantics: {escape(str(timeline_contract.get('event_vs_note_explanation') or ''))}</li>"
     )
     model_notes = "".join(f"<li>{escape(note)}</li>" for note in payload["model_notes"])
     date_nav = "".join(
@@ -1612,9 +1709,11 @@ def _render_events_page(payload: dict) -> str:
                 f"<p class='muted'>{payload['cluster_count']} event clusters from {payload['event_count']} timeline rows across {len(payload['dates'])} dates.",
                 f" Pack scope: {escape(requested_pack)}." if requested_pack else "",
                 f"{escape(limit_note)}</p>",
+                _render_compiled_sections(lead_sections),
+                operator_rail_card,
                 assembly_contract_card,
                 (f"<nav class='subnav'>{section_nav}</nav>" if section_nav else ""),
-                _render_compiled_sections(payload.get("compiled_sections", [])),
+                _render_compiled_sections(remaining_sections),
                 f"<div class='link-row'>{type_breakdown}</div>",
                 f"{_render_production_summary_card(payload['production_summary'], requested_pack=requested_pack)}",
                 f"{_render_review_context_card(payload['review_context'])}",
@@ -1752,6 +1851,8 @@ def _render_production_browser_page(payload: dict) -> str:
     query = payload.get("query", "")
     requested_pack = payload.get("requested_pack", "")
     surface_contract_card = _render_surface_contract_card(payload)
+    operator_rail_card = _render_operator_rail(payload)
+    lead_sections, remaining_sections = _split_lead_compiled_sections(payload.get("compiled_sections", []))
     limit_note = (
         f" Showing the most recent {payload['limit']} production-chain entries in this browser window."
         if payload.get("is_limited")
@@ -1761,9 +1862,13 @@ def _render_production_browser_page(payload: dict) -> str:
         "<li>"
         f'<a href="{escape(_note_href(item["path"], requested_pack))}">{escape(item["title"])}</a>'
         + f" <span class='pill'>{escape(item['stage_label'].replace('_', ' '))}</span>"
+        + f" <span class='pill'>{escape(str(item['traceability'].get('chain_status') or ''))}</span>"
         + f" <span class='pill'>{item['traceability']['counts']['deep_dives']} deep dives</span>"
         + f" <span class='pill'>{item['traceability']['counts']['objects']} objects</span>"
         + f" <span class='pill'>{item['traceability']['counts']['atlas_pages']} atlas pages</span>"
+        + f"<div class='muted'>Chain status: {escape(str(item['traceability'].get('chain_status') or ''))}</div>"
+        + f"<div class='muted'>Missing stages: {escape(', '.join(str(value).replace('_', ' ') for value in item['traceability'].get('missing_stages', [])) or 'None')}</div>"
+        + f"<div class='muted'>Chain summary: {escape(str(item['traceability'].get('chain_summary') or ''))}</div>"
         + f"<div class='muted'>Deep Dives: {_render_named_note_links(item['traceability']['deep_dives'], requested_pack=requested_pack)}</div>"
         + f"<div class='muted'>Objects: {_render_object_links(item['traceability']['objects'], requested_pack=requested_pack)}</div>"
         + f"<div class='muted'>Atlas / MOC Reach: {_render_named_note_links(item['traceability']['atlas_pages'], requested_pack=requested_pack)}</div>"
@@ -1778,6 +1883,10 @@ def _render_production_browser_page(payload: dict) -> str:
         "</li>"
         for item in payload["weak_points"]
     ) or "<li class='muted'>No production-chain weak points surfaced.</li>"
+    section_nav = "".join(
+        f'<a href="{escape(str(item["href"]))}">{escape(str(item["label"]))}</a>'
+        for item in payload.get("section_nav", [])
+    )
     return _layout(
         "Production Browser",
         "".join(
@@ -1795,7 +1904,11 @@ def _render_production_browser_page(payload: dict) -> str:
                 f"<p class='muted'>{payload['count']} production-chain entries. {payload['counts']['source_notes']} source notes and {payload['counts']['deep_dives']} deep dives.",
                 f" Pack scope: {escape(requested_pack)}." if requested_pack else "",
                 f"{escape(limit_note)}</p>",
+                _render_compiled_sections(lead_sections),
+                operator_rail_card,
                 surface_contract_card,
+                f"<nav class='subnav'>{section_nav}</nav>" if section_nav else "",
+                _render_compiled_sections(remaining_sections),
                 "<section class='card'><h2>Chain Model</h2><p class='muted'>This browser shows the current upstream/downstream chain from traceable notes into deep dives, evergreen objects, and Atlas placement.</p></section>",
                 f"<section class='card'><h2>Weak Points</h2><ul class='list-tight'>{weak_points}</ul></section>",
                 f"<section class='card'><ul class='list-tight'>{items}</ul></section>",
@@ -1808,7 +1921,6 @@ def _render_production_browser_page(payload: dict) -> str:
 def _render_clusters_page(payload: dict) -> str:
     query = payload.get("query", "")
     requested_pack = payload.get("requested_pack", "")
-    graph_path = payload.get("graph_path", _shell_href("/graph", requested_pack))
     limit_note = (
         f" Showing the first {payload['limit']} graph clusters in this browser window."
         if payload.get("is_limited")
@@ -1866,11 +1978,6 @@ def _render_clusters_page(payload: dict) -> str:
             else ""
         )
         + (
-            f"<div class='muted'><a href='{escape(item['graph_path'])}'>Open this cluster in graph</a></div>"
-            if item.get("graph_path")
-            else ""
-        )
-        + (
             f"<div class='muted'>{escape(item['top_summary_bullet'])}</div>"
             if item.get("top_summary_bullet")
             else ""
@@ -1893,7 +2000,6 @@ def _render_clusters_page(payload: dict) -> str:
                 f"<input type='text' name='q' value='{escape(query)}' placeholder='Filter clusters or members' /> ",
                 "<button type='submit'>Search</button>",
                 "</form>",
-                f"<p><a href='{escape(graph_path)}'>Open cluster overview graph</a></p>",
                 f"<p class='muted'>{payload['count']} graph clusters. Largest cluster has {payload['largest_cluster_size']} objects.",
                 f" Pack scope: {escape(requested_pack)}." if requested_pack else "",
                 f"{escape(limit_note)}</p>",
@@ -1909,7 +2015,6 @@ def _render_clusters_page(payload: dict) -> str:
 def _render_cluster_detail_page(payload: dict) -> str:
     cluster = payload["cluster"]
     requested_pack = payload.get("requested_pack", "")
-    graph_path = payload.get("graph_path", "")
     edge_kind_counts = "".join(
         f"<span class='pill'>{escape(edge_kind)}: {count}</span>"
         for edge_kind, count in payload["edge_kind_counts"].items()
@@ -2025,9 +2130,7 @@ def _render_cluster_detail_page(payload: dict) -> str:
         "Graph Cluster",
         (
             "<h1>Graph Cluster</h1>"
-            f"<p><a href='{escape(payload['browser_path'])}'>Back to clusters</a>"
-            + (f" · <a href='{escape(graph_path)}'>Open in graph</a>" if graph_path else "")
-            + "</p>"
+            f"<p><a href='{escape(payload['browser_path'])}'>Back to clusters</a></p>"
             f"<section class='card'><h2>{escape(payload.get('display_title') or cluster['label'])}</h2>"
             f"<p class='muted'>Pack: {escape(cluster['pack'])} · Kind: {escape(cluster['cluster_kind'])} · Score: {cluster['score']:.1f}</p>"
             f"<p class='muted'>Canonical cluster id: {escape(cluster['cluster_id'])}</p>"
@@ -2055,328 +2158,6 @@ def _render_cluster_detail_page(payload: dict) -> str:
             f"<section class='card'><h2>Members</h2><ul class='list-tight'>{members}</ul></section>"
             f"<section class='card'><h2>Internal Edges</h2><ul class='list-tight'>{edges}</ul></section>"
             f"<section class='card'><h2>Model Notes</h2><ul class='list-tight'>{model_notes}</ul></section>"
-        ),
-        requested_pack=requested_pack,
-    )
-
-
-def _render_graph_page(payload: dict) -> str:
-    requested_pack = payload.get("requested_pack", "")
-    controls = payload["controls"]
-    entry_links = "".join(
-        f"<a href='{escape(item['path'])}'>{escape(item['label'])}</a>"
-        for item in payload["entry_links"]
-    ) or "<span class='muted'>No entry links.</span>"
-    stats = payload["stats"]
-    stat_pills = "".join(
-        [
-            f"<span class='pill'>{stats['node_count']} nodes</span>",
-            f"<span class='pill'>{stats['edge_count']} edges</span>",
-        ]
-        + (
-            [f"<span class='pill'>{stats['hidden_member_count']} hidden members</span>"]
-            if stats.get("hidden_member_count")
-            else []
-        )
-        + (
-            [f"<span class='pill'>{stats['hidden_neighbor_count']} hidden neighbors</span>"]
-            if stats.get("hidden_neighbor_count")
-            else []
-        )
-        + (
-            [f"<span class='pill'>{stats['hidden_node_count']} additional clusters off-canvas</span>"]
-            if stats.get("hidden_node_count")
-            else []
-        )
-    )
-    filter_options = "".join(
-        f"<option value='{escape(item['value'])}'{' selected' if item['value'] == controls['edge_filter'] else ''}>{escape(item['label'])}</option>"
-        for item in controls["edge_filter_items"]
-    )
-    model_notes = "".join(f"<li>{escape(note)}</li>" for note in payload["model_notes"])
-    payload_json = json.dumps(payload).replace("</", "<\\/")
-    return _layout(
-        f"Graph: {payload['title']}",
-        "".join(
-            [
-                """
-<style>
-.graph-shell { display: grid; gap: 1rem; }
-.graph-toolbar { display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center; margin-bottom: 0.75rem; }
-.graph-toolbar button, .graph-toolbar select, .graph-toolbar a {
-  border: 1px solid var(--border);
-  background: var(--surface);
-  color: var(--text);
-  border-radius: 999px;
-  padding: 0.45rem 0.8rem;
-  text-decoration: none;
-  font: inherit;
-}
-.graph-layout { display: grid; grid-template-columns: minmax(0, 1.7fr) minmax(320px, 0.8fr); gap: 1rem; align-items: start; }
-.graph-canvas-card { padding: 0; overflow: hidden; }
-.graph-canvas-header { padding: 1rem 1rem 0; }
-.graph-stage-wrap { position: relative; height: 72vh; min-height: 540px; background: linear-gradient(180deg, #fffdfa 0%, #f7f6f2 100%); border-top: 1px solid var(--border); }
-.graph-stage { width: 100%; height: 100%; display: block; cursor: grab; }
-.graph-stage.dragging { cursor: grabbing; }
-.graph-side { position: sticky; top: 1rem; }
-.graph-side .meta-list { margin: 0; }
-.graph-side .meta-list div { display: grid; grid-template-columns: 120px 1fr; gap: 0.5rem; padding: 0.25rem 0; }
-.graph-side .meta-list dt { color: var(--muted); }
-.graph-side .meta-list dd { margin: 0; }
-.graph-empty { color: var(--muted); }
-.graph-node-label { font-size: 13px; font-weight: 700; text-anchor: middle; pointer-events: none; fill: var(--text); }
-.graph-node-secondary { font-size: 11px; text-anchor: middle; pointer-events: none; fill: var(--muted); }
-.graph-edge-label { font-size: 11px; text-anchor: middle; pointer-events: none; fill: var(--muted); }
-</style>
-""",
-                f"<section class='hero'><h1>{escape(payload['title'])}</h1>",
-                f"<p class='muted'>{escape(payload['subtitle'])}"
-                + (f" Pack scope: {escape(requested_pack)}." if requested_pack else "")
-                + "</p>",
-                f"<div class='link-row'>{entry_links}</div></section>",
-                f"<section class='card'><h2>Graph Scope</h2><div class='link-row'>{stat_pills}</div><ul class='list-tight'>{model_notes}</ul></section>",
-                "<section class='graph-shell'>",
-                "<section class='card graph-canvas-card'>",
-                "<div class='graph-canvas-header'>",
-                "<div class='graph-toolbar'>",
-                "<button type='button' id='graph-zoom-in'>Zoom in</button>",
-                "<button type='button' id='graph-zoom-out'>Zoom out</button>",
-                "<button type='button' id='graph-recenter'>Recenter</button>",
-                (
-                    f"<a href='{escape(controls['expand_path'])}' id='graph-expand'>Expand graph</a>"
-                    if controls.get("can_expand") and controls.get("expand_path")
-                    else "<span class='pill'>Fully expanded for current bound</span>"
-                ),
-                f"<label class='muted'>Edges <select id='graph-filter'>{filter_options}</select></label>",
-                "</div></div>",
-                "<div class='graph-layout'>",
-                "<div class='graph-stage-wrap'>",
-                "<svg id='graph-stage' class='graph-stage' viewBox='-900 -700 1800 1400' role='img' aria-label='Research graph canvas'>",
-                "<g id='graph-viewport'><g id='graph-edges'></g><g id='graph-nodes'></g></g>",
-                "</svg></div>",
-                "<aside class='card graph-side'>",
-                "<h2 id='graph-side-title'>Selection</h2>",
-                "<p id='graph-side-subtitle' class='muted'>Choose a node in the graph.</p>",
-                "<div id='graph-side-badges' class='link-row'></div>",
-                "<ul id='graph-side-summary' class='list-tight'></ul>",
-                "<dl id='graph-side-meta' class='meta-list'></dl>",
-                "<div id='graph-side-actions' class='link-row'></div>",
-                "</aside></div></section></section>",
-                f"<script id='graph-payload' type='application/json'>{payload_json}</script>",
-                """
-<script>
-(() => {
-  const payload = JSON.parse(document.getElementById('graph-payload').textContent);
-  const svg = document.getElementById('graph-stage');
-  const viewport = document.getElementById('graph-viewport');
-  const edgesLayer = document.getElementById('graph-edges');
-  const nodesLayer = document.getElementById('graph-nodes');
-  const state = { scale: 1, tx: 0, ty: 0, dragging: false, dragX: 0, dragY: 0, selectedId: payload.default_selection_id || "" };
-  const nodeMap = new Map(payload.nodes.map((node) => [node.id, node]));
-
-  const tonePalette = {
-    attention: { fill: '#f7c4bf', stroke: '#9f4f24' },
-    active: { fill: '#f4dfd2', stroke: '#9f4f24' },
-    reference: { fill: '#ece7e0', stroke: '#71675d' },
-    center: { fill: '#f6e8a4', stroke: '#8a6f00' },
-    neutral: { fill: '#ffffff', stroke: '#71675d' },
-    strong: { fill: '#dde9ff', stroke: '#315da8' },
-    medium: { fill: '#eef2ff', stroke: '#4b63a6' },
-    light: { fill: '#f6f7fb', stroke: '#7a8091' }
-  };
-
-  function applyTransform() {
-    viewport.setAttribute('transform', `translate(${state.tx} ${state.ty}) scale(${state.scale})`);
-  }
-
-  function clear(el) {
-    while (el.firstChild) el.removeChild(el.firstChild);
-  }
-
-  function makeSvg(tag, attrs = {}) {
-    const el = document.createElementNS('http://www.w3.org/2000/svg', tag);
-    for (const [key, value] of Object.entries(attrs)) el.setAttribute(key, String(value));
-    return el;
-  }
-
-  function updateSidePanel(node) {
-    const title = document.getElementById('graph-side-title');
-    const subtitle = document.getElementById('graph-side-subtitle');
-    const badges = document.getElementById('graph-side-badges');
-    const summary = document.getElementById('graph-side-summary');
-    const meta = document.getElementById('graph-side-meta');
-    const actions = document.getElementById('graph-side-actions');
-    title.textContent = node?.detail?.title || 'Selection';
-    subtitle.textContent = node?.detail?.subtitle || 'Choose a node in the graph.';
-    badges.innerHTML = '';
-    summary.innerHTML = '';
-    meta.innerHTML = '';
-    actions.innerHTML = '';
-    (node?.badges || []).forEach((item) => {
-      const span = document.createElement('span');
-      span.className = 'pill';
-      span.textContent = item;
-      badges.appendChild(span);
-    });
-    const summaryLines = node?.detail?.summary_lines || [];
-    if (!summaryLines.length) {
-      const li = document.createElement('li');
-      li.className = 'graph-empty';
-      li.textContent = 'No additional summary for this node.';
-      summary.appendChild(li);
-    } else {
-      summaryLines.forEach((line) => {
-        const li = document.createElement('li');
-        li.textContent = line;
-        summary.appendChild(li);
-      });
-    }
-    (node?.detail?.meta_rows || []).forEach((line) => {
-      const wrap = document.createElement('div');
-      const dt = document.createElement('dt');
-      const dd = document.createElement('dd');
-      const parts = String(line).split(':');
-      dt.textContent = parts.length > 1 ? parts.shift() : 'Info';
-      dd.textContent = parts.length > 0 ? parts.join(':').trim() : String(line);
-      wrap.appendChild(dt);
-      wrap.appendChild(dd);
-      meta.appendChild(wrap);
-    });
-    (node?.detail?.actions || []).forEach((item) => {
-      const link = document.createElement('a');
-      link.href = item.path;
-      link.textContent = item.label;
-      actions.appendChild(link);
-    });
-  }
-
-  function selectNode(nodeId) {
-    state.selectedId = nodeId;
-    render();
-  }
-
-  function render() {
-    clear(edgesLayer);
-    clear(nodesLayer);
-    payload.edges.forEach((edge) => {
-      const source = nodeMap.get(edge.source);
-      const target = nodeMap.get(edge.target);
-      if (!source || !target) return;
-      const line = makeSvg('line', {
-        x1: source.x,
-        y1: source.y,
-        x2: target.x,
-        y2: target.y,
-        stroke: edge.edge_type === 'contradiction' ? '#c0504d' : edge.edge_type === 'bridge' ? '#315da8' : '#c7beb2',
-        'stroke-width': edge.edge_type === 'bridge' ? 3 : 2,
-        'stroke-dasharray': edge.edge_type === 'bridge' ? '8 6' : '',
-        opacity: state.scale < 0.55 ? 0.35 : 0.85
-      });
-      edgesLayer.appendChild(line);
-      if (state.scale >= 0.8) {
-        const label = makeSvg('text', {
-          x: (source.x + target.x) / 2,
-          y: (source.y + target.y) / 2 - 8,
-          class: 'graph-edge-label'
-        });
-        label.textContent = edge.label;
-        edgesLayer.appendChild(label);
-      }
-    });
-    payload.nodes.forEach((node) => {
-      const group = makeSvg('g', { transform: `translate(${node.x} ${node.y})`, tabindex: 0 });
-      const palette = tonePalette[node.tone] || tonePalette.neutral;
-      const selected = node.id === state.selectedId;
-      const shape = (node.node_type === 'cluster' || node.node_type === 'cluster_root' || node.node_type === 'related_cluster')
-        ? makeSvg('rect', {
-            x: -node.size,
-            y: -node.size * 0.55,
-            rx: 18,
-            ry: 18,
-            width: node.size * 2,
-            height: node.size * 1.1,
-            fill: palette.fill,
-            stroke: selected ? '#1f1a17' : palette.stroke,
-            'stroke-width': selected ? 4 : 2
-          })
-        : makeSvg('circle', {
-            cx: 0,
-            cy: 0,
-            r: node.size,
-            fill: palette.fill,
-            stroke: selected ? '#1f1a17' : palette.stroke,
-            'stroke-width': selected ? 4 : 2
-          });
-      group.appendChild(shape);
-      if (state.scale >= 0.45) {
-        const label = makeSvg('text', { x: 0, y: 4, class: 'graph-node-label' });
-        label.textContent = node.label;
-        group.appendChild(label);
-      }
-      if (state.scale >= 0.85 && node.secondary_label) {
-        const secondary = makeSvg('text', { x: 0, y: node.size + 20, class: 'graph-node-secondary' });
-        secondary.textContent = node.secondary_label;
-        group.appendChild(secondary);
-      }
-      group.addEventListener('click', () => selectNode(node.id));
-      group.addEventListener('keydown', (event) => {
-        if (event.key === 'Enter' || event.key === ' ') {
-          event.preventDefault();
-          selectNode(node.id);
-        }
-      });
-      nodesLayer.appendChild(group);
-    });
-    updateSidePanel(nodeMap.get(state.selectedId));
-    applyTransform();
-  }
-
-  function zoom(delta) {
-    state.scale = Math.max(0.35, Math.min(2.6, state.scale + delta));
-    render();
-  }
-
-  svg.addEventListener('wheel', (event) => {
-    event.preventDefault();
-    zoom(event.deltaY < 0 ? 0.12 : -0.12);
-  });
-  svg.addEventListener('mousedown', (event) => {
-    state.dragging = true;
-    state.dragX = event.clientX;
-    state.dragY = event.clientY;
-    svg.classList.add('dragging');
-  });
-  window.addEventListener('mousemove', (event) => {
-    if (!state.dragging) return;
-    state.tx += event.clientX - state.dragX;
-    state.ty += event.clientY - state.dragY;
-    state.dragX = event.clientX;
-    state.dragY = event.clientY;
-    applyTransform();
-  });
-  window.addEventListener('mouseup', () => {
-    state.dragging = false;
-    svg.classList.remove('dragging');
-  });
-  document.getElementById('graph-zoom-in').addEventListener('click', () => zoom(0.15));
-  document.getElementById('graph-zoom-out').addEventListener('click', () => zoom(-0.15));
-  document.getElementById('graph-recenter').addEventListener('click', () => {
-    state.scale = 1;
-    state.tx = 0;
-    state.ty = 0;
-    render();
-  });
-  document.getElementById('graph-filter').addEventListener('change', (event) => {
-    const next = new URL(window.location.href);
-    if (event.target.value === 'all') next.searchParams.delete('edge_filter');
-    else next.searchParams.set('edge_filter', event.target.value);
-    window.location.href = next.toString();
-  });
-  render();
-})();
-</script>
-""",
-            ]
         ),
         requested_pack=requested_pack,
     )
@@ -2437,6 +2218,7 @@ def _render_signals_page(payload: dict) -> str:
     next_path = "/signals" + (f"?pack={quote(requested_pack, safe='')}" if requested_pack else "")
     surface_contract_card = _render_surface_contract_card(payload)
     governance_contract_card = _render_governance_contract_card(payload)
+    operator_rail_card = _render_operator_rail(payload)
     options = ["", *sorted(payload["signal_type_explanations"].keys())]
     option_html = "".join(
         f"<option value='{escape(option)}' {'selected' if option == selected_type else ''}>"
@@ -2448,6 +2230,21 @@ def _render_signals_page(payload: dict) -> str:
         f'<span class="pill">{escape(item["signal_type"])}</span> '
         f'<a href="{escape(item["source_path"])}">{escape(item["title"])}</a>'
         f"<div class='muted'>{escape(item['detail'])}</div>"
+        + (
+            f"<div class='muted'>Impact: {escape(str(item['impact_summary']['impact_label']))}</div>"
+            if item.get("impact_summary", {}).get("impact_label")
+            else ""
+        )
+        + (
+            f"<div class='muted'>{escape(str(item['impact_summary']['impact_detail']))}</div>"
+            if item.get("impact_summary", {}).get("impact_detail")
+            else ""
+        )
+        + (
+            f"<div class='muted'>Inbound capture: {escape(str(item['capture_summary']['summary']))}</div>"
+            if item.get("capture_summary", {}).get("summary")
+            else ""
+        )
         + (
             "<div class='muted'>Recommended Action: "
             + f'<a href="{escape(item["recommended_action"]["path"])}">{escape(item["recommended_action"]["label"])}</a>'
@@ -2532,8 +2329,15 @@ def _render_signals_page(payload: dict) -> str:
                 "<button type='submit'>Filter</button>",
                 "</form>",
                 f"<p class='muted'>{payload['count']} active signals.",
+                (
+                    " "
+                    + f"{payload.get('impact_counts', {}).get('productive', 0)} productive, "
+                    + f"{payload.get('impact_counts', {}).get('waiting', 0)} waiting, "
+                    + f"{payload.get('impact_counts', {}).get('failed', 0) + payload.get('impact_counts', {}).get('stalled', 0)} failed/stalled."
+                ),
                 f" Pack scope: {escape(requested_pack)}." if requested_pack else "",
                 "</p>",
+                operator_rail_card,
                 surface_contract_card,
                 governance_contract_card,
                 f"<section class='card'><h2>Signal Types</h2><ul class='list-tight'>{explanations}</ul></section>",
@@ -2550,6 +2354,8 @@ def _render_briefing_page(payload: dict) -> str:
     surface_contract_card = _render_surface_contract_card(payload)
     assembly_contract_card = _render_assembly_contract_card(payload)
     governance_contract_card = _render_governance_contract_card(payload)
+    operator_rail_card = _render_operator_rail(payload)
+    lead_sections, remaining_sections = _split_lead_compiled_sections(payload.get("compiled_sections", []))
     first_useful_sign = payload.get("first_useful_sign")
     first_useful_sign_html = (
         "<li>"
@@ -2662,23 +2468,32 @@ def _render_briefing_page(payload: dict) -> str:
         for item in payload.get("section_nav", [])
     )
     queue_summary = payload.get("queue_summary", {})
+    loop_summary = payload.get("loop_summary", {})
     failure_buckets = "".join(
         f"<li><span class='pill'>{escape(bucket)}</span> {count}</li>"
         for bucket, count in queue_summary.get("failure_buckets", {}).items()
     ) or "<li class='muted'>No failed actions.</li>"
     return _layout(
-        "Orientation Brief",
+        "Working Memory Snapshot",
         "".join(
             [
                 "<h1>Orientation Brief</h1>",
                 f"<p class='muted'>Generated at {escape(payload['generated_at'])}. {payload['recent_signal_count']} recent signals, {payload['unresolved_issue_count']} unresolved issues.",
+                (
+                    " "
+                    + f"Loop: {loop_summary.get('productive_count', 0)} productive, "
+                    + f"{loop_summary.get('waiting_count', 0)} waiting, "
+                    + f"{loop_summary.get('failed_count', 0) + loop_summary.get('stalled_count', 0)} blocked."
+                ),
                 f" Pack scope: {escape(requested_pack)}." if requested_pack else "",
                 "</p>",
+                _render_compiled_sections(lead_sections),
+                operator_rail_card,
                 surface_contract_card,
                 assembly_contract_card,
                 governance_contract_card,
                 f"<nav class='subnav'>{section_nav}</nav>" if section_nav else "",
-                _render_compiled_sections(payload.get("compiled_sections", [])),
+                _render_compiled_sections(remaining_sections),
                 f"<section class='card'><h2>First Useful Sign</h2><ul class='list-tight'>{first_useful_sign_html}</ul></section>",
                 f"<section class='card'><h2>Insights</h2><ul class='list-tight'>{insights}</ul></section>",
                 f"<section class='card'><h2>Priority Items</h2><ul class='list-tight'>{priority_items}</ul></section>",
@@ -2745,6 +2560,16 @@ def _render_actions_page(payload: dict) -> str:
         + (
             f"<div class='muted'>Failure bucket: {escape(str(item['failure_bucket']))}</div>"
             if item.get("failure_bucket")
+            else ""
+        )
+        + (
+            f"<div class='muted'>Impact: {escape(str(item['impact_summary']['impact_label']))}</div>"
+            if item.get("impact_summary", {}).get("impact_label")
+            else ""
+        )
+        + (
+            f"<div class='muted'>{escape(str(item['impact_summary']['impact_detail']))}</div>"
+            if item.get("impact_summary", {}).get("impact_detail")
             else ""
         )
         + (
@@ -2854,7 +2679,13 @@ def _render_actions_page(payload: dict) -> str:
                 f"<select name='status'>{option_html}</select>",
                 "<button type='submit'>Filter</button>",
                 "</form>",
-                f"<p class='muted'>{payload['count']} actions in the current execution surface. {payload.get('queued_safe_count', 0)} queued safe actions. {payload.get('failed_count', 0)} failed actions.</p>",
+                (
+                    f"<p class='muted'>{payload['count']} actions in the current execution surface. "
+                    f"{payload.get('impact_counts', {}).get('productive', 0)} productive, "
+                    f"{payload.get('impact_counts', {}).get('waiting', 0)} waiting, "
+                    f"{payload.get('impact_counts', {}).get('failed', 0) + payload.get('impact_counts', {}).get('stalled', 0)} failed/stalled. "
+                    f"{payload.get('queued_safe_count', 0)} queued safe actions. {payload.get('failed_count', 0)} failed actions.</p>"
+                ),
                 governance_contract_card,
                 f"<section class='card'><ul class='list-tight'>{items}</ul></section>",
             ]
@@ -2869,6 +2700,8 @@ def _render_contradictions_page(payload: dict) -> str:
     requested_pack = payload.get("requested_pack", "")
     next_path = "/contradictions" + (f"?pack={quote(requested_pack, safe='')}" if requested_pack else "")
     assembly_contract_card = _render_assembly_contract_card(payload)
+    operator_rail_card = _render_operator_rail(payload)
+    lead_sections, remaining_sections = _split_lead_compiled_sections(payload.get("compiled_sections", []))
     detection_notes = "".join(f"<li>{escape(note)}</li>" for note in payload["detection_notes"])
     scope_summary = payload["scope_summary"]
     scope_summary_items = (
@@ -2880,6 +2713,8 @@ def _render_contradictions_page(payload: dict) -> str:
     detection_contract_items = (
         f"<li>Model: {escape(detection_contract['model'])}</li>"
         + f"<li>Confidence: {escape(detection_contract['confidence'])}</li>"
+        + f"<li>Polarity semantics: {escape(str(detection_contract.get('polarity_semantics') or ''))}</li>"
+        + f"<li>Evidence semantics: {escape(str(detection_contract.get('evidence_semantics') or ''))}</li>"
         + "".join(
             f"<li>Status bucket {escape(str(bucket))}: {count}</li>"
             for bucket, count in detection_contract["status_buckets"].items()
@@ -2970,6 +2805,7 @@ def _render_contradictions_page(payload: dict) -> str:
             )
             + "</ul></details>"
         )
+        + f"<div class='muted'>Tension Summary: {escape(str(item.get('tension_summary') or ''))}</div>"
         + (
             "<details><summary>Review History</summary><ul class='list-tight'>"
             + "".join(
@@ -3043,9 +2879,11 @@ def _render_contradictions_page(payload: dict) -> str:
                 f"<p class='muted'>{payload['count']} records, {payload['open_count']} open.",
                 f" Pack scope: {escape(requested_pack)}." if requested_pack else "",
                 "</p>",
+                _render_compiled_sections(lead_sections),
+                operator_rail_card,
                 assembly_contract_card,
                 f"<nav class='subnav'>{section_nav}</nav>" if section_nav else "",
-                _render_compiled_sections(payload.get("compiled_sections", [])),
+                _render_compiled_sections(remaining_sections),
                 f"<section class='card'><h2>Detection Notes</h2><ul class='list-tight'>{detection_notes}</ul></section>",
                 "<section class='card'>",
                 "<h2>Batch Resolve</h2>",
@@ -3365,43 +3203,6 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
                         return
                     payload = build_cluster_browser_payload(resolved_vault, pack_name=pack_name, query=q)
                     self._write_html(_render_clusters_page(payload))
-                    return
-                if path == "/api/graph":
-                    pack_name = query.get("pack", [""])[0] or None
-                    cluster_id = query.get("cluster_id", [""])[0] or None
-                    object_id = query.get("object_id", [""])[0] or None
-                    expand = query.get("expand", ["0"])[0] or "0"
-                    edge_filter = query.get("edge_filter", ["all"])[0] or "all"
-                    if self._guard_research_route(pack_name=pack_name, route_path="/graph", api=True):
-                        return
-                    self._write_json(
-                        build_graph_canvas_payload(
-                            resolved_vault,
-                            pack_name=pack_name,
-                            cluster_id=cluster_id,
-                            object_id=object_id,
-                            expand=expand,
-                            edge_filter=edge_filter,
-                        )
-                    )
-                    return
-                if path == "/graph":
-                    pack_name = query.get("pack", [""])[0] or None
-                    cluster_id = query.get("cluster_id", [""])[0] or None
-                    object_id = query.get("object_id", [""])[0] or None
-                    expand = query.get("expand", ["0"])[0] or "0"
-                    edge_filter = query.get("edge_filter", ["all"])[0] or "all"
-                    if self._guard_research_route(pack_name=pack_name, route_path="/graph", api=False):
-                        return
-                    payload = build_graph_canvas_payload(
-                        resolved_vault,
-                        pack_name=pack_name,
-                        cluster_id=cluster_id,
-                        object_id=object_id,
-                        expand=expand,
-                        edge_filter=edge_filter,
-                    )
-                    self._write_html(_render_graph_page(payload))
                     return
                 if path == "/api/cluster":
                     cluster_id = self._required(query, "id")

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -1932,22 +1932,22 @@ def _build_signal_impact_summary(
         return _build_action_impact_summary(action)
     if bool(recommended_action.get("executable")):
         return {
-            "impact_status": "review_only",
-            "lifecycle_stage": "manual_review",
+            "impact_status": "ready",
+            "lifecycle_stage": "recommendation_only",
             "action_kind": str(recommended_action.get("kind") or ""),
             "action_status": "",
-            "impact_label": "Review-only signal",
-            "impact_detail": "This signal currently routes to an operator review flow instead of queued execution.",
+            "impact_label": "Action available",
+            "impact_detail": "An executable action exists for this signal, but nothing is currently queued.",
             "produced_artifact_count": 0,
             "produced_artifact_types": [],
         }
     return {
-        "impact_status": "ready",
-        "lifecycle_stage": "recommendation_only",
+        "impact_status": "review_only",
+        "lifecycle_stage": "manual_review",
         "action_kind": str(recommended_action.get("kind") or ""),
         "action_status": "",
-        "impact_label": "Action available",
-        "impact_detail": "A queueable action exists for this signal, but nothing is currently queued.",
+        "impact_label": "Review-only signal",
+        "impact_detail": "This signal currently routes to an operator review flow instead of queued execution.",
         "produced_artifact_count": 0,
         "produced_artifact_types": [],
     }
@@ -2734,9 +2734,12 @@ def _match_note_capture_event(
     relative_path_field = _vault_relative_path(vault_dir, str(payload.get("path") or ""))
     file_name = Path(str(payload.get("file") or "")).name
     source_name = Path(str(payload.get("source") or "")).name
+    staged_name = Path(relative_staged).name
+    archived_name = Path(relative_archived).name
+    restored_name = Path(relative_restored).name
 
     if event_type == "source_staged_for_processing" and (
-        relative_source == note_path or relative_staged == note_path or note_name in {Path(relative_source).name, Path(relative_staged).name}
+        relative_source == note_path or relative_staged == note_path or note_name in {source_name, staged_name}
     ):
         return _note_capture_item(
             kind="source_staged",
@@ -2745,7 +2748,7 @@ def _match_note_capture_event(
             detail="Source note was staged for processing.",
         )
     if event_type == "source_archived_to_processed" and (
-        relative_source == note_path or relative_archived == note_path or note_name in {Path(relative_source).name, Path(relative_archived).name}
+        relative_source == note_path or relative_archived == note_path or note_name in {source_name, archived_name}
     ):
         return _note_capture_item(
             kind="processed_source",
@@ -2754,7 +2757,7 @@ def _match_note_capture_event(
             detail="Source note was archived into the processed intake.",
         )
     if event_type == "source_restored_to_raw" and (
-        relative_source == note_path or relative_restored == note_path or note_name in {Path(relative_source).name, Path(relative_restored).name}
+        relative_source == note_path or relative_restored == note_path or note_name in {source_name, restored_name}
     ):
         return _note_capture_item(
             kind="source_restored",
@@ -2851,25 +2854,10 @@ def _match_note_capture_event(
     return None
 
 
-def get_note_inbound_capture_summary(vault_dir: Path | str, *, note_path: str) -> dict[str, Any]:
-    resolved_vault = resolve_vault_dir(vault_dir)
-    layout = VaultLayout.from_vault(resolved_vault)
-    targets = _note_capture_targets(resolved_vault, note_path)
-    derived_note_names: set[str] = {str(targets["note_name"])}
-    items: list[dict[str, Any]] = []
-    for log_path in (layout.pipeline_log, layout.logs_dir / "refine-mutations.jsonl"):
-        if not log_path.exists():
-            continue
-        for payload in _read_jsonl_items(log_path):
-            item = _match_note_capture_event(
-                resolved_vault,
-                payload=payload,
-                targets=targets,
-                derived_note_names=derived_note_names,
-            )
-            if item is not None:
-                items.append(item)
-
+def _capture_summary_payload(
+    note_path: str,
+    items: list[dict[str, Any]],
+) -> dict[str, Any]:
     items.sort(key=lambda item: (str(item.get("timestamp") or ""), str(item.get("kind") or "")))
     captured_event_count = len(items)
     produced_artifact_count = sum(int(item.get("produced_artifact_count") or 0) for item in items)
@@ -2902,6 +2890,49 @@ def get_note_inbound_capture_summary(vault_dir: Path | str, *, note_path: str) -
     }
 
 
+def _collect_note_capture_summaries(
+    vault_dir: Path | str,
+    note_paths: list[str],
+) -> dict[str, dict[str, Any]]:
+    resolved_vault = resolve_vault_dir(vault_dir)
+    layout = VaultLayout.from_vault(resolved_vault)
+    target_state: dict[str, dict[str, Any]] = {}
+    for note_path in note_paths:
+        normalized_path = str(note_path)
+        if not normalized_path.strip() or normalized_path in target_state:
+            continue
+        targets = _note_capture_targets(resolved_vault, normalized_path)
+        target_state[normalized_path] = {
+            "targets": targets,
+            "derived_note_names": {str(targets["note_name"])},
+            "items": [],
+        }
+    for log_path in (layout.pipeline_log, layout.logs_dir / "refine-mutations.jsonl"):
+        if not log_path.exists():
+            continue
+        for payload in _read_jsonl_items(log_path):
+            for state in target_state.values():
+                item = _match_note_capture_event(
+                    resolved_vault,
+                    payload=payload,
+                    targets=state["targets"],
+                    derived_note_names=state["derived_note_names"],
+                )
+                if item is not None:
+                    state["items"].append(item)
+    return {
+        note_path: _capture_summary_payload(note_path, list(state["items"]))
+        for note_path, state in target_state.items()
+    }
+
+
+def get_note_inbound_capture_summary(vault_dir: Path | str, *, note_path: str) -> dict[str, Any]:
+    return _collect_note_capture_summaries(vault_dir, [str(note_path)]).get(
+        str(note_path),
+        _capture_summary_payload(str(note_path), []),
+    )
+
+
 def _aggregate_note_capture_summaries(
     vault_dir: Path | str,
     note_paths: list[str],
@@ -2925,7 +2956,8 @@ def _aggregate_note_capture_summaries(
         payload["note_paths"] = normalized_paths
         return payload
 
-    summaries = [get_note_inbound_capture_summary(vault_dir, note_path=item) for item in normalized_paths]
+    summary_map = _collect_note_capture_summaries(vault_dir, normalized_paths)
+    summaries = [summary_map[item] for item in normalized_paths]
     captured_event_count = sum(item["captured_event_count"] for item in summaries)
     produced_artifact_count = sum(item["produced_artifact_count"] for item in summaries)
     candidate_count = sum(item["candidate_count"] for item in summaries)

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -19,6 +19,7 @@ from .governance_registry import (
     list_effective_governance_specs,
 )
 from .handler_registry import execute_focused_action_handler
+from .identity import canonicalize_note_id
 from .knowledge_index import ensure_knowledge_db_current
 from .observation_surface_registry import execute_observation_surface_builder
 from .pack_resolution import iter_compatible_packs
@@ -1383,108 +1384,6 @@ def get_graph_cluster_detail(
     }
 
 
-def _graph_scope_limit(value: int, *, default: int, maximum: int) -> int:
-    try:
-        normalized = int(value)
-    except (TypeError, ValueError):
-        normalized = default
-    return max(1, min(normalized, maximum))
-
-
-def get_graph_cluster_scope(
-    vault_dir: Path | str,
-    cluster_id: str,
-    *,
-    pack_name: str | None = None,
-    object_limit: int = 10,
-    edge_limit: int = 48,
-) -> dict[str, Any]:
-    detail = get_graph_cluster_detail(vault_dir, cluster_id, pack_name=pack_name)
-    object_limit = _graph_scope_limit(object_limit, default=10, maximum=48)
-    edge_limit = _graph_scope_limit(edge_limit, default=48, maximum=192)
-
-    cluster = detail["cluster"]
-    edges = detail["edges"]
-    member_rows = {str(member["object_id"]): member for member in cluster["members"]}
-    degree_counts: Counter[str] = Counter()
-    for edge in edges:
-        degree_counts[str(edge["source_object_id"])] += 1
-        degree_counts[str(edge["target_object_id"])] += 1
-
-    center_object_id = str(cluster["center_object_id"])
-    ordered_member_ids = [center_object_id]
-    ordered_member_ids.extend(
-        object_id
-        for object_id, _member in sorted(
-            (
-                (str(member["object_id"]), member)
-                for member in cluster["members"]
-                if str(member["object_id"]) != center_object_id
-            ),
-            key=lambda item: (
-                -degree_counts.get(item[0], 0),
-                str(item[1].get("title") or item[0]).lower(),
-                item[0],
-            ),
-        )
-    )
-    visible_member_ids = ordered_member_ids[:object_limit]
-    visible_member_id_set = set(visible_member_ids)
-    visible_edges = [
-        edge
-        for edge in edges
-        if str(edge["source_object_id"]) in visible_member_id_set
-        and str(edge["target_object_id"]) in visible_member_id_set
-    ][:edge_limit]
-
-    return {
-        "cluster": cluster,
-        "visible_members": [
-            {
-                **member_rows[object_id],
-                "graph_degree": degree_counts.get(object_id, 0),
-                "is_center": object_id == center_object_id,
-            }
-            for object_id in visible_member_ids
-            if object_id in member_rows
-        ],
-        "visible_edges": visible_edges,
-        "member_limit": object_limit,
-        "edge_limit": edge_limit,
-        "hidden_member_count": max(0, int(cluster["member_count"]) - len(visible_member_ids)),
-        "hidden_edge_count": max(0, len(edges) - len(visible_edges)),
-    }
-
-
-def get_graph_object_scope(
-    vault_dir: Path | str,
-    object_id: str,
-    *,
-    pack_name: str | None = None,
-    neighbor_limit: int = 10,
-    edge_limit: int = 48,
-) -> dict[str, Any]:
-    neighbor_limit = _graph_scope_limit(neighbor_limit, default=10, maximum=48)
-    edge_limit = _graph_scope_limit(edge_limit, default=48, maximum=192)
-    neighborhood = get_topic_neighborhood(vault_dir, object_id, pack_name=pack_name, depth=1)
-    visible_neighbors = neighborhood["neighbors"][:neighbor_limit]
-    visible_neighbor_ids = {str(item["object_id"]) for item in visible_neighbors}
-    visible_edges = [
-        edge
-        for edge in neighborhood["edges"]
-        if str(edge["target_object_id"]) in visible_neighbor_ids
-    ][:edge_limit]
-    return {
-        "center": neighborhood["center"],
-        "visible_neighbors": visible_neighbors,
-        "visible_edges": visible_edges,
-        "neighbor_limit": neighbor_limit,
-        "edge_limit": edge_limit,
-        "hidden_neighbor_count": max(0, len(neighborhood["neighbors"]) - len(visible_neighbors)),
-        "hidden_edge_count": max(0, len(neighborhood["edges"]) - len(visible_edges)),
-    }
-
-
 def _find_note_by_source(vault_dir: Path, *, source_url: str, exclude_path: str) -> dict[str, str] | None:
     cache_key = (str(vault_dir.resolve()), _search_root_signatures(vault_dir))
     source_index = _SOURCE_NOTE_INDEX_CACHE.get(cache_key)
@@ -1880,7 +1779,178 @@ def _normalize_action_queue_item(item: dict[str, Any]) -> dict[str, Any]:
         current = normalized.get(key)
         if key not in normalized or current in (None, "", []):
             normalized[key] = value
+    normalized["impact_summary"] = _build_action_impact_summary(normalized)
     return normalized
+
+
+def _count_nonempty_strings(value: Any) -> int:
+    if isinstance(value, str):
+        return 1 if value.strip() else 0
+    if isinstance(value, (list, tuple, set)):
+        return sum(1 for item in value if isinstance(item, str) and item.strip())
+    return 0
+
+
+def _count_sequence_items(value: Any) -> int:
+    if isinstance(value, (list, tuple, set)):
+        return sum(1 for item in value if item)
+    return 0
+
+
+def _result_artifact_summary(action: dict[str, Any]) -> tuple[int, list[str]]:
+    result = action.get("result")
+    if not isinstance(result, dict):
+        return 0, []
+    processor_outputs = {str(item) for item in action.get("processor_outputs", []) if item}
+    summary = result.get("summary") if isinstance(result.get("summary"), dict) else {}
+
+    note_output_count = max(
+        _count_nonempty_strings(result.get("output_path")),
+        _count_nonempty_strings(result.get("output")),
+        _count_nonempty_strings(result.get("output_paths")),
+    )
+    object_output_count = max(
+        _count_sequence_items(result.get("object_ids")),
+        _count_sequence_items(result.get("created_object_ids")),
+        _count_sequence_items(result.get("promoted_object_ids")),
+        _count_sequence_items(result.get("rebuilt_object_ids")),
+        int(summary.get("concepts_promoted") or 0) + int(summary.get("concepts_created") or 0),
+        int(summary.get("objects_rebuilt") or 0),
+    )
+
+    artifact_types: list[str] = []
+    if note_output_count > 0:
+        artifact_types.append("deep_dive" if "deep_dive" in processor_outputs else "note_artifact")
+    if object_output_count > 0:
+        if "evergreen_object" in processor_outputs:
+            artifact_types.append("evergreen_object")
+        else:
+            artifact_types.append("knowledge_artifact")
+    return note_output_count + object_output_count, artifact_types
+
+
+def _build_action_impact_summary(action: dict[str, Any]) -> dict[str, Any]:
+    action_status = str(action.get("status") or "")
+    action_kind = str(action.get("action_kind") or "")
+    produced_artifact_count, produced_artifact_types = _result_artifact_summary(action)
+    base = {
+        "impact_status": "unknown",
+        "lifecycle_stage": action_status or "unknown",
+        "action_kind": action_kind,
+        "action_status": action_status,
+        "impact_label": "Unknown execution state",
+        "impact_detail": "The action queue item does not currently expose a recognized lifecycle state.",
+        "produced_artifact_count": produced_artifact_count,
+        "produced_artifact_types": produced_artifact_types,
+    }
+    if action_status == "queued":
+        return {
+            **base,
+            "impact_status": "waiting",
+            "lifecycle_stage": "queued",
+            "impact_label": "Waiting on queue execution",
+            "impact_detail": "A queueable action exists and is currently waiting to run.",
+        }
+    if action_status == "running":
+        return {
+            **base,
+            "impact_status": "running",
+            "lifecycle_stage": "running",
+            "impact_label": "Execution in progress",
+            "impact_detail": "The queued action is currently running.",
+        }
+    if action_status == "failed":
+        bucket = str(action.get("failure_bucket") or "")
+        detail = "Execution failed."
+        if bucket:
+            detail = f"Execution failed in bucket '{bucket}'."
+        return {
+            **base,
+            "impact_status": "failed",
+            "lifecycle_stage": "failed",
+            "impact_label": "Execution failed",
+            "impact_detail": detail,
+        }
+    if action_status in {"dismissed", "obsolete"}:
+        detail = (
+            "Execution was dismissed before completion."
+            if action_status == "dismissed"
+            else "Execution became obsolete because the source signal disappeared."
+        )
+        return {
+            **base,
+            "impact_status": "stalled",
+            "lifecycle_stage": action_status,
+            "impact_label": "Execution stopped",
+            "impact_detail": detail,
+        }
+    if action_status == "succeeded":
+        if produced_artifact_count > 0:
+            noun = "artifact" if produced_artifact_count == 1 else "artifacts"
+            type_detail = (
+                f" ({', '.join(str(item) for item in produced_artifact_types)})"
+                if produced_artifact_types
+                else ""
+            )
+            return {
+                **base,
+                "impact_status": "productive",
+                "lifecycle_stage": "succeeded",
+                "impact_label": "Produced downstream change",
+                "impact_detail": (
+                    f"Execution completed and produced {produced_artifact_count} tracked {noun}{type_detail}."
+                ),
+            }
+        return {
+            **base,
+            "impact_status": "completed",
+            "lifecycle_stage": "succeeded",
+            "impact_label": "Execution completed",
+            "impact_detail": "Execution completed without a tracked downstream artifact.",
+        }
+    return base
+
+
+def _build_signal_impact_summary(
+    signal: dict[str, Any],
+    *,
+    action: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    recommended_action = signal.get("recommended_action")
+    if not isinstance(recommended_action, dict) or not recommended_action.get("kind"):
+        return {
+            "impact_status": "review_only",
+            "lifecycle_stage": "manual_review",
+            "action_kind": "",
+            "action_status": "",
+            "impact_label": "Review-only signal",
+            "impact_detail": "This signal currently has no execution path and remains an operator review item.",
+            "produced_artifact_count": 0,
+            "produced_artifact_types": [],
+        }
+    if action is not None:
+        return _build_action_impact_summary(action)
+    if bool(recommended_action.get("executable")):
+        return {
+            "impact_status": "review_only",
+            "lifecycle_stage": "manual_review",
+            "action_kind": str(recommended_action.get("kind") or ""),
+            "action_status": "",
+            "impact_label": "Review-only signal",
+            "impact_detail": "This signal currently routes to an operator review flow instead of queued execution.",
+            "produced_artifact_count": 0,
+            "produced_artifact_types": [],
+        }
+    return {
+        "impact_status": "ready",
+        "lifecycle_stage": "recommendation_only",
+        "action_kind": str(recommended_action.get("kind") or ""),
+        "action_status": "",
+        "impact_label": "Action available",
+        "impact_detail": "A queueable action exists for this signal, but nothing is currently queued.",
+        "produced_artifact_count": 0,
+        "produced_artifact_types": [],
+    }
 
 
 def _signal_by_id(
@@ -2312,8 +2382,10 @@ def _attach_action_queue_state(
             if key not in enriched or current in (None, "", False):
                 enriched[key] = value
         recommended_action = item.get("recommended_action")
+        matched_action: dict[str, Any] | None = None
         if isinstance(recommended_action, dict):
             action = queue_state.get(str(item.get("signal_id") or ""))
+            matched_action = action
             recommended = dict(recommended_action)
             resolver_metadata = _resolver_rule_metadata_for_action_kind(
                 str(recommended.get("kind") or ""),
@@ -2334,6 +2406,27 @@ def _attach_action_queue_state(
                 )
                 recommended["safe_to_run"] = bool(action.get("safe_to_run"))
             enriched["recommended_action"] = recommended
+        note_paths = [
+            str(path)
+            for path in enriched.get("note_paths", [])
+            if isinstance(path, str) and path.strip()
+        ]
+        try:
+            enriched["capture_summary"] = _aggregate_note_capture_summaries(vault_dir, note_paths)
+        except Exception:
+            enriched["capture_summary"] = {
+                "status": "missing",
+                "captured_event_count": 0,
+                "produced_artifact_count": 0,
+                "candidate_count": 0,
+                "error_count": 0,
+                "skipped_count": 0,
+                "latest_timestamp": "",
+                "summary": "No inbound capture audit was found for this note yet.",
+                "items": [],
+                "note_paths": note_paths,
+            }
+        enriched["impact_summary"] = _build_signal_impact_summary(enriched, action=matched_action)
         annotated.append(enriched)
     return annotated
 
@@ -2533,6 +2626,343 @@ def get_note_provenance(vault_dir: Path | str, *, note_path: str) -> dict[str, A
         "note_path": note_path,
         "original_source_note": original_source_note,
         "derived_deep_dives": derived_deep_dives,
+    }
+
+
+def _capture_summary_status(
+    *,
+    event_count: int,
+    produced_artifact_count: int,
+    error_count: int,
+    skipped_count: int,
+) -> str:
+    if produced_artifact_count > 0:
+        return "productive"
+    if error_count > 0:
+        return "failed"
+    if skipped_count > 0:
+        return "skipped"
+    if event_count > 0:
+        return "observed"
+    return "missing"
+
+
+def _capture_summary_text(
+    *,
+    status: str,
+    event_count: int,
+    produced_artifact_count: int,
+    candidate_count: int,
+    error_count: int,
+) -> str:
+    if status == "productive":
+        artifact_noun = "artifact" if produced_artifact_count == 1 else "artifacts"
+        candidate_text = (
+            f" and surfaced {candidate_count} candidate" + ("" if candidate_count == 1 else "s")
+            if candidate_count
+            else ""
+        )
+        return (
+            f"Captured {event_count} inbound events and produced "
+            f"{produced_artifact_count} downstream {artifact_noun}{candidate_text}."
+        )
+    if status == "failed":
+        issue_noun = "error" if error_count == 1 else "errors"
+        return f"Observed {event_count} inbound capture events with {error_count} {issue_noun}."
+    if status == "skipped":
+        return f"Observed {event_count} inbound capture events, but the run stopped before downstream output."
+    if status == "observed":
+        noun = "event" if event_count == 1 else "events"
+        return f"Observed {event_count} inbound capture {noun} but no downstream artifact yet."
+    return "No inbound capture audit was found for this note yet."
+
+
+def _note_capture_item(
+    *,
+    kind: str,
+    label: str,
+    timestamp: str,
+    detail: str,
+    path: str = "",
+    produced_artifact_count: int = 0,
+    candidate_count: int = 0,
+    error_count: int = 0,
+    skipped_count: int = 0,
+) -> dict[str, Any]:
+    return {
+        "kind": kind,
+        "label": label,
+        "timestamp": timestamp,
+        "detail": detail,
+        "path": path,
+        "produced_artifact_count": produced_artifact_count,
+        "candidate_count": candidate_count,
+        "error_count": error_count,
+        "skipped_count": skipped_count,
+    }
+
+
+def _note_capture_targets(vault_dir: Path | str, note_path: str) -> dict[str, Any]:
+    relative_path = str(note_path)
+    note_name = Path(relative_path).name
+    frontmatter = _read_note_frontmatter(vault_dir, relative_path)
+    note_slug = canonicalize_note_id(str(frontmatter.get("note_id") or Path(relative_path).stem))
+    return {
+        "note_path": relative_path,
+        "note_name": note_name,
+        "note_slug": note_slug,
+    }
+
+
+def _match_note_capture_event(
+    vault_dir: Path | str,
+    *,
+    payload: dict[str, Any],
+    targets: dict[str, Any],
+    derived_note_names: set[str],
+) -> dict[str, Any] | None:
+    note_path = str(targets["note_path"])
+    note_name = str(targets["note_name"])
+    note_slug = str(targets["note_slug"])
+    event_type = str(payload.get("event_type") or "").strip()
+    timestamp = str(payload.get("timestamp") or "")
+    relative_source = _vault_relative_path(vault_dir, str(payload.get("source") or ""))
+    relative_staged = _vault_relative_path(vault_dir, str(payload.get("staged") or ""))
+    relative_archived = _vault_relative_path(vault_dir, str(payload.get("archived") or ""))
+    relative_restored = _vault_relative_path(vault_dir, str(payload.get("restored") or ""))
+    relative_output = _vault_relative_path(vault_dir, str(payload.get("output") or ""))
+    relative_path_field = _vault_relative_path(vault_dir, str(payload.get("path") or ""))
+    file_name = Path(str(payload.get("file") or "")).name
+    source_name = Path(str(payload.get("source") or "")).name
+
+    if event_type == "source_staged_for_processing" and (
+        relative_source == note_path or relative_staged == note_path or note_name in {Path(relative_source).name, Path(relative_staged).name}
+    ):
+        return _note_capture_item(
+            kind="source_staged",
+            label="Source staged",
+            timestamp=timestamp,
+            detail="Source note was staged for processing.",
+        )
+    if event_type == "source_archived_to_processed" and (
+        relative_source == note_path or relative_archived == note_path or note_name in {Path(relative_source).name, Path(relative_archived).name}
+    ):
+        return _note_capture_item(
+            kind="processed_source",
+            label="Source processed",
+            timestamp=timestamp,
+            detail="Source note was archived into the processed intake.",
+        )
+    if event_type == "source_restored_to_raw" and (
+        relative_source == note_path or relative_restored == note_path or note_name in {Path(relative_source).name, Path(relative_restored).name}
+    ):
+        return _note_capture_item(
+            kind="source_restored",
+            label="Source restored",
+            timestamp=timestamp,
+            detail="Source note was restored to raw intake before downstream output landed.",
+            skipped_count=1,
+        )
+    if event_type == "article_processed" and (relative_output == note_path or file_name == note_name):
+        if relative_output:
+            derived_note_names.add(Path(relative_output).name)
+        return _note_capture_item(
+            kind="deep_dive_created",
+            label="Deep dive created",
+            timestamp=timestamp,
+            detail=(
+                f"Created downstream deep dive at {relative_output}."
+                if relative_output
+                else "Created downstream deep dive."
+            ),
+            path=relative_output,
+            produced_artifact_count=1,
+        )
+    if event_type == "article_abstained" and file_name == note_name:
+        return _note_capture_item(
+            kind="capture_abstained",
+            label="Capture abstained",
+            timestamp=timestamp,
+            detail=f"Interpretation abstained: {str(payload.get('reason') or 'unspecified')}.",
+            skipped_count=1,
+        )
+    if event_type in {"article_error", "candidate_upsert_error", "evergreen_error"} and (
+        file_name == note_name or Path(str(payload.get("file") or "")).name == note_name
+    ):
+        return _note_capture_item(
+            kind="capture_error",
+            label="Capture error",
+            timestamp=timestamp,
+            detail=str(payload.get("error") or "Capture error."),
+            error_count=1,
+        )
+    if event_type == "candidates_upserted" and file_name == note_name:
+        candidates = [str(item) for item in payload.get("candidates", []) if str(item).strip()]
+        return _note_capture_item(
+            kind="candidate_upserted",
+            label="Candidate surfaced",
+            timestamp=timestamp,
+            detail=(
+                f"Surfaced {len(candidates)} candidate"
+                + ("" if len(candidates) == 1 else "s")
+                + (f": {', '.join(candidates)}." if candidates else ".")
+            ),
+            candidate_count=len(candidates),
+        )
+    if event_type in {"evergreen_auto_promoted", "evergreen_created"} and (
+        relative_path_field == note_path
+        or canonicalize_note_id(str(payload.get("concept") or payload.get("mutation", {}).get("target_slug") or "")) == note_slug
+        or source_name == note_name
+        or source_name in derived_note_names
+    ):
+        object_id = str(payload.get("mutation", {}).get("target_slug") or payload.get("concept") or "").strip()
+        label = "Evergreen promoted" if event_type == "evergreen_auto_promoted" else "Evergreen created"
+        detail = (
+            f"Promoted evergreen object {object_id}."
+            if event_type == "evergreen_auto_promoted" and object_id
+            else (
+                f"Created evergreen object {object_id}."
+                if object_id
+                else "Created evergreen output."
+            )
+        )
+        return _note_capture_item(
+            kind="evergreen_promoted" if event_type == "evergreen_auto_promoted" else "evergreen_created",
+            label=label,
+            timestamp=timestamp,
+            detail=detail,
+            path=relative_path_field,
+            produced_artifact_count=1,
+        )
+    if event_type == "refine_mutation_applied":
+        targets_list = [
+            canonicalize_note_id(str(item))
+            for item in payload.get("targets", [])
+            if isinstance(item, str) and item.strip()
+        ]
+        if note_slug in targets_list:
+            return _note_capture_item(
+                kind="refine_mutation",
+                label="Refine mutation",
+                timestamp=timestamp,
+                detail=f"Applied refine mutation in mode {str(payload.get('mode') or 'unknown')}.",
+                produced_artifact_count=1,
+            )
+    return None
+
+
+def get_note_inbound_capture_summary(vault_dir: Path | str, *, note_path: str) -> dict[str, Any]:
+    resolved_vault = resolve_vault_dir(vault_dir)
+    layout = VaultLayout.from_vault(resolved_vault)
+    targets = _note_capture_targets(resolved_vault, note_path)
+    derived_note_names: set[str] = {str(targets["note_name"])}
+    items: list[dict[str, Any]] = []
+    for log_path in (layout.pipeline_log, layout.logs_dir / "refine-mutations.jsonl"):
+        if not log_path.exists():
+            continue
+        for payload in _read_jsonl_items(log_path):
+            item = _match_note_capture_event(
+                resolved_vault,
+                payload=payload,
+                targets=targets,
+                derived_note_names=derived_note_names,
+            )
+            if item is not None:
+                items.append(item)
+
+    items.sort(key=lambda item: (str(item.get("timestamp") or ""), str(item.get("kind") or "")))
+    captured_event_count = len(items)
+    produced_artifact_count = sum(int(item.get("produced_artifact_count") or 0) for item in items)
+    candidate_count = sum(int(item.get("candidate_count") or 0) for item in items)
+    error_count = sum(int(item.get("error_count") or 0) for item in items)
+    skipped_count = sum(int(item.get("skipped_count") or 0) for item in items)
+    status = _capture_summary_status(
+        event_count=captured_event_count,
+        produced_artifact_count=produced_artifact_count,
+        error_count=error_count,
+        skipped_count=skipped_count,
+    )
+    return {
+        "note_path": str(note_path),
+        "status": status,
+        "captured_event_count": captured_event_count,
+        "produced_artifact_count": produced_artifact_count,
+        "candidate_count": candidate_count,
+        "error_count": error_count,
+        "skipped_count": skipped_count,
+        "latest_timestamp": str(items[-1]["timestamp"]) if items else "",
+        "summary": _capture_summary_text(
+            status=status,
+            event_count=captured_event_count,
+            produced_artifact_count=produced_artifact_count,
+            candidate_count=candidate_count,
+            error_count=error_count,
+        ),
+        "items": items[:8],
+    }
+
+
+def _aggregate_note_capture_summaries(
+    vault_dir: Path | str,
+    note_paths: list[str],
+) -> dict[str, Any]:
+    normalized_paths = [str(item) for item in note_paths if str(item).strip()]
+    if not normalized_paths:
+        return {
+            "status": "missing",
+            "captured_event_count": 0,
+            "produced_artifact_count": 0,
+            "candidate_count": 0,
+            "error_count": 0,
+            "skipped_count": 0,
+            "latest_timestamp": "",
+            "summary": "No inbound capture audit was found for this note yet.",
+            "items": [],
+            "note_paths": [],
+        }
+    if len(normalized_paths) == 1:
+        payload = get_note_inbound_capture_summary(vault_dir, note_path=normalized_paths[0])
+        payload["note_paths"] = normalized_paths
+        return payload
+
+    summaries = [get_note_inbound_capture_summary(vault_dir, note_path=item) for item in normalized_paths]
+    captured_event_count = sum(item["captured_event_count"] for item in summaries)
+    produced_artifact_count = sum(item["produced_artifact_count"] for item in summaries)
+    candidate_count = sum(item["candidate_count"] for item in summaries)
+    error_count = sum(item["error_count"] for item in summaries)
+    skipped_count = sum(item["skipped_count"] for item in summaries)
+    latest_timestamp = max((str(item["latest_timestamp"]) for item in summaries if item["latest_timestamp"]), default="")
+    status = _capture_summary_status(
+        event_count=captured_event_count,
+        produced_artifact_count=produced_artifact_count,
+        error_count=error_count,
+        skipped_count=skipped_count,
+    )
+    return {
+        "status": status,
+        "captured_event_count": captured_event_count,
+        "produced_artifact_count": produced_artifact_count,
+        "candidate_count": candidate_count,
+        "error_count": error_count,
+        "skipped_count": skipped_count,
+        "latest_timestamp": latest_timestamp,
+        "summary": _capture_summary_text(
+            status=status,
+            event_count=captured_event_count,
+            produced_artifact_count=produced_artifact_count,
+            candidate_count=candidate_count,
+            error_count=error_count,
+        ),
+        "items": [
+            {
+                "kind": "capture_note",
+                "label": Path(item["note_path"]).name,
+                "path": item["note_path"],
+                "detail": item["summary"],
+            }
+            for item in summaries
+        ][:8],
+        "note_paths": normalized_paths,
     }
 
 
@@ -2815,12 +3245,56 @@ def get_note_traceability(
             [item["object_id"] for item in objects],
             pack_name=pack_name,
         )
+    note_type = str(note.get("note_type") or "")
+    if note_type == "deep_dive":
+        stage_label = "deep_dive"
+        stage_presence = {
+            "source_notes": bool(source_notes),
+            "deep_dives": True,
+            "objects": bool(objects),
+            "atlas_pages": bool(atlas_pages),
+        }
+        chain_summary = (
+            f"Deep dive currently traces to {len(source_notes)} source notes, "
+            f"{len(objects)} objects, {len(atlas_pages)} atlas pages."
+        )
+    elif note_type == "evergreen":
+        stage_label = "evergreen_note"
+        stage_presence = {
+            "source_notes": bool(source_notes),
+            "deep_dives": bool(deep_dives),
+            "objects": True,
+            "atlas_pages": bool(atlas_pages),
+        }
+        chain_summary = (
+            f"Evergreen note currently traces to {len(source_notes)} source notes, "
+            f"{len(deep_dives)} deep dives, {len(objects)} objects, {len(atlas_pages)} atlas pages."
+        )
+    else:
+        stage_label = "source_note"
+        stage_presence = {
+            "source_notes": True,
+            "deep_dives": bool(deep_dives),
+            "objects": bool(objects),
+            "atlas_pages": bool(atlas_pages),
+        }
+        chain_summary = (
+            f"Source note currently traces to {len(deep_dives)} deep dives, "
+            f"{len(objects)} objects, {len(atlas_pages)} atlas pages."
+        )
+    missing_stages = [stage for stage, present in stage_presence.items() if not present]
+    chain_status = "complete" if not missing_stages else "partial"
     return {
         "note": note,
+        "stage_label": stage_label,
         "source_notes": source_notes,
         "deep_dives": deep_dives,
         "objects": objects,
         "atlas_pages": atlas_pages,
+        "stage_presence": stage_presence,
+        "missing_stages": missing_stages,
+        "chain_status": chain_status,
+        "chain_summary": chain_summary,
         "counts": {
             "source_notes": len(source_notes),
             "deep_dives": len(deep_dives),
@@ -2843,8 +3317,16 @@ def get_object_traceability(
         original = get_note_provenance(vault_dir, note_path=deep_dive["path"])["original_source_note"]
         if original:
             source_note_map.setdefault(original["path"], original)
+    stage_presence = {
+        "source_notes": bool(source_note_map),
+        "deep_dives": bool(deep_dives),
+        "atlas_pages": bool(detail["provenance"]["mocs"]),
+    }
+    missing_stages = [stage for stage, present in stage_presence.items() if not present]
+    chain_status = "complete" if not missing_stages else "partial"
     return {
         "object": detail["object"],
+        "stage_label": "evergreen_object",
         "evergreen_note": {
             "title": detail["object"]["title"],
             "path": detail["provenance"]["evergreen_path"],
@@ -2852,6 +3334,13 @@ def get_object_traceability(
         "source_notes": list(source_note_map.values()),
         "deep_dives": deep_dives,
         "atlas_pages": detail["provenance"]["mocs"],
+        "stage_presence": stage_presence,
+        "missing_stages": missing_stages,
+        "chain_status": chain_status,
+        "chain_summary": (
+            f"Object currently traces to {len(source_note_map)} source notes, "
+            f"{len(deep_dives)} deep dives, {len(detail['provenance']['mocs'])} atlas pages."
+        ),
         "counts": {
             "source_notes": len(source_note_map),
             "deep_dives": len(deep_dives),
@@ -2991,19 +3480,40 @@ def list_contradictions(
             item["status"],
             "Reviewed contradiction state.",
         )
+        source_note_count = len(
+            {
+                evidence["source_slug"]
+                for claim in item["positive_claims"] + item["negative_claims"]
+                for evidence in claim["evidence"]
+            }
+        )
+        quote_count = sum(
+            1
+            for claim in item["positive_claims"] + item["negative_claims"]
+            for evidence in claim["evidence"]
+            if str(evidence.get("quote_text") or "").strip()
+        )
         item["scope_summary"] = {
             "object_count": len(object_ids),
             "positive_claim_count": len(item["positive_claims"]),
             "negative_claim_count": len(item["negative_claims"]),
-            "source_note_count": len(
-                {
-                    evidence["source_slug"]
-                    for claim in item["positive_claims"] + item["negative_claims"]
-                    for evidence in claim["evidence"]
-                }
-            ),
+            "source_note_count": source_note_count,
         }
         item["ranked_evidence"] = _rank_contradiction_evidence(item)
+        item["polarity_summary"] = {
+            "positive_claim_count": len(item["positive_claims"]),
+            "negative_claim_count": len(item["negative_claims"]),
+            "object_count": len(object_ids),
+        }
+        item["evidence_summary"] = {
+            "ranked_evidence_count": len(item["ranked_evidence"]),
+            "source_note_count": source_note_count,
+            "quote_count": quote_count,
+        }
+        item["tension_summary"] = (
+            f"{len(item['positive_claims'])} positive claims vs "
+            f"{len(item['negative_claims'])} negative claims across {len(object_ids)} objects."
+        )
         item["review_history"] = list_review_actions(vault_dir, object_ids=object_ids, limit=5)
     return items
 

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import sqlite3
-import math
 from collections import Counter
 from pathlib import Path
 from typing import Any
@@ -22,11 +21,10 @@ from ..truth_api import (
     _batch_object_rows,
     count_objects,
     get_briefing_snapshot,
-    get_graph_cluster_scope,
     get_graph_cluster_detail,
-    get_graph_object_scope,
     get_object_detail,
     get_object_traceability,
+    get_note_inbound_capture_summary,
     get_note_provenance,
     get_note_traceability,
     get_object_provenance_map,
@@ -89,6 +87,46 @@ def _compiled_section(
     }
 
 
+def _workflow_group(
+    group_id: str,
+    title: str,
+    summary: str,
+    items: list[dict[str, str]],
+) -> dict[str, Any]:
+    return {
+        "id": group_id,
+        "title": title,
+        "summary": summary,
+        "items": items,
+    }
+
+
+def _operator_action(label: str, path: str, detail: str) -> dict[str, str]:
+    return {
+        "label": label,
+        "path": path,
+        "detail": detail,
+    }
+
+
+def _impact_counts(items: list[dict[str, Any]]) -> dict[str, int]:
+    return dict(
+        Counter(
+            str((item.get("impact_summary") or {}).get("impact_status") or "unknown")
+            for item in items
+        )
+    )
+
+
+def _capture_status_counts(items: list[dict[str, Any]]) -> dict[str, int]:
+    return dict(
+        Counter(
+            str((item.get("capture_summary") or {}).get("status") or "missing")
+            for item in items
+        )
+    )
+
+
 def _section_nav_from_compiled_sections(sections: list[dict[str, Any]]) -> list[dict[str, str]]:
     return [
         {
@@ -97,27 +135,6 @@ def _section_nav_from_compiled_sections(sections: list[dict[str, Any]]) -> list[
         }
         for section in sections
     ]
-
-
-def _compiled_section_by_id(
-    sections: list[dict[str, Any]],
-    section_id: str,
-) -> dict[str, Any]:
-    return next((section for section in sections if str(section.get("id") or "") == section_id), {})
-
-
-def _remap_compiled_section(
-    section: dict[str, Any],
-    *,
-    section_id: str,
-    label: str,
-    summary: str,
-    limit: int | None = None,
-) -> dict[str, Any]:
-    items = list(section.get("items") or [])
-    if limit is not None:
-        items = items[:limit]
-    return _compiled_section(section_id, label, summary=summary, items=items)
 
 
 def _db_path(vault_dir: Path | str) -> Path:
@@ -877,6 +894,7 @@ def build_signal_browser_payload(
             "requested_pack": requested_pack,
             "surface_contract": surface_contract,
             "governance_contract": governance_contract,
+            "operator_rail": [],
             "surface_error": (
                 f"Pack '{surface_contract['requested_pack']}' does not expose a shared shell "
                 f"'signals' surface."
@@ -886,6 +904,7 @@ def build_signal_browser_payload(
             "query": query or "",
             "signal_type": signal_type or "",
             "type_counts": {},
+            "impact_counts": {},
             "signal_type_explanations": SIGNAL_TYPE_EXPLANATIONS,
         }
     items = list_signals(vault_dir, pack_name=pack_name, signal_type=signal_type, query=query)
@@ -894,11 +913,42 @@ def build_signal_browser_payload(
         "requested_pack": requested_pack,
         "surface_contract": surface_contract,
         "governance_contract": governance_contract,
+        "operator_rail": [
+            _operator_action(
+                "Action Queue",
+                _scoped_path("/actions", pack_name=requested_pack),
+                "Run or inspect queued actions.",
+            ),
+            _operator_action(
+                "Production Browser",
+                _scoped_path("/production", pack_name=requested_pack),
+                "Trace current production weak points.",
+            ),
+            _operator_action(
+                "Contradictions",
+                _scoped_path(
+                    "/contradictions" if _supports_research_shell(pack_name) else "/search",
+                    pack_name=requested_pack,
+                ),
+                (
+                    "Review semantic tensions."
+                    if _supports_research_shell(pack_name)
+                    else "Shared-shell search fallback."
+                ),
+            ),
+            _operator_action(
+                "Orientation Brief",
+                _scoped_path("/briefing", pack_name=requested_pack),
+                "Return to the current entry product.",
+            ),
+        ],
         "items": items,
         "count": len(items),
         "query": query or "",
         "signal_type": signal_type or "",
         "type_counts": dict(Counter(item["signal_type"] for item in items)),
+        "impact_counts": _impact_counts(items),
+        "capture_status_counts": _capture_status_counts(items),
         "signal_type_explanations": SIGNAL_TYPE_EXPLANATIONS,
     }
 
@@ -921,6 +971,7 @@ def build_action_queue_payload(
         "query": query or "",
         "status": status or "",
         "status_counts": dict(Counter(str(item["status"]) for item in items)),
+        "impact_counts": _impact_counts(items),
         "queued_safe_count": sum(1 for item in items if item.get("status") == "queued" and item.get("safe_to_run")),
         "failed_count": sum(1 for item in items if item.get("status") == "failed"),
         "failure_buckets": dict(
@@ -968,6 +1019,16 @@ def build_briefing_payload(vault_dir: Path | str, *, pack_name: str | None = Non
             "compiled_sections": [],
             "section_nav": [],
             "first_useful_sign": None,
+            "loop_summary": {
+                "productive_count": 0,
+                "waiting_count": 0,
+                "running_count": 0,
+                "ready_count": 0,
+                "completed_count": 0,
+                "failed_count": 0,
+                "stalled_count": 0,
+                "review_only_count": 0,
+            },
             "queue_summary": {
                 "queued_count": 0,
                 "safe_queued_count": 0,
@@ -1022,7 +1083,140 @@ def build_briefing_payload(vault_dir: Path | str, *, pack_name: str | None = Non
         }
         for item in snapshot.get("priority_items", [])[:5]
     ]
+    loop_summary = {
+        "productive_count": sum(
+            1
+            for item in snapshot.get("recent_signals", [])
+            if str((item.get("impact_summary") or {}).get("impact_status") or "") == "productive"
+        ),
+        "waiting_count": sum(
+            1
+            for item in snapshot.get("recent_signals", [])
+            if str((item.get("impact_summary") or {}).get("impact_status") or "") == "waiting"
+        ),
+        "running_count": sum(
+            1
+            for item in snapshot.get("recent_signals", [])
+            if str((item.get("impact_summary") or {}).get("impact_status") or "") == "running"
+        ),
+        "ready_count": sum(
+            1
+            for item in snapshot.get("recent_signals", [])
+            if str((item.get("impact_summary") or {}).get("impact_status") or "") == "ready"
+        ),
+        "completed_count": sum(
+            1
+            for item in snapshot.get("recent_signals", [])
+            if str((item.get("impact_summary") or {}).get("impact_status") or "") == "completed"
+        ),
+        "failed_count": sum(
+            1
+            for item in snapshot.get("recent_signals", [])
+            if str((item.get("impact_summary") or {}).get("impact_status") or "") == "failed"
+        ),
+        "stalled_count": sum(
+            1
+            for item in snapshot.get("recent_signals", [])
+            if str((item.get("impact_summary") or {}).get("impact_status") or "") == "stalled"
+        ),
+        "review_only_count": sum(
+            1
+            for item in snapshot.get("recent_signals", [])
+            if str((item.get("impact_summary") or {}).get("impact_status") or "") == "review_only"
+        ),
+    }
+    signal_loop_items = [
+        {
+            "kind": "productive",
+            "label": "Productive",
+            "path": _scoped_path("/signals", pack_name=requested_pack),
+            "detail": f"{loop_summary['productive_count']} signals produced visible downstream change.",
+        },
+        {
+            "kind": "waiting",
+            "label": "Waiting",
+            "path": _scoped_path("/actions", pack_name=requested_pack),
+            "detail": f"{loop_summary['waiting_count']} signals currently have queued execution waiting.",
+        },
+        {
+            "kind": "running",
+            "label": "Running",
+            "path": _scoped_path("/actions", pack_name=requested_pack),
+            "detail": f"{loop_summary['running_count']} signals are currently executing.",
+        },
+        {
+            "kind": "blocked",
+            "label": "Blocked",
+            "path": _scoped_path("/actions", pack_name=requested_pack),
+            "detail": (
+                f"{loop_summary['failed_count'] + loop_summary['stalled_count']} signals are failed or stalled."
+            ),
+        },
+        {
+            "kind": "review_only",
+            "label": "Review Only",
+            "path": _scoped_path("/signals", pack_name=requested_pack),
+            "detail": f"{loop_summary['review_only_count']} signals currently route to review rather than queued execution.",
+        },
+    ]
+    productive_signal = next(
+        (
+            item
+            for item in snapshot.get("recent_signals", [])
+            if str((item.get("impact_summary") or {}).get("impact_status") or "") == "productive"
+        ),
+        None,
+    )
+    first_useful_sign = (
+        {
+            "signal_id": str(productive_signal.get("signal_id") or ""),
+            "kind": str(productive_signal.get("signal_type") or ""),
+            "title": str(productive_signal.get("title") or ""),
+            "detail": str((productive_signal.get("impact_summary") or {}).get("impact_detail") or ""),
+            "path": str(
+                ((productive_signal.get("recommended_action") or {}).get("queue_path"))
+                or ((productive_signal.get("recommended_action") or {}).get("path"))
+                or productive_signal.get("source_path")
+                or ""
+            ),
+            "source_paths": list(productive_signal.get("note_paths", [])),
+            "object_ids": list(productive_signal.get("object_ids", [])),
+            "recommended_action": productive_signal.get("recommended_action"),
+        }
+        if productive_signal is not None
+        else snapshot.get("first_useful_sign")
+    )
+    inbound_capture_items = [
+        {
+            "kind": "capture_signal",
+            "label": str(item.get("title") or ""),
+            "path": str(item.get("source_path") or ""),
+            "detail": str((item.get("capture_summary") or {}).get("summary") or ""),
+        }
+        for item in snapshot.get("recent_signals", [])
+        if str((item.get("capture_summary") or {}).get("status") or "") != "missing"
+    ]
     compiled_sections = [
+        _compiled_section(
+            "signal_loop",
+            "Signal Loop",
+            summary=(
+                f"{loop_summary['productive_count']} productive, "
+                f"{loop_summary['waiting_count']} waiting, "
+                f"{loop_summary['failed_count'] + loop_summary['stalled_count']} blocked/stalled."
+            ),
+            items=signal_loop_items,
+        ),
+        _compiled_section(
+            "inbound_capture",
+            "Inbound Capture",
+            summary=(
+                f"{len(inbound_capture_items)} recent signals currently expose deterministic inbound capture audit."
+                if inbound_capture_items
+                else "No recent signals currently carry inbound capture audit."
+            ),
+            items=inbound_capture_items,
+        ),
         _compiled_section(
             "what_changed",
             "What Changed",
@@ -1054,6 +1248,28 @@ def build_briefing_payload(vault_dir: Path | str, *, pack_name: str | None = Non
             items=next_action_items,
         ),
     ]
+    operator_rail = [
+        _operator_action(
+            "Signals",
+            _scoped_path("/signals", pack_name=requested_pack),
+            "Open active signal review from the current shell.",
+        ),
+        _operator_action(
+            "Action Queue",
+            _scoped_path("/actions", pack_name=requested_pack),
+            "Run or inspect queued actions.",
+        ),
+        _operator_action(
+            "Production Browser",
+            _scoped_path("/production", pack_name=requested_pack),
+            "Inspect production-chain weak points and reach.",
+        ),
+        _operator_action(
+            "Search",
+            _scoped_path("/search", pack_name=requested_pack),
+            "Jump into freeform search from the current orientation pass.",
+        ),
+    ]
     return {
         "screen": "briefing/intelligence",
         "requested_pack": requested_pack,
@@ -1061,6 +1277,9 @@ def build_briefing_payload(vault_dir: Path | str, *, pack_name: str | None = Non
         "assembly_contract": assembly_contract,
         "governance_contract": governance_contract,
         **snapshot,
+        "first_useful_sign": first_useful_sign,
+        "loop_summary": loop_summary,
+        "operator_rail": operator_rail,
         "compiled_sections": compiled_sections,
         "section_nav": _section_nav_from_compiled_sections(compiled_sections),
     }
@@ -1140,6 +1359,7 @@ def build_object_page_payload(
         if research_shell_enabled
         else []
     )
+    production_chain = get_object_traceability(vault_dir, object_id, pack_name=pack_name)
     compiled_sections = [
         _compiled_section(
             "current_state",
@@ -1209,6 +1429,53 @@ def build_object_page_payload(
             ],
         ),
         _compiled_section(
+            "production_chain",
+            "Production Chain",
+            summary=str(production_chain.get("chain_summary") or ""),
+            items=[
+                {
+                    "kind": "chain_status",
+                    "label": "Chain status",
+                    "path": "",
+                    "detail": str(production_chain.get("chain_status") or ""),
+                },
+                {
+                    "kind": "missing_stages",
+                    "label": "Missing stages",
+                    "path": "",
+                    "detail": ", ".join(
+                        str(item).replace("_", " ")
+                        for item in production_chain.get("missing_stages", [])
+                    )
+                    or "None",
+                },
+                *[
+                    {
+                        "kind": "deep_dive",
+                        "label": item["title"],
+                        "path": _scoped_path(
+                            f"/note?path={quote(item['path'], safe='')}",
+                            pack_name=requested_pack,
+                        ),
+                        "detail": "Downstream deep dive",
+                    }
+                    for item in production_chain["deep_dives"][:2]
+                ],
+                *[
+                    {
+                        "kind": "atlas_page",
+                        "label": item["title"],
+                        "path": _scoped_path(
+                            f"/note?path={quote(item['path'], safe='')}",
+                            pack_name=requested_pack,
+                        ),
+                        "detail": "Atlas / MOC reach",
+                    }
+                    for item in production_chain["atlas_pages"][:2]
+                ],
+            ],
+        ),
+        _compiled_section(
             "open_tensions",
             "Open Tensions",
             summary=f"{len(detail['contradictions']) if research_shell_enabled else 0} contradictions and {len(stale_summary_details) if research_shell_enabled else 0} stale-summary signals remain.",
@@ -1265,13 +1532,43 @@ def build_object_page_payload(
             ],
         ),
     ]
+    operator_rail = [
+        _operator_action(
+            "Topic overview",
+            _scoped_path(f"/topic?id={quote(object_id, safe='')}", pack_name=requested_pack),
+            "Open the surrounding topic page.",
+        ),
+        _operator_action(
+            "Event dossier" if research_shell_enabled else "Signals",
+            research_links["events_path"] if research_shell_enabled else _scoped_path("/signals", pack_name=requested_pack),
+            (
+                "See timeline context for this object."
+                if research_shell_enabled
+                else "Open active signal review."
+            ),
+        ),
+        _operator_action(
+            "Contradiction review" if research_shell_enabled else "Search",
+            research_links["contradictions_path"] if research_shell_enabled else _scoped_path("/search", pack_name=requested_pack),
+            (
+                "Inspect open contradictions for this object."
+                if research_shell_enabled
+                else "Search laterally from this object."
+            ),
+        ),
+        _operator_action(
+            "Production Browser",
+            _scoped_path("/production", pack_name=requested_pack),
+            "Inspect downstream production chain state.",
+        ),
+    ]
     return {
         "screen": "object/page",
         "requested_pack": requested_pack,
         "assembly_contract": _assembly_contract("object_brief", pack_name=pack_name),
         "research_shell_enabled": research_shell_enabled,
         **detail,
-        "production_chain": get_object_traceability(vault_dir, object_id, pack_name=pack_name),
+        "production_chain": production_chain,
         "relations": relations,
         "claim_count": len(detail["claims"]),
         "relation_count": len(relations),
@@ -1294,9 +1591,9 @@ def build_object_page_payload(
         ),
         "links": {
             "topic_path": _scoped_path(f"/topic?id={quote(object_id, safe='')}", pack_name=requested_pack),
-            "graph_path": _graph_path(pack_name=requested_pack, object_id=object_id),
             **research_links,
         },
+        "operator_rail": operator_rail,
         "compiled_sections": compiled_sections,
         "section_nav": [{"href": "#summary", "label": "Summary"}, *_section_nav_from_compiled_sections(compiled_sections)],
     }
@@ -1353,6 +1650,11 @@ def build_topic_overview_payload(
         }
         for item in neighborhood["neighbors"]
     ]
+    production_summary = _build_production_summary(
+        vault_dir,
+        scoped_object_ids,
+        pack_name=pack_name,
+    )
     research_links = {
         "events_path": _scoped_path(f"/events?q={quote(object_id, safe='')}", pack_name=requested_pack),
         "contradictions_path": _scoped_path(
@@ -1368,14 +1670,12 @@ def build_topic_overview_payload(
             pack_name=requested_pack,
         ),
         "atlas_path": _scoped_path(f"/atlas?q={quote(object_id, safe='')}", pack_name=requested_pack),
-        "graph_path": _graph_path(pack_name=requested_pack, object_id=object_id),
     } if research_shell_enabled else {
         "events_path": "",
         "contradictions_path": "",
         "summaries_path": "",
         "deep_dives_path": "",
         "atlas_path": "",
-        "graph_path": _graph_path(pack_name=requested_pack, object_id=object_id),
     }
     compiled_sections = [
         _compiled_section(
@@ -1451,6 +1751,54 @@ def build_topic_overview_payload(
             ],
         ),
         _compiled_section(
+            "production_chain",
+            "Production Chain",
+            summary=(
+                f"{production_summary['object_count']} objects in scope currently resolve to "
+                f"{production_summary['counts']['source_notes']} source notes, "
+                f"{production_summary['counts']['deep_dives']} deep dives, and "
+                f"{production_summary['counts']['atlas_pages']} atlas pages."
+            ),
+            items=[
+                *[
+                    {
+                        "kind": "top_deep_dive",
+                        "label": item["title"],
+                        "path": _scoped_path(
+                            f"/note?path={quote(item['path'], safe='')}",
+                            pack_name=requested_pack,
+                        ),
+                        "detail": f"Supports {item['object_count']} objects in this topic scope.",
+                    }
+                    for item in production_summary["top_deep_dives"][:2]
+                ],
+                *[
+                    {
+                        "kind": "top_atlas_page",
+                        "label": item["title"],
+                        "path": _scoped_path(
+                            f"/note?path={quote(item['path'], safe='')}",
+                            pack_name=requested_pack,
+                        ),
+                        "detail": f"Reaches {item['object_count']} objects in this topic scope.",
+                    }
+                    for item in production_summary["top_atlas_pages"][:2]
+                ],
+                *[
+                    {
+                        "kind": "gap_signal",
+                        "label": item["label"],
+                        "path": _scoped_path(
+                            f"/production?q={quote(object_id, safe='')}",
+                            pack_name=requested_pack,
+                        ),
+                        "detail": f"{item['count']} objects in this topic scope.",
+                    }
+                    for item in production_summary["signals"][:3]
+                ],
+            ],
+        ),
+        _compiled_section(
             "open_tensions",
             "Open Tensions",
             summary=f"{len(scoped_contradictions)} open contradictions and {len(scoped_stale_summaries)} stale summaries remain in this topic scope.",
@@ -1507,6 +1855,36 @@ def build_topic_overview_payload(
             ],
         ),
     ]
+    operator_rail = [
+        _operator_action(
+            "Center object",
+            _scoped_path(f"/object?id={quote(object_id, safe='')}", pack_name=requested_pack),
+            "Open the canonical object page.",
+        ),
+        _operator_action(
+            "Event dossier" if research_shell_enabled else "Signals",
+            research_links["events_path"] if research_shell_enabled else _scoped_path("/signals", pack_name=requested_pack),
+            (
+                "See time-bounded activity around this topic."
+                if research_shell_enabled
+                else "Review active shell signals."
+            ),
+        ),
+        _operator_action(
+            "Contradictions" if research_shell_enabled else "Search",
+            research_links["contradictions_path"] if research_shell_enabled else _scoped_path("/search", pack_name=requested_pack),
+            (
+                "Review open tensions in topic scope."
+                if research_shell_enabled
+                else "Search laterally from this topic."
+            ),
+        ),
+        _operator_action(
+            "Production Browser",
+            _scoped_path("/production", pack_name=requested_pack),
+            "Inspect production-chain weak points in the current shell.",
+        ),
+    ]
     return {
         "screen": "overview/topic",
         "requested_pack": requested_pack,
@@ -1518,11 +1896,7 @@ def build_topic_overview_payload(
         "neighbor_count": len(neighbors),
         "center_summary": detail["summary"]["summary_text"] if detail["summary"] else "",
         "provenance": detail["provenance"],
-        "production_summary": _build_production_summary(
-            vault_dir,
-            scoped_object_ids,
-            pack_name=pack_name,
-        ),
+        "production_summary": production_summary,
         "review_context": review_context,
         "review_history": (
             list_review_actions(
@@ -1560,9 +1934,9 @@ def build_topic_overview_payload(
                 f"/object?id={quote(object_id, safe='')}",
                 pack_name=requested_pack,
             ),
-            "graph_path": _graph_path(pack_name=requested_pack, object_id=object_id),
             **research_links,
         },
+        "operator_rail": operator_rail,
         "compiled_sections": compiled_sections,
         "section_nav": _section_nav_from_compiled_sections(compiled_sections),
     }
@@ -1580,6 +1954,7 @@ def build_event_dossier_payload(
     limit: int | None = None,
 ) -> dict[str, Any]:
     requested_pack = pack_name or ""
+    research_shell_enabled = _supports_research_shell(pack_name)
     effective_limit = DEFAULT_EVENT_DOSSIER_LIMIT if limit is None else limit
     events = [
         _build_timeline_event_item(row)
@@ -1646,6 +2021,7 @@ def build_event_dossier_payload(
     ]
     event_type_counts = Counter(event["event_kind"] for event in events)
     row_type_counts = Counter(event["row_type"] for event in events)
+    anchor_kind_counts = Counter(event["timeline_anchor_kind"] for event in events)
     semantic_roles = Counter(event["semantic_role"] for event in events)
     compiled_sections = [
         _compiled_section(
@@ -1738,6 +2114,37 @@ def build_event_dossier_payload(
             ],
         ),
     ]
+    operator_rail = [
+        _operator_action(
+            "Production Browser",
+            _scoped_path("/production", pack_name=requested_pack),
+            "Inspect production chains behind the visible timeline scope.",
+        ),
+        _operator_action(
+            "Contradictions",
+            _scoped_path(
+                f"/contradictions?q={quote(query or '', safe='')}",
+                pack_name=requested_pack,
+            )
+            if query
+            else _scoped_path("/contradictions", pack_name=requested_pack),
+            "Review contradiction rows for the current dossier scope.",
+        ),
+        _operator_action(
+            "Signals",
+            _scoped_path("/signals", pack_name=requested_pack),
+            "Open the active signal queue.",
+        ),
+        _operator_action(
+            "Clusters" if research_shell_enabled else "Search",
+            _scoped_path("/clusters" if research_shell_enabled else "/search", pack_name=requested_pack),
+            (
+                "Explore graph clusters connected to current work."
+                if research_shell_enabled
+                else "Search laterally from the current shell."
+            ),
+        ),
+    ]
     return {
         "screen": "event/dossier",
         "requested_pack": requested_pack,
@@ -1752,8 +2159,14 @@ def build_event_dossier_payload(
         "is_limited": effective_limit is not None,
         "timeline_contract": {
             "timeline_kind": "dated_note_projection",
+            "grouping_kind": "object_date_rollup",
             "row_type_counts": dict(row_type_counts),
+            "anchor_kind_counts": dict(anchor_kind_counts),
             "semantic_roles": dict(semantic_roles),
+            "event_vs_note_explanation": (
+                "Event Dossier groups dated note and heading projections by object and date; "
+                "it is not a canonical event entity store."
+            ),
         },
         "production_summary": _build_production_summary(
             vault_dir,
@@ -1769,6 +2182,7 @@ def build_event_dossier_payload(
             "Event Dossier is a timeline over dated notes projected from indexed pages, not a separate event entity system.",
             "page_date rows come from note-level dates; heading_date rows come from dated section headings.",
         ],
+        "operator_rail": operator_rail,
         "query": query or "",
         "compiled_sections": compiled_sections,
         "section_nav": _section_nav_from_compiled_sections(compiled_sections),
@@ -1879,10 +2293,6 @@ def build_cluster_browser_payload(
                 "row_pack": str(item.get("row_pack") or item["pack"]),
                 "pack": requested_pack,
                 "detail_path": summary["cluster"]["detail_path"],
-                "graph_path": _graph_path(
-                    pack_name=requested_pack,
-                    cluster_id=str(item["cluster_id"]),
-                ),
                 "center_object_path": summary["cluster"]["center_object_path"],
                 "member_links": summary["cluster"]["member_links"],
                 "display_title": summary["display_title"],
@@ -1939,7 +2349,6 @@ def build_cluster_browser_payload(
     return {
         "screen": "graph/clusters",
         "requested_pack": pack_name or "",
-        "graph_path": _graph_path(pack_name=pack_name or ""),
         "query": query or "",
         "limit": limit,
         "is_limited": True,
@@ -2025,10 +2434,6 @@ def build_cluster_detail_payload(
         "requested_pack": requested_pack,
         "cluster": enriched_cluster,
         "browser_path": f"/clusters?pack={quote(requested_pack, safe='')}",
-        "graph_path": _graph_path(
-            pack_name=requested_pack,
-            cluster_id=str(cluster["cluster_id"]),
-        ),
         "edges": enriched_edges,
         **sections,
         "model_notes": [
@@ -2036,641 +2441,6 @@ def build_cluster_detail_payload(
             "Edges are filtered to the cluster's own member set inside the requested pack projection.",
         ],
     }
-
-
-DEFAULT_GRAPH_CANVAS_CLUSTER_LIMIT = 12
-DEFAULT_GRAPH_CANVAS_MEMBER_LIMIT = 10
-DEFAULT_GRAPH_CANVAS_RELATED_LIMIT = 4
-DEFAULT_GRAPH_CANVAS_EXPAND_STEP = 6
-MAX_GRAPH_CANVAS_EXPAND_LEVEL = 4
-
-
-def _graph_expand_level(value: int | str | None) -> int:
-    try:
-        normalized = int(value or 0)
-    except (TypeError, ValueError):
-        normalized = 0
-    return max(0, min(normalized, MAX_GRAPH_CANVAS_EXPAND_LEVEL))
-
-
-def _graph_path(
-    *,
-    pack_name: str,
-    cluster_id: str | None = None,
-    object_id: str | None = None,
-    expand: int = 0,
-    edge_filter: str = "all",
-) -> str:
-    query_items = []
-    if cluster_id:
-        query_items.append(f"cluster_id={quote(cluster_id, safe='')}")
-    if object_id:
-        query_items.append(f"object_id={quote(object_id, safe='')}")
-    if expand:
-        query_items.append(f"expand={expand}")
-    if edge_filter and edge_filter != "all":
-        query_items.append(f"edge_filter={quote(edge_filter, safe='')}")
-    if pack_name:
-        query_items.append(f"pack={quote(pack_name, safe='')}")
-    return "/graph" + (f"?{'&'.join(query_items)}" if query_items else "")
-
-
-def _graph_node_id(kind: str, raw_id: str) -> str:
-    return f"{kind}:{raw_id}"
-
-
-def _ring_layout(
-    node_ids: list[str],
-    *,
-    center_x: float = 0.0,
-    center_y: float = 0.0,
-    start_radius: float = 260.0,
-    ring_step: float = 180.0,
-    slots_per_ring: int = 8,
-) -> dict[str, dict[str, float]]:
-    positions: dict[str, dict[str, float]] = {}
-    if not node_ids:
-        return positions
-    for index, node_id in enumerate(node_ids):
-        ring = index // slots_per_ring
-        slot = index % slots_per_ring
-        slot_count = min(slots_per_ring, len(node_ids) - ring * slots_per_ring)
-        angle = (2 * math.pi * slot / max(1, slot_count)) - (math.pi / 2)
-        radius = start_radius + ring * ring_step
-        positions[node_id] = {
-            "x": center_x + math.cos(angle) * radius,
-            "y": center_y + math.sin(angle) * radius,
-        }
-    return positions
-
-
-def _overview_layout(node_ids: list[str]) -> dict[str, dict[str, float]]:
-    if not node_ids:
-        return {}
-    positions = {node_ids[0]: {"x": 0.0, "y": 0.0}}
-    positions.update(_ring_layout(node_ids[1:], start_radius=360.0, ring_step=220.0, slots_per_ring=6))
-    return positions
-
-
-def _graph_edge_family(edge_kind: str) -> str:
-    family, _subtype = _edge_kind_parts(edge_kind)
-    return family
-
-
-def _detail_action(label: str, path: str) -> dict[str, str]:
-    return {"label": label, "path": path}
-
-
-def _graph_node(
-    *,
-    node_id: str,
-    label: str,
-    node_type: str,
-    x: float,
-    y: float,
-    size: float,
-    tone: str,
-    detail: dict[str, Any],
-    secondary_label: str = "",
-    badges: list[str] | None = None,
-) -> dict[str, Any]:
-    return {
-        "id": node_id,
-        "label": label,
-        "secondary_label": secondary_label,
-        "node_type": node_type,
-        "x": round(x, 2),
-        "y": round(y, 2),
-        "size": size,
-        "tone": tone,
-        "badges": badges or [],
-        "detail": detail,
-    }
-
-
-def _graph_controls(
-    *,
-    requested_pack: str,
-    expand_level: int,
-    can_expand: bool,
-    cluster_id: str | None = None,
-    object_id: str | None = None,
-    edge_filter: str = "all",
-    edge_filter_items: list[dict[str, str]] | None = None,
-) -> dict[str, Any]:
-    next_expand = expand_level + 1
-    return {
-        "expand_level": expand_level,
-        "can_expand": can_expand,
-        "expand_path": (
-            _graph_path(
-                pack_name=requested_pack,
-                cluster_id=cluster_id,
-                object_id=object_id,
-                expand=next_expand,
-                edge_filter=edge_filter,
-            )
-            if can_expand
-            else ""
-        ),
-        "reset_path": _graph_path(
-            pack_name=requested_pack,
-            cluster_id=cluster_id,
-            object_id=object_id,
-        ),
-        "edge_filter": edge_filter,
-        "edge_filter_items": edge_filter_items or [{"value": "all", "label": "All edges"}],
-    }
-
-
-def _build_cluster_overview_graph_payload(
-    vault_dir: Path | str,
-    *,
-    pack_name: str | None = None,
-    expand_level: int = 0,
-    edge_filter: str = "all",
-) -> dict[str, Any]:
-    requested_pack = pack_name or ""
-    cluster_limit = DEFAULT_GRAPH_CANVAS_CLUSTER_LIMIT + expand_level * DEFAULT_GRAPH_CANVAS_EXPAND_STEP
-    browser = build_cluster_browser_payload(vault_dir, pack_name=pack_name, limit=cluster_limit)
-    items = browser["items"]
-    node_id_by_cluster = {
-        str(item["cluster_id"]): _graph_node_id("cluster", str(item["cluster_id"]))
-        for item in items
-    }
-    positions = _overview_layout([node_id_by_cluster[str(item["cluster_id"])] for item in items])
-    nodes = []
-    for item in items:
-        cluster_id = str(item["cluster_id"])
-        node_id = node_id_by_cluster[cluster_id]
-        graph_path = _graph_path(pack_name=requested_pack, cluster_id=cluster_id)
-        detail = {
-            "title": item.get("display_title") or item["label"],
-            "subtitle": f"{item['member_count']} objects · {item['priority_reason']}",
-            "summary_lines": item["summary_bullets"][:3],
-            "meta_rows": [
-                f"Cluster kind: {item['cluster_kind']}",
-                f"Priority band: {item['priority_band']}",
-                f"Related clusters: {item['related_cluster_count']}",
-            ],
-            "actions": [
-                _detail_action("Open cluster detail", item["detail_path"]),
-                _detail_action("Open cluster graph", graph_path),
-                _detail_action("Open center object", item["center_object_path"]),
-            ],
-        }
-        tone = "attention" if item["priority_band"] == "attention" else "active"
-        nodes.append(
-            _graph_node(
-                node_id=node_id,
-                label=item.get("display_title") or item["label"],
-                node_type="cluster",
-                x=positions[node_id]["x"],
-                y=positions[node_id]["y"],
-                size=46.0 if cluster_id == str(items[0]["cluster_id"]) else 36.0,
-                tone=tone,
-                secondary_label=item["priority_band"],
-                badges=[item["priority_band"], f"{item['member_count']} objects"],
-                detail=detail,
-            )
-        )
-
-    cluster_priority = {str(item["cluster_id"]): str(item["priority_band"]) for item in items}
-    edges: list[dict[str, Any]] = []
-    seen_edges: set[tuple[str, str]] = set()
-    for item in items:
-        source_cluster_id = str(item["cluster_id"])
-        for related in item["related_clusters"]:
-            target_cluster_id = str(related["cluster_id"])
-            if target_cluster_id not in node_id_by_cluster:
-                continue
-            edge_key = tuple(sorted((source_cluster_id, target_cluster_id)))
-            if edge_key in seen_edges:
-                continue
-            seen_edges.add(edge_key)
-            if edge_filter == "strong" and str(related["bridge_band"]) != "strong":
-                continue
-            if edge_filter == "attention" and not (
-                cluster_priority.get(source_cluster_id) == "attention"
-                or cluster_priority.get(target_cluster_id) == "attention"
-            ):
-                continue
-            edges.append(
-                {
-                    "id": f"bridge:{edge_key[0]}:{edge_key[1]}",
-                    "source": node_id_by_cluster[source_cluster_id],
-                    "target": node_id_by_cluster[target_cluster_id],
-                    "edge_type": "cluster_bridge",
-                    "label": str(related["bridge_kind"]).replace("_", " "),
-                    "strength": str(related["bridge_band"]),
-                    "weight": float(related["score"]),
-                }
-            )
-
-    edge_filter_items = [
-        {"value": "all", "label": "All bridges"},
-        {"value": "strong", "label": "Strong bridges"},
-        {"value": "attention", "label": "Attention clusters"},
-    ]
-    return {
-        "screen": "graph/canvas",
-        "requested_pack": requested_pack,
-        "scope": "clusters",
-        "title": "Research Graph",
-        "subtitle": f"{len(nodes)} clusters in view with bounded bridge rendering.",
-        "nodes": nodes,
-        "edges": edges,
-        "default_selection_id": nodes[0]["id"] if nodes else "",
-        "stats": {
-            "node_count": len(nodes),
-            "edge_count": len(edges),
-            "hidden_node_count": max(0, browser["count"] - len(nodes)),
-        },
-        "entry_links": [
-            _detail_action("Back to clusters", _scoped_path("/clusters", pack_name=requested_pack)),
-            _detail_action("Back to briefing", _scoped_path("/briefing", pack_name=requested_pack)),
-        ],
-        "controls": _graph_controls(
-            requested_pack=requested_pack,
-            expand_level=expand_level,
-            can_expand=bool(browser.get("is_limited")) and len(nodes) >= cluster_limit,
-            edge_filter=edge_filter,
-            edge_filter_items=edge_filter_items,
-        ),
-        "model_notes": [
-            "The overview graph is bounded to the top-ranked clusters in the current browser window.",
-            "Bridge edges are derived from pack-scoped related-cluster evidence, not a global full-vault render.",
-        ],
-    }
-
-
-def _build_cluster_graph_payload(
-    vault_dir: Path | str,
-    *,
-    cluster_id: str,
-    pack_name: str | None = None,
-    expand_level: int = 0,
-    edge_filter: str = "all",
-) -> dict[str, Any]:
-    requested_pack = pack_name or ""
-    member_limit = DEFAULT_GRAPH_CANVAS_MEMBER_LIMIT + expand_level * DEFAULT_GRAPH_CANVAS_EXPAND_STEP
-    related_limit = DEFAULT_GRAPH_CANVAS_RELATED_LIMIT + expand_level * 2
-    scope = get_graph_cluster_scope(vault_dir, cluster_id, pack_name=pack_name, object_limit=member_limit)
-    summary = build_cluster_detail_payload(vault_dir, cluster_id=cluster_id, pack_name=pack_name)
-    cluster = summary["cluster"]
-    root_id = _graph_node_id("cluster-root", str(cluster["cluster_id"]))
-    member_node_ids = {
-        str(member["object_id"]): _graph_node_id("object", str(member["object_id"]))
-        for member in scope["visible_members"]
-    }
-    related_clusters = summary["related_clusters"][:related_limit]
-    related_node_ids = {
-        str(item["cluster_id"]): _graph_node_id("cluster", str(item["cluster_id"]))
-        for item in related_clusters
-    }
-    positions = {root_id: {"x": 0.0, "y": 0.0}}
-    positions.update(_ring_layout(list(member_node_ids.values()), start_radius=280.0, ring_step=150.0, slots_per_ring=8))
-    positions.update(
-        _ring_layout(
-            list(related_node_ids.values()),
-            start_radius=620.0,
-            ring_step=190.0,
-            slots_per_ring=6,
-        )
-    )
-
-    nodes = [
-        _graph_node(
-            node_id=root_id,
-            label=summary["display_title"],
-            node_type="cluster_root",
-            x=0.0,
-            y=0.0,
-            size=54.0,
-            tone="attention" if summary["review_context"]["open_contradiction_count"] else "active",
-            secondary_label=cluster["cluster_kind"],
-            badges=[
-                f"{cluster['member_count']} members",
-                f"{summary['review_context']['open_contradiction_count']} contradictions",
-            ],
-            detail={
-                "title": summary["display_title"],
-                "subtitle": f"{cluster['member_count']} objects · {summary['edge_count']} internal edges",
-                "summary_lines": summary["summary_bullets"][:4],
-                "meta_rows": [
-                    f"Structural label: {summary['structural_label']['title']}",
-                    f"Review pressure: {summary['review_context']['open_contradiction_count']} contradictions / {summary['review_context']['stale_summary_count']} stale summaries",
-                    f"Coverage: {summary['review_context']['source_note_count']} source notes / {summary['review_context']['moc_count']} atlas pages",
-                ],
-                "actions": [
-                    _detail_action("Open cluster detail", cluster["detail_path"]),
-                    _detail_action("Back to clusters", summary["browser_path"]),
-                ],
-            },
-        )
-    ]
-    for member in scope["visible_members"]:
-        object_id = str(member["object_id"])
-        node_id = member_node_ids[object_id]
-        graph_path = _graph_path(pack_name=requested_pack, object_id=object_id)
-        nodes.append(
-            _graph_node(
-                node_id=node_id,
-                label=str(member["title"]),
-                node_type="object",
-                x=positions[node_id]["x"],
-                y=positions[node_id]["y"],
-                size=32.0 if member["is_center"] else 24.0,
-                tone="center" if member["is_center"] else "neutral",
-                secondary_label=str(member["object_kind"]),
-                badges=(["center"] if member["is_center"] else []) + [f"degree {member['graph_degree']}"],
-                detail={
-                    "title": str(member["title"]),
-                    "subtitle": f"{member['object_kind']} · degree {member['graph_degree']}",
-                    "summary_lines": [],
-                    "meta_rows": [
-                        f"Object id: {object_id}",
-                        f"Graph role: {'center object' if member['is_center'] else 'cluster member'}",
-                    ],
-                    "actions": [
-                        _detail_action("Open object", _scoped_path(f"/object?id={quote(object_id, safe='')}", pack_name=requested_pack)),
-                        _detail_action("Open topic", _scoped_path(f"/topic?id={quote(object_id, safe='')}", pack_name=requested_pack)),
-                        _detail_action("Open object graph", graph_path),
-                    ],
-                },
-            )
-        )
-    for item in related_clusters:
-        related_cluster_id = str(item["cluster_id"])
-        node_id = related_node_ids[related_cluster_id]
-        nodes.append(
-            _graph_node(
-                node_id=node_id,
-                label=str(item["display_title"]),
-                node_type="related_cluster",
-                x=positions[node_id]["x"],
-                y=positions[node_id]["y"],
-                size=26.0,
-                tone=str(item["bridge_band"]),
-                secondary_label=str(item["bridge_kind"]).replace("_", " "),
-                badges=[str(item["bridge_band"]), f"{item['member_count']} objects"],
-                detail={
-                    "title": str(item["display_title"]),
-                    "subtitle": f"{item['member_count']} objects · {item['reason']}",
-                    "summary_lines": [],
-                    "meta_rows": [
-                        f"Bridge kind: {item['bridge_kind']}",
-                        f"Shared source notes: {item['shared_source_count']}",
-                        f"Shared atlas pages: {item['shared_moc_count']}",
-                    ],
-                    "actions": [
-                        _detail_action("Open related cluster", item["detail_path"]),
-                        _detail_action("Open related cluster graph", _graph_path(pack_name=requested_pack, cluster_id=related_cluster_id)),
-                    ],
-                },
-            )
-        )
-
-    edges = [
-        {
-            "id": f"cluster-center:{cluster['cluster_id']}:{cluster['center_object_id']}",
-            "source": root_id,
-            "target": member_node_ids[str(cluster["center_object_id"])],
-            "edge_type": "cluster_center",
-            "label": "center",
-            "strength": "strong",
-            "weight": 1.0,
-        }
-    ] if str(cluster["center_object_id"]) in member_node_ids else []
-    for edge in scope["visible_edges"]:
-        edge_family = _graph_edge_family(str(edge["edge_kind"]))
-        if edge_filter != "all" and edge_filter != edge_family:
-            continue
-        edges.append(
-            {
-                "id": str(edge["edge_id"]),
-                "source": member_node_ids[str(edge["source_object_id"])],
-                "target": member_node_ids[str(edge["target_object_id"])],
-                "edge_type": edge_family,
-                "label": str(edge["edge_kind"]).replace(":", " · "),
-                "strength": "medium",
-                "weight": float(edge["weight"]),
-            }
-        )
-    if edge_filter in {"all", "bridges"}:
-        for item in related_clusters:
-            edges.append(
-                {
-                    "id": f"bridge:{cluster['cluster_id']}:{item['cluster_id']}",
-                    "source": root_id,
-                    "target": related_node_ids[str(item["cluster_id"])],
-                    "edge_type": "bridge",
-                    "label": str(item["bridge_kind"]).replace("_", " "),
-                    "strength": str(item["bridge_band"]),
-                    "weight": float(item["score"]),
-                }
-            )
-    edge_filter_items = [
-        {"value": "all", "label": "All edges"},
-        {"value": "relation", "label": "Relations"},
-        {"value": "contradiction", "label": "Contradictions"},
-        {"value": "bridges", "label": "Related cluster bridges"},
-    ]
-    return {
-        "screen": "graph/canvas",
-        "requested_pack": requested_pack,
-        "scope": "cluster",
-        "title": summary["display_title"],
-        "subtitle": f"Bounded cluster graph with {len(scope['visible_members'])} visible members and {len(related_clusters)} surfaced neighbor clusters.",
-        "nodes": nodes,
-        "edges": edges,
-        "default_selection_id": root_id,
-        "stats": {
-            "node_count": len(nodes),
-            "edge_count": len(edges),
-            "hidden_member_count": scope["hidden_member_count"],
-            "hidden_edge_count": scope["hidden_edge_count"],
-        },
-        "entry_links": [
-            _detail_action("Back to cluster detail", cluster["detail_path"]),
-            _detail_action("Back to clusters", summary["browser_path"]),
-        ],
-        "controls": _graph_controls(
-            requested_pack=requested_pack,
-            cluster_id=str(cluster["cluster_id"]),
-            expand_level=expand_level,
-            can_expand=scope["hidden_member_count"] > 0 or len(summary["related_clusters"]) > len(related_clusters),
-            edge_filter=edge_filter,
-            edge_filter_items=edge_filter_items,
-        ),
-        "model_notes": [
-            "Cluster graph rendering is intentionally bounded; expand reveals more members rather than loading the full vault graph.",
-            "Related clusters are shown as bridge nodes on the outer ring to keep local structure readable.",
-        ],
-    }
-
-
-def _build_object_graph_payload(
-    vault_dir: Path | str,
-    *,
-    object_id: str,
-    pack_name: str | None = None,
-    expand_level: int = 0,
-    edge_filter: str = "all",
-) -> dict[str, Any]:
-    requested_pack = pack_name or ""
-    neighbor_limit = DEFAULT_GRAPH_CANVAS_MEMBER_LIMIT + expand_level * DEFAULT_GRAPH_CANVAS_EXPAND_STEP
-    scope = get_graph_object_scope(vault_dir, object_id, pack_name=pack_name, neighbor_limit=neighbor_limit)
-    detail = get_object_detail(vault_dir, object_id, pack_name=pack_name)
-    center = scope["center"]
-    center_id = _graph_node_id("object", str(center["object_id"]))
-    neighbor_node_ids = {
-        str(item["object_id"]): _graph_node_id("object", str(item["object_id"]))
-        for item in scope["visible_neighbors"]
-    }
-    positions = {center_id: {"x": 0.0, "y": 0.0}}
-    positions.update(_ring_layout(list(neighbor_node_ids.values()), start_radius=320.0, ring_step=180.0, slots_per_ring=10))
-    relation_types = sorted({str(edge["relation_type"]) for edge in scope["visible_edges"]})
-    if edge_filter not in {"all", *relation_types}:
-        edge_filter = "all"
-    edges = []
-    for edge in scope["visible_edges"]:
-        relation_type = str(edge["relation_type"])
-        if edge_filter != "all" and edge_filter != relation_type:
-            continue
-        edges.append(
-            {
-                "id": f"{edge['source_object_id']}:{edge['target_object_id']}:{relation_type}",
-                "source": center_id,
-                "target": neighbor_node_ids[str(edge["target_object_id"])],
-                "edge_type": "relation",
-                "label": relation_type,
-                "strength": "medium",
-                "weight": 1.0,
-            }
-        )
-    nodes = [
-        _graph_node(
-            node_id=center_id,
-            label=str(center["title"]),
-            node_type="object_center",
-            x=0.0,
-            y=0.0,
-            size=48.0,
-            tone="center",
-            secondary_label=str(center["object_kind"]),
-            badges=[f"{len(detail['relations'])} relations", f"{len(detail['contradictions'])} contradictions"],
-            detail={
-                "title": str(center["title"]),
-                "subtitle": f"{center['object_kind']} · {len(detail['relations'])} outgoing relations",
-                "summary_lines": [str(detail["summary"]["summary_text"])] if detail.get("summary") else [],
-                "meta_rows": [
-                    f"Source slug: {center['source_slug']}",
-                    f"Contradictions: {len(detail['contradictions'])}",
-                    f"Evidence items: {len(detail['evidence'])}",
-                ],
-                "actions": [
-                    _detail_action("Open object", _scoped_path(f"/object?id={quote(str(center['object_id']), safe='')}", pack_name=requested_pack)),
-                    _detail_action("Open topic", _scoped_path(f"/topic?id={quote(str(center['object_id']), safe='')}", pack_name=requested_pack)),
-                ],
-            },
-        )
-    ]
-    for item in scope["visible_neighbors"]:
-        neighbor_id = str(item["object_id"])
-        nodes.append(
-            _graph_node(
-                node_id=neighbor_node_ids[neighbor_id],
-                label=str(item["title"]),
-                node_type="object_neighbor",
-                x=positions[neighbor_node_ids[neighbor_id]]["x"],
-                y=positions[neighbor_node_ids[neighbor_id]]["y"],
-                size=24.0,
-                tone="neutral",
-                secondary_label=str(item["object_kind"]),
-                badges=[str(item["object_kind"])],
-                detail={
-                    "title": str(item["title"]),
-                    "subtitle": f"{item['object_kind']} neighbor",
-                    "summary_lines": [],
-                    "meta_rows": [f"Source slug: {item['source_slug']}"],
-                    "actions": [
-                        _detail_action("Open object", _scoped_path(f"/object?id={quote(neighbor_id, safe='')}", pack_name=requested_pack)),
-                        _detail_action("Open object graph", _graph_path(pack_name=requested_pack, object_id=neighbor_id)),
-                    ],
-                },
-            )
-        )
-    edge_filter_items = [{"value": "all", "label": "All relations"}] + [
-        {"value": relation_type, "label": relation_type}
-        for relation_type in relation_types
-    ]
-    return {
-        "screen": "graph/canvas",
-        "requested_pack": requested_pack,
-        "scope": "object",
-        "title": f"Object Graph: {center['title']}",
-        "subtitle": f"One-hop neighborhood with {len(scope['visible_neighbors'])} visible neighbors.",
-        "nodes": nodes,
-        "edges": edges,
-        "default_selection_id": center_id,
-        "stats": {
-            "node_count": len(nodes),
-            "edge_count": len(edges),
-            "hidden_neighbor_count": scope["hidden_neighbor_count"],
-            "hidden_edge_count": scope["hidden_edge_count"],
-        },
-        "entry_links": [
-            _detail_action("Back to object", _scoped_path(f"/object?id={quote(str(center['object_id']), safe='')}", pack_name=requested_pack)),
-            _detail_action("Back to topic", _scoped_path(f"/topic?id={quote(str(center['object_id']), safe='')}", pack_name=requested_pack)),
-        ],
-        "controls": _graph_controls(
-            requested_pack=requested_pack,
-            object_id=str(center["object_id"]),
-            expand_level=expand_level,
-            can_expand=scope["hidden_neighbor_count"] > 0,
-            edge_filter=edge_filter,
-            edge_filter_items=edge_filter_items,
-        ),
-        "model_notes": [
-            "Object graph is limited to a one-hop neighborhood to keep interaction responsive.",
-            "Expand reveals more neighbors from the same pack-scoped truth projection.",
-        ],
-    }
-
-
-def build_graph_canvas_payload(
-    vault_dir: Path | str,
-    *,
-    pack_name: str | None = None,
-    cluster_id: str | None = None,
-    object_id: str | None = None,
-    expand: int = 0,
-    edge_filter: str = "all",
-) -> dict[str, Any]:
-    expand_level = _graph_expand_level(expand)
-    if cluster_id:
-        return _build_cluster_graph_payload(
-            vault_dir,
-            cluster_id=cluster_id,
-            pack_name=pack_name,
-            expand_level=expand_level,
-            edge_filter=edge_filter,
-        )
-    if object_id:
-        return _build_object_graph_payload(
-            vault_dir,
-            object_id=object_id,
-            pack_name=pack_name,
-            expand_level=expand_level,
-            edge_filter=edge_filter,
-        )
-    return _build_cluster_overview_graph_payload(
-        vault_dir,
-        pack_name=pack_name,
-        expand_level=expand_level,
-        edge_filter=edge_filter,
-    )
 
 
 def build_contradiction_browser_payload(
@@ -2808,6 +2578,28 @@ def build_contradiction_browser_payload(
             ],
         ),
     ]
+    operator_rail = [
+        _operator_action(
+            "Signals",
+            _scoped_path("/signals", pack_name=requested_pack),
+            "Open active signals for related maintenance entry points.",
+        ),
+        _operator_action(
+            "Action Queue",
+            _scoped_path("/actions", pack_name=requested_pack),
+            "Inspect queued or failed execution work.",
+        ),
+        _operator_action(
+            "Production Browser",
+            _scoped_path("/production", pack_name=requested_pack),
+            "Trace production gaps behind the visible contradictions.",
+        ),
+        _operator_action(
+            "Events",
+            _scoped_path("/events", pack_name=requested_pack),
+            "Compare contradiction scope against the timeline surface.",
+        ),
+    ]
     return {
         "screen": "truth/contradictions",
         "requested_pack": requested_pack,
@@ -2830,6 +2622,8 @@ def build_contradiction_browser_payload(
         "detection_contract": {
             "model": "page_summary_polarity",
             "confidence": "heuristic",
+            "polarity_semantics": "Positive and negative claim sets are compared within the same contradiction subject scope.",
+            "evidence_semantics": "Ranked evidence is assembled from claim_evidence rows attached to both polarity sides.",
             "status_buckets": {
                 "open": status_counts.get("open", 0),
                 "reviewed": sum(count for row_status, count in status_counts.items() if row_status != "open"),
@@ -2842,6 +2636,7 @@ def build_contradiction_browser_payload(
             CONTRADICTION_HEURISTIC_NOTE,
         ],
         "empty_state": "Zero results usually means the current heuristic did not detect a conflict, not that the vault is globally contradiction-free.",
+        "operator_rail": operator_rail,
         "status": status or "",
         "query": query or "",
         "compiled_sections": compiled_sections,
@@ -2915,6 +2710,11 @@ def _cluster_timeline_events(events: list[dict[str, Any]]) -> list[dict[str, Any
                 "event_labels": [],
                 "semantic_roles": [],
                 "timeline_anchor_labels": [],
+                "grouping_kind": "object_date_rollup",
+                "event_vs_note_explanation": (
+                    "This cluster groups timeline rows for the same object and date; "
+                    "it is a dossier rollup, not a canonical event entity."
+                ),
             },
         )
         cluster["row_count"] += 1
@@ -3017,28 +2817,67 @@ def build_truth_dashboard_payload(
             }
         )
     orientation = build_briefing_payload(vault_dir, pack_name=pack_name)
-    orientation_sections = list(orientation.get("compiled_sections") or [])
     entry_sections = [
-        _remap_compiled_section(
-            _compiled_section_by_id(orientation_sections, "what_changed"),
-            section_id="what_changed_recently",
-            label="What Changed Recently",
+        _compiled_section(
+            "what_changed_recently",
+            "What Changed Recently",
             summary=f"{orientation.get('changed_object_count', 0)} changed objects and {orientation.get('recent_signal_count', 0)} recent signals surfaced.",
-            limit=4,
+            items=[
+                *[
+                    {
+                        "kind": "changed_object",
+                        "label": item["title"],
+                        "path": item["path"],
+                        "detail": f"Changed object · {item['object_id']}",
+                    }
+                    for item in orientation.get("changed_objects", [])[:4]
+                ]
+            ],
         ),
-        _remap_compiled_section(
-            _compiled_section_by_id(orientation_sections, "next_actions"),
-            section_id="important_right_now",
-            label="Important Right Now",
+        _compiled_section(
+            "important_right_now",
+            "Important Right Now",
             summary=f"{len(orientation.get('priority_items', []))} priority items are currently surfaced.",
-            limit=4,
+            items=[
+                *[
+                    {
+                        "kind": str(item["kind"]),
+                        "label": str(item["title"]),
+                        "path": str(item["path"]),
+                        "detail": str(item["detail"]),
+                    }
+                    for item in orientation.get("priority_items", [])[:4]
+                ]
+            ],
         ),
-        _remap_compiled_section(
-            _compiled_section_by_id(orientation_sections, "needs_review"),
-            section_id="deserves_review",
-            label="Deserves Review",
-            summary=f"{orientation.get('unresolved_issue_count', 0)} review-oriented items are currently in scope.",
-            limit=4,
+        _compiled_section(
+            "deserves_review",
+            "Deserves Review",
+            summary=f"{contradictions['open_count'] if research_overview_supported else signals['count']} review-oriented items are currently in scope.",
+            items=(
+                [
+                    {
+                        "kind": "contradiction",
+                        "label": item["subject_key"],
+                        "path": _scoped_path(
+                            f"/contradictions?q={quote(str(item['subject_key']), safe='')}",
+                            pack_name=requested_pack,
+                        ),
+                        "detail": f"{len(item['object_ids'])} objects in scope",
+                    }
+                    for item in contradictions["items"][:4]
+                ]
+                if research_overview_supported
+                else [
+                    {
+                        "kind": str(item["signal_type"]),
+                        "label": str(item["title"]),
+                        "path": str(item["source_path"]),
+                        "detail": str(item["detail"]),
+                    }
+                    for item in signals["items"][:4]
+                ]
+            ),
         ),
         _compiled_section(
             "recommended_next_steps",
@@ -3075,6 +2914,121 @@ def build_truth_dashboard_payload(
                     if research_overview_supported
                     else []
                 ),
+            ],
+        ),
+    ]
+    workflow_groups = [
+        _workflow_group(
+            "orient",
+            "Orient",
+            "Start with the compiled entry products before diving into individual queues.",
+            [
+                {
+                    "label": "Orientation Brief",
+                    "path": _scoped_path("/briefing", pack_name=requested_pack),
+                    "detail": "Read the current entry product.",
+                },
+                {
+                    "label": "Workbench Home",
+                    "path": _scoped_path("/", pack_name=requested_pack),
+                    "detail": "Return to the current shell overview.",
+                },
+            ],
+        ),
+        _workflow_group(
+            "inspect",
+            "Inspect",
+            "Read the current knowledge state directly from compiled browsing surfaces.",
+            [
+                {
+                    "label": "Objects",
+                    "path": _scoped_path("/objects", pack_name=requested_pack),
+                    "detail": "Browse indexed evergreen objects.",
+                },
+                {
+                    "label": "Search",
+                    "path": _scoped_path("/search", pack_name=requested_pack),
+                    "detail": "Search notes and objects across the shell.",
+                },
+            ],
+        ),
+        _workflow_group(
+            "review",
+            "Review",
+            "Open the highest-signal maintenance surfaces for contradictions, summaries, and signals.",
+            [
+                {
+                    "label": "Signals",
+                    "path": _scoped_path("/signals", pack_name=requested_pack),
+                    "detail": "Review current active signals.",
+                },
+                {
+                    "label": "Contradictions" if research_overview_supported else "Actions",
+                    "path": _scoped_path(
+                        "/contradictions" if research_overview_supported else "/actions",
+                        pack_name=requested_pack,
+                    ),
+                    "detail": (
+                        "Inspect open semantic tensions."
+                        if research_overview_supported
+                        else "Review queued execution actions."
+                    ),
+                },
+            ],
+        ),
+        _workflow_group(
+            "trace",
+            "Trace",
+            "Follow provenance and downstream production chains before editing or reviewing.",
+            [
+                {
+                    "label": "Production",
+                    "path": _scoped_path("/production", pack_name=requested_pack),
+                    "detail": "Inspect production weak points and chain state.",
+                },
+                {
+                    "label": "Deep Dives" if research_overview_supported else "Notes",
+                    "path": _scoped_path(
+                        "/deep-dives" if research_overview_supported else "/objects",
+                        pack_name=requested_pack,
+                    ),
+                    "detail": (
+                        "Follow note -> deep dive -> object derivation."
+                        if research_overview_supported
+                        else "Use object pages as the primary trace surface."
+                    ),
+                },
+            ],
+        ),
+        _workflow_group(
+            "explore",
+            "Explore",
+            "Move through topic, graph, and timeline surfaces once the shell has oriented you.",
+            [
+                {
+                    "label": "Events" if research_overview_supported else "Objects",
+                    "path": _scoped_path(
+                        "/events" if research_overview_supported else "/objects",
+                        pack_name=requested_pack,
+                    ),
+                    "detail": (
+                        "Explore timeline and dossier surfaces."
+                        if research_overview_supported
+                        else "Explore the shared-shell object browser."
+                    ),
+                },
+                {
+                    "label": "Clusters" if research_overview_supported else "Search",
+                    "path": _scoped_path(
+                        "/clusters" if research_overview_supported else "/search",
+                        pack_name=requested_pack,
+                    ),
+                    "detail": (
+                        "Explore graph clusters and higher-order structure."
+                        if research_overview_supported
+                        else "Use search to move laterally through the vault."
+                    ),
+                },
             ],
         ),
     ]
@@ -3126,6 +3080,7 @@ def build_truth_dashboard_payload(
             "browser_path": _scoped_path("/signals", pack_name=requested_pack),
         },
         "orientation": orientation,
+        "workflow_groups": workflow_groups,
         "entry_sections": entry_sections,
         "recent_review_actions": list_review_actions(vault_dir, limit=8),
         "priorities": priorities[:8],
@@ -3328,6 +3283,9 @@ def build_production_browser_payload(
                 "source_notes": 0,
                 "deep_dives": 0,
             },
+            "operator_rail": [],
+            "compiled_sections": [],
+            "section_nav": [],
         }
     items = list_production_chains(
         vault_dir,
@@ -3338,6 +3296,111 @@ def build_production_browser_payload(
     source_items = [item for item in items if item["stage_label"] == "source_note"]
     deep_dive_items = [item for item in items if item["stage_label"] == "deep_dive"]
     weak_points = _build_production_weak_points(vault_dir, pack_name=pack_name, query=query)
+    compiled_sections = [
+        _compiled_section(
+            "current_state",
+            "Current State",
+            summary=(
+                f"{len(items)} production-chain entries are currently visible, spanning "
+                f"{len(source_items)} source notes and {len(deep_dive_items)} deep dives."
+            ),
+            items=[
+                {
+                    "kind": "source_notes",
+                    "label": "Source notes",
+                    "path": "",
+                    "detail": f"{len(source_items)} source-note chain entries in scope.",
+                },
+                {
+                    "kind": "deep_dives",
+                    "label": "Deep dives",
+                    "path": "",
+                    "detail": f"{len(deep_dive_items)} deep-dive chain entries in scope.",
+                },
+            ],
+        ),
+        _compiled_section(
+            "why_it_matters",
+            "Why It Matters",
+            summary=(
+                f"{len(weak_points)} chain weak points currently block full source-to-object-to-atlas legibility."
+            ),
+            items=[
+                *[
+                    {
+                        "kind": "weak_point",
+                        "label": item["title"],
+                        "path": _scoped_path(
+                            f"/note?path={quote(str(item['note_path']), safe='')}",
+                            pack_name=requested_pack,
+                        ),
+                        "detail": f"Missing {', '.join(item['missing'])}",
+                    }
+                    for item in weak_points[:3]
+                ]
+            ],
+        ),
+        _compiled_section(
+            "chain_gaps",
+            "Chain Gaps",
+            summary="Weak points highlight where the current production chain stops short of a complete downstream path.",
+            items=[
+                *[
+                    {
+                        "kind": item["stage_label"],
+                        "label": item["title"],
+                        "path": _scoped_path(
+                            f"/note?path={quote(str(item['note_path']), safe='')}",
+                            pack_name=requested_pack,
+                        ),
+                        "detail": ", ".join(item["missing"]),
+                    }
+                    for item in weak_points[:5]
+                ]
+            ],
+        ),
+        _compiled_section(
+            "where_to_go_next",
+            "Where To Go Next",
+            summary="Use the visible source and deep-dive entries to continue into note, object, and atlas-level traceability.",
+            items=[
+                *[
+                    {
+                        "kind": item["stage_label"],
+                        "label": item["title"],
+                        "path": _scoped_path(
+                            f"/note?path={quote(str(item['path']), safe='')}",
+                            pack_name=requested_pack,
+                        ),
+                        "detail": str(item["traceability"].get("chain_summary") or ""),
+                    }
+                    for item in items[:4]
+                ]
+            ],
+        ),
+    ]
+    operator_rail = [
+        _operator_action(
+            "Orientation Brief",
+            _scoped_path("/briefing", pack_name=requested_pack),
+            "Return to the current entry product.",
+        ),
+        _operator_action(
+            "Signals",
+            _scoped_path("/signals", pack_name=requested_pack),
+            "Review active signals related to chain maintenance.",
+        ),
+        _operator_action(
+            "Action Queue",
+            _scoped_path("/actions", pack_name=requested_pack),
+            "Run or inspect queued execution work.",
+        ),
+        _operator_action(
+            "Search",
+            _scoped_path("/search", pack_name=requested_pack),
+            "Search laterally from the current production scope.",
+        ),
+    ]
     return {
         "screen": "production/browser",
         "requested_pack": requested_pack,
@@ -3354,6 +3417,9 @@ def build_production_browser_payload(
             "source_notes": len(source_items),
             "deep_dives": len(deep_dive_items),
         },
+        "operator_rail": operator_rail,
+        "compiled_sections": compiled_sections,
+        "section_nav": _section_nav_from_compiled_sections(compiled_sections),
     }
 
 
@@ -3436,6 +3502,7 @@ def build_note_page_payload(
     requested_pack = pack_name or ""
     provenance = get_note_provenance(vault_dir, note_path=note_path)
     production_chain = get_note_traceability(vault_dir, note_path=note_path, pack_name=pack_name)
+    inbound_capture = get_note_inbound_capture_summary(vault_dir, note_path=note_path)
     production_chain["source_notes"] = [
         {
             **item,
@@ -3476,10 +3543,144 @@ def build_note_page_payload(
         }
         for item in production_chain["atlas_pages"]
     ]
+    compiled_sections = [
+        _compiled_section(
+            "current_state",
+            "Current State",
+            summary=(
+                f"{production_chain['note']['title']} currently resolves as a "
+                f"{production_chain.get('stage_label', '').replace('_', ' ')} with "
+                f"{production_chain['counts']['deep_dives']} deep dives, "
+                f"{production_chain['counts']['objects']} objects, and "
+                f"{production_chain['counts']['atlas_pages']} atlas pages downstream."
+            ),
+            items=[
+                {
+                    "kind": "stage",
+                    "label": str(production_chain.get("stage_label") or "").replace("_", " "),
+                    "path": "",
+                    "detail": str(production_chain.get("chain_status") or ""),
+                }
+            ],
+        ),
+        _compiled_section(
+            "inbound_capture",
+            "Inbound Capture",
+            summary=str(inbound_capture.get("summary") or ""),
+            items=[
+                {
+                    "kind": str(item.get("kind") or ""),
+                    "label": str(item.get("label") or ""),
+                    "path": (
+                        _scoped_path(f"/note?path={quote(str(item['path']), safe='')}", pack_name=requested_pack)
+                        if item.get("path")
+                        else ""
+                    ),
+                    "detail": str(item.get("detail") or ""),
+                }
+                for item in inbound_capture.get("items", [])
+            ],
+        ),
+        _compiled_section(
+            "evidence_traceability",
+            "Evidence Traceability",
+            summary="The note traceability chain shows which deep dives, objects, and atlas pages this note currently anchors.",
+            items=[
+                *[
+                    {
+                        "kind": "deep_dive",
+                        "label": item["title"],
+                        "path": item["note_path"],
+                        "detail": "Downstream deep dive",
+                    }
+                    for item in production_chain["deep_dives"][:3]
+                ],
+                *[
+                    {
+                        "kind": "object",
+                        "label": item["title"],
+                        "path": item["object_path"],
+                        "detail": "Derived evergreen object",
+                    }
+                    for item in production_chain["objects"][:3]
+                ],
+            ],
+        ),
+        _compiled_section(
+            "production_chain",
+            "Production Chain",
+            summary=str(production_chain.get("chain_summary") or ""),
+            items=[
+                {
+                    "kind": "chain_status",
+                    "label": "Chain status",
+                    "path": "",
+                    "detail": str(production_chain.get("chain_status") or ""),
+                },
+                {
+                    "kind": "missing_stages",
+                    "label": "Missing stages",
+                    "path": "",
+                    "detail": ", ".join(str(item).replace("_", " ") for item in production_chain.get("missing_stages", [])) or "None",
+                },
+            ],
+        ),
+        _compiled_section(
+            "where_to_go_next",
+            "Where To Go Next",
+            summary="Continue into downstream deep dives, derived objects, or atlas reach from this note.",
+            items=[
+                *[
+                    {
+                        "kind": "deep_dive",
+                        "label": item["title"],
+                        "path": item["note_path"],
+                        "detail": "Open downstream deep dive.",
+                    }
+                    for item in production_chain["deep_dives"][:2]
+                ],
+                *[
+                    {
+                        "kind": "object",
+                        "label": item["title"],
+                        "path": item["object_path"],
+                        "detail": "Open derived object page.",
+                    }
+                    for item in production_chain["objects"][:2]
+                ],
+            ],
+        ),
+    ]
+    fallback_object_path = (
+        production_chain["objects"][0]["object_path"]
+        if production_chain["objects"]
+        else _scoped_path("/objects", pack_name=requested_pack)
+    )
+    fallback_object_label = "Open derived object" if production_chain["objects"] else "Objects"
     return {
         "screen": "note/page",
         "requested_pack": requested_pack,
         "note_path": note_path,
         "provenance": provenance,
+        "inbound_capture": inbound_capture,
         "production_chain": production_chain,
+        "operator_rail": [
+            _operator_action(
+                "Production Browser",
+                _scoped_path("/production", pack_name=requested_pack),
+                "Inspect broader production-chain weak points.",
+            ),
+            _operator_action(
+                "Signals",
+                _scoped_path("/signals", pack_name=requested_pack),
+                "Open active signals for this shell scope.",
+            ),
+            _operator_action(
+                fallback_object_label,
+                fallback_object_path,
+                "Jump into the most relevant derived object surface.",
+            ),
+        ],
+        "compiled_sections": compiled_sections,
+        "section_nav": _section_nav_from_compiled_sections(compiled_sections),
     }

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -1083,47 +1083,16 @@ def build_briefing_payload(vault_dir: Path | str, *, pack_name: str | None = Non
         }
         for item in snapshot.get("priority_items", [])[:5]
     ]
+    impact_counts = _impact_counts(snapshot.get("recent_signals", []))
     loop_summary = {
-        "productive_count": sum(
-            1
-            for item in snapshot.get("recent_signals", [])
-            if str((item.get("impact_summary") or {}).get("impact_status") or "") == "productive"
-        ),
-        "waiting_count": sum(
-            1
-            for item in snapshot.get("recent_signals", [])
-            if str((item.get("impact_summary") or {}).get("impact_status") or "") == "waiting"
-        ),
-        "running_count": sum(
-            1
-            for item in snapshot.get("recent_signals", [])
-            if str((item.get("impact_summary") or {}).get("impact_status") or "") == "running"
-        ),
-        "ready_count": sum(
-            1
-            for item in snapshot.get("recent_signals", [])
-            if str((item.get("impact_summary") or {}).get("impact_status") or "") == "ready"
-        ),
-        "completed_count": sum(
-            1
-            for item in snapshot.get("recent_signals", [])
-            if str((item.get("impact_summary") or {}).get("impact_status") or "") == "completed"
-        ),
-        "failed_count": sum(
-            1
-            for item in snapshot.get("recent_signals", [])
-            if str((item.get("impact_summary") or {}).get("impact_status") or "") == "failed"
-        ),
-        "stalled_count": sum(
-            1
-            for item in snapshot.get("recent_signals", [])
-            if str((item.get("impact_summary") or {}).get("impact_status") or "") == "stalled"
-        ),
-        "review_only_count": sum(
-            1
-            for item in snapshot.get("recent_signals", [])
-            if str((item.get("impact_summary") or {}).get("impact_status") or "") == "review_only"
-        ),
+        "productive_count": impact_counts.get("productive", 0),
+        "waiting_count": impact_counts.get("waiting", 0),
+        "running_count": impact_counts.get("running", 0),
+        "ready_count": impact_counts.get("ready", 0),
+        "completed_count": impact_counts.get("completed", 0),
+        "failed_count": impact_counts.get("failed", 0),
+        "stalled_count": impact_counts.get("stalled", 0),
+        "review_only_count": impact_counts.get("review_only", 0),
     }
     signal_loop_items = [
         {

--- a/task_plan.md
+++ b/task_plan.md
@@ -83,3 +83,23 @@ Phase 4
   - `/` workbench home now exposes entry sections and routes into orientation
   - object/topic/event/contradiction pages now expose stable compiled sections
   - docs and verify checklists now treat orientation and compiled-page contracts as pack-level product semantics
+- `Phase 20` is complete:
+  - event / contradiction semantics are now explicit on the product surface
+  - production-chain traceability is now legible across note/object/topic/production views
+- `Phase 21` is complete:
+  - `/` now exposes workflow-group IA instead of only a flat card pile
+  - key shell surfaces now expose explicit `Next Actions`
+  - shell pages now lead with a compiled lead section before deeper detail blocks
+- `Phase 22` is complete:
+  - signals and queued actions now expose deterministic `impact_summary` contracts
+  - `/signals`, `/actions`, and `/briefing` now speak the same lifecycle language about loop productivity
+  - the first Milestone 7 slice is now about visible impact, not only passive signal presence
+- `Phase 23` is complete:
+  - note-level inbound capture is now a deterministic contract over existing pipeline/refine logs
+  - signal rows now expose `capture_summary` inherited from their backing notes
+  - note and briefing surfaces now expose `Inbound Capture` compiled sections
+  - `/signals` now renders inbound capture legibility directly, not only queue impact
+- Next active planning target after `Phase 23` remains inside `Milestone 7: Active Signal Loop`
+  - focus next on brain-first lookup before object/link creation plus backlink legibility
+  - do not reopen shell UX unless a new operator-navigation gap appears
+  - do not widen immediately into temporal truth, harness memory, or benchmark tracks

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -181,7 +181,147 @@ def test_truth_api_reads_signal_and_action_ledgers_without_knowledge_db(temp_vau
 
     assert signals[0]["signal_id"] == "source_needs_deep_dive::demo"
     assert signals[0]["recommended_action"]["queue_status"] == "queued"
+    assert signals[0]["impact_summary"]["impact_status"] == "waiting"
+    assert signals[0]["impact_summary"]["lifecycle_stage"] == "queued"
+    assert signals[0]["impact_summary"]["action_status"] == "queued"
     assert actions[0]["action_id"] == "action::demo"
+    assert actions[0]["impact_summary"]["impact_status"] == "waiting"
+    assert actions[0]["impact_summary"]["lifecycle_stage"] == "queued"
+
+
+def test_truth_api_builds_note_inbound_capture_summary_and_attaches_it_to_signals(temp_vault):
+    from openclaw_pipeline.truth_api import get_note_inbound_capture_summary, list_signals
+
+    processed = temp_vault / "50-Inbox" / "03-Processed" / "2026-04" / "Harness.md"
+    processed.parent.mkdir(parents=True, exist_ok=True)
+    processed.write_text(
+        """---
+title: Harness
+source: https://example.com/harness
+---
+
+Processed source note.
+""",
+        encoding="utf-8",
+    )
+    deep_dive = temp_vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "Harness_深度解读.md"
+    deep_dive.parent.mkdir(parents=True, exist_ok=True)
+    deep_dive.write_text(
+        """---
+note_id: harness-deep-dive
+title: Harness Deep Dive
+type: deep_dive
+source: https://example.com/harness
+date: 2026-04-13
+---
+
+# Harness Deep Dive
+
+Mentions [[alpha]].
+""",
+        encoding="utf-8",
+    )
+    logs_dir = temp_vault / "60-Logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    (logs_dir / "pipeline.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "timestamp": "2026-04-18T09:00:00Z",
+                        "event_type": "source_archived_to_processed",
+                        "source": "50-Inbox/02-Processing/Harness.md",
+                        "archived": str(processed),
+                    },
+                    ensure_ascii=False,
+                ),
+                json.dumps(
+                    {
+                        "timestamp": "2026-04-18T09:10:00Z",
+                        "event_type": "article_processed",
+                        "file": "Harness.md",
+                        "output": str(deep_dive),
+                        "classification": "AI-Research",
+                    },
+                    ensure_ascii=False,
+                ),
+                json.dumps(
+                    {
+                        "timestamp": "2026-04-18T09:11:00Z",
+                        "event_type": "candidates_upserted",
+                        "file": "Harness.md",
+                        "candidates": ["agent-harness"],
+                    },
+                    ensure_ascii=False,
+                ),
+                json.dumps(
+                    {
+                        "timestamp": "2026-04-18T09:12:00Z",
+                        "event_type": "evergreen_auto_promoted",
+                        "concept": "alpha",
+                        "source": "Harness_深度解读.md",
+                        "mutation": {"target_slug": "alpha"},
+                    },
+                    ensure_ascii=False,
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    capture = get_note_inbound_capture_summary(
+        temp_vault,
+        note_path="50-Inbox/03-Processed/2026-04/Harness.md",
+    )
+
+    assert capture["status"] == "productive"
+    assert capture["captured_event_count"] == 4
+    assert capture["produced_artifact_count"] == 2
+    assert capture["candidate_count"] == 1
+    assert capture["latest_timestamp"] == "2026-04-18T09:12:00Z"
+    assert [item["kind"] for item in capture["items"]] == [
+        "processed_source",
+        "deep_dive_created",
+        "candidate_upserted",
+        "evergreen_promoted",
+    ]
+
+    loose_source = temp_vault / "50-Inbox" / "03-Processed" / "2026-04" / "Loose Source.md"
+    loose_source.write_text(
+        """---
+title: Loose Source
+source: https://example.com/loose
+---
+
+Processed source note without downstream chain.
+""",
+        encoding="utf-8",
+    )
+    with (logs_dir / "pipeline.jsonl").open("a", encoding="utf-8") as handle:
+        handle.write(
+            json.dumps(
+                {
+                    "timestamp": "2026-04-18T10:00:00Z",
+                    "event_type": "source_archived_to_processed",
+                    "source": "50-Inbox/02-Processing/Loose Source.md",
+                    "archived": str(loose_source),
+                },
+                ensure_ascii=False,
+            )
+            + "\n"
+        )
+    rebuild_knowledge_index(temp_vault)
+
+    source_signal = next(
+        item for item in list_signals(temp_vault) if item["signal_type"] == "source_needs_deep_dive"
+    )
+
+    assert source_signal["capture_summary"]["status"] == "observed"
+    assert source_signal["capture_summary"]["captured_event_count"] == 1
+    assert source_signal["capture_summary"]["produced_artifact_count"] == 0
+    assert source_signal["capture_summary"]["summary"].startswith("Observed 1 inbound capture event")
 
 
 def test_truth_api_avoids_datetime_utc_import_for_python_310_compatibility():
@@ -381,50 +521,6 @@ def test_truth_api_lists_research_graph_clusters(temp_vault):
     assert "target-note" in clusters[0]["member_object_ids"]
 
 
-def test_truth_api_builds_bounded_graph_cluster_scope(temp_vault):
-    from openclaw_pipeline.truth_api import get_graph_cluster_scope, list_graph_clusters
-
-    vault = _seed_truth_vault(temp_vault)
-    cluster = list_graph_clusters(vault, pack_name="research-tech")[0]
-
-    scope = get_graph_cluster_scope(
-        vault,
-        cluster["cluster_id"],
-        pack_name="research-tech",
-        object_limit=2,
-        edge_limit=4,
-    )
-
-    assert scope["cluster"]["cluster_id"] == cluster["cluster_id"]
-    assert len(scope["visible_members"]) == 2
-    assert scope["visible_members"][0]["is_center"] is True
-    visible_ids = {item["object_id"] for item in scope["visible_members"]}
-    assert "source-note" in visible_ids
-    assert all(edge["source_object_id"] in visible_ids and edge["target_object_id"] in visible_ids for edge in scope["visible_edges"])
-    assert scope["hidden_member_count"] == 1
-
-
-def test_truth_api_builds_bounded_graph_object_scope(temp_vault):
-    from openclaw_pipeline.truth_api import get_graph_object_scope
-
-    vault = _seed_truth_vault(temp_vault)
-
-    scope = get_graph_object_scope(
-        vault,
-        "source-note",
-        pack_name="research-tech",
-        neighbor_limit=1,
-        edge_limit=2,
-    )
-
-    assert scope["center"]["object_id"] == "source-note"
-    assert len(scope["visible_neighbors"]) == 1
-    assert scope["visible_neighbors"][0]["object_id"] == "target-note"
-    assert len(scope["visible_edges"]) == 1
-    assert scope["visible_edges"][0]["target_object_id"] == "target-note"
-    assert scope["hidden_neighbor_count"] == 0
-
-
 def test_truth_api_does_not_fallback_when_requested_pack_is_materialized(temp_vault, monkeypatch):
     from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
     from openclaw_pipeline.truth_api import get_object_detail, list_graph_clusters, list_objects
@@ -505,6 +601,15 @@ def test_truth_api_lists_contradictions(temp_vault):
     assert items[0]["scope_summary"]["positive_claim_count"] == 1
     assert items[0]["scope_summary"]["negative_claim_count"] == 1
     assert items[0]["ranked_evidence"][0]["rank"] == 1
+    assert items[0]["polarity_summary"] == {
+        "positive_claim_count": 1,
+        "negative_claim_count": 1,
+        "object_count": 2,
+    }
+    assert items[0]["evidence_summary"]["ranked_evidence_count"] == len(items[0]["ranked_evidence"])
+    assert items[0]["evidence_summary"]["source_note_count"] == 2
+    assert items[0]["evidence_summary"]["quote_count"] == 2
+    assert items[0]["tension_summary"] == "1 positive claims vs 1 negative claims across 2 objects."
     assert items[0]["positive_claim_ids"]
     assert items[0]["negative_claim_ids"]
 
@@ -1468,6 +1573,16 @@ date: 2026-04-13
     assert [item["title"] for item in traceability["deep_dives"]] == ["Harness Deep Dive"]
     assert [item["object_id"] for item in traceability["objects"]] == ["alpha"]
     assert [item["slug"] for item in traceability["atlas_pages"]] == ["atlas-index"]
+    assert traceability["stage_label"] == "source_note"
+    assert traceability["chain_status"] == "complete"
+    assert traceability["missing_stages"] == []
+    assert traceability["stage_presence"] == {
+        "source_notes": True,
+        "deep_dives": True,
+        "objects": True,
+        "atlas_pages": True,
+    }
+    assert "1 deep dives, 1 objects, 1 atlas pages" in traceability["chain_summary"]
 
 
 def test_truth_api_returns_object_traceability(temp_vault):
@@ -1555,6 +1670,15 @@ date: 2026-04-13
     assert [item["slug"] for item in traceability["deep_dives"]] == ["harness-deep-dive"]
     assert [item["path"] for item in traceability["source_notes"]] == ["50-Inbox/03-Processed/2026-04/Harness.md"]
     assert [item["slug"] for item in traceability["atlas_pages"]] == ["atlas-index"]
+    assert traceability["stage_label"] == "evergreen_object"
+    assert traceability["chain_status"] == "complete"
+    assert traceability["missing_stages"] == []
+    assert traceability["stage_presence"] == {
+        "source_notes": True,
+        "deep_dives": True,
+        "atlas_pages": True,
+    }
+    assert "1 source notes, 1 deep dives, 1 atlas pages" in traceability["chain_summary"]
 
 
 def test_truth_api_object_traceability_excludes_incidental_deep_dive_mentions(temp_vault):
@@ -2296,6 +2420,9 @@ Processed source note without any derived deep dive.
     assert payload["action"]["finished_at"]
     assert calls == ["deep_dive_workflow"]
     assert actions[0]["status"] == "succeeded"
+    assert actions[0]["impact_summary"]["impact_status"] == "productive"
+    assert actions[0]["impact_summary"]["produced_artifact_count"] == 1
+    assert actions[0]["impact_summary"]["produced_artifact_types"] == ["deep_dive"]
 
 
 def test_truth_api_run_next_action_queue_item_marks_obsolete_when_signal_is_gone(temp_vault, monkeypatch):
@@ -2519,6 +2646,8 @@ Processed source note without any derived deep dive.
     assert failed_action["status"] == "failed"
     assert failed_action["retry_count"] == 1
     assert failed_action["failure_bucket"] == "missing_target"
+    assert failed_action["impact_summary"]["impact_status"] == "failed"
+    assert failed_action["impact_summary"]["lifecycle_stage"] == "failed"
 
 
 def test_truth_api_run_action_queue_can_limit_to_safe_actions(temp_vault, monkeypatch):

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -324,6 +324,115 @@ Processed source note without downstream chain.
     assert source_signal["capture_summary"]["summary"].startswith("Observed 1 inbound capture event")
 
 
+def test_truth_api_marks_non_executable_recommended_actions_as_review_only():
+    from openclaw_pipeline.truth_api import _build_signal_impact_summary
+
+    review_only = _build_signal_impact_summary(
+        {
+            "recommended_action": {
+                "kind": "inspect_production_gap",
+                "label": "Inspect production gap",
+                "path": "/production?q=gap",
+                "executable": False,
+            }
+        }
+    )
+    ready = _build_signal_impact_summary(
+        {
+            "recommended_action": {
+                "kind": "review_contradiction",
+                "label": "Review contradiction",
+                "path": "/contradictions?q=alpha",
+                "executable": True,
+            }
+        }
+    )
+
+    assert review_only["impact_status"] == "review_only"
+    assert review_only["lifecycle_stage"] == "manual_review"
+    assert ready["impact_status"] == "ready"
+    assert ready["lifecycle_stage"] == "recommendation_only"
+
+
+def test_truth_api_aggregates_note_capture_summaries_with_single_log_scan_per_file(
+    temp_vault,
+    monkeypatch,
+):
+    import openclaw_pipeline.truth_api as truth_api
+
+    note_alpha = temp_vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "Alpha_深度解读.md"
+    note_beta = temp_vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "Beta_深度解读.md"
+    note_alpha.parent.mkdir(parents=True, exist_ok=True)
+    note_alpha.write_text(
+        """---
+note_id: alpha-deep-dive
+title: Alpha Deep Dive
+type: deep_dive
+---
+""",
+        encoding="utf-8",
+    )
+    note_beta.write_text(
+        """---
+note_id: beta-deep-dive
+title: Beta Deep Dive
+type: deep_dive
+---
+""",
+        encoding="utf-8",
+    )
+
+    logs_dir = temp_vault / "60-Logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    (logs_dir / "pipeline.jsonl").write_text("", encoding="utf-8")
+    (logs_dir / "refine-mutations.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "timestamp": "2026-04-18T11:00:00Z",
+                        "event_type": "refine_mutation_applied",
+                        "targets": ["alpha-deep-dive"],
+                        "mode": "focused",
+                    },
+                    ensure_ascii=False,
+                ),
+                json.dumps(
+                    {
+                        "timestamp": "2026-04-18T11:05:00Z",
+                        "event_type": "refine_mutation_applied",
+                        "targets": ["beta-deep-dive"],
+                        "mode": "focused",
+                    },
+                    ensure_ascii=False,
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    read_paths: list[str] = []
+    original_read_jsonl_items = truth_api._read_jsonl_items
+
+    def counting_read_jsonl_items(path):
+        read_paths.append(Path(path).name)
+        return original_read_jsonl_items(path)
+
+    monkeypatch.setattr(truth_api, "_read_jsonl_items", counting_read_jsonl_items)
+
+    payload = truth_api._aggregate_note_capture_summaries(
+        temp_vault,
+        [
+            "20-Areas/AI-Research/Topics/2026-04/Alpha_深度解读.md",
+            "20-Areas/AI-Research/Topics/2026-04/Beta_深度解读.md",
+        ],
+    )
+
+    assert payload["captured_event_count"] == 2
+    assert sorted(read_paths) == ["pipeline.jsonl", "refine-mutations.jsonl"]
+
+
 def test_truth_api_avoids_datetime_utc_import_for_python_310_compatibility():
     source = (
         Path(__file__).resolve().parents[1]

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -81,6 +81,10 @@ def test_ui_server_root_serves_html_shell(temp_vault):
 
     assert response.status == 200
     assert "OpenClaw Truth UI" in body
+    assert "Workflow Map" in body
+    assert "Orient" in body
+    assert "Inspect" in body
+    assert "Review" in body
     assert "Where To Start" in body
     assert "Orientation Brief" in body
     assert "/api/objects" in body
@@ -106,32 +110,10 @@ def test_ui_server_root_accepts_pack_scope(temp_vault):
 
     assert response.status == 200
     assert "Pack scope: default-knowledge" in body
+    assert 'href="/briefing?pack=default-knowledge"' in body
     assert "/signals?pack=default-knowledge" in body
     assert "inherited from research-tech-signals" in body
     assert "inherited from research-tech-production-chains" in body
-
-
-def test_ui_server_briefing_page_uses_orientation_title(temp_vault):
-    from openclaw_pipeline.commands.ui_server import create_server
-
-    _seed_truth_store(temp_vault)
-    server = create_server(temp_vault, host="127.0.0.1", port=0)
-    port = server.server_address[1]
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    try:
-        conn = HTTPConnection("127.0.0.1", port, timeout=5)
-        conn.request("GET", "/briefing")
-        response = conn.getresponse()
-        body = response.read().decode("utf-8")
-    finally:
-        server.shutdown()
-        server.server_close()
-        thread.join(timeout=5)
-
-    assert response.status == 200
-    assert "<title>Orientation Brief</title>" in body
-    assert "<h1>Orientation Brief</h1>" in body
 
 
 def test_ui_server_objects_endpoint_returns_json(temp_vault):
@@ -340,6 +322,7 @@ def test_ui_server_object_page_preserves_pack_scope_in_shell_nav(temp_vault):
     assert "Why It Matters" in body
     assert "Where To Go Next" in body
     assert "Source contract: wiki_view · object/page" in body
+    assert body.index("Current State") < body.index("Next Actions") < body.index("Why It Matters")
 
 
 def test_ui_server_note_page_preserves_pack_scope_in_shell_nav(temp_vault):
@@ -408,9 +391,27 @@ date: 2026-04-13
     (logs_dir / "pipeline.jsonl").write_text(
         "\n".join(
             [
+                json.dumps(
+                    {
+                        "timestamp": "2026-04-18T09:00:00Z",
+                        "event_type": "source_archived_to_processed",
+                        "source": "50-Inbox/02-Processing/Harness.md",
+                        "archived": str(processed),
+                    },
+                    ensure_ascii=False,
+                ),
                 '{"event_type":"article_processed","file":"Harness.md","output":"'
                 + str(deep_dive)
                 + '"}',
+                json.dumps(
+                    {
+                        "timestamp": "2026-04-18T09:11:00Z",
+                        "event_type": "candidates_upserted",
+                        "file": "Harness.md",
+                        "candidates": ["agent-harness"],
+                    },
+                    ensure_ascii=False,
+                ),
                 '{"event_type":"evergreen_auto_promoted","concept":"alpha","source":"Harness_深度解读.md","mutation":{"target_slug":"alpha"}}',
             ]
         )
@@ -440,6 +441,13 @@ date: 2026-04-13
     assert 'href="/signals?pack=default-knowledge"' in body
     assert 'href="/object?id=alpha&amp;pack=default-knowledge"' in body
     assert 'href="/note?path=20-Areas%2FAI-Research%2FTopics%2F2026-04%2FHarness_%E6%B7%B1%E5%BA%A6%E8%A7%A3%E8%AF%BB.md&amp;pack=default-knowledge"' in body
+    assert "Current State" in body
+    assert "Inbound Capture" in body
+    assert "Captured 4 inbound events" in body
+    assert "Evidence Traceability" in body
+    assert "Production Chain" in body
+    assert "Next Actions" in body
+    assert body.index("Current State") < body.index("Next Actions") < body.index("Inbound Capture")
 
 
 def test_ui_server_contradictions_endpoint_returns_payload(temp_vault):
@@ -597,6 +605,7 @@ def test_ui_server_signals_page_preserves_pack_scope_in_shell_nav(temp_vault):
     assert 'href="/events?pack=default-knowledge"' in body
     assert 'href="/summaries?pack=default-knowledge"' in body
     assert "inherited from research-tech-signals" in body
+    assert body.index("Next Actions") < body.index("Signal Types")
 
 
 def test_ui_server_signals_page_renders_missing_surface_contract_error(temp_vault, monkeypatch):
@@ -839,6 +848,9 @@ def test_ui_server_events_page_preserves_pack_scope_in_shell_nav(temp_vault):
     assert "inherited from event_dossier in research-tech" in body
     assert "Source contract: wiki_view · event/dossier" in body
     assert "Source provider: default-knowledge · event/dossier" in body
+    assert "Grouping kind: object_date_rollup" in body
+    assert "Anchor kind note: 3" in body
+    assert "not a canonical event entity store" in body
 
 
 def test_ui_server_atlas_endpoint_accepts_pack_scope(temp_vault):
@@ -1013,79 +1025,6 @@ def test_ui_server_clusters_endpoint_returns_payload(temp_vault):
     assert payload["items"][0]["priority_reason"]
     assert payload["items"][0]["display_title"]
     assert payload["items"][0]["relation_pattern_preview"]
-
-
-def test_ui_server_graph_endpoint_returns_payload(temp_vault):
-    from openclaw_pipeline.commands.ui_server import create_server
-
-    _seed_truth_store(temp_vault)
-    server = create_server(temp_vault, host="127.0.0.1", port=0)
-    port = server.server_address[1]
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    try:
-        conn = HTTPConnection("127.0.0.1", port, timeout=5)
-        conn.request("GET", "/api/graph?pack=default-knowledge")
-        response = conn.getresponse()
-        payload = json.loads(response.read().decode("utf-8"))
-    finally:
-        server.shutdown()
-        server.server_close()
-        thread.join(timeout=5)
-
-    assert response.status == 200
-    assert payload["screen"] == "graph/canvas"
-    assert payload["scope"] == "clusters"
-    assert payload["nodes"]
-    assert payload["controls"]["edge_filter_items"]
-
-
-def test_ui_server_graph_page_renders_canvas(temp_vault):
-    from openclaw_pipeline.commands.ui_server import create_server
-    from openclaw_pipeline.truth_api import list_graph_clusters
-
-    _seed_truth_store(temp_vault)
-    cluster = list_graph_clusters(temp_vault)[0]
-    server = create_server(temp_vault, host="127.0.0.1", port=0)
-    port = server.server_address[1]
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    try:
-        conn = HTTPConnection("127.0.0.1", port, timeout=5)
-        conn.request("GET", f"/graph?cluster_id={cluster['cluster_id']}&pack={cluster['pack']}")
-        response = conn.getresponse()
-        body = response.read().decode("utf-8")
-    finally:
-        server.shutdown()
-        server.server_close()
-        thread.join(timeout=5)
-
-    assert response.status == 200
-    assert "id='graph-stage'" in body or 'id="graph-stage"' in body
-    assert "Graph Scope" in body
-    assert "Expand graph" in body or "Fully expanded for current bound" in body
-
-
-def test_ui_server_graph_route_is_guarded_for_non_research_packs(temp_vault):
-    from openclaw_pipeline.commands.ui_server import create_server
-
-    _seed_truth_store(temp_vault)
-    server = create_server(temp_vault, host="127.0.0.1", port=0)
-    port = server.server_address[1]
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    try:
-        conn = HTTPConnection("127.0.0.1", port, timeout=5)
-        conn.request("GET", "/api/graph?pack=media-editorial")
-        response = conn.getresponse()
-        payload = json.loads(response.read().decode("utf-8"))
-    finally:
-        server.shutdown()
-        server.server_close()
-        thread.join(timeout=5)
-
-    assert response.status == 409
-    assert payload["status"] == "unsupported_pack"
 
 
 def test_ui_server_clusters_page_preserves_pack_scope_in_shell_nav(temp_vault):
@@ -1436,6 +1375,8 @@ def test_ui_server_briefing_endpoint_returns_payload(temp_vault):
     assert payload["active_topics"]
     assert payload["assembly_contract"]["recipe_name"] == "orientation_brief"
     assert [section["id"] for section in payload["compiled_sections"]] == [
+        "signal_loop",
+        "inbound_capture",
         "what_changed",
         "what_matters",
         "needs_review",
@@ -1475,6 +1416,34 @@ def test_ui_server_briefing_page_preserves_pack_scope_in_shell_nav(temp_vault):
     from openclaw_pipeline.commands.ui_server import create_server
 
     _seed_truth_store(temp_vault)
+    loose_source = temp_vault / "50-Inbox" / "03-Processed" / "2026-04" / "Loose Source.md"
+    loose_source.parent.mkdir(parents=True, exist_ok=True)
+    loose_source.write_text(
+        """---
+title: Loose Source
+source: https://example.com/loose
+---
+
+Processed source note without downstream chain.
+""",
+        encoding="utf-8",
+    )
+    logs_dir = temp_vault / "60-Logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    (logs_dir / "pipeline.jsonl").write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-04-18T10:00:00Z",
+                "event_type": "source_archived_to_processed",
+                "source": "50-Inbox/02-Processing/Loose Source.md",
+                "archived": str(loose_source),
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
     server = create_server(temp_vault, host="127.0.0.1", port=0)
     port = server.server_address[1]
     thread = threading.Thread(target=server.serve_forever, daemon=True)
@@ -1498,8 +1467,11 @@ def test_ui_server_briefing_page_preserves_pack_scope_in_shell_nav(temp_vault):
     assert "Source provider: research-tech · research-tech-briefing" in body
     assert "Governance Contract" in body
     assert "inherited from research_governance in research-tech" in body
+    assert "Signal Loop" in body
+    assert "Inbound Capture" in body
     assert "What Changed" in body
     assert "Next Actions" in body
+    assert body.index("Signal Loop") < body.index("Next Actions") < body.index("Inbound Capture")
 
 
 def test_ui_server_briefing_page_renders_governance_resolver_metadata(temp_vault, monkeypatch):
@@ -1691,6 +1663,36 @@ Processed source note without downstream chain.
     assert response.status == 200
     assert 'href="/note?path=50-Inbox%2F03-Processed%2F2026-04%2FLoose%20Source.md&amp;pack=default-knowledge"' in body
     assert "inherited from research-tech-production-chains" in body
+    assert "Chain status:" in body
+    assert "Missing stages:" in body
+    assert "Current State" in body
+    assert "Chain Gaps" in body
+    assert "Next Actions" in body
+    assert body.index("Current State") < body.index("Next Actions") < body.index("Chain Gaps")
+
+
+def test_ui_server_contradictions_page_renders_detection_semantics(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+
+    _seed_truth_store(temp_vault)
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("GET", "/contradictions")
+        response = conn.getresponse()
+        body = response.read().decode("utf-8")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 200
+    assert "Polarity semantics:" in body
+    assert "Evidence semantics:" in body
+    assert "1 positive claims vs 1 negative claims across 2 objects." in body
 
 
 def test_ui_server_actions_page_renders_execution_contract_metadata(temp_vault, monkeypatch):
@@ -1736,12 +1738,20 @@ def test_ui_server_actions_page_renders_execution_contract_metadata(temp_vault, 
                     "processor_inputs": ["source_note"],
                     "processor_outputs": ["deep_dive"],
                     "processor_quality_hooks": ["quality"],
+                    "impact_summary": {
+                        "impact_status": "waiting",
+                        "lifecycle_stage": "queued",
+                        "impact_label": "Waiting on queue execution",
+                        "impact_detail": "A queueable action exists and is currently waiting to run.",
+                        "produced_artifact_count": 0,
+                    },
                 }
             ],
             "count": 1,
             "query": "",
             "status": "",
             "status_counts": {"queued": 1},
+            "impact_counts": {"waiting": 1},
             "queued_safe_count": 1,
             "failed_count": 0,
             "failure_buckets": {},
@@ -1770,6 +1780,7 @@ def test_ui_server_actions_page_renders_execution_contract_metadata(temp_vault, 
     assert "Processor: llm_structured" in body
     assert "Inputs: source_note" in body
     assert "Outputs: deep_dive" in body
+    assert "Impact: Waiting on queue execution" in body
     assert "Quality hooks: quality" in body
     assert "Governance Contract" in body
     assert "declared by research_governance in research-tech" in body
@@ -1813,6 +1824,12 @@ def test_ui_server_signals_page_renders_governance_resolver_metadata(temp_vault,
                     "title": "Loose Source",
                     "detail": "Processed source note has no derived deep dive yet.",
                     "source_path": "/note?path=50-Inbox%2F03-Processed%2FLoose%20Source.md",
+                    "capture_summary": {
+                        "status": "observed",
+                        "summary": "Observed 1 inbound capture event but no downstream artifact yet.",
+                        "captured_event_count": 1,
+                        "produced_artifact_count": 0,
+                    },
                     "downstream_effects": [],
                     "recommended_action": {
                         "kind": "deep_dive_workflow",
@@ -1826,13 +1843,28 @@ def test_ui_server_signals_page_renders_governance_resolver_metadata(temp_vault,
                         "governance_provider_pack": "research-tech",
                         "safe_to_run": True,
                     },
+                    "impact_summary": {
+                        "impact_status": "waiting",
+                        "lifecycle_stage": "queued",
+                        "impact_label": "Waiting on queue execution",
+                        "impact_detail": "A queueable action exists and is currently waiting to run.",
+                        "produced_artifact_count": 0,
+                    },
                 }
             ],
             "count": 1,
             "query": query or "",
             "signal_type": signal_type or "",
             "type_counts": {"source_needs_deep_dive": 1},
+            "impact_counts": {"waiting": 1},
             "signal_type_explanations": {"source_needs_deep_dive": "demo"},
+            "operator_rail": [
+                {
+                    "label": "Action Queue",
+                    "path": "/actions",
+                    "detail": "Run or inspect queued actions derived from signals.",
+                }
+            ],
         },
     )
 
@@ -1858,6 +1890,9 @@ def test_ui_server_signals_page_renders_governance_resolver_metadata(temp_vault,
     assert "safe" in body
     assert "Governance Contract" in body
     assert "declared by research_governance in research-tech" in body
+    assert "Next Actions" in body
+    assert "Impact: Waiting on queue execution" in body
+    assert "Inbound capture: Observed 1 inbound capture event but no downstream artifact yet." in body
 
 
 def test_ui_server_actions_endpoint_accepts_pack_scope(temp_vault, monkeypatch):
@@ -2770,6 +2805,19 @@ def test_render_topic_page_hides_research_affordances_when_pack_lacks_research_s
     assert "Review scoped contradictions" not in body
     assert "<h2>Evolution</h2>" not in body
     assert "<h2>Atlas / MOC</h2>" not in body
+
+
+def test_render_topic_page_includes_production_chain_section(temp_vault):
+    import openclaw_pipeline.commands.ui_server as ui_server
+    from openclaw_pipeline.ui.view_models import build_topic_overview_payload
+
+    _seed_truth_store(temp_vault)
+    payload = build_topic_overview_payload(temp_vault, "alpha")
+
+    body = ui_server._render_topic_page(payload)
+
+    assert "<h2>Production Chain</h2>" in body
+    assert "Missing source notes" in body or "Missing deep dives" in body or "Missing Atlas / MOC reach" in body
 
 
 def test_ui_server_main_starts_server_with_requested_bind(temp_vault, capsys, monkeypatch):

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sqlite3
 
 from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
@@ -97,10 +98,17 @@ def test_build_object_page_payload(temp_vault):
     assert payload["assembly_contract"]["source_contract_name"] == "object/page"
     assert payload["assembly_contract"]["source_provider_pack"] == "research-tech"
     assert payload["assembly_contract"]["source_provider_name"] == "object/page"
+    assert [item["label"] for item in payload["operator_rail"]] == [
+        "Topic overview",
+        "Event dossier",
+        "Contradiction review",
+        "Production Browser",
+    ]
     assert [section["id"] for section in payload["compiled_sections"]] == [
         "current_state",
         "why_it_matters",
         "evidence_traceability",
+        "production_chain",
         "open_tensions",
         "where_to_go_next",
     ]
@@ -154,6 +162,7 @@ def test_build_object_page_payload_hides_research_affordances_when_research_shel
         "Current State",
         "Why It Matters",
         "Evidence Traceability",
+        "Production Chain",
         "Open Tensions",
         "Where To Go Next",
     ]
@@ -235,10 +244,17 @@ def test_build_topic_overview_payload(temp_vault):
     assert payload["assembly_contract"]["source_contract_name"] == "overview/topic"
     assert payload["assembly_contract"]["source_provider_pack"] == "research-tech"
     assert payload["assembly_contract"]["source_provider_name"] == "overview/topic"
+    assert [item["label"] for item in payload["operator_rail"]] == [
+        "Center object",
+        "Event dossier",
+        "Contradictions",
+        "Production Browser",
+    ]
     assert [section["id"] for section in payload["compiled_sections"]] == [
         "current_state",
         "why_it_matters",
         "evidence_traceability",
+        "production_chain",
         "open_tensions",
         "where_to_go_next",
     ]
@@ -337,6 +353,11 @@ date: 2026-04-13
     assert payload["production_summary"]["top_deep_dives"] == []
     assert any(signal["code"] == "missing_source_notes" for signal in payload["production_summary"]["signals"])
     assert any(signal["code"] == "missing_deep_dives" for signal in payload["production_summary"]["signals"])
+    production_chain = next(
+        section for section in payload["compiled_sections"] if section["id"] == "production_chain"
+    )
+    assert production_chain["summary"]
+    assert any(item["kind"] == "gap_signal" for item in production_chain["items"])
 
 
 def test_build_event_dossier_payload(temp_vault):
@@ -352,6 +373,12 @@ def test_build_event_dossier_payload(temp_vault):
     assert payload["assembly_contract"]["source_contract_name"] == "event/dossier"
     assert payload["assembly_contract"]["source_provider_pack"] == "research-tech"
     assert payload["assembly_contract"]["source_provider_name"] == "event/dossier"
+    assert [item["label"] for item in payload["operator_rail"]] == [
+        "Production Browser",
+        "Contradictions",
+        "Signals",
+        "Clusters",
+    ]
     assert [section["id"] for section in payload["compiled_sections"]] == [
         "current_state",
         "why_it_matters",
@@ -372,8 +399,11 @@ def test_build_event_dossier_payload(temp_vault):
     assert payload["limit"] == 50
     assert payload["is_limited"] is True
     assert payload["timeline_contract"]["timeline_kind"] == "dated_note_projection"
+    assert payload["timeline_contract"]["grouping_kind"] == "object_date_rollup"
     assert payload["timeline_contract"]["row_type_counts"] == {"page_date": 3}
+    assert payload["timeline_contract"]["anchor_kind_counts"] == {"note": 3}
     assert payload["timeline_contract"]["semantic_roles"] == {"note_date_projection": 3}
+    assert "not a canonical event entity store" in payload["timeline_contract"]["event_vs_note_explanation"]
     assert "dated notes projected from indexed pages" in payload["model_notes"][0]
     assert payload["review_context"]["object_count"] == 3
     assert payload["review_context"]["open_contradiction_count"] == 1
@@ -679,80 +709,6 @@ date: 2026-04-13
     assert payload["top_mocs"][0]["slug"] == "atlas-index"
 
 
-def test_build_graph_canvas_payload_cluster_overview(temp_vault):
-    from openclaw_pipeline.ui.view_models import build_graph_canvas_payload
-
-    _seed_truth_store(temp_vault)
-
-    payload = build_graph_canvas_payload(temp_vault, pack_name="default-knowledge")
-
-    assert payload["screen"] == "graph/canvas"
-    assert payload["scope"] == "clusters"
-    assert payload["requested_pack"] == "default-knowledge"
-    assert payload["nodes"]
-    assert payload["nodes"][0]["detail"]["actions"]
-    assert payload["controls"]["edge_filter_items"]
-    assert payload["entry_links"][0]["path"].startswith("/clusters")
-
-
-def test_build_graph_canvas_payload_cluster_scope(temp_vault):
-    from openclaw_pipeline.truth_api import list_graph_clusters
-    from openclaw_pipeline.ui.view_models import build_graph_canvas_payload
-
-    _seed_truth_store(temp_vault)
-    cluster = list_graph_clusters(temp_vault)[0]
-
-    payload = build_graph_canvas_payload(
-        temp_vault,
-        pack_name=cluster["pack"],
-        cluster_id=cluster["cluster_id"],
-    )
-
-    assert payload["scope"] == "cluster"
-    assert payload["default_selection_id"].startswith("cluster-root:")
-    assert any(node["node_type"] == "cluster_root" for node in payload["nodes"])
-    assert any(node["node_type"] == "object" for node in payload["nodes"])
-    assert payload["controls"]["edge_filter_items"]
-    assert payload["entry_links"][0]["path"].startswith("/cluster?id=")
-
-
-def test_build_graph_canvas_payload_object_scope(temp_vault):
-    from openclaw_pipeline.ui.view_models import build_graph_canvas_payload
-
-    _seed_truth_store(temp_vault)
-
-    payload = build_graph_canvas_payload(
-        temp_vault,
-        pack_name="default-knowledge",
-        object_id="alpha",
-    )
-
-    assert payload["scope"] == "object"
-    assert payload["default_selection_id"] == "object:alpha"
-    assert payload["nodes"][0]["detail"]["actions"][0]["path"].startswith("/object?id=alpha")
-    assert payload["controls"]["edge_filter_items"][0]["value"] == "all"
-
-
-def test_build_object_page_payload_includes_graph_link(temp_vault):
-    from openclaw_pipeline.ui.view_models import build_object_page_payload
-
-    _seed_truth_store(temp_vault)
-
-    payload = build_object_page_payload(temp_vault, "alpha", pack_name="default-knowledge")
-
-    assert payload["links"]["graph_path"] == "/graph?object_id=alpha&pack=default-knowledge"
-
-
-def test_build_topic_overview_payload_includes_graph_link(temp_vault):
-    from openclaw_pipeline.ui.view_models import build_topic_overview_payload
-
-    _seed_truth_store(temp_vault)
-
-    payload = build_topic_overview_payload(temp_vault, "alpha", pack_name="default-knowledge")
-
-    assert payload["links"]["graph_path"] == "/graph?object_id=alpha&pack=default-knowledge"
-
-
 def test_build_cluster_detail_payload_filters_relevant_contradictions_before_slicing(
     temp_vault,
     monkeypatch,
@@ -998,6 +954,12 @@ def test_build_contradiction_browser_payload(temp_vault):
     assert payload["assembly_contract"]["source_contract_name"] == "truth/contradictions"
     assert payload["assembly_contract"]["source_provider_pack"] == "research-tech"
     assert payload["assembly_contract"]["source_provider_name"] == "truth/contradictions"
+    assert [item["label"] for item in payload["operator_rail"]] == [
+        "Signals",
+        "Action Queue",
+        "Production Browser",
+        "Events",
+    ]
     assert [section["id"] for section in payload["compiled_sections"]] == [
         "current_state",
         "why_it_matters",
@@ -1013,10 +975,15 @@ def test_build_contradiction_browser_payload(temp_vault):
     assert payload["items"][0]["detection_confidence"] == "heuristic"
     assert payload["items"][0]["status_bucket"] == "open"
     assert payload["items"][0]["scope_summary"]["object_count"] == 2
+    assert payload["items"][0]["polarity_summary"]["object_count"] == 2
+    assert payload["items"][0]["evidence_summary"]["ranked_evidence_count"] == len(payload["items"][0]["ranked_evidence"])
+    assert payload["items"][0]["tension_summary"] == "1 positive claims vs 1 negative claims across 2 objects."
     assert payload["items"][0]["status_explanation"] == "Active contradiction awaiting review."
     assert payload["items"][0]["ranked_evidence"][0]["rank"] == 1
     assert payload["detection_contract"]["model"] == "page_summary_polarity"
     assert payload["detection_contract"]["confidence"] == "heuristic"
+    assert payload["detection_contract"]["polarity_semantics"].startswith("Positive and negative claim sets")
+    assert payload["detection_contract"]["evidence_semantics"].startswith("Ranked evidence")
     assert payload["detection_contract"]["status_explanations"]["resolved_keep_positive"].startswith("Reviewed")
     assert "page_summary claim polarity" in payload["detection_notes"][0]
 
@@ -1173,6 +1140,14 @@ Thin note.
         "deserves_review",
         "recommended_next_steps",
     ]
+    assert [group["id"] for group in payload["workflow_groups"]] == [
+        "orient",
+        "inspect",
+        "review",
+        "trace",
+        "explore",
+    ]
+    assert payload["workflow_groups"][0]["items"][0]["path"] == "/briefing"
     assert payload["objects"]["count"] == 4
     assert payload["contradictions"]["count"] == 1
     assert payload["events"]["count"] == 4
@@ -1185,11 +1160,6 @@ Thin note.
     production_gap = next(item for item in payload["priorities"] if item["kind"] == "production_gap")
     assert production_gap["path"].startswith("/note?path=50-Inbox%2F03-Processed%2F2026-04%2FLoose%20Source.md")
     assert payload["recent_review_actions"] == []
-    orientation_sections = {section["id"]: section for section in payload["orientation"]["compiled_sections"]}
-    entry_sections = {section["id"]: section for section in payload["entry_sections"]}
-    assert entry_sections["what_changed_recently"]["items"] == orientation_sections["what_changed"]["items"][:4]
-    assert entry_sections["important_right_now"]["items"] == orientation_sections["next_actions"]["items"][:4]
-    assert entry_sections["deserves_review"]["items"] == orientation_sections["needs_review"]["items"][:4]
 
 
 def test_build_truth_dashboard_payload_preserves_requested_pack(temp_vault):
@@ -1216,6 +1186,7 @@ Processed source note without downstream chain.
     assert payload["objects"]["items"][0]["object_path"] == "/object?id=alpha&pack=default-knowledge"
     assert payload["signals"]["browser_path"] == "/signals?pack=default-knowledge"
     assert payload["production"]["browser_path"] == "/production?pack=default-knowledge"
+    assert payload["workflow_groups"][0]["items"][0]["path"] == "/briefing?pack=default-knowledge"
     production_gap = next(item for item in payload["priorities"] if item["kind"] == "production_gap")
     assert production_gap["path"].endswith("&pack=default-knowledge")
     assert payload["signals"]["surface_contract"]["status"] == "inherited"
@@ -1337,6 +1308,21 @@ Processed source note without downstream chain.
 """,
         encoding="utf-8",
     )
+    logs_dir = temp_vault / "60-Logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    (logs_dir / "pipeline.jsonl").write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-04-18T10:00:00Z",
+                "event_type": "source_archived_to_processed",
+                "source": "50-Inbox/02-Processing/Loose Source.md",
+                "archived": str(loose_source),
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
     rebuild_knowledge_index(temp_vault)
 
     payload = build_signal_browser_payload(temp_vault)
@@ -1347,9 +1333,19 @@ Processed source note without downstream chain.
     assert payload["governance_contract"]["provider_pack"] == "research-tech"
     assert payload["governance_contract"]["provider_name"] == "research_governance"
     assert payload["governance_contract"]["signal_rule_count"] >= 1
+    assert [item["label"] for item in payload["operator_rail"]] == [
+        "Action Queue",
+        "Production Browser",
+        "Contradictions",
+        "Orientation Brief",
+    ]
     assert "contradiction_open" in payload["governance_contract"]["signal_rule_names"]
     assert payload["type_counts"]["contradiction_open"] >= 1
+    assert "review_only" in payload["impact_counts"]
     assert any(item["signal_type"] == "production_gap" for item in payload["items"])
+    source_signal = next(item for item in payload["items"] if item["signal_type"] == "source_needs_deep_dive")
+    assert source_signal["capture_summary"]["status"] == "observed"
+    assert source_signal["capture_summary"]["captured_event_count"] == 1
 
 
 def test_build_signal_browser_payload_preserves_requested_pack(temp_vault):
@@ -1417,6 +1413,13 @@ def test_build_action_queue_payload_preserves_requested_pack(temp_vault, monkeyp
                 "action_kind": "deep_dive_workflow",
                 "title": "Run deep dive",
                 "safe_to_run": True,
+                "impact_summary": {
+                    "impact_status": "waiting",
+                    "lifecycle_stage": "queued",
+                    "impact_label": "Waiting on queue execution",
+                    "impact_detail": "A queueable action exists and is currently waiting to run.",
+                    "produced_artifact_count": 0,
+                },
             }
         ]
 
@@ -1439,6 +1442,7 @@ def test_build_action_queue_payload_preserves_requested_pack(temp_vault, monkeyp
     assert payload["governance_contract"]["status"] == "inherited"
     assert payload["governance_contract"]["provider_pack"] == "research-tech"
     assert payload["governance_contract"]["provider_name"] == "research_governance"
+    assert payload["impact_counts"] == {"waiting": 1}
 
 
 def test_build_briefing_payload(temp_vault):
@@ -1446,6 +1450,18 @@ def test_build_briefing_payload(temp_vault):
     from openclaw_pipeline.truth_api import record_review_action
 
     _seed_truth_store(temp_vault)
+    loose_source = temp_vault / "50-Inbox" / "03-Processed" / "2026-04" / "Loose Source.md"
+    loose_source.parent.mkdir(parents=True, exist_ok=True)
+    loose_source.write_text(
+        """---
+title: Loose Source
+source: https://example.com/loose
+---
+
+Processed source note without downstream chain.
+""",
+        encoding="utf-8",
+    )
     record_review_action(
         temp_vault,
         event_type="ui_summaries_rebuilt",
@@ -1455,6 +1471,21 @@ def test_build_briefing_payload(temp_vault):
             "objects_rebuilt": 1,
             "rebuilt_object_ids": ["alpha"],
         },
+    )
+    logs_dir = temp_vault / "60-Logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    (logs_dir / "pipeline.jsonl").write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-04-18T10:00:00Z",
+                "event_type": "source_archived_to_processed",
+                "source": "50-Inbox/02-Processing/Loose Source.md",
+                "archived": str(loose_source),
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
     )
     rebuild_knowledge_index(temp_vault)
 
@@ -1476,7 +1507,11 @@ def test_build_briefing_payload(temp_vault):
     assert payload["active_topics"]
     assert payload["insights"]
     assert payload["priority_items"]
+    assert payload["loop_summary"]["review_only_count"] >= 0
+    assert payload["loop_summary"]["productive_count"] >= 0
     assert [section["id"] for section in payload["compiled_sections"]] == [
+        "signal_loop",
+        "inbound_capture",
         "what_changed",
         "what_matters",
         "needs_review",
@@ -1484,12 +1519,17 @@ def test_build_briefing_payload(temp_vault):
         "next_actions",
     ]
     assert [item["href"] for item in payload["section_nav"]] == [
+        "#signal-loop",
+        "#inbound-capture",
         "#what-changed",
         "#what-matters",
         "#needs-review",
         "#next-reads",
         "#next-actions",
     ]
+    inbound_section = next(section for section in payload["compiled_sections"] if section["id"] == "inbound_capture")
+    assert inbound_section["items"]
+    assert inbound_section["items"][0]["kind"] == "capture_signal"
     assert payload["queue_summary"]["queued_count"] >= 0
 
 
@@ -1741,6 +1781,8 @@ Shipped the local-first harness update.
     assert payload["cluster_sections"][0]["clusters"][0]["object_id"] == "alpha"
     assert payload["cluster_sections"][0]["clusters"][0]["row_count"] == 2
     assert payload["cluster_sections"][0]["clusters"][0]["row_types"] == ["heading_date", "page_date"]
+    assert payload["cluster_sections"][0]["clusters"][0]["grouping_kind"] == "object_date_rollup"
+    assert "same object and date" in payload["cluster_sections"][0]["clusters"][0]["event_vs_note_explanation"]
 
 
 def test_build_atlas_browser_payload(temp_vault):
@@ -2074,6 +2116,18 @@ Mentions [[alpha]].
     assert payload["screen"] == "production/browser"
     assert payload["counts"]["source_notes"] == 1
     assert payload["counts"]["deep_dives"] == 1
+    assert [item["label"] for item in payload["operator_rail"]] == [
+        "Orientation Brief",
+        "Signals",
+        "Action Queue",
+        "Search",
+    ]
+    assert [section["id"] for section in payload["compiled_sections"]] == [
+        "current_state",
+        "why_it_matters",
+        "chain_gaps",
+        "where_to_go_next",
+    ]
     assert any(item["stage_label"] == "source_note" for item in payload["items"])
     assert any(item["stage_label"] == "deep_dive" for item in payload["items"])
     assert payload["limit"] == 50
@@ -2459,9 +2513,27 @@ date: 2026-04-13
     (logs_dir / "pipeline.jsonl").write_text(
         "\n".join(
             [
+                json.dumps(
+                    {
+                        "timestamp": "2026-04-18T09:00:00Z",
+                        "event_type": "source_archived_to_processed",
+                        "source": "50-Inbox/02-Processing/Harness.md",
+                        "archived": str(processed),
+                    },
+                    ensure_ascii=False,
+                ),
                 '{"event_type":"article_processed","file":"Harness.md","output":"'
                 + str(deep_dive)
                 + '"}',
+                json.dumps(
+                    {
+                        "timestamp": "2026-04-18T09:11:00Z",
+                        "event_type": "candidates_upserted",
+                        "file": "Harness.md",
+                        "candidates": ["agent-harness"],
+                    },
+                    ensure_ascii=False,
+                ),
                 '{"event_type":"evergreen_auto_promoted","concept":"alpha","source":"Harness_深度解读.md","mutation":{"target_slug":"alpha"}}',
             ]
         )
@@ -2479,6 +2551,23 @@ date: 2026-04-13
     assert [item["title"] for item in payload["production_chain"]["deep_dives"]] == ["Harness Deep Dive"]
     assert [item["object_id"] for item in payload["production_chain"]["objects"]] == ["alpha"]
     assert [item["slug"] for item in payload["production_chain"]["atlas_pages"]] == ["atlas-index"]
+    assert payload["production_chain"]["chain_status"] == "complete"
+    assert payload["production_chain"]["missing_stages"] == []
+    assert payload["inbound_capture"]["status"] == "productive"
+    assert payload["inbound_capture"]["captured_event_count"] == 4
+    assert payload["inbound_capture"]["produced_artifact_count"] == 2
+    assert [item["label"] for item in payload["operator_rail"]] == [
+        "Production Browser",
+        "Signals",
+        "Open derived object",
+    ]
+    assert [section["id"] for section in payload["compiled_sections"]] == [
+        "current_state",
+        "inbound_capture",
+        "evidence_traceability",
+        "production_chain",
+        "where_to_go_next",
+    ]
 
 
 def test_build_search_payload_preserves_requested_pack(temp_vault):
@@ -2673,3 +2762,5 @@ date: 2026-04-13
     assert [item["slug"] for item in payload["production_chain"]["deep_dives"]] == ["harness-deep-dive"]
     assert [item["path"] for item in payload["production_chain"]["source_notes"]] == ["50-Inbox/03-Processed/2026-04/Harness.md"]
     assert [item["slug"] for item in payload["production_chain"]["atlas_pages"]] == ["atlas-index"]
+    assert payload["production_chain"]["chain_status"] == "complete"
+    assert payload["production_chain"]["missing_stages"] == []


### PR DESCRIPTION
## What changed
This PR lands the next four local-workbench slices as one coherent product increment:

- Phase 20: semantic trust and production traceability
- Phase 21: product shell and operator UX
- Phase 22: active signal impact accounting
- Phase 23: inbound capture audit visibility

Concretely, it:

- hardens event and contradiction semantics on the product surface
- makes note/object/topic/production chain traceability legible as compiled sections
- upgrades the shell with workflow IA and consistent `Next Actions`
- gives signals/actions/briefing a shared lifecycle and impact vocabulary
- adds deterministic inbound-capture summaries from existing pipeline/refine logs
- spends those capture summaries on note, signal, and briefing surfaces
- updates the milestone/phase docs and verify checklist to match the shipped behavior

## Why it changed
After Phase 19, the biggest remaining product gap was not more infrastructure. It was trust and legibility:

- could users trust what event/contradiction pages meant?
- could they trace where knowledge came from and what it produced?
- could they see whether the signal loop was actually productive?
- could they tell what inbound note capture did before queue execution mattered?

These four phases close that gap without widening into temporal truth, harness memory, or opaque background automation.

## User and developer impact
Users now get:

- clearer event/contradiction semantics
- traceable production-chain views on note/object/topic/production pages
- a more navigable operator shell
- signal/action/briefing pages that explain lifecycle and impact directly
- note and signal surfaces that expose what inbound capture actually detected or produced

Developers now get:

- tighter UI/view-model/truth-api contracts for trust and signal-loop visibility
- explicit phase plans and updated milestone guidance for what comes next
- focused tests that lock the new semantics and product behavior

## Root cause
The previous workbench could inspect current state, but too much of the meaning still lived in implementation details:

- semantic trust was implied rather than explicit
- production traceability existed, but was thin
- signal execution state existed, but product-level impact was weak
- inbound capture lived in logs, not in the workbench

This PR moves those concerns into stable product contracts and rendered surfaces.

## Validation
Ran in a clean worktree from `origin/main`:

```bash
python3.11 -m py_compile src/openclaw_pipeline/truth_api.py src/openclaw_pipeline/ui/view_models.py src/openclaw_pipeline/commands/ui_server.py
PYTHONPATH=src pytest -q tests/test_truth_api.py tests/test_ui_view_models.py tests/test_ui_server.py
```

Result: `216 passed in 41.14s`
