### PR TITLE
feat: add projection repair lifecycle markers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -433,6 +433,13 @@ Operational rules:
 - `claimed_by` and `claim_lease_until` prevent duplicate workers from handling the same marker.
 - if the current Authority schema version is newer than the marker or projection version, promote to `full_rebuild`.
 
+Current implementation:
+
+- `projection_lifecycle.py` records projection repair marker events in `60-Logs/projection-repair.jsonl`.
+- The marker event log is append-oriented and reconstructs current marker state from `written`, `superseded`, `claimed`, and `closed` events.
+- `ensure_knowledge_db_current()` writes and closes a `full_rebuild` marker when `knowledge.db` is missing or has an incompatible legacy schema.
+- The broader Authority/projection schema metadata contract is still partial: current code has a schema constant and rebuild triggers, but does not yet persist `.ovp/schema_version` or projection metadata inside `knowledge.db`.
+
 ## 12. Canonical Scenarios
 
 ### Scenario A: User Clips An Article
@@ -656,6 +663,7 @@ Current implementation roughly maps as follows:
 | `truth_api.py` | read/query interface | Layer 2/3 access |
 | `ovp-ui` | dashboard, object pages, graph, signals/actions | Layer 3 + some Layer 4 controls |
 | promotion modules | candidate/relation/workspace promotion | Layer 4 Promotion + Audit |
+| `projection_lifecycle.py` | structured projection repair marker log and leases | Layer 4 Repair + Verification |
 | source lifecycle routing preview | `ovp-absorb --dry-run --json` `source_lifecycle.routing_preview` | Layer 4 Routing / Dispatch |
 | doctor/lint | checks and repair hints | Layer 4 Verification + Repair |
 | packs | `research-tech`, `default-knowledge` | ownership perspective |
@@ -665,8 +673,8 @@ Main gaps:
 - Layer 1 claim/evidence contracts now carry a first line/char span schema in derived evidence rows; factual evidence_kind enforcement and richer claim lifecycle fields still need hardening.
 - Layer 2 / Layer 3 projection labels now exist on core access payloads and materialized reader artifacts; doctor/export enforcement and future surfaces still need to consume them consistently.
 - Layer 4 fitness checks now cover the first hot-path, workflow-wiring, source routing preview, evidence span backfill, and candidate risk cases; deeper evidence completeness, projection replay, and import-boundary checks are still open.
-- Projection lifecycle markers need structured schema, scope, lease, and supersession.
-- Schema versioning is not yet wired into projection lifecycle.
+- Projection lifecycle markers now have structured schema, scope, lease, supersession, and `knowledge.db` rebuild integration.
+- Schema versioning is partially wired into projection lifecycle for rebuild markers; persistent Authority/projection version metadata is still open.
 - The reader-first home is now the default entry; object pages have reader profiles, source rails, and kind-specific reader lenses; `/graph` has a first spatial map projection; `/search` groups reader results by kind, summary, evidence count, and match reason.
 
 ## 18. Near-Term Architecture Actions
@@ -674,10 +682,10 @@ Main gaps:
 Recommended order:
 
 1. Keep projection metadata attached to new access surfaces and add doctor/export checks that verify the labels are present.
-2. Move to projection repair lifecycle and schema-version rebuild triggers now that the first reader-facing product loop is coherent.
+2. Finish the remaining schema-version metadata contract now that the first rebuild-marker trigger is wired.
 3. Add stricter factual evidence completeness checks before expanding automatic promotion.
-4. Introduce structured `ProjectionRepairMarker` schema.
-5. Add schema version fields to Authority and derived projection state.
+4. Add schema version fields to Authority and derived projection state.
+5. Expand doctor/export checks to verify projection marker replay and projection labels together.
 
 ## Appendix: Backlog Mapping
 
@@ -693,5 +701,5 @@ The architecture should not depend on backlog IDs to be valid. The table below i
 | Candidate risk layering | `BL-007`, `KSR-003` done in PR #82 |
 | Reader-first access surfaces | `BL-001`; `BL-008` and `BL-009` done through PR #79 and PR #83; `BL-010` done in PR #80 |
 | Reader-oriented search | `BL-011` done in PR #84 |
-| Projection repair lifecycle | `BL-020` |
-| Schema versioning and migration trigger | `BL-021` |
+| Projection repair lifecycle | `BL-020` done in PR #87 |
+| Schema versioning and migration trigger | `BL-021` partial in PR #87 |

--- a/ARCHITECTURE.zh-CN.md
+++ b/ARCHITECTURE.zh-CN.md
@@ -279,6 +279,7 @@ Layer 4 是 OVP 的控制面。
 - focused action handlers
 - signals/actions
 - doctor checks
+- projection repair marker lifecycle
 - pack contracts
 - workflow/profile routing
 
@@ -532,7 +533,12 @@ Operational rules:
 - 如果 marker 的 `authority_schema_version` 小于当前 Authority schema version，resolver 必须提升到 `full_rebuild`。
 - 如果 projection backend 支持 partial rebuild，scope 必须被用于限制 rebuild 范围。
 
