### PR TITLE
fix: scope incremental quality checks

### DIFF
--- a/src/ovp_pipeline/unified_pipeline_enhanced.py
+++ b/src/ovp_pipeline/unified_pipeline_enhanced.py
@@ -719,14 +719,55 @@ class EnhancedPipeline:
         self.txn_id = None
         self.workflow_pack_name = DEFAULT_WORKFLOW_PACK_NAME
         self.workflow_profile_name = "full"
+        self.run_mode = "custom"
 
-    def _quality_stage_inputs(self) -> tuple[list[Path], str, str, str]:
-        files = collect_quality_files(self.layout, all_areas=True)
+    def _normalize_quality_target_files(self, target_files: list[str | Path] | None) -> list[Path]:
+        if target_files is None:
+            return collect_quality_files(self.layout, all_areas=True)
+
+        normalized: list[Path] = []
+        seen: set[Path] = set()
+        for raw_path in target_files:
+            resolved = self._resolve_existing_vault_file(raw_path)
+            if resolved is None:
+                continue
+            path = Path(resolved)
+            if path in seen:
+                continue
+            seen.add(path)
+            normalized.append(path)
+        return sorted(normalized)
+
+    def _recent_quality_files(self, *, days: int = 1) -> list[Path]:
+        cutoff = time.time() - (days * 24 * 60 * 60)
+        recent: list[Path] = []
+        for path in collect_quality_files(self.layout, all_areas=True):
+            try:
+                if path.stat().st_mtime >= cutoff:
+                    recent.append(path)
+            except OSError:
+                continue
+        return sorted(recent)
+
+    def _incremental_quality_target_files(self, results: dict[str, Any] | None) -> list[str | Path] | None:
+        if self.run_mode != "incremental":
+            return None
+
+        article_result = (results or {}).get("articles", {})
+        if isinstance(article_result, dict) and "produced_files" in article_result:
+            produced_files = article_result.get("produced_files")
+            return produced_files if isinstance(produced_files, list) else []
+
+        return self._recent_quality_files(days=1)
+
+    def _quality_stage_inputs(self, target_files: list[str | Path] | None = None) -> tuple[list[Path], str, str, str]:
+        files = self._normalize_quality_target_files(target_files)
         input_digest = hash_file_set(self.vault_dir, files)
         algorithm_digest = hash_json_payload(
             {
                 "stage": "quality",
                 "algorithm_version": QUALITY_STAGE_ALGORITHM_VERSION,
+                "input_scope": "targeted" if target_files is not None else "all_current_month",
             }
         )
         fingerprint = build_stage_fingerprint(
@@ -945,6 +986,14 @@ class EnhancedPipeline:
                 **input_payload,
                 "qualified_file_count": len(input_payload["qualified_files"]),
             }
+        elif stage == "quality":
+            files, input_digest, algorithm_digest, fingerprint = self._quality_stage_inputs(
+                self._incremental_quality_target_files(results)
+            )
+            inputs = {
+                "files": [self._relative_artifact_path(path) for path in files],
+                "file_count": len(files),
+            }
         else:
             files = self._stage_input_files(stage)
             input_digest = hash_file_set(self.vault_dir, files)
@@ -952,13 +1001,14 @@ class EnhancedPipeline:
                 "files": [self._relative_artifact_path(path) for path in files],
                 "file_count": len(files),
             }
-        fingerprint = build_stage_fingerprint(
-            stage=stage,
-            input_digest=input_digest,
-            algorithm_digest=algorithm_digest,
-            pack_name=self.workflow_pack_name,
-            workflow_profile=self.workflow_profile_name,
-        )
+        if stage != "quality":
+            fingerprint = build_stage_fingerprint(
+                stage=stage,
+                input_digest=input_digest,
+                algorithm_digest=algorithm_digest,
+                pack_name=self.workflow_pack_name,
+                workflow_profile=self.workflow_profile_name,
+            )
         output_files = self._stage_output_files(stage)
         outputs = {
             "paths": [self._relative_artifact_path(path) for path in output_files],
@@ -1140,6 +1190,11 @@ class EnhancedPipeline:
         counts["interpretations"] = sum(
             len(list(d.glob("*_深度解读.md"))) for d in topics_dirs if d.exists()
         )
+        interpretation_files: list[str] = []
+        for directory in topics_dirs:
+            if directory.exists():
+                interpretation_files.extend(str(path.resolve()) for path in directory.glob("*_深度解读.md"))
+        counts["interpretation_files"] = sorted(interpretation_files)
 
         # Evergreen 数量（供 absorb 产出统计使用）
         evergreen_dir = self.layout.evergreen_dir
@@ -1192,9 +1247,20 @@ class EnhancedPipeline:
                 self.layout.month_topics_dir("Programming"),
                 self.layout.month_topics_dir("Tools"),
             ]
