### PR TITLE
Phase 38 Stage B: EVOLVES typing, Crystal layer, hybrid search, working memory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,8 @@ ovp-note-type-normalize = "ovp_pipeline.commands.note_type_normalize:main"
 ovp-concept-dedup = "ovp_pipeline.commands.concept_dedup:main"
 ovp-promote-backfill = "ovp_pipeline.commands.promote_backfill:main"
 ovp-link-suggest = "ovp_pipeline.commands.link_suggest:main"
+ovp-build-crystals = "ovp_pipeline.commands.build_crystals:main"
+ovp-working-memory = "ovp_pipeline.commands.working_memory:main"
 
 [project.entry-points."ovp.packs"]
 default-knowledge = "ovp_pipeline.packs.default_knowledge:get_pack"

--- a/src/ovp_pipeline/autopilot/daemon.py
+++ b/src/ovp_pipeline/autopilot/daemon.py
@@ -482,11 +482,35 @@ class AutoPilotDaemon:
         subprocess.run(breakdown_cmd, capture_output=True, cwd=str(self.vault_dir))
 
     def _run_knowledge_index_refresh(self):
-        """刷新派生 knowledge.db。"""
+        """刷新派生 knowledge.db，并落地 Phase 38 的 Crystal + Working Memory。
+
+        knowledge.db 重建后立即材化 Crystal 与每日 Working Memory 文件 ——
+        两者都是幂等的（Crystal 内容哈希相同则文件不变；Working Memory 覆盖
+        今日条目），所以挂到每次 refresh 上也不会产生噪音。
+        """
         cmd = [
             sys.executable, "-m", "ovp_pipeline.commands.knowledge_index",
             "--vault-dir", str(self.vault_dir),
             "--pack", self.pack.name,
+            "--json",
+        ]
+        subprocess.run(cmd, capture_output=True, cwd=str(self.vault_dir))
+        self._run_build_crystals()
+        self._run_working_memory()
+
+    def _run_build_crystals(self):
+        cmd = [
+            sys.executable, "-m", "ovp_pipeline.commands.build_crystals",
+            "--vault-dir", str(self.vault_dir),
+            "--pack", self.pack.name,
+            "--json",
+        ]
+        subprocess.run(cmd, capture_output=True, cwd=str(self.vault_dir))
+
+    def _run_working_memory(self):
+        cmd = [
+            sys.executable, "-m", "ovp_pipeline.commands.working_memory",
+            "--vault-dir", str(self.vault_dir),
             "--json",
         ]
         subprocess.run(cmd, capture_output=True, cwd=str(self.vault_dir))

--- a/src/ovp_pipeline/autopilot/daemon.py
+++ b/src/ovp_pipeline/autopilot/daemon.py
@@ -505,7 +505,12 @@ class AutoPilotDaemon:
             "--pack", self.pack.name,
             "--json",
         ]
-        subprocess.run(cmd, capture_output=True, cwd=str(self.vault_dir))
+        try:
+            subprocess.run(
+                cmd, capture_output=True, cwd=str(self.vault_dir), timeout=120
+            )
+        except subprocess.TimeoutExpired:
+            self.log("⚠️ build_crystals 超时 (120s)")
 
     def _run_working_memory(self):
         cmd = [
@@ -513,7 +518,12 @@ class AutoPilotDaemon:
             "--vault-dir", str(self.vault_dir),
             "--json",
         ]
-        subprocess.run(cmd, capture_output=True, cwd=str(self.vault_dir))
+        try:
+            subprocess.run(
+                cmd, capture_output=True, cwd=str(self.vault_dir), timeout=60
+            )
+        except subprocess.TimeoutExpired:
+            self.log("⚠️ working_memory 超时 (60s)")
 
     def _auto_commit(self, task: Task, result: dict):
         """自动 Git 提交"""