-当前 OVP 对 “derived 可重建” 已经有原则和习惯，但 marker/control plane 还不够显式。
+当前实现：
+
+- `projection_lifecycle.py` 将 projection repair marker events 记录在 `60-Logs/projection-repair.jsonl`。
+- marker event log 通过 `written`、`superseded`、`claimed`、`closed` events replay 出当前 marker state。
+- `ensure_knowledge_db_current()` 在 `knowledge.db` 缺失或 legacy schema 不兼容时，会写入并关闭一个 `full_rebuild` marker。
+- 更完整的 Authority/projection schema metadata contract 仍是 partial：当前代码有 schema constant 和 rebuild trigger，但还没有持久化 `.ovp/schema_version` 或 `knowledge.db` 内部 projection metadata。
 
 ## 11. Canonical Scenarios
 
@@ -771,11 +777,11 @@ Do not rely on ad hoc "just rerun the pipeline" behavior for schema changes.
 - canonical artifact contract 仍需继续一等公民化；derived evidence rows 已有第一版 line/char span schema，但 factual evidence_kind enforcement 和 claim lifecycle 字段仍需加强。
 - Layer 4 子轴还没有完全反映到代码结构。
 - projection labels 已经贯穿核心 access payload 和 materialized reader artifacts；doctor/export enforcement 以及未来新增 surface 还需要持续消费这些标注。
-- projection lifecycle marker 还没有明确区分 metadata_only / full_rebuild / semantic_reindex。
+- projection lifecycle marker 已有结构化 kind/scope/reason、supersession、claim lease，并已接入 `knowledge.db` rebuild 路径。
 - dashboard/search hot path、workflow wiring、source routing preview、evidence span backfill 和 candidate risk 已经有第一批 fitness checks；更深的 evidence completeness、projection replay、import-boundary checks 仍未完成。
 - context assembly recipes 还需要收束。
 - governance / resolver contracts 还需要显式化。
-- schema versioning 和 projection compatibility 还需要工程化。
+- schema versioning 已经有第一版 rebuild marker trigger；Authority/projection version metadata 持久化仍需工程化。
 - fitness functions 只落地了第一批，仍需扩展到 CI/doctor/pre-commit 的完整契约。
 - reader-first home 已经成为默认入口；object page 已有 reader profile、source rail 和按 kind 区分的 reader lens；`/graph` 已有第一版 spatial map projection；`/search` 已按 kind、summary、evidence count、match reason 组织 reader results。
 
@@ -786,10 +792,10 @@ Do not rely on ad hoc "just rerun the pipeline" behavior for schema changes.
 优先顺序：
 
 1. 新增 access surface 时必须继续带 projection metadata，并补 doctor/export checks 验证标注存在。
-2. 第一版 reader-facing product loop 已经成形，下一步转向 projection repair lifecycle 和 schema-version rebuild trigger。
+2. 第一版 rebuild-marker trigger 已接上，下一步补完 schema-version metadata contract。
 3. 在扩大自动 promotion 前，补更严格的 factual evidence completeness checks。
-4. 引入结构化 ProjectionRepairMarker。
-5. 给 Authority 和 derived projection state 增加 schema version 字段。
+4. 给 Authority 和 derived projection state 增加 schema version 字段。
+5. 扩展 doctor/export checks，同时验证 projection marker replay 和 projection labels。
 6. 把 routing、promotion、review、permission 从 prompt/散落代码中收束为显式 governance/dispatch contract。
 7. 预留 semantic_reindex lifecycle kind，但不提前锁定 LanceDB 或其它 backend。
 
@@ -807,8 +813,8 @@ Do not rely on ad hoc "just rerun the pipeline" behavior for schema changes.
 | Candidate risk layering | `BL-007`, `KSR-003` 已在 PR #82 交付 |
 | Reader-first access surfaces | `BL-001`；`BL-008`、`BL-009` 已通过 PR #79 和 PR #83 交付；`BL-010` 已在 PR #80 交付 |
 | Reader-oriented search | `BL-011` 已在 PR #84 交付 |
-| Projection repair lifecycle | `BL-020` |
-| Schema versioning and migration trigger | `BL-021` |
+| Projection repair lifecycle | `BL-020` 已在 PR #87 落地 |
+| Schema versioning and migration trigger | `BL-021` 已在 PR #87 落地第一片 |
 
 ## Bottom Line
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -51,8 +51,11 @@ Rule: historical plans and vault research notes feed this file; they do not over
 | BL-017 | P2 | Later | Schema-on-demand guard for new claim/candidate profiles | M6, KSR-028 |
 | BL-018 | P2 | Later | Reviewed semantic relation extractor and query feedback loop | M7, April 22 roadmap |
 | BL-019 | P2 | Later | Skill/routine extraction profile, notebook/raw-source mode, ingest ROI, hybrid retrieval, multimodal caption-first ingest, follow-up object model | M7, KSR-010, KSR-011, KSR-012, KSR-016, KSR-019, KSR-029 |
