### PR TITLE
[codex] Add observable runtime run ledger

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,10 +321,14 @@ interpretation
 |---|---|
 | `ovp --check` | 检查运行环境 |
 | `ovp --full` | 完整日常流水线 |
+| `ovp --incremental` | 日常增量流水线（包含近期 Pinboard + Clippings + 后续步骤） |
 | `ovp --full --with-refine` | 完整流水线 + cleanup/breakdown |
 | `ovp --step absorb` | 单独跑吸收层 |
 | `ovp --step refine` | 单独跑批处理整形 |
 | `ovp --from-step absorb` | 从吸收层之后继续跑 |
+
+`ovp --incremental` 是推荐的日常入口。
+它和 `ovp --from-step clippings` 不同：前者会先跑 `pinboard -> pinboard_process`，后者会显式跳过 Pinboard。
 
 ### 内容处理
 

--- a/docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
+++ b/docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
@@ -345,14 +345,14 @@ Current slice:
 - review-action-derived change signals for contradiction resolution and summary rebuild,
 - extraction-trigger signals for missing deep dives and missing downstream objects,
 - briefing-ready snapshot payloads over recent signals, unresolved issues, changed objects, and active topics.
-- `Phase 22` landed active signal impact accounting across `/signals`, `/actions`, and `/briefing`
-- `Phase 23` landed inbound-capture audit visibility for notes, signals, and briefing surfaces
-- `Phase 25` now hardens the runtime itself with:
+- [[2026-04-17-phase22-active-signal-impact-accounting|Phase 22]] landed active signal impact accounting across `/signals`, `/actions`, and `/briefing`
+- [[2026-04-18-phase23-inbound-capture-audit-visibility|Phase 23]] landed inbound-capture audit visibility for notes, signals, and briefing surfaces
+- [[2026-04-18-phase25-observable-runtime-and-run-ledger|Phase 25]] now hardens the runtime itself with:
   - canonical run-ledger state
   - watcher/API/UI reader unification
   - counted progress for `pinboard_process` and `absorb`
   - explicit stale-run classification
-- `Phase 25` is now complete:
+- [[2026-04-18-phase25-observable-runtime-and-run-ledger|Phase 25]] is now complete:
   - real local `ovp --incremental` validation confirmed the same active run and counted progress in:
     - `watch_progress`
     - `/api/runtime`
@@ -361,7 +361,7 @@ Current slice:
 
 Next slice:
 
-- `Phase 24: brain-first lookup + backlink legibility`
+- [[2026-04-18-phase24-brain-first-lookup-and-backlink-legibility|Phase 24: brain-first lookup + backlink legibility]]
 - This is no longer gated on runtime validation.
 
 ### Milestone 8: Knowledge Evolution Layer

--- a/docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
+++ b/docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
@@ -345,6 +345,24 @@ Current slice:
 - review-action-derived change signals for contradiction resolution and summary rebuild,
 - extraction-trigger signals for missing deep dives and missing downstream objects,
 - briefing-ready snapshot payloads over recent signals, unresolved issues, changed objects, and active topics.
+- `Phase 22` landed active signal impact accounting across `/signals`, `/actions`, and `/briefing`
+- `Phase 23` landed inbound-capture audit visibility for notes, signals, and briefing surfaces
+- `Phase 25` now hardens the runtime itself with:
+  - canonical run-ledger state
+  - watcher/API/UI reader unification
+  - counted progress for `pinboard_process` and `absorb`
+  - explicit stale-run classification
+- `Phase 25` is now complete:
+  - real local `ovp --incremental` validation confirmed the same active run and counted progress in:
+    - `watch_progress`
+    - `/api/runtime`
+    - `/`
+  - `/` now uses a runtime-first home shell so current workflow visibility stays fast during live runs
+
+Next slice:
+
+- `Phase 24: brain-first lookup + backlink legibility`
+- This is no longer gated on runtime validation.
 
 ### Milestone 8: Knowledge Evolution Layer
 

--- a/docs/plans/2026-04-18-phase24-brain-first-lookup-and-backlink-legibility.md
+++ b/docs/plans/2026-04-18-phase24-brain-first-lookup-and-backlink-legibility.md
@@ -1,0 +1,24 @@
+# Phase 24: Brain-First Lookup And Backlink Legibility
+
+> **Status:** Planned, gated on Phase 25 runtime validation
+
+## Goal
+
+Make new object/link creation more conservative and more legible by forcing the system to search existing vault truth before creating downstream knowledge, and by making the resulting backlink/candidate decisions obvious to operators.
+
+## Why It Is Gated
+
+This phase remains valuable, but it should not proceed on top of a black-box runtime.
+
+`Phase 25` now establishes:
+
+- one canonical run ledger,
+- honest counted progress,
+- stale-run separation,
+- unified watcher/API/UI runtime truth.
+
+Only after that runtime contract is validated against a real `ovp --incremental` run should the project continue into:
+
+- brain-first lookup before object creation,
+- backlink legibility,
+- candidate vs canonical downstream boundary improvements.

--- a/docs/plans/2026-04-18-phase24-brain-first-lookup-and-backlink-legibility.md
+++ b/docs/plans/2026-04-18-phase24-brain-first-lookup-and-backlink-legibility.md
@@ -1,23 +1,23 @@
 # Phase 24: Brain-First Lookup And Backlink Legibility
 
-> **Status:** Planned, gated on Phase 25 runtime validation
+> **Status:** Planned, ready after Phase 25 runtime validation
 
 ## Goal
 
 Make new object/link creation more conservative and more legible by forcing the system to search existing vault truth before creating downstream knowledge, and by making the resulting backlink/candidate decisions obvious to operators.
 
-## Why It Is Gated
+## Why This Follows Phase 25
 
 This phase remains valuable, but it should not proceed on top of a black-box runtime.
 
-`Phase 25` now establishes:
+[[2026-04-18-phase25-observable-runtime-and-run-ledger|Phase 25]] now establishes:
 
 - one canonical run ledger,
 - honest counted progress,
 - stale-run separation,
 - unified watcher/API/UI runtime truth.
 
-Only after that runtime contract is validated against a real `ovp --incremental` run should the project continue into:
+That runtime contract has been validated against a real `ovp --incremental` run, so this phase can continue into:
 
 - brain-first lookup before object creation,
 - backlink legibility,

--- a/docs/plans/2026-04-18-phase25-observable-runtime-and-run-ledger.md
+++ b/docs/plans/2026-04-18-phase25-observable-runtime-and-run-ledger.md
@@ -1,0 +1,88 @@
+# Phase 25: Observable Runtime And Run Ledger
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the current black-box pipeline feel with one canonical run ledger that answers "what is happening now?" for operators, while keeping `pipeline.jsonl` as the append-only evidence stream.
+
+**Status:** Complete
+
+## What Landed
+
+- `txn.py`
+  - canonical `run_ledger` contract
+  - active vs stale classification
+  - current-step progress fields
+  - heartbeat support
+- `unified_pipeline_enhanced.py`
+  - transaction start now records pack/profile/planned steps
+  - `run_command(...)` heartbeats during long subprocess stages
+  - short timeouts no longer get swallowed by a fixed 5-second poll interval
+  - `pinboard_process` now exposes counted file progress and file-level events
+  - `absorb` now runs as a direct workflow with counted per-file progress instead of a subprocess black box
+  - CLI now exposes `ovp --incremental` as the explicit daily entrypoint
+- `auto_evergreen_extractor.py`
+  - absorb workflow now reports per-file progress callbacks
+  - recent-mode target collection is unique and ordered
+- operator readers now consume the same runtime truth:
+  - `watch_progress`
+  - `truth_api.get_runtime_status(...)`
+  - dashboard payload/runtime API
+  - root UI shell `Current Workflow` card
+
+## What This Changes For Operators
+
+Operators no longer need to stitch together:
+
+- transaction JSON
+- `pipeline.jsonl`
+- `ps`
+- ad hoc watcher heuristics
+
+to infer current workflow state.
+
+The canonical run ledger now answers:
+
+1. what run is active,
+2. which step is active,
+3. whether the run is stale,
+4. counted progress when the denominator is real,
+5. which item is being processed now,
+6. what the last meaningful event was.
+
+## Real Validation
+
+This phase was closed only after synthetic tests **and** a real local incremental run.
+
+Validated command:
+
+```bash
+ovp --incremental --pack research-tech --vault-dir /Users/chris/Documents/openclaw-vault
+```
+
+Verified during the live run:
+
+- `watch_progress`
+- `/api/runtime`
+- `/`
+
+all reported the same active run and progress state for:
+
+- `run_id = pipeline-20260418-081131-ca15f0f3`
+- `current_step = pinboard_process`
+- `progress_summary = 8/29 files processed`
+- `current_item = 2026-04-12_NousResearch_hermes-agent-self.md`
+
+The root shell also had to be hardened during validation:
+
+- `/api/runtime` was already fast and correct
+- `/` was too heavy for a live operator workflow, so the home shell was switched to a runtime-first payload
+- the heavier full dashboard contract remains available in code, but the default home route now prioritizes current workflow truth over expensive aggregate surfaces
+
+## Verification
+
+- `PYTHONPATH=src pytest -q`
+  - `620 passed`
+- real-vault runtime validation:
+  - `watch_progress` showed active txn, counted progress, current item, and stale-run count from the canonical run ledger
+  - `/api/runtime` returned the same active run and step progress
+  - `/` rendered the same run id and progress in under a second using the runtime-first home shell

--- a/docs/plans/2026-04-18-phase25-observable-runtime-and-run-ledger.md
+++ b/docs/plans/2026-04-18-phase25-observable-runtime-and-run-ledger.md
@@ -6,6 +6,8 @@
 
 **Status:** Complete
 
+Related: [[2026-04-14-local-knowledge-workbench-milestone|Local Knowledge Workbench Milestone]], [[2026-04-18-phase24-brain-first-lookup-and-backlink-legibility|Phase 24]], [[2026-04-17-phase22-active-signal-impact-accounting|Phase 22]]
+
 ## What Landed
 
 - `txn.py`
@@ -56,7 +58,7 @@ This phase was closed only after synthetic tests **and** a real local incrementa
 Validated command:
 
 ```bash
-ovp --incremental --pack research-tech --vault-dir /Users/chris/Documents/openclaw-vault
+ovp --incremental --pack research-tech --vault-dir /path/to/vault
 ```
 
 Verified during the live run:

--- a/docs/recipes/research-tech/clippings.md
+++ b/docs/recipes/research-tech/clippings.md
@@ -10,6 +10,17 @@ Move new clipping sources into the normal `research-tech` interpretation and abs
 ovp --full --pack research-tech --from-step clippings --batch-size 25
 ```
 
+## Scope Note
+
+This recipe intentionally skips `pinboard` and `pinboard_process`.
+
+Use it only when you want to continue from local clipping sources already present in the vault.
+For the normal daily incremental run that also pulls recent Pinboard bookmarks, use:
+
+```bash
+ovp --incremental --pack research-tech --batch-size 25
+```
+
 ## Verify
 
 Check that:

--- a/docs/recipes/research-tech/pinboard.md
+++ b/docs/recipes/research-tech/pinboard.md
@@ -7,7 +7,7 @@ Run the `research-tech` pack from fresh Pinboard source items through the full w
 ## Command
 
 ```bash
-ovp --full --pack research-tech --batch-size 25
+ovp --incremental --pack research-tech --batch-size 25
 ```
 
 ## Verify

--- a/docs/recipes/research-tech/pinboard.md
+++ b/docs/recipes/research-tech/pinboard.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Run the `research-tech` pack from fresh Pinboard source items through the full workflow.
+Run the `research-tech` pack from fresh Pinboard source items through the daily incremental workflow.
 
 ## Command
 

--- a/docs/research-tech/RESEARCH_TECH_VERIFY.md
+++ b/docs/research-tech/RESEARCH_TECH_VERIFY.md
@@ -8,10 +8,15 @@ Use this checklist when validating the primary `research-tech` pack.
 ovp-packs --json
 ovp-doctor --pack research-tech --json
 ovp-truth objects --vault-dir /path/to/vault
-ovp-ui --vault-dir /path/to/vault --port 8787
 python3 -m openclaw_pipeline.commands.watch_progress --vault-dir /path/to/vault --once
 ovp --help
 ovp-autopilot --help
+```
+
+Start the UI server in a separate terminal before browser or `/api/runtime` checks:
+
+```bash
+ovp-ui --vault-dir /path/to/vault --port 8787
 ```
 
 Expected:
@@ -48,10 +53,16 @@ ovp --incremental --pack research-tech --vault-dir /path/to/vault
 While it is running, inspect the same run through all three operator readers:
 
 ```bash
+# Terminal A, keep running:
+ovp-ui --vault-dir /path/to/vault --port 8787
+
+# Terminal B:
 python3 -m openclaw_pipeline.commands.watch_progress --vault-dir /path/to/vault --once
 curl -s http://127.0.0.1:8787/api/runtime | jq
 open http://127.0.0.1:8787/
 ```
+
+`curl /api/runtime` and the root page require `ovp-ui` to be running in Terminal A.
 
 Expected:
 

--- a/docs/research-tech/RESEARCH_TECH_VERIFY.md
+++ b/docs/research-tech/RESEARCH_TECH_VERIFY.md
@@ -9,6 +9,7 @@ ovp-packs --json
 ovp-doctor --pack research-tech --json
 ovp-truth objects --vault-dir /path/to/vault
 ovp-ui --vault-dir /path/to/vault --port 8787
