### PR TITLE
[codex] Label projection surfaces

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -658,8 +658,8 @@ Current implementation roughly maps as follows:
 Main gaps:
 
 - Layer 1 claim/evidence contracts are not explicit enough yet.
-- Layer 2 / Layer 3 projection labels are incomplete.
-- Layer 4 fitness checks are not fully implemented.
+- Layer 2 / Layer 3 projection labels now exist on core access payloads and materialized reader artifacts; doctor/export enforcement and future surfaces still need to consume them consistently.
+- Layer 4 fitness checks now cover the first hot-path and workflow-wiring cases; evidence completeness, projection replay, and import-boundary checks are still open.
 - Projection lifecycle markers need structured schema, scope, lease, and supersession.
 - Schema versioning is not yet wired into projection lifecycle.
 - The reader-first home is now the default entry; object pages, graph, backlinks, and search still need product shape.
@@ -668,12 +668,12 @@ Main gaps:
 
 Recommended order:
 
-1. Move backlog mapping out of architecture prose and into `BACKLOG.md`.
-2. Implement the first fitness checks for hot-path access, workflow wiring, read/write boundary, and naming discipline.
-3. Add projection labels for dashboard, MOC, wiki, briefing, reader pages, graph, and context packs.
-4. Introduce structured `ProjectionRepairMarker` schema.
-5. Add schema version fields to Authority and derived projection state.
-6. Continue reader-first Layer 3 product work on object pages, graph, backlinks, and search.
+1. Keep projection metadata attached to new access surfaces and add doctor/export checks that verify the labels are present.
+2. Continue reader-first Layer 3 product work on object pages, graph, backlinks, and search.
+3. Add evidence spans and factual evidence completeness checks.
+4. Add candidate risk tiers and routing preview before expanding automatic promotion.
+5. Introduce structured `ProjectionRepairMarker` schema.
+6. Add schema version fields to Authority and derived projection state.
 
 ## Appendix: Backlog Mapping
 
@@ -681,9 +681,9 @@ The architecture should not depend on backlog IDs to be valid. The table below i
 
 | Architecture work | Current backlog/task mapping |
 | --- | --- |
-| Projection marking | `BL-002`, `KSR-002` |
-| Dashboard/search hot-path audit | `BL-003`, `KSR-015` |
-| Workflow wiring eval suite | `BL-004`, `KSR-026` |
+| Projection marking | `BL-002`, `KSR-002` shipped in PR #78 |
+| Dashboard/search hot-path audit | `BL-003`, `KSR-015` shipped in PR #77 |
+| Workflow wiring eval suite | `BL-004`, `KSR-026` shipped in PR #77 |
 | Evidence span / factual evidence completeness | `BL-006`, `KSR-001`, `KSR-018` |
 | Candidate risk layering | `BL-007`, `KSR-003` |
 | Reader-first access surfaces | `BL-001`, `BL-008`, `BL-009`, `BL-010` |

--- a/ARCHITECTURE.zh-CN.md
+++ b/ARCHITECTURE.zh-CN.md
@@ -766,13 +766,13 @@ Do not rely on ad hoc "just rerun the pipeline" behavior for schema changes.
 
 - canonical artifact contract 还不够一等公民化。
 - Layer 4 子轴还没有完全反映到代码结构。
-- projection labels 没有贯穿 dashboard、MOC、wiki、briefing、graph、reader page、context pack。
+- projection labels 已经贯穿核心 access payload 和 materialized reader artifacts；doctor/export enforcement 以及未来新增 surface 还需要持续消费这些标注。
 - projection lifecycle marker 还没有明确区分 metadata_only / full_rebuild / semantic_reindex。
-- dashboard/search hot path 还需要显式保证不触发重 raw scan / LLM / embedding。
+- dashboard/search hot path 和 workflow wiring 已经有第一批 fitness checks；evidence completeness、projection replay、import-boundary checks 仍未完成。
 - context assembly recipes 还需要收束。
 - governance / resolver contracts 还需要显式化。
 - schema versioning 和 projection compatibility 还需要工程化。
-- fitness functions 还没有落地到 CI/doctor/pre-commit。
+- fitness functions 只落地了第一批，仍需扩展到 CI/doctor/pre-commit 的完整契约。
 - reader-first home 已经成为默认入口；object page、graph、backlink、search 还需要继续产品化。
 
 ## 17. 近期架构动作
@@ -781,16 +781,14 @@ Do not rely on ad hoc "just rerun the pipeline" behavior for schema changes.
 
 优先顺序：
 
-1. 明确并文档化 Layer 4 子轴：Policy / Review / Verification / Routing / Repair / Audit。
-2. 给关键路径补 canonical scenarios，并以 scenarios 推导 invariants。
-3. 建立最小 architectural fitness functions。
-4. 明确哪些文件、registry、audit event 是 Authority。
-5. 给 `knowledge.db` 内部 projection 分类。
-6. 先把 dashboard/search hot-path eval、workflow wiring eval、read/write boundary、naming discipline 做成第一批 fitness functions。
-7. 给 dashboard、MOC、wiki、briefing、graph、reader page、context pack 加 projection label。
-8. 引入结构化 ProjectionRepairMarker。
-9. 把 routing、promotion、review、permission 从 prompt/散落代码中收束为显式 governance/dispatch contract。
-10. 预留 semantic_reindex lifecycle kind，但不提前锁定 LanceDB 或其它 backend。
+1. 新增 access surface 时必须继续带 projection metadata，并补 doctor/export checks 验证标注存在。
+2. 继续做 reader-first Layer 3：object page、graph、backlink、search 的产品化。
+3. 补 evidence span 和 factual evidence completeness checks。
+4. 补 candidate risk tiers 和 routing preview，再扩大自动 promotion。
+5. 引入结构化 ProjectionRepairMarker。
+6. 给 Authority 和 derived projection state 增加 schema version 字段。
+7. 把 routing、promotion、review、permission 从 prompt/散落代码中收束为显式 governance/dispatch contract。
+8. 预留 semantic_reindex lifecycle kind，但不提前锁定 LanceDB 或其它 backend。
 
 ## Appendix: Backlog Mapping
 
@@ -798,9 +796,9 @@ Do not rely on ad hoc "just rerun the pipeline" behavior for schema changes.
 
 | 架构工作 | 当前 backlog/task 对应 |
 | --- | --- |
-| Projection marking | `BL-002`, `KSR-002` |
-| Dashboard/search hot-path audit | `BL-003`, `KSR-015` |
-| Workflow wiring eval suite | `BL-004`, `KSR-026` |
+| Projection marking | `BL-002`, `KSR-002` PR #78 已交付 |
+| Dashboard/search hot-path audit | `BL-003`, `KSR-015` PR #77 已交付 |
+| Workflow wiring eval suite | `BL-004`, `KSR-026` PR #77 已交付 |
 | Evidence span / factual evidence completeness | `BL-006`, `KSR-001`, `KSR-018` |
 | Candidate risk layering | `BL-007`, `KSR-003` |
 | Reader-first access surfaces | `BL-001`, `BL-008`, `BL-009`, `BL-010` |

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -22,7 +22,7 @@ Rule: historical plans and vault research notes feed this file; they do not over
 | M1 Operator Workbench And Review Runtime | Done / maintain | truth UI, candidates, signals/actions, contradictions, action worker |
 | M2 Roadmap And README Consolidation | Done | merged historical milestones, compiler roadmap, recent KSR input, reader-product research, and English-primary docs |
 | M3 Reader-First Knowledge Atlas | Active | reader home and `/ops` split shipped; object pages, backlinks, and graph still need product shape |
