### PR TITLE
Bump version to 0.9.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "obsidian-vault-pipeline"
-version = "0.8.6"
+version = "0.9.2"
 description = "全自动Obsidian知识管理Pipeline - 生产级知识管理流水线"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Tags Phase 38 as v0.9.2 (Phase 38 closeout):

- Stage A (#59) — link density emergency fix
- Stage B (#61) — EVOLVES typing, Crystal layer, hybrid search, working memory daily distill
- Stage C — graph_ops, MCP graph tools, /explore reviewer UI
- Review fixes (#63) — descriptor/clamp alignment, SSE keepalive, _dispatch tightening, atomicity / DB-init / XSS / SSE-scoping fixes

No DB schema or runtime contract change in this PR — version bump only.

## Test plan

- [x] `pytest tests/` — 980 passing on the merge base
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/64" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version to 0.9.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->