### PR TITLE
Lazy-collapse hop2 nodes in ovp-graph HTML viewer (Phase 38.E)

### DIFF
--- a/src/ovp_pipeline/graph/visualize.py
+++ b/src/ovp_pipeline/graph/visualize.py
@@ -164,6 +164,14 @@ _CYTOSCAPE_TEMPLATE = r"""<!DOCTYPE html>
       <button id="btn-layout">Re-layout</button>
       <button id="btn-reset">Reset</button>
     </div>
+
+    <h3>Hop2 collapse</h3>
+    <div id="collapse-stat" class="meta">—</div>
+    <div class="btn-row">
+      <button id="btn-expand-all">Expand all hop2</button>
+      <button id="btn-collapse-all">Collapse all hop2</button>
+      <button id="btn-expand-selected">Expand connected to selected</button>
+    </div>
   </aside>
 
   <main id="cy"></main>
@@ -177,6 +185,8 @@ _CYTOSCAPE_TEMPLATE = r"""<!DOCTYPE html>
 <script>
 (function() {{
   var payload = {elements_json};
+  var COLLAPSE_THRESHOLD = {collapse_threshold};
+  var INITIAL_AUTO_COLLAPSE = {initial_auto_collapse_js};
 
   var TYPE_STYLE = {{
     'evergreen':          ['#34d399','ellipse'],
@@ -243,7 +253,8 @@ _CYTOSCAPE_TEMPLATE = r"""<!DOCTYPE html>
         'width': 2,
         'opacity': 1
     }}}},
-    {{ selector: '.hidden', style: {{ 'display':'none' }} }}
+    {{ selector: '.hidden', style: {{ 'display':'none' }} }},
+    {{ selector: '.collapsed-hop2', style: {{ 'display':'none' }} }}
   ];
 
   var cy = cytoscape({{
@@ -404,6 +415,88 @@ _CYTOSCAPE_TEMPLATE = r"""<!DOCTYPE html>
     cy.fit(null, 30);
   }});
 
+  // ---------- Hop2 lazy-collapse ----------
+  // 大图（>COLLAPSE_THRESHOLD 节点）默认折叠 hop2，点击 hop1 时按需展开。
+  // URL 参数可强制覆盖：?collapse_hop2=auto|always|never。
+  function getCollapseMode() {{
+    var m = (location.search || '').match(/[?&]collapse_hop2=(auto|always|never)/);
+    return m ? m[1] : 'auto';
+  }}
+  function shouldCollapseInitially() {{
+    var mode = getCollapseMode();
+    if (mode === 'always') return true;
+    if (mode === 'never')  return false;
+    return INITIAL_AUTO_COLLAPSE;  // auto: server-side default based on size
+  }}
+
+  var collapseStatEl = document.getElementById('collapse-stat');
+  function updateCollapseStat() {{
+    var total = cy.nodes().length;
+    var collapsed = cy.nodes('.collapsed-hop2').length;
+    var shown = total - collapsed;
+    if (collapsed > 0) {{
+      collapseStatEl.textContent =
+        'Showing ' + shown + ' of ' + total + ' nodes (' + collapsed + ' hop2 collapsed)';
+    }} else {{
+      collapseStatEl.textContent = 'Showing all ' + total + ' nodes';
+    }}
+  }}
+
+  function collapseHop2(nodes) {{
+    nodes.addClass('collapsed-hop2');
+    updateCollapseStat();
+  }}
+  function expandHop2(nodes) {{
+    nodes.removeClass('collapsed-hop2');
+    updateCollapseStat();
+  }}
+
+  // hop2 candidates = nodes flagged server-side, OR — if absent — fall back
+  // to seed_role-based detection so the JS still works without the marker.
+  function hop2Nodes() {{
+    var marked = cy.nodes('[?collapsed]').filter(function(n) {{
+      return n.data('collapsed') === 'hop2';
+    }});
+    if (marked.nonempty()) return marked;
+    return cy.nodes().filter(function(n) {{
+      return n.data('seed_role') === 'neighbor_2hop';
+    }});
+  }}
+
+  // Initial collapse — runs after layout so positions are computed with the
+  // full graph in place; subsequent expand simply un-hides at preserved coords.
+  if (shouldCollapseInitially()) {{
+    collapseHop2(hop2Nodes());
+  }} else {{
+    updateCollapseStat();
+  }}
+
+  // Click a hop1 node → toggle visibility of its hop2 neighbors only.
+  cy.on('tap', 'node.role-neighbor_1hop', function(evt) {{
+    var hop1 = evt.target;
+    var hop2Neighbors = hop1.neighborhood('node').filter(function(n) {{
+      return n.data('seed_role') === 'neighbor_2hop';
+    }});
+    if (hop2Neighbors.empty()) return;
+    var anyCollapsed = hop2Neighbors.some(function(n) {{ return n.hasClass('collapsed-hop2'); }});
+    if (anyCollapsed) expandHop2(hop2Neighbors);
+    else              collapseHop2(hop2Neighbors);
+  }});
+
+  document.getElementById('btn-expand-all').addEventListener('click', function() {{
+    expandHop2(cy.nodes('.collapsed-hop2'));
+  }});
+  document.getElementById('btn-collapse-all').addEventListener('click', function() {{
+    collapseHop2(hop2Nodes());
+  }});
+  document.getElementById('btn-expand-selected').addEventListener('click', function() {{
+    if (!currentSelection) return;
+    var nbrs = currentSelection.neighborhood('node').filter(function(n) {{
+      return n.data('seed_role') === 'neighbor_2hop';
+    }});
+    expandHop2(nbrs);
+  }});
+
   // Initial focus on seeds if any
   var seeds = cy.nodes('.role-seed');
   if (seeds.nonempty()) cy.fit(seeds, 80);
@@ -506,7 +599,12 @@ class GraphVisualizer:
         lines.append("\n" + "=" * 60)
         return "\n".join(lines)
 
-    def html(self, output_path: Optional[Path] = None) -> str:
+    def html(
+        self,
+        output_path: Optional[Path] = None,
+        *,
+        collapse_hop2_threshold: int = 300,
+    ) -> str:
         """生成交互式 HTML 可视化（基于 Cytoscape.js）。
 
         替代了原来的 vis.js 实现。原版在 ~6K 节点上互动僵硬、信息密度低、
@@ -524,6 +622,16 @@ class GraphVisualizer:
         edges_data = self._cytoscape_edges()
         type_counts = self._type_counts(nodes_data)
 
+        # Decide auto-collapse: when the graph is large, mark hop2 nodes so
+        # the page boots collapsed (JS can override via ?collapse_hop2=...).
+        # Threshold is server-side default; the URL param lets a reviewer flip
+        # the decision per-session without re-rendering.
+        auto_collapse = len(nodes_data) > collapse_hop2_threshold
+        if auto_collapse:
+            for node in nodes_data:
+                if node['data'].get('seed_role') == 'neighbor_2hop':
+                    node['data']['collapsed'] = 'hop2'
+
         title = self.delta.get('day_id', '') or 'OVP Graph'
         seed_pattern = self.delta.get('seed_pattern', '')
         if seed_pattern:
@@ -537,6 +645,8 @@ class GraphVisualizer:
             seed_count=len(self.delta.get('seed_note_ids', [])),
             type_filter_html=_render_type_filter(type_counts),
             elements_json=_safe_json({'nodes': nodes_data, 'edges': edges_data}),
+            collapse_threshold=collapse_hop2_threshold,
+            initial_auto_collapse_js='true' if auto_collapse else 'false',
         )
 
         if output_path:

--- a/tests/test_graph_visualize_lazy.py
+++ b/tests/test_graph_visualize_lazy.py
@@ -1,0 +1,111 @@
+"""Phase 38.E: Cytoscape lazy-loading of hop2 nodes.
+
+Validates the server-side decisions that drive the JS:
+  * graphs over the threshold mark hop2 nodes with ``collapsed: hop2`` and
+    flip ``INITIAL_AUTO_COLLAPSE`` to ``true``;
+  * graphs under the threshold leave the markers off and let the page boot
+    fully expanded;
+  * the sidebar surfaces the three required buttons.
+"""
+
+from __future__ import annotations
+
+
+from ovp_pipeline.graph.visualize import GraphVisualizer
+
+
+def _node(idx: int, role: str) -> dict:
+    return {
+        "note_id": f"n{idx}",
+        "title": f"Node {idx}",
+        "note_type": "evergreen",
+        "seed_role": role,
+        "distance_from_seed": 0 if role == "seed" else (1 if role == "neighbor_1hop" else 2),
+    }
+
+
+def _payload(node_count: int, *, hop2_count: int = 0) -> dict:
+    nodes: list[dict] = [_node(0, "seed")]
+    hop1_count = max(0, node_count - 1 - hop2_count)
+    for i in range(hop1_count):
+        nodes.append(_node(1 + i, "neighbor_1hop"))
+    for i in range(hop2_count):
+        nodes.append(_node(1 + hop1_count + i, "neighbor_2hop"))
+    return {
+        "day_id": "test",
+        "generated_at": "2026-04-23",
+        "nodes": nodes,
+        "edges": [],
+        "seed_note_ids": ["n0"],
+    }
+
+
+def test_large_graph_marks_hop2_nodes_with_collapsed_attribute():
+    """A graph above the default threshold must annotate every hop2 node so
+    the JS layer can hide them on initial render."""
+    payload = _payload(node_count=320, hop2_count=120)
+
+    html = GraphVisualizer(payload).html()
+
+    assert '"collapsed": "hop2"' in html
+    assert "INITIAL_AUTO_COLLAPSE = true" in html
+
+
+def test_small_graph_does_not_auto_collapse():
+    """Under the threshold, hop2 markers stay absent — small vaults render
+    every node up-front."""
+    payload = _payload(node_count=50, hop2_count=20)
+
+    html = GraphVisualizer(payload).html()
+
+    assert '"collapsed": "hop2"' not in html
+    assert "INITIAL_AUTO_COLLAPSE = false" in html
+
+
+def test_threshold_override_via_kwarg():
+    """Lowering the threshold flips a small graph into auto-collapse mode —
+    used by tests and by callers who want stricter defaults."""
+    payload = _payload(node_count=50, hop2_count=20)
+
+    html = GraphVisualizer(payload).html(collapse_hop2_threshold=10)
+
+    assert '"collapsed": "hop2"' in html
+    assert "INITIAL_AUTO_COLLAPSE = true" in html
+    assert "COLLAPSE_THRESHOLD = 10" in html
+
+
+def test_collapse_mode_query_param_handler_present():
+    """The JS that parses ?collapse_hop2= must ship in every page so the
+    URL-level override works without server changes."""
+    payload = _payload(node_count=10)
+
+    html = GraphVisualizer(payload).html()
+
+    # Each branch of the override must be parsed and routed.
+    assert "collapse_hop2=(auto|always|never)" in html
+    assert "shouldCollapseInitially" in html
+
+
+def test_sidebar_exposes_three_collapse_buttons():
+    """Locks in the labels — the plan calls these out explicitly so a
+    reviewer building muscle memory can spot UX regressions."""
+    html = GraphVisualizer(_payload(node_count=10)).html()
+
+    assert 'id="btn-expand-all"' in html
+    assert "Expand all hop2" in html
+    assert 'id="btn-collapse-all"' in html
+    assert "Collapse all hop2" in html
+    assert 'id="btn-expand-selected"' in html
+    assert "Expand connected to selected" in html
+    assert 'id="collapse-stat"' in html
+
+
+def test_only_hop2_nodes_get_marked_not_seeds_or_hop1():
+    """Marker discipline: seeds and hop1s must never carry ``collapsed`` —
+    that would hide the very nodes the reviewer is trying to navigate."""
+    payload = _payload(node_count=320, hop2_count=120)
+
+    html = GraphVisualizer(payload).html(collapse_hop2_threshold=10)
+
+    # Total marker count == hop2 count.
+    assert html.count('"collapsed": "hop2"') == 120


### PR DESCRIPTION
## Summary

Phase 38.E (final piece) — defers hop2 source-md rendering until the reviewer
asks for it, so layered graphs above ~300 nodes stay readable.

- Server marks hop2 nodes with \`collapsed: hop2\` and flips \`INITIAL_AUTO_COLLAPSE\` true when total nodes exceed the threshold (default 300, override via \`html(..., collapse_hop2_threshold=...)\`).
- JS reads \`?collapse_hop2=auto|always|never\` from the URL — per-session override without re-rendering.
- After cose-bilkent lays out the full graph, marked hop2 nodes get \`display: none\` — positions stay computed, toggling reuses the same coords (no relayout).
- Click a hop1 to toggle its hop2 neighbors only.
- Three sidebar buttons (Expand all / Collapse all / Expand connected to selected) + live "Showing N of M" stat.

Below threshold: the page is byte-equivalent to the prior version modulo two new JS constants and the new sidebar block.

## Test plan
- [x] \`pytest tests/test_graph_visualize_lazy.py -q\` (6 new unit tests)
- [x] \`pytest tests/test_graph_seed_match.py -q\` (existing visualize tests still pass — template format unbroken)
- [x] Full suite green: \`pytest -q\` → 836 passed
- [ ] Live vault smoke: \`ovp-graph build --layered --seed-match agent --output /tmp/g.html\`; open in browser; verify ?collapse_hop2=always & ?collapse_hop2=never override correctly; click hop1 to toggle.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/54" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