-| M4 KSR Safety And Hot-Path Hardening | Active | next implementation wave for projection labels, hot-path audit, wiring evals, routing preview, evidence spans, candidate risk |
+| M4 KSR Safety And Hot-Path Hardening | Active | projection labels, hot-path audit, and wiring evals shipped; routing preview, evidence spans, and candidate risk remain |
 | M5 Context Pack And Operational Runtime | Later | session snapshots, context budget, claim leases, provider facade, observability |
 | M6 Policy, Permission, And Knowledge Evolution | Later | permission layer, claim lifecycle, conflict detection, policy promotion |
 | M7 Semantic Extraction And Query Feedback Loop | Later | relation extractor, query feedback, routines, notebook/raw-source mode |
@@ -33,9 +33,9 @@ Rule: historical plans and vault research notes feed this file; they do not over
 | --- | --- | --- | --- | --- |
 | BL-000 | P0 | Done | Commit current roadmap/README/backlog consolidation, including English-primary README/Architecture/Milestone docs with Chinese alternates | M2, PR #74 |
 | BL-001 | P0 | Done | Reader shell route split: make `/` a Knowledge Atlas home and move current dashboard to `/ops` | M3, reader-product note, PR #75 |
-| BL-002 | P0 | Next | Projection marking: label dashboard, MOC, wiki, briefing, reader pages, graph, and context packs as projections | M4, KSR-002 |
-| BL-003 | P0 | Active | Dashboard/search hot-path audit: default UI/search paths must not scan raw/PDF/Office sources | M4, KSR-015, `docs/plans/2026-04-30-bl-003-004-hot-path-wiring-safety.md` |
-| BL-004 | P0 | Active | Workflow wiring eval suite for lifecycle routing, promote gates, projection labels, hot paths, and read/write boundaries | M4, KSR-026, `docs/plans/2026-04-30-bl-003-004-hot-path-wiring-safety.md` |
+| BL-002 | P0 | Done | Projection marking: label dashboard, MOC, wiki, briefing, reader pages, graph, and context packs as projections | M4, KSR-002, PR #78 |
+| BL-003 | P0 | Done | Dashboard/search hot-path audit: default UI/search paths must not scan raw/PDF/Office sources | M4, KSR-015, `docs/plans/2026-04-30-bl-003-004-hot-path-wiring-safety.md`, PR #77 |
+| BL-004 | P0 | Done | Workflow wiring eval suite for lifecycle routing, promote gates, projection labels, hot paths, and read/write boundaries | M4, KSR-026, `docs/plans/2026-04-30-bl-003-004-hot-path-wiring-safety.md`, PR #77 |
 | BL-005 | P0 | Next | Article routing preview before source lifecycle changes | M4, KSR-014 |
 | BL-006 | P0 | Next | Evidence span schema and markdown-aware locator backfill | M4, KSR-001, KSR-018 |
 | BL-007 | P0 | Next | Candidate risk layering by evidence strength, identity ambiguity, sensitivity, and impact | M4, KSR-003 |
@@ -59,20 +59,20 @@ Rule: historical plans and vault research notes feed this file; they do not over
 | KSR ID | Backlog mapping | Current status in this backlog |
 | --- | --- | --- |
 | KSR-001 Evidence span 化 | BL-006 | Next |
-| KSR-002 Projection 标注 | BL-002 | Next |
+| KSR-002 Projection 标注 | BL-002 | Done |
 | KSR-003 Candidate 风险分层 | BL-007 | Next |
 | KSR-004 Session snapshot/context pack | BL-013 | Later |
 | KSR-005 Permission layer 分离 | BL-015 | Later |
 | KSR-006 Claim lifecycle 字段 | BL-015 | Later |
 | KSR-007 Conflict detection 常规化 | BL-016 | Later |
 | KSR-008 High-risk user profile gate | BL-016 | Later |
-| KSR-009 Cost-aware workflow routing | BL-003/BL-005 | Next |
+| KSR-009 Cost-aware workflow routing | BL-003/BL-005 | Partial: hot-path guard done; article routing preview remains |
 | KSR-010 Skill/routine extraction profile | BL-019 | Later |
 | KSR-011 Notebook/raw-source mode | BL-019 | Later |
 | KSR-012 Ingest ROI metrics | BL-019 | Later |
 | KSR-013 Source lifecycle idempotency | M0/M4 | Repo first slice done; verify and mirror vault status |
 | KSR-014 Article routing preview | BL-005 | Next |
-| KSR-015 Dashboard/search hot-path audit | BL-003 | Next |
+| KSR-015 Dashboard/search hot-path audit | BL-003 | Done |
 | KSR-016 Hybrid retrieval experiment | BL-019 | Later |
 | KSR-017 Explicit context budget | BL-013 | Later |
 | KSR-018 Markdown-aware evidence chunking | BL-006 | Next |
@@ -83,20 +83,20 @@ Rule: historical plans and vault research notes feed this file; they do not over
 | KSR-023 Pipeline observability metrics | BL-014 | Later |
 | KSR-024 Candidate compaction with restore | BL-016 | Later |
 | KSR-025 Context provider facade | BL-014 | Later |
-| KSR-026 Workflow wiring eval suite | BL-004 | Next |
+| KSR-026 Workflow wiring eval suite | BL-004 | Done |
 | KSR-027 Live-source routing policy | BL-005/BL-014 | Later |
 | KSR-028 Schema-on-demand guard | BL-017 | Later |
 | KSR-029 Follow-up object model | BL-019 | Later |
 
 ## Next Decision
 
-`BL-001` is shipped in PR #75, so the default UI now has a reader-first entry point and `/ops` owns the operator dashboard.
+`BL-001` is shipped in PR #75, `BL-003 + BL-004` are shipped in PR #77, and `BL-002` is shipped in PR #78. The default UI now has a reader-first entry point, `/ops` owns the operator dashboard, and core access/materialized surfaces carry explicit projection labels.
 
-The next implementation PR should be the **BL-003 + BL-004 safety pass**. It protects the new default product entry by proving that reader/search/dashboard routes do not trigger heavy raw-source scans and by adding no-LLM wiring evals for the critical routing and read/write boundaries.
+The next implementation PR should move back to the reader product shape: **BL-008 + BL-009**. The projection boundary is now explicit enough to improve object pages and backlink/source rails without making those surfaces look like canonical truth.
 
 Recommended order:
 
-1. BL-003 + BL-004
-2. BL-002
-3. BL-008 + BL-009
-4. BL-010
+1. BL-008 + BL-009
+2. BL-010
+3. BL-005
+4. BL-006 + BL-007