-            current_count = sum(len(list(d.glob("*_深度解读.md"))) for d in topics_dirs if d.exists())
+            current_files: list[Path] = []
+            for directory in topics_dirs:
+                if directory.exists():
+                    current_files.extend(sorted(directory.glob("*_深度解读.md")))
+            current_count = len(current_files)
+            before_files = set(before_counts.get("interpretation_files", []))
+            produced_files = [
+                str(path.resolve())
+                for path in current_files
+                if str(path.resolve()) not in before_files
+            ]
             results["produced"] = current_count - before_counts.get("interpretations", 0)
             results["total_interpretations"] = current_count
+            results["produced_files"] = sorted(produced_files)
 
         elif step == "absorb":
             # 检查 absorb 阶段新增的 Evergreen 数量
@@ -1858,7 +1924,12 @@ class EnhancedPipeline:
 
         return result
 
-    def step_quality(self, batch_size: int | None = None, dry_run: bool = False) -> dict:
+    def step_quality(
+        self,
+        batch_size: int | None = None,
+        dry_run: bool = False,
+        target_files: list[str | Path] | None = None,
+    ) -> dict:
         """执行质量检查步骤"""
         print("\n" + "="*60)
         print("STEP 5: Quality Check")
@@ -1876,8 +1947,8 @@ class EnhancedPipeline:
                 "quality_score": 0.0,
             }
 
-        target_files, input_digest, algorithm_digest, fingerprint = self._quality_stage_inputs()
-        total_files = len(target_files)
+        quality_files, input_digest, algorithm_digest, fingerprint = self._quality_stage_inputs(target_files)
+        total_files = len(quality_files)
         effective_batch_size = batch_size or total_files
 
         if total_files == 0:
@@ -1894,7 +1965,7 @@ class EnhancedPipeline:
             if not dry_run:
                 self._write_quality_stage_artifact(
                     result,
-                    target_files,
+                    quality_files,
                     input_digest,
                     algorithm_digest,
                     fingerprint,
@@ -1911,87 +1982,119 @@ class EnhancedPipeline:
             "quality_score": 0.0,
         }
 
