### PR TITLE
Add Phase 37: Workbench, Pulse, and MCP compiler primitives

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ ovp-evidence = "ovp_pipeline.commands.evidence_verify:main"
 ovp-promote = "ovp_pipeline.commands.promote:main"
 ovp-init = "ovp_pipeline.commands.init_project:main"
 ovp-ui = "ovp_pipeline.commands.ui_server:main"
+ovp-mcp = "ovp_pipeline.commands.mcp:main"
 
 [project.entry-points."ovp.packs"]
 default-knowledge = "ovp_pipeline.packs.default_knowledge:get_pack"

--- a/src/ovp_pipeline/commands/mcp.py
+++ b/src/ovp_pipeline/commands/mcp.py
@@ -1,0 +1,93 @@
+"""``ovp-mcp`` — CLI entry for the Phase 37 MCP stdio server.
+
+Three modes:
+
+* ``ovp-mcp --vault-dir <path>`` — long-lived stdio server. Reads JSON-RPC
+  requests on stdin, writes replies on stdout, one per line.
+* ``ovp-mcp --vault-dir <path> --tools-list`` — one-shot listing of the
+  registered tool descriptors as JSON. Useful for shell scripting and CI.
+* ``ovp-mcp --vault-dir <path> --call NAME --json '{...}'`` — invoke a
+  single tool with the supplied JSON arguments and print the JSON result.
+
+The server class lives in :mod:`ovp_pipeline.mcp_server`; this module is a
+thin argparse + dispatch wrapper.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from ..mcp_server import MCPServer
+from ..runtime import resolve_vault_dir
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="ovp-mcp",
+        description="Phase 37 MCP stdio server for the OVP compiler primitives.",
+    )
+    parser.add_argument(
+        "--vault-dir",
+        type=Path,
+        default=None,
+        help="Path to the vault. Defaults to env / discovery via resolve_vault_dir.",
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--tools-list",
+        action="store_true",
+        help="One-shot: print the registered tool descriptors as JSON and exit.",
+    )
+    mode.add_argument(
+        "--call",
+        metavar="NAME",
+        default=None,
+        help="One-shot: invoke a single tool by name. Pair with --json.",
+    )
+    parser.add_argument(
+        "--json",
+        metavar="JSON",
+        default="{}",
+        help="JSON object passed as the tool's arguments (used with --call).",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    vault_dir = resolve_vault_dir(args.vault_dir)
+    server = MCPServer(vault_dir)
+
+    if args.tools_list:
+        print(json.dumps({"tools": server.list_tools()}, ensure_ascii=False, indent=2))
+        return 0
+
+    if args.call:
+        try:
+            arguments = json.loads(args.json)
+        except json.JSONDecodeError as exc:
+            print(json.dumps({"error": f"Invalid --json: {exc}"}), file=sys.stderr)
+            return 2
+        if not isinstance(arguments, dict):
+            print(json.dumps({"error": "--json must encode an object"}), file=sys.stderr)
+            return 2
+        try:
+            result = server.call_tool(args.call, arguments)
+        except KeyError:
+            print(json.dumps({"error": f"Unknown tool: {args.call}"}), file=sys.stderr)
+            return 2
+        except (TypeError, ValueError) as exc:
+            print(json.dumps({"error": str(exc)}), file=sys.stderr)
+            return 2
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        return 0
+
+    server.serve()
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/ovp_pipeline/commands/mcp.py
+++ b/src/ovp_pipeline/commands/mcp.py
@@ -20,7 +20,7 @@ import json
 import sys
 from pathlib import Path
 
-from ..mcp_server import MCPServer
+from ..mcp_server import MCPServer, _InvalidParams
 from ..runtime import resolve_vault_dir
 
 
@@ -79,7 +79,7 @@ def main(argv: list[str] | None = None) -> int:
         except KeyError:
             print(json.dumps({"error": f"Unknown tool: {args.call}"}), file=sys.stderr)
             return 2
-        except (TypeError, ValueError) as exc:
+        except (TypeError, ValueError, _InvalidParams) as exc:
             print(json.dumps({"error": str(exc)}), file=sys.stderr)
             return 2
         print(json.dumps(result, ensure_ascii=False, indent=2))

--- a/src/ovp_pipeline/commands/mcp.py
+++ b/src/ovp_pipeline/commands/mcp.py
@@ -33,7 +33,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "--vault-dir",
         type=Path,
         default=None,
-        help="Path to the vault. Defaults to env / discovery via resolve_vault_dir.",
+        help="Path to the vault. Defaults to the current working directory.",
     )
     mode = parser.add_mutually_exclusive_group()
     mode.add_argument(

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -7,6 +7,7 @@ import sqlite3
 import re
 import subprocess
 import sys
+import time
 from html import escape
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -23,6 +24,7 @@ from ..knowledge_index import (
 )
 from ..pack_resolution import iter_compatible_packs
 from ..packs.loader import DEFAULT_PACK_NAME, PRIMARY_PACK_NAME
+from ..pulse import initial_positions, tail_events
 from ..runtime import VaultLayout, resolve_vault_dir
 from .reuse_report import build_reuse_report_payload
 from ..ui.view_models import (
@@ -97,6 +99,7 @@ def _shell_nav_items(requested_pack: str = "") -> list[tuple[str, str]]:
         ("Briefing", "/briefing"),
         ("Actions", "/actions"),
         ("Production", "/production"),
+        ("Workbench", "/workbench"),
     ]
     if _shell_supports_research_nav(requested_pack):
         items.extend(
@@ -3952,6 +3955,199 @@ def _render_writing_prompts_page(payload: dict) -> str:
     )
 
 
+_SHELL_BODY_OPEN = '<div class="shell-body">'
+
+
+def _fragment_from_page(page_html: str) -> str:
+    """Extract the body content from a ``_layout``-wrapped page.
+
+    Phase 37 reuses every existing page renderer for the Workbench panes by
+    un-wrapping the chrome instead of refactoring each renderer.
+
+    Strategy: find the literal ``shell-body`` opener, then walk forward
+    through the body counting balanced ``<div ...>`` / ``</div>`` to locate
+    the matching close. This is whitespace-insensitive and tolerates inner
+    ``<div>`` tags inside the body content.
+
+    Returns the raw body HTML. Falls back to the full page if the opening
+    marker is not found (defensive — never raise).
+    """
+    open_idx = page_html.find(_SHELL_BODY_OPEN)
+    if open_idx == -1:
+        return page_html
+    cursor = open_idx + len(_SHELL_BODY_OPEN)
+    depth = 1
+    n = len(page_html)
+    while cursor < n and depth > 0:
+        next_open = page_html.find("<div", cursor)
+        next_close = page_html.find("</div>", cursor)
+        if next_close == -1:
+            return page_html
+        if next_open != -1 and next_open < next_close:
+            # Skip past the opening tag's `>` to avoid matching attributes.
+            tag_end = page_html.find(">", next_open)
+            if tag_end == -1:
+                return page_html
+            depth += 1
+            cursor = tag_end + 1
+        else:
+            depth -= 1
+            if depth == 0:
+                return page_html[open_idx + len(_SHELL_BODY_OPEN) : next_close].strip("\n")
+            cursor = next_close + len("</div>")
+    return page_html
+
+
+def _render_pulse_fragment() -> str:
+    """Phase 37 — self-contained Pulse SSE consumer.
+
+    The fragment opens an ``EventSource`` against ``/pulse/stream`` and
+    appends frames into a tight scrolling list. Designed for the Workbench
+    bottom pane; works equally well as a standalone iframe.
+    """
+    return (
+        "<section class='pulse'>"
+        "<style>"
+        ".pulse{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.78rem;}"
+        ".pulse ul{list-style:none;margin:0;padding:.4rem;max-height:240px;overflow:auto;"
+        "background:#0e1116;color:#d6deeb;border-radius:6px;}"
+        ".pulse li{margin:.1rem 0;white-space:pre-wrap;}"
+        ".pulse li .ts{color:#7c8593;margin-right:.4rem;}"
+        ".pulse li .et{color:#82aaff;margin-right:.4rem;}"
+        ".pulse li .pk{color:#c792ea;margin-right:.4rem;}"
+        ".pulse .empty{color:#7c8593;padding:.4rem;}"
+        "</style>"
+        "<ul id='pulse-feed'><li class='empty'>Waiting for events…</li></ul>"
+        "<script>(function(){"
+        "var feed=document.getElementById('pulse-feed');"
+        "var empty=feed.querySelector('.empty');"
+        "var src=new EventSource('/pulse/stream');"
+        "src.onmessage=function(ev){"
+        "if(empty){empty.remove();empty=null;}"
+        "try{var obj=JSON.parse(ev.data);"
+        "var li=document.createElement('li');"
+        "var ts=document.createElement('span');ts.className='ts';ts.textContent=obj.ts||'';"
+        "var et=document.createElement('span');et.className='et';et.textContent=obj.event_type||'';"
+        "var pk=document.createElement('span');pk.className='pk';pk.textContent=obj.pack||'';"
+        "var body=document.createElement('span');"
+        "var keys=Object.keys(obj).filter(function(k){"
+        "return k!=='ts'&&k!=='event_type'&&k!=='pack'&&k!=='event_id'&&k!=='session_id';});"
+        "body.textContent=keys.slice(0,3).map(function(k){"
+        "return k+'='+JSON.stringify(obj[k]).slice(0,80);}).join(' ');"
+        "li.appendChild(ts);li.appendChild(et);li.appendChild(pk);li.appendChild(body);"
+        "feed.appendChild(li);"
+        "while(feed.children.length>200){feed.removeChild(feed.firstChild);}"
+        "feed.scrollTop=feed.scrollHeight;"
+        "}catch(e){/* swallow */}};"
+        "src.onerror=function(){src.close();};"
+        "})();</script>"
+        "</section>"
+    )
+
+
+def _render_pulse_page() -> str:
+    fragment = _render_pulse_fragment()
+    return (
+        "<!doctype html><html><head><meta charset='utf-8'>"
+        "<title>Pulse</title>"
+        "<style>body{font-family:system-ui,sans-serif;max-width:1080px;margin:1.5rem auto;padding:0 1rem}"
+        "h1{margin-bottom:.4rem}p.muted{color:#71675d}"
+        "</style></head><body>"
+        "<h1>Pulse</h1>"
+        "<p class='muted'>Live tail of <code>60-Logs/*.jsonl</code> (pipeline, reuse, "
+        "evidence, open-questions). Polls once per second.</p>"
+        f"{fragment}</body></html>"
+    )
+
+
+def _render_workbench_page(*, object_id: str, requested_pack: str) -> str:
+    """Phase 37 — 4-pane reviewer surface composed from existing fragments.
+
+    Layout (CSS grid):
+
+        ┌───────────────┬──────────────────────────┬───────────────┐
+        │ Candidates    │ Object body (top)        │ Actions       │
+        │ (left)        │ Briefing  (bottom)       │ (right)       │
+        ├───────────────┴──────────────────────────┴───────────────┤
+        │ Pulse (full-width)                                       │
+        └──────────────────────────────────────────────────────────┘
+
+    Selecting an object_id is a query-string param so back/forward navigation
+    just works. Iframes post a ``select_object`` message to the parent on
+    candidate clicks; the parent updates child ``src`` attributes and
+    rewrites ``location.search`` via ``history.replaceState``.
+    """
+    # Fragment URLs. Candidate / Briefing / Actions are pack-aware but do not
+    # care about the object id; Object pane needs the id and is hidden when
+    # none is selected (the iframe falls back to the Objects index).
+    cand_src = "/candidates/fragment" + (f"?pack={quote(requested_pack, safe='')}" if requested_pack else "")
+    actions_src = "/actions/fragment" + (f"?pack={quote(requested_pack, safe='')}" if requested_pack else "")
+    briefing_src = "/briefing/fragment" + (f"?pack={quote(requested_pack, safe='')}" if requested_pack else "")
+    object_src = (
+        f"/object/fragment?id={quote(object_id, safe='')}"
+        + (f"&pack={quote(requested_pack, safe='')}" if requested_pack else "")
+        if object_id
+        else "/objects" + (f"?pack={quote(requested_pack, safe='')}" if requested_pack else "")
+    )
+    pulse_src = "/pulse/fragment"
+
+    return (
+        "<!doctype html><html lang='en'><head><meta charset='utf-8'>"
+        "<meta name='viewport' content='width=device-width, initial-scale=1' />"
+        "<title>Workbench</title>"
+        "<style>"
+        "*{box-sizing:border-box}"
+        "body{margin:0;font-family:ui-sans-serif,system-ui,sans-serif;background:#f7f6f2;color:#1f1a17}"
+        "header{padding:.6rem 1rem;border-bottom:1px solid #e7e1d8;display:flex;gap:1rem;align-items:center}"
+        "header h1{font-size:1rem;margin:0;color:#9f4f24}"
+        "header .meta{color:#71675d;font-size:.85rem}"
+        ".grid{display:grid;height:calc(100vh - 56px);"
+        "grid-template-columns:280px 1fr 280px;"
+        "grid-template-rows:1fr 1fr 220px;"
+        "gap:1px;background:#e7e1d8;}"
+        ".pane{background:#fffdfa;overflow:auto}"
+        ".pane iframe{width:100%;height:100%;border:0;display:block}"
+        ".pane.cand{grid-row:1/3}"
+        ".pane.obj{grid-row:1/2}"
+        ".pane.brief{grid-row:2/3}"
+        ".pane.act{grid-row:1/3}"
+        ".pane.pulse{grid-column:1/4;grid-row:3/4}"
+        "</style></head><body>"
+        "<header>"
+        "<h1>Workbench</h1>"
+        f"<span class='meta'>object: <code id='wb-object'>{escape(object_id) or '∅'}</code></span>"
+        f"<span class='meta'>pack: <code>{escape(requested_pack) or '∅'}</code></span>"
+        "<a href='/' style='margin-left:auto;color:#9f4f24;text-decoration:none'>← Shell</a>"
+        "</header>"
+        "<div class='grid'>"
+        f"<section class='pane cand'><iframe id='pane-cand' src='{escape(cand_src)}'></iframe></section>"
+        f"<section class='pane obj'><iframe id='pane-obj' src='{escape(object_src)}'></iframe></section>"
+        f"<section class='pane brief'><iframe id='pane-brief' src='{escape(briefing_src)}'></iframe></section>"
+        f"<section class='pane act'><iframe id='pane-act' src='{escape(actions_src)}'></iframe></section>"
+        f"<section class='pane pulse'><iframe id='pane-pulse' src='{escape(pulse_src)}'></iframe></section>"
+        "</div>"
+        "<script>(function(){"
+        f"var pack={json.dumps(requested_pack)};"
+        "function selectObject(id){"
+        "var packQs=pack?'&pack='+encodeURIComponent(pack):'';"
+        "var packQsLead=pack?'?pack='+encodeURIComponent(pack):'';"
+        "document.getElementById('pane-obj').src=id"
+        "?'/object/fragment?id='+encodeURIComponent(id)+packQs"
+        ":'/objects'+packQsLead;"
+        "document.getElementById('wb-object').textContent=id||'∅';"
+        "var url=new URL(window.location.href);"
+        "if(id){url.searchParams.set('object_id',id);}else{url.searchParams.delete('object_id');}"
+        "history.replaceState({},'',url.toString());"
+        "}"
+        "window.addEventListener('message',function(ev){"
+        "var d=ev.data;if(!d||typeof d!=='object')return;"
+        "if(d.type==='select_object'&&typeof d.id==='string'){selectObject(d.id);}"
+        "});"
+        "})();</script>"
+        "</body></html>"
+    )
+
+
 def create_server(
     vault_dir: Path | str, *, host: str = "127.0.0.1", port: int = 8787
 ) -> ThreadingHTTPServer:
@@ -4034,13 +4230,15 @@ def create_server(
                     pack_name = query.get("pack", [""])[0] or None
                     self._write_json(build_briefing_payload(resolved_vault, pack_name=pack_name))
                     return
-                if path == "/briefing":
+                if path in {"/briefing", "/briefing/fragment"}:
                     pack_name = query.get("pack", [""])[0] or None
-                    self._write_html(
-                        _render_briefing_page(
-                            build_briefing_payload(resolved_vault, pack_name=pack_name)
-                        )
+                    page = _render_briefing_page(
+                        build_briefing_payload(resolved_vault, pack_name=pack_name)
                     )
+                    if path == "/briefing/fragment":
+                        self._write_html(_fragment_from_page(page))
+                    else:
+                        self._write_html(page)
                     return
                 if path == "/api/signals":
                     q = query.get("q", [""])[0]
@@ -4082,7 +4280,7 @@ def create_server(
                         )
                     )
                     return
-                if path == "/candidates":
+                if path in {"/candidates", "/candidates/fragment"}:
                     q = query.get("q", [""])[0]
                     pack_name = query.get("pack", [""])[0] or None
                     candidate_warning = query.get("candidate_warning", [""])[0]
@@ -4096,7 +4294,11 @@ def create_server(
                         query=q,
                     )
                     payload["candidate_warning"] = candidate_warning
-                    self._write_html(_render_candidates_page(payload))
+                    page = _render_candidates_page(payload)
+                    if path == "/candidates/fragment":
+                        self._write_html(_fragment_from_page(page))
+                    else:
+                        self._write_html(page)
                     return
                 if path == "/api/evolution":
                     q = query.get("q", [""])[0]
@@ -4142,13 +4344,17 @@ def create_server(
                         build_object_page_payload(resolved_vault, object_id, pack_name=pack_name)
                     )
                     return
-                if path == "/object":
+                if path in {"/object", "/object/fragment"}:
                     object_id = self._required(query, "id")
                     pack_name = query.get("pack", [""])[0] or None
                     payload = build_object_page_payload(
                         resolved_vault, object_id, pack_name=pack_name
                     )
-                    self._write_html(_render_object_page(payload))
+                    page = _render_object_page(payload)
+                    if path == "/object/fragment":
+                        self._write_html(_fragment_from_page(page))
+                    else:
+                        self._write_html(page)
                     return
                 if path == "/api/topic":
                     object_id = self._required(query, "id")
@@ -4314,7 +4520,7 @@ def create_server(
                         )
                     )
                     return
-                if path == "/actions":
+                if path in {"/actions", "/actions/fragment"}:
                     status = query.get("status", [""])[0] or None
                     q = query.get("q", [""])[0]
                     pack_name = query.get("pack", [""])[0] or None
@@ -4324,7 +4530,11 @@ def create_server(
                         status=status,
                         query=q,
                     )
-                    self._write_html(_render_actions_page(payload))
+                    page = _render_actions_page(payload)
+                    if path == "/actions/fragment":
+                        self._write_html(_fragment_from_page(page))
+                    else:
+                        self._write_html(page)
                     return
                 if path == "/api/summaries":
                     q = query.get("q", [""])[0]
@@ -4430,6 +4640,30 @@ def create_server(
                         self._write_html(_render_writing_prompts_fragment(payload))
                     else:
                         self._write_html(_render_writing_prompts_page(payload))
+                    return
+                if path == "/workbench":
+                    object_id = query.get("object_id", [""])[0]
+                    pack_name = query.get("pack", [""])[0] or ""
+                    self._write_html(
+                        _render_workbench_page(
+                            object_id=object_id, requested_pack=pack_name
+                        )
+                    )
+                    return
+                if path == "/pulse":
+                    self._write_html(_render_pulse_page())
+                    return
+                if path == "/pulse/fragment":
+                    self._write_html(_render_pulse_fragment())
+                    return
+                if path == "/pulse/stream":
+                    raw_max = query.get("max_polls", [""])[0]
+                    raw_interval = query.get("poll_interval", [""])[0]
+                    max_polls = int(raw_max) if raw_max else None
+                    poll_interval = float(raw_interval) if raw_interval else 1.0
+                    self._stream_pulse_sse(
+                        poll_interval=poll_interval, max_polls=max_polls
+                    )
                     return
                 self.send_error(404, "Not Found")
             except ValueError as exc:
@@ -4816,6 +5050,62 @@ def create_server(
             self.send_header("Content-Length", str(len(body)))
             self.end_headers()
             self.wfile.write(body)
+
+        def _stream_pulse_sse(
+            self,
+            *,
+            poll_interval: float = 1.0,
+            max_polls: int | None = None,
+        ) -> None:
+            """Stream events from ``60-Logs/*.jsonl`` to the client as SSE.
+
+            Long-lived response. ``max_polls`` is for tests; production callers
+            leave it ``None`` (loop until the client disconnects). Each event
+            becomes one SSE frame with ``event:`` set to its ``event_type`` and
+            ``data:`` carrying the JSON-encoded payload — matching the closed
+            vocabulary documented in :mod:`event_emitter`.
+            """
+            layout = VaultLayout.from_vault(resolved_vault)
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream; charset=utf-8")
+            self.send_header("Cache-Control", "no-cache")
+            self.send_header("X-Accel-Buffering", "no")
+            self.end_headers()
+
+            try:
+                self.wfile.write(b": ovp pulse stream\n\n")
+                self.wfile.flush()
+            except (BrokenPipeError, ConnectionResetError):
+                return
+
+            positions = initial_positions(layout)
+            polls = 0
+            while True:
+                if max_polls is not None and polls >= max_polls:
+                    return
+                polls += 1
+                events, positions = tail_events(layout, since_position=positions)
+                for event in events:
+                    event_id = str(event.get("event_id") or "")
+                    event_type = str(event.get("event_type") or "message")
+                    data = json.dumps(event, ensure_ascii=False)
+                    frame = (
+                        (f"id: {event_id}\n" if event_id else "")
+                        + f"event: {event_type}\n"
+                        + f"data: {data}\n\n"
+                    ).encode("utf-8")
+                    try:
+                        self.wfile.write(frame)
+                        self.wfile.flush()
+                    except (BrokenPipeError, ConnectionResetError):
+                        return
+                if not events:
+                    try:
+                        self.wfile.write(b": keepalive\n\n")
+                        self.wfile.flush()
+                    except (BrokenPipeError, ConnectionResetError):
+                        return
+                time.sleep(poll_interval)
 
         def _write_bytes(self, body: bytes, content_type: str) -> None:
             self.send_response(200)

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -3958,6 +3958,26 @@ def _render_writing_prompts_page(payload: dict) -> str:
 _SHELL_BODY_OPEN = '<div class="shell-body">'
 
 
+# Bridge script appended to every fragment so iframe clicks on `/object?id=...`
+# anchors become `postMessage({type:'select_object', id})` calls — the
+# Workbench parent listens for this and re-points the object pane without a
+# full page reload.
+_FRAGMENT_BRIDGE_SCRIPT = (
+    "<script>(function(){"
+    "if(window.parent===window)return;"
+    "document.addEventListener('click',function(ev){"
+    "var a=ev.target&&ev.target.closest&&ev.target.closest('a[href]');"
+    "if(!a)return;"
+    "var href=a.getAttribute('href')||'';"
+    "var m=href.match(/\\/object(?:\\/fragment)?\\?(?:[^#]*&)?id=([^&#]+)/);"
+    "if(!m)return;"
+    "ev.preventDefault();"
+    "window.parent.postMessage({type:'select_object',id:decodeURIComponent(m[1])},'*');"
+    "},true);"
+    "})();</script>"
+)
+
+
 def _fragment_from_page(page_html: str) -> str:
     """Extract the body content from a ``_layout``-wrapped page.
 
@@ -3968,6 +3988,10 @@ def _fragment_from_page(page_html: str) -> str:
     through the body counting balanced ``<div ...>`` / ``</div>`` to locate
     the matching close. This is whitespace-insensitive and tolerates inner
     ``<div>`` tags inside the body content.
+
+    A small bridge script is appended so anchor clicks on ``/object?id=...``
+    bubble up to the Workbench parent as ``select_object`` messages instead
+    of navigating the iframe in isolation.
 
     Returns the raw body HTML. Falls back to the full page if the opening
     marker is not found (defensive — never raise).
@@ -3993,7 +4017,8 @@ def _fragment_from_page(page_html: str) -> str:
         else:
             depth -= 1
             if depth == 0:
-                return page_html[open_idx + len(_SHELL_BODY_OPEN) : next_close].strip("\n")
+                body = page_html[open_idx + len(_SHELL_BODY_OPEN) : next_close].strip("\n")
+                return body + _FRAGMENT_BRIDGE_SCRIPT
             cursor = next_close + len("</div>")
     return page_html
 
@@ -4022,7 +4047,7 @@ def _render_pulse_fragment() -> str:
         "var feed=document.getElementById('pulse-feed');"
         "var empty=feed.querySelector('.empty');"
         "var src=new EventSource('/pulse/stream');"
-        "src.onmessage=function(ev){"
+        "function render(ev){"
         "if(empty){empty.remove();empty=null;}"
         "try{var obj=JSON.parse(ev.data);"
         "var li=document.createElement('li');"
@@ -4038,7 +4063,14 @@ def _render_pulse_fragment() -> str:
         "feed.appendChild(li);"
         "while(feed.children.length>200){feed.removeChild(feed.firstChild);}"
         "feed.scrollTop=feed.scrollHeight;"
-        "}catch(e){/* swallow */}};"
+        "}catch(e){/* swallow */}}"
+        # Server emits named SSE frames (`event: <event_type>`) — onmessage
+        # only fires for default-named frames, so subscribe to every event_type
+        # in our closed vocabulary plus a generic 'message' fallback.
+        "var TYPES=['trusted_reuse_event','promotion','relation_promoted',"
+        "'evidence_reverified','evidence_verified','zone_violation','feedback_yield'];"
+        "TYPES.forEach(function(t){src.addEventListener(t,render);});"
+        "src.onmessage=render;"
         "src.onerror=function(){src.close();};"
         "})();</script>"
         "</section>"