--- a/MILESTONE.md
+++ b/MILESTONE.md
@@ -34,7 +34,7 @@ That means the user-facing product should make compiled knowledge easy to read f
 | M1 Operator Workbench And Review Runtime | Done / maintain | truth UI, candidates, signals/actions, contradictions, action worker |
 | M2 Roadmap And README Consolidation | Done | merged historical milestones, compiler roadmap, recent KSR input, reader-product research, and the English-primary docs structure |
 | M3 Reader-First Knowledge Atlas | Active | reader home and `/ops` split shipped; objects, backlinks, and graph remain the next product surfaces |
-| M4 KSR Safety And Hot-Path Hardening | Active | next implementation wave for projection labels, hot-path audit, wiring evals, routing preview, evidence spans, candidate risk |
+| M4 KSR Safety And Hot-Path Hardening | Active | projection labels, hot-path audit, and wiring evals shipped; routing preview, evidence spans, and candidate risk remain |
 | M5 Context Pack And Operational Runtime | Later | session snapshots, context budget, claim leases, provider facade, observability |
 | M6 Policy, Permission, And Knowledge Evolution | Later | permission layer, claim lifecycle, conflict detection, policy promotion |
 | M7 Semantic Extraction And Query Feedback Loop | Later | relation extractor, query feedback, routines, notebook/raw-source mode |
@@ -44,9 +44,9 @@ That means the user-facing product should make compiled knowledge easy to read f
 | Architecture / product work | Active backlog mapping |
 | --- | --- |
 | Reader shell route split | `BL-001` done in PR #75 |
-| Projection marking | `BL-002`, `KSR-002` |
-| Dashboard/search hot-path audit | `BL-003`, `KSR-015` |
-| Workflow wiring eval suite | `BL-004`, `KSR-026` |
+| Projection marking | `BL-002`, `KSR-002` done in PR #78 |
+| Dashboard/search hot-path audit | `BL-003`, `KSR-015` done in PR #77 |
+| Workflow wiring eval suite | `BL-004`, `KSR-026` done in PR #77 |
 | Article routing preview | `BL-005`, `KSR-014` |
 | Evidence span / factual evidence completeness | `BL-006`, `KSR-001`, `KSR-018` |
 | Candidate risk layering | `BL-007`, `KSR-003` |
@@ -59,10 +59,10 @@ That means the user-facing product should make compiled knowledge easy to read f
 
 Recommended order:
 
-1. Implement `BL-003 + BL-004`: lock the hot paths and wiring boundaries now that the reader surface is the default entry.
-2. Implement `BL-002`: label reader, dashboard, graph, briefing, and context-pack surfaces as projections.
-3. Implement `BL-008 + BL-009`: make object pages readable and add source/backlink rails.
-4. Implement `BL-010`: ship the visual `/graph` MVP as a spatial corpus map.
+1. Implement `BL-008 + BL-009`: make object pages readable and add source/backlink rails.
+2. Implement `BL-010`: ship the visual `/graph` MVP as a spatial corpus map.
+3. Implement `BL-005`: add article routing preview before source lifecycle changes.
+4. Implement `BL-006 + BL-007`: evidence spans and candidate risk layering.
 
 ## Documentation Rules
 

--- a/MILESTONE.zh-CN.md
+++ b/MILESTONE.zh-CN.md
@@ -34,7 +34,7 @@ OVP 正在从 document-processing pipeline 变成：
 | M1 Operator Workbench And Review Runtime | Done / maintain | truth UI、candidates、signals/actions、contradictions、action worker |
 | M2 Roadmap And README Consolidation | Done | 已合并历史 milestones、compiler roadmap、近期 KSR 输入、reader-product 研究，以及英文主文档结构 |
 | M3 Reader-First Knowledge Atlas | Active | reader home 和 `/ops` 拆分已交付；object pages、backlinks、graph 仍是下一批产品化 surface |
-| M4 KSR Safety And Hot-Path Hardening | Active | 下一批实施重点：projection labels、hot-path audit、wiring evals、routing preview、evidence spans、candidate risk |
+| M4 KSR Safety And Hot-Path Hardening | Active | projection labels、hot-path audit、wiring evals 已交付；routing preview、evidence spans、candidate risk 仍待推进 |
 | M5 Context Pack And Operational Runtime | Later | session snapshots、context budget、claim leases、provider facade、observability |
 | M6 Policy, Permission, And Knowledge Evolution | Later | permission layer、claim lifecycle、conflict detection、policy promotion |
 | M7 Semantic Extraction And Query Feedback Loop | Later | relation extractor、query feedback、routines、notebook/raw-source mode |
@@ -44,9 +44,9 @@ OVP 正在从 document-processing pipeline 变成：
 | 架构 / 产品工作 | Active backlog 映射 |
 | --- | --- |
 | Reader shell route split | `BL-001` 已在 PR #75 交付 |
-| Projection marking | `BL-002`, `KSR-002` |
-| Dashboard/search hot-path audit | `BL-003`, `KSR-015` |
-| Workflow wiring eval suite | `BL-004`, `KSR-026` |
+| Projection marking | `BL-002`, `KSR-002` 已在 PR #78 交付 |
+| Dashboard/search hot-path audit | `BL-003`, `KSR-015` 已在 PR #77 交付 |
+| Workflow wiring eval suite | `BL-004`, `KSR-026` 已在 PR #77 交付 |
 | Article routing preview | `BL-005`, `KSR-014` |
 | Evidence span / factual evidence completeness | `BL-006`, `KSR-001`, `KSR-018` |
 | Candidate risk layering | `BL-007`, `KSR-003` |
@@ -59,10 +59,10 @@ OVP 正在从 document-processing pipeline 变成：
 
 建议顺序：
 
-1. 实施 `BL-003 + BL-004`：reader surface 已成为默认入口，先锁住 hot path 和 wiring boundary。
-2. 实施 `BL-002`：把 reader、dashboard、graph、briefing、context pack 等 surface 标注为 projection。
-3. 实施 `BL-008 + BL-009`：让 object page 更可读，并补 source/backlink rail。
-4. 实施 `BL-010`：把 `/graph` 做成 spatial corpus map 的 MVP。
+1. 实施 `BL-008 + BL-009`：让 object page 更可读，并补 source/backlink rail。
+2. 实施 `BL-010`：把 `/graph` 做成 spatial corpus map 的 MVP。
+3. 实施 `BL-005`：在 source lifecycle 继续变化前补 article routing preview。
+4. 实施 `BL-006 + BL-007`：推进 evidence span 和 candidate risk layering。
 
 ## 文档规则
 

--- a/README.md
+++ b/README.md
@@ -95,10 +95,16 @@ Current milestone sequence:
 | M1 Operator Workbench And Review Runtime | Complete enough | truth UI, candidates, signals/actions, contradictions, action worker |
 | M2 Roadmap And README Consolidation | Complete | merged historical milestones, compiler roadmap, recent KSR input, and reader-product research |
 | M3 Reader-First Knowledge Atlas | Active | reader home and `/ops` split shipped; object and graph pages still need product shape |
