### PR TITLE
feat: add working memory context budget

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -677,6 +677,7 @@ Main gaps:
 - Layer 4 fitness checks now cover the first hot-path, workflow-wiring, source routing preview, evidence span backfill, and candidate risk cases; deeper evidence completeness, projection replay, and import-boundary checks are still open.
 - Projection lifecycle markers now have structured schema, scope, lease, supersession, and `knowledge.db` rebuild integration.
 - Schema versioning is wired into projection lifecycle for `knowledge.db`: Authority and projection versions are persisted and stale metadata triggers a full rebuild marker.
+- Working memory is the first budgeted context-pack projection: it records context budget metadata and emits `working_memory` reuse events for selected canonical objects.
 - The reader-first home is now the default entry; object pages have reader profiles, source rails, and kind-specific reader lenses; `/graph` has a first spatial map projection; `/search` groups reader results by kind, summary, evidence count, and match reason.
 
 ## 18. Near-Term Architecture Actions
@@ -686,7 +687,7 @@ Recommended order:
 1. Keep projection metadata attached to new access surfaces and add doctor/export checks that verify the labels are present.
 2. Add stricter factual evidence completeness checks before expanding automatic promotion.
 3. Expand doctor/export checks to verify projection marker replay and projection labels together.
-4. Move trusted reuse events into the reader/context-pack loop.
+4. Continue the trusted reuse/context-pack loop with session snapshots and an OVP prime input.
 5. Keep future projection backends on the same metadata contract before adding semantic reindex workers.
 
 ## Appendix: Backlog Mapping
@@ -703,5 +704,6 @@ The architecture should not depend on backlog IDs to be valid. The table below i
 | Candidate risk layering | `BL-007`, `KSR-003` done in PR #82 |
 | Reader-first access surfaces | `BL-001`; `BL-008` and `BL-009` done through PR #79 and PR #83; `BL-010` done in PR #80 |
 | Reader-oriented search | `BL-011` done in PR #84 |
+| Trusted reuse / context-pack loop | `BL-012` and `BL-013` partial in PR #89 |
 | Projection repair lifecycle | `BL-020` done in PR #87 |
 | Schema versioning and migration trigger | `BL-021` done in PR #87 plus PR #88 |

--- a/ARCHITECTURE.zh-CN.md
+++ b/ARCHITECTURE.zh-CN.md
@@ -785,6 +785,7 @@ Do not rely on ad hoc "just rerun the pipeline" behavior for schema changes.
 - governance / resolver contracts 还需要显式化。
 - schema versioning 已接入 `knowledge.db` projection lifecycle：Authority/projection version metadata 已持久化，stale metadata 会触发 full rebuild marker。
 - fitness functions 只落地了第一批，仍需扩展到 CI/doctor/pre-commit 的完整契约。
+- working memory 是第一版带 budget 的 context-pack projection：会记录 context budget metadata，并为选入的 canonical objects 写入 `working_memory` reuse events。
 - reader-first home 已经成为默认入口；object page 已有 reader profile、source rail 和按 kind 区分的 reader lens；`/graph` 已有第一版 spatial map projection；`/search` 已按 kind、summary、evidence count、match reason 组织 reader results。
 
 ## 17. 近期架构动作
@@ -796,7 +797,7 @@ Do not rely on ad hoc "just rerun the pipeline" behavior for schema changes.
 1. 新增 access surface 时必须继续带 projection metadata，并补 doctor/export checks 验证标注存在。
 2. 在扩大自动 promotion 前，补更严格的 factual evidence completeness checks。
 3. 扩展 doctor/export checks，同时验证 projection marker replay 和 projection labels。
-4. 把 trusted reuse events 接进 reader/context-pack loop。
+4. 继续 trusted reuse/context-pack loop，补 session snapshot 和 OVP prime input。
 5. 未来新增 projection backend 前，先沿用同一套 metadata contract，再加 semantic reindex worker。
 6. 把 routing、promotion、review、permission 从 prompt/散落代码中收束为显式 governance/dispatch contract。
 7. 预留 semantic_reindex lifecycle kind，但不提前锁定 LanceDB 或其它 backend。
