### PR TITLE
Add candidate canonicalization workbench

### DIFF
--- a/docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
+++ b/docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
@@ -363,10 +363,15 @@ Current slice:
   - note/object traceability exposes `backlink_expectation`
   - production signals carry these contracts into `/signals`
   - deep dives that already wikilink existing objects now surface `reuse_existing` instead of looking like blind object-creation work
+- [[2026-04-21-phase26-candidate-canonicalization-workbench|Phase 26]] closes the remaining candidate/canonical operator gap:
+  - registry candidates are visible through `/candidates` and `/api/candidates`
+  - promote / merge / reject actions reuse the existing candidate lifecycle helpers
+  - review actions write `ui_candidate_reviewed` audit events
+  - promote / merge refresh derived knowledge state so active objects and rewritten links become visible without a separate manual reindex
 
 Next slice:
 
-- Continue Milestone 7 only where there is still a concrete operator loop gap. Do not widen into background intelligence until the reviewed candidate/canonical transition needs stricter enforcement.
+- Milestone 7 should be treated as closed once Phase 26 lands. The next work should move to the explicit roadmap gaps in Milestone 9A / 10 rather than widening candidate review into hidden semantic automation.
 
 ### Milestone 8: Knowledge Evolution Layer
 
@@ -543,7 +548,7 @@ Completed references:
 
 Active next reference:
 
-- `Milestone 7: Active Signal Loop` (next execution slice should focus on brain-first lookup + backlink legibility)
+- `Milestone 9A: Background Intelligence Orchestration Integration`, unless Phase 26 follow-up bugs show that candidate review still lacks operator safety.
 
 What those phases accomplished:
 
@@ -555,6 +560,8 @@ What those phases accomplished:
 - `Phase 22` turned passive signal surfaces into a first active loop by making signal/action/result impact legible from the product itself
 - `Phase 23` made inbound note capture legible by turning existing pipeline/refine audit into note, signal, and briefing products
 - `Phase 24` made object-creation routing legible by exposing brain-first lookup and backlink expectation contracts from traceability through signals into the UI
+- `Phase 25` made long-running pipeline execution observable from the same run-ledger truth in CLI, API, and UI
+- `Phase 26` makes candidate/canonical transitions directly reviewable from the operator surface without introducing a second canonicalization system
 
 What this sequence closed:
 
@@ -565,12 +572,13 @@ What this sequence closed:
 - the signal loop no longer stops at passive visibility; it now shows whether execution was productive, stalled, failed, or still waiting
 - the signal loop now also shows what recent inbound note capture actually did before queue execution became relevant
 - the signal loop no longer implies blind downstream object creation when the note already links to canonical brain objects
+- candidate concepts are no longer trapped behind a CLI-only lifecycle; they now have an explicit review surface and audit trail
 
 What the next phase should close:
 
-- reviewed candidate/canonical transitions should become easier to act on from the operator surface
 - if we enforce backlinks at write time, the enforcement should reuse the `backlink_expectation` contract instead of introducing a second source of truth
 - if we add richer semantic relation extraction, it should be a pack-level extraction contract, not a hidden global memory backend
+- background intelligence orchestration should reuse the action queue and run ledger instead of creating another execution path
 
 Sequence rule:
 
@@ -582,7 +590,8 @@ Sequence rule:
 - treat `Phase 22` as the first closeout slice for Milestone 7
 - treat `Phase 23` as the second closeout slice for Milestone 7
 - treat `Phase 24` as the third closeout slice for Milestone 7: brain-first lookup + backlink legibility
-- continue within Milestone 7 only for reviewed candidate/canonical actionability; otherwise move to the next explicit roadmap gap
+- treat `Phase 26` as the final Milestone 7 closeout slice for reviewed candidate/canonical actionability
+- do not continue within Milestone 7 unless Phase 26 reveals a concrete safety defect
 
 This keeps the roadmap moving from substrate -> contracts -> entry products, instead of looping back into infrastructure.
 
@@ -630,18 +639,20 @@ As of this plan:
 - Milestone 4: complete
 - Milestone 5: complete
 - Milestone 6: complete
-- Milestone 7: in progress
-- Milestone 8+: not started
+- Milestone 7: complete once Phase 26 lands
+- Milestone 8: complete
+- Milestone 9: in progress
+- Milestone 9A: planned
 
 So the honest product statement is:
 
-> OVP is already a usable local knowledge workbench core with a real review console, but it is not yet an active knowledge system.
+> OVP is a usable local knowledge workbench with a real review console, observable runtime, and active signal loop. It is not yet a fully orchestrated background intelligence system.
 
 The remaining gap is no longer “can this architecture support it?” It is now a sequence problem:
 
-- finish semantic hardening,
-- make the production chain legible,
-- then add signal capture, evolution, and background intelligence in that order.
+- keep candidate review explicit and auditable,
+- route background actions through the existing queue / run-ledger contracts,
+- add richer pack-level semantic extraction only after the orchestration path is observable.
 
 ## PR Review Gate
 

--- a/docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
+++ b/docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
@@ -371,7 +371,7 @@ Current slice:
 
 Next slice:
 
-- Milestone 7 should be treated as closed once Phase 26 lands. The next work should move to the explicit roadmap gaps in Milestone 9A / 10 rather than widening candidate review into hidden semantic automation.
+- Milestone 7 should be treated as closed once Phase 26 lands. The next work should move to the explicit roadmap gaps in Milestone 9A rather than widening candidate review into hidden semantic automation.
 
 ### Milestone 8: Knowledge Evolution Layer
 

--- a/docs/plans/2026-04-17-ovp-architecture-mapping.md
+++ b/docs/plans/2026-04-17-ovp-architecture-mapping.md
@@ -154,7 +154,7 @@ This means OVP is already doing context assembly, but it has not yet been declar
 
 ### Layer 4: Governance / Resolver / Review
 
-This exists in fragments and is the least explicit.
+This exists and is becoming explicit, but it is still assembled from several surfaces rather than one governance product.
 
 Current components:
 
@@ -167,7 +167,14 @@ Current components:
 - signals log / signal ledger
 - truth API review actions
 
-So governance is not missing. It is **present but not yet unified**.
+So governance is not missing. It is **present and partially unified**.
+
+Phase 26 adds the missing candidate/canonical review surface without changing the identity model:
+
+- `ConceptRegistry` remains the source of truth for candidate / active / rejected state.
+- `/candidates` and `/api/candidates` are an access layer over registry candidates, not a second registry.
+- promote / merge / reject actions route through `promote_candidates.py`, so filesystem, registry, Atlas, link rewrite, audit, and knowledge-index refresh stay in one lifecycle path.
+- candidate links are ordinary canonical Obsidian wikilinks plus lifecycle state. They are not typed graph triples and should not be treated as semantic relations like `replaces`, `enriches`, `confirms`, or `challenges`.
 
 ## The Architectural Upgrade Path
 

