### PR TITLE
feat(entities): split person → person + organization (PR-F1)

### DIFF
--- a/src/ovp_pipeline/commands/merge_identities.py
+++ b/src/ovp_pipeline/commands/merge_identities.py
@@ -1,4 +1,4 @@
-"""ovp-merge-identities — collapse twitter_author + github_user into person.
+"""ovp-merge-identities — collapse twitter_author + github_user into person/organization.
 
 Three modes:
 
@@ -9,10 +9,11 @@ Three modes:
 
 The merge is read-only against twitter_author / github_user — they
 stay untouched.  We only INSERT/UPDATE rows in the ``entities`` table
-where ``entity_type='person'``.
+where ``entity_type='person'`` or ``'organization'`` (PR-F1).
 
-Re-running is safe: each apply UPSERTs by ``(person, twitter_handle)``,
-so a person row that already exists is just refreshed.
+Re-running is safe: each apply UPSERTs by canonical handle.  A first
+``--migrate-existing`` pass also reclassifies pre-PR-F1 ``person``
+rows whose linked github_user is actually an organization.
 """
 
 from __future__ import annotations
@@ -22,8 +23,11 @@ import sys
 from pathlib import Path
 
 from ..entities.identity_merge import (
+    ORGANIZATION_TYPE,
+    PERSON_TYPE,
     apply_merge,
     find_merge_candidates,
+    reclassify_persons_to_orgs,
 )
 from ..entities.store import EntityStore
 
@@ -38,6 +42,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--include-fuzzy", action="store_true",
                         help="Also apply fuzzy (Levenshtein) candidates — "
                              "review the dry-run output first")
+    parser.add_argument("--migrate-existing", action="store_true",
+                        help="Before merging, reclassify pre-PR-F1 person "
+                             "rows that should be organization (one-shot, "
+                             "idempotent).  Default off so a routine refresh "
+                             "doesn't surprise anyone.")
     args = parser.parse_args(argv)
 
     vault = args.vault_dir.resolve()
@@ -47,6 +56,35 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     store = EntityStore(db_path=db_path)
+
+    if args.migrate_existing and not args.dry_run:
+        reclassified, kept = reclassify_persons_to_orgs(store)
+        print(f"PR-F1 migration: {reclassified} person → organization "
+              f"({kept} unchanged)")
+    elif args.migrate_existing and args.dry_run:
+        # Dry-run preview: only count, don't apply.
+        kept = 0
+        org_candidates: list[str] = []
+        for p in store.list_by_type(PERSON_TYPE):
+            gh_link = next(
+                (ln for ln in (p.signals.get("links") or [])
+                 if ln.get("entity_type") == "github_user"),
+                None,
+            )
+            if gh_link is None:
+                kept += 1
+                continue
+            gh = store.get("github_user", gh_link.get("identity_key", ""))
+            if gh and (gh.signals.get("type") or "").lower() == "organization":
+                org_candidates.append(p.identity_key)
+            else:
+                kept += 1
+        print(f"PR-F1 migration (dry-run): {len(org_candidates)} would be "
+              f"reclassified, {kept} unchanged")
+        for handle in org_candidates[:20]:
+            print(f"  person → organization: {handle}")
+        print()
+
     candidates = find_merge_candidates(store)
 
     by_method = {"self_reported": 0, "exact_handle": 0, "fuzzy": 0}
@@ -100,20 +138,25 @@ def main(argv: list[str] | None = None) -> int:
         else:
             skipped += 1
 
-    print(f"applied: {applied}  (person entities inserted/updated)")
+    print(f"applied: {applied}  (canonical entities inserted/updated)")
     print(f"skipped: {skipped}  (review queue + missing-side cases)")
-    print()
-    print("Top 10 person entities by authority:")
-    for e in store.list_by_type("person", limit=10):
-        if e.derived_authority is None:
+
+    for canonical_type in (PERSON_TYPE, ORGANIZATION_TYPE):
+        rows = store.list_by_type(canonical_type, limit=10)
+        if not rows:
             continue
-        links = e.signals.get("links", [])
-        link_summary = " + ".join(
-            f"{ln['entity_type'].split('_')[0]}:{ln['identity_key']}"
-            for ln in links
-        )
-        print(f"  {e.derived_authority:.2f}  {e.identity_key:<25} "
-              f"({link_summary})")
+        print()
+        print(f"Top 10 {canonical_type} entities by authority:")
+        for e in rows:
+            if e.derived_authority is None:
+                continue
+            links = e.signals.get("links", [])
+            link_summary = " + ".join(
+                f"{ln['entity_type'].split('_')[0]}:{ln['identity_key']}"
+                for ln in links
+            )
+            print(f"  {e.derived_authority:.2f}  {e.identity_key:<25} "
+                  f"({link_summary})")
 
     return 0
 

--- a/src/ovp_pipeline/commands/merge_identities.py
+++ b/src/ovp_pipeline/commands/merge_identities.py
@@ -32,6 +32,14 @@ from ..entities.identity_merge import (
 from ..entities.store import EntityStore
 
 
+# Cap on how many reclassification candidates we print inline.  The
+# rest are summarized via "and N more"; full list lives in the JSON
+# status file (PR-E5).
+_MIGRATION_PREVIEW_LIMIT = 20
+_FUZZY_PREVIEW_LIMIT = 20
+_TOP_K = 10
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Merge twitter_author + github_user into person entities",
@@ -57,32 +65,19 @@ def main(argv: list[str] | None = None) -> int:
 
     store = EntityStore(db_path=db_path)
 
-    if args.migrate_existing and not args.dry_run:
-        reclassified, kept = reclassify_persons_to_orgs(store)
-        print(f"PR-F1 migration: {reclassified} person → organization "
-              f"({kept} unchanged)")
-    elif args.migrate_existing and args.dry_run:
-        # Dry-run preview: only count, don't apply.
-        kept = 0
-        org_candidates: list[str] = []
-        for p in store.list_by_type(PERSON_TYPE):
-            gh_link = next(
-                (ln for ln in (p.signals.get("links") or [])
-                 if ln.get("entity_type") == "github_user"),
-                None,
-            )
-            if gh_link is None:
-                kept += 1
-                continue
-            gh = store.get("github_user", gh_link.get("identity_key", ""))
-            if gh and (gh.signals.get("type") or "").lower() == "organization":
-                org_candidates.append(p.identity_key)
-            else:
-                kept += 1
-        print(f"PR-F1 migration (dry-run): {len(org_candidates)} would be "
-              f"reclassified, {kept} unchanged")
-        for handle in org_candidates[:20]:
+    if args.migrate_existing:
+        # Single source of truth — both real and dry-run go through
+        # reclassify_persons_to_orgs so the preview can never disagree
+        # with the actual write.
+        reclassified, kept, handles = reclassify_persons_to_orgs(
+            store, dry_run=args.dry_run,
+        )
+        verb = "would be reclassified" if args.dry_run else "person → organization"
+        print(f"PR-F1 migration: {reclassified} {verb} ({kept} unchanged)")
+        for handle in handles[:_MIGRATION_PREVIEW_LIMIT]:
             print(f"  person → organization: {handle}")
+        if len(handles) > _MIGRATION_PREVIEW_LIMIT:
+            print(f"  ... and {len(handles) - _MIGRATION_PREVIEW_LIMIT} more")
         print()
 
     candidates = find_merge_candidates(store)
@@ -112,10 +107,10 @@ def main(argv: list[str] | None = None) -> int:
                 print(f"  {c.confidence:.2f}  github:{c.github_login:<25} "
                       f"↔ twitter:@{c.twitter_handle}")
         print()
-        print("=== fuzzy (review queue, top 20) ===")
+        print(f"=== fuzzy (review queue, top {_FUZZY_PREVIEW_LIMIT}) ===")
         fuzzy = [c for c in candidates if c.method == "fuzzy"]
         fuzzy.sort(key=lambda c: -c.confidence)
-        for c in fuzzy[:20]:
+        for c in fuzzy[:_FUZZY_PREVIEW_LIMIT]:
             print(f"  {c.confidence:.2f}  github:{c.github_login:<25} "
                   f"↔ twitter:@{c.twitter_handle:<25}  ({c.rationale})")
         print()
@@ -142,11 +137,11 @@ def main(argv: list[str] | None = None) -> int:
     print(f"skipped: {skipped}  (review queue + missing-side cases)")
 
     for canonical_type in (PERSON_TYPE, ORGANIZATION_TYPE):
-        rows = store.list_by_type(canonical_type, limit=10)
+        rows = store.list_by_type(canonical_type, limit=_TOP_K)
         if not rows:
             continue
         print()
-        print(f"Top 10 {canonical_type} entities by authority:")
+        print(f"Top {_TOP_K} {canonical_type} entities by authority:")
         for e in rows:
             if e.derived_authority is None:
                 continue

--- a/src/ovp_pipeline/entities/identity_merge.py
+++ b/src/ovp_pipeline/entities/identity_merge.py
@@ -1,19 +1,30 @@
-"""Identity merge — collapse twitter_author + github_user into person.
+"""Identity merge — collapse twitter_author + github_user into person/organization.
 
 Why
 ---
 
 After PR-E1 (twitter_author) and PR-E2 (github_project + github_user)
-the entity table has two parallel slices for the same human.  E.g.
+the entity table has two parallel slices for the same actor.  E.g.
 @karpathy on Twitter (followers 1.5M, score 0.50) and karpathy on
 GitHub (50k followers, score 0.65) are the same person — but the
 entity store doesn't know that.
 
-The fix is **another entity type** rather than a pointer column:
+The fix is **two new entity types** rather than a pointer column:
 
   * ``person`` — canonical identity for a human
-  * its ``signals_json`` carries a ``links`` array pointing back at
-    the platform-specific entities
+  * ``organization`` — canonical identity for an org (huggingface,
+    polymarket, posthog) — split from ``person`` in PR-F1 because
+    the semantics differ:
+      - persons inherit individual-author authority (followers,
+        bio, written works)
+      - orgs inherit institutional-author authority (membership,
+        endorsements, brand)
+    Conflating them mis-files karpathy@x↔karpathy@gh next to
+    polymarket@x↔polymarket@gh in the same bucket.
+
+Both types carry the same ``links`` array pointing back at the
+platform-specific entities, so downstream code only needs ONE union
+read path (see ``resolver.py``).
 
 Three merge sources, in order of confidence:
 
@@ -55,8 +66,25 @@ logger = logging.getLogger(__name__)
 
 # Entity types we emit and consume.
 PERSON_TYPE = "person"
+ORGANIZATION_TYPE = "organization"
 TWITTER_TYPE = "twitter_author"
 GITHUB_USER_TYPE = "github_user"
+
+# All canonical-identity entity types that this module produces.
+# Resolver lookups iterate this set so adding a future type (e.g.
+# ``team`` for github org-within-org) only edits one constant.
+CANONICAL_TYPES: tuple[str, ...] = (PERSON_TYPE, ORGANIZATION_TYPE)
+
+
+def _is_organization(github_user: Entity) -> bool:
+    """Decide whether to file a merged actor under organization or person.
+
+    Source of truth: GitHub's own ``type`` field on the user object,
+    which is either ``User`` or ``Organization``.  We don't try to
+    second-guess via heuristics on the name (``-ai``, ``Inc.``, …) —
+    GitHub already classifies, just trust it.
+    """
+    return (github_user.signals.get("type") or "").lower() == "organization"
 
 # Confidence categories for the report / review queue.
 MergeMethod = Literal["self_reported", "exact_handle", "fuzzy"]
@@ -214,17 +242,22 @@ def find_merge_candidates(store: EntityStore) -> list[MergeCandidate]:
 def apply_merge(
     store: EntityStore, candidate: MergeCandidate,
 ) -> Entity | None:
-    """Upsert a person entity that links the gh + tw entities.
+    """Upsert a person OR organization entity linking the gh + tw entities.
 
-    Returns the freshly-written ``person`` Entity, or ``None`` if either
+    The choice between ``person`` and ``organization`` is driven by
+    ``github_user.signals.type`` — GitHub already classifies its
+    accounts, and we trust that classification.
+
+    Returns the freshly-written canonical Entity, or ``None`` if either
     side disappeared between discovery and apply (rare race).
 
-    Person identity_key
-    -------------------
-    We use the **lowercased twitter handle** as the canonical key.
-    Reason: Twitter handles are typically more "famous" / oft-quoted
-    than the GitHub login (think @karpathy vs karpathy@github), so
-    naming the person by their twitter handle keeps human-facing
+    identity_key
+    ------------
+    We use the **lowercased twitter handle** as the canonical key
+    for both types.  Reason: Twitter handles are typically more
+    "famous" / oft-quoted than the GitHub login (think @karpathy vs
+    karpathy@github, @langchain vs langchain-ai@github), so naming
+    the canonical entity by its twitter handle keeps human-facing
     surfaces (logs, dashboards) intuitive.
     """
     gh = store.get(GITHUB_USER_TYPE, candidate.github_login)
