### PR TITLE
feat: add reader graph map

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -662,14 +662,14 @@ Main gaps:
 - Layer 4 fitness checks now cover the first hot-path and workflow-wiring cases; evidence completeness, projection replay, and import-boundary checks are still open.
 - Projection lifecycle markers need structured schema, scope, lease, and supersession.
 - Schema versioning is not yet wired into projection lifecycle.
-- The reader-first home is now the default entry; object pages have a first reader profile/source rail, while graph, search, and deeper per-kind object layouts still need product shape.
+- The reader-first home is now the default entry; object pages have a first reader profile/source rail; `/graph` has a first spatial map projection; search and deeper per-kind object layouts still need product shape.
 
 ## 18. Near-Term Architecture Actions
 
 Recommended order:
 
 1. Keep projection metadata attached to new access surfaces and add doctor/export checks that verify the labels are present.
-2. Continue reader-first Layer 3 product work on graph, search, and deeper per-kind object layouts.
+2. Continue reader-first Layer 3 product work on search and deeper per-kind object layouts.
 3. Add evidence spans and factual evidence completeness checks.
 4. Add candidate risk tiers and routing preview before expanding automatic promotion.
 5. Introduce structured `ProjectionRepairMarker` schema.
@@ -686,6 +686,6 @@ The architecture should not depend on backlog IDs to be valid. The table below i
 | Workflow wiring eval suite | `BL-004`, `KSR-026` shipped in PR #77 |
 | Evidence span / factual evidence completeness | `BL-006`, `KSR-001`, `KSR-018` |
 | Candidate risk layering | `BL-007`, `KSR-003` |
-| Reader-first access surfaces | `BL-001`; `BL-008` partial and `BL-009` done in PR #79; `BL-010` next |
+| Reader-first access surfaces | `BL-001`; `BL-008` partial and `BL-009` done in PR #79; `BL-010` done in PR #80 |
 | Projection repair lifecycle | `BL-020` |
 | Schema versioning and migration trigger | `BL-021` |

--- a/ARCHITECTURE.zh-CN.md
+++ b/ARCHITECTURE.zh-CN.md
@@ -773,7 +773,7 @@ Do not rely on ad hoc "just rerun the pipeline" behavior for schema changes.
 - governance / resolver contracts 还需要显式化。
 - schema versioning 和 projection compatibility 还需要工程化。
 - fitness functions 只落地了第一批，仍需扩展到 CI/doctor/pre-commit 的完整契约。
-- reader-first home 已经成为默认入口；object page 已有第一版 reader profile/source rail，graph、search 和更深的 per-kind object layout 还需要继续产品化。
+- reader-first home 已经成为默认入口；object page 已有第一版 reader profile/source rail；`/graph` 已有第一版 spatial map projection；search 和更深的 per-kind object layout 还需要继续产品化。
 
 ## 17. 近期架构动作
 
@@ -782,7 +782,7 @@ Do not rely on ad hoc "just rerun the pipeline" behavior for schema changes.
 优先顺序：
 
 1. 新增 access surface 时必须继续带 projection metadata，并补 doctor/export checks 验证标注存在。
-2. 继续做 reader-first Layer 3：graph、search 和更深的 per-kind object layout。
+2. 继续做 reader-first Layer 3：search 和更深的 per-kind object layout。
 3. 补 evidence span 和 factual evidence completeness checks。
 4. 补 candidate risk tiers 和 routing preview，再扩大自动 promotion。
 5. 引入结构化 ProjectionRepairMarker。
@@ -801,7 +801,7 @@ Do not rely on ad hoc "just rerun the pipeline" behavior for schema changes.
 | Workflow wiring eval suite | `BL-004`, `KSR-026` PR #77 已交付 |
 | Evidence span / factual evidence completeness | `BL-006`, `KSR-001`, `KSR-018` |
 | Candidate risk layering | `BL-007`, `KSR-003` |
-| Reader-first access surfaces | `BL-001`；`BL-008` partial、`BL-009` 已在 PR #79 交付；`BL-010` next |
+| Reader-first access surfaces | `BL-001`；`BL-008` partial、`BL-009` 已在 PR #79 交付；`BL-010` 已在 PR #80 交付 |
 | Projection repair lifecycle | `BL-020` |
 | Schema versioning and migration trigger | `BL-021` |
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -21,7 +21,7 @@ Rule: historical plans and vault research notes feed this file; they do not over
 | M0 Pipeline And Pack Foundation | Done | CLI, source lifecycle, pack/profile runtime, `knowledge.db`, first source-lifecycle idempotency slice |
 | M1 Operator Workbench And Review Runtime | Done / maintain | truth UI, candidates, signals/actions, contradictions, action worker |
 | M2 Roadmap And README Consolidation | Done | merged historical milestones, compiler roadmap, recent KSR input, reader-product research, and English-primary docs |
-| M3 Reader-First Knowledge Atlas | Active | reader home, `/ops` split, and first object source/backlink rail shipped; graph and deeper kind-specific object layouts still need product shape |
+| M3 Reader-First Knowledge Atlas | Active | reader home, `/ops` split, first object source/backlink rail, and visual graph map shipped; deeper kind-specific object layouts still need product shape |
 | M4 KSR Safety And Hot-Path Hardening | Active | projection labels, hot-path audit, and wiring evals shipped; routing preview, evidence spans, and candidate risk remain |
 | M5 Context Pack And Operational Runtime | Later | session snapshots, context budget, claim leases, provider facade, observability |
 | M6 Policy, Permission, And Knowledge Evolution | Later | permission layer, claim lifecycle, conflict detection, policy promotion |
@@ -41,7 +41,7 @@ Rule: historical plans and vault research notes feed this file; they do not over
 | BL-007 | P0 | Next | Candidate risk layering by evidence strength, identity ambiguity, sensitivity, and impact | M4, KSR-003 |
 | BL-008 | P1 | Partial | Kind-aware object pages for people, concepts, companies/tools/projects, events, and claims; first slice adds reader profile/kind labels | M3, PR #79 |
 | BL-009 | P1 | Done | Mention/backlink rail with excerpts, source jumps, and relation context | M3, reader-product note, PR #79 |
-| BL-010 | P1 | Next | Visual `/graph` MVP as a spatial corpus map; keep analytical clusters under ops/debug | M3 |
+| BL-010 | P1 | Done | Visual `/graph` MVP as a spatial corpus map; analytical clusters remain under `/clusters` for ops/debug | M3, PR #80 |
 | BL-011 | P1 | Later | Reader-oriented search grouped by kind, summary, evidence, and reason | M3/M4 |
 | BL-012 | P1 | Later | Trusted reuse event instrumentation for downstream use of accepted/cited knowledge | April 22 roadmap |
 | BL-013 | P1 | Later | Session snapshot / OVP context pack / explicit context budget | M5, KSR-004, KSR-017, KSR-022 |
@@ -90,13 +90,13 @@ Rule: historical plans and vault research notes feed this file; they do not over
 
 ## Next Decision
 
