### PR TITLE
feat: persist projection schema metadata

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -438,7 +438,9 @@ Current implementation:
 - `projection_lifecycle.py` records projection repair marker events in `60-Logs/projection-repair.jsonl`.
 - The marker event log is append-oriented and reconstructs current marker state from `written`, `superseded`, `claimed`, and `closed` events.
 - `ensure_knowledge_db_current()` writes and closes a `full_rebuild` marker when `knowledge.db` is missing or has an incompatible legacy schema.
-- The broader Authority/projection schema metadata contract is still partial: current code has a schema constant and rebuild triggers, but does not yet persist `.ovp/schema_version` or projection metadata inside `knowledge.db`.
+- `.ovp/schema_version` persists the Authority schema version for the vault.
+- `knowledge.db.projection_metadata` records the Authority schema version and projection schema version used to build the derived store.
+- `ensure_knowledge_db_current()` compares those versions and writes a `full_rebuild` marker when Authority or projection schema metadata is newer than the current derived store.
 
 ## 12. Canonical Scenarios
 
@@ -609,9 +611,9 @@ Authority and derived projection schemas evolve separately.
 
 Rules:
 
-- Authority schema version should live at vault root, for example `.ovp/schema_version`.
-- Derived stores must record which Authority schema version they were built from.
-- Derived projection schemas must record their own version.
+- Authority schema version lives at vault root in `.ovp/schema_version`.
+- Derived stores record which Authority schema version they were built from.
+- Derived projection schemas record their own version; `knowledge.db` stores this in `projection_metadata`.
 - Startup checks compare current Authority version, projection schema version, and marker versions.
 - If current Authority schema version is newer than the marker or projection version, write or promote to `ProjectionRepairMarker(kind="full_rebuild")`.
 - Avoid silent version jumps; migrations should be explicit and monotonic.
@@ -674,7 +676,7 @@ Main gaps:
 - Layer 2 / Layer 3 projection labels now exist on core access payloads and materialized reader artifacts; doctor/export enforcement and future surfaces still need to consume them consistently.
 - Layer 4 fitness checks now cover the first hot-path, workflow-wiring, source routing preview, evidence span backfill, and candidate risk cases; deeper evidence completeness, projection replay, and import-boundary checks are still open.
 - Projection lifecycle markers now have structured schema, scope, lease, supersession, and `knowledge.db` rebuild integration.
-- Schema versioning is partially wired into projection lifecycle for rebuild markers; persistent Authority/projection version metadata is still open.
+- Schema versioning is wired into projection lifecycle for `knowledge.db`: Authority and projection versions are persisted and stale metadata triggers a full rebuild marker.
 - The reader-first home is now the default entry; object pages have reader profiles, source rails, and kind-specific reader lenses; `/graph` has a first spatial map projection; `/search` groups reader results by kind, summary, evidence count, and match reason.
 
 ## 18. Near-Term Architecture Actions
@@ -682,10 +684,10 @@ Main gaps:
 Recommended order:
 
 1. Keep projection metadata attached to new access surfaces and add doctor/export checks that verify the labels are present.
-2. Finish the remaining schema-version metadata contract now that the first rebuild-marker trigger is wired.
-3. Add stricter factual evidence completeness checks before expanding automatic promotion.
-4. Add schema version fields to Authority and derived projection state.
-5. Expand doctor/export checks to verify projection marker replay and projection labels together.
+2. Add stricter factual evidence completeness checks before expanding automatic promotion.
+3. Expand doctor/export checks to verify projection marker replay and projection labels together.
+4. Move trusted reuse events into the reader/context-pack loop.
+5. Keep future projection backends on the same metadata contract before adding semantic reindex workers.
 
 ## Appendix: Backlog Mapping
 
@@ -702,4 +704,4 @@ The architecture should not depend on backlog IDs to be valid. The table below i
 | Reader-first access surfaces | `BL-001`; `BL-008` and `BL-009` done through PR #79 and PR #83; `BL-010` done in PR #80 |
 | Reader-oriented search | `BL-011` done in PR #84 |
 | Projection repair lifecycle | `BL-020` done in PR #87 |
-| Schema versioning and migration trigger | `BL-021` partial in PR #87 |
+| Schema versioning and migration trigger | `BL-021` done in PR #87 plus PR #88 |

