### PR TITLE
fix: backfill entity_type for 51 existing Evergreen notes

### DIFF
--- a/10-Knowledge/Evergreen/Agent-task-complexity-guides-architecture.md
+++ b/10-Knowledge/Evergreen/Agent-task-complexity-guides-architecture.md
@@ -1,0 +1,40 @@
+---
+schema_version: "1.0.0"
+note_id: agent-task-complexity-guides-architecture-0e7b8efb
+title: "Agent架构应根据任务复杂度分级设计"
+type: evergreen
+entity_type: concept
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["Agent-task-complexity-guides-architecture"]
+---
+
+# Agent架构应根据任务复杂度分级设计
+
+> **一句话定义**: 简单任务可使用纯LLM，中等复杂度需要基础推理+行动循环，复杂任务（长期目标）需要多Agent协作+记忆+反思机制。
+
+## 📝 详细解释
+
+### 是什么？
+任务复杂度决定Agent架构选择：1) 简单任务（单轮问答、摘要等）：直接使用LLM，不需要Agent架构，过度设计会引入不必要的复杂性；2) 中等任务（多步骤操作、多工具调用）：实现基础的Perception-Reasoning-Action循环，加入短期上下文记忆；3) 复杂任务（研究代理、项目管理、长期目标）：设计多Agent协作系统，加入长期记忆（知识库）、反思机制（self-reflection）、主动规划能力。架构复杂度应匹配任务需求，避免over-engineering。
+
+### 为什么重要？
+正确的架构选择决定系统可行性和可维护性。理解任务复杂度与架构的对应关系是Agent系统设计的第一步，避免过度设计或设计不足。
+
+## 🔗 关联概念
+- [[AI-Agent]]
+- [[Memory-Mechanism]]
+- [[Multi-Agent-Collaboration]]
+- [[Self-Reflection]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[ai-agent-task-complexity评估|AI Agent architecture should match task complexity level]]
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[agent-autonomous-capability-c35f723f|AI Agent具备自主感知、推理和行动能力]]
+- [[ai-agent-performs-perception-reasoning-action-d533b9f1|AI Agent执行感知-推理-行动的反馈循环]]
+- [[agent-autonomy-9be9ea0e|AI Agent具备自主性，能够自主感知、推理和行动]]

--- a/10-Knowledge/Evergreen/Agent-tool-use-via-function-calling.md
+++ b/10-Knowledge/Evergreen/Agent-tool-use-via-function-calling.md
@@ -1,0 +1,41 @@
+---
+schema_version: "1.0.0"
+note_id: agent-tool-use-via-function-calling-12ab48fa
+title: "Agent通过Function Calling调用外部工具执行实际操作"
+type: evergreen
+entity_type: method
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["Agent-tool-use-via-function-calling", "function-calling-tool-use"]
+---
+
+# Agent通过Function Calling调用外部工具执行实际操作
+
+> **一句话定义**: Function Calling是Agent调用外部函数、API或工具的技术机制，使Agent能够突破模型本体限制，执行搜索、计算、数据库查询、代码执行等实际操作。
+
+## 📝 详细解释
+
+### 是什么？
+Function Calling允许LLM生成结构化的函数调用请求，由执行环境解析并调用相应工具。Agent的行动(Action)能力本质上依赖于Function Calling机制。工具生态系统包括：基础工具（搜索引擎、计算器、日历）、业务工具（CRM系统、代码仓库）、执行工具（API调用、代码沙箱、文件操作）。Agent的能力边界很大程度上由其可调用的工具决定。
+
+### 为什么重要？
+没有Function Calling，Agent只能生成文本响应而无法真正影响环境或完成任务。工具集成是Agent实现复杂任务自动化的关键。
+
+## 🔗 关联概念
+- [[AI-Agent]]
+- [[Action]]
+- [[MCP-Protocol]]
+- [[Tool-Use]]
+- [[API-Integration]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[agent-tool-use-capability-0c5535bf|AI Agent capability is bounded by its tool ecosystem]]
+- [[ai-agent-task-complexity评估|AI Agent architecture should match task complexity level]]
+- [[multi-modal-perception-e8af11cc|AI Agent感知模块支持多模态输入]]
+- [[ai-agent-has-perception-reasoning-action-capabilities|AI Agent具有感知、推理、行动三大核心能力]]
+- [[ai-agent-performs-perception-reasoning-action-d533b9f1|AI Agent执行感知-推理-行动的反馈循环]]

--- a/10-Knowledge/Evergreen/MCP-Protocol-standardizes-tool-integration.md
+++ b/10-Knowledge/Evergreen/MCP-Protocol-standardizes-tool-integration.md
@@ -1,0 +1,40 @@
+---
+schema_version: "1.0.0"
+note_id: mcp-protocol-standardizes-tool-integration-5f2e65b7
+title: "MCP Protocol标准化Agent的工具集成"
+type: evergreen
+entity_type: tool
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["MCP-Protocol-standardizes-tool-integration", "mcp-protocol-standardizes-agent-tool-integration"]
+---
+
+# MCP Protocol标准化Agent的工具集成
+
+> **一句话定义**: MCP Protocol (Model Context Protocol) 是一个开放的标准化协议，定义了Agent与外部工具、服务交互的统一接口，使Agent能够灵活扩展工具能力。
+
+## 📝 详细解释
+
+### 是什么？
+MCP Protocol由Anthropic提出，旨在解决Agent工具集成的碎片化问题。传统方式下每个工具需要独立集成，而MCP提供统一的通信协议，Agent可以动态发现和调用支持MCP的服务。协议定义了：工具描述格式、调用语义、结果返回结构、上下文传递机制。该协议使Agent具备可扩展的工具生态系统，是构建下一代Agent应用的基础设施。
+
+### 为什么重要？
+标准化协议降低工具集成成本，使Agent能够动态扩展能力，实现真正的 plug-and-play 工具生态，是Agent架构演进的重要趋势。
+
+## 🔗 关联概念
+- [[Function-Calling]]
+- [[Tool-Use]]
+- [[AI-Agent-Architecture]]
+- [[API-Integration]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[ai-agent-tool-ecosystem|AI Agent capabilities are bounded by its tool ecosystem]]
+- [[ai-agent-task-complexity评估|AI Agent architecture should match task complexity level]]
+- [[multi-modal-perception-e8af11cc|AI Agent感知模块支持多模态输入]]
+- [[ai-agent-performs-perception-reasoning-action-d533b9f1|AI Agent执行感知-推理-行动的反馈循环]]

--- a/10-Knowledge/Evergreen/ReAct-reasoning-combines-thought-and-action.md
+++ b/10-Knowledge/Evergreen/ReAct-reasoning-combines-thought-and-action.md
@@ -1,0 +1,41 @@
+---
+schema_version: "1.0.0"
+note_id: react-reasoning-combines-thought-and-action-8d4fe6c2
+title: "ReAct Reasoning策略结合推理与行动"
+type: evergreen
+entity_type: framework
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["ReAct-reasoning-combines-thought-and-action"]
+---
+
+# ReAct Reasoning策略结合推理与行动
+
+> **一句话定义**: ReAct (Reasoning + Acting) 是一种prompt策略，让Agent在推理过程中交替进行思考和行动调用，通过实际行动获取的反馈来增强推理准确性。
+
+## 📝 详细解释
+
+### 是什么？
+ReAct策略由Google提出，核心思想是在每个推理步骤中，Agent不仅生成思考(thought)，还决定是否需要采取行动(action)。例如：思考「用户询问最新股价」→ 行动「调用股票API获取价格」→ 观察「返回数据」→ 思考「基于数据进行分析」。这种交织方式使Agent能够：1) 获取实时信息辅助推理；2) 纠正推理错误；3) 处理需要多步骤信息收集的复杂问题。与单纯的Chain of Thought相比，ReAct通过实际行动获取外部知识，减少幻觉。
+
+### 为什么重要？
+ReAct是Agent实现有效推理的核心策略之一，使Agent能够主动获取环境信息而不是仅依赖训练数据，是构建可靠Agent系统的关键技术。
+
+## 🔗 关联概念
+- [[Reasoning]]
+- [[Chain-of-Thought]]
+- [[AI-Agent]]
+- [[Observation]]
+- [[Tool-Use]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[ai-agent-has-perception-reasoning-action-capabilities|AI Agent具有感知、推理、行动三大核心能力]]
+- [[ai-agent-performs-perception-reasoning-action-d533b9f1|AI Agent执行感知-推理-行动的反馈循环]]
+- [[multi-modal-perception-e8af11cc|AI Agent感知模块支持多模态输入]]
+- [[react-reasoning-strategy-80329943|📝 详细解释]]

--- a/10-Knowledge/Evergreen/agent-action-module-transforms-decisions-into-execution.md
+++ b/10-Knowledge/Evergreen/agent-action-module-transforms-decisions-into-execution.md
@@ -1,0 +1,40 @@
+---
+schema_version: "1.0.0"
+note_id: agent-action-module-transforms-decisions-into-exec-8aaadf2b
+title: "Agent action module transforms decisions into execution"
+type: evergreen
+entity_type: concept
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["agent-action-module-transforms-decisions-into-execution"]
+---
+
+# Agent action module transforms decisions into execution
+
+> **一句话定义**: 行动模块将推理决策转化为实际行动，包括信息检索、内容生成、工具调用、系统操作等
+
+## 📝 详细解释
+
+### 是什么？
+Action模块负责将Reasoning阶段的决策转化为具体操作，影响外部环境。行动类型包括：信息检索（查询数据库、搜索文档）、内容生成（生成文本、代码、图像）、工具调用（调用API、执行函数）、系统操作（修改数据、触发流程）等。Action模块需要与外部系统进行集成，是Agent产生实际价值的环节。
+
+### 为什么重要？
+行动模块是Agent产生实际价值的环节，再好的推理如果无法转化为有效行动则无法实现目标闭环
+
+## 🔗 关联概念
+- [[Perception-Reasoning-Action]]
+- [[Tool-Calling]]
+- [[API-Integration]]
+- [[Execution]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[ai-agent-has-perception-reasoning-action-capabilities|AI Agent具有感知、推理、行动三大核心能力]]
+- [[agent-tool-use-capability-0c5535bf|AI Agent capability is bounded by its tool ecosystem]]
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[ai-agent-autonomous-vs-passive-ai|AI Agent代表从被动响应到自主执行的范式转变]]
+- [[ai-agent-definition-411752f4|AI Agent是具备感知、推理、行动能力的自主系统]]

--- a/10-Knowledge/Evergreen/agent-action-module.md
+++ b/10-Knowledge/Evergreen/agent-action-module.md
@@ -1,0 +1,39 @@
+---
+schema_version: "1.0.0"
+note_id: agent-action-module-b91d3ae4
+title: "Action模块将决策转化为实际行动"
+type: evergreen
+entity_type: concept
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["agent-action-module"]
+---
+
+# Action模块将决策转化为实际行动
+
+> **一句话定义**: Action模块负责执行推理阶段生成的计划，包括信息检索、内容生成、工具调用、系统操作等行动类型
+
+## 📝 详细解释
+
+### 是什么？
+行动模块是Agent影响环境的唯一途径，需要与外部系统进行集成。它接收推理模块的输出，将其转化为具体的操作步骤，如调用API、生成内容、修改数据等。执行结果会反馈到感知阶段，形成完整的闭环
+
+### 为什么重要？
+行动是Agent价值的最终体现，再好的推理如果不能有效执行则毫无意义
+
+## 🔗 关联概念
+- [[perception-reasoning-action-architecture]]
+- [[agent-feedback-loop]]
+- [[external-system-integration]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[ai-agent-has-perception-reasoning-action-capabilities|AI Agent具有感知、推理、行动三大核心能力]]
+- [[ai-agent-definition-411752f4|AI Agent是具备感知、推理、行动能力的自主系统]]
+- [[multimodal-perception-96f84e06|AI Agent支持多模态感知输入]]
+- [[feedback-loop-mechanism-8a1b68aa|🔗 关联概念]]