@@ -4661,6 +4693,12 @@ def create_server(
                     raw_interval = query.get("poll_interval", [""])[0]
                     max_polls = int(raw_max) if raw_max else None
                     poll_interval = float(raw_interval) if raw_interval else 1.0
+                    if poll_interval <= 0:
+                        self.send_error(400, "poll_interval must be > 0")
+                        return
+                    if max_polls is not None and max_polls < 0:
+                        self.send_error(400, "max_polls must be >= 0")
+                        return
                     self._stream_pulse_sse(
                         poll_interval=poll_interval, max_polls=max_polls
                     )

--- a/src/ovp_pipeline/mcp_server.py
+++ b/src/ovp_pipeline/mcp_server.py
@@ -1,0 +1,429 @@
+"""Phase 37 — hand-rolled JSON-RPC 2.0 over stdio MCP server.
+
+Exposes three compiler primitives that Phases 32–36 already shipped as
+JSON-serializable Python functions:
+
+* ``evaluate_promotion`` — wraps :mod:`promotion_policy.evaluate_concept`,
+  ``evaluate_relation``, and ``evaluate_workspace``. Each returns a
+  :class:`PolicyDecision` frozen dataclass; we ``asdict`` it for the wire.
+* ``assemble_prompt`` — wraps :func:`prompt_assembler.assemble`. Side effect:
+  emits one ``trusted_reuse_event`` per resolved object_id.
+* ``route_feedback`` — wraps :mod:`feedback_router`. Writes to the candidate
+  registry, ``open-questions.jsonl``, ``Writing-Prompts.md``, or the relation
+  review queue depending on the ``stream`` discriminator.
+
+Why hand-rolled rather than the official ``mcp`` SDK: the rest of this
+codebase has zero web dependencies (stdlib ``http.server`` for UI, sqlite3
+for storage). MCP-over-stdio is a line-delimited JSON-RPC 2.0 protocol; the
+minimal verb set Claude Desktop actually invokes (``initialize``,
+``tools/list``, ``tools/call``) fits in ~250 LOC of stdlib.
+
+Forward-compat: any deferred verb (``resources/*``, ``prompts/*``,
+``sampling/*``) returns the JSON-RPC ``method-not-found`` error envelope, not
+a Python traceback.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, Callable, IO
+
+from .concept_registry import ConceptEntry
+from .feedback_router import (
+    CandidateConcept,
+    OpenQuestion,
+    WritingPrompt,
+    route_candidate_concepts,
+    route_open_questions,
+    route_proposed_relations,
+    route_writing_prompts,
+)
+from .extraction.semantic_relations import SemanticRelationCandidate
+from .pack_resolution import coerce_pack
+from .prompt_assembler import assemble as _assemble_prompt
+from .promotion_policy import (
+    evaluate_concept,
+    evaluate_relation,
+    evaluate_workspace,
+)
+
+
+# JSON-RPC 2.0 error codes (subset we actually emit).
+_PARSE_ERROR = -32700
+_INVALID_REQUEST = -32600
+_METHOD_NOT_FOUND = -32601
+_INVALID_PARAMS = -32602
+_INTERNAL_ERROR = -32603
+
+
+# ---------------------------------------------------------------------------
+# Tool descriptors (returned by tools/list verbatim)
+# ---------------------------------------------------------------------------
+
+
+_TOOLS_DESCRIPTORS: tuple[dict[str, Any], ...] = (
+    {
+        "name": "evaluate_promotion",
+        "description": (
+            "Decide the promotion lane for a concept, semantic relation, or "
+            "workspace draft. Returns a PolicyDecision dict with lane, "
+            "reason_code, blocking_facts, payload."
+        ),
+        "side_effects": "none (pure function)",
+        "inputSchema": {
+            "type": "object",
+            "required": ["candidate_kind", "payload", "pack"],
+            "properties": {
+                "candidate_kind": {
+                    "type": "string",
+                    "enum": ["concept", "relation", "workspace"],
+                },
+                "payload": {"type": "object"},
+                "pack": {"type": "string"},
+                "has_open_contradiction": {"type": "boolean"},
+                "evidence_kinds": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                },
+            },
+        },
+    },
+    {
+        "name": "assemble_prompt",
+        "description": (
+            "Join slot_specs into a single prompt string and emit one "
+            "trusted_reuse_event per resolved canonical object_id."
+        ),
+        "side_effects": "writes 60-Logs/reuse-events.jsonl",
+        "inputSchema": {
+            "type": "object",
+            "required": ["slot_specs", "object_ids", "pack"],
+            "properties": {
+                "slot_specs": {"type": "array", "items": {"type": "string"}},
+                "object_ids": {"type": "array", "items": {"type": "string"}},
+                "pack": {"type": "string"},
+                "consumer_ref": {"type": "string"},
+                "separator": {"type": "string"},
+                "session_id": {"type": "string"},
+            },
+        },
+    },
+    {
+        "name": "route_feedback",
+        "description": (
+            "Route a batch of feedback items into the matching stream. "
+            "stream ∈ {candidate_concept, open_question, writing_prompt, "
+            "proposed_relation}."
+        ),
+        "side_effects": (
+            "writes one of: concept registry, open-questions.jsonl, "
+            "Writing-Prompts.md, or the semantic-relations review queue"
+        ),
+        "inputSchema": {
+            "type": "object",
+            "required": ["stream", "items", "pack"],
+            "properties": {
+                "stream": {
+                    "type": "string",
+                    "enum": [
+                        "candidate_concept",
+                        "open_question",
+                        "writing_prompt",
+                        "proposed_relation",
+                    ],
+                },
+                "items": {"type": "array", "items": {"type": "object"}},
+                "pack": {"type": "string"},
+            },
+        },
+    },
+)
+
+
+# ---------------------------------------------------------------------------
+# Server
+# ---------------------------------------------------------------------------
+
+
+class MCPServer:
+    """JSON-RPC 2.0 dispatcher for the three compiler primitives.
+
+    A single instance is bound to a vault directory. Holds no per-call state
+    beyond what each tool already persists through its existing emit paths.
+    """
+
+    PROTOCOL_VERSION = "2026-04-22"
+    SERVER_INFO = {"name": "ovp-mcp", "version": "0.1.0"}
+
+    def __init__(self, vault_dir: Path | str) -> None:
+        self.vault_dir = Path(vault_dir)
+        self._tools: dict[str, Callable[..., dict[str, Any]]] = {
+            "evaluate_promotion": self._tool_evaluate_promotion,
+            "assemble_prompt": self._tool_assemble_prompt,
+            "route_feedback": self._tool_route_feedback,
+        }
+
+    # -- Public surface -----------------------------------------------------
+
+    def serve(
+        self,
+        *,
+        stdin: IO[str] | None = None,
+        stdout: IO[str] | None = None,
+    ) -> None:
+        """Read JSON-RPC requests line-by-line from stdin, write replies to stdout.
+
+        One request per line, one reply per line — newline-delimited so a
+        single OS pipe can carry both directions without framing headers.
+        Loop exits when stdin reaches EOF.
+        """
+        in_stream = stdin or sys.stdin
+        out_stream = stdout or sys.stdout
+        for raw_line in in_stream:
+            line = raw_line.strip()
+            if not line:
+                continue
+            response = self.handle_line(line)
+            if response is None:
+                continue
+            out_stream.write(json.dumps(response, ensure_ascii=False) + "\n")
+            out_stream.flush()
+
+    def list_tools(self) -> list[dict[str, Any]]:
+        """Return the public tool descriptors as a fresh list."""
+        return [dict(d) for d in _TOOLS_DESCRIPTORS]
+
+    def call_tool(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        """Invoke a tool by name and return its result dict.
+
+        Raises ``KeyError`` for unknown tools and ``TypeError`` /
+        ``ValueError`` for malformed arguments — the JSON-RPC layer turns
+        those into the appropriate error envelope.
+        """
+        impl = self._tools.get(name)
+        if impl is None:
+            raise KeyError(name)
+        return impl(**arguments)
+
+    # -- JSON-RPC plumbing --------------------------------------------------
+
+    def handle_line(self, line: str) -> dict[str, Any] | None:
+        """Parse a single JSON-RPC line and return the reply dict (or None
+        for notifications, which have no ``id``)."""
+        try:
+            request = json.loads(line)
+        except json.JSONDecodeError as exc:
+            return _error_envelope(None, _PARSE_ERROR, f"Invalid JSON: {exc}")
+        if not isinstance(request, dict):
+            return _error_envelope(None, _INVALID_REQUEST, "Request must be an object")
+
+        request_id = request.get("id")
+        method = request.get("method")
+        params = request.get("params") or {}
+        if not isinstance(method, str) or not method:
+            return _error_envelope(request_id, _INVALID_REQUEST, "Missing method")
+        if not isinstance(params, dict):
+            return _error_envelope(
+                request_id, _INVALID_PARAMS, "params must be an object"
+            )
+
+        try:
+            result = self._dispatch(method, params)
+        except _MethodNotFound:
+            return _error_envelope(
+                request_id,
+                _METHOD_NOT_FOUND,
+                f"Method not implemented: {method}",
+            )
+        except _InvalidParams as exc:
+            return _error_envelope(request_id, _INVALID_PARAMS, str(exc))
+        except Exception as exc:  # noqa: BLE001 — guard the loop
+            return _error_envelope(request_id, _INTERNAL_ERROR, str(exc))
+
+        # Notifications (no id) get no reply.
+        if request_id is None:
+            return None
+        return {"jsonrpc": "2.0", "id": request_id, "result": result}
+
+    def _dispatch(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        if method == "initialize":
+            return {
+                "protocolVersion": self.PROTOCOL_VERSION,
+                "capabilities": {"tools": {}},
+                "serverInfo": self.SERVER_INFO,
+            }
+        if method == "tools/list":
+            return {"tools": self.list_tools()}
+        if method == "tools/call":
+            name = params.get("name")
+            arguments = params.get("arguments") or {}
+            if not isinstance(name, str) or not name:
+                raise _InvalidParams("tools/call requires a string 'name'")
+            if not isinstance(arguments, dict):
+                raise _InvalidParams("tools/call 'arguments' must be an object")
+            try:
+                result = self.call_tool(name, arguments)
+            except KeyError:
+                raise _InvalidParams(f"Unknown tool: {name}")
+            except TypeError as exc:
+                raise _InvalidParams(str(exc))
+            return {"result": result}
+        raise _MethodNotFound(method)
+
+    # -- Tool implementations ----------------------------------------------
+
+    def _tool_evaluate_promotion(
+        self,
+        *,
+        candidate_kind: str,
+        payload: dict[str, Any],
+        pack: str,
+        has_open_contradiction: bool = False,
+        evidence_kinds: list[str] | None = None,
+    ) -> dict[str, Any]:
+        pack_obj = coerce_pack(pack)
+        if candidate_kind == "concept":
+            entry = _concept_entry_from_payload(payload)
+            decision = evaluate_concept(
+                entry,
+                pack=pack_obj,
+                has_open_contradiction=has_open_contradiction,
+                evidence_kinds=frozenset(evidence_kinds or ()),
+            )
+        elif candidate_kind == "relation":
+            candidate = SemanticRelationCandidate.from_dict(payload)
+            decision = evaluate_relation(
+                candidate,
+                pack=pack_obj,
+                has_open_contradiction=has_open_contradiction,
+            )
+        elif candidate_kind == "workspace":
+            draft = Path(str(payload.get("draft", "")))
+            target = Path(str(payload.get("target", "")))
+            decision = evaluate_workspace(draft, target, pack=pack_obj)
+        else:
+            raise _InvalidParams(f"Unknown candidate_kind: {candidate_kind}")
+        result = asdict(decision)
+        result["blocking_facts"] = list(decision.blocking_facts)
+        return result
+
+    def _tool_assemble_prompt(
+        self,
+        *,
+        slot_specs: list[str],
+        object_ids: list[str],
+        pack: str,
+        consumer_ref: str = "",
+        separator: str = "\n\n",
+        session_id: str | None = None,
+    ) -> dict[str, Any]:
+        text = _assemble_prompt(
+            vault_dir=self.vault_dir,
+            pack=pack,
+            slot_specs=list(slot_specs),
+            object_ids=list(object_ids),
+            consumer_ref=consumer_ref,
+            separator=separator,
+            session_id=session_id,
+        )
+        return {"text": text, "object_ids": list(object_ids)}
+
+    def _tool_route_feedback(
+        self,
+        *,
+        stream: str,
+        items: list[dict[str, Any]],
+        pack: str,
+    ) -> dict[str, Any]:
+        pack_obj = coerce_pack(pack)
+        if stream == "candidate_concept":
+            decoded = [
+                CandidateConcept(
+                    term=str(item.get("term") or ""),
+                    definition=str(item.get("definition") or ""),
+                    area=str(item.get("area") or ""),
+                )
+                for item in items
+            ]
+            written = route_candidate_concepts(
+                decoded, vault_dir=self.vault_dir, pack=pack_obj
+            )
+            return {"stream": stream, "written": written}
+        if stream == "open_question":
+            decoded_q = [
+                OpenQuestion(
+                    question=str(item.get("question") or ""),
+                    consumer_ref=str(item.get("consumer_ref") or ""),
+                )
+                for item in items
+            ]
+            written = route_open_questions(
+                decoded_q, vault_dir=self.vault_dir, pack=pack_obj
+            )
+            return {"stream": stream, "written": written}
+        if stream == "writing_prompt":
+            decoded_p = [
+                WritingPrompt(
+                    prompt=str(item.get("prompt") or ""),
+                    rationale=str(item.get("rationale") or ""),
+                )
+                for item in items
+            ]
+            written = route_writing_prompts(
+                decoded_p, vault_dir=self.vault_dir, pack=pack_obj
+            )
+            return {"stream": stream, "written": written}
+        if stream == "proposed_relation":
+            decoded_r = [SemanticRelationCandidate.from_dict(item) for item in items]
+            paths = route_proposed_relations(
+                decoded_r, vault_dir=self.vault_dir, pack=pack_obj
+            )
+            return {"stream": stream, "written": len(paths), "paths": [str(p) for p in paths]}
+        raise _InvalidParams(f"Unknown stream: {stream}")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _MethodNotFound(Exception):
+    """Sentinel for the JSON-RPC method_not_found envelope."""
+
+
+class _InvalidParams(Exception):
+    """Sentinel for the JSON-RPC invalid_params envelope."""
+
+
+def _error_envelope(
+    request_id: Any, code: int, message: str
+) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "error": {"code": code, "message": message},
+    }
+
+
+def _concept_entry_from_payload(payload: dict[str, Any]) -> ConceptEntry:
+    """Build a ``ConceptEntry`` from the wire payload.
+
+    Only ``slug`` is required; everything else has a sensible default. This
+    is a pure transport adapter — no validation beyond the dataclass's own
+    ``__post_init__`` checks.
+    """
+    slug = str(payload.get("slug") or "")
+    if not slug:
+        raise _InvalidParams("concept payload requires 'slug'")
+    return ConceptEntry(
+        slug=slug,
+        title=str(payload.get("title") or slug),
+        aliases=list(payload.get("aliases") or []),
+        definition=str(payload.get("definition") or ""),
+        area=str(payload.get("area") or ""),
+        source_count=int(payload.get("source_count") or 0),
+        evidence_count=int(payload.get("evidence_count") or 0),
+    )

--- a/src/ovp_pipeline/mcp_server.py
+++ b/src/ovp_pipeline/mcp_server.py
@@ -29,7 +29,7 @@ import json
 import sys
 from dataclasses import asdict
 from pathlib import Path
-from typing import Any, Callable, IO
+from typing import Any, Callable, ClassVar, IO
 
 from .concept_registry import ConceptEntry
 from .feedback_router import (
@@ -155,8 +155,8 @@ class MCPServer:
     beyond what each tool already persists through its existing emit paths.
     """
 
-    PROTOCOL_VERSION = "2026-04-22"
-    SERVER_INFO = {"name": "ovp-mcp", "version": "0.1.0"}
+    PROTOCOL_VERSION: ClassVar[str] = "2026-04-22"
+    SERVER_INFO: ClassVar[dict[str, str]] = {"name": "ovp-mcp", "version": "0.1.0"}
 
     def __init__(self, vault_dir: Path | str) -> None:
         self.vault_dir = Path(vault_dir)
@@ -233,14 +233,22 @@ class MCPServer:
         try:
             result = self._dispatch(method, params)
         except _MethodNotFound:
+            # JSON-RPC 2.0 §4.1: notifications MUST NOT receive any reply,
+            # not even an error envelope.
+            if request_id is None:
+                return None
             return _error_envelope(
                 request_id,
                 _METHOD_NOT_FOUND,
                 f"Method not implemented: {method}",
             )
         except _InvalidParams as exc:
+            if request_id is None:
+                return None
             return _error_envelope(request_id, _INVALID_PARAMS, str(exc))
         except Exception as exc:  # noqa: BLE001 — guard the loop
+            if request_id is None:
+                return None
             return _error_envelope(request_id, _INTERNAL_ERROR, str(exc))
 
         # Notifications (no id) get no reply.
@@ -266,11 +274,22 @@ class MCPServer:
                 raise _InvalidParams("tools/call 'arguments' must be an object")
             try:
                 result = self.call_tool(name, arguments)
-            except KeyError:
-                raise _InvalidParams(f"Unknown tool: {name}")
+            except KeyError as exc:
+                raise _InvalidParams(f"Unknown tool: {name}") from exc
             except TypeError as exc:
-                raise _InvalidParams(str(exc))
-            return {"result": result}
+                raise _InvalidParams(str(exc)) from exc
+            # MCP tools/call result shape: a content array of typed parts
+            # plus an isError flag. We serialize the tool's dict as JSON text
+            # so MCP clients can both display it and parse it back. The raw
+            # dict is also exposed under "result" for callers that want to
+            # skip the JSON round-trip.
+            return {
+                "content": [
+                    {"type": "text", "text": json.dumps(result, ensure_ascii=False)}
+                ],
+                "isError": False,
+                "result": result,
+            }
         raise _MethodNotFound(method)
 
     # -- Tool implementations ----------------------------------------------
@@ -301,9 +320,15 @@ class MCPServer:
                 has_open_contradiction=has_open_contradiction,
             )
         elif candidate_kind == "workspace":
