### PR TITLE
Rework ovp-graph build (layered BFS, Cytoscape viz, audit-event provenance) + vault search perf

### DIFF
--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -1196,8 +1196,12 @@ def _render_search_page(payload: dict) -> str:
 
         prev_link = _link(max(1, page - 1), "« Prev", page <= 1)
         next_link = _link(min(last_page, page + 1), "Next »", page >= last_page)
+        # Objects and notes share the same `page` cursor but may have different
+        # totals, so clamp the displayed value to avoid "page 3 of 2" when the
+        # smaller result set runs out.
+        displayed_page = min(page, last_page)
         return (
-            f"<p class='muted'>{label}: page {page} of {last_page} "
+            f"<p class='muted'>{label}: page {displayed_page} of {last_page} "
             f"&middot; {prev_link} &middot; {next_link}</p>"
         )
 

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -1174,6 +1174,33 @@ def _render_note_page(
 def _render_search_page(payload: dict) -> str:
     query = payload["query"]
     requested_pack = payload.get("requested_pack", "")
+    page = int(payload.get("page", 1))
+    page_size = int(payload.get("page_size", len(payload["objects"]) or 1))
+    object_total = int(payload.get("object_total", payload["object_count"]))
+    note_total = int(payload.get("note_total", payload["note_count"]))
+
+    def _pager(total: int, label: str) -> str:
+        last_page = max(1, (total + page_size - 1) // page_size)
+        if last_page <= 1:
+            return ""
+        from urllib.parse import urlencode
+
+        def _link(target_page: int, text: str, disabled: bool) -> str:
+            if disabled:
+                return f"<span class='muted'>{text}</span>"
+            params = {"q": query, "page": target_page}
+            if requested_pack:
+                params["pack"] = requested_pack
+            href = "/search?" + urlencode(params)
+            return f"<a href='{escape(href)}'>{text}</a>"
+
+        prev_link = _link(max(1, page - 1), "« Prev", page <= 1)
+        next_link = _link(min(last_page, page + 1), "Next »", page >= last_page)
+        return (
+            f"<p class='muted'>{label}: page {page} of {last_page} "
+            f"&middot; {prev_link} &middot; {next_link}</p>"
+        )
+
     object_items = (
         "".join(
             f'<li><a href="{escape(item.get("object_path") or _object_href(item["object_id"], requested_pack=requested_pack))}">{escape(item["title"])}</a> '
@@ -1190,6 +1217,10 @@ def _render_search_page(payload: dict) -> str:
         )
         or "<li class='muted'>No note hits.</li>"
     )
+    showing = (
+        f"Showing {payload['object_count']} of {object_total} object hits, "
+        f"{payload['note_count']} of {note_total} note hits."
+    )
     return _layout(
         f"Search: {query}",
         "".join(
@@ -1204,10 +1235,18 @@ def _render_search_page(payload: dict) -> str:
                 f"<input type='text' name='q' value='{escape(query)}' placeholder='Search vault' /> ",
                 "<button type='submit'>Search</button>",
                 "</form>",
-                f"<p class='muted'>{payload['object_count']} object hits, {payload['note_count']} note hits.</p>",
+                f"<p class='muted'>{escape(showing)}</p>",
                 "<section class='grid two-col'>",
-                f"<section class='card'><h2>Objects</h2><ul class='list-tight'>{object_items}</ul></section>",
-                f"<section class='card'><h2>Notes</h2><ul class='list-tight'>{note_items}</ul></section>",
+                "<section class='card'>"
+                f"<h2>Objects</h2>"
+                f"<ul class='list-tight'>{object_items}</ul>"
+                f"{_pager(object_total, 'Objects')}"
+                "</section>",
+                "<section class='card'>"
+                f"<h2>Notes</h2>"
+                f"<ul class='list-tight'>{note_items}</ul>"
+                f"{_pager(note_total, 'Notes')}"
+                "</section>",
                 "</section>",
             ]
         ),
@@ -4248,14 +4287,26 @@ def create_server(
                 if path == "/api/search":
                     q = query.get("q", [""])[0]
                     pack_name = query.get("pack", [""])[0] or None
+                    try:
+                        page = max(1, int(query.get("page", ["1"])[0]))
+                    except (TypeError, ValueError):
+                        page = 1
                     self._write_json(
-                        build_search_payload(resolved_vault, query=q, pack_name=pack_name)
+                        build_search_payload(
+                            resolved_vault, query=q, pack_name=pack_name, page=page
+                        )
                     )
                     return
                 if path == "/search":
                     q = query.get("q", [""])[0]
                     pack_name = query.get("pack", [""])[0] or None
-                    payload = build_search_payload(resolved_vault, query=q, pack_name=pack_name)
+                    try:
+                        page = max(1, int(query.get("page", ["1"])[0]))
+                    except (TypeError, ValueError):
+                        page = 1
+                    payload = build_search_payload(
+                        resolved_vault, query=q, pack_name=pack_name, page=page
+                    )
                     self._write_html(_render_search_page(payload))
                     return
                 if path == "/api/briefing":

--- a/src/ovp_pipeline/concept_registry.py
+++ b/src/ovp_pipeline/concept_registry.py
@@ -176,6 +176,17 @@ def slug_to_surface(slug: str) -> str:
     return normalize_surface(slug.replace("/", " ").replace("-", " ").replace("_", " "))
 
 
+def _trigrams(text: str) -> set[str]:
+    """Character 3-grams of `text`. Strings shorter than 3 chars are padded
+    so the returned set is non-empty (otherwise pruning would drop them
+    entirely instead of falling through to the full scan)."""
+    if not text:
+        return set()
+    if len(text) < 3:
+        text = text.ljust(3)
+    return {text[i : i + 3] for i in range(len(text) - 2)}
+
+
 # =============================================================================
 # Legacy ConceptEntry (for backwards compatibility with existing code)
 # =============================================================================
@@ -331,6 +342,26 @@ class ConceptRegistry:
         self._surface_index: dict[str, list[SurfaceRecord]] = defaultdict(list)
         self._surface_records: list[SurfaceRecord] = []
 
+        # Trigram inverted index over normalized surfaces. _safe_near_candidates
+        # otherwise scans every surface for every mention; with N=12k surfaces
+        # and ~45k wikilinks per rebuild that's ~500M comparisons. Pruning to
+        # candidates that share at least one trigram cuts it ~100x. Pruning is
+        # safety-preserving because the score formula weights trigram-Jaccard
+        # at 0.35 — if Jaccard=0 the max possible score (0.45+0.20=0.65) cannot
+        # cross the 0.72 threshold.
+        self._trigram_index: dict[str, set[int]] = defaultdict(set)
+
+        # Parallel arrays to _surface_records: precomputed token/ngram sets so
+        # _safe_near_candidates can skip per-iteration tokenization (was
+        # ~12k * O(len) recomputations per mention).
+        self._surface_tokens: list[set[str]] = []
+        self._surface_ngrams: list[set[str]] = []
+
+        # Mention resolution cache: same surface mention is linked many times
+        # across the vault, so memoizing skips repeated near-match scans.
+        # Cleared whenever load() rebuilds the surface tables.
+        self._mention_cache: dict[tuple[str, str | None, bool], ResolutionResult] = {}
+
     # ========== Persistence ==========
 
     @property
@@ -345,6 +376,7 @@ class ConceptRegistry:
         """Load registry from disk."""
         self._entries = []
         self._registry_entries = []
+        self._mention_cache.clear()
 
         if not self.registry_path.exists():
             return self
@@ -392,6 +424,10 @@ class ConceptRegistry:
         """
         self._surface_index = defaultdict(list)
         self._surface_records = []
+        self._trigram_index = defaultdict(set)
+        self._surface_tokens = []
+        self._surface_ngrams = []
+        self._mention_cache.clear()
 
         # Use _entries (ConceptEntry) to check resolver eligibility
         for entry in self._entries:
@@ -423,7 +459,16 @@ class ConceptRegistry:
                     source=source,
                 )
                 self._surface_index[norm].append(rec)
+                rec_idx = len(self._surface_records)
                 self._surface_records.append(rec)
+                norm_trigrams = _trigrams(norm)
+                for tri in norm_trigrams:
+                    self._trigram_index[tri].add(rec_idx)
+                self._surface_tokens.append(set(tokenize_surface(norm)))
+                # Use the same padded-ngram convention as _trigram_jaccard so
+                # the precomputed sets are interchangeable with the existing
+                # scoring math (no behavior change).
+                self._surface_ngrams.append(ConceptRegistry._char_ngrams(norm, 3))
 
     # ========== Query (Legacy compatibility) ==========
 
@@ -506,6 +551,26 @@ class ConceptRegistry:
     # ========== New Resolution API ==========
 
     def resolve_mention(
+        self,
+        mention: str,
+        area: str | None = None,
+        *,
+        include_related_context: bool = True,
+    ) -> ResolutionResult:
+        """Cached wrapper — same mention is resolved many times across the
+        vault. Underlying scan is O(N) over all surfaces.
+        """
+        cache_key = (mention, area, include_related_context)
+        cached = self._mention_cache.get(cache_key)
+        if cached is not None:
+            return cached
+        result = self._resolve_mention_uncached(
+            mention, area, include_related_context=include_related_context
+        )
+        self._mention_cache[cache_key] = result
+        return result
+
+    def _resolve_mention_uncached(
         self,
         mention: str,
         area: str | None = None,
@@ -672,18 +737,65 @@ class ConceptRegistry:
         """
         norm = normalize_surface(mention)
         q_tokens = tokenize_surface(norm)
+        q_token_set = set(q_tokens)
+        q_ngrams = ConceptRegistry._char_ngrams(norm, 3)
+        q_len = len(norm)
+        q_tokens_len = len(q_tokens)
         out: list[NearMatch] = []
 
-        for rec in self._surface_records:
+        # Trigram prune: any surface that shares zero trigrams with the query
+        # has tri=0, capping its max possible score at 0.45*tf1 + 0.20*lr <=
+        # 0.65 < 0.72 threshold, so it cannot pass. Skip them entirely.
+        q_tris = _trigrams(norm)
+        candidate_ids: set[int] = set()
+        for tri in q_tris:
+            bucket = self._trigram_index.get(tri)
+            if bucket:
+                candidate_ids.update(bucket)
+        if not candidate_ids and self._surface_records:
+            return []
+        if candidate_ids:
+            iter_ids: list[int] = list(candidate_ids)
+        else:
+            iter_ids = list(range(len(self._surface_records)))
+
+        for idx in iter_ids:
+            rec = self._surface_records[idx]
             if area and rec.entry.area and rec.entry.area != area:
                 continue
-            t_tokens = tokenize_surface(rec.normalized)
 
-            tf1 = self._token_f1(q_tokens, t_tokens)
-            tri = self._trigram_jaccard(norm, rec.normalized)
-            lr = self._length_ratio(norm, rec.normalized)
-            extra = max(0, len(set(t_tokens) - set(q_tokens)))
-            missing = max(0, len(set(q_tokens) - set(t_tokens)))
+            t_token_set = self._surface_tokens[idx]
+            t_ngrams = self._surface_ngrams[idx]
+            t_len = len(rec.normalized)
+            t_tokens_len = len(t_token_set)
+
+            # token F1
+            if not q_token_set or not t_token_set:
+                tf1 = 0.0
+            else:
+                inter = len(q_token_set & t_token_set)
+                if inter == 0:
+                    tf1 = 0.0
+                else:
+                    p = inter / t_tokens_len
+                    r = inter / len(q_token_set)
+                    tf1 = 2 * p * r / (p + r) if (p + r) > 0 else 0.0
+
+            # trigram Jaccard
+            if not q_ngrams or not t_ngrams:
+                tri = 0.0
+            else:
+                ng_inter = len(q_ngrams & t_ngrams)
+                tri = ng_inter / (len(q_ngrams) + len(t_ngrams) - ng_inter)
+
+            # length ratio
+            if not q_len or not t_len:
+                lr = 0.0
+            else:
+                lr = min(q_len, t_len) / max(q_len, t_len)
+
+            extra = max(0, t_tokens_len - len(q_token_set & t_token_set))
+            missing = max(0, len(q_token_set) - len(q_token_set & t_token_set))
 
             # Weighted combination
             score = 0.45 * tf1 + 0.35 * tri + 0.20 * lr
@@ -696,7 +808,7 @@ class ConceptRegistry:
 
             # Prevent short entity names from matching long命题 slugs
             # e.g., "Claude Code" should NOT auto-match "claude-code-uses-index-not..."
-            if len(q_tokens) <= 3 and len(t_tokens) - len(q_tokens) >= 2:
+            if q_tokens_len <= 3 and t_tokens_len - q_tokens_len >= 2:
                 score -= 0.25
 
             if score >= 0.72:

--- a/src/ovp_pipeline/graph/visualize.py
+++ b/src/ovp_pipeline/graph/visualize.py
@@ -10,7 +10,401 @@ Visualization - 图谱可视化
 from pathlib import Path
 from typing import Optional
 from dataclasses import asdict
+import html as _html
 import json
+import re
+
+
+def _safe_json(payload: object) -> str:
+    """JSON-in-HTML 安全序列化：把 </ 换成 <\\/，避免 "</script>" 字面值
+    提前关闭 <script> 块（JS 字符串里 \\/ 和 / 等价）。"""
+    return json.dumps(payload, ensure_ascii=False).replace("</", "<\\/")
+
+
+def _html_escape(s: str) -> str:
+    return _html.escape(s or '', quote=True)
+
+
+_SAFE_CLASS_RE = re.compile(r'[^a-zA-Z0-9_-]')
+
+
+def _safe_class(s: str) -> str:
+    """把 note_type / edge_type 映射成 Cytoscape class 名（只保留字母数字/_/-）"""
+    return _SAFE_CLASS_RE.sub('-', s or 'unknown') or 'unknown'
+
+
+# note_type → (颜色, 形状)。颜色来自 Tailwind 调色板；形状有限区分概念 vs 源文档。
+_TYPE_STYLE: dict[str, tuple[str, str]] = {
+    'evergreen': ('#34d399', 'ellipse'),
+    'moc': ('#f472b6', 'diamond'),
+    'deep_dive': ('#818cf8', 'round-rectangle'),
+    'raw': ('#94a3b8', 'round-rectangle'),
+    'article': ('#fbbf24', 'round-rectangle'),
+    'technical-analysis': ('#06b6d4', 'round-rectangle'),
+    'github-project': ('#f97316', 'round-rectangle'),
+    'project': ('#a78bfa', 'round-rectangle'),
+    'ai': ('#22d3ee', 'round-rectangle'),
+    'daily_view': ('#fb923c', 'hexagon'),
+    'interpretation': ('#fde047', 'round-rectangle'),
+}
+
+
+def _render_type_filter(counts: list[tuple[str, int]]) -> str:
+    rows = []
+    for note_type, count in counts:
+        color, _shape = _TYPE_STYLE.get(note_type, ('#888', 'ellipse'))
+        rows.append(
+            f'<label class="type-row"><input type="checkbox" checked '
+            f'data-type="{_html_escape(note_type)}"> '
+            f'<span class="swatch" style="background:{color}"></span>'
+            f'{_html_escape(note_type)} '
+            f'<span class="count">{count}</span></label>'
+        )
+    return '\n'.join(rows)
+
+
+_CYTOSCAPE_TEMPLATE = r"""<!DOCTYPE html>
+<html lang="zh">
+<head>
+<meta charset="utf-8">
+<title>{page_title}</title>
+<script src="https://unpkg.com/cytoscape@3.28.1/dist/cytoscape.min.js"></script>
+<script src="https://unpkg.com/layout-base@1.0.2/layout-base.js"></script>
+<script src="https://unpkg.com/cose-base@1.0.3/cose-base.js"></script>
+<script src="https://unpkg.com/cytoscape-cose-bilkent@4.1.0/cytoscape-cose-bilkent.js"></script>
+<style>
+  :root {{
+    --bg: #0b0e17;
+    --panel: #121826;
+    --panel-border: #1f2a3d;
+    --text: #e6edf3;
+    --muted: #8b96a6;
+    --accent: #00d4ff;
+    --seed: #00d4ff;
+    --hop1: #4ade80;
+    --hop2: #fbbf24;
+    --hop3: #f87171;
+  }}
+  * {{ box-sizing: border-box; }}
+  html, body {{ margin: 0; padding: 0; height: 100%; background: var(--bg); color: var(--text);
+    font: 13px/1.5 -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }}
+  .app {{ display: grid; grid-template-columns: 260px 1fr 320px; height: 100vh; }}
+  .sidebar, .detail {{ background: var(--panel); border-right: 1px solid var(--panel-border);
+    overflow-y: auto; padding: 14px; }}
+  .detail {{ border-right: none; border-left: 1px solid var(--panel-border); }}
+  .sidebar h2, .detail h2 {{ margin: 0 0 4px 0; font-size: 14px; color: var(--accent); }}
+  .sidebar h3 {{ margin: 16px 0 6px 0; font-size: 11px; color: var(--muted);
+    text-transform: uppercase; letter-spacing: 0.5px; }}
+  .meta {{ color: var(--muted); font-size: 11px; margin-bottom: 6px; }}
+  .stats {{ display: flex; gap: 8px; flex-wrap: wrap; margin: 8px 0 12px; }}
+  .stat {{ background: #0f1524; border: 1px solid var(--panel-border);
+    padding: 6px 10px; border-radius: 6px; min-width: 70px; }}
+  .stat .v {{ font-size: 18px; font-weight: 600; color: var(--accent); }}
+  .stat .l {{ font-size: 10px; color: var(--muted); text-transform: uppercase; }}
+  input[type=text] {{ width: 100%; background: #0f1524; color: var(--text);
+    border: 1px solid var(--panel-border); border-radius: 6px; padding: 6px 8px; font: inherit; }}
+  .type-row {{ display: flex; align-items: center; gap: 6px; padding: 3px 2px; cursor: pointer;
+    font-size: 12px; }}
+  .type-row:hover {{ background: #0f1524; border-radius: 4px; }}
+  .swatch {{ display: inline-block; width: 10px; height: 10px; border-radius: 3px; }}
+  .count {{ color: var(--muted); font-size: 11px; margin-left: auto; }}
+  .btn-row {{ display: flex; gap: 6px; flex-wrap: wrap; }}
+  button {{ background: #0f1524; color: var(--text); border: 1px solid var(--panel-border);
+    padding: 5px 10px; border-radius: 5px; cursor: pointer; font: inherit; }}
+  button:hover {{ border-color: var(--accent); color: var(--accent); }}
+  #cy {{ width: 100%; height: 100%; background: #070a12; }}
+  .detail .empty {{ color: var(--muted); font-size: 12px; margin-top: 20px; }}
+  .detail .field {{ margin: 8px 0; }}
+  .detail .field .k {{ color: var(--muted); font-size: 11px; text-transform: uppercase; }}
+  .detail .field .v {{ word-break: break-word; font-size: 12px; }}
+  .detail .neighbor {{ padding: 3px 4px; border-radius: 4px; cursor: pointer; font-size: 12px;
+    color: var(--text); display: block; text-decoration: none; }}
+  .detail .neighbor:hover {{ background: #0f1524; color: var(--accent); }}
+  .detail .neighbor .pill {{ display: inline-block; padding: 0 5px; margin-right: 5px;
+    border-radius: 9px; font-size: 10px; background: #1f2a3d; color: var(--muted); }}
+  .row-hop-label {{ font-size: 11px; color: var(--muted); margin-right: 6px; }}
+  .legend-hop {{ display: flex; gap: 10px; font-size: 11px; margin-top: 8px; color: var(--muted); }}
+  .legend-hop .dot {{ display: inline-block; width: 8px; height: 8px; border-radius: 50%;
+    margin-right: 3px; vertical-align: middle; }}
+</style>
+</head>
+<body>
+<div class="app">
+  <aside class="sidebar">
+    <h2>{page_title}</h2>
+    <div class="meta">Generated: {generated_at}</div>
+    <div class="stats">
+      <div class="stat"><div class="v">{node_count}</div><div class="l">Nodes</div></div>
+      <div class="stat"><div class="v">{edge_count}</div><div class="l">Edges</div></div>
+      <div class="stat"><div class="v">{seed_count}</div><div class="l">Seeds</div></div>
+    </div>
+
+    <h3>Search</h3>
+    <input type="text" id="search" placeholder="filter by title…">
+
+    <h3>Filter by type</h3>
+    <div id="type-filter">
+{type_filter_html}
+    </div>
+
+    <h3>Filter by hop</h3>
+    <label class="type-row"><input type="checkbox" checked data-hop="0">
+      <span class="swatch" style="background:var(--seed)"></span>Seed (hop 0)</label>
+    <label class="type-row"><input type="checkbox" checked data-hop="1">
+      <span class="swatch" style="background:var(--hop1)"></span>Hop 1</label>
+    <label class="type-row"><input type="checkbox" checked data-hop="2">
+      <span class="swatch" style="background:var(--hop2)"></span>Hop 2</label>
+    <label class="type-row"><input type="checkbox" checked data-hop="3">
+      <span class="swatch" style="background:var(--hop3)"></span>Hop 3+</label>
+
+    <h3>View</h3>
+    <div class="btn-row">
+      <button id="btn-fit">Fit</button>
+      <button id="btn-seeds">Focus Seeds</button>
+      <button id="btn-layout">Re-layout</button>
+      <button id="btn-reset">Reset</button>
+    </div>
+  </aside>
+
+  <main id="cy"></main>
+
+  <aside class="detail">
+    <h2>Node</h2>
+    <div id="detail-body" class="empty">点击任意节点查看详情。</div>
+  </aside>
+</div>
+
+<script>
+(function() {{
+  var payload = {elements_json};
+
+  var TYPE_STYLE = {{
+    'evergreen':          ['#34d399','ellipse'],
+    'moc':                ['#f472b6','diamond'],
+    'deep_dive':          ['#818cf8','round-rectangle'],
+    'raw':                ['#94a3b8','round-rectangle'],
+    'article':            ['#fbbf24','round-rectangle'],
+    'technical-analysis': ['#06b6d4','round-rectangle'],
+    'github-project':     ['#f97316','round-rectangle'],
+    'project':            ['#a78bfa','round-rectangle'],
+    'ai':                 ['#22d3ee','round-rectangle'],
+    'daily_view':         ['#fb923c','hexagon'],
+    'interpretation':     ['#fde047','round-rectangle']
+  }};
+
+  function typeStyle(t) {{ return TYPE_STYLE[t] || ['#888','ellipse']; }}
+
+  var style = [
+    {{ selector: 'node', style: {{
+        'label': 'data(label)',
+        'color': '#e6edf3',
+        'font-size': 10,
+        'text-wrap': 'wrap',
+        'text-max-width': 140,
+        'text-valign': 'bottom',
+        'text-margin-y': 4,
+        'background-color': function(ele) {{ return typeStyle(ele.data('note_type'))[0]; }},
+        'shape': function(ele) {{ return typeStyle(ele.data('note_type'))[1]; }},
+        'border-color': '#1f2a3d',
+        'border-width': 1,
+        'width': 22, 'height': 22,
+        'transition-property': 'opacity, border-width, border-color',
+        'transition-duration': '120ms'
+    }}}},
+    {{ selector: 'node.role-seed',           style: {{ 'border-color':'#00d4ff','border-width':4,'width':40,'height':40,'font-size':12 }} }},
+    {{ selector: 'node.role-neighbor_1hop',  style: {{ 'border-color':'#4ade80','border-width':2,'width':28,'height':28 }} }},
+    {{ selector: 'node.role-neighbor_2hop',  style: {{ 'border-color':'#fbbf24','border-width':2,'width':22,'height':22 }} }},
+    {{ selector: 'node.role-neighbor_3hop',  style: {{ 'border-color':'#f87171','border-width':1,'width':18,'height':18 }} }},
+    {{ selector: 'edge', style: {{
+        'width': 1,
+        'line-color': '#263248',
+        'target-arrow-color': '#263248',
+        'target-arrow-shape': 'triangle',
+        'curve-style': 'bezier',
+        'arrow-scale': 0.8,
+        'opacity': 0.75,
+        'transition-property': 'opacity, line-color, width',
+        'transition-duration': '120ms'
+    }}}},
+    {{ selector: '.faded', style: {{ 'opacity': 0.08 }} }},
+    {{ selector: '.highlighted', style: {{
+        'border-color':'#00d4ff',
+        'border-width': 3
+    }}}},
+    {{ selector: 'edge.highlighted', style: {{
+        'line-color':'#00d4ff',
+        'target-arrow-color':'#00d4ff',
+        'width': 2,
+        'opacity': 1
+    }}}},
+    {{ selector: '.hidden', style: {{ 'display':'none' }} }}
+  ];
+
+  var cy = cytoscape({{
+    container: document.getElementById('cy'),
+    elements: payload,
+    style: style,
+    layout: {{
+      name: 'cose-bilkent',
+      animate: 'end',
+      idealEdgeLength: 100,
+      nodeRepulsion: 8000,
+      nodeOverlap: 20,
+      gravity: 0.25,
+      numIter: 2000,
+      tile: true,
+      padding: 30
+    }},
+    wheelSensitivity: 0.2,
+    minZoom: 0.1,
+    maxZoom: 3
+  }});
+
+  // ---------- Detail panel ----------
+  var detailEl = document.getElementById('detail-body');
+
+  function renderDetail(node) {{
+    if (!node) {{
+      detailEl.className = 'empty';
+      detailEl.textContent = '点击任意节点查看详情。';
+      return;
+    }}
+    var d = node.data();
+    var incoming = node.incomers('node');
+    var outgoing = node.outgoers('node');
+    var html = '';
+    html += '<div class="field"><div class="k">title</div><div class="v"><strong>' + esc(d.title) + '</strong></div></div>';
+    html += '<div class="field"><div class="k">type</div><div class="v">' + esc(d.note_type) + '</div></div>';
+    if (d.distance >= 0) {{
+      var label = d.distance === 0 ? 'seed' : 'hop ' + d.distance;
+      html += '<div class="field"><div class="k">distance</div><div class="v">' + label + '</div></div>';
+    }}
+    if (d.path) {{
+      html += '<div class="field"><div class="k">path</div><div class="v" style="font-family:ui-monospace,Menlo,monospace;font-size:11px;">' + esc(d.path) + '</div></div>';
+    }}
+    if (d.day_id) {{
+      html += '<div class="field"><div class="k">day</div><div class="v">' + esc(d.day_id) + '</div></div>';
+    }}
+    html += '<div class="field"><div class="k">incoming (' + incoming.length + ')</div><div class="v">' + neighborList(incoming) + '</div></div>';
+    html += '<div class="field"><div class="k">outgoing (' + outgoing.length + ')</div><div class="v">' + neighborList(outgoing) + '</div></div>';
+    detailEl.className = '';
+    detailEl.innerHTML = html;
+    detailEl.querySelectorAll('.neighbor').forEach(function(a) {{
+      a.addEventListener('click', function(e) {{
+        e.preventDefault();
+        var target = cy.getElementById(a.dataset.id);
+        if (target.nonempty()) {{
+          selectNode(target);
+          cy.center(target);
+        }}
+      }});
+    }});
+  }}
+
+  function neighborList(collection) {{
+    if (!collection.length) return '<span style="color:var(--muted)">(none)</span>';
+    var items = [];
+    collection.forEach(function(n) {{
+      var nd = n.data();
+      items.push('<a class="neighbor" href="#" data-id="' + esc(nd.id) + '">'
+        + '<span class="pill">' + esc(nd.note_type) + '</span>' + esc(nd.title) + '</a>');
+    }});
+    return items.join('');
+  }}
+
+  function esc(s) {{
+    return String(s == null ? '' : s)
+      .replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')
+      .replace(/"/g,'&quot;').replace(/'/g,'&#39;');
+  }}
+
+  // ---------- Selection / highlight ----------
+  var currentSelection = null;
+
+  function selectNode(node) {{
+    currentSelection = node;
+    cy.elements().removeClass('highlighted faded');
+    var nbrs = node.closedNeighborhood();
+    cy.elements().not(nbrs).addClass('faded');
+    nbrs.addClass('highlighted');
+    renderDetail(node);
+  }}
+
+  function clearSelection() {{
+    currentSelection = null;
+    cy.elements().removeClass('highlighted faded');
+    renderDetail(null);
+  }}
+
+  cy.on('tap', 'node', function(evt) {{ selectNode(evt.target); }});
+  cy.on('tap', function(evt) {{ if (evt.target === cy) clearSelection(); }});
+
+  // ---------- Filters ----------
+  var activeTypes = new Set();
+  document.querySelectorAll('#type-filter input[type=checkbox]').forEach(function(cb) {{
+    activeTypes.add(cb.dataset.type);
+    cb.addEventListener('change', function() {{
+      if (cb.checked) activeTypes.add(cb.dataset.type); else activeTypes.delete(cb.dataset.type);
+      applyFilters();
+    }});
+  }});
+
+  var activeHops = new Set([0,1,2,3]);
+  document.querySelectorAll('[data-hop]').forEach(function(cb) {{
+    cb.addEventListener('change', function() {{
+      var h = parseInt(cb.dataset.hop, 10);
+      if (cb.checked) activeHops.add(h); else activeHops.delete(h);
+      applyFilters();
+    }});
+  }});
+
+  var searchEl = document.getElementById('search');
+  searchEl.addEventListener('input', applyFilters);
+
+  function applyFilters() {{
+    var query = (searchEl.value || '').trim().toLowerCase();
+    cy.batch(function() {{
+      cy.nodes().forEach(function(n) {{
+        var d = n.data();
+        var hopBucket = d.distance >= 3 ? 3 : (d.distance < 0 ? 3 : d.distance);
+        var keep =
+          activeTypes.has(d.note_type) &&
+          activeHops.has(hopBucket) &&
+          (!query || (d.title || '').toLowerCase().indexOf(query) >= 0);
+        n.toggleClass('hidden', !keep);
+      }});
+      cy.edges().forEach(function(e) {{
+        var hidden = e.source().hasClass('hidden') || e.target().hasClass('hidden');
+        e.toggleClass('hidden', hidden);
+      }});
+    }});
+  }}
+
+  // ---------- Buttons ----------
+  document.getElementById('btn-fit').addEventListener('click', function() {{ cy.fit(null, 30); }});
+  document.getElementById('btn-seeds').addEventListener('click', function() {{
+    var seeds = cy.nodes('.role-seed');
+    if (seeds.nonempty()) cy.fit(seeds, 60);
+  }});
+  document.getElementById('btn-layout').addEventListener('click', function() {{
+    cy.layout({{ name:'cose-bilkent', animate:'end', numIter:1500, padding:30 }}).run();
+  }});
+  document.getElementById('btn-reset').addEventListener('click', function() {{
+    searchEl.value = '';
+    document.querySelectorAll('#type-filter input').forEach(function(cb) {{ cb.checked = true; activeTypes.add(cb.dataset.type); }});
+    document.querySelectorAll('[data-hop]').forEach(function(cb) {{ cb.checked = true; activeHops.add(parseInt(cb.dataset.hop,10)); }});
+    applyFilters();
+    clearSelection();
+    cy.fit(null, 30);
+  }});
+
+  // Initial focus on seeds if any
+  var seeds = cy.nodes('.role-seed');
+  if (seeds.nonempty()) cy.fit(seeds, 80);
+}})();
+</script>
+</body>
+</html>"""
 
 
 class GraphVisualizer:
@@ -107,204 +501,94 @@ class GraphVisualizer:
         return "\n".join(lines)
 
     def html(self, output_path: Optional[Path] = None) -> str:
-        """生成交互式HTML可视化 (使用vis.js)"""
-        html_template = """<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="utf-8">
-    <title>OVP Graph - {day_id}</title>
-    <script src="https://unpkg.com/vis-network/standalone/umd/vis-network.min.js"></script>
-    <style>
-        body {{
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-            margin: 0;
-            padding: 20px;
-            background: #1a1a2e;
-            color: #eee;
-        }}
-        h1 {{ color: #00d4ff; margin-bottom: 10px; }}
-        .stats {{
-            display: flex;
-            gap: 20px;
-            margin-bottom: 20px;
-            flex-wrap: wrap;
-        }}
-        .stat {{
-            background: #16213e;
-            padding: 10px 20px;
-            border-radius: 8px;
-            border: 1px solid #0f3460;
-        }}
-        .stat-value {{ font-size: 24px; font-weight: bold; color: #00d4ff; }}
-        .stat-label {{ font-size: 12px; color: #888; }}
-        #graph {{ width: 100%; height: 600px; border: 1px solid #0f3460; border-radius: 8px; }}
-        .legend {{
-            margin-top: 20px;
-            display: flex;
-            gap: 15px;
-            flex-wrap: wrap;
-        }}
-        .legend-item {{
-            display: flex;
-            align-items: center;
-            gap: 5px;
-            font-size: 12px;
-        }}
-        .legend-color {{
-            width: 12px;
-            height: 12px;
-            border-radius: 50%;
-        }}
-        .seed {{ background: #00d4ff; }}
-        .1hop {{ background: #4ade80; }}
-        .2hop {{ background: #fbbf24; }}
-        .3hop {{ background: #f87171; }}
-        .note-raw {{ background: #94a3b8; }}
-        .note-deep_dive {{ background: #818cf8; }}
-        .note-evergreen {{ background: #34d399; }}
-        .note-moc {{ background: #f472b6; }}
-    </style>
-</head>
-<body>
-    <h1>📊 OVP Daily Delta Graph</h1>
-    <p>日期: {day_id} | 生成时间: {generated_at}</p>
+        """生成交互式 HTML 可视化（基于 Cytoscape.js）。
 
-    <div class="stats">
-        <div class="stat">
-            <div class="stat-value">{node_count}</div>
-            <div class="stat-label">节点</div>
-        </div>
-        <div class="stat">
-            <div class="stat-value">{edge_count}</div>
-            <div class="stat-label">边</div>
-        </div>
-        <div class="stat">
-            <div class="stat-value">{seed_count}</div>
-            <div class="stat-label">Seeds</div>
-        </div>
-    </div>
+        替代了原来的 vis.js 实现。原版在 ~6K 节点上互动僵硬、信息密度低、
+        靠 tooltip 表达；这里改成：
+            * 左侧 toolbar：搜索 + note_type 过滤 + hop 过滤 + 布局/聚焦按钮
+            * 主画布：cose-bilkent 布局；节点按 note_type 着色 + 形状区分；
+              seed/1hop/2hop 用边框宽度+尺寸表达
+            * 右侧 detail panel：点击节点显示 title / type / distance / path /
+              入出邻居列表（可点击跳转）
+            * 点击节点会高亮邻域（其余节点淡出）
 
-    <div id="graph"></div>
+        所有 JS/CSS 走 CDN unpkg；HTML 自包含，生成后直接双击即可打开。
+        """
+        nodes_data = self._cytoscape_nodes()
+        edges_data = self._cytoscape_edges()
+        type_counts = self._type_counts(nodes_data)
 
-    <div class="legend">
-        <div class="legend-item"><div class="legend-color seed"></div> Seed</div>
-        <div class="legend-item"><div class="legend-color 1hop"></div> 1-hop</div>
-        <div class="legend-item"><div class="legend-color 2hop"></div> 2-hop</div>
-        <div class="legend-item"><div class="legend-color 3hop"></div> 3-hop</div>
-        <div style="width:20px"></div>
-        <div class="legend-item"><div class="legend-color note-raw"></div> Raw</div>
-        <div class="legend-item"><div class="legend-color note-deep_dive"></div> Deep Dive</div>
-        <div class="legend-item"><div class="legend-color note-evergreen"></div> Evergreen</div>
-        <div class="legend-item"><div class="legend-color note-moc"></div> MOC</div>
-    </div>
+        title = self.delta.get('day_id', '') or 'OVP Graph'
+        seed_pattern = self.delta.get('seed_pattern', '')
+        if seed_pattern:
+            title = f"OVP Graph · seed={seed_pattern!r}"
 
-    <script>
-    var nodes = new vis.DataSet({nodes_json});
-    var edges = new vis.DataSet({edges_json});
-
-    var container = document.getElementById('graph');
-    var data = {{ nodes: nodes, edges: edges }};
-    var options = {{
-        nodes: {{
-            shape: 'dot',
-            size: 15,
-            font: {{ color: '#eee', size: 12 }},
-            borderWidth: 2,
-            shadow: true
-        }},
-        edges: {{
-            width: 1,
-            color: {{ color: '#555', highlight: '#00d4ff' }},
-            smooth: {{ type: 'continuous' }}
-        }},
-        physics: {{
-            stabilization: {{ iterations: 100 }},
-            barnesHut: {{
-                gravitationalConstant: -2000,
-                springLength: 150
-            }}
-        }},
-        interaction: {{
-            hover: true,
-            tooltipDelay: 200
-        }},
-        layout: {{
-            improvedLayout: true
-        }}
-    }};
-
-    var network = new vis.Network(container, data, options);
-    </script>
-</body>
-</html>"""
-
-        # 构建节点数据
-        nodes_data = []
-        for node in self.delta.get('nodes', []):
-            seed_role = node.get('seed_role', 'unknown')
-            note_type = node.get('note_type', 'unknown')
-
-            # 颜色映射
-            role_colors = {
-                'seed': '#00d4ff',
-                'neighbor_1hop': '#4ade80',
-                'neighbor_2hop': '#fbbf24',
-                'neighbor_3hop': '#f87171',
-            }
-            type_colors = {
-                'raw': '#94a3b8',
-                'deep_dive': '#818cf8',
-                'evergreen': '#34d399',
-                'moc': '#f472b6',
-                'daily_view': '#fb923c',
-            }
-
-            color = type_colors.get(note_type, '#888')
-
-            title = node.get('title', '') or node['note_id']
-            title_short = title[:40] + '...' if len(title) > 40 else title
-
-            nodes_data.append({
-                'id': node['note_id'],
-                'label': title_short,
-                'title': f"{title}\n类型: {note_type}\n角色: {seed_role}",
-                'color': {
-                    'background': color,
-                    'border': role_colors.get(seed_role, '#888')
-                },
-                'size': 25 if seed_role == 'seed' else 15
-            })
-
-        # 构建边数据
-        edges_data = []
-        for edge in self.delta.get('edges', []):
-            edges_data.append({
-                'from': edge['source'],
-                'to': edge['target'],
-                'label': edge.get('edge_type', ''),
-                'title': f"{edge.get('edge_type', '')}\n{edge['source']} → {edge['target']}"
-            })
-
-        # 渲染。把 </ 转成 <\/ 防止节点 title 里的 "</script>" 字面值
-        # 提前关闭 <script> 块（JS 字符串里 \/ 仍然合法）。
-        def _safe_json(payload: object) -> str:
-            return json.dumps(payload, ensure_ascii=False).replace("</", "<\\/")
-
-        html = html_template.format(
-            day_id=self.delta.get('day_id', ''),
-            generated_at=self.delta.get('generated_at', ''),
+        html = _CYTOSCAPE_TEMPLATE.format(
+            page_title=_html_escape(title),
+            generated_at=_html_escape(self.delta.get('generated_at', '')),
             node_count=len(nodes_data),
             edge_count=len(edges_data),
             seed_count=len(self.delta.get('seed_note_ids', [])),
-            nodes_json=_safe_json(nodes_data),
-            edges_json=_safe_json(edges_data),
+            type_filter_html=_render_type_filter(type_counts),
+            elements_json=_safe_json({'nodes': nodes_data, 'edges': edges_data}),
         )
 
         if output_path:
             output_path.write_text(html, encoding='utf-8')
-            print(f"✅ HTML已生成: {output_path}")
+            print(f"✅ HTML 已生成: {output_path}")
 
         return html
+
+    # ---------- Cytoscape data shaping ----------
+
+    def _cytoscape_nodes(self) -> list[dict]:
+        out = []
+        for node in self.delta.get('nodes', []):
+            note_type = (node.get('note_type') or 'unknown')
+            seed_role = node.get('seed_role') or 'unknown'
+            distance = node.get('distance_from_seed', None)
+            title = node.get('title') or node.get('note_id', '')
+            label = title if len(title) <= 32 else title[:30] + '…'
+            out.append({
+                'data': {
+                    'id': node['note_id'],
+                    'label': label,
+                    'title': title,
+                    'note_type': note_type,
+                    'seed_role': seed_role,
+                    'distance': distance if distance is not None else -1,
+                    'path': node.get('path', '') or '',
+                    'day_id': node.get('day_id', '') or '',
+                },
+                'classes': ' '.join([
+                    f"type-{_safe_class(note_type)}",
+                    f"role-{_safe_class(seed_role)}",
+                ]),
+            })
+        return out
+
+    def _cytoscape_edges(self) -> list[dict]:
+        out = []
+        for edge in self.delta.get('edges', []):
+            edge_type = edge.get('edge_type') or 'wikilink'
+            out.append({
+                'data': {
+                    'id': edge.get('edge_id') or f"{edge['source']}-{edge['target']}",
+                    'source': edge['source'],
+                    'target': edge['target'],
+                    'edge_type': edge_type,
+                    'anchor_text': edge.get('anchor_text', '') or '',
+                },
+                'classes': f"edgetype-{_safe_class(edge_type)}",
+            })
+        return out
+
+    @staticmethod
+    def _type_counts(nodes_data: list[dict]) -> list[tuple[str, int]]:
+        from collections import Counter
+        counter: Counter = Counter(n['data']['note_type'] for n in nodes_data)
+        # 稳定顺序：先按数量降序，再按名字升序
+        return sorted(counter.items(), key=lambda kv: (-kv[1], kv[0]))
 
     def export_graphml(self, output_path: Path):
         """导出为GraphML格式 (兼容Gephi, yEd)"""

--- a/src/ovp_pipeline/graph/visualize.py
+++ b/src/ovp_pipeline/graph/visualize.py
@@ -226,6 +226,12 @@ _CYTOSCAPE_TEMPLATE = r"""<!DOCTYPE html>
         'transition-property': 'opacity, line-color, width',
         'transition-duration': '120ms'
     }}}},
+    {{ selector: 'edge.edgetype-promoted_from', style: {{
+        'line-color': '#a78bfa',
+        'target-arrow-color': '#a78bfa',
+        'line-style': 'dashed',
+        'opacity': 0.6
+    }}}},
     {{ selector: '.faded', style: {{ 'opacity': 0.08 }} }},
     {{ selector: '.highlighted', style: {{
         'border-color':'#00d4ff',

--- a/src/ovp_pipeline/graph/visualize.py
+++ b/src/ovp_pipeline/graph/visualize.py
@@ -285,15 +285,19 @@ class GraphVisualizer:
                 'title': f"{edge.get('edge_type', '')}\n{edge['source']} → {edge['target']}"
             })
 
-        # 渲染
+        # 渲染。把 </ 转成 <\/ 防止节点 title 里的 "</script>" 字面值
+        # 提前关闭 <script> 块（JS 字符串里 \/ 仍然合法）。
+        def _safe_json(payload: object) -> str:
+            return json.dumps(payload, ensure_ascii=False).replace("</", "<\\/")
+
         html = html_template.format(
             day_id=self.delta.get('day_id', ''),
             generated_at=self.delta.get('generated_at', ''),
             node_count=len(nodes_data),
             edge_count=len(edges_data),
             seed_count=len(self.delta.get('seed_note_ids', [])),
-            nodes_json=json.dumps(nodes_data, ensure_ascii=False),
-            edges_json=json.dumps(edges_data, ensure_ascii=False)
+            nodes_json=_safe_json(nodes_data),
+            edges_json=_safe_json(edges_data),
         )
 
         if output_path:

--- a/src/ovp_pipeline/graph_cli.py
+++ b/src/ovp_pipeline/graph_cli.py
@@ -13,6 +13,7 @@ Usage:
 
 import argparse
 import sys
+from datetime import datetime
 from pathlib import Path
 
 from ovp_pipeline.runtime import iter_markdown_files, resolve_vault_dir
@@ -22,42 +23,209 @@ from ovp_pipeline.runtime import iter_markdown_files, resolve_vault_dir
 VAULT_DIR = resolve_vault_dir()
 
 
-def cmd_build(args):
-    """全量构建图谱"""
+def _load_graph_from_index(vault_dir: Path) -> tuple[list[dict], list[dict], Path]:
+    """读取已经在 ovp-knowledge-index 阶段持久化的图谱。
+
+    pages_index → nodes、page_links → edges。Registry 解析在那边一次性跑完，
+    这里只做 SELECT，比扫盘快几个数量级。
+    """
+    import sqlite3
+
+    from ovp_pipeline.runtime import VaultLayout
+
+    layout = VaultLayout(vault_dir)
+    db_path = layout.knowledge_db
+    if not db_path.exists():
+        raise FileNotFoundError(db_path)
+
+    nodes: list[dict] = []
+    edges: list[dict] = []
+    seen_edges: set[str] = set()
+
+    with sqlite3.connect(db_path) as conn:
+        for slug, title, note_type, path, day_id in conn.execute(
+            "SELECT slug, title, note_type, path, day_id FROM pages_index"
+        ):
+            nodes.append({
+                "note_id": slug,
+                "title": title or slug,
+                "note_type": note_type or "unknown",
+                "path": path or "",
+                "day_id": day_id or "",
+                "distance_from_seed": 0,
+                "seed_role": "seed",
+                "degree": 0,
+                "in_degree": 0,
+                "out_degree": 0,
+                "seed_support": 0,
+                "topic_clusters": [],
+                "entities": [],
+                "tags": [],
+            })
+        for source_slug, target_slug, target_raw, link_type, line_number in conn.execute(
+            "SELECT source_slug, target_slug, target_raw, link_type, line_number"
+            " FROM page_links"
+        ):
+            edge_id = f"{source_slug}-{target_slug}-{link_type or 'wikilink'}"
+            if edge_id in seen_edges:
+                continue
+            seen_edges.add(edge_id)
+            edges.append({
+                "edge_id": edge_id,
+                "source": source_slug,
+                "target": target_slug,
+                "edge_type": link_type or "wikilink",
+                "weight": 1.0,
+                "is_new_today": False,
+                "anchor_text": target_raw or "",
+                "evidence_line": line_number or 0,
+            })
+
+    return nodes, edges, db_path
+
+
+def _scan_graph_from_filesystem(vault_dir: Path) -> tuple[list[dict], list[dict]]:
+    """扫盘 fallback：当 knowledge.db 还没建立时使用。"""
     from ovp_pipeline.graph import GraphBuilder
 
-    vault_dir = resolve_vault_dir(args.vault_dir or VAULT_DIR)
     builder = GraphBuilder(vault_dir)
-
-    print("📊 开始构建全量图谱...")
-
     directories = [
         vault_dir / "10-Knowledge" / "Evergreen",
         vault_dir / "20-Areas",
         vault_dir / "50-Inbox" / "01-Raw",
     ]
-
-    all_nodes = []
-    all_edges = []
-
+    all_nodes: list[dict] = []
+    all_edges: list[dict] = []
     for directory in directories:
         if directory.exists():
             print(f"  处理: {directory.relative_to(vault_dir)}")
             nodes, edges = builder.build_from_directory(directory, recursive=True)
             all_nodes.extend(nodes)
             all_edges.extend(edges)
+    return all_nodes, all_edges
+
+
+def cmd_build(args):
+    """全量构建图谱（默认从 knowledge.db 读取，可选 --seed-match 子图过滤）"""
+    from ovp_pipeline.graph.daily_delta import DailyDelta
+
+    vault_dir = resolve_vault_dir(args.vault_dir or VAULT_DIR)
+    no_index = getattr(args, "no_index", False)
+
+    all_nodes: list[dict] = []
+    all_edges: list[dict] = []
+
+    if not no_index:
+        try:
+            all_nodes, all_edges, db_path = _load_graph_from_index(vault_dir)
+            try:
+                rel = db_path.relative_to(vault_dir)
+            except ValueError:
+                rel = db_path
+            print(f"📊 从 knowledge.db 加载图谱: {rel}")
+        except FileNotFoundError:
+            print(
+                "⚠️ 未找到 knowledge.db，回退到扫盘模式（先跑 ovp-knowledge-index 会快几个数量级）"
+            )
+            no_index = True
+
+    if no_index:
+        print("📊 扫盘构建全量图谱...")
+        all_nodes, all_edges = _scan_graph_from_filesystem(vault_dir)
 
     print(f"\n✅ 图谱构建完成:")
     print(f"   节点: {len(all_nodes)}")
     print(f"   边: {len(all_edges)}")
 
-    # 导出
+    seed_match = getattr(args, "seed_match", None)
+    expand_hops = getattr(args, "expand_hops", 1)
+
+    if seed_match:
+        import re
+
+        try:
+            pattern = re.compile(seed_match, re.IGNORECASE)
+        except re.error as exc:
+            print(f"❌ 无效的 --seed-match 正则: {exc}")
+            return 1
+
+        seed_ids = {
+            node["note_id"]
+            for node in all_nodes
+            if pattern.search(node.get("title", "") or "")
+            or pattern.search(node.get("note_id", "") or "")
+        }
+        if not seed_ids:
+            print(f"⚠️ --seed-match {seed_match!r} 没有匹配到任何节点")
+            return 1
+
+        edge_index = {edge["edge_id"]: edge for edge in all_edges}
+        delta_helper = DailyDelta(vault_dir)
+        expanded_ids, distance_map = delta_helper._expand_hops(
+            seed_ids, edge_index, expand_hops
+        )
+
+        all_nodes = [n for n in all_nodes if n["note_id"] in expanded_ids]
+        all_edges = [
+            e for e in all_edges
+            if e["source"] in expanded_ids and e["target"] in expanded_ids
+        ]
+        for node in all_nodes:
+            distance = distance_map.get(node["note_id"], expand_hops + 1)
+            node["distance_from_seed"] = distance
+            if distance == 0:
+                node["seed_role"] = "seed"
+            else:
+                node["seed_role"] = f"neighbor_{min(distance, 3)}hop"
+
+        print(f"\n🎯 子图过滤 (--seed-match {seed_match!r}, --expand-hops {expand_hops}):")
+        print(f"   Seeds: {len(seed_ids)}")
+        print(f"   节点: {len(all_nodes)}")
+        print(f"   边: {len(all_edges)}")
+
+    # 构建 daily-delta 形态的 dict，供 JSON / HTML 共享
+    delta_payload = {
+        "schema_version": "1.0.0",
+        "day_id": "full" if not seed_match else f"seed-{seed_match}",
+        "generated_at": datetime.now().isoformat(),
+        "nodes": all_nodes,
+        "edges": all_edges,
+        "stats": {
+            "expanded_node_count": len(all_nodes),
+            "expanded_edge_count": len(all_edges),
+        },
+        "seed_note_ids": list(seed_ids) if seed_match else [],
+    }
+    if seed_match:
+        delta_payload["seed_pattern"] = seed_match
+        delta_payload["expand_hops"] = expand_hops
+
+    # 导出（全部基于 dict payload，不依赖 GraphBuilder 内部状态）
     if args.output:
+        import json as _json
+
+        from ovp_pipeline.graph.visualize import GraphVisualizer
+
         output_path = Path(args.output)
-        if args.output.endswith('.json'):
-            builder.export_json(output_path)
-        elif args.output.endswith('.graphml'):
-            builder.export_graphml(output_path)
+        suffix = output_path.suffix.lower()
+        if suffix == ".json":
+            output_path.write_text(
+                _json.dumps(delta_payload, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+            print(f"✅ 已导出 JSON: {output_path}")
+        elif suffix == ".graphml":
+            GraphVisualizer(delta_payload).export_graphml(output_path)
+        elif suffix in (".html", ".htm"):
+            GraphVisualizer(delta_payload).html(output_path)
+            if getattr(args, "open", False):
+                import webbrowser
+                webbrowser.open(f"file://{output_path.resolve()}")
+        else:
+            print(f"⚠️ 未知输出格式 {suffix!r}，支持 .json / .graphml / .html")
+            return 1
+
+    return 0
 
 
 def cmd_daily(args):
@@ -248,6 +416,26 @@ def main():
     # ovp-graph --build
     build_parser = subparsers.add_parser("build", help="全量构建图谱")
     build_parser.add_argument("--output", "-o", help="输出文件路径")
+    build_parser.add_argument(
+        "--seed-match",
+        help="正则匹配 title/note_id，把命中节点作为种子并截取子图",
+    )
+    build_parser.add_argument(
+        "--expand-hops",
+        type=int,
+        default=1,
+        help="--seed-match 命中后向邻居扩展的跳数 (默认 1)",
+    )
+    build_parser.add_argument(
+        "--open",
+        action="store_true",
+        help="导出 .html 后自动在浏览器打开",
+    )
+    build_parser.add_argument(
+        "--no-index",
+        action="store_true",
+        help="跳过 knowledge.db，强制扫盘构建（默认走 db，秒级；扫盘可能十分钟）",
+    )
 
     # ovp-graph --daily
     daily_parser = subparsers.add_parser("daily", help="生成每日增量图谱")

--- a/src/ovp_pipeline/graph_cli.py
+++ b/src/ovp_pipeline/graph_cli.py
@@ -159,15 +159,37 @@ def cmd_build(args):
             print(f"⚠️ --seed-match {seed_match!r} 没有匹配到任何节点")
             return 1
 
-        edge_index = {edge["edge_id"]: edge for edge in all_edges}
+        # --source-walk: 剔除 evergreen↔evergreen / evergreen↔moc 这种"概念内部"
+        # 的边，让 BFS 从概念种子直接跳到产生它的源文档（deep_dive / raw / article ...）
+        # 而不是在 evergreen 网里空转。
+        traversal_edges = all_edges
+        if getattr(args, "source_walk", False):
+            type_by_id = {n["note_id"]: n.get("note_type", "") for n in all_nodes}
+            bridge_types = {"evergreen", "moc"}
+            traversal_edges = [
+                e
+                for e in all_edges
+                if not (
+                    type_by_id.get(e["source"]) in bridge_types
+                    and type_by_id.get(e["target"]) in bridge_types
+                )
+            ]
+            print(
+                f"🚦 source-walk: 剔除 evergreen/moc 之间的桥接边"
+                f" ({len(all_edges) - len(traversal_edges)}/{len(all_edges)})"
+            )
+
+        edge_index = {edge["edge_id"]: edge for edge in traversal_edges}
         delta_helper = DailyDelta(vault_dir)
         expanded_ids, distance_map = delta_helper._expand_hops(
             seed_ids, edge_index, expand_hops
         )
 
         all_nodes = [n for n in all_nodes if n["note_id"] in expanded_ids]
+        # 渲染用的边集和 BFS 用的边集保持一致——source-walk 模式下不要把刚剔掉的
+        # evergreen↔evergreen 桥又画回到图上，否则视觉上还是一团 evergreen mesh
         all_edges = [
-            e for e in all_edges
+            e for e in traversal_edges
             if e["source"] in expanded_ids and e["target"] in expanded_ids
         ]
         for node in all_nodes:
@@ -435,6 +457,12 @@ def main():
         "--no-index",
         action="store_true",
         help="跳过 knowledge.db，强制扫盘构建（默认走 db，秒级；扫盘可能十分钟）",
+    )
+    build_parser.add_argument(
+        "--source-walk",
+        action="store_true",
+        help="BFS 时剔除 evergreen↔evergreen / evergreen↔moc 边，让 evergreen 种子"
+             "直接跳到产生它的源文档（deep_dive / raw / article），而不是在概念网里空转",
     )
 
     # ovp-graph --daily

--- a/src/ovp_pipeline/graph_cli.py
+++ b/src/ovp_pipeline/graph_cli.py
@@ -84,6 +84,83 @@ def _load_graph_from_index(vault_dir: Path) -> tuple[list[dict], list[dict], Pat
     return nodes, edges, db_path
 
 
+# 概念网类型：evergreen 是原子概念，moc 是索引页，两者一起构成"概念波"。
+# --layered 模式下，hop 2 跳到非概念网的节点 (即 source markdown / 原文档)。
+#
+# 之所以用"反白名单"而不是正向枚举 source 类型：vault 里 source markdown 的
+# note_type 字段实际有 50+ 种变体（deep_dive / technical-analysis / engineering /
+# ai-skill / 论文深度解读 / Threat Intelligence Report ...），每加一个 pack 都要
+# 维护这个列表会持续踩坑。任何"非 evergreen 非 moc"都视为源文档更稳。
+CONCEPT_NETWORK_TYPES = frozenset({"evergreen", "moc"})
+
+
+def _is_source_markdown(note_type: str) -> bool:
+    return bool(note_type) and note_type not in CONCEPT_NETWORK_TYPES
+
+
+def _expand_layered(
+    seed_ids: set[str],
+    edge_index: dict,
+    type_by_id: dict[str, str],
+) -> tuple[set[str], dict[str, int], list[dict]]:
+    """两层 BFS（用于 --layered）：
+
+        hop 1: 从 seed 出发，只跳到 evergreen 邻居（"概念波"）
+        hop 2: 从概念波（evergreen seed + hop1 evergreen）出发，
+               只跳到 source markdown（deep_dive / raw / article ...）
+
+    返回 (expanded_ids, distance_map, used_edges)。used_edges 只包含
+    BFS 实际走过的边，避免把剔除掉的 evergreen↔evergreen 桥又画回到子图上。
+    """
+    adjacency: dict[str, list[dict]] = {}
+    for edge in edge_index.values():
+        adjacency.setdefault(edge["source"], []).append(edge)
+        adjacency.setdefault(edge["target"], []).append(edge)
+
+    expanded = set(seed_ids)
+    distance_map: dict[str, int] = {sid: 0 for sid in seed_ids}
+    used_edges: list[dict] = []
+    used_edge_ids: set[str] = set()
+
+    def _record(edge: dict) -> None:
+        eid = edge["edge_id"]
+        if eid not in used_edge_ids:
+            used_edges.append(edge)
+            used_edge_ids.add(eid)
+
+    # Hop 1: seeds → evergreen 邻居
+    hop1: set[str] = set()
+    for sid in seed_ids:
+        for edge in adjacency.get(sid, ()):
+            other = edge["target"] if edge["source"] == sid else edge["source"]
+            if other in expanded:
+                continue
+            if type_by_id.get(other) == "evergreen":
+                hop1.add(other)
+                _record(edge)
+    expanded |= hop1
+    for nid in hop1:
+        distance_map[nid] = 1
+
+    # Hop 2: 概念层（evergreen seed + hop1 evergreen）→ source markdown
+    concept_layer = {sid for sid in seed_ids if type_by_id.get(sid) == "evergreen"}
+    concept_layer |= hop1
+    hop2: set[str] = set()
+    for cid in concept_layer:
+        for edge in adjacency.get(cid, ()):
+            other = edge["target"] if edge["source"] == cid else edge["source"]
+            if other in expanded:
+                continue
+            if _is_source_markdown(type_by_id.get(other, "")):
+                hop2.add(other)
+                _record(edge)
+    expanded |= hop2
+    for nid in hop2:
+        distance_map[nid] = 2
+
+    return expanded, distance_map, used_edges
+
+
 def _scan_graph_from_filesystem(vault_dir: Path) -> tuple[list[dict], list[dict]]:
     """扫盘 fallback：当 knowledge.db 还没建立时使用。"""
     from ovp_pipeline.graph import GraphBuilder
@@ -159,48 +236,74 @@ def cmd_build(args):
             print(f"⚠️ --seed-match {seed_match!r} 没有匹配到任何节点")
             return 1
 
-        # --source-walk: 剔除 evergreen↔evergreen / evergreen↔moc 这种"概念内部"
-        # 的边，让 BFS 从概念种子直接跳到产生它的源文档（deep_dive / raw / article ...）
-        # 而不是在 evergreen 网里空转。
-        traversal_edges = all_edges
-        if getattr(args, "source_walk", False):
-            type_by_id = {n["note_id"]: n.get("note_type", "") for n in all_nodes}
-            bridge_types = {"evergreen", "moc"}
-            traversal_edges = [
-                e
-                for e in all_edges
-                if not (
-                    type_by_id.get(e["source"]) in bridge_types
-                    and type_by_id.get(e["target"]) in bridge_types
+        layered = getattr(args, "layered", False)
+        source_walk = getattr(args, "source_walk", False)
+        if layered and source_walk:
+            print("❌ --layered 和 --source-walk 互斥，请只选一个")
+            return 1
+
+        type_by_id = {n["note_id"]: n.get("note_type", "") for n in all_nodes}
+
+        if layered:
+            if expand_hops != 1:
+                print(
+                    f"ℹ️  --layered 固定为两层（hop1=evergreen, hop2=source-md），"
+                    f"忽略 --expand-hops {expand_hops}"
                 )
-            ]
-            print(
-                f"🚦 source-walk: 剔除 evergreen/moc 之间的桥接边"
-                f" ({len(all_edges) - len(traversal_edges)}/{len(all_edges)})"
+            edge_index = {edge["edge_id"]: edge for edge in all_edges}
+            expanded_ids, distance_map, used_edges = _expand_layered(
+                seed_ids, edge_index, type_by_id
+            )
+            all_nodes = [n for n in all_nodes if n["note_id"] in expanded_ids]
+            # 只画 BFS 实际走过的边，否则 hop1 的 evergreen 之间又会拉一堆桥
+            all_edges = used_edges
+            mode_label = "--layered (hop1=evergreen, hop2=source-md)"
+        else:
+            # --source-walk: 剔除 evergreen↔evergreen / evergreen↔moc 这种"概念内部"
+            # 的边，让 BFS 从概念种子直接跳到产生它的源文档（deep_dive / raw / article ...）
+            # 而不是在 evergreen 网里空转。
+            traversal_edges = all_edges
+            if source_walk:
+                bridge_types = {"evergreen", "moc"}
+                traversal_edges = [
+                    e
+                    for e in all_edges
+                    if not (
+                        type_by_id.get(e["source"]) in bridge_types
+                        and type_by_id.get(e["target"]) in bridge_types
+                    )
+                ]
+                print(
+                    f"🚦 source-walk: 剔除 evergreen/moc 之间的桥接边"
+                    f" ({len(all_edges) - len(traversal_edges)}/{len(all_edges)})"
+                )
+
+            edge_index = {edge["edge_id"]: edge for edge in traversal_edges}
+            delta_helper = DailyDelta(vault_dir)
+            expanded_ids, distance_map = delta_helper._expand_hops(
+                seed_ids, edge_index, expand_hops
             )
 
-        edge_index = {edge["edge_id"]: edge for edge in traversal_edges}
-        delta_helper = DailyDelta(vault_dir)
-        expanded_ids, distance_map = delta_helper._expand_hops(
-            seed_ids, edge_index, expand_hops
-        )
+            all_nodes = [n for n in all_nodes if n["note_id"] in expanded_ids]
+            # 渲染用的边集和 BFS 用的边集保持一致——source-walk 模式下不要把刚剔掉的
+            # evergreen↔evergreen 桥又画回到图上，否则视觉上还是一团 evergreen mesh
+            all_edges = [
+                e for e in traversal_edges
+                if e["source"] in expanded_ids and e["target"] in expanded_ids
+            ]
+            mode_label = f"--expand-hops {expand_hops}" + (
+                " --source-walk" if source_walk else ""
+            )
 
-        all_nodes = [n for n in all_nodes if n["note_id"] in expanded_ids]
-        # 渲染用的边集和 BFS 用的边集保持一致——source-walk 模式下不要把刚剔掉的
-        # evergreen↔evergreen 桥又画回到图上，否则视觉上还是一团 evergreen mesh
-        all_edges = [
-            e for e in traversal_edges
-            if e["source"] in expanded_ids and e["target"] in expanded_ids
-        ]
         for node in all_nodes:
-            distance = distance_map.get(node["note_id"], expand_hops + 1)
+            distance = distance_map.get(node["note_id"], 99)
             node["distance_from_seed"] = distance
             if distance == 0:
                 node["seed_role"] = "seed"
             else:
                 node["seed_role"] = f"neighbor_{min(distance, 3)}hop"
 
-        print(f"\n🎯 子图过滤 (--seed-match {seed_match!r}, --expand-hops {expand_hops}):")
+        print(f"\n🎯 子图过滤 (--seed-match {seed_match!r}, {mode_label}):")
         print(f"   Seeds: {len(seed_ids)}")
         print(f"   节点: {len(all_nodes)}")
         print(f"   边: {len(all_edges)}")
@@ -463,6 +566,13 @@ def main():
         action="store_true",
         help="BFS 时剔除 evergreen↔evergreen / evergreen↔moc 边，让 evergreen 种子"
              "直接跳到产生它的源文档（deep_dive / raw / article），而不是在概念网里空转",
+    )
+    build_parser.add_argument(
+        "--layered",
+        action="store_true",
+        help="两层 BFS：hop1 只扩 evergreen 邻居（概念波），"
+             "hop2 只从这些 evergreen 跳到 source markdown。--expand-hops 被忽略。"
+             "和 --source-walk 互斥",
     )
 
     # ovp-graph --daily

--- a/src/ovp_pipeline/graph_cli.py
+++ b/src/ovp_pipeline/graph_cli.py
@@ -28,6 +28,14 @@ def _load_graph_from_index(vault_dir: Path) -> tuple[list[dict], list[dict], Pat
 
     pages_index → nodes、page_links → edges。Registry 解析在那边一次性跑完，
     这里只做 SELECT，比扫盘快几个数量级。
+
+    *额外补充*：absorb 管道把 evergreen 从源文档抽出来后**不会**回写
+    `[[concept]]` 到源文档 body 里，所以 page_links 里压根没有
+    "source_md → evergreen" 的边。但每次 promote 都发了一条
+    `evergreen_auto_promoted` 审计事件，里面带 (concept, source) 对。
+    我们在这里把这条隐式 provenance 翻译成显式 graph edge
+    (`edge_type='promoted_from'`)，不然图谱里几乎所有源文档都会"漂"在
+    evergreen 网外面。
     """
     import sqlite3
 
@@ -80,6 +88,40 @@ def _load_graph_from_index(vault_dir: Path) -> tuple[list[dict], list[dict], Pat
                 "anchor_text": target_raw or "",
                 "evidence_line": line_number or 0,
             })
+
+        # Provenance edges: source MD → evergreen，从 audit_events 重建
+        # （audit_events.payload_json.source 是 basename，所以用 LIKE '%/'||source 匹配 path）
+        promo_count = 0
+        for src_slug, concept_slug in conn.execute(
+            """
+            SELECT DISTINCT p_src.slug, p_concept.slug
+            FROM audit_events a
+            JOIN pages_index p_src
+              ON p_src.path LIKE '%/' || json_extract(a.payload_json, '$.source')
+            JOIN pages_index p_concept
+              ON p_concept.slug = json_extract(a.payload_json, '$.concept')
+            WHERE a.event_type='evergreen_auto_promoted'
+            """
+        ):
+            if not src_slug or not concept_slug or src_slug == concept_slug:
+                continue
+            edge_id = f"promoted-{src_slug}-{concept_slug}"
+            if edge_id in seen_edges:
+                continue
+            seen_edges.add(edge_id)
+            edges.append({
+                "edge_id": edge_id,
+                "source": src_slug,
+                "target": concept_slug,
+                "edge_type": "promoted_from",
+                "weight": 1.0,
+                "is_new_today": False,
+                "anchor_text": "",
+                "evidence_line": 0,
+            })
+            promo_count += 1
+        if promo_count:
+            print(f"📜 Provenance: 从 audit_events 补 {promo_count} 条 source→evergreen 边")
 
     return nodes, edges, db_path
 

--- a/src/ovp_pipeline/knowledge_index.py
+++ b/src/ovp_pipeline/knowledge_index.py
@@ -38,10 +38,14 @@ CREATE TABLE pages_index (
   body TEXT NOT NULL
 );
 
+-- Trigram tokenizer gives substring-style matching that works for English
+-- and CJK alike (the default unicode61 tokenizer treats consecutive Chinese
+-- characters as one opaque token, missing every mid-sentence query).
 CREATE VIRTUAL TABLE page_fts USING fts5(
   slug UNINDEXED,
   title,
-  body
+  body,
+  tokenize='trigram'
 );
 
 CREATE TABLE page_links (

--- a/src/ovp_pipeline/truth_api.py
+++ b/src/ovp_pipeline/truth_api.py
@@ -593,6 +593,69 @@ def _escape_like(value: str) -> str:
     return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
+_CJK_RE = re.compile(r"[\u4e00-\u9fff]")
+_ASCII_TOKEN_RE = re.compile(r"[A-Za-z0-9]+")
+
+
+def _tokenize_for_search(query: str) -> list[str]:
+    """Split a free-form query into searchable tokens.
+
+    English words come straight from a word-character regex. Chinese segments
+    are run through jieba (when available) so that "智能体记忆" splits into
+    ["智能体", "记忆"] instead of being treated as one opaque blob — which is
+    what the FTS5 unicode61 tokenizer would otherwise see.
+    """
+    if not query or not query.strip():
+        return []
+    lowered = query.lower()
+    tokens: list[str] = []
+    seen: set[str] = set()
+
+    def _add(tok: str) -> None:
+        tok = tok.strip()
+        if not tok or tok in seen:
+            return
+        # Drop pure ASCII single chars (too noisy); keep single Chinese chars.
+        if len(tok) == 1 and not _CJK_RE.match(tok):
+            return
+        seen.add(tok)
+        tokens.append(tok)
+
+    # ASCII words first — covers `agent-memory`, `RAG`, `gpt-4`.
+    for match in _ASCII_TOKEN_RE.findall(lowered):
+        _add(match)
+
+    # Chinese segments via jieba (best-effort: degrade to char-level if absent).
+    if _CJK_RE.search(lowered):
+        try:
+            import jieba
+
+            for word in jieba.cut(lowered):
+                if _CJK_RE.search(word):
+                    _add(word)
+        except ImportError:
+            for ch in lowered:
+                if _CJK_RE.match(ch):
+                    _add(ch)
+    return tokens
+
+
+def _build_fts_match(tokens: list[str]) -> str:
+    """Quote each token and AND them together into an FTS5 MATCH expression.
+
+    The trigram tokenizer silently drops tokens shorter than 3 characters
+    (anything that can't fit a full trigram), so an AND-clause containing a
+    2-char token would force the whole query to return nothing. Filter those
+    out here and let the caller decide whether to fall back to a substring
+    scan when no tokens remain.
+    """
+    long_enough = [tok for tok in tokens if len(tok) >= 3]
+    if not long_enough:
+        return ""
+    quoted = [f'"{tok.replace(chr(34), chr(34) * 2)}"' for tok in long_enough]
+    return " AND ".join(quoted)
+
+
 def _parse_frontmatter(markdown: str) -> dict[str, Any]:
     fenced_match = _FENCED_FRONTMATTER_RE.match(markdown)
     if fenced_match:
@@ -1369,84 +1432,205 @@ def search_vault_surface(
     vault_dir: Path | str,
     *,
     query: str,
-    object_limit: int = 25,
-    note_limit: int = 25,
+    object_limit: int = 50,
+    note_limit: int = 50,
+    object_offset: int = 0,
+    note_offset: int = 0,
     pack_name: str | None = None,
 ) -> dict[str, Any]:
     normalized_query = query.strip()
-    object_limit, _ = _validate_page_args(limit=object_limit, offset=0)
-    note_limit, _ = _validate_page_args(limit=note_limit, offset=0)
+    object_limit, object_offset = _validate_page_args(limit=object_limit, offset=object_offset)
+    note_limit, note_offset = _validate_page_args(limit=note_limit, offset=note_offset)
     requested_pack = _truth_pack_name(pack_name)
     if not normalized_query:
         return {
             "query": "",
             "objects": [],
             "notes": [],
+            "object_total": 0,
+            "note_total": 0,
+            "object_offset": object_offset,
+            "note_offset": note_offset,
+            "object_limit": object_limit,
+            "note_limit": note_limit,
+        }
+    tokens = _tokenize_for_search(normalized_query)
+    if not tokens:
+        return {
+            "query": normalized_query,
+            "objects": [],
+            "notes": [],
+            "object_total": 0,
+            "note_total": 0,
+            "object_offset": object_offset,
+            "note_offset": note_offset,
+            "object_limit": object_limit,
+            "note_limit": note_limit,
         }
     db_path = _db_path(vault_dir)
     resolved_vault = resolve_vault_dir(vault_dir)
     pack_candidates = _materialized_truth_packs(
         vault_dir, pack_name=pack_name, table_name="objects"
     )
-    escaped_query = _escape_like(normalized_query.lower())
-    with sqlite3.connect(db_path) as conn:
-        object_rows = conn.execute(
-            f"""
-            SELECT DISTINCT objects.object_id, objects.object_kind, objects.title, objects.canonical_path, objects.source_slug, objects.pack
-            FROM objects
-            LEFT JOIN compiled_summaries
-              ON compiled_summaries.pack = objects.pack
-             AND compiled_summaries.object_id = objects.object_id
-            LEFT JOIN claims
-              ON claims.pack = objects.pack
-             AND claims.object_id = objects.object_id
-            WHERE objects.pack IN ({",".join("?" for _ in pack_candidates)})
-              AND (
-                lower(objects.object_id) LIKE ? ESCAPE '\\'
-                OR lower(objects.title) LIKE ? ESCAPE '\\'
-                OR lower(objects.source_slug) LIKE ? ESCAPE '\\'
-                OR lower(compiled_summaries.summary_text) LIKE ? ESCAPE '\\'
-                OR lower(claims.claim_text) LIKE ? ESCAPE '\\'
-              )
-            ORDER BY objects.object_id
-            LIMIT ?
-            """,
-            (
-                *pack_candidates,
-                f"%{escaped_query}%",
-                f"%{escaped_query}%",
-                f"%{escaped_query}%",
-                f"%{escaped_query}%",
-                f"%{escaped_query}%",
-                object_limit,
-            ),
-        ).fetchall()
-        note_rows = conn.execute(
-            """
+
+    # Objects: per-token (field1 LIKE %tok% OR ...) joined by AND so a query
+    # like "agent memory" matches a row mentioning the words anywhere, not
+    # only as a contiguous substring. Then rank by a hand-rolled relevance
+    # score (no FTS index on objects) so a title containing the literal
+    # phrase "agent memory" beats one whose object_id just happens to come
+    # first alphabetically.
+    object_fields = (
+        "objects.object_id",
+        "objects.title",
+        "objects.source_slug",
+        "compiled_summaries.summary_text",
+        "claims.claim_text",
+    )
+    token_clauses: list[str] = []
+    base_object_filter_params: list[Any] = list(pack_candidates)
+    for tok in tokens:
+        like = f"%{_escape_like(tok)}%"
+        token_clauses.append(
+            "("
+            + " OR ".join(f"lower({field}) LIKE ? ESCAPE '\\'" for field in object_fields)
+            + ")"
+        )
+        base_object_filter_params.extend([like] * len(object_fields))
+    object_join_where = f"""
+        FROM objects
+        LEFT JOIN compiled_summaries
+          ON compiled_summaries.pack = objects.pack
+         AND compiled_summaries.object_id = objects.object_id
+        LEFT JOIN claims
+          ON claims.pack = objects.pack
+         AND claims.object_id = objects.object_id
+        WHERE objects.pack IN ({",".join("?" for _ in pack_candidates)})
+          AND {" AND ".join(token_clauses)}
+    """
+    object_count_sql = f"""
+        SELECT COUNT(*) FROM (
+            SELECT DISTINCT objects.object_id
+            {object_join_where}
+        )
+    """
+    # Relevance: full phrase in title is the strongest signal; slug phrase
+    # next; then per-token title/slug hits. Higher = better, so we ORDER DESC.
+    title_lower_query = normalized_query.lower()
+    per_token_title_bonus = " + ".join(
+        "CASE WHEN instr(lower(objects.title), ?) > 0 THEN 10 ELSE 0 END" for _ in tokens
+    )
+    per_token_slug_bonus = " + ".join(
+        "CASE WHEN instr(lower(objects.object_id), ?) > 0 THEN 5 ELSE 0 END" for _ in tokens
+    )
+    object_relevance_expr = (
+        "CASE WHEN instr(lower(objects.title), ?) > 0 THEN 100 ELSE 0 END"
+        " + CASE WHEN instr(lower(objects.object_id), ?) > 0 THEN 50 ELSE 0 END"
+        f" + ({per_token_title_bonus})"
+        f" + ({per_token_slug_bonus})"
+    )
+    object_relevance_params = (
+        title_lower_query,
+        title_lower_query,
+        *tokens,  # per_token_title_bonus
+        *tokens,  # per_token_slug_bonus
+    )
+    object_sql = f"""
+        SELECT DISTINCT objects.object_id, objects.object_kind, objects.title,
+               objects.canonical_path, objects.source_slug, objects.pack,
+               {object_relevance_expr} AS relevance
+        {object_join_where}
+        ORDER BY relevance DESC, objects.object_id
+        LIMIT ? OFFSET ?
+    """
+
+    # Notes: feed jieba-tokenized query into FTS5 (`page_fts`) and rank by
+    # bm25 with the title column boosted, plus explicit title-substring
+    # bonuses so a note titled "agent memory" beats a note that just
+    # mentions "memory" many times in its body. Trigram tokenizer can't
+    # index <3-char tokens, so when every token is too short (e.g. a bare
+    # 2-char Chinese query like "记忆") we fall back to a per-token
+    # body-LIKE scan. Note: bm25() weights are positional across ALL
+    # declared columns including UNINDEXED ones, so the schema
+    # (slug UNINDEXED, title, body) takes three weights:
+    # (slug=ignored, title=5x, body=1x). The bonuses subtract from rank
+    # because FTS5 bm25 is negative-better.
+    fts_match = _build_fts_match(tokens)
+    if fts_match:
+        title_lower_query = normalized_query.lower()
+        # Per-token title bonus accumulates so multi-word out-of-order title
+        # matches still rise above body-only ones.
+        per_token_bonus_sql = " + ".join(
+            "CASE WHEN instr(lower(pages_index.title), ?) > 0 THEN 2.0 ELSE 0.0 END"
+            for _ in tokens
+        )
+        # Whole-query phrase bonus: a literal substring hit in the title is
+        # the strongest signal a human would want surfaced first.
+        rank_expr = (
+            "bm25(page_fts, 1.0, 5.0, 1.0)"
+            f" - ({per_token_bonus_sql})"
+            " - CASE WHEN instr(lower(pages_index.title), ?) > 0 THEN 8.0 ELSE 0.0 END"
+        )
+        note_count_sql = """
+            SELECT COUNT(*) FROM page_fts WHERE page_fts MATCH ?
+        """
+        note_sql = f"""
+            SELECT pages_index.slug, pages_index.title, pages_index.note_type,
+                   pages_index.path, {rank_expr} AS rank
+            FROM page_fts
+            JOIN pages_index ON pages_index.slug = page_fts.slug
+            WHERE page_fts MATCH ?
+            ORDER BY rank
+            LIMIT ? OFFSET ?
+        """
+        note_count_params: tuple[Any, ...] = (fts_match,)
+        note_params = (
+            *tokens,
+            title_lower_query,
+            fts_match,
+            note_limit,
+            note_offset,
+        )
+    else:
+        note_token_clauses: list[str] = []
+        note_like_params: list[Any] = []
+        for tok in tokens:
+            like = f"%{_escape_like(tok)}%"
+            note_token_clauses.append(
+                "(lower(slug) LIKE ? ESCAPE '\\' OR lower(title) LIKE ? ESCAPE '\\' "
+                "OR lower(path) LIKE ? ESCAPE '\\' OR lower(body) LIKE ? ESCAPE '\\')"
+            )
+            note_like_params.extend([like] * 4)
+        note_where = f"WHERE {' AND '.join(note_token_clauses)}"
+        note_count_sql = f"SELECT COUNT(*) FROM pages_index {note_where}"
+        note_sql = f"""
             SELECT slug, title, note_type, path
             FROM pages_index
-            WHERE lower(slug) LIKE ? ESCAPE '\\'
-               OR lower(title) LIKE ? ESCAPE '\\'
-               OR lower(path) LIKE ? ESCAPE '\\'
-               OR lower(body) LIKE ? ESCAPE '\\'
-            ORDER BY
-              CASE note_type
-                WHEN 'evergreen' THEN 0
-                WHEN 'deep_dive' THEN 1
-                WHEN 'moc' THEN 2
-                ELSE 3
-              END,
-              slug
-            LIMIT ?
-            """,
+            {note_where}
+            ORDER BY slug
+            LIMIT ? OFFSET ?
+        """
+        note_count_params = tuple(note_like_params)
+        note_params = (*note_like_params, note_limit, note_offset)
+    with sqlite3.connect(db_path) as conn:
+        object_total = conn.execute(
+            object_count_sql, tuple(base_object_filter_params)
+        ).fetchone()[0]
+        object_rows = conn.execute(
+            object_sql,
             (
-                f"%{escaped_query}%",
-                f"%{escaped_query}%",
-                f"%{escaped_query}%",
-                f"%{escaped_query}%",
-                note_limit,
+                *object_relevance_params,
+                *base_object_filter_params,
+                object_limit,
+                object_offset,
             ),
         ).fetchall()
+        try:
+            note_total = conn.execute(note_count_sql, note_count_params).fetchone()[0]
+            note_rows = conn.execute(note_sql, note_params).fetchall()
+        except sqlite3.OperationalError:
+            # FTS query parser rejected the expression — fall back to empty.
+            note_total = 0
+            note_rows = []
 
     objects = [
         {
@@ -1473,6 +1657,12 @@ def search_vault_surface(
         "query": normalized_query,
         "objects": objects,
         "notes": notes,
+        "object_total": int(object_total),
+        "note_total": int(note_total),
+        "object_offset": object_offset,
+        "note_offset": note_offset,
+        "object_limit": object_limit,
+        "note_limit": note_limit,
     }
 
 

--- a/src/ovp_pipeline/truth_api.py
+++ b/src/ovp_pipeline/truth_api.py
@@ -1555,6 +1555,10 @@ def search_vault_surface(
     # (slug=ignored, title=5x, body=1x). The bonuses subtract from rank
     # because FTS5 bm25 is negative-better.
     fts_match = _build_fts_match(tokens)
+    # Trigram FTS5 can't index <3-char tokens, so they were dropped from the
+    # MATCH expression. Re-apply them as LIKE filters against pages_index so a
+    # query like "AI agent" doesn't return every "agent" page regardless of "AI".
+    short_tokens = [tok for tok in tokens if len(tok) < 3]
     if fts_match:
         title_lower_query = normalized_query.lower()
         # Per-token title bonus accumulates so multi-word out-of-order title
@@ -1570,23 +1574,39 @@ def search_vault_surface(
             f" - ({per_token_bonus_sql})"
             " - CASE WHEN instr(lower(pages_index.title), ?) > 0 THEN 8.0 ELSE 0.0 END"
         )
-        note_count_sql = """
-            SELECT COUNT(*) FROM page_fts WHERE page_fts MATCH ?
+        short_filter_sql = ""
+        short_filter_params: list[Any] = []
+        if short_tokens:
+            short_clauses: list[str] = []
+            for tok in short_tokens:
+                like = f"%{_escape_like(tok)}%"
+                short_clauses.append(
+                    "(lower(pages_index.title) LIKE ? ESCAPE '\\' "
+                    "OR lower(pages_index.body) LIKE ? ESCAPE '\\' "
+                    "OR lower(pages_index.slug) LIKE ? ESCAPE '\\')"
+                )
+                short_filter_params.extend([like] * 3)
+            short_filter_sql = " AND " + " AND ".join(short_clauses)
+        note_count_sql = f"""
+            SELECT COUNT(*) FROM page_fts
+            JOIN pages_index ON pages_index.slug = page_fts.slug
+            WHERE page_fts MATCH ?{short_filter_sql}
         """
         note_sql = f"""
             SELECT pages_index.slug, pages_index.title, pages_index.note_type,
                    pages_index.path, {rank_expr} AS rank
             FROM page_fts
             JOIN pages_index ON pages_index.slug = page_fts.slug
-            WHERE page_fts MATCH ?
+            WHERE page_fts MATCH ?{short_filter_sql}
             ORDER BY rank
             LIMIT ? OFFSET ?
         """
-        note_count_params: tuple[Any, ...] = (fts_match,)
+        note_count_params: tuple[Any, ...] = (fts_match, *short_filter_params)
         note_params = (
             *tokens,
             title_lower_query,
             fts_match,
+            *short_filter_params,
             note_limit,
             note_offset,
         )

--- a/src/ovp_pipeline/ui/view_models.py
+++ b/src/ovp_pipeline/ui/view_models.py
@@ -3708,9 +3708,22 @@ def build_search_payload(
     *,
     query: str,
     pack_name: str | None = None,
+    page: int = 1,
+    page_size: int = 50,
 ) -> dict[str, Any]:
     requested_pack = pack_name or ""
-    results = search_vault_surface(vault_dir, query=query, pack_name=pack_name)
+    page = max(1, int(page))
+    page_size = max(1, min(int(page_size), 200))
+    offset = (page - 1) * page_size
+    results = search_vault_surface(
+        vault_dir,
+        query=query,
+        pack_name=pack_name,
+        object_limit=page_size,
+        note_limit=page_size,
+        object_offset=offset,
+        note_offset=offset,
+    )
     return {
         "screen": "search/results",
         "requested_pack": requested_pack,
@@ -3737,6 +3750,8 @@ def build_search_payload(
         ],
         "object_count": len(results["objects"]),
         "note_count": len(results["notes"]),
+        "page": page,
+        "page_size": page_size,
     }
 
 

--- a/tests/test_graph_seed_match.py
+++ b/tests/test_graph_seed_match.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from ovp_pipeline.graph_cli import cmd_build
+
+
+def _write_note(directory: Path, slug: str, title: str, links: list[str] = ()) -> None:
+    body = "\n".join(f"[[{target}]]" for target in links)
+    (directory / f"{slug}.md").write_text(
+        "---\n"
+        f'title: "{title}"\n'
+        "type: evergreen\n"
+        "date: 2026-04-07\n"
+        "---\n\n"
+        f"# {title}\n\n"
+        f"{body}\n",
+        encoding="utf-8",
+    )
+
+
+def _make_vault(tmp_path: Path) -> Path:
+    vault = tmp_path / "vault"
+    evergreen = vault / "10-Knowledge" / "Evergreen"
+    evergreen.mkdir(parents=True)
+
+    # Two seeds (titles match "agent memory")
+    _write_note(evergreen, "Agent-Memory-Core", "Agent Memory Core",
+                links=["Episodic Buffer"])
+    _write_note(evergreen, "Agent-Memory-Eviction", "Agent Memory Eviction",
+                links=["Cache Policy"])
+
+    # 1-hop neighbours (no "agent memory" in title — only reachable by edge)
+    _write_note(evergreen, "Episodic-Buffer", "Episodic Buffer",
+                links=["LLM Context Window"])
+    _write_note(evergreen, "Cache-Policy", "Cache Policy")
+
+    # 2-hop (only included with --expand-hops 2+)
+    _write_note(evergreen, "LLM-Context-Window", "LLM Context Window")
+
+    # Unrelated (must never appear)
+    _write_note(evergreen, "Investing-Notes", "Investing Notes")
+    return vault
+
+
+def _build_args(vault: Path, output: Path, *, seed_match=None, expand_hops=1,
+                open=False, no_index=True):
+    # 默认 no_index=True：现有用例走扫盘路径，避免依赖 ovp-knowledge-index 的 fixture
+    return argparse.Namespace(
+        vault_dir=vault,
+        output=str(output),
+        seed_match=seed_match,
+        expand_hops=expand_hops,
+        open=open,
+        no_index=no_index,
+    )
+
+
+def test_build_seed_match_extracts_subgraph_with_one_hop(tmp_path):
+    vault = _make_vault(tmp_path)
+    output = tmp_path / "subgraph.json"
+
+    rc = cmd_build(_build_args(vault, output, seed_match="agent memory", expand_hops=1))
+    assert rc == 0
+
+    data = json.loads(output.read_text(encoding="utf-8"))
+    titles = {n["title"] for n in data["nodes"]}
+
+    # Both seeds + both 1-hop neighbours
+    assert "Agent Memory Core" in titles
+    assert "Agent Memory Eviction" in titles
+    assert "Episodic Buffer" in titles
+    assert "Cache Policy" in titles
+
+    # 2-hop and unrelated must be excluded at hops=1
+    assert "LLM Context Window" not in titles
+    assert "Investing Notes" not in titles
+
+    # Subgraph metadata is preserved
+    assert data["seed_pattern"] == "agent memory"
+    assert data["expand_hops"] == 1
+    assert data["stats"]["expanded_node_count"] == len(data["nodes"])
+
+    # Seed roles are annotated
+    by_title = {n["title"]: n for n in data["nodes"]}
+    assert by_title["Agent Memory Core"]["seed_role"] == "seed"
+    assert by_title["Agent Memory Core"]["distance_from_seed"] == 0
+    assert by_title["Episodic Buffer"]["seed_role"] == "neighbor_1hop"
+    assert by_title["Episodic Buffer"]["distance_from_seed"] == 1
+
+
+def test_build_seed_match_expand_hops_two_includes_second_neighbour(tmp_path):
+    vault = _make_vault(tmp_path)
+    output = tmp_path / "subgraph.json"
+
+    rc = cmd_build(_build_args(vault, output, seed_match="agent memory", expand_hops=2))
+    assert rc == 0
+
+    data = json.loads(output.read_text(encoding="utf-8"))
+    titles = {n["title"] for n in data["nodes"]}
+
+    assert "LLM Context Window" in titles
+    assert "Investing Notes" not in titles
+
+    by_title = {n["title"]: n for n in data["nodes"]}
+    assert by_title["LLM Context Window"]["seed_role"] == "neighbor_2hop"
+    assert by_title["LLM Context Window"]["distance_from_seed"] == 2
+
+
+def test_build_seed_match_no_match_returns_error(tmp_path):
+    vault = _make_vault(tmp_path)
+    output = tmp_path / "subgraph.json"
+
+    rc = cmd_build(_build_args(vault, output, seed_match="nonexistent-topic"))
+    assert rc == 1
+    assert not output.exists()
+
+
+def test_build_html_escapes_script_tags_in_node_titles(tmp_path):
+    """节点 title 字面包含 '</script>' 时必须转义，否则 <script> 块被提前关闭、
+    后续 JSON 当 HTML 渲染（用户实测：legend 后大段 JSON 文字泄露）。"""
+    from ovp_pipeline.graph.visualize import GraphVisualizer
+
+    payload = {
+        "day_id": "test",
+        "generated_at": "2026-04-23",
+        "nodes": [
+            {
+                "note_id": "evil",
+                "title": "Title with </script><img src=x> in it",
+                "note_type": "evergreen",
+                "seed_role": "seed",
+            }
+        ],
+        "edges": [],
+        "seed_note_ids": ["evil"],
+    }
+    out = tmp_path / "evil.html"
+    GraphVisualizer(payload).html(out)
+    html = out.read_text(encoding="utf-8")
+
+    # vis.js bundle close + body script close = 2; any third means injection escaped
+    assert html.count("</script>") == 2
+    # And the title content survives (just escaped) so the node still renders
+    assert "<\\/script>" in html
+
+
+def test_build_seed_match_writes_interactive_html(tmp_path):
+    vault = _make_vault(tmp_path)
+    output = tmp_path / "subgraph.html"
+
+    rc = cmd_build(_build_args(vault, output, seed_match="agent memory", expand_hops=1))
+    assert rc == 0
+    assert output.exists()
+
+    html = output.read_text(encoding="utf-8")
+    # vis.js bundle + every kept node label rendered into the page
+    assert "vis-network" in html
+    assert "Agent Memory Core" in html
+    assert "Episodic Buffer" in html
+    assert "Investing Notes" not in html
+
+
+def test_build_uses_knowledge_db_when_available(tmp_path):
+    """默认走 knowledge.db，跳过昂贵的 registry 解析；扫盘 fallback 仅在 db 缺失时触发。"""
+    from ovp_pipeline.knowledge_index import rebuild_knowledge_index
+
+    vault = _make_vault(tmp_path)
+    rebuild_knowledge_index(vault)
+    output = tmp_path / "from-db.json"
+
+    rc = cmd_build(_build_args(vault, output, seed_match="agent memory",
+                               expand_hops=1, no_index=False))
+    assert rc == 0
+
+    data = json.loads(output.read_text(encoding="utf-8"))
+    titles = {n["title"] for n in data["nodes"]}
+
+    # 同样的子图过滤语义在两条路径下都成立
+    assert "Agent Memory Core" in titles
+    assert "Agent Memory Eviction" in titles
+    assert "Episodic Buffer" in titles
+    assert "Cache Policy" in titles
+    assert "LLM Context Window" not in titles
+    assert "Investing Notes" not in titles
+    assert data["seed_pattern"] == "agent memory"
+
+
+def test_build_falls_back_to_filesystem_when_db_missing(tmp_path, capsys):
+    vault = _make_vault(tmp_path)
+    output = tmp_path / "fallback.json"
+
+    # 没跑 rebuild_knowledge_index，knowledge.db 不存在
+    rc = cmd_build(_build_args(vault, output, seed_match="agent memory",
+                               expand_hops=1, no_index=False))
+    assert rc == 0
+
+    out = capsys.readouterr().out
+    assert "knowledge.db" in out and "回退" in out
+
+    data = json.loads(output.read_text(encoding="utf-8"))
+    assert any(n["title"] == "Agent Memory Core" for n in data["nodes"])
+
+
+def test_build_without_seed_match_writes_full_graph(tmp_path):
+    vault = _make_vault(tmp_path)
+    output = tmp_path / "full.json"
+
+    rc = cmd_build(_build_args(vault, output))
+    assert rc == 0
+
+    data = json.loads(output.read_text(encoding="utf-8"))
+    titles = {n["title"] for n in data["nodes"]}
+
+    # Full-graph mode: every note is present, no seed_pattern key
+    assert "Investing Notes" in titles
+    assert "seed_pattern" not in data

--- a/tests/test_graph_seed_match.py
+++ b/tests/test_graph_seed_match.py
@@ -7,12 +7,13 @@ from pathlib import Path
 from ovp_pipeline.graph_cli import cmd_build
 
 
-def _write_note(directory: Path, slug: str, title: str, links: list[str] = ()) -> None:
+def _write_note(directory: Path, slug: str, title: str, links: list[str] = (),
+                note_type: str = "evergreen") -> None:
     body = "\n".join(f"[[{target}]]" for target in links)
     (directory / f"{slug}.md").write_text(
         "---\n"
         f'title: "{title}"\n'
-        "type: evergreen\n"
+        f"type: {note_type}\n"
         "date: 2026-04-07\n"
         "---\n\n"
         f"# {title}\n\n"
@@ -46,7 +47,7 @@ def _make_vault(tmp_path: Path) -> Path:
 
 
 def _build_args(vault: Path, output: Path, *, seed_match=None, expand_hops=1,
-                open=False, no_index=True):
+                open=False, no_index=True, source_walk=False):
     # 默认 no_index=True：现有用例走扫盘路径，避免依赖 ovp-knowledge-index 的 fixture
     return argparse.Namespace(
         vault_dir=vault,
@@ -55,6 +56,7 @@ def _build_args(vault: Path, output: Path, *, seed_match=None, expand_hops=1,
         expand_hops=expand_hops,
         open=open,
         no_index=no_index,
+        source_walk=source_walk,
     )
 
 
@@ -202,6 +204,43 @@ def test_build_falls_back_to_filesystem_when_db_missing(tmp_path, capsys):
 
     data = json.loads(output.read_text(encoding="utf-8"))
     assert any(n["title"] == "Agent Memory Core" for n in data["nodes"])
+
+
+def test_build_source_walk_skips_evergreen_bridges_to_reach_deep_dive(tmp_path):
+    """--source-walk 模式：从 evergreen 种子出发，1 跳就能到引用它的源 markdown
+    (deep_dive)，而不是被困在 evergreen 之间互链上。"""
+    vault = tmp_path / "vault"
+    evergreen = vault / "10-Knowledge" / "Evergreen"
+    areas = vault / "20-Areas" / "Topics" / "2026-04"
+    evergreen.mkdir(parents=True)
+    areas.mkdir(parents=True)
+
+    # Seed evergreen, also linked to another evergreen (the noisy bridge)
+    _write_note(evergreen, "Agent-Memory-Core", "Agent Memory Core",
+                links=["Episodic Buffer"])
+    # Bridge evergreen — without source-walk, BFS would land here on hop 1
+    _write_note(evergreen, "Episodic-Buffer", "Episodic Buffer",
+                links=["Cache Policy"])
+    _write_note(evergreen, "Cache-Policy", "Cache Policy")
+
+    # Source markdown that REFERENCES the seed evergreen — this is what user wants
+    _write_note(areas, "agent-memory-deep-dive", "Agent Memory 深度解读",
+                links=["Agent Memory Core"], note_type="deep_dive")
+
+    output = tmp_path / "src.json"
+    rc = cmd_build(_build_args(vault, output, seed_match="agent memory",
+                               expand_hops=1, source_walk=True))
+    assert rc == 0
+
+    data = json.loads(output.read_text(encoding="utf-8"))
+    titles = {n["title"] for n in data["nodes"]}
+
+    # Deep dive (the source markdown) must reach the result via the surviving edge
+    assert "Agent Memory 深度解读" in titles
+    # Bridge evergreens must NOT be pulled in (their evergreen↔evergreen edges
+    # were stripped from the BFS adjacency)
+    assert "Episodic Buffer" not in titles
+    assert "Cache Policy" not in titles
 
 
 def test_build_without_seed_match_writes_full_graph(tmp_path):

--- a/tests/test_graph_seed_match.py
+++ b/tests/test_graph_seed_match.py
@@ -47,7 +47,7 @@ def _make_vault(tmp_path: Path) -> Path:
 
 
 def _build_args(vault: Path, output: Path, *, seed_match=None, expand_hops=1,
-                open=False, no_index=True, source_walk=False):
+                open=False, no_index=True, source_walk=False, layered=False):
     # 默认 no_index=True：现有用例走扫盘路径，避免依赖 ovp-knowledge-index 的 fixture
     return argparse.Namespace(
         vault_dir=vault,
@@ -57,6 +57,7 @@ def _build_args(vault: Path, output: Path, *, seed_match=None, expand_hops=1,
         open=open,
         no_index=no_index,
         source_walk=source_walk,
+        layered=layered,
     )
 
 
@@ -122,31 +123,43 @@ def test_build_seed_match_no_match_returns_error(tmp_path):
 
 def test_build_html_escapes_script_tags_in_node_titles(tmp_path):
     """节点 title 字面包含 '</script>' 时必须转义，否则 <script> 块被提前关闭、
-    后续 JSON 当 HTML 渲染（用户实测：legend 后大段 JSON 文字泄露）。"""
+    后续 JSON 当 HTML 渲染（用户实测：legend 后大段 JSON 文字泄露）。
+
+    用 baseline diff 判断：渲染恶意 title 的 HTML 中 </script> 个数应等于
+    空 vault 渲染出的基线，否则就说明 title 注入了一个新的 </script>。
+    """
     from ovp_pipeline.graph.visualize import GraphVisualizer
 
-    payload = {
+    benign_payload = {
         "day_id": "test",
         "generated_at": "2026-04-23",
         "nodes": [
             {
-                "note_id": "evil",
-                "title": "Title with </script><img src=x> in it",
+                "note_id": "ok",
+                "title": "Plain title",
                 "note_type": "evergreen",
                 "seed_role": "seed",
             }
         ],
         "edges": [],
-        "seed_note_ids": ["evil"],
+        "seed_note_ids": ["ok"],
     }
-    out = tmp_path / "evil.html"
-    GraphVisualizer(payload).html(out)
-    html = out.read_text(encoding="utf-8")
+    evil_payload = dict(benign_payload, nodes=[
+        {
+            "note_id": "evil",
+            "title": "Title with </script><img src=x> in it",
+            "note_type": "evergreen",
+            "seed_role": "seed",
+        }
+    ], seed_note_ids=["evil"])
 
-    # vis.js bundle close + body script close = 2; any third means injection escaped
-    assert html.count("</script>") == 2
-    # And the title content survives (just escaped) so the node still renders
-    assert "<\\/script>" in html
+    benign_html = GraphVisualizer(benign_payload).html(tmp_path / "ok.html")
+    evil_html = GraphVisualizer(evil_payload).html(tmp_path / "evil.html")
+
+    # 注入的 </script> 必须被转义掉，所以两份 HTML 的 </script> 计数相等
+    assert evil_html.count("</script>") == benign_html.count("</script>")
+    # 转义后的字面串出现在 JSON payload 里
+    assert "<\\/script>" in evil_html
 
 
 def test_build_seed_match_writes_interactive_html(tmp_path):
@@ -158,8 +171,8 @@ def test_build_seed_match_writes_interactive_html(tmp_path):
     assert output.exists()
 
     html = output.read_text(encoding="utf-8")
-    # vis.js bundle + every kept node label rendered into the page
-    assert "vis-network" in html
+    # cytoscape bundle + every kept node label rendered into the page
+    assert "cytoscape" in html
     assert "Agent Memory Core" in html
     assert "Episodic Buffer" in html
     assert "Investing Notes" not in html
@@ -241,6 +254,86 @@ def test_build_source_walk_skips_evergreen_bridges_to_reach_deep_dive(tmp_path):
     # were stripped from the BFS adjacency)
     assert "Episodic Buffer" not in titles
     assert "Cache Policy" not in titles
+
+
+def test_build_layered_keeps_evergreen_hop1_and_source_hop2(tmp_path):
+    """--layered: hop1 只到 evergreen，hop2 只到这些 evergreen 的 source markdown。
+
+    场景设计：
+        seed (Agent Memory Core, evergreen)
+            ├─[evergreen→evergreen]─→ Episodic Buffer (evergreen)            # hop1 ✅
+            │                              └─[deep_dive→evergreen]─ Buffer Deep Dive (deep_dive)  # hop2 ✅
+            ├─[evergreen→moc]──────→ MOC AI Memory (moc)                     # hop1 ✗ (非 evergreen)
+            └─[deep_dive→evergreen]─ Direct Source (deep_dive)               # hop1 ✗ (非 evergreen)；
+                                                                              # hop2 ✅ (seed 是 evergreen)
+        Episodic Buffer
+            └─[evergreen→evergreen]─ Cache Policy (evergreen)
+                                       └─ Cache Deep Dive (deep_dive)        # 不应进入：超过 2 跳
+    """
+    vault = tmp_path / "vault"
+    evergreen = vault / "10-Knowledge" / "Evergreen"
+    atlas = vault / "10-Knowledge" / "Atlas"
+    areas = vault / "20-Areas" / "Topics" / "2026-04"
+    evergreen.mkdir(parents=True)
+    atlas.mkdir(parents=True)
+    areas.mkdir(parents=True)
+
+    _write_note(evergreen, "Agent-Memory-Core", "Agent Memory Core",
+                links=["Episodic Buffer"])
+    _write_note(evergreen, "Episodic-Buffer", "Episodic Buffer",
+                links=["Cache Policy"])
+    _write_note(evergreen, "Cache-Policy", "Cache Policy")
+
+    # MOC 引用 seed —— 不应在 hop1 出现（hop1 限定 evergreen）
+    _write_note(atlas, "MOC-AI-Memory", "MOC AI Memory",
+                links=["Agent Memory Core"], note_type="moc")
+
+    # Source markdown 直接引用 seed —— hop2 应包含
+    _write_note(areas, "direct-source", "Direct Source",
+                links=["Agent Memory Core"], note_type="deep_dive")
+    # Source markdown 引用 hop1 evergreen —— hop2 应包含
+    _write_note(areas, "buffer-deep-dive", "Buffer Deep Dive",
+                links=["Episodic Buffer"], note_type="deep_dive")
+    # Source markdown 引用超出层之外的 Cache Policy —— 不应包含
+    _write_note(areas, "cache-deep-dive", "Cache Deep Dive",
+                links=["Cache Policy"], note_type="deep_dive")
+
+    output = tmp_path / "layered.json"
+    rc = cmd_build(_build_args(vault, output, seed_match="agent memory",
+                               layered=True))
+    assert rc == 0
+
+    data = json.loads(output.read_text(encoding="utf-8"))
+    by_title = {n["title"]: n for n in data["nodes"]}
+
+    # Seed (hop 0)
+    assert by_title["Agent Memory Core"]["distance_from_seed"] == 0
+
+    # Hop 1: evergreen 邻居
+    assert "Episodic Buffer" in by_title
+    assert by_title["Episodic Buffer"]["distance_from_seed"] == 1
+    # MOC 不应在 hop 1（被 evergreen-only 过滤掉）
+    assert "MOC AI Memory" not in by_title
+
+    # Hop 2: source markdowns of seed + hop1 evergreens
+    assert "Direct Source" in by_title
+    assert by_title["Direct Source"]["distance_from_seed"] == 2
+    assert "Buffer Deep Dive" in by_title
+    assert by_title["Buffer Deep Dive"]["distance_from_seed"] == 2
+
+    # 超出 2 层的不能进来
+    assert "Cache Policy" not in by_title       # 是 evergreen 但只能从 hop1 evergreen 跳
+    assert "Cache Deep Dive" not in by_title    # 4 跳路径
+
+
+def test_build_layered_rejects_combo_with_source_walk(tmp_path):
+    vault = _make_vault(tmp_path)
+    output = tmp_path / "layered.json"
+
+    rc = cmd_build(_build_args(vault, output, seed_match="agent memory",
+                               layered=True, source_walk=True))
+    assert rc == 1
+    assert not output.exists()
 
 
 def test_build_without_seed_match_writes_full_graph(tmp_path):

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -1855,6 +1855,167 @@ Mentions [[source-note]].
     )
 
 
+def test_truth_api_search_matches_words_out_of_order(temp_vault):
+    """A query should match a row that contains the words anywhere, not only
+    as one contiguous substring — the LIKE-substring search this replaced
+    silently dropped any match where the words were re-ordered or split by
+    intervening text."""
+    from ovp_pipeline.truth_api import search_vault_surface
+
+    vault = _seed_truth_vault(temp_vault)
+    note = vault / "10-Knowledge" / "Evergreen" / "Reordered.md"
+    note.write_text(
+        """---
+note_id: reordered-note
+title: Reordered Note
+type: evergreen
+date: 2026-04-13
+---
+
+# Reordered Note
+
+Memory persists across sessions for every agent we operate.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(vault)
+
+    payload = search_vault_surface(vault, query="agent memory")
+    note_slugs = {item["slug"] for item in payload["notes"]}
+    assert "reordered-note" in note_slugs
+
+
+def test_truth_api_search_paginates_and_reports_totals(temp_vault):
+    """The seed vault has multiple notes mentioning 'agent harness'. Asking
+    for page_size=1 must return one row plus a total >= 2 so the UI can show
+    a real pager instead of pretending the first slice is the whole result."""
+    from ovp_pipeline.truth_api import search_vault_surface
+
+    vault = _seed_truth_vault(temp_vault)
+    page1 = search_vault_surface(vault, query="agent harness", note_limit=1, note_offset=0)
+    page2 = search_vault_surface(vault, query="agent harness", note_limit=1, note_offset=1)
+
+    assert page1["note_total"] >= 2
+    assert page1["note_total"] == page2["note_total"]
+    assert len(page1["notes"]) == 1
+    assert len(page2["notes"]) == 1
+    assert {n["slug"] for n in page1["notes"]} != {n["slug"] for n in page2["notes"]}
+
+
+def test_truth_api_search_ranks_objects_by_title_phrase_not_alphabetical(temp_vault):
+    """Objects pane was sorting by `object_id` ASC, so any concept whose
+    slug starts with 'a' beat real title hits. Title-phrase matches must now
+    win regardless of where they fall alphabetically."""
+    from ovp_pipeline.truth_api import search_vault_surface
+
+    vault = temp_vault
+    ev = vault / "10-Knowledge" / "Evergreen"
+    ev.mkdir(parents=True, exist_ok=True)
+    # Slug starts with 'a' so it would alphabetically come first.
+    (ev / "Adjacent.md").write_text(
+        """---
+note_id: adjacent-memory-topic
+title: Adjacent memory topic about agents
+type: evergreen
+date: 2026-04-13
+---
+
+Mentions agent and memory in body.
+""",
+        encoding="utf-8",
+    )
+    # Slug starts with 'z' but title literally contains 'agent memory'.
+    (ev / "Zenith.md").write_text(
+        """---
+note_id: zenith-agent-memory
+title: agent memory layer
+type: evergreen
+date: 2026-04-13
+---
+
+Body content about agent memory.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(vault)
+
+    payload = search_vault_surface(vault, query="agent memory")
+    object_ids = [o["object_id"] for o in payload["objects"]]
+    assert "zenith-agent-memory" in object_ids and "adjacent-memory-topic" in object_ids
+    assert object_ids.index("zenith-agent-memory") < object_ids.index("adjacent-memory-topic")
+
+
+def test_truth_api_search_ranks_title_matches_above_body_only_matches(temp_vault):
+    """Title hits must outrank body-only hits — the previous bm25 call left
+    the title column at default weight, so notes with the query in the body
+    sometimes beat notes whose title literally was the query."""
+    from ovp_pipeline.truth_api import search_vault_surface
+
+    vault = temp_vault
+    ev = vault / "10-Knowledge" / "Evergreen"
+    ev.mkdir(parents=True, exist_ok=True)
+    (ev / "Title-hit.md").write_text(
+        """---
+note_id: title-hit
+title: Agent memory systems
+type: evergreen
+date: 2026-04-13
+---
+
+Some unrelated body text about caches.
+""",
+        encoding="utf-8",
+    )
+    (ev / "Body-only.md").write_text(
+        """---
+note_id: body-only
+title: Caching strategies
+type: evergreen
+date: 2026-04-13
+---
+
+The agent has a memory subsystem with memory eviction and memory tiering.
+The memory layer is the agent's long-term storage. agent memory.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(vault)
+
+    payload = search_vault_surface(vault, query="agent memory")
+    note_slugs = [n["slug"] for n in payload["notes"]]
+    assert "title-hit" in note_slugs and "body-only" in note_slugs
+    assert note_slugs.index("title-hit") < note_slugs.index("body-only")
+
+
+def test_truth_api_search_supports_chinese_via_jieba(temp_vault):
+    """Chinese queries should be jieba-segmented before hitting FTS — without
+    that step the FTS5 unicode61 tokenizer treats the whole CJK run as one
+    opaque blob and misses every page."""
+    from ovp_pipeline.truth_api import search_vault_surface
+
+    vault = _seed_truth_vault(temp_vault)
+    note = vault / "10-Knowledge" / "Evergreen" / "智能体记忆.md"
+    note.write_text(
+        """---
+note_id: chinese-memory-note
+title: 智能体的记忆机制
+type: evergreen
+date: 2026-04-13
+---
+
+# 智能体的记忆机制
+
+智能体通过持久化的记忆来跨会话维持上下文与状态。
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(vault)
+
+    payload = search_vault_surface(vault, query="智能体 记忆")
+    note_slugs = {item["slug"] for item in payload["notes"]}
+    assert "chinese-memory-note" in note_slugs
+
+
 def test_truth_api_resolves_deep_dive_source_note_from_frontmatter_and_logs(temp_vault):
     from ovp_pipeline.truth_api import get_note_provenance
 


### PR DESCRIPTION
## Summary

Two coherent threads sitting on `main` ahead of `origin/main`:

### A. Vault search & concept-resolution performance
- `Speed up concept resolution with trigram pruning and mention cache` — slashed per-link `resolve_mention` cost; underlies the graph-build speedup below.
- `Rework vault search: FTS5, relevance ranking, pagination, jieba` — `truth_api` now uses FTS5 + BM25 with jieba CJK tokenization, paginated; `ui_server` + `view_models` updated; new `tests/test_truth_api.py` covering ranking + pagination.

### B. `ovp-graph build` — full rework
1. **`--seed-match <regex>`** to extract a subgraph around topic seeds, sourced from `knowledge.db` (was scanning the filesystem and per-link `resolve_mention` — 15 minutes → ~3 seconds on prod).
2. **`--source-walk`** strips evergreen↔evergreen / evergreen↔moc bridge edges so BFS doesn't get stuck in the concept mesh.
3. **`--layered`** — two-wave BFS the user asked for: hop 1 = evergreen neighbours of seeds, hop 2 = source markdowns of those evergreens. Mutually exclusive with `--source-walk`. Source detection is a negative test (`NOT IN {evergreen, moc}`) since the prod vault has 50+ source `note_type` variants and a positive whitelist would silently drop half.
4. **Audit-event provenance edges** — the absorb pipeline doesn't write `[[concept]]` wikilinks back into source markdowns, so `page_links` had ~zero source→evergreen edges. We now JOIN `audit_events.evergreen_auto_promoted` against `pages_index` at index-load time and synthesize ~6.2K real `source → evergreen` edges (`edge_type='promoted_from'`). Without this, `--layered` hop 2 was returning 0 source MDs even when the vault clearly had them.
5. **Cytoscape.js visualizer** replaces vis.js. New layout: sidebar with type/hop filters + search + view buttons; canvas with type-coloured nodes + cose-bilkent clustering + click-to-highlight; right detail panel with title/type/distance/path and clickable in/out neighbours. `</script>` injection escape preserved and re-tested with a baseline-diff invariant so future template changes don't break it.

Smoke verification (prod vault `~/Documents/openclaw-vault`):
- `--seed-match "agent memory" --layered`: 12 seeds → 23 hop-1 evergreens → 11 hop-2 source MDs (deep_dives like "Why memory isnt a plugin its the harness", OpenHarness, etc.). Was 0 before audit-event provenance landed.
- `--seed-match "MCP Protocol" --layered`: 27 → 124 → 70 hop-2 source MDs across 13 distinct note_types.

## Test plan

- [x] `pytest -q` — 830 passing locally
- [x] `tests/test_graph_seed_match.py` — 11 cases covering `--seed-match`, `--expand-hops`, `--source-walk`, `--layered`, JSON / HTML / GraphML outputs, `</script>` injection escape, knowledge.db source path, scan fallback
- [x] `tests/test_truth_api.py` — new ranking + pagination + jieba coverage
- [x] Smoke `ovp-graph build --layered` against prod vault, viewed result in Cytoscape HTML
- [ ] Reviewer to open `/tmp/agent-memory-layered.html` (or generate fresh) and confirm interaction is materially better than the previous vis.js renderer

## Notes for review

- The two threads (A & B) are file-disjoint — A touches `concept_registry`, `truth_api`, `ui_server`, `view_models`, `knowledge_index`; B touches `graph_cli`, `graph/visualize`, `tests/test_graph_seed_match`. Easy to split into two PRs if preferred.
- `audit_events` provenance ingestion already runs as part of `ovp-knowledge-index`, so no migration / backfill is needed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/49" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search results now support pagination with previous/next page navigation
  * Graph visualization redesigned with interactive features: searchable node titles, filterable note types, dynamic neighbor highlighting, and node detail panels
  * Added graph filtering options including seed matching for subgraph extraction and layered traversal modes
  * Improved search ranking to prioritize relevant results and added support for Chinese language queries

* **Performance**
  * Accelerated concept name resolution through optimized search indexing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->