### PR TITLE
Add LLM gate to link-suggest + fix indexer slug divergence

### DIFF
--- a/src/ovp_pipeline/commands/link_suggest.py
+++ b/src/ovp_pipeline/commands/link_suggest.py
@@ -261,9 +261,11 @@ def _llm_gate_for_page(
     log_dir: Path,
 ) -> dict[str, dict[str, Any]]:
     """Return ``{target_slug: {"decision","confidence","rationale"}}`` for every
-    candidate. When the gate is unavailable / disabled, every candidate is
-    accepted with ``rrf-only`` rationale and confidence taken from the RRF
-    score so the rest of the pipeline can stay uniform."""
+    candidate. ``run_link_suggest`` no longer calls this with ``gate_client=None``
+    (that path is short-circuited to the legacy RRF-only branch upstream), but
+    the defensive fallback below sets ``confidence=1.0`` so any direct caller
+    still gets the documented ``accept all`` semantics instead of having every
+    candidate silently fail the threshold filter."""
     decisions_by_slug: dict[str, dict[str, Any]] = {}
     cache_misses: list[dict[str, Any]] = []
     for candidate in candidates:
@@ -282,11 +284,10 @@ def _llm_gate_for_page(
         return decisions_by_slug
 
     if gate_client is None:
-        # Graceful degradation: accept all, confidence = rrf_score (capped 1.0).
         for candidate in cache_misses:
             decisions_by_slug[candidate["slug"]] = {
                 "decision": "link",
-                "confidence": min(1.0, float(candidate.get("rrf_score", 0.0))),
+                "confidence": 1.0,
                 "rationale": "rrf-only (no LLM gate)",
             }
         return decisions_by_slug
@@ -543,8 +544,11 @@ def run_link_suggest(
     Gate flow: top-``gate_prefilter`` RRF candidates → LLM gate → keep only
     ``decision == 'link'`` AND ``confidence >= gate_threshold`` → cap at
     ``suggestions_per_page`` for the apply step. When ``use_llm_gate=False`` or
-    no API key / litellm is available, the gate degrades to RRF-only (every
-    retrieved candidate accepted, confidence = rrf_score)."""
+    no API key / litellm is available, the gate degrades cleanly to the
+    legacy RRF-only path (every retrieved candidate accepted, no gate
+    metadata in rows). The previous fallback returned ``confidence=rrf_score``
+    inside the gate path, which then failed the threshold filter and silently
+    rejected everything — the explicit fall-through avoids that trap."""
     layout = VaultLayout.from_vault(vault_dir)
     if apply and not confirm:
         raise ValueError("--apply requires --confirm")
@@ -564,11 +568,23 @@ def run_link_suggest(
     effective_client: GateClient | None = None
     if use_llm_gate:
         effective_client = gate_client or _make_default_gate_client(gate_model)
+        if effective_client is None:
+            # No API key / litellm → the gate would reject everything via the
+            # threshold filter. Disable cleanly so reviewers see RRF rows
+            # (no decision/confidence) instead of an empty apply.
+            print(
+                "ovp-link-suggest: --llm-gate requested but no LLM client available; "
+                "falling back to RRF-only (no gate metadata in rows).",
+                file=sys.stderr,
+            )
+            use_llm_gate = False
     cache = _load_gate_cache(log_root) if use_llm_gate else {}
 
-    # Retrieve top-N where N covers both the gate budget and the apply budget;
-    # the gate decides on the larger pool, apply takes the top suggestions.
-    retrieve_n = max(suggestions_per_page, gate_prefilter if use_llm_gate else suggestions_per_page)
+    # gate_prefilter is the HARD cap on what the LLM sees; apply takes the
+    # top-suggestions_per_page from gate-passed. If suggestions_per_page >
+    # gate_prefilter, the gate becomes the bottleneck (correctly) — we don't
+    # quietly send more to the LLM than --gate-prefilter requests.
+    retrieve_n = gate_prefilter if use_llm_gate else suggestions_per_page
 
     run_id = _new_run_id()
     rows: list[dict[str, Any]] = []

--- a/src/ovp_pipeline/commands/link_suggest.py
+++ b/src/ovp_pipeline/commands/link_suggest.py
@@ -16,6 +16,16 @@ Each candidate gets a fused score = BM25_rank_score + vector_rank_score
 (reciprocal rank, k=60). Self-references and existing outbound targets are
 dropped before ranking. The naive fusion here will be replaced by the proper
 RRF + bi-temporal decay layer in Stage B.
+
+After RRF the top ``--gate-prefilter`` candidates per page are sent to an
+LLM second-opinion gate (Phase 38 plan §2.2 step 3). The gate classifies
+each candidate as ``link`` or ``skip`` with a confidence + 1-line rationale,
+and only ``link`` decisions with ``confidence >= --gate-threshold`` survive
+into ``--apply``. Decisions are cached in
+``60-Logs/link-suggestions/.gate-cache.jsonl`` so a second dry-run / apply
+pass doesn't re-bill the LLM. When no API key / litellm is available the
+gate degrades to the previous RRF-only behavior (every retrieved candidate
+treated as ``link`` with confidence ``rrf_score``).
 """
 
 from __future__ import annotations
@@ -26,7 +36,7 @@ import sqlite3
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 try:
     from ..runtime import VaultLayout, resolve_vault_dir
@@ -36,6 +46,13 @@ try:
         sanitize_fts_query,
         search_knowledge_index,
     )
+    from ..llm_defaults import (
+        DEFAULT_LITELLM_TIMEOUT_SECONDS,
+        DEFAULT_MINIMAX_MODEL,
+        normalize_model_for_api_base,
+        resolve_api_base,
+        resolve_api_key,
+    )
 except ImportError:
     from ovp_pipeline.runtime import VaultLayout, resolve_vault_dir  # type: ignore
     from ovp_pipeline.knowledge_index import (  # type: ignore
@@ -44,18 +61,272 @@ except ImportError:
         sanitize_fts_query,
         search_knowledge_index,
     )
