### PR TITLE
Add background value and backlink enforcement

### DIFF
--- a/docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
+++ b/docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
@@ -607,6 +607,10 @@ What the next phase should close:
 - if we enforce backlinks at write time, the enforcement should reuse the `backlink_expectation` contract instead of introducing a second source of truth
 - if we add richer semantic relation extraction, it should be a pack-level extraction contract, not a hidden global memory backend
 - background intelligence orchestration should reuse the action queue and run ledger instead of creating another execution path
+- after Phase 27, the immediate next closeout is Phase 28/29:
+  - prove background-intelligence value directly in the briefing surface
+  - enforce backlink expectations before focused object writes
+  - keep semantic relation extraction deferred until this trust boundary is closed
 
 Sequence rule:
 
@@ -680,7 +684,15 @@ The remaining gap is no longer “can this architecture support it?” It is now
 
 - keep candidate review explicit and auditable,
 - route background actions through the existing queue / run-ledger contracts,
+- prove that background intelligence is useful with explicit evidence and policy reasons,
+- enforce backlink expectations before object extraction creates downstream knowledge,
 - add richer pack-level semantic extraction only after the orchestration path is observable.
+
+Phase 28/29 status:
+
+- background-intelligence value proof is now implemented in the briefing payload and UI,
+- background policy is now visible from effective governance signal rules,
+- focused object extraction now blocks when the target deep dive lacks source backlink provenance.
 
 ## PR Review Gate
 

--- a/docs/plans/2026-04-21-phase28-29-background-value-and-backlink-enforcement.md
+++ b/docs/plans/2026-04-21-phase28-29-background-value-and-backlink-enforcement.md
@@ -1,0 +1,127 @@
+# Phase 28/29: Background Value And Backlink Enforcement Implementation Plan
+
+Status: **Implemented**
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Close the next two roadmap gaps by proving background intelligence value in the briefing surface and enforcing backlink provenance before focused object writes.
+
+**Architecture:** Keep `signals`, `briefing`, and `actions` on the existing signal ledger, action queue, and run ledger. Do not add a second scheduler, hidden memory backend, or semantic relation extractor. Phase 28 adds value/provenance/policy fields to the current briefing payload. Phase 29 reuses the existing `backlink_expectation` contract as a focused-action precondition for object extraction.
+
+**Tech Stack:** Python, SQLite-backed `knowledge.db`, JSONL ledgers in `60-Logs`, pack governance contracts, pytest.
+
+## Implementation Notes
+
+- Briefing snapshots now expose `first_useful_sign_check` with value status, evidence count, and actionability.
+- Briefing insights and priority items now expose `value_kind`, `value_reason`, `evidence_count`, and `actionability`.
+- Briefing snapshots now expose `background_policy` derived from effective governance signal rules and current action queue state.
+- `/briefing` now renders `Value Proof` and `Background Policy` sections.
+- `object_extraction_workflow` now blocks before handler dispatch when the target deep dive has an unsatisfied `backlink_expectation`.
+
+## Task 1: Roadmap State Closeout
+
+**Files:**
+
+- Modify: `task_plan.md`
+- Modify: `progress.md`
+- Modify: `docs/plans/2026-04-14-local-knowledge-workbench-milestone.md`
+
+**Steps:**
+
+1. Mark Phase 27 as merged in PR #43.
+2. Update verification counts to the post-review result: `689 passed`.
+3. Set Phase 28/29 as the current active plan.
+4. Preserve the existing non-goals: no hosted scheduler, no harness/session memory, no hidden semantic relation extractor.
+
+**Verification:**
+
+- Scan `task_plan.md`, `progress.md`, and the roadmap for stale active Phase 27 closeout wording.
+- Expected: no stale active Phase 27 wording remains.
+
+## Task 2: Phase 28 Background Intelligence Value Contract
+
+**Files:**
+
+- Modify: `src/ovp_pipeline/packs/research_tech/surfaces.py`
+- Modify: `src/ovp_pipeline/ui/view_models.py`
+- Modify: `src/ovp_pipeline/commands/ui_server.py`
+- Test: `tests/test_truth_api.py`
+- Test: `tests/test_ui_server.py`
+
+**Behavior:**
+
+- Every briefing insight and priority item should expose why it is useful:
+  - `value_kind`
+  - `value_reason`
+  - `evidence_count`
+  - `actionability`
+- The briefing snapshot should expose `first_useful_sign_check`:
+  - `status`
+  - `kind`
+  - `reason`
+  - `evidence_count`
+  - `actionability`
+- The briefing snapshot should expose `background_policy`:
+  - governed signal types
+  - auto-queue enabled types
+  - review-only types
+  - active auto-queued signal counts
+  - skipped signal counts and reasons
+
+**TDD Steps:**
+
+1. Add a failing test that `get_briefing_snapshot(...)` returns `first_useful_sign_check` with evidence and actionability.
+2. Add a failing test that `get_briefing_snapshot(...)` returns a `background_policy` summary derived from governance rules and active signals.
+3. Add a failing UI test that `/briefing` renders value proof and background policy.
+4. Implement the smallest payload helpers in `research_tech.surfaces`.
+5. Pass the targeted tests.
+
+## Task 3: Phase 29 Backlink Enforcement At Write Time
+
+**Files:**
+
+- Modify: `src/ovp_pipeline/truth_api.py`
+- Test: `tests/test_truth_api.py`
+
+**Behavior:**
+
+- `object_extraction_workflow` must not run when its target deep dive has an unsatisfied `backlink_expectation`.
+- The precondition should block before handler dispatch.
+- The blocked action should persist:
+  - `status=blocked`
+  - `precondition_status=blocked`
+  - `blocked_reason=backlink_expectation_failed:<status>:<note_path>`
+- `deep_dive_workflow` should not be blocked by this gate, because a source note naturally starts with missing downstream links.
+
+**TDD Steps:**
+
+1. Add a failing test that queues `object_extraction_workflow` for a deep dive with no source backlink.
+2. Verify the handler is not called and the action is blocked with a backlink reason.
+3. Add a passing-control test or extend an existing object extraction test to prove a deep dive with source provenance can still run.
+4. Implement a small focused-action backlink precondition helper that calls `get_note_traceability(...)`.
+5. Pass the targeted tests.
+
+## Task 4: Verification
+
+Run:
+
+```bash
+ruff check src/ovp_pipeline/truth_api.py src/ovp_pipeline/packs/research_tech/surfaces.py src/ovp_pipeline/ui/view_models.py src/ovp_pipeline/commands/ui_server.py tests/test_truth_api.py tests/test_ui_server.py
+pytest tests/test_truth_api.py tests/test_ui_view_models.py tests/test_ui_server.py -q
+pytest -q
+git diff --check
+```
+
+Expected:
+
+- Ruff passes.
+- Targeted tests pass.
+- Full suite passes.
+- No whitespace errors.
+
+Verified locally:
+
+- `ruff check src/ovp_pipeline/truth_api.py src/ovp_pipeline/packs/research_tech/surfaces.py src/ovp_pipeline/ui/view_models.py src/ovp_pipeline/commands/ui_server.py tests/test_truth_api.py tests/test_ui_server.py` -> `All checks passed!`
+- `pytest tests/test_truth_api.py tests/test_ui_view_models.py tests/test_ui_server.py -q` -> `255 passed`
+- `pytest -q` -> `690 passed`
+- `git diff --check` -> clean

--- a/progress.md
+++ b/progress.md
@@ -51,7 +51,7 @@
   - Next planning target was `Phase 27: Background Intelligence Orchestration Closeout`
 
 ### Phase 27: Background Intelligence Orchestration Closeout
-- **Status:** implemented and verified locally
+- **Status:** complete; merged to `main` in PR #43 (`75febbd`)
 - Actions taken:
   - Reconciled the roadmap after Phase 26 landed
   - Confirmed that the next gap is not another candidate/canonical surface
@@ -99,7 +99,7 @@
   - `pytest tests/test_truth_api.py::test_truth_api_get_runtime_status_includes_action_worker_state tests/test_truth_api.py::test_truth_api_run_next_action_queue_item_marks_obsolete_when_signal_is_gone tests/test_truth_api.py::test_truth_api_run_next_action_queue_item_blocks_missing_action_target_before_handler tests/test_truth_api.py::test_truth_api_action_queue_items_include_execution_contract_metadata tests/test_truth_api.py::test_truth_api_list_action_queue_backfills_execution_contract_metadata_for_legacy_rows tests/test_truth_api.py::test_truth_api_run_action_queue_can_limit_to_safe_actions tests/test_truth_api.py::test_truth_api_builds_briefing_snapshot tests/test_ui_server.py::test_render_runtime_card_shows_action_worker_state tests/test_ui_server.py::test_ui_server_actions_page_preserves_pack_scope_in_shell_nav -q`
   - `9 passed`
   - `pytest tests/test_run_actions_command.py tests/test_truth_api.py tests/test_ui_view_models.py tests/test_ui_server.py tests/test_watch_progress_command.py -q`
