### PR TITLE
feat(backup): ovp-backup-db — point-in-time snapshots of knowledge.db

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,7 @@ ovp-backfill-entity-type = "ovp_pipeline.commands.backfill_entity_type:main"
 ovp-backfill-entities = "ovp_pipeline.commands.backfill_entities:main"
 ovp-refresh-entities = "ovp_pipeline.commands.refresh_entities:main"
 ovp-embedding-dedup = "ovp_pipeline.commands.embedding_dedup:main"
+ovp-backup-db = "ovp_pipeline.commands.backup_db:main"
 
 [project.entry-points."ovp.packs"]
 default-knowledge = "ovp_pipeline.packs.default_knowledge:get_pack"

--- a/src/ovp_pipeline/commands/backup_db.py
+++ b/src/ovp_pipeline/commands/backup_db.py
@@ -78,6 +78,12 @@ from pathlib import Path
 
 _DEFAULT_KEEP = 14
 _BUFFER_PAGES = 200    # Pages copied per Backup API step (200 ≈ 800KB)
+# ``sqlite3.Connection.backup`` defaults to ``sleep=0.25`` between
+# batches.  At our buffer size that would stretch a 215 MB snapshot
+# from ~3 s to ~60 s.  A tiny non-zero sleep still lets concurrent
+# autopilot writers slip in between batches without paying the full
+# default cost.
+_BACKUP_SLEEP_INTERVAL_S = 0.05
 
 
 def _iso_compact_now() -> str:
@@ -114,7 +120,11 @@ def backup_one(src: Path, dst: Path) -> int:
     try:
         # ``pages=N`` lets long-running writers slip in between
         # batches; ``progress=None`` because we don't need callbacks.
-        src_conn.backup(dst_conn, pages=_BUFFER_PAGES)
+        src_conn.backup(
+            dst_conn,
+            pages=_BUFFER_PAGES,
+            sleep=_BACKUP_SLEEP_INTERVAL_S,
+        )
     finally:
         dst_conn.close()
         src_conn.close()

