### PR TITLE
feat: add evidence spans and candidate risk tiers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -662,9 +662,9 @@ Current implementation roughly maps as follows:
 
 Main gaps:
 
-- Layer 1 claim/evidence contracts are not explicit enough yet.
+- Layer 1 claim/evidence contracts now carry a first line/char span schema in derived evidence rows; factual evidence_kind enforcement and richer claim lifecycle fields still need hardening.
 - Layer 2 / Layer 3 projection labels now exist on core access payloads and materialized reader artifacts; doctor/export enforcement and future surfaces still need to consume them consistently.
-- Layer 4 fitness checks now cover the first hot-path, workflow-wiring, and source routing preview cases; evidence completeness, projection replay, and import-boundary checks are still open.
+- Layer 4 fitness checks now cover the first hot-path, workflow-wiring, source routing preview, evidence span backfill, and candidate risk cases; deeper evidence completeness, projection replay, and import-boundary checks are still open.
 - Projection lifecycle markers need structured schema, scope, lease, and supersession.
 - Schema versioning is not yet wired into projection lifecycle.
 - The reader-first home is now the default entry; object pages have a first reader profile/source rail; `/graph` has a first spatial map projection; search and deeper per-kind object layouts still need product shape.
@@ -674,11 +674,10 @@ Main gaps:
 Recommended order:
 
 1. Keep projection metadata attached to new access surfaces and add doctor/export checks that verify the labels are present.
-2. Continue reader-first Layer 3 product work on search and deeper per-kind object layouts.
-3. Add evidence spans and factual evidence completeness checks.
-4. Add candidate risk tiers before expanding automatic promotion.
-5. Introduce structured `ProjectionRepairMarker` schema.
-6. Add schema version fields to Authority and derived projection state.
+2. Continue reader-first Layer 3 product work on deeper per-kind object layouts and search using the new evidence spans/risk tiers.
+3. Add stricter factual evidence completeness checks before expanding automatic promotion.
+4. Introduce structured `ProjectionRepairMarker` schema.
+5. Add schema version fields to Authority and derived projection state.
 
 ## Appendix: Backlog Mapping
 
@@ -690,8 +689,8 @@ The architecture should not depend on backlog IDs to be valid. The table below i
 | Dashboard/search hot-path audit | `BL-003`, `KSR-015` shipped in PR #77 |
 | Workflow wiring eval suite | `BL-004`, `KSR-026` shipped in PR #77 |
 | Article routing preview | `BL-005`, `KSR-014` done in PR #81 |
-| Evidence span / factual evidence completeness | `BL-006`, `KSR-001`, `KSR-018` |
-| Candidate risk layering | `BL-007`, `KSR-003` |
+| Evidence span / factual evidence completeness | `BL-006`, `KSR-001`, `KSR-018` done in PR #82 |
+| Candidate risk layering | `BL-007`, `KSR-003` done in PR #82 |
 | Reader-first access surfaces | `BL-001`; `BL-008` partial and `BL-009` done in PR #79; `BL-010` done in PR #80 |
 | Projection repair lifecycle | `BL-020` |
 | Schema versioning and migration trigger | `BL-021` |

--- a/ARCHITECTURE.zh-CN.md
+++ b/ARCHITECTURE.zh-CN.md
@@ -768,11 +768,11 @@ Do not rely on ad hoc "just rerun the pipeline" behavior for schema changes.
 
 仍然太隐式的部分：
 
-- canonical artifact contract 还不够一等公民化。
+- canonical artifact contract 仍需继续一等公民化；derived evidence rows 已有第一版 line/char span schema，但 factual evidence_kind enforcement 和 claim lifecycle 字段仍需加强。
 - Layer 4 子轴还没有完全反映到代码结构。
 - projection labels 已经贯穿核心 access payload 和 materialized reader artifacts；doctor/export enforcement 以及未来新增 surface 还需要持续消费这些标注。
 - projection lifecycle marker 还没有明确区分 metadata_only / full_rebuild / semantic_reindex。
-- dashboard/search hot path、workflow wiring 和 source routing preview 已经有第一批 fitness checks；evidence completeness、projection replay、import-boundary checks 仍未完成。
+- dashboard/search hot path、workflow wiring、source routing preview、evidence span backfill 和 candidate risk 已经有第一批 fitness checks；更深的 evidence completeness、projection replay、import-boundary checks 仍未完成。
 - context assembly recipes 还需要收束。
 - governance / resolver contracts 还需要显式化。
 - schema versioning 和 projection compatibility 还需要工程化。
@@ -786,13 +786,12 @@ Do not rely on ad hoc "just rerun the pipeline" behavior for schema changes.
 优先顺序：
 
 1. 新增 access surface 时必须继续带 projection metadata，并补 doctor/export checks 验证标注存在。
-2. 继续做 reader-first Layer 3：search 和更深的 per-kind object layout。
-3. 补 evidence span 和 factual evidence completeness checks。
-4. 补 candidate risk tiers，再扩大自动 promotion。
-5. 引入结构化 ProjectionRepairMarker。
-6. 给 Authority 和 derived projection state 增加 schema version 字段。
-7. 把 routing、promotion、review、permission 从 prompt/散落代码中收束为显式 governance/dispatch contract。
-8. 预留 semantic_reindex lifecycle kind，但不提前锁定 LanceDB 或其它 backend。
+2. 继续做 reader-first Layer 3：用新的 evidence span / risk tier 推进更深的 per-kind object layout 和 search。
+3. 在扩大自动 promotion 前，补更严格的 factual evidence completeness checks。
+4. 引入结构化 ProjectionRepairMarker。
+5. 给 Authority 和 derived projection state 增加 schema version 字段。
+6. 把 routing、promotion、review、permission 从 prompt/散落代码中收束为显式 governance/dispatch contract。
+7. 预留 semantic_reindex lifecycle kind，但不提前锁定 LanceDB 或其它 backend。
 
 ## Appendix: Backlog Mapping
 
@@ -804,8 +803,8 @@ Do not rely on ad hoc "just rerun the pipeline" behavior for schema changes.
 | Dashboard/search hot-path audit | `BL-003`, `KSR-015` PR #77 已交付 |
 | Workflow wiring eval suite | `BL-004`, `KSR-026` PR #77 已交付 |
 | Article routing preview | `BL-005`, `KSR-014` 已在 PR #81 交付 |
-| Evidence span / factual evidence completeness | `BL-006`, `KSR-001`, `KSR-018` |
-| Candidate risk layering | `BL-007`, `KSR-003` |
+| Evidence span / factual evidence completeness | `BL-006`, `KSR-001`, `KSR-018` 已在 PR #82 交付 |
+| Candidate risk layering | `BL-007`, `KSR-003` 已在 PR #82 交付 |
 | Reader-first access surfaces | `BL-001`；`BL-008` partial、`BL-009` 已在 PR #79 交付；`BL-010` 已在 PR #80 交付 |
 | Projection repair lifecycle | `BL-020` |
 | Schema versioning and migration trigger | `BL-021` |

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -22,7 +22,7 @@ Rule: historical plans and vault research notes feed this file; they do not over
 | M1 Operator Workbench And Review Runtime | Done / maintain | truth UI, candidates, signals/actions, contradictions, action worker |
 | M2 Roadmap And README Consolidation | Done | merged historical milestones, compiler roadmap, recent KSR input, reader-product research, and English-primary docs |
 | M3 Reader-First Knowledge Atlas | Active | reader home, `/ops` split, first object source/backlink rail, and visual graph map shipped; deeper kind-specific object layouts still need product shape |
