### PR TITLE
feat: add kind-specific object reader lenses

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -667,14 +667,14 @@ Main gaps:
 - Layer 4 fitness checks now cover the first hot-path, workflow-wiring, source routing preview, evidence span backfill, and candidate risk cases; deeper evidence completeness, projection replay, and import-boundary checks are still open.
 - Projection lifecycle markers need structured schema, scope, lease, and supersession.
 - Schema versioning is not yet wired into projection lifecycle.
-- The reader-first home is now the default entry; object pages have a first reader profile/source rail; `/graph` has a first spatial map projection; search and deeper per-kind object layouts still need product shape.
+- The reader-first home is now the default entry; object pages have reader profiles, source rails, and kind-specific reader lenses; `/graph` has a first spatial map projection; search still needs product shape.
 
 ## 18. Near-Term Architecture Actions
 
 Recommended order:
 
 1. Keep projection metadata attached to new access surfaces and add doctor/export checks that verify the labels are present.
-2. Continue reader-first Layer 3 product work on deeper per-kind object layouts and search using the new evidence spans/risk tiers.
+2. Continue reader-first Layer 3 product work on search using the new kind lenses, evidence spans, and risk tiers.
 3. Add stricter factual evidence completeness checks before expanding automatic promotion.
 4. Introduce structured `ProjectionRepairMarker` schema.
 5. Add schema version fields to Authority and derived projection state.
@@ -691,6 +691,6 @@ The architecture should not depend on backlog IDs to be valid. The table below i
 | Article routing preview | `BL-005`, `KSR-014` done in PR #81 |
 | Evidence span / factual evidence completeness | `BL-006`, `KSR-001`, `KSR-018` done in PR #82 |
 | Candidate risk layering | `BL-007`, `KSR-003` done in PR #82 |
-| Reader-first access surfaces | `BL-001`; `BL-008` partial and `BL-009` done in PR #79; `BL-010` done in PR #80 |
+| Reader-first access surfaces | `BL-001`; `BL-008` and `BL-009` done through PR #79 and PR #83; `BL-010` done in PR #80 |
 | Projection repair lifecycle | `BL-020` |
 | Schema versioning and migration trigger | `BL-021` |

--- a/ARCHITECTURE.zh-CN.md
+++ b/ARCHITECTURE.zh-CN.md
@@ -777,7 +777,7 @@ Do not rely on ad hoc "just rerun the pipeline" behavior for schema changes.
 - governance / resolver contracts 还需要显式化。
 - schema versioning 和 projection compatibility 还需要工程化。
 - fitness functions 只落地了第一批，仍需扩展到 CI/doctor/pre-commit 的完整契约。
-- reader-first home 已经成为默认入口；object page 已有第一版 reader profile/source rail；`/graph` 已有第一版 spatial map projection；search 和更深的 per-kind object layout 还需要继续产品化。
+- reader-first home 已经成为默认入口；object page 已有 reader profile、source rail 和按 kind 区分的 reader lens；`/graph` 已有第一版 spatial map projection；search 还需要继续产品化。
 
 ## 17. 近期架构动作
 
@@ -786,7 +786,7 @@ Do not rely on ad hoc "just rerun the pipeline" behavior for schema changes.
 优先顺序：
 
 1. 新增 access surface 时必须继续带 projection metadata，并补 doctor/export checks 验证标注存在。
-2. 继续做 reader-first Layer 3：用新的 evidence span / risk tier 推进更深的 per-kind object layout 和 search。
+2. 继续做 reader-first Layer 3：用新的 kind lens、evidence span、risk tier 推进 search。
 3. 在扩大自动 promotion 前，补更严格的 factual evidence completeness checks。
 4. 引入结构化 ProjectionRepairMarker。
 5. 给 Authority 和 derived projection state 增加 schema version 字段。
@@ -805,7 +805,7 @@ Do not rely on ad hoc "just rerun the pipeline" behavior for schema changes.
 | Article routing preview | `BL-005`, `KSR-014` 已在 PR #81 交付 |
 | Evidence span / factual evidence completeness | `BL-006`, `KSR-001`, `KSR-018` 已在 PR #82 交付 |
 | Candidate risk layering | `BL-007`, `KSR-003` 已在 PR #82 交付 |
