### PR TITLE
Clear pre-existing ruff debt in graph_cli, visualize, lint_checker

### DIFF
--- a/src/ovp_pipeline/graph/visualize.py
+++ b/src/ovp_pipeline/graph/visualize.py
@@ -9,7 +9,6 @@ Visualization - 图谱可视化
 
 from pathlib import Path
 from typing import Optional
-from dataclasses import asdict
 import html as _html
 import json
 import re
@@ -522,17 +521,17 @@ class GraphVisualizer:
 
         # 统计
         stats = self.delta.get('stats', {})
-        lines.append(f"\n📈 统计:")
+        lines.append("\n📈 统计:")
         lines.append(f"   Seeds: {len(self.delta.get('seed_note_ids', []))}")
         lines.append(f"   Nodes: {stats.get('expanded_node_count', 0)}")
         lines.append(f"   Edges: {stats.get('expanded_edge_count', 0)}")
 
         # 图例
-        lines.append(f"\n📝 图例:")
-        lines.append(f"   🌱 seed        - 今日新增/修改")
-        lines.append(f"   🔗 1-hop      - 直接关联")
-        lines.append(f"   🔄 2-hop      - 2跳关联")
-        lines.append(f"   📦 3-hop      - 3跳关联")
+        lines.append("\n📝 图例:")
+        lines.append("   🌱 seed        - 今日新增/修改")
+        lines.append("   🔗 1-hop      - 直接关联")
+        lines.append("   🔄 2-hop      - 2跳关联")
+        lines.append("   📦 3-hop      - 3跳关联")
 
         # 过滤模板文件
         def is_valid_node(node: dict) -> bool:
@@ -556,7 +555,7 @@ class GraphVisualizer:
                 t = node.get('note_type', 'unknown')
                 by_type.setdefault(t, []).append(node)
 
-        lines.append(f"\n📚 按类型:")
+        lines.append("\n📚 按类型:")
         type_icons = {
             'raw': '📄',
             'deep_dive': '📑',

--- a/src/ovp_pipeline/graph_cli.py
+++ b/src/ovp_pipeline/graph_cli.py
@@ -330,7 +330,7 @@ def cmd_build(args):
         print("📊 扫盘构建全量图谱...")
         all_nodes, all_edges = _scan_graph_from_filesystem(vault_dir)
 
-    print(f"\n✅ 图谱构建完成:")
+    print("\n✅ 图谱构建完成:")
     print(f"   节点: {len(all_nodes)}")
     print(f"   边: {len(all_edges)}")
 
@@ -509,7 +509,7 @@ def cmd_daily(args):
 
     # --full 模式: 显示完整图谱
     if args.full:
-        print(f"📊 构建完整图谱...")
+        print("📊 构建完整图谱...")
 
         builder = GraphBuilder(vault_dir)
         directories = [
@@ -543,7 +543,6 @@ def cmd_daily(args):
             "edges": all_edges,
         }
 
-        output_file = vault_dir / "60-Logs" / "daily-deltas" / f"delta-{day_id}.json"
         delta_computer.save(delta)
     else:
         print(f"📅 生成每日增量图谱: {day_id}")
@@ -554,12 +553,11 @@ def cmd_daily(args):
             expand_hops=args.expand_hops
         )
 
-        # 保存JSON
-        output_file = delta_computer.save(delta)
+        delta_computer.save(delta)
 
     # 打印统计
     stats = delta.get('stats', {})
-    print(f"\n📊 统计:")
+    print("\n📊 统计:")
     print(f"   节点: {stats.get('expanded_node_count', 0)}")
     print(f"   边: {stats.get('expanded_edge_count', 0)}")
     if not args.full:
@@ -660,10 +658,10 @@ def cmd_stats(args):
 
     stats = builder.get_stats()
 
-    print(f"\n📈 全局统计:")
+    print("\n📈 全局统计:")
     print(f"   总节点: {stats['total_nodes']}")
     print(f"   总边: {stats['total_edges']}")
-    print(f"\n📚 按类型分布:")
+    print("\n📚 按类型分布:")
     for note_type, count in stats.get('note_types', {}).items():
         print(f"   {note_type}: {count}")
 

--- a/src/ovp_pipeline/lint_checker.py
+++ b/src/ovp_pipeline/lint_checker.py
@@ -17,7 +17,6 @@ Usage:
     ovp-lint --wigs            # 启用 WIGS 5层架构检查
 """
 
-import os
 import re
 import json
 import argparse
@@ -25,7 +24,7 @@ import subprocess
 from pathlib import Path
 from datetime import datetime, timedelta, timezone
 from dataclasses import dataclass, asdict
-from typing import List, Dict, Set, Tuple, Optional
+from typing import List, Dict, Set, Optional
 from collections import defaultdict
 
 try:
@@ -455,7 +454,7 @@ class KnowledgeLinter:
                         type=self.BROKEN_LINK,
                         file=file_path,
                         message=f"断裂链接: [[{link}]] 指向不存在的页面",
-                        suggestion=f"创建页面或修复链接",
+                        suggestion="创建页面或修复链接",
                         auto_fixable=False
                     )
                     self.issues.append(issue)
@@ -916,7 +915,7 @@ class KnowledgeLinter:
                 lines.append(f"   → {issue.message}")
                 lines.append(f"   💡 {issue.suggestion}")
                 if issue.auto_fixable:
-                    lines.append(f"   🔧 可自动修复")
+                    lines.append("   🔧 可自动修复")
                 lines.append("")
 
         # 信息


### PR DESCRIPTION
## Summary
- Fixes 18 pre-existing ruff errors localized to `graph_cli.py`, `graph/visualize.py`, `lint_checker.py` (14 × F541 extraneous f-prefix, 3 × F401 unused imports, 1 × F841 dead `output_file` assignment in `cmd_daily`).
- Pure cleanup — no behavior change. The 78 ruff errors elsewhere in the tree remain out of scope and were not touched.

## Test plan
- [x] `ruff check src/ovp_pipeline/graph_cli.py src/ovp_pipeline/graph/visualize.py src/ovp_pipeline/lint_checker.py` — clean.
- [x] `pytest -q` — 886 passed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/56" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code cleanup and refactoring to improve maintainability, including removal of unused code elements and optimization of string handling across multiple modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->