### PR TITLE
Fix vault root resolution before pipeline runs

### DIFF
--- a/src/ovp_pipeline/runtime.py
+++ b/src/ovp_pipeline/runtime.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from pathlib import Path
 from contextlib import contextmanager
 import fcntl
+import os
 import time
 from typing import Iterator
 
@@ -13,8 +14,30 @@ import yaml
 
 def resolve_vault_dir(vault_dir: Path | str | None = None) -> Path:
     """Resolve the vault directory once and use the absolute path everywhere."""
+    if vault_dir is None:
+        vault_dir = os.environ.get("OVP_VAULT_DIR") or os.environ.get("VAULT_DIR")
     base = Path.cwd() if vault_dir is None else Path(vault_dir)
     return base.expanduser().resolve()
+
+
+def looks_like_vault_dir(vault_dir: Path | str) -> bool:
+    """Return True when the path has the core OpenClaw/Obsidian vault layout."""
+    base = resolve_vault_dir(vault_dir)
+    has_core_dirs = (
+        (base / "10-Knowledge").is_dir()
+        and (base / "20-Areas").is_dir()
+        and (base / "50-Inbox").is_dir()
+        and (base / "60-Logs").is_dir()
+    )
+    has_vault_marker = (
+        (base / ".obsidian").is_dir()
+        or ((base / "Index.md").is_file() and (base / "Log.md").is_file())
+    )
+    is_package_checkout = (
+        (base / "pyproject.toml").is_file()
+        and (base / "src" / "ovp_pipeline").is_dir()
+    )
+    return has_core_dirs and has_vault_marker and not is_package_checkout
 
 
 def is_hidden_path(path: Path) -> bool:

--- a/src/ovp_pipeline/runtime.py
+++ b/src/ovp_pipeline/runtime.py
@@ -27,7 +27,6 @@ def looks_like_vault_dir(vault_dir: Path | str) -> bool:
         (base / "10-Knowledge").is_dir()
         and (base / "20-Areas").is_dir()
         and (base / "50-Inbox").is_dir()
-        and (base / "60-Logs").is_dir()
     )
     has_vault_marker = (
         (base / ".obsidian").is_dir()

--- a/src/ovp_pipeline/unified_pipeline_enhanced.py
+++ b/src/ovp_pipeline/unified_pipeline_enhanced.py
@@ -251,7 +251,7 @@ def _check_api_key() -> tuple[bool, str]:
 
 
 def init_env_file(vault_dir: Path | str | None = None) -> int:
-    """初始化 .env 文件（交互式）"""
+    """初始化 .env 文件(交互式)"""
     resolved_vault = resolve_vault_dir(vault_dir)
     env_file = resolved_vault / ".env"
     env_example = resolved_vault / ".env.example"
@@ -265,9 +265,9 @@ def init_env_file(vault_dir: Path | str | None = None) -> int:
         print(f"\n✓ 发现已有配置文件: {env_file}")
         content = env_file.read_text(encoding="utf-8")
         if "AUTO_VAULT_API_KEY=" in content and "your_key" not in content:
-            print("  看起来已经配置好了。如需重新配置，请先删除该文件。")
+            print("  看起来已经配置好了。如需重新配置, 请先删除该文件。")
             return 0
-        print("  但可能未正确配置，继续引导设置...\n")
+        print("  但可能未正确配置, 继续引导设置...\n")
 
     # 创建 .env.example 如果不存在
     if not env_example.exists():
@@ -2909,10 +2909,10 @@ def main():
             print(f"  API Key: {key}...")
             print(f"  API Base: {os.environ.get('AUTO_VAULT_API_BASE', 'N/A')}")
         else:
-            print("\n✗ 环境未就绪，请确认 --vault-dir/VAULT_DIR 指向 vault，并检查 .env")
+            print("\n✗ 环境未就绪, 请确认 --vault-dir/OVP_VAULT_DIR/VAULT_DIR 指向 vault, 并检查 .env")
         return 0 if ok else 1
 
-    # 检查环境（运行前）
+    # 检查环境(运行前)
     ok, issues = check_environment(vault_dir)
     if not ok:
         print("\n" + "="*60)
@@ -2920,7 +2920,7 @@ def main():
         print("="*60)
         for issue in issues:
             print(f"  ✗ {issue}")
-        print("\n请确认 --vault-dir/VAULT_DIR 指向 vault，并检查 .env")
+        print("\n请确认 --vault-dir/OVP_VAULT_DIR/VAULT_DIR 指向 vault, 并检查 .env")
         return 1
 
     execution_plan = build_execution_plan(args)

--- a/src/ovp_pipeline/unified_pipeline_enhanced.py
+++ b/src/ovp_pipeline/unified_pipeline_enhanced.py
@@ -44,7 +44,7 @@ from typing import Any
 
 try:
     from .handler_registry import execute_profile_stage_handler
-    from .runtime import VaultLayout, vault_workflow_lock
+    from .runtime import VaultLayout, looks_like_vault_dir, resolve_vault_dir, vault_workflow_lock
     from .packs.loader import DEFAULT_PACK_NAME, DEFAULT_WORKFLOW_PACK_NAME, PRIMARY_PACK_NAME, resolve_workflow_profile
     from .batch_quality_checker import collect_quality_files
     from .auto_evergreen_extractor import run_absorb_workflow
@@ -58,7 +58,7 @@ try:
     )
 except ImportError:  # pragma: no cover - script mode fallback
     from handler_registry import execute_profile_stage_handler