@@ -815,6 +816,7 @@ Do not rely on ad hoc "just rerun the pipeline" behavior for schema changes.
 | Candidate risk layering | `BL-007`, `KSR-003` 已在 PR #82 交付 |
 | Reader-first access surfaces | `BL-001`；`BL-008`、`BL-009` 已通过 PR #79 和 PR #83 交付；`BL-010` 已在 PR #80 交付 |
 | Reader-oriented search | `BL-011` 已在 PR #84 交付 |
+| Trusted reuse / context-pack loop | `BL-012`、`BL-013` 已在 PR #89 落地第一片 |
 | Projection repair lifecycle | `BL-020` 已在 PR #87 落地 |
 | Schema versioning and migration trigger | `BL-021` 已在 PR #87 和 PR #88 中补完 |
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -43,8 +43,8 @@ Rule: historical plans and vault research notes feed this file; they do not over
 | BL-009 | P1 | Done | Mention/backlink rail with excerpts, source jumps, and relation context | M3, reader-product note, PR #79 |
 | BL-010 | P1 | Done | Visual `/graph` MVP as a spatial corpus map; analytical clusters remain under `/clusters` for ops/debug | M3, PR #80 |
 | BL-011 | P1 | Done | Reader-oriented search grouped by kind, summary, evidence, and reason | M3/M4, PR #84 |
-| BL-012 | P1 | Later | Trusted reuse event instrumentation for downstream use of accepted/cited knowledge | April 22 roadmap |
-| BL-013 | P1 | Later | Session snapshot / OVP context pack / explicit context budget | M5, KSR-004, KSR-017, KSR-022 |
+| BL-012 | P1 | Partial | Trusted reuse event instrumentation for downstream use of accepted/cited knowledge | April 22 roadmap, PR #89 |
+| BL-013 | P1 | Partial | Session snapshot / OVP context pack / explicit context budget | M5, KSR-004, KSR-017, KSR-022, PR #89 |
 | BL-014 | P1 | Later | Operational runtime graph, claim lease, observability metrics, provider facade | M5, KSR-020, KSR-021, KSR-023, KSR-025 |
 | BL-015 | P1 | Later | Permission layer and claim lifecycle fields | M6, KSR-005, KSR-006 |
 | BL-016 | P2 | Later | Conflict detection regularization, high-risk profile gate, candidate compaction with restore | M6, KSR-007, KSR-008, KSR-024 |
@@ -64,7 +64,7 @@ Rule: historical plans and vault research notes feed this file; they do not over
 | KSR-001 Evidence span 化 | BL-006 | Done |
 | KSR-002 Projection 标注 | BL-002 | Done |
 | KSR-003 Candidate 风险分层 | BL-007 | Done |
-| KSR-004 Session snapshot/context pack | BL-013 | Later |
+| KSR-004 Session snapshot/context pack | BL-013 | Partial: working-memory context pack exists; session snapshot still open |
 | KSR-005 Permission layer 分离 | BL-015 | Later |
 | KSR-006 Claim lifecycle 字段 | BL-015 | Later |
 | KSR-007 Conflict detection 常规化 | BL-016 | Later |
@@ -77,12 +77,12 @@ Rule: historical plans and vault research notes feed this file; they do not over
 | KSR-014 Article routing preview | BL-005 | Done |
 | KSR-015 Dashboard/search hot-path audit | BL-003 | Done |
 | KSR-016 Hybrid retrieval experiment | BL-019 | Later |
-| KSR-017 Explicit context budget | BL-013 | Later |
+| KSR-017 Explicit context budget | BL-013 | Partial: working-memory context pack records budget, selected tokens, selected objects, and omitted objects |
 | KSR-018 Markdown-aware evidence chunking | BL-006 | Done |
 | KSR-019 Multimodal caption-first ingest | BL-019 | Later |
 | KSR-020 Operational runtime graph | BL-014 | Later |
 | KSR-021 Claim lease for workflow items | BL-014 | Later |