--- a/10-Knowledge/Evergreen/agent-autonomous-capability.md
+++ b/10-Knowledge/Evergreen/agent-autonomous-capability.md
@@ -1,0 +1,40 @@
+---
+schema_version: "1.0.0"
+note_id: agent-autonomous-capability-c35f723f
+title: "AI Agent具备自主感知、推理和行动能力"
+type: evergreen
+entity_type: concept
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["agent-autonomous-capability"]
+---
+
+# AI Agent具备自主感知、推理和行动能力
+
+> **一句话定义**: Agent区别于传统被动AI系统的核心在于其自主性，能够自主感知环境变化、基于目标进行推理决策、主动执行行动完成任务
+
+## 📝 详细解释
+
+### 是什么？
+传统AI系统需要人类明确触发才能执行任务，属于被动响应式。而Agent具备三大自主能力：1)自主感知环境变化（无需人工干预）2)基于目标进行推理决策（而非简单规则匹配）3)主动执行行动（而非等待指令）。这代表了AI从被动响应向主动智能的演进
+
+### 为什么重要？
+自主性是Agent的本质特征，决定了Agent能够独立完成复杂任务，是评估一个系统是否属于Agent的标准，也是AI发展的下一阶段方向
+
+## 🔗 关联概念
+- [[Passive-AI-Systems]]
+- [[AI-Evolution]]
+- [[Goal-Oriented-Behavior]]
+- [[Autonomous-Systems]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[ai-agent-enables-autonomous-behavior-64c858a0|AI Agent实现从被动响应到主动智能的演进]]
+- [[agent-autonomy-9be9ea0e|AI Agent具备自主性，能够自主感知、推理和行动]]
+- [[ai-agent-core-characteristics-ab47e9e1|AI Agent具有四大核心特性：自主性、反应性、主动性和社会性]]
+- [[autonomous-task-execution-0dae97b5|AI Agent实现复杂任务的自主执行]]

--- a/10-Knowledge/Evergreen/agent-autonomy-paradigm.md
+++ b/10-Knowledge/Evergreen/agent-autonomy-paradigm.md
@@ -1,0 +1,40 @@
+---
+schema_version: "1.0.0"
+note_id: agent-autonomy-paradigm-4dd305f5
+title: "AI agents represent paradigm shift from passive to autonomous systems"
+type: evergreen
+entity_type: concept
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["agent-autonomy-paradigm"]
+---
+
+# AI agents represent paradigm shift from passive to autonomous systems
+
+> **一句话定义**: AI Agent代表人工智能从被动响应用户指令向自主理解目标、主动规划执行任务的范式转变
+
+## 📝 详细解释
+
+### 是什么？
+传统AI（搜索引擎、SOTA LLM）是『被动响应型』——用户输入-query，AI输出-response。而Agent是『自主目标导向型』——用户给出高层目标，Agent自主理解目标、制定计划、调用工具、执行任务、反馈结果。这种转变的核心价值：1) 用户不再需要给出每一步具体指令；2) 能处理需要多步骤、长时间跨度的复杂任务；3) 能与外部系统进行实时交互。Agent的自主性来自Perception-Reasoning-Action架构、工具生态、记忆机制（短期上下文+长期知识）的组合
+
+### 为什么重要？
+理解这一范式转变是设计Agent系统的前提。Agent不是『更聪明的LLM』，而是一种全新的系统架构——从单一模型向多组件系统演进。这决定了我们在设计Agent时需要考虑：任务复杂度评估（简单任务无需Agent）、工具集成、记忆设计、多Agent协作等架构问题，而非仅关注模型选择
+
+## 🔗 关联概念
+- [[Perception-Reasoning-Action-Loop]]
+- [[Agent-Tool-Ecosystem]]
+- [[Autonomous-Systems]]
+- [[Task-Complexity]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[agent-autonomy-9be9ea0e|AI Agent具备自主性，能够自主感知、推理和行动]]
+- [[ai-agent-core-characteristics-ab47e9e1|AI Agent具有四大核心特性：自主性、反应性、主动性和社会性]]
+- [[agent-autonomous-capability-c35f723f|AI Agent具备自主感知、推理和行动能力]]
+- [[ai-agent-task-complexity评估|AI Agent architecture should match task complexity level]]

--- a/10-Knowledge/Evergreen/agent-autonomy.md
+++ b/10-Knowledge/Evergreen/agent-autonomy.md
@@ -1,0 +1,39 @@
+---
+schema_version: "1.0.0"
+note_id: agent-autonomy-9be9ea0e
+title: "AI Agent具备自主性，能够自主感知、推理和行动"
+type: evergreen
+entity_type: concept
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["agent-autonomy", "ai-agent-autonomy"]
+---
+
+# AI Agent具备自主性，能够自主感知、推理和行动
+
+> **一句话定义**: AI Agent的自主性是指系统能够自主感知环境变化、基于目标进行推理决策、主动执行行动完成任务的能力。
+
+## 📝 详细解释
+
+### 是什么？
+传统的AI系统多为被动响应式，需要人类明确触发才能执行任务。而AI Agent具备自主性特征：能够自主感知环境变化（无需人为触发即可接收环境信息）；能够基于目标进行推理决策（理解意图、检索知识、制定计划）；能够主动执行行动完成任务（将决策转化为实际行动并影响环境）。这种自主性使Agent能够处理复杂、动态的任务场景。
+
+### 为什么重要？
+自主性是AI Agent区别于传统AI系统的核心特征，也是评估Agent能力的重要指标。自主性越强，Agent的应用价值越高。
+
+## 🔗 关联概念
+- [[ai-agent-definition]]
+- [[autonomous-systems]]
+- [[ai-evolution]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[ai-agent-core-characteristics-ab47e9e1|AI Agent具有四大核心特性：自主性、反应性、主动性和社会性]]
+- [[ai-agent-enables-autonomous-behavior-64c858a0|AI Agent实现从被动响应到主动智能的演进]]
+- [[ai-agent-definition-core-features-2d802700|AI Agent是具有自主性的软件系统]]
+- [[ai-agent-task-complexity评估|AI Agent architecture should match task complexity level]]

--- a/10-Knowledge/Evergreen/agent-memory-architecture-supports-context-persistence.md
+++ b/10-Knowledge/Evergreen/agent-memory-architecture-supports-context-persistence.md
@@ -1,0 +1,39 @@
+---
+schema_version: "1.0.0"
+note_id: agent-memory-architecture-supports-context-persist-b0945f29
+title: "Agent Memory架构支持上下文持久化"
+type: evergreen
+entity_type: concept
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["agent-memory-architecture-supports-context-persistence"]
+---
+
+# Agent Memory架构支持上下文持久化
+
+> **一句话定义**: AI Agent采用分层Memory架构——短期记忆（上下文窗口）和长期记忆（知识库）——实现任务连续性和个性化交互。
+
+## 📝 详细解释
+
+### 是什么？
+短期记忆利用LLM的context window存储当前会话的临时信息（任务进度、中间结果、用户偏好），随着对话进行动态更新；长期记忆将重要信息持久化存储到外部知识库，支持跨会话的个性化（用户历史、积累知识）。这种分层设计使Agent能够：处理长周期任务（记住之前步骤）、积累经验（从历史中学习）、多会话连续性（不丢失上下文）。Memory是Agent实现真正自主性的关键组件。
+
+### 为什么重要？
+Memory架构解决LLM的上下文限制，使Agent能够处理需要多步骤、跨会话的复杂任务，是实现长期目标导向行为的基础。
+
+## 🔗 关联概念
+- [[Perception-Reasoning-Action-Loop]]
+- [[AI-Agent]]
+- [[Context-Window]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[ai-agent-core-characteristics-ab47e9e1|AI Agent具有四大核心特性：自主性、反应性、主动性和社会性]]
+- [[agent-autonomy-9be9ea0e|AI Agent具备自主性，能够自主感知、推理和行动]]
+- [[ai-agent-task-complexity评估|AI Agent architecture should match task complexity level]]
+- [[agent-memory-mechanism-a48a7e0f|AI Agent requires layered memory mechanism]]

--- a/10-Knowledge/Evergreen/agent-memory-mechanism.md
+++ b/10-Knowledge/Evergreen/agent-memory-mechanism.md
@@ -1,0 +1,39 @@
+---
+schema_version: "1.0.0"
+note_id: agent-memory-mechanism-a48a7e0f
+title: "AI Agent requires layered memory mechanism"
+type: evergreen
+entity_type: concept
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["agent-memory-mechanism"]
+---
+
+# AI Agent requires layered memory mechanism
+
+> **一句话定义**: AI Agent需要分层记忆机制，包括短期记忆（上下文）和长期记忆（知识库）来实现持续任务执行。
+
+## 📝 详细解释
+
+### 是什么？
+对于复杂任务和长期目标，Agent需要记忆机制来保持任务连续性。短期记忆（Short-term Memory）通常通过Context Window实现，存储当前会话的上下文信息；长期记忆（Long-term Memory）通过外部知识库或向量数据库实现，存储跨会话的知识和经验。多Agent协作系统中，还需要Agent间的共享记忆来协调任务。记忆机制使Agent能够记住之前行动的 результат、反思策略有效性、积累学习经验，是实现真正自主性的关键组件。
+
+### 为什么重要？
+复杂任务的Agent系统离不开记忆机制的支持，缺少记忆的Agent只能完成单轮任务，无法实现持续的目标追求。
+
+## 🔗 关联概念
+- [[ai-agents-perception-reasoning-action-loop]]
+- [[Autonomous-Systems]]
+- [[Tool-Use]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[ai-agent-task-complexity评估|AI Agent architecture should match task complexity level]]
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[ai-agent-has-perception-reasoning-action-capabilities|AI Agent具有感知、推理、行动三大核心能力]]
+- [[ai-agent-core-characteristics-ab47e9e1|AI Agent具有四大核心特性：自主性、反应性、主动性和社会性]]
+- [[ai-agent-definition-411752f4|AI Agent是具备感知、推理、行动能力的自主系统]]

--- a/10-Knowledge/Evergreen/agent-memory-requires-layered-design.md
+++ b/10-Knowledge/Evergreen/agent-memory-requires-layered-design.md
@@ -1,0 +1,37 @@
+---
+title: "Agent的记忆机制需要分层设计"
+type: evergreen
+entity_type: concept
+date: 2026-04-07
+tags: [evergreen]
+aliases: ["agent-memory-requires-layered-design"]
+---
+
+# Agent的记忆机制需要分层设计
+
+> **一句话定义**: Agent的记忆机制通常采用短期记忆（上下文）和长期记忆（知识库）的分层设计，以支持短期任务执行和长期知识积累。
+
+## 📝 详细解释
+
+### 是什么？
+短期记忆存储当前任务上下文，使Agent能够理解对话历史和当前状态；长期记忆存储跨任务的知识和经验，使Agent能够从历史交互中学习。分层设计确保Agent既能处理当前任务，又能在多次交互中积累知识。长期记忆通常采用向量数据库等知识检索技术实现。
+
+### 为什么重要？
+记忆机制是Agent实现持续性任务和个性化服务的基础。对于需要多轮交互或长期目标导向的复杂任务，缺少记忆机制将导致Agent无法保持上下文一致性，也无法从历史经验中学习。
+
+## 🔗 关联概念
+- [[AI-Agent-Architecture]]
+- [[Perception-Reasoning-Action]]
+- [[Autonomous-Systems]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[ai-agent-task-complexity评估|AI Agent architecture should match task complexity level]]
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[ai-agent-performs-perception-reasoning-action-d533b9f1|AI Agent执行感知-推理-行动的反馈循环]]
+- [[multi-modal-perception-e8af11cc|AI Agent感知模块支持多模态输入]]
+- [[ai-agent-has-perception-reasoning-action-capabilities|AI Agent具有感知、推理、行动三大核心能力]]