-| Reader-first access surfaces | `BL-001`；`BL-008` partial、`BL-009` 已在 PR #79 交付；`BL-010` 已在 PR #80 交付 |
+| Reader-first access surfaces | `BL-001`；`BL-008`、`BL-009` 已通过 PR #79 和 PR #83 交付；`BL-010` 已在 PR #80 交付 |
 | Projection repair lifecycle | `BL-020` |
 | Schema versioning and migration trigger | `BL-021` |
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -21,7 +21,7 @@ Rule: historical plans and vault research notes feed this file; they do not over
 | M0 Pipeline And Pack Foundation | Done | CLI, source lifecycle, pack/profile runtime, `knowledge.db`, first source-lifecycle idempotency slice |
 | M1 Operator Workbench And Review Runtime | Done / maintain | truth UI, candidates, signals/actions, contradictions, action worker |
 | M2 Roadmap And README Consolidation | Done | merged historical milestones, compiler roadmap, recent KSR input, reader-product research, and English-primary docs |
-| M3 Reader-First Knowledge Atlas | Active | reader home, `/ops` split, first object source/backlink rail, and visual graph map shipped; deeper kind-specific object layouts still need product shape |
+| M3 Reader-First Knowledge Atlas | Active | reader home, `/ops` split, object source/backlink rail, visual graph map, and kind-specific object reader lenses shipped; reader search remains |
 | M4 KSR Safety And Hot-Path Hardening | Active | projection labels, hot-path audit, wiring evals, article routing preview, evidence spans, and candidate risk shipped; deeper enforcement remains |
 | M5 Context Pack And Operational Runtime | Later | session snapshots, context budget, claim leases, provider facade, observability |
 | M6 Policy, Permission, And Knowledge Evolution | Later | permission layer, claim lifecycle, conflict detection, policy promotion |
@@ -39,7 +39,7 @@ Rule: historical plans and vault research notes feed this file; they do not over
 | BL-005 | P0 | Done | Article routing preview before source lifecycle changes | M4, KSR-014 |
 | BL-006 | P0 | Done | Evidence span schema and markdown-aware locator backfill | M4, KSR-001, KSR-018 |
 | BL-007 | P0 | Done | Candidate risk layering by evidence strength, identity ambiguity, sensitivity, and impact | M4, KSR-003 |
-| BL-008 | P1 | Partial | Kind-aware object pages for people, concepts, companies/tools/projects, events, and claims; first slice adds reader profile/kind labels | M3, PR #79 |
+| BL-008 | P1 | Done | Kind-aware object pages for people, concepts, companies/tools/projects, events, and claims, with reader profiles, source/backlink rails, kind-specific lenses, and section labels | M3, PR #79, PR #83 |
 | BL-009 | P1 | Done | Mention/backlink rail with excerpts, source jumps, and relation context | M3, reader-product note, PR #79 |
 | BL-010 | P1 | Done | Visual `/graph` MVP as a spatial corpus map; analytical clusters remain under `/clusters` for ops/debug | M3, PR #80 |
 | BL-011 | P1 | Later | Reader-oriented search grouped by kind, summary, evidence, and reason | M3/M4 |
@@ -90,12 +90,12 @@ Rule: historical plans and vault research notes feed this file; they do not over
 
 ## Next Decision
 
-`BL-001` is shipped in PR #75, `BL-003 + BL-004` are shipped in PR #77, `BL-002` is shipped in PR #78, `BL-009` plus the first `BL-008` slice are shipped in PR #79, `BL-010` is shipped in PR #80, `BL-005` is shipped in PR #81, and `BL-006 + BL-007` are implemented in PR #82. The default UI now has a reader-first entry point, `/ops` owns the operator dashboard, core access/materialized surfaces carry explicit projection labels, object pages expose readable source/backlink rails, `/graph` renders a reader-facing spatial map over graph projections, `ovp-absorb --dry-run --json` explains source lifecycle routing before mutation, evidence rows carry line/char spans, and candidate review payloads expose risk tiers.
+`BL-001` is shipped in PR #75, `BL-003 + BL-004` are shipped in PR #77, `BL-002` is shipped in PR #78, `BL-009` plus the first `BL-008` slice are shipped in PR #79, `BL-010` is shipped in PR #80, `BL-005` is shipped in PR #81, and `BL-006 + BL-007` are implemented in PR #82. The default UI now has a reader-first entry point, `/ops` owns the operator dashboard, core access/materialized surfaces carry explicit projection labels, object pages expose readable source/backlink rails and kind-specific reader lenses, `/graph` renders a reader-facing spatial map over graph projections, `ovp-absorb --dry-run --json` explains source lifecycle routing before mutation, evidence rows carry line/char spans, and candidate review payloads expose risk tiers.
 
-The next implementation PR should return to the reader product lane with **BL-008** deeper per-kind object layouts, then **BL-011** reader-oriented search. M4 still has deeper enforcement work, but the P0 risk reducers needed before richer reader surfaces are now in place.
+The next implementation PR should continue the reader product lane with **BL-011** reader-oriented search grouped by kind, summary, evidence, and reason. M4 still has deeper enforcement work, but the P0 risk reducers needed before richer reader surfaces are now in place.
 
 Recommended order:
 
