### PR TITLE
[codex] Add object source backlink rail

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -662,14 +662,14 @@ Main gaps:
 - Layer 4 fitness checks now cover the first hot-path and workflow-wiring cases; evidence completeness, projection replay, and import-boundary checks are still open.
 - Projection lifecycle markers need structured schema, scope, lease, and supersession.
 - Schema versioning is not yet wired into projection lifecycle.
-- The reader-first home is now the default entry; object pages, graph, backlinks, and search still need product shape.
+- The reader-first home is now the default entry; object pages have a first reader profile/source rail, while graph, search, and deeper per-kind object layouts still need product shape.
 
 ## 18. Near-Term Architecture Actions
 
 Recommended order:
 
 1. Keep projection metadata attached to new access surfaces and add doctor/export checks that verify the labels are present.
-2. Continue reader-first Layer 3 product work on object pages, graph, backlinks, and search.
+2. Continue reader-first Layer 3 product work on graph, search, and deeper per-kind object layouts.
 3. Add evidence spans and factual evidence completeness checks.
 4. Add candidate risk tiers and routing preview before expanding automatic promotion.
 5. Introduce structured `ProjectionRepairMarker` schema.
@@ -686,6 +686,6 @@ The architecture should not depend on backlog IDs to be valid. The table below i
 | Workflow wiring eval suite | `BL-004`, `KSR-026` shipped in PR #77 |
 | Evidence span / factual evidence completeness | `BL-006`, `KSR-001`, `KSR-018` |
 | Candidate risk layering | `BL-007`, `KSR-003` |
-| Reader-first access surfaces | `BL-001`, `BL-008`, `BL-009`, `BL-010` |
+| Reader-first access surfaces | `BL-001`; `BL-008` partial and `BL-009` done in PR #79; `BL-010` next |
 | Projection repair lifecycle | `BL-020` |
 | Schema versioning and migration trigger | `BL-021` |

--- a/ARCHITECTURE.zh-CN.md
+++ b/ARCHITECTURE.zh-CN.md
@@ -773,7 +773,7 @@ Do not rely on ad hoc "just rerun the pipeline" behavior for schema changes.
 - governance / resolver contracts 还需要显式化。
 - schema versioning 和 projection compatibility 还需要工程化。
 - fitness functions 只落地了第一批，仍需扩展到 CI/doctor/pre-commit 的完整契约。
-- reader-first home 已经成为默认入口；object page、graph、backlink、search 还需要继续产品化。
+- reader-first home 已经成为默认入口；object page 已有第一版 reader profile/source rail，graph、search 和更深的 per-kind object layout 还需要继续产品化。
 
 ## 17. 近期架构动作
 
@@ -782,7 +782,7 @@ Do not rely on ad hoc "just rerun the pipeline" behavior for schema changes.
 优先顺序：
 
 1. 新增 access surface 时必须继续带 projection metadata，并补 doctor/export checks 验证标注存在。
-2. 继续做 reader-first Layer 3：object page、graph、backlink、search 的产品化。
+2. 继续做 reader-first Layer 3：graph、search 和更深的 per-kind object layout。
 3. 补 evidence span 和 factual evidence completeness checks。
 4. 补 candidate risk tiers 和 routing preview，再扩大自动 promotion。
 5. 引入结构化 ProjectionRepairMarker。
@@ -801,7 +801,7 @@ Do not rely on ad hoc "just rerun the pipeline" behavior for schema changes.
 | Workflow wiring eval suite | `BL-004`, `KSR-026` PR #77 已交付 |
 | Evidence span / factual evidence completeness | `BL-006`, `KSR-001`, `KSR-018` |
 | Candidate risk layering | `BL-007`, `KSR-003` |
-| Reader-first access surfaces | `BL-001`, `BL-008`, `BL-009`, `BL-010` |
+| Reader-first access surfaces | `BL-001`；`BL-008` partial、`BL-009` 已在 PR #79 交付；`BL-010` next |
 | Projection repair lifecycle | `BL-020` |
 | Schema versioning and migration trigger | `BL-021` |
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -21,7 +21,7 @@ Rule: historical plans and vault research notes feed this file; they do not over
 | M0 Pipeline And Pack Foundation | Done | CLI, source lifecycle, pack/profile runtime, `knowledge.db`, first source-lifecycle idempotency slice |
 | M1 Operator Workbench And Review Runtime | Done / maintain | truth UI, candidates, signals/actions, contradictions, action worker |
 | M2 Roadmap And README Consolidation | Done | merged historical milestones, compiler roadmap, recent KSR input, reader-product research, and English-primary docs |
