### PR TITLE
fix: P0+P1 bug fixes from PR #74-96 review

### DIFF
--- a/docs/REVIEW-FINDINGS.md
+++ b/docs/REVIEW-FINDINGS.md
@@ -1,0 +1,154 @@
+# PR #74–#96 Review Findings — 待讨论事项
+
+> 本文档记录 PR #74–#96 全量 Review 中识别的核心 **User Story / Product Design** 和 **Architecture Design** 问题。
+> Bug 修复完成后，本文档是讨论优先事项的基础。
+>
+> 生成时间: 2026-04-30
+
+---
+
+## 一、User Story / Product Design 问题
+
+### 1.1 读者旅程缺乏端到端验证（Critical）
+
+**现状**: UI Shell 从 `/` 入口开始提供了丰富的浏览面板（objects、atlas、clusters、evolution、signals、briefing），但缺少一条端到端的"Reader Happy Path"验证——即一个新用户打开 dashboard → 发现感兴趣的主题 → 深入阅读 → 获得 insight 这条完整链路没有被任何测试或 dogfood 流程覆盖。
+
+**风险**: 功能可能在"展示面板数据"层面 OK，但"发现→深入→收获"的体验断裂会导致产品价值无法兑现。
+
+**建议**:
+- 定义 3-5 条关键 Reader Scenario（如 "atlas 探索 → concept 深入 → evidence 追溯"）
+- 每个 Scenario 用 Playwright/browser-test 或 manual dogfood checklist 覆盖
+- 将 Scenario 通过率作为 Milestone 的 gate 条件
+
+### 1.2 Operator 与 Reader 的混合呈现（Major）
+
+**现状**: 同一个 UI Shell 同时服务两类截然不同的用户：
+- **Reader**（消费知识的人）：关心 concept、evidence、reading route
+- **Operator**（维护 pipeline 的人）：关心 action queue、repair markers、signal ledger
+
+两类功能在同一个 dashboard 上平铺，导致 Reader 看到大量不相关的运维面板。
+
+**建议**:
+- 引入 `?mode=reader` / `?mode=operator` 参数或双入口
+- Reader mode 隐藏 action queue、repair markers、signal ledger
+- Operator mode 保留全部面板
+
+### 1.3 产品文档膨胀（Major）
+
+**现状**: `BACKLOG.md` 已从结构化任务追踪退化为一个 run-on paragraph：
+- BL-XXX 和 KSR-XXX 条目混杂
+- 已完成和未完成没有清晰分界
+- 缺少按 Milestone 分组的视图
+
+**建议**:
+- 拆分为 `BACKLOG-ACTIVE.md`（当前 Sprint 目标）和 `BACKLOG-DONE.md`（已完成归档）
+- 每个条目标注关联 Milestone（M0-M7）
+- 考虑迁移到 GitHub Issues/Projects 以获得自动状态跟踪
+
+### 1.4 "质量" 对用户不可见（Minor）
+
+**现状**: 6 维度质量评分（Definition、Explanation、Details、Structure、Actionable、Linking）仅在 pipeline 内部使用，Reader 无法在 UI 上看到一篇深度解读的质量评级。
+
+**建议**:
+- 在 object page 上以 badge/stars 展示质量评分
+- 低于 3.0 分的条目标注 "Draft" 警告
+- 提供质量维度的 drill-down 视图
+
+---
+
+## 二、Architecture Design 问题
+
+### 2.1 四层架构边界模糊（Critical）
+
+**现状**: `ARCHITECTURE.md` 定义了四层架构：
+1. **Layer 1 — Canonical Knowledge**: registry + vault markdown
+2. **Layer 2 — Derived Indexes/Views**: knowledge.db, projections
+3. **Layer 3 — Context Assembly/Access**: working-memory, prime, assembly recipes
+4. **Layer 4 — Governance/Control Plane**: action queue, signal ledger, review queues
+
+但实际代码中层间调用常跨层：
+- `truth_api.py`（L2）直接操作 action queue（L4）
+- `ui_server.py`（L3 surface）直接调用 L4 mutation 端点
+- `doctor.py`（L4 诊断）直接读取 L2 的 knowledge.db
+
+**风险**: 任何 L2 变更（如 knowledge.db schema 升级）会影响 L4 代码，反之亦然。变更成本随时间累积。
+
+**建议**:
+- 每层通过显式的 API 模块暴露接口（如 `truth_api.py` 只暴露 L2 接口，L4 操作移到 `governance_api.py`）
+- 在 CI 中加入 import-graph lint（如 `import_linter`），强制层间依赖方向
+- 当前 `truth_api.py` (6099 行) 和 `ui_server.py` (6035 行) 是违反最严重的两个文件
+
+### 2.2 JSONL 日志无 Rotation 机制（Critical）
+
+**现状**: `pipeline.jsonl`、`reuse-events.jsonl`、`projection-repair.jsonl`、`actions.jsonl` 均为 append-only 无上限。`build_runtime_state()` 和 `_feedback_payload()` 等函数在每次调用时全文扫描这些文件。
+
+**风险**: 日志线性增长 → 读取耗时线性增长 → `ovp doctor` 和 UI dashboard 越来越慢 → 最终超时或 OOM。
+
+**建议**:
+- 引入 JSONL rotation：每达到 N 行或 M MB 时，将旧数据 snapshot 到 `*.YYYYMMDD.jsonl` 并重置主文件
+- `_summarize_event_log()` 和 `_summarize_reuse_event_log()` 改为只读最近 N 行的 tail-read 策略
+- 对只需要聚合统计的场景，在 rotation 时将统计写入 sidecar JSON（如 `pipeline-stats.json`）
+
+### 2.3 巨型文件的拆分计划（Critical）
+
+**现状**:
+| 文件 | 行数 | 职责 |
+|------|------|------|
+| `ui_server.py` | 6035 | HTTP routing + HTML rendering + mutation handlers |
+| `truth_api.py` | 6099 | Truth query + Governance mutations + Search |
+| `doctor.py` | 1485 | Pack 诊断 + 健康检查 |
+
+**建议**:
+- `ui_server.py` → 拆分为 `ui_routes.py`（路由分发）、`ui_renderers.py`（HTML 渲染）、`ui_mutations.py`（POST 处理）
+- `truth_api.py` → 拆分为 `truth_queries.py`（L2 读取）、`governance_api.py`（L4 操作）、`search_api.py`（FTS 查询）
+- 每个文件控制在 1000 行以内
+
+### 2.4 时间工具函数重复（Major）
+
+**现状**: 以下函数在多个模块中重复实现：
+- `_utc_now()` → `projection_lifecycle.py`、`runtime_state.py`
+- `_parse_dt()` → `projection_lifecycle.py`、`runtime_state.py`
+- `_format_dt()` → `projection_lifecycle.py`、`runtime_state.py`
+
+`runtime.py` 中有 `format_utc_timestamp()` 但格式与上述函数不完全一致（strftime vs isoformat）。
+
+**建议**:
+- 在 `runtime.py` 中统一定义 `utc_now()`、`parse_utc_timestamp()`、`format_utc_timestamp()`
+- 其他模块统一 import，消除重复
+
+### 2.5 Architectural Fitness 测试形同虚设（Major）
+
+**现状**: `tests/test_architecture_fitness.py` 存在但其断言过于粗放：
+- 只检查 import 是否成功
+- 不验证层间依赖方向
+- 不验证模块职责边界
+
+**建议**:
+- 加入 import-graph 依赖方向测试（L1 不能 import L4）
+- 加入文件行数上限测试（触发拆分时自动 fail）
+- 加入 public API surface 测试（防止内部函数被外部使用）
+
+### 2.6 安全架构缺失（Major）
+
+**现状**: UI server（`ui_server.py`）运行在 `0.0.0.0:9111`（默认配置），存在：
+- 无认证/鉴权
+- 无 CSRF 保护
+- `next` 参数 open redirect
+- 无 Content Security Policy
+
+**建议**:
+- 默认绑定 `127.0.0.1`（仅本地访问）
+- POST 表单加入 CSRF token
+- `next` 参数白名单（仅允许相对路径）
+- 添加基本的 CSP header
+
+---
+
+## 三、修复后讨论议程
+
+1. **Reader Happy Path**: 是否需要在 M7 前定义并验证 Reader Scenario？
+2. **Reader vs Operator 分离**: 是否引入 mode 参数？还是彻底拆分两个端口？
+3. **JSONL Rotation 策略**: threshold 设多大？snapshot 格式是 JSONL 还是聚合 JSON？
+4. **巨型文件拆分优先级**: 先拆 `ui_server.py` 还是 `truth_api.py`？
+5. **四层架构 Lint**: 是否引入 `import_linter` 或自定义 AST 检查？
+6. **BACKLOG 管理**: 留在 Markdown 还是迁移到 GitHub Issues？

