### PR TITLE
docs: consolidate active backlog roadmap

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,0 +1,102 @@
+# OVP Active Backlog
+
+**Updated:** 2026-04-29
+**Status:** Active implementation backlog source
+
+This file is the single current backlog entry point for implementation sequencing.
+
+It is not the only evidence source. It is the maintained merge view over:
+
+- repo milestone history and shipped phase docs
+- `docs/plans/2026-04-22-vision-and-roadmap-trusted-reuse-compiler.md`
+- recent KSR task extraction in `/Users/chris/Documents/ovp-vault/30-Projects/Active/OVP-Knowledge-State-Runtime.md`
+- `docs/plans/2026-04-29-reader-product-shape-and-backlog-reconciliation.md`
+
+Rule: historical plans and vault research notes feed this file; they do not override it silently. When a PR lands or a KSR task changes state, update this file first, then mirror or annotate secondary docs as needed.
+
+## Current Milestones
+
+| Milestone | Status | Meaning |
+| --- | --- | --- |
+| M0 Pipeline And Pack Foundation | Done | CLI, source lifecycle, pack/profile runtime, `knowledge.db`, first source-lifecycle idempotency slice |
+| M1 Operator Workbench And Review Runtime | Done / maintain | truth UI, candidates, signals/actions, contradictions, action worker |
+| M2 Roadmap And README Consolidation | Active | merge historical milestones, compiler roadmap, recent KSR input, and reader-product research |
+| M3 Reader-First Knowledge Atlas | Next | `/` becomes reader home; current dashboard moves to `/ops`; objects and graph become knowledge products |
+| M4 KSR Safety And Hot-Path Hardening | Next | projection labels, hot-path audit, wiring evals, routing preview, evidence spans, candidate risk |
+| M5 Context Pack And Operational Runtime | Later | session snapshots, context budget, claim leases, provider facade, observability |
+| M6 Policy, Permission, And Knowledge Evolution | Later | permission layer, claim lifecycle, conflict detection, policy promotion |
+| M7 Semantic Extraction And Query Feedback Loop | Later | relation extractor, query feedback, routines, notebook/raw-source mode |
+
+## Active Implementation Backlog
+
+| ID | Priority | Status | Work item | Source links |
+| --- | --- | --- | --- | --- |
+| BL-000 | P0 | Active | Commit current roadmap/README/backlog consolidation | M2 |
+| BL-001 | P0 | Next | Reader shell route split: make `/` a Knowledge Atlas home and move current dashboard to `/ops` | M3, reader-product note |
+| BL-002 | P0 | Next | Projection marking: label dashboard, MOC, wiki, briefing, reader pages, graph, and context packs as projections | M4, KSR-002 |
+| BL-003 | P0 | Next | Dashboard/search hot-path audit: default UI/search paths must not scan raw/PDF/Office sources | M4, KSR-015 |
+| BL-004 | P0 | Next | Workflow wiring eval suite for lifecycle routing, promote gates, projection labels, hot paths, and read/write boundaries | M4, KSR-026 |
+| BL-005 | P0 | Next | Article routing preview before source lifecycle changes | M4, KSR-014 |
+| BL-006 | P0 | Next | Evidence span schema and markdown-aware locator backfill | M4, KSR-001, KSR-018 |
+| BL-007 | P0 | Next | Candidate risk layering by evidence strength, identity ambiguity, sensitivity, and impact | M4, KSR-003 |
+| BL-008 | P1 | Next | Kind-aware object pages for people, concepts, companies/tools/projects, events, and claims | M3 |
+| BL-009 | P1 | Next | Mention/backlink rail with excerpts, source jumps, and relation context | M3, reader-product note |
+| BL-010 | P1 | Next | Visual `/graph` MVP as a spatial corpus map; keep analytical clusters under ops/debug | M3 |
+| BL-011 | P1 | Later | Reader-oriented search grouped by kind, summary, evidence, and reason | M3/M4 |
+| BL-012 | P1 | Later | Trusted reuse event instrumentation for downstream use of accepted/cited knowledge | April 22 roadmap |
+| BL-013 | P1 | Later | Session snapshot / OVP context pack / explicit context budget | M5, KSR-004, KSR-017, KSR-022 |
+| BL-014 | P1 | Later | Operational runtime graph, claim lease, observability metrics, provider facade | M5, KSR-020, KSR-021, KSR-023, KSR-025 |
+| BL-015 | P1 | Later | Permission layer and claim lifecycle fields | M6, KSR-005, KSR-006 |
+| BL-016 | P2 | Later | Conflict detection regularization, high-risk profile gate, candidate compaction with restore | M6, KSR-007, KSR-008, KSR-024 |
+| BL-017 | P2 | Later | Schema-on-demand guard for new claim/candidate profiles | M6, KSR-028 |
+| BL-018 | P2 | Later | Reviewed semantic relation extractor and query feedback loop | M7, April 22 roadmap |
+| BL-019 | P2 | Later | Skill/routine extraction profile, notebook/raw-source mode, ingest ROI, hybrid retrieval, multimodal caption-first ingest, follow-up object model | M7, KSR-010, KSR-011, KSR-012, KSR-016, KSR-019, KSR-029 |
+
+## KSR Task Coverage
+
+| KSR ID | Backlog mapping | Current status in this backlog |
+| --- | --- | --- |
+| KSR-001 Evidence span 化 | BL-006 | Next |
+| KSR-002 Projection 标注 | BL-002 | Next |
+| KSR-003 Candidate 风险分层 | BL-007 | Next |
+| KSR-004 Session snapshot/context pack | BL-013 | Later |
+| KSR-005 Permission layer 分离 | BL-015 | Later |
+| KSR-006 Claim lifecycle 字段 | BL-015 | Later |
+| KSR-007 Conflict detection 常规化 | BL-016 | Later |
+| KSR-008 High-risk user profile gate | BL-016 | Later |
+| KSR-009 Cost-aware workflow routing | BL-003/BL-005 | Next |
+| KSR-010 Skill/routine extraction profile | BL-019 | Later |
+| KSR-011 Notebook/raw-source mode | BL-019 | Later |
+| KSR-012 Ingest ROI metrics | BL-019 | Later |
+| KSR-013 Source lifecycle idempotency | M0/M4 | Repo first slice done; verify and mirror vault status |
+| KSR-014 Article routing preview | BL-005 | Next |
+| KSR-015 Dashboard/search hot-path audit | BL-003 | Next |
+| KSR-016 Hybrid retrieval experiment | BL-019 | Later |
+| KSR-017 Explicit context budget | BL-013 | Later |
+| KSR-018 Markdown-aware evidence chunking | BL-006 | Next |
+| KSR-019 Multimodal caption-first ingest | BL-019 | Later |
+| KSR-020 Operational runtime graph | BL-014 | Later |
+| KSR-021 Claim lease for workflow items | BL-014 | Later |
+| KSR-022 OVP prime/context pack | BL-013 | Later |
+| KSR-023 Pipeline observability metrics | BL-014 | Later |
+| KSR-024 Candidate compaction with restore | BL-016 | Later |
+| KSR-025 Context provider facade | BL-014 | Later |
+| KSR-026 Workflow wiring eval suite | BL-004 | Next |
+| KSR-027 Live-source routing policy | BL-005/BL-014 | Later |
+| KSR-028 Schema-on-demand guard | BL-017 | Later |
+| KSR-029 Follow-up object model | BL-019 | Later |
+
+## Next Decision
+
+After BL-000 is committed, choose the first implementation PR:
+
+1. **BL-001 Reader shell route split**: best product-shape move; makes the app understandable without changing data models.
+2. **BL-003 + BL-004 safety pass**: best engineering-risk move; locks hot paths and wiring before UI becomes the default product surface.
+
+Recommended order:
+
+1. BL-001
+2. BL-003 + BL-004
+3. BL-002
+4. BL-008 + BL-009
+5. BL-010

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 schema_version: "1.0.0"
 note_id: readme-dc2a69e8
 title: "Obsidian Vault Pipeline"