--- a/ARCHITECTURE.zh-CN.md
+++ b/ARCHITECTURE.zh-CN.md
@@ -538,7 +538,9 @@ Operational rules:
 - `projection_lifecycle.py` 将 projection repair marker events 记录在 `60-Logs/projection-repair.jsonl`。
 - marker event log 通过 `written`、`superseded`、`claimed`、`closed` events replay 出当前 marker state。
 - `ensure_knowledge_db_current()` 在 `knowledge.db` 缺失或 legacy schema 不兼容时，会写入并关闭一个 `full_rebuild` marker。
-- 更完整的 Authority/projection schema metadata contract 仍是 partial：当前代码有 schema constant 和 rebuild trigger，但还没有持久化 `.ovp/schema_version` 或 `knowledge.db` 内部 projection metadata。
+- `.ovp/schema_version` 持久化当前 vault 的 Authority schema version。
+- `knowledge.db.projection_metadata` 记录 derived store 是由哪个 Authority schema version 和 projection schema version 构建出来的。
+- `ensure_knowledge_db_current()` 会比较这些 version；当 Authority 或 projection schema metadata 新于当前 derived store 时，写入 `full_rebuild` marker 并重建。
 
 ## 11. Canonical Scenarios
 
@@ -708,8 +710,8 @@ Layer 1 schema and Layer 2 projection schema will evolve. This must be explicit.
 
 Suggested rules:
 
-- Authority schema version should be recorded near the vault root, for example `.ovp/schema_version`.
-- Projection schema version should be recorded inside `knowledge.db` metadata.
+- Authority schema version 记录在 vault root 的 `.ovp/schema_version`。
+- Projection schema version 记录在 `knowledge.db` 的 `projection_metadata`。
 - Every derived projection should record which Authority schema version and projection schema version it was built from.
 - Startup/doctor checks compare current versions against projection versions.
 - If current Authority schema version is newer than the marker or projection version, write or promote to `ProjectionRepairMarker(kind="full_rebuild")`.
@@ -781,7 +783,7 @@ Do not rely on ad hoc "just rerun the pipeline" behavior for schema changes.
 - dashboard/search hot path、workflow wiring、source routing preview、evidence span backfill 和 candidate risk 已经有第一批 fitness checks；更深的 evidence completeness、projection replay、import-boundary checks 仍未完成。
 - context assembly recipes 还需要收束。
 - governance / resolver contracts 还需要显式化。
-- schema versioning 已经有第一版 rebuild marker trigger；Authority/projection version metadata 持久化仍需工程化。
+- schema versioning 已接入 `knowledge.db` projection lifecycle：Authority/projection version metadata 已持久化，stale metadata 会触发 full rebuild marker。
 - fitness functions 只落地了第一批，仍需扩展到 CI/doctor/pre-commit 的完整契约。
 - reader-first home 已经成为默认入口；object page 已有 reader profile、source rail 和按 kind 区分的 reader lens；`/graph` 已有第一版 spatial map projection；`/search` 已按 kind、summary、evidence count、match reason 组织 reader results。
 
@@ -792,10 +794,10 @@ Do not rely on ad hoc "just rerun the pipeline" behavior for schema changes.
 优先顺序：
 
 1. 新增 access surface 时必须继续带 projection metadata，并补 doctor/export checks 验证标注存在。
-2. 第一版 rebuild-marker trigger 已接上，下一步补完 schema-version metadata contract。
-3. 在扩大自动 promotion 前，补更严格的 factual evidence completeness checks。
-4. 给 Authority 和 derived projection state 增加 schema version 字段。
-5. 扩展 doctor/export checks，同时验证 projection marker replay 和 projection labels。
+2. 在扩大自动 promotion 前，补更严格的 factual evidence completeness checks。
+3. 扩展 doctor/export checks，同时验证 projection marker replay 和 projection labels。
+4. 把 trusted reuse events 接进 reader/context-pack loop。
+5. 未来新增 projection backend 前，先沿用同一套 metadata contract，再加 semantic reindex worker。
 6. 把 routing、promotion、review、permission 从 prompt/散落代码中收束为显式 governance/dispatch contract。
 7. 预留 semantic_reindex lifecycle kind，但不提前锁定 LanceDB 或其它 backend。
 