-| M4 KSR Safety And Hot-Path Hardening | Active | hot-path audit and wiring evals are next, followed by evidence spans, projection labels, candidate risk tiers, routing preview |
+| M4 KSR Safety And Hot-Path Hardening | Active | projection labels, hot-path audit, and wiring evals have shipped; evidence spans, candidate risk tiers, routing preview, and product-facing object/graph polish are next |
 | M5 Context Pack And Operational Runtime | Later | session snapshots, context budget, claim leases, provider facades, observability |
 | M6 Policy, Permission, And Knowledge Evolution | Later | permission layer, claim lifecycle, conflict detection, policy promotion |
 | M7 Semantic Extraction And Query Feedback Loop | Later | relation extractor, query feedback, skill/routine extraction, notebook/raw-source mode |
+
+Current active backlog focus:
+
+- Shipped: `KSR-002` projection labels, `KSR-015` dashboard/search hot-path audit, `KSR-026` workflow wiring eval suite.
+- Next: `KSR-014` article routing preview, `KSR-001` evidence spans, `KSR-003` candidate risk tiers.
+- Product track: reader-first Knowledge Atlas stays a projection layer, not a new state system.
 
 ## Domain Packs
 
@@ -189,7 +195,7 @@ The built-in profiles currently shipped are:
 - `ovp-truth`
   reads object / contradiction / neighborhood truth rows directly from `knowledge.db`
 - `ovp-ui`
-  launches a local UI. The current default page is operator-oriented; the roadmap moves the reader-facing atlas to the homepage and keeps the current dashboard under `/ops`.
+  launches a local UI. The default `/` entry is the reader-first Knowledge Library; the operator dashboard lives under `/ops`.
 - `docs/research-tech/RESEARCH_TECH_SKILLPACK.md`
 - `docs/research-tech/RESEARCH_TECH_VERIFY.md`
 - `docs/recipes/research-tech/*.md`
@@ -522,7 +528,7 @@ HTTP_PROXY=http://127.0.0.1:7897
 - vault files + registry define canonical state
 - `knowledge.db` is derived retrieval, never a second Authority
 - absorb is part of daily automation; refine is powerful and opt-in by default
-- Wiki, MOC, dashboard, briefing, and context packs are projections that must trace back to source/evidence
+- Wiki, MOC, dashboard, briefing, graph, reader pages, and context packs are projections that carry explicit projection metadata and must trace back to source/evidence
 - reader-facing UI should explain knowledge first, then expose operator/debug detail
 - docs must describe what actually ships, not a future architecture sketch
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -93,20 +93,16 @@ Obsidian Vault Pipeline（OVP）不是一个“多脚本拼装包”，也不只
 | M1 Operator Workbench And Review Runtime | Complete enough | truth UI、candidates、signals/actions、contradictions、action worker |
 | M2 Roadmap And README Consolidation | Complete | 已合并历史 milestone、compiler roadmap、近期 KSR 输入与 reader-product 研究，重整 README |
 | M3 Reader-First Knowledge Atlas | Active | reader home 和 `/ops` 拆分已交付；object page / graph page 仍需产品化 |
-| M4 KSR Safety And Hot-Path Hardening | Active | 下一步先做 hot-path audit 和 wiring eval，再推进 evidence span、projection 标注、candidate 风险分层、routing preview |
+| M4 KSR Safety And Hot-Path Hardening | Active | projection 标注、hot-path audit、wiring eval 已交付；下一步推进 evidence span、candidate 风险分层、routing preview，以及 object/graph 的产品化 |
 | M5 Context Pack And Operational Runtime | Later | session snapshot、context budget、claim lease、provider facade、observability |
 | M6 Policy, Permission, And Knowledge Evolution | Later | permission layer、claim lifecycle、conflict detection、policy promotion |
 | M7 Semantic Extraction And Query Feedback Loop | Later | relation extractor、query feedback、skill/routine extraction、notebook/raw-source mode |
 
-当前 P0 候选 backlog（合并草案）：
+当前 active backlog 重点：
 
-- `KSR-002` Projection 标注
-- `KSR-015` Dashboard/search hot-path audit
-- `KSR-026` Workflow wiring eval suite
-- `KSR-014` Article routing preview
-- `KSR-001` Evidence span 化
-- `KSR-003` Candidate 风险分层
-- Reader-first Knowledge Atlas（产品 P0，作为 projection layer 实现，不另建状态系统）
+- 已交付：`KSR-002` Projection 标注、`KSR-015` Dashboard/search hot-path audit、`KSR-026` Workflow wiring eval suite。
+- 下一步：`KSR-014` Article routing preview、`KSR-001` Evidence span 化、`KSR-003` Candidate 风险分层。
+- 产品线：Reader-first Knowledge Atlas 作为 projection layer 实现，不另建状态系统。
 
 ## Domain Packs
 
@@ -198,7 +194,7 @@ profile 是某个 pack 下的一条可执行 DAG。
 - `ovp-truth`
   直接读取 `knowledge.db` 中的 object / contradiction / neighborhood truth rows
 - `ovp-ui`
-  启动一个本地 UI。当前默认页偏 operator dashboard；路线图会把 reader-facing atlas 设为首页，并把现有 dashboard 移到 `/ops`
+  启动一个本地 UI。默认 `/` 入口是 reader-first Knowledge Library；operator dashboard 放在 `/ops`
 - `docs/research-tech/RESEARCH_TECH_SKILLPACK.md`
 - `docs/research-tech/RESEARCH_TECH_VERIFY.md`
 - `docs/recipes/research-tech/*.md`
@@ -570,7 +566,7 @@ HTTP_PROXY=http://127.0.0.1:7897
 - `registry` 与文件系统共同定义 canonical 状态
 - `knowledge.db` 只做 derived retrieval，不做第二真相源
 - 吸收是日常自动化的一部分；整形是强能力，但默认 opt-in
-- Wiki、MOC、Dashboard、Briefing、Context Pack 都是 projection，必须能追回 source/evidence
+- Wiki、MOC、Dashboard、Briefing、Graph、Reader Page、Context Pack 都是 projection，已带显式 projection metadata，并且必须能追回 source/evidence
 - Reader-facing UI 应先让用户理解知识，再暴露 operator/debug 细节
 - 文档必须描述“现在真实能跑的东西”，不是未来路线图
 

--- a/src/ovp_pipeline/commands/working_memory.py
+++ b/src/ovp_pipeline/commands/working_memory.py
@@ -39,8 +39,10 @@ from pathlib import Path
 from typing import Any
 
 try:
+    from ..projection_labels import frontmatter_projection_fields
     from ..runtime import VaultLayout, resolve_vault_dir
 except ImportError:
+    from ovp_pipeline.projection_labels import frontmatter_projection_fields  # type: ignore
     from ovp_pipeline.runtime import VaultLayout, resolve_vault_dir  # type: ignore
 
 
@@ -291,7 +293,23 @@ def build_working_memory(
         evolves_today=_evolves_today(layout, since=since),
         pulse_highlights=_pulse_highlights(layout, since=since),
     )
