### PR TITLE
[codex] Split reader library from ops dashboard

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -31,8 +31,8 @@ Rule: historical plans and vault research notes feed this file; they do not over
 
 | ID | Priority | Status | Work item | Source links |
 | --- | --- | --- | --- | --- |
-| BL-000 | P0 | Active | Commit current roadmap/README/backlog consolidation, including English-primary README/Architecture/Milestone docs with Chinese alternates | M2 |
-| BL-001 | P0 | Next | Reader shell route split: make `/` a Knowledge Atlas home and move current dashboard to `/ops` | M3, reader-product note |
+| BL-000 | P0 | Done | Commit current roadmap/README/backlog consolidation, including English-primary README/Architecture/Milestone docs with Chinese alternates | M2, PR #74 |
+| BL-001 | P0 | Active | Reader shell route split: make `/` a Knowledge Atlas home and move current dashboard to `/ops` | M3, reader-product note |
 | BL-002 | P0 | Next | Projection marking: label dashboard, MOC, wiki, briefing, reader pages, graph, and context packs as projections | M4, KSR-002 |
 | BL-003 | P0 | Next | Dashboard/search hot-path audit: default UI/search paths must not scan raw/PDF/Office sources | M4, KSR-015 |
 | BL-004 | P0 | Next | Workflow wiring eval suite for lifecycle routing, promote gates, projection labels, hot paths, and read/write boundaries | M4, KSR-026 |

--- a/docs/plans/2026-04-29-bl-001-reader-shell-route-split.md
+++ b/docs/plans/2026-04-29-bl-001-reader-shell-route-split.md
@@ -1,0 +1,103 @@
+# BL-001 Reader Shell Route Split Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make `/` a reader-first Library home and move the current operator dashboard to `/ops`.
+
+**Architecture:** This is a Layer 3 access-surface change only. It must reuse existing payloads and renderers, preserve the current dashboard behavior under `/ops`, and avoid introducing new state or schema. User-facing copy must use product language: Library, Map, Workbench.
+
+**Tech Stack:** Python HTTP server in `src/ovp_pipeline/commands/ui_server.py`, pytest-based HTTP smoke tests in `tests/test_ui_server.py` and related UI tests.
+
+## Product Rules
+
+- Do not put internal architecture terms on the reader homepage.
+- Avoid terms such as projection, derived, canonical, KSR, claim lifecycle, hot path, resolver, and governance.
+- Primary navigation should read as a product, not as an engineering console:
+  - `Library`
+  - `Map`
+  - `Workbench`
+- `/ops` owns the current operator dashboard and maintenance workflows.
+- `/` should answer: what is in my knowledge library, what is worth reading, how things connect, and where maintenance work lives.
+
+## Task 1: Lock The Route Contract
+
+**Files:**
+
+- Modify: `tests/test_ui_server.py`
+
+**Step 1: Write failing tests**
+
+Add tests proving:
+
+- `/` renders a reader-first Library page.
+- `/` does not render the old dashboard-only `Workflow Map` page.
+- top navigation includes `Library`, `Map`, and `Workbench`.
+- `/ops` renders the existing dashboard content, including `Workflow Map`.
+
+**Step 2: Verify RED**
+
+Run:
+
+```bash
+python -m pytest tests/test_ui_server.py::test_ui_server_root_serves_reader_library_home tests/test_ui_server.py::test_ui_server_ops_route_serves_operator_dashboard -q
+```
+
+Expected: fail because `/` still renders the current dashboard and `/ops` is not routed.
+
+## Task 2: Implement Minimal Route Split
+
+**Files:**
+
+- Modify: `src/ovp_pipeline/commands/ui_server.py`
+
+**Step 1: Implement**
+
+- Add a reader-home renderer that uses existing dashboard payload fields.
+- Change `GET /` to render the reader-home renderer.
+- Add `GET /ops` to render the current `_render_dashboard(payload)`.
+- Change shell nav to `Library`, `Map`, `Workbench`.
+- Keep existing routes such as `/workbench`, `/explore`, `/objects`, `/search`, `/briefing`, and `/actions`.
+
+**Step 2: Verify GREEN**
+
+Run:
+
+```bash
+python -m pytest tests/test_ui_server.py::test_ui_server_root_serves_reader_library_home tests/test_ui_server.py::test_ui_server_ops_route_serves_operator_dashboard -q
+```
+
+Expected: pass.
+
+## Task 3: Preserve Existing UI Behavior
+
+**Files:**
+
+- Modify tests as needed only to reflect the intentional route split.
+
+**Step 1: Run targeted regression tests**
+
+Run:
+
+```bash
+python -m pytest tests/test_ui_server.py tests/test_workbench.py tests/test_explore_ui.py -q
+```
+
+Expected: pass.
+
+**Step 2: Update backlog state**
+
+Modify `BACKLOG.md`:
+
+- mark `BL-000` as done
+- mark `BL-001` as active
+
+## Task 4: Final Verification And PR
+
+Run:
+
+```bash
+git diff --check
+python -m pytest tests/test_ui_server.py tests/test_workbench.py tests/test_explore_ui.py -q
+```
+
+Then commit and open a PR for `BL-001`.