-| M4 KSR Safety And Hot-Path Hardening | Active | projection labels, hot-path audit, wiring evals, and article routing preview shipped; evidence spans and candidate risk remain |
+| M4 KSR Safety And Hot-Path Hardening | Active | projection labels, hot-path audit, wiring evals, article routing preview, evidence spans, and candidate risk shipped; deeper enforcement remains |
 | M5 Context Pack And Operational Runtime | Later | session snapshots, context budget, claim leases, provider facade, observability |
 | M6 Policy, Permission, And Knowledge Evolution | Later | permission layer, claim lifecycle, conflict detection, policy promotion |
 | M7 Semantic Extraction And Query Feedback Loop | Later | relation extractor, query feedback, routines, notebook/raw-source mode |
@@ -37,8 +37,8 @@ Rule: historical plans and vault research notes feed this file; they do not over
 | BL-003 | P0 | Done | Dashboard/search hot-path audit: default UI/search paths must not scan raw/PDF/Office sources | M4, KSR-015, `docs/plans/2026-04-30-bl-003-004-hot-path-wiring-safety.md`, PR #77 |
 | BL-004 | P0 | Done | Workflow wiring eval suite for lifecycle routing, promote gates, projection labels, hot paths, and read/write boundaries | M4, KSR-026, `docs/plans/2026-04-30-bl-003-004-hot-path-wiring-safety.md`, PR #77 |
 | BL-005 | P0 | Done | Article routing preview before source lifecycle changes | M4, KSR-014 |
-| BL-006 | P0 | Next | Evidence span schema and markdown-aware locator backfill | M4, KSR-001, KSR-018 |
-| BL-007 | P0 | Next | Candidate risk layering by evidence strength, identity ambiguity, sensitivity, and impact | M4, KSR-003 |
+| BL-006 | P0 | Done | Evidence span schema and markdown-aware locator backfill | M4, KSR-001, KSR-018 |
+| BL-007 | P0 | Done | Candidate risk layering by evidence strength, identity ambiguity, sensitivity, and impact | M4, KSR-003 |
 | BL-008 | P1 | Partial | Kind-aware object pages for people, concepts, companies/tools/projects, events, and claims; first slice adds reader profile/kind labels | M3, PR #79 |
 | BL-009 | P1 | Done | Mention/backlink rail with excerpts, source jumps, and relation context | M3, reader-product note, PR #79 |
 | BL-010 | P1 | Done | Visual `/graph` MVP as a spatial corpus map; analytical clusters remain under `/clusters` for ops/debug | M3, PR #80 |
@@ -58,9 +58,9 @@ Rule: historical plans and vault research notes feed this file; they do not over
 
 | KSR ID | Backlog mapping | Current status in this backlog |
 | --- | --- | --- |
-| KSR-001 Evidence span 化 | BL-006 | Next |
+| KSR-001 Evidence span 化 | BL-006 | Done |
 | KSR-002 Projection 标注 | BL-002 | Done |
-| KSR-003 Candidate 风险分层 | BL-007 | Next |
+| KSR-003 Candidate 风险分层 | BL-007 | Done |
 | KSR-004 Session snapshot/context pack | BL-013 | Later |
 | KSR-005 Permission layer 分离 | BL-015 | Later |
 | KSR-006 Claim lifecycle 字段 | BL-015 | Later |
@@ -75,7 +75,7 @@ Rule: historical plans and vault research notes feed this file; they do not over
 | KSR-015 Dashboard/search hot-path audit | BL-003 | Done |
 | KSR-016 Hybrid retrieval experiment | BL-019 | Later |
 | KSR-017 Explicit context budget | BL-013 | Later |
-| KSR-018 Markdown-aware evidence chunking | BL-006 | Next |
+| KSR-018 Markdown-aware evidence chunking | BL-006 | Done |
 | KSR-019 Multimodal caption-first ingest | BL-019 | Later |
 | KSR-020 Operational runtime graph | BL-014 | Later |
 | KSR-021 Claim lease for workflow items | BL-014 | Later |
@@ -90,12 +90,12 @@ Rule: historical plans and vault research notes feed this file; they do not over
 
 ## Next Decision
 
-`BL-001` is shipped in PR #75, `BL-003 + BL-004` are shipped in PR #77, `BL-002` is shipped in PR #78, `BL-009` plus the first `BL-008` slice are shipped in PR #79, `BL-010` is shipped in PR #80, and `BL-005` is implemented in PR #81. The default UI now has a reader-first entry point, `/ops` owns the operator dashboard, core access/materialized surfaces carry explicit projection labels, object pages expose readable source/backlink rails, `/graph` renders a reader-facing spatial map over graph projections, and `ovp-absorb --dry-run --json` explains source lifecycle routing before mutation.
+`BL-001` is shipped in PR #75, `BL-003 + BL-004` are shipped in PR #77, `BL-002` is shipped in PR #78, `BL-009` plus the first `BL-008` slice are shipped in PR #79, `BL-010` is shipped in PR #80, `BL-005` is shipped in PR #81, and `BL-006 + BL-007` are implemented in PR #82. The default UI now has a reader-first entry point, `/ops` owns the operator dashboard, core access/materialized surfaces carry explicit projection labels, object pages expose readable source/backlink rails, `/graph` renders a reader-facing spatial map over graph projections, `ovp-absorb --dry-run --json` explains source lifecycle routing before mutation, evidence rows carry line/char spans, and candidate review payloads expose risk tiers.
 
-The next implementation PR should continue the KSR safety lane with **BL-006 + BL-007**. Evidence spans and candidate risk tiers are the next P0 risk reducers before expanding automatic promotion or richer reader search.
+The next implementation PR should return to the reader product lane with **BL-008** deeper per-kind object layouts, then **BL-011** reader-oriented search. M4 still has deeper enforcement work, but the P0 risk reducers needed before richer reader surfaces are now in place.
 
 Recommended order:
 
-1. BL-006 + BL-007
-2. Continue BL-008 with deeper per-kind layouts
-3. BL-011
+1. Continue BL-008 with deeper per-kind layouts
+2. BL-011
+3. BL-020 / BL-021 when projection repair and schema migration become the next operational bottleneck

--- a/MILESTONE.md
+++ b/MILESTONE.md
@@ -34,7 +34,7 @@ That means the user-facing product should make compiled knowledge easy to read f
 | M1 Operator Workbench And Review Runtime | Done / maintain | truth UI, candidates, signals/actions, contradictions, action worker |
 | M2 Roadmap And README Consolidation | Done | merged historical milestones, compiler roadmap, recent KSR input, reader-product research, and the English-primary docs structure |
 | M3 Reader-First Knowledge Atlas | Active | reader home, `/ops` split, first object source/backlink rail, and visual graph map shipped; deeper kind-specific object layouts remain |
-| M4 KSR Safety And Hot-Path Hardening | Active | projection labels, hot-path audit, wiring evals, and article routing preview shipped; evidence spans and candidate risk remain |
+| M4 KSR Safety And Hot-Path Hardening | Active | projection labels, hot-path audit, wiring evals, article routing preview, evidence spans, and candidate risk shipped; deeper enforcement remains |
 | M5 Context Pack And Operational Runtime | Later | session snapshots, context budget, claim leases, provider facade, observability |
 | M6 Policy, Permission, And Knowledge Evolution | Later | permission layer, claim lifecycle, conflict detection, policy promotion |
 | M7 Semantic Extraction And Query Feedback Loop | Later | relation extractor, query feedback, routines, notebook/raw-source mode |
@@ -48,8 +48,8 @@ That means the user-facing product should make compiled knowledge easy to read f
 | Dashboard/search hot-path audit | `BL-003`, `KSR-015` done in PR #77 |
 | Workflow wiring eval suite | `BL-004`, `KSR-026` done in PR #77 |
 | Article routing preview | `BL-005`, `KSR-014` done in PR #81 |