+    from ovp_pipeline.llm_defaults import (  # type: ignore
+        DEFAULT_LITELLM_TIMEOUT_SECONDS,
+        DEFAULT_MINIMAX_MODEL,
+        normalize_model_for_api_base,
+        resolve_api_base,
+        resolve_api_key,
+    )
+
+try:
+    import litellm  # type: ignore
+
+    _LITELLM_AVAILABLE = True
+except ImportError:
+    _LITELLM_AVAILABLE = False
 
 
 DEFAULT_MIN_LINKS = 3
 DEFAULT_CANDIDATES_PER_PAGE = 20
 DEFAULT_SUGGESTIONS_PER_PAGE = 5
+DEFAULT_GATE_PREFILTER = 8
+DEFAULT_GATE_THRESHOLD = 0.6
 RRF_K = 60
+GATE_CACHE_FILENAME = ".gate-cache.jsonl"
 BACKFILL_HEADING = "## 🔗 自动建议链接 (link-suggest)"
 BACKFILL_MARKER = "<!-- link-suggest:backfill -->"
+
+LINK_SUGGEST_GATE_PROMPT = """你是一个 wikilink 质量过滤器。给定一篇源文章和若干候选目标 evergreen 概念，判断每个候选是否值得在源文章里 backfill 一个 wikilink。
+
+判定原则：
+1. 候选概念应是源文章的 prose 真正讨论 / 例证 / 反例引用的对象，不是泛泛同领域。
+2. 不要因为同领域就 link；关注是否有 substantive 的概念关联（同一现象、相同机制、互为前置 / 反例）。
+3. confidence 要保守：0.8+ 强相关；0.6-0.79 合理；<0.6 一律 skip。
+4. rationale 用 ≤30 字中文，说明为什么 link 或 skip。
+5. 只输出 JSON，不要解释。
+
+输入：
+{"source": {"slug": "...", "title": "...", "preview": "..."}, "candidates": [{"slug": "...", "title": "..."}]}
+
+输出：
+{"decisions": [{"slug": "...", "decision": "link"|"skip", "confidence": 0.0, "rationale": "..."}]}
+"""
+
+
+GateClient = Callable[[str, str], str]
 
 
 def _new_run_id() -> str:
     return datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+