-| KSR-022 OVP prime/context pack | BL-013 | Later |
+| KSR-022 OVP prime/context pack | BL-013 | Partial: first working-memory context-pack loop exists; OVP prime remains open |
 | KSR-023 Pipeline observability metrics | BL-014 | Later |
 | KSR-024 Candidate compaction with restore | BL-016 | Later |
 | KSR-025 Context provider facade | BL-014 | Later |
@@ -99,10 +99,12 @@ Rule: historical plans and vault research notes feed this file; they do not over
 
 `BL-001` is shipped in PR #75, `BL-003 + BL-004` are shipped in PR #77, `BL-002` is shipped in PR #78, `BL-009` plus the first `BL-008` slice are shipped in PR #79, `BL-010` is shipped in PR #80, `BL-005` is shipped in PR #81, `BL-006 + BL-007` are implemented in PR #82, `BL-008` is completed in PR #83, `BL-011` is completed in PR #84, the first `BL-020 / BL-021` slice is in PR #87, and BL-021 schema metadata is in PR #88. The default UI now has a reader-first entry point, `/ops` owns the operator dashboard, core access/materialized surfaces carry explicit projection labels, object pages expose readable source/backlink rails and kind-specific reader lenses, `/graph` renders a reader-facing spatial map over graph projections, `/search` groups reader results by kind with summaries, evidence counts, and match reasons, `ovp-absorb --dry-run --json` explains source lifecycle routing before mutation, evidence rows carry line/char spans, candidate review payloads expose risk tiers, and `knowledge.db` rebuilds now leave structured projection repair markers tied to persisted Authority/projection schema metadata.
 
-The next implementation PR should move into trusted reuse and context-pack loops.
+The current context-budget PR starts the trusted reuse/context-pack loop by making `ovp-working-memory` emit explicit budget metadata and `working_memory` reuse events for selected canonical objects.
+
+The next implementation PR should continue BL-012 / BL-013 by turning this daily context pack into a reusable session snapshot / OVP prime input.
 
 Recommended order:
 
-1. BL-012 / BL-013 trusted reuse events and context-pack loops
+1. BL-012 / BL-013 continuation: session snapshot / OVP prime input over the budgeted working-memory context pack
 2. BL-014 when operational runtime observability becomes the next bottleneck
 3. BL-015 when permission and claim lifecycle become the active blocker

--- a/MILESTONE.md
+++ b/MILESTONE.md
@@ -60,7 +60,7 @@ That means the user-facing product should make compiled knowledge easy to read f
 
 Recommended order:
 
-1. Move into `BL-012 + BL-013` once the reader surfaces need stronger reuse and context-pack loops.
+1. Continue `BL-012 + BL-013`: session snapshot / OVP prime input over the budgeted working-memory context pack.
 2. Pick up `BL-014` when operational runtime observability becomes the next bottleneck.
 3. Pick up `BL-015` when permission and claim lifecycle become the active blocker.
 

--- a/MILESTONE.zh-CN.md
+++ b/MILESTONE.zh-CN.md
@@ -60,7 +60,7 @@ OVP 正在从 document-processing pipeline 变成：
 
 建议顺序：
 
-1. 当 reader surface 需要更强的复用和 context-pack 闭环时，进入 `BL-012 + BL-013`。
+1. 继续 `BL-012 + BL-013`：基于带 budget 的 working-memory context pack，补 session snapshot / OVP prime input。
 2. 当 operational runtime observability 成为下一个瓶颈时，再进入 `BL-014`。
 3. 当 permission 和 claim lifecycle 成为主动瓶颈时，再进入 `BL-015`。
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Current active backlog focus:
 
 - Shipped: `KSR-001` evidence spans, `KSR-002` projection labels, `KSR-003` candidate risk tiers, `KSR-014` article routing preview, `KSR-015` dashboard/search hot-path audit, `KSR-018` markdown-aware evidence span backfill, `KSR-026` workflow wiring eval suite, and the first structured projection repair marker lifecycle.
 - Product shipped: readable object page profiles, source/backlink rail, kind-specific reader lenses, visual `/graph` map, and reader-oriented search grouped by kind, evidence, and reason.