-| Evidence span / factual evidence completeness | `BL-006`, `KSR-001`, `KSR-018` |
-| Candidate risk layering | `BL-007`, `KSR-003` |
+| Evidence span / factual evidence completeness | `BL-006`, `KSR-001`, `KSR-018` done in PR #82 |
+| Candidate risk layering | `BL-007`, `KSR-003` done in PR #82 |
 | Kind-aware object pages and backlink rail | `BL-008` partial and `BL-009` done in PR #79 |
 | Visual graph MVP | `BL-010` done in PR #80 |
 | Projection repair lifecycle | `BL-020` |
@@ -59,9 +59,9 @@ That means the user-facing product should make compiled knowledge easy to read f
 
 Recommended order:
 
-1. Implement `BL-006 + BL-007`: evidence spans and candidate risk layering.
-2. Continue `BL-008`: deeper per-kind object layouts beyond the first reader profile.
-3. Implement `BL-011`: reader-oriented search grouped by kind, summary, evidence, and reason.
+1. Continue `BL-008`: deeper per-kind object layouts beyond the first reader profile.
+2. Implement `BL-011`: reader-oriented search grouped by kind, summary, evidence, and reason.
+3. Return to `BL-020 + BL-021` when projection repair and schema migration need operational hardening.
 
 ## Documentation Rules
 

--- a/MILESTONE.zh-CN.md
+++ b/MILESTONE.zh-CN.md
@@ -34,7 +34,7 @@ OVP 正在从 document-processing pipeline 变成：
 | M1 Operator Workbench And Review Runtime | Done / maintain | truth UI、candidates、signals/actions、contradictions、action worker |
 | M2 Roadmap And README Consolidation | Done | 已合并历史 milestones、compiler roadmap、近期 KSR 输入、reader-product 研究，以及英文主文档结构 |
 | M3 Reader-First Knowledge Atlas | Active | reader home、`/ops` 拆分、第一版 object source/backlink rail、visual graph map 已交付；更深的 kind-specific object layout 仍待推进 |
-| M4 KSR Safety And Hot-Path Hardening | Active | projection labels、hot-path audit、wiring evals、article routing preview 已交付；evidence spans、candidate risk 仍待推进 |
+| M4 KSR Safety And Hot-Path Hardening | Active | projection labels、hot-path audit、wiring evals、article routing preview、evidence spans、candidate risk 已交付；更深的 enforcement 仍待推进 |
 | M5 Context Pack And Operational Runtime | Later | session snapshots、context budget、claim leases、provider facade、observability |
 | M6 Policy, Permission, And Knowledge Evolution | Later | permission layer、claim lifecycle、conflict detection、policy promotion |
 | M7 Semantic Extraction And Query Feedback Loop | Later | relation extractor、query feedback、routines、notebook/raw-source mode |
@@ -48,8 +48,8 @@ OVP 正在从 document-processing pipeline 变成：
 | Dashboard/search hot-path audit | `BL-003`, `KSR-015` 已在 PR #77 交付 |
 | Workflow wiring eval suite | `BL-004`, `KSR-026` 已在 PR #77 交付 |
 | Article routing preview | `BL-005`, `KSR-014` 已在 PR #81 交付 |
-| Evidence span / factual evidence completeness | `BL-006`, `KSR-001`, `KSR-018` |
-| Candidate risk layering | `BL-007`, `KSR-003` |
+| Evidence span / factual evidence completeness | `BL-006`, `KSR-001`, `KSR-018` 已在 PR #82 交付 |
+| Candidate risk layering | `BL-007`, `KSR-003` 已在 PR #82 交付 |
 | Kind-aware object pages and backlink rail | `BL-008` partial，`BL-009` 已在 PR #79 交付 |
 | Visual graph MVP | `BL-010` 已在 PR #80 交付 |
 | Projection repair lifecycle | `BL-020` |
@@ -59,9 +59,9 @@ OVP 正在从 document-processing pipeline 变成：
 
 建议顺序：
 
-1. 实施 `BL-006 + BL-007`：推进 evidence span 和 candidate risk layering。
-2. 继续 `BL-008`：在第一版 reader profile 之后补更深的 per-kind object layout。
-3. 实施 `BL-011`：按 kind、summary、evidence、reason 重做 reader-oriented search。
+1. 继续 `BL-008`：在第一版 reader profile 之后补更深的 per-kind object layout。
+2. 实施 `BL-011`：按 kind、summary、evidence、reason 重做 reader-oriented search。
+3. 当 projection repair 和 schema migration 成为运营瓶颈时，回到 `BL-020 + BL-021`。
 
 ## 文档规则
 

--- a/README.md
+++ b/README.md
@@ -95,16 +95,16 @@ Current milestone sequence:
 | M1 Operator Workbench And Review Runtime | Complete enough | truth UI, candidates, signals/actions, contradictions, action worker |
 | M2 Roadmap And README Consolidation | Complete | merged historical milestones, compiler roadmap, recent KSR input, and reader-product research |
 | M3 Reader-First Knowledge Atlas | Active | reader home, `/ops` split, first object source/backlink rail, and visual graph map shipped; deeper per-kind object layouts still need product shape |
-| M4 KSR Safety And Hot-Path Hardening | Active | projection labels, hot-path audit, wiring evals, and article routing preview have shipped; evidence spans and candidate risk tiers are next |
+| M4 KSR Safety And Hot-Path Hardening | Active | projection labels, hot-path audit, wiring evals, article routing preview, evidence spans, and candidate risk tiers have shipped; deeper enforcement remains |
 | M5 Context Pack And Operational Runtime | Later | session snapshots, context budget, claim leases, provider facades, observability |
 | M6 Policy, Permission, And Knowledge Evolution | Later | permission layer, claim lifecycle, conflict detection, policy promotion |
 | M7 Semantic Extraction And Query Feedback Loop | Later | relation extractor, query feedback, skill/routine extraction, notebook/raw-source mode |
 
 Current active backlog focus:
 
-- Shipped: `KSR-002` projection labels, `KSR-014` article routing preview, `KSR-015` dashboard/search hot-path audit, `KSR-026` workflow wiring eval suite.
+- Shipped: `KSR-001` evidence spans, `KSR-002` projection labels, `KSR-003` candidate risk tiers, `KSR-014` article routing preview, `KSR-015` dashboard/search hot-path audit, `KSR-018` markdown-aware evidence span backfill, `KSR-026` workflow wiring eval suite.
 - Product shipped: first readable object page profile, source/backlink rail, and visual `/graph` map.
-- Next: `KSR-001` evidence spans, `KSR-003` candidate risk tiers, then deeper per-kind object layouts.
+- Next: deeper per-kind object layouts, then reader-oriented search grouped by kind, evidence, and reason.
 - Product track: reader-first Knowledge Atlas stays a projection layer, not a new state system.
 
 ## Domain Packs

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -93,16 +93,16 @@ Obsidian Vault Pipeline（OVP）不是一个“多脚本拼装包”，也不只
 | M1 Operator Workbench And Review Runtime | Complete enough | truth UI、candidates、signals/actions、contradictions、action worker |
 | M2 Roadmap And README Consolidation | Complete | 已合并历史 milestone、compiler roadmap、近期 KSR 输入与 reader-product 研究，重整 README |
 | M3 Reader-First Knowledge Atlas | Active | reader home、`/ops` 拆分、第一版 object source/backlink rail、visual graph map 已交付；更深的 per-kind object layout 仍需产品化 |
