### PR TITLE
[codex] Add hot-path and workflow wiring fitness checks

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,9 @@ Pytest fixtures for ovp_pipeline tests.
 import pytest
 import tempfile
 import json
+import threading
 from pathlib import Path
+from http.client import HTTPConnection
 from datetime import datetime
 
 
@@ -24,6 +26,87 @@ def temp_vault(tmp_path):
     (vault / "60-Logs" / "migration-reports").mkdir(parents=True)
 
     return vault
+
+
+@pytest.fixture
+def fetch_ui():
+    def _fetch(temp_vault, path: str) -> tuple[int, str, str]:
+        from ovp_pipeline.commands.ui_server import create_server
+
+        server = create_server(temp_vault, host="127.0.0.1", port=0)
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            conn = HTTPConnection("127.0.0.1", port, timeout=5)
+            conn.request("GET", path)
+            response = conn.getresponse()
+            body = response.read().decode("utf-8")
+            content_type = response.getheader("Content-Type") or ""
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=5)
+        return response.status, body, content_type
+
+    return _fetch
+
+
+@pytest.fixture
+def post_ui():
+    def _post(temp_vault, path: str, body: str) -> tuple[int, str]:
+        from ovp_pipeline.commands.ui_server import create_server
+
+        server = create_server(temp_vault, host="127.0.0.1", port=0)
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            conn = HTTPConnection("127.0.0.1", port, timeout=5)
+            conn.request(
+                "POST",
+                path,
+                body=body,
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+            )
+            response = conn.getresponse()
+            payload = response.read().decode("utf-8")
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=5)
+        return response.status, payload
+
+    return _post
+
+
+@pytest.fixture
+def seed_hot_path_vault():
+    def _seed(temp_vault) -> None:
+        from ovp_pipeline.knowledge_index import rebuild_knowledge_index
+
+        note = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
+        note.write_text(
+            """---
+note_id: alpha
+title: Alpha
+type: evergreen
+date: 2026-04-30
+---
+
+# Alpha
+
+Alpha supports reader-first local knowledge reuse.
+""",
+            encoding="utf-8",
+        )
+        raw_dir = temp_vault / "00-Capture" / "Raw"
+        raw_dir.mkdir(parents=True, exist_ok=True)
+        (raw_dir / "heavy.pdf").write_bytes(b"%PDF-1.4 sentinel")
+        (raw_dir / "heavy.docx").write_bytes(b"PK sentinel")
+        rebuild_knowledge_index(temp_vault)
+
+    return _seed
 
 
 @pytest.fixture

--- a/tests/test_architecture_fitness.py
+++ b/tests/test_architecture_fitness.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+@pytest.mark.parametrize("path", ["/", "/search?q=alpha", "/objects"])
+def test_reader_routes_do_not_expose_operator_jargon(
+    temp_vault,
+    fetch_ui,
+    seed_hot_path_vault,
+    path,
+):
+    seed_hot_path_vault(temp_vault)
+
+    status, body, _content_type = fetch_ui(temp_vault, path)
+
+    assert status == 200
+    for banned in ["Workflow Map", "Compile gate", "Projection lifecycle", "source of truth"]:
+        assert banned not in body
+
+
+def test_readme_and_milestone_avoid_source_of_truth_language(repo_root):
+    docs = [
+        repo_root / "README.md",
+        repo_root / "README.zh-CN.md",
+        repo_root / "MILESTONE.md",
+        repo_root / "MILESTONE.zh-CN.md",
+    ]
+    for path in docs:
+        text = path.read_text(encoding="utf-8")
+        assert "source of truth" not in text.lower()

