### PR TITLE
feat: preview article source routing

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -90,7 +90,7 @@ Layer 4 must not become a junk drawer. It is split into at least seven subaxes:
 | Promotion | The Policy + Review intersection that turns a candidate or derived proposal into accepted state | `promote_candidates.py`, `promotion_policy.py`, `promotion_audit.py`, `relation_promotion.py`, `workspace_promotion.py` |
 | Review | Human review and queue lifecycle | candidate review, contradiction review, stale-summary review |
 | Verification | Evidence, hash, freshness, and replay checks | evidence status, content hash check, review-state replay |
-| Routing / Dispatch | Workflow path selection, task dispatch, and ambiguity routing | workflow profile routing, ambiguity dispatch, source routing preview |
+| Routing / Dispatch | Workflow path selection, task dispatch, and ambiguity routing | workflow profile routing, ambiguity dispatch, source routing preview JSON |
 | Repair | Projection lifecycle and rebuild control | metadata repair marker, full rebuild marker, semantic reindex marker |
 | Audit | Accountability chain and immutable event records | audit JSONL, promotion event, review event |
 
@@ -442,6 +442,10 @@ Operational rules:
    - Runtime: Ingest
    - Architecture: Layer 1 input
 
+1a. `ovp-absorb --dry-run --json` can emit `source_lifecycle.routing_preview`
+   - Layer 4: Routing / Dispatch explains the planned source route before mutation
+   - The preview does not move files, initialize LLMs, or create derived state
+
 2. Ingest normalizes source metadata
    - Runtime: Ingest
    - Does not create accepted factual claims
@@ -652,6 +656,7 @@ Current implementation roughly maps as follows:
 | `truth_api.py` | read/query interface | Layer 2/3 access |
 | `ovp-ui` | dashboard, object pages, graph, signals/actions | Layer 3 + some Layer 4 controls |
 | promotion modules | candidate/relation/workspace promotion | Layer 4 Promotion + Audit |
+| source lifecycle routing preview | `ovp-absorb --dry-run --json` `source_lifecycle.routing_preview` | Layer 4 Routing / Dispatch |
 | doctor/lint | checks and repair hints | Layer 4 Verification + Repair |
 | packs | `research-tech`, `default-knowledge` | ownership perspective |
 
@@ -659,7 +664,7 @@ Main gaps:
 
 - Layer 1 claim/evidence contracts are not explicit enough yet.
 - Layer 2 / Layer 3 projection labels now exist on core access payloads and materialized reader artifacts; doctor/export enforcement and future surfaces still need to consume them consistently.
-- Layer 4 fitness checks now cover the first hot-path and workflow-wiring cases; evidence completeness, projection replay, and import-boundary checks are still open.
+- Layer 4 fitness checks now cover the first hot-path, workflow-wiring, and source routing preview cases; evidence completeness, projection replay, and import-boundary checks are still open.
 - Projection lifecycle markers need structured schema, scope, lease, and supersession.
 - Schema versioning is not yet wired into projection lifecycle.
 - The reader-first home is now the default entry; object pages have a first reader profile/source rail; `/graph` has a first spatial map projection; search and deeper per-kind object layouts still need product shape.
@@ -671,7 +676,7 @@ Recommended order:
 1. Keep projection metadata attached to new access surfaces and add doctor/export checks that verify the labels are present.
 2. Continue reader-first Layer 3 product work on search and deeper per-kind object layouts.
 3. Add evidence spans and factual evidence completeness checks.
-4. Add candidate risk tiers and routing preview before expanding automatic promotion.
+4. Add candidate risk tiers before expanding automatic promotion.
 5. Introduce structured `ProjectionRepairMarker` schema.
 6. Add schema version fields to Authority and derived projection state.
 
@@ -684,6 +689,7 @@ The architecture should not depend on backlog IDs to be valid. The table below i
 | Projection marking | `BL-002`, `KSR-002` shipped in PR #78 |
 | Dashboard/search hot-path audit | `BL-003`, `KSR-015` shipped in PR #77 |
 | Workflow wiring eval suite | `BL-004`, `KSR-026` shipped in PR #77 |
+| Article routing preview | `BL-005`, `KSR-014` done in PR #81 |
 | Evidence span / factual evidence completeness | `BL-006`, `KSR-001`, `KSR-018` |
 | Candidate risk layering | `BL-007`, `KSR-003` |
 | Reader-first access surfaces | `BL-001`; `BL-008` partial and `BL-009` done in PR #79; `BL-010` done in PR #80 |

--- a/ARCHITECTURE.zh-CN.md
+++ b/ARCHITECTURE.zh-CN.md
@@ -90,7 +90,7 @@ Layer 4 不能变成“什么都往里塞”的 junk drawer。它内部至少拆
 | Promotion | Policy + Review 的交集，把 candidate / derived proposal 变成 accepted state | `promote_candidates.py`, `promotion_policy.py`, `promotion_audit.py`, `relation_promotion.py`, `workspace_promotion.py` |
 | Review | 人工审阅和队列生命周期 | candidate review, contradiction review, stale summary review |
 | Verification | evidence、hash、freshness、replay 的验证 | evidence status, content hash check, review state replay |
-| Routing / Dispatch | workflow 走向、任务派发和歧义分流 | workflow profile routing, ambiguity dispatch, source routing preview |
+| Routing / Dispatch | workflow 走向、任务派发和歧义分流 | workflow profile routing, ambiguity dispatch, source routing preview JSON |
 | Repair | projection lifecycle 和 rebuild 控制 | metadata repair marker, full rebuild marker, semantic reindex marker |
 | Audit | 责任链和不可变事件记录 | audit JSONL, promotion event, review event |
 
