### PR TITLE
feat(entities): Twitter author entity layer + twitterapi.io backfill

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,7 @@ ovp-runtime-state = "ovp_pipeline.commands.runtime_state:main"
 ovp-schema = "ovp_pipeline.commands.schema_cmd:main"
 ovp-backfill-entity-type = "ovp_pipeline.commands.backfill_entity_type:main"
 ovp-backfill-entities = "ovp_pipeline.commands.backfill_entities:main"
+ovp-backfill-twitter-authors = "ovp_pipeline.commands.backfill_twitter_authors:main"
 ovp-refresh-entities = "ovp_pipeline.commands.refresh_entities:main"
 ovp-embedding-dedup = "ovp_pipeline.commands.embedding_dedup:main"
 

--- a/src/ovp_pipeline/commands/backfill_twitter_authors.py
+++ b/src/ovp_pipeline/commands/backfill_twitter_authors.py
@@ -1,0 +1,234 @@
+"""ovp-backfill-twitter-authors — populate entities for X/Twitter handles.
+
+Scans the vault for X handles, calls twitterapi.io for each one not
+already cached (or stale), persists the result into the ``entities``
+table, and prints a progress + cost summary.
+
+Usage::
+
+    ovp-backfill-twitter-authors --vault-dir ~/Documents/ovp-vault
+    ovp-backfill-twitter-authors --vault-dir ~/Documents/ovp-vault --dry-run
+    ovp-backfill-twitter-authors --only karpathy --force
+
+Authentication
+--------------
+
+API key is read in this order, first match wins:
+  1. ``--api-key`` CLI arg
+  2. ``TWITTERAPI_IO_KEY`` environment variable
+  3. First non-comment line of ``<vault-dir>/60-Logs/.twitterapi-io-key``
+
+Cost
+----
+
+Single-user calls cost $0.00018 each.  The CLI tracks running cost
+and prints it in the summary; pass ``--max-handles N`` to cap the
+spend if you're nervous.
+
+Idempotence
+-----------
+
+Handles already in ``entities`` are skipped unless their
+``last_fetched_at`` is older than ``--max-age-days`` (default 30).
+``--force`` re-fetches everything regardless.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from ..entities.scan import scan_twitter_handles
+from ..entities.store import EntityStore
+from ..entities.twitter_backfill import (
+    PRICE_PER_CALL_USD,
+    derive_authority_from_payload,
+    fetch_user_info,
+    stub_signals_for_missing,
+)
+
+
+_ENTITY_TYPE = "twitter_author"
+_FETCH_SOURCE = "twitterapi.io"
+_DEFAULT_MAX_AGE_DAYS = 30
+# Tiny pause between calls to be polite even if rate limit isn't hit.
+_PER_CALL_SLEEP_S = 0.1
+
+
+def _resolve_api_key(cli_arg: str | None, vault_dir: Path) -> str | None:
+    if cli_arg:
+        return cli_arg.strip()
+    env = os.environ.get("TWITTERAPI_IO_KEY")
+    if env:
+        return env.strip()
+    keyfile = vault_dir / "60-Logs" / ".twitterapi-io-key"
+    if keyfile.exists():
+        for line in keyfile.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line and not line.startswith("#"):
+                return line
+    return None
+
+
+def _is_stale(last_fetched_at: str, max_age_days: int) -> bool:
+    try:
+        dt = datetime.fromisoformat(last_fetched_at)
+    except ValueError:
+        return True
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return (datetime.now(timezone.utc) - dt) > timedelta(days=max_age_days)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Backfill twitter_author entities via twitterapi.io",
+    )
+    parser.add_argument("--vault-dir", type=Path, default=Path.cwd())
+    parser.add_argument("--api-key", default=None,
+                        help="twitterapi.io API key (else env / keyfile)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Plan + cost only, no API calls, no DB writes")
+    parser.add_argument("--max-handles", type=int, default=None,
+                        help="Stop after N new fetches (cost cap)")
+    parser.add_argument("--max-age-days", type=int, default=_DEFAULT_MAX_AGE_DAYS,
+                        help="Re-fetch entities older than this many days")
+    parser.add_argument("--force", action="store_true",
+                        help="Re-fetch every handle, even if cached + fresh")
+    parser.add_argument("--only", default=None,
+                        help="Only fetch this single handle (debug)")
+    parser.add_argument("--min-mentions", type=int, default=1,
+                        help="Skip handles with fewer than N total mentions "
+                             "(default 1 = all)")
+    args = parser.parse_args(argv)
+
+    vault = args.vault_dir.resolve()
+    if not vault.is_dir():
+        print(f"vault not found: {vault}", file=sys.stderr)
+        return 2
+
+    db_path = vault / "60-Logs" / "knowledge.db"
+    store = EntityStore(db_path=db_path)
+
+    # ---- discover handles --------------------------------------------------
+
+    if args.only:
+        target_handles = [(args.only.lower().lstrip("@"), 0)]
+    else:
+        mentions = scan_twitter_handles(vault)
+        target_handles = [
+            (m.handle, m.mention_count)
+            for m in mentions
+            if m.mention_count >= args.min_mentions
+        ]
+
+    if not target_handles:
+        print("no handles to process")
+        return 0
+
+    # ---- filter against cache ---------------------------------------------
+
+    to_fetch: list[tuple[str, int]] = []
+    cached_fresh: int = 0
+    for handle, mentions in target_handles:
+        existing = store.get(_ENTITY_TYPE, handle)
+        if existing and not args.force:
+            if not _is_stale(existing.last_fetched_at, args.max_age_days):
+                cached_fresh += 1
+                continue
+        to_fetch.append((handle, mentions))
+
+    if args.max_handles is not None:
+        to_fetch = to_fetch[: args.max_handles]
+
+    # ---- preflight summary -------------------------------------------------
+
+    cost_estimate = len(to_fetch) * PRICE_PER_CALL_USD
+    print(f"vault:                {vault}")
+    print(f"db:                   {db_path}")
+    print(f"handles discovered:   {len(target_handles)}")
+    print(f"already cached fresh: {cached_fresh}")
+    print(f"to fetch this run:    {len(to_fetch)}")
+    print(f"estimated cost:       ${cost_estimate:.4f}  "
+          f"(at ${PRICE_PER_CALL_USD}/call)")
+
+    if args.dry_run:
+        print("\n--dry-run set; not calling API or writing DB")
+        return 0
+
+    if not to_fetch:
+        print("\nnothing to do — all handles cached fresh")
+        return 0
+
+    # ---- auth --------------------------------------------------------------
+
+    api_key = _resolve_api_key(args.api_key, vault)
+    if not api_key:
+        print("error: no API key found (--api-key, TWITTERAPI_IO_KEY env, "
+              "or 60-Logs/.twitterapi-io-key file)", file=sys.stderr)
+        return 2
+
+    # ---- fetch loop --------------------------------------------------------
+
+    n_ok = n_not_found = n_error = 0
+    for i, (handle, mentions) in enumerate(to_fetch, 1):
+        result = fetch_user_info(handle, api_key=api_key)
+        if result.status == "ok" and result.payload is not None:
+            authority, signals = derive_authority_from_payload(result.payload)
+            signals["mention_count_in_vault"] = mentions
+            store.upsert(
+                entity_type=_ENTITY_TYPE,
+                identity_key=handle,
+                canonical_name=result.payload.get("name"),
+                signals=signals,
+                derived_authority=authority,
+                fetch_source=_FETCH_SOURCE,
+            )
+            n_ok += 1
+        elif result.status == "not_found":
+            store.upsert(
+                entity_type=_ENTITY_TYPE,
+                identity_key=handle,
+                canonical_name=None,
+                signals=stub_signals_for_missing(handle, result.error or ""),
+                derived_authority=None,
+                fetch_source=_FETCH_SOURCE,
+            )
+            n_not_found += 1
+        else:
+            print(f"  [error] @{handle}: {result.error}", file=sys.stderr)
+            n_error += 1
+
+        if i % 25 == 0 or i == len(to_fetch):
+            done = n_ok + n_not_found + n_error
+            print(f"  progress: {done:>4}/{len(to_fetch)}  "
+                  f"ok={n_ok} not_found={n_not_found} error={n_error}")
+        time.sleep(_PER_CALL_SLEEP_S)
+
+    actual_cost = (n_ok + n_not_found + n_error) * PRICE_PER_CALL_USD
+
+    print()
+    print("=== Summary ===")
+    print(f"  ok:        {n_ok:>5}")
+    print(f"  not_found: {n_not_found:>5}")
+    print(f"  error:     {n_error:>5}")
+    print(f"  cached:    {cached_fresh:>5}  (skipped — already fresh)")
+    print(f"  cost:      ${actual_cost:.4f}  (actual, including failed calls)")
+    print()
+    print("Top 10 by partial authority:")
+    top = store.list_by_type(_ENTITY_TYPE, limit=10)
+    for e in top:
+        if e.derived_authority is None:
+            continue
+        print(f"  {e.derived_authority:.2f}  @{e.identity_key:<25} "
+              f"{(e.canonical_name or '')[:40]}")
+
+    return 0 if n_error == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ovp_pipeline/entities/__init__.py
+++ b/src/ovp_pipeline/entities/__init__.py
@@ -1,0 +1,32 @@
+"""Entity layer — first-class Author/Project records that signals attach to.
+
+Until PR-E1 every author/project signal lived only in the per-clipping
+frontmatter.  That worked when each clipping carried full data, but
+breaks down when:
+
+  * the same handle appears in 50 clippings (denormalized waste)
+  * the clipping was captured before the new adapter (no data at all)
+  * we want to accumulate signal across multiple captures of the same
+    author (e.g. "we've bookmarked this person 12 times")
+
+This package introduces an ``entities`` table indexed by
+``(entity_type, identity_key)`` that holds the merged view.  Authority
+scoring will (in PR-E3) read from here instead of frontmatter.
+
+Entity types currently supported:
+  * ``twitter_author``  — populated by ovp-backfill-twitter-authors
+  * (future) ``github_project`` and ``github_user`` in PR-E2
+  * (future) ``wechat_mp``, ``substack_publication`` in later PRs
+"""
+
+from .store import (
+    Entity,
+    EntityStore,
+    init_schema,
+)
+
+__all__ = [
+    "Entity",
+    "EntityStore",
+    "init_schema",
+]

--- a/src/ovp_pipeline/entities/scan.py
+++ b/src/ovp_pipeline/entities/scan.py
@@ -23,23 +23,25 @@ from pathlib import Path
 from typing import Iterator
 
 
+# Shared URL terminator class — applied as a lookahead so the
+# captured group stops at any character that ends a URL inside prose
+# (path separators, query/fragment markers, closing brackets/parens
+# from markdown links, whitespace, quotes).
+_URL_END = r"(?=[/?#)\]\s\"'`>]|$)"
+
 # X/Twitter handle inside a status URL or a bare profile URL.
-# We accept both ``x.com/<handle>`` and ``x.com/<handle>/status/<id>``
-# because the question is "does this handle appear" not "did they
-# write a tweet we ingested".
+# Accepts both ``x.com/<handle>`` and ``x.com/<handle>/status/<id>``.
+# The terminator prevents over-matching on sub-paths like
+# ``x.com/karpathy/settings`` (which would otherwise capture
+# ``karpathy`` AND continue reading).
 _X_HANDLE_RE = re.compile(
-    r"(?:x|twitter)\.com/(@?[A-Za-z0-9_]+)(?:/status/\d+)?",
+    rf"(?:x|twitter)\.com/(@?[A-Za-z0-9_]+)(?:/status/\d+)?{_URL_END}",
     re.IGNORECASE,
 )
 
-# GitHub owner/repo from a URL.  Stops at the first ``/?#`` after the
-# repo segment so we don't pick up sub-paths like ``/issues/12`` as
-# part of the repo name.
+# GitHub owner/repo from a URL.
 _GH_REPO_RE = re.compile(
-    # The repo segment ends at any URL-terminating character: path
-    # separators, query/fragment markers, closing brackets/parens
-    # (markdown links!), whitespace, quotes, or end-of-string.
-    r"github\.com/([\w.-]+)/([\w.-]+?)(?=[/?#)\]\s\"'`>]|$)",
+    rf"github\.com/([\w.-]+)/([\w.-]+?){_URL_END}",
     re.IGNORECASE,
 )
 
@@ -87,26 +89,38 @@ def iter_markdown_files(vault_dir: Path) -> Iterator[Path]:
         yield p
 
 
-def scan_twitter_handles(vault_dir: Path) -> list[HandleMention]:
-    """Return handles sorted descending by mention_count."""
-    total: Counter[str] = Counter()
-    files: dict[str, set[Path]] = {}
+def _iter_relevant_files(
+    vault_dir: Path, keywords: tuple[str, ...],
+) -> Iterator[tuple[Path, str]]:
+    """Walk the vault yielding ``(path, text)`` only for files that
+    contain at least one of ``keywords``.
 
