### PR TITLE
Fix candidate dashboard responsiveness

### DIFF
--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -67,6 +67,7 @@ _FENCED_FRONTMATTER_RE = re.compile(r"^```ya?ml\s*\n---\n(.*?)\n---\n```\s*\n?",
 _GITHUB_REPO_RE = re.compile(r"https://github\.com/([^/\s]+)/([^/\s#]+)")
 _EVOLUTION_LINK_TYPES = ["challenges", "replaces", "enriches", "confirms"]
 _CANDIDATE_MERGE_AUTOFILL_THRESHOLD = 0.7
+_INLINE_MEMBER_LINK_LIMIT = 8
 
 
 def _shell_href(path: str, requested_pack: str = "") -> str:
@@ -2239,6 +2240,17 @@ def _render_atlas_page(payload: dict) -> str:
         if payload.get("is_limited")
         else ""
     )
+    def render_member_links(members: list[dict[str, object]]) -> str:
+        visible = members[:_INLINE_MEMBER_LINK_LIMIT]
+        hidden_count = max(0, len(members) - len(visible))
+        links = ", ".join(
+            f'<a href="{escape(_object_href(str(member["object_id"]), str(member.get("object_path", "")), requested_pack=requested_pack))}">{escape(str(member["title"]))}</a>'
+            for member in visible
+        )
+        if hidden_count:
+            links += f" <span class='muted'>+{hidden_count} more</span>"
+        return links
+
     items = (
         "".join(
             "<li>"
@@ -2246,14 +2258,7 @@ def _render_atlas_page(payload: dict) -> str:
             + f" <span class='pill'>{item['member_count']} objects</span>"
             + f" <span class='pill'>{len(item['deep_dives'])} deep dives</span>"
             + f" <span class='pill'>{len(item['source_notes'])} source notes</span>"
-            + (
-                " <span class='muted'>"
-                + ", ".join(
-                    f'<a href="{escape(_object_href(member["object_id"], member.get("object_path", ""), requested_pack=requested_pack))}">{escape(member["title"])}</a>'
-                    for member in item["members"]
-                )
-                + "</span>"
-            )
+            + f" <span class='muted'>{render_member_links(item['members'])}</span>"
             + (
                 f"<div class='muted'>Preview: {escape(', '.join(item['preview_titles']))}</div>"
                 if item["preview_titles"]
@@ -2445,6 +2450,17 @@ def _render_clusters_page(payload: dict) -> str:
         )
         or "<span class='muted'>None</span>"
     )
+    def render_member_links(members: list[dict[str, object]]) -> str:
+        visible = members[:_INLINE_MEMBER_LINK_LIMIT]
+        hidden_count = max(0, len(members) - len(visible))
+        links = ", ".join(
+            f'<a href="{escape(str(member["path"]))}">{escape(str(member["title"]))}</a>'
+            for member in visible
+        )
+        if hidden_count:
+            links += f" <span class='muted'>+{hidden_count} more</span>"
+        return links
+
     items = (
         "".join(
             "<li>"
@@ -2452,14 +2468,7 @@ def _render_clusters_page(payload: dict) -> str:
             + f" <span class='pill'>{escape(item['cluster_kind'])}</span>"
             + f" <span class='pill'>{escape(item['priority_band'])}</span>"
             + f" <span class='pill'>{item['member_count']} objects</span>"
-            + (
-                " <span class='muted'>"
-                + ", ".join(
-                    f'<a href="{escape(member["path"])}">{escape(member["title"])}</a>'
-                    for member in item["member_links"]
-                )
-                + "</span>"
-            )
+            + f" <span class='muted'>{render_member_links(item['member_links'])}</span>"
             + f"<div class='muted'>Canonical cluster: {escape(item['label'])}</div>"
             + f"<div class='muted'>Center: <a href='{escape(item['center_object_path'])}'>{escape(item['center_title'])}</a></div>"
             + f"<div class='muted'>Priority: {escape(item['priority_reason'])}</div>"

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -28,6 +28,7 @@ from ..pulse import initial_positions, tail_events
 from ..runtime import VaultLayout, resolve_vault_dir
 from .reuse_report import build_reuse_report_payload
 from ..ui.view_models import (
+    DEFAULT_CANDIDATE_BROWSER_LIMIT,
     build_action_queue_payload,
     build_atlas_browser_payload,
     build_briefing_payload,
@@ -68,6 +69,20 @@ _GITHUB_REPO_RE = re.compile(r"https://github\.com/([^/\s]+)/([^/\s#]+)")
 _EVOLUTION_LINK_TYPES = ["challenges", "replaces", "enriches", "confirms"]
 _CANDIDATE_MERGE_AUTOFILL_THRESHOLD = 0.7
 _INLINE_MEMBER_LINK_LIMIT = 8
+
+
+def _render_limited_inline_links(
+    items,
+    render_link,
+    *,
+    limit: int = _INLINE_MEMBER_LINK_LIMIT,
+) -> str:
+    visible = items[:limit]
+    hidden_count = max(0, len(items) - len(visible))
+    links = ", ".join(render_link(item) for item in visible)
+    if hidden_count:
+        links += f" <span class='muted'>+{hidden_count} more</span>"
+    return links
 
 
 def _shell_href(path: str, requested_pack: str = "") -> str:
@@ -2240,16 +2255,13 @@ def _render_atlas_page(payload: dict) -> str:
         if payload.get("is_limited")
         else ""
     )
-    def render_member_links(members: list[dict[str, object]]) -> str:
-        visible = members[:_INLINE_MEMBER_LINK_LIMIT]
-        hidden_count = max(0, len(members) - len(visible))
-        links = ", ".join(
-            f'<a href="{escape(_object_href(str(member["object_id"]), str(member.get("object_path", "")), requested_pack=requested_pack))}">{escape(str(member["title"]))}</a>'
-            for member in visible
+    def render_member_link(member: dict[str, object]) -> str:
+        href = _object_href(
+            str(member["object_id"]),
+            str(member.get("object_path", "")),
+            requested_pack=requested_pack,
         )
-        if hidden_count:
-            links += f" <span class='muted'>+{hidden_count} more</span>"
-        return links
+        return f'<a href="{escape(href)}">{escape(str(member["title"]))}</a>'
 
     items = (
         "".join(
@@ -2258,7 +2270,7 @@ def _render_atlas_page(payload: dict) -> str:
             + f" <span class='pill'>{item['member_count']} objects</span>"
             + f" <span class='pill'>{len(item['deep_dives'])} deep dives</span>"
             + f" <span class='pill'>{len(item['source_notes'])} source notes</span>"
-            + f" <span class='muted'>{render_member_links(item['members'])}</span>"
+            + f" <span class='muted'>{_render_limited_inline_links(item['members'], render_member_link)}</span>"
             + (
                 f"<div class='muted'>Preview: {escape(', '.join(item['preview_titles']))}</div>"
                 if item["preview_titles"]
@@ -2450,16 +2462,8 @@ def _render_clusters_page(payload: dict) -> str:
         )
         or "<span class='muted'>None</span>"
     )
-    def render_member_links(members: list[dict[str, object]]) -> str:
-        visible = members[:_INLINE_MEMBER_LINK_LIMIT]
-        hidden_count = max(0, len(members) - len(visible))
-        links = ", ".join(
-            f'<a href="{escape(str(member["path"]))}">{escape(str(member["title"]))}</a>'
-            for member in visible
-        )
-        if hidden_count:
-            links += f" <span class='muted'>+{hidden_count} more</span>"
-        return links
+    def render_member_link(member: dict[str, object]) -> str:
+        return f'<a href="{escape(str(member["path"]))}">{escape(str(member["title"]))}</a>'
 
     items = (
         "".join(
@@ -2468,7 +2472,7 @@ def _render_clusters_page(payload: dict) -> str:
             + f" <span class='pill'>{escape(item['cluster_kind'])}</span>"
             + f" <span class='pill'>{escape(item['priority_band'])}</span>"
             + f" <span class='pill'>{item['member_count']} objects</span>"
-            + f" <span class='muted'>{render_member_links(item['member_links'])}</span>"
+            + f" <span class='muted'>{_render_limited_inline_links(item['member_links'], render_member_link)}</span>"
             + f"<div class='muted'>Canonical cluster: {escape(item['label'])}</div>"
             + f"<div class='muted'>Center: <a href='{escape(item['center_object_path'])}'>{escape(item['center_title'])}</a></div>"
             + f"<div class='muted'>Priority: {escape(item['priority_reason'])}</div>"
@@ -2865,6 +2869,43 @@ def _render_candidate_items(payload: dict) -> str:
     return f"<ul class='list-tight'>{''.join(rendered)}</ul>"
 
 
+def _render_candidates_pagination(payload: dict) -> str:
+    count = int(payload.get("count") or 0)
+    limit = int(payload.get("limit") or DEFAULT_CANDIDATE_BROWSER_LIMIT)
+    offset = int(payload.get("offset") or 0)
+    if limit <= 0 or count <= limit:
+        return ""
+
+    query = str(payload.get("query") or "")
+    requested_pack = str(payload.get("requested_pack") or "")
+
+    def href(next_offset: int) -> str:
+        parts = []
+        if query:
+            parts.append(f"q={quote(query, safe='')}")
+        parts.append(f"limit={limit}")
+        parts.append(f"offset={max(0, next_offset)}")
+        if requested_pack:
+            parts.append(f"pack={quote(requested_pack, safe='')}")
+        return "/candidates?" + "&".join(parts)
+
+    links = []
+    if offset > 0:
+        links.append(f'<a href="{escape(href(max(0, offset - limit)))}">Previous</a>')
+    if offset + limit < count:
+        links.append(f'<a href="{escape(href(offset + limit))}">Next</a>')
+    if not links:
+        return ""
+    current_start = offset + 1 if count else 0
+    current_end = min(count, offset + limit)
+    return (
+        "<div class='link-row'>"
+        f"<span class='muted'>Showing {current_start}-{current_end} of {count}</span>"
+        + "".join(links)
+        + "</div>"
+    )
+
+
 def _render_candidates_page(payload: dict) -> str:
     query = str(payload.get("query") or "")
     requested_pack = str(payload.get("requested_pack") or "")
@@ -2879,6 +2920,7 @@ def _render_candidates_page(payload: dict) -> str:
         if candidate_warning
         else ""
     )
+    pagination = _render_candidates_pagination(payload)
     return _layout(
         "Candidate Workbench",
         "".join(
@@ -2894,9 +2936,11 @@ def _render_candidates_page(payload: dict) -> str:
                     else ""
                 ),
                 f"<input type='text' name='q' value='{escape(query)}' placeholder='Filter candidates' />",
+                f"<input type='hidden' name='limit' value='{escape(str(payload.get('limit') or DEFAULT_CANDIDATE_BROWSER_LIMIT))}' />",
                 "<button type='submit'>Search</button>",
                 "</form>",
                 f"<p class='muted'>{escape(str(payload.get('count') or 0))} candidate(s) in view.</p>",
+                pagination,
                 f"<section class='card'><h2>Status</h2><div class='link-row'>{status_counts}</div></section>",
                 operator_rail,
                 warning_card,
@@ -4509,6 +4553,8 @@ def create_server(
                 if path == "/api/candidates":
                     q = query.get("q", [""])[0]
                     pack_name = query.get("pack", [""])[0] or None
+                    limit = int(query.get("limit", [str(DEFAULT_CANDIDATE_BROWSER_LIMIT)])[0])
+                    offset = int(query.get("offset", ["0"])[0])
                     if self._guard_research_route(
                         pack_name=pack_name, route_path="/candidates", api=True
                     ):
@@ -4518,12 +4564,16 @@ def create_server(
                             resolved_vault,
                             pack_name=pack_name,
                             query=q,
+                            limit=limit,
+                            offset=offset,
                         )
                     )
                     return
                 if path in {"/candidates", "/candidates/fragment"}:
                     q = query.get("q", [""])[0]
                     pack_name = query.get("pack", [""])[0] or None
+                    limit = int(query.get("limit", [str(DEFAULT_CANDIDATE_BROWSER_LIMIT)])[0])
+                    offset = int(query.get("offset", ["0"])[0])
                     candidate_warning = query.get("candidate_warning", [""])[0]
                     if self._guard_research_route(
                         pack_name=pack_name, route_path="/candidates", api=False
@@ -4533,6 +4583,8 @@ def create_server(
                         resolved_vault,
                         pack_name=pack_name,
                         query=q,
+                        limit=limit,
+                        offset=offset,
                     )
                     payload["candidate_warning"] = candidate_warning
                     page = _render_candidates_page(payload)
@@ -5513,7 +5565,8 @@ def main(argv: list[str] | None = None) -> int:
     server = create_server(resolved_vault, host=args.host, port=args.port)
     try:
         build_objects_index_payload(resolved_vault, limit=1, offset=0)
-        ensure_signal_ledger_synced(resolved_vault)
+        if not VaultLayout.from_vault(resolved_vault).signals_log.exists():
+            ensure_signal_ledger_synced(resolved_vault)
         _start_ui_prewarm(resolved_vault)
         if args.with_action_worker:
             _spawn_action_worker_process(

--- a/src/ovp_pipeline/concept_registry.py
+++ b/src/ovp_pipeline/concept_registry.py
@@ -527,7 +527,7 @@ class ConceptRegistry:
         the deterministic resolver abstains. Keep exact-resolution semantics first,
         then fall back to a lexical surface search over registry-managed identifiers.
         """
-        result = self.resolve_mention(query, area=area)
+        result = self.resolve_mention(query, area=area, include_related_context=False)
         if result.action == ResolutionAction.LINK_EXISTING and result.entry:
             # Find legacy ConceptEntry
             entry = self.find_by_slug(result.entry.slug)

--- a/src/ovp_pipeline/truth_api.py
+++ b/src/ovp_pipeline/truth_api.py
@@ -3479,6 +3479,22 @@ def _attach_action_queue_state(
 ) -> list[dict[str, Any]]:
     queue_state = _action_queue_state_map(vault_dir)
     normalized_pack = str(pack_name or DEFAULT_WORKFLOW_PACK_NAME)
+    capture_note_paths = list(
+        dict.fromkeys(
+            str(path)
+            for item in items
+            for path in item.get("note_paths", [])
+            if isinstance(path, str) and path.strip()
+        )
+    )
+    try:
+        capture_summaries = (
+            _collect_note_capture_summaries(vault_dir, capture_note_paths)
+            if capture_note_paths
+            else {}
+        )
+    except Exception:
+        capture_summaries = {}
     annotated: list[dict[str, Any]] = []
     for item in items:
         enriched = dict(item)
@@ -3527,21 +3543,7 @@ def _attach_action_queue_state(
             for path in enriched.get("note_paths", [])
             if isinstance(path, str) and path.strip()
         ]
-        try:
-            enriched["capture_summary"] = _aggregate_note_capture_summaries(vault_dir, note_paths)
-        except Exception:
-            enriched["capture_summary"] = {
-                "status": "missing",
-                "captured_event_count": 0,
-                "produced_artifact_count": 0,
-                "candidate_count": 0,
-                "error_count": 0,
-                "skipped_count": 0,
-                "latest_timestamp": "",
-                "summary": "No inbound capture audit was found for this note yet.",
-                "items": [],
-                "note_paths": note_paths,
-            }
+        enriched["capture_summary"] = _capture_summary_from_map(note_paths, capture_summaries)
         enriched["impact_summary"] = _build_signal_impact_summary(enriched, action=matched_action)
         enriched["action_lifecycle"] = (
             {
@@ -3743,10 +3745,12 @@ def get_briefing_snapshot(
     limit: int = 8,
 ) -> dict[str, Any]:
     normalized_pack = str(pack_name or DEFAULT_WORKFLOW_PACK_NAME)
-    ensure_signal_ledger_synced(vault_dir, pack_name=normalized_pack)
+    resolved_vault = resolve_vault_dir(vault_dir)
+    if not _signal_ledger_path(resolved_vault, pack_name=normalized_pack).exists():
+        ensure_signal_ledger_synced(resolved_vault, pack_name=normalized_pack)
     _, payload = execute_observation_surface_builder(
         surface_kind="briefing",
-        vault_dir=resolve_vault_dir(vault_dir),
+        vault_dir=resolved_vault,
         pack_name=normalized_pack,
         limit=limit,
     )
@@ -4088,21 +4092,45 @@ def _collect_note_capture_summaries(
     resolved_vault = resolve_vault_dir(vault_dir)
     layout = VaultLayout.from_vault(resolved_vault)
     target_state: dict[str, dict[str, Any]] = {}
+    states_by_path: dict[str, list[dict[str, Any]]] = {}
+    states_by_name: dict[str, list[dict[str, Any]]] = {}
+    states_by_slug: dict[str, list[dict[str, Any]]] = {}
+
+    def add_index(index: dict[str, list[dict[str, Any]]], key: str, state: dict[str, Any]) -> None:
+        normalized_key = str(key or "").strip()
+        if not normalized_key:
+            return
+        bucket = index.setdefault(normalized_key, [])
+        if not any(item["note_path"] == state["note_path"] for item in bucket):
+            bucket.append(state)
+
     for note_path in note_paths:
         normalized_path = str(note_path)
         if not normalized_path.strip() or normalized_path in target_state:
             continue
         targets = _note_capture_targets(resolved_vault, normalized_path)
-        target_state[normalized_path] = {
+        state = {
+            "note_path": normalized_path,
             "targets": targets,
             "derived_note_names": {str(targets["note_name"])},
             "items": [],
         }
+        target_state[normalized_path] = state
+        add_index(states_by_path, normalized_path, state)
+        add_index(states_by_name, str(targets["note_name"]), state)
+        add_index(states_by_slug, str(targets["note_slug"]), state)
     for log_path in (layout.pipeline_log, layout.logs_dir / "refine-mutations.jsonl"):
         if not log_path.exists():
             continue
         for payload in _read_jsonl_items(log_path):
-            for state in target_state.values():
+            for state in _candidate_capture_states(
+                resolved_vault,
+                payload,
+                states_by_path=states_by_path,
+                states_by_name=states_by_name,
+                states_by_slug=states_by_slug,
+            ):
+                previous_derived_names = set(state["derived_note_names"])
                 item = _match_note_capture_event(
                     resolved_vault,
                     payload=payload,
@@ -4111,10 +4139,74 @@ def _collect_note_capture_summaries(
                 )
                 if item is not None:
                     state["items"].append(item)
+                    for derived_name in state["derived_note_names"] - previous_derived_names:
+                        add_index(states_by_name, str(derived_name), state)
     return {
         note_path: _capture_summary_payload(note_path, list(state["items"]))
         for note_path, state in target_state.items()
     }
+
+
+def _candidate_capture_states(
+    vault_dir: Path | str,
+    payload: dict[str, Any],
+    *,
+    states_by_path: dict[str, list[dict[str, Any]]],
+    states_by_name: dict[str, list[dict[str, Any]]],
+    states_by_slug: dict[str, list[dict[str, Any]]],
+) -> list[dict[str, Any]]:
+    event_type = str(payload.get("event_type") or "").strip()
+    if event_type not in _NOTE_CAPTURE_EVENT_TYPES:
+        return []
+    candidates: dict[str, dict[str, Any]] = {}
+
+    def add_states(states: list[dict[str, Any]] | None) -> None:
+        for state in states or []:
+            candidates[str(state["note_path"])] = state
+
+    def add_path(value: str) -> None:
+        relative_path = _vault_relative_path(vault_dir, str(value or ""))
+        add_states(states_by_path.get(relative_path))
+
+    def add_name(value: str) -> None:
+        name = Path(str(value or "")).name
+        add_states(states_by_name.get(name))
+
+    def add_slug(value: str) -> None:
+        slug = canonicalize_note_id(str(value or ""))
+        add_states(states_by_slug.get(slug))
+
+    if event_type == "source_staged_for_processing":
+        for key in ("source", "staged"):
+            add_path(str(payload.get(key) or ""))
+            add_name(str(payload.get(key) or ""))
+    elif event_type == "source_archived_to_processed":
+        for key in ("source", "archived"):
+            add_path(str(payload.get(key) or ""))
+            add_name(str(payload.get(key) or ""))
+    elif event_type == "source_restored_to_raw":
+        for key in ("source", "restored"):
+            add_path(str(payload.get(key) or ""))
+            add_name(str(payload.get(key) or ""))
+    elif event_type == "article_processed":
+        add_path(str(payload.get("output") or ""))
+        add_name(str(payload.get("file") or ""))
+    elif event_type in {
+        "article_abstained",
+        "article_error",
+        "candidate_upsert_error",
+        "evergreen_error",
+        "candidates_upserted",
+    }:
+        add_name(str(payload.get("file") or ""))
+    elif event_type in {"evergreen_auto_promoted", "evergreen_created"}:
+        add_path(str(payload.get("path") or ""))
+        add_name(str(payload.get("source") or ""))
+        add_slug(str(payload.get("concept") or payload.get("mutation", {}).get("target_slug") or ""))
+    elif event_type == "refine_mutation_applied":
+        for target in _canonicalized_payload_targets(payload):
+            add_states(states_by_slug.get(target))
+    return list(candidates.values())
 
 
 def get_note_inbound_capture_summary(vault_dir: Path | str, *, note_path: str) -> dict[str, Any]:
@@ -4129,26 +4221,29 @@ def _aggregate_note_capture_summaries(
     note_paths: list[str],
 ) -> dict[str, Any]:
     normalized_paths = [str(item) for item in note_paths if str(item).strip()]
+    summary_map = _collect_note_capture_summaries(vault_dir, normalized_paths)
+    return _capture_summary_from_map(normalized_paths, summary_map)
+
+
+def _capture_summary_from_map(
+    normalized_paths: list[str],
+    summary_map: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    normalized_paths = [str(item) for item in normalized_paths if str(item).strip()]
     if not normalized_paths:
-        return {
-            "status": "missing",
-            "captured_event_count": 0,
-            "produced_artifact_count": 0,
-            "candidate_count": 0,
-            "error_count": 0,
-            "skipped_count": 0,
-            "latest_timestamp": "",
-            "summary": "No inbound capture audit was found for this note yet.",
-            "items": [],
-            "note_paths": [],
-        }
+        return _missing_capture_summary([])
     if len(normalized_paths) == 1:
-        payload = get_note_inbound_capture_summary(vault_dir, note_path=normalized_paths[0])
+        payload = dict(
+            summary_map.get(normalized_paths[0])
+            or _capture_summary_payload(normalized_paths[0], [])
+        )
         payload["note_paths"] = normalized_paths
         return payload
 
-    summary_map = _collect_note_capture_summaries(vault_dir, normalized_paths)
-    summaries = [summary_map[item] for item in normalized_paths]
+    summaries = [
+        summary_map.get(item) or _capture_summary_payload(item, [])
+        for item in normalized_paths
+    ]
     captured_event_count = sum(item["captured_event_count"] for item in summaries)
     produced_artifact_count = sum(item["produced_artifact_count"] for item in summaries)
     candidate_count = sum(item["candidate_count"] for item in summaries)
@@ -4189,6 +4284,21 @@ def _aggregate_note_capture_summaries(
             for item in summaries
         ][:8],
         "note_paths": normalized_paths,
+    }
+
+
+def _missing_capture_summary(note_paths: list[str]) -> dict[str, Any]:
+    return {
+        "status": "missing",
+        "captured_event_count": 0,
+        "produced_artifact_count": 0,
+        "candidate_count": 0,
+        "error_count": 0,
+        "skipped_count": 0,
+        "latest_timestamp": "",
+        "summary": "No inbound capture audit was found for this note yet.",
+        "items": [],
+        "note_paths": list(note_paths),
     }
 
 

--- a/src/ovp_pipeline/truth_api.py
+++ b/src/ovp_pipeline/truth_api.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta, timezone
 from collections import Counter
 import hashlib
 import json
+import logging
 import os
 import re
 import sqlite3
@@ -44,6 +45,7 @@ from .run_history import list_run_history
 from .txn import classify_run_ledgers
 
 MAX_PAGE_SIZE = 500
+LOGGER = logging.getLogger(__name__)
 _FENCED_FRONTMATTER_RE = re.compile(r"^```ya?ml\s*\n---\n(.*?)\n---\n```\s*\n?", re.DOTALL)
 _REVIEW_AUDIT_LOG_NAME = "review-actions"
 _SIGNAL_LOG_NAME = "signals"
@@ -730,6 +732,7 @@ def _candidate_review_suggestion(
 ) -> tuple[str, list[tuple[Any, float]]]:
     similar: list[tuple[Any, float]] = []
     seen_slugs: set[str] = set()
+    found_ambiguous_active = False
     resolution = registry.resolve_mention(
         entry.title,
         area=entry.area or None,
@@ -753,8 +756,9 @@ def _candidate_review_suggestion(
                 and candidate.status == STATUS_ACTIVE
                 and candidate.slug not in seen_slugs
             ):
-                similar.append((candidate, 0.0))
+                similar.append((candidate, resolution.confidence))
                 seen_slugs.add(candidate.slug)
+                found_ambiguous_active = True
 
     if not similar:
         for near in registry._safe_near_candidates(entry.title, area=entry.area or None, topk=10):
@@ -772,7 +776,9 @@ def _candidate_review_suggestion(
 
     similar = sorted(similar, key=lambda item: item[1], reverse=True)[:5]
     action = "keep_as_candidate"
-    if entry.source_count >= 2 or entry.evidence_count >= 3:
+    if found_ambiguous_active:
+        action = "keep_as_candidate"
+    elif entry.source_count >= 2 or entry.evidence_count >= 3:
         if similar and similar[0][1] >= 0.7:
             action = "merge_as_alias"
         else:
@@ -3487,14 +3493,7 @@ def _attach_action_queue_state(
             if isinstance(path, str) and path.strip()
         )
     )
-    try:
-        capture_summaries = (
-            _collect_note_capture_summaries(vault_dir, capture_note_paths)
-            if capture_note_paths
-            else {}
-        )
-    except Exception:
-        capture_summaries = {}
+    capture_summaries = _collect_capture_summaries_resilient(vault_dir, capture_note_paths)
     annotated: list[dict[str, Any]] = []
     for item in items:
         enriched = dict(item)
@@ -3562,6 +3561,32 @@ def _attach_action_queue_state(
         )
         annotated.append(enriched)
     return annotated
+
+
+_CAPTURE_SUMMARY_RECOVERABLE_ERRORS = (OSError, ValueError, sqlite3.Error)
+
+
+def _collect_capture_summaries_resilient(
+    vault_dir: Path | str,
+    note_paths: list[str],
+) -> dict[str, dict[str, Any]]:
+    if not note_paths:
+        return {}
+    try:
+        return _collect_note_capture_summaries(vault_dir, note_paths)
+    except _CAPTURE_SUMMARY_RECOVERABLE_ERRORS:
+        LOGGER.exception(
+            "Failed to collect capture summaries for %d notes; falling back per note.",
+            len(note_paths),
+        )
+
+    summaries: dict[str, dict[str, Any]] = {}
+    for note_path in note_paths:
+        try:
+            summaries.update(_collect_note_capture_summaries(vault_dir, [note_path]))
+        except _CAPTURE_SUMMARY_RECOVERABLE_ERRORS:
+            LOGGER.exception("Failed to collect capture summary for %s.", note_path)
+    return summaries
 
 
 def list_production_gaps(
@@ -4002,8 +4027,9 @@ def _match_note_capture_event(
     if event_type in {"evergreen_auto_promoted", "evergreen_created"}:
         relative_path_field = _vault_relative_path(vault_dir, str(payload.get("path") or ""))
         source_name = Path(str(payload.get("source") or "")).name
+        mutation = payload.get("mutation") if isinstance(payload.get("mutation"), dict) else {}
         target_slug = canonicalize_note_id(
-            str(payload.get("concept") or payload.get("mutation", {}).get("target_slug") or "")
+            str(payload.get("concept") or mutation.get("target_slug") or "")
         )
         if not (
             relative_path_field == note_path
@@ -4013,7 +4039,7 @@ def _match_note_capture_event(
         ):
             return None
         object_id = str(
-            payload.get("mutation", {}).get("target_slug") or payload.get("concept") or ""
+            mutation.get("target_slug") or payload.get("concept") or ""
         ).strip()
         label = (
             "Evergreen promoted" if event_type == "evergreen_auto_promoted" else "Evergreen created"
@@ -4200,9 +4226,10 @@ def _candidate_capture_states(
     }:
         add_name(str(payload.get("file") or ""))
     elif event_type in {"evergreen_auto_promoted", "evergreen_created"}:
+        mutation = payload.get("mutation") if isinstance(payload.get("mutation"), dict) else {}
         add_path(str(payload.get("path") or ""))
         add_name(str(payload.get("source") or ""))
-        add_slug(str(payload.get("concept") or payload.get("mutation", {}).get("target_slug") or ""))
+        add_slug(str(payload.get("concept") or mutation.get("target_slug") or ""))
     elif event_type == "refine_mutation_applied":
         for target in _canonicalized_payload_targets(payload):
             add_states(states_by_slug.get(target))

--- a/src/ovp_pipeline/truth_api.py
+++ b/src/ovp_pipeline/truth_api.py
@@ -25,7 +25,7 @@ from .knowledge_index import ensure_knowledge_db_current, rebuild_knowledge_inde
 from .observation_surface_registry import execute_observation_surface_builder
 from .pack_resolution import iter_compatible_packs
 from .packs.loader import DEFAULT_WORKFLOW_PACK_NAME
-from .concept_registry import ConceptRegistry
+from .concept_registry import ConceptRegistry, ResolutionAction, STATUS_ACTIVE
 from .promote_candidates import (
     candidate_file_path,
     merge_candidate,
@@ -728,12 +728,49 @@ def record_review_action(
 def _candidate_review_suggestion(
     registry: ConceptRegistry, entry: Any
 ) -> tuple[str, list[tuple[Any, float]]]:
-    similar = registry.search(entry.title, topk=5)
-    similar = [
-        (candidate, score)
-        for candidate, score in similar
-        if candidate.slug != entry.slug and candidate.status == "active"
-    ]
+    similar: list[tuple[Any, float]] = []
+    seen_slugs: set[str] = set()
+    resolution = registry.resolve_mention(
+        entry.title,
+        area=entry.area or None,
+        include_related_context=False,
+    )
+    if resolution.action == ResolutionAction.LINK_EXISTING and resolution.entry:
+        candidate = registry.find_by_slug(resolution.entry.slug)
+        if (
+            candidate
+            and candidate.slug != entry.slug
+            and candidate.status == STATUS_ACTIVE
+        ):
+            similar.append((candidate, resolution.confidence))
+            seen_slugs.add(candidate.slug)
+    elif resolution.action == ResolutionAction.REVIEW_AMBIGUOUS:
+        for ambiguous in resolution.ambiguous_entries:
+            candidate = registry.find_by_slug(ambiguous.slug)
+            if (
+                candidate
+                and candidate.slug != entry.slug
+                and candidate.status == STATUS_ACTIVE
+                and candidate.slug not in seen_slugs
+            ):
+                similar.append((candidate, 0.0))
+                seen_slugs.add(candidate.slug)
+
+    if not similar:
+        for near in registry._safe_near_candidates(entry.title, area=entry.area or None, topk=10):
+            candidate = registry.find_by_slug(near.record.entry.slug)
+            if (
+                candidate
+                and candidate.slug != entry.slug
+                and candidate.status == STATUS_ACTIVE
+                and candidate.slug not in seen_slugs
+            ):
+                similar.append((candidate, near.score))
+                seen_slugs.add(candidate.slug)
+                if len(similar) >= 5:
+                    break
+
+    similar = sorted(similar, key=lambda item: item[1], reverse=True)[:5]
     action = "keep_as_candidate"
     if entry.source_count >= 2 or entry.evidence_count >= 3:
         if similar and similar[0][1] >= 0.7:

--- a/src/ovp_pipeline/ui/view_models.py
+++ b/src/ovp_pipeline/ui/view_models.py
@@ -52,7 +52,7 @@ from ..truth_api import (
 
 DEFAULT_CANDIDATE_BROWSER_LIMIT = 25
 DEFAULT_EVENT_DOSSIER_LIMIT = 25
-DEFAULT_TRACEABILITY_BROWSER_LIMIT = 20
+DEFAULT_TRACEABILITY_BROWSER_LIMIT = 15
 
 
 def _scoped_path(path: str, *, pack_name: str | None = None) -> str:

--- a/src/ovp_pipeline/ui/view_models.py
+++ b/src/ovp_pipeline/ui/view_models.py
@@ -50,8 +50,9 @@ from ..truth_api import (
     search_vault_surface,
 )
 
-DEFAULT_EVENT_DOSSIER_LIMIT = 50
-DEFAULT_TRACEABILITY_BROWSER_LIMIT = 50
+DEFAULT_CANDIDATE_BROWSER_LIMIT = 25
+DEFAULT_EVENT_DOSSIER_LIMIT = 25
+DEFAULT_TRACEABILITY_BROWSER_LIMIT = 20
 
 
 def _scoped_path(path: str, *, pack_name: str | None = None) -> str:
@@ -1202,7 +1203,7 @@ def build_candidate_browser_payload(
     *,
     pack_name: str | None = None,
     query: str | None = None,
-    limit: int = 100,
+    limit: int = DEFAULT_CANDIDATE_BROWSER_LIMIT,
     offset: int = 0,
 ) -> dict[str, Any]:
     requested_pack = pack_name or ""

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -4919,6 +4919,45 @@ def test_truth_api_candidate_listing_filters_before_expensive_suggestions(temp_v
     assert payload["items"] == []
 
 
+def test_truth_api_candidate_listing_skips_related_context_discovery(temp_vault, monkeypatch):
+    from ovp_pipeline.concept_registry import ConceptEntry, ConceptRegistry
+    from ovp_pipeline import concept_registry, truth_api
+    from ovp_pipeline.promote_candidates import write_candidate_file
+
+    registry = ConceptRegistry(temp_vault)
+    registry.add_entry(
+        ConceptEntry(
+            slug="alpha-existing",
+            title="Alpha Existing",
+            aliases=[],
+            definition="Existing canonical concept.",
+            area="testing",
+        )
+    )
+    candidate = registry.upsert_candidate(
+        slug="beta-candidate",
+        title="Beta Candidate",
+        definition="Candidate concept awaiting review.",
+        area="testing",
+    )
+    registry.save()
+    write_candidate_file(temp_vault, candidate, dry_run=False)
+
+    def fail_related_context(self, mention, topk=5):
+        raise AssertionError("candidate similarity search should not discover related context")
+
+    def fail_legacy_surface_search(self, query, area=None, topk=10):
+        raise AssertionError("candidate listing should not run full legacy surface search")
+
+    monkeypatch.setattr(concept_registry.ConceptRegistry, "_discover_related_context", fail_related_context)
+    monkeypatch.setattr(concept_registry.ConceptRegistry, "_legacy_surface_search", fail_legacy_surface_search)
+
+    payload = truth_api.list_candidate_concepts(temp_vault)
+
+    assert payload["count"] == 1
+    assert payload["items"][0]["slug"] == "beta-candidate"
+
+
 def test_truth_api_review_candidate_concept_promotes_and_records_audit(temp_vault):
     from ovp_pipeline.concept_registry import ConceptRegistry, STATUS_ACTIVE
     from ovp_pipeline.truth_api import list_review_actions, review_candidate_concept

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -188,6 +188,137 @@ def test_truth_api_reads_signal_and_action_ledgers_without_knowledge_db(temp_vau
     assert actions[0]["impact_summary"]["lifecycle_stage"] == "queued"
 
 
+def test_truth_api_batches_capture_summary_lookup_for_signal_listing(temp_vault, monkeypatch):
+    from ovp_pipeline import truth_api
+
+    logs_dir = temp_vault / "60-Logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    note_paths = [f"50-Inbox/03-Processed/Demo-{index}.md" for index in range(3)]
+    (logs_dir / "signals.jsonl").write_text(
+        "\n".join(
+            json.dumps(
+                {
+                    "signal_id": f"source_needs_deep_dive::demo-{index}",
+                    "signal_type": "source_needs_deep_dive",
+                    "detected_at": "2026-04-15T00:00:00Z",
+                    "status": "active",
+                    "title": f"Create deep dive for Demo {index}",
+                    "detail": "Demo source is missing a deep dive.",
+                    "source_path": f"/note?path=50-Inbox%2F03-Processed%2FDemo-{index}.md",
+                    "object_ids": [],
+                    "note_paths": [note_path],
+                    "recommended_action": {
+                        "kind": "deep_dive_workflow",
+                        "label": "Create deep dive",
+                        "path": f"/note?path=50-Inbox%2F03-Processed%2FDemo-{index}.md",
+                        "executable": False,
+                    },
+                },
+                ensure_ascii=False,
+            )
+            for index, note_path in enumerate(note_paths)
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    calls = []
+
+    def fake_collect_note_capture_summaries(vault_dir, requested_note_paths):
+        calls.append(tuple(requested_note_paths))
+        return {
+            note_path: {
+                "status": "observed",
+                "captured_event_count": 1,
+                "produced_artifact_count": 0,
+                "candidate_count": 0,
+                "error_count": 0,
+                "skipped_count": 0,
+                "latest_timestamp": "2026-04-15T00:00:00Z",
+                "summary": f"Observed capture for {note_path}.",
+                "items": [],
+            }
+            for note_path in requested_note_paths
+        }
+
+    monkeypatch.setattr(
+        truth_api,
+        "_collect_note_capture_summaries",
+        fake_collect_note_capture_summaries,
+    )
+
+    signals = truth_api.list_signals(temp_vault, limit=3)
+
+    assert len(signals) == 3
+    assert calls == [tuple(note_paths)]
+    assert [item["capture_summary"]["status"] for item in signals] == [
+        "observed",
+        "observed",
+        "observed",
+    ]
+
+
+def test_truth_api_capture_summary_collection_routes_events_to_relevant_targets(
+    temp_vault, monkeypatch
+):
+    from ovp_pipeline import truth_api
+
+    note_paths = [f"50-Inbox/03-Processed/Demo-{index}.md" for index in range(3)]
+    for note_path in note_paths:
+        target = temp_vault / note_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(
+            f"---\nnote_id: {target.stem}\ntitle: {target.stem}\n---\n\n# {target.stem}\n",
+            encoding="utf-8",
+        )
+
+    logs_dir = temp_vault / "60-Logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    (logs_dir / "pipeline.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "event_type": "article_abstained",
+                        "timestamp": "2026-04-15T00:00:00Z",
+                        "file": "Unrelated.md",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "event_type": "article_abstained",
+                        "timestamp": "2026-04-15T00:01:00Z",
+                        "file": "Demo-1.md",
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    calls = []
+
+    def fake_match_note_capture_event(vault_dir, *, payload, targets, derived_note_names):
+        calls.append((payload["event_type"], payload.get("file", ""), targets["note_path"]))
+        if payload.get("file") != targets["note_name"]:
+            return None
+        return truth_api._note_capture_item(
+            kind="capture_abstained",
+            label="Capture abstained",
+            timestamp=str(payload["timestamp"]),
+            detail="Interpretation abstained.",
+            skipped_count=1,
+        )
+
+    monkeypatch.setattr(truth_api, "_match_note_capture_event", fake_match_note_capture_event)
+
+    summaries = truth_api._collect_note_capture_summaries(temp_vault, note_paths)
+
+    assert calls == [("article_abstained", "Demo-1.md", "50-Inbox/03-Processed/Demo-1.md")]
+    assert summaries["50-Inbox/03-Processed/Demo-1.md"]["status"] == "skipped"
+
+
 def test_truth_api_marks_old_running_action_as_stale():
     from ovp_pipeline.truth_api import _build_action_impact_summary
 
@@ -4534,6 +4665,37 @@ def test_truth_api_get_briefing_snapshot_dispatches_via_observation_surface_regi
     )
 
     assert payload["priority_item_count"] == 1
+
+
+def test_truth_api_get_briefing_snapshot_reuses_existing_signal_ledger(temp_vault, monkeypatch):
+    import ovp_pipeline.truth_api as truth_api_source
+
+    logs_dir = temp_vault / "60-Logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    (logs_dir / "signals.jsonl").write_text("", encoding="utf-8")
+
+    def fake_sync_signal_ledger(*args, **kwargs):
+        raise AssertionError("existing signal ledger should be reused for UI briefing reads")
+
+    def fake_execute(*, surface_kind, vault_dir, pack_name=None, **kwargs):
+        assert surface_kind == "briefing"
+        return object(), {
+            "generated_at": "2026-04-15T00:00:00Z",
+            "priority_item_count": 0,
+            "recent_signals": [],
+        }
+
+    monkeypatch.setattr(truth_api_source, "sync_signal_ledger", fake_sync_signal_ledger)
+    monkeypatch.setattr(
+        truth_api_source,
+        "execute_observation_surface_builder",
+        fake_execute,
+        raising=False,
+    )
+
+    payload = truth_api_source.get_briefing_snapshot(temp_vault)
+
+    assert payload["priority_item_count"] == 0
 
 
 def test_research_tech_observation_surface_build_briefing_delegates_to_surface_module(

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -258,6 +258,65 @@ def test_truth_api_batches_capture_summary_lookup_for_signal_listing(temp_vault,
     ]
 
 
+def test_truth_api_signal_capture_summary_falls_back_per_note_when_batch_collection_fails(
+    temp_vault, monkeypatch
+):
+    from ovp_pipeline import truth_api
+
+    calls = []
+
+    def fake_collect_note_capture_summaries(vault_dir, requested_note_paths):
+        calls.append(tuple(requested_note_paths))
+        if len(requested_note_paths) > 1:
+            raise OSError("batch read failed")
+        return {
+            requested_note_paths[0]: {
+                "status": "observed",
+                "captured_event_count": 1,
+                "produced_artifact_count": 0,
+                "candidate_count": 0,
+                "error_count": 0,
+                "skipped_count": 0,
+                "latest_timestamp": "2026-04-15T00:00:00Z",
+                "summary": f"Observed capture for {requested_note_paths[0]}.",
+                "items": [],
+            }
+        }
+
+    monkeypatch.setattr(
+        truth_api,
+        "_collect_note_capture_summaries",
+        fake_collect_note_capture_summaries,
+    )
+
+    signals = truth_api._attach_action_queue_state(
+        temp_vault,
+        [
+            {
+                "signal_id": "signal::one",
+                "signal_type": "source_needs_deep_dive",
+                "title": "One",
+                "detail": "One",
+                "note_paths": ["50-Inbox/03-Processed/One.md"],
+            },
+            {
+                "signal_id": "signal::two",
+                "signal_type": "source_needs_deep_dive",
+                "title": "Two",
+                "detail": "Two",
+                "note_paths": ["50-Inbox/03-Processed/Two.md"],
+            },
+        ],
+    )
+
+    assert calls == [
+        ("50-Inbox/03-Processed/One.md", "50-Inbox/03-Processed/Two.md"),
+        ("50-Inbox/03-Processed/One.md",),
+        ("50-Inbox/03-Processed/Two.md",),
+    ]
+    assert [item["capture_summary"]["status"] for item in signals] == ["observed", "observed"]
+
+
 def test_truth_api_capture_summary_collection_routes_events_to_relevant_targets(
     temp_vault, monkeypatch
 ):
@@ -317,6 +376,39 @@ def test_truth_api_capture_summary_collection_routes_events_to_relevant_targets(
 
     assert calls == [("article_abstained", "Demo-1.md", "50-Inbox/03-Processed/Demo-1.md")]
     assert summaries["50-Inbox/03-Processed/Demo-1.md"]["status"] == "skipped"
+
+
+def test_truth_api_capture_summary_handles_null_mutation_payload(temp_vault):
+    from ovp_pipeline import truth_api
+
+    note_path = "10-Knowledge/Evergreen/Alpha.md"
+    target = temp_vault / note_path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        "---\nnote_id: alpha\ntitle: Alpha\n---\n\n# Alpha\n",
+        encoding="utf-8",
+    )
+    logs_dir = temp_vault / "60-Logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    (logs_dir / "pipeline.jsonl").write_text(
+        json.dumps(
+            {
+                "event_type": "evergreen_created",
+                "timestamp": "2026-04-15T00:00:00Z",
+                "concept": "alpha",
+                "mutation": None,
+                "path": note_path,
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    summary = truth_api.get_note_inbound_capture_summary(temp_vault, note_path=note_path)
+
+    assert summary["status"] == "productive"
+    assert summary["produced_artifact_count"] == 1
 
 
 def test_truth_api_marks_old_running_action_as_stale():
@@ -5118,6 +5210,50 @@ def test_truth_api_candidate_listing_skips_related_context_discovery(temp_vault,
 
     assert payload["count"] == 1
     assert payload["items"][0]["slug"] == "beta-candidate"
+
+
+def test_truth_api_ambiguous_candidate_suggestion_does_not_promote_duplicate_risk(temp_vault):
+    from ovp_pipeline.concept_registry import ConceptEntry, ConceptRegistry
+    from ovp_pipeline.promote_candidates import write_candidate_file
+    from ovp_pipeline.truth_api import list_candidate_concepts
+
+    registry = ConceptRegistry(temp_vault)
+    registry.add_entry(
+        ConceptEntry(
+            slug="alpha-existing",
+            title="Alpha Existing",
+            aliases=["Ambiguous Candidate"],
+            definition="Existing canonical concept.",
+            area="testing",
+        )
+    )
+    registry.add_entry(
+        ConceptEntry(
+            slug="beta-existing",
+            title="Beta Existing",
+            aliases=["Ambiguous Candidate"],
+            definition="Another canonical concept.",
+            area="testing",
+        )
+    )
+    candidate = registry.upsert_candidate(
+        slug="ambiguous-candidate",
+        title="Ambiguous Candidate",
+        definition="High-evidence candidate with ambiguous active matches.",
+        area="testing",
+    )
+    candidate.evidence_count = 3
+    registry.save()
+    write_candidate_file(temp_vault, candidate, dry_run=False)
+
+    payload = list_candidate_concepts(temp_vault)
+
+    assert payload["items"][0]["slug"] == "ambiguous-candidate"
+    assert payload["items"][0]["suggested_action"] == "keep_as_candidate"
+    assert {item["slug"] for item in payload["items"][0]["similar_existing"]} == {
+        "alpha-existing",
+        "beta-existing",
+    }
 
 
 def test_truth_api_review_candidate_concept_promotes_and_records_audit(temp_vault):

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -3440,6 +3440,47 @@ def test_ui_server_main_can_spawn_detached_action_worker_when_enabled(
     assert calls["worker_process"]["kwargs"]["start_new_session"] is True
 
 
+def test_ui_server_main_reuses_existing_signal_ledger_during_preflight(
+    temp_vault, capsys, monkeypatch
+):
+    from ovp_pipeline.commands.ui_server import main
+
+    calls = {}
+    logs_dir = temp_vault / "60-Logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    (logs_dir / "signals.jsonl").write_text("", encoding="utf-8")
+
+    class FakeServer:
+        def serve_forever(self):
+            raise KeyboardInterrupt
+
+        def server_close(self):
+            calls["closed"] = True
+
+    monkeypatch.setattr(
+        "ovp_pipeline.commands.ui_server.create_server",
+        lambda vault_dir, *, host, port: FakeServer(),
+    )
+    monkeypatch.setattr(
+        "ovp_pipeline.commands.ui_server.build_objects_index_payload",
+        lambda vault_dir, *, limit, offset: {"items": []},
+    )
+    monkeypatch.setattr(
+        "ovp_pipeline.commands.ui_server.ensure_signal_ledger_synced",
+        lambda vault_dir: (_ for _ in ()).throw(
+            AssertionError("existing signal ledger should not be rebuilt during startup")
+        ),
+    )
+    monkeypatch.setattr("ovp_pipeline.commands.ui_server._start_ui_prewarm", lambda vault_dir: None)
+
+    exit_code = main(["--vault-dir", str(temp_vault)])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["vault_dir"] == str(temp_vault)
+    assert calls == {"closed": True}
+
+
 def test_ui_server_main_exits_nonzero_when_preflight_fails(temp_vault, capsys, monkeypatch):
     from ovp_pipeline.commands.ui_server import main
 
@@ -3530,6 +3571,55 @@ def test_ui_server_candidates_endpoint_returns_payload(temp_vault):
     assert payload["items"][0]["slug"] == "alpha-candidate"
 
 
+def test_ui_server_candidates_endpoint_forwards_pagination_params(temp_vault, monkeypatch):
+    import ovp_pipeline.commands.ui_server as ui_server
+    from ovp_pipeline.commands.ui_server import create_server
+
+    calls = []
+
+    def fake_build_candidate_browser_payload(
+        vault_dir,
+        *,
+        pack_name=None,
+        query=None,
+        limit=25,
+        offset=0,
+    ):
+        calls.append((pack_name, query, limit, offset))
+        return {
+            "screen": "candidates/browser",
+            "requested_pack": pack_name or "",
+            "query": query or "",
+            "limit": limit,
+            "offset": offset,
+            "count": 100,
+            "status_counts": {"candidate": 100},
+            "items": [],
+            "operator_rail": [],
+        }
+
+    monkeypatch.setattr(ui_server, "build_candidate_browser_payload", fake_build_candidate_browser_payload)
+
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("GET", "/api/candidates?q=alpha&limit=7&offset=14&pack=default-knowledge")
+        response = conn.getresponse()
+        payload = json.loads(response.read().decode("utf-8"))
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 200
+    assert payload["limit"] == 7
+    assert payload["offset"] == 14
+    assert calls == [("default-knowledge", "alpha", 7, 14)]
+
+
 def test_ui_server_candidates_page_renders_review_controls(temp_vault):
     from ovp_pipeline.commands.ui_server import create_server
 
@@ -3554,6 +3644,26 @@ def test_ui_server_candidates_page_renders_review_controls(temp_vault):
     assert "Promote" in body
     assert "Merge" in body
     assert "Reject" in body
+
+
+def test_ui_server_candidates_page_renders_pagination_links():
+    from ovp_pipeline.commands.ui_server import _render_candidates_page
+
+    html = _render_candidates_page(
+        {
+            "query": "alpha",
+            "requested_pack": "default-knowledge",
+            "limit": 25,
+            "offset": 25,
+            "count": 80,
+            "status_counts": {"candidate": 80},
+            "items": [],
+            "operator_rail": [],
+        }
+    )
+
+    assert 'href="/candidates?q=alpha&amp;limit=25&amp;offset=0&amp;pack=default-knowledge"' in html
+    assert 'href="/candidates?q=alpha&amp;limit=25&amp;offset=50&amp;pack=default-knowledge"' in html
 
 
 def test_ui_server_candidate_item_keeps_zero_score_and_requires_low_score_merge_target():

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -3604,6 +3604,83 @@ def test_ui_server_candidates_page_renders_review_warning():
     assert "rebuild failed" in html
 
 
+def test_ui_server_atlas_and_cluster_pages_truncate_large_member_lists():
+    from ovp_pipeline.commands.ui_server import _render_atlas_page, _render_clusters_page
+
+    members = [
+        {
+            "object_id": f"obj-{index}",
+            "title": f"Object {index}",
+            "object_path": f"/object?id=obj-{index}",
+        }
+        for index in range(20)
+    ]
+    atlas = _render_atlas_page(
+        {
+            "requested_pack": "",
+            "query": "",
+            "limit": 20,
+            "is_limited": True,
+            "count": 1,
+            "items": [
+                {
+                    "path": "00-Atlas/Demo.md",
+                    "title": "Demo Atlas",
+                    "member_count": 20,
+                    "members": members,
+                    "deep_dives": [],
+                    "source_notes": [],
+                    "preview_titles": [],
+                }
+            ],
+        }
+    )
+    clusters = _render_clusters_page(
+        {
+            "requested_pack": "",
+            "query": "",
+            "limit": 20,
+            "is_limited": True,
+            "cluster_kind_counts": {"component": 1},
+            "largest_cluster_size": 20,
+            "model_notes": [],
+            "count": 1,
+            "items": [
+                {
+                    "detail_path": "/cluster?id=demo",
+                    "display_title": "Demo Cluster",
+                    "label": "Demo Cluster",
+                    "cluster_kind": "component",
+                    "priority_band": "active",
+                    "member_count": 20,
+                    "member_links": [
+                        {"title": f"Object {index}", "path": f"/object?id=obj-{index}"}
+                        for index in range(20)
+                    ],
+                    "center_object_path": "/object?id=obj-0",
+                    "center_title": "Object 0",
+                    "priority_reason": "demo",
+                    "relation_pattern_preview": "",
+                    "related_cluster_count": 0,
+                    "related_cluster_preview": "",
+                    "neighborhood_score": 0,
+                    "next_read_title": "",
+                    "top_reading_route_kind": "",
+                    "reading_intent_count": 0,
+                    "top_summary_bullet": "",
+                }
+            ],
+        }
+    )
+
+    assert "Object 7" in atlas
+    assert "Object 8" not in atlas
+    assert "12 more" in atlas
+    assert "Object 7" in clusters
+    assert "Object 8" not in clusters
+    assert "12 more" in clusters
+
+
 def test_ui_server_can_promote_candidate_via_api(temp_vault):
     from ovp_pipeline.commands.ui_server import create_server
     from ovp_pipeline.concept_registry import ConceptRegistry, STATUS_ACTIVE

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -14,9 +14,12 @@ def _fresh_timestamp(*, seconds_ago: int = 0) -> str:
 def test_default_dashboard_browser_limits_stay_responsive():
     from ovp_pipeline.ui import view_models
 
+    assert view_models.DEFAULT_CANDIDATE_BROWSER_LIMIT >= 1
+    assert view_models.DEFAULT_EVENT_DOSSIER_LIMIT >= 1
+    assert view_models.DEFAULT_TRACEABILITY_BROWSER_LIMIT >= 1
     assert view_models.DEFAULT_CANDIDATE_BROWSER_LIMIT <= 25
     assert view_models.DEFAULT_EVENT_DOSSIER_LIMIT <= 25
-    assert view_models.DEFAULT_TRACEABILITY_BROWSER_LIMIT <= 20
+    assert view_models.DEFAULT_TRACEABILITY_BROWSER_LIMIT <= 15
 
 
 def _seed_truth_store(temp_vault):

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -11,6 +11,14 @@ def _fresh_timestamp(*, seconds_ago: int = 0) -> str:
     return (datetime.now(timezone.utc) - timedelta(seconds=seconds_ago)).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
+def test_default_dashboard_browser_limits_stay_responsive():
+    from ovp_pipeline.ui import view_models
+
+    assert view_models.DEFAULT_CANDIDATE_BROWSER_LIMIT <= 25
+    assert view_models.DEFAULT_EVENT_DOSSIER_LIMIT <= 25
+    assert view_models.DEFAULT_TRACEABILITY_BROWSER_LIMIT <= 20
+
+
 def _seed_truth_store(temp_vault):
     alpha = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
     beta = temp_vault / "10-Knowledge" / "Evergreen" / "Beta.md"
@@ -432,7 +440,7 @@ date: 2026-04-13
 
 
 def test_build_event_dossier_payload(temp_vault):
-    from ovp_pipeline.ui.view_models import build_event_dossier_payload
+    from ovp_pipeline.ui.view_models import DEFAULT_EVENT_DOSSIER_LIMIT, build_event_dossier_payload
 
     _seed_truth_store(temp_vault)
 
@@ -467,7 +475,7 @@ def test_build_event_dossier_payload(temp_vault):
     assert payload["events"][0]["semantic_role"] == "note_date_projection"
     assert payload["cluster_sections"][0]["date"] == "2026-04-13"
     assert payload["event_type_counts"] == {"dated_note": 3}
-    assert payload["limit"] == 50
+    assert payload["limit"] == DEFAULT_EVENT_DOSSIER_LIMIT
     assert payload["is_limited"] is True
     assert payload["timeline_contract"]["timeline_kind"] == "dated_note_projection"
     assert payload["timeline_contract"]["grouping_kind"] == "object_date_rollup"
@@ -1980,7 +1988,7 @@ Shipped the local-first harness update.
 
 
 def test_build_atlas_browser_payload(temp_vault):
-    from ovp_pipeline.ui.view_models import build_atlas_browser_payload
+    from ovp_pipeline.ui.view_models import DEFAULT_TRACEABILITY_BROWSER_LIMIT, build_atlas_browser_payload
 
     alpha = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
     alpha.write_text(
@@ -2022,12 +2030,12 @@ date: 2026-04-13
     assert payload["items"][0]["members"][0]["object_id"] == "alpha"
     assert payload["items"][0]["member_count"] == 1
     assert payload["items"][0]["preview_titles"] == ["Alpha"]
-    assert payload["limit"] == 50
+    assert payload["limit"] == DEFAULT_TRACEABILITY_BROWSER_LIMIT
     assert payload["is_limited"] is True
 
 
 def test_build_derivation_browser_payload(temp_vault):
-    from ovp_pipeline.ui.view_models import build_derivation_browser_payload
+    from ovp_pipeline.ui.view_models import DEFAULT_TRACEABILITY_BROWSER_LIMIT, build_derivation_browser_payload
 
     alpha = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
     alpha.write_text(
@@ -2077,7 +2085,7 @@ Mentions [[alpha]].
     assert payload["items"][0]["derived_object_count"] == 1
     assert payload["items"][0]["preview_titles"] == ["Alpha"]
     assert payload["items"][0]["source_notes"] == []
-    assert payload["limit"] == 50
+    assert payload["limit"] == DEFAULT_TRACEABILITY_BROWSER_LIMIT
     assert payload["is_limited"] is True
 
 
@@ -2230,7 +2238,7 @@ date: 2026-04-13
 
 
 def test_build_production_browser_payload(temp_vault):
-    from ovp_pipeline.ui.view_models import build_production_browser_payload
+    from ovp_pipeline.ui.view_models import DEFAULT_TRACEABILITY_BROWSER_LIMIT, build_production_browser_payload
 
     processed = temp_vault / "50-Inbox" / "03-Processed" / "2026-04" / "Harness.md"
     processed.parent.mkdir(parents=True, exist_ok=True)
@@ -2324,7 +2332,7 @@ Mentions [[alpha]].
     ]
     assert any(item["stage_label"] == "source_note" for item in payload["items"])
     assert any(item["stage_label"] == "deep_dive" for item in payload["items"])
-    assert payload["limit"] == 50
+    assert payload["limit"] == DEFAULT_TRACEABILITY_BROWSER_LIMIT
     assert payload["is_limited"] is True
 
 


### PR DESCRIPTION
## Summary\n- keep candidate review suggestions from triggering expensive related-context and legacy registry scans\n- batch and index signal capture-summary lookups so /signals and /briefing do not repeatedly scan pipeline logs\n- reduce default heavy browser limits and truncate large Atlas/cluster inline member lists\n\n## Verification\n- pytest -q tests/test_truth_api.py tests/test_ui_server.py tests/test_ui_view_models.py\n- HTTP crawl of all 25 links from http://127.0.0.1:8788/ completed with 200 responses\n- Playwright clicked all homepage nav links from the running 8788 dashboard
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/70" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Member links on Atlas and Clusters pages now truncate to 8 entries with "+X more" indicator for large lists.
  * Enhanced candidate review suggestions with deduplication and confidence-based sorting.
  * Updated default pagination limits for improved browsing experience (candidate browser: 25, event dossier: 25, traceability browser: 20).

* **Bug Fixes**
  * Fixed legacy search to exclude related context from results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->