-  - `262 passed`
+  - `263 passed`
   - `ruff check src/ovp_pipeline/commands/run_actions.py src/ovp_pipeline/commands/ui_server.py src/ovp_pipeline/packs/research_tech/surfaces.py src/ovp_pipeline/runtime.py src/ovp_pipeline/runtime_processes.py src/ovp_pipeline/truth_api.py tests/test_truth_api.py tests/test_ui_server.py`
   - `All checks passed`
   - `python -m pip install -e .`
@@ -112,7 +112,33 @@
   - `git diff --check`
   - clean
   - `pytest -q`
-  - `688 passed`
+  - `689 passed`
+
+### Phase 28/29: Background Value And Backlink Enforcement
+- **Status:** implemented and verified locally
+- Goal:
+  - Phase 28: prove background intelligence value in `/briefing` with evidence, actionability, and policy legibility.
+  - Phase 29: reuse `backlink_expectation` as a focused-action precondition before object extraction writes downstream knowledge.
+- Canonical plan:
+  - docs/plans/2026-04-21-phase28-29-background-value-and-backlink-enforcement.md
+- Actions taken:
+  - Added `first_useful_sign_check` to briefing snapshots.
+  - Added `value_kind`, `value_reason`, `evidence_count`, and `actionability` to briefing insights and priority items.
+  - Added `background_policy` over effective governance signal rules, auto-queue policy, review-only policy, active signal counts, queue counts, and skipped reasons.
+  - Rendered `Value Proof` and `Background Policy` on `/briefing`.
+  - Added focused-action backlink precondition enforcement for `object_extraction_workflow`.
+  - Preserved `deep_dive_workflow` behavior; source notes with missing downstream links are still runnable.
+- Verification:
+  - `pytest tests/test_truth_api.py::test_truth_api_builds_briefing_snapshot tests/test_truth_api.py::test_truth_api_run_next_action_queue_item_blocks_object_extraction_without_source_backlink tests/test_ui_server.py::test_ui_server_briefing_endpoint_returns_payload tests/test_ui_server.py::test_ui_server_briefing_page_preserves_pack_scope_in_shell_nav -q`
+  - `4 passed`
+  - `ruff check src/ovp_pipeline/truth_api.py src/ovp_pipeline/packs/research_tech/surfaces.py src/ovp_pipeline/ui/view_models.py src/ovp_pipeline/commands/ui_server.py tests/test_truth_api.py tests/test_ui_server.py`
+  - `All checks passed!`
+  - `pytest tests/test_truth_api.py tests/test_ui_view_models.py tests/test_ui_server.py -q`
+  - `255 passed`
+  - `pytest -q`
+  - `690 passed`
+  - `git diff --check`
+  - clean
 
 ## Session: 2026-04-20
 

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -3153,12 +3153,30 @@ def _render_briefing_page(payload: dict) -> str:
     )
     queue_summary = payload.get("queue_summary", {})
     loop_summary = payload.get("loop_summary", {})
+    first_useful_sign_check = payload.get("first_useful_sign_check") or {}
+    background_policy = payload.get("background_policy") or {}
     failure_buckets = (
         "".join(
             f"<li><span class='pill'>{escape(bucket)}</span> {count}</li>"
             for bucket, count in queue_summary.get("failure_buckets", {}).items()
         )
         or "<li class='muted'>No failed actions.</li>"
+    )
+    policy_decisions = (
+        "".join(
+            "<li>"
+            f"<span class='pill'>{escape(str(signal_type))}</span> "
+            f"{escape(str(decision.get('decision') or ''))}"
+            f"<div class='muted'>Active: {escape(str(decision.get('active_signal_count') or 0))} · "
+            f"Queued: {escape(str(decision.get('queued_action_count') or 0))} · "
+            f"Skipped: {escape(str(decision.get('skipped_count') or 0))}</div>"
+            "</li>"
+            for signal_type, decision in (
+                background_policy.get("signal_type_decisions") or {}
+            ).items()
+            if isinstance(decision, dict)
+        )
+        or "<li class='muted'>No governed signal policy decisions are active.</li>"
     )
     return _layout(
         "Working Memory Snapshot",
@@ -3182,6 +3200,24 @@ def _render_briefing_page(payload: dict) -> str:
                 f"<nav class='subnav'>{section_nav}</nav>" if section_nav else "",
                 _render_compiled_sections(remaining_sections),
                 f"<section class='card'><h2>First Useful Sign</h2><ul class='list-tight'>{first_useful_sign_html}</ul></section>",
+                "<section class='card'><h2>Value Proof</h2>"
+                f"<p class='muted'>{escape(str(first_useful_sign_check.get('reason') or 'No value proof yet.'))}</p>"
+                "<div class='link-row'>"
+                f"<span class='pill'>Status: {escape(str(first_useful_sign_check.get('status') or 'empty'))}</span>"
+                f"<span class='pill'>Evidence: {escape(str(first_useful_sign_check.get('evidence_count') or 0))}</span>"
+                f"<span class='pill'>Actionability: {escape(str(first_useful_sign_check.get('actionability') or 'review'))}</span>"
+                "</div></section>",
+                "<section class='card'><h2>Background Policy</h2>"
+                "<p class='muted'>Auto-queue enabled: "
+                + escape(
+                    ", ".join(background_policy.get("auto_queue_enabled_signal_types") or [])
+                    or "none"
+                )
+                + ". Review-only: "
+                + escape(", ".join(background_policy.get("review_only_signal_types") or []) or "none")
+                + ".</p>"
+                f"<p class='muted'>Skipped: {escape(str(background_policy.get('skipped_signal_count') or 0))}</p>"
+                f"<ul class='list-tight'>{policy_decisions}</ul></section>",
                 f"<section class='card'><h2>Insights</h2><ul class='list-tight'>{insights}</ul></section>",
                 f"<section class='card'><h2>Priority Items</h2><ul class='list-tight'>{priority_items}</ul></section>",
                 "<section class='card'><h2>Execution Surface</h2>",

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -3151,14 +3151,34 @@ def _render_briefing_page(payload: dict) -> str:
         f'<a href="{escape(str(item["href"]))}">{escape(str(item["label"]))}</a>'
         for item in payload.get("section_nav", [])
     )
-    queue_summary = payload.get("queue_summary", {})
-    loop_summary = payload.get("loop_summary", {})
-    first_useful_sign_check = payload.get("first_useful_sign_check") or {}
-    background_policy = payload.get("background_policy") or {}
+    queue_summary = payload.get("queue_summary")
+    if not isinstance(queue_summary, dict):
+        queue_summary = {}
+    loop_summary = payload.get("loop_summary")
+    if not isinstance(loop_summary, dict):
+        loop_summary = {}
+    first_useful_sign_check = payload.get("first_useful_sign_check")
+    if not isinstance(first_useful_sign_check, dict):
+        first_useful_sign_check = {}
+    background_policy = payload.get("background_policy")
+    if not isinstance(background_policy, dict):
+        background_policy = {}
+    failure_bucket_values = queue_summary.get("failure_buckets")
+    if not isinstance(failure_bucket_values, dict):
+        failure_bucket_values = {}
+    signal_type_decisions = background_policy.get("signal_type_decisions")
+    if not isinstance(signal_type_decisions, dict):
+        signal_type_decisions = {}
+    auto_queue_enabled_signal_types = background_policy.get("auto_queue_enabled_signal_types")
+    if not isinstance(auto_queue_enabled_signal_types, list):
+        auto_queue_enabled_signal_types = []
+    review_only_signal_types = background_policy.get("review_only_signal_types")
+    if not isinstance(review_only_signal_types, list):
+        review_only_signal_types = []
     failure_buckets = (
         "".join(
             f"<li><span class='pill'>{escape(bucket)}</span> {count}</li>"
-            for bucket, count in queue_summary.get("failure_buckets", {}).items()
+            for bucket, count in failure_bucket_values.items()
         )
         or "<li class='muted'>No failed actions.</li>"
     )
@@ -3171,9 +3191,7 @@ def _render_briefing_page(payload: dict) -> str:
             f"Queued: {escape(str(decision.get('queued_action_count') or 0))} · "
             f"Skipped: {escape(str(decision.get('skipped_count') or 0))}</div>"
             "</li>"
-            for signal_type, decision in (
-                background_policy.get("signal_type_decisions") or {}
-            ).items()
+            for signal_type, decision in signal_type_decisions.items()
             if isinstance(decision, dict)
         )
         or "<li class='muted'>No governed signal policy decisions are active.</li>"
@@ -3210,11 +3228,20 @@ def _render_briefing_page(payload: dict) -> str:
                 "<section class='card'><h2>Background Policy</h2>"
                 "<p class='muted'>Auto-queue enabled: "
                 + escape(
-                    ", ".join(background_policy.get("auto_queue_enabled_signal_types") or [])
+                    ", ".join(
+                        str(item)
+                        for item in auto_queue_enabled_signal_types
+                        if str(item or "").strip()
+                    )
                     or "none"
                 )
                 + ". Review-only: "