@@ -547,6 +547,10 @@ Operational rules:
    - 架构层: Layer 1 input
    - Layer 4: Routing 决定进入哪条 workflow
 
+1a. `ovp-absorb --dry-run --json` 可以输出 `source_lifecycle.routing_preview`
+   - Layer 4: Routing / Dispatch 在 mutation 前解释计划路由
+   - preview 不移动文件、不初始化 LLM、不创建 derived state
+
 2. Ingest stage normalize 文件和 source metadata
    - 写入 source note / raw material
    - 不直接产生 accepted factual claim
@@ -768,7 +772,7 @@ Do not rely on ad hoc "just rerun the pipeline" behavior for schema changes.
 - Layer 4 子轴还没有完全反映到代码结构。
 - projection labels 已经贯穿核心 access payload 和 materialized reader artifacts；doctor/export enforcement 以及未来新增 surface 还需要持续消费这些标注。
 - projection lifecycle marker 还没有明确区分 metadata_only / full_rebuild / semantic_reindex。
-- dashboard/search hot path 和 workflow wiring 已经有第一批 fitness checks；evidence completeness、projection replay、import-boundary checks 仍未完成。
+- dashboard/search hot path、workflow wiring 和 source routing preview 已经有第一批 fitness checks；evidence completeness、projection replay、import-boundary checks 仍未完成。
 - context assembly recipes 还需要收束。
 - governance / resolver contracts 还需要显式化。
 - schema versioning 和 projection compatibility 还需要工程化。
@@ -784,7 +788,7 @@ Do not rely on ad hoc "just rerun the pipeline" behavior for schema changes.
 1. 新增 access surface 时必须继续带 projection metadata，并补 doctor/export checks 验证标注存在。
 2. 继续做 reader-first Layer 3：search 和更深的 per-kind object layout。
 3. 补 evidence span 和 factual evidence completeness checks。
-4. 补 candidate risk tiers 和 routing preview，再扩大自动 promotion。
+4. 补 candidate risk tiers，再扩大自动 promotion。
 5. 引入结构化 ProjectionRepairMarker。
 6. 给 Authority 和 derived projection state 增加 schema version 字段。
 7. 把 routing、promotion、review、permission 从 prompt/散落代码中收束为显式 governance/dispatch contract。
@@ -799,6 +803,7 @@ Do not rely on ad hoc "just rerun the pipeline" behavior for schema changes.
 | Projection marking | `BL-002`, `KSR-002` PR #78 已交付 |
 | Dashboard/search hot-path audit | `BL-003`, `KSR-015` PR #77 已交付 |
 | Workflow wiring eval suite | `BL-004`, `KSR-026` PR #77 已交付 |
+| Article routing preview | `BL-005`, `KSR-014` 已在 PR #81 交付 |
 | Evidence span / factual evidence completeness | `BL-006`, `KSR-001`, `KSR-018` |
 | Candidate risk layering | `BL-007`, `KSR-003` |
 | Reader-first access surfaces | `BL-001`；`BL-008` partial、`BL-009` 已在 PR #79 交付；`BL-010` 已在 PR #80 交付 |

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -22,7 +22,7 @@ Rule: historical plans and vault research notes feed this file; they do not over
 | M1 Operator Workbench And Review Runtime | Done / maintain | truth UI, candidates, signals/actions, contradictions, action worker |
 | M2 Roadmap And README Consolidation | Done | merged historical milestones, compiler roadmap, recent KSR input, reader-product research, and English-primary docs |
 | M3 Reader-First Knowledge Atlas | Active | reader home, `/ops` split, first object source/backlink rail, and visual graph map shipped; deeper kind-specific object layouts still need product shape |
-| M4 KSR Safety And Hot-Path Hardening | Active | projection labels, hot-path audit, and wiring evals shipped; routing preview, evidence spans, and candidate risk remain |
+| M4 KSR Safety And Hot-Path Hardening | Active | projection labels, hot-path audit, wiring evals, and article routing preview shipped; evidence spans and candidate risk remain |
 | M5 Context Pack And Operational Runtime | Later | session snapshots, context budget, claim leases, provider facade, observability |
 | M6 Policy, Permission, And Knowledge Evolution | Later | permission layer, claim lifecycle, conflict detection, policy promotion |
 | M7 Semantic Extraction And Query Feedback Loop | Later | relation extractor, query feedback, routines, notebook/raw-source mode |
@@ -36,7 +36,7 @@ Rule: historical plans and vault research notes feed this file; they do not over
 | BL-002 | P0 | Done | Projection marking: label dashboard, MOC, wiki, briefing, reader pages, graph, and context packs as projections | M4, KSR-002, PR #78 |
 | BL-003 | P0 | Done | Dashboard/search hot-path audit: default UI/search paths must not scan raw/PDF/Office sources | M4, KSR-015, `docs/plans/2026-04-30-bl-003-004-hot-path-wiring-safety.md`, PR #77 |
 | BL-004 | P0 | Done | Workflow wiring eval suite for lifecycle routing, promote gates, projection labels, hot paths, and read/write boundaries | M4, KSR-026, `docs/plans/2026-04-30-bl-003-004-hot-path-wiring-safety.md`, PR #77 |
