### PR TITLE
chore: address batch 2 review findings

### DIFF
--- a/src/ovp_pipeline/commands/absorb.py
+++ b/src/ovp_pipeline/commands/absorb.py
@@ -61,32 +61,22 @@ def _dedupe_paths(paths: list[Path]) -> list[Path]:
     return unique
 
 
-def _unique_child(directory: Path, name: str) -> Path:
+def _unique_child(directory: Path, name: str, *, reserved: set[Path] | None = None) -> Path:
     candidate = directory / name
-    if not candidate.exists():
+    candidate_key = candidate.resolve(strict=False)
+    if not candidate.exists() and (reserved is None or candidate_key not in reserved):
+        if reserved is not None:
+            reserved.add(candidate_key)
         return candidate
     stem = candidate.stem
     suffix = candidate.suffix
     counter = 2
     while True:
         next_candidate = directory / f"{stem}-{counter}{suffix}"
-        if not next_candidate.exists():
-            return next_candidate
-        counter += 1
-
-
-def _unique_child_with_reservations(directory: Path, name: str, reserved: set[Path]) -> Path:
-    candidate = directory / name
-    if not candidate.exists() and candidate.resolve(strict=False) not in reserved:
-        reserved.add(candidate.resolve(strict=False))
-        return candidate
-    stem = candidate.stem
-    suffix = candidate.suffix
-    counter = 2
-    while True:
-        next_candidate = directory / f"{stem}-{counter}{suffix}"
-        if not next_candidate.exists() and next_candidate.resolve(strict=False) not in reserved:
-            reserved.add(next_candidate.resolve(strict=False))
+        next_key = next_candidate.resolve(strict=False)
+        if not next_candidate.exists() and (reserved is None or next_key not in reserved):
+            if reserved is not None:
+                reserved.add(next_key)
             return next_candidate
         counter += 1
 
@@ -146,7 +136,7 @@ def _preview_clipping_raw_destination(
     when: datetime,
 ) -> Path:
     new_name = _clipping_raw_name(processor, source, when=when)
-    return _unique_child_with_reservations(layout.raw_dir, new_name, reserved)
+    return _unique_child(layout.raw_dir, new_name, reserved=reserved)
 
 
 def _archive_preview_path(layout: VaultLayout, source: Path) -> Path:

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -1271,47 +1271,49 @@ def _render_search_page(payload: dict) -> str:
             f"&middot; {prev_link} &middot; {next_link}</p>"
         )
 
-    def _render_reader_group(group: dict) -> str:
-        items = group.get("items") or []
-        item_html = (
-            "".join(
-                "<li>"
-                f'<a href="{escape(item.get("object_path") or _object_href(item["object_id"], requested_pack=requested_pack))}">{escape(str(item["title"]))}</a>'
-                f"<p>{escape(str(item.get('summary') or 'No compiled summary yet.'))}</p>"
-                f"<p class='muted'>{escape(str(item.get('reason') or 'Matched object text.'))} "
-                f"Evidence: {int(item.get('evidence_count') or 0)}</p>"
-                "</li>"
-                for item in items
-            )
-            or "<li class='muted'>No object hits.</li>"
-        )
+    def _render_group_card(group: dict, *, fallback_label: str, empty_text: str, item_html: str) -> str:
+        rendered_items = item_html or f'<li class="muted">{escape(empty_text)}</li>'
         return (
             "<section class='card'>"
-            f"<h2>{escape(str(group.get('label') or 'Objects'))}</h2>"
+            f"<h2>{escape(str(group.get('label') or fallback_label))}</h2>"
             f"<p class='muted'>{int(group.get('result_count') or 0)} result(s)</p>"
-            f"<ul class='list-tight'>{item_html}</ul>"
+            f"<ul class='list-tight'>{rendered_items}</ul>"
             "</section>"
+        )
+
+    def _render_reader_group(group: dict) -> str:
+        items = group.get("items") or []
+        item_html = "".join(
+            "<li>"
+            f'<a href="{escape(item.get("object_path") or _object_href(item["object_id"], requested_pack=requested_pack))}">{escape(str(item["title"]))}</a>'
+            f"<p>{escape(str(item.get('summary') or 'No compiled summary yet.'))}</p>"
+            f"<p class='muted'>{escape(str(item.get('reason') or 'Matched object text.'))} "
+            f"Evidence: {int(item.get('evidence_count') or 0)}</p>"
+            "</li>"
+            for item in items
+        )
+        return _render_group_card(
+            group,
+            fallback_label="Objects",
+            empty_text="No object hits.",
+            item_html=item_html,
         )
 
     def _render_source_group(group: dict) -> str:
         items = group.get("items") or []
