### PR TITLE
Add brain-first backlink legibility

### DIFF
--- a/docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
+++ b/docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
@@ -358,11 +358,15 @@ Current slice:
     - `/api/runtime`
     - `/`
   - `/` now uses a runtime-first home shell so current workflow visibility stays fast during live runs
+- [[2026-04-18-phase24-brain-first-lookup-and-backlink-legibility|Phase 24]] now lands the missing legibility contract for object creation:
+  - note traceability exposes `brain_first_lookup`
+  - note/object traceability exposes `backlink_expectation`
+  - production signals carry these contracts into `/signals`
+  - deep dives that already wikilink existing objects now surface `reuse_existing` instead of looking like blind object-creation work
 
 Next slice:
 
-- [[2026-04-18-phase24-brain-first-lookup-and-backlink-legibility|Phase 24: brain-first lookup + backlink legibility]]
-- This is no longer gated on runtime validation.
+- Continue Milestone 7 only where there is still a concrete operator loop gap. Do not widen into background intelligence until the reviewed candidate/canonical transition needs stricter enforcement.
 
 ### Milestone 8: Knowledge Evolution Layer
 
@@ -550,6 +554,7 @@ What those phases accomplished:
 - `Phase 21` turned the trustworthy workbench into a clearer operator shell with workflow IA, next-step rails, and denser page ordering
 - `Phase 22` turned passive signal surfaces into a first active loop by making signal/action/result impact legible from the product itself
 - `Phase 23` made inbound note capture legible by turning existing pipeline/refine audit into note, signal, and briefing products
+- `Phase 24` made object-creation routing legible by exposing brain-first lookup and backlink expectation contracts from traceability through signals into the UI
 
 What this sequence closed:
 
@@ -559,12 +564,13 @@ What this sequence closed:
 - the current product surface now has a clearer default entry path and stronger compiled pages
 - the signal loop no longer stops at passive visibility; it now shows whether execution was productive, stalled, failed, or still waiting
 - the signal loop now also shows what recent inbound note capture actually did before queue execution became relevant
+- the signal loop no longer implies blind downstream object creation when the note already links to canonical brain objects
 
 What the next phase should close:
 
-- the next phase should tighten brain-first lookup before object/link creation
-- newly created downstream objects should make backlink expectations more explicit
-- the operator should be able to see when capture created candidate vs canonical downstream knowledge without widening into opaque background automation
+- reviewed candidate/canonical transitions should become easier to act on from the operator surface
+- if we enforce backlinks at write time, the enforcement should reuse the `backlink_expectation` contract instead of introducing a second source of truth
+- if we add richer semantic relation extraction, it should be a pack-level extraction contract, not a hidden global memory backend
 
 Sequence rule:
 
@@ -575,7 +581,8 @@ Sequence rule:
 - treat `Phase 21` as the closeout for Milestone 6
 - treat `Phase 22` as the first closeout slice for Milestone 7
 - treat `Phase 23` as the second closeout slice for Milestone 7
-- use the next Milestone 7 slice for brain-first lookup + backlink legibility instead of reopening shell UX or widening immediately into background intelligence
+- treat `Phase 24` as the third closeout slice for Milestone 7: brain-first lookup + backlink legibility
+- continue within Milestone 7 only for reviewed candidate/canonical actionability; otherwise move to the next explicit roadmap gap
 
 This keeps the roadmap moving from substrate -> contracts -> entry products, instead of looping back into infrastructure.
 

--- a/docs/plans/2026-04-18-phase24-brain-first-lookup-and-backlink-legibility.md
+++ b/docs/plans/2026-04-18-phase24-brain-first-lookup-and-backlink-legibility.md
@@ -1,6 +1,6 @@
 # Phase 24: Brain-First Lookup And Backlink Legibility
 
-> **Status:** Planned, ready after Phase 25 runtime validation
+> **Status:** Complete in current branch
 
 ## Goal
 
@@ -22,3 +22,47 @@ That runtime contract has been validated against a real `ovp --incremental` run,
 - brain-first lookup before object creation,
 - backlink legibility,
 - candidate vs canonical downstream boundary improvements.