-- Next: trusted reuse events and context-pack loops.
+- Next: continue the trusted reuse/context-pack loop with session snapshots and an OVP prime input.
 - Product track: reader-first Knowledge Atlas stays a projection layer, not a new state system.
 
 ## Domain Packs

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -102,7 +102,7 @@ Obsidian Vault Pipeline（OVP）不是一个“多脚本拼装包”，也不只
 
 - 已交付：`KSR-001` Evidence span 化、`KSR-002` Projection 标注、`KSR-003` Candidate 风险分层、`KSR-014` Article routing preview、`KSR-015` Dashboard/search hot-path audit、`KSR-018` Markdown-aware evidence span backfill、`KSR-026` Workflow wiring eval suite，以及第一版结构化 projection repair marker lifecycle。
 - 产品侧已交付：readable object page profile、source/backlink rail、按 kind 区分的 reader lens、visual `/graph` map，以及按 kind、evidence、reason 组织的 reader-oriented search。
-- 下一步：trusted reuse event 和 context-pack loop。
+- 下一步：继续 trusted reuse/context-pack loop，补 session snapshot 和 OVP prime input。
 - 产品线：Reader-first Knowledge Atlas 作为 projection layer 实现，不另建状态系统。
 
 ## Domain Packs

--- a/src/ovp_pipeline/commands/working_memory.py
+++ b/src/ovp_pipeline/commands/working_memory.py
@@ -1,9 +1,9 @@
 """Phase 38 — Working Memory daily distill.
 
 Writes a single markdown file under ``60-Logs/working-memory/YYYY-MM-DD.md``
-that summarizes the state of the vault at a moment in time. Designed to be
-re-run cheaply (idempotent overwrite of today's file) so the autopilot daemon
-can call it once a day.
+that summarizes the state of the vault at a moment in time. The file itself is
+an idempotent overwrite; selected canonical objects also append reuse events so
+context-pack consumption remains auditable.
 
 Sections:
 
@@ -39,10 +39,14 @@ from pathlib import Path
 from typing import Any
 
 try:
+    from ..packs.loader import DEFAULT_WORKFLOW_PACK_NAME
     from ..projection_labels import frontmatter_projection_fields
+    from ..reuse_emitter import emit_reuse_events
     from ..runtime import VaultLayout, resolve_vault_dir
 except ImportError:
+    from ovp_pipeline.packs.loader import DEFAULT_WORKFLOW_PACK_NAME  # type: ignore
     from ovp_pipeline.projection_labels import frontmatter_projection_fields  # type: ignore
+    from ovp_pipeline.reuse_emitter import emit_reuse_events  # type: ignore
     from ovp_pipeline.runtime import VaultLayout, resolve_vault_dir  # type: ignore
 
 
@@ -50,6 +54,7 @@ WORKING_MEMORY_DIR = ("60-Logs", "working-memory")
 DEFAULT_TOP_N = 5
 DEFAULT_LOOKBACK_HOURS = 24
 DEFAULT_TOP_OF_MIND_LOOKBACK_DAYS = 7
+DEFAULT_CONTEXT_BUDGET_TOKENS = 1200
 
 
 def _parse_ts(value: object) -> datetime | None:
@@ -199,9 +204,47 @@ def _pulse_highlights(layout: VaultLayout, *, since: datetime) -> Counter:
     return counts
 
 
+def _estimate_tokens(text: str) -> int:
+    stripped = text.strip()
+    if not stripped:
+        return 0
+    return max(1, (len(stripped) + 3) // 4)
+
+
+def _top_of_mind_line(row: dict[str, Any]) -> str:
+    return (
+        f"- [[{row['slug']}]] — {row['citation_count']} citations, "
+        f"{row['reuse_count']} reuses"
+    )
+
+
+def _select_top_of_mind_for_budget(
+    rows: list[dict[str, Any]],
+    *,
+    context_budget_tokens: int,
+) -> tuple[list[dict[str, Any]], dict[str, int]]:
+    budget = max(0, int(context_budget_tokens))
+    selected: list[dict[str, Any]] = []
+    used_tokens = 0
+    for row in rows:
+        cost = _estimate_tokens(_top_of_mind_line(row))
+        if used_tokens + cost > budget:
+            continue
+        selected.append(row)
+        used_tokens += cost
+    return selected, {
+        "budget_tokens": budget,
+        "selected_tokens": used_tokens,
+        "remaining_tokens": max(0, budget - used_tokens),
+        "selected_objects": len(selected),
+        "omitted_objects": max(0, len(rows) - len(selected)),
+    }
+
+
 def _render(
     *,
     target_date: _date_cls,
+    context_budget: dict[str, int],
     top_of_mind: list[dict[str, Any]],
     fresh_crystals: list[dict[str, Any]],
     pending_decisions: list[str],
@@ -211,13 +254,18 @@ def _render(
     sections: list[str] = []
     sections.append(f"# Working Memory — {target_date.isoformat()}\n")
 
+    sections.append("## Context Budget\n")
+    sections.append(f"- Budget: {context_budget['budget_tokens']} tokens")
+    sections.append(f"- Selected: {context_budget['selected_tokens']} tokens")
+    sections.append(f"- Remaining: {context_budget['remaining_tokens']} tokens")
+    sections.append(f"- Selected objects: {context_budget['selected_objects']}")
+    sections.append(f"- Omitted by budget: {context_budget['omitted_objects']}")
+    sections.append("")
+
     sections.append("## Top of Mind\n")
     if top_of_mind:
         for row in top_of_mind:
-            sections.append(
-                f"- [[{row['slug']}]] — {row['citation_count']} citations, "
-                f"{row['reuse_count']} reuses"
-            )
+            sections.append(_top_of_mind_line(row))
     else:
         sections.append("- (none)")
     sections.append("")
@@ -268,6 +316,7 @@ def build_working_memory(
     target_date: _date_cls | None = None,
     lookback_hours: int = DEFAULT_LOOKBACK_HOURS,
     top_n: int = DEFAULT_TOP_N,
+    context_budget_tokens: int = DEFAULT_CONTEXT_BUDGET_TOKENS,
     now: datetime | None = None,
 ) -> Path:
     """Materialize the working-memory file for ``target_date``.
