### PR TITLE
[codex] Plan hot-path and wiring safety pass

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -662,18 +662,18 @@ Main gaps:
 - Layer 4 fitness checks are not fully implemented.
 - Projection lifecycle markers need structured schema, scope, lease, and supersession.
 - Schema versioning is not yet wired into projection lifecycle.
-- Reader-first surfaces are not yet the default product shape.
+- The reader-first home is now the default entry; object pages, graph, backlinks, and search still need product shape.
 
 ## 18. Near-Term Architecture Actions
 
 Recommended order:
 
 1. Move backlog mapping out of architecture prose and into `BACKLOG.md`.
-2. Add projection labels for dashboard, MOC, wiki, briefing, reader pages, graph, and context packs.
-3. Implement the first fitness checks for evidence completeness, hot-path access, read/write boundary, and naming discipline.
+2. Implement the first fitness checks for hot-path access, workflow wiring, read/write boundary, and naming discipline.
+3. Add projection labels for dashboard, MOC, wiki, briefing, reader pages, graph, and context packs.
 4. Introduce structured `ProjectionRepairMarker` schema.
 5. Add schema version fields to Authority and derived projection state.
-6. Make reader-first Layer 3 surfaces the default product entry while keeping operator surfaces under `/ops`.
+6. Continue reader-first Layer 3 product work on object pages, graph, backlinks, and search.
 
 ## Appendix: Backlog Mapping
 

--- a/ARCHITECTURE.zh-CN.md
+++ b/ARCHITECTURE.zh-CN.md
@@ -773,6 +773,7 @@ Do not rely on ad hoc "just rerun the pipeline" behavior for schema changes.
 - governance / resolver contracts 还需要显式化。
 - schema versioning 和 projection compatibility 还需要工程化。
 - fitness functions 还没有落地到 CI/doctor/pre-commit。
+- reader-first home 已经成为默认入口；object page、graph、backlink、search 还需要继续产品化。
 
 ## 17. 近期架构动作
 
@@ -785,9 +786,9 @@ Do not rely on ad hoc "just rerun the pipeline" behavior for schema changes.
 3. 建立最小 architectural fitness functions。
 4. 明确哪些文件、registry、audit event 是 Authority。
 5. 给 `knowledge.db` 内部 projection 分类。
-6. 给 dashboard、MOC、wiki、briefing、graph、reader page、context pack 加 projection label。
-7. 引入结构化 ProjectionRepairMarker。
-8. 给 dashboard/search 加 hot-path eval。
+6. 先把 dashboard/search hot-path eval、workflow wiring eval、read/write boundary、naming discipline 做成第一批 fitness functions。
+7. 给 dashboard、MOC、wiki、briefing、graph、reader page、context pack 加 projection label。
+8. 引入结构化 ProjectionRepairMarker。
 9. 把 routing、promotion、review、permission 从 prompt/散落代码中收束为显式 governance/dispatch contract。
 10. 预留 semantic_reindex lifecycle kind，但不提前锁定 LanceDB 或其它 backend。
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,6 +1,6 @@
 # OVP Active Backlog
 
-**Updated:** 2026-04-29
+**Updated:** 2026-04-30
 **Status:** Active implementation backlog source
 
 This file is the single current backlog entry point for implementation sequencing.
@@ -20,9 +20,9 @@ Rule: historical plans and vault research notes feed this file; they do not over
 | --- | --- | --- |
 | M0 Pipeline And Pack Foundation | Done | CLI, source lifecycle, pack/profile runtime, `knowledge.db`, first source-lifecycle idempotency slice |
 | M1 Operator Workbench And Review Runtime | Done / maintain | truth UI, candidates, signals/actions, contradictions, action worker |
-| M2 Roadmap And README Consolidation | Active | merge historical milestones, compiler roadmap, recent KSR input, reader-product research, and English-primary docs |
-| M3 Reader-First Knowledge Atlas | Next | `/` becomes reader home; current dashboard moves to `/ops`; objects and graph become knowledge products |
-| M4 KSR Safety And Hot-Path Hardening | Next | projection labels, hot-path audit, wiring evals, routing preview, evidence spans, candidate risk |
+| M2 Roadmap And README Consolidation | Done | merged historical milestones, compiler roadmap, recent KSR input, reader-product research, and English-primary docs |
+| M3 Reader-First Knowledge Atlas | Active | reader home and `/ops` split shipped; object pages, backlinks, and graph still need product shape |
+| M4 KSR Safety And Hot-Path Hardening | Active | next implementation wave for projection labels, hot-path audit, wiring evals, routing preview, evidence spans, candidate risk |
 | M5 Context Pack And Operational Runtime | Later | session snapshots, context budget, claim leases, provider facade, observability |
 | M6 Policy, Permission, And Knowledge Evolution | Later | permission layer, claim lifecycle, conflict detection, policy promotion |
 | M7 Semantic Extraction And Query Feedback Loop | Later | relation extractor, query feedback, routines, notebook/raw-source mode |