+
+## Implemented Scope
+
+This phase intentionally stays inside the existing OVP architecture:
+
+- Markdown notes remain canonical authoring artifacts.
+- `knowledge.db` remains the derived runtime/index layer.
+- `ConceptRegistry` remains the deterministic resolver for mention-to-object decisions.
+- `ovp-ui` remains the operator surface.
+
+The implementation does **not** add a new semantic relation extractor or a new background memory system. Instead, it closes the legibility gap around decisions the system already needs to make.
+
+### Brain-First Lookup Contract
+
+`truth_api.get_note_traceability(...)` now exposes a `brain_first_lookup` contract for each note chain:
+
+- `decision = skip_existing` when promoted/canonical objects are already attached,
+- `decision = reuse_existing` when the note links to existing canonical objects through `page_links`,
+- `decision = create_candidate` when no existing object link is found and extraction may safely create candidates,
+- `decision = inspect` when the current stage does not need object-creation routing.
+
+The important boundary is that `page_links -> objects` can prove that a deep dive already points at existing brain truth even when no `evergreen_auto_promoted` event exists yet. In that case, the operator sees `reuse_existing` instead of a blind “create object” implication.
+
+### Backlink Expectation Contract
+
+`truth_api.get_note_traceability(...)` and `get_object_traceability(...)` now expose a `backlink_expectation` contract with:
+
+- linked source note paths,
+- linked deep dive paths,
+- linked object ids,
+- linked Atlas/MOC paths,
+- a small status string such as `satisfied`, `missing_source_backlink`, or `missing_downstream_links`.
+
+This is a legibility contract, not a hard enforcement layer. It makes the expected provenance/backlink shape visible before we add stricter write-time gates.
+
+### Signal And UI Propagation
+
+`research-tech` production signals now carry the lookup/backlink contracts in their payloads. In particular:
+
+- `deep_dive_needs_objects` can point at existing canonical objects discovered through brain-first lookup,
+- `production_gap` and extraction-trigger signals keep the traceability counts plus the new contracts,
+- `/signals` renders the brain-first decision and backlink status directly on each row.
+
+This keeps the single source of truth intact: the UI reads the signal payload; the signal payload reads traceability; traceability reads `knowledge.db` and existing audit/provenance records.

--- a/progress.md
+++ b/progress.md
@@ -1,5 +1,43 @@
 # Progress Log
 
+## Session: 2026-04-20
+
+### Phase 24: Brain-First Lookup And Backlink Legibility
+- **Status:** complete
+- Actions taken:
+  - Added note-level `brain_first_lookup` to `truth_api.get_note_traceability(...)`
+  - Added note/object `backlink_expectation` contracts
+  - Made brain-first lookup use existing `knowledge.db` truth:
+    - `pages_index`
+    - `page_links`
+    - `objects`
+  - Preserved the existing write architecture:
+    - `ConceptRegistry` remains the deterministic resolver
+    - promoted objects remain canonical
+    - unresolved extraction still routes through candidates
+  - Updated `research-tech` production signals so `production_gap`, `source_needs_deep_dive`, and `deep_dive_needs_objects` carry lookup/backlink contracts in payloads
+  - Made `deep_dive_needs_objects` associate with existing canonical object ids when a deep dive already wikilinks those objects
+  - Updated `/signals` to render:
+    - brain-first lookup decision/status/count
+    - backlink expectation status/source count
+  - Updated roadmap docs to mark Phase 24 as the third Milestone 7 closeout slice
+- Files modified:
+  - docs/plans/2026-04-18-phase24-brain-first-lookup-and-backlink-legibility.md
+  - docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
+  - src/ovp_pipeline/truth_api.py
+  - src/ovp_pipeline/packs/research_tech/surfaces.py
+  - src/ovp_pipeline/commands/ui_server.py
+  - tests/test_truth_api.py
+  - tests/test_ui_server.py
+- Verification so far:
+  - `PYTHONPATH=src pytest tests/test_truth_api.py::test_truth_api_note_traceability_exposes_brain_first_lookup_for_existing_links tests/test_truth_api.py::test_research_tech_deep_dive_signal_exposes_brain_first_lookup_contract tests/test_ui_server.py::test_ui_server_signals_page_renders_governance_resolver_metadata -q`
+  - `3 passed`
+  - `PYTHONPATH=src pytest tests/test_truth_api.py tests/test_ui_server.py tests/test_ui_smoke.py -q`
+  - `197 passed`
+  - `git diff --check`
+  - `PYTHONPATH=src pytest -q`
+  - `672 passed`
+
 ## Session: 2026-04-18
 
 ### Phase 25: Observable Runtime And Run Ledger

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -2395,6 +2395,31 @@ def _render_evolution_browser_page(payload: dict) -> str:
     )
 
 