-| BL-005 | P0 | Next | Article routing preview before source lifecycle changes | M4, KSR-014 |
+| BL-005 | P0 | Done | Article routing preview before source lifecycle changes | M4, KSR-014 |
 | BL-006 | P0 | Next | Evidence span schema and markdown-aware locator backfill | M4, KSR-001, KSR-018 |
 | BL-007 | P0 | Next | Candidate risk layering by evidence strength, identity ambiguity, sensitivity, and impact | M4, KSR-003 |
 | BL-008 | P1 | Partial | Kind-aware object pages for people, concepts, companies/tools/projects, events, and claims; first slice adds reader profile/kind labels | M3, PR #79 |
@@ -66,12 +66,12 @@ Rule: historical plans and vault research notes feed this file; they do not over
 | KSR-006 Claim lifecycle 字段 | BL-015 | Later |
 | KSR-007 Conflict detection 常规化 | BL-016 | Later |
 | KSR-008 High-risk user profile gate | BL-016 | Later |
-| KSR-009 Cost-aware workflow routing | BL-003/BL-005 | Partial: hot-path guard done; article routing preview remains |
+| KSR-009 Cost-aware workflow routing | BL-003/BL-005 | Partial: hot-path guard and article routing preview done; broader routing policy remains |
 | KSR-010 Skill/routine extraction profile | BL-019 | Later |
 | KSR-011 Notebook/raw-source mode | BL-019 | Later |
 | KSR-012 Ingest ROI metrics | BL-019 | Later |
 | KSR-013 Source lifecycle idempotency | M0/M4 | Repo first slice done; verify and mirror vault status |
-| KSR-014 Article routing preview | BL-005 | Next |
+| KSR-014 Article routing preview | BL-005 | Done |
 | KSR-015 Dashboard/search hot-path audit | BL-003 | Done |
 | KSR-016 Hybrid retrieval experiment | BL-019 | Later |
 | KSR-017 Explicit context budget | BL-013 | Later |
@@ -90,13 +90,12 @@ Rule: historical plans and vault research notes feed this file; they do not over
 
 ## Next Decision
 
-`BL-001` is shipped in PR #75, `BL-003 + BL-004` are shipped in PR #77, `BL-002` is shipped in PR #78, `BL-009` plus the first `BL-008` slice are shipped in PR #79, and `BL-010` is shipped in PR #80. The default UI now has a reader-first entry point, `/ops` owns the operator dashboard, core access/materialized surfaces carry explicit projection labels, object pages expose readable source/backlink rails, and `/graph` renders a reader-facing spatial map over graph projections.
+`BL-001` is shipped in PR #75, `BL-003 + BL-004` are shipped in PR #77, `BL-002` is shipped in PR #78, `BL-009` plus the first `BL-008` slice are shipped in PR #79, `BL-010` is shipped in PR #80, and `BL-005` is implemented in PR #81. The default UI now has a reader-first entry point, `/ops` owns the operator dashboard, core access/materialized surfaces carry explicit projection labels, object pages expose readable source/backlink rails, `/graph` renders a reader-facing spatial map over graph projections, and `ovp-absorb --dry-run --json` explains source lifecycle routing before mutation.
 
-The next implementation PR should move back to the KSR safety lane with **BL-005**. The reader shell now has a first-pass library, object page, and visual graph map; deeper per-kind object layouts remain, but routing preview is the next P0 risk reducer before more source lifecycle work.
+The next implementation PR should continue the KSR safety lane with **BL-006 + BL-007**. Evidence spans and candidate risk tiers are the next P0 risk reducers before expanding automatic promotion or richer reader search.
 
 Recommended order:
 
-1. BL-005
-2. BL-006 + BL-007
-3. Continue BL-008 with deeper per-kind layouts
-4. BL-011
+1. BL-006 + BL-007
+2. Continue BL-008 with deeper per-kind layouts
+3. BL-011

--- a/MILESTONE.md
+++ b/MILESTONE.md
@@ -34,7 +34,7 @@ That means the user-facing product should make compiled knowledge easy to read f
 | M1 Operator Workbench And Review Runtime | Done / maintain | truth UI, candidates, signals/actions, contradictions, action worker |
 | M2 Roadmap And README Consolidation | Done | merged historical milestones, compiler roadmap, recent KSR input, reader-product research, and the English-primary docs structure |
 | M3 Reader-First Knowledge Atlas | Active | reader home, `/ops` split, first object source/backlink rail, and visual graph map shipped; deeper kind-specific object layouts remain |
-| M4 KSR Safety And Hot-Path Hardening | Active | projection labels, hot-path audit, and wiring evals shipped; routing preview, evidence spans, and candidate risk remain |
+| M4 KSR Safety And Hot-Path Hardening | Active | projection labels, hot-path audit, wiring evals, and article routing preview shipped; evidence spans and candidate risk remain |
 | M5 Context Pack And Operational Runtime | Later | session snapshots, context budget, claim leases, provider facade, observability |
 | M6 Policy, Permission, And Knowledge Evolution | Later | permission layer, claim lifecycle, conflict detection, policy promotion |
 | M7 Semantic Extraction And Query Feedback Loop | Later | relation extractor, query feedback, routines, notebook/raw-source mode |
@@ -47,7 +47,7 @@ That means the user-facing product should make compiled knowledge easy to read f
 | Projection marking | `BL-002`, `KSR-002` done in PR #78 |
 | Dashboard/search hot-path audit | `BL-003`, `KSR-015` done in PR #77 |
 | Workflow wiring eval suite | `BL-004`, `KSR-026` done in PR #77 |