-    output_path.write_text(body, encoding="utf-8")
+    frontmatter = (
+        "---\n"
+        "type: working_memory\n"
+        f"date: {target_date.isoformat()}\n"
+        + "\n".join(
+            frontmatter_projection_fields(
+                surface="working_memory",
+                projection_kind="context_pack_projection",
+                owner_pack="research-tech",
+                generated_by="build_working_memory",
+                derived_from=("knowledge.db", "crystals", "audit ledgers"),
+                rebuild_policy="on_derived_refresh",
+            )
+        )
+        + "\n---\n\n"
+    )
+    output_path.write_text(frontmatter + body, encoding="utf-8")
     return output_path
 
 

--- a/src/ovp_pipeline/materializers/cluster_crystal.py
+++ b/src/ovp_pipeline/materializers/cluster_crystal.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from urllib.parse import quote
 
+from ..projection_labels import markdown_projection_lines
 from ..runtime import VaultLayout, resolve_vault_dir
 from ..ui.view_models import build_cluster_detail_payload
 
@@ -25,6 +26,14 @@ def materialize_cluster_crystal(vault_dir: Path, *, pack_name: str, cluster_id: 
         "",
         f"- pack: {pack_name}",
         "- builder: cluster_crystal",
+        *markdown_projection_lines(
+            surface="cluster_crystal",
+            projection_kind="compiled_wiki_projection",
+            owner_pack=pack_name,
+            generated_by="materialize_cluster_crystal",
+            derived_from=("knowledge.db.graph_clusters", "knowledge.db.graph_edges"),
+            rebuild_policy="on_demand_or_refresh",
+        ),
         f"- cluster_kind: {cluster['cluster_kind']}",
         f"- center: [[{cluster['center_object_id']}]]",
         f"- member_count: {cluster['member_count']}",

--- a/src/ovp_pipeline/materializers/cluster_view.py
+++ b/src/ovp_pipeline/materializers/cluster_view.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from ..derived.paths import compiled_view_path
+from ..projection_labels import markdown_projection_lines
 from ..runtime import VaultLayout, resolve_vault_dir
 from ..ui.view_models import build_cluster_browser_payload
 
@@ -21,6 +22,14 @@ def materialize_cluster_view(vault_dir: Path, *, pack_name: str, view_name: str)
         "",
         f"- pack: {pack_name}",
         "- builder: cluster_view",
+        *markdown_projection_lines(
+            surface="cluster_view",
+            projection_kind="compiled_wiki_projection",
+            owner_pack=pack_name,
+            generated_by="materialize_cluster_view",
+            derived_from=("knowledge.db.graph_clusters", "knowledge.db.graph_edges"),
+            rebuild_policy="on_derived_refresh",
+        ),
         "",
         "## Graph Clusters",
         "",

--- a/src/ovp_pipeline/materializers/contradiction_view.py
+++ b/src/ovp_pipeline/materializers/contradiction_view.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from ..derived.paths import compiled_view_path
 from ..knowledge_index import list_contradictions
+from ..projection_labels import markdown_projection_lines
 from ..runtime import VaultLayout, resolve_vault_dir
 
 
@@ -20,6 +21,14 @@ def materialize_contradiction_view(vault_dir: Path, *, pack_name: str, view_name
         "",
         f"- pack: {pack_name}",
         "- builder: contradiction_view",
+        *markdown_projection_lines(
+            surface="contradiction_view",
+            projection_kind="compiled_wiki_projection",
+            owner_pack=pack_name,
+            generated_by="materialize_contradiction_view",
+            derived_from=("knowledge.db.contradictions", "review audit"),
+            rebuild_policy="on_derived_refresh",
+        ),
         "",
         "## Contradiction Records",
         "",

--- a/src/ovp_pipeline/materializers/crystal.py
+++ b/src/ovp_pipeline/materializers/crystal.py
@@ -32,6 +32,8 @@ from datetime import date as _date_cls
 from pathlib import Path
 from typing import Any, Iterable
 
+from ..projection_labels import frontmatter_projection_fields
+
 CRYSTAL_DIR = ("40-Resources", "Crystals")
 ASSEMBLY_RECIPE = "operator_briefing"
 
@@ -290,7 +292,18 @@ def materialize_crystal(
         f"type: crystal\n"
         f"date: {target_date.isoformat()}\n"
         f"pack: {pack_name}\n"
-        f"assembly_recipe: {ASSEMBLY_RECIPE}\n"
+        + "\n".join(
+            frontmatter_projection_fields(
+                surface="crystal",
+                projection_kind="context_pack_projection",
+                owner_pack=pack_name,
+                generated_by="materialize_crystal",
+                derived_from=("briefing snapshot", "knowledge.db.graph_edges"),
+                rebuild_policy="on_demand_or_refresh",
+            )
+        )
+        + "\n"
+        + f"assembly_recipe: {ASSEMBLY_RECIPE}\n"
         f"source_object_ids: {_yaml_list(object_ids)}\n"
         f"evolves_relations:{_evolves_yaml(relations)}\n"
         "---\n\n"

--- a/src/ovp_pipeline/materializers/event_dossier.py
+++ b/src/ovp_pipeline/materializers/event_dossier.py
@@ -4,6 +4,7 @@ import sqlite3
 from pathlib import Path
 
 from ..derived.paths import compiled_view_path
+from ..projection_labels import markdown_projection_lines
 from ..runtime import VaultLayout, resolve_vault_dir
 
 
@@ -29,6 +30,14 @@ def materialize_event_dossier(vault_dir: Path, *, pack_name: str, view_name: str
         "",
         f"- pack: {pack_name}",
         "- builder: event_dossier",
+        *markdown_projection_lines(
+            surface="event_dossier",
+            projection_kind="compiled_wiki_projection",
+            owner_pack=pack_name,
+            generated_by="materialize_event_dossier",
+            derived_from=("knowledge.db.timeline_events",),
+            rebuild_policy="on_derived_refresh",
+        ),
         "",
         "## Timeline",
         "",

--- a/src/ovp_pipeline/materializers/object_page.py
+++ b/src/ovp_pipeline/materializers/object_page.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from ..projection_labels import markdown_projection_lines
 from ..runtime import VaultLayout, resolve_vault_dir
 from ..truth_api import get_object_detail
 
@@ -25,6 +26,14 @@ def materialize_object_page(vault_dir: Path, *, pack_name: str, object_id: str) 
         f"- object_id: {object_id}",
         f"- object_kind: {object_kind}",
         f"- pack: {pack_name}",
+        *markdown_projection_lines(
+            surface="object_page",
+            projection_kind="compiled_wiki_projection",
+            owner_pack=pack_name,
+            generated_by="materialize_object_page",
+            derived_from=("knowledge.db",),
+            rebuild_policy="on_demand_or_refresh",
+        ),
         f"- canonical_path: {canonical_path}",
         "",
         "## Compiled Summary",

--- a/src/ovp_pipeline/materializers/topic_view.py
+++ b/src/ovp_pipeline/materializers/topic_view.py
@@ -4,6 +4,7 @@ import sqlite3
 from pathlib import Path
 
 from ..derived.paths import compiled_view_path
+from ..projection_labels import markdown_projection_lines
 from ..runtime import VaultLayout, resolve_vault_dir
 
 
@@ -39,6 +40,14 @@ def materialize_topic_view(vault_dir: Path, *, pack_name: str, view_name: str) -
         "",
         f"- pack: {pack_name}",
         "- builder: topic_view",
+        *markdown_projection_lines(
+            surface="topic_view",
+            projection_kind="compiled_wiki_projection",
+            owner_pack=pack_name,
+            generated_by="materialize_topic_view",
+            derived_from=("knowledge.db",),
+            rebuild_policy="on_derived_refresh",
+        ),
         "",
         "## Object Summaries",
         "",

--- a/src/ovp_pipeline/projection_labels.py
+++ b/src/ovp_pipeline/projection_labels.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+PROJECTION_LABEL_SCHEMA_VERSION = 1
+PROJECTION_AUTHORITY_BOUNDARY = "derived_not_authority"
+
+
+def projection_label(
+    *,
+    surface: str,
+    projection_kind: str,
+    layer: str,
+    owner_pack: str,
+    generated_by: str,
+    derived_from: Iterable[str],
+    rebuild_policy: str,
+) -> dict[str, object]:
+    return {
+        "projection_schema_version": PROJECTION_LABEL_SCHEMA_VERSION,
+        "projection_kind": projection_kind,
+        "projection_surface": surface,
+        "projection_layer": layer,
+        "projection_owner_pack": owner_pack,
+        "projection_generated_by": generated_by,
+        "projection_derived_from": list(derived_from),
+        "projection_rebuild_policy": rebuild_policy,
+        "projection_authority_boundary": PROJECTION_AUTHORITY_BOUNDARY,
+    }
+
+
+def markdown_projection_lines(
+    *,
+    surface: str,
+    projection_kind: str,
+    layer: str = "Layer 3",
+    owner_pack: str,
+    generated_by: str,
+    derived_from: Iterable[str],
+    rebuild_policy: str,
+) -> list[str]:
+    return [
+        f"- projection_schema_version: {PROJECTION_LABEL_SCHEMA_VERSION}",
+        f"- projection_kind: {projection_kind}",
+        f"- projection_surface: {surface}",
+        f"- projection_layer: {layer}",
+        f"- projection_owner_pack: {owner_pack}",
+        f"- projection_generated_by: {generated_by}",
+        f"- projection_derived_from: {', '.join(derived_from)}",
+        f"- projection_rebuild_policy: {rebuild_policy}",
+        f"- projection_authority_boundary: {PROJECTION_AUTHORITY_BOUNDARY}",
+    ]
+
+
+def frontmatter_projection_fields(
+    *,
+    surface: str,
+    projection_kind: str,
+    layer: str = "Layer 3",
+    owner_pack: str,
+    generated_by: str,
+    derived_from: Iterable[str],
+    rebuild_policy: str,
+) -> list[str]:
+    return [
+        f"projection_schema_version: {PROJECTION_LABEL_SCHEMA_VERSION}",
+        f"projection_kind: {projection_kind}",
+        f"projection_surface: {surface}",
+        f"projection_layer: {layer}",
+        f"projection_owner_pack: {owner_pack}",
+        f"projection_generated_by: {generated_by}",
+        f"projection_derived_from: [{', '.join(derived_from)}]",
+        f"projection_rebuild_policy: {rebuild_policy}",
+        f"projection_authority_boundary: {PROJECTION_AUTHORITY_BOUNDARY}",
+    ]

--- a/src/ovp_pipeline/query_tool.py
+++ b/src/ovp_pipeline/query_tool.py
@@ -45,6 +45,11 @@ except ImportError:
     from packs.loader import DEFAULT_PACK_NAME  # type: ignore
 
 try:
+    from .projection_labels import frontmatter_projection_fields
+except ImportError:
+    from projection_labels import frontmatter_projection_fields  # type: ignore
+
+try:
     from .llm_defaults import (
         DEFAULT_LITELLM_TIMEOUT_SECONDS,
         DEFAULT_MINIMAX_API_BASE,
@@ -420,10 +425,21 @@ title: {question}
         if moc_file.exists():
             content = moc_file.read_text(encoding='utf-8')
         else:
-            content = """---
+            projection_fields = "\n".join(
+                frontmatter_projection_fields(
+                    surface="moc_queries",
+                    projection_kind="compiled_wiki_projection",
+                    owner_pack=self.pack,
+                    generated_by="ovp-query",
+                    derived_from=("query results", "user query"),
+                    rebuild_policy="append_on_query_save",
+                )
+            )
+            content = f"""---
 title: "MOC - 查询归档"
 date: 2026-04-03
 type: moc
+{projection_fields}
 ---
 
 # MOC - 查询归档

--- a/src/ovp_pipeline/ui/view_models.py
+++ b/src/ovp_pipeline/ui/view_models.py
@@ -12,6 +12,7 @@ from ..governance_registry import describe_governance_contract
 from ..observation_surface_registry import describe_observation_surface_contract
 from ..pack_resolution import iter_compatible_packs
 from ..packs.loader import PRIMARY_PACK_NAME
+from ..projection_labels import projection_label
 from ..reuse_emitter import collect_object_ids, emit_reuse_events_for_object_ids
 from ..runtime import VaultLayout, resolve_vault_dir
 from ..truth_store import CONTRADICTION_HEURISTIC_NOTE
@@ -100,6 +101,25 @@ def _supports_research_shell(pack_name: str | None = None) -> bool:
 
 def _assembly_contract(recipe_name: str, *, pack_name: str | None = None) -> dict[str, str]:
     return describe_assembly_recipe_contract(pack_name=pack_name, recipe_name=recipe_name)
+
+
+def _access_projection_label(
+    *,
+    surface: str,
+    pack_name: str | None,
+    generated_by: str,
+    derived_from: tuple[str, ...] = ("knowledge.db",),
+    rebuild_policy: str = "read_time",
+) -> dict[str, object]:
+    return projection_label(
+        surface=surface,
+        projection_kind="access_surface",
+        layer="Layer 3",
+        owner_pack=pack_name or PRIMARY_PACK_NAME,
+        generated_by=generated_by,
+        derived_from=derived_from,
+        rebuild_policy=rebuild_policy,
+    )
 
 
 def _compiled_section(
@@ -1247,6 +1267,12 @@ def build_briefing_payload(vault_dir: Path | str, *, pack_name: str | None = Non
         return {
             "screen": "briefing/intelligence",
             "requested_pack": requested_pack,
+            "projection_label": _access_projection_label(
+                surface="briefing",
+                pack_name=pack_name,
+                generated_by="build_briefing_payload",
+                derived_from=("knowledge.db", "signals ledger", "actions ledger"),
+            ),
             "surface_contract": surface_contract,
             "assembly_contract": assembly_contract,
             "governance_contract": governance_contract,
@@ -1511,6 +1537,12 @@ def build_briefing_payload(vault_dir: Path | str, *, pack_name: str | None = Non
     payload: dict[str, Any] = {
         "screen": "briefing/intelligence",
         "requested_pack": requested_pack,
+        "projection_label": _access_projection_label(
+            surface="briefing",
+            pack_name=pack_name,
+            generated_by="build_briefing_payload",
+            derived_from=("knowledge.db", "signals ledger", "actions ledger"),
+        ),
         "surface_contract": surface_contract,
         "assembly_contract": assembly_contract,
         "governance_contract": governance_contract,
@@ -1812,6 +1844,12 @@ def build_object_page_payload(
     payload: dict[str, Any] = {
         "screen": "object/page",
         "requested_pack": requested_pack,
+        "projection_label": _access_projection_label(
+            surface="object_page",
+            pack_name=pack_name,
+            generated_by="build_object_page_payload",
+            derived_from=("knowledge.db", "review audit"),
+        ),
         "assembly_contract": _assembly_contract("object_brief", pack_name=pack_name),
         "research_shell_enabled": research_shell_enabled,
         **detail,
@@ -2620,6 +2658,12 @@ def build_cluster_browser_payload(
     return {
         "screen": "graph/clusters",
         "requested_pack": pack_name or "",
+        "projection_label": _access_projection_label(
+            surface="graph_clusters",
+            pack_name=pack_name,
+            generated_by="build_cluster_browser_payload",
+            derived_from=("knowledge.db.graph_clusters", "knowledge.db.graph_edges"),
+        ),
         "query": query or "",
         "limit": limit,
         "is_limited": True,
@@ -2702,6 +2746,12 @@ def build_cluster_detail_payload(
     return {
         "screen": "graph/cluster-detail",
         "requested_pack": requested_pack,
+        "projection_label": _access_projection_label(
+            surface="graph_cluster_detail",
+            pack_name=pack_name,
+            generated_by="build_cluster_detail_payload",
+            derived_from=("knowledge.db.graph_clusters", "knowledge.db.graph_edges"),
+        ),
         "cluster": enriched_cluster,
         "browser_path": f"/clusters?pack={quote(requested_pack, safe='')}",
         "edges": enriched_edges,
@@ -3195,6 +3245,12 @@ def build_truth_dashboard_payload(
     return {
         "screen": "truth/dashboard",
         "requested_pack": requested_pack,
+        "projection_label": _access_projection_label(
+            surface="ops_dashboard",
+            pack_name=pack_name,
+            generated_by="build_truth_dashboard_payload",
+            derived_from=("knowledge.db", "runtime ledgers", "review audit"),
+        ),
         "research_overview": {
             "status": "supported" if research_overview_supported else "shared_shell_only",
             "reason": (
@@ -3268,6 +3324,12 @@ def build_runtime_home_payload(
     return {
         "screen": "truth/runtime-home",
         "requested_pack": requested_pack,
+        "projection_label": _access_projection_label(
+            surface="reader_home",
+            pack_name=pack_name,
+            generated_by="build_runtime_home_payload",
+            derived_from=("knowledge.db", "runtime ledgers"),
+        ),
         "runtime": runtime,
         "research_overview": {
             "status": "supported" if research_overview_supported else "shared_shell_only",
@@ -3358,6 +3420,11 @@ def build_objects_index_payload(
     return {
         "screen": "objects/index",
         "requested_pack": requested_pack,
+        "projection_label": _access_projection_label(
+            surface="objects_index",
+            pack_name=pack_name,
+            generated_by="build_objects_index_payload",
+        ),
         "items": items,
         "count": len(items),
         "total_count": total_count,
@@ -3728,6 +3795,12 @@ def build_search_payload(
     return {
         "screen": "search/results",
         "requested_pack": requested_pack,
+        "projection_label": _access_projection_label(
+            surface="search_results",
+            pack_name=pack_name,
+            generated_by="build_search_payload",
+            derived_from=("knowledge.db.objects", "knowledge.db.pages_index"),
+        ),
         **results,
         "objects": [
             {

--- a/src/ovp_pipeline/wiki_views/runtime.py
+++ b/src/ovp_pipeline/wiki_views/runtime.py
@@ -10,6 +10,7 @@ from ..materializers.contradiction_view import materialize_contradiction_view
 from ..materializers.event_dossier import materialize_event_dossier
 from ..materializers.object_page import materialize_object_page
 from ..materializers.topic_view import materialize_topic_view
+from ..projection_labels import markdown_projection_lines
 from ..runtime import VaultLayout, iter_markdown_files, markdown_title, resolve_vault_dir
 from .specs import WikiViewSpec
 
@@ -87,6 +88,14 @@ def build_view(
             "",
             f"- pack: {spec.pack}",
             f"- publish_target: {spec.publish_target}",
+            *markdown_projection_lines(
+                surface=spec.name,
+                projection_kind="compiled_wiki_projection",
+                owner_pack=spec.pack,
+                generated_by=f"wiki_view:{spec.builder}",
+                derived_from=("extraction artifacts",),
+                rebuild_policy="on_derived_refresh",
+            ),
             "",
             "## Extraction Runs",
             "",
@@ -105,11 +114,19 @@ def build_view(
 
     lines = [
         f"# {spec.name}",
-        "",
-        f"- pack: {spec.pack}",
-        f"- publish_target: {spec.publish_target}",
-        "",
-        "## Included Notes",
+            "",
+            f"- pack: {spec.pack}",
+            f"- publish_target: {spec.publish_target}",
+            *markdown_projection_lines(
+                surface=spec.name,
+                projection_kind="compiled_wiki_projection",
+                owner_pack=spec.pack,
+                generated_by=f"wiki_view:{spec.builder}",
+                derived_from=("vault markdown",),
+                rebuild_policy="on_derived_refresh",
+            ),
+            "",
+            "## Included Notes",
         "",
     ]
     if titles:

--- a/tests/test_projection_labels.py
+++ b/tests/test_projection_labels.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from datetime import date
+
+from ovp_pipeline.knowledge_index import rebuild_knowledge_index
+
+
+def _seed_projection_vault(temp_vault):
+    alpha = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
+    beta = temp_vault / "10-Knowledge" / "Evergreen" / "Beta.md"
+    alpha.write_text(
+        """---
+note_id: alpha
+title: Alpha
+type: evergreen
+date: 2026-04-30
+---
+
+# Alpha
+
+Alpha is a compiled knowledge object.
+
+Links to [[beta]].
+""",
+        encoding="utf-8",
+    )
+    beta.write_text(
+        """---
+note_id: beta
+title: Beta
+type: evergreen
+date: 2026-04-30
+---
+
+# Beta
+
+Beta extends Alpha.
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+
+def _assert_projection_label(
+    payload: dict,
+    *,
+    surface: str,
+    projection_kind: str = "access_surface",
+) -> None:
+    label = payload["projection_label"]
+    assert label["projection_schema_version"] == 1
+    assert label["projection_kind"] == projection_kind
+    assert label["projection_surface"] == surface
+    assert label["projection_layer"] == "Layer 3"
+    assert label["projection_authority_boundary"] == "derived_not_authority"
+    assert label["projection_derived_from"]
+    assert label["projection_rebuild_policy"]
+
+
+def test_core_reader_payloads_carry_projection_labels(temp_vault):
+    from ovp_pipeline.ui.view_models import (
+        build_briefing_payload,
+        build_cluster_browser_payload,
+        build_object_page_payload,
+        build_runtime_home_payload,
+        build_search_payload,
+        build_truth_dashboard_payload,
+    )
+
+    _seed_projection_vault(temp_vault)
+
+    cases = [
+        (build_runtime_home_payload(temp_vault), "reader_home"),
+        (build_truth_dashboard_payload(temp_vault), "ops_dashboard"),
+        (build_search_payload(temp_vault, query="alpha"), "search_results"),
+        (build_object_page_payload(temp_vault, "alpha"), "object_page"),
+        (build_briefing_payload(temp_vault), "briefing"),
+        (build_cluster_browser_payload(temp_vault), "graph_clusters"),
+    ]
+    for payload, surface in cases:
+        _assert_projection_label(payload, surface=surface)
+
+
+def test_projection_label_helper_keeps_stable_boundary_fields():
+    from ovp_pipeline.projection_labels import projection_label
+
+    label = projection_label(
+        surface="reader_home",
+        projection_kind="access_surface",
+        layer="Layer 3",
+        owner_pack="research-tech",
+        generated_by="build_runtime_home_payload",
+        derived_from=("knowledge.db", "runtime ledgers"),
+        rebuild_policy="read_time",
+    )
+
+    assert label == {
+        "projection_schema_version": 1,
+        "projection_kind": "access_surface",
+        "projection_surface": "reader_home",
+        "projection_layer": "Layer 3",
+        "projection_owner_pack": "research-tech",
+        "projection_generated_by": "build_runtime_home_payload",
+        "projection_derived_from": ["knowledge.db", "runtime ledgers"],
+        "projection_rebuild_policy": "read_time",
+        "projection_authority_boundary": "derived_not_authority",
+    }
+
+
+def test_markdown_projection_lines_are_stable_metadata():
+    from ovp_pipeline.projection_labels import markdown_projection_lines
+
+    assert markdown_projection_lines(
+        surface="cluster_view",
+        projection_kind="compiled_wiki_projection",
+        owner_pack="research-tech",
+        generated_by="cluster_view",
+        derived_from=("knowledge.db",),
+        rebuild_policy="on_derived_refresh",
+    ) == [
+        "- projection_schema_version: 1",
+        "- projection_kind: compiled_wiki_projection",
+        "- projection_surface: cluster_view",
+        "- projection_layer: Layer 3",
+        "- projection_owner_pack: research-tech",
+        "- projection_generated_by: cluster_view",
+        "- projection_derived_from: knowledge.db",
+        "- projection_rebuild_policy: on_derived_refresh",
+        "- projection_authority_boundary: derived_not_authority",
+    ]
+
+
+def test_materialized_projection_artifacts_carry_labels(temp_vault):
+    from ovp_pipeline.commands.working_memory import build_working_memory
+    from ovp_pipeline.materializers.crystal import materialize_crystal
+    from ovp_pipeline.materializers.object_page import materialize_object_page
+    from ovp_pipeline.materializers.topic_view import materialize_topic_view
+
+    _seed_projection_vault(temp_vault)
+
+    working_memory = build_working_memory(temp_vault, target_date=date(2026, 4, 30))
+    working_memory_text = working_memory.read_text(encoding="utf-8")
+    assert "projection_kind: context_pack_projection" in working_memory_text
+    assert "projection_surface: working_memory" in working_memory_text
+    assert "projection_authority_boundary: derived_not_authority" in working_memory_text
+
+    crystal = materialize_crystal(
+        {"generated_at": "2026-04-30T00:00:00Z", "active_topics": []},
+        temp_vault,
+        when=date(2026, 4, 30),
+    )
+    crystal_text = crystal.path.read_text(encoding="utf-8")
+    assert "projection_kind: context_pack_projection" in crystal_text
+    assert "projection_surface: crystal" in crystal_text
+    assert "projection_authority_boundary: derived_not_authority" in crystal_text
+
+    object_page = materialize_object_page(temp_vault, pack_name="research-tech", object_id="alpha")
+    object_page_text = object_page.read_text(encoding="utf-8")
+    assert "- projection_kind: compiled_wiki_projection" in object_page_text
+    assert "- projection_surface: object_page" in object_page_text
+
+    topic_view = materialize_topic_view(temp_vault, pack_name="research-tech", view_name="topic/overview")
+    topic_view_text = topic_view.read_text(encoding="utf-8")
+    assert "- projection_kind: compiled_wiki_projection" in topic_view_text
+    assert "- projection_surface: topic_view" in topic_view_text
+
+
+def test_query_moc_carries_projection_frontmatter(temp_vault):
+    from ovp_pipeline.query_tool import VaultQuerier
+
+    target_file = temp_vault / "20-Areas" / "Queries" / "Alpha.md"
+    target_file.parent.mkdir(parents=True, exist_ok=True)
+    target_file.write_text("# Alpha\n", encoding="utf-8")
+
+    querier = VaultQuerier(temp_vault, pack="research-tech")
+    querier._update_moc_queries("What is Alpha?", target_file, {})
+
+    moc_text = (temp_vault / "10-Knowledge" / "Atlas" / "MOC-Queries.md").read_text(
+        encoding="utf-8"
+    )
+    assert "projection_kind: compiled_wiki_projection" in moc_text
+    assert "projection_surface: moc_queries" in moc_text
+    assert "projection_authority_boundary: derived_not_authority" in moc_text
+    assert "[[20-Areas/Queries/Alpha|What is Alpha?]]" in moc_text

--- a/tests/test_working_memory.py
+++ b/tests/test_working_memory.py
@@ -35,7 +35,11 @@ def test_empty_vault_renders_all_section_headers(temp_vault):
 
     assert output.parent == temp_vault.joinpath(*WORKING_MEMORY_DIR)
     assert output.name == "2026-04-24.md"
-    assert text.startswith("# Working Memory — 2026-04-24")
+    assert text.startswith("---\n")
+    assert "projection_kind: context_pack_projection" in text
+    assert "projection_surface: working_memory" in text
+    assert "projection_layer: Layer 3" in text
+    assert "# Working Memory — 2026-04-24" in text
     for section in (
         "## Top of Mind",
         "## Fresh Crystals",


### PR DESCRIPTION
## Summary
- Add a shared projection label helper for Layer 3 access payloads and materialized projection artifacts.
- Label reader home, ops dashboard, search, briefing, object pages, graph cluster views, wiki/materialized views, context packs, working memory, and query MOC output.
- Backfill README, Architecture, Milestone, and Backlog docs for PR #77 status and this BL-002 projection-label round.

## Validation
- `PYTHONPATH=src python -m pytest tests/test_projection_labels.py tests/test_working_memory.py tests/test_crystal_materializer.py tests/test_build_views_command.py tests/test_ui_view_models.py tests/test_ui_hot_paths.py tests/test_workflow_wiring.py tests/test_architecture_fitness.py -q` -> 119 passed
- `git diff --check` -> passed
- `python -m compileall -q src/ovp_pipeline` -> passed
- `PYTHONPATH=src python -m pytest -q` -> 1068 passed

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/78" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