-`BL-001` is shipped in PR #75, `BL-003 + BL-004` are shipped in PR #77, `BL-002` is shipped in PR #78, and `BL-009` plus the first `BL-008` slice are shipped in PR #79. The default UI now has a reader-first entry point, `/ops` owns the operator dashboard, core access/materialized surfaces carry explicit projection labels, and object pages expose readable source/backlink rails.
+`BL-001` is shipped in PR #75, `BL-003 + BL-004` are shipped in PR #77, `BL-002` is shipped in PR #78, `BL-009` plus the first `BL-008` slice are shipped in PR #79, and `BL-010` is shipped in PR #80. The default UI now has a reader-first entry point, `/ops` owns the operator dashboard, core access/materialized surfaces carry explicit projection labels, object pages expose readable source/backlink rails, and `/graph` renders a reader-facing spatial map over graph projections.
 
-The next implementation PR should continue the reader product shape with **BL-010**. Object pages now have first-pass readable context, so the remaining obvious product gap is the visual graph MVP.
+The next implementation PR should move back to the KSR safety lane with **BL-005**. The reader shell now has a first-pass library, object page, and visual graph map; deeper per-kind object layouts remain, but routing preview is the next P0 risk reducer before more source lifecycle work.
 
 Recommended order:
 
-1. BL-010
-2. BL-005
-3. BL-006 + BL-007
-4. Continue BL-008 with deeper per-kind layouts
+1. BL-005
+2. BL-006 + BL-007
+3. Continue BL-008 with deeper per-kind layouts
+4. BL-011

--- a/MILESTONE.md
+++ b/MILESTONE.md
@@ -33,7 +33,7 @@ That means the user-facing product should make compiled knowledge easy to read f
 | M0 Pipeline And Pack Foundation | Done | CLI, source lifecycle, pack/profile runtime, `knowledge.db`, first source-lifecycle idempotency slice |
 | M1 Operator Workbench And Review Runtime | Done / maintain | truth UI, candidates, signals/actions, contradictions, action worker |
 | M2 Roadmap And README Consolidation | Done | merged historical milestones, compiler roadmap, recent KSR input, reader-product research, and the English-primary docs structure |
-| M3 Reader-First Knowledge Atlas | Active | reader home, `/ops` split, and first object source/backlink rail shipped; graph and deeper kind-specific object layouts remain |
+| M3 Reader-First Knowledge Atlas | Active | reader home, `/ops` split, first object source/backlink rail, and visual graph map shipped; deeper kind-specific object layouts remain |
 | M4 KSR Safety And Hot-Path Hardening | Active | projection labels, hot-path audit, and wiring evals shipped; routing preview, evidence spans, and candidate risk remain |
 | M5 Context Pack And Operational Runtime | Later | session snapshots, context budget, claim leases, provider facade, observability |
 | M6 Policy, Permission, And Knowledge Evolution | Later | permission layer, claim lifecycle, conflict detection, policy promotion |
@@ -51,7 +51,7 @@ That means the user-facing product should make compiled knowledge easy to read f
 | Evidence span / factual evidence completeness | `BL-006`, `KSR-001`, `KSR-018` |
 | Candidate risk layering | `BL-007`, `KSR-003` |
 | Kind-aware object pages and backlink rail | `BL-008` partial and `BL-009` done in PR #79 |
-| Visual graph MVP | `BL-010` |
+| Visual graph MVP | `BL-010` done in PR #80 |
 | Projection repair lifecycle | `BL-020` |
 | Schema versioning and migration trigger | `BL-021` |
 
@@ -59,10 +59,10 @@ That means the user-facing product should make compiled knowledge easy to read f
 
 Recommended order:
 
-1. Implement `BL-010`: ship the visual `/graph` MVP as a spatial corpus map.
-2. Implement `BL-005`: add article routing preview before source lifecycle changes.
-3. Implement `BL-006 + BL-007`: evidence spans and candidate risk layering.
-4. Continue `BL-008`: deeper per-kind object layouts beyond the first reader profile.
+1. Implement `BL-005`: add article routing preview before source lifecycle changes.
+2. Implement `BL-006 + BL-007`: evidence spans and candidate risk layering.
+3. Continue `BL-008`: deeper per-kind object layouts beyond the first reader profile.
+4. Implement `BL-011`: reader-oriented search grouped by kind, summary, evidence, and reason.
 
 ## Documentation Rules
 

--- a/MILESTONE.zh-CN.md
+++ b/MILESTONE.zh-CN.md
@@ -33,7 +33,7 @@ OVP 正在从 document-processing pipeline 变成：
 | M0 Pipeline And Pack Foundation | Done | CLI、source lifecycle、pack/profile runtime、`knowledge.db`、第一段 source-lifecycle idempotency |
 | M1 Operator Workbench And Review Runtime | Done / maintain | truth UI、candidates、signals/actions、contradictions、action worker |
 | M2 Roadmap And README Consolidation | Done | 已合并历史 milestones、compiler roadmap、近期 KSR 输入、reader-product 研究，以及英文主文档结构 |
-| M3 Reader-First Knowledge Atlas | Active | reader home、`/ops` 拆分、第一版 object source/backlink rail 已交付；graph 和更深的 kind-specific object layout 仍待推进 |
+| M3 Reader-First Knowledge Atlas | Active | reader home、`/ops` 拆分、第一版 object source/backlink rail、visual graph map 已交付；更深的 kind-specific object layout 仍待推进 |
 | M4 KSR Safety And Hot-Path Hardening | Active | projection labels、hot-path audit、wiring evals 已交付；routing preview、evidence spans、candidate risk 仍待推进 |
 | M5 Context Pack And Operational Runtime | Later | session snapshots、context budget、claim leases、provider facade、observability |
 | M6 Policy, Permission, And Knowledge Evolution | Later | permission layer、claim lifecycle、conflict detection、policy promotion |
@@ -51,7 +51,7 @@ OVP 正在从 document-processing pipeline 变成：
 | Evidence span / factual evidence completeness | `BL-006`, `KSR-001`, `KSR-018` |
 | Candidate risk layering | `BL-007`, `KSR-003` |
 | Kind-aware object pages and backlink rail | `BL-008` partial，`BL-009` 已在 PR #79 交付 |
-| Visual graph MVP | `BL-010` |
+| Visual graph MVP | `BL-010` 已在 PR #80 交付 |
 | Projection repair lifecycle | `BL-020` |
 | Schema versioning and migration trigger | `BL-021` |
 
@@ -59,10 +59,10 @@ OVP 正在从 document-processing pipeline 变成：
 
 建议顺序：
 
-1. 实施 `BL-010`：把 `/graph` 做成 spatial corpus map 的 MVP。
-2. 实施 `BL-005`：在 source lifecycle 继续变化前补 article routing preview。
-3. 实施 `BL-006 + BL-007`：推进 evidence span 和 candidate risk layering。
-4. 继续 `BL-008`：在第一版 reader profile 之后补更深的 per-kind object layout。
+1. 实施 `BL-005`：在 source lifecycle 继续变化前补 article routing preview。
+2. 实施 `BL-006 + BL-007`：推进 evidence span 和 candidate risk layering。
+3. 继续 `BL-008`：在第一版 reader profile 之后补更深的 per-kind object layout。
+4. 实施 `BL-011`：按 kind、summary、evidence、reason 重做 reader-oriented search。
 
 ## 文档规则
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The current release wires those layers into the actual runtime:
 - `ovp --full --with-refine` inserts `refine` before the final derived refresh
 - `ovp-autopilot` runs real-time `absorb -> moc -> knowledge_index`
 - `ovp-autopilot --with-refine` adds `refine` to that path
