### PR TITLE
Fix working_memory crash on naive legacy timestamps

### DIFF
--- a/src/ovp_pipeline/commands/working_memory.py
+++ b/src/ovp_pipeline/commands/working_memory.py
@@ -59,9 +59,14 @@ def _parse_ts(value: object) -> datetime | None:
     if text.endswith("Z"):
         text = text[:-1] + "+00:00"
     try:
-        return datetime.fromisoformat(text)
+        dt = datetime.fromisoformat(text)
     except ValueError:
         return None
+    # Legacy "timestamp" fields were written without TZ info; coerce to UTC
+    # so the `<` comparison against the offset-aware `since` cutoff works.
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
 
 
 def _read_jsonl(path: Path) -> list[dict[str, Any]]:

--- a/tests/test_phase38_followups.py
+++ b/tests/test_phase38_followups.py
@@ -243,6 +243,32 @@ def test_pulse_highlights_falls_back_to_timestamp(temp_vault: Path) -> None:
     assert counts.get("modern_event") == 1
 
 
+def test_pulse_highlights_handles_naive_legacy_timestamp(temp_vault: Path) -> None:
+    """Real-world pipeline.jsonl carries naive ``timestamp`` fields like
+    "2026-04-03T04:16:12.625311" (no Z, no offset). The previous
+    ``_parse_ts`` returned a naive datetime, which then crashed the
+    ``ts < since`` comparison with TypeError. Coerce naive ts to UTC."""
+    from datetime import datetime, timezone
+
+    layout = VaultLayout.from_vault(temp_vault)
+    layout.logs_dir.mkdir(parents=True, exist_ok=True)
+    layout.pipeline_log.write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-04-03T04:16:12.625311",
+                "event_type": "naive_legacy_event",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    counts = working_memory._pulse_highlights(
+        layout, since=datetime(2026, 4, 1, tzinfo=timezone.utc)
+    )
+    assert counts.get("naive_legacy_event") == 1
+
+
 # ---------------------------------------------------------------------------
 # /explore SSE: scope events to the requested object_id
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Hotfix exposed by the v0.9.2 incremental run.

PR #63's working_memory follow-up added `event.get("ts") or event.get("timestamp")` so legacy events count toward Pulse Highlights. But real `60-Logs/pipeline.jsonl` entries written before the `ts` rename look like `"timestamp": "2026-04-03T04:16:12.625311"` — no `Z`, no offset. `_parse_ts` returned a naive datetime, which then crashed the `ts < since` comparison with `TypeError: can't compare offset-naive and offset-aware datetimes`.

`ovp-working-memory` was unrunnable on any vault dominated by legacy events.

Fix: coerce naive parses to UTC inside `_parse_ts`. Pinned by a regression test that writes a naive-timestamp event and asserts the Pulse counter increments.

## Test plan

- [x] `pytest tests/test_phase38_followups.py -v` — 16 passing (added 1)
- [x] `ovp-working-memory --vault-dir <vault>` runs to completion against the real vault
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/65" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