--- a/docs/plans/2026-04-21-phase26-candidate-canonicalization-workbench.md
+++ b/docs/plans/2026-04-21-phase26-candidate-canonicalization-workbench.md
@@ -1,0 +1,166 @@
+# Phase 26: Candidate Canonicalization Workbench Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make candidate concepts visible, reviewable, and safely promotable from the OVP UI/API without inventing a second canonicalization path.
+
+**Architecture:** `ConceptRegistry` remains the source of truth for candidate/active/rejected state. The workbench adds a read payload over existing registry candidates, then routes promote/merge/reject UI/API actions through the existing `promote_candidates.py` lifecycle functions. Successful mutations write a review audit event and refresh derived knowledge state when the mutation changes active Evergreen content or links.
+
+**Tech Stack:** Python stdlib HTTP server, existing OVP truth API/view-model layer, `ConceptRegistry`, `promote_candidates.py`, pytest.
+
+### Task 1: Candidate Browser Truth API
+
+**Files:**
+- Modify: `src/ovp_pipeline/truth_api.py`
+- Test: `tests/test_truth_api.py`
+
+**Step 1: Write failing tests**
+
+Add tests that seed a candidate registry entry and assert:
+- `list_candidate_concepts()` returns candidate metadata, suggested action, candidate note path, and similar active concepts.
+- `review_candidate_concept(action="promote")` promotes the candidate, deletes the candidate note, creates the Evergreen note, records a review action, and reports whether the knowledge index was rebuilt.
+
+**Step 2: Run RED tests**
+
+Run: `pytest tests/test_truth_api.py::test_truth_api_lists_candidate_concepts tests/test_truth_api.py::test_truth_api_review_candidate_concept_promotes_and_records_audit -q`
+
+Expected: fail because the new truth API functions do not exist.
+
+**Step 3: Implement truth API**
+
+Add:
+- `list_candidate_concepts(vault_dir, query="", limit=100, offset=0) -> dict`
+- `review_candidate_concept(vault_dir, slug, action, target_slug=None, note="", pack_name=None) -> dict`
+
+Implementation notes:
+- Load `ConceptRegistry(resolve_vault_dir(vault_dir)).load()`.
+- Use `review_candidates(registry)` for suggested actions and similar concepts.
+- Use relative candidate path `10-Knowledge/Evergreen/_Candidates/<slug>.md` when it exists.
+- Use existing `promote_candidate`, `merge_candidate`, and `reject_candidate` for lifecycle side effects.
+- Rebuild `knowledge.db` after `promote` and `merge` so UI surfaces reflect active content/link changes.
+- Record `ui_candidate_reviewed` through `record_review_action`.
+
+**Step 4: Run GREEN tests**
+
+Run the same two tests. Expected: pass.
+
+### Task 2: Candidate Browser View Model
+
+**Files:**
+- Modify: `src/ovp_pipeline/ui/view_models.py`
+- Test: `tests/test_truth_api.py`
+
+**Step 1: Write failing test**
+
+Add a test asserting `build_candidate_browser_payload()` returns:
+- `screen == "candidates/browser"`
+- requested pack/query metadata
+- candidate items from the truth API
+- operator rail links back to briefing, signals, actions, and objects.
+
+**Step 2: Run RED test**
+
+Run: `pytest tests/test_truth_api.py::test_candidate_browser_payload_exposes_operator_context -q`
+
+Expected: fail because the view model does not exist.
+
+**Step 3: Implement view model**
+
+Add `build_candidate_browser_payload(vault_dir, pack_name=None, query="")` that wraps `list_candidate_concepts()` and exposes a small operator rail. Do not add new persistence or business logic here.
+
+**Step 4: Run GREEN test**
+
+Run the same test. Expected: pass.
+
+### Task 3: Candidate UI/API Routes
+
+**Files:**
+- Modify: `src/ovp_pipeline/commands/ui_server.py`
+- Test: `tests/test_ui_server.py`
+
+**Step 1: Write failing tests**
+
+Add tests that assert:
+- `GET /api/candidates` returns `screen == "candidates/browser"` and candidate items.
+- `GET /candidates` renders candidate title plus promote/merge/reject controls.
+- `POST /api/candidates/review` can promote a candidate and returns the lifecycle mutation.
+
+**Step 2: Run RED tests**
+
+Run: `pytest tests/test_ui_server.py::test_ui_server_candidates_endpoint_returns_payload tests/test_ui_server.py::test_ui_server_candidates_page_renders_review_controls tests/test_ui_server.py::test_ui_server_can_promote_candidate_via_api -q`
+
+Expected: fail because candidate routes do not exist.
+
+**Step 3: Implement routes and HTML**
+
+Add:
+- Shell nav item `Candidates` for research-compatible shells.
+- `GET /api/candidates` and `GET /candidates`.
+- `POST /api/candidates/review` and `POST /candidates/review`.
+- `_render_candidates_page(payload)` and `_render_candidate_items(...)`.
+- `_review_candidate_action(form)` that delegates to `review_candidate_concept()`.
+
+Use `_guard_research_route()` for the new surface, matching other research-only review surfaces.
+
+**Step 4: Run GREEN tests**
+
+Run the same three tests. Expected: pass.
+
+### Task 4: Documentation and Roadmap Closeout
+
+**Files:**
+- Modify: `docs/plans/2026-04-17-ovp-architecture-mapping.md`
+- Modify: current roadmap/progress docs that mention stale milestone status
+- Modify: `docs/plans/2026-04-21-phase26-candidate-canonicalization-workbench.md`
+
+**Step 1: Update docs**
+
+Document:
+- Candidate workbench uses registry candidates as source of truth.
+- Promote/merge/reject are operator review actions, not automatic semantic assertions.
+- Candidate links are not typed graph triples; they are canonical Obsidian wikilink targets plus lifecycle state.
+- Phase 26 completion criteria.
+
+**Step 2: Run docs sanity checks**
+
+Run: `rg -n "Phase 26|Candidate|Milestone 8\\+|not started" docs`
+
+Expected: Phase 26 appears in plan/progress docs and stale milestone text is corrected or explicitly contextualized.
+
+### Task 5: Verification, Commit, PR
+
+**Files:**
+- Modified files from Tasks 1-4
+
+**Step 1: Run targeted tests**
+
+Run:
+- `pytest tests/test_truth_api.py::test_truth_api_lists_candidate_concepts tests/test_truth_api.py::test_truth_api_review_candidate_concept_promotes_and_records_audit tests/test_truth_api.py::test_candidate_browser_payload_exposes_operator_context -q`
+- `pytest tests/test_ui_server.py::test_ui_server_candidates_endpoint_returns_payload tests/test_ui_server.py::test_ui_server_candidates_page_renders_review_controls tests/test_ui_server.py::test_ui_server_can_promote_candidate_via_api -q`
+
+**Step 2: Run broader safety suite**
+
+Run:
+- `pytest tests/test_promote_candidates.py tests/test_truth_api.py tests/test_ui_server.py -q`
+- `git diff --check`
+
+**Step 3: Commit and PR**
+
+Commit with a Phase 26 message, push `feat/phase26-candidate-workbench`, open a PR, inspect review feedback, fix actionable bugs, and merge only if review/CI are clean.
+
+## Closeout Notes
+
+Phase 26 is complete when the PR lands with these properties:
+
+- Candidate concepts are visible through `/candidates` and `/api/candidates`.
+- The workbench reads candidates from `ConceptRegistry`; it does not create a second candidate store.
+- `promote`, `merge`, and `reject` actions route through `promote_candidates.py`.
+- Every UI/API review action writes a `ui_candidate_reviewed` event.
+- `promote` and `merge` rebuild the knowledge index so active object/link state does not remain stale after an operator action.
+- Candidate canonicalization remains distinct from typed semantic evolution links. A candidate wikilink is an identity/lifecycle concern; typed links like `replaces`, `enriches`, `confirms`, and `challenges` remain evolution/relation concerns.
+
+Verification completed during implementation:
+
+- `pytest tests/test_truth_api.py::test_truth_api_lists_candidate_concepts tests/test_truth_api.py::test_truth_api_review_candidate_concept_promotes_and_records_audit tests/test_truth_api.py::test_candidate_browser_payload_exposes_operator_context tests/test_ui_server.py::test_ui_server_candidates_endpoint_returns_payload tests/test_ui_server.py::test_ui_server_candidates_page_renders_review_controls tests/test_ui_server.py::test_ui_server_can_promote_candidate_via_api -q`
+- `pytest tests/test_truth_api.py::test_truth_api_review_candidate_concept_merges_into_existing_and_rebuilds tests/test_truth_api.py::test_truth_api_review_candidate_concept_rejects_without_rebuilding_index -q`
+- `pytest tests/test_promote_candidates.py tests/test_truth_api.py tests/test_ui_server.py -q`

--- a/progress.md
+++ b/progress.md
@@ -1,5 +1,45 @@
 # Progress Log
 
