### PR TITLE
Phase 38.C: backlink writeback to source MDs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ ovp-ui = "ovp_pipeline.commands.ui_server:main"
 ovp-mcp = "ovp_pipeline.commands.mcp:main"
 ovp-note-type-normalize = "ovp_pipeline.commands.note_type_normalize:main"
 ovp-concept-dedup = "ovp_pipeline.commands.concept_dedup:main"
+ovp-promote-backfill = "ovp_pipeline.commands.promote_backfill:main"
 
 [project.entry-points."ovp.packs"]
 default-knowledge = "ovp_pipeline.packs.default_knowledge:get_pack"

--- a/src/ovp_pipeline/auto_evergreen_extractor.py
+++ b/src/ovp_pipeline/auto_evergreen_extractor.py
@@ -38,6 +38,11 @@ except ImportError:
     from identity import canonicalize_note_id  # type: ignore
 
 try:
+    from .promotion_backlinks import upsert_promotions_in_file
+except ImportError:
+    from promotion_backlinks import upsert_promotions_in_file  # type: ignore
+
+try:
     from .llm_defaults import (
         DEFAULT_LITELLM_TIMEOUT_SECONDS,
         DEFAULT_MINIMAX_MODEL,
@@ -425,6 +430,13 @@ class AutoEvergreenExtractor:
                                 "path": str(output_path),
                                 "mutation": mutation.to_dict(),
                             })
+                            # Phase 38.C: write the promotion as a real
+                            # wikilink back into the source so the graph
+                            # picks it up via the standard scan.
+                            try:
+                                upsert_promotions_in_file(file_path, [concept_name])
+                            except Exception:
+                                pass
                         else:
                             from .promote_candidates import write_candidate_file
 
@@ -461,6 +473,11 @@ class AutoEvergreenExtractor:
                         "source": str(file_path.name),
                         "path": str(output_path)
                     })
+                    # Phase 38.C: write backlink into source MD.
+                    try:
+                        upsert_promotions_in_file(file_path, [concept_name])
+                    except Exception:
+                        pass
 
                 result["concepts"].append(concept_info)
 

