### PR TITLE
chore: bump version to 0.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "obsidian-vault-pipeline"
-version = "0.9.2"
+version = "0.10.0"
 description = "全自动Obsidian知识管理Pipeline - 生产级知识管理流水线"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump pyproject.toml version from 0.9.2 to 0.10.0
- M8 (Canonical Object Kind Taxonomy) and M9 (Pack as Domain Ontology) warrant a minor version bump

## After merge
Tag `v0.10.0` on main.


Made with [Cursor](https://cursor.com)