--- a/10-Knowledge/Evergreen/agent-modular-architecture-enables-specialization.md
+++ b/10-Knowledge/Evergreen/agent-modular-architecture-enables-specialization.md
@@ -1,0 +1,40 @@
+---
+schema_version: "1.0.0"
+note_id: agent-modular-architecture-enables-specialization-ad92ee2f
+title: "Agent模块化架构支持专业化实现"
+type: evergreen
+entity_type: concept
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["agent-modular-architecture-enables-specialization"]
+---
+
+# Agent模块化架构支持专业化实现
+
+> **一句话定义**: Agent的Perception、Reasoning、Action模块可独立演进和优化，支持不同技术方案的实现和专业化分工。
+
+## 📝 详细解释
+
+### 是什么？
+每个模块可以采用不同的技术方案：感知模块可使用NLP、CV等具体技术；推理模块可采用RAG、CoT等框架；行动模块可集成各类API和外部系统。这种模块化设计使得各部分可以独立演进，开发者可以根据具体场景选择合适的技术方案，也便于系统的扩展和维护。原文未详细说明具体技术实现，但架构本身支持多样化的技术选择。
+
+### 为什么重要？
+模块化设计提供了架构的灵活性和可扩展性，使开发者能够根据具体需求定制Agent系统。
+
+## 🔗 关联概念
+- [[Agent-Architecture]]
+- [[Perception-Module]]
+- [[Reasoning-Module]]
+- [[Action-Module]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[ai-agent-has-perception-reasoning-action-capabilities|AI Agent具有感知、推理、行动三大核心能力]]
+- [[ai-agent-definition-411752f4|AI Agent是具备感知、推理、行动能力的自主系统]]
+- [[multimodal-perception-96f84e06|AI Agent支持多模态感知输入]]
+- [[multi-modal-perception-e8af11cc|AI Agent感知模块支持多模态输入]]

--- a/10-Knowledge/Evergreen/agent-perception-module-enables-environment-input.md
+++ b/10-Knowledge/Evergreen/agent-perception-module-enables-environment-input.md
@@ -1,0 +1,39 @@
+---
+schema_version: "1.0.0"
+note_id: agent-perception-module-enables-environment-input-d822bb69
+title: "Agent perception module enables multi-modal environment input"
+type: evergreen
+entity_type: concept
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["agent-perception-module-enables-environment-input"]
+---
+
+# Agent perception module enables multi-modal environment input
+
+> **一句话定义**: 感知模块是Agent与环境的交互入口，支持文本、图像、语音、API数据等多模态输入
+
+## 📝 详细解释
+
+### 是什么？
+Perception模块负责接收和预处理来自环境的信息输入，包括用户请求、数据库数据、API响应、传感器数据等。该模块将原始输入转换为Agent内部可处理的格式，是Agent感知世界的窗口。原文未详细说明具体的技术实现（如NLP、CV等），但多模态感知能力是现代Agent的重要特征。
+
+### 为什么重要？
+感知是Agent闭环工作的起点，决定了Agent能够处理哪类信息及信息处理的准确性，进而影响后续推理决策的质量
+
+## 🔗 关联概念
+- [[Perception-Reasoning-Action]]
+- [[Multi-Modal-Input]]
+- [[Environment-Interaction]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[ai-agent-has-perception-reasoning-action-capabilities|AI Agent具有感知、推理、行动三大核心能力]]
+- [[multimodal-perception-96f84e06|AI Agent支持多模态感知输入]]
+- [[ai-agent-tool-ecosystem|AI Agent capabilities are bounded by its tool ecosystem]]
+- [[multi-modal-perception-e8af11cc|AI Agent感知模块支持多模态输入]]

--- a/10-Knowledge/Evergreen/agent-perception-module.md
+++ b/10-Knowledge/Evergreen/agent-perception-module.md
@@ -1,0 +1,38 @@
+---
+schema_version: "1.0.0"
+note_id: agent-perception-module-8129ff91
+title: "Perception模块是Agent与环境的交互入口"
+type: evergreen
+entity_type: concept
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["agent-perception-module"]
+---
+
+# Perception模块是Agent与环境的交互入口
+
+> **一句话定义**: Perception模块负责接收和处理来自环境的各种输入，包括用户请求、数据库数据、API响应等多模态信息
+
+## 📝 详细解释
+
+### 是什么？
+感知是Agent工作的第一步，决定了Agent能够获取哪些信息。该模块支持多模态输入（文本、图像、语音、API数据等），需要完成输入处理、信息提取和格式转换等工作，为后续推理提供结构化的输入数据
+
+### 为什么重要？
+感知是Agent闭环工作的起点，高质量的感知能力直接影响Agent的决策质量
+
+## 🔗 关联概念
+- [[perception-reasoning-action-architecture]]
+- [[multi-modal-input]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[ai-agent-has-perception-reasoning-action-capabilities|AI Agent具有感知、推理、行动三大核心能力]]
+- [[ai-agent-task-complexity评估|AI Agent architecture should match task complexity level]]
+- [[multimodal-perception-96f84e06|AI Agent支持多模态感知输入]]
+- [[ai-agent-tool-ecosystem|AI Agent capabilities are bounded by its tool ecosystem]]

--- a/10-Knowledge/Evergreen/agent-reasoning-module-enables-intelligent-decision-making.md
+++ b/10-Knowledge/Evergreen/agent-reasoning-module-enables-intelligent-decision-making.md
@@ -1,0 +1,40 @@
+---
+schema_version: "1.0.0"
+note_id: agent-reasoning-module-enables-intelligent-decisio-c8cfcffc
+title: "Agent reasoning module enables intelligent decision-making"
+type: evergreen
+entity_type: concept
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["agent-reasoning-module-enables-intelligent-decision-making"]
+---
+
+# Agent reasoning module enables intelligent decision-making
+
+> **一句话定义**: 推理模块是Agent的核心智能所在，涉及知识表示、逻辑推理、规划等能力
+
+## 📝 详细解释
+
+### 是什么？
+Reasoning模块是AI Agent的智能核心，负责对感知到的信息进行深度处理和分析。该模块涉及知识表示、逻辑推理、规划、决策等能力，根据目标制定行动计划。原文未详细说明具体的推理框架（如RAG、CoT等），但推理能力直接决定了Agent能否像人类一样思考和解决问题。
+
+### 为什么重要？
+推理模块的质量直接决定了Agent的智能水平，是AI Agent从『执行工具』进化为『智能助手』的关键
+
+## 🔗 关联概念
+- [[Perception-Reasoning-Action]]
+- [[Knowledge-Representation]]
+- [[Logical-Reasoning]]
+- [[Planning]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[ai-agent-has-perception-reasoning-action-capabilities|AI Agent具有感知、推理、行动三大核心能力]]
+- [[agent-autonomy-9be9ea0e|AI Agent具备自主性，能够自主感知、推理和行动]]
+- [[ai-agent-core-characteristics-ab47e9e1|AI Agent具有四大核心特性：自主性、反应性、主动性和社会性]]
+- [[ai-agent-task-complexity评估|AI Agent architecture should match task complexity level]]

--- a/10-Knowledge/Evergreen/agent-reasoning-module.md
+++ b/10-Knowledge/Evergreen/agent-reasoning-module.md
@@ -1,0 +1,39 @@
+---
+schema_version: "1.0.0"
+note_id: agent-reasoning-module-5ea9446a
+title: "Reasoning模块是Agent的核心智能所在"
+type: evergreen
+entity_type: concept
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["agent-reasoning-module"]
+---
+
+# Reasoning模块是Agent的核心智能所在
+
+> **一句话定义**: Reasoning模块负责理解意图、知识检索、推理决策和计划生成，模拟人类的思考过程
+
+## 📝 详细解释
+
+### 是什么？
+推理模块涉及知识表示、逻辑推理、规划等核心能力。该模块接收感知模块的结构化输入，进行理解和分析，制定行动计划。推理质量直接决定了Agent能否正确完成目标任务
+
+### 为什么重要？
+推理能力是AI Agent智能水平的关键体现，是区分Agent能力强弱的核心因素
+
+## 🔗 关联概念
+- [[perception-reasoning-action-architecture]]
+- [[agent-action-module]]
+- [[knowledge-representation]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[ai-agent-has-perception-reasoning-action-capabilities|AI Agent具有感知、推理、行动三大核心能力]]
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[ai-agent-task-complexity评估|AI Agent architecture should match task complexity level]]
+- [[ai-agent-definition-411752f4|AI Agent是具备感知、推理、行动能力的自主系统]]
+- [[ai-agent-core-characteristics-ab47e9e1|AI Agent具有四大核心特性：自主性、反应性、主动性和社会性]]

--- a/10-Knowledge/Evergreen/agent-tool-use-capability.md
+++ b/10-Knowledge/Evergreen/agent-tool-use-capability.md
@@ -1,0 +1,39 @@
+---
+schema_version: "1.0.0"
+note_id: agent-tool-use-capability-0c5535bf
+title: "AI Agent capability is bounded by its tool ecosystem"
+type: evergreen
+entity_type: concept
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["agent-tool-use-capability", "agent-tool-calling-capability"]
+---
+
+# AI Agent capability is bounded by its tool ecosystem
+
+> **一句话定义**: Agent的能力边界主要由其可调用的工具决定，工具生态系统越丰富，Agent能完成的任务越复杂。
+
+## 📝 详细解释
+
+### 是什么？
+Tool Use（工具使用能力）是Agent‘行动(Action)’要素的核心体现。Agent通过调用外部工具（搜索引擎、API、代码执行环境、数据库等）来执行实际操作。基础工具包括搜索引擎、计算器、日历；业务工具包括CRM系统、代码仓库、文档库；执行工具包括API调用、代码沙箱、文件操作。工具的丰富程度直接决定了Agent的实用价值。
+
+### 为什么重要？
+理解工具生态是构建实用Agent系统的关键，设计Agent时首先需要明确需要哪些工具来支撑任务完成。
+
+## 🔗 关联概念
+- [[MCP-Protocol]]
+- [[Function-Calling]]
+- [[ai-agents-perception-reasoning-action-loop]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[ai-agent-task-complexity评估|AI Agent architecture should match task complexity level]]
+- [[ai-agent-has-perception-reasoning-action-capabilities|AI Agent具有感知、推理、行动三大核心能力]]
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[ai-agent-definition-411752f4|AI Agent是具备感知、推理、行动能力的自主系统]]
+- [[multi-modal-perception-e8af11cc|AI Agent感知模块支持多模态输入]]

--- a/10-Knowledge/Evergreen/ai-agent-applications-span-multiple-domains.md
+++ b/10-Knowledge/Evergreen/ai-agent-applications-span-multiple-domains.md
@@ -1,0 +1,40 @@
+---
+schema_version: "1.0.0"
+note_id: ai-agent-applications-span-multiple-domains-9b372400
+title: "AI Agent应用场景覆盖多个领域"
+type: evergreen
+entity_type: concept
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["ai-agent-applications-span-multiple-domains"]
+---
+
+# AI Agent应用场景覆盖多个领域
+
+> **一句话定义**: AI Agent的典型应用场景包括客户服务机器人、代码生成助手和研究自动化三大领域。
+
+## 📝 详细解释
+
+### 是什么？
+具体应用场景包括：1)Customer service bots客户服务机器人，用于自动响应客户咨询；2)Code generation assistants代码生成助手，辅助开发者编写和调试代码；3)Research automation研究自动化，辅助科研人员完成文献检索、实验数据分析等任务。这些场景代表了Agent在企业服务、开发工具和科研领域的典型应用方向。
+
+### 为什么重要？
+了解应用场景有助于选择合适的切入点进行实践，从简单场景逐步扩展到复杂场景是推荐的落地路径。
+
+## 🔗 关联概念
+- [[AI-Applications]]
+- [[Customer-Service-Bots]]
+- [[Code-Generation]]
+- [[Research-Automation]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[agent-autonomous-capability-c35f723f|AI Agent具备自主感知、推理和行动能力]]
+- [[autonomous-task-execution-0dae97b5|AI Agent实现复杂任务的自主执行]]
+- [[agent-autonomy-9be9ea0e|AI Agent具备自主性，能够自主感知、推理和行动]]
+- [[ai-agent-enables-autonomous-behavior-64c858a0|AI Agent实现从被动响应到主动智能的演进]]

