### PR TITLE
fix: harden runtime state and projection lifecycle

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -679,7 +679,7 @@ Main gaps:
 - Schema versioning is wired into projection lifecycle for `knowledge.db`: Authority and projection versions are persisted and stale metadata triggers a full rebuild marker.
 - Working memory is the first budgeted context-pack projection: it records context budget metadata and emits `working_memory` reuse events for selected canonical objects.
 - OVP Prime materializes that budgeted context pack into `60-Logs/session-snapshots/<session_id>.md` plus `latest.md`, and emits `ovp_prime` reuse events for the selected objects injected into a session.
-- Runtime state is now a derived operational projection and read surface: `ovp-runtime-state` writes `60-Logs/runtime-state/current.{json,md}`, `/ops` and `ovp doctor` consume the same health projection, `GET /api/runtime-state` prefers the materialized `current.json`, and `POST /api/runtime-state` refreshes that materialized projection. It also tracks workflow action queue health; workflow actions use the existing action worker lock plus stale-running attention instead of a generalized lease until multi-worker scheduling exists.
+- Runtime state is now a derived operational projection and read surface: `ovp-runtime-state` writes `60-Logs/runtime-state/current.{json,md}`, `/ops` and `ovp doctor` consume the same health projection, `GET /api/runtime-state` prefers the materialized `current.json`, and `POST /api/runtime-state` refreshes that materialized projection. Runtime-state refreshes stream event logs and keep workflow-action display rows bounded while preserving aggregate counts. It also tracks workflow action queue health; workflow actions use the existing action worker lock plus stale-running attention instead of a generalized lease until multi-worker scheduling exists.
 - The reader-first home is now the default entry; object pages have reader profiles, source rails, and kind-specific reader lenses; `/graph` has a first spatial map projection; `/search` groups reader results by kind, summary, evidence count, and match reason.
 
 ## 18. Near-Term Architecture Actions
@@ -689,7 +689,7 @@ Recommended order:
 1. Keep projection metadata attached to new access surfaces and add doctor/export checks that verify the labels are present.
 2. Add stricter factual evidence completeness checks before expanding automatic promotion.
 3. Expand doctor/export checks to verify projection marker replay and projection labels together.
-4. Keep future projection backends on the same metadata contract before adding semantic reindex workers.
+4. Keep future projection backends on the same metadata contract before adding semantic reindex workers; projection-repair marker state transitions must remain under the marker log file lock.
 5. Add generalized workflow leases only when action processing moves beyond the current single-worker lock model; keep runtime state as a projection, not Authority.
 
 ## Appendix: Backlog Mapping

--- a/ARCHITECTURE.zh-CN.md
+++ b/ARCHITECTURE.zh-CN.md
@@ -787,7 +787,7 @@ Do not rely on ad hoc "just rerun the pipeline" behavior for schema changes.
 - fitness functions 只落地了第一批，仍需扩展到 CI/doctor/pre-commit 的完整契约。
 - working memory 是第一版带 budget 的 context-pack projection：会记录 context budget metadata，并为选入的 canonical objects 写入 `working_memory` reuse events。
 - OVP Prime 会把带 budget 的 context pack 物化成 `60-Logs/session-snapshots/<session_id>.md` 和 `latest.md`，并为注入会话的 selected objects 写入 `ovp_prime` reuse events。
-- runtime state 现在是一层派生的 operational projection 和读取 surface：`ovp-runtime-state` 写出 `60-Logs/runtime-state/current.{json,md}`，`/ops` 和 `ovp doctor` 消费同一份 health projection，`GET /api/runtime-state` 优先读取已物化的 `current.json`，`POST /api/runtime-state` 刷新并写入这份 projection。它也会追踪 workflow action queue health；workflow action 继续使用现有 action worker lock 加 stale-running attention，不在多 worker 调度出现前抽象成通用 lease。
+- runtime state 现在是一层派生的 operational projection 和读取 surface：`ovp-runtime-state` 写出 `60-Logs/runtime-state/current.{json,md}`，`/ops` 和 `ovp doctor` 消费同一份 health projection，`GET /api/runtime-state` 优先读取已物化的 `current.json`，`POST /api/runtime-state` 刷新并写入这份 projection。runtime-state refresh 会流式读取 event log，并限制 workflow-action 展示行数，同时保留聚合计数。它也会追踪 workflow action queue health；workflow action 继续使用现有 action worker lock 加 stale-running attention，不在多 worker 调度出现前抽象成通用 lease。
 - reader-first home 已经成为默认入口；object page 已有 reader profile、source rail 和按 kind 区分的 reader lens；`/graph` 已有第一版 spatial map projection；`/search` 已按 kind、summary、evidence count、match reason 组织 reader results。
 
 ## 17. 近期架构动作
