### PR TITLE
fix: P0-P2 dedup pipeline integration + promote semantic guard

### DIFF
--- a/src/ovp_pipeline/concept_dedup.py
+++ b/src/ovp_pipeline/concept_dedup.py
@@ -251,8 +251,31 @@ def _pick_canonical(members: list[DedupCandidate]) -> DedupCandidate:
     )
 
 
-def find_clusters(vault_dir: Path, *, threshold: float = DEFAULT_THRESHOLD) -> list[DedupCluster]:
+def find_clusters(
+    vault_dir: Path,
+    *,
+    threshold: float = DEFAULT_THRESHOLD,
+    scope_slugs: set[str] | None = None,
+) -> list[DedupCluster]:
+    """Find duplicate clusters among Evergreen files.
+
+    If *scope_slugs* is given, only candidates whose normalized slug is in the
+    scope set — or whose trigram-Jaccard similarity to any scope slug is above
+    *threshold* — are considered.  This makes incremental (post-absorb) runs
+    O(scope × N) instead of O(N²).
+    """
     cands = _scan_evergreen(vault_dir)
+    if scope_slugs is not None:
+        scope_norms = {_normalize_slug_for_compare(s) for s in scope_slugs}
+        filtered: list[DedupCandidate] = []
+        for c in cands:
+            cn = _normalize_slug_for_compare(c.slug)
+            if cn in scope_norms:
+                filtered.append(c)
+                continue
+            if any(trigram_jaccard(cn, sn) >= threshold for sn in scope_norms):
+                filtered.append(c)
+        cands = filtered
     raw = _cluster_by_similarity(cands, threshold=threshold)
     clusters: list[DedupCluster] = []
     for members, min_sim in raw:
@@ -263,6 +286,30 @@ def find_clusters(vault_dir: Path, *, threshold: float = DEFAULT_THRESHOLD) -> l
         clusters.append(DedupCluster(canonical=canonical, duplicates=dups, min_similarity=min_sim))
     clusters.sort(key=lambda c: (-len(c.duplicates), c.canonical.slug))
     return clusters
+
+
+def find_similar_slugs(
+    vault_dir: Path,
+    slug: str,
+    *,
+    threshold: float = DEFAULT_THRESHOLD,
+) -> list[tuple[str, float]]:
+    """Return existing Evergreen slugs with trigram-Jaccard >= *threshold* to *slug*.
+
+    Returns a list of ``(existing_slug, similarity)`` pairs sorted by
+    descending similarity.  An empty list means *slug* is sufficiently unique.
+    """
+    cands = _scan_evergreen(vault_dir)
+    norm = _normalize_slug_for_compare(slug)
+    hits: list[tuple[str, float]] = []
+    for c in cands:
+        if c.slug == slug:
+            continue
+        sim = trigram_jaccard(norm, _normalize_slug_for_compare(c.slug))
+        if sim >= threshold:
+            hits.append((c.slug, sim))
+    hits.sort(key=lambda t: -t[1])
+    return hits
 
 
 # ---------------------------------------------------------------------------