-| Article routing preview | `BL-005`, `KSR-014` |
+| Article routing preview | `BL-005`, `KSR-014` done in PR #81 |
 | Evidence span / factual evidence completeness | `BL-006`, `KSR-001`, `KSR-018` |
 | Candidate risk layering | `BL-007`, `KSR-003` |
 | Kind-aware object pages and backlink rail | `BL-008` partial and `BL-009` done in PR #79 |
@@ -59,10 +59,9 @@ That means the user-facing product should make compiled knowledge easy to read f
 
 Recommended order:
 
-1. Implement `BL-005`: add article routing preview before source lifecycle changes.
-2. Implement `BL-006 + BL-007`: evidence spans and candidate risk layering.
-3. Continue `BL-008`: deeper per-kind object layouts beyond the first reader profile.
-4. Implement `BL-011`: reader-oriented search grouped by kind, summary, evidence, and reason.
+1. Implement `BL-006 + BL-007`: evidence spans and candidate risk layering.
+2. Continue `BL-008`: deeper per-kind object layouts beyond the first reader profile.
+3. Implement `BL-011`: reader-oriented search grouped by kind, summary, evidence, and reason.
 
 ## Documentation Rules
 

--- a/MILESTONE.zh-CN.md
+++ b/MILESTONE.zh-CN.md
@@ -34,7 +34,7 @@ OVP 正在从 document-processing pipeline 变成：
 | M1 Operator Workbench And Review Runtime | Done / maintain | truth UI、candidates、signals/actions、contradictions、action worker |
 | M2 Roadmap And README Consolidation | Done | 已合并历史 milestones、compiler roadmap、近期 KSR 输入、reader-product 研究，以及英文主文档结构 |
 | M3 Reader-First Knowledge Atlas | Active | reader home、`/ops` 拆分、第一版 object source/backlink rail、visual graph map 已交付；更深的 kind-specific object layout 仍待推进 |
-| M4 KSR Safety And Hot-Path Hardening | Active | projection labels、hot-path audit、wiring evals 已交付；routing preview、evidence spans、candidate risk 仍待推进 |
+| M4 KSR Safety And Hot-Path Hardening | Active | projection labels、hot-path audit、wiring evals、article routing preview 已交付；evidence spans、candidate risk 仍待推进 |
 | M5 Context Pack And Operational Runtime | Later | session snapshots、context budget、claim leases、provider facade、observability |
 | M6 Policy, Permission, And Knowledge Evolution | Later | permission layer、claim lifecycle、conflict detection、policy promotion |
 | M7 Semantic Extraction And Query Feedback Loop | Later | relation extractor、query feedback、routines、notebook/raw-source mode |
@@ -47,7 +47,7 @@ OVP 正在从 document-processing pipeline 变成：
 | Projection marking | `BL-002`, `KSR-002` 已在 PR #78 交付 |
 | Dashboard/search hot-path audit | `BL-003`, `KSR-015` 已在 PR #77 交付 |
 | Workflow wiring eval suite | `BL-004`, `KSR-026` 已在 PR #77 交付 |
-| Article routing preview | `BL-005`, `KSR-014` |
+| Article routing preview | `BL-005`, `KSR-014` 已在 PR #81 交付 |
 | Evidence span / factual evidence completeness | `BL-006`, `KSR-001`, `KSR-018` |
 | Candidate risk layering | `BL-007`, `KSR-003` |
 | Kind-aware object pages and backlink rail | `BL-008` partial，`BL-009` 已在 PR #79 交付 |
@@ -59,10 +59,9 @@ OVP 正在从 document-processing pipeline 变成：
 
 建议顺序：
 
-1. 实施 `BL-005`：在 source lifecycle 继续变化前补 article routing preview。
-2. 实施 `BL-006 + BL-007`：推进 evidence span 和 candidate risk layering。
-3. 继续 `BL-008`：在第一版 reader profile 之后补更深的 per-kind object layout。
-4. 实施 `BL-011`：按 kind、summary、evidence、reason 重做 reader-oriented search。
+1. 实施 `BL-006 + BL-007`：推进 evidence span 和 candidate risk layering。
+2. 继续 `BL-008`：在第一版 reader profile 之后补更深的 per-kind object layout。
+3. 实施 `BL-011`：按 kind、summary、evidence、reason 重做 reader-oriented search。
 
 ## 文档规则
 

--- a/README.md
+++ b/README.md
@@ -95,16 +95,16 @@ Current milestone sequence:
 | M1 Operator Workbench And Review Runtime | Complete enough | truth UI, candidates, signals/actions, contradictions, action worker |
 | M2 Roadmap And README Consolidation | Complete | merged historical milestones, compiler roadmap, recent KSR input, and reader-product research |
 | M3 Reader-First Knowledge Atlas | Active | reader home, `/ops` split, first object source/backlink rail, and visual graph map shipped; deeper per-kind object layouts still need product shape |
-| M4 KSR Safety And Hot-Path Hardening | Active | projection labels, hot-path audit, and wiring evals have shipped; routing preview, evidence spans, and candidate risk tiers are next |
+| M4 KSR Safety And Hot-Path Hardening | Active | projection labels, hot-path audit, wiring evals, and article routing preview have shipped; evidence spans and candidate risk tiers are next |
 | M5 Context Pack And Operational Runtime | Later | session snapshots, context budget, claim leases, provider facades, observability |
 | M6 Policy, Permission, And Knowledge Evolution | Later | permission layer, claim lifecycle, conflict detection, policy promotion |
 | M7 Semantic Extraction And Query Feedback Loop | Later | relation extractor, query feedback, skill/routine extraction, notebook/raw-source mode |
 
 Current active backlog focus:
 