-| M3 Reader-First Knowledge Atlas | Active | reader home and `/ops` split shipped; object pages, backlinks, and graph still need product shape |
+| M3 Reader-First Knowledge Atlas | Active | reader home, `/ops` split, and first object source/backlink rail shipped; graph and deeper kind-specific object layouts still need product shape |
 | M4 KSR Safety And Hot-Path Hardening | Active | projection labels, hot-path audit, and wiring evals shipped; routing preview, evidence spans, and candidate risk remain |
 | M5 Context Pack And Operational Runtime | Later | session snapshots, context budget, claim leases, provider facade, observability |
 | M6 Policy, Permission, And Knowledge Evolution | Later | permission layer, claim lifecycle, conflict detection, policy promotion |
@@ -39,8 +39,8 @@ Rule: historical plans and vault research notes feed this file; they do not over
 | BL-005 | P0 | Next | Article routing preview before source lifecycle changes | M4, KSR-014 |
 | BL-006 | P0 | Next | Evidence span schema and markdown-aware locator backfill | M4, KSR-001, KSR-018 |
 | BL-007 | P0 | Next | Candidate risk layering by evidence strength, identity ambiguity, sensitivity, and impact | M4, KSR-003 |
-| BL-008 | P1 | Next | Kind-aware object pages for people, concepts, companies/tools/projects, events, and claims | M3 |
-| BL-009 | P1 | Next | Mention/backlink rail with excerpts, source jumps, and relation context | M3, reader-product note |
+| BL-008 | P1 | Partial | Kind-aware object pages for people, concepts, companies/tools/projects, events, and claims; first slice adds reader profile/kind labels | M3, PR #79 |
+| BL-009 | P1 | Done | Mention/backlink rail with excerpts, source jumps, and relation context | M3, reader-product note, PR #79 |
 | BL-010 | P1 | Next | Visual `/graph` MVP as a spatial corpus map; keep analytical clusters under ops/debug | M3 |
 | BL-011 | P1 | Later | Reader-oriented search grouped by kind, summary, evidence, and reason | M3/M4 |
 | BL-012 | P1 | Later | Trusted reuse event instrumentation for downstream use of accepted/cited knowledge | April 22 roadmap |
@@ -90,13 +90,13 @@ Rule: historical plans and vault research notes feed this file; they do not over
 
 ## Next Decision
 
-`BL-001` is shipped in PR #75, `BL-003 + BL-004` are shipped in PR #77, and `BL-002` is shipped in PR #78. The default UI now has a reader-first entry point, `/ops` owns the operator dashboard, and core access/materialized surfaces carry explicit projection labels.
+`BL-001` is shipped in PR #75, `BL-003 + BL-004` are shipped in PR #77, `BL-002` is shipped in PR #78, and `BL-009` plus the first `BL-008` slice are shipped in PR #79. The default UI now has a reader-first entry point, `/ops` owns the operator dashboard, core access/materialized surfaces carry explicit projection labels, and object pages expose readable source/backlink rails.
 
-The next implementation PR should move back to the reader product shape: **BL-008 + BL-009**. The projection boundary is now explicit enough to improve object pages and backlink/source rails without making those surfaces look like canonical truth.
+The next implementation PR should continue the reader product shape with **BL-010**. Object pages now have first-pass readable context, so the remaining obvious product gap is the visual graph MVP.
 
 Recommended order:
 
-1. BL-008 + BL-009
-2. BL-010
-3. BL-005
-4. BL-006 + BL-007
+1. BL-010
+2. BL-005
+3. BL-006 + BL-007
+4. Continue BL-008 with deeper per-kind layouts

--- a/MILESTONE.md
+++ b/MILESTONE.md
@@ -33,7 +33,7 @@ That means the user-facing product should make compiled knowledge easy to read f
 | M0 Pipeline And Pack Foundation | Done | CLI, source lifecycle, pack/profile runtime, `knowledge.db`, first source-lifecycle idempotency slice |
 | M1 Operator Workbench And Review Runtime | Done / maintain | truth UI, candidates, signals/actions, contradictions, action worker |
 | M2 Roadmap And README Consolidation | Done | merged historical milestones, compiler roadmap, recent KSR input, reader-product research, and the English-primary docs structure |
-| M3 Reader-First Knowledge Atlas | Active | reader home and `/ops` split shipped; objects, backlinks, and graph remain the next product surfaces |
+| M3 Reader-First Knowledge Atlas | Active | reader home, `/ops` split, and first object source/backlink rail shipped; graph and deeper kind-specific object layouts remain |
 | M4 KSR Safety And Hot-Path Hardening | Active | projection labels, hot-path audit, and wiring evals shipped; routing preview, evidence spans, and candidate risk remain |
 | M5 Context Pack And Operational Runtime | Later | session snapshots, context budget, claim leases, provider facade, observability |
 | M6 Policy, Permission, And Knowledge Evolution | Later | permission layer, claim lifecycle, conflict detection, policy promotion |