--- a/10-Knowledge/Evergreen/ai-agent-autonomous-system-definition.md
+++ b/10-Knowledge/Evergreen/ai-agent-autonomous-system-definition.md
@@ -1,0 +1,39 @@
+---
+schema_version: "1.0.0"
+note_id: ai-agent-autonomous-system-definition-7db854ae
+title: "AI Agent是具有自主性的软件系统，能感知环境并主动执行动作"
+type: evergreen
+entity_type: concept
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["ai-agent-autonomous-system-definition", "ai-agent-autonomous-system"]
+---
+
+# AI Agent是具有自主性的软件系统，能感知环境并主动执行动作
+
+> **一句话定义**: AI Agent是能够感知环境、处理信息并自主执行动作以达成目标的自主系统，核心特征包括自主性、反应性、主动性和社会性。
+
+## 📝 详细解释
+
+### 是什么？
+AI Agent代表了人工智能系统从被动响应向主动行动的重要演进。传统的LLM只在接收prompt时才产生输出，而Agent能够在无需人类持续干预的情况下独立运作，不仅响应环境变化，还能主动规划和实现目标。这使得Agent能够完成复杂的多步骤任务，如客户服务、代码生成和研究自动化等场景。
+
+### 为什么重要？
+理解AI Agent的自主性特征是构建有效Agent系统的基础，它区分了被动AI系统与主动AI系统的本质差异。
+
+## 🔗 关联概念
+- [[Perception-Reasoning-Action]]
+- [[Autonomous-Systems]]
+- [[LLM-Architecture]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[agent-autonomy-9be9ea0e|AI Agent具备自主性，能够自主感知、推理和行动]]
+- [[ai-agent-enables-autonomous-behavior-64c858a0|AI Agent实现从被动响应到主动智能的演进]]
+- [[ai-agent-paradigm-shift-8724d39e|AI Agent代表从被动响应到主动行动的范式转移]]
+- [[ai-agent-autonomous-vs-passive-ai|AI Agent代表从被动响应到自主执行的范式转变]]

--- a/10-Knowledge/Evergreen/ai-agent-autonomous-vs-passive-ai.md
+++ b/10-Knowledge/Evergreen/ai-agent-autonomous-vs-passive-ai.md
@@ -1,0 +1,31 @@
+---
+schema_version: "1.0.0"
+note_id: ai-agent-autonomous-vs-passive-ai-3e6bc60f
+title: "AI Agent represents shift from passive response to autonomous execution"
+type: evergreen
+entity_type: concept
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["ai-agent-autonomous-vs-passive-ai", "ai-agent-autonomous-vs-passive-ai-3e6bc60f"]
+---
+
+# AI Agent represents shift from passive response to autonomous execution
+
+> **一句话定义**: AI Agent代表人工智能从被动响应用户指令向主动规划和执行目标的重要范式转变，是AI系统进化的下一次飞跃。
+
+## 📝 详细解释
+
+### 是什么？
+传统AI模型是被动响应式的：用户输入 prompts，模型生成 outputs，每次交互独立发生。Agent则具备自主性：能够理解高层目标而非具体指令、自主制定实现路径、持续多步骤执行行动、根据环境反馈动态调整行为。这一转变的核心价值在于：释放人类从『告诉AI怎么做』到『告诉AI要什么』的重复劳动，使AI能够处理需要多工具、多步骤、多阶段完成的复杂工作流程。
+
+### 为什么重要？
+这一范式转变是理解AI Agent战略价值的核心，它不仅是技术演进，更是人机协作模式的根本性变化，将大幅提升AI处理复杂业务场景的能力。
+
+## 🔗 关联概念
+- [[ai-agent-goal-oriented-behavior]]
+- [[autonomous-systems]]
+- [[task-decomposition]]
+- [[agent-planning]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]

--- a/10-Knowledge/Evergreen/ai-agent-autonomy-characteristics.md
+++ b/10-Knowledge/Evergreen/ai-agent-autonomy-characteristics.md
@@ -1,0 +1,39 @@
+---
+schema_version: "1.0.0"
+note_id: ai-agent-autonomy-characteristics-accef419
+title: "AI Agent具有自主性、反应性、主动性和社会性四大核心特征"
+type: evergreen
+entity_type: concept
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["ai-agent-autonomy-characteristics", "ai-agent-core-characteristics"]
+---
+
+# AI Agent具有自主性、反应性、主动性和社会性四大核心特征
+
+> **一句话定义**: AI Agent是能够感知环境、处理信息并自主执行动作以达成目标的自主系统，具备自主性、反应性、主动性和社会性四大核心特征。
+
+## 📝 详细解释
+
+### 是什么？
+自主性（Autonomy）使agent能在无需人类持续干预的情况下独立运作；反应性（Reactivity）使其能够感知环境变化并做出响应；主动性（Proactivity）使其不仅响应环境，还能主动规划和实现目标；社会性（Social Ability）使其能与人类或其他agent进行交互协作。这四个特征区别于传统的被动响应式AI系统（如大型语言模型），是AI Agent区别于其他AI系统的本质特征。
+
+### 为什么重要？
+理解这四大特征是正确理解和设计AI Agent的基础，也是评估一个系统是否真正构成AI Agent的标准。这四个特征共同构成了AI Agent的完整能力图谱，使其能够实现复杂任务的自动化执行。
+
+## 🔗 关联概念
+- [[Perception-Reasoning-Action]]
+- [[Autonomous-Systems]]
+- [[AI-Systems-Evolution]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[agent-autonomy-9be9ea0e|AI Agent具备自主性，能够自主感知、推理和行动]]
+- [[ai-agent-enables-autonomous-behavior-64c858a0|AI Agent实现从被动响应到主动智能的演进]]
+- [[ai-agent-autonomous-vs-passive-ai|AI Agent代表从被动响应到自主执行的范式转变]]
+- [[ai-agent-core-characteristics-ab47e9e1|AI Agent具有四大核心特性：自主性、反应性、主动性和社会性]]

--- a/10-Knowledge/Evergreen/ai-agent-definition-core-features.md
+++ b/10-Knowledge/Evergreen/ai-agent-definition-core-features.md
@@ -1,0 +1,41 @@
+---
+schema_version: "1.0.0"
+note_id: ai-agent-definition-core-features-2d802700
+title: "AI Agent是具有自主性的软件系统"
+type: evergreen
+entity_type: concept
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["ai-agent-definition-core-features"]
+---
+
+# AI Agent是具有自主性的软件系统
+
+> **一句话定义**: AI Agent是能够感知环境、处理信息并自主执行动作以达成目标的自主系统，具备自主性、反应性、主动性和社会性四大核心特征。
+
+## 📝 详细解释
+
+### 是什么？
+AI Agent代表了人工智能从被动响应向主动行动的重要演进。自主性使其能够在无需人类持续干预的情况下独立运作；反应性使其能感知环境变化并做出响应；主动性使其不仅响应环境，还能主动规划和实现目标；社会性使其能与人类或其他agent进行交互协作。这四个特征共同构成了AI Agent区别于传统LLM的本质区别。
+
+### 为什么重要？
+理解AI Agent的核心特征是构建任何agent系统的基础，也是区分AI Agent与传统AI系统的关键标准。
+
+## 🔗 关联概念
+- [[Perception-Reasoning-Action-Loop]]
+- [[Autonomy]]
+- [[Reactivity]]
+- [[Proactivity]]
+- [[Social-Ability]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[ai-agent-autonomy-characteristics-accef419|AI Agent具有自主性、反应性、主动性和社会性四大核心特征]]
+- [[agent-autonomy-9be9ea0e|AI Agent具备自主性，能够自主感知、推理和行动]]
+- [[ai-agent-core-characteristics-ab47e9e1|AI Agent具有四大核心特性：自主性、反应性、主动性和社会性]]
+- [[ai-agent-enables-autonomous-behavior-64c858a0|AI Agent实现从被动响应到主动智能的演进]]

--- a/10-Knowledge/Evergreen/ai-agent-definition.md
+++ b/10-Knowledge/Evergreen/ai-agent-definition.md
@@ -1,0 +1,39 @@
+---
+schema_version: "1.0.0"
+note_id: ai-agent-definition-411752f4
+title: "AI Agent是具备感知、推理、行动能力的自主系统"
+type: evergreen
+entity_type: concept
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["ai-agent-definition"]
+---
+
+# AI Agent是具备感知、推理、行动能力的自主系统
+
+> **一句话定义**: AI Agent是能够感知环境、进行推理并采取行动以实现目标的自主系统，代表人工智能从被动响应向主动智能的演进方向。
+
+## 📝 详细解释
+
+### 是什么？
+AI Agent具备三大核心能力模块：Perception（感知）负责接收环境信息输入，包括用户请求、数据库数据、API响应等；Reasoning（推理）负责对感知信息进行处理、分析和决策，模拟人类思考过程；Action（行动）负责执行具体操作来影响环境，如生成回复、调用API、修改数据等。这三者形成闭环，使Agent能够自主完成复杂任务。
+
+### 为什么重要？
+AI Agent代表了AI系统从被动响应式向主动智能的演进，是人工智能发展的下一阶段。理解其定义是学习Agent技术的基础。
+
+## 🔗 关联概念
+- [[perception-reasoning-action-architecture]]
+- [[agent-autonomy]]
+- [[autonomous-systems]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[agent-autonomy-9be9ea0e|AI Agent具备自主性，能够自主感知、推理和行动]]
+- [[ai-agent-task-complexity评估|AI Agent architecture should match task complexity level]]
+- [[ai-agent-core-characteristics-ab47e9e1|AI Agent具有四大核心特性：自主性、反应性、主动性和社会性]]
+- [[ai-agent-autonomy-characteristics-accef419|AI Agent具有自主性、反应性、主动性和社会性四大核心特征]]

--- a/10-Knowledge/Evergreen/ai-agent-enables-autonomous-behavior.md
+++ b/10-Knowledge/Evergreen/ai-agent-enables-autonomous-behavior.md
@@ -1,0 +1,39 @@
+---
+schema_version: "1.0.0"
+note_id: ai-agent-enables-autonomous-behavior-64c858a0
+title: "AI Agent实现从被动响应到主动智能的演进"
+type: evergreen
+entity_type: concept
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["ai-agent-enables-autonomous-behavior"]
+---
+
+# AI Agent实现从被动响应到主动智能的演进
+
+> **一句话定义**: AI Agent具备自主性，能够自主感知环境变化、基于目标进行推理决策并主动执行行动完成任务，代表AI从被动响应式向主动智能的转型。
+
+## 📝 详细解释
+
+### 是什么？
+传统AI系统多为被动响应式，需要人类明确触发才能执行任务。而AI Agent具备自主性特征：自主感知环境变化、基于目标进行推理决策、主动执行行动完成任务。这代表了AI系统向更高层次自主智能的演进，是人工智能发展的下一阶段方向。自主性使Agent能够在无人干预下处理复杂多步任务。
+
+### 为什么重要？
+自主性是AI Agent的核心价值主张，决定了其在自动化、效率提升方面的应用潜力，是AI技术范式的重要跃迁。
+
+## 🔗 关联概念
+- [[Autonomous-Systems]]
+- [[AI-Evolution]]
+- [[Passive-AI-vs-Active-AI]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[ai-agent-autonomous-vs-passive-ai|AI Agent代表从被动响应到自主执行的范式转变]]
+- [[ai-agent-paradigm-shift-8724d39e|AI Agent代表从被动响应到主动行动的范式转移]]
+- [[agent-autonomy-9be9ea0e|AI Agent具备自主性，能够自主感知、推理和行动]]
+- [[ai-agent-autonomy-characteristics-accef419|AI Agent具有自主性、反应性、主动性和社会性四大核心特征]]

--- a/10-Knowledge/Evergreen/ai-agent-has-perception-reasoning-action-capabilities.md
+++ b/10-Knowledge/Evergreen/ai-agent-has-perception-reasoning-action-capabilities.md
@@ -1,0 +1,39 @@
+---
+schema_version: "1.0.0"
+note_id: ai-agent-has-perception-reasoning-action-capabilit-23e500f4
+title: "AI Agent具有感知、推理、行动三大核心能力"
+type: evergreen
+entity_type: framework
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["ai-agent-has-perception-reasoning-action-capabilities", "ai-agent-has-perception-reasoning-action-capabilit-23e500f4"]
+---
+
+# AI Agent具有感知、推理、行动三大核心能力
+
+> **一句话定义**: AI Agent通过Perception接收环境信息，经Reasoning处理和决策，最后通过Action执行操作影响环境，形成完整的自主系统闭环。
+
+## 📝 详细解释
+
+### 是什么？
+感知模块(Perception)作为Agent与环境的交互入口，支持多模态输入包括文本、图像、语音和API数据。推理模块(Reasoning)是Agent的核心智能所在，涉及知识表示、逻辑推理和规划等能力。行动模块(Action)将决策转化为实际执行，包括信息检索、内容生成、工具调用和系统操作等。三者形成循环：感知输入→推理决策→行动输出→反馈更新→继续迭代。
+
+### 为什么重要？
+这三大能力构成了AI Agent的基础架构范式，理解其分工与协作是构建任何Agent系统的前提。
+
+## 🔗 关联概念
+- [[Perception-Reasoning-Action]]
+- [[Agent-Architecture]]
+- [[Autonomous-Systems]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[ai-agent-task-complexity评估|AI Agent architecture should match task complexity level]]
+- [[ai-agent-core-characteristics-ab47e9e1|AI Agent具有四大核心特性：自主性、反应性、主动性和社会性]]
+- [[ai-agent-definition-411752f4|AI Agent是具备感知、推理、行动能力的自主系统]]
+- [[agent-autonomy-9be9ea0e|AI Agent具备自主性，能够自主感知、推理和行动]]