@@ -799,7 +799,7 @@ Do not rely on ad hoc "just rerun the pipeline" behavior for schema changes.
 1. 新增 access surface 时必须继续带 projection metadata，并补 doctor/export checks 验证标注存在。
 2. 在扩大自动 promotion 前，补更严格的 factual evidence completeness checks。
 3. 扩展 doctor/export checks，同时验证 projection marker replay 和 projection labels。
-4. 未来新增 projection backend 前，先沿用同一套 metadata contract，再加 semantic reindex worker。
+4. 未来新增 projection backend 前，先沿用同一套 metadata contract，再加 semantic reindex worker；projection-repair marker 的状态转移必须继续在 marker log file lock 下完成。
 5. 只有 action processing 超出现有 single-worker lock 模型时，才新增通用 workflow lease；runtime state 必须保持为 projection，不能变成 Authority。
 6. 把 routing、promotion、review、permission 从 prompt/散落代码中收束为显式 governance/dispatch contract。
 7. 预留 semantic_reindex lifecycle kind，但不提前锁定 LanceDB 或其它 backend。

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -101,7 +101,7 @@ Rule: historical plans and vault research notes feed this file; they do not over
 
 PR #90 completes the first trusted reuse/context-pack loop: `ovp-working-memory` emits explicit budget metadata and `working_memory` reuse events, while `ovp-prime` turns that pack into a session snapshot and emits `ovp_prime` reuse events for selected canonical objects.
 
-PR #91 starts the operational runtime graph by adding `ovp-runtime-state`, a derived projection over projection repair markers, pipeline events, and trusted reuse events. PR #92 wires that projection into `/ops`, `ovp doctor`, and the provider-facing `/api/runtime-state` read API. The current closeout slice adds workflow action queue health, makes runtime-state reads prefer `60-Logs/runtime-state/current.json`, moves refresh writes to `POST /api/runtime-state`, and records the decision not to generalize workflow item leases before multi-worker scheduling exists.
+PR #91 starts the operational runtime graph by adding `ovp-runtime-state`, a derived projection over projection repair markers, pipeline events, and trusted reuse events. PR #92 wires that projection into `/ops`, `ovp doctor`, and the provider-facing `/api/runtime-state` read API. The current closeout slice adds workflow action queue health, makes runtime-state reads prefer `60-Logs/runtime-state/current.json`, moves refresh writes to `POST /api/runtime-state`, streams runtime-state log reads with bounded action display rows, and records the decision not to generalize workflow item leases before multi-worker scheduling exists.
 
 Recommended order:
 

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -1871,7 +1871,9 @@ def _render_objects_index(payload: dict) -> str:
 
 def _render_source_backlink_rail(payload: dict, *, requested_pack: str) -> str:
     rail = payload.get("source_backlink_rail") or {}
+    rail = rail if isinstance(rail, dict) else {}
     evergreen = rail.get("evergreen") or {}
+    evergreen = evergreen if isinstance(evergreen, dict) else {}
     evergreen_path = str(evergreen.get("path") or "")
     evergreen_html = (
         f'<a href="{escape(str(evergreen.get("jump_path") or _note_href(evergreen_path, requested_pack)))}">{escape(evergreen_path)}</a>'
@@ -1909,17 +1911,23 @@ def _render_source_backlink_rail(payload: dict, *, requested_pack: str) -> str:
             "</li>"
         )
 
-    source_notes = rail.get("source_notes") or []
+    source_notes = [
+        item for item in rail.get("source_notes") or [] if isinstance(item, dict)
+    ]
     source_html = (
         "".join(render_source_note(item) for item in source_notes)
         or "<li class='muted'>No source notes linked yet.</li>"
     )
-    atlas_pages = rail.get("atlas_pages") or []
+    atlas_pages = [
+        item for item in rail.get("atlas_pages") or [] if isinstance(item, dict)
+    ]
     atlas_html = (
         "".join(render_atlas_page(item) for item in atlas_pages)
         or "<li class='muted'>No atlas pages link here yet.</li>"
     )