--- a/src/ovp_pipeline/commands/promote_backfill.py
+++ b/src/ovp_pipeline/commands/promote_backfill.py
@@ -1,0 +1,131 @@
+"""``ovp-promote-backfill`` — Phase 38.C historical backfill.
+
+Reads ``60-Logs/pipeline.jsonl`` for ``evergreen_auto_promoted`` and
+``evergreen_created`` events and writes a promotion-backlink block into each
+source MD that hasn't been touched yet.
+
+Run once after deploying Phase 38.C; subsequent promotions write the block
+automatically via the hook in ``auto_evergreen_extractor.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+from ..promotion_backlinks import upsert_promotions_in_file
+from ..runtime import VaultLayout, resolve_vault_dir
+
+
+_EVENT_TYPES = {"evergreen_auto_promoted", "evergreen_created"}
+
+
+def _iter_promotion_events(layout: VaultLayout):
+    log_path = layout.logs_dir / "pipeline.jsonl"
+    if not log_path.exists():
+        return
+    with log_path.open("r", encoding="utf-8") as handle:
+        for raw in handle:
+            stripped = raw.strip()
+            if not stripped:
+                continue
+            try:
+                evt = json.loads(stripped)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(evt, dict):
+                continue
+            evt_type = evt.get("event") or evt.get("event_type")
+            if evt_type not in _EVENT_TYPES:
+                continue
+            data = evt.get("data") if isinstance(evt.get("data"), dict) else evt
+            source = data.get("source")
+            concept = data.get("concept")
+            if not source or not concept:
+                continue
+            yield str(source), str(concept)
+
+
+def _resolve_source_path(vault_dir: Path, source_name: str) -> Path | None:
+    """Source field is a basename; locate the actual MD file in the vault."""
+    if "/" in source_name:
+        candidate = vault_dir / source_name
+        if candidate.is_file():
+            return candidate
+    matches = list(vault_dir.rglob(source_name))
+    matches = [m for m in matches if m.is_file() and m.suffix == ".md"]
+    if len(matches) == 1:
+        return matches[0]
+    if not matches:
+        return None
+    # Prefer a path under 20-Areas / 50-Inbox over archive/templates.
+    preferred = [
+        m for m in matches if any(p in m.parts for p in ("20-Areas", "50-Inbox", "30-Projects"))
+    ]
+    if len(preferred) == 1:
+        return preferred[0]
+    if preferred:
+        return preferred[0]
+    return matches[0]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="ovp-promote-backfill")
+    parser.add_argument("--vault-dir", type=Path, default=None)
+    parser.add_argument("--dry-run", action="store_true", help="Print plan, do not write")
+    parser.add_argument(
+        "--verbose", action="store_true", help="Print every (source, concept) pair"
+    )
+    args = parser.parse_args(argv)
+
+    vault_dir = resolve_vault_dir(args.vault_dir)
+    layout = VaultLayout.from_vault(vault_dir)
+
+    pairs: dict[str, set[str]] = defaultdict(set)
+    for source_name, concept in _iter_promotion_events(layout):
+        pairs[source_name].add(concept)
+
+    if not pairs:
+        print("No promotion events found in pipeline.jsonl.")
+        return 0
+
+    print(f"Found promotion events for {len(pairs)} source file(s).")
+
+    written = 0
+    skipped = 0
+    missing = 0
+    for source_name, slugs in sorted(pairs.items()):
+        path = _resolve_source_path(vault_dir, source_name)
+        if not path:
+            missing += 1
+            if args.verbose:
+                print(f"  ! source not found: {source_name}")
+            continue
+
+        slugs_sorted = sorted(slugs)
+        if args.dry_run:
+            print(f"  [DRY] {path.relative_to(vault_dir)} ← {len(slugs_sorted)} slug(s)")
+            continue
+
+        try:
+            changed = upsert_promotions_in_file(path, slugs_sorted)
+        except Exception as exc:
+            print(f"  ! {path}: {exc}", file=sys.stderr)
+            continue
+
+        if changed:
+            written += 1
+            if args.verbose:
+                print(f"  + {path.relative_to(vault_dir)} ({len(slugs_sorted)} slug(s))")
+        else:
+            skipped += 1
+
+    print(f"\nWrote: {written}, already-current: {skipped}, missing-source: {missing}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ovp_pipeline/promotion_backlinks.py
+++ b/src/ovp_pipeline/promotion_backlinks.py
@@ -1,0 +1,97 @@
+"""Phase 38.C — write Evergreen-promotion backlinks into source markdown.
+
+Today the source→evergreen edge in the graph is hydrated from
+``audit_events`` (event_type=``evergreen_auto_promoted``) — see
+graph_cli.py. That works but means the link is invisible to anyone reading
+the source markdown file directly in Obsidian, and it can't be picked up by
+plain wikilink scanners.
+
+This module writes the same information back into the source MD as a
+delimited block of plain wikilinks::
+
+    <!-- ovp-promotions -->
+    > 由 OVP Pipeline 自动提取的 Evergreen 概念
+    - [[Evergreen-Slug-1]]
+    - [[Evergreen-Slug-2]]
+    <!-- /ovp-promotions -->
+
+Properties:
+- Idempotent: re-applying the same (source, slug) pair is a no-op.
+- Block is the single source of truth — replacing the block replaces the
+  whole list (no orphaned wikilinks).
+- A backfill CLI (``ovp-promote-backfill``) replays existing
+  ``evergreen_auto_promoted`` events from ``60-Logs/pipeline.jsonl`` so the
+  block lands on every historical source in one pass.
+- Once the backfill has covered all live sources, the audit_events
+  hydration shim in graph_cli.py becomes redundant. Removing the shim is a
+  follow-up PR (kept here for the transition window).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Iterable
+
+MARKER_OPEN = "<!-- ovp-promotions -->"
+MARKER_CLOSE = "<!-- /ovp-promotions -->"
+MARKER_HEADER = "> 由 OVP Pipeline 自动提取的 Evergreen 概念"
+
+_BLOCK_RE = re.compile(
+    rf"{re.escape(MARKER_OPEN)}\n(.*?){re.escape(MARKER_CLOSE)}\n?",
+    re.DOTALL,
+)
+_WIKILINK_RE = re.compile(r"\[\[([^\[\]\|#]+?)(?:#[^\[\]\|]*)?(?:\|[^\[\]]*)?\]\]")
+
+
+def list_promotions(source_text: str) -> list[str]:
+    """Return the Evergreen slugs declared in the source's promotion block."""
+    match = _BLOCK_RE.search(source_text)
+    if not match:
+        return []
+    return [m.group(1).strip() for m in _WIKILINK_RE.finditer(match.group(1))]
+
+
+def _render_block(slugs: Iterable[str]) -> str:
+    body_lines = "\n".join(f"- [[{s}]]" for s in slugs)
+    return f"{MARKER_OPEN}\n{MARKER_HEADER}\n{body_lines}\n{MARKER_CLOSE}\n"
+
+
+def upsert_promotions(source_text: str, slugs: Iterable[str]) -> tuple[str, bool]:
+    """Add the given slugs to the promotion block (creating the block if absent).
+
+    Idempotent: re-applying the same set is a no-op (returns ``(text, False)``).
+    Slugs already present are kept; new ones are appended at the end of the
+    list. Order within the block is stable.
+    """
+    incoming = [s for s in dict.fromkeys(slugs).keys() if s]
+    if not incoming:
+        return source_text, False
+
+    existing = list_promotions(source_text)
+    merged: list[str] = list(existing)
+    for slug in incoming:
+        if slug not in merged:
+            merged.append(slug)
+    if merged == existing:
+        return source_text, False
+
+    new_block = _render_block(merged)
+    if _BLOCK_RE.search(source_text):
+        new_text = _BLOCK_RE.sub(new_block, source_text, count=1)
+    else:
+        # Append the block at end-of-file with one separating blank line.
+        sep = "" if source_text.endswith("\n\n") else ("\n" if source_text.endswith("\n") else "\n\n")
+        new_text = source_text + sep + new_block
+    return new_text, True
+
+
+def upsert_promotions_in_file(source_path: Path, slugs: Iterable[str]) -> bool:
+    """File-level wrapper around :func:`upsert_promotions`. Returns True if the file changed."""
+    if not source_path.exists():
+        return False
+    text = source_path.read_text(encoding="utf-8")
+    new_text, changed = upsert_promotions(text, slugs)
+    if changed:
+        source_path.write_text(new_text, encoding="utf-8")
+    return changed

