### PR TITLE
feat(source-signals): GitHubSignalProvider entity-table fast path

### DIFF
--- a/src/ovp_pipeline/source_authority.py
+++ b/src/ovp_pipeline/source_authority.py
@@ -37,7 +37,6 @@ from __future__ import annotations
 
 import json
 import logging
-import math
 import sqlite3
 from dataclasses import asdict
 from math import isfinite
@@ -69,21 +68,29 @@ def default_providers(vault_dir: Path) -> list[SignalProvider]:
     Order matters only for ``AuthorityScore.signals`` audit clarity;
     the combination rule treats them as a multiset.
 
-    Picks up user overrides from:
-      * ``60-Logs/domain_overrides.yaml`` — extended/overridden domain table
-      * ``60-Logs/authors.jsonl`` — primary author list (legacy)
-      * ``60-Logs/author_overrides.yaml`` — alternate author surface
+    Three input surfaces wired in here:
+      * ``60-Logs/authors.jsonl`` + ``60-Logs/author_overrides.yaml``
+        — curated whitelist (PR-D1 / PR-D3)
+      * ``60-Logs/domain_overrides.yaml``
+        — extended/overridden domain table (PR-D3)
+      * ``60-Logs/knowledge.db``
+        — entity table fast path (PR-E1 / E2 / E3 / E4) for handles +
+        repos that aren't curated yet.  Providers no-op gracefully
+        when the file or its tables don't exist, so a fresh vault
+        still works.
     """
     authors_path = vault_dir / "60-Logs" / "authors.jsonl"
     domain_overrides_path = vault_dir / "60-Logs" / "domain_overrides.yaml"
     author_overrides_path = vault_dir / "60-Logs" / "author_overrides.yaml"
+    entity_store_path = vault_dir / "60-Logs" / "knowledge.db"
     return [
         DomainRulesProvider(overrides_path=domain_overrides_path),
         AuthorRulesProvider(
             authors_path=authors_path,
             overrides_path=author_overrides_path,
+            entity_store_path=entity_store_path,
         ),
-        GitHubSignalProvider(),
+        GitHubSignalProvider(entity_store_path=entity_store_path),
         ArxivSignalProvider(),
         TwitterSignalProvider(),    # stub; returns None unless OVP_TWITTER_BACKEND set
         SubstackSignalProvider(),   # stub; returns None unless OVP_SUBSTACK_BACKEND set

--- a/src/ovp_pipeline/source_signals/github.py
+++ b/src/ovp_pipeline/source_signals/github.py
@@ -36,9 +36,10 @@ import urllib.error
 import urllib.request
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
-from .base import Signal, SignalProvider
+from .base import Signal
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +54,12 @@ _TIMEOUT_S = 10.0
 class GitHubSignalProvider:
     name: str = "github_stars"
     user_agent: str = "ovp-pipeline-source-authority/0.1"
+    # When set, scoring first consults the ``entities`` table (populated
+    # by ``ovp-backfill-github``).  An entity hit returns immediately —
+    # no live API call.  An entity miss falls through to the live fetch
+    # path below, preserving correctness for repos we haven't backfilled.
+    # Default ``None`` keeps PR-D2 behavior unchanged.
+    entity_store_path: Path | None = None
 
     def applies(self, source_url: str, frontmatter: dict[str, Any]) -> bool:
         return bool(source_url and _GITHUB_REPO_RE.match(source_url))
@@ -69,6 +76,13 @@ class GitHubSignalProvider:
         repo = m.group("repo")
         if repo.endswith(".git"):
             repo = repo[:-4]
+
+        # Entity-table fast path — returns the github_backfill score
+        # (more dimensions, calibrated 0-1) without an API call.
+        entity_signal = self._entity_fast_path(owner, repo)
+        if entity_signal is not None:
+            return entity_signal
+
         url = _API.format(owner=owner, repo=repo)
         req = urllib.request.Request(url, headers={"User-Agent": self.user_agent})
         try:
@@ -127,5 +141,47 @@ class GitHubSignalProvider:
                     "star": round(star_component, 3),
                     "recency": round(recency_component, 3),
                 },
+            },
+        )
+
+    def _entity_fast_path(self, owner: str, repo: str) -> Signal | None:
+        """Return a Signal from the entity table or None.
+
+        Hits ``entities/github_project`` first (most precise), then
+        ``entities/github_user`` as an owner-fallback (capped at 0.55
+        inside the resolver — see entities/resolver.py).  Either path
+        yields the github_backfill formula score, which has more
+        dimensions than the live ``score`` body below.
+
+        Returns ``None`` (so the caller falls through to live fetch) if:
+          * ``entity_store_path`` is not configured;
+          * the store can't be opened;
+          * neither the project nor the owner has been backfilled yet.
+        """
+        if self.entity_store_path is None:
+            return None
+        # Lazy import keeps source_signals/ free of an entities/ dep
+        # when this fast path isn't wired.
+        from ..entities.resolver import resolve_github_project_authority
+        from ..entities.store import EntityStore
+
+        try:
+            store = EntityStore(db_path=self.entity_store_path)
+        except Exception as exc:  # noqa: BLE001 - resilience over diagnostics
+            logger.warning("entity store unavailable for %s/%s: %s",
+                           owner, repo, exc)
+            return None
+        result = resolve_github_project_authority(store, owner, repo)
+        if result.authority is None:
+            return None
+        return Signal(
+            provider=self.name,
+            value=round(result.authority, 4),
+            raw={
+                "owner": owner,
+                "repo": repo,
+                "matched_via": "entity_table",
+                "entity_source": result.source,
+                "entity_authority": result.authority,
             },
         )

--- a/tests/test_github_signal_entity_fast_path.py
+++ b/tests/test_github_signal_entity_fast_path.py
@@ -1,0 +1,148 @@
+"""Tests for PR-E4: GitHubSignalProvider's entity-table fast path.
+
+Mirrors the test pattern from test_author_rules_entity_fallback.py
+(which proved AuthorRulesProvider's entity-table integration).
+
+Three invariants:
+  * entity hit returns immediately (no live API call)
+  * entity miss falls through to live fetch (back-compat)
+  * no entity_store_path is a no-op (PR-D2 behavior preserved)
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from unittest.mock import patch
+
+from ovp_pipeline.entities.store import EntityStore
+from ovp_pipeline.source_signals.github import GitHubSignalProvider
+
+
+def _seed_project(store, identity, authority):
+    store.upsert(
+        entity_type="github_project",
+        identity_key=identity,
+        canonical_name=identity,
+        signals={"stargazers_count": 10000},
+        derived_authority=authority,
+        fetch_source="github_rest",
+    )
+
+
+def _seed_user(store, login, authority):
+    store.upsert(
+        entity_type="github_user",
+        identity_key=login,
+        canonical_name=login,
+        signals={"followers": 5000},
+        derived_authority=authority,
+        fetch_source="github_rest",
+    )
+
+
+def _fake_response(status: int, body):
+    raw = body if isinstance(body, str) else json.dumps(body)
+    f = io.BytesIO(raw.encode("utf-8"))
+    f.status = status
+    return f
+
+
+class TestEntityHitShortCircuitsLiveAPI:
+    def test_project_hit_returns_signal_without_api_call(self, tmp_path):
+        db = tmp_path / "k.db"
+        store = EntityStore(db_path=db)
+        _seed_project(store, "karpathy/nanogpt", 0.92)
+
+        provider = GitHubSignalProvider(entity_store_path=db)
+        # Patch urlopen — if the fast path works, this is never called.
+        with patch(
+            "ovp_pipeline.source_signals.github.urllib.request.urlopen"
+        ) as m:
+            sig = provider.score("https://github.com/karpathy/nanoGPT", {})
+        assert sig is not None
+        assert sig.value == 0.92
+        assert sig.raw["matched_via"] == "entity_table"
+        assert sig.raw["entity_source"] == "github_project"
+        # Critical: no live HTTP request was made.
+        m.assert_not_called()
+
+    def test_owner_fallback_uses_capped_score(self, tmp_path):
+        # No project entity, but the owner is known.  Resolver caps
+        # the owner-fallback at 0.55 (see entities/resolver.py); the
+        # provider should surface that cap, not the raw user score.
+        db = tmp_path / "k.db"
+        store = EntityStore(db_path=db)
+        _seed_user(store, "karpathy", 0.65)
+
+        provider = GitHubSignalProvider(entity_store_path=db)
+        with patch(
+            "ovp_pipeline.source_signals.github.urllib.request.urlopen"
+        ) as m:
+            sig = provider.score("https://github.com/karpathy/dotfiles", {})
+        assert sig is not None
+        assert sig.value == 0.55
+        assert sig.raw["entity_source"] == "github_user"
+        m.assert_not_called()
+
+
+class TestEntityMissFallsThroughToLive:
+    def test_unknown_repo_hits_live_api(self, tmp_path):
+        # Empty entity store — provider should fall through to live
+        # fetch (PR-D2 behavior).
+        db = tmp_path / "k.db"
+        EntityStore(db_path=db)        # init schema only
+
+        provider = GitHubSignalProvider(entity_store_path=db)
+        with patch(
+            "ovp_pipeline.source_signals.github.urllib.request.urlopen"
+        ) as m:
+            m.return_value.__enter__.return_value = _fake_response(
+                200, {"stargazers_count": 1234, "forks_count": 56,
+                      "pushed_at": "2026-04-01T00:00:00Z"},
+            )
+            sig = provider.score("https://github.com/freshrepo/x", {})
+        assert sig is not None
+        # Live formula: 0.40 base + tanh(...) star + recency
+        assert 0.40 < sig.value <= 1.0
+        # Came from the live path, not the entity table.
+        assert sig.raw.get("matched_via") != "entity_table"
+        m.assert_called_once()
+
+
+class TestNoEntityStorePathIsNoOp:
+    def test_default_constructor_preserves_pr_d2_behavior(self):
+        # No entity_store_path provided → exactly PR-D2 behavior.
+        provider = GitHubSignalProvider()
+        with patch(
+            "ovp_pipeline.source_signals.github.urllib.request.urlopen"
+        ) as m:
+            m.return_value.__enter__.return_value = _fake_response(
+                200, {"stargazers_count": 100, "forks_count": 5,
+                      "pushed_at": "2026-04-01T00:00:00Z"},
+            )
+            sig = provider.score("https://github.com/owner/repo", {})
+        assert sig is not None
+        assert sig.raw.get("matched_via") != "entity_table"
+
+
+class TestMissingDbDoesNotCrash:
+    def test_nonexistent_db_path_falls_through(self, tmp_path):
+        # Provider was wired with a path that doesn't exist (e.g.
+        # vault never had the entity layer initialized).  Behavior
+        # must be: fall through to live API, NOT raise.
+        bogus_db = tmp_path / "does-not-exist.db"
+        provider = GitHubSignalProvider(entity_store_path=bogus_db)
+        with patch(
+            "ovp_pipeline.source_signals.github.urllib.request.urlopen"
+        ) as m:
+            m.return_value.__enter__.return_value = _fake_response(
+                200, {"stargazers_count": 50, "forks_count": 2,
+                      "pushed_at": "2026-04-01T00:00:00Z"},
+            )
+            sig = provider.score("https://github.com/x/y", {})
+        # Schema gets auto-created by EntityStore.__post_init__, so
+        # the store opens cleanly but has no rows → falls through.
+        # Either way, the live API was hit.
+        m.assert_called_once()
+        assert sig is not None


### PR DESCRIPTION
## Summary

- **PR-E4** finishes the entity-layer integration started in PR-E3 (#120).
- \`GitHubSignalProvider\` now consults the \`entities\` table populated by \`ovp-backfill-github\` (#119) BEFORE hitting the live REST API.
- An entity hit returns immediately — no HTTP call.  An entity miss falls through to the live fetch path, preserving coverage for un-backfilled repos.
- Standalone PR (off main).

## Why now

PR-E2 already collected stars / forks / recency / owner-lift into \`entities/github_project\` + \`github_user\` (922 rows in the OVP vault).  Until this PR, ingest-time scoring still hit GitHub's REST API once per source URL — wasteful when the answer was already on disk.

## Behavior matrix

| \`entity_store_path\` | entity has it? | result |
|---|---|---|
| not set (default) | n/a | unchanged (PR-D2 live fetch + old formula) |
| set | hit (project) | github_backfill formula score, 0 HTTP calls |
| set | hit (owner only) | resolver's owner-fallback (capped at 0.55), 0 HTTP calls |
| set | miss | fall through to live fetch (PR-D2 path) |
| set, DB missing | — | fall through gracefully (fresh-vault tolerance) |

## Smoke against real vault

\`\`\`
huggingface/transformers  →  0.97  via=entity_table (github_project)
karpathy/nanoGPT          →  0.52  via=entity_table (github_user owner-fallback)
\`\`\`

Both returned without an HTTP request.

## Test plan

- [x] \`test_project_hit_returns_signal_without_api_call\` — pins the no-HTTP invariant via \`mock.assert_not_called()\`
- [x] \`test_owner_fallback_uses_capped_score\` — owner-fallback path, resolver's 0.55 cap honored
- [x] \`test_unknown_repo_hits_live_api\` — entity miss → live fetch
- [x] \`test_default_constructor_preserves_pr_d2_behavior\` — back-compat (no entity_store_path = unchanged)
- [x] \`test_nonexistent_db_path_falls_through\` — fresh-vault resilience
- [x] Full suite: **1739 passed**, lint clean

## Stack history

- PR #115 — twitter_author backfill
- PR #119 — github_project + github_user backfill (E2 reopened)
- PR #117 — db backup
- PR #120 — scorer reads entity table (Twitter side) + identity merge (E3 reopened)
- **This PR** — scorer reads entity table (GitHub side)

## What's deferred

- Period entity refresh (e.g. weekly cron of \`ovp-backfill-github\`) — design only, no code yet.  Currently entity data ages until manual rerun.
- Entity-table integration for the other live-API providers (\`arxiv\`, future Substack) — same pattern, not in this PR.