+## Session: 2026-04-21
+
+### Phase 26: Candidate Canonicalization Workbench
+- **Status:** implementation complete; PR verification in progress
+- Actions taken:
+  - Added `list_candidate_concepts(...)` to expose registry candidate metadata, candidate note paths, suggested lifecycle action, and similar active concepts
+  - Added `review_candidate_concept(...)` as the UI/API-safe gateway for candidate lifecycle actions
+  - Kept candidate mutations on the existing lifecycle path:
+    - `promote_candidate`
+    - `merge_candidate`
+    - `reject_candidate`
+  - Added `ui_candidate_reviewed` audit events for promote / merge / reject actions
+  - Rebuilt `knowledge.db` after promote and merge so newly active objects and rewritten links are visible without a separate manual reindex
+  - Added `build_candidate_browser_payload(...)` with operator rails back to briefing, signals, actions, and objects
+  - Added `/api/candidates` and `/candidates`
+  - Added `/api/candidates/review` and `/candidates/review`
+  - Added the `Candidates` nav item for research-compatible shells
+  - Updated roadmap docs to treat Phase 26 as the final Milestone 7 candidate/canonical closeout slice
+  - Clarified that candidate wikilinks are identity/lifecycle state, not typed semantic graph triples
+- Files created/modified:
+  - docs/plans/2026-04-21-phase26-candidate-canonicalization-workbench.md
+  - docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
+  - docs/plans/2026-04-17-ovp-architecture-mapping.md
+  - src/ovp_pipeline/truth_api.py
+  - src/ovp_pipeline/ui/view_models.py
+  - src/ovp_pipeline/commands/ui_server.py
+  - tests/test_truth_api.py
+  - tests/test_ui_server.py
+- Verification so far:
+  - `pytest tests/test_truth_api.py::test_truth_api_lists_candidate_concepts tests/test_truth_api.py::test_truth_api_review_candidate_concept_promotes_and_records_audit tests/test_truth_api.py::test_candidate_browser_payload_exposes_operator_context tests/test_ui_server.py::test_ui_server_candidates_endpoint_returns_payload tests/test_ui_server.py::test_ui_server_candidates_page_renders_review_controls tests/test_ui_server.py::test_ui_server_can_promote_candidate_via_api -q`
+  - `6 passed`
+  - `pytest tests/test_truth_api.py::test_truth_api_review_candidate_concept_merges_into_existing_and_rebuilds tests/test_truth_api.py::test_truth_api_review_candidate_concept_rejects_without_rebuilding_index -q`
+  - `2 passed`
+  - `pytest tests/test_promote_candidates.py tests/test_truth_api.py tests/test_ui_server.py -q`
+  - `188 passed`
+  - `git diff --check`
+  - clean
+  - `pytest -q`
+  - `680 passed`
+
 ## Session: 2026-04-20
 
 ### Phase 24: Brain-First Lookup And Backlink Legibility

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -24,6 +24,7 @@ from ..ui.view_models import (
     build_action_queue_payload,
     build_atlas_browser_payload,
     build_briefing_payload,
+    build_candidate_browser_payload,
     build_cluster_browser_payload,
     build_cluster_detail_payload,
     build_contradiction_browser_payload,
@@ -46,6 +47,7 @@ from ..truth_api import (
     ensure_signal_ledger_synced,
     get_runtime_status,
     record_review_action,
+    review_candidate_concept,
     retry_action_queue_item,
     review_evolution_candidate,
     run_action_queue,
@@ -85,6 +87,7 @@ def _shell_nav_items(requested_pack: str = "") -> list[tuple[str, str]]:
     if _shell_supports_research_nav(requested_pack):
         items.extend(
             [
+                ("Candidates", "/candidates"),
                 ("Evolution", "/evolution"),
                 ("Clusters", "/clusters"),
                 ("Atlas", "/atlas"),
@@ -2395,6 +2398,113 @@ def _render_evolution_browser_page(payload: dict) -> str:
     )
 
 
+def _render_candidate_items(payload: dict) -> str:
+    requested_pack = str(payload.get("requested_pack") or "")
+    next_path = _shell_href("/candidates", requested_pack)
+    rendered: list[str] = []
+    for item in payload.get("items", []):
+        if not isinstance(item, dict):
+            continue
+        slug = str(item.get("slug") or "")
+        title = str(item.get("title") or slug)
+        candidate_note_path = str(item.get("candidate_note_path") or "")
+        suggested_action = str(item.get("suggested_action") or "keep_as_candidate")
+        similar_existing = item.get("similar_existing") if isinstance(item.get("similar_existing"), list) else []
+        first_similar = similar_existing[0] if similar_existing else {}
+        default_target = str(first_similar.get("slug") or "") if isinstance(first_similar, dict) else ""
+        similar_html = "".join(
+            "<li>"
+            f"<a href='{escape(str(similar.get('path') or ''))}'>{escape(str(similar.get('title') or similar.get('slug') or ''))}</a> "
+            f"<span class='pill'>{escape(str(similar.get('score') or ''))}</span>"
+            "</li>"
+            for similar in similar_existing[:5]
+            if isinstance(similar, dict)
+        ) or "<li class='muted'>No strong active concept matches.</li>"
+        pack_hidden = (
+            f"<input type='hidden' name='pack' value='{escape(requested_pack)}' />"
+            if requested_pack
+            else ""
+        )
+        title_html = (
+            f"<a href='{escape(candidate_note_path)}'>{escape(title)}</a>"
+            if candidate_note_path
+            else escape(title)
+        )
+        rendered.append(
+            "<li>"
+            f"<h3>{title_html} <span class='pill'>{escape(slug)}</span></h3>"
+            f"<div class='muted'>Suggested: {escape(suggested_action)} · "
+            f"sources {escape(str(item.get('source_count') or 0))} · "
+            f"evidence {escape(str(item.get('evidence_count') or 0))}</div>"
+            f"<p>{escape(str(item.get('definition') or ''))}</p>"
+            "<div class='muted'>Similar active concepts</div>"
+            f"<ul class='list-tight'>{similar_html}</ul>"
+            "<div class='link-row'>"
+            "<form method='post' action='/candidates/review' class='link-row'>"
+            f"{pack_hidden}"
+            f"<input type='hidden' name='slug' value='{escape(slug)}' />"
+            "<input type='hidden' name='action' value='promote' />"
+            f"<input type='hidden' name='next' value='{escape(next_path)}' />"
+            "<button type='submit'>Promote</button>"
+            "</form>"
+            "<form method='post' action='/candidates/review' class='link-row'>"
+            f"{pack_hidden}"
+            f"<input type='hidden' name='slug' value='{escape(slug)}' />"
+            "<input type='hidden' name='action' value='merge' />"
+            f"<input type='hidden' name='next' value='{escape(next_path)}' />"
+            f"<input type='text' name='target_slug' value='{escape(default_target)}' placeholder='target slug' />"
+            "<button type='submit'>Merge</button>"
+            "</form>"
+            "<form method='post' action='/candidates/review' class='link-row'>"
+            f"{pack_hidden}"
+            f"<input type='hidden' name='slug' value='{escape(slug)}' />"
+            "<input type='hidden' name='action' value='reject' />"
+            f"<input type='hidden' name='next' value='{escape(next_path)}' />"
+            "<button type='submit'>Reject</button>"
+            "</form>"
+            "</div>"
+            "</li>"
+        )
+    if not rendered:
+        return "<p class='muted'>No candidate concepts match the current filter.</p>"
+    return f"<ul class='list-tight'>{''.join(rendered)}</ul>"
+
+
+def _render_candidates_page(payload: dict) -> str:
+    query = str(payload.get("query") or "")
+    requested_pack = str(payload.get("requested_pack") or "")
+    operator_rail = _render_operator_rail(payload)
+    status_counts = " ".join(
+        f"<span class='pill'>{escape(str(status))}: {escape(str(count))}</span>"
+        for status, count in (payload.get("status_counts") or {}).items()
+    )
+    return _layout(
+        "Candidate Workbench",
+        "".join(
+            [
+                "<h1>Candidate Workbench</h1>",
+                "<p class='muted'>Review registry candidates before they become canonical Evergreen objects. "
+                "Promote creates an active note, merge rewrites candidate links into an existing object, "
+                "and reject removes the pending candidate artifact.</p>",
+                "<form method='get' action='/candidates' class='link-row'>",
+                (
+                    f"<input type='hidden' name='pack' value='{escape(requested_pack)}' />"
+                    if requested_pack
+                    else ""
+                ),
+                f"<input type='text' name='q' value='{escape(query)}' placeholder='Filter candidates' />",
+                "<button type='submit'>Search</button>",
+                "</form>",
+                f"<p class='muted'>{escape(str(payload.get('count') or 0))} candidate(s) in view.</p>",
+                f"<section class='card'><h2>Status</h2><div class='link-row'>{status_counts}</div></section>",
+                operator_rail,
+                f"<section class='card'><h2>Review Queue</h2>{_render_candidate_items(payload)}</section>",
+            ]
+        ),
+        requested_pack=requested_pack,
+    )
+
+
 def _render_signal_context_contract(item: dict) -> str:
     payload = item.get("payload") or {}
     brain_lookup = payload.get("brain_first_lookup") or {}
@@ -3304,6 +3414,31 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
                     )
                     self._write_html(_render_signals_page(payload))
                     return
+                if path == "/api/candidates":
+                    q = query.get("q", [""])[0]
+                    pack_name = query.get("pack", [""])[0] or None
+                    if self._guard_research_route(pack_name=pack_name, route_path="/candidates", api=True):
+                        return
+                    self._write_json(
+                        build_candidate_browser_payload(
+                            resolved_vault,
+                            pack_name=pack_name,
+                            query=q,
+                        )
+                    )
+                    return
+                if path == "/candidates":
+                    q = query.get("q", [""])[0]
+                    pack_name = query.get("pack", [""])[0] or None
+                    if self._guard_research_route(pack_name=pack_name, route_path="/candidates", api=False):
+                        return
+                    payload = build_candidate_browser_payload(
+                        resolved_vault,
+                        pack_name=pack_name,
+                        query=q,
+                    )
+                    self._write_html(_render_candidates_page(payload))
+                    return
                 if path == "/api/evolution":
                     q = query.get("q", [""])[0]
                     status = query.get("status", ["all"])[0] or "all"
@@ -3574,6 +3709,19 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
                     payload = self._review_evolution_action(form)
                     self._redirect(str(payload["next_path"]))
                     return
+                if path == "/api/candidates/review":
+                    pack_name = self._form_first(form, "pack").strip() or None
+                    if self._guard_research_route(pack_name=pack_name, route_path="/candidates/review", api=True):
+                        return
+                    self._write_json(self._review_candidate_action(form))
+                    return
+                if path == "/candidates/review":
+                    pack_name = self._form_first(form, "pack").strip() or None
+                    if self._guard_research_route(pack_name=pack_name, route_path="/candidates/review", api=False):
+                        return
+                    payload = self._review_candidate_action(form)
+                    self._redirect(str(payload["next_path"]))
+                    return
                 if path == "/api/actions/enqueue":
                     self._write_json(self._enqueue_signal_action(form))
                     return
@@ -3752,6 +3900,26 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
             )
             payload["next_path"] = self._form_first(form, "next").strip() or _shell_href(
                 "/evolution",
+                pack_name or "",
+            )
+            return payload
+
+        def _review_candidate_action(self, form: dict[str, list[str]]) -> dict[str, object]:
+            slug = self._form_first(form, "slug").strip()
+            action = self._form_first(form, "action").strip()
+            target_slug = self._form_first(form, "target_slug").strip() or None
+            note = self._form_first(form, "note").strip()
+            pack_name = self._form_first(form, "pack").strip() or None
+            payload = review_candidate_concept(
+                resolved_vault,
+                slug=slug,
+                action=action,
+                target_slug=target_slug,
+                note=note,
+                pack_name=pack_name,
+            )
+            payload["next_path"] = self._form_first(form, "next").strip() or _shell_href(
+                "/candidates",
                 pack_name or "",
             )
             return payload

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -58,6 +58,7 @@ _MARKDOWN_RENDERER = MarkdownIt("commonmark", {"breaks": True, "html": False}).e
 _FENCED_FRONTMATTER_RE = re.compile(r"^```ya?ml\s*\n---\n(.*?)\n---\n```\s*\n?", re.DOTALL)
 _GITHUB_REPO_RE = re.compile(r"https://github\.com/([^/\s]+)/([^/\s#]+)")
 _EVOLUTION_LINK_TYPES = ["challenges", "replaces", "enriches", "confirms"]
+_CANDIDATE_MERGE_AUTOFILL_THRESHOLD = 0.7
 
 
 def _shell_href(path: str, requested_pack: str = "") -> str:
@@ -2411,11 +2412,18 @@ def _render_candidate_items(payload: dict) -> str:
         suggested_action = str(item.get("suggested_action") or "keep_as_candidate")
         similar_existing = item.get("similar_existing") if isinstance(item.get("similar_existing"), list) else []
         first_similar = similar_existing[0] if similar_existing else {}
-        default_target = str(first_similar.get("slug") or "") if isinstance(first_similar, dict) else ""
+        default_target = ""
+        if isinstance(first_similar, dict):
+            try:
+                first_score = float(first_similar.get("score", 0.0))
+            except (TypeError, ValueError):
+                first_score = 0.0
+            if first_score >= _CANDIDATE_MERGE_AUTOFILL_THRESHOLD:
+                default_target = str(first_similar.get("slug") or "")
         similar_html = "".join(
             "<li>"
             f"<a href='{escape(str(similar.get('path') or ''))}'>{escape(str(similar.get('title') or similar.get('slug') or ''))}</a> "
-            f"<span class='pill'>{escape(str(similar.get('score') or ''))}</span>"
+            f"<span class='pill'>{escape(str(similar['score']) if 'score' in similar else '')}</span>"
             "</li>"
             for similar in similar_existing[:5]
             if isinstance(similar, dict)

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -46,6 +46,7 @@ from ..truth_api import (
     enqueue_signal_action,
     ensure_signal_ledger_synced,
     get_runtime_status,
+    list_review_actions,
     record_review_action,
     review_candidate_concept,
     retry_action_queue_item,
@@ -66,6 +67,11 @@ def _shell_href(path: str, requested_pack: str = "") -> str:
         return path
     separator = "&" if "?" in path else "?"
     return f"{path}{separator}pack={quote(requested_pack, safe='')}"
+
+
+def _append_query_param(path: str, key: str, value: str) -> str:
+    separator = "&" if "?" in path else "?"
+    return f"{path}{separator}{quote(key, safe='')}={quote(value, safe='')}"
 
 
 def _shell_supports_research_nav(requested_pack: str = "") -> bool:
@@ -149,6 +155,7 @@ def _layout(title: str, body: str, *, requested_pack: str = "", auto_refresh_sec
       .shell-head {{ padding: 1.1rem 1.25rem 0; }}
       .shell-body {{ padding: 0 1.25rem 1.25rem; }}
       .card {{ border: 1px solid var(--border); background: var(--surface); border-radius: 16px; padding: 1rem; margin-bottom: 1rem; }}
+      .warning {{ border-color: #d48a2f; background: #fff8ec; }}
       .grid {{ display: grid; gap: 1rem; }}
       .stats {{ grid-template-columns: repeat(auto-fit, minmax(190px, 1fr)); }}
       .two-col {{ grid-template-columns: minmax(0, 2.1fr) minmax(280px, 1fr); align-items: start; }}
@@ -2481,10 +2488,16 @@ def _render_candidate_items(payload: dict) -> str:
 def _render_candidates_page(payload: dict) -> str:
     query = str(payload.get("query") or "")
     requested_pack = str(payload.get("requested_pack") or "")
+    candidate_warning = str(payload.get("candidate_warning") or "")
     operator_rail = _render_operator_rail(payload)
     status_counts = " ".join(
         f"<span class='pill'>{escape(str(status))}: {escape(str(count))}</span>"
         for status, count in (payload.get("status_counts") or {}).items()
+    )
+    warning_card = (
+        f"<section class='card warning'><h2>Review Warning</h2><p>{escape(candidate_warning)}</p></section>"
+        if candidate_warning
+        else ""
     )
     return _layout(
         "Candidate Workbench",
@@ -2506,6 +2519,7 @@ def _render_candidates_page(payload: dict) -> str:
                 f"<p class='muted'>{escape(str(payload.get('count') or 0))} candidate(s) in view.</p>",
                 f"<section class='card'><h2>Status</h2><div class='link-row'>{status_counts}</div></section>",
                 operator_rail,
+                warning_card,
                 f"<section class='card'><h2>Review Queue</h2>{_render_candidate_items(payload)}</section>",
             ]
         ),
@@ -3438,6 +3452,7 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
                 if path == "/candidates":
                     q = query.get("q", [""])[0]
                     pack_name = query.get("pack", [""])[0] or None
+                    candidate_warning = query.get("candidate_warning", [""])[0]
                     if self._guard_research_route(pack_name=pack_name, route_path="/candidates", api=False):
                         return
                     payload = build_candidate_browser_payload(
@@ -3445,6 +3460,7 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
                         pack_name=pack_name,
                         query=q,
                     )
+                    payload["candidate_warning"] = candidate_warning
                     self._write_html(_render_candidates_page(payload))
                     return
                 if path == "/api/evolution":
@@ -3918,19 +3934,70 @@ def create_server(vault_dir: Path | str, *, host: str = "127.0.0.1", port: int =
             target_slug = self._form_first(form, "target_slug").strip() or None
             note = self._form_first(form, "note").strip()
             pack_name = self._form_first(form, "pack").strip() or None
-            payload = review_candidate_concept(
-                resolved_vault,
-                slug=slug,
-                action=action,
-                target_slug=target_slug,
-                note=note,
-                pack_name=pack_name,
-            )
-            payload["next_path"] = self._form_first(form, "next").strip() or _shell_href(
+            next_path = self._form_first(form, "next").strip() or _shell_href(
                 "/candidates",
                 pack_name or "",
             )
+            try:
+                payload = review_candidate_concept(
+                    resolved_vault,
+                    slug=slug,
+                    action=action,
+                    target_slug=target_slug,
+                    note=note,
+                    pack_name=pack_name,
+                )
+            except RuntimeError as exc:
+                payload = self._candidate_review_rebuild_warning_payload(
+                    slug=slug,
+                    action=action,
+                    target_slug=target_slug,
+                    note=note,
+                    error=exc,
+                )
+                if not payload["partial_success"]:
+                    raise
+            payload["next_path"] = next_path
+            knowledge_index_error = str(payload.get("knowledge_index_error") or "")
+            if knowledge_index_error:
+                payload["next_path"] = _append_query_param(
+                    next_path,
+                    "candidate_warning",
+                    knowledge_index_error,
+                )
             return payload
+
+        def _candidate_review_rebuild_warning_payload(
+            self,
+            *,
+            slug: str,
+            action: str,
+            target_slug: str | None,
+            note: str,
+            error: RuntimeError,
+        ) -> dict[str, object]:
+            audit_event: dict[str, object] = {}
+            for item in list_review_actions(resolved_vault, limit=20):
+                if (
+                    item.get("event_type") == "ui_candidate_reviewed"
+                    and item.get("candidate_slug") == slug
+                ):
+                    audit_event = item
+                    break
+            knowledge_index_error = str(audit_event.get("knowledge_index_error") or error)
+            return {
+                "action": str(audit_event.get("action") or action),
+                "slug": str(audit_event.get("candidate_slug") or slug),
+                "target_slug": str(audit_event.get("target_slug") or target_slug or ""),
+                "status": str(audit_event.get("status") or "applied_with_warning"),
+                "note": str(audit_event.get("note") or note),
+                "mutation": audit_event.get("mutation") if isinstance(audit_event.get("mutation"), dict) else {},
+                "knowledge_index_rebuilt": bool(audit_event.get("knowledge_index_rebuilt")),
+                "knowledge_index_error": knowledge_index_error,
+                "warning": str(error),
+                "partial_success": bool(audit_event),
+                "audit_event": audit_event,
+            }
 
         def _enqueue_signal_action(self, form: dict[str, list[str]]) -> dict[str, object]:
             signal_id = self._form_first(form, "signal_id").strip()

--- a/src/ovp_pipeline/truth_api.py
+++ b/src/ovp_pipeline/truth_api.py
@@ -1858,6 +1858,7 @@ def _review_action_items(
             payload = json.loads(payload_json)
         except json.JSONDecodeError:
             payload = {}
+        mutation_payload = payload.get("mutation")
         action_object_ids = [
             str(value)
             for value in payload.get("object_ids", [])
@@ -1883,6 +1884,7 @@ def _review_action_items(
                 "candidate_slug": str(payload.get("candidate_slug") or ""),
                 "target_slug": str(payload.get("target_slug") or ""),
                 "action": str(payload.get("action") or ""),
+                "mutation": mutation_payload if isinstance(mutation_payload, dict) else {},
                 "knowledge_index_rebuilt": bool(payload.get("knowledge_index_rebuilt")),
                 "knowledge_index_error": str(payload.get("knowledge_index_error") or ""),
                 "contradiction_ids": [

--- a/src/ovp_pipeline/truth_api.py
+++ b/src/ovp_pipeline/truth_api.py
@@ -599,7 +599,6 @@ def list_candidate_concepts(
             }
         )
 
-    paginated = items[offset: offset + limit]
     return {
         "screen": "candidates/browser",
         "query": query or "",

--- a/src/ovp_pipeline/truth_api.py
+++ b/src/ovp_pipeline/truth_api.py
@@ -20,10 +20,18 @@ from .governance_registry import (
 )
 from .handler_registry import execute_focused_action_handler
 from .identity import canonicalize_note_id
-from .knowledge_index import ensure_knowledge_db_current
+from .knowledge_index import ensure_knowledge_db_current, rebuild_knowledge_index
 from .observation_surface_registry import execute_observation_surface_builder
 from .pack_resolution import iter_compatible_packs
 from .packs.loader import DEFAULT_WORKFLOW_PACK_NAME
+from .concept_registry import ConceptRegistry
+from .promote_candidates import (
+    candidate_file_path,
+    merge_candidate,
+    promote_candidate,
+    reject_candidate,
+    review_candidates,
+)
 from .runtime import (
     VaultLayout,
     action_queue_write_lock,
@@ -505,6 +513,162 @@ def record_review_action(
     }
     _append_jsonl(layout.logs_dir / f"{_REVIEW_AUDIT_LOG_NAME}.jsonl", event)
     return event
+
+
+def list_candidate_concepts(
+    vault_dir: Path | str,
+    *,
+    query: str | None = None,
+    limit: int = 100,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """List candidate concepts from the registry with review suggestions."""
+    limit, offset = _validate_page_args(limit=limit, offset=offset)
+    resolved_vault = resolve_vault_dir(vault_dir)
+    registry = ConceptRegistry(resolved_vault).load()
+    normalized_query = (query or "").strip().lower()
+    suggestions = {
+        entry.slug: (suggested_action, similar_existing)
+        for entry, suggested_action, similar_existing in review_candidates(registry)
+    }
+    items: list[dict[str, Any]] = []
+
+    for entry in sorted(registry.candidates, key=lambda item: (item.last_seen_at, item.slug), reverse=True):
+        searchable = " ".join(
+            [
+                entry.slug,
+                entry.title,
+                entry.definition,
+                entry.area,
+                *entry.aliases,
+            ]
+        ).lower()
+        if normalized_query and normalized_query not in searchable:
+            continue
+
+        suggested_action, similar_existing = suggestions.get(entry.slug, ("keep_as_candidate", []))
+        candidate_path = candidate_file_path(resolved_vault, entry.slug)
+        candidate_rel = ""
+        candidate_note_path = ""
+        if candidate_path.exists():
+            candidate_rel = str(candidate_path.relative_to(resolved_vault))
+            candidate_note_path = f"/note?path={quote(candidate_rel, safe='')}"
+
+        items.append(
+            {
+                "slug": entry.slug,
+                "title": entry.title,
+                "aliases": list(entry.aliases),
+                "definition": entry.definition,
+                "area": entry.area,
+                "status": entry.status,
+                "review_state": entry.review_state,
+                "source_count": entry.source_count,
+                "evidence_count": entry.evidence_count,
+                "last_seen_at": entry.last_seen_at,
+                "candidate_path": candidate_rel,
+                "candidate_note_path": candidate_note_path,
+                "suggested_action": suggested_action,
+                "similar_existing": [
+                    {
+                        "slug": similar.slug,
+                        "title": similar.title,
+                        "score": score,
+                        "path": f"/object?id={quote(similar.slug, safe='')}",
+                    }
+                    for similar, score in similar_existing
+                ],
+            }
+        )
+
+    paginated = items[offset: offset + limit]
+    return {
+        "screen": "candidates/browser",
+        "query": query or "",
+        "limit": limit,
+        "offset": offset,
+        "count": len(items),
+        "status_counts": {"candidate": len(items)},
+        "items": paginated,
+    }
+
+
+def review_candidate_concept(
+    vault_dir: Path | str,
+    *,
+    slug: str,
+    action: str,
+    target_slug: str | None = None,
+    note: str = "",
+    pack_name: str | None = None,
+) -> dict[str, Any]:
+    """Apply a candidate review action through the existing lifecycle helpers."""
+    resolved_vault = resolve_vault_dir(vault_dir)
+    normalized_slug = slug.strip()
+    normalized_action = action.strip()
+    normalized_target = (target_slug or "").strip()
+    if not normalized_slug:
+        raise ValueError("missing candidate slug")
+
+    action_aliases = {
+        "promote": "promote",
+        "promote_to_active": "promote",
+        "merge": "merge",
+        "merge_as_alias": "merge",
+        "reject": "reject",
+    }
+    lifecycle_action = action_aliases.get(normalized_action)
+    if lifecycle_action is None:
+        raise ValueError("invalid candidate action")
+
+    if lifecycle_action == "promote":
+        mutation = promote_candidate(resolved_vault, normalized_slug, dry_run=False)
+    elif lifecycle_action == "merge":
+        if not normalized_target:
+            raise ValueError("missing target_slug for merge")
+        mutation = merge_candidate(resolved_vault, normalized_slug, normalized_target, dry_run=False)
+    else:
+        mutation = reject_candidate(resolved_vault, normalized_slug, dry_run=False)
+
+    knowledge_index_rebuilt = False
+    knowledge_index_result: dict[str, Any] = {}
+    if lifecycle_action in {"promote", "merge"}:
+        knowledge_index_result = rebuild_knowledge_index(resolved_vault, pack_name=pack_name)
+        knowledge_index_rebuilt = True
+
+    status_by_action = {
+        "promote": "promoted",
+        "merge": "merged",
+        "reject": "rejected",
+    }
+    mutation_payload = mutation.to_dict()
+    event = record_review_action(
+        resolved_vault,
+        event_type="ui_candidate_reviewed",
+        slug=normalized_slug,
+        payload={
+            "candidate_slug": normalized_slug,
+            "target_slug": mutation.target_slug or normalized_target,
+            "action": lifecycle_action,
+            "status": status_by_action[lifecycle_action],
+            "note": note,
+            "pack": _truth_pack_name(pack_name),
+            "mutation": mutation_payload,
+            "knowledge_index_rebuilt": knowledge_index_rebuilt,
+            "knowledge_index_result": knowledge_index_result,
+        },
+    )
+    return {
+        "action": lifecycle_action,
+        "slug": normalized_slug,
+        "target_slug": mutation.target_slug or normalized_target,
+        "status": status_by_action[lifecycle_action],
+        "note": note,
+        "mutation": mutation_payload,
+        "knowledge_index_rebuilt": knowledge_index_rebuilt,
+        "knowledge_index_result": knowledge_index_result,
+        "audit_event": event,
+    }
 
 
 def _is_moc_row(note_type: str, path: str) -> bool:

--- a/src/ovp_pipeline/truth_api.py
+++ b/src/ovp_pipeline/truth_api.py
@@ -30,7 +30,6 @@ from .promote_candidates import (
     merge_candidate,
     promote_candidate,
     reject_candidate,
-    review_candidates,
 )
 from .runtime import (
     VaultLayout,
@@ -515,6 +514,24 @@ def record_review_action(
     return event
 
 
+def _candidate_review_suggestion(registry: ConceptRegistry, entry: Any) -> tuple[str, list[tuple[Any, float]]]:
+    similar = registry.search(entry.title, topk=5)
+    similar = [
+        (candidate, score)
+        for candidate, score in similar
+        if candidate.slug != entry.slug and candidate.status == "active"
+    ]
+    action = "keep_as_candidate"
+    if entry.source_count >= 2 or entry.evidence_count >= 3:
+        if similar and similar[0][1] >= 0.7:
+            action = "merge_as_alias"
+        else:
+            action = "promote_to_active"
+    elif similar and similar[0][1] >= 0.8:
+        action = "merge_as_alias"
+    return action, similar
+
+
 def list_candidate_concepts(
     vault_dir: Path | str,
     *,
@@ -527,13 +544,8 @@ def list_candidate_concepts(
     resolved_vault = resolve_vault_dir(vault_dir)
     registry = ConceptRegistry(resolved_vault).load()
     normalized_query = (query or "").strip().lower()
-    suggestions = {
-        entry.slug: (suggested_action, similar_existing)
-        for entry, suggested_action, similar_existing in review_candidates(registry)
-    }
-    items: list[dict[str, Any]] = []
-
-    for entry in sorted(registry.candidates, key=lambda item: (item.last_seen_at, item.slug), reverse=True):
+    filtered_candidates = []
+    for entry in registry.candidates:
         searchable = " ".join(
             [
                 entry.slug,
@@ -545,8 +557,14 @@ def list_candidate_concepts(
         ).lower()
         if normalized_query and normalized_query not in searchable:
             continue
+        filtered_candidates.append(entry)
 
-        suggested_action, similar_existing = suggestions.get(entry.slug, ("keep_as_candidate", []))
+    sorted_candidates = sorted(filtered_candidates, key=lambda item: (item.last_seen_at, item.slug), reverse=True)
+    page_candidates = sorted_candidates[offset: offset + limit]
+    items: list[dict[str, Any]] = []
+
+    for entry in page_candidates:
+        suggested_action, similar_existing = _candidate_review_suggestion(registry, entry)
         candidate_path = candidate_file_path(resolved_vault, entry.slug)
         candidate_rel = ""
         candidate_note_path = ""
@@ -587,9 +605,9 @@ def list_candidate_concepts(
         "query": query or "",
         "limit": limit,
         "offset": offset,
-        "count": len(items),
-        "status_counts": {"candidate": len(items)},
-        "items": paginated,
+        "count": len(filtered_candidates),
+        "status_counts": {"candidate": len(filtered_candidates)},
+        "items": items,
     }
 
 
@@ -632,9 +650,15 @@ def review_candidate_concept(
 
     knowledge_index_rebuilt = False
     knowledge_index_result: dict[str, Any] = {}
+    knowledge_index_error = ""
+    rebuild_exception: Exception | None = None
     if lifecycle_action in {"promote", "merge"}:
-        knowledge_index_result = rebuild_knowledge_index(resolved_vault, pack_name=pack_name)
-        knowledge_index_rebuilt = True
+        try:
+            knowledge_index_result = rebuild_knowledge_index(resolved_vault, pack_name=pack_name)
+            knowledge_index_rebuilt = True
+        except Exception as exc:
+            knowledge_index_error = str(exc)
+            rebuild_exception = exc
 
     status_by_action = {
         "promote": "promoted",
@@ -656,8 +680,13 @@ def review_candidate_concept(
             "mutation": mutation_payload,
             "knowledge_index_rebuilt": knowledge_index_rebuilt,
             "knowledge_index_result": knowledge_index_result,
+            "knowledge_index_error": knowledge_index_error,
         },
     )
+    if rebuild_exception is not None:
+        raise RuntimeError(
+            f"candidate review applied but knowledge index rebuild failed: {knowledge_index_error}"
+        ) from rebuild_exception
     return {
         "action": lifecycle_action,
         "slug": normalized_slug,
@@ -667,6 +696,7 @@ def review_candidate_concept(
         "mutation": mutation_payload,
         "knowledge_index_rebuilt": knowledge_index_rebuilt,
         "knowledge_index_result": knowledge_index_result,
+        "knowledge_index_error": knowledge_index_error,
         "audit_event": event,
     }
 
@@ -1851,6 +1881,11 @@ def _review_action_items(
                 "later_ref": str(payload.get("later_ref") or ""),
                 "link_type": str(payload.get("link_type") or ""),
                 "candidate_link_type": str(payload.get("candidate_link_type") or ""),
+                "candidate_slug": str(payload.get("candidate_slug") or ""),
+                "target_slug": str(payload.get("target_slug") or ""),
+                "action": str(payload.get("action") or ""),
+                "knowledge_index_rebuilt": bool(payload.get("knowledge_index_rebuilt")),
+                "knowledge_index_error": str(payload.get("knowledge_index_error") or ""),
                 "contradiction_ids": [
                     str(value)
                     for value in payload.get("contradiction_ids", [])

--- a/src/ovp_pipeline/ui/view_models.py
+++ b/src/ovp_pipeline/ui/view_models.py
@@ -31,6 +31,7 @@ from ..truth_api import (
     get_review_context,
     get_runtime_status,
     get_topic_neighborhood,
+    list_candidate_concepts,
     list_evolution_candidates,
     list_evolution_links,
     list_review_actions,
@@ -1105,6 +1106,43 @@ def build_action_queue_payload(
             )
         ),
     }
+
+
+def build_candidate_browser_payload(
+    vault_dir: Path | str,
+    *,
+    pack_name: str | None = None,
+    query: str | None = None,
+    limit: int = 100,
+    offset: int = 0,
+) -> dict[str, Any]:
+    requested_pack = pack_name or ""
+    payload = list_candidate_concepts(vault_dir, query=query, limit=limit, offset=offset)
+    payload["requested_pack"] = requested_pack
+    payload["operator_rail"] = [
+        _operator_action(
+            "Orientation Brief",
+            _scoped_path("/briefing", pack_name=requested_pack),
+            "Read the compiled context before changing canonical concepts.",
+        ),
+        _operator_action(
+            "Signals",
+            _scoped_path("/signals", pack_name=requested_pack),
+            "Check whether this candidate is attached to active production signals.",
+        ),
+        _operator_action(
+            "Actions",
+            _scoped_path("/actions", pack_name=requested_pack),
+            "Inspect queued work that may depend on candidate canonicalization.",
+        ),
+        _operator_action(
+            "Objects",
+            _scoped_path("/objects", pack_name=requested_pack),
+            "Compare candidates against active Evergreen objects.",
+        ),
+    ]
+    payload["query"] = query or ""
+    return payload
 
 
 def build_briefing_payload(vault_dir: Path | str, *, pack_name: str | None = None) -> dict[str, Any]:

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -4193,6 +4193,7 @@ def _seed_candidate_registry(temp_vault):
             area="testing",
         )
     )
+    # Intentional duplicate upsert: this fixture needs source_count == 2.
     registry.upsert_candidate(
         slug="alpha-candidate",
         title="Alpha Candidate",
@@ -4236,6 +4237,22 @@ def test_truth_api_lists_candidate_concepts(temp_vault):
     assert empty_page["items"] == []
 
 
+def test_truth_api_candidate_listing_filters_before_expensive_suggestions(temp_vault, monkeypatch):
+    from ovp_pipeline import truth_api
+
+    _seed_candidate_registry(temp_vault)
+
+    def fail_candidate_review_suggestion(registry, entry):
+        raise AssertionError("candidate suggestions should not run for an empty filtered page")
+
+    monkeypatch.setattr(truth_api, "_candidate_review_suggestion", fail_candidate_review_suggestion)
+
+    payload = truth_api.list_candidate_concepts(temp_vault, query="no-match")
+
+    assert payload["count"] == 0
+    assert payload["items"] == []
+
+
 def test_truth_api_review_candidate_concept_promotes_and_records_audit(temp_vault):
     from ovp_pipeline.concept_registry import ConceptRegistry, STATUS_ACTIVE
     from ovp_pipeline.truth_api import list_review_actions, review_candidate_concept
@@ -4266,9 +4283,41 @@ def test_truth_api_review_candidate_concept_promotes_and_records_audit(temp_vaul
     assert audit["note"] == "Promote from workbench"
 
 
+def test_truth_api_review_candidate_concept_records_audit_when_rebuild_fails(temp_vault, monkeypatch):
+    from ovp_pipeline import truth_api
+    from ovp_pipeline.concept_registry import ConceptRegistry, STATUS_ACTIVE
+    from ovp_pipeline.truth_api import list_review_actions
+
+    _seed_candidate_registry(temp_vault)
+
+    def fail_rebuild(vault_dir, *, pack_name=None):
+        raise RuntimeError("rebuild failed")
+
+    monkeypatch.setattr(truth_api, "rebuild_knowledge_index", fail_rebuild)
+
+    with pytest.raises(RuntimeError, match="candidate review applied but knowledge index rebuild failed"):
+        truth_api.review_candidate_concept(
+            temp_vault,
+            slug="alpha-candidate",
+            action="promote",
+            note="Promote with rebuild failure",
+        )
+
+    promoted = ConceptRegistry(temp_vault).load().find_by_slug("alpha-candidate")
+    audit = list_review_actions(temp_vault, limit=1)[0]
+    assert promoted is not None
+    assert promoted.status == STATUS_ACTIVE
+    assert audit["event_type"] == "ui_candidate_reviewed"
+    assert audit["slug"] == "alpha-candidate"
+    assert audit["status"] == "promoted"
+    assert audit["note"] == "Promote with rebuild failure"
+    assert audit["knowledge_index_rebuilt"] is False
+    assert audit["knowledge_index_error"] == "rebuild failed"
+
+
 def test_truth_api_review_candidate_concept_merges_into_existing_and_rebuilds(temp_vault):
     from ovp_pipeline.concept_registry import ConceptRegistry
-    from ovp_pipeline.truth_api import review_candidate_concept
+    from ovp_pipeline.truth_api import list_review_actions, review_candidate_concept
 
     _seed_candidate_registry(temp_vault)
     article_path = temp_vault / "20-Areas" / "AI-Research" / "Topics" / "Candidate Link.md"
@@ -4291,12 +4340,19 @@ def test_truth_api_review_candidate_concept_merges_into_existing_and_rebuilds(te
     assert registry.find_by_slug("alpha-candidate") is None
     assert target is not None
     assert "alpha-candidate" in target.redirects
-    assert "[[alpha-existing|Alpha Candidate]]" in article_path.read_text(encoding="utf-8")
+    article_text = article_path.read_text(encoding="utf-8")
+    assert "[[alpha-existing|Alpha Candidate]]" in article_text
+    assert "[[alpha-existing|alpha draft]]" in article_text
+    audit = list_review_actions(temp_vault, limit=1)[0]
+    assert audit["event_type"] == "ui_candidate_reviewed"
+    assert audit["slug"] == "alpha-candidate"
+    assert audit["status"] == "merged"
+    assert audit["note"] == "Merge duplicate surface"
 
 
 def test_truth_api_review_candidate_concept_rejects_without_rebuilding_index(temp_vault):
     from ovp_pipeline.concept_registry import ConceptRegistry, STATUS_REJECTED
-    from ovp_pipeline.truth_api import review_candidate_concept
+    from ovp_pipeline.truth_api import list_review_actions, review_candidate_concept
 
     _seed_candidate_registry(temp_vault)
 
@@ -4314,6 +4370,11 @@ def test_truth_api_review_candidate_concept_rejects_without_rebuilding_index(tem
     assert rejected is not None
     assert rejected.status == STATUS_REJECTED
     assert not (temp_vault / "10-Knowledge" / "Evergreen" / "_Candidates" / "alpha-candidate.md").exists()
+    audit = list_review_actions(temp_vault, limit=1)[0]
+    assert audit["event_type"] == "ui_candidate_reviewed"
+    assert audit["slug"] == "alpha-candidate"
+    assert audit["status"] == "rejected"
+    assert audit["note"] == "Not canonical"
 
 
 def test_candidate_browser_payload_exposes_operator_context(temp_vault):

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -4177,3 +4177,160 @@ def test_truth_api_record_review_action_writes_jsonl_without_db_lock(temp_vault,
     assert review_log.exists()
     lines = [line for line in review_log.read_text(encoding="utf-8").splitlines() if line.strip()]
     assert len(lines) == 1
+
+
+def _seed_candidate_registry(temp_vault):
+    from ovp_pipeline.concept_registry import ConceptEntry, ConceptRegistry
+    from ovp_pipeline.promote_candidates import write_candidate_file
+
+    registry = ConceptRegistry(temp_vault)
+    registry.add_entry(
+        ConceptEntry(
+            slug="alpha-existing",
+            title="Alpha Existing",
+            aliases=["Alpha Candidate"],
+            definition="Existing canonical concept.",
+            area="testing",
+        )
+    )
+    registry.upsert_candidate(
+        slug="alpha-candidate",
+        title="Alpha Candidate",
+        definition="Candidate concept awaiting review.",
+        area="testing",
+        aliases=["alpha draft"],
+    )
+    candidate = registry.upsert_candidate(
+        slug="alpha-candidate",
+        title="Alpha Candidate",
+        definition="Candidate concept awaiting review.",
+        area="testing",
+        aliases=["alpha draft"],
+    )
+    registry.save()
+    write_candidate_file(temp_vault, candidate, dry_run=False)
+    return candidate
+
+
+def test_truth_api_lists_candidate_concepts(temp_vault):
+    from ovp_pipeline.truth_api import list_candidate_concepts
+
+    _seed_candidate_registry(temp_vault)
+
+    payload = list_candidate_concepts(temp_vault)
+
+    assert payload["screen"] == "candidates/browser"
+    assert payload["count"] == 1
+    assert payload["status_counts"] == {"candidate": 1}
+    item = payload["items"][0]
+    assert item["slug"] == "alpha-candidate"
+    assert item["title"] == "Alpha Candidate"
+    assert item["source_count"] == 2
+    assert item["candidate_path"] == "10-Knowledge/Evergreen/_Candidates/alpha-candidate.md"
+    assert item["candidate_note_path"] == "/note?path=10-Knowledge%2FEvergreen%2F_Candidates%2Falpha-candidate.md"
+    assert item["suggested_action"] == "merge_as_alias"
+    assert item["similar_existing"][0]["slug"] == "alpha-existing"
+
+    empty_page = list_candidate_concepts(temp_vault, limit=0)
+    assert empty_page["count"] == 1
+    assert empty_page["items"] == []
+
+
+def test_truth_api_review_candidate_concept_promotes_and_records_audit(temp_vault):
+    from ovp_pipeline.concept_registry import ConceptRegistry, STATUS_ACTIVE
+    from ovp_pipeline.truth_api import list_review_actions, review_candidate_concept
+
+    _seed_candidate_registry(temp_vault)
+
+    payload = review_candidate_concept(
+        temp_vault,
+        slug="alpha-candidate",
+        action="promote",
+        note="Promote from workbench",
+    )
+
+    registry = ConceptRegistry(temp_vault).load()
+    promoted = registry.find_by_slug("alpha-candidate")
+    assert payload["action"] == "promote"
+    assert payload["mutation"]["action"] == "promote"
+    assert payload["knowledge_index_rebuilt"] is True
+    assert promoted is not None
+    assert promoted.status == STATUS_ACTIVE
+    assert (temp_vault / "10-Knowledge" / "Evergreen" / "alpha-candidate.md").exists()
+    assert not (temp_vault / "10-Knowledge" / "Evergreen" / "_Candidates" / "alpha-candidate.md").exists()
+
+    audit = list_review_actions(temp_vault, limit=1)[0]
+    assert audit["event_type"] == "ui_candidate_reviewed"
+    assert audit["slug"] == "alpha-candidate"
+    assert audit["status"] == "promoted"
+    assert audit["note"] == "Promote from workbench"
+
+
+def test_truth_api_review_candidate_concept_merges_into_existing_and_rebuilds(temp_vault):
+    from ovp_pipeline.concept_registry import ConceptRegistry
+    from ovp_pipeline.truth_api import review_candidate_concept
+
+    _seed_candidate_registry(temp_vault)
+    article_path = temp_vault / "20-Areas" / "AI-Research" / "Topics" / "Candidate Link.md"
+    article_path.parent.mkdir(parents=True, exist_ok=True)
+    article_path.write_text("Links [[Alpha Candidate]] and [[alpha draft]].\n", encoding="utf-8")
+
+    payload = review_candidate_concept(
+        temp_vault,
+        slug="alpha-candidate",
+        action="merge",
+        target_slug="alpha-existing",
+        note="Merge duplicate surface",
+    )
+
+    registry = ConceptRegistry(temp_vault).load()
+    target = registry.find_by_slug("alpha-existing")
+    assert payload["action"] == "merge"
+    assert payload["status"] == "merged"
+    assert payload["knowledge_index_rebuilt"] is True
+    assert registry.find_by_slug("alpha-candidate") is None
+    assert target is not None
+    assert "alpha-candidate" in target.redirects
+    assert "[[alpha-existing|Alpha Candidate]]" in article_path.read_text(encoding="utf-8")
+
+
+def test_truth_api_review_candidate_concept_rejects_without_rebuilding_index(temp_vault):
+    from ovp_pipeline.concept_registry import ConceptRegistry, STATUS_REJECTED
+    from ovp_pipeline.truth_api import review_candidate_concept
+
+    _seed_candidate_registry(temp_vault)
+
+    payload = review_candidate_concept(
+        temp_vault,
+        slug="alpha-candidate",
+        action="reject",
+        note="Not canonical",
+    )
+
+    rejected = ConceptRegistry(temp_vault).load().find_by_slug("alpha-candidate")
+    assert payload["action"] == "reject"
+    assert payload["status"] == "rejected"
+    assert payload["knowledge_index_rebuilt"] is False
+    assert rejected is not None
+    assert rejected.status == STATUS_REJECTED
+    assert not (temp_vault / "10-Knowledge" / "Evergreen" / "_Candidates" / "alpha-candidate.md").exists()
+
+
+def test_candidate_browser_payload_exposes_operator_context(temp_vault):
+    from ovp_pipeline.ui.view_models import build_candidate_browser_payload
+
+    _seed_candidate_registry(temp_vault)
+
+    payload = build_candidate_browser_payload(temp_vault, pack_name="research-tech", query="alpha")
+
+    assert payload["screen"] == "candidates/browser"
+    assert payload["requested_pack"] == "research-tech"
+    assert payload["query"] == "alpha"
+    assert payload["count"] == 1
+    assert payload["items"][0]["slug"] == "alpha-candidate"
+    assert [item["label"] for item in payload["operator_rail"]] == [
+        "Orientation Brief",
+        "Signals",
+        "Actions",
+        "Objects",
+    ]

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -3283,3 +3283,118 @@ def test_ui_server_module_compiles_on_python311():
     )
 
     assert result.returncode == 0, result.stderr
+
+
+def _seed_candidate_for_ui(temp_vault):
+    from ovp_pipeline.concept_registry import ConceptEntry, ConceptRegistry
+    from ovp_pipeline.promote_candidates import write_candidate_file
+
+    registry = ConceptRegistry(temp_vault)
+    registry.add_entry(
+        ConceptEntry(
+            slug="alpha-existing",
+            title="Alpha Existing",
+            aliases=["Alpha Candidate"],
+            definition="Existing canonical concept.",
+            area="testing",
+        )
+    )
+    candidate = registry.upsert_candidate(
+        slug="alpha-candidate",
+        title="Alpha Candidate",
+        definition="Candidate concept awaiting review.",
+        area="testing",
+        aliases=["alpha draft"],
+    )
+    registry.save()
+    write_candidate_file(temp_vault, candidate, dry_run=False)
+    return candidate
+
+
+def test_ui_server_candidates_endpoint_returns_payload(temp_vault):
+    from ovp_pipeline.commands.ui_server import create_server
+
+    _seed_candidate_for_ui(temp_vault)
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("GET", "/api/candidates")
+        response = conn.getresponse()
+        payload = json.loads(response.read().decode("utf-8"))
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 200
+    assert payload["screen"] == "candidates/browser"
+    assert payload["count"] == 1
+    assert payload["items"][0]["slug"] == "alpha-candidate"
+
+
+def test_ui_server_candidates_page_renders_review_controls(temp_vault):
+    from ovp_pipeline.commands.ui_server import create_server
+
+    _seed_candidate_for_ui(temp_vault)
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("GET", "/candidates")
+        response = conn.getresponse()
+        body = response.read().decode("utf-8")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 200
+    assert "Candidate Workbench" in body
+    assert "Alpha Candidate" in body
+    assert "Promote" in body
+    assert "Merge" in body
+    assert "Reject" in body
+
+
+def test_ui_server_can_promote_candidate_via_api(temp_vault):
+    from ovp_pipeline.commands.ui_server import create_server
+    from ovp_pipeline.concept_registry import ConceptRegistry, STATUS_ACTIVE
+
+    _seed_candidate_for_ui(temp_vault)
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        body = urlencode(
+            {
+                "slug": "alpha-candidate",
+                "action": "promote",
+                "note": "Promote from UI",
+            }
+        )
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request(
+            "POST",
+            "/api/candidates/review",
+            body=body,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        response = conn.getresponse()
+        payload = json.loads(response.read().decode("utf-8"))
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    promoted = ConceptRegistry(temp_vault).load().find_by_slug("alpha-candidate")
+    assert response.status == 200
+    assert payload["action"] == "promote"
+    assert payload["mutation"]["action"] == "promote"
+    assert payload["knowledge_index_rebuilt"] is True
+    assert promoted.status == STATUS_ACTIVE

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -3361,9 +3361,40 @@ def test_ui_server_candidates_page_renders_review_controls(temp_vault):
     assert "Reject" in body
 
 
+def test_ui_server_candidate_item_keeps_zero_score_and_requires_low_score_merge_target():
+    from ovp_pipeline.commands.ui_server import _render_candidate_items
+
+    html = _render_candidate_items(
+        {
+            "requested_pack": "research-tech",
+            "items": [
+                {
+                    "slug": "alpha-candidate",
+                    "title": "Alpha Candidate",
+                    "definition": "Candidate concept awaiting review.",
+                    "source_count": 1,
+                    "evidence_count": 1,
+                    "similar_existing": [
+                        {
+                            "slug": "alpha-existing",
+                            "title": "Alpha Existing",
+                            "score": 0.0,
+                            "path": "/object?id=alpha-existing",
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+
+    assert "<span class='pill'>0.0</span>" in html
+    assert "name='target_slug' value=''" in html
+
+
 def test_ui_server_can_promote_candidate_via_api(temp_vault):
     from ovp_pipeline.commands.ui_server import create_server
     from ovp_pipeline.concept_registry import ConceptRegistry, STATUS_ACTIVE
+    from ovp_pipeline.truth_api import list_review_actions
 
     _seed_candidate_for_ui(temp_vault)
     server = create_server(temp_vault, host="127.0.0.1", port=0)
@@ -3398,3 +3429,8 @@ def test_ui_server_can_promote_candidate_via_api(temp_vault):
     assert payload["mutation"]["action"] == "promote"
     assert payload["knowledge_index_rebuilt"] is True
     assert promoted.status == STATUS_ACTIVE
+    audit = list_review_actions(temp_vault, limit=1)[0]
+    assert audit["event_type"] == "ui_candidate_reviewed"
+    assert audit["slug"] == "alpha-candidate"
+    assert audit["status"] == "promoted"
+    assert audit["note"] == "Promote from UI"

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -5,7 +5,7 @@ import sqlite3
 import subprocess
 import threading
 from datetime import datetime, timedelta, timezone
-from http.client import HTTPConnection
+from http.client import HTTPConnection, RemoteDisconnected
 from pathlib import Path
 from urllib.parse import urlencode
 
@@ -3391,6 +3391,24 @@ def test_ui_server_candidate_item_keeps_zero_score_and_requires_low_score_merge_
     assert "name='target_slug' value=''" in html
 
 
+def test_ui_server_candidates_page_renders_review_warning():
+    from ovp_pipeline.commands.ui_server import _render_candidates_page
+
+    html = _render_candidates_page(
+        {
+            "query": "",
+            "requested_pack": "",
+            "count": 0,
+            "status_counts": {},
+            "items": [],
+            "candidate_warning": "rebuild failed",
+        }
+    )
+
+    assert "Review Warning" in html
+    assert "rebuild failed" in html
+
+
 def test_ui_server_can_promote_candidate_via_api(temp_vault):
     from ovp_pipeline.commands.ui_server import create_server
     from ovp_pipeline.concept_registry import ConceptRegistry, STATUS_ACTIVE
@@ -3434,3 +3452,54 @@ def test_ui_server_can_promote_candidate_via_api(temp_vault):
     assert audit["slug"] == "alpha-candidate"
     assert audit["status"] == "promoted"
     assert audit["note"] == "Promote from UI"
+
+
+def test_ui_server_candidate_review_reports_rebuild_failure_without_disconnect(temp_vault, monkeypatch):
+    from ovp_pipeline.commands.ui_server import create_server
+    from ovp_pipeline.concept_registry import ConceptRegistry, STATUS_ACTIVE
+
+    _seed_candidate_for_ui(temp_vault)
+
+    def fail_rebuild(vault_dir, *, pack_name=None):
+        raise ValueError("rebuild failed")
+
+    monkeypatch.setattr("ovp_pipeline.truth_api.rebuild_knowledge_index", fail_rebuild)
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        body = urlencode(
+            {
+                "slug": "alpha-candidate",
+                "action": "promote",
+                "note": "Promote from UI",
+            }
+        )
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request(
+            "POST",
+            "/api/candidates/review",
+            body=body,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        try:
+            response = conn.getresponse()
+        except RemoteDisconnected as exc:
+            raise AssertionError("candidate review request disconnected") from exc
+        payload = json.loads(response.read().decode("utf-8"))
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    promoted = ConceptRegistry(temp_vault).load().find_by_slug("alpha-candidate")
+    assert response.status == 200
+    assert payload["partial_success"] is True
+    assert payload["action"] == "promote"
+    assert payload["mutation"]["action"] == "promote"
+    assert payload["knowledge_index_rebuilt"] is False
+    assert payload["knowledge_index_error"] == "rebuild failed"
+    assert "candidate review applied" in payload["warning"]
+    assert "candidate_warning=rebuild%20failed" in payload["next_path"]
+    assert promoted.status == STATUS_ACTIVE


### PR DESCRIPTION
## Summary
- Add a candidate concept browser payload and `/candidates` UI/API surface over `ConceptRegistry` candidates.
- Add promote / merge / reject review actions that reuse the existing candidate lifecycle helpers, write `ui_candidate_reviewed` audit events, and rebuild the knowledge index after promote/merge.
- Update roadmap/progress docs to mark Phase 26 as the candidate/canonical closeout slice and clarify candidate wikilinks vs typed semantic evolution links.

## Test Plan
- `pytest tests/test_truth_api.py::test_truth_api_lists_candidate_concepts tests/test_truth_api.py::test_truth_api_review_candidate_concept_promotes_and_records_audit tests/test_truth_api.py::test_truth_api_review_candidate_concept_merges_into_existing_and_rebuilds tests/test_truth_api.py::test_truth_api_review_candidate_concept_rejects_without_rebuilding_index tests/test_truth_api.py::test_candidate_browser_payload_exposes_operator_context tests/test_ui_server.py::test_ui_server_candidates_endpoint_returns_payload tests/test_ui_server.py::test_ui_server_candidates_page_renders_review_controls tests/test_ui_server.py::test_ui_server_can_promote_candidate_via_api -q`
- `pytest tests/test_promote_candidates.py tests/test_truth_api.py tests/test_ui_server.py -q`
- `git diff --check`
- `pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Candidate Canonicalization Workbench, enabling operators to review, promote, merge, and reject candidate concepts through a new candidate browser interface.
  * Added `/candidates` and `/api/candidates` endpoints with search/filter capabilities and review actions.
  * Candidate actions automatically rebuild knowledge state so rewritten links and active objects become immediately visible.
  * Review actions recorded as auditable events.

* **Documentation**
  * Updated Phase 26 implementation plan and roadmap to reflect completed candidate review surface and observable runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->