@@ -814,7 +816,7 @@ Do not rely on ad hoc "just rerun the pipeline" behavior for schema changes.
 | Reader-first access surfaces | `BL-001`；`BL-008`、`BL-009` 已通过 PR #79 和 PR #83 交付；`BL-010` 已在 PR #80 交付 |
 | Reader-oriented search | `BL-011` 已在 PR #84 交付 |
 | Projection repair lifecycle | `BL-020` 已在 PR #87 落地 |
-| Schema versioning and migration trigger | `BL-021` 已在 PR #87 落地第一片 |
+| Schema versioning and migration trigger | `BL-021` 已在 PR #87 和 PR #88 中补完 |
 
 ## Bottom Line
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -52,7 +52,7 @@ Rule: historical plans and vault research notes feed this file; they do not over
 | BL-018 | P2 | Later | Reviewed semantic relation extractor and query feedback loop | M7, April 22 roadmap |
 | BL-019 | P2 | Later | Skill/routine extraction profile, notebook/raw-source mode, ingest ROI, hybrid retrieval, multimodal caption-first ingest, follow-up object model | M7, KSR-010, KSR-011, KSR-012, KSR-016, KSR-019, KSR-029 |
 | BL-020 | P1 | Done | Projection repair lifecycle: structured marker kind/scope/reason, supersession, claim lease, and repair audit events | M4/M5, Architecture, PR #87 |
-| BL-021 | P1 | Partial | Authority/projection schema versioning and migration-triggered full rebuild markers | M4/M5, Architecture, PR #87 |
+| BL-021 | P1 | Done | Authority/projection schema versioning and migration-triggered full rebuild markers | M4/M5, Architecture, PR #87 + PR #88 |
 | BL-022 | P1 | Later | Decision context memory: first-class rationale, rejected alternatives, dissent, owner, participants, and validity windows for high-value decisions | M6/M7, KSR-030, Company Brain research |
 | BL-023 | P1 | Later | Agent workspace substrate and information-health loop: expose AGENTS/MEMORY/Skills/Heartbeat/autonomy policy as runtime state and run approval-based stale/conflict/term-drift reviews | M6/M7, KSR-031, KSR-032, Moxt research |
 | BL-024 | P1 | Later | Machine-facing memory substrate: typed scored memory records with freshness, evidence count, supersession, last-used telemetry, and token-budgeted selective injection | M6/M7, KSR-033, Mercury research |
@@ -97,12 +97,12 @@ Rule: historical plans and vault research notes feed this file; they do not over
 
 ## Next Decision
 
-`BL-001` is shipped in PR #75, `BL-003 + BL-004` are shipped in PR #77, `BL-002` is shipped in PR #78, `BL-009` plus the first `BL-008` slice are shipped in PR #79, `BL-010` is shipped in PR #80, `BL-005` is shipped in PR #81, `BL-006 + BL-007` are implemented in PR #82, `BL-008` is completed in PR #83, `BL-011` is completed in PR #84, and the first `BL-020 / BL-021` slice is in PR #87. The default UI now has a reader-first entry point, `/ops` owns the operator dashboard, core access/materialized surfaces carry explicit projection labels, object pages expose readable source/backlink rails and kind-specific reader lenses, `/graph` renders a reader-facing spatial map over graph projections, `/search` groups reader results by kind with summaries, evidence counts, and match reasons, `ovp-absorb --dry-run --json` explains source lifecycle routing before mutation, evidence rows carry line/char spans, candidate review payloads expose risk tiers, and `knowledge.db` rebuilds now leave structured projection repair markers.
+`BL-001` is shipped in PR #75, `BL-003 + BL-004` are shipped in PR #77, `BL-002` is shipped in PR #78, `BL-009` plus the first `BL-008` slice are shipped in PR #79, `BL-010` is shipped in PR #80, `BL-005` is shipped in PR #81, `BL-006 + BL-007` are implemented in PR #82, `BL-008` is completed in PR #83, `BL-011` is completed in PR #84, the first `BL-020 / BL-021` slice is in PR #87, and BL-021 schema metadata is in PR #88. The default UI now has a reader-first entry point, `/ops` owns the operator dashboard, core access/materialized surfaces carry explicit projection labels, object pages expose readable source/backlink rails and kind-specific reader lenses, `/graph` renders a reader-facing spatial map over graph projections, `/search` groups reader results by kind with summaries, evidence counts, and match reasons, `ovp-absorb --dry-run --json` explains source lifecycle routing before mutation, evidence rows carry line/char spans, candidate review payloads expose risk tiers, and `knowledge.db` rebuilds now leave structured projection repair markers tied to persisted Authority/projection schema metadata.
 
