### PR TITLE
feat: group search results for readers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -667,14 +667,14 @@ Main gaps:
 - Layer 4 fitness checks now cover the first hot-path, workflow-wiring, source routing preview, evidence span backfill, and candidate risk cases; deeper evidence completeness, projection replay, and import-boundary checks are still open.
 - Projection lifecycle markers need structured schema, scope, lease, and supersession.
 - Schema versioning is not yet wired into projection lifecycle.
-- The reader-first home is now the default entry; object pages have reader profiles, source rails, and kind-specific reader lenses; `/graph` has a first spatial map projection; search still needs product shape.
+- The reader-first home is now the default entry; object pages have reader profiles, source rails, and kind-specific reader lenses; `/graph` has a first spatial map projection; `/search` groups reader results by kind, summary, evidence count, and match reason.
 
 ## 18. Near-Term Architecture Actions
 
 Recommended order:
 
 1. Keep projection metadata attached to new access surfaces and add doctor/export checks that verify the labels are present.
-2. Continue reader-first Layer 3 product work on search using the new kind lenses, evidence spans, and risk tiers.
+2. Move to projection repair lifecycle and schema-version rebuild triggers now that the first reader-facing product loop is coherent.
 3. Add stricter factual evidence completeness checks before expanding automatic promotion.
 4. Introduce structured `ProjectionRepairMarker` schema.
 5. Add schema version fields to Authority and derived projection state.
@@ -692,5 +692,6 @@ The architecture should not depend on backlog IDs to be valid. The table below i
 | Evidence span / factual evidence completeness | `BL-006`, `KSR-001`, `KSR-018` done in PR #82 |
 | Candidate risk layering | `BL-007`, `KSR-003` done in PR #82 |
 | Reader-first access surfaces | `BL-001`; `BL-008` and `BL-009` done through PR #79 and PR #83; `BL-010` done in PR #80 |
+| Reader-oriented search | `BL-011` done in PR #84 |
 | Projection repair lifecycle | `BL-020` |
 | Schema versioning and migration trigger | `BL-021` |

--- a/ARCHITECTURE.zh-CN.md
+++ b/ARCHITECTURE.zh-CN.md
@@ -777,7 +777,7 @@ Do not rely on ad hoc "just rerun the pipeline" behavior for schema changes.
 - governance / resolver contracts 还需要显式化。
 - schema versioning 和 projection compatibility 还需要工程化。
 - fitness functions 只落地了第一批，仍需扩展到 CI/doctor/pre-commit 的完整契约。
-- reader-first home 已经成为默认入口；object page 已有 reader profile、source rail 和按 kind 区分的 reader lens；`/graph` 已有第一版 spatial map projection；search 还需要继续产品化。
+- reader-first home 已经成为默认入口；object page 已有 reader profile、source rail 和按 kind 区分的 reader lens；`/graph` 已有第一版 spatial map projection；`/search` 已按 kind、summary、evidence count、match reason 组织 reader results。
 
 ## 17. 近期架构动作
 
@@ -786,7 +786,7 @@ Do not rely on ad hoc "just rerun the pipeline" behavior for schema changes.
 优先顺序：
 
 1. 新增 access surface 时必须继续带 projection metadata，并补 doctor/export checks 验证标注存在。
-2. 继续做 reader-first Layer 3：用新的 kind lens、evidence span、risk tier 推进 search。
+2. 第一版 reader-facing product loop 已经成形，下一步转向 projection repair lifecycle 和 schema-version rebuild trigger。
 3. 在扩大自动 promotion 前，补更严格的 factual evidence completeness checks。
 4. 引入结构化 ProjectionRepairMarker。
 5. 给 Authority 和 derived projection state 增加 schema version 字段。
@@ -806,6 +806,7 @@ Do not rely on ad hoc "just rerun the pipeline" behavior for schema changes.
 | Evidence span / factual evidence completeness | `BL-006`, `KSR-001`, `KSR-018` 已在 PR #82 交付 |
 | Candidate risk layering | `BL-007`, `KSR-003` 已在 PR #82 交付 |
 | Reader-first access surfaces | `BL-001`；`BL-008`、`BL-009` 已通过 PR #79 和 PR #83 交付；`BL-010` 已在 PR #80 交付 |
+| Reader-oriented search | `BL-011` 已在 PR #84 交付 |
 | Projection repair lifecycle | `BL-020` |
 | Schema versioning and migration trigger | `BL-021` |
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -21,7 +21,7 @@ Rule: historical plans and vault research notes feed this file; they do not over
 | M0 Pipeline And Pack Foundation | Done | CLI, source lifecycle, pack/profile runtime, `knowledge.db`, first source-lifecycle idempotency slice |
 | M1 Operator Workbench And Review Runtime | Done / maintain | truth UI, candidates, signals/actions, contradictions, action worker |
 | M2 Roadmap And README Consolidation | Done | merged historical milestones, compiler roadmap, recent KSR input, reader-product research, and English-primary docs |