-| M4 KSR Safety And Hot-Path Hardening | Active | projection 标注、hot-path audit、wiring eval、article routing preview 已交付；下一步推进 evidence span 和 candidate 风险分层 |
+| M4 KSR Safety And Hot-Path Hardening | Active | projection 标注、hot-path audit、wiring eval、article routing preview、evidence span、candidate 风险分层已交付；更深的 enforcement 仍待推进 |
 | M5 Context Pack And Operational Runtime | Later | session snapshot、context budget、claim lease、provider facade、observability |
 | M6 Policy, Permission, And Knowledge Evolution | Later | permission layer、claim lifecycle、conflict detection、policy promotion |
 | M7 Semantic Extraction And Query Feedback Loop | Later | relation extractor、query feedback、skill/routine extraction、notebook/raw-source mode |
 
 当前 active backlog 重点：
 
-- 已交付：`KSR-002` Projection 标注、`KSR-014` Article routing preview、`KSR-015` Dashboard/search hot-path audit、`KSR-026` Workflow wiring eval suite。
+- 已交付：`KSR-001` Evidence span 化、`KSR-002` Projection 标注、`KSR-003` Candidate 风险分层、`KSR-014` Article routing preview、`KSR-015` Dashboard/search hot-path audit、`KSR-018` Markdown-aware evidence span backfill、`KSR-026` Workflow wiring eval suite。
 - 产品侧已交付：第一版 readable object page profile、source/backlink rail 和 visual `/graph` map。
-- 下一步：`KSR-001` Evidence span 化、`KSR-003` Candidate 风险分层，然后继续更深的 per-kind object layout。
+- 下一步：继续更深的 per-kind object layout，然后做按 kind、evidence、reason 组织的 reader-oriented search。
 - 产品线：Reader-first Knowledge Atlas 作为 projection layer 实现，不另建状态系统。
 
 ## Domain Packs

--- a/docs/plans/2026-04-29-consolidated-product-roadmap.md
+++ b/docs/plans/2026-04-29-consolidated-product-roadmap.md
@@ -172,12 +172,12 @@ Third PR slice:
 
 ### M4. KSR Safety And Hot-Path Hardening
 
-**Status:** Active engineering wave; hot-path audit, wiring evals, and first article routing preview are shipped
+**Status:** Active engineering wave; hot-path audit, wiring evals, first article routing preview, evidence spans, and candidate risk payloads are shipped
 
 Related KSR tasks:
 
-- `KSR-001 Evidence span 化`
-- `KSR-003 Candidate 风险分层`
+- `KSR-001 Evidence span 化` (first line/char span schema shipped)
+- `KSR-003 Candidate 风险分层` (first review payload shipped)
 - `KSR-014 Article routing preview` (first JSON preview shipped)
 - `KSR-015 Dashboard/search hot-path audit`
 - `KSR-018 Markdown-aware evidence chunking`
@@ -185,9 +185,9 @@ Related KSR tasks:
 
 Goal:
 
-- every important claim/candidate can point to source path, content hash, heading/paragraph anchor, quote hash, line span, and relation/evidence type
+- every important claim/candidate can point to source path, content hash, heading/paragraph anchor, quote hash, line span, and relation/evidence type; first derived evidence rows now carry line/char spans
 - dashboard/search never trigger heavy raw/PDF/Office scans on default paths
-- candidate review is grouped by risk and evidence strength
+- candidate review payloads expose risk tier, reasons, and factors for evidence strength, identity ambiguity, sensitivity, and impact
 - routing decisions are previewed/explained before changing lifecycle behavior; first source lifecycle JSON preview is available from `ovp-absorb --dry-run --json`
 - no-LLM wiring evals lock critical invariants
 
@@ -199,7 +199,7 @@ First likely implementation order:
 4. evidence span schema and markdown-aware locator backfill
 5. candidate risk grouping
 
-Items 1-3 are shipped in the repo. The next P0 safety work is items 4-5.
+Items 1-5 are shipped as first slices in the repo. Remaining M4 work is deeper enforcement, doctor/lint coverage, and projection/schema lifecycle hardening.
 
 ### M5. Context Pack And Operational Runtime
 
@@ -279,8 +279,8 @@ The current P0 set is:
 | KSR-015 | Dashboard/search hot-path audit | M3/M4 | Needed before making UI the default product surface |
 | KSR-026 | Workflow wiring eval suite | M4 | Prevents regressions in lifecycle, promote gate, projection marking, hot paths, write boundaries |
 | KSR-014 | Article routing preview | M4 | First `ovp-absorb --dry-run --json` preview shipped; do not route sources invisibly |
-| KSR-001 | Evidence span | M4 | Foundation for reader trust and future policy promotion |
-| KSR-003 | Candidate risk layering | M4 | Needed to keep review workload small |
+| KSR-001 | Evidence span | M4 | First line/char span schema and backfill shipped; foundation for reader trust and future policy promotion |
+| KSR-003 | Candidate risk layering | M4 | First review payload shipped; needed to keep review workload small |
 
 Reader-first Knowledge Atlas is product P0, but it should be implemented as a projection layer over the same runtime facts, not as a separate state system.
 

--- a/docs/plans/2026-04-29-reader-product-shape-and-backlog-reconciliation.md
+++ b/docs/plans/2026-04-29-reader-product-shape-and-backlog-reconciliation.md
@@ -170,8 +170,8 @@ The recent vault KSR backlog makes the same direction more concrete. The reader-
 | KSR-002 Projection 标注 | Reader pages, dashboard, graph, MOC, briefing must show they are derived projections, not source of truth |
 | KSR-015 Dashboard/search hot-path audit | The default home page and reader search must not trigger heavy raw/PDF/Office scans |
 | KSR-026 Workflow wiring eval suite | Tests should lock projection labels, source lifecycle routing, dashboard hot paths, and read/write boundaries |
-| KSR-001 Evidence span 化 | Object pages and backlink rails need precise source/evidence spans |
-| KSR-003 Candidate 风险分层 | Reader pages should show unresolved/risky knowledge without implying it is canonical |
+| KSR-001 Evidence span 化 | First line/char span schema is shipped in derived evidence rows and exposed through object detail payloads |
+| KSR-003 Candidate 风险分层 | First candidate risk payload is shipped for review surfaces; reader pages can show unresolved/risky knowledge without implying it is canonical |
 | KSR-014 Article routing preview | Shipped first JSON preview in `ovp-absorb --dry-run --json`; richer UI presentation can build on this |
 
 ### Keep From Existing Roadmap

--- a/src/ovp_pipeline/commands/evidence_verify.py
+++ b/src/ovp_pipeline/commands/evidence_verify.py
@@ -26,6 +26,7 @@ from typing import Any, Iterable
 
 from ..evidence import (
     compute_content_hash,
+    compute_evidence_span,
     compute_locator,
     compute_retrieval_context,
     verify_evidence_row,
@@ -77,6 +78,10 @@ def _row_dict(table: str, row: tuple[Any, ...]) -> dict[str, Any]:
             "locator",
             "content_hash",
             "retrieval_context",
+            "quote_start_line",
+            "quote_end_line",
+            "quote_start_char",
+            "quote_end_char",
             "status",
             "verified_at",
         )
@@ -91,6 +96,10 @@ def _row_dict(table: str, row: tuple[Any, ...]) -> dict[str, Any]:
             "locator",
             "content_hash",
             "retrieval_context",
+            "quote_start_line",
+            "quote_end_line",
+            "quote_start_char",
+            "quote_end_char",
             "status",
             "verified_at",
         )