--- a/docs/REVIEW-FINDINGS.md
+++ b/docs/REVIEW-FINDINGS.md
@@ -92,6 +92,7 @@
 ### 2.3 巨型文件的拆分计划（Critical）
 
 **现状**:
+
 | 文件 | 行数 | 职责 |
 |------|------|------|
 | `ui_server.py` | 6035 | HTTP routing + HTML rendering + mutation handlers |

--- a/src/ovp_pipeline/commands/doctor.py
+++ b/src/ovp_pipeline/commands/doctor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 from datetime import datetime, timedelta, timezone
 import json
+import logging
 from pathlib import Path
 
 from ..artifact_registry import list_effective_artifact_specs
@@ -1013,8 +1014,6 @@ def _promotion_health_payload(vault_dir: Path | None, *, pack_name: str) -> dict
             )
             lane_counts[decision.lane] = lane_counts.get(decision.lane, 0) + 1
     except Exception as exc:
-        import logging
-
         logging.getLogger(__name__).warning(
             "lane evaluation failed, returning zero counts: %s", exc
         )

--- a/src/ovp_pipeline/commands/doctor.py
+++ b/src/ovp_pipeline/commands/doctor.py
@@ -1012,8 +1012,12 @@ def _promotion_health_payload(vault_dir: Path | None, *, pack_name: str) -> dict
                 has_open_contradiction=entry.slug in disputed_ids,
             )
             lane_counts[decision.lane] = lane_counts.get(decision.lane, 0) + 1