-1. Continue BL-008 with deeper per-kind layouts
-2. BL-011
-3. BL-020 / BL-021 when projection repair and schema migration become the next operational bottleneck
+1. BL-011 reader-oriented search
+2. BL-020 / BL-021 when projection repair and schema migration become the next operational bottleneck
+3. BL-012 / BL-013 once the reader surfaces need stronger reuse/context-pack loops

--- a/MILESTONE.md
+++ b/MILESTONE.md
@@ -33,7 +33,7 @@ That means the user-facing product should make compiled knowledge easy to read f
 | M0 Pipeline And Pack Foundation | Done | CLI, source lifecycle, pack/profile runtime, `knowledge.db`, first source-lifecycle idempotency slice |
 | M1 Operator Workbench And Review Runtime | Done / maintain | truth UI, candidates, signals/actions, contradictions, action worker |
 | M2 Roadmap And README Consolidation | Done | merged historical milestones, compiler roadmap, recent KSR input, reader-product research, and the English-primary docs structure |
-| M3 Reader-First Knowledge Atlas | Active | reader home, `/ops` split, first object source/backlink rail, and visual graph map shipped; deeper kind-specific object layouts remain |
+| M3 Reader-First Knowledge Atlas | Active | reader home, `/ops` split, object source/backlink rail, visual graph map, and kind-specific object reader lenses shipped; reader search remains |
 | M4 KSR Safety And Hot-Path Hardening | Active | projection labels, hot-path audit, wiring evals, article routing preview, evidence spans, and candidate risk shipped; deeper enforcement remains |
 | M5 Context Pack And Operational Runtime | Later | session snapshots, context budget, claim leases, provider facade, observability |
 | M6 Policy, Permission, And Knowledge Evolution | Later | permission layer, claim lifecycle, conflict detection, policy promotion |
@@ -50,7 +50,7 @@ That means the user-facing product should make compiled knowledge easy to read f
 | Article routing preview | `BL-005`, `KSR-014` done in PR #81 |
 | Evidence span / factual evidence completeness | `BL-006`, `KSR-001`, `KSR-018` done in PR #82 |
 | Candidate risk layering | `BL-007`, `KSR-003` done in PR #82 |
-| Kind-aware object pages and backlink rail | `BL-008` partial and `BL-009` done in PR #79 |
+| Kind-aware object pages and backlink rail | `BL-008` and `BL-009` done through PR #79 and PR #83 |
 | Visual graph MVP | `BL-010` done in PR #80 |
 | Projection repair lifecycle | `BL-020` |
 | Schema versioning and migration trigger | `BL-021` |
@@ -59,9 +59,9 @@ That means the user-facing product should make compiled knowledge easy to read f
 
 Recommended order:
 
-1. Continue `BL-008`: deeper per-kind object layouts beyond the first reader profile.
-2. Implement `BL-011`: reader-oriented search grouped by kind, summary, evidence, and reason.
-3. Return to `BL-020 + BL-021` when projection repair and schema migration need operational hardening.
+1. Implement `BL-011`: reader-oriented search grouped by kind, summary, evidence, and reason.
+2. Return to `BL-020 + BL-021` when projection repair and schema migration need operational hardening.
+3. Move into `BL-012 + BL-013` once the reader surfaces need stronger reuse and context-pack loops.
 
 ## Documentation Rules
 

--- a/MILESTONE.zh-CN.md
+++ b/MILESTONE.zh-CN.md
@@ -33,7 +33,7 @@ OVP 正在从 document-processing pipeline 变成：
 | M0 Pipeline And Pack Foundation | Done | CLI、source lifecycle、pack/profile runtime、`knowledge.db`、第一段 source-lifecycle idempotency |
 | M1 Operator Workbench And Review Runtime | Done / maintain | truth UI、candidates、signals/actions、contradictions、action worker |
 | M2 Roadmap And README Consolidation | Done | 已合并历史 milestones、compiler roadmap、近期 KSR 输入、reader-product 研究，以及英文主文档结构 |
-| M3 Reader-First Knowledge Atlas | Active | reader home、`/ops` 拆分、第一版 object source/backlink rail、visual graph map 已交付；更深的 kind-specific object layout 仍待推进 |
+| M3 Reader-First Knowledge Atlas | Active | reader home、`/ops` 拆分、object source/backlink rail、visual graph map、按 kind 区分的 object reader lens 已交付；reader search 仍待推进 |
 | M4 KSR Safety And Hot-Path Hardening | Active | projection labels、hot-path audit、wiring evals、article routing preview、evidence spans、candidate risk 已交付；更深的 enforcement 仍待推进 |
 | M5 Context Pack And Operational Runtime | Later | session snapshots、context budget、claim leases、provider facade、observability |
 | M6 Policy, Permission, And Knowledge Evolution | Later | permission layer、claim lifecycle、conflict detection、policy promotion |