@@ -32,10 +32,10 @@ Rule: historical plans and vault research notes feed this file; they do not over
 | ID | Priority | Status | Work item | Source links |
 | --- | --- | --- | --- | --- |
 | BL-000 | P0 | Done | Commit current roadmap/README/backlog consolidation, including English-primary README/Architecture/Milestone docs with Chinese alternates | M2, PR #74 |
-| BL-001 | P0 | Active | Reader shell route split: make `/` a Knowledge Atlas home and move current dashboard to `/ops` | M3, reader-product note |
+| BL-001 | P0 | Done | Reader shell route split: make `/` a Knowledge Atlas home and move current dashboard to `/ops` | M3, reader-product note, PR #75 |
 | BL-002 | P0 | Next | Projection marking: label dashboard, MOC, wiki, briefing, reader pages, graph, and context packs as projections | M4, KSR-002 |
-| BL-003 | P0 | Next | Dashboard/search hot-path audit: default UI/search paths must not scan raw/PDF/Office sources | M4, KSR-015 |
-| BL-004 | P0 | Next | Workflow wiring eval suite for lifecycle routing, promote gates, projection labels, hot paths, and read/write boundaries | M4, KSR-026 |
+| BL-003 | P0 | Active | Dashboard/search hot-path audit: default UI/search paths must not scan raw/PDF/Office sources | M4, KSR-015, `docs/plans/2026-04-30-bl-003-004-hot-path-wiring-safety.md` |
+| BL-004 | P0 | Active | Workflow wiring eval suite for lifecycle routing, promote gates, projection labels, hot paths, and read/write boundaries | M4, KSR-026, `docs/plans/2026-04-30-bl-003-004-hot-path-wiring-safety.md` |
 | BL-005 | P0 | Next | Article routing preview before source lifecycle changes | M4, KSR-014 |
 | BL-006 | P0 | Next | Evidence span schema and markdown-aware locator backfill | M4, KSR-001, KSR-018 |
 | BL-007 | P0 | Next | Candidate risk layering by evidence strength, identity ambiguity, sensitivity, and impact | M4, KSR-003 |
@@ -90,15 +90,13 @@ Rule: historical plans and vault research notes feed this file; they do not over
 
 ## Next Decision
 
-After BL-000 is committed, choose the first implementation PR:
+`BL-001` is shipped in PR #75, so the default UI now has a reader-first entry point and `/ops` owns the operator dashboard.
 
-1. **BL-001 Reader shell route split**: best product-shape move; makes the app understandable without changing data models.
-2. **BL-003 + BL-004 safety pass**: best engineering-risk move; locks hot paths and wiring before UI becomes the default product surface.
+The next implementation PR should be the **BL-003 + BL-004 safety pass**. It protects the new default product entry by proving that reader/search/dashboard routes do not trigger heavy raw-source scans and by adding no-LLM wiring evals for the critical routing and read/write boundaries.
 
 Recommended order:
 
-1. BL-001
-2. BL-003 + BL-004
-3. BL-002
-4. BL-008 + BL-009
-5. BL-010
+1. BL-003 + BL-004
+2. BL-002
+3. BL-008 + BL-009
+4. BL-010

--- a/MILESTONE.md
+++ b/MILESTONE.md
@@ -2,7 +2,7 @@
 
 > Language: English | [简体中文](MILESTONE.zh-CN.md)
 
-**Updated:** 2026-04-29
+**Updated:** 2026-04-30
 **Status:** Current milestone sequence and implementation direction
 
 This document is the stable milestone entry point. It summarizes the current product and engineering route; [BACKLOG.md](BACKLOG.md) remains the single active implementation queue.
@@ -32,9 +32,9 @@ That means the user-facing product should make compiled knowledge easy to read f
 | --- | --- | --- |
 | M0 Pipeline And Pack Foundation | Done | CLI, source lifecycle, pack/profile runtime, `knowledge.db`, first source-lifecycle idempotency slice |
 | M1 Operator Workbench And Review Runtime | Done / maintain | truth UI, candidates, signals/actions, contradictions, action worker |
-| M2 Roadmap And README Consolidation | Active | merge historical milestones, compiler roadmap, recent KSR input, reader-product research, and the English-primary docs structure |
-| M3 Reader-First Knowledge Atlas | Next | `/` becomes reader home; current dashboard moves to `/ops`; objects and graph become knowledge products |
-| M4 KSR Safety And Hot-Path Hardening | Next | projection labels, hot-path audit, wiring evals, routing preview, evidence spans, candidate risk |
+| M2 Roadmap And README Consolidation | Done | merged historical milestones, compiler roadmap, recent KSR input, reader-product research, and the English-primary docs structure |
+| M3 Reader-First Knowledge Atlas | Active | reader home and `/ops` split shipped; objects, backlinks, and graph remain the next product surfaces |
+| M4 KSR Safety And Hot-Path Hardening | Active | next implementation wave for projection labels, hot-path audit, wiring evals, routing preview, evidence spans, candidate risk |
 | M5 Context Pack And Operational Runtime | Later | session snapshots, context budget, claim leases, provider facade, observability |
 | M6 Policy, Permission, And Knowledge Evolution | Later | permission layer, claim lifecycle, conflict detection, policy promotion |
 | M7 Semantic Extraction And Query Feedback Loop | Later | relation extractor, query feedback, routines, notebook/raw-source mode |