@@ -50,7 +50,7 @@ That means the user-facing product should make compiled knowledge easy to read f
 | Article routing preview | `BL-005`, `KSR-014` |
 | Evidence span / factual evidence completeness | `BL-006`, `KSR-001`, `KSR-018` |
 | Candidate risk layering | `BL-007`, `KSR-003` |
-| Kind-aware object pages and backlink rail | `BL-008`, `BL-009` |
+| Kind-aware object pages and backlink rail | `BL-008` partial and `BL-009` done in PR #79 |
 | Visual graph MVP | `BL-010` |
 | Projection repair lifecycle | `BL-020` |
 | Schema versioning and migration trigger | `BL-021` |
@@ -59,10 +59,10 @@ That means the user-facing product should make compiled knowledge easy to read f
 
 Recommended order:
 
-1. Implement `BL-008 + BL-009`: make object pages readable and add source/backlink rails.
-2. Implement `BL-010`: ship the visual `/graph` MVP as a spatial corpus map.
-3. Implement `BL-005`: add article routing preview before source lifecycle changes.
-4. Implement `BL-006 + BL-007`: evidence spans and candidate risk layering.
+1. Implement `BL-010`: ship the visual `/graph` MVP as a spatial corpus map.
+2. Implement `BL-005`: add article routing preview before source lifecycle changes.
+3. Implement `BL-006 + BL-007`: evidence spans and candidate risk layering.
+4. Continue `BL-008`: deeper per-kind object layouts beyond the first reader profile.
 
 ## Documentation Rules
 

--- a/MILESTONE.zh-CN.md
+++ b/MILESTONE.zh-CN.md
@@ -33,7 +33,7 @@ OVP 正在从 document-processing pipeline 变成：
 | M0 Pipeline And Pack Foundation | Done | CLI、source lifecycle、pack/profile runtime、`knowledge.db`、第一段 source-lifecycle idempotency |
 | M1 Operator Workbench And Review Runtime | Done / maintain | truth UI、candidates、signals/actions、contradictions、action worker |
 | M2 Roadmap And README Consolidation | Done | 已合并历史 milestones、compiler roadmap、近期 KSR 输入、reader-product 研究，以及英文主文档结构 |
-| M3 Reader-First Knowledge Atlas | Active | reader home 和 `/ops` 拆分已交付；object pages、backlinks、graph 仍是下一批产品化 surface |
+| M3 Reader-First Knowledge Atlas | Active | reader home、`/ops` 拆分、第一版 object source/backlink rail 已交付；graph 和更深的 kind-specific object layout 仍待推进 |
 | M4 KSR Safety And Hot-Path Hardening | Active | projection labels、hot-path audit、wiring evals 已交付；routing preview、evidence spans、candidate risk 仍待推进 |
 | M5 Context Pack And Operational Runtime | Later | session snapshots、context budget、claim leases、provider facade、observability |
 | M6 Policy, Permission, And Knowledge Evolution | Later | permission layer、claim lifecycle、conflict detection、policy promotion |
@@ -50,7 +50,7 @@ OVP 正在从 document-processing pipeline 变成：
 | Article routing preview | `BL-005`, `KSR-014` |
 | Evidence span / factual evidence completeness | `BL-006`, `KSR-001`, `KSR-018` |
 | Candidate risk layering | `BL-007`, `KSR-003` |
-| Kind-aware object pages and backlink rail | `BL-008`, `BL-009` |
+| Kind-aware object pages and backlink rail | `BL-008` partial，`BL-009` 已在 PR #79 交付 |
 | Visual graph MVP | `BL-010` |
 | Projection repair lifecycle | `BL-020` |
 | Schema versioning and migration trigger | `BL-021` |
@@ -59,10 +59,10 @@ OVP 正在从 document-processing pipeline 变成：
 
 建议顺序：
 
-1. 实施 `BL-008 + BL-009`：让 object page 更可读，并补 source/backlink rail。
-2. 实施 `BL-010`：把 `/graph` 做成 spatial corpus map 的 MVP。
-3. 实施 `BL-005`：在 source lifecycle 继续变化前补 article routing preview。
-4. 实施 `BL-006 + BL-007`：推进 evidence span 和 candidate risk layering。
+1. 实施 `BL-010`：把 `/graph` 做成 spatial corpus map 的 MVP。
+2. 实施 `BL-005`：在 source lifecycle 继续变化前补 article routing preview。
+3. 实施 `BL-006 + BL-007`：推进 evidence span 和 candidate risk layering。
+4. 继续 `BL-008`：在第一版 reader profile 之后补更深的 per-kind object layout。
 
 ## 文档规则
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Current milestone sequence:
 | M0 Pipeline And Pack Foundation | Complete | CLI, source lifecycle, pack/profile runtime, `knowledge.db`, first KSR-013 slice |
 | M1 Operator Workbench And Review Runtime | Complete enough | truth UI, candidates, signals/actions, contradictions, action worker |
 | M2 Roadmap And README Consolidation | Complete | merged historical milestones, compiler roadmap, recent KSR input, and reader-product research |