-    from runtime import VaultLayout, vault_workflow_lock
+    from runtime import VaultLayout, looks_like_vault_dir, resolve_vault_dir, vault_workflow_lock
     from packs.loader import DEFAULT_PACK_NAME, DEFAULT_WORKFLOW_PACK_NAME, PRIMARY_PACK_NAME, resolve_workflow_profile
     from batch_quality_checker import collect_quality_files
     from auto_evergreen_extractor import run_absorb_workflow
@@ -354,9 +354,10 @@ AUTO_VAULT_MODEL={model}
 def check_environment(vault_dir: Path | None = None) -> tuple[bool, list[str]]:
     """检查环境配置，返回(是否就绪, 问题列表)"""
     issues = []
+    resolved_vault = resolve_vault_dir(vault_dir)
 
     # 加载环境变量（尝试多个位置）
-    _load_env(vault_dir)
+    _load_env(resolved_vault)
 
     # 检查 API Key
     key_ok, key_msg = _check_api_key()
@@ -376,8 +377,7 @@ def check_environment(vault_dir: Path | None = None) -> tuple[bool, list[str]]:
 
     # 检查 .env 文件（多个位置）
     env_paths = []
-    if vault_dir:
-        env_paths.append(vault_dir / ".env")
+    env_paths.append(resolved_vault / ".env")
     env_paths.append(Path.cwd() / ".env")
     env_paths.append(ENV_FILE)
     env_paths.append(ENV_FILE_ALT)
@@ -393,7 +393,16 @@ def check_environment(vault_dir: Path | None = None) -> tuple[bool, list[str]]:
     else:
         issues.append(".env file: NOT FOUND")
 
-    return key_ok, issues
+    vault_ok = looks_like_vault_dir(resolved_vault)
+    if vault_ok:
+        issues.append(f"Vault root: OK ({resolved_vault})")
+    else:
+        issues.append(
+            "Vault root: not a vault "
+            f"({resolved_vault}; expected core vault dirs plus .obsidian or root Index.md/Log.md)"
+        )
+
+    return key_ok and vault_ok, issues
 
 
 # ========== 配置 ==========
@@ -2868,9 +2877,10 @@ def main():
         ),
     )
     parser.add_argument("--profile", default=None, help="Workflow profile 名称（默认: full）")
-    parser.add_argument("--vault-dir", type=Path, default=VAULT_DIR, help="Vault根目录")
+    parser.add_argument("--vault-dir", type=Path, default=None, help="Vault根目录")
 
     args = parser.parse_args()
+    vault_dir = resolve_vault_dir(args.vault_dir)
 
     # 处理 init 命令
     if args.init:
@@ -2881,7 +2891,7 @@ def main():
         print("\n" + "="*60)
         print("环境检查")
         print("="*60)
-        ok, issues = check_environment(args.vault_dir)
+        ok, issues = check_environment(vault_dir)
         for issue in issues:
             print(f"  {'✓' if 'OK' in issue or 'Found' in issue else '✗'} {issue}")
         if ok:
@@ -2890,18 +2900,18 @@ def main():
             print(f"  API Key: {key}...")
             print(f"  API Base: {os.environ.get('AUTO_VAULT_API_BASE', 'N/A')}")
         else:
-            print("\n✗ 环境未就绪，请运行: ovp --init")
+            print("\n✗ 环境未就绪，请确认 --vault-dir/VAULT_DIR 指向 vault，并检查 .env")
         return 0 if ok else 1
 
     # 检查环境（运行前）
-    ok, issues = check_environment(args.vault_dir)
+    ok, issues = check_environment(vault_dir)
     if not ok:
         print("\n" + "="*60)
         print("环境错误")
         print("="*60)
         for issue in issues:
             print(f"  ✗ {issue}")