-            draft = Path(str(payload.get("draft", "")))
-            target = Path(str(payload.get("target", "")))
-            decision = evaluate_workspace(draft, target, pack=pack_obj)
+            draft_str = str(payload.get("draft", ""))
+            target_str = str(payload.get("target", ""))
+            if not draft_str or not target_str:
+                raise _InvalidParams(
+                    "workspace payload requires non-empty 'draft' and 'target'"
+                )
+            decision = evaluate_workspace(
+                Path(draft_str), Path(target_str), pack=pack_obj
+            )
         else:
             raise _InvalidParams(f"Unknown candidate_kind: {candidate_kind}")
         result = asdict(decision)

--- a/src/ovp_pipeline/pulse.py
+++ b/src/ovp_pipeline/pulse.py
@@ -1,0 +1,107 @@
+"""Phase 37 — Pulse: poll-based tail of the JSONL event logs.
+
+Phases 32–36 already declared a closed ``event_type`` vocabulary in
+:mod:`event_emitter`; Pulse is its first real-time consumer. The Workbench
+shell embeds Pulse in its bottom pane and any future UI (or external watcher)
+can consume the same stream over SSE.
+
+Design decisions:
+
+* **Polling, not inotify.** Human-scale traffic; zero new deps; no platform
+  forks. The SSE handler in ``ui_server`` sleeps ~1s between polls.
+* **Byte offsets per file**, not (file, line_no), so a file that is rewritten
+  out-of-band (e.g. log rotation in the future) is detected by truncation
+  rather than line drift.
+* **Open-by-name on every poll.** A new log file appearing mid-session
+  (``evidence-verifications.jsonl`` after the first ``ovp-evidence verify``)
+  enters the position dict at offset 0 on its first sighting and is read in
+  full from then on.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Iterable
+
+from .runtime import VaultLayout
+
+
+DEFAULT_LOGS: tuple[str, ...] = (
+    "pipeline.jsonl",
+    "reuse-events.jsonl",
+    "evidence-verifications.jsonl",
+    "open-questions.jsonl",
+)
+
+
+def tail_events(
+    layout: VaultLayout,
+    *,
+    since_position: dict[str, int] | None = None,
+    logs: Iterable[str] = DEFAULT_LOGS,
+) -> tuple[list[dict[str, object]], dict[str, int]]:
+    """Read all new lines across ``logs`` since the per-file byte offsets in
+    ``since_position`` and return ``(chronological_events, new_positions)``.
+
+    Iteration order across files: events from each file are appended, then the
+    full batch is sorted by ``ts`` so the SSE consumer sees a strict
+    chronological feed even when two files were appended to between polls.
+    Lines that fail to parse are silently skipped — JSONL is a log, not an
+    authoritative store.
+    """
+    positions: dict[str, int] = dict(since_position or {})
+    new_events: list[dict[str, object]] = []
+
+    for log_name in logs:
+        log_path = layout.logs_dir / log_name
+        if not log_path.exists():
+            # Reset to 0 so the file is read in full on its first appearance.
+            positions[log_name] = 0
+            continue
+
+        size = log_path.stat().st_size
+        offset = positions.get(log_name, 0)
+        if offset > size:
+            # File was truncated/rotated under us — start fresh.
+            offset = 0
+
+        if offset == size:
+            positions[log_name] = size
+            continue
+
+        with log_path.open("rb") as handle:
+            handle.seek(offset)
+            chunk = handle.read(size - offset)
+            new_offset = handle.tell()
+
+        for raw_line in chunk.splitlines():
+            stripped = raw_line.strip()
+            if not stripped:
+                continue
+            try:
+                obj = json.loads(stripped)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(obj, dict):
+                new_events.append(obj)
+
+        positions[log_name] = new_offset
+
+    new_events.sort(key=lambda event: str(event.get("ts") or ""))
+    return new_events, positions
+
+
+def initial_positions(
+    layout: VaultLayout, *, logs: Iterable[str] = DEFAULT_LOGS
+) -> dict[str, int]:
+    """Return the *current* end-of-file offset per log without emitting events.
+
+    Used by the SSE handler when a client connects without a ``Last-Event-ID``
+    header — we want only events from this point forward, not a replay of
+    everything ever logged.
+    """
+    positions: dict[str, int] = {}
+    for log_name in logs:
+        log_path = layout.logs_dir / log_name
+        positions[log_name] = log_path.stat().st_size if log_path.exists() else 0
+    return positions

--- a/src/ovp_pipeline/pulse.py
+++ b/src/ovp_pipeline/pulse.py
@@ -1,6 +1,6 @@
-"""Phase 37 — Pulse: poll-based tail of the JSONL event logs.
+"""Phase 37 - Pulse: poll-based tail of the JSONL event logs.
 
-Phases 32–36 already declared a closed ``event_type`` vocabulary in
+Phases 32-36 already declared a closed ``event_type`` vocabulary in
 :mod:`event_emitter`; Pulse is its first real-time consumer. The Workbench
 shell embeds Pulse in its bottom pane and any future UI (or external watcher)
 can consume the same stream over SSE.
@@ -16,6 +16,10 @@ Design decisions:
   (``evidence-verifications.jsonl`` after the first ``ovp-evidence verify``)
   enters the position dict at offset 0 on its first sighting and is read in
   full from then on.
+* **Partial-write safety.** A poll that races a partial JSONL append must not
+  advance the offset past the incomplete tail line. We split on newlines and
+  only commit the offset up to the last terminator we actually read; the
+  trailing partial bytes get re-read on the next poll once the writer flushes.
 """
 
 from __future__ import annotations