@@ -50,7 +50,7 @@ OVP 正在从 document-processing pipeline 变成：
 | Article routing preview | `BL-005`, `KSR-014` 已在 PR #81 交付 |
 | Evidence span / factual evidence completeness | `BL-006`, `KSR-001`, `KSR-018` 已在 PR #82 交付 |
 | Candidate risk layering | `BL-007`, `KSR-003` 已在 PR #82 交付 |
-| Kind-aware object pages and backlink rail | `BL-008` partial，`BL-009` 已在 PR #79 交付 |
+| Kind-aware object pages and backlink rail | `BL-008`、`BL-009` 已通过 PR #79 和 PR #83 交付 |
 | Visual graph MVP | `BL-010` 已在 PR #80 交付 |
 | Projection repair lifecycle | `BL-020` |
 | Schema versioning and migration trigger | `BL-021` |
@@ -59,9 +59,9 @@ OVP 正在从 document-processing pipeline 变成：
 
 建议顺序：
 
-1. 继续 `BL-008`：在第一版 reader profile 之后补更深的 per-kind object layout。
-2. 实施 `BL-011`：按 kind、summary、evidence、reason 重做 reader-oriented search。
-3. 当 projection repair 和 schema migration 成为运营瓶颈时，回到 `BL-020 + BL-021`。
+1. 实施 `BL-011`：按 kind、summary、evidence、reason 重做 reader-oriented search。
+2. 当 projection repair 和 schema migration 成为运营瓶颈时，回到 `BL-020 + BL-021`。
+3. 当 reader surface 需要更强的复用和 context-pack 闭环时，再进入 `BL-012 + BL-013`。
 
 ## 文档规则
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Current milestone sequence:
 | M0 Pipeline And Pack Foundation | Complete | CLI, source lifecycle, pack/profile runtime, `knowledge.db`, first KSR-013 slice |
 | M1 Operator Workbench And Review Runtime | Complete enough | truth UI, candidates, signals/actions, contradictions, action worker |
 | M2 Roadmap And README Consolidation | Complete | merged historical milestones, compiler roadmap, recent KSR input, and reader-product research |
-| M3 Reader-First Knowledge Atlas | Active | reader home, `/ops` split, first object source/backlink rail, and visual graph map shipped; deeper per-kind object layouts still need product shape |
+| M3 Reader-First Knowledge Atlas | Active | reader home, `/ops` split, object source/backlink rail, visual graph map, and kind-specific object reader lenses shipped; reader search remains |
 | M4 KSR Safety And Hot-Path Hardening | Active | projection labels, hot-path audit, wiring evals, article routing preview, evidence spans, and candidate risk tiers have shipped; deeper enforcement remains |
 | M5 Context Pack And Operational Runtime | Later | session snapshots, context budget, claim leases, provider facades, observability |
 | M6 Policy, Permission, And Knowledge Evolution | Later | permission layer, claim lifecycle, conflict detection, policy promotion |
@@ -103,8 +103,8 @@ Current milestone sequence:
 Current active backlog focus:
 
 - Shipped: `KSR-001` evidence spans, `KSR-002` projection labels, `KSR-003` candidate risk tiers, `KSR-014` article routing preview, `KSR-015` dashboard/search hot-path audit, `KSR-018` markdown-aware evidence span backfill, `KSR-026` workflow wiring eval suite.
-- Product shipped: first readable object page profile, source/backlink rail, and visual `/graph` map.
-- Next: deeper per-kind object layouts, then reader-oriented search grouped by kind, evidence, and reason.
+- Product shipped: readable object page profiles, source/backlink rail, kind-specific reader lenses, and visual `/graph` map.
+- Next: reader-oriented search grouped by kind, evidence, and reason.
 - Product track: reader-first Knowledge Atlas stays a projection layer, not a new state system.
 
 ## Domain Packs

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -92,7 +92,7 @@ Obsidian Vault Pipeline（OVP）不是一个“多脚本拼装包”，也不只
 | M0 Pipeline And Pack Foundation | Complete | CLI、source lifecycle、pack/profile、`knowledge.db`、KSR-013 第一版 |
 | M1 Operator Workbench And Review Runtime | Complete enough | truth UI、candidates、signals/actions、contradictions、action worker |
 | M2 Roadmap And README Consolidation | Complete | 已合并历史 milestone、compiler roadmap、近期 KSR 输入与 reader-product 研究，重整 README |