+
+def _make_default_gate_client(model: str | None = None) -> GateClient | None:
+    """Return a callable wrapping LiteLLM, or ``None`` if litellm/API key are
+    unavailable. Tests monkey-patch by passing their own callable directly to
+    ``run_link_suggest``."""
+    if not _LITELLM_AVAILABLE:
+        return None
+    api_key = resolve_api_key(None)
+    if not api_key:
+        return None
+    api_base = resolve_api_base(None)
+    resolved_model = normalize_model_for_api_base(
+        model or DEFAULT_MINIMAX_MODEL,
+        api_type="anthropic",
+        api_base=api_base,
+        default_model=DEFAULT_MINIMAX_MODEL,
+    )
+
+    def _call(system_prompt: str, user_prompt: str) -> str:
+        kwargs: dict[str, Any] = {
+            "model": resolved_model,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+            "temperature": 0.1,
+            "max_tokens": 1500,
+            "timeout": DEFAULT_LITELLM_TIMEOUT_SECONDS,
+        }
+        if api_key:
+            kwargs["api_key"] = api_key
+        if api_base:
+            kwargs["api_base"] = api_base
+        response = litellm.completion(**kwargs)
+        return response.choices[0].message.content or ""
+
+    return _call
+
+
+def _load_gate_cache(log_dir: Path) -> dict[tuple[str, str], dict[str, Any]]:
+    """Read prior gate decisions; last-write-wins per ``(source, target)`` key
+    so re-running on the same vault doesn't re-bill the LLM."""
+    cache_path = log_dir / GATE_CACHE_FILENAME
+    cache: dict[tuple[str, str], dict[str, Any]] = {}
+    if not cache_path.exists():
+        return cache
+    for line in cache_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        source = row.get("source_slug")
+        target = row.get("target_slug")
+        if not source or not target:
+            continue
+        cache[(source, target)] = row
+    return cache
+
+
+def _append_gate_cache(log_dir: Path, source_slug: str, decisions: list[dict[str, Any]]) -> None:
+    if not decisions:
+        return
+    log_dir.mkdir(parents=True, exist_ok=True)
+    cache_path = log_dir / GATE_CACHE_FILENAME
+    ts = datetime.now(timezone.utc).isoformat()
+    with cache_path.open("a", encoding="utf-8") as fh:
+        for decision in decisions:
+            row = {
+                "source_slug": source_slug,
+                "target_slug": decision["slug"],
+                "decision": decision["decision"],
+                "confidence": decision["confidence"],
+                "rationale": decision.get("rationale", ""),
+                "ts": ts,
+            }
+            fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+def _build_gate_user_prompt(page: dict[str, Any], candidates: list[dict[str, Any]]) -> str:
+    body = (page.get("body") or "")[:_BODY_PREVIEW_CHARS]
+    payload = {
+        "source": {
+            "slug": page["slug"],
+            "title": page.get("title") or page["slug"],
+            "preview": body,
+        },
+        "candidates": [
+            {"slug": c["slug"], "title": c.get("title") or c["slug"]} for c in candidates
+        ],
+    }
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _parse_gate_response(text: str) -> list[dict[str, Any]]:
+    """Tolerant JSON parser. The model occasionally wraps output in a
+    ```json fence or trailing prose; pull out the first balanced object and
+    keep going."""
+    if not text:
+        return []
+    cleaned = text.strip()
+    if cleaned.startswith("```"):
+        # strip code fence
+        cleaned = cleaned.lstrip("`").lstrip("json").strip()
+        if cleaned.endswith("```"):
+            cleaned = cleaned[:-3].strip()
+    start = cleaned.find("{")
+    end = cleaned.rfind("}")
+    if start < 0 or end <= start:
+        return []
+    try:
+        obj = json.loads(cleaned[start : end + 1])
+    except json.JSONDecodeError:
+        return []
+    decisions = obj.get("decisions") if isinstance(obj, dict) else None
+    if not isinstance(decisions, list):
+        return []
+    out: list[dict[str, Any]] = []
+    for item in decisions:
+        if not isinstance(item, dict):
+            continue
+        slug = item.get("slug")
+        decision = item.get("decision")
+        if not slug or decision not in {"link", "skip"}:
+            continue
+        try:
+            confidence = float(item.get("confidence", 0.0))
+        except (TypeError, ValueError):
+            confidence = 0.0
+        out.append(
+            {
+                "slug": str(slug),
+                "decision": decision,
+                "confidence": max(0.0, min(1.0, confidence)),
+                "rationale": str(item.get("rationale", "") or ""),
+            }
+        )
+    return out
+
+
+def _llm_gate_for_page(
+    page: dict[str, Any],
+    candidates: list[dict[str, Any]],
+    *,
+    gate_client: GateClient | None,
+    cache: dict[tuple[str, str], dict[str, Any]],
+    log_dir: Path,
+) -> dict[str, dict[str, Any]]:
+    """Return ``{target_slug: {"decision","confidence","rationale"}}`` for every
+    candidate. When the gate is unavailable / disabled, every candidate is
+    accepted with ``rrf-only`` rationale and confidence taken from the RRF
+    score so the rest of the pipeline can stay uniform."""
+    decisions_by_slug: dict[str, dict[str, Any]] = {}
+    cache_misses: list[dict[str, Any]] = []
+    for candidate in candidates:
+        slug = candidate["slug"]
+        cached = cache.get((page["slug"], slug))
+        if cached:
+            decisions_by_slug[slug] = {
+                "decision": cached["decision"],
+                "confidence": float(cached.get("confidence", 0.0)),
+                "rationale": cached.get("rationale", ""),
+            }
+        else:
+            cache_misses.append(candidate)
+
+    if not cache_misses:
+        return decisions_by_slug
+
+    if gate_client is None:
+        # Graceful degradation: accept all, confidence = rrf_score (capped 1.0).
+        for candidate in cache_misses:
+            decisions_by_slug[candidate["slug"]] = {
+                "decision": "link",
+                "confidence": min(1.0, float(candidate.get("rrf_score", 0.0))),
+                "rationale": "rrf-only (no LLM gate)",
+            }
+        return decisions_by_slug
+
+    user_prompt = _build_gate_user_prompt(page, cache_misses)
+    try:
+        raw = gate_client(LINK_SUGGEST_GATE_PROMPT, user_prompt)
+    except Exception as exc:  # noqa: BLE001 — gate is best-effort
+        for candidate in cache_misses:
+            decisions_by_slug[candidate["slug"]] = {
+                "decision": "skip",
+                "confidence": 0.0,
+                "rationale": f"gate error: {type(exc).__name__}",
+            }
+        return decisions_by_slug
+
+    parsed = _parse_gate_response(raw)
+    parsed_by_slug = {item["slug"]: item for item in parsed}
+    new_cache_rows: list[dict[str, Any]] = []
+    miss_slugs = {c["slug"] for c in cache_misses}
+    for candidate in cache_misses:
+        slug = candidate["slug"]
+        decision = parsed_by_slug.get(slug)
+        if decision is None:
+            decision = {
+                "slug": slug,
+                "decision": "skip",
+                "confidence": 0.0,
+                "rationale": "gate omitted candidate",
+            }
+        decisions_by_slug[slug] = {
+            "decision": decision["decision"],
+            "confidence": decision["confidence"],
+            "rationale": decision["rationale"],
+        }
+        new_cache_rows.append(decision)
+    # Persist whatever the gate returned for the misses so re-runs are cheap.
+    new_cache_rows = [r for r in new_cache_rows if r["slug"] in miss_slugs]
+    _append_gate_cache(log_dir, page["slug"], new_cache_rows)
+    return decisions_by_slug
 
 
 _BODY_PREVIEW_CHARS = 800
