### PR TITLE
docs: cover Phase 38 capabilities

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,14 +80,18 @@ my-vault/
 │   └── Programming/
 ├── 30-Projects/         # 项目：有截止日的具体项目
 ├── 40-Resources/        # 资源：参考资料库
+│   └── Crystals/        # ovp-build-crystals 物化的持久化 briefing (Phase 38 Stage B)
 ├── 50-Inbox/            # 收件箱：原始输入
 │   ├── 01-Raw/         # 原始文章（AutoPilot 监控目录）
 │   └── Processing-Queue.md
 ├── 60-Logs/             # 日志：审计与调试
 │   ├── scripts/         # 维护脚本
 │   ├── pipeline.jsonl   # 结构化日志
-│   └── transactions/    # 事务状态
+│   ├── transactions/    # 事务状态
+│   ├── link-suggestions/ # ovp-link-suggest JSONL 输出
+│   └── working-memory/  # ovp-working-memory 每日 distill (YYYY-MM-DD.md)
 ├── 70-Archive/          # 归档：已完成/过时内容
+│   └── dedup-merged/    # ovp-concept-dedup --apply 归档失败者
 ├── 80-Views/            # 视图：数据展示
 ├── 90-Templates/        # 模板：可复用模板
 └── CLAUDE.md           # 本文件：Schema 定义

--- a/README.md
+++ b/README.md
@@ -367,6 +367,22 @@ interpretation
 | `ovp-graph daily today --vault-dir <vault>` | 生成 daily delta |
 | `ovp-graph build --layered --seed-match <pattern> --output <out.html>` | 子图浏览（HTML 交互式） |
 | `ovp-lint --check --vault-dir <vault>` | 运行链接/结构检查 |
+| `ovp-query "..." --engine fused` | 默认即 fused（BM25 + 向量 RRF + Recency/Frequency/Importance 衰减），`--engine bm25 \| vector` 显式回退 |
+
+### 链接密度 / 语义层 / Crystal / Exploration
+
+Phase 38 把链接密度和语义层补齐，并给 reviewer 一个图原生的探索面。
+
+| 命令 | 说明 |
+|---|---|
+| `ovp-link-suggest --vault-dir <vault> --dry-run` | 为 `link_out_count < 3` 的 evergreen / deep_dive 跑 BM25+向量混合检索，输出 JSONL 候选到 `60-Logs/link-suggestions/<run_id>.jsonl` |
+| `ovp-link-suggest --apply --confirm` | 把候选写回原 markdown body（默认 `--dry-run`，必须 `--confirm` 才能落盘） |
+| `ovp-link-suggest --llm-gate` | 增加 LLM 二次裁判，按 `link \| skip` 分类；客户端不可用时打印 stderr 警告并回退到 RRF-only |
+| `ovp-build-crystals --vault-dir <vault>` | 物化 briefing 快照到 `40-Resources/Crystals/<crystal_id>.md`，frontmatter 记录 `source_object_ids` 与 `evolves_relations` |
+| `ovp-working-memory --vault-dir <vault>` | 写入今日 `60-Logs/working-memory/YYYY-MM-DD.md`：Top of Mind / Fresh Crystals / Pending Decisions / EVOLVES Today / Pulse Highlights；幂等覆盖 |
+| `ovp-concept-dedup --propose` / `--apply --confirm` | 基于 cosine 相似度合并近义 evergreen，`--apply` 写回链接并归档失败者到 `70-Archive/dedup-merged/` |
+| `ovp-mcp --vault-dir <vault>` | stdio JSON-RPC 服务，暴露 `graph_node_details / graph_neighborhood / graph_shortest_path / graph_bridge_nodes / graph_communities` 等 MCP 工具；`graph_neighborhood` 接受 `render: "json" \| "html"` |
+| `ovp-ui` 路由 `/explore?object_id=<id>` | 三栏 reviewer UI：图谱 canvas + agent timeline (SSE) + Crystal 合成面板 |
 
 #### `ovp-graph build` 推荐组合
 
@@ -407,14 +423,19 @@ vault/
 │       └── alias-index.json
 ├── 20-Areas/
 │   └── {AI-Research, Investing, Programming, Tools}/Topics/YYYY-MM/
+├── 40-Resources/
+│   └── Crystals/                    # ovp-build-crystals 物化的持久化 briefing
 ├── 60-Logs/
 │   ├── pipeline.jsonl
 │   ├── refine-mutations.jsonl
 │   ├── transactions/
 │   ├── quality-reports/
 │   ├── daily-deltas/
+│   ├── link-suggestions/            # ovp-link-suggest 输出 JSONL
+│   ├── working-memory/              # ovp-working-memory 每日 distill
 │   └── knowledge.db
 └── 70-Archive/
+    └── dedup-merged/                # ovp-concept-dedup --apply 归档
 ```
 
 ## `knowledge.db` 提供什么
@@ -428,6 +449,7 @@ vault/
 - `timeline_events`
 - `audit_events`
 - `page_embeddings`
+- `page_metrics`（last_seen_ts / reuse_count / citation_count，供 `search_fused` 衰减排序）
 
 它由 `ovp-knowledge-index` 重建，供以下读取场景使用：
 
@@ -439,9 +461,8 @@ vault/
 
 默认 discovery 也已经统一到这里：
 
-- `ovp-query` 默认走 `knowledge.db`
-- 关键词检索使用 FTS5 BM25
-- 语义检索使用本地 deterministic embeddings
+- `ovp-query` 默认走 `knowledge.db` 的 `search_fused`：BM25 + 向量 RRF (k=60)，再叠 Recency / Frequency / Importance 衰减
+- `--engine bm25` / `--engine vector` 可显式回退到单引擎
 - QMD 不再是默认检索依赖，只能通过显式 `--engine qmd` 启用
 
 ## 快速开始


### PR DESCRIPTION
## Summary

Phase 38 (Stage A/B/C — PRs #59, #61, #62) shipped without README/CLAUDE updates. This PR closes that gap.

- **README**: new `链接密度 / 语义层 / Crystal / Exploration` command table; `search_fused` as default for `ovp-query`; `page_metrics` added to `knowledge.db` schema list; vault directory tree updated for `40-Resources/Crystals/`, `60-Logs/link-suggestions/`, `60-Logs/working-memory/`, `70-Archive/dedup-merged/`.
- **CLAUDE.md**: mirror the new derived directories in §1.

Doc-only — no code changes, no test impact.

## Test plan

- [x] Manually rendered `README.md` and `CLAUDE.md` to verify markdown layout
- [x] Cross-checked CLI list against `pyproject.toml [project.scripts]`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/67" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated search and retrieval documentation describing the new default behavior combining multiple search methods with enhanced ranking and relevance capabilities.
  * Added documentation for new command-line switches and exploration-phase commands covering link suggestions, content generation, concept organization, and service features.
  * Expanded vault directory structure documentation to reflect new persistent output locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->