-- `ovp-ui` provides a local UI. The default `/` entry is now a reader-first Knowledge Library, while the operator dashboard lives under `/ops`; the next product wave makes object and graph pages readable.
+- `ovp-ui` provides a local UI. The default `/` entry is now a reader-first Knowledge Library, the operator dashboard lives under `/ops`, object pages expose source/backlink context, and `/graph` renders a reader-facing knowledge map.
 
 ## Why The Architecture Looks Like This
 
@@ -94,8 +94,8 @@ Current milestone sequence:
 | M0 Pipeline And Pack Foundation | Complete | CLI, source lifecycle, pack/profile runtime, `knowledge.db`, first KSR-013 slice |
 | M1 Operator Workbench And Review Runtime | Complete enough | truth UI, candidates, signals/actions, contradictions, action worker |
 | M2 Roadmap And README Consolidation | Complete | merged historical milestones, compiler roadmap, recent KSR input, and reader-product research |
-| M3 Reader-First Knowledge Atlas | Active | reader home, `/ops` split, and first object source/backlink rail shipped; graph pages and deeper per-kind object layouts still need product shape |
-| M4 KSR Safety And Hot-Path Hardening | Active | projection labels, hot-path audit, and wiring evals have shipped; evidence spans, candidate risk tiers, routing preview, and product-facing object/graph polish are next |
+| M3 Reader-First Knowledge Atlas | Active | reader home, `/ops` split, first object source/backlink rail, and visual graph map shipped; deeper per-kind object layouts still need product shape |
+| M4 KSR Safety And Hot-Path Hardening | Active | projection labels, hot-path audit, and wiring evals have shipped; routing preview, evidence spans, and candidate risk tiers are next |
 | M5 Context Pack And Operational Runtime | Later | session snapshots, context budget, claim leases, provider facades, observability |
 | M6 Policy, Permission, And Knowledge Evolution | Later | permission layer, claim lifecycle, conflict detection, policy promotion |
 | M7 Semantic Extraction And Query Feedback Loop | Later | relation extractor, query feedback, skill/routine extraction, notebook/raw-source mode |
@@ -103,8 +103,8 @@ Current milestone sequence:
 Current active backlog focus:
 
 - Shipped: `KSR-002` projection labels, `KSR-015` dashboard/search hot-path audit, `KSR-026` workflow wiring eval suite.
-- Product shipped: first readable object page profile and source/backlink rail.
-- Next: visual `/graph` MVP, `KSR-014` article routing preview, `KSR-001` evidence spans, `KSR-003` candidate risk tiers.
+- Product shipped: first readable object page profile, source/backlink rail, and visual `/graph` map.
+- Next: `KSR-014` article routing preview, `KSR-001` evidence spans, `KSR-003` candidate risk tiers, then deeper per-kind object layouts.
 - Product track: reader-first Knowledge Atlas stays a projection layer, not a new state system.
 
 ## Domain Packs

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The current release wires those layers into the actual runtime:
 - `ovp --full --with-refine` inserts `refine` before the final derived refresh
 - `ovp-autopilot` runs real-time `absorb -> moc -> knowledge_index`
 - `ovp-autopilot --with-refine` adds `refine` to that path
-- `ovp-ui` provides a local UI. The default `/` entry is now a reader-first Knowledge Library, the operator dashboard lives under `/ops`, object pages expose source/backlink context, and `/graph` renders a reader-facing knowledge map.
+- `ovp-ui` provides a local UI. The default `/` entry is now a reader-first Knowledge Library, the operator dashboard lives under `/ops`, object pages expose source/backlink context, and `/graph` (also `/map`) renders a reader-facing knowledge map.
 
 ## Why The Architecture Looks Like This
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -45,7 +45,7 @@ Obsidian Vault Pipeline（OVP）不是一个“多脚本拼装包”，也不只
 - `ovp --full --with-refine` 会在 `moc` 后追加 `refine`
 - `ovp-autopilot` 默认实时跑 `absorb -> moc -> knowledge_index`
 - `ovp-autopilot --with-refine` 会在实时链路里追加 `refine`
-- `ovp-ui` 提供本地 UI。默认 `/` 入口现在是 reader-first Knowledge Library，operator dashboard 放在 `/ops`；object page 已有 source/backlink 上下文，`/graph` 已是面向读者的 knowledge map。
+- `ovp-ui` 提供本地 UI。默认 `/` 入口现在是 reader-first Knowledge Library，operator dashboard 放在 `/ops`；object page 已有 source/backlink 上下文，`/graph`（也包括 `/map`）已是面向读者的 knowledge map。
 
 ## 为什么会变成现在这套架构
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -45,7 +45,7 @@ Obsidian Vault Pipeline（OVP）不是一个“多脚本拼装包”，也不只
 - `ovp --full --with-refine` 会在 `moc` 后追加 `refine`
 - `ovp-autopilot` 默认实时跑 `absorb -> moc -> knowledge_index`
 - `ovp-autopilot --with-refine` 会在实时链路里追加 `refine`
-- `ovp-ui` 提供本地 UI。默认 `/` 入口现在是 reader-first Knowledge Library，operator dashboard 放在 `/ops`；下一阶段继续把 object page 和 graph page 做成可读产品界面
+- `ovp-ui` 提供本地 UI。默认 `/` 入口现在是 reader-first Knowledge Library，operator dashboard 放在 `/ops`；object page 已有 source/backlink 上下文，`/graph` 已是面向读者的 knowledge map。
 
 ## 为什么会变成现在这套架构
 
@@ -92,8 +92,8 @@ Obsidian Vault Pipeline（OVP）不是一个“多脚本拼装包”，也不只
 | M0 Pipeline And Pack Foundation | Complete | CLI、source lifecycle、pack/profile、`knowledge.db`、KSR-013 第一版 |
 | M1 Operator Workbench And Review Runtime | Complete enough | truth UI、candidates、signals/actions、contradictions、action worker |
 | M2 Roadmap And README Consolidation | Complete | 已合并历史 milestone、compiler roadmap、近期 KSR 输入与 reader-product 研究，重整 README |
