### PR TITLE
[codex] Unify single-source lifecycle handling

### DIFF
--- a/src/ovp_pipeline/auto_article_processor.py
+++ b/src/ovp_pipeline/auto_article_processor.py
@@ -69,6 +69,19 @@ except ImportError:  # pragma: no cover - script mode fallback
     from markdown_generation import sanitize_generated_markdown
 
 try:
+    from .source_lifecycle import (
+        archive_pinboard_source,
+        is_under as lifecycle_is_under,
+        unique_child as lifecycle_unique_child,
+    )
+except ImportError:  # pragma: no cover - script mode fallback
+    from source_lifecycle import (  # type: ignore
+        archive_pinboard_source,
+        is_under as lifecycle_is_under,
+        unique_child as lifecycle_unique_child,
+    )
+
+try:
     from .txn import (
         build_transaction_payload,
         heartbeat_transaction,
@@ -560,6 +573,124 @@ class AutoArticleProcessor:
             "archived": str(archived),
         })
         return archived
+
+    @staticmethod
+    def _is_under(path: Path, parent: Path) -> bool:
+        return lifecycle_is_under(path, parent)
+
+    @staticmethod
+    def _unique_child(directory: Path, name: str) -> Path:
+        return lifecycle_unique_child(directory, name)
+
+    def _source_lifecycle_zone(self, source: Path) -> str:
+        if self._is_under(source, self.layout.clippings_dir):
+            return "clippings"
+        if self._is_under(source, self.layout.pinboard_dir):
+            return "pinboard"
+        if self._is_under(source, self.raw_dir):
+            return "raw"
+        if self._is_under(source, self.processing_dir):
+            return "processing"
+        if self._is_under(source, self.processed_dir):
+            return "processed"
+        return "outside_source_lifecycle"
+
+    def _move_clipping_to_raw(self, source: Path) -> Path:
+        try:
+            from .clippings_processor import ClippingsProcessor
+        except ImportError:  # pragma: no cover - script mode fallback
+            from clippings_processor import ClippingsProcessor
+
+        clippings = ClippingsProcessor(self.vault_dir, self.logger, self.txn)
+        clean_name = clippings.sanitize_filename(source.stem) + ".md"
+        new_name = f"{datetime.now().strftime('%Y-%m-%d')}_{clean_name}"
+        destination = self._unique_child(self.raw_dir, new_name)
+        self.raw_dir.mkdir(parents=True, exist_ok=True)
+
+        if not clippings.obsidian_move(source, self.raw_dir, destination.name):
+            raise RuntimeError(f"failed to move clipping into raw intake: {source}")
+        if not destination.exists():
+            if source.exists():
+                source.rename(destination)
+            else:
+                raise FileNotFoundError(
+                    f"obsidian move reported success but destination did not appear: {destination}"
+                )
+        return destination
+
+    def _finalize_lifecycle_source(self, working_path: Path, result: dict, dry_run: bool = False) -> Path | None:
+        if dry_run:
+            return None
+        if self._is_under(working_path, self.layout.pinboard_dir):
+            if result["status"] == "completed" and working_path.exists():
+                archived = archive_pinboard_source(self.layout, working_path)
+                result["source_path"] = str(archived)
+                return archived
+            return None
+        if not self._is_under(working_path, self.processing_dir):
+            return None
+        if result["status"] == "completed":
+            archived = self._archive_source_to_processed(working_path)
+            result["source_path"] = str(archived)
+            return archived
+        if working_path.exists():
+            restored = self._restore_source_to_raw(working_path)
+            result["source_path"] = str(restored)
+            return restored
+        return None
+
+    def process_single_source(self, file_path: Path, dry_run: bool = False) -> dict:
+        """Process one source while honoring the same lifecycle as inbox runs."""
+        source = Path(file_path)
+        zone = self._source_lifecycle_zone(source)
+
+        if dry_run:
+            result = {
+                "file": str(source),
+                "status": "dry_run",
+                "output_path": None,
+                "tokens_used": 0,
+                "images_downloaded": 0,
+                "error": None,
+                "source_lifecycle": {
+                    "zone": zone,
+                    "would_move": zone in {"clippings", "raw", "processing", "pinboard"},
+                },
+            }
+            return result
+
+        working_path = source
+        try:
+            if zone == "clippings":
+                working_path = self._move_clipping_to_raw(source)
+
+            if self._is_under(working_path, self.raw_dir):
+                working_path = self._stage_source_for_processing(working_path)
+
+            result = self.process_single_file(working_path, dry_run=False)
+            result["source_lifecycle"] = {
+                "zone": zone,
+                "working_path": str(working_path),
+            }
+            self._finalize_lifecycle_source(working_path, result, dry_run=False)
+            return result
+        except Exception as e:
+            result = {
+                "file": str(source),
+                "status": "error",
+                "output_path": None,
+                "tokens_used": 0,
+                "images_downloaded": 0,
+                "error": str(e),
+                "source_lifecycle": {
+                    "zone": zone,
+                    "working_path": str(working_path),
+                },
+            }
+            if self._is_under(working_path, self.processing_dir) and working_path.exists():
+                self._finalize_lifecycle_source(working_path, result, dry_run=False)
+            self.logger.log("article_error", {"file": str(source), "error": str(e)})
+            return result
 
     @staticmethod
     def _clean_body_text(body: str, title: str = "") -> str:
@@ -1064,16 +1195,13 @@ class AutoArticleProcessor:
             if result["status"] == "completed":
                 results["completed"] += 1
                 results["total_tokens"] += result.get("tokens_used", 0)
-                if not dry_run:
-                    self._archive_source_to_processed(working_path)
+                self._finalize_lifecycle_source(working_path, result, dry_run=dry_run)
             elif result["status"] == "error":
                 results["failed"] += 1
-                if not dry_run and working_path.exists():
-                    self._restore_source_to_raw(working_path)
+                self._finalize_lifecycle_source(working_path, result, dry_run=dry_run)
             else:
                 results["skipped"] += 1
-                if not dry_run and working_path.exists():
-                    self._restore_source_to_raw(working_path)
+                self._finalize_lifecycle_source(working_path, result, dry_run=dry_run)
 
             if txn_id:
                 self.txn.heartbeat(
@@ -1130,7 +1258,7 @@ def main():
     if args.process_inbox:
         results = processor.process_inbox(dry_run=args.dry_run, batch_size=args.batch_size, txn_id=txn_id)
     elif args.process_single:
-        result = processor.process_single_file(args.process_single, dry_run=args.dry_run)
+        result = processor.process_single_source(args.process_single, dry_run=args.dry_run)
         results = {
             "total": 1,
             "completed": 1 if result["status"] == "completed" else 0,

--- a/src/ovp_pipeline/auto_article_processor.py
+++ b/src/ovp_pipeline/auto_article_processor.py
@@ -71,12 +71,14 @@ except ImportError:  # pragma: no cover - script mode fallback
 try:
     from .source_lifecycle import (
         archive_pinboard_source,
+        clipping_raw_name,
         is_under as lifecycle_is_under,
         unique_child as lifecycle_unique_child,
     )
 except ImportError:  # pragma: no cover - script mode fallback
     from source_lifecycle import (  # type: ignore
         archive_pinboard_source,
+        clipping_raw_name,
         is_under as lifecycle_is_under,
         unique_child as lifecycle_unique_child,
     )
@@ -602,14 +604,15 @@ class AutoArticleProcessor:
             from clippings_processor import ClippingsProcessor
 
         clippings = ClippingsProcessor(self.vault_dir, self.logger, self.txn)
-        clean_name = clippings.sanitize_filename(source.stem) + ".md"
-        new_name = f"{datetime.now().strftime('%Y-%m-%d')}_{clean_name}"
+        new_name = clipping_raw_name(source, clippings.sanitize_filename)
         destination = self._unique_child(self.raw_dir, new_name)
         self.raw_dir.mkdir(parents=True, exist_ok=True)
 
         if not clippings.obsidian_move(source, self.raw_dir, destination.name):
             raise RuntimeError(f"failed to move clipping into raw intake: {source}")
         if not destination.exists():
+            # Obsidian CLI can report success before the destination is visible;
+            # keep the fallback so a completed move cannot leave Clippings live.
             if source.exists():
                 source.rename(destination)
             else:

--- a/src/ovp_pipeline/auto_github_processor.py
+++ b/src/ovp_pipeline/auto_github_processor.py
@@ -59,6 +59,11 @@ try:
 except ImportError:
     from markdown_generation import sanitize_generated_markdown  # type: ignore
 
+try:
+    from .source_lifecycle import maybe_archive_pinboard_process_single
+except ImportError:
+    from source_lifecycle import maybe_archive_pinboard_process_single  # type: ignore
+
 
 VAULT_DIR = resolve_vault_dir()
 DEFAULT_LAYOUT = VaultLayout.from_vault(VAULT_DIR)
@@ -530,6 +535,12 @@ def main():
             description=item["description"],
             llm_client=llm_client,
             output_dir=args.output_dir,
+            dry_run=args.dry_run,
+        )
+        maybe_archive_pinboard_process_single(
+            layout,
+            args.process_single if args.process_single and len(urls_to_process) == 1 else None,
+            result,
             dry_run=args.dry_run,
         )
         results.append(result)

--- a/src/ovp_pipeline/auto_paper_processor.py
+++ b/src/ovp_pipeline/auto_paper_processor.py
@@ -63,6 +63,11 @@ try:
 except ImportError:
     from markdown_generation import sanitize_generated_markdown  # type: ignore
 
+try:
+    from .source_lifecycle import maybe_archive_pinboard_process_single
+except ImportError:
+    from source_lifecycle import maybe_archive_pinboard_process_single  # type: ignore
+
 
 VAULT_DIR = resolve_vault_dir()
 DEFAULT_LAYOUT = VaultLayout.from_vault(VAULT_DIR)
@@ -623,6 +628,12 @@ def main():
             date=item["date"],
             llm_client=llm_client,
             output_dir=args.output_dir,
+            dry_run=args.dry_run,
+        )
+        maybe_archive_pinboard_process_single(
+            layout,
+            args.process_single if args.process_single and len(papers_to_process) == 1 else None,
+            result,
             dry_run=args.dry_run,
         )
         results.append(result)