--- a/10-Knowledge/Evergreen/ai-agent-paradigm-shift.md
+++ b/10-Knowledge/Evergreen/ai-agent-paradigm-shift.md
@@ -1,0 +1,40 @@
+---
+schema_version: "1.0.0"
+note_id: ai-agent-paradigm-shift-8724d39e
+title: "AI Agent代表从被动响应到主动行动的范式转移"
+type: evergreen
+entity_type: concept
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["ai-agent-paradigm-shift"]
+---
+
+# AI Agent代表从被动响应到主动行动的范式转移
+
+> **一句话定义**: AI Agent标志着AI系统从被动响应prompt的模型，转变为具有主动性、持续循环、有状态的主动行动系统。
+
+## 📝 详细解释
+
+### 是什么？
+传统大型语言模型是被动的——只在接收prompt时产生输出，是单次交互且无状态的。而AI Agent实现了四大转变：从被动响应转向主动行动；从单次交互转向持续循环；从无状态转向有状态（维护上下文状态）；从固定输出转向动态策略（根据环境调整行为）。这种范式转移使AI系统能够处理需要多步骤、动态调整的复杂任务。
+
+### 为什么重要？
+理解这一范式转移有助于把握AI技术的发展方向。AI Agent代表了AI从工具向自主系统的演进，是当前AI发展的重要趋势，对于技术选型和系统设计具有指导意义。
+
+## 🔗 关联概念
+- [[LLM Architecture]]
+- [[Agentic AI]]
+- [[Autonomous Systems]]
+- [[Stateful AI]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[ai-agent-autonomous-vs-passive-ai|AI Agent代表从被动响应到自主执行的范式转变]]
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[ai-agent-enables-autonomous-behavior-64c858a0|AI Agent实现从被动响应到主动智能的演进]]
+- [[ai-agent-core-characteristics-ab47e9e1|AI Agent具有四大核心特性：自主性、反应性、主动性和社会性]]
+- [[agent-autonomy-9be9ea0e|AI Agent具备自主性，能够自主感知、推理和行动]]

--- a/10-Knowledge/Evergreen/ai-agent-performs-perception-reasoning-action-d533b9f1.md
+++ b/10-Knowledge/Evergreen/ai-agent-performs-perception-reasoning-action-d533b9f1.md
@@ -1,0 +1,35 @@
+---
+note_id: ai-agent-performs-perception-reasoning-action-d533b9f1
+title: "AI Agent执行感知-推理-行动的反馈循环"
+type: evergreen
+entity_type: framework
+date: 2026-04-25
+tags: [general, evergreen]
+aliases: ["ai-agent-performs-perception-reasoning-action-d533b9f1", "ai-agent-performs-perception-reasoning-action"]
+area: general
+---
+
+# AI Agent执行感知-推理-行动的反馈循环
+
+> **定义**: AI Agent通过不断循环的感知-推理-行动流程与环境交互，根据执行结果调整后续行动，形成持续优化的闭环系统。
+
+## 📝 详细解释
+Agent的运作遵循闭环流程：首先从用户输入或环境获取任务目标，然后解析输入理解需求；接着分析情况制定行动计划（可采用ReAct、CoT等策略）；之后调用工具执行操作；最后根据执行结果影响环境并反馈给下一轮循环。这个反馈循环使Agent能够在执行过程中不断调整策略，适应动态变化的环境，是实现真正自主性的关键机制。
+
+## 为什么重要
+反馈循环机制使AI Agent具有了真正的'自主性'和'适应性'。没有反馈循环，Agent只能执行一次性任务；有了反馈循环，Agent能够处理需要多步骤、动态调整的复杂任务，实现长期目标的追求。
+
+## 🔗 关联概念
+- [[ai-agent-has-perception-reasoning-action-capabilities]]
+- [[ai-agent-autonomous-vs-passive-ai]]
+- [[agent-memory-mechanism-a48a7e0f]]
+
+## 📚 来源
+- [[2026-04-06_test-ai-article_深度解读]]
+
+
+---
+
+---
+
+*Promoted from candidate on 2026-04-25*

--- a/10-Knowledge/Evergreen/ai-agent-task-complexity评估.md
+++ b/10-Knowledge/Evergreen/ai-agent-task-complexity评估.md
@@ -1,0 +1,40 @@
+---
+schema_version: "1.0.0"
+note_id: ai-agent-task-complexity评估-63f3eb47
+title: "AI Agent architecture should match task complexity level"
+type: evergreen
+entity_type: concept
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["ai-agent-task-complexity评估", "ai-agent-task-complexity评估-63f3eb47"]
+---
+
+# AI Agent architecture should match task complexity level
+
+> **一句话定义**: AI Agent的架构设计需匹配任务复杂度，简单任务直接使用LLM、中等任务需实现推理+行动循环、复杂任务需设计多Agent协作与记忆机制。
+
+## 📝 详细解释
+
+### 是什么？
+这是Agent系统设计的重要方法论。任务复杂度分为三个等级：简单任务（单轮问答、即时响应）可直接使用基础LLM，无需Agent架构；中等任务（多步骤操作、工具调用）需实现基础的推理-行动循环，让Agent能够自主规划步骤并调用工具；复杂任务（长期目标、多方协作）需设计多Agent协作系统，加入短期记忆（上下文保持）、长期记忆（知识积累）、反思机制等组件。架构复杂度应『刚好够用』而非过度设计。
+
+### 为什么重要？
+正确匹配架构复杂度是AI Agent系统落地的关键，既能避免过度设计导致的资源浪费，又能确保系统能力满足任务需求，是工程实践的核心决策点。
+
+## 🔗 关联概念
+- [[multi-agent-collaboration]]
+- [[agent-memory-mechanism]]
+- [[agent-reflection]]
+- [[task-planning]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[agent-autonomy-9be9ea0e|AI Agent具备自主性，能够自主感知、推理和行动]]
+- [[ai-agent-core-characteristics-ab47e9e1|AI Agent具有四大核心特性：自主性、反应性、主动性和社会性]]
+- [[ai-agent-performs-perception-reasoning-action-d533b9f1|AI Agent执行感知-推理-行动的反馈循环]]
+- [[agent-autonomous-capability-c35f723f|AI Agent具备自主感知、推理和行动能力]]

--- a/10-Knowledge/Evergreen/ai-agent-tool-ecosystem.md
+++ b/10-Knowledge/Evergreen/ai-agent-tool-ecosystem.md
@@ -1,0 +1,40 @@
+---
+schema_version: "1.0.0"
+note_id: ai-agent-tool-ecosystem-2e933204
+title: "AI Agent capabilities are bounded by its tool ecosystem"
+type: evergreen
+entity_type: concept
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["ai-agent-tool-ecosystem", "agent-tool-ecosystem", "ai-agent-tools-ecosystem", "ai-agent-tool-ecosystem-2e933204"]
+---
+
+# AI Agent capabilities are bounded by its tool ecosystem
+
+> **一句话定义**: AI Agent的能力边界主要由其可调用的工具生态决定，工具包括搜索引擎、API调用、代码执行器、数据库操作等功能模块。
+
+## 📝 详细解释
+
+### 是什么？
+Agent的核心价值在于能够与外部系统交互并执行实际操作。工具生态通常分为三个层次：基础工具（搜索引擎、计算器、日历）、业务工具（CRM系统、代码仓库、文档库）、执行工具（API调用、代码沙箱、文件操作）。工具的丰富程度直接决定了Agent能完成的业务场景复杂度。建议采用MCP Protocol（Model Context Protocol）标准化工具集成，实现灵活的工具扩展和能力增强。
+
+### 为什么重要？
+工具生态是Agent能力的放大器，决定了Agent从『能想』到『能做』的转化能力，是评估和设计AI Agent系统的关键维度。
+
+## 🔗 关联概念
+- [[mcp-protocol]]
+- [[function-calling]]
+- [[api-integration]]
+- [[tool-ecosystem]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[ai-agent-task-complexity评估|AI Agent architecture should match task complexity level]]
+- [[agent-autonomy-9be9ea0e|AI Agent具备自主性，能够自主感知、推理和行动]]
+- [[ai-agent-core-characteristics-ab47e9e1|AI Agent具有四大核心特性：自主性、反应性、主动性和社会性]]
+- [[ai-agent-definition-411752f4|AI Agent是具备感知、推理、行动能力的自主系统]]

--- a/10-Knowledge/Evergreen/ai-agents-perception-reasoning-action-loop.md
+++ b/10-Knowledge/Evergreen/ai-agents-perception-reasoning-action-loop.md
@@ -1,0 +1,39 @@
+---
+schema_version: "1.0.0"
+note_id: ai-agents-perception-reasoning-action-loop-dc769935
+title: "AI agents have perception-reasoning-action loop"
+type: evergreen
+entity_type: framework
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["ai-agents-perception-reasoning-action-loop", "ai-agent-perception-reasoning-action-loop", "perception-reasoning-action-cycle", "perception-reasoning-action-loop"]
+---
+
+# AI agents have perception-reasoning-action loop
+
+> **一句话定义**: AI Agent通过感知(Perception)、推理(Reasoning)、行动(Action)三要素形成闭环，实现自主完成任务的人工智能系统。
+
+## 📝 详细解释
+
+### 是什么？
+Perception是Agent接收多模态输入（用户指令、API响应、数据库结果等）的能力，决定了对任务上下文的理解深度；Reasoning是Agent的'大脑'，涉及逻辑推理、因果分析、规划生成等认知过程；Action是Agent通过调用外部工具、API、函数执行实际操作的能力。三者形成反馈循环：Agent接收输入→理解任务→推理规划→执行行动→根据结果调整后续行动。这种闭环架构使Agent能够独立完成复杂任务，而不仅仅是响应单次查询。
+
+### 为什么重要？
+这是AI Agent区别于传统被动式AI的核心架构，理解此循环是设计和评估AI Agent系统的基础。
+
+## 🔗 关联概念
+- [[Function Calling]]
+- [[Tool Use]]
+- [[ReAct Reasoning]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[ai-agent-definition-411752f4|AI Agent是具备感知、推理、行动能力的自主系统]]
+- [[ai-agent-has-perception-reasoning-action-capabilities|AI Agent具有感知、推理、行动三大核心能力]]
+- [[multimodal-perception-96f84e06|AI Agent支持多模态感知输入]]
+- [[agent-autonomy-9be9ea0e|AI Agent具备自主性，能够自主感知、推理和行动]]

--- a/10-Knowledge/Evergreen/ai-evolution-from-reactive-to-proactive.md
+++ b/10-Knowledge/Evergreen/ai-evolution-from-reactive-to-proactive.md
@@ -1,0 +1,40 @@
+---
+schema_version: "1.0.0"
+note_id: ai-evolution-from-reactive-to-proactive-df206d50
+title: "AI evolution from reactive to proactive"
+type: evergreen
+entity_type: concept
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["ai-evolution-from-reactive-to-proactive"]
+---
+
+# AI evolution from reactive to proactive
+
+> **一句话定义**: AI从被动响应式系统向主动智能Agent演进，代表人工智能发展的下一阶段
+
+## 📝 详细解释
+
+### 是什么？
+传统的AI系统多为被动响应式，需要人类明确触发才能执行任务。而AI Agent具备自主性，能够自主感知环境变化、基于目标进行推理决策、主动执行行动完成任务。这代表了AI系统向更高层次自主智能的演进，从Perception-Reasoning-Action的闭环模式可以看出，Agent不再需要人类每一步的指令，而是能够自主完成目标。
+
+### 为什么重要？
+理解AI的这一演进方向有助于把握技术发展趋势，对于架构设计和技术选型具有指导意义
+
+## 🔗 关联概念
+- [[AI-Agent]]
+- [[Autonomous-Systems]]
+- [[AI-Evolution]]
+- [[Proactive-Intelligence]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[ai-agent-autonomous-vs-passive-ai|AI Agent代表从被动响应到自主执行的范式转变]]
+- [[ai-agent-core-characteristics-ab47e9e1|AI Agent具有四大核心特性：自主性、反应性、主动性和社会性]]
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[ai-agent-paradigm-shift-8724d39e|AI Agent代表从被动响应到主动行动的范式转移]]
+- [[agent-autonomy-9be9ea0e|AI Agent具备自主性，能够自主感知、推理和行动]]