-| M3 Reader-First Knowledge Atlas | Active | reader home, `/ops` split, object source/backlink rail, visual graph map, and kind-specific object reader lenses shipped; reader search remains |
+| M3 Reader-First Knowledge Atlas | Done / iterate | reader home, `/ops` split, object source/backlink rail, visual graph map, kind-specific object reader lenses, and reader-oriented search shipped |
 | M4 KSR Safety And Hot-Path Hardening | Active | projection labels, hot-path audit, wiring evals, article routing preview, evidence spans, and candidate risk shipped; deeper enforcement remains |
 | M5 Context Pack And Operational Runtime | Later | session snapshots, context budget, claim leases, provider facade, observability |
 | M6 Policy, Permission, And Knowledge Evolution | Later | permission layer, claim lifecycle, conflict detection, policy promotion |
@@ -42,7 +42,7 @@ Rule: historical plans and vault research notes feed this file; they do not over
 | BL-008 | P1 | Done | Kind-aware object pages for people, concepts, companies/tools/projects, events, and claims, with reader profiles, source/backlink rails, kind-specific lenses, and section labels | M3, PR #79, PR #83 |
 | BL-009 | P1 | Done | Mention/backlink rail with excerpts, source jumps, and relation context | M3, reader-product note, PR #79 |
 | BL-010 | P1 | Done | Visual `/graph` MVP as a spatial corpus map; analytical clusters remain under `/clusters` for ops/debug | M3, PR #80 |
-| BL-011 | P1 | Later | Reader-oriented search grouped by kind, summary, evidence, and reason | M3/M4 |
+| BL-011 | P1 | Done | Reader-oriented search grouped by kind, summary, evidence, and reason | M3/M4, PR #84 |
 | BL-012 | P1 | Later | Trusted reuse event instrumentation for downstream use of accepted/cited knowledge | April 22 roadmap |
 | BL-013 | P1 | Later | Session snapshot / OVP context pack / explicit context budget | M5, KSR-004, KSR-017, KSR-022 |
 | BL-014 | P1 | Later | Operational runtime graph, claim lease, observability metrics, provider facade | M5, KSR-020, KSR-021, KSR-023, KSR-025 |
@@ -90,12 +90,12 @@ Rule: historical plans and vault research notes feed this file; they do not over
 
 ## Next Decision
 
-`BL-001` is shipped in PR #75, `BL-003 + BL-004` are shipped in PR #77, `BL-002` is shipped in PR #78, `BL-009` plus the first `BL-008` slice are shipped in PR #79, `BL-010` is shipped in PR #80, `BL-005` is shipped in PR #81, and `BL-006 + BL-007` are implemented in PR #82. The default UI now has a reader-first entry point, `/ops` owns the operator dashboard, core access/materialized surfaces carry explicit projection labels, object pages expose readable source/backlink rails and kind-specific reader lenses, `/graph` renders a reader-facing spatial map over graph projections, `ovp-absorb --dry-run --json` explains source lifecycle routing before mutation, evidence rows carry line/char spans, and candidate review payloads expose risk tiers.
+`BL-001` is shipped in PR #75, `BL-003 + BL-004` are shipped in PR #77, `BL-002` is shipped in PR #78, `BL-009` plus the first `BL-008` slice are shipped in PR #79, `BL-010` is shipped in PR #80, `BL-005` is shipped in PR #81, `BL-006 + BL-007` are implemented in PR #82, `BL-008` is completed in PR #83, and `BL-011` is completed in PR #84. The default UI now has a reader-first entry point, `/ops` owns the operator dashboard, core access/materialized surfaces carry explicit projection labels, object pages expose readable source/backlink rails and kind-specific reader lenses, `/graph` renders a reader-facing spatial map over graph projections, `/search` groups reader results by kind with summaries, evidence counts, and match reasons, `ovp-absorb --dry-run --json` explains source lifecycle routing before mutation, evidence rows carry line/char spans, and candidate review payloads expose risk tiers.
 
-The next implementation PR should continue the reader product lane with **BL-011** reader-oriented search grouped by kind, summary, evidence, and reason. M4 still has deeper enforcement work, but the P0 risk reducers needed before richer reader surfaces are now in place.
+The next implementation PR should move from reader product shape back into operational hardening: **BL-020 / BL-021** projection repair lifecycle and schema-version rebuild triggers. The first reader-facing product loop is now coherent enough to support that reliability work.
 
 Recommended order:
 