-                + escape(", ".join(background_policy.get("review_only_signal_types") or []) or "none")
+                + escape(
+                    ", ".join(
+                        str(item) for item in review_only_signal_types if str(item or "").strip()
+                    )
+                    or "none"
+                )
                 + ".</p>"
                 f"<p class='muted'>Skipped: {escape(str(background_policy.get('skipped_signal_count') or 0))}</p>"
                 f"<ul class='list-tight'>{policy_decisions}</ul></section>",

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -3175,9 +3175,21 @@ def _render_briefing_page(payload: dict) -> str:
     review_only_signal_types = background_policy.get("review_only_signal_types")
     if not isinstance(review_only_signal_types, list):
         review_only_signal_types = []
+
+    def _safe_count(value: object) -> int:
+        try:
+            return max(0, int(value or 0))
+        except (TypeError, ValueError):
+            return 0
+
+    loop_blocked_count = _safe_count(loop_summary.get("failed_count")) + _safe_count(
+        loop_summary.get("stalled_count")
+    )
+    skipped_signal_count = _safe_count(background_policy.get("skipped_signal_count"))
     failure_buckets = (
         "".join(
-            f"<li><span class='pill'>{escape(bucket)}</span> {count}</li>"
+            f"<li><span class='pill'>{escape(str(bucket))}</span> "
+            f"{_safe_count(count)}</li>"
             for bucket, count in failure_bucket_values.items()
         )
         or "<li class='muted'>No failed actions.</li>"
@@ -3187,9 +3199,9 @@ def _render_briefing_page(payload: dict) -> str:
             "<li>"
             f"<span class='pill'>{escape(str(signal_type))}</span> "
             f"{escape(str(decision.get('decision') or ''))}"
-            f"<div class='muted'>Active: {escape(str(decision.get('active_signal_count') or 0))} · "
-            f"Queued: {escape(str(decision.get('queued_action_count') or 0))} · "
-            f"Skipped: {escape(str(decision.get('skipped_count') or 0))}</div>"
+            f"<div class='muted'>Active: {_safe_count(decision.get('active_signal_count'))} · "
+            f"Queued: {_safe_count(decision.get('queued_action_count'))} · "
+            f"Skipped: {_safe_count(decision.get('skipped_count'))}</div>"
             "</li>"
             for signal_type, decision in signal_type_decisions.items()
             if isinstance(decision, dict)
@@ -3201,12 +3213,14 @@ def _render_briefing_page(payload: dict) -> str:
         "".join(
             [
                 "<h1>Orientation Brief</h1>",
-                f"<p class='muted'>Generated at {escape(payload['generated_at'])}. {payload['recent_signal_count']} recent signals, {payload['unresolved_issue_count']} unresolved issues.",
+                f"<p class='muted'>Generated at {escape(str(payload['generated_at']))}. "
+                f"{_safe_count(payload.get('recent_signal_count'))} recent signals, "
+                f"{_safe_count(payload.get('unresolved_issue_count'))} unresolved issues.",
                 (
                     " "
-                    + f"Loop: {loop_summary.get('productive_count', 0)} productive, "
-                    + f"{loop_summary.get('waiting_count', 0)} waiting, "
-                    + f"{loop_summary.get('failed_count', 0) + loop_summary.get('stalled_count', 0)} blocked."
+                    + f"Loop: {_safe_count(loop_summary.get('productive_count'))} productive, "
+                    + f"{_safe_count(loop_summary.get('waiting_count'))} waiting, "
+                    + f"{loop_blocked_count} blocked."
                 ),
                 f" Pack scope: {escape(requested_pack)}." if requested_pack else "",
                 "</p>",
@@ -3243,15 +3257,15 @@ def _render_briefing_page(payload: dict) -> str:
                     or "none"
                 )
                 + ".</p>"
-                f"<p class='muted'>Skipped: {escape(str(background_policy.get('skipped_signal_count') or 0))}</p>"
+                f"<p class='muted'>Skipped: {skipped_signal_count}</p>"
                 f"<ul class='list-tight'>{policy_decisions}</ul></section>",
                 f"<section class='card'><h2>Insights</h2><ul class='list-tight'>{insights}</ul></section>",
                 f"<section class='card'><h2>Priority Items</h2><ul class='list-tight'>{priority_items}</ul></section>",
                 "<section class='card'><h2>Execution Surface</h2>",
-                f"<p class='muted'>{queue_summary.get('queued_count', 0)} queued, ",
-                f"{queue_summary.get('safe_queued_count', 0)} safe to auto-run, ",
-                f"{queue_summary.get('running_count', 0)} running, ",
-                f"{queue_summary.get('failed_count', 0)} failed.</p>",
+                f"<p class='muted'>{_safe_count(queue_summary.get('queued_count'))} queued, ",
+                f"{_safe_count(queue_summary.get('safe_queued_count'))} safe to auto-run, ",
+                f"{_safe_count(queue_summary.get('running_count'))} running, ",
+                f"{_safe_count(queue_summary.get('failed_count'))} failed.</p>",
                 "<form method='post' action='/actions/run-batch' class='link-row'>",
                 "<input type='hidden' name='limit' value='5' />",
                 "<input type='hidden' name='safe_only' value='1' />",

--- a/src/ovp_pipeline/packs/research_tech/surfaces.py
+++ b/src/ovp_pipeline/packs/research_tech/surfaces.py
@@ -43,6 +43,156 @@ def _traceability_contract_payload(traceability: dict[str, Any]) -> dict[str, An
     }
 
 
+def _briefing_evidence_count(item: dict[str, Any]) -> int:
+    evidence: set[str] = set()
+    for key in ("source_paths", "note_paths", "object_ids"):
+        value = item.get(key)
+        if isinstance(value, list):
+            evidence.update(str(entry) for entry in value if str(entry or "").strip())
+    for key in ("signal_id", "path"):
+        value = str(item.get(key) or "").strip()
+        if value:
+            evidence.add(value)
+    return len(evidence)
+
+
+def _briefing_actionability(item: dict[str, Any]) -> str:
+    recommended_action = item.get("recommended_action")
+    if not isinstance(recommended_action, dict):
+        return "review"
+    if str(recommended_action.get("queue_status") or "").strip():
+        return "queued"
+    if bool(recommended_action.get("executable")):
+        return "executable"
+    return "review"
+
+
+def _annotate_briefing_value(
+    item: dict[str, Any],
+    *,
+    value_kind: str,
+    value_reason: str,
+) -> dict[str, Any]:
+    item["value_kind"] = value_kind
+    item["value_reason"] = value_reason
+    item["evidence_count"] = _briefing_evidence_count(item)
+    item["actionability"] = _briefing_actionability(item)
+    return item
+
+
+def _first_useful_sign_check(first_useful_sign: dict[str, Any] | None) -> dict[str, Any]:
+    if not first_useful_sign:
+        return {
+            "status": "empty",
+            "kind": "",
+            "reason": "No background insight or priority item has enough current evidence to surface.",
+            "evidence_count": 0,
+            "actionability": "review",
+        }
+    evidence_count = int(
+        first_useful_sign.get("evidence_count")
+        if "evidence_count" in first_useful_sign
+        else _briefing_evidence_count(first_useful_sign)
+    )
+    actionability = str(
+        first_useful_sign.get("actionability") or _briefing_actionability(first_useful_sign)
+    )
+    kind = str(first_useful_sign.get("kind") or "")
+    title = str(first_useful_sign.get("title") or "")
+    return {
+        "status": "useful",
+        "kind": kind,
+        "reason": (
+            f"{title or kind} surfaced with {evidence_count} evidence reference(s) "
+            f"and {actionability} follow-up."
+        ),
+        "evidence_count": evidence_count,
+        "actionability": actionability,
+    }
+
+
+def _background_policy_summary(
+    *,
+    pack_name: str,
+    recent_signals: list[dict[str, Any]],
+    action_by_signal_id: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    governed: dict[str, dict[str, Any]] = {}
+    for governance_spec in core.list_effective_governance_specs(pack_name=pack_name):
+        for rule in governance_spec.signal_rules:
+            signal_type = str(rule.signal_type or "").strip()
+            if not signal_type:
+                continue
+            governed[signal_type] = {
+                "signal_type": signal_type,
+                "resolver_rule": str(rule.resolver_rule or ""),
+                "auto_queue": bool(rule.auto_queue),
+                "provider_pack": str(governance_spec.pack or ""),
+                "provider_name": str(governance_spec.name or ""),
+            }
+
+    signal_counts = Counter(str(item.get("signal_type") or "") for item in recent_signals)
+    signal_type_decisions: dict[str, dict[str, Any]] = {}
+    skipped_reasons: Counter[str] = Counter()
+    for signal_type, rule in sorted(governed.items()):
+        matching = [
+            item
+            for item in recent_signals
+            if str(item.get("signal_type") or "") == signal_type
+        ]
+        queued_count = sum(
+            1
+            for item in matching
+            if str(item.get("signal_id") or "") in action_by_signal_id
+        )
+        skipped_count = 0
+        type_reasons: Counter[str] = Counter()
+        if rule["auto_queue"]:
+            for item in matching:
+                recommended_action = item.get("recommended_action")
+                if not isinstance(recommended_action, dict) or not recommended_action.get("kind"):
+                    skipped_count += 1
+                    type_reasons["missing_recommended_action"] += 1
+                elif str(item.get("signal_id") or "") not in action_by_signal_id:
+                    skipped_count += 1
+                    type_reasons["not_queued"] += 1
+        else:
+            skipped_count = len(matching)
+            if matching:
+                type_reasons["review_only"] = len(matching)
+
+        skipped_reasons.update(type_reasons)
+        signal_type_decisions[signal_type] = {
+            **rule,
+            "decision": "auto_queue_enabled" if rule["auto_queue"] else "review_only",
+            "active_signal_count": int(signal_counts.get(signal_type, 0)),
+            "queued_action_count": queued_count,
+            "skipped_count": skipped_count,
+            "skipped_reasons": dict(type_reasons),
+        }
+
+    auto_queue_types = sorted(
+        signal_type for signal_type, rule in governed.items() if rule["auto_queue"]
+    )
+    review_only_types = sorted(
+        signal_type for signal_type, rule in governed.items() if not rule["auto_queue"]
+    )
+    return {
+        "governed_signal_types": sorted(governed),
+        "auto_queue_enabled_signal_types": auto_queue_types,
+        "review_only_signal_types": review_only_types,
+        "active_auto_queue_signal_count": sum(
+            int(signal_counts.get(signal_type, 0)) for signal_type in auto_queue_types
+        ),
+        "active_review_only_signal_count": sum(
+            int(signal_counts.get(signal_type, 0)) for signal_type in review_only_types
+        ),
+        "skipped_signal_count": sum(skipped_reasons.values()),
+        "skipped_reasons": dict(skipped_reasons),
+        "signal_type_decisions": signal_type_decisions,
+    }
+
+
 def list_production_chains(
     vault_dir: Path | str,
     *,
@@ -610,6 +760,11 @@ def build_briefing_snapshot(
                 executable=True,
             ),
         }
+        _annotate_briefing_value(
+            insight,
+            value_kind="synthesis",
+            value_reason="Evolution candidates connect current objects to source-backed change signals.",
+        )
         key = (str(insight["kind"]), str(insight["title"]), str(insight["path"]))
         existing = merged_insights.get(key)
         if existing is None:
@@ -655,30 +810,37 @@ def build_briefing_snapshot(
                 "blocked_reason": str(action.get("blocked_reason") or ""),
                 "obsolete_reason": str(action.get("obsolete_reason") or ""),
             }
-        priority_items.append(
-            {
-                "signal_id": signal_id,
-                "kind": item["signal_type"],
-                "title": item["title"],
-                "detail": item["detail"],
-                "path": item["source_path"],
-                "source_paths": list(item.get("note_paths", [])),
-                "object_ids": list(item.get("object_ids", [])),
-                "recommended_action": recommended_action,
-                "action_lifecycle": item.get("action_lifecycle")
-                or (
-                    {
-                        "queue_status": str(action.get("status") or ""),
-                        "action_id": str(action.get("action_id") or ""),
-                        "precondition_status": str(action.get("precondition_status") or ""),
-                        "blocked_reason": str(action.get("blocked_reason") or ""),
-                        "obsolete_reason": str(action.get("obsolete_reason") or ""),
-                    }
-                    if action
-                    else {}
-                ),
-            }
+        priority_item = {
+            "signal_id": signal_id,
+            "kind": item["signal_type"],
+            "title": item["title"],
+            "detail": item["detail"],
+            "path": item["source_path"],
+            "source_paths": list(item.get("note_paths", [])),
+            "object_ids": list(item.get("object_ids", [])),
+            "recommended_action": recommended_action,
+            "action_lifecycle": item.get("action_lifecycle")
+            or (
+                {
+                    "queue_status": str(action.get("status") or ""),
+                    "action_id": str(action.get("action_id") or ""),
+                    "precondition_status": str(action.get("precondition_status") or ""),
+                    "blocked_reason": str(action.get("blocked_reason") or ""),
+                    "obsolete_reason": str(action.get("obsolete_reason") or ""),
+                }
+                if action
+                else {}
+            ),
+        }
+        _annotate_briefing_value(
+            priority_item,
+            value_kind="actionable_priority",
+            value_reason=(
+                "Active signals with resolver metadata indicate maintenance work the operator "
+                "does not need to rediscover manually."
+            ),
         )
+        priority_items.append(priority_item)
         if len(priority_items) >= limit:
             break
     seen_priority_keys = {(item["kind"], item["title"], item["path"]) for item in priority_items}
@@ -724,6 +886,12 @@ def build_briefing_snapshot(
         else:
             item.setdefault("action_lifecycle", {})
     first_useful_sign = insights[0] if insights else (priority_items[0] if priority_items else None)
+    first_useful_sign_check = _first_useful_sign_check(first_useful_sign)
+    background_policy = _background_policy_summary(
+        pack_name=normalized_pack,
+        recent_signals=recent_signals,
+        action_by_signal_id=action_by_signal_id,
+    )
     queue_summary = {
         "queued_count": sum(1 for item in action_items if item.get("status") == "queued"),
         "safe_queued_count": sum(
@@ -757,5 +925,7 @@ def build_briefing_snapshot(
         "insights": insights,
         "priority_items": priority_items,
         "first_useful_sign": first_useful_sign,
+        "first_useful_sign_check": first_useful_sign_check,
+        "background_policy": background_policy,
         "queue_summary": queue_summary,
     }

--- a/src/ovp_pipeline/packs/research_tech/surfaces.py
+++ b/src/ovp_pipeline/packs/research_tech/surfaces.py
@@ -60,7 +60,8 @@ def _briefing_actionability(item: dict[str, Any]) -> str:
     recommended_action = item.get("recommended_action")
     if not isinstance(recommended_action, dict):
         return "review"
-    if str(recommended_action.get("queue_status") or "").strip():
+    queue_status = str(recommended_action.get("queue_status") or "").strip().lower()
+    if queue_status in {"queued", "running", "pending", "scheduled", "in_progress"}:
         return "queued"
     if bool(recommended_action.get("executable")):
         return "executable"
@@ -89,13 +90,16 @@ def _first_useful_sign_check(first_useful_sign: dict[str, Any] | None) -> dict[s
             "evidence_count": 0,
             "actionability": "review",
         }
-    evidence_count = int(
-        first_useful_sign.get("evidence_count")
-        if "evidence_count" in first_useful_sign
-        else _briefing_evidence_count(first_useful_sign)
-    )
-    actionability = str(
-        first_useful_sign.get("actionability") or _briefing_actionability(first_useful_sign)
+    raw_evidence = first_useful_sign.get("evidence_count")
+    try:
+        evidence_count = int(raw_evidence)
+    except (TypeError, ValueError):
+        evidence_count = _briefing_evidence_count(first_useful_sign)
+    raw_actionability = first_useful_sign.get("actionability")
+    actionability = (
+        str(raw_actionability).strip()
+        if str(raw_actionability or "").strip()
+        else _briefing_actionability(first_useful_sign)
     )
     kind = str(first_useful_sign.get("kind") or "")
     title = str(first_useful_sign.get("title") or "")
@@ -132,14 +136,13 @@ def _background_policy_summary(
             }
 
     signal_counts = Counter(str(item.get("signal_type") or "") for item in recent_signals)
+    signals_by_type: dict[str, list[dict[str, Any]]] = {}
+    for item in recent_signals:
+        signals_by_type.setdefault(str(item.get("signal_type") or ""), []).append(item)
     signal_type_decisions: dict[str, dict[str, Any]] = {}
     skipped_reasons: Counter[str] = Counter()
     for signal_type, rule in sorted(governed.items()):
-        matching = [
-            item
-            for item in recent_signals
-            if str(item.get("signal_type") or "") == signal_type
-        ]
+        matching = signals_by_type.get(signal_type, [])
         queued_count = sum(
             1
             for item in matching
@@ -157,11 +160,10 @@ def _background_policy_summary(
                     skipped_count += 1
                     type_reasons["not_queued"] += 1
         else:
-            skipped_count = len(matching)
-            if matching:
-                type_reasons["review_only"] = len(matching)
+            skipped_count = 0
 
-        skipped_reasons.update(type_reasons)
+        if rule["auto_queue"]:
+            skipped_reasons.update(type_reasons)
         signal_type_decisions[signal_type] = {
             **rule,
             "decision": "auto_queue_enabled" if rule["auto_queue"] else "review_only",
@@ -191,6 +193,40 @@ def _background_policy_summary(
         "skipped_reasons": dict(skipped_reasons),
         "signal_type_decisions": signal_type_decisions,
     }
+
+
+def _merge_briefing_action_metadata(
+    item: dict[str, Any],
+    action: dict[str, Any],
+) -> None:
+    recommended_action = item.get("recommended_action")
+    if isinstance(recommended_action, dict):
+        if action:
+            recommended_action["queue_status"] = str(action.get("status") or "")
+            recommended_action["action_id"] = str(action.get("action_id") or "")
+            recommended_action["precondition_status"] = str(
+                action.get("precondition_status") or ""
+            )
+            recommended_action["blocked_reason"] = str(action.get("blocked_reason") or "")
+            recommended_action["obsolete_reason"] = str(action.get("obsolete_reason") or "")
+        recommended_action.setdefault("queue_status", "")
+        recommended_action.setdefault("action_id", "")
+        recommended_action.setdefault("precondition_status", "")
+        recommended_action.setdefault("blocked_reason", "")
+        recommended_action.setdefault("obsolete_reason", "")
+    if action:
+        item["action_lifecycle"] = {
+            **(item.get("action_lifecycle") if isinstance(item.get("action_lifecycle"), dict) else {}),
+            "queue_status": str(action.get("status") or ""),
+            "action_id": str(action.get("action_id") or ""),
+            "precondition_status": str(action.get("precondition_status") or ""),
+            "blocked_reason": str(action.get("blocked_reason") or ""),
+            "obsolete_reason": str(action.get("obsolete_reason") or ""),
+        }
+    else:
+        item.setdefault("action_lifecycle", {})
+    item["evidence_count"] = _briefing_evidence_count(item)
+    item["actionability"] = _briefing_actionability(item)
 
 
 def list_production_chains(
@@ -776,6 +812,8 @@ def build_briefing_snapshot(
             existing["object_ids"] = list(
                 dict.fromkeys([*existing.get("object_ids", []), *insight.get("object_ids", [])])
             )
+            existing["evidence_count"] = _briefing_evidence_count(existing)
+            existing["actionability"] = _briefing_actionability(existing)
     insights = list(merged_insights.values())
     insights.sort(
         key=lambda item: (
@@ -819,18 +857,7 @@ def build_briefing_snapshot(
             "source_paths": list(item.get("note_paths", [])),
             "object_ids": list(item.get("object_ids", [])),
             "recommended_action": recommended_action,
-            "action_lifecycle": item.get("action_lifecycle")
-            or (
-                {
-                    "queue_status": str(action.get("status") or ""),
-                    "action_id": str(action.get("action_id") or ""),
-                    "precondition_status": str(action.get("precondition_status") or ""),
-                    "blocked_reason": str(action.get("blocked_reason") or ""),
-                    "obsolete_reason": str(action.get("obsolete_reason") or ""),
-                }
-                if action
-                else {}
-            ),
+            "action_lifecycle": item.get("action_lifecycle") or {},
         }
         _annotate_briefing_value(
             priority_item,
@@ -855,36 +882,9 @@ def build_briefing_snapshot(
     for item in priority_items:
         signal_id = str(item.get("signal_id") or "")
         action = action_by_signal_id.get(signal_id, {})
-        recommended_action = item.get("recommended_action")
-        if isinstance(recommended_action, dict):
-            if action:
-                recommended_action.setdefault("queue_status", str(action.get("status") or ""))
-                recommended_action.setdefault("action_id", str(action.get("action_id") or ""))
-                recommended_action.setdefault(
-                    "precondition_status", str(action.get("precondition_status") or "")
-                )
-                recommended_action.setdefault(
-                    "blocked_reason", str(action.get("blocked_reason") or "")
-                )
-                recommended_action.setdefault(
-                    "obsolete_reason", str(action.get("obsolete_reason") or "")
-                )
-            recommended_action.setdefault("queue_status", "")
-            recommended_action.setdefault("action_id", "")
-            recommended_action.setdefault("precondition_status", "")
-            recommended_action.setdefault("blocked_reason", "")
-            recommended_action.setdefault("obsolete_reason", "")
-        if action:
-            item["action_lifecycle"] = {
-                "queue_status": str(action.get("status") or ""),
-                "action_id": str(action.get("action_id") or ""),
-                "precondition_status": str(action.get("precondition_status") or ""),
-                "blocked_reason": str(action.get("blocked_reason") or ""),
-                "obsolete_reason": str(action.get("obsolete_reason") or ""),
-                **(item.get("action_lifecycle") if isinstance(item.get("action_lifecycle"), dict) else {}),
-            }
-        else:
-            item.setdefault("action_lifecycle", {})
+        _merge_briefing_action_metadata(item, action)
+    for item in insights:
+        _merge_briefing_action_metadata(item, {})
     first_useful_sign = insights[0] if insights else (priority_items[0] if priority_items else None)
     first_useful_sign_check = _first_useful_sign_check(first_useful_sign)
     background_policy = _background_policy_summary(

--- a/src/ovp_pipeline/truth_api.py
+++ b/src/ovp_pipeline/truth_api.py
@@ -2888,14 +2888,20 @@ def _focused_action_backlink_precondition(
     if action_kind != "object_extraction_workflow":
         return {"status": "ready", "reason": ""}
     pack_name = str(action.get("pack") or DEFAULT_WORKFLOW_PACK_NAME)
-    for note_path in _focused_action_note_paths(action):
+    note_paths = _focused_action_note_paths(action)
+    if not note_paths:
+        return {
+            "status": "blocked",
+            "reason": "backlink_expectation_unavailable:missing_note_path",
+        }
+    for note_path in note_paths:
         try:
             traceability = get_note_traceability(
                 vault_dir,
                 note_path=note_path,
                 pack_name=pack_name,
             )
-        except Exception as exc:
+        except (OSError, sqlite3.Error, ValueError) as exc:
             return {
                 "status": "blocked",
                 "reason": f"backlink_expectation_unavailable:{note_path}:{type(exc).__name__}",

--- a/src/ovp_pipeline/truth_api.py
+++ b/src/ovp_pipeline/truth_api.py
@@ -2871,10 +2871,48 @@ def _focused_action_precondition(
                 "status": "blocked",
                 "reason": f"missing_note_path:{note_path}",
             }
+    backlink_precondition = _focused_action_backlink_precondition(vault_dir, action)
+    if str(backlink_precondition.get("status") or "") != "ready":
+        return backlink_precondition
     return {
         "status": "ready",
         "reason": "",
     }
+
+
+def _focused_action_backlink_precondition(
+    vault_dir: Path | str,
+    action: dict[str, Any],
+) -> dict[str, Any]:
+    action_kind = str(action.get("action_kind") or "")
+    if action_kind != "object_extraction_workflow":
+        return {"status": "ready", "reason": ""}
+    pack_name = str(action.get("pack") or DEFAULT_WORKFLOW_PACK_NAME)
+    for note_path in _focused_action_note_paths(action):
+        try:
+            traceability = get_note_traceability(
+                vault_dir,
+                note_path=note_path,
+                pack_name=pack_name,
+            )
+        except Exception as exc:
+            return {
+                "status": "blocked",
+                "reason": f"backlink_expectation_unavailable:{note_path}:{type(exc).__name__}",
+            }
+        expectation = traceability.get("backlink_expectation")
+        if not isinstance(expectation, dict):
+            return {
+                "status": "blocked",
+                "reason": f"backlink_expectation_unavailable:{note_path}:missing_payload",
+            }
+        expectation_status = str(expectation.get("status") or "")
+        if expectation_status != "satisfied":
+            return {
+                "status": "blocked",
+                "reason": f"backlink_expectation_failed:{expectation_status}:{note_path}",
+            }
+    return {"status": "ready", "reason": ""}
 
 
 def _apply_failed_precondition(

--- a/src/ovp_pipeline/ui/view_models.py
+++ b/src/ovp_pipeline/ui/view_models.py
@@ -1180,6 +1180,23 @@ def build_briefing_payload(vault_dir: Path | str, *, pack_name: str | None = Non
             "compiled_sections": [],
             "section_nav": [],
             "first_useful_sign": None,
+            "first_useful_sign_check": {
+                "status": "empty",
+                "kind": "",
+                "reason": "No briefing surface is available for this pack.",
+                "evidence_count": 0,
+                "actionability": "review",
+            },
+            "background_policy": {
+                "governed_signal_types": [],
+                "auto_queue_enabled_signal_types": [],
+                "review_only_signal_types": [],
+                "active_auto_queue_signal_count": 0,
+                "active_review_only_signal_count": 0,
+                "skipped_signal_count": 0,
+                "skipped_reasons": {},
+                "signal_type_decisions": {},
+            },
             "loop_summary": {
                 "productive_count": 0,
                 "waiting_count": 0,
@@ -2515,7 +2532,6 @@ def build_cluster_detail_payload(
     cluster = detail["cluster"]
     requested_pack = pack_name or str(cluster["pack"])
     member_index = {str(member["object_id"]): member for member in cluster["members"]}
-    member_object_ids = [str(member["object_id"]) for member in cluster["members"]]
     detail_path = (
         f"/cluster?id={quote(str(cluster['cluster_id']), safe='')}"
         f"&pack={quote(requested_pack, safe='')}"

--- a/src/ovp_pipeline/ui/view_models.py
+++ b/src/ovp_pipeline/ui/view_models.py
@@ -103,6 +103,65 @@ def _workflow_group(
     }
 
 
+def _briefing_value_evidence_count(item: dict[str, Any]) -> int:
+    evidence: set[str] = set()
+    for key in ("source_paths", "note_paths", "object_ids"):
+        value = item.get(key)
+        if isinstance(value, list):
+            evidence.update(str(entry) for entry in value if str(entry or "").strip())
+    for key in ("signal_id", "path"):
+        value = str(item.get(key) or "").strip()
+        if value:
+            evidence.add(value)
+    return len(evidence)
+
+
+def _briefing_value_actionability(item: dict[str, Any]) -> str:
+    recommended_action = item.get("recommended_action")
+    if not isinstance(recommended_action, dict):
+        return "review"
+    queue_status = str(recommended_action.get("queue_status") or "").strip().lower()
+    if queue_status in {"queued", "running", "pending", "scheduled", "in_progress"}:
+        return "queued"
+    if bool(recommended_action.get("executable")):
+        return "executable"
+    return "review"
+
+
+def _briefing_value_check(first_useful_sign: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(first_useful_sign, dict):
+        return {
+            "status": "empty",
+            "kind": "",
+            "reason": "No background insight or priority item has enough current evidence to surface.",
+            "evidence_count": 0,
+            "actionability": "review",
+        }
+    raw_evidence = first_useful_sign.get("evidence_count")
+    try:
+        evidence_count = int(raw_evidence)
+    except (TypeError, ValueError):
+        evidence_count = _briefing_value_evidence_count(first_useful_sign)
+    raw_actionability = first_useful_sign.get("actionability")
+    actionability = (
+        str(raw_actionability).strip()
+        if str(raw_actionability or "").strip()
+        else _briefing_value_actionability(first_useful_sign)
+    )
+    kind = str(first_useful_sign.get("kind") or "")
+    title = str(first_useful_sign.get("title") or "")
+    return {
+        "status": "useful",
+        "kind": kind,
+        "reason": (
+            f"{title or kind} surfaced with {evidence_count} evidence reference(s) "
+            f"and {actionability} follow-up."
+        ),
+        "evidence_count": evidence_count,
+        "actionability": actionability,
+    }
+
+
 def _build_dashboard_workflow_groups(
     *,
     requested_pack: str,
@@ -1333,6 +1392,7 @@ def build_briefing_payload(vault_dir: Path | str, *, pack_name: str | None = Non
         if productive_signal is not None
         else snapshot.get("first_useful_sign")
     )
+    first_useful_sign_check = _briefing_value_check(first_useful_sign)
     inbound_capture_items = [
         {
             "kind": "capture_signal",
@@ -1425,6 +1485,7 @@ def build_briefing_payload(vault_dir: Path | str, *, pack_name: str | None = Non
         "governance_contract": governance_contract,
         **snapshot,
         "first_useful_sign": first_useful_sign,
+        "first_useful_sign_check": first_useful_sign_check,
         "loop_summary": loop_summary,
         "operator_rail": operator_rail,
         "compiled_sections": compiled_sections,

--- a/task_plan.md
+++ b/task_plan.md
@@ -1,10 +1,10 @@
-# Task Plan: OVP Roadmap Closeout And Phase 27
+# Task Plan: OVP Roadmap Closeout And Phase 28/29
 
 ## Runtime Note
 
-- Current branch: `main`
-- Current merged head: `21dcebf Add candidate canonicalization workbench`
-- Last full verification on `main`: `pytest -q` -> `685 passed`
+- Current branch: `phase28-29-background-value-backlinks`
+- Current remote base: `75febbd Add Phase 27 orchestration closeout`
+- Last full verification on merged Phase 27 branch: `pytest -q` -> `689 passed`
 - Untracked local files intentionally not part of the roadmap work:
   - `.review-venv/`
   - `AGENTS.md`
@@ -22,17 +22,19 @@ OVP is now a usable local knowledge workbench with:
 - active signal loop
 - action queue and focused action worker execution surface
 
-The current missing product claim is:
+The current missing product claims are:
 
-> OVP has a single focused execution surface, but broader background intelligence is still an incremental roadmap, not a hosted scheduler or autonomous harness.
+> OVP has a single focused execution surface, but broader background intelligence still needs a clearer value proof: why a briefing item is useful, what evidence supports it, and what background policy allowed or skipped it.
+
+> OVP exposes backlink expectations, but focused object writes do not yet enforce them before creating downstream knowledge.
 
 ## Current Phase
 
-`Phase 27: Background Intelligence Orchestration Closeout` is implemented locally.
+`Phase 28/29: Background Value And Backlink Enforcement` is implemented and verified locally.
 
 Canonical plan:
 
-- `docs/plans/2026-04-21-phase27-background-intelligence-orchestration-closeout.md`
+- `docs/plans/2026-04-21-phase28-29-background-value-and-backlink-enforcement.md`
 
 ## Roadmap Status
 
@@ -47,7 +49,7 @@ Canonical plan:
 | Milestone 6 | Complete | Product shell and operator UX |
 | Milestone 7 | Complete | Active signal loop, runtime visibility, candidate/canonical workbench |
 | Milestone 8 | Complete | Knowledge evolution layer |
-| Milestone 9 | In Progress | Background intelligence has observable execution foundations; broader intelligence loops remain future work |
+| Milestone 9 | In Progress | Background intelligence has observable execution foundations; Phase 28 now closes value proof and policy legibility |
 | Milestone 9A | Complete | Single focused execution surface via action queue / worker / handler contracts |
 
 ## Completed Recent Phases
@@ -61,19 +63,27 @@ Canonical plan:
 
 ## Current TODO
 
-- Phase 27 implementation is done locally.
-- Diff has been reviewed for unrelated tracked-file changes.
+- Phase 27 has been squash-merged to `origin/main` in PR #43.
+- Phase 28 adds background-intelligence value proof and policy legibility.
+- Phase 29 enforces backlink expectations before focused object writes.
 - Remaining before PR:
   - commit and open PR when requested
 
-Completed verification:
+Latest completed Phase 27 verification:
 
-- `pytest tests/test_run_actions_command.py tests/test_truth_api.py tests/test_ui_view_models.py tests/test_ui_server.py tests/test_watch_progress_command.py -q` -> `262 passed`
+- `pytest tests/test_run_actions_command.py tests/test_truth_api.py tests/test_ui_view_models.py tests/test_ui_server.py tests/test_watch_progress_command.py -q` -> `263 passed`
 - `ruff check ...` on touched Python files -> `All checks passed`
 - `python -m pip install -e .` -> installed editable `obsidian-vault-pipeline==0.8.6`
 - installed-command validation with `python -m ovp_pipeline.commands.run_actions --once --safe-only` -> blocked missing target with persisted worker state
 - `git diff --check` -> clean
-- `pytest -q` -> `688 passed`
+- `pytest -q` -> `689 passed`
+
+Completed Phase 28/29 verification:
+
+- `ruff check src/ovp_pipeline/truth_api.py src/ovp_pipeline/packs/research_tech/surfaces.py src/ovp_pipeline/ui/view_models.py src/ovp_pipeline/commands/ui_server.py tests/test_truth_api.py tests/test_ui_server.py` -> `All checks passed!`
+- `pytest tests/test_truth_api.py tests/test_ui_view_models.py tests/test_ui_server.py -q` -> `255 passed`
+- `pytest -q` -> `690 passed`
+- `git diff --check` -> clean
 
 ## Implemented In Phase 27
 
@@ -94,13 +104,13 @@ Completed verification:
 | Do not create a second execution system | Phase 27 kept the existing action queue as the single focused execution surface. |
 | Treat Phase 27 as closeout/hardening, not greenfield | The implementation hardened action queue, worker, handler registry, focused action contracts, and auto-queue rather than adding a new engine. |
 | Keep `ovp --incremental` / `ovp --full` as broad reconcilers | The action queue is for focused follow-up execution, not batch replacement. |
-| Defer richer semantic extraction | It should enter later as a pack-level extraction contract after orchestration is observable. |
+| Defer richer semantic extraction | It should enter later as a pack-level extraction contract after value proof and backlink trust boundaries are closed. |
 
 ## Non-Goals For The Next Phase
 
 - No hosted scheduler.
 - No harness/session memory backend.
-- No new semantic relation extractor.
+- No new semantic relation extractor; Phase 29 only enforces the existing backlink contract.
 - No direct UI-to-workflow execution outside the action queue.
 - No broad frontend redesign.
 

--- a/task_plan.md
+++ b/task_plan.md
@@ -66,8 +66,11 @@ Canonical plan:
 - Phase 27 has been squash-merged to `origin/main` in PR #43.
 - Phase 28 adds background-intelligence value proof and policy legibility.
 - Phase 29 enforces backlink expectations before focused object writes.
-- Remaining before PR:
-  - commit and open PR when requested
+- PR #44 is open for Phase 28/29 and currently in review/merge validation.
+- Remaining before merge:
+  - resolve current review findings
+  - rerun targeted and full verification
+  - merge after no blocking review threads remain
 
 Latest completed Phase 27 verification:
 
@@ -116,7 +119,7 @@ Completed Phase 28/29 verification:
 
 ## Verification Habit
 
-Before opening or closing the Phase 27 implementation PR:
+Before closing the Phase 28/29 implementation PR:
 
 1. run targeted tests for the changed action/runtime path,
 2. run `pytest tests/test_truth_api.py tests/test_ui_view_models.py tests/test_ui_server.py tests/test_watch_progress_command.py -q`,

--- a/task_plan.md
+++ b/task_plan.md
@@ -25,7 +25,7 @@ OVP is now a usable local knowledge workbench with:
 The current missing product claims are:
 
 > OVP has a single focused execution surface, but broader background intelligence still needs a clearer value proof: why a briefing item is useful, what evidence supports it, and what background policy allowed or skipped it.
-
+>
 > OVP exposes backlink expectations, but focused object writes do not yet enforce them before creating downstream knowledge.
 
 ## Current Phase

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -3312,6 +3312,46 @@ def test_truth_api_run_next_action_queue_item_blocks_missing_action_target_befor
     assert action["retry_count"] == 0
 
 
+def test_truth_api_run_next_action_queue_item_blocks_object_extraction_without_note_target(
+    temp_vault, monkeypatch
+):
+    import ovp_pipeline.truth_api as truth_api
+
+    logs_dir = temp_vault / "60-Logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    (logs_dir / "actions.jsonl").write_text(
+        json.dumps(
+            {
+                "action_id": "action::missing-object-target",
+                "action_kind": "object_extraction_workflow",
+                "pack": "research-tech",
+                "title": "Extract missing target",
+                "target_ref": "",
+                "note_paths": [],
+                "status": "queued",
+                "created_at": "2026-04-21T00:00:00Z",
+                "safe_to_run": True,
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        truth_api,
+        "execute_focused_action_handler",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("handler should not run")),
+        raising=False,
+    )
+
+    payload = truth_api.run_next_action_queue_item(temp_vault)
+    action = truth_api.list_action_queue(temp_vault)[0]
+
+    assert payload["ran"] is False
+    assert payload["reason"] == "blocked"
+    assert action["blocked_reason"] == "backlink_expectation_unavailable:missing_note_path"
+
+
 def test_truth_api_run_next_action_queue_item_blocks_object_extraction_without_source_backlink(
     temp_vault, monkeypatch
 ):
@@ -3721,9 +3761,12 @@ Thin.
         "executable",
     }
     assert payload["background_policy"]["auto_queue_enabled_signal_types"] == [
+        *sorted(payload["background_policy"]["auto_queue_enabled_signal_types"])
+    ]
+    assert {
         "deep_dive_needs_objects",
         "source_needs_deep_dive",
-    ]
+    }.issubset(payload["background_policy"]["auto_queue_enabled_signal_types"])
     assert payload["background_policy"]["active_review_only_signal_count"] >= 1
     assert "source_needs_deep_dive" in payload["background_policy"]["signal_type_decisions"]
     assert any(item.get("recommended_action") for item in payload["priority_items"])
@@ -3756,7 +3799,7 @@ def test_truth_api_briefing_dedupes_equivalent_evolution_insights(temp_vault, mo
                 "link_type": "challenges",
                 "subject_id": "agent harness",
                 "object_ids": ["source-note"],
-                "source_paths": ["10-Knowledge/Evergreen/Source.md"],
+                "source_paths": ["10-Knowledge/Evergreen/Other.md"],
             },
         ],
     )
@@ -3767,6 +3810,42 @@ def test_truth_api_briefing_dedupes_equivalent_evolution_insights(temp_vault, mo
 
     assert len(payload["insights"]) == 1
     assert len(payload["priority_items"]) == 1
+    assert payload["insights"][0]["source_paths"] == [
+        "10-Knowledge/Evergreen/Source.md",
+        "10-Knowledge/Evergreen/Other.md",
+    ]
+    assert payload["insights"][0]["evidence_count"] >= 4
+
+
+def test_research_tech_briefing_value_helpers_handle_terminal_and_malformed_inputs():
+    from ovp_pipeline.packs.research_tech import surfaces as research_surfaces
+
+    assert (
+        research_surfaces._briefing_actionability(
+            {"recommended_action": {"queue_status": "blocked", "executable": False}}
+        )
+        == "review"
+    )
+    assert (
+        research_surfaces._briefing_actionability(
+            {"recommended_action": {"queue_status": "queued", "executable": False}}
+        )
+        == "queued"
+    )
+
+    check = research_surfaces._first_useful_sign_check(
+        {
+            "signal_id": "sig-malformed",
+            "kind": None,
+            "title": None,
+            "evidence_count": None,
+            "recommended_action": {"queue_status": "blocked"},
+        }
+    )
+
+    assert check["status"] == "useful"
+    assert check["evidence_count"] >= 1
+    assert check["actionability"] == "review"
 
 
 def test_truth_api_briefing_prioritizes_actionable_unresolved_issues(temp_vault, monkeypatch):

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -2925,7 +2925,7 @@ Processed source note without any derived deep dive.
 note_id: harness-deep-dive
 title: Harness Deep Dive
 type: deep_dive
-source: https://example.com/another-harness
+source: https://example.com/harness
 date: 2026-04-13
 ---
 
@@ -3041,7 +3041,7 @@ Processed source note without any derived deep dive.
 note_id: harness-deep-dive
 title: Harness Deep Dive
 type: deep_dive
-source: https://example.com/another-harness
+source: https://example.com/harness
 date: 2026-04-13
 ---
 
@@ -3312,6 +3312,82 @@ def test_truth_api_run_next_action_queue_item_blocks_missing_action_target_befor
     assert action["retry_count"] == 0
 
 
+def test_truth_api_run_next_action_queue_item_blocks_object_extraction_without_source_backlink(
+    temp_vault, monkeypatch
+):
+    import ovp_pipeline.truth_api as truth_api
+
+    deep_dive = (
+        temp_vault
+        / "20-Areas"
+        / "AI-Research"
+        / "Topics"
+        / "2026-04"
+        / "Orphan Dive_深度解读.md"
+    )
+    deep_dive.parent.mkdir(parents=True, exist_ok=True)
+    deep_dive.write_text(
+        """---
+note_id: orphan-dive
+title: Orphan Dive
+type: deep_dive
+date: 2026-04-21
+---
+
+# Orphan Dive
+
+Mentions [[agent-memory]] but has no source provenance.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+    relative_path = str(deep_dive.relative_to(temp_vault))
+    logs_dir = temp_vault / "60-Logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    (logs_dir / "actions.jsonl").write_text(
+        json.dumps(
+            {
+                "action_id": "action::orphan-object-extraction",
+                "action_kind": "object_extraction_workflow",
+                "pack": "research-tech",
+                "source_signal_id": "deep_dive_needs_objects::orphan",
+                "title": "Extract orphan objects",
+                "target_ref": relative_path,
+                "note_paths": [relative_path],
+                "status": "queued",
+                "created_at": "2026-04-21T00:00:00Z",
+                "safe_to_run": True,
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        truth_api,
+        "_signal_by_id",
+        lambda vault_dir, signal_id, **kwargs: {"signal_id": signal_id},
+    )
+    monkeypatch.setattr(
+        truth_api,
+        "execute_focused_action_handler",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("handler should not run")),
+        raising=False,
+    )
+
+    payload = truth_api.run_next_action_queue_item(temp_vault)
+    action = truth_api.list_action_queue(temp_vault)[0]
+
+    assert payload["ran"] is False
+    assert payload["reason"] == "blocked"
+    assert action["status"] == "blocked"
+    assert action["precondition_status"] == "blocked"
+    assert (
+        action["blocked_reason"]
+        == f"backlink_expectation_failed:missing_source_backlink:{relative_path}"
+    )
+
+
 def test_truth_api_can_retry_failed_action_queue_item(temp_vault, monkeypatch):
     import ovp_pipeline.truth_api as truth_api
 
@@ -3438,7 +3514,7 @@ Processed source note without any derived deep dive.
 note_id: harness-deep-dive
 title: Harness Deep Dive
 type: deep_dive
-source: https://example.com/another-harness
+source: https://example.com/harness
 date: 2026-04-13
 ---
 
@@ -3637,11 +3713,28 @@ Thin.
     assert payload["insights"]
     assert payload["priority_items"]
     assert payload["first_useful_sign"] in payload["insights"]
+    assert payload["first_useful_sign_check"]["status"] == "useful"
+    assert payload["first_useful_sign_check"]["evidence_count"] >= 1
+    assert payload["first_useful_sign_check"]["actionability"] in {
+        "review",
+        "queued",
+        "executable",
+    }
+    assert payload["background_policy"]["auto_queue_enabled_signal_types"] == [
+        "deep_dive_needs_objects",
+        "source_needs_deep_dive",
+    ]
+    assert payload["background_policy"]["active_review_only_signal_count"] >= 1
+    assert "source_needs_deep_dive" in payload["background_policy"]["signal_type_decisions"]
     assert any(item.get("recommended_action") for item in payload["priority_items"])
     actionable = next(item for item in payload["priority_items"] if item.get("recommended_action"))
     assert actionable["recommended_action"]["queue_status"] in {"queued", ""}
     assert actionable["recommended_action"]["resolver_rule_name"]
     assert "action_lifecycle" in actionable
+    assert actionable["value_kind"]
+    assert actionable["value_reason"]
+    assert actionable["evidence_count"] >= 1
+    assert actionable["actionability"] in {"review", "queued", "executable"}
 
 
 def test_truth_api_briefing_dedupes_equivalent_evolution_insights(temp_vault, monkeypatch):

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -1760,6 +1760,8 @@ def test_ui_server_briefing_endpoint_returns_payload(temp_vault):
     assert payload["recent_signal_count"] >= 1
     assert payload["active_topics"]
     assert payload["assembly_contract"]["recipe_name"] == "orientation_brief"
+    assert payload["first_useful_sign_check"]["status"] in {"useful", "empty"}
+    assert "auto_queue_enabled_signal_types" in payload["background_policy"]
     assert [section["id"] for section in payload["compiled_sections"]] == [
         "signal_loop",
         "inbound_capture",
@@ -1857,6 +1859,9 @@ Processed source note without downstream chain.
     assert "Inbound Capture" in body
     assert "What Changed" in body
     assert "Next Actions" in body
+    assert "Value Proof" in body
+    assert "Background Policy" in body
+    assert "Auto-queue enabled" in body
     assert body.index("Signal Loop") < body.index("Next Actions") < body.index("Inbound Capture")
 
 

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -1878,13 +1878,36 @@ def test_render_briefing_page_tolerates_malformed_background_policy():
             "section_nav": [],
             "first_useful_sign": None,
             "first_useful_sign_check": ["bad"],
-            "background_policy": "bad",
+            "background_policy": {
+                "auto_queue_enabled_signal_types": "bad",
+                "review_only_signal_types": "bad",
+                "skipped_signal_count": "<script>bad</script>",
+                "signal_type_decisions": {
+                    "<b>signal</b>": {
+                        "decision": "<b>review</b>",
+                        "active_signal_count": "bad",
+                        "queued_action_count": "<script>bad</script>",
+                        "skipped_count": object(),
+                    }
+                },
+            },
             "surface_contract": {},
             "assembly_contract": {},
             "governance_contract": {},
             "operator_rail": [],
-            "queue_summary": {"failure_buckets": ["bad"]},
-            "loop_summary": {},
+            "queue_summary": {
+                "queued_count": "bad",
+                "safe_queued_count": object(),
+                "running_count": "<script>bad</script>",
+                "failed_count": None,
+                "failure_buckets": {"<b>bucket</b>": "<script>bad</script>"},
+            },
+            "loop_summary": {
+                "productive_count": "bad",
+                "waiting_count": "<script>bad</script>",
+                "failed_count": "bad",
+                "stalled_count": object(),
+            },
             "insights": [],
             "priority_items": [],
             "recent_signals": [],
@@ -1897,6 +1920,8 @@ def test_render_briefing_page_tolerates_malformed_background_policy():
     assert "Value Proof" in body
     assert "Background Policy" in body
     assert "Auto-queue enabled: none" in body
+    assert "&lt;b&gt;bucket&lt;/b&gt;" in body
+    assert "<script>bad</script>" not in body
 
 
 def test_ui_server_briefing_page_renders_governance_resolver_metadata(temp_vault, monkeypatch):

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -1865,6 +1865,40 @@ Processed source note without downstream chain.
     assert body.index("Signal Loop") < body.index("Next Actions") < body.index("Inbound Capture")
 
 
+def test_render_briefing_page_tolerates_malformed_background_policy():
+    from ovp_pipeline.commands import ui_server
+
+    body = ui_server._render_briefing_page(
+        {
+            "requested_pack": "",
+            "generated_at": "2026-04-21T00:00:00Z",
+            "recent_signal_count": 0,
+            "unresolved_issue_count": 0,
+            "compiled_sections": [],
+            "section_nav": [],
+            "first_useful_sign": None,
+            "first_useful_sign_check": ["bad"],
+            "background_policy": "bad",
+            "surface_contract": {},
+            "assembly_contract": {},
+            "governance_contract": {},
+            "operator_rail": [],
+            "queue_summary": {"failure_buckets": ["bad"]},
+            "loop_summary": {},
+            "insights": [],
+            "priority_items": [],
+            "recent_signals": [],
+            "unresolved_issues": [],
+            "changed_objects": [],
+            "active_topics": [],
+        }
+    )
+
+    assert "Value Proof" in body
+    assert "Background Policy" in body
+    assert "Auto-queue enabled: none" in body
+
+
 def test_ui_server_briefing_page_renders_governance_resolver_metadata(temp_vault, monkeypatch):
     import ovp_pipeline.commands.ui_server as ui_server
     from ovp_pipeline.commands.ui_server import create_server

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -1664,6 +1664,92 @@ def test_build_briefing_payload_preserves_requested_pack(temp_vault):
     assert payload["governance_contract"]["provider_name"] == "research_governance"
 
 
+def test_build_briefing_payload_recomputes_value_check_for_productive_override(
+    temp_vault, monkeypatch
+):
+    from ovp_pipeline.ui import view_models
+
+    monkeypatch.setattr(
+        view_models,
+        "get_briefing_snapshot",
+        lambda *args, **kwargs: {
+            "generated_at": "2026-04-21T00:00:00Z",
+            "recent_signal_count": 1,
+            "unresolved_issue_count": 0,
+            "changed_object_count": 0,
+            "active_topic_count": 0,
+            "recent_signals": [
+                {
+                    "signal_id": "signal::productive",
+                    "signal_type": "source_needs_deep_dive",
+                    "title": "Productive signal",
+                    "detail": "Action produced a deep dive.",
+                    "source_path": "/signals",
+                    "note_paths": ["50-Inbox/03-Processed/Productive.md"],
+                    "object_ids": ["productive-object"],
+                    "recommended_action": {
+                        "label": "Inspect action",
+                        "path": "/actions",
+                        "queue_path": "/actions",
+                        "queue_status": "succeeded",
+                    },
+                    "impact_summary": {
+                        "impact_status": "productive",
+                        "impact_detail": "Produced 1 tracked artifact.",
+                    },
+                }
+            ],
+            "unresolved_issues": [],
+            "changed_objects": [],
+            "active_topics": [],
+            "insight_count": 1,
+            "priority_item_count": 1,
+            "insights": [],
+            "priority_items": [],
+            "first_useful_sign": {
+                "kind": "old_insight",
+                "title": "Old insight",
+                "detail": "Old detail.",
+                "path": "/old",
+                "source_paths": ["old.md"],
+                "object_ids": [],
+                "evidence_count": 1,
+                "actionability": "executable",
+            },
+            "first_useful_sign_check": {
+                "status": "useful",
+                "kind": "old_insight",
+                "reason": "Old insight surfaced with 1 evidence reference(s).",
+                "evidence_count": 1,
+                "actionability": "executable",
+            },
+            "background_policy": {
+                "governed_signal_types": [],
+                "auto_queue_enabled_signal_types": [],
+                "review_only_signal_types": [],
+                "active_auto_queue_signal_count": 0,
+                "active_review_only_signal_count": 0,
+                "skipped_signal_count": 0,
+                "skipped_reasons": {},
+                "signal_type_decisions": {},
+            },
+            "queue_summary": {
+                "queued_count": 0,
+                "safe_queued_count": 0,
+                "running_count": 0,
+                "failed_count": 0,
+                "failure_buckets": {},
+            },
+        },
+    )
+
+    payload = view_models.build_briefing_payload(temp_vault)
+
+    assert payload["first_useful_sign"]["title"] == "Productive signal"
+    assert payload["first_useful_sign_check"]["kind"] == "source_needs_deep_dive"
+    assert "Productive signal" in payload["first_useful_sign_check"]["reason"]
+
+
 def test_build_briefing_payload_handles_missing_surface_contract(temp_vault, monkeypatch):
     from ovp_pipeline.ui import view_models
 
@@ -2319,7 +2405,6 @@ Processed source note without downstream chain.
 
 def test_build_derivation_browser_payload_filters_stale_object_ids(temp_vault):
     from ovp_pipeline.ui.view_models import build_derivation_browser_payload
-    from ovp_pipeline.runtime import VaultLayout
 
     alpha = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
     alpha.write_text(


### PR DESCRIPTION
## Summary
- add Phase 28/29 plan and update roadmap/progress state after Phase 27 merge
- add briefing value proof fields plus background policy visibility for governed signal handling
- enforce `backlink_expectation` before focused object extraction writes downstream knowledge

## Verification
- `ruff check src/ovp_pipeline/truth_api.py src/ovp_pipeline/packs/research_tech/surfaces.py src/ovp_pipeline/ui/view_models.py src/ovp_pipeline/commands/ui_server.py tests/test_truth_api.py tests/test_ui_server.py`
- `pytest tests/test_truth_api.py tests/test_ui_view_models.py tests/test_ui_server.py -q` -> `255 passed`
- `pytest -q` -> `690 passed`
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/44" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Value Proof" and "Background Policy" to briefings, showing evidence counts, actionability, policy decisions, and counts.
  * Enforced backlink provenance: focused object extraction is blocked when required source backlinks are missing.

* **Bug Fixes / Robustness**
  * Briefing rendering and payload consumption now tolerate malformed/missing background policy and normalize types.

* **Tests**
  * Added/updated tests covering briefing fields, blocking behavior, and helper edge cases.

* **Documentation**
  * Updated roadmap and task plans for Phase 28/29 and verification notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->