-- Shipped: `KSR-002` projection labels, `KSR-015` dashboard/search hot-path audit, `KSR-026` workflow wiring eval suite.
+- Shipped: `KSR-002` projection labels, `KSR-014` article routing preview, `KSR-015` dashboard/search hot-path audit, `KSR-026` workflow wiring eval suite.
 - Product shipped: first readable object page profile, source/backlink rail, and visual `/graph` map.
-- Next: `KSR-014` article routing preview, `KSR-001` evidence spans, `KSR-003` candidate risk tiers, then deeper per-kind object layouts.
+- Next: `KSR-001` evidence spans, `KSR-003` candidate risk tiers, then deeper per-kind object layouts.
 - Product track: reader-first Knowledge Atlas stays a projection layer, not a new state system.
 
 ## Domain Packs
@@ -382,6 +382,7 @@ Refine is not hidden or missing. It is wired in, but opt-in by default to avoid 
 | Command | Purpose |
 |---|---|
 | `ovp-absorb --recent 7 --json` | Absorb recent deep dives |
+| `ovp-absorb --file <source.md> --dry-run --json` | Preview source lifecycle routing before moving or processing source material |
 | `ovp-evergreen --recent 7 --json` | Compatibility alias for `ovp-absorb` |
 | `ovp-cleanup --all --json` | Generate cleanup proposals |
 | `ovp-cleanup --all --write --json` | Apply deterministic cleanup |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -93,16 +93,16 @@ Obsidian Vault Pipeline（OVP）不是一个“多脚本拼装包”，也不只
 | M1 Operator Workbench And Review Runtime | Complete enough | truth UI、candidates、signals/actions、contradictions、action worker |
 | M2 Roadmap And README Consolidation | Complete | 已合并历史 milestone、compiler roadmap、近期 KSR 输入与 reader-product 研究，重整 README |
 | M3 Reader-First Knowledge Atlas | Active | reader home、`/ops` 拆分、第一版 object source/backlink rail、visual graph map 已交付；更深的 per-kind object layout 仍需产品化 |
-| M4 KSR Safety And Hot-Path Hardening | Active | projection 标注、hot-path audit、wiring eval 已交付；下一步推进 routing preview、evidence span 和 candidate 风险分层 |
+| M4 KSR Safety And Hot-Path Hardening | Active | projection 标注、hot-path audit、wiring eval、article routing preview 已交付；下一步推进 evidence span 和 candidate 风险分层 |
 | M5 Context Pack And Operational Runtime | Later | session snapshot、context budget、claim lease、provider facade、observability |
 | M6 Policy, Permission, And Knowledge Evolution | Later | permission layer、claim lifecycle、conflict detection、policy promotion |
 | M7 Semantic Extraction And Query Feedback Loop | Later | relation extractor、query feedback、skill/routine extraction、notebook/raw-source mode |
 
 当前 active backlog 重点：
 
-- 已交付：`KSR-002` Projection 标注、`KSR-015` Dashboard/search hot-path audit、`KSR-026` Workflow wiring eval suite。
+- 已交付：`KSR-002` Projection 标注、`KSR-014` Article routing preview、`KSR-015` Dashboard/search hot-path audit、`KSR-026` Workflow wiring eval suite。
 - 产品侧已交付：第一版 readable object page profile、source/backlink rail 和 visual `/graph` map。
-- 下一步：`KSR-014` Article routing preview、`KSR-001` Evidence span 化、`KSR-003` Candidate 风险分层，然后继续更深的 per-kind object layout。
+- 下一步：`KSR-001` Evidence span 化、`KSR-003` Candidate 风险分层，然后继续更深的 per-kind object layout。
 - 产品线：Reader-first Knowledge Atlas 作为 projection layer 实现，不另建状态系统。
 
 ## Domain Packs
@@ -384,6 +384,7 @@ interpretation
 | 命令 | 说明 |
 |---|---|
 | `ovp-absorb --recent 7 --json` | 吸收最近解读 |
+| `ovp-absorb --file <source.md> --dry-run --json` | 在移动或处理 source material 前预览 source lifecycle 路由 |
 | `ovp-evergreen --recent 7 --json` | `ovp-absorb` 的兼容别名 |
 | `ovp-cleanup --all --json` | 生成 cleanup proposal |
 | `ovp-cleanup --all --write --json` | 执行确定性 cleanup |

--- a/docs/plans/2026-04-29-consolidated-product-roadmap.md
+++ b/docs/plans/2026-04-29-consolidated-product-roadmap.md
@@ -172,13 +172,13 @@ Third PR slice:
 
 ### M4. KSR Safety And Hot-Path Hardening
 
-**Status:** Near-term engineering wave
+**Status:** Active engineering wave; hot-path audit, wiring evals, and first article routing preview are shipped
 
 Related KSR tasks:
 
 - `KSR-001 Evidence span 化`
 - `KSR-003 Candidate 风险分层`
-- `KSR-014 Article routing preview`
+- `KSR-014 Article routing preview` (first JSON preview shipped)
 - `KSR-015 Dashboard/search hot-path audit`
 - `KSR-018 Markdown-aware evidence chunking`
 - `KSR-026 Workflow wiring eval suite`