-        total_batches = (total_files + effective_batch_size - 1) // effective_batch_size
-        for batch_index, start_index in enumerate(range(0, total_files, effective_batch_size), start=1):
-            current_batch = min(effective_batch_size, total_files - start_index)
-            cmd = [
-                sys.executable, "-m", "ovp_pipeline.batch_quality_checker",
-                "--all",
-                "--vault-dir", str(self.vault_dir),
-                "--start-index", str(start_index),
-                "--batch-size", str(current_batch),
-            ]
-            if dry_run:
-                cmd.append("--dry-run")
-
-            if self.txn_id:
-                self.txn.heartbeat(
-                    self.txn_id,
-                    step_name="quality",
-                    progress_mode="counted",
-                    work_units_total=total_files,
-                    work_units_done=aggregated["quality_checked"],
-                    work_units_failed=aggregated["quality_failed"],
-                    current_item=f"quality batch {batch_index}/{total_batches}",
-                    progress_summary=f"{aggregated['quality_checked']}/{total_files} files checked",
-                    last_meaningful_event={
-                        "event_type": "quality_batch_started",
-                        "start_index": start_index,
-                        "batch_size": current_batch,
-                    },
+        temp_quality_dir = None
+        quality_target_dir: Path | None = None
+        quality_original_by_name: dict[str, str] = {}
+        try:
+            if target_files is not None:
+                self.layout.logs_dir.mkdir(parents=True, exist_ok=True)
+                temp_quality_dir = tempfile.TemporaryDirectory(
+                    prefix="quality-targets-",
+                    dir=str(self.layout.logs_dir),
                 )
-
-            result = self.run_command(
-                cmd,
-                "quality",
-                timeout=self._calculate_timeout("quality", batch_size=current_batch),
-            )
-
-            if not result["success"]:
-                print(f"✗ Quality check failed: {result.get('error', 'Unknown error')}")
-                result.update(aggregated)
-                return result
-
-            batch_payload = None
-            stdout = result.get("stdout", "")
-            for line in stdout.split("\n"):
-                if line.startswith("__QC_JSON__:"):
+                quality_target_dir = Path(temp_quality_dir.name)
+                for index, path in enumerate(quality_files):
+                    link_name = path.name
+                    if (quality_target_dir / link_name).exists():
+                        link_name = f"{index:04d}-{path.name}"
+                    link = quality_target_dir / link_name
                     try:
-                        batch_payload = json.loads(line.split("__QC_JSON__:", 1)[1].strip())
-                    except json.JSONDecodeError:
-                        batch_payload = None
-                    break
+                        link.symlink_to(path)
+                    except OSError:
+                        link.write_text(path.read_text(encoding="utf-8"), encoding="utf-8")
+                    quality_original_by_name[link.name] = str(path.resolve())
 
-            if batch_payload is None:
-                print("✗ Quality check failed: missing __QC_JSON__ payload")
-                return {
-                    "success": False,
-                    "error": "missing_quality_payload",
-                    **aggregated,
-                }
+            total_batches = (total_files + effective_batch_size - 1) // effective_batch_size
+            for batch_index, start_index in enumerate(range(0, total_files, effective_batch_size), start=1):
+                current_batch = min(effective_batch_size, total_files - start_index)
+                cmd = [
+                    sys.executable, "-m", "ovp_pipeline.batch_quality_checker",
+                    "--vault-dir", str(self.vault_dir),
+                    "--start-index", str(start_index),
+                    "--batch-size", str(current_batch),
+                ]
+                if quality_target_dir is not None:
+                    cmd.extend(["--dir", str(quality_target_dir)])
+                else:
+                    cmd.append("--all")
+                if dry_run:
+                    cmd.append("--dry-run")
 
-            aggregated["quality_checked"] += batch_payload.get("checked", 0)
-            aggregated["quality_qualified"] += batch_payload.get("qualified", 0)
-            aggregated["quality_failed"] += batch_payload.get("failed", 0)
-            aggregated["quality_qualified_files"].extend(batch_payload.get("qualified_files", []))
-            aggregated["quality_results_json"] = batch_payload.get("results_json")
-            if self.txn_id:
-                self.txn.heartbeat(
-                    self.txn_id,
-                    step_name="quality",
-                    progress_mode="counted",
-                    work_units_total=total_files,
-                    work_units_done=aggregated["quality_checked"],
-                    work_units_failed=aggregated["quality_failed"],
-                    current_item=f"quality batch {batch_index}/{total_batches}",
-                    progress_summary=f"{aggregated['quality_checked']}/{total_files} files checked",
-                    last_meaningful_event={
-                        "event_type": "quality_batch_completed",
-                        "checked": batch_payload.get("checked", 0),
-                        "qualified": batch_payload.get("qualified", 0),
-                        "failed": batch_payload.get("failed", 0),
-                    },
+                if self.txn_id:
+                    self.txn.heartbeat(
+                        self.txn_id,
+                        step_name="quality",
+                        progress_mode="counted",
+                        work_units_total=total_files,
+                        work_units_done=aggregated["quality_checked"],
+                        work_units_failed=aggregated["quality_failed"],
+                        current_item=f"quality batch {batch_index}/{total_batches}",
+                        progress_summary=f"{aggregated['quality_checked']}/{total_files} files checked",
+                        last_meaningful_event={
+                            "event_type": "quality_batch_started",
+                            "start_index": start_index,
+                            "batch_size": current_batch,
+                        },
+                    )
+
+                result = self.run_command(
+                    cmd,
+                    "quality",
+                    timeout=self._calculate_timeout("quality", batch_size=current_batch),
                 )
+
+                if not result["success"]:
+                    print(f"✗ Quality check failed: {result.get('error', 'Unknown error')}")
+                    result.update(aggregated)
+                    return result
+
+                batch_payload = None
+                stdout = result.get("stdout", "")
+                for line in stdout.split("\n"):
+                    if line.startswith("__QC_JSON__:"):
+                        try:
+                            batch_payload = json.loads(line.split("__QC_JSON__:", 1)[1].strip())
+                        except json.JSONDecodeError:
+                            batch_payload = None
+                        break
+
+                if batch_payload is None:
+                    print("✗ Quality check failed: missing __QC_JSON__ payload")
+                    return {
+                        "success": False,
+                        "error": "missing_quality_payload",
+                        **aggregated,
+                    }
+
+                aggregated["quality_checked"] += batch_payload.get("checked", 0)
+                aggregated["quality_qualified"] += batch_payload.get("qualified", 0)
+                aggregated["quality_failed"] += batch_payload.get("failed", 0)
+                qualified_files = []
+                for raw_path in batch_payload.get("qualified_files", []):
+                    original = quality_original_by_name.get(Path(raw_path).name)
+                    qualified_files.append(original or raw_path)
+                aggregated["quality_qualified_files"].extend(qualified_files)
+                aggregated["quality_results_json"] = batch_payload.get("results_json")
+                if self.txn_id:
+                    self.txn.heartbeat(
+                        self.txn_id,
+                        step_name="quality",
+                        progress_mode="counted",
+                        work_units_total=total_files,
+                        work_units_done=aggregated["quality_checked"],
+                        work_units_failed=aggregated["quality_failed"],
+                        current_item=f"quality batch {batch_index}/{total_batches}",
+                        progress_summary=f"{aggregated['quality_checked']}/{total_files} files checked",
+                        last_meaningful_event={
+                            "event_type": "quality_batch_completed",
+                            "checked": batch_payload.get("checked", 0),
+                            "qualified": batch_payload.get("qualified", 0),
+                            "failed": batch_payload.get("failed", 0),
+                        },
+                    )
+        finally:
+            if temp_quality_dir is not None:
+                temp_quality_dir.cleanup()
 
         if aggregated["quality_checked"] > 0:
             aggregated["quality_score"] = (
@@ -2002,7 +2105,7 @@ class EnhancedPipeline:
         if not dry_run:
             self._write_quality_stage_artifact(
                 aggregated,
-                target_files,
+                quality_files,
                 input_digest,
                 algorithm_digest,
                 fingerprint,
@@ -2727,6 +2830,10 @@ class EnhancedPipeline:
                             before_counts["pinboard_archived"] += produced
                         elif step == "articles":
                             before_counts["interpretations"] = before_counts.get("interpretations", 0) + produced
+                            before_counts["interpretation_files"] = sorted(
+                                set(before_counts.get("interpretation_files", []))
+                                | set(cmd_result.get("produced_files", []))
+                            )
                         elif step == "absorb":
                             before_counts["evergreen"] += produced
                         elif step == "refine":
@@ -2938,6 +3045,7 @@ def main():
     logger = PipelineLogger(layout.pipeline_log)
     txn = TransactionManager(layout.transactions_dir)
     pipeline = EnhancedPipeline(layout.vault_dir, logger, txn)
+    pipeline.run_mode = "full" if args.full else ("incremental" if args.incremental else "custom")
 
     steps = execution_plan["steps"]
     pinboard_days = execution_plan["pinboard_days"]
@@ -2955,7 +3063,7 @@ def main():
     )
     logger.log("pipeline_started", {
         "txn_id": pipeline.txn_id,
-        "mode": "full" if args.full else "custom",
+        "mode": pipeline.run_mode,
         "steps": steps or "all"
     })
 

--- a/src/ovp_pipeline/unified_pipeline_enhanced.py
+++ b/src/ovp_pipeline/unified_pipeline_enhanced.py
@@ -767,7 +767,6 @@ class EnhancedPipeline:
             {
                 "stage": "quality",
                 "algorithm_version": QUALITY_STAGE_ALGORITHM_VERSION,
-                "input_scope": "targeted" if target_files is not None else "all_current_month",
             }
         )
         fingerprint = build_stage_fingerprint(
@@ -1102,12 +1101,25 @@ class EnhancedPipeline:
         result["stage_artifact"] = str(self._stage_artifact_store().path_for(stage, manifest["fingerprint"]))
 
     def _load_quality_stage_artifact(self) -> dict[str, Any] | None:
-        _, _, _, fingerprint = self._quality_stage_inputs()
-        artifact = self._stage_artifact_store().load(
-            "quality",
-            fingerprint,
-            validate_outputs_under=self.vault_dir,
-        )
+        candidate_targets: list[list[str | Path] | None] = []
+        if self.run_mode == "incremental":
+            candidate_targets.append(self._incremental_quality_target_files(None))
+        candidate_targets.append(None)
+
+        artifact = None
+        seen_fingerprints: set[str] = set()
+        for target_files in candidate_targets:
+            _, _, _, fingerprint = self._quality_stage_inputs(target_files)
+            if fingerprint in seen_fingerprints:
+                continue
+            seen_fingerprints.add(fingerprint)
+            artifact = self._stage_artifact_store().load(
+                "quality",
+                fingerprint,
+                validate_outputs_under=self.vault_dir,
+            )
+            if artifact is not None:
+                break
         if artifact is None:
             return None
         artifact_files = artifact.get("outputs", {}).get("qualified_files")
@@ -1254,11 +1266,11 @@ class EnhancedPipeline:
             current_count = len(current_files)
             before_files = set(before_counts.get("interpretation_files", []))
             produced_files = [
-                str(path.resolve())
+                resolved
                 for path in current_files
-                if str(path.resolve()) not in before_files
+                if (resolved := str(path.resolve())) not in before_files
             ]
-            results["produced"] = current_count - before_counts.get("interpretations", 0)
+            results["produced"] = len(produced_files)
             results["total_interpretations"] = current_count
             results["produced_files"] = sorted(produced_files)
 

--- a/src/ovp_pipeline/workflow_handlers.py
+++ b/src/ovp_pipeline/workflow_handlers.py
@@ -49,9 +49,13 @@ def run_pipeline_quality(
     pipeline: Any,
     batch_size: int | None = None,
     dry_run: bool = False,
+    results: dict[str, Any] | None = None,
     **_: Any,
 ) -> dict[str, Any]:
-    return pipeline.step_quality(batch_size=batch_size, dry_run=dry_run)
+    target_files = None
+    if getattr(pipeline, "run_mode", None) == "incremental":
+        target_files = pipeline._incremental_quality_target_files(results or {})
+    return pipeline.step_quality(batch_size=batch_size, dry_run=dry_run, target_files=target_files)
 
 
 def run_pipeline_fix_links(*, pipeline: Any, dry_run: bool = False, **_: Any) -> dict[str, Any]:

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -728,6 +728,53 @@ def test_step_quality_parses_qualified_files_from_qc_json(tmp_path, monkeypatch)
     assert result["quality_qualified_files"] == [str(qualified_file)]
 
 
+def test_incremental_quality_uses_article_outputs_instead_of_all_current_month(tmp_path, monkeypatch):
+    from ovp_pipeline.unified_pipeline_enhanced import PipelineLogger, TransactionManager
+    from ovp_pipeline.workflow_handlers import run_pipeline_quality
+
+    vault = tmp_path / "vault"
+    (vault / "60-Logs").mkdir(parents=True)
+    logger = PipelineLogger(vault / "60-Logs" / "pipeline.jsonl")
+    txn = TransactionManager(vault / "60-Logs" / "transactions")
+    pipeline = EnhancedPipeline(vault, logger, txn)
+    pipeline.run_mode = "incremental"
+
+    month = datetime.now().strftime("%Y-%m")
+    old_file = vault / "20-Areas" / "Tools" / "Topics" / month / "old_深度解读.md"
+    new_file = vault / "20-Areas" / "Tools" / "Topics" / month / "new_深度解读.md"
+    old_file.parent.mkdir(parents=True, exist_ok=True)
+    old_file.write_text("# old\n", encoding="utf-8")
+    new_file.write_text("# new\n", encoding="utf-8")
+
+    captured_commands: list[list[str]] = []
+    stdout = (
+        "__QC_JSON__: "
+        '{"checked": 1, "qualified": 1, "failed": 0, '
+        f'"qualified_files": ["{new_file}"]'
+        "}"
+    )
+
+    def fake_run_command(cmd: list[str], step_name: str, timeout: int | None = None) -> dict:
+        captured_commands.append(cmd)
+        return {"success": True, "stdout": stdout, "stderr": ""}
+
+    monkeypatch.setattr(pipeline, "run_command", fake_run_command)
+
+    result = run_pipeline_quality(
+        pipeline=pipeline,
+        results={"articles": {"produced_files": [str(new_file)]}},
+        dry_run=False,
+    )
+
+    assert result["success"] is True
+    assert result["quality_checked"] == 1
+    assert captured_commands
+    command = captured_commands[0]
+    assert "--all" not in command
+    assert "--dir" in command
+    assert command[command.index("--batch-size") + 1] == "1"
+
+
 def test_step_quality_writes_reusable_stage_artifact(tmp_path, monkeypatch):
     from ovp_pipeline.stage_artifacts import StageArtifactStore
     from ovp_pipeline.unified_pipeline_enhanced import PipelineLogger, TransactionManager

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -27,6 +27,8 @@ from ovp_pipeline.unified_pipeline_enhanced import (
     init_env_file,
 )
 
+QUALITY_TEST_MONTH = datetime.now().strftime("%Y-%m")
+
 
 def test_resolve_vault_dir_returns_absolute_path(tmp_path, monkeypatch):
     workspace = tmp_path / "workspace"
@@ -424,7 +426,7 @@ def test_run_pipeline_checkouts_cacheable_stage_artifact_without_dispatching_han
     from ovp_pipeline.unified_pipeline_enhanced import PipelineLogger, TransactionManager
 
     vault = tmp_path / "vault"
-    topic_dir = vault / "20-Areas" / "Tools" / "Topics" / "2026-04"
+    topic_dir = vault / "20-Areas" / "Tools" / "Topics" / QUALITY_TEST_MONTH
     topic_dir.mkdir(parents=True, exist_ok=True)
     (topic_dir / "cached_深度解读.md").write_text("# cached\n", encoding="utf-8")
     (vault / "60-Logs").mkdir(parents=True)
@@ -560,7 +562,7 @@ def test_run_pipeline_writes_stage_artifact_after_cacheable_stage_success(tmp_pa
     from ovp_pipeline.unified_pipeline_enhanced import PipelineLogger, TransactionManager
 
     vault = tmp_path / "vault"
-    topic_dir = vault / "20-Areas" / "Tools" / "Topics" / "2026-04"
+    topic_dir = vault / "20-Areas" / "Tools" / "Topics" / QUALITY_TEST_MONTH
     topic_dir.mkdir(parents=True, exist_ok=True)
     (topic_dir / "write_artifact_深度解读.md").write_text("# write artifact\n", encoding="utf-8")
     (vault / "60-Logs").mkdir(parents=True)
@@ -704,7 +706,7 @@ def test_step_quality_parses_qualified_files_from_qc_json(tmp_path, monkeypatch)
     txn = TransactionManager(vault / "60-Logs" / "transactions")
     pipeline = EnhancedPipeline(vault, logger, txn)
 
-    qualified_file = vault / "20-Areas" / "Tools" / "Topics" / "2026-04" / "example_深度解读.md"
+    qualified_file = vault / "20-Areas" / "Tools" / "Topics" / QUALITY_TEST_MONTH / "example_深度解读.md"
     qualified_file.parent.mkdir(parents=True, exist_ok=True)
     qualified_file.write_text("# example\n", encoding="utf-8")
 
@@ -775,6 +777,70 @@ def test_incremental_quality_uses_article_outputs_instead_of_all_current_month(t
     assert command[command.index("--batch-size") + 1] == "1"
 
 
+def test_incremental_load_quality_artifact_finds_recent_targeted_manifest(tmp_path, monkeypatch):
+    from ovp_pipeline.unified_pipeline_enhanced import PipelineLogger, TransactionManager
+
+    vault = tmp_path / "vault"
+    (vault / "60-Logs").mkdir(parents=True)
+    logger = PipelineLogger(vault / "60-Logs" / "pipeline.jsonl")
+    txn = TransactionManager(vault / "60-Logs" / "transactions")
+    pipeline = EnhancedPipeline(vault, logger, txn)
+    pipeline.run_mode = "incremental"
+
+    month = datetime.now().strftime("%Y-%m")
+    old_file = vault / "20-Areas" / "Tools" / "Topics" / month / "old_深度解读.md"
+    target_file = vault / "20-Areas" / "Tools" / "Topics" / month / "target_深度解读.md"
+    old_file.parent.mkdir(parents=True, exist_ok=True)
+    old_file.write_text("# old\n", encoding="utf-8")
+    target_file.write_text("# target\n", encoding="utf-8")
+    old_mtime = datetime.now().timestamp() - (3 * 24 * 60 * 60)
+    os.utime(old_file, (old_mtime, old_mtime))
+
+    stdout = (
+        "__QC_JSON__: "
+        '{"checked": 1, "qualified": 1, "failed": 0, '
+        f'"qualified_files": ["{target_file}"]'
+        "}"
+    )
+
+    monkeypatch.setattr(
+        pipeline,
+        "run_command",
+        lambda *_args, **_kwargs: {"success": True, "stdout": stdout, "stderr": ""},
+    )
+
+    result = pipeline.step_quality(target_files=[target_file], dry_run=False)
+
+    assert result["success"] is True
+    assert pipeline._load_quality_stage_artifact() is not None
+
+
+def test_articles_output_count_matches_new_interpretation_files(tmp_path):
+    from ovp_pipeline.unified_pipeline_enhanced import PipelineLogger, TransactionManager
+
+    vault = tmp_path / "vault"
+    (vault / "60-Logs").mkdir(parents=True)
+    logger = PipelineLogger(vault / "60-Logs" / "pipeline.jsonl")
+    txn = TransactionManager(vault / "60-Logs" / "transactions")
+    pipeline = EnhancedPipeline(vault, logger, txn)
+
+    month = datetime.now().strftime("%Y-%m")
+    topics_dir = vault / "20-Areas" / "Tools" / "Topics" / month
+    topics_dir.mkdir(parents=True, exist_ok=True)
+    old_file = topics_dir / "old_深度解读.md"
+    new_file = topics_dir / "new_深度解读.md"
+    old_file.write_text("# old\n", encoding="utf-8")
+    before_counts = pipeline._get_before_counts()
+
+    old_file.unlink()
+    new_file.write_text("# new\n", encoding="utf-8")
+
+    result = pipeline._count_output_files("articles", before_counts, {})
+
+    assert result["produced"] == 1
+    assert result["produced_files"] == [str(new_file.resolve())]
+
+
 def test_step_quality_writes_reusable_stage_artifact(tmp_path, monkeypatch):
     from ovp_pipeline.stage_artifacts import StageArtifactStore
     from ovp_pipeline.unified_pipeline_enhanced import PipelineLogger, TransactionManager
@@ -786,7 +852,7 @@ def test_step_quality_writes_reusable_stage_artifact(tmp_path, monkeypatch):
     pipeline = EnhancedPipeline(vault, logger, txn)
     pipeline.txn_id = txn.start("enhanced-pipeline", "Quality artifact")
 
-    qualified_file = vault / "20-Areas" / "Tools" / "Topics" / "2026-04" / "artifact_深度解读.md"
+    qualified_file = vault / "20-Areas" / "Tools" / "Topics" / QUALITY_TEST_MONTH / "artifact_深度解读.md"
     qualified_file.parent.mkdir(parents=True, exist_ok=True)
     qualified_file.write_text("# artifact\n", encoding="utf-8")
 
@@ -843,7 +909,7 @@ def test_step_absorb_checkouts_matching_quality_stage_artifact(tmp_path, monkeyp
     quality_pipeline = EnhancedPipeline(vault, logger, txn)
     quality_pipeline.txn_id = txn.start("enhanced-pipeline", "Quality artifact source")
 
-    qualified_file = vault / "20-Areas" / "Tools" / "Topics" / "2026-04" / "checkout_深度解读.md"
+    qualified_file = vault / "20-Areas" / "Tools" / "Topics" / QUALITY_TEST_MONTH / "checkout_深度解读.md"
     qualified_file.parent.mkdir(parents=True, exist_ok=True)
     qualified_file.write_text("# checkout\n", encoding="utf-8")
 
@@ -926,7 +992,7 @@ def test_step_quality_batches_and_aggregates_qc_results(tmp_path, monkeypatch):
 
     vault = tmp_path / "vault"
     (vault / "60-Logs").mkdir(parents=True)
-    topic_dir = vault / "20-Areas" / "Tools" / "Topics" / "2026-04"
+    topic_dir = vault / "20-Areas" / "Tools" / "Topics" / QUALITY_TEST_MONTH
     topic_dir.mkdir(parents=True, exist_ok=True)
     files = []
     for idx in range(3):
@@ -986,7 +1052,7 @@ def test_step_quality_updates_parent_run_progress_before_each_batch(tmp_path, mo
 
     vault = tmp_path / "vault"
     (vault / "60-Logs").mkdir(parents=True)
-    topic_dir = vault / "20-Areas" / "Tools" / "Topics" / "2026-04"
+    topic_dir = vault / "20-Areas" / "Tools" / "Topics" / QUALITY_TEST_MONTH
     topic_dir.mkdir(parents=True, exist_ok=True)
     files = []
     for idx in range(3):
@@ -1096,7 +1162,7 @@ def test_step_absorb_uses_qualified_files_even_when_quality_score_is_low(tmp_pat
     txn = TransactionManager(vault / "60-Logs" / "transactions")
     pipeline = EnhancedPipeline(vault, logger, txn)
 
-    qualified_file = vault / "20-Areas" / "Tools" / "Topics" / "2026-04" / "example_深度解读.md"
+    qualified_file = vault / "20-Areas" / "Tools" / "Topics" / QUALITY_TEST_MONTH / "example_深度解读.md"
     qualified_file.parent.mkdir(parents=True, exist_ok=True)
     qualified_file.write_text("# example\n", encoding="utf-8")
 
@@ -1187,7 +1253,7 @@ def test_step_absorb_requires_quality_artifact_without_using_quality_report_hist
     txn = TransactionManager(vault / "60-Logs" / "transactions")
     pipeline = EnhancedPipeline(vault, logger, txn)
 
-    qualified_file = vault / "20-Areas" / "Tools" / "Topics" / "2026-04" / "example_深度解读.md"
+    qualified_file = vault / "20-Areas" / "Tools" / "Topics" / QUALITY_TEST_MONTH / "example_深度解读.md"
     qualified_file.parent.mkdir(parents=True, exist_ok=True)
     qualified_file.write_text("# example\n", encoding="utf-8")
 
@@ -1232,8 +1298,8 @@ def test_load_quality_stage_artifact_returns_none_without_matching_manifest(tmp_
     txn = TransactionManager(vault / "60-Logs" / "transactions")
     pipeline = EnhancedPipeline(vault, logger, txn)
 
-    file_a = vault / "20-Areas" / "Tools" / "Topics" / "2026-04" / "a_深度解读.md"
-    file_b = vault / "20-Areas" / "Tools" / "Topics" / "2026-04" / "b_深度解读.md"
+    file_a = vault / "20-Areas" / "Tools" / "Topics" / QUALITY_TEST_MONTH / "a_深度解读.md"
+    file_b = vault / "20-Areas" / "Tools" / "Topics" / QUALITY_TEST_MONTH / "b_深度解读.md"
     file_a.parent.mkdir(parents=True, exist_ok=True)
     file_a.write_text("# a\n", encoding="utf-8")
     file_b.write_text("# b\n", encoding="utf-8")
@@ -1286,7 +1352,7 @@ def test_step_absorb_batches_qualified_files_and_aggregates_results(tmp_path, mo
     txn = TransactionManager(vault / "60-Logs" / "transactions")
     pipeline = EnhancedPipeline(vault, logger, txn)
 
-    topic_dir = vault / "20-Areas" / "Tools" / "Topics" / "2026-04"
+    topic_dir = vault / "20-Areas" / "Tools" / "Topics" / QUALITY_TEST_MONTH
     topic_dir.mkdir(parents=True, exist_ok=True)
     files = []
     for idx in range(3):
@@ -1358,7 +1424,7 @@ def test_step_absorb_skips_previously_succeeded_items_and_retries_failed_items(t
     txn = TransactionManager(vault / "60-Logs" / "transactions")
     pipeline = EnhancedPipeline(vault, logger, txn)
 
-    topic_dir = vault / "20-Areas" / "Tools" / "Topics" / "2026-04"
+    topic_dir = vault / "20-Areas" / "Tools" / "Topics" / QUALITY_TEST_MONTH
     topic_dir.mkdir(parents=True, exist_ok=True)
     succeeded = topic_dir / "succeeded_深度解读.md"
     failed = topic_dir / "failed_深度解读.md"
@@ -1474,7 +1540,7 @@ def test_step_absorb_updates_txn_ledger_with_counted_progress(tmp_path, monkeypa
     pipeline = EnhancedPipeline(vault, logger, txn)
     pipeline.txn_id = txn.start("enhanced-pipeline", "Phase 25 absorb progress")
 
-    topic_dir = vault / "20-Areas" / "Tools" / "Topics" / "2026-04"
+    topic_dir = vault / "20-Areas" / "Tools" / "Topics" / QUALITY_TEST_MONTH
     topic_dir.mkdir(parents=True, exist_ok=True)
     deep_dives = []
     for name in ("alpha_深度解读.md", "beta_深度解读.md"):
@@ -1917,7 +1983,7 @@ def test_fix_links_timeout_scales_with_deep_dive_count(tmp_path):
     from ovp_pipeline.unified_pipeline_enhanced import PipelineLogger, TransactionManager
 
     vault = tmp_path / "vault"
-    topic_dir = vault / "20-Areas" / "Tools" / "Topics" / "2026-04"
+    topic_dir = vault / "20-Areas" / "Tools" / "Topics" / QUALITY_TEST_MONTH
     topic_dir.mkdir(parents=True, exist_ok=True)
     (vault / "60-Logs").mkdir(parents=True, exist_ok=True)
 
@@ -1960,7 +2026,7 @@ def test_step_fix_links_uses_dynamic_timeout(tmp_path, monkeypatch):
     from ovp_pipeline.unified_pipeline_enhanced import PipelineLogger, TransactionManager
 
     vault = tmp_path / "vault"
-    topic_dir = vault / "20-Areas" / "Tools" / "Topics" / "2026-04"
+    topic_dir = vault / "20-Areas" / "Tools" / "Topics" / QUALITY_TEST_MONTH
     topic_dir.mkdir(parents=True, exist_ok=True)
     (vault / "60-Logs").mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
## Summary
- Track article-stage deep-dive files produced in the current run.
- Limit incremental quality checks to those outputs, with a recent-output fallback for quality-only incremental runs.
- Preserve full/current-month quality behavior outside incremental mode.

## Test Plan
- pytest tests/test_runtime_paths.py -k 'quality or absorb or execution_plan_incremental' -q\n- python -m compileall -q src/ovp_pipeline/unified_pipeline_enhanced.py src/ovp_pipeline/workflow_handlers.py\n- git diff --check\n- pytest -q (1135 passed; one UI server timeout passed on immediate rerun)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pipeline now supports incremental quality checking mode, targeting only newly produced content instead of full-scan analysis.
  * Quality stage automatically derives target files from previous execution results.

* **Tests**
  * Added unit tests validating incremental quality selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->