-The next implementation PR should finish the remaining **BL-021** schema/version metadata contract and then move into trusted reuse and context-pack loops.
+The next implementation PR should move into trusted reuse and context-pack loops.
 
 Recommended order:
 
-1. BL-021 completion: persist Authority/projection schema versions and migration metadata beyond the current marker trigger
-2. BL-012 / BL-013 trusted reuse events and context-pack loops
-3. BL-014 when operational runtime observability becomes the next bottleneck
+1. BL-012 / BL-013 trusted reuse events and context-pack loops
+2. BL-014 when operational runtime observability becomes the next bottleneck
+3. BL-015 when permission and claim lifecycle become the active blocker

--- a/MILESTONE.md
+++ b/MILESTONE.md
@@ -54,15 +54,15 @@ That means the user-facing product should make compiled knowledge easy to read f
 | Visual graph MVP | `BL-010` done in PR #80 |
 | Reader-oriented search | `BL-011` done in PR #84 |
 | Projection repair lifecycle | `BL-020` done in PR #87 |
-| Schema versioning and migration trigger | `BL-021` partial in PR #87 |
+| Schema versioning and migration trigger | `BL-021` done in PR #87 plus PR #88 |
 
 ## Near-Term Sequence
 
 Recommended order:
 
-1. Finish the remaining `BL-021` schema/version metadata contract beyond the current rebuild marker trigger.
-2. Move into `BL-012 + BL-013` once the reader surfaces need stronger reuse and context-pack loops.
-3. Pick up `BL-014` when operational runtime observability becomes the next bottleneck.
+1. Move into `BL-012 + BL-013` once the reader surfaces need stronger reuse and context-pack loops.
+2. Pick up `BL-014` when operational runtime observability becomes the next bottleneck.
+3. Pick up `BL-015` when permission and claim lifecycle become the active blocker.
 
 ## Documentation Rules
 

--- a/MILESTONE.zh-CN.md
+++ b/MILESTONE.zh-CN.md
@@ -54,15 +54,15 @@ OVP 正在从 document-processing pipeline 变成：
 | Visual graph MVP | `BL-010` 已在 PR #80 交付 |
 | Reader-oriented search | `BL-011` 已在 PR #84 交付 |
 | Projection repair lifecycle | `BL-020` 已在 PR #87 落地 |
-| Schema versioning and migration trigger | `BL-021` 已在 PR #87 落地第一片 |
+| Schema versioning and migration trigger | `BL-021` 已在 PR #87 和 PR #88 中补完 |
 
 ## 近期顺序
 
 建议顺序：
 
-1. 补完 `BL-021` 剩余的 schema/version metadata contract，不只停留在当前 rebuild marker trigger。
-2. 当 reader surface 需要更强的复用和 context-pack 闭环时，再进入 `BL-012 + BL-013`。
-3. 当 operational runtime observability 成为下一个瓶颈时，再进入 `BL-014`。
+1. 当 reader surface 需要更强的复用和 context-pack 闭环时，进入 `BL-012 + BL-013`。
+2. 当 operational runtime observability 成为下一个瓶颈时，再进入 `BL-014`。
+3. 当 permission 和 claim lifecycle 成为主动瓶颈时，再进入 `BL-015`。
 
 ## 文档规则
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Current active backlog focus:
 
 - Shipped: `KSR-001` evidence spans, `KSR-002` projection labels, `KSR-003` candidate risk tiers, `KSR-014` article routing preview, `KSR-015` dashboard/search hot-path audit, `KSR-018` markdown-aware evidence span backfill, `KSR-026` workflow wiring eval suite, and the first structured projection repair marker lifecycle.
 - Product shipped: readable object page profiles, source/backlink rail, kind-specific reader lenses, visual `/graph` map, and reader-oriented search grouped by kind, evidence, and reason.
