### PR TITLE
Add hop1 edge-weight pruning to ovp-graph build (Phase 38.B)

### DIFF
--- a/src/ovp_pipeline/graph_cli.py
+++ b/src/ovp_pipeline/graph_cli.py
@@ -203,6 +203,84 @@ def _expand_layered(
     return expanded, distance_map, used_edges
 
 
+def _prune_hop1(
+    seed_ids: set[str],
+    expanded_ids: set[str],
+    distance_map: dict[str, int],
+    used_edges: list[dict],
+    *,
+    min_seed_degree: int = 1,
+    top_k_per_seed: int | None = None,
+) -> tuple[set[str], dict[str, int], list[dict], dict[str, int]]:
+    """Trim hop1 nodes by their seed-connection count.
+
+    Two filters compose. ``min_seed_degree=N`` drops hop1 nodes that bridge
+    fewer than N distinct seeds (suppresses concept-drift hop1 nodes that
+    each touch only one seed). ``top_k_per_seed=K`` then ranks each seed's
+    surviving hop1 neighbors by their seed-degree (descending) and keeps
+    only the K highest — a horizontal cap on per-seed fan-out.
+
+    Hop2 nodes that lose all their hop1/seed bridges as a result are also
+    dropped (otherwise the visualization shows orphaned source-markdown
+    nodes floating in space).
+
+    Returns ``(new_expanded_ids, new_distance_map, new_used_edges, drop_summary)``.
+    """
+    from collections import defaultdict
+
+    if min_seed_degree <= 1 and not top_k_per_seed:
+        return expanded_ids, distance_map, used_edges, {"hop1_dropped": 0, "hop2_dropped": 0}
+
+    hop1_ids = {nid for nid, d in distance_map.items() if d == 1}
+    hop2_ids = {nid for nid, d in distance_map.items() if d == 2}
+
+    # For each hop1 node, collect the set of seed_ids it directly bridges.
+    hop1_seed_links: dict[str, set[str]] = defaultdict(set)
+    for edge in used_edges:
+        for endpoint, other in (
+            (edge["source"], edge["target"]),
+            (edge["target"], edge["source"]),
+        ):
+            if endpoint in hop1_ids and other in seed_ids:
+                hop1_seed_links[endpoint].add(other)
+
+    kept_hop1 = {hid for hid, seeds in hop1_seed_links.items() if len(seeds) >= min_seed_degree}
+
+    if top_k_per_seed:
+        seed_to_hop1: dict[str, list[str]] = defaultdict(list)
+        for hid in kept_hop1:
+            for sid in hop1_seed_links[hid]:
+                seed_to_hop1[sid].append(hid)
+        kept_via_topk: set[str] = set()
+        for sid, hids in seed_to_hop1.items():
+            ranked = sorted(hids, key=lambda h: (-len(hop1_seed_links[h]), h))
+            kept_via_topk.update(ranked[:top_k_per_seed])
+        kept_hop1 = kept_hop1 & kept_via_topk
+
+    dropped_hop1 = hop1_ids - kept_hop1
+
+    # Re-assess hop2: keep only those still bridged by a kept hop1 or a seed.
+    kept_hop2: set[str] = set()
+    for edge in used_edges:
+        for endpoint, other in (
+            (edge["source"], edge["target"]),
+            (edge["target"], edge["source"]),
+        ):
+            if endpoint in hop2_ids and (other in seed_ids or other in kept_hop1):
+                kept_hop2.add(endpoint)
+    dropped_hop2 = hop2_ids - kept_hop2
+
+    new_expanded = expanded_ids - dropped_hop1 - dropped_hop2
+    new_distance_map = {nid: d for nid, d in distance_map.items() if nid in new_expanded}
+    new_edges = [
+        e for e in used_edges if e["source"] in new_expanded and e["target"] in new_expanded
+    ]
+    return new_expanded, new_distance_map, new_edges, {
+        "hop1_dropped": len(dropped_hop1),
+        "hop2_dropped": len(dropped_hop2),
+    }
+
+
 def _scan_graph_from_filesystem(vault_dir: Path) -> tuple[list[dict], list[dict]]:
     """扫盘 fallback：当 knowledge.db 还没建立时使用。"""
     from ovp_pipeline.graph import GraphBuilder
@@ -296,10 +374,32 @@ def cmd_build(args):
             expanded_ids, distance_map, used_edges = _expand_layered(
                 seed_ids, edge_index, type_by_id
             )
+
+            min_seed_degree = max(1, getattr(args, "min_seed_degree", 1) or 1)
+            top_k_per_seed = getattr(args, "top_k_per_seed", None)
+            if min_seed_degree > 1 or top_k_per_seed:
+                expanded_ids, distance_map, used_edges, drop_summary = _prune_hop1(
+                    seed_ids,
+                    expanded_ids,
+                    distance_map,
+                    used_edges,
+                    min_seed_degree=min_seed_degree,
+                    top_k_per_seed=top_k_per_seed,
+                )
+                print(
+                    f"✂️  hop1 prune: dropped {drop_summary['hop1_dropped']} hop1 / "
+                    f"{drop_summary['hop2_dropped']} hop2 nodes "
+                    f"(min_seed_degree={min_seed_degree}, top_k_per_seed={top_k_per_seed})"
+                )
+
             all_nodes = [n for n in all_nodes if n["note_id"] in expanded_ids]
             # 只画 BFS 实际走过的边，否则 hop1 的 evergreen 之间又会拉一堆桥
             all_edges = used_edges
             mode_label = "--layered (hop1=evergreen, hop2=source-md)"
+            if min_seed_degree > 1 or top_k_per_seed:
+                mode_label += (
+                    f" + prune(min_seed_degree={min_seed_degree}, top_k_per_seed={top_k_per_seed})"
+                )
         else:
             # --source-walk: 剔除 evergreen↔evergreen / evergreen↔moc 这种"概念内部"
             # 的边，让 BFS 从概念种子直接跳到产生它的源文档（deep_dive / raw / article ...）
@@ -615,6 +715,20 @@ def main():
         help="两层 BFS：hop1 只扩 evergreen 邻居（概念波），"
              "hop2 只从这些 evergreen 跳到 source markdown。--expand-hops 被忽略。"
              "和 --source-walk 互斥",
+    )
+    build_parser.add_argument(
+        "--min-seed-degree",
+        type=int,
+        default=1,
+        help="(仅 --layered) 丢弃只连接到 <N 个 seed 的 hop1 节点 — 抑制 concept drift。"
+             "默认 1 (关闭)，常用 2",
+    )
+    build_parser.add_argument(
+        "--top-k-per-seed",
+        type=int,
+        default=None,
+        help="(仅 --layered) 每个 seed 只保留 K 个 seed-degree 最高的 hop1 邻居。"
+             "用于横向裁剪极宽的 fan-out",
     )
 
     # ovp-graph --daily