-        print("\n请先运行: ovp --init")
+        print("\n请确认 --vault-dir/VAULT_DIR 指向 vault，并检查 .env")
         return 1
 
     execution_plan = build_execution_plan(args)
@@ -2909,7 +2919,7 @@ def main():
         parser.print_help()
         sys.exit(1)
 
-    layout = VaultLayout.from_vault(args.vault_dir or VAULT_DIR)
+    layout = VaultLayout.from_vault(vault_dir)
 
     # 初始化
     logger = PipelineLogger(layout.pipeline_log)

--- a/src/ovp_pipeline/unified_pipeline_enhanced.py
+++ b/src/ovp_pipeline/unified_pipeline_enhanced.py
@@ -250,23 +250,27 @@ def _check_api_key() -> tuple[bool, str]:
     return True, "OK"
 
 
-def init_env_file() -> int:
+def init_env_file(vault_dir: Path | str | None = None) -> int:
     """初始化 .env 文件（交互式）"""
+    resolved_vault = resolve_vault_dir(vault_dir)
+    env_file = resolved_vault / ".env"
+    env_example = resolved_vault / ".env.example"
+
     print("="*60)
     print("Obsidian Vault Pipeline - 环境初始化")
     print("="*60)
 
     # 检查是否已有 .env
-    if ENV_FILE.exists():
-        print(f"\n✓ 发现已有配置文件: {ENV_FILE}")
-        content = ENV_FILE.read_text(encoding="utf-8")
+    if env_file.exists():
+        print(f"\n✓ 发现已有配置文件: {env_file}")
+        content = env_file.read_text(encoding="utf-8")
         if "AUTO_VAULT_API_KEY=" in content and "your_key" not in content:
             print("  看起来已经配置好了。如需重新配置，请先删除该文件。")
             return 0
         print("  但可能未正确配置，继续引导设置...\n")
 
     # 创建 .env.example 如果不存在
-    if not ENV_EXAMPLE.exists():
+    if not env_example.exists():
         example_content = '''# Obsidian Vault Pipeline 环境配置
 # ══════════════════════════════════════════════════════════
 # 配置说明:
@@ -296,8 +300,8 @@ PINBOARD_TOKEN=your_username:your_token
 # ── 代理配置 (可选) ─────────────────────────────────────
 # HTTP_PROXY=http://127.0.0.1:7897
 '''
-        ENV_EXAMPLE.write_text(example_content, encoding="utf-8")
-        print(f"✓ 创建模板文件: {ENV_EXAMPLE}")
+        env_example.write_text(example_content, encoding="utf-8")
+        print(f"✓ 创建模板文件: {env_example}")
 
     # 提示用户获取 API Key
     print("\n📋 你需要一个 LLM API Key 才能运行 Pipeline")
@@ -311,8 +315,8 @@ PINBOARD_TOKEN=your_username:your_token
     api_key = input("\n🔑 你的 API Key (sk-...): ").strip()
     if not api_key:
         print("\n❌ 未提供 API Key，初始化取消")
-        print(f"\n你可以稍后手动创建 {ENV_FILE}:")
-        print(f"  cp {ENV_EXAMPLE} {ENV_FILE}")
+        print(f"\n你可以稍后手动创建 {env_file}:")
+        print(f"  cp {env_example} {env_file}")
         print("  然后编辑填入你的 Key")
         return 1
 