@@ -43,7 +43,7 @@ That means the user-facing product should make compiled knowledge easy to read f
 
 | Architecture / product work | Active backlog mapping |
 | --- | --- |
-| Reader shell route split | `BL-001` |
+| Reader shell route split | `BL-001` done in PR #75 |
 | Projection marking | `BL-002`, `KSR-002` |
 | Dashboard/search hot-path audit | `BL-003`, `KSR-015` |
 | Workflow wiring eval suite | `BL-004`, `KSR-026` |
@@ -59,12 +59,10 @@ That means the user-facing product should make compiled knowledge easy to read f
 
 Recommended order:
 
-1. Finish the documentation consolidation PR: English-primary README, Architecture, and Milestone with Chinese alternates.
-2. Implement `BL-001`: split the reader home from the operator dashboard by moving the current dashboard to `/ops`.
-3. Implement `BL-003 + BL-004`: lock the hot paths and wiring boundaries before making the reader surface the default entry.
-4. Implement `BL-002`: label reader, dashboard, graph, briefing, and context-pack surfaces as projections.
-5. Implement `BL-008 + BL-009`: make object pages readable and add source/backlink rails.
-6. Implement `BL-010`: ship the visual `/graph` MVP as a spatial corpus map.
+1. Implement `BL-003 + BL-004`: lock the hot paths and wiring boundaries now that the reader surface is the default entry.
+2. Implement `BL-002`: label reader, dashboard, graph, briefing, and context-pack surfaces as projections.
+3. Implement `BL-008 + BL-009`: make object pages readable and add source/backlink rails.
+4. Implement `BL-010`: ship the visual `/graph` MVP as a spatial corpus map.
 
 ## Documentation Rules
 

--- a/MILESTONE.zh-CN.md
+++ b/MILESTONE.zh-CN.md
@@ -2,7 +2,7 @@
 
 > 语言： [English](MILESTONE.md) | 简体中文
 
-**更新时间：** 2026-04-29
+**更新时间：** 2026-04-30
 **状态：** 当前 milestone 顺序与实施方向
 
 这份文档是稳定的 milestone 入口。它总结当前产品和工程路线；[BACKLOG.md](BACKLOG.md) 仍然是唯一 active implementation queue。
@@ -32,9 +32,9 @@ OVP 正在从 document-processing pipeline 变成：
 | --- | --- | --- |
 | M0 Pipeline And Pack Foundation | Done | CLI、source lifecycle、pack/profile runtime、`knowledge.db`、第一段 source-lifecycle idempotency |
 | M1 Operator Workbench And Review Runtime | Done / maintain | truth UI、candidates、signals/actions、contradictions、action worker |
-| M2 Roadmap And README Consolidation | Active | 合并历史 milestones、compiler roadmap、近期 KSR 输入、reader-product 研究，以及英文主文档结构 |
-| M3 Reader-First Knowledge Atlas | Next | `/` 变成 reader home；当前 dashboard 移到 `/ops`；objects 和 graph 成为知识产品 |
-| M4 KSR Safety And Hot-Path Hardening | Next | projection labels、hot-path audit、wiring evals、routing preview、evidence spans、candidate risk |
+| M2 Roadmap And README Consolidation | Done | 已合并历史 milestones、compiler roadmap、近期 KSR 输入、reader-product 研究，以及英文主文档结构 |
+| M3 Reader-First Knowledge Atlas | Active | reader home 和 `/ops` 拆分已交付；object pages、backlinks、graph 仍是下一批产品化 surface |
+| M4 KSR Safety And Hot-Path Hardening | Active | 下一批实施重点：projection labels、hot-path audit、wiring evals、routing preview、evidence spans、candidate risk |
 | M5 Context Pack And Operational Runtime | Later | session snapshots、context budget、claim leases、provider facade、observability |
 | M6 Policy, Permission, And Knowledge Evolution | Later | permission layer、claim lifecycle、conflict detection、policy promotion |
 | M7 Semantic Extraction And Query Feedback Loop | Later | relation extractor、query feedback、routines、notebook/raw-source mode |
@@ -43,7 +43,7 @@ OVP 正在从 document-processing pipeline 变成：
 
 | 架构 / 产品工作 | Active backlog 映射 |
 | --- | --- |
-| Reader shell route split | `BL-001` |
+| Reader shell route split | `BL-001` 已在 PR #75 交付 |
 | Projection marking | `BL-002`, `KSR-002` |
 | Dashboard/search hot-path audit | `BL-003`, `KSR-015` |
 | Workflow wiring eval suite | `BL-004`, `KSR-026` |
@@ -59,12 +59,10 @@ OVP 正在从 document-processing pipeline 变成：
 
 建议顺序：
 
