### PR TITLE
Fix promote-backfill dry-run summary counts

### DIFF
--- a/src/ovp_pipeline/commands/promote_backfill.py
+++ b/src/ovp_pipeline/commands/promote_backfill.py
@@ -97,7 +97,7 @@ def main(argv: list[str] | None = None) -> int:
     written = 0
     skipped = 0
     missing = 0
-    would_write = 0
+    candidates = 0
     for source_name, slugs in sorted(pairs.items()):
         path = _resolve_source_path(vault_dir, source_name)
         if not path:
@@ -108,7 +108,7 @@ def main(argv: list[str] | None = None) -> int:
 
         slugs_sorted = sorted(slugs)
         if args.dry_run:
-            would_write += 1
+            candidates += 1
             print(f"  [DRY] {path.relative_to(vault_dir)} ← {len(slugs_sorted)} slug(s)")
             continue
 
@@ -125,10 +125,12 @@ def main(argv: list[str] | None = None) -> int:
         else:
             skipped += 1
 
-    if args.dry_run:
-        print(f"\nWould-write: {would_write}, missing-source: {missing}")
-    else:
-        print(f"\nWrote: {written}, already-current: {skipped}, missing-source: {missing}")
+    head = (
+        f"Candidates: {candidates}"
+        if args.dry_run
+        else f"Wrote: {written}, already-current: {skipped}"
+    )
+    print(f"\n{head}, missing-source: {missing}")
     return 0
 
 

--- a/src/ovp_pipeline/commands/promote_backfill.py
+++ b/src/ovp_pipeline/commands/promote_backfill.py
@@ -97,6 +97,7 @@ def main(argv: list[str] | None = None) -> int:
     written = 0
     skipped = 0
     missing = 0
+    would_write = 0
     for source_name, slugs in sorted(pairs.items()):
         path = _resolve_source_path(vault_dir, source_name)
         if not path:
@@ -107,6 +108,7 @@ def main(argv: list[str] | None = None) -> int:
 
         slugs_sorted = sorted(slugs)
         if args.dry_run:
+            would_write += 1
             print(f"  [DRY] {path.relative_to(vault_dir)} ← {len(slugs_sorted)} slug(s)")
             continue
 
@@ -123,7 +125,10 @@ def main(argv: list[str] | None = None) -> int:
         else:
             skipped += 1
 
-    print(f"\nWrote: {written}, already-current: {skipped}, missing-source: {missing}")
+    if args.dry_run:
+        print(f"\nWould-write: {would_write}, missing-source: {missing}")
+    else:
+        print(f"\nWrote: {written}, already-current: {skipped}, missing-source: {missing}")
     return 0
 
 

--- a/tests/test_promote_backfill_cli.py
+++ b/tests/test_promote_backfill_cli.py
@@ -78,7 +78,7 @@ def test_backfill_dry_run_summary_counts(tmp_path: Path, capsys):
     rc = backfill_main(["--vault-dir", str(vault), "--dry-run"])
     assert rc == 0
     out = capsys.readouterr().out
-    assert "Would-write: 2" in out
+    assert "Candidates: 2" in out
     assert "missing-source: 1" in out
 
 

--- a/tests/test_promote_backfill_cli.py
+++ b/tests/test_promote_backfill_cli.py
@@ -60,6 +60,28 @@ def test_backfill_dry_run_does_not_write(tmp_path: Path):
     assert list_promotions(src.read_text(encoding="utf-8")) == []
 
 
+def test_backfill_dry_run_summary_counts(tmp_path: Path, capsys):
+    vault = tmp_path / "vault"
+    src_a = vault / "20-Areas" / "a.md"
+    src_b = vault / "20-Areas" / "b.md"
+    _write(src_a, "body\n")
+    _write(src_b, "body\n")
+    _write_pipeline_log(
+        vault,
+        [
+            {"event_type": "evergreen_auto_promoted", "concept": "X", "source": "a.md"},
+            {"event_type": "evergreen_auto_promoted", "concept": "Y", "source": "b.md"},
+            {"event_type": "evergreen_auto_promoted", "concept": "Z", "source": "ghost.md"},
+        ],
+    )
+
+    rc = backfill_main(["--vault-dir", str(vault), "--dry-run"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Would-write: 2" in out
+    assert "missing-source: 1" in out
+
+
 def test_backfill_groups_concepts_per_source(tmp_path: Path):
     vault = tmp_path / "vault"
     src = vault / "20-Areas" / "topic.md"


### PR DESCRIPTION
## Summary
- Dry-run mode in `ovp-promote-backfill` always printed `Wrote: 0, already-current: 0, missing-source: 0` — even when it had just enumerated hundreds of pending writes — because the counter increments live behind the not-dry-run branch.
- Surfaced during a real vault smoke pass (458 source files, summary still read 0/0/0).
- Adds a `would_write` counter + dedicated dry-run summary line. Wet-run output unchanged.

## Test plan
- [x] New focused `capsys` test pins the new dry-run summary (`Would-write: 2`, `missing-source: 1`).
- [x] `pytest tests/test_promote_backfill_cli.py -q` — 6 passed.
- [x] Full `pytest -q` — 887 passed locally on a sibling branch with the same change.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/57" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dry-run mode now displays a candidates count for resolved source files, providing visibility into the scope of backfill operations before execution.
  * Summary reporting is now mode-aware, showing candidates count during dry-run and write/already-current counts during standard execution.

* **Tests**
  * Added validation tests for dry-run summary reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->