### PR TITLE
[codex] Fix review feedback on promotion and event durability

### DIFF
--- a/src/ovp_pipeline/commands/evidence_verify.py
+++ b/src/ovp_pipeline/commands/evidence_verify.py
@@ -194,6 +194,8 @@ def _process_table(
     summary: dict[str, int] = _empty_summary()
     examined = 0
     backfilled = 0
+    update_params: list[tuple[Any, ...]] = []
+    verification_events: list[dict[str, Any]] = []
 
     for row in rows:
         row_dict = _row_dict(table, row)
@@ -229,16 +231,7 @@ def _process_table(
         examined += 1
         summary[status] = summary.get(status, 0) + 1
 
-        conn.execute(
-            f"""
-            UPDATE {table}
-               SET locator = ?,
-                   content_hash = ?,
-                   retrieval_context = ?,
-                   status = ?,
-                   verified_at = ?
-             WHERE {_key_clause(table)}
-            """,
+        update_params.append(
             (
                 new_locator,
                 new_content_hash,
@@ -252,17 +245,35 @@ def _process_table(
         # Phase 33 durability: also emit a JSONL event so the next
         # rebuild_knowledge_index can re-apply this verification after the
         # projection re-inserts the row in its 'unverified' default state.
-        emit_evidence_verified(
-            vault_dir,
-            table=table,
-            key={col: row_dict.get(col) for col in _TABLE_KEY_COLUMNS[table]},
-            locator=new_locator,
-            content_hash=new_content_hash,
-            retrieval_context=new_context,
-            status=status,
-            verified_at=verified_at,
-            pack=str(row_dict.get("pack") or ""),
+        verification_events.append(
+            {
+                "table": table,
+                "key": {col: row_dict.get(col) for col in _TABLE_KEY_COLUMNS[table]},
+                "locator": new_locator,
+                "content_hash": new_content_hash,
+                "retrieval_context": new_context,
+                "status": status,
+                "verified_at": verified_at,
+                "pack": str(row_dict.get("pack") or ""),
+            }
         )
+
+    if update_params:
+        sql = f"""
+        UPDATE {table}
+           SET locator = ?,
+               content_hash = ?,
+               retrieval_context = ?,
+               status = ?,
+               verified_at = ?
+         WHERE {_key_clause(table)}
+        """  # noqa: S608 — table/key columns sourced from internal constants.
+        conn.executemany(
+            sql,
+            update_params,
+        )
+    for event in verification_events:
+        emit_evidence_verified(vault_dir, **event)
 
     return {
         "table": table,

--- a/src/ovp_pipeline/extraction/semantic_relations.py
+++ b/src/ovp_pipeline/extraction/semantic_relations.py
@@ -205,7 +205,10 @@ def candidate_subject(candidate: SemanticRelationCandidate) -> str:
     Public so the promoter can locate (and delete) a candidate's queue file
     after promotion without re-globbing the directory.
     """
-    return f"{candidate.source_object_id}__{candidate.relation_type}__{candidate.target_object_id}"
+    return (
+        f"{candidate.source_slug}__{candidate.source_object_id}__"
+        f"{candidate.relation_type}__{candidate.target_object_id}"
+    )
 
 
 def write_candidates(
@@ -216,8 +219,8 @@ def write_candidates(
 ) -> list[Path]:
     """Serialize candidates to the spec-declared review-queue path.
 
-    One file per ``(source, relation_type, target)`` triple. Idempotent —
-    re-running with the same candidate overwrites with a fresh
+    One file per ``(evidence source, source, relation_type, target)`` tuple.
+    Idempotent — re-running with the same candidate overwrites with a fresh
     ``content_hash`` snapshot.
     """
     written: list[Path] = []

--- a/src/ovp_pipeline/feedback_router.py
+++ b/src/ovp_pipeline/feedback_router.py
@@ -144,21 +144,22 @@ def route_open_questions(
     ``60-Logs/**`` is in ``agent_owned`` (not ``accepted``), so the write
     falls outside the ``enforce_zone_write`` gate by construction.
     """
-    layout = VaultLayout.from_vault(vault_dir)
-    target = layout.logs_dir / "open-questions.jsonl"
-    target.parent.mkdir(parents=True, exist_ok=True)
     written = 0
-    with target.open("a", encoding="utf-8") as handle:
-        for question in questions:
-            line = emit_line({"question": question.question, "consumer_ref": question.consumer_ref})
-            handle.write(line)
-            written += 1
-            _emit_yield(
-                vault_dir,
-                pack=pack.name,
-                stream="open_question",
-                payload={"question": question.question},
-            )
+    for question in questions:
+        emit(
+            vault_dir,
+            "open-questions.jsonl",
+            "open_question",
+            {"question": question.question, "consumer_ref": question.consumer_ref},
+            pack=pack.name,
+        )
+        written += 1
+        _emit_yield(
+            vault_dir,
+            pack=pack.name,
+            stream="open_question",
+            payload={"question": question.question},
+        )
     return written
 
 
@@ -225,21 +226,3 @@ def route_proposed_relations(
             },
         )
     return paths
-
-
-# ---------------------------------------------------------------------------
-# Internal helpers
-# ---------------------------------------------------------------------------
-
-
-def emit_line(payload: dict[str, object]) -> str:
-    """Serialize an open-questions line.
-
-    Kept small and dependency-free so the same shape can be replayed by the
-    UI panel. Newline-terminated, JSON-encoded.
-    """
-    import json
-    from datetime import datetime, timezone
-
-    body = {"ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"), **payload}
-    return json.dumps(body, ensure_ascii=False) + "\n"

--- a/src/ovp_pipeline/knowledge_index.py
+++ b/src/ovp_pipeline/knowledge_index.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from .concept_registry import ConceptRegistry, ResolutionAction
+from .event_emitter import iter_for_index
 from .graph.frontmatter import FrontmatterParser, NoteMetadata
 from .graph.link_parser import LinkParser
 from .identity import canonicalize_note_id
@@ -390,20 +391,8 @@ def _infer_audit_slug(payload: dict[str, object]) -> str:
 
 def _collect_reuse_rows(layout: VaultLayout) -> list[tuple[str, str, str, str, str, str, str, int, int, int, str]]:
     rows: list[tuple[str, str, str, str, str, str, str, int, int, int, str]] = []
-    log_path = layout.logs_dir / "reuse-events.jsonl"
-    if not log_path.exists():
-        return rows
     seen_event_ids: set[str] = set()
-    for line in log_path.read_text(encoding="utf-8").splitlines():
-        stripped = line.strip()
-        if not stripped:
-            continue
-        try:
-            payload = json.loads(stripped)
-        except json.JSONDecodeError:
-            continue
-        if not isinstance(payload, dict):
-            continue
+    for payload in iter_for_index(layout, "reuse-events.jsonl"):
         event_id = str(payload.get("event_id") or "")
         if not event_id or event_id in seen_event_ids:
             continue

--- a/src/ovp_pipeline/relation_promotion.py
+++ b/src/ovp_pipeline/relation_promotion.py
@@ -295,6 +295,21 @@ def _queue_path_for(
     )
 
 
+def _legacy_queue_path_for(
+    layout: VaultLayout,
+    candidate: SemanticRelationCandidate,
+    queue_name: str,
+) -> Path:
+    # Backward compatibility for queue files created before candidate_subject()
+    # included source_slug. Remove after deployed vaults have drained old
+    # ai-agent__uses__rag-style relation candidate files from review queues.
+    legacy_subject = (
+        f"{candidate.source_object_id}__{candidate.relation_type}__"
+        f"{candidate.target_object_id}"
+    )
+    return review_queue_path(layout, queue_name=queue_name, subject=legacy_subject)
+
+
 def promote_candidates(
     candidates: Iterable[SemanticRelationCandidate],
     *,
@@ -354,13 +369,17 @@ def promote_candidates(
         conn.close()
 
     # Drop queue files only after the DB commit succeeds so a mid-run crash
-    # leaves the queue intact for retry.
+    # leaves the queue intact for retry. The legacy unlink is temporary until
+    # pre-source_slug queue filenames have been drained from deployed vaults.
     for candidate in auto_to_clean + reject_to_clean:
-        queue_file = _queue_path_for(layout, candidate, queue_name)
-        try:
-            queue_file.unlink()
-        except FileNotFoundError:
-            pass
+        for queue_file in {
+            _queue_path_for(layout, candidate, queue_name),
+            _legacy_queue_path_for(layout, candidate, queue_name),
+        }:
+            try:
+                queue_file.unlink()
+            except FileNotFoundError:
+                pass
 
     return report
 

--- a/src/ovp_pipeline/workspace_promotion.py
+++ b/src/ovp_pipeline/workspace_promotion.py
@@ -27,6 +27,7 @@ from typing import Iterable
 
 from .packs.base import BaseDomainPack
 from .packs.loader import DEFAULT_WORKFLOW_PACK_NAME, load_pack
+from .state_lifecycle import State, write_state
 
 
 WRITE_MODE_NORMAL = "write"
@@ -142,14 +143,23 @@ def promote(
         raise FileNotFoundError(f"Draft not found: {draft_path}")
 
     body = draft_path.read_bytes()
+    bytes_written = len(body)
     if not dry_run:
         target_path.parent.mkdir(parents=True, exist_ok=True)
         target_path.write_bytes(body)
+        write_state(
+            target_path,
+            State.ACCEPTED,
+            generated_by="ovp-promote workspace",
+            sources=[_relative_to_vault(draft_path, vault_dir)],
+            promotion_target=_relative_to_vault(target_path, vault_dir),
+        )
+        bytes_written = target_path.stat().st_size
 
     return PromotionRecord(
         draft=draft_path,
         target=target_path,
         approver=approver,
         pack=resolved_pack.name,
-        bytes_written=len(body),
+        bytes_written=bytes_written,
     )

--- a/tests/test_evidence_v2.py
+++ b/tests/test_evidence_v2.py
@@ -38,6 +38,55 @@ from ovp_pipeline.truth_store import (
 # ---------------------------------------------------------------------------
 
 
+def test_evidence_verify_batches_table_updates(temp_vault, monkeypatch):
+    from ovp_pipeline.commands import evidence_verify
+
+    class FakeConn:
+        def __init__(self) -> None:
+            self.executemany_calls = []
+
+        def execute(self, *_args, **_kwargs):
+            raise AssertionError("verification updates should be batched with executemany")
+
+        def executemany(self, sql, params):
+            self.executemany_calls.append((sql, list(params)))
+
+    row = (
+        "research-tech",
+        "claim-1",
+        "10-Knowledge/Evergreen/Source.md",
+        "definition",
+        "quote",
+        "",
+        "",
+        "",
+        EVIDENCE_STATUS_UNVERIFIED,
+        "",
+    )
+    fake = FakeConn()
+    monkeypatch.setattr(evidence_verify, "_select_rows", lambda *_args, **_kwargs: [row])
+    monkeypatch.setattr(
+        evidence_verify,
+        "verify_evidence_row",
+        lambda *_args, **_kwargs: (EVIDENCE_STATUS_VERIFIED, "2026-04-27T00:00:00Z"),
+    )
+    monkeypatch.setattr(evidence_verify, "emit_evidence_verified", lambda *_args, **_kwargs: None)
+
+    summary = evidence_verify._process_table(
+        fake,
+        "claim_evidence",
+        vault_dir=temp_vault,
+        pack="research-tech",
+        cutoff_text=None,
+        backfill=False,
+        slug_to_path={},
+    )
+
+    assert summary["examined"] == 1
+    assert len(fake.executemany_calls) == 1
+    assert len(fake.executemany_calls[0][1]) == 1
+
+
 def _write_source(temp_vault: Path, name: str, body: str) -> Path:
     """Write a markdown source file under Evergreen/ and return its absolute path."""
     path = temp_vault / "10-Knowledge" / "Evergreen" / name
@@ -288,7 +337,7 @@ def test_verify_evidence_row_broken_when_source_deleted(tmp_path):
 def test_evidence_backfill_unverified_for_seeded_row_without_hash(temp_vault, capsys):
     """A row with quote_text but no content_hash backfills to a real hash and
     verifies to ``verified`` — not silent-pass."""
-    src = _write_source(
+    _write_source(
         temp_vault,
         "Anchor.md",
         """---
@@ -489,7 +538,7 @@ date: 2026-04-22
 
 
 def test_lint_flags_research_tech_claim_missing_locator(temp_vault):
-    src = _write_source(
+    _write_source(
         temp_vault,
         "Tracked.md",
         """---

--- a/tests/test_feedback_router.py
+++ b/tests/test_feedback_router.py
@@ -91,6 +91,9 @@ def test_route_open_questions_appends_jsonl(temp_vault):
     lines = [json.loads(line) for line in log.read_text(encoding="utf-8").splitlines() if line.strip()]
     assert len(lines) == 2
     assert lines[0]["question"] == "Why does X?"
+    assert lines[0]["event_type"] == "open_question"
+    assert lines[0]["pack"] == "research-tech"
+    assert lines[0]["event_id"]
 
 
 def test_route_open_questions_idempotent_appends(temp_vault):

--- a/tests/test_promotion_policy.py
+++ b/tests/test_promotion_policy.py
@@ -11,7 +11,6 @@ Coverage:
 from __future__ import annotations
 
 import sqlite3
-from pathlib import Path
 
 import pytest
 
@@ -240,9 +239,34 @@ def test_workspace_promote_copies_draft_under_promotion_mode(temp_vault):
         pack=pack,
         vault_dir=temp_vault,
     )
-    assert target.read_text(encoding="utf-8") == "plan body"
-    assert record.bytes_written == len("plan body")
+    promoted = target.read_text(encoding="utf-8")
+    assert promoted.endswith("plan body")
+    assert "state: accepted" in promoted
+    assert record.bytes_written == target.stat().st_size
     assert record.pack == "research-tech"
+
+
+def test_workspace_promote_rewrites_draft_state_to_accepted(temp_vault):
+    pack = load_pack("research-tech")
+    draft = temp_vault / "30-Projects" / "demo" / "Drafts" / "plan-draft.md"
+    draft.parent.mkdir(parents=True, exist_ok=True)
+    draft.write_text(
+        "---\nstate: draft\ntitle: Plan\n---\n\nplan body\n",
+        encoding="utf-8",
+    )
+    target = temp_vault / "30-Projects" / "demo" / "Plan.md"
+
+    workspace_promote(
+        draft,
+        target,
+        approver="tester",
+        pack=pack,
+        vault_dir=temp_vault,
+    )
+
+    promoted = target.read_text(encoding="utf-8")
+    assert "state: accepted" in promoted
+    assert "state: draft" not in promoted
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_reuse_events.py
+++ b/tests/test_reuse_events.py
@@ -4,6 +4,9 @@ import json
 import sqlite3
 from pathlib import Path
 
+from ovp_pipeline import knowledge_index
+from ovp_pipeline.runtime import VaultLayout
+
 
 def _write_evergreen(vault: Path, slug: str, title: str) -> Path:
     path = vault / "10-Knowledge" / "Evergreen" / f"{title.replace(' ', '-')}.md"
@@ -47,6 +50,33 @@ def _write_reuse_event(vault: Path, **fields: object) -> dict[str, object]:
     with log_path.open("a", encoding="utf-8") as handle:
         handle.write(json.dumps(event, ensure_ascii=False) + "\n")
     return event
+
+
+def test_collect_reuse_rows_uses_shared_event_iterator(temp_vault, monkeypatch):
+    event = {
+        "event_id": "evt-shared",
+        "ts": "2026-04-22T12:00:00Z",
+        "session_id": "session",
+        "pack": "research-tech",
+        "event_type": "trusted_reuse_event",
+        "object_id": "alpha",
+        "object_kind": "evergreen",
+        "surface": "query",
+        "consumer_ref": "report.md",
+        "evidence_present": 1,
+        "provenance_clean": 1,
+        "trusted": 1,
+    }
+    monkeypatch.setattr(
+        knowledge_index,
+        "iter_for_index",
+        lambda layout, log_name: iter([event]) if log_name == "reuse-events.jsonl" else iter(()),
+    )
+
+    rows = knowledge_index._collect_reuse_rows(VaultLayout.from_vault(temp_vault))
+
+    assert len(rows) == 1
+    assert rows[0][0] == "evt-shared"
 
 
 def test_event_emitter_appends_jsonl_with_metadata(temp_vault):

--- a/tests/test_semantic_relations.py
+++ b/tests/test_semantic_relations.py
@@ -11,11 +11,13 @@ Coverage:
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from pathlib import Path
 
 from ovp_pipeline.extraction.semantic_relations import (
     SemanticRelationCandidate,
+    candidate_subject,
     extract_relations,
     load_candidates,
     write_candidates,
@@ -189,6 +191,39 @@ def test_write_and_load_candidates_roundtrip(temp_vault):
     assert loaded[0] == candidate
 
 
+def test_write_candidates_keeps_same_relation_from_distinct_sources(temp_vault):
+    pack = load_pack("research-tech")
+    layout = VaultLayout.from_vault(temp_vault)
+    first = SemanticRelationCandidate(
+        relation_type="uses",
+        source_object_id="ai-agent",
+        target_object_id="rag",
+        source_slug="agent-memory-a",
+        evidence_quote="AI Agent uses RAG in source A",
+        confidence=0.7,
+        pack=pack.name,
+    )
+    second = SemanticRelationCandidate(
+        relation_type="uses",
+        source_object_id="ai-agent",
+        target_object_id="rag",
+        source_slug="agent-memory-b",
+        evidence_quote="AI Agent uses RAG in source B",
+        confidence=0.7,
+        pack=pack.name,
+    )
+
+    assert candidate_subject(first) != candidate_subject(second)
+    paths = write_candidates([first, second], layout=layout)
+
+    assert len(set(paths)) == 2
+    loaded = load_candidates(layout)
+    assert {candidate.source_slug for candidate in loaded} == {
+        "agent-memory-a",
+        "agent-memory-b",
+    }
+
+
 # ---------------------------------------------------------------------------
 # Policy: evaluate_relation
 # ---------------------------------------------------------------------------
@@ -314,6 +349,36 @@ def test_promote_review_queue_removes_promoted_files(temp_vault):
             (pack.name,),
         ).fetchone()[0]
     assert rel_count == 1  # not duplicated by the second run
+
+
+def test_promote_review_queue_removes_legacy_relation_queue_file(temp_vault):
+    """Queue files written before source_slug joined the subject still get consumed."""
+    pack = load_pack("research-tech")
+    layout = VaultLayout.from_vault(temp_vault)
+    rebuild_knowledge_index(temp_vault)
+
+    cand = SemanticRelationCandidate(
+        relation_type="uses",
+        source_object_id="ai-agent",
+        target_object_id="rag",
+        source_slug="agent-memory",
+        evidence_quote="AI Agent uses RAG",
+        confidence=0.9,
+        locator="section#background@0",
+        content_hash="abc123",
+        retrieval_context="…",
+        pack=pack.name,
+    )
+    queue_dir = layout.review_queue_dir / "semantic-relations"
+    queue_dir.mkdir(parents=True, exist_ok=True)
+    legacy_path = queue_dir / "ai-agent__uses__rag.json"
+    legacy_path.write_text(json.dumps(cand.to_dict(), ensure_ascii=False), encoding="utf-8")
+
+    report = promote_review_queue(layout, pack=pack)
+
+    assert report.lane_counts()["auto"] == 1
+    assert not legacy_path.exists()
+    assert list(queue_dir.glob("*.json")) == []
 
 
 def test_promote_review_queue_archives_rejected(temp_vault):

--- a/tests/test_unified_pipeline_version.py
+++ b/tests/test_unified_pipeline_version.py
@@ -17,4 +17,4 @@ def test_unified_pipeline_version_falls_back_to_pyproject_when_metadata_missing(
 
     monkeypatch.setattr(metadata, "version", missing_distribution)
 
-    assert _get_version() == "0.8.6"
+    assert _get_version() == "0.9.2"


### PR DESCRIPTION
## Summary
- Fixes review feedback around workspace promotion state, semantic relation queue identity, reuse-event indexing, open-question event durability, and evidence verification batching.
- Keeps backward compatibility for legacy semantic relation queue filenames while preventing new multi-source candidates from overwriting each other.
- Updates regression coverage, including the current pyproject version fallback expectation.

## Root Cause
Several paths had converged on the right product behavior but still used narrower implementation shortcuts: raw workspace copies preserved draft state, relation queue filenames ignored evidence source, open-question writes bypassed the shared event emitter, reuse indexing duplicated JSONL parsing, and evidence verification updated rows one at a time.

## Validation
- `ruff check src/ovp_pipeline/workspace_promotion.py src/ovp_pipeline/extraction/semantic_relations.py src/ovp_pipeline/relation_promotion.py src/ovp_pipeline/feedback_router.py src/ovp_pipeline/knowledge_index.py src/ovp_pipeline/commands/evidence_verify.py tests/test_promotion_policy.py tests/test_semantic_relations.py tests/test_feedback_router.py tests/test_reuse_events.py tests/test_evidence_v2.py tests/test_unified_pipeline_version.py`
- `pytest -q` (`997 passed`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Workspace promotion now records state lifecycle transitions with provenance information (generated source and target references).

* **Performance**
  * Evidence verification batches database operations for improved processing efficiency.

* **Improvements**
  * Enhanced queue file identification using source slug information for better distinction between candidates.
  * Automatic legacy queue file cleanup support during promotion.
  * Streamlined reuse event data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->