--- a/10-Knowledge/Evergreen/autonomous-task-execution.md
+++ b/10-Knowledge/Evergreen/autonomous-task-execution.md
@@ -1,0 +1,39 @@
+---
+schema_version: "1.0.0"
+note_id: autonomous-task-execution-0dae97b5
+title: "AI Agent实现复杂任务的自主执行"
+type: evergreen
+entity_type: concept
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["autonomous-task-execution"]
+---
+
+# AI Agent实现复杂任务的自主执行
+
+> **一句话定义**: AI Agent通过任务分解、策略制定和工具选择，能够自主完成多步骤的复杂任务，降低人工干预成本。
+
+## 📝 详细解释
+
+### 是什么？
+自主任务执行是AI Agent的核心价值体现。相比单次交互的LLM，agent能够：1) 将复杂目标拆解为可执行的子任务；2) 在执行过程中维护上下文状态；3) 根据环境反馈动态调整策略；4) 持续运作直到达成目标。这使得客户服务、代码生成、研究自动化等场景的真正自动化成为可能。
+
+### 为什么重要？
+自主任务执行能力使AI Agent能够替代人工完成重复性、流程化的工作，是企业应用AI技术提升效率的关键场景。
+
+## 🔗 关联概念
+- [[ai-agent-autonomous-system-definition]]
+- [[ai-agents-perception-reasoning-action-loop]]
+- [[task-automation]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[ai-agent-enables-autonomous-behavior-64c858a0|AI Agent实现从被动响应到主动智能的演进]]
+- [[agent-autonomy-9be9ea0e|AI Agent具备自主性，能够自主感知、推理和行动]]
+- [[ai-agent-definition-core-features-2d802700|AI Agent是具有自主性的软件系统]]
+- [[ai-agent-paradigm-shift-8724d39e|AI Agent代表从被动响应到主动行动的范式转移]]

--- a/10-Knowledge/Evergreen/chain-of-thought-enables-multi-step-reasoning.md
+++ b/10-Knowledge/Evergreen/chain-of-thought-enables-multi-step-reasoning.md
@@ -1,0 +1,38 @@
+---
+schema_version: "1.0.0"
+note_id: chain-of-thought-enables-multi-step-reasoning-477d3095
+title: "Chain of Thought使能多步推理过程"
+type: evergreen
+entity_type: framework
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["chain-of-thought-enables-multi-step-reasoning", "chain-of-thought-enables-reasoning"]
+---
+
+# Chain of Thought使能多步推理过程
+
+> **一句话定义**: Chain of Thought（思维链，CoT）是一种prompting技术，通过引导模型生成中间推理步骤，展示清晰的逻辑推导过程。
+
+## 📝 详细解释
+
+### 是什么？
+CoT通过在prompt中加入"Let's think step by step"或展示推理示例，引导模型将复杂问题分解为多个中间步骤：问题理解→步骤1推理→步骤2推理→...→最终结论。这种显式推理过程提高了模型在数学、逻辑、常识推理任务上的准确性。对于Agent架构，CoT是Reasoning层的核心技术，使Agent能够进行因果分析和规划生成。
+
+### 为什么重要？
+CoT是提升Agent推理质量的基础技术，是实现复杂任务规划的必经之路。
+
+## 🔗 关联概念
+- [[ReAct-Reasoning]]
+- [[Perception-Reasoning-Action-Loop]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[ai-agent-performs-perception-reasoning-action-d533b9f1|AI Agent执行感知-推理-行动的反馈循环]]
+- [[chain-of-thought-enables-reasoning-bcd17d12|📝 详细解释]]
+- [[ai-agent-task-complexity评估|AI Agent architecture should match task complexity level]]
+- [[react-reasoning-combines-inference-with-action-03d68e23|🔗 关联概念]]

--- a/10-Knowledge/Evergreen/feedback-loop-mechanism.md
+++ b/10-Knowledge/Evergreen/feedback-loop-mechanism.md
@@ -1,0 +1,39 @@
+---
+schema_version: "1.0.0"
+note_id: feedback-loop-mechanism-8a1b68aa
+title: "AI Agent通过反馈循环实现持续迭代"
+type: evergreen
+entity_type: framework
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["feedback-loop-mechanism", "agent-feedback-loop-mechanism"]
+---
+
+# AI Agent通过反馈循环实现持续迭代
+
+> **一句话定义**: AI Agent的工作流程形成感知-推理-行动-反馈的闭环，通过反馈循环实现持续学习和迭代优化。
+
+## 📝 详细解释
+
+### 是什么？
+Agent的工作流程为：1）感知阶段接收环境输入（用户请求、传感器数据等）；2）推理阶段对信息进行理解和推理，制定行动计划；3）行动阶段执行计划并影响环境；4）反馈循环阶段根据行动结果更新感知，继续迭代。反馈机制使Agent能够根据执行结果调整下一步行动，实现动态适应和持续优化。这是Agent系统能够处理复杂任务的关键机制。
+
+### 为什么重要？
+反馈循环机制使AI Agent能够处理动态、复杂的任务场景，是实现真正自主智能的基础。没有反馈循环，Agent无法适应环境变化和任务偏差。
+
+## 🔗 关联概念
+- [[perception-reasoning-action-architecture]]
+- [[ai-agent-definition]]
+- [[agent-autonomy]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[ai-agent-task-complexity评估|AI Agent architecture should match task complexity level]]
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[agent-autonomy-9be9ea0e|AI Agent具备自主性，能够自主感知、推理和行动]]
+- [[ai-agent-core-characteristics-ab47e9e1|AI Agent具有四大核心特性：自主性、反应性、主动性和社会性]]
+- [[agent-autonomous-capability-c35f723f|AI Agent具备自主感知、推理和行动能力]]

--- a/10-Knowledge/Evergreen/feedback-loop-workflow.md
+++ b/10-Knowledge/Evergreen/feedback-loop-workflow.md
@@ -1,0 +1,38 @@
+---
+schema_version: "1.0.0"
+note_id: feedback-loop-workflow-aadc21e4
+title: "AI Agent通过反馈循环实现持续迭代"
+type: evergreen
+entity_type: framework
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["feedback-loop-workflow"]
+---
+
+# AI Agent通过反馈循环实现持续迭代
+
+> **一句话定义**: Agent执行行动后将结果反馈到感知阶段，形成感知-推理-行动-反馈的闭环工作流程
+
+## 📝 详细解释
+
+### 是什么？
+工作流程为：1)感知阶段接收环境输入；2)推理阶段制定行动计划；3)行动阶段执行计划并影响环境；4)反馈循环根据行动结果更新感知，继续迭代。这种闭环机制使Agent能够适应动态环境并持续优化决策
+
+### 为什么重要？
+反馈循环是Agent实现真正自主性的关键机制，使其能够在执行过程中根据环境反馈不断调整策略，而不仅仅是一次性执行固定任务
+
+## 🔗 关联概念
+- [[Perception-Reasoning-Action-Architecture]]
+- [[AI-Agent-Autonomy]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[agent-autonomous-capability-c35f723f|AI Agent具备自主感知、推理和行动能力]]
+- [[ai-agent-task-complexity评估|AI Agent architecture should match task complexity level]]
+- [[agent-autonomy-9be9ea0e|AI Agent具备自主性，能够自主感知、推理和行动]]
+- [[ai-agent-core-characteristics-ab47e9e1|AI Agent具有四大核心特性：自主性、反应性、主动性和社会性]]

--- a/10-Knowledge/Evergreen/function-calling-enables-agent-tool-execution.md
+++ b/10-Knowledge/Evergreen/function-calling-enables-agent-tool-execution.md
@@ -1,0 +1,39 @@
+---
+schema_version: "1.0.0"
+note_id: function-calling-enables-agent-tool-execution-cd891ea4
+title: "Function calling enables agents to execute external tools"
+type: evergreen
+entity_type: method
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["function-calling-enables-agent-tool-execution"]
+---
+
+# Function calling enables agents to execute external tools
+
+> **一句话定义**: Function Calling是Agent调用外部函数/工具的技术机制，使AI Agent能够突破模型本身的能力边界，执行实际操作。
+
+## 📝 详细解释
+
+### 是什么？
+Function Calling允许LLM生成结构化的函数调用请求，而非仅生成文本。Agent可以调用搜索引擎、数据库API、代码执行环境、文件操作等外部工具。这种机制使得AI的能力从'回答问题'扩展到'解决问题'。典型的Function Calling流程包括：1) 定义工具签名（名称、参数schema）；2) LLM根据任务判断是否需要调用工具；3) 执行工具并返回结果；4) LLM基于结果生成最终响应。
+
+### 为什么重要？
+Function Calling是实现Agent自主行动能力的关键技术，是连接LLM推理能力与真实世界操作的桥梁。
+
+## 🔗 关联概念
+- [[ai-agents-perception-reasoning-action-loop]]
+- [[Tool Use]]
+- [[MCP Protocol]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[agent-tool-use-capability-0c5535bf|AI Agent capability is bounded by its tool ecosystem]]
+- [[ai-agent-autonomous-vs-passive-ai|AI Agent代表从被动响应到自主执行的范式转变]]
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[ai-agent-paradigm-shift-8724d39e|AI Agent代表从被动响应到主动行动的范式转移]]
+- [[ai-agent-enables-autonomous-behavior-64c858a0|AI Agent实现从被动响应到主动智能的演进]]

--- a/10-Knowledge/Evergreen/human-in-the-loop-control.md
+++ b/10-Knowledge/Evergreen/human-in-the-loop-control.md
@@ -1,0 +1,39 @@
+---
+schema_version: "1.0.0"
+note_id: human-in-the-loop-control-5bb8750c
+title: "AI Agent需要人类在环机制确保安全可控"
+type: evergreen
+entity_type: framework
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["human-in-the-loop-control"]
+---
+
+# AI Agent需要人类在环机制确保安全可控
+
+> **一句话定义**: 
+
+## 📝 详细解释
+
+### 是什么？
+尽管AI Agent具有自主性，但在实际应用中必须保留人类控制能力。具体实现包括：关键决策需人工确认（而非完全自动执行）；限制agent可访问的资源和可执行的操作范围；建立完整的监控与审计日志，记录所有决策和行动历史。
+
+### 为什么重要？
+安全可控是AI Agent从实验走向生产应用的前提，缺乏人类在环机制的agent可能在实际部署中带来不可控风险。
+
+## 🔗 关联概念
+- [[ai-agent-autonomous-system-definition]]
+- [[agent-access-control]]
+- [[ai-safety-mechanisms]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[agent-autonomy-9be9ea0e|AI Agent具备自主性，能够自主感知、推理和行动]]
+- [[ai-agent-task-complexity评估|AI Agent architecture should match task complexity level]]
+- [[ai-agent-core-characteristics-ab47e9e1|AI Agent具有四大核心特性：自主性、反应性、主动性和社会性]]
+- [[ai-agent-autonomy-characteristics-accef419|AI Agent具有自主性、反应性、主动性和社会性四大核心特征]]

--- a/10-Knowledge/Evergreen/human-in-the-loop-safety.md
+++ b/10-Knowledge/Evergreen/human-in-the-loop-safety.md
@@ -1,0 +1,39 @@
+---
+schema_version: "1.0.0"
+note_id: human-in-the-loop-safety-2211026a
+title: "AI Agent需要Human-in-the-Loop机制确保安全性和可控性"
+type: evergreen
+entity_type: framework
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["human-in-the-loop-safety"]
+---
+
+# AI Agent需要Human-in-the-Loop机制确保安全性和可控性
+
+> **一句话定义**: 
+
+## 📝 详细解释
+
+### 是什么？
+由于Agent具有自主执行能力，安全性和可控性成为核心挑战。Human-in-the-Loop机制包括：关键决策的人工确认（如财务决策、权限操作）、权限边界设置（限制Agent可访问的资源）、监控与审计日志（记录所有决策和行动）。这一机制平衡了自动化效率与人工监督需求，是企业级Agent应用落地的必要条件。
+
+### 为什么重要？
+安全性和可控性是企业应用Agent的前提，缺乏人类监督的自主Agent可能带来严重风险。
+
+## 🔗 关联概念
+- [[AI-Agent-Autonomous-System-Definition]]
+- [[Agent-Security]]
+- [[Access-Control]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[ai-agent-task-complexity评估|AI Agent architecture should match task complexity level]]
+- [[agent-autonomy-9be9ea0e|AI Agent具备自主性，能够自主感知、推理和行动]]
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[ai-agent-core-characteristics-ab47e9e1|AI Agent具有四大核心特性：自主性、反应性、主动性和社会性]]
+- [[ai-agent-performs-perception-reasoning-action-d533b9f1|AI Agent执行感知-推理-行动的反馈循环]]