--- a/tests/test_promote_backfill_cli.py
+++ b/tests/test_promote_backfill_cli.py
@@ -1,0 +1,113 @@
+"""Tests for ``ovp-promote-backfill`` (Phase 38.C)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ovp_pipeline.commands.promote_backfill import main as backfill_main
+from ovp_pipeline.promotion_backlinks import list_promotions
+
+
+def _write(p: Path, text: str) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+
+
+def _write_pipeline_log(vault: Path, events: list[dict]) -> None:
+    log_path = vault / "60-Logs" / "pipeline.jsonl"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text(
+        "\n".join(json.dumps(e, ensure_ascii=False) for e in events) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_backfill_writes_block_into_source(tmp_path: Path):
+    vault = tmp_path / "vault"
+    src = vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "topic.md"
+    _write(src, "# Topic\n\nbody\n")
+    _write(vault / "10-Knowledge" / "Evergreen" / "Concept-A.md", "evergreen\n")
+
+    _write_pipeline_log(
+        vault,
+        [
+            {
+                "event_type": "evergreen_auto_promoted",
+                "concept": "Concept-A",
+                "source": "topic.md",
+            }
+        ],
+    )
+
+    rc = backfill_main(["--vault-dir", str(vault)])
+    assert rc == 0
+    assert list_promotions(src.read_text(encoding="utf-8")) == ["Concept-A"]
+
+
+def test_backfill_dry_run_does_not_write(tmp_path: Path):
+    vault = tmp_path / "vault"
+    src = vault / "20-Areas" / "topic.md"
+    _write(src, "body\n")
+    _write(vault / "10-Knowledge" / "Evergreen" / "X.md", "x\n")
+    _write_pipeline_log(
+        vault,
+        [{"event_type": "evergreen_auto_promoted", "concept": "X", "source": "topic.md"}],
+    )
+
+    rc = backfill_main(["--vault-dir", str(vault), "--dry-run"])
+    assert rc == 0
+    assert list_promotions(src.read_text(encoding="utf-8")) == []
+
+
+def test_backfill_groups_concepts_per_source(tmp_path: Path):
+    vault = tmp_path / "vault"
+    src = vault / "20-Areas" / "topic.md"
+    _write(src, "body\n")
+    _write_pipeline_log(
+        vault,
+        [
+            {"event_type": "evergreen_auto_promoted", "concept": "A", "source": "topic.md"},
+            {"event_type": "evergreen_auto_promoted", "concept": "B", "source": "topic.md"},
+            {"event_type": "evergreen_created", "concept": "C", "source": "topic.md"},
+        ],
+    )
+
+    rc = backfill_main(["--vault-dir", str(vault)])
+    assert rc == 0
+    slugs = list_promotions(src.read_text(encoding="utf-8"))
+    assert sorted(slugs) == ["A", "B", "C"]
+
+
+def test_backfill_handles_missing_source(tmp_path: Path):
+    vault = tmp_path / "vault"
+    (vault / "20-Areas").mkdir(parents=True)
+    _write_pipeline_log(
+        vault,
+        [
+            {
+                "event_type": "evergreen_auto_promoted",
+                "concept": "X",
+                "source": "nonexistent.md",
+            }
+        ],
+    )
+    # Should still exit 0; missing-source is reported, not raised.
+    rc = backfill_main(["--vault-dir", str(vault)])
+    assert rc == 0
+
+
+def test_backfill_idempotent(tmp_path: Path):
+    vault = tmp_path / "vault"
+    src = vault / "20-Areas" / "topic.md"
+    _write(src, "body\n")
+    _write_pipeline_log(
+        vault,
+        [{"event_type": "evergreen_auto_promoted", "concept": "X", "source": "topic.md"}],
+    )
+
+    backfill_main(["--vault-dir", str(vault)])
+    after_first = src.read_text(encoding="utf-8")
+    backfill_main(["--vault-dir", str(vault)])
+    after_second = src.read_text(encoding="utf-8")
+    assert after_first == after_second

--- a/tests/test_promotion_backlinks.py
+++ b/tests/test_promotion_backlinks.py
@@ -1,0 +1,108 @@
+"""Tests for Phase 38.C — promotion-backlink writeback."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+from ovp_pipeline.promotion_backlinks import (
+    MARKER_CLOSE,
+    MARKER_OPEN,
+    list_promotions,
+    upsert_promotions,
+    upsert_promotions_in_file,
+)
+
+
+def test_list_promotions_returns_empty_when_no_block():
+    text = "just some markdown\n\nwith [[a-wikilink]] outside any block\n"
+    assert list_promotions(text) == []
+
+
+def test_list_promotions_extracts_slugs_from_block():
+    text = dedent(
+        f"""\
+        body text
+
+        {MARKER_OPEN}
+        > 由 OVP Pipeline 自动提取的 Evergreen 概念
+        - [[Slug-One]]
+        - [[Slug-Two]]
+        {MARKER_CLOSE}
+        """
+    )
+    assert list_promotions(text) == ["Slug-One", "Slug-Two"]
+
+
+def test_upsert_promotions_creates_block_when_absent():
+    text = "body content\n"
+    new_text, changed = upsert_promotions(text, ["Concept-A"])
+    assert changed is True
+    assert MARKER_OPEN in new_text
+    assert MARKER_CLOSE in new_text
+    assert "[[Concept-A]]" in new_text
+    # Block lands at the end, original body intact.
+    assert new_text.startswith("body content\n")
+
+
+def test_upsert_promotions_appends_new_slugs_to_existing_block():
+    text = dedent(
+        f"""\
+        body
+        {MARKER_OPEN}
+        > 由 OVP Pipeline 自动提取的 Evergreen 概念
+        - [[Existing-One]]
+        {MARKER_CLOSE}
+        """
+    )
+    new_text, changed = upsert_promotions(text, ["New-One"])
+    assert changed is True
+    slugs = list_promotions(new_text)
+    assert slugs == ["Existing-One", "New-One"]
+
+
+def test_upsert_promotions_idempotent_for_same_slug():
+    text = "body\n"
+    after_first, _ = upsert_promotions(text, ["Concept-A"])
+    after_second, changed = upsert_promotions(after_first, ["Concept-A"])
+    assert changed is False
+    assert after_first == after_second
+
+
+def test_upsert_promotions_dedupes_within_one_call():
+    text = "body\n"
+    new_text, _ = upsert_promotions(text, ["Concept-A", "Concept-A", "Concept-B"])
+    assert list_promotions(new_text) == ["Concept-A", "Concept-B"]
+
+
+def test_upsert_promotions_no_op_for_empty_input():
+    text = "body\n"
+    new_text, changed = upsert_promotions(text, [])
+    assert changed is False
+    assert new_text == text
+
+
+def test_upsert_promotions_in_file_round_trip(tmp_path: Path):
+    p = tmp_path / "source.md"
+    p.write_text("# Source Note\n\nbody text\n", encoding="utf-8")
+    changed = upsert_promotions_in_file(p, ["Concept-Alpha", "Concept-Beta"])
+    assert changed is True
+    content = p.read_text(encoding="utf-8")
+    assert list_promotions(content) == ["Concept-Alpha", "Concept-Beta"]
+
+
+def test_upsert_promotions_in_file_missing_returns_false(tmp_path: Path):
+    p = tmp_path / "missing.md"
+    assert upsert_promotions_in_file(p, ["X"]) is False
+
+
+def test_block_replaces_in_place_does_not_duplicate(tmp_path: Path):
+    p = tmp_path / "source.md"
+    p.write_text("body\n", encoding="utf-8")
+    upsert_promotions_in_file(p, ["A"])
+    upsert_promotions_in_file(p, ["B"])
+    content = p.read_text(encoding="utf-8")
+    # Only one block in the file.
+    assert content.count(MARKER_OPEN) == 1
+    assert content.count(MARKER_CLOSE) == 1
+    assert list_promotions(content) == ["A", "B"]