-| M3 Reader-First Knowledge Atlas | Active | reader home、`/ops` 拆分、第一版 object source/backlink rail 已交付；graph page 和更深的 per-kind object layout 仍需产品化 |
-| M4 KSR Safety And Hot-Path Hardening | Active | projection 标注、hot-path audit、wiring eval 已交付；下一步推进 evidence span、candidate 风险分层、routing preview，以及 object/graph 的产品化 |
+| M3 Reader-First Knowledge Atlas | Active | reader home、`/ops` 拆分、第一版 object source/backlink rail、visual graph map 已交付；更深的 per-kind object layout 仍需产品化 |
+| M4 KSR Safety And Hot-Path Hardening | Active | projection 标注、hot-path audit、wiring eval 已交付；下一步推进 routing preview、evidence span 和 candidate 风险分层 |
 | M5 Context Pack And Operational Runtime | Later | session snapshot、context budget、claim lease、provider facade、observability |
 | M6 Policy, Permission, And Knowledge Evolution | Later | permission layer、claim lifecycle、conflict detection、policy promotion |
 | M7 Semantic Extraction And Query Feedback Loop | Later | relation extractor、query feedback、skill/routine extraction、notebook/raw-source mode |
@@ -101,8 +101,8 @@ Obsidian Vault Pipeline（OVP）不是一个“多脚本拼装包”，也不只
 当前 active backlog 重点：
 
 - 已交付：`KSR-002` Projection 标注、`KSR-015` Dashboard/search hot-path audit、`KSR-026` Workflow wiring eval suite。
-- 产品侧已交付：第一版 readable object page profile 和 source/backlink rail。
-- 下一步：visual `/graph` MVP、`KSR-014` Article routing preview、`KSR-001` Evidence span 化、`KSR-003` Candidate 风险分层。
+- 产品侧已交付：第一版 readable object page profile、source/backlink rail 和 visual `/graph` map。
+- 下一步：`KSR-014` Article routing preview、`KSR-001` Evidence span 化、`KSR-003` Candidate 风险分层，然后继续更深的 per-kind object layout。
 - 产品线：Reader-first Knowledge Atlas 作为 projection layer 实现，不另建状态系统。
 
 ## Domain Packs

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -70,6 +70,8 @@ _GITHUB_REPO_RE = re.compile(r"https://github\.com/([^/\s]+)/([^/\s#]+)")
 _EVOLUTION_LINK_TYPES = ["challenges", "replaces", "enriches", "confirms"]
 _CANDIDATE_MERGE_AUTOFILL_THRESHOLD = 0.7
 _INLINE_MEMBER_LINK_LIMIT = 8