--- a/10-Knowledge/Evergreen/mcp-protocol-standard.md
+++ b/10-Knowledge/Evergreen/mcp-protocol-standard.md
@@ -1,0 +1,39 @@
+---
+schema_version: "1.0.0"
+note_id: mcp-protocol-standard-4391e021
+title: "MCP Protocol standardizes agent-tool integration"
+type: evergreen
+entity_type: tool
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["mcp-protocol-standard"]
+---
+
+# MCP Protocol standardizes agent-tool integration
+
+> **一句话定义**: MCP Protocol（Model Context Protocol）是标准化Agent工具集成的协议，使Agent能够灵活扩展工具能力。
+
+## 📝 详细解释
+
+### 是什么？
+MCP Protocol是Anthropic提出的模型上下文协议，旨在标准化AI Agent与外部工具、数据的连接方式。传统方式下每个Agent需要为不同工具编写独立的集成代码，导致扩展困难。MCP提供统一的接口规范，使Agent能够即插即用地扩展工具能力，降低开发成本，提高互操作性。该协议类似于软件行业的USB协议，为Agent工具生态提供标准化的连接层。
+
+### 为什么重要？
+随着Agent应用场景扩展，标准化工具集成协议将变得至关重要，MCP Protocol有望成为行业标准。
+
+## 🔗 关联概念
+- [[Tool-Use]]
+- [[Function-Calling]]
+- [[ai-agents-perception-reasoning-action-loop]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[ai-agent-tool-ecosystem|AI Agent capabilities are bounded by its tool ecosystem]]
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[ai-agent-task-complexity评估|AI Agent architecture should match task complexity level]]
+- [[ai-agent-has-perception-reasoning-action-capabilities|AI Agent具有感知、推理、行动三大核心能力]]
+- [[ai-agent-performs-perception-reasoning-action-d533b9f1|AI Agent执行感知-推理-行动的反馈循环]]

--- a/10-Knowledge/Evergreen/multi-agent-collaboration-enables-complex-task-solving.md
+++ b/10-Knowledge/Evergreen/multi-agent-collaboration-enables-complex-task-solving.md
@@ -1,0 +1,37 @@
+---
+title: "多Agent协作系统能够处理超复杂任务"
+type: evergreen
+entity_type: framework
+date: 2026-04-07
+tags: [evergreen]
+aliases: ["multi-agent-collaboration-enables-complex-task-solving"]
+---
+
+# 多Agent协作系统能够处理超复杂任务
+
+> **一句话定义**: 多Agent协作系统通过将复杂任务分解为子任务，由多个专业Agent分别执行并协同完成，实现超越单一Agent能力的复杂任务处理。
+
+## 📝 详细解释
+
+### 是什么？
+当任务复杂度超出单一Agent能力边界时，多Agent架构成为必要选择。典型模式包括：垂直分工（不同Agent负责不同专业领域）、水平协作（Agent并行处理不同子任务）、层次结构（Manager Agent协调Worker Agents）。多Agent系统需要解决通信协议、任务分解、冲突协调等工程挑战。
+
+### 为什么重要？
+多Agent协作是AI Agent架构演进的重要方向，它使系统能够处理需要多领域知识、多步骤操作、长期规划的超级复杂任务，是构建企业级AI应用的基础架构模式。
+
+## 🔗 关联概念
+- [[AI-Agent-Architecture]]
+- [[Autonomous-Systems]]
+- [[Tool-Use]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[ai-agent-task-complexity评估|AI Agent architecture should match task complexity level]]
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[ai-agent-performs-perception-reasoning-action-d533b9f1|AI Agent执行感知-推理-行动的反馈循环]]
+- [[ai-agent-core-characteristics-ab47e9e1|AI Agent具有四大核心特性：自主性、反应性、主动性和社会性]]
+- [[multi-modal-perception-e8af11cc|AI Agent感知模块支持多模态输入]]

--- a/10-Knowledge/Evergreen/multimodal-perception.md
+++ b/10-Knowledge/Evergreen/multimodal-perception.md
@@ -1,0 +1,39 @@
+---
+schema_version: "1.0.0"
+note_id: multimodal-perception-96f84e06
+title: "AI Agent支持多模态感知输入"
+type: evergreen
+entity_type: concept
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["multimodal-perception", "agent-multimodal-perception", "multi-modal-perception"]
+---
+
+# AI Agent支持多模态感知输入
+
+> **一句话定义**: AI Agent的感知模块支持多种形式的输入，包括文本、图像、语音和API数据等多模态信息。
+
+## 📝 详细解释
+
+### 是什么？
+Perception模块作为Agent与环境交互的入口，负责接收和处理各种形式的环境信息输入。支持的输入类型包括：文本（用户请求、文档内容）、图像（视觉数据、图表）、语音（音频输入）、API数据（外部系统响应、数据库数据）等。感知模块将这些多模态输入进行处理、信息提取和格式转换，为后续的推理模块提供标准化的问题表示。感知能力直接决定了Agent能够处理的任务类型和复杂度。
+
+### 为什么重要？
+多模态感知能力决定了Agent的应用广度。支持越多模态的输入，Agent能够处理的任务类型越丰富，应用场景越广泛。
+
+## 🔗 关联概念
+- [[perception-reasoning-action-architecture]]
+- [[ai-agent-definition]]
+- [[ai-applications]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[agent-autonomy-9be9ea0e|AI Agent具备自主性，能够自主感知、推理和行动]]
+- [[ai-agent-core-characteristics-ab47e9e1|AI Agent具有四大核心特性：自主性、反应性、主动性和社会性]]
+- [[ai-agent-definition-411752f4|AI Agent是具备感知、推理、行动能力的自主系统]]
+- [[ai-agent-task-complexity评估|AI Agent architecture should match task complexity level]]

--- a/10-Knowledge/Evergreen/perception-reasoning-action-architecture.md
+++ b/10-Knowledge/Evergreen/perception-reasoning-action-architecture.md
@@ -1,0 +1,40 @@
+---
+schema_version: "1.0.0"
+note_id: perception-reasoning-action-architecture-49d27957
+title: "AI Agent采用Perception-Reasoning-Action三环架构"
+type: evergreen
+entity_type: framework
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["perception-reasoning-action-architecture", "ai-agent-perception-reasoning-action-architecture", "perception-reasoning-action-forms闭环-architecture"]
+---
+
+# AI Agent采用Perception-Reasoning-Action三环架构
+
+> **一句话定义**: AI Agent通过感知(Perception)、推理(Reasoning)、行动(Action)三个核心模块的协同工作实现自主智能
+
+## 📝 详细解释
+
+### 是什么？
+这是AI Agent的基础架构模式。Perception负责接收环境输入（用户请求、传感器数据、API响应等）；Reasoning对信息进行处理、分析和决策，模拟人类思考过程；Action将决策转化为实际行动并影响环境。三个模块形成闭环，持续迭代工作
+
+### 为什么重要？
+三环架构是理解所有AI Agent系统的基础，无论是客户服务机器人、代码生成助手还是研究自动化工具，都遵循这一架构模式
+
+## 🔗 关联概念
+- [[AI-Agent-Autonomy]]
+- [[Feedback-Loop-WorkFlow]]
+- [[Multi-modal-Perception]]
+- [[Tool-Calling]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[ai-agent-definition-411752f4|AI Agent是具备感知、推理、行动能力的自主系统]]
+- [[ai-agent-has-perception-reasoning-action-capabilities|AI Agent具有感知、推理、行动三大核心能力]]
+- [[multimodal-perception-96f84e06|AI Agent支持多模态感知输入]]
+- [[ai-agent-performs-perception-reasoning-action-d533b9f1|AI Agent执行感知-推理-行动的反馈循环]]

--- a/10-Knowledge/Evergreen/react-reasoning-combines-reasoning-with-action.md
+++ b/10-Knowledge/Evergreen/react-reasoning-combines-reasoning-with-action.md
@@ -1,0 +1,39 @@
+---
+schema_version: "1.0.0"
+note_id: react-reasoning-combines-reasoning-with-action-05fa5abf
+title: "ReAct reasoning combines reasoning with action"
+type: evergreen
+entity_type: framework
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["react-reasoning-combines-reasoning-with-action", "react-reasoning-combines-inference-with-action"]
+---
+
+# ReAct reasoning combines reasoning with action
+
+> **一句话定义**: ReAct (Reasoning + Action) 是一种prompt策略，将推理过程与行动调用结合，使Agent能够边思考边执行。
+
+## 📝 详细解释
+
+### 是什么？
+ReAct是Yao等人在2022年提出的推理框架，其核心思想是在每个推理步骤中同时生成思考(Thought)、行动(Action)和观察(Observation)。与传统Chain of Thought不同，ReAct允许Agent在推理过程中主动调用工具。例如：Thought（思考）→Action（调用搜索API）→Observation（获得搜索结果）→基于结果继续推理。这种'边想边做'的模式使Agent能够处理需要外部信息的多步骤任务，避免了纯推理模型可能出现的'幻觉'问题。ReAct在复杂推理任务上表现优于纯CoT或仅使用搜索的方法。
+
+### 为什么重要？
+ReAct是实现Agent推理能力的重要技术选择，尤其适用于需要调用工具获取外部信息的任务。
+
+## 🔗 关联概念
+- [[Chain of Thought]]
+- [[ai-agents-perception-reasoning-action-loop]]
+- [[Function Calling]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[multimodal-perception-96f84e06|AI Agent支持多模态感知输入]]
+- [[chain-of-thought-enables-multi-step-reasoning-477d3095|🔗 关联概念]]
+- [[ai-agent-task-complexity评估|AI Agent architecture should match task complexity level]]
+- [[chain-of-thought-enables-reasoning-bcd17d12|🔗 关联概念]]

--- a/10-Knowledge/Evergreen/react-reasoning-strategy.md
+++ b/10-Knowledge/Evergreen/react-reasoning-strategy.md
@@ -1,0 +1,39 @@
+---
+schema_version: "1.0.0"
+note_id: react-reasoning-strategy-80329943
+title: "ReAct strategy combines reasoning with action execution"
+type: evergreen
+entity_type: framework
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["react-reasoning-strategy"]
+---
+
+# ReAct strategy combines reasoning with action execution
+
+> **一句话定义**: ReAct（Reasoning + Action）是一种结合推理与行动的prompt策略，使Agent在推理过程中同步规划行动。
+
+## 📝 详细解释
+
+### 是什么？
+ReAct是Google提出的推理策略，核心思想是在推理过程中同时考虑行动方案。传统Chain of Thought（思维链）仅关注推理过程，而ReAct将推理分为‘思考(Thought)’和‘行动(Act)’两个交替阶段：思考阶段分析情况、规划行动；行动阶段执行操作、获取结果。这种交替迭代使Agent能够在推理过程中实时利用环境反馈调整行动方案，特别适合需要多步骤工具调用的复杂任务。ReAct已成为AI Agent推理层的核心技术策略之一。
+
+### 为什么重要？
+ReAct策略是将推理能力转化为实际行动的关键技术，是实现Agent自主性的核心机制。
+
+## 🔗 关联概念
+- [[Chain-of-Thought]]
+- [[ai-agents-perception-reasoning-action-loop]]
+- [[Tool-Use]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[multimodal-perception-96f84e06|AI Agent支持多模态感知输入]]
+- [[chain-of-thought-enables-reasoning-bcd17d12|🔗 关联概念]]
+- [[ai-agent-task-complexity评估|AI Agent architecture should match task complexity level]]
+- [[react-reasoning-combines-reasoning-with-action-05fa5abf|📝 详细解释]]