-| M3 Reader-First Knowledge Atlas | Active | reader home and `/ops` split shipped; object and graph pages still need product shape |
+| M3 Reader-First Knowledge Atlas | Active | reader home, `/ops` split, and first object source/backlink rail shipped; graph pages and deeper per-kind object layouts still need product shape |
 | M4 KSR Safety And Hot-Path Hardening | Active | projection labels, hot-path audit, and wiring evals have shipped; evidence spans, candidate risk tiers, routing preview, and product-facing object/graph polish are next |
 | M5 Context Pack And Operational Runtime | Later | session snapshots, context budget, claim leases, provider facades, observability |
 | M6 Policy, Permission, And Knowledge Evolution | Later | permission layer, claim lifecycle, conflict detection, policy promotion |
@@ -103,7 +103,8 @@ Current milestone sequence:
 Current active backlog focus:
 
 - Shipped: `KSR-002` projection labels, `KSR-015` dashboard/search hot-path audit, `KSR-026` workflow wiring eval suite.
-- Next: `KSR-014` article routing preview, `KSR-001` evidence spans, `KSR-003` candidate risk tiers.
+- Product shipped: first readable object page profile and source/backlink rail.
+- Next: visual `/graph` MVP, `KSR-014` article routing preview, `KSR-001` evidence spans, `KSR-003` candidate risk tiers.
 - Product track: reader-first Knowledge Atlas stays a projection layer, not a new state system.
 
 ## Domain Packs

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -92,7 +92,7 @@ Obsidian Vault Pipeline（OVP）不是一个“多脚本拼装包”，也不只
 | M0 Pipeline And Pack Foundation | Complete | CLI、source lifecycle、pack/profile、`knowledge.db`、KSR-013 第一版 |
 | M1 Operator Workbench And Review Runtime | Complete enough | truth UI、candidates、signals/actions、contradictions、action worker |
 | M2 Roadmap And README Consolidation | Complete | 已合并历史 milestone、compiler roadmap、近期 KSR 输入与 reader-product 研究，重整 README |
-| M3 Reader-First Knowledge Atlas | Active | reader home 和 `/ops` 拆分已交付；object page / graph page 仍需产品化 |
+| M3 Reader-First Knowledge Atlas | Active | reader home、`/ops` 拆分、第一版 object source/backlink rail 已交付；graph page 和更深的 per-kind object layout 仍需产品化 |
 | M4 KSR Safety And Hot-Path Hardening | Active | projection 标注、hot-path audit、wiring eval 已交付；下一步推进 evidence span、candidate 风险分层、routing preview，以及 object/graph 的产品化 |
 | M5 Context Pack And Operational Runtime | Later | session snapshot、context budget、claim lease、provider facade、observability |
 | M6 Policy, Permission, And Knowledge Evolution | Later | permission layer、claim lifecycle、conflict detection、policy promotion |
@@ -101,7 +101,8 @@ Obsidian Vault Pipeline（OVP）不是一个“多脚本拼装包”，也不只
 当前 active backlog 重点：
 
 - 已交付：`KSR-002` Projection 标注、`KSR-015` Dashboard/search hot-path audit、`KSR-026` Workflow wiring eval suite。
-- 下一步：`KSR-014` Article routing preview、`KSR-001` Evidence span 化、`KSR-003` Candidate 风险分层。
+- 产品侧已交付：第一版 readable object page profile 和 source/backlink rail。
+- 下一步：visual `/graph` MVP、`KSR-014` Article routing preview、`KSR-001` Evidence span 化、`KSR-003` Candidate 风险分层。
 - 产品线：Reader-first Knowledge Atlas 作为 projection layer 实现，不另建状态系统。
 
 ## Domain Packs

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -1783,6 +1783,73 @@ def _render_objects_index(payload: dict) -> str:
     )
 
 
