### PR TITLE
feat(entities): GitHub project + user entity backfill (PR-E2 reopened)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,7 @@ ovp-schema = "ovp_pipeline.commands.schema_cmd:main"
 ovp-backfill-entity-type = "ovp_pipeline.commands.backfill_entity_type:main"
 ovp-backfill-entities = "ovp_pipeline.commands.backfill_entities:main"
 ovp-backfill-twitter-authors = "ovp_pipeline.commands.backfill_twitter_authors:main"
+ovp-backfill-github = "ovp_pipeline.commands.backfill_github:main"
 ovp-refresh-entities = "ovp_pipeline.commands.refresh_entities:main"
 ovp-embedding-dedup = "ovp_pipeline.commands.embedding_dedup:main"
 

--- a/src/ovp_pipeline/commands/backfill_github.py
+++ b/src/ovp_pipeline/commands/backfill_github.py
@@ -173,16 +173,21 @@ def _backfill_projects(
     if not to_fetch:
         return 0, 0, 0, cached
 
+    # Pre-fetch all github_user entities once.  Without this, scoring
+    # 559 projects opens ~559 SQLite connections just to look up the
+    # owner_lift — measured ~50% of total runtime in profile traces.
+    user_authorities: dict[str, float | None] = {
+        u.identity_key: u.derived_authority
+        for u in store.list_by_type(_USER_TYPE)
+    }
+
     n_ok = n_nf = n_err = 0
     for i, (owner, repo, mentions) in enumerate(to_fetch, 1):
         identity = f"{owner}/{repo}"
         result = fetch_repo(owner, repo, token=token)
         if result.status == "ok" and result.payload is not None:
             owner_login = (result.payload.get("owner") or {}).get("login") or owner
-            owner_entity = store.get(_USER_TYPE, owner_login.lower())
-            owner_authority = (
-                owner_entity.derived_authority if owner_entity is not None else 0.0
-            ) or 0.0
+            owner_authority = user_authorities.get(owner_login.lower()) or 0.0
             authority, signals = derive_project_signals(
                 result.payload, owner_authority_0_75=owner_authority,
             )

--- a/src/ovp_pipeline/commands/backfill_github.py
+++ b/src/ovp_pipeline/commands/backfill_github.py
@@ -1,0 +1,336 @@
+"""ovp-backfill-github — populate github_project + github_user entities.
+
+Scans the vault for ``github.com/<owner>/<repo>`` and ``github.com/<owner>``
+mentions, calls the GitHub REST API for each unique entity, persists
+results in the ``entities`` table.
+
+Two-pass strategy:
+  1. Fetch all unique users first (so per-user authority is known).
+  2. Fetch all unique repos, looking up each repo's owner_login in
+     the just-populated user store to compute owner_lift.
+
+This means a fresh repo whose owner you've never seen still gets
+scored from its intrinsic stars/forks/recency — owner_lift just
+becomes a bonus signal when available.
+
+Usage::
+
+    ovp-backfill-github --vault-dir ~/Documents/ovp-vault          # both passes
+    ovp-backfill-github --kind users                               # users only
+    ovp-backfill-github --kind projects                            # projects only
+    ovp-backfill-github --dry-run                                  # plan + budget
+
+Auth
+----
+
+Public-repo reads work without a token at 60 req/hour, but for the
+~280 entity OVP vault that's a 5-hour stagger.  Provide a token via:
+
+  1. ``--token`` CLI arg
+  2. ``GITHUB_TOKEN`` env var
+  3. First non-comment line of ``<vault>/60-Logs/.github-token``
+
+A no-scope (public-only) PAT is sufficient — we never write.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from ..entities.github_backfill import (
+    PRICE_PER_CALL_USD,
+    derive_project_signals,
+    derive_user_signals,
+    fetch_repo,
+    fetch_user,
+    stub_signals_for_missing,
+)
+from ..entities.scan import scan_github_mentions
+from ..entities.store import EntityStore
+
+
+_PROJECT_TYPE = "github_project"
+_USER_TYPE = "github_user"
+_FETCH_SOURCE = "github_rest"
+_DEFAULT_MAX_AGE_DAYS = 30
+# GitHub allows ~50 req/sec authenticated; we go slower to be polite
+# and to dodge any secondary rate limits.
+_PER_CALL_SLEEP_S = 0.05
+
+
+def _resolve_token(cli_arg: str | None, vault_dir: Path) -> str | None:
+    if cli_arg:
+        return cli_arg.strip()
+    env = os.environ.get("GITHUB_TOKEN")
+    if env:
+        return env.strip()
+    keyfile = vault_dir / "60-Logs" / ".github-token"
+    if keyfile.exists():
+        for line in keyfile.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line and not line.startswith("#"):
+                return line
+    return None
+
+
+def _is_stale(last_fetched_at: str, max_age_days: int) -> bool:
+    try:
+        dt = datetime.fromisoformat(last_fetched_at)
+    except ValueError:
+        return True
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return (datetime.now(timezone.utc) - dt) > timedelta(days=max_age_days)
+
+
+def _backfill_users(
+    *,
+    store: EntityStore,
+    usernames: list[tuple[str, int]],
+    token: str | None,
+    max_age_days: int,
+    force: bool,
+    max_handles: int | None,
+) -> tuple[int, int, int, int]:
+    """Returns (n_ok, n_not_found, n_error, n_cached)."""
+    to_fetch: list[tuple[str, int]] = []
+    cached = 0
+    for login, mentions in usernames:
+        existing = store.get(_USER_TYPE, login)
+        if existing and not force:
+            if not _is_stale(existing.last_fetched_at, max_age_days):
+                cached += 1
+                continue
+        to_fetch.append((login, mentions))
+    if max_handles is not None:
+        to_fetch = to_fetch[:max_handles]
+
+    print(f"  users: {len(usernames)} discovered, {cached} fresh-cached, "
+          f"{len(to_fetch)} to fetch")
+    if not to_fetch:
+        return 0, 0, 0, cached
+
+    n_ok = n_nf = n_err = 0
+    for i, (login, mentions) in enumerate(to_fetch, 1):
+        result = fetch_user(login, token=token)
+        if result.status == "ok" and result.payload is not None:
+            authority, signals = derive_user_signals(result.payload)
+            signals["mention_count_in_vault"] = mentions
+            store.upsert(
+                entity_type=_USER_TYPE, identity_key=login,
+                canonical_name=result.payload.get("name") or login,
+                signals=signals, derived_authority=authority,
+                fetch_source=_FETCH_SOURCE,
+            )
+            n_ok += 1
+        elif result.status == "not_found":
+            store.upsert(
+                entity_type=_USER_TYPE, identity_key=login,
+                canonical_name=None,
+                signals=stub_signals_for_missing(login, "user", result.error or ""),
+                derived_authority=None, fetch_source=_FETCH_SOURCE,
+            )
+            n_nf += 1
+        else:
+            print(f"    [error] {login}: {result.error}", file=sys.stderr)
+            n_err += 1
+        if i % 25 == 0 or i == len(to_fetch):
+            print(f"    users progress: {i:>4}/{len(to_fetch)}  "
+                  f"ok={n_ok} not_found={n_nf} error={n_err}", flush=True)
+        time.sleep(_PER_CALL_SLEEP_S)
+    return n_ok, n_nf, n_err, cached
+
+
+def _backfill_projects(
+    *,
+    store: EntityStore,
+    repos: list[tuple[str, str, int]],   # (owner, repo, mention_count)
+    token: str | None,
+    max_age_days: int,
+    force: bool,
+    max_handles: int | None,
+) -> tuple[int, int, int, int]:
+    to_fetch: list[tuple[str, str, int]] = []
+    cached = 0
+    for owner, repo, mentions in repos:
+        identity = f"{owner}/{repo}"
+        existing = store.get(_PROJECT_TYPE, identity)
+        if existing and not force:
+            if not _is_stale(existing.last_fetched_at, max_age_days):
+                cached += 1
+                continue
+        to_fetch.append((owner, repo, mentions))
+    if max_handles is not None:
+        to_fetch = to_fetch[:max_handles]
+
+    print(f"  projects: {len(repos)} discovered, {cached} fresh-cached, "
+          f"{len(to_fetch)} to fetch")
+    if not to_fetch:
+        return 0, 0, 0, cached
+
+    n_ok = n_nf = n_err = 0
+    for i, (owner, repo, mentions) in enumerate(to_fetch, 1):
+        identity = f"{owner}/{repo}"
+        result = fetch_repo(owner, repo, token=token)
+        if result.status == "ok" and result.payload is not None:
+            owner_login = (result.payload.get("owner") or {}).get("login") or owner
+            owner_entity = store.get(_USER_TYPE, owner_login.lower())
+            owner_authority = (
+                owner_entity.derived_authority if owner_entity is not None else 0.0
+            ) or 0.0
+            authority, signals = derive_project_signals(
+                result.payload, owner_authority_0_75=owner_authority,
+            )
+            signals["mention_count_in_vault"] = mentions
+            store.upsert(
+                entity_type=_PROJECT_TYPE, identity_key=identity,
+                canonical_name=result.payload.get("full_name") or identity,
+                signals=signals, derived_authority=authority,
+                fetch_source=_FETCH_SOURCE,
+            )
+            n_ok += 1
+        elif result.status == "not_found":
+            store.upsert(
+                entity_type=_PROJECT_TYPE, identity_key=identity,
+                canonical_name=None,
+                signals=stub_signals_for_missing(identity, "project", result.error or ""),
+                derived_authority=None, fetch_source=_FETCH_SOURCE,
+            )
+            n_nf += 1
+        else:
+            print(f"    [error] {identity}: {result.error}", file=sys.stderr)
+            n_err += 1
+        if i % 25 == 0 or i == len(to_fetch):
+            print(f"    projects progress: {i:>4}/{len(to_fetch)}  "
+                  f"ok={n_ok} not_found={n_nf} error={n_err}", flush=True)
+        time.sleep(_PER_CALL_SLEEP_S)
+    return n_ok, n_nf, n_err, cached
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Backfill github_project + github_user entities",
+    )
+    parser.add_argument("--vault-dir", type=Path, default=Path.cwd())
+    parser.add_argument("--token", default=None,
+                        help="GitHub PAT (else env GITHUB_TOKEN or keyfile)")
+    parser.add_argument("--kind", choices=["both", "users", "projects"],
+                        default="both",
+                        help="Which entity type(s) to backfill (default both)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Plan + rate-limit budget only, no API calls")
+    parser.add_argument("--max-handles", type=int, default=None,
+                        help="Cap fetches per kind (debug / partial run)")
+    parser.add_argument("--max-age-days", type=int, default=_DEFAULT_MAX_AGE_DAYS,
+                        help="Re-fetch entities older than this many days")
+    parser.add_argument("--force", action="store_true",
+                        help="Re-fetch every entity, even if cached + fresh")
+    args = parser.parse_args(argv)
+
+    vault = args.vault_dir.resolve()
+    if not vault.is_dir():
+        print(f"vault not found: {vault}", file=sys.stderr)
+        return 2
+
+    db_path = vault / "60-Logs" / "knowledge.db"
+    store = EntityStore(db_path=db_path)
+
+    # ---- discover entities -------------------------------------------------
+
+    print("scanning vault...")
+    mentions = scan_github_mentions(vault)
+    repos: list[tuple[str, str, int]] = [
+        (m.owner, m.repo, m.mention_count)
+        for m in mentions if m.repo is not None
+    ]
+    # Owners come from the union of (a) all repo owners and (b) any
+    # github.com/<owner> URLs that didn't carry a /repo segment.
+    owner_counts: dict[str, int] = {}
+    for owner, _repo, c in repos:
+        owner_counts[owner] = owner_counts.get(owner, 0) + c
+    users: list[tuple[str, int]] = sorted(
+        owner_counts.items(), key=lambda kv: -kv[1],
+    )
+
+    print(f"vault: {vault}")
+    print(f"db:    {db_path}")
+    print(f"discovered: {len(repos)} unique repos, {len(users)} unique owners")
+
+    # ---- preflight summary -------------------------------------------------
+
+    if args.dry_run:
+        print("\n--dry-run set; no API calls, no DB writes")
+        print(f"would fetch: kind={args.kind}")
+        if args.kind in {"both", "users"}:
+            print(f"  users:    {len(users)} calls (cost $0)")
+        if args.kind in {"both", "projects"}:
+            print(f"  projects: {len(repos)} calls (cost $0)")
+        return 0
+
+    token = _resolve_token(args.token, vault)
+    if not token:
+        print("warning: no GITHUB_TOKEN; falling back to 60 req/hr unauthenticated.",
+              file=sys.stderr)
+        print("         For >60 entities, set --token or env GITHUB_TOKEN.",
+              file=sys.stderr)
+
+    # ---- run pass(es) ------------------------------------------------------
+
+    totals = {"ok": 0, "not_found": 0, "error": 0, "cached": 0}
+
+    if args.kind in {"both", "users"}:
+        print("\n=== users pass ===")
+        ok, nf, err, cached = _backfill_users(
+            store=store, usernames=users, token=token,
+            max_age_days=args.max_age_days, force=args.force,
+            max_handles=args.max_handles,
+        )
+        totals["ok"] += ok
+        totals["not_found"] += nf
+        totals["error"] += err
+        totals["cached"] += cached
+
+    if args.kind in {"both", "projects"}:
+        print("\n=== projects pass ===")
+        ok, nf, err, cached = _backfill_projects(
+            store=store, repos=repos, token=token,
+            max_age_days=args.max_age_days, force=args.force,
+            max_handles=args.max_handles,
+        )
+        totals["ok"] += ok
+        totals["not_found"] += nf
+        totals["error"] += err
+        totals["cached"] += cached
+
+    print()
+    print("=== Summary ===")
+    print(f"  ok:        {totals['ok']:>5}")
+    print(f"  not_found: {totals['not_found']:>5}")
+    print(f"  error:     {totals['error']:>5}")
+    print(f"  cached:    {totals['cached']:>5}")
+    print(f"  cost:      ${PRICE_PER_CALL_USD * (totals['ok'] + totals['not_found']):.4f}")
+
+    print("\nTop 10 projects by authority:")
+    for e in store.list_by_type(_PROJECT_TYPE, limit=10):
+        if e.derived_authority is None:
+            continue
+        print(f"  {e.derived_authority:.2f}  {e.identity_key:<35} "
+              f"{(e.canonical_name or '')[:40]}")
+
+    print("\nTop 10 users/orgs by authority:")
+    for e in store.list_by_type(_USER_TYPE, limit=10):
+        if e.derived_authority is None:
+            continue
+        print(f"  {e.derived_authority:.2f}  {e.identity_key:<25} "
+              f"{(e.canonical_name or '')[:40]}")
+
+    return 0 if totals["error"] == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ovp_pipeline/entities/github_backfill.py
+++ b/src/ovp_pipeline/entities/github_backfill.py
@@ -188,6 +188,95 @@ def fetch_user(
 
 
 # ---------------------------------------------------------------------------
+# Score formula constants
+# ---------------------------------------------------------------------------
+# Each band table is ``(threshold, points)`` pairs evaluated top-to-bottom;
+# first matching threshold wins.  Tuples (vs. inline elif chains) make the
+# bands trivial to inspect, tune, and unit-test.
+
+_PROJECT_STARS_BANDS: tuple[tuple[int, int], ...] = (
+    (50_000, 30),
+    (10_000, 25),
+    (1_000,  20),
+    (100,    12),
+    (10,      5),
+)
+
+_PROJECT_FORKS_BANDS: tuple[tuple[int, int], ...] = (
+    (1_000, 10),
+    (100,    7),
+    (10,     3),
+)
+
+# (max_days_since_push, points) — first-match wins; days are non-negative.
+_PROJECT_RECENCY_BANDS: tuple[tuple[float, int], ...] = (
+    (30,         15),
+    (180,        10),
+    (365,         5),
+    (365 * 3,     2),
+)
+
+_PROJECT_AGE_BANDS: tuple[tuple[float, int], ...] = (
+    (5.0, 10),
+    (2.0,  6),
+    (1.0,  3),
+)
+
+_PROJECT_LICENSE_POINTS = 5
+_PROJECT_NOT_ARCHIVED_POINTS = 5
+_PROJECT_NOT_FORK_POINTS = 5
+_PROJECT_OWNER_LIFT_MAX = 20
+
+_USER_FOLLOWERS_BANDS: tuple[tuple[int, int], ...] = (
+    (10_000, 25),
+    (1_000,  20),
+    (100,    12),
+    (10,      5),
+)
+
+_USER_REPOS_BANDS: tuple[tuple[int, int], ...] = (
+    (100, 10),
+    (30,   7),
+    (5,    3),
+)
+
+_USER_AGE_BANDS: tuple[tuple[float, int], ...] = (
+    (7.0, 10),
+    (3.0,  6),
+    (1.0,  3),
+)
+
+_USER_BIO_POINTS = 5
+_USER_BLOG_POINTS = 5
+_USER_COMPANY_POINTS = 10
+_USER_ORGANIZATION_POINTS = 10
+
+_PROJECT_AUTHORITY_DENOMINATOR = 100.0
+_USER_AUTHORITY_DENOMINATOR = 100.0
+
+
+def _band_lookup(value: float, bands: tuple[tuple[float, int], ...]) -> int:
+    """Walk ``bands`` top-to-bottom; return the first band whose
+    threshold ``value`` meets or exceeds.  Returns 0 if no band matches.
+    """
+    for threshold, points in bands:
+        if value >= threshold:
+            return points
+    return 0
+
+
+def _band_lookup_max(value: float, bands: tuple[tuple[float, int], ...]) -> int:
+    """Like ``_band_lookup`` but for "≤ threshold" semantics — used by
+    the recency table where the score is determined by *how recent*,
+    not "at least N points of activity".
+    """
+    for threshold, points in bands:
+        if value <= threshold:
+            return points
+    return 0
+
+
+# ---------------------------------------------------------------------------
 # Score derivation
 # ---------------------------------------------------------------------------
 
@@ -228,73 +317,44 @@ def compute_project_authority(
     """
     breakdown: dict[str, int] = {}
 
-    # 1. stars (max 30) — log10 bands so 100k-star repos don't crowd
-    # out 1k-star repos that are still meaningful.
-    stars = int(payload.get("stargazers_count") or 0)
-    if stars >= 50_000:
-        breakdown["stars"] = 30
-    elif stars >= 10_000:
-        breakdown["stars"] = 25
-    elif stars >= 1_000:
-        breakdown["stars"] = 20
-    elif stars >= 100:
-        breakdown["stars"] = 12
-    elif stars >= 10:
-        breakdown["stars"] = 5
-    else:
-        breakdown["stars"] = 0
+    # 1. stars — log10-style bands so 100k-star repos don't crowd out
+    # 1k-star repos that are still meaningful.
+    breakdown["stars"] = _band_lookup(
+        int(payload.get("stargazers_count") or 0), _PROJECT_STARS_BANDS,
+    )
 
-    # 2. forks (max 10)
-    forks = int(payload.get("forks_count") or 0)
-    if forks >= 1_000:
-        breakdown["forks"] = 10
-    elif forks >= 100:
-        breakdown["forks"] = 7
-    elif forks >= 10:
-        breakdown["forks"] = 3
-    else:
-        breakdown["forks"] = 0
+    # 2. forks
+    breakdown["forks"] = _band_lookup(
+        int(payload.get("forks_count") or 0), _PROJECT_FORKS_BANDS,
+    )
 
-    # 3. recency (max 15) — last push window
+    # 3. recency — last push window (smaller-is-better, hence _band_lookup_max)
     pushed_at = payload.get("pushed_at") or payload.get("updated_at")
-    days = _days_since(pushed_at)
-    if days <= 30:
-        breakdown["recency"] = 15
-    elif days <= 180:
-        breakdown["recency"] = 10
-    elif days <= 365:
-        breakdown["recency"] = 5
-    elif days <= 365 * 3:
-        breakdown["recency"] = 2
-    else:
-        breakdown["recency"] = 0
+    breakdown["recency"] = _band_lookup_max(_days_since(pushed_at), _PROJECT_RECENCY_BANDS)
 
-    # 4. age (max 10) — mature repos earn trust
-    years = _years_since(payload.get("created_at"))
-    if years >= 5:
-        breakdown["age"] = 10
-    elif years >= 2:
-        breakdown["age"] = 6
-    elif years >= 1:
-        breakdown["age"] = 3
-    else:
-        breakdown["age"] = 0
+    # 4. age — mature repos earn trust
+    breakdown["age"] = _band_lookup(
+        _years_since(payload.get("created_at")), _PROJECT_AGE_BANDS,
+    )
 
-    # 5. license (max 5) — legitimate OSS signal
+    # 5. license — legitimate OSS signal
     license_obj = payload.get("license")
-    if isinstance(license_obj, dict) and license_obj.get("spdx_id"):
-        breakdown["license"] = 5
-    else:
-        breakdown["license"] = 0
+    breakdown["license"] = (
+        _PROJECT_LICENSE_POINTS
+        if isinstance(license_obj, dict) and license_obj.get("spdx_id")
+        else 0
+    )
 
-    # 6. not archived (max 5)
-    breakdown["not_archived"] = 0 if payload.get("archived") else 5
+    # 6. not archived
+    breakdown["not_archived"] = (
+        0 if payload.get("archived") else _PROJECT_NOT_ARCHIVED_POINTS
+    )
 
-    # 7. not a fork (max 5) — originals over mirrors
-    breakdown["not_fork"] = 0 if payload.get("fork") else 5
+    # 7. not a fork — originals over mirrors
+    breakdown["not_fork"] = 0 if payload.get("fork") else _PROJECT_NOT_FORK_POINTS
 
-    # 8. owner lift (max 20) — provided by caller after fetching user
-    breakdown["owner_lift"] = max(0, min(20, owner_lift))
+    # 8. owner lift — provided by caller after fetching the github_user
+    breakdown["owner_lift"] = max(0, min(_PROJECT_OWNER_LIFT_MAX, owner_lift))
 
     score = max(0, sum(breakdown.values()))
     return score, breakdown
@@ -304,54 +364,34 @@ def compute_user_authority(payload: dict[str, Any]) -> tuple[int, dict[str, int]
     """Score one GitHub user / org (0-75)."""
     breakdown: dict[str, int] = {}
 
-    # 1. followers (max 25)
-    followers = int(payload.get("followers") or 0)
-    if followers >= 10_000:
-        breakdown["followers"] = 25
-    elif followers >= 1_000:
-        breakdown["followers"] = 20
-    elif followers >= 100:
-        breakdown["followers"] = 12
-    elif followers >= 10:
-        breakdown["followers"] = 5
-    else:
-        breakdown["followers"] = 0
+    # 1. followers
+    breakdown["followers"] = _band_lookup(
+        int(payload.get("followers") or 0), _USER_FOLLOWERS_BANDS,
+    )
 
-    # 2. public_repos (max 10) — output volume
-    repos = int(payload.get("public_repos") or 0)
-    if repos >= 100:
-        breakdown["public_repos"] = 10
-    elif repos >= 30:
-        breakdown["public_repos"] = 7
-    elif repos >= 5:
-        breakdown["public_repos"] = 3
-    else:
-        breakdown["public_repos"] = 0
+    # 2. public_repos — output volume
+    breakdown["public_repos"] = _band_lookup(
+        int(payload.get("public_repos") or 0), _USER_REPOS_BANDS,
+    )
 
-    # 3. age (max 10)
-    years = _years_since(payload.get("created_at"))
-    if years >= 7:
-        breakdown["age"] = 10
-    elif years >= 3:
-        breakdown["age"] = 6
-    elif years >= 1:
-        breakdown["age"] = 3
-    else:
-        breakdown["age"] = 0
+    # 3. age
+    breakdown["age"] = _band_lookup(
+        _years_since(payload.get("created_at")), _USER_AGE_BANDS,
+    )
 
-    # 4. has bio (max 5) — populated profile is a humanity / care signal
-    breakdown["has_bio"] = 5 if (payload.get("bio") or "").strip() else 0
+    # 4. populated profile is a humanity / care signal
+    breakdown["has_bio"] = _USER_BIO_POINTS if (payload.get("bio") or "").strip() else 0
+    breakdown["has_blog"] = _USER_BLOG_POINTS if (payload.get("blog") or "").strip() else 0
+    breakdown["has_company"] = (
+        _USER_COMPANY_POINTS if (payload.get("company") or "").strip() else 0
+    )
 
-    # 5. has blog/url (max 5)
-    breakdown["has_blog"] = 5 if (payload.get("blog") or "").strip() else 0
-
-    # 6. has company affiliation (max 10)
-    breakdown["has_company"] = 10 if (payload.get("company") or "").strip() else 0
-
-    # 7. account type Organization (max 10)
-    breakdown["is_organization"] = 10 if (
-        (payload.get("type") or "").lower() == "organization"
-    ) else 0
+    # 5. account type Organization
+    breakdown["is_organization"] = (
+        _USER_ORGANIZATION_POINTS
+        if (payload.get("type") or "").lower() == "organization"
+        else 0
+    )
 
     score = max(0, sum(breakdown.values()))
     return score, breakdown

--- a/src/ovp_pipeline/entities/github_backfill.py
+++ b/src/ovp_pipeline/entities/github_backfill.py
@@ -1,0 +1,453 @@
+"""GitHub REST API → entities (github_project + github_user).
+
+Two endpoints, two entity types:
+
+  * ``GET /repos/{owner}/{repo}``  → ``github_project``
+  * ``GET /users/{username}``      → ``github_user``
+
+The existing ``source_signals/github.py`` (T2 SignalProvider) computes
+a single 0-1 score from /repos for ingest-time use.  This module is
+broader: it persists the full payload + a multi-dimension authority
+score for use across the entity layer.  The two will converge in
+PR-E3 when SignalProvider starts reading from the entity table; for
+now they coexist.
+
+Auth & rate limit
+-----------------
+
+GitHub's REST API is **free** but rate-limited.  Unauthenticated:
+60 req/hour per IP.  With a personal access token (no scopes
+required for public-repo reads): 5000 req/hour.
+
+For the OVP vault (~281 unique repos+owners) we need a PAT — the
+unauth limit would force a 5-hour stagger.  Pass the token via
+``--token``, env ``GITHUB_TOKEN``, or ``60-Logs/.github-token``.
+
+Score formulas
+--------------
+
+``github_project`` (max 100 → derived_authority ≤ 1.0):
+    stars        max 30  (logarithmic bands)
+    forks        max 10  (log bands)
+    recency      max 15  (active <30d full credit, decays to 0 at 3y)
+    age          max 10  (mature wins, but cap so brand-new can score)
+    has_license  max  5
+    not_archived max  5  (archived projects lose this)
+    not_a_fork   max  5  (originals weighted over mirrors)
+    owner_lift   max 20  (filled in once github_user is known)
+
+``github_user`` (max 75 → derived_authority ≤ 0.75):
+    followers       max 25
+    public_repos    max 10
+    age             max 10
+    has_bio         max  5
+    has_blog        max  5
+    has_company     max 10  (affiliation signal — same logic as Twitter)
+    is_organization max 10  (Org accounts are aggregator-of-record)
+
+The 0.75 ceiling on github_user reserves the 0.75-1.0 band for
+explicit human curation (anthropic, openai etc. via
+``domain_overrides.yaml``) — same pattern as the twitter backfill's
+0.70 ceiling.
+
+Failure handling
+----------------
+
+  * 401/403   → if rate limit, surface clearly; if auth, abort
+  * 404       → entity stub (deleted/renamed), no retry
+  * 429/secondary rate limit → exponential backoff
+  * network   → retry up to 3 times then mark error
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+logger = logging.getLogger(__name__)
+
+_API_BASE = "https://api.github.com"
+_USER_AGENT = "ovp-backfill/1.0 (https://github.com/fakechris/obsidian_vault_pipeline)"
+_DEFAULT_TIMEOUT_S = 15.0
+_MAX_RETRIES = 3
+_BACKOFF_BASE_S = 1.5
+
+# GitHub REST is free; we track no monetary cost, only rate-limit budget.
+PRICE_PER_CALL_USD = 0.0
+
+
+# ---------------------------------------------------------------------------
+# Fetch
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class FetchResult:
+    """Outcome of a single GitHub REST call."""
+
+    identity: str           # 'owner/repo' for projects, 'login' for users
+    kind: Literal["project", "user"]
+    status: str             # "ok" | "not_found" | "error"
+    payload: dict[str, Any] | None
+    error: str | None
+
+
+def _request(
+    path: str, *, token: str | None, timeout_s: float = _DEFAULT_TIMEOUT_S,
+) -> tuple[int, dict[str, Any] | str]:
+    """Single GET, returns (status_code, parsed_or_raw)."""
+    url = f"{_API_BASE}{path}"
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": _USER_AGENT,
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout_s) as resp:
+            body = resp.read().decode("utf-8")
+        try:
+            return 200, json.loads(body)
+        except json.JSONDecodeError:
+            return 200, body
+    except urllib.error.HTTPError as e:
+        try:
+            err_body = json.loads(e.read().decode("utf-8"))
+        except Exception:  # noqa: BLE001 - best-effort error decoding
+            err_body = {"message": str(e)}
+        return e.code, err_body
+    except (urllib.error.URLError, TimeoutError, OSError) as e:
+        return -1, {"message": str(e)}
+
+
+def _retryable_fetch(
+    path: str, *, token: str | None, identity: str, kind: str,
+) -> FetchResult:
+    last_err = "unknown"
+    for attempt in range(_MAX_RETRIES):
+        code, body = _request(path, token=token)
+        if code == 200 and isinstance(body, dict):
+            return FetchResult(identity, kind, "ok", body, None)
+        if code == 404:
+            msg = (body or {}).get("message", "not found") if isinstance(body, dict) else "not found"
+            return FetchResult(identity, kind, "not_found", None, msg)
+        if code in (401, 403):
+            # Distinguish auth failure from rate limiting by message body.
+            msg = (body or {}).get("message", "") if isinstance(body, dict) else ""
+            if "rate limit" in msg.lower() or "abuse" in msg.lower():
+                wait = _BACKOFF_BASE_S * (2 ** attempt)
+                logger.info("rate limited on %s, sleeping %.1fs", identity, wait)
+                time.sleep(wait)
+                last_err = f"HTTP {code} (rate limit)"
+                continue
+            return FetchResult(
+                identity, kind, "error", None,
+                f"auth failed: HTTP {code} ({msg or 'check token'})",
+            )
+        if code == 429:
+            wait = _BACKOFF_BASE_S * (2 ** attempt)
+            time.sleep(wait)
+            last_err = "HTTP 429"
+            continue
+        # transport / 5xx
+        last_err = f"HTTP {code}: {body}" if code > 0 else f"network: {body}"
+        time.sleep(_BACKOFF_BASE_S * (2 ** attempt))
+    return FetchResult(identity, kind, "error", None, last_err)
+
+
+def fetch_repo(
+    owner: str, repo: str, *, token: str | None = None,
+) -> FetchResult:
+    if not owner or not repo:
+        return FetchResult(f"{owner}/{repo}", "project", "error", None,
+                           "missing owner or repo")
+    return _retryable_fetch(
+        f"/repos/{urllib.parse.quote(owner)}/{urllib.parse.quote(repo)}",
+        token=token, identity=f"{owner}/{repo}", kind="project",
+    )
+
+
+def fetch_user(
+    username: str, *, token: str | None = None,
+) -> FetchResult:
+    if not username:
+        return FetchResult("", "user", "error", None, "missing username")
+    return _retryable_fetch(
+        f"/users/{urllib.parse.quote(username)}",
+        token=token, identity=username, kind="user",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Score derivation
+# ---------------------------------------------------------------------------
+
+
+def _parse_iso(ts: str | None) -> datetime | None:
+    if not ts:
+        return None
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _years_since(ts: str | None) -> float:
+    dt = _parse_iso(ts)
+    if dt is None:
+        return 0.0
+    return max((datetime.now(timezone.utc) - dt).days / 365.25, 0.0)
+
+
+def _days_since(ts: str | None) -> float:
+    dt = _parse_iso(ts)
+    if dt is None:
+        return float("inf")
+    return max((datetime.now(timezone.utc) - dt).days, 0.0)
+
+
+def compute_project_authority(
+    payload: dict[str, Any],
+    *,
+    owner_lift: int = 0,
+) -> tuple[int, dict[str, int]]:
+    """Score one repo (0-100).
+
+    ``owner_lift`` is the github_user's contribution (0-20).  Pass 0
+    when the user hasn't been fetched yet — the project still gets
+    a useful score from its own intrinsic signals.
+    """
+    breakdown: dict[str, int] = {}
+
+    # 1. stars (max 30) — log10 bands so 100k-star repos don't crowd
+    # out 1k-star repos that are still meaningful.
+    stars = int(payload.get("stargazers_count") or 0)
+    if stars >= 50_000:
+        breakdown["stars"] = 30
+    elif stars >= 10_000:
+        breakdown["stars"] = 25
+    elif stars >= 1_000:
+        breakdown["stars"] = 20
+    elif stars >= 100:
+        breakdown["stars"] = 12
+    elif stars >= 10:
+        breakdown["stars"] = 5
+    else:
+        breakdown["stars"] = 0
+
+    # 2. forks (max 10)
+    forks = int(payload.get("forks_count") or 0)
+    if forks >= 1_000:
+        breakdown["forks"] = 10
+    elif forks >= 100:
+        breakdown["forks"] = 7
+    elif forks >= 10:
+        breakdown["forks"] = 3
+    else:
+        breakdown["forks"] = 0
+
+    # 3. recency (max 15) — last push window
+    pushed_at = payload.get("pushed_at") or payload.get("updated_at")
+    days = _days_since(pushed_at)
+    if days <= 30:
+        breakdown["recency"] = 15
+    elif days <= 180:
+        breakdown["recency"] = 10
+    elif days <= 365:
+        breakdown["recency"] = 5
+    elif days <= 365 * 3:
+        breakdown["recency"] = 2
+    else:
+        breakdown["recency"] = 0
+
+    # 4. age (max 10) — mature repos earn trust
+    years = _years_since(payload.get("created_at"))
+    if years >= 5:
+        breakdown["age"] = 10
+    elif years >= 2:
+        breakdown["age"] = 6
+    elif years >= 1:
+        breakdown["age"] = 3
+    else:
+        breakdown["age"] = 0
+
+    # 5. license (max 5) — legitimate OSS signal
+    license_obj = payload.get("license")
+    if isinstance(license_obj, dict) and license_obj.get("spdx_id"):
+        breakdown["license"] = 5
+    else:
+        breakdown["license"] = 0
+
+    # 6. not archived (max 5)
+    breakdown["not_archived"] = 0 if payload.get("archived") else 5
+
+    # 7. not a fork (max 5) — originals over mirrors
+    breakdown["not_fork"] = 0 if payload.get("fork") else 5
+
+    # 8. owner lift (max 20) — provided by caller after fetching user
+    breakdown["owner_lift"] = max(0, min(20, owner_lift))
+
+    score = max(0, sum(breakdown.values()))
+    return score, breakdown
+
+
+def compute_user_authority(payload: dict[str, Any]) -> tuple[int, dict[str, int]]:
+    """Score one GitHub user / org (0-75)."""
+    breakdown: dict[str, int] = {}
+
+    # 1. followers (max 25)
+    followers = int(payload.get("followers") or 0)
+    if followers >= 10_000:
+        breakdown["followers"] = 25
+    elif followers >= 1_000:
+        breakdown["followers"] = 20
+    elif followers >= 100:
+        breakdown["followers"] = 12
+    elif followers >= 10:
+        breakdown["followers"] = 5
+    else:
+        breakdown["followers"] = 0
+
+    # 2. public_repos (max 10) — output volume
+    repos = int(payload.get("public_repos") or 0)
+    if repos >= 100:
+        breakdown["public_repos"] = 10
+    elif repos >= 30:
+        breakdown["public_repos"] = 7
+    elif repos >= 5:
+        breakdown["public_repos"] = 3
+    else:
+        breakdown["public_repos"] = 0
+
+    # 3. age (max 10)
+    years = _years_since(payload.get("created_at"))
+    if years >= 7:
+        breakdown["age"] = 10
+    elif years >= 3:
+        breakdown["age"] = 6
+    elif years >= 1:
+        breakdown["age"] = 3
+    else:
+        breakdown["age"] = 0
+
+    # 4. has bio (max 5) — populated profile is a humanity / care signal
+    breakdown["has_bio"] = 5 if (payload.get("bio") or "").strip() else 0
+
+    # 5. has blog/url (max 5)
+    breakdown["has_blog"] = 5 if (payload.get("blog") or "").strip() else 0
+
+    # 6. has company affiliation (max 10)
+    breakdown["has_company"] = 10 if (payload.get("company") or "").strip() else 0
+
+    # 7. account type Organization (max 10)
+    breakdown["is_organization"] = 10 if (
+        (payload.get("type") or "").lower() == "organization"
+    ) else 0
+
+    score = max(0, sum(breakdown.values()))
+    return score, breakdown
+
+
+def derive_project_signals(
+    payload: dict[str, Any], *, owner_authority_0_75: float = 0.0,
+) -> tuple[float, dict[str, Any]]:
+    """High-level: compute project authority + signals dict to persist.
+
+    ``owner_authority_0_75`` is the github_user's derived_authority on
+    a 0-0.75 scale; we map it to a 0-20 contribution to the project.
+    Pass 0.0 when the owner hasn't been fetched yet.
+    """
+    owner_lift = int(round(20 * owner_authority_0_75 / 0.75)) if owner_authority_0_75 > 0 else 0
+    score, breakdown = compute_project_authority(payload, owner_lift=owner_lift)
+    authority = round(score / 100.0, 4)
+
+    signals = {
+        "owner_login": (payload.get("owner") or {}).get("login"),
+        "name": payload.get("name"),
+        "full_name": payload.get("full_name"),
+        "description": payload.get("description"),
+        "html_url": payload.get("html_url"),
+        "homepage": payload.get("homepage"),
+        "language": payload.get("language"),
+        "stargazers_count": payload.get("stargazers_count"),
+        "forks_count": payload.get("forks_count"),
+        "watchers_count": payload.get("watchers_count"),
+        "subscribers_count": payload.get("subscribers_count"),
+        "open_issues_count": payload.get("open_issues_count"),
+        "created_at": payload.get("created_at"),
+        "pushed_at": payload.get("pushed_at"),
+        "updated_at": payload.get("updated_at"),
+        "archived": payload.get("archived"),
+        "fork": payload.get("fork"),
+        "disabled": payload.get("disabled"),
+        "license_spdx": (payload.get("license") or {}).get("spdx_id")
+        if isinstance(payload.get("license"), dict) else None,
+        "default_branch": payload.get("default_branch"),
+        "topics": payload.get("topics"),
+        # derived
+        "project_authority_score": score,
+        "weight_breakdown": breakdown,
+        "missing_dimensions": [
+            "commit_velocity_30d",       # would need /commits or /stats endpoints
+            "contributor_count",         # would need /contributors
+            "issue_resolution_velocity", # would need /issues
+            "release_cadence",           # would need /releases
+            "ci_status",                 # would need /actions
+        ],
+    }
+    return authority, signals
+
+
+def derive_user_signals(payload: dict[str, Any]) -> tuple[float, dict[str, Any]]:
+    """High-level: compute user/org authority + signals dict to persist."""
+    score, breakdown = compute_user_authority(payload)
+    # 75 is the theoretical max; we normalize to 0-1 via /100, leaving
+    # 0.75-1.0 for explicit human curation (e.g. canonical orgs).
+    authority = round(score / 100.0, 4)
+
+    signals = {
+        "login": payload.get("login"),
+        "name": payload.get("name"),
+        "id": payload.get("id"),
+        "type": payload.get("type"),                # User | Organization
+        "company": payload.get("company"),
+        "blog": payload.get("blog"),
+        "location": payload.get("location"),
+        "email": payload.get("email"),
+        "bio": payload.get("bio"),
+        "twitter_username": payload.get("twitter_username"),  # ⚡ cross-platform link!
+        "public_repos": payload.get("public_repos"),
+        "public_gists": payload.get("public_gists"),
+        "followers": payload.get("followers"),
+        "following": payload.get("following"),
+        "created_at": payload.get("created_at"),
+        "updated_at": payload.get("updated_at"),
+        # derived
+        "user_authority_score": score,
+        "weight_breakdown": breakdown,
+        "missing_dimensions": [
+            "total_stars_across_repos",   # would need /repos enumeration
+            "contribution_streak",        # would need /events
+            "sponsor_count",              # would need /sponsors
+        ],
+    }
+    return authority, signals
+
+
+def stub_signals_for_missing(identity: str, kind: str, reason: str) -> dict[str, Any]:
+    """For 404s — record the fact without authority."""
+    return {
+        "identity": identity,
+        "kind": kind,
+        "fetch_status": "not_found",
+        "fetch_reason": reason,
+    }

--- a/tests/test_github_backfill.py
+++ b/tests/test_github_backfill.py
@@ -304,6 +304,152 @@ class TestFetchUser:
         assert r.payload["followers"] == 100_000
 
 
+class TestBandConstants:
+    """Pin the named-constant tables so a future tune to one band
+    can't silently break another.  Same pattern as
+    test_twitter_backfill.TestBandConstants."""
+
+    def test_project_bands_monotonic_high_to_low(self):
+        from ovp_pipeline.entities.github_backfill import (
+            _PROJECT_AGE_BANDS,
+            _PROJECT_FORKS_BANDS,
+            _PROJECT_STARS_BANDS,
+        )
+        # First-match-wins requires high-to-low ordering.
+        for table in (_PROJECT_STARS_BANDS, _PROJECT_FORKS_BANDS,
+                      _PROJECT_AGE_BANDS):
+            thresholds = [t for t, _ in table]
+            assert thresholds == sorted(thresholds, reverse=True), \
+                f"non-monotonic: {table}"
+
+    def test_recency_bands_monotonic_low_to_high(self):
+        # Recency uses _band_lookup_max which expects ascending thresholds.
+        from ovp_pipeline.entities.github_backfill import _PROJECT_RECENCY_BANDS
+        thresholds = [t for t, _ in _PROJECT_RECENCY_BANDS]
+        assert thresholds == sorted(thresholds)
+
+    def test_user_bands_monotonic_high_to_low(self):
+        from ovp_pipeline.entities.github_backfill import (
+            _USER_AGE_BANDS,
+            _USER_FOLLOWERS_BANDS,
+            _USER_REPOS_BANDS,
+        )
+        for table in (_USER_FOLLOWERS_BANDS, _USER_REPOS_BANDS,
+                      _USER_AGE_BANDS):
+            thresholds = [t for t, _ in table]
+            assert thresholds == sorted(thresholds, reverse=True)
+
+    def test_band_lookup_picks_highest_match(self):
+        from ovp_pipeline.entities.github_backfill import (
+            _PROJECT_STARS_BANDS,
+            _band_lookup,
+        )
+        # 30_000 stars: between 10_000 (25 pts) and 50_000 (30 pts) — must return 25.
+        assert _band_lookup(30_000, _PROJECT_STARS_BANDS) == 25
+
+    def test_band_lookup_max_picks_smallest_match(self):
+        from ovp_pipeline.entities.github_backfill import (
+            _PROJECT_RECENCY_BANDS,
+            _band_lookup_max,
+        )
+        # days=100 → falls in the ≤180 band (10 points), not ≤30.
+        assert _band_lookup_max(100, _PROJECT_RECENCY_BANDS) == 10
+        # days=400 → only fits ≤365*3 (2 points).
+        assert _band_lookup_max(400, _PROJECT_RECENCY_BANDS) == 2
+        # days=∞ → no band matches → 0
+        assert _band_lookup_max(float("inf"), _PROJECT_RECENCY_BANDS) == 0
+
+    def test_band_lookup_zero_below_lowest(self):
+        from ovp_pipeline.entities.github_backfill import (
+            _PROJECT_STARS_BANDS,
+            _band_lookup,
+        )
+        assert _band_lookup(0, _PROJECT_STARS_BANDS) == 0
+
+
+class TestBackfillProjectsUsesPrefetchedUsers:
+    """The review-fix invariant: scoring N projects must NOT issue
+    N more SQLite connections to look up the owner.  Pin it so a
+    refactor can't silently regress."""
+
+    def test_owner_lookup_uses_prefetched_dict(self, tmp_path):
+        from ovp_pipeline.commands.backfill_github import _backfill_projects
+        from ovp_pipeline.entities.store import EntityStore
+
+        store = EntityStore(db_path=tmp_path / "k.db")
+        # Seed two known github_user entities (owners of the test repos).
+        store.upsert(
+            entity_type="github_user", identity_key="alice",
+            canonical_name="Alice", signals={"followers": 5000},
+            derived_authority=0.45, fetch_source="github_rest",
+        )
+        store.upsert(
+            entity_type="github_user", identity_key="bob",
+            canonical_name="Bob", signals={"followers": 100},
+            derived_authority=0.20, fetch_source="github_rest",
+        )
+
+        # Stub the fetch — never hit the real network.
+        repo_payloads = {
+            ("alice", "x"): {
+                "full_name": "alice/x", "stargazers_count": 5000,
+                "owner": {"login": "alice"},
+            },
+            ("bob", "y"): {
+                "full_name": "bob/y", "stargazers_count": 50,
+                "owner": {"login": "bob"},
+            },
+        }
+        from ovp_pipeline.commands import backfill_github as bg
+        from ovp_pipeline.entities.github_backfill import FetchResult
+
+        def fake_fetch(owner, repo, *, token=None):
+            payload = repo_payloads.get((owner, repo))
+            if payload is None:
+                return FetchResult(f"{owner}/{repo}", "project",
+                                   "not_found", None, "404")
+            return FetchResult(f"{owner}/{repo}", "project",
+                               "ok", payload, None)
+
+        # Track every store.get call so we can prove the loop doesn't
+        # re-hit the DB for owner lookups.
+        original_get = store.get
+        get_call_log: list[tuple[str, str]] = []
+
+        def logged_get(entity_type, identity_key):
+            get_call_log.append((entity_type, identity_key))
+            return original_get(entity_type, identity_key)
+
+        store.get = logged_get  # type: ignore[method-assign]
+
+        # Patch the names imported INTO commands.backfill_github —
+        # patching the source module wouldn't update the binding.
+        with patch.object(bg, "fetch_repo", side_effect=fake_fetch), \
+             patch.object(bg, "time"):
+            ok, nf, err, cached = _backfill_projects(
+                store=store,
+                repos=[("alice", "x", 1), ("bob", "y", 1)],
+                token=None, max_age_days=30, force=False, max_handles=None,
+            )
+        assert (ok, nf, err) == (2, 0, 0)
+
+        # The store.get calls inside the loop should ONLY be the
+        # cache-staleness checks for the project identity.  No
+        # per-project (_USER_TYPE, ...) calls.
+        user_lookups = [
+            (t, k) for t, k in get_call_log if t == "github_user"
+        ]
+        assert user_lookups == [], (
+            f"unexpected per-project user lookups: {user_lookups}"
+        )
+
+        # Owner authority IS still applied: alice's 0.45 should have
+        # produced a non-zero owner_lift in alice/x's signals.
+        alice_proj = store.get("github_project", "alice/x")
+        assert alice_proj is not None
+        assert alice_proj.signals["weight_breakdown"]["owner_lift"] > 0
+
+
 def test_price_constant_is_zero():
     # GitHub REST is free; if we ever switch to a paid mirror this
     # test is the canary.

--- a/tests/test_github_backfill.py
+++ b/tests/test_github_backfill.py
@@ -1,0 +1,332 @@
+"""Tests for entities/github_backfill.py.
+
+Mocks ``urllib.request.urlopen`` — never hits the real GitHub API.
+Covers:
+  * project + user score formulas at each dimension threshold
+  * 200 / 404 / 401 (auth) / 403 (rate limit) / 429 / network paths
+  * the owner_lift mechanism that pulls user authority into project score
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import urllib.error
+
+from ovp_pipeline.entities.github_backfill import (
+    PRICE_PER_CALL_USD,
+    _years_since,
+    _days_since,
+    compute_project_authority,
+    compute_user_authority,
+    derive_project_signals,
+    derive_user_signals,
+    fetch_repo,
+    fetch_user,
+    stub_signals_for_missing,
+)
+
+
+def _years_ago_iso(years: float) -> str:
+    delta = years * 365.25 * 86400
+    ts = datetime.now(timezone.utc).timestamp() - delta
+    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _days_ago_iso(days: float) -> str:
+    ts = datetime.now(timezone.utc).timestamp() - days * 86400
+    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _fake_response(status: int, body):
+    raw = body if isinstance(body, str) else json.dumps(body)
+    f = io.BytesIO(raw.encode("utf-8"))
+    f.status = status
+    return f
+
+
+# ---------------------------------------------------------------------------
+# Project score formula
+# ---------------------------------------------------------------------------
+
+
+class TestComputeProjectAuthority:
+    def test_zero_signals_zero_score(self):
+        score, b = compute_project_authority({})
+        # not_archived (5) + not_fork (5) trigger by default — that's
+        # the signal "this isn't an archived fork", which is true of an
+        # empty payload.  Everything else is 0.
+        assert b["stars"] == 0
+        assert b["forks"] == 0
+        assert b["recency"] == 0
+        assert b["age"] == 0
+        assert b["license"] == 0
+        # archived/fork default to falsy → those credits apply
+        assert b["not_archived"] == 5
+        assert b["not_fork"] == 5
+        assert score == 10  # not_archived + not_fork
+
+    def test_high_stars_capped_at_30(self):
+        _, b = compute_project_authority({"stargazers_count": 200_000})
+        assert b["stars"] == 30
+
+    def test_star_log_bands(self):
+        _, b1 = compute_project_authority({"stargazers_count": 1500})
+        _, b2 = compute_project_authority({"stargazers_count": 150})
+        _, b3 = compute_project_authority({"stargazers_count": 5})
+        assert b1["stars"] == 20
+        assert b2["stars"] == 12
+        assert b3["stars"] == 0
+
+    def test_archived_loses_5_points(self):
+        _, b = compute_project_authority({"archived": True})
+        assert b["not_archived"] == 0
+
+    def test_fork_loses_5_points(self):
+        _, b = compute_project_authority({"fork": True})
+        assert b["not_fork"] == 0
+
+    def test_recent_push_full_credit(self):
+        _, b = compute_project_authority({"pushed_at": _days_ago_iso(15)})
+        assert b["recency"] == 15
+
+    def test_dormant_3y_zero_recency(self):
+        _, b = compute_project_authority({"pushed_at": _days_ago_iso(365 * 5)})
+        assert b["recency"] == 0
+
+    def test_license_credit(self):
+        _, b = compute_project_authority({"license": {"spdx_id": "MIT"}})
+        assert b["license"] == 5
+        # malformed license obj shouldn't credit
+        _, b2 = compute_project_authority({"license": "MIT"})  # str not dict
+        assert b2["license"] == 0
+
+    def test_owner_lift_passed_through(self):
+        _, b = compute_project_authority({}, owner_lift=20)
+        assert b["owner_lift"] == 20
+
+    def test_owner_lift_clamped(self):
+        _, b = compute_project_authority({}, owner_lift=999)
+        assert b["owner_lift"] == 20
+        _, b2 = compute_project_authority({}, owner_lift=-5)
+        assert b2["owner_lift"] == 0
+
+    def test_max_score_cap(self):
+        score, _ = compute_project_authority({
+            "stargazers_count": 100_000,
+            "forks_count": 5_000,
+            "pushed_at": _days_ago_iso(1),
+            "created_at": _years_ago_iso(10),
+            "license": {"spdx_id": "Apache-2.0"},
+            "archived": False, "fork": False,
+        }, owner_lift=20)
+        # 30 + 10 + 15 + 10 + 5 + 5 + 5 + 20 = 100
+        assert score == 100
+
+
+# ---------------------------------------------------------------------------
+# User score formula
+# ---------------------------------------------------------------------------
+
+
+class TestComputeUserAuthority:
+    def test_zero_signals_zero_score(self):
+        score, _ = compute_user_authority({})
+        assert score == 0
+
+    def test_high_followers(self):
+        _, b = compute_user_authority({"followers": 50_000})
+        assert b["followers"] == 25
+
+    def test_organization_account_credited(self):
+        _, b = compute_user_authority({"type": "Organization"})
+        assert b["is_organization"] == 10
+
+    def test_user_account_no_org_credit(self):
+        _, b = compute_user_authority({"type": "User"})
+        assert b["is_organization"] == 0
+
+    def test_company_string_credited_only_if_nonempty(self):
+        _, b1 = compute_user_authority({"company": "Anthropic"})
+        _, b2 = compute_user_authority({"company": ""})
+        _, b3 = compute_user_authority({"company": None})
+        assert b1["has_company"] == 10
+        assert b2["has_company"] == 0
+        assert b3["has_company"] == 0
+
+    def test_max_score_cap(self):
+        score, _ = compute_user_authority({
+            "followers": 50_000,
+            "public_repos": 200,
+            "created_at": _years_ago_iso(15),
+            "bio": "researcher",
+            "blog": "https://example.com",
+            "company": "Anthropic",
+            "type": "User",
+        })
+        # 25 + 10 + 10 + 5 + 5 + 10 = 65 (no org credit for User)
+        assert score == 65
+
+
+# ---------------------------------------------------------------------------
+# Derive helpers
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveProjectSignals:
+    def test_records_missing_dimensions(self):
+        _, signals = derive_project_signals({"stargazers_count": 100})
+        assert "commit_velocity_30d" in signals["missing_dimensions"]
+        assert "contributor_count" in signals["missing_dimensions"]
+
+    def test_owner_authority_maps_to_owner_lift(self):
+        # owner_authority_0_75 == 0.75 should max out owner_lift at 20
+        a_full, signals_full = derive_project_signals(
+            {"stargazers_count": 1000}, owner_authority_0_75=0.75,
+        )
+        a_zero, signals_zero = derive_project_signals(
+            {"stargazers_count": 1000}, owner_authority_0_75=0.0,
+        )
+        assert signals_full["weight_breakdown"]["owner_lift"] == 20
+        assert signals_zero["weight_breakdown"]["owner_lift"] == 0
+        # full owner authority should yield strictly higher project authority
+        assert a_full > a_zero
+
+    def test_authority_in_unit_interval(self):
+        a, _ = derive_project_signals({
+            "stargazers_count": 100_000,
+            "forks_count": 10_000,
+            "pushed_at": _days_ago_iso(1),
+            "created_at": _years_ago_iso(10),
+            "license": {"spdx_id": "MIT"},
+        }, owner_authority_0_75=0.75)
+        assert 0.0 <= a <= 1.0
+
+
+class TestDeriveUserSignals:
+    def test_authority_caps_below_canonical_band(self):
+        # Even fully-loaded github_user maxes at 75/100 = 0.75, leaving
+        # 0.75-1.0 reserved for explicit human curation.
+        a, _ = derive_user_signals({
+            "followers": 50_000,
+            "public_repos": 200,
+            "created_at": _years_ago_iso(15),
+            "bio": "ok", "blog": "ok", "company": "ok",
+            "type": "Organization",
+        })
+        assert a == 0.75
+
+    def test_persists_twitter_username_for_cross_platform_link(self):
+        # PR-E3 will use this to merge github_user with twitter_author.
+        _, signals = derive_user_signals({
+            "login": "karpathy", "twitter_username": "karpathy",
+        })
+        assert signals["twitter_username"] == "karpathy"
+
+
+# ---------------------------------------------------------------------------
+# Fetch
+# ---------------------------------------------------------------------------
+
+
+class TestFetchRepo:
+    def test_success(self):
+        body = {"full_name": "karpathy/nanoGPT", "stargazers_count": 30000}
+        with patch(
+            "ovp_pipeline.entities.github_backfill.urllib.request.urlopen"
+        ) as m:
+            m.return_value.__enter__.return_value = _fake_response(200, body)
+            r = fetch_repo("karpathy", "nanoGPT", token="t")
+        assert r.status == "ok"
+        assert r.payload["stargazers_count"] == 30000
+
+    def test_404(self):
+        with patch(
+            "ovp_pipeline.entities.github_backfill.urllib.request.urlopen"
+        ) as m:
+            m.side_effect = urllib.error.HTTPError(
+                "u", 404, "not found", {}, io.BytesIO(b'{"message":"Not Found"}'),
+            )
+            r = fetch_repo("ghost", "missing", token="t")
+        assert r.status == "not_found"
+
+    def test_403_rate_limit_retries(self):
+        # Fresh HTTPError per call — re-using one instance would have
+        # the body BytesIO drained after the first .read(), which
+        # masks the "rate limit" message on subsequent attempts.
+        def _raise_rate_limit(*_args, **_kwargs):
+            raise urllib.error.HTTPError(
+                "u", 403, "rate", {},
+                io.BytesIO(b'{"message":"API rate limit exceeded"}'),
+            )
+        with patch(
+            "ovp_pipeline.entities.github_backfill.urllib.request.urlopen",
+            side_effect=_raise_rate_limit,
+        ) as m, patch(
+            "ovp_pipeline.entities.github_backfill.time.sleep"
+        ) as sleeper:
+            r = fetch_repo("a", "b", token="t")
+        assert r.status == "error"
+        assert m.call_count == 3
+        assert sleeper.call_count >= 2
+
+    def test_401_no_retry(self):
+        with patch(
+            "ovp_pipeline.entities.github_backfill.urllib.request.urlopen"
+        ) as m:
+            m.side_effect = urllib.error.HTTPError(
+                "u", 401, "auth", {},
+                io.BytesIO(b'{"message":"Bad credentials"}'),
+            )
+            r = fetch_repo("a", "b", token="bad")
+        assert r.status == "error"
+        assert "auth" in (r.error or "").lower()
+
+    def test_missing_owner_or_repo(self):
+        r = fetch_repo("", "x", token="t")
+        assert r.status == "error"
+        r2 = fetch_repo("x", "", token="t")
+        assert r2.status == "error"
+
+
+class TestFetchUser:
+    def test_success(self):
+        body = {"login": "karpathy", "followers": 100_000, "type": "User"}
+        with patch(
+            "ovp_pipeline.entities.github_backfill.urllib.request.urlopen"
+        ) as m:
+            m.return_value.__enter__.return_value = _fake_response(200, body)
+            r = fetch_user("karpathy", token="t")
+        assert r.status == "ok"
+        assert r.payload["followers"] == 100_000
+
+
+def test_price_constant_is_zero():
+    # GitHub REST is free; if we ever switch to a paid mirror this
+    # test is the canary.
+    assert PRICE_PER_CALL_USD == 0.0
+
+
+def test_stub_signals_for_missing():
+    s = stub_signals_for_missing("ghost/missing", "project", "404")
+    assert s["identity"] == "ghost/missing"
+    assert s["kind"] == "project"
+    assert s["fetch_status"] == "not_found"
+
+
+class TestParseHelpers:
+    def test_years_since_handles_z_suffix(self):
+        # GitHub returns ISO-with-Z; ensure parser accepts it
+        s = _years_ago_iso(2.0)
+        assert 1.9 < _years_since(s) < 2.1
+
+    def test_years_since_unparseable_returns_zero(self):
+        assert _years_since("nonsense") == 0.0
+        assert _years_since(None) == 0.0
+
+    def test_days_since_unparseable_returns_inf(self):
+        # Used for "no recency credit" — unparseable should mean "very old"
+        assert _days_since(None) == float("inf")


### PR DESCRIPTION
Reopens #116 after its base branch was deleted on the squash-merge of #115.  Same code, rebased onto main + cherry-picked review fixes.

See #116 for the full discussion + real-backfill report.

## Summary

- Two new entity types fed by GitHub's free REST API:
  - \`github_project\` (one entity per \`owner/repo\`)
  - \`github_user\` (one entity per \`owner\`, User or Organization)
- Two-pass strategy: users first, then projects (so \`owner_lift\` is available when scoring projects).
- Cross-platform-link prep: \`github_user\` signals include \`twitter_username\` — **193 of 406 (47.5%)** users self-reported a Twitter handle, the bridge PR-E3 (#118) uses for identity merge.

## Includes round-2 review fixes

Already applied on top of the original PR #116 commits:

- HIGH: pre-fetch \`github_user\` entities into a dict before the projects loop, instead of \`store.get(_USER_TYPE, owner)\` per project (~559 SQLite connections eliminated).
- MEDIUM: promote scoring-band magic numbers to named constants (\`_PROJECT_STARS_BANDS\`, \`_PROJECT_FORKS_BANDS\`, \`_USER_FOLLOWERS_BANDS\`, etc.).  Tables walked by shared \`_band_lookup\` / \`_band_lookup_max\` helpers.
- New tests: \`TestBandConstants\` (monotonicity + canary), \`TestBackfillProjectsUsesPrefetchedUsers.test_owner_lookup_uses_prefetched_dict\` (pins the N+1 prevention).

## Real backfill report (from #116)

| | count | % |
|---|---|---|
| ok | 922 | 94.1% |
| not_found | 58 | 5.9% |
| cost | \$0.00 | (free API) |
| runtime | ~13 min | (5000/hr PAT) |

Top projects by authority: huggingface/transformers (0.97), pytorch/pytorch (0.95), zed-industries/zed (0.95), gin-gonic/gin (0.93), …

Top users/orgs: microsoft (0.65), huggingface (0.65), addyosmani (0.65), google (0.65), openai (0.60).

## Test plan

- [x] Score formulas — each dimension's threshold band, score ceilings, owner_lift mapping
- [x] Mocked HTTP for 200 / 404 / 401 (no retry) / 403 (rate-limit retries)
- [x] Pre-fetch optimization — patches \`store.get\` and asserts zero per-project user lookups
- [x] Full suite: **1684 passed**, lint clean