### PR TITLE
fix: resume absorb at item level

### DIFF
--- a/src/ovp_pipeline/unified_pipeline_enhanced.py
+++ b/src/ovp_pipeline/unified_pipeline_enhanced.py
@@ -417,7 +417,7 @@ STAGE_CACHE_POLICIES = {
 STAGE_ALGORITHM_VERSIONS = {
     "quality": QUALITY_STAGE_ALGORITHM_VERSION,
     "fix_links": "fix_links:exact-only:v1",
-    "absorb": "absorb:qualified-files:v1",
+    "absorb": "absorb:qualified-files:item-ledger:v2",
     "registry_sync": "registry_sync:rebuild-registry:v1",
     "moc": "moc:auto-moc-scan:v1",
     "knowledge_index": "knowledge_index:truth-projection:v1",
@@ -800,6 +800,88 @@ class EnhancedPipeline:
                 "algorithm_version": STAGE_ALGORITHM_VERSIONS.get(stage, f"{stage}:v1"),
             }
         )
+
+    def _absorb_item_ledger_path(self) -> Path:
+        return self.layout.logs_dir / "item-ledgers" / "absorb.jsonl"
+
+    def _absorb_item_context(self, source_path: str | Path) -> dict[str, Any]:
+        path = Path(source_path).resolve()
+        file_records = build_file_records(self.vault_dir, [path])
+        file_record = file_records[0]
+        input_digest = hash_json_payload(file_record)
+        algorithm_digest = self._stage_algorithm_digest("absorb")
+        fingerprint = build_stage_fingerprint(
+            stage="absorb_item",
+            input_digest=input_digest,
+            algorithm_digest=algorithm_digest,
+            pack_name=self.workflow_pack_name,
+            workflow_profile=self.workflow_profile_name,
+        )
+        return {
+            "fingerprint": fingerprint,
+            "input_digest": input_digest,
+            "algorithm_digest": algorithm_digest,
+            "source_path": str(path),
+            "source_relpath": file_record["path"],
+            "source_sha256": file_record["sha256"],
+            "source_size": file_record["size"],
+        }
+
+    def _load_absorb_item_statuses(self) -> dict[str, dict[str, Any]]:
+        path = self._absorb_item_ledger_path()
+        if not path.exists():
+            return {}
+        statuses: dict[str, dict[str, Any]] = {}
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            return statuses
+        for line in lines:
+            if not line.strip():
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(record, dict) or record.get("stage") != "absorb":
+                continue
+            fingerprint = record.get("fingerprint")
+            if isinstance(fingerprint, str) and fingerprint:
+                statuses[fingerprint] = record
+        return statuses
+
+    def _absorb_item_succeeded(self, source_path: str | Path, statuses: dict[str, dict[str, Any]]) -> bool:
+        context = self._absorb_item_context(source_path)
+        record = statuses.get(context["fingerprint"])
+        return bool(record and record.get("status") == "succeeded")
+
+    def _append_absorb_item_record(self, source_path: str | Path, event: dict[str, Any]) -> dict[str, Any]:
+        result = event.get("result") if isinstance(event.get("result"), dict) else {}
+        error = result.get("error") or event.get("error") or ""
+        context = self._absorb_item_context(source_path)
+        record = {
+            "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "stage": "absorb",
+            "status": "failed" if error else "succeeded",
+            "run_id": self.txn_id or "",
+            "pack_name": self.workflow_pack_name,
+            "workflow_profile": self.workflow_profile_name,
+            "current_item": str(event.get("current_item") or event.get("file") or ""),
+            "error": str(error) if error else "",
+            **context,
+            "metrics": {
+                "concepts_extracted": _safe_int(result.get("concepts_extracted")),
+                "concepts_created": _safe_int(result.get("concepts_created")),
+                "concepts_promoted": _safe_int(result.get("concepts_promoted")),
+                "concepts_skipped": _safe_int(result.get("concepts_skipped")),
+                "candidates_added": _safe_int(result.get("candidates_added")),
+            },
+        }
+        path = self._absorb_item_ledger_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n")
+        return record
 
     def _build_stage_artifact_context(
         self,
@@ -1948,12 +2030,16 @@ class EnhancedPipeline:
         total_files: int | None,
         completed_before: int = 0,
         failed_before: int = 0,
+        staged_sources: dict[str, str] | None = None,
+        record_item_ledger: bool = False,
     ):
         def _callback(event: dict[str, Any]) -> None:
             effective_total = total_files or int(event.get("files_total") or 0) or None
             batch_done = int(event.get("files_done") or 0)
             batch_failed = int(event.get("files_failed") or 0)
             current_item = str(event.get("current_item") or event.get("file") or "").strip() or None