+def _render_source_backlink_rail(payload: dict, *, requested_pack: str) -> str:
+    rail = payload.get("source_backlink_rail") or {}
+    evergreen = rail.get("evergreen") or {}
+    evergreen_path = str(evergreen.get("path") or "")
+    evergreen_html = (
+        f'<a href="{escape(str(evergreen.get("jump_path") or _note_href(evergreen_path, requested_pack)))}">{escape(evergreen_path)}</a>'
+        if evergreen_path
+        else "<span class='muted'>None</span>"
+    )
+
+    def render_source_note(item: dict) -> str:
+        href = str(item.get("jump_path") or _note_href(str(item.get("path") or ""), requested_pack))
+        title = str(item.get("title") or item.get("slug") or "Source")
+        note_type = str(item.get("note_type") or "source")
+        excerpt = str(item.get("excerpt") or "")
+        return (
+            "<li>"
+            f'<a href="{escape(href)}">{escape(title)}</a>'
+            f" <span class='muted'>({escape(note_type)})</span>"
+            + (f"<p class='muted'>{escape(excerpt)}</p>" if excerpt else "")
+            + "</li>"
+        )
+
+    def render_atlas_page(item: dict) -> str:
+        href = str(item.get("jump_path") or _note_href(str(item.get("path") or ""), requested_pack))
+        title = str(item.get("title") or item.get("slug") or "Atlas page")
+        return f'<li><a href="{escape(href)}">{escape(title)}</a></li>'
+
+    def render_related_object(item: dict) -> str:
+        object_id = str(item.get("object_id") or "")
+        href = _object_href(object_id, str(item.get("path") or ""), requested_pack=requested_pack)
+        title = str(item.get("title") or object_id or "Object")
+        relation_type = str(item.get("relation_type") or "related")
+        return (
+            "<li>"
+            f'<a href="{escape(href)}">{escape(title)}</a>'
+            f" <span class='muted'>({escape(relation_type)})</span>"
+            "</li>"
+        )
+
+    source_notes = rail.get("source_notes") or []
+    source_html = (
+        "".join(render_source_note(item) for item in source_notes)
+        or "<li class='muted'>No source notes linked yet.</li>"
+    )
+    atlas_pages = rail.get("atlas_pages") or []
+    atlas_html = (
+        "".join(render_atlas_page(item) for item in atlas_pages)
+        or "<li class='muted'>No atlas pages link here yet.</li>"
+    )
+    related_objects = rail.get("related_objects") or []
+    related_html = (
+        "".join(render_related_object(item) for item in related_objects)
+        or "<li class='muted'>No related objects yet.</li>"
+    )
+    return (
+        "<section id='sources' class='card'><h2>Sources &amp; Backlinks</h2>"
+        f"<p class='muted'>{escape(str(rail.get('summary') or 'No source links yet.'))}</p>"
+        "<dl class='meta-list'>"
+        f"<div><dt>Evergreen</dt><dd>{evergreen_html}</dd></div>"
+        f"<div><dt>Source Notes</dt><dd><ul class='list-tight'>{source_html}</ul></dd></div>"
+        f"<div><dt>Atlas Pages</dt><dd><ul class='list-tight'>{atlas_html}</ul></dd></div>"
+        f"<div><dt>Related Objects</dt><dd><ul class='list-tight'>{related_html}</ul></dd></div>"
+        "</dl></section>"
+    )
+
+
 def _render_object_page(payload: dict) -> str:
     requested_pack = payload.get("requested_pack", "")
     research_shell_enabled = bool(
@@ -1848,6 +1915,7 @@ def _render_object_page(payload: dict) -> str:
         or "<li>None</li>"
     )
     summary_text = payload["summary"]["summary_text"] if payload["summary"] else ""