@@ -195,8 +466,9 @@ def _suggestion_row(
     suggestion: dict[str, Any],
     *,
     run_id: str,
+    gated: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    return {
+    row = {
         "run_id": run_id,
         "source_slug": page["slug"],
         "source_title": page.get("title", ""),
@@ -206,6 +478,11 @@ def _suggestion_row(
         "target_title": suggestion.get("title", ""),
         "rrf_score": round(suggestion.get("rrf_score", 0.0), 6),
     }
+    if gated is not None:
+        row["decision"] = gated["decision"]
+        row["confidence"] = round(float(gated["confidence"]), 4)
+        row["rationale"] = gated.get("rationale", "")
+    return row
 
 
 def _emit_jsonl(rows: list[dict[str, Any]], log_path: Path) -> None:
@@ -254,9 +531,20 @@ def run_link_suggest(
     confirm: bool = False,
     limit: int | None = None,
     log_dir: Path | None = None,
+    use_llm_gate: bool = True,
+    gate_threshold: float = DEFAULT_GATE_THRESHOLD,
+    gate_prefilter: int = DEFAULT_GATE_PREFILTER,
+    gate_model: str | None = None,
+    gate_client: GateClient | None = None,
 ) -> dict[str, Any]:
     """Top-level entry. Emits the JSONL log unconditionally; only mutates
-    markdown when ``apply`` *and* ``confirm`` are both True."""
+    markdown when ``apply`` *and* ``confirm`` are both True.
+
+    Gate flow: top-``gate_prefilter`` RRF candidates → LLM gate → keep only
+    ``decision == 'link'`` AND ``confidence >= gate_threshold`` → cap at
+    ``suggestions_per_page`` for the apply step. When ``use_llm_gate=False`` or
+    no API key / litellm is available, the gate degrades to RRF-only (every
+    retrieved candidate accepted, confidence = rrf_score)."""
     layout = VaultLayout.from_vault(vault_dir)
     if apply and not confirm:
         raise ValueError("--apply requires --confirm")
@@ -269,24 +557,65 @@ def run_link_suggest(
         layout, min_links=min_links, note_types=note_types, limit=limit
     )
 
+    log_root = log_dir or (layout.vault_dir / "60-Logs" / "link-suggestions")
+    log_root.mkdir(parents=True, exist_ok=True)
+
+    # Gate setup: prefer caller-supplied client (tests) over env-resolved one.
+    effective_client: GateClient | None = None
+    if use_llm_gate:
+        effective_client = gate_client or _make_default_gate_client(gate_model)
+    cache = _load_gate_cache(log_root) if use_llm_gate else {}
+
+    # Retrieve top-N where N covers both the gate budget and the apply budget;
+    # the gate decides on the larger pool, apply takes the top suggestions.
+    retrieve_n = max(suggestions_per_page, gate_prefilter if use_llm_gate else suggestions_per_page)
+
     run_id = _new_run_id()
     rows: list[dict[str, Any]] = []
     files_mutated = 0
     suggestions_total = 0
+    gate_passed_total = 0
     for page in pages:
-        suggestions = _suggest_for_page(
+        candidates = _suggest_for_page(
             layout,
             page,
             candidates_per_page=candidates_per_page,
-            suggestions_per_page=suggestions_per_page,
+            suggestions_per_page=retrieve_n,
         )
-        for suggestion in suggestions:
-            rows.append(_suggestion_row(page, suggestion, run_id=run_id))
-        suggestions_total += len(suggestions)
-        if apply and confirm and _apply_to_markdown(layout, page, suggestions):
+        if use_llm_gate:
+            decisions = _llm_gate_for_page(
+                page,
+                candidates,
+                gate_client=effective_client,
+                cache=cache,
+                log_dir=log_root,
+            )
+            # Emit one row per retrieved candidate (link AND skip), preserving RRF
+            # order so reviewers can diff what the gate filtered out.
+            page_passed: list[dict[str, Any]] = []
+            for candidate in candidates:
+                gated = decisions.get(candidate["slug"])
+                rows.append(_suggestion_row(page, candidate, run_id=run_id, gated=gated))
+                if (
+                    gated is not None
+                    and gated["decision"] == "link"
+                    and float(gated["confidence"]) >= gate_threshold
+                ):
+                    page_passed.append(candidate)
+            suggestions_total += len(candidates)
+            gate_passed_total += len(page_passed)
+            to_apply = page_passed[:suggestions_per_page]
+        else:
+            # Legacy RRF-only path: skip the gate entirely, omit gate metadata
+            # from rows, and apply the top-suggestions_per_page directly.
+            for candidate in candidates:
+                rows.append(_suggestion_row(page, candidate, run_id=run_id))
+            suggestions_total += len(candidates)
+            gate_passed_total += len(candidates)
+            to_apply = candidates[:suggestions_per_page]
+        if apply and confirm and _apply_to_markdown(layout, page, to_apply):
             files_mutated += 1
 
-    log_root = log_dir or (layout.vault_dir / "60-Logs" / "link-suggestions")
     log_path = log_root / f"{run_id}.jsonl"
     _emit_jsonl(rows, log_path)
 
@@ -295,8 +624,10 @@ def run_link_suggest(
         "log_path": str(log_path),
         "pages_examined": len(pages),
         "suggestions_emitted": suggestions_total,
+        "gate_passed": gate_passed_total,
         "files_mutated": files_mutated,
         "applied": apply and confirm,
+        "gate_enabled": use_llm_gate and effective_client is not None,
     }
 
 
@@ -338,6 +669,41 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--confirm", action="store_true", help="Required with --apply to actually mutate files."
     )
+    gate_group = parser.add_mutually_exclusive_group()
+    gate_group.add_argument(
+        "--llm-gate",
+        dest="use_llm_gate",
+        action="store_true",
+        default=True,
+        help="Filter RRF candidates through an LLM second-opinion gate (default).",
+    )
+    gate_group.add_argument(
+        "--no-llm-gate",
+        dest="use_llm_gate",
+        action="store_false",
+        help="Disable the LLM gate; emit RRF results directly (legacy behavior).",
+    )
+    parser.add_argument(
+        "--gate-threshold",
+        type=float,
+        default=DEFAULT_GATE_THRESHOLD,
+        help=(
+            f"Min confidence for a 'link' decision to survive into --apply "
+            f"(default: {DEFAULT_GATE_THRESHOLD})"
+        ),
+    )
+    parser.add_argument(
+        "--gate-prefilter",
+        type=int,
+        default=DEFAULT_GATE_PREFILTER,
+        help=f"Top-N RRF candidates per page sent to the gate (default: {DEFAULT_GATE_PREFILTER})",
+    )
+    parser.add_argument(
+        "--gate-model",
+        type=str,
+        default=None,
+        help="Override the LLM model for the gate (default: env-resolved MiniMax).",
+    )
     parser.add_argument("--json", action="store_true", help="Print structured summary to stdout.")
     args = parser.parse_args(argv)
 
@@ -353,6 +719,10 @@ def main(argv: list[str] | None = None) -> int:
             apply=args.apply,
             confirm=args.confirm,
             limit=args.limit,
+            use_llm_gate=args.use_llm_gate,
+            gate_threshold=args.gate_threshold,
+            gate_prefilter=args.gate_prefilter,
+            gate_model=args.gate_model,
         )
     except ValueError as exc:
         print(f"✗ {exc}", file=sys.stderr)
@@ -368,6 +738,9 @@ def main(argv: list[str] | None = None) -> int:
     print(f"Run ID:              {summary['run_id']}")
     print(f"Pages examined:      {summary['pages_examined']}")
     print(f"Suggestions emitted: {summary['suggestions_emitted']}")
+    print(
+        f"Gate passed:         {summary['gate_passed']}  (gate={'on' if summary['gate_enabled'] else 'off'})"
+    )
     print(f"Files mutated:       {summary['files_mutated']}")
     print(f"Mode:                {'APPLY' if summary['applied'] else 'dry-run'}")
     print(f"Log:                 {summary['log_path']}")

--- a/src/ovp_pipeline/graph/frontmatter.py
+++ b/src/ovp_pipeline/graph/frontmatter.py
@@ -99,8 +99,13 @@ class NoteMetadata:
         """从markdown内容解析frontmatter"""
         meta = cls()
 
-        # 提取frontmatter
-        fm_match = re.match(r'^---\n(.*?)\n---', markdown, re.DOTALL)
+        # Tolerate frontmatter wrapped in a ```yaml code fence (~387 such files
+        # in production vaults). LinkParser._get_note_id mirrors this so both
+        # parsers agree on the source slug — divergence here causes
+        # pages_index.slug ≠ page_links.source_slug and outbound-link queries
+        # silently return zero.
+        text_for_fm = re.sub(r"^```yaml\s*\n", "", markdown, count=1)
+        fm_match = re.match(r'^---\n(.*?)\n---', text_for_fm, re.DOTALL)
         if fm_match:
             fm_text = fm_match.group(1)
             meta._parse_fm_text(fm_text)

--- a/src/ovp_pipeline/graph/link_parser.py
+++ b/src/ovp_pipeline/graph/link_parser.py
@@ -128,7 +128,11 @@ class LinkParser:
             return self._note_id_cache[cache_key]
 
         text = content if content is not None else file_path.read_text(encoding="utf-8")
-        fm_match = re.match(r'^---\n(.*?)\n---', text, re.DOTALL)
+        # Tolerate frontmatter wrapped in a ```yaml code fence (~387 such files
+        # in production vaults). FrontmatterParser already handles this, so
+        # both parsers must agree to keep pages_index.slug == page_links.source_slug.
+        text_for_fm = re.sub(r"^```yaml\s*\n", "", text, count=1)
+        fm_match = re.match(r'^---\n(.*?)\n---', text_for_fm, re.DOTALL)
         if fm_match:
             note_id_match = re.search(r"^note_id:\s*['\"]?(.+?)['\"]?\s*$", fm_match.group(1), re.MULTILINE)
             if note_id_match:
@@ -136,7 +140,11 @@ class LinkParser:
                 self._note_id_cache[cache_key] = note_id
                 return note_id
 
-        note_id = self._slug_to_note_id(file_path.stem)
+        # Mirror NoteMetadata._generate_note_id: same canonicalization AND same
+        # 50-char truncation. Without alignment, page_links.source_slug derived
+        # from file_path.stem diverges from pages_index.slug for files lacking
+        # explicit note_id, leaving outbound links unjoinable.
+        note_id = self._slug_to_note_id(file_path.stem)[:50]
         self._note_id_cache[cache_key] = note_id
         return note_id
 

--- a/tests/test_graph_identity.py
+++ b/tests/test_graph_identity.py
@@ -33,6 +33,73 @@ Links to [[Another Concept]].
     assert links[0].target_raw == "Another Concept"
 
 
+def test_link_parser_tolerates_codefenced_frontmatter(temp_vault):
+    """Regression: ~387 production files have ```yaml-wrapped frontmatter.
+    FrontmatterParser tolerates the wrapper, so LinkParser must too — otherwise
+    pages_index.slug (from frontmatter) and page_links.source_slug (from
+    LinkParser) diverge and outbound-link queries silently return zero."""
+    note_path = (
+        temp_vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04-02_Long_Name.md"
+    )
+    note_path.parent.mkdir(parents=True, exist_ok=True)
+    note_path.write_text(
+        """```yaml
+---
+note_id: short-id
+title: Long Filename Note
+type: deep_dive
+date: 2026-04-02
+---
+```
+
+# Long Filename Note
+
+Refers to [[Some Target]].
+""",
+        encoding="utf-8",
+    )
+
+    meta = FrontmatterParser(temp_vault).parse_file(note_path)
+    links = LinkParser(temp_vault).parse_file(note_path)
+
+    # Both parsers must agree on the source slug — the bug was that LinkParser
+    # fell through to file_path.stem when it didn't see the leading "---".
+    assert meta.note_id == "short-id"
+    assert links, "expected at least one wikilink to be parsed"
+    assert links[0].source == "short-id"
+    assert links[0].target == "some-target"
+
+
+def test_link_parser_falls_back_to_truncated_path_slug(temp_vault):
+    """Regression: when a file lacks note_id in frontmatter, both parsers
+    must agree on the path-derived fallback slug. NoteMetadata._generate_note_id
+    truncates to 50 chars; LinkParser must mirror that or page_links.source_slug
+    won't join pages_index.slug for long-titled deep_dives."""
+    long_stem = "2026-04-09_Hyperagents a new way to auto-research_深度解读"
+    note_path = temp_vault / "20-Areas" / "AI-Research" / "Topics" / f"{long_stem}.md"
+    note_path.parent.mkdir(parents=True, exist_ok=True)
+    note_path.write_text(
+        """---
+title: "Hyperagents"
+type: deep_dive
+date: 2026-04-09
+---
+
+# Hyperagents
+
+Mentions [[AI Agent]].
+""",
+        encoding="utf-8",
+    )
+
+    meta = FrontmatterParser(temp_vault).parse_file(note_path)
+    links = LinkParser(temp_vault).parse_file(note_path)
+
+    # Both fall through to path-derived fallback; they MUST produce the same slug.
+    assert meta.note_id == links[0].source
+    assert len(meta.note_id) <= 50
+
+
 def test_graph_builder_resolves_registry_alias_without_unknown_placeholder(temp_vault):
     registry = ConceptRegistry(temp_vault)
     registry.add_entry(

--- a/tests/test_link_suggest.py
+++ b/tests/test_link_suggest.py
@@ -465,6 +465,36 @@ def test_no_llm_gate_falls_back_to_rrf_only(temp_vault):
         assert "confidence" not in row
 
 
+def test_llm_gate_requested_but_no_client_falls_back_cleanly(temp_vault, capsys, monkeypatch):
+    """Regression for the silent-rejection bug flagged on PR #66: when the
+    user passes --llm-gate but no API key is available, the previous fallback
+    returned confidence=rrf_score (~0.03) which then failed the 0.6 threshold
+    filter, silently dropping every candidate. The fix short-circuits to the
+    legacy RRF-only path with a stderr warning."""
+    _seed_evergreens(temp_vault)
+    rebuild_knowledge_index(temp_vault)
+
+    # Simulate "no API key / litellm" by forcing the default client factory
+    # to return None — the production code path the bug originally hit.
+    monkeypatch.setattr(
+        "ovp_pipeline.commands.link_suggest._make_default_gate_client",
+        lambda model=None: None,
+    )
+
+    summary = run_link_suggest(
+        temp_vault,
+        min_links=3,
+        suggestions_per_page=5,
+        apply=True,
+        confirm=True,
+        use_llm_gate=True,
+    )
+    assert summary["gate_enabled"] is False, "should report gate disabled after fallback"
+    assert summary["files_mutated"] >= 1, "RRF fallback must still produce applied suggestions"
+    captured = capsys.readouterr()
+    assert "falling back to RRF-only" in captured.err
+
+
 def test_gate_error_marks_candidates_as_skip(temp_vault):
     _seed_evergreens(temp_vault)
     rebuild_knowledge_index(temp_vault)

--- a/tests/test_link_suggest.py
+++ b/tests/test_link_suggest.py
@@ -17,7 +17,10 @@ import pytest
 from ovp_pipeline.commands.link_suggest import (
     BACKFILL_HEADING,
     BACKFILL_MARKER,
+    GATE_CACHE_FILENAME,
+    LINK_SUGGEST_GATE_PROMPT,
     RRF_K,
+    _parse_gate_response,
     run_link_suggest,
 )
 from ovp_pipeline.knowledge_index import rebuild_knowledge_index
@@ -101,7 +104,7 @@ def test_dry_run_emits_jsonl_for_under_linked_page(temp_vault):
     _seed_evergreens(temp_vault)
     rebuild_knowledge_index(temp_vault)
 
-    summary = run_link_suggest(temp_vault, min_links=3, suggestions_per_page=5)
+    summary = run_link_suggest(temp_vault, min_links=3, suggestions_per_page=5, use_llm_gate=False)
 
     assert summary["applied"] is False
     assert summary["files_mutated"] == 0
@@ -140,6 +143,7 @@ def test_apply_appends_backfill_section_and_is_idempotent(temp_vault):
         suggestions_per_page=3,
         apply=True,
         confirm=True,
+        use_llm_gate=False,
     )
     assert summary["applied"] is True
     assert summary["files_mutated"] >= 1
@@ -164,6 +168,7 @@ def test_apply_appends_backfill_section_and_is_idempotent(temp_vault):
         suggestions_per_page=3,
         apply=True,
         confirm=True,
+        use_llm_gate=False,
     )
     assert second["files_mutated"] == 0
     body_after = deep_dive_path.read_text(encoding="utf-8")
@@ -188,7 +193,7 @@ def test_existing_link_targets_are_skipped(temp_vault):
     )
 
     rebuild_knowledge_index(temp_vault)
-    summary = run_link_suggest(temp_vault, min_links=3, suggestions_per_page=5)
+    summary = run_link_suggest(temp_vault, min_links=3, suggestions_per_page=5, use_llm_gate=False)
 
     log_path = temp_vault / "60-Logs" / "link-suggestions" / f"{summary['run_id']}.jsonl"
     rows = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines() if line]
@@ -216,7 +221,7 @@ def test_min_links_threshold_excludes_well_linked_pages(temp_vault):
     )
 
     rebuild_knowledge_index(temp_vault)
-    summary = run_link_suggest(temp_vault, min_links=3)
+    summary = run_link_suggest(temp_vault, min_links=3, use_llm_gate=False)
 
     log_path = temp_vault / "60-Logs" / "link-suggestions" / f"{summary['run_id']}.jsonl"
     rows = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines() if line]
@@ -229,7 +234,7 @@ def test_log_path_round_trips_through_summary(temp_vault):
     _seed_evergreens(temp_vault)
     rebuild_knowledge_index(temp_vault)
 
-    summary = run_link_suggest(temp_vault, min_links=3, limit=2)
+    summary = run_link_suggest(temp_vault, min_links=3, limit=2, use_llm_gate=False)
     log_path = summary["log_path"]
     assert log_path.endswith(".jsonl")
     # The summary's count must equal the number of rows written.
@@ -246,7 +251,7 @@ def test_log_path_round_trips_through_summary(temp_vault):
 def test_no_pages_when_index_empty(temp_vault):
     """Empty vault → rebuild creates the schema → run returns zero rows."""
     rebuild_knowledge_index(temp_vault)
-    summary = run_link_suggest(temp_vault, min_links=3)
+    summary = run_link_suggest(temp_vault, min_links=3, use_llm_gate=False)
     assert summary["pages_examined"] == 0
     assert summary["suggestions_emitted"] == 0
     log_path = temp_vault / "60-Logs" / "link-suggestions" / f"{summary['run_id']}.jsonl"
@@ -289,7 +294,7 @@ function-calling, all in one stack.
     )
 
     rebuild_knowledge_index(temp_vault)
-    summary = run_link_suggest(temp_vault, min_links=3, suggestions_per_page=5)
+    summary = run_link_suggest(temp_vault, min_links=3, suggestions_per_page=5, use_llm_gate=False)
 
     log_path = temp_vault / "60-Logs" / "link-suggestions" / f"{summary['run_id']}.jsonl"
     rows = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines() if line]
@@ -299,3 +304,222 @@ function-calling, all in one stack.
     assert any(
         r["rrf_score"] > single_branch_ceiling for r in deep_dive_rows
     ), "at least one row must score above the single-branch ceiling — proves BM25 fired"
+
+
+# ---------------------------------------------------------------------------
+# Phase 38 Stage A.2 — LLM second-opinion gate
+# ---------------------------------------------------------------------------
+
+
+def _make_recording_gate(decisions_by_slug: dict[str, dict]) -> tuple[list, callable]:
+    """Build a fake gate client that returns canned decisions per candidate
+    slug. Returns ``(call_log, client)`` so tests can assert call counts."""
+    calls: list[tuple[str, str]] = []
+
+    def _client(system_prompt: str, user_prompt: str) -> str:
+        calls.append((system_prompt, user_prompt))
+        payload = json.loads(user_prompt)
+        decisions = []
+        for cand in payload["candidates"]:
+            slug = cand["slug"]
+            if slug in decisions_by_slug:
+                d = decisions_by_slug[slug]
+                decisions.append(
+                    {
+                        "slug": slug,
+                        "decision": d["decision"],
+                        "confidence": d["confidence"],
+                        "rationale": d.get("rationale", ""),
+                    }
+                )
+            else:
+                decisions.append(
+                    {"slug": slug, "decision": "skip", "confidence": 0.0, "rationale": "unknown"}
+                )
+        return json.dumps({"decisions": decisions})
+
+    return calls, _client
+
+
+def test_gate_filters_by_threshold_and_decision(temp_vault):
+    _seed_evergreens(temp_vault)
+    rebuild_knowledge_index(temp_vault)
+
+    canned = {
+        "ai-agent": {"decision": "link", "confidence": 0.9, "rationale": "core"},
+        "rag": {"decision": "link", "confidence": 0.5, "rationale": "weak"},  # below threshold
+        "function-calling": {"decision": "skip", "confidence": 0.95, "rationale": "off-topic"},
+    }
+    _, client = _make_recording_gate(canned)
+
+    summary = run_link_suggest(
+        temp_vault,
+        min_links=3,
+        suggestions_per_page=5,
+        gate_threshold=0.6,
+        gate_client=client,
+    )
+
+    assert summary["gate_enabled"] is True
+    log_path = temp_vault / "60-Logs" / "link-suggestions" / f"{summary['run_id']}.jsonl"
+    rows = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines() if line]
+    deep = [r for r in rows if r["source_slug"] == "2026-04-23-ai-stack"]
+    # Every candidate should be present with a decision/confidence/rationale.
+    assert deep
+    for row in deep:
+        assert "decision" in row and row["decision"] in {"link", "skip"}
+        assert "confidence" in row
+        assert "rationale" in row
+    # Only ai-agent (link, 0.9) should pass — rag is below threshold, function-calling skipped.
+    passed = [r for r in deep if r["decision"] == "link" and r["confidence"] >= 0.6]
+    passed_slugs = {r["target_slug"] for r in passed}
+    assert "ai-agent" in passed_slugs
+    assert "rag" not in passed_slugs
+    assert "function-calling" not in passed_slugs
+    assert summary["gate_passed"] >= 1
+
+
+def test_gate_apply_only_writes_link_decisions(temp_vault):
+    _seed_evergreens(temp_vault)
+    rebuild_knowledge_index(temp_vault)
+
+    canned = {
+        "ai-agent": {"decision": "link", "confidence": 0.9, "rationale": "core"},
+        "rag": {"decision": "skip", "confidence": 0.95, "rationale": "off-topic"},
+        "function-calling": {"decision": "skip", "confidence": 0.9, "rationale": "off-topic"},
+    }
+    _, client = _make_recording_gate(canned)
+
+    summary = run_link_suggest(
+        temp_vault,
+        min_links=3,
+        suggestions_per_page=5,
+        apply=True,
+        confirm=True,
+        gate_threshold=0.6,
+        gate_client=client,
+    )
+    assert summary["applied"] is True
+
+    deep_path = (
+        temp_vault
+        / "20-Areas"
+        / "AI-Research"
+        / "Topics"
+        / "2026-04"
+        / "2026-04-23_AI_Stack_深度解读.md"
+    )
+    body = deep_path.read_text(encoding="utf-8")
+    assert BACKFILL_MARKER in body
+    assert "[[ai-agent" in body
+    # Skipped candidates must NOT appear in the backfill section.
+    backfill_section = body[body.index(BACKFILL_MARKER) :]
+    assert "[[rag" not in backfill_section
+    assert "[[function-calling" not in backfill_section
+
+
+def test_gate_cache_skips_redundant_llm_calls(temp_vault):
+    _seed_evergreens(temp_vault)
+    rebuild_knowledge_index(temp_vault)
+
+    canned = {
+        "ai-agent": {"decision": "link", "confidence": 0.9, "rationale": "core"},
+        "rag": {"decision": "link", "confidence": 0.85, "rationale": "ground"},
+        "function-calling": {"decision": "skip", "confidence": 0.9, "rationale": "off"},
+    }
+    calls, client = _make_recording_gate(canned)
+
+    run_link_suggest(
+        temp_vault,
+        min_links=3,
+        suggestions_per_page=5,
+        gate_client=client,
+    )
+    first_calls = len(calls)
+    assert first_calls >= 1
+
+    cache_path = temp_vault / "60-Logs" / "link-suggestions" / GATE_CACHE_FILENAME
+    assert cache_path.exists()
+
+    # Re-run: cache should absorb every candidate, so no new gate calls fire.
+    run_link_suggest(
+        temp_vault,
+        min_links=3,
+        suggestions_per_page=5,
+        gate_client=client,
+    )
+    assert len(calls) == first_calls, "cache must short-circuit the gate on re-run"
+
+
+def test_no_llm_gate_falls_back_to_rrf_only(temp_vault):
+    _seed_evergreens(temp_vault)
+    rebuild_knowledge_index(temp_vault)
+
+    summary = run_link_suggest(temp_vault, min_links=3, suggestions_per_page=5, use_llm_gate=False)
+    assert summary["gate_enabled"] is False
+    log_path = temp_vault / "60-Logs" / "link-suggestions" / f"{summary['run_id']}.jsonl"
+    rows = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines() if line]
+    # Without the gate, rows must NOT carry decision/confidence/rationale.
+    for row in rows:
+        assert "decision" not in row
+        assert "confidence" not in row
+
+
+def test_gate_error_marks_candidates_as_skip(temp_vault):
+    _seed_evergreens(temp_vault)
+    rebuild_knowledge_index(temp_vault)
+
+    def _broken_client(system_prompt: str, user_prompt: str) -> str:
+        raise RuntimeError("simulated LLM outage")
+
+    summary = run_link_suggest(
+        temp_vault,
+        min_links=3,
+        suggestions_per_page=5,
+        apply=True,
+        confirm=True,
+        gate_client=_broken_client,
+    )
+    assert summary["files_mutated"] == 0  # everything skipped → nothing to write
+    log_path = temp_vault / "60-Logs" / "link-suggestions" / f"{summary['run_id']}.jsonl"
+    rows = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines() if line]
+    # All rows must be marked skip with the gate-error rationale.
+    skipped = [r for r in rows if r.get("decision") == "skip"]
+    assert skipped
+    assert any("gate error" in r["rationale"] for r in skipped)
+
+
+def test_parse_gate_response_handles_fenced_json():
+    fenced = """```json
+{"decisions": [{"slug": "x", "decision": "link", "confidence": 0.8, "rationale": "ok"}]}
+```"""
+    parsed = _parse_gate_response(fenced)
+    assert len(parsed) == 1
+    assert parsed[0]["slug"] == "x"
+    assert parsed[0]["decision"] == "link"
+    assert parsed[0]["confidence"] == 0.8
+
+
+def test_parse_gate_response_drops_invalid_decisions():
+    text = json.dumps(
+        {
+            "decisions": [
+                {"slug": "ok", "decision": "link", "confidence": 0.9},
+                {"slug": "", "decision": "link", "confidence": 0.9},  # empty slug → drop
+                {"slug": "bad", "decision": "maybe", "confidence": 0.9},  # bad decision → drop
+                {"slug": "clamp", "decision": "link", "confidence": 2.5},  # clamps to 1.0
+            ]
+        }
+    )
+    parsed = _parse_gate_response(text)
+    by_slug = {p["slug"]: p for p in parsed}
+    assert "ok" in by_slug
+    assert "" not in by_slug
+    assert "bad" not in by_slug
+    assert by_slug["clamp"]["confidence"] == 1.0
+
+
+def test_gate_prompt_is_chinese_with_strict_rubric():
+    # Sanity: the prompt that ships must enforce the conservative confidence rubric.
+    assert "0.6" in LINK_SUGGEST_GATE_PROMPT
+    assert "skip" in LINK_SUGGEST_GATE_PROMPT


### PR DESCRIPTION
## Summary

Two related Phase 38 Stage A follow-ups discovered while running the first full `--apply` on a production vault.

### 1. LLM second-opinion gate for `ovp-link-suggest`

RRF-only precision was ~33% (noisy "related but not really link-worthy" suggestions). Added a LiteLLM/MiniMax gate that classifies each candidate as `link | skip` with confidence + 1-line rationale.

- New flags: `--llm-gate / --no-llm-gate`, `--gate-threshold` (default 0.6), `--gate-prefilter`, `--gate-model`
- Decisions cached in `60-Logs/link-suggestions/.gate-cache.jsonl` (idempotent re-runs)
- Graceful fallback when the gate is unavailable
- Smoke test on openclaw-vault: 5 candidates passed at 0.68–0.9 confidence (12.5% pass rate vs 33% legacy)

### 2. Indexer slug-derivation bug

Full `--apply` on 249 deep_dives mutated 189 files, but only 75 showed up with indexed wikilinks. Two divergences between `FrontmatterParser` and `LinkParser`:

- **Codefenced frontmatter** (~387 such files): neither parser stripped a leading `` ```yaml `` fence, so both fell through to path-derived defaults.
- **50-char truncation**: `NoteMetadata._generate_note_id` truncates path stems to 50 chars; `LinkParser._get_note_id` did not, leaving `pages_index.slug ≠ page_links.source_slug`.

Both parsers now strip the codefence before regex match, and `LinkParser` mirrors the 50-char truncation.

**Result:** edge count 11,366 → 20,999. 187/189 (99%) mutated files correctly indexed (the remaining 2 link only to deep_dives, which `page_links` excludes by design).

## Test plan

- [x] `pytest tests/test_link_suggest.py` — 8 new gate tests + 8 modified existing tests pass
- [x] `pytest tests/test_graph_identity.py` — 2 new regression tests for codefence + truncation alignment pass
- [x] Full suite: 990/991 pass (one pre-existing unrelated version-string test)
- [x] Smoke: full `--apply` against openclaw-vault confirmed 187/189 indexed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/66" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional LLM-based filtering for link suggestions with configurable confidence thresholds and persistent caching to avoid redundant API calls.
  * Enhanced output with gate metadata (decision confidence and rationale).

* **Bug Fixes**
  * Improved handling of YAML-formatted frontmatter blocks.
  * Fixed slug consistency for notes lacking explicit identifiers.

* **Tests**
  * Added regression tests for parser and filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->