-| M3 Reader-First Knowledge Atlas | Active | reader home、`/ops` 拆分、第一版 object source/backlink rail、visual graph map 已交付；更深的 per-kind object layout 仍需产品化 |
+| M3 Reader-First Knowledge Atlas | Active | reader home、`/ops` 拆分、object source/backlink rail、visual graph map、按 kind 区分的 object reader lens 已交付；reader search 仍需推进 |
 | M4 KSR Safety And Hot-Path Hardening | Active | projection 标注、hot-path audit、wiring eval、article routing preview、evidence span、candidate 风险分层已交付；更深的 enforcement 仍待推进 |
 | M5 Context Pack And Operational Runtime | Later | session snapshot、context budget、claim lease、provider facade、observability |
 | M6 Policy, Permission, And Knowledge Evolution | Later | permission layer、claim lifecycle、conflict detection、policy promotion |
@@ -101,8 +101,8 @@ Obsidian Vault Pipeline（OVP）不是一个“多脚本拼装包”，也不只
 当前 active backlog 重点：
 
 - 已交付：`KSR-001` Evidence span 化、`KSR-002` Projection 标注、`KSR-003` Candidate 风险分层、`KSR-014` Article routing preview、`KSR-015` Dashboard/search hot-path audit、`KSR-018` Markdown-aware evidence span backfill、`KSR-026` Workflow wiring eval suite。
-- 产品侧已交付：第一版 readable object page profile、source/backlink rail 和 visual `/graph` map。
-- 下一步：继续更深的 per-kind object layout，然后做按 kind、evidence、reason 组织的 reader-oriented search。
+- 产品侧已交付：readable object page profile、source/backlink rail、按 kind 区分的 reader lens 和 visual `/graph` map。
+- 下一步：做按 kind、evidence、reason 组织的 reader-oriented search。
 - 产品线：Reader-first Knowledge Atlas 作为 projection layer 实现，不另建状态系统。
 
 ## Domain Packs

--- a/docs/plans/2026-04-29-consolidated-product-roadmap.md
+++ b/docs/plans/2026-04-29-consolidated-product-roadmap.md
@@ -161,6 +161,7 @@ First PR slice:
 Second PR slice:
 
 - kind-aware object pages for person, concept, company/tool/project, event, claim
+- kind-specific reader lenses and section labels for those object pages
 - backlink/mention rail with excerpts and source jumps
 - raw audit/provenance kept secondary and expandable
 
@@ -313,5 +314,5 @@ The better sequence is likely:
 
 1. reader shell route split (`/` vs `/ops`)
 2. hot-path/wiring evals
-3. kind-aware object pages and backlink rail
+3. kind-aware object pages, reader lenses, and backlink rail
 4. visual graph MVP

--- a/docs/plans/2026-04-29-reader-product-shape-and-backlog-reconciliation.md
+++ b/docs/plans/2026-04-29-reader-product-shape-and-backlog-reconciliation.md
@@ -209,7 +209,7 @@ Recommended ordering:
 2. **Object Pages v2**
    - Replace database-like object pages with kind-aware reader templates.
    - Use existing object detail, evidence, relations, backlinks, capture summaries, and compiled sections.
-   - Person/concept/company pages should be the first three templates.
+   - Person, concept, company/tool/project, event, and claim pages now have a first reader-lens slice.
 
 3. **Visual Graph MVP**
    - Add `/graph` as a reader-facing visual map.
@@ -255,7 +255,7 @@ Suggested second PR:
 Scope:
 
 - update object page view model with page kind contract
-- add Person / Concept / Company / generic templates
+- add Person / Concept / Company / Tool / Project / Event / Claim reader lenses
 - render evidence and backlinks as reading context
 - keep raw audit/provenance collapsible
 
@@ -275,12 +275,12 @@ Scope:
 
 | Item | Priority | Status | Notes |
 | --- | --- | --- | --- |
-| Reader home / Knowledge Atlas | P0 | proposed next | Highest leverage product-shape correction |
-| Move current dashboard to `/ops` | P0 | proposed next | Preserves operator value while changing first impression |
-| Kind-aware object pages | P0 | next | Turns extraction objects into user-readable pages |
-| Mention/backlink rail | P1 | next | Direct LearnBuffett lesson; evidence-backed reading context |
-| Visual `/graph` map | P1 | next | Use current graph data; no new backend |
-| Reader-oriented search | P1 | later | Depends on object summaries and evidence counts |
+| Reader home / Knowledge Atlas | P0 | shipped | Highest leverage product-shape correction |
+| Move current dashboard to `/ops` | P0 | shipped | Preserves operator value while changing first impression |
+| Kind-aware object pages | P0 | shipped first reader-lens slice | Turns extraction objects into user-readable pages |
+| Mention/backlink rail | P1 | shipped | Direct LearnBuffett lesson; evidence-backed reading context |
+| Visual `/graph` map | P1 | shipped first MVP | Use current graph data; no new backend |
+| Reader-oriented search | P1 | next | Depends on object summaries and evidence counts |
 | Trusted reuse loop | P1 | keep | Still core north-star measurement |
 | Evidence v2 | P1 | keep | Still needed for long-term trust |
 | Policy promotion | P2 | keep | Important, but after product entry is understandable |

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -1853,6 +1853,30 @@ def _render_source_backlink_rail(payload: dict, *, requested_pack: str) -> str:
     )
 
 