-1. BL-011 reader-oriented search
-2. BL-020 / BL-021 when projection repair and schema migration become the next operational bottleneck
-3. BL-012 / BL-013 once the reader surfaces need stronger reuse/context-pack loops
+1. BL-020 / BL-021 projection repair lifecycle and schema migration triggers
+2. BL-012 / BL-013 trusted reuse events and context-pack loops
+3. BL-014 when operational runtime observability becomes the next bottleneck

--- a/MILESTONE.md
+++ b/MILESTONE.md
@@ -33,7 +33,7 @@ That means the user-facing product should make compiled knowledge easy to read f
 | M0 Pipeline And Pack Foundation | Done | CLI, source lifecycle, pack/profile runtime, `knowledge.db`, first source-lifecycle idempotency slice |
 | M1 Operator Workbench And Review Runtime | Done / maintain | truth UI, candidates, signals/actions, contradictions, action worker |
 | M2 Roadmap And README Consolidation | Done | merged historical milestones, compiler roadmap, recent KSR input, reader-product research, and the English-primary docs structure |
-| M3 Reader-First Knowledge Atlas | Active | reader home, `/ops` split, object source/backlink rail, visual graph map, and kind-specific object reader lenses shipped; reader search remains |
+| M3 Reader-First Knowledge Atlas | Done / iterate | reader home, `/ops` split, object source/backlink rail, visual graph map, kind-specific object reader lenses, and reader-oriented search shipped |
 | M4 KSR Safety And Hot-Path Hardening | Active | projection labels, hot-path audit, wiring evals, article routing preview, evidence spans, and candidate risk shipped; deeper enforcement remains |
 | M5 Context Pack And Operational Runtime | Later | session snapshots, context budget, claim leases, provider facade, observability |
 | M6 Policy, Permission, And Knowledge Evolution | Later | permission layer, claim lifecycle, conflict detection, policy promotion |
@@ -52,6 +52,7 @@ That means the user-facing product should make compiled knowledge easy to read f
 | Candidate risk layering | `BL-007`, `KSR-003` done in PR #82 |
 | Kind-aware object pages and backlink rail | `BL-008` and `BL-009` done through PR #79 and PR #83 |
 | Visual graph MVP | `BL-010` done in PR #80 |
+| Reader-oriented search | `BL-011` done in PR #84 |
 | Projection repair lifecycle | `BL-020` |
 | Schema versioning and migration trigger | `BL-021` |
 
@@ -59,9 +60,9 @@ That means the user-facing product should make compiled knowledge easy to read f
 
 Recommended order:
 
-1. Implement `BL-011`: reader-oriented search grouped by kind, summary, evidence, and reason.
-2. Return to `BL-020 + BL-021` when projection repair and schema migration need operational hardening.
-3. Move into `BL-012 + BL-013` once the reader surfaces need stronger reuse and context-pack loops.
+1. Return to `BL-020 + BL-021` for projection repair and schema-migration rebuild triggers.
+2. Move into `BL-012 + BL-013` once the reader surfaces need stronger reuse and context-pack loops.
+3. Pick up `BL-014` when operational runtime observability becomes the next bottleneck.
 
 ## Documentation Rules
 

--- a/MILESTONE.zh-CN.md
+++ b/MILESTONE.zh-CN.md
@@ -33,7 +33,7 @@ OVP 正在从 document-processing pipeline 变成：
 | M0 Pipeline And Pack Foundation | Done | CLI、source lifecycle、pack/profile runtime、`knowledge.db`、第一段 source-lifecycle idempotency |
 | M1 Operator Workbench And Review Runtime | Done / maintain | truth UI、candidates、signals/actions、contradictions、action worker |
 | M2 Roadmap And README Consolidation | Done | 已合并历史 milestones、compiler roadmap、近期 KSR 输入、reader-product 研究，以及英文主文档结构 |
-| M3 Reader-First Knowledge Atlas | Active | reader home、`/ops` 拆分、object source/backlink rail、visual graph map、按 kind 区分的 object reader lens 已交付；reader search 仍待推进 |
+| M3 Reader-First Knowledge Atlas | Done / iterate | reader home、`/ops` 拆分、object source/backlink rail、visual graph map、按 kind 区分的 object reader lens、reader-oriented search 已交付 |
 | M4 KSR Safety And Hot-Path Hardening | Active | projection labels、hot-path audit、wiring evals、article routing preview、evidence spans、candidate risk 已交付；更深的 enforcement 仍待推进 |
 | M5 Context Pack And Operational Runtime | Later | session snapshots、context budget、claim leases、provider facade、observability |
 | M6 Policy, Permission, And Knowledge Evolution | Later | permission layer、claim lifecycle、conflict detection、policy promotion |
@@ -52,6 +52,7 @@ OVP 正在从 document-processing pipeline 变成：
 | Candidate risk layering | `BL-007`, `KSR-003` 已在 PR #82 交付 |
 | Kind-aware object pages and backlink rail | `BL-008`、`BL-009` 已通过 PR #79 和 PR #83 交付 |
 | Visual graph MVP | `BL-010` 已在 PR #80 交付 |
