### PR TITLE
fix: add missing llm_client.py + dedup backfill against extraction log

### DIFF
--- a/src/ovp_pipeline/commands/backfill_entities.py
+++ b/src/ovp_pipeline/commands/backfill_entities.py
@@ -41,6 +41,7 @@ def run(
     use_llm: bool = True,
     rate_limit_rpm: int = 0,
     inter_call_sleep_s: float = 0.0,
+    force: bool = False,
 ) -> dict[str, Any]:
     from ..entity_extractor import make_extractor
     from ..entity_registry import EntityRegistry
@@ -85,7 +86,28 @@ def run(
     extraction_log = vault_dir / "60-Logs" / "entity-extractions.jsonl"
     extraction_log.parent.mkdir(parents=True, exist_ok=True)
 
+    # Dedup against prior runs: skip files already extracted unless --force.
+    # Without this, ``ovp-backfill-entities`` would re-process every file
+    # on every run (we hit this in the May 2026 history rerun: 274 files
+    # got 2-4 entries in the log, doubling token cost for no new data).
+    already_extracted: set[str] = set()
+    if not force and extraction_log.exists():
+        for line in extraction_log.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+                sf = obj.get("source_file", "")
+                if sf:
+                    already_extracted.add(sf)
+            except json.JSONDecodeError:
+                continue
+        if already_extracted:
+            print(f"  Skipping {len(already_extracted)} previously-extracted files (use --force to re-process)")
+
     processed = 0
+    skipped_already_extracted = 0
     total_mentions = 0
     total_candidates = 0
     errors = 0
@@ -113,6 +135,9 @@ def run(
             call_timestamps.append(time.time())
 
     for i, fpath in enumerate(md_files):
+        if str(fpath) in already_extracted:
+            skipped_already_extracted += 1
+            continue
         _throttle()
         try:
             extraction = extractor.extract_entities_from_file(fpath)
@@ -155,6 +180,7 @@ def run(
     summary = {
         "files_total": total,
         "files_processed": processed,
+        "files_skipped_already_extracted": skipped_already_extracted,
         "errors": errors,
         "mentions_extracted": total_mentions,
         "candidates_created": total_candidates,
@@ -232,6 +258,13 @@ def main() -> None:
         help="Seconds to sleep between consecutive LLM calls (default 0). "
              "Useful for providers with strict per-second limits.",
     )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-process files that already have entries in the extraction "
+             "log.  By default, dedup against the log so reruns only "
+             "process new files.",
+    )
     args = parser.parse_args()
     result = run(
         args.vault_dir,
@@ -242,6 +275,7 @@ def main() -> None:
         use_llm=not args.no_llm,
         rate_limit_rpm=args.rate_limit_rpm,
         inter_call_sleep_s=args.inter_call_sleep,
+        force=args.force,
     )
     if result.get("error"):
         sys.exit(1)

--- a/src/ovp_pipeline/commands/backfill_entities.py
+++ b/src/ovp_pipeline/commands/backfill_entities.py
@@ -90,19 +90,29 @@ def run(
     # Without this, ``ovp-backfill-entities`` would re-process every file
     # on every run (we hit this in the May 2026 history rerun: 274 files
     # got 2-4 entries in the log, doubling token cost for no new data).
+    #
+    # Both sides of the comparison go through ``_canonical_path`` so a log
+    # entry written as a relative or non-resolved path still matches.
+    def _canonical_path(p: str | Path) -> str:
+        try:
+            return str(Path(p).resolve(strict=False))
+        except (OSError, ValueError):
+            return str(p)
+
     already_extracted: set[str] = set()
     if not force and extraction_log.exists():
-        for line in extraction_log.read_text(encoding="utf-8").splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                obj = json.loads(line)
+        with extraction_log.open(encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
                 sf = obj.get("source_file", "")
                 if sf:
-                    already_extracted.add(sf)
-            except json.JSONDecodeError:
-                continue
+                    already_extracted.add(_canonical_path(sf))
         if already_extracted:
             print(f"  Skipping {len(already_extracted)} previously-extracted files (use --force to re-process)")
 
@@ -135,7 +145,7 @@ def run(
             call_timestamps.append(time.time())
 
     for i, fpath in enumerate(md_files):
-        if str(fpath) in already_extracted:
+        if _canonical_path(fpath) in already_extracted:
             skipped_already_extracted += 1
             continue
         _throttle()

--- a/src/ovp_pipeline/llm_client.py
+++ b/src/ovp_pipeline/llm_client.py
@@ -15,8 +15,11 @@ fall back to alias-only mode.
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 
 class _CallableLLMClient:
@@ -54,8 +57,9 @@ def get_litellm_client(vault_dir: Path | None = None) -> _CallableLLMClient | No
     if vault_dir is not None:
         try:
             load_env_file(Path(vault_dir))
-        except Exception:
-            # Don't fail client creation just because .env was missing.
+        except (FileNotFoundError, IsADirectoryError):
+            # .env genuinely missing or shadowed by a directory — fine,
+            # we'll fall back to whatever's already in the shell env.
             pass
 
     if not resolve_api_key():
@@ -63,7 +67,17 @@ def get_litellm_client(vault_dir: Path | None = None) -> _CallableLLMClient | No
 
     try:
         inner = LiteLLMClient()
-    except Exception:
+    except ValueError:
+        # LiteLLMClient raises ValueError specifically when api_key is
+        # absent (rare race after resolve_api_key succeeded but before
+        # construction) — caller's intended fallback path.
         return None
+    except Exception as exc:
+        # Anything else (network init, missing dep, bad config) is a
+        # real setup error.  Surface it loudly instead of silently
+        # falling back to alias-only mode — that's exactly the bug
+        # llm_client.py was created to prevent recurrence of.
+        logger.error("get_litellm_client: unexpected failure constructing client: %r", exc)
+        raise
 
     return _CallableLLMClient(inner)

--- a/src/ovp_pipeline/llm_client.py
+++ b/src/ovp_pipeline/llm_client.py
@@ -1,0 +1,69 @@
+"""Lightweight LLM client wrapper for entity extraction and similar tasks.
+
+Provides a single factory ``get_litellm_client(vault_dir)`` returning an
+object with ``.call(system_prompt, user_prompt, max_tokens) -> str``.
+This is the contract ``EntityExtractor`` and similar consumers expect.
+
+Backed by ``LiteLLMClient`` from ``auto_evergreen_extractor``, which
+already handles retries, the proxy policy, and api_key/api_base
+resolution from the vault's ``.env`` file plus shell environment
+fallbacks (``AUTO_VAULT_API_KEY`` → ``MINIMAX_API_KEY`` → ...).
+
+Returns ``None`` when no API key is available so callers can gracefully
+fall back to alias-only mode.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+class _CallableLLMClient:
+    """Adapt LiteLLMClient.generate(...) → .call(...) for entity_extractor."""
+
+    def __init__(self, inner: Any) -> None:
+        self._inner = inner
+
+    def call(self, system_prompt: str, user_prompt: str, max_tokens: int = 3000) -> str:
+        # ``LiteLLMClient.generate`` in auto_evergreen_extractor returns
+        # plain ``str``; the auto_article_processor variant returns
+        # ``tuple[str, dict]``.  Handle either shape.
+        out = self._inner.generate(system_prompt, user_prompt, max_tokens=max_tokens)
+        if isinstance(out, tuple):
+            text = out[0]
+        else:
+            text = out
+        return text or ""
+
+
+def get_litellm_client(vault_dir: Path | None = None) -> _CallableLLMClient | None:
+    """Construct an LLM client for the given vault, or return ``None`` if
+    no API key is configured.
+
+    The vault's ``.env`` is loaded first so values like
+    ``AUTO_VAULT_API_BASE`` / ``AUTO_VAULT_MODEL`` set there take effect
+    when the shell environment doesn't override them.
+    """
+    try:
+        from .auto_evergreen_extractor import LiteLLMClient, load_env_file
+        from .llm_defaults import resolve_api_key
+    except ImportError:
+        return None
+
+    if vault_dir is not None:
+        try:
+            load_env_file(Path(vault_dir))
+        except Exception:
+            # Don't fail client creation just because .env was missing.
+            pass
+
+    if not resolve_api_key():
+        return None
+
+    try:
+        inner = LiteLLMClient()
+    except Exception:
+        return None
+
+    return _CallableLLMClient(inner)

--- a/tests/test_backfill_entities_dedup.py
+++ b/tests/test_backfill_entities_dedup.py
@@ -108,12 +108,10 @@ class TestLLMClientFactory:
 
     def test_returns_none_without_api_key(self, temp_vault, monkeypatch):
         from ovp_pipeline.llm_client import get_litellm_client
-        # Strip every API key env var the resolver checks.
-        for env_name in (
-            "AUTO_VAULT_API_KEY", "SPEC_ORCH_LLM_API_KEY",
-            "MINIMAX_API_KEY", "MINIMAX_CN_API_KEY",
-            "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_API_KEY",
-        ):
+        from ovp_pipeline.llm_defaults import API_KEY_FALLBACKS
+        # Strip every API key env var the resolver checks — pull the list
+        # from llm_defaults so this test stays in lockstep with the resolver.
+        for env_name in API_KEY_FALLBACKS:
             monkeypatch.delenv(env_name, raising=False)
         client = get_litellm_client(vault_dir=temp_vault)
         assert client is None

--- a/tests/test_backfill_entities_dedup.py
+++ b/tests/test_backfill_entities_dedup.py
@@ -1,0 +1,119 @@
+"""Tests for ``ovp-backfill-entities`` re-extraction dedup.
+
+The May 2026 history rerun discovered that ``backfill_entities.py`` had
+no dedup against ``entity-extractions.jsonl``: every invocation
+re-processed all files in ``20-Areas/``, even ones already in the log.
+This re-extraction caused 274 files to get 2-4 log entries during a
+single run, doubling the LLM token cost without producing new data.
+
+Locks the new behaviour:
+  * by default, files already in the extraction log are skipped
+  * ``--force`` overrides and re-processes them
+  * the summary reports how many were skipped
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from ovp_pipeline.commands import backfill_entities
+
+
+@pytest.fixture
+def vault_with_one_deepdive(temp_vault):
+    """Vault with a single deep dive ready for backfill, no LLM client."""
+    md = temp_vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "x_深度解读.md"
+    md.parent.mkdir(parents=True, exist_ok=True)
+    md.write_text("---\ntitle: x\n---\nbody mentioning Claude.\n", encoding="utf-8")
+    return temp_vault, md
+
+
+def _read_log_lines(vault: Path) -> list[dict]:
+    log = vault / "60-Logs" / "entity-extractions.jsonl"
+    if not log.exists():
+        return []
+    return [json.loads(line) for line in log.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+class TestDedupAgainstExtractionLog:
+
+    def test_default_run_skips_already_extracted(self, vault_with_one_deepdive):
+        vault, md = vault_with_one_deepdive
+        # Pre-seed the extraction log so this file looks "already done".
+        log = vault / "60-Logs" / "entity-extractions.jsonl"
+        log.parent.mkdir(parents=True, exist_ok=True)
+        log.write_text(
+            json.dumps({
+                "source_file": str(md),
+                "source_slug": "x-深度解读",
+                "mentions": [],
+                "backfilled_at": "2026-05-01T00:00:00+00:00",
+            }) + "\n",
+            encoding="utf-8",
+        )
+
+        summary = backfill_entities.run(
+            vault, dry_run=False, use_llm=False,  # alias-only, no LLM client needed
+        )
+        assert summary["files_processed"] == 0
+        assert summary["files_skipped_already_extracted"] == 1
+        # No new log lines written:
+        assert len(_read_log_lines(vault)) == 1
+
+    def test_force_reprocesses_already_extracted(self, vault_with_one_deepdive):
+        vault, md = vault_with_one_deepdive
+        log = vault / "60-Logs" / "entity-extractions.jsonl"
+        log.parent.mkdir(parents=True, exist_ok=True)
+        log.write_text(
+            json.dumps({
+                "source_file": str(md),
+                "source_slug": "x-深度解读",
+                "mentions": [],
+                "backfilled_at": "2026-05-01T00:00:00+00:00",
+            }) + "\n",
+            encoding="utf-8",
+        )
+
+        summary = backfill_entities.run(
+            vault, dry_run=False, use_llm=False, force=True,
+        )
+        assert summary["files_processed"] == 1
+        assert summary["files_skipped_already_extracted"] == 0
+
+    def test_fresh_vault_processes_everything(self, vault_with_one_deepdive):
+        vault, _md = vault_with_one_deepdive
+        # No prior extraction log → every file is "new".
+        summary = backfill_entities.run(
+            vault, dry_run=False, use_llm=False,
+        )
+        assert summary["files_processed"] == 1
+        assert summary["files_skipped_already_extracted"] == 0
+
+
+class TestLLMClientFactory:
+    """Smoke test for src/ovp_pipeline/llm_client.py — the missing module
+    that caused entity_extract to silently fall back to alias-only mode
+    for months (entity_extractor / backfill_entities both import it via
+    try/except ImportError: pass).
+    """
+
+    def test_module_importable(self):
+        """If this fails, the file vanished and the silent-fallback is back."""
+        from ovp_pipeline import llm_client  # noqa: F401
+        assert hasattr(llm_client, "get_litellm_client")
+
+    def test_returns_none_without_api_key(self, temp_vault, monkeypatch):
+        from ovp_pipeline.llm_client import get_litellm_client
+        # Strip every API key env var the resolver checks.
+        for env_name in (
+            "AUTO_VAULT_API_KEY", "SPEC_ORCH_LLM_API_KEY",
+            "MINIMAX_API_KEY", "MINIMAX_CN_API_KEY",
+            "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_API_KEY",
+        ):
+            monkeypatch.delenv(env_name, raising=False)
+        client = get_litellm_client(vault_dir=temp_vault)
+        assert client is None


### PR DESCRIPTION
## Summary

Two real bugs uncovered during the May 2026 history rerun:

### 1. `src/ovp_pipeline/llm_client.py` was missing

`backfill_entities.py` and `step_entity_extract` both import via:
```python
try:
    from .llm_client import get_litellm_client
    ...
except Exception:
    pass
```

Since the module didn't exist, every import silently returned None, and **entity_extract has been running in alias-only mode for months**. Adds a thin wrapper around the existing `LiteLLMClient` that returns None when no API key is configured (so alias-only fallback is intentional).

After this fix the May 2026 rerun produced **1,466 entities** (vs the 27 seeded ones). Same call sites, same code path — just had to put the module on disk.

### 2. `ovp-backfill-entities` had no dedup against the extraction log

`step_entity_extract` already maintains an `already_extracted` set and skips files in it. The CLI command didn't — it re-processed all 654 deep dives every run. In the rerun this caused 274 files to produce 2–4 entries in the log, doubling token cost.

Now mirrors the dispatcher behaviour by default; `--force` restores re-processing.

## Test plan

- [x] 5 new tests in `tests/test_backfill_entities_dedup.py`:
  * `llm_client` module importable
  * `get_litellm_client` returns None without API key
  * default run skips already-extracted
  * `--force` re-processes
  * fresh vault processes everything
- [x] All 1525 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--force` flag to the backfill entities command, allowing users to reprocess previously extracted files.
  * Backfill command now automatically skips files already processed, improving efficiency on repeated runs.

* **Tests**
  * Added comprehensive test coverage for file deduplication and LLM client functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->