--- a/src/ovp_pipeline/concept_dedup.py
+++ b/src/ovp_pipeline/concept_dedup.py
@@ -267,13 +267,18 @@ def find_clusters(
     cands = _scan_evergreen(vault_dir)
     if scope_slugs is not None:
         scope_norms = {_normalize_slug_for_compare(s) for s in scope_slugs}
+        scope_ngrams = [_char_ngrams(sn) for sn in scope_norms]
         filtered: list[DedupCandidate] = []
         for c in cands:
             cn = _normalize_slug_for_compare(c.slug)
             if cn in scope_norms:
                 filtered.append(c)
                 continue
-            if any(trigram_jaccard(cn, sn) >= threshold for sn in scope_norms):
+            gn = _char_ngrams(cn)
+            if any(
+                len(gn & gs) / max(len(gn | gs), 1) >= threshold
+                for gs in scope_ngrams
+            ):
                 filtered.append(c)
         cands = filtered
     raw = _cluster_by_similarity(cands, threshold=threshold)
@@ -298,16 +303,24 @@ def find_similar_slugs(
 
     Returns a list of ``(existing_slug, similarity)`` pairs sorted by
     descending similarity.  An empty list means *slug* is sufficiently unique.
+
+    Uses a lightweight directory scan (filenames only) rather than reading
+    file contents, since only slugs are needed for comparison.
     """
-    cands = _scan_evergreen(vault_dir)
+    eg_dir = vault_dir / "10-Knowledge" / "Evergreen"
+    if not eg_dir.is_dir():
+        return []
     norm = _normalize_slug_for_compare(slug)
     hits: list[tuple[str, float]] = []
-    for c in cands:
-        if c.slug == slug:
+    for p in eg_dir.iterdir():
+        if not p.suffix == ".md" or p.name.startswith(("_", ".")):
             continue
-        sim = trigram_jaccard(norm, _normalize_slug_for_compare(c.slug))
+        existing_slug = p.stem
+        if existing_slug == slug:
+            continue
+        sim = trigram_jaccard(norm, _normalize_slug_for_compare(existing_slug))
         if sim >= threshold:
-            hits.append((c.slug, sim))
+            hits.append((existing_slug, sim))
     hits.sort(key=lambda t: -t[1])
     return hits
 

--- a/src/ovp_pipeline/promote_candidates.py
+++ b/src/ovp_pipeline/promote_candidates.py
@@ -288,13 +288,35 @@ def rewrite_candidate_links(
 
 
 def promote_candidate(vault_dir: Path, slug: str, dry_run: bool = True) -> LifecycleMutation:
-    """Promote a candidate and synchronize filesystem side effects."""
+    """Promote a candidate and synchronize filesystem side effects.
+
+    Before creating a new Evergreen, a trigram-Jaccard similarity check runs
+    against existing active slugs.  If a near-duplicate is found (>= 0.82),
+    the candidate is merged into the existing Evergreen instead of creating a
+    new file — preventing paraphrastic clones at the source.
+    """
     registry = ConceptRegistry(vault_dir).load()
     entry = registry.find_by_slug(slug)
     if not entry:
         raise ValueError(f"Concept '{slug}' not found")
     if entry.status != STATUS_CANDIDATE:
         raise ValueError(f"'{slug}' is not a candidate (status: {entry.status})")
+
+    try:
+        from .concept_dedup import find_similar_slugs
+
+        similar = find_similar_slugs(vault_dir, slug, threshold=0.82)
+        if similar:
+            best_slug, best_sim = similar[0]
+            best_entry = registry.find_by_slug(best_slug)
+            if best_entry and best_entry.status == "active":
+                print(
+                    f"  [dedup-guard] '{slug}' similar to active '{best_slug}' "
+                    f"(sim={best_sim:.2f}) — merging instead of promoting."
+                )
+                return merge_candidate(vault_dir, slug, best_slug, dry_run=dry_run)
+    except Exception:
+        pass
 
     mutation = LifecycleMutation(action="promote", slug=slug, target_slug=slug)
 

--- a/src/ovp_pipeline/promote_candidates.py
+++ b/src/ovp_pipeline/promote_candidates.py
@@ -303,20 +303,20 @@ def promote_candidate(vault_dir: Path, slug: str, dry_run: bool = True) -> Lifec
         raise ValueError(f"'{slug}' is not a candidate (status: {entry.status})")
 
     try:
-        from .concept_dedup import find_similar_slugs
+        from .concept_dedup import DEFAULT_THRESHOLD, find_similar_slugs
 
-        similar = find_similar_slugs(vault_dir, slug, threshold=0.82)
+        similar = find_similar_slugs(vault_dir, slug, threshold=DEFAULT_THRESHOLD)
         if similar:
             best_slug, best_sim = similar[0]
             best_entry = registry.find_by_slug(best_slug)
-            if best_entry and best_entry.status == "active":
+            if best_entry and best_entry.status == STATUS_ACTIVE:
                 print(
                     f"  [dedup-guard] '{slug}' similar to active '{best_slug}' "
                     f"(sim={best_sim:.2f}) — merging instead of promoting."
                 )
                 return merge_candidate(vault_dir, slug, best_slug, dry_run=dry_run)
-    except Exception:
-        pass
+    except Exception as exc:
+        print(f"  [dedup-guard] Warning: similarity check failed for '{slug}': {exc}")
 
     mutation = LifecycleMutation(action="promote", slug=slug, target_slug=slug)
 

--- a/src/ovp_pipeline/unified_pipeline_enhanced.py
+++ b/src/ovp_pipeline/unified_pipeline_enhanced.py
@@ -419,6 +419,7 @@ BASE_PIPELINE_STEPS = [
     "quality",        # 5. 质量检查
     "fix_links",      # 6. 修复断裂链接
     "absorb",         # 7. 吸收 Evergreen 生命周期动作（quality >= 3.0 才能执行）
+    "dedup",          # 7a. 去重刚吸收的 Evergreen（scope 限于本轮 absorb 产出）
     "note_type_normalize",  # 8. 规范化 note_type 元数据
     "registry_sync",  # 9. 同步Registry与文件系统
     "moc",            # 10. 更新MOC
@@ -2304,10 +2305,16 @@ class EnhancedPipeline:
                 "stderr": stderr,
             },
         )
+        promoted_slugs: list[str] = []
+        for item in results:
+            for concept in (item.get("concepts") or []):
+                if concept.get("status") == "promoted_created" and concept.get("slug"):
+                    promoted_slugs.append(concept["slug"])
         result = {
             "success": success,
             "stdout": stdout,
             "stderr": stderr,
+            "promoted_slugs": promoted_slugs,
             **payload,
         }
         if not success:
@@ -2557,6 +2564,76 @@ class EnhancedPipeline:
     def step_evergreen(self, recent_days: int = 7, dry_run: bool = False, quality_score: float = -1.0) -> dict:
         """兼容旧调用，内部转到 Absorb。"""
         return self.step_absorb(recent_days=recent_days, dry_run=dry_run, quality_score=quality_score)
+
+    def step_dedup(self, dry_run: bool = False) -> dict:
+        """Post-absorb deduplication scoped to recently absorbed slugs."""
+        print("\n" + "=" * 60)
+        print("STEP 7a: Dedup Evergreen (scoped to absorbed)")
+        print("=" * 60)
+
+        from .concept_dedup import (
+            apply_proposal,
+            find_clusters,
+            write_proposal,
+        )
+
+        scope_slugs: set[str] | None = None
+        absorb_result = self.step_results.get("absorb")
+        if absorb_result and isinstance(absorb_result, dict):
+            promoted = absorb_result.get("promoted_slugs") or []
+            if promoted:
+                scope_slugs = set(promoted)
+
+        threshold = 0.82
+        clusters = find_clusters(self.vault_dir, threshold=threshold, scope_slugs=scope_slugs)
+
+        if not clusters:
+            scope_desc = f"scope={len(scope_slugs)} slugs" if scope_slugs else "full vault"
+            print(f"  No duplicates found ({scope_desc}, threshold={threshold}).")
+            return {"success": True, "clusters": 0, "archived": 0, "rewrites": 0}
+
+        prop_path, proposal = write_proposal(self.vault_dir, clusters, threshold=threshold)
+        print(f"  Proposal: {prop_path.name} ({len(clusters)} cluster(s))")
+
+        if dry_run:
+            for cl in clusters:
+                dups = ", ".join(d.slug for d in cl.duplicates)
+                print(f"    [DRY] {cl.canonical.slug} ← {dups}")
+            return {
+                "success": True,
+                "clusters": len(clusters),
+                "archived": 0,
+                "rewrites": 0,
+                "dry_run": True,
+                "proposal_id": proposal.proposal_id,
+            }
+
+        results = apply_proposal(
+            self.vault_dir, proposal, dry_run=False, pack=self.pack_name
+        )
+        from .concept_dedup import archive_applied_proposal
+        archive_applied_proposal(self.vault_dir, prop_path)
+
+        total_archived = sum(len(r.archived) for r in results)
+        total_rewrites = sum(r.wikilink_rewrites for r in results)
+        errors = [e for r in results for e in r.errors]
+
+        for r in results:
+            dups = ", ".join(str(p.name) for p in r.archived) if r.archived else "(none)"
+            print(f"    {r.canonical_slug}: archived={len(r.archived)} rewrites={r.wikilink_rewrites}")
+
+        if errors:
+            for e in errors:
+                print(f"    [WARN] {e}")
+
+        print(f"  ✓ Dedup complete: {len(clusters)} clusters, {total_archived} archived, {total_rewrites} rewrites")
+        return {
+            "success": not errors,
+            "clusters": len(clusters),
+            "archived": total_archived,
+            "rewrites": total_rewrites,
+            "errors": errors,
+        }
 
     def step_moc(self, dry_run: bool = False) -> dict:
         """执行MOC更新步骤"""

--- a/src/ovp_pipeline/unified_pipeline_enhanced.py
+++ b/src/ovp_pipeline/unified_pipeline_enhanced.py
@@ -2572,6 +2572,7 @@ class EnhancedPipeline:
         print("=" * 60)
 
         from .concept_dedup import (
+            DEFAULT_THRESHOLD,
             apply_proposal,
             find_clusters,
             write_proposal,
@@ -2584,7 +2585,7 @@ class EnhancedPipeline:
             if promoted:
                 scope_slugs = set(promoted)
 
-        threshold = 0.82
+        threshold = DEFAULT_THRESHOLD
         clusters = find_clusters(self.vault_dir, threshold=threshold, scope_slugs=scope_slugs)
 
         if not clusters:

--- a/tests/test_concept_dedup.py
+++ b/tests/test_concept_dedup.py
@@ -14,6 +14,7 @@ from ovp_pipeline.concept_dedup import (
     apply_proposal,
     archive_applied_proposal,
     find_clusters,
+    find_similar_slugs,
     list_proposals,
     load_proposal,
     trigram_jaccard,
@@ -352,3 +353,73 @@ def test_concept_dedup_apply_uses_vault_workflow_lock(tmp_path: Path, monkeypatc
 
     assert exit_code == 0
     assert calls == ["enter", "apply", "archive", "exit"]
+
+
+# ---------------------------------------------------------------------------
+# scope_slugs filtering
+# ---------------------------------------------------------------------------
+
+
+def test_find_clusters_scope_slugs_limits_search(tmp_path: Path):
+    """Only candidates in scope (or similar to scope) should be clustered."""
+    _evergreen(tmp_path, "MCP-Client", body="canonical " * 10)
+    _evergreen(tmp_path, "MCP-Clients", body="dup")
+    _evergreen(tmp_path, "Vector-Database", body="canonical " * 10)
+    _evergreen(tmp_path, "Vector-Databases", body="dup")
+
+    clusters = find_clusters(tmp_path, threshold=0.5, scope_slugs={"MCP-Client"})
+    slugs_in_clusters = {c.canonical.slug for c in clusters} | {
+        d.slug for c in clusters for d in c.duplicates
+    }
+    assert "MCP-Client" in slugs_in_clusters or "MCP-Clients" in slugs_in_clusters
+    assert "Vector-Database" not in slugs_in_clusters
+    assert "Vector-Databases" not in slugs_in_clusters
+
+
+def test_find_clusters_scope_slugs_none_returns_all(tmp_path: Path):
+    _evergreen(tmp_path, "MCP-Client", body="canonical " * 10)
+    _evergreen(tmp_path, "MCP-Clients", body="dup")
+    _evergreen(tmp_path, "Vector-Database", body="canonical " * 10)
+    _evergreen(tmp_path, "Vector-Databases", body="dup")
+
+    clusters_all = find_clusters(tmp_path, threshold=0.5, scope_slugs=None)
+    assert len(clusters_all) == 2
+
+
+def test_find_clusters_scope_slugs_empty_set_returns_none(tmp_path: Path):
+    _evergreen(tmp_path, "MCP-Client", body="canonical " * 10)
+    _evergreen(tmp_path, "MCP-Clients", body="dup")
+
+    clusters = find_clusters(tmp_path, threshold=0.5, scope_slugs=set())
+    assert clusters == []
+
+
+# ---------------------------------------------------------------------------
+# find_similar_slugs
+# ---------------------------------------------------------------------------
+
+
+def test_find_similar_slugs_returns_matches(tmp_path: Path):
+    _evergreen(tmp_path, "MCP-Client", body="canonical " * 10)
+    _evergreen(tmp_path, "MCP-Clients", body="dup")
+    _evergreen(tmp_path, "Unrelated-Concept", body="no match")
+
+    hits = find_similar_slugs(tmp_path, "MCP-Client", threshold=0.5)
+    matched_slugs = {s for s, _ in hits}
+    assert "MCP-Clients" in matched_slugs
+    assert "Unrelated-Concept" not in matched_slugs
+
+
+def test_find_similar_slugs_excludes_self(tmp_path: Path):
+    _evergreen(tmp_path, "MCP-Client", body="body")
+
+    hits = find_similar_slugs(tmp_path, "MCP-Client", threshold=0.1)
+    assert all(s != "MCP-Client" for s, _ in hits)
+
+
+def test_find_similar_slugs_empty_when_no_match(tmp_path: Path):
+    _evergreen(tmp_path, "Quantum-Computing")
+    _evergreen(tmp_path, "Banana-Bread")
+
+    hits = find_similar_slugs(tmp_path, "MCP-Client", threshold=0.8)
+    assert hits == []

--- a/tests/test_promote_semantic_check.py
+++ b/tests/test_promote_semantic_check.py
@@ -1,0 +1,107 @@
+"""Tests for P2 — semantic similarity guard in promote_candidate."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from ovp_pipeline.concept_registry import ConceptRegistry
+from ovp_pipeline.promote_candidates import (
+    merge_candidate,
+    promote_candidate,
+)
+
+
+def _setup_vault(vault: Path) -> None:
+    """Create minimal vault layout required by promote_candidate."""
+    (vault / "10-Knowledge" / "Evergreen").mkdir(parents=True, exist_ok=True)
+    (vault / "10-Knowledge" / "Atlas").mkdir(parents=True, exist_ok=True)
+    (vault / "10-Knowledge" / "Atlas" / "Atlas-Index.md").write_text(
+        "---\ntitle: Atlas Index\n---\n", encoding="utf-8"
+    )
+    (vault / "60-Logs").mkdir(parents=True, exist_ok=True)
+
+
+def _register_candidate(vault: Path, slug: str, title: str = "") -> None:
+    registry = ConceptRegistry(vault).load()
+    registry.upsert_candidate(
+        slug=slug,
+        title=title or slug.replace("-", " "),
+        definition="test def",
+        area="general",
+        aliases=[slug],
+    )
+    registry.save()
+
+
+def _register_active(vault: Path, slug: str, title: str = "") -> None:
+    registry = ConceptRegistry(vault).load()
+    registry.upsert_candidate(
+        slug=slug,
+        title=title or slug.replace("-", " "),
+        definition="test def",
+        area="general",
+        aliases=[slug],
+    )
+    registry.promote_to_active(slug)
+    registry.save()
+    eg = vault / "10-Knowledge" / "Evergreen" / f"{slug}.md"
+    eg.write_text(
+        dedent(f"""\
+        ---
+        title: "{title or slug.replace('-', ' ')}"
+        type: evergreen
+        ---
+
+        Body of {slug}.
+        """),
+        encoding="utf-8",
+    )
+
+
+def test_promote_merges_when_similar_active_exists(tmp_path: Path):
+    _setup_vault(tmp_path)
+    _register_active(
+        tmp_path,
+        "retrieval-augmented-generation",
+        "Retrieval Augmented Generation",
+    )
+    _register_candidate(
+        tmp_path,
+        "retrieval-augmented-generations",
+        "Retrieval Augmented Generations",
+    )
+
+    mutation = promote_candidate(
+        tmp_path, "retrieval-augmented-generations", dry_run=False
+    )
+
+    assert mutation.action == "merge"
+    assert mutation.target_slug == "retrieval-augmented-generation"
+
+
+def test_promote_creates_new_when_no_similar(tmp_path: Path):
+    _setup_vault(tmp_path)
+    _register_active(tmp_path, "quantum-computing", "Quantum Computing")
+    _register_candidate(tmp_path, "banana-bread-recipe", "Banana Bread Recipe")
+
+    mutation = promote_candidate(tmp_path, "banana-bread-recipe", dry_run=False)
+
+    assert mutation.action == "promote"
+    assert mutation.slug == "banana-bread-recipe"
+
+
+def test_promote_guard_does_not_match_inactive(tmp_path: Path):
+    """If the similar slug is not active, do NOT merge — just promote normally."""
+    _setup_vault(tmp_path)
+    _register_candidate(tmp_path, "mcp-client")
+    _register_candidate(tmp_path, "mcp-clients")
+    (tmp_path / "10-Knowledge" / "Evergreen" / "mcp-clients.md").write_text(
+        '---\ntitle: "MCP Clients"\ntype: evergreen\n---\nbody\n', encoding="utf-8"
+    )
+
+    mutation = promote_candidate(tmp_path, "mcp-client", dry_run=False)
+
+    assert mutation.action == "promote"


### PR DESCRIPTION
## Summary

- **P0 Data Cleanup**: Ran `concept_dedup` to clean 10 historical duplicate Evergreens (archived + rewrote 44 wikilinks), reducing total from 71 to 61
- **P1 Pipeline Integration**: Added `dedup` step to DAG after `absorb`, scoped to recently promoted slugs via new `scope_slugs` param in `find_clusters()` + new `find_similar_slugs()` utility
- **P2 Semantic Guard**: `promote_candidate()` now checks trigram-Jaccard similarity (>= 0.82) against active Evergreens before promoting — merges into existing concept instead of creating paraphrastic clones

## Changes

| File | What changed |
|------|-------------|
| `concept_dedup.py` | `scope_slugs` param for `find_clusters()` + new `find_similar_slugs()` |
| `unified_pipeline_enhanced.py` | New `step_dedup()` in DAG + `promoted_slugs` output from absorb |
| `promote_candidates.py` | Pre-promote similarity check with merge fallback |
| `test_concept_dedup.py` | 6 new tests for scope_slugs + find_similar_slugs |
| `test_promote_semantic_check.py` | 3 new tests for promote semantic guard |

## Test plan

- [x] 6 scope_slugs + find_similar_slugs tests pass
- [x] 3 promote semantic guard tests pass
- [x] Full test suite: 1189 passed


Made with [Cursor](https://cursor.com)