--- a/tests/test_ui_hot_paths.py
+++ b/tests/test_ui_hot_paths.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import pytest
+
+
+def _forbid_rebuilds(monkeypatch) -> None:
+    def fail(*args, **kwargs):
+        raise AssertionError("hot GET route must not rebuild knowledge.db")
+
+    import ovp_pipeline.knowledge_index as knowledge_index
+    import ovp_pipeline.truth_api as truth_api
+
+    monkeypatch.setattr(knowledge_index, "rebuild_knowledge_index", fail)
+    monkeypatch.setattr(truth_api, "rebuild_knowledge_index", fail)
+
+
+@pytest.mark.parametrize(
+    ("path", "expected_text"),
+    [
+        ("/", "Knowledge Library"),
+        ("/ops", "OVP Truth UI"),
+        ("/objects", "Alpha"),
+        ("/api/objects", '"object_id": "alpha"'),
+        ("/search?q=alpha", "Alpha"),
+        ("/api/search?q=alpha", '"query": "alpha"'),
+    ],
+)
+def test_ui_hot_get_routes_do_not_rebuild_knowledge_db(
+    temp_vault,
+    monkeypatch,
+    fetch_ui,
+    seed_hot_path_vault,
+    path,
+    expected_text,
+):
+    seed_hot_path_vault(temp_vault)
+    _forbid_rebuilds(monkeypatch)
+
+    status, body, _content_type = fetch_ui(temp_vault, path)
+
+    assert status == 200
+    assert expected_text in body

--- a/tests/test_ui_hot_paths.py
+++ b/tests/test_ui_hot_paths.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
+
+RAW_SOURCE_SUFFIXES = {".pdf", ".doc", ".docx", ".ppt", ".pptx", ".xls", ".xlsx"}
 
 
 def _forbid_rebuilds(monkeypatch) -> None:
@@ -12,6 +16,44 @@ def _forbid_rebuilds(monkeypatch) -> None:
 
     monkeypatch.setattr(knowledge_index, "rebuild_knowledge_index", fail)
     monkeypatch.setattr(truth_api, "rebuild_knowledge_index", fail)