+    The keyword pre-filter saves the regex engine from being run
+    against the ~90% of vault files that don't mention the platform
+    in question — measured: ~30x faster on the full OVP vault.
+    Errors reading a file are swallowed so a single bad path can't
+    abort the whole scan.
+    """
     for path in iter_markdown_files(vault_dir):
         try:
             text = path.read_text(encoding="utf-8", errors="replace")
         except OSError:
             continue
-        # Cheap pre-filter — saves regex work on the >90% of files
-        # that don't reference Twitter at all.
-        if "x.com" not in text and "twitter.com" not in text:
+        if not any(kw in text for kw in keywords):
             continue
+        yield path, text
+
+
+def scan_twitter_handles(vault_dir: Path) -> list[HandleMention]:
+    """Return handles sorted descending by mention_count."""
+    total: Counter[str] = Counter()
+    files: dict[str, set[Path]] = {}
+
+    for path, text in _iter_relevant_files(vault_dir, ("x.com", "twitter.com")):
         seen_in_file: set[str] = set()
         for m in _X_HANDLE_RE.finditer(text):
             handle = m.group(1).lstrip("@").lower()
-            if handle in _X_NON_HANDLE:
-                continue
-            if not handle:
+            if not handle or handle in _X_NON_HANDLE:
                 continue
             total[handle] += 1
             seen_in_file.add(handle)
@@ -131,18 +145,9 @@ def scan_github_mentions(vault_dir: Path) -> list[GitHubMention]:
     """
     repo_total: Counter[tuple[str, str]] = Counter()
     repo_files: dict[tuple[str, str], set[Path]] = {}
-    owner_total: Counter[str] = Counter()
-    owner_files: dict[str, set[Path]] = {}
 
-    for path in iter_markdown_files(vault_dir):
-        try:
-            text = path.read_text(encoding="utf-8", errors="replace")
-        except OSError:
-            continue
-        if "github.com" not in text:
-            continue
+    for path, text in _iter_relevant_files(vault_dir, ("github.com",)):
         seen_repos_in_file: set[tuple[str, str]] = set()
-        seen_owners_in_file: set[str] = set()
         for m in _GH_REPO_RE.finditer(text):
             owner = m.group(1).lower()
             if owner in _GH_NON_REPO_OWNERS:
@@ -151,20 +156,16 @@ def scan_github_mentions(vault_dir: Path) -> list[GitHubMention]:
             if repo.endswith(".git"):
                 repo = repo[:-4]
             repo_total[(owner, repo)] += 1
-            owner_total[owner] += 1
             seen_repos_in_file.add((owner, repo))
-            seen_owners_in_file.add(owner)
         for key in seen_repos_in_file:
             repo_files.setdefault(key, set()).add(path)
-        for owner in seen_owners_in_file:
-            owner_files.setdefault(owner, set()).add(path)
 
-    out: list[GitHubMention] = []
-    for (owner, repo), c in repo_total.most_common():
-        out.append(GitHubMention(
+    return [
+        GitHubMention(
             owner=owner,
             repo=repo,
             mention_count=c,
             file_count=len(repo_files.get((owner, repo), ())),
-        ))
-    return out
+        )
+        for (owner, repo), c in repo_total.most_common()
+    ]