-    except Exception:
-        pass
+    except Exception as exc:
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "lane evaluation failed, returning zero counts: %s", exc
+        )
 
     unreviewed_mutations = 0
     if db_path.exists():

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -73,6 +73,8 @@ _EVOLUTION_LINK_TYPES = ["challenges", "replaces", "enriches", "confirms"]
 
 def _safe_redirect_path(location: str, *, fallback: str = "/") -> str:
     """Validate redirect target is a safe relative path (no open redirect)."""
+    if any(ord(ch) < 0x20 or ch == "\\" for ch in location):
+        return fallback
     stripped = location.strip()
     if not stripped:
         return fallback

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -69,6 +69,21 @@ _MARKDOWN_RENDERER = MarkdownIt("commonmark", {"breaks": True, "html": False}).e
 _FENCED_FRONTMATTER_RE = re.compile(r"^```ya?ml\s*\n---\n(.*?)\n---\n```\s*\n?", re.DOTALL)
 _GITHUB_REPO_RE = re.compile(r"https://github\.com/([^/\s]+)/([^/\s#]+)")
 _EVOLUTION_LINK_TYPES = ["challenges", "replaces", "enriches", "confirms"]
+
+
+def _safe_redirect_path(location: str, *, fallback: str = "/") -> str:
+    """Validate redirect target is a safe relative path (no open redirect)."""
+    stripped = location.strip()
+    if not stripped:
+        return fallback
+    parsed = urlparse(stripped)
+    if parsed.scheme or parsed.netloc:
+        return fallback
+    if stripped.startswith("//"):
+        return fallback
+    if not stripped.startswith("/"):
+        return fallback
+    return stripped
 _CANDIDATE_MERGE_AUTOFILL_THRESHOLD = 0.7
 _INLINE_MEMBER_LINK_LIMIT = 8
 _GRAPH_MAP_CLUSTER_PREVIEW_LIMIT = 6
@@ -5947,8 +5962,9 @@ def create_server(
             self.wfile.write(body)
 
         def _redirect(self, location: str) -> None:
+            safe_location = _safe_redirect_path(location)
             self.send_response(303)
-            self.send_header("Location", location)
+            self.send_header("Location", safe_location)
             self.send_header("Content-Length", "0")
             self.end_headers()
 

--- a/src/ovp_pipeline/projection_lifecycle.py
+++ b/src/ovp_pipeline/projection_lifecycle.py
@@ -4,35 +4,25 @@ import hashlib
 import json
 from contextlib import contextmanager
 from dataclasses import dataclass, replace
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Iterator, Literal
 
-from .runtime import VaultLayout, advisory_file_lock, resolve_vault_dir
+from .runtime import (
+    VaultLayout,
+    advisory_file_lock,
+    format_utc_iso,
+    parse_utc_timestamp,
+    resolve_vault_dir,
+    utc_now,
+)
 
 ProjectionRepairKind = Literal["metadata_only", "full_rebuild", "semantic_reindex"]
 ProjectionRepairStatus = Literal["open", "claimed", "closed", "superseded"]
 
-
-def _utc_now() -> datetime:
-    return datetime.now(timezone.utc)
-
-
-def _format_dt(value: datetime | None) -> str:
-    if value is None:
-        return ""
-    normalized = value.astimezone(timezone.utc)
-    return normalized.isoformat().replace("+00:00", "Z")
-
-
-def _parse_dt(value: object) -> datetime | None:
-    text = str(value or "").strip()
-    if not text:
-        return None
-    try:
-        return datetime.fromisoformat(text.replace("Z", "+00:00")).astimezone(timezone.utc)
-    except ValueError:
-        return None
+_utc_now = utc_now
+_format_dt = format_utc_iso
+_parse_dt = parse_utc_timestamp
 
 
 def _marker_log_path(vault_dir: Path | str) -> Path:
@@ -110,22 +100,25 @@ class ProjectionRepairMarker:
         }
 
     @classmethod
-    def from_dict(cls, payload: dict[str, object]) -> "ProjectionRepairMarker":
-        return cls(
-            marker_id=str(payload["marker_id"]),
-            kind=str(payload["kind"]),  # type: ignore[arg-type]
-            scope=dict(payload.get("scope") or {}),
-            reason=str(payload.get("reason") or ""),
-            caused_by=str(payload.get("caused_by") or ""),
-            created_at=_parse_dt(payload.get("created_at")) or _utc_now(),
-            authority_schema_version=int(payload.get("authority_schema_version") or 0),
-            projection_schema_version=int(payload.get("projection_schema_version") or 0),
-            status=str(payload.get("status") or "open"),  # type: ignore[arg-type]
-            superseded_by=str(payload.get("superseded_by") or ""),
-            claimed_by=str(payload.get("claimed_by") or ""),
-            claim_lease_until=_parse_dt(payload.get("claim_lease_until")),
-            closed_at=_parse_dt(payload.get("closed_at")),
-        )
+    def from_dict(cls, payload: dict[str, object]) -> "ProjectionRepairMarker | None":
+        try:
+            return cls(
+                marker_id=str(payload["marker_id"]),
+                kind=str(payload.get("kind") or "metadata_only"),  # type: ignore[arg-type]
+                scope=dict(payload.get("scope") or {}),
+                reason=str(payload.get("reason") or ""),
+                caused_by=str(payload.get("caused_by") or ""),
+                created_at=_parse_dt(payload.get("created_at")) or _utc_now(),
+                authority_schema_version=int(payload.get("authority_schema_version") or 0),
+                projection_schema_version=int(payload.get("projection_schema_version") or 0),
+                status=str(payload.get("status") or "open"),  # type: ignore[arg-type]
+                superseded_by=str(payload.get("superseded_by") or ""),
+                claimed_by=str(payload.get("claimed_by") or ""),
+                claim_lease_until=_parse_dt(payload.get("claim_lease_until")),
+                closed_at=_parse_dt(payload.get("closed_at")),
+            )
+        except (KeyError, TypeError, ValueError):
+            return None
 
 
 def _append_event(vault_dir: Path | str, event: dict[str, object]) -> None:
@@ -168,7 +161,12 @@ def _list_projection_repair_markers_unlocked(vault_dir: Path | str) -> list[Proj
         event_type = str(event.get("event_type") or "")
         marker_id = str(event.get("marker_id") or "")
         if event_type == "projection_repair_marker_written":
-            marker = ProjectionRepairMarker.from_dict(dict(event["marker"]))
+            raw_marker = event.get("marker")
+            if not isinstance(raw_marker, dict):
+                continue
+            marker = ProjectionRepairMarker.from_dict(dict(raw_marker))
+            if marker is None:
+                continue
             markers[marker.marker_id] = marker
             if marker.marker_id not in order:
                 order.append(marker.marker_id)

--- a/src/ovp_pipeline/projection_lifecycle.py
+++ b/src/ovp_pipeline/projection_lifecycle.py
@@ -102,16 +102,32 @@ class ProjectionRepairMarker:
     @classmethod
     def from_dict(cls, payload: dict[str, object]) -> "ProjectionRepairMarker | None":
         try:
+            marker_id = str(payload.get("marker_id") or "").strip()
+            if not marker_id:
+                return None
+            kind = str(payload.get("kind") or "metadata_only")
+            if kind not in {"metadata_only", "full_rebuild", "semantic_reindex"}:
+                return None
+            status = str(payload.get("status") or "open")
+            if status not in {"open", "claimed", "closed", "superseded"}:
+                return None
+            raw_scope = payload.get("scope")
+            if raw_scope is None:
+                scope: dict[str, object] = {}
+            elif isinstance(raw_scope, dict):
+                scope = dict(raw_scope)
+            else:
+                return None
             return cls(
-                marker_id=str(payload["marker_id"]),
-                kind=str(payload.get("kind") or "metadata_only"),  # type: ignore[arg-type]
-                scope=dict(payload.get("scope") or {}),
+                marker_id=marker_id,
+                kind=kind,  # type: ignore[arg-type]
+                scope=scope,
                 reason=str(payload.get("reason") or ""),
                 caused_by=str(payload.get("caused_by") or ""),
                 created_at=_parse_dt(payload.get("created_at")) or _utc_now(),
                 authority_schema_version=int(payload.get("authority_schema_version") or 0),
                 projection_schema_version=int(payload.get("projection_schema_version") or 0),
-                status=str(payload.get("status") or "open"),  # type: ignore[arg-type]
+                status=status,  # type: ignore[arg-type]
                 superseded_by=str(payload.get("superseded_by") or ""),
                 claimed_by=str(payload.get("claimed_by") or ""),
                 claim_lease_until=_parse_dt(payload.get("claim_lease_until")),

--- a/src/ovp_pipeline/runtime.py
+++ b/src/ovp_pipeline/runtime.py
@@ -86,9 +86,32 @@ def split_markdown_frontmatter(text: str) -> tuple[dict[str, object], str]:
     return parsed, body
 
 
+def utc_now() -> datetime:
+    """Return the current UTC datetime."""
+    return datetime.now(timezone.utc)
+
+
 def format_utc_timestamp(value: datetime) -> str:
     """Return stable second-precision UTC timestamps for projections and logs."""
     return value.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def format_utc_iso(value: datetime | None) -> str:
+    """Return ISO 8601 UTC timestamp, or empty string for None."""
+    if value is None:
+        return ""
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def parse_utc_timestamp(value: object) -> datetime | None:
+    """Parse an ISO 8601 or Z-suffixed UTC timestamp, returning None on failure."""
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00")).astimezone(timezone.utc)
+    except ValueError:
+        return None
 
 
 def markdown_title(path: Path) -> str:

--- a/src/ovp_pipeline/runtime_state.py
+++ b/src/ovp_pipeline/runtime_state.py
@@ -10,7 +10,13 @@ from typing import Any, Iterable
 
 from .projection_labels import frontmatter_projection_fields
 from .projection_lifecycle import ProjectionRepairMarker, list_projection_repair_markers
-from .runtime import VaultLayout, format_utc_timestamp, resolve_vault_dir
+from .runtime import (
+    VaultLayout,
+    format_utc_timestamp,
+    parse_utc_timestamp,
+    resolve_vault_dir,
+    utc_now,
+)
 
 
 DEFAULT_RECENT_LIMIT = 20
@@ -18,25 +24,9 @@ DEFAULT_ACTION_DISPLAY_LIMIT = 200
 RUNTIME_STATE_DIR = ("60-Logs", "runtime-state")
 ACTION_RUNNING_STALE_AFTER_SECONDS = 3600
 
-
-def _utc_now() -> datetime:
-    return datetime.now(timezone.utc)
-
-
-def _format_dt(value: datetime | None) -> str:
-    if value is None:
-        return ""
-    return format_utc_timestamp(value)
-
-
-def _parse_dt(value: object) -> datetime | None:
-    text = str(value or "").strip()
-    if not text:
-        return None
-    try:
-        return datetime.fromisoformat(text.replace("Z", "+00:00")).astimezone(timezone.utc)
-    except ValueError:
-        return None
+_utc_now = utc_now
+_format_dt = format_utc_timestamp
+_parse_dt = parse_utc_timestamp
 
 
 def _iter_jsonl(path: Path) -> Iterable[dict[str, Any]]:
@@ -52,6 +42,18 @@ def _iter_jsonl(path: Path) -> Iterable[dict[str, Any]]:
                 continue
             if isinstance(payload, dict):
                 yield payload
+
+
+def _count_jsonl_lines(path: Path) -> int:
+    """Count non-empty lines in a JSONL file without parsing JSON."""
+    if not path.exists():
+        return 0
+    count = 0
+    with path.open("r", encoding="utf-8", errors="ignore") as handle:
+        for line in handle:
+            if line.strip():
+                count += 1
+    return count
 
 
 def _event_time(event: dict[str, Any]) -> datetime | None:
@@ -342,7 +344,7 @@ def build_runtime_state(
     layout = VaultLayout.from_vault(resolved_vault)
     current_time = now or _utc_now()
 
-    repair_event_count = sum(1 for _event in _iter_jsonl(layout.logs_dir / "projection-repair.jsonl"))
+    repair_event_count = _count_jsonl_lines(layout.logs_dir / "projection-repair.jsonl")
     repair_markers = list_projection_repair_markers(resolved_vault)
     repair_rows = [_marker_row(marker, now=current_time) for marker in repair_markers]
     open_markers = [marker for marker in repair_markers if marker.status == "open"]

--- a/src/ovp_pipeline/runtime_state.py
+++ b/src/ovp_pipeline/runtime_state.py
@@ -49,10 +49,13 @@ def _count_jsonl_lines(path: Path) -> int:
     if not path.exists():
         return 0
     count = 0
-    with path.open("r", encoding="utf-8", errors="ignore") as handle:
-        for line in handle:
-            if line.strip():
-                count += 1
+    try:
+        with path.open("r", encoding="utf-8", errors="ignore") as handle:
+            for line in handle:
+                if line.strip():
+                    count += 1
+    except OSError:
+        return 0
     return count
 
 

--- a/src/ovp_pipeline/truth_api.py
+++ b/src/ovp_pipeline/truth_api.py
@@ -1575,9 +1575,9 @@ def list_objects(
     if normalized_query:
         where_clause += (
             " AND ("
-            " lower(object_id) LIKE ? ESCAPE '\\'"
-            " OR lower(title) LIKE ? ESCAPE '\\'"
-            " OR lower(source_slug) LIKE ? ESCAPE '\\'"
+            " object_id LIKE ? ESCAPE '\\'"
+            " OR title LIKE ? ESCAPE '\\'"
+            " OR source_slug LIKE ? ESCAPE '\\'"
             ")"
         )
         inner_params.extend([

--- a/src/ovp_pipeline/truth_api.py
+++ b/src/ovp_pipeline/truth_api.py
@@ -1563,56 +1563,59 @@ def list_objects(
         vault_dir, pack_name=pack_name, table_name="objects"
     )
     normalized_query = _escape_like(query.strip().lower()) if query else ""
-    with sqlite3.connect(db_path) as conn:
-        sql = """
-            SELECT pack, object_id, object_kind, title, canonical_path, source_slug
+
+    pack_placeholders = ",".join("?" for _ in pack_candidates)
+    pack_order = " ".join(
+        f"WHEN ? THEN {index}" for index, _ in enumerate(pack_candidates)
+    )
+    fallback_order = len(pack_candidates)
+
+    inner_params: list[Any] = [*pack_candidates]
+    where_clause = f"pack IN ({pack_placeholders})"
+    if normalized_query:
+        where_clause += (
+            " AND ("
+            " lower(object_id) LIKE ? ESCAPE '\\'"
+            " OR lower(title) LIKE ? ESCAPE '\\'"
+            " OR lower(source_slug) LIKE ? ESCAPE '\\'"
+            ")"
+        )
+        inner_params.extend([
+            f"%{normalized_query}%",
+            f"%{normalized_query}%",
+            f"%{normalized_query}%",
+        ])
+
+    sql = f"""
+        SELECT pack, object_id, object_kind, title, canonical_path, source_slug
+        FROM (
+            SELECT pack, object_id, object_kind, title, canonical_path, source_slug,
+                   ROW_NUMBER() OVER (
+                       PARTITION BY object_id
+                       ORDER BY CASE pack {pack_order} ELSE {fallback_order} END
+                   ) AS rn
             FROM objects
-        """
-        params: list[Any] = [*pack_candidates]
-        sql += f" WHERE pack IN ({','.join('?' for _ in pack_candidates)})"
-        if normalized_query:
-            sql += """
-                AND (
-                  lower(object_id) LIKE ? ESCAPE '\\'
-                  OR lower(title) LIKE ? ESCAPE '\\'
-                  OR lower(source_slug) LIKE ? ESCAPE '\\'
-                )
-            """
-            params.extend(
-                [
-                    f"%{normalized_query}%",
-                    f"%{normalized_query}%",
-                    f"%{normalized_query}%",
-                ]
-            )
-        sql += """
-            ORDER BY CASE pack
-              {pack_order}
-              ELSE {fallback_order}
-            END, object_id
-        """.format(
-            pack_order=" ".join(f"WHEN ? THEN {index}" for index, _ in enumerate(pack_candidates)),
-            fallback_order=len(pack_candidates),
+            WHERE {where_clause}
         )
-        params.extend(pack_candidates)
+        WHERE rn = 1
+        ORDER BY object_id
+        LIMIT ? OFFSET ?
+    """
+    params: list[Any] = [*pack_candidates, *inner_params, limit, offset]
+
+    with sqlite3.connect(db_path) as conn:
         rows = conn.execute(sql, tuple(params)).fetchall()
-    items: list[dict[str, Any]] = []
-    seen_object_ids: set[str] = set()
-    for pack, object_id, object_kind, title, canonical_path, source_slug in rows:
-        if object_id in seen_object_ids:
-            continue
-        seen_object_ids.add(object_id)
-        items.append(
-            {
-                "object_id": object_id,
-                "object_kind": object_kind,
-                "title": title,
-                "canonical_path": _vault_relative_path(resolved_vault, canonical_path),
-                "source_slug": source_slug,
-                "pack": pack,
-            }
-        )
-    return items[offset : offset + limit]
+    return [
+        {
+            "object_id": object_id,
+            "object_kind": object_kind,
+            "title": title,
+            "canonical_path": _vault_relative_path(resolved_vault, canonical_path),
+            "source_slug": source_slug,
+            "pack": pack,
+        }
+        for pack, object_id, object_kind, title, canonical_path, source_slug in rows
+    ]
 
 
 def search_vault_surface(

--- a/tests/test_evidence_replay.py
+++ b/tests/test_evidence_replay.py
@@ -163,6 +163,12 @@ class TestEmitEvidenceVerified:
             "source_slug": "s1",
             "evidence_kind": "ek",
         }
+        assert event["content_hash"] == "abc"
+        assert event["retrieval_context"] == "ctx"
+        assert event["status"] == "verified"
+        assert event["verified_at"] == "2026-04-30T00:00:00Z"
+        assert event.get("quote_start_line", 0) == 0
+        assert event.get("quote_end_line", 0) == 0
 
     def test_rejects_unknown_table(self, replay_vault: Path):
         with pytest.raises(ValueError, match="Unsupported evidence table"):

--- a/tests/test_evidence_replay.py
+++ b/tests/test_evidence_replay.py
@@ -25,7 +25,7 @@ def replay_vault(tmp_path: Path) -> Path:
 
 
 @pytest.fixture()
-def replay_db(replay_vault: Path) -> sqlite3.Connection:
+def replay_db(replay_vault: Path):
     db_path = replay_vault / "knowledge.db"
     conn = sqlite3.connect(db_path)
     conn.execute("""
@@ -64,7 +64,10 @@ def replay_db(replay_vault: Path) -> sqlite3.Connection:
         )
     """)
     conn.commit()
-    return conn
+    try:
+        yield conn
+    finally:
+        conn.close()
 
 
 class TestLatestPerKey:

--- a/tests/test_evidence_replay.py
+++ b/tests/test_evidence_replay.py
@@ -1,0 +1,228 @@
+"""Tests for ovp_pipeline.evidence_replay — event collapse and SQL replay."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from ovp_pipeline.evidence_replay import (
+    _latest_per_key,
+    emit_evidence_verified,
+    replay_evidence_verifications,
+)
+from ovp_pipeline.runtime import VaultLayout
+
+
+@pytest.fixture()
+def replay_vault(tmp_path: Path) -> Path:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "60-Logs").mkdir(parents=True)
+    return vault
+
+
+@pytest.fixture()
+def replay_db(replay_vault: Path) -> sqlite3.Connection:
+    db_path = replay_vault / "knowledge.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute("""
+        CREATE TABLE claim_evidence (
+            pack TEXT,
+            claim_id TEXT,
+            source_slug TEXT,
+            evidence_kind TEXT,
+            locator TEXT DEFAULT '',
+            content_hash TEXT DEFAULT '',
+            retrieval_context TEXT DEFAULT '',
+            quote_start_line INTEGER DEFAULT 0,
+            quote_end_line INTEGER DEFAULT 0,
+            quote_start_char INTEGER DEFAULT 0,
+            quote_end_char INTEGER DEFAULT 0,
+            status TEXT DEFAULT 'unverified',
+            verified_at TEXT DEFAULT ''
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE relations (
+            pack TEXT,
+            source_object_id TEXT,
+            target_object_id TEXT,
+            relation_type TEXT,
+            evidence_source_slug TEXT,
+            locator TEXT DEFAULT '',
+            content_hash TEXT DEFAULT '',
+            retrieval_context TEXT DEFAULT '',
+            quote_start_line INTEGER DEFAULT 0,
+            quote_end_line INTEGER DEFAULT 0,
+            quote_start_char INTEGER DEFAULT 0,
+            quote_end_char INTEGER DEFAULT 0,
+            status TEXT DEFAULT 'unverified',
+            verified_at TEXT DEFAULT ''
+        )
+    """)
+    conn.commit()
+    return conn
+
+
+class TestLatestPerKey:
+    def test_empty_input(self):
+        assert _latest_per_key([]) == {}
+
+    def test_single_event(self):
+        event = {
+            "event_type": "evidence_verified",
+            "table": "claim_evidence",
+            "key": {
+                "pack": "default",
+                "claim_id": "c1",
+                "source_slug": "s1",
+                "evidence_kind": "ek1",
+            },
+            "locator": "loc1",
+        }
+        result = _latest_per_key([event])
+        assert len(result) == 1
+
+    def test_last_event_wins(self):
+        base_key = {
+            "pack": "default",
+            "claim_id": "c1",
+            "source_slug": "s1",
+            "evidence_kind": "ek1",
+        }
+        first = {
+            "event_type": "evidence_verified",
+            "table": "claim_evidence",
+            "key": base_key,
+            "locator": "old-locator",
+        }
+        second = {
+            "event_type": "evidence_verified",
+            "table": "claim_evidence",
+            "key": base_key,
+            "locator": "new-locator",
+        }
+        result = _latest_per_key([first, second])
+        assert len(result) == 1
+        stored = list(result.values())[0]
+        assert stored["locator"] == "new-locator"
+
+    def test_skips_non_verified_events(self):
+        event = {
+            "event_type": "something_else",
+            "table": "claim_evidence",
+            "key": {"pack": "a", "claim_id": "b", "source_slug": "c", "evidence_kind": "d"},
+        }
+        assert _latest_per_key([event]) == {}
+
+    def test_skips_unknown_table(self):
+        event = {
+            "event_type": "evidence_verified",
+            "table": "nonexistent",
+            "key": {"pack": "a"},
+        }
+        assert _latest_per_key([event]) == {}
+
+    def test_skips_missing_key_column(self):
+        event = {
+            "event_type": "evidence_verified",
+            "table": "claim_evidence",
+            "key": {"pack": "a", "claim_id": "b"},
+        }
+        assert _latest_per_key([event]) == {}
+
+
+class TestEmitEvidenceVerified:
+    def test_emits_valid_event(self, replay_vault: Path):
+        emit_evidence_verified(
+            replay_vault,
+            table="claim_evidence",
+            key={"pack": "default", "claim_id": "c1", "source_slug": "s1", "evidence_kind": "ek"},
+            locator="loc",
+            content_hash="abc",
+            retrieval_context="ctx",
+            status="verified",
+            verified_at="2026-04-30T00:00:00Z",
+            pack="default",
+        )
+        log_path = replay_vault / "60-Logs" / "evidence-verifications.jsonl"
+        assert log_path.exists()
+        lines = [line for line in log_path.read_text().splitlines() if line.strip()]
+        assert len(lines) == 1
+        event = json.loads(lines[0])
+        assert event["event_type"] == "evidence_verified"
+        assert event["table"] == "claim_evidence"
+        assert event["locator"] == "loc"
+
+    def test_rejects_unknown_table(self, replay_vault: Path):
+        with pytest.raises(ValueError, match="Unsupported evidence table"):
+            emit_evidence_verified(
+                replay_vault,
+                table="bad_table",
+                key={},
+                locator="",
+                content_hash="",
+                retrieval_context="",
+                status="",
+                verified_at="",
+                pack="default",
+            )
+
+
+class TestReplayEvidenceVerifications:
+    def test_replay_updates_matching_row(self, replay_vault: Path, replay_db: sqlite3.Connection):
+        replay_db.execute(
+            "INSERT INTO claim_evidence (pack, claim_id, source_slug, evidence_kind)"
+            " VALUES (?, ?, ?, ?)",
+            ("default", "c1", "s1", "ek1"),
+        )
+        replay_db.commit()
+
+        emit_evidence_verified(
+            replay_vault,
+            table="claim_evidence",
+            key={"pack": "default", "claim_id": "c1", "source_slug": "s1", "evidence_kind": "ek1"},
+            locator="file.md:10",
+            content_hash="hash123",
+            retrieval_context="context-text",
+            status="verified",
+            verified_at="2026-04-30T12:00:00Z",
+            pack="default",
+        )
+
+        layout = VaultLayout.from_vault(replay_vault)
+        applied = replay_evidence_verifications(replay_db, layout, pack_name="default")
+        assert applied == 1
+
+        row = replay_db.execute(
+            "SELECT locator, status, verified_at FROM claim_evidence WHERE claim_id = 'c1'"
+        ).fetchone()
+        assert row[0] == "file.md:10"
+        assert row[1] == "verified"
+        assert row[2] == "2026-04-30T12:00:00Z"
+
+    def test_replay_returns_zero_for_empty_log(
+        self, replay_vault: Path, replay_db: sqlite3.Connection
+    ):
+        layout = VaultLayout.from_vault(replay_vault)
+        applied = replay_evidence_verifications(replay_db, layout, pack_name="default")
+        assert applied == 0
+
+    def test_replay_ignores_missing_row(self, replay_vault: Path, replay_db: sqlite3.Connection):
+        emit_evidence_verified(
+            replay_vault,
+            table="claim_evidence",
+            key={"pack": "default", "claim_id": "gone", "source_slug": "s", "evidence_kind": "e"},
+            locator="loc",
+            content_hash="h",
+            retrieval_context="c",
+            status="verified",
+            verified_at="2026-04-30T00:00:00Z",
+            pack="default",
+        )
+        layout = VaultLayout.from_vault(replay_vault)
+        applied = replay_evidence_verifications(replay_db, layout, pack_name="default")
+        assert applied == 0

--- a/tests/test_evidence_replay.py
+++ b/tests/test_evidence_replay.py
@@ -156,6 +156,13 @@ class TestEmitEvidenceVerified:
         assert event["event_type"] == "evidence_verified"
         assert event["table"] == "claim_evidence"
         assert event["locator"] == "loc"
+        assert event["pack"] == "default"
+        assert event["key"] == {
+            "pack": "default",
+            "claim_id": "c1",
+            "source_slug": "s1",
+            "evidence_kind": "ek",
+        }
 
     def test_rejects_unknown_table(self, replay_vault: Path):
         with pytest.raises(ValueError, match="Unsupported evidence table"):
@@ -198,11 +205,13 @@ class TestReplayEvidenceVerifications:
         assert applied == 1
 
         row = replay_db.execute(
-            "SELECT locator, status, verified_at FROM claim_evidence WHERE claim_id = 'c1'"
+            """
+            SELECT locator, content_hash, retrieval_context, status, verified_at
+              FROM claim_evidence
+             WHERE claim_id = 'c1'
+            """
         ).fetchone()
-        assert row[0] == "file.md:10"
-        assert row[1] == "verified"
-        assert row[2] == "2026-04-30T12:00:00Z"
+        assert row == ("file.md:10", "hash123", "context-text", "verified", "2026-04-30T12:00:00Z")
 
     def test_replay_returns_zero_for_empty_log(
         self, replay_vault: Path, replay_db: sqlite3.Connection


### PR DESCRIPTION
## Summary

基于 PR #74-96 的三轮 code review，修复所有 P0 和 P1 级别的 bug。

### P0 修复
- **JSONL 损坏容错**: `projection_lifecycle.from_dict` 增加 try/except 降级 + 调用侧 isinstance 防御，防止单条损坏 JSONL 导致全量 marker 列表失败
- **SQL 级分页**: `truth_api.list_objects` 改用 SQL window function (ROW_NUMBER OVER PARTITION) 做数据库级分页和去重，消除内存全量加载
- **Open Redirect 防御**: `ui_server._safe_redirect_path` 白名单校验 redirect 目标，阻止外部 URL 重定向
- **JSONL 性能**: `runtime_state._count_jsonl_lines` 不解析 JSON 直接计行数，避免大文件全量 parse

### P1 修复
- **统一时间工具**: `runtime.py` 集中提供 `utc_now()`, `format_utc_iso()`, `parse_utc_timestamp()`；`projection_lifecycle.py` 和 `runtime_state.py` 消除本地重复实现
- **Doctor 静默吞异常**: `doctor.py` 的 `except Exception: pass` 改为 `logging.warning`，避免 lane 评估失败被完全隐藏
- **Evidence replay 测试**: 新增 `tests/test_evidence_replay.py`，11 个测试覆盖事件折叠、emit、replay 三层逻辑

### 文档
- 新增 `docs/REVIEW-FINDINGS.md`，记录 User Story/Product Design 和 Architecture Design 核心问题，供 bug 修复后重点讨论

## Test plan
- [x] `ruff check` — 所有修改文件 lint 通过
- [x] 针对性测试 151 passed (evidence_replay + projection_lifecycle + runtime_state + truth_api + doctor)
- [x] 全量测试 1135 passed in 104s

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Safer HTTP redirect handling with destination validation
  * Better resilience to malformed log entries and evaluation errors (now warned/skipped instead of failing)

* **Documentation**
  * Added a consolidated review findings document highlighting design and quality gaps

* **Refactor**
  * More efficient database query/pagination behavior
  * Centralized and standardized UTC time utilities

* **Tests**
  * New end-to-end evidence replay validation test suite
<!-- end of auto-generated comment: release notes by coderabbit.ai -->