+| Reader-oriented search | `BL-011` 已在 PR #84 交付 |
 | Projection repair lifecycle | `BL-020` |
 | Schema versioning and migration trigger | `BL-021` |
 
@@ -59,9 +60,9 @@ OVP 正在从 document-processing pipeline 变成：
 
 建议顺序：
 
-1. 实施 `BL-011`：按 kind、summary、evidence、reason 重做 reader-oriented search。
-2. 当 projection repair 和 schema migration 成为运营瓶颈时，回到 `BL-020 + BL-021`。
-3. 当 reader surface 需要更强的复用和 context-pack 闭环时，再进入 `BL-012 + BL-013`。
+1. 回到 `BL-020 + BL-021`：projection repair lifecycle 和 schema migration rebuild trigger。
+2. 当 reader surface 需要更强的复用和 context-pack 闭环时，再进入 `BL-012 + BL-013`。
+3. 当 operational runtime observability 成为下一个瓶颈时，再进入 `BL-014`。
 
 ## 文档规则
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Current milestone sequence:
 | M0 Pipeline And Pack Foundation | Complete | CLI, source lifecycle, pack/profile runtime, `knowledge.db`, first KSR-013 slice |
 | M1 Operator Workbench And Review Runtime | Complete enough | truth UI, candidates, signals/actions, contradictions, action worker |
 | M2 Roadmap And README Consolidation | Complete | merged historical milestones, compiler roadmap, recent KSR input, and reader-product research |
-| M3 Reader-First Knowledge Atlas | Active | reader home, `/ops` split, object source/backlink rail, visual graph map, and kind-specific object reader lenses shipped; reader search remains |
+| M3 Reader-First Knowledge Atlas | Done / iterate | reader home, `/ops` split, object source/backlink rail, visual graph map, kind-specific object reader lenses, and reader-oriented search shipped |
 | M4 KSR Safety And Hot-Path Hardening | Active | projection labels, hot-path audit, wiring evals, article routing preview, evidence spans, and candidate risk tiers have shipped; deeper enforcement remains |
 | M5 Context Pack And Operational Runtime | Later | session snapshots, context budget, claim leases, provider facades, observability |
 | M6 Policy, Permission, And Knowledge Evolution | Later | permission layer, claim lifecycle, conflict detection, policy promotion |
@@ -103,8 +103,8 @@ Current milestone sequence:
 Current active backlog focus:
 
 - Shipped: `KSR-001` evidence spans, `KSR-002` projection labels, `KSR-003` candidate risk tiers, `KSR-014` article routing preview, `KSR-015` dashboard/search hot-path audit, `KSR-018` markdown-aware evidence span backfill, `KSR-026` workflow wiring eval suite.
-- Product shipped: readable object page profiles, source/backlink rail, kind-specific reader lenses, and visual `/graph` map.
-- Next: reader-oriented search grouped by kind, evidence, and reason.
+- Product shipped: readable object page profiles, source/backlink rail, kind-specific reader lenses, visual `/graph` map, and reader-oriented search grouped by kind, evidence, and reason.
+- Next: projection repair lifecycle and schema-version rebuild triggers.
 - Product track: reader-first Knowledge Atlas stays a projection layer, not a new state system.
 
 ## Domain Packs

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -92,7 +92,7 @@ Obsidian Vault Pipeline（OVP）不是一个“多脚本拼装包”，也不只
 | M0 Pipeline And Pack Foundation | Complete | CLI、source lifecycle、pack/profile、`knowledge.db`、KSR-013 第一版 |
 | M1 Operator Workbench And Review Runtime | Complete enough | truth UI、candidates、signals/actions、contradictions、action worker |
 | M2 Roadmap And README Consolidation | Complete | 已合并历史 milestone、compiler roadmap、近期 KSR 输入与 reader-product 研究，重整 README |
-| M3 Reader-First Knowledge Atlas | Active | reader home、`/ops` 拆分、object source/backlink rail、visual graph map、按 kind 区分的 object reader lens 已交付；reader search 仍需推进 |
+| M3 Reader-First Knowledge Atlas | Done / iterate | reader home、`/ops` 拆分、object source/backlink rail、visual graph map、按 kind 区分的 object reader lens、reader-oriented search 已交付 |
 | M4 KSR Safety And Hot-Path Hardening | Active | projection 标注、hot-path audit、wiring eval、article routing preview、evidence span、candidate 风险分层已交付；更深的 enforcement 仍待推进 |
 | M5 Context Pack And Operational Runtime | Later | session snapshot、context budget、claim lease、provider facade、observability |
 | M6 Policy, Permission, And Knowledge Evolution | Later | permission layer、claim lifecycle、conflict detection、policy promotion |