--- a/docs/plans/2026-04-29-bl-001-reader-shell-route-split.md
+++ b/docs/plans/2026-04-29-bl-001-reader-shell-route-split.md
@@ -79,7 +79,7 @@ Expected: pass.
 Run:
 
 ```bash
-python -m pytest tests/test_ui_server.py tests/test_workbench.py tests/test_explore_ui.py -q
+python -m pytest tests/test_ui_server.py tests/test_workbench.py tests/test_explore_ui.py tests/test_ui_smoke.py -q
 ```
 
 Expected: pass.
@@ -97,7 +97,7 @@ Run:
 
 ```bash
 git diff --check
-python -m pytest tests/test_ui_server.py tests/test_workbench.py tests/test_explore_ui.py -q
+python -m pytest tests/test_ui_server.py tests/test_workbench.py tests/test_explore_ui.py tests/test_ui_smoke.py -q
 ```
 
 Then commit and open a PR for `BL-001`.

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -107,31 +107,12 @@ def _shell_supports_research_nav(requested_pack: str = "") -> bool:
 
 
 def _shell_nav_items(requested_pack: str = "") -> list[tuple[str, str]]:
-    items = [
-        ("Home", "/"),
-        ("Objects", "/objects"),
+    return [
+        ("Library", "/"),
+        ("Map", "/map"),
         ("Search", "/search"),
-        ("Signals", "/signals"),
-        ("Briefing", "/briefing"),
-        ("Actions", "/actions"),
-        ("Production", "/production"),
-        ("Workbench", "/workbench"),
-        ("Explore", "/explore"),
+        ("Workbench", "/ops"),
     ]
-    if _shell_supports_research_nav(requested_pack):
-        items.extend(
-            [
-                ("Candidates", "/candidates"),
-                ("Evolution", "/evolution"),
-                ("Clusters", "/clusters"),
-                ("Atlas", "/atlas"),
-                ("Deep Dives", "/deep-dives"),
-                ("Event Dossier", "/events"),
-                ("Contradictions", "/contradictions"),
-                ("Stale Summaries", "/summaries"),
-            ]
-        )
-    return items
 
 
 def _layout(
@@ -1718,6 +1699,44 @@ def _render_dashboard(payload: dict) -> str:
         requested_pack=requested_pack,
         auto_refresh_seconds=10,
     )
+
+
+def _render_library_home(payload: dict) -> str:
+    requested_pack = payload.get("requested_pack", "")
+    object_items = (
+        "".join(
+            f'<li><a href="{escape(_object_href(item["object_id"], item.get("object_path", ""), requested_pack=requested_pack))}">{escape(item["title"])}</a></li>'
+            for item in payload.get("objects", {}).get("items", [])
+        )
+        or "<li class='muted'>No library items yet.</li>"
+    )
+    object_count = int(payload.get("objects", {}).get("count") or 0)
+    map_path = _shell_href("/map", requested_pack)
+    workbench_path = _shell_href("/ops", requested_pack)
+    search_path = _shell_href("/search", requested_pack)
+    body = "".join(
+        [
+            "<section class='hero'>",
+            "<h1>Knowledge Library</h1>",
+            "<p class='muted'>Browse the people, concepts, sources, and ideas in this vault.</p>",
+            "</section>",
+            "<section class='grid stats'>",
+            f"<div class='card'><h2>Library Items</h2><p>{object_count}</p></div>",
+            f"<div class='card'><h2>Search Library</h2><p><a href='{escape(search_path)}'>Search by title, topic, or source</a></p></div>",
+            f"<div class='card'><h2>Knowledge Map</h2><p><a href='{escape(map_path)}'>See how ideas connect</a></p></div>",
+            "</section>",
+            "<section class='grid two-col'>",
+            "<section class='card'><h2>Recent Knowledge</h2>",
+            f"<ul class='list-tight'>{object_items}</ul>",
+            "</section>",
+            "<section class='card'><h2>Open Workbench</h2>",
+            "<p class='muted'>Use the workbench when you need to fix items or check recent activity.</p>",
+            f"<p><a href='{escape(workbench_path)}'>Open Workbench</a></p>",
+            "</section>",
+            "</section>",
+        ]
+    )
+    return _layout("Knowledge Library", body, requested_pack=requested_pack)
 
 
 def _render_objects_index(payload: dict) -> str:
@@ -4439,6 +4458,11 @@ def create_server(
                 if path == "/":
                     pack_name = query.get("pack", [""])[0] or None
                     payload = build_runtime_home_payload(resolved_vault, pack_name=pack_name)
+                    self._write_html(_render_library_home(payload))
+                    return
+                if path == "/ops":
+                    pack_name = query.get("pack", [""])[0] or None
+                    payload = build_runtime_home_payload(resolved_vault, pack_name=pack_name)
                     self._write_html(_render_dashboard(payload))
                     return
                 if path == "/api/objects":
@@ -4768,6 +4792,18 @@ def create_server(
                     pack_name = query.get("pack", [""])[0] or None
                     if self._guard_research_route(
                         pack_name=pack_name, route_path="/clusters", api=False
+                    ):
+                        return
+                    payload = build_cluster_browser_payload(
+                        resolved_vault, pack_name=pack_name, query=q
+                    )
+                    self._write_html(_render_clusters_page(payload))
+                    return
+                if path == "/map":
+                    q = query.get("q", [""])[0]
+                    pack_name = query.get("pack", [""])[0] or None
+                    if self._guard_research_route(
+                        pack_name=pack_name, route_path="/map", api=False
                     ):
                         return
                     payload = build_cluster_browser_payload(

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -115,6 +115,13 @@ def _shell_nav_items(requested_pack: str = "") -> list[tuple[str, str]]:
     ]
 
 
+def _build_runtime_home_payload_from_query(
+    vault_dir: Path, query: dict[str, list[str]]
+) -> dict:
+    pack_name = query.get("pack", [""])[0] or None
+    return build_runtime_home_payload(vault_dir, pack_name=pack_name)
+
+
 def _layout(
     title: str, body: str, *, requested_pack: str = "", auto_refresh_seconds: int | None = None
 ) -> str:
@@ -4456,13 +4463,11 @@ def create_server(
 
             try:
                 if path == "/":
-                    pack_name = query.get("pack", [""])[0] or None
-                    payload = build_runtime_home_payload(resolved_vault, pack_name=pack_name)
+                    payload = _build_runtime_home_payload_from_query(resolved_vault, query)
                     self._write_html(_render_library_home(payload))
                     return
                 if path == "/ops":
-                    pack_name = query.get("pack", [""])[0] or None
-                    payload = build_runtime_home_payload(resolved_vault, pack_name=pack_name)
+                    payload = _build_runtime_home_payload_from_query(resolved_vault, query)
                     self._write_html(_render_dashboard(payload))
                     return
                 if path == "/api/objects":

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -2480,7 +2480,7 @@ def _render_production_browser_page(payload: dict) -> str:
     )
 
 
-def _render_clusters_page(payload: dict) -> str:
+def _render_clusters_page(payload: dict, *, action_path: str = "/clusters") -> str:
     query = payload.get("query", "")
     requested_pack = payload.get("requested_pack", "")
     limit_note = (
@@ -2555,7 +2555,7 @@ def _render_clusters_page(payload: dict) -> str:
         "".join(
             [
                 "<h1>Graph Clusters</h1>",
-                "<form method='get' action='/clusters'>",
+                f"<form method='get' action='{escape(action_path)}'>",
                 (
                     f"<input type='hidden' name='pack' value='{escape(requested_pack)}' />"
                     if requested_pack
@@ -4821,7 +4821,7 @@ def create_server(
                     payload = build_cluster_browser_payload(
                         resolved_vault, pack_name=pack_name, query=q
                     )
-                    self._write_html(_render_clusters_page(payload))
+                    self._write_html(_render_clusters_page(payload, action_path="/map"))
                     return
                 if path == "/api/cluster":
                     cluster_id = self._required(query, "id")

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -107,12 +107,14 @@ def _shell_supports_research_nav(requested_pack: str = "") -> bool:
 
 
 def _shell_nav_items(requested_pack: str = "") -> list[tuple[str, str]]:
-    return [
+    items = [
         ("Library", "/"),
-        ("Map", "/map"),
         ("Search", "/search"),
         ("Workbench", "/ops"),
     ]
+    if _shell_supports_research_nav(requested_pack):
+        items.insert(1, ("Map", "/map"))
+    return items
 
 
 def _build_runtime_home_payload_from_query(
@@ -1721,6 +1723,11 @@ def _render_library_home(payload: dict) -> str:
     map_path = _shell_href("/map", requested_pack)
     workbench_path = _shell_href("/ops", requested_pack)
     search_path = _shell_href("/search", requested_pack)
+    map_card = (
+        f"<div class='card'><h2>Knowledge Map</h2><p><a href='{escape(map_path)}'>See how ideas connect</a></p></div>"
+        if _shell_supports_research_nav(requested_pack)
+        else ""
+    )
     body = "".join(
         [
             "<section class='hero'>",
@@ -1730,7 +1737,7 @@ def _render_library_home(payload: dict) -> str:
             "<section class='grid stats'>",
             f"<div class='card'><h2>Library Items</h2><p>{object_count}</p></div>",
             f"<div class='card'><h2>Search Library</h2><p><a href='{escape(search_path)}'>Search by title, topic, or source</a></p></div>",
-            f"<div class='card'><h2>Knowledge Map</h2><p><a href='{escape(map_path)}'>See how ideas connect</a></p></div>",
+            map_card,
             "</section>",
             "<section class='grid two-col'>",
             "<section class='card'><h2>Recent Knowledge</h2>",

--- a/tests/test_explore_ui.py
+++ b/tests/test_explore_ui.py
@@ -93,7 +93,7 @@ def test_explore_route_returns_three_pane_html(running_server) -> None:
 
 def test_explore_navbar_link_present(running_server) -> None:
     home = _fetch(running_server, "/")
-    assert 'href="/explore"' in home
+    assert 'href="/map"' in home
 
 
 def test_explore_stream_round_trips_one_synthetic_event(temp_vault: Path, running_server) -> None:

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -192,6 +192,8 @@ def test_ui_server_map_route_serves_readable_map_entry(temp_vault):
 
     assert status == 200
     assert "Graph Clusters" in body
+    assert "action='/map'" in body
+    assert "action='/clusters'" not in body
     assert 'href="/">Library</a>' in body
     assert 'href="/map">Map</a>' in body
     assert 'href="/ops">Workbench</a>' in body

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -70,10 +70,26 @@ Alpha does not support local-first execution.
     rebuild_knowledge_index(temp_vault)
 
 
-def test_ui_server_root_serves_html_shell(temp_vault):
+def _fetch_ui_html(temp_vault, path: str) -> tuple[int, str]:
     from ovp_pipeline.commands.ui_server import create_server
 
-    _seed_truth_store(temp_vault)
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("GET", path)
+        response = conn.getresponse()
+        body = response.read().decode("utf-8")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+    return response.status, body
+
+
+def _seed_running_transaction(temp_vault) -> None:
     transactions_dir = temp_vault / "60-Logs" / "transactions"
     transactions_dir.mkdir(parents=True, exist_ok=True)
     (transactions_dir / "txn-1.json").write_text(
@@ -116,21 +132,33 @@ def test_ui_server_root_serves_html_shell(temp_vault):
         ),
         encoding="utf-8",
     )
-    server = create_server(temp_vault, host="127.0.0.1", port=0)
-    port = server.server_address[1]
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    try:
-        conn = HTTPConnection("127.0.0.1", port, timeout=5)
-        conn.request("GET", "/")
-        response = conn.getresponse()
-        body = response.read().decode("utf-8")
-    finally:
-        server.shutdown()
-        server.server_close()
-        thread.join(timeout=5)
 
-    assert response.status == 200
+
+def test_ui_server_root_serves_reader_library_home(temp_vault):
+    _seed_truth_store(temp_vault)
+    _seed_running_transaction(temp_vault)
+
+    status, body = _fetch_ui_html(temp_vault, "/")
+
+    assert status == 200
+    assert "Knowledge Library" in body
+    assert 'href="/">Library</a>' in body
+    assert 'href="/map">Map</a>' in body
+    assert 'href="/ops">Workbench</a>' in body
+    assert "Recent Knowledge" in body
+    assert "Knowledge Map" in body
+    assert "Open Workbench" in body
+    assert "Workflow Map" not in body
+    assert "OVP Truth UI" not in body
+
+
+def test_ui_server_ops_route_serves_operator_dashboard(temp_vault):
+    _seed_truth_store(temp_vault)
+    _seed_running_transaction(temp_vault)
+
+    status, body = _fetch_ui_html(temp_vault, "/ops")
+
+    assert status == 200
     assert "OVP Truth UI" in body
     assert "Workflow Map" in body
     assert "Orient" in body
@@ -155,6 +183,18 @@ def test_ui_server_root_serves_html_shell(temp_vault):
     assert "<h2>Surface Contract</h2>" not in body
     assert "Orientation Brief" in body
     assert "/api/objects" in body
+
+
+def test_ui_server_map_route_serves_readable_map_entry(temp_vault):
+    _seed_truth_store(temp_vault)
+
+    status, body = _fetch_ui_html(temp_vault, "/map")
+
+    assert status == 200
+    assert "Graph Clusters" in body
+    assert 'href="/">Library</a>' in body
+    assert 'href="/map">Map</a>' in body
+    assert 'href="/ops">Workbench</a>' in body
 
 
 def test_render_runtime_card_shows_pipeline_process_identity():
@@ -463,11 +503,11 @@ def test_ui_server_root_accepts_pack_scope(temp_vault):
         thread.join(timeout=5)
 
     assert response.status == 200
-    assert "Pack scope: default-knowledge" in body
-    assert 'href="/briefing?pack=default-knowledge"' in body
-    assert "/signals?pack=default-knowledge" in body
-    assert "inherited from research-tech-signals" in body
-    assert "inherited from research-tech-production-chains" in body
+    assert 'href="/?pack=default-knowledge"' in body
+    assert 'href="/map?pack=default-knowledge"' in body
+    assert 'href="/search?pack=default-knowledge"' in body
+    assert 'href="/ops?pack=default-knowledge"' in body
+    assert "Knowledge Library" in body
 
 
 def test_ui_server_objects_endpoint_returns_json(temp_vault):
@@ -672,9 +712,9 @@ def test_ui_server_object_page_preserves_pack_scope_in_shell_nav(temp_vault):
 
     assert response.status == 200
     assert 'href="/?pack=default-knowledge"' in body
-    assert 'href="/objects?pack=default-knowledge"' in body
-    assert 'href="/signals?pack=default-knowledge"' in body
-    assert 'href="/atlas?pack=default-knowledge"' in body
+    assert 'href="/map?pack=default-knowledge"' in body
+    assert 'href="/search?pack=default-knowledge"' in body
+    assert 'href="/ops?pack=default-knowledge"' in body
     assert (
         'href="/note?path=10-Knowledge%2FEvergreen%2FAlpha.md&amp;pack=default-knowledge"' in body
     )
@@ -803,7 +843,8 @@ date: 2026-04-13
 
     assert response.status == 200
     assert 'href="/search?pack=default-knowledge"' in body
-    assert 'href="/signals?pack=default-knowledge"' in body
+    assert 'href="/map?pack=default-knowledge"' in body
+    assert 'href="/ops?pack=default-knowledge"' in body
     assert 'href="/object?id=alpha&amp;pack=default-knowledge"' in body
     assert (
         'href="/note?path=20-Areas%2FAI-Research%2FTopics%2F2026-04%2FHarness_%E6%B7%B1%E5%BA%A6%E8%A7%A3%E8%AF%BB.md&amp;pack=default-knowledge"'
@@ -970,8 +1011,9 @@ def test_ui_server_signals_page_preserves_pack_scope_in_shell_nav(temp_vault):
         thread.join(timeout=5)
 
     assert response.status == 200
-    assert 'href="/events?pack=default-knowledge"' in body
-    assert 'href="/summaries?pack=default-knowledge"' in body
+    assert 'href="/?pack=default-knowledge"' in body
+    assert 'href="/map?pack=default-knowledge"' in body
+    assert 'href="/ops?pack=default-knowledge"' in body
     assert "inherited from research-tech-signals" in body
     assert body.index("Next Actions") < body.index("Signal Types")
 
@@ -1064,8 +1106,9 @@ def test_ui_server_shell_nav_hides_research_links_for_non_research_pack(temp_vau
         thread.join(timeout=5)
 
     assert response.status == 200
-    assert 'href="/signals?pack=media-editorial"' in body
-    assert 'href="/production?pack=media-editorial"' in body
+    assert 'href="/?pack=media-editorial"' in body
+    assert 'href="/map?pack=media-editorial"' in body
+    assert 'href="/ops?pack=media-editorial"' in body
     assert 'href="/clusters?pack=media-editorial"' not in body
     assert 'href="/contradictions?pack=media-editorial"' not in body
     assert 'href="/events?pack=media-editorial"' not in body
@@ -1213,8 +1256,9 @@ def test_ui_server_events_page_preserves_pack_scope_in_shell_nav(temp_vault):
         thread.join(timeout=5)
 
     assert response.status == 200
-    assert 'href="/signals?pack=default-knowledge"' in body
-    assert 'href="/atlas?pack=default-knowledge"' in body
+    assert 'href="/?pack=default-knowledge"' in body
+    assert 'href="/map?pack=default-knowledge"' in body
+    assert 'href="/ops?pack=default-knowledge"' in body
     assert (
         'href="/note?path=10-Knowledge%2FEvergreen%2FAlpha.md&amp;pack=default-knowledge"' in body
     )
@@ -1426,8 +1470,9 @@ def test_ui_server_clusters_page_preserves_pack_scope_in_shell_nav(temp_vault):
         thread.join(timeout=5)
 
     assert response.status == 200
-    assert 'href="/briefing?pack=default-knowledge"' in body
-    assert 'href="/atlas?pack=default-knowledge"' in body
+    assert 'href="/?pack=default-knowledge"' in body
+    assert 'href="/map?pack=default-knowledge"' in body
+    assert 'href="/ops?pack=default-knowledge"' in body
 
 
 def test_ui_server_cluster_detail_endpoint_returns_payload(temp_vault):
@@ -1847,8 +1892,9 @@ Processed source note without downstream chain.
         thread.join(timeout=5)
 
     assert response.status == 200
-    assert 'href="/signals?pack=default-knowledge"' in body
-    assert 'href="/clusters?pack=default-knowledge"' in body
+    assert 'href="/?pack=default-knowledge"' in body
+    assert 'href="/map?pack=default-knowledge"' in body
+    assert 'href="/ops?pack=default-knowledge"' in body
     assert "inherited from research-tech-briefing" in body
     assert "inherited from orientation_brief in research-tech" in body
     assert "Source contract: observation_surface · briefing" in body
@@ -3262,8 +3308,9 @@ def test_ui_server_topic_page_preserves_pack_scope_in_shell_nav(temp_vault):
         thread.join(timeout=5)
 
     assert response.status == 200
-    assert 'href="/signals?pack=default-knowledge"' in body
-    assert 'href="/summaries?pack=default-knowledge"' in body
+    assert 'href="/?pack=default-knowledge"' in body
+    assert 'href="/map?pack=default-knowledge"' in body
+    assert 'href="/ops?pack=default-knowledge"' in body
     assert "Assembly Contract" in body
     assert "inherited from topic_overview in research-tech" in body
     assert "Source contract: wiki_view · overview/topic" in body

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -144,6 +144,7 @@ def test_ui_server_root_serves_reader_library_home(temp_vault):
     assert "Knowledge Library" in body
     assert 'href="/">Library</a>' in body
     assert 'href="/map">Map</a>' in body
+    assert 'href="/search">Search</a>' in body
     assert 'href="/ops">Workbench</a>' in body
     assert "Recent Knowledge" in body
     assert "Knowledge Map" in body
@@ -196,6 +197,7 @@ def test_ui_server_map_route_serves_readable_map_entry(temp_vault):
     assert "action='/clusters'" not in body
     assert 'href="/">Library</a>' in body
     assert 'href="/map">Map</a>' in body
+    assert 'href="/search">Search</a>' in body
     assert 'href="/ops">Workbench</a>' in body
 
 

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -197,6 +197,23 @@ def test_ui_server_map_route_serves_readable_map_entry(temp_vault):
     assert 'href="/ops">Workbench</a>' in body
 
 
+def test_render_library_home_hides_unavailable_map_for_non_research_pack():
+    from ovp_pipeline.commands.ui_server import _render_library_home
+
+    body = _render_library_home(
+        {
+            "requested_pack": "media-editorial",
+            "objects": {"count": 0, "items": []},
+        }
+    )
+
+    assert "Knowledge Library" in body
+    assert "Search Library" in body
+    assert "Open Workbench" in body
+    assert "Knowledge Map" not in body
+    assert 'href="/map?pack=media-editorial"' not in body
+
+
 def test_render_runtime_card_shows_pipeline_process_identity():
     from ovp_pipeline.commands.ui_server import _render_runtime_card
 
@@ -1107,7 +1124,7 @@ def test_ui_server_shell_nav_hides_research_links_for_non_research_pack(temp_vau
 
     assert response.status == 200
     assert 'href="/?pack=media-editorial"' in body
-    assert 'href="/map?pack=media-editorial"' in body
+    assert 'href="/map?pack=media-editorial"' not in body
     assert 'href="/ops?pack=media-editorial"' in body
     assert 'href="/clusters?pack=media-editorial"' not in body
     assert 'href="/contradictions?pack=media-editorial"' not in body
@@ -1176,6 +1193,40 @@ def test_ui_server_research_html_route_rejects_non_research_pack(temp_vault, mon
     assert "Route Unavailable" in body
     assert "research-specific observation shell" in body
     assert "media-editorial" in body
+
+
+def test_ui_server_map_route_rejects_non_research_pack_without_nav_link(
+    temp_vault, monkeypatch
+):
+    import ovp_pipeline.commands.ui_server as ui_server
+    from ovp_pipeline.commands.ui_server import create_server
+
+    monkeypatch.setattr(
+        ui_server,
+        "build_cluster_browser_payload",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("cluster builder should not run")
+        ),
+    )
+
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("GET", "/map?pack=media-editorial")
+        response = conn.getresponse()
+        body = response.read().decode("utf-8")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 200
+    assert "Route Unavailable" in body
+    assert "research-specific observation shell" in body
+    assert 'href="/map?pack=media-editorial"' not in body
 
 
 def test_ui_server_summaries_endpoint_accepts_pack_scope(temp_vault):

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -7,6 +7,10 @@ from urllib.parse import quote, urlencode
 
 from ovp_pipeline.knowledge_index import rebuild_knowledge_index
 from ovp_pipeline.runtime import VaultLayout
+from ovp_pipeline.ui.view_models import (
+    DEFAULT_EVENT_DOSSIER_LIMIT,
+    DEFAULT_TRACEABILITY_BROWSER_LIMIT,
+)
 
 
 def _seed_truth_store(temp_vault):
@@ -202,7 +206,7 @@ date: 2026-04-13
     assert "Event Clusters" in events_body
     assert "Review Context" in events_body
     assert "Production Contribution" in events_body
-    assert "Showing the most recent 50 timeline rows" in events_body
+    assert f"Showing the most recent {DEFAULT_EVENT_DOSSIER_LIMIT} timeline rows" in events_body
     assert "Top Source Notes" in events_body
     assert "/summaries?q=alpha" in events_body
     assert "Quick Maintenance" in events_body
@@ -216,7 +220,7 @@ date: 2026-04-13
     assert atlas_status == 200
     assert "Atlas / MOC Browser" in atlas_body
     assert "Contribution Summary" in atlas_body
-    assert "Showing the most recent 50 atlas pages" in atlas_body
+    assert f"Showing the most recent {DEFAULT_TRACEABILITY_BROWSER_LIMIT} atlas pages" in atlas_body
 
     assert deep_dives_status == 200
     assert "Deep Dive Derivations" in deep_dives_body
@@ -226,13 +230,16 @@ date: 2026-04-13
     assert "Evolution Browser" in evolution_body
     assert "Candidate Links" in evolution_body
     assert "/evolution/review" in evolution_body
-    assert "Showing the most recent 50 deep dives" in deep_dives_body
+    assert f"Showing the most recent {DEFAULT_TRACEABILITY_BROWSER_LIMIT} deep dives" in deep_dives_body
     assert "Source Deep Dive" in deep_dives_body
 
     assert production_status == 200
     assert "Production Browser" in production_body
     assert "Chain Model" in production_body
-    assert "Showing the most recent 50 production-chain entries" in production_body
+    assert (
+        f"Showing the most recent {DEFAULT_TRACEABILITY_BROWSER_LIMIT} production-chain entries"
+        in production_body
+    )
     assert "Weak Points" in production_body
     assert "Source Deep Dive" in production_body
     assert "deep dive" in production_body
@@ -945,7 +952,7 @@ Mentions [[alpha]].
     assert f'/note?path={quote("20-Areas/AI-Research/Topics/2026-04/Agent Harness_深度解读.md", safe="")}' in body
 
 
-def test_ui_root_dashboard_renders_db_summary(temp_vault):
+def test_ui_root_library_and_ops_dashboard_render_db_summary(temp_vault):
     from ovp_pipeline.commands.ui_server import create_server
 
     _seed_truth_store(temp_vault)
@@ -983,24 +990,38 @@ Thin note.
     thread.start()
     try:
         root_status, root_body = _get(port, "/")
+        ops_status, ops_body = _get(port, "/ops")
     finally:
         server.shutdown()
         server.server_close()
         thread.join(timeout=5)
 
     assert root_status == 200
-    assert "Objects Indexed" in root_body
-    assert "Contradictions Open" in root_body
-    assert "Recent Events" in root_body
-    assert "Stale Summaries" in root_body
-    assert "Evolution Candidates" in root_body
-    assert "Needs Attention Now" in root_body
+    assert "Knowledge Library" in root_body
+    assert 'href="/">Library</a>' in root_body
+    assert 'href="/map">Map</a>' in root_body
+    assert 'href="/ops">Workbench</a>' in root_body
+    assert "Recent Knowledge" in root_body
+    assert "Knowledge Map" in root_body
     assert "Alpha" in root_body
     assert "Thin Note" in root_body
-    assert "/summaries" in root_body
-    assert "/evolution" in root_body
-    assert "Production Weak Points" in root_body
-    assert "Signals" in root_body
+    assert "OVP Truth UI" not in root_body
+    assert "Workflow Map" not in root_body
+
+    assert ops_status == 200
+    assert "OVP Truth UI" in ops_body
+    assert "Objects Indexed" in ops_body
+    assert "Contradictions Open" in ops_body
+    assert "Recent Events" in ops_body
+    assert "Stale Summaries" in ops_body
+    assert "Evolution Candidates" in ops_body
+    assert "Needs Attention Now" in ops_body
+    assert "Alpha" in ops_body
+    assert "Thin Note" in ops_body
+    assert "/summaries" in ops_body
+    assert "/evolution" in ops_body
+    assert "Production Weak Points" in ops_body
+    assert "Signals" in ops_body
 
 
 def test_ui_signals_page_renders_active_signal_ledger(temp_vault):

--- a/tests/test_workbench.py
+++ b/tests/test_workbench.py
@@ -175,4 +175,4 @@ def test_object_fragment_omits_full_page_chrome(running_server) -> None:
 
 def test_workbench_navbar_link_present(running_server) -> None:
     home = _fetch(running_server, "/")
-    assert 'href="/workbench"' in home
+    assert 'href="/ops"' in home


### PR DESCRIPTION
## Summary
- Makes `/` a reader-first Knowledge Library home with product navigation: Library, Map, Search, Workbench.
- Moves the existing operator dashboard to `/ops` without removing legacy deep routes.
- Adds `/map` as a readable alias for the graph cluster surface and updates UI smoke tests.

## Validation
- `PYTHONPATH=src python -m pytest tests/test_ui_server.py::test_ui_server_root_serves_reader_library_home tests/test_ui_smoke.py::test_ui_root_library_and_ops_dashboard_render_db_summary -q` -> 2 passed
- `PYTHONPATH=src python -m pytest tests/test_ui_server.py tests/test_workbench.py tests/test_explore_ui.py tests/test_ui_smoke.py -q` -> 135 passed
- `git diff --cached --check` before commit -> clean

## Notes
- Did not run the local `ovp` CLI.
- During verification, the system temp volume hit `No space left on device`; I cleared pytest-generated temp/cache directories and reran the suite successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Redesigned navigation structure centered on Library, Map, and Workbench
- New Library home page as the primary entry point
- New Map route for knowledge visualization

**Documentation**
- Added implementation plan documentation for navigation updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->