### PR TITLE
Phase 38.A: canonical Evergreen file-level dedup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,7 @@ ovp-init = "ovp_pipeline.commands.init_project:main"
 ovp-ui = "ovp_pipeline.commands.ui_server:main"
 ovp-mcp = "ovp_pipeline.commands.mcp:main"
 ovp-note-type-normalize = "ovp_pipeline.commands.note_type_normalize:main"
+ovp-concept-dedup = "ovp_pipeline.commands.concept_dedup:main"
 
 [project.entry-points."ovp.packs"]
 default-knowledge = "ovp_pipeline.packs.default_knowledge:get_pack"

--- a/src/ovp_pipeline/commands/concept_dedup.py
+++ b/src/ovp_pipeline/commands/concept_dedup.py
@@ -1,0 +1,176 @@
+"""``ovp-concept-dedup`` — Phase 38.A canonical Evergreen file dedup CLI.
+
+Three subcommands:
+
+  propose [--threshold 0.82] [--write]
+      Scan ``10-Knowledge/Evergreen/`` for near-duplicate clusters and print
+      the report. With ``--write`` (or no ``--dry-run``) save the proposal as
+      JSON to ``60-Logs/dedup-proposals/`` for later application.
+
+  list
+      Show all pending proposals.
+
+  apply <proposal-id-or-path> [--dry-run] [--only <slug,slug,...>]
+      Execute the proposal: archive duplicates, rewrite wikilinks, update
+      canonical aliases, update concept registry (best effort), emit
+      ``concept_merged`` audit events.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from ..concept_dedup import (
+    DEFAULT_THRESHOLD,
+    apply_proposal,
+    find_clusters,
+    list_proposals,
+    load_proposal,
+    write_proposal,
+)
+from ..runtime import resolve_vault_dir
+
+
+def _resolve_proposal_path(vault_dir: Path, ident: str) -> Path:
+    candidate = Path(ident)
+    if candidate.is_file():
+        return candidate
+    direct = vault_dir / "60-Logs" / "dedup-proposals" / ident
+    if direct.is_file():
+        return direct
+    if not direct.suffix:
+        with_suffix = direct.with_suffix(".json")
+        if with_suffix.is_file():
+            return with_suffix
+    matches = [p for p in list_proposals(vault_dir) if ident in p.name]
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1:
+        raise SystemExit(
+            f"Ambiguous proposal '{ident}'; matches: {', '.join(m.name for m in matches)}"
+        )
+    raise SystemExit(f"Proposal not found: {ident}")
+
+
+def _cmd_propose(args: argparse.Namespace) -> int:
+    vault_dir = resolve_vault_dir(args.vault_dir)
+    clusters = find_clusters(vault_dir, threshold=args.threshold)
+    if not clusters:
+        print(f"No duplicate clusters found at threshold {args.threshold}.")
+        return 0
+
+    total_dups = sum(len(c.duplicates) for c in clusters)
+    print(
+        f"Found {len(clusters)} cluster(s) covering {total_dups} duplicate file(s) "
+        f"(threshold={args.threshold})."
+    )
+    for i, cluster in enumerate(clusters, 1):
+        print(
+            f"\n[{i}] canonical={cluster.canonical.slug} "
+            f"({cluster.canonical.size_bytes}B, similarity≥{cluster.min_similarity:.2f})"
+        )
+        for dup in cluster.duplicates:
+            print(f"      → {dup.slug} ({dup.size_bytes}B)")
+
+    if args.write:
+        path, proposal = write_proposal(vault_dir, clusters, threshold=args.threshold)
+        print(f"\nProposal written: {path}")
+        print(f"Apply with: ovp-concept-dedup apply {proposal.proposal_id} --dry-run")
+    else:
+        print("\n(dry run — re-run with --write to save a proposal file)")
+    return 0
+
+
+def _cmd_list(args: argparse.Namespace) -> int:
+    vault_dir = resolve_vault_dir(args.vault_dir)
+    proposals = list_proposals(vault_dir)
+    if not proposals:
+        print("No pending proposals.")
+        return 0
+    print(f"{len(proposals)} proposal(s):")
+    for path in proposals:
+        try:
+            proposal = load_proposal(path)
+            n = len(proposal.clusters)
+            d = sum(len(c.duplicates) for c in proposal.clusters)
+            print(f"  {proposal.proposal_id}  ({n} clusters, {d} duplicates)  {path}")
+        except Exception as exc:
+            print(f"  ! {path.name}  unreadable: {exc}")
+    return 0
+
+
+def _cmd_apply(args: argparse.Namespace) -> int:
+    vault_dir = resolve_vault_dir(args.vault_dir)
+    path = _resolve_proposal_path(vault_dir, args.proposal)
+    proposal = load_proposal(path)
+
+    only = None
+    if args.only:
+        only = {s.strip() for s in args.only.split(",") if s.strip()}
+
+    results = apply_proposal(
+        vault_dir,
+        proposal,
+        dry_run=args.dry_run,
+        pack=args.pack or "",
+        only_canonicals=only,
+    )
+
+    if not results:
+        print("No clusters matched filter.")
+        return 0
+
+    archived = sum(len(r.archived) for r in results)
+    rewrites = sum(r.wikilink_rewrites for r in results)
+    errors = sum(len(r.errors) for r in results)
+    mode = "DRY RUN" if args.dry_run else "APPLIED"
+    print(f"[{mode}] {len(results)} cluster(s): {archived} archived, {rewrites} wikilinks rewritten, {errors} error(s)")
+    for r in results:
+        line = f"  {r.canonical_slug}: archived={len(r.archived)} rewrites={r.wikilink_rewrites} aliases={len(r.aliases_added)} registry={r.registry_updated}"
+        if r.errors:
+            line += f" errors={r.errors}"
+        print(line)
+    return 0 if errors == 0 else 1
+
+
+def _add_common(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--vault-dir", type=Path, default=None)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="ovp-concept-dedup")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_propose = sub.add_parser("propose", help="Scan vault and print/save a dedup proposal")
+    _add_common(p_propose)
+    p_propose.add_argument("--threshold", type=float, default=DEFAULT_THRESHOLD)
+    p_propose.add_argument(
+        "--write",
+        action="store_true",
+        help="Save the proposal to 60-Logs/dedup-proposals/ (otherwise dry-print only)",
+    )
+    p_propose.set_defaults(func=_cmd_propose)
+
+    p_list = sub.add_parser("list", help="List pending proposals")
+    _add_common(p_list)
+    p_list.set_defaults(func=_cmd_list)
+
+    p_apply = sub.add_parser("apply", help="Apply a proposal")
+    _add_common(p_apply)
+    p_apply.add_argument("proposal", help="Proposal id or path to JSON file")
+    p_apply.add_argument("--dry-run", action="store_true")
+    p_apply.add_argument("--pack", default="")
+    p_apply.add_argument(
+        "--only",
+        help="Comma-separated canonical slugs to apply (skip other clusters in the proposal)",
+    )
+    p_apply.set_defaults(func=_cmd_apply)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ovp_pipeline/concept_dedup.py
+++ b/src/ovp_pipeline/concept_dedup.py
@@ -1,0 +1,533 @@
+"""Phase 38.A — Canonical Evergreen file-level deduplication.
+
+Identifies clusters of near-duplicate Evergreen files (e.g. 7 variants of
+"MCP Client") and merges them safely:
+
+  1. Find clusters by trigram-Jaccard over normalized slugs.
+  2. Write the proposal as JSON under ``60-Logs/dedup-proposals/`` so a human
+     can review before any file is touched.
+  3. ``apply`` the proposal:
+       - Archive each duplicate file to ``70-Archive/dedup-merged/<slug>.md``
+         (atomic rename; preserves git blame via ``git mv`` if available, but
+         falls back to ``Path.replace`` so tests don't need git).
+       - Add the duplicate slug to the canonical's ``aliases:`` frontmatter.
+       - Rewrite ``[[dup_slug]]`` / ``[[dup_slug#anchor]]`` /
+         ``[[dup_slug|display]]`` across the vault to point at the canonical
+         (display text and anchors are preserved).
+       - Emit a ``concept_merged`` audit event to
+         ``60-Logs/concept-merges.jsonl``.
+       - Best-effort: if a ``ConceptRegistry`` is loadable, call
+         ``merge_as_alias`` so the registry tracks the redirect. Failure to
+         update the registry does not abort the merge — the JSONL audit log is
+         the truth, registry rebuild can replay it.
+
+The operation is **invertible**: archived files retain their original slug as
+the filename and their full content; the canonical's aliases list records the
+merge; the audit JSONL holds the full mapping.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+from .event_emitter import emit
+
+
+CONCEPT_MERGES_LOG = "concept-merges.jsonl"
+DEDUP_PROPOSALS_DIR = "dedup-proposals"
+DEDUP_ARCHIVE_DIR = "dedup-merged"
+DEFAULT_THRESHOLD = 0.82
+
+
+# ---------------------------------------------------------------------------
+# Data shapes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DedupCandidate:
+    slug: str
+    title: str
+    path: Path
+    size_bytes: int
+
+    def to_dict(self) -> dict:
+        return {
+            "slug": self.slug,
+            "title": self.title,
+            "path": str(self.path),
+            "size_bytes": self.size_bytes,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "DedupCandidate":
+        return cls(
+            slug=data["slug"],
+            title=data["title"],
+            path=Path(data["path"]),
+            size_bytes=int(data.get("size_bytes", 0)),
+        )
+
+
+@dataclass(frozen=True)
+class DedupCluster:
+    canonical: DedupCandidate
+    duplicates: tuple[DedupCandidate, ...]
+    min_similarity: float
+
+    def to_dict(self) -> dict:
+        return {
+            "canonical": self.canonical.to_dict(),
+            "duplicates": [d.to_dict() for d in self.duplicates],
+            "min_similarity": self.min_similarity,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "DedupCluster":
+        return cls(
+            canonical=DedupCandidate.from_dict(data["canonical"]),
+            duplicates=tuple(DedupCandidate.from_dict(d) for d in data["duplicates"]),
+            min_similarity=float(data["min_similarity"]),
+        )
+
+
+@dataclass(frozen=True)
+class DedupProposal:
+    proposal_id: str
+    created_at: str
+    threshold: float
+    clusters: tuple[DedupCluster, ...]
+
+    def to_dict(self) -> dict:
+        return {
+            "proposal_id": self.proposal_id,
+            "created_at": self.created_at,
+            "threshold": self.threshold,
+            "clusters": [c.to_dict() for c in self.clusters],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "DedupProposal":
+        return cls(
+            proposal_id=data["proposal_id"],
+            created_at=data["created_at"],
+            threshold=float(data["threshold"]),
+            clusters=tuple(DedupCluster.from_dict(c) for c in data["clusters"]),
+        )
+
+
+@dataclass
+class ApplyResult:
+    canonical_slug: str
+    archived: list[Path] = field(default_factory=list)
+    wikilink_rewrites: int = 0
+    aliases_added: list[str] = field(default_factory=list)
+    registry_updated: bool = False
+    audit_event_ids: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Cluster discovery
+# ---------------------------------------------------------------------------
+
+
+def _char_ngrams(text: str, n: int = 3) -> set[str]:
+    padded = f"  {text}  "
+    if len(padded) < n:
+        return {padded}
+    return {padded[i : i + n] for i in range(len(padded) - n + 1)}
+
+
+def trigram_jaccard(a: str, b: str) -> float:
+    ga = _char_ngrams(a)
+    gb = _char_ngrams(b)
+    if not ga or not gb:
+        return 0.0
+    return len(ga & gb) / len(ga | gb)
+
+
+def _normalize_slug_for_compare(slug: str) -> str:
+    return re.sub(r"[-_\s]+", " ", slug.strip().lower())
+
+
+_FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n", re.DOTALL)
+_TITLE_RE = re.compile(r'^title:\s*"?([^"\n]+)"?\s*$', re.MULTILINE)
+
+
+def _read_title(path: Path) -> str:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return path.stem
+    fm = _FRONTMATTER_RE.match(text)
+    if not fm:
+        return path.stem
+    title = _TITLE_RE.search(fm.group(1))
+    if title:
+        return title.group(1).strip().strip('"').strip("'")
+    return path.stem
+
+
+def _scan_evergreen(vault_dir: Path) -> list[DedupCandidate]:
+    evergreen_dir = vault_dir / "10-Knowledge" / "Evergreen"
+    if not evergreen_dir.exists():
+        return []
+    cands: list[DedupCandidate] = []
+    for md_file in sorted(evergreen_dir.glob("*.md")):
+        if md_file.stem.startswith(("_", ".")):
+            continue
+        try:
+            size = md_file.stat().st_size
+        except OSError:
+            continue
+        cands.append(
+            DedupCandidate(
+                slug=md_file.stem,
+                title=_read_title(md_file),
+                path=md_file,
+                size_bytes=size,
+            )
+        )
+    return cands
+
+
+def _cluster_by_similarity(
+    cands: list[DedupCandidate], threshold: float
+) -> list[tuple[list[DedupCandidate], float]]:
+    """Union-find clustering by trigram similarity over normalized slugs."""
+    n = len(cands)
+    parent = list(range(n))
+
+    def find(x: int) -> int:
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def union(a: int, b: int) -> None:
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[ra] = rb
+
+    edge_sims: dict[tuple[int, int], float] = {}
+    norms = [_normalize_slug_for_compare(c.slug) for c in cands]
+    for i in range(n):
+        for j in range(i + 1, n):
+            sim = trigram_jaccard(norms[i], norms[j])
+            if sim >= threshold:
+                edge_sims[(i, j)] = sim
+                union(i, j)
+
+    groups: dict[int, list[int]] = defaultdict(list)
+    for idx in range(n):
+        groups[find(idx)].append(idx)
+
+    out: list[tuple[list[DedupCandidate], float]] = []
+    for members in groups.values():
+        if len(members) < 2:
+            continue
+        # min similarity inside the cluster (drop singletons that joined via transitive union)
+        min_sim = min(
+            (edge_sims.get((min(a, b), max(a, b)), 1.0) for a in members for b in members if a < b),
+            default=1.0,
+        )
+        out.append(([cands[i] for i in members], min_sim))
+    return out
+
+
+def _pick_canonical(members: list[DedupCandidate]) -> DedupCandidate:
+    """Canonical = largest body (most curated content), tiebreak shortest slug, tiebreak slug asc."""
+    return max(members, key=lambda c: (c.size_bytes, -len(c.slug), -ord(c.slug[0]) if c.slug else 0))
+
+
+def find_clusters(vault_dir: Path, *, threshold: float = DEFAULT_THRESHOLD) -> list[DedupCluster]:
+    cands = _scan_evergreen(vault_dir)
+    raw = _cluster_by_similarity(cands, threshold=threshold)
+    clusters: list[DedupCluster] = []
+    for members, min_sim in raw:
+        canonical = _pick_canonical(members)
+        dups = tuple(sorted((m for m in members if m.slug != canonical.slug), key=lambda c: c.slug))
+        if not dups:
+            continue
+        clusters.append(DedupCluster(canonical=canonical, duplicates=dups, min_similarity=min_sim))
+    clusters.sort(key=lambda c: (-len(c.duplicates), c.canonical.slug))
+    return clusters
+
+
+# ---------------------------------------------------------------------------
+# Proposal storage
+# ---------------------------------------------------------------------------
+
+
+def _proposals_dir(vault_dir: Path) -> Path:
+    return vault_dir / "60-Logs" / DEDUP_PROPOSALS_DIR
+
+
+def _utc_now_text() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def write_proposal(
+    vault_dir: Path,
+    clusters: list[DedupCluster],
+    *,
+    threshold: float = DEFAULT_THRESHOLD,
+) -> tuple[Path, DedupProposal]:
+    proposal_id = f"dedup-{datetime.now().strftime('%Y%m%d-%H%M%S')}-{uuid.uuid4().hex[:6]}"
+    proposal = DedupProposal(
+        proposal_id=proposal_id,
+        created_at=_utc_now_text(),
+        threshold=threshold,
+        clusters=tuple(clusters),
+    )
+    out_dir = _proposals_dir(vault_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    path = out_dir / f"{proposal_id}.json"
+    path.write_text(json.dumps(proposal.to_dict(), ensure_ascii=False, indent=2), encoding="utf-8")
+    return path, proposal
+
+
+def list_proposals(vault_dir: Path) -> list[Path]:
+    out_dir = _proposals_dir(vault_dir)
+    if not out_dir.exists():
+        return []
+    return sorted(out_dir.glob("dedup-*.json"))
+
+
+def load_proposal(path: Path) -> DedupProposal:
+    return DedupProposal.from_dict(json.loads(path.read_text(encoding="utf-8")))
+
+
+# ---------------------------------------------------------------------------
+# Apply
+# ---------------------------------------------------------------------------
+
+
+_WIKILINK_RE = re.compile(r"\[\[([^\[\]\|#]+)(#[^\[\]\|]+)?(\|[^\[\]]+)?\]\]")
+_ALIASES_BLOCK_RE = re.compile(r"^aliases:\s*\[(.*?)\]", re.MULTILINE)
+_ALIASES_LINE_RE = re.compile(r"^aliases:\s*$", re.MULTILINE)
+
+
+def _rewrite_wikilinks(text: str, slug_map: dict[str, str]) -> tuple[str, int]:
+    """Replace ``[[old_slug...]]`` with ``[[new_slug...]]``. Anchor + display preserved."""
+    count = 0
+
+    def repl(match: re.Match) -> str:
+        nonlocal count
+        target, anchor, display = match.group(1), match.group(2) or "", match.group(3) or ""
+        new_target = slug_map.get(target.strip(), target)
+        if new_target != target:
+            count += 1
+            return f"[[{new_target}{anchor}{display}]]"
+        return match.group(0)
+
+    new_text = _WIKILINK_RE.sub(repl, text)
+    return new_text, count
+
+
+def _add_alias_to_frontmatter(text: str, alias: str) -> str:
+    """Add ``alias`` to the ``aliases:`` list in YAML frontmatter (idempotent)."""
+    fm_match = _FRONTMATTER_RE.match(text)
+    if not fm_match:
+        return text
+    fm_body = fm_match.group(1)
+    block_match = _ALIASES_BLOCK_RE.search(fm_body)
+    if block_match:
+        existing = block_match.group(1)
+        # naive parse — split on commas, strip quotes/whitespace
+        items = [s.strip().strip('"').strip("'") for s in existing.split(",") if s.strip()]
+        if alias in items:
+            return text
+        items.append(alias)
+        new_block = "aliases: [" + ", ".join(f'"{it}"' for it in items) + "]"
+        new_body = fm_body[: block_match.start()] + new_block + fm_body[block_match.end() :]
+    else:
+        # no aliases line — insert after first frontmatter line
+        new_body = fm_body.rstrip() + f'\naliases: ["{alias}"]'
+    return f"---\n{new_body}\n---\n" + text[fm_match.end() :]
+
+
+def _archive_dest(vault_dir: Path, slug: str) -> Path:
+    archive_dir = vault_dir / "70-Archive" / DEDUP_ARCHIVE_DIR
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    base = archive_dir / f"{slug}.md"
+    if not base.exists():
+        return base
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    return archive_dir / f"{slug}.{stamp}.md"
+
+
+def _iter_vault_md(vault_dir: Path) -> Iterable[Path]:
+    skip_dirs = {".git", ".obsidian", "70-Archive", "60-Logs"}
+    for md in vault_dir.rglob("*.md"):
+        parts = md.relative_to(vault_dir).parts
+        if any(p in skip_dirs for p in parts):
+            continue
+        yield md
+
+
+def _try_registry_merge(
+    vault_dir: Path, canonical_slug: str, dup_slugs: list[str]
+) -> tuple[bool, str | None]:
+    try:
+        from .concept_registry import ConceptRegistry  # local import — heavy module
+    except Exception as exc:  # pragma: no cover
+        return False, f"registry import failed: {exc}"
+
+    try:
+        registry = ConceptRegistry(vault_dir).load()
+    except Exception as exc:
+        return False, f"registry load failed: {exc}"
+
+    target = registry.find_by_slug(canonical_slug)
+    if not target:
+        # Canonical isn't tracked in the registry yet — that's fine, the
+        # frontmatter alias + audit log carry the truth. Not an error.
+        return False, None
+
+    merged_any = False
+    for dup_slug in dup_slugs:
+        cand = registry.find_by_slug(dup_slug)
+        if not cand:
+            continue
+        try:
+            registry.merge_as_alias(dup_slug, canonical_slug, [dup_slug])
+            merged_any = True
+        except Exception as exc:
+            return merged_any, f"merge_as_alias({dup_slug}) failed: {exc}"
+
+    if merged_any:
+        try:
+            registry.save()
+        except Exception as exc:
+            return False, f"registry save failed: {exc}"
+    return merged_any, None
+
+
+def apply_cluster(
+    vault_dir: Path,
+    cluster: DedupCluster,
+    *,
+    dry_run: bool = True,
+    pack: str = "",
+    proposal_id: str = "",
+) -> ApplyResult:
+    result = ApplyResult(canonical_slug=cluster.canonical.slug)
+    canonical_path = cluster.canonical.path
+    if not canonical_path.exists():
+        result.errors.append(f"canonical file missing: {canonical_path}")
+        return result
+
+    dup_slugs = [d.slug for d in cluster.duplicates]
+    slug_map = {dup: cluster.canonical.slug for dup in dup_slugs}
+
+    # 1. Rewrite wikilinks across vault (skip the duplicates themselves — about to archive).
+    dup_paths = {d.path for d in cluster.duplicates}
+    for md in _iter_vault_md(vault_dir):
+        if md in dup_paths:
+            continue
+        try:
+            text = md.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        new_text, count = _rewrite_wikilinks(text, slug_map)
+        if count == 0:
+            continue
+        result.wikilink_rewrites += count
+        if not dry_run:
+            md.write_text(new_text, encoding="utf-8")
+
+    # 2. Add duplicate slugs as aliases on canonical.
+    try:
+        canonical_text = canonical_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        result.errors.append(f"read canonical: {exc}")
+        return result
+    new_canonical_text = canonical_text
+    for dup_slug in dup_slugs:
+        before = new_canonical_text
+        new_canonical_text = _add_alias_to_frontmatter(new_canonical_text, dup_slug)
+        if new_canonical_text != before:
+            result.aliases_added.append(dup_slug)
+    if not dry_run and new_canonical_text != canonical_text:
+        canonical_path.write_text(new_canonical_text, encoding="utf-8")
+
+    # 3. Archive duplicates.
+    archived: list[tuple[Path, Path]] = []
+    for dup in cluster.duplicates:
+        if not dup.path.exists():
+            result.errors.append(f"duplicate missing: {dup.path}")
+            continue
+        dest = _archive_dest(vault_dir, dup.slug)
+        if dry_run:
+            result.archived.append(dest)
+            continue
+        try:
+            dup.path.rename(dest)
+        except OSError as exc:
+            result.errors.append(f"archive {dup.slug}: {exc}")
+            continue
+        result.archived.append(dest)
+        archived.append((dup.path, dest))
+
+    # 4. Best-effort registry merge.
+    if not dry_run:
+        ok, err = _try_registry_merge(vault_dir, cluster.canonical.slug, dup_slugs)
+        result.registry_updated = ok
+        if err:
+            result.errors.append(f"registry: {err}")
+
+    # 5. Audit event.
+    if not dry_run:
+        event = emit(
+            vault_dir,
+            CONCEPT_MERGES_LOG,
+            "concept_merged",
+            {
+                "proposal_id": proposal_id,
+                "canonical_slug": cluster.canonical.slug,
+                "canonical_path": str(canonical_path.relative_to(vault_dir)),
+                "merged_slugs": dup_slugs,
+                "archived_to": [str(p.relative_to(vault_dir)) for p in result.archived],
+                "wikilink_rewrites": result.wikilink_rewrites,
+                "aliases_added": result.aliases_added,
+                "registry_updated": result.registry_updated,
+                "min_similarity": cluster.min_similarity,
+            },
+            pack=pack,
+        )
+        result.audit_event_ids.append(event["event_id"])
+
+    return result
+
+
+def apply_proposal(
+    vault_dir: Path,
+    proposal: DedupProposal,
+    *,
+    dry_run: bool = True,
+    pack: str = "",
+    only_canonicals: set[str] | None = None,
+) -> list[ApplyResult]:
+    results: list[ApplyResult] = []
+    for cluster in proposal.clusters:
+        if only_canonicals is not None and cluster.canonical.slug not in only_canonicals:
+            continue
+        results.append(
+            apply_cluster(
+                vault_dir,
+                cluster,
+                dry_run=dry_run,
+                pack=pack,
+                proposal_id=proposal.proposal_id,
+            )
+        )
+    return results

--- a/src/ovp_pipeline/event_emitter.py
+++ b/src/ovp_pipeline/event_emitter.py
@@ -30,6 +30,9 @@ Closed `event_type` vocabulary (forward-compat for Phase 37 Pulse feed):
                              promotion command.
   feedback_yield           — Phase 36. ovp-query produced a downstream
                              candidate / question / writing prompt.
+  concept_merged           — Phase 38.A. Duplicate Evergreen file(s) merged
+                             into a canonical concept (file archived,
+                             wikilinks rewritten, alias added).
 
 Adding a new event_type requires: (a) appending here, (b) updating any
 collector(s) in knowledge_index.py, (c) updating ingest tests.

--- a/tests/test_concept_dedup.py
+++ b/tests/test_concept_dedup.py
@@ -1,0 +1,260 @@
+"""Tests for Phase 38.A — concept_dedup."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from textwrap import dedent
+
+from ovp_pipeline.concept_dedup import (
+    DEFAULT_THRESHOLD,
+    apply_cluster,
+    apply_proposal,
+    find_clusters,
+    list_proposals,
+    load_proposal,
+    trigram_jaccard,
+    write_proposal,
+    _add_alias_to_frontmatter,
+    _rewrite_wikilinks,
+)
+
+
+def _evergreen(vault: Path, slug: str, *, title: str | None = None, body: str = "body") -> Path:
+    eg_dir = vault / "10-Knowledge" / "Evergreen"
+    eg_dir.mkdir(parents=True, exist_ok=True)
+    text = dedent(
+        f"""\
+        ---
+        title: "{title or slug.replace('-', ' ')}"
+        type: evergreen
+        ---
+
+        {body}
+        """
+    )
+    path = eg_dir / f"{slug}.md"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _other(vault: Path, rel: str, body: str) -> Path:
+    p = vault / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+def test_trigram_jaccard_high_for_near_dupes():
+    assert trigram_jaccard("mcp client", "mcp client") == 1.0
+    # "mcp client" vs "mcp clients": ~0.67 — close but not identical
+    assert trigram_jaccard("mcp client", "mcp clients") > 0.6
+    assert trigram_jaccard("mcp client", "totally unrelated thing") < 0.2
+
+
+def test_find_clusters_groups_near_duplicates(tmp_path: Path):
+    _evergreen(tmp_path, "MCP-Client", body="canonical body long content " * 10)
+    _evergreen(tmp_path, "MCP-Clients", body="dup")
+    _evergreen(tmp_path, "MCP-Client-Variant", body="dup")
+    _evergreen(tmp_path, "Some-Other-Concept", body="unrelated")
+
+    clusters = find_clusters(tmp_path, threshold=0.5)
+
+    assert len(clusters) == 1
+    cluster = clusters[0]
+    # Canonical should be the largest file.
+    assert cluster.canonical.slug == "MCP-Client"
+    dup_slugs = {d.slug for d in cluster.duplicates}
+    assert dup_slugs == {"MCP-Clients", "MCP-Client-Variant"}
+
+
+def test_find_clusters_skips_underscored_and_hidden(tmp_path: Path):
+    _evergreen(tmp_path, "_Candidate-Note")
+    _evergreen(tmp_path, "Real-Note")
+    _evergreen(tmp_path, "Real-Notes")
+
+    clusters = find_clusters(tmp_path, threshold=0.7)
+    canonical_slugs = {c.canonical.slug for c in clusters}
+    dup_slugs = {d.slug for c in clusters for d in c.duplicates}
+    assert "_Candidate-Note" not in canonical_slugs
+    assert "_Candidate-Note" not in dup_slugs
+
+
+def test_find_clusters_returns_empty_when_no_evergreen_dir(tmp_path: Path):
+    assert find_clusters(tmp_path) == []
+
+
+def test_rewrite_wikilinks_preserves_anchor_and_display():
+    text = "see [[old-slug]] and [[old-slug#section]] and [[old-slug|Display Name]] and [[other]]"
+    new_text, count = _rewrite_wikilinks(text, {"old-slug": "new-slug"})
+    assert count == 3
+    assert "[[new-slug]]" in new_text
+    assert "[[new-slug#section]]" in new_text
+    assert "[[new-slug|Display Name]]" in new_text
+    assert "[[other]]" in new_text
+
+
+def test_rewrite_wikilinks_no_change_when_slug_absent():
+    text = "see [[unrelated]]"
+    new_text, count = _rewrite_wikilinks(text, {"old-slug": "new-slug"})
+    assert count == 0
+    assert new_text == text
+
+
+def test_add_alias_to_frontmatter_inserts_when_absent():
+    text = '---\ntitle: "X"\ntype: evergreen\n---\n\nbody\n'
+    out = _add_alias_to_frontmatter(text, "old-slug")
+    assert 'aliases: ["old-slug"]' in out
+    assert "body" in out
+
+
+def test_add_alias_to_frontmatter_appends_to_existing():
+    text = '---\ntitle: "X"\naliases: ["existing"]\n---\n\nbody\n'
+    out = _add_alias_to_frontmatter(text, "new-one")
+    assert '"existing"' in out
+    assert '"new-one"' in out
+
+
+def test_add_alias_to_frontmatter_idempotent():
+    text = '---\ntitle: "X"\naliases: ["dup"]\n---\n\nbody\n'
+    out = _add_alias_to_frontmatter(text, "dup")
+    assert out == text
+
+
+def test_write_and_load_proposal_roundtrip(tmp_path: Path):
+    _evergreen(tmp_path, "MCP-Client", body="canonical " * 10)
+    _evergreen(tmp_path, "MCP-Clients")
+
+    clusters = find_clusters(tmp_path, threshold=0.6)
+    path, proposal = write_proposal(tmp_path, clusters, threshold=0.6)
+
+    assert path.is_file()
+    listed = list_proposals(tmp_path)
+    assert path in listed
+
+    loaded = load_proposal(path)
+    assert loaded.proposal_id == proposal.proposal_id
+    assert len(loaded.clusters) == 1
+    assert loaded.clusters[0].canonical.slug == "MCP-Client"
+
+
+def test_apply_cluster_dry_run_makes_no_writes(tmp_path: Path):
+    canonical = _evergreen(tmp_path, "MCP-Client", body="canonical " * 10)
+    dup = _evergreen(tmp_path, "MCP-Clients", body="dup")
+    refer = _other(tmp_path, "20-Areas/Note.md", "see [[MCP-Clients]] and [[MCP-Clients|Friendly]]")
+
+    clusters = find_clusters(tmp_path, threshold=0.6)
+    assert clusters
+
+    result = apply_cluster(tmp_path, clusters[0], dry_run=True)
+
+    # Wikilink rewrite count is computed even in dry run.
+    assert result.wikilink_rewrites == 2
+    # But files are untouched.
+    assert dup.exists()
+    assert canonical.read_text(encoding="utf-8") == canonical.read_text(encoding="utf-8")
+    assert "[[MCP-Clients]]" in refer.read_text(encoding="utf-8")
+    # No audit event written.
+    log = tmp_path / "60-Logs" / "concept-merges.jsonl"
+    assert not log.exists()
+
+
+def test_apply_cluster_writes_archive_aliases_audit(tmp_path: Path):
+    canonical = _evergreen(tmp_path, "MCP-Client", body="canonical body that is long " * 10)
+    dup = _evergreen(tmp_path, "MCP-Clients", body="dup body")
+    refer = _other(
+        tmp_path,
+        "20-Areas/Topic.md",
+        "see [[MCP-Clients]] and [[MCP-Clients#anchor]] and [[MCP-Clients|Display]]",
+    )
+
+    clusters = find_clusters(tmp_path, threshold=0.6)
+    assert clusters
+
+    result = apply_cluster(tmp_path, clusters[0], dry_run=False, proposal_id="test-prop")
+
+    assert result.canonical_slug == "MCP-Client"
+    assert result.wikilink_rewrites == 3
+    assert "MCP-Clients" in result.aliases_added
+    assert result.errors == []
+    assert len(result.audit_event_ids) == 1
+
+    # Duplicate file moved out of Evergreen.
+    assert not dup.exists()
+    archived = tmp_path / "70-Archive" / "dedup-merged" / "MCP-Clients.md"
+    assert archived.exists()
+
+    # References rewritten.
+    rewritten = refer.read_text(encoding="utf-8")
+    assert "[[MCP-Client]]" in rewritten
+    assert "[[MCP-Client#anchor]]" in rewritten
+    assert "[[MCP-Client|Display]]" in rewritten
+    assert "[[MCP-Clients" not in rewritten
+
+    # Canonical aliases updated.
+    canon_text = canonical.read_text(encoding="utf-8")
+    assert "MCP-Clients" in canon_text
+
+    # Audit event recorded.
+    log = tmp_path / "60-Logs" / "concept-merges.jsonl"
+    assert log.exists()
+    events = [json.loads(line) for line in log.read_text(encoding="utf-8").splitlines() if line]
+    assert len(events) == 1
+    ev = events[0]
+    assert ev["event_type"] == "concept_merged"
+    assert ev["canonical_slug"] == "MCP-Client"
+    assert ev["merged_slugs"] == ["MCP-Clients"]
+    assert ev["proposal_id"] == "test-prop"
+
+
+def test_apply_cluster_skips_archive_dir_during_rewrite(tmp_path: Path):
+    """A second pass after merge must not rewrite anything in the archive."""
+    _evergreen(tmp_path, "MCP-Client", body="canonical " * 10)
+    _evergreen(tmp_path, "MCP-Clients")
+    _other(tmp_path, "20-Areas/Note.md", "see [[MCP-Clients]]")
+
+    clusters = find_clusters(tmp_path, threshold=0.6)
+    apply_cluster(tmp_path, clusters[0], dry_run=False)
+
+    # Re-scan: cluster should be gone.
+    clusters_after = find_clusters(tmp_path, threshold=DEFAULT_THRESHOLD)
+    assert clusters_after == []
+
+
+def test_apply_cluster_handles_archive_collision(tmp_path: Path):
+    """If the archive already has a file with the same name, second one gets a timestamp suffix."""
+    _evergreen(tmp_path, "MCP-Client", body="canonical " * 10)
+    _evergreen(tmp_path, "MCP-Clients")
+    archive_dir = tmp_path / "70-Archive" / "dedup-merged"
+    archive_dir.mkdir(parents=True)
+    (archive_dir / "MCP-Clients.md").write_text("pre-existing", encoding="utf-8")
+
+    clusters = find_clusters(tmp_path, threshold=0.6)
+    result = apply_cluster(tmp_path, clusters[0], dry_run=False)
+
+    assert result.errors == []
+    assert (archive_dir / "MCP-Clients.md").read_text(encoding="utf-8") == "pre-existing"
+    # New archive file lands with a timestamp suffix.
+    other_files = [
+        p for p in archive_dir.glob("MCP-Clients*.md") if p.name != "MCP-Clients.md"
+    ]
+    assert len(other_files) == 1
+
+
+def test_apply_proposal_only_filter(tmp_path: Path):
+    _evergreen(tmp_path, "MCP-Client", body="canonical " * 10)
+    _evergreen(tmp_path, "MCP-Clients")
+    _evergreen(tmp_path, "Vector-Database", body="canonical " * 10)
+    _evergreen(tmp_path, "Vector-Databases")
+
+    clusters = find_clusters(tmp_path, threshold=0.6)
+    assert len(clusters) == 2
+    _, proposal = write_proposal(tmp_path, clusters, threshold=DEFAULT_THRESHOLD)
+
+    results = apply_proposal(
+        tmp_path, proposal, dry_run=False, only_canonicals={"MCP-Client"}
+    )
+    assert len(results) == 1
+    assert results[0].canonical_slug == "MCP-Client"
+    # Vector-Databases must NOT be archived.
+    assert (tmp_path / "10-Knowledge" / "Evergreen" / "Vector-Databases.md").exists()


### PR DESCRIPTION
## Summary

Phase 38.A — second slice of Phase 38. Adds an invertible, audit-logged dedup workflow for near-duplicate Evergreen files.

The need was surfaced by the layered MCP graph review: 7 near-duplicate "MCP Client" Evergreen slugs were inflating hop1 degree and making the canonical concept look like 7 different ones. The existing `ovp-merge-duplicates` CLI did most of the lifting but **deleted** files outright (not invertible), didn't write an audit event, and didn't try to update the concept registry. 38.A keeps the proven trigram clustering and adds the missing safety properties.

## Changes

- `concept_dedup.py` — pure clustering + apply logic. Trigram-Jaccard over normalized slugs, union-find clustering, canonical picked by file size (largest curated body wins).
- `ovp-concept-dedup` CLI — `propose / list / apply`. Proposals are written as JSON to `60-Logs/dedup-proposals/<id>.json` for review before any file is touched.
- Apply step:
  - Archives each duplicate to `70-Archive/dedup-merged/<slug>.md` (atomic rename, not unlink — invertible).
  - Adds the duplicate slug to the canonical's `aliases:` frontmatter.
  - Rewrites `[[dup_slug]]`, `[[dup_slug#anchor]]`, and `[[dup_slug|display]]` across the vault to point at the canonical (anchors and display text preserved).
  - Best-effort `ConceptRegistry.merge_as_alias` call (no-op if registry doesn't track the slug; not an error).
  - Emits a `concept_merged` event to `60-Logs/concept-merges.jsonl`.
- `event_emitter.py` — declares `concept_merged` in the closed event_type vocabulary so Pulse and `knowledge_index` rebuild can consume it.
- `--only <slug,…>` filter on `apply` lets reviewers stage one cluster at a time.

## Live impact (dry-run on `openclaw-vault` @ threshold 0.85)

- 104 clusters covering 110 duplicate Evergreen files
- Sample clusters caught: `agent-harness-is/as/core-infrastructure` (3 ways), `attention/intention-economy` orderings, `sandbox-execution/isolation` permutations, casing variants like `X-Creator-Ad-Revenue-Sharing-Mechanism` vs `x-creator-revenue-sharing-mechanism`

## Workflow

```bash
# 1. Generate a proposal (no writes).
ovp-concept-dedup propose --threshold 0.85 --write
# → 60-Logs/dedup-proposals/dedup-20260423-XXXXXX-XXXXXX.json

# 2. Review the JSON (or use ovp-concept-dedup list).
ovp-concept-dedup list

# 3. Dry-run the proposal to see exactly what would change.
ovp-concept-dedup apply dedup-20260423-XXXXXX-XXXXXX --dry-run

# 4. Apply, optionally one cluster at a time.
ovp-concept-dedup apply dedup-20260423-XXXXXX-XXXXXX --only mcp-client
```

## Test plan

- [x] `pytest tests/test_concept_dedup.py` — 15/15 pass (trigram math, cluster discovery, underscore exclusion, wikilink anchor/display preservation, alias frontmatter idempotency, dry-run no-write, full apply with archive+aliases+audit, archive collision handling, `--only` filter)
- [x] Full suite — 845 passed
- [x] Live vault dry-run on 104 clusters — output matches expectations
- [ ] After merge: apply against the live vault and re-run `ovp-graph build --pack research-tech --seed-match mcp` to verify hop1 degree-inflation goes away
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/51" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