--- a/src/ovp_pipeline/entities/scan.py
+++ b/src/ovp_pipeline/entities/scan.py
@@ -1,0 +1,170 @@
+"""Scan a vault for entity references.
+
+The recon script in ``/tmp/recon_entities.py`` proved the design;
+this is the productionized version.
+
+Why "anywhere in markdown" rather than "frontmatter source only":
+  * a Twitter handle may be quoted as ``@karpathy`` in body prose
+    even when the source URL is GitHub or anthropic.com
+  * a GitHub repo may be linked in a wikilink like
+    ``[karpathy/nanoGPT](https://github.com/karpathy/nanoGPT)`` from
+    a regular evergreen note
+  * the entity-as-citizen view is platform-agnostic; we should pick
+    up *all* mentions, not just the ones lucky enough to be the
+    primary source of a clipping
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator
+
+
+# X/Twitter handle inside a status URL or a bare profile URL.
+# We accept both ``x.com/<handle>`` and ``x.com/<handle>/status/<id>``
+# because the question is "does this handle appear" not "did they
+# write a tweet we ingested".
+_X_HANDLE_RE = re.compile(
+    r"(?:x|twitter)\.com/(@?[A-Za-z0-9_]+)(?:/status/\d+)?",
+    re.IGNORECASE,
+)
+
+# GitHub owner/repo from a URL.  Stops at the first ``/?#`` after the
+# repo segment so we don't pick up sub-paths like ``/issues/12`` as
+# part of the repo name.
+_GH_REPO_RE = re.compile(
+    # The repo segment ends at any URL-terminating character: path
+    # separators, query/fragment markers, closing brackets/parens
+    # (markdown links!), whitespace, quotes, or end-of-string.
+    r"github\.com/([\w.-]+)/([\w.-]+?)(?=[/?#)\]\s\"'`>]|$)",
+    re.IGNORECASE,
+)
+
+# Path segments that look like ``<owner>/<repo>`` to the regex but are
+# really top-level GitHub features.  Drop them.
+_GH_NON_REPO_OWNERS = frozenset({
+    "orgs", "topics", "marketplace", "settings", "pricing", "search",
+    "about", "features", "explore", "trending", "issues", "pulls",
+    "notifications", "sponsors", "collections", "events",
+})
+
+# Reserved X paths that look like handles but aren't.
+_X_NON_HANDLE = frozenset({
+    "home", "explore", "i", "search", "messages", "notifications",
+    "compose", "settings", "intent", "share", "login", "signup",
+    "tos", "privacy", "about",
+})
+
+
+@dataclass(frozen=True, slots=True)
+class HandleMention:
+    """One X/Twitter handle and how often it appears across the vault."""
+
+    handle: str            # lowercased, no @
+    mention_count: int     # total occurrences across all files
+    file_count: int        # number of distinct files that mention it
+
+
+@dataclass(frozen=True, slots=True)
+class GitHubMention:
+    """A GitHub repo + its owner."""
+
+    owner: str
+    repo: str | None       # None if we only saw the owner, not a repo URL
+    mention_count: int
+    file_count: int
+
+
+def iter_markdown_files(vault_dir: Path) -> Iterator[Path]:
+    """Yield every .md path under the vault, skipping caches/backups."""
+    skip_parts = frozenset({"__pycache__", "_backup", ".git", "node_modules"})
+    for p in vault_dir.rglob("*.md"):
+        if any(part in skip_parts for part in p.parts):
+            continue
+        yield p
+
+
+def scan_twitter_handles(vault_dir: Path) -> list[HandleMention]:
+    """Return handles sorted descending by mention_count."""
+    total: Counter[str] = Counter()
+    files: dict[str, set[Path]] = {}
+
+    for path in iter_markdown_files(vault_dir):
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        # Cheap pre-filter — saves regex work on the >90% of files
+        # that don't reference Twitter at all.
+        if "x.com" not in text and "twitter.com" not in text:
+            continue
+        seen_in_file: set[str] = set()
+        for m in _X_HANDLE_RE.finditer(text):
+            handle = m.group(1).lstrip("@").lower()
+            if handle in _X_NON_HANDLE:
+                continue
+            if not handle:
+                continue
+            total[handle] += 1
+            seen_in_file.add(handle)
+        for handle in seen_in_file:
+            files.setdefault(handle, set()).add(path)
+
+    return [
+        HandleMention(
+            handle=h,
+            mention_count=c,
+            file_count=len(files.get(h, ())),
+        )
+        for h, c in total.most_common()
+    ]
+
+
+def scan_github_mentions(vault_dir: Path) -> list[GitHubMention]:
+    """Return repo+owner mentions sorted descending by mention_count.
+
+    A ``repo=None`` row means "we only saw owner-level URLs"; a row
+    with a repo also exists for the same owner if both kinds appear.
+    """
+    repo_total: Counter[tuple[str, str]] = Counter()
+    repo_files: dict[tuple[str, str], set[Path]] = {}
+    owner_total: Counter[str] = Counter()
+    owner_files: dict[str, set[Path]] = {}
+
+    for path in iter_markdown_files(vault_dir):
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if "github.com" not in text:
+            continue
+        seen_repos_in_file: set[tuple[str, str]] = set()
+        seen_owners_in_file: set[str] = set()
+        for m in _GH_REPO_RE.finditer(text):
+            owner = m.group(1).lower()
+            if owner in _GH_NON_REPO_OWNERS:
+                continue
+            repo = m.group(2).lower()
+            if repo.endswith(".git"):
+                repo = repo[:-4]
+            repo_total[(owner, repo)] += 1
+            owner_total[owner] += 1
+            seen_repos_in_file.add((owner, repo))
+            seen_owners_in_file.add(owner)
+        for key in seen_repos_in_file:
+            repo_files.setdefault(key, set()).add(path)
+        for owner in seen_owners_in_file:
+            owner_files.setdefault(owner, set()).add(path)
+
+    out: list[GitHubMention] = []
+    for (owner, repo), c in repo_total.most_common():
+        out.append(GitHubMention(
+            owner=owner,
+            repo=repo,
+            mention_count=c,
+            file_count=len(repo_files.get((owner, repo), ())),
+        ))
+    return out

--- a/src/ovp_pipeline/entities/store.py
+++ b/src/ovp_pipeline/entities/store.py
@@ -1,0 +1,246 @@
+"""SQLite-backed entity store.
+
+Two tables:
+
+``entities``
+    Latest snapshot per ``(entity_type, identity_key)``.  ``signals_json``
+    is the raw fetched payload (twitterapi.io response, GitHub API
+    response, etc.).  ``derived_authority`` is our best 0-1 estimate
+    computed from those signals — separated from the raw data so a
+    formula change can be re-derived without re-fetching.
+
+``entity_signals_history``
+    Append-only time series.  One row per fetch.  Keeps the audit
+    trail and makes it possible to compute trends later (followers
+    growth rate, star velocity, "active vs going dormant" detection).
+
+Both tables use ``CREATE TABLE IF NOT EXISTS`` so they coexist with
+the other knowledge.db schemas.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Iterator
+
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS entities (
+    entity_id        INTEGER PRIMARY KEY AUTOINCREMENT,
+    entity_type      TEXT NOT NULL,
+    identity_key     TEXT NOT NULL,
+    canonical_name   TEXT,
+    signals_json     TEXT NOT NULL,
+    derived_authority REAL,
+    fetch_source     TEXT NOT NULL,
+    first_seen_at    TEXT NOT NULL,
+    last_fetched_at  TEXT NOT NULL,
+    UNIQUE(entity_type, identity_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_entities_type
+    ON entities(entity_type);
+
+CREATE INDEX IF NOT EXISTS idx_entities_authority
+    ON entities(entity_type, derived_authority DESC);
+
+CREATE TABLE IF NOT EXISTS entity_signals_history (
+    history_id    INTEGER PRIMARY KEY AUTOINCREMENT,
+    entity_id     INTEGER NOT NULL,
+    observed_at   TEXT NOT NULL,
+    signals_json  TEXT NOT NULL,
+    fetch_source  TEXT NOT NULL,
+    FOREIGN KEY (entity_id) REFERENCES entities(entity_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_entity_signals_history_entity
+    ON entity_signals_history(entity_id, observed_at DESC);
+"""
+
+
+@dataclass(frozen=True, slots=True)
+class Entity:
+    """A merged-view row from the ``entities`` table."""
+
+    entity_id: int
+    entity_type: str
+    identity_key: str
+    canonical_name: str | None
+    signals: dict[str, Any]
+    derived_authority: float | None
+    fetch_source: str
+    first_seen_at: str
+    last_fetched_at: str
+
+
+def init_schema(db_path: Path) -> None:
+    """Create the entity tables if they don't exist.
+
+    Idempotent — safe to call on every CLI invocation.
+    """
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(_SCHEMA)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _row_to_entity(row: sqlite3.Row) -> Entity:
+    try:
+        signals = json.loads(row["signals_json"]) if row["signals_json"] else {}
+    except json.JSONDecodeError:
+        signals = {}
+    return Entity(
+        entity_id=row["entity_id"],
+        entity_type=row["entity_type"],
+        identity_key=row["identity_key"],
+        canonical_name=row["canonical_name"],
+        signals=signals,
+        derived_authority=row["derived_authority"],
+        fetch_source=row["fetch_source"],
+        first_seen_at=row["first_seen_at"],
+        last_fetched_at=row["last_fetched_at"],
+    )
+
+
+@dataclass
+class EntityStore:
+    """Thin DAO over the ``entities`` + ``entity_signals_history`` tables."""
+
+    db_path: Path
+
+    def __post_init__(self) -> None:
+        init_schema(self.db_path)
+
+    # ---- read ----------------------------------------------------------
+
+    def get(self, entity_type: str, identity_key: str) -> Entity | None:
+        conn = sqlite3.connect(self.db_path)
+        try:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute(
+                "SELECT * FROM entities WHERE entity_type=? AND identity_key=?",
+                (entity_type, identity_key),
+            ).fetchone()
+            return _row_to_entity(row) if row else None
+        finally:
+            conn.close()
+
+    def list_by_type(
+        self, entity_type: str, *, limit: int | None = None,
+    ) -> list[Entity]:
+        conn = sqlite3.connect(self.db_path)
+        try:
+            conn.row_factory = sqlite3.Row
+            sql = (
+                "SELECT * FROM entities WHERE entity_type=? "
+                "ORDER BY derived_authority DESC NULLS LAST"
+            )
+            if limit is not None:
+                sql += f" LIMIT {int(limit)}"
+            rows = conn.execute(sql, (entity_type,)).fetchall()
+            return [_row_to_entity(r) for r in rows]
+        finally:
+            conn.close()
+
+    def history(
+        self, entity_id: int, *, limit: int = 50,
+    ) -> Iterator[tuple[str, dict[str, Any], str]]:
+        """Yield (observed_at, signals_dict, fetch_source) most-recent first."""
+        conn = sqlite3.connect(self.db_path)
+        try:
+            # Tiebreak on history_id DESC so two rows that share an
+            # observed_at to the second still come back newest-first.
+            rows = conn.execute(
+                "SELECT observed_at, signals_json, fetch_source "
+                "FROM entity_signals_history WHERE entity_id=? "
+                "ORDER BY observed_at DESC, history_id DESC LIMIT ?",
+                (entity_id, limit),
+            ).fetchall()
+            for observed_at, signals_json, fetch_source in rows:
+                try:
+                    signals = json.loads(signals_json) if signals_json else {}
+                except json.JSONDecodeError:
+                    signals = {}
+                yield observed_at, signals, fetch_source
+        finally:
+            conn.close()
+
+    # ---- write ---------------------------------------------------------
+
+    def upsert(
+        self,
+        *,
+        entity_type: str,
+        identity_key: str,
+        canonical_name: str | None,
+        signals: dict[str, Any],
+        derived_authority: float | None,
+        fetch_source: str,
+    ) -> Entity:
+        """Insert or update a single entity, plus append a history row.
+
+        Returns the freshly-read entity (after upsert).
+        """
+        now = _iso_now()
+        signals_json = json.dumps(signals, ensure_ascii=False, sort_keys=True)
+        conn = sqlite3.connect(self.db_path)
+        try:
+            conn.row_factory = sqlite3.Row
+            existing = conn.execute(
+                "SELECT entity_id, first_seen_at FROM entities "
+                "WHERE entity_type=? AND identity_key=?",
+                (entity_type, identity_key),
+            ).fetchone()
+            if existing is None:
+                cur = conn.execute(
+                    "INSERT INTO entities (entity_type, identity_key, "
+                    "canonical_name, signals_json, derived_authority, "
+                    "fetch_source, first_seen_at, last_fetched_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                    (entity_type, identity_key, canonical_name, signals_json,
+                     derived_authority, fetch_source, now, now),
+                )
+                entity_id = cur.lastrowid
+            else:
+                entity_id = existing["entity_id"]
+                conn.execute(
+                    "UPDATE entities SET canonical_name=?, signals_json=?, "
+                    "derived_authority=?, fetch_source=?, last_fetched_at=? "
+                    "WHERE entity_id=?",
+                    (canonical_name, signals_json, derived_authority,
+                     fetch_source, now, entity_id),
+                )
+            conn.execute(
+                "INSERT INTO entity_signals_history "
+                "(entity_id, observed_at, signals_json, fetch_source) "
+                "VALUES (?, ?, ?, ?)",
+                (entity_id, now, signals_json, fetch_source),
+            )
+            conn.commit()
+            row = conn.execute(
+                "SELECT * FROM entities WHERE entity_id=?",
+                (entity_id,),
+            ).fetchone()
+            return _row_to_entity(row)
+        finally:
+            conn.close()
+
+    def upsert_many(
+        self, records: Iterable[dict[str, Any]],
+    ) -> list[Entity]:
+        """Bulk version — same fields as ``upsert`` keys per record."""
+        out = []
+        for rec in records:
+            out.append(self.upsert(**rec))
+        return out

--- a/src/ovp_pipeline/entities/store.py
+++ b/src/ovp_pipeline/entities/store.py
@@ -178,6 +178,52 @@ class EntityStore:
 
     # ---- write ---------------------------------------------------------
 
+    def _upsert_in(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        entity_type: str,
+        identity_key: str,
+        canonical_name: str | None,
+        signals: dict[str, Any],
+        derived_authority: float | None,
+        fetch_source: str,
+    ) -> Entity:
+        """Atomic UPSERT against an open connection.
+
+        Uses SQLite's native ``INSERT ... ON CONFLICT(...) DO UPDATE``
+        (3.24+, available since 2018) so the insert-vs-update decision
+        is one round trip, atomically applied, and ``first_seen_at`` is
+        preserved on update without a separate SELECT.
+        """
+        now = _iso_now()
+        signals_json = json.dumps(signals, ensure_ascii=False, sort_keys=True)
+        conn.row_factory = sqlite3.Row
+        conn.execute(
+            "INSERT INTO entities (entity_type, identity_key, canonical_name, "
+            "signals_json, derived_authority, fetch_source, first_seen_at, "
+            "last_fetched_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?) "
+            "ON CONFLICT(entity_type, identity_key) DO UPDATE SET "
+            "canonical_name=excluded.canonical_name, "
+            "signals_json=excluded.signals_json, "
+            "derived_authority=excluded.derived_authority, "
+            "fetch_source=excluded.fetch_source, "
+            "last_fetched_at=excluded.last_fetched_at",
+            (entity_type, identity_key, canonical_name, signals_json,
+             derived_authority, fetch_source, now, now),
+        )
+        row = conn.execute(
+            "SELECT * FROM entities WHERE entity_type=? AND identity_key=?",
+            (entity_type, identity_key),
+        ).fetchone()
+        conn.execute(
+            "INSERT INTO entity_signals_history "
+            "(entity_id, observed_at, signals_json, fetch_source) "
+            "VALUES (?, ?, ?, ?)",
+            (row["entity_id"], now, signals_json, fetch_source),
+        )
+        return _row_to_entity(row)
+
     def upsert(
         self,
         *,
@@ -188,59 +234,39 @@ class EntityStore:
         derived_authority: float | None,
         fetch_source: str,
     ) -> Entity:
-        """Insert or update a single entity, plus append a history row.
-
-        Returns the freshly-read entity (after upsert).
-        """
-        now = _iso_now()
-        signals_json = json.dumps(signals, ensure_ascii=False, sort_keys=True)
+        """Insert or update a single entity, plus append a history row."""
         conn = sqlite3.connect(self.db_path)
         try:
-            conn.row_factory = sqlite3.Row
-            existing = conn.execute(
-                "SELECT entity_id, first_seen_at FROM entities "
-                "WHERE entity_type=? AND identity_key=?",
-                (entity_type, identity_key),
-            ).fetchone()
-            if existing is None:
-                cur = conn.execute(
-                    "INSERT INTO entities (entity_type, identity_key, "
-                    "canonical_name, signals_json, derived_authority, "
-                    "fetch_source, first_seen_at, last_fetched_at) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                    (entity_type, identity_key, canonical_name, signals_json,
-                     derived_authority, fetch_source, now, now),
-                )
-                entity_id = cur.lastrowid
-            else:
-                entity_id = existing["entity_id"]
-                conn.execute(
-                    "UPDATE entities SET canonical_name=?, signals_json=?, "
-                    "derived_authority=?, fetch_source=?, last_fetched_at=? "
-                    "WHERE entity_id=?",
-                    (canonical_name, signals_json, derived_authority,
-                     fetch_source, now, entity_id),
-                )
-            conn.execute(
-                "INSERT INTO entity_signals_history "
-                "(entity_id, observed_at, signals_json, fetch_source) "
-                "VALUES (?, ?, ?, ?)",
-                (entity_id, now, signals_json, fetch_source),
+            entity = self._upsert_in(
+                conn,
+                entity_type=entity_type, identity_key=identity_key,
+                canonical_name=canonical_name, signals=signals,
+                derived_authority=derived_authority,
+                fetch_source=fetch_source,
             )
             conn.commit()
-            row = conn.execute(
-                "SELECT * FROM entities WHERE entity_id=?",
-                (entity_id,),
-            ).fetchone()
-            return _row_to_entity(row)
+            return entity
         finally:
             conn.close()
 
     def upsert_many(
         self, records: Iterable[dict[str, Any]],
     ) -> list[Entity]:
-        """Bulk version — same fields as ``upsert`` keys per record."""
-        out = []
-        for rec in records:
-            out.append(self.upsert(**rec))
-        return out
+        """Bulk version — single connection + transaction for the whole batch.
+
+        Faster than calling ``upsert`` in a loop (one connection vs N,
+        one fsync at the end vs N), and the whole batch is committed
+        atomically: a mid-batch failure rolls back, no partial state.
+        """
+        conn = sqlite3.connect(self.db_path)
+        out: list[Entity] = []
+        try:
+            for rec in records:
+                out.append(self._upsert_in(conn, **rec))
+            conn.commit()
+            return out
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()

--- a/src/ovp_pipeline/entities/twitter_backfill.py
+++ b/src/ovp_pipeline/entities/twitter_backfill.py
@@ -1,0 +1,312 @@
+"""twitterapi.io fetch + partial author_weight computation.
+
+The obsidian-clipper Twitter adapter computes a 7-dimension
+``author_weight`` (0-100) at clip time.  This module reconstructs an
+approximation from the fields twitterapi.io exposes — necessarily
+weaker because two of the strongest dimensions (``listed_count`` and
+mutual-network signals) aren't available via that API.
+
+Fidelity tradeoff (vs. clipper's 100-point scale):
+  * Clipper:  followers + listed + mutuals + i_follow + age +
+              verified/company + automated  → 100 max
+  * Backfill: followers + age + verified + company-affiliation +
+              automated penalty             → ~70 max
+
+Therefore the partial score is **always strictly weaker than** the
+clipper's, and the runtime authority resolver (PR-E3) should prefer
+clipper-sourced values when both exist.
+
+API details:
+  * GET /twitter/user/info?userName=<handle>
+  * Header: X-API-Key
+  * $0.00018 / call (single-user)
+  * 521 handles in the OVP vault → ~$0.094 one-shot
+
+Failure modes handled:
+  * 401 / 403  — bad key, raise immediately
+  * 429        — exponential backoff
+  * 404 / "user not found" — record as suspended, don't retry
+  * Network    — retry up to 3 times then mark failed
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_API_BASE = "https://api.twitterapi.io"
+_USER_INFO_PATH = "/twitter/user/info"
+_USER_AGENT = "ovp-backfill/1.0 (https://github.com/fakechris/obsidian_vault_pipeline)"
+_DEFAULT_TIMEOUT_S = 15.0
+_MAX_RETRIES = 3
+_BACKOFF_BASE_S = 1.5
+
+# Cost in USD per single-user call (per twitterapi.io intro page).
+PRICE_PER_CALL_USD = 0.00018
+
+
+# ---------------------------------------------------------------------------
+# Fetch
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class FetchResult:
+    """Outcome of one twitterapi.io call.
+
+    Three terminal states:
+      * ``ok``        — got a user payload; ``payload`` is non-None
+      * ``not_found`` — handle suspended/deleted; record stub entity
+      * ``error``     — network/auth/quota; do NOT mark as authoritative
+
+    The CLI counts these into the final summary.
+    """
+
+    handle: str
+    status: str          # "ok" | "not_found" | "error"
+    payload: dict[str, Any] | None
+    error: str | None    # human-readable diagnosis if status != "ok"
+
+
+def fetch_user_info(
+    handle: str, *, api_key: str, timeout_s: float = _DEFAULT_TIMEOUT_S,
+) -> FetchResult:
+    """Single-call wrapper around GET /twitter/user/info.
+
+    Idempotent / safe to call repeatedly — twitterapi.io has no
+    mutating side effects on this endpoint.
+    """
+    if not handle or not api_key:
+        return FetchResult(handle, "error", None, "missing handle or api_key")
+
+    qs = urllib.parse.urlencode({"userName": handle})
+    url = f"{_API_BASE}{_USER_INFO_PATH}?{qs}"
+    headers = {
+        "X-API-Key": api_key,
+        "Accept": "application/json",
+        "User-Agent": _USER_AGENT,
+    }
+
+    last_error: str = "unknown"
+    for attempt in range(_MAX_RETRIES):
+        try:
+            req = urllib.request.Request(url, headers=headers)
+            with urllib.request.urlopen(req, timeout=timeout_s) as resp:
+                body = resp.read().decode("utf-8")
+        except urllib.error.HTTPError as e:
+            # 401/403 are auth — bail immediately.
+            if e.code in (401, 403):
+                return FetchResult(
+                    handle, "error", None,
+                    f"auth failed: HTTP {e.code} (check API key)",
+                )
+            # 404 or "user not found"-style.
+            if e.code == 404:
+                return FetchResult(handle, "not_found", None, "404 from API")
+            # 429 → backoff
+            if e.code == 429:
+                wait = _BACKOFF_BASE_S * (2 ** attempt)
+                logger.info("rate limited on %s, sleeping %.1fs", handle, wait)
+                time.sleep(wait)
+                last_error = "HTTP 429"
+                continue
+            last_error = f"HTTP {e.code}"
+            time.sleep(_BACKOFF_BASE_S * (2 ** attempt))
+            continue
+        except (urllib.error.URLError, TimeoutError, OSError) as e:
+            last_error = f"network: {e}"
+            time.sleep(_BACKOFF_BASE_S * (2 ** attempt))
+            continue
+
+        try:
+            parsed = json.loads(body)
+        except json.JSONDecodeError as e:
+            return FetchResult(handle, "error", None, f"bad JSON: {e}")
+
+        status = parsed.get("status")
+        if status == "success":
+            data = parsed.get("data") or {}
+            if not isinstance(data, dict) or not data:
+                # API returned success but empty body — treat as not found.
+                return FetchResult(handle, "not_found", None, "empty data")
+            return FetchResult(handle, "ok", data, None)
+
+        # status == "error" or unknown.
+        msg = str(parsed.get("msg") or parsed.get("message") or "")
+        if "not found" in msg.lower() or "suspended" in msg.lower() \
+                or "unavailable" in msg.lower():
+            return FetchResult(handle, "not_found", None, msg or "user not found")
+        return FetchResult(handle, "error", None, msg or "API returned error")
+
+    return FetchResult(handle, "error", None, last_error)
+
+
+# ---------------------------------------------------------------------------
+# Score derivation
+# ---------------------------------------------------------------------------
+
+
+def _account_age_years(created_at: str | None) -> float:
+    """Parse ``createdAt`` and return age in years (0 if unparseable).
+
+    twitterapi.io can return either ISO 8601
+    (``2016-03-20T17:01:04.000000Z``) or X's classic format
+    (``Thu Dec 13 08:41:26 +0000 2007``).
+    """
+    if not created_at:
+        return 0.0
+    candidates = [
+        ("%Y-%m-%dT%H:%M:%S.%f%z", created_at.replace("Z", "+0000")),
+        ("%Y-%m-%dT%H:%M:%S%z", created_at.replace("Z", "+0000")),
+        ("%a %b %d %H:%M:%S %z %Y", created_at),
+    ]
+    for fmt, val in candidates:
+        try:
+            dt = datetime.strptime(val, fmt)
+        except ValueError:
+            continue
+        delta = datetime.now(timezone.utc) - dt
+        return max(delta.days / 365.25, 0.0)
+    return 0.0
+
+
+def compute_partial_author_weight(payload: dict[str, Any]) -> tuple[int, dict[str, int]]:
+    """Compute partial author_weight (0-100 scale) + per-dimension breakdown.
+
+    Returns ``(score, {dimension: points})`` so the breakdown can be
+    persisted alongside the score for explainability.
+
+    The dimensions deliberately mirror the obsidian-clipper formula
+    where a corresponding signal exists, and zero-out the dimensions
+    that twitterapi.io can't supply (listed, mutuals, i_follow).
+    Total possible: 70.  Anything higher comes from clipper-frontmatter,
+    not from this code.
+    """
+    breakdown: dict[str, int] = {}
+
+    # 1. followers (max 25)
+    fol = int(payload.get("followers") or 0)
+    if fol >= 100_000:
+        breakdown["followers"] = 25
+    elif fol >= 10_000:
+        breakdown["followers"] = 22
+    elif fol >= 1_000:
+        breakdown["followers"] = 17
+    elif fol >= 500:
+        breakdown["followers"] = 10
+    elif fol >= 100:
+        breakdown["followers"] = 5
+    else:
+        breakdown["followers"] = 0
+
+    # 2. account age in years (max 10)
+    age_y = _account_age_years(payload.get("createdAt"))
+    if age_y >= 7:
+        breakdown["age"] = 10
+    elif age_y >= 3:
+        breakdown["age"] = 7
+    elif age_y >= 1:
+        breakdown["age"] = 3
+    else:
+        breakdown["age"] = 0
+
+    # 3. blue-verified flag (max 5).
+    # Per the clipper docs: "蓝标现在已经没用" — kept low intentionally.
+    breakdown["blue_verified"] = 5 if payload.get("isBlueVerified") else 0
+
+    # 4. legacy verified / verifiedType — closer to "old blue check"
+    # which the clipper docs flag as a strong signal (max 10).
+    verified_type = (payload.get("verifiedType") or "").strip().lower()
+    is_legacy_verified = bool(payload.get("isVerified"))
+    if verified_type in {"government", "business", "company"} or is_legacy_verified:
+        breakdown["legacy_verified"] = 10
+    else:
+        breakdown["legacy_verified"] = 0
+
+    # 5. affiliation label (max 10).
+    # twitterapi.io exposes ``affiliatesHighlightedLabel`` which
+    # corresponds to the company-badge UI feature on X.  Treat any
+    # non-empty mapping as "has affiliation".
+    aff = payload.get("affiliatesHighlightedLabel")
+    if isinstance(aff, dict) and aff:
+        breakdown["affiliation"] = 10
+    else:
+        breakdown["affiliation"] = 0
+
+    # 6. activity / statusesCount (max 10).
+    # Anti-correlated with brand-new accounts and with bots.  Cap at
+    # the high end so a tweet-spam farm doesn't get a free 10 points.
+    statuses = int(payload.get("statusesCount") or 0)
+    if 500 <= statuses <= 50_000:
+        breakdown["activity"] = 10
+    elif 50 <= statuses < 500:
+        breakdown["activity"] = 5
+    elif statuses > 50_000:
+        breakdown["activity"] = 8       # too active, slight discount
+    else:
+        breakdown["activity"] = 0
+
+    # 7. automated penalty (negative).
+    breakdown["automated_penalty"] = -10 if payload.get("isAutomated") else 0
+
+    score = max(0, sum(breakdown.values()))
+    return score, breakdown
+
+
+def derive_authority_from_payload(payload: dict[str, Any]) -> tuple[float, dict[str, Any]]:
+    """High-level helper used by the CLI.
+
+    Returns ``(authority_0_to_1, signals_dict_to_persist)``.  The
+    signals dict is what gets stored in ``entities.signals_json``.
+    """
+    score, breakdown = compute_partial_author_weight(payload)
+    # Map 0-70 (theoretical max) → 0-1 by dividing by 100, NOT 70.
+    # That reserves the 0.71-1.0 band for clipper-rich frontmatter
+    # which has the missing-dimensions signal.  See PR-E3 design.
+    authority = round(score / 100.0, 4)
+
+    signals = {
+        # raw fields we care about for downstream score reconstruction
+        "userName": payload.get("userName"),
+        "id": payload.get("id"),
+        "name": payload.get("name"),
+        "description": payload.get("description"),
+        "location": payload.get("location"),
+        "createdAt": payload.get("createdAt"),
+        "followers": payload.get("followers"),
+        "following": payload.get("following"),
+        "statusesCount": payload.get("statusesCount"),
+        "mediaCount": payload.get("mediaCount"),
+        "favouritesCount": payload.get("favouritesCount"),
+        "isBlueVerified": payload.get("isBlueVerified"),
+        "isVerified": payload.get("isVerified"),
+        "verifiedType": payload.get("verifiedType"),
+        "isAutomated": payload.get("isAutomated"),
+        "affiliatesHighlightedLabel": payload.get("affiliatesHighlightedLabel"),
+        # derived
+        "partial_author_weight": score,
+        "weight_breakdown": breakdown,
+        # missing dimensions (kept explicit so future formula changes
+        # don't silently fail to detect "we never had this data"):
+        "missing_dimensions": ["listed_count", "mutuals_count",
+                                "mutuals_top", "i_follow", "follows_me"],
+    }
+    return authority, signals
+
+
+def stub_signals_for_missing(handle: str, reason: str) -> dict[str, Any]:
+    """For 'not_found' / suspended handles — record the fact without authority."""
+    return {
+        "userName": handle,
+        "fetch_status": "not_found",
+        "fetch_reason": reason,
+    }

--- a/src/ovp_pipeline/entities/twitter_backfill.py
+++ b/src/ovp_pipeline/entities/twitter_backfill.py
@@ -55,6 +55,49 @@ PRICE_PER_CALL_USD = 0.00018
 
 
 # ---------------------------------------------------------------------------
+# Score formula constants
+# ---------------------------------------------------------------------------
+# Each dimension is a list of ``(threshold, points)`` tuples evaluated
+# top-to-bottom; first matching threshold wins.  Tuples (vs. inline
+# elif chains) make the bands trivial to inspect, tune, and unit-test.
+
+# (followers ≥ N)  →  points
+_FOLLOWER_BANDS: tuple[tuple[int, int], ...] = (
+    (100_000, 25),
+    (10_000,  22),
+    (1_000,   17),
+    (500,     10),
+    (100,      5),
+)
+
+# (years_since_creation ≥ N)  →  points
+_AGE_YEAR_BANDS: tuple[tuple[float, int], ...] = (
+    (7.0, 10),
+    (3.0,  7),
+    (1.0,  3),
+)
+
+_BLUE_VERIFIED_POINTS = 5         # Twitter Blue alone — minor signal.
+_LEGACY_VERIFIED_POINTS = 10      # gov / business / company badge.
+_LEGACY_VERIFIED_TYPES = frozenset({"government", "business", "company"})
+
+_AFFILIATION_POINTS = 10          # affiliatesHighlightedLabel non-empty.
+
+# Three-band activity score: dormant 0, normal 5/10, suspicious 8.
+_ACTIVITY_NORMAL_MIN = 500
+_ACTIVITY_NORMAL_MAX = 50_000
+_ACTIVITY_LOW_MIN = 50
+_ACTIVITY_NORMAL_POINTS = 10
+_ACTIVITY_LOW_POINTS = 5
+_ACTIVITY_SUSPICIOUS_POINTS = 8   # firehose accounts (>50k tweets).
+
+_AUTOMATED_PENALTY_POINTS = -10
+
+# Total possible: 70.  See module docstring for the cap rationale.
+_PARTIAL_AUTHORITY_DENOMINATOR = 100.0
+
+
+# ---------------------------------------------------------------------------
 # Fetch
 # ---------------------------------------------------------------------------
 
@@ -193,73 +236,66 @@ def compute_partial_author_weight(payload: dict[str, Any]) -> tuple[int, dict[st
     """
     breakdown: dict[str, int] = {}
 
-    # 1. followers (max 25)
+    # 1. followers
     fol = int(payload.get("followers") or 0)
-    if fol >= 100_000:
-        breakdown["followers"] = 25
-    elif fol >= 10_000:
-        breakdown["followers"] = 22
-    elif fol >= 1_000:
-        breakdown["followers"] = 17
-    elif fol >= 500:
-        breakdown["followers"] = 10
-    elif fol >= 100:
-        breakdown["followers"] = 5
-    else:
-        breakdown["followers"] = 0
+    breakdown["followers"] = _band_lookup(fol, _FOLLOWER_BANDS)
 
-    # 2. account age in years (max 10)
+    # 2. account age (years)
     age_y = _account_age_years(payload.get("createdAt"))
-    if age_y >= 7:
-        breakdown["age"] = 10
-    elif age_y >= 3:
-        breakdown["age"] = 7
-    elif age_y >= 1:
-        breakdown["age"] = 3
-    else:
-        breakdown["age"] = 0
+    breakdown["age"] = _band_lookup(age_y, _AGE_YEAR_BANDS)
 
-    # 3. blue-verified flag (max 5).
-    # Per the clipper docs: "蓝标现在已经没用" — kept low intentionally.
-    breakdown["blue_verified"] = 5 if payload.get("isBlueVerified") else 0
+    # 3. Twitter Blue (low weight per clipper docs: "蓝标现在已经没用")
+    breakdown["blue_verified"] = (
+        _BLUE_VERIFIED_POINTS if payload.get("isBlueVerified") else 0
+    )
 
     # 4. legacy verified / verifiedType — closer to "old blue check"
-    # which the clipper docs flag as a strong signal (max 10).
+    # which the clipper docs flag as a strong signal.
     verified_type = (payload.get("verifiedType") or "").strip().lower()
     is_legacy_verified = bool(payload.get("isVerified"))
-    if verified_type in {"government", "business", "company"} or is_legacy_verified:
-        breakdown["legacy_verified"] = 10
+    if verified_type in _LEGACY_VERIFIED_TYPES or is_legacy_verified:
+        breakdown["legacy_verified"] = _LEGACY_VERIFIED_POINTS
     else:
         breakdown["legacy_verified"] = 0
 
-    # 5. affiliation label (max 10).
-    # twitterapi.io exposes ``affiliatesHighlightedLabel`` which
-    # corresponds to the company-badge UI feature on X.  Treat any
-    # non-empty mapping as "has affiliation".
+    # 5. affiliation label — twitterapi.io's ``affiliatesHighlightedLabel``
+    # corresponds to the company-badge UI feature.  Treat any non-empty
+    # mapping as "has affiliation".
     aff = payload.get("affiliatesHighlightedLabel")
-    if isinstance(aff, dict) and aff:
-        breakdown["affiliation"] = 10
-    else:
-        breakdown["affiliation"] = 0
+    breakdown["affiliation"] = (
+        _AFFILIATION_POINTS if isinstance(aff, dict) and aff else 0
+    )
 
-    # 6. activity / statusesCount (max 10).
-    # Anti-correlated with brand-new accounts and with bots.  Cap at
-    # the high end so a tweet-spam farm doesn't get a free 10 points.
+    # 6. activity / statusesCount.  Anti-correlated with brand-new
+    # accounts and with firehose bots — too-high tweet count gets a
+    # discount, not full credit.
     statuses = int(payload.get("statusesCount") or 0)
-    if 500 <= statuses <= 50_000:
-        breakdown["activity"] = 10
-    elif 50 <= statuses < 500:
-        breakdown["activity"] = 5
-    elif statuses > 50_000:
-        breakdown["activity"] = 8       # too active, slight discount
+    if _ACTIVITY_NORMAL_MIN <= statuses <= _ACTIVITY_NORMAL_MAX:
+        breakdown["activity"] = _ACTIVITY_NORMAL_POINTS
+    elif _ACTIVITY_LOW_MIN <= statuses < _ACTIVITY_NORMAL_MIN:
+        breakdown["activity"] = _ACTIVITY_LOW_POINTS
+    elif statuses > _ACTIVITY_NORMAL_MAX:
+        breakdown["activity"] = _ACTIVITY_SUSPICIOUS_POINTS
     else:
         breakdown["activity"] = 0
 
-    # 7. automated penalty (negative).
-    breakdown["automated_penalty"] = -10 if payload.get("isAutomated") else 0
+    # 7. automated penalty
+    breakdown["automated_penalty"] = (
+        _AUTOMATED_PENALTY_POINTS if payload.get("isAutomated") else 0
+    )
 
     score = max(0, sum(breakdown.values()))
     return score, breakdown
+
+
+def _band_lookup(value: float, bands: tuple[tuple[float, int], ...]) -> int:
+    """Walk ``bands`` top-to-bottom; return the first band whose
+    threshold ``value`` meets or exceeds.  Returns 0 if no band matches.
+    """
+    for threshold, points in bands:
+        if value >= threshold:
+            return points
+    return 0
 
 
 def derive_authority_from_payload(payload: dict[str, Any]) -> tuple[float, dict[str, Any]]:
@@ -272,7 +308,7 @@ def derive_authority_from_payload(payload: dict[str, Any]) -> tuple[float, dict[
     # Map 0-70 (theoretical max) → 0-1 by dividing by 100, NOT 70.
     # That reserves the 0.71-1.0 band for clipper-rich frontmatter
     # which has the missing-dimensions signal.  See PR-E3 design.
-    authority = round(score / 100.0, 4)
+    authority = round(score / _PARTIAL_AUTHORITY_DENOMINATOR, 4)
 
     signals = {
         # raw fields we care about for downstream score reconstruction

--- a/tests/test_architecture_fitness.py
+++ b/tests/test_architecture_fitness.py
@@ -181,6 +181,7 @@ SQLITE_ALLOWED_MODULES = {
     "commands/working_memory",
     "commands/score_sources",
     "source_authority",
+    "entities/store",
     "discovery",
     "evidence",
     "evidence_replay",

--- a/tests/test_entities_scan.py
+++ b/tests/test_entities_scan.py
@@ -1,0 +1,112 @@
+"""Tests for entities/scan.py — vault traversal + handle/repo extraction."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ovp_pipeline.entities.scan import (
+    scan_github_mentions,
+    scan_twitter_handles,
+)
+
+
+def _write(p: Path, body: str) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(body, encoding="utf-8")
+
+
+class TestScanTwitterHandles:
+    def test_picks_up_status_url(self, tmp_path):
+        _write(tmp_path / "a.md",
+               "Saw [tweet](https://x.com/karpathy/status/12345) today.")
+        result = scan_twitter_handles(tmp_path)
+        assert any(m.handle == "karpathy" for m in result)
+
+    def test_picks_up_bare_profile_url(self, tmp_path):
+        _write(tmp_path / "a.md",
+               "Profile: https://twitter.com/sama")
+        result = scan_twitter_handles(tmp_path)
+        assert any(m.handle == "sama" for m in result)
+
+    def test_lowercases_handle(self, tmp_path):
+        _write(tmp_path / "a.md", "https://x.com/Karpathy/status/1")
+        result = scan_twitter_handles(tmp_path)
+        assert result[0].handle == "karpathy"
+
+    def test_filters_reserved_paths(self, tmp_path):
+        # /home, /search etc. aren't real handles — drop them.
+        _write(tmp_path / "a.md",
+               "Visit https://x.com/home and https://x.com/search "
+               "and https://twitter.com/i/lists")
+        result = scan_twitter_handles(tmp_path)
+        handles = {m.handle for m in result}
+        assert "home" not in handles
+        assert "search" not in handles
+        assert "i" not in handles
+
+    def test_counts_mentions_and_files(self, tmp_path):
+        _write(tmp_path / "a.md", "https://x.com/karpathy/status/1")
+        _write(tmp_path / "b.md",
+               "https://x.com/karpathy/status/2 and https://x.com/karpathy")
+        result = scan_twitter_handles(tmp_path)
+        kar = next(m for m in result if m.handle == "karpathy")
+        assert kar.mention_count == 3
+        assert kar.file_count == 2
+
+    def test_skips_files_without_twitter(self, tmp_path):
+        _write(tmp_path / "a.md", "no twitter here, just plain text")
+        _write(tmp_path / "b.md", "https://x.com/sama/status/1")
+        result = scan_twitter_handles(tmp_path)
+        assert len(result) == 1
+        assert result[0].handle == "sama"
+
+    def test_skips_pycache_and_backup_dirs(self, tmp_path):
+        _write(tmp_path / "__pycache__" / "x.md", "https://x.com/leak/status/1")
+        _write(tmp_path / "_backup" / "y.md", "https://x.com/leak2/status/1")
+        _write(tmp_path / "real.md", "https://x.com/real/status/1")
+        result = scan_twitter_handles(tmp_path)
+        handles = {m.handle for m in result}
+        assert "real" in handles
+        assert "leak" not in handles
+        assert "leak2" not in handles
+
+    def test_returns_descending_by_count(self, tmp_path):
+        _write(tmp_path / "a.md",
+               "https://x.com/once/status/1 "
+               "https://x.com/many/status/1 "
+               "https://x.com/many/status/2 "
+               "https://x.com/many/status/3")
+        result = scan_twitter_handles(tmp_path)
+        assert result[0].handle == "many"
+        assert result[1].handle == "once"
+
+
+class TestScanGithubMentions:
+    def test_picks_up_repo_url(self, tmp_path):
+        _write(tmp_path / "a.md",
+               "Check [karpathy/nanoGPT](https://github.com/karpathy/nanoGPT)")
+        result = scan_github_mentions(tmp_path)
+        assert any(m.owner == "karpathy" and m.repo == "nanogpt" for m in result)
+
+    def test_drops_git_suffix(self, tmp_path):
+        _write(tmp_path / "a.md", "https://github.com/foo/bar.git")
+        result = scan_github_mentions(tmp_path)
+        assert any(m.repo == "bar" for m in result)
+
+    def test_drops_non_repo_owner_paths(self, tmp_path):
+        # /orgs/anthropic isn't a repo
+        _write(tmp_path / "a.md",
+               "https://github.com/orgs/anthropic/people "
+               "https://github.com/topics/llm")
+        result = scan_github_mentions(tmp_path)
+        owners = {m.owner for m in result}
+        assert "orgs" not in owners
+        assert "topics" not in owners
+
+    def test_strips_trailing_path(self, tmp_path):
+        # /issues/12 should not become part of the repo name
+        _write(tmp_path / "a.md",
+               "https://github.com/karpathy/nanoGPT/issues/12")
+        result = scan_github_mentions(tmp_path)
+        nano = next(m for m in result if m.repo == "nanogpt")
+        assert nano.owner == "karpathy"

--- a/tests/test_entities_scan.py
+++ b/tests/test_entities_scan.py
@@ -33,6 +33,21 @@ class TestScanTwitterHandles:
         result = scan_twitter_handles(tmp_path)
         assert result[0].handle == "karpathy"
 
+    def test_terminator_stops_at_subpath(self, tmp_path):
+        # Without the URL-end lookahead, x.com/karpathy/settings would
+        # capture "karpathy" but the regex would keep walking into the
+        # subpath.  Pin: the captured handle must be exactly "karpathy".
+        _write(tmp_path / "a.md",
+               "Linked to https://x.com/karpathy/settings/account "
+               "and https://x.com/sama)")
+        result = scan_twitter_handles(tmp_path)
+        handles = {m.handle for m in result}
+        assert "karpathy" in handles
+        assert "sama" in handles
+        # Settings sub-segments must not become handles
+        assert "settings" not in handles
+        assert "account" not in handles
+
     def test_filters_reserved_paths(self, tmp_path):
         # /home, /search etc. aren't real handles — drop them.
         _write(tmp_path / "a.md",

--- a/tests/test_entities_store.py
+++ b/tests/test_entities_store.py
@@ -151,6 +151,37 @@ class TestUpsert:
         assert "🐯" in round_trip.signals["description"]
 
 
+class TestUpsertMany:
+    def test_bulk_writes_in_one_transaction(self, tmp_path):
+        # Verifies the review-fix invariant: upsert_many opens one
+        # connection, runs the whole batch, commits at end.  We can't
+        # observe transactions directly via the public API, but we can
+        # observe that an exception mid-batch rolls back the previously-
+        # inserted rows in the same call.
+        store = EntityStore(db_path=tmp_path / "k.db")
+        good = [
+            {"entity_type": "twitter_author", "identity_key": f"u{i}",
+             "canonical_name": f"U{i}", "signals": {"i": i},
+             "derived_authority": 0.5, "fetch_source": "t"}
+            for i in range(3)
+        ]
+        bad = [{"entity_type": "twitter_author", "identity_key": "ok",
+                "canonical_name": "OK", "signals": {}, "derived_authority": 0.5,
+                "fetch_source": "t"},
+               # Wrong key triggers TypeError → rollback.
+               {"entity_type": "twitter_author", "wrong_field": "boom"}]
+        store.upsert_many(good)
+        # Three rows after the good batch.
+        assert len(store.list_by_type("twitter_author")) == 3
+        # Bad batch raises.  Rollback must keep total row count at 3,
+        # not 4 (the "ok" row inserted before the failure).
+        import pytest as _pytest
+        with _pytest.raises(TypeError):
+            store.upsert_many(bad)
+        assert len(store.list_by_type("twitter_author")) == 3
+        assert store.get("twitter_author", "ok") is None
+
+
 class TestRead:
     def test_get_missing_returns_none(self, tmp_path):
         store = EntityStore(db_path=tmp_path / "k.db")

--- a/tests/test_entities_store.py
+++ b/tests/test_entities_store.py
@@ -1,0 +1,200 @@
+"""Tests for entities/store.py — schema + upsert + history + reads."""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+
+from ovp_pipeline.entities.store import EntityStore, init_schema
+
+
+class TestInitSchema:
+    def test_creates_both_tables(self, tmp_path):
+        db = tmp_path / "k.db"
+        init_schema(db)
+        conn = sqlite3.connect(db)
+        try:
+            tables = {
+                row[0]
+                for row in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                ).fetchall()
+            }
+            assert "entities" in tables
+            assert "entity_signals_history" in tables
+        finally:
+            conn.close()
+
+    def test_idempotent(self, tmp_path):
+        db = tmp_path / "k.db"
+        init_schema(db)
+        # Second call must not error or wipe data — exercises the
+        # CREATE TABLE IF NOT EXISTS contract.
+        init_schema(db)
+        # Insert a row, re-init, row must still be there.
+        conn = sqlite3.connect(db)
+        try:
+            conn.execute(
+                "INSERT INTO entities (entity_type, identity_key, "
+                "signals_json, fetch_source, first_seen_at, last_fetched_at) "
+                "VALUES ('twitter_author', 'foo', '{}', 'test', 'now', 'now')"
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        init_schema(db)
+        conn = sqlite3.connect(db)
+        try:
+            assert conn.execute(
+                "SELECT COUNT(*) FROM entities"
+            ).fetchone()[0] == 1
+        finally:
+            conn.close()
+
+
+class TestUpsert:
+    def test_first_insert(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "k.db")
+        e = store.upsert(
+            entity_type="twitter_author",
+            identity_key="karpathy",
+            canonical_name="Andrej Karpathy",
+            signals={"followers": 500_000, "partial_author_weight": 67},
+            derived_authority=0.67,
+            fetch_source="twitterapi.io",
+        )
+        assert e.entity_id > 0
+        assert e.identity_key == "karpathy"
+        assert e.derived_authority == 0.67
+        assert e.signals["followers"] == 500_000
+
+    def test_second_upsert_updates_in_place(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "k.db")
+        e1 = store.upsert(
+            entity_type="twitter_author", identity_key="x",
+            canonical_name="Mr X", signals={"followers": 100},
+            derived_authority=0.10, fetch_source="twitterapi.io",
+        )
+        first_seen = e1.first_seen_at
+        time.sleep(0.01)
+        e2 = store.upsert(
+            entity_type="twitter_author", identity_key="x",
+            canonical_name="Mr X", signals={"followers": 200},
+            derived_authority=0.20, fetch_source="twitterapi.io",
+        )
+        assert e2.entity_id == e1.entity_id     # same row, updated
+        assert e2.first_seen_at == first_seen   # original first_seen kept
+        assert e2.last_fetched_at >= first_seen
+        assert e2.signals["followers"] == 200
+        assert e2.derived_authority == 0.20
+
+    def test_upsert_appends_history_row(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "k.db")
+        store.upsert(
+            entity_type="twitter_author", identity_key="x",
+            canonical_name="X", signals={"followers": 100},
+            derived_authority=0.1, fetch_source="twitterapi.io",
+        )
+        time.sleep(0.01)
+        e = store.upsert(
+            entity_type="twitter_author", identity_key="x",
+            canonical_name="X", signals={"followers": 200},
+            derived_authority=0.2, fetch_source="twitterapi.io",
+        )
+        history = list(store.history(e.entity_id))
+        # Two upserts → two history rows, newest first.
+        assert len(history) == 2
+        assert history[0][1]["followers"] == 200
+        assert history[1][1]["followers"] == 100
+
+    def test_different_identity_keys_create_separate_entities(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "k.db")
+        e_a = store.upsert(
+            entity_type="twitter_author", identity_key="a",
+            canonical_name="A", signals={}, derived_authority=0.5,
+            fetch_source="t",
+        )
+        e_b = store.upsert(
+            entity_type="twitter_author", identity_key="b",
+            canonical_name="B", signals={}, derived_authority=0.6,
+            fetch_source="t",
+        )
+        assert e_a.entity_id != e_b.entity_id
+
+    def test_same_key_different_type_are_separate_entities(self, tmp_path):
+        # @karpathy on Twitter and karpathy on GitHub are different
+        # platform accounts — must not collide.
+        store = EntityStore(db_path=tmp_path / "k.db")
+        e_tw = store.upsert(
+            entity_type="twitter_author", identity_key="karpathy",
+            canonical_name="Andrej Karpathy (Twitter)", signals={},
+            derived_authority=0.7, fetch_source="twitterapi.io",
+        )
+        e_gh = store.upsert(
+            entity_type="github_user", identity_key="karpathy",
+            canonical_name="Andrej Karpathy (GitHub)", signals={},
+            derived_authority=0.8, fetch_source="github_rest",
+        )
+        assert e_tw.entity_id != e_gh.entity_id
+
+    def test_unicode_signals_roundtrip(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "k.db")
+        store.upsert(
+            entity_type="twitter_author", identity_key="松_老虎",
+            canonical_name="松老虎",
+            signals={"description": "中文 bio with emoji 🐯"},
+            derived_authority=0.5, fetch_source="t",
+        )
+        round_trip = store.get("twitter_author", "松_老虎")
+        assert round_trip is not None
+        assert round_trip.canonical_name == "松老虎"
+        assert "🐯" in round_trip.signals["description"]
+
+
+class TestRead:
+    def test_get_missing_returns_none(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "k.db")
+        assert store.get("twitter_author", "ghost") is None
+
+    def test_list_by_type_sorted_by_authority_desc(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "k.db")
+        for h, a in [("low", 0.2), ("high", 0.9), ("mid", 0.5)]:
+            store.upsert(
+                entity_type="twitter_author", identity_key=h,
+                canonical_name=h, signals={}, derived_authority=a,
+                fetch_source="t",
+            )
+        rows = store.list_by_type("twitter_author")
+        assert [r.identity_key for r in rows] == ["high", "mid", "low"]
+
+    def test_list_by_type_excludes_other_types(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "k.db")
+        store.upsert(
+            entity_type="twitter_author", identity_key="a",
+            canonical_name="A", signals={}, derived_authority=0.5,
+            fetch_source="t",
+        )
+        store.upsert(
+            entity_type="github_project", identity_key="x/y",
+            canonical_name="X/Y", signals={}, derived_authority=0.7,
+            fetch_source="g",
+        )
+        rows = store.list_by_type("twitter_author")
+        assert len(rows) == 1
+        assert rows[0].identity_key == "a"
+
+    def test_history_limit(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "k.db")
+        for i in range(5):
+            store.upsert(
+                entity_type="twitter_author", identity_key="x",
+                canonical_name="X", signals={"i": i},
+                derived_authority=0.1, fetch_source="t",
+            )
+            time.sleep(0.005)
+        e = store.get("twitter_author", "x")
+        assert e is not None
+        rows = list(store.history(e.entity_id, limit=3))
+        assert len(rows) == 3
+        # newest first
+        assert rows[0][1]["i"] == 4

--- a/tests/test_twitter_backfill.py
+++ b/tests/test_twitter_backfill.py
@@ -272,6 +272,36 @@ class TestStubSignalsForMissing:
         assert "404" in s["fetch_reason"]
 
 
+class TestBandConstants:
+    """Pin the named-constant tables so a future tune to one band
+    doesn't silently break another.  Each test is one band boundary."""
+
+    def test_follower_bands_monotonic(self):
+        from ovp_pipeline.entities.twitter_backfill import _FOLLOWER_BANDS
+        thresholds = [t for t, _ in _FOLLOWER_BANDS]
+        # Bands must be sorted high-to-low for first-match-wins semantics.
+        assert thresholds == sorted(thresholds, reverse=True)
+
+    def test_age_bands_monotonic(self):
+        from ovp_pipeline.entities.twitter_backfill import _AGE_YEAR_BANDS
+        thresholds = [t for t, _ in _AGE_YEAR_BANDS]
+        assert thresholds == sorted(thresholds, reverse=True)
+
+    def test_band_lookup_zero_below_lowest(self):
+        from ovp_pipeline.entities.twitter_backfill import (
+            _FOLLOWER_BANDS, _band_lookup,
+        )
+        assert _band_lookup(0, _FOLLOWER_BANDS) == 0
+
+    def test_band_lookup_picks_highest_match(self):
+        from ovp_pipeline.entities.twitter_backfill import (
+            _FOLLOWER_BANDS, _band_lookup,
+        )
+        # 50_000 is between 10_000 (22pts) and 100_000 (25pts) — must
+        # return the higher 22, not silently fall through.
+        assert _band_lookup(50_000, _FOLLOWER_BANDS) == 22
+
+
 def test_price_constant_matches_intro_doc():
     # If twitterapi.io changes pricing we should see this fail.
     # Anchor against the documented $0.18/1k = $0.00018 figure.

--- a/tests/test_twitter_backfill.py
+++ b/tests/test_twitter_backfill.py
@@ -1,0 +1,278 @@
+"""Tests for entities/twitter_backfill.py.
+
+Uses unittest.mock to fake urlopen — never hits the real twitterapi.io
+in CI.  Verifies:
+  * the score formula matches the documented dimension table
+  * fetch_user_info handles 200 / 401 / 404 / 429 / network errors
+  * the persisted ``signals`` dict carries the missing-dimensions list
+    so reviewers can tell apart "we never had this signal" from
+    "this signal was zero".
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import urllib.error
+
+from ovp_pipeline.entities.twitter_backfill import (
+    PRICE_PER_CALL_USD,
+    _account_age_years,
+    compute_partial_author_weight,
+    derive_authority_from_payload,
+    fetch_user_info,
+    stub_signals_for_missing,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _years_ago_iso(years: float) -> str:
+    """ISO timestamp ``years`` years ago in UTC, accepted by twitterapi.io."""
+    delta_days = years * 365.25
+    now = datetime.now(timezone.utc)
+    target_ts = now.timestamp() - delta_days * 86400
+    return datetime.fromtimestamp(target_ts, tz=timezone.utc).isoformat(
+        timespec="microseconds"
+    ).replace("+00:00", "Z")
+
+
+def _fake_response(status: int, body: dict | str):
+    """Build a FakeURLOpen-ready return value for urllib.request.urlopen."""
+    raw = body if isinstance(body, str) else json.dumps(body)
+    f = io.BytesIO(raw.encode("utf-8"))
+    f.status = status
+    return f
+
+
+# ---------------------------------------------------------------------------
+# Score formula
+# ---------------------------------------------------------------------------
+
+
+class TestComputePartialAuthorWeight:
+    def test_zero_inputs_zero_score(self):
+        score, breakdown = compute_partial_author_weight({})
+        assert score == 0
+        # negative-only outcome (automated penalty) is clipped to 0 by max()
+        assert all(v == 0 for v in breakdown.values())
+
+    def test_high_followers_dominates(self):
+        score, b = compute_partial_author_weight({
+            "followers": 500_000,
+            "createdAt": _years_ago_iso(10),
+            "isBlueVerified": True,
+            "isVerified": True,
+        })
+        assert b["followers"] == 25
+        assert b["age"] == 10
+        assert b["blue_verified"] == 5
+        assert b["legacy_verified"] == 10
+        assert score == 50
+
+    def test_company_affiliation_adds_10(self):
+        score, b = compute_partial_author_weight({
+            "followers": 1500,
+            "createdAt": _years_ago_iso(4),
+            "affiliatesHighlightedLabel": {"label": {"text": "Anthropic"}},
+        })
+        assert b["affiliation"] == 10
+
+    def test_automated_account_penalized(self):
+        score_normal, _ = compute_partial_author_weight({
+            "followers": 5000, "createdAt": _years_ago_iso(5),
+            "statusesCount": 1000,
+        })
+        score_bot, b_bot = compute_partial_author_weight({
+            "followers": 5000, "createdAt": _years_ago_iso(5),
+            "statusesCount": 1000, "isAutomated": True,
+        })
+        assert b_bot["automated_penalty"] == -10
+        assert score_bot == score_normal - 10
+
+    def test_activity_band(self):
+        # too-active accounts get a slight discount, not full credit.
+        _, b_normal = compute_partial_author_weight({"statusesCount": 1000})
+        _, b_extreme = compute_partial_author_weight({"statusesCount": 100_000})
+        assert b_normal["activity"] == 10
+        assert b_extreme["activity"] == 8
+
+    def test_max_score_caps_under_70(self):
+        # Even with every dimension maxed, score can't reach 70 because
+        # listed/mutuals/i_follow are deliberately not modeled here.
+        score, _ = compute_partial_author_weight({
+            "followers": 10_000_000,
+            "createdAt": _years_ago_iso(15),
+            "isBlueVerified": True,
+            "isVerified": True,
+            "verifiedType": "company",
+            "affiliatesHighlightedLabel": {"label": "ok"},
+            "statusesCount": 5000,
+        })
+        # 25 + 10 + 5 + 10 + 10 + 10 = 70 (no penalty)
+        assert score == 70
+
+    def test_negative_only_score_floors_at_zero(self):
+        # If an account is automated and has no other signals, the
+        # raw sum is -10; max() clips it to 0 so the persisted
+        # authority stays in [0, 1].
+        score, _ = compute_partial_author_weight({"isAutomated": True})
+        assert score == 0
+
+
+class TestAccountAgeYears:
+    def test_iso_format(self):
+        s = _years_ago_iso(5.0)
+        years = _account_age_years(s)
+        assert 4.9 < years < 5.1
+
+    def test_x_legacy_format(self):
+        # X's classic API used this shape; twitterapi.io may sometimes echo it.
+        years = _account_age_years("Thu Dec 13 08:41:26 +0000 2007")
+        assert years > 16   # 2026 - 2007
+
+    def test_unparseable_returns_zero(self):
+        assert _account_age_years("nonsense") == 0.0
+        assert _account_age_years(None) == 0.0
+        assert _account_age_years("") == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Authority derivation
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveAuthorityFromPayload:
+    def test_persists_missing_dimensions_marker(self):
+        # The signals dict must record what we DON'T have, so a future
+        # formula change can detect "we never collected this" vs
+        # "this was zero".
+        _, signals = derive_authority_from_payload(
+            {"userName": "x", "followers": 100, "createdAt": _years_ago_iso(2)}
+        )
+        assert "listed_count" in signals["missing_dimensions"]
+        assert "mutuals_count" in signals["missing_dimensions"]
+        assert "i_follow" in signals["missing_dimensions"]
+
+    def test_authority_in_unit_interval(self):
+        a, _ = derive_authority_from_payload(
+            {"followers": 10_000_000, "createdAt": _years_ago_iso(15),
+             "isBlueVerified": True, "verifiedType": "company",
+             "affiliatesHighlightedLabel": {"label": "ok"},
+             "statusesCount": 5000}
+        )
+        assert 0.0 <= a <= 1.0
+
+    def test_authority_caps_below_clipper_max(self):
+        # 70 / 100 = 0.70 — leaves the 0.71-1.0 band reserved for
+        # clipper-rich frontmatter that has the missing signals.
+        a, _ = derive_authority_from_payload(
+            {"followers": 10_000_000, "createdAt": _years_ago_iso(15),
+             "isBlueVerified": True, "verifiedType": "company",
+             "affiliatesHighlightedLabel": {"label": "ok"},
+             "statusesCount": 5000}
+        )
+        assert a == 0.70
+
+
+# ---------------------------------------------------------------------------
+# Fetch
+# ---------------------------------------------------------------------------
+
+
+class TestFetchUserInfo:
+    def test_success_returns_payload(self):
+        body = {
+            "status": "success",
+            "data": {"userName": "karpathy", "followers": 1_000_000},
+        }
+        with patch(
+            "ovp_pipeline.entities.twitter_backfill.urllib.request.urlopen"
+        ) as m:
+            m.return_value.__enter__.return_value = _fake_response(200, body)
+            r = fetch_user_info("karpathy", api_key="k")
+        assert r.status == "ok"
+        assert r.payload["followers"] == 1_000_000
+
+    def test_404_marks_not_found_no_retry(self):
+        with patch(
+            "ovp_pipeline.entities.twitter_backfill.urllib.request.urlopen"
+        ) as m:
+            m.side_effect = urllib.error.HTTPError(
+                "u", 404, "not found", {}, None,
+            )
+            r = fetch_user_info("ghost", api_key="k")
+        assert r.status == "not_found"
+        # only one attempt — no retries on 404
+        assert m.call_count == 1
+
+    def test_401_aborts_immediately(self):
+        with patch(
+            "ovp_pipeline.entities.twitter_backfill.urllib.request.urlopen"
+        ) as m:
+            m.side_effect = urllib.error.HTTPError(
+                "u", 401, "auth", {}, None,
+            )
+            r = fetch_user_info("x", api_key="bad")
+        assert r.status == "error"
+        assert "auth" in (r.error or "").lower()
+        assert m.call_count == 1
+
+    def test_429_retries_then_gives_up(self):
+        with patch(
+            "ovp_pipeline.entities.twitter_backfill.urllib.request.urlopen"
+        ) as m, patch(
+            "ovp_pipeline.entities.twitter_backfill.time.sleep"
+        ) as sleeper:
+            m.side_effect = urllib.error.HTTPError(
+                "u", 429, "rate", {}, None,
+            )
+            r = fetch_user_info("x", api_key="k")
+        assert r.status == "error"
+        # Retried up to _MAX_RETRIES times.
+        assert m.call_count == 3
+        # Backoff is exercised between attempts.
+        assert sleeper.call_count >= 2
+
+    def test_api_error_status_with_user_not_found_msg(self):
+        body = {"status": "error", "msg": "user not found"}
+        with patch(
+            "ovp_pipeline.entities.twitter_backfill.urllib.request.urlopen"
+        ) as m:
+            m.return_value.__enter__.return_value = _fake_response(200, body)
+            r = fetch_user_info("ghost", api_key="k")
+        assert r.status == "not_found"
+
+    def test_missing_api_key_short_circuits(self):
+        r = fetch_user_info("x", api_key="")
+        assert r.status == "error"
+        # No call attempted.
+
+    def test_bad_json_marks_error(self):
+        with patch(
+            "ovp_pipeline.entities.twitter_backfill.urllib.request.urlopen"
+        ) as m:
+            m.return_value.__enter__.return_value = _fake_response(200, "<not json>")
+            r = fetch_user_info("x", api_key="k")
+        assert r.status == "error"
+        assert "json" in (r.error or "").lower()
+
+
+class TestStubSignalsForMissing:
+    def test_records_handle_and_reason(self):
+        s = stub_signals_for_missing("ghost", "404 from API")
+        assert s["userName"] == "ghost"
+        assert s["fetch_status"] == "not_found"
+        assert "404" in s["fetch_reason"]
+
+
+def test_price_constant_matches_intro_doc():
+    # If twitterapi.io changes pricing we should see this fail.
+    # Anchor against the documented $0.18/1k = $0.00018 figure.
+    assert PRICE_PER_CALL_USD == 0.00018


### PR DESCRIPTION
## Summary

- **PR-E1** of the entity-layer rebuild (see prior `research/RESEARCH_BRIEF_source_authority.md` Q3/Q4/Q5).
- Read-only for now — authority scorer continues to read per-clipping frontmatter; the runtime read-path migration is **PR-E3**.
- Two new SQLite tables (`entities`, `entity_signals_history`), one new CLI (`ovp-backfill-twitter-authors`), and the first concrete entity producer: a twitterapi.io fetcher.

## Why

Until now every Twitter author signal lived only in per-clipping frontmatter. Three problems:

1. The same handle showing up in 50 clippings = 50 redundant copies of `followers`/`listed`/etc.
2. Most legacy clippings have **none** of these fields (the obsidian-clipper Twitter adapter is a recent feature — only 1 of ~7000 vault clippings has full data).
3. Signal can't accumulate across captures — there's no "we've bookmarked this person 12 times so they're more relevant to us than their 3000 followers suggest".

An entity layer fixes all three by keying on `(entity_type, identity_key)` and treating signals as a merged-view that updates over time.

## Schema (additive — both tables `CREATE TABLE IF NOT EXISTS`)

```sql
entities
    entity_id          INTEGER PK
    entity_type        TEXT NOT NULL    -- 'twitter_author', future: 'github_project', etc.
    identity_key       TEXT NOT NULL    -- handle / owner-repo / etc.
    canonical_name     TEXT
    signals_json       TEXT NOT NULL    -- raw fetched payload
    derived_authority  REAL             -- 0-1 estimate
    fetch_source       TEXT NOT NULL    -- 'twitterapi.io' | 'github_rest' | 'manual' | ...
    first_seen_at      TEXT NOT NULL
    last_fetched_at    TEXT NOT NULL
    UNIQUE(entity_type, identity_key)

entity_signals_history
    history_id    INTEGER PK
    entity_id     INTEGER FK → entities
    observed_at   TEXT NOT NULL
    signals_json  TEXT NOT NULL
    fetch_source  TEXT NOT NULL
```

## The honest "partial" in `partial_author_weight`

The obsidian-clipper Twitter adapter computes a 7-dimension `author_weight` (0-100) at clip time using browser-side scrapes that include **`listed_count`** (per the clipper docs, "underrated true signal") and **mutual-network** signals. twitterapi.io's `/twitter/user/info` endpoint does **not** surface these.

This PR reconstructs 5 of those 7 dimensions:

| Dim | Max | Source |
|---|---|---|
| followers | 25 | API |
| account age | 10 | API (`createdAt`) |
| blue verified | 5 | API (low weight per clipper docs) |
| legacy verified / verifiedType | 10 | API |
| affiliation badge | 10 | API (`affiliatesHighlightedLabel`) |
| activity (statusesCount band) | 10 | API |
| automated penalty | -10 | API (`isAutomated`) |
| **listed_count** | — | ❌ NOT IN twitterapi.io |
| **mutuals_*** | — | ❌ NOT IN twitterapi.io |

Sum caps at 70 → `derived_authority ≤ 0.70`. The 0.71-1.0 band is **deliberately reserved** for clipper-rich frontmatter so PR-E3's runtime resolver can prefer the higher-fidelity signal when both exist. The persisted `signals` dict carries an explicit `missing_dimensions` list to keep the gap auditable.

## Backfill economics

- 521 unique X handles in the OVP vault (recon scan included)
- $0.00018 / call (twitterapi.io single-user pricing)
- **Total: $0.094 one-shot** — covered by the free trial credits

## Failure handling

- `401/403` → abort run (auth misconfig is never something to mask)
- `404 / "not found"` → store stub entity, no retry, no authority
- `429` → exponential backoff, up to 3 retries
- network → 3 retries then mark error (entity NOT written, retry next run)

## Idempotence

Cached entities skipped if `last_fetched_at` is within `--max-age-days` (default 30). `--force` re-fetches everything. `--dry-run` plans + cost-estimates without hitting the API.

## Test plan

- [x] Schema idempotency — `init_schema` is safe to call repeatedly without losing data
- [x] Upsert: insert, update-in-place (preserves `first_seen_at`), history append, multi-key isolation, same-key-different-type isolation, unicode roundtrip
- [x] Vault scanner: handle extraction from status URLs and bare profiles, reserved-path filter, markdown-link regex termination, `__pycache__`/`_backup` skipping
- [x] Score formula: each dimension's threshold band, the 70 ceiling, the missing-dimensions marker
- [x] Fetch: 200/401/404/429/network paths via mocked urlopen, retry+backoff verification
- [x] Architecture fitness — `entities/store` allow-listed for direct sqlite3 (data-layer module)
- [x] Full suite: **1644 passed**, lint clean
- [ ] Real backfill against `~/Documents/ovp-vault` — running now (~30-40 min, will append report as a comment)

## What this PR does NOT do

- Does not change the authority scorer — `AuthorRulesProvider` etc. still read per-clipping frontmatter. PR-E3.
- Does not handle GitHub projects/users — PR-E2.
- Does not de-duplicate across platforms (same person on Twitter+GitHub+Substack) — PR-E3 / cross-source identity.
- Does not collect `listed_count` or mutuals — those signals require either the obsidian-clipper Twitter adapter (going forward, automatic) or a separately-paid scraper. **Forward-only is the recommended approach** per the discussion thread.

## Out of scope but worth flagging

The existing `ovp-backfill-entities` / `ovp-backfill-entity-type` / `ovp-refresh-entities` commands operate on a different concept ("entity" as in NER-extracted person/concept/tool from text). This PR's `entities` table holds platform accounts (twitter_author etc.) and is genuinely a separate concern. No collision: the existing system uses `entity_mentions` / `EntityRegistry`, this PR adds the `entities` table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ovp-backfill-twitter-authors` CLI command to discover Twitter handles in your vault and fetch enriched author metadata from external API
  * Built entity storage system to persist and track author information with historical snapshots
  * Added vault scanning to identify Twitter handles and GitHub repository references
  * Supports dry-run mode, mention-based filtering, and API cost controls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->