-- Next: finish the schema/version metadata contract, then move into trusted reuse events and context-pack loops.
+- Next: trusted reuse events and context-pack loops.
 - Product track: reader-first Knowledge Atlas stays a projection layer, not a new state system.
 
 ## Domain Packs

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -102,7 +102,7 @@ Obsidian Vault Pipeline（OVP）不是一个“多脚本拼装包”，也不只
 
 - 已交付：`KSR-001` Evidence span 化、`KSR-002` Projection 标注、`KSR-003` Candidate 风险分层、`KSR-014` Article routing preview、`KSR-015` Dashboard/search hot-path audit、`KSR-018` Markdown-aware evidence span backfill、`KSR-026` Workflow wiring eval suite，以及第一版结构化 projection repair marker lifecycle。
 - 产品侧已交付：readable object page profile、source/backlink rail、按 kind 区分的 reader lens、visual `/graph` map，以及按 kind、evidence、reason 组织的 reader-oriented search。
-- 下一步：补完 schema/version metadata contract，然后进入 trusted reuse event 和 context-pack loop。
+- 下一步：trusted reuse event 和 context-pack loop。
 - 产品线：Reader-first Knowledge Atlas 作为 projection layer 实现，不另建状态系统。
 
 ## Domain Packs

--- a/src/ovp_pipeline/knowledge_index.py
+++ b/src/ovp_pipeline/knowledge_index.py
@@ -25,6 +25,8 @@ from .truth_store import TRUTH_STORE_SCHEMA
 SUMMARY_MAX_LEN = 320
 SUMMARY_RELATED_LIMIT = 3
 AUTHORITY_SCHEMA_VERSION = 1
+KNOWLEDGE_DB_PROJECTION_KIND = "knowledge_db"
+KNOWLEDGE_DB_PROJECTION_SCHEMA_VERSION = 1
 
 
 _FTS_QUERY_SCRUB = re.compile(r"[^\w\u4e00-\u9fff]+", flags=re.UNICODE)
@@ -125,6 +127,13 @@ CREATE TABLE page_metrics (
 );
 
 CREATE INDEX idx_page_metrics_last_seen ON page_metrics(last_seen_ts);