@@ -101,8 +101,8 @@ Obsidian Vault Pipeline（OVP）不是一个“多脚本拼装包”，也不只
 当前 active backlog 重点：
 
 - 已交付：`KSR-001` Evidence span 化、`KSR-002` Projection 标注、`KSR-003` Candidate 风险分层、`KSR-014` Article routing preview、`KSR-015` Dashboard/search hot-path audit、`KSR-018` Markdown-aware evidence span backfill、`KSR-026` Workflow wiring eval suite。
-- 产品侧已交付：readable object page profile、source/backlink rail、按 kind 区分的 reader lens 和 visual `/graph` map。
-- 下一步：做按 kind、evidence、reason 组织的 reader-oriented search。
+- 产品侧已交付：readable object page profile、source/backlink rail、按 kind 区分的 reader lens、visual `/graph` map，以及按 kind、evidence、reason 组织的 reader-oriented search。
+- 下一步：projection repair lifecycle 和 schema-version rebuild trigger。
 - 产品线：Reader-first Knowledge Atlas 作为 projection layer 实现，不另建状态系统。
 
 ## Domain Packs

--- a/docs/plans/2026-04-29-consolidated-product-roadmap.md
+++ b/docs/plans/2026-04-29-consolidated-product-roadmap.md
@@ -316,3 +316,4 @@ The better sequence is likely:
 2. hot-path/wiring evals
 3. kind-aware object pages, reader lenses, and backlink rail
 4. visual graph MVP
+5. reader-oriented search grouped by kind, summary, evidence, and reason

--- a/docs/plans/2026-04-29-reader-product-shape-and-backlog-reconciliation.md
+++ b/docs/plans/2026-04-29-reader-product-shape-and-backlog-reconciliation.md
@@ -280,7 +280,7 @@ Scope:
 | Kind-aware object pages | P0 | shipped first reader-lens slice | Turns extraction objects into user-readable pages |
 | Mention/backlink rail | P1 | shipped | Direct LearnBuffett lesson; evidence-backed reading context |
 | Visual `/graph` map | P1 | shipped first MVP | Use current graph data; no new backend |
-| Reader-oriented search | P1 | next | Depends on object summaries and evidence counts |
+| Reader-oriented search | P1 | shipped | Results group by object kind and source kind with summaries, evidence counts, and match reasons |
 | Trusted reuse loop | P1 | keep | Still core north-star measurement |
 | Evidence v2 | P1 | keep | Still needed for long-term trust |
 | Policy promotion | P2 | keep | Important, but after product entry is understandable |

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -1222,21 +1222,58 @@ def _render_search_page(payload: dict) -> str:
             f"&middot; {prev_link} &middot; {next_link}</p>"
         )
 