+_GRAPH_MAP_CLUSTER_PREVIEW_LIMIT = 6
+_GRAPH_MAP_NODE_LABEL_Y_OFFSET = 13
 
 
 def _render_limited_inline_links(
@@ -2652,6 +2654,11 @@ def _render_graph_map_page(payload: dict, *, action_path: str = "/graph") -> str
     query = payload.get("query", "")
     requested_pack = payload.get("requested_pack", "")
     layout = payload["layout"]
+    limit_note = (
+        f" Showing the first {payload['map_summary']['limit']} graph neighborhoods in this map."
+        if payload["map_summary"].get("is_limited")
+        else ""
+    )
     clusters = (
         "".join(
             "<li>"
@@ -2660,27 +2667,24 @@ def _render_graph_map_page(payload: dict, *, action_path: str = "/graph") -> str
             f" <span class='muted'>{cluster['member_count']} objects</span>"
             f"<div class='muted'>{escape(str(cluster['summary']))}</div>"
             "</li>"
-            for cluster in payload["clusters"][:6]
+            for cluster in payload["clusters"][:_GRAPH_MAP_CLUSTER_PREVIEW_LIMIT]
         )
         or "<li class='muted'>No graph clusters found yet.</li>"
     )
     notes = "".join(f"<li>{escape(note)}</li>" for note in payload["model_notes"])
-    payload = {
-        **payload,
-        "_node_lookup": {str(node["object_id"]): node for node in payload["nodes"]},
-    }
+    node_lookup = {str(node["object_id"]): node for node in payload["nodes"]}
     edge_lines = "".join(
         "<line "
-        f"x1='{payload['_node_lookup'][edge['source_object_id']]['x']}' "
-        f"y1='{payload['_node_lookup'][edge['source_object_id']]['y']}' "
-        f"x2='{payload['_node_lookup'][edge['target_object_id']]['x']}' "
-        f"y2='{payload['_node_lookup'][edge['target_object_id']]['y']}' "
+        f"x1='{node_lookup[edge['source_object_id']]['x']}' "
+        f"y1='{node_lookup[edge['source_object_id']]['y']}' "
+        f"x2='{node_lookup[edge['target_object_id']]['x']}' "
+        f"y2='{node_lookup[edge['target_object_id']]['y']}' "
         "stroke='#c7b8a6' stroke-width='1.4' stroke-opacity='0.7'>"
         f"<title>{escape(edge['source_title'])} -> {escape(edge['target_title'])}: {escape(edge['edge_kind'])}</title>"
         "</line>"
         for edge in payload["edges"]
-        if edge["source_object_id"] in payload["_node_lookup"]
-        and edge["target_object_id"] in payload["_node_lookup"]
+        if edge["source_object_id"] in node_lookup
+        and edge["target_object_id"] in node_lookup
     )
     node_marks = "".join(
         "<a "
@@ -2689,7 +2693,7 @@ def _render_graph_map_page(payload: dict, *, action_path: str = "/graph") -> str
         "stroke='#fffdfa' stroke-width='2'>"
         f"<title>{escape(str(node['title']))} · {escape(str(node['kind_label']))} · {node['degree']} links</title>"
         "</circle>"
-        f"<text x='{node['x']}' y='{float(node['y']) + float(node['radius']) + 13}' "
+        f"<text x='{node['x']}' y='{float(node['y']) + float(node['radius']) + _GRAPH_MAP_NODE_LABEL_Y_OFFSET}' "
         "text-anchor='middle' font-size='12' fill='#3c332b'>"
         f"{escape(str(node['title']))}</text>"
         "</a>"
@@ -2700,7 +2704,8 @@ def _render_graph_map_page(payload: dict, *, action_path: str = "/graph") -> str
         "".join(
             [
                 "<h1>Knowledge Graph</h1>",
-                "<p class='muted'>A reader map of nearby concepts, claims, people, and sources in this vault.</p>",
+                "<p class='muted'>A reader map of nearby concepts, claims, people, and sources in this vault."
+                f"{escape(limit_note)}</p>",
                 f"<form method='get' action='{escape(action_path)}'>",
                 (
                     f"<input type='hidden' name='pack' value='{escape(requested_pack)}' />"
@@ -2717,8 +2722,10 @@ def _render_graph_map_page(payload: dict, *, action_path: str = "/graph") -> str
                 "</section>",
                 "<section class='card'>",
                 "<h2>Map</h2>",
-                f"<svg id='graph-map-canvas' role='img' aria-label='Knowledge graph map' viewBox='0 0 {layout['width']} {layout['height']}' "
+                f"<svg id='graph-map-canvas' viewBox='0 0 {layout['width']} {layout['height']}' "
                 "style='width:100%;height:auto;max-height:68vh;background:#fffdfa;border:1px solid #e7e1d8;border-radius:8px'>",
+                "<title>Knowledge graph map</title>",
+                "<desc>Interactive map of knowledge objects and their connections.</desc>",
                 edge_lines,
                 node_marks,
                 "</svg>",

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -39,6 +39,7 @@ from ..ui.view_models import (
     build_derivation_browser_payload,
     build_evolution_browser_payload,
     build_event_dossier_payload,
+    build_graph_map_payload,
     build_note_page_payload,
     build_object_page_payload,
     build_objects_index_payload,
@@ -2647,6 +2648,99 @@ def _render_clusters_page(payload: dict, *, action_path: str = "/clusters") -> s
     )
 
 
+def _render_graph_map_page(payload: dict, *, action_path: str = "/graph") -> str:
+    query = payload.get("query", "")
+    requested_pack = payload.get("requested_pack", "")
+    layout = payload["layout"]
+    clusters = (
+        "".join(
+            "<li>"
+            f"<a href='{escape(str(cluster['detail_path']))}'>{escape(str(cluster['title']))}</a>"
+            f" <span class='pill'>{escape(str(cluster['priority_band']))}</span>"
+            f" <span class='muted'>{cluster['member_count']} objects</span>"
+            f"<div class='muted'>{escape(str(cluster['summary']))}</div>"
+            "</li>"
+            for cluster in payload["clusters"][:6]
+        )
+        or "<li class='muted'>No graph clusters found yet.</li>"
+    )
+    notes = "".join(f"<li>{escape(note)}</li>" for note in payload["model_notes"])
+    payload = {
+        **payload,
+        "_node_lookup": {str(node["object_id"]): node for node in payload["nodes"]},
+    }
+    edge_lines = "".join(
+        "<line "
+        f"x1='{payload['_node_lookup'][edge['source_object_id']]['x']}' "
+        f"y1='{payload['_node_lookup'][edge['source_object_id']]['y']}' "
+        f"x2='{payload['_node_lookup'][edge['target_object_id']]['x']}' "
+        f"y2='{payload['_node_lookup'][edge['target_object_id']]['y']}' "
+        "stroke='#c7b8a6' stroke-width='1.4' stroke-opacity='0.7'>"
+        f"<title>{escape(edge['source_title'])} -> {escape(edge['target_title'])}: {escape(edge['edge_kind'])}</title>"
+        "</line>"
+        for edge in payload["edges"]
+        if edge["source_object_id"] in payload["_node_lookup"]
+        and edge["target_object_id"] in payload["_node_lookup"]
+    )
+    node_marks = "".join(
+        "<a "
+        f"href='{escape(str(node['path']))}' aria-label='{escape(str(node['title']))}'>"
+        f"<circle cx='{node['x']}' cy='{node['y']}' r='{node['radius']}' fill='#9f4f24' "
+        "stroke='#fffdfa' stroke-width='2'>"
+        f"<title>{escape(str(node['title']))} · {escape(str(node['kind_label']))} · {node['degree']} links</title>"
+        "</circle>"
+        f"<text x='{node['x']}' y='{float(node['y']) + float(node['radius']) + 13}' "
+        "text-anchor='middle' font-size='12' fill='#3c332b'>"
+        f"{escape(str(node['title']))}</text>"
+        "</a>"
+        for node in payload["nodes"]
+    )
+    return _layout(
+        "Knowledge Graph",
+        "".join(
+            [
+                "<h1>Knowledge Graph</h1>",
+                "<p class='muted'>A reader map of nearby concepts, claims, people, and sources in this vault.</p>",
+                f"<form method='get' action='{escape(action_path)}'>",
+                (
+                    f"<input type='hidden' name='pack' value='{escape(requested_pack)}' />"
+                    if requested_pack
+                    else ""
+                ),
+                f"<input type='text' name='q' value='{escape(query)}' placeholder='Filter the map' /> ",
+                "<button type='submit'>Search</button>",
+                "</form>",
+                "<section class='grid stats'>",
+                f"<div class='card'><h2>Ideas</h2><p>{payload['map_summary']['node_count']}</p></div>",
+                f"<div class='card'><h2>Connections</h2><p>{payload['map_summary']['edge_count']}</p></div>",
+                f"<div class='card'><h2>Neighborhoods</h2><p>{payload['map_summary']['cluster_count']}</p></div>",
+                "</section>",
+                "<section class='card'>",
+                "<h2>Map</h2>",
+                f"<svg id='graph-map-canvas' role='img' aria-label='Knowledge graph map' viewBox='0 0 {layout['width']} {layout['height']}' "
+                "style='width:100%;height:auto;max-height:68vh;background:#fffdfa;border:1px solid #e7e1d8;border-radius:8px'>",
+                edge_lines,
+                node_marks,
+                "</svg>",
+                "</section>",
+                "<section class='grid two-col'>",
+                "<section class='card'><h2>How To Read This Map</h2>"
+                "<ul class='list-tight'>"
+                "<li>Each dot is a knowledge object you can open.</li>"
+                "<li>Lines show accepted graph relations from the local projection.</li>"
+                "<li>Nearby groups are reading neighborhoods, not canonical truth boundaries.</li>"
+                "</ul></section>",
+                "<section class='card'><h2>Neighborhoods</h2>"
+                f"<p><a href='{escape(_shell_href('/clusters', requested_pack))}'>Open Cluster Browser</a></p>"
+                f"<ul class='list-tight'>{clusters}</ul></section>",
+                "</section>",
+                f"<section class='card'><h2>Model Notes</h2><ul class='list-tight'>{notes}</ul></section>",
+            ]
+        ),
+        requested_pack=requested_pack,
+    )
+
+
 def _render_cluster_detail_page(payload: dict) -> str:
     cluster = payload["cluster"]
     requested_pack = payload.get("requested_pack", "")
@@ -4882,6 +4976,29 @@ def create_server(
                     )
                     self._write_html(_render_clusters_page(payload))
                     return
+                if path == "/api/graph":
+                    q = query.get("q", [""])[0]
+                    pack_name = query.get("pack", [""])[0] or None
+                    if self._guard_research_route(
+                        pack_name=pack_name, route_path="/graph", api=True
+                    ):
+                        return
+                    self._write_json(
+                        build_graph_map_payload(resolved_vault, pack_name=pack_name, query=q)
+                    )
+                    return
+                if path == "/graph":
+                    q = query.get("q", [""])[0]
+                    pack_name = query.get("pack", [""])[0] or None
+                    if self._guard_research_route(
+                        pack_name=pack_name, route_path="/graph", api=False
+                    ):
+                        return
+                    payload = build_graph_map_payload(
+                        resolved_vault, pack_name=pack_name, query=q
+                    )
+                    self._write_html(_render_graph_map_page(payload, action_path="/graph"))
+                    return
                 if path == "/map":
                     q = query.get("q", [""])[0]
                     pack_name = query.get("pack", [""])[0] or None
@@ -4889,10 +5006,10 @@ def create_server(
                         pack_name=pack_name, route_path="/map", api=False
                     ):
                         return
-                    payload = build_cluster_browser_payload(
+                    payload = build_graph_map_payload(
                         resolved_vault, pack_name=pack_name, query=q
                     )
-                    self._write_html(_render_clusters_page(payload, action_path="/map"))
+                    self._write_html(_render_graph_map_page(payload, action_path="/map"))
                     return
                 if path == "/api/cluster":
                     cluster_id = self._required(query, "id")

--- a/src/ovp_pipeline/ui/view_models.py
+++ b/src/ovp_pipeline/ui/view_models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import math
 import re
 import sqlite3
 from collections import Counter
@@ -55,6 +56,9 @@ from ..truth_api import (
 DEFAULT_CANDIDATE_BROWSER_LIMIT = 25
 DEFAULT_EVENT_DOSSIER_LIMIT = 25
 DEFAULT_TRACEABILITY_BROWSER_LIMIT = 15
+DEFAULT_GRAPH_MAP_LIMIT = 24
+GRAPH_MAP_WIDTH = 960
+GRAPH_MAP_HEIGHT = 640
 
 
 def _scoped_path(path: str, *, pack_name: str | None = None) -> str:
@@ -2837,6 +2841,148 @@ def build_cluster_browser_payload(
         "model_notes": [
             "Graph clusters currently come from pack-owned graph seed projections, not from a final semantic clustering model.",
             "Current research-tech clusters are relation/contradiction connected components over pack-scoped truth rows.",
+        ],
+    }
+
+
+def _clamp_graph_coordinate(value: float, minimum: float, maximum: float) -> float:
+    return max(minimum, min(maximum, value))
+
+
+def build_graph_map_payload(
+    vault_dir: Path | str,
+    *,
+    pack_name: str | None = None,
+    query: str | None = None,
+    limit: int = DEFAULT_GRAPH_MAP_LIMIT,
+) -> dict[str, Any]:
+    cluster_payload = build_cluster_browser_payload(
+        vault_dir,
+        pack_name=pack_name,
+        query=query,
+        limit=limit,
+    )
+    clusters = cluster_payload["items"]
+    requested_pack = pack_name or cluster_payload.get("requested_pack", "")
+    center_x = GRAPH_MAP_WIDTH / 2
+    center_y = GRAPH_MAP_HEIGHT / 2
+    cluster_orbit_x = GRAPH_MAP_WIDTH * 0.26
+    cluster_orbit_y = GRAPH_MAP_HEIGHT * 0.22
+    margin = 42.0
+    nodes: dict[str, dict[str, Any]] = {}
+    edges: dict[tuple[str, str, str], dict[str, Any]] = {}
+
+    for cluster_index, cluster in enumerate(clusters):
+        cluster_count = max(1, len(clusters))
+        cluster_angle = (2 * math.pi * cluster_index / cluster_count) if cluster_count > 1 else 0
+        cluster_x = center_x + (math.cos(cluster_angle) * cluster_orbit_x if cluster_count > 1 else 0)
+        cluster_y = center_y + (math.sin(cluster_angle) * cluster_orbit_y if cluster_count > 1 else 0)
+        members = cluster.get("members", [])
+        member_count = max(1, len(members))
+        local_radius = min(128.0, 42.0 + member_count * 12.0)
+        for member_index, member in enumerate(members):
+            object_id = str(member["object_id"])
+            member_angle = (2 * math.pi * member_index / member_count) - (math.pi / 2)
+            x = _clamp_graph_coordinate(cluster_x + math.cos(member_angle) * local_radius, margin, GRAPH_MAP_WIDTH - margin)
+            y = _clamp_graph_coordinate(cluster_y + math.sin(member_angle) * local_radius, margin, GRAPH_MAP_HEIGHT - margin)
+            node = nodes.setdefault(
+                object_id,
+                {
+                    "object_id": object_id,
+                    "title": str(member.get("title") or object_id),
+                    "object_kind": str(member.get("object_kind") or "object"),
+                    "kind_label": _object_kind_label(str(member.get("object_kind") or "")),
+                    "path": _scoped_path(
+                        f"/object?id={quote(object_id, safe='')}",
+                        pack_name=requested_pack,
+                    ),
+                    "x": round(x, 1),
+                    "y": round(y, 1),
+                    "degree": 0,
+                    "cluster_ids": [],
+                    "cluster_titles": [],
+                },
+            )
+            if cluster["cluster_id"] not in node["cluster_ids"]:
+                node["cluster_ids"].append(cluster["cluster_id"])
+                node["cluster_titles"].append(cluster.get("display_title") or cluster["label"])
+
+        try:
+            detail = get_graph_cluster_detail(
+                vault_dir,
+                str(cluster["cluster_id"]),
+                pack_name=requested_pack or None,
+            )
+        except (OSError, sqlite3.Error, ValueError):
+            detail = {"edges": []}
+        for edge in detail["edges"]:
+            source_id = str(edge["source_object_id"])
+            target_id = str(edge["target_object_id"])
+            if source_id not in nodes or target_id not in nodes:
+                continue
+            key = (source_id, target_id, str(edge["edge_kind"]))
+            edges.setdefault(
+                key,
+                {
+                    "source_object_id": source_id,
+                    "target_object_id": target_id,
+                    "edge_kind": str(edge["edge_kind"]),
+                    "weight": float(edge.get("weight") or 0.0),
+                    "source_title": nodes[source_id]["title"],
+                    "target_title": nodes[target_id]["title"],
+                },
+            )
+
+    for edge in edges.values():
+        nodes[edge["source_object_id"]]["degree"] += 1
+        nodes[edge["target_object_id"]]["degree"] += 1
+
+    node_items = sorted(nodes.values(), key=lambda item: (-int(item["degree"]), str(item["title"]).lower()))
+    for node in node_items:
+        node["radius"] = 7 + min(10, int(node["degree"]) * 2)
+    edge_items = sorted(
+        edges.values(),
+        key=lambda item: (
+            str(item["source_title"]).lower(),
+            str(item["target_title"]).lower(),
+            str(item["edge_kind"]),
+        ),
+    )
+    return {
+        "screen": "graph/map",
+        "requested_pack": requested_pack,
+        "projection_label": _access_projection_label(
+            surface="graph_map",
+            pack_name=pack_name,
+            generated_by="build_graph_map_payload",
+            derived_from=("knowledge.db.graph_clusters", "knowledge.db.graph_edges"),
+        ),
+        "query": query or "",
+        "limit": limit,
+        "is_limited": cluster_payload["is_limited"],
+        "layout": {"width": GRAPH_MAP_WIDTH, "height": GRAPH_MAP_HEIGHT},
+        "nodes": node_items,
+        "edges": edge_items,
+        "clusters": [
+            {
+                "cluster_id": str(cluster["cluster_id"]),
+                "title": str(cluster.get("display_title") or cluster["label"]),
+                "detail_path": str(cluster["detail_path"]),
+                "member_count": int(cluster["member_count"]),
+                "priority_band": str(cluster["priority_band"]),
+                "summary": str(cluster.get("top_summary_bullet") or cluster["priority_reason"]),
+            }
+            for cluster in clusters
+        ],
+        "map_summary": {
+            "node_count": len(node_items),
+            "edge_count": len(edge_items),
+            "cluster_count": len(clusters),
+            "largest_cluster_size": cluster_payload["largest_cluster_size"],
+        },
+        "model_notes": [
+            "This spatial map is a reader projection over graph clusters and edges.",
+            "Use it to see nearby ideas first; use the cluster browser for analytical/debug detail.",
         ],
     }
 

--- a/src/ovp_pipeline/ui/view_models.py
+++ b/src/ovp_pipeline/ui/view_models.py
@@ -59,6 +59,15 @@ DEFAULT_TRACEABILITY_BROWSER_LIMIT = 15
 DEFAULT_GRAPH_MAP_LIMIT = 24
 GRAPH_MAP_WIDTH = 960
 GRAPH_MAP_HEIGHT = 640
+GRAPH_MAP_CLUSTER_ORBIT_X_FACTOR = 0.26
+GRAPH_MAP_CLUSTER_ORBIT_Y_FACTOR = 0.22
+GRAPH_MAP_MARGIN = 42.0
+GRAPH_MAP_LOCAL_RADIUS_BASE = 42.0
+GRAPH_MAP_LOCAL_RADIUS_PER_MEMBER = 12.0
+GRAPH_MAP_LOCAL_RADIUS_MAX = 128.0
+GRAPH_MAP_NODE_BASE_RADIUS = 7
+GRAPH_MAP_NODE_RADIUS_PER_DEGREE = 2
+GRAPH_MAP_NODE_RADIUS_BONUS_MAX = 10
 
 
 def _scoped_path(path: str, *, pack_name: str | None = None) -> str:
@@ -2866,25 +2875,36 @@ def build_graph_map_payload(
     requested_pack = pack_name or cluster_payload.get("requested_pack", "")
     center_x = GRAPH_MAP_WIDTH / 2
     center_y = GRAPH_MAP_HEIGHT / 2
-    cluster_orbit_x = GRAPH_MAP_WIDTH * 0.26
-    cluster_orbit_y = GRAPH_MAP_HEIGHT * 0.22
-    margin = 42.0
+    cluster_orbit_x = GRAPH_MAP_WIDTH * GRAPH_MAP_CLUSTER_ORBIT_X_FACTOR
+    cluster_orbit_y = GRAPH_MAP_HEIGHT * GRAPH_MAP_CLUSTER_ORBIT_Y_FACTOR
     nodes: dict[str, dict[str, Any]] = {}
     edges: dict[tuple[str, str, str], dict[str, Any]] = {}
 
     for cluster_index, cluster in enumerate(clusters):
+        cluster_pack = str(cluster.get("pack") or requested_pack)
         cluster_count = max(1, len(clusters))
         cluster_angle = (2 * math.pi * cluster_index / cluster_count) if cluster_count > 1 else 0
         cluster_x = center_x + (math.cos(cluster_angle) * cluster_orbit_x if cluster_count > 1 else 0)
         cluster_y = center_y + (math.sin(cluster_angle) * cluster_orbit_y if cluster_count > 1 else 0)
         members = cluster.get("members", [])
         member_count = max(1, len(members))
-        local_radius = min(128.0, 42.0 + member_count * 12.0)
+        local_radius = min(
+            GRAPH_MAP_LOCAL_RADIUS_MAX,
+            GRAPH_MAP_LOCAL_RADIUS_BASE + member_count * GRAPH_MAP_LOCAL_RADIUS_PER_MEMBER,
+        )
         for member_index, member in enumerate(members):
             object_id = str(member["object_id"])
             member_angle = (2 * math.pi * member_index / member_count) - (math.pi / 2)
-            x = _clamp_graph_coordinate(cluster_x + math.cos(member_angle) * local_radius, margin, GRAPH_MAP_WIDTH - margin)
-            y = _clamp_graph_coordinate(cluster_y + math.sin(member_angle) * local_radius, margin, GRAPH_MAP_HEIGHT - margin)
+            x = _clamp_graph_coordinate(
+                cluster_x + math.cos(member_angle) * local_radius,
+                GRAPH_MAP_MARGIN,
+                GRAPH_MAP_WIDTH - GRAPH_MAP_MARGIN,
+            )
+            y = _clamp_graph_coordinate(
+                cluster_y + math.sin(member_angle) * local_radius,
+                GRAPH_MAP_MARGIN,
+                GRAPH_MAP_HEIGHT - GRAPH_MAP_MARGIN,
+            )
             node = nodes.setdefault(
                 object_id,
                 {
@@ -2894,7 +2914,7 @@ def build_graph_map_payload(
                     "kind_label": _object_kind_label(str(member.get("object_kind") or "")),
                     "path": _scoped_path(
                         f"/object?id={quote(object_id, safe='')}",
-                        pack_name=requested_pack,
+                        pack_name=cluster_pack,
                     ),
                     "x": round(x, 1),
                     "y": round(y, 1),
@@ -2911,7 +2931,7 @@ def build_graph_map_payload(
             detail = get_graph_cluster_detail(
                 vault_dir,
                 str(cluster["cluster_id"]),
-                pack_name=requested_pack or None,
+                pack_name=cluster_pack or None,
             )
         except (OSError, sqlite3.Error, ValueError):
             detail = {"edges": []}
@@ -2921,17 +2941,18 @@ def build_graph_map_payload(
             if source_id not in nodes or target_id not in nodes:
                 continue
             key = (source_id, target_id, str(edge["edge_kind"]))
-            edges.setdefault(
-                key,
-                {
+            edge_weight = float(edge.get("weight") or 0.0)
+            if key in edges:
+                edges[key]["weight"] += edge_weight
+            else:
+                edges[key] = {
                     "source_object_id": source_id,
                     "target_object_id": target_id,
                     "edge_kind": str(edge["edge_kind"]),
-                    "weight": float(edge.get("weight") or 0.0),
+                    "weight": edge_weight,
                     "source_title": nodes[source_id]["title"],
                     "target_title": nodes[target_id]["title"],
-                },
-            )
+                }
 
     for edge in edges.values():
         nodes[edge["source_object_id"]]["degree"] += 1
@@ -2939,7 +2960,10 @@ def build_graph_map_payload(
 
     node_items = sorted(nodes.values(), key=lambda item: (-int(item["degree"]), str(item["title"]).lower()))
     for node in node_items:
-        node["radius"] = 7 + min(10, int(node["degree"]) * 2)
+        node["radius"] = GRAPH_MAP_NODE_BASE_RADIUS + min(
+            GRAPH_MAP_NODE_RADIUS_BONUS_MAX,
+            int(node["degree"]) * GRAPH_MAP_NODE_RADIUS_PER_DEGREE,
+        )
     edge_items = sorted(
         edges.values(),
         key=lambda item: (
@@ -2979,6 +3003,8 @@ def build_graph_map_payload(
             "edge_count": len(edge_items),
             "cluster_count": len(clusters),
             "largest_cluster_size": cluster_payload["largest_cluster_size"],
+            "is_limited": cluster_payload["is_limited"],
+            "limit": limit,
         },
         "model_notes": [
             "This spatial map is a reader projection over graph clusters and edges.",

--- a/tests/test_projection_labels.py
+++ b/tests/test_projection_labels.py
@@ -61,6 +61,7 @@ def test_core_reader_payloads_carry_projection_labels(temp_vault):
     from ovp_pipeline.ui.view_models import (
         build_briefing_payload,
         build_cluster_browser_payload,
+        build_graph_map_payload,
         build_object_page_payload,
         build_runtime_home_payload,
         build_search_payload,
@@ -75,6 +76,7 @@ def test_core_reader_payloads_carry_projection_labels(temp_vault):
         (build_search_payload(temp_vault, query="alpha"), "search_results"),
         (build_object_page_payload(temp_vault, "alpha"), "object_page"),
         (build_briefing_payload(temp_vault), "briefing"),
+        (build_graph_map_payload(temp_vault), "graph_map"),
         (build_cluster_browser_payload(temp_vault), "graph_clusters"),
     ]
     for payload, surface in cases:

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -198,6 +198,9 @@ def test_ui_server_map_route_serves_readable_map_entry(temp_vault):
     assert "Beta" in body
     assert "How To Read This Map" in body
     assert "Open Cluster Browser" in body
+    assert "Showing the first 24 graph neighborhoods" in body
+    assert "<title>Knowledge graph map</title>" in body
+    assert "role='img'" not in body
     assert "action='/map'" in body
     assert "action='/clusters'" not in body
     assert 'href="/">Library</a>' in body
@@ -216,6 +219,7 @@ def test_ui_server_graph_route_serves_visual_graph_mvp(temp_vault):
     assert "graph-map-canvas" in body
     assert "Alpha" in body
     assert "Beta" in body
+    assert "Showing the first 24 graph neighborhoods" in body
     assert "action='/graph'" in body
     assert "action='/clusters'" not in body
     assert 'href="/">Library</a>' in body

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -192,8 +192,31 @@ def test_ui_server_map_route_serves_readable_map_entry(temp_vault):
     status, body = _fetch_ui_html(temp_vault, "/map")
 
     assert status == 200
-    assert "Graph Clusters" in body
+    assert "Knowledge Graph" in body
+    assert "graph-map-canvas" in body
+    assert "Alpha" in body
+    assert "Beta" in body
+    assert "How To Read This Map" in body
+    assert "Open Cluster Browser" in body
     assert "action='/map'" in body
+    assert "action='/clusters'" not in body
+    assert 'href="/">Library</a>' in body
+    assert 'href="/map">Map</a>' in body
+    assert 'href="/search">Search</a>' in body
+    assert 'href="/ops">Workbench</a>' in body
+
+
+def test_ui_server_graph_route_serves_visual_graph_mvp(temp_vault):
+    _seed_truth_store(temp_vault)
+
+    status, body = _fetch_ui_html(temp_vault, "/graph")
+
+    assert status == 200
+    assert "Knowledge Graph" in body
+    assert "graph-map-canvas" in body
+    assert "Alpha" in body
+    assert "Beta" in body
+    assert "action='/graph'" in body
     assert "action='/clusters'" not in body
     assert 'href="/">Library</a>' in body
     assert 'href="/map">Map</a>' in body

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -700,6 +700,77 @@ date: 2026-04-10
     assert all(item["pack"] == "default-knowledge" for item in payload["items"])
 
 
+def test_build_graph_map_payload_projects_clusters_into_reader_map(temp_vault):
+    from ovp_pipeline.knowledge_index import rebuild_knowledge_index
+    from ovp_pipeline.ui.view_models import build_graph_map_payload
+
+    source = temp_vault / "10-Knowledge" / "Evergreen" / "Source.md"
+    target = temp_vault / "10-Knowledge" / "Evergreen" / "Target.md"
+    third = temp_vault / "10-Knowledge" / "Evergreen" / "Third.md"
+    source.write_text(
+        """---
+note_id: source-note
+title: Source Note
+type: evergreen
+date: 2026-04-10
+---
+
+# Source Note
+
+Links to [[target-note]] and [[third-note]].
+""",
+        encoding="utf-8",
+    )
+    target.write_text(
+        """---
+note_id: target-note
+title: Target Note
+type: evergreen
+date: 2026-04-10
+---
+
+# Target Note
+
+Links back to [[source-note]].
+""",
+        encoding="utf-8",
+    )
+    third.write_text(
+        """---
+note_id: third-note
+title: Third Note
+type: evergreen
+date: 2026-04-10
+---
+
+# Third Note
+""",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    payload = build_graph_map_payload(temp_vault, pack_name="default-knowledge")
+
+    assert payload["screen"] == "graph/map"
+    assert payload["requested_pack"] == "default-knowledge"
+    assert payload["map_summary"]["node_count"] >= 3
+    assert payload["map_summary"]["edge_count"] >= 2
+    assert payload["map_summary"]["cluster_count"] >= 1
+    assert payload["projection_label"]["projection_surface"] == "graph_map"
+    assert payload["layout"]["width"] > 0
+    assert payload["layout"]["height"] > 0
+    assert {node["object_id"] for node in payload["nodes"]} >= {
+        "source-note",
+        "target-note",
+        "third-note",
+    }
+    assert all(0 <= node["x"] <= payload["layout"]["width"] for node in payload["nodes"])
+    assert all(0 <= node["y"] <= payload["layout"]["height"] for node in payload["nodes"])
+    assert any(edge["source_object_id"] == "source-note" for edge in payload["edges"])
+    assert payload["clusters"][0]["detail_path"].startswith("/cluster?id=")
+    assert "spatial" in payload["model_notes"][0].lower()
+
+
 def test_build_atlas_browser_payload_preserves_requested_pack(temp_vault):
     from ovp_pipeline.ui.view_models import build_atlas_browser_payload
 

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -768,6 +768,7 @@ date: 2026-04-10
     assert all(0 <= node["y"] <= payload["layout"]["height"] for node in payload["nodes"])
     assert any(edge["source_object_id"] == "source-note" for edge in payload["edges"])
     assert payload["clusters"][0]["detail_path"].startswith("/cluster?id=")
+    assert "pack=default-knowledge" in payload["clusters"][0]["detail_path"]
     assert "spatial" in payload["model_notes"][0].lower()
 
 


### PR DESCRIPTION
## Summary
- add a reader-facing graph map payload over graph cluster/edge projections
- render /graph and /map as a visual Knowledge Graph while keeping /clusters as the analytical browser
- update README, Architecture, Milestone, and Backlog docs for BL-010 and the next BL-005 sequence

## Tests
- PYTHONPATH=src python -m pytest tests/test_ui_view_models.py tests/test_ui_server.py tests/test_projection_labels.py tests/test_architecture_fitness.py -q
- python -m compileall -q src/ovp_pipeline
- PYTHONPATH=src python -m pytest -q
- git diff --check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/80" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Knowledge graph visualization now available at `/graph` with a spatial map displaying knowledge relationships, clusters, and connections in an interactive visual format.

* **Documentation**
  * Architecture, backlog, and milestone documentation updated to reflect the completed visual graph feature and adjusted implementation priorities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->