+
+CREATE TABLE projection_metadata (
+  projection_kind TEXT PRIMARY KEY,
+  authority_schema_version INTEGER NOT NULL,
+  projection_schema_version INTEGER NOT NULL,
+  built_at TEXT NOT NULL
+);
 """
 
 SCHEMA += "\n" + TRUTH_STORE_SCHEMA
@@ -205,6 +214,43 @@ def _truth_pack_name(pack_name: str | None = None) -> str:
 
 def _utc_now_text() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _authority_schema_version_path(vault_dir: Path | str) -> Path:
+    return resolve_vault_dir(vault_dir) / ".ovp" / "schema_version"
+
+
+def _ensure_authority_schema_version(vault_dir: Path | str) -> int:
+    path = _authority_schema_version_path(vault_dir)
+    if not path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(f"{AUTHORITY_SCHEMA_VERSION}\n", encoding="utf-8")
+        return AUTHORITY_SCHEMA_VERSION
+    try:
+        return int(path.read_text(encoding="utf-8").strip() or "0")
+    except ValueError:
+        path.write_text(f"{AUTHORITY_SCHEMA_VERSION}\n", encoding="utf-8")
+        return AUTHORITY_SCHEMA_VERSION
+
+
+def _read_knowledge_db_projection_metadata(db_path: Path) -> tuple[int, int] | None:
+    if not db_path.exists():
+        return None
+    try:
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                """
+                SELECT authority_schema_version, projection_schema_version
+                FROM projection_metadata
+                WHERE projection_kind = ?
+                """,
+                (KNOWLEDGE_DB_PROJECTION_KIND,),
+            ).fetchone()
+    except sqlite3.DatabaseError:
+        return None
+    if row is None:
+        return None
+    return int(row[0] or 0), int(row[1] or 0)
 
 
 def _projection_metadata(pack_name: str) -> tuple[str, str]:
@@ -530,21 +576,33 @@ def _initialize_database(db_path: Path) -> sqlite3.Connection:
 def _ensure_knowledge_db(vault_dir: Path) -> tuple[Path, VaultLayout]:
     resolved_vault = resolve_vault_dir(vault_dir)
     layout = VaultLayout.from_vault(resolved_vault)
+    authority_schema_version = _ensure_authority_schema_version(resolved_vault)
     rebuild_reason = ""
+    projection_schema_version = 0
     if not layout.knowledge_db.exists():
         rebuild_reason = "knowledge_db_missing"
     elif not _knowledge_db_supports_pack_schema(layout.knowledge_db):
         rebuild_reason = "knowledge_db_schema_incompatible"
+    else:
+        projection_metadata = _read_knowledge_db_projection_metadata(layout.knowledge_db)
+        if projection_metadata is None:
+            rebuild_reason = "knowledge_db_projection_metadata_missing"
+        else:
+            built_authority_schema_version, projection_schema_version = projection_metadata
+            if authority_schema_version > built_authority_schema_version:
+                rebuild_reason = "authority_schema_version_newer_than_projection"
+            elif KNOWLEDGE_DB_PROJECTION_SCHEMA_VERSION > projection_schema_version:
+                rebuild_reason = "projection_schema_version_newer_than_metadata"
 
     if rebuild_reason:
         marker = write_projection_repair_marker(
             resolved_vault,
             kind="full_rebuild",
-            scope={"projection_kind": "knowledge_db"},
+            scope={"projection_kind": KNOWLEDGE_DB_PROJECTION_KIND},
             reason=rebuild_reason,
             caused_by="ensure_knowledge_db_current",
-            authority_schema_version=AUTHORITY_SCHEMA_VERSION,
-            projection_schema_version=0,
+            authority_schema_version=authority_schema_version,
+            projection_schema_version=projection_schema_version,
         )
         rebuild_knowledge_index(resolved_vault)
         close_projection_repair_marker(resolved_vault, marker.marker_id)
@@ -588,6 +646,12 @@ def _knowledge_db_supports_pack_schema(db_path: Path) -> bool:
         "truth_projections": {"pack", "owner_pack", "builder_name", "built_at"},
         "reuse_events": {"event_id", "ts", "pack", "surface", "trusted"},
         "page_metrics": {"slug", "last_seen_ts", "reuse_count", "citation_count"},
+        "projection_metadata": {
+            "projection_kind",
+            "authority_schema_version",
+            "projection_schema_version",
+            "built_at",
+        },
     }
     try:
         with sqlite3.connect(db_path) as conn:
@@ -658,6 +722,7 @@ def rebuild_knowledge_index(
     resolved_vault = resolve_vault_dir(vault_dir)
     layout = VaultLayout.from_vault(resolved_vault)
     truth_pack = _truth_pack_name(pack_name)
+    authority_schema_version = _ensure_authority_schema_version(resolved_vault)
     with knowledge_db_write_lock(resolved_vault):
         evergreen_dir = layout.evergreen_dir
         atlas_dir = layout.atlas_dir
@@ -874,6 +939,23 @@ def rebuild_knowledge_index(
                     truth_pack,
                     projection_spec.pack,
                     getattr(projection_spec, "name", ""),
+                    _utc_now_text(),
+                ),
+            )
+            conn.execute(
+                """
+                INSERT INTO projection_metadata (
+                    projection_kind,
+                    authority_schema_version,
+                    projection_schema_version,
+                    built_at
+                )
+                VALUES (?, ?, ?, ?)
+                """,
+                (
+                    KNOWLEDGE_DB_PROJECTION_KIND,
+                    authority_schema_version,
+                    KNOWLEDGE_DB_PROJECTION_SCHEMA_VERSION,
                     _utc_now_text(),
                 ),
             )

--- a/tests/test_knowledge_index.py
+++ b/tests/test_knowledge_index.py
@@ -967,6 +967,135 @@ date: 2026-04-07
     assert layout.knowledge_db.exists()
 
 
+def test_ensure_knowledge_db_current_persists_schema_version_metadata(temp_vault):
+    from ovp_pipeline.knowledge_index import ensure_knowledge_db_current
+    from ovp_pipeline.runtime import VaultLayout
+
+    note = temp_vault / "10-Knowledge" / "Evergreen" / "Agent-Harness.md"
+    note.write_text(
+        """---
+note_id: agent-harness
+title: Agent Harness
+type: evergreen
+date: 2026-04-07
+---
+
+# Agent Harness
+""",
+        encoding="utf-8",
+    )
+
+    layout = VaultLayout.from_vault(temp_vault)
+    ensure_knowledge_db_current(temp_vault)
+
+    assert (temp_vault / ".ovp" / "schema_version").read_text(encoding="utf-8") == "1\n"
+    with sqlite3.connect(layout.knowledge_db) as conn:
+        row = conn.execute(
+            """
+            SELECT projection_kind, authority_schema_version, projection_schema_version, built_at
+            FROM projection_metadata
+            WHERE projection_kind = 'knowledge_db'
+            """
+        ).fetchone()
+
+    assert row[0] == "knowledge_db"
+    assert row[1] == 1
+    assert row[2] == 1
+    assert row[3]
+
+
+def test_ensure_knowledge_db_current_rebuilds_when_authority_schema_version_advances(temp_vault):
+    from ovp_pipeline.knowledge_index import ensure_knowledge_db_current
+    from ovp_pipeline.projection_lifecycle import list_projection_repair_markers
+    from ovp_pipeline.runtime import VaultLayout
+
+    note = temp_vault / "10-Knowledge" / "Evergreen" / "Agent-Harness.md"
+    note.write_text(
+        """---
+note_id: agent-harness
+title: Agent Harness
+type: evergreen
+date: 2026-04-07
+---
+
+# Agent Harness
+""",
+        encoding="utf-8",
+    )
+    layout = VaultLayout.from_vault(temp_vault)
+    ensure_knowledge_db_current(temp_vault)
+    (temp_vault / ".ovp" / "schema_version").write_text("2\n", encoding="utf-8")
+
+    ensure_knowledge_db_current(temp_vault)
+
+    markers = list_projection_repair_markers(temp_vault)
+    assert [marker.reason for marker in markers] == [
+        "knowledge_db_missing",
+        "authority_schema_version_newer_than_projection",
+    ]
+    assert markers[-1].authority_schema_version == 2
+    assert markers[-1].projection_schema_version == 1
+    assert markers[-1].status == "closed"
+    with sqlite3.connect(layout.knowledge_db) as conn:
+        row = conn.execute(
+            """
+            SELECT authority_schema_version, projection_schema_version
+            FROM projection_metadata
+            WHERE projection_kind = 'knowledge_db'
+            """
+        ).fetchone()
+    assert row == (2, 1)
+
+
+def test_ensure_knowledge_db_current_rebuilds_when_projection_schema_version_advances(temp_vault):
+    from ovp_pipeline.knowledge_index import ensure_knowledge_db_current
+    from ovp_pipeline.projection_lifecycle import list_projection_repair_markers
+    from ovp_pipeline.runtime import VaultLayout
+
+    note = temp_vault / "10-Knowledge" / "Evergreen" / "Agent-Harness.md"
+    note.write_text(
+        """---
+note_id: agent-harness
+title: Agent Harness
+type: evergreen
+date: 2026-04-07
+---
+
+# Agent Harness
+""",
+        encoding="utf-8",
+    )
+    layout = VaultLayout.from_vault(temp_vault)
+    ensure_knowledge_db_current(temp_vault)
+    with sqlite3.connect(layout.knowledge_db) as conn:
+        conn.execute(
+            """
+            UPDATE projection_metadata
+            SET projection_schema_version = 0
+            WHERE projection_kind = 'knowledge_db'
+            """
+        )
+
+    ensure_knowledge_db_current(temp_vault)
+
+    markers = list_projection_repair_markers(temp_vault)
+    assert [marker.reason for marker in markers] == [
+        "knowledge_db_missing",
+        "projection_schema_version_newer_than_metadata",
+    ]
+    assert markers[-1].projection_schema_version == 0
+    assert markers[-1].status == "closed"
+    with sqlite3.connect(layout.knowledge_db) as conn:
+        row = conn.execute(
+            """
+            SELECT authority_schema_version, projection_schema_version
+            FROM projection_metadata
+            WHERE projection_kind = 'knowledge_db'
+            """
+        ).fetchone()
+    assert row == (1, 1)
+
+
 def test_recent_audit_events_returns_newest_rows_first(temp_vault):
     from ovp_pipeline.knowledge_index import rebuild_knowledge_index, recent_audit_events
     from ovp_pipeline.runtime import VaultLayout


### PR DESCRIPTION
## Summary
- persist Authority schema metadata at .ovp/schema_version
- add knowledge.db projection_metadata with Authority/projection schema versions and built_at
- trigger structured full-rebuild markers when Authority or projection metadata is stale
- update backlog, milestone, README, and architecture docs for BL-021 completion

## Tests
- PYTHONPATH=src python -m pytest tests/test_knowledge_index.py tests/test_projection_lifecycle.py -q
- python -m ruff check src/ovp_pipeline/knowledge_index.py tests/test_knowledge_index.py
- PYTHONPATH=src python -m pytest -q
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/88" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