+python3 -m openclaw_pipeline.commands.watch_progress --vault-dir /path/to/vault --once
 ovp --help
 ovp-autopilot --help
 ```
@@ -20,6 +21,7 @@ Expected:
 - default workflow pack is `research-tech`
 - `ovp-truth` can read object rows directly from `knowledge.db`
 - `ovp-ui` starts a local DB-backed browser surface
+- `watch_progress --once` reports one canonical runtime view instead of forcing operator inference from `ps` + JSONL
 
 ## Test Checks
 
@@ -34,6 +36,46 @@ Expected:
 - pack-level e2e stays green
 - orchestrated runtime e2e stays green
 - full suite stays green under Python 3.13
+
+## Incremental Runtime Checks
+
+Run the real daily entrypoint:
+
+```bash
+ovp --incremental --pack research-tech --vault-dir /path/to/vault
+```
+
+While it is running, inspect the same run through all three operator readers:
+
+```bash
+python3 -m openclaw_pipeline.commands.watch_progress --vault-dir /path/to/vault --once
+curl -s http://127.0.0.1:8787/api/runtime | jq
+open http://127.0.0.1:8787/
+```
+
+Expected:
+
+- `ovp --incremental` includes:
+  - `pinboard`
+  - `pinboard_process`
+  - `clippings`
+  - `articles`
+  - `quality`
+  - `fix_links`
+  - `absorb`
+  - `registry_sync`
+  - `moc`
+  - `knowledge_index`
+- `watch_progress`, `/api/runtime`, and `/` agree on the same active run id
+- `watch_progress`, `/api/runtime`, and `/` agree on the same:
+  - current step
+  - current item
+  - progress summary
+- counted stages expose a real denominator rather than a phase-count guess
+- stale runs are reported separately from the active run
+- `/` shows a `Current Workflow` card with the same progress summary as `/api/runtime`
+- `pinboard_process` shows counted file progress
+- `absorb` shows counted deep-dive progress with a live current item
 
 ## Vault Checks
 

--- a/progress.md
+++ b/progress.md
@@ -33,7 +33,7 @@
   - Switched the local editable install to the `phase25-observable-runtime-run-ledger` worktree
   - Stopped the legacy black-box local run that had lost transaction truth but was still burning CPU
   - Repaired historical stuck transactions with `ovp-repair --transactions --write`
-  - Ran a real local `ovp --incremental` validation on `/Users/chris/Documents/openclaw-vault`
+  - Ran a real local `ovp --incremental` validation on `{LOCAL_VAULT_PATH}`
   - Verified that `watch_progress`, `/api/runtime`, and `/` all reported the same active run and counted progress during the live run
 - Files created/modified:
   - docs/plans/2026-04-18-phase25-observable-runtime-and-run-ledger.md

--- a/progress.md
+++ b/progress.md
@@ -2,6 +2,71 @@
 
 ## Session: 2026-04-18
 
+### Phase 25: Observable Runtime And Run Ledger
+- **Status:** complete
+- Actions taken:
+  - Added a canonical `run_ledger` contract in `txn.py`
+  - Added active/stale run classification with heartbeat semantics
+  - Upgraded `TransactionManager` start/step/heartbeat/complete/fail paths to preserve the ledger
+  - Unified watcher/API/UI runtime readers over the same ledger:
+    - `watch_progress`
+    - `truth_api.get_runtime_status(...)`
+    - dashboard payload
+    - `/api/runtime`
+    - root-shell `Current Workflow`
+  - Made `absorb` observable with real counted file progress by switching the qualified-file path to direct workflow execution plus per-file callbacks
+  - Made `pinboard_process` observable with counted file progress and file-level evidence events
+  - Fixed `run_command(...)` timeout polling so short timeouts fail honestly instead of being swallowed by a 5-second sleep
+  - Added the explicit daily entrypoint `ovp --incremental` so normal incremental runs include:
+    - `pinboard`
+    - `pinboard_process`
+    - `clippings`
+    - `articles`
+    - `quality`
+    - `fix_links`
+    - `absorb`
+    - `registry_sync`
+    - `moc`
+    - `knowledge_index`
+  - Updated README, recipe docs, verify checklist, and roadmap docs so operator guidance matches the new runtime contract
+  - Added a runtime-first home shell for `/` so live operator visibility no longer depends on rebuilding every heavy dashboard surface during an active run
+  - Switched the local editable install to the `phase25-observable-runtime-run-ledger` worktree
+  - Stopped the legacy black-box local run that had lost transaction truth but was still burning CPU
+  - Repaired historical stuck transactions with `ovp-repair --transactions --write`
+  - Ran a real local `ovp --incremental` validation on `/Users/chris/Documents/openclaw-vault`
+  - Verified that `watch_progress`, `/api/runtime`, and `/` all reported the same active run and counted progress during the live run
+- Files created/modified:
+  - docs/plans/2026-04-18-phase25-observable-runtime-and-run-ledger.md
+  - docs/plans/2026-04-18-phase24-brain-first-lookup-and-backlink-legibility.md
+  - docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
+  - docs/research-tech/RESEARCH_TECH_VERIFY.md
+  - docs/recipes/research-tech/pinboard.md
+  - docs/recipes/research-tech/clippings.md
+  - README.md
+  - src/openclaw_pipeline/txn.py
+  - src/openclaw_pipeline/unified_pipeline_enhanced.py
+  - src/openclaw_pipeline/auto_evergreen_extractor.py
+  - src/openclaw_pipeline/commands/watch_progress.py
+  - src/openclaw_pipeline/truth_api.py
+  - src/openclaw_pipeline/ui/view_models.py
+  - src/openclaw_pipeline/commands/ui_server.py
+  - tests/test_txn_runtime_ledger.py
+  - tests/test_runtime_paths.py
+  - tests/test_watch_progress_command.py
+  - tests/test_truth_api.py
+  - tests/test_ui_view_models.py
+  - tests/test_ui_server.py
+  - tests/test_export_command.py
+  - tests/test_promote_candidates.py
+  - tests/test_ui_smoke.py
+- Verification:
+  - `PYTHONPATH=src pytest -q`
+  - `620 passed in 58.93s`
+  - real runtime validation confirmed:
+    - `run_id = pipeline-20260418-081131-ca15f0f3`
+    - `current_step = pinboard_process`
+    - counted progress visible in all operator surfaces
+
 ### Phase 23: Inbound Capture Audit Visibility
 - **Status:** complete
 - Actions taken:

--- a/src/openclaw_pipeline/auto_evergreen_extractor.py
+++ b/src/openclaw_pipeline/auto_evergreen_extractor.py
@@ -23,7 +23,7 @@ import json
 import os
 import re
 import sys
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Callable
 
@@ -551,17 +551,32 @@ def _collect_absorb_targets(
             return []
         return sorted(directory.glob("*_深度解读.md"))
     if recent:
-        areas = ["AI-Research", "Tools", "Investing", "Programming"]
+        areas_root = layout.vault_dir / "20-Areas"
+        area_dirs = (
+            sorted(path for path in areas_root.iterdir() if path.is_dir() and (path / "Topics").exists())
+            if areas_root.exists()
+            else []
+        )
+        now = datetime.now(timezone.utc)
+        cutoff = now - timedelta(days=recent)
+        month_names = {
+            (now - timedelta(days=days_ago)).strftime("%Y-%m")
+            for days_ago in range(recent)
+        }
         ordered: list[Path] = []
         seen: set[str] = set()
-        for area in areas:
-            for days_ago in range(recent):
-                month_dir = layout.vault_dir / "20-Areas" / area / "Topics" / (
-                    datetime.now() - __import__("datetime").timedelta(days=days_ago)
-                ).strftime("%Y-%m")
+        for area_dir in area_dirs:
+            for month_name in sorted(month_names):
+                month_dir = area_dir / "Topics" / month_name
                 if not month_dir.exists():
                     continue
                 for candidate in sorted(month_dir.glob("*_深度解读.md")):
+                    try:
+                        modified_at = datetime.fromtimestamp(candidate.stat().st_mtime, tz=timezone.utc)
+                    except OSError:
+                        continue
+                    if modified_at < cutoff:
+                        continue
                     key = str(candidate.resolve())
                     if key in seen:
                         continue

--- a/src/openclaw_pipeline/auto_evergreen_extractor.py
+++ b/src/openclaw_pipeline/auto_evergreen_extractor.py
@@ -25,7 +25,7 @@ import re
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 try:
     from .runtime import VaultLayout, resolve_vault_dir
@@ -537,6 +537,40 @@ def build_extraction_summary(
     }
 
 
+def _collect_absorb_targets(
+    layout: VaultLayout,
+    *,
+    file_path: Path | None = None,
+    directory: Path | None = None,
+    recent: int | None = None,
+) -> list[Path]:
+    if file_path:
+        return [file_path]
+    if directory:
+        if not directory.exists():
+            return []
+        return sorted(directory.glob("*_深度解读.md"))
+    if recent:
+        areas = ["AI-Research", "Tools", "Investing", "Programming"]
+        ordered: list[Path] = []
+        seen: set[str] = set()
+        for area in areas:
+            for days_ago in range(recent):
+                month_dir = layout.vault_dir / "20-Areas" / area / "Topics" / (
+                    datetime.now() - __import__("datetime").timedelta(days=days_ago)
+                ).strftime("%Y-%m")
+                if not month_dir.exists():
+                    continue
+                for candidate in sorted(month_dir.glob("*_深度解读.md")):
+                    key = str(candidate.resolve())
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    ordered.append(candidate)
+        return ordered
+    raise ValueError("one of file_path, directory, or recent must be provided")
+
+
 def run_absorb_workflow(
     vault_dir: Path,
     *,
@@ -549,6 +583,7 @@ def run_absorb_workflow(
     api_key: str | None = None,
     api_base: str | None = None,
     verbose: bool = False,
+    progress_callback: Callable[[dict[str, Any]], None] | None = None,
 ) -> dict[str, Any]:
     layout = VaultLayout.from_vault(vault_dir)
     load_env_file(layout.vault_dir)
@@ -559,47 +594,82 @@ def run_absorb_workflow(
     if verbose:
         print("✓ LLM Client initialized")
 
-    if directory:
-        if verbose:
-            print(f"\nProcessing directory: {directory}")
+    if directory and progress_callback is None and hasattr(extractor, "process_directory"):
         results = extractor.process_directory(
             directory,
             dry_run=dry_run,
             auto_promote=auto_promote,
             promote_threshold=promote_threshold,
         )
-    elif file_path:
+        payload = build_extraction_summary(
+            results,
+            dry_run=dry_run,
+            auto_promote=auto_promote,
+            promote_threshold=promote_threshold,
+            source_scope={
+                "file": str(file_path) if file_path else None,
+                "dir": str(directory) if directory else None,
+                "recent": recent,
+            },
+        )
+        logger.log(
+            "evergreen_extraction_complete",
+            {
+                **payload["summary"],
+                "auto_promote": auto_promote,
+                "dry_run": dry_run,
+                **payload["source_scope"],
+            },
+        )
+        return payload
+
+    targets = _collect_absorb_targets(
+        layout,
+        file_path=file_path,
+        directory=directory,
+        recent=recent,
+    )
+
+    if verbose and directory:
+        print(f"\nProcessing directory: {directory}")
+    elif verbose and file_path:
+        print(f"\nProcessing file: {file_path}")
+    elif verbose and recent:
+        print(f"\nProcessing recent deep dives: {recent} day window")
+
+    results: list[dict[str, Any]] = []
+    files_failed = 0
+    for index, target in enumerate(targets, start=1):
         if verbose:
-            print(f"\nProcessing file: {file_path}")
-        results = [
-            extractor.process_file(
-                file_path,
-                dry_run=dry_run,
-                auto_promote=auto_promote,
-                promote_threshold=promote_threshold,
+            print(f"  Processing: {target.name}")
+        result = extractor.process_file(
+            target,
+            dry_run=dry_run,
+            auto_promote=auto_promote,
+            promote_threshold=promote_threshold,
+        )
+        results.append(result)
+        if result.get("error"):
+            files_failed += 1
+        if verbose:
+            print(
+                f"    Extracted: {result['concepts_extracted']}, "
+                f"Candidates: {result['candidates_added']}, "
+                f"Promoted: {result.get('concepts_promoted', 0)}, "
+                f"Skipped: {result['concepts_skipped']}"
             )
-        ]
-    elif recent:
-        areas = ["AI-Research", "Tools", "Investing", "Programming"]
-        results = []
-        for area in areas:
-            for days_ago in range(recent):
-                date_dir = layout.vault_dir / "20-Areas" / area / "Topics" / (
-                    datetime.now() - __import__("datetime").timedelta(days=days_ago)
-                ).strftime("%Y-%m")
-                if date_dir.exists():
-                    if verbose:
-                        print(f"\nProcessing {area} - {date_dir.name}...")
-                    results.extend(
-                        extractor.process_directory(
-                            date_dir,
-                            dry_run=dry_run,
-                            auto_promote=auto_promote,
-                            promote_threshold=promote_threshold,
-                        )
-                    )
-    else:
-        raise ValueError("one of file_path, directory, or recent must be provided")
+        if progress_callback is not None:
+            progress_callback(
+                {
+                    "event_type": "absorb_file_processed",
+                    "file": target.name,
+                    "current_item": target.name,
+                    "files_total": len(targets),
+                    "files_done": index,
+                    "files_failed": files_failed,
+                    "result": result,
+                }
+            )
 
     payload = build_extraction_summary(
         results,

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -34,16 +34,17 @@ from ..ui.view_models import (
     build_object_page_payload,
     build_objects_index_payload,
     build_production_browser_payload,
+    build_runtime_home_payload,
     build_search_payload,
     build_signal_browser_payload,
     build_stale_summary_browser_payload,
-    build_truth_dashboard_payload,
     build_topic_overview_payload,
 )
 from ..truth_api import (
     dismiss_action_queue_item,
     enqueue_signal_action,
     ensure_signal_ledger_synced,
+    get_runtime_status,
     record_review_action,
     retry_action_queue_item,
     review_evolution_candidate,
@@ -312,6 +313,47 @@ def _render_governance_contract_card(payload: dict) -> str:
     return (
         f"<section class='card'><h2>Governance Contract</h2><p class='muted'>{detail}</p>"
         f"{description_html}{facts_html}</section>"
+    )
+
+
+def _render_runtime_card(runtime: dict[str, object] | None) -> str:
+    if not isinstance(runtime, dict):
+        return ""
+    active_run = runtime.get("active_run")
+    stale_count = int(runtime.get("stale_count") or 0)
+    if not isinstance(active_run, dict):
+        detail = "No active workflow is currently recorded in the canonical run ledger."
+        stale_html = (
+            f"<p class='muted'>{stale_count} stale run(s) remain in the ledger and need operator cleanup.</p>"
+            if stale_count
+            else ""
+        )
+        return f"<section class='card'><h2>Current Workflow</h2><p class='muted'>{detail}</p>{stale_html}</section>"
+
+    ledger = active_run.get("run_ledger") if isinstance(active_run.get("run_ledger"), dict) else {}
+    current = ledger.get("current_step") if isinstance(ledger.get("current_step"), dict) else {}
+    run_state = str(ledger.get("run_state") or active_run.get("status") or "running")
+    step_name = str(current.get("step_name") or ledger.get("current_step_name") or active_run.get("checkpoint") or "")
+    progress_summary = str(current.get("progress_summary") or "Progress is currently indeterminate.")
+    current_item = str(current.get("current_item") or "").strip()
+    heartbeat_at = str(ledger.get("heartbeat_at") or active_run.get("last_updated") or "")
+    facts = [
+        f"<li>Run: {escape(str(active_run.get('id') or ''))}</li>",
+        f"<li>State: {escape(run_state)}</li>",
+    ]
+    if step_name:
+        facts.append(f"<li>Step: {escape(step_name)}</li>")
+    if heartbeat_at:
+        facts.append(f"<li>Heartbeat: {escape(heartbeat_at)}</li>")
+    if stale_count:
+        facts.append(f"<li>Stale runs: {stale_count}</li>")
+    current_item_html = f"<p class='muted'>Current item: {escape(current_item)}</p>" if current_item else ""
+    return (
+        "<section class='card'><h2>Current Workflow</h2>"
+        f"<p class='muted'>{escape(progress_summary)}</p>"
+        f"{current_item_html}"
+        f"<ul class='list-tight'>{''.join(facts)}</ul>"
+        "</section>"
     )
 
 
@@ -1130,6 +1172,7 @@ def _render_workflow_groups(groups: list[dict[str, object]]) -> str:
 
 def _render_dashboard(payload: dict) -> str:
     requested_pack = payload.get("requested_pack", "")
+    runtime_card = _render_runtime_card(payload.get("runtime"))
     research_overview = payload.get("research_overview", {})
     research_overview_supported = research_overview.get("status") == "supported"
     orientation = payload.get("orientation", {})
@@ -1248,6 +1291,7 @@ def _render_dashboard(payload: dict) -> str:
             "<section class='section-stack'>",
             "<section class='card'><h2>Workflow Map</h2><p class='muted'>Start here if you do not yet know which route to open. Each group maps one common operator workflow onto the current shell.</p></section>",
             workflow_groups_html,
+            runtime_card,
             "<section class='card'><h2>Where To Start</h2><p class='muted'>Use the orientation brief and the compiled entry sections below to decide what to read, review, or do next.</p></section>",
             orientation_assembly_contract,
             orientation_governance_contract,
@@ -3002,7 +3046,7 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
             try:
                 if path == "/":
                     pack_name = query.get("pack", [""])[0] or None
-                    payload = build_truth_dashboard_payload(resolved_vault, pack_name=pack_name)
+                    payload = build_runtime_home_payload(resolved_vault, pack_name=pack_name)
                     self._write_html(_render_dashboard(payload))
                     return
                 if path == "/api/objects":
@@ -3019,6 +3063,9 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
                             pack_name=pack_name,
                         )
                     )
+                    return
+                if path == "/api/runtime":
+                    self._write_json(get_runtime_status(resolved_vault))
                     return
                 if path == "/objects":
                     limit = int(query.get("limit", ["100"])[0])

--- a/src/openclaw_pipeline/commands/ui_server.py
+++ b/src/openclaw_pipeline/commands/ui_server.py
@@ -320,7 +320,10 @@ def _render_runtime_card(runtime: dict[str, object] | None) -> str:
     if not isinstance(runtime, dict):
         return ""
     active_run = runtime.get("active_run")
-    stale_count = int(runtime.get("stale_count") or 0)
+    try:
+        stale_count = int(runtime.get("stale_count") or 0)
+    except (TypeError, ValueError):
+        stale_count = 0
     if not isinstance(active_run, dict):
         detail = "No active workflow is currently recorded in the canonical run ledger."
         stale_html = (
@@ -3065,7 +3068,20 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
                     )
                     return
                 if path == "/api/runtime":
-                    self._write_json(get_runtime_status(resolved_vault))
+                    try:
+                        self._write_json(get_runtime_status(resolved_vault))
+                    except (OSError, sqlite3.Error) as exc:
+                        self._write_json(
+                            {
+                                "active_count": 0,
+                                "stale_count": 0,
+                                "active_run": None,
+                                "stale_runs": [],
+                                "error": "runtime_status_unavailable",
+                                "detail": str(exc),
+                            },
+                            status=503,
+                        )
                     return
                 if path == "/objects":
                     limit = int(query.get("limit", ["100"])[0])

--- a/src/openclaw_pipeline/commands/watch_progress.py
+++ b/src/openclaw_pipeline/commands/watch_progress.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from ..runtime import VaultLayout, resolve_vault_dir
+from ..txn import classify_run_ledgers
 
 
 PROCESS_MARKERS = (
@@ -72,29 +73,6 @@ def detect_openclaw_process_lines(vault_dir: Path) -> list[str]:
     return lines
 
 
-def _load_in_progress_transactions(layout: VaultLayout) -> list[dict[str, Any]]:
-    txns: list[dict[str, Any]] = []
-    if not layout.transactions_dir.exists():
-        return txns
-    for txn_file in layout.transactions_dir.glob("*.json"):
-        try:
-            payload = json.loads(txn_file.read_text(encoding="utf-8"))
-        except json.JSONDecodeError:
-            continue
-        if payload.get("status") != "in_progress":
-            continue
-        txns.append(
-            {
-                "id": payload.get("id"),
-                "type": payload.get("type"),
-                "checkpoint": payload.get("checkpoint"),
-                "last_updated": payload.get("last_updated"),
-            }
-        )
-    txns.sort(key=lambda item: item.get("last_updated") or "", reverse=True)
-    return txns
-
-
 def _count_state(layout: VaultLayout) -> dict[str, int]:
     candidates_dir = layout.evergreen_dir / "_Candidates"
     return {
@@ -111,6 +89,9 @@ def _count_state(layout: VaultLayout) -> dict[str, int]:
 def collect_progress_snapshot(vault_dir: Path, process_lines: list[str] | None = None) -> dict[str, Any]:
     layout = VaultLayout.from_vault(vault_dir)
     process_lines = detect_openclaw_process_lines(layout.vault_dir) if process_lines is None else process_lines
+    classified_runs = classify_run_ledgers(layout.transactions_dir)
+    active_runs = classified_runs["active"]
+    stale_runs = classified_runs["stale"]
 
     def _safe_mtime(path: Path) -> float:
         try:
@@ -130,7 +111,9 @@ def collect_progress_snapshot(vault_dir: Path, process_lines: list[str] | None =
         "counts": _count_state(layout),
         "active_processes": len(process_lines),
         "process_lines": process_lines,
-        "active_transactions": _load_in_progress_transactions(layout),
+        "active_transactions": active_runs,
+        "active_run": active_runs[0] if active_runs else None,
+        "stale_transactions": stale_runs,
         "latest_event": _read_last_json_line(layout.pipeline_log),
         "latest_report": str(reports[0]) if reports else None,
     }
@@ -173,8 +156,17 @@ def format_progress_snapshot(snapshot: dict[str, Any], previous: dict[str, Any] 
             "Active txn: "
             f"{txn.get('id')} type={txn.get('type')} checkpoint={txn.get('checkpoint')} updated={txn.get('last_updated')}"
         )
+        ledger = txn.get("run_ledger") or {}
+        current = ledger.get("current_step") or {}
+        progress_summary = current.get("progress_summary")
+        if progress_summary:
+            lines.append(f"Step progress: {progress_summary}")
+        current_item = current.get("current_item")
+        if current_item:
+            lines.append(f"Current item: {current_item}")
     else:
         lines.append("Active txn: none")
+    lines.append(f"Stale txns: {len(snapshot.get('stale_transactions', []))}")
     latest_event = snapshot.get("latest_event")
     if latest_event:
         event_bits = [

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -31,6 +31,7 @@ from .runtime import (
     resolve_vault_dir,
     signal_ledger_write_lock,
 )
+from .txn import classify_run_ledgers
 
 MAX_PAGE_SIZE = 500
 _FENCED_FRONTMATTER_RE = re.compile(r"^```ya?ml\s*\n---\n(.*?)\n---\n```\s*\n?", re.DOTALL)
@@ -86,6 +87,23 @@ _BRIEFING_EVOLUTION_PRIORITY = {
     "confirms": 70,
     "enriches": 60,
 }
+
+
+def get_runtime_status(
+    vault_dir: Path | str,
+    *,
+    now_iso: str | None = None,
+) -> dict[str, Any]:
+    resolved_vault = resolve_vault_dir(vault_dir)
+    layout = VaultLayout.from_vault(resolved_vault)
+    classified = classify_run_ledgers(layout.transactions_dir, now_iso=now_iso)
+    return {
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "active_count": len(classified["active"]),
+        "stale_count": len(classified["stale"]),
+        "active_run": classified["active"][0] if classified["active"] else None,
+        "stale_runs": classified["stale"],
+    }
 
 
 def _db_path(vault_dir: Path | str) -> Path:

--- a/src/openclaw_pipeline/truth_api.py
+++ b/src/openclaw_pipeline/truth_api.py
@@ -98,7 +98,7 @@ def get_runtime_status(
     layout = VaultLayout.from_vault(resolved_vault)
     classified = classify_run_ledgers(layout.transactions_dir, now_iso=now_iso)
     return {
-        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "generated_at": now_iso or datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "active_count": len(classified["active"]),
         "stale_count": len(classified["stale"]),
         "active_run": classified["active"][0] if classified["active"] else None,

--- a/src/openclaw_pipeline/txn.py
+++ b/src/openclaw_pipeline/txn.py
@@ -256,7 +256,7 @@ def mark_transaction_completed(payload: dict[str, Any], *, timestamp: str | None
         if current.get("progress_mode") == "counted" and current.get("work_units_total") is not None:
             current["work_units_done"] = current.get("work_units_total")
             current["progress_percent"] = 100.0
-            current["progress_summary"] = progress_summary = _derive_progress_summary(
+            current["progress_summary"] = _derive_progress_summary(
                 progress_mode="counted",
                 work_units_done=current.get("work_units_done"),
                 work_units_total=current.get("work_units_total"),
@@ -334,7 +334,7 @@ def classify_run_ledgers(
     now_iso: str | None = None,
     stale_after_seconds: int = RUN_STALE_AFTER_SECONDS,
 ) -> dict[str, list[dict[str, Any]]]:
-    now = _parse_timestamp(now_iso) if now_iso else datetime.now(timezone.utc)
+    now = (_parse_timestamp(now_iso) if now_iso else None) or datetime.now(timezone.utc)
     active: list[dict[str, Any]] = []
     stale: list[dict[str, Any]] = []
 
@@ -344,7 +344,7 @@ def classify_run_ledgers(
     for txn_file in sorted(transactions_dir.glob("*.json")):
         try:
             payload = json.loads(txn_file.read_text(encoding="utf-8"))
-        except json.JSONDecodeError:
+        except (OSError, json.JSONDecodeError):
             continue
         if payload.get("status") != "in_progress":
             continue
@@ -357,11 +357,13 @@ def classify_run_ledgers(
         ledger["stale"] = is_stale
         (stale if is_stale else active).append(payload)
 
-    key_fn = lambda item: (
-        item.get("run_ledger", {}).get("heartbeat_at")
-        or item.get("last_updated")
-        or ""
-    )
+    def key_fn(item: dict[str, Any]) -> str:
+        return (
+            item.get("run_ledger", {}).get("heartbeat_at")
+            or item.get("last_updated")
+            or ""
+        )
+
     active.sort(key=key_fn, reverse=True)
     stale.sort(key=key_fn, reverse=True)
     return {"active": active, "stale": stale}

--- a/src/openclaw_pipeline/txn.py
+++ b/src/openclaw_pipeline/txn.py
@@ -35,7 +35,10 @@ import json
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
+
+
+RUN_STALE_AFTER_SECONDS = 30 * 60
 
 
 # =============================================================================
@@ -45,6 +48,323 @@ from typing import Literal
 def _get_timestamp() -> str:
     """Get current UTC timestamp in ISO format."""
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_timestamp(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        normalized = value.replace("Z", "+00:00")
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _normalize_step_state(status: str) -> str:
+    return {
+        "pending": "pending",
+        "processing": "running",
+        "in_progress": "running",
+        "completed": "completed",
+        "failed": "failed",
+        "blocked": "blocked",
+    }.get(status, status)
+
+
+def _derive_progress_percent(work_units_done: int | None, work_units_total: int | None) -> float | None:
+    if work_units_total is None or work_units_total <= 0 or work_units_done is None:
+        return None
+    return round((float(work_units_done) / float(work_units_total)) * 100.0, 1)
+
+
+def _derive_progress_summary(
+    *,
+    progress_mode: str,
+    work_units_done: int | None,
+    work_units_total: int | None,
+    work_units_failed: int | None,
+) -> str:
+    if progress_mode != "counted" or work_units_total is None:
+        return "Progress is currently indeterminate."
+    failed = work_units_failed or 0
+    if failed:
+        return f"{work_units_done or 0}/{work_units_total} work units completed, {failed} failed"
+    return f"{work_units_done or 0}/{work_units_total} work units completed"
+
+
+def build_transaction_payload(
+    txn_id: str,
+    workflow_type: str,
+    description: str,
+    *,
+    timestamp: str | None = None,
+    pack_name: str | None = None,
+    workflow_profile: str | None = None,
+    planned_steps: list[str] | None = None,
+) -> dict[str, Any]:
+    ts = timestamp or _get_timestamp()
+    return {
+        "id": txn_id,
+        "type": workflow_type,
+        "description": description,
+        "start_time": ts,
+        "status": "in_progress",
+        "steps": {},
+        "checkpoint": "initialized",
+        "last_updated": ts,
+        "run_ledger": {
+            "run_id": txn_id,
+            "run_state": "running",
+            "workflow_profile": workflow_profile or "",
+            "pack_name": pack_name or "",
+            "planned_steps": planned_steps or [],
+            "started_at": ts,
+            "updated_at": ts,
+            "heartbeat_at": ts,
+            "current_step_name": "initialized",
+            "current_step": {
+                "step_name": "initialized",
+                "step_state": "pending",
+                "step_started_at": ts,
+                "step_heartbeat_at": ts,
+                "progress_mode": "indeterminate",
+                "work_units_total": None,
+                "work_units_done": 0,
+                "work_units_failed": 0,
+                "current_item": None,
+                "progress_percent": None,
+                "progress_summary": "Waiting to start.",
+            },
+            "last_meaningful_event": None,
+            "stale": False,
+            "blocked_reason": None,
+            "error_summary": None,
+        },
+    }
+
+
+def ensure_run_ledger(payload: dict[str, Any]) -> dict[str, Any]:
+    if "run_ledger" in payload:
+        return payload
+    ts = payload.get("start_time") or payload.get("last_updated") or _get_timestamp()
+    payload["run_ledger"] = {
+        "run_id": payload.get("id", ""),
+        "run_state": "completed" if payload.get("status") == "completed" else ("failed" if payload.get("status") == "failed" else "running"),
+        "workflow_profile": "",
+        "pack_name": "",
+        "planned_steps": list(payload.get("steps", {}).keys()),
+        "started_at": ts,
+        "updated_at": payload.get("last_updated", ts),
+        "heartbeat_at": payload.get("last_updated", ts),
+        "current_step_name": payload.get("checkpoint", "initialized"),
+        "current_step": {
+            "step_name": payload.get("checkpoint", "initialized"),
+            "step_state": _normalize_step_state(payload.get("status", "pending")),
+            "step_started_at": ts,
+            "step_heartbeat_at": payload.get("last_updated", ts),
+            "progress_mode": "indeterminate",
+            "work_units_total": None,
+            "work_units_done": 0,
+            "work_units_failed": 0,
+            "current_item": None,
+            "progress_percent": None,
+            "progress_summary": "Progress is currently indeterminate.",
+        },
+        "last_meaningful_event": None,
+        "stale": False,
+        "blocked_reason": None,
+        "error_summary": payload.get("failure_reason"),
+    }
+    return payload
+
+
+def update_transaction_step(
+    payload: dict[str, Any],
+    step_name: str,
+    status: str,
+    *,
+    output: str = "",
+    timestamp: str | None = None,
+    progress_mode: str | None = None,
+    work_units_total: int | None = None,
+    work_units_done: int | None = None,
+    work_units_failed: int | None = None,
+    current_item: str | None = None,
+    progress_summary: str | None = None,
+    last_meaningful_event: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    ensure_run_ledger(payload)
+    ts = timestamp or _get_timestamp()
+
+    payload["steps"][step_name] = {
+        "status": status,
+        "output": output,
+        "updated_at": ts,
+    }
+    payload["checkpoint"] = step_name
+    payload["last_updated"] = ts
+
+    run_ledger = payload["run_ledger"]
+    current = dict(run_ledger.get("current_step") or {})
+    previous_step = current.get("step_name")
+    if previous_step != step_name:
+        current["step_started_at"] = ts
+    current["step_name"] = step_name
+    current["step_state"] = _normalize_step_state(status)
+    current["step_heartbeat_at"] = ts
+    current["progress_mode"] = progress_mode or current.get("progress_mode") or "indeterminate"
+    current["work_units_total"] = work_units_total if work_units_total is not None else current.get("work_units_total")
+    current["work_units_done"] = work_units_done if work_units_done is not None else current.get("work_units_done", 0)
+    current["work_units_failed"] = work_units_failed if work_units_failed is not None else current.get("work_units_failed", 0)
+    current["current_item"] = current_item if current_item is not None else current.get("current_item")
+    current["progress_percent"] = _derive_progress_percent(current.get("work_units_done"), current.get("work_units_total"))
+    current["progress_summary"] = progress_summary or _derive_progress_summary(
+        progress_mode=current.get("progress_mode") or "indeterminate",
+        work_units_done=current.get("work_units_done"),
+        work_units_total=current.get("work_units_total"),
+        work_units_failed=current.get("work_units_failed"),
+    )
+
+    run_ledger["current_step_name"] = step_name
+    run_ledger["current_step"] = current
+    run_ledger["updated_at"] = ts
+    run_ledger["heartbeat_at"] = ts
+    run_ledger["run_state"] = "failed" if status == "failed" else ("completed" if status == "completed" and payload.get("status") == "completed" else "running")
+    run_ledger["stale"] = False
+    run_ledger["error_summary"] = output if status == "failed" and output else run_ledger.get("error_summary")
+    if last_meaningful_event is not None:
+        run_ledger["last_meaningful_event"] = last_meaningful_event
+    return payload
+
+
+def mark_transaction_completed(payload: dict[str, Any], *, timestamp: str | None = None) -> dict[str, Any]:
+    ensure_run_ledger(payload)
+    ts = timestamp or _get_timestamp()
+    payload["status"] = "completed"
+    payload["completed_at"] = ts
+    payload["last_updated"] = ts
+    payload["run_ledger"]["run_state"] = "completed"
+    payload["run_ledger"]["updated_at"] = ts
+    payload["run_ledger"]["heartbeat_at"] = ts
+    current = payload["run_ledger"].get("current_step") or {}
+    if current:
+        current["step_state"] = "completed"
+        current["step_heartbeat_at"] = ts
+        if current.get("progress_mode") == "counted" and current.get("work_units_total") is not None:
+            current["work_units_done"] = current.get("work_units_total")
+            current["progress_percent"] = 100.0
+            current["progress_summary"] = progress_summary = _derive_progress_summary(
+                progress_mode="counted",
+                work_units_done=current.get("work_units_done"),
+                work_units_total=current.get("work_units_total"),
+                work_units_failed=current.get("work_units_failed"),
+            )
+    return payload
+
+
+def mark_transaction_failed(payload: dict[str, Any], reason: str, *, timestamp: str | None = None) -> dict[str, Any]:
+    ensure_run_ledger(payload)
+    ts = timestamp or _get_timestamp()
+    payload["status"] = "failed"
+    payload["failure_reason"] = reason
+    payload["last_updated"] = ts
+    payload["run_ledger"]["run_state"] = "failed"
+    payload["run_ledger"]["error_summary"] = reason
+    payload["run_ledger"]["updated_at"] = ts
+    payload["run_ledger"]["heartbeat_at"] = ts
+    current = payload["run_ledger"].get("current_step") or {}
+    if current:
+        current["step_state"] = "failed"
+        current["step_heartbeat_at"] = ts
+    return payload
+
+
+def heartbeat_transaction(
+    payload: dict[str, Any],
+    *,
+    step_name: str | None = None,
+    timestamp: str | None = None,
+    current_item: str | None = None,
+    work_units_done: int | None = None,
+    work_units_total: int | None = None,
+    work_units_failed: int | None = None,
+    progress_mode: str | None = None,
+    progress_summary: str | None = None,
+    last_meaningful_event: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    ensure_run_ledger(payload)
+    ts = timestamp or _get_timestamp()
+    run_ledger = payload["run_ledger"]
+    current = dict(run_ledger.get("current_step") or {})
+    effective_step = step_name or current.get("step_name") or payload.get("checkpoint") or "initialized"
+    current["step_name"] = effective_step
+    current["step_state"] = current.get("step_state") or "running"
+    current["step_started_at"] = current.get("step_started_at") or ts
+    current["step_heartbeat_at"] = ts
+    current["progress_mode"] = progress_mode or current.get("progress_mode") or "indeterminate"
+    current["work_units_total"] = work_units_total if work_units_total is not None else current.get("work_units_total")
+    current["work_units_done"] = work_units_done if work_units_done is not None else current.get("work_units_done", 0)
+    current["work_units_failed"] = work_units_failed if work_units_failed is not None else current.get("work_units_failed", 0)
+    current["current_item"] = current_item if current_item is not None else current.get("current_item")
+    current["progress_percent"] = _derive_progress_percent(current.get("work_units_done"), current.get("work_units_total"))
+    current["progress_summary"] = progress_summary or current.get("progress_summary") or _derive_progress_summary(
+        progress_mode=current.get("progress_mode") or "indeterminate",
+        work_units_done=current.get("work_units_done"),
+        work_units_total=current.get("work_units_total"),
+        work_units_failed=current.get("work_units_failed"),
+    )
+    run_ledger["current_step_name"] = effective_step
+    run_ledger["current_step"] = current
+    run_ledger["updated_at"] = ts
+    run_ledger["heartbeat_at"] = ts
+    run_ledger["run_state"] = "running"
+    run_ledger["stale"] = False
+    payload["last_updated"] = ts
+    if last_meaningful_event is not None:
+        run_ledger["last_meaningful_event"] = last_meaningful_event
+    return payload
+
+
+def classify_run_ledgers(
+    transactions_dir: Path,
+    *,
+    now_iso: str | None = None,
+    stale_after_seconds: int = RUN_STALE_AFTER_SECONDS,
+) -> dict[str, list[dict[str, Any]]]:
+    now = _parse_timestamp(now_iso) if now_iso else datetime.now(timezone.utc)
+    active: list[dict[str, Any]] = []
+    stale: list[dict[str, Any]] = []
+
+    if not transactions_dir.exists():
+        return {"active": active, "stale": stale}
+
+    for txn_file in sorted(transactions_dir.glob("*.json")):
+        try:
+            payload = json.loads(txn_file.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            continue
+        if payload.get("status") != "in_progress":
+            continue
+        ensure_run_ledger(payload)
+        ledger = payload["run_ledger"]
+        heartbeat = _parse_timestamp(ledger.get("heartbeat_at")) or _parse_timestamp(payload.get("last_updated"))
+        is_stale = False
+        if heartbeat is not None:
+            is_stale = (now - heartbeat).total_seconds() > stale_after_seconds
+        ledger["stale"] = is_stale
+        (stale if is_stale else active).append(payload)
+
+    key_fn = lambda item: (
+        item.get("run_ledger", {}).get("heartbeat_at")
+        or item.get("last_updated")
+        or ""
+    )
+    active.sort(key=key_fn, reverse=True)
+    stale.sort(key=key_fn, reverse=True)
+    return {"active": active, "stale": stale}
 
 
 def _generate_txn_id() -> str:

--- a/src/openclaw_pipeline/txn.py
+++ b/src/openclaw_pipeline/txn.py
@@ -211,7 +211,7 @@ def update_transaction_step(
     current = dict(run_ledger.get("current_step") or {})
     previous_step = current.get("step_name")
     if previous_step != step_name:
-        current["step_started_at"] = ts
+        current = {"step_started_at": ts}
     current["step_name"] = step_name
     current["step_state"] = _normalize_step_state(status)
     current["step_heartbeat_at"] = ts
@@ -300,6 +300,9 @@ def heartbeat_transaction(
     run_ledger = payload["run_ledger"]
     current = dict(run_ledger.get("current_step") or {})
     effective_step = step_name or current.get("step_name") or payload.get("checkpoint") or "initialized"
+    previous_step = current.get("step_name")
+    if previous_step != effective_step:
+        current = {"step_started_at": ts}
     current["step_name"] = effective_step
     current["step_state"] = current.get("step_state") or "running"
     current["step_started_at"] = current.get("step_started_at") or ts

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -29,6 +29,7 @@ from ..truth_api import (
     get_note_traceability,
     get_object_provenance_map,
     get_review_context,
+    get_runtime_status,
     get_topic_neighborhood,
     list_evolution_candidates,
     list_evolution_links,
@@ -99,6 +100,128 @@ def _workflow_group(
         "summary": summary,
         "items": items,
     }
+
+
+def _build_dashboard_workflow_groups(
+    *,
+    requested_pack: str,
+    research_overview_supported: bool,
+) -> list[dict[str, Any]]:
+    return [
+        _workflow_group(
+            "orient",
+            "Orient",
+            "Start with the compiled entry products before diving into individual queues.",
+            [
+                {
+                    "label": "Orientation Brief",
+                    "path": _scoped_path("/briefing", pack_name=requested_pack),
+                    "detail": "Read the current entry product.",
+                },
+                {
+                    "label": "Workbench Home",
+                    "path": _scoped_path("/", pack_name=requested_pack),
+                    "detail": "Return to the current shell overview.",
+                },
+            ],
+        ),
+        _workflow_group(
+            "inspect",
+            "Inspect",
+            "Read the current knowledge state directly from compiled browsing surfaces.",
+            [
+                {
+                    "label": "Objects",
+                    "path": _scoped_path("/objects", pack_name=requested_pack),
+                    "detail": "Browse indexed evergreen objects.",
+                },
+                {
+                    "label": "Search",
+                    "path": _scoped_path("/search", pack_name=requested_pack),
+                    "detail": "Search notes and objects across the shell.",
+                },
+            ],
+        ),
+        _workflow_group(
+            "review",
+            "Review",
+            "Open the highest-signal maintenance surfaces for contradictions, summaries, and signals.",
+            [
+                {
+                    "label": "Signals",
+                    "path": _scoped_path("/signals", pack_name=requested_pack),
+                    "detail": "Review current active signals.",
+                },
+                {
+                    "label": "Contradictions" if research_overview_supported else "Actions",
+                    "path": _scoped_path(
+                        "/contradictions" if research_overview_supported else "/actions",
+                        pack_name=requested_pack,
+                    ),
+                    "detail": (
+                        "Inspect open semantic tensions."
+                        if research_overview_supported
+                        else "Review queued execution actions."
+                    ),
+                },
+            ],
+        ),
+        _workflow_group(
+            "trace",
+            "Trace",
+            "Follow provenance and downstream production chains before editing or reviewing.",
+            [
+                {
+                    "label": "Production",
+                    "path": _scoped_path("/production", pack_name=requested_pack),
+                    "detail": "Inspect production weak points and chain state.",
+                },
+                {
+                    "label": "Deep Dives" if research_overview_supported else "Notes",
+                    "path": _scoped_path(
+                        "/deep-dives" if research_overview_supported else "/objects",
+                        pack_name=requested_pack,
+                    ),
+                    "detail": (
+                        "Follow note -> deep dive -> object derivation."
+                        if research_overview_supported
+                        else "Use object pages as the primary trace surface."
+                    ),
+                },
+            ],
+        ),
+        _workflow_group(
+            "explore",
+            "Explore",
+            "Move through topic, graph, and timeline surfaces once the shell has oriented you.",
+            [
+                {
+                    "label": "Events" if research_overview_supported else "Objects",
+                    "path": _scoped_path(
+                        "/events" if research_overview_supported else "/objects",
+                        pack_name=requested_pack,
+                    ),
+                    "detail": (
+                        "Explore timeline and dossier surfaces."
+                        if research_overview_supported
+                        else "Explore the shared-shell object browser."
+                    ),
+                },
+                {
+                    "label": "Clusters" if research_overview_supported else "Search",
+                    "path": _scoped_path(
+                        "/clusters" if research_overview_supported else "/search",
+                        pack_name=requested_pack,
+                    ),
+                    "detail": (
+                        "Explore graph clusters and higher-order structure."
+                        if research_overview_supported
+                        else "Use search to move laterally through the vault."
+                    ),
+                },
+            ],
+        ),
+    ]
 
 
 def _operator_action(label: str, path: str, detail: str) -> dict[str, str]:
@@ -1564,7 +1687,17 @@ def build_object_page_payload(
         },
         "operator_rail": operator_rail,
         "compiled_sections": compiled_sections,
-        "section_nav": [{"href": "#summary", "label": "Summary"}, *_section_nav_from_compiled_sections(compiled_sections)],
+        "section_nav": [
+            {"href": "#summary", "label": "Summary"},
+            *_section_nav_from_compiled_sections(compiled_sections),
+            {"href": "#claims", "label": "Claims"},
+            {"href": "#relations", "label": "Relations"},
+            *(
+                [{"href": "#contradictions", "label": "Contradictions"}]
+                if research_shell_enabled
+                else []
+            ),
+        ],
     }
 
 
@@ -2707,6 +2840,7 @@ def build_truth_dashboard_payload(
     pack_name: str | None = None,
 ) -> dict[str, Any]:
     requested_pack = pack_name or ""
+    runtime = get_runtime_status(vault_dir)
     objects = build_objects_index_payload(vault_dir, limit=12, offset=0, pack_name=pack_name)
     signals = build_signal_browser_payload(vault_dir, pack_name=pack_name)
     production = build_production_browser_payload(vault_dir, pack_name=pack_name)
@@ -2886,121 +3020,10 @@ def build_truth_dashboard_payload(
             ],
         ),
     ]
-    workflow_groups = [
-        _workflow_group(
-            "orient",
-            "Orient",
-            "Start with the compiled entry products before diving into individual queues.",
-            [
-                {
-                    "label": "Orientation Brief",
-                    "path": _scoped_path("/briefing", pack_name=requested_pack),
-                    "detail": "Read the current entry product.",
-                },
-                {
-                    "label": "Workbench Home",
-                    "path": _scoped_path("/", pack_name=requested_pack),
-                    "detail": "Return to the current shell overview.",
-                },
-            ],
-        ),
-        _workflow_group(
-            "inspect",
-            "Inspect",
-            "Read the current knowledge state directly from compiled browsing surfaces.",
-            [
-                {
-                    "label": "Objects",
-                    "path": _scoped_path("/objects", pack_name=requested_pack),
-                    "detail": "Browse indexed evergreen objects.",
-                },
-                {
-                    "label": "Search",
-                    "path": _scoped_path("/search", pack_name=requested_pack),
-                    "detail": "Search notes and objects across the shell.",
-                },
-            ],
-        ),
-        _workflow_group(
-            "review",
-            "Review",
-            "Open the highest-signal maintenance surfaces for contradictions, summaries, and signals.",
-            [
-                {
-                    "label": "Signals",
-                    "path": _scoped_path("/signals", pack_name=requested_pack),
-                    "detail": "Review current active signals.",
-                },
-                {
-                    "label": "Contradictions" if research_overview_supported else "Actions",
-                    "path": _scoped_path(
-                        "/contradictions" if research_overview_supported else "/actions",
-                        pack_name=requested_pack,
-                    ),
-                    "detail": (
-                        "Inspect open semantic tensions."
-                        if research_overview_supported
-                        else "Review queued execution actions."
-                    ),
-                },
-            ],
-        ),
-        _workflow_group(
-            "trace",
-            "Trace",
-            "Follow provenance and downstream production chains before editing or reviewing.",
-            [
-                {
-                    "label": "Production",
-                    "path": _scoped_path("/production", pack_name=requested_pack),
-                    "detail": "Inspect production weak points and chain state.",
-                },
-                {
-                    "label": "Deep Dives" if research_overview_supported else "Notes",
-                    "path": _scoped_path(
-                        "/deep-dives" if research_overview_supported else "/objects",
-                        pack_name=requested_pack,
-                    ),
-                    "detail": (
-                        "Follow note -> deep dive -> object derivation."
-                        if research_overview_supported
-                        else "Use object pages as the primary trace surface."
-                    ),
-                },
-            ],
-        ),
-        _workflow_group(
-            "explore",
-            "Explore",
-            "Move through topic, graph, and timeline surfaces once the shell has oriented you.",
-            [
-                {
-                    "label": "Events" if research_overview_supported else "Objects",
-                    "path": _scoped_path(
-                        "/events" if research_overview_supported else "/objects",
-                        pack_name=requested_pack,
-                    ),
-                    "detail": (
-                        "Explore timeline and dossier surfaces."
-                        if research_overview_supported
-                        else "Explore the shared-shell object browser."
-                    ),
-                },
-                {
-                    "label": "Clusters" if research_overview_supported else "Search",
-                    "path": _scoped_path(
-                        "/clusters" if research_overview_supported else "/search",
-                        pack_name=requested_pack,
-                    ),
-                    "detail": (
-                        "Explore graph clusters and higher-order structure."
-                        if research_overview_supported
-                        else "Use search to move laterally through the vault."
-                    ),
-                },
-            ],
-        ),
-    ]
+    workflow_groups = _build_dashboard_workflow_groups(
+        requested_pack=requested_pack,
+        research_overview_supported=research_overview_supported,
+    )
     return {
         "screen": "truth/dashboard",
         "requested_pack": requested_pack,
@@ -3048,11 +3071,163 @@ def build_truth_dashboard_payload(
             "items": signals["items"][:8],
             "browser_path": _scoped_path("/signals", pack_name=requested_pack),
         },
+        "runtime": runtime,
         "orientation": orientation,
         "workflow_groups": workflow_groups,
         "entry_sections": entry_sections,
         "recent_review_actions": list_review_actions(vault_dir, limit=8),
         "priorities": priorities[:8],
+    }
+
+
+def build_runtime_home_payload(
+    vault_dir: Path | str,
+    *,
+    pack_name: str | None = None,
+) -> dict[str, Any]:
+    requested_pack = pack_name or ""
+    runtime = get_runtime_status(vault_dir)
+    research_overview_supported = _supports_research_shell(pack_name)
+    objects = build_objects_index_payload(vault_dir, limit=8, offset=0, pack_name=pack_name)
+    active_run = runtime.get("active_run") if isinstance(runtime.get("active_run"), dict) else {}
+    run_ledger = active_run.get("run_ledger") if isinstance(active_run, dict) and isinstance(active_run.get("run_ledger"), dict) else {}
+    current_step = run_ledger.get("current_step") if isinstance(run_ledger.get("current_step"), dict) else {}
+    current_step_name = str(current_step.get("step_name") or run_ledger.get("current_step_name") or active_run.get("checkpoint") or "")
+    progress_summary = str(current_step.get("progress_summary") or "No active workflow is currently recorded in the canonical run ledger.")
+    current_item = str(current_step.get("current_item") or "").strip()
+    entry_sections = [
+        _compiled_section(
+            "current_workflow",
+            "Current Workflow",
+            summary=progress_summary,
+            items=[
+                *(
+                    [
+                        {
+                            "kind": "run",
+                            "label": str(active_run.get("id") or ""),
+                            "path": "",
+                            "detail": f"Step: {current_step_name or 'unknown'}",
+                        }
+                    ]
+                    if active_run
+                    else []
+                ),
+                *(
+                    [
+                        {
+                            "kind": "current_item",
+                            "label": "Current item",
+                            "path": "",
+                            "detail": current_item,
+                        }
+                    ]
+                    if current_item
+                    else []
+                ),
+            ],
+        ),
+        _compiled_section(
+            "where_to_start",
+            "Where To Start",
+            summary="Use the workflow map and the focused shell links below before opening heavier knowledge surfaces.",
+            items=[
+                {
+                    "kind": "orientation",
+                    "label": "Orientation Brief",
+                    "path": _scoped_path("/briefing", pack_name=requested_pack),
+                    "detail": "Open the compiled entry product for this shell.",
+                },
+                {
+                    "kind": "signals",
+                    "label": "Signals",
+                    "path": _scoped_path("/signals", pack_name=requested_pack),
+                    "detail": "Review active signals and queue impact.",
+                },
+                {
+                    "kind": "production",
+                    "label": "Production",
+                    "path": _scoped_path("/production", pack_name=requested_pack),
+                    "detail": "Inspect downstream weak points and chain state.",
+                },
+                {
+                    "kind": "events" if research_overview_supported else "objects",
+                    "label": "Events" if research_overview_supported else "Objects",
+                    "path": _scoped_path("/events" if research_overview_supported else "/objects", pack_name=requested_pack),
+                    "detail": (
+                        "Open the timeline surface."
+                        if research_overview_supported
+                        else "Browse indexed evergreen objects."
+                    ),
+                },
+            ],
+        ),
+    ]
+    return {
+        "screen": "truth/runtime-home",
+        "requested_pack": requested_pack,
+        "runtime": runtime,
+        "research_overview": {
+            "status": "supported" if research_overview_supported else "shared_shell_only",
+            "reason": (
+                "Research-specific overview surfaces are available because this pack resolves through research-tech."
+                if research_overview_supported
+                else "This pack currently gets the shared home shell only; research-specific overview panels stay hidden until the pack defines its own equivalents."
+            ),
+        },
+        "workflow_groups": _build_dashboard_workflow_groups(
+            requested_pack=requested_pack,
+            research_overview_supported=research_overview_supported,
+        ),
+        "entry_sections": entry_sections,
+        "objects": {
+            "count": objects["total_count"],
+            "items": objects["items"],
+        },
+        "orientation": {
+            "assembly_contract": _assembly_contract("orientation_brief", pack_name=pack_name),
+            "governance_contract": describe_governance_contract(pack_name=pack_name),
+        },
+        "signals": {
+            "count": 0,
+            "items": [],
+            "browser_path": _scoped_path("/signals", pack_name=requested_pack),
+            "surface_contract": describe_observation_surface_contract(pack_name=pack_name, surface_kind="signals"),
+        },
+        "production": {
+            "weak_points": [],
+            "weak_point_count": 0,
+            "browser_path": _scoped_path("/production", pack_name=requested_pack),
+            "surface_contract": describe_observation_surface_contract(
+                pack_name=pack_name,
+                surface_kind="production_chains",
+            ),
+        },
+        "contradictions": {
+            "count": 0,
+            "open_count": 0,
+            "items": [],
+            "browser_path": _scoped_path("/contradictions", pack_name=requested_pack),
+        },
+        "events": {
+            "count": 0,
+            "items": [],
+            "dates": [],
+            "browser_path": _scoped_path("/events", pack_name=requested_pack),
+        },
+        "stale_summaries": {
+            "count": 0,
+            "items": [],
+            "browser_path": _scoped_path("/summaries", pack_name=requested_pack),
+        },
+        "evolution": {
+            "candidate_count": 0,
+            "accepted_count": 0,
+            "items": [],
+        },
+        "recent_review_actions": [],
+        "priorities": [],
+        "mode": "runtime_first",
     }
 
 

--- a/src/openclaw_pipeline/ui/view_models.py
+++ b/src/openclaw_pipeline/ui/view_models.py
@@ -3088,12 +3088,24 @@ def build_runtime_home_payload(
     requested_pack = pack_name or ""
     runtime = get_runtime_status(vault_dir)
     research_overview_supported = _supports_research_shell(pack_name)
-    objects = build_objects_index_payload(vault_dir, limit=8, offset=0, pack_name=pack_name)
+    try:
+        objects = build_objects_index_payload(vault_dir, limit=8, offset=0, pack_name=pack_name)
+    except (OSError, sqlite3.Error):
+        objects = {
+            "total_count": 0,
+            "items": [],
+            "error": "object_index_unavailable",
+        }
     active_run = runtime.get("active_run") if isinstance(runtime.get("active_run"), dict) else {}
     run_ledger = active_run.get("run_ledger") if isinstance(active_run, dict) and isinstance(active_run.get("run_ledger"), dict) else {}
     current_step = run_ledger.get("current_step") if isinstance(run_ledger.get("current_step"), dict) else {}
     current_step_name = str(current_step.get("step_name") or run_ledger.get("current_step_name") or active_run.get("checkpoint") or "")
-    progress_summary = str(current_step.get("progress_summary") or "No active workflow is currently recorded in the canonical run ledger.")
+    if current_step.get("progress_summary"):
+        progress_summary = str(current_step["progress_summary"])
+    elif active_run:
+        progress_summary = f"Active run at step {current_step_name or 'unknown'}."
+    else:
+        progress_summary = "No active workflow is currently recorded in the canonical run ledger."
     current_item = str(current_step.get("current_item") or "").strip()
     entry_sections = [
         _compiled_section(
@@ -3182,7 +3194,9 @@ def build_runtime_home_payload(
         "entry_sections": entry_sections,
         "objects": {
             "count": objects["total_count"],
+            "total_count": objects["total_count"],
             "items": objects["items"],
+            **({"error": objects["error"]} if objects.get("error") else {}),
         },
         "orientation": {
             "assembly_contract": _assembly_contract("orientation_brief", pack_name=pack_name),

--- a/src/openclaw_pipeline/unified_pipeline_enhanced.py
+++ b/src/openclaw_pipeline/unified_pipeline_enhanced.py
@@ -150,6 +150,13 @@ def _extract_json_suffix(text: str) -> dict[str, Any] | None:
     return None
 
 
+def _safe_int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
 def _load_env(vault_dir: Path | None = None) -> bool:
     """加载 .env 文件，返回是否成功
 
@@ -553,8 +560,34 @@ class TransactionManager:
     def _write(self, txn_id: str, txn_data: dict[str, Any]) -> None:
         txn_file = self._txn_file(txn_id)
         txn_file.parent.mkdir(parents=True, exist_ok=True)
-        with open(txn_file, "w", encoding="utf-8") as f:
-            json.dump(txn_data, f, indent=2, ensure_ascii=False)
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=txn_file.parent,
+            prefix=f".{txn_file.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as f:
+            tmp_file = Path(f.name)
+            try:
+                json.dump(txn_data, f, indent=2, ensure_ascii=False)
+                f.write("\n")
+                f.flush()
+                os.fsync(f.fileno())
+            except Exception:
+                try:
+                    tmp_file.unlink()
+                except OSError:
+                    pass
+                raise
+        try:
+            os.replace(tmp_file, txn_file)
+        finally:
+            if tmp_file.exists():
+                try:
+                    tmp_file.unlink()
+                except OSError:
+                    pass
 
     def start(
         self,
@@ -848,13 +881,14 @@ class EnhancedPipeline:
                     env=self._subprocess_env(),
                 )
                 started = time.monotonic()
-                poll_interval = min(1.0, max(0.1, float(timeout) / 10.0))
+                timeout_seconds = float(timeout)
+                poll_interval = min(1.0, max(0.1, timeout_seconds / 10.0))
                 while True:
                     returncode = process.poll()
                     if returncode is not None:
                         break
                     elapsed = time.monotonic() - started
-                    if elapsed > timeout:
+                    if elapsed > timeout_seconds:
                         process.kill()
                         process.wait()
                         self.logger.log("command_timeout", {"step": step_name, "timeout": timeout})
@@ -1063,6 +1097,21 @@ class EnhancedPipeline:
                     "pinboard_process_file_started",
                     {"file": f.name, "index": index, "total": total_files},
                 )
+                if self.txn_id:
+                    self.txn.heartbeat(
+                        self.txn_id,
+                        step_name="pinboard_process",
+                        progress_mode="counted",
+                        work_units_total=total_files,
+                        work_units_done=index - 1,
+                        work_units_failed=results["failed"],
+                        current_item=f.name,
+                        progress_summary=f"{index - 1}/{total_files} files processed",
+                        last_meaningful_event={
+                            "event_type": "pinboard_process_file_started",
+                            "file": f.name,
+                        },
+                    )
                 content = f.read_text(encoding="utf-8")
                 url_type = detect_pinboard_processor(content)
                 if not url_type:
@@ -1169,16 +1218,9 @@ class EnhancedPipeline:
                     continue
 
                 # 执行处理器
-                result = subprocess.run(
-                    cmd,
-                    capture_output=True,
-                    text=True,
-                    cwd=str(self.vault_dir),
-                    timeout=600,
-                    env=self._subprocess_env(),
-                )
+                result = self.run_command(cmd, "pinboard_process", timeout=600)
 
-                if result.returncode == 0:
+                if result.get("success"):
                     print(f"  ✅ {url_type}: {f.name}")
                     results["processed"] += 1
 
@@ -1205,9 +1247,10 @@ class EnhancedPipeline:
                         )
                 else:
                     print(f"  ❌ {url_type} 处理失败: {f.name}")
-                    print(f"     {result.stderr[:100]}")
+                    stderr = str(result.get("stderr") or result.get("error") or "")
+                    print(f"     {stderr[:100]}")
                     results["failed"] += 1
-                    self.logger.log("pinboard_process_file_failed", {"file": f.name, "processor": url_type, "error": result.stderr[:500]})
+                    self.logger.log("pinboard_process_file_failed", {"file": f.name, "processor": url_type, "error": stderr[:500]})
                     if self.txn_id:
                         self.txn.heartbeat(
                             self.txn_id,
@@ -1549,26 +1592,38 @@ class EnhancedPipeline:
             self.logger.log("command_error", {"step": "absorb", "error": str(exc)})
             return {"success": False, "error": str(exc)}
 
+        summary = payload.get("summary") if isinstance(payload.get("summary"), dict) else {}
+        results = payload.get("results") if isinstance(payload.get("results"), list) else []
+        error_count = _safe_int(summary.get("errors"))
+        error_count += _safe_int(summary.get("failed"))
+        error_count += _safe_int(summary.get("files_failed"))
+        if error_count == 0:
+            error_count = sum(1 for item in results if isinstance(item, dict) and item.get("error"))
+        success = error_count == 0
         stdout = json.dumps(payload, ensure_ascii=False)
+        stderr = "" if success else f"{error_count} absorb file(s) failed"
         self.logger.log(
             "command_completed",
             {
                 "step": "absorb",
-                "success": True,
+                "success": success,
                 "mode": "direct_workflow",
                 "directory": str(directory) if directory else "",
                 "recent": recent,
                 "total_files": total_files,
                 "stdout": stdout[-1000:],
-                "stderr": "",
+                "stderr": stderr,
             },
         )
-        return {
-            "success": True,
+        result = {
+            "success": success,
             "stdout": stdout,
-            "stderr": "",
+            "stderr": stderr,
             **payload,
         }
+        if not success:
+            result["error"] = stderr
+        return result
 
     def step_absorb(
         self,

--- a/src/openclaw_pipeline/unified_pipeline_enhanced.py
+++ b/src/openclaw_pipeline/unified_pipeline_enhanced.py
@@ -37,6 +37,7 @@ import re
 import subprocess
 import sys
 import tempfile
+import time
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -46,11 +47,27 @@ try:
     from .runtime import VaultLayout, resolve_vault_dir
     from .packs.loader import DEFAULT_PACK_NAME, DEFAULT_WORKFLOW_PACK_NAME, PRIMARY_PACK_NAME, resolve_workflow_profile
     from .batch_quality_checker import collect_quality_files
+    from .auto_evergreen_extractor import run_absorb_workflow
+    from .txn import (
+        build_transaction_payload,
+        heartbeat_transaction,
+        mark_transaction_completed,
+        mark_transaction_failed,
+        update_transaction_step,
+    )
 except ImportError:  # pragma: no cover - script mode fallback
     from handler_registry import execute_profile_stage_handler
     from runtime import VaultLayout, resolve_vault_dir
     from packs.loader import DEFAULT_PACK_NAME, DEFAULT_WORKFLOW_PACK_NAME, PRIMARY_PACK_NAME, resolve_workflow_profile
     from batch_quality_checker import collect_quality_files
+    from auto_evergreen_extractor import run_absorb_workflow
+    from txn import (
+        build_transaction_payload,
+        heartbeat_transaction,
+        mark_transaction_completed,
+        mark_transaction_failed,
+        update_transaction_step,
+    )
 
 # ========== 环境初始化 ==========
 # 加载 .env 文件（从 Vault 根目录或 auto_vault 目录）
@@ -392,6 +409,7 @@ def pipeline_steps(
 def build_execution_plan(args: argparse.Namespace) -> dict[str, Any]:
     """Build the requested execution plan from CLI args."""
     include_refine = bool(getattr(args, "with_refine", False))
+    incremental = bool(getattr(args, "incremental", False))
     pack_name = getattr(args, "pack", None)
     profile_name = getattr(args, "profile", None)
     pack, profile = resolve_workflow_profile(
@@ -430,6 +448,21 @@ def build_execution_plan(args: argparse.Namespace) -> dict[str, Any]:
             f"Full pipeline from {normalized_from_step} ({pack.name}/{profile.name})"
             if normalized_from_step
             else f"Full pipeline ({pack.name}/{profile.name})"
+        )
+        return plan_dict(
+            requested_steps,
+            description,
+            args.pinboard_days or 7,
+            None,
+            None,
+        )
+
+    if incremental:
+        requested_steps = slice_from_step(selected_steps)
+        description = (
+            f"Incremental pipeline from {normalized_from_step} ({pack.name}/{profile.name})"
+            if normalized_from_step
+            else f"Incremental pipeline ({pack.name}/{profile.name})"
         )
         return plan_dict(
             requested_steps,
@@ -507,75 +540,70 @@ class TransactionManager:
     def __init__(self, txn_dir: Path):
         self.txn_dir = txn_dir
 
-    def start(self, workflow_type: str, description: str) -> str:
-        txn_id = f"pipeline-{datetime.now().strftime('%Y%m%d-%H%M%S')}-{os.urandom(4).hex()[:8]}"
-        txn_file = self.txn_dir / f"{txn_id}.json"
+    def _txn_file(self, txn_id: str) -> Path:
+        return self.txn_dir / f"{txn_id}.json"
 
-        txn_data = {
-            "id": txn_id,
-            "type": workflow_type,
-            "description": description,
-            "start_time": datetime.now().isoformat(),
-            "status": "in_progress",
-            "steps": {},
-            "checkpoint": "initialized",
-            "last_updated": datetime.now().isoformat()
-        }
+    def _read(self, txn_id: str) -> dict[str, Any] | None:
+        txn_file = self._txn_file(txn_id)
+        if not txn_file.exists():
+            return None
+        with open(txn_file, "r", encoding="utf-8") as f:
+            return json.load(f)
 
+    def _write(self, txn_id: str, txn_data: dict[str, Any]) -> None:
+        txn_file = self._txn_file(txn_id)
         txn_file.parent.mkdir(parents=True, exist_ok=True)
         with open(txn_file, "w", encoding="utf-8") as f:
             json.dump(txn_data, f, indent=2, ensure_ascii=False)
 
+    def start(
+        self,
+        workflow_type: str,
+        description: str,
+        *,
+        pack_name: str | None = None,
+        workflow_profile: str | None = None,
+        planned_steps: list[str] | None = None,
+    ) -> str:
+        txn_id = f"pipeline-{datetime.now().strftime('%Y%m%d-%H%M%S')}-{os.urandom(4).hex()[:8]}"
+        txn_data = build_transaction_payload(
+            txn_id,
+            workflow_type,
+            description,
+            pack_name=pack_name,
+            workflow_profile=workflow_profile,
+            planned_steps=planned_steps,
+        )
+        self._write(txn_id, txn_data)
         return txn_id
 
-    def step(self, txn_id: str, step_name: str, status: str, output: str = ""):
-        txn_file = self.txn_dir / f"{txn_id}.json"
-        if not txn_file.exists():
+    def step(self, txn_id: str, step_name: str, status: str, output: str = "", **progress_kwargs: Any):
+        txn_data = self._read(txn_id)
+        if txn_data is None:
             return
+        update_transaction_step(txn_data, step_name, status, output=output, **progress_kwargs)
+        self._write(txn_id, txn_data)
 
-        with open(txn_file, "r", encoding="utf-8") as f:
-            txn_data = json.load(f)
-
-        txn_data["steps"][step_name] = {
-            "status": status,
-            "output": output,
-            "updated_at": datetime.now().isoformat()
-        }
-        txn_data["checkpoint"] = step_name
-        txn_data["last_updated"] = datetime.now().isoformat()
-
-        with open(txn_file, "w", encoding="utf-8") as f:
-            json.dump(txn_data, f, indent=2, ensure_ascii=False)
+    def heartbeat(self, txn_id: str, *, step_name: str | None = None, **kwargs: Any):
+        txn_data = self._read(txn_id)
+        if txn_data is None:
+            return
+        heartbeat_transaction(txn_data, step_name=step_name, **kwargs)
+        self._write(txn_id, txn_data)
 
     def complete(self, txn_id: str):
-        txn_file = self.txn_dir / f"{txn_id}.json"
-        if not txn_file.exists():
+        txn_data = self._read(txn_id)
+        if txn_data is None:
             return
-
-        with open(txn_file, "r", encoding="utf-8") as f:
-            txn_data = json.load(f)
-
-        txn_data["status"] = "completed"
-        txn_data["completed_at"] = datetime.now().isoformat()
-        txn_data["last_updated"] = datetime.now().isoformat()
-
-        with open(txn_file, "w", encoding="utf-8") as f:
-            json.dump(txn_data, f, indent=2, ensure_ascii=False)
+        mark_transaction_completed(txn_data)
+        self._write(txn_id, txn_data)
 
     def fail(self, txn_id: str, reason: str):
-        txn_file = self.txn_dir / f"{txn_id}.json"
-        if not txn_file.exists():
+        txn_data = self._read(txn_id)
+        if txn_data is None:
             return
-
-        with open(txn_file, "r", encoding="utf-8") as f:
-            txn_data = json.load(f)
-
-        txn_data["status"] = "failed"
-        txn_data["failure_reason"] = reason
-        txn_data["last_updated"] = datetime.now().isoformat()
-
-        with open(txn_file, "w", encoding="utf-8") as f:
-            json.dump(txn_data, f, indent=2, ensure_ascii=False)
+        mark_transaction_failed(txn_data, reason)
+        self._write(txn_id, txn_data)
 
 
 class EnhancedPipeline:
@@ -807,36 +835,59 @@ class EnhancedPipeline:
         self.logger.log("command_started", {"step": step_name, "cmd": " ".join(cmd), "timeout": timeout})
 
         try:
-            result = subprocess.run(
-                cmd,
-                cwd=self.vault_dir,
-                capture_output=True,
-                text=True,
-                timeout=timeout,
-                env=self._subprocess_env(),
-            )
+            with tempfile.NamedTemporaryFile(mode="w+", encoding="utf-8") as stdout_file, tempfile.NamedTemporaryFile(
+                mode="w+",
+                encoding="utf-8",
+            ) as stderr_file:
+                process = subprocess.Popen(
+                    cmd,
+                    cwd=self.vault_dir,
+                    stdout=stdout_file,
+                    stderr=stderr_file,
+                    text=True,
+                    env=self._subprocess_env(),
+                )
+                started = time.monotonic()
+                poll_interval = min(1.0, max(0.1, float(timeout) / 10.0))
+                while True:
+                    returncode = process.poll()
+                    if returncode is not None:
+                        break
+                    elapsed = time.monotonic() - started
+                    if elapsed > timeout:
+                        process.kill()
+                        process.wait()
+                        self.logger.log("command_timeout", {"step": step_name, "timeout": timeout})
+                        return {"success": False, "timeout": True, "error": f"Timeout after {timeout}s"}
+                    if self.txn_id:
+                        self.txn.heartbeat(self.txn_id, step_name=step_name)
+                    time.sleep(poll_interval)
 
-            success = result.returncode == 0
+                stdout_file.flush()
+                stderr_file.flush()
+                stdout_file.seek(0)
+                stderr_file.seek(0)
+                stdout = stdout_file.read()
+                stderr = stderr_file.read()
+
+            success = returncode == 0
 
             self.logger.log("command_completed", {
                 "step": step_name,
                 "success": success,
-                "returncode": result.returncode,
+                "returncode": returncode,
                 "timeout": timeout,
-                "stdout": result.stdout[-1000:] if result.stdout else "",
-                "stderr": result.stderr[-500:] if result.stderr else ""
+                "stdout": stdout[-1000:] if stdout else "",
+                "stderr": stderr[-500:] if stderr else ""
             })
 
             return {
                 "success": success,
-                "returncode": result.returncode,
-                "stdout": result.stdout,
-                "stderr": result.stderr
+                "returncode": returncode,
+                "stdout": stdout,
+                "stderr": stderr
             }
 
-        except subprocess.TimeoutExpired:
-            self.logger.log("command_timeout", {"step": step_name, "timeout": timeout})
-            return {"success": False, "timeout": True, "error": f"Timeout after {timeout}s"}
         except Exception as e:
             self.logger.log("command_error", {"step": step_name, "error": str(e)})
             return {"success": False, "error": str(e)}
@@ -849,6 +900,7 @@ class EnhancedPipeline:
         if project_src not in segments:
             segments.insert(0, project_src)
         env["PYTHONPATH"] = os.pathsep.join(segments)
+        env.setdefault("PYTHONUNBUFFERED", "1")
         return env
 
     def step_pinboard(
@@ -992,19 +1044,67 @@ class EnhancedPipeline:
         print(f"  找到 {len(files)} 个 Pinboard 文件")
 
         results = {"processed": 0, "skipped": 0, "failed": 0}
+        total_files = len(files)
 
-        for f in files:
+        if self.txn_id:
+            self.txn.heartbeat(
+                self.txn_id,
+                step_name="pinboard_process",
+                progress_mode="counted",
+                work_units_total=total_files,
+                work_units_done=0,
+                work_units_failed=0,
+                progress_summary=f"0/{total_files} files processed",
+            )
+
+        for index, f in enumerate(files, start=1):
             try:
+                self.logger.log(
+                    "pinboard_process_file_started",
+                    {"file": f.name, "index": index, "total": total_files},
+                )
                 content = f.read_text(encoding="utf-8")
                 url_type = detect_pinboard_processor(content)
                 if not url_type:
                     print(f"  ⚠️  无法识别类型: {f.name}")
                     results["skipped"] += 1
+                    self.logger.log("pinboard_process_file_skipped", {"file": f.name, "reason": "unknown_type"})
+                    if self.txn_id:
+                        self.txn.heartbeat(
+                            self.txn_id,
+                            step_name="pinboard_process",
+                            progress_mode="counted",
+                            work_units_total=total_files,
+                            work_units_done=index,
+                            work_units_failed=results["failed"],
+                            current_item=f.name,
+                            progress_summary=f"{index}/{total_files} files processed",
+                            last_meaningful_event={
+                                "event_type": "pinboard_process_file_skipped",
+                                "file": f.name,
+                            },
+                        )
                     continue
 
                 if url_type == "social":
                     print(f"  ⏭️  跳过 social: {f.name}")
                     results["skipped"] += 1
+                    self.logger.log("pinboard_process_file_skipped", {"file": f.name, "reason": "social"})
+                    if self.txn_id:
+                        self.txn.heartbeat(
+                            self.txn_id,
+                            step_name="pinboard_process",
+                            progress_mode="counted",
+                            work_units_total=total_files,
+                            work_units_done=index,
+                            work_units_failed=results["failed"],
+                            current_item=f.name,
+                            progress_summary=f"{index}/{total_files} files processed",
+                            last_meaningful_event={
+                                "event_type": "pinboard_process_file_skipped",
+                                "file": f.name,
+                            },
+                        )
                     continue
 
                 # 构建命令
@@ -1029,11 +1129,43 @@ class EnhancedPipeline:
                 else:
                     print(f"  ⏭️  跳过未知类型 {url_type}: {f.name}")
                     results["skipped"] += 1
+                    self.logger.log("pinboard_process_file_skipped", {"file": f.name, "reason": f"unsupported:{url_type}"})
+                    if self.txn_id:
+                        self.txn.heartbeat(
+                            self.txn_id,
+                            step_name="pinboard_process",
+                            progress_mode="counted",
+                            work_units_total=total_files,
+                            work_units_done=index,
+                            work_units_failed=results["failed"],
+                            current_item=f.name,
+                            progress_summary=f"{index}/{total_files} files processed",
+                            last_meaningful_event={
+                                "event_type": "pinboard_process_file_skipped",
+                                "file": f.name,
+                            },
+                        )
                     continue
 
                 if dry_run:
                     print(f"  🔍 [DRY RUN] 路由 {url_type}: {f.name}")
                     results["processed"] += 1
+                    self.logger.log("pinboard_process_file_completed", {"file": f.name, "processor": url_type, "dry_run": True})
+                    if self.txn_id:
+                        self.txn.heartbeat(
+                            self.txn_id,
+                            step_name="pinboard_process",
+                            progress_mode="counted",
+                            work_units_total=total_files,
+                            work_units_done=index,
+                            work_units_failed=results["failed"],
+                            current_item=f.name,
+                            progress_summary=f"{index}/{total_files} files processed",
+                            last_meaningful_event={
+                                "event_type": "pinboard_process_file_completed",
+                                "file": f.name,
+                            },
+                        )
                     continue
 
                 # 执行处理器
@@ -1055,14 +1187,62 @@ class EnhancedPipeline:
                     month_dir.mkdir(parents=True, exist_ok=True)
                     archive_file = month_dir / f.name
                     f.rename(archive_file)
+                    self.logger.log("pinboard_process_file_completed", {"file": f.name, "processor": url_type, "archived_to": str(archive_file)})
+                    if self.txn_id:
+                        self.txn.heartbeat(
+                            self.txn_id,
+                            step_name="pinboard_process",
+                            progress_mode="counted",
+                            work_units_total=total_files,
+                            work_units_done=index,
+                            work_units_failed=results["failed"],
+                            current_item=f.name,
+                            progress_summary=f"{index}/{total_files} files processed",
+                            last_meaningful_event={
+                                "event_type": "pinboard_process_file_completed",
+                                "file": f.name,
+                            },
+                        )
                 else:
                     print(f"  ❌ {url_type} 处理失败: {f.name}")
                     print(f"     {result.stderr[:100]}")
                     results["failed"] += 1
+                    self.logger.log("pinboard_process_file_failed", {"file": f.name, "processor": url_type, "error": result.stderr[:500]})
+                    if self.txn_id:
+                        self.txn.heartbeat(
+                            self.txn_id,
+                            step_name="pinboard_process",
+                            progress_mode="counted",
+                            work_units_total=total_files,
+                            work_units_done=index,
+                            work_units_failed=results["failed"],
+                            current_item=f.name,
+                            progress_summary=f"{index}/{total_files} files processed",
+                            last_meaningful_event={
+                                "event_type": "pinboard_process_file_failed",
+                                "file": f.name,
+                            },
+                        )
 
             except Exception as e:
                 print(f"  ❌ 处理异常 {f.name}: {e}")
                 results["failed"] += 1
+                self.logger.log("pinboard_process_file_failed", {"file": f.name, "error": str(e)})
+                if self.txn_id:
+                    self.txn.heartbeat(
+                        self.txn_id,
+                        step_name="pinboard_process",
+                        progress_mode="counted",
+                        work_units_total=total_files,
+                        work_units_done=index,
+                        work_units_failed=results["failed"],
+                        current_item=f.name,
+                        progress_summary=f"{index}/{total_files} files processed",
+                        last_meaningful_event={
+                            "event_type": "pinboard_process_file_failed",
+                            "file": f.name,
+                        },
+                    )
 
         print(f"\n  汇总: 处理 {results['processed']}, 跳过 {results['skipped']}, 失败 {results['failed']}")
         return {"success": results["failed"] == 0, **results}
@@ -1284,6 +1464,112 @@ class EnhancedPipeline:
                     merged.append(resolved)
         return merged
 
+    def _build_absorb_progress_callback(
+        self,
+        *,
+        total_files: int | None,
+        completed_before: int = 0,
+        failed_before: int = 0,
+    ):
+        def _callback(event: dict[str, Any]) -> None:
+            effective_total = total_files or int(event.get("files_total") or 0) or None
+            batch_done = int(event.get("files_done") or 0)
+            batch_failed = int(event.get("files_failed") or 0)
+            current_item = str(event.get("current_item") or event.get("file") or "").strip() or None
+            work_units_done = completed_before + batch_done
+            work_units_failed = failed_before + batch_failed
+            progress_summary = (
+                f"{work_units_done}/{effective_total} files processed"
+                if effective_total is not None
+                else "Progress is currently indeterminate."
+            )
+            if self.txn_id:
+                self.txn.heartbeat(
+                    self.txn_id,
+                    step_name="absorb",
+                    progress_mode="counted" if effective_total is not None else "indeterminate",
+                    work_units_total=effective_total,
+                    work_units_done=work_units_done,
+                    work_units_failed=work_units_failed,
+                    current_item=current_item,
+                    progress_summary=progress_summary,
+                    last_meaningful_event={
+                        "event_type": str(event.get("event_type") or "absorb_file_processed"),
+                        "file": current_item or "",
+                    },
+                )
+
+        return _callback
+
+    def _run_absorb_workflow_direct(
+        self,
+        *,
+        dry_run: bool,
+        total_files: int | None = None,
+        completed_before: int = 0,
+        failed_before: int = 0,
+        directory: Path | None = None,
+        recent: int | None = None,
+    ) -> dict[str, Any]:
+        self.logger.log(
+            "command_started",
+            {
+                "step": "absorb",
+                "mode": "direct_workflow",
+                "directory": str(directory) if directory else "",
+                "recent": recent,
+                "total_files": total_files,
+            },
+        )
+        if self.txn_id and total_files is not None:
+            self.txn.heartbeat(
+                self.txn_id,
+                step_name="absorb",
+                progress_mode="counted",
+                work_units_total=total_files,
+                work_units_done=completed_before,
+                work_units_failed=failed_before,
+                progress_summary=f"{completed_before}/{total_files} files processed",
+            )
+        try:
+            payload = run_absorb_workflow(
+                self.vault_dir,
+                directory=directory,
+                recent=recent,
+                dry_run=dry_run,
+                auto_promote=True,
+                promote_threshold=1,
+                progress_callback=self._build_absorb_progress_callback(
+                    total_files=total_files,
+                    completed_before=completed_before,
+                    failed_before=failed_before,
+                ),
+            )
+        except Exception as exc:
+            self.logger.log("command_error", {"step": "absorb", "error": str(exc)})
+            return {"success": False, "error": str(exc)}
+
+        stdout = json.dumps(payload, ensure_ascii=False)
+        self.logger.log(
+            "command_completed",
+            {
+                "step": "absorb",
+                "success": True,
+                "mode": "direct_workflow",
+                "directory": str(directory) if directory else "",
+                "recent": recent,
+                "total_files": total_files,
+                "stdout": stdout[-1000:],
+                "stderr": "",
+            },
+        )
+        return {
+            "success": True,
+            "stdout": stdout,
+            "stderr": "",
+            **payload,
+        }
+
     def step_absorb(
         self,
         recent_days: int = 7,
@@ -1346,7 +1632,8 @@ class EnhancedPipeline:
         print("="*60)
 
         if normalized_files is not None:
-            effective_batch_size = batch_size or len(normalized_files)
+            total_files = len(normalized_files)
+            effective_batch_size = batch_size or total_files
             aggregated_summary = {
                 "files_processed": 0,
                 "concepts_extracted": 0,
@@ -1383,21 +1670,12 @@ class EnhancedPipeline:
                         except OSError:
                             target.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
 
-                    cmd = [
-                        sys.executable, "-m", "openclaw_pipeline.commands.absorb",
-                        "--vault-dir", str(self.vault_dir),
-                        "--dir", str(staging_path),
-                        "--auto-promote",
-                        "--promote-threshold", "1",
-                        "--json",
-                    ]
-                    if dry_run:
-                        cmd.append("--dry-run")
-
-                    result = self.run_command(
-                        cmd,
-                        "absorb",
-                        timeout=self._calculate_timeout("absorb", batch_size=len(batch_files)),
+                    result = self._run_absorb_workflow_direct(
+                        directory=staging_path,
+                        dry_run=dry_run,
+                        total_files=total_files,
+                        completed_before=aggregated_summary["files_processed"],
+                        failed_before=aggregated_summary["errors"],
                     )
                     if not result["success"]:
                         print(f"✗ Absorb stage failed: {result.get('error', 'Unknown error')}")
@@ -1406,21 +1684,10 @@ class EnhancedPipeline:
                         result["results"] = aggregated_results
                         return result
 
-                    payload = _extract_json_suffix(result.get("stdout", ""))
-                    if payload is None:
-                        print("✗ Absorb stage failed: missing absorb JSON payload")
-                        return {
-                            "success": False,
-                            "error": "missing_absorb_payload",
-                            "qualified_files": normalized_files,
-                            "summary": aggregated_summary,
-                            "results": aggregated_results,
-                        }
-
-                    summary = payload.get("summary", {})
+                    summary = result.get("summary", {})
                     for key in aggregated_summary:
                         aggregated_summary[key] += int(summary.get(key, 0) or 0)
-                    aggregated_results.extend(payload.get("results", []))
+                    aggregated_results.extend(result.get("results", []))
 
             result = {
                 "success": True,
@@ -1437,16 +1704,7 @@ class EnhancedPipeline:
                 "stderr": "",
             }
         else:
-            cmd = [
-                sys.executable, "-m", "openclaw_pipeline.commands.absorb",
-                "--vault-dir", str(self.vault_dir),
-                "--recent", str(recent_days),
-                "--json",
-            ]
-            if dry_run:
-                cmd.append("--dry-run")
-
-            result = self.run_command(cmd, "absorb")
+            result = self._run_absorb_workflow_direct(dry_run=dry_run, recent=recent_days)
 
         if result["success"]:
             print("✓ Absorb stage completed")
@@ -1729,6 +1987,8 @@ def main():
     # 运行模式
     parser.add_argument("--full", action="store_true",
                        help="完整Pipeline（Pinboard+Clippings+Articles+Quality+Absorb+MOC+knowledge.db）")
+    parser.add_argument("--incremental", action="store_true",
+                       help="日常增量流水线（默认包含最近7天 Pinboard + Clippings + 后续步骤）")
     parser.add_argument("--step", choices=PIPELINE_STEP_CHOICES,
                        help="运行指定步骤")
     parser.add_argument("--from-step", choices=PIPELINE_STEP_CHOICES,
@@ -1815,7 +2075,13 @@ def main():
     description = execution_plan["description"]
 
     # 创建事务
-    pipeline.txn_id = txn.start("enhanced-pipeline", description)
+    pipeline.txn_id = txn.start(
+        "enhanced-pipeline",
+        description,
+        pack_name=execution_plan["pack"],
+        workflow_profile=execution_plan["profile"],
+        planned_steps=steps,
+    )
     logger.log("pipeline_started", {
         "txn_id": pipeline.txn_id,
         "mode": "full" if args.full else "custom",

--- a/task_plan.md
+++ b/task_plan.md
@@ -1,5 +1,16 @@
 # Task Plan: External Project Discovery for OVP
 
+## Runtime Note
+
+- `Phase 25` is complete in the codebase and validated against a real local incremental run:
+  - canonical run ledger
+  - honest counted progress
+  - watcher/API/UI reader unification
+  - explicit daily `ovp --incremental` entrypoint
+- `Phase 24` is the next active planned slice:
+  - brain-first lookup before object/link creation
+  - backlink legibility
+
 ## Goal
 Build a running comparative map of external memory, context, runtime, and governance systems; classify what each project is actually doing; and extract only the durable ideas that matter for Obsidian Vault Pipeline.
 

--- a/tests/test_export_command.py
+++ b/tests/test_export_command.py
@@ -142,6 +142,8 @@ def test_export_command_can_export_orientation_brief(temp_vault, tmp_path, capsy
     assert exported["screen"] == "briefing/intelligence"
     assert exported["assembly_contract"]["recipe_name"] == "orientation_brief"
     assert [section["id"] for section in exported["compiled_sections"]] == [
+        "signal_loop",
+        "inbound_capture",
         "what_changed",
         "what_matters",
         "needs_review",

--- a/tests/test_migration_processing_guards.py
+++ b/tests/test_migration_processing_guards.py
@@ -51,11 +51,12 @@ tags: [paper]
 
     captured: list[list[str]] = []
 
-    def fake_run(cmd, capture_output, text, cwd, timeout, env=None):
+    def fake_run_command(cmd, step_name, timeout=None):
+        assert step_name == "pinboard_process"
         captured.append(cmd)
-        return SimpleNamespace(returncode=0, stdout="", stderr="")
+        return {"success": True, "stdout": "", "stderr": ""}
 
-    monkeypatch.setattr("openclaw_pipeline.unified_pipeline_enhanced.subprocess.run", fake_run)
+    monkeypatch.setattr(pipeline, "run_command", fake_run_command)
 
     result = pipeline.step_pinboard_process(dry_run=False)
 
@@ -91,13 +92,14 @@ example/repo
     txn = TransactionManager(temp_vault / "60-Logs" / "transactions")
     pipeline = EnhancedPipeline(temp_vault, logger, txn)
 
-    captured: list[int] = []
+    captured: list[int | None] = []
 
-    def fake_run(cmd, capture_output, text, cwd, timeout, env=None):
+    def fake_run_command(cmd, step_name, timeout=None):
+        assert step_name == "pinboard_process"
         captured.append(timeout)
-        return SimpleNamespace(returncode=0, stdout="", stderr="")
+        return {"success": True, "stdout": "", "stderr": ""}
 
-    monkeypatch.setattr("openclaw_pipeline.unified_pipeline_enhanced.subprocess.run", fake_run)
+    monkeypatch.setattr(pipeline, "run_command", fake_run_command)
 
     result = pipeline.step_pinboard_process(dry_run=False)
 
@@ -126,19 +128,9 @@ example/repo
     txn = TransactionManager(temp_vault / "60-Logs" / "transactions")
     pipeline = EnhancedPipeline(temp_vault, logger, txn)
 
-    captured_envs: list[dict[str, str]] = []
+    env = pipeline._subprocess_env()
 
-    def fake_run(cmd, capture_output, text, cwd, timeout, env):
-        captured_envs.append(env)
-        return SimpleNamespace(returncode=0, stdout="", stderr="")
-
-    monkeypatch.setattr("openclaw_pipeline.unified_pipeline_enhanced.subprocess.run", fake_run)
-
-    result = pipeline.step_pinboard_process(dry_run=False)
-
-    assert result["processed"] == 1
-    assert captured_envs
-    assert str((Path(__file__).resolve().parents[1] / "src")) in captured_envs[0]["PYTHONPATH"]
+    assert str((Path(__file__).resolve().parents[1] / "src")) in env["PYTHONPATH"]
 
 
 def test_sanitize_generated_markdown_unwraps_fenced_frontmatter():

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -134,6 +134,28 @@ def test_build_execution_plan_full_respects_from_step():
     assert plan["steps"][-2:] == ["refine", "knowledge_index"]
 
 
+def test_build_execution_plan_incremental_includes_pinboard_and_defaults_recent_days():
+    args = Namespace(
+        full=False,
+        incremental=True,
+        with_refine=False,
+        pinboard_new=False,
+        pinboard_history=None,
+        pinboard_days=None,
+        step=None,
+        from_step=None,
+        pack=None,
+        profile=None,
+    )
+
+    plan = build_execution_plan(args)
+
+    assert plan["steps"][:3] == ["pinboard", "pinboard_process", "clippings"]
+    assert plan["steps"][-1] == "knowledge_index"
+    assert plan["pinboard_days"] == 7
+    assert plan["description"] == "Incremental pipeline (research-tech/full)"
+
+
 def test_run_pipeline_dispatches_profile_stages_via_handler_registry(tmp_path, monkeypatch):
     import openclaw_pipeline.unified_pipeline_enhanced as pipeline_source
     from openclaw_pipeline.unified_pipeline_enhanced import PipelineLogger, TransactionManager
@@ -324,19 +346,20 @@ def test_step_absorb_invokes_absorb_command(tmp_path, monkeypatch):
 
     captured: dict[str, object] = {}
 
-    def fake_run_command(cmd: list[str], step_name: str, timeout: int | None = None) -> dict:
-        captured["cmd"] = cmd
-        captured["step_name"] = step_name
-        return {"success": True, "stdout": "", "stderr": ""}
+    def fake_run_absorb_workflow(vault_dir, *, recent=None, dry_run=False, **_):
+        captured["vault_dir"] = Path(vault_dir)
+        captured["recent"] = recent
+        captured["dry_run"] = dry_run
+        return {"summary": {"files_processed": 0}, "results": []}
 
-    monkeypatch.setattr(pipeline, "run_command", fake_run_command)
+    monkeypatch.setattr("openclaw_pipeline.unified_pipeline_enhanced.run_absorb_workflow", fake_run_absorb_workflow)
 
     result = pipeline.step_absorb(dry_run=True)
 
     assert result["success"] is True
-    assert captured["step_name"] == "absorb"
-    assert "openclaw_pipeline.commands.absorb" in " ".join(captured["cmd"])
-    assert "--vault-dir" in captured["cmd"]
+    assert captured["vault_dir"] == vault
+    assert captured["recent"] == 7
+    assert captured["dry_run"] is True
 
 
 def test_step_quality_parses_qualified_files_from_qc_json(tmp_path, monkeypatch):
@@ -447,9 +470,45 @@ def test_step_quality_rejects_non_positive_batch_size(tmp_path):
     assert result["error"] == "invalid_batch_size (0 <= 0)"
 
 
-def test_step_absorb_uses_qualified_files_even_when_quality_score_is_low(tmp_path, monkeypatch):
+def test_step_pinboard_process_updates_txn_ledger_with_counted_progress(tmp_path, monkeypatch):
     from openclaw_pipeline.unified_pipeline_enhanced import PipelineLogger, TransactionManager
     import json
+
+    vault = tmp_path / "vault"
+    pinboard_dir = vault / "50-Inbox" / "02-Pinboard"
+    pinboard_dir.mkdir(parents=True, exist_ok=True)
+    logger = PipelineLogger(vault / "60-Logs" / "pipeline.jsonl")
+    txn = TransactionManager(vault / "60-Logs" / "transactions")
+    pipeline = EnhancedPipeline(vault, logger, txn)
+    pipeline.txn_id = txn.start("enhanced-pipeline", "Phase 25 pinboard progress")
+
+    for name in ("one.md", "two.md"):
+        (pinboard_dir / name).write_text("---\ntitle: Demo\nsource: https://example.com\n---\n", encoding="utf-8")
+
+    monkeypatch.setattr("openclaw_pipeline.unified_pipeline_enhanced.detect_pinboard_processor", lambda content: "article")
+
+    class _Completed:
+        returncode = 0
+        stderr = ""
+
+    monkeypatch.setattr("openclaw_pipeline.unified_pipeline_enhanced.subprocess.run", lambda *args, **kwargs: _Completed())
+
+    result = pipeline.step_pinboard_process(dry_run=False)
+
+    assert result["success"] is True
+    payload = json.loads((vault / "60-Logs" / "transactions" / f"{pipeline.txn_id}.json").read_text(encoding="utf-8"))
+    current = payload["run_ledger"]["current_step"]
+    assert current["step_name"] == "pinboard_process"
+    assert current["progress_mode"] == "counted"
+    assert current["work_units_total"] == 2
+    assert current["work_units_done"] == 2
+    assert current["progress_percent"] == 100.0
+    assert current["current_item"] == "two.md"
+    assert payload["run_ledger"]["last_meaningful_event"]["event_type"] == "pinboard_process_file_completed"
+
+
+def test_step_absorb_uses_qualified_files_even_when_quality_score_is_low(tmp_path, monkeypatch):
+    from openclaw_pipeline.unified_pipeline_enhanced import PipelineLogger, TransactionManager
 
     vault = tmp_path / "vault"
     (vault / "60-Logs").mkdir(parents=True)
@@ -463,34 +522,47 @@ def test_step_absorb_uses_qualified_files_even_when_quality_score_is_low(tmp_pat
 
     captured: dict[str, object] = {}
 
-    def fake_run_command(cmd: list[str], step_name: str, timeout: int | None = None) -> dict:
-        captured["cmd"] = cmd
-        captured["step_name"] = step_name
-        captured["timeout"] = timeout
-        absorb_dir = Path(cmd[cmd.index("--dir") + 1])
-        staged_files = sorted(p.name for p in absorb_dir.glob("*.md"))
-        captured["staged_files"] = staged_files
-        return {
-            "success": True,
-            "stdout": json.dumps(
+    def fake_run_absorb_workflow(
+        vault_dir,
+        *,
+        directory=None,
+        dry_run=False,
+        auto_promote=False,
+        promote_threshold=0,
+        progress_callback=None,
+        **_,
+    ):
+        captured["vault_dir"] = Path(vault_dir)
+        captured["directory"] = Path(directory)
+        captured["dry_run"] = dry_run
+        captured["auto_promote"] = auto_promote
+        captured["promote_threshold"] = promote_threshold
+        captured["staged_files"] = sorted(p.name for p in Path(directory).glob("*.md"))
+        if progress_callback is not None:
+            progress_callback(
                 {
-                    "summary": {
-                        "files_processed": 1,
-                        "concepts_extracted": 1,
-                        "candidates_added": 1,
-                        "concepts_created": 1,
-                        "concepts_promoted": 1,
-                        "concepts_skipped": 0,
-                        "errors": 0,
-                    },
-                    "results": [],
-                },
-                ensure_ascii=False,
-            ),
-            "stderr": "",
+                    "event_type": "absorb_file_processed",
+                    "file": "example_深度解读.md",
+                    "files_total": 1,
+                    "files_done": 1,
+                    "files_failed": 0,
+                    "current_item": "example_深度解读.md",
+                }
+            )
+        return {
+            "summary": {
+                "files_processed": 1,
+                "concepts_extracted": 1,
+                "candidates_added": 1,
+                "concepts_created": 1,
+                "concepts_promoted": 1,
+                "concepts_skipped": 0,
+                "errors": 0,
+            },
+            "results": [],
         }
 
-    monkeypatch.setattr(pipeline, "run_command", fake_run_command)
+    monkeypatch.setattr("openclaw_pipeline.unified_pipeline_enhanced.run_absorb_workflow", fake_run_absorb_workflow)
 
     result = pipeline.step_absorb(
         dry_run=False,
@@ -499,12 +571,10 @@ def test_step_absorb_uses_qualified_files_even_when_quality_score_is_low(tmp_pat
     )
 
     assert result["success"] is True
-    assert captured["step_name"] == "absorb"
-    assert "--dir" in captured["cmd"]
-    assert "--auto-promote" in captured["cmd"]
-    assert captured["cmd"][captured["cmd"].index("--promote-threshold") + 1] == "1"
+    assert captured["vault_dir"] == vault
+    assert captured["auto_promote"] is True
+    assert captured["promote_threshold"] == 1
     assert captured["staged_files"] == ["example_深度解读.md"]
-    assert captured["timeout"] == 600
 
 
 def test_step_absorb_skips_cleanly_when_no_qualified_files(tmp_path):
@@ -557,40 +627,30 @@ def test_step_absorb_falls_back_to_latest_quality_results_file(tmp_path, monkeyp
 
     captured: dict[str, object] = {}
 
-    def fake_run_command(cmd: list[str], step_name: str, timeout: int | None = None) -> dict:
-        captured["cmd"] = cmd
-        captured["timeout"] = timeout
-        absorb_dir = Path(cmd[cmd.index("--dir") + 1])
-        captured["staged_files"] = sorted(p.name for p in absorb_dir.glob("*.md"))
+    def fake_run_absorb_workflow(vault_dir, *, directory=None, **_):
+        captured["vault_dir"] = Path(vault_dir)
+        captured["directory"] = Path(directory)
+        captured["staged_files"] = sorted(p.name for p in Path(directory).glob("*.md"))
         return {
-            "success": True,
-            "stdout": json.dumps(
-                {
-                    "summary": {
-                        "files_processed": 1,
-                        "concepts_extracted": 1,
-                        "candidates_added": 1,
-                        "concepts_created": 1,
-                        "concepts_promoted": 1,
-                        "concepts_skipped": 0,
-                        "errors": 0,
-                    },
-                    "results": [],
-                },
-                ensure_ascii=False,
-            ),
-            "stderr": "",
+            "summary": {
+                "files_processed": 1,
+                "concepts_extracted": 1,
+                "candidates_added": 1,
+                "concepts_created": 1,
+                "concepts_promoted": 1,
+                "concepts_skipped": 0,
+                "errors": 0,
+            },
+            "results": [],
         }
 
-    monkeypatch.setattr(pipeline, "run_command", fake_run_command)
+    monkeypatch.setattr("openclaw_pipeline.unified_pipeline_enhanced.run_absorb_workflow", fake_run_absorb_workflow)
 
     result = pipeline.step_absorb(dry_run=False, quality_score=-1.0, qualified_files=None)
 
     assert result["success"] is True
-    assert "--dir" in captured["cmd"]
-    assert "--auto-promote" in captured["cmd"]
+    assert captured["vault_dir"] == vault
     assert captured["staged_files"] == ["example_深度解读.md"]
-    assert captured["timeout"] == 600
 
 
 def test_load_latest_qualified_files_unions_batches(tmp_path):
@@ -623,7 +683,6 @@ def test_load_latest_qualified_files_unions_batches(tmp_path):
 
 def test_step_absorb_batches_qualified_files_and_aggregates_results(tmp_path, monkeypatch):
     from openclaw_pipeline.unified_pipeline_enhanced import PipelineLogger, TransactionManager
-    import json
 
     vault = tmp_path / "vault"
     (vault / "60-Logs").mkdir(parents=True)
@@ -639,7 +698,7 @@ def test_step_absorb_batches_qualified_files_and_aggregates_results(tmp_path, mo
         path.write_text(f"# {idx}\n", encoding="utf-8")
         files.append(path)
 
-    calls: list[tuple[list[str], int | None]] = []
+    calls: list[list[str]] = []
     payloads = [
         {
             "summary": {
@@ -667,19 +726,13 @@ def test_step_absorb_batches_qualified_files_and_aggregates_results(tmp_path, mo
         },
     ]
 
-    def fake_run_command(cmd: list[str], step_name: str, timeout: int | None = None) -> dict:
-        calls.append((cmd, timeout))
-        absorb_dir = Path(cmd[cmd.index("--dir") + 1])
-        staged_files = sorted(p.name for p in absorb_dir.glob("*.md"))
+    def fake_run_absorb_workflow(vault_dir, *, directory=None, **_):
+        absorb_dir = Path(directory)
+        calls.append(sorted(p.name for p in absorb_dir.glob("*.md")))
         payload = payloads[len(calls) - 1]
-        return {
-            "success": True,
-            "stdout": json.dumps(payload, ensure_ascii=False),
-            "stderr": "",
-            "staged_files": staged_files,
-        }
+        return payload
 
-    monkeypatch.setattr(pipeline, "run_command", fake_run_command)
+    monkeypatch.setattr("openclaw_pipeline.unified_pipeline_enhanced.run_absorb_workflow", fake_run_absorb_workflow)
 
     result = pipeline.step_absorb(
         dry_run=False,
@@ -696,8 +749,8 @@ def test_step_absorb_batches_qualified_files_and_aggregates_results(tmp_path, mo
     assert result["summary"]["concepts_promoted"] == 3
     assert result["summary"]["concepts_skipped"] == 1
     assert len(calls) == 2
-    assert calls[0][1] == 600
-    assert calls[1][1] == 600
+    assert calls[0] == ["absorb_0_深度解读.md", "absorb_1_深度解读.md"]
+    assert calls[1] == ["absorb_2_深度解读.md"]
 
 
 def test_absorb_timeout_scales_with_batch_size(tmp_path):
@@ -714,7 +767,7 @@ def test_absorb_timeout_scales_with_batch_size(tmp_path):
     assert timeout > 300
 
 
-def test_step_absorb_parses_json_payload_after_log_prefix(tmp_path, monkeypatch):
+def test_step_absorb_updates_txn_ledger_with_counted_progress(tmp_path, monkeypatch):
     from openclaw_pipeline.unified_pipeline_enhanced import PipelineLogger, TransactionManager
     import json
 
@@ -723,41 +776,62 @@ def test_step_absorb_parses_json_payload_after_log_prefix(tmp_path, monkeypatch)
     logger = PipelineLogger(vault / "60-Logs" / "pipeline.jsonl")
     txn = TransactionManager(vault / "60-Logs" / "transactions")
     pipeline = EnhancedPipeline(vault, logger, txn)
+    pipeline.txn_id = txn.start("enhanced-pipeline", "Phase 25 absorb progress")
 
     topic_dir = vault / "20-Areas" / "Tools" / "Topics" / "2026-04"
     topic_dir.mkdir(parents=True, exist_ok=True)
-    deep_dive = topic_dir / "prefixed_深度解读.md"
-    deep_dive.write_text("# prefixed\n", encoding="utf-8")
+    deep_dives = []
+    for name in ("alpha_深度解读.md", "beta_深度解读.md"):
+        deep_dive = topic_dir / name
+        deep_dive.write_text("# item\n", encoding="utf-8")
+        deep_dives.append(deep_dive)
 
-    payload = {
-        "summary": {
-            "files_processed": 1,
-            "concepts_extracted": 2,
-            "candidates_added": 1,
-            "concepts_created": 1,
-            "concepts_promoted": 1,
-            "concepts_skipped": 0,
-            "errors": 0,
-        },
-        "results": [],
-    }
+    def fake_run_absorb_workflow(vault_dir, *, directory=None, progress_callback=None, **_):
+        staged = sorted(p.name for p in Path(directory).glob("*.md"))
+        if progress_callback is not None:
+            for idx, name in enumerate(staged, start=1):
+                progress_callback(
+                    {
+                        "event_type": "absorb_file_processed",
+                        "file": name,
+                        "files_total": len(staged),
+                        "files_done": idx,
+                        "files_failed": 0,
+                        "current_item": name,
+                    }
+                )
+        return {
+            "summary": {
+                "files_processed": len(staged),
+                "concepts_extracted": 2,
+                "candidates_added": 1,
+                "concepts_created": 1,
+                "concepts_promoted": 1,
+                "concepts_skipped": 0,
+                "errors": 0,
+            },
+            "results": [],
+        }
 
-    def fake_run_command(cmd: list[str], step_name: str, timeout: int | None = None) -> dict:
-        stdout = "processing batch...\nextra note\n" + json.dumps(payload, ensure_ascii=False)
-        return {"success": True, "stdout": stdout, "stderr": ""}
-
-    monkeypatch.setattr(pipeline, "run_command", fake_run_command)
+    monkeypatch.setattr("openclaw_pipeline.unified_pipeline_enhanced.run_absorb_workflow", fake_run_absorb_workflow)
 
     result = pipeline.step_absorb(
         dry_run=False,
         quality_score=4.0,
-        qualified_files=[str(deep_dive)],
-        batch_size=1,
+        qualified_files=[str(path) for path in deep_dives],
+        batch_size=2,
     )
 
     assert result["success"] is True
-    assert result["summary"]["files_processed"] == 1
-    assert result["summary"]["concepts_promoted"] == 1
+    payload = json.loads((vault / "60-Logs" / "transactions" / f"{pipeline.txn_id}.json").read_text(encoding="utf-8"))
+    current = payload["run_ledger"]["current_step"]
+    assert current["step_name"] == "absorb"
+    assert current["progress_mode"] == "counted"
+    assert current["work_units_total"] == 2
+    assert current["work_units_done"] == 2
+    assert current["progress_percent"] == 100.0
+    assert current["current_item"] == "beta_深度解读.md"
+    assert payload["run_ledger"]["last_meaningful_event"]["event_type"] == "absorb_file_processed"
 
 
 def test_step_absorb_rejects_non_positive_batch_size(tmp_path):

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from argparse import Namespace
 from datetime import datetime
+import json
+import os
 from pathlib import Path
 import sys
 
@@ -834,6 +836,38 @@ def test_step_absorb_updates_txn_ledger_with_counted_progress(tmp_path, monkeypa
     assert payload["run_ledger"]["last_meaningful_event"]["event_type"] == "absorb_file_processed"
 
 
+def test_run_absorb_workflow_direct_reports_file_level_errors(tmp_path, monkeypatch):
+    import openclaw_pipeline.unified_pipeline_enhanced as pipeline_module
+    from openclaw_pipeline.unified_pipeline_enhanced import PipelineLogger, TransactionManager
+
+    vault = tmp_path / "vault"
+    (vault / "60-Logs").mkdir(parents=True, exist_ok=True)
+    logger = PipelineLogger(vault / "60-Logs" / "pipeline.jsonl")
+    txn = TransactionManager(vault / "60-Logs" / "transactions")
+    pipeline = EnhancedPipeline(vault, logger, txn)
+
+    def fake_run_absorb_workflow(*_args, **_kwargs):
+        return {
+            "summary": {
+                "files_processed": 1,
+                "errors": 1,
+            },
+            "results": [
+                {
+                    "file": "broken_深度解读.md",
+                    "error": "extract failed",
+                }
+            ],
+        }
+
+    monkeypatch.setattr(pipeline_module, "run_absorb_workflow", fake_run_absorb_workflow)
+
+    result = pipeline._run_absorb_workflow_direct(dry_run=False, recent=7, total_files=1)
+
+    assert result["success"] is False
+    assert result["error"] == "1 absorb file(s) failed"
+
+
 def test_step_absorb_rejects_non_positive_batch_size(tmp_path):
     from openclaw_pipeline.unified_pipeline_enhanced import PipelineLogger, TransactionManager
 
@@ -862,6 +896,52 @@ def test_run_command_timeout_is_failure(tmp_path):
 
     assert result["success"] is False
     assert result["timeout"] is True
+
+
+def test_step_pinboard_process_heartbeats_current_item_before_processor_runs(tmp_path, monkeypatch):
+    import openclaw_pipeline.unified_pipeline_enhanced as pipeline_module
+    from openclaw_pipeline.unified_pipeline_enhanced import PipelineLogger, TransactionManager
+
+    vault = tmp_path / "vault"
+    (vault / "50-Inbox" / "02-Pinboard").mkdir(parents=True)
+    (vault / "50-Inbox" / "02-Pinboard-Archive").mkdir(parents=True)
+    (vault / "60-Logs").mkdir(parents=True)
+    pinboard_file = vault / "50-Inbox" / "02-Pinboard" / "sample.md"
+    pinboard_file.write_text(
+        """---
+title: Sample
+type: pinboard-article
+source: https://example.com/sample
+---
+
+# Sample
+""",
+        encoding="utf-8",
+    )
+    logger = PipelineLogger(vault / "60-Logs" / "pipeline.jsonl")
+    txn = TransactionManager(vault / "60-Logs" / "transactions")
+    pipeline = EnhancedPipeline(vault, logger, txn)
+    pipeline.txn_id = txn.start("enhanced-pipeline", "Pinboard processor heartbeat")
+    current_items_seen: list[str | None] = []
+
+    def direct_subprocess_run_is_not_allowed(*_args, **_kwargs):
+        raise AssertionError("pinboard processors must run through run_command")
+
+    def fake_run_command(_cmd: list[str], step_name: str, timeout: int | None = None) -> dict:
+        assert step_name == "pinboard_process"
+        assert timeout == 600
+        payload = json.loads((vault / "60-Logs" / "transactions" / f"{pipeline.txn_id}.json").read_text(encoding="utf-8"))
+        current_items_seen.append(payload["run_ledger"]["current_step"].get("current_item"))
+        return {"success": True, "stdout": "ok", "stderr": ""}
+
+    monkeypatch.setattr(pipeline_module.subprocess, "run", direct_subprocess_run_is_not_allowed)
+    monkeypatch.setattr(pipeline, "run_command", fake_run_command)
+
+    result = pipeline.step_pinboard_process(dry_run=False)
+
+    assert result["success"] is True
+    assert current_items_seen == ["sample.md"]
+    assert not pinboard_file.exists()
 
 
 def test_step_pinboard_decomposes_cross_day_history_into_daily_requests(tmp_path, monkeypatch):
@@ -893,6 +973,25 @@ def test_step_pinboard_decomposes_cross_day_history_into_daily_requests(tmp_path
     assert captured_cmds[0][-5:] == ["--start-date", "2026-04-01", "--end-date", "2026-04-01", "--dry-run=false"]
     assert captured_cmds[1][-5:] == ["--start-date", "2026-04-02", "--end-date", "2026-04-02", "--dry-run=false"]
     assert captured_cmds[2][-5:] == ["--start-date", "2026-04-03", "--end-date", "2026-04-03", "--dry-run=false"]
+
+
+def test_collect_absorb_targets_recent_filters_by_file_mtime(tmp_path):
+    from openclaw_pipeline.auto_evergreen_extractor import _collect_absorb_targets
+
+    vault = tmp_path / "vault"
+    layout = VaultLayout.from_vault(vault)
+    month_dir = layout.vault_dir / "20-Areas" / "AI-Research" / "Topics" / datetime.now().strftime("%Y-%m")
+    month_dir.mkdir(parents=True, exist_ok=True)
+    recent_file = month_dir / "recent_深度解读.md"
+    old_file = month_dir / "old_深度解读.md"
+    recent_file.write_text("# recent\n", encoding="utf-8")
+    old_file.write_text("# old\n", encoding="utf-8")
+    old_ts = datetime.now().timestamp() - (30 * 24 * 60 * 60)
+    os.utime(old_file, (old_ts, old_ts))
+
+    targets = _collect_absorb_targets(layout, recent=7)
+
+    assert targets == [recent_file]
 
 
 def test_before_counts_include_monthly_processed_files(tmp_path):

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -189,6 +189,79 @@ def test_truth_api_reads_signal_and_action_ledgers_without_knowledge_db(temp_vau
     assert actions[0]["impact_summary"]["lifecycle_stage"] == "queued"
 
 
+def test_truth_api_get_runtime_status_reads_active_run_ledger(temp_vault):
+    from openclaw_pipeline.truth_api import get_runtime_status
+
+    logs_dir = temp_vault / "60-Logs"
+    transactions_dir = logs_dir / "transactions"
+    transactions_dir.mkdir(parents=True, exist_ok=True)
+    (transactions_dir / "txn-1.json").write_text(
+        json.dumps(
+            {
+                "id": "txn-1",
+                "type": "enhanced-pipeline",
+                "status": "in_progress",
+                "checkpoint": "absorb",
+                "last_updated": "2026-04-09T00:15:00Z",
+                "run_ledger": {
+                    "run_id": "txn-1",
+                    "run_state": "running",
+                    "workflow_profile": "full",
+                    "pack_name": "research-tech",
+                    "heartbeat_at": "2026-04-09T00:15:00Z",
+                    "current_step_name": "absorb",
+                    "current_step": {
+                        "step_name": "absorb",
+                        "step_state": "running",
+                        "progress_mode": "counted",
+                        "work_units_total": 20,
+                        "work_units_done": 5,
+                        "work_units_failed": 1,
+                        "current_item": "Alpha.md",
+                        "progress_percent": 25.0,
+                        "progress_summary": "5/20 files processed",
+                    },
+                    "last_meaningful_event": {
+                        "event_type": "absorb_file_processed",
+                        "file": "Alpha.md",
+                    },
+                },
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    (transactions_dir / "txn-old.json").write_text(
+        json.dumps(
+            {
+                "id": "txn-old",
+                "type": "enhanced-pipeline",
+                "status": "in_progress",
+                "checkpoint": "fix_links",
+                "last_updated": "2026-04-08T00:15:00Z",
+                "run_ledger": {
+                    "run_id": "txn-old",
+                    "run_state": "running",
+                    "heartbeat_at": "2026-04-08T00:15:00Z",
+                    "current_step": {
+                        "step_name": "fix_links",
+                        "step_state": "running",
+                    },
+                },
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    payload = get_runtime_status(temp_vault, now_iso="2026-04-09T00:20:00Z")
+
+    assert payload["active_run"]["id"] == "txn-1"
+    assert payload["active_run"]["run_ledger"]["current_step"]["progress_percent"] == 25.0
+    assert payload["active_run"]["run_ledger"]["current_step"]["current_item"] == "Alpha.md"
+    assert payload["stale_count"] == 1
+
+
 def test_truth_api_builds_note_inbound_capture_summary_and_attaches_it_to_signals(temp_vault):
     from openclaw_pipeline.truth_api import get_note_inbound_capture_summary, list_signals
 

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -256,6 +256,7 @@ def test_truth_api_get_runtime_status_reads_active_run_ledger(temp_vault):
 
     payload = get_runtime_status(temp_vault, now_iso="2026-04-09T00:20:00Z")
 
+    assert payload["generated_at"] == "2026-04-09T00:20:00Z"
     assert payload["active_run"]["id"] == "txn-1"
     assert payload["active_run"]["run_ledger"]["current_step"]["progress_percent"] == 25.0
     assert payload["active_run"]["run_ledger"]["current_step"]["current_item"] == "Alpha.md"

--- a/tests/test_txn_runtime_ledger.py
+++ b/tests/test_txn_runtime_ledger.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def test_transaction_manager_start_creates_run_ledger(tmp_path):
+    from openclaw_pipeline.unified_pipeline_enhanced import TransactionManager
+
+    txn = TransactionManager(tmp_path)
+    txn_id = txn.start(
+        "enhanced-pipeline",
+        "Incremental pipeline",
+        pack_name="research-tech",
+        workflow_profile="full",
+        planned_steps=["pinboard", "clippings", "articles"],
+    )
+
+    payload = json.loads((tmp_path / f"{txn_id}.json").read_text(encoding="utf-8"))
+
+    assert payload["run_ledger"]["run_id"] == txn_id
+    assert payload["run_ledger"]["run_state"] == "running"
+    assert payload["run_ledger"]["pack_name"] == "research-tech"
+    assert payload["run_ledger"]["workflow_profile"] == "full"
+    assert payload["run_ledger"]["planned_steps"] == ["pinboard", "clippings", "articles"]
+    assert payload["run_ledger"]["current_step"]["step_name"] == "initialized"
+    assert payload["run_ledger"]["current_step"]["step_state"] == "pending"
+
+
+def test_transaction_manager_tracks_step_progress_and_percent(tmp_path):
+    from openclaw_pipeline.unified_pipeline_enhanced import TransactionManager
+
+    txn = TransactionManager(tmp_path)
+    txn_id = txn.start("enhanced-pipeline", "Incremental pipeline")
+
+    txn.step(
+        txn_id,
+        "absorb",
+        "in_progress",
+        progress_mode="counted",
+        work_units_total=10,
+        work_units_done=3,
+        work_units_failed=1,
+        current_item="Alpha_深度解读.md",
+        progress_summary="3/10 files processed",
+        last_meaningful_event={
+            "event_type": "absorb_file_processed",
+            "file": "Alpha_深度解读.md",
+        },
+    )
+
+    payload = json.loads((tmp_path / f"{txn_id}.json").read_text(encoding="utf-8"))
+    current = payload["run_ledger"]["current_step"]
+
+    assert payload["run_ledger"]["current_step_name"] == "absorb"
+    assert current["step_name"] == "absorb"
+    assert current["step_state"] == "running"
+    assert current["progress_mode"] == "counted"
+    assert current["work_units_total"] == 10
+    assert current["work_units_done"] == 3
+    assert current["work_units_failed"] == 1
+    assert current["current_item"] == "Alpha_深度解读.md"
+    assert current["progress_percent"] == 30.0
+    assert current["progress_summary"] == "3/10 files processed"
+    assert payload["run_ledger"]["last_meaningful_event"]["event_type"] == "absorb_file_processed"
+
+
+def test_classify_run_ledgers_separates_active_and_stale(tmp_path):
+    from openclaw_pipeline.txn import classify_run_ledgers
+
+    active = tmp_path / "txn-active.json"
+    active.write_text(
+        json.dumps(
+            {
+                "id": "txn-active",
+                "status": "in_progress",
+                "checkpoint": "absorb",
+                "last_updated": "2026-04-18T12:05:00Z",
+                "run_ledger": {
+                    "run_id": "txn-active",
+                    "run_state": "running",
+                    "heartbeat_at": "2026-04-18T12:05:00Z",
+                    "current_step": {
+                        "step_name": "absorb",
+                        "step_state": "running",
+                    },
+                },
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    stale = tmp_path / "txn-stale.json"
+    stale.write_text(
+        json.dumps(
+            {
+                "id": "txn-stale",
+                "status": "in_progress",
+                "checkpoint": "fix_links",
+                "last_updated": "2026-04-18T10:00:00Z",
+                "run_ledger": {
+                    "run_id": "txn-stale",
+                    "run_state": "running",
+                    "heartbeat_at": "2026-04-18T10:00:00Z",
+                    "current_step": {
+                        "step_name": "fix_links",
+                        "step_state": "running",
+                    },
+                },
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    classified = classify_run_ledgers(
+        tmp_path,
+        now_iso="2026-04-18T12:10:00Z",
+        stale_after_seconds=1800,
+    )
+
+    assert [item["id"] for item in classified["active"]] == ["txn-active"]
+    assert [item["id"] for item in classified["stale"]] == ["txn-stale"]

--- a/tests/test_txn_runtime_ledger.py
+++ b/tests/test_txn_runtime_ledger.py
@@ -88,6 +88,46 @@ def test_transaction_manager_tracks_step_progress_and_percent(tmp_path):
     assert payload["run_ledger"]["last_meaningful_event"]["event_type"] == "absorb_file_processed"
 
 
+def test_transaction_step_transition_resets_previous_progress_fields():
+    from openclaw_pipeline.txn import build_transaction_payload, heartbeat_transaction, update_transaction_step
+
+    payload = build_transaction_payload("txn-1", "enhanced-pipeline", "demo")
+    update_transaction_step(
+        payload,
+        "absorb",
+        "in_progress",
+        progress_mode="counted",
+        work_units_total=10,
+        work_units_done=4,
+        work_units_failed=1,
+        current_item="Alpha_深度解读.md",
+        progress_summary="4/10 files processed",
+    )
+
+    update_transaction_step(payload, "moc", "in_progress")
+
+    current = payload["run_ledger"]["current_step"]
+    assert current["step_name"] == "moc"
+    assert current["progress_mode"] == "indeterminate"
+    assert current["work_units_total"] is None
+    assert current["work_units_done"] == 0
+    assert current["work_units_failed"] == 0
+    assert current["current_item"] is None
+    assert current["progress_percent"] is None
+    assert current["progress_summary"] == "Progress is currently indeterminate."
+
+    heartbeat_transaction(payload, step_name="knowledge_index")
+
+    current = payload["run_ledger"]["current_step"]
+    assert current["step_name"] == "knowledge_index"
+    assert current["progress_mode"] == "indeterminate"
+    assert current["work_units_total"] is None
+    assert current["work_units_done"] == 0
+    assert current["work_units_failed"] == 0
+    assert current["current_item"] is None
+    assert current["progress_percent"] is None
+
+
 def test_classify_run_ledgers_separates_active_and_stale(tmp_path):
     from openclaw_pipeline.txn import classify_run_ledgers
 

--- a/tests/test_txn_runtime_ledger.py
+++ b/tests/test_txn_runtime_ledger.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 
 def test_transaction_manager_start_creates_run_ledger(tmp_path):
     from openclaw_pipeline.unified_pipeline_enhanced import TransactionManager
@@ -25,6 +27,27 @@ def test_transaction_manager_start_creates_run_ledger(tmp_path):
     assert payload["run_ledger"]["planned_steps"] == ["pinboard", "clippings", "articles"]
     assert payload["run_ledger"]["current_step"]["step_name"] == "initialized"
     assert payload["run_ledger"]["current_step"]["step_state"] == "pending"
+
+
+def test_transaction_manager_write_preserves_previous_ledger_on_dump_failure(tmp_path, monkeypatch):
+    import openclaw_pipeline.unified_pipeline_enhanced as pipeline_module
+    from openclaw_pipeline.unified_pipeline_enhanced import TransactionManager
+
+    txn = TransactionManager(tmp_path)
+    txn_file = tmp_path / "txn-1.json"
+    txn_file.write_text(json.dumps({"id": "txn-1", "status": "in_progress"}), encoding="utf-8")
+
+    def broken_dump(_payload, fp, **_kwargs):
+        fp.write('{"partial":')
+        raise RuntimeError("simulated dump failure")
+
+    monkeypatch.setattr(pipeline_module.json, "dump", broken_dump)
+
+    with pytest.raises(RuntimeError, match="simulated dump failure"):
+        txn._write("txn-1", {"id": "txn-1", "status": "completed"})
+
+    assert json.loads(txn_file.read_text(encoding="utf-8")) == {"id": "txn-1", "status": "in_progress"}
+    assert not list(tmp_path.glob(".txn-1.json*.tmp"))
 
 
 def test_transaction_manager_tracks_step_progress_and_percent(tmp_path):
@@ -121,3 +144,34 @@ def test_classify_run_ledgers_separates_active_and_stale(tmp_path):
 
     assert [item["id"] for item in classified["active"]] == ["txn-active"]
     assert [item["id"] for item in classified["stale"]] == ["txn-stale"]
+
+
+def test_classify_run_ledgers_falls_back_when_now_iso_is_malformed(tmp_path):
+    from openclaw_pipeline.txn import classify_run_ledgers
+
+    txn_file = tmp_path / "txn-active.json"
+    txn_file.write_text(
+        json.dumps(
+            {
+                "id": "txn-active",
+                "status": "in_progress",
+                "checkpoint": "absorb",
+                "last_updated": "2026-04-18T12:05:00Z",
+                "run_ledger": {
+                    "run_id": "txn-active",
+                    "run_state": "running",
+                    "heartbeat_at": "2026-04-18T12:05:00Z",
+                    "current_step": {
+                        "step_name": "absorb",
+                        "step_state": "running",
+                    },
+                },
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    classified = classify_run_ledgers(tmp_path, now_iso="not-a-timestamp", stale_after_seconds=10**9)
+
+    assert [item["id"] for item in classified["active"]] == ["txn-active"]

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -189,6 +189,41 @@ def test_ui_server_runtime_endpoint_returns_payload(temp_vault):
     assert payload["active_run"]["run_ledger"]["current_step"]["progress_percent"] == 25.0
 
 
+def test_ui_server_runtime_endpoint_returns_structured_error(temp_vault, monkeypatch):
+    import openclaw_pipeline.commands.ui_server as ui_server
+
+    def fail_runtime_status(_vault_dir):
+        raise OSError("ledger read failed")
+
+    monkeypatch.setattr(ui_server, "get_runtime_status", fail_runtime_status)
+    server = ui_server.create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("GET", "/api/runtime")
+        response = conn.getresponse()
+        payload = json.loads(response.read().decode("utf-8"))
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 503
+    assert payload["active_run"] is None
+    assert payload["stale_count"] == 0
+    assert payload["error"] == "runtime_status_unavailable"
+
+
+def test_render_runtime_card_tolerates_malformed_stale_count():
+    from openclaw_pipeline.commands.ui_server import _render_runtime_card
+
+    html = _render_runtime_card({"active_run": None, "stale_count": "not-a-number"})
+
+    assert "No active workflow is currently recorded" in html
+
+
 def test_ui_server_root_accepts_pack_scope(temp_vault):
     from openclaw_pipeline.commands.ui_server import create_server
 

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -4,11 +4,16 @@ import json
 import sqlite3
 import subprocess
 import threading
+from datetime import datetime, timedelta, timezone
 from http.client import HTTPConnection
 from pathlib import Path
 from urllib.parse import urlencode
 
 from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
+
+
+def _fresh_timestamp(*, seconds_ago: int = 0) -> str:
+    return (datetime.now(timezone.utc) - timedelta(seconds=seconds_ago)).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def _seed_truth_store(temp_vault):
@@ -65,6 +70,41 @@ def test_ui_server_root_serves_html_shell(temp_vault):
     from openclaw_pipeline.commands.ui_server import create_server
 
     _seed_truth_store(temp_vault)
+    transactions_dir = temp_vault / "60-Logs" / "transactions"
+    transactions_dir.mkdir(parents=True, exist_ok=True)
+    (transactions_dir / "txn-1.json").write_text(
+        json.dumps(
+            {
+                "id": "txn-1",
+                "type": "enhanced-pipeline",
+                "status": "in_progress",
+                "checkpoint": "absorb",
+                "last_updated": _fresh_timestamp(seconds_ago=60),
+                "run_ledger": {
+                    "run_id": "txn-1",
+                    "run_state": "running",
+                    "workflow_profile": "full",
+                    "pack_name": "research-tech",
+                    "heartbeat_at": _fresh_timestamp(seconds_ago=30),
+                    "current_step_name": "absorb",
+                    "current_step": {
+                        "step_name": "absorb",
+                        "step_state": "running",
+                        "progress_mode": "counted",
+                        "work_units_total": 10,
+                        "work_units_done": 3,
+                        "work_units_failed": 0,
+                        "current_item": "Alpha.md",
+                        "progress_percent": 30.0,
+                        "progress_summary": "3/10 files processed",
+                    },
+                    "last_meaningful_event": {"event_type": "absorb_file_processed", "file": "Alpha.md"},
+                },
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
     server = create_server(temp_vault, host="127.0.0.1", port=0)
     port = server.server_address[1]
     thread = threading.Thread(target=server.serve_forever, daemon=True)
@@ -85,9 +125,68 @@ def test_ui_server_root_serves_html_shell(temp_vault):
     assert "Orient" in body
     assert "Inspect" in body
     assert "Review" in body
+    assert "Current Workflow" in body
+    assert "3/10 files processed" in body
+    assert "Alpha.md" in body
     assert "Where To Start" in body
     assert "Orientation Brief" in body
     assert "/api/objects" in body
+
+
+def test_ui_server_runtime_endpoint_returns_payload(temp_vault):
+    from openclaw_pipeline.commands.ui_server import create_server
+
+    transactions_dir = temp_vault / "60-Logs" / "transactions"
+    transactions_dir.mkdir(parents=True, exist_ok=True)
+    (transactions_dir / "txn-1.json").write_text(
+        json.dumps(
+            {
+                "id": "txn-1",
+                "type": "enhanced-pipeline",
+                "status": "in_progress",
+                "checkpoint": "absorb",
+                "last_updated": _fresh_timestamp(seconds_ago=60),
+                "run_ledger": {
+                    "run_id": "txn-1",
+                    "run_state": "running",
+                    "workflow_profile": "full",
+                    "pack_name": "research-tech",
+                    "heartbeat_at": _fresh_timestamp(seconds_ago=30),
+                    "current_step_name": "absorb",
+                    "current_step": {
+                        "step_name": "absorb",
+                        "step_state": "running",
+                        "progress_mode": "counted",
+                        "work_units_total": 20,
+                        "work_units_done": 5,
+                        "work_units_failed": 0,
+                        "current_item": "Beta.md",
+                        "progress_percent": 25.0,
+                        "progress_summary": "5/20 files processed",
+                    },
+                },
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("GET", "/api/runtime")
+        response = conn.getresponse()
+        payload = json.loads(response.read().decode("utf-8"))
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 200
+    assert payload["active_run"]["id"] == "txn-1"
+    assert payload["active_run"]["run_ledger"]["current_step"]["progress_percent"] == 25.0
 
 
 def test_ui_server_root_accepts_pack_scope(temp_vault):

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -177,6 +177,69 @@ def test_build_object_page_payload_hides_research_affordances_when_research_shel
     assert payload["evolution"]["accepted_count"] == 0
 
 
+def test_build_runtime_home_payload_keeps_runtime_when_objects_index_fails(temp_vault, monkeypatch):
+    import openclaw_pipeline.ui.view_models as view_models
+
+    monkeypatch.setattr(
+        view_models,
+        "get_runtime_status",
+        lambda _vault_dir: {
+            "generated_at": "2026-04-18T12:00:00Z",
+            "active_count": 0,
+            "stale_count": 0,
+            "active_run": None,
+            "stale_runs": [],
+        },
+    )
+
+    def fail_objects_index(*_args, **_kwargs):
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(view_models, "build_objects_index_payload", fail_objects_index)
+
+    payload = view_models.build_runtime_home_payload(temp_vault)
+
+    assert payload["runtime"]["generated_at"] == "2026-04-18T12:00:00Z"
+    assert payload["objects"]["total_count"] == 0
+    assert payload["objects"]["items"] == []
+    assert payload["objects"]["error"] == "object_index_unavailable"
+
+
+def test_build_runtime_home_payload_uses_active_step_fallback_without_progress_summary(temp_vault, monkeypatch):
+    import openclaw_pipeline.ui.view_models as view_models
+
+    monkeypatch.setattr(
+        view_models,
+        "get_runtime_status",
+        lambda _vault_dir: {
+            "generated_at": "2026-04-18T12:00:00Z",
+            "active_count": 1,
+            "stale_count": 0,
+            "active_run": {
+                "id": "txn-1",
+                "status": "in_progress",
+                "checkpoint": "pinboard_process",
+                "run_ledger": {
+                    "current_step_name": "pinboard_process",
+                    "current_step": {
+                        "step_name": "pinboard_process",
+                    },
+                },
+            },
+            "stale_runs": [],
+        },
+    )
+    monkeypatch.setattr(
+        view_models,
+        "build_objects_index_payload",
+        lambda *_args, **_kwargs: {"total_count": 0, "items": []},
+    )
+
+    payload = view_models.build_runtime_home_payload(temp_vault)
+
+    assert payload["entry_sections"][0]["summary"] == "Active run at step pinboard_process."
+
+
 def test_build_object_page_payload_includes_provenance(temp_vault):
     from openclaw_pipeline.ui.view_models import build_object_page_payload
 

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -2,8 +2,13 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from datetime import datetime, timedelta, timezone
 
 from openclaw_pipeline.knowledge_index import rebuild_knowledge_index
+
+
+def _fresh_timestamp(*, seconds_ago: int = 0) -> str:
+    return (datetime.now(timezone.utc) - timedelta(seconds=seconds_ago)).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def _seed_truth_store(temp_vault):
@@ -165,6 +170,8 @@ def test_build_object_page_payload_hides_research_affordances_when_research_shel
         "Production Chain",
         "Open Tensions",
         "Where To Go Next",
+        "Claims",
+        "Relations",
     ]
     assert payload["evolution"]["candidate_count"] == 0
     assert payload["evolution"]["accepted_count"] == 0
@@ -1101,6 +1108,41 @@ def test_build_truth_dashboard_payload(temp_vault):
     from openclaw_pipeline.ui.view_models import build_truth_dashboard_payload
 
     _seed_truth_store(temp_vault)
+    transactions_dir = temp_vault / "60-Logs" / "transactions"
+    transactions_dir.mkdir(parents=True, exist_ok=True)
+    (transactions_dir / "txn-1.json").write_text(
+        json.dumps(
+            {
+                "id": "txn-1",
+                "type": "enhanced-pipeline",
+                "status": "in_progress",
+                "checkpoint": "absorb",
+                "last_updated": _fresh_timestamp(seconds_ago=60),
+                "run_ledger": {
+                    "run_id": "txn-1",
+                    "run_state": "running",
+                    "workflow_profile": "full",
+                    "pack_name": "research-tech",
+                    "heartbeat_at": _fresh_timestamp(seconds_ago=30),
+                    "current_step_name": "absorb",
+                    "current_step": {
+                        "step_name": "absorb",
+                        "step_state": "running",
+                        "progress_mode": "counted",
+                        "work_units_total": 10,
+                        "work_units_done": 3,
+                        "work_units_failed": 0,
+                        "current_item": "Alpha.md",
+                        "progress_percent": 30.0,
+                        "progress_summary": "3/10 files processed",
+                    },
+                    "last_meaningful_event": {"event_type": "absorb_file_processed", "file": "Alpha.md"},
+                },
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
     loose_source = temp_vault / "50-Inbox" / "03-Processed" / "2026-04" / "Loose Source.md"
     loose_source.parent.mkdir(parents=True, exist_ok=True)
     loose_source.write_text(
@@ -1133,6 +1175,8 @@ Thin note.
     payload = build_truth_dashboard_payload(temp_vault)
 
     assert payload["screen"] == "truth/dashboard"
+    assert payload["runtime"]["active_run"]["id"] == "txn-1"
+    assert payload["runtime"]["active_run"]["run_ledger"]["current_step"]["progress_percent"] == 30.0
     assert payload["orientation"]["assembly_contract"]["recipe_name"] == "orientation_brief"
     assert [section["id"] for section in payload["entry_sections"]] == [
         "what_changed_recently",

--- a/tests/test_watch_progress_command.py
+++ b/tests/test_watch_progress_command.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from openclaw_pipeline.runtime import VaultLayout
+
+
+def _fresh_timestamp(*, seconds_ago: int = 0) -> str:
+    return (datetime.now(timezone.utc) - timedelta(seconds=seconds_ago)).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def test_collect_progress_snapshot_reads_counts_transactions_and_latest_event(temp_vault):
@@ -32,7 +37,7 @@ def test_collect_progress_snapshot_reads_counts_transactions_and_latest_event(te
                 "type": "pipeline",
                 "status": "in_progress",
                 "checkpoint": "articles",
-                "last_updated": "2026-04-09T00:15:00Z",
+                "last_updated": _fresh_timestamp(seconds_ago=60),
             }
         ),
         encoding="utf-8",
@@ -69,6 +74,53 @@ def test_collect_progress_snapshot_reads_counts_transactions_and_latest_event(te
     assert snapshot["latest_event"]["event_type"] == "article_processed"
     assert snapshot["latest_report"] == str(report)
     assert snapshot["active_processes"] == 1
+
+
+def test_collect_progress_snapshot_surfaces_run_ledger_progress(temp_vault):
+    layout = VaultLayout.from_vault(temp_vault)
+    layout.transactions_dir.mkdir(parents=True, exist_ok=True)
+    (layout.transactions_dir / "txn-1.json").write_text(
+        json.dumps(
+            {
+                "id": "txn-1",
+                "type": "pipeline",
+                "status": "in_progress",
+                "checkpoint": "absorb",
+                "last_updated": _fresh_timestamp(seconds_ago=60),
+                "run_ledger": {
+                    "run_id": "txn-1",
+                    "run_state": "running",
+                    "workflow_profile": "full",
+                    "pack_name": "research-tech",
+                    "heartbeat_at": _fresh_timestamp(seconds_ago=30),
+                    "current_step_name": "absorb",
+                    "last_meaningful_event": {"event_type": "absorb_file_processed", "file": "Alpha.md"},
+                    "current_step": {
+                        "step_name": "absorb",
+                        "step_state": "running",
+                        "progress_mode": "counted",
+                        "work_units_total": 10,
+                        "work_units_done": 3,
+                        "work_units_failed": 0,
+                        "current_item": "Alpha.md",
+                        "progress_percent": 30.0,
+                        "progress_summary": "3/10 files processed",
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    from openclaw_pipeline.commands.watch_progress import collect_progress_snapshot, format_progress_snapshot
+
+    snapshot = collect_progress_snapshot(temp_vault, process_lines=["python -m openclaw_pipeline.unified_pipeline_enhanced"])
+
+    assert snapshot["active_run"]["id"] == "txn-1"
+    assert snapshot["active_run"]["run_ledger"]["current_step"]["progress_percent"] == 30.0
+    rendered = format_progress_snapshot(snapshot)
+    assert "Step progress: 3/10 files processed" in rendered
+    assert "Current item: Alpha.md" in rendered
 
 
 def test_collect_progress_snapshot_ignores_report_removed_during_sort(temp_vault, monkeypatch):


### PR DESCRIPTION
## Summary

This PR closes Phase 25 by replacing the black-box pipeline operator experience with a canonical runtime ledger and shared reader stack.

Changes include:

- Adds a `run_ledger` contract for active/stale workflow state, current step, heartbeat, counted progress, current item, and last meaningful event.
- Upgrades pipeline execution so `TransactionManager`, subprocess stages, `pinboard_process`, and `absorb` write observable runtime state.
- Adds `ovp --incremental` as the explicit daily entrypoint, including Pinboard through `knowledge_index`.
- Unifies operator readers so `watch_progress`, `truth_api.get_runtime_status(...)`, `/api/runtime`, and the UI root shell read the same runtime truth.
- Switches `/` to a runtime-first home shell so current workflow visibility stays fast during live runs instead of rebuilding every heavy dashboard surface.
- Updates docs, recipes, verify checklist, roadmap notes, and tests.

## Root Cause

The previous workflow required stitching together transaction JSON, `pipeline.jsonl`, process lists, and ad hoc watcher output. Long-running steps like `fix_links` and `absorb` could appear stuck or alive depending on which surface was consulted, and normal "incremental" operation was being approximated with `--from-step clippings`, which skipped Pinboard entirely.

## Validation

Synthetic verification:

```bash
PYTHONPATH=src pytest -q
```

Result: `620 passed in 58.93s`.

Real-vault validation:

```bash
ovp --incremental --pack research-tech --vault-dir /Users/chris/Documents/openclaw-vault
```

During the live run, all three operator surfaces reported the same active runtime truth:

- `watch_progress`
- `/api/runtime`
- `/`

Observed run state:

- `run_id = pipeline-20260418-081131-ca15f0f3`
- `current_step = pinboard_process`
- counted progress visible as `8/29 files processed`, later `11/29 files processed`
- current item visible from the canonical run ledger

## Notes

The local validation run is still continuing independently in the user's vault. This PR contains only code/docs/tests from the isolated Phase 25 worktree and does not include generated vault data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ovp --incremental` CLI option for streamlined daily workflows.
  * Introduced `/api/runtime` endpoint and "Current Workflow" UI card for real-time run monitoring.
  * Enhanced progress reporting with actual counted work units and current-item visibility.
  * Active vs. stale run classification for clearer run state tracking.

* **Documentation**
  * Phase 25 completion: observable runtime and canonical run ledger.
  * Phase 24 planning: brain-first lookup and backlink legibility roadmap.
  * Updated recipes and validation guidance for incremental workflows.

* **Tests**
  * Added comprehensive runtime ledger and progress tracking test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->