+            if record_item_ledger and current_item and staged_sources and current_item in staged_sources:
+                self._append_absorb_item_record(staged_sources[current_item], event)
             work_units_done = completed_before + batch_done
             work_units_failed = failed_before + batch_failed
             progress_summary = (
@@ -1988,6 +2074,8 @@ class EnhancedPipeline:
         failed_before: int = 0,
         directory: Path | None = None,
         recent: int | None = None,
+        staged_sources: dict[str, str] | None = None,
+        record_item_ledger: bool = False,
     ) -> dict[str, Any]:
         self.logger.log(
             "command_started",
@@ -2021,6 +2109,8 @@ class EnhancedPipeline:
                     total_files=total_files,
                     completed_before=completed_before,
                     failed_before=failed_before,
+                    staged_sources=staged_sources,
+                    record_item_ledger=record_item_ledger,
                 ),
             )
         except Exception as exc:
@@ -2153,8 +2243,52 @@ class EnhancedPipeline:
         print("="*60)
 
         if normalized_files is not None:
-            total_files = len(normalized_files)
-            effective_batch_size = batch_size or total_files
+            qualified_input_files = list(normalized_files)
+            item_cache_hit_files: list[str] = []
+            if not dry_run:
+                item_statuses = self._load_absorb_item_statuses()
+                pending_files: list[str] = []
+                for path in normalized_files:
+                    if self._absorb_item_succeeded(path, item_statuses):
+                        item_cache_hit_files.append(path)
+                    else:
+                        pending_files.append(path)
+                normalized_files = pending_files
+
+            total_files = len(qualified_input_files)
+            if not normalized_files:
+                print("✓ Absorb stage completed from item cache")
+                result = {
+                    "success": True,
+                    "skipped": True,
+                    "reason": "all_absorb_items_cached",
+                    "qualified_files": qualified_input_files,
+                    "pending_qualified_files": [],
+                    "item_cache_hits": len(item_cache_hit_files),
+                    "item_cache_hit_files": item_cache_hit_files,
+                    "summary": {
+                        "files_processed": 0,
+                        "concepts_extracted": 0,
+                        "candidates_added": 0,
+                        "concepts_created": 0,
+                        "concepts_promoted": 0,
+                        "concepts_skipped": 0,
+                        "errors": 0,
+                    },
+                    "results": [],
+                    "stdout": "All qualified files already absorbed",
+                    "stderr": "",
+                    "produced": 0,
+                }
+                if input_artifact is not None:
+                    result["input_artifact"] = {
+                        "stage": input_artifact.get("stage"),
+                        "fingerprint": input_artifact.get("fingerprint"),
+                        "run_id": input_artifact.get("run_id"),
+                    }
+                return result
+
+            effective_batch_size = batch_size or len(normalized_files)
             aggregated_summary = {
                 "files_processed": 0,
                 "concepts_extracted": 0,
@@ -2171,6 +2305,7 @@ class EnhancedPipeline:
                 batch_files = normalized_files[start_index:start_index + effective_batch_size]
                 with tempfile.TemporaryDirectory(prefix="absorb-qualified-", dir=str(self.layout.logs_dir)) as staging_dir:
                     staging_path = Path(staging_dir)
+                    staged_sources: dict[str, str] = {}
                     used_targets: set[Path] = set()
                     for path in batch_files:
                         source = Path(path)
@@ -2186,6 +2321,7 @@ class EnhancedPipeline:
                                     break
                                 counter += 1
                         used_targets.add(target)
+                        staged_sources[target.name] = str(source)
                         try:
                             target.symlink_to(source)
                         except OSError:
@@ -2195,12 +2331,17 @@ class EnhancedPipeline:
                         directory=staging_path,
                         dry_run=dry_run,
                         total_files=total_files,
-                        completed_before=aggregated_summary["files_processed"],
+                        completed_before=len(item_cache_hit_files) + aggregated_summary["files_processed"],
                         failed_before=aggregated_summary["errors"],
+                        staged_sources=staged_sources,
+                        record_item_ledger=not dry_run,
                     )
                     if not result["success"]:
                         print(f"✗ Absorb stage failed: {result.get('error', 'Unknown error')}")