@@ -232,9 +265,10 @@ def apply_merge(
     if gh is None or tw is None:
         return None
 
-    person_key = candidate.twitter_handle
+    canonical_type = ORGANIZATION_TYPE if _is_organization(gh) else PERSON_TYPE
+    canonical_key = candidate.twitter_handle
     canonical_name = (
-        tw.canonical_name or gh.canonical_name or person_key
+        tw.canonical_name or gh.canonical_name or canonical_key
     )
     derived = max(
         a for a in (gh.derived_authority, tw.derived_authority)
@@ -242,7 +276,8 @@ def apply_merge(
     )
 
     signals = {
-        "person_canonical_handle": person_key,
+        "canonical_handle": canonical_key,
+        "actor_kind": canonical_type,        # "person" | "organization"
         "links": [
             {"entity_type": GITHUB_USER_TYPE,
              "identity_key": gh.identity_key,
@@ -264,14 +299,70 @@ def apply_merge(
         "bio": gh.signals.get("bio") or tw.signals.get("description"),
     }
 
+    # Migration safety: if a stale ``person`` row exists for an entity
+    # we now classify as ``organization`` (or vice versa), delete it
+    # so the entity table doesn't carry both.  See migration helper
+    # ``reclassify_persons_to_orgs`` for bulk-mode behavior.
+    other_type = (
+        PERSON_TYPE if canonical_type == ORGANIZATION_TYPE else ORGANIZATION_TYPE
+    )
+    stale = store.get(other_type, canonical_key)
+    if stale is not None:
+        store.delete(other_type, canonical_key)
+
     return store.upsert(
-        entity_type=PERSON_TYPE,
-        identity_key=person_key,
+        entity_type=canonical_type,
+        identity_key=canonical_key,
         canonical_name=canonical_name,
         signals=signals,
         derived_authority=derived,
         fetch_source="identity_merge",
     )
+
+
+def reclassify_persons_to_orgs(store: EntityStore) -> tuple[int, int]:
+    """One-shot migration: walk existing ``person`` rows and re-file
+    those whose linked github_user has ``type == "Organization"``.
+
+    Returns ``(reclassified, kept)``.  Idempotent — running twice is
+    a no-op on the second pass.
+
+    This is the bulk equivalent of ``apply_merge``'s inline cleanup;
+    use it once after PR-F1 lands to fix the 54 pre-split person
+    entities created by PR-E3.
+    """
+    reclassified = 0
+    kept = 0
+    for person in list(store.list_by_type(PERSON_TYPE)):
+        # The github_user link inside signals tells us which actor we
+        # came from — look it up and inspect its current type.
+        gh_link = next(
+            (ln for ln in (person.signals.get("links") or [])
+             if ln.get("entity_type") == GITHUB_USER_TYPE),
+            None,
+        )
+        if gh_link is None:
+            kept += 1
+            continue
+        gh = store.get(GITHUB_USER_TYPE, gh_link.get("identity_key", ""))
+        if gh is None or not _is_organization(gh):
+            kept += 1
+            continue
+        # Reclassify: re-upsert under organization with the same
+        # signals; delete the old person row.
+        new_signals = dict(person.signals)
+        new_signals["actor_kind"] = ORGANIZATION_TYPE
+        store.upsert(
+            entity_type=ORGANIZATION_TYPE,
+            identity_key=person.identity_key,
+            canonical_name=person.canonical_name,
+            signals=new_signals,
+            derived_authority=person.derived_authority,
+            fetch_source="identity_merge",
+        )
+        store.delete(PERSON_TYPE, person.identity_key)
+        reclassified += 1
+    return reclassified, kept
 
 
 def iter_auto_apply(

--- a/src/ovp_pipeline/entities/identity_merge.py
+++ b/src/ovp_pipeline/entities/identity_merge.py
@@ -277,6 +277,9 @@ def apply_merge(
 
     signals = {
         "canonical_handle": canonical_key,
+        # Pre-PR-F1 readers expected ``person_canonical_handle``.  Keep
+        # both keys until we've audited the downstream consumers.
+        "person_canonical_handle": canonical_key,
         "actor_kind": canonical_type,        # "person" | "organization"
         "links": [
             {"entity_type": GITHUB_USER_TYPE,
@@ -320,38 +323,66 @@ def apply_merge(
     )
 
 
-def reclassify_persons_to_orgs(store: EntityStore) -> tuple[int, int]:
-    """One-shot migration: walk existing ``person`` rows and re-file
-    those whose linked github_user has ``type == "Organization"``.
-
-    Returns ``(reclassified, kept)``.  Idempotent — running twice is
-    a no-op on the second pass.
-
-    This is the bulk equivalent of ``apply_merge``'s inline cleanup;
-    use it once after PR-F1 lands to fix the 54 pre-split person
-    entities created by PR-E3.
+def _iter_reclassify_targets(store: EntityStore) -> Iterator[Entity]:
+    """Yield ``person`` rows whose linked github_user is now classified
+    as an organization.  Single source of truth for both the bulk
+    migration and any dry-run / preview caller — guarantees the two
+    can never disagree.
     """
-    reclassified = 0
-    kept = 0
-    for person in list(store.list_by_type(PERSON_TYPE)):
-        # The github_user link inside signals tells us which actor we
-        # came from — look it up and inspect its current type.
+    for person in store.list_by_type(PERSON_TYPE):
         gh_link = next(
             (ln for ln in (person.signals.get("links") or [])
              if ln.get("entity_type") == GITHUB_USER_TYPE),
             None,
         )
         if gh_link is None:
-            kept += 1
             continue
         gh = store.get(GITHUB_USER_TYPE, gh_link.get("identity_key", ""))
         if gh is None or not _is_organization(gh):
-            kept += 1
             continue
+        yield person
+
+
+def reclassify_persons_to_orgs(
+    store: EntityStore, *, dry_run: bool = False,
+) -> tuple[int, int, list[str]]:
+    """One-shot migration: walk existing ``person`` rows and re-file
+    those whose linked github_user has ``type == "Organization"``.
+
+    Parameters
+    ----------
+    dry_run :
+        When True, scans + reports without writing.
+
+    Returns
+    -------
+    ``(reclassified, kept, candidate_handles)``
+        ``reclassified`` is the count of rows moved (or that would be
+        moved in dry-run); ``kept`` is everything else; ``candidate_handles``
+        lists the identity_keys at issue (handy for CLI display).
+
+    Idempotent — running twice is a no-op on the second pass because
+    the org-typed rows are no longer ``person``.
+
+    This is the bulk equivalent of ``apply_merge``'s inline cleanup;
+    use it once after PR-F1 lands to fix the pre-split person entities
+    created by PR-E3.
+    """
+    candidates: list[Entity] = list(_iter_reclassify_targets(store))
+    candidate_handles = [p.identity_key for p in candidates]
+
+    if dry_run:
+        kept = len(store.list_by_type(PERSON_TYPE)) - len(candidates)
+        return len(candidates), kept, candidate_handles
+
+    for person in candidates:
         # Reclassify: re-upsert under organization with the same
-        # signals; delete the old person row.
+        # signals (plus the new actor_kind + canonical_handle keys
+        # so migrated rows match newly-merged rows exactly); delete
+        # the old person row.
         new_signals = dict(person.signals)
         new_signals["actor_kind"] = ORGANIZATION_TYPE
+        new_signals.setdefault("canonical_handle", person.identity_key)
         store.upsert(
             entity_type=ORGANIZATION_TYPE,
             identity_key=person.identity_key,
@@ -361,8 +392,9 @@ def reclassify_persons_to_orgs(store: EntityStore) -> tuple[int, int]:
             fetch_source="identity_merge",
         )
         store.delete(PERSON_TYPE, person.identity_key)
-        reclassified += 1
-    return reclassified, kept
+
+    kept = len(store.list_by_type(PERSON_TYPE))
+    return len(candidates), kept, candidate_handles
 
 
 def iter_auto_apply(

--- a/src/ovp_pipeline/entities/resolver.py
+++ b/src/ovp_pipeline/entities/resolver.py
@@ -26,7 +26,16 @@ from .store import Entity, EntityStore
 
 # Source-of-truth labels we pass back so callers can record where the
 # authority came from in the audit log.
-ResolveSource = Literal["person", "twitter_author", "github_user", "github_project", "none"]
+ResolveSource = Literal[
+    "person", "organization", "twitter_author",
+    "github_user", "github_project", "none",
+]
+
+
+# Canonical-identity types in lookup-priority order.  Both share
+# the same ``identity_key`` namespace (lowercased twitter handle),
+# so a given handle can only resolve to one of them.
+_CANONICAL_TYPES: tuple[ResolveSource, ...] = ("person", "organization")
 
 
 @dataclass(frozen=True, slots=True)
@@ -55,12 +64,16 @@ def resolve_twitter_authority(
     if not norm:
         return ResolveResult(None, "none", None)
 
-    # 1. Person entity keyed by twitter handle (PR-E3 merges).  This is
-    #    the right answer when the handle has been linked to a github
-    #    entity — it carries the max-of-all-platforms authority.
-    person = store.get("person", norm)
-    if person is not None and person.derived_authority is not None:
-        return ResolveResult(person.derived_authority, "person", person)
+    # 1. Canonical-identity entity (person or organization) keyed by
+    #    twitter handle.  PR-F1 split person → person + organization;
+    #    a given handle is only in one bucket so the loop returns on
+    #    first hit.
+    for canonical_type in _CANONICAL_TYPES:
+        canonical = store.get(canonical_type, norm)
+        if canonical is not None and canonical.derived_authority is not None:
+            return ResolveResult(
+                canonical.derived_authority, canonical_type, canonical,
+            )
 
     # 2. Plain twitter_author entity from PR-E1.
     tw = store.get("twitter_author", norm)
@@ -113,16 +126,21 @@ def resolve_github_user_authority(
     if not norm:
         return ResolveResult(None, "none", None)
 
-    # Person merge takes precedence here too — if karpathy was merged
-    # to a person entity via his twitter handle, we want that view.
-    # Look up via the github_user's twitter_username field.
+    # Canonical-identity merge takes precedence here too — if karpathy
+    # was merged to a person entity via his twitter handle, or
+    # langchain-ai was merged to an organization entity, we want
+    # that view.  Look up via the github_user's twitter_username field.
     gh = store.get("github_user", norm)
     if gh is not None and gh.derived_authority is not None:
         tw_username = _normalize(gh.signals.get("twitter_username"))
         if tw_username:
-            person = store.get("person", tw_username)
-            if person is not None and person.derived_authority is not None:
-                return ResolveResult(person.derived_authority, "person", person)
+            for canonical_type in _CANONICAL_TYPES:
+                canonical = store.get(canonical_type, tw_username)
+                if (canonical is not None
+                        and canonical.derived_authority is not None):
+                    return ResolveResult(
+                        canonical.derived_authority, canonical_type, canonical,
+                    )
         return ResolveResult(gh.derived_authority, "github_user", gh)
 
     return ResolveResult(None, "none", None)

--- a/src/ovp_pipeline/entities/store.py
+++ b/src/ovp_pipeline/entities/store.py
@@ -136,6 +136,38 @@ class EntityStore:
         finally:
             conn.close()
 
+    def delete(self, entity_type: str, identity_key: str) -> bool:
+        """Remove an entity + its history rows.
+
+        Returns True if a row was deleted, False if the entity wasn't
+        present.  Used by identity_merge's reclassification when a
+        ``person`` should be re-filed as ``organization`` (or vice
+        versa) — the unique constraint on (entity_type, identity_key)
+        means we can't just upsert across types.
+        """
+        conn = sqlite3.connect(self.db_path)
+        try:
+            row = conn.execute(
+                "SELECT entity_id FROM entities "
+                "WHERE entity_type=? AND identity_key=?",
+                (entity_type, identity_key),
+            ).fetchone()
+            if row is None:
+                return False
+            entity_id = row[0]
+            conn.execute(
+                "DELETE FROM entity_signals_history WHERE entity_id=?",
+                (entity_id,),
+            )
+            conn.execute(
+                "DELETE FROM entities WHERE entity_id=?",
+                (entity_id,),
+            )
+            conn.commit()
+            return True
+        finally:
+            conn.close()
+
     def list_by_type(
         self, entity_type: str, *, limit: int | None = None,
     ) -> list[Entity]:

--- a/tests/test_entity_resolver.py
+++ b/tests/test_entity_resolver.py
@@ -38,6 +38,13 @@ def _seed_person(store, h, auth):
     )
 
 
+def _seed_organization(store, h, auth):
+    store.upsert(
+        entity_type="organization", identity_key=h, canonical_name=h,
+        signals={"links": []}, derived_authority=auth, fetch_source="m",
+    )
+
+
 class TestResolveTwitter:
     def test_falls_back_to_twitter_author(self, tmp_path):
         store = EntityStore(db_path=tmp_path / "k.db")
@@ -118,3 +125,44 @@ class TestResolveGithubUser:
         r = resolve_github_user_authority(store, "karpathy")
         assert r.authority == 0.75
         assert r.source == "person"
+
+
+# ---------------------------------------------------------------------------
+# PR-F1: organization resolution
+# ---------------------------------------------------------------------------
+
+
+class TestOrganizationResolution:
+    def test_twitter_resolves_to_organization(self, tmp_path):
+        # langchain is filed as ``organization`` (PR-F1) — twitter
+        # resolution must surface that, not silently miss.
+        store = EntityStore(db_path=tmp_path / "k.db")
+        _seed_organization(store, "langchain", 0.57)
+        r = resolve_twitter_authority(store, "langchain")
+        assert r.authority == 0.57
+        assert r.source == "organization"
+
+    def test_github_user_via_org_canonical(self, tmp_path):
+        # github_user.langchain-ai has twitter_username="langchain";
+        # the organization entity for "langchain" should win over
+        # the bare github_user authority.
+        store = EntityStore(db_path=tmp_path / "k.db")
+        _seed_gh_user(store, "langchain-ai", 0.55, twitter_username="langchain")
+        _seed_organization(store, "langchain", 0.65)
+        r = resolve_github_user_authority(store, "langchain-ai")
+        assert r.authority == 0.65
+        assert r.source == "organization"
+
+    def test_person_and_org_dont_collide_on_same_handle(self, tmp_path):
+        # In practice the same identity_key won't exist as both — the
+        # apply_merge migration cleans up — but the resolver should
+        # behave deterministically if a stale row sneaks through.
+        # _CANONICAL_TYPES iterates person before organization, so
+        # person wins (matches the migration's expected end state
+        # where the stale row is the org one).
+        store = EntityStore(db_path=tmp_path / "k.db")
+        _seed_person(store, "ambiguous", 0.5)
+        _seed_organization(store, "ambiguous", 0.7)
+        r = resolve_twitter_authority(store, "ambiguous")
+        assert r.source == "person"
+        assert r.authority == 0.5

--- a/tests/test_identity_merge.py
+++ b/tests/test_identity_merge.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 from ovp_pipeline.entities.identity_merge import (
+    GITHUB_USER_TYPE,
     MergeCandidate,
+    ORGANIZATION_TYPE,
     PERSON_TYPE,
+    TWITTER_TYPE,
     apply_merge,
     find_merge_candidates,
+    reclassify_persons_to_orgs,
     _levenshtein,
 )
 from ovp_pipeline.entities.store import EntityStore
@@ -198,3 +202,184 @@ class TestApplyMerge:
         )
         # Neither entity exists.
         assert apply_merge(store, c) is None
+
+
+# ---------------------------------------------------------------------------
+# PR-F1: person/organization split
+# ---------------------------------------------------------------------------
+
+
+class TestOrganizationSplit:
+    def test_org_typed_github_user_creates_organization(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "k.db")
+        _make_tw(store, "langchain", authority=0.55,
+                 signals={"followers": 248_000})
+        _make_gh(
+            store, "langchain-ai", authority=0.65,
+            signals={"twitter_username": "langchain",
+                     "type": "Organization", "followers": 18_700},
+        )
+        cands = find_merge_candidates(store)
+        applied = [apply_merge(store, c) for c in cands if c.is_auto]
+        assert len(applied) == 1
+        # Should be an organization, NOT a person.
+        org = store.get(ORGANIZATION_TYPE, "langchain")
+        person = store.get(PERSON_TYPE, "langchain")
+        assert org is not None
+        assert person is None
+        assert org.signals["actor_kind"] == ORGANIZATION_TYPE
+
+    def test_user_typed_github_user_still_creates_person(self, tmp_path):
+        # PR-F1 must not break the person path — User-typed accounts
+        # still file under person.
+        store = EntityStore(db_path=tmp_path / "k.db")
+        _make_tw(store, "karpathy", authority=0.50)
+        _make_gh(store, "karpathy", authority=0.65,
+                 signals={"twitter_username": "karpathy", "type": "User"})
+        cands = find_merge_candidates(store)
+        applied = [apply_merge(store, c) for c in cands if c.is_auto]
+        assert len(applied) == 1
+        person = store.get(PERSON_TYPE, "karpathy")
+        org = store.get(ORGANIZATION_TYPE, "karpathy")
+        assert person is not None
+        assert org is None
+        assert person.signals["actor_kind"] == PERSON_TYPE
+
+    def test_missing_type_field_defaults_to_person(self, tmp_path):
+        # Backward-compat: pre-PR-F1 github_user entities don't have
+        # a ``type`` field in signals.  Default is person, not org.
+        store = EntityStore(db_path=tmp_path / "k.db")
+        _make_tw(store, "x", authority=0.4)
+        _make_gh(store, "x", authority=0.5,
+                 signals={"twitter_username": "x"})  # no type
+        cands = find_merge_candidates(store)
+        for c in cands:
+            apply_merge(store, c)
+        assert store.get(PERSON_TYPE, "x") is not None
+        assert store.get(ORGANIZATION_TYPE, "x") is None
+
+    def test_apply_reclassifies_existing_person_as_org(self, tmp_path):
+        # Simulates a PR-E3-era person row that should be reclassified
+        # when this PR's apply_merge runs.  The old row must be
+        # deleted, not duplicated.
+        store = EntityStore(db_path=tmp_path / "k.db")
+        _make_tw(store, "polymarket", authority=0.57,
+                 signals={"followers": 1_467_000})
+        _make_gh(store, "polymarket", authority=0.55,
+                 signals={"twitter_username": "polymarket",
+                          "type": "Organization"})
+        # Pre-seed a stale person entity (as if from PR-E3).
+        store.upsert(
+            entity_type=PERSON_TYPE, identity_key="polymarket",
+            canonical_name="Polymarket", signals={"stale": True},
+            derived_authority=0.57, fetch_source="identity_merge",
+        )
+        cands = find_merge_candidates(store)
+        for c in cands:
+            apply_merge(store, c)
+        # Now organization, no person.
+        assert store.get(ORGANIZATION_TYPE, "polymarket") is not None
+        assert store.get(PERSON_TYPE, "polymarket") is None
+
+
+class TestReclassifyMigration:
+    def test_bulk_migrates_orgs_only(self, tmp_path):
+        # Three pre-existing person rows: two are actually orgs, one is
+        # a real person.  reclassify_persons_to_orgs should move only
+        # the two org-typed ones.
+        store = EntityStore(db_path=tmp_path / "k.db")
+
+        # Org #1 — langchain-ai on github
+        _make_gh(store, "langchain-ai", authority=0.65,
+                 signals={"twitter_username": "langchain",
+                          "type": "Organization"})
+        store.upsert(
+            entity_type=PERSON_TYPE, identity_key="langchain",
+            canonical_name="LangChain", signals={
+                "links": [{"entity_type": GITHUB_USER_TYPE,
+                           "identity_key": "langchain-ai"}],
+            }, derived_authority=0.57, fetch_source="identity_merge",
+        )
+        # Org #2 — posthog
+        _make_gh(store, "posthog", authority=0.65,
+                 signals={"twitter_username": "posthog",
+                          "type": "Organization"})
+        store.upsert(
+            entity_type=PERSON_TYPE, identity_key="posthog",
+            canonical_name="PostHog", signals={
+                "links": [{"entity_type": GITHUB_USER_TYPE,
+                           "identity_key": "posthog"}],
+            }, derived_authority=0.56, fetch_source="identity_merge",
+        )
+        # Real person — karpathy
+        _make_gh(store, "karpathy", authority=0.65,
+                 signals={"twitter_username": "karpathy", "type": "User"})
+        store.upsert(
+            entity_type=PERSON_TYPE, identity_key="karpathy",
+            canonical_name="Andrej Karpathy", signals={
+                "links": [{"entity_type": GITHUB_USER_TYPE,
+                           "identity_key": "karpathy"}],
+            }, derived_authority=0.65, fetch_source="identity_merge",
+        )
+
+        reclassified, kept = reclassify_persons_to_orgs(store)
+        assert reclassified == 2
+        assert kept == 1
+        # Orgs are now organization rows; person rows for those gone.
+        assert store.get(ORGANIZATION_TYPE, "langchain") is not None
+        assert store.get(PERSON_TYPE, "langchain") is None
+        assert store.get(ORGANIZATION_TYPE, "posthog") is not None
+        assert store.get(PERSON_TYPE, "posthog") is None
+        # Karpathy stays a person.
+        assert store.get(PERSON_TYPE, "karpathy") is not None
+        assert store.get(ORGANIZATION_TYPE, "karpathy") is None
+
+    def test_idempotent(self, tmp_path):
+        # Second run should be a no-op.
+        store = EntityStore(db_path=tmp_path / "k.db")
+        _make_gh(store, "langchain-ai", authority=0.65,
+                 signals={"type": "Organization"})
+        store.upsert(
+            entity_type=PERSON_TYPE, identity_key="langchain",
+            canonical_name="LangChain", signals={
+                "links": [{"entity_type": GITHUB_USER_TYPE,
+                           "identity_key": "langchain-ai"}],
+            }, derived_authority=0.57, fetch_source="identity_merge",
+        )
+        first = reclassify_persons_to_orgs(store)
+        second = reclassify_persons_to_orgs(store)
+        assert first == (1, 0)
+        assert second == (0, 0)
+
+    def test_skips_when_github_link_missing(self, tmp_path):
+        # If a person row's links don't include a github_user (perhaps
+        # a future merge source like substack-only), we can't tell —
+        # leave it alone.
+        store = EntityStore(db_path=tmp_path / "k.db")
+        store.upsert(
+            entity_type=PERSON_TYPE, identity_key="orphan",
+            canonical_name="Orphan", signals={"links": []},
+            derived_authority=0.5, fetch_source="identity_merge",
+        )
+        reclassified, kept = reclassify_persons_to_orgs(store)
+        assert reclassified == 0
+        assert kept == 1
+        assert store.get(PERSON_TYPE, "orphan") is not None
+
+
+class TestStoreDelete:
+    def test_delete_removes_row_and_history(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "k.db")
+        _make_tw(store, "ghost", authority=0.4)
+        e = store.get(TWITTER_TYPE, "ghost")
+        assert e is not None
+        ok = store.delete(TWITTER_TYPE, "ghost")
+        assert ok is True
+        assert store.get(TWITTER_TYPE, "ghost") is None
+        # History rows for that entity_id are gone too.
+        rows = list(store.history(e.entity_id))
+        assert rows == []
+
+    def test_delete_nonexistent_returns_false(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "k.db")
+        assert store.delete(TWITTER_TYPE, "never-existed") is False

--- a/tests/test_identity_merge.py
+++ b/tests/test_identity_merge.py
@@ -180,6 +180,11 @@ class TestApplyMerge:
         assert person.signals["twitter_followers"] == 1_500_000
         assert person.signals["github_followers"] == 60_000
         assert person.signals["bio"] == "AI researcher"
+        # Back-compat: ``person_canonical_handle`` (the pre-PR-F1
+        # name) must coexist with the new ``canonical_handle`` so
+        # downstream consumers reading the old key keep working.
+        assert person.signals["canonical_handle"] == "karpathy"
+        assert person.signals["person_canonical_handle"] == "karpathy"
 
     def test_apply_is_idempotent(self, tmp_path):
         store = EntityStore(db_path=tmp_path / "k.db")
@@ -322,9 +327,11 @@ class TestReclassifyMigration:
             }, derived_authority=0.65, fetch_source="identity_merge",
         )
 
-        reclassified, kept = reclassify_persons_to_orgs(store)
+        reclassified, kept, handles = reclassify_persons_to_orgs(store)
         assert reclassified == 2
         assert kept == 1
+        # The handles list lets the CLI preview match the actual write.
+        assert set(handles) == {"langchain", "posthog"}
         # Orgs are now organization rows; person rows for those gone.
         assert store.get(ORGANIZATION_TYPE, "langchain") is not None
         assert store.get(PERSON_TYPE, "langchain") is None
@@ -348,8 +355,58 @@ class TestReclassifyMigration:
         )
         first = reclassify_persons_to_orgs(store)
         second = reclassify_persons_to_orgs(store)
-        assert first == (1, 0)
-        assert second == (0, 0)
+        assert (first[0], first[1]) == (1, 0)       # 1 reclassified, 0 kept
+        assert (second[0], second[1]) == (0, 0)     # idempotent: no-op
+        # The handles list mirrors the count.
+        assert first[2] == ["langchain"]
+        assert second[2] == []
+
+    def test_dry_run_reports_without_writing(self, tmp_path):
+        # The CLI's --dry-run preview must use the same code path as
+        # the actual write so the two can never disagree.
+        store = EntityStore(db_path=tmp_path / "k.db")
+        _make_gh(store, "langchain-ai", authority=0.65,
+                 signals={"type": "Organization"})
+        store.upsert(
+            entity_type=PERSON_TYPE, identity_key="langchain",
+            canonical_name="LangChain", signals={
+                "links": [{"entity_type": GITHUB_USER_TYPE,
+                           "identity_key": "langchain-ai"}],
+            }, derived_authority=0.57, fetch_source="identity_merge",
+        )
+
+        reclassified, kept, handles = reclassify_persons_to_orgs(
+            store, dry_run=True,
+        )
+        assert reclassified == 1
+        assert kept == 0
+        assert handles == ["langchain"]
+        # Nothing was actually written: person row still there, org
+        # row not created.
+        assert store.get(PERSON_TYPE, "langchain") is not None
+        assert store.get(ORGANIZATION_TYPE, "langchain") is None
+
+    def test_migrated_row_carries_canonical_handle(self, tmp_path):
+        # Pre-PR-F1 person rows had ``person_canonical_handle`` (or
+        # nothing).  After migration the row should carry the unified
+        # ``canonical_handle`` so it matches newly-merged rows.
+        store = EntityStore(db_path=tmp_path / "k.db")
+        _make_gh(store, "langchain-ai", authority=0.65,
+                 signals={"type": "Organization"})
+        # Stale row missing the new key entirely.
+        store.upsert(
+            entity_type=PERSON_TYPE, identity_key="langchain",
+            canonical_name="LangChain", signals={
+                "person_canonical_handle": "langchain",
+                "links": [{"entity_type": GITHUB_USER_TYPE,
+                           "identity_key": "langchain-ai"}],
+            }, derived_authority=0.57, fetch_source="identity_merge",
+        )
+        reclassify_persons_to_orgs(store)
+        org = store.get(ORGANIZATION_TYPE, "langchain")
+        assert org is not None
+        assert org.signals["canonical_handle"] == "langchain"
+        assert org.signals["actor_kind"] == ORGANIZATION_TYPE
 
     def test_skips_when_github_link_missing(self, tmp_path):
         # If a person row's links don't include a github_user (perhaps
@@ -361,9 +418,10 @@ class TestReclassifyMigration:
             canonical_name="Orphan", signals={"links": []},
             derived_authority=0.5, fetch_source="identity_merge",
         )
-        reclassified, kept = reclassify_persons_to_orgs(store)
+        reclassified, kept, handles = reclassify_persons_to_orgs(store)
         assert reclassified == 0
         assert kept == 1
+        assert handles == []
         assert store.get(PERSON_TYPE, "orphan") is not None
 
 


### PR DESCRIPTION
## Summary

- **PR-F1** — splits the \`person\` entity type into \`person\` + \`organization\`.
- Source of truth: GitHub's own \`user.type\` field (\`User\` vs \`Organization\`).  No name-based heuristics.
- One-shot migration of pre-existing \`person\` rows.  Idempotent.

## Why

PR-E3 created a single \`person\` entity for every merged twitter↔github actor.  That bucketed individuals next to orgs — addyosmani next to polymarket, karpathy next to langchain-ai.  Same final number (0-1 authority) but **wrong semantics** for any downstream consumer that wants to reason about "who endorsed this" vs "which institution backs this".

## Real migration against the vault

| | before | after |
|---|---|---|
| person | 54 | **37** |
| organization | 0 | **17** |

Orgs that moved out: polymarket (1.47M Twitter followers), langchain, nousresearch, posthog, openclaw, primeintellect, mem0ai, infisical, letta_ai, …

Persons that stayed: addyosmani, dimillian, twostraws, garrytan, twannl, …

## Migration mechanics

\`reclassify_persons_to_orgs(store)\` walks existing person rows; for each one whose linked github_user is \`type=Organization\`, deletes the person row and inserts an organization row.  Same authority, same canonical handle, just different bucket.

Wired into \`ovp-merge-identities --migrate-existing\` (off by default — routine refreshes shouldn't surprise anyone).

\`apply_merge\` also has an inline cleanup: if a stale row of the *other* type exists for the same canonical handle (e.g. langchain showed up as \`person\` before this PR landed and is now being re-merged as \`organization\`), the stale row is deleted before the upsert.

## New \`EntityStore.delete()\`

Needed for the migration: the unique constraint on \`(entity_type, identity_key)\` means we can't just upsert across types.  Cascades through \`entity_signals_history\`, returns \`False\` for absent rows (no-op safe).

## Resolver

\`resolve_twitter_authority\` / \`resolve_github_user_authority\` now walk a \`_CANONICAL_TYPES = ("person", "organization")\` tuple.  Adding a future canonical type (e.g. \`team\`) edits one constant.

## What this PR does NOT change

- \`signals_json\` schema — the new \`actor_kind\` field is additive.
- AuthorRulesProvider's fallback chain — still calls \`resolve_twitter_authority\`, which now correctly surfaces orgs.
- Existing tests that don't seed a \`type\` field — back-compat preserved (defaults to person).

## Test plan

- [x] org-typed github_user creates organization, NOT person
- [x] user-typed github_user still creates person
- [x] missing type field defaults to person (back-compat)
- [x] apply_merge reclassifies stale person → organization in-place
- [x] bulk migration moves only org-typed (idempotent on second run)
- [x] resolver surfaces \`organization\` as a valid \`source\`
- [x] EntityStore.delete cascades through history; nonexistent returns False
- [x] Full suite: **1746 passed**, lint clean
- [x] Real migration applied to vault: 54 → 37 person + 17 organization

## Stack history

- #115 / #119 / #120 / #117 / #121 — entity layer + scorer integration
- #122 — refresh-source-authority wrapper
- **This PR** — person/organization split

After this lands, the planned design pause: think about how the entity table feeds **back into entity extraction** during ingestion (e.g., LLM extractor sees "we already know @karpathy with authority 0.65, prefer him over a fresh entity" — closes the loop the user flagged).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for organization entities in identity merging and cross-platform resolution.
  * Introduced `--migrate-existing` CLI flag to reclassify existing person records to organizations based on linked account type.
  * Extended final reporting to display "Top 10" entities by authority for both persons and organizations.

* **Tests**
  * Comprehensive test coverage for organization resolution, classification logic, and bulk migration workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->