+
+
+def _forbid_raw_source_access(monkeypatch) -> None:
+    original_glob = Path.glob
+    original_iterdir = Path.iterdir
+    original_read_bytes = Path.read_bytes
+    original_read_text = Path.read_text
+    original_rglob = Path.rglob
+
+    def assert_not_raw_source(path: Path) -> None:
+        if "Raw" in path.parts or path.suffix.lower() in RAW_SOURCE_SUFFIXES:
+            raise AssertionError(f"hot GET route must not touch raw source path: {path}")
+
+    def guarded_glob(self, pattern):
+        assert_not_raw_source(self)
+        return original_glob(self, pattern)
+
+    def guarded_iterdir(self):
+        assert_not_raw_source(self)
+        return original_iterdir(self)
+
+    def guarded_read_bytes(self):
+        assert_not_raw_source(self)
+        return original_read_bytes(self)
+
+    def guarded_read_text(self, *args, **kwargs):
+        assert_not_raw_source(self)
+        return original_read_text(self, *args, **kwargs)
+
+    def guarded_rglob(self, pattern):
+        assert_not_raw_source(self)
+        return original_rglob(self, pattern)
+
+    monkeypatch.setattr(Path, "glob", guarded_glob)
+    monkeypatch.setattr(Path, "iterdir", guarded_iterdir)
+    monkeypatch.setattr(Path, "read_bytes", guarded_read_bytes)
+    monkeypatch.setattr(Path, "read_text", guarded_read_text)
+    monkeypatch.setattr(Path, "rglob", guarded_rglob)
 
 
 @pytest.mark.parametrize(
@@ -35,6 +77,7 @@ def test_ui_hot_get_routes_do_not_rebuild_knowledge_db(
 ):
     seed_hot_path_vault(temp_vault)
     _forbid_rebuilds(monkeypatch)
+    _forbid_raw_source_access(monkeypatch)
 
     status, body, _content_type = fetch_ui(temp_vault, path)
 

--- a/tests/test_workflow_wiring.py
+++ b/tests/test_workflow_wiring.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+def test_root_and_ops_dispatch_to_distinct_renderers(temp_vault, monkeypatch, fetch_ui):
+    import ovp_pipeline.commands.ui_server as ui_server
+
+    calls = []
+    monkeypatch.setattr(
+        ui_server,
+        "_build_runtime_home_payload_from_query",
+        lambda vault_dir, query: {"screen": "runtime/home", "requested_pack": ""},
+    )
+    monkeypatch.setattr(
+        ui_server,
+        "_render_library_home",
+        lambda payload: calls.append("library") or "<html>library</html>",
+    )
+    monkeypatch.setattr(
+        ui_server,
+        "_render_dashboard",
+        lambda payload: calls.append("dashboard") or "<html>dashboard</html>",
+    )
+
+    assert fetch_ui(temp_vault, "/")[0] == 200
+    assert fetch_ui(temp_vault, "/ops")[0] == 200
+    assert calls == ["library", "dashboard"]
+
+
+def test_candidate_review_route_uses_truth_api_governance_seam(
+    temp_vault, monkeypatch, post_ui
+):
+    import ovp_pipeline.commands.ui_server as ui_server
+
+    calls = []
+
+    def fake_review_candidate_concept(*args, **kwargs):
+        calls.append(kwargs)
+        return {
+            "action": "promote",
+            "mutation": {"action": "promote"},
+            "knowledge_index_rebuilt": False,
+            "next_path": "/candidates",
+        }
+
+    monkeypatch.setattr(ui_server, "review_candidate_concept", fake_review_candidate_concept)
+
+    status, payload = post_ui(
+        temp_vault,
+        "/api/candidates/review",
+        "slug=alpha-candidate&action=promote",
+    )
+
+    assert status == 200
+    assert json.loads(payload)["action"] == "promote"
+    assert calls == [
+        {
+            "slug": "alpha-candidate",
+            "action": "promote",
+            "target_slug": None,
+            "note": "",
+            "pack_name": None,
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    ("path", "body", "patched_name"),
+    [
+        (
+            "/api/evolution/review",
+            "evolution_id=evo-1&status=accepted&pack=media-editorial",
+            "review_evolution_candidate",
+        ),
+        (
+            "/api/candidates/review",
+            "slug=alpha&action=promote&pack=media-editorial",
+            "review_candidate_concept",
+        ),
+        (
+            "/api/summaries/rebuild",
+            "object_id=alpha&pack=media-editorial",
+            "rebuild_compiled_summaries",
+        ),
+    ],
+)
+def test_research_mutation_routes_guard_non_research_pack_before_work(
+    temp_vault,
+    monkeypatch,
+    post_ui,
+    path,
+    body,
+    patched_name,
+):
+    import ovp_pipeline.commands.ui_server as ui_server
+
+    monkeypatch.setattr(
+        ui_server,
+        patched_name,
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("mutation should not run")
+        ),
+    )
+
+    status, payload = post_ui(temp_vault, path, body)
+
+    parsed = json.loads(payload)
+    assert status == 409
+    assert parsed["status"] == "unsupported_pack"
+
+
+def test_action_enqueue_route_uses_truth_api_action_queue_seam(
+    temp_vault, monkeypatch, post_ui
+):
+    import ovp_pipeline.commands.ui_server as ui_server
+
+    calls = []
+
+    def fake_enqueue(*args, **kwargs):
+        calls.append(kwargs)
+        return {"status": "queued", "next_path": "/signals"}
+
+    monkeypatch.setattr(ui_server, "enqueue_signal_action", fake_enqueue)
+
+    status, payload = post_ui(
+        temp_vault,
+        "/api/actions/enqueue",
+        "signal_id=sig-1&action_kind=deep_dive_workflow",
+    )
+
+    assert status == 200
+    assert json.loads(payload)["status"] == "queued"
+    assert calls == [{"signal_id": "sig-1"}]


### PR DESCRIPTION
## Summary
- Add hot-path UI fitness tests proving reader/dashboard/search GET routes do not rebuild knowledge.db when the derived store is current.
- Add workflow wiring tests for the reader vs ops route split, governance/truth API seams, research-only mutation guards, and action queue dispatch.
- Add lightweight architecture fitness checks for reader-facing jargon and public docs naming discipline.

## Validation
- `git diff --check`
- `PYTHONPATH=src python -m pytest tests/test_ui_hot_paths.py tests/test_workflow_wiring.py tests/test_architecture_fitness.py -q` -> 16 passed
- `PYTHONPATH=src python -m pytest tests/test_ui_server.py tests/test_ui_view_models.py tests/test_truth_api.py tests/test_promotion_policy.py -q` -> 297 passed

No OVP app or pipeline command was run.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/77" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