@@ -285,9 +334,15 @@ def build_working_memory(
     output_dir.mkdir(parents=True, exist_ok=True)
     output_path = output_dir / f"{target_date.isoformat()}.md"
 
+    top_of_mind_candidates = _top_of_mind(layout, top_n=top_n, now=now)
+    top_of_mind, context_budget = _select_top_of_mind_for_budget(
+        top_of_mind_candidates,
+        context_budget_tokens=context_budget_tokens,
+    )
     body = _render(
         target_date=target_date,
-        top_of_mind=_top_of_mind(layout, top_n=top_n, now=now),
+        context_budget=context_budget,
+        top_of_mind=top_of_mind,
         fresh_crystals=_fresh_crystals(vault_dir, since=since),
         pending_decisions=_pending_decisions(vault_dir),
         evolves_today=_evolves_today(layout, since=since),
@@ -297,6 +352,10 @@ def build_working_memory(
         "---\n"
         "type: working_memory\n"
         f"date: {target_date.isoformat()}\n"
+        f"context_budget_tokens: {context_budget['budget_tokens']}\n"
+        f"context_selected_tokens: {context_budget['selected_tokens']}\n"
+        f"context_selected_objects: {context_budget['selected_objects']}\n"
+        f"context_omitted_objects: {context_budget['omitted_objects']}\n"
         + "\n".join(
             frontmatter_projection_fields(
                 surface="working_memory",
@@ -310,6 +369,20 @@ def build_working_memory(
         + "\n---\n\n"
     )
     output_path.write_text(frontmatter + body, encoding="utf-8")
+    selected_slugs = [str(row["slug"]) for row in top_of_mind if row.get("slug")]
+    if selected_slugs:
+        emit_reuse_events(
+            vault_dir,
+            pack=DEFAULT_WORKFLOW_PACK_NAME,
+            slugs=selected_slugs,
+            surface="working_memory",
+            consumer_ref=str(output_path.relative_to(vault_dir)),
+            extra_payload={
+                "context_pack_date": target_date.isoformat(),
+                "context_budget_tokens": context_budget["budget_tokens"],
+                "context_selected_tokens": context_budget["selected_tokens"],
+            },
+        )
     return output_path
 
 
@@ -336,6 +409,12 @@ def main(argv: list[str] | None = None) -> int:
         default=DEFAULT_TOP_N,
         help=f"Top-N items per ranked section (default: {DEFAULT_TOP_N})",
     )
+    parser.add_argument(
+        "--budget-tokens",
+        type=int,
+        default=DEFAULT_CONTEXT_BUDGET_TOKENS,
+        help=f"Approximate context budget for selected objects (default: {DEFAULT_CONTEXT_BUDGET_TOKENS})",
+    )
     parser.add_argument("--json", action="store_true", help="Print structured summary to stdout.")
     args = parser.parse_args(argv)
 
@@ -348,6 +427,7 @@ def main(argv: list[str] | None = None) -> int:
         target_date=target_date,
         lookback_hours=args.lookback_hours,
         top_n=args.top_n,
+        context_budget_tokens=args.budget_tokens,
     )
 
     if args.json:

--- a/src/ovp_pipeline/event_emitter.py
+++ b/src/ovp_pipeline/event_emitter.py
@@ -11,8 +11,8 @@ This module owns the contract:
 Closed `event_type` vocabulary (forward-compat for Phase 37 Pulse feed):
 
   trusted_reuse_event      — Phase 32. Canonical object consumed by a surface
-                             (query|briefing|writing_prompt|compiled_view|
-                              export|truth_api|prompt).
+                             (query|briefing|working_memory|writing_prompt|
+                              compiled_view|export|truth_api|prompt).
   promotion                — Phase 32/34/35. State boundary crossed
                              (candidate→canonical, draft→accepted,
                               relation_candidate→relation_row).

--- a/tests/test_working_memory.py
+++ b/tests/test_working_memory.py
@@ -7,6 +7,8 @@ Coverage:
 * Top of Mind respects citation_count from page_metrics
 * EVOLVES Today groups events by subtype within the lookback window
 * Pulse Highlights counts pipeline.jsonl events in the window
+* Context Budget records explicit budget/usage and limits Top of Mind items
+* selected Top of Mind items emit working_memory reuse events
 * CLI runs end-to-end on an empty vault
 """
 
@@ -39,8 +41,10 @@ def test_empty_vault_renders_all_section_headers(temp_vault):
     assert "projection_kind: context_pack_projection" in text
     assert "projection_surface: working_memory" in text
     assert "projection_layer: Layer 3" in text
+    assert "context_budget_tokens: 1200" in text
     assert "# Working Memory — 2026-04-24" in text
     for section in (
+        "## Context Budget",
         "## Top of Mind",
         "## Fresh Crystals",
         "## Pending Decisions",
@@ -105,6 +109,88 @@ def test_top_of_mind_uses_page_metrics(temp_vault):
     cold_idx = text.find("[[cold]]")
     assert hot_idx != -1 and cold_idx != -1
     assert hot_idx < cold_idx
+
+
+def test_context_budget_limits_top_of_mind_items(temp_vault):
+    eg = temp_vault / "10-Knowledge" / "Evergreen"
+    (eg / "Hot.md").write_text(
+        "---\nnote_id: hot\ntitle: Hot\ntype: evergreen\ndate: 2026-04-24\n---\n# Hot\n",
+        encoding="utf-8",
+    )
+    (eg / "Cold.md").write_text(
+        "---\nnote_id: cold\ntitle: Cold\ntype: evergreen\ndate: 2026-04-24\n---\n# Cold\n",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    now = datetime(2026, 4, 24, 12, 0, tzinfo=timezone.utc)
+    db = VaultLayout.from_vault(temp_vault).knowledge_db
+    with sqlite3.connect(db) as conn:
+        conn.executemany(
+            "INSERT OR REPLACE INTO page_metrics "
+            "(slug, last_seen_ts, reuse_count, citation_count) VALUES (?, ?, ?, ?)",
+            [
+                ("hot", int(now.timestamp()), 5, 12),
+                ("cold", int(now.timestamp()), 1, 1),
+            ],
+        )
+        conn.commit()
+
+    output = build_working_memory(
+        temp_vault,
+        target_date=now.date(),
+        now=now,
+        context_budget_tokens=10,
+    )
+    text = output.read_text(encoding="utf-8")
+
+    assert "context_budget_tokens: 10" in text
+    assert "- Budget: 10 tokens" in text
+    assert "- Selected objects: 1" in text
+    assert "- Omitted by budget: 1" in text
+    assert "[[hot]]" in text
+    assert "[[cold]]" not in text
+
+
+def test_working_memory_emits_reuse_events_for_selected_context(temp_vault):
+    eg = temp_vault / "10-Knowledge" / "Evergreen"
+    (eg / "Hot.md").write_text(
+        "---\nnote_id: hot\ntitle: Hot\ntype: evergreen\ndate: 2026-04-24\n---\n# Hot\n",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault, pack_name="research-tech")
+
+    now = datetime(2026, 4, 24, 12, 0, tzinfo=timezone.utc)
+    db = VaultLayout.from_vault(temp_vault).knowledge_db
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO page_metrics "
+            "(slug, last_seen_ts, reuse_count, citation_count) VALUES (?, ?, ?, ?)",
+            ("hot", int(now.timestamp()), 1, 12),
+        )
+        conn.commit()
+
+    output = build_working_memory(
+        temp_vault,
+        target_date=now.date(),
+        now=now,
+        context_budget_tokens=1200,
+    )
+
+    events = [
+        json.loads(line)
+        for line in (temp_vault / "60-Logs" / "reuse-events.jsonl").read_text(
+            encoding="utf-8"
+        ).splitlines()
+        if line.strip()
+    ]
+    assert len(events) == 1
+    assert events[0]["event_type"] == "trusted_reuse_event"
+    assert events[0]["surface"] == "working_memory"
+    assert events[0]["object_id"] == "hot"
+    assert events[0]["consumer_ref"] == str(output.relative_to(temp_vault))
+    assert events[0]["context_budget_tokens"] == 1200
+    assert events[0]["context_pack_date"] == "2026-04-24"
 
 
 def test_evolves_today_groups_by_subtype(temp_vault):


### PR DESCRIPTION
## Summary
- add explicit context budget metadata to ovp-working-memory frontmatter and body
- limit Top of Mind context selection by approximate token budget
- emit working_memory trusted_reuse_event entries for selected canonical objects
- update README, Architecture, Milestone, and Backlog for the first BL-012/BL-013 context-pack loop slice

## Tests
- PYTHONPATH=src python -m pytest tests/test_working_memory.py -q
- PYTHONPATH=src python -m pytest tests/test_working_memory.py tests/test_reuse_events.py tests/test_knowledge_index.py -q -k "working_memory or reuse_events or page_metrics"
- python -m ruff check src/ovp_pipeline/commands/working_memory.py src/ovp_pipeline/event_emitter.py tests/test_working_memory.py
- PYTHONPATH=src python -m pytest -q
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fakechris/obsidian_vault_pipeline/pull/89" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
