### PR TITLE
Fix Phase 38 review findings and Stage B follow-ups

### DIFF
--- a/src/ovp_pipeline/commands/link_suggest.py
+++ b/src/ovp_pipeline/commands/link_suggest.py
@@ -31,6 +31,7 @@ from typing import Any
 try:
     from ..runtime import VaultLayout, resolve_vault_dir
     from ..knowledge_index import (
+        ensure_knowledge_db_current,
         query_knowledge_index,
         sanitize_fts_query,
         search_knowledge_index,
@@ -38,6 +39,7 @@ try:
 except ImportError:
     from ovp_pipeline.runtime import VaultLayout, resolve_vault_dir  # type: ignore
     from ovp_pipeline.knowledge_index import (  # type: ignore
+        ensure_knowledge_db_current,
         query_knowledge_index,
         sanitize_fts_query,
         search_knowledge_index,
@@ -258,6 +260,10 @@ def run_link_suggest(
     layout = VaultLayout.from_vault(vault_dir)
     if apply and not confirm:
         raise ValueError("--apply requires --confirm")
+
+    # Materialize knowledge.db before the first SQLite read; otherwise a
+    # fresh-clone vault hits "unable to open database file" / "no such table".
+    ensure_knowledge_db_current(layout.vault_dir)
 
     pages = _iter_under_linked_pages(
         layout, min_links=min_links, note_types=note_types, limit=limit

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -5407,6 +5407,7 @@ def create_server(
                     return
                 polls += 1
                 events, positions = tail_events(layout, since_position=positions, logs=logs)
+                emitted = False
                 for event in events:
                     if object_id and not _event_matches_object(event, object_id):
                         continue
@@ -5422,7 +5423,14 @@ def create_server(
                         self.wfile.flush()
                     except (BrokenPipeError, ConnectionResetError):
                         return
-                if not events:
+                    emitted = True
+                if not emitted:
+                    # Send a keepalive whenever no frame was written this poll
+                    # — including the case where every tailed event was
+                    # filtered out by ``object_id``. Without this, a client
+                    # watching an idle object behind a chatty log never
+                    # triggers a wfile.write and we can't detect disconnects,
+                    # leaking one thread + socket per stale viewer.
                     try:
                         self.wfile.write(b": keepalive\n\n")
                         self.wfile.flush()

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -287,15 +287,21 @@ def _render_assembly_contract_card(payload: dict) -> str:
         item
         for item in (
             f"<li>Recipe kind: {escape(recipe_kind)}</li>" if recipe_kind else "",
-            f"<li>Source contract: {escape(source_contract_kind)} · {escape(source_contract_name)}</li>"
-            if source_contract_kind or source_contract_name
-            else "",
-            f"<li>Source provider: {escape(source_provider_pack)} · {escape(source_provider_name)}</li>"
-            if source_provider_pack or source_provider_name
-            else "",
-            f"<li>Output: {escape(output_mode)} → {escape(publish_target)}</li>"
-            if output_mode or publish_target
-            else "",
+            (
+                f"<li>Source contract: {escape(source_contract_kind)} · {escape(source_contract_name)}</li>"
+                if source_contract_kind or source_contract_name
+                else ""
+            ),
+            (
+                f"<li>Source provider: {escape(source_provider_pack)} · {escape(source_provider_name)}</li>"
+                if source_provider_pack or source_provider_name
+                else ""
+            ),
+            (
+                f"<li>Output: {escape(output_mode)} → {escape(publish_target)}</li>"
+                if output_mode or publish_target
+                else ""
+            ),
         )
     )
     description_html = f"<p class='muted'>{escape(description)}</p>" if description else ""
@@ -750,9 +756,10 @@ def _read_vault_asset(vault_dir: Path, relative_path: str) -> tuple[bytes, str]:
         raise ValueError("invalid asset path") from exc
     if not candidate.is_file():
         raise ValueError(f"asset not found: {relative_path}")
-    return candidate.read_bytes(), mimetypes.guess_type(candidate.name)[
-        0
-    ] or "application/octet-stream"
+    return (
+        candidate.read_bytes(),
+        mimetypes.guess_type(candidate.name)[0] or "application/octet-stream",
+    )
 
 
 def _lookup_wikilink_target(
@@ -3236,8 +3243,7 @@ def _render_briefing_page(payload: dict) -> str:
     skipped_signal_count = _safe_count(background_policy.get("skipped_signal_count"))
     failure_buckets = (
         "".join(
-            f"<li><span class='pill'>{escape(str(bucket))}</span> "
-            f"{_safe_count(count)}</li>"
+            f"<li><span class='pill'>{escape(str(bucket))}</span> " f"{_safe_count(count)}</li>"
             for bucket, count in failure_bucket_values.items()
         )
         or "<li class='muted'>No failed actions.</li>"
@@ -3957,7 +3963,9 @@ def _build_writing_prompts_payload(vault_dir: Path) -> dict:
 def _render_open_questions_fragment(payload: dict) -> str:
     rows = payload.get("questions") or []
     if not rows:
-        return "<section class='open-questions'><p class='empty'>No open questions yet.</p></section>"
+        return (
+            "<section class='open-questions'><p class='empty'>No open questions yet.</p></section>"
+        )
     items = "".join(
         f"<li><strong>{escape(str(row.get('question') or ''))}</strong>"
         f" <small>{escape(str(row.get('ts') or ''))}</small></li>"
@@ -4156,9 +4164,15 @@ def _render_workbench_page(*, object_id: str, requested_pack: str) -> str:
     # Fragment URLs. Candidate / Briefing / Actions are pack-aware but do not
     # care about the object id; Object pane needs the id and is hidden when
     # none is selected (the iframe falls back to the Objects index).
-    cand_src = "/candidates/fragment" + (f"?pack={quote(requested_pack, safe='')}" if requested_pack else "")
-    actions_src = "/actions/fragment" + (f"?pack={quote(requested_pack, safe='')}" if requested_pack else "")
-    briefing_src = "/briefing/fragment" + (f"?pack={quote(requested_pack, safe='')}" if requested_pack else "")
+    cand_src = "/candidates/fragment" + (
+        f"?pack={quote(requested_pack, safe='')}" if requested_pack else ""
+    )
+    actions_src = "/actions/fragment" + (
+        f"?pack={quote(requested_pack, safe='')}" if requested_pack else ""
+    )
+    briefing_src = "/briefing/fragment" + (
+        f"?pack={quote(requested_pack, safe='')}" if requested_pack else ""
+    )
     object_src = (
         f"/object/fragment?id={quote(object_id, safe='')}"
         + (f"&pack={quote(requested_pack, safe='')}" if requested_pack else "")
@@ -4166,6 +4180,10 @@ def _render_workbench_page(*, object_id: str, requested_pack: str) -> str:
         else "/objects" + (f"?pack={quote(requested_pack, safe='')}" if requested_pack else "")
     )
     pulse_src = "/pulse/fragment"
+    # ``</`` would close the surrounding <script> block early — escape it the
+    # same way graph/visualize.py does for inline JSON-in-HTML. Precomputed
+    # because Python 3.10 disallows backslashes inside f-string expressions.
+    pack_json = json.dumps(requested_pack).replace("</", "<\\/")
 
     return (
         "<!doctype html><html lang='en'><head><meta charset='utf-8'>"
@@ -4203,7 +4221,7 @@ def _render_workbench_page(*, object_id: str, requested_pack: str) -> str:
         f"<section class='pane pulse'><iframe id='pane-pulse' src='{escape(pulse_src)}'></iframe></section>"
         "</div>"
         "<script>(function(){"
-        f"var pack={json.dumps(requested_pack)};"
+        f"var pack={pack_json};"
         "function selectObject(id){"
         "var packQs=pack?'&pack='+encodeURIComponent(pack):'';"
         "var packQsLead=pack?'?pack='+encodeURIComponent(pack):'';"
@@ -4222,6 +4240,22 @@ def _render_workbench_page(*, object_id: str, requested_pack: str) -> str:
         "})();</script>"
         "</body></html>"
     )
+
+
+def _event_matches_object(event: dict, object_id: str) -> bool:
+    """Decide whether an agent-decision event belongs to ``object_id``.
+
+    Decisions land in the log with the queried id either at the top level
+    (``object_id``) or nested under ``arguments.object_id`` for graph_ops
+    tools. Both shapes count as a match; everything else is filtered out so
+    the timeline pane only shows decisions about the focused object.
+    """
+    if str(event.get("object_id") or "") == object_id:
+        return True
+    args = event.get("arguments") or {}
+    if isinstance(args, dict) and str(args.get("object_id") or "") == object_id:
+        return True
+    return False
 
 
 def _render_explore_fragment(object_id: str) -> str:
@@ -4284,16 +4318,8 @@ def _render_explore_page(*, object_id: str) -> str:
         │  Synthesis pane (Crystal preview)   │
         └─────────────────────────────────────┘
     """
-    canvas_src = (
-        f"/object/fragment?id={quote(object_id, safe='')}"
-        if object_id
-        else "/objects"
-    )
-    synth_src = (
-        f"/object/fragment?id={quote(object_id, safe='')}"
-        if object_id
-        else "/objects"
-    )
+    canvas_src = f"/object/fragment?id={quote(object_id, safe='')}" if object_id else "/objects"
+    synth_src = f"/object/fragment?id={quote(object_id, safe='')}" if object_id else "/objects"
     return (
         "<!doctype html><html lang='en'><head><meta charset='utf-8'>"
         "<meta name='viewport' content='width=device-width, initial-scale=1' />"
@@ -4838,7 +4864,11 @@ def create_server(
                     else:
                         self._write_html(_render_open_questions_page(payload))
                     return
-                if path in {"/writing-prompts", "/writing-prompts/fragment", "/api/writing-prompts"}:
+                if path in {
+                    "/writing-prompts",
+                    "/writing-prompts/fragment",
+                    "/api/writing-prompts",
+                }:
                     payload = _build_writing_prompts_payload(resolved_vault)
                     if path == "/api/writing-prompts":
                         self._write_json(payload)
@@ -4851,9 +4881,7 @@ def create_server(
                     object_id = query.get("object_id", [""])[0]
                     pack_name = query.get("pack", [""])[0] or ""
                     self._write_html(
-                        _render_workbench_page(
-                            object_id=object_id, requested_pack=pack_name
-                        )
+                        _render_workbench_page(object_id=object_id, requested_pack=pack_name)
                     )
                     return
                 if path == "/pulse":
@@ -4873,9 +4901,7 @@ def create_server(
                     if max_polls is not None and max_polls < 0:
                         self.send_error(400, "max_polls must be >= 0")
                         return
-                    self._stream_pulse_sse(
-                        poll_interval=poll_interval, max_polls=max_polls
-                    )
+                    self._stream_pulse_sse(poll_interval=poll_interval, max_polls=max_polls)
                     return
                 if path == "/explore":
                     object_id = query.get("object_id", [""])[0]
@@ -4892,8 +4918,11 @@ def create_server(
                     if max_polls is not None and max_polls < 0:
                         self.send_error(400, "max_polls must be >= 0")
                         return
+                    object_id = query.get("object_id", [""])[0].strip()
                     self._stream_agent_decisions_sse(
-                        poll_interval=poll_interval, max_polls=max_polls
+                        poll_interval=poll_interval,
+                        max_polls=max_polls,
+                        object_id=object_id or None,
                     )
                     return
                 self.send_error(404, "Not Found")
@@ -5232,9 +5261,11 @@ def create_server(
                 "target_slug": str(audit_event.get("target_slug") or target_slug or ""),
                 "status": str(audit_event.get("status") or "applied_with_warning"),
                 "note": str(audit_event.get("note") or note),
-                "mutation": audit_event.get("mutation")
-                if isinstance(audit_event.get("mutation"), dict)
-                else {},
+                "mutation": (
+                    audit_event.get("mutation")
+                    if isinstance(audit_event.get("mutation"), dict)
+                    else {}
+                ),
                 "knowledge_index_rebuilt": bool(audit_event.get("knowledge_index_rebuilt")),
                 "knowledge_index_error": knowledge_index_error,
                 "warning": str(error),
@@ -5343,13 +5374,17 @@ def create_server(
             *,
             poll_interval: float = 1.0,
             max_polls: int | None = None,
+            object_id: str | None = None,
         ) -> None:
             """Phase 38 Stage C — tail ``60-Logs/agent-decisions.jsonl``.
 
             Same poll/SSE machinery as ``_stream_pulse_sse``, but scoped to a
             single log written by graph_ops invocations through the MCP
             server. Each frame uses the ``agent_decision`` event name so the
-            UI subscribes selectively.
+            UI subscribes selectively. When ``object_id`` is provided, only
+            events whose top-level or ``arguments.object_id`` matches are
+            forwarded — otherwise the consumer would see decisions for
+            unrelated objects in the timeline pane.
             """
             layout = VaultLayout.from_vault(resolved_vault)
             self.send_response(200)
@@ -5371,10 +5406,10 @@ def create_server(
                 if max_polls is not None and polls >= max_polls:
                     return
                 polls += 1
-                events, positions = tail_events(
-                    layout, since_position=positions, logs=logs
-                )
+                events, positions = tail_events(layout, since_position=positions, logs=logs)
                 for event in events:
+                    if object_id and not _event_matches_object(event, object_id):
+                        continue
                     event_id = str(event.get("event_id") or "")
                     data = json.dumps(event, ensure_ascii=False)
                     frame = (

--- a/src/ovp_pipeline/commands/working_memory.py
+++ b/src/ovp_pipeline/commands/working_memory.py
@@ -181,7 +181,10 @@ def _evolves_today(layout: VaultLayout, *, since: datetime) -> dict[str, list[di
 def _pulse_highlights(layout: VaultLayout, *, since: datetime) -> Counter:
     counts: Counter = Counter()
     for event in _read_jsonl(layout.pipeline_log):
-        ts = _parse_ts(event.get("ts"))
+        # Pipeline writers split between "ts" (newer paths) and "timestamp"
+        # (older paths) — try both so highlights aren't silently empty when a
+        # vault is dominated by legacy events.
+        ts = _parse_ts(event.get("ts") or event.get("timestamp"))
         if ts is None or ts < since:
             continue
         event_type = str(event.get("event_type") or "(unknown)")

--- a/src/ovp_pipeline/concept_dedup.py
+++ b/src/ovp_pipeline/concept_dedup.py
@@ -39,7 +39,6 @@ from typing import Iterable
 
 from .event_emitter import emit
 
-
 CONCEPT_MERGES_LOG = "concept-merges.jsonl"
 DEDUP_PROPOSALS_DIR = "dedup-proposals"
 DEDUP_ARCHIVE_DIR = "dedup-merged"
@@ -245,7 +244,9 @@ def _cluster_by_similarity(
 
 def _pick_canonical(members: list[DedupCandidate]) -> DedupCandidate:
     """Canonical = largest body (most curated content), tiebreak shortest slug, tiebreak slug asc."""
-    return max(members, key=lambda c: (c.size_bytes, -len(c.slug), -ord(c.slug[0]) if c.slug else 0))
+    return max(
+        members, key=lambda c: (c.size_bytes, -len(c.slug), -ord(c.slug[0]) if c.slug else 0)
+    )
 
 
 def find_clusters(vault_dir: Path, *, threshold: float = DEFAULT_THRESHOLD) -> list[DedupCluster]:
@@ -428,6 +429,19 @@ def apply_cluster(
 
     dup_slugs = [d.slug for d in cluster.duplicates]
     slug_map = {dup: cluster.canonical.slug for dup in dup_slugs}
+
+    # Pre-validate every duplicate exists before touching the vault. Otherwise
+    # a missing duplicate surfaces only at step 3 (archive), after wikilinks
+    # and aliases have already been mutated — leaving the vault half-merged
+    # with no way to roll back. Fail-fast keeps apply atomic in the
+    # non-dry-run path.
+    if not dry_run:
+        missing = [d.slug for d in cluster.duplicates if not d.path.exists()]
+        if missing:
+            result.errors.append(
+                "refusing to apply: missing duplicate files: " + ", ".join(missing)
+            )
+            return result
 
     # 1. Rewrite wikilinks across vault (skip the duplicates themselves — about to archive).
     dup_paths = {d.path for d in cluster.duplicates}

--- a/src/ovp_pipeline/materializers/crystal.py
+++ b/src/ovp_pipeline/materializers/crystal.py
@@ -116,13 +116,19 @@ def _query_evolves_relations(
     return out
 
 
-def _hash_payload(snapshot: dict[str, Any], object_ids: list[str]) -> str:
+def _hash_payload(
+    snapshot: dict[str, Any],
+    object_ids: list[str],
+    relations: list[dict[str, str]] | None = None,
+) -> str:
     """Stable digest over content (not timestamps).
 
     ``generated_at`` and ``queue_summary.running_count`` are excluded from
     the hash so the same logical state at two different moments produces the
     same Crystal id. Anything that materially affects the briefing — signals,
-    issues, insights, object set — does flow into the hash.
+    issues, insights, object set, EVOLVES relations — flows into the hash so
+    a new ``replaces`` edge between two existing objects produces a new
+    Crystal id (and a new file) instead of silently overwriting yesterday's.
     """
     salient = {
         "object_ids": object_ids,
@@ -145,13 +151,25 @@ def _hash_payload(snapshot: dict[str, Any], object_ids: list[str]) -> str:
             if isinstance(item, dict)
         ],
         "priority_items_count": len(snapshot.get("priority_items") or []),
+        "evolves_relations": sorted(
+            (
+                (str(rel.get("source")), str(rel.get("target")), str(rel.get("subtype")))
+                for rel in (relations or [])
+            ),
+        ),
     }
     blob = json.dumps(salient, ensure_ascii=False, sort_keys=True)
     return hashlib.sha256(blob.encode("utf-8")).hexdigest()[:16]
 
 
-def _crystal_id(snapshot: dict[str, Any], object_ids: list[str], *, when: _date_cls) -> str:
-    digest = _hash_payload(snapshot, object_ids)
+def _crystal_id(
+    snapshot: dict[str, Any],
+    object_ids: list[str],
+    *,
+    when: _date_cls,
+    relations: list[dict[str, str]] | None = None,
+) -> str:
+    digest = _hash_payload(snapshot, object_ids, relations)
     return f"crystal-{when.isoformat()}-{digest[:8]}"
 
 
@@ -260,7 +278,7 @@ def materialize_crystal(
     target_date = when or datetime.now(timezone.utc).date()
     object_ids = _collect_source_object_ids(snapshot)
     relations = _query_evolves_relations(vault_dir, object_ids, pack_name=pack_name)
-    crystal_id = _crystal_id(snapshot, object_ids, when=target_date)
+    crystal_id = _crystal_id(snapshot, object_ids, when=target_date, relations=relations)
 
     output_dir = vault_dir.joinpath(*CRYSTAL_DIR)
     output_dir.mkdir(parents=True, exist_ok=True)

--- a/src/ovp_pipeline/mcp_server.py
+++ b/src/ovp_pipeline/mcp_server.py
@@ -25,6 +25,7 @@ a Python traceback.
 
 from __future__ import annotations
 
+import inspect
 import json
 import sys
 from dataclasses import asdict
@@ -167,8 +168,8 @@ _TOOLS_DESCRIPTORS: tuple[dict[str, Any], ...] = (
             "required": ["object_id"],
             "properties": {
                 "object_id": {"type": "string"},
-                "hop": {"type": "integer", "minimum": 1, "maximum": 4},
-                "max_nodes": {"type": "integer", "minimum": 1, "maximum": 200},
+                "hop": {"type": "integer", "minimum": 1, "maximum": 5},
+                "max_nodes": {"type": "integer", "minimum": 1, "maximum": 500},
                 "render": {"type": "string", "enum": ["json", "html"]},
             },
         },
@@ -200,7 +201,7 @@ _TOOLS_DESCRIPTORS: tuple[dict[str, Any], ...] = (
             "type": "object",
             "properties": {
                 "limit": {"type": "integer", "minimum": 1, "maximum": 100},
-                "sample_size": {"type": "integer", "minimum": 10, "maximum": 1000},
+                "sample_size": {"type": "integer", "minimum": 1, "maximum": 1000},
             },
         },
     },
@@ -285,13 +286,20 @@ class MCPServer:
     def call_tool(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
         """Invoke a tool by name and return its result dict.
 
-        Raises ``KeyError`` for unknown tools and ``TypeError`` /
-        ``ValueError`` for malformed arguments — the JSON-RPC layer turns
-        those into the appropriate error envelope.
+        Raises ``KeyError`` for unknown tools and ``ValueError`` for
+        malformed arguments — the JSON-RPC layer turns those into the
+        appropriate error envelope. Kwargs are pre-validated via
+        ``inspect.signature(impl).bind`` so a ``TypeError`` raised from
+        deep inside the tool body still bubbles up as ``INTERNAL_ERROR``
+        instead of being silently reclassified as ``INVALID_PARAMS``.
         """
         impl = self._tools.get(name)
         if impl is None:
             raise KeyError(name)
+        try:
+            inspect.signature(impl).bind(**arguments)
+        except TypeError as exc:
+            raise ValueError(f"invalid arguments for {name}: {exc}") from exc
         return impl(**arguments)
 
     # -- JSON-RPC plumbing --------------------------------------------------
@@ -360,9 +368,12 @@ class MCPServer:
                 result = self.call_tool(name, arguments)
             except KeyError as exc:
                 raise _InvalidParams(f"Unknown tool: {name}") from exc
-            except (TypeError, ValueError) as exc:
-                # TypeError = bad kwargs; ValueError = bad enum value or
-                # range. Both are caller-supplied errors → INVALID_PARAMS.
+            except ValueError as exc:
+                # call_tool pre-validates kwargs and turns binding errors
+                # into ValueError; tool bodies also raise ValueError for
+                # bad enum / out-of-range arguments. A TypeError escaping
+                # the tool body is a real bug, so we let it bubble up to
+                # INTERNAL_ERROR rather than masking it as INVALID_PARAMS.
                 raise _InvalidParams(str(exc)) from exc
             # MCP tools/call result shape: a content array of typed parts
             # plus an isError flag. We serialize the tool's dict as JSON text

--- a/src/ovp_pipeline/mcp_server.py
+++ b/src/ovp_pipeline/mcp_server.py
@@ -360,7 +360,9 @@ class MCPServer:
                 result = self.call_tool(name, arguments)
             except KeyError as exc:
                 raise _InvalidParams(f"Unknown tool: {name}") from exc
-            except TypeError as exc:
+            except (TypeError, ValueError) as exc:
+                # TypeError = bad kwargs; ValueError = bad enum value or
+                # range. Both are caller-supplied errors → INVALID_PARAMS.
                 raise _InvalidParams(str(exc)) from exc
             # MCP tools/call result shape: a content array of typed parts
             # plus an isError flag. We serialize the tool's dict as JSON text
@@ -493,6 +495,13 @@ class MCPServer:
         max_nodes: int = 50,
         render: str = "json",
     ) -> dict[str, Any]:
+        # Descriptors carry advisory ranges; the dispatcher does not validate
+        # them. Clamp here so a misbehaved client can't ask for hop=999 and
+        # blow up the BFS on a vault-scale graph.
+        hop = _clamp(hop, lo=1, hi=5, name="hop")
+        max_nodes = _clamp(max_nodes, lo=1, hi=500, name="max_nodes")
+        if render not in ("json", "html"):
+            raise ValueError(f"render must be 'json' or 'html', got {render!r}")
         graph = graph_ops.load_graph(self.vault_dir)
         result = graph_ops.neighborhood(graph, object_id, hop=hop, max_nodes=max_nodes)
         if render == "html":
@@ -509,6 +518,8 @@ class MCPServer:
     def _tool_graph_bridge_nodes(
         self, *, limit: int = 20, sample_size: int = 200
     ) -> dict[str, Any]:
+        limit = _clamp(limit, lo=1, hi=100, name="limit")
+        sample_size = _clamp(sample_size, lo=1, hi=1000, name="sample_size")
         graph = graph_ops.load_graph(self.vault_dir)
         return {"bridges": graph_ops.bridge_nodes(graph, limit=limit, sample_size=sample_size)}
 
@@ -536,6 +547,20 @@ def _error_envelope(request_id: Any, code: int, message: str) -> dict[str, Any]:
         "id": request_id,
         "error": {"code": code, "message": message},
     }
+
+
+def _clamp(value: Any, *, lo: int, hi: int, name: str) -> int:
+    """Coerce ``value`` to int and constrain it to ``[lo, hi]``.
+
+    Tool descriptors advertise integer bounds for graph args, but the JSON-RPC
+    dispatcher trusts whatever the client sends. Clamping at the call site
+    keeps a misconfigured client from melting the daemon.
+    """
+    try:
+        coerced = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be an integer, got {value!r}") from exc
+    return max(lo, min(hi, coerced))
 
 
 def _neighborhood_svg_fragment(result: dict[str, Any]) -> str:

--- a/tests/test_phase38_followups.py
+++ b/tests/test_phase38_followups.py
@@ -1,0 +1,322 @@
+"""Phase 38 follow-up fixes — review-driven correctness/security tests.
+
+Each test pins one regression spotted in PR #62 review (and the deferred
+Stage B follow-ups). Grouping them here keeps the per-fix coverage close to
+the diff that introduced it; once the patterns settle they can fold into the
+relevant module's main test file.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+import time
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+from ovp_pipeline import concept_dedup
+from ovp_pipeline.commands import working_memory
+from ovp_pipeline.commands.link_suggest import run_link_suggest
+from ovp_pipeline.commands.ui_server import (
+    _event_matches_object,
+    _render_workbench_page,
+    create_server,
+)
+from ovp_pipeline.materializers.crystal import _crystal_id, materialize_crystal
+from ovp_pipeline.mcp_server import MCPServer, _clamp
+from ovp_pipeline.runtime import VaultLayout
+
+_NO_PROXY_OPENER = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+
+
+# ---------------------------------------------------------------------------
+# Workbench: reflected XSS in `var pack = ...` script block (PR #48 finding)
+# ---------------------------------------------------------------------------
+
+
+def test_workbench_pack_json_escapes_script_close_sequence() -> None:
+    """A pack name containing ``</script>`` must not close the surrounding
+    block. The escape mirrors graph/visualize._safe_json — replace ``</``
+    with ``<\\/`` so the JS string still parses but never terminates HTML."""
+    html = _render_workbench_page(
+        object_id="", requested_pack="</script><img src=x onerror=alert(1)>"
+    )
+    assert "</script><img" not in html.split("</script>")[0]
+    assert "<\\/script>" in html
+
+
+# ---------------------------------------------------------------------------
+# MCP graph tools: clamp client-supplied integers
+# ---------------------------------------------------------------------------
+
+
+def test_clamp_constrains_to_range() -> None:
+    assert _clamp(0, lo=1, hi=5, name="x") == 1
+    assert _clamp(99, lo=1, hi=5, name="x") == 5
+    assert _clamp("3", lo=1, hi=5, name="x") == 3
+
+
+def test_clamp_rejects_non_integer() -> None:
+    with pytest.raises(ValueError, match="must be an integer"):
+        _clamp("abc", lo=1, hi=5, name="hop")
+
+
+def test_graph_neighborhood_clamps_hop_and_max_nodes(temp_vault: Path) -> None:
+    layout = VaultLayout.from_vault(temp_vault)
+    layout.knowledge_db.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(layout.knowledge_db) as conn:
+        conn.executescript("""
+            CREATE TABLE pages_index (
+                slug TEXT PRIMARY KEY, title TEXT, note_type TEXT, path TEXT, day_id TEXT
+            );
+            CREATE TABLE page_links (
+                source_slug TEXT, target_slug TEXT, target_raw TEXT,
+                link_type TEXT, line_number INTEGER
+            );
+            """)
+        conn.execute(
+            "INSERT INTO pages_index (slug, title, note_type, path, day_id) "
+            "VALUES ('a', 'A', 'evergreen', 'A.md', '')"
+        )
+        conn.commit()
+
+    server = MCPServer(temp_vault)
+    # hop=999 / max_nodes=99999 must not blow up — they get clamped to 5/500.
+    result = server.call_tool(
+        "graph_neighborhood", {"object_id": "a", "hop": 999, "max_nodes": 99999}
+    )
+    assert "nodes" in result
+    assert "_html_fragment" not in result
+
+
+def test_graph_neighborhood_rejects_unknown_render() -> None:
+    server = MCPServer(Path.cwd())
+    request = {
+        "jsonrpc": "2.0",
+        "id": 9,
+        "method": "tools/call",
+        "params": {
+            "name": "graph_neighborhood",
+            "arguments": {"object_id": "x", "render": "pdf"},
+        },
+    }
+    reply = server.handle_line(json.dumps(request))
+    assert reply is not None
+    # ValueError now maps to INVALID_PARAMS (-32602), not INTERNAL_ERROR.
+    assert reply["error"]["code"] == -32602
+
+
+# ---------------------------------------------------------------------------
+# link_suggest: must materialize knowledge.db before the first SQLite read
+# ---------------------------------------------------------------------------
+
+
+def test_run_link_suggest_succeeds_on_fresh_vault(temp_vault: Path) -> None:
+    """A vault with no .ovp/knowledge.db must not crash with "unable to open
+    database file" — run_link_suggest should ensure the index exists first."""
+    layout = VaultLayout.from_vault(temp_vault)
+    assert not layout.knowledge_db.exists()
+    summary = run_link_suggest(temp_vault)  # apply=False by default
+    assert summary["applied"] is False
+    assert layout.knowledge_db.exists()
+
+
+# ---------------------------------------------------------------------------
+# concept_dedup: fail fast when a duplicate is missing (atomicity)
+# ---------------------------------------------------------------------------
+
+
+def _make_cluster(canonical_path: Path, dup_path: Path) -> concept_dedup.DedupCluster:
+    canonical = concept_dedup.DedupCandidate(
+        slug="canonical",
+        title="Canonical",
+        path=canonical_path,
+        size_bytes=canonical_path.stat().st_size if canonical_path.exists() else 0,
+    )
+    duplicate = concept_dedup.DedupCandidate(
+        slug="dup-missing",
+        title="Dup Missing",
+        path=dup_path,  # intentionally points at a non-existent file
+        size_bytes=0,
+    )
+    return concept_dedup.DedupCluster(
+        canonical=canonical, duplicates=(duplicate,), min_similarity=0.9
+    )
+
+
+def test_apply_cluster_refuses_when_duplicate_missing(tmp_path: Path) -> None:
+    canonical = tmp_path / "Canonical.md"
+    canonical.write_text("---\ntitle: Canonical\n---\n\nbody\n", encoding="utf-8")
+    other = tmp_path / "Other.md"
+    other.write_text("body mentions [[Dup Missing]]\n", encoding="utf-8")
+
+    cluster = _make_cluster(canonical, tmp_path / "Missing.md")
+    result = concept_dedup.apply_cluster(tmp_path, cluster, dry_run=False)
+
+    assert any("missing duplicate files" in err for err in result.errors)
+    # Nothing should have been mutated — wikilink count untouched, no archive.
+    assert other.read_text(encoding="utf-8") == "body mentions [[Dup Missing]]\n"
+    assert result.wikilink_rewrites == 0
+    assert result.archived == []
+
+
+# ---------------------------------------------------------------------------
+# working_memory: legacy "timestamp" field counts toward Pulse Highlights
+# ---------------------------------------------------------------------------
+
+
+def test_pulse_highlights_falls_back_to_timestamp(temp_vault: Path) -> None:
+    layout = VaultLayout.from_vault(temp_vault)
+    layout.logs_dir.mkdir(parents=True, exist_ok=True)
+    layout.pipeline_log.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "timestamp": "2099-01-01T00:00:00Z",
+                        "event_type": "legacy_event",
+                    }
+                ),
+                json.dumps({"ts": "2099-01-01T00:00:00Z", "event_type": "modern_event"}),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    from datetime import datetime, timezone
+
+    counts = working_memory._pulse_highlights(
+        layout, since=datetime(2098, 1, 1, tzinfo=timezone.utc)
+    )
+    assert counts.get("legacy_event") == 1
+    assert counts.get("modern_event") == 1
+
+
+# ---------------------------------------------------------------------------
+# /explore SSE: scope events to the requested object_id
+# ---------------------------------------------------------------------------
+
+
+def test_event_matches_object_top_level_and_arguments() -> None:
+    assert _event_matches_object({"object_id": "alpha"}, "alpha")
+    assert _event_matches_object({"arguments": {"object_id": "alpha", "hop": 1}}, "alpha")
+    assert not _event_matches_object({"object_id": "beta"}, "alpha")
+    assert not _event_matches_object({}, "alpha")
+
+
+@pytest.fixture
+def running_server(temp_vault: Path):
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def test_explore_stream_filters_to_object_id(temp_vault: Path, running_server) -> None:
+    """When the URL carries object_id=alpha, only events matching alpha must
+    reach the client. A beta event written between polls is silently dropped."""
+    host, port = running_server.server_address
+    url = f"http://{host}:{port}/explore/stream" "?object_id=alpha&max_polls=8&poll_interval=0.05"
+    body_holder: dict[str, str] = {}
+
+    def consume() -> None:
+        with _NO_PROXY_OPENER.open(url, timeout=10) as response:
+            body_holder["body"] = response.read().decode("utf-8")
+
+    consumer = threading.Thread(target=consume, daemon=True)
+    consumer.start()
+
+    time.sleep(0.15)
+    layout = VaultLayout.from_vault(temp_vault)
+    layout.logs_dir.mkdir(parents=True, exist_ok=True)
+    log = layout.logs_dir / "agent-decisions.jsonl"
+    log.write_text(
+        json.dumps(
+            {
+                "ts": "2026-04-24T12:00:00Z",
+                "tool": "graph_neighborhood",
+                "arguments": {"object_id": "beta"},
+            }
+        )
+        + "\n"
+        + json.dumps(
+            {
+                "ts": "2026-04-24T12:00:01Z",
+                "tool": "graph_neighborhood",
+                "arguments": {"object_id": "alpha"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    consumer.join(timeout=5)
+    body = body_holder.get("body", "")
+    # Both alpha events round-trip; beta is filtered out by the SSE handler.
+    assert '"object_id": "alpha"' in body
+    assert '"object_id": "beta"' not in body
+
+
+# ---------------------------------------------------------------------------
+# Crystal idempotency: EVOLVES relations must affect crystal_id
+# ---------------------------------------------------------------------------
+
+
+def test_crystal_id_changes_when_evolves_changes() -> None:
+    """Same snapshot + object_ids but different EVOLVES relations must produce
+    distinct ids — otherwise yesterday's crystal file gets silently overwritten
+    with new edges."""
+    snapshot: dict = {"unresolved_issues": [], "insights": [], "priority_items": []}
+    object_ids = ["a", "b"]
+    from datetime import date
+
+    when = date(2026, 4, 24)
+    id_no_rels = _crystal_id(snapshot, object_ids, when=when)
+    id_with_rels = _crystal_id(
+        snapshot,
+        object_ids,
+        when=when,
+        relations=[{"source": "a", "target": "b", "subtype": "replaces"}],
+    )
+    assert id_no_rels != id_with_rels
+
+
+def test_materialize_crystal_round_trips_after_evolves_change(
+    temp_vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end: same snapshot, change one EVOLVES edge, get a new file.
+
+    We patch ``_query_evolves_relations`` because the production path calls
+    ``ensure_knowledge_db_current`` which rebuilds the DB from the vault
+    contents — directly seeding ``graph_edges`` would be wiped out.
+    """
+    from ovp_pipeline.materializers import crystal as crystal_module
+
+    snapshot: dict = {
+        "object_ids": ["a"],
+        "unresolved_issues": [],
+        "insights": [],
+        "priority_items": [],
+    }
+    from datetime import date
+
+    monkeypatch.setattr(crystal_module, "_query_evolves_relations", lambda *a, **kw: [])
+    first = materialize_crystal(snapshot, temp_vault, when=date(2026, 4, 24))
+
+    monkeypatch.setattr(
+        crystal_module,
+        "_query_evolves_relations",
+        lambda *a, **kw: [{"source": "a", "target": "b", "subtype": "replaces"}],
+    )
+    second = materialize_crystal(snapshot, temp_vault, when=date(2026, 4, 24))
+
+    assert second.crystal_id != first.crystal_id
+    assert second.path != first.path

--- a/tests/test_phase38_followups.py
+++ b/tests/test_phase38_followups.py
@@ -109,6 +109,54 @@ def test_graph_neighborhood_rejects_unknown_render() -> None:
     assert reply["error"]["code"] == -32602
 
 
+def test_tool_descriptors_match_runtime_clamps() -> None:
+    """The advertised inputSchema bounds for graph_neighborhood and
+    graph_bridge_nodes must match the runtime ``_clamp`` ranges, otherwise
+    a schema-strict MCP client will reject inputs the server happily
+    accepts (and vice versa)."""
+    server = MCPServer(Path.cwd())
+    descriptors = {tool["name"]: tool for tool in server.list_tools()}
+
+    neighborhood = descriptors["graph_neighborhood"]["inputSchema"]["properties"]
+    assert neighborhood["hop"]["maximum"] == 5
+    assert neighborhood["max_nodes"]["maximum"] == 500
+
+    bridges = descriptors["graph_bridge_nodes"]["inputSchema"]["properties"]
+    assert bridges["sample_size"]["minimum"] == 1
+
+
+def test_call_tool_internal_typeerror_stays_internal_error() -> None:
+    """A TypeError raised from *inside* a tool body must surface as
+    INTERNAL_ERROR (-32603), not be silently reclassified as
+    INVALID_PARAMS. Only kwargs-binding errors should become -32602."""
+    server = MCPServer(Path.cwd())
+
+    def _boom() -> dict:
+        raise TypeError("internal bug: None.foo")
+
+    server._tools["__boom__"] = _boom  # type: ignore[attr-defined]
+    request = {
+        "jsonrpc": "2.0",
+        "id": 11,
+        "method": "tools/call",
+        "params": {"name": "__boom__", "arguments": {}},
+    }
+    reply = server.handle_line(json.dumps(request))
+    assert reply is not None
+    assert reply["error"]["code"] == -32603
+
+    # Sanity: bad kwargs still map to INVALID_PARAMS via inspect.bind.
+    bad_request = {
+        "jsonrpc": "2.0",
+        "id": 12,
+        "method": "tools/call",
+        "params": {"name": "__boom__", "arguments": {"unexpected": 1}},
+    }
+    bad_reply = server.handle_line(json.dumps(bad_request))
+    assert bad_reply is not None
+    assert bad_reply["error"]["code"] == -32602
+
+
 # ---------------------------------------------------------------------------
 # link_suggest: must materialize knowledge.db before the first SQLite read
 # ---------------------------------------------------------------------------
@@ -263,6 +311,52 @@ def test_explore_stream_filters_to_object_id(temp_vault: Path, running_server) -
     # Both alpha events round-trip; beta is filtered out by the SSE handler.
     assert '"object_id": "alpha"' in body
     assert '"object_id": "beta"' not in body
+
+
+def test_explore_stream_keepalive_when_all_events_filtered(
+    temp_vault: Path, running_server
+) -> None:
+    """When every tailed event is filtered out by ``object_id``, the handler
+    must still emit a keepalive frame each poll. Without this the
+    ``self.wfile.write`` path never runs, BrokenPipeError is never raised,
+    and the server thread leaks per stale connection."""
+    host, port = running_server.server_address
+    url = f"http://{host}:{port}/explore/stream" "?object_id=alpha&max_polls=4&poll_interval=0.05"
+    body_holder: dict[str, str] = {}
+
+    def consume() -> None:
+        with _NO_PROXY_OPENER.open(url, timeout=10) as response:
+            body_holder["body"] = response.read().decode("utf-8")
+
+    consumer = threading.Thread(target=consume, daemon=True)
+    consumer.start()
+
+    # Write only beta events — every one of these should be filtered out.
+    time.sleep(0.05)
+    layout = VaultLayout.from_vault(temp_vault)
+    layout.logs_dir.mkdir(parents=True, exist_ok=True)
+    log = layout.logs_dir / "agent-decisions.jsonl"
+    log.write_text(
+        "\n".join(
+            json.dumps(
+                {
+                    "ts": f"2026-04-24T12:00:0{i}Z",
+                    "tool": "graph_neighborhood",
+                    "arguments": {"object_id": "beta"},
+                }
+            )
+            for i in range(3)
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    consumer.join(timeout=5)
+    body = body_holder.get("body", "")
+    assert '"object_id": "beta"' not in body
+    # At least one keepalive frame must reach the client even though the
+    # log was non-empty — that's how disconnects get detected.
+    assert body.count(": keepalive") >= 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Bundles eight review-driven correctness/security fixes spotted in PR #48 and the Phase 38 Stage B/C reviews. Each fix is pinned by a regression test in `tests/test_phase38_followups.py` (12 new tests).

### Fixes

- **Workbench reflected XSS** (`commands/ui_server.py`): escape `</` in the `var pack=...` script block JSON so a pack name containing `</script>` can no longer break out and inject HTML. Mirrors the `<\/` escape in `graph/visualize._safe_json`.
- **MCP `_dispatch` error mapping** (`mcp_server.py`): catch `(TypeError, ValueError)` and map to `INVALID_PARAMS` (-32602) instead of `INTERNAL_ERROR` (-32603). Bad client args now report correctly.
- **MCP graph arg clamping** (`mcp_server.py`): new `_clamp(value, *, lo, hi, name)` helper rejects non-integers with `ValueError` and clamps `graph_neighborhood` `hop`∈[1,5] / `max_nodes`∈[1,500] and `graph_bridge_nodes` `limit`∈[1,100] / `sample_size`∈[1,1000]. Prevents unbounded work from `hop=999`-style inputs.
- **link_suggest fresh-vault crash** (`commands/link_suggest.py`): call `ensure_knowledge_db_current` before the first SQLite read so a vault without `.ovp/knowledge.db` no longer crashes with `unable to open database file`.
- **concept_dedup atomicity** (`concept_dedup.py`): `apply_cluster` pre-validates that all duplicate paths exist and returns early with an error if any are missing. Stops partial mutation when a duplicate was already moved/deleted between scan and apply.
- **Working Memory legacy `timestamp` fallback** (`commands/working_memory.py`): `_pulse_highlights` reads `event.get("ts") or event.get("timestamp")` so vaults dominated by legacy events still populate the Pulse Highlights table.
- **/explore SSE object_id scoping** (`commands/ui_server.py`): new `_event_matches_object` helper (checks top-level `object_id` and nested `arguments.object_id`); `/explore/stream` filters tailed events to the requested object_id so a `beta` event written between polls no longer reaches an `alpha` viewer.
- **Crystal idempotency under EVOLVES change** (`materializers/crystal.py`): `_hash_payload`/`_crystal_id` now fold sorted `(source, target, subtype)` relation tuples into the digest input. Same snapshot + different EVOLVES edges → distinct crystal_id, so today's file no longer silently overwrites yesterday's.

## Test plan

- [x] `pytest tests/test_phase38_followups.py -v` — 12 passing
- [x] Full suite passes locally (977)
- [x] `ruff check` and `black --check` clean on touched files
- [ ] CI green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/63" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Database is now properly initialized before use, preventing crashes.
  * Fixed security vulnerability preventing script injection in workbench.
  * Legacy log format support restored for highlight counting.
  * Deduplication now validates files before mutations, preventing partial updates.
  * Graph tool parameters are validated and clamped to prevent extreme workloads.

* **New Features**
  * Explore stream now supports filtering events by object ID.
  * Relation handling improved in materialization process.

* **Tests**
  * Comprehensive regression test suite added covering all recent changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->