### PR TITLE
Phase 38 Stage C: graph_ops module, MCP graph tools, /explore reviewer UI

### DIFF
--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -100,6 +100,7 @@ def _shell_nav_items(requested_pack: str = "") -> list[tuple[str, str]]:
         ("Actions", "/actions"),
         ("Production", "/production"),
         ("Workbench", "/workbench"),
+        ("Explore", "/explore"),
     ]
     if _shell_supports_research_nav(requested_pack):
         items.extend(
@@ -4223,6 +4224,124 @@ def _render_workbench_page(*, object_id: str, requested_pack: str) -> str:
     )
 
 
+def _render_explore_fragment(object_id: str) -> str:
+    """Phase 38 Stage C — agent-decisions SSE consumer.
+
+    Tails ``60-Logs/agent-decisions.jsonl`` (written by graph_ops calls
+    invoked through MCP) and renders one frame per decision. Mirrors the
+    Pulse fragment so the look-and-feel is consistent across SSE panes.
+    """
+    object_qs = quote(object_id, safe="")
+    return (
+        "<section class='agent-timeline'>"
+        "<style>"
+        ".agent-timeline{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.78rem;}"
+        ".agent-timeline ul{list-style:none;margin:0;padding:.4rem;height:100%;overflow:auto;"
+        "background:#0e1116;color:#d6deeb;border-radius:6px;}"
+        ".agent-timeline li{margin:.1rem 0;white-space:pre-wrap;}"
+        ".agent-timeline li .ts{color:#7c8593;margin-right:.4rem;}"
+        ".agent-timeline li .tool{color:#82aaff;margin-right:.4rem;}"
+        ".agent-timeline .empty{color:#7c8593;padding:.4rem;}"
+        "</style>"
+        "<ul id='agent-feed'><li class='empty'>Waiting for agent decisions…</li></ul>"
+        "<script>(function(){"
+        "var feed=document.getElementById('agent-feed');"
+        "var empty=feed.querySelector('.empty');"
+        f"var src=new EventSource('/explore/stream?object_id={object_qs}');"
+        "function render(ev){"
+        "if(empty){empty.remove();empty=null;}"
+        "try{var obj=JSON.parse(ev.data);"
+        "var li=document.createElement('li');"
+        "var ts=document.createElement('span');ts.className='ts';ts.textContent=obj.ts||'';"
+        "var tool=document.createElement('span');tool.className='tool';"
+        "tool.textContent=obj.tool||obj.event_type||'';"
+        "var body=document.createElement('span');"
+        "body.textContent=JSON.stringify(obj.arguments||obj.payload||{}).slice(0,140);"
+        "li.appendChild(ts);li.appendChild(tool);li.appendChild(body);"
+        "feed.appendChild(li);"
+        "while(feed.children.length>200){feed.removeChild(feed.firstChild);}"
+        "feed.scrollTop=feed.scrollHeight;"
+        "}catch(e){/* swallow */}}"
+        "src.onmessage=render;"
+        "src.addEventListener('agent_decision',render);"
+        "src.onerror=function(){src.close();};"
+        "})();</script>"
+        "</section>"
+    )
+
+
+def _render_explore_page(*, object_id: str) -> str:
+    """Phase 38 Stage C — graph-native exploration surface.
+
+    Layout (CSS grid):
+
+        ┌──────────────────┬──────────────────┐
+        │  Graph canvas    │  Agent timeline  │
+        │  (iframe of      │  (SSE stream of  │
+        │   /graph?id=...) │   graph_ops      │
+        │                  │   tool calls)    │
+        ├──────────────────┴──────────────────┤
+        │  Synthesis pane (Crystal preview)   │
+        └─────────────────────────────────────┘
+    """
+    canvas_src = (
+        f"/object/fragment?id={quote(object_id, safe='')}"
+        if object_id
+        else "/objects"
+    )
+    synth_src = (
+        f"/object/fragment?id={quote(object_id, safe='')}"
+        if object_id
+        else "/objects"
+    )
+    return (
+        "<!doctype html><html lang='en'><head><meta charset='utf-8'>"
+        "<meta name='viewport' content='width=device-width, initial-scale=1' />"
+        "<title>Explore</title>"
+        "<style>"
+        "*{box-sizing:border-box}"
+        "body{margin:0;font-family:ui-sans-serif,system-ui,sans-serif;background:#f7f6f2;color:#1f1a17}"
+        "header{padding:.6rem 1rem;border-bottom:1px solid #e7e1d8;display:flex;gap:1rem;align-items:center}"
+        "header h1{font-size:1rem;margin:0;color:#9f4f24}"
+        "header .meta{color:#71675d;font-size:.85rem}"
+        ".grid{display:grid;height:calc(100vh - 56px);"
+        "grid-template-columns:1fr 360px;"
+        "grid-template-rows:1fr 260px;"
+        "gap:1px;background:#e7e1d8;}"
+        ".pane{background:#fffdfa;overflow:auto}"
+        ".pane iframe{width:100%;height:100%;border:0;display:block}"
+        ".pane.canvas{grid-row:1/2;grid-column:1/2}"
+        ".pane.timeline{grid-row:1/2;grid-column:2/3;padding:.4rem}"
+        ".pane.synth{grid-column:1/3;grid-row:2/3}"
+        "</style></head><body>"
+        "<header>"
+        "<h1>Explore</h1>"
+        f"<span class='meta'>object: <code id='ex-object'>{escape(object_id) or '∅'}</code></span>"
+        "<a href='/' style='margin-left:auto;color:#9f4f24;text-decoration:none'>← Shell</a>"
+        "</header>"
+        "<div class='grid'>"
+        f"<section class='pane canvas'><iframe id='pane-canvas' src='{escape(canvas_src)}'></iframe></section>"
+        f"<section class='pane timeline'>{_render_explore_fragment(object_id)}</section>"
+        f"<section class='pane synth'><iframe id='pane-synth' src='{escape(synth_src)}'></iframe></section>"
+        "</div>"
+        "<script>(function(){"
+        "function selectObject(id){"
+        "document.getElementById('pane-canvas').src=id?'/object/fragment?id='+encodeURIComponent(id):'/objects';"
+        "document.getElementById('pane-synth').src=id?'/object/fragment?id='+encodeURIComponent(id):'/objects';"
+        "document.getElementById('ex-object').textContent=id||'∅';"
+        "var url=new URL(window.location.href);"
+        "if(id){url.searchParams.set('object_id',id);}else{url.searchParams.delete('object_id');}"
+        "history.replaceState({},'',url.toString());"
+        "}"
+        "window.addEventListener('message',function(ev){"
+        "var d=ev.data;if(!d||typeof d!=='object')return;"
+        "if(d.type==='select_object'&&typeof d.id==='string'){selectObject(d.id);}"
+        "});"
+        "})();</script>"
+        "</body></html>"
+    )
+
+
 def create_server(
     vault_dir: Path | str, *, host: str = "127.0.0.1", port: int = 8787
 ) -> ThreadingHTTPServer:
@@ -4758,6 +4877,25 @@ def create_server(
                         poll_interval=poll_interval, max_polls=max_polls
                     )
                     return
+                if path == "/explore":
+                    object_id = query.get("object_id", [""])[0]
+                    self._write_html(_render_explore_page(object_id=object_id))
+                    return
+                if path == "/explore/stream":
+                    raw_max = query.get("max_polls", [""])[0]
+                    raw_interval = query.get("poll_interval", [""])[0]
+                    max_polls = int(raw_max) if raw_max else None
+                    poll_interval = float(raw_interval) if raw_interval else 1.0
+                    if poll_interval <= 0:
+                        self.send_error(400, "poll_interval must be > 0")
+                        return
+                    if max_polls is not None and max_polls < 0:
+                        self.send_error(400, "max_polls must be >= 0")
+                        return
+                    self._stream_agent_decisions_sse(
+                        poll_interval=poll_interval, max_polls=max_polls
+                    )
+                    return
                 self.send_error(404, "Not Found")
             except ValueError as exc:
                 self.send_error(400, str(exc))
@@ -5185,6 +5323,63 @@ def create_server(
                     frame = (
                         (f"id: {event_id}\n" if event_id else "")
                         + f"event: {event_type}\n"
+                        + f"data: {data}\n\n"
+                    ).encode("utf-8")
+                    try:
+                        self.wfile.write(frame)
+                        self.wfile.flush()
+                    except (BrokenPipeError, ConnectionResetError):
+                        return
+                if not events:
+                    try:
+                        self.wfile.write(b": keepalive\n\n")
+                        self.wfile.flush()
+                    except (BrokenPipeError, ConnectionResetError):
+                        return
+                time.sleep(poll_interval)
+
+        def _stream_agent_decisions_sse(
+            self,
+            *,
+            poll_interval: float = 1.0,
+            max_polls: int | None = None,
+        ) -> None:
+            """Phase 38 Stage C — tail ``60-Logs/agent-decisions.jsonl``.
+
+            Same poll/SSE machinery as ``_stream_pulse_sse``, but scoped to a
+            single log written by graph_ops invocations through the MCP
+            server. Each frame uses the ``agent_decision`` event name so the
+            UI subscribes selectively.
+            """
+            layout = VaultLayout.from_vault(resolved_vault)
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream; charset=utf-8")
+            self.send_header("Cache-Control", "no-cache")
+            self.send_header("X-Accel-Buffering", "no")
+            self.end_headers()
+
+            try:
+                self.wfile.write(b": ovp explore stream\n\n")
+                self.wfile.flush()
+            except (BrokenPipeError, ConnectionResetError):
+                return
+
+            logs = ("agent-decisions.jsonl",)
+            positions = initial_positions(layout, logs=logs)
+            polls = 0
+            while True:
+                if max_polls is not None and polls >= max_polls:
+                    return
+                polls += 1
+                events, positions = tail_events(
+                    layout, since_position=positions, logs=logs
+                )
+                for event in events:
+                    event_id = str(event.get("event_id") or "")
+                    data = json.dumps(event, ensure_ascii=False)
+                    frame = (
+                        (f"id: {event_id}\n" if event_id else "")
+                        + "event: agent_decision\n"
                         + f"data: {data}\n\n"
                     ).encode("utf-8")
                     try:

--- a/src/ovp_pipeline/graph/graph_ops.py
+++ b/src/ovp_pipeline/graph/graph_ops.py
@@ -1,0 +1,266 @@
+"""Phase 38 Stage C — graph operators backed by ``knowledge.db``.
+
+These operators give the MCP server and the ``/explore`` UI a single,
+budget-aware view over the same ``pages_index`` + ``page_links`` rows that
+``ovp-graph`` already consumes. The loader is deliberately a duplicate of
+``graph_cli._load_graph_from_index`` minus the audit-event provenance pass —
+operators only need the canonical wikilink graph; the provenance shim is a
+visualization concern that bloats the in-memory graph for shortest-path /
+betweenness queries.
+
+All operators return JSON-serializable dicts so they round-trip cleanly
+through the MCP envelope. Any operator that walks the graph respects the
+``max_nodes`` budget so a runaway BFS never melts the daemon.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import networkx as nx
+
+from ..runtime import VaultLayout, resolve_vault_dir
+
+
+def load_graph(vault_dir: Path | str | None = None) -> nx.MultiDiGraph:
+    """Build a ``MultiDiGraph`` from ``pages_index`` + ``page_links``.
+
+    Returns an empty graph when ``knowledge.db`` is missing — operators then
+    short-circuit to empty results rather than raising. Each node carries
+    its title and ``note_type`` as attributes; edges carry ``link_type``.
+    """
+    layout = VaultLayout(resolve_vault_dir(vault_dir))
+    graph: nx.MultiDiGraph = nx.MultiDiGraph()
+    if not layout.knowledge_db.exists():
+        return graph
+    with sqlite3.connect(layout.knowledge_db) as conn:
+        for slug, title, note_type, path in conn.execute(
+            "SELECT slug, title, note_type, path FROM pages_index"
+        ):
+            graph.add_node(
+                slug,
+                title=title or slug,
+                note_type=note_type or "unknown",
+                path=path or "",
+            )
+        for source_slug, target_slug, link_type in conn.execute(
+            "SELECT source_slug, target_slug, link_type FROM page_links"
+        ):
+            if not source_slug or not target_slug:
+                continue
+            if target_slug not in graph:
+                graph.add_node(target_slug, title=target_slug, note_type="unknown", path="")
+            if source_slug not in graph:
+                graph.add_node(source_slug, title=source_slug, note_type="unknown", path="")
+            graph.add_edge(source_slug, target_slug, link_type=link_type or "wikilink")
+    return graph
+
+
+def _node_payload(graph: nx.MultiDiGraph, node_id: str) -> dict[str, Any]:
+    data = graph.nodes[node_id]
+    return {
+        "object_id": node_id,
+        "title": data.get("title", node_id),
+        "note_type": data.get("note_type", "unknown"),
+        "path": data.get("path", ""),
+    }
+
+
+def node_details(graph: nx.MultiDiGraph, node_id: str) -> dict[str, Any]:
+    """Return node metadata, in/out neighbors, degree, and approximate
+    betweenness. ``betweenness`` is computed on a sampled subgraph capped at
+    200 nodes so a vault-scale graph stays under one second per call.
+    """
+    if node_id not in graph:
+        return {"object_id": node_id, "exists": False}
+
+    in_neighbors = [_node_payload(graph, src) for src in graph.predecessors(node_id)]
+    out_neighbors = [_node_payload(graph, tgt) for tgt in graph.successors(node_id)]
+
+    sample_nodes = list(graph.nodes)
+    if len(sample_nodes) > 200:
+        # Always keep the requested node + its 1-hop frontier so the
+        # estimate is meaningful for *this* node rather than a random slice.
+        keep = {node_id}
+        keep.update(graph.predecessors(node_id))
+        keep.update(graph.successors(node_id))
+        for nid in sample_nodes:
+            if len(keep) >= 200:
+                break
+            keep.add(nid)
+        sample_nodes = list(keep)
+    sub = graph.subgraph(sample_nodes)
+    try:
+        bc = nx.betweenness_centrality(nx.DiGraph(sub), normalized=True)
+    except Exception:
+        bc = {}
+
+    return {
+        "object_id": node_id,
+        "exists": True,
+        "node": _node_payload(graph, node_id),
+        "in_neighbors": in_neighbors,
+        "out_neighbors": out_neighbors,
+        "degree": graph.in_degree(node_id) + graph.out_degree(node_id),
+        "in_degree": graph.in_degree(node_id),
+        "out_degree": graph.out_degree(node_id),
+        "betweenness": float(bc.get(node_id, 0.0)),
+    }
+
+
+def neighborhood(
+    graph: nx.MultiDiGraph,
+    node_id: str,
+    *,
+    hop: int = 1,
+    max_nodes: int = 50,
+) -> dict[str, Any]:
+    """BFS the ``hop``-neighborhood of ``node_id`` undirected, capped at
+    ``max_nodes``. Edges between nodes inside the captured set are returned
+    so the caller can render a coherent sub-graph.
+    """
+    if node_id not in graph or hop <= 0 or max_nodes <= 0:
+        return {"object_id": node_id, "nodes": [], "edges": [], "truncated": False}
+
+    visited: set[str] = {node_id}
+    frontier: list[str] = [node_id]
+    truncated = False
+
+    for _ in range(hop):
+        next_frontier: list[str] = []
+        for nid in frontier:
+            for neighbor in list(graph.predecessors(nid)) + list(graph.successors(nid)):
+                if neighbor in visited:
+                    continue
+                if len(visited) >= max_nodes:
+                    truncated = True
+                    break
+                visited.add(neighbor)
+                next_frontier.append(neighbor)
+            if truncated:
+                break
+        if truncated or not next_frontier:
+            break
+        frontier = next_frontier
+
+    nodes_payload = [_node_payload(graph, nid) for nid in visited]
+    edges_payload: list[dict[str, Any]] = []
+    seen_edge: set[tuple[str, str, str]] = set()
+    for src, tgt, data in graph.edges(data=True):
+        if src not in visited or tgt not in visited:
+            continue
+        link_type = str(data.get("link_type") or "wikilink")
+        key = (src, tgt, link_type)
+        if key in seen_edge:
+            continue
+        seen_edge.add(key)
+        edges_payload.append({"source": src, "target": tgt, "link_type": link_type})
+
+    return {
+        "object_id": node_id,
+        "hop": hop,
+        "nodes": nodes_payload,
+        "edges": edges_payload,
+        "truncated": truncated,
+    }
+
+
+def shortest_path(
+    graph: nx.MultiDiGraph,
+    source: str,
+    target: str,
+) -> dict[str, Any] | None:
+    """Find the shortest *undirected* path between ``source`` and
+    ``target``. Wikilinks are inherently directional but reviewers think in
+    "is this concept reachable from that one" terms — bidirectional search
+    matches that mental model.
+    """
+    if source not in graph or target not in graph:
+        return None
+    undirected = graph.to_undirected(as_view=True)
+    try:
+        nodes = nx.shortest_path(undirected, source=source, target=target)
+    except nx.NetworkXNoPath:
+        return None
+    except nx.NodeNotFound:
+        return None
+    edges: list[dict[str, str]] = []
+    for src, tgt in zip(nodes, nodes[1:]):
+        if graph.has_edge(src, tgt):
+            link_type = next(iter(graph.get_edge_data(src, tgt).values())).get(
+                "link_type", "wikilink"
+            )
+            edges.append({"source": src, "target": tgt, "link_type": link_type})
+        elif graph.has_edge(tgt, src):
+            link_type = next(iter(graph.get_edge_data(tgt, src).values())).get(
+                "link_type", "wikilink"
+            )
+            edges.append({"source": tgt, "target": src, "link_type": link_type})
+    return {
+        "source": source,
+        "target": target,
+        "nodes": [_node_payload(graph, nid) for nid in nodes],
+        "edges": edges,
+        "length": len(nodes) - 1,
+    }
+
+
+def bridge_nodes(
+    graph: nx.MultiDiGraph,
+    *,
+    limit: int = 20,
+    sample_size: int = 200,
+) -> list[dict[str, Any]]:
+    """Top-``limit`` nodes by approximate betweenness centrality.
+
+    Betweenness on a vault-scale graph is O(V*E) — too slow for an
+    interactive call. We compute on a sampled subgraph (``sample_size``
+    nodes) which keeps it well under a second while still surfacing the
+    same kind of bridge nodes a full computation would.
+    """
+    if graph.number_of_nodes() == 0:
+        return []
+    sample_nodes = list(graph.nodes)
+    if len(sample_nodes) > sample_size:
+        sample_nodes = sample_nodes[:sample_size]
+    sub = nx.DiGraph(graph.subgraph(sample_nodes))
+    try:
+        bc = nx.betweenness_centrality(sub, normalized=True)
+    except Exception:
+        return []
+    ranked = sorted(bc.items(), key=lambda kv: kv[1], reverse=True)[:limit]
+    return [
+        {**_node_payload(graph, nid), "betweenness": float(score)}
+        for nid, score in ranked
+        if score > 0
+    ]
+
+
+def communities(
+    graph: nx.MultiDiGraph,
+    *,
+    algorithm: str = "label_prop",
+) -> dict[str, Any]:
+    """Cluster nodes into communities. ``label_prop`` is asynchronous label
+    propagation — fast, deterministic given the same graph + seed, and
+    unsupervised so we don't need to pick a cluster count up front.
+    """
+    if graph.number_of_nodes() == 0:
+        return {"algorithm": algorithm, "clusters": {}}
+    undirected = graph.to_undirected(as_view=True)
+    if algorithm == "label_prop":
+        from networkx.algorithms.community import asyn_lpa_communities
+
+        groups = list(asyn_lpa_communities(undirected, seed=42))
+    elif algorithm == "greedy_modularity":
+        from networkx.algorithms.community import greedy_modularity_communities
+
+        groups = list(greedy_modularity_communities(undirected))
+    else:
+        raise ValueError(f"Unknown community algorithm: {algorithm}")
+    clusters: dict[str, list[str]] = {}
+    for idx, group in enumerate(groups):
+        clusters[f"c{idx}"] = sorted(group)
+    return {"algorithm": algorithm, "clusters": clusters}

--- a/src/ovp_pipeline/graph/graph_ops.py
+++ b/src/ovp_pipeline/graph/graph_ops.py
@@ -15,6 +15,7 @@ through the MCP envelope. Any operator that walks the graph respects the
 
 from __future__ import annotations
 
+import random
 import sqlite3
 from pathlib import Path
 from typing import Any
@@ -148,9 +149,9 @@ def neighborhood(
     nodes_payload = [_node_payload(graph, nid) for nid in visited]
     edges_payload: list[dict[str, Any]] = []
     seen_edge: set[tuple[str, str, str]] = set()
-    for src, tgt, data in graph.edges(data=True):
-        if src not in visited or tgt not in visited:
-            continue
+    # Iterating subgraph edges is O(E_visited) instead of O(E_total) — matters
+    # once the vault graph dwarfs the captured neighborhood.
+    for src, tgt, data in graph.subgraph(visited).edges(data=True):
         link_type = str(data.get("link_type") or "wikilink")
         key = (src, tgt, link_type)
         if key in seen_edge:
@@ -212,19 +213,23 @@ def bridge_nodes(
     *,
     limit: int = 20,
     sample_size: int = 200,
+    seed: int = 42,
 ) -> list[dict[str, Any]]:
     """Top-``limit`` nodes by approximate betweenness centrality.
 
     Betweenness on a vault-scale graph is O(V*E) — too slow for an
     interactive call. We compute on a sampled subgraph (``sample_size``
     nodes) which keeps it well under a second while still surfacing the
-    same kind of bridge nodes a full computation would.
+    same kind of bridge nodes a full computation would. The sample is drawn
+    with a seeded RNG so the result is deterministic across calls but not
+    biased toward whatever order ``pages_index`` happened to load (which
+    would otherwise return only bridges from the alphabetical prefix).
     """
     if graph.number_of_nodes() == 0:
         return []
     sample_nodes = list(graph.nodes)
     if len(sample_nodes) > sample_size:
-        sample_nodes = sample_nodes[:sample_size]
+        sample_nodes = random.Random(seed).sample(sample_nodes, sample_size)
     sub = nx.DiGraph(graph.subgraph(sample_nodes))
     try:
         bc = nx.betweenness_centrality(sub, normalized=True)

--- a/src/ovp_pipeline/mcp_server.py
+++ b/src/ovp_pipeline/mcp_server.py
@@ -42,6 +42,7 @@ from .feedback_router import (
     route_writing_prompts,
 )
 from .extraction.semantic_relations import SemanticRelationCandidate
+from .graph import graph_ops
 from .pack_resolution import coerce_pack
 from .prompt_assembler import assemble as _assemble_prompt
 from .promotion_policy import (
@@ -49,7 +50,6 @@ from .promotion_policy import (
     evaluate_relation,
     evaluate_workspace,
 )
-
 
 # JSON-RPC 2.0 error codes (subset we actually emit).
 _PARSE_ERROR = -32700
@@ -140,6 +140,86 @@ _TOOLS_DESCRIPTORS: tuple[dict[str, Any], ...] = (
             },
         },
     },
+    {
+        "name": "graph_node_details",
+        "description": (
+            "Return metadata, in/out neighbors, degree, and approximate "
+            "betweenness for a node in the wikilink graph."
+        ),
+        "side_effects": "none (read-only over knowledge.db)",
+        "inputSchema": {
+            "type": "object",
+            "required": ["object_id"],
+            "properties": {"object_id": {"type": "string"}},
+        },
+    },
+    {
+        "name": "graph_neighborhood",
+        "description": (
+            "BFS the hop-neighborhood of a node, capped at max_nodes. "
+            "render='html' returns an SVG fragment in `_html_fragment` for "
+            "MCP Apps clients; render='json' (default) returns nodes/edges."
+        ),
+        "side_effects": "none (read-only over knowledge.db)",
+        "inputSchema": {
+            "type": "object",
+            "required": ["object_id"],
+            "properties": {
+                "object_id": {"type": "string"},
+                "hop": {"type": "integer", "minimum": 1, "maximum": 4},
+                "max_nodes": {"type": "integer", "minimum": 1, "maximum": 200},
+                "render": {"type": "string", "enum": ["json", "html"]},
+            },
+        },
+    },
+    {
+        "name": "graph_shortest_path",
+        "description": (
+            "Find the shortest undirected path between two nodes. Returns "
+            "{nodes, edges, length} or null when disconnected."
+        ),
+        "side_effects": "none (read-only over knowledge.db)",
+        "inputSchema": {
+            "type": "object",
+            "required": ["source", "target"],
+            "properties": {
+                "source": {"type": "string"},
+                "target": {"type": "string"},
+            },
+        },
+    },
+    {
+        "name": "graph_bridge_nodes",
+        "description": (
+            "Top-N nodes by approximate betweenness centrality — surfaces "
+            "the high-leverage bridges between communities."
+        ),
+        "side_effects": "none (read-only over knowledge.db)",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "limit": {"type": "integer", "minimum": 1, "maximum": 100},
+                "sample_size": {"type": "integer", "minimum": 10, "maximum": 1000},
+            },
+        },
+    },
+    {
+        "name": "graph_communities",
+        "description": (
+            "Cluster the wikilink graph. algorithm ∈ {label_prop, "
+            "greedy_modularity}. Returns {algorithm, clusters: {cid: [ids]}}."
+        ),
+        "side_effects": "none (read-only over knowledge.db)",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "algorithm": {
+                    "type": "string",
+                    "enum": ["label_prop", "greedy_modularity"],
+                }
+            },
+        },
+    },
 )
 
 
@@ -164,6 +244,11 @@ class MCPServer:
             "evaluate_promotion": self._tool_evaluate_promotion,
             "assemble_prompt": self._tool_assemble_prompt,
             "route_feedback": self._tool_route_feedback,
+            "graph_node_details": self._tool_graph_node_details,
+            "graph_neighborhood": self._tool_graph_neighborhood,
+            "graph_shortest_path": self._tool_graph_shortest_path,
+            "graph_bridge_nodes": self._tool_graph_bridge_nodes,
+            "graph_communities": self._tool_graph_communities,
         }
 
     # -- Public surface -----------------------------------------------------
@@ -226,9 +311,7 @@ class MCPServer:
         if not isinstance(method, str) or not method:
             return _error_envelope(request_id, _INVALID_REQUEST, "Missing method")
         if not isinstance(params, dict):
-            return _error_envelope(
-                request_id, _INVALID_PARAMS, "params must be an object"
-            )
+            return _error_envelope(request_id, _INVALID_PARAMS, "params must be an object")
 
         try:
             result = self._dispatch(method, params)
@@ -284,9 +367,7 @@ class MCPServer:
             # dict is also exposed under "result" for callers that want to
             # skip the JSON round-trip.
             return {
-                "content": [
-                    {"type": "text", "text": json.dumps(result, ensure_ascii=False)}
-                ],
+                "content": [{"type": "text", "text": json.dumps(result, ensure_ascii=False)}],
                 "isError": False,
                 "result": result,
             }
@@ -323,12 +404,8 @@ class MCPServer:
             draft_str = str(payload.get("draft", ""))
             target_str = str(payload.get("target", ""))
             if not draft_str or not target_str:
-                raise _InvalidParams(
-                    "workspace payload requires non-empty 'draft' and 'target'"
-                )
-            decision = evaluate_workspace(
-                Path(draft_str), Path(target_str), pack=pack_obj
-            )
+                raise _InvalidParams("workspace payload requires non-empty 'draft' and 'target'")
+            decision = evaluate_workspace(Path(draft_str), Path(target_str), pack=pack_obj)
         else:
             raise _InvalidParams(f"Unknown candidate_kind: {candidate_kind}")
         result = asdict(decision)
@@ -373,9 +450,7 @@ class MCPServer:
                 )
                 for item in items
             ]
-            written = route_candidate_concepts(
-                decoded, vault_dir=self.vault_dir, pack=pack_obj
-            )
+            written = route_candidate_concepts(decoded, vault_dir=self.vault_dir, pack=pack_obj)
             return {"stream": stream, "written": written}
         if stream == "open_question":
             decoded_q = [
@@ -385,9 +460,7 @@ class MCPServer:
                 )
                 for item in items
             ]
-            written = route_open_questions(
-                decoded_q, vault_dir=self.vault_dir, pack=pack_obj
-            )
+            written = route_open_questions(decoded_q, vault_dir=self.vault_dir, pack=pack_obj)
             return {"stream": stream, "written": written}
         if stream == "writing_prompt":
             decoded_p = [
@@ -397,17 +470,50 @@ class MCPServer:
                 )
                 for item in items
             ]
-            written = route_writing_prompts(
-                decoded_p, vault_dir=self.vault_dir, pack=pack_obj
-            )
+            written = route_writing_prompts(decoded_p, vault_dir=self.vault_dir, pack=pack_obj)
             return {"stream": stream, "written": written}
         if stream == "proposed_relation":
             decoded_r = [SemanticRelationCandidate.from_dict(item) for item in items]
-            paths = route_proposed_relations(
-                decoded_r, vault_dir=self.vault_dir, pack=pack_obj
-            )
+            paths = route_proposed_relations(decoded_r, vault_dir=self.vault_dir, pack=pack_obj)
             return {"stream": stream, "written": len(paths), "paths": [str(p) for p in paths]}
         raise _InvalidParams(f"Unknown stream: {stream}")
+
+    # -- Graph operators (Phase 38 Stage C) --------------------------------
+
+    def _tool_graph_node_details(self, *, object_id: str) -> dict[str, Any]:
+        graph = graph_ops.load_graph(self.vault_dir)
+        return graph_ops.node_details(graph, object_id)
+
+    def _tool_graph_neighborhood(
+        self,
+        *,
+        object_id: str,
+        hop: int = 1,
+        max_nodes: int = 50,
+        render: str = "json",
+    ) -> dict[str, Any]:
+        graph = graph_ops.load_graph(self.vault_dir)
+        result = graph_ops.neighborhood(graph, object_id, hop=hop, max_nodes=max_nodes)
+        if render == "html":
+            result["_html_fragment"] = _neighborhood_svg_fragment(result)
+        return result
+
+    def _tool_graph_shortest_path(self, *, source: str, target: str) -> dict[str, Any]:
+        graph = graph_ops.load_graph(self.vault_dir)
+        result = graph_ops.shortest_path(graph, source, target)
+        return (
+            result if result is not None else {"source": source, "target": target, "found": False}
+        )
+
+    def _tool_graph_bridge_nodes(
+        self, *, limit: int = 20, sample_size: int = 200
+    ) -> dict[str, Any]:
+        graph = graph_ops.load_graph(self.vault_dir)
+        return {"bridges": graph_ops.bridge_nodes(graph, limit=limit, sample_size=sample_size)}
+
+    def _tool_graph_communities(self, *, algorithm: str = "label_prop") -> dict[str, Any]:
+        graph = graph_ops.load_graph(self.vault_dir)
+        return graph_ops.communities(graph, algorithm=algorithm)
 
 
 # ---------------------------------------------------------------------------
@@ -423,14 +529,81 @@ class _InvalidParams(Exception):
     """Sentinel for the JSON-RPC invalid_params envelope."""
 
 
-def _error_envelope(
-    request_id: Any, code: int, message: str
-) -> dict[str, Any]:
+def _error_envelope(request_id: Any, code: int, message: str) -> dict[str, Any]:
     return {
         "jsonrpc": "2.0",
         "id": request_id,
         "error": {"code": code, "message": message},
     }
+
+
+def _neighborhood_svg_fragment(result: dict[str, Any]) -> str:
+    """Render a self-contained SVG card for a ``neighborhood`` result.
+
+    Uses networkx ``spring_layout`` for static positions — small, no JS, and
+    safe to drop into an iframe. The center node is the queried ``object_id``
+    so reviewers can orient at a glance. This is the experimental MCP Apps
+    payload — Claude Desktop ignores ``_html_fragment`` today, but a client
+    that honors the convention can render the card inline.
+    """
+    import math
+
+    nodes = list(result.get("nodes") or [])
+    edges = list(result.get("edges") or [])
+    if not nodes:
+        return '<div id="cy-neighborhood" data-empty="true">no nodes</div>'
+
+    width = 400
+    height = 300
+    cx, cy = width / 2, height / 2
+    radius = 110
+
+    center_id = str(result.get("object_id") or nodes[0]["object_id"])
+    others = [n for n in nodes if n["object_id"] != center_id]
+    positions: dict[str, tuple[float, float]] = {center_id: (cx, cy)}
+    n_others = max(len(others), 1)
+    for idx, node in enumerate(others):
+        theta = 2 * math.pi * idx / n_others
+        positions[node["object_id"]] = (
+            cx + radius * math.cos(theta),
+            cy + radius * math.sin(theta),
+        )
+
+    edge_svgs: list[str] = []
+    for edge in edges:
+        src = positions.get(str(edge.get("source")))
+        tgt = positions.get(str(edge.get("target")))
+        if not src or not tgt:
+            continue
+        edge_svgs.append(
+            f'<line x1="{src[0]:.1f}" y1="{src[1]:.1f}" '
+            f'x2="{tgt[0]:.1f}" y2="{tgt[1]:.1f}" '
+            f'stroke="#9ca3af" stroke-width="1" />'
+        )
+
+    node_svgs: list[str] = []
+    for node in nodes:
+        nid = str(node["object_id"])
+        x, y = positions[nid]
+        is_center = nid == center_id
+        fill = "#2563eb" if is_center else "#e5e7eb"
+        text_fill = "#ffffff" if is_center else "#111827"
+        title = str(node.get("title") or nid)[:20]
+        node_svgs.append(
+            f'<g><circle cx="{x:.1f}" cy="{y:.1f}" r="14" fill="{fill}" '
+            f'stroke="#374151" stroke-width="1" />'
+            f'<text x="{x:.1f}" y="{y + 4:.1f}" font-size="9" '
+            f'text-anchor="middle" fill="{text_fill}">{title}</text></g>'
+        )
+
+    return (
+        f'<div id="cy-neighborhood" data-object-id="{center_id}">'
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" '
+        f'viewBox="0 0 {width} {height}">'
+        + "".join(edge_svgs)
+        + "".join(node_svgs)
+        + "</svg></div>"
+    )
 
 
 def _concept_entry_from_payload(payload: dict[str, Any]) -> ConceptEntry:

--- a/src/ovp_pipeline/mcp_server.py
+++ b/src/ovp_pipeline/mcp_server.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import json
 import sys
 from dataclasses import asdict
+from html import escape
 from pathlib import Path
 from typing import Any, Callable, ClassVar, IO
 
@@ -540,11 +541,13 @@ def _error_envelope(request_id: Any, code: int, message: str) -> dict[str, Any]:
 def _neighborhood_svg_fragment(result: dict[str, Any]) -> str:
     """Render a self-contained SVG card for a ``neighborhood`` result.
 
-    Uses networkx ``spring_layout`` for static positions — small, no JS, and
-    safe to drop into an iframe. The center node is the queried ``object_id``
-    so reviewers can orient at a glance. This is the experimental MCP Apps
-    payload — Claude Desktop ignores ``_html_fragment`` today, but a client
-    that honors the convention can render the card inline.
+    Uses a deterministic circular layout — small, no JS, and safe to drop
+    into an iframe. The center node is the queried ``object_id`` so reviewers
+    can orient at a glance. This is the experimental MCP Apps payload —
+    Claude Desktop ignores ``_html_fragment`` today, but a client that honors
+    the convention can render the card inline. All user-supplied strings are
+    HTML-escaped before interpolation so titles like ``"A & B"`` round-trip
+    safely through XML.
     """
     import math
 
@@ -588,7 +591,7 @@ def _neighborhood_svg_fragment(result: dict[str, Any]) -> str:
         is_center = nid == center_id
         fill = "#2563eb" if is_center else "#e5e7eb"
         text_fill = "#ffffff" if is_center else "#111827"
-        title = str(node.get("title") or nid)[:20]
+        title = escape(str(node.get("title") or nid)[:20])
         node_svgs.append(
             f'<g><circle cx="{x:.1f}" cy="{y:.1f}" r="14" fill="{fill}" '
             f'stroke="#374151" stroke-width="1" />'
@@ -597,7 +600,7 @@ def _neighborhood_svg_fragment(result: dict[str, Any]) -> str:
         )
 
     return (
-        f'<div id="cy-neighborhood" data-object-id="{center_id}">'
+        f'<div id="cy-neighborhood" data-object-id="{escape(center_id, quote=True)}">'
         f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" '
         f'viewBox="0 0 {width} {height}">'
         + "".join(edge_svgs)

--- a/tests/test_explore_ui.py
+++ b/tests/test_explore_ui.py
@@ -1,0 +1,132 @@
+"""Phase 38 Stage C — /explore reviewer surface + agent-decisions SSE."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+from ovp_pipeline.commands.ui_server import (
+    _render_explore_fragment,
+    _render_explore_page,
+    create_server,
+)
+from ovp_pipeline.runtime import VaultLayout
+
+_NO_PROXY_OPENER = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+
+
+# ---------------------------------------------------------------------------
+# Pure renderer tests
+# ---------------------------------------------------------------------------
+
+
+def test_render_explore_page_includes_three_panes() -> None:
+    html = _render_explore_page(object_id="alpha")
+    assert "id='pane-canvas'" in html
+    assert "id='pane-synth'" in html
+    assert "agent-feed" in html  # the timeline pane is the SSE fragment
+
+
+def test_render_explore_page_threads_object_id_into_canvas_and_synthesis() -> None:
+    html = _render_explore_page(object_id="alpha")
+    assert "/object/fragment?id=alpha" in html
+    # Both canvas and synthesis iframes resolve to the object fragment.
+    assert html.count("/object/fragment?id=alpha") >= 2
+
+
+def test_render_explore_page_falls_back_when_no_object_selected() -> None:
+    html = _render_explore_page(object_id="")
+    # Without an object id, both iframes default to /objects.
+    assert "id='pane-canvas' src='/objects'" in html
+    assert "id='pane-synth' src='/objects'" in html
+
+
+def test_render_explore_fragment_targets_explore_stream() -> None:
+    fragment = _render_explore_fragment("alpha")
+    # The SSE source must include the object_id query so the server can
+    # later (Phase 38+) scope decisions; today it just round-trips.
+    assert "EventSource('/explore/stream?object_id=alpha')" in fragment
+    assert "agent_decision" in fragment
+
+
+# ---------------------------------------------------------------------------
+# Live HTTP route + SSE round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def running_server(temp_vault: Path):
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def _server_url(server, path: str) -> str:
+    host, port = server.server_address
+    return f"http://{host}:{port}{path}"
+
+
+def _fetch(server, path: str) -> str:
+    with _NO_PROXY_OPENER.open(_server_url(server, path), timeout=5) as resp:
+        assert resp.status == 200
+        return resp.read().decode("utf-8")
+
+
+def test_explore_route_returns_three_pane_html(running_server) -> None:
+    body = _fetch(running_server, "/explore?object_id=alpha")
+    assert "<title>Explore</title>" in body
+    assert "id='pane-canvas'" in body
+    assert "id='pane-synth'" in body
+    assert "agent-feed" in body
+
+
+def test_explore_navbar_link_present(running_server) -> None:
+    home = _fetch(running_server, "/")
+    assert 'href="/explore"' in home
+
+
+def test_explore_stream_round_trips_one_synthetic_event(temp_vault: Path, running_server) -> None:
+    """The SSE handler captures byte offsets at connect time, then any new
+    line appended to ``agent-decisions.jsonl`` becomes one ``agent_decision``
+    SSE frame on the next poll."""
+    url = _server_url(running_server, "/explore/stream?max_polls=8&poll_interval=0.05")
+    body_holder: dict[str, str] = {}
+
+    def consume() -> None:
+        with _NO_PROXY_OPENER.open(url, timeout=10) as response:
+            body_holder["body"] = response.read().decode("utf-8")
+
+    consumer = threading.Thread(target=consume, daemon=True)
+    consumer.start()
+
+    time.sleep(0.15)
+    layout = VaultLayout.from_vault(temp_vault)
+    layout.logs_dir.mkdir(parents=True, exist_ok=True)
+    decision_log = layout.logs_dir / "agent-decisions.jsonl"
+    decision_log.write_text(
+        json.dumps(
+            {
+                "ts": "2026-04-24T12:00:00Z",
+                "tool": "graph_neighborhood",
+                "arguments": {"object_id": "alpha", "hop": 1},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    consumer.join(timeout=5)
+    body = body_holder.get("body", "")
+    assert "event: agent_decision" in body
+    assert "graph_neighborhood" in body

--- a/tests/test_graph_ops.py
+++ b/tests/test_graph_ops.py
@@ -1,0 +1,151 @@
+"""Phase 38 Stage C — graph_ops operators.
+
+Coverage:
+* ``load_graph`` returns an empty graph for a vault without ``knowledge.db``
+* ``load_graph`` reads ``pages_index`` + ``page_links`` after a rebuild
+* ``node_details`` reports degree + neighbors for a synthetic 5-node graph
+* ``neighborhood`` respects ``hop`` and ``max_nodes`` budgets
+* ``shortest_path`` finds the obvious path; returns None when disconnected
+* ``bridge_nodes`` ranks the central node above leaves
+* ``communities`` returns a non-empty cluster map for a multi-component graph
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import networkx as nx
+import pytest
+
+from ovp_pipeline.graph import graph_ops
+from ovp_pipeline.runtime import VaultLayout
+
+
+def _star_graph() -> nx.MultiDiGraph:
+    """5-node star: hub <-> {a, b, c, d}. Hub is the obvious bridge."""
+    g: nx.MultiDiGraph = nx.MultiDiGraph()
+    for nid in ("hub", "a", "b", "c", "d"):
+        g.add_node(nid, title=nid.upper(), note_type="evergreen", path=f"{nid}.md")
+    for leaf in ("a", "b", "c", "d"):
+        g.add_edge("hub", leaf, link_type="wikilink")
+        g.add_edge(leaf, "hub", link_type="wikilink")
+    return g
+
+
+def _two_component_graph() -> nx.MultiDiGraph:
+    g: nx.MultiDiGraph = nx.MultiDiGraph()
+    for nid in ("a1", "a2", "a3", "b1", "b2"):
+        g.add_node(nid, title=nid, note_type="evergreen", path=f"{nid}.md")
+    g.add_edge("a1", "a2", link_type="wikilink")
+    g.add_edge("a2", "a3", link_type="wikilink")
+    g.add_edge("b1", "b2", link_type="wikilink")
+    return g
+
+
+def test_load_graph_empty_when_no_knowledge_db(temp_vault):
+    g = graph_ops.load_graph(temp_vault)
+    assert g.number_of_nodes() == 0
+    assert g.number_of_edges() == 0
+
+
+def test_load_graph_reads_pages_index_and_page_links(temp_vault):
+    layout = VaultLayout.from_vault(temp_vault)
+    layout.knowledge_db.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(layout.knowledge_db) as conn:
+        conn.executescript("""
+            CREATE TABLE pages_index (
+                slug TEXT PRIMARY KEY, title TEXT, note_type TEXT, path TEXT, day_id TEXT
+            );
+            CREATE TABLE page_links (
+                source_slug TEXT, target_slug TEXT, target_raw TEXT,
+                link_type TEXT, line_number INTEGER
+            );
+            """)
+        conn.executemany(
+            "INSERT INTO pages_index (slug, title, note_type, path, day_id) VALUES (?, ?, ?, ?, ?)",
+            [
+                ("rag", "RAG", "evergreen", "10-Knowledge/Evergreen/RAG.md", ""),
+                ("agent", "Agent", "evergreen", "10-Knowledge/Evergreen/Agent.md", ""),
+            ],
+        )
+        conn.execute(
+            "INSERT INTO page_links (source_slug, target_slug, target_raw, link_type, line_number)"
+            " VALUES ('agent', 'rag', 'RAG', 'wikilink', 1)"
+        )
+        conn.commit()
+
+    g = graph_ops.load_graph(temp_vault)
+    assert g.number_of_nodes() == 2
+    assert g.has_edge("agent", "rag")
+    assert g.nodes["rag"]["title"] == "RAG"
+
+
+def test_node_details_reports_neighbors_and_degree():
+    g = _star_graph()
+    details = graph_ops.node_details(g, "hub")
+    assert details["exists"] is True
+    assert details["degree"] == 8  # 4 in + 4 out
+    assert {n["object_id"] for n in details["in_neighbors"]} == {"a", "b", "c", "d"}
+    assert {n["object_id"] for n in details["out_neighbors"]} == {"a", "b", "c", "d"}
+    assert details["betweenness"] > 0.0
+
+
+def test_node_details_missing_node_returns_exists_false():
+    g = _star_graph()
+    assert graph_ops.node_details(g, "missing")["exists"] is False
+
+
+def test_neighborhood_respects_hop_and_max_nodes_budget():
+    g = _star_graph()
+    one_hop = graph_ops.neighborhood(g, "hub", hop=1, max_nodes=50)
+    assert {n["object_id"] for n in one_hop["nodes"]} == {"hub", "a", "b", "c", "d"}
+    assert one_hop["truncated"] is False
+
+    capped = graph_ops.neighborhood(g, "hub", hop=1, max_nodes=2)
+    # hub itself + at most one more
+    assert len(capped["nodes"]) <= 2
+    assert capped["truncated"] is True
+
+
+def test_shortest_path_finds_undirected_path():
+    g = _star_graph()
+    path = graph_ops.shortest_path(g, "a", "b")
+    assert path is not None
+    assert path["length"] == 2  # a -> hub -> b
+    assert [n["object_id"] for n in path["nodes"]] == ["a", "hub", "b"]
+
+
+def test_shortest_path_returns_none_when_disconnected():
+    g = _two_component_graph()
+    assert graph_ops.shortest_path(g, "a1", "b1") is None
+
+
+def test_shortest_path_returns_none_for_unknown_node():
+    g = _star_graph()
+    assert graph_ops.shortest_path(g, "hub", "ghost") is None
+
+
+def test_bridge_nodes_ranks_hub_first():
+    g = _star_graph()
+    bridges = graph_ops.bridge_nodes(g, limit=5)
+    assert bridges, "expected at least one bridge node"
+    assert bridges[0]["object_id"] == "hub"
+
+
+def test_bridge_nodes_empty_graph():
+    assert graph_ops.bridge_nodes(nx.MultiDiGraph()) == []
+
+
+def test_communities_returns_non_empty_clusters():
+    g = _two_component_graph()
+    out = graph_ops.communities(g, algorithm="label_prop")
+    assert out["algorithm"] == "label_prop"
+    assert len(out["clusters"]) >= 2
+    flat = [nid for ids in out["clusters"].values() for nid in ids]
+    assert set(flat) == {"a1", "a2", "a3", "b1", "b2"}
+
+
+def test_communities_unknown_algorithm_raises():
+    g = _star_graph()
+    with pytest.raises(ValueError):
+        graph_ops.communities(g, algorithm="unknown")

--- a/tests/test_mcp_graph_tools.py
+++ b/tests/test_mcp_graph_tools.py
@@ -1,0 +1,114 @@
+"""Phase 38 Stage C — MCP server graph tools.
+
+Coverage:
+* ``tools/list`` exposes the 5 new graph tool descriptors
+* ``graph_node_details`` round-trips through the JSON-RPC envelope
+* ``graph_neighborhood`` with ``render="html"`` returns ``_html_fragment`` containing an ``<svg>``
+* ``graph_neighborhood`` with default ``render="json"`` omits ``_html_fragment``
+* ``graph_shortest_path`` returns ``found=False`` when nodes are disconnected
+* ``graph_communities`` returns a non-empty cluster map for a multi-component graph
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+from ovp_pipeline.mcp_server import MCPServer
+from ovp_pipeline.runtime import VaultLayout
+
+
+def _seed_three_node_graph(vault_dir):
+    layout = VaultLayout.from_vault(vault_dir)
+    layout.knowledge_db.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(layout.knowledge_db) as conn:
+        conn.executescript("""
+            CREATE TABLE pages_index (
+                slug TEXT PRIMARY KEY, title TEXT, note_type TEXT, path TEXT, day_id TEXT
+            );
+            CREATE TABLE page_links (
+                source_slug TEXT, target_slug TEXT, target_raw TEXT,
+                link_type TEXT, line_number INTEGER
+            );
+            """)
+        conn.executemany(
+            "INSERT INTO pages_index (slug, title, note_type, path, day_id) VALUES (?, ?, ?, ?, ?)",
+            [
+                ("rag", "RAG", "evergreen", "10-Knowledge/Evergreen/RAG.md", ""),
+                ("agent", "Agent", "evergreen", "10-Knowledge/Evergreen/Agent.md", ""),
+                ("orphan", "Orphan", "evergreen", "10-Knowledge/Evergreen/Orphan.md", ""),
+            ],
+        )
+        conn.execute(
+            "INSERT INTO page_links (source_slug, target_slug, target_raw, link_type, line_number)"
+            " VALUES ('agent', 'rag', 'RAG', 'wikilink', 1)"
+        )
+        conn.commit()
+
+
+def test_tools_list_includes_graph_tools(temp_vault):
+    server = MCPServer(temp_vault)
+    names = {t["name"] for t in server.list_tools()}
+    assert {
+        "graph_node_details",
+        "graph_neighborhood",
+        "graph_shortest_path",
+        "graph_bridge_nodes",
+        "graph_communities",
+    } <= names
+
+
+def test_graph_node_details_round_trips_jsonrpc(temp_vault):
+    _seed_three_node_graph(temp_vault)
+    server = MCPServer(temp_vault)
+    request = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": "graph_node_details", "arguments": {"object_id": "rag"}},
+    }
+    reply = server.handle_line(json.dumps(request))
+    assert reply is not None
+    result = reply["result"]["result"]
+    assert result["exists"] is True
+    assert result["in_degree"] == 1
+    assert {n["object_id"] for n in result["in_neighbors"]} == {"agent"}
+
+
+def test_graph_neighborhood_html_render_returns_svg_fragment(temp_vault):
+    _seed_three_node_graph(temp_vault)
+    server = MCPServer(temp_vault)
+    result = server.call_tool(
+        "graph_neighborhood",
+        {"object_id": "rag", "hop": 1, "render": "html"},
+    )
+    assert "_html_fragment" in result
+    fragment = result["_html_fragment"]
+    assert "<svg" in fragment
+    assert 'id="cy-neighborhood"' in fragment
+
+
+def test_graph_neighborhood_json_render_omits_html_fragment(temp_vault):
+    _seed_three_node_graph(temp_vault)
+    server = MCPServer(temp_vault)
+    result = server.call_tool(
+        "graph_neighborhood",
+        {"object_id": "rag", "hop": 1},  # render defaults to "json"
+    )
+    assert "_html_fragment" not in result
+    assert {n["object_id"] for n in result["nodes"]} == {"rag", "agent"}
+
+
+def test_graph_shortest_path_found_false_when_disconnected(temp_vault):
+    _seed_three_node_graph(temp_vault)
+    server = MCPServer(temp_vault)
+    result = server.call_tool("graph_shortest_path", {"source": "rag", "target": "orphan"})
+    assert result == {"source": "rag", "target": "orphan", "found": False}
+
+
+def test_graph_communities_returns_clusters(temp_vault):
+    _seed_three_node_graph(temp_vault)
+    server = MCPServer(temp_vault)
+    result = server.call_tool("graph_communities", {})
+    assert result["algorithm"] == "label_prop"
+    assert len(result["clusters"]) >= 1

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -26,7 +26,17 @@ def test_tools_list_returns_three_descriptors(temp_vault: Path) -> None:
     assert reply["id"] == 1
     tools = reply["result"]["tools"]
     names = sorted(t["name"] for t in tools)
-    assert names == ["assemble_prompt", "evaluate_promotion", "route_feedback"]
+    # Phase 38 Stage C added 5 graph operators alongside the 3 compiler primitives.
+    assert names == [
+        "assemble_prompt",
+        "evaluate_promotion",
+        "graph_bridge_nodes",
+        "graph_communities",
+        "graph_neighborhood",
+        "graph_node_details",
+        "graph_shortest_path",
+        "route_feedback",
+    ]
     # Every descriptor must declare its side effects so MCP clients can gate
     # writes when running a dry-run preview.
     for tool in tools:
@@ -303,6 +313,11 @@ def test_list_tools_direct(temp_vault: Path) -> None:
         "evaluate_promotion",
         "assemble_prompt",
         "route_feedback",
+        "graph_node_details",
+        "graph_neighborhood",
+        "graph_shortest_path",
+        "graph_bridge_nodes",
+        "graph_communities",
     }
 
 


### PR DESCRIPTION
## Summary

Stage C of Phase 38 — closes the link-density loop opened in Stages A (#59) and B (#61) by giving reviewers a graph-native exploration surface and exposing graph operators to MCP clients.

- **`src/ovp_pipeline/graph/graph_ops.py`** (new, ~250 LOC) — single budget-aware view over `pages_index` + `page_links`. 6 operators:
  - `load_graph(vault_dir)` returns `nx.MultiDiGraph` (empty when `knowledge.db` missing)
  - `node_details` — degree, in/out neighbors, sampled betweenness (200-node subgraph keeps interactive call <1s)
  - `neighborhood` — undirected BFS respecting `hop` + `max_nodes` budget; reports `truncated`
  - `shortest_path` — undirected (reviewers think reachability, even though wikilinks are directional)
  - `bridge_nodes` — top-N by sampled betweenness
  - `communities` — `label_prop` (asyn_lpa, seed=42) and `greedy_modularity`
- **`src/ovp_pipeline/mcp_server.py`** — 5 new read-only graph tools (`graph_node_details`, `graph_neighborhood`, `graph_shortest_path`, `graph_bridge_nodes`, `graph_communities`). `graph_neighborhood` accepts `render="json"|"html"` — the HTML variant returns an `_html_fragment` SVG card per the Stage C MCP Apps experiment.
- **`src/ovp_pipeline/commands/ui_server.py`** — new `/explore?object_id=<id>` 3-pane reviewer surface (canvas / agent-decisions timeline / synthesis) plus `/explore/stream` SSE endpoint tailing `60-Logs/agent-decisions.jsonl`. Explore link added to navbar.

25 new tests (12 graph_ops + 6 MCP graph + 7 explore UI). Pre-existing MCP descriptor tests updated for the 8-tool surface.

## Test plan
- [x] `pytest tests/test_graph_ops.py tests/test_mcp_graph_tools.py tests/test_explore_ui.py tests/test_mcp_server.py -q` — 47/47 pass
- [ ] Smoke: `ovp-mcp --call graph_neighborhood --json '{"object_id":"<id>","hop":2,"render":"html"}'` returns HTML fragment with `<svg>`
- [ ] Smoke: `ovp-ui` → `/explore?object_id=<known-id>` renders three panes; SSE timeline updates as MCP graph tools run
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/62" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added Explore page displaying live agent decisions timeline with integrated graph canvas and synthesis visualization panes
- Introduced graph analysis suite including node inspection, neighborhood exploration with depth/size controls, shortest-path computation, community detection, and influential node ranking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->