+    reader_profile = payload.get("reader_profile") or {}
     evolution = payload.get(
         "evolution",
         {
@@ -1947,6 +2015,7 @@ def _render_object_page(payload: dict) -> str:
         right_sections.append(_render_research_scope_notice(requested_pack))
     right_sections.extend(
         [
+            _render_source_backlink_rail(payload, requested_pack=requested_pack),
             "<section class='card'><h2>Context</h2><dl class='meta-list'>"
             f"<div><dt>Object Kind</dt><dd>{escape(payload['context']['object_kind'])}</dd></div>"
             f"<div><dt>Source Slug</dt><dd>{escape(payload['context']['source_slug'])}</dd></div>"
@@ -1979,8 +2048,10 @@ def _render_object_page(payload: dict) -> str:
     return _layout(
         f"Object: {payload['object']['title']}",
         (
-            f"<section class='hero'><h1>Object: {escape(payload['object']['title'])}</h1>"
-            f"<p class='muted'>{escape(payload['object']['object_id'])}"
+            f"<section class='hero'><span class=\"pill\">{escape(str(reader_profile.get('kind_label') or payload['context']['object_kind']))}</span>"
+            f"<h1>{escape(str(reader_profile.get('headline') or payload['object']['title']))}</h1>"
+            f"<p>{escape(str(reader_profile.get('dek') or summary_text or 'No compiled summary yet.'))}</p>"
+            f"<p class='muted'>{escape(str(reader_profile.get('supporting_line') or payload['object']['object_id']))}"
             + (f" Pack scope: {escape(requested_pack)}." if requested_pack else "")
             + "</p>"
             + f"<div class='link-row'>{''.join(hero_links)}</div></section>"

--- a/src/ovp_pipeline/ui/view_models.py
+++ b/src/ovp_pipeline/ui/view_models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 import sqlite3
 from collections import Counter
 from pathlib import Path
@@ -120,6 +121,158 @@ def _access_projection_label(
         derived_from=derived_from,
         rebuild_policy=rebuild_policy,
     )
+
+
+_OBJECT_KIND_LABELS = {
+    "person": "Person",
+    "concept": "Concept",
+    "company": "Company",
+    "tool": "Tool",
+    "project": "Project",
+    "event": "Event",
+    "claim": "Claim",
+    "evergreen": "Concept",
+}
+_LIST_MARKER_RE = re.compile(r"^([-*•]|\d+\.)\s+")
+OBJECT_SOURCE_RAIL_RELATED_LIMIT = 8
+
+
+def _object_kind_label(object_kind: str) -> str:
+    normalized = (object_kind or "").strip().lower()
+    if not normalized:
+        return "Object"
+    return _OBJECT_KIND_LABELS.get(normalized, normalized.replace("_", " ").title())
+
+
+def _object_reader_profile(detail: dict[str, Any], *, relation_count: int) -> dict[str, object]:
+    summary_text = str((detail.get("summary") or {}).get("summary_text") or "").strip()
+    source_note_count = len(detail["provenance"]["source_notes"])
+    atlas_count = len(detail["provenance"]["mocs"])
+    return {
+        "kind_label": _object_kind_label(str(detail["object"].get("object_kind") or "")),
+        "headline": detail["object"]["title"],
+        "dek": summary_text or "No compiled summary yet.",
+        "supporting_line": (
+            f"{len(detail['claims'])} claims · {relation_count} relations · "
+            f"{source_note_count} source notes · {atlas_count} atlas pages"
+        ),
+        "empty_summary": not bool(summary_text),
+    }
+
+
+def _clean_excerpt_line(line: str) -> str:
+    return _LIST_MARKER_RE.sub("", line.strip()).strip()
+
+
+def _source_excerpt_for_object(
+    vault_dir: Path | str,
+    *,
+    note_path: str,
+    object_id: str,
+    title: str,
+) -> str:
+    if not note_path:
+        return ""
+    path = resolve_vault_dir(vault_dir) / note_path
+    if not path.exists() or not path.is_file():
+        return ""
+    needles = [
+        f"[[{object_id}]]",
+        f"[[{title}]]",
+        object_id,
+        title,
+    ]
+    try:
+        in_frontmatter = False
+        with path.open(encoding="utf-8") as handle:
+            for index, raw_line in enumerate(handle):
+                raw_line = raw_line.rstrip("\n")
+                if raw_line.strip() == "---":
+                    if index == 0:
+                        in_frontmatter = True
+                        continue
+                    if in_frontmatter:
+                        in_frontmatter = False
+                        continue
+                if in_frontmatter:
+                    continue
+                line = _clean_excerpt_line(raw_line)
+                if not line or line.startswith("---") or line.startswith("#"):
+                    continue
+                lowered = line.lower()
+                if any(needle and needle.lower() in lowered for needle in needles):
+                    return line[:240]
+    except (OSError, UnicodeDecodeError):
+        return ""
+    return ""
+
+
+def _build_source_backlink_rail(
+    vault_dir: Path | str,
+    *,
+    detail: dict[str, Any],
+    relations: list[dict[str, Any]],
+    requested_pack: str,
+) -> dict[str, object]:
+    object_id = str(detail["object"]["object_id"])
+    title = str(detail["object"]["title"])
+    evergreen_path = str(detail["provenance"].get("evergreen_path") or "")
+    source_notes = [
+        {
+            **item,
+            "excerpt": _source_excerpt_for_object(
+                vault_dir,
+                note_path=str(item.get("path") or ""),
+                object_id=object_id,
+                title=title,
+            ),
+            "jump_path": _scoped_path(
+                f"/note?path={quote(str(item.get('path') or ''), safe='')}",
+                pack_name=requested_pack,
+            ),
+        }
+        for item in detail["provenance"]["source_notes"]
+    ]
+    atlas_pages = [
+        {
+            **item,
+            "jump_path": _scoped_path(
+                f"/note?path={quote(str(item.get('path') or ''), safe='')}",
+                pack_name=requested_pack,
+            ),
+        }
+        for item in detail["provenance"]["mocs"]
+    ]
+    related_objects = []
+    for item in relations:
+        if len(related_objects) >= OBJECT_SOURCE_RAIL_RELATED_LIMIT:
+            break
+        related_objects.append(
+            {
+                "object_id": item["target_object_id"],
+                "title": item.get("target_title", item["target_object_id"]),
+                "relation_type": item["relation_type"],
+                "path": item.get("target_path", ""),
+            }
+        )
+    return {
+        "summary": (
+            f"{len(source_notes)} source notes, {len(atlas_pages)} atlas pages, "
+            f"{len(related_objects)} related objects"
+        ),
+        "evergreen": {
+            "title": title,
+            "path": evergreen_path,
+            "jump_path": (
+                _scoped_path(f"/note?path={quote(evergreen_path, safe='')}", pack_name=requested_pack)
+                if evergreen_path
+                else ""
+            ),
+        },
+        "source_notes": source_notes,
+        "atlas_pages": atlas_pages,
+        "related_objects": related_objects,
+    }
 
 
 def _compiled_section(
@@ -1628,6 +1781,13 @@ def build_object_page_payload(
         }
     )
     summary_text = detail["summary"]["summary_text"] if detail["summary"] else ""
+    reader_profile = _object_reader_profile(detail, relation_count=len(relations))
+    source_backlink_rail = _build_source_backlink_rail(
+        vault_dir,
+        detail=detail,
+        relations=relations,
+        requested_pack=requested_pack,
+    )
     stale_summary_details = (
         list_stale_summaries(
             vault_dir,
@@ -1853,6 +2013,8 @@ def build_object_page_payload(
         "assembly_contract": _assembly_contract("object_brief", pack_name=pack_name),
         "research_shell_enabled": research_shell_enabled,
         **detail,
+        "reader_profile": reader_profile,
+        "source_backlink_rail": source_backlink_rail,
         "production_chain": production_chain,
         "relations": relations,
         "claim_count": len(detail["claims"]),
@@ -1882,6 +2044,7 @@ def build_object_page_payload(
         "compiled_sections": compiled_sections,
         "section_nav": [
             {"href": "#summary", "label": "Summary"},
+            {"href": "#sources", "label": "Sources"},
             *_section_nav_from_compiled_sections(compiled_sections),
             {"href": "#claims", "label": "Claims"},
             {"href": "#relations", "label": "Relations"},

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -3396,6 +3396,44 @@ def test_render_object_page_hides_research_affordances_when_pack_lacks_research_
     assert "<h2>Contradictions</h2>" not in body
 
 
+def test_render_object_page_surfaces_reader_profile_and_source_rail(temp_vault):
+    import ovp_pipeline.commands.ui_server as ui_server
+    from ovp_pipeline.runtime import VaultLayout
+    from ovp_pipeline.ui.view_models import build_object_page_payload
+
+    source = temp_vault / "20-Areas" / "Tools" / "Topics" / "2026-04" / "Source Deep Dive_深度解读.md"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text(
+        """---
+note_id: source-deep-dive
+title: Source Deep Dive
+type: deep_dive
+date: 2026-04-13
+---
+
+# Source Deep Dive
+
+Mentions [[alpha]] as a local-first execution pattern.
+""",
+        encoding="utf-8",
+    )
+    _seed_truth_store(temp_vault)
+    db_path = VaultLayout.from_vault(temp_vault).knowledge_db
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("UPDATE objects SET object_kind = 'concept' WHERE object_id = 'alpha'")
+        conn.commit()
+
+    body = ui_server._render_object_page(build_object_page_payload(temp_vault, "alpha"))
+
+    assert '<span class="pill">Concept</span>' in body
+    assert "Alpha supports local-first execution." in body
+    assert "<h2>Sources &amp; Backlinks</h2>" in body
+    assert "Source Deep Dive" in body
+    assert "Mentions [[alpha]] as a local-first execution pattern." in body
+    assert "Related Objects" in body
+    assert "Beta" in body
+
+
 def test_render_topic_page_hides_research_affordances_when_pack_lacks_research_semantics(
     temp_vault, monkeypatch
 ):

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -175,6 +175,7 @@ def test_build_object_page_payload_hides_research_affordances_when_research_shel
     assert payload["open_contradiction_ids"] == []
     assert [item["label"] for item in payload["section_nav"]] == [
         "Summary",
+        "Sources",
         "Current State",
         "Why It Matters",
         "Evidence Traceability",
@@ -260,7 +261,7 @@ def test_build_object_page_payload_includes_provenance(temp_vault):
     source.write_text(
         """---
 note_id: source-deep-dive
-title: Source Deep Dive
+title: Alpha Source Deep Dive
 type: deep_dive
 date: 2026-04-13
 ---
@@ -308,6 +309,102 @@ Alpha supports local-first execution.
     assert payload["provenance"]["evergreen_path"].endswith("10-Knowledge/Evergreen/Alpha.md")
     assert payload["provenance"]["source_notes"][0]["slug"] == "source-deep-dive"
     assert payload["provenance"]["mocs"][0]["slug"] == "atlas-index"
+
+
+def test_build_object_page_payload_adds_reader_profile_and_source_backlink_rail(temp_vault):
+    from ovp_pipeline.runtime import VaultLayout
+    from ovp_pipeline.ui.view_models import build_object_page_payload
+
+    source = temp_vault / "20-Areas" / "Tools" / "Topics" / "2026-04" / "Source Deep Dive_深度解读.md"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text(
+        """---
+note_id: source-deep-dive
+title: Alpha Source Deep Dive
+type: deep_dive
+date: 2026-04-13
+---
+
+# Source Deep Dive
+
+Opening context.
+
+2026 Alpha adoption stayed local-first.
+
+Mentions [[alpha]] as a local-first execution pattern.
+""",
+        encoding="utf-8",
+    )
+    atlas = temp_vault / "10-Knowledge" / "Atlas" / "Atlas-Index.md"
+    atlas.write_text(
+        """---
+note_id: atlas-index
+title: Atlas Index
+type: moc
+date: 2026-04-13
+---
+
+# Atlas Index
+
+- [[alpha]]
+""",
+        encoding="utf-8",
+    )
+    _seed_truth_store(temp_vault)
+    db_path = VaultLayout.from_vault(temp_vault).knowledge_db
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("UPDATE objects SET object_kind = 'concept' WHERE object_id = 'alpha'")
+        conn.commit()
+
+    payload = build_object_page_payload(temp_vault, "alpha")
+
+    assert payload["reader_profile"] == {
+        "kind_label": "Concept",
+        "headline": "Alpha",
+        "dek": "Alpha supports local-first execution.",
+        "supporting_line": "1 claims · 1 relations · 1 source notes · 1 atlas pages",
+        "empty_summary": False,
+    }
+    assert payload["source_backlink_rail"]["summary"] == "1 source notes, 1 atlas pages, 1 related objects"
+    assert payload["source_backlink_rail"]["evergreen"]["path"].endswith("10-Knowledge/Evergreen/Alpha.md")
+    assert payload["source_backlink_rail"]["source_notes"][0]["title"] == "Alpha Source Deep Dive"
+    assert payload["source_backlink_rail"]["source_notes"][0]["excerpt"] == (
+        "2026 Alpha adoption stayed local-first."
+    )
+    assert payload["source_backlink_rail"]["source_notes"][0]["jump_path"] == (
+        "/note?path=20-Areas%2FTools%2FTopics%2F2026-04%2FSource%20Deep%20Dive_%E6%B7%B1%E5%BA%A6%E8%A7%A3%E8%AF%BB.md"
+    )
+    assert payload["source_backlink_rail"]["atlas_pages"][0]["title"] == "Atlas Index"
+    assert payload["source_backlink_rail"]["related_objects"][0]["title"] == "Beta"
+    assert payload["source_backlink_rail"]["related_objects"][0]["relation_type"] == "wikilink"
+
+
+def test_build_object_page_payload_degrades_when_source_excerpt_is_not_utf8(temp_vault):
+    from ovp_pipeline.ui.view_models import build_object_page_payload
+
+    source = temp_vault / "20-Areas" / "Tools" / "Topics" / "2026-04" / "Source Deep Dive_深度解读.md"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text(
+        """---
+note_id: source-deep-dive
+title: Source Deep Dive
+type: deep_dive
+date: 2026-04-13
+---
+
+# Source Deep Dive
+
+Mentions [[alpha]].
+""",
+        encoding="utf-8",
+    )
+    _seed_truth_store(temp_vault)
+    source.write_bytes(b"\xff\xfe\xfa")
+
+    payload = build_object_page_payload(temp_vault, "alpha")
+
+    assert payload["source_backlink_rail"]["source_notes"][0]["title"] == "Source Deep Dive"
+    assert payload["source_backlink_rail"]["source_notes"][0]["excerpt"] == ""
 
 
 def test_build_topic_overview_payload(temp_vault):


### PR DESCRIPTION
## Summary
- Add a reader-facing object profile with kind labels, readable headline/dek, and support counts.
- Add a Sources & Backlinks rail with evergreen jump, source-note excerpts, atlas links, and relation context.
- Update README, Architecture, Milestone, and Backlog so this round documents BL-009 as shipped and BL-008 as a first slice.

## Validation
- `PYTHONPATH=src python -m pytest tests/test_ui_view_models.py tests/test_ui_server.py tests/test_projection_labels.py tests/test_architecture_fitness.py -q` -> 173 passed
- `git diff --check` -> passed
- `python -m compileall -q src/ovp_pipeline` -> passed
- `PYTHONPATH=src python -m pytest -q` -> 1070 passed

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/79" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