--- a/tests/test_graph_cli_prune.py
+++ b/tests/test_graph_cli_prune.py
@@ -1,0 +1,160 @@
+"""Unit tests for ``_prune_hop1`` in graph_cli.
+
+The helper trims hop1 nodes whose seed-degree is below a threshold, and
+optionally caps each seed's hop1 fan-out by top-K seed-degree. Hop2 nodes
+that lose all their bridges to surviving hop1/seed nodes are also dropped.
+"""
+
+from __future__ import annotations
+
+from ovp_pipeline.graph_cli import _prune_hop1
+
+
+def _edge(src: str, tgt: str) -> dict:
+    return {
+        "edge_id": f"{src}-{tgt}",
+        "source": src,
+        "target": tgt,
+        "edge_type": "wikilink",
+        "weight": 1.0,
+        "is_new_today": False,
+        "anchor_text": tgt,
+        "evidence_line": 0,
+    }
+
+
+def test_no_op_when_both_flags_default():
+    """min_seed_degree=1 and top_k_per_seed=None must short-circuit unchanged."""
+    seeds = {"S1"}
+    expanded = {"S1", "H1"}
+    distance = {"S1": 0, "H1": 1}
+    edges = [_edge("S1", "H1")]
+
+    new_expanded, new_distance, new_edges, summary = _prune_hop1(
+        seeds, expanded, distance, edges
+    )
+
+    assert new_expanded == expanded
+    assert new_distance == distance
+    assert new_edges == edges
+    assert summary == {"hop1_dropped": 0, "hop2_dropped": 0}
+
+
+def test_drops_hop1_below_min_seed_degree():
+    """A hop1 connected to only 1 seed is dropped when min_seed_degree=2."""
+    seeds = {"S1", "S2"}
+    # H_shared bridges both seeds; H_only bridges S1 alone.
+    expanded = {"S1", "S2", "H_shared", "H_only"}
+    distance = {"S1": 0, "S2": 0, "H_shared": 1, "H_only": 1}
+    edges = [
+        _edge("S1", "H_shared"),
+        _edge("S2", "H_shared"),
+        _edge("S1", "H_only"),
+    ]
+
+    new_expanded, _, new_edges, summary = _prune_hop1(
+        seeds, expanded, distance, edges, min_seed_degree=2
+    )
+
+    assert new_expanded == {"S1", "S2", "H_shared"}
+    assert summary["hop1_dropped"] == 1
+    # The S1↔H_only edge must vanish from the edge list.
+    assert all("H_only" not in (e["source"], e["target"]) for e in new_edges)
+
+
+def test_top_k_per_seed_caps_fanout():
+    """Per-seed cap keeps the K hop1s with highest seed-degree."""
+    seeds = {"S1"}
+    # Three hop1s, all touching only S1, ranked by tie-break (alphabetical).
+    expanded = {"S1", "Ha", "Hb", "Hc"}
+    distance = {"S1": 0, "Ha": 1, "Hb": 1, "Hc": 1}
+    edges = [_edge("S1", "Ha"), _edge("S1", "Hb"), _edge("S1", "Hc")]
+
+    new_expanded, _, _, summary = _prune_hop1(
+        seeds, expanded, distance, edges, top_k_per_seed=2
+    )
+
+    # All three have seed-degree=1 → tie-broken alphabetically → keep Ha, Hb.
+    assert new_expanded == {"S1", "Ha", "Hb"}
+    assert summary["hop1_dropped"] == 1
+
+
+def test_top_k_prefers_higher_seed_degree():
+    """When K=1 and one hop1 bridges more seeds, that one survives."""
+    seeds = {"S1", "S2"}
+    expanded = {"S1", "S2", "H_shared", "H_solo"}
+    distance = {"S1": 0, "S2": 0, "H_shared": 1, "H_solo": 1}
+    edges = [
+        _edge("S1", "H_shared"),
+        _edge("S2", "H_shared"),
+        _edge("S1", "H_solo"),
+    ]
+
+    new_expanded, _, _, summary = _prune_hop1(
+        seeds, expanded, distance, edges, top_k_per_seed=1
+    )
+
+    # S1's top-1: H_shared (degree 2) > H_solo (degree 1).
+    # S2's top-1: H_shared. Union → {H_shared}.
+    assert new_expanded == {"S1", "S2", "H_shared"}
+    assert "H_solo" not in new_expanded
+    assert summary["hop1_dropped"] == 1
+
+
+def test_orphaned_hop2_dropped_after_hop1_prune():
+    """Hop2 source-md nodes lose their hop1 bridge → must be removed."""
+    seeds = {"S1", "S2"}
+    expanded = {"S1", "S2", "H_shared", "H_only", "Src_orphan", "Src_kept"}
+    distance = {
+        "S1": 0,
+        "S2": 0,
+        "H_shared": 1,
+        "H_only": 1,
+        "Src_orphan": 2,
+        "Src_kept": 2,
+    }
+    edges = [
+        _edge("S1", "H_shared"),
+        _edge("S2", "H_shared"),
+        _edge("S1", "H_only"),
+        # Src_orphan only reachable via H_only (which gets pruned).
+        _edge("H_only", "Src_orphan"),
+        # Src_kept reachable via H_shared (survives).
+        _edge("H_shared", "Src_kept"),
+    ]
+
+    new_expanded, _, new_edges, summary = _prune_hop1(
+        seeds, expanded, distance, edges, min_seed_degree=2
+    )
+
+    assert "H_only" not in new_expanded
+    assert "Src_orphan" not in new_expanded
+    assert "Src_kept" in new_expanded
+    assert summary["hop1_dropped"] == 1
+    assert summary["hop2_dropped"] == 1
+    # Edges referencing dropped nodes are gone.
+    for edge in new_edges:
+        assert edge["source"] in new_expanded
+        assert edge["target"] in new_expanded
+
+
+def test_hop2_kept_when_directly_bridged_by_seed():
+    """A hop2 also reachable directly from a seed survives hop1 pruning."""
+    seeds = {"S1", "S2"}
+    expanded = {"S1", "S2", "H_only", "Src_dual"}
+    distance = {"S1": 0, "S2": 0, "H_only": 1, "Src_dual": 2}
+    edges = [
+        _edge("S1", "H_only"),
+        _edge("H_only", "Src_dual"),
+        # Direct seed→Src_dual bridge.
+        _edge("S2", "Src_dual"),
+    ]
+
+    new_expanded, _, _, summary = _prune_hop1(
+        seeds, expanded, distance, edges, min_seed_degree=2
+    )
+
+    assert "H_only" not in new_expanded
+    # Src_dual survives via the S2 bridge even after H_only drops.
+    assert "Src_dual" in new_expanded
+    assert summary["hop2_dropped"] == 0


### PR DESCRIPTION
## Summary

Phase 38.B — adds two flags to `ovp-graph build --layered` that suppress
concept-drift hop1 nodes overwhelming the canvas:

- `--min-seed-degree N` drops hop1 nodes that bridge fewer than N seeds
- `--top-k-per-seed K` per-seed cap on hop1 fan-out, ranked by seed-degree

Hop2 source-md nodes orphaned by hop1 pruning are also dropped, and the
edge list is filtered to the surviving node set so downstream
Cytoscape rendering stays consistent.

Both flags default off — existing invocations are unchanged.

## Test plan
- [x] `pytest tests/test_graph_cli_prune.py -q` (6 new unit tests)
- [x] Full suite green: `pytest -q` → 836 passed
- [x] `ovp-graph build --help` shows the two new flags
- [ ] Live vault smoke: `ovp-graph build --layered --seed-match "agent" --min-seed-degree 2 --top-k-per-seed 5` (drop summary printed; hop1 count visibly reduced)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/53" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