-description: "六层 Obsidian 知识流水线"
+description: "面向 Obsidian 的可审计知识状态运行时"
 date: 2026-04-07
 type: meta
 ---
@@ -15,8 +15,8 @@ type: meta
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![PyPI](https://img.shields.io/pypi/v/obsidian-vault-pipeline.svg)](https://pypi.org/project/obsidian-vault-pipeline/)
 
-面向 Obsidian Vault 的生产级知识流水线  
-Ingest → Interpret → Absorb → Refine → Canonical → Derived
+面向 Obsidian Vault 的可审计知识状态运行时<br>
+Capture → Compile → Reuse
 
 [🇬🇧 English](README_EN.md)
 
@@ -24,21 +24,22 @@ Ingest → Interpret → Absorb → Refine → Canonical → Derived
 
 ## 这是什么
 
-这不是一个“多脚本拼装包”，而是一套围绕 Obsidian Vault 构建的知识编排系统：
+Obsidian Vault Pipeline（OVP）不是一个“多脚本拼装包”，也不只是 RAG over Markdown。它是一套围绕 Obsidian Vault 构建的本地知识状态运行时：
 
-- 输入层负责接收 Pinboard、Clippings、Raw Markdown
-- 解释层负责生成深度解读
-- 吸收层负责把解读编入 Evergreen 生命周期
-- 整形层负责 cleanup / breakdown
-- 规范层负责 registry / alias / Atlas / MOC
-- 派生层负责 `knowledge.db`、graph、lint、daily delta
+- **Capture**：接收 Pinboard、Clippings、Raw Markdown、论文、GitHub、网页等资料，并保持 source lifecycle 可追踪。
+- **Compile**：把资料编译成 deep dive、candidate、claim、evidence、relation、contradiction、registry 和 graph。
+- **Reuse**：把已编译知识投影成 reader atlas、object page、graph、briefing、search、context pack、writing prompt 和 operator workbench。
 
-当前版本已经把这 6 层真正接入到了日常运行链路里：
+内部仍保留六层工程模型（Ingest → Interpret → Absorb → Refine → Canonical → Derived），但产品叙事收敛为 Capture → Compile → Reuse。
+
+当前版本已经把主要运行链路接入到日常工作流：
 
 - `ovp --full` 默认跑到 `knowledge_index`
+- `ovp --incremental` 是日常增量入口，包含近期 Pinboard + Clippings + 后续步骤
 - `ovp --full --with-refine` 会在 `moc` 后追加 `refine`
 - `ovp-autopilot` 默认实时跑 `absorb -> moc -> knowledge_index`
 - `ovp-autopilot --with-refine` 会在实时链路里追加 `refine`
+- `ovp-ui` 提供本地 UI，目前偏 operator workbench；下一阶段会把默认入口改成 reader-first Knowledge Atlas
 
 ## 为什么会变成现在这套架构
 
@@ -50,19 +51,55 @@ Ingest → Interpret → Absorb → Refine → Canonical → Derived
 
 现在这套设计的目标就是把这些问题拆开：
 
+- 用 Capture → Compile → Reuse 解释产品价值
+- 用 source → observation → claim → evidence → validity → projection → permission 解释长期知识状态
 - 用六层运行模型明确“什么是编排层、什么是真相层、什么是派生层”
-- 先把当前技术研究语义正式化为 `research-tech`
-- 再把 `default-knowledge` 收敛成默认兼容层，而不是继续承担所有领域语义
+- 用 `research-tech` 把当前技术研究语义正式化
+- 用 `default-knowledge` 保留默认兼容层
 - 用 Pack API 让不同领域通过 pack 接入，而不是继续往 core 里硬编码特例
 
 这意味着当前仓库已经不只是一个 Vault 自动化项目，而是一个：
 
-> 面向 Obsidian/Vault 工作流的可扩展知识编排平台
+> reader-first, evidence-backed knowledge atlas over an auditable knowledge state runtime
 
 其中：
 
 - `research-tech` 是第一套显式内置标准 pack
 - `default-knowledge` 当前仍保留为默认兼容 pack
+- `knowledge.db` 是 derived store，不是 source of truth
+- vault markdown + registry + evidence chain 才是长期可信边界
+
+## 当前路线图
+
+当前路线图正在合并 repo 历史 milestone、4 月 22 compiler roadmap、vault 内近期 KSR backlog，以及 reader-first 产品形态研究。这里的 KSR 页是近期任务抽取输入，不是完整 backlog 事实源：
+
+- 当前 active backlog：`BACKLOG.md`
+- 近期 KSR backlog 输入：`/Users/chris/Documents/ovp-vault/30-Projects/Active/OVP-Knowledge-State-Runtime.md`
+- 当前合并路线图：`docs/plans/2026-04-29-consolidated-product-roadmap.md`
+- reader 产品形态记录：`docs/plans/2026-04-29-reader-product-shape-and-backlog-reconciliation.md`
+
+当前 milestone 顺序：
+
+| Milestone | 状态 | 说明 |
+| --- | --- | --- |
+| M0 Pipeline And Pack Foundation | Complete | CLI、source lifecycle、pack/profile、`knowledge.db`、KSR-013 第一版 |
+| M1 Operator Workbench And Review Runtime | Complete enough | truth UI、candidates、signals/actions、contradictions、action worker |
+| M2 Roadmap And README Consolidation | Active now | 合并历史 milestone、compiler roadmap、近期 KSR 输入与 reader-product 研究，重整 README |
+| M3 Reader-First Knowledge Atlas | Next | `/` 变成 reader home，当前 dashboard 移到 `/ops`，对象页/图谱更像知识产品 |
+| M4 KSR Safety And Hot-Path Hardening | Next | evidence span、projection 标注、candidate 风险分层、routing preview、wiring eval |
+| M5 Context Pack And Operational Runtime | Later | session snapshot、context budget、claim lease、provider facade、observability |
+| M6 Policy, Permission, And Knowledge Evolution | Later | permission layer、claim lifecycle、conflict detection、policy promotion |
+| M7 Semantic Extraction And Query Feedback Loop | Later | relation extractor、query feedback、skill/routine extraction、notebook/raw-source mode |
+
+当前 P0 候选 backlog（合并草案）：
+
+- `KSR-002` Projection 标注
+- `KSR-015` Dashboard/search hot-path audit
+- `KSR-026` Workflow wiring eval suite
+- `KSR-014` Article routing preview
+- `KSR-001` Evidence span 化
+- `KSR-003` Candidate 风险分层
+- Reader-first Knowledge Atlas（产品 P0，作为 projection layer 实现，不另建状态系统）
 
 ## Domain Packs
 
@@ -154,7 +191,7 @@ profile 是某个 pack 下的一条可执行 DAG。
 - `ovp-truth`
   直接读取 `knowledge.db` 中的 object / contradiction / neighborhood truth rows
 - `ovp-ui`
-  启动一个本地只读 DB 浏览面，直接查看 object / topic / event / contradiction
+  启动一个本地 UI。当前默认页偏 operator dashboard；路线图会把 reader-facing atlas 设为首页，并把现有 dashboard 移到 `/ops`
 - `docs/research-tech/RESEARCH_TECH_SKILLPACK.md`
 - `docs/research-tech/RESEARCH_TECH_VERIFY.md`
 - `docs/recipes/research-tech/*.md`
@@ -526,6 +563,8 @@ HTTP_PROXY=http://127.0.0.1:7897
 - `registry` 与文件系统共同定义 canonical 状态
 - `knowledge.db` 只做 derived retrieval，不做第二真相源
 - 吸收是日常自动化的一部分；整形是强能力，但默认 opt-in
+- Wiki、MOC、Dashboard、Briefing、Context Pack 都是 projection，必须能追回 source/evidence
+- Reader-facing UI 应先让用户理解知识，再暴露 operator/debug 细节
 - 文档必须描述“现在真实能跑的东西”，不是未来路线图
 
 ## 相关资源
@@ -536,4 +575,4 @@ HTTP_PROXY=http://127.0.0.1:7897
 
 ---
 
-当前文档对应版本：`v0.8.6`
+当前文档对应版本：`v0.9.2`

--- a/README_EN.md
+++ b/README_EN.md
@@ -2,7 +2,7 @@
 schema_version: "1.0.0"
 note_id: readme_en-5d661efc
 title: "Obsidian Vault Pipeline"
-description: "A six-layer Obsidian knowledge pipeline"
+description: "An auditable knowledge state runtime for Obsidian"
 date: 2026-04-07
 type: meta
 ---
@@ -15,32 +15,33 @@ type: meta
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![PyPI](https://img.shields.io/pypi/v/obsidian-vault-pipeline.svg)](https://pypi.org/project/obsidian-vault-pipeline/)
 
-Production-grade knowledge orchestration for Obsidian Vaults  
-Ingest → Interpret → Absorb → Refine → Canonical → Derived
+Auditable knowledge state runtime for Obsidian Vaults<br>
+Capture → Compile → Reuse
 
 [🇨🇳 中文](README.md)
 
 </div>
 
-Current document version: `v0.8.4`
+Current document version: `v0.9.2`
 
 ## What This Is
 
-This project is not a loose collection of scripts. It is a layered knowledge system built around an Obsidian vault:
+Obsidian Vault Pipeline is not a loose collection of scripts, and it is not only RAG over Markdown. It is a local knowledge state runtime built around an Obsidian vault:
 
-- Ingest normalizes incoming raw material
-- Interpret turns raw material into deep-dive notes
-- Absorb compiles those notes into evergreen lifecycle actions
-- Refine performs cleanup and breakdown on existing notes
-- Canonical maintains registry, aliases, Atlas, and MOC
-- Derived builds `knowledge.db`, graph views, lint, and daily deltas
+- **Capture** receives Pinboard, Clippings, raw Markdown, papers, GitHub repos, and web pages while keeping source lifecycle traceable.
+- **Compile** turns material into deep dives, candidates, claims, evidence, relations, contradictions, registry rows, and graph rows.
+- **Reuse** projects compiled knowledge into reader atlas pages, object pages, graph views, briefings, search, context packs, writing prompts, and the operator workbench.
+
+Internally the engineering model still uses six layers: Ingest -> Interpret -> Absorb -> Refine -> Canonical -> Derived. The product narrative is Capture -> Compile -> Reuse.
 
 The current release wires those layers into the actual runtime:
 
 - `ovp --full` runs through `knowledge_index` by default
+- `ovp --incremental` is the daily incremental entry point, including recent Pinboard + Clippings and downstream stages
 - `ovp --full --with-refine` inserts `refine` before the final derived refresh
 - `ovp-autopilot` runs real-time `absorb -> moc -> knowledge_index`
 - `ovp-autopilot --with-refine` adds `refine` to that path
+- `ovp-ui` provides a local UI. It is currently operator-oriented; the next product wave moves the default entry toward a reader-first Knowledge Atlas.
 
 ## Why The Architecture Looks Like This
 
@@ -52,6 +53,8 @@ This repository started as a set of Obsidian automation scripts, but that model 
 
 The current architecture is the direct answer to those failures:
 
+- Capture -> Compile -> Reuse explains the product value
+- source -> observation -> claim -> evidence -> validity -> projection -> permission explains the long-term knowledge state
 - the six-layer runtime makes orchestration, canonical state, and derived state explicit
 - `research-tech` makes the current engineering research semantics explicit
 - `default-knowledge` is being reduced to a default compatibility layer instead of carrying every domain semantic
@@ -59,12 +62,36 @@ The current architecture is the direct answer to those failures:
 
 So the project is no longer just a Vault automation repo. It is now:
 
-> an extensible knowledge orchestration platform for Obsidian-style vault workflows
+> a reader-first, evidence-backed knowledge atlas over an auditable knowledge state runtime
 
 with:
 
 - `research-tech` as the first explicit built-in standard pack
 - `default-knowledge` retained as the default compatibility pack
+- `knowledge.db` as a derived store, never the source of truth
+- vault markdown + registry + evidence chains as the long-term trust boundary
+
+## Current Roadmap
+
+The current roadmap is consolidating repo milestone history, the April 22 compiler roadmap, the recent KSR backlog in the dogfooding vault, and reader-first product-shape research. The KSR page is a recent task-extraction input, not the complete backlog source of truth:
+
+- active backlog: `BACKLOG.md`
+- recent KSR backlog input: `/Users/chris/Documents/ovp-vault/30-Projects/Active/OVP-Knowledge-State-Runtime.md`
+- current merged roadmap: `docs/plans/2026-04-29-consolidated-product-roadmap.md`
+- reader product-shape note: `docs/plans/2026-04-29-reader-product-shape-and-backlog-reconciliation.md`
+
+Current milestone sequence:
+
+| Milestone | Status | Meaning |
+| --- | --- | --- |
+| M0 Pipeline And Pack Foundation | Complete | CLI, source lifecycle, pack/profile runtime, `knowledge.db`, first KSR-013 slice |
+| M1 Operator Workbench And Review Runtime | Complete enough | truth UI, candidates, signals/actions, contradictions, action worker |
+| M2 Roadmap And README Consolidation | Active now | merge historical milestones, compiler roadmap, recent KSR input, and reader-product research |
+| M3 Reader-First Knowledge Atlas | Next | `/` becomes reader home, current dashboard moves to `/ops`, objects/graph become knowledge products |
+| M4 KSR Safety And Hot-Path Hardening | Next | evidence spans, projection labels, candidate risk tiers, routing preview, wiring evals |
+| M5 Context Pack And Operational Runtime | Later | session snapshots, context budget, claim leases, provider facades, observability |
+| M6 Policy, Permission, And Knowledge Evolution | Later | permission layer, claim lifecycle, conflict detection, policy promotion |
+| M7 Semantic Extraction And Query Feedback Loop | Later | relation extractor, query feedback, skill/routine extraction, notebook/raw-source mode |
 
 ## Domain Packs
 
@@ -155,7 +182,7 @@ The built-in profiles currently shipped are:
 - `ovp-truth`
   reads object / contradiction / neighborhood truth rows directly from `knowledge.db`
 - `ovp-ui`
-  launches a local read-only DB browser for object / topic / event / contradiction views
+  launches a local UI. The current default page is operator-oriented; the roadmap moves the reader-facing atlas to the homepage and keeps the current dashboard under `/ops`.
 - `docs/research-tech/RESEARCH_TECH_SKILLPACK.md`
 - `docs/research-tech/RESEARCH_TECH_VERIFY.md`
 - `docs/recipes/research-tech/*.md`
@@ -488,6 +515,8 @@ HTTP_PROXY=http://127.0.0.1:7897
 - vault files + registry define canonical state
 - `knowledge.db` is derived retrieval, never a second truth source
 - absorb is part of daily automation; refine is powerful and opt-in by default
+- Wiki, MOC, dashboard, briefing, and context packs are projections that must trace back to source/evidence
+- reader-facing UI should explain knowledge first, then expose operator/debug detail
 - docs must describe what actually ships, not a future architecture sketch
 
 ## Related Resources
@@ -498,4 +527,4 @@ HTTP_PROXY=http://127.0.0.1:7897
 
 ---
 
-This document targets: `v0.8.4`
+This document targets: `v0.9.2`

--- a/docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
+++ b/docs/plans/2026-04-14-local-knowledge-workbench-milestone.md
@@ -1,5 +1,9 @@
 # Local Knowledge Workbench Milestone Plan
 
+> **Roadmap status, 2026-04-29:** This file is now a historical milestone record for the workbench buildout. The current consolidated roadmap draft is `docs/plans/2026-04-29-consolidated-product-roadmap.md`. Recent KSR backlog rows live in `/Users/chris/Documents/ovp-vault/30-Projects/Active/OVP-Knowledge-State-Runtime.md`, but that page is a new input, not a replacement for this historical record.
+>
+> Use the current roadmap for new implementation sequencing. Use this document only to understand how earlier workbench milestones mapped to shipped phases.
+
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
 **Goal:** Define the remaining product and engineering milestones from the current OVP state to a real local knowledge workbench.

--- a/docs/plans/2026-04-29-consolidated-product-roadmap.md
+++ b/docs/plans/2026-04-29-consolidated-product-roadmap.md
@@ -1,0 +1,315 @@
+# Consolidated Product Roadmap
+
+**Date:** 2026-04-29
+**Status:** Draft synthesis / reconciliation target
+
+**Active backlog:** `BACKLOG.md`
+
+## Roadmap Inputs
+
+This roadmap is a synthesis over several planning layers. No single input below should be treated as complete on its own.
+
+1. **Historical workbench milestone record**
+   - `docs/plans/2026-04-14-local-knowledge-workbench-milestone.md`
+   - Covers the shipped workbench phases, graph/truth/operator surfaces, and older milestone numbering.
+
+2. **April 22 compiler roadmap**
+   - `docs/plans/2026-04-22-vision-and-roadmap-trusted-reuse-compiler.md`
+   - Covers Capture -> Compile -> Reuse, trusted reuse, evidence v2, policy promotion, semantic extraction, and query feedback.
+
+3. **Recent KSR backlog input**
+   - `/Users/chris/Documents/ovp-vault/30-Projects/Active/OVP-Knowledge-State-Runtime.md`
+   - Created from recent article/project research on 2026-04-29.
+   - Covers detailed Knowledge State Runtime tasks such as evidence spans, projection labels, candidate risk, routing preview, context packs, permission, and workflow wiring evals.
+   - This is a high-signal current input, but it is not an exhaustive source for all prior roadmap history.
+
+4. **Reader product-shape input**
+   - `docs/plans/2026-04-29-reader-product-shape-and-backlog-reconciliation.md`
+   - Covers the LearnBuffett-inspired reader-first product form: readable object pages, backlink rails, and visual graph.
+
+This document is the roadmap rationale and merge view. `BACKLOG.md` is the active to-do list for implementation sequencing. Both should be revised as older roadmap gaps are re-read and reconciled, rather than assuming the latest KSR page supersedes all previous history.
+
+## Backlog Reconciliation Rule
+
+Do not treat the vault KSR page as the backlog source of truth.
+
+It is a recent, useful task extraction from 2026-04-29 research. It is strongest for naming Knowledge State Runtime gaps, but it does not contain all previously shipped work, older product bets, or the April 22 compiler roadmap. Roadmap decisions should therefore merge four inputs:
+
+- shipped/history record from repo milestone docs
+- future architecture from the April 22 trusted-reuse/compiler roadmap
+- recent KSR task extraction from the dogfooding vault
+- reader-first product-shape research from LearnBuffett comparison
+
+When these disagree, prefer the merged roadmap here for implementation sequencing, and preserve the original source notes as evidence rather than rewriting history.
+
+## Product Thesis
+
+OVP is moving from a document-processing pipeline into:
+
+> **A reader-first, evidence-backed knowledge atlas over an auditable knowledge state runtime.**
+
+This combines two threads that were previously split:
+
+- **Knowledge State Runtime (KSR):** source -> observation -> claim -> evidence -> validity -> projection -> permission.
+- **Reader Product Shape:** people, concepts, companies, topics, graph maps, backlinks, and evidence rails that make compiled knowledge understandable before exposing operator internals.
+
+The internal architecture remains Capture -> Compile -> Reuse:
+
+- **Capture:** source lifecycle, raw materials, clippings, papers, GitHub repos, web pages.
+- **Compile:** deep dives, candidates, claims, evidence, relations, contradictions, graph rows.
+- **Reuse:** reader atlas, object pages, graph, briefing, search, context packs, writing prompts, operational routines.
+
+## Current State
+
+Completed or substantially implemented:
+
+- pack-aware pipeline and `research-tech` reference pack
+- source lifecycle and absorb path hardening
+- `knowledge.db` as rebuildable derived truth/query store
+- truth API, object browsing, signals, actions, candidates, contradictions
+- action queue and focused worker surface
+- semantic relation contract boundary
+- local `ovp-ui` operator shell
+
+Still messy:
+
+- README and milestone docs still emphasize historical six-layer/operator terms.
+- recent KSR task extraction lives in the vault, while repo docs have older phase roadmaps.
+- The UI starts as an operator dashboard instead of a reader-facing knowledge product.
+- Existing object and graph pages expose internal data structures before explaining knowledge.
+
+## Roadmap Milestones
+
+### M0. Pipeline And Pack Foundation
+
+**Status:** Complete
+
+What it means:
+
+- installable CLI
+- vault layout resolution
+- source lifecycle
+- pack/profile runtime
+- `research-tech` and `default-knowledge`
+- `knowledge.db` rebuild path
+
+Representative completed work:
+
+- `ovp --full`, `ovp --incremental`, `ovp-absorb`
+- pack API and doctor/export/truth commands
+- source lifecycle idempotency first slice, corresponding to `KSR-013`
+
+### M1. Operator Workbench And Review Runtime
+
+**Status:** Complete enough / maintain
+
+What it means:
+
+- truth/object browsing
+- review queues and candidate lifecycle
+- signals/actions/briefing
+- contradictions/stale summaries
+- action queue and action worker
+- run ledger and runtime observability baseline
+
+This is valuable, but it should become an `/ops` surface rather than the product homepage.
+
+### M2. Roadmap And README Consolidation
+
+**Status:** Active now
+
+Goal:
+
+- merge repo roadmap, older phase history, recent vault KSR backlog, and reader-product research into one understandable route
+- make README describe the current product direction
+- mark old milestone docs as historical foundations
+- define the next implementation wave without creating another competing backlog
+
+Deliverables:
+
+- consolidated roadmap doc
+- README refresh
+- master milestone doc pointer to this roadmap
+- KSR/Reader/history mapping in `task_plan.md`
+
+### M3. Reader-First Knowledge Atlas
+
+**Status:** Next product wave
+
+Related KSR tasks:
+
+- `KSR-002 Projection 标注`
+- `KSR-015 Dashboard/search hot-path audit`
+- `KSR-026 Workflow wiring eval suite`
+- Reader-product note: `docs/plans/2026-04-29-reader-product-shape-and-backlog-reconciliation.md`
+
+Goal:
+
+- `/` becomes a reader-facing Knowledge Atlas.
+- Current runtime dashboard moves to `/ops`.
+- Objects become readable pages, not database rows.
+- `/graph` becomes a spatial corpus map, not only a cluster/debug report.
+
+First PR slice:
+
+- add `/ops` preserving current dashboard
+- make `/` render a reader home from existing payloads
+- group navigation into Read / Understand / Maintain
+- add tests for root and `/ops`
+- do not add new data models yet
+
+Second PR slice:
+
+- kind-aware object pages for person, concept, company/tool/project, event, claim
+- backlink/mention rail with excerpts and source jumps
+- raw audit/provenance kept secondary and expandable
+
+Third PR slice:
+
+- visual `/graph` MVP using current graph/truth data
+- type legend, bounded node count, search/filter, click side panel
+- keep analytical clusters available as an ops/debug route
+
+### M4. KSR Safety And Hot-Path Hardening
+
+**Status:** Near-term engineering wave
+
+Related KSR tasks:
+
+- `KSR-001 Evidence span 化`
+- `KSR-003 Candidate 风险分层`
+- `KSR-014 Article routing preview`
+- `KSR-015 Dashboard/search hot-path audit`
+- `KSR-018 Markdown-aware evidence chunking`
+- `KSR-026 Workflow wiring eval suite`
+
+Goal:
+
+- every important claim/candidate can point to source path, content hash, heading/paragraph anchor, quote hash, line span, and relation/evidence type
+- dashboard/search never trigger heavy raw/PDF/Office scans on default paths
+- candidate review is grouped by risk and evidence strength
+- routing decisions are previewed/explained before changing lifecycle behavior
+- no-LLM wiring evals lock critical invariants
+
+First likely implementation order:
+
+1. hot-path audit for dashboard/search
+2. wiring eval suite for source lifecycle, projection marking, promote gate, hot path, read/write boundaries
+3. article routing preview payload
+4. evidence span schema and markdown-aware locator backfill
+5. candidate risk grouping
+
+### M5. Context Pack And Operational Runtime
+
+**Status:** Next after M4, some pieces can be pulled forward if needed
+
+Related KSR tasks:
+
+- `KSR-004 Session snapshot/context pack`
+- `KSR-017 Explicit context budget`
+- `KSR-020 Operational runtime graph`
+- `KSR-021 Claim lease for workflow items`
+- `KSR-022 OVP prime/context pack`
+- `KSR-023 Pipeline observability metrics`
+- `KSR-025 Context provider facade`
+- `KSR-027 Live-source routing policy`
+
+Goal:
+
+- agent sessions can load a small, explicit, versioned OVP context pack
+- source/candidate/pipeline tasks expose ready/blocked/claimed/closed/superseded states
+- workflow items can be claimed/leased to avoid duplicate concurrent processing
+- context providers expose stable `query_*` / `update_*` facades instead of raw tool sprawl
+- pipeline/LLM/dashboard operations produce useful duration, retry, cost, and queue metrics
+
+### M6. Policy, Permission, And Knowledge Evolution
+
+**Status:** Later, after M3/M4 clarify the user-facing product and safety invariants
+
+Related KSR tasks:
+
+- `KSR-005 Permission layer 分离`
+- `KSR-006 Claim lifecycle 字段`
+- `KSR-007 Conflict detection 常规化`
+- `KSR-008 High-risk user profile gate`
+- `KSR-024 Candidate compaction with restore`
+- `KSR-028 Schema-on-demand guard`
+- older roadmap: Phase 32 Trusted Reuse, Phase 33 Evidence v2, Phase 34 Policy Promotion
+
+Goal:
+
+- distinguish ordinary memory writes from fact-authority writes
+- support claim validity windows, supersession, contradiction state, and confidence decay
+- keep high-risk user/profile claims out of automatic canonical paths
+- compact low-quality stale candidates without losing restore ability
+- require schema/review registration for new claim types and candidate profiles
+
+### M7. Semantic Extraction And Query Feedback Loop
+
+**Status:** Later
+
+Related tasks:
+
+- older roadmap: Phase 35 Reviewed Semantic Extractor
+- older roadmap: Phase 36 Query Feedback Loop
+- `KSR-010 Skill/routine extraction profile`
+- `KSR-011 Notebook/raw-source mode`
+- `KSR-012 Ingest ROI metrics`
+- `KSR-016 Hybrid retrieval experiment`
+- `KSR-019 Multimodal caption-first ingest`
+- `KSR-029 Follow-up object model`
+
+Goal:
+
+- relation extraction produces candidates only, with evidence
+- query can emit reuse events, open questions, writing prompts, candidate concepts, and proposed relations
+- action-oriented sources can produce checklists, routines, playbooks, and review prompts
+- low-risk transient sources can stay in notebook/raw-source mode instead of always becoming high-cost wiki/evergreen projections
+
+## Current P0 Backlog
+
+The current P0 set is:
+
+| ID | Task | Roadmap milestone | Notes |
+| --- | --- | --- | --- |
+| KSR-013 | Source lifecycle idempotency | M0/M4 | First implementation merged in PR #72; vault backlog should be marked complete/reviewed |
+| KSR-002 | Projection marking | M3/M4 | Must apply to dashboard, MOC, wiki, briefing, reader atlas |
+| KSR-015 | Dashboard/search hot-path audit | M3/M4 | Needed before making UI the default product surface |
+| KSR-026 | Workflow wiring eval suite | M4 | Prevents regressions in lifecycle, promote gate, projection marking, hot paths, write boundaries |
+| KSR-014 | Article routing preview | M4 | Preview/evaluate only at first; do not route sources invisibly |
+| KSR-001 | Evidence span | M4 | Foundation for reader trust and future policy promotion |
+| KSR-003 | Candidate risk layering | M4 | Needed to keep review workload small |
+
+Reader-first Knowledge Atlas is product P0, but it should be implemented as a projection layer over the same runtime facts, not as a separate state system.
+
+## Documentation Rules Going Forward
+
+- `OVP-Knowledge-State-Runtime.md` in the vault records the current KSR task extraction, but it is a recent backlog input, not a complete history or source of truth.
+- This repo roadmap owns milestone grouping and implementation sequence after reconciling old milestone docs, April 22 roadmap, KSR, and reader-product research.
+- README should explain product direction and runnable commands, not duplicate every KSR row.
+- Old phase docs remain historical records unless explicitly referenced by the current roadmap.
+- Any new research note should link to the vault KSR project if it adds KSR tasks.
+- Any new implementation plan should cite the KSR IDs it advances.
+
+## Immediate Next Step
+
+After this docs consolidation, the next implementation PR should be either:
+
+1. **Reader-first Knowledge Atlas shell**
+   - `/ops` for current dashboard
+   - `/` for reader home
+   - no new data model
+
+or:
+
+2. **KSR hot-path/wiring safety**
+   - dashboard/search hot-path audit
+   - wiring eval suite
+   - projection marking tests
+
+The better sequence is likely:
+
+1. reader shell route split (`/` vs `/ops`)
+2. hot-path/wiring evals
+3. kind-aware object pages and backlink rail
+4. visual graph MVP

--- a/docs/plans/2026-04-29-reader-product-shape-and-backlog-reconciliation.md
+++ b/docs/plans/2026-04-29-reader-product-shape-and-backlog-reconciliation.md
@@ -1,0 +1,310 @@
+# Reader Product Shape And Backlog Reconciliation
+
+**Date:** 2026-04-29
+**Status:** Working backlog note
+**Reference inputs:**
+
+- `/Users/chris/Documents/ovp-vault/30-Projects/Active/OVP-Knowledge-State-Runtime.md`
+- `/Users/chris/Documents/ovp-vault/20-Areas/AI-Research/Topics/2026-04/2026-04-29_AI个人知识库难用问题_研究札记.md`
+- `docs/plans/2026-04-10-ovp-knowledge-system-execution-plan.md`
+- `docs/plans/2026-04-16-phase17-research-graph-visualization-plan.md`
+- `docs/plans/2026-04-17-phase19-orientation-and-compiled-knowledge-products.md`
+- `docs/plans/2026-04-22-vision-and-roadmap-trusted-reuse-compiler.md`
+- `docs/plans/2026-04-29-consolidated-product-roadmap.md`
+- LearnBuffett person page: <https://learnbuffett.com/people/%E6%A0%BC%E9%9B%B7%E5%8E%84%E5%A7%86>
+- LearnBuffett graph page: <https://learnbuffett.com/graph>
+
+## Product Shape Finding
+
+LearnBuffett is useful as a product-shape reference because it makes the knowledge base feel readable before it feels operational.
+
+The important pattern is not the visual skin. The important pattern is the default posture:
+
+- a user lands in a knowledge product, not an operator console
+- people, concepts, companies, letters, and graph nodes are readable entry points
+- evidence and backlinks are present, but they sit behind the reading flow
+- graph exploration is spatial and legible, not a cluster/debug report
+- operations remain available, but they are not the first screen
+
+OVP currently has more powerful internal structure than this reference:
+
+- typed objects
+- evidence rows
+- claims and relations
+- contradictions
+- action queue
+- runtime ledger
+- pack-owned semantics
+- review and provenance surfaces
+
+But the default UI still presents itself as an engineering shell. The current home page starts with runtime state, worker state, run history, and workflow maps. The object list is database-like. The cluster page exposes internal modeling terms such as relation components, model notes, and route mechanics before showing a user what the knowledge means.
+
+The backlog should therefore add a reader-facing product layer without weakening the auditable compiler architecture.
+
+The recent KSR project page is the most detailed current task table for knowledge-state-runtime work, but it is not a complete historical source. This note only adds the reader/product projection interpretation and must be reconciled with both KSR and the older repo milestone history.
+
+## Reconciled Thesis
+
+The April 22 vision says:
+
+> OVP is an auditable knowledge compiler for Obsidian: it turns external material into evidence-backed, review-gated, reusable long-term knowledge without polluting the human vault.
+
+This remains the right architecture narrative.
+
+The LearnBuffett reference adds the missing product requirement:
+
+> The compiled knowledge must first be understandable as a reader-facing knowledge base, and only secondarily visible as an operator workbench.
+
+So the external product should be:
+
+> **A reader-first, evidence-backed knowledge atlas over an auditable compiler.**
+
+This does not replace Capture -> Compile -> Reuse. It clarifies the Reuse surface:
+
+- Capture creates traceable sources and deep dives.
+- Compile creates objects, claims, relations, contradictions, summaries, and graph structure.
+- Reuse should primarily feel like reading and exploring a knowledge atlas, not monitoring a pipeline.
+
+## Reader Surface Principles
+
+### 1. Knowledge Objects Are Pages
+
+Every important object should be renderable as a readable page.
+
+Minimum sections:
+
+- title and kind
+- short readable definition or introduction
+- why this matters
+- key claims or takeaways
+- important relations
+- source-backed evidence
+- mentions / backlinks
+- unresolved tensions or open questions
+- next reads
+
+Different object kinds need different page contracts:
+
+| Kind | Reader-first page shape |
+| --- | --- |
+| Person | Who they are, why they matter, key ideas, relationships, quoted/evidenced mentions |
+| Concept | Definition, role in the knowledge system, adjacent concepts, canonical claims, tensions |
+| Company / tool / project | What it is, why it matters, capabilities, risks, related people/concepts |
+| Event | What happened, timeline, involved objects, evidence, downstream implications |
+| Claim | Statement, supporting evidence, opposing evidence, status, related claims |
+
+### 2. Evidence Is A Reading Aid Before It Is An Audit Table
+
+Evidence remains first-class, but the UI should not lead with database structure.
+
+Reader flow:
+
+1. readable synthesis
+2. selected quotes and source snippets
+3. expandable evidence trail
+4. raw audit fields only when needed
+
+### 3. Graph Is A Map, Not A Report
+
+The graph page should make users feel the shape of the corpus.
+
+Default graph behavior:
+
+- full-screen or near-full-screen visual canvas
+- type-colored nodes
+- node size based on degree / evidence / reuse
+- minimal count header
+- search and type filters
+- legend
+- click node -> side panel with reader summary and jump links
+- ops/debug graph cluster details remain available elsewhere
+
+This is compatible with Phase 17's cluster-first / bounded graph strategy. The difference is the default product route:
+
+- `/graph` should be a visual map
+- `/clusters` can remain an analytical/debug route, likely under `/ops/clusters`
+
+### 4. Operator Surfaces Move Behind `/ops`
+
+The current OVP shell is valuable, but it should be framed as maintenance.
+
+Move or reframe these as operator surfaces:
+
+- runtime
+- action worker
+- run history
+- signals
+- actions
+- candidates
+- contradictions
+- stale summaries
+- review queues
+- debug clusters
+
+They should be easy to reach, but not the default product identity.
+
+### 5. Backlinks Become Reading Context
+
+LearnBuffett's strongest small pattern is the "linked to this page" rail. OVP should treat backlinks as a first-class reading context:
+
+- where this object is mentioned
+- source excerpt around the mention
+- source type and date
+- why this mention is meaningful
+- "view source" and "open related object" links
+
+This maps directly to existing evidence, page links, and capture summaries.
+
+## Backlog Reconciliation
+
+The older Knowledge System Execution Plan was right to avoid early UI overbuilding. At that time extraction visibility and truth modeling were the risky foundations.
+
+That constraint has changed.
+
+OVP now has enough truth/API/UI substrate that the next highest-leverage backlog slice can be presentation/product shape, not another backend-heavy subsystem.
+
+The recent vault KSR backlog makes the same direction more concrete. The reader-first work should be treated as a projection/product slice that advances KSR and the older product-shell/graph milestones, especially:
+
+| KSR ID | How reader-first product work uses it |
+| --- | --- |
+| KSR-002 Projection 标注 | Reader pages, dashboard, graph, MOC, briefing must show they are derived projections, not source of truth |
+| KSR-015 Dashboard/search hot-path audit | The default home page and reader search must not trigger heavy raw/PDF/Office scans |
+| KSR-026 Workflow wiring eval suite | Tests should lock projection labels, source lifecycle routing, dashboard hot paths, and read/write boundaries |
+| KSR-001 Evidence span 化 | Object pages and backlink rails need precise source/evidence spans |
+| KSR-003 Candidate 风险分层 | Reader pages should show unresolved/risky knowledge without implying it is canonical |
+| KSR-014 Article routing preview | Reader-product ingestion should explain where a source will go before changing lifecycle behavior |
+
+### Keep From Existing Roadmap
+
+Keep these as architectural guardrails:
+
+- markdown/canonical-vs-derived boundary
+- `knowledge.db` as rebuildable derived store
+- evidence-first promotion
+- policy-gated review
+- pack-owned semantics
+- no new graph backend
+- no silent agent mutation of accepted-state files
+- no UI that hides provenance or review state
+
+Keep these as product commitments:
+
+- orientation brief
+- compiled object/topic/event/contradiction sections
+- graph exploration
+- trusted reuse reporting
+- writing prompts and open questions as reuse outputs
+
+### Change The Order
+
+Before pushing deeper into semantic extraction and query feedback, add a reader-facing entry layer that makes existing compiled knowledge understandable.
+
+Recommended ordering:
+
+1. **Reader Home / Knowledge Atlas**
+   - `/` becomes a knowledge atlas entry product.
+   - Existing operational dashboard moves to `/ops`.
+   - Home answers: what is in this corpus, what is important, what changed, what should I read next.
+
+2. **Object Pages v2**
+   - Replace database-like object pages with kind-aware reader templates.
+   - Use existing object detail, evidence, relations, backlinks, capture summaries, and compiled sections.
+   - Person/concept/company pages should be the first three templates.
+
+3. **Visual Graph MVP**
+   - Add `/graph` as a reader-facing visual map.
+   - Use current graph data; do not introduce a new backend.
+   - Start bounded if necessary: top objects, selected pack, or cluster summary graph.
+   - Keep debug cluster reports under `/ops/clusters`.
+
+4. **Backlink / Mention Rail**
+   - Add a right rail or section to object pages showing mentions with excerpts.
+   - This should feel like LearnBuffett's source-linked reading context, not raw link rows.
+
+5. **Reader-Oriented Search**
+   - Search results group by object kind and reading intent.
+   - Each result shows summary, kind, evidence count, and why it matched.
+
+6. **Operator Shell Reframing**
+   - Keep all current maintenance surfaces.
+   - Rename or route them as ops/admin surfaces.
+   - Avoid making runtime state the product's first impression.
+
+## Near-Term Implementation Slice
+
+Suggested first PR:
+
+**Title:** `Add reader-first knowledge atlas entry surface`
+
+Scope:
+
+- add `/ops` route preserving the current dashboard
+- make `/` render a new reader home from existing payloads
+- add product navigation groups:
+  - `Read`: Objects, Graph, Search, Deep Dives
+  - `Understand`: Briefing, Atlas, Clusters
+  - `Maintain`: Ops, Actions, Signals, Candidates, Contradictions
+- update tests for root and `/ops`
+- no new data model
+- no graph visualization yet
+
+Suggested second PR:
+
+**Title:** `Render kind-aware object pages`
+
+Scope:
+
+- update object page view model with page kind contract
+- add Person / Concept / Company / generic templates
+- render evidence and backlinks as reading context
+- keep raw audit/provenance collapsible
+
+Suggested third PR:
+
+**Title:** `Add visual graph map MVP`
+
+Scope:
+
+- new `/graph` route
+- browser-rendered graph using current truth graph payload
+- type legend, search/filter, zoom/recenter, click side panel
+- bounded node count and graceful empty state
+- keep `/clusters` for analytical route
+
+## Backlog Status
+
+| Item | Priority | Status | Notes |
+| --- | --- | --- | --- |
+| Reader home / Knowledge Atlas | P0 | proposed next | Highest leverage product-shape correction |
+| Move current dashboard to `/ops` | P0 | proposed next | Preserves operator value while changing first impression |
+| Kind-aware object pages | P0 | next | Turns extraction objects into user-readable pages |
+| Mention/backlink rail | P1 | next | Direct LearnBuffett lesson; evidence-backed reading context |
+| Visual `/graph` map | P1 | next | Use current graph data; no new backend |
+| Reader-oriented search | P1 | later | Depends on object summaries and evidence counts |
+| Trusted reuse loop | P1 | keep | Still core north-star measurement |
+| Evidence v2 | P1 | keep | Still needed for long-term trust |
+| Policy promotion | P2 | keep | Important, but after product entry is understandable |
+| Reviewed semantic extractor | P2 | later | Do not add more graph complexity before graph is readable |
+| Query feedback loop | P2 | later | Strong compounding loop, but depends on clearer reader surfaces |
+
+## Non-Goals
+
+- Do not clone LearnBuffett's brand or exact visual design.
+- Do not remove operator surfaces.
+- Do not make a hosted product.
+- Do not introduce a graph database.
+- Do not weaken evidence, review, or provenance requirements.
+- Do not hide raw audit data; make it secondary instead of primary.
+
+## Decision
+
+The backlog should now treat "reader-first knowledge atlas" as the next product layer.
+
+OVP should continue to be an auditable compiler internally, but the user-facing result should look more like a readable, navigable knowledge base:
+
+- object pages that explain
+- graph pages that orient
+- backlinks that contextualize
+- ops pages that maintain
+
+This is the product bridge between the older knowledge-system roadmap and the current over-engineered dashboard feel.

--- a/findings.md
+++ b/findings.md
@@ -112,7 +112,7 @@
   - a warning against assuming that better embeddings alone will solve memory-system failure modes
 - The most relevant lesson from No Escape for OVP is to avoid overcommitting to pure semantic retrieval and instead lean harder on explicit structure, provenance, canonical objects, review loops, and resolver-guided narrowing.
 - Round 15 added `campfirein/byterover-cli`. The key conclusion is that ByteRover CLI is best understood not as a simple memory backend, but as a file-canonical, review-governed, dream-maintained, versioned context-curation platform.
-- ByteRover CLI’s strongest ideas are:
+- ByteRover CLI's strongest ideas are:
   - a writable `.brv/context-tree/` as the main working surface, with snapshot/sync logic treating files as canonical state
   - a clean split between deterministic search, synthesized query, and curation/write-back
   - a real review queue for pending high-impact curation operations
@@ -149,6 +149,14 @@
   - a benchmark worldview that treats memory quality and agent evolution as first-class evaluation targets
   - an integration pattern that connects memory at the context-engine layer rather than treating it as a loose memory tool
 - The most relevant lesson from EverOS for OVP is to strengthen construction schemas, typed artifact thinking, and benchmark rigor, while avoiding a drift into heavy service/database-native architecture at the expense of file-native inspectability and user-owned artifacts.
+- Round 20 added LearnBuffett as a product-shape reference rather than an architecture reference.
+- LearnBuffett's strongest lesson is reader-first presentation:
+  - person / concept / company pages are readable knowledge objects first, with backlinks and evidence as supporting context
+  - the graph is a spatial map with type-colored nodes, counts, legend, zoom controls, and a corpus-shape first impression
+  - operational or source mechanics are secondary to comprehension
+- The most relevant lesson for OVP is that the current truth/runtime shell should not be the default product face. OVP can keep its auditable compiler architecture while adding a reader-first knowledge atlas over it.
+- Recorded the reconciliation in `docs/plans/2026-04-29-reader-product-shape-and-backlog-reconciliation.md`: the next product layer should prioritize reader home, kind-aware object pages, backlink/mention rail, and visual `/graph`, while moving operator surfaces behind `/ops`.
+- Follow-up roadmap correction: the KSR project page in the dogfooding vault is a recent task-extraction input, not a complete backlog source of truth. Implementation sequencing should merge it with repo milestone history, the April 22 compiler roadmap, and the LearnBuffett product-shape note.
 - Current actionable synthesis across all rounds:
   - OVP should not become a generic memory backend or a hosted coding-agent runtime
   - OVP should lean into user-owned, file-native, reviewable canonical knowledge artifacts

--- a/progress.md
+++ b/progress.md
@@ -1,5 +1,34 @@
 # Progress Log
 
+## Session: 2026-04-29
+
+### Reader-First Product Shape And Backlog Reconciliation
+- **Status:** documented
+- Corrected the backlog-source assumption:
+  - the vault KSR project page is a recent task extraction from 2026-04-29 research, not the complete backlog source of truth
+  - roadmap sequencing must merge repo milestone history, the April 22 compiler roadmap, recent KSR tasks, and reader-first product-shape research
+- Reviewed LearnBuffett as a product-shape reference:
+  - person page: <https://learnbuffett.com/people/%E6%A0%BC%E9%9B%B7%E5%8E%84%E5%A7%86>
+  - graph page: <https://learnbuffett.com/graph>
+- Compared the reference against the current local `ovp-ui` surfaces:
+  - `/` currently leads with runtime/workflow/operator state
+  - `/objects` is database-like rather than reader-oriented
+  - `/clusters` exposes analytical graph internals rather than a spatial corpus map
+- Added `docs/plans/2026-04-29-reader-product-shape-and-backlog-reconciliation.md`.
+- Added `docs/plans/2026-04-29-consolidated-product-roadmap.md`.
+- Added `BACKLOG.md` as the single active implementation backlog entry point.
+- Updated `task_plan.md` with the current reader-product backlog.
+- Updated `findings.md` with LearnBuffett as Round 16 external/product reference.
+- Current backlog recommendation:
+  - P0: reader home / Knowledge Atlas
+  - P0: move current dashboard to `/ops`
+  - P0: kind-aware object pages
+  - P1: mention/backlink rail
+  - P1: visual `/graph` map
+- Decision:
+  - OVP remains an auditable knowledge compiler internally.
+  - The default user-facing product should become a reader-first, evidence-backed knowledge atlas rather than an operator dashboard.
+
 ## Session: 2026-04-22
 
 ### Phase 30/31: Release Hygiene And Semantic Relation Contract

--- a/task_plan.md
+++ b/task_plan.md
@@ -24,6 +24,52 @@ OVP is now a usable local knowledge workbench with:
 - active signal loop
 - action queue and focused action worker execution surface
 
+## Product Shape Addendum: 2026-04-29
+
+Reference: `docs/plans/2026-04-29-reader-product-shape-and-backlog-reconciliation.md`
+
+Active implementation backlog: `BACKLOG.md`
+
+The current UI is too operator-first. It exposes real system power, but its first impression is runtime state, actions, signals, candidates, clusters, and run history. That makes the product feel more like an engineering console than a readable knowledge base.
+
+LearnBuffett is now recorded as a product-shape reference:
+
+- person / concept / company objects should feel like readable topic pages first
+- graph should be a spatial map of the corpus, not primarily a cluster/debug report
+- backlinks and evidence should support the reading flow instead of leading with raw operational tables
+- operator surfaces should remain available, but behind an `/ops` framing
+
+Reconciled product thesis:
+
+> OVP remains an auditable knowledge compiler internally, but its default user-facing surface should be a reader-first, evidence-backed knowledge atlas.
+
+## Backlog Reconciliation Addendum: 2026-04-29
+
+The KSR project page in `/Users/chris/Documents/ovp-vault/` should not be treated as the backlog source of truth. It appears to be a recent task extraction from the latest research notes, so it is high-signal for KSR gaps but incomplete for prior roadmap history.
+
+Use a four-input merge when deciding roadmap sequence:
+
+- repo milestone history for what has shipped and what older product bets existed
+- `docs/plans/2026-04-22-vision-and-roadmap-trusted-reuse-compiler.md` for the trusted-reuse/compiler direction
+- vault KSR page for recent Knowledge State Runtime task extraction
+- `docs/plans/2026-04-29-reader-product-shape-and-backlog-reconciliation.md` for reader-first product shape
+
+## Current Reader-Product Backlog
+
+| Priority | Item | Status | Notes |
+| --- | --- | --- | --- |
+| P0 | Reader home / Knowledge Atlas | Proposed next | Make `/` answer what the corpus knows, what matters, what changed, and what to read next |
+| P0 | Move current dashboard to `/ops` | Proposed next | Preserve runtime/action/operator value without making it first impression |
+| P0 | Kind-aware object pages | Next | Person, concept, company/tool/project, event, claim templates |
+| P1 | Mention/backlink rail | Next | LearnBuffett-style "linked to this page" context with excerpts and source jumps |
+| P1 | Visual `/graph` map | Next | Spatial type-colored graph; keep analytical clusters as ops/debug surface |
+| P1 | Reader-oriented search | Later | Group by kind and reading intent, show summary/evidence/reason |
+| P1 | Trusted reuse loop | Keep | Still the north-star measurement layer |
+| P1 | Evidence v2 | Keep | Needed for long-term trust |
+| P2 | Policy promotion | Keep | Important, but after product entry is understandable |
+| P2 | Reviewed semantic extractor | Later | Do not add more graph complexity before graph is readable |
+| P2 | Query feedback loop | Later | Strong compounding loop, after reader surfaces are clearer |
+
 The previous missing product claims are now closed by Phase 28/29:
 
 > OVP has a single focused execution surface, but broader background intelligence still needs a clearer value proof: why a briefing item is useful, what evidence supports it, and what background policy allowed or skipped it.


### PR DESCRIPTION
## Summary
- add BACKLOG.md as the active implementation backlog entry point
- consolidate roadmap inputs from historical milestones, April 22 compiler roadmap, recent KSR extraction, and reader-first product research
- refresh README/progress/task plan pointers so KSR is treated as recent input, not the complete backlog source of truth

## Verification
- git diff --check
- git diff --cached --check
- git diff --check HEAD~1..HEAD
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/73" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product narrative to emphasize reader-first knowledge atlas alongside internal auditable compilation.
  * Added consolidated milestone roadmap (M0–M7) with prioritized backlog and implementation sequencing.
  * Clarified architecture boundaries and incremental workflow entry points.
  * Created centralized backlog document for implementation tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->