-| BL-020 | P1 | Later | Projection repair lifecycle: structured marker kind/scope/reason, supersession, claim lease, and repair audit events | M4/M5, Architecture |
-| BL-021 | P1 | Later | Authority/projection schema versioning and migration-triggered full rebuild markers | M4/M5, Architecture |
+| BL-020 | P1 | Done | Projection repair lifecycle: structured marker kind/scope/reason, supersession, claim lease, and repair audit events | M4/M5, Architecture, PR #87 |
+| BL-021 | P1 | Partial | Authority/projection schema versioning and migration-triggered full rebuild markers | M4/M5, Architecture, PR #87 |
+| BL-022 | P1 | Later | Decision context memory: first-class rationale, rejected alternatives, dissent, owner, participants, and validity windows for high-value decisions | M6/M7, KSR-030, Company Brain research |
+| BL-023 | P1 | Later | Agent workspace substrate and information-health loop: expose AGENTS/MEMORY/Skills/Heartbeat/autonomy policy as runtime state and run approval-based stale/conflict/term-drift reviews | M6/M7, KSR-031, KSR-032, Moxt research |
+| BL-024 | P1 | Later | Machine-facing memory substrate: typed scored memory records with freshness, evidence count, supersession, last-used telemetry, and token-budgeted selective injection | M6/M7, KSR-033, Mercury research |
 
 ## KSR Task Coverage
 
@@ -87,15 +90,19 @@ Rule: historical plans and vault research notes feed this file; they do not over
 | KSR-027 Live-source routing policy | BL-005/BL-014 | Later |
 | KSR-028 Schema-on-demand guard | BL-017 | Later |
 | KSR-029 Follow-up object model | BL-019 | Later |
+| KSR-030 Decision context memory | BL-022 | Later |
+| KSR-031 Agent workspace substrate | BL-023 | Later |
+| KSR-032 Information health loop | BL-023 | Later |
+| KSR-033 Machine-facing memory substrate | BL-024 | Later |
 
 ## Next Decision
 
-`BL-001` is shipped in PR #75, `BL-003 + BL-004` are shipped in PR #77, `BL-002` is shipped in PR #78, `BL-009` plus the first `BL-008` slice are shipped in PR #79, `BL-010` is shipped in PR #80, `BL-005` is shipped in PR #81, `BL-006 + BL-007` are implemented in PR #82, `BL-008` is completed in PR #83, and `BL-011` is completed in PR #84. The default UI now has a reader-first entry point, `/ops` owns the operator dashboard, core access/materialized surfaces carry explicit projection labels, object pages expose readable source/backlink rails and kind-specific reader lenses, `/graph` renders a reader-facing spatial map over graph projections, `/search` groups reader results by kind with summaries, evidence counts, and match reasons, `ovp-absorb --dry-run --json` explains source lifecycle routing before mutation, evidence rows carry line/char spans, and candidate review payloads expose risk tiers.
+`BL-001` is shipped in PR #75, `BL-003 + BL-004` are shipped in PR #77, `BL-002` is shipped in PR #78, `BL-009` plus the first `BL-008` slice are shipped in PR #79, `BL-010` is shipped in PR #80, `BL-005` is shipped in PR #81, `BL-006 + BL-007` are implemented in PR #82, `BL-008` is completed in PR #83, `BL-011` is completed in PR #84, and the first `BL-020 / BL-021` slice is in PR #87. The default UI now has a reader-first entry point, `/ops` owns the operator dashboard, core access/materialized surfaces carry explicit projection labels, object pages expose readable source/backlink rails and kind-specific reader lenses, `/graph` renders a reader-facing spatial map over graph projections, `/search` groups reader results by kind with summaries, evidence counts, and match reasons, `ovp-absorb --dry-run --json` explains source lifecycle routing before mutation, evidence rows carry line/char spans, candidate review payloads expose risk tiers, and `knowledge.db` rebuilds now leave structured projection repair markers.
 
-The next implementation PR should move from reader product shape back into operational hardening: **BL-020 / BL-021** projection repair lifecycle and schema-version rebuild triggers. The first reader-facing product loop is now coherent enough to support that reliability work.
+The next implementation PR should finish the remaining **BL-021** schema/version metadata contract and then move into trusted reuse and context-pack loops.
 
 Recommended order:
 
-1. BL-020 / BL-021 projection repair lifecycle and schema migration triggers
+1. BL-021 completion: persist Authority/projection schema versions and migration metadata beyond the current marker trigger
 2. BL-012 / BL-013 trusted reuse events and context-pack loops
 3. BL-014 when operational runtime observability becomes the next bottleneck

--- a/MILESTONE.md
+++ b/MILESTONE.md
@@ -53,14 +53,14 @@ That means the user-facing product should make compiled knowledge easy to read f
 | Kind-aware object pages and backlink rail | `BL-008` and `BL-009` done through PR #79 and PR #83 |
 | Visual graph MVP | `BL-010` done in PR #80 |
 | Reader-oriented search | `BL-011` done in PR #84 |
-| Projection repair lifecycle | `BL-020` |
-| Schema versioning and migration trigger | `BL-021` |
+| Projection repair lifecycle | `BL-020` done in PR #87 |
+| Schema versioning and migration trigger | `BL-021` partial in PR #87 |
 
 ## Near-Term Sequence
 
 Recommended order:
 