-        item_html = (
-            "".join(
-                "<li>"
-                f'<a href="{escape(item.get("note_path") or _note_href(item["path"], requested_pack))}">{escape(str(item["title"]))}</a> '
-                f'<span class="pill">{escape(str(item["note_type"]))}</span>'
-                f"<p class='muted'>{escape(str(item.get('reason') or 'Matched note title or body.'))}</p>"
-                "</li>"
-                for item in items
-            )
-            or "<li class='muted'>No note hits.</li>"
+        item_html = "".join(
+            "<li>"
+            f'<a href="{escape(item.get("note_path") or _note_href(item["path"], requested_pack))}">{escape(str(item["title"]))}</a> '
+            f'<span class="pill">{escape(str(item["note_type"]))}</span>'
+            f"<p class='muted'>{escape(str(item.get('reason') or 'Matched note title or body.'))}</p>"
+            "</li>"
+            for item in items
         )
-        return (
-            "<section class='card'>"
-            f"<h2>{escape(str(group.get('label') or 'Notes'))}</h2>"
-            f"<p class='muted'>{int(group.get('result_count') or 0)} result(s)</p>"
-            f"<ul class='list-tight'>{item_html}</ul>"
-            "</section>"
+        return _render_group_card(
+            group,
+            fallback_label="Notes",
+            empty_text="No note hits.",
+            item_html=item_html,
         )
 
     reader_groups = payload.get("reader_groups") or []

--- a/src/ovp_pipeline/truth_api.py
+++ b/src/ovp_pipeline/truth_api.py
@@ -2265,6 +2265,54 @@ def list_graph_clusters(
     return items
 
 
+def list_graph_edges_for_object_scope(
+    vault_dir: Path | str,
+    *,
+    object_ids: list[str],
+    pack_names: list[str] | None = None,
+    pack_name: str | None = None,
+) -> list[dict[str, Any]]:
+    normalized_object_ids = sorted({str(object_id) for object_id in object_ids if object_id})
+    if not normalized_object_ids:
+        return []
+    if pack_names:
+        candidate_packs = sorted({str(pack) for pack in pack_names if pack})
+    else:
+        candidate_packs = _materialized_truth_packs(
+            vault_dir, pack_name=pack_name, table_name="graph_edges"
+        )
+    if not candidate_packs:
+        return []
+
+    db_path = _db_path(vault_dir)
+    object_placeholders = ",".join("?" for _ in normalized_object_ids)
+    pack_placeholders = ",".join("?" for _ in candidate_packs)
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            f"""
+            SELECT pack, edge_id, source_object_id, target_object_id, edge_kind, weight, evidence_source_slug
+            FROM graph_edges
+            WHERE pack IN ({pack_placeholders})
+              AND source_object_id IN ({object_placeholders})
+              AND target_object_id IN ({object_placeholders})
+            ORDER BY pack, weight DESC, edge_kind, source_object_id, target_object_id
+            """,
+            (*candidate_packs, *normalized_object_ids, *normalized_object_ids),
+        ).fetchall()
+    return [
+        {
+            "pack": str(row[0]),
+            "edge_id": str(row[1]),
+            "source_object_id": str(row[2]),
+            "target_object_id": str(row[3]),
+            "edge_kind": str(row[4]),
+            "weight": float(row[5] or 0.0),
+            "evidence_source_slug": str(row[6] or ""),
+        }
+        for row in rows
+    ]
+
+
 def get_graph_cluster_detail(
     vault_dir: Path | str,
     cluster_id: str,

--- a/src/ovp_pipeline/ui/view_models.py
+++ b/src/ovp_pipeline/ui/view_models.py
@@ -45,6 +45,7 @@ from ..truth_api import (
     list_contradictions,
     list_deep_dive_derivations,
     list_graph_clusters,
+    list_graph_edges_for_object_scope,
     list_objects,
     list_production_gaps,
     list_production_chains,
@@ -963,7 +964,7 @@ def _build_related_cluster_groups(related_clusters: list[dict[str, Any]]) -> lis
 
 
 def _plural_reader_label(label: str) -> str:
-    if label.endswith("y"):
+    if len(label) >= 2 and label.endswith("y") and label[-2].lower() not in "aeiou":
         return f"{label[:-1]}ies"
     if label.endswith("s"):
         return label
@@ -1026,14 +1027,21 @@ def _build_reader_search_projection(
     objects: list[dict[str, Any]],
     notes: list[dict[str, Any]],
 ) -> dict[str, Any]:
-    object_ids = [str(item["object_id"]) for item in objects]
-    row_packs = sorted({str(item.get("row_pack") or item.get("pack") or "") for item in objects})
+    object_pack_pairs = sorted(
+        {
+            (str(item["object_id"]), str(item.get("row_pack") or item.get("pack") or ""))
+            for item in objects
+        }
+    )
     summary_by_object: dict[tuple[str, str], str] = {}
     evidence_count_by_object: dict[tuple[str, str], int] = {}
-    if object_ids:
+    if object_pack_pairs:
         db_path = _db_path(vault_dir)
-        object_placeholders = ",".join("?" for _ in object_ids)
-        pack_placeholders = ",".join("?" for _ in row_packs)
+        pair_clause = " OR ".join("(object_id = ? AND pack = ?)" for _ in object_pack_pairs)
+        claim_pair_clause = " OR ".join(
+            "(claims.object_id = ? AND claims.pack = ?)" for _ in object_pack_pairs
+        )
+        pair_params = [value for pair in object_pack_pairs for value in pair]
         with sqlite3.connect(db_path) as conn:
             summary_by_object = {
                 (str(object_id), str(pack)): str(summary_text or "")
@@ -1041,10 +1049,9 @@ def _build_reader_search_projection(
                     f"""
                     SELECT object_id, pack, summary_text
                     FROM compiled_summaries
-                    WHERE object_id IN ({object_placeholders})
-                      AND pack IN ({pack_placeholders})
+                    WHERE {pair_clause}
                     """,
-                    (*object_ids, *row_packs),
+                    tuple(pair_params),
                 ).fetchall()
             }
             evidence_count_by_object = {
@@ -1056,11 +1063,10 @@ def _build_reader_search_projection(
                     LEFT JOIN claim_evidence
                       ON claim_evidence.pack = claims.pack
                      AND claim_evidence.claim_id = claims.claim_id
-                    WHERE claims.object_id IN ({object_placeholders})
-                      AND claims.pack IN ({pack_placeholders})
+                    WHERE {claim_pair_clause}
                     GROUP BY claims.object_id, claims.pack
                     """,
-                    (*object_ids, *row_packs),
+                    tuple(pair_params),
                 ).fetchall()
             }
 
@@ -3190,9 +3196,34 @@ def build_graph_map_payload(
     cluster_orbit_y = GRAPH_MAP_HEIGHT * GRAPH_MAP_CLUSTER_ORBIT_Y_FACTOR
     nodes: dict[str, dict[str, Any]] = {}
     edges: dict[tuple[str, str, str], dict[str, Any]] = {}
+    all_member_ids = sorted(
+        {
+            str(member["object_id"])
+            for cluster in clusters
+            for member in cluster.get("members", [])
+            if member.get("object_id")
+        }
+    )
+    cluster_packs = sorted(
+        {
+            str(cluster.get("row_pack") or cluster.get("pack") or requested_pack)
+            for cluster in clusters
+            if cluster.get("row_pack") or cluster.get("pack") or requested_pack
+        }
+    )
+    scoped_edges = list_graph_edges_for_object_scope(
+        vault_dir,
+        object_ids=all_member_ids,
+        pack_names=cluster_packs,
+        pack_name=pack_name,
+    )
+    edges_by_pack: dict[str, list[dict[str, Any]]] = {}
+    for edge in scoped_edges:
+        edges_by_pack.setdefault(str(edge.get("pack") or ""), []).append(edge)
 
     for cluster_index, cluster in enumerate(clusters):
-        cluster_pack = str(cluster.get("pack") or requested_pack)
+        display_pack = str(cluster.get("pack") or requested_pack)
+        edge_pack = str(cluster.get("row_pack") or display_pack)
         cluster_count = max(1, len(clusters))
         cluster_angle = (2 * math.pi * cluster_index / cluster_count) if cluster_count > 1 else 0
         cluster_x = center_x + (math.cos(cluster_angle) * cluster_orbit_x if cluster_count > 1 else 0)
@@ -3225,7 +3256,7 @@ def build_graph_map_payload(
                     "kind_label": _object_kind_label(str(member.get("object_kind") or "")),
                     "path": _scoped_path(
                         f"/object?id={quote(object_id, safe='')}",
-                        pack_name=cluster_pack,
+                        pack_name=display_pack,
                     ),
                     "x": round(x, 1),
                     "y": round(y, 1),
@@ -3238,17 +3269,12 @@ def build_graph_map_payload(
                 node["cluster_ids"].append(cluster["cluster_id"])
                 node["cluster_titles"].append(cluster.get("display_title") or cluster["label"])
 
-        try:
-            detail = get_graph_cluster_detail(
-                vault_dir,
-                str(cluster["cluster_id"]),
-                pack_name=cluster_pack or None,
-            )
-        except (OSError, sqlite3.Error, ValueError):
-            detail = {"edges": []}
-        for edge in detail["edges"]:
+        member_ids = {str(member["object_id"]) for member in members if member.get("object_id")}
+        for edge in edges_by_pack.get(edge_pack, []):
             source_id = str(edge["source_object_id"])
             target_id = str(edge["target_object_id"])
+            if source_id not in member_ids or target_id not in member_ids:
+                continue
             if source_id not in nodes or target_id not in nodes:
                 continue
             key = (source_id, target_id, str(edge["edge_kind"]))

--- a/tests/test_ui_view_models.py
+++ b/tests/test_ui_view_models.py
@@ -757,8 +757,9 @@ date: 2026-04-10
     assert all(item["pack"] == "default-knowledge" for item in payload["items"])
 
 
-def test_build_graph_map_payload_projects_clusters_into_reader_map(temp_vault):
+def test_build_graph_map_payload_projects_clusters_into_reader_map(temp_vault, monkeypatch):
     from ovp_pipeline.knowledge_index import rebuild_knowledge_index
+    import ovp_pipeline.ui.view_models as view_models
     from ovp_pipeline.ui.view_models import build_graph_map_payload
 
     source = temp_vault / "10-Knowledge" / "Evergreen" / "Source.md"
@@ -805,9 +806,18 @@ date: 2026-04-10
         encoding="utf-8",
     )
     rebuild_knowledge_index(temp_vault)
+    bulk_calls = {"count": 0}
+    original_bulk_edges = view_models.list_graph_edges_for_object_scope
+
+    def counted_bulk_edges(*args, **kwargs):
+        bulk_calls["count"] += 1
+        return original_bulk_edges(*args, **kwargs)
+
+    monkeypatch.setattr(view_models, "list_graph_edges_for_object_scope", counted_bulk_edges)
 
     payload = build_graph_map_payload(temp_vault, pack_name="default-knowledge")
 
+    assert bulk_calls["count"] == 1
     assert payload["screen"] == "graph/map"
     assert payload["requested_pack"] == "default-knowledge"
     assert payload["map_summary"]["node_count"] >= 3
@@ -827,6 +837,21 @@ date: 2026-04-10
     assert payload["clusters"][0]["detail_path"].startswith("/cluster?id=")
     assert "pack=default-knowledge" in payload["clusters"][0]["detail_path"]
     assert "spatial" in payload["model_notes"][0].lower()
+
+
+def test_build_search_payload_pluralizes_vowel_y_reader_kinds(temp_vault):
+    from ovp_pipeline.runtime import VaultLayout
+    from ovp_pipeline.ui.view_models import build_search_payload
+
+    _seed_truth_store(temp_vault)
+    db_path = VaultLayout.from_vault(temp_vault).knowledge_db
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("UPDATE objects SET object_kind = 'journey' WHERE object_id = 'alpha'")
+        conn.commit()
+
+    payload = build_search_payload(temp_vault, query="alpha")
+
+    assert any(group["label"] == "Journeys" for group in payload["reader_groups"])
 
 
 def test_build_atlas_browser_payload_preserves_requested_pack(temp_vault):


### PR DESCRIPTION
## Summary\n- bulk-load graph map edges instead of calling cluster detail per cluster\n- fold absorb preview reservations into the shared unique-child helper\n- fix vowel+y reader plural labels and tighten reader search summary/evidence SQL pair filtering\n- share the search result group card wrapper between object and source groups\n\n## Validation\n- python -m ruff check src/ovp_pipeline/commands/absorb.py src/ovp_pipeline/truth_api.py src/ovp_pipeline/ui/view_models.py src/ovp_pipeline/commands/ui_server.py tests/test_ui_view_models.py\n- PYTHONPATH=src python -m pytest tests/test_absorb_refine_commands.py::test_source_lifecycle_routing_preview_reserves_duplicate_clipping_destinations tests/test_ui_view_models.py::test_build_graph_map_payload_projects_clusters_into_reader_map tests/test_ui_view_models.py::test_build_search_payload_groups_results_for_readers tests/test_ui_view_models.py::test_build_search_payload_pluralizes_vowel_y_reader_kinds tests/test_ui_server.py::test_ui_server_search_page_renders_reader_grouped_results -q\n- PYTHONPATH=src python -m pytest tests/test_ui_view_models.py tests/test_ui_server.py::test_ui_server_search_page_renders_reader_grouped_results tests/test_absorb_refine_commands.py tests/test_truth_api.py -q\n- PYTHONPATH=src python -m pytest -q