-    related_objects = rail.get("related_objects") or []
+    related_objects = [
+        item for item in rail.get("related_objects") or [] if isinstance(item, dict)
+    ]
     related_html = (
         "".join(render_related_object(item) for item in related_objects)
         or "<li class='muted'>No related objects yet.</li>"
@@ -2781,27 +2789,34 @@ def _render_graph_map_page(payload: dict, *, action_path: str = "/graph") -> str
     )
     notes = "".join(f"<li>{escape(note)}</li>" for note in payload["model_notes"])
     node_lookup = {str(node["object_id"]): node for node in payload["nodes"]}
+
+    def node_x(node: dict) -> float:
+        return float(node.get("x") or 0)
+
+    def node_y(node: dict) -> float:
+        return float(node.get("y") or 0)
+
     edge_lines = "".join(
         "<line "
-        f"x1='{node_lookup[edge['source_object_id']]['x']}' "
-        f"y1='{node_lookup[edge['source_object_id']]['y']}' "
-        f"x2='{node_lookup[edge['target_object_id']]['x']}' "
-        f"y2='{node_lookup[edge['target_object_id']]['y']}' "
+        f"x1='{node_x(node_lookup[str(edge['source_object_id'])])}' "
+        f"y1='{node_y(node_lookup[str(edge['source_object_id'])])}' "
+        f"x2='{node_x(node_lookup[str(edge['target_object_id'])])}' "
+        f"y2='{node_y(node_lookup[str(edge['target_object_id'])])}' "
         "stroke='#c7b8a6' stroke-width='1.4' stroke-opacity='0.7'>"
         f"<title>{escape(edge['source_title'])} -> {escape(edge['target_title'])}: {escape(edge['edge_kind'])}</title>"
         "</line>"
         for edge in payload["edges"]
-        if edge["source_object_id"] in node_lookup
-        and edge["target_object_id"] in node_lookup
+        if str(edge["source_object_id"]) in node_lookup
+        and str(edge["target_object_id"]) in node_lookup
     )
     node_marks = "".join(
         "<a "
         f"href='{escape(str(node['path']))}' aria-label='{escape(str(node['title']))}'>"
-        f"<circle cx='{node['x']}' cy='{node['y']}' r='{node['radius']}' fill='#9f4f24' "
+        f"<circle cx='{node_x(node)}' cy='{node_y(node)}' r='{node['radius']}' fill='#9f4f24' "
         "stroke='#fffdfa' stroke-width='2'>"
         f"<title>{escape(str(node['title']))} · {escape(str(node['kind_label']))} · {node['degree']} links</title>"
         "</circle>"
-        f"<text x='{node['x']}' y='{float(node['y']) + float(node['radius']) + _GRAPH_MAP_NODE_LABEL_Y_OFFSET}' "
+        f"<text x='{node_x(node)}' y='{node_y(node) + float(node['radius']) + _GRAPH_MAP_NODE_LABEL_Y_OFFSET}' "
         "text-anchor='middle' font-size='12' fill='#3c332b'>"
         f"{escape(str(node['title']))}</text>"
         "</a>"
@@ -4791,6 +4806,20 @@ def create_server(
                 if path == "/api/runtime-state":
                     try:
                         limit = int(query.get("limit", ["20"])[0])
+                    except ValueError as exc:
+                        self._write_json(
+                            {
+                                "type": "operational_runtime_state",
+                                "status": "invalid_request",
+                                "error": "invalid_runtime_state_limit",
+                                "detail": str(exc),
+                                "metrics": {},
+                                "attention": [],
+                            },
+                            status=400,
+                        )
+                        return
+                    try:
                         self._write_json(
                             get_operational_runtime_state(
                                 resolved_vault,
@@ -5379,6 +5408,20 @@ def create_server(
                 if path == "/api/runtime-state":
                     try:
                         limit = int(self._form_first(form, "limit").strip() or "20")
+                    except ValueError as exc:
+                        self._write_json(
+                            {
+                                "type": "operational_runtime_state",
+                                "status": "invalid_request",
+                                "error": "invalid_runtime_state_limit",
+                                "detail": str(exc),
+                                "metrics": {},
+                                "attention": [],
+                            },
+                            status=400,
+                        )
+                        return
+                    try:
                         self._write_json(
                             get_operational_runtime_state(
                                 resolved_vault,

--- a/src/ovp_pipeline/projection_lifecycle.py
+++ b/src/ovp_pipeline/projection_lifecycle.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import hashlib
 import json
+from contextlib import contextmanager
 from dataclasses import dataclass, replace
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Literal
+from typing import Iterator, Literal
 
-from .runtime import VaultLayout, resolve_vault_dir
+from .runtime import VaultLayout, advisory_file_lock, resolve_vault_dir
 
 ProjectionRepairKind = Literal["metadata_only", "full_rebuild", "semantic_reindex"]
 ProjectionRepairStatus = Literal["open", "claimed", "closed", "superseded"]
@@ -28,12 +29,25 @@ def _parse_dt(value: object) -> datetime | None:
     text = str(value or "").strip()
     if not text:
         return None
-    return datetime.fromisoformat(text.replace("Z", "+00:00")).astimezone(timezone.utc)
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00")).astimezone(timezone.utc)
+    except ValueError:
+        return None
 
 
 def _marker_log_path(vault_dir: Path | str) -> Path:
     layout = VaultLayout.from_vault(resolve_vault_dir(vault_dir))
     return layout.logs_dir / "projection-repair.jsonl"
+
+
+def _marker_log_lock_path(vault_dir: Path | str) -> Path:
+    return _marker_log_path(vault_dir).with_suffix(".jsonl.lock")
+
+
+@contextmanager
+def _marker_log_lock(vault_dir: Path | str) -> Iterator[None]:
+    with advisory_file_lock(_marker_log_lock_path(vault_dir)):
+        yield
 
 
 def _canonical_json(value: object) -> str:
@@ -121,21 +135,20 @@ def _append_event(vault_dir: Path | str, event: dict[str, object]) -> None:
         handle.write(json.dumps(event, ensure_ascii=False, sort_keys=True) + "\n")
 
 
-def _events(vault_dir: Path | str) -> list[dict[str, object]]:
+def _iter_events(vault_dir: Path | str) -> Iterator[dict[str, object]]:
     path = _marker_log_path(vault_dir)
     if not path.exists():
-        return []
-    events: list[dict[str, object]] = []
-    for raw_line in path.read_text(encoding="utf-8").splitlines():
-        if not raw_line.strip():
-            continue
-        try:
-            payload = json.loads(raw_line)
-        except json.JSONDecodeError:
-            continue
-        if isinstance(payload, dict):
-            events.append(payload)
-    return events
+        return
+    with path.open("r", encoding="utf-8", errors="ignore") as handle:
+        for raw_line in handle:
+            if not raw_line.strip():
+                continue
+            try:
+                payload = json.loads(raw_line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(payload, dict):
+                yield payload
 
 
 def _is_broader_marker(new_marker: ProjectionRepairMarker, old_marker: ProjectionRepairMarker) -> bool:
@@ -148,10 +161,10 @@ def _is_broader_marker(new_marker: ProjectionRepairMarker, old_marker: Projectio
     return bool(new_projection and new_projection == old_projection)
 
 
-def list_projection_repair_markers(vault_dir: Path | str) -> list[ProjectionRepairMarker]:
+def _list_projection_repair_markers_unlocked(vault_dir: Path | str) -> list[ProjectionRepairMarker]:
     markers: dict[str, ProjectionRepairMarker] = {}
     order: list[str] = []
-    for event in _events(vault_dir):
+    for event in _iter_events(vault_dir):
         event_type = str(event.get("event_type") or "")
         marker_id = str(event.get("marker_id") or "")
         if event_type == "projection_repair_marker_written":
@@ -185,6 +198,11 @@ def list_projection_repair_markers(vault_dir: Path | str) -> list[ProjectionRepa
     return [markers[marker_id] for marker_id in order if marker_id in markers]
 
 
+def list_projection_repair_markers(vault_dir: Path | str) -> list[ProjectionRepairMarker]:
+    with _marker_log_lock(vault_dir):
+        return _list_projection_repair_markers_unlocked(vault_dir)
+
+
 def write_projection_repair_marker(
     vault_dir: Path | str,
     *,
@@ -213,28 +231,29 @@ def write_projection_repair_marker(
         authority_schema_version=int(authority_schema_version),
         projection_schema_version=int(projection_schema_version),
     )
-    _append_event(
-        vault_dir,
-        {
-            "event_type": "projection_repair_marker_written",
-            "marker_id": marker.marker_id,
-            "timestamp": _format_dt(created),
-            "marker": marker.to_dict(),
-        },
-    )
-    for existing in list_projection_repair_markers(vault_dir):
-        if existing.marker_id == marker.marker_id:
-            continue
-        if _is_broader_marker(marker, existing):
-            _append_event(
-                vault_dir,
-                {
-                    "event_type": "projection_repair_marker_superseded",
-                    "marker_id": existing.marker_id,
-                    "superseded_by": marker.marker_id,
-                    "timestamp": _format_dt(created),
-                },
-            )
+    with _marker_log_lock(vault_dir):
+        _append_event(
+            vault_dir,
+            {
+                "event_type": "projection_repair_marker_written",
+                "marker_id": marker.marker_id,
+                "timestamp": _format_dt(created),
+                "marker": marker.to_dict(),
+            },
+        )
+        for existing in _list_projection_repair_markers_unlocked(vault_dir):
+            if existing.marker_id == marker.marker_id:
+                continue
+            if _is_broader_marker(marker, existing):
+                _append_event(
+                    vault_dir,
+                    {
+                        "event_type": "projection_repair_marker_superseded",
+                        "marker_id": existing.marker_id,
+                        "superseded_by": marker.marker_id,
+                        "timestamp": _format_dt(created),
+                    },
+                )
     return marker
 
 
@@ -247,29 +266,33 @@ def claim_projection_repair_marker(
     now: datetime | None = None,
 ) -> ProjectionRepairMarker | None:
     current_time = now or _utc_now()
-    markers = {marker.marker_id: marker for marker in list_projection_repair_markers(vault_dir)}
-    marker = markers.get(marker_id)
-    if marker is None or marker.status not in {"open", "claimed"}:
-        return None
-    if marker.claimed_by and marker.claim_lease_until and marker.claim_lease_until > current_time:
-        return None
-    lease_until = current_time + timedelta(seconds=lease_seconds)
-    _append_event(
-        vault_dir,
-        {
-            "event_type": "projection_repair_marker_claimed",
-            "marker_id": marker_id,
-            "claimed_by": worker_id,
-            "claim_lease_until": _format_dt(lease_until),
-            "timestamp": _format_dt(current_time),
-        },
-    )
-    return replace(
-        marker,
-        status="claimed",
-        claimed_by=worker_id,
-        claim_lease_until=lease_until,
-    )
+    with _marker_log_lock(vault_dir):
+        markers = {
+            marker.marker_id: marker
+            for marker in _list_projection_repair_markers_unlocked(vault_dir)
+        }
+        marker = markers.get(marker_id)
+        if marker is None or marker.status not in {"open", "claimed"}:
+            return None
+        if marker.claimed_by and marker.claim_lease_until and marker.claim_lease_until > current_time:
+            return None
+        lease_until = current_time + timedelta(seconds=lease_seconds)
+        _append_event(
+            vault_dir,
+            {
+                "event_type": "projection_repair_marker_claimed",
+                "marker_id": marker_id,
+                "claimed_by": worker_id,
+                "claim_lease_until": _format_dt(lease_until),
+                "timestamp": _format_dt(current_time),
+            },
+        )
+        return replace(
+            marker,
+            status="claimed",
+            claimed_by=worker_id,
+            claim_lease_until=lease_until,
+        )
 
 
 def close_projection_repair_marker(
@@ -279,19 +302,23 @@ def close_projection_repair_marker(
     closed_at: datetime | None = None,
 ) -> ProjectionRepairMarker | None:
     current_time = closed_at or _utc_now()
-    markers = {marker.marker_id: marker for marker in list_projection_repair_markers(vault_dir)}
-    if marker_id not in markers:
-        return None
-    _append_event(
-        vault_dir,
-        {
-            "event_type": "projection_repair_marker_closed",
-            "marker_id": marker_id,
-            "closed_at": _format_dt(current_time),
-            "timestamp": _format_dt(current_time),
-        },
-    )
-    return replace(markers[marker_id], status="closed", closed_at=current_time)
+    with _marker_log_lock(vault_dir):
+        markers = {
+            marker.marker_id: marker
+            for marker in _list_projection_repair_markers_unlocked(vault_dir)
+        }
+        if marker_id not in markers:
+            return None
+        _append_event(
+            vault_dir,
+            {
+                "event_type": "projection_repair_marker_closed",
+                "marker_id": marker_id,
+                "closed_at": _format_dt(current_time),
+                "timestamp": _format_dt(current_time),
+            },
+        )
+        return replace(markers[marker_id], status="closed", closed_at=current_time)
 
 
 def ensure_projection_schema_current(

--- a/src/ovp_pipeline/runtime_state.py
+++ b/src/ovp_pipeline/runtime_state.py
@@ -14,6 +14,7 @@ from .runtime import VaultLayout, format_utc_timestamp, resolve_vault_dir
 
 
 DEFAULT_RECENT_LIMIT = 20
+DEFAULT_ACTION_DISPLAY_LIMIT = 200
 RUNTIME_STATE_DIR = ("60-Logs", "runtime-state")
 ACTION_RUNNING_STALE_AFTER_SECONDS = 3600
 
@@ -51,10 +52,6 @@ def _iter_jsonl(path: Path) -> Iterable[dict[str, Any]]:
                 continue
             if isinstance(payload, dict):
                 yield payload
-
-
-def _read_jsonl(path: Path) -> list[dict[str, Any]]:
-    return list(_iter_jsonl(path))
 
 
 def _event_time(event: dict[str, Any]) -> datetime | None:
@@ -225,6 +222,16 @@ class ReuseEventSummary:
     recent: list[dict[str, Any]]
 
 
+@dataclass(frozen=True)
+class ActionQueueSummary:
+    total: int
+    counts: Counter[str]
+    rows: list[dict[str, Any]]
+    stale_running_actions: list[dict[str, Any]]
+    failed_actions: list[dict[str, Any]]
+    blocked_actions: list[dict[str, Any]]
+
+
 def _summarize_reuse_event_log(path: Path, *, recent_limit: int) -> ReuseEventSummary:
     total = 0
     trusted = 0
@@ -269,6 +276,49 @@ def _summarize_reuse_event_log(path: Path, *, recent_limit: int) -> ReuseEventSu
     )
 
 
+def _summarize_action_queue(
+    path: Path,
+    *,
+    now: datetime,
+    row_limit: int = DEFAULT_ACTION_DISPLAY_LIMIT,
+) -> ActionQueueSummary:
+    total = 0
+    counts: Counter[str] = Counter()
+    important_rows: list[dict[str, Any]] = []
+    fallback_rows: list[dict[str, Any]] = []
+    stale_running_actions: list[dict[str, Any]] = []
+    failed_actions: list[dict[str, Any]] = []
+    blocked_actions: list[dict[str, Any]] = []
+    for action in _iter_jsonl(path):
+        total += 1
+        row = _action_row(action, now=now)
+        status = str(row.get("status") or "(unknown)")
+        counts[status] += 1
+
+        if row["stale_running"] and len(stale_running_actions) < 5:
+            stale_running_actions.append(row)
+        if status == "failed" and len(failed_actions) < 5:
+            failed_actions.append(row)
+        if status == "blocked" and len(blocked_actions) < 5:
+            blocked_actions.append(row)
+
+        is_active_or_attention = status in {"queued", "running", "failed", "blocked"}
+        if is_active_or_attention and len(important_rows) < row_limit:
+            important_rows.append(row)
+        elif not important_rows and len(fallback_rows) < row_limit:
+            fallback_rows.append(row)
+
+    rows = important_rows if important_rows else fallback_rows
+    return ActionQueueSummary(
+        total=total,
+        counts=counts,
+        rows=rows,
+        stale_running_actions=stale_running_actions,
+        failed_actions=failed_actions,
+        blocked_actions=blocked_actions,
+    )
+
+
 def _marker_projection_kind(marker: ProjectionRepairMarker) -> str:
     return str(marker.scope.get("projection_kind") or "unknown")
 
@@ -308,12 +358,12 @@ def build_runtime_state(
         layout.logs_dir / "reuse-events.jsonl",
         recent_limit=recent_limit,
     )
-    raw_actions = _read_jsonl(_action_queue_path(layout))
-    action_rows = [_action_row(action, now=current_time) for action in raw_actions]
-    action_counts = Counter(str(action.get("status") or "(unknown)") for action in action_rows)
-    stale_running_actions = [action for action in action_rows if action["stale_running"]]
-    failed_actions = [action for action in action_rows if action["status"] == "failed"]
-    blocked_actions = [action for action in action_rows if action["status"] == "blocked"]
+    action_summary = _summarize_action_queue(_action_queue_path(layout), now=current_time)
+    action_rows = action_summary.rows
+    action_counts = action_summary.counts
+    stale_running_actions = action_summary.stale_running_actions
+    failed_actions = action_summary.failed_actions
+    blocked_actions = action_summary.blocked_actions
     worker_state = _action_worker_state(layout, now=current_time)
 
     pipeline_counts = pipeline_summary.counts
@@ -386,7 +436,7 @@ def build_runtime_state(
             "id": "log:actions",
             "kind": "event_log",
             "label": "actions.jsonl",
-            "events": len(action_rows),
+            "events": action_summary.total,
         },
     ]
     edges: list[dict[str, str]] = [
@@ -506,7 +556,7 @@ def build_runtime_state(
         "open_projection_repair_markers": len(open_markers),
         "claimed_projection_repair_markers": len(claimed_markers),
         "expired_projection_repair_leases": len(expired_claims),
-        "action_queue_items": len(action_rows),
+        "action_queue_items": action_summary.total,
         "queued_actions": action_counts.get("queued", 0),
         "running_actions": action_counts.get("running", 0),
         "stale_running_actions": len(stale_running_actions),

--- a/tests/test_runtime_state.py
+++ b/tests/test_runtime_state.py
@@ -183,6 +183,55 @@ def test_runtime_state_reports_action_queue_health_without_generalized_leases(te
     } in state["graph"]["edges"]
 
 
+def test_runtime_state_streams_large_action_queue_with_bounded_rows(temp_vault):
+    logs_dir = temp_vault / "60-Logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    rows = [
+        {
+            "action_id": f"action::succeeded-{idx}",
+            "action_kind": "deep_dive_workflow",
+            "status": "succeeded",
+            "finished_at": "2026-04-30T10:00:00Z",
+        }
+        for idx in range(250)
+    ]
+    rows.extend(
+        [
+            {
+                "action_id": "action::failed-late",
+                "action_kind": "deep_dive_workflow",
+                "status": "failed",
+                "failure_bucket": "workflow_failed",
+            },
+            {
+                "action_id": "action::running-late",
+                "action_kind": "object_extraction_workflow",
+                "status": "running",
+                "started_at": "2026-04-30T10:00:00Z",
+            },
+        ]
+    )
+    (logs_dir / "actions.jsonl").write_text(
+        "\n".join(json.dumps(row) for row in rows) + "\n",
+        encoding="utf-8",
+    )
+
+    state = build_runtime_state(
+        temp_vault,
+        now=datetime(2026, 4, 30, 12, 0, tzinfo=timezone.utc),
+    )
+
+    assert state["metrics"]["action_queue_items"] == 252
+    assert state["metrics"]["succeeded_actions"] == 250
+    assert state["metrics"]["failed_actions"] == 1
+    assert state["metrics"]["stale_running_actions"] == 1
+    assert len(state["workflow_actions"]) == 2
+    assert {row["action_id"] for row in state["workflow_actions"]} == {
+        "action::failed-late",
+        "action::running-late",
+    }
+
+
 def test_write_runtime_state_materializes_json_and_markdown(temp_vault):
     state = build_runtime_state(
         temp_vault,

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -555,6 +555,48 @@ def test_ui_server_runtime_state_get_is_read_only(temp_vault):
     assert not (temp_vault / "60-Logs" / "runtime-state" / "current.json").exists()
 
 
+def test_ui_server_runtime_state_get_rejects_invalid_limit_as_json(temp_vault):
+    from ovp_pipeline.commands.ui_server import create_server
+
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("GET", "/api/runtime-state?limit=abc")
+        response = conn.getresponse()
+        payload = json.loads(response.read().decode("utf-8"))
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 400
+    assert payload["error"] == "invalid_runtime_state_limit"
+
+
+def test_ui_server_runtime_state_post_rejects_invalid_limit_as_json(temp_vault):
+    from ovp_pipeline.commands.ui_server import create_server
+
+    server = create_server(temp_vault, host="127.0.0.1", port=0)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        conn = HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("POST", "/api/runtime-state", body="limit=abc")
+        response = conn.getresponse()
+        payload = json.loads(response.read().decode("utf-8"))
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 400
+    assert payload["error"] == "invalid_runtime_state_limit"
+
+
 def test_ui_server_runtime_state_endpoint_returns_503_on_provider_error(temp_vault, monkeypatch):
     import ovp_pipeline.commands.ui_server as ui_server
     from ovp_pipeline.commands.ui_server import create_server
@@ -580,6 +622,81 @@ def test_ui_server_runtime_state_endpoint_returns_503_on_provider_error(temp_vau
 
     assert response.status == 503
     assert payload["error"] == "runtime_state_unavailable"
+
+
+def test_render_source_backlink_rail_skips_non_dict_items():
+    from ovp_pipeline.commands.ui_server import _render_source_backlink_rail
+
+    html = _render_source_backlink_rail(
+        {
+            "source_backlink_rail": {
+                "evergreen": "bad-data",
+                "source_notes": ["bad-data", {"title": "Source A", "path": "A.md"}],
+                "atlas_pages": ["bad-data", {"title": "Atlas A", "path": "Atlas.md"}],
+                "related_objects": [
+                    "bad-data",
+                    {"object_id": "obj-a", "title": "Object A", "path": "Object.md"},
+                ],
+            }
+        },
+        requested_pack="",
+    )
+
+    assert "Source A" in html
+    assert "Atlas A" in html
+    assert "Object A" in html
+    assert "bad-data" not in html
+
+
+def test_render_graph_map_defaults_missing_coordinates():
+    from ovp_pipeline.commands.ui_server import _render_graph_map_page
+
+    html = _render_graph_map_page(
+        {
+            "query": "",
+            "requested_pack": "",
+            "layout": {"width": 640, "height": 360},
+            "map_summary": {
+                "limit": 20,
+                "is_limited": False,
+                "node_count": 2,
+                "edge_count": 1,
+                "cluster_count": 0,
+            },
+            "clusters": [],
+            "model_notes": [],
+            "nodes": [
+                {
+                    "object_id": "a",
+                    "path": "/object?id=a",
+                    "title": "A",
+                    "radius": 8,
+                    "kind_label": "Concept",
+                    "degree": 1,
+                },
+                {
+                    "object_id": "b",
+                    "path": "/object?id=b",
+                    "title": "B",
+                    "radius": 8,
+                    "kind_label": "Concept",
+                    "degree": 1,
+                },
+            ],
+            "edges": [
+                {
+                    "source_object_id": "a",
+                    "target_object_id": "b",
+                    "source_title": "A",
+                    "target_title": "B",
+                    "edge_kind": "related",
+                }
+            ],
+        }
+    )
+
+    assert "cx='0.0'" in html
+    assert "x1='0.0'" in html
 
 
 def test_ui_server_ops_route_renders_runtime_state_card(temp_vault):


### PR DESCRIPTION
## Summary
- stream projection-repair marker events and guard marker write/claim/close state transitions with a marker log file lock
- stream runtime-state action queue reads, preserve aggregate counts, and bound workflow-action display rows
- return JSON 400 for invalid runtime-state API limits and harden source/backlink + graph map renderers against malformed projection rows
- update architecture/backlog docs for bounded runtime-state reads and marker lock discipline

## Review Findings Addressed
- Critical: projection lifecycle JSONL no longer uses read_text().splitlines(); marker transitions now run under an advisory file lock
- Critical/High: runtime-state no longer materializes all action rows just to render the projection; action display rows are bounded while metrics still cover the full file
- High: invalid /api/runtime-state limit values now return JSON 400 instead of falling through to generic HTML errors
- High: reader source rails and graph-map SVG rendering tolerate malformed projection rows / missing coordinates

## Verification
- uv run ruff check src/ovp_pipeline/projection_lifecycle.py src/ovp_pipeline/runtime_state.py src/ovp_pipeline/commands/ui_server.py tests/test_runtime_state.py tests/test_ui_server.py
- uv run pytest tests/test_projection_lifecycle.py tests/test_runtime_state.py tests/test_ui_server.py::test_ui_server_runtime_state_endpoint_returns_provider_projection tests/test_ui_server.py::test_ui_server_runtime_state_get_is_read_only tests/test_ui_server.py::test_ui_server_runtime_state_get_rejects_invalid_limit_as_json tests/test_ui_server.py::test_ui_server_runtime_state_post_rejects_invalid_limit_as_json tests/test_ui_server.py::test_ui_server_runtime_state_endpoint_returns_503_on_provider_error tests/test_ui_server.py::test_render_source_backlink_rail_skips_non_dict_items tests/test_ui_server.py::test_render_graph_map_defaults_missing_coordinates
- uv run pytest