-1. Return to `BL-020 + BL-021` for projection repair and schema-migration rebuild triggers.
+1. Finish the remaining `BL-021` schema/version metadata contract beyond the current rebuild marker trigger.
 2. Move into `BL-012 + BL-013` once the reader surfaces need stronger reuse and context-pack loops.
 3. Pick up `BL-014` when operational runtime observability becomes the next bottleneck.
 

--- a/MILESTONE.zh-CN.md
+++ b/MILESTONE.zh-CN.md
@@ -53,14 +53,14 @@ OVP 正在从 document-processing pipeline 变成：
 | Kind-aware object pages and backlink rail | `BL-008`、`BL-009` 已通过 PR #79 和 PR #83 交付 |
 | Visual graph MVP | `BL-010` 已在 PR #80 交付 |
 | Reader-oriented search | `BL-011` 已在 PR #84 交付 |
-| Projection repair lifecycle | `BL-020` |
-| Schema versioning and migration trigger | `BL-021` |
+| Projection repair lifecycle | `BL-020` 已在 PR #87 落地 |
+| Schema versioning and migration trigger | `BL-021` 已在 PR #87 落地第一片 |
 
 ## 近期顺序
 
 建议顺序：
 
-1. 回到 `BL-020 + BL-021`：projection repair lifecycle 和 schema migration rebuild trigger。
+1. 补完 `BL-021` 剩余的 schema/version metadata contract，不只停留在当前 rebuild marker trigger。
 2. 当 reader surface 需要更强的复用和 context-pack 闭环时，再进入 `BL-012 + BL-013`。
 3. 当 operational runtime observability 成为下一个瓶颈时，再进入 `BL-014`。
 

--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ Current milestone sequence:
 
 Current active backlog focus:
 
-- Shipped: `KSR-001` evidence spans, `KSR-002` projection labels, `KSR-003` candidate risk tiers, `KSR-014` article routing preview, `KSR-015` dashboard/search hot-path audit, `KSR-018` markdown-aware evidence span backfill, `KSR-026` workflow wiring eval suite.
+- Shipped: `KSR-001` evidence spans, `KSR-002` projection labels, `KSR-003` candidate risk tiers, `KSR-014` article routing preview, `KSR-015` dashboard/search hot-path audit, `KSR-018` markdown-aware evidence span backfill, `KSR-026` workflow wiring eval suite, and the first structured projection repair marker lifecycle.
 - Product shipped: readable object page profiles, source/backlink rail, kind-specific reader lenses, visual `/graph` map, and reader-oriented search grouped by kind, evidence, and reason.
-- Next: projection repair lifecycle and schema-version rebuild triggers.
+- Next: finish the schema/version metadata contract, then move into trusted reuse events and context-pack loops.
 - Product track: reader-first Knowledge Atlas stays a projection layer, not a new state system.
 
 ## Domain Packs

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -100,9 +100,9 @@ Obsidian Vault Pipeline（OVP）不是一个“多脚本拼装包”，也不只
 
 当前 active backlog 重点：
 
-- 已交付：`KSR-001` Evidence span 化、`KSR-002` Projection 标注、`KSR-003` Candidate 风险分层、`KSR-014` Article routing preview、`KSR-015` Dashboard/search hot-path audit、`KSR-018` Markdown-aware evidence span backfill、`KSR-026` Workflow wiring eval suite。
+- 已交付：`KSR-001` Evidence span 化、`KSR-002` Projection 标注、`KSR-003` Candidate 风险分层、`KSR-014` Article routing preview、`KSR-015` Dashboard/search hot-path audit、`KSR-018` Markdown-aware evidence span backfill、`KSR-026` Workflow wiring eval suite，以及第一版结构化 projection repair marker lifecycle。
 - 产品侧已交付：readable object page profile、source/backlink rail、按 kind 区分的 reader lens、visual `/graph` map，以及按 kind、evidence、reason 组织的 reader-oriented search。
-- 下一步：projection repair lifecycle 和 schema-version rebuild trigger。
+- 下一步：补完 schema/version metadata contract，然后进入 trusted reuse event 和 context-pack loop。
 - 产品线：Reader-first Knowledge Atlas 作为 projection layer 实现，不另建状态系统。
 
 ## Domain Packs

--- a/src/ovp_pipeline/knowledge_index.py
+++ b/src/ovp_pipeline/knowledge_index.py
@@ -17,12 +17,14 @@ from .graph.frontmatter import FrontmatterParser, NoteMetadata
 from .graph.link_parser import LinkParser
 from .identity import canonicalize_note_id
 from .packs.loader import DEFAULT_WORKFLOW_PACK_NAME
+from .projection_lifecycle import close_projection_repair_marker, write_projection_repair_marker
 from .runtime import VaultLayout, knowledge_db_write_lock, resolve_vault_dir
 from .truth_projection_registry import execute_truth_projection_builder, resolve_truth_projection_builder
 from .truth_store import TRUTH_STORE_SCHEMA
 
 SUMMARY_MAX_LEN = 320
 SUMMARY_RELATED_LIMIT = 3
