### PR TITLE
Phase 38 Stage A: link density emergency fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,7 @@ ovp-mcp = "ovp_pipeline.commands.mcp:main"
 ovp-note-type-normalize = "ovp_pipeline.commands.note_type_normalize:main"
 ovp-concept-dedup = "ovp_pipeline.commands.concept_dedup:main"
 ovp-promote-backfill = "ovp_pipeline.commands.promote_backfill:main"
+ovp-link-suggest = "ovp_pipeline.commands.link_suggest:main"
 
 [project.entry-points."ovp.packs"]
 default-knowledge = "ovp_pipeline.packs.default_knowledge:get_pack"

--- a/src/ovp_pipeline/auto_evergreen_extractor.py
+++ b/src/ovp_pipeline/auto_evergreen_extractor.py
@@ -179,7 +179,7 @@ Evergreen笔记标准：
     "one_sentence_def": "一句话定义（中文，但保留技术术语英文）",
     "explanation": "详细解释（中文，技术术语不翻译）",
     "importance": "为什么重要",
-    "related_concepts": ["Related-Concept-1", "Related-Concept-2"]
+    "related_concepts": ["Related-Concept-1", "Related-Concept-2", "Related-Concept-3"]
   }
 ]
 
@@ -191,16 +191,106 @@ Evergreen笔记标准：
 - `one_sentence_def` 不能为空，必须是完整定义句
 - `concept_name` 必须是稳定的 kebab-case slug，不能包含文件扩展名或 URL 片段
 - `title` 应该是紧凑、可复用的知识标题，不要直接复述文件名/README 标题
-- `related_concepts` 至少给出 1-3 个真正相关的概念；如果没有合适项，返回空数组
+- `related_concepts` **必须给出至少 3 个真正相关的概念**。当用户提示中包含"已有概念目录"时，优先从该目录复用 slug（精确匹配，区分大小写）；目录之外的新概念也允许，但要确保是稳定、可命名的原子概念，不要凭空发明
 - 如果全文主要是项目包装、目录说明、营销文案、或信息不足以形成稳定知识，请返回空数组
 """
 
-    def __init__(self, llm_client: LiteLLMClient, logger: PipelineLogger):
+    def __init__(
+        self,
+        llm_client: LiteLLMClient,
+        logger: PipelineLogger,
+        vault_dir: Path | None = None,
+    ):
         self.llm = llm_client
         self.logger = logger
+        self.vault_dir = vault_dir
+
+    @staticmethod
+    def _sanitize_fts_query(query_text: str) -> str:
+        """FTS5 MATCH treats `:`, `-`, `"`, etc. as syntax — `multi-step` parses
+        as `multi NOT step`, then `step` is read as a column qualifier and the
+        whole query throws `no such column: step`. Strip everything except
+        alphanumerics + CJK and collapse whitespace so the query stays a
+        plain bag of tokens."""
+        cleaned = re.sub(r"[^\w\u4e00-\u9fff]+", " ", query_text, flags=re.UNICODE)
+        return " ".join(cleaned.split())
+
+    def _retrieve_related_for_extraction(
+        self,
+        query_text: str,
+        k: int = 20,
+    ) -> list[dict[str, str]]:
+        """Pull top-k existing concepts (BM25 over the knowledge index) so the
+        prompt can ground new evergreens in the real registry instead of
+        inventing slugs in a vacuum. Returns [] if no vault_dir or the index
+        is unavailable."""
+        if self.vault_dir is None:
+            return []
+        try:
+            from .knowledge_index import search_knowledge_index
+        except ImportError:
+            try:
+                from knowledge_index import search_knowledge_index  # type: ignore
+            except ImportError:
+                return []
+
+        sanitized = self._sanitize_fts_query(query_text)
+        if not sanitized:
+            return []
+        try:
+            hits = search_knowledge_index(self.vault_dir, sanitized, limit=k)
+        except Exception:
+            return []
+
+        registry = None
+        if HAS_REGISTRY:
+            try:
+                registry = ConceptRegistry(self.vault_dir).load()
+            except Exception:
+                registry = None
+
+        results: list[dict[str, str]] = []
+        for hit in hits:
+            slug = str(hit.get("slug") or "")
+            title = str(hit.get("title") or "")
+            if not slug:
+                continue
+            definition = ""
+            if registry is not None:
+                try:
+                    entry = registry.find_by_slug(slug)
+                    if entry and entry.definition:
+                        definition = entry.definition
+                except Exception:
+                    pass
+            results.append({"slug": slug, "title": title, "definition": definition})
+        return results
+
+    @staticmethod
+    def _format_related_block(related: list[dict[str, str]]) -> str:
+        """Render retrieved candidates as a markdown checklist for the prompt.
+        Definitions are truncated to keep the prompt small."""
+        if not related:
+            return ""
+        lines = ["", "已有概念目录（请优先复用以下 slug，仅当确无对应项时再发明新 slug）:"]
+        for item in related:
+            slug = item.get("slug", "")
+            title = item.get("title", "") or slug
+            definition = (item.get("definition") or "").strip()
+            if definition:
+                if len(definition) > 80:
+                    definition = definition[:77] + "..."
+                lines.append(f"- `{slug}` — {title} — {definition}")
+            else:
+                lines.append(f"- `{slug}` — {title}")
+        return "\n".join(lines)
 
     def extract_concepts(self, file_path: Path, content: str) -> list[dict]:
         """从内容中提取概念"""
+        retrieval_query = f"{file_path.stem}\n{content[:500]}".strip()
+        related = self._retrieve_related_for_extraction(retrieval_query)
+        related_block = self._format_related_block(related)
+
         user_prompt = f"""请从以下深度解读中提取3-5个核心概念：
 
 文件: {file_path}
@@ -209,6 +299,7 @@ Evergreen笔记标准：
 ```
 {content[:6000]}
 ```