@@ -188,7 +188,7 @@ Goal:
 - every important claim/candidate can point to source path, content hash, heading/paragraph anchor, quote hash, line span, and relation/evidence type
 - dashboard/search never trigger heavy raw/PDF/Office scans on default paths
 - candidate review is grouped by risk and evidence strength
-- routing decisions are previewed/explained before changing lifecycle behavior
+- routing decisions are previewed/explained before changing lifecycle behavior; first source lifecycle JSON preview is available from `ovp-absorb --dry-run --json`
 - no-LLM wiring evals lock critical invariants
 
 First likely implementation order:
@@ -198,6 +198,8 @@ First likely implementation order:
 3. article routing preview payload
 4. evidence span schema and markdown-aware locator backfill
 5. candidate risk grouping
+
+Items 1-3 are shipped in the repo. The next P0 safety work is items 4-5.
 
 ### M5. Context Pack And Operational Runtime
 
@@ -276,7 +278,7 @@ The current P0 set is:
 | KSR-002 | Projection marking | M3/M4 | Must apply to dashboard, MOC, wiki, briefing, reader atlas |
 | KSR-015 | Dashboard/search hot-path audit | M3/M4 | Needed before making UI the default product surface |
 | KSR-026 | Workflow wiring eval suite | M4 | Prevents regressions in lifecycle, promote gate, projection marking, hot paths, write boundaries |
-| KSR-014 | Article routing preview | M4 | Preview/evaluate only at first; do not route sources invisibly |
+| KSR-014 | Article routing preview | M4 | First `ovp-absorb --dry-run --json` preview shipped; do not route sources invisibly |
 | KSR-001 | Evidence span | M4 | Foundation for reader trust and future policy promotion |
 | KSR-003 | Candidate risk layering | M4 | Needed to keep review workload small |
 

--- a/docs/plans/2026-04-29-reader-product-shape-and-backlog-reconciliation.md
+++ b/docs/plans/2026-04-29-reader-product-shape-and-backlog-reconciliation.md
@@ -172,7 +172,7 @@ The recent vault KSR backlog makes the same direction more concrete. The reader-
 | KSR-026 Workflow wiring eval suite | Tests should lock projection labels, source lifecycle routing, dashboard hot paths, and read/write boundaries |
 | KSR-001 Evidence span 化 | Object pages and backlink rails need precise source/evidence spans |
 | KSR-003 Candidate 风险分层 | Reader pages should show unresolved/risky knowledge without implying it is canonical |
-| KSR-014 Article routing preview | Reader-product ingestion should explain where a source will go before changing lifecycle behavior |
+| KSR-014 Article routing preview | Shipped first JSON preview in `ovp-absorb --dry-run --json`; richer UI presentation can build on this |
 
 ### Keep From Existing Roadmap
 

--- a/src/ovp_pipeline/commands/absorb.py
+++ b/src/ovp_pipeline/commands/absorb.py
@@ -13,6 +13,8 @@ from ..clippings_processor import ClippingsProcessor
 from ..evidence import build_evidence_payload
 from ..runtime import VaultLayout, resolve_vault_dir
 
+ISO_DATE_PREFIX_LEN = 10
+
 
 def _is_under(path: Path, parent: Path) -> bool:
     try:
@@ -72,6 +74,33 @@ def _unique_child(directory: Path, name: str) -> Path:
         counter += 1
 
 