+AUTHORITY_SCHEMA_VERSION = 1
 
 
 _FTS_QUERY_SCRUB = re.compile(r"[^\w\u4e00-\u9fff]+", flags=re.UNICODE)
@@ -528,8 +530,24 @@ def _initialize_database(db_path: Path) -> sqlite3.Connection:
 def _ensure_knowledge_db(vault_dir: Path) -> tuple[Path, VaultLayout]:
     resolved_vault = resolve_vault_dir(vault_dir)
     layout = VaultLayout.from_vault(resolved_vault)
-    if not layout.knowledge_db.exists() or not _knowledge_db_supports_pack_schema(layout.knowledge_db):
+    rebuild_reason = ""
+    if not layout.knowledge_db.exists():
+        rebuild_reason = "knowledge_db_missing"
+    elif not _knowledge_db_supports_pack_schema(layout.knowledge_db):
+        rebuild_reason = "knowledge_db_schema_incompatible"
+
+    if rebuild_reason:
+        marker = write_projection_repair_marker(
+            resolved_vault,
+            kind="full_rebuild",
+            scope={"projection_kind": "knowledge_db"},
+            reason=rebuild_reason,
+            caused_by="ensure_knowledge_db_current",
+            authority_schema_version=AUTHORITY_SCHEMA_VERSION,
+            projection_schema_version=0,
+        )
         rebuild_knowledge_index(resolved_vault)
+        close_projection_repair_marker(resolved_vault, marker.marker_id)
     return resolved_vault, layout
 
 