--- a/src/ovp_pipeline/clippings_processor.py
+++ b/src/ovp_pipeline/clippings_processor.py
@@ -34,6 +34,11 @@ try:
 except ImportError:
     from runtime import VaultLayout, resolve_vault_dir  # type: ignore
 
+try:
+    from .source_lifecycle import clipping_raw_name
+except ImportError:
+    from source_lifecycle import clipping_raw_name  # type: ignore
+
 
 VAULT_DIR = resolve_vault_dir()
 DEFAULT_LAYOUT = VaultLayout.from_vault(VAULT_DIR)
@@ -316,10 +321,7 @@ class ClippingsProcessor:
                 "status": "pending"
             }
 
-            # 清理文件名
-            clean_name = self.sanitize_filename(file_path.stem) + ".md"
-            date_prefix = datetime.now().strftime("%Y-%m-%d")
-            new_name = f"{date_prefix}_{clean_name}"
+            new_name = clipping_raw_name(file_path, self.sanitize_filename)
 
             file_info["new_name"] = new_name
 

--- a/src/ovp_pipeline/commands/absorb.py
+++ b/src/ovp_pipeline/commands/absorb.py
@@ -12,6 +12,7 @@ from ..auto_article_processor import AutoArticleProcessor, PipelineLogger, Trans
 from ..clippings_processor import ClippingsProcessor
 from ..evidence import build_evidence_payload
 from ..runtime import VaultLayout, resolve_vault_dir
+from ..source_lifecycle import clipping_raw_name
 
 ISO_DATE_PREFIX_LEN = 10
 
@@ -96,9 +97,7 @@ def _clipping_raw_name(
     *,
     when: datetime | None = None,
 ) -> str:
-    clean_name = processor.sanitize_filename(source.stem) + ".md"
-    timestamp = (when or datetime.now()).strftime("%Y-%m-%d")
-    return f"{timestamp}_{clean_name}"
+    return clipping_raw_name(source, processor.sanitize_filename, when=when)
 
 
 def _move_clipping_to_raw(

--- a/src/ovp_pipeline/focused_actions.py
+++ b/src/ovp_pipeline/focused_actions.py
@@ -25,7 +25,7 @@ def run_deep_dive_workflow_action(
     txn = TransactionManager(layout.transactions_dir)
     processor = AutoArticleProcessor(resolved_vault, logger, txn)
     processor.init_llm()
-    result = processor.process_single_file(source_path, dry_run=False)
+    result = processor.process_single_source(source_path, dry_run=False)
     if result.get("status") != "completed":
         raise RuntimeError(str(result.get("error") or "deep_dive_workflow_failed"))
     return result

--- a/src/ovp_pipeline/source_lifecycle.py
+++ b/src/ovp_pipeline/source_lifecycle.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from pathlib import Path
+from typing import Callable
 
 try:
     from .runtime import VaultLayout
@@ -29,6 +30,17 @@ def unique_child(directory: Path, name: str) -> Path:
         if not next_candidate.exists():
             return next_candidate
         counter += 1
+
+
+def clipping_raw_name(
+    source: Path,
+    sanitize_filename: Callable[[str], str],
+    *,
+    when: datetime | None = None,
+) -> str:
+    clean_name = sanitize_filename(source.stem) + ".md"
+    timestamp = (when or datetime.now()).strftime("%Y-%m-%d")
+    return f"{timestamp}_{clean_name}"
 
 
 def archive_pinboard_source(layout: VaultLayout, source: Path) -> Path:

--- a/src/ovp_pipeline/source_lifecycle.py
+++ b/src/ovp_pipeline/source_lifecycle.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+try:
+    from .runtime import VaultLayout
+except ImportError:  # pragma: no cover - script mode fallback
+    from runtime import VaultLayout  # type: ignore
+
+
+def is_under(path: Path, parent: Path) -> bool:
+    try:
+        path.resolve().relative_to(parent.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def unique_child(directory: Path, name: str) -> Path:
+    candidate = directory / name
+    if not candidate.exists():
+        return candidate
+    stem = candidate.stem
+    suffix = candidate.suffix
+    counter = 2
+    while True:
+        next_candidate = directory / f"{stem}-{counter}{suffix}"
+        if not next_candidate.exists():
+            return next_candidate
+        counter += 1
+
+
+def archive_pinboard_source(layout: VaultLayout, source: Path) -> Path:
+    month_dir = layout.pinboard_archive_dir / datetime.now().strftime("%Y-%m")
+    month_dir.mkdir(parents=True, exist_ok=True)
+    destination = unique_child(month_dir, source.name)
+    return source.rename(destination)
+
+
+def maybe_archive_pinboard_process_single(
+    layout: VaultLayout,
+    source: Path | None,
+    result: dict,
+    *,
+    dry_run: bool = False,
+) -> Path | None:
+    if dry_run or not source or result.get("status") != "completed":
+        return None
+    if not source.exists() or not is_under(source, layout.pinboard_dir):
+        return None
+    archived = archive_pinboard_source(layout, source)
+    result["source_path"] = str(archived)
+    return archived

--- a/src/ovp_pipeline/unified_pipeline_enhanced.py
+++ b/src/ovp_pipeline/unified_pipeline_enhanced.py
@@ -1740,11 +1740,15 @@ class EnhancedPipeline:
                     results["processed"] += 1
 
                     # 移动到 archive
-                    month_dir = archive_dir / datetime.now().strftime("%Y-%m")
-                    month_dir.mkdir(parents=True, exist_ok=True)
-                    archive_file = month_dir / f.name
-                    f.rename(archive_file)
-                    self.logger.log("pinboard_process_file_completed", {"file": f.name, "processor": url_type, "archived_to": str(archive_file)})
+                    if f.exists():
+                        month_dir = archive_dir / datetime.now().strftime("%Y-%m")
+                        month_dir.mkdir(parents=True, exist_ok=True)
+                        archive_file = month_dir / f.name
+                        f.rename(archive_file)
+                        archived_to = str(archive_file)
+                    else:
+                        archived_to = "processor-managed"
+                    self.logger.log("pinboard_process_file_completed", {"file": f.name, "processor": url_type, "archived_to": archived_to})
                     if self.txn_id:
                         self.txn.heartbeat(
                             self.txn_id,

--- a/tests/test_migration_processing_guards.py
+++ b/tests/test_migration_processing_guards.py
@@ -326,6 +326,141 @@ Example SDK body
     assert processed_file.exists()
 
 
+def test_process_single_source_moves_clipping_through_lifecycle(temp_vault, monkeypatch):
+    clipping = temp_vault / "Clippings" / "Raw Clip.md"
+    clipping.parent.mkdir(parents=True, exist_ok=True)
+    clipping.write_text(
+        """---
+title: "Raw Clip"
+source: https://example.com/raw-clip
+author: unknown
+date: 2026-04-07
+type: article
+tags: [sdk]
+---
+
+Raw clip body
+""",
+        encoding="utf-8",
+    )
+
+    logger = ArticleLogger(temp_vault / "60-Logs" / "pipeline.jsonl")
+    txn = ArticleTxn(temp_vault / "60-Logs" / "transactions")
+    processor = AutoArticleProcessor(temp_vault, logger, txn)
+    processor.article_processor = SimpleNamespace(
+        generate_interpretation=lambda **kwargs: (
+            "---\ntitle: Test\nsource: x\nauthor: y\ndate: 2026-04-07\ntype: article\ntags: []\nstatus: draft\n---\n\n# ok",
+            {"tokens": 1},
+            "tools",
+        )
+    )
+    monkeypatch.setattr(
+        processor,
+        "_prepare_interpretation_source",
+        lambda file_data: ("Substantive source material " * 80, {"origin": "body"}),
+    )
+    monkeypatch.setattr(
+        "ovp_pipeline.image_downloader.ImageDownloader.process_file",
+        lambda self, file_path, backup=True: [],
+    )
+
+    def fake_obsidian_move(self, source, dest_dir, new_name=None):
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        source.rename(dest_dir / (new_name or source.name))
+        return True
+
+    monkeypatch.setattr("ovp_pipeline.clippings_processor.ClippingsProcessor.obsidian_move", fake_obsidian_move)
+
+    result = processor.process_single_source(clipping, dry_run=False)
+
+    processed_files = list((temp_vault / "50-Inbox" / "03-Processed").glob("*/*Raw_Clip.md"))
+
+    assert result["status"] == "completed"
+    assert not clipping.exists()
+    assert not list((temp_vault / "50-Inbox" / "01-Raw").glob("*Raw_Clip.md"))
+    assert not list((temp_vault / "50-Inbox" / "02-Processing").glob("*Raw_Clip.md"))
+    assert len(processed_files) == 1
+
+
+def test_article_cli_process_single_uses_source_lifecycle(temp_vault, monkeypatch):
+    clipping = temp_vault / "Clippings" / "Raw Clip.md"
+    clipping.parent.mkdir(parents=True, exist_ok=True)
+    clipping.write_text("# Raw Clip\n", encoding="utf-8")
+
+    called: dict[str, object] = {}
+
+    def stub_init_llm(self, *, api_key=None, api_base=None):
+        self.llm = SimpleNamespace(model="stub-model")
+
+    def stub_process_single_source(self, file_path, dry_run=False):
+        called["file_path"] = Path(file_path)
+        called["dry_run"] = dry_run
+        return {"status": "completed", "tokens_used": 0, "output_path": "out.md"}
+
+    monkeypatch.setattr(article_module.AutoArticleProcessor, "init_llm", stub_init_llm)
+    monkeypatch.setattr(article_module.AutoArticleProcessor, "process_single_source", stub_process_single_source)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "auto_article_processor.py",
+            "--process-single",
+            str(clipping),
+            "--vault-dir",
+            str(temp_vault),
+        ],
+    )
+
+    assert article_module.main() == 0
+    assert called == {"file_path": clipping, "dry_run": False}
+
+
+def test_process_single_source_archives_pinboard_after_success(temp_vault, monkeypatch):
+    pinboard_file = temp_vault / "50-Inbox" / "02-Pinboard" / "2026-04-07_example.md"
+    pinboard_file.parent.mkdir(parents=True, exist_ok=True)
+    pinboard_file.write_text(
+        """---
+title: "Example SDK"
+source: https://example.com
+author: unknown
+date: 2026-04-07
+type: article
+tags: [sdk]
+---
+
+Example body
+""",
+        encoding="utf-8",
+    )
+
+    logger = ArticleLogger(temp_vault / "60-Logs" / "pipeline.jsonl")
+    txn = ArticleTxn(temp_vault / "60-Logs" / "transactions")
+    processor = AutoArticleProcessor(temp_vault, logger, txn)
+    processor.article_processor = SimpleNamespace(
+        generate_interpretation=lambda **kwargs: (
+            "---\ntitle: Test\nsource: x\nauthor: y\ndate: 2026-04-07\ntype: article\ntags: []\nstatus: draft\n---\n\n# ok",
+            {"tokens": 1},
+            "tools",
+        )
+    )
+    monkeypatch.setattr(
+        processor,
+        "_prepare_interpretation_source",
+        lambda file_data: ("Substantive source material " * 80, {"origin": "body"}),
+    )
+    monkeypatch.setattr(
+        "ovp_pipeline.image_downloader.ImageDownloader.process_file",
+        lambda self, file_path, backup=True: [],
+    )
+
+    result = processor.process_single_source(pinboard_file, dry_run=False)
+    archived_files = list((temp_vault / "70-Archive" / "Pinboard").glob("*/2026-04-07_example.md"))
+
+    assert result["status"] == "completed"
+    assert not pinboard_file.exists()
+    assert len(archived_files) == 1
+
+
 def test_process_inbox_restores_failed_sources_back_to_raw(temp_vault, monkeypatch):
     raw_file = temp_vault / "50-Inbox" / "01-Raw" / "2026-04-07_failure.md"
     raw_file.parent.mkdir(parents=True, exist_ok=True)
@@ -574,6 +709,8 @@ tags: [tool]
 
     assert github_module.main() == 0
     assert captured["model"] is None
+    assert not pinboard_file.exists()
+    assert len(list((temp_vault / "70-Archive" / "Pinboard").glob("*/2026-04-07_example.md"))) == 1
 
 
 def test_paper_cli_does_not_override_auto_vault_model_when_flag_is_omitted(temp_vault, monkeypatch):
@@ -618,6 +755,8 @@ tags: [paper]
 
     assert paper_module.main() == 0
     assert captured["model"] is None
+    assert not pinboard_file.exists()
+    assert len(list((temp_vault / "70-Archive" / "Pinboard").glob("*/2026-04-07_paper.md"))) == 1
 
 
 def test_article_cli_summary_handles_results_without_queued_total(temp_vault, monkeypatch, capsys):


### PR DESCRIPTION
## Summary

This PR makes single-file processing commands follow the same source lifecycle behavior as the broader OVP pipeline.

## Root Cause

`ovp-absorb --file` had source lifecycle protection, but `ovp-article --process-single` still called the low-level `process_single_file()` path directly. That meant a clipping could be analyzed and have images localized while the source stayed in `Clippings/`, so it would be picked up again by the normal clippings workflow. Related single-file Pinboard processor paths had the same class of lifecycle mismatch.

## Changes

- Add `AutoArticleProcessor.process_single_source()` as the source-aware single-file entrypoint.
- Route `ovp-article --process-single` and focused deep-dive actions through that source-aware path.
- Move Clippings through `Clippings -> 50-Inbox/01-Raw -> 50-Inbox/02-Processing -> 50-Inbox/03-Processed/YYYY-MM` for successful single-file article processing.
- Archive successful single-file Pinboard article/paper/github sources to `70-Archive/Pinboard/YYYY-MM`.
- Let the outer `pinboard_process` step tolerate processor-managed archiving to avoid double-renaming.
- Add regression tests for Clippings, Pinboard, GitHub, and paper single-file lifecycle behavior.

## Validation

- `pytest -q tests/test_migration_processing_guards.py tests/test_runtime_paths.py::test_step_pinboard_process_updates_txn_ledger_with_counted_progress tests/test_runtime_paths.py::test_step_pinboard_process_heartbeats_current_item_before_processor_runs tests/test_absorb_refine_commands.py::test_absorb_file_under_clippings_runs_source_lifecycle_before_absorb tests/test_absorb_refine_commands.py::test_absorb_dry_run_under_clippings_reports_source_lifecycle_plan`
- `python -m compileall -q src/ovp_pipeline/auto_article_processor.py src/ovp_pipeline/auto_paper_processor.py src/ovp_pipeline/auto_github_processor.py src/ovp_pipeline/focused_actions.py src/ovp_pipeline/unified_pipeline_enhanced.py src/ovp_pipeline/source_lifecycle.py`
- `git diff --check`