-    object_items = (
-        "".join(
-            f'<li><a href="{escape(item.get("object_path") or _object_href(item["object_id"], requested_pack=requested_pack))}">{escape(item["title"])}</a> '
-            f'<span class="muted">({escape(item["object_id"])})</span></li>'
-            for item in payload["objects"]
+    def _render_reader_group(group: dict) -> str:
+        items = group.get("items") or []
+        item_html = (
+            "".join(
+                "<li>"
+                f'<a href="{escape(item.get("object_path") or _object_href(item["object_id"], requested_pack=requested_pack))}">{escape(str(item["title"]))}</a>'
+                f"<p>{escape(str(item.get('summary') or 'No compiled summary yet.'))}</p>"
+                f"<p class='muted'>{escape(str(item.get('reason') or 'Matched object text.'))} "
+                f"Evidence: {int(item.get('evidence_count') or 0)}</p>"
+                "</li>"
+                for item in items
+            )
+            or "<li class='muted'>No object hits.</li>"
         )
-        or "<li class='muted'>No object hits.</li>"
+        return (
+            "<section class='card'>"
+            f"<h2>{escape(str(group.get('label') or 'Objects'))}</h2>"
+            f"<p class='muted'>{int(group.get('result_count') or 0)} result(s)</p>"
+            f"<ul class='list-tight'>{item_html}</ul>"
+            "</section>"
+        )
+
+    def _render_source_group(group: dict) -> str:
+        items = group.get("items") or []
+        item_html = (
+            "".join(
+                "<li>"
+                f'<a href="{escape(item.get("note_path") or _note_href(item["path"], requested_pack))}">{escape(str(item["title"]))}</a> '
+                f'<span class="pill">{escape(str(item["note_type"]))}</span>'
+                f"<p class='muted'>{escape(str(item.get('reason') or 'Matched note title or body.'))}</p>"
+                "</li>"
+                for item in items
+            )
+            or "<li class='muted'>No note hits.</li>"
+        )
+        return (
+            "<section class='card'>"
+            f"<h2>{escape(str(group.get('label') or 'Notes'))}</h2>"
+            f"<p class='muted'>{int(group.get('result_count') or 0)} result(s)</p>"
+            f"<ul class='list-tight'>{item_html}</ul>"
+            "</section>"
+        )
+
+    reader_groups = payload.get("reader_groups") or []
+    source_groups = payload.get("source_groups") or []
+    reader_group_html = (
+        "".join(_render_reader_group(group) for group in reader_groups)
+        or "<section class='card'><h2>Objects</h2><p class='muted'>No object hits.</p></section>"
     )
-    note_items = (
-        "".join(
-            f'<li><a href="{escape(item.get("note_path") or _note_href(item["path"], requested_pack))}">{escape(item["title"])}</a> '
-            f'<span class="pill">{escape(item["note_type"])}</span></li>'
-            for item in payload["notes"]
-        )
-        or "<li class='muted'>No note hits.</li>"
+    source_group_html = (
+        "".join(_render_source_group(group) for group in source_groups)
+        or "<section class='card'><h2>Notes</h2><p class='muted'>No note hits.</p></section>"
     )
     showing = (
         f"Showing {payload['object_count']} of {object_total} object hits, "
@@ -1246,7 +1283,7 @@ def _render_search_page(payload: dict) -> str:
         f"Search: {query}",
         "".join(
             [
-                "<h1>Search</h1>",
+                "<h1>Reader Search</h1>",
                 "<form method='get' action='/search'>",
                 (
                     f"<input type='hidden' name='pack' value='{escape(requested_pack)}' /> "
@@ -1256,18 +1293,11 @@ def _render_search_page(payload: dict) -> str:
                 f"<input type='text' name='q' value='{escape(query)}' placeholder='Search vault' /> ",
                 "<button type='submit'>Search</button>",
                 "</form>",
-                f"<p class='muted'>{escape(showing)}</p>",
+                f"<p class='muted'>{escape(str(payload.get('reader_summary') or showing))}</p>",
+                "<p class='muted'>Objects are grouped by kind. Notes are grouped by source type.</p>",
                 "<section class='grid two-col'>",
-                "<section class='card'>"
-                f"<h2>Objects</h2>"
-                f"<ul class='list-tight'>{object_items}</ul>"
-                f"{_pager(object_total, 'Objects')}"
-                "</section>",
-                "<section class='card'>"
-                f"<h2>Notes</h2>"
-                f"<ul class='list-tight'>{note_items}</ul>"
-                f"{_pager(note_total, 'Notes')}"
-                "</section>",
+                f"<div class='section-stack'>{reader_group_html}{_pager(object_total, 'Objects')}</div>",
+                f"<div class='section-stack'>{source_group_html}{_pager(note_total, 'Notes')}</div>",
                 "</section>",
             ]
         ),

--- a/src/ovp_pipeline/ui/view_models.py
+++ b/src/ovp_pipeline/ui/view_models.py
@@ -964,6 +964,168 @@ def _build_related_cluster_groups(related_clusters: list[dict[str, Any]]) -> lis
     )
 
 
+def _plural_reader_label(label: str) -> str:
+    if label.endswith("y"):
+        return f"{label[:-1]}ies"
+    if label.endswith("s"):
+        return label
+    return f"{label}s"
+
+
+def _search_match_reason(
+    *,
+    query: str,
+    title: str,
+    summary: str,
+    evidence_count: int,
+) -> str:
+    normalized_query = query.strip().lower()
+    title_match = bool(normalized_query and normalized_query in title.lower())
+    summary_match = bool(normalized_query and normalized_query in summary.lower())
+    if title_match and summary_match and evidence_count > 0:
+        return "Matched title, summary, and evidence-backed claims."
+    if title_match and evidence_count > 0:
+        return "Matched title and evidence-backed claims."
+    if summary_match and evidence_count > 0:
+        return "Matched summary and evidence-backed claims."
+    if title_match:
+        return "Matched title."
+    if summary_match:
+        return "Matched summary."
+    if evidence_count > 0:
+        return "Matched evidence-backed claims."
+    return "Matched object text."
+
+
+def _search_note_type_label(note_type: str) -> str:
+    normalized = (note_type or "note").replace("_", " ").strip().title()
+    if not normalized:
+        normalized = "Note"
+    if normalized.endswith("Note") or normalized.endswith("Notes"):
+        return _plural_reader_label(normalized)
+    return f"{normalized} Notes"
+
+
+def _reader_summary(
+    reader_groups: list[dict[str, Any]],
+    source_groups: list[dict[str, Any]],
+) -> str:
+    object_parts = [
+        f"{group['result_count']} {str(group['kind']).replace('_', ' ')}"
+        + ("" if int(group["result_count"]) == 1 else "s")
+        for group in reader_groups
+    ]
+    note_count = sum(int(group["result_count"]) for group in source_groups)
+    if note_count:
+        object_parts.append(f"{note_count} note" + ("" if note_count == 1 else "s"))
+    return ", ".join(object_parts) if object_parts else "No reader results"
+
+
+def _build_reader_search_projection(
+    vault_dir: Path | str,
+    *,
+    query: str,
+    objects: list[dict[str, Any]],
+    notes: list[dict[str, Any]],
+) -> dict[str, Any]:
+    object_ids = [str(item["object_id"]) for item in objects]
+    row_packs = sorted({str(item.get("row_pack") or item.get("pack") or "") for item in objects})
+    summary_by_object: dict[tuple[str, str], str] = {}
+    evidence_count_by_object: dict[tuple[str, str], int] = {}
+    if object_ids:
+        db_path = _db_path(vault_dir)
+        object_placeholders = ",".join("?" for _ in object_ids)
+        pack_placeholders = ",".join("?" for _ in row_packs)
+        with sqlite3.connect(db_path) as conn:
+            summary_by_object = {
+                (str(object_id), str(pack)): str(summary_text or "")
+                for object_id, pack, summary_text in conn.execute(
+                    f"""
+                    SELECT object_id, pack, summary_text
+                    FROM compiled_summaries
+                    WHERE object_id IN ({object_placeholders})
+                      AND pack IN ({pack_placeholders})
+                    """,
+                    (*object_ids, *row_packs),
+                ).fetchall()
+            }
+            evidence_count_by_object = {
+                (str(object_id), str(pack)): int(count)
+                for object_id, pack, count in conn.execute(
+                    f"""
+                    SELECT claims.object_id, claims.pack, COUNT(claim_evidence.claim_id)
+                    FROM claims
+                    LEFT JOIN claim_evidence
+                      ON claim_evidence.pack = claims.pack
+                     AND claim_evidence.claim_id = claims.claim_id
+                    WHERE claims.object_id IN ({object_placeholders})
+                      AND claims.pack IN ({pack_placeholders})
+                    GROUP BY claims.object_id, claims.pack
+                    """,
+                    (*object_ids, *row_packs),
+                ).fetchall()
+            }
+
+    grouped_objects: dict[str, dict[str, Any]] = {}
+    for item in objects:
+        object_kind = str(item.get("object_kind") or "object").strip().lower() or "object"
+        group = grouped_objects.setdefault(
+            object_kind,
+            {
+                "kind": object_kind,
+                "label": _plural_reader_label(_object_kind_label(object_kind)),
+                "items": [],
+                "result_count": 0,
+            },
+        )
+        object_id = str(item["object_id"])
+        row_pack = str(item.get("row_pack") or item.get("pack") or "")
+        summary = summary_by_object.get((object_id, row_pack), "")
+        evidence_count = evidence_count_by_object.get((object_id, row_pack), 0)
+        group["items"].append(
+            {
+                **item,
+                "summary": summary or "No compiled summary yet.",
+                "evidence_count": evidence_count,
+                "reason": _search_match_reason(
+                    query=query,
+                    title=str(item.get("title") or ""),
+                    summary=summary,
+                    evidence_count=evidence_count,
+                ),
+            }
+        )
+        group["result_count"] += 1
+
+    source_groups_by_type: dict[str, dict[str, Any]] = {}
+    for item in notes:
+        note_type = str(item.get("note_type") or "note").strip().lower() or "note"
+        group = source_groups_by_type.setdefault(
+            note_type,
+            {
+                "kind": note_type,
+                "label": _search_note_type_label(note_type),
+                "items": [],
+                "result_count": 0,
+            },
+        )
+        group["items"].append(
+            {
+                **item,
+                "reason": "Matched note title or body.",
+            }
+        )
+        group["result_count"] += 1
+
+    reader_groups = list(grouped_objects.values())
+    source_groups = list(source_groups_by_type.values())
+    return {
+        "reader_groups": reader_groups,
+        "source_groups": source_groups,
+        "reader_summary": _reader_summary(reader_groups, source_groups),
+    }
+
+
 def _build_reading_routes(related_clusters: list[dict[str, Any]]) -> list[dict[str, Any]]:
     route_specs = [
         (
@@ -4278,6 +4440,32 @@ def build_search_payload(
         object_offset=offset,
         note_offset=offset,
     )
+    objects = [
+        {
+            **item,
+            "object_path": _scoped_path(
+                f"/object?id={quote(str(item['object_id']), safe='')}",
+                pack_name=requested_pack,
+            ),
+        }
+        for item in results["objects"]
+    ]
+    notes = [
+        {
+            **item,
+            "note_path": _scoped_path(
+                f"/note?path={quote(str(item['path']), safe='')}",
+                pack_name=requested_pack,
+            ),
+        }
+        for item in results["notes"]
+    ]
+    reader_projection = _build_reader_search_projection(
+        vault_dir,
+        query=query,
+        objects=objects,
+        notes=notes,
+    )
     return {
         "screen": "search/results",
         "requested_pack": requested_pack,
@@ -4288,26 +4476,9 @@ def build_search_payload(
             derived_from=("knowledge.db.objects", "knowledge.db.pages_index"),
         ),
         **results,
-        "objects": [
-            {
-                **item,
-                "object_path": _scoped_path(
-                    f"/object?id={quote(str(item['object_id']), safe='')}",
-                    pack_name=requested_pack,
-                ),
-            }
-            for item in results["objects"]
-        ],
-        "notes": [
-            {
-                **item,
-                "note_path": _scoped_path(
-                    f"/note?path={quote(str(item['path']), safe='')}",
-                    pack_name=requested_pack,
-                ),
-            }
-            for item in results["notes"]
-        ],
+        "objects": objects,
+        "notes": notes,
+        **reader_projection,
         "object_count": len(results["objects"]),
         "note_count": len(results["notes"]),
         "page": page,

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -694,6 +694,38 @@ def test_ui_server_search_page_preserves_pack_scope_in_shell_nav(temp_vault):
     assert 'href="/object?id=alpha&amp;pack=default-knowledge"' in body
 
 
+def test_ui_server_search_page_renders_reader_grouped_results(temp_vault):
+    from ovp_pipeline.commands.ui_server import create_server
+    from ovp_pipeline.runtime import VaultLayout
+
+    _seed_truth_store(temp_vault)
+    db_path = VaultLayout.from_vault(temp_vault).knowledge_db
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("UPDATE objects SET object_kind = 'concept' WHERE object_id = 'alpha'")
+        conn.commit()
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("GET", "/search?q=alpha")
+        response = conn.getresponse()
+        body = response.read().decode("utf-8")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 200
+    assert "<h1>Reader Search</h1>" in body
+    assert "<h2>Concepts</h2>" in body
+    assert "Alpha supports local-first execution." in body
+    assert "Matched title, summary, and evidence-backed claims." in body
+    assert "Evidence: 1" in body
+    assert "<h2>Evergreen Notes</h2>" in body
+
+
 def test_ui_server_object_endpoint_returns_detail_payload(temp_vault):
     from ovp_pipeline.commands.ui_server import create_server
 

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -408,6 +408,34 @@ def test_build_object_page_payload_adds_kind_specific_reader_lens(temp_vault):
     }
 
 
+def test_build_search_payload_groups_results_for_readers(temp_vault):
+    from ovp_pipeline.runtime import VaultLayout
+    from ovp_pipeline.ui.view_models import build_search_payload
+
+    _seed_truth_store(temp_vault)
+    db_path = VaultLayout.from_vault(temp_vault).knowledge_db
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("UPDATE objects SET object_kind = 'concept' WHERE object_id = 'alpha'")
+        conn.commit()
+
+    payload = build_search_payload(temp_vault, query="alpha")
+
+    assert payload["screen"] == "search/results"
+    assert payload["reader_summary"] == "1 concept, 2 evergreens, 3 notes"
+    assert payload["reader_groups"][0]["kind"] == "concept"
+    assert payload["reader_groups"][0]["label"] == "Concepts"
+    assert payload["reader_groups"][0]["items"][0]["title"] == "Alpha"
+    assert payload["reader_groups"][0]["items"][0]["summary"] == (
+        "Alpha supports local-first execution."
+    )
+    assert payload["reader_groups"][0]["items"][0]["evidence_count"] == 1
+    assert payload["reader_groups"][0]["items"][0]["reason"] == (
+        "Matched title, summary, and evidence-backed claims."
+    )
+    assert {group["label"] for group in payload["source_groups"]} >= {"Evergreen Notes"}
+    assert payload["source_groups"][0]["items"][0]["reason"] == "Matched note title or body."
+
+
 def test_build_object_page_payload_degrades_when_source_excerpt_is_not_utf8(temp_vault):
     from ovp_pipeline.ui.view_models import build_object_page_payload
 


### PR DESCRIPTION
## Summary
- add reader-oriented search groups for object results by kind, with summaries, evidence counts, and match reasons
- group source/note hits by source type and render search as Reader Search while preserving existing API fields
- keep enrichment scoped to materialized knowledge.db rows and update BL-011 docs/milestones

## Tests
- PYTHONPATH=src python -m pytest tests/test_ui_view_models.py tests/test_ui_server.py tests/test_ui_smoke.py tests/test_ui_hot_paths.py tests/test_truth_api.py -q -k "search or hot_path"
- python -m ruff check src/ovp_pipeline/ui/view_models.py src/ovp_pipeline/commands/ui_server.py tests/test_ui_view_models.py tests/test_ui_server.py
- git diff --check
- PYTHONPATH=src python -m pytest -q