### PR TITLE
feat(entities): scorer reads entity table + person identity merge

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,7 @@ ovp-schema = "ovp_pipeline.commands.schema_cmd:main"
 ovp-backfill-entity-type = "ovp_pipeline.commands.backfill_entity_type:main"
 ovp-backfill-entities = "ovp_pipeline.commands.backfill_entities:main"
 ovp-backfill-twitter-authors = "ovp_pipeline.commands.backfill_twitter_authors:main"
+ovp-backfill-github = "ovp_pipeline.commands.backfill_github:main"
 ovp-refresh-entities = "ovp_pipeline.commands.refresh_entities:main"
 ovp-embedding-dedup = "ovp_pipeline.commands.embedding_dedup:main"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,7 @@ ovp-backfill-entity-type = "ovp_pipeline.commands.backfill_entity_type:main"
 ovp-backfill-entities = "ovp_pipeline.commands.backfill_entities:main"
 ovp-backfill-twitter-authors = "ovp_pipeline.commands.backfill_twitter_authors:main"
 ovp-backfill-github = "ovp_pipeline.commands.backfill_github:main"
+ovp-merge-identities = "ovp_pipeline.commands.merge_identities:main"
 ovp-refresh-entities = "ovp_pipeline.commands.refresh_entities:main"
 ovp-embedding-dedup = "ovp_pipeline.commands.embedding_dedup:main"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,7 @@ ovp-runtime-state = "ovp_pipeline.commands.runtime_state:main"
 ovp-schema = "ovp_pipeline.commands.schema_cmd:main"
 ovp-backfill-entity-type = "ovp_pipeline.commands.backfill_entity_type:main"
 ovp-backfill-entities = "ovp_pipeline.commands.backfill_entities:main"
+ovp-backfill-twitter-authors = "ovp_pipeline.commands.backfill_twitter_authors:main"
 ovp-refresh-entities = "ovp_pipeline.commands.refresh_entities:main"
 ovp-embedding-dedup = "ovp_pipeline.commands.embedding_dedup:main"
 