+{related_block}
 
 请按JSON格式输出概念列表。"""
 
@@ -305,7 +396,7 @@ class AutoEvergreenExtractor:
             model=DEFAULT_MINIMAX_MODEL,
             api_type="anthropic"
         )
-        self.extractor = EvergreenExtractor(llm_client, self.logger)
+        self.extractor = EvergreenExtractor(llm_client, self.logger, vault_dir=self.vault_dir)
 
     def evergreen_exists(self, concept_name: str, registry=None) -> bool:
         """检查Evergreen笔记是否已存在（registry优先，文件系统备选）"""
@@ -374,6 +465,14 @@ class AutoEvergreenExtractor:
                     "name": concept_name,
                     "status": "pending"
                 }
+
+                related = concept.get("related_concepts") or []
+                if len(related) < 3:
+                    self.logger.log("evergreen_low_link", {
+                        "concept": concept_name,
+                        "source": str(file_path.name),
+                        "related_count": len(related),
+                    })
 
                 # 检查是否已存在（registry或文件系统）
                 if self.evergreen_exists(concept_name, registry=registry):

--- a/src/ovp_pipeline/auto_evergreen_extractor.py
+++ b/src/ovp_pipeline/auto_evergreen_extractor.py
@@ -205,36 +205,30 @@ Evergreen笔记标准：
         self.logger = logger
         self.vault_dir = vault_dir
 
-    @staticmethod
-    def _sanitize_fts_query(query_text: str) -> str:
-        """FTS5 MATCH treats `:`, `-`, `"`, etc. as syntax — `multi-step` parses
-        as `multi NOT step`, then `step` is read as a column qualifier and the
-        whole query throws `no such column: step`. Strip everything except
-        alphanumerics + CJK and collapse whitespace so the query stays a
-        plain bag of tokens."""
-        cleaned = re.sub(r"[^\w\u4e00-\u9fff]+", " ", query_text, flags=re.UNICODE)
-        return " ".join(cleaned.split())
-
     def _retrieve_related_for_extraction(
         self,
         query_text: str,
         k: int = 20,
+        *,
+        registry: Any = None,
     ) -> list[dict[str, str]]:
         """Pull top-k existing concepts (BM25 over the knowledge index) so the
         prompt can ground new evergreens in the real registry instead of
         inventing slugs in a vacuum. Returns [] if no vault_dir or the index
-        is unavailable."""
+        is unavailable. ``registry`` may be a pre-loaded ``ConceptRegistry`` —
+        callers in batch mode should pass their cached instance to avoid
+        re-parsing the registry file per article."""
         if self.vault_dir is None:
             return []
         try:
-            from .knowledge_index import search_knowledge_index
+            from .knowledge_index import sanitize_fts_query, search_knowledge_index
         except ImportError:
             try:
-                from knowledge_index import search_knowledge_index  # type: ignore
+                from knowledge_index import sanitize_fts_query, search_knowledge_index  # type: ignore
             except ImportError:
                 return []
 
-        sanitized = self._sanitize_fts_query(query_text)
+        sanitized = sanitize_fts_query(query_text)
         if not sanitized:
             return []
         try:
@@ -242,8 +236,7 @@ Evergreen笔记标准：
         except Exception:
             return []
 
-        registry = None
-        if HAS_REGISTRY:
+        if registry is None and HAS_REGISTRY:
             try:
                 registry = ConceptRegistry(self.vault_dir).load()
             except Exception:
@@ -285,10 +278,16 @@ Evergreen笔记标准：
                 lines.append(f"- `{slug}` — {title}")
         return "\n".join(lines)
 
-    def extract_concepts(self, file_path: Path, content: str) -> list[dict]:
-        """从内容中提取概念"""
+    def extract_concepts(
+        self,
+        file_path: Path,
+        content: str,
+        *,
+        registry: Any = None,
+    ) -> list[dict]:
+        """从内容中提取概念。``registry`` 由批量调用方注入以避免重复加载。"""
         retrieval_query = f"{file_path.stem}\n{content[:500]}".strip()