@@ -341,10 +345,10 @@ AUTO_VAULT_API_BASE={base_url}
 AUTO_VAULT_MODEL={model}
 '''
 
-    ENV_FILE.write_text(env_content, encoding="utf-8")
-    os.chmod(ENV_FILE, 0o600)  # 设置权限为仅用户可读
+    env_file.write_text(env_content, encoding="utf-8")
+    os.chmod(env_file, 0o600)  # 设置权限为仅用户可读
 
-    print(f"\n✓ 配置文件已创建: {ENV_FILE}")
+    print(f"\n✓ 配置文件已创建: {env_file}")
     print(f"  Provider: {base_url}")
     print(f"  Model: {model}")
     print("\n现在可以运行: ovp --full")
@@ -399,7 +403,7 @@ def check_environment(vault_dir: Path | None = None) -> tuple[bool, list[str]]:
     else:
         issues.append(
             "Vault root: not a vault "
-            f"({resolved_vault}; expected core vault dirs plus .obsidian or root Index.md/Log.md)"
+            f"({resolved_vault}; expected 10-Knowledge, 20-Areas, 50-Inbox plus .obsidian or root Index.md/Log.md)"
         )
 
     return key_ok and vault_ok, issues
@@ -2877,14 +2881,19 @@ def main():
         ),
     )
     parser.add_argument("--profile", default=None, help="Workflow profile 名称（默认: full）")
-    parser.add_argument("--vault-dir", type=Path, default=None, help="Vault根目录")
+    parser.add_argument(
+        "--vault-dir",
+        type=Path,
+        default=None,
+        help="Vault根目录 (默认: OVP_VAULT_DIR, VAULT_DIR, 或当前目录)",
+    )
 
     args = parser.parse_args()
     vault_dir = resolve_vault_dir(args.vault_dir)
 
     # 处理 init 命令
     if args.init:
-        return init_env_file()
+        return init_env_file(vault_dir)
 
     # 处理 check 命令
     if args.check:

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -45,11 +45,25 @@ def test_resolve_vault_dir_prefers_environment_when_not_explicit(tmp_path, monke
     workspace.mkdir()
     vault.mkdir()
     monkeypatch.chdir(workspace)
+    monkeypatch.delenv("OVP_VAULT_DIR", raising=False)
     monkeypatch.setenv("VAULT_DIR", str(vault))
 
     resolved = resolve_vault_dir()
 
     assert resolved == vault.resolve()
+
+
+def test_resolve_vault_dir_prefers_ovp_vault_dir_over_vault_dir(tmp_path, monkeypatch):
+    ovp_vault = tmp_path / "ovp-vault"
+    legacy_vault = tmp_path / "legacy-vault"
+    ovp_vault.mkdir()
+    legacy_vault.mkdir()
+    monkeypatch.setenv("OVP_VAULT_DIR", str(ovp_vault))
+    monkeypatch.setenv("VAULT_DIR", str(legacy_vault))
+
+    resolved = resolve_vault_dir()
+
+    assert resolved == ovp_vault.resolve()
 
 
 def test_resolve_vault_dir_explicit_argument_overrides_environment(tmp_path, monkeypatch):

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -7,8 +7,6 @@ import os
 from pathlib import Path
 import sys
 
-import pytest
-
 from ovp_pipeline.auto_github_processor import build_default_output_dir as github_output_dir
 from ovp_pipeline.auto_paper_processor import build_default_output_dir as paper_output_dir
 from ovp_pipeline.runtime import (
@@ -21,6 +19,7 @@ from ovp_pipeline.runtime import (
 from ovp_pipeline.unified_pipeline_enhanced import (
     EnhancedPipeline,
     build_execution_plan,
+    check_environment,
     detect_pinboard_processor,
 )
 
@@ -36,6 +35,31 @@ def test_resolve_vault_dir_returns_absolute_path(tmp_path, monkeypatch):
     resolved = resolve_vault_dir(Path("..") / "vault")
 
     assert resolved == vault.resolve()
+
+
+def test_resolve_vault_dir_prefers_environment_when_not_explicit(tmp_path, monkeypatch):
+    workspace = tmp_path / "workspace"
+    vault = tmp_path / "vault"
+    workspace.mkdir()
+    vault.mkdir()
+    monkeypatch.chdir(workspace)
+    monkeypatch.setenv("VAULT_DIR", str(vault))
+
+    resolved = resolve_vault_dir()
+
+    assert resolved == vault.resolve()
+
+
+def test_resolve_vault_dir_explicit_argument_overrides_environment(tmp_path, monkeypatch):
+    env_vault = tmp_path / "env-vault"
+    explicit_vault = tmp_path / "explicit-vault"
+    env_vault.mkdir()
+    explicit_vault.mkdir()
+    monkeypatch.setenv("VAULT_DIR", str(env_vault))
+
+    resolved = resolve_vault_dir(explicit_vault)
+
+    assert resolved == explicit_vault.resolve()
 
 
 def test_vault_layout_uses_resolved_vault_dir(tmp_path):
@@ -55,6 +79,54 @@ def test_vault_layout_uses_resolved_vault_dir(tmp_path):
     assert layout.processed_month_dir(datetime(2026, 4, 8)) == (
         tmp_path / "vault" / "50-Inbox" / "03-Processed" / "2026-04"
     ).resolve()
+
+
+def test_check_environment_rejects_non_vault_directory(tmp_path, monkeypatch):
+    non_vault = tmp_path / "template-checkout"
+    non_vault.mkdir()
+    (non_vault / ".env").write_text("AUTO_VAULT_API_KEY=sk-test-valid-key\n", encoding="utf-8")
+    monkeypatch.setenv("AUTO_VAULT_API_KEY", "sk-test-valid-key")
+
+    ok, issues = check_environment(non_vault)
+
+    assert ok is False
+    assert any("not a vault" in issue for issue in issues)
+
+
+def test_check_environment_rejects_package_checkout_with_vault_scaffold(tmp_path, monkeypatch):
+    package_checkout = tmp_path / "openclaw-template"
+    for rel in (
+        "10-Knowledge",
+        "20-Areas",
+        "50-Inbox",
+        "60-Logs",
+        "src/ovp_pipeline",
+    ):
+        (package_checkout / rel).mkdir(parents=True)
+    (package_checkout / "pyproject.toml").write_text(
+        "[project]\nname = 'obsidian-vault-pipeline'\n",
+        encoding="utf-8",
+    )
+    (package_checkout / ".env").write_text("AUTO_VAULT_API_KEY=sk-test-valid-key\n", encoding="utf-8")
+    monkeypatch.setenv("AUTO_VAULT_API_KEY", "sk-test-valid-key")
+
+    ok, issues = check_environment(package_checkout)
+
+    assert ok is False
+    assert any("not a vault" in issue for issue in issues)
+
+
+def test_check_environment_accepts_obsidian_vault_layout(tmp_path, monkeypatch):
+    vault = tmp_path / "vault"
+    for rel in ("10-Knowledge", "20-Areas", "50-Inbox", "60-Logs", ".obsidian"):
+        (vault / rel).mkdir(parents=True)
+    (vault / ".env").write_text("AUTO_VAULT_API_KEY=sk-test-valid-key\n", encoding="utf-8")
+    monkeypatch.setenv("AUTO_VAULT_API_KEY", "sk-test-valid-key")
+
+    ok, issues = check_environment(vault)
+
+    assert ok is True
+    assert any("Vault root: OK" in issue for issue in issues)
 
 
 def test_specialized_processors_derive_default_outputs_from_vault(tmp_path):

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -12,6 +12,7 @@ from ovp_pipeline.auto_paper_processor import build_default_output_dir as paper_
 from ovp_pipeline.runtime import (
     VaultLayout,
     iter_markdown_files,
+    looks_like_vault_dir,
     markdown_title,
     read_markdown_frontmatter,
     resolve_vault_dir,
@@ -21,6 +22,7 @@ from ovp_pipeline.unified_pipeline_enhanced import (
     build_execution_plan,
     check_environment,
     detect_pinboard_processor,
+    init_env_file,
 )
 
 
@@ -127,6 +129,28 @@ def test_check_environment_accepts_obsidian_vault_layout(tmp_path, monkeypatch):
 
     assert ok is True
     assert any("Vault root: OK" in issue for issue in issues)
+
+
+def test_fresh_obsidian_vault_does_not_require_logs_dir(tmp_path):
+    vault = tmp_path / "fresh-vault"
+    for rel in ("10-Knowledge", "20-Areas", "50-Inbox", ".obsidian"):
+        (vault / rel).mkdir(parents=True)
+
+    assert looks_like_vault_dir(vault) is True
+
+
+def test_init_env_file_writes_to_resolved_vault_dir(tmp_path, monkeypatch):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    inputs = iter(["sk-test-valid-key", "1"])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(inputs))
+
+    exit_code = init_env_file(vault)
+
+    env_file = vault / ".env"
+    assert exit_code == 0
+    assert env_file.exists()
+    assert "AUTO_VAULT_API_KEY=sk-test-valid-key" in env_file.read_text(encoding="utf-8")
 
 
 def test_specialized_processors_derive_default_outputs_from_vault(tmp_path):


### PR DESCRIPTION
## Summary
- resolve default vault roots from explicit args, OVP_VAULT_DIR/VAULT_DIR, then cwd
- reject package checkouts and non-vault directories before running the pipeline
- add regression coverage for env resolution and vault root validation

## Test Plan
- pytest -q tests/test_runtime_paths.py
- ruff check src/ovp_pipeline/runtime.py src/ovp_pipeline/unified_pipeline_enhanced.py tests/test_runtime_paths.py
- env -u VAULT_DIR -u OVP_VAULT_DIR ovp --check
- env -u OVP_VAULT_DIR VAULT_DIR=/Users/chris/Documents/openclaw-vault ovp --check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/71" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Vault directory can now be automatically resolved from `OVP_VAULT_DIR` or `VAULT_DIR` environment variables when not explicitly specified

* **Bug Fixes**
  * Enhanced vault directory validation to detect proper vault structures
  * Improved error messaging to guide users toward correct vault configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->