@@ -115,10 +124,12 @@ def _select_rows(
     where_sql = ("WHERE " + " AND ".join(where)) if where else ""
     columns = (
         "pack, claim_id, source_slug, evidence_kind, quote_text, "
-        "locator, content_hash, retrieval_context, status, verified_at"
+        "locator, content_hash, retrieval_context, "
+        "quote_start_line, quote_end_line, quote_start_char, quote_end_char, status, verified_at"
         if table == "claim_evidence"
         else "pack, source_object_id, target_object_id, relation_type, evidence_source_slug, "
-        "quote_text, locator, content_hash, retrieval_context, status, verified_at"
+        "quote_text, locator, content_hash, retrieval_context, "
+        "quote_start_line, quote_end_line, quote_start_char, quote_end_char, status, verified_at"
     )
     return list(conn.execute(f"SELECT {columns} FROM {table} {where_sql}", params).fetchall())
 
@@ -206,6 +217,10 @@ def _process_table(
         new_locator = row_dict.get("locator") or ""
         new_content_hash = row_dict.get("content_hash") or ""
         new_context = row_dict.get("retrieval_context") or ""
+        new_start_line = int(row_dict.get("quote_start_line") or 0)
+        new_end_line = int(row_dict.get("quote_end_line") or 0)
+        new_start_char = int(row_dict.get("quote_start_char") or 0)
+        new_end_char = int(row_dict.get("quote_end_char") or 0)
         if backfill:
             if not new_content_hash and source_path:
                 new_content_hash = compute_content_hash(source_path, vault_dir=vault_dir)
@@ -213,10 +228,22 @@ def _process_table(
                 new_locator = compute_locator(source_path, quote, vault_dir=vault_dir)
             if not new_context and quote and source_path:
                 new_context = compute_retrieval_context(source_path, quote, vault_dir=vault_dir)
+            if quote and source_path and not all(
+                (new_start_line, new_end_line, new_end_char)
+            ):
+                span = compute_evidence_span(source_path, quote, vault_dir=vault_dir)
+                new_start_line = span["quote_start_line"]
+                new_end_line = span["quote_end_line"]
+                new_start_char = span["quote_start_char"]
+                new_end_char = span["quote_end_char"]
             if (
                 new_locator != (row_dict.get("locator") or "")
                 or new_content_hash != (row_dict.get("content_hash") or "")
                 or new_context != (row_dict.get("retrieval_context") or "")
+                or new_start_line != int(row_dict.get("quote_start_line") or 0)
+                or new_end_line != int(row_dict.get("quote_end_line") or 0)
+                or new_start_char != int(row_dict.get("quote_start_char") or 0)
+                or new_end_char != int(row_dict.get("quote_end_char") or 0)
             ):
                 backfilled += 1
 
@@ -236,6 +263,10 @@ def _process_table(
                 new_locator,
                 new_content_hash,
                 new_context,
+                new_start_line,
+                new_end_line,
+                new_start_char,
+                new_end_char,
                 status,
                 verified_at,
                 *_key_values(table, row_dict),
@@ -252,6 +283,10 @@ def _process_table(
                 "locator": new_locator,
                 "content_hash": new_content_hash,
                 "retrieval_context": new_context,
+                "quote_start_line": new_start_line,
+                "quote_end_line": new_end_line,
+                "quote_start_char": new_start_char,
+                "quote_end_char": new_end_char,
                 "status": status,
                 "verified_at": verified_at,
                 "pack": str(row_dict.get("pack") or ""),
@@ -264,6 +299,10 @@ def _process_table(
            SET locator = ?,
                content_hash = ?,
                retrieval_context = ?,
+               quote_start_line = ?,
+               quote_end_line = ?,
+               quote_start_char = ?,
+               quote_end_char = ?,
                status = ?,
                verified_at = ?
          WHERE {_key_clause(table)}

--- a/src/ovp_pipeline/evidence.py
+++ b/src/ovp_pipeline/evidence.py
@@ -408,6 +408,43 @@ def compute_retrieval_context(
     return text[start:end]
 
 
+def compute_evidence_span(
+    source_path: Path | str,
+    quote_text: str,
+    *,
+    vault_dir: Path | str | None = None,
+) -> dict[str, int]:
+    """Return 1-based line span and 0-based char offsets for a verbatim quote."""
+    empty = {
+        "quote_start_line": 0,
+        "quote_end_line": 0,
+        "quote_start_char": 0,
+        "quote_end_char": 0,
+    }
+    if not quote_text:
+        return empty
+    path = _resolve_source_path(source_path, vault_dir)
+    if not path.exists() or not path.is_file():
+        return empty
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return empty
+    needle = quote_text.strip()
+    if not needle:
+        return empty
+    start = text.find(needle)
+    if start == -1:
+        return empty
+    end = start + len(needle)
+    return {
+        "quote_start_line": text.count("\n", 0, start) + 1,
+        "quote_end_line": text.count("\n", 0, max(start, end - 1)) + 1,
+        "quote_start_char": start,
+        "quote_end_char": end,
+    }
+
+
 def verify_evidence_row(
     row: dict[str, Any],
     vault_dir: Path | str,

--- a/src/ovp_pipeline/evidence_replay.py
+++ b/src/ovp_pipeline/evidence_replay.py
@@ -2,8 +2,8 @@
 
 ``rebuild_knowledge_index`` recreates ``claim_evidence`` and ``relations`` from
 the pack projection, which would clobber the per-row verification fields
-(``locator``, ``content_hash``, ``retrieval_context``, ``status``,
-``verified_at``) that :mod:`commands.evidence_verify` writes. Each verify pass
+(``locator``, ``content_hash``, ``retrieval_context``, span offsets,
+``status``, ``verified_at``) that :mod:`commands.evidence_verify` writes. Each verify pass
 appends one ``evidence_verified`` event per row to
 ``60-Logs/evidence-verifications.jsonl``; this module replays them after the
 projection inserts so verification survives rebuild.
@@ -47,6 +47,10 @@ def emit_evidence_verified(
     status: str,
     verified_at: str,
     pack: str,
+    quote_start_line: int = 0,
+    quote_end_line: int = 0,
+    quote_start_char: int = 0,
+    quote_end_char: int = 0,
 ) -> None:
     """Append one ``evidence_verified`` event for replay on next rebuild."""
     if table not in _TABLE_KEY_COLUMNS:
@@ -61,6 +65,10 @@ def emit_evidence_verified(
             "locator": locator,
             "content_hash": content_hash,
             "retrieval_context": retrieval_context,
+            "quote_start_line": int(quote_start_line or 0),
+            "quote_end_line": int(quote_end_line or 0),
+            "quote_start_char": int(quote_start_char or 0),
+            "quote_end_char": int(quote_end_char or 0),
             "status": status,
             "verified_at": verified_at,
         },
@@ -128,6 +136,10 @@ def replay_evidence_verifications(
                SET locator = ?,
                    content_hash = ?,
                    retrieval_context = ?,
+                   quote_start_line = ?,
+                   quote_end_line = ?,
+                   quote_start_char = ?,
+                   quote_end_char = ?,
                    status = ?,
                    verified_at = ?
              WHERE {where_sql}
@@ -136,6 +148,10 @@ def replay_evidence_verifications(
                 str(event.get("locator") or ""),
                 str(event.get("content_hash") or ""),
                 str(event.get("retrieval_context") or ""),
+                int(event.get("quote_start_line") or 0),
+                int(event.get("quote_end_line") or 0),
+                int(event.get("quote_start_char") or 0),
+                int(event.get("quote_end_char") or 0),
                 str(event.get("status") or ""),
                 str(event.get("verified_at") or ""),
                 *key_values,

--- a/src/ovp_pipeline/knowledge_index.py
+++ b/src/ovp_pipeline/knowledge_index.py
@@ -141,6 +141,10 @@ TRUTH_PROJECTION_TABLE_COLUMNS: dict[str, tuple[str, ...]] = {
         "locator",
         "content_hash",
         "retrieval_context",
+        "quote_start_line",
+        "quote_end_line",
+        "quote_start_char",
+        "quote_end_char",
         "status",
         "verified_at",
     ),
@@ -154,6 +158,10 @@ TRUTH_PROJECTION_TABLE_COLUMNS: dict[str, tuple[str, ...]] = {
         "locator",
         "content_hash",
         "retrieval_context",
+        "quote_start_line",
+        "quote_end_line",
+        "quote_start_char",
+        "quote_end_char",
         "status",
         "verified_at",
     ),
@@ -532,8 +540,29 @@ def _knowledge_db_supports_pack_schema(db_path: Path) -> bool:
         "timeline_events": {"slug", "event_date", "event_type", "heading", "payload_json"},
         "objects": {"pack"},
         "claims": {"pack"},
-        "claim_evidence": {"pack", "locator", "content_hash", "status", "verified_at"},
-        "relations": {"pack", "quote_text", "locator", "content_hash", "status", "verified_at"},
+        "claim_evidence": {
+            "pack",
+            "locator",
+            "content_hash",
+            "quote_start_line",
+            "quote_end_line",
+            "quote_start_char",
+            "quote_end_char",
+            "status",
+            "verified_at",
+        },
+        "relations": {
+            "pack",
+            "quote_text",
+            "locator",
+            "content_hash",
+            "quote_start_line",
+            "quote_end_line",
+            "quote_start_char",
+            "quote_end_char",
+            "status",
+            "verified_at",
+        },
         "compiled_summaries": {"pack"},
         "contradictions": {"pack"},
         "graph_edges": {"pack"},
@@ -745,9 +774,11 @@ def rebuild_knowledge_index(
                 """
                 INSERT INTO claim_evidence (
                     pack, claim_id, source_slug, evidence_kind, quote_text,
-                    locator, content_hash, retrieval_context, status, verified_at
+                    locator, content_hash, retrieval_context,
+                    quote_start_line, quote_end_line, quote_start_char, quote_end_char,
+                    status, verified_at
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 [row.to_row() for row in truth_projection.claim_evidence],
             )
@@ -755,9 +786,11 @@ def rebuild_knowledge_index(
                 """
                 INSERT INTO relations (
                     pack, source_object_id, target_object_id, relation_type, evidence_source_slug,
-                    quote_text, locator, content_hash, retrieval_context, status, verified_at
+                    quote_text, locator, content_hash, retrieval_context,
+                    quote_start_line, quote_end_line, quote_start_char, quote_end_char,
+                    status, verified_at
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 [row.to_row() for row in truth_projection.relations],
             )

--- a/src/ovp_pipeline/truth_api.py
+++ b/src/ovp_pipeline/truth_api.py
@@ -104,6 +104,19 @@ _BRIEFING_EVOLUTION_PRIORITY = {
     "confirms": 70,
     "enriches": 60,
 }
+_CANDIDATE_STRONG_EVIDENCE_COUNT = 3
+_CANDIDATE_STRONG_SOURCE_COUNT = 2
+_CANDIDATE_SENSITIVE_TERMS = (
+    "credential",
+    "medical",
+    "health",
+    "legal",
+    "finance",
+    "permission",
+    "personal",
+    "private",
+    "user profile",
+)
 _NOTE_CAPTURE_EVENT_TYPES = frozenset(
     {
         "source_staged_for_processing",
@@ -778,7 +791,10 @@ def _candidate_review_suggestion(
     action = "keep_as_candidate"
     if found_ambiguous_active:
         action = "keep_as_candidate"
-    elif entry.source_count >= 2 or entry.evidence_count >= 3:
+    elif (
+        entry.source_count >= _CANDIDATE_STRONG_SOURCE_COUNT
+        or entry.evidence_count >= _CANDIDATE_STRONG_EVIDENCE_COUNT
+    ):
         if similar and similar[0][1] >= 0.7:
             action = "merge_as_alias"
         else:
@@ -786,6 +802,80 @@ def _candidate_review_suggestion(
     elif similar and similar[0][1] >= 0.8:
         action = "merge_as_alias"
     return action, similar
+
+
+def _candidate_risk_layer(
+    entry: Any,
+    *,
+    suggested_action: str,
+    similar_existing: list[tuple[Any, float]],
+) -> dict[str, Any]:
+    source_count = int(getattr(entry, "source_count", 0) or 0)
+    evidence_count = int(getattr(entry, "evidence_count", 0) or 0)
+    if (
+        evidence_count >= _CANDIDATE_STRONG_EVIDENCE_COUNT
+        or source_count >= _CANDIDATE_STRONG_SOURCE_COUNT
+    ):
+        evidence_strength = "strong"
+    elif evidence_count > 0 or source_count > 0:
+        evidence_strength = "partial"
+    else:
+        evidence_strength = "weak"
+
+    identity_ambiguity = "clear"
+    if len(similar_existing) >= 2 and suggested_action == "keep_as_candidate":
+        identity_ambiguity = "ambiguous"
+    elif similar_existing:
+        identity_ambiguity = "possible_duplicate"
+
+    sensitivity_text = " ".join(
+        [
+            str(getattr(entry, "title", "") or ""),
+            str(getattr(entry, "definition", "") or ""),
+            str(getattr(entry, "area", "") or ""),
+        ]
+    ).lower()
+    sensitivity = "sensitive" if any(term in sensitivity_text for term in _CANDIDATE_SENSITIVE_TERMS) else "normal"
+    impact = {
+        "promote_to_active": "canonical_write",
+        "merge_as_alias": "identity_merge",
+        "keep_as_candidate": "review_only",
+    }.get(suggested_action, "review_only")
+
+    reasons: list[str] = []
+    if evidence_strength == "weak":
+        reasons.append("weak_evidence")
+    elif evidence_strength == "partial":
+        reasons.append("partial_evidence")
+    if identity_ambiguity == "ambiguous":
+        reasons.append("identity_ambiguous")
+    elif identity_ambiguity == "possible_duplicate":
+        reasons.append("possible_duplicate")
+    if sensitivity == "sensitive":
+        reasons.append("sensitive_subject")
+    if impact in {"canonical_write", "identity_merge"}:
+        reasons.append("canonical_impact")
+
+    tier = "low"
+    if identity_ambiguity == "ambiguous" or (sensitivity == "sensitive" and impact != "review_only"):
+        tier = "high"
+    elif (
+        evidence_strength in {"weak", "partial"}
+        or identity_ambiguity == "possible_duplicate"
+        or impact in {"canonical_write", "identity_merge"}
+    ):
+        tier = "medium"
+
+    return {
+        "tier": tier,
+        "reasons": reasons,
+        "factors": {
+            "evidence_strength": evidence_strength,
+            "identity_ambiguity": identity_ambiguity,
+            "sensitivity": sensitivity,
+            "impact": impact,
+        },
+    }
 
 
 def list_candidate_concepts(
@@ -823,6 +913,11 @@ def list_candidate_concepts(
 
     for entry in page_candidates:
         suggested_action, similar_existing = _candidate_review_suggestion(registry, entry)
+        risk = _candidate_risk_layer(
+            entry,
+            suggested_action=suggested_action,
+            similar_existing=similar_existing,
+        )
         candidate_path = candidate_file_path(resolved_vault, entry.slug)
         candidate_rel = ""
         candidate_note_path = ""
@@ -845,6 +940,7 @@ def list_candidate_concepts(
                 "candidate_path": candidate_rel,
                 "candidate_note_path": candidate_note_path,
                 "suggested_action": suggested_action,
+                "risk": risk,
                 "similar_existing": [
                     {
                         "slug": similar.slug,
@@ -857,6 +953,13 @@ def list_candidate_concepts(
             }
         )
 
+    risk_counts = {"low": 0, "medium": 0, "high": 0}
+    for item in items:
+        tier = str(item.get("risk", {}).get("tier") or "low")
+        if tier not in risk_counts:
+            continue
+        risk_counts[tier] += 1
+
     return {
         "screen": "candidates/browser",
         "query": query or "",
@@ -864,6 +967,7 @@ def list_candidate_concepts(
         "offset": offset,
         "count": len(filtered_candidates),
         "status_counts": {"candidate": len(filtered_candidates)},
+        "risk_counts": risk_counts,
         "items": items,
     }
 
@@ -1239,7 +1343,8 @@ def _claim_evidence_map(
     with sqlite3.connect(db_path) as conn:
         rows = conn.execute(
             f"""
-            SELECT claim_id, source_slug, evidence_kind, quote_text
+            SELECT claim_id, source_slug, evidence_kind, quote_text,
+                   quote_start_line, quote_end_line, quote_start_char, quote_end_char
             FROM claim_evidence
             WHERE claim_id IN ({placeholders})
             ORDER BY claim_id, source_slug, evidence_kind
@@ -1247,12 +1352,17 @@ def _claim_evidence_map(
             tuple(normalized_claim_ids),
         ).fetchall()
     evidence_map: dict[str, list[dict[str, Any]]] = {}
-    for claim_id, source_slug, evidence_kind, quote_text in rows:
+    for row in rows:
+        claim_id, source_slug, evidence_kind, quote_text = row[:4]
         evidence_map.setdefault(claim_id, []).append(
             {
                 "source_slug": source_slug,
                 "evidence_kind": evidence_kind,
                 "quote_text": quote_text or "",
+                "quote_start_line": int(row[4] or 0),
+                "quote_end_line": int(row[5] or 0),
+                "quote_start_char": int(row[6] or 0),
+                "quote_end_char": int(row[7] or 0),
             }
         )
     return evidence_map
@@ -1898,7 +2008,8 @@ def get_object_detail(
         ).fetchall()
         evidence_rows = conn.execute(
             """
-            SELECT claim_id, source_slug, evidence_kind, quote_text
+            SELECT claim_id, source_slug, evidence_kind, quote_text,
+                   quote_start_line, quote_end_line, quote_start_char, quote_end_char
             FROM claim_evidence
             WHERE claim_id IN (
                 SELECT claim_id FROM claims WHERE pack = ? AND object_id = ?
@@ -2009,6 +2120,10 @@ def get_object_detail(
                 "source_slug": row[1],
                 "evidence_kind": row[2],
                 "quote_text": row[3],
+                "quote_start_line": int(row[4] or 0),
+                "quote_end_line": int(row[5] or 0),
+                "quote_start_char": int(row[6] or 0),
+                "quote_end_char": int(row[7] or 0),
             }
             for row in evidence_rows
         ],

--- a/src/ovp_pipeline/truth_store.py
+++ b/src/ovp_pipeline/truth_store.py
@@ -54,6 +54,10 @@ CREATE TABLE claim_evidence (
   locator TEXT NOT NULL DEFAULT '',
   content_hash TEXT NOT NULL DEFAULT '',
   retrieval_context TEXT NOT NULL DEFAULT '',
+  quote_start_line INTEGER NOT NULL DEFAULT 0,
+  quote_end_line INTEGER NOT NULL DEFAULT 0,
+  quote_start_char INTEGER NOT NULL DEFAULT 0,
+  quote_end_char INTEGER NOT NULL DEFAULT 0,
   status TEXT NOT NULL DEFAULT 'unverified',
   verified_at TEXT NOT NULL DEFAULT ''
 );
@@ -71,6 +75,10 @@ CREATE TABLE relations (
   locator TEXT NOT NULL DEFAULT '',
   content_hash TEXT NOT NULL DEFAULT '',
   retrieval_context TEXT NOT NULL DEFAULT '',
+  quote_start_line INTEGER NOT NULL DEFAULT 0,
+  quote_end_line INTEGER NOT NULL DEFAULT 0,
+  quote_start_char INTEGER NOT NULL DEFAULT 0,
+  quote_end_char INTEGER NOT NULL DEFAULT 0,
   status TEXT NOT NULL DEFAULT 'unverified',
   verified_at TEXT NOT NULL DEFAULT ''
 );
@@ -278,10 +286,14 @@ class ClaimEvidenceRow:
     locator: str = ""
     content_hash: str = ""
     retrieval_context: str = ""
+    quote_start_line: int = 0
+    quote_end_line: int = 0
+    quote_start_char: int = 0
+    quote_end_char: int = 0
     status: str = EVIDENCE_STATUS_UNVERIFIED
     verified_at: str = ""
 
-    def to_row(self) -> tuple[str, str, str, str, str, str, str, str, str, str]:
+    def to_row(self) -> tuple[str, str, str, str, str, str, str, str, int, int, int, int, str, str]:
         return (
             self.pack,
             self.claim_id,
@@ -291,6 +303,10 @@ class ClaimEvidenceRow:
             self.locator,
             self.content_hash,
             self.retrieval_context,
+            int(self.quote_start_line),
+            int(self.quote_end_line),
+            int(self.quote_start_char),
+            int(self.quote_end_char),
             self.status,
             self.verified_at,
         )
@@ -314,10 +330,14 @@ class RelationRow:
     locator: str = ""
     content_hash: str = ""
     retrieval_context: str = ""
+    quote_start_line: int = 0
+    quote_end_line: int = 0
+    quote_start_char: int = 0
+    quote_end_char: int = 0
     status: str = EVIDENCE_STATUS_UNVERIFIED
     verified_at: str = ""
 
-    def to_row(self) -> tuple[str, str, str, str, str, str, str, str, str, str, str]:
+    def to_row(self) -> tuple[str, str, str, str, str, str, str, str, int, int, int, int, str, str, str]:
         return (
             self.pack,
             self.source_object_id,
@@ -328,6 +348,10 @@ class RelationRow:
             self.locator,
             self.content_hash,
             self.retrieval_context,
+            int(self.quote_start_line),
+            int(self.quote_end_line),
+            int(self.quote_start_char),
+            int(self.quote_end_char),
             self.status,
             self.verified_at,
         )
@@ -430,6 +454,12 @@ def _coerce_rows(values: Iterable[Any], row_type: type) -> list[Any]:
         if isinstance(item, row_type):
             coerced.append(item)
         elif isinstance(item, tuple):
+            if row_type is ClaimEvidenceRow and len(item) == 10:
+                coerced.append(row_type(*item[:8], 0, 0, 0, 0, *item[8:]))
+                continue
+            if row_type is RelationRow and len(item) == 11:
+                coerced.append(row_type(*item[:9], 0, 0, 0, 0, *item[9:]))
+                continue
             coerced.append(row_type(*item))
         elif isinstance(item, dict):
             coerced.append(row_type(**item))

--- a/tests/test_evidence_v2.py
+++ b/tests/test_evidence_v2.py
@@ -19,6 +19,7 @@ import pytest
 
 from ovp_pipeline.evidence import (
     compute_content_hash,
+    compute_evidence_span,
     compute_locator,
     compute_retrieval_context,
     verify_evidence_row,
@@ -60,6 +61,10 @@ def test_evidence_verify_batches_table_updates(temp_vault, monkeypatch):
         "",
         "",
         "",
+        0,
+        0,
+        0,
+        0,
         EVIDENCE_STATUS_UNVERIFIED,
         "",
     )
@@ -104,6 +109,10 @@ def _seed_claim_evidence_row(
     locator: str = "",
     content_hash: str = "",
     retrieval_context: str = "",
+    quote_start_line: int = 0,
+    quote_end_line: int = 0,
+    quote_start_char: int = 0,
+    quote_end_char: int = 0,
     status: str = EVIDENCE_STATUS_UNVERIFIED,
     verified_at: str = "",
 ) -> None:
@@ -113,8 +122,10 @@ def _seed_claim_evidence_row(
             """
             INSERT INTO claim_evidence
               (pack, claim_id, source_slug, evidence_kind, quote_text,
-               locator, content_hash, retrieval_context, status, verified_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+               locator, content_hash, retrieval_context,
+               quote_start_line, quote_end_line, quote_start_char, quote_end_char,
+               status, verified_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 pack,
@@ -125,6 +136,10 @@ def _seed_claim_evidence_row(
                 locator,
                 content_hash,
                 retrieval_context,
+                quote_start_line,
+                quote_end_line,
+                quote_start_char,
+                quote_end_char,
                 status,
                 verified_at,
             ),
@@ -169,6 +184,10 @@ date: 2026-04-22
         "locator",
         "content_hash",
         "retrieval_context",
+        "quote_start_line",
+        "quote_end_line",
+        "quote_start_char",
+        "quote_end_char",
         "status",
         "verified_at",
     }.issubset(columns)
@@ -198,6 +217,10 @@ date: 2026-04-22
         "locator",
         "content_hash",
         "retrieval_context",
+        "quote_start_line",
+        "quote_end_line",
+        "quote_start_char",
+        "quote_end_char",
         "status",
         "verified_at",
     }.issubset(columns)
@@ -249,6 +272,20 @@ def test_compute_retrieval_context_centers_on_quote(tmp_path):
     context = compute_retrieval_context(src, "ANCHOR", radius=20)
     assert "ANCHOR" in context
     assert len(context) <= len("ANCHOR") + 40 + 5  # radius padding tolerance
+
+
+def test_compute_evidence_span_returns_markdown_line_and_char_offsets(tmp_path):
+    src = tmp_path / "doc.md"
+    src.write_text(
+        "# Top\n\nintro paragraph\n\n## Evidence\n\nfirst line\nsecond unique line\nthird line\n",
+        encoding="utf-8",
+    )
+
+    span = compute_evidence_span(src, "second unique line")
+
+    assert span["quote_start_line"] == 8
+    assert span["quote_end_line"] == 8
+    assert span["quote_start_char"] < span["quote_end_char"]
 
 
 # ---------------------------------------------------------------------------
@@ -380,12 +417,16 @@ The signal phrase to locate.
 
     with sqlite3.connect(db_path) as conn:
         row = conn.execute(
-            "SELECT locator, content_hash, status, verified_at FROM claim_evidence "
+            "SELECT locator, content_hash, quote_start_line, quote_end_line, "
+            "quote_start_char, quote_end_char, status, verified_at FROM claim_evidence "
             "WHERE pack='research-tech' AND claim_id='claim-1'"
         ).fetchone()
-    locator, content_hash, status, verified_at = row
+    locator, content_hash, start_line, end_line, start_char, end_char, status, verified_at = row
     assert content_hash  # backfilled
     assert locator.startswith("section#")  # quote was locatable
+    assert start_line > 0
+    assert end_line >= start_line
+    assert start_char < end_char
     assert status == EVIDENCE_STATUS_VERIFIED
     assert verified_at
 

--- a/tests/test_truth_api.py
+++ b/tests/test_truth_api.py
@@ -1254,6 +1254,12 @@ def test_truth_api_returns_object_detail_with_claims_relations_and_summary(temp_
     assert detail["claims"][0]["claim_kind"] == "page_summary"
     assert detail["relations"][0]["target_object_id"] == "target-note"
     assert detail["evidence"][0]["evidence_kind"] == "page_summary"
+    assert {
+        "quote_start_line",
+        "quote_end_line",
+        "quote_start_char",
+        "quote_end_char",
+    }.issubset(detail["evidence"][0])
     assert detail["contradictions"][0]["subject_key"] == "agent harness"
 
 
@@ -5151,6 +5157,10 @@ def test_truth_api_lists_candidate_concepts(temp_vault):
     )
     assert item["suggested_action"] == "merge_as_alias"
     assert item["similar_existing"][0]["slug"] == "alpha-existing"
+    assert item["risk"]["tier"] == "medium"
+    assert item["risk"]["factors"]["evidence_strength"] == "strong"
+    assert "possible_duplicate" in item["risk"]["reasons"]
+    assert payload["risk_counts"]["medium"] == 1
 
     empty_page = list_candidate_concepts(temp_vault, limit=0)
     assert empty_page["count"] == 1
@@ -5250,6 +5260,9 @@ def test_truth_api_ambiguous_candidate_suggestion_does_not_promote_duplicate_ris
 
     assert payload["items"][0]["slug"] == "ambiguous-candidate"
     assert payload["items"][0]["suggested_action"] == "keep_as_candidate"
+    assert payload["items"][0]["risk"]["tier"] == "high"
+    assert payload["items"][0]["risk"]["factors"]["identity_ambiguity"] == "ambiguous"
+    assert "identity_ambiguous" in payload["items"][0]["risk"]["reasons"]
     assert {item["slug"] for item in payload["items"][0]["similar_existing"]} == {
         "alpha-existing",
         "beta-existing",

--- a/tests/test_truth_store.py
+++ b/tests/test_truth_store.py
@@ -3,6 +3,49 @@ from __future__ import annotations
 import sqlite3
 
 
+def test_truth_store_projection_accepts_legacy_evidence_tuples():
+    from ovp_pipeline.truth_store import TruthStoreProjection
+
+    projection = TruthStoreProjection(
+        claim_evidence=[
+            (
+                "research-tech",
+                "claim-1",
+                "source",
+                "page_summary",
+                "quote",
+                "locator",
+                "hash",
+                "context",
+                "verified",
+                "2026-04-30T00:00:00Z",
+            )
+        ],
+        relations=[
+            (
+                "research-tech",
+                "source",
+                "target",
+                "uses",
+                "source",
+                "quote",
+                "locator",
+                "hash",
+                "context",
+                "verified",
+                "2026-04-30T00:00:00Z",
+            )
+        ],
+    )
+
+    claim = projection.claim_evidence[0]
+    relation = projection.relations[0]
+    assert claim.status == "verified"
+    assert claim.quote_start_line == 0
+    assert relation.status == "verified"
+    assert relation.quote_start_line == 0
+
+
 def test_rebuild_knowledge_index_populates_truth_store_tables(temp_vault):
     from ovp_pipeline.knowledge_index import rebuild_knowledge_index
     from ovp_pipeline.runtime import VaultLayout


### PR DESCRIPTION
## Summary
- add line/char evidence span fields to claim_evidence and relations projections
- backfill and replay evidence spans alongside locator/hash/context verification metadata
- expose evidence spans through truth object/detail payloads and candidate risk tiers through candidate review payloads
- update backlog, README, milestone, architecture, and roadmap docs for BL-006/BL-007 and KSR-001/KSR-003/KSR-018

## Tests
- `PYTHONPATH=src python -m pytest tests/test_evidence_v2.py tests/test_evidence_schema.py tests/test_truth_api.py tests/test_promotion_policy.py tests/test_semantic_relations.py tests/test_semantic_relations_evolves.py tests/test_reuse_events.py tests/test_knowledge_index.py tests/test_truth_store.py -q`
- `python -m ruff check src/ovp_pipeline/evidence.py src/ovp_pipeline/truth_store.py src/ovp_pipeline/knowledge_index.py src/ovp_pipeline/commands/evidence_verify.py src/ovp_pipeline/evidence_replay.py src/ovp_pipeline/truth_api.py tests/test_evidence_v2.py tests/test_truth_api.py tests/test_truth_store.py`
- `PYTHONPATH=src python -m pytest -q`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/82" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