-1. 完成文档整理 PR：README、Architecture、Milestone 都改成英文主文档，并提供中文副本。
-2. 实施 `BL-001`：把 reader home 和 operator dashboard 拆开，当前 dashboard 移到 `/ops`。
-3. 实施 `BL-003 + BL-004`：在 reader surface 成为默认入口之前，锁住 hot path 和 wiring boundary。
-4. 实施 `BL-002`：把 reader、dashboard、graph、briefing、context pack 等 surface 标注为 projection。
-5. 实施 `BL-008 + BL-009`：让 object page 更可读，并补 source/backlink rail。
-6. 实施 `BL-010`：把 `/graph` 做成 spatial corpus map 的 MVP。
+1. 实施 `BL-003 + BL-004`：reader surface 已成为默认入口，先锁住 hot path 和 wiring boundary。
+2. 实施 `BL-002`：把 reader、dashboard、graph、briefing、context pack 等 surface 标注为 projection。
+3. 实施 `BL-008 + BL-009`：让 object page 更可读，并补 source/backlink rail。
+4. 实施 `BL-010`：把 `/graph` 做成 spatial corpus map 的 MVP。
 
 ## 文档规则
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The current release wires those layers into the actual runtime:
 - `ovp --full --with-refine` inserts `refine` before the final derived refresh
 - `ovp-autopilot` runs real-time `absorb -> moc -> knowledge_index`
 - `ovp-autopilot --with-refine` adds `refine` to that path
-- `ovp-ui` provides a local UI. It is currently operator-oriented; the next product wave moves the default entry toward a reader-first Knowledge Atlas.
+- `ovp-ui` provides a local UI. The default `/` entry is now a reader-first Knowledge Library, while the operator dashboard lives under `/ops`; the next product wave makes object and graph pages readable.
 
 ## Why The Architecture Looks Like This
 
@@ -93,9 +93,9 @@ Current milestone sequence:
 | --- | --- | --- |
 | M0 Pipeline And Pack Foundation | Complete | CLI, source lifecycle, pack/profile runtime, `knowledge.db`, first KSR-013 slice |
 | M1 Operator Workbench And Review Runtime | Complete enough | truth UI, candidates, signals/actions, contradictions, action worker |
-| M2 Roadmap And README Consolidation | Active now | merge historical milestones, compiler roadmap, recent KSR input, and reader-product research |
-| M3 Reader-First Knowledge Atlas | Next | `/` becomes reader home, current dashboard moves to `/ops`, objects/graph become knowledge products |
-| M4 KSR Safety And Hot-Path Hardening | Next | evidence spans, projection labels, candidate risk tiers, routing preview, wiring evals |
+| M2 Roadmap And README Consolidation | Complete | merged historical milestones, compiler roadmap, recent KSR input, and reader-product research |
+| M3 Reader-First Knowledge Atlas | Active | reader home and `/ops` split shipped; object and graph pages still need product shape |
+| M4 KSR Safety And Hot-Path Hardening | Active | hot-path audit and wiring evals are next, followed by evidence spans, projection labels, candidate risk tiers, routing preview |
 | M5 Context Pack And Operational Runtime | Later | session snapshots, context budget, claim leases, provider facades, observability |
 | M6 Policy, Permission, And Knowledge Evolution | Later | permission layer, claim lifecycle, conflict detection, policy promotion |
 | M7 Semantic Extraction And Query Feedback Loop | Later | relation extractor, query feedback, skill/routine extraction, notebook/raw-source mode |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -45,7 +45,7 @@ Obsidian Vault Pipeline（OVP）不是一个“多脚本拼装包”，也不只
 - `ovp --full --with-refine` 会在 `moc` 后追加 `refine`
 - `ovp-autopilot` 默认实时跑 `absorb -> moc -> knowledge_index`
 - `ovp-autopilot --with-refine` 会在实时链路里追加 `refine`
-- `ovp-ui` 提供本地 UI，目前偏 operator workbench；下一阶段会把默认入口改成 reader-first Knowledge Atlas
+- `ovp-ui` 提供本地 UI。默认 `/` 入口现在是 reader-first Knowledge Library，operator dashboard 放在 `/ops`；下一阶段继续把 object page 和 graph page 做成可读产品界面
 
 ## 为什么会变成现在这套架构
 
@@ -91,9 +91,9 @@ Obsidian Vault Pipeline（OVP）不是一个“多脚本拼装包”，也不只
 | --- | --- | --- |
 | M0 Pipeline And Pack Foundation | Complete | CLI、source lifecycle、pack/profile、`knowledge.db`、KSR-013 第一版 |
 | M1 Operator Workbench And Review Runtime | Complete enough | truth UI、candidates、signals/actions、contradictions、action worker |