-                        result["qualified_files"] = normalized_files
+                        result["qualified_files"] = qualified_input_files
+                        result["pending_qualified_files"] = normalized_files
+                        result["item_cache_hits"] = len(item_cache_hit_files)
+                        result["item_cache_hit_files"] = item_cache_hit_files
                         result["summary"] = aggregated_summary
                         result["results"] = aggregated_results
                         return result
@@ -2212,7 +2353,10 @@ class EnhancedPipeline:
 
             result = {
                 "success": True,
-                "qualified_files": normalized_files,
+                "qualified_files": qualified_input_files,
+                "pending_qualified_files": normalized_files,
+                "item_cache_hits": len(item_cache_hit_files),
+                "item_cache_hit_files": item_cache_hit_files,
                 "summary": aggregated_summary,
                 "results": aggregated_results,
                 "stdout": json.dumps(

--- a/src/ovp_pipeline/unified_pipeline_enhanced.py
+++ b/src/ovp_pipeline/unified_pipeline_enhanced.py
@@ -2245,15 +2245,14 @@ class EnhancedPipeline:
         if normalized_files is not None:
             qualified_input_files = list(normalized_files)
             item_cache_hit_files: list[str] = []
-            if not dry_run:
-                item_statuses = self._load_absorb_item_statuses()
-                pending_files: list[str] = []
-                for path in normalized_files:
-                    if self._absorb_item_succeeded(path, item_statuses):
-                        item_cache_hit_files.append(path)
-                    else:
-                        pending_files.append(path)
-                normalized_files = pending_files
+            item_statuses = self._load_absorb_item_statuses()
+            pending_files: list[str] = []
+            for path in normalized_files:
+                if self._absorb_item_succeeded(path, item_statuses):
+                    item_cache_hit_files.append(path)
+                else:
+                    pending_files.append(path)
+            normalized_files = pending_files
 
             total_files = len(qualified_input_files)
             if not normalized_files:

--- a/src/ovp_pipeline/unified_pipeline_enhanced.py
+++ b/src/ovp_pipeline/unified_pipeline_enhanced.py
@@ -2337,6 +2337,13 @@ class EnhancedPipeline:
                     )
                     if not result["success"]:
                         print(f"✗ Absorb stage failed: {result.get('error', 'Unknown error')}")
+                        summary = result.get("summary", {})
+                        if isinstance(summary, dict):
+                            for key in aggregated_summary:
+                                aggregated_summary[key] += _safe_int(summary.get(key))
+                        batch_results = result.get("results", [])
+                        if isinstance(batch_results, list):
+                            aggregated_results.extend(batch_results)
                         result["qualified_files"] = qualified_input_files
                         result["pending_qualified_files"] = normalized_files
                         result["item_cache_hits"] = len(item_cache_hit_files)

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -1178,6 +1178,89 @@ def test_step_absorb_batches_qualified_files_and_aggregates_results(tmp_path, mo
     assert calls[1] == ["absorb_2_深度解读.md"]
 
 
+def test_step_absorb_skips_previously_succeeded_items_and_retries_failed_items(tmp_path, monkeypatch):
+    from ovp_pipeline.unified_pipeline_enhanced import PipelineLogger, TransactionManager
+
+    vault = tmp_path / "vault"
+    (vault / "60-Logs").mkdir(parents=True)
+    logger = PipelineLogger(vault / "60-Logs" / "pipeline.jsonl")
+    txn = TransactionManager(vault / "60-Logs" / "transactions")
+    pipeline = EnhancedPipeline(vault, logger, txn)
+
+    topic_dir = vault / "20-Areas" / "Tools" / "Topics" / "2026-04"
+    topic_dir.mkdir(parents=True, exist_ok=True)
+    succeeded = topic_dir / "succeeded_深度解读.md"
+    failed = topic_dir / "failed_深度解读.md"
+    succeeded.write_text("# succeeded\n", encoding="utf-8")
+    failed.write_text("# failed\n", encoding="utf-8")
+
+    calls: list[list[str]] = []
+
+    def fake_run_absorb_workflow(vault_dir, *, directory=None, progress_callback=None, **_):
+        staged = sorted(p.name for p in Path(directory).glob("*.md"))
+        calls.append(staged)
+        errors = 0
+        for idx, name in enumerate(staged, start=1):
+            result = {
+                "file": str(Path(directory) / name),
+                "concepts_extracted": 1,
+                "concepts_created": 1,
+                "concepts_skipped": 0,
+                "candidates_added": 0,
+                "concepts_promoted": 1,
+                "concepts": [],
+            }
+            if name == failed.name and len(calls) == 1:
+                result["error"] = "transient failure"
+                errors += 1
+            if progress_callback is not None:
+                progress_callback(
+                    {
+                        "event_type": "absorb_file_processed",
+                        "file": name,
+                        "current_item": name,
+                        "files_total": len(staged),
+                        "files_done": idx,
+                        "files_failed": errors,
+                        "result": result,
+                    }
+                )
+        return {
+            "summary": {
+                "files_processed": len(staged),
+                "concepts_extracted": len(staged),
+                "candidates_added": 0,
+                "concepts_created": len(staged) - errors,
+                "concepts_promoted": len(staged) - errors,
+                "concepts_skipped": 0,
+                "errors": errors,
+            },
+            "results": [],
+        }
+
+    monkeypatch.setattr("ovp_pipeline.unified_pipeline_enhanced.run_absorb_workflow", fake_run_absorb_workflow)
+
+    first = pipeline.step_absorb(
+        dry_run=False,
+        quality_score=4.0,
+        qualified_files=[str(succeeded), str(failed)],
+        batch_size=2,
+    )
+    second = pipeline.step_absorb(
+        dry_run=False,
+        quality_score=4.0,
+        qualified_files=[str(succeeded), str(failed)],
+        batch_size=2,
+    )
+
+    assert first["success"] is False
+    assert second["success"] is True
+    assert calls == [[failed.name, succeeded.name], [failed.name]]
+    assert second["summary"]["files_processed"] == 1
+    assert second["item_cache_hits"] == 1
+    assert second["item_cache_hit_files"] == [str(succeeded.resolve())]
+
+
 def test_absorb_timeout_scales_with_batch_size(tmp_path):
     from ovp_pipeline.unified_pipeline_enhanced import PipelineLogger, TransactionManager
 

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -1200,6 +1200,7 @@ def test_step_absorb_skips_previously_succeeded_items_and_retries_failed_items(t
         staged = sorted(p.name for p in Path(directory).glob("*.md"))
         calls.append(staged)
         errors = 0
+        result_rows = []
         for idx, name in enumerate(staged, start=1):
             result = {
                 "file": str(Path(directory) / name),
@@ -1213,6 +1214,7 @@ def test_step_absorb_skips_previously_succeeded_items_and_retries_failed_items(t
             if name == failed.name and len(calls) == 1:
                 result["error"] = "transient failure"
                 errors += 1
+            result_rows.append(result)
             if progress_callback is not None:
                 progress_callback(
                     {
@@ -1235,7 +1237,7 @@ def test_step_absorb_skips_previously_succeeded_items_and_retries_failed_items(t
                 "concepts_skipped": 0,
                 "errors": errors,
             },
-            "results": [],
+            "results": result_rows,
         }
 
     monkeypatch.setattr("ovp_pipeline.unified_pipeline_enhanced.run_absorb_workflow", fake_run_absorb_workflow)
@@ -1266,6 +1268,9 @@ def test_step_absorb_skips_previously_succeeded_items_and_retries_failed_items(t
     assert third["success"] is True
     assert third["skipped"] is True
     assert calls == [[failed.name, succeeded.name], [failed.name]]
+    assert first["summary"]["files_processed"] == 2
+    assert first["summary"]["errors"] == 1
+    assert len(first["results"]) == 2
     assert second["summary"]["files_processed"] == 1
     assert second["item_cache_hits"] == 1
     assert second["item_cache_hit_files"] == [str(succeeded.resolve())]

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -1252,13 +1252,25 @@ def test_step_absorb_skips_previously_succeeded_items_and_retries_failed_items(t
         qualified_files=[str(succeeded), str(failed)],
         batch_size=2,
     )
+    ledger_path = pipeline._absorb_item_ledger_path()
+    ledger_before_dry_run = ledger_path.read_text(encoding="utf-8")
+    third = pipeline.step_absorb(
+        dry_run=True,
+        quality_score=4.0,
+        qualified_files=[str(succeeded), str(failed)],
+        batch_size=2,
+    )
 
     assert first["success"] is False
     assert second["success"] is True
+    assert third["success"] is True
+    assert third["skipped"] is True
     assert calls == [[failed.name, succeeded.name], [failed.name]]
     assert second["summary"]["files_processed"] == 1
     assert second["item_cache_hits"] == 1
     assert second["item_cache_hit_files"] == [str(succeeded.resolve())]
+    assert third["item_cache_hits"] == 2
+    assert ledger_path.read_text(encoding="utf-8") == ledger_before_dry_run
 
 
 def test_absorb_timeout_scales_with_batch_size(tmp_path):


### PR DESCRIPTION
## Summary
- Add an absorb item ledger at `60-Logs/item-ledgers/absorb.jsonl` so successful files are checkpointed as each file finishes.
- Use stable per-file fingerprints from file content, absorb algorithm version, pack, and workflow profile.
- Skip previously succeeded absorb inputs on rerun while retrying failed or unrecorded items.
- Preserve run progress counts by including cached item hits in absorb progress callbacks.

## Test plan
- [x] `git diff --check -- src/ovp_pipeline/unified_pipeline_enhanced.py tests/test_runtime_paths.py`
- [x] `PYTHONPATH=src pytest tests/test_runtime_paths.py -q` -> 56 passed
- [x] `PYTHONPATH=src pytest -q` -> 670 passed

## Operational validation
- Verified against the latest real local incremental run after editable install: `pipeline-20260420-014343-2f153f78` completed all stages.
- Confirmed absorb item ledger recorded 270 succeeded item records for that run, which future reruns can skip when the input and algorithm fingerprint match.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/40" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented item-level caching for the absorb stage, enabling the pipeline to automatically skip previously succeeded items and focus processing on failed or new items, improving overall pipeline efficiency.

* **Tests**
  * Added comprehensive test coverage for item-level caching and retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->