+def _render_kind_profile_card(payload: dict) -> str:
+    profile = payload.get("kind_profile") or {}
+    prompts = profile.get("reading_prompts") or []
+    prompt_html = (
+        "".join(
+            "<li>"
+            f"<strong>{escape(str(item.get('label') or 'Prompt'))}</strong>"
+            f"<p class='muted'>{escape(str(item.get('detail') or ''))}</p>"
+            "</li>"
+            for item in prompts
+            if isinstance(item, dict)
+        )
+        or "<li class='muted'>Start with the summary, then verify against sources.</li>"
+    )
+    return (
+        "<section class='card'><h2>"
+        f"{escape(str(profile.get('title') or 'Object Brief'))}"
+        "</h2>"
+        f"<p>{escape(str(profile.get('primary_question') or 'What should I understand here?'))}</p>"
+        f"<ul class='list-tight'>{prompt_html}</ul>"
+        "</section>"
+    )
+
+
 def _render_object_page(payload: dict) -> str:
     requested_pack = payload.get("requested_pack", "")
     research_shell_enabled = bool(
@@ -2018,6 +2042,7 @@ def _render_object_page(payload: dict) -> str:
         right_sections.append(_render_research_scope_notice(requested_pack))
     right_sections.extend(
         [
+            _render_kind_profile_card(payload),
             _render_source_backlink_rail(payload, requested_pack=requested_pack),
             "<section class='card'><h2>Context</h2><dl class='meta-list'>"
             f"<div><dt>Object Kind</dt><dd>{escape(payload['context']['object_kind'])}</dd></div>"

--- a/src/ovp_pipeline/ui/view_models.py
+++ b/src/ovp_pipeline/ui/view_models.py
@@ -146,6 +146,115 @@ _OBJECT_KIND_LABELS = {
     "claim": "Claim",
     "evergreen": "Concept",
 }
+_OBJECT_KIND_READER_PROFILES = {
+    "person": {
+        "layout": "person_profile",
+        "title": "Person Profile",
+        "primary_question": (
+            "Who is this person, what are they known for, and how do they connect to this library?"
+        ),
+        "prompts": (
+            ("Role", "Use the summary and claims to understand this person's role in the library."),
+            ("Ideas", "Look for repeated concepts, claims, and source notes tied to this person."),
+            ("Connections", "Follow relations and backlinks to nearby people, projects, and concepts."),
+        ),
+        "section_labels": {
+            "current_state": "Profile",
+            "why_it_matters": "Why They Matter",
+            "evidence_traceability": "Sources About This Person",
+        },
+    },
+    "concept": {
+        "layout": "concept_brief",
+        "title": "Concept Brief",
+        "primary_question": "What does this idea mean, where is it used, and what supports it?",
+        "prompts": (
+            ("Definition", "Start with the compiled summary and strongest claims."),
+            ("Use", "Follow relations to see where the idea appears in the library."),
+            ("Evidence", "Check source notes and quoted evidence before reusing the concept."),
+        ),
+        "section_labels": {
+            "current_state": "Definition",
+            "why_it_matters": "Where It Matters",
+            "evidence_traceability": "Evidence For This Concept",
+        },
+    },
+    "company": {
+        "layout": "entity_brief",
+        "title": "Company Brief",
+        "primary_question": "What is this organization, why is it relevant, and what is it connected to?",
+        "prompts": (
+            ("Identity", "Start with what the company is and how it is described."),
+            ("Relevance", "Look for why it appears in this library."),
+            ("Connections", "Follow related tools, people, projects, and claims."),
+        ),
+        "section_labels": {
+            "current_state": "Company Snapshot",
+            "why_it_matters": "Why It Matters",
+            "evidence_traceability": "Sources About This Company",
+        },
+    },
+    "tool": {
+        "layout": "entity_brief",
+        "title": "Tool Brief",
+        "primary_question": "What does this tool do, when is it useful, and what is the evidence?",
+        "prompts": (
+            ("Use", "Start with the job this tool is used for."),
+            ("Fit", "Look for projects, workflows, or claims that explain when it matters."),
+            ("Evidence", "Check source notes before treating capabilities as facts."),
+        ),
+        "section_labels": {
+            "current_state": "Tool Snapshot",
+            "why_it_matters": "When It Matters",
+            "evidence_traceability": "Sources About This Tool",
+        },
+    },
+    "project": {
+        "layout": "entity_brief",
+        "title": "Project Brief",
+        "primary_question": "What is this project trying to do, what changed, and what evidence supports it?",
+        "prompts": (
+            ("Goal", "Start with the compiled goal or current state."),
+            ("Progress", "Look for events, claims, and production traces."),
+            ("Connections", "Follow related people, tools, and concepts."),
+        ),
+        "section_labels": {
+            "current_state": "Project Snapshot",
+            "why_it_matters": "Why It Matters",
+            "evidence_traceability": "Project Sources",
+        },
+    },
+    "event": {
+        "layout": "event_dossier",
+        "title": "Event Dossier",
+        "primary_question": "What happened, why does it matter, and what changed afterward?",
+        "prompts": (
+            ("What Happened", "Start with the compiled event summary."),
+            ("Impact", "Look for claims and relations that changed because of this event."),
+            ("Evidence", "Use source notes to verify timing and attribution."),
+        ),
+        "section_labels": {
+            "current_state": "What Happened",
+            "why_it_matters": "Impact",
+            "evidence_traceability": "Event Sources",
+        },
+    },
+    "claim": {
+        "layout": "claim_review",
+        "title": "Claim Review",
+        "primary_question": "What assertion is being made, how strong is the evidence, and can it be reused?",
+        "prompts": (
+            ("Assertion", "Read the claim in plain language first."),
+            ("Support", "Check evidence rows and source spans before trusting it."),
+            ("Risk", "Look for contradictions or stale summaries before reuse."),
+        ),
+        "section_labels": {
+            "current_state": "Claim",
+            "why_it_matters": "Confidence And Risk",
+            "evidence_traceability": "Evidence For This Claim",
+        },
+    },
+}
 _LIST_MARKER_RE = re.compile(r"^([-*•]|\d+\.)\s+")
 OBJECT_SOURCE_RAIL_RELATED_LIMIT = 8
 
@@ -170,6 +279,45 @@ def _object_reader_profile(detail: dict[str, Any], *, relation_count: int) -> di
             f"{source_note_count} source notes · {atlas_count} atlas pages"
         ),
         "empty_summary": not bool(summary_text),
+    }
+
+
+def _object_kind_profile(detail: dict[str, Any], *, relation_count: int) -> dict[str, object]:
+    object_row = detail["object"]
+    object_kind = str(object_row.get("object_kind") or "").strip().lower()
+    spec = _OBJECT_KIND_READER_PROFILES.get(object_kind)
+    if spec is None:
+        return {
+            "kind": object_kind or "object",
+            "layout": "object_brief",
+            "title": f"{_object_kind_label(object_kind)} Brief",
+            "primary_question": "What is this object, what supports it, and where should I read next?",
+            "reading_prompts": [
+                {
+                    "label": "Summary",
+                    "detail": "Start with the compiled summary and claims.",
+                },
+                {
+                    "label": "Evidence",
+                    "detail": "Check source notes and evidence rows before reuse.",
+                },
+                {
+                    "label": "Connections",
+                    "detail": f"Follow {relation_count} relation(s) and backlinks for surrounding context.",
+                },
+            ],
+            "section_labels": {},
+        }
+    return {
+        "kind": object_kind,
+        "layout": spec["layout"],
+        "title": spec["title"],
+        "primary_question": spec["primary_question"],
+        "reading_prompts": [
+            {"label": label, "detail": detail_text}
+            for label, detail_text in spec["prompts"]
+        ],
+        "section_labels": dict(spec["section_labels"]),
     }
 
 
@@ -1795,6 +1943,8 @@ def build_object_page_payload(
     )
     summary_text = detail["summary"]["summary_text"] if detail["summary"] else ""
     reader_profile = _object_reader_profile(detail, relation_count=len(relations))
+    kind_profile = _object_kind_profile(detail, relation_count=len(relations))
+    section_labels = kind_profile["section_labels"]
     source_backlink_rail = _build_source_backlink_rail(
         vault_dir,
         detail=detail,
@@ -1815,7 +1965,7 @@ def build_object_page_payload(
     compiled_sections = [
         _compiled_section(
             "current_state",
-            "Current State",
+            str(section_labels.get("current_state") or "Current State"),
             summary=summary_text or "No compiled summary yet.",
             items=[
                 {
@@ -1830,7 +1980,7 @@ def build_object_page_payload(
         ),
         _compiled_section(
             "why_it_matters",
-            "Why It Matters",
+            str(section_labels.get("why_it_matters") or "Why It Matters"),
             summary=f"{len(detail['contradictions']) if research_shell_enabled else 0} contradictions and {review_context.get('stale_summary_count', 0)} stale summaries shape current maintenance urgency.",
             items=[
                 {
@@ -1855,7 +2005,7 @@ def build_object_page_payload(
         ),
         _compiled_section(
             "evidence_traceability",
-            "Evidence Traceability",
+            str(section_labels.get("evidence_traceability") or "Evidence Traceability"),
             summary=f"{len(detail['evidence'])} evidence rows, {len(detail['provenance']['source_notes'])} source notes, {len(detail['provenance']['mocs'])} atlas pages.",
             items=[
                 {
@@ -2027,6 +2177,7 @@ def build_object_page_payload(
         "research_shell_enabled": research_shell_enabled,
         **detail,
         "reader_profile": reader_profile,
+        "kind_profile": kind_profile,
         "source_backlink_rail": source_backlink_rail,
         "production_chain": production_chain,
         "relations": relations,

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -3461,6 +3461,26 @@ Mentions [[alpha]] as a local-first execution pattern.
     assert "Beta" in body
 
 
+def test_render_object_page_surfaces_kind_specific_reader_lens(temp_vault):
+    import ovp_pipeline.commands.ui_server as ui_server
+    from ovp_pipeline.runtime import VaultLayout
+    from ovp_pipeline.ui.view_models import build_object_page_payload
+
+    _seed_truth_store(temp_vault)
+    db_path = VaultLayout.from_vault(temp_vault).knowledge_db
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("UPDATE objects SET object_kind = 'person' WHERE object_id = 'alpha'")
+        conn.commit()
+
+    body = ui_server._render_object_page(build_object_page_payload(temp_vault, "alpha"))
+
+    assert "<h2>Person Profile</h2>" in body
+    assert "Who is this person, what are they known for" in body
+    assert "<strong>Role</strong>" in body
+    assert "<h2>Profile</h2>" in body
+    assert "<h2>Why They Matter</h2>" in body
+
+
 def test_render_topic_page_hides_research_affordances_when_pack_lacks_research_semantics(
     temp_vault, monkeypatch
 ):

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -379,6 +379,35 @@ date: 2026-04-13
     assert payload["source_backlink_rail"]["related_objects"][0]["relation_type"] == "wikilink"
 
 
+def test_build_object_page_payload_adds_kind_specific_reader_lens(temp_vault):
+    from ovp_pipeline.runtime import VaultLayout
+    from ovp_pipeline.ui.view_models import build_object_page_payload
+
+    _seed_truth_store(temp_vault)
+    db_path = VaultLayout.from_vault(temp_vault).knowledge_db
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("UPDATE objects SET object_kind = 'person' WHERE object_id = 'alpha'")
+        conn.commit()
+
+    payload = build_object_page_payload(temp_vault, "alpha")
+
+    assert payload["kind_profile"]["layout"] == "person_profile"
+    assert payload["kind_profile"]["title"] == "Person Profile"
+    assert payload["kind_profile"]["primary_question"] == (
+        "Who is this person, what are they known for, and how do they connect to this library?"
+    )
+    assert [item["label"] for item in payload["kind_profile"]["reading_prompts"]] == [
+        "Role",
+        "Ideas",
+        "Connections",
+    ]
+    assert payload["kind_profile"]["section_labels"] == {
+        "current_state": "Profile",
+        "why_it_matters": "Why They Matter",
+        "evidence_traceability": "Sources About This Person",
+    }
+
+
 def test_build_object_page_payload_degrades_when_source_excerpt_is_not_utf8(temp_vault):
     from ovp_pipeline.ui.view_models import build_object_page_payload
 


### PR DESCRIPTION
## Summary
- add kind-specific reader lenses for person, concept, company, tool, project, event, and claim object pages
- render the lens on object pages and apply kind-specific section labels
- update backlog, milestone, README, architecture, and product-shape docs so BL-008 now points to BL-011 next

## Tests
- PYTHONPATH=src python -m pytest tests/test_ui_view_models.py tests/test_ui_server.py tests/test_ui_smoke.py tests/test_ui_hot_paths.py -q
- python -m ruff check src/ovp_pipeline/ui/view_models.py src/ovp_pipeline/commands/ui_server.py tests/test_ui_view_models.py tests/test_ui_server.py
- git diff --check
- PYTHONPATH=src python -m pytest -q
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/83" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Object pages now display kind-specific reader lenses tailored for different entity types (Person, concept, company, tool, project, event, claim), providing customized reading experiences.

* **Documentation**
  * Updated roadmap, architecture, and milestone documentation to reflect completion of kind-specific reader lenses and refocus upcoming development priorities on reader-oriented search capabilities grouped by kind, evidence, and reason.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->