+def _render_signal_context_contract(item: dict) -> str:
+    payload = item.get("payload") or {}
+    brain_lookup = payload.get("brain_first_lookup") or {}
+    backlink_expectation = payload.get("backlink_expectation") or {}
+    parts: list[str] = []
+    if brain_lookup:
+        count = int(brain_lookup.get("existing_object_count") or 0)
+        parts.append(
+            "<div class='muted'>Brain-first lookup: "
+            f"{escape(str(brain_lookup.get('decision') or 'inspect'))} · "
+            f"{escape(str(brain_lookup.get('status') or 'unknown'))} · "
+            f"{count} existing objects"
+            "</div>"
+        )
+    if backlink_expectation:
+        source_count = len(backlink_expectation.get("source_note_paths") or [])
+        parts.append(
+            "<div class='muted'>Backlinks: "
+            f"{escape(str(backlink_expectation.get('status') or 'unknown'))} · "
+            f"{source_count} source notes"
+            "</div>"
+        )
+    return "".join(parts)
+
+
 def _render_signals_page(payload: dict) -> str:
     query = payload.get("query", "")
     selected_type = payload.get("signal_type", "")
@@ -2429,6 +2454,7 @@ def _render_signals_page(payload: dict) -> str:
             if item.get("capture_summary", {}).get("summary")
             else ""
         )