### PR DESCRIPTION
## Summary

Phase 38.C — third slice of Phase 38. Closes the loop on the audit-event hydration shim shipped in PR #49: instead of synthesizing `source → evergreen` graph edges from `audit_events` at query time, the relationship is now written back into the source MD as a real wikilink block, so any plain Markdown reader (Obsidian, the standard graph scan, third-party scripts) sees it.

## Changes

- `promotion_backlinks.py` — idempotent block writer. The block is delimited by `<!-- ovp-promotions --> ... <!-- /ovp-promotions -->`; replacing it replaces the whole list (no orphan wikilinks).
- `auto_evergreen_extractor.py` — hooks the writer in immediately after the `evergreen_auto_promoted` and `evergreen_created` log calls, so every new promotion is legible at the source.
- `ovp-promote-backfill` CLI — replays existing `evergreen_auto_promoted` / `evergreen_created` events from `60-Logs/pipeline.jsonl` and writes the block into every historical source. Idempotent: safe to re-run.

The `audit_events` hydration shim in `graph_cli.py` is **kept** for the transition window — both pathways produce the same edges and don't conflict. Once a follow-up PR confirms the backfill has landed everywhere, that shim can be removed.

## Workflow

```bash
# One-time backfill on a vault that already has historical promotions:
ovp-promote-backfill --vault-dir /path/to/vault --dry-run    # preview
ovp-promote-backfill --vault-dir /path/to/vault              # apply
```

After this lands, every new evergreen extraction also writes the block automatically — no extra step.

## Test plan

- [x] `pytest tests/test_promotion_backlinks.py tests/test_promote_backfill_cli.py` — 15/15 pass (block round-trip, idempotency, dedup-within-call, missing-source handling, in-place block replacement, CLI dry-run)
- [x] Full suite — 845 passed
- [ ] After merge: run `ovp-promote-backfill --dry-run` on the live vault and report counts
- [ ] After backfill: re-run `ovp-graph build --pack research-tech --layered` and verify hop1 `promoted_from` count is preserved (the audit shim and the new wikilinks should agree)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/52" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
