### PR TITLE
Route absorb sources through source lifecycle

### DIFF
--- a/docs/plans/2026-04-22-vision-and-roadmap-trusted-reuse-compiler.md
+++ b/docs/plans/2026-04-22-vision-and-roadmap-trusted-reuse-compiler.md
@@ -11,7 +11,7 @@ tools:
 projects:
   - OVP
   - research-tech
-  - OpenClaw
+  - Obsidian Vault Pipeline
 ---
 # Vision & Roadmap: The Auditable Knowledge Compiler
 

--- a/src/ovp_pipeline/auto_evergreen_extractor.py
+++ b/src/ovp_pipeline/auto_evergreen_extractor.py
@@ -63,7 +63,7 @@ except ImportError:
 
 # Try to import concept registry
 try:
-    from .concept_registry import ConceptRegistry, STATUS_ACTIVE, STATUS_CANDIDATE
+    from .concept_registry import ConceptRegistry
     HAS_REGISTRY = True
 except ImportError:
     HAS_REGISTRY = False
@@ -655,6 +655,27 @@ def build_extraction_summary(
     }
 
 
+def _is_under_path(path: Path, parent: Path) -> bool:
+    try:
+        path.resolve(strict=False).relative_to(parent.resolve(strict=False))
+        return True
+    except ValueError:
+        return False
+
+
+def _reject_intake_source_target(layout: VaultLayout, path: Path) -> None:
+    for source_root in (
+        layout.clippings_dir,
+        layout.raw_dir,
+        layout.processing_dir,
+        layout.processed_dir,
+    ):
+        if _is_under_path(path, source_root):
+            raise ValueError(
+                f"absorb target is an intake source and must go through source lifecycle first: {path}"
+            )
+
+
 def _collect_absorb_targets(
     layout: VaultLayout,
     *,
@@ -663,11 +684,16 @@ def _collect_absorb_targets(
     recent: int | None = None,
 ) -> list[Path]:
     if file_path:
+        _reject_intake_source_target(layout, file_path)
         return [file_path]
     if directory:
+        _reject_intake_source_target(layout, directory)
         if not directory.exists():
             return []
-        return sorted(directory.glob("*_深度解读.md"))
+        targets = sorted(directory.glob("*_深度解读.md"))
+        for target in targets:
+            _reject_intake_source_target(layout, target)
+        return targets
     if recent:
         areas_root = layout.vault_dir / "20-Areas"
         area_dirs = (
@@ -727,6 +753,13 @@ def run_absorb_workflow(
     if verbose:
         print("✓ LLM Client initialized")
 
+    targets = _collect_absorb_targets(
+        layout,
+        file_path=file_path,
+        directory=directory,
+        recent=recent,
+    )
+
     if directory and progress_callback is None and hasattr(extractor, "process_directory"):
         results = extractor.process_directory(
             directory,
@@ -755,13 +788,6 @@ def run_absorb_workflow(
             },
         )
         return payload
-
-    targets = _collect_absorb_targets(
-        layout,
-        file_path=file_path,
-        directory=directory,
-        recent=recent,
-    )
 
     if verbose and directory:
         print(f"\nProcessing directory: {directory}")
@@ -872,7 +898,7 @@ def main(argv: list[str] | None = None):
         return 0
 
     print(f"\n{'='*60}")
-    print(f"EVERGREEN EXTRACTION COMPLETE")
+    print("EVERGREEN EXTRACTION COMPLETE")
     print(f"{'='*60}")
     print(f"Files processed: {payload['summary']['files_processed']}")
     print(f"Concepts extracted: {payload['summary']['concepts_extracted']}")

--- a/src/ovp_pipeline/commands/absorb.py
+++ b/src/ovp_pipeline/commands/absorb.py
@@ -1,12 +1,170 @@
 from __future__ import annotations
 
 import argparse
+from datetime import datetime
 import json
 from pathlib import Path
+import shutil
+import time
 
 from ..auto_evergreen_extractor import run_absorb_workflow
+from ..auto_article_processor import AutoArticleProcessor, PipelineLogger, TransactionManager
+from ..clippings_processor import ClippingsProcessor
 from ..evidence import build_evidence_payload
-from ..runtime import resolve_vault_dir
+from ..runtime import VaultLayout, resolve_vault_dir
+
+
+def _is_under(path: Path, parent: Path) -> bool:
+    try:
+        path.resolve(strict=False).relative_to(parent.resolve(strict=False))
+        return True
+    except ValueError:
+        return False
+
+
+def _path_needs_source_lifecycle(layout: VaultLayout, path: Path) -> bool:
+    return any(
+        _is_under(path, root)
+        for root in (
+            layout.clippings_dir,
+            layout.raw_dir,
+            layout.processing_dir,
+            layout.processed_dir,
+        )
+    )
+
+
+def _expand_cli_target(path: Path) -> list[Path]:
+    if path.is_dir():
+        return sorted(candidate for candidate in path.rglob("*.md") if candidate.is_file())
+    return [path]
+
+
+def _unique_child(directory: Path, name: str) -> Path:
+    candidate = directory / name
+    if not candidate.exists():
+        return candidate
+    stem = candidate.stem
+    suffix = candidate.suffix
+    counter = 2
+    while True:
+        next_candidate = directory / f"{stem}-{counter}{suffix}"
+        if not next_candidate.exists():
+            return next_candidate
+        counter += 1
+
+
+def _move_clipping_to_raw(
+    layout: VaultLayout,
+    processor: ClippingsProcessor,
+    source: Path,
+    *,
+    settle_timeout_s: float = 5.0,
+) -> Path:
+    clean_name = processor.sanitize_filename(source.stem) + ".md"
+    new_name = f"{datetime.now().strftime('%Y-%m-%d')}_{clean_name}"
+    destination = _unique_child(layout.raw_dir, new_name)
+    if not processor.obsidian_move(source, layout.raw_dir, destination.name):
+        raise RuntimeError(f"failed to move clipping into raw intake: {source}")
+    deadline = time.monotonic() + settle_timeout_s
+    while not destination.exists() and time.monotonic() < deadline:
+        time.sleep(0.1)
+    if not destination.exists():
+        if source.exists():
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(source), str(destination))
+        else:
+            raise FileNotFoundError(
+                f"obsidian move reported success but destination did not appear: {destination}"
+            )
+    return destination
+
+
+def run_source_lifecycle_for_absorb_targets(vault_dir: Path, targets: list[Path], *, dry_run: bool) -> list[Path]:
+    layout = VaultLayout.from_vault(vault_dir)
+    logger = PipelineLogger(layout.pipeline_log)
+    txn = TransactionManager(layout.transactions_dir)
+    clippings = ClippingsProcessor(layout.vault_dir, logger, txn)
+    processor = AutoArticleProcessor(layout.vault_dir, logger, txn)
+    if not dry_run:
+        processor.init_llm()
+
+    deep_dive_targets: list[Path] = []
+    for target in targets:
+        for source in _expand_cli_target(target):
+            working_source = source
+            if _is_under(source, layout.clippings_dir):
+                working_source = _move_clipping_to_raw(layout, clippings, source)
+
+            if dry_run:
+                continue
+
+            if _is_under(working_source, layout.raw_dir):
+                working_source = processor._stage_source_for_processing(working_source)
+
+            result = processor.process_single_file(working_source, dry_run=False)
+            if result.get("status") == "completed" and result.get("output_path"):
+                deep_dive_targets.append(Path(str(result["output_path"])))
+                if _is_under(working_source, layout.processing_dir):
+                    processor._archive_source_to_processed(working_source)
+            elif _is_under(working_source, layout.processing_dir) and working_source.exists():
+                processor._restore_source_to_raw(working_source)
+
+    return deep_dive_targets
+
+
+def _merge_absorb_payloads(payloads: list[dict]) -> dict:
+    summary_keys = (
+        "files_processed",
+        "concepts_extracted",
+        "candidates_added",
+        "concepts_promoted",
+        "concepts_created",
+        "concepts_skipped",
+        "errors",
+    )
+    return {
+        "mode": "absorb",
+        "dry_run": False,
+        "summary": {
+            key: sum(int(payload.get("summary", {}).get(key, 0)) for payload in payloads)
+            for key in summary_keys
+        },
+        "results": [
+            result
+            for payload in payloads
+            for result in payload.get("results", [])
+        ],
+    }
+
+
+def _run_absorb_for_targets(
+    vault_dir: Path,
+    targets: list[Path],
+    *,
+    auto_promote: bool,
+    promote_threshold: int,
+) -> dict:
+    if len(targets) == 1:
+        return run_absorb_workflow(
+            vault_dir,
+            file_path=targets[0],
+            dry_run=False,
+            auto_promote=auto_promote,
+            promote_threshold=promote_threshold,
+        )
+    return _merge_absorb_payloads(
+        [
+            run_absorb_workflow(
+                vault_dir,
+                file_path=target,
+                dry_run=False,
+                auto_promote=auto_promote,
+                promote_threshold=promote_threshold,
+            )
+            for target in targets
+        ]
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -22,6 +180,18 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     vault_dir = resolve_vault_dir(args.vault_dir)
+    layout = VaultLayout.from_vault(vault_dir)
+    cli_targets = []
+    if args.file:
+        cli_targets.extend(_expand_cli_target(args.file))
+    if args.dir:
+        cli_targets.extend(_expand_cli_target(args.dir))
+    source_lifecycle_targets = [
+        target for target in cli_targets if _path_needs_source_lifecycle(layout, target)
+    ]
+    direct_absorb_targets = [
+        target for target in cli_targets if not _path_needs_source_lifecycle(layout, target)
+    ]
     payload = {
         "mode": "absorb",
         "vault_dir": str(vault_dir),
@@ -31,6 +201,11 @@ def main(argv: list[str] | None = None) -> int:
         "dry_run": args.dry_run,
         "auto_promote": args.auto_promote,
         "promote_threshold": args.promote_threshold,
+        "source_lifecycle": {
+            "required": bool(source_lifecycle_targets),
+            "source_targets": [str(target) for target in source_lifecycle_targets],
+            "absorb_targets": [],
+        },
     }
 
     if args.dry_run:
@@ -40,15 +215,63 @@ def main(argv: list[str] | None = None) -> int:
             print("absorb dry-run")
         return 0
 
-    workflow_payload = run_absorb_workflow(
-        vault_dir,
-        file_path=args.file,
-        directory=args.dir,
-        recent=args.recent,
-        dry_run=False,
-        auto_promote=args.auto_promote,
-        promote_threshold=args.promote_threshold,
-    )
+    absorb_targets = list(direct_absorb_targets)
+    if source_lifecycle_targets:
+        lifecycle_targets = run_source_lifecycle_for_absorb_targets(
+            vault_dir,
+            source_lifecycle_targets,
+            dry_run=False,
+        )
+        payload["source_lifecycle"]["absorb_targets"] = [str(target) for target in lifecycle_targets]
+        absorb_targets.extend(lifecycle_targets)
+        if not lifecycle_targets:
+            workflow_payload = {
+                "mode": "absorb",
+                "dry_run": False,
+                "source_lifecycle": payload["source_lifecycle"],
+                "summary": {
+                    "files_processed": 0,
+                    "concepts_extracted": 0,
+                    "candidates_added": 0,
+                    "concepts_promoted": 0,
+                    "concepts_created": 0,
+                    "concepts_skipped": 0,
+                    "errors": 1,
+                },
+                "results": [],
+                "error": "source lifecycle produced no absorb targets",
+            }
+            if args.json:
+                print(json.dumps(workflow_payload, ensure_ascii=False, indent=2))
+            else:
+                print("error: source lifecycle produced no absorb targets")
+            return 1
+
+    file_path = args.file
+    directory = args.dir
+    recent = args.recent
+    if source_lifecycle_targets or (args.file and args.dir):
+        file_path = None
+        directory = None
+        recent = None
+        workflow_payload = _run_absorb_for_targets(
+            vault_dir,
+            absorb_targets,
+            auto_promote=args.auto_promote,
+            promote_threshold=args.promote_threshold,
+        )
+    else:
+        workflow_payload = run_absorb_workflow(
+            vault_dir,
+            file_path=file_path,
+            directory=directory,
+            recent=recent,
+            dry_run=False,
+            auto_promote=args.auto_promote,
+            promote_threshold=args.promote_threshold,
+        )
+    if source_lifecycle_targets:
+        workflow_payload["source_lifecycle"] = payload["source_lifecycle"]
     mentions = [
         str(concept.get("name") or "")
         for result in workflow_payload.get("results", [])

--- a/src/ovp_pipeline/commands/absorb.py
+++ b/src/ovp_pipeline/commands/absorb.py
@@ -34,10 +34,28 @@ def _path_needs_source_lifecycle(layout: VaultLayout, path: Path) -> bool:
     )
 
 
-def _expand_cli_target(path: Path) -> list[Path]:
+def _expand_markdown_sources(path: Path) -> list[Path]:
     if path.is_dir():
         return sorted(candidate for candidate in path.rglob("*.md") if candidate.is_file())
     return [path]
+
+
+def _expand_deep_dive_targets(path: Path) -> list[Path]:
+    if path.is_dir():
+        return sorted(candidate for candidate in path.glob("*_深度解读.md") if candidate.is_file())
+    return [path]
+
+
+def _dedupe_paths(paths: list[Path]) -> list[Path]:
+    unique: list[Path] = []
+    seen: set[Path] = set()
+    for path in paths:
+        key = path.resolve(strict=False)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(path)
+    return unique
 
 
 def _unique_child(directory: Path, name: str) -> Path:
@@ -80,7 +98,67 @@ def _move_clipping_to_raw(
     return destination
 
 
-def run_source_lifecycle_for_absorb_targets(vault_dir: Path, targets: list[Path], *, dry_run: bool) -> list[Path]:
+def _record_source_lifecycle_failure(
+    logger: PipelineLogger,
+    failures: list[dict[str, str]] | None,
+    *,
+    source: Path,
+    stage: str,
+    exc: Exception,
+) -> None:
+    failure = {
+        "source": str(source),
+        "stage": stage,
+        "error": str(exc),
+    }
+    if failures is not None:
+        failures.append(failure)
+    logger.log("source_lifecycle_finalize_error", failure)
+
+
+def _safe_archive_source_to_processed(
+    processor: AutoArticleProcessor,
+    logger: PipelineLogger,
+    failures: list[dict[str, str]] | None,
+    source: Path,
+) -> None:
+    try:
+        processor._archive_source_to_processed(source)
+    except Exception as exc:
+        _record_source_lifecycle_failure(
+            logger,
+            failures,
+            source=source,
+            stage="archive_to_processed",
+            exc=exc,
+        )
+
+
+def _safe_restore_source_to_raw(
+    processor: AutoArticleProcessor,
+    logger: PipelineLogger,
+    failures: list[dict[str, str]] | None,
+    source: Path,
+) -> None:
+    try:
+        processor._restore_source_to_raw(source)
+    except Exception as exc:
+        _record_source_lifecycle_failure(
+            logger,
+            failures,
+            source=source,
+            stage="restore_to_raw",
+            exc=exc,
+        )
+
+
+def run_source_lifecycle_for_absorb_targets(
+    vault_dir: Path,
+    targets: list[Path],
+    *,
+    dry_run: bool,
+    failures: list[dict[str, str]] | None = None,
+) -> list[Path]:
     layout = VaultLayout.from_vault(vault_dir)
     logger = PipelineLogger(layout.pipeline_log)
     txn = TransactionManager(layout.transactions_dir)
@@ -91,9 +169,11 @@ def run_source_lifecycle_for_absorb_targets(vault_dir: Path, targets: list[Path]
 
     deep_dive_targets: list[Path] = []
     for target in targets:
-        for source in _expand_cli_target(target):
+        for source in _expand_markdown_sources(target):
             working_source = source
             if _is_under(source, layout.clippings_dir):
+                if dry_run:
+                    continue
                 working_source = _move_clipping_to_raw(layout, clippings, source)
 
             if dry_run:
@@ -106,9 +186,9 @@ def run_source_lifecycle_for_absorb_targets(vault_dir: Path, targets: list[Path]
             if result.get("status") == "completed" and result.get("output_path"):
                 deep_dive_targets.append(Path(str(result["output_path"])))
                 if _is_under(working_source, layout.processing_dir):
-                    processor._archive_source_to_processed(working_source)
+                    _safe_archive_source_to_processed(processor, logger, failures, working_source)
             elif _is_under(working_source, layout.processing_dir) and working_source.exists():
-                processor._restore_source_to_raw(working_source)
+                _safe_restore_source_to_raw(processor, logger, failures, working_source)
 
     return deep_dive_targets
 
@@ -181,17 +261,20 @@ def main(argv: list[str] | None = None) -> int:
 
     vault_dir = resolve_vault_dir(args.vault_dir)
     layout = VaultLayout.from_vault(vault_dir)
-    cli_targets = []
+    source_lifecycle_targets = []
+    direct_absorb_targets = []
     if args.file:
-        cli_targets.extend(_expand_cli_target(args.file))
+        if _path_needs_source_lifecycle(layout, args.file):
+            source_lifecycle_targets.extend(_expand_markdown_sources(args.file))
+        else:
+            direct_absorb_targets.append(args.file)
     if args.dir:
-        cli_targets.extend(_expand_cli_target(args.dir))
-    source_lifecycle_targets = [
-        target for target in cli_targets if _path_needs_source_lifecycle(layout, target)
-    ]
-    direct_absorb_targets = [
-        target for target in cli_targets if not _path_needs_source_lifecycle(layout, target)
-    ]
+        if _path_needs_source_lifecycle(layout, args.dir):
+            source_lifecycle_targets.extend(_expand_markdown_sources(args.dir))
+        else:
+            direct_absorb_targets.extend(_expand_deep_dive_targets(args.dir))
+    source_lifecycle_targets = _dedupe_paths(source_lifecycle_targets)
+    direct_absorb_targets = _dedupe_paths(direct_absorb_targets)
     payload = {
         "mode": "absorb",
         "vault_dir": str(vault_dir),
@@ -205,6 +288,7 @@ def main(argv: list[str] | None = None) -> int:
             "required": bool(source_lifecycle_targets),
             "source_targets": [str(target) for target in source_lifecycle_targets],
             "absorb_targets": [],
+            "failures": [],
         },
     }
 
@@ -217,14 +301,18 @@ def main(argv: list[str] | None = None) -> int:
 
     absorb_targets = list(direct_absorb_targets)
     if source_lifecycle_targets:
+        lifecycle_failures: list[dict[str, str]] = []
         lifecycle_targets = run_source_lifecycle_for_absorb_targets(
             vault_dir,
             source_lifecycle_targets,
             dry_run=False,
+            failures=lifecycle_failures,
         )
         payload["source_lifecycle"]["absorb_targets"] = [str(target) for target in lifecycle_targets]
+        payload["source_lifecycle"]["failures"] = lifecycle_failures
         absorb_targets.extend(lifecycle_targets)
-        if not lifecycle_targets:
+        absorb_targets = _dedupe_paths(absorb_targets)
+        if not absorb_targets:
             workflow_payload = {
                 "mode": "absorb",
                 "dry_run": False,

--- a/src/ovp_pipeline/runtime.py
+++ b/src/ovp_pipeline/runtime.py
@@ -21,7 +21,7 @@ def resolve_vault_dir(vault_dir: Path | str | None = None) -> Path:
 
 
 def looks_like_vault_dir(vault_dir: Path | str) -> bool:
-    """Return True when the path has the core OpenClaw/Obsidian vault layout."""
+    """Return True when the path has the core OVP/Obsidian vault layout."""
     base = resolve_vault_dir(vault_dir)
     has_core_dirs = (
         (base / "10-Knowledge").is_dir()

--- a/tests/test_absorb_refine_commands.py
+++ b/tests/test_absorb_refine_commands.py
@@ -252,10 +252,17 @@ def test_absorb_file_under_clippings_runs_source_lifecycle_before_absorb(temp_va
     clipping.write_text("# Raw Clip\n", encoding="utf-8")
     deep_dive = temp_vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "Raw Clip_深度解读.md"
 
-    def fake_run_source_lifecycle_for_absorb_targets(vault_dir: Path, targets: list[Path], *, dry_run: bool) -> list[Path]:
+    def fake_run_source_lifecycle_for_absorb_targets(
+        vault_dir: Path,
+        targets: list[Path],
+        *,
+        dry_run: bool,
+        failures: list[dict[str, str]] | None = None,
+    ) -> list[Path]:
         assert vault_dir == temp_vault
         assert targets == [clipping]
         assert dry_run is False
+        assert failures == []
         return [deep_dive]
 
     def fake_run_absorb_workflow(
@@ -349,3 +356,207 @@ def test_absorb_dry_run_under_clippings_reports_source_lifecycle_plan(temp_vault
     payload = json.loads(captured.out)
     assert payload["source_lifecycle"]["required"] is True
     assert payload["source_lifecycle"]["source_targets"] == [str(clipping)]
+
+
+def test_run_source_lifecycle_dry_run_does_not_move_clippings(temp_vault):
+    from ovp_pipeline.commands.absorb import run_source_lifecycle_for_absorb_targets
+    from ovp_pipeline.runtime import VaultLayout
+
+    layout = VaultLayout.from_vault(temp_vault)
+    layout.clippings_dir.mkdir(parents=True, exist_ok=True)
+    clipping = layout.clippings_dir / "Dry Run Clip.md"
+    clipping.write_text("# Dry Run Clip\n", encoding="utf-8")
+
+    targets = run_source_lifecycle_for_absorb_targets(temp_vault, [clipping], dry_run=True)
+
+    assert targets == []
+    assert clipping.exists()
+    assert not any(layout.raw_dir.glob("*.md"))
+
+
+def test_absorb_mixed_lifecycle_failure_keeps_direct_targets(temp_vault, capsys, monkeypatch):
+    from ovp_pipeline.commands import absorb
+
+    clipping = temp_vault / "Clippings" / "Raw Clip.md"
+    clipping.parent.mkdir(parents=True, exist_ok=True)
+    clipping.write_text("# Raw Clip\n", encoding="utf-8")
+    topic_dir = temp_vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04"
+    topic_dir.mkdir(parents=True, exist_ok=True)
+    deep_dive = topic_dir / "Direct_深度解读.md"
+    deep_dive.write_text("# Direct\n", encoding="utf-8")
+
+    def fake_run_source_lifecycle_for_absorb_targets(
+        vault_dir: Path,
+        targets: list[Path],
+        *,
+        dry_run: bool,
+        failures: list[dict[str, str]] | None = None,
+    ) -> list[Path]:
+        assert vault_dir == temp_vault
+        assert targets == [clipping]
+        assert dry_run is False
+        if failures is not None:
+            failures.append({"source": str(clipping), "stage": "process", "error": "failed"})
+        return []
+
+    def fake_run_absorb_workflow(
+        vault_dir: Path,
+        *,
+        file_path: Path | None = None,
+        directory: Path | None = None,
+        recent: int | None = None,
+        dry_run: bool = False,
+        auto_promote: bool = False,
+        promote_threshold: int = 3,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> dict:
+        assert vault_dir == temp_vault
+        assert file_path == deep_dive
+        assert directory is None
+        assert recent is None
+        assert dry_run is False
+        assert api_key is None
+        assert api_base is None
+        return {
+            "mode": "absorb",
+            "dry_run": False,
+            "summary": {
+                "files_processed": 1,
+                "concepts_extracted": 1,
+                "candidates_added": 0,
+                "concepts_promoted": 0,
+                "concepts_created": 0,
+                "concepts_skipped": 0,
+                "errors": 0,
+            },
+            "results": [],
+        }
+
+    monkeypatch.setattr(absorb, "run_source_lifecycle_for_absorb_targets", fake_run_source_lifecycle_for_absorb_targets)
+    monkeypatch.setattr(absorb, "run_absorb_workflow", fake_run_absorb_workflow)
+
+    result = absorb.main(
+        [
+            "--vault-dir",
+            str(temp_vault),
+            "--file",
+            str(clipping),
+            "--dir",
+            str(topic_dir),
+            "--json",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert result == 0
+    payload = json.loads(captured.out)
+    assert payload["source_lifecycle"]["absorb_targets"] == []
+    assert payload["source_lifecycle"]["failures"][0]["stage"] == "process"
+
+
+def test_absorb_file_and_dir_filters_direct_dir_to_deduped_deep_dives(temp_vault, monkeypatch):
+    from ovp_pipeline.commands import absorb
+
+    topic_dir = temp_vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04"
+    topic_dir.mkdir(parents=True, exist_ok=True)
+    deep_dive = topic_dir / "Direct_深度解读.md"
+    ordinary_note = topic_dir / "ordinary.md"
+    nested_deep_dive = topic_dir / "nested" / "Nested_深度解读.md"
+    nested_deep_dive.parent.mkdir(parents=True, exist_ok=True)
+    deep_dive.write_text("# Direct\n", encoding="utf-8")
+    ordinary_note.write_text("# Ordinary\n", encoding="utf-8")
+    nested_deep_dive.write_text("# Nested\n", encoding="utf-8")
+    calls: list[Path] = []
+
+    def fake_run_absorb_workflow(
+        vault_dir: Path,
+        *,
+        file_path: Path | None = None,
+        directory: Path | None = None,
+        recent: int | None = None,
+        dry_run: bool = False,
+        auto_promote: bool = False,
+        promote_threshold: int = 3,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> dict:
+        assert vault_dir == temp_vault
+        assert file_path is not None
+        assert directory is None
+        assert recent is None
+        assert dry_run is False
+        assert api_key is None
+        assert api_base is None
+        calls.append(file_path)
+        return {
+            "mode": "absorb",
+            "dry_run": False,
+            "summary": {
+                "files_processed": 1,
+                "concepts_extracted": 1,
+                "candidates_added": 0,
+                "concepts_promoted": 0,
+                "concepts_created": 0,
+                "concepts_skipped": 0,
+                "errors": 0,
+            },
+            "results": [],
+        }
+
+    monkeypatch.setattr(absorb, "run_absorb_workflow", fake_run_absorb_workflow)
+
+    result = absorb.main(["--vault-dir", str(temp_vault), "--file", str(deep_dive), "--dir", str(topic_dir)])
+
+    assert result == 0
+    assert calls == [deep_dive]
+
+
+def test_source_lifecycle_archive_failure_is_reported_without_dropping_deep_dive(temp_vault, monkeypatch):
+    from ovp_pipeline.commands import absorb
+    from ovp_pipeline.runtime import VaultLayout
+
+    layout = VaultLayout.from_vault(temp_vault)
+    layout.processing_dir.mkdir(parents=True, exist_ok=True)
+    source = layout.processing_dir / "Article.md"
+    source.write_text("# Article\n", encoding="utf-8")
+    deep_dive = temp_vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "Article_深度解读.md"
+
+    class FakeAutoArticleProcessor:
+        def __init__(self, vault_dir: Path, logger, txn):
+            self.layout = VaultLayout.from_vault(vault_dir)
+            self.logger = logger
+
+        def init_llm(self) -> None:
+            pass
+
+        def process_single_file(self, file_path: Path, *, dry_run: bool) -> dict:
+            assert file_path == source
+            assert dry_run is False
+            return {"status": "completed", "output_path": str(deep_dive)}
+
+        def _archive_source_to_processed(self, file_path: Path) -> Path:
+            assert file_path == source
+            raise OSError("archive denied")
+
+        def _restore_source_to_raw(self, file_path: Path) -> Path:
+            raise AssertionError("completed sources should not be restored")
+
+    monkeypatch.setattr(absorb, "AutoArticleProcessor", FakeAutoArticleProcessor)
+    failures: list[dict[str, str]] = []
+
+    targets = absorb.run_source_lifecycle_for_absorb_targets(
+        temp_vault,
+        [source],
+        dry_run=False,
+        failures=failures,
+    )
+
+    assert targets == [deep_dive]
+    assert failures == [
+        {
+            "source": str(source),
+            "stage": "archive_to_processed",
+            "error": "archive denied",
+        }
+    ]

--- a/tests/test_absorb_refine_commands.py
+++ b/tests/test_absorb_refine_commands.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import sys
 from pathlib import Path
 
 import pytest
@@ -243,3 +242,110 @@ date: 2026-04-07
     assert payload["dry_run"] is False
     assert payload["summary"]["files_processed"] == 1
     assert payload["summary"]["concepts_promoted"] == 1
+
+
+def test_absorb_file_under_clippings_runs_source_lifecycle_before_absorb(temp_vault, capsys, monkeypatch):
+    from ovp_pipeline.commands import absorb
+
+    clipping = temp_vault / "Clippings" / "Raw Clip.md"
+    clipping.parent.mkdir(parents=True, exist_ok=True)
+    clipping.write_text("# Raw Clip\n", encoding="utf-8")
+    deep_dive = temp_vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "Raw Clip_深度解读.md"
+
+    def fake_run_source_lifecycle_for_absorb_targets(vault_dir: Path, targets: list[Path], *, dry_run: bool) -> list[Path]:
+        assert vault_dir == temp_vault
+        assert targets == [clipping]
+        assert dry_run is False
+        return [deep_dive]
+
+    def fake_run_absorb_workflow(
+        vault_dir: Path,
+        *,
+        file_path: Path | None = None,
+        directory: Path | None = None,
+        recent: int | None = None,
+        dry_run: bool = False,
+        auto_promote: bool = False,
+        promote_threshold: int = 3,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> dict:
+        assert vault_dir == temp_vault
+        assert file_path == deep_dive
+        assert directory is None
+        assert recent is None
+        assert dry_run is False
+        return {
+            "mode": "absorb",
+            "dry_run": False,
+            "summary": {
+                "files_processed": 1,
+                "concepts_extracted": 1,
+                "candidates_added": 1,
+                "concepts_promoted": 0,
+                "concepts_created": 0,
+                "concepts_skipped": 0,
+                "errors": 0,
+            },
+            "results": [],
+        }
+
+    monkeypatch.setattr(
+        absorb,
+        "run_source_lifecycle_for_absorb_targets",
+        fake_run_source_lifecycle_for_absorb_targets,
+    )
+    monkeypatch.setattr(absorb, "run_absorb_workflow", fake_run_absorb_workflow)
+
+    result = absorb.main(["--vault-dir", str(temp_vault), "--file", str(clipping), "--json"])
+    captured = capsys.readouterr()
+
+    assert result == 0
+    payload = json.loads(captured.out)
+    assert payload["source_lifecycle"]["source_targets"] == [str(clipping)]
+    assert payload["source_lifecycle"]["absorb_targets"] == [str(deep_dive)]
+
+
+def test_move_clipping_to_raw_waits_for_real_destination(temp_vault):
+    from ovp_pipeline.commands.absorb import _move_clipping_to_raw
+    from ovp_pipeline.runtime import VaultLayout
+
+    layout = VaultLayout.from_vault(temp_vault)
+    layout.clippings_dir.mkdir(parents=True, exist_ok=True)
+    layout.raw_dir.mkdir(parents=True, exist_ok=True)
+    clipping = layout.clippings_dir / "Async Clip.md"
+    clipping.write_text("# Async Clip\n", encoding="utf-8")
+
+    class FakeProcessor:
+        def sanitize_filename(self, value: str) -> str:
+            return value.replace(" ", "_")
+
+        def obsidian_move(self, source: Path, dest_dir: Path, new_name: str | None = None) -> bool:
+            return True
+
+    moved = _move_clipping_to_raw(
+        layout,
+        FakeProcessor(),  # type: ignore[arg-type]
+        clipping,
+        settle_timeout_s=0.01,
+    )
+
+    assert moved.exists()
+    assert moved.parent == layout.raw_dir
+    assert not clipping.exists()
+
+
+def test_absorb_dry_run_under_clippings_reports_source_lifecycle_plan(temp_vault, capsys):
+    from ovp_pipeline.commands import absorb
+
+    clipping = temp_vault / "Clippings" / "Raw Clip.md"
+    clipping.parent.mkdir(parents=True, exist_ok=True)
+    clipping.write_text("# Raw Clip\n", encoding="utf-8")
+
+    result = absorb.main(["--vault-dir", str(temp_vault), "--file", str(clipping), "--dry-run", "--json"])
+    captured = capsys.readouterr()
+
+    assert result == 0
+    payload = json.loads(captured.out)
+    assert payload["source_lifecycle"]["required"] is True
+    assert payload["source_lifecycle"]["source_targets"] == [str(clipping)]

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -7,6 +7,8 @@ import os
 from pathlib import Path
 import sys
 
+import pytest
+
 from ovp_pipeline.auto_github_processor import build_default_output_dir as github_output_dir
 from ovp_pipeline.auto_paper_processor import build_default_output_dir as paper_output_dir
 from ovp_pipeline.runtime import (
@@ -110,7 +112,7 @@ def test_check_environment_rejects_non_vault_directory(tmp_path, monkeypatch):
 
 
 def test_check_environment_rejects_package_checkout_with_vault_scaffold(tmp_path, monkeypatch):
-    package_checkout = tmp_path / "openclaw-template"
+    package_checkout = tmp_path / "obsidian-vault-pipeline"
     for rel in (
         "10-Knowledge",
         "20-Areas",
@@ -1767,6 +1769,45 @@ def test_collect_absorb_targets_recent_filters_by_file_mtime(tmp_path):
     targets = _collect_absorb_targets(layout, recent=7)
 
     assert targets == [recent_file]
+
+
+def test_collect_absorb_targets_rejects_intake_source_files(tmp_path):
+    from ovp_pipeline.auto_evergreen_extractor import _collect_absorb_targets
+
+    vault = tmp_path / "vault"
+    layout = VaultLayout.from_vault(vault)
+    clipping = layout.clippings_dir / "Raw Clip.md"
+    clipping.parent.mkdir(parents=True, exist_ok=True)
+    clipping.write_text("# raw\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="source lifecycle"):
+        _collect_absorb_targets(layout, file_path=clipping)
+
+
+def test_run_absorb_workflow_rejects_intake_source_directories(tmp_path, monkeypatch):
+    from ovp_pipeline import auto_evergreen_extractor as extractor_module
+    from ovp_pipeline.auto_evergreen_extractor import run_absorb_workflow
+
+    vault = tmp_path / "vault"
+    layout = VaultLayout.from_vault(vault)
+    clipping = layout.clippings_dir / "Raw Clip_深度解读.md"
+    clipping.parent.mkdir(parents=True, exist_ok=True)
+    clipping.write_text("# raw\n", encoding="utf-8")
+
+    class FakeExtractor:
+        def __init__(self, vault_dir, logger):
+            self.vault_dir = vault_dir
+
+        def init_llm(self, *args, **kwargs):
+            return None
+
+        def process_directory(self, *args, **kwargs):
+            raise AssertionError("intake directory must be rejected before process_directory")
+
+    monkeypatch.setattr(extractor_module, "AutoEvergreenExtractor", FakeExtractor)
+
+    with pytest.raises(ValueError, match="source lifecycle"):
+        run_absorb_workflow(vault, directory=layout.clippings_dir)
 
 
 def test_before_counts_include_monthly_processed_files(tmp_path):


### PR DESCRIPTION
## Summary
- route `ovp-absorb --file/--dir` intake sources through the standard source lifecycle before evergreen absorb
- reject direct absorb of Clippings/Inbox sources at the lower `run_absorb_workflow` target collection layer
- update OVP naming in the touched plan/docstring references

## Test Plan
- `PYTHONPATH=src pytest -q tests/test_absorb_refine_commands.py tests/test_runtime_paths.py::test_collect_absorb_targets_recent_filters_by_file_mtime tests/test_runtime_paths.py::test_collect_absorb_targets_rejects_intake_source_files tests/test_runtime_paths.py::test_run_absorb_workflow_rejects_intake_source_directories`
- `ruff check src/ovp_pipeline/commands/absorb.py src/ovp_pipeline/auto_evergreen_extractor.py src/ovp_pipeline/runtime.py tests/test_absorb_refine_commands.py tests/test_runtime_paths.py`
- `python3 -m compileall -q src/ovp_pipeline`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/72" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Absorb workflow now routes clippings through source lifecycle phase with automatic staging and archival.
  * Multi-target absorb aggregation with enhanced JSON output including lifecycle metadata.

* **Bug Fixes**
  * Path validation prevents processing of files under intake lifecycle directories.

* **Tests**
  * Extended coverage for clippings behavior and lifecycle orchestration.

* **Documentation**
  * Updated project association metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->