--- a/src/ovp_pipeline/commands/backup_db.py
+++ b/src/ovp_pipeline/commands/backup_db.py
@@ -1,0 +1,214 @@
+"""ovp-backup-db — point-in-time snapshot of knowledge.db.
+
+Uses SQLite's online Backup API (``sqlite3.Connection.backup``) which
+takes a consistent snapshot **without locking out concurrent writers**.
+Safe to run while ``ovp-autopilot`` or any ingest job is active.
+
+Why we need this
+----------------
+
+knowledge.db is the single source of truth for ~7000 evergreen
+artifacts, ~25k audit events, ~13k relations, the source-authority
+table, and the new entity layer.  A single corrupted write or
+accidental ``DROP TABLE`` would lose months of curation.  The
+markdown notes are recoverable from git, but the derived state
+(embeddings, FTS index, graph_clusters, audit_events,
+source_authority, entities) is expensive to rebuild.
+
+Default schedule (no install — suggested launchd plist below)::
+
+    ovp-backup-db --vault-dir ~/Documents/ovp-vault --keep 14
+        # daily at 03:00; keeps the 14 most recent snapshots
+        # ~211 MB × 14 ≈ 3 GB at the current DB size
+
+Output layout::
+
+    <vault>/60-Logs/backups/
+        knowledge-2026-05-03T03-00-00.db      # full snapshot
+        knowledge-2026-05-02T03-00-00.db
+        ...
+        knowledge-2026-05-03T03-00-00.sha256  # checksum manifest
+
+The sha256 manifest lets you verify a snapshot decades later without
+re-opening it through SQLite.
+
+Schedule via launchd (macOS)
+----------------------------
+
+Drop the following at ``~/Library/LaunchAgents/ai.ovp.backup-db.plist``
+and run ``launchctl load -w ~/Library/LaunchAgents/ai.ovp.backup-db.plist``::
+
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+        "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+        <key>Label</key>          <string>ai.ovp.backup-db</string>
+        <key>ProgramArguments</key>
+        <array>
+            <string>/path/to/ovp-backup-db</string>
+            <string>--vault-dir</string>
+            <string>/Users/USERNAME/Documents/ovp-vault</string>
+            <string>--keep</string>
+            <string>14</string>
+        </array>
+        <key>StartCalendarInterval</key>
+        <dict>
+            <key>Hour</key>    <integer>3</integer>
+            <key>Minute</key>  <integer>0</integer>
+        </dict>
+        <key>StandardOutPath</key>
+        <string>/tmp/ovp-backup-db.log</string>
+        <key>StandardErrorPath</key>
+        <string>/tmp/ovp-backup-db.log</string>
+    </dict>
+    </plist>
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import sqlite3
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+_DEFAULT_KEEP = 14
+_BUFFER_PAGES = 200    # Pages copied per Backup API step (200 ≈ 800KB)
+
+
+def _iso_compact_now() -> str:
+    """Filesystem-safe ISO timestamp: ``2026-05-03T03-00-00``."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%S")
+
+
+def _sha256_of(path: Path, *, chunk_size: int = 1 << 20) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        while True:
+            buf = f.read(chunk_size)
+            if not buf:
+                break
+            h.update(buf)
+    return h.hexdigest()
+
+
+def backup_one(src: Path, dst: Path) -> int:
+    """Atomically online-backup ``src`` → ``dst``.
+
+    Writes to a ``.tmp`` first then renames so a partially-written
+    backup can never masquerade as a complete one.  Returns the
+    final file's size in bytes.
+    """
+    if not src.exists():
+        raise FileNotFoundError(f"source DB not found: {src}")
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dst.with_suffix(dst.suffix + ".tmp")
+    if tmp.exists():
+        tmp.unlink()
+    src_conn = sqlite3.connect(src)
+    dst_conn = sqlite3.connect(tmp)
+    try:
+        # ``pages=N`` lets long-running writers slip in between
+        # batches; ``progress=None`` because we don't need callbacks.
+        src_conn.backup(dst_conn, pages=_BUFFER_PAGES)
+    finally:
+        dst_conn.close()
+        src_conn.close()
+    tmp.replace(dst)
+    return dst.stat().st_size
+
+
+def prune(backup_dir: Path, *, keep: int) -> list[Path]:
+    """Keep the ``keep`` most recent ``knowledge-*.db`` snapshots,
+    delete older ones (and their sidecar ``.sha256`` files).
+
+    Returns the list of pruned paths.
+    """
+    if keep < 1:
+        return []
+    snapshots = sorted(
+        backup_dir.glob("knowledge-*.db"),
+        key=lambda p: p.name,           # ISO timestamps sort naturally
+        reverse=True,
+    )
+    pruned: list[Path] = []
+    for old in snapshots[keep:]:
+        sidecar = old.with_suffix(".sha256")
+        if sidecar.exists():
+            sidecar.unlink()
+            pruned.append(sidecar)
+        old.unlink()
+        pruned.append(old)
+    return pruned
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Snapshot knowledge.db via SQLite online backup",
+    )
+    parser.add_argument("--vault-dir", type=Path, default=Path.cwd())
+    parser.add_argument("--keep", type=int, default=_DEFAULT_KEEP,
+                        help=f"Retain N most recent snapshots (default {_DEFAULT_KEEP})")
+    parser.add_argument("--no-checksum", action="store_true",
+                        help="Skip the .sha256 sidecar (faster on huge DBs)")
+    parser.add_argument("--no-prune", action="store_true",
+                        help="Don't delete old snapshots after writing the new one")
+    parser.add_argument("--quiet", action="store_true",
+                        help="Suppress per-file progress output")
+    args = parser.parse_args(argv)
+
+    vault = args.vault_dir.resolve()
+    src = vault / "60-Logs" / "knowledge.db"
+    backup_dir = vault / "60-Logs" / "backups"
+
+    if not src.exists():
+        print(f"error: knowledge.db not found at {src}", file=sys.stderr)
+        return 2
+
+    started = time.monotonic()
+    src_size = src.stat().st_size
+    timestamp = _iso_compact_now()
+    dst = backup_dir / f"knowledge-{timestamp}.db"
+
+    if not args.quiet:
+        print(f"source: {src}  ({src_size / 1024 / 1024:.1f} MB)")
+        print(f"target: {dst}")
+
+    try:
+        written = backup_one(src, dst)
+    except Exception as exc:
+        print(f"error: backup failed: {exc}", file=sys.stderr)
+        return 1
+
+    elapsed_s = time.monotonic() - started
+
+    sha = ""
+    if not args.no_checksum:
+        sha = _sha256_of(dst)
+        sidecar = dst.with_suffix(".sha256")
+        sidecar.write_text(f"{sha}  {dst.name}\n", encoding="utf-8")
+
+    if not args.quiet:
+        print(f"wrote   {written / 1024 / 1024:.1f} MB in {elapsed_s:.1f}s")
+        if sha:
+            print(f"sha256  {sha[:16]}…")
+
+    pruned: list[Path] = []
+    if not args.no_prune:
+        pruned = prune(backup_dir, keep=args.keep)
+        if pruned and not args.quiet:
+            kept = sorted(
+                p.name for p in backup_dir.glob("knowledge-*.db")
+            )
+            print(f"pruned  {len(pruned)} old files; "
+                  f"{len(kept)} snapshots remain (oldest: {kept[0]})")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_architecture_fitness.py
+++ b/tests/test_architecture_fitness.py
@@ -180,6 +180,7 @@ SQLITE_ALLOWED_MODULES = {
     "commands/_ui_renderers",
     "commands/working_memory",
     "commands/score_sources",
+    "commands/backup_db",
     "source_authority",
     "discovery",
     "evidence",

--- a/tests/test_backup_db.py
+++ b/tests/test_backup_db.py
@@ -1,0 +1,170 @@
+"""Tests for ovp-backup-db.
+
+Don't depend on the real knowledge.db; build a tiny SQLite fixture
+in tmp_path and prove the round-trip.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from ovp_pipeline.commands.backup_db import (
+    _sha256_of,
+    backup_one,
+    main,
+    prune,
+)
+
+
+def _make_fixture_db(path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+        for i in range(50):
+            conn.execute("INSERT INTO t VALUES (?, ?)", (i, f"row-{i}"))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+class TestBackupOne:
+    def test_round_trip(self, tmp_path):
+        src = tmp_path / "src.db"
+        _make_fixture_db(src)
+        dst = tmp_path / "out" / "snap.db"
+
+        size = backup_one(src, dst)
+        assert size > 0
+        assert dst.exists()
+
+        # Reading the snapshot must yield identical rows.
+        conn = sqlite3.connect(dst)
+        try:
+            rows = conn.execute("SELECT id, v FROM t ORDER BY id").fetchall()
+        finally:
+            conn.close()
+        assert len(rows) == 50
+        assert rows[0] == (0, "row-0")
+        assert rows[-1] == (49, "row-49")
+
+    def test_atomic_no_tmp_left_behind(self, tmp_path):
+        # Successful backup must clean up the .tmp staging file.
+        src = tmp_path / "src.db"
+        _make_fixture_db(src)
+        dst = tmp_path / "snap.db"
+        backup_one(src, dst)
+        assert dst.exists()
+        assert not dst.with_suffix(".db.tmp").exists()
+
+    def test_overwrites_existing(self, tmp_path):
+        # Re-running the same target path replaces, doesn't error.
+        src = tmp_path / "src.db"
+        _make_fixture_db(src)
+        dst = tmp_path / "snap.db"
+        backup_one(src, dst)
+        backup_one(src, dst)        # second run must succeed
+        assert dst.exists()
+
+    def test_missing_source_raises(self, tmp_path):
+        src = tmp_path / "doesnotexist.db"
+        dst = tmp_path / "snap.db"
+        with pytest.raises(FileNotFoundError):
+            backup_one(src, dst)
+
+
+class TestPrune:
+    def test_keeps_newest_n(self, tmp_path):
+        # Six snapshot files with naturally-sortable ISO timestamps.
+        for i in range(6):
+            (tmp_path / f"knowledge-2026-05-0{i+1}T03-00-00.db").write_text("")
+        pruned = prune(tmp_path, keep=3)
+        kept = sorted(p.name for p in tmp_path.glob("knowledge-*.db"))
+        assert len(kept) == 3
+        # The three newest survived (highest dates)
+        assert kept[-1].endswith("06T03-00-00.db")
+        assert kept[0].endswith("04T03-00-00.db")
+        # Pruner reported three deletions
+        assert len(pruned) == 3
+
+    def test_also_removes_sidecar_checksums(self, tmp_path):
+        # Each .db has its .sha256 sibling — pruning should delete
+        # both, not orphan the manifest.
+        for i in range(4):
+            db = tmp_path / f"knowledge-2026-05-0{i+1}T03-00-00.db"
+            db.write_text("")
+            db.with_suffix(".sha256").write_text("hash")
+        prune(tmp_path, keep=2)
+        assert len(list(tmp_path.glob("*.db"))) == 2
+        assert len(list(tmp_path.glob("*.sha256"))) == 2
+
+    def test_keep_zero_no_op_for_safety(self, tmp_path):
+        # keep<1 is treated as "don't prune" rather than "delete everything".
+        # Better to leave snapshots than to nuke them on a misconfig.
+        (tmp_path / "knowledge-2026-05-01T03-00-00.db").write_text("")
+        pruned = prune(tmp_path, keep=0)
+        assert pruned == []
+        assert len(list(tmp_path.glob("*.db"))) == 1
+
+
+class TestSha256:
+    def test_known_value(self, tmp_path):
+        f = tmp_path / "x.bin"
+        f.write_bytes(b"ovp")
+        # python -c 'import hashlib;print(hashlib.sha256(b"ovp").hexdigest())'
+        assert _sha256_of(f) == (
+            "6b25ca9b509d11025a53fde57c09cf10f4c13836eeffb1d2a3545d58ef3e8efa"
+        )
+
+
+class TestMain:
+    def test_full_run_creates_snapshot_and_checksum(self, tmp_path):
+        vault = tmp_path / "vault"
+        src = vault / "60-Logs" / "knowledge.db"
+        _make_fixture_db(src)
+
+        rc = main(["--vault-dir", str(vault), "--quiet"])
+        assert rc == 0
+
+        backups = list((vault / "60-Logs" / "backups").glob("knowledge-*.db"))
+        assert len(backups) == 1
+        sidecar = backups[0].with_suffix(".sha256")
+        assert sidecar.exists()
+        # Sidecar format: "<hex>  <filename>\n"
+        text = sidecar.read_text(encoding="utf-8")
+        assert backups[0].name in text
+
+    def test_main_missing_db_returns_2(self, tmp_path):
+        vault = tmp_path / "empty"
+        (vault / "60-Logs").mkdir(parents=True)
+        rc = main(["--vault-dir", str(vault), "--quiet"])
+        assert rc == 2
+
+    def test_main_no_checksum_flag(self, tmp_path):
+        vault = tmp_path / "vault"
+        _make_fixture_db(vault / "60-Logs" / "knowledge.db")
+        rc = main(["--vault-dir", str(vault), "--no-checksum", "--quiet"])
+        assert rc == 0
+        sidecars = list((vault / "60-Logs" / "backups").glob("*.sha256"))
+        assert sidecars == []
+
+    def test_main_prunes_old_snapshots(self, tmp_path):
+        # Pre-populate with stale snapshots, run main, observe rotation.
+        vault = tmp_path / "vault"
+        _make_fixture_db(vault / "60-Logs" / "knowledge.db")
+        backups = vault / "60-Logs" / "backups"
+        backups.mkdir(parents=True)
+        # Five old snapshots, all dated before "now" so they sort lower
+        for i in range(5):
+            (backups / f"knowledge-2025-01-0{i+1}T03-00-00.db").write_text("stale")
+
+        rc = main(["--vault-dir", str(vault), "--keep", "3", "--quiet"])
+        assert rc == 0
+        # 5 stale + 1 fresh = 6, keep 3 → 3 remaining (the fresh one
+        # plus 2 newest stale ones).
+        remaining = sorted(p.name for p in backups.glob("knowledge-*.db"))
+        assert len(remaining) == 3
+        # The freshly-written snapshot survived.
+        assert any("2026" in name for name in remaining)

--- a/tests/test_backup_db.py
+++ b/tests/test_backup_db.py
@@ -156,9 +156,12 @@ class TestMain:
         _make_fixture_db(vault / "60-Logs" / "knowledge.db")
         backups = vault / "60-Logs" / "backups"
         backups.mkdir(parents=True)
-        # Five old snapshots, all dated before "now" so they sort lower
+        # Five stale snapshots dated firmly in the past — using 1970
+        # instead of e.g. 2025 future-proofs the test (otherwise it
+        # silently flips when the system clock passes those dates).
+        stale_prefix = "knowledge-1970-01-"
         for i in range(5):
-            (backups / f"knowledge-2025-01-0{i+1}T03-00-00.db").write_text("stale")
+            (backups / f"{stale_prefix}0{i+1}T03-00-00.db").write_text("stale")
 
         rc = main(["--vault-dir", str(vault), "--keep", "3", "--quiet"])
         assert rc == 0
@@ -166,5 +169,5 @@ class TestMain:
         # plus 2 newest stale ones).
         remaining = sorted(p.name for p in backups.glob("knowledge-*.db"))
         assert len(remaining) == 3
-        # The freshly-written snapshot survived.
-        assert any("2026" in name for name in remaining)
+        # The freshly-written snapshot (any non-1970 date) survived.
+        assert any(stale_prefix not in name for name in remaining)


### PR DESCRIPTION
## Summary

- New CLI \`ovp-backup-db\` that snapshots \`60-Logs/knowledge.db\` via SQLite's **online Backup API** (`sqlite3.Connection.backup`).  Consistent without locking concurrent writers — safe to run while \`ovp-autopilot\` is active.
- Atomic write through a \`.tmp\` stage so a partial backup can never masquerade as a complete one.
- SHA-256 sidecar manifest for decade-later verification.
- Retention via \`--keep N\` (default 14, ~3 GB at the current 215 MB DB size).
- Smoke-tested against the real \`~/Documents/ovp-vault/60-Logs/knowledge.db\`: 215 MB written in **3.0 seconds**.

## Why now

\`knowledge.db\` is the single source of truth for ~7000 evergreen artifacts, ~25k audit events, ~13k relations, source_authority + entity-layer derivations.  Markdown notes are recoverable from git, but the derived state is expensive to rebuild.  Until this PR, no backup mechanism existed.

## Schedule (no auto-install)

Documented in the module docstring — drop a launchd plist at \`~/Library/LaunchAgents/ai.ovp.backup-db.plist\` calling \`ovp-backup-db --vault-dir <vault> --keep 14\`.  Cron line is the same one-liner.

## Test plan

- [x] Round-trip identity (snapshot read-back yields identical rows)
- [x] Atomic write — successful backup leaves no \`.tmp\` artifact
- [x] Idempotent overwrite (re-running same target succeeds)
- [x] Missing source DB returns 2
- [x] Prune keeps newest N, deletes \`.sha256\` siblings together
- [x] \`--keep 0\` is a safety no-op (don't nuke on misconfig)
- [x] \`--no-checksum\` flag skips manifest
- [x] Real-DB run: 215 MB → 215 MB snapshot in 3.0 s with sha256 sidecar

## Scope

Standalone — independent of #115 / #116.  Branched off main, merges cleanly today.