--- a/10-Knowledge/Evergreen/task-decomposition-and-planning.md
+++ b/10-Knowledge/Evergreen/task-decomposition-and-planning.md
@@ -1,0 +1,40 @@
+---
+schema_version: "1.0.0"
+note_id: task-decomposition-and-planning-0ec9d3dd
+title: "AI Agent通过任务分解和规划实现复杂目标处理"
+type: evergreen
+entity_type: method
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["task-decomposition-and-planning", "task-decomposition-planning"]
+---
+
+# AI Agent通过任务分解和规划实现复杂目标处理
+
+> **一句话定义**: AI Agent通过任务分解（Task Decomposition）将复杂目标拆解为可执行的子任务，并通过规划（Planning）制定策略来逐步实现目标。
+
+## 📝 详细解释
+
+### 是什么？
+任务分解与规划是AI Agent核心智能层的能力体现。任务分解涉及将一个复杂的总体目标分解为多个可管理的子任务步骤；规划则涉及确定任务执行的顺序、选择合适的工具和资源、预测可能的问题并准备应对策略。这要求Agent具备上下文状态追踪能力，以维护任务执行过程中的状态信息。常见的推理框架包括ReAct（Reasoning and Acting）和Chain-of-Thought（思维链），它们为Agent提供了结构化的推理路径。
+
+### 为什么重要？
+任务分解与规划能力是AI Agent处理复杂、多步骤任务的关键。这一能力使Agent能够处理远超单次LLM调用能力的复杂工作流程，是实现真正任务自动化的核心技术基础。没有这一能力，Agent只能处理简单的单一指令。
+
+## 🔗 关联概念
+- [[ReAct-Framework]]
+- [[Chain-of-Thought]]
+- [[Perception-Reasoning-Action]]
+- [[Task-Automation]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[agent-autonomy-9be9ea0e|AI Agent具备自主性，能够自主感知、推理和行动]]
+- [[ai-agent-core-characteristics-ab47e9e1|AI Agent具有四大核心特性：自主性、反应性、主动性和社会性]]
+- [[ai-agent-task-complexity评估|AI Agent architecture should match task complexity level]]
+- [[ai-agent-autonomy-characteristics-accef419|AI Agent具有自主性、反应性、主动性和社会性四大核心特征]]

--- a/10-Knowledge/Evergreen/task-decomposition-tool-selection.md
+++ b/10-Knowledge/Evergreen/task-decomposition-tool-selection.md
@@ -1,0 +1,40 @@
+---
+schema_version: "1.0.0"
+note_id: task-decomposition-tool-selection-73925ae5
+title: "AI Agent通过任务分解和工具选择实现复杂目标"
+type: evergreen
+entity_type: method
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["task-decomposition-tool-selection"]
+---
+
+# AI Agent通过任务分解和工具选择实现复杂目标
+
+> **一句话定义**: AI Agent的推理层通过将复杂目标拆解为可执行的子任务，并动态选择合适的工具来完成这些任务。
+
+## 📝 详细解释
+
+### 是什么？
+任务分解是AI Agent处理复杂问题的核心能力，将模糊的高层目标转化为具体可执行的子任务序列。工具选择则涉及根据当前任务需求，从可用的工具集（如搜索、计算、API调用、代码执行等）中动态决定使用哪些工具。这两个过程需要agent具备对任务的理解、对工具能力的认知以及对执行状态的追踪能力。典型的推理框架包括ReAct（推理+行动）和Chain-of-Thought（思维链）。
+
+### 为什么重要？
+任务分解和工具选择是AI Agent实现复杂任务自动化的关键能力，直接决定了agent能否有效处理多步骤工作流程。
+
+## 🔗 关联概念
+- [[Perception-Reasoning-Action-Loop]]
+- [[ReAct-Framework]]
+- [[Chain-of-Thought]]
+- [[Tool-Calling]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[agent-autonomy-9be9ea0e|AI Agent具备自主性，能够自主感知、推理和行动]]
+- [[ai-agent-core-characteristics-ab47e9e1|AI Agent具有四大核心特性：自主性、反应性、主动性和社会性]]
+- [[ai-agent-task-complexity评估|AI Agent architecture should match task complexity level]]
+- [[ai-agent-autonomy-characteristics-accef419|AI Agent具有自主性、反应性、主动性和社会性四大核心特征]]

--- a/10-Knowledge/Evergreen/tool-calling-mechanism.md
+++ b/10-Knowledge/Evergreen/tool-calling-mechanism.md
@@ -1,0 +1,39 @@
+---
+schema_version: "1.0.0"
+note_id: tool-calling-mechanism-1d57954a
+title: "AI Agent通过Tool Calling机制扩展能力并影响外部环境"
+type: evergreen
+entity_type: method
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["tool-calling-mechanism"]
+---
+
+# AI Agent通过Tool Calling机制扩展能力并影响外部环境
+
+> **一句话定义**: Tool Calling是Agent调用外部API、执行代码或操作外部系统的能力，使Agent能够突破纯语言生成的限制。
+
+## 📝 详细解释
+
+### 是什么？
+工具调用是Agent影响环境的主要方式之一。Agent通过工具注册与发现机制，动态选择合适的工具完成特定子任务。常见工具包括搜索API、数据库查询、代码执行、文件操作等。Tool Calling机制通常涉及：工具描述（让LLM理解可用工具）、参数生成（根据任务需求构造调用参数）、结果解析（处理工具返回并纳入推理上下文）。这一机制使Agent从被动的文本生成器转变为能够主动操作外部系统的主动执行者。
+
+### 为什么重要？
+Tool Calling是实现Agent真实世界应用的关键能力，它连接了LLM的语言理解与实际系统操作。
+
+## 🔗 关联概念
+- [[Perception-Reasoning-Action]]
+- [[Tool-Ecosystem]]
+- [[Function-Calling]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[ai-agent-task-complexity评估|AI Agent architecture should match task complexity level]]
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[ai-agent-core-characteristics-ab47e9e1|AI Agent具有四大核心特性：自主性、反应性、主动性和社会性]]
+- [[agent-autonomy-9be9ea0e|AI Agent具备自主性，能够自主感知、推理和行动]]
+- [[ai-agent-definition-411752f4|AI Agent是具备感知、推理、行动能力的自主系统]]

--- a/10-Knowledge/Evergreen/tool-calling.md
+++ b/10-Knowledge/Evergreen/tool-calling.md
@@ -1,0 +1,38 @@
+---
+schema_version: "1.0.0"
+note_id: tool-calling-6325a76b
+title: "工具调用是Agent行动模块的核心能力"
+type: evergreen
+entity_type: method
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["tool-calling"]
+---
+
+# 工具调用是Agent行动模块的核心能力
+
+> **一句话定义**: Agent通过工具调用与外部系统集成，执行API调用、数据修改、系统操作等行动
+
+## 📝 详细解释
+
+### 是什么？
+行动模块将推理决策转化为实际行动。工具调用是其中关键的技术实现，使Agent能够调用外部API、访问数据库、执行代码、操作系统等，与外部系统进行集成和交互
+
+### 为什么重要？
+工具调用能力使AI Agent从单纯的信息处理升级为能够执行实际操作任务的系统，是实现真正实用化Agent的关键技术
+
+## 🔗 关联概念
+- [[Perception-Reasoning-Action-Architecture]]
+- [[Feedback-Loop-WorkFlow]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[ai-agent-has-perception-reasoning-action-capabilities|AI Agent具有感知、推理、行动三大核心能力]]
+- [[ai-agent-task-complexity评估|AI Agent architecture should match task complexity level]]
+- [[multi-modal-perception-e8af11cc|AI Agent感知模块支持多模态输入]]
+- [[ai-agent-definition-411752f4|AI Agent是具备感知、推理、行动能力的自主系统]]

--- a/10-Knowledge/Evergreen/tool-ecosystems-define-agent-capability-boundaries.md
+++ b/10-Knowledge/Evergreen/tool-ecosystems-define-agent-capability-boundaries.md
@@ -1,0 +1,39 @@
+---
+schema_version: "1.0.0"
+note_id: tool-ecosystems-define-agent-capability-boundaries-dd8b3511
+title: "Tool ecosystems define agent capability boundaries"
+type: evergreen
+entity_type: concept
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["tool-ecosystems-define-agent-capability-boundaries"]
+---
+
+# Tool ecosystems define agent capability boundaries
+
+> **一句话定义**: Agent的能力边界很大程度上由其可调用的工具集合（Tool Ecosystem）决定，工具越丰富，Agent能完成的任务越复杂。
+
+## 📝 详细解释
+
+### 是什么？
+Tool Ecosystem指的是Agent能够访问和调用的外部工具集合。典型的工具有三层：基础工具（搜索引擎、计算器、日历）、业务工具（CRM、代码仓库、文档库）、执行工具（API调用、代码沙箱、文件操作）。工具的质量和覆盖度直接决定Agent能在何种场景发挥作用。在设计Agent系统时，需要根据任务需求选择和扩展工具生态。好的工具生态设计应该支持灵活扩展，新增工具后Agent应能自动发现并调用。
+
+### 为什么重要？
+理解工具生态的重要性有助于在Agent设计中做出正确的架构选择：先明确任务需要的工具，再设计Agent的推理能力。
+
+## 🔗 关联概念
+- [[Function Calling]]
+- [[MCP Protocol]]
+- [[Tool Use]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[agent-tool-use-capability-0c5535bf|AI Agent capability is bounded by its tool ecosystem]]
+- [[ai-agent-task-complexity评估|AI Agent architecture should match task complexity level]]
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[ai-agent-tool-ecosystem|AI Agent capabilities are bounded by its tool ecosystem]]
+- [[multi-modal-perception-e8af11cc|AI Agent感知模块支持多模态输入]]

--- a/10-Knowledge/Evergreen/tool-use-in-ai-agents.md
+++ b/10-Knowledge/Evergreen/tool-use-in-ai-agents.md
@@ -1,0 +1,39 @@
+---
+schema_version: "1.0.0"
+note_id: tool-use-in-ai-agents-d5d525c5
+title: "工具调用是AI Agent执行行动的核心机制"
+type: evergreen
+entity_type: concept
+date: 2026-04-06
+tags: [evergreen]
+aliases: ["tool-use-in-ai-agents"]
+---
+
+# 工具调用是AI Agent执行行动的核心机制
+
+> **一句话定义**: AI Agent通过Function Calling和Tool Use机制调用外部API、执行代码、查询数据库等方式影响环境并完成任务。
+
+## 📝 详细解释
+
+### 是什么？
+工具调用是Agent「行动(Action)」阶段的关键实现方式，使agent能够突破语言模型的固有局限，获取实时信息、执行实际操作。典型的工具类型包括：搜索API、计算工具、数据库查询、代码执行器等。工具注册与发现机制使agent能动态选择合适工具完成任务。
+
+### 为什么重要？
+工具调用能力直接决定了AI Agent的任务范围和实用价值，是实现真正「能做事的AI」的技术基础。
+
+## 🔗 关联概念
+- [[ai-agents-perception-reasoning-action-loop]]
+- [[function-calling]]
+- [[ai-agent-tool-ecosystem]]
+
+## 📚 来源与扩展阅读
+- [[2026-04-06_test-ai-article_深度解读]]
+
+## 🔗 自动建议链接 (link-suggest)
+<!-- link-suggest:backfill -->
+
+- [[2026-04-06-test-ai-article-深度解读|2026 04 06 test ai article 深度解读]]
+- [[agent-autonomy-9be9ea0e|AI Agent具备自主性，能够自主感知、推理和行动]]
+- [[ai-agent-definition-411752f4|AI Agent是具备感知、推理、行动能力的自主系统]]
+- [[ai-agent-core-characteristics-ab47e9e1|AI Agent具有四大核心特性：自主性、反应性、主动性和社会性]]
+- [[ai-agent-task-complexity评估|AI Agent architecture should match task complexity level]]


### PR DESCRIPTION
## Summary
- Backfill `entity_type` field in frontmatter for all 51 existing Evergreen notes
- Uses heuristic title-keyword matching to assign canonical types
- Distribution: concept (30), framework (13), method (6), tool (2)
- Completes the M8 type unification for historical data

## Context
PR #102 introduced the canonical object kind taxonomy and `entity_type` field
for newly created Evergreen notes. This PR retroactively annotates all existing
notes so `ovp-schema validate --strict` passes.


Made with [Cursor](https://cursor.com)