-        related = self._retrieve_related_for_extraction(retrieval_query)
+        related = self._retrieve_related_for_extraction(retrieval_query, registry=registry)
         related_block = self._format_related_block(related)
 
         user_prompt = f"""请从以下深度解读中提取3-5个核心概念：
@@ -449,12 +448,13 @@ class AutoEvergreenExtractor:
             with open(file_path, "r", encoding="utf-8") as f:
                 content = f.read()
 
-            # 提取概念
-            concepts = self.extractor.extract_concepts(file_path, content)
-            result["concepts_extracted"] = len(concepts)
-
             # 获取已加载的 registry（每文件一次，不是每概念一次）
+            # 注入到 extractor 以便检索阶段也复用同一个缓存。
             registry = self._get_registry()
+
+            # 提取概念
+            concepts = self.extractor.extract_concepts(file_path, content, registry=registry)
+            result["concepts_extracted"] = len(concepts)
 
             for concept in concepts:
                 concept_name = concept.get("concept_name")

--- a/src/ovp_pipeline/commands/link_suggest.py
+++ b/src/ovp_pipeline/commands/link_suggest.py
@@ -1,0 +1,355 @@
+"""One-shot backfill: propose wikilinks for pages that are under-linked.
+
+The Phase 38 link-density audit found 73% of deep_dives carry zero outbound
+wikilinks because the extractor (pre-Phase 38) didn't ground its
+``related_concepts`` in the existing registry. This command repairs the
+legacy backlog: for every page with fewer than ``--min-links`` outbound
+wikilinks, query the knowledge index for related concepts and emit a JSONL
+suggestion log. ``--apply --confirm`` writes a clearly-labelled section of
+backfilled wikilinks to the source markdown.
+
+Two retrieval signals are merged:
+- BM25 over ``page_fts`` (substring-style, picks up exact term hits)
+- Vector dot-product over ``page_embeddings`` (catches paraphrases)
+
+Each candidate gets a fused score = BM25_rank_score + vector_rank_score
+(reciprocal rank, k=60). Self-references and existing outbound targets are
+dropped before ranking. The naive fusion here will be replaced by the proper
+RRF + bi-temporal decay layer in Stage B.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+try:
+    from ..runtime import VaultLayout, resolve_vault_dir
+    from ..knowledge_index import (
+        _ensure_knowledge_db,
+        query_knowledge_index,
+        search_knowledge_index,
+    )
+except ImportError:
+    from ovp_pipeline.runtime import VaultLayout, resolve_vault_dir  # type: ignore
+    from ovp_pipeline.knowledge_index import (  # type: ignore
+        _ensure_knowledge_db,
+        query_knowledge_index,
+        search_knowledge_index,
+    )
+
+
+DEFAULT_MIN_LINKS = 3
+DEFAULT_CANDIDATES_PER_PAGE = 20
+DEFAULT_SUGGESTIONS_PER_PAGE = 5
+RRF_K = 60
+BACKFILL_HEADING = "## 🔗 自动建议链接 (link-suggest)"
+BACKFILL_MARKER = "<!-- link-suggest:backfill -->"
+
+
+def _new_run_id() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+
+
+def _iter_under_linked_pages(
+    layout: VaultLayout,
+    *,
+    min_links: int,
+    note_types: tuple[str, ...] | None = None,
+) -> list[dict[str, Any]]:
+    """Return pages whose outbound wikilink count is below ``min_links``."""
+    _ensure_knowledge_db(layout.vault_dir)
+    type_clause = ""
+    params: list[Any] = []
+    if note_types:
+        placeholders = ",".join("?" for _ in note_types)
+        type_clause = f"WHERE pi.note_type IN ({placeholders})"
+        params.extend(note_types)
+    params.append(min_links)
+    with sqlite3.connect(layout.knowledge_db) as conn:
+        rows = conn.execute(
+            f"""
+            SELECT pi.slug, pi.title, pi.note_type, pi.path, pi.body,
+                   COUNT(pl.target_slug) AS link_out_count
+            FROM pages_index pi
+            LEFT JOIN page_links pl
+              ON pl.source_slug = pi.slug AND pl.link_type = 'wikilink'
+            {type_clause}
+            GROUP BY pi.slug
+            HAVING link_out_count < ?
+            ORDER BY pi.slug
+            """,
+            params,
+        ).fetchall()
+    return [
+        {
+            "slug": slug,
+            "title": title,
+            "note_type": note_type,
+            "path": path,
+            "body": body,
+            "link_out_count": link_out_count,
+        }
+        for slug, title, note_type, path, body, link_out_count in rows
+    ]
+
+
+def _existing_link_targets(layout: VaultLayout, source_slug: str) -> set[str]:
+    with sqlite3.connect(layout.knowledge_db) as conn:
+        rows = conn.execute(
+            "SELECT target_slug FROM page_links WHERE source_slug = ?",
+            (source_slug,),
+        ).fetchall()
+    return {row[0] for row in rows}
+
+
+def _fuse_candidates(
+    bm25_hits: list[dict[str, Any]],
+    vector_hits: list[dict[str, Any]],
+    *,
+    self_slug: str,
+    skip_slugs: set[str],
+) -> list[dict[str, Any]]:
+    """Merge BM25 + vector results via reciprocal rank fusion. Vector hits are
+    keyed on ``slug`` (collapsing chunk_index — best chunk per slug wins)."""
+    fused: dict[str, dict[str, Any]] = {}
+    for rank, hit in enumerate(bm25_hits, start=1):
+        slug = str(hit.get("slug") or "")
+        if not slug or slug == self_slug or slug in skip_slugs:
+            continue
+        record = fused.setdefault(
+            slug,
+            {"slug": slug, "title": hit.get("title", ""), "rrf_score": 0.0},
+        )
+        record["rrf_score"] += 1.0 / (RRF_K + rank)
+    seen_vector_slugs: set[str] = set()
+    for rank, hit in enumerate(vector_hits, start=1):
+        slug = str(hit.get("slug") or "")
+        if not slug or slug == self_slug or slug in skip_slugs:
+            continue
+        if slug in seen_vector_slugs:
+            continue
+        seen_vector_slugs.add(slug)
+        record = fused.setdefault(
+            slug,
+            {"slug": slug, "title": hit.get("section_title") or slug, "rrf_score": 0.0},
+        )
+        record["rrf_score"] += 1.0 / (RRF_K + rank)
+    return sorted(fused.values(), key=lambda item: item["rrf_score"], reverse=True)
+
+
+def _suggest_for_page(
+    layout: VaultLayout,
+    page: dict[str, Any],
+    *,
+    candidates_per_page: int,
+    suggestions_per_page: int,
+) -> list[dict[str, Any]]:
+    title = page.get("title") or page["slug"]
+    body = page.get("body") or ""
+    query_text = f"{title}\n{body[:800]}".strip()
+    if not query_text:
+        return []
+    try:
+        bm25 = search_knowledge_index(layout.vault_dir, query_text, limit=candidates_per_page)
+    except Exception:
+        bm25 = []
+    try:
+        vector = query_knowledge_index(layout.vault_dir, query_text, limit=candidates_per_page)
+    except Exception:
+        vector = []
+    skip = _existing_link_targets(layout, page["slug"])
+    fused = _fuse_candidates(bm25, vector, self_slug=page["slug"], skip_slugs=skip)
+    return fused[:suggestions_per_page]
+
+
+def _suggestion_row(
+    page: dict[str, Any],
+    suggestion: dict[str, Any],
+    *,
+    run_id: str,
+) -> dict[str, Any]:
+    return {
+        "run_id": run_id,
+        "source_slug": page["slug"],
+        "source_title": page.get("title", ""),
+        "source_path": page.get("path", ""),
+        "source_link_out_count": page.get("link_out_count", 0),
+        "target_slug": suggestion["slug"],
+        "target_title": suggestion.get("title", ""),
+        "rrf_score": round(suggestion.get("rrf_score", 0.0), 6),
+    }
+
+
+def _emit_jsonl(rows: list[dict[str, Any]], log_path: Path) -> None:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("w", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+def _apply_to_markdown(
+    layout: VaultLayout, page: dict[str, Any], suggestions: list[dict[str, Any]]
+) -> bool:
+    """Append a clearly-labelled section to the source markdown. Returns True
+    when the file is mutated, False when the marker is already present
+    (idempotent re-runs are a no-op)."""
+    if not suggestions:
+        return False
+    source_path = layout.vault_dir / page["path"]
+    if not source_path.exists():
+        return False
+    text = source_path.read_text(encoding="utf-8")
+    if BACKFILL_MARKER in text:
+        return False
+    block_lines = [BACKFILL_HEADING, BACKFILL_MARKER, ""]
+    for suggestion in suggestions:
+        slug = suggestion["slug"]
+        title = suggestion.get("title") or slug
+        if title and title != slug:
+            block_lines.append(f"- [[{slug}|{title}]]")
+        else:
+            block_lines.append(f"- [[{slug}]]")
+    block_lines.append("")
+    new_text = text.rstrip() + "\n\n" + "\n".join(block_lines)
+    source_path.write_text(new_text, encoding="utf-8")
+    return True
+
+
+def run_link_suggest(
+    vault_dir: Path,
+    *,
+    min_links: int = DEFAULT_MIN_LINKS,
+    note_types: tuple[str, ...] | None = None,
+    candidates_per_page: int = DEFAULT_CANDIDATES_PER_PAGE,
+    suggestions_per_page: int = DEFAULT_SUGGESTIONS_PER_PAGE,
+    apply: bool = False,
+    confirm: bool = False,
+    limit: int | None = None,
+    log_dir: Path | None = None,
+) -> dict[str, Any]:
+    """Top-level entry. Emits the JSONL log unconditionally; only mutates
+    markdown when ``apply`` *and* ``confirm`` are both True."""
+    layout = VaultLayout.from_vault(vault_dir)
+    if apply and not confirm:
+        raise ValueError("--apply requires --confirm")
+
+    pages = _iter_under_linked_pages(layout, min_links=min_links, note_types=note_types)
+    if limit is not None:
+        pages = pages[:limit]
+
+    run_id = _new_run_id()
+    rows: list[dict[str, Any]] = []
+    files_mutated = 0
+    suggestions_total = 0
+    for page in pages:
+        suggestions = _suggest_for_page(
+            layout,
+            page,
+            candidates_per_page=candidates_per_page,
+            suggestions_per_page=suggestions_per_page,
+        )
+        for suggestion in suggestions:
+            rows.append(_suggestion_row(page, suggestion, run_id=run_id))
+        suggestions_total += len(suggestions)
+        if apply and confirm and _apply_to_markdown(layout, page, suggestions):
+            files_mutated += 1
+
+    log_root = log_dir or (layout.vault_dir / "60-Logs" / "link-suggestions")
+    log_path = log_root / f"{run_id}.jsonl"
+    _emit_jsonl(rows, log_path)
+
+    return {
+        "run_id": run_id,
+        "log_path": str(log_path),
+        "pages_examined": len(pages),
+        "suggestions_emitted": suggestions_total,
+        "files_mutated": files_mutated,
+        "applied": apply and confirm,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Propose wikilinks for under-linked pages and (optionally) backfill them.",
+    )
+    parser.add_argument("--vault-dir", type=Path, default=None, help="Vault root (default: cwd)")
+    parser.add_argument(
+        "--min-links",
+        type=int,
+        default=DEFAULT_MIN_LINKS,
+        help=f"Pages with fewer outbound wikilinks are eligible (default: {DEFAULT_MIN_LINKS})",
+    )
+    parser.add_argument(
+        "--note-type",
+        action="append",
+        default=None,
+        help="Restrict to these note_type values (repeatable). Default: all.",
+    )
+    parser.add_argument(
+        "--candidates",
+        type=int,
+        default=DEFAULT_CANDIDATES_PER_PAGE,
+        help=f"Top-k retrieved per side before fusion (default: {DEFAULT_CANDIDATES_PER_PAGE})",
+    )
+    parser.add_argument(
+        "--suggestions",
+        type=int,
+        default=DEFAULT_SUGGESTIONS_PER_PAGE,
+        help=f"Suggestions to keep per page (default: {DEFAULT_SUGGESTIONS_PER_PAGE})",
+    )
+    parser.add_argument(
+        "--limit", type=int, default=None, help="Process at most N pages (smoke testing)."
+    )
+    parser.add_argument(
+        "--apply", action="store_true", help="Rewrite source markdown to append a backfill section."
+    )
+    parser.add_argument(
+        "--confirm", action="store_true", help="Required with --apply to actually mutate files."
+    )
+    parser.add_argument("--json", action="store_true", help="Print structured summary to stdout.")
+    args = parser.parse_args(argv)
+
+    vault_dir = resolve_vault_dir(args.vault_dir)
+    note_types = tuple(args.note_type) if args.note_type else None
+    try:
+        summary = run_link_suggest(
+            vault_dir,
+            min_links=args.min_links,
+            note_types=note_types,
+            candidates_per_page=args.candidates,
+            suggestions_per_page=args.suggestions,
+            apply=args.apply,
+            confirm=args.confirm,
+            limit=args.limit,
+        )
+    except ValueError as exc:
+        print(f"✗ {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(summary, ensure_ascii=False, indent=2))
+        return 0
+
+    print("=" * 60)
+    print("LINK SUGGEST SUMMARY")
+    print("=" * 60)
+    print(f"Run ID:              {summary['run_id']}")
+    print(f"Pages examined:      {summary['pages_examined']}")
+    print(f"Suggestions emitted: {summary['suggestions_emitted']}")
+    print(f"Files mutated:       {summary['files_mutated']}")
+    print(f"Mode:                {'APPLY' if summary['applied'] else 'dry-run'}")
+    print(f"Log:                 {summary['log_path']}")
+    if not summary["applied"]:
+        print()
+        print("Pass --apply --confirm to write the backfill section into source files.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ovp_pipeline/commands/link_suggest.py
+++ b/src/ovp_pipeline/commands/link_suggest.py
@@ -31,15 +31,15 @@ from typing import Any
 try:
     from ..runtime import VaultLayout, resolve_vault_dir
     from ..knowledge_index import (
-        _ensure_knowledge_db,
         query_knowledge_index,
+        sanitize_fts_query,
         search_knowledge_index,
     )
 except ImportError:
     from ovp_pipeline.runtime import VaultLayout, resolve_vault_dir  # type: ignore
     from ovp_pipeline.knowledge_index import (  # type: ignore
-        _ensure_knowledge_db,
         query_knowledge_index,
+        sanitize_fts_query,
         search_knowledge_index,
     )
 
@@ -56,25 +56,36 @@ def _new_run_id() -> str:
     return datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
 
 
+_BODY_PREVIEW_CHARS = 800
+
+
 def _iter_under_linked_pages(
     layout: VaultLayout,
     *,
     min_links: int,
     note_types: tuple[str, ...] | None = None,
+    limit: int | None = None,
 ) -> list[dict[str, Any]]:
-    """Return pages whose outbound wikilink count is below ``min_links``."""
-    _ensure_knowledge_db(layout.vault_dir)
+    """Return pages whose outbound wikilink count is below ``min_links``.
+    Body is truncated in SQL to ``_BODY_PREVIEW_CHARS`` (the suggester only
+    uses the first 800 chars) and ``limit`` is pushed into the query so we
+    never materialize the whole vault in memory."""
     type_clause = ""
     params: list[Any] = []
     if note_types:
         placeholders = ",".join("?" for _ in note_types)
-        type_clause = f"WHERE pi.note_type IN ({placeholders})"
+        type_clause = f"WHERE pi.note_type IN ({placeholders})"  # noqa: S608 — placeholders only, values bound via params
         params.extend(note_types)
     params.append(min_links)
+    limit_clause = ""
+    if limit is not None:
+        limit_clause = "LIMIT ?"
+        params.append(limit)
     with sqlite3.connect(layout.knowledge_db) as conn:
         rows = conn.execute(
             f"""
-            SELECT pi.slug, pi.title, pi.note_type, pi.path, pi.body,
+            SELECT pi.slug, pi.title, pi.note_type, pi.path,
+                   SUBSTR(pi.body, 1, ?) AS body,
                    COUNT(pl.target_slug) AS link_out_count
             FROM pages_index pi
             LEFT JOIN page_links pl
@@ -83,8 +94,9 @@ def _iter_under_linked_pages(
             GROUP BY pi.slug
             HAVING link_out_count < ?
             ORDER BY pi.slug
-            """,
-            params,
+            {limit_clause}
+            """,  # noqa: S608 — clauses are placeholder-only, all values bound via params
+            (_BODY_PREVIEW_CHARS, *params),
         ).fetchall()
     return [
         {
@@ -152,13 +164,21 @@ def _suggest_for_page(
 ) -> list[dict[str, Any]]:
     title = page.get("title") or page["slug"]
     body = page.get("body") or ""
-    query_text = f"{title}\n{body[:800]}".strip()
+    query_text = f"{title}\n{body[:_BODY_PREVIEW_CHARS]}".strip()
     if not query_text:
         return []
-    try:
-        bm25 = search_knowledge_index(layout.vault_dir, query_text, limit=candidates_per_page)
-    except Exception:
-        bm25 = []
+    # FTS5 MATCH parses `-`/`:`/`"` as syntax (e.g. `multi-step` →
+    # `multi NOT step` → "no such column: step"); without sanitizing, the
+    # blind `except` below would silently collapse the BM25 branch and the
+    # command would quietly degrade to vector-only retrieval. See
+    # `knowledge_index.sanitize_fts_query`.
+    bm25_query = sanitize_fts_query(query_text)
+    bm25: list[dict[str, Any]] = []
+    if bm25_query:
+        try:
+            bm25 = search_knowledge_index(layout.vault_dir, bm25_query, limit=candidates_per_page)
+        except Exception:
+            bm25 = []
     try:
         vector = query_knowledge_index(layout.vault_dir, query_text, limit=candidates_per_page)
     except Exception:
@@ -239,9 +259,9 @@ def run_link_suggest(
     if apply and not confirm:
         raise ValueError("--apply requires --confirm")
 
-    pages = _iter_under_linked_pages(layout, min_links=min_links, note_types=note_types)
-    if limit is not None:
-        pages = pages[:limit]
+    pages = _iter_under_linked_pages(
+        layout, min_links=min_links, note_types=note_types, limit=limit
+    )
 
     run_id = _new_run_id()
     rows: list[dict[str, Any]] = []

--- a/src/ovp_pipeline/knowledge_index.py
+++ b/src/ovp_pipeline/knowledge_index.py
@@ -24,6 +24,18 @@ SUMMARY_MAX_LEN = 320
 SUMMARY_RELATED_LIMIT = 3
 
 
+_FTS_QUERY_SCRUB = re.compile(r"[^\w\u4e00-\u9fff]+", flags=re.UNICODE)
+
+
+def sanitize_fts_query(query_text: str) -> str:
+    """Strip FTS5 syntax characters (`-`, `:`, `"`, etc.) from free-text input
+    so prose like ``multi-step`` doesn't parse as ``multi NOT step`` and crash
+    with ``no such column: step``. Keeps alphanumerics + CJK and collapses
+    whitespace; returns ``""`` when nothing usable remains."""
+    cleaned = _FTS_QUERY_SCRUB.sub(" ", query_text or "")
+    return " ".join(cleaned.split())
+
+
 SCHEMA = """
 PRAGMA journal_mode = WAL;
 PRAGMA foreign_keys = ON;

--- a/tests/test_evergreen_extractor_retrieval.py
+++ b/tests/test_evergreen_extractor_retrieval.py
@@ -1,0 +1,234 @@
+"""Stage A 2.1 — extractor retrieval injection.
+
+Pins the contract that the Phase 38 link-density fix relies on at extraction
+time: every new evergreen is born grounded in the existing concept registry,
+not in a vacuum.
+
+- ``_format_related_block`` produces a deterministic checklist for the prompt.
+- ``_retrieve_related_for_extraction`` short-circuits when ``vault_dir`` is None
+  (so legacy callers keep working) and pulls definitions from the registry when
+  available.
+- ``extract_concepts`` injects the "已有概念目录" block into ``user_prompt``
+  whenever retrieval finds anything, so the LLM is forced to reuse known slugs.
+- ``process_file`` emits an ``evergreen_low_link`` audit event whenever the LLM
+  returns a concept with fewer than 3 related_concepts — this is the Phase 38
+  watchdog for "the prompt didn't bind".
+"""
+
+from __future__ import annotations
+
+import json
+
+from ovp_pipeline.auto_evergreen_extractor import (
+    AutoEvergreenExtractor,
+    EvergreenExtractor,
+    PipelineLogger,
+)
+from ovp_pipeline.knowledge_index import rebuild_knowledge_index
+
+
+def _seed_evergreens(temp_vault):
+    evergreen = temp_vault / "10-Knowledge" / "Evergreen"
+    (evergreen / "ai-agent.md").write_text(
+        """---
+note_id: ai-agent
+title: AI Agent
+type: evergreen
+date: 2026-04-23
+---
+
+# AI Agent
+
+> 一句话定义: 能感知环境并自主决策的 AI 系统。
+
+AI agents combine planning, memory, and tool use to execute multi-step tasks.
+""",
+        encoding="utf-8",
+    )
+    (evergreen / "rag.md").write_text(
+        """---
+note_id: rag
+title: RAG
+type: evergreen
+date: 2026-04-23
+---
+
+# RAG
+
+> 一句话定义: 检索增强生成。
+
+Retrieval-Augmented Generation grounds language model responses in external
+documents to reduce hallucination.
+""",
+        encoding="utf-8",
+    )
+
+
+class _FakeLLM:
+    """Captures the (system_prompt, user_prompt) handed to ``generate`` and
+    replays a canned JSON response. Mirrors ``LiteLLMClient.generate``'s
+    signature so the extractor can't tell the difference."""
+
+    def __init__(self, response_concepts):
+        self.response_concepts = response_concepts
+        self.calls: list[dict] = []
+
+    def generate(self, system_prompt: str, user_prompt: str, max_tokens: int = 4000) -> str:
+        self.calls.append(
+            {
+                "system_prompt": system_prompt,
+                "user_prompt": user_prompt,
+                "max_tokens": max_tokens,
+            }
+        )
+        return json.dumps(self.response_concepts, ensure_ascii=False)
+
+
+def test_format_related_block_empty_returns_empty_string():
+    assert EvergreenExtractor._format_related_block([]) == ""
+
+
+def test_format_related_block_renders_slug_title_definition():
+    block = EvergreenExtractor._format_related_block(
+        [
+            {"slug": "ai-agent", "title": "AI Agent", "definition": "自主决策的 AI 系统。"},
+            {"slug": "rag", "title": "RAG", "definition": ""},
+        ]
+    )
+    assert "已有概念目录" in block
+    assert "`ai-agent` — AI Agent — 自主决策的 AI 系统。" in block
+    assert "`rag` — RAG" in block
+    # No definition → no trailing em-dash for that row.
+    assert "`rag` — RAG — " not in block
+
+
+def test_format_related_block_truncates_long_definitions():
+    long_def = "x" * 200
+    block = EvergreenExtractor._format_related_block(
+        [{"slug": "s", "title": "T", "definition": long_def}]
+    )
+    # Truncation marker (…) appears, and the row never crosses ~100 chars.
+    assert "..." in block
+    assert all(len(line) < 120 for line in block.splitlines())
+
+
+def test_retrieve_returns_empty_when_vault_dir_is_none(temp_vault):
+    logger = PipelineLogger(temp_vault / "60-Logs" / "pipeline.jsonl")
+    extractor = EvergreenExtractor(_FakeLLM([]), logger, vault_dir=None)
+    assert extractor._retrieve_related_for_extraction("anything") == []
+
+
+def test_retrieve_pulls_hits_from_knowledge_index(temp_vault):
+    _seed_evergreens(temp_vault)
+    rebuild_knowledge_index(temp_vault)
+
+    logger = PipelineLogger(temp_vault / "60-Logs" / "pipeline.jsonl")
+    extractor = EvergreenExtractor(_FakeLLM([]), logger, vault_dir=temp_vault)
+
+    hits = extractor._retrieve_related_for_extraction("AI agent planning memory")
+    slugs = {h["slug"] for h in hits}
+    assert "ai-agent" in slugs
+
+
+def test_extract_concepts_injects_related_block_into_user_prompt(temp_vault, tmp_path):
+    _seed_evergreens(temp_vault)
+    rebuild_knowledge_index(temp_vault)
+
+    logger = PipelineLogger(temp_vault / "60-Logs" / "pipeline.jsonl")
+    fake_llm = _FakeLLM([])
+    extractor = EvergreenExtractor(fake_llm, logger, vault_dir=temp_vault)
+
+    fake_path = tmp_path / "ai_agent_deep_dive.md"
+    fake_path.write_text(
+        "AI agents use planning and memory to execute multi-step tasks. "
+        "Function calling lets them invoke external tools.",
+        encoding="utf-8",
+    )
+
+    extractor.extract_concepts(fake_path, fake_path.read_text(encoding="utf-8"))
+
+    assert len(fake_llm.calls) == 1
+    user_prompt = fake_llm.calls[0]["user_prompt"]
+    assert "已有概念目录" in user_prompt
+    assert "ai-agent" in user_prompt
+
+
+def test_extract_concepts_omits_block_when_vault_dir_none(temp_vault, tmp_path):
+    logger = PipelineLogger(temp_vault / "60-Logs" / "pipeline.jsonl")
+    fake_llm = _FakeLLM([])
+    extractor = EvergreenExtractor(fake_llm, logger, vault_dir=None)
+
+    fake_path = tmp_path / "irrelevant.md"
+    fake_path.write_text("body", encoding="utf-8")
+    extractor.extract_concepts(fake_path, "body")
+
+    assert len(fake_llm.calls) == 1
+    assert "已有概念目录" not in fake_llm.calls[0]["user_prompt"]
+
+
+def test_process_file_logs_evergreen_low_link_below_threshold(temp_vault, tmp_path):
+    """When the LLM ignores the ≥3 requirement, the audit log must record it
+    so the link-density watchdog can spot regressions."""
+    log_path = temp_vault / "60-Logs" / "pipeline.jsonl"
+    logger = PipelineLogger(log_path)
+    auto = AutoEvergreenExtractor(temp_vault, logger)
+
+    # Inject our fake LLM directly — bypass init_llm so we don't need litellm.
+    auto.extractor = EvergreenExtractor(
+        _FakeLLM(
+            [
+                {
+                    "concept_name": "underlinked-concept",
+                    "title": "Underlinked Concept",
+                    "one_sentence_def": "测试用概念。",
+                    "explanation": "测试。",
+                    "importance": "测试。",
+                    "related_concepts": ["only-one"],
+                }
+            ]
+        ),
+        logger,
+        vault_dir=temp_vault,
+    )
+
+    fake_path = tmp_path / "fake_deep_dive.md"
+    fake_path.write_text("body content", encoding="utf-8")
+    auto.process_file(fake_path, dry_run=True)
+
+    rows = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines() if line]
+    low_link_rows = [r for r in rows if r.get("event_type") == "evergreen_low_link"]
+    assert len(low_link_rows) == 1
+    assert low_link_rows[0]["concept"] == "underlinked-concept"
+    assert low_link_rows[0]["related_count"] == 1
+
+
+def test_process_file_does_not_log_when_threshold_met(temp_vault, tmp_path):
+    log_path = temp_vault / "60-Logs" / "pipeline.jsonl"
+    logger = PipelineLogger(log_path)
+    auto = AutoEvergreenExtractor(temp_vault, logger)
+    auto.extractor = EvergreenExtractor(
+        _FakeLLM(
+            [
+                {
+                    "concept_name": "well-linked-concept",
+                    "title": "Well-Linked Concept",
+                    "one_sentence_def": "测试用概念。",
+                    "explanation": "测试。",
+                    "importance": "测试。",
+                    "related_concepts": ["a", "b", "c"],
+                }
+            ]
+        ),
+        logger,
+        vault_dir=temp_vault,
+    )
+
+    fake_path = tmp_path / "fake_deep_dive.md"
+    fake_path.write_text("body content", encoding="utf-8")
+    auto.process_file(fake_path, dry_run=True)
+
+    if not log_path.exists():
+        return
+    rows = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines() if line]
+    low_link_rows = [r for r in rows if r.get("event_type") == "evergreen_low_link"]
+    assert low_link_rows == []

--- a/tests/test_link_suggest.py
+++ b/tests/test_link_suggest.py
@@ -1,0 +1,253 @@
+"""Stage A 2.2 — ovp-link-suggest backfill.
+
+These tests pin the contract that the Phase 38 link-density audit relies on:
+- pages with fewer than ``--min-links`` outbound wikilinks become suggestion
+  targets;
+- candidates already linked from the source are never re-proposed;
+- ``--apply`` requires ``--confirm`` and is idempotent (the backfill marker
+  is the gate).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from ovp_pipeline.commands.link_suggest import (
+    BACKFILL_HEADING,
+    BACKFILL_MARKER,
+    run_link_suggest,
+)
+from ovp_pipeline.knowledge_index import rebuild_knowledge_index
+
+
+def _seed_evergreens(temp_vault):
+    """Three semantically related evergreens + one isolated deep_dive that
+    mentions all three in prose but carries zero outbound wikilinks."""
+    evergreen = temp_vault / "10-Knowledge" / "Evergreen"
+    (evergreen / "ai-agent.md").write_text(
+        """---
+note_id: ai-agent
+title: AI Agent
+type: evergreen
+date: 2026-04-23
+---
+
+# AI Agent
+
+> 一句话定义: 能感知环境并自主决策的 AI 系统。
+
+AI agents combine planning, memory, and tool use to execute multi-step tasks.
+""",
+        encoding="utf-8",
+    )
+    (evergreen / "rag.md").write_text(
+        """---
+note_id: rag
+title: RAG
+type: evergreen
+date: 2026-04-23
+---
+
+# RAG
+
+> 一句话定义: 检索增强生成。
+
+Retrieval-Augmented Generation grounds language model responses in external
+documents to reduce hallucination.
+""",
+        encoding="utf-8",
+    )
+    (evergreen / "function-calling.md").write_text(
+        """---
+note_id: function-calling
+title: Function Calling
+type: evergreen
+date: 2026-04-23
+---
+
+# Function Calling
+
+> 一句话定义: 让 LLM 调用外部工具的接口。
+
+Function calling lets an AI agent invoke external tools through a structured
+schema.
+""",
+        encoding="utf-8",
+    )
+    deep_dive_dir = temp_vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04"
+    deep_dive_dir.mkdir(parents=True, exist_ok=True)
+    (deep_dive_dir / "2026-04-23_AI_Stack_深度解读.md").write_text(
+        """---
+note_id: 2026-04-23-ai-stack
+title: AI Stack Deep Dive
+type: deep_dive
+date: 2026-04-23
+---
+
+# AI Stack Deep Dive
+
+This article explores how an AI agent uses RAG to ground its answers and
+function calling to take actions. Retrieval-Augmented Generation pairs well
+with structured tool use.
+""",
+        encoding="utf-8",
+    )
+
+
+def test_dry_run_emits_jsonl_for_under_linked_page(temp_vault):
+    _seed_evergreens(temp_vault)
+    rebuild_knowledge_index(temp_vault)
+
+    summary = run_link_suggest(temp_vault, min_links=3, suggestions_per_page=5)
+
+    assert summary["applied"] is False
+    assert summary["files_mutated"] == 0
+    assert summary["pages_examined"] >= 1
+    assert summary["suggestions_emitted"] >= 1
+
+    log_path = temp_vault / "60-Logs" / "link-suggestions" / f"{summary['run_id']}.jsonl"
+    assert log_path.exists()
+    rows = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines() if line]
+    assert rows, "expected at least one suggestion row"
+
+    deep_dive_row = next(
+        (r for r in rows if r["source_slug"] == "2026-04-23-ai-stack"),
+        None,
+    )
+    assert deep_dive_row is not None, "deep_dive should appear in suggestions"
+    assert deep_dive_row["target_slug"] in {"ai-agent", "rag", "function-calling"}
+    assert deep_dive_row["rrf_score"] > 0
+
+
+def test_apply_requires_confirm(temp_vault):
+    _seed_evergreens(temp_vault)
+    rebuild_knowledge_index(temp_vault)
+
+    with pytest.raises(ValueError, match="confirm"):
+        run_link_suggest(temp_vault, apply=True, confirm=False)
+
+
+def test_apply_appends_backfill_section_and_is_idempotent(temp_vault):
+    _seed_evergreens(temp_vault)
+    rebuild_knowledge_index(temp_vault)
+
+    summary = run_link_suggest(
+        temp_vault,
+        min_links=3,
+        suggestions_per_page=3,
+        apply=True,
+        confirm=True,
+    )
+    assert summary["applied"] is True
+    assert summary["files_mutated"] >= 1
+
+    deep_dive_path = (
+        temp_vault
+        / "20-Areas"
+        / "AI-Research"
+        / "Topics"
+        / "2026-04"
+        / "2026-04-23_AI_Stack_深度解读.md"
+    )
+    body = deep_dive_path.read_text(encoding="utf-8")
+    assert BACKFILL_HEADING in body
+    assert BACKFILL_MARKER in body
+    assert "[[ai-agent" in body or "[[rag" in body or "[[function-calling" in body
+
+    # Re-run with --apply --confirm: the marker must short-circuit the rewrite.
+    second = run_link_suggest(
+        temp_vault,
+        min_links=3,
+        suggestions_per_page=3,
+        apply=True,
+        confirm=True,
+    )
+    assert second["files_mutated"] == 0
+    body_after = deep_dive_path.read_text(encoding="utf-8")
+    # Marker should still appear exactly once.
+    assert body_after.count(BACKFILL_MARKER) == 1
+
+
+def test_existing_link_targets_are_skipped(temp_vault):
+    _seed_evergreens(temp_vault)
+    # Pre-link the deep_dive to one evergreen so the candidate is already known.
+    deep_dive_path = (
+        temp_vault
+        / "20-Areas"
+        / "AI-Research"
+        / "Topics"
+        / "2026-04"
+        / "2026-04-23_AI_Stack_深度解读.md"
+    )
+    body = deep_dive_path.read_text(encoding="utf-8")
+    deep_dive_path.write_text(
+        body + "\n\nSee [[ai-agent]] for the agent primitive.\n", encoding="utf-8"
+    )
+
+    rebuild_knowledge_index(temp_vault)
+    summary = run_link_suggest(temp_vault, min_links=3, suggestions_per_page=5)
+
+    log_path = temp_vault / "60-Logs" / "link-suggestions" / f"{summary['run_id']}.jsonl"
+    rows = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines() if line]
+    deep_dive_rows = [r for r in rows if r["source_slug"] == "2026-04-23-ai-stack"]
+    assert all(
+        r["target_slug"] != "ai-agent" for r in deep_dive_rows
+    ), "candidates already linked from the source must be excluded"
+
+
+def test_min_links_threshold_excludes_well_linked_pages(temp_vault):
+    _seed_evergreens(temp_vault)
+    deep_dive_path = (
+        temp_vault
+        / "20-Areas"
+        / "AI-Research"
+        / "Topics"
+        / "2026-04"
+        / "2026-04-23_AI_Stack_深度解读.md"
+    )
+    body = deep_dive_path.read_text(encoding="utf-8")
+    # Make the deep_dive carry 3 outbound wikilinks → no longer under-linked.
+    deep_dive_path.write_text(
+        body + "\n\nSee [[ai-agent]], [[rag]], and [[function-calling]] for primitives.\n",
+        encoding="utf-8",
+    )
+
+    rebuild_knowledge_index(temp_vault)
+    summary = run_link_suggest(temp_vault, min_links=3)
+
+    log_path = temp_vault / "60-Logs" / "link-suggestions" / f"{summary['run_id']}.jsonl"
+    rows = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines() if line]
+    assert all(
+        r["source_slug"] != "2026-04-23-ai-stack" for r in rows
+    ), "pages at or above the threshold must not appear in suggestions"
+
+
+def test_log_path_round_trips_through_summary(temp_vault):
+    _seed_evergreens(temp_vault)
+    rebuild_knowledge_index(temp_vault)
+
+    summary = run_link_suggest(temp_vault, min_links=3, limit=2)
+    log_path = summary["log_path"]
+    assert log_path.endswith(".jsonl")
+    # The summary's count must equal the number of rows written.
+    rows = [
+        json.loads(line)
+        for line in (temp_vault / "60-Logs" / "link-suggestions" / f"{summary['run_id']}.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+        if line
+    ]
+    assert len(rows) == summary["suggestions_emitted"]
+
+
+def test_no_pages_when_index_empty(temp_vault):
+    """Empty vault → rebuild creates the schema → run returns zero rows."""
+    rebuild_knowledge_index(temp_vault)
+    summary = run_link_suggest(temp_vault, min_links=3)
+    assert summary["pages_examined"] == 0
+    assert summary["suggestions_emitted"] == 0
+    log_path = temp_vault / "60-Logs" / "link-suggestions" / f"{summary['run_id']}.jsonl"
+    assert log_path.exists()
+    assert log_path.read_text(encoding="utf-8") == ""

--- a/tests/test_link_suggest.py
+++ b/tests/test_link_suggest.py
@@ -17,6 +17,7 @@ import pytest
 from ovp_pipeline.commands.link_suggest import (
     BACKFILL_HEADING,
     BACKFILL_MARKER,
+    RRF_K,
     run_link_suggest,
 )
 from ovp_pipeline.knowledge_index import rebuild_knowledge_index
@@ -251,3 +252,50 @@ def test_no_pages_when_index_empty(temp_vault):
     log_path = temp_vault / "60-Logs" / "link-suggestions" / f"{summary['run_id']}.jsonl"
     assert log_path.exists()
     assert log_path.read_text(encoding="utf-8") == ""
+
+
+def test_bm25_branch_survives_hyphens_and_colons_in_query(temp_vault):
+    """Regression: prose like ``Retrieval-Augmented`` or ``AI: ...`` used to
+    crash FTS5 (`no such column: step`); the blind ``except`` then silently
+    collapsed BM25 to ``[]``. With both branches contributing, at least one
+    suggestion's ``rrf_score`` must exceed the single-branch ceiling of
+    ``1/(RRF_K+1)`` — that's the algebraic proof that BM25 didn't quietly
+    disappear."""
+    _seed_evergreens(temp_vault)
+    deep_dive_path = (
+        temp_vault
+        / "20-Areas"
+        / "AI-Research"
+        / "Topics"
+        / "2026-04"
+        / "2026-04-23_AI_Stack_深度解读.md"
+    )
+    # Overwrite with content packed with FTS5-hostile syntax in title and body.
+    deep_dive_path.write_text(
+        """---
+note_id: 2026-04-23-ai-stack
+title: "AI Stack: Retrieval-Augmented Multi-Step Agents"
+type: deep_dive
+date: 2026-04-23
+---
+
+# AI Stack: Retrieval-Augmented Multi-Step Agents
+
+Retrieval-Augmented Generation pairs with multi-step AI agents that use
+function-calling to invoke external tools. The pattern: agent + RAG +
+function-calling, all in one stack.
+""",
+        encoding="utf-8",
+    )
+
+    rebuild_knowledge_index(temp_vault)
+    summary = run_link_suggest(temp_vault, min_links=3, suggestions_per_page=5)
+
+    log_path = temp_vault / "60-Logs" / "link-suggestions" / f"{summary['run_id']}.jsonl"
+    rows = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines() if line]
+    deep_dive_rows = [r for r in rows if r["source_slug"] == "2026-04-23-ai-stack"]
+    assert deep_dive_rows, "deep_dive with FTS5-hostile prose must still get suggestions"
+    single_branch_ceiling = 1.0 / (RRF_K + 1)
+    assert any(
+        r["rrf_score"] > single_branch_ceiling for r in deep_dive_rows
+    ), "at least one row must score above the single-branch ceiling — proves BM25 fired"

--- a/tests/test_promote_candidates.py
+++ b/tests/test_promote_candidates.py
@@ -220,7 +220,7 @@ class TestCandidatePromotion:
         logger = EvergreenLogger(temp_vault / "60-Logs" / "pipeline.jsonl")
         extractor = AutoEvergreenExtractor(temp_vault, logger)
         extractor.extractor = SimpleNamespace(
-            extract_concepts=lambda file_path, content: [{
+            extract_concepts=lambda file_path, content, **_: [{
                 "concept_name": "new-candidate",
                 "title": "New Candidate",
                 "one_sentence_def": "Candidate definition",
@@ -248,7 +248,7 @@ class TestCandidatePromotion:
         logger = EvergreenLogger(temp_vault / "60-Logs" / "pipeline.jsonl")
         extractor = AutoEvergreenExtractor(temp_vault, logger)
         extractor.extractor = SimpleNamespace(
-            extract_concepts=lambda file_path, content: [{
+            extract_concepts=lambda file_path, content, **_: [{
                 "concept_name": "promoted-concept",
                 "title": "Promoted Concept",
                 "one_sentence_def": "Promoted definition",


### PR DESCRIPTION
## Summary

First of three Phase 38 stages. Tackles the link-density bottleneck observed
after PR #58 (avg 1.83 wikilinks/evergreen, 73% of deep_dives carry zero).

- **Extractor retrieval injection** (`auto_evergreen_extractor.py`): every new
  evergreen is now grounded in the existing concept registry via a top-20 BM25
  retrieval pass that renders an "已有概念目录" checklist into the user prompt.
  Required `related_concepts` count bumped 1-3 → ≥3; misses emit an
  `evergreen_low_link` audit event. FTS5 query sanitized so prose with `-`/`:`
  no longer silently breaks the search.
- **`ovp-link-suggest`** (new CLI, `commands/link_suggest.py`): walks pages with
  `link_out_count < --min-links`, fuses BM25 + vector candidates via RRF (k=60),
  drops already-linked targets, writes a JSONL diff to
  `60-Logs/link-suggestions/<run_id>.jsonl`. `--apply --confirm` appends a
  marked backfill section (`<!-- link-suggest:backfill -->`) that short-circuits
  re-runs.
- **Tests** (16 new): `test_evergreen_extractor_retrieval.py` (9),
  `test_link_suggest.py` (7).

## Test plan

- [x] `pytest -q` — 915 passed (was 899, +16 new)
- [x] `ruff check` — clean on new files; pre-existing warnings in
      `auto_evergreen_extractor.py` (lines 64, 873) untouched
- [x] `black` — formatted
- [ ] Smoke run on real vault: `ovp-link-suggest --vault-dir <vault> --dry-run`
      then inspect JSONL; confirm `--apply --confirm` lifts deep_dive coverage

## Out of scope

Stage B (EVOLVES typing, Crystal materializer, hybrid search + decay, daily
working-memory distill) and Stage C (graph_ops + `/explore` UI + MCP Apps) ship
as follow-up PRs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/59" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new CLI command to audit and suggest links for under-linked pages, with optional auto-application of suggestions to page files.
  * Enhanced concept extraction to reference existing concepts when available, improving consistency and reducing duplication.

* **Tests**
  * Added comprehensive test coverage for link suggestion auditing, filtering, and file mutation behavior.
  * Added test coverage for concept extraction with existing concept retrieval and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->