-| M2 Roadmap And README Consolidation | Active now | 合并历史 milestone、compiler roadmap、近期 KSR 输入与 reader-product 研究，重整 README |
-| M3 Reader-First Knowledge Atlas | Next | `/` 变成 reader home，当前 dashboard 移到 `/ops`，对象页/图谱更像知识产品 |
-| M4 KSR Safety And Hot-Path Hardening | Next | evidence span、projection 标注、candidate 风险分层、routing preview、wiring eval |
+| M2 Roadmap And README Consolidation | Complete | 已合并历史 milestone、compiler roadmap、近期 KSR 输入与 reader-product 研究，重整 README |
+| M3 Reader-First Knowledge Atlas | Active | reader home 和 `/ops` 拆分已交付；object page / graph page 仍需产品化 |
+| M4 KSR Safety And Hot-Path Hardening | Active | 下一步先做 hot-path audit 和 wiring eval，再推进 evidence span、projection 标注、candidate 风险分层、routing preview |
 | M5 Context Pack And Operational Runtime | Later | session snapshot、context budget、claim lease、provider facade、observability |
 | M6 Policy, Permission, And Knowledge Evolution | Later | permission layer、claim lifecycle、conflict detection、policy promotion |
 | M7 Semantic Extraction And Query Feedback Loop | Later | relation extractor、query feedback、skill/routine extraction、notebook/raw-source mode |