+        + _render_signal_context_contract(item)
         + (
             "<div class='muted'>Recommended Action: "
             + f'<a href="{escape(item["recommended_action"]["path"])}">{escape(item["recommended_action"]["label"])}</a>'

--- a/src/ovp_pipeline/packs/research_tech/surfaces.py
+++ b/src/ovp_pipeline/packs/research_tech/surfaces.py
@@ -18,6 +18,31 @@ def _scoped_path(path: str, *, pack_name: str | None = None) -> str:
     return f"{path}{separator}pack={quote(normalized_pack, safe='')}"
 
 
+def _traceability_object_ids(traceability: dict[str, Any]) -> list[str]:
+    object_ids = [
+        str(entry.get("object_id") or "")
+        for entry in traceability.get("objects", [])
+        if str(entry.get("object_id") or "").strip()
+    ]
+    if object_ids:
+        return list(dict.fromkeys(object_ids))
+    brain_lookup = traceability.get("brain_first_lookup") or {}
+    return list(
+        dict.fromkeys(
+            str(entry.get("object_id") or "")
+            for entry in brain_lookup.get("existing_objects", [])
+            if str(entry.get("object_id") or "").strip()
+        )
+    )
+
+
+def _traceability_contract_payload(traceability: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "brain_first_lookup": traceability.get("brain_first_lookup") or {},
+        "backlink_expectation": traceability.get("backlink_expectation") or {},
+    }
+
+
 def list_production_chains(
     vault_dir: Path | str,
     *,
@@ -229,7 +254,7 @@ def build_signal_entries(
         limit=core.MAX_PAGE_SIZE,
     )
     for item in core._production_gap_items_from_chains(production_chains, limit=core.MAX_PAGE_SIZE):
-        object_ids = [entry["object_id"] for entry in item["traceability"]["objects"]]
+        object_ids = _traceability_object_ids(item["traceability"])
         signals.append(
             {
                 "signal_id": item["signal_id"],
@@ -266,6 +291,7 @@ def build_signal_entries(
                     "stage_label": item["stage_label"],
                     "missing": item["missing"],
                     "traceability_counts": item["traceability"]["counts"],
+                    **_traceability_contract_payload(item["traceability"]),
                 },
             }
         )
@@ -305,10 +331,23 @@ def build_signal_entries(
                     "payload": {
                         "stage_label": item["stage_label"],
                         "traceability_counts": traceability["counts"],
+                        **_traceability_contract_payload(traceability),
                     },
                 }
             )
         if item["stage_label"] == "deep_dive" and not traceability["objects"]:
+            object_ids = _traceability_object_ids(traceability)
+            object_effects = [
+                {
+                    "label": f"Existing object: {entry['title']}",
+                    "path": _scoped_path(
+                        f"/object?id={quote(str(entry['object_id']), safe='')}",
+                        pack_name=normalized_pack,
+                    ),
+                }
+                for entry in (traceability.get("brain_first_lookup") or {}).get("existing_objects", [])[:2]
+                if entry.get("object_id")
+            ]
             signals.append(
                 {
                     "signal_id": core._signal_id("deep_dive_needs_objects", item["path"]),
@@ -320,10 +359,11 @@ def build_signal_entries(
                     "explanation": core.SIGNAL_TYPE_EXPLANATIONS["deep_dive_needs_objects"],
                     "source_path": f"/note?path={quote(item['path'], safe='')}",
                     "source_label": "Production",
-                    "object_ids": [],
+                    "object_ids": object_ids,
                     "note_paths": [item["path"]],
                     "downstream_effects": [
                         {"label": "Open deep dive", "path": f"/note?path={quote(item['path'], safe='')}"},
+                        *object_effects,
                         {
                             "label": "Inspect production chain",
                             "path": _scoped_path(
@@ -341,6 +381,7 @@ def build_signal_entries(
                     "payload": {
                         "stage_label": item["stage_label"],
                         "traceability_counts": traceability["counts"],
+                        **_traceability_contract_payload(traceability),
                     },
                 }
             )

--- a/src/ovp_pipeline/truth_api.py
+++ b/src/ovp_pipeline/truth_api.py
@@ -3285,6 +3285,147 @@ def _deep_dive_objects_for_path(vault_dir: Path | str, note_path: str) -> list[d
     return list(_deep_dive_object_map(vault_dir).get(normalized_target, []))
 
 
+def _linked_existing_objects_for_note_path(
+    vault_dir: Path | str,
+    note_path: str,
+    *,
+    pack_name: str | None = None,
+) -> list[dict[str, Any]]:
+    db_path = _db_path(vault_dir)
+    resolved_vault = resolve_vault_dir(vault_dir)
+    absolute_path = str((resolved_vault / note_path).resolve())
+    pack_candidates = _materialized_truth_packs(vault_dir, pack_name=pack_name, table_name="objects")
+    if not pack_candidates:
+        return []
+    pack_placeholders = ",".join("?" for _ in pack_candidates)
+    with sqlite3.connect(db_path) as conn:
+        source_row = conn.execute(
+            """
+            SELECT slug
+            FROM pages_index
+            WHERE path = ?
+            LIMIT 1
+            """,
+            (absolute_path,),
+        ).fetchone()
+        if source_row is None:
+            return []
+        source_slug = str(source_row[0])
+        rows = conn.execute(
+            f"""
+            SELECT objects.pack, objects.object_id, objects.object_kind, objects.title,
+                   objects.canonical_path, page_links.target_raw, page_links.line_number
+            FROM page_links
+            JOIN objects ON objects.object_id = page_links.target_slug
+            WHERE page_links.source_slug = ?
+              AND objects.pack IN ({pack_placeholders})
+            ORDER BY CASE objects.pack
+              {''.join(f"WHEN ? THEN {index} " for index, _ in enumerate(pack_candidates))}
+              ELSE {len(pack_candidates)}
+            END, page_links.line_number, objects.object_id
+            """,
+            (source_slug, *pack_candidates, *pack_candidates),
+        ).fetchall()
+
+    items: dict[str, dict[str, Any]] = {}
+    for pack, object_id, object_kind, title, canonical_path, target_raw, line_number in rows:
+        if object_id in items:
+            continue
+        items[str(object_id)] = {
+            "object_id": str(object_id),
+            "object_kind": str(object_kind),
+            "title": str(title),
+            "canonical_path": _vault_relative_path(resolved_vault, str(canonical_path)),
+            "target_raw": str(target_raw or ""),
+            "line_number": int(line_number or 0),
+            "pack": str(pack),
+        }
+    return list(items.values())
+
+
+def _brain_first_lookup_payload(
+    *,
+    stage_label: str,
+    canonical_objects: list[dict[str, Any]],
+    linked_existing_objects: list[dict[str, Any]],
+) -> dict[str, Any]:
+    if canonical_objects:
+        return {
+            "status": "canonical_objects_present",
+            "decision": "skip_existing",
+            "existing_object_count": len(canonical_objects),
+            "existing_objects": canonical_objects,
+            "lookup_source": "promoted_traceability",
+            "summary": f"{len(canonical_objects)} canonical objects are already attached to this chain.",
+        }
+    if linked_existing_objects:
+        return {
+            "status": "existing_links_found",
+            "decision": "reuse_existing",
+            "existing_object_count": len(linked_existing_objects),
+            "existing_objects": linked_existing_objects,
+            "lookup_source": "page_links",
+            "summary": (
+                f"Brain-first lookup found {len(linked_existing_objects)} existing object links; "
+                "reuse or reconcile before creating new candidates."
+            ),
+        }
+    if stage_label in {"source_note", "deep_dive"}:
+        return {
+            "status": "no_existing_objects",
+            "decision": "create_candidate",
+            "existing_object_count": 0,
+            "existing_objects": [],
+            "lookup_source": "page_links",
+            "summary": "No existing object links were found; candidate creation is allowed if extraction finds a stable concept.",
+        }
+    return {
+        "status": "not_applicable",
+        "decision": "inspect",
+        "existing_object_count": 0,
+        "existing_objects": [],
+        "lookup_source": "page_links",
+        "summary": "Brain-first lookup is not required for this note stage.",
+    }
+
+
+def _note_backlink_expectation_payload(
+    *,
+    note_path: str,
+    stage_label: str,
+    source_notes: list[dict[str, Any]],
+    deep_dives: list[dict[str, Any]],
+    objects: list[dict[str, Any]],
+    atlas_pages: list[dict[str, Any]],
+) -> dict[str, Any]:
+    source_note_paths = [str(item.get("path") or "") for item in source_notes if item.get("path")]
+    deep_dive_paths = [str(item.get("path") or "") for item in deep_dives if item.get("path")]
+    object_ids = [str(item.get("object_id") or item.get("slug") or "") for item in objects if item.get("object_id") or item.get("slug")]
+    atlas_paths = [str(item.get("path") or "") for item in atlas_pages if item.get("path")]
+
+    if stage_label == "source_note":
+        status = "satisfied" if deep_dive_paths or object_ids or atlas_paths else "missing_downstream_links"
+    elif stage_label == "deep_dive":
+        status = "satisfied" if source_note_paths else "missing_source_backlink"
+    elif stage_label in {"evergreen_note", "evergreen_object"}:
+        status = "satisfied" if source_note_paths or deep_dive_paths else "missing_source_backlink"
+    else:
+        status = "inspect"
+
+    return {
+        "status": status,
+        "note_path": str(note_path),
+        "source_note_paths": source_note_paths,
+        "deep_dive_paths": deep_dive_paths,
+        "object_ids": object_ids,
+        "atlas_paths": atlas_paths,
+        "summary": (
+            f"{len(source_note_paths)} source notes, {len(deep_dive_paths)} deep dives, "
+            f"{len(object_ids)} objects, {len(atlas_paths)} atlas pages linked."
+        ),
+    }
+
+
 def _atlas_pages_for_object_ids(
     vault_dir: Path | str,
     object_ids: list[str],
@@ -3567,6 +3708,24 @@ def get_note_traceability(
             f"Source note currently traces to {len(deep_dives)} deep dives, "
             f"{len(objects)} objects, {len(atlas_pages)} atlas pages."
         )
+    linked_existing_objects = _linked_existing_objects_for_note_path(
+        vault_dir,
+        note_path,
+        pack_name=pack_name,
+    )
+    brain_first_lookup = _brain_first_lookup_payload(
+        stage_label=stage_label,
+        canonical_objects=objects,
+        linked_existing_objects=linked_existing_objects,
+    )
+    backlink_expectation = _note_backlink_expectation_payload(
+        note_path=note_path,
+        stage_label=stage_label,
+        source_notes=source_notes,
+        deep_dives=deep_dives,
+        objects=objects,
+        atlas_pages=atlas_pages,
+    )
     missing_stages = [stage for stage, present in stage_presence.items() if not present]
     chain_status = "complete" if not missing_stages else "partial"
     return {
@@ -3580,6 +3739,8 @@ def get_note_traceability(
         "missing_stages": missing_stages,
         "chain_status": chain_status,
         "chain_summary": chain_summary,
+        "brain_first_lookup": brain_first_lookup,
+        "backlink_expectation": backlink_expectation,
         "counts": {
             "source_notes": len(source_notes),
             "deep_dives": len(deep_dives),
@@ -3609,6 +3770,26 @@ def get_object_traceability(
     }
     missing_stages = [stage for stage, present in stage_presence.items() if not present]
     chain_status = "complete" if not missing_stages else "partial"
+    object_as_link = {
+        "object_id": detail["object"]["object_id"],
+        "object_kind": detail["object"].get("object_kind", "evergreen"),
+        "title": detail["object"]["title"],
+        "canonical_path": detail["object"].get("canonical_path", ""),
+        "pack": detail["object"].get("pack", ""),
+    }
+    brain_first_lookup = _brain_first_lookup_payload(
+        stage_label="evergreen_object",
+        canonical_objects=[object_as_link],
+        linked_existing_objects=[],
+    )
+    backlink_expectation = _note_backlink_expectation_payload(
+        note_path=str(detail["provenance"]["evergreen_path"]),
+        stage_label="evergreen_object",
+        source_notes=list(source_note_map.values()),
+        deep_dives=deep_dives,
+        objects=[object_as_link],
+        atlas_pages=detail["provenance"]["mocs"],
+    )
     return {
         "object": detail["object"],
         "stage_label": "evergreen_object",
@@ -3626,6 +3807,8 @@ def get_object_traceability(
             f"Object currently traces to {len(source_note_map)} source notes, "
             f"{len(deep_dives)} deep dives, {len(detail['provenance']['mocs'])} atlas pages."
         ),
+        "brain_first_lookup": brain_first_lookup,
+        "backlink_expectation": backlink_expectation,
         "counts": {
             "source_notes": len(source_note_map),
             "deep_dives": len(deep_dives),

--- a/src/ovp_pipeline/truth_api.py
+++ b/src/ovp_pipeline/truth_api.py
@@ -3299,32 +3299,25 @@ def _linked_existing_objects_for_note_path(
         return []
     pack_placeholders = ",".join("?" for _ in pack_candidates)
     with sqlite3.connect(db_path) as conn:
-        source_row = conn.execute(
-            """
-            SELECT slug
-            FROM pages_index
-            WHERE path = ?
-            LIMIT 1
-            """,
-            (absolute_path,),
-        ).fetchone()
-        if source_row is None:
-            return []
-        source_slug = str(source_row[0])
         rows = conn.execute(
             f"""
             SELECT objects.pack, objects.object_id, objects.object_kind, objects.title,
                    objects.canonical_path, page_links.target_raw, page_links.line_number
             FROM page_links
             JOIN objects ON objects.object_id = page_links.target_slug
-            WHERE page_links.source_slug = ?
+            WHERE page_links.source_slug = (
+                SELECT slug
+                FROM pages_index
+                WHERE path = ?
+                LIMIT 1
+            )
               AND objects.pack IN ({pack_placeholders})
             ORDER BY CASE objects.pack
               {''.join(f"WHEN ? THEN {index} " for index, _ in enumerate(pack_candidates))}
               ELSE {len(pack_candidates)}
             END, page_links.line_number, objects.object_id
             """,
-            (source_slug, *pack_candidates, *pack_candidates),
+            (absolute_path, *pack_candidates, *pack_candidates),
         ).fetchall()
 
     items: dict[str, dict[str, Any]] = {}
@@ -3708,11 +3701,13 @@ def get_note_traceability(
             f"Source note currently traces to {len(deep_dives)} deep dives, "
             f"{len(objects)} objects, {len(atlas_pages)} atlas pages."
         )
-    linked_existing_objects = _linked_existing_objects_for_note_path(
-        vault_dir,
-        note_path,
-        pack_name=pack_name,
-    )
+    linked_existing_objects = []
+    if not objects:
+        linked_existing_objects = _linked_existing_objects_for_note_path(
+            vault_dir,
+            note_path,
+            pack_name=pack_name,
+        )
     brain_first_lookup = _brain_first_lookup_payload(
         stage_label=stage_label,
         canonical_objects=objects,

--- a/task_plan.md
+++ b/task_plan.md
@@ -7,9 +7,10 @@
   - honest counted progress
   - watcher/API/UI reader unification
   - explicit daily `ovp --incremental` entrypoint
-- `Phase 24` is the next active planned slice:
+- `Phase 24` is the active implementation slice in this branch:
   - brain-first lookup before object/link creation
   - backlink legibility
+  - signal/UI propagation of candidate-vs-existing-object decisions
 
 ## Goal
 Build a running comparative map of external memory, context, runtime, and governance systems; classify what each project is actually doing; and extract only the durable ideas that matter for Obsidian Vault Pipeline.
@@ -110,7 +111,10 @@ Phase 4
   - signal rows now expose `capture_summary` inherited from their backing notes
   - note and briefing surfaces now expose `Inbound Capture` compiled sections
   - `/signals` now renders inbound capture legibility directly, not only queue impact
-- Next active planning target after `Phase 23` remains inside `Milestone 7: Active Signal Loop`
-  - focus next on brain-first lookup before object/link creation plus backlink legibility
+- `Phase 24` now closes the brain-first lookup + backlink legibility slice:
+  - traceability exposes lookup/backlink contracts
+  - production signals carry those contracts
+  - `/signals` renders the operator-visible decision
+- Next active planning target remains inside `Milestone 7: Active Signal Loop` only if reviewed candidate/canonical transitions still need operator actionability
   - do not reopen shell UX unless a new operator-navigation gap appears
   - do not widen immediately into temporal truth, harness memory, or benchmark tracks

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -2002,6 +2002,73 @@ date: 2026-04-13
     assert [item["slug"] for item in detail["provenance"]["mocs"]] == ["alias-atlas"]
 
 
+def test_truth_api_note_traceability_exposes_brain_first_lookup_for_existing_links(temp_vault):
+    from ovp_pipeline.truth_api import get_note_traceability
+
+    processed = temp_vault / "50-Inbox" / "03-Processed" / "2026-04" / "Harness.md"
+    processed.parent.mkdir(parents=True, exist_ok=True)
+    processed.write_text(
+        """---
+title: Harness
+source: https://example.com/harness
+---
+
+Processed source note.
+""",
+        encoding="utf-8",
+    )
+    deep_dive = temp_vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "Harness_深度解读.md"
+    deep_dive.parent.mkdir(parents=True, exist_ok=True)
+    deep_dive.write_text(
+        """---
+note_id: harness-deep-dive
+title: Harness Deep Dive
+type: deep_dive
+source: https://example.com/harness
+date: 2026-04-13
+---
+
+# Harness Deep Dive
+
+Mentions the existing canonical object [[Alpha Concept]].
+""",
+        encoding="utf-8",
+    )
+    evergreen = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
+    evergreen.parent.mkdir(parents=True, exist_ok=True)
+    evergreen.write_text(
+        """---
+note_id: alpha
+title: Alpha
+type: evergreen
+aliases: [Alpha Concept]
+date: 2026-04-13
+---
+
+# Alpha
+""",
+        encoding="utf-8",
+    )
+
+    rebuild_knowledge_index(temp_vault)
+
+    traceability = get_note_traceability(
+        temp_vault,
+        note_path="20-Areas/AI-Research/Topics/2026-04/Harness_深度解读.md",
+    )
+
+    assert traceability["objects"] == []
+    assert traceability["brain_first_lookup"]["decision"] == "reuse_existing"
+    assert traceability["brain_first_lookup"]["status"] == "existing_links_found"
+    assert traceability["brain_first_lookup"]["existing_object_count"] == 1
+    assert traceability["brain_first_lookup"]["existing_objects"][0]["object_id"] == "alpha"
+    assert traceability["brain_first_lookup"]["existing_objects"][0]["target_raw"] == "Alpha Concept"
+    assert traceability["backlink_expectation"]["status"] == "satisfied"
+    assert traceability["backlink_expectation"]["source_note_paths"] == [
+        "50-Inbox/03-Processed/2026-04/Harness.md"
+    ]
+
+
 def test_truth_api_returns_note_traceability_for_processed_source(temp_vault):
     from ovp_pipeline.truth_api import get_note_traceability
 
@@ -3953,6 +4020,57 @@ def test_truth_api_compute_signal_entries_reuses_production_chains(temp_vault, m
         "source_needs_deep_dive",
         "deep_dive_needs_objects",
     }
+
+
+def test_research_tech_deep_dive_signal_exposes_brain_first_lookup_contract(temp_vault, monkeypatch):
+    from ovp_pipeline.packs.research_tech import surfaces as research_surfaces
+
+    monkeypatch.setattr(research_surfaces.core, "list_contradictions", lambda *args, **kwargs: [])
+    monkeypatch.setattr(research_surfaces.core, "list_stale_summaries", lambda *args, **kwargs: [])
+    monkeypatch.setattr(research_surfaces.core, "list_review_actions", lambda *args, **kwargs: [])
+
+    def fake_chains(vault_dir, *, pack_name=None, query=None, limit=100):
+        return [
+            {
+                "title": "Loose Deep Dive",
+                "path": "20-Areas/AI-Research/Topics/2026-04/Loose Deep Dive_深度解读.md",
+                "stage_label": "deep_dive",
+                "traceability": {
+                    "deep_dives": [],
+                    "objects": [],
+                    "atlas_pages": [],
+                    "source_notes": [{"path": "50-Inbox/03-Processed/2026-04/Loose Source.md"}],
+                    "counts": {
+                        "source_notes": 1,
+                        "deep_dives": 0,
+                        "objects": 0,
+                        "atlas_pages": 0,
+                    },
+                    "brain_first_lookup": {
+                        "decision": "reuse_existing",
+                        "status": "existing_links_found",
+                        "existing_object_count": 1,
+                        "existing_objects": [{"object_id": "alpha", "title": "Alpha"}],
+                    },
+                    "backlink_expectation": {
+                        "status": "satisfied",
+                        "source_note_paths": ["50-Inbox/03-Processed/2026-04/Loose Source.md"],
+                        "deep_dive_paths": [
+                            "20-Areas/AI-Research/Topics/2026-04/Loose Deep Dive_深度解读.md"
+                        ],
+                    },
+                },
+            },
+        ]
+
+    monkeypatch.setattr(research_surfaces.core, "list_production_chains", fake_chains)
+
+    items = research_surfaces.build_signal_entries(temp_vault)
+    signal = next(item for item in items if item["signal_type"] == "deep_dive_needs_objects")
+
+    assert signal["payload"]["brain_first_lookup"]["decision"] == "reuse_existing"
+    assert signal["payload"]["brain_first_lookup"]["existing_objects"][0]["object_id"] == "alpha"
+    assert signal["payload"]["backlink_expectation"]["status"] == "satisfied"
 
 
 def test_truth_api_briefing_batches_topic_title_lookups(temp_vault, monkeypatch):

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -2160,6 +2160,17 @@ def test_ui_server_signals_page_renders_governance_resolver_metadata(temp_vault,
                         "impact_detail": "A queueable action exists and is currently waiting to run.",
                         "produced_artifact_count": 0,
                     },
+                    "payload": {
+                        "brain_first_lookup": {
+                            "decision": "reuse_existing",
+                            "status": "existing_links_found",
+                            "existing_object_count": 1,
+                        },
+                        "backlink_expectation": {
+                            "status": "satisfied",
+                            "source_note_paths": ["50-Inbox/03-Processed/Loose Source.md"],
+                        },
+                    },
                 }
             ],
             "count": 1,
@@ -2203,6 +2214,8 @@ def test_ui_server_signals_page_renders_governance_resolver_metadata(temp_vault,
     assert "Next Actions" in body
     assert "Impact: Waiting on queue execution" in body
     assert "Inbound capture: Observed 1 inbound capture event but no downstream artifact yet." in body
+    assert "Brain-first lookup: reuse_existing · existing_links_found · 1 existing objects" in body
+    assert "Backlinks: satisfied · 1 source notes" in body
 
 
 def test_ui_server_actions_endpoint_accepts_pack_scope(temp_vault, monkeypatch):


### PR DESCRIPTION
## Summary
- Add `brain_first_lookup` and `backlink_expectation` contracts to note/object traceability.
- Propagate those contracts into research-tech production signals so existing canonical object links surface as `reuse_existing` instead of blind object creation.
- Render brain-first lookup and backlink status on `/signals`, and update Phase 24/Milestone docs.

## Test Plan
- `PYTHONPATH=src pytest tests/test_truth_api.py::test_truth_api_note_traceability_exposes_brain_first_lookup_for_existing_links tests/test_truth_api.py::test_research_tech_deep_dive_signal_exposes_brain_first_lookup_contract tests/test_ui_server.py::test_ui_server_signals_page_renders_governance_resolver_metadata -q`
- `PYTHONPATH=src pytest tests/test_truth_api.py tests/test_ui_server.py tests/test_ui_smoke.py -q`
- `git diff --check`
- `PYTHONPATH=src pytest -q`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/41" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