--- a/src/ovp_pipeline/projection_lifecycle.py
+++ b/src/ovp_pipeline/projection_lifecycle.py
@@ -1,0 +1,312 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, replace
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Literal
+
+from .runtime import VaultLayout, resolve_vault_dir
+
+ProjectionRepairKind = Literal["metadata_only", "full_rebuild", "semantic_reindex"]
+ProjectionRepairStatus = Literal["open", "claimed", "closed", "superseded"]
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _format_dt(value: datetime | None) -> str:
+    if value is None:
+        return ""
+    normalized = value.astimezone(timezone.utc)
+    return normalized.isoformat().replace("+00:00", "Z")
+
+
+def _parse_dt(value: object) -> datetime | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    return datetime.fromisoformat(text.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+def _marker_log_path(vault_dir: Path | str) -> Path:
+    layout = VaultLayout.from_vault(resolve_vault_dir(vault_dir))
+    return layout.logs_dir / "projection-repair.jsonl"
+
+
+def _canonical_json(value: object) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _marker_id(
+    *,
+    kind: str,
+    scope: dict[str, object],
+    reason: str,
+    caused_by: str,
+    created_at: datetime,
+) -> str:
+    digest = hashlib.sha256(
+        "|".join(
+            [
+                kind,
+                _canonical_json(scope),
+                reason,
+                caused_by,
+                _format_dt(created_at),
+            ]
+        ).encode("utf-8")
+    ).hexdigest()[:16]
+    return f"prm_{digest}"
+
+
+@dataclass(frozen=True)
+class ProjectionRepairMarker:
+    marker_id: str
+    kind: ProjectionRepairKind
+    scope: dict[str, object]
+    reason: str
+    caused_by: str
+    created_at: datetime
+    authority_schema_version: int
+    projection_schema_version: int
+    status: ProjectionRepairStatus = "open"
+    superseded_by: str = ""
+    claimed_by: str = ""
+    claim_lease_until: datetime | None = None
+    closed_at: datetime | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "marker_id": self.marker_id,
+            "kind": self.kind,
+            "scope": self.scope,
+            "reason": self.reason,
+            "caused_by": self.caused_by,
+            "created_at": _format_dt(self.created_at),
+            "authority_schema_version": self.authority_schema_version,
+            "projection_schema_version": self.projection_schema_version,
+            "status": self.status,
+            "superseded_by": self.superseded_by,
+            "claimed_by": self.claimed_by,
+            "claim_lease_until": _format_dt(self.claim_lease_until),
+            "closed_at": _format_dt(self.closed_at),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, object]) -> "ProjectionRepairMarker":
+        return cls(
+            marker_id=str(payload["marker_id"]),
+            kind=str(payload["kind"]),  # type: ignore[arg-type]
+            scope=dict(payload.get("scope") or {}),
+            reason=str(payload.get("reason") or ""),
+            caused_by=str(payload.get("caused_by") or ""),
+            created_at=_parse_dt(payload.get("created_at")) or _utc_now(),
+            authority_schema_version=int(payload.get("authority_schema_version") or 0),
+            projection_schema_version=int(payload.get("projection_schema_version") or 0),
+            status=str(payload.get("status") or "open"),  # type: ignore[arg-type]
+            superseded_by=str(payload.get("superseded_by") or ""),
+            claimed_by=str(payload.get("claimed_by") or ""),
+            claim_lease_until=_parse_dt(payload.get("claim_lease_until")),
+            closed_at=_parse_dt(payload.get("closed_at")),
+        )
+
+
+def _append_event(vault_dir: Path | str, event: dict[str, object]) -> None:
+    path = _marker_log_path(vault_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(event, ensure_ascii=False, sort_keys=True) + "\n")
+
+
+def _events(vault_dir: Path | str) -> list[dict[str, object]]:
+    path = _marker_log_path(vault_dir)
+    if not path.exists():
+        return []
+    events: list[dict[str, object]] = []
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        if not raw_line.strip():
+            continue
+        try:
+            payload = json.loads(raw_line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            events.append(payload)
+    return events
+
+
+def _is_broader_marker(new_marker: ProjectionRepairMarker, old_marker: ProjectionRepairMarker) -> bool:
+    if old_marker.status not in {"open", "claimed"}:
+        return False
+    if new_marker.kind != "full_rebuild" or old_marker.kind == "full_rebuild":
+        return False
+    new_projection = str(new_marker.scope.get("projection_kind") or "")
+    old_projection = str(old_marker.scope.get("projection_kind") or "")
+    return bool(new_projection and new_projection == old_projection)
+
+
+def list_projection_repair_markers(vault_dir: Path | str) -> list[ProjectionRepairMarker]:
+    markers: dict[str, ProjectionRepairMarker] = {}
+    order: list[str] = []
+    for event in _events(vault_dir):
+        event_type = str(event.get("event_type") or "")
+        marker_id = str(event.get("marker_id") or "")
+        if event_type == "projection_repair_marker_written":
+            marker = ProjectionRepairMarker.from_dict(dict(event["marker"]))
+            markers[marker.marker_id] = marker
+            if marker.marker_id not in order:
+                order.append(marker.marker_id)
+            continue
+        if marker_id not in markers:
+            continue
+        marker = markers[marker_id]
+        if event_type == "projection_repair_marker_superseded":
+            markers[marker_id] = replace(
+                marker,
+                status="superseded",
+                superseded_by=str(event.get("superseded_by") or ""),
+            )
+        elif event_type == "projection_repair_marker_claimed":
+            markers[marker_id] = replace(
+                marker,
+                status="claimed",
+                claimed_by=str(event.get("claimed_by") or ""),
+                claim_lease_until=_parse_dt(event.get("claim_lease_until")),
+            )
+        elif event_type == "projection_repair_marker_closed":
+            markers[marker_id] = replace(
+                marker,
+                status="closed",
+                closed_at=_parse_dt(event.get("closed_at")),
+            )
+    return [markers[marker_id] for marker_id in order if marker_id in markers]
+
+
+def write_projection_repair_marker(
+    vault_dir: Path | str,
+    *,
+    kind: ProjectionRepairKind,
+    scope: dict[str, object],
+    reason: str,
+    caused_by: str,
+    authority_schema_version: int,
+    projection_schema_version: int,
+    created_at: datetime | None = None,
+) -> ProjectionRepairMarker:
+    created = created_at or _utc_now()
+    marker = ProjectionRepairMarker(
+        marker_id=_marker_id(
+            kind=kind,
+            scope=scope,
+            reason=reason,
+            caused_by=caused_by,
+            created_at=created,
+        ),
+        kind=kind,
+        scope=dict(scope),
+        reason=reason,
+        caused_by=caused_by,
+        created_at=created,
+        authority_schema_version=int(authority_schema_version),
+        projection_schema_version=int(projection_schema_version),
+    )
+    _append_event(
+        vault_dir,
+        {
+            "event_type": "projection_repair_marker_written",
+            "marker_id": marker.marker_id,
+            "timestamp": _format_dt(created),
+            "marker": marker.to_dict(),
+        },
+    )
+    for existing in list_projection_repair_markers(vault_dir):
+        if existing.marker_id == marker.marker_id:
+            continue
+        if _is_broader_marker(marker, existing):
+            _append_event(
+                vault_dir,
+                {
+                    "event_type": "projection_repair_marker_superseded",
+                    "marker_id": existing.marker_id,
+                    "superseded_by": marker.marker_id,
+                    "timestamp": _format_dt(created),
+                },
+            )
+    return marker
+
+
+def claim_projection_repair_marker(
+    vault_dir: Path | str,
+    marker_id: str,
+    *,
+    worker_id: str,
+    lease_seconds: int,
+    now: datetime | None = None,
+) -> ProjectionRepairMarker | None:
+    current_time = now or _utc_now()
+    markers = {marker.marker_id: marker for marker in list_projection_repair_markers(vault_dir)}
+    marker = markers.get(marker_id)
+    if marker is None or marker.status not in {"open", "claimed"}:
+        return None
+    if marker.claimed_by and marker.claim_lease_until and marker.claim_lease_until > current_time:
+        return None
+    lease_until = current_time + timedelta(seconds=lease_seconds)
+    _append_event(
+        vault_dir,
+        {
+            "event_type": "projection_repair_marker_claimed",
+            "marker_id": marker_id,
+            "claimed_by": worker_id,
+            "claim_lease_until": _format_dt(lease_until),
+            "timestamp": _format_dt(current_time),
+        },
+    )
+    return {item.marker_id: item for item in list_projection_repair_markers(vault_dir)}[marker_id]
+
+
+def close_projection_repair_marker(
+    vault_dir: Path | str,
+    marker_id: str,
+    *,
+    closed_at: datetime | None = None,
+) -> ProjectionRepairMarker | None:
+    current_time = closed_at or _utc_now()
+    markers = {marker.marker_id: marker for marker in list_projection_repair_markers(vault_dir)}
+    if marker_id not in markers:
+        return None
+    _append_event(
+        vault_dir,
+        {
+            "event_type": "projection_repair_marker_closed",
+            "marker_id": marker_id,
+            "closed_at": _format_dt(current_time),
+            "timestamp": _format_dt(current_time),
+        },
+    )
+    return {item.marker_id: item for item in list_projection_repair_markers(vault_dir)}[marker_id]
+
+
+def ensure_projection_schema_current(
+    vault_dir: Path | str,
+    *,
+    projection_kind: str,
+    current_authority_schema_version: int,
+    projection_schema_version: int,
+    caused_by: str,
+    now: datetime | None = None,
+) -> ProjectionRepairMarker | None:
+    if int(current_authority_schema_version) <= int(projection_schema_version):
+        return None
+    return write_projection_repair_marker(
+        vault_dir,
+        kind="full_rebuild",
+        scope={"projection_kind": projection_kind},
+        reason="authority_schema_version_newer_than_projection",
+        caused_by=caused_by,
+        authority_schema_version=int(current_authority_schema_version),
+        projection_schema_version=int(projection_schema_version),
+        created_at=now,
+    )

--- a/tests/test_knowledge_index.py
+++ b/tests/test_knowledge_index.py
@@ -897,6 +897,76 @@ def test_knowledge_db_supports_pack_schema_requires_timeline_events(tmp_path):
     assert _knowledge_db_supports_pack_schema(db_path) is False
 
 
+def test_ensure_knowledge_db_current_records_projection_rebuild_marker_for_legacy_schema(temp_vault):
+    from ovp_pipeline.knowledge_index import ensure_knowledge_db_current
+    from ovp_pipeline.projection_lifecycle import list_projection_repair_markers
+    from ovp_pipeline.runtime import VaultLayout
+
+    note = temp_vault / "10-Knowledge" / "Evergreen" / "Agent-Harness.md"
+    note.write_text(
+        """---
+note_id: agent-harness
+title: Agent Harness
+type: evergreen
+date: 2026-04-07
+---
+
+# Agent Harness
+""",
+        encoding="utf-8",
+    )
+    layout = VaultLayout.from_vault(temp_vault)
+    layout.knowledge_db.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(layout.knowledge_db) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE objects (object_id TEXT PRIMARY KEY, title TEXT);
+            """
+        )
+
+    ensure_knowledge_db_current(temp_vault)
+
+    markers = list_projection_repair_markers(temp_vault)
+    assert len(markers) == 1
+    assert markers[0].kind == "full_rebuild"
+    assert markers[0].scope == {"projection_kind": "knowledge_db"}
+    assert markers[0].reason == "knowledge_db_schema_incompatible"
+    assert markers[0].status == "closed"
+    assert layout.knowledge_db.exists()
+
+
+def test_ensure_knowledge_db_current_records_projection_rebuild_marker_for_missing_db(temp_vault):
+    from ovp_pipeline.knowledge_index import ensure_knowledge_db_current
+    from ovp_pipeline.projection_lifecycle import list_projection_repair_markers
+    from ovp_pipeline.runtime import VaultLayout
+
+    note = temp_vault / "10-Knowledge" / "Evergreen" / "Agent-Harness.md"
+    note.write_text(
+        """---
+note_id: agent-harness
+title: Agent Harness
+type: evergreen
+date: 2026-04-07
+---
+
+# Agent Harness
+""",
+        encoding="utf-8",
+    )
+    layout = VaultLayout.from_vault(temp_vault)
+    assert not layout.knowledge_db.exists()
+
+    ensure_knowledge_db_current(temp_vault)
+
+    markers = list_projection_repair_markers(temp_vault)
+    assert len(markers) == 1
+    assert markers[0].kind == "full_rebuild"
+    assert markers[0].scope == {"projection_kind": "knowledge_db"}
+    assert markers[0].reason == "knowledge_db_missing"
+    assert markers[0].status == "closed"
+    assert layout.knowledge_db.exists()
+
+
 def test_recent_audit_events_returns_newest_rows_first(temp_vault):
     from ovp_pipeline.knowledge_index import rebuild_knowledge_index, recent_audit_events
     from ovp_pipeline.runtime import VaultLayout

--- a/tests/test_projection_lifecycle.py
+++ b/tests/test_projection_lifecycle.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+def test_projection_repair_marker_supersedes_narrower_open_marker(temp_vault):
+    from ovp_pipeline.projection_lifecycle import (
+        list_projection_repair_markers,
+        write_projection_repair_marker,
+    )
+
+    first = write_projection_repair_marker(
+        temp_vault,
+        kind="metadata_only",
+        scope={"projection_kind": "knowledge_db", "object_ids": ["alpha"]},
+        reason="missing evidence span columns",
+        caused_by="doctor_check",
+        authority_schema_version=1,
+        projection_schema_version=1,
+        created_at=datetime(2026, 4, 30, 12, 0, tzinfo=timezone.utc),
+    )
+    second = write_projection_repair_marker(
+        temp_vault,
+        kind="full_rebuild",
+        scope={"projection_kind": "knowledge_db"},
+        reason="schema incompatible",
+        caused_by="schema_check",
+        authority_schema_version=2,
+        projection_schema_version=1,
+        created_at=datetime(2026, 4, 30, 12, 1, tzinfo=timezone.utc),
+    )
+
+    markers = list_projection_repair_markers(temp_vault)
+
+    assert [marker.marker_id for marker in markers] == [first.marker_id, second.marker_id]
+    assert markers[0].superseded_by == second.marker_id
+    assert markers[0].status == "superseded"
+    assert markers[1].status == "open"
+    assert markers[1].kind == "full_rebuild"
+
+
+def test_projection_repair_marker_claim_uses_expiring_lease(temp_vault):
+    from ovp_pipeline.projection_lifecycle import (
+        claim_projection_repair_marker,
+        list_projection_repair_markers,
+        write_projection_repair_marker,
+    )
+
+    marker = write_projection_repair_marker(
+        temp_vault,
+        kind="full_rebuild",
+        scope={"projection_kind": "knowledge_db"},
+        reason="knowledge db missing",
+        caused_by="startup_check",
+        authority_schema_version=1,
+        projection_schema_version=0,
+        created_at=datetime(2026, 4, 30, 12, 0, tzinfo=timezone.utc),
+    )
+
+    claimed = claim_projection_repair_marker(
+        temp_vault,
+        marker.marker_id,
+        worker_id="worker-a",
+        lease_seconds=60,
+        now=datetime(2026, 4, 30, 12, 1, tzinfo=timezone.utc),
+    )
+    blocked = claim_projection_repair_marker(
+        temp_vault,
+        marker.marker_id,
+        worker_id="worker-b",
+        lease_seconds=60,
+        now=datetime(2026, 4, 30, 12, 1, 30, tzinfo=timezone.utc),
+    )
+    reclaimed = claim_projection_repair_marker(
+        temp_vault,
+        marker.marker_id,
+        worker_id="worker-b",
+        lease_seconds=60,
+        now=datetime(2026, 4, 30, 12, 2, 1, tzinfo=timezone.utc),
+    )
+
+    assert claimed is not None
+    assert blocked is None
+    assert reclaimed is not None
+    [current] = list_projection_repair_markers(temp_vault)
+    assert current.claimed_by == "worker-b"
+    assert current.claim_lease_until == datetime(2026, 4, 30, 12, 3, 1, tzinfo=timezone.utc)
+
+
+def test_projection_schema_mismatch_writes_full_rebuild_marker(temp_vault):
+    from ovp_pipeline.projection_lifecycle import (
+        ensure_projection_schema_current,
+        list_projection_repair_markers,
+    )
+
+    marker = ensure_projection_schema_current(
+        temp_vault,
+        projection_kind="knowledge_db",
+        current_authority_schema_version=3,
+        projection_schema_version=2,
+        caused_by="startup_check",
+        now=datetime(2026, 4, 30, 12, 0, tzinfo=timezone.utc),
+    )
+
+    assert marker is not None
+    assert marker.kind == "full_rebuild"
+    assert marker.reason == "authority_schema_version_newer_than_projection"
+    assert marker.scope == {"projection_kind": "knowledge_db"}
+    assert marker.authority_schema_version == 3
+    assert marker.projection_schema_version == 2
+    assert list_projection_repair_markers(temp_vault)[0].marker_id == marker.marker_id
+
+
+def test_projection_schema_match_does_not_write_marker(temp_vault):
+    from ovp_pipeline.projection_lifecycle import (
+        ensure_projection_schema_current,
+        list_projection_repair_markers,
+    )
+
+    marker = ensure_projection_schema_current(
+        temp_vault,
+        projection_kind="knowledge_db",
+        current_authority_schema_version=2,
+        projection_schema_version=2,
+        caused_by="startup_check",
+        now=datetime(2026, 4, 30, 12, 0, tzinfo=timezone.utc),
+    )
+
+    assert marker is None
+    assert list_projection_repair_markers(temp_vault) == []


### PR DESCRIPTION
## Summary
- add structured projection repair markers with event replay, supersession, claim leases, close events, and schema-mismatch marker creation
- record and close full-rebuild markers when ensure_knowledge_db_current rebuilds a missing or incompatible knowledge.db
- merge the new KSR-030..033 research into BACKLOG and update README/MILESTONE/ARCHITECTURE in English and Chinese

## Tests
- PYTHONPATH=src python -m pytest tests/test_projection_lifecycle.py tests/test_knowledge_index.py -q
- python -m ruff check src/ovp_pipeline/projection_lifecycle.py src/ovp_pipeline/knowledge_index.py tests/test_projection_lifecycle.py tests/test_knowledge_index.py
- PYTHONPATH=src python -m pytest -q
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/87" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