--- a/docs/plans/2026-04-30-bl-003-004-hot-path-wiring-safety.md
+++ b/docs/plans/2026-04-30-bl-003-004-hot-path-wiring-safety.md
@@ -1,0 +1,549 @@
+# BL-003/004 Hot Path And Wiring Safety Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Protect the reader-first default UI by proving reader, dashboard, and search routes do not rebuild or rescan raw source content, and by adding no-LLM wiring evals for critical workflow boundaries.
+
+**Architecture:** PR #75 made `/` the reader-first Knowledge Library and moved the operator dashboard to `/ops`. The next implementation slice should make that route split mechanically safe: hot GET routes read from derived state only, while write/review routes keep going through governance APIs that emit audit events. These checks are architectural fitness functions, not product features.
+
+**Tech Stack:** Python, pytest, `http.client`, `ThreadingHTTPServer`, `ovp_pipeline.commands.ui_server`, `ovp_pipeline.ui.view_models`, `ovp_pipeline.truth_api`, `ovp_pipeline.knowledge_index`. No network, no LLM calls, no `ovp` CLI run.
+
+## Current Context
+
+- `BACKLOG.md` now treats `BL-003` and `BL-004` as the active safety slice after the reader shell route split.
+- `src/ovp_pipeline/commands/ui_server.py` owns the HTTP route table. Key read routes are `/`, `/ops`, `/search`, `/api/search`, `/objects`, and `/api/objects`.
+- `src/ovp_pipeline/ui/view_models.py` builds reader/dashboard/search payloads.
+- `src/ovp_pipeline/truth_api.py` reads `knowledge.db` projections through `ensure_knowledge_db_current()`.
+- `src/ovp_pipeline/knowledge_index.py::rebuild_knowledge_index()` is the heavy derived rebuild path and scans vault content. It must not run during normal hot GET routes when `knowledge.db` already exists and has the expected schema.
+- Existing tests already cover basic UI route behavior in `tests/test_ui_server.py`; this plan adds focused architectural tests instead of expanding those smoke tests indefinitely.
+
+## Product Constraint
+
+Default user-facing reader routes should remain simple:
+
+- No source ingestion language in reader pages.
+- No workflow jargon in `/` unless the user opens `/ops`.
+- No heavy rebuild, raw/PDF/Office scan, embedding, or LLM call during a normal GET route.
+- Mutating review routes may trigger rebuild or repair work only after an explicit POST action, and only through governance/truth APIs.
+
+## Out Of Scope
+
+- Do not implement `BL-002` projection labels except where a minimal route metadata field is necessary for an eval.
+- Do not redesign object pages, graph pages, backlinks, or search UX in this slice.
+- Do not introduce LanceDB, semantic search backend changes, or projection repair markers.
+- Do not run the local OVP app or user vault workflow.
+
+## Task 1: Add Hot Path Guard Tests
+
+**Files:**
+
+- Modify: `tests/conftest.py`
+- Create: `tests/test_ui_hot_paths.py`
+- Reuse helper patterns from: `tests/test_ui_server.py`
+
+**Step 1: Add shared HTTP and seed fixtures**
+
+Add fixtures to `tests/conftest.py` so the hot-path, wiring, and architecture fitness tests do not import private helpers from another test module.
+
+```python
+import threading
+from http.client import HTTPConnection
+
+import pytest
+
+
+@pytest.fixture
+def fetch_ui():
+    def _fetch(temp_vault, path: str) -> tuple[int, str, str]:
+        from ovp_pipeline.commands.ui_server import create_server
+
+        server = create_server(temp_vault, host="127.0.0.1", port=0)
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            conn = HTTPConnection("127.0.0.1", port, timeout=5)
+            conn.request("GET", path)
+            response = conn.getresponse()
+            body = response.read().decode("utf-8")
+            content_type = response.getheader("Content-Type") or ""
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=5)
+        return response.status, body, content_type
+
+    return _fetch
+
+
+@pytest.fixture
+def post_ui():
+    def _post(temp_vault, path: str, body: str) -> tuple[int, str]:
+        from ovp_pipeline.commands.ui_server import create_server
+
+        server = create_server(temp_vault, host="127.0.0.1", port=0)
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            conn = HTTPConnection("127.0.0.1", port, timeout=5)
+            conn.request(
+                "POST",
+                path,
+                body=body,
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+            )
+            response = conn.getresponse()
+            payload = response.read().decode("utf-8")
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=5)
+        return response.status, payload
+
+    return _post
+
+
+@pytest.fixture
+def seed_hot_path_vault():
+    def _seed(temp_vault) -> None:
+        from ovp_pipeline.knowledge_index import rebuild_knowledge_index
+
+        note = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
+        note.write_text(
+            """---
+note_id: alpha
+title: Alpha
+type: evergreen
+date: 2026-04-30
+---
+
+# Alpha
+
+Alpha supports reader-first local knowledge reuse.
+""",
+            encoding="utf-8",
+        )
+        raw_dir = temp_vault / "00-Capture" / "Raw"
+        raw_dir.mkdir(parents=True, exist_ok=True)
+        (raw_dir / "heavy.pdf").write_bytes(b"%PDF-1.4 sentinel")
+        (raw_dir / "heavy.docx").write_bytes(b"PK sentinel")
+        rebuild_knowledge_index(temp_vault)
+
+    return _seed
+```
+
+**Step 2: Write the failing hot-path test scaffold**
+
+Create `tests/test_ui_hot_paths.py`.
+
+```python
+from __future__ import annotations
+
+import pytest
+```
+
+**Step 3: Add the guard monkeypatch**
+
+Patch all rebuild entry points that a hot GET route could accidentally call after the seed rebuild has completed.
+
+```python
+def _forbid_rebuilds(monkeypatch) -> None:
+    def fail(*args, **kwargs):
+        raise AssertionError("hot GET route must not rebuild knowledge.db")
+
+    import ovp_pipeline.knowledge_index as knowledge_index
+    import ovp_pipeline.truth_api as truth_api
+
+    monkeypatch.setattr(knowledge_index, "rebuild_knowledge_index", fail)
+    monkeypatch.setattr(truth_api, "rebuild_knowledge_index", fail)
+```
+
+**Step 4: Add route coverage**
+
+Start with routes that are now default reader/product entry points plus operator dashboard/search surfaces.
+
+```python
+@pytest.mark.parametrize(
+    ("path", "expected_text"),
+    [
+        ("/", "Knowledge Library"),
+        ("/ops", "OVP Truth UI"),
+        ("/objects", "Alpha"),
+        ("/api/objects", '"object_id": "alpha"'),
+        ("/search?q=alpha", "Alpha"),
+        ("/api/search?q=alpha", '"query": "alpha"'),
+    ],
+)
+def test_ui_hot_get_routes_do_not_rebuild_knowledge_db(
+    temp_vault,
+    monkeypatch,
+    fetch_ui,
+    seed_hot_path_vault,
+    path,
+    expected_text,
+):
+    seed_hot_path_vault(temp_vault)
+    _forbid_rebuilds(monkeypatch)
+
+    status, body, _content_type = fetch_ui(temp_vault, path)
+
+    assert status == 200
+    assert expected_text in body
+```
+
+**Step 5: Run and confirm the expected state**
+
+Run:
+
+```bash
+PYTHONPATH=src python -m pytest tests/test_ui_hot_paths.py -q
+```
+
+Expected before implementation: fail if any route rebuilds `knowledge.db`; pass if current code already respects the boundary.
+
+**Step 6: Minimal implementation if the test fails**
+
+If a route rebuilds despite a current `knowledge.db`, inspect the stack and fix the smallest boundary:
+
+- Prefer making `ensure_knowledge_db_current()` a schema/existence check only on hot read paths.
+- Do not add route-specific caches.
+- Do not skip schema validation.
+- Do not silence rebuild failures globally.
+
+Likely files if a fix is needed:
+
+- Modify: `src/ovp_pipeline/truth_api.py`
+- Modify only if necessary: `src/ovp_pipeline/knowledge_index.py`
+
+**Step 7: Commit after Task 1**
+
+```bash
+git add tests/conftest.py tests/test_ui_hot_paths.py src/ovp_pipeline/truth_api.py src/ovp_pipeline/knowledge_index.py
+git commit -m "test: guard ui hot paths from rebuilds"
+```
+
+If no source files changed, commit only `tests/conftest.py` and `tests/test_ui_hot_paths.py`.
+
+## Task 2: Add Workflow Wiring Fitness Tests
+
+**Files:**
+
+- Create: `tests/test_workflow_wiring.py`
+- Modify if needed: `src/ovp_pipeline/commands/ui_server.py`
+- Modify if needed: `src/ovp_pipeline/truth_api.py`
+
+Add this header to `tests/test_workflow_wiring.py`:
+
+```python
+from __future__ import annotations
+
+import json
+
+import pytest
+```
+
+**Step 1: Test reader/operator route dispatch**
+
+Lock the route split so future edits do not accidentally make `/` operator-first again.
+
+```python
+def test_root_and_ops_dispatch_to_distinct_renderers(temp_vault, monkeypatch, fetch_ui):
+    import ovp_pipeline.commands.ui_server as ui_server
+
+    calls = []
+    monkeypatch.setattr(
+        ui_server,
+        "_build_runtime_home_payload_from_query",
+        lambda vault_dir, query: {"screen": "runtime/home", "requested_pack": ""},
+    )
+    monkeypatch.setattr(
+        ui_server,
+        "_render_library_home",
+        lambda payload: calls.append("library") or "<html>library</html>",
+    )
+    monkeypatch.setattr(
+        ui_server,
+        "_render_dashboard",
+        lambda payload: calls.append("dashboard") or "<html>dashboard</html>",
+    )
+
+    assert fetch_ui(temp_vault, "/")[0] == 200
+    assert fetch_ui(temp_vault, "/ops")[0] == 200
+    assert calls == ["library", "dashboard"]
+```
+
+**Step 2: Test read/write boundary for candidate promotion**
+
+Patch the governance/truth API seam imported by `ui_server.py`. The route should call `review_candidate_concept()` and should not mutate `ConceptRegistry` directly from the route handler.
+
+```python
+def test_candidate_review_route_uses_truth_api_governance_seam(temp_vault, monkeypatch, post_ui):
+    import ovp_pipeline.commands.ui_server as ui_server
+
+    calls = []
+
+    def fake_review_candidate_concept(*args, **kwargs):
+        calls.append(kwargs.get("action") or args)
+        return {
+            "action": "promote",
+            "mutation": {"action": "promote"},
+            "knowledge_index_rebuilt": False,
+            "next_path": "/candidates",
+        }
+
+    monkeypatch.setattr(ui_server, "review_candidate_concept", fake_review_candidate_concept)
+
+    status, payload = post_ui(
+        temp_vault,
+        "/api/candidates/review",
+        "slug=alpha-candidate&action=promote",
+    )
+
+    assert status == 200
+    assert json.loads(payload)["action"] == "promote"
+    assert calls
+```
+
+**Step 3: Test research-only route guard before mutation**
+
+Generalize the existing contradiction guard coverage to the other research mutation routes. The guard should return 409 before running the mutation function.
+
+```python
+@pytest.mark.parametrize(
+    ("path", "body", "patched_name"),
+    [
+        ("/api/evolution/review", "candidate_id=evo-1&action=accept&pack=media-editorial", "review_evolution_candidate"),
+        ("/api/candidates/review", "slug=alpha&action=promote&pack=media-editorial", "review_candidate_concept"),
+        ("/api/summaries/rebuild", "object_id=alpha&pack=media-editorial", "rebuild_compiled_summaries"),
+    ],
+)
+def test_research_mutation_routes_guard_non_research_pack_before_work(
+    temp_vault,
+    monkeypatch,
+    post_ui,
+    path,
+    body,
+    patched_name,
+):
+    import ovp_pipeline.commands.ui_server as ui_server
+
+    monkeypatch.setattr(
+        ui_server,
+        patched_name,
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("mutation should not run")),
+    )
+
+    status, payload = post_ui(temp_vault, path, body)
+
+    parsed = json.loads(payload)
+    assert status == 409
+    assert parsed["status"] == "unsupported_pack"
+```
+
+**Step 4: Test action queue routes use explicit action APIs**
+
+Patch `enqueue_signal_action()` and `run_next_action_queue_item()` on `ui_server.py`. These are workflow operations and must stay out of renderer/view-model code.
+
+```python
+def test_action_enqueue_route_uses_truth_api_action_queue_seam(temp_vault, monkeypatch, post_ui):
+    import ovp_pipeline.commands.ui_server as ui_server
+
+    calls = []
+
+    def fake_enqueue(*args, **kwargs):
+        calls.append(kwargs)
+        return {"status": "queued", "next_path": "/signals"}
+
+    monkeypatch.setattr(ui_server, "enqueue_signal_action", fake_enqueue)
+
+    status, payload = post_ui(
+        temp_vault,
+        "/api/actions/enqueue",
+        "signal_id=sig-1&action_kind=deep_dive_workflow",
+    )
+
+    assert status == 200
+    assert json.loads(payload)["status"] == "queued"
+    assert calls
+```
+
+**Step 5: Run the wiring suite**
+
+Run:
+
+```bash
+PYTHONPATH=src python -m pytest tests/test_workflow_wiring.py -q
+```
+
+Expected before implementation: fail only where the route currently bypasses the intended seam.
+
+**Step 6: Minimal implementation if tests fail**
+
+- Keep route handlers as dispatchers.
+- Move direct mutation logic into `truth_api.py` or the existing governance/action API.
+- Keep renderer functions pure: payload in, HTML out.
+- Keep pack guard checks before any mutation or rebuild call.
+
+**Step 7: Commit after Task 2**
+
+```bash
+git add tests/test_workflow_wiring.py src/ovp_pipeline/commands/ui_server.py src/ovp_pipeline/truth_api.py
+git commit -m "test: lock workflow wiring boundaries"
+```
+
+## Task 3: Add Naming And Product-Surface Fitness Checks
+
+**Files:**
+
+- Create: `tests/test_architecture_fitness.py`
+- Modify if needed: `src/ovp_pipeline/commands/ui_server.py`
+
+Add this header to `tests/test_architecture_fitness.py`:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+```
+
+**Step 1: Add a small banned-term check for reader routes**
+
+Reader routes should not show operator/workflow language on the first screen. Keep the banned list small and concrete.
+
+```python
+@pytest.mark.parametrize("path", ["/", "/search?q=alpha", "/objects"])
+def test_reader_routes_do_not_expose_operator_jargon(
+    temp_vault,
+    fetch_ui,
+    seed_hot_path_vault,
+    path,
+):
+    seed_hot_path_vault(temp_vault)
+
+    status, body, _content_type = fetch_ui(temp_vault, path)
+
+    assert status == 200
+    for banned in ["Workflow Map", "Compile gate", "Projection lifecycle", "source of truth"]:
+        assert banned not in body
+```
+
+**Step 2: Add naming discipline check for public docs**
+
+This is a cheap guard until a real lint script exists. Exclude `ARCHITECTURE.md` from the simple banned-term check because the architecture document intentionally contains do/don't examples for naming discipline.
+
+```python
+def test_readme_and_milestone_avoid_source_of_truth_language(repo_root):
+    docs = [
+        repo_root / "README.md",
+        repo_root / "MILESTONE.md",
+    ]
+    for path in docs:
+        text = path.read_text(encoding="utf-8")
+        assert "source of truth" not in text.lower()
+```
+
+**Step 3: Run the fitness check**
+
+```bash
+PYTHONPATH=src python -m pytest tests/test_architecture_fitness.py -q
+```
+
+Expected: pass after any terminology cleanup.
+
+**Step 4: Commit after Task 3**
+
+```bash
+git add tests/test_architecture_fitness.py README.md ARCHITECTURE.md MILESTONE.md
+git commit -m "test: add lightweight architecture fitness checks"
+```
+
+## Task 4: Consolidate Validation
+
+**Files:**
+
+- Modify only if useful: `Makefile`, `pyproject.toml`, or no files.
+
+**Step 1: Run focused checks**
+
+```bash
+PYTHONPATH=src python -m pytest \
+  tests/test_ui_hot_paths.py \
+  tests/test_workflow_wiring.py \
+  tests/test_architecture_fitness.py \
+  -q
+```
+
+Expected: all tests pass.
+
+**Step 2: Run nearby regression tests**
+
+```bash
+PYTHONPATH=src python -m pytest \
+  tests/test_ui_server.py \
+  tests/test_ui_view_models.py \
+  tests/test_truth_api.py \
+  tests/test_promotion_policy.py \
+  -q
+```
+
+Expected: all tests pass.
+
+**Step 3: Confirm no product route started invoking heavy work**
+
+```bash
+PYTHONPATH=src python -m pytest tests/test_ui_hot_paths.py::test_ui_hot_get_routes_do_not_rebuild_knowledge_db -q
+```
+
+Expected: pass.
+
+**Step 4: Commit validation harness changes if any**
+
+If Task 4 adds a command alias:
+
+```bash
+git add Makefile pyproject.toml
+git commit -m "chore: expose architecture fitness checks"
+```
+
+Skip this commit if no files changed.
+
+## Task 5: PR Scope And Review Checklist
+
+Before opening the implementation PR:
+
+- Confirm all changed files are tests or minimal route/API boundary changes.
+- Confirm no user vault files changed.
+- Confirm no `ovp` CLI workflow was run.
+- Confirm reader routes still use user-facing language and `/ops` remains the operator surface.
+- Confirm any route that mutates Layer 1 state goes through a governance/truth API seam.
+- Confirm every failed hot-path test was fixed by removing accidental heavy work, not by weakening the test.
+
+Final commands:
+
+```bash
+git status -sb
+git diff --check
+PYTHONPATH=src python -m pytest \
+  tests/test_ui_hot_paths.py \
+  tests/test_workflow_wiring.py \
+  tests/test_architecture_fitness.py \
+  tests/test_ui_server.py \
+  tests/test_ui_view_models.py \
+  tests/test_truth_api.py \
+  tests/test_promotion_policy.py \
+  -q
+```
+
+Open a normal implementation PR after these pass. Keep the PR title explicit, for example:
+
+```text
+[codex] Add hot-path and workflow wiring fitness checks
+```


### PR DESCRIPTION
## Summary
- Marks BL-001 / reader shell split as shipped in PR #75 and updates M2/M3/M4 status in English and Chinese docs.
- Moves the next implementation focus to BL-003 + BL-004 across README, Milestone, Architecture, and Backlog.
- Adds a concrete implementation plan for hot-path rebuild guards and workflow wiring fitness checks.

## Validation
- `git diff --check`
- `git diff --cached --check`
- stale-status search for old BL-001/M2/M3/M4 wording

Docs-only PR. No OVP app or pipeline command was run.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/76" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