@@ -72,9 +76,15 @@ def tail_events(
         with log_path.open("rb") as handle:
             handle.seek(offset)
             chunk = handle.read(size - offset)
-            new_offset = handle.tell()
 
-        for raw_line in chunk.splitlines():
+        lines = chunk.splitlines(keepends=True)
+        if lines and not lines[-1].endswith((b"\n", b"\r")):
+            partial = lines.pop()
+            new_offset = offset + len(chunk) - len(partial)
+        else:
+            new_offset = offset + len(chunk)
+
+        for raw_line in lines:
             stripped = raw_line.strip()
             if not stripped:
                 continue

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -408,6 +408,38 @@ def test_evaluate_promotion_workspace_empty_paths_invalid(temp_vault: Path) -> N
 # ---------------------------------------------------------------------------
 
 
+def test_cli_call_invalid_params_returns_clean_error(
+    temp_vault: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``ovp-mcp --call`` must catch ``_InvalidParams`` (raised by tool
+    bodies for missing required fields) and emit a JSON error envelope on
+    stderr — never an unhandled traceback."""
+    from ovp_pipeline.commands.mcp import main
+
+    rc = main(
+        [
+            "--vault-dir",
+            str(temp_vault),
+            "--call",
+            "evaluate_promotion",
+            "--json",
+            json.dumps(
+                {
+                    "candidate_kind": "workspace",
+                    "pack": "default-knowledge",
+                    "payload": {"draft": "", "target": ""},
+                }
+            ),
+        ]
+    )
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert captured.err.strip()  # non-empty error
+    payload = json.loads(captured.err.strip())
+    assert "error" in payload
+    assert "non-empty" in payload["error"]
+
+
 def test_tools_call_result_has_mcp_content_array(temp_vault: Path) -> None:
     """``tools/call`` must return MCP-shaped content + isError so a generic
     MCP client can render the reply without knowing per-tool schemas."""

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -323,3 +323,116 @@ def test_call_tool_unknown_raises_keyerror(temp_vault: Path) -> None:
     server = MCPServer(temp_vault)
     with pytest.raises(KeyError):
         server.call_tool("nope", {})
+
+
+# ---------------------------------------------------------------------------
+# JSON-RPC 2.0 §4.1: notifications never receive any reply, even on error.
+# ---------------------------------------------------------------------------
+
+
+def test_notification_unknown_method_returns_no_reply(temp_vault: Path) -> None:
+    server = MCPServer(temp_vault)
+    reply = server.handle_line(json.dumps({"jsonrpc": "2.0", "method": "resources/read"}))
+    assert reply is None
+
+
+def test_notification_invalid_params_returns_no_reply(temp_vault: Path) -> None:
+    server = MCPServer(temp_vault)
+    reply = server.handle_line(
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {"name": "frobnicate", "arguments": {}},
+            }
+        )
+    )
+    assert reply is None
+
+
+def test_notification_internal_error_returns_no_reply(temp_vault: Path) -> None:
+    """A notification that triggers a generic exception inside a tool must
+    still get no reply."""
+    server = MCPServer(temp_vault)
+    reply = server.handle_line(
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {
+                    "name": "evaluate_promotion",
+                    "arguments": {
+                        "candidate_kind": "concept",
+                        "pack": "default-knowledge",
+                        # Missing required 'slug' raises _InvalidParams inside
+                        # the tool body.
+                        "payload": {"source_count": 1, "evidence_count": 1},
+                    },
+                },
+            }
+        )
+    )
+    assert reply is None
+
+
+# ---------------------------------------------------------------------------
+# Workspace candidate kind validation
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_promotion_workspace_empty_paths_invalid(temp_vault: Path) -> None:
+    server = MCPServer(temp_vault)
+    request = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 99,
+            "method": "tools/call",
+            "params": {
+                "name": "evaluate_promotion",
+                "arguments": {
+                    "candidate_kind": "workspace",
+                    "pack": "default-knowledge",
+                    "payload": {"draft": "", "target": ""},
+                },
+            },
+        }
+    )
+    reply = server.handle_line(request)
+    assert reply is not None
+    assert reply["error"]["code"] == -32602
+    assert "non-empty" in reply["error"]["message"]
+
+
+# ---------------------------------------------------------------------------
+# tools/call result follows the MCP shape
+# ---------------------------------------------------------------------------
+
+
+def test_tools_call_result_has_mcp_content_array(temp_vault: Path) -> None:
+    """``tools/call`` must return MCP-shaped content + isError so a generic
+    MCP client can render the reply without knowing per-tool schemas."""
+    server = MCPServer(temp_vault)
+    reply = server.handle_line(
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "evaluate_promotion",
+                    "arguments": {
+                        "candidate_kind": "concept",
+                        "pack": "default-knowledge",
+                        "payload": {"slug": "x", "source_count": 5, "evidence_count": 5},
+                    },
+                },
+            }
+        )
+    )
+    assert reply is not None
+    result = reply["result"]
+    assert result["isError"] is False
+    assert isinstance(result["content"], list)
+    assert result["content"][0]["type"] == "text"
+    parsed = json.loads(result["content"][0]["text"])
+    assert parsed["lane"] == "auto"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,325 @@
+"""Phase 37 — tests for the MCP stdio JSON-RPC server."""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from ovp_pipeline.mcp_server import MCPServer
+from ovp_pipeline.pulse import DEFAULT_LOGS  # noqa: F401  (sanity import)
+
+
+# ---------------------------------------------------------------------------
+# tools/list
+# ---------------------------------------------------------------------------
+
+
+def test_tools_list_returns_three_descriptors(temp_vault: Path) -> None:
+    server = MCPServer(temp_vault)
+    request = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+    reply = server.handle_line(request)
+    assert reply is not None
+    assert reply["jsonrpc"] == "2.0"
+    assert reply["id"] == 1
+    tools = reply["result"]["tools"]
+    names = sorted(t["name"] for t in tools)
+    assert names == ["assemble_prompt", "evaluate_promotion", "route_feedback"]
+    # Every descriptor must declare its side effects so MCP clients can gate
+    # writes when running a dry-run preview.
+    for tool in tools:
+        assert "side_effects" in tool
+        assert "inputSchema" in tool
+
+
+def test_initialize_returns_capability_block(temp_vault: Path) -> None:
+    server = MCPServer(temp_vault)
+    request = json.dumps({"jsonrpc": "2.0", "id": "boot", "method": "initialize"})
+    reply = server.handle_line(request)
+    assert reply is not None
+    result = reply["result"]
+    assert "protocolVersion" in result
+    assert result["serverInfo"]["name"] == "ovp-mcp"
+    assert "tools" in result["capabilities"]
+
+
+# ---------------------------------------------------------------------------
+# tools/call: evaluate_promotion
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_promotion_concept_legacy_or_rule(temp_vault: Path) -> None:
+    """default-knowledge is the permissive pack: source_count>=2 OR
+    evidence_count>=3 promotes. We pass evidence_count=4 and expect LANE_AUTO."""
+    server = MCPServer(temp_vault)
+    request = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 7,
+            "method": "tools/call",
+            "params": {
+                "name": "evaluate_promotion",
+                "arguments": {
+                    "candidate_kind": "concept",
+                    "pack": "default-knowledge",
+                    "payload": {
+                        "slug": "alpha",
+                        "title": "Alpha",
+                        "source_count": 1,
+                        "evidence_count": 4,
+                    },
+                },
+            },
+        }
+    )
+    reply = server.handle_line(request)
+    assert reply is not None
+    decision = reply["result"]["result"]
+    assert decision["lane"] == "auto"
+    assert decision["reason_code"] == "legacy_or_rule"
+    assert decision["payload"]["slug"] == "alpha"
+
+
+def test_evaluate_promotion_concept_below_threshold_holds(temp_vault: Path) -> None:
+    server = MCPServer(temp_vault)
+    request = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 8,
+            "method": "tools/call",
+            "params": {
+                "name": "evaluate_promotion",
+                "arguments": {
+                    "candidate_kind": "concept",
+                    "pack": "default-knowledge",
+                    "payload": {
+                        "slug": "weak",
+                        "source_count": 1,
+                        "evidence_count": 1,
+                    },
+                },
+            },
+        }
+    )
+    reply = server.handle_line(request)
+    decision = reply["result"]["result"]
+    assert decision["lane"] == "hold"
+    assert decision["blocking_facts"]
+
+
+def test_evaluate_promotion_workspace_permissive(temp_vault: Path) -> None:
+    server = MCPServer(temp_vault)
+    request = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 9,
+            "method": "tools/call",
+            "params": {
+                "name": "evaluate_promotion",
+                "arguments": {
+                    "candidate_kind": "workspace",
+                    "pack": "default-knowledge",
+                    "payload": {
+                        "draft": "10-Knowledge/Evergreen/_Candidates/x.md",
+                        "target": "10-Knowledge/Evergreen/x.md",
+                    },
+                },
+            },
+        }
+    )
+    reply = server.handle_line(request)
+    assert reply["result"]["result"]["lane"] == "auto"
+
+
+# ---------------------------------------------------------------------------
+# tools/call: assemble_prompt
+# ---------------------------------------------------------------------------
+
+
+def test_assemble_prompt_joins_slots_and_returns_object_ids(temp_vault: Path) -> None:
+    """``assemble_prompt`` joins the slot strings and echoes the object_ids
+    it attempted to record reuse events for. Emission of ``trusted_reuse_event``
+    rows is gated on the canonical objects existing in ``knowledge.db``; that
+    path is exercised exhaustively by ``test_reuse_emitter`` and we don't
+    re-prove it here. We just want to confirm the MCP wire shape works
+    end-to-end without raising."""
+    server = MCPServer(temp_vault)
+    request = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 10,
+            "method": "tools/call",
+            "params": {
+                "name": "assemble_prompt",
+                "arguments": {
+                    "slot_specs": ["alpha context", "beta context"],
+                    "object_ids": ["alpha", "beta"],
+                    "pack": "default-knowledge",
+                    "consumer_ref": "test://mcp",
+                    "separator": " | ",
+                },
+            },
+        }
+    )
+    reply = server.handle_line(request)
+    payload = reply["result"]["result"]
+    assert payload["text"] == "alpha context | beta context"
+    assert payload["object_ids"] == ["alpha", "beta"]
+
+
+# ---------------------------------------------------------------------------
+# tools/call: route_feedback
+# ---------------------------------------------------------------------------
+
+
+def test_route_feedback_open_question_writes_jsonl(temp_vault: Path) -> None:
+    server = MCPServer(temp_vault)
+    request = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 11,
+            "method": "tools/call",
+            "params": {
+                "name": "route_feedback",
+                "arguments": {
+                    "stream": "open_question",
+                    "pack": "default-knowledge",
+                    "items": [
+                        {"question": "what is X?", "consumer_ref": "ref-1"},
+                        {"question": "why is Y?", "consumer_ref": "ref-2"},
+                    ],
+                },
+            },
+        }
+    )
+    reply = server.handle_line(request)
+    assert reply["result"]["result"]["written"] == 2
+
+    log = temp_vault / "60-Logs" / "open-questions.jsonl"
+    assert log.exists()
+    lines = [json.loads(line) for line in log.read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert {row["question"] for row in lines} == {"what is X?", "why is Y?"}
+
+
+def test_route_feedback_candidate_concept_upserts_registry(temp_vault: Path) -> None:
+    server = MCPServer(temp_vault)
+    request = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 12,
+            "method": "tools/call",
+            "params": {
+                "name": "route_feedback",
+                "arguments": {
+                    "stream": "candidate_concept",
+                    "pack": "default-knowledge",
+                    "items": [
+                        {"term": "Quantum Slime", "definition": "a thing", "area": "ai"},
+                    ],
+                },
+            },
+        }
+    )
+    reply = server.handle_line(request)
+    assert reply["result"]["result"]["written"] == 1
+
+    from ovp_pipeline.concept_registry import ConceptRegistry
+
+    registry = ConceptRegistry(temp_vault).load()
+    assert registry.find_by_slug("quantum-slime") is not None
+
+
+# ---------------------------------------------------------------------------
+# Error envelopes — server stays alive
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_method_returns_method_not_found(temp_vault: Path) -> None:
+    server = MCPServer(temp_vault)
+    reply = server.handle_line(json.dumps({"jsonrpc": "2.0", "id": 1, "method": "resources/read"}))
+    assert reply is not None
+    assert reply["error"]["code"] == -32601
+
+
+def test_unknown_tool_returns_invalid_params(temp_vault: Path) -> None:
+    server = MCPServer(temp_vault)
+    request = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "frobnicate", "arguments": {}},
+        }
+    )
+    reply = server.handle_line(request)
+    assert reply["error"]["code"] == -32602
+
+
+def test_malformed_json_returns_parse_error(temp_vault: Path) -> None:
+    server = MCPServer(temp_vault)
+    reply = server.handle_line("{not json")
+    assert reply is not None
+    assert reply["error"]["code"] == -32700
+
+
+def test_notification_returns_no_reply(temp_vault: Path) -> None:
+    """JSON-RPC requests without ``id`` are notifications — no response."""
+    server = MCPServer(temp_vault)
+    reply = server.handle_line(json.dumps({"jsonrpc": "2.0", "method": "initialize"}))
+    assert reply is None
+
+
+def test_serve_loop_processes_multiple_requests(temp_vault: Path) -> None:
+    """The serve() loop must keep going after an error envelope. We feed two
+    lines: a bogus method, then a real tools/list. Both should reply, and the
+    second reply must still be the well-formed tools/list result — proving the
+    error didn't kill the loop."""
+    server = MCPServer(temp_vault)
+    lines = [
+        json.dumps({"jsonrpc": "2.0", "id": 1, "method": "resources/read"}),
+        json.dumps({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
+    ]
+    stdin = io.StringIO("\n".join(lines) + "\n")
+    stdout = io.StringIO()
+    server.serve(stdin=stdin, stdout=stdout)
+
+    replies = [json.loads(line) for line in stdout.getvalue().splitlines() if line.strip()]
+    assert len(replies) == 2
+    assert replies[0]["error"]["code"] == -32601
+    assert "tools" in replies[1]["result"]
+
+
+# ---------------------------------------------------------------------------
+# Direct call_tool / list_tools API (used by the CLI's --call / --tools-list)
+# ---------------------------------------------------------------------------
+
+
+def test_list_tools_direct(temp_vault: Path) -> None:
+    server = MCPServer(temp_vault)
+    tools = server.list_tools()
+    assert {t["name"] for t in tools} == {
+        "evaluate_promotion",
+        "assemble_prompt",
+        "route_feedback",
+    }
+
+
+def test_call_tool_direct_evaluate_promotion(temp_vault: Path) -> None:
+    server = MCPServer(temp_vault)
+    result = server.call_tool(
+        "evaluate_promotion",
+        {
+            "candidate_kind": "concept",
+            "pack": "default-knowledge",
+            "payload": {"slug": "x", "source_count": 5, "evidence_count": 5},
+        },
+    )
+    assert result["lane"] == "auto"
+
+
+def test_call_tool_unknown_raises_keyerror(temp_vault: Path) -> None:
+    server = MCPServer(temp_vault)
+    with pytest.raises(KeyError):
+        server.call_tool("nope", {})

--- a/tests/test_pulse.py
+++ b/tests/test_pulse.py
@@ -1,0 +1,196 @@
+"""Phase 37 — tests for the Pulse JSONL tail and the SSE endpoint."""
+
+from __future__ import annotations
+
+import json
+import threading
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+from ovp_pipeline.commands.ui_server import create_server
+from ovp_pipeline.event_emitter import emit
+from ovp_pipeline.pulse import (
+    DEFAULT_LOGS,
+    initial_positions,
+    tail_events,
+)
+from ovp_pipeline.runtime import VaultLayout
+
+
+# Tests must talk to a localhost server without going through any HTTP_PROXY
+# the developer environment may export — build an opener with an empty proxy
+# map and use it for every request below.
+_NO_PROXY_OPENER = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+
+
+def _make_layout(vault: Path) -> VaultLayout:
+    return VaultLayout.from_vault(vault)
+
+
+def test_tail_events_empty_layout_returns_no_events(temp_vault: Path) -> None:
+    layout = _make_layout(temp_vault)
+    events, positions = tail_events(layout)
+    assert events == []
+    assert all(positions[name] == 0 for name in DEFAULT_LOGS)
+
+
+def test_tail_events_picks_up_emitted_events_then_drains(temp_vault: Path) -> None:
+    layout = _make_layout(temp_vault)
+    positions = initial_positions(layout)
+
+    emit(temp_vault, "pipeline.jsonl", "promotion", {"slug": "alpha"}, pack="default-knowledge")
+    emit(
+        temp_vault,
+        "reuse-events.jsonl",
+        "trusted_reuse_event",
+        {"object_id": "alpha"},
+        pack="default-knowledge",
+    )
+
+    events, positions = tail_events(layout, since_position=positions)
+    assert [e["event_type"] for e in events] == sorted(
+        ["promotion", "trusted_reuse_event"], key=lambda et: et
+    ) or [e["event_type"] for e in events] in (
+        ["promotion", "trusted_reuse_event"],
+        ["trusted_reuse_event", "promotion"],
+    )
+    # Second poll with no new events returns nothing.
+    drain, positions = tail_events(layout, since_position=positions)
+    assert drain == []
+
+
+def test_tail_events_chronological_across_files(temp_vault: Path) -> None:
+    layout = _make_layout(temp_vault)
+    positions = initial_positions(layout)
+
+    # Emit interleaved across two files; the merged batch must be sorted by ts.
+    emit(temp_vault, "pipeline.jsonl", "promotion", {"n": 1}, pack="p")
+    emit(temp_vault, "reuse-events.jsonl", "trusted_reuse_event", {"n": 2}, pack="p")
+    emit(temp_vault, "pipeline.jsonl", "promotion", {"n": 3}, pack="p")
+
+    events, _ = tail_events(layout, since_position=positions)
+    timestamps = [str(e["ts"]) for e in events]
+    assert timestamps == sorted(timestamps)
+
+
+def test_tail_events_picks_up_new_file_mid_session(temp_vault: Path) -> None:
+    layout = _make_layout(temp_vault)
+    positions = initial_positions(layout)
+    # `evidence-verifications.jsonl` doesn't exist yet — its position is 0.
+    assert positions["evidence-verifications.jsonl"] == 0
+
+    emit(
+        temp_vault,
+        "evidence-verifications.jsonl",
+        "evidence_verified",
+        {"table": "claim_evidence", "key": {}, "locator": "", "content_hash": "",
+         "retrieval_context": "", "status": "verified", "verified_at": "now"},
+        pack="p",
+    )
+
+    events, _ = tail_events(layout, since_position=positions)
+    assert any(e["event_type"] == "evidence_verified" for e in events)
+
+
+def test_tail_events_handles_truncation(temp_vault: Path) -> None:
+    layout = _make_layout(temp_vault)
+    log = layout.logs_dir / "pipeline.jsonl"
+    emit(temp_vault, "pipeline.jsonl", "promotion", {"n": 1}, pack="p")
+    _, positions = tail_events(layout)
+
+    # Replace the file with a single fresh line — total size shrinks.
+    log.write_text(
+        json.dumps(
+            {
+                "event_id": "x",
+                "ts": "2099-01-01T00:00:00Z",
+                "session_id": "s",
+                "pack": "p",
+                "event_type": "promotion",
+                "n": 99,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    events, _ = tail_events(layout, since_position=positions)
+    assert len(events) == 1
+    assert events[0]["n"] == 99
+
+
+# ---------------------------------------------------------------------------
+# /pulse/stream SSE round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def running_server(temp_vault: Path):
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def _server_url(server, path: str) -> str:
+    host, port = server.server_address
+    return f"http://{host}:{port}{path}"
+
+
+def test_pulse_stream_round_trip(temp_vault: Path, running_server) -> None:
+    # Open the SSE stream first (so initial_positions captures end-of-file at
+    # this moment), then emit an event from another thread. The next poll
+    # inside the SSE loop must pick it up and ship a frame back. max_polls
+    # bounds the loop so urlopen.read() returns instead of hanging forever.
+    url = _server_url(running_server, "/pulse/stream?max_polls=8&poll_interval=0.05")
+
+    body_holder: dict[str, str] = {}
+
+    def consume() -> None:
+        with _NO_PROXY_OPENER.open(url, timeout=10) as response:
+            body_holder["body"] = response.read().decode("utf-8")
+
+    consumer = threading.Thread(target=consume, daemon=True)
+    consumer.start()
+
+    # Wait briefly for the consumer to connect & capture initial positions,
+    # then emit the event we expect to see streamed.
+    import time as _time
+
+    _time.sleep(0.15)
+    emit(
+        temp_vault,
+        "pipeline.jsonl",
+        "promotion",
+        {"slug": "alpha"},
+        pack="default-knowledge",
+    )
+
+    consumer.join(timeout=5)
+    body = body_holder.get("body", "")
+
+    assert "event: promotion" in body
+    assert '"slug": "alpha"' in body or '"slug":"alpha"' in body
+
+
+def test_pulse_fragment_returns_html(temp_vault: Path, running_server) -> None:
+    url = _server_url(running_server, "/pulse/fragment")
+    with _NO_PROXY_OPENER.open(url, timeout=5) as response:
+        body = response.read().decode("utf-8")
+    assert "EventSource('/pulse/stream')" in body
+    assert "<section class='pulse'>" in body
+
+
+def test_pulse_page_renders(temp_vault: Path, running_server) -> None:
+    url = _server_url(running_server, "/pulse")
+    with _NO_PROXY_OPENER.open(url, timeout=5) as response:
+        body = response.read().decode("utf-8")
+    assert "<title>Pulse</title>" in body
+    assert "<section class='pulse'>" in body

--- a/tests/test_pulse.py
+++ b/tests/test_pulse.py
@@ -94,6 +94,40 @@ def test_tail_events_picks_up_new_file_mid_session(temp_vault: Path) -> None:
     assert any(e["event_type"] == "evidence_verified" for e in events)
 
 
+def test_tail_events_skips_unterminated_trailing_line(temp_vault: Path) -> None:
+    """Partial-write safety: a poll that races a writer must not advance the
+    offset past an incomplete tail line; otherwise the next poll skips the
+    line entirely once the writer flushes the trailing newline.
+
+    Setup: emit one complete event, then write a half-line directly to the
+    file (no newline). After the first tail call we expect the complete event
+    AND the offset to point at the start of the partial tail. After we then
+    flush a newline + the rest of the line, the next tail call must surface it.
+    """
+    layout = _make_layout(temp_vault)
+    log = layout.logs_dir / "pipeline.jsonl"
+
+    # One complete event followed by a half-written second line.
+    emit(temp_vault, "pipeline.jsonl", "promotion", {"n": 1}, pack="p")
+    with log.open("ab") as handle:
+        handle.write(b'{"event_id":"y","ts":"2099-01-02T00:00:00Z","session_id":"s",')
+        # No newline yet — this is a partial write the next poll must NOT eat.
+
+    events, positions = tail_events(layout)
+    # We see the complete first event but NOT a corrupted parse of the second.
+    assert len(events) == 1
+    assert events[0]["n"] == 1
+
+    # Now finish writing the partial line + add the terminator.
+    with log.open("ab") as handle:
+        handle.write(b'"pack":"p","event_type":"promotion","n":2}\n')
+
+    events, _ = tail_events(layout, since_position=positions)
+    # The previously-partial line is now complete and surfaces in this poll.
+    assert len(events) == 1
+    assert events[0]["n"] == 2
+
+
 def test_tail_events_handles_truncation(temp_vault: Path) -> None:
     layout = _make_layout(temp_vault)
     log = layout.logs_dir / "pipeline.jsonl"

--- a/tests/test_workbench.py
+++ b/tests/test_workbench.py
@@ -1,0 +1,178 @@
+"""Phase 37 — tests for the Workbench shell + the new fragment routes."""
+
+from __future__ import annotations
+
+import threading
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+from ovp_pipeline.commands.ui_server import (
+    _fragment_from_page,
+    _render_workbench_page,
+    create_server,
+)
+from ovp_pipeline.knowledge_index import rebuild_knowledge_index
+
+
+_NO_PROXY_OPENER = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+
+
+# ---------------------------------------------------------------------------
+# Pure renderer tests (no server needed)
+# ---------------------------------------------------------------------------
+
+
+def test_fragment_from_page_strips_layout_chrome() -> None:
+    """``_fragment_from_page`` must remove ``_layout``'s outer chrome and
+    return only the body content. We build a synthetic page that matches the
+    template and assert the inner body survives but the html/main/shell
+    wrappers do not."""
+    page = (
+        '<!doctype html><html lang="en">'
+        "<head><title>x</title></head>"
+        "<body><main>"
+        '<div class="shell">'
+        '<div class="shell-head"><nav></nav></div>'
+        '<div class="shell-body">'
+        "<h1>INNER</h1><p>real content</p>"
+        "</div>"
+        "</div>"
+        "</main></body></html>"
+    )
+    fragment = _fragment_from_page(page)
+    assert "<h1>INNER</h1>" in fragment
+    assert "<p>real content</p>" in fragment
+    assert "<!doctype" not in fragment
+    assert "<main>" not in fragment
+    assert 'class="shell"' not in fragment
+
+
+def test_fragment_from_page_falls_back_when_markers_missing() -> None:
+    """Defensive: if the page doesn't contain the expected markers, return
+    the original string rather than raising."""
+    page = "<p>just a fragment already</p>"
+    assert _fragment_from_page(page) == page
+
+
+def test_render_workbench_page_includes_all_four_iframes() -> None:
+    html = _render_workbench_page(object_id="alpha", requested_pack="research-tech")
+    assert "id='pane-cand'" in html
+    assert "id='pane-obj'" in html
+    assert "id='pane-brief'" in html
+    assert "id='pane-act'" in html
+    assert "id='pane-pulse'" in html
+
+
+def test_render_workbench_page_threads_object_id_into_object_pane() -> None:
+    html = _render_workbench_page(object_id="alpha", requested_pack="research-tech")
+    assert "/object/fragment?id=alpha" in html
+    assert "alpha" in html  # mentioned in the header strip too
+
+
+def test_render_workbench_page_falls_back_when_no_object_selected() -> None:
+    html = _render_workbench_page(object_id="", requested_pack="research-tech")
+    # With no object selected, the object pane's iframe src must NOT include
+    # an `id=` query — the JS bridge mentions `/object/fragment` as a string
+    # literal in the selectObject() builder, which is fine.
+    assert "id='pane-obj' src='/object/fragment" not in html
+    assert "id='pane-obj' src='/objects" in html
+
+
+def test_render_workbench_page_threads_pack_into_each_pane() -> None:
+    html = _render_workbench_page(object_id="", requested_pack="research-tech")
+    assert "/candidates/fragment?pack=research-tech" in html
+    assert "/actions/fragment?pack=research-tech" in html
+    assert "/briefing/fragment?pack=research-tech" in html
+
+
+# ---------------------------------------------------------------------------
+# Live HTTP fragment + workbench tests
+# ---------------------------------------------------------------------------
+
+
+def _seed_minimal_truth_store(vault: Path) -> None:
+    """Smallest seed that keeps the four payload builders happy."""
+    alpha = vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
+    alpha.write_text(
+        """---
+note_id: alpha
+title: Alpha
+type: evergreen
+date: 2026-04-13
+---
+
+# Alpha
+
+Alpha supports local-first execution.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(vault)
+
+
+@pytest.fixture
+def running_server(temp_vault: Path):
+    _seed_minimal_truth_store(temp_vault)
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def _fetch(server, path: str) -> str:
+    host, port = server.server_address
+    with _NO_PROXY_OPENER.open(f"http://{host}:{port}{path}", timeout=5) as resp:
+        assert resp.status == 200
+        return resp.read().decode("utf-8")
+
+
+def test_workbench_route_returns_html_with_iframes(running_server) -> None:
+    body = _fetch(running_server, "/workbench?object_id=alpha")
+    assert "<title>Workbench</title>" in body
+    assert "/object/fragment?id=alpha" in body
+    assert "/candidates/fragment" in body
+    assert "/actions/fragment" in body
+    assert "/briefing/fragment" in body
+    assert "/pulse/fragment" in body
+
+
+def test_briefing_fragment_omits_full_page_chrome(running_server) -> None:
+    fragment = _fetch(running_server, "/briefing/fragment?pack=default-knowledge")
+    page = _fetch(running_server, "/briefing?pack=default-knowledge")
+    # The fragment must be strictly shorter than the full page (chrome stripped).
+    assert len(fragment) < len(page)
+    # Fragment must not contain the outer html chrome.
+    assert "<!doctype" not in fragment.lower()
+    assert "<main>" not in fragment
+    # But the page-specific content marker (e.g. shell nav) should be gone.
+    assert "<nav>" not in fragment
+    # Some recognisable page heading still survives.
+    assert "Signal" in fragment or "Briefing" in fragment or "section" in fragment
+
+
+def test_actions_fragment_omits_full_page_chrome(running_server) -> None:
+    fragment = _fetch(running_server, "/actions/fragment?pack=default-knowledge")
+    page = _fetch(running_server, "/actions?pack=default-knowledge")
+    assert len(fragment) < len(page)
+    assert "<!doctype" not in fragment.lower()
+
+
+def test_object_fragment_omits_full_page_chrome(running_server) -> None:
+    fragment = _fetch(running_server, "/object/fragment?id=alpha")
+    page = _fetch(running_server, "/object?id=alpha")
+    assert len(fragment) < len(page)
+    assert "<!doctype" not in fragment.lower()
+    # The object's title should still be present in the fragment.
+    assert "Alpha" in fragment
+
+
+def test_workbench_navbar_link_present(running_server) -> None:
+    home = _fetch(running_server, "/")
+    assert 'href="/workbench"' in home


### PR DESCRIPTION
## Summary

Closes the renovation arc started by PRs #46/#47. Three independently-shippable layers, each consuming hooks Phases 32–36 already wired:

- **37.A Pulse** — poll-based JSONL tail (`pulse.py`) plus `/pulse`, `/pulse/fragment`, and the `/pulse/stream` SSE endpoint. Per-file byte offsets survive truncation; new logs appearing mid-session enter the position dict at offset 0 on first sighting.
- **37.B Workbench** — four new `/fragment` routes (candidates, object, briefing, actions) extracted from the existing renderers via a defensive `_fragment_from_page` chrome stripper, plus a CSS-grid `/workbench` shell with a postMessage object-selection bridge and a navbar entry.
- **37.C MCP** — hand-rolled JSON-RPC 2.0 stdio server (`mcp_server.py`) exposing `evaluate_promotion` / `assemble_prompt` / `route_feedback` as typed primitives. Each tool descriptor declares a `side_effects` field so MCP clients can gate dry-run previews. New `ovp-mcp` CLI supports stdio serve (default), `--tools-list`, and `--call NAME --json '{...}'`.

Why hand-rolled JSON-RPC rather than the official `mcp` SDK: the codebase has zero web dependencies today (stdlib `http.server` for UI, sqlite3 for storage). The minimal verb set Claude Desktop actually invokes (`initialize`, `tools/list`, `tools/call`) fits in stdlib; deferred verbs return the JSON-RPC `method-not-found` envelope rather than crashing.

## Test plan

- [x] `pytest -q` — 807/807 pass (35 new: 8 pulse + 11 workbench + 16 MCP)
- [x] `ruff check` — all touched/new Phase 37 files clean
- [ ] Smoke `/workbench?object_id=<id>` end-to-end with `ovp-ui` running
- [ ] Smoke `echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | ovp-mcp --vault-dir <vault>`
- [ ] Smoke `curl -N http://localhost:7878/pulse/stream` while another terminal runs `ovp-query`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/48" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `ovp-mcp` command-line tool supporting MCP protocol: list tools, call tools, and run as a long-lived stdio server
  * Workbench UI: multi-pane grid for coordinated object selection and embedded fragments
  * Pulse UI: live event streaming via Server-Sent Events with robust tailing for log-based events
  * Fragment routes for embedding pages without full-page chrome

* **Tests**
  * Comprehensive tests for MCP server, Workbench UI, and Pulse streaming/features
<!-- end of auto-generated comment: release notes by coderabbit.ai -->