+def _unique_child_with_reservations(directory: Path, name: str, reserved: set[Path]) -> Path:
+    candidate = directory / name
+    if not candidate.exists() and candidate.resolve(strict=False) not in reserved:
+        reserved.add(candidate.resolve(strict=False))
+        return candidate
+    stem = candidate.stem
+    suffix = candidate.suffix
+    counter = 2
+    while True:
+        next_candidate = directory / f"{stem}-{counter}{suffix}"
+        if not next_candidate.exists() and next_candidate.resolve(strict=False) not in reserved:
+            reserved.add(next_candidate.resolve(strict=False))
+            return next_candidate
+        counter += 1
+
+
+def _clipping_raw_name(
+    processor: ClippingsProcessor,
+    source: Path,
+    *,
+    when: datetime | None = None,
+) -> str:
+    clean_name = processor.sanitize_filename(source.stem) + ".md"
+    timestamp = (when or datetime.now()).strftime("%Y-%m-%d")
+    return f"{timestamp}_{clean_name}"
+
+
 def _move_clipping_to_raw(
     layout: VaultLayout,
     processor: ClippingsProcessor,
@@ -79,8 +108,7 @@ def _move_clipping_to_raw(
     *,
     settle_timeout_s: float = 5.0,
 ) -> Path:
-    clean_name = processor.sanitize_filename(source.stem) + ".md"
-    new_name = f"{datetime.now().strftime('%Y-%m-%d')}_{clean_name}"
+    new_name = _clipping_raw_name(processor, source)
     destination = _unique_child(layout.raw_dir, new_name)
     if not processor.obsidian_move(source, layout.raw_dir, destination.name):
         raise RuntimeError(f"failed to move clipping into raw intake: {source}")
@@ -96,6 +124,119 @@ def _move_clipping_to_raw(
                 f"obsidian move reported success but destination did not appear: {destination}"
             )
     return destination
+
+
+def _source_lifecycle_zone(layout: VaultLayout, source: Path) -> str:
+    if _is_under(source, layout.clippings_dir):
+        return "clippings"
+    if _is_under(source, layout.raw_dir):
+        return "raw"
+    if _is_under(source, layout.processing_dir):
+        return "processing"
+    if _is_under(source, layout.processed_dir):
+        return "processed"
+    return "outside_source_lifecycle"
+
+
+def _preview_clipping_raw_destination(
+    layout: VaultLayout,
+    processor: ClippingsProcessor,
+    source: Path,
+    reserved: set[Path],
+    *,
+    when: datetime,
+) -> Path:
+    new_name = _clipping_raw_name(processor, source, when=when)
+    return _unique_child_with_reservations(layout.raw_dir, new_name, reserved)
+
+
+def _archive_preview_path(layout: VaultLayout, source: Path) -> Path:
+    match = source.name[:ISO_DATE_PREFIX_LEN]
+    try:
+        source_date = datetime.strptime(match, "%Y-%m-%d")
+    except ValueError:
+        source_date = datetime.now()
+    return layout.processed_month_dir(source_date) / source.name
+
+
+def build_source_lifecycle_routing_preview(layout: VaultLayout, targets: list[Path]) -> dict:
+    """Build a non-mutating preview of source lifecycle routing for absorb."""
+    logger = PipelineLogger(layout.pipeline_log)
+    txn = TransactionManager(layout.transactions_dir)
+    clippings = ClippingsProcessor(layout.vault_dir, logger, txn)
+    preview_time = datetime.now()
+    items: list[dict] = []
+    reserved_raw_destinations: set[Path] = set()
+    sources = _dedupe_paths(
+        [source for target in targets for source in _expand_markdown_sources(target)]
+    )
+    for source in sources:
+        zone = _source_lifecycle_zone(layout, source)
+        planned_actions: list[dict[str, str]] = []
+        route = "unsupported_source_lifecycle_route"
+        reason = "source is outside the supported source lifecycle directories"
+        working_source = source
+
+        if zone == "clippings":
+            raw_target = _preview_clipping_raw_destination(
+                layout,
+                clippings,
+                source,
+                reserved_raw_destinations,
+                when=preview_time,
+            )
+            staged_target = layout.processing_dir / raw_target.name
+            route = "clippings_to_raw_to_processing_to_deep_dive_absorb"
+            reason = "clipping must be finalized into Raw before article interpretation and absorb"
+            planned_actions.extend(
+                [
+                    {"action": "move_to_raw", "target": str(raw_target)},
+                    {"action": "stage_for_processing", "target": str(staged_target)},
+                ]
+            )
+            working_source = staged_target
+        elif zone == "raw":
+            staged_target = layout.processing_dir / source.name
+            route = "raw_to_processing_to_deep_dive_absorb"
+            reason = "raw source must be staged before article interpretation and absorb"
+            planned_actions.append({"action": "stage_for_processing", "target": str(staged_target)})
+            working_source = staged_target
+        elif zone == "processing":
+            route = "processing_to_deep_dive_absorb"
+            reason = "processing source can be interpreted directly before absorb"
+        elif zone == "processed":
+            route = "processed_to_deep_dive_absorb"
+            reason = "processed source can be re-interpreted directly before absorb"
+
+        if zone in {"clippings", "raw", "processing", "processed"}:
+            planned_actions.append({"action": "process_article", "target": "generated_deep_dive"})
+            if zone in {"clippings", "raw", "processing"}:
+                planned_actions.append(
+                    {
+                        "action": "archive_source_to_processed",
+                        "target": str(_archive_preview_path(layout, working_source)),
+                    }
+                )
+            planned_actions.append(
+                {"action": "absorb_generated_deep_dive", "target": "generated_deep_dive"}
+            )
+
+        items.append(
+            {
+                "source": str(source),
+                "source_zone": zone,
+                "route": route,
+                "processor": "auto_article_processor",
+                "will_mutate_on_execute": zone in {"clippings", "raw", "processing", "processed"},
+                "planned_actions": planned_actions,
+                "reason": reason,
+            }
+        )
+
+    return {
+        "preview_schema_version": 1,
+        "items": items,
+    }
 
 
 def _record_source_lifecycle_failure(
@@ -275,6 +416,7 @@ def main(argv: list[str] | None = None) -> int:
             direct_absorb_targets.extend(_expand_deep_dive_targets(args.dir))
     source_lifecycle_targets = _dedupe_paths(source_lifecycle_targets)
     direct_absorb_targets = _dedupe_paths(direct_absorb_targets)
+    routing_preview = build_source_lifecycle_routing_preview(layout, source_lifecycle_targets)
     payload = {
         "mode": "absorb",
         "vault_dir": str(vault_dir),
@@ -287,6 +429,7 @@ def main(argv: list[str] | None = None) -> int:
         "source_lifecycle": {
             "required": bool(source_lifecycle_targets),
             "source_targets": [str(target) for target in source_lifecycle_targets],
+            "routing_preview": routing_preview,
             "absorb_targets": [],
             "failures": [],
         },

--- a/tests/test_absorb_refine_commands.py
+++ b/tests/test_absorb_refine_commands.py
@@ -356,6 +356,101 @@ def test_absorb_dry_run_under_clippings_reports_source_lifecycle_plan(temp_vault
     payload = json.loads(captured.out)
     assert payload["source_lifecycle"]["required"] is True
     assert payload["source_lifecycle"]["source_targets"] == [str(clipping)]
+    preview = payload["source_lifecycle"]["routing_preview"]
+    assert preview["preview_schema_version"] == 1
+    assert len(preview["items"]) == 1
+    route = preview["items"][0]
+    assert route["source"] == str(clipping)
+    assert route["source_zone"] == "clippings"
+    assert route["route"] == "clippings_to_raw_to_processing_to_deep_dive_absorb"
+    assert route["processor"] == "auto_article_processor"
+    assert route["will_mutate_on_execute"] is True
+    assert [step["action"] for step in route["planned_actions"]] == [
+        "move_to_raw",
+        "stage_for_processing",
+        "process_article",
+        "archive_source_to_processed",
+        "absorb_generated_deep_dive",
+    ]
+    assert route["planned_actions"][0]["target"].endswith("_Raw_Clip.md")
+    assert route["planned_actions"][1]["target"].endswith("_Raw_Clip.md")
+    assert route["planned_actions"][2]["target"] == "generated_deep_dive"
+    assert clipping.exists()
+
+
+def test_source_lifecycle_routing_preview_explains_raw_and_processing_routes(temp_vault):
+    from ovp_pipeline.commands.absorb import build_source_lifecycle_routing_preview
+    from ovp_pipeline.runtime import VaultLayout
+
+    layout = VaultLayout.from_vault(temp_vault)
+    layout.raw_dir.mkdir(parents=True, exist_ok=True)
+    layout.processing_dir.mkdir(parents=True, exist_ok=True)
+    raw_source = layout.raw_dir / "2026-04-30_Raw_Article.md"
+    processing_source = layout.processing_dir / "2026-04-29_Working_Article.md"
+    raw_source.write_text("# Raw Article\n", encoding="utf-8")
+    processing_source.write_text("# Working Article\n", encoding="utf-8")
+
+    preview = build_source_lifecycle_routing_preview(layout, [raw_source, processing_source])
+
+    routes = {item["source_zone"]: item for item in preview["items"]}
+    assert routes["raw"]["route"] == "raw_to_processing_to_deep_dive_absorb"
+    assert [step["action"] for step in routes["raw"]["planned_actions"]] == [
+        "stage_for_processing",
+        "process_article",
+        "archive_source_to_processed",
+        "absorb_generated_deep_dive",
+    ]
+    assert routes["raw"]["planned_actions"][0]["target"] == str(layout.processing_dir / raw_source.name)
+    assert routes["processing"]["route"] == "processing_to_deep_dive_absorb"
+    assert [step["action"] for step in routes["processing"]["planned_actions"]] == [
+        "process_article",
+        "archive_source_to_processed",
+        "absorb_generated_deep_dive",
+    ]
+    assert raw_source.exists()
+    assert processing_source.exists()
+
+
+def test_source_lifecycle_routing_preview_reserves_duplicate_clipping_destinations(temp_vault):
+    from ovp_pipeline.commands.absorb import build_source_lifecycle_routing_preview
+    from ovp_pipeline.runtime import VaultLayout
+
+    layout = VaultLayout.from_vault(temp_vault)
+    clipping_a = layout.clippings_dir / "a" / "Same Clip.md"
+    clipping_b = layout.clippings_dir / "b" / "Same Clip.md"
+    clipping_a.parent.mkdir(parents=True, exist_ok=True)
+    clipping_b.parent.mkdir(parents=True, exist_ok=True)
+    clipping_a.write_text("# Same Clip A\n", encoding="utf-8")
+    clipping_b.write_text("# Same Clip B\n", encoding="utf-8")
+
+    preview = build_source_lifecycle_routing_preview(layout, [layout.clippings_dir])
+
+    raw_targets = [
+        item["planned_actions"][0]["target"]
+        for item in preview["items"]
+        if item["source_zone"] == "clippings"
+    ]
+    assert len(raw_targets) == 2
+    assert len(set(raw_targets)) == 2
+    assert raw_targets[0].endswith("_Same_Clip.md")
+    assert raw_targets[1].endswith("_Same_Clip-2.md")
+    assert clipping_a.exists()
+    assert clipping_b.exists()
+
+
+def test_source_lifecycle_routing_preview_dedupes_overlapping_targets(temp_vault):
+    from ovp_pipeline.commands.absorb import build_source_lifecycle_routing_preview
+    from ovp_pipeline.runtime import VaultLayout
+
+    layout = VaultLayout.from_vault(temp_vault)
+    clipping = layout.clippings_dir / "Overlap Clip.md"
+    clipping.parent.mkdir(parents=True, exist_ok=True)
+    clipping.write_text("# Overlap Clip\n", encoding="utf-8")
+
+    preview = build_source_lifecycle_routing_preview(layout, [layout.clippings_dir, clipping])
+
+    assert [item["source"] for item in preview["items"]] == [str(clipping)]
+    assert clipping.exists()
 
 
 def test_run_source_lifecycle_dry_run_does_not_move_clippings(temp_vault):


### PR DESCRIPTION
## Summary
- add a non-mutating source lifecycle routing preview to `ovp-absorb --dry-run --json`
- explain clippings/raw/processing/processed article routes before source lifecycle mutations
- update backlog, README, milestone, architecture, and roadmap docs for BL-005 / KSR-014

## Tests
- `PYTHONPATH=src python -m pytest tests/test_absorb_refine_commands.py -q -k "routing_preview or dry_run_under_clippings"`
- `python -m ruff check src/ovp_pipeline/commands/absorb.py tests/test_absorb_refine_commands.py`
- `PYTHONPATH=src python -m pytest -q`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/81" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented JSON routing preview via `ovp-absorb --dry-run --json`, enabling users to preview planned source destinations and all actions that will be taken without applying any changes.

* **Documentation**
  * Comprehensive documentation updates across multiple languages documenting the new dry-run JSON preview capability and article routing preview feature completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->