### PR TITLE
chore: address batch 1 review findings

### DIFF
--- a/src/ovp_pipeline/projection_labels.py
+++ b/src/ovp_pipeline/projection_labels.py
@@ -29,6 +29,34 @@ def projection_label(
     }
 
 
+def _projection_label_for_output(
+    *,
+    surface: str,
+    projection_kind: str,
+    layer: str,
+    owner_pack: str,
+    generated_by: str,
+    derived_from: Iterable[str],
+    rebuild_policy: str,
+) -> dict[str, object]:
+    return projection_label(
+        surface=surface,
+        projection_kind=projection_kind,
+        layer=layer,
+        owner_pack=owner_pack,
+        generated_by=generated_by,
+        derived_from=derived_from,
+        rebuild_policy=rebuild_policy,
+    )
+
+
+def _format_projection_value(value: object, *, frontmatter: bool) -> str:
+    if isinstance(value, list):
+        joined = ", ".join(str(item) for item in value)
+        return f"[{joined}]" if frontmatter else joined
+    return str(value)
+
+
 def markdown_projection_lines(
     *,
     surface: str,
@@ -39,17 +67,16 @@ def markdown_projection_lines(
     derived_from: Iterable[str],
     rebuild_policy: str,
 ) -> list[str]:
-    return [
-        f"- projection_schema_version: {PROJECTION_LABEL_SCHEMA_VERSION}",
-        f"- projection_kind: {projection_kind}",
-        f"- projection_surface: {surface}",
-        f"- projection_layer: {layer}",
-        f"- projection_owner_pack: {owner_pack}",
-        f"- projection_generated_by: {generated_by}",
-        f"- projection_derived_from: {', '.join(derived_from)}",
-        f"- projection_rebuild_policy: {rebuild_policy}",
-        f"- projection_authority_boundary: {PROJECTION_AUTHORITY_BOUNDARY}",
-    ]
+    label = _projection_label_for_output(
+        surface=surface,
+        projection_kind=projection_kind,
+        layer=layer,
+        owner_pack=owner_pack,
+        generated_by=generated_by,
+        derived_from=derived_from,
+        rebuild_policy=rebuild_policy,
+    )
+    return [f"- {key}: {_format_projection_value(value, frontmatter=False)}" for key, value in label.items()]
 
 
 def frontmatter_projection_fields(
@@ -62,14 +89,13 @@ def frontmatter_projection_fields(
     derived_from: Iterable[str],
     rebuild_policy: str,
 ) -> list[str]:
-    return [
-        f"projection_schema_version: {PROJECTION_LABEL_SCHEMA_VERSION}",
-        f"projection_kind: {projection_kind}",
-        f"projection_surface: {surface}",
-        f"projection_layer: {layer}",
-        f"projection_owner_pack: {owner_pack}",
-        f"projection_generated_by: {generated_by}",
-        f"projection_derived_from: [{', '.join(derived_from)}]",
-        f"projection_rebuild_policy: {rebuild_policy}",
-        f"projection_authority_boundary: {PROJECTION_AUTHORITY_BOUNDARY}",
-    ]
+    label = _projection_label_for_output(
+        surface=surface,
+        projection_kind=projection_kind,
+        layer=layer,
+        owner_pack=owner_pack,
+        generated_by=generated_by,
+        derived_from=derived_from,
+        rebuild_policy=rebuild_policy,
+    )
+    return [f"{key}: {_format_projection_value(value, frontmatter=True)}" for key, value in label.items()]

--- a/src/ovp_pipeline/ui/view_models.py
+++ b/src/ovp_pipeline/ui/view_models.py
@@ -78,6 +78,13 @@ def _scoped_path(path: str, *, pack_name: str | None = None) -> str:
     return f"{path}{separator}pack={quote(pack_name, safe='')}"
 
 
+def _build_note_jump_path(path: object, *, pack_name: str | None = None) -> str:
+    normalized = str(path or "").strip()
+    if not normalized:
+        return ""
+    return _scoped_path(f"/note?path={quote(normalized, safe='')}", pack_name=pack_name)
+
+
 def _emit_briefing_reuse(
     vault_dir: Path | str,
     payload: dict[str, Any],
@@ -388,20 +395,14 @@ def _build_source_backlink_rail(
                 object_id=object_id,
                 title=title,
             ),
-            "jump_path": _scoped_path(
-                f"/note?path={quote(str(item.get('path') or ''), safe='')}",
-                pack_name=requested_pack,
-            ),
+            "jump_path": _build_note_jump_path(item.get("path"), pack_name=requested_pack),
         }
         for item in detail["provenance"]["source_notes"]
     ]
     atlas_pages = [
         {
             **item,
-            "jump_path": _scoped_path(
-                f"/note?path={quote(str(item.get('path') or ''), safe='')}",
-                pack_name=requested_pack,
-            ),
+            "jump_path": _build_note_jump_path(item.get("path"), pack_name=requested_pack),
         }
         for item in detail["provenance"]["mocs"]
     ]
@@ -425,11 +426,7 @@ def _build_source_backlink_rail(
         "evergreen": {
             "title": title,
             "path": evergreen_path,
-            "jump_path": (
-                _scoped_path(f"/note?path={quote(evergreen_path, safe='')}", pack_name=requested_pack)
-                if evergreen_path
-                else ""
-            ),
+            "jump_path": _build_note_jump_path(evergreen_path, pack_name=requested_pack),
         },
         "source_notes": source_notes,
         "atlas_pages": atlas_pages,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,12 +3,8 @@ Pytest fixtures for ovp_pipeline tests.
 """
 
 import pytest
-import tempfile
-import json
 import threading
-from pathlib import Path
 from http.client import HTTPConnection
-from datetime import datetime
 
 
 @pytest.fixture
@@ -29,40 +25,42 @@ def temp_vault(tmp_path):
 
 
 @pytest.fixture
-def fetch_ui():
-    def _fetch(temp_vault, path: str) -> tuple[int, str, str]:
-        from ovp_pipeline.commands.ui_server import create_server
+def ui_server_port(temp_vault):
+    from ovp_pipeline.commands.ui_server import create_server
 
-        server = create_server(temp_vault, host="127.0.0.1", port=0)
-        port = server.server_address[1]
-        thread = threading.Thread(target=server.serve_forever, daemon=True)
-        thread.start()
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield port
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+@pytest.fixture
+def fetch_ui(ui_server_port):
+    def _fetch(_temp_vault, path: str) -> tuple[int, str, str]:
+        conn = HTTPConnection("127.0.0.1", ui_server_port, timeout=5)
         try:
-            conn = HTTPConnection("127.0.0.1", port, timeout=5)
             conn.request("GET", path)
             response = conn.getresponse()
             body = response.read().decode("utf-8")
             content_type = response.getheader("Content-Type") or ""
         finally:
-            server.shutdown()
-            server.server_close()
-            thread.join(timeout=5)
+            conn.close()
         return response.status, body, content_type
 
     return _fetch
 
 
 @pytest.fixture
-def post_ui():
-    def _post(temp_vault, path: str, body: str) -> tuple[int, str]:
-        from ovp_pipeline.commands.ui_server import create_server
-
-        server = create_server(temp_vault, host="127.0.0.1", port=0)
-        port = server.server_address[1]
-        thread = threading.Thread(target=server.serve_forever, daemon=True)
-        thread.start()
+def post_ui(ui_server_port):
+    def _post(_temp_vault, path: str, body: str) -> tuple[int, str]:
+        conn = HTTPConnection("127.0.0.1", ui_server_port, timeout=5)
         try:
-            conn = HTTPConnection("127.0.0.1", port, timeout=5)
             conn.request(
                 "POST",
                 path,
@@ -72,9 +70,7 @@ def post_ui():
             response = conn.getresponse()
             payload = response.read().decode("utf-8")
         finally:
-            server.shutdown()
-            server.server_close()
-            thread.join(timeout=5)
+            conn.close()
         return response.status, payload
 
     return _post

--- a/tests/test_projection_labels.py
+++ b/tests/test_projection_labels.py
@@ -110,7 +110,10 @@ def test_projection_label_helper_keeps_stable_boundary_fields():
 
 
 def test_markdown_projection_lines_are_stable_metadata():
-    from ovp_pipeline.projection_labels import markdown_projection_lines
+    from ovp_pipeline.projection_labels import (
+        frontmatter_projection_fields,
+        markdown_projection_lines,
+    )
 
     assert markdown_projection_lines(
         surface="cluster_view",
@@ -129,6 +132,24 @@ def test_markdown_projection_lines_are_stable_metadata():
         "- projection_derived_from: knowledge.db",
         "- projection_rebuild_policy: on_derived_refresh",
         "- projection_authority_boundary: derived_not_authority",
+    ]
+    assert frontmatter_projection_fields(
+        surface="cluster_view",
+        projection_kind="compiled_wiki_projection",
+        owner_pack="research-tech",
+        generated_by="cluster_view",
+        derived_from=("knowledge.db",),
+        rebuild_policy="on_derived_refresh",
+    ) == [
+        "projection_schema_version: 1",
+        "projection_kind: compiled_wiki_projection",
+        "projection_surface: cluster_view",
+        "projection_layer: Layer 3",
+        "projection_owner_pack: research-tech",
+        "projection_generated_by: cluster_view",
+        "projection_derived_from: [knowledge.db]",
+        "projection_rebuild_policy: on_derived_refresh",
+        "projection_authority_boundary: derived_not_authority",
     ]
 
 

--- a/tests/test_workflow_wiring.py
+++ b/tests/test_workflow_wiring.py
@@ -5,29 +5,18 @@ import json
 import pytest
 
 
-def test_root_and_ops_dispatch_to_distinct_renderers(temp_vault, monkeypatch, fetch_ui):
-    import ovp_pipeline.commands.ui_server as ui_server
+def test_root_and_ops_dispatch_to_distinct_reader_and_ops_surfaces(temp_vault, fetch_ui):
+    root_status, root_body, _ = fetch_ui(temp_vault, "/")
+    ops_status, ops_body, _ = fetch_ui(temp_vault, "/ops")
 
-    calls = []
-    monkeypatch.setattr(
-        ui_server,
-        "_build_runtime_home_payload_from_query",
-        lambda vault_dir, query: {"screen": "runtime/home", "requested_pack": ""},
-    )
-    monkeypatch.setattr(
-        ui_server,
-        "_render_library_home",
-        lambda payload: calls.append("library") or "<html>library</html>",
-    )
-    monkeypatch.setattr(
-        ui_server,
-        "_render_dashboard",
-        lambda payload: calls.append("dashboard") or "<html>dashboard</html>",
-    )
-
-    assert fetch_ui(temp_vault, "/")[0] == 200
-    assert fetch_ui(temp_vault, "/ops")[0] == 200
-    assert calls == ["library", "dashboard"]
+    assert root_status == 200
+    assert ops_status == 200
+    assert "Knowledge Library" in root_body
+    assert "Search Library" in root_body
+    assert "OVP Truth UI" not in root_body
+    assert "OVP Truth UI" in ops_body
+    assert "Workflow Map" in ops_body
+    assert root_body != ops_body
 
 
 def test_candidate_review_route_uses_truth_api_governance_seam(


### PR DESCRIPTION
## Summary\n- share UI server lifecycle setup across fetch/post test fixtures\n- make the root-vs-ops workflow wiring test assert rendered content instead of private render hooks\n- derive markdown/frontmatter projection metadata from projection_label output\n- extract note jump path construction for object source/backlink rails\n\n## Validation\n- python -m ruff check tests/conftest.py tests/test_workflow_wiring.py tests/test_projection_labels.py src/ovp_pipeline/projection_labels.py src/ovp_pipeline/ui/view_models.py\n- PYTHONPATH=src python -m pytest tests/test_workflow_wiring.py tests/test_projection_labels.py tests/test_ui_view_models.py::test_build_object_page_payload_adds_reader_profile_and_source_backlink_rail tests/test_ui_hot_paths.py tests/test_architecture_fitness.py -q\n- PYTHONPATH=src python -m pytest -q