--- a/src/ovp_pipeline/commands/backfill_github.py
+++ b/src/ovp_pipeline/commands/backfill_github.py
@@ -1,0 +1,336 @@
+"""ovp-backfill-github — populate github_project + github_user entities.
+
+Scans the vault for ``github.com/<owner>/<repo>`` and ``github.com/<owner>``
+mentions, calls the GitHub REST API for each unique entity, persists
+results in the ``entities`` table.
+
+Two-pass strategy:
+  1. Fetch all unique users first (so per-user authority is known).
+  2. Fetch all unique repos, looking up each repo's owner_login in
+     the just-populated user store to compute owner_lift.
+
+This means a fresh repo whose owner you've never seen still gets
+scored from its intrinsic stars/forks/recency — owner_lift just
+becomes a bonus signal when available.
+
+Usage::
+
+    ovp-backfill-github --vault-dir ~/Documents/ovp-vault          # both passes
+    ovp-backfill-github --kind users                               # users only
+    ovp-backfill-github --kind projects                            # projects only
+    ovp-backfill-github --dry-run                                  # plan + budget
+
+Auth
+----
+
+Public-repo reads work without a token at 60 req/hour, but for the
+~280 entity OVP vault that's a 5-hour stagger.  Provide a token via:
+
+  1. ``--token`` CLI arg
+  2. ``GITHUB_TOKEN`` env var
+  3. First non-comment line of ``<vault>/60-Logs/.github-token``
+
+A no-scope (public-only) PAT is sufficient — we never write.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from ..entities.github_backfill import (
+    PRICE_PER_CALL_USD,
+    derive_project_signals,
+    derive_user_signals,
+    fetch_repo,
+    fetch_user,
+    stub_signals_for_missing,
+)
+from ..entities.scan import scan_github_mentions
+from ..entities.store import EntityStore
+
+
+_PROJECT_TYPE = "github_project"
+_USER_TYPE = "github_user"
+_FETCH_SOURCE = "github_rest"
+_DEFAULT_MAX_AGE_DAYS = 30
+# GitHub allows ~50 req/sec authenticated; we go slower to be polite
+# and to dodge any secondary rate limits.
+_PER_CALL_SLEEP_S = 0.05
+
+
+def _resolve_token(cli_arg: str | None, vault_dir: Path) -> str | None:
+    if cli_arg:
+        return cli_arg.strip()
+    env = os.environ.get("GITHUB_TOKEN")
+    if env:
+        return env.strip()
+    keyfile = vault_dir / "60-Logs" / ".github-token"
+    if keyfile.exists():
+        for line in keyfile.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line and not line.startswith("#"):
+                return line
+    return None
+
+
+def _is_stale(last_fetched_at: str, max_age_days: int) -> bool:
+    try:
+        dt = datetime.fromisoformat(last_fetched_at)
+    except ValueError:
+        return True
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return (datetime.now(timezone.utc) - dt) > timedelta(days=max_age_days)
+
+
+def _backfill_users(
+    *,
+    store: EntityStore,
+    usernames: list[tuple[str, int]],
+    token: str | None,
+    max_age_days: int,
+    force: bool,
+    max_handles: int | None,
+) -> tuple[int, int, int, int]:
+    """Returns (n_ok, n_not_found, n_error, n_cached)."""
+    to_fetch: list[tuple[str, int]] = []
+    cached = 0
+    for login, mentions in usernames:
+        existing = store.get(_USER_TYPE, login)
+        if existing and not force:
+            if not _is_stale(existing.last_fetched_at, max_age_days):
+                cached += 1
+                continue
+        to_fetch.append((login, mentions))
+    if max_handles is not None:
+        to_fetch = to_fetch[:max_handles]
+
+    print(f"  users: {len(usernames)} discovered, {cached} fresh-cached, "
+          f"{len(to_fetch)} to fetch")
+    if not to_fetch:
+        return 0, 0, 0, cached
+
+    n_ok = n_nf = n_err = 0
+    for i, (login, mentions) in enumerate(to_fetch, 1):
+        result = fetch_user(login, token=token)
+        if result.status == "ok" and result.payload is not None:
+            authority, signals = derive_user_signals(result.payload)
+            signals["mention_count_in_vault"] = mentions
+            store.upsert(
+                entity_type=_USER_TYPE, identity_key=login,
+                canonical_name=result.payload.get("name") or login,
+                signals=signals, derived_authority=authority,
+                fetch_source=_FETCH_SOURCE,
+            )
+            n_ok += 1
+        elif result.status == "not_found":
+            store.upsert(
+                entity_type=_USER_TYPE, identity_key=login,
+                canonical_name=None,
+                signals=stub_signals_for_missing(login, "user", result.error or ""),
+                derived_authority=None, fetch_source=_FETCH_SOURCE,
+            )
+            n_nf += 1
+        else:
+            print(f"    [error] {login}: {result.error}", file=sys.stderr)
+            n_err += 1
+        if i % 25 == 0 or i == len(to_fetch):
+            print(f"    users progress: {i:>4}/{len(to_fetch)}  "
+                  f"ok={n_ok} not_found={n_nf} error={n_err}", flush=True)
+        time.sleep(_PER_CALL_SLEEP_S)
+    return n_ok, n_nf, n_err, cached
+
+
+def _backfill_projects(
+    *,
+    store: EntityStore,
+    repos: list[tuple[str, str, int]],   # (owner, repo, mention_count)
+    token: str | None,
+    max_age_days: int,
+    force: bool,
+    max_handles: int | None,
+) -> tuple[int, int, int, int]:
+    to_fetch: list[tuple[str, str, int]] = []
+    cached = 0
+    for owner, repo, mentions in repos:
+        identity = f"{owner}/{repo}"
+        existing = store.get(_PROJECT_TYPE, identity)
+        if existing and not force:
+            if not _is_stale(existing.last_fetched_at, max_age_days):
+                cached += 1
+                continue
+        to_fetch.append((owner, repo, mentions))
+    if max_handles is not None:
+        to_fetch = to_fetch[:max_handles]
+
+    print(f"  projects: {len(repos)} discovered, {cached} fresh-cached, "
+          f"{len(to_fetch)} to fetch")
+    if not to_fetch:
+        return 0, 0, 0, cached
+
+    n_ok = n_nf = n_err = 0
+    for i, (owner, repo, mentions) in enumerate(to_fetch, 1):
+        identity = f"{owner}/{repo}"
+        result = fetch_repo(owner, repo, token=token)
+        if result.status == "ok" and result.payload is not None:
+            owner_login = (result.payload.get("owner") or {}).get("login") or owner
+            owner_entity = store.get(_USER_TYPE, owner_login.lower())
+            owner_authority = (
+                owner_entity.derived_authority if owner_entity is not None else 0.0
+            ) or 0.0
+            authority, signals = derive_project_signals(
+                result.payload, owner_authority_0_75=owner_authority,
+            )
+            signals["mention_count_in_vault"] = mentions
+            store.upsert(
+                entity_type=_PROJECT_TYPE, identity_key=identity,
+                canonical_name=result.payload.get("full_name") or identity,
+                signals=signals, derived_authority=authority,
+                fetch_source=_FETCH_SOURCE,
+            )
+            n_ok += 1
+        elif result.status == "not_found":
+            store.upsert(
+                entity_type=_PROJECT_TYPE, identity_key=identity,
+                canonical_name=None,
+                signals=stub_signals_for_missing(identity, "project", result.error or ""),
+                derived_authority=None, fetch_source=_FETCH_SOURCE,
+            )
+            n_nf += 1
+        else:
+            print(f"    [error] {identity}: {result.error}", file=sys.stderr)
+            n_err += 1
+        if i % 25 == 0 or i == len(to_fetch):
+            print(f"    projects progress: {i:>4}/{len(to_fetch)}  "
+                  f"ok={n_ok} not_found={n_nf} error={n_err}", flush=True)
+        time.sleep(_PER_CALL_SLEEP_S)
+    return n_ok, n_nf, n_err, cached
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Backfill github_project + github_user entities",
+    )
+    parser.add_argument("--vault-dir", type=Path, default=Path.cwd())
+    parser.add_argument("--token", default=None,
+                        help="GitHub PAT (else env GITHUB_TOKEN or keyfile)")
+    parser.add_argument("--kind", choices=["both", "users", "projects"],
+                        default="both",
+                        help="Which entity type(s) to backfill (default both)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Plan + rate-limit budget only, no API calls")
+    parser.add_argument("--max-handles", type=int, default=None,
+                        help="Cap fetches per kind (debug / partial run)")
+    parser.add_argument("--max-age-days", type=int, default=_DEFAULT_MAX_AGE_DAYS,
+                        help="Re-fetch entities older than this many days")
+    parser.add_argument("--force", action="store_true",
+                        help="Re-fetch every entity, even if cached + fresh")
+    args = parser.parse_args(argv)
+
+    vault = args.vault_dir.resolve()
+    if not vault.is_dir():
+        print(f"vault not found: {vault}", file=sys.stderr)
+        return 2
+
+    db_path = vault / "60-Logs" / "knowledge.db"
+    store = EntityStore(db_path=db_path)
+
+    # ---- discover entities -------------------------------------------------
+
+    print("scanning vault...")
+    mentions = scan_github_mentions(vault)
+    repos: list[tuple[str, str, int]] = [
+        (m.owner, m.repo, m.mention_count)
+        for m in mentions if m.repo is not None
+    ]
+    # Owners come from the union of (a) all repo owners and (b) any
+    # github.com/<owner> URLs that didn't carry a /repo segment.
+    owner_counts: dict[str, int] = {}
+    for owner, _repo, c in repos:
+        owner_counts[owner] = owner_counts.get(owner, 0) + c
+    users: list[tuple[str, int]] = sorted(
+        owner_counts.items(), key=lambda kv: -kv[1],
+    )
+
+    print(f"vault: {vault}")
+    print(f"db:    {db_path}")
+    print(f"discovered: {len(repos)} unique repos, {len(users)} unique owners")
+
+    # ---- preflight summary -------------------------------------------------
+
+    if args.dry_run:
+        print("\n--dry-run set; no API calls, no DB writes")
+        print(f"would fetch: kind={args.kind}")
+        if args.kind in {"both", "users"}:
+            print(f"  users:    {len(users)} calls (cost $0)")
+        if args.kind in {"both", "projects"}:
+            print(f"  projects: {len(repos)} calls (cost $0)")
+        return 0
+
+    token = _resolve_token(args.token, vault)
+    if not token:
+        print("warning: no GITHUB_TOKEN; falling back to 60 req/hr unauthenticated.",
+              file=sys.stderr)
+        print("         For >60 entities, set --token or env GITHUB_TOKEN.",
+              file=sys.stderr)
+
+    # ---- run pass(es) ------------------------------------------------------
+
+    totals = {"ok": 0, "not_found": 0, "error": 0, "cached": 0}
+
+    if args.kind in {"both", "users"}:
+        print("\n=== users pass ===")
+        ok, nf, err, cached = _backfill_users(
+            store=store, usernames=users, token=token,
+            max_age_days=args.max_age_days, force=args.force,
+            max_handles=args.max_handles,
+        )
+        totals["ok"] += ok
+        totals["not_found"] += nf
+        totals["error"] += err
+        totals["cached"] += cached
+
+    if args.kind in {"both", "projects"}:
+        print("\n=== projects pass ===")
+        ok, nf, err, cached = _backfill_projects(
+            store=store, repos=repos, token=token,
+            max_age_days=args.max_age_days, force=args.force,
+            max_handles=args.max_handles,
+        )
+        totals["ok"] += ok
+        totals["not_found"] += nf
+        totals["error"] += err
+        totals["cached"] += cached
+
+    print()
+    print("=== Summary ===")
+    print(f"  ok:        {totals['ok']:>5}")
+    print(f"  not_found: {totals['not_found']:>5}")
+    print(f"  error:     {totals['error']:>5}")
+    print(f"  cached:    {totals['cached']:>5}")
+    print(f"  cost:      ${PRICE_PER_CALL_USD * (totals['ok'] + totals['not_found']):.4f}")
+
+    print("\nTop 10 projects by authority:")
+    for e in store.list_by_type(_PROJECT_TYPE, limit=10):
+        if e.derived_authority is None:
+            continue
+        print(f"  {e.derived_authority:.2f}  {e.identity_key:<35} "
+              f"{(e.canonical_name or '')[:40]}")
+
+    print("\nTop 10 users/orgs by authority:")
+    for e in store.list_by_type(_USER_TYPE, limit=10):
+        if e.derived_authority is None:
+            continue
+        print(f"  {e.derived_authority:.2f}  {e.identity_key:<25} "
+              f"{(e.canonical_name or '')[:40]}")
+
+    return 0 if totals["error"] == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ovp_pipeline/commands/backfill_twitter_authors.py
+++ b/src/ovp_pipeline/commands/backfill_twitter_authors.py
@@ -1,0 +1,234 @@
+"""ovp-backfill-twitter-authors — populate entities for X/Twitter handles.
+
+Scans the vault for X handles, calls twitterapi.io for each one not
+already cached (or stale), persists the result into the ``entities``
+table, and prints a progress + cost summary.
+
+Usage::
+
+    ovp-backfill-twitter-authors --vault-dir ~/Documents/ovp-vault
+    ovp-backfill-twitter-authors --vault-dir ~/Documents/ovp-vault --dry-run
+    ovp-backfill-twitter-authors --only karpathy --force
+
+Authentication
+--------------
+
+API key is read in this order, first match wins:
+  1. ``--api-key`` CLI arg
+  2. ``TWITTERAPI_IO_KEY`` environment variable
+  3. First non-comment line of ``<vault-dir>/60-Logs/.twitterapi-io-key``
+
+Cost
+----
+
+Single-user calls cost $0.00018 each.  The CLI tracks running cost
+and prints it in the summary; pass ``--max-handles N`` to cap the
+spend if you're nervous.
+
+Idempotence
+-----------
+
+Handles already in ``entities`` are skipped unless their
+``last_fetched_at`` is older than ``--max-age-days`` (default 30).
+``--force`` re-fetches everything regardless.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from ..entities.scan import scan_twitter_handles
+from ..entities.store import EntityStore
+from ..entities.twitter_backfill import (
+    PRICE_PER_CALL_USD,
+    derive_authority_from_payload,
+    fetch_user_info,
+    stub_signals_for_missing,
+)
+
+
+_ENTITY_TYPE = "twitter_author"
+_FETCH_SOURCE = "twitterapi.io"
+_DEFAULT_MAX_AGE_DAYS = 30
+# Tiny pause between calls to be polite even if rate limit isn't hit.
+_PER_CALL_SLEEP_S = 0.1
+
+
+def _resolve_api_key(cli_arg: str | None, vault_dir: Path) -> str | None:
+    if cli_arg:
+        return cli_arg.strip()
+    env = os.environ.get("TWITTERAPI_IO_KEY")
+    if env:
+        return env.strip()
+    keyfile = vault_dir / "60-Logs" / ".twitterapi-io-key"
+    if keyfile.exists():
+        for line in keyfile.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line and not line.startswith("#"):
+                return line
+    return None
+
+
+def _is_stale(last_fetched_at: str, max_age_days: int) -> bool:
+    try:
+        dt = datetime.fromisoformat(last_fetched_at)
+    except ValueError:
+        return True
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return (datetime.now(timezone.utc) - dt) > timedelta(days=max_age_days)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Backfill twitter_author entities via twitterapi.io",
+    )
+    parser.add_argument("--vault-dir", type=Path, default=Path.cwd())
+    parser.add_argument("--api-key", default=None,
+                        help="twitterapi.io API key (else env / keyfile)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Plan + cost only, no API calls, no DB writes")
+    parser.add_argument("--max-handles", type=int, default=None,
+                        help="Stop after N new fetches (cost cap)")
+    parser.add_argument("--max-age-days", type=int, default=_DEFAULT_MAX_AGE_DAYS,
+                        help="Re-fetch entities older than this many days")
+    parser.add_argument("--force", action="store_true",
+                        help="Re-fetch every handle, even if cached + fresh")
+    parser.add_argument("--only", default=None,
+                        help="Only fetch this single handle (debug)")
+    parser.add_argument("--min-mentions", type=int, default=1,
+                        help="Skip handles with fewer than N total mentions "
+                             "(default 1 = all)")
+    args = parser.parse_args(argv)
+
+    vault = args.vault_dir.resolve()
+    if not vault.is_dir():
+        print(f"vault not found: {vault}", file=sys.stderr)
+        return 2
+
+    db_path = vault / "60-Logs" / "knowledge.db"
+    store = EntityStore(db_path=db_path)
+
+    # ---- discover handles --------------------------------------------------
+
+    if args.only:
+        target_handles = [(args.only.lower().lstrip("@"), 0)]
+    else:
+        mentions = scan_twitter_handles(vault)
+        target_handles = [
+            (m.handle, m.mention_count)
+            for m in mentions
+            if m.mention_count >= args.min_mentions
+        ]
+
+    if not target_handles:
+        print("no handles to process")
+        return 0
+
+    # ---- filter against cache ---------------------------------------------
+
+    to_fetch: list[tuple[str, int]] = []
+    cached_fresh: int = 0
+    for handle, mentions in target_handles:
+        existing = store.get(_ENTITY_TYPE, handle)
+        if existing and not args.force:
+            if not _is_stale(existing.last_fetched_at, args.max_age_days):
+                cached_fresh += 1
+                continue
+        to_fetch.append((handle, mentions))
+
+    if args.max_handles is not None:
+        to_fetch = to_fetch[: args.max_handles]
+
+    # ---- preflight summary -------------------------------------------------
+
+    cost_estimate = len(to_fetch) * PRICE_PER_CALL_USD
+    print(f"vault:                {vault}")
+    print(f"db:                   {db_path}")
+    print(f"handles discovered:   {len(target_handles)}")
+    print(f"already cached fresh: {cached_fresh}")
+    print(f"to fetch this run:    {len(to_fetch)}")
+    print(f"estimated cost:       ${cost_estimate:.4f}  "
+          f"(at ${PRICE_PER_CALL_USD}/call)")
+
+    if args.dry_run:
+        print("\n--dry-run set; not calling API or writing DB")
+        return 0
+
+    if not to_fetch:
+        print("\nnothing to do — all handles cached fresh")
+        return 0
+
+    # ---- auth --------------------------------------------------------------
+
+    api_key = _resolve_api_key(args.api_key, vault)
+    if not api_key:
+        print("error: no API key found (--api-key, TWITTERAPI_IO_KEY env, "
+              "or 60-Logs/.twitterapi-io-key file)", file=sys.stderr)
+        return 2
+
+    # ---- fetch loop --------------------------------------------------------
+
+    n_ok = n_not_found = n_error = 0
+    for i, (handle, mentions) in enumerate(to_fetch, 1):
+        result = fetch_user_info(handle, api_key=api_key)
+        if result.status == "ok" and result.payload is not None:
+            authority, signals = derive_authority_from_payload(result.payload)
+            signals["mention_count_in_vault"] = mentions
+            store.upsert(
+                entity_type=_ENTITY_TYPE,
+                identity_key=handle,
+                canonical_name=result.payload.get("name"),
+                signals=signals,
+                derived_authority=authority,
+                fetch_source=_FETCH_SOURCE,
+            )
+            n_ok += 1
+        elif result.status == "not_found":
+            store.upsert(
+                entity_type=_ENTITY_TYPE,
+                identity_key=handle,
+                canonical_name=None,
+                signals=stub_signals_for_missing(handle, result.error or ""),
+                derived_authority=None,
+                fetch_source=_FETCH_SOURCE,
+            )
+            n_not_found += 1
+        else:
+            print(f"  [error] @{handle}: {result.error}", file=sys.stderr)
+            n_error += 1
+
+        if i % 25 == 0 or i == len(to_fetch):
+            done = n_ok + n_not_found + n_error
+            print(f"  progress: {done:>4}/{len(to_fetch)}  "
+                  f"ok={n_ok} not_found={n_not_found} error={n_error}")
+        time.sleep(_PER_CALL_SLEEP_S)
+
+    actual_cost = (n_ok + n_not_found + n_error) * PRICE_PER_CALL_USD
+
+    print()
+    print("=== Summary ===")
+    print(f"  ok:        {n_ok:>5}")
+    print(f"  not_found: {n_not_found:>5}")
+    print(f"  error:     {n_error:>5}")
+    print(f"  cached:    {cached_fresh:>5}  (skipped — already fresh)")
+    print(f"  cost:      ${actual_cost:.4f}  (actual, including failed calls)")
+    print()
+    print("Top 10 by partial authority:")
+    top = store.list_by_type(_ENTITY_TYPE, limit=10)
+    for e in top:
+        if e.derived_authority is None:
+            continue
+        print(f"  {e.derived_authority:.2f}  @{e.identity_key:<25} "
+              f"{(e.canonical_name or '')[:40]}")
+
+    return 0 if n_error == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ovp_pipeline/commands/merge_identities.py
+++ b/src/ovp_pipeline/commands/merge_identities.py
@@ -1,0 +1,122 @@
+"""ovp-merge-identities — collapse twitter_author + github_user into person.
+
+Three modes:
+
+  --dry-run            list every candidate (auto + review), no writes
+  (default)            apply auto candidates only, print review queue
+  --include-fuzzy      also apply fuzzy candidates (DANGEROUS — review
+                       the dry-run output first; mostly here for tests)
+
+The merge is read-only against twitter_author / github_user — they
+stay untouched.  We only INSERT/UPDATE rows in the ``entities`` table
+where ``entity_type='person'``.
+
+Re-running is safe: each apply UPSERTs by ``(person, twitter_handle)``,
+so a person row that already exists is just refreshed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from ..entities.identity_merge import (
+    apply_merge,
+    find_merge_candidates,
+)
+from ..entities.store import EntityStore
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Merge twitter_author + github_user into person entities",
+    )
+    parser.add_argument("--vault-dir", type=Path, default=Path.cwd())
+    parser.add_argument("--dry-run", action="store_true",
+                        help="List candidates without writing person entities")
+    parser.add_argument("--include-fuzzy", action="store_true",
+                        help="Also apply fuzzy (Levenshtein) candidates — "
+                             "review the dry-run output first")
+    args = parser.parse_args(argv)
+
+    vault = args.vault_dir.resolve()
+    db_path = vault / "60-Logs" / "knowledge.db"
+    if not db_path.exists():
+        print(f"knowledge.db not found at {db_path}", file=sys.stderr)
+        return 2
+
+    store = EntityStore(db_path=db_path)
+    candidates = find_merge_candidates(store)
+
+    by_method = {"self_reported": 0, "exact_handle": 0, "fuzzy": 0}
+    for c in candidates:
+        by_method[c.method] += 1
+
+    print(f"vault: {vault}")
+    print(f"db:    {db_path}")
+    print(f"candidates discovered: {len(candidates)}")
+    print(f"  self_reported (auto):  {by_method['self_reported']:>4}")
+    print(f"  exact_handle (review): {by_method['exact_handle']:>4}")
+    print(f"  fuzzy (review):        {by_method['fuzzy']:>4}")
+    print()
+
+    if args.dry_run:
+        print("=== self_reported (would auto-apply) ===")
+        for c in candidates:
+            if c.method == "self_reported":
+                print(f"  {c.confidence:.2f}  github:{c.github_login:<25} "
+                      f"↔ twitter:@{c.twitter_handle}")
+        print()
+        print("=== exact_handle (review queue) ===")
+        for c in candidates:
+            if c.method == "exact_handle":
+                print(f"  {c.confidence:.2f}  github:{c.github_login:<25} "
+                      f"↔ twitter:@{c.twitter_handle}")
+        print()
+        print("=== fuzzy (review queue, top 20) ===")
+        fuzzy = [c for c in candidates if c.method == "fuzzy"]
+        fuzzy.sort(key=lambda c: -c.confidence)
+        for c in fuzzy[:20]:
+            print(f"  {c.confidence:.2f}  github:{c.github_login:<25} "
+                  f"↔ twitter:@{c.twitter_handle:<25}  ({c.rationale})")
+        print()
+        print("--dry-run set; not writing.  "
+              "Re-run without --dry-run to apply self_reported merges.")
+        return 0
+
+    # Apply.  Fuzzy and exact_handle stay manual unless --include-fuzzy.
+    applied = 0
+    skipped = 0
+    for c in candidates:
+        if c.method == "self_reported" or (
+            args.include_fuzzy and c.method in {"exact_handle", "fuzzy"}
+        ):
+            person = apply_merge(store, c)
+            if person is not None:
+                applied += 1
+            else:
+                skipped += 1
+        else:
+            skipped += 1
+
+    print(f"applied: {applied}  (person entities inserted/updated)")
+    print(f"skipped: {skipped}  (review queue + missing-side cases)")
+    print()
+    print("Top 10 person entities by authority:")
+    for e in store.list_by_type("person", limit=10):
+        if e.derived_authority is None:
+            continue
+        links = e.signals.get("links", [])
+        link_summary = " + ".join(
+            f"{ln['entity_type'].split('_')[0]}:{ln['identity_key']}"
+            for ln in links
+        )
+        print(f"  {e.derived_authority:.2f}  {e.identity_key:<25} "
+              f"({link_summary})")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ovp_pipeline/entities/__init__.py
+++ b/src/ovp_pipeline/entities/__init__.py
@@ -1,0 +1,32 @@
+"""Entity layer — first-class Author/Project records that signals attach to.
+
+Until PR-E1 every author/project signal lived only in the per-clipping
+frontmatter.  That worked when each clipping carried full data, but
+breaks down when:
+
+  * the same handle appears in 50 clippings (denormalized waste)
+  * the clipping was captured before the new adapter (no data at all)
+  * we want to accumulate signal across multiple captures of the same
+    author (e.g. "we've bookmarked this person 12 times")
+
+This package introduces an ``entities`` table indexed by
+``(entity_type, identity_key)`` that holds the merged view.  Authority
+scoring will (in PR-E3) read from here instead of frontmatter.
+
+Entity types currently supported:
+  * ``twitter_author``  — populated by ovp-backfill-twitter-authors
+  * (future) ``github_project`` and ``github_user`` in PR-E2
+  * (future) ``wechat_mp``, ``substack_publication`` in later PRs
+"""
+
+from .store import (
+    Entity,
+    EntityStore,
+    init_schema,
+)
+
+__all__ = [
+    "Entity",
+    "EntityStore",
+    "init_schema",
+]

--- a/src/ovp_pipeline/entities/github_backfill.py
+++ b/src/ovp_pipeline/entities/github_backfill.py
@@ -1,0 +1,453 @@
+"""GitHub REST API → entities (github_project + github_user).
+
+Two endpoints, two entity types:
+
+  * ``GET /repos/{owner}/{repo}``  → ``github_project``
+  * ``GET /users/{username}``      → ``github_user``
+
+The existing ``source_signals/github.py`` (T2 SignalProvider) computes
+a single 0-1 score from /repos for ingest-time use.  This module is
+broader: it persists the full payload + a multi-dimension authority
+score for use across the entity layer.  The two will converge in
+PR-E3 when SignalProvider starts reading from the entity table; for
+now they coexist.
+
+Auth & rate limit
+-----------------
+
+GitHub's REST API is **free** but rate-limited.  Unauthenticated:
+60 req/hour per IP.  With a personal access token (no scopes
+required for public-repo reads): 5000 req/hour.
+
+For the OVP vault (~281 unique repos+owners) we need a PAT — the
+unauth limit would force a 5-hour stagger.  Pass the token via
+``--token``, env ``GITHUB_TOKEN``, or ``60-Logs/.github-token``.
+
+Score formulas
+--------------
+
+``github_project`` (max 100 → derived_authority ≤ 1.0):
+    stars        max 30  (logarithmic bands)
+    forks        max 10  (log bands)
+    recency      max 15  (active <30d full credit, decays to 0 at 3y)
+    age          max 10  (mature wins, but cap so brand-new can score)
+    has_license  max  5
+    not_archived max  5  (archived projects lose this)
+    not_a_fork   max  5  (originals weighted over mirrors)
+    owner_lift   max 20  (filled in once github_user is known)
+
+``github_user`` (max 75 → derived_authority ≤ 0.75):
+    followers       max 25
+    public_repos    max 10
+    age             max 10
+    has_bio         max  5
+    has_blog        max  5
+    has_company     max 10  (affiliation signal — same logic as Twitter)
+    is_organization max 10  (Org accounts are aggregator-of-record)
+
+The 0.75 ceiling on github_user reserves the 0.75-1.0 band for
+explicit human curation (anthropic, openai etc. via
+``domain_overrides.yaml``) — same pattern as the twitter backfill's
+0.70 ceiling.
+
+Failure handling
+----------------
+
+  * 401/403   → if rate limit, surface clearly; if auth, abort
+  * 404       → entity stub (deleted/renamed), no retry
+  * 429/secondary rate limit → exponential backoff
+  * network   → retry up to 3 times then mark error
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+logger = logging.getLogger(__name__)
+
+_API_BASE = "https://api.github.com"
+_USER_AGENT = "ovp-backfill/1.0 (https://github.com/fakechris/obsidian_vault_pipeline)"
+_DEFAULT_TIMEOUT_S = 15.0
+_MAX_RETRIES = 3
+_BACKOFF_BASE_S = 1.5
+
+# GitHub REST is free; we track no monetary cost, only rate-limit budget.
+PRICE_PER_CALL_USD = 0.0
+
+
+# ---------------------------------------------------------------------------
+# Fetch
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class FetchResult:
+    """Outcome of a single GitHub REST call."""
+
+    identity: str           # 'owner/repo' for projects, 'login' for users
+    kind: Literal["project", "user"]
+    status: str             # "ok" | "not_found" | "error"
+    payload: dict[str, Any] | None
+    error: str | None
+
+
+def _request(
+    path: str, *, token: str | None, timeout_s: float = _DEFAULT_TIMEOUT_S,
+) -> tuple[int, dict[str, Any] | str]:
+    """Single GET, returns (status_code, parsed_or_raw)."""
+    url = f"{_API_BASE}{path}"
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": _USER_AGENT,
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout_s) as resp:
+            body = resp.read().decode("utf-8")
+        try:
+            return 200, json.loads(body)
+        except json.JSONDecodeError:
+            return 200, body
+    except urllib.error.HTTPError as e:
+        try:
+            err_body = json.loads(e.read().decode("utf-8"))
+        except Exception:  # noqa: BLE001 - best-effort error decoding
+            err_body = {"message": str(e)}
+        return e.code, err_body
+    except (urllib.error.URLError, TimeoutError, OSError) as e:
+        return -1, {"message": str(e)}
+
+
+def _retryable_fetch(
+    path: str, *, token: str | None, identity: str, kind: str,
+) -> FetchResult:
+    last_err = "unknown"
+    for attempt in range(_MAX_RETRIES):
+        code, body = _request(path, token=token)
+        if code == 200 and isinstance(body, dict):
+            return FetchResult(identity, kind, "ok", body, None)
+        if code == 404:
+            msg = (body or {}).get("message", "not found") if isinstance(body, dict) else "not found"
+            return FetchResult(identity, kind, "not_found", None, msg)
+        if code in (401, 403):
+            # Distinguish auth failure from rate limiting by message body.
+            msg = (body or {}).get("message", "") if isinstance(body, dict) else ""
+            if "rate limit" in msg.lower() or "abuse" in msg.lower():
+                wait = _BACKOFF_BASE_S * (2 ** attempt)
+                logger.info("rate limited on %s, sleeping %.1fs", identity, wait)
+                time.sleep(wait)
+                last_err = f"HTTP {code} (rate limit)"
+                continue
+            return FetchResult(
+                identity, kind, "error", None,
+                f"auth failed: HTTP {code} ({msg or 'check token'})",
+            )
+        if code == 429:
+            wait = _BACKOFF_BASE_S * (2 ** attempt)
+            time.sleep(wait)
+            last_err = "HTTP 429"
+            continue
+        # transport / 5xx
+        last_err = f"HTTP {code}: {body}" if code > 0 else f"network: {body}"
+        time.sleep(_BACKOFF_BASE_S * (2 ** attempt))
+    return FetchResult(identity, kind, "error", None, last_err)
+
+
+def fetch_repo(
+    owner: str, repo: str, *, token: str | None = None,
+) -> FetchResult:
+    if not owner or not repo:
+        return FetchResult(f"{owner}/{repo}", "project", "error", None,
+                           "missing owner or repo")
+    return _retryable_fetch(
+        f"/repos/{urllib.parse.quote(owner)}/{urllib.parse.quote(repo)}",
+        token=token, identity=f"{owner}/{repo}", kind="project",
+    )
+
+
+def fetch_user(
+    username: str, *, token: str | None = None,
+) -> FetchResult:
+    if not username:
+        return FetchResult("", "user", "error", None, "missing username")
+    return _retryable_fetch(
+        f"/users/{urllib.parse.quote(username)}",
+        token=token, identity=username, kind="user",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Score derivation
+# ---------------------------------------------------------------------------
+
+
+def _parse_iso(ts: str | None) -> datetime | None:
+    if not ts:
+        return None
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _years_since(ts: str | None) -> float:
+    dt = _parse_iso(ts)
+    if dt is None:
+        return 0.0
+    return max((datetime.now(timezone.utc) - dt).days / 365.25, 0.0)
+
+
+def _days_since(ts: str | None) -> float:
+    dt = _parse_iso(ts)
+    if dt is None:
+        return float("inf")
+    return max((datetime.now(timezone.utc) - dt).days, 0.0)
+
+
+def compute_project_authority(
+    payload: dict[str, Any],
+    *,
+    owner_lift: int = 0,
+) -> tuple[int, dict[str, int]]:
+    """Score one repo (0-100).
+
+    ``owner_lift`` is the github_user's contribution (0-20).  Pass 0
+    when the user hasn't been fetched yet — the project still gets
+    a useful score from its own intrinsic signals.
+    """
+    breakdown: dict[str, int] = {}
+
+    # 1. stars (max 30) — log10 bands so 100k-star repos don't crowd
+    # out 1k-star repos that are still meaningful.
+    stars = int(payload.get("stargazers_count") or 0)
+    if stars >= 50_000:
+        breakdown["stars"] = 30
+    elif stars >= 10_000:
+        breakdown["stars"] = 25
+    elif stars >= 1_000:
+        breakdown["stars"] = 20
+    elif stars >= 100:
+        breakdown["stars"] = 12
+    elif stars >= 10:
+        breakdown["stars"] = 5
+    else:
+        breakdown["stars"] = 0
+
+    # 2. forks (max 10)
+    forks = int(payload.get("forks_count") or 0)
+    if forks >= 1_000:
+        breakdown["forks"] = 10
+    elif forks >= 100:
+        breakdown["forks"] = 7
+    elif forks >= 10:
+        breakdown["forks"] = 3
+    else:
+        breakdown["forks"] = 0
+
+    # 3. recency (max 15) — last push window
+    pushed_at = payload.get("pushed_at") or payload.get("updated_at")
+    days = _days_since(pushed_at)
+    if days <= 30:
+        breakdown["recency"] = 15
+    elif days <= 180:
+        breakdown["recency"] = 10
+    elif days <= 365:
+        breakdown["recency"] = 5
+    elif days <= 365 * 3:
+        breakdown["recency"] = 2
+    else:
+        breakdown["recency"] = 0
+
+    # 4. age (max 10) — mature repos earn trust
+    years = _years_since(payload.get("created_at"))
+    if years >= 5:
+        breakdown["age"] = 10
+    elif years >= 2:
+        breakdown["age"] = 6
+    elif years >= 1:
+        breakdown["age"] = 3
+    else:
+        breakdown["age"] = 0
+
+    # 5. license (max 5) — legitimate OSS signal
+    license_obj = payload.get("license")
+    if isinstance(license_obj, dict) and license_obj.get("spdx_id"):
+        breakdown["license"] = 5
+    else:
+        breakdown["license"] = 0
+
+    # 6. not archived (max 5)
+    breakdown["not_archived"] = 0 if payload.get("archived") else 5
+
+    # 7. not a fork (max 5) — originals over mirrors
+    breakdown["not_fork"] = 0 if payload.get("fork") else 5
+
+    # 8. owner lift (max 20) — provided by caller after fetching user
+    breakdown["owner_lift"] = max(0, min(20, owner_lift))
+
+    score = max(0, sum(breakdown.values()))
+    return score, breakdown
+
+
+def compute_user_authority(payload: dict[str, Any]) -> tuple[int, dict[str, int]]:
+    """Score one GitHub user / org (0-75)."""
+    breakdown: dict[str, int] = {}
+
+    # 1. followers (max 25)
+    followers = int(payload.get("followers") or 0)
+    if followers >= 10_000:
+        breakdown["followers"] = 25
+    elif followers >= 1_000:
+        breakdown["followers"] = 20
+    elif followers >= 100:
+        breakdown["followers"] = 12
+    elif followers >= 10:
+        breakdown["followers"] = 5
+    else:
+        breakdown["followers"] = 0
+
+    # 2. public_repos (max 10) — output volume
+    repos = int(payload.get("public_repos") or 0)
+    if repos >= 100:
+        breakdown["public_repos"] = 10
+    elif repos >= 30:
+        breakdown["public_repos"] = 7
+    elif repos >= 5:
+        breakdown["public_repos"] = 3
+    else:
+        breakdown["public_repos"] = 0
+
+    # 3. age (max 10)
+    years = _years_since(payload.get("created_at"))
+    if years >= 7:
+        breakdown["age"] = 10
+    elif years >= 3:
+        breakdown["age"] = 6
+    elif years >= 1:
+        breakdown["age"] = 3
+    else:
+        breakdown["age"] = 0
+
+    # 4. has bio (max 5) — populated profile is a humanity / care signal
+    breakdown["has_bio"] = 5 if (payload.get("bio") or "").strip() else 0
+
+    # 5. has blog/url (max 5)
+    breakdown["has_blog"] = 5 if (payload.get("blog") or "").strip() else 0
+
+    # 6. has company affiliation (max 10)
+    breakdown["has_company"] = 10 if (payload.get("company") or "").strip() else 0
+
+    # 7. account type Organization (max 10)
+    breakdown["is_organization"] = 10 if (
+        (payload.get("type") or "").lower() == "organization"
+    ) else 0
+
+    score = max(0, sum(breakdown.values()))
+    return score, breakdown
+
+
+def derive_project_signals(
+    payload: dict[str, Any], *, owner_authority_0_75: float = 0.0,
+) -> tuple[float, dict[str, Any]]:
+    """High-level: compute project authority + signals dict to persist.
+
+    ``owner_authority_0_75`` is the github_user's derived_authority on
+    a 0-0.75 scale; we map it to a 0-20 contribution to the project.
+    Pass 0.0 when the owner hasn't been fetched yet.
+    """
+    owner_lift = int(round(20 * owner_authority_0_75 / 0.75)) if owner_authority_0_75 > 0 else 0
+    score, breakdown = compute_project_authority(payload, owner_lift=owner_lift)
+    authority = round(score / 100.0, 4)
+
+    signals = {
+        "owner_login": (payload.get("owner") or {}).get("login"),
+        "name": payload.get("name"),
+        "full_name": payload.get("full_name"),
+        "description": payload.get("description"),
+        "html_url": payload.get("html_url"),
+        "homepage": payload.get("homepage"),
+        "language": payload.get("language"),
+        "stargazers_count": payload.get("stargazers_count"),
+        "forks_count": payload.get("forks_count"),
+        "watchers_count": payload.get("watchers_count"),
+        "subscribers_count": payload.get("subscribers_count"),
+        "open_issues_count": payload.get("open_issues_count"),
+        "created_at": payload.get("created_at"),
+        "pushed_at": payload.get("pushed_at"),
+        "updated_at": payload.get("updated_at"),
+        "archived": payload.get("archived"),
+        "fork": payload.get("fork"),
+        "disabled": payload.get("disabled"),
+        "license_spdx": (payload.get("license") or {}).get("spdx_id")
+        if isinstance(payload.get("license"), dict) else None,
+        "default_branch": payload.get("default_branch"),
+        "topics": payload.get("topics"),
+        # derived
+        "project_authority_score": score,
+        "weight_breakdown": breakdown,
+        "missing_dimensions": [
+            "commit_velocity_30d",       # would need /commits or /stats endpoints
+            "contributor_count",         # would need /contributors
+            "issue_resolution_velocity", # would need /issues
+            "release_cadence",           # would need /releases
+            "ci_status",                 # would need /actions
+        ],
+    }
+    return authority, signals
+
+
+def derive_user_signals(payload: dict[str, Any]) -> tuple[float, dict[str, Any]]:
+    """High-level: compute user/org authority + signals dict to persist."""
+    score, breakdown = compute_user_authority(payload)
+    # 75 is the theoretical max; we normalize to 0-1 via /100, leaving
+    # 0.75-1.0 for explicit human curation (e.g. canonical orgs).
+    authority = round(score / 100.0, 4)
+
+    signals = {
+        "login": payload.get("login"),
+        "name": payload.get("name"),
+        "id": payload.get("id"),
+        "type": payload.get("type"),                # User | Organization
+        "company": payload.get("company"),
+        "blog": payload.get("blog"),
+        "location": payload.get("location"),
+        "email": payload.get("email"),
+        "bio": payload.get("bio"),
+        "twitter_username": payload.get("twitter_username"),  # ⚡ cross-platform link!
+        "public_repos": payload.get("public_repos"),
+        "public_gists": payload.get("public_gists"),
+        "followers": payload.get("followers"),
+        "following": payload.get("following"),
+        "created_at": payload.get("created_at"),
+        "updated_at": payload.get("updated_at"),
+        # derived
+        "user_authority_score": score,
+        "weight_breakdown": breakdown,
+        "missing_dimensions": [
+            "total_stars_across_repos",   # would need /repos enumeration
+            "contribution_streak",        # would need /events
+            "sponsor_count",              # would need /sponsors
+        ],
+    }
+    return authority, signals
+
+
+def stub_signals_for_missing(identity: str, kind: str, reason: str) -> dict[str, Any]:
+    """For 404s — record the fact without authority."""
+    return {
+        "identity": identity,
+        "kind": kind,
+        "fetch_status": "not_found",
+        "fetch_reason": reason,
+    }

--- a/src/ovp_pipeline/entities/identity_merge.py
+++ b/src/ovp_pipeline/entities/identity_merge.py
@@ -1,0 +1,286 @@
+"""Identity merge — collapse twitter_author + github_user into person.
+
+Why
+---
+
+After PR-E1 (twitter_author) and PR-E2 (github_project + github_user)
+the entity table has two parallel slices for the same human.  E.g.
+@karpathy on Twitter (followers 1.5M, score 0.50) and karpathy on
+GitHub (50k followers, score 0.65) are the same person — but the
+entity store doesn't know that.
+
+The fix is **another entity type** rather than a pointer column:
+
+  * ``person`` — canonical identity for a human
+  * its ``signals_json`` carries a ``links`` array pointing back at
+    the platform-specific entities
+
+Three merge sources, in order of confidence:
+
+  1. **GitHub-self-reported Twitter handle**.  ``github_user.signals.
+     twitter_username`` is a string the user typed into their own
+     GitHub profile — high signal, low effort.  In the OVP vault
+     this rule alone produces ~193 auto-merge candidates.
+  2. **Exact handle equality** when one platform is empty.  E.g. a
+     user with @karpathy@twitter and karpathy@github but neither
+     self-reported the other.  Same string, ≥4 chars, both exist
+     as entities — merge.
+  3. **Manual / fuzzy review**.  Levenshtein distance ≤ 2 (e.g.
+     mattpocock ↔ mattpocockuk).  Surfaced for human approval, not
+     auto-applied.
+
+This module produces the merge plan; the CLI in
+``commands/merge_identities.py`` applies it.
+
+Person authority
+----------------
+
+When two slices are merged, the person's derived_authority is the
+**max** of its links — never the average.  Reasoning: if karpathy's
+github score is 0.65 and twitter score is 0.50, what we know about
+him as a Person is at least 0.65 (the strong signal).  Averaging
+would punish him for being more famous on one platform than the other.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Iterator, Literal
+
+from .store import Entity, EntityStore
+
+logger = logging.getLogger(__name__)
+
+
+# Entity types we emit and consume.
+PERSON_TYPE = "person"
+TWITTER_TYPE = "twitter_author"
+GITHUB_USER_TYPE = "github_user"
+
+# Confidence categories for the report / review queue.
+MergeMethod = Literal["self_reported", "exact_handle", "fuzzy"]
+_FUZZY_MAX_DISTANCE = 2
+_MIN_HANDLE_LEN_FOR_EXACT = 4
+
+
+@dataclass(frozen=True, slots=True)
+class MergeCandidate:
+    """One proposed link between a github_user and a twitter_author."""
+
+    github_login: str
+    twitter_handle: str
+    method: MergeMethod
+    confidence: float           # 0-1; auto-applied if ≥ AUTO_THRESHOLD
+    rationale: str
+
+    @property
+    def is_auto(self) -> bool:
+        return self.confidence >= 0.9
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+
+def _normalize_handle(s: str | None) -> str:
+    """Lowercase + strip @ + trim whitespace.  Empty inputs → ''."""
+    if not s:
+        return ""
+    return s.strip().lstrip("@").lower()
+
+
+def _levenshtein(a: str, b: str) -> int:
+    """Iterative Levenshtein distance.  Small enough for handle pairs."""
+    if a == b:
+        return 0
+    if not a:
+        return len(b)
+    if not b:
+        return len(a)
+    prev = list(range(len(b) + 1))
+    for i, ca in enumerate(a, 1):
+        cur = [i] + [0] * len(b)
+        for j, cb in enumerate(b, 1):
+            cost = 0 if ca == cb else 1
+            cur[j] = min(
+                cur[j - 1] + 1,        # insertion
+                prev[j] + 1,           # deletion
+                prev[j - 1] + cost,    # substitution
+            )
+        prev = cur
+    return prev[len(b)]
+
+
+def find_merge_candidates(store: EntityStore) -> list[MergeCandidate]:
+    """Scan the entity table and return all proposed links.
+
+    The result mixes auto-mergeable + review candidates; callers
+    filter via ``is_auto`` to apply only the high-confidence subset.
+    """
+    twitter_entities = store.list_by_type(TWITTER_TYPE)
+    github_users = store.list_by_type(GITHUB_USER_TYPE)
+
+    twitter_by_handle: dict[str, Entity] = {
+        _normalize_handle(e.identity_key): e for e in twitter_entities
+    }
+    twitter_handles_set: set[str] = set(twitter_by_handle)
+
+    candidates: list[MergeCandidate] = []
+    seen_pairs: set[tuple[str, str]] = set()  # (github_login, twitter_handle)
+
+    # --- 1. GitHub self-reported twitter_username -------------------------
+    for gh in github_users:
+        if gh.derived_authority is None:
+            continue   # not_found stub — skip
+        tw_self = _normalize_handle(gh.signals.get("twitter_username"))
+        if not tw_self:
+            continue
+        if tw_self not in twitter_by_handle:
+            continue
+        pair = (gh.identity_key, tw_self)
+        if pair in seen_pairs:
+            continue
+        seen_pairs.add(pair)
+        candidates.append(MergeCandidate(
+            github_login=gh.identity_key,
+            twitter_handle=tw_self,
+            method="self_reported",
+            confidence=0.95,
+            rationale=f"github_user.twitter_username='{tw_self}' matches "
+                      f"existing twitter_author entity",
+        ))
+
+    # --- 2. Exact handle equality -----------------------------------------
+    # Only fire when (a) the same string ≥4 chars exists on both platforms
+    # AND (b) we didn't already self-report-merge it.
+    for gh in github_users:
+        if gh.derived_authority is None:
+            continue
+        gh_login = _normalize_handle(gh.identity_key)
+        if len(gh_login) < _MIN_HANDLE_LEN_FOR_EXACT:
+            continue
+        if gh_login not in twitter_handles_set:
+            continue
+        pair = (gh.identity_key, gh_login)
+        if pair in seen_pairs:
+            continue
+        seen_pairs.add(pair)
+        candidates.append(MergeCandidate(
+            github_login=gh.identity_key,
+            twitter_handle=gh_login,
+            method="exact_handle",
+            confidence=0.85,    # below the auto threshold by default
+            rationale=f"identical handle '{gh_login}' on both platforms",
+        ))
+
+    # --- 3. Fuzzy (review queue, never auto) ------------------------------
+    # Pairs of handles within Levenshtein 2 — surfaces near-matches like
+    # mattpocock ↔ mattpocockuk that a human can approve in one click.
+    fuzzy_seen: set[tuple[str, str]] = set()
+    for gh in github_users:
+        if gh.derived_authority is None:
+            continue
+        gh_login = _normalize_handle(gh.identity_key)
+        if len(gh_login) < _MIN_HANDLE_LEN_FOR_EXACT:
+            continue
+        for tw_handle in twitter_handles_set:
+            if (gh.identity_key, tw_handle) in seen_pairs:
+                continue
+            if (gh_login, tw_handle) in fuzzy_seen:
+                continue
+            if abs(len(gh_login) - len(tw_handle)) > _FUZZY_MAX_DISTANCE:
+                continue
+            d = _levenshtein(gh_login, tw_handle)
+            if 0 < d <= _FUZZY_MAX_DISTANCE:
+                fuzzy_seen.add((gh_login, tw_handle))
+                candidates.append(MergeCandidate(
+                    github_login=gh.identity_key,
+                    twitter_handle=tw_handle,
+                    method="fuzzy",
+                    confidence=max(0.0, 0.6 - 0.1 * d),
+                    rationale=f"levenshtein({gh_login!r}, {tw_handle!r}) = {d}",
+                ))
+
+    return candidates
+
+
+# ---------------------------------------------------------------------------
+# Apply
+# ---------------------------------------------------------------------------
+
+
+def apply_merge(
+    store: EntityStore, candidate: MergeCandidate,
+) -> Entity | None:
+    """Upsert a person entity that links the gh + tw entities.
+
+    Returns the freshly-written ``person`` Entity, or ``None`` if either
+    side disappeared between discovery and apply (rare race).
+
+    Person identity_key
+    -------------------
+    We use the **lowercased twitter handle** as the canonical key.
+    Reason: Twitter handles are typically more "famous" / oft-quoted
+    than the GitHub login (think @karpathy vs karpathy@github), so
+    naming the person by their twitter handle keeps human-facing
+    surfaces (logs, dashboards) intuitive.
+    """
+    gh = store.get(GITHUB_USER_TYPE, candidate.github_login)
+    tw = store.get(TWITTER_TYPE, candidate.twitter_handle)
+    if gh is None or tw is None:
+        return None
+
+    person_key = candidate.twitter_handle
+    canonical_name = (
+        tw.canonical_name or gh.canonical_name or person_key
+    )
+    derived = max(
+        a for a in (gh.derived_authority, tw.derived_authority)
+        if a is not None
+    )
+
+    signals = {
+        "person_canonical_handle": person_key,
+        "links": [
+            {"entity_type": GITHUB_USER_TYPE,
+             "identity_key": gh.identity_key,
+             "derived_authority": gh.derived_authority,
+             "fetch_source": gh.fetch_source},
+            {"entity_type": TWITTER_TYPE,
+             "identity_key": tw.identity_key,
+             "derived_authority": tw.derived_authority,
+             "fetch_source": tw.fetch_source},
+        ],
+        "merge_method": candidate.method,
+        "merge_confidence": candidate.confidence,
+        "merge_rationale": candidate.rationale,
+        # surface the strongest fields from each side for quick reads
+        "twitter_followers": tw.signals.get("followers"),
+        "github_followers": gh.signals.get("followers"),
+        "github_public_repos": gh.signals.get("public_repos"),
+        "company": gh.signals.get("company") or tw.signals.get("location"),
+        "bio": gh.signals.get("bio") or tw.signals.get("description"),
+    }
+
+    return store.upsert(
+        entity_type=PERSON_TYPE,
+        identity_key=person_key,
+        canonical_name=canonical_name,
+        signals=signals,
+        derived_authority=derived,
+        fetch_source="identity_merge",
+    )
+
+
+def iter_auto_apply(
+    store: EntityStore, candidates: list[MergeCandidate],
+) -> Iterator[Entity]:
+    """Apply only the high-confidence candidates; yield the upserted person rows."""
+    for c in candidates:
+        if not c.is_auto:
+            continue
+        person = apply_merge(store, c)
+        if person is not None:
+            yield person

--- a/src/ovp_pipeline/entities/resolver.py
+++ b/src/ovp_pipeline/entities/resolver.py
@@ -1,0 +1,128 @@
+"""Entity-table resolver — single read path for source-signal providers.
+
+Use case: ``AuthorRulesProvider.score()`` falls through when an X handle
+isn't in ``authors.jsonl``.  Before PR-E3 that meant a hardcoded 0.45
+default (via the orchestrator).  After PR-E3 the fallback is "look up
+the entity table" — using the partial author_weight that PR-E1 collected.
+
+The resolver also resolves person-merged identities: a handle that has
+been merged with another platform's entity returns the **higher**
+authority.  E.g. @karpathy on Twitter scores 0.50, but PR-E2 found him
+on GitHub at 0.65, so the merged person scores 0.65.
+
+Public surface kept tiny on purpose — only what callers need:
+
+  * ``resolve_twitter_authority(store, handle)``
+  * ``resolve_github_project_authority(store, owner, repo)``
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from .store import Entity, EntityStore
+
+
+# Source-of-truth labels we pass back so callers can record where the
+# authority came from in the audit log.
+ResolveSource = Literal["person", "twitter_author", "github_user", "github_project", "none"]
+
+
+@dataclass(frozen=True, slots=True)
+class ResolveResult:
+    """What the resolver knows about one platform handle.
+
+    ``authority`` is None when the entity isn't in the table at all
+    (or only exists as a not_found stub).  Callers should treat this
+    like ``Signal == None`` and let the fallback logic apply.
+    """
+
+    authority: float | None
+    source: ResolveSource
+    entity: Entity | None
+
+
+def _normalize(s: str | None) -> str:
+    return (s or "").strip().lstrip("@").lower()
+
+
+def resolve_twitter_authority(
+    store: EntityStore, handle: str,
+) -> ResolveResult:
+    """Look up a Twitter handle's authority via person → twitter_author."""
+    norm = _normalize(handle)
+    if not norm:
+        return ResolveResult(None, "none", None)
+
+    # 1. Person entity keyed by twitter handle (PR-E3 merges).  This is
+    #    the right answer when the handle has been linked to a github
+    #    entity — it carries the max-of-all-platforms authority.
+    person = store.get("person", norm)
+    if person is not None and person.derived_authority is not None:
+        return ResolveResult(person.derived_authority, "person", person)
+
+    # 2. Plain twitter_author entity from PR-E1.
+    tw = store.get("twitter_author", norm)
+    if tw is not None and tw.derived_authority is not None:
+        return ResolveResult(tw.derived_authority, "twitter_author", tw)
+
+    return ResolveResult(None, "none", None)
+
+
+def resolve_github_project_authority(
+    store: EntityStore, owner: str, repo: str,
+) -> ResolveResult:
+    """Look up a GitHub project's authority by ``owner/repo``.
+
+    Falls back to the owner's authority (capped) if the project is
+    missing — covers fresh repos we haven't backfilled yet but whose
+    owner is well-known.
+    """
+    owner_n = _normalize(owner)
+    repo_n = _normalize(repo)
+    if not owner_n or not repo_n:
+        return ResolveResult(None, "none", None)
+
+    proj = store.get("github_project", f"{owner_n}/{repo_n}")
+    if proj is not None and proj.derived_authority is not None:
+        return ResolveResult(proj.derived_authority, "github_project", proj)
+
+    user = store.get("github_user", owner_n)
+    if user is not None and user.derived_authority is not None:
+        # Owner-only fallback gets dampened — we don't actually know
+        # whether THIS particular repo is high quality, only that the
+        # owner usually ships good things.  Cap at 0.55 so an
+        # explicit project entity always wins on re-fetch.
+        return ResolveResult(
+            min(user.derived_authority, 0.55),
+            "github_user", user,
+        )
+
+    return ResolveResult(None, "none", None)
+
+
+def resolve_github_user_authority(
+    store: EntityStore, login: str,
+) -> ResolveResult:
+    """Look up a GitHub user's authority — used by author_rules when
+    the source URL is e.g. ``github.com/karpathy/dotfiles`` and we
+    want to credit Karpathy's reputation, not the dotfiles repo's
+    star count."""
+    norm = _normalize(login)
+    if not norm:
+        return ResolveResult(None, "none", None)
+
+    # Person merge takes precedence here too — if karpathy was merged
+    # to a person entity via his twitter handle, we want that view.
+    # Look up via the github_user's twitter_username field.
+    gh = store.get("github_user", norm)
+    if gh is not None and gh.derived_authority is not None:
+        tw_username = _normalize(gh.signals.get("twitter_username"))
+        if tw_username:
+            person = store.get("person", tw_username)
+            if person is not None and person.derived_authority is not None:
+                return ResolveResult(person.derived_authority, "person", person)
+        return ResolveResult(gh.derived_authority, "github_user", gh)
+
+    return ResolveResult(None, "none", None)

--- a/src/ovp_pipeline/entities/scan.py
+++ b/src/ovp_pipeline/entities/scan.py
@@ -1,0 +1,170 @@
+"""Scan a vault for entity references.
+
+The recon script in ``/tmp/recon_entities.py`` proved the design;
+this is the productionized version.
+
+Why "anywhere in markdown" rather than "frontmatter source only":
+  * a Twitter handle may be quoted as ``@karpathy`` in body prose
+    even when the source URL is GitHub or anthropic.com
+  * a GitHub repo may be linked in a wikilink like
+    ``[karpathy/nanoGPT](https://github.com/karpathy/nanoGPT)`` from
+    a regular evergreen note
+  * the entity-as-citizen view is platform-agnostic; we should pick
+    up *all* mentions, not just the ones lucky enough to be the
+    primary source of a clipping
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator
+
+
+# X/Twitter handle inside a status URL or a bare profile URL.
+# We accept both ``x.com/<handle>`` and ``x.com/<handle>/status/<id>``
+# because the question is "does this handle appear" not "did they
+# write a tweet we ingested".
+_X_HANDLE_RE = re.compile(
+    r"(?:x|twitter)\.com/(@?[A-Za-z0-9_]+)(?:/status/\d+)?",
+    re.IGNORECASE,
+)
+
+# GitHub owner/repo from a URL.  Stops at the first ``/?#`` after the
+# repo segment so we don't pick up sub-paths like ``/issues/12`` as
+# part of the repo name.
+_GH_REPO_RE = re.compile(
+    # The repo segment ends at any URL-terminating character: path
+    # separators, query/fragment markers, closing brackets/parens
+    # (markdown links!), whitespace, quotes, or end-of-string.
+    r"github\.com/([\w.-]+)/([\w.-]+?)(?=[/?#)\]\s\"'`>]|$)",
+    re.IGNORECASE,
+)
+
+# Path segments that look like ``<owner>/<repo>`` to the regex but are
+# really top-level GitHub features.  Drop them.
+_GH_NON_REPO_OWNERS = frozenset({
+    "orgs", "topics", "marketplace", "settings", "pricing", "search",
+    "about", "features", "explore", "trending", "issues", "pulls",
+    "notifications", "sponsors", "collections", "events",
+})
+
+# Reserved X paths that look like handles but aren't.
+_X_NON_HANDLE = frozenset({
+    "home", "explore", "i", "search", "messages", "notifications",
+    "compose", "settings", "intent", "share", "login", "signup",
+    "tos", "privacy", "about",
+})
+
+
+@dataclass(frozen=True, slots=True)
+class HandleMention:
+    """One X/Twitter handle and how often it appears across the vault."""
+
+    handle: str            # lowercased, no @
+    mention_count: int     # total occurrences across all files
+    file_count: int        # number of distinct files that mention it
+
+
+@dataclass(frozen=True, slots=True)
+class GitHubMention:
+    """A GitHub repo + its owner."""
+
+    owner: str
+    repo: str | None       # None if we only saw the owner, not a repo URL
+    mention_count: int
+    file_count: int
+
+
+def iter_markdown_files(vault_dir: Path) -> Iterator[Path]:
+    """Yield every .md path under the vault, skipping caches/backups."""
+    skip_parts = frozenset({"__pycache__", "_backup", ".git", "node_modules"})
+    for p in vault_dir.rglob("*.md"):
+        if any(part in skip_parts for part in p.parts):
+            continue
+        yield p
+
+
+def scan_twitter_handles(vault_dir: Path) -> list[HandleMention]:
+    """Return handles sorted descending by mention_count."""
+    total: Counter[str] = Counter()
+    files: dict[str, set[Path]] = {}
+
+    for path in iter_markdown_files(vault_dir):
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        # Cheap pre-filter — saves regex work on the >90% of files
+        # that don't reference Twitter at all.
+        if "x.com" not in text and "twitter.com" not in text:
+            continue
+        seen_in_file: set[str] = set()
+        for m in _X_HANDLE_RE.finditer(text):
+            handle = m.group(1).lstrip("@").lower()
+            if handle in _X_NON_HANDLE:
+                continue
+            if not handle:
+                continue
+            total[handle] += 1
+            seen_in_file.add(handle)
+        for handle in seen_in_file:
+            files.setdefault(handle, set()).add(path)
+
+    return [
+        HandleMention(
+            handle=h,
+            mention_count=c,
+            file_count=len(files.get(h, ())),
+        )
+        for h, c in total.most_common()
+    ]
+
+
+def scan_github_mentions(vault_dir: Path) -> list[GitHubMention]:
+    """Return repo+owner mentions sorted descending by mention_count.
+
+    A ``repo=None`` row means "we only saw owner-level URLs"; a row
+    with a repo also exists for the same owner if both kinds appear.
+    """
+    repo_total: Counter[tuple[str, str]] = Counter()
+    repo_files: dict[tuple[str, str], set[Path]] = {}
+    owner_total: Counter[str] = Counter()
+    owner_files: dict[str, set[Path]] = {}
+
+    for path in iter_markdown_files(vault_dir):
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if "github.com" not in text:
+            continue
+        seen_repos_in_file: set[tuple[str, str]] = set()
+        seen_owners_in_file: set[str] = set()
+        for m in _GH_REPO_RE.finditer(text):
+            owner = m.group(1).lower()
+            if owner in _GH_NON_REPO_OWNERS:
+                continue
+            repo = m.group(2).lower()
+            if repo.endswith(".git"):
+                repo = repo[:-4]
+            repo_total[(owner, repo)] += 1
+            owner_total[owner] += 1
+            seen_repos_in_file.add((owner, repo))
+            seen_owners_in_file.add(owner)
+        for key in seen_repos_in_file:
+            repo_files.setdefault(key, set()).add(path)
+        for owner in seen_owners_in_file:
+            owner_files.setdefault(owner, set()).add(path)
+
+    out: list[GitHubMention] = []
+    for (owner, repo), c in repo_total.most_common():
+        out.append(GitHubMention(
+            owner=owner,
+            repo=repo,
+            mention_count=c,
+            file_count=len(repo_files.get((owner, repo), ())),
+        ))
+    return out

--- a/src/ovp_pipeline/entities/store.py
+++ b/src/ovp_pipeline/entities/store.py
@@ -1,0 +1,246 @@
+"""SQLite-backed entity store.
+
+Two tables:
+
+``entities``
+    Latest snapshot per ``(entity_type, identity_key)``.  ``signals_json``
+    is the raw fetched payload (twitterapi.io response, GitHub API
+    response, etc.).  ``derived_authority`` is our best 0-1 estimate
+    computed from those signals — separated from the raw data so a
+    formula change can be re-derived without re-fetching.
+
+``entity_signals_history``
+    Append-only time series.  One row per fetch.  Keeps the audit
+    trail and makes it possible to compute trends later (followers
+    growth rate, star velocity, "active vs going dormant" detection).
+
+Both tables use ``CREATE TABLE IF NOT EXISTS`` so they coexist with
+the other knowledge.db schemas.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Iterator
+
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS entities (
+    entity_id        INTEGER PRIMARY KEY AUTOINCREMENT,
+    entity_type      TEXT NOT NULL,
+    identity_key     TEXT NOT NULL,
+    canonical_name   TEXT,
+    signals_json     TEXT NOT NULL,
+    derived_authority REAL,
+    fetch_source     TEXT NOT NULL,
+    first_seen_at    TEXT NOT NULL,
+    last_fetched_at  TEXT NOT NULL,
+    UNIQUE(entity_type, identity_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_entities_type
+    ON entities(entity_type);
+
+CREATE INDEX IF NOT EXISTS idx_entities_authority
+    ON entities(entity_type, derived_authority DESC);
+
+CREATE TABLE IF NOT EXISTS entity_signals_history (
+    history_id    INTEGER PRIMARY KEY AUTOINCREMENT,
+    entity_id     INTEGER NOT NULL,
+    observed_at   TEXT NOT NULL,
+    signals_json  TEXT NOT NULL,
+    fetch_source  TEXT NOT NULL,
+    FOREIGN KEY (entity_id) REFERENCES entities(entity_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_entity_signals_history_entity
+    ON entity_signals_history(entity_id, observed_at DESC);
+"""
+
+
+@dataclass(frozen=True, slots=True)
+class Entity:
+    """A merged-view row from the ``entities`` table."""
+
+    entity_id: int
+    entity_type: str
+    identity_key: str
+    canonical_name: str | None
+    signals: dict[str, Any]
+    derived_authority: float | None
+    fetch_source: str
+    first_seen_at: str
+    last_fetched_at: str
+
+
+def init_schema(db_path: Path) -> None:
+    """Create the entity tables if they don't exist.
+
+    Idempotent — safe to call on every CLI invocation.
+    """
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(_SCHEMA)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _row_to_entity(row: sqlite3.Row) -> Entity:
+    try:
+        signals = json.loads(row["signals_json"]) if row["signals_json"] else {}
+    except json.JSONDecodeError:
+        signals = {}
+    return Entity(
+        entity_id=row["entity_id"],
+        entity_type=row["entity_type"],
+        identity_key=row["identity_key"],
+        canonical_name=row["canonical_name"],
+        signals=signals,
+        derived_authority=row["derived_authority"],
+        fetch_source=row["fetch_source"],
+        first_seen_at=row["first_seen_at"],
+        last_fetched_at=row["last_fetched_at"],
+    )
+
+
+@dataclass
+class EntityStore:
+    """Thin DAO over the ``entities`` + ``entity_signals_history`` tables."""
+
+    db_path: Path
+
+    def __post_init__(self) -> None:
+        init_schema(self.db_path)
+
+    # ---- read ----------------------------------------------------------
+
+    def get(self, entity_type: str, identity_key: str) -> Entity | None:
+        conn = sqlite3.connect(self.db_path)
+        try:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute(
+                "SELECT * FROM entities WHERE entity_type=? AND identity_key=?",
+                (entity_type, identity_key),
+            ).fetchone()
+            return _row_to_entity(row) if row else None
+        finally:
+            conn.close()
+
+    def list_by_type(
+        self, entity_type: str, *, limit: int | None = None,
+    ) -> list[Entity]:
+        conn = sqlite3.connect(self.db_path)
+        try:
+            conn.row_factory = sqlite3.Row
+            sql = (
+                "SELECT * FROM entities WHERE entity_type=? "
+                "ORDER BY derived_authority DESC NULLS LAST"
+            )
+            if limit is not None:
+                sql += f" LIMIT {int(limit)}"
+            rows = conn.execute(sql, (entity_type,)).fetchall()
+            return [_row_to_entity(r) for r in rows]
+        finally:
+            conn.close()
+
+    def history(
+        self, entity_id: int, *, limit: int = 50,
+    ) -> Iterator[tuple[str, dict[str, Any], str]]:
+        """Yield (observed_at, signals_dict, fetch_source) most-recent first."""
+        conn = sqlite3.connect(self.db_path)
+        try:
+            # Tiebreak on history_id DESC so two rows that share an
+            # observed_at to the second still come back newest-first.
+            rows = conn.execute(
+                "SELECT observed_at, signals_json, fetch_source "
+                "FROM entity_signals_history WHERE entity_id=? "
+                "ORDER BY observed_at DESC, history_id DESC LIMIT ?",
+                (entity_id, limit),
+            ).fetchall()
+            for observed_at, signals_json, fetch_source in rows:
+                try:
+                    signals = json.loads(signals_json) if signals_json else {}
+                except json.JSONDecodeError:
+                    signals = {}
+                yield observed_at, signals, fetch_source
+        finally:
+            conn.close()
+
+    # ---- write ---------------------------------------------------------
+
+    def upsert(
+        self,
+        *,
+        entity_type: str,
+        identity_key: str,
+        canonical_name: str | None,
+        signals: dict[str, Any],
+        derived_authority: float | None,
+        fetch_source: str,
+    ) -> Entity:
+        """Insert or update a single entity, plus append a history row.
+
+        Returns the freshly-read entity (after upsert).
+        """
+        now = _iso_now()
+        signals_json = json.dumps(signals, ensure_ascii=False, sort_keys=True)
+        conn = sqlite3.connect(self.db_path)
+        try:
+            conn.row_factory = sqlite3.Row
+            existing = conn.execute(
+                "SELECT entity_id, first_seen_at FROM entities "
+                "WHERE entity_type=? AND identity_key=?",
+                (entity_type, identity_key),
+            ).fetchone()
+            if existing is None:
+                cur = conn.execute(
+                    "INSERT INTO entities (entity_type, identity_key, "
+                    "canonical_name, signals_json, derived_authority, "
+                    "fetch_source, first_seen_at, last_fetched_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                    (entity_type, identity_key, canonical_name, signals_json,
+                     derived_authority, fetch_source, now, now),
+                )
+                entity_id = cur.lastrowid
+            else:
+                entity_id = existing["entity_id"]
+                conn.execute(
+                    "UPDATE entities SET canonical_name=?, signals_json=?, "
+                    "derived_authority=?, fetch_source=?, last_fetched_at=? "
+                    "WHERE entity_id=?",
+                    (canonical_name, signals_json, derived_authority,
+                     fetch_source, now, entity_id),
+                )
+            conn.execute(
+                "INSERT INTO entity_signals_history "
+                "(entity_id, observed_at, signals_json, fetch_source) "
+                "VALUES (?, ?, ?, ?)",
+                (entity_id, now, signals_json, fetch_source),
+            )
+            conn.commit()
+            row = conn.execute(
+                "SELECT * FROM entities WHERE entity_id=?",
+                (entity_id,),
+            ).fetchone()
+            return _row_to_entity(row)
+        finally:
+            conn.close()
+
+    def upsert_many(
+        self, records: Iterable[dict[str, Any]],
+    ) -> list[Entity]:
+        """Bulk version — same fields as ``upsert`` keys per record."""
+        out = []
+        for rec in records:
+            out.append(self.upsert(**rec))
+        return out

--- a/src/ovp_pipeline/entities/twitter_backfill.py
+++ b/src/ovp_pipeline/entities/twitter_backfill.py
@@ -1,0 +1,312 @@
+"""twitterapi.io fetch + partial author_weight computation.
+
+The obsidian-clipper Twitter adapter computes a 7-dimension
+``author_weight`` (0-100) at clip time.  This module reconstructs an
+approximation from the fields twitterapi.io exposes — necessarily
+weaker because two of the strongest dimensions (``listed_count`` and
+mutual-network signals) aren't available via that API.
+
+Fidelity tradeoff (vs. clipper's 100-point scale):
+  * Clipper:  followers + listed + mutuals + i_follow + age +
+              verified/company + automated  → 100 max
+  * Backfill: followers + age + verified + company-affiliation +
+              automated penalty             → ~70 max
+
+Therefore the partial score is **always strictly weaker than** the
+clipper's, and the runtime authority resolver (PR-E3) should prefer
+clipper-sourced values when both exist.
+
+API details:
+  * GET /twitter/user/info?userName=<handle>
+  * Header: X-API-Key
+  * $0.00018 / call (single-user)
+  * 521 handles in the OVP vault → ~$0.094 one-shot
+
+Failure modes handled:
+  * 401 / 403  — bad key, raise immediately
+  * 429        — exponential backoff
+  * 404 / "user not found" — record as suspended, don't retry
+  * Network    — retry up to 3 times then mark failed
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_API_BASE = "https://api.twitterapi.io"
+_USER_INFO_PATH = "/twitter/user/info"
+_USER_AGENT = "ovp-backfill/1.0 (https://github.com/fakechris/obsidian_vault_pipeline)"
+_DEFAULT_TIMEOUT_S = 15.0
+_MAX_RETRIES = 3
+_BACKOFF_BASE_S = 1.5
+
+# Cost in USD per single-user call (per twitterapi.io intro page).
+PRICE_PER_CALL_USD = 0.00018
+
+
+# ---------------------------------------------------------------------------
+# Fetch
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class FetchResult:
+    """Outcome of one twitterapi.io call.
+
+    Three terminal states:
+      * ``ok``        — got a user payload; ``payload`` is non-None
+      * ``not_found`` — handle suspended/deleted; record stub entity
+      * ``error``     — network/auth/quota; do NOT mark as authoritative
+
+    The CLI counts these into the final summary.
+    """
+
+    handle: str
+    status: str          # "ok" | "not_found" | "error"
+    payload: dict[str, Any] | None
+    error: str | None    # human-readable diagnosis if status != "ok"
+
+
+def fetch_user_info(
+    handle: str, *, api_key: str, timeout_s: float = _DEFAULT_TIMEOUT_S,
+) -> FetchResult:
+    """Single-call wrapper around GET /twitter/user/info.
+
+    Idempotent / safe to call repeatedly — twitterapi.io has no
+    mutating side effects on this endpoint.
+    """
+    if not handle or not api_key:
+        return FetchResult(handle, "error", None, "missing handle or api_key")
+
+    qs = urllib.parse.urlencode({"userName": handle})
+    url = f"{_API_BASE}{_USER_INFO_PATH}?{qs}"
+    headers = {
+        "X-API-Key": api_key,
+        "Accept": "application/json",
+        "User-Agent": _USER_AGENT,
+    }
+
+    last_error: str = "unknown"
+    for attempt in range(_MAX_RETRIES):
+        try:
+            req = urllib.request.Request(url, headers=headers)
+            with urllib.request.urlopen(req, timeout=timeout_s) as resp:
+                body = resp.read().decode("utf-8")
+        except urllib.error.HTTPError as e:
+            # 401/403 are auth — bail immediately.
+            if e.code in (401, 403):
+                return FetchResult(
+                    handle, "error", None,
+                    f"auth failed: HTTP {e.code} (check API key)",
+                )
+            # 404 or "user not found"-style.
+            if e.code == 404:
+                return FetchResult(handle, "not_found", None, "404 from API")
+            # 429 → backoff
+            if e.code == 429:
+                wait = _BACKOFF_BASE_S * (2 ** attempt)
+                logger.info("rate limited on %s, sleeping %.1fs", handle, wait)
+                time.sleep(wait)
+                last_error = "HTTP 429"
+                continue
+            last_error = f"HTTP {e.code}"
+            time.sleep(_BACKOFF_BASE_S * (2 ** attempt))
+            continue
+        except (urllib.error.URLError, TimeoutError, OSError) as e:
+            last_error = f"network: {e}"
+            time.sleep(_BACKOFF_BASE_S * (2 ** attempt))
+            continue
+
+        try:
+            parsed = json.loads(body)
+        except json.JSONDecodeError as e:
+            return FetchResult(handle, "error", None, f"bad JSON: {e}")
+
+        status = parsed.get("status")
+        if status == "success":
+            data = parsed.get("data") or {}
+            if not isinstance(data, dict) or not data:
+                # API returned success but empty body — treat as not found.
+                return FetchResult(handle, "not_found", None, "empty data")
+            return FetchResult(handle, "ok", data, None)
+
+        # status == "error" or unknown.
+        msg = str(parsed.get("msg") or parsed.get("message") or "")
+        if "not found" in msg.lower() or "suspended" in msg.lower() \
+                or "unavailable" in msg.lower():
+            return FetchResult(handle, "not_found", None, msg or "user not found")
+        return FetchResult(handle, "error", None, msg or "API returned error")
+
+    return FetchResult(handle, "error", None, last_error)
+
+
+# ---------------------------------------------------------------------------
+# Score derivation
+# ---------------------------------------------------------------------------
+
+
+def _account_age_years(created_at: str | None) -> float:
+    """Parse ``createdAt`` and return age in years (0 if unparseable).
+
+    twitterapi.io can return either ISO 8601
+    (``2016-03-20T17:01:04.000000Z``) or X's classic format
+    (``Thu Dec 13 08:41:26 +0000 2007``).
+    """
+    if not created_at:
+        return 0.0
+    candidates = [
+        ("%Y-%m-%dT%H:%M:%S.%f%z", created_at.replace("Z", "+0000")),
+        ("%Y-%m-%dT%H:%M:%S%z", created_at.replace("Z", "+0000")),
+        ("%a %b %d %H:%M:%S %z %Y", created_at),
+    ]
+    for fmt, val in candidates:
+        try:
+            dt = datetime.strptime(val, fmt)
+        except ValueError:
+            continue
+        delta = datetime.now(timezone.utc) - dt
+        return max(delta.days / 365.25, 0.0)
+    return 0.0
+
+
+def compute_partial_author_weight(payload: dict[str, Any]) -> tuple[int, dict[str, int]]:
+    """Compute partial author_weight (0-100 scale) + per-dimension breakdown.
+
+    Returns ``(score, {dimension: points})`` so the breakdown can be
+    persisted alongside the score for explainability.
+
+    The dimensions deliberately mirror the obsidian-clipper formula
+    where a corresponding signal exists, and zero-out the dimensions
+    that twitterapi.io can't supply (listed, mutuals, i_follow).
+    Total possible: 70.  Anything higher comes from clipper-frontmatter,
+    not from this code.
+    """
+    breakdown: dict[str, int] = {}
+
+    # 1. followers (max 25)
+    fol = int(payload.get("followers") or 0)
+    if fol >= 100_000:
+        breakdown["followers"] = 25
+    elif fol >= 10_000:
+        breakdown["followers"] = 22
+    elif fol >= 1_000:
+        breakdown["followers"] = 17
+    elif fol >= 500:
+        breakdown["followers"] = 10
+    elif fol >= 100:
+        breakdown["followers"] = 5
+    else:
+        breakdown["followers"] = 0
+
+    # 2. account age in years (max 10)
+    age_y = _account_age_years(payload.get("createdAt"))
+    if age_y >= 7:
+        breakdown["age"] = 10
+    elif age_y >= 3:
+        breakdown["age"] = 7
+    elif age_y >= 1:
+        breakdown["age"] = 3
+    else:
+        breakdown["age"] = 0
+
+    # 3. blue-verified flag (max 5).
+    # Per the clipper docs: "蓝标现在已经没用" — kept low intentionally.
+    breakdown["blue_verified"] = 5 if payload.get("isBlueVerified") else 0
+
+    # 4. legacy verified / verifiedType — closer to "old blue check"
+    # which the clipper docs flag as a strong signal (max 10).
+    verified_type = (payload.get("verifiedType") or "").strip().lower()
+    is_legacy_verified = bool(payload.get("isVerified"))
+    if verified_type in {"government", "business", "company"} or is_legacy_verified:
+        breakdown["legacy_verified"] = 10
+    else:
+        breakdown["legacy_verified"] = 0
+
+    # 5. affiliation label (max 10).
+    # twitterapi.io exposes ``affiliatesHighlightedLabel`` which
+    # corresponds to the company-badge UI feature on X.  Treat any
+    # non-empty mapping as "has affiliation".
+    aff = payload.get("affiliatesHighlightedLabel")
+    if isinstance(aff, dict) and aff:
+        breakdown["affiliation"] = 10
+    else:
+        breakdown["affiliation"] = 0
+
+    # 6. activity / statusesCount (max 10).
+    # Anti-correlated with brand-new accounts and with bots.  Cap at
+    # the high end so a tweet-spam farm doesn't get a free 10 points.
+    statuses = int(payload.get("statusesCount") or 0)
+    if 500 <= statuses <= 50_000:
+        breakdown["activity"] = 10
+    elif 50 <= statuses < 500:
+        breakdown["activity"] = 5
+    elif statuses > 50_000:
+        breakdown["activity"] = 8       # too active, slight discount
+    else:
+        breakdown["activity"] = 0
+
+    # 7. automated penalty (negative).
+    breakdown["automated_penalty"] = -10 if payload.get("isAutomated") else 0
+
+    score = max(0, sum(breakdown.values()))
+    return score, breakdown
+
+
+def derive_authority_from_payload(payload: dict[str, Any]) -> tuple[float, dict[str, Any]]:
+    """High-level helper used by the CLI.
+
+    Returns ``(authority_0_to_1, signals_dict_to_persist)``.  The
+    signals dict is what gets stored in ``entities.signals_json``.
+    """
+    score, breakdown = compute_partial_author_weight(payload)
+    # Map 0-70 (theoretical max) → 0-1 by dividing by 100, NOT 70.
+    # That reserves the 0.71-1.0 band for clipper-rich frontmatter
+    # which has the missing-dimensions signal.  See PR-E3 design.
+    authority = round(score / 100.0, 4)
+
+    signals = {
+        # raw fields we care about for downstream score reconstruction
+        "userName": payload.get("userName"),
+        "id": payload.get("id"),
+        "name": payload.get("name"),
+        "description": payload.get("description"),
+        "location": payload.get("location"),
+        "createdAt": payload.get("createdAt"),
+        "followers": payload.get("followers"),
+        "following": payload.get("following"),
+        "statusesCount": payload.get("statusesCount"),
+        "mediaCount": payload.get("mediaCount"),
+        "favouritesCount": payload.get("favouritesCount"),
+        "isBlueVerified": payload.get("isBlueVerified"),
+        "isVerified": payload.get("isVerified"),
+        "verifiedType": payload.get("verifiedType"),
+        "isAutomated": payload.get("isAutomated"),
+        "affiliatesHighlightedLabel": payload.get("affiliatesHighlightedLabel"),
+        # derived
+        "partial_author_weight": score,
+        "weight_breakdown": breakdown,
+        # missing dimensions (kept explicit so future formula changes
+        # don't silently fail to detect "we never had this data"):
+        "missing_dimensions": ["listed_count", "mutuals_count",
+                                "mutuals_top", "i_follow", "follows_me"],
+    }
+    return authority, signals
+
+
+def stub_signals_for_missing(handle: str, reason: str) -> dict[str, Any]:
+    """For 'not_found' / suspended handles — record the fact without authority."""
+    return {
+        "userName": handle,
+        "fetch_status": "not_found",
+        "fetch_reason": reason,
+    }

--- a/src/ovp_pipeline/source_signals/author_rules.py
+++ b/src/ovp_pipeline/source_signals/author_rules.py
@@ -35,7 +35,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
-from .base import Signal, SignalProvider
+from .base import Signal
 
 logger = logging.getLogger(__name__)
 
@@ -46,10 +46,30 @@ _HANDLE_FROM_X_URL = re.compile(
 
 @dataclass
 class AuthorRulesProvider:
-    """Match author identity against a curated authority list."""
+    """Match author identity against a curated authority list.
+
+    Two-tier lookup:
+
+      1. Curated whitelist (``authors.jsonl``) — explicit user trust.
+         Wins when present.
+      2. Entity table fallback (``entity_store_path``, optional) —
+         partial authority computed by PR-E1/E2 backfills, used when
+         a handle isn't in the whitelist.  Returns Signals with a
+         softer 0.85 multiplier so explicit curation always beats
+         derived data.
+
+    When ``entity_store_path`` is None (default), behavior is
+    identical to PR-D1 — whitelist or nothing.
+    """
 
     authors_path: Path
     name: str = "author_rules"
+    entity_store_path: Path | None = None
+    # Multiplier applied to entity-derived authority to keep curated
+    # whitelist entries strictly above derived ones at the same raw
+    # score.  Tunable via the dataclass field if a future calibration
+    # round wants to lift entity signals.
+    entity_score_multiplier: float = 0.85
     _index: dict[str, dict[str, Any]] | None = None
 
     def _load(self) -> dict[str, dict[str, Any]]:
@@ -106,8 +126,6 @@ class AuthorRulesProvider:
         self, source_url: str, frontmatter: dict[str, Any],
     ) -> Signal | None:
         index = self._load()
-        if not index:
-            return None
 
         candidates: list[str] = []
         author = frontmatter.get("author") or ""
@@ -152,4 +170,50 @@ class AuthorRulesProvider:
                         },
                     )
 
+        # PR-E3 fallback: not in whitelist → consult the entity table
+        # (twitter_author + person merges).  This is where the 521
+        # twitterapi.io-backfilled entities start affecting scoring.
+        entity_signal = self._entity_fallback(candidates)
+        if entity_signal is not None:
+            return entity_signal
+
+        return None
+
+    def _entity_fallback(self, candidates: list[str]) -> Signal | None:
+        """Resolve a candidate handle through the entity table.
+
+        Returns ``None`` if no ``entity_store_path`` is configured,
+        if the store is empty, or if no candidate maps to an entity
+        with a derived_authority.  Multiplied by
+        ``entity_score_multiplier`` so curated whitelist entries
+        strictly outrank entity-derived ones at the same raw score.
+        """
+        if self.entity_store_path is None:
+            return None
+        # Lazy import keeps source_signals/ import-time graph clean
+        # (no entities/ pulled in unless this fallback fires).
+        from ..entities.store import EntityStore
+        from ..entities.resolver import resolve_twitter_authority
+
+        try:
+            store = EntityStore(db_path=self.entity_store_path)
+        except Exception as exc:  # noqa: BLE001 - resilience over diagnostics
+            logger.warning("entity store unavailable: %s", exc)
+            return None
+
+        for cand in candidates:
+            result = resolve_twitter_authority(store, cand)
+            if result.authority is None:
+                continue
+            return Signal(
+                provider=self.name,
+                value=round(result.authority * self.entity_score_multiplier, 4),
+                raw={
+                    "matched": cand,
+                    "matched_via": "entity_table",
+                    "entity_source": result.source,
+                    "raw_authority": result.authority,
+                    "multiplier": self.entity_score_multiplier,
+                },
+            )
         return None

--- a/tests/test_architecture_fitness.py
+++ b/tests/test_architecture_fitness.py
@@ -181,6 +181,7 @@ SQLITE_ALLOWED_MODULES = {
     "commands/working_memory",
     "commands/score_sources",
     "source_authority",
+    "entities/store",
     "discovery",
     "evidence",
     "evidence_replay",

--- a/tests/test_author_rules_entity_fallback.py
+++ b/tests/test_author_rules_entity_fallback.py
@@ -1,0 +1,103 @@
+"""Tests for AuthorRulesProvider's PR-E3 entity-table fallback.
+
+The whitelist behavior remains untouched.  These tests cover the
+new code path: when ``entity_store_path`` is set and a candidate
+handle isn't in the whitelist, look it up in the entity table.
+"""
+
+from __future__ import annotations
+
+import json
+
+from ovp_pipeline.entities.store import EntityStore
+from ovp_pipeline.source_signals.author_rules import AuthorRulesProvider
+
+
+def _empty_jsonl(tmp_path):
+    p = tmp_path / "authors.jsonl"
+    p.write_text("", encoding="utf-8")
+    return p
+
+
+def _whitelist_jsonl(tmp_path, *records):
+    p = tmp_path / "authors.jsonl"
+    p.write_text("\n".join(json.dumps(r) for r in records), encoding="utf-8")
+    return p
+
+
+def _seed_twitter(store, handle, auth):
+    store.upsert(
+        entity_type="twitter_author", identity_key=handle, canonical_name=handle,
+        signals={}, derived_authority=auth, fetch_source="t",
+    )
+
+
+class TestEntityFallback:
+    def test_fallback_used_when_handle_not_in_whitelist(self, tmp_path):
+        db = tmp_path / "k.db"
+        store = EntityStore(db_path=db)
+        _seed_twitter(store, "newperson", 0.60)
+        provider = AuthorRulesProvider(
+            authors_path=_empty_jsonl(tmp_path),
+            entity_store_path=db,
+        )
+        sig = provider.score("https://x.com/newperson/status/1", {})
+        assert sig is not None
+        # Score is the entity's authority × multiplier (0.85 default)
+        assert sig.value == round(0.60 * 0.85, 4)
+        assert sig.raw["matched_via"] == "entity_table"
+        assert sig.raw["entity_source"] == "twitter_author"
+
+    def test_whitelist_still_wins_when_present(self, tmp_path):
+        # Curated whitelist must outrank entity-table data.
+        db = tmp_path / "k.db"
+        store = EntityStore(db_path=db)
+        _seed_twitter(store, "shared", 0.70)
+        whitelist = _whitelist_jsonl(
+            tmp_path, {"handle": "shared", "authority": 0.95},
+        )
+        provider = AuthorRulesProvider(
+            authors_path=whitelist,
+            entity_store_path=db,
+        )
+        sig = provider.score("https://x.com/shared/status/1", {})
+        assert sig is not None
+        # Whitelist gives 0.95 directly; entity fallback would give
+        # 0.70 * 0.85 = 0.595 — confirm whitelist wins.
+        assert sig.value == 0.95
+        assert "matched_via" not in sig.raw or sig.raw.get("matched_via") != "entity_table"
+
+    def test_fallback_returns_none_when_no_entity_store(self, tmp_path):
+        # No entity_store_path → behavior unchanged from PR-D1.
+        provider = AuthorRulesProvider(
+            authors_path=_empty_jsonl(tmp_path),
+            # entity_store_path defaults to None
+        )
+        sig = provider.score("https://x.com/newperson/status/1", {})
+        assert sig is None
+
+    def test_fallback_returns_none_when_handle_unknown(self, tmp_path):
+        db = tmp_path / "k.db"
+        # Empty store — no entity for "ghost"
+        EntityStore(db_path=db)
+        provider = AuthorRulesProvider(
+            authors_path=_empty_jsonl(tmp_path),
+            entity_store_path=db,
+        )
+        sig = provider.score("https://x.com/ghost/status/1", {})
+        assert sig is None
+
+    def test_multiplier_dampens_entity_score(self, tmp_path):
+        # A custom multiplier of 1.0 disables the dampening — useful
+        # when the user trusts entity data as much as the whitelist.
+        db = tmp_path / "k.db"
+        store = EntityStore(db_path=db)
+        _seed_twitter(store, "newperson", 0.6)
+        provider = AuthorRulesProvider(
+            authors_path=_empty_jsonl(tmp_path),
+            entity_store_path=db,
+            entity_score_multiplier=1.0,
+        )
+        sig = provider.score("https://x.com/newperson/status/1", {})
+        assert sig is not None
+        assert sig.value == 0.6

--- a/tests/test_entities_scan.py
+++ b/tests/test_entities_scan.py
@@ -1,0 +1,112 @@
+"""Tests for entities/scan.py — vault traversal + handle/repo extraction."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ovp_pipeline.entities.scan import (
+    scan_github_mentions,
+    scan_twitter_handles,
+)
+
+
+def _write(p: Path, body: str) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(body, encoding="utf-8")
+
+
+class TestScanTwitterHandles:
+    def test_picks_up_status_url(self, tmp_path):
+        _write(tmp_path / "a.md",
+               "Saw [tweet](https://x.com/karpathy/status/12345) today.")
+        result = scan_twitter_handles(tmp_path)
+        assert any(m.handle == "karpathy" for m in result)
+
+    def test_picks_up_bare_profile_url(self, tmp_path):
+        _write(tmp_path / "a.md",
+               "Profile: https://twitter.com/sama")
+        result = scan_twitter_handles(tmp_path)
+        assert any(m.handle == "sama" for m in result)
+
+    def test_lowercases_handle(self, tmp_path):
+        _write(tmp_path / "a.md", "https://x.com/Karpathy/status/1")
+        result = scan_twitter_handles(tmp_path)
+        assert result[0].handle == "karpathy"
+
+    def test_filters_reserved_paths(self, tmp_path):
+        # /home, /search etc. aren't real handles — drop them.
+        _write(tmp_path / "a.md",
+               "Visit https://x.com/home and https://x.com/search "
+               "and https://twitter.com/i/lists")
+        result = scan_twitter_handles(tmp_path)
+        handles = {m.handle for m in result}
+        assert "home" not in handles
+        assert "search" not in handles
+        assert "i" not in handles
+
+    def test_counts_mentions_and_files(self, tmp_path):
+        _write(tmp_path / "a.md", "https://x.com/karpathy/status/1")
+        _write(tmp_path / "b.md",
+               "https://x.com/karpathy/status/2 and https://x.com/karpathy")
+        result = scan_twitter_handles(tmp_path)
+        kar = next(m for m in result if m.handle == "karpathy")
+        assert kar.mention_count == 3
+        assert kar.file_count == 2
+
+    def test_skips_files_without_twitter(self, tmp_path):
+        _write(tmp_path / "a.md", "no twitter here, just plain text")
+        _write(tmp_path / "b.md", "https://x.com/sama/status/1")
+        result = scan_twitter_handles(tmp_path)
+        assert len(result) == 1
+        assert result[0].handle == "sama"
+
+    def test_skips_pycache_and_backup_dirs(self, tmp_path):
+        _write(tmp_path / "__pycache__" / "x.md", "https://x.com/leak/status/1")
+        _write(tmp_path / "_backup" / "y.md", "https://x.com/leak2/status/1")
+        _write(tmp_path / "real.md", "https://x.com/real/status/1")
+        result = scan_twitter_handles(tmp_path)
+        handles = {m.handle for m in result}
+        assert "real" in handles
+        assert "leak" not in handles
+        assert "leak2" not in handles
+
+    def test_returns_descending_by_count(self, tmp_path):
+        _write(tmp_path / "a.md",
+               "https://x.com/once/status/1 "
+               "https://x.com/many/status/1 "
+               "https://x.com/many/status/2 "
+               "https://x.com/many/status/3")
+        result = scan_twitter_handles(tmp_path)
+        assert result[0].handle == "many"
+        assert result[1].handle == "once"
+
+
+class TestScanGithubMentions:
+    def test_picks_up_repo_url(self, tmp_path):
+        _write(tmp_path / "a.md",
+               "Check [karpathy/nanoGPT](https://github.com/karpathy/nanoGPT)")
+        result = scan_github_mentions(tmp_path)
+        assert any(m.owner == "karpathy" and m.repo == "nanogpt" for m in result)
+
+    def test_drops_git_suffix(self, tmp_path):
+        _write(tmp_path / "a.md", "https://github.com/foo/bar.git")
+        result = scan_github_mentions(tmp_path)
+        assert any(m.repo == "bar" for m in result)
+
+    def test_drops_non_repo_owner_paths(self, tmp_path):
+        # /orgs/anthropic isn't a repo
+        _write(tmp_path / "a.md",
+               "https://github.com/orgs/anthropic/people "
+               "https://github.com/topics/llm")
+        result = scan_github_mentions(tmp_path)
+        owners = {m.owner for m in result}
+        assert "orgs" not in owners
+        assert "topics" not in owners
+
+    def test_strips_trailing_path(self, tmp_path):
+        # /issues/12 should not become part of the repo name
+        _write(tmp_path / "a.md",
+               "https://github.com/karpathy/nanoGPT/issues/12")
+        result = scan_github_mentions(tmp_path)
+        nano = next(m for m in result if m.repo == "nanogpt")
+        assert nano.owner == "karpathy"

--- a/tests/test_entities_store.py
+++ b/tests/test_entities_store.py
@@ -1,0 +1,200 @@
+"""Tests for entities/store.py — schema + upsert + history + reads."""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+
+from ovp_pipeline.entities.store import EntityStore, init_schema
+
+
+class TestInitSchema:
+    def test_creates_both_tables(self, tmp_path):
+        db = tmp_path / "k.db"
+        init_schema(db)
+        conn = sqlite3.connect(db)
+        try:
+            tables = {
+                row[0]
+                for row in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                ).fetchall()
+            }
+            assert "entities" in tables
+            assert "entity_signals_history" in tables
+        finally:
+            conn.close()
+
+    def test_idempotent(self, tmp_path):
+        db = tmp_path / "k.db"
+        init_schema(db)
+        # Second call must not error or wipe data — exercises the
+        # CREATE TABLE IF NOT EXISTS contract.
+        init_schema(db)
+        # Insert a row, re-init, row must still be there.
+        conn = sqlite3.connect(db)
+        try:
+            conn.execute(
+                "INSERT INTO entities (entity_type, identity_key, "
+                "signals_json, fetch_source, first_seen_at, last_fetched_at) "
+                "VALUES ('twitter_author', 'foo', '{}', 'test', 'now', 'now')"
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        init_schema(db)
+        conn = sqlite3.connect(db)
+        try:
+            assert conn.execute(
+                "SELECT COUNT(*) FROM entities"
+            ).fetchone()[0] == 1
+        finally:
+            conn.close()
+
+
+class TestUpsert:
+    def test_first_insert(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "k.db")
+        e = store.upsert(
+            entity_type="twitter_author",
+            identity_key="karpathy",
+            canonical_name="Andrej Karpathy",
+            signals={"followers": 500_000, "partial_author_weight": 67},
+            derived_authority=0.67,
+            fetch_source="twitterapi.io",
+        )
+        assert e.entity_id > 0
+        assert e.identity_key == "karpathy"
+        assert e.derived_authority == 0.67
+        assert e.signals["followers"] == 500_000
+
+    def test_second_upsert_updates_in_place(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "k.db")
+        e1 = store.upsert(
+            entity_type="twitter_author", identity_key="x",
+            canonical_name="Mr X", signals={"followers": 100},
+            derived_authority=0.10, fetch_source="twitterapi.io",
+        )
+        first_seen = e1.first_seen_at
+        time.sleep(0.01)
+        e2 = store.upsert(
+            entity_type="twitter_author", identity_key="x",
+            canonical_name="Mr X", signals={"followers": 200},
+            derived_authority=0.20, fetch_source="twitterapi.io",
+        )
+        assert e2.entity_id == e1.entity_id     # same row, updated
+        assert e2.first_seen_at == first_seen   # original first_seen kept
+        assert e2.last_fetched_at >= first_seen
+        assert e2.signals["followers"] == 200
+        assert e2.derived_authority == 0.20
+
+    def test_upsert_appends_history_row(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "k.db")
+        store.upsert(
+            entity_type="twitter_author", identity_key="x",
+            canonical_name="X", signals={"followers": 100},
+            derived_authority=0.1, fetch_source="twitterapi.io",
+        )
+        time.sleep(0.01)
+        e = store.upsert(
+            entity_type="twitter_author", identity_key="x",
+            canonical_name="X", signals={"followers": 200},
+            derived_authority=0.2, fetch_source="twitterapi.io",
+        )
+        history = list(store.history(e.entity_id))
+        # Two upserts → two history rows, newest first.
+        assert len(history) == 2
+        assert history[0][1]["followers"] == 200
+        assert history[1][1]["followers"] == 100
+
+    def test_different_identity_keys_create_separate_entities(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "k.db")
+        e_a = store.upsert(
+            entity_type="twitter_author", identity_key="a",
+            canonical_name="A", signals={}, derived_authority=0.5,
+            fetch_source="t",
+        )
+        e_b = store.upsert(
+            entity_type="twitter_author", identity_key="b",
+            canonical_name="B", signals={}, derived_authority=0.6,
+            fetch_source="t",
+        )
+        assert e_a.entity_id != e_b.entity_id
+
+    def test_same_key_different_type_are_separate_entities(self, tmp_path):
+        # @karpathy on Twitter and karpathy on GitHub are different
+        # platform accounts — must not collide.
+        store = EntityStore(db_path=tmp_path / "k.db")
+        e_tw = store.upsert(
+            entity_type="twitter_author", identity_key="karpathy",
+            canonical_name="Andrej Karpathy (Twitter)", signals={},
+            derived_authority=0.7, fetch_source="twitterapi.io",
+        )
+        e_gh = store.upsert(
+            entity_type="github_user", identity_key="karpathy",
+            canonical_name="Andrej Karpathy (GitHub)", signals={},
+            derived_authority=0.8, fetch_source="github_rest",
+        )
+        assert e_tw.entity_id != e_gh.entity_id
+
+    def test_unicode_signals_roundtrip(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "k.db")
+        store.upsert(
+            entity_type="twitter_author", identity_key="松_老虎",
+            canonical_name="松老虎",
+            signals={"description": "中文 bio with emoji 🐯"},
+            derived_authority=0.5, fetch_source="t",
+        )
+        round_trip = store.get("twitter_author", "松_老虎")
+        assert round_trip is not None
+        assert round_trip.canonical_name == "松老虎"
+        assert "🐯" in round_trip.signals["description"]
+
+
+class TestRead:
+    def test_get_missing_returns_none(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "k.db")
+        assert store.get("twitter_author", "ghost") is None
+
+    def test_list_by_type_sorted_by_authority_desc(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "k.db")
+        for h, a in [("low", 0.2), ("high", 0.9), ("mid", 0.5)]:
+            store.upsert(
+                entity_type="twitter_author", identity_key=h,
+                canonical_name=h, signals={}, derived_authority=a,
+                fetch_source="t",
+            )
+        rows = store.list_by_type("twitter_author")
+        assert [r.identity_key for r in rows] == ["high", "mid", "low"]
+
+    def test_list_by_type_excludes_other_types(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "k.db")
+        store.upsert(
+            entity_type="twitter_author", identity_key="a",
+            canonical_name="A", signals={}, derived_authority=0.5,
+            fetch_source="t",
+        )
+        store.upsert(
+            entity_type="github_project", identity_key="x/y",
+            canonical_name="X/Y", signals={}, derived_authority=0.7,
+            fetch_source="g",
+        )
+        rows = store.list_by_type("twitter_author")
+        assert len(rows) == 1
+        assert rows[0].identity_key == "a"
+
+    def test_history_limit(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "k.db")
+        for i in range(5):
+            store.upsert(
+                entity_type="twitter_author", identity_key="x",
+                canonical_name="X", signals={"i": i},
+                derived_authority=0.1, fetch_source="t",
+            )
+            time.sleep(0.005)
+        e = store.get("twitter_author", "x")
+        assert e is not None
+        rows = list(store.history(e.entity_id, limit=3))
+        assert len(rows) == 3
+        # newest first
+        assert rows[0][1]["i"] == 4

--- a/tests/test_entity_resolver.py
+++ b/tests/test_entity_resolver.py
@@ -1,0 +1,120 @@
+"""Tests for entities/resolver.py."""
+
+from __future__ import annotations
+
+from ovp_pipeline.entities.resolver import (
+    resolve_github_project_authority,
+    resolve_github_user_authority,
+    resolve_twitter_authority,
+)
+from ovp_pipeline.entities.store import EntityStore
+
+
+def _seed_twitter(store, h, auth):
+    store.upsert(
+        entity_type="twitter_author", identity_key=h, canonical_name=h,
+        signals={}, derived_authority=auth, fetch_source="t",
+    )
+
+
+def _seed_gh_user(store, login, auth, **signals):
+    store.upsert(
+        entity_type="github_user", identity_key=login, canonical_name=login,
+        signals=signals, derived_authority=auth, fetch_source="g",
+    )
+
+
+def _seed_gh_project(store, ident, auth):
+    store.upsert(
+        entity_type="github_project", identity_key=ident, canonical_name=ident,
+        signals={}, derived_authority=auth, fetch_source="g",
+    )
+
+
+def _seed_person(store, h, auth):
+    store.upsert(
+        entity_type="person", identity_key=h, canonical_name=h,
+        signals={"links": []}, derived_authority=auth, fetch_source="m",
+    )
+
+
+class TestResolveTwitter:
+    def test_falls_back_to_twitter_author(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "k.db")
+        _seed_twitter(store, "karpathy", 0.50)
+        r = resolve_twitter_authority(store, "karpathy")
+        assert r.authority == 0.50
+        assert r.source == "twitter_author"
+
+    def test_person_wins_over_twitter(self, tmp_path):
+        # When a person entity exists for the handle, it carries the
+        # max-of-platforms authority — beat the bare twitter_author.
+        store = EntityStore(db_path=tmp_path / "k.db")
+        _seed_twitter(store, "karpathy", 0.50)
+        _seed_person(store, "karpathy", 0.65)
+        r = resolve_twitter_authority(store, "karpathy")
+        assert r.authority == 0.65
+        assert r.source == "person"
+
+    def test_normalizes_atsign_and_case(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "k.db")
+        _seed_twitter(store, "karpathy", 0.50)
+        r = resolve_twitter_authority(store, "@KARPATHY")
+        assert r.authority == 0.50
+
+    def test_unknown_returns_none(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "k.db")
+        r = resolve_twitter_authority(store, "ghost")
+        assert r.authority is None
+        assert r.source == "none"
+
+    def test_empty_handle_returns_none(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "k.db")
+        r = resolve_twitter_authority(store, "")
+        assert r.authority is None
+        r2 = resolve_twitter_authority(store, "@")
+        assert r2.authority is None
+
+
+class TestResolveGithubProject:
+    def test_direct_project_hit(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "k.db")
+        _seed_gh_project(store, "karpathy/nanogpt", 0.92)
+        r = resolve_github_project_authority(store, "karpathy", "nanoGPT")
+        assert r.authority == 0.92
+        assert r.source == "github_project"
+
+    def test_owner_fallback_capped(self, tmp_path):
+        # No project entity, but owner is well-known.  Falls back but
+        # caps at 0.55 — we don't actually know whether THIS particular
+        # repo is high-quality.
+        store = EntityStore(db_path=tmp_path / "k.db")
+        _seed_gh_user(store, "karpathy", 0.65)
+        r = resolve_github_project_authority(store, "karpathy", "experiments")
+        assert r.authority == 0.55
+        assert r.source == "github_user"
+
+    def test_unknown_owner_unknown_repo(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "k.db")
+        r = resolve_github_project_authority(store, "ghost", "missing")
+        assert r.authority is None
+
+
+class TestResolveGithubUser:
+    def test_direct_hit(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "k.db")
+        _seed_gh_user(store, "karpathy", 0.65)
+        r = resolve_github_user_authority(store, "karpathy")
+        assert r.authority == 0.65
+        assert r.source == "github_user"
+
+    def test_person_via_self_reported_twitter(self, tmp_path):
+        # github_user has twitter_username="karpathy", and a person
+        # entity exists keyed by that twitter handle — return the
+        # person's higher score.
+        store = EntityStore(db_path=tmp_path / "k.db")
+        _seed_gh_user(store, "karpathy", 0.65, twitter_username="karpathy")
+        _seed_person(store, "karpathy", 0.75)
+        r = resolve_github_user_authority(store, "karpathy")
+        assert r.authority == 0.75
+        assert r.source == "person"

--- a/tests/test_github_backfill.py
+++ b/tests/test_github_backfill.py
@@ -1,0 +1,332 @@
+"""Tests for entities/github_backfill.py.
+
+Mocks ``urllib.request.urlopen`` — never hits the real GitHub API.
+Covers:
+  * project + user score formulas at each dimension threshold
+  * 200 / 404 / 401 (auth) / 403 (rate limit) / 429 / network paths
+  * the owner_lift mechanism that pulls user authority into project score
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import urllib.error
+
+from ovp_pipeline.entities.github_backfill import (
+    PRICE_PER_CALL_USD,
+    _years_since,
+    _days_since,
+    compute_project_authority,
+    compute_user_authority,
+    derive_project_signals,
+    derive_user_signals,
+    fetch_repo,
+    fetch_user,
+    stub_signals_for_missing,
+)
+
+
+def _years_ago_iso(years: float) -> str:
+    delta = years * 365.25 * 86400
+    ts = datetime.now(timezone.utc).timestamp() - delta
+    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _days_ago_iso(days: float) -> str:
+    ts = datetime.now(timezone.utc).timestamp() - days * 86400
+    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _fake_response(status: int, body):
+    raw = body if isinstance(body, str) else json.dumps(body)
+    f = io.BytesIO(raw.encode("utf-8"))
+    f.status = status
+    return f
+
+
+# ---------------------------------------------------------------------------
+# Project score formula
+# ---------------------------------------------------------------------------
+
+
+class TestComputeProjectAuthority:
+    def test_zero_signals_zero_score(self):
+        score, b = compute_project_authority({})
+        # not_archived (5) + not_fork (5) trigger by default — that's
+        # the signal "this isn't an archived fork", which is true of an
+        # empty payload.  Everything else is 0.
+        assert b["stars"] == 0
+        assert b["forks"] == 0
+        assert b["recency"] == 0
+        assert b["age"] == 0
+        assert b["license"] == 0
+        # archived/fork default to falsy → those credits apply
+        assert b["not_archived"] == 5
+        assert b["not_fork"] == 5
+        assert score == 10  # not_archived + not_fork
+
+    def test_high_stars_capped_at_30(self):
+        _, b = compute_project_authority({"stargazers_count": 200_000})
+        assert b["stars"] == 30
+
+    def test_star_log_bands(self):
+        _, b1 = compute_project_authority({"stargazers_count": 1500})
+        _, b2 = compute_project_authority({"stargazers_count": 150})
+        _, b3 = compute_project_authority({"stargazers_count": 5})
+        assert b1["stars"] == 20
+        assert b2["stars"] == 12
+        assert b3["stars"] == 0
+
+    def test_archived_loses_5_points(self):
+        _, b = compute_project_authority({"archived": True})
+        assert b["not_archived"] == 0
+
+    def test_fork_loses_5_points(self):
+        _, b = compute_project_authority({"fork": True})
+        assert b["not_fork"] == 0
+
+    def test_recent_push_full_credit(self):
+        _, b = compute_project_authority({"pushed_at": _days_ago_iso(15)})
+        assert b["recency"] == 15
+
+    def test_dormant_3y_zero_recency(self):
+        _, b = compute_project_authority({"pushed_at": _days_ago_iso(365 * 5)})
+        assert b["recency"] == 0
+
+    def test_license_credit(self):
+        _, b = compute_project_authority({"license": {"spdx_id": "MIT"}})
+        assert b["license"] == 5
+        # malformed license obj shouldn't credit
+        _, b2 = compute_project_authority({"license": "MIT"})  # str not dict
+        assert b2["license"] == 0
+
+    def test_owner_lift_passed_through(self):
+        _, b = compute_project_authority({}, owner_lift=20)
+        assert b["owner_lift"] == 20
+
+    def test_owner_lift_clamped(self):
+        _, b = compute_project_authority({}, owner_lift=999)
+        assert b["owner_lift"] == 20
+        _, b2 = compute_project_authority({}, owner_lift=-5)
+        assert b2["owner_lift"] == 0
+
+    def test_max_score_cap(self):
+        score, _ = compute_project_authority({
+            "stargazers_count": 100_000,
+            "forks_count": 5_000,
+            "pushed_at": _days_ago_iso(1),
+            "created_at": _years_ago_iso(10),
+            "license": {"spdx_id": "Apache-2.0"},
+            "archived": False, "fork": False,
+        }, owner_lift=20)
+        # 30 + 10 + 15 + 10 + 5 + 5 + 5 + 20 = 100
+        assert score == 100
+
+
+# ---------------------------------------------------------------------------
+# User score formula
+# ---------------------------------------------------------------------------
+
+
+class TestComputeUserAuthority:
+    def test_zero_signals_zero_score(self):
+        score, _ = compute_user_authority({})
+        assert score == 0
+
+    def test_high_followers(self):
+        _, b = compute_user_authority({"followers": 50_000})
+        assert b["followers"] == 25
+
+    def test_organization_account_credited(self):
+        _, b = compute_user_authority({"type": "Organization"})
+        assert b["is_organization"] == 10
+
+    def test_user_account_no_org_credit(self):
+        _, b = compute_user_authority({"type": "User"})
+        assert b["is_organization"] == 0
+
+    def test_company_string_credited_only_if_nonempty(self):
+        _, b1 = compute_user_authority({"company": "Anthropic"})
+        _, b2 = compute_user_authority({"company": ""})
+        _, b3 = compute_user_authority({"company": None})
+        assert b1["has_company"] == 10
+        assert b2["has_company"] == 0
+        assert b3["has_company"] == 0
+
+    def test_max_score_cap(self):
+        score, _ = compute_user_authority({
+            "followers": 50_000,
+            "public_repos": 200,
+            "created_at": _years_ago_iso(15),
+            "bio": "researcher",
+            "blog": "https://example.com",
+            "company": "Anthropic",
+            "type": "User",
+        })
+        # 25 + 10 + 10 + 5 + 5 + 10 = 65 (no org credit for User)
+        assert score == 65
+
+
+# ---------------------------------------------------------------------------
+# Derive helpers
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveProjectSignals:
+    def test_records_missing_dimensions(self):
+        _, signals = derive_project_signals({"stargazers_count": 100})
+        assert "commit_velocity_30d" in signals["missing_dimensions"]
+        assert "contributor_count" in signals["missing_dimensions"]
+
+    def test_owner_authority_maps_to_owner_lift(self):
+        # owner_authority_0_75 == 0.75 should max out owner_lift at 20
+        a_full, signals_full = derive_project_signals(
+            {"stargazers_count": 1000}, owner_authority_0_75=0.75,
+        )
+        a_zero, signals_zero = derive_project_signals(
+            {"stargazers_count": 1000}, owner_authority_0_75=0.0,
+        )
+        assert signals_full["weight_breakdown"]["owner_lift"] == 20
+        assert signals_zero["weight_breakdown"]["owner_lift"] == 0
+        # full owner authority should yield strictly higher project authority
+        assert a_full > a_zero
+
+    def test_authority_in_unit_interval(self):
+        a, _ = derive_project_signals({
+            "stargazers_count": 100_000,
+            "forks_count": 10_000,
+            "pushed_at": _days_ago_iso(1),
+            "created_at": _years_ago_iso(10),
+            "license": {"spdx_id": "MIT"},
+        }, owner_authority_0_75=0.75)
+        assert 0.0 <= a <= 1.0
+
+
+class TestDeriveUserSignals:
+    def test_authority_caps_below_canonical_band(self):
+        # Even fully-loaded github_user maxes at 75/100 = 0.75, leaving
+        # 0.75-1.0 reserved for explicit human curation.
+        a, _ = derive_user_signals({
+            "followers": 50_000,
+            "public_repos": 200,
+            "created_at": _years_ago_iso(15),
+            "bio": "ok", "blog": "ok", "company": "ok",
+            "type": "Organization",
+        })
+        assert a == 0.75
+
+    def test_persists_twitter_username_for_cross_platform_link(self):
+        # PR-E3 will use this to merge github_user with twitter_author.
+        _, signals = derive_user_signals({
+            "login": "karpathy", "twitter_username": "karpathy",
+        })
+        assert signals["twitter_username"] == "karpathy"
+
+
+# ---------------------------------------------------------------------------
+# Fetch
+# ---------------------------------------------------------------------------
+
+
+class TestFetchRepo:
+    def test_success(self):
+        body = {"full_name": "karpathy/nanoGPT", "stargazers_count": 30000}
+        with patch(
+            "ovp_pipeline.entities.github_backfill.urllib.request.urlopen"
+        ) as m:
+            m.return_value.__enter__.return_value = _fake_response(200, body)
+            r = fetch_repo("karpathy", "nanoGPT", token="t")
+        assert r.status == "ok"
+        assert r.payload["stargazers_count"] == 30000
+
+    def test_404(self):
+        with patch(
+            "ovp_pipeline.entities.github_backfill.urllib.request.urlopen"
+        ) as m:
+            m.side_effect = urllib.error.HTTPError(
+                "u", 404, "not found", {}, io.BytesIO(b'{"message":"Not Found"}'),
+            )
+            r = fetch_repo("ghost", "missing", token="t")
+        assert r.status == "not_found"
+
+    def test_403_rate_limit_retries(self):
+        # Fresh HTTPError per call — re-using one instance would have
+        # the body BytesIO drained after the first .read(), which
+        # masks the "rate limit" message on subsequent attempts.
+        def _raise_rate_limit(*_args, **_kwargs):
+            raise urllib.error.HTTPError(
+                "u", 403, "rate", {},
+                io.BytesIO(b'{"message":"API rate limit exceeded"}'),
+            )
+        with patch(
+            "ovp_pipeline.entities.github_backfill.urllib.request.urlopen",
+            side_effect=_raise_rate_limit,
+        ) as m, patch(
+            "ovp_pipeline.entities.github_backfill.time.sleep"
+        ) as sleeper:
+            r = fetch_repo("a", "b", token="t")
+        assert r.status == "error"
+        assert m.call_count == 3
+        assert sleeper.call_count >= 2
+
+    def test_401_no_retry(self):
+        with patch(
+            "ovp_pipeline.entities.github_backfill.urllib.request.urlopen"
+        ) as m:
+            m.side_effect = urllib.error.HTTPError(
+                "u", 401, "auth", {},
+                io.BytesIO(b'{"message":"Bad credentials"}'),
+            )
+            r = fetch_repo("a", "b", token="bad")
+        assert r.status == "error"
+        assert "auth" in (r.error or "").lower()
+
+    def test_missing_owner_or_repo(self):
+        r = fetch_repo("", "x", token="t")
+        assert r.status == "error"
+        r2 = fetch_repo("x", "", token="t")
+        assert r2.status == "error"
+
+
+class TestFetchUser:
+    def test_success(self):
+        body = {"login": "karpathy", "followers": 100_000, "type": "User"}
+        with patch(
+            "ovp_pipeline.entities.github_backfill.urllib.request.urlopen"
+        ) as m:
+            m.return_value.__enter__.return_value = _fake_response(200, body)
+            r = fetch_user("karpathy", token="t")
+        assert r.status == "ok"
+        assert r.payload["followers"] == 100_000
+
+
+def test_price_constant_is_zero():
+    # GitHub REST is free; if we ever switch to a paid mirror this
+    # test is the canary.
+    assert PRICE_PER_CALL_USD == 0.0
+
+
+def test_stub_signals_for_missing():
+    s = stub_signals_for_missing("ghost/missing", "project", "404")
+    assert s["identity"] == "ghost/missing"
+    assert s["kind"] == "project"
+    assert s["fetch_status"] == "not_found"
+
+
+class TestParseHelpers:
+    def test_years_since_handles_z_suffix(self):
+        # GitHub returns ISO-with-Z; ensure parser accepts it
+        s = _years_ago_iso(2.0)
+        assert 1.9 < _years_since(s) < 2.1
+
+    def test_years_since_unparseable_returns_zero(self):
+        assert _years_since("nonsense") == 0.0
+        assert _years_since(None) == 0.0
+
+    def test_days_since_unparseable_returns_inf(self):
+        # Used for "no recency credit" — unparseable should mean "very old"
+        assert _days_since(None) == float("inf")

--- a/tests/test_identity_merge.py
+++ b/tests/test_identity_merge.py
@@ -1,0 +1,200 @@
+"""Tests for entities/identity_merge.py."""
+
+from __future__ import annotations
+
+from ovp_pipeline.entities.identity_merge import (
+    MergeCandidate,
+    PERSON_TYPE,
+    apply_merge,
+    find_merge_candidates,
+    _levenshtein,
+)
+from ovp_pipeline.entities.store import EntityStore
+
+
+def _make_tw(store, handle, **kw):
+    return store.upsert(
+        entity_type="twitter_author", identity_key=handle,
+        canonical_name=kw.pop("name", handle),
+        signals=kw.pop("signals", {}),
+        derived_authority=kw.pop("authority", 0.5),
+        fetch_source="twitterapi.io",
+    )
+
+
+def _make_gh(store, login, **kw):
+    return store.upsert(
+        entity_type="github_user", identity_key=login,
+        canonical_name=kw.pop("name", login),
+        signals=kw.pop("signals", {}),
+        derived_authority=kw.pop("authority", 0.5),
+        fetch_source="github_rest",
+    )
+
+
+class TestLevenshtein:
+    def test_identical(self):
+        assert _levenshtein("abc", "abc") == 0
+
+    def test_one_substitution(self):
+        assert _levenshtein("abc", "abd") == 1
+
+    def test_one_insertion(self):
+        assert _levenshtein("abc", "abxc") == 1
+
+    def test_empty_either_side(self):
+        assert _levenshtein("", "abc") == 3
+        assert _levenshtein("abc", "") == 3
+
+    def test_real_world_pair(self):
+        # The mattpocock case from the PR-E2 cross-link report.
+        assert _levenshtein("mattpocock", "mattpocockuk") == 2
+
+
+class TestSelfReportedMerge:
+    def test_picks_up_self_reported_handle(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "k.db")
+        _make_tw(store, "karpathy", authority=0.50)
+        _make_gh(store, "karpathy",
+                 signals={"twitter_username": "karpathy"},
+                 authority=0.65)
+        cands = find_merge_candidates(store)
+        self_rep = [c for c in cands if c.method == "self_reported"]
+        assert len(self_rep) == 1
+        assert self_rep[0].github_login == "karpathy"
+        assert self_rep[0].twitter_handle == "karpathy"
+        assert self_rep[0].is_auto
+
+    def test_self_report_normalizes_atsign_and_case(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "k.db")
+        _make_tw(store, "karpathy", authority=0.50)
+        _make_gh(store, "kp",
+                 signals={"twitter_username": "@KARPATHY"},
+                 authority=0.65)
+        cands = find_merge_candidates(store)
+        self_rep = [c for c in cands if c.method == "self_reported"]
+        assert len(self_rep) == 1
+        assert self_rep[0].twitter_handle == "karpathy"
+
+    def test_self_report_skipped_when_twitter_entity_missing(self, tmp_path):
+        # GitHub user reports a Twitter handle we never backfilled —
+        # nothing to link, no candidate emitted.
+        store = EntityStore(db_path=tmp_path / "k.db")
+        _make_gh(store, "ghost",
+                 signals={"twitter_username": "neverseen"},
+                 authority=0.4)
+        cands = find_merge_candidates(store)
+        assert cands == []
+
+
+class TestExactHandle:
+    def test_emits_review_candidate(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "k.db")
+        _make_tw(store, "simonw", authority=0.50)
+        _make_gh(store, "simonw", authority=0.65)   # no twitter_username field
+        cands = find_merge_candidates(store)
+        exact = [c for c in cands if c.method == "exact_handle"]
+        assert len(exact) == 1
+        # Exact-handle is below the auto threshold by default
+        assert not exact[0].is_auto
+
+    def test_exact_skips_short_handles(self, tmp_path):
+        # "abc" exists on both sides but is too short to call a same-person.
+        store = EntityStore(db_path=tmp_path / "k.db")
+        _make_tw(store, "abc", authority=0.5)
+        _make_gh(store, "abc", authority=0.5)
+        cands = find_merge_candidates(store)
+        assert all(c.method != "exact_handle" for c in cands)
+
+    def test_exact_skipped_when_self_report_already_matches(self, tmp_path):
+        # github_user reports the same twitter handle — only the
+        # self_reported entry should fire, not also exact_handle.
+        store = EntityStore(db_path=tmp_path / "k.db")
+        _make_tw(store, "simonw", authority=0.5)
+        _make_gh(store, "simonw",
+                 signals={"twitter_username": "simonw"},
+                 authority=0.5)
+        cands = find_merge_candidates(store)
+        # No duplicate emission for the same (github, twitter) pair.
+        pairs = {(c.github_login, c.twitter_handle) for c in cands}
+        assert len(pairs) == len(cands)
+
+
+class TestFuzzy:
+    def test_emits_low_confidence_review(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "k.db")
+        _make_tw(store, "mattpocockuk", authority=0.4)
+        _make_gh(store, "mattpocock", authority=0.5)
+        cands = find_merge_candidates(store)
+        fuzzy = [c for c in cands if c.method == "fuzzy"]
+        assert len(fuzzy) == 1
+        # Fuzzy candidates must NOT be auto-applied
+        assert not fuzzy[0].is_auto
+
+    def test_fuzzy_distance_cap(self, tmp_path):
+        # Levenshtein distance of 3 is past the cap — must not fire.
+        store = EntityStore(db_path=tmp_path / "k.db")
+        _make_tw(store, "alice123", authority=0.5)
+        _make_gh(store, "bob", authority=0.5)   # length difference alone is 5
+        cands = find_merge_candidates(store)
+        assert not any(c.method == "fuzzy" for c in cands)
+
+
+class TestNotFoundStubsExcluded:
+    def test_stub_entities_not_merged(self, tmp_path):
+        # not_found stubs (derived_authority=None) must never appear
+        # in merge candidates — there's no signal to merge.
+        store = EntityStore(db_path=tmp_path / "k.db")
+        _make_tw(store, "ghost", authority=None)
+        _make_gh(store, "ghost", authority=None,
+                 signals={"twitter_username": "ghost"})
+        cands = find_merge_candidates(store)
+        assert cands == []
+
+
+class TestApplyMerge:
+    def test_creates_person_entity(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "k.db")
+        _make_tw(store, "karpathy", authority=0.50,
+                 signals={"followers": 1_500_000})
+        _make_gh(store, "karpathy", authority=0.65,
+                 signals={"twitter_username": "karpathy",
+                          "followers": 60_000,
+                          "bio": "AI researcher"})
+        cands = find_merge_candidates(store)
+        applied = [apply_merge(store, c) for c in cands if c.is_auto]
+        assert len(applied) == 1
+
+        person = store.get(PERSON_TYPE, "karpathy")
+        assert person is not None
+        # Authority is the MAX of the two sides, not the average
+        assert person.derived_authority == 0.65
+        # Both platforms are linked
+        link_types = {ln["entity_type"] for ln in person.signals["links"]}
+        assert link_types == {"twitter_author", "github_user"}
+        # Surfaced fields from both sides
+        assert person.signals["twitter_followers"] == 1_500_000
+        assert person.signals["github_followers"] == 60_000
+        assert person.signals["bio"] == "AI researcher"
+
+    def test_apply_is_idempotent(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "k.db")
+        _make_tw(store, "x", authority=0.4)
+        _make_gh(store, "x", authority=0.5,
+                 signals={"twitter_username": "x"})
+        cands = find_merge_candidates(store)
+        for c in cands:
+            apply_merge(store, c)
+            apply_merge(store, c)   # second call must not error or duplicate
+        assert len(store.list_by_type(PERSON_TYPE)) == 1
+
+    def test_apply_returns_none_when_side_disappears(self, tmp_path):
+        # Race: candidate built from a snapshot, then one side gets
+        # deleted before apply runs.  Should return None, not crash.
+        store = EntityStore(db_path=tmp_path / "k.db")
+        c = MergeCandidate(
+            github_login="ghost", twitter_handle="ghost",
+            method="self_reported", confidence=0.95, rationale="",
+        )
+        # Neither entity exists.
+        assert apply_merge(store, c) is None

--- a/tests/test_twitter_backfill.py
+++ b/tests/test_twitter_backfill.py
@@ -1,0 +1,278 @@
+"""Tests for entities/twitter_backfill.py.
+
+Uses unittest.mock to fake urlopen — never hits the real twitterapi.io
+in CI.  Verifies:
+  * the score formula matches the documented dimension table
+  * fetch_user_info handles 200 / 401 / 404 / 429 / network errors
+  * the persisted ``signals`` dict carries the missing-dimensions list
+    so reviewers can tell apart "we never had this signal" from
+    "this signal was zero".
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import urllib.error
+
+from ovp_pipeline.entities.twitter_backfill import (
+    PRICE_PER_CALL_USD,
+    _account_age_years,
+    compute_partial_author_weight,
+    derive_authority_from_payload,
+    fetch_user_info,
+    stub_signals_for_missing,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _years_ago_iso(years: float) -> str:
+    """ISO timestamp ``years`` years ago in UTC, accepted by twitterapi.io."""
+    delta_days = years * 365.25
+    now = datetime.now(timezone.utc)
+    target_ts = now.timestamp() - delta_days * 86400
+    return datetime.fromtimestamp(target_ts, tz=timezone.utc).isoformat(
+        timespec="microseconds"
+    ).replace("+00:00", "Z")
+
+
+def _fake_response(status: int, body: dict | str):
+    """Build a FakeURLOpen-ready return value for urllib.request.urlopen."""
+    raw = body if isinstance(body, str) else json.dumps(body)
+    f = io.BytesIO(raw.encode("utf-8"))
+    f.status = status
+    return f
+
+
+# ---------------------------------------------------------------------------
+# Score formula
+# ---------------------------------------------------------------------------
+
+
+class TestComputePartialAuthorWeight:
+    def test_zero_inputs_zero_score(self):
+        score, breakdown = compute_partial_author_weight({})
+        assert score == 0
+        # negative-only outcome (automated penalty) is clipped to 0 by max()
+        assert all(v == 0 for v in breakdown.values())
+
+    def test_high_followers_dominates(self):
+        score, b = compute_partial_author_weight({
+            "followers": 500_000,
+            "createdAt": _years_ago_iso(10),
+            "isBlueVerified": True,
+            "isVerified": True,
+        })
+        assert b["followers"] == 25
+        assert b["age"] == 10
+        assert b["blue_verified"] == 5
+        assert b["legacy_verified"] == 10
+        assert score == 50
+
+    def test_company_affiliation_adds_10(self):
+        score, b = compute_partial_author_weight({
+            "followers": 1500,
+            "createdAt": _years_ago_iso(4),
+            "affiliatesHighlightedLabel": {"label": {"text": "Anthropic"}},
+        })
+        assert b["affiliation"] == 10
+
+    def test_automated_account_penalized(self):
+        score_normal, _ = compute_partial_author_weight({
+            "followers": 5000, "createdAt": _years_ago_iso(5),
+            "statusesCount": 1000,
+        })
+        score_bot, b_bot = compute_partial_author_weight({
+            "followers": 5000, "createdAt": _years_ago_iso(5),
+            "statusesCount": 1000, "isAutomated": True,
+        })
+        assert b_bot["automated_penalty"] == -10
+        assert score_bot == score_normal - 10
+
+    def test_activity_band(self):
+        # too-active accounts get a slight discount, not full credit.
+        _, b_normal = compute_partial_author_weight({"statusesCount": 1000})
+        _, b_extreme = compute_partial_author_weight({"statusesCount": 100_000})
+        assert b_normal["activity"] == 10
+        assert b_extreme["activity"] == 8
+
+    def test_max_score_caps_under_70(self):
+        # Even with every dimension maxed, score can't reach 70 because
+        # listed/mutuals/i_follow are deliberately not modeled here.
+        score, _ = compute_partial_author_weight({
+            "followers": 10_000_000,
+            "createdAt": _years_ago_iso(15),
+            "isBlueVerified": True,
+            "isVerified": True,
+            "verifiedType": "company",
+            "affiliatesHighlightedLabel": {"label": "ok"},
+            "statusesCount": 5000,
+        })
+        # 25 + 10 + 5 + 10 + 10 + 10 = 70 (no penalty)
+        assert score == 70
+
+    def test_negative_only_score_floors_at_zero(self):
+        # If an account is automated and has no other signals, the
+        # raw sum is -10; max() clips it to 0 so the persisted
+        # authority stays in [0, 1].
+        score, _ = compute_partial_author_weight({"isAutomated": True})
+        assert score == 0
+
+
+class TestAccountAgeYears:
+    def test_iso_format(self):
+        s = _years_ago_iso(5.0)
+        years = _account_age_years(s)
+        assert 4.9 < years < 5.1
+
+    def test_x_legacy_format(self):
+        # X's classic API used this shape; twitterapi.io may sometimes echo it.
+        years = _account_age_years("Thu Dec 13 08:41:26 +0000 2007")
+        assert years > 16   # 2026 - 2007
+
+    def test_unparseable_returns_zero(self):
+        assert _account_age_years("nonsense") == 0.0
+        assert _account_age_years(None) == 0.0
+        assert _account_age_years("") == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Authority derivation
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveAuthorityFromPayload:
+    def test_persists_missing_dimensions_marker(self):
+        # The signals dict must record what we DON'T have, so a future
+        # formula change can detect "we never collected this" vs
+        # "this was zero".
+        _, signals = derive_authority_from_payload(
+            {"userName": "x", "followers": 100, "createdAt": _years_ago_iso(2)}
+        )
+        assert "listed_count" in signals["missing_dimensions"]
+        assert "mutuals_count" in signals["missing_dimensions"]
+        assert "i_follow" in signals["missing_dimensions"]
+
+    def test_authority_in_unit_interval(self):
+        a, _ = derive_authority_from_payload(
+            {"followers": 10_000_000, "createdAt": _years_ago_iso(15),
+             "isBlueVerified": True, "verifiedType": "company",
+             "affiliatesHighlightedLabel": {"label": "ok"},
+             "statusesCount": 5000}
+        )
+        assert 0.0 <= a <= 1.0
+
+    def test_authority_caps_below_clipper_max(self):
+        # 70 / 100 = 0.70 — leaves the 0.71-1.0 band reserved for
+        # clipper-rich frontmatter that has the missing signals.
+        a, _ = derive_authority_from_payload(
+            {"followers": 10_000_000, "createdAt": _years_ago_iso(15),
+             "isBlueVerified": True, "verifiedType": "company",
+             "affiliatesHighlightedLabel": {"label": "ok"},
+             "statusesCount": 5000}
+        )
+        assert a == 0.70
+
+
+# ---------------------------------------------------------------------------
+# Fetch
+# ---------------------------------------------------------------------------
+
+
+class TestFetchUserInfo:
+    def test_success_returns_payload(self):
+        body = {
+            "status": "success",
+            "data": {"userName": "karpathy", "followers": 1_000_000},
+        }
+        with patch(
+            "ovp_pipeline.entities.twitter_backfill.urllib.request.urlopen"
+        ) as m:
+            m.return_value.__enter__.return_value = _fake_response(200, body)
+            r = fetch_user_info("karpathy", api_key="k")
+        assert r.status == "ok"
+        assert r.payload["followers"] == 1_000_000
+
+    def test_404_marks_not_found_no_retry(self):
+        with patch(
+            "ovp_pipeline.entities.twitter_backfill.urllib.request.urlopen"
+        ) as m:
+            m.side_effect = urllib.error.HTTPError(
+                "u", 404, "not found", {}, None,
+            )
+            r = fetch_user_info("ghost", api_key="k")
+        assert r.status == "not_found"
+        # only one attempt — no retries on 404
+        assert m.call_count == 1
+
+    def test_401_aborts_immediately(self):
+        with patch(
+            "ovp_pipeline.entities.twitter_backfill.urllib.request.urlopen"
+        ) as m:
+            m.side_effect = urllib.error.HTTPError(
+                "u", 401, "auth", {}, None,
+            )
+            r = fetch_user_info("x", api_key="bad")
+        assert r.status == "error"
+        assert "auth" in (r.error or "").lower()
+        assert m.call_count == 1
+
+    def test_429_retries_then_gives_up(self):
+        with patch(
+            "ovp_pipeline.entities.twitter_backfill.urllib.request.urlopen"
+        ) as m, patch(
+            "ovp_pipeline.entities.twitter_backfill.time.sleep"
+        ) as sleeper:
+            m.side_effect = urllib.error.HTTPError(
+                "u", 429, "rate", {}, None,
+            )
+            r = fetch_user_info("x", api_key="k")
+        assert r.status == "error"
+        # Retried up to _MAX_RETRIES times.
+        assert m.call_count == 3
+        # Backoff is exercised between attempts.
+        assert sleeper.call_count >= 2
+
+    def test_api_error_status_with_user_not_found_msg(self):
+        body = {"status": "error", "msg": "user not found"}
+        with patch(
+            "ovp_pipeline.entities.twitter_backfill.urllib.request.urlopen"
+        ) as m:
+            m.return_value.__enter__.return_value = _fake_response(200, body)
+            r = fetch_user_info("ghost", api_key="k")
+        assert r.status == "not_found"
+
+    def test_missing_api_key_short_circuits(self):
+        r = fetch_user_info("x", api_key="")
+        assert r.status == "error"
+        # No call attempted.
+
+    def test_bad_json_marks_error(self):
+        with patch(
+            "ovp_pipeline.entities.twitter_backfill.urllib.request.urlopen"
+        ) as m:
+            m.return_value.__enter__.return_value = _fake_response(200, "<not json>")
+            r = fetch_user_info("x", api_key="k")
+        assert r.status == "error"
+        assert "json" in (r.error or "").lower()
+
+
+class TestStubSignalsForMissing:
+    def test_records_handle_and_reason(self):
+        s = stub_signals_for_missing("ghost", "404 from API")
+        assert s["userName"] == "ghost"
+        assert s["fetch_status"] == "not_found"
+        assert "404" in s["fetch_reason"]
+
+
+def test_price_constant_matches_intro_doc():
+    # If twitterapi.io changes pricing we should see this fail.
+    # Anchor against the documented $0.18/1k = $0.00018 figure.
+    assert PRICE_PER_CALL_USD == 0.00018


### PR DESCRIPTION
## Summary

- **PR-E3** — closes the loop on the entity layer.
- Source-signal providers (\`AuthorRulesProvider\`) now read from the entities populated by #115 / #116.
- New \`person\` entity type collapses \`twitter_author\` + \`github_user\` pairs into a single canonical identity.
- **54 high-confidence merges** auto-applied against the real vault (full report in comment below).
- Stacked on #116; will rebase onto main after #115/#116 merge.

## What gets wired

### Identity merge (\`entities/identity_merge.py\`)

Three rules in confidence order:

| method | confidence | applied? | source |
|---|---|---|---|
| \`self_reported\` | 0.95 | ✅ auto | \`github_user.twitter_username\` matches an existing \`twitter_author\` |
| \`exact_handle\` | 0.85 | review | identical handle on both platforms, ≥4 chars |
| \`fuzzy\` | ≤0.55 | review | Levenshtein distance ≤ 2 (mattpocock ↔ mattpocockuk) |

\`person\` \`identity_key\` is the canonical Twitter handle.  \`derived_authority\` is **max** of linked entities (never average) — being more famous on one platform shouldn't punish the merged record.

### Resolver (\`entities/resolver.py\`)

Single read path for source-signal providers:

\`\`\`
resolve_twitter_authority(store, handle)        →  person → twitter_author
resolve_github_project_authority(store, o, r)   →  project → owner-fallback (capped 0.55)
resolve_github_user_authority(store, login)     →  person-via-twitter-username → github_user
\`\`\`

The owner-fallback cap of 0.55 prevents an unknown repo from inheriting Karpathy's full reputation just because Karpathy owns it; an explicit project entity always wins on the next backfill.

### \`AuthorRulesProvider\` fallback

When an X handle isn't in \`authors.jsonl\` (curated whitelist), the provider now consults the entity table.  Entity authority × 0.85 (configurable) so curated whitelist entries strictly outrank entity-derived ones at the same raw score.

The PR-E1 promise stays intact: no ingestion paths change, \`authors.jsonl\` stays user-curated, only the \`score()\` return value gains a new fallback branch.

## CLI: \`ovp-merge-identities\`

\`\`\`
ovp-merge-identities --dry-run            # list candidates (auto + review)
ovp-merge-identities                      # apply self_reported only
ovp-merge-identities --include-fuzzy      # apply exact + fuzzy too (DANGEROUS)
\`\`\`

Idempotent — re-runs just refresh existing person rows.

## Test plan

- [x] Levenshtein helper — identical / one-substitution / one-insertion / empty / real-world pair
- [x] self_reported merge — pickup, normalization, missing-side skip
- [x] exact_handle — review-not-auto, length floor, dedup vs self-report
- [x] fuzzy — low-confidence review, distance cap
- [x] not_found stubs never merged (no signal to merge)
- [x] apply_merge — max-not-avg authority, idempotent, missing-side race
- [x] resolver — twitter (person-wins), github project (owner-fallback-capped), github user (person via twitter_username)
- [x] AuthorRulesProvider fallback — used when not whitelisted, whitelist wins when present, no-op without store, unknown-handle no-op, multiplier customizable
- [x] Full suite: **1709 passed**, lint clean
- [x] Real merge run against vault — see comment

## What this PR does NOT do

- Doesn't touch the GitHub SignalProvider (still uses its own /repos call at ingest time).  PR-E4 will redirect it to read the entity table.
- Doesn't extend the merge to other platforms (Substack, WeChat, etc.).  Same pattern transfers; deferred.
- Doesn't write back to authors.jsonl.  The whitelist remains user-curated; entity table is the inferred parallel.