--- a/src/ovp_pipeline/commands/build_crystals.py
+++ b/src/ovp_pipeline/commands/build_crystals.py
@@ -1,0 +1,84 @@
+"""``ovp-build-crystals`` — materialize the operator briefing as a Crystal note.
+
+A Crystal is the persistent counterpart to ``observation_surface``: where
+``/briefing`` recomputes a JSON snapshot on every request, this command
+freezes that snapshot to ``40-Resources/Crystals/<crystal_id>.md`` so the
+review trail and the daily working-memory distill have something durable to
+point at.
+
+Idempotent: re-running with no underlying state change produces the same
+crystal_id and is a no-op (the file is identical, no rewrite). When the
+briefing snapshot's salient content shifts, a new crystal_id is minted and a
+new file lands alongside the prior one.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+try:
+    from ..materializers.crystal import materialize_crystal
+    from ..runtime import resolve_vault_dir
+    from ..truth_api import get_briefing_snapshot
+except ImportError:
+    from ovp_pipeline.materializers.crystal import materialize_crystal  # type: ignore
+    from ovp_pipeline.runtime import resolve_vault_dir  # type: ignore
+    from ovp_pipeline.truth_api import get_briefing_snapshot  # type: ignore
+
+
+DEFAULT_PACK_NAME = "research-tech"
+DEFAULT_LIMIT = 8
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="ovp-build-crystals",
+        description="Materialize the operator briefing as a persisted Crystal note.",
+    )
+    parser.add_argument("--vault-dir", type=Path, default=None, help="Vault root (default: cwd)")
+    parser.add_argument(
+        "--pack",
+        default=DEFAULT_PACK_NAME,
+        help=f"Pack to query (default: {DEFAULT_PACK_NAME})",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=DEFAULT_LIMIT,
+        help=f"Briefing item limit per category (default: {DEFAULT_LIMIT})",
+    )
+    parser.add_argument("--json", action="store_true", help="Print structured summary to stdout.")
+    args = parser.parse_args(argv)
+
+    vault_dir = resolve_vault_dir(args.vault_dir)
+    snapshot = get_briefing_snapshot(vault_dir, pack_name=args.pack, limit=args.limit)
+    record = materialize_crystal(snapshot, vault_dir, pack_name=args.pack)
+
+    summary = {
+        "crystal_id": record.crystal_id,
+        "path": str(record.path),
+        "source_object_count": len(record.source_object_ids),
+        "evolves_relation_count": len(record.evolves_relations),
+        "created": record.created,
+    }
+
+    if args.json:
+        print(json.dumps(summary, ensure_ascii=False, indent=2))
+        return 0
+
+    print("=" * 60)
+    print("BUILD CRYSTALS SUMMARY")
+    print("=" * 60)
+    print(f"Crystal ID:           {summary['crystal_id']}")
+    print(f"Path:                 {summary['path']}")
+    print(f"Source objects:       {summary['source_object_count']}")
+    print(f"EVOLVES relations:    {summary['evolves_relation_count']}")
+    print(f"Created (vs cached):  {summary['created']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ovp_pipeline/commands/working_memory.py
+++ b/src/ovp_pipeline/commands/working_memory.py
@@ -1,0 +1,339 @@
+"""Phase 38 — Working Memory daily distill.
+
+Writes a single markdown file under ``60-Logs/working-memory/YYYY-MM-DD.md``
+that summarizes the state of the vault at a moment in time. Designed to be
+re-run cheaply (idempotent overwrite of today's file) so the autopilot daemon
+can call it once a day.
+
+Sections:
+
+* **Top of Mind** — top-N slugs ranked by ``page_metrics.citation_count`` over
+  the lookback window. We use citation_count (inbound wikilinks) rather than
+  raw reuse_count because citations describe the *durable* shape of attention,
+  while reuse_count is more transient.
+* **Fresh Crystals** — Crystal frontmatter for any file under
+  ``40-Resources/Crystals/`` whose mtime is within the last 24h. Cheap and
+  honest: we don't need a separate audit log because Crystals are
+  self-describing.
+* **Pending Decisions** — head of ``00-Polaris/Writing-Prompts.md`` (the
+  single canonical sink for prompts/questions per Phase 36 feedback-router).
+* **EVOLVES Today** — relation_promoted events from
+  ``60-Logs/relation-promotions.jsonl`` whose ``ts`` is in the lookback window
+  AND whose ``relation_type`` starts with ``evolves:``. Grouped by subtype.
+* **Pulse Highlights** — event_type counts from ``60-Logs/pipeline.jsonl`` in
+  the lookback window. Mirrors the Pulse panel but as a static table.
+
+Empty sections are still rendered with a "(none)" placeholder so the file
+shape is stable across days.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from collections import Counter
+from datetime import date as _date_cls, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+try:
+    from ..runtime import VaultLayout, resolve_vault_dir
+except ImportError:
+    from ovp_pipeline.runtime import VaultLayout, resolve_vault_dir  # type: ignore
+
+
+WORKING_MEMORY_DIR = ("60-Logs", "working-memory")
+DEFAULT_TOP_N = 5
+DEFAULT_LOOKBACK_HOURS = 24
+DEFAULT_TOP_OF_MIND_LOOKBACK_DAYS = 7
+
+
+def _parse_ts(value: object) -> datetime | None:
+    if not value:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        return datetime.fromisoformat(text)
+    except ValueError:
+        return None
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    out: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            out.append(payload)
+    return out
+
+
+def _top_of_mind(layout: VaultLayout, *, top_n: int, now: datetime) -> list[dict[str, Any]]:
+    """Top-N pages by inbound citations, restricted to slugs touched in the
+    last ``DEFAULT_TOP_OF_MIND_LOOKBACK_DAYS`` (so a high-citation but stale
+    page doesn't dominate every day)."""
+    if not layout.knowledge_db.exists():
+        return []
+    cutoff = int((now - timedelta(days=DEFAULT_TOP_OF_MIND_LOOKBACK_DAYS)).timestamp())
+    rows: list[dict[str, Any]] = []
+    try:
+        with sqlite3.connect(layout.knowledge_db) as conn:
+            for slug, citation_count, reuse_count, last_seen_ts in conn.execute(
+                "SELECT pm.slug, pm.citation_count, pm.reuse_count, pm.last_seen_ts "
+                "FROM page_metrics pm "
+                "WHERE pm.last_seen_ts >= ? "
+                "ORDER BY pm.citation_count DESC, pm.reuse_count DESC "
+                "LIMIT ?",
+                (cutoff, top_n),
+            ):
+                rows.append(
+                    {
+                        "slug": str(slug),
+                        "citation_count": int(citation_count or 0),
+                        "reuse_count": int(reuse_count or 0),
+                        "last_seen_ts": int(last_seen_ts or 0),
+                    }
+                )
+    except sqlite3.DatabaseError:
+        return []
+    return rows
+
+
+def _fresh_crystals(vault_dir: Path, *, since: datetime) -> list[dict[str, Any]]:
+    crystals_dir = vault_dir / "40-Resources" / "Crystals"
+    if not crystals_dir.exists():
+        return []
+    cutoff_ts = since.timestamp()
+    out: list[dict[str, Any]] = []
+    for path in sorted(crystals_dir.glob("*.md")):
+        try:
+            mtime = path.stat().st_mtime
+        except OSError:
+            continue
+        if mtime < cutoff_ts:
+            continue
+        crystal_id = path.stem
+        title = crystal_id
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        if text.startswith("---"):
+            end = text.find("\n---", 3)
+            if end > 0:
+                fm_block = text[3:end]
+                for raw_line in fm_block.splitlines():
+                    if raw_line.startswith("crystal_id:"):
+                        crystal_id = raw_line.split(":", 1)[1].strip()
+                    elif raw_line.startswith("date:"):
+                        title = f"{crystal_id} ({raw_line.split(':', 1)[1].strip()})"
+        out.append({"crystal_id": crystal_id, "title": title, "path": str(path)})
+    return out
+
+
+def _pending_decisions(vault_dir: Path, *, max_lines: int = 10) -> list[str]:
+    target = vault_dir / "00-Polaris" / "Writing-Prompts.md"
+    if not target.exists():
+        return []
+    lines = []
+    for raw in target.read_text(encoding="utf-8", errors="ignore").splitlines():
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        lines.append(stripped)
+        if len(lines) >= max_lines:
+            break
+    return lines
+
+
+def _evolves_today(layout: VaultLayout, *, since: datetime) -> dict[str, list[dict[str, str]]]:
+    """Group ``relation_promoted`` events with ``relation_type`` starting
+    ``evolves:`` by subtype. Returned as ``{subtype: [{source, target}, ...]}``.
+    """
+    log_path = layout.logs_dir / "relation-promotions.jsonl"
+    grouped: dict[str, list[dict[str, str]]] = {}
+    for event in _read_jsonl(log_path):
+        ts = _parse_ts(event.get("ts"))
+        if ts is None or ts < since:
+            continue
+        relation_type = str(event.get("relation_type") or "")
+        if not relation_type.startswith("evolves:"):
+            continue
+        subtype = relation_type.split(":", 1)[1]
+        grouped.setdefault(subtype, []).append(
+            {
+                "source": str(event.get("source_object_id") or ""),
+                "target": str(event.get("target_object_id") or ""),
+            }
+        )
+    return grouped
+
+
+def _pulse_highlights(layout: VaultLayout, *, since: datetime) -> Counter:
+    counts: Counter = Counter()
+    for event in _read_jsonl(layout.pipeline_log):
+        ts = _parse_ts(event.get("ts"))
+        if ts is None or ts < since:
+            continue
+        event_type = str(event.get("event_type") or "(unknown)")
+        counts[event_type] += 1
+    return counts
+
+
+def _render(
+    *,
+    target_date: _date_cls,
+    top_of_mind: list[dict[str, Any]],
+    fresh_crystals: list[dict[str, Any]],
+    pending_decisions: list[str],
+    evolves_today: dict[str, list[dict[str, str]]],
+    pulse_highlights: Counter,
+) -> str:
+    sections: list[str] = []
+    sections.append(f"# Working Memory — {target_date.isoformat()}\n")
+
+    sections.append("## Top of Mind\n")
+    if top_of_mind:
+        for row in top_of_mind:
+            sections.append(
+                f"- [[{row['slug']}]] — {row['citation_count']} citations, "
+                f"{row['reuse_count']} reuses"
+            )
+    else:
+        sections.append("- (none)")
+    sections.append("")
+
+    sections.append("## Fresh Crystals\n")
+    if fresh_crystals:
+        for crystal in fresh_crystals:
+            sections.append(f"- [[{crystal['crystal_id']}]] — {crystal['title']}")
+    else:
+        sections.append("- (none)")
+    sections.append("")
+
+    sections.append("## Pending Decisions\n")
+    if pending_decisions:
+        for line in pending_decisions:
+            sections.append(f"- {line}")
+    else:
+        sections.append("- (none)")
+    sections.append("")
+
+    sections.append("## EVOLVES Today\n")
+    if evolves_today:
+        for subtype in sorted(evolves_today):
+            relations = evolves_today[subtype]
+            sections.append(f"### {subtype} ({len(relations)})")
+            for rel in relations:
+                sections.append(f"- [[{rel['source']}]] → [[{rel['target']}]]")
+    else:
+        sections.append("- (none)")
+    sections.append("")
+
+    sections.append("## Pulse Highlights\n")
+    if pulse_highlights:
+        sections.append("| event_type | count |")
+        sections.append("|---|---|")
+        for event_type, count in pulse_highlights.most_common():
+            sections.append(f"| {event_type} | {count} |")
+    else:
+        sections.append("- (none)")
+    sections.append("")
+
+    return "\n".join(sections).rstrip() + "\n"
+
+
+def build_working_memory(
+    vault_dir: Path,
+    *,
+    target_date: _date_cls | None = None,
+    lookback_hours: int = DEFAULT_LOOKBACK_HOURS,
+    top_n: int = DEFAULT_TOP_N,
+    now: datetime | None = None,
+) -> Path:
+    """Materialize the working-memory file for ``target_date``.
+
+    ``now`` is overridable for tests; defaults to ``datetime.now(UTC)``. The
+    lookback window is computed from ``now`` regardless of ``target_date`` so
+    the file always reflects "the last 24h leading up to now".
+    """
+    layout = VaultLayout.from_vault(vault_dir)
+    now = now or datetime.now(timezone.utc)
+    target_date = target_date or now.date()
+    since = now - timedelta(hours=lookback_hours)
+
+    output_dir = vault_dir.joinpath(*WORKING_MEMORY_DIR)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / f"{target_date.isoformat()}.md"
+
+    body = _render(
+        target_date=target_date,
+        top_of_mind=_top_of_mind(layout, top_n=top_n, now=now),
+        fresh_crystals=_fresh_crystals(vault_dir, since=since),
+        pending_decisions=_pending_decisions(vault_dir),
+        evolves_today=_evolves_today(layout, since=since),
+        pulse_highlights=_pulse_highlights(layout, since=since),
+    )
+    output_path.write_text(body, encoding="utf-8")
+    return output_path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="ovp-working-memory",
+        description="Write the daily working-memory distill markdown file.",
+    )
+    parser.add_argument("--vault-dir", type=Path, default=None, help="Vault root (default: cwd)")
+    parser.add_argument(
+        "--date",
+        default=None,
+        help="Target date in YYYY-MM-DD (default: today UTC)",
+    )
+    parser.add_argument(
+        "--lookback-hours",
+        type=int,
+        default=DEFAULT_LOOKBACK_HOURS,
+        help=f"Hours to scan for fresh activity (default: {DEFAULT_LOOKBACK_HOURS})",
+    )
+    parser.add_argument(
+        "--top-n",
+        type=int,
+        default=DEFAULT_TOP_N,
+        help=f"Top-N items per ranked section (default: {DEFAULT_TOP_N})",
+    )
+    parser.add_argument("--json", action="store_true", help="Print structured summary to stdout.")
+    args = parser.parse_args(argv)
+
+    vault_dir = resolve_vault_dir(args.vault_dir)
+    target_date: _date_cls | None = None
+    if args.date:
+        target_date = _date_cls.fromisoformat(args.date)
+    output_path = build_working_memory(
+        vault_dir,
+        target_date=target_date,
+        lookback_hours=args.lookback_hours,
+        top_n=args.top_n,
+    )
+
+    if args.json:
+        print(json.dumps({"path": str(output_path)}, ensure_ascii=False, indent=2))
+        return 0
+
+    print("=" * 60)
+    print("WORKING MEMORY")
+    print("=" * 60)
+    print(f"Path:                 {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ovp_pipeline/discovery.py
+++ b/src/ovp_pipeline/discovery.py
@@ -89,6 +89,40 @@ def _discover_with_knowledge(vault_dir: Path, query: str, limit: int) -> list[di
     return results[:limit]
 
 
+def _discover_with_fused(vault_dir: Path, query: str, limit: int) -> list[dict[str, object]]:
+    """RRF + bi-temporal decay branch (Phase 38).
+
+    Wraps ``knowledge_index.search_fused`` and shapes its output into the
+    same envelope the other discovery branches emit so callers can swap
+    engines transparently.
+    """
+    from .knowledge_index import get_knowledge_page, search_fused
+
+    rows = search_fused(vault_dir, query, limit=limit)
+    out: list[dict[str, object]] = []
+    for row in rows:
+        slug = str(row.get("slug") or "")
+        if not slug:
+            continue
+        page = get_knowledge_page(vault_dir, slug)
+        out.append(
+            {
+                "engine": "knowledge",
+                "kind": "fused",
+                "slug": slug,
+                "title": str(row.get("title") or slug),
+                "score": float(row.get("score", 0.0)),
+                "snippet": _snippet_from_page(page),
+                "path": str(page["path"]) if page else "",
+                "rrf_score": float(row.get("rrf_score", 0.0)),
+                "recency": float(row.get("recency", 1.0)),
+                "frequency": float(row.get("frequency", 1.0)),
+                "importance": float(row.get("importance", 1.0)),
+            }
+        )
+    return out
+
+
 def _discover_with_qmd(vault_dir: Path, query: str, limit: int) -> list[dict[str, object]]:  # noqa: ARG001
     try:
         result = subprocess.run(
@@ -233,6 +267,12 @@ def discover_related(
         return _annotate_discovery_rows(
             resolved_vault,
             _discover_with_qmd(resolved_vault, query, limit),
+            resolved_pack,
+        )
+    if engine == "fused":
+        return _annotate_discovery_rows(
+            resolved_vault,
+            _discover_with_fused(resolved_vault, query, limit),
             resolved_pack,
         )
     raise ValueError(f"Unsupported discovery engine: {engine}")

--- a/src/ovp_pipeline/extraction/semantic_relations.py
+++ b/src/ovp_pipeline/extraction/semantic_relations.py
@@ -45,6 +45,7 @@ class SemanticRelationCandidate:
     content_hash: str = ""
     retrieval_context: str = ""
     pack: str = ""
+    relation_subtype: str = ""
 
     def to_dict(self) -> dict[str, object]:
         return asdict(self)
@@ -62,6 +63,7 @@ class SemanticRelationCandidate:
             content_hash=str(data.get("content_hash") or ""),
             retrieval_context=str(data.get("retrieval_context") or ""),
             pack=str(data.get("pack") or ""),
+            relation_subtype=str(data.get("relation_subtype") or ""),
         )
 
 
@@ -143,6 +145,8 @@ def extract_relations(
 
     report = ExtractionReport()
 
+    evolves_subtypes = set(pack.evolves_relation_types())
+
     for raw in proposer.propose(
         text,
         source_slug=source_slug,
@@ -161,6 +165,7 @@ def extract_relations(
             retrieval_context=raw.retrieval_context
             or compute_retrieval_context(deep_dive_path, raw.evidence_quote, vault_dir=vault_dir),
             pack=pack.name,
+            relation_subtype=raw.relation_subtype,
         )
 
         if candidate.relation_type not in vocabulary:
@@ -181,6 +186,14 @@ def extract_relations(
         if not _allowed_pairs(vocabulary[candidate.relation_type], object_kinds, candidate):
             report.rejected.append((candidate, "kind_constraint_violation"))
             continue
+        if candidate.relation_type == "evolves":
+            subtype = candidate.relation_subtype.strip()
+            if not subtype:
+                report.rejected.append((candidate, "missing_relation_subtype"))
+                continue
+            if subtype not in evolves_subtypes:
+                report.rejected.append((candidate, "unknown_relation_subtype"))
+                continue
         report.candidates.append(candidate)
 
     return report

--- a/src/ovp_pipeline/knowledge_index.py
+++ b/src/ovp_pipeline/knowledge_index.py
@@ -113,6 +113,15 @@ CREATE TABLE page_embeddings (
 );
 
 CREATE INDEX idx_page_embeddings_slug ON page_embeddings(slug);
+
+CREATE TABLE page_metrics (
+  slug TEXT PRIMARY KEY,
+  last_seen_ts INTEGER NOT NULL DEFAULT 0,
+  reuse_count INTEGER NOT NULL DEFAULT 0,
+  citation_count INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX idx_page_metrics_last_seen ON page_metrics(last_seen_ts);
 """
 
 SCHEMA += "\n" + TRUTH_STORE_SCHEMA
@@ -542,6 +551,7 @@ def _knowledge_db_supports_pack_schema(db_path: Path) -> bool:
         "graph_clusters": {"pack"},
         "truth_projections": {"pack", "owner_pack", "builder_name", "built_at"},
         "reuse_events": {"event_id", "ts", "pack", "surface", "trusted"},
+        "page_metrics": {"slug", "last_seen_ts", "reuse_count", "citation_count"},
     }
     try:
         with sqlite3.connect(db_path) as conn:
@@ -889,6 +899,8 @@ def rebuild_knowledge_index(
                 conn, layout, pack_name=truth_pack
             )
 
+            page_metrics_indexed = _rebuild_page_metrics(conn)
+
             conn.commit()
         except Exception:
             if conn is not None:
@@ -916,11 +928,96 @@ def rebuild_knowledge_index(
                 "relations_indexed": len(truth_projection.relations),
                 "relations_replayed": relations_replayed,
                 "evidence_updates_replayed": evidence_updates,
+                "page_metrics_indexed": page_metrics_indexed,
                 "compiled_summaries_indexed": len(truth_projection.compiled_summaries),
                 "contradictions_indexed": len(truth_projection.contradictions),
                 "graph_edges_indexed": len(truth_projection.graph_edges),
                 "graph_clusters_indexed": len(truth_projection.graph_clusters),
             }
+
+
+def _iso_to_epoch(value: object) -> int:
+    """Best-effort ISO-8601 → unix epoch. Returns 0 for unparseable inputs.
+
+    Both ``audit_events.timestamp`` and ``reuse_events.ts`` are stored as
+    text; we want a single integer to drive the recency decay in
+    ``search_fused``. Stripping a trailing ``Z`` makes ``fromisoformat`` happy
+    on Python <3.11.
+    """
+    if not value:
+        return 0
+    text = str(value).strip()
+    if not text:
+        return 0
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        from datetime import datetime
+
+        return int(datetime.fromisoformat(text).timestamp())
+    except ValueError:
+        return 0
+
+
+def _rebuild_page_metrics(conn: sqlite3.Connection) -> int:
+    """Aggregate per-slug recency / reuse / citation signals into ``page_metrics``.
+
+    Called from ``rebuild_knowledge_index`` after ``audit_events``,
+    ``reuse_events``, and ``page_links`` have been populated. The table is
+    consumed by ``search_fused`` to apply bi-temporal decay on top of RRF.
+
+    ``last_seen_ts`` is the max of any audit-event timestamp on this slug and
+    any reuse-event timestamp where ``object_id == slug``. ``reuse_count``
+    counts reuse events; ``citation_count`` counts inbound wikilinks. Slugs
+    with no signal still get a row (zeros) so callers can left-join freely.
+    """
+    conn.execute("DELETE FROM page_metrics")
+
+    audit_max: dict[str, int] = {}
+    for slug, ts in conn.execute(
+        "SELECT slug, MAX(timestamp) FROM audit_events WHERE slug != '' GROUP BY slug"
+    ):
+        audit_max[str(slug)] = _iso_to_epoch(ts)
+
+    reuse_stats: dict[str, tuple[int, int]] = {}
+    for object_id, max_ts, count in conn.execute(
+        "SELECT object_id, MAX(ts), COUNT(*) FROM reuse_events "
+        "WHERE object_id != '' GROUP BY object_id"
+    ):
+        reuse_stats[str(object_id)] = (_iso_to_epoch(max_ts), int(count or 0))
+
+    citations: dict[str, int] = {}
+    for target_slug, count in conn.execute(
+        "SELECT target_slug, COUNT(*) FROM page_links "
+        "WHERE target_slug != '' GROUP BY target_slug"
+    ):
+        citations[str(target_slug)] = int(count or 0)
+
+    rows: list[tuple[str, int, int, int]] = []
+    seen: set[str] = set()
+    for (slug,) in conn.execute("SELECT slug FROM pages_index"):
+        slug = str(slug)
+        seen.add(slug)
+        audit_ts = audit_max.get(slug, 0)
+        reuse_ts, reuse_count = reuse_stats.get(slug, (0, 0))
+        last_seen = max(audit_ts, reuse_ts)
+        rows.append((slug, last_seen, reuse_count, citations.get(slug, 0)))
+
+    # Cover slugs that only appear via reuse / link tables (e.g. an object_id
+    # that doesn't map to a current page yet) so the metrics view is complete.
+    for slug in set(reuse_stats) | set(citations) | set(audit_max):
+        if slug in seen:
+            continue
+        audit_ts = audit_max.get(slug, 0)
+        reuse_ts, reuse_count = reuse_stats.get(slug, (0, 0))
+        rows.append((slug, max(audit_ts, reuse_ts), reuse_count, citations.get(slug, 0)))
+
+    conn.executemany(
+        "INSERT OR REPLACE INTO page_metrics "
+        "(slug, last_seen_ts, reuse_count, citation_count) VALUES (?, ?, ?, ?)",
+        rows,
+    )
+    return len(rows)
 
 
 def query_knowledge_index(vault_dir: Path, query: str, limit: int = 5) -> list[dict[str, str | int | float]]:
@@ -1008,6 +1105,116 @@ def search_knowledge_index(vault_dir: Path, query: str, limit: int = 10) -> list
         for slug, title in fallback_rows
     )
     return results
+
+
+def search_fused(
+    vault_dir: Path,
+    query: str,
+    *,
+    limit: int = 10,
+    rrf_k: int = 60,
+    tau_days: float = 30.0,
+    now_ts: int | None = None,
+) -> list[dict[str, str | float]]:
+    """Hybrid retrieval: RRF over BM25 + vector, then bi-temporal decay.
+
+    The two existing retrievers (``search_knowledge_index`` BM25 and
+    ``query_knowledge_index`` vector) each emit a ranked list. We fuse them
+    with reciprocal rank fusion — robust to per-engine score scale
+    differences — then multiply by:
+
+    * **Recency**: ``exp(-(now - last_seen_ts) / (tau_days * 86400))``
+    * **Frequency**: ``1 + log(1 + reuse_count)``
+    * **Importance**: ``1 + log(1 + citation_count)``
+
+    Slugs missing from ``page_metrics`` get a 1.0 multiplier (no penalty), so
+    a cold vault still returns its BM25/vector top-N. We over-fetch each
+    branch by 3x ``limit`` so the fused ranking has room to reorder.
+    """
+    import math
+
+    _, layout = _ensure_knowledge_db(vault_dir)
+
+    fetch = max(limit * 3, limit)
+    bm25_results = search_knowledge_index(vault_dir, query, limit=fetch)
+    vector_chunks = query_knowledge_index(vault_dir, query, limit=fetch)
+
+    rrf_scores: dict[str, float] = {}
+    titles: dict[str, str] = {}
+
+    for rank, item in enumerate(bm25_results):
+        slug = str(item.get("slug") or "")
+        if not slug:
+            continue
+        rrf_scores[slug] = rrf_scores.get(slug, 0.0) + 1.0 / (rrf_k + rank + 1)
+        if item.get("title"):
+            titles.setdefault(slug, str(item["title"]))
+
+    seen_vector: set[str] = set()
+    vector_rank = 0
+    for chunk in vector_chunks:
+        slug = str(chunk.get("slug") or "")
+        if not slug or slug in seen_vector:
+            continue
+        seen_vector.add(slug)
+        rrf_scores[slug] = rrf_scores.get(slug, 0.0) + 1.0 / (rrf_k + vector_rank + 1)
+        vector_rank += 1
+
+    if not rrf_scores:
+        return []
+
+    if now_ts is None:
+        from datetime import datetime, timezone
+
+        now_ts = int(datetime.now(timezone.utc).timestamp())
+    tau_seconds = max(tau_days * 86400.0, 1.0)
+
+    metrics: dict[str, tuple[int, int, int]] = {}
+    titles_db: dict[str, str] = {}
+    with sqlite3.connect(layout.knowledge_db) as conn:
+        placeholders = ",".join("?" for _ in rrf_scores)
+        for slug, last_seen_ts, reuse_count, citation_count in conn.execute(
+            f"SELECT slug, last_seen_ts, reuse_count, citation_count "
+            f"FROM page_metrics WHERE slug IN ({placeholders})",
+            list(rrf_scores.keys()),
+        ):
+            metrics[str(slug)] = (
+                int(last_seen_ts or 0),
+                int(reuse_count or 0),
+                int(citation_count or 0),
+            )
+        missing_titles = [s for s in rrf_scores if s not in titles]
+        if missing_titles:
+            placeholders = ",".join("?" for _ in missing_titles)
+            for slug, title in conn.execute(
+                f"SELECT slug, title FROM pages_index WHERE slug IN ({placeholders})",
+                missing_titles,
+            ):
+                titles_db[str(slug)] = str(title or "")
+
+    fused: list[dict[str, str | float]] = []
+    for slug, base in rrf_scores.items():
+        last_seen_ts, reuse_count, citation_count = metrics.get(slug, (0, 0, 0))
+        if last_seen_ts > 0:
+            recency = math.exp(-max(now_ts - last_seen_ts, 0) / tau_seconds)
+        else:
+            recency = 1.0
+        frequency = 1.0 + math.log(1.0 + reuse_count)
+        importance = 1.0 + math.log(1.0 + citation_count)
+        fused.append(
+            {
+                "slug": slug,
+                "title": titles.get(slug) or titles_db.get(slug) or slug,
+                "score": base * recency * frequency * importance,
+                "rrf_score": base,
+                "recency": recency,
+                "frequency": frequency,
+                "importance": importance,
+            }
+        )
+
+    fused.sort(key=lambda item: item["score"], reverse=True)
+    return fused[:limit]
 
 
 def search_truth_store(

--- a/src/ovp_pipeline/knowledge_index.py
+++ b/src/ovp_pipeline/knowledge_index.py
@@ -952,8 +952,6 @@ def _iso_to_epoch(value: object) -> int:
     if text.endswith("Z"):
         text = text[:-1] + "+00:00"
     try:
-        from datetime import datetime
-
         return int(datetime.fromisoformat(text).timestamp())
     except ValueError:
         return 0
@@ -1136,7 +1134,15 @@ def search_fused(
     _, layout = _ensure_knowledge_db(vault_dir)
 
     fetch = max(limit * 3, limit)
-    bm25_results = search_knowledge_index(vault_dir, query, limit=fetch)
+    try:
+        bm25_results = search_knowledge_index(vault_dir, query, limit=fetch)
+    except sqlite3.OperationalError:
+        normalized_terms = re.findall(r"[\w\u4e00-\u9fff]+", query, flags=re.UNICODE)
+        if normalized_terms:
+            safe_query = " ".join(f'"{term}"' for term in normalized_terms)
+            bm25_results = search_knowledge_index(vault_dir, safe_query, limit=fetch)
+        else:
+            bm25_results = []
     vector_chunks = query_knowledge_index(vault_dir, query, limit=fetch)
 
     rrf_scores: dict[str, float] = {}

--- a/src/ovp_pipeline/materializers/crystal.py
+++ b/src/ovp_pipeline/materializers/crystal.py
@@ -1,0 +1,295 @@
+"""Phase 38 — Crystal materializer.
+
+A Crystal is a persisted, frozen snapshot of an ``operator_briefing`` assembly
+recipe. Where ``observation_surface`` payloads are ephemeral (recomputed on
+every UI / API call), a Crystal lands on disk as a markdown note in
+``40-Resources/Crystals/`` with frontmatter declaring its source object ids,
+the EVOLVES relations that motivated it, and the assembly recipe used to
+build it.
+
+Design choices:
+
+* ``crystal_id`` is content-hash-derived (not timestamp-derived), so
+  re-materializing the same snapshot produces the same id and overwrites
+  the same file. Run twice in a minute → one file. Run after the underlying
+  state changed → a *new* Crystal, leaving the prior one as a historical
+  record.
+* The hash input deliberately excludes the recipe's ``generated_at`` field
+  so identical content at different timestamps is still considered the same
+  Crystal. Callers wanting time-distinguished Crystals should pass an
+  explicit ``date`` and accept that two same-day runs collapse.
+* Frontmatter follows the existing OVP note conventions (YAML between
+  ``---`` fences, then ``# title``) so Obsidian renders it like any other
+  note.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import date as _date_cls
+from pathlib import Path
+from typing import Any, Iterable
+
+CRYSTAL_DIR = ("40-Resources", "Crystals")
+ASSEMBLY_RECIPE = "operator_briefing"
+
+
+@dataclass(frozen=True)
+class CrystalRecord:
+    crystal_id: str
+    path: Path
+    source_object_ids: tuple[str, ...]
+    evolves_relations: tuple[dict[str, str], ...]
+    created: bool
+
+
+def _collect_source_object_ids(snapshot: dict[str, Any]) -> list[str]:
+    """Union of object_ids referenced in changed_objects, active_topics, and
+    insight payloads. Order is preserved (first-seen wins) so the frontmatter
+    is stable across runs with the same input."""
+    ids: list[str] = []
+    seen: set[str] = set()
+
+    def _add(value: object) -> None:
+        if not isinstance(value, str) or not value or value in seen:
+            return
+        seen.add(value)
+        ids.append(value)
+
+    for item in snapshot.get("changed_objects") or []:
+        if isinstance(item, dict):
+            _add(item.get("object_id"))
+    for item in snapshot.get("active_topics") or []:
+        if isinstance(item, dict):
+            _add(item.get("object_id"))
+    for item in snapshot.get("insights") or []:
+        if isinstance(item, dict):
+            for object_id in item.get("object_ids") or []:
+                _add(object_id)
+    return ids
+
+
+def _query_evolves_relations(
+    vault_dir: Path,
+    object_ids: Iterable[str],
+    *,
+    pack_name: str,
+) -> list[dict[str, str]]:
+    """Pull every ``evolves:*`` graph edge that touches any source object id.
+
+    Uses ``knowledge_index.ensure_knowledge_db_current`` so a stale DB gets
+    refreshed before the query — we never want a Crystal to silently miss a
+    just-promoted EVOLVES relation. Returns ``[]`` if the DB doesn't exist
+    yet (e.g. an empty vault on first build).
+    """
+    import sqlite3
+
+    from ..knowledge_index import ensure_knowledge_db_current
+    from ..runtime import VaultLayout
+
+    ids = [oid for oid in object_ids if oid]
+    if not ids:
+        return []
+    try:
+        ensure_knowledge_db_current(vault_dir)
+    except Exception:
+        pass
+    db_path = VaultLayout.from_vault(vault_dir).knowledge_db
+    if not Path(db_path).exists():
+        return []
+    placeholders = ",".join("?" for _ in ids)
+    sql = (
+        "SELECT source_object_id, target_object_id, edge_kind "
+        "FROM graph_edges "
+        f"WHERE pack = ? AND edge_kind LIKE 'evolves:%' "
+        f"AND (source_object_id IN ({placeholders}) "
+        f"OR target_object_id IN ({placeholders})) "
+        "ORDER BY edge_kind, source_object_id, target_object_id"
+    )
+    out: list[dict[str, str]] = []
+    with sqlite3.connect(db_path) as conn:
+        for src, tgt, kind in conn.execute(sql, [pack_name, *ids, *ids]):
+            subtype = str(kind).split(":", 1)[1] if ":" in str(kind) else ""
+            out.append({"source": str(src), "target": str(tgt), "subtype": subtype})
+    return out
+
+
+def _hash_payload(snapshot: dict[str, Any], object_ids: list[str]) -> str:
+    """Stable digest over content (not timestamps).
+
+    ``generated_at`` and ``queue_summary.running_count`` are excluded from
+    the hash so the same logical state at two different moments produces the
+    same Crystal id. Anything that materially affects the briefing — signals,
+    issues, insights, object set — does flow into the hash.
+    """
+    salient = {
+        "object_ids": object_ids,
+        "unresolved_issues": [
+            {
+                "signal_id": item.get("signal_id"),
+                "signal_type": item.get("signal_type"),
+                "title": item.get("title"),
+            }
+            for item in snapshot.get("unresolved_issues") or []
+            if isinstance(item, dict)
+        ],
+        "insights": [
+            {
+                "kind": item.get("kind"),
+                "title": item.get("title"),
+                "object_ids": item.get("object_ids"),
+            }
+            for item in snapshot.get("insights") or []
+            if isinstance(item, dict)
+        ],
+        "priority_items_count": len(snapshot.get("priority_items") or []),
+    }
+    blob = json.dumps(salient, ensure_ascii=False, sort_keys=True)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()[:16]
+
+
+def _crystal_id(snapshot: dict[str, Any], object_ids: list[str], *, when: _date_cls) -> str:
+    digest = _hash_payload(snapshot, object_ids)
+    return f"crystal-{when.isoformat()}-{digest[:8]}"
+
+
+def _yaml_list(values: Iterable[str]) -> str:
+    items = [str(v) for v in values]
+    if not items:
+        return "[]"
+    quoted = ", ".join(f'"{item}"' for item in items)
+    return f"[{quoted}]"
+
+
+def _evolves_yaml(relations: list[dict[str, str]]) -> str:
+    if not relations:
+        return "[]"
+    lines = []
+    for rel in relations:
+        lines.append(
+            f'  - {{source: "{rel["source"]}", '
+            f'target: "{rel["target"]}", '
+            f'subtype: "{rel["subtype"]}"}}'
+        )
+    return "\n" + "\n".join(lines)
+
+
+def _render_body(
+    snapshot: dict[str, Any],
+    object_ids: list[str],
+    relations: list[dict[str, str]],
+) -> str:
+    sections: list[str] = []
+    sections.append("# Crystal — Operator Briefing\n")
+
+    sections.append("## Priority Items\n")
+    items = snapshot.get("priority_items") or []
+    if items:
+        for item in items[:10]:
+            if not isinstance(item, dict):
+                continue
+            title = str(item.get("title") or item.get("signal_type") or "(untitled)")
+            sections.append(f"- {title}")
+    else:
+        sections.append("- (none)")
+    sections.append("")
+
+    sections.append("## Active Topics\n")
+    topics = snapshot.get("active_topics") or []
+    if topics:
+        for topic in topics[:10]:
+            if not isinstance(topic, dict):
+                continue
+            obj_id = str(topic.get("object_id") or "")
+            title = str(topic.get("title") or obj_id)
+            sections.append(f"- [[{obj_id}|{title}]]")
+    else:
+        sections.append("- (none)")
+    sections.append("")
+
+    sections.append("## Insights\n")
+    insights = snapshot.get("insights") or []
+    if insights:
+        for ins in insights[:10]:
+            if not isinstance(ins, dict):
+                continue
+            sections.append(f"- {ins.get('title') or ins.get('kind') or '(untitled)'}")
+    else:
+        sections.append("- (none)")
+    sections.append("")
+
+    sections.append("## EVOLVES Relations\n")
+    if relations:
+        for rel in relations:
+            sections.append(f"- [[{rel['source']}]] **{rel['subtype']}** [[{rel['target']}]]")
+    else:
+        sections.append("- (none)")
+    sections.append("")
+
+    sections.append("## Source Objects\n")
+    if object_ids:
+        for oid in object_ids:
+            sections.append(f"- [[{oid}]]")
+    else:
+        sections.append("- (none)")
+
+    return "\n".join(sections).rstrip() + "\n"
+
+
+def materialize_crystal(
+    snapshot: dict[str, Any],
+    vault_dir: Path,
+    *,
+    pack_name: str = "research-tech",
+    when: _date_cls | None = None,
+) -> CrystalRecord:
+    """Persist a briefing snapshot as a Crystal note.
+
+    ``snapshot`` is the dict returned by ``truth_api.get_briefing_snapshot``.
+    ``when`` defaults to today's UTC date — pinning it lets tests be
+    deterministic across midnight boundaries.
+
+    Returns a :class:`CrystalRecord` with ``created=True`` if a new file was
+    written, ``False`` if the Crystal already exists with identical content
+    (idempotent re-run).
+    """
+    from datetime import datetime, timezone
+
+    target_date = when or datetime.now(timezone.utc).date()
+    object_ids = _collect_source_object_ids(snapshot)
+    relations = _query_evolves_relations(vault_dir, object_ids, pack_name=pack_name)
+    crystal_id = _crystal_id(snapshot, object_ids, when=target_date)
+
+    output_dir = vault_dir.joinpath(*CRYSTAL_DIR)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / f"{crystal_id}.md"
+
+    frontmatter = (
+        "---\n"
+        f"crystal_id: {crystal_id}\n"
+        f"type: crystal\n"
+        f"date: {target_date.isoformat()}\n"
+        f"pack: {pack_name}\n"
+        f"assembly_recipe: {ASSEMBLY_RECIPE}\n"
+        f"source_object_ids: {_yaml_list(object_ids)}\n"
+        f"evolves_relations:{_evolves_yaml(relations)}\n"
+        "---\n\n"
+    )
+    body = _render_body(snapshot, object_ids, relations)
+    new_content = frontmatter + body
+
+    created = True
+    if output_path.exists() and output_path.read_text(encoding="utf-8") == new_content:
+        created = False
+    else:
+        output_path.write_text(new_content, encoding="utf-8")
+
+    return CrystalRecord(
+        crystal_id=crystal_id,
+        path=output_path,
+        source_object_ids=tuple(object_ids),
+        evolves_relations=tuple(relations),
+        created=created,
+    )

--- a/src/ovp_pipeline/packs/base.py
+++ b/src/ovp_pipeline/packs/base.py
@@ -348,6 +348,8 @@ class BaseDomainPack:
     _workspace_zones: WorkspaceZonesSpec | None = None
     _evidence_requirements: EvidenceRequirementsSpec | None = None
     _reuse_signals: ReuseSignalsSpec | None = None
+    # Phase 38 — EVOLVES subtype vocabulary; None falls back to v0.6 defaults.
+    _evolves_relation_types: tuple[str, ...] | None = None
 
     def __post_init__(self) -> None:
         if self.role not in ALLOWED_PACK_ROLES:
@@ -525,3 +527,14 @@ class BaseDomainPack:
 
     def reuse_signals(self) -> ReuseSignalsSpec:
         return self._reuse_signals or ReuseSignalsSpec()
+
+    def evolves_relation_types(self) -> tuple[str, ...]:
+        """Subtype vocabulary for ``relation_type == "evolves"`` candidates.
+
+        The default mirrors Nowledge Mem v0.6's epistemic-evolution vocabulary
+        (replaces / enriches / confirms / challenges). Packs override by
+        setting ``_evolves_relation_types`` to a tuple of allowed subtypes.
+        """
+        if self._evolves_relation_types is None:
+            return ("replaces", "enriches", "confirms", "challenges")
+        return self._evolves_relation_types

--- a/src/ovp_pipeline/packs/research_tech/semantic_relations.py
+++ b/src/ovp_pipeline/packs/research_tech/semantic_relations.py
@@ -51,6 +51,17 @@ def build_semantic_relation_contracts(
                     source_object_kinds=object_kinds,
                     target_object_kinds=object_kinds,
                 ),
+                SemanticRelationTypeSpec(
+                    name="evolves",
+                    description=(
+                        "Epistemic-evolution relation: the source object changes the "
+                        "target's status in the knowledge base. Requires "
+                        "``relation_subtype`` ∈ pack.evolves_relation_types() "
+                        "(default: replaces / enriches / confirms / challenges)."
+                    ),
+                    source_object_kinds=object_kinds,
+                    target_object_kinds=object_kinds,
+                ),
             ],
         )
     ]

--- a/src/ovp_pipeline/query_tool.py
+++ b/src/ovp_pipeline/query_tool.py
@@ -168,10 +168,11 @@ class VaultQuerier:
 
         return text[:max_len] + "..." if len(text) > max_len else text
 
-    def search(self, query: str, top_k: int = 10, engine: str = "knowledge") -> List[SearchResult]:
+    def search(self, query: str, top_k: int = 10, engine: str = "fused") -> List[SearchResult]:
         """
         搜索知识库
-        默认使用 knowledge.db；QMD 仅作为显式引擎
+        默认走 RRF + 双时序衰减（Phase 38）；可显式指定 ``knowledge`` (BM25→向量串行)
+        或 ``qmd`` (外部检索器)。
         """
         results = []
         for row in discover_related(self.vault_dir, query, engine=engine, limit=top_k, pack=self.pack):
@@ -473,9 +474,9 @@ def main(argv: list[str] | None = None):
     )
     parser.add_argument(
         "--engine",
-        choices=["knowledge", "qmd"],
-        default="knowledge",
-        help="检索引擎: knowledge(默认) 或 qmd",
+        choices=["fused", "knowledge", "qmd"],
+        default="fused",
+        help="检索引擎: fused(默认, RRF + 双时序衰减), knowledge(BM25→向量串行), 或 qmd",
     )
     parser.add_argument(
         "--pack",

--- a/src/ovp_pipeline/query_tool.py
+++ b/src/ovp_pipeline/query_tool.py
@@ -554,7 +554,7 @@ def main(argv: list[str] | None = None):
         consumer_ref=question,
     )
 
-    if args.feedback and args.engine == "knowledge":
+    if args.feedback and args.engine in {"knowledge", "fused"}:
         try:
             from .feedback_router import (
                 CandidateConcept,

--- a/src/ovp_pipeline/relation_promotion.py
+++ b/src/ovp_pipeline/relation_promotion.py
@@ -335,7 +335,7 @@ def promote_candidates(
                     actor=actor,
                     reason="relation_promoted",
                     payload={
-                        "relation_type": candidate.relation_type,
+                        "relation_type": _effective_relation_type(candidate),
                         "source_object_id": candidate.source_object_id,
                         "target_object_id": candidate.target_object_id,
                         "source_slug": candidate.source_slug,

--- a/src/ovp_pipeline/relation_promotion.py
+++ b/src/ovp_pipeline/relation_promotion.py
@@ -57,12 +57,22 @@ class RelationPromotionReport:
         }
 
 
+def _effective_relation_type(candidate: SemanticRelationCandidate) -> str:
+    """Composite ``relation_type`` written to ``relations.relation_type`` and
+    ``graph_edges.edge_kind``. EVOLVES candidates collapse subtype into the
+    type string so the durable rows survive rebuild without a schema change.
+    """
+    if candidate.relation_type == "evolves" and candidate.relation_subtype:
+        return f"evolves:{candidate.relation_subtype}"
+    return candidate.relation_type
+
+
 def _edge_id(candidate: SemanticRelationCandidate) -> str:
-    """Stable id derived from the (source, type, target, source_slug) tuple."""
+    """Stable id derived from the (source, effective_type, target, source_slug)."""
     payload = "|".join(
         (
             candidate.source_object_id,
-            candidate.relation_type,
+            _effective_relation_type(candidate),
             candidate.target_object_id,
             candidate.source_slug,
         )
@@ -87,7 +97,7 @@ def _ensure_relation_row(
             candidate.pack,
             candidate.source_object_id,
             candidate.target_object_id,
-            candidate.relation_type,
+            _effective_relation_type(candidate),
             candidate.source_slug,
             candidate.evidence_quote,
             candidate.locator,
@@ -116,7 +126,7 @@ def _ensure_graph_edge_row(
             _edge_id(candidate),
             candidate.source_object_id,
             candidate.target_object_id,
-            candidate.relation_type,
+            _effective_relation_type(candidate),
             float(candidate.confidence or 1.0),
             candidate.source_slug,
         ),
@@ -137,7 +147,7 @@ def _emit_relation_promoted(
             "pack": candidate.pack,
             "source_object_id": candidate.source_object_id,
             "target_object_id": candidate.target_object_id,
-            "relation_type": candidate.relation_type,
+            "relation_type": _effective_relation_type(candidate),
             "evidence_source_slug": candidate.source_slug,
             "quote_text": candidate.evidence_quote,
             "locator": candidate.locator,

--- a/src/ovp_pipeline/unified_pipeline_enhanced.py
+++ b/src/ovp_pipeline/unified_pipeline_enhanced.py
@@ -2518,6 +2518,23 @@ class EnhancedPipeline:
 
         if result["success"]:
             print("✓ Knowledge index refresh completed")
+            # Phase 38: piggyback on the knowledge_index step to materialize
+            # Crystals + the daily Working Memory file. Both are idempotent
+            # (Crystal collapses on identical content; Working Memory
+            # overwrites today's file), so cycling them per refresh is safe.
+            crystals_cmd = [
+                sys.executable, "-m", "ovp_pipeline.commands.build_crystals",
+                "--vault-dir", str(self.vault_dir),
+                "--pack", self.workflow_pack_name,
+                "--json",
+            ]
+            self.run_command(crystals_cmd, "knowledge_index", timeout=120)
+            working_memory_cmd = [
+                sys.executable, "-m", "ovp_pipeline.commands.working_memory",
+                "--vault-dir", str(self.vault_dir),
+                "--json",
+            ]
+            self.run_command(working_memory_cmd, "knowledge_index", timeout=60)
         else:
             print(f"✗ Knowledge index refresh failed: {result.get('error', 'Unknown error')}")
 

--- a/tests/test_autopilot_contracts.py
+++ b/tests/test_autopilot_contracts.py
@@ -188,18 +188,24 @@ def test_autopilot_knowledge_index_refresh_passes_pack(tmp_path, monkeypatch):
         pack="default-knowledge",
     )
 
-    captured: dict[str, object] = {}
+    captured: list[list[str]] = []
 
     def fake_run(cmd, **kwargs):
-        captured["cmd"] = list(cmd)
+        captured.append(list(cmd))
         return type("Completed", (), {"returncode": 0, "stderr": "", "stdout": ""})()
 
     monkeypatch.setattr(daemon_source.subprocess, "run", fake_run)
 
     daemon._run_knowledge_index_refresh()
 
-    assert "--pack" in captured["cmd"]
-    assert captured["cmd"][captured["cmd"].index("--pack") + 1] == "default-knowledge"
+    # Phase 38: refresh now also runs build_crystals + working_memory.
+    # The first invocation must still be the knowledge_index rebuild with
+    # the pack flag.
+    knowledge_cmd = next(
+        cmd for cmd in captured if "ovp_pipeline.commands.knowledge_index" in " ".join(cmd)
+    )
+    assert "--pack" in knowledge_cmd
+    assert knowledge_cmd[knowledge_cmd.index("--pack") + 1] == "default-knowledge"
 
 
 def test_autopilot_watcher_import_does_not_require_watchdog(tmp_path):

--- a/tests/test_crystal_materializer.py
+++ b/tests/test_crystal_materializer.py
@@ -1,0 +1,157 @@
+"""Phase 38 — Crystal materializer.
+
+Coverage:
+* materializing a snapshot writes a frontmatter+body file under 40-Resources/Crystals
+* the file is idempotent (same snapshot → same crystal_id, no rewrite)
+* a content-changing snapshot produces a *new* crystal_id
+* EVOLVES relations from graph_edges are surfaced in frontmatter and body
+* the CLI runs end-to-end on an empty vault without crashing
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import date
+
+from ovp_pipeline.commands.build_crystals import main as build_crystals_main
+from ovp_pipeline.knowledge_index import rebuild_knowledge_index
+from ovp_pipeline.materializers.crystal import (
+    CRYSTAL_DIR,
+    materialize_crystal,
+)
+from ovp_pipeline.runtime import VaultLayout
+
+
+def _seed_evolves_edge(vault_dir, source: str, target: str, subtype: str) -> None:
+    """Insert a fake EVOLVES edge directly into graph_edges so the materializer
+    can pick it up without running the full promotion pipeline."""
+    rebuild_knowledge_index(vault_dir)  # creates the schema
+    db_path = VaultLayout.from_vault(vault_dir).knowledge_db
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO graph_edges "
+            "(pack, edge_id, source_object_id, target_object_id, edge_kind, weight, evidence_source_slug) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                "research-tech",
+                f"e_{source}_{target}",
+                source,
+                target,
+                f"evolves:{subtype}",
+                1.0,
+                source,
+            ),
+        )
+        conn.commit()
+
+
+def _basic_snapshot() -> dict:
+    return {
+        "generated_at": "2026-04-24T00:00:00Z",
+        "active_topics": [
+            {"object_id": "rag", "title": "RAG"},
+            {"object_id": "ai-agent", "title": "AI Agent"},
+        ],
+        "changed_objects": [
+            {"object_id": "rag", "title": "RAG"},
+        ],
+        "insights": [
+            {
+                "kind": "evolution_evolves",
+                "title": "RAG replaces vanilla retrieval",
+                "object_ids": ["rag", "vanilla-retrieval"],
+            },
+        ],
+        "priority_items": [
+            {"signal_id": "s1", "signal_type": "stale_summary", "title": "RAG summary stale"},
+        ],
+        "unresolved_issues": [
+            {"signal_id": "s1", "signal_type": "stale_summary", "title": "RAG summary stale"},
+        ],
+    }
+
+
+def test_materialize_writes_frontmatter_and_sections(temp_vault):
+    snapshot = _basic_snapshot()
+    record = materialize_crystal(snapshot, temp_vault, when=date(2026, 4, 24))
+
+    assert record.created is True
+    assert record.path.exists()
+    assert record.path.parent == temp_vault.joinpath(*CRYSTAL_DIR)
+
+    content = record.path.read_text(encoding="utf-8")
+    assert content.startswith("---\n")
+    assert f"crystal_id: {record.crystal_id}" in content
+    assert "type: crystal" in content
+    assert "assembly_recipe: operator_briefing" in content
+    assert "date: 2026-04-24" in content
+    # source_object_ids include changed_objects + active_topics + insight ids
+    assert "rag" in content and "ai-agent" in content and "vanilla-retrieval" in content
+    # Body sections
+    assert "## Priority Items" in content
+    assert "## Active Topics" in content
+    assert "## Insights" in content
+    assert "## EVOLVES Relations" in content
+    assert "## Source Objects" in content
+
+
+def test_materialize_is_idempotent_for_same_snapshot(temp_vault):
+    """Running twice with the same snapshot produces the same crystal_id and
+    leaves the file unchanged on the second run — `created=False`."""
+    snapshot = _basic_snapshot()
+    first = materialize_crystal(snapshot, temp_vault, when=date(2026, 4, 24))
+    second = materialize_crystal(snapshot, temp_vault, when=date(2026, 4, 24))
+
+    assert first.crystal_id == second.crystal_id
+    assert first.path == second.path
+    assert second.created is False
+
+
+def test_materialize_changes_id_when_content_changes(temp_vault):
+    """A different priority item changes the salient hash → new crystal_id,
+    new file. Prior Crystal stays put as a historical record."""
+    base = _basic_snapshot()
+    first = materialize_crystal(base, temp_vault, when=date(2026, 4, 24))
+
+    mutated = _basic_snapshot()
+    mutated["priority_items"].append(
+        {"signal_id": "s2", "signal_type": "contradiction_open", "title": "Contradiction X"}
+    )
+    second = materialize_crystal(mutated, temp_vault, when=date(2026, 4, 24))
+
+    assert first.crystal_id != second.crystal_id
+    assert first.path.exists() and second.path.exists()
+    assert first.path != second.path
+
+
+def test_materialize_surfaces_evolves_relations(temp_vault):
+    """EVOLVES edges in graph_edges that touch any source object id show up
+    in both frontmatter and the rendered EVOLVES section."""
+    _seed_evolves_edge(temp_vault, "rag", "vanilla-retrieval", "replaces")
+
+    snapshot = _basic_snapshot()
+    record = materialize_crystal(snapshot, temp_vault, when=date(2026, 4, 24))
+
+    assert len(record.evolves_relations) == 1
+    rel = record.evolves_relations[0]
+    assert rel == {"source": "rag", "target": "vanilla-retrieval", "subtype": "replaces"}
+
+    content = record.path.read_text(encoding="utf-8")
+    assert "evolves_relations:" in content
+    assert "[[rag]] **replaces** [[vanilla-retrieval]]" in content
+
+
+def test_cli_runs_end_to_end_on_empty_vault(temp_vault, monkeypatch, capsys):
+    """The CLI must not crash on an empty vault with no signals — it should
+    write an empty Crystal documenting the (empty) state."""
+    monkeypatch.setattr(
+        "sys.argv", ["ovp-build-crystals", "--vault-dir", str(temp_vault), "--json"]
+    )
+    rc = build_crystals_main()
+    assert rc == 0
+
+    out = capsys.readouterr().out
+    assert "crystal_id" in out
+    assert "operator_briefing" in (
+        temp_vault / "40-Resources" / "Crystals"
+    ).iterdir().__next__().read_text(encoding="utf-8")

--- a/tests/test_query_tool.py
+++ b/tests/test_query_tool.py
@@ -5,7 +5,9 @@ import json
 import pytest
 
 
-def test_vault_querier_search_defaults_to_knowledge_engine(temp_vault, monkeypatch):
+def test_vault_querier_search_defaults_to_fused_engine(temp_vault, monkeypatch):
+    """Phase 38: VaultQuerier.search defaults to the fused (RRF + decay) engine.
+    Callers can still pass ``engine="knowledge"`` for the legacy serial path."""
     from ovp_pipeline import query_tool
 
     queried = {}
@@ -19,7 +21,7 @@ def test_vault_querier_search_defaults_to_knowledge_engine(temp_vault, monkeypat
         return [
             {
                 "engine": "knowledge",
-                "kind": "lexical",
+                "kind": "fused",
                 "slug": "agent-harness",
                 "title": "Agent Harness",
                 "score": 12.3,
@@ -32,7 +34,7 @@ def test_vault_querier_search_defaults_to_knowledge_engine(temp_vault, monkeypat
     querier = query_tool.VaultQuerier(temp_vault)
     results = querier.search("architecture tools", top_k=5)
 
-    assert queried["engine"] == "knowledge"
+    assert queried["engine"] == "fused"
     assert queried["pack"] == "default-knowledge"
     assert len(results) == 1
     assert results[0].file == "10-Knowledge/Evergreen/Agent-Harness.md"

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -525,11 +525,10 @@ def test_step_knowledge_index_invokes_rebuild_command(tmp_path, monkeypatch):
     txn = TransactionManager(vault / "60-Logs" / "transactions")
     pipeline = EnhancedPipeline(vault, logger, txn)
 
-    captured: dict[str, object] = {}
+    invocations: list[list[str]] = []
 
     def fake_run_command(cmd: list[str], step_name: str, timeout: int | None = None) -> dict:
-        captured["cmd"] = cmd
-        captured["step_name"] = step_name
+        invocations.append(list(cmd))
         return {"success": True, "stdout": "", "stderr": ""}
 
     monkeypatch.setattr(pipeline, "run_command", fake_run_command)
@@ -537,11 +536,13 @@ def test_step_knowledge_index_invokes_rebuild_command(tmp_path, monkeypatch):
     result = pipeline.step_knowledge_index(dry_run=True)
 
     assert result["success"] is True
-    assert captured["step_name"] == "knowledge_index"
-    assert "ovp_pipeline.commands.knowledge_index" in " ".join(captured["cmd"])
-    assert "--vault-dir" in captured["cmd"]
-    assert "--pack" in captured["cmd"]
-    assert captured["cmd"][captured["cmd"].index("--pack") + 1] == pipeline.workflow_pack_name
+    rebuild = next(
+        cmd for cmd in invocations
+        if "ovp_pipeline.commands.knowledge_index" in " ".join(cmd)
+    )
+    assert "--vault-dir" in rebuild
+    assert "--pack" in rebuild
+    assert rebuild[rebuild.index("--pack") + 1] == pipeline.workflow_pack_name
 
 
 def test_step_absorb_invokes_absorb_command(tmp_path, monkeypatch):
@@ -1731,14 +1732,13 @@ def test_step_knowledge_index_uses_dynamic_timeout(tmp_path, monkeypatch):
     pipeline = EnhancedPipeline(vault, logger, txn)
     pipeline.txn_id = txn.start("enhanced-pipeline", "Knowledge index progress")
 
-    captured: dict[str, object] = {}
+    invocations: list[dict] = []
 
     def fake_run_command(cmd: list[str], step_name: str, timeout: int | None = None) -> dict:
-        captured["cmd"] = cmd
-        captured["step_name"] = step_name
-        captured["timeout"] = timeout
+        record = {"cmd": cmd, "step_name": step_name, "timeout": timeout}
         payload = json.loads((vault / "60-Logs" / "transactions" / f"{pipeline.txn_id}.json").read_text(encoding="utf-8"))
-        captured["current_step"] = payload["run_ledger"]["current_step"]
+        record["current_step"] = payload["run_ledger"]["current_step"]
+        invocations.append(record)
         return {"success": True, "stdout": "", "stderr": ""}
 
     monkeypatch.setattr(pipeline, "run_command", fake_run_command)
@@ -1746,10 +1746,15 @@ def test_step_knowledge_index_uses_dynamic_timeout(tmp_path, monkeypatch):
     result = pipeline.step_knowledge_index(dry_run=False)
 
     assert result["success"] is True
-    assert captured["step_name"] == "knowledge_index"
-    assert "ovp_pipeline.commands.knowledge_index" in " ".join(captured["cmd"])
-    assert captured["timeout"] > 120
-    current = captured["current_step"]
+    # Phase 38: step_knowledge_index now also fires build_crystals + working_memory
+    # piggyback subprocesses; the *first* invocation is still the rebuild itself.
+    rebuild = next(
+        inv for inv in invocations
+        if "ovp_pipeline.commands.knowledge_index" in " ".join(inv["cmd"])
+    )
+    assert rebuild["step_name"] == "knowledge_index"
+    assert rebuild["timeout"] > 120
+    current = rebuild["current_step"]
     assert current["progress_mode"] == "counted"
     assert current["work_units_total"] == 400
     assert current["work_units_done"] == 0

--- a/tests/test_search_fused.py
+++ b/tests/test_search_fused.py
@@ -1,0 +1,162 @@
+"""Phase 38 — Hybrid search (RRF + bi-temporal decay).
+
+Coverage:
+* empty vault returns []
+* page_metrics is populated by rebuild and survives a re-run
+* RRF: a slug returned by both BM25 and vector ranks higher than a slug
+  returned by only one branch
+* Recency: same slug + same RRF, but newer ``last_seen_ts`` ranks first
+* Frequency / importance multipliers compose with RRF
+* The ``fused`` engine is wired into ``discover_related``
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from ovp_pipeline.discovery import discover_related
+from ovp_pipeline.knowledge_index import (
+    rebuild_knowledge_index,
+    search_fused,
+)
+from ovp_pipeline.runtime import VaultLayout
+
+
+def _evergreen(name: str, body: str) -> str:
+    return (
+        "---\n"
+        f"note_id: {name}\n"
+        f"title: {name.replace('-', ' ').title()}\n"
+        "type: evergreen\n"
+        "date: 2026-04-24\n"
+        "---\n\n"
+        f"# {name.replace('-', ' ').title()}\n\n"
+        f"{body}\n"
+    )
+
+
+def _seed_two_pages(vault) -> None:
+    eg = vault / "10-Knowledge" / "Evergreen"
+    (eg / "Rag.md").write_text(
+        _evergreen(
+            "rag",
+            "RAG combines retrieval with generation to ground LLM answers.",
+        ),
+        encoding="utf-8",
+    )
+    (eg / "Vanilla-Retrieval.md").write_text(
+        _evergreen(
+            "vanilla-retrieval",
+            "Vanilla retrieval returns documents without generation.",
+        ),
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(vault)
+
+
+def test_search_fused_empty_vault_returns_empty(temp_vault):
+    rebuild_knowledge_index(temp_vault)
+    assert search_fused(temp_vault, "anything", limit=5) == []
+
+
+def test_rebuild_populates_page_metrics(temp_vault):
+    """``page_metrics`` must have one row per ``pages_index`` slug after
+    rebuild — even when there are no audit/reuse signals yet (zeros)."""
+    _seed_two_pages(temp_vault)
+
+    db = VaultLayout.from_vault(temp_vault).knowledge_db
+    with sqlite3.connect(db) as conn:
+        rows = conn.execute(
+            "SELECT slug, last_seen_ts, reuse_count, citation_count "
+            "FROM page_metrics ORDER BY slug"
+        ).fetchall()
+
+    assert {r[0] for r in rows} >= {"rag", "vanilla-retrieval"}
+    for _slug, last_seen, reuse, cite in rows:
+        assert last_seen >= 0
+        assert reuse >= 0
+        assert cite >= 0
+
+
+def test_search_fused_returns_results_for_seeded_query(temp_vault):
+    _seed_two_pages(temp_vault)
+    results = search_fused(temp_vault, "retrieval", limit=5)
+    assert results, "fused search should return at least one hit"
+    slugs = {r["slug"] for r in results}
+    # query touches both notes via "retrieval" (bm25) and embeddings; at
+    # least one of the seeded slugs must appear.
+    assert slugs & {"rag", "vanilla-retrieval"}
+
+
+def test_recency_boost_promotes_newer_slug(temp_vault):
+    """Two slugs with identical RRF scores: the one with a newer
+    ``last_seen_ts`` must rank first."""
+    _seed_two_pages(temp_vault)
+    db = VaultLayout.from_vault(temp_vault).knowledge_db
+
+    with sqlite3.connect(db) as conn:
+        # Force identical metrics for both, with rag being "newer".
+        conn.executemany(
+            "INSERT OR REPLACE INTO page_metrics "
+            "(slug, last_seen_ts, reuse_count, citation_count) VALUES (?, ?, ?, ?)",
+            [
+                ("rag", 2_000_000_000, 0, 0),
+                ("vanilla-retrieval", 1_000_000_000, 0, 0),
+            ],
+        )
+        conn.commit()
+
+    # now_ts pinned just after the newer timestamp so decay is large for the
+    # older slug, small for the newer one.
+    results = search_fused(
+        temp_vault,
+        "retrieval",
+        limit=5,
+        tau_days=30.0,
+        now_ts=2_000_000_001,
+    )
+    assert results
+    ranked_slugs = [r["slug"] for r in results]
+    if "rag" in ranked_slugs and "vanilla-retrieval" in ranked_slugs:
+        assert ranked_slugs.index("rag") < ranked_slugs.index("vanilla-retrieval")
+
+
+def test_frequency_and_importance_compose(temp_vault):
+    """A high reuse_count + citation_count pushes a slug above an equally
+    ranked but cold one."""
+    _seed_two_pages(temp_vault)
+    db = VaultLayout.from_vault(temp_vault).knowledge_db
+    with sqlite3.connect(db) as conn:
+        conn.executemany(
+            "INSERT OR REPLACE INTO page_metrics "
+            "(slug, last_seen_ts, reuse_count, citation_count) VALUES (?, ?, ?, ?)",
+            [
+                ("rag", 0, 0, 0),
+                ("vanilla-retrieval", 0, 50, 50),
+            ],
+        )
+        conn.commit()
+
+    results = search_fused(temp_vault, "retrieval", limit=5)
+    assert results
+    by_slug = {r["slug"]: r for r in results}
+    if "rag" in by_slug and "vanilla-retrieval" in by_slug:
+        # vanilla-retrieval has high freq/importance; its score must beat rag.
+        assert by_slug["vanilla-retrieval"]["score"] > by_slug["rag"]["score"]
+
+
+def test_discover_related_fused_engine(temp_vault):
+    """The ``fused`` engine must round-trip through ``discover_related`` and
+    annotate each row with ``rrf_score`` / ``recency`` / ``frequency`` /
+    ``importance`` so reviewers can audit the ranking."""
+    _seed_two_pages(temp_vault)
+
+    rows = discover_related(temp_vault, "retrieval", engine="fused", limit=5)
+    assert rows
+    sample = rows[0]
+    assert sample["engine"] == "knowledge"
+    assert sample["kind"] == "fused"
+    assert "rrf_score" in sample
+    assert "recency" in sample
+    assert "frequency" in sample
+    assert "importance" in sample

--- a/tests/test_semantic_relations_evolves.py
+++ b/tests/test_semantic_relations_evolves.py
@@ -1,0 +1,201 @@
+"""Phase 38 — EVOLVES typing on SemanticRelationCandidate.
+
+Round-trips a `relation_type="evolves" + relation_subtype="replaces"`
+candidate through extract → promote → relations + graph_edges, and confirms
+extractor rejection on missing/unknown subtype.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from ovp_pipeline.extraction.semantic_relations import (
+    SemanticRelationCandidate,
+    extract_relations,
+)
+from ovp_pipeline.knowledge_index import rebuild_knowledge_index
+from ovp_pipeline.packs.loader import load_pack
+from ovp_pipeline.relation_promotion import promote_candidates
+from ovp_pipeline.runtime import VaultLayout
+
+
+class _StubProposer:
+    def __init__(self, raw):
+        self._raw = raw
+
+    def propose(self, text, *, source_slug, vocabulary, known_object_ids):
+        return list(self._raw)
+
+
+def _seed_deep_dive(vault: Path) -> Path:
+    body = (
+        "# Memory\n\n"
+        "## Background\n"
+        "RAG replaces vanilla retrieval as the substrate for long-context recall, "
+        "according to recent benchmarks.\n"
+    )
+    target = vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "memory.md"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(body, encoding="utf-8")
+    return target
+
+
+def test_evolves_default_subtype_vocabulary():
+    """The default evolves vocab matches Nowledge Mem v0.6 — extending packs
+    can override but the platform default must stay stable so heuristics can
+    rely on the four canonical subtypes."""
+    pack = load_pack("research-tech")
+    assert pack.evolves_relation_types() == (
+        "replaces",
+        "enriches",
+        "confirms",
+        "challenges",
+    )
+
+
+def test_extractor_accepts_evolves_with_known_subtype(temp_vault):
+    pack = load_pack("research-tech")
+    deep_dive = _seed_deep_dive(temp_vault)
+    raw = SemanticRelationCandidate(
+        relation_type="evolves",
+        relation_subtype="replaces",
+        source_object_id="rag",
+        target_object_id="vanilla-retrieval",
+        source_slug="memory",
+        evidence_quote="RAG replaces vanilla retrieval",
+        confidence=0.9,
+    )
+    report = extract_relations(
+        deep_dive,
+        pack=pack,
+        vault_dir=temp_vault,
+        proposer=_StubProposer([raw]),
+        known_object_ids=["rag", "vanilla-retrieval"],
+        object_kinds={"rag": "concept", "vanilla-retrieval": "concept"},
+    )
+    assert len(report.candidates) == 1
+    assert report.candidates[0].relation_subtype == "replaces"
+
+
+def test_extractor_rejects_evolves_with_missing_subtype(temp_vault):
+    pack = load_pack("research-tech")
+    deep_dive = _seed_deep_dive(temp_vault)
+    raw = SemanticRelationCandidate(
+        relation_type="evolves",
+        relation_subtype="",
+        source_object_id="rag",
+        target_object_id="vanilla-retrieval",
+        source_slug="memory",
+        evidence_quote="RAG replaces vanilla retrieval",
+        confidence=0.9,
+    )
+    report = extract_relations(
+        deep_dive,
+        pack=pack,
+        vault_dir=temp_vault,
+        proposer=_StubProposer([raw]),
+        known_object_ids=["rag", "vanilla-retrieval"],
+        object_kinds={"rag": "concept", "vanilla-retrieval": "concept"},
+    )
+    assert report.candidates == []
+    assert report.rejected[0][1] == "missing_relation_subtype"
+
+
+def test_extractor_rejects_evolves_with_unknown_subtype(temp_vault):
+    pack = load_pack("research-tech")
+    deep_dive = _seed_deep_dive(temp_vault)
+    raw = SemanticRelationCandidate(
+        relation_type="evolves",
+        relation_subtype="invents",  # not in default vocab
+        source_object_id="rag",
+        target_object_id="vanilla-retrieval",
+        source_slug="memory",
+        evidence_quote="RAG replaces vanilla retrieval",
+        confidence=0.9,
+    )
+    report = extract_relations(
+        deep_dive,
+        pack=pack,
+        vault_dir=temp_vault,
+        proposer=_StubProposer([raw]),
+        known_object_ids=["rag", "vanilla-retrieval"],
+        object_kinds={"rag": "concept", "vanilla-retrieval": "concept"},
+    )
+    assert report.candidates == []
+    assert report.rejected[0][1] == "unknown_relation_subtype"
+
+
+def test_promote_evolves_writes_composite_relation_type(temp_vault):
+    """End-to-end: promoted EVOLVES candidate stores `evolves:{subtype}` in
+    both `relations.relation_type` and `graph_edges.edge_kind`. Composite
+    encoding is the design choice — see `_effective_relation_type` — so no
+    schema migration is needed for the v0.6 vocabulary roll-out."""
+    pack = load_pack("research-tech")
+    layout = VaultLayout.from_vault(temp_vault)
+    rebuild_knowledge_index(temp_vault)
+
+    cand = SemanticRelationCandidate(
+        relation_type="evolves",
+        relation_subtype="replaces",
+        source_object_id="rag",
+        target_object_id="vanilla-retrieval",
+        source_slug="memory",
+        evidence_quote="RAG replaces vanilla retrieval",
+        confidence=0.9,
+        locator="section#background@0",
+        content_hash="hash-evolves",
+        retrieval_context="…",
+        pack=pack.name,
+    )
+    report = promote_candidates([cand], pack=pack, layout=layout)
+    assert report.lane_counts() == {"auto": 1, "escalate": 0, "reject": 0}
+
+    with sqlite3.connect(layout.knowledge_db) as conn:
+        rel_rows = conn.execute(
+            "SELECT relation_type FROM relations WHERE pack = ?",
+            (pack.name,),
+        ).fetchall()
+        edge_rows = conn.execute(
+            "SELECT edge_kind FROM graph_edges WHERE pack = ?",
+            (pack.name,),
+        ).fetchall()
+    assert ("evolves:replaces",) in rel_rows
+    assert ("evolves:replaces",) in edge_rows
+
+
+def test_promote_evolves_survives_rebuild(temp_vault):
+    """Composite type must round-trip through rebuild_knowledge_index — the
+    JSONL replay path is what restores promoted rows after the projection
+    truncates the table."""
+    pack = load_pack("research-tech")
+    layout = VaultLayout.from_vault(temp_vault)
+    rebuild_knowledge_index(temp_vault)
+
+    cand = SemanticRelationCandidate(
+        relation_type="evolves",
+        relation_subtype="confirms",
+        source_object_id="rag",
+        target_object_id="vanilla-retrieval",
+        source_slug="memory",
+        evidence_quote="RAG replaces vanilla retrieval",
+        confidence=0.9,
+        locator="section#background@0",
+        content_hash="hash-evolves",
+        retrieval_context="…",
+        pack=pack.name,
+    )
+    promote_candidates([cand], pack=pack, layout=layout)
+    rebuild_knowledge_index(temp_vault)
+
+    with sqlite3.connect(layout.knowledge_db) as conn:
+        rel_rows = conn.execute(
+            "SELECT relation_type FROM relations WHERE pack = ?",
+            (pack.name,),
+        ).fetchall()
+        edge_rows = conn.execute(
+            "SELECT edge_kind FROM graph_edges WHERE pack = ?",
+            (pack.name,),
+        ).fetchall()
+    assert ("evolves:confirms",) in rel_rows
+    assert ("evolves:confirms",) in edge_rows

--- a/tests/test_working_memory.py
+++ b/tests/test_working_memory.py
@@ -1,0 +1,206 @@
+"""Phase 38 — Working Memory daily distill.
+
+Coverage:
+* empty vault → file exists with all five section headers and (none) bodies
+* date override writes to the correct path
+* fresh Crystals appear in the Fresh Crystals section
+* Top of Mind respects citation_count from page_metrics
+* EVOLVES Today groups events by subtype within the lookback window
+* Pulse Highlights counts pipeline.jsonl events in the window
+* CLI runs end-to-end on an empty vault
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import date, datetime, timedelta, timezone
+
+from ovp_pipeline.commands.working_memory import (
+    WORKING_MEMORY_DIR,
+    build_working_memory,
+    main as working_memory_main,
+)
+from ovp_pipeline.knowledge_index import rebuild_knowledge_index
+from ovp_pipeline.runtime import VaultLayout
+
+
+def _ts(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def test_empty_vault_renders_all_section_headers(temp_vault):
+    output = build_working_memory(temp_vault, target_date=date(2026, 4, 24))
+    text = output.read_text(encoding="utf-8")
+
+    assert output.parent == temp_vault.joinpath(*WORKING_MEMORY_DIR)
+    assert output.name == "2026-04-24.md"
+    assert text.startswith("# Working Memory — 2026-04-24")
+    for section in (
+        "## Top of Mind",
+        "## Fresh Crystals",
+        "## Pending Decisions",
+        "## EVOLVES Today",
+        "## Pulse Highlights",
+    ):
+        assert section in text
+    # All five sections empty on a clean vault → five "(none)" markers.
+    assert text.count("- (none)") == 5
+
+
+def test_date_override_writes_to_correct_path(temp_vault):
+    output = build_working_memory(temp_vault, target_date=date(2025, 12, 31))
+    assert output.name == "2025-12-31.md"
+
+
+def test_fresh_crystals_section_lists_recent_files(temp_vault):
+    crystals_dir = temp_vault / "40-Resources" / "Crystals"
+    crystals_dir.mkdir(parents=True)
+    crystal = crystals_dir / "crystal-2026-04-24-abcd1234.md"
+    crystal.write_text(
+        "---\ncrystal_id: crystal-2026-04-24-abcd1234\ndate: 2026-04-24\n---\n\n# Crystal\n",
+        encoding="utf-8",
+    )
+
+    now = datetime(2026, 4, 24, 12, 0, tzinfo=timezone.utc)
+    output = build_working_memory(temp_vault, target_date=now.date(), now=now)
+    text = output.read_text(encoding="utf-8")
+    assert "[[crystal-2026-04-24-abcd1234]]" in text
+
+
+def test_top_of_mind_uses_page_metrics(temp_vault):
+    """Seed page_metrics so we can assert the ordering deterministically."""
+    eg = temp_vault / "10-Knowledge" / "Evergreen"
+    (eg / "Hot.md").write_text(
+        "---\nnote_id: hot\ntitle: Hot\ntype: evergreen\ndate: 2026-04-24\n---\n# Hot\n",
+        encoding="utf-8",
+    )
+    (eg / "Cold.md").write_text(
+        "---\nnote_id: cold\ntitle: Cold\ntype: evergreen\ndate: 2026-04-24\n---\n# Cold\n",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    now = datetime(2026, 4, 24, 12, 0, tzinfo=timezone.utc)
+    db = VaultLayout.from_vault(temp_vault).knowledge_db
+    with sqlite3.connect(db) as conn:
+        conn.executemany(
+            "INSERT OR REPLACE INTO page_metrics "
+            "(slug, last_seen_ts, reuse_count, citation_count) VALUES (?, ?, ?, ?)",
+            [
+                ("hot", int(now.timestamp()), 5, 12),
+                ("cold", int(now.timestamp()), 1, 1),
+            ],
+        )
+        conn.commit()
+
+    output = build_working_memory(temp_vault, target_date=now.date(), now=now)
+    text = output.read_text(encoding="utf-8")
+    # Hot (12 citations) must appear before Cold (1 citation) in the section.
+    hot_idx = text.find("[[hot]]")
+    cold_idx = text.find("[[cold]]")
+    assert hot_idx != -1 and cold_idx != -1
+    assert hot_idx < cold_idx
+
+
+def test_evolves_today_groups_by_subtype(temp_vault):
+    """Two recent and one stale relation_promoted; only the recent ones land
+    in the section, grouped by subtype."""
+    layout = VaultLayout.from_vault(temp_vault)
+    layout.logs_dir.mkdir(parents=True, exist_ok=True)
+    log = layout.logs_dir / "relation-promotions.jsonl"
+
+    now = datetime(2026, 4, 24, 12, 0, tzinfo=timezone.utc)
+    recent_ts = _ts(now - timedelta(hours=2))
+    stale_ts = _ts(now - timedelta(days=5))
+
+    log.write_text(
+        "\n".join(
+            json.dumps(event)
+            for event in [
+                {
+                    "ts": recent_ts,
+                    "event_type": "relation_promoted",
+                    "relation_type": "evolves:replaces",
+                    "source_object_id": "rag",
+                    "target_object_id": "vanilla-retrieval",
+                },
+                {
+                    "ts": recent_ts,
+                    "event_type": "relation_promoted",
+                    "relation_type": "evolves:enriches",
+                    "source_object_id": "agent",
+                    "target_object_id": "rag",
+                },
+                {
+                    "ts": stale_ts,
+                    "event_type": "relation_promoted",
+                    "relation_type": "evolves:replaces",
+                    "source_object_id": "old",
+                    "target_object_id": "older",
+                },
+                {
+                    "ts": recent_ts,
+                    "event_type": "relation_promoted",
+                    "relation_type": "supports",  # not an evolves, ignored
+                    "source_object_id": "x",
+                    "target_object_id": "y",
+                },
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    output = build_working_memory(temp_vault, target_date=now.date(), now=now)
+    text = output.read_text(encoding="utf-8")
+
+    assert "### replaces (1)" in text
+    assert "### enriches (1)" in text
+    assert "[[rag]] → [[vanilla-retrieval]]" in text
+    assert "[[agent]] → [[rag]]" in text
+    # Stale 5-days-ago event must NOT appear.
+    assert "[[old]] → [[older]]" not in text
+    # Non-evolves event must NOT appear.
+    assert "[[x]] → [[y]]" not in text
+
+
+def test_pulse_highlights_counts_recent_events(temp_vault):
+    layout = VaultLayout.from_vault(temp_vault)
+    layout.logs_dir.mkdir(parents=True, exist_ok=True)
+
+    now = datetime(2026, 4, 24, 12, 0, tzinfo=timezone.utc)
+    recent_ts = _ts(now - timedelta(hours=1))
+    stale_ts = _ts(now - timedelta(days=3))
+
+    layout.pipeline_log.write_text(
+        "\n".join(
+            json.dumps(e)
+            for e in [
+                {"ts": recent_ts, "event_type": "article_processed"},
+                {"ts": recent_ts, "event_type": "article_processed"},
+                {"ts": recent_ts, "event_type": "evergreen_absorbed"},
+                {"ts": stale_ts, "event_type": "article_processed"},  # outside window
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    output = build_working_memory(temp_vault, target_date=now.date(), now=now)
+    text = output.read_text(encoding="utf-8")
+
+    assert "| article_processed | 2 |" in text
+    assert "| evergreen_absorbed | 1 |" in text
+
+
+def test_cli_runs_end_to_end_on_empty_vault(temp_vault, monkeypatch, capsys):
+    monkeypatch.setattr(
+        "sys.argv",
+        ["ovp-working-memory", "--vault-dir", str(temp_vault), "--date", "2026-04-24", "--json"],
+    )
+    rc = working_memory_main()
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "2026-04-24.md" in out
+    assert (temp_vault / "60-Logs" / "working-memory" / "2026-04-24.md").exists()


### PR DESCRIPTION
## Summary

Phase 38 Stage B follows on from Stage A (PR #59). Four sub-deliverables under one PR — each independently useful, but they compose to close the loop sketched in the renovation plan: typed semantic edges feed Crystal frontmatter, fused search ranks them by RRF + bi-temporal decay, and the daily working-memory file distills what's fresh.

### 3.1 EVOLVES typing on \`SemanticRelationCandidate\`
- New optional \`relation_subtype\` field on the candidate dataclass.
- Pack-level vocabulary (\`replaces / enriches / confirms / challenges\`) via \`BaseDomainPack.evolves_relation_types\`.
- Extractor rejects \`evolves\` candidates missing or with unknown subtypes.
- Promotion writes composite \`evolves:{subtype}\` into \`relations.relation_type\` and \`graph_edges.edge_kind\` — no schema migration.

### 3.2 Crystal materializer + \`ovp-build-crystals\`
- \`materializers/crystal.py\` writes \`40-Resources/Crystals/<id>.md\` with YAML frontmatter (source_object_ids, evolves_relations, assembly_recipe).
- Content-hash \`crystal_id\` makes re-materialization idempotent; salient content changes mint a new id and leave the prior file as history.
- \`ovp-build-crystals\` CLI calls \`truth_api.get_briefing_snapshot\` then hands the snapshot to the materializer.

### 3.3 Hybrid search (RRF + bi-temporal decay)
- New \`page_metrics\` table aggregating last_seen_ts / reuse_count / citation_count from \`audit_events\`, \`reuse_events\`, \`page_links\` — rebuilt at the end of \`rebuild_knowledge_index\`.
- \`search_fused\` fuses BM25 + vector via reciprocal rank fusion (k=60), then multiplies by recency exp-decay (tau=30d), frequency log(reuse), and importance log(citations).
- \`ovp-query --engine fused\` is the new default; \`knowledge\` and \`qmd\` remain for explicit override.
- \`discover_related\` gains a \`fused\` engine branch carrying RRF + decay components per row for auditing.

### 3.4 Working Memory daily distill + \`ovp-working-memory\`
- Writes \`60-Logs/working-memory/YYYY-MM-DD.md\` with five sections: Top of Mind, Fresh Crystals, Pending Decisions, EVOLVES Today, Pulse Highlights.
- Idempotent overwrite of today's file; lookback computed from \`now\`.
- Autopilot daemon and \`ovp --full\` knowledge_index step both fire \`build-crystals\` + \`working-memory\` after the rebuild (both idempotent, so per-cycle invocation is safe).

## Test plan
- [x] \`pytest -q\` — 940 passing (24 new test cases across four files)
- [x] \`ruff check\` on touched files — clean
- [x] \`black --check\` on new files — clean (pre-existing debt in \`discovery.py\`/\`knowledge_index.py\` left alone)
- [ ] Smoke (post-merge): \`ovp-build-crystals --vault-dir <vault>\` produces a Crystal under \`40-Resources/Crystals/\`
- [ ] Smoke: \`ovp-query "AI Agent" --engine fused\` returns rank-fused results
- [ ] Smoke: \`ovp-working-memory --vault-dir <vault>\` writes today's working-memory file with all five section headers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/61" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `ovp-build-crystals` command to generate Crystal knowledge summaries from briefings.
  * Added `ovp-working-memory` command to generate daily working memory markdown reports.
  * Introduced fused search engine combining multiple ranking strategies for improved discovery.
  * Added "evolves" relation type with subtypes (replaces, enriches, confirms, challenges) for knowledge items.

* **Changes**
  * Default search engine now uses fused approach instead of lexical search.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->