### PR TITLE
fix(entities): 12 review-pass fixes across the entity layer

### DIFF
--- a/src/ovp_pipeline/commands/backfill_github.py
+++ b/src/ovp_pipeline/commands/backfill_github.py
@@ -253,11 +253,19 @@ def main(argv: list[str] | None = None) -> int:
         (m.owner, m.repo, m.mention_count)
         for m in mentions if m.repo is not None
     ]
-    # Owners come from the union of (a) all repo owners and (b) any
-    # github.com/<owner> URLs that didn't carry a /repo segment.
+    # Owners come from the union of:
+    #   (a) all repo owners (one user per <owner>/<repo> mention)
+    #   (b) bare profile URLs (``github.com/<owner>`` with no /repo)
+    # The scanner emits profile-only mentions as ``repo=None`` rows;
+    # we union both into owner_counts so a vault note that just says
+    # "Visit https://github.com/karpathy" still triggers a karpathy
+    # github_user backfill.
     owner_counts: dict[str, int] = {}
     for owner, _repo, c in repos:
         owner_counts[owner] = owner_counts.get(owner, 0) + c
+    for m in mentions:
+        if m.repo is None:
+            owner_counts[m.owner] = owner_counts.get(m.owner, 0) + m.mention_count
     users: list[tuple[str, int]] = sorted(
         owner_counts.items(), key=lambda kv: -kv[1],
     )

--- a/src/ovp_pipeline/commands/refresh_source_authority.py
+++ b/src/ovp_pipeline/commands/refresh_source_authority.py
@@ -125,9 +125,20 @@ def _exclusive_lock(lock_path: Path) -> Iterator[None]:
                 f"another refresh is running (pid {existing_pid}); "
                 f"remove {lock_path} after confirming it crashed",
             )
-        # Stale — overwrite.
+        # Stale — overwrite, but guard against the steal race: two
+        # concurrent refreshes might both observe the stale lock,
+        # both unlink it, and both try to recreate.  The second
+        # ``os.open`` then races; we must catch the FileExistsError
+        # and treat it as "the other process won the steal" so we
+        # bail cleanly instead of crashing.
         lock_path.unlink(missing_ok=True)
-        fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        try:
+            fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        except FileExistsError:
+            raise SystemExit(
+                f"lost the lock-steal race against another refresh; "
+                f"the other process now owns {lock_path}",
+            )
     try:
         os.write(fd, str(os.getpid()).encode("utf-8"))
         os.close(fd)
@@ -182,6 +193,10 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--skip-twitter", action="store_true")
     parser.add_argument("--skip-github", action="store_true")
     parser.add_argument("--skip-merge", action="store_true")
+    parser.add_argument("--migrate-existing", action="store_true",
+                        help="Forwarded to ovp-merge-identities — runs the "
+                             "person → organization reclassification on "
+                             "pre-PR-F1 rows.  Idempotent; safe to leave on.")
     parser.add_argument("--strict", action="store_true",
                         help="Exit non-zero if any step failed (default: keep "
                              "running, surface failures in the status JSON)")
@@ -230,9 +245,12 @@ def main(argv: list[str] | None = None) -> int:
             )
 
         if not args.skip_merge:
+            merge_args = ["--vault-dir", str(vault)]
+            if args.migrate_existing:
+                merge_args.append("--migrate-existing")
             _run_step(
                 "identity_merge", merge_identities,
-                args=["--vault-dir", str(vault)],
+                args=merge_args,
                 capture=capture,
             )
 

--- a/src/ovp_pipeline/commands/score_sources.py
+++ b/src/ovp_pipeline/commands/score_sources.py
@@ -33,35 +33,34 @@ import sqlite3
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import Any
 
 from ..layer_schemas import parse_frontmatter
 from ..source_authority import (
-    AuthorityScore,
     default_providers,
     ensure_schema,
     score_source,
     serialize_audit_record,
     upsert_score,
 )
-from ..source_signals import (
-    ArxivSignalProvider,
-    AuthorRulesProvider,
-    DomainRulesProvider,
-    GitHubSignalProvider,
-    SignalProvider,
-    SubstackSignalProvider,
-    TwitterSignalProvider,
-)
+from ..source_signals import SignalProvider
 
 
 def _build_providers(vault_dir: Path, *, domains_only: bool) -> list[SignalProvider]:
+    """Construct the provider stack.
+
+    For ``--domains-only`` we reuse ``default_providers`` and FILTER OUT
+    the network-bound providers (GitHub / Twitter / Substack / arXiv)
+    instead of hand-building a stripped pair.  Hand-building was
+    silently dropping the user's ``domain_overrides.yaml`` /
+    ``author_overrides.yaml`` / entity-store wiring, so a domain that
+    was upgraded to canonical via overrides would score the unknown-host
+    default 0.45 in offline mode.
+    """
+    providers = default_providers(vault_dir)
     if domains_only:
-        return [
-            DomainRulesProvider(),
-            AuthorRulesProvider(authors_path=vault_dir / "60-Logs" / "authors.jsonl"),
-        ]
-    return default_providers(vault_dir)
+        offline_provider_names = {"domain_rules", "author_rules"}
+        providers = [p for p in providers if p.name in offline_provider_names]
+    return providers
 
 
 def _iter_sources(vault_dir: Path, *, since: datetime | None):

--- a/src/ovp_pipeline/commands/source_coverage.py
+++ b/src/ovp_pipeline/commands/source_coverage.py
@@ -165,21 +165,63 @@ def collect_host_stats(
 
 
 def collect_unrecognized_x_handles(
-    vault_dir: Path, *, known_authors: set[str],
+    vault_dir: Path,
+    *,
+    known_authors: set[str],
+    entity_resolved: set[str] | None = None,
 ) -> list[tuple[str, int]]:
-    """List X handles in source URLs that aren't already in authors.jsonl.
+    """List X handles in source URLs that aren't already curated.
+
+    Curation has two layers (PR-E3+):
+      * ``known_authors`` — explicit whitelist (``authors.jsonl`` +
+        ``author_overrides.yaml``).  Wins by definition.
+      * ``entity_resolved`` — handles that the entity table can map
+        to a person/organization/twitter_author with non-None
+        derived_authority.  When passed, those handles are treated
+        as "already known" too, so the dashboard surfaces only
+        truly-unresolved long-tail handles.
+
+    Pass ``entity_resolved=None`` to keep the pre-PR-F1 behavior
+    (only the curated whitelist counts as known).
 
     Returns ``[(handle, count_of_sources)]`` descending by count.
     """
     db_path = vault_dir / "60-Logs" / "knowledge.db"
     authorities = _query_source_authorities(db_path)
     handle_counts: dict[str, int] = defaultdict(int)
+    resolved = entity_resolved or set()
     for source_id, _ in authorities:
         handle = extract_x_handle(source_id)
-        if handle is None or handle in known_authors:
+        if handle is None:
+            continue
+        if handle in known_authors or handle in resolved:
             continue
         handle_counts[handle] += 1
     return sorted(handle_counts.items(), key=lambda kv: -kv[1])
+
+
+def _load_entity_resolved_handles(vault_dir: Path) -> set[str]:
+    """Return the set of X handles that the entity table can resolve
+    to a non-None ``derived_authority`` (twitter_author, person, or
+    organization).  These handles aren't on the curated whitelist
+    but ARE recognized by the runtime resolver — so flagging them as
+    "unknown" in the discovery dashboard is misleading.
+    """
+    db_path = vault_dir / "60-Logs" / "knowledge.db"
+    if not db_path.exists():
+        return set()
+    # Lazy import — avoids pulling entities/* into source_coverage's
+    # import graph for users who never wired the entity layer.
+    from ..entities.store import EntityStore
+
+    store = EntityStore(db_path=db_path)
+    out: set[str] = set()
+    for entity_type in ("twitter_author", "person", "organization"):
+        for e in store.list_by_type(entity_type):
+            if e.derived_authority is None:
+                continue
+            out.add(e.identity_key.lower())
+    return out
 
 
 def _load_known_authors(vault_dir: Path) -> set[str]:
@@ -269,8 +311,14 @@ def main(argv: list[str] | None = None) -> int:
         host_stats = [s for s in host_stats if s.authoritative_count == 0]
 
     known_authors = _load_known_authors(vault)
+    # Treat entity-resolved handles as "already curated" — they're
+    # picked up at runtime by the AuthorRulesProvider entity-fallback
+    # (PR-E3) and therefore aren't actually unrecognized.
+    entity_resolved = _load_entity_resolved_handles(vault)
     unknown_handles = collect_unrecognized_x_handles(
-        vault, known_authors=known_authors,
+        vault,
+        known_authors=known_authors,
+        entity_resolved=entity_resolved,
     )
 
     if args.triage:

--- a/src/ovp_pipeline/entities/identity_merge.py
+++ b/src/ovp_pipeline/entities/identity_merge.py
@@ -313,13 +313,53 @@ def apply_merge(
     if stale is not None:
         store.delete(other_type, canonical_key)
 
-    return store.upsert(
+    canonical = store.upsert(
         entity_type=canonical_type,
         identity_key=canonical_key,
         canonical_name=canonical_name,
         signals=signals,
         derived_authority=derived,
         fetch_source="identity_merge",
+    )
+
+    # Back-link: write the canonical entity's identity_key + type into
+    # the source github_user / twitter_author rows so the resolver can
+    # find the merged authority no matter which side it starts from.
+    # Pre-fix, ``resolve_github_user_authority`` only used
+    # ``twitter_username`` to reach the canonical entity, which meant
+    # exact_handle and fuzzy merges (where we don't know
+    # twitter_username) silently fell back to the bare github score.
+    _write_canonical_backlink(store, gh, canonical_type, canonical_key)
+    _write_canonical_backlink(store, tw, canonical_type, canonical_key)
+    return canonical
+
+
+def _write_canonical_backlink(
+    store: EntityStore,
+    side: Entity,
+    canonical_type: str,
+    canonical_key: str,
+) -> None:
+    """Mutate the platform-specific entity to point back at its canonical.
+
+    Writes ``signals.canonical_entity_type`` + ``signals.canonical_handle``
+    so the resolver — given a github_user (or twitter_author) — can
+    reach the merged person/organization without having to walk a
+    ``twitter_username`` field that exists only on self_reported merges.
+    """
+    new_signals = dict(side.signals)
+    if (new_signals.get("canonical_entity_type") == canonical_type
+            and new_signals.get("canonical_handle") == canonical_key):
+        return  # already linked, no-op
+    new_signals["canonical_entity_type"] = canonical_type
+    new_signals["canonical_handle"] = canonical_key
+    store.upsert(
+        entity_type=side.entity_type,
+        identity_key=side.identity_key,
+        canonical_name=side.canonical_name,
+        signals=new_signals,
+        derived_authority=side.derived_authority,
+        fetch_source=side.fetch_source,
     )
 
 

--- a/src/ovp_pipeline/entities/resolver.py
+++ b/src/ovp_pipeline/entities/resolver.py
@@ -127,11 +127,23 @@ def resolve_github_user_authority(
         return ResolveResult(None, "none", None)
 
     # Canonical-identity merge takes precedence here too — if karpathy
-    # was merged to a person entity via his twitter handle, or
-    # langchain-ai was merged to an organization entity, we want
-    # that view.  Look up via the github_user's twitter_username field.
+    # was merged to a person entity, or langchain-ai was merged to an
+    # organization entity, we want that view.
+    #
+    # Two ways to reach the canonical entity:
+    #
+    #   (a) The back-link written by ``apply_merge`` — works for ALL
+    #       merge methods (self_reported / exact_handle / fuzzy).
+    #   (b) Falling back to ``github_user.signals.twitter_username`` —
+    #       works only when the user self-reported their Twitter
+    #       handle.  Kept as a belt-and-suspenders for pre-fix data
+    #       that was migrated before the back-link writes shipped.
     gh = store.get("github_user", norm)
     if gh is not None and gh.derived_authority is not None:
+        backlink = _resolve_via_backlink(store, gh)
+        if backlink is not None:
+            return backlink
+
         tw_username = _normalize(gh.signals.get("twitter_username"))
         if tw_username:
             for canonical_type in _CANONICAL_TYPES:
@@ -144,3 +156,25 @@ def resolve_github_user_authority(
         return ResolveResult(gh.derived_authority, "github_user", gh)
 
     return ResolveResult(None, "none", None)
+
+
+def _resolve_via_backlink(
+    store: EntityStore, side: Entity,
+) -> ResolveResult | None:
+    """If ``side.signals`` carries a ``canonical_handle`` back-link
+    (written by ``identity_merge.apply_merge``), load that canonical
+    entity and return its authority.
+
+    Returns ``None`` when the back-link is missing or the linked
+    entity can't be loaded (e.g. deleted between writes).
+    """
+    canonical_type = side.signals.get("canonical_entity_type")
+    canonical_key = _normalize(side.signals.get("canonical_handle"))
+    if canonical_type not in _CANONICAL_TYPES or not canonical_key:
+        return None
+    canonical = store.get(canonical_type, canonical_key)
+    if canonical is None or canonical.derived_authority is None:
+        return None
+    return ResolveResult(
+        canonical.derived_authority, canonical_type, canonical,
+    )

--- a/src/ovp_pipeline/entities/scan.py
+++ b/src/ovp_pipeline/entities/scan.py
@@ -45,6 +45,15 @@ _GH_REPO_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Bare GitHub profile URL — ``github.com/<owner>`` with NO ``/<repo>``
+# segment after.  Catches profile-only mentions that the repo regex
+# misses (e.g. ``Visit https://github.com/karpathy``), which would
+# otherwise be invisible to backfill_github's user pass.
+_GH_OWNER_RE = re.compile(
+    r"github\.com/([\w.-]+)(?=[?#)\]\s\"'`>]|$)",
+    re.IGNORECASE,
+)
+
 # Path segments that look like ``<owner>/<repo>`` to the regex but are
 # really top-level GitHub features.  Drop them.
 _GH_NON_REPO_OWNERS = frozenset({
@@ -138,16 +147,26 @@ def scan_twitter_handles(vault_dir: Path) -> list[HandleMention]:
 
 
 def scan_github_mentions(vault_dir: Path) -> list[GitHubMention]:
-    """Return repo+owner mentions sorted descending by mention_count.
+    """Return repo + owner mentions sorted descending by mention_count.
 
-    A ``repo=None`` row means "we only saw owner-level URLs"; a row
-    with a repo also exists for the same owner if both kinds appear.
+    Includes:
+      * (owner, repo) entries for every ``github.com/<owner>/<repo>`` URL
+      * (owner, None) entries for every bare ``github.com/<owner>``
+        profile URL (review-fix: previously missed, so a vault note
+        like "Visit https://github.com/karpathy" never triggered a
+        backfill of karpathy's github_user entity)
     """
     repo_total: Counter[tuple[str, str]] = Counter()
     repo_files: dict[tuple[str, str], set[Path]] = {}
+    owner_only_total: Counter[str] = Counter()
+    owner_only_files: dict[str, set[Path]] = {}
 
     for path, text in _iter_relevant_files(vault_dir, ("github.com",)):
         seen_repos_in_file: set[tuple[str, str]] = set()
+        # First pass: owner/repo URLs.  We track which owners already
+        # got a repo hit on this page so the profile-only regex below
+        # doesn't double-count them.
+        owners_with_repo: set[str] = set()
         for m in _GH_REPO_RE.finditer(text):
             owner = m.group(1).lower()
             if owner in _GH_NON_REPO_OWNERS:
@@ -157,10 +176,24 @@ def scan_github_mentions(vault_dir: Path) -> list[GitHubMention]:
                 repo = repo[:-4]
             repo_total[(owner, repo)] += 1
             seen_repos_in_file.add((owner, repo))
+            owners_with_repo.add(owner)
         for key in seen_repos_in_file:
             repo_files.setdefault(key, set()).add(path)
 
-    return [
+        # Second pass: profile-only URLs (no /<repo> after owner).  We
+        # detect them via a separate regex with a tighter terminator
+        # (no ``/`` allowed) so they don't overlap the repo regex.
+        seen_owners_in_file: set[str] = set()
+        for m in _GH_OWNER_RE.finditer(text):
+            owner = m.group(1).lower()
+            if owner in _GH_NON_REPO_OWNERS:
+                continue
+            owner_only_total[owner] += 1
+            seen_owners_in_file.add(owner)
+        for owner in seen_owners_in_file:
+            owner_only_files.setdefault(owner, set()).add(path)
+
+    out: list[GitHubMention] = [
         GitHubMention(
             owner=owner,
             repo=repo,
@@ -169,3 +202,15 @@ def scan_github_mentions(vault_dir: Path) -> list[GitHubMention]:
         )
         for (owner, repo), c in repo_total.most_common()
     ]
+    # Append owner-only rows.  An owner that only ever appeared via
+    # bare profile URLs gets a ``repo=None`` row; if the same owner
+    # also appeared with a repo, both rows coexist (consumers can
+    # union the counts).
+    for owner, c in owner_only_total.most_common():
+        out.append(GitHubMention(
+            owner=owner,
+            repo=None,
+            mention_count=c,
+            file_count=len(owner_only_files.get(owner, ())),
+        ))
+    return out

--- a/src/ovp_pipeline/entities/scan.py
+++ b/src/ovp_pipeline/entities/scan.py
@@ -49,8 +49,13 @@ _GH_REPO_RE = re.compile(
 # segment after.  Catches profile-only mentions that the repo regex
 # misses (e.g. ``Visit https://github.com/karpathy``), which would
 # otherwise be invisible to backfill_github's user pass.
+# Note: the terminator class includes ``.,`` — sentence delimiters
+# would otherwise prevent a match at end-of-clause prose like
+# ``Visit github.com/karpathy.`` or ``..., github.com/karpathy,``.
+# Crucially the class still excludes ``/`` so we don't overlap with
+# the owner/repo regex.
 _GH_OWNER_RE = re.compile(
-    r"github\.com/([\w.-]+)(?=[?#)\]\s\"'`>]|$)",
+    r"github\.com/([\w.-]+?)(?=[?#)\],.\s\"'`>]|$)",
     re.IGNORECASE,
 )
 
@@ -163,10 +168,7 @@ def scan_github_mentions(vault_dir: Path) -> list[GitHubMention]:
 
     for path, text in _iter_relevant_files(vault_dir, ("github.com",)):
         seen_repos_in_file: set[tuple[str, str]] = set()
-        # First pass: owner/repo URLs.  We track which owners already
-        # got a repo hit on this page so the profile-only regex below
-        # doesn't double-count them.
-        owners_with_repo: set[str] = set()
+        # First pass: owner/repo URLs.
         for m in _GH_REPO_RE.finditer(text):
             owner = m.group(1).lower()
             if owner in _GH_NON_REPO_OWNERS:
@@ -176,7 +178,6 @@ def scan_github_mentions(vault_dir: Path) -> list[GitHubMention]:
                 repo = repo[:-4]
             repo_total[(owner, repo)] += 1
             seen_repos_in_file.add((owner, repo))
-            owners_with_repo.add(owner)
         for key in seen_repos_in_file:
             repo_files.setdefault(key, set()).add(path)
 

--- a/src/ovp_pipeline/entities/store.py
+++ b/src/ovp_pipeline/entities/store.py
@@ -138,13 +138,20 @@ class EntityStore:
         doesn't exist yet (fresh vault) — read paths treat that as
         "no entities" rather than "create the schema for me".
         """
-        if not Path(self.db_path).exists():
+        path = Path(self.db_path)
+        if not path.exists():
+            return None
+        # ``Path.as_uri()`` is required for cross-platform safety:
+        # raw f-strings would break on Windows backslashes and on
+        # paths with spaces or '#' chars.  ``as_uri()`` requires the
+        # path be absolute, so resolve first — relative paths come
+        # in legitimately when callers use ``Path("knowledge.db")``.
+        try:
+            uri = f"{path.resolve().as_uri()}?mode=ro"
+        except ValueError:
             return None
         try:
-            conn = sqlite3.connect(
-                f"file:{self.db_path}?mode=ro",
-                uri=True,
-            )
+            conn = sqlite3.connect(uri, uri=True)
         except sqlite3.OperationalError:
             return None
         conn.row_factory = sqlite3.Row
@@ -186,6 +193,12 @@ class EntityStore:
         """
         if not Path(self.db_path).exists():
             return False
+        # ``delete`` is a write path: ensure the schema exists before
+        # trying to query the entities table.  Without this an
+        # existing-but-unitialized DB file (e.g., touched by some
+        # other tool, or partially-written) would raise
+        # OperationalError on the SELECT below.
+        init_schema(self.db_path)
         conn = sqlite3.connect(self.db_path)
         try:
             row = conn.execute(

--- a/src/ovp_pipeline/entities/store.py
+++ b/src/ovp_pipeline/entities/store.py
@@ -115,36 +115,77 @@ def _row_to_entity(row: sqlite3.Row) -> Entity:
 
 @dataclass
 class EntityStore:
-    """Thin DAO over the ``entities`` + ``entity_signals_history`` tables."""
+    """Thin DAO over the ``entities`` + ``entity_signals_history`` tables.
+
+    Read paths (``get``, ``list_by_type``, ``history``) are *side-effect
+    free*: they will NOT create the SQLite file, NOT initialize the
+    schema, and silently return empty results when ``db_path`` doesn't
+    exist.  This matters for source-signal providers that consult the
+    entity table as a fast path during ingestion: a fresh vault must
+    not gain a knowledge.db just because we tried to score a URL.
+
+    Write paths (``upsert``, ``upsert_many``, ``delete``) call
+    ``init_schema`` at the top so a first-write to a fresh DB still
+    sets up the tables.  Idempotent.
+    """
 
     db_path: Path
 
-    def __post_init__(self) -> None:
-        init_schema(self.db_path)
-
     # ---- read ----------------------------------------------------------
 
-    def get(self, entity_type: str, identity_key: str) -> Entity | None:
-        conn = sqlite3.connect(self.db_path)
+    def _open_read(self) -> sqlite3.Connection | None:
+        """Open a read-only connection.  Returns ``None`` if the DB file
+        doesn't exist yet (fresh vault) — read paths treat that as
+        "no entities" rather than "create the schema for me".
+        """
+        if not Path(self.db_path).exists():
+            return None
         try:
-            conn.row_factory = sqlite3.Row
-            row = conn.execute(
-                "SELECT * FROM entities WHERE entity_type=? AND identity_key=?",
-                (entity_type, identity_key),
-            ).fetchone()
+            conn = sqlite3.connect(
+                f"file:{self.db_path}?mode=ro",
+                uri=True,
+            )
+        except sqlite3.OperationalError:
+            return None
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def get(self, entity_type: str, identity_key: str) -> Entity | None:
+        conn = self._open_read()
+        if conn is None:
+            return None
+        try:
+            try:
+                row = conn.execute(
+                    "SELECT * FROM entities WHERE entity_type=? AND identity_key=?",
+                    (entity_type, identity_key),
+                ).fetchone()
+            except sqlite3.OperationalError:
+                # Schema not initialized yet — same shape as no-entity.
+                return None
             return _row_to_entity(row) if row else None
         finally:
             conn.close()
 
     def delete(self, entity_type: str, identity_key: str) -> bool:
-        """Remove an entity + its history rows.
+        """Remove the latest-snapshot row for an entity.
 
         Returns True if a row was deleted, False if the entity wasn't
         present.  Used by identity_merge's reclassification when a
         ``person`` should be re-filed as ``organization`` (or vice
         versa) — the unique constraint on (entity_type, identity_key)
         means we can't just upsert across types.
+
+        **Preserves ``entity_signals_history`` rows.**  The history
+        table is documented as an append-only audit trail at the top
+        of this module.  Deleting it would lose the "what did we know
+        about langchain when we still classified it as a person"
+        record.  The orphan history rows still query cleanly via
+        ``history(entity_id)`` and serve as a forensic trail for
+        future migrations.
         """
+        if not Path(self.db_path).exists():
+            return False
         conn = sqlite3.connect(self.db_path)
         try:
             row = conn.execute(
@@ -155,10 +196,9 @@ class EntityStore:
             if row is None:
                 return False
             entity_id = row[0]
-            conn.execute(
-                "DELETE FROM entity_signals_history WHERE entity_id=?",
-                (entity_id,),
-            )
+            # NOTE: history rows for this entity_id are deliberately
+            # preserved — see docstring above for the append-only
+            # invariant rationale.
             conn.execute(
                 "DELETE FROM entities WHERE entity_id=?",
                 (entity_id,),
@@ -171,16 +211,20 @@ class EntityStore:
     def list_by_type(
         self, entity_type: str, *, limit: int | None = None,
     ) -> list[Entity]:
-        conn = sqlite3.connect(self.db_path)
+        conn = self._open_read()
+        if conn is None:
+            return []
         try:
-            conn.row_factory = sqlite3.Row
             sql = (
                 "SELECT * FROM entities WHERE entity_type=? "
                 "ORDER BY derived_authority DESC NULLS LAST"
             )
             if limit is not None:
                 sql += f" LIMIT {int(limit)}"
-            rows = conn.execute(sql, (entity_type,)).fetchall()
+            try:
+                rows = conn.execute(sql, (entity_type,)).fetchall()
+            except sqlite3.OperationalError:
+                return []
             return [_row_to_entity(r) for r in rows]
         finally:
             conn.close()
@@ -189,16 +233,21 @@ class EntityStore:
         self, entity_id: int, *, limit: int = 50,
     ) -> Iterator[tuple[str, dict[str, Any], str]]:
         """Yield (observed_at, signals_dict, fetch_source) most-recent first."""
-        conn = sqlite3.connect(self.db_path)
+        conn = self._open_read()
+        if conn is None:
+            return
         try:
             # Tiebreak on history_id DESC so two rows that share an
             # observed_at to the second still come back newest-first.
-            rows = conn.execute(
-                "SELECT observed_at, signals_json, fetch_source "
-                "FROM entity_signals_history WHERE entity_id=? "
-                "ORDER BY observed_at DESC, history_id DESC LIMIT ?",
-                (entity_id, limit),
-            ).fetchall()
+            try:
+                rows = conn.execute(
+                    "SELECT observed_at, signals_json, fetch_source "
+                    "FROM entity_signals_history WHERE entity_id=? "
+                    "ORDER BY observed_at DESC, history_id DESC LIMIT ?",
+                    (entity_id, limit),
+                ).fetchall()
+            except sqlite3.OperationalError:
+                return
             for observed_at, signals_json, fetch_source in rows:
                 try:
                     signals = json.loads(signals_json) if signals_json else {}
@@ -266,7 +315,12 @@ class EntityStore:
         derived_authority: float | None,
         fetch_source: str,
     ) -> Entity:
-        """Insert or update a single entity, plus append a history row."""
+        """Insert or update a single entity, plus append a history row.
+
+        Schema is initialized lazily on first write, not on instance
+        construction — keeps the read paths side-effect free.
+        """
+        init_schema(self.db_path)
         conn = sqlite3.connect(self.db_path)
         try:
             entity = self._upsert_in(
@@ -290,6 +344,7 @@ class EntityStore:
         one fsync at the end vs N), and the whole batch is committed
         atomically: a mid-batch failure rolls back, no partial state.
         """
+        init_schema(self.db_path)
         conn = sqlite3.connect(self.db_path)
         out: list[Entity] = []
         try:

--- a/src/ovp_pipeline/source_signals/arxiv.py
+++ b/src/ovp_pipeline/source_signals/arxiv.py
@@ -40,7 +40,7 @@ try:
 except ImportError:  # pragma: no cover - defusedxml is in requirements
     import xml.etree.ElementTree as ET  # type: ignore[no-redef]
 
-from .base import Signal, SignalProvider
+from .base import Signal
 
 logger = logging.getLogger(__name__)
 

--- a/src/ovp_pipeline/source_signals/domain_rules.py
+++ b/src/ovp_pipeline/source_signals/domain_rules.py
@@ -27,7 +27,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
-from .base import Signal, SignalProvider
+from .base import Signal
 from .overrides import DomainOverrides
 from .url_utils import normalize_host
 
@@ -152,9 +152,20 @@ class DomainRulesProvider:
 
         overrides = self._load_overrides()
 
-        # 0. Excluded hosts — return None so the orchestrator falls back to default
+        # 0. Excluded hosts — return a tagged Signal instead of None.
+        # Returning None would have meant the audit log shows nothing
+        # for an exclusion, contradicting the overrides.py contract
+        # ("Returns Signal value=0.45 default but flags the source as
+        # excluded: true in audit log").  The combination rule still
+        # treats this as a neutral floor so the source isn't
+        # *promoted* by the exclusion — it's just visibly recorded.
         if host in overrides.excluded_hosts:
-            return None
+            return Signal(
+                provider=self.name,
+                value=_DEFAULT_AUTHORITY,
+                raw={"host": host, "bucket": "excluded", "excluded": True,
+                     "source": "override"},
+            )
 
         # 0a. User overrides win over hardcoded tables for any host
         if host in overrides.domains:

--- a/src/ovp_pipeline/source_signals/substack.py
+++ b/src/ovp_pipeline/source_signals/substack.py
@@ -48,7 +48,7 @@ from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urlparse
 
-from .base import Signal, SignalProvider
+from .base import Signal
 
 _SUBSTACK_RE = re.compile(
     r"^https?://(?P<handle>[\w-]+)\.substack\.com/(?:p/[\w-]+/?)?$"

--- a/src/ovp_pipeline/source_signals/twitter.py
+++ b/src/ovp_pipeline/source_signals/twitter.py
@@ -55,9 +55,8 @@ import os
 import re
 from dataclasses import dataclass
 from typing import Any
-from urllib.parse import urlparse
 
-from .base import Signal, SignalProvider
+from .base import Signal
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_entity_layer_review_fixes.py
+++ b/tests/test_entity_layer_review_fixes.py
@@ -1,0 +1,475 @@
+"""Pinning tests for the May 2026 entity-layer review fixes.
+
+One file, one test class per review issue, with the issue summary
+embedded in the docstring so future readers can trace why each
+invariant exists.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from ovp_pipeline.entities.identity_merge import (
+    GITHUB_USER_TYPE,
+    ORGANIZATION_TYPE,
+    PERSON_TYPE,
+    TWITTER_TYPE,
+    apply_merge,
+    find_merge_candidates,
+)
+from ovp_pipeline.entities.resolver import (
+    resolve_github_user_authority,
+)
+from ovp_pipeline.entities.scan import scan_github_mentions
+from ovp_pipeline.entities.store import EntityStore
+
+
+# ---------------------------------------------------------------------------
+# Pass A — read-side write side effects
+# ---------------------------------------------------------------------------
+
+
+class TestStoreReadIsSideEffectFree:
+    """Issue: ``EntityStore.__post_init__`` unconditionally called
+    ``init_schema``, so any source-signal provider that consulted the
+    entity table on a fresh vault would silently materialize a 60-Logs
+    directory + empty knowledge.db.  Read paths must be pure reads.
+    """
+
+    def test_construction_does_not_create_db(self, tmp_path):
+        db = tmp_path / "no.db"
+        EntityStore(db_path=db)
+        assert not db.exists()
+
+    def test_get_on_missing_db_returns_none(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "no.db")
+        assert store.get("twitter_author", "anyone") is None
+
+    def test_list_by_type_on_missing_db_returns_empty(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "no.db")
+        assert store.list_by_type("twitter_author") == []
+
+    def test_history_on_missing_db_yields_nothing(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "no.db")
+        assert list(store.history(entity_id=1)) == []
+
+    def test_first_write_creates_db(self, tmp_path):
+        db = tmp_path / "fresh.db"
+        store = EntityStore(db_path=db)
+        assert not db.exists()
+        store.upsert(
+            entity_type="twitter_author", identity_key="x",
+            canonical_name="X", signals={}, derived_authority=0.5,
+            fetch_source="t",
+        )
+        assert db.exists()
+
+
+class TestProviderFastPathDoesNotCreateDB:
+    """The same invariant from the provider perspective: scoring a URL
+    when the entity table doesn't exist must NOT create it."""
+
+    def test_author_rules_no_op_on_missing_db(self, tmp_path):
+        from ovp_pipeline.source_signals.author_rules import AuthorRulesProvider
+
+        # No authors.jsonl, no entity DB — nothing to learn from.
+        empty_jsonl = tmp_path / "authors.jsonl"
+        empty_jsonl.write_text("", encoding="utf-8")
+        missing_db = tmp_path / "knowledge.db"
+
+        provider = AuthorRulesProvider(
+            authors_path=empty_jsonl,
+            entity_store_path=missing_db,
+        )
+        sig = provider.score("https://x.com/ghost/status/1", {})
+        assert sig is None
+        # Critical: no DB was created.
+        assert not missing_db.exists()
+
+    def test_github_signal_no_op_on_missing_db(self, tmp_path):
+        from ovp_pipeline.source_signals.github import GitHubSignalProvider
+
+        missing_db = tmp_path / "knowledge.db"
+        provider = GitHubSignalProvider(entity_store_path=missing_db)
+        # Fast path returns None → falls through to live API; mock that
+        # so we don't hit GitHub from CI.
+        with patch(
+            "ovp_pipeline.source_signals.github.urllib.request.urlopen"
+        ) as m:
+            m.side_effect = Exception("blocked in test")
+            try:
+                provider.score("https://github.com/owner/repo", {})
+            except Exception:
+                pass
+        # The fast path should not have created the DB even when the
+        # live fetch errored.
+        assert not missing_db.exists()
+
+
+# ---------------------------------------------------------------------------
+# Pass B — identity merge backlink
+# ---------------------------------------------------------------------------
+
+
+def _seed(store, gh_login, tw_handle, *, gh_type="User",
+          gh_signals=None, twitter_username=None,
+          gh_authority=0.65, tw_authority=0.5):
+    sig = {"type": gh_type}
+    if gh_signals:
+        sig.update(gh_signals)
+    if twitter_username is not None:
+        sig["twitter_username"] = twitter_username
+    store.upsert(
+        entity_type=GITHUB_USER_TYPE, identity_key=gh_login,
+        canonical_name=gh_login, signals=sig,
+        derived_authority=gh_authority, fetch_source="github_rest",
+    )
+    store.upsert(
+        entity_type=TWITTER_TYPE, identity_key=tw_handle,
+        canonical_name=tw_handle, signals={},
+        derived_authority=tw_authority, fetch_source="twitterapi.io",
+    )
+
+
+class TestApplyMergeWritesBacklink:
+    """Issue: ``apply_merge`` only created the canonical entity but
+    didn't write a back-link into github_user.signals.  The resolver
+    then could only reach the canonical via
+    ``twitter_username`` — which only self_reported merges write.
+    exact_handle / fuzzy merges silently bypassed the merged
+    authority and returned the bare github score.
+    """
+
+    def test_self_reported_writes_canonical_handle_to_github_user(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "k.db")
+        _seed(store, "karpathy", "karpathy", twitter_username="karpathy")
+        cands = find_merge_candidates(store)
+        for c in cands:
+            apply_merge(store, c)
+        gh = store.get(GITHUB_USER_TYPE, "karpathy")
+        assert gh is not None
+        assert gh.signals["canonical_handle"] == "karpathy"
+        assert gh.signals["canonical_entity_type"] == PERSON_TYPE
+        # Same back-link written on the twitter side too.
+        tw = store.get(TWITTER_TYPE, "karpathy")
+        assert tw is not None
+        assert tw.signals["canonical_handle"] == "karpathy"
+
+    def test_exact_handle_merge_writes_backlink(self, tmp_path):
+        # The bug: exact_handle merges didn't have twitter_username,
+        # so the resolver couldn't reach the canonical entity.  Fix:
+        # apply_merge writes the back-link regardless of merge method.
+        # Pre-seed a person entity directly so apply_merge has a side
+        # to read; it'll re-upsert it via the merge.
+        store = EntityStore(db_path=tmp_path / "k.db")
+        _seed(store, "simonw", "simonw")     # no twitter_username field
+        # Trigger merge.  exact_handle is below auto threshold, so we
+        # construct the candidate manually.
+        from ovp_pipeline.entities.identity_merge import MergeCandidate
+        c = MergeCandidate(
+            github_login="simonw", twitter_handle="simonw",
+            method="exact_handle", confidence=0.85,
+            rationale="test",
+        )
+        apply_merge(store, c)
+        gh = store.get(GITHUB_USER_TYPE, "simonw")
+        assert gh is not None
+        assert gh.signals.get("canonical_handle") == "simonw"
+
+    def test_organization_backlink_uses_org_type(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "k.db")
+        _seed(store, "langchain-ai", "langchain",
+              gh_type="Organization",
+              twitter_username="langchain")
+        for c in find_merge_candidates(store):
+            apply_merge(store, c)
+        gh = store.get(GITHUB_USER_TYPE, "langchain-ai")
+        assert gh is not None
+        assert gh.signals["canonical_entity_type"] == ORGANIZATION_TYPE
+
+
+class TestResolverFollowsBacklink:
+    """Issue: ``resolve_github_user_authority`` only used
+    ``twitter_username`` to reach the canonical entity, missing
+    exact_handle / fuzzy merges.  Fix: also follow the back-link
+    written by apply_merge.
+    """
+
+    def test_resolver_uses_backlink_for_exact_handle_merge(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "k.db")
+        _seed(store, "simonw", "simonw")
+        from ovp_pipeline.entities.identity_merge import MergeCandidate
+        c = MergeCandidate(
+            github_login="simonw", twitter_handle="simonw",
+            method="exact_handle", confidence=0.85, rationale="",
+        )
+        apply_merge(store, c)
+        # Resolver should now return the canonical authority (the max
+        # of the two sides), not just the bare github score.
+        r = resolve_github_user_authority(store, "simonw")
+        assert r.source == "person"
+        # gh=0.65, tw=0.5 → max=0.65
+        assert r.authority == 0.65
+
+    def test_resolver_falls_through_when_no_backlink(self, tmp_path):
+        # Pre-fix data (or unmerged actor) — back-link absent.  Must
+        # still return the bare github authority, not crash.
+        store = EntityStore(db_path=tmp_path / "k.db")
+        _seed(store, "loneuser", "loneuser")
+        r = resolve_github_user_authority(store, "loneuser")
+        assert r.authority == 0.65       # bare github_user score
+        assert r.source == "github_user"
+
+
+# ---------------------------------------------------------------------------
+# Pass C — refresh wrapper lock-steal race
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshLockStealRace:
+    """Issue: when stealing a stale lock, the second ``os.open`` wasn't
+    wrapped in a try/except, so two concurrent refreshes that both
+    saw the stale lock would race — one would crash with FileExistsError
+    instead of bailing cleanly with the documented "another refresh
+    is running" SystemExit.
+    """
+
+    def test_lost_steal_race_raises_systemexit_not_filesystem_error(self, tmp_path):
+        from ovp_pipeline.commands.refresh_source_authority import (
+            _LOCKFILE_NAME,
+            _exclusive_lock,
+        )
+
+        vault_logs = tmp_path / "60-Logs"
+        vault_logs.mkdir(parents=True)
+        lock_path = vault_logs / _LOCKFILE_NAME
+        # Stale lock points at a dead PID.
+        lock_path.write_text("999999", encoding="utf-8")
+
+        with patch(
+            "ovp_pipeline.commands.refresh_source_authority._pid_alive",
+            return_value=False,
+        ):
+            # Inject a race: between unlink and second open, another
+            # refresh re-creates the file.  We simulate with an
+            # os.open patch that fakes the second call.
+            real_open = os.open
+            calls = {"n": 0}
+
+            def fake_open(path, flags, *args, **kwargs):
+                calls["n"] += 1
+                if calls["n"] == 2:    # second call (post-unlink)
+                    raise FileExistsError("simulated steal race")
+                return real_open(path, flags, *args, **kwargs)
+
+            with patch("ovp_pipeline.commands.refresh_source_authority.os.open",
+                       side_effect=fake_open):
+                with pytest.raises(SystemExit) as exc:
+                    with _exclusive_lock(lock_path):
+                        pass
+                assert "race" in str(exc.value).lower()
+
+
+# ---------------------------------------------------------------------------
+# Pass D — schema + semantic fixes
+# ---------------------------------------------------------------------------
+
+
+class TestDeletePreservesHistory:
+    """Issue: ``EntityStore.delete`` cascaded through
+    ``entity_signals_history``, contradicting the module docstring's
+    "append-only time series" contract.  Fix: keep history rows
+    (orphaned by entity_id) as a forensic trail.
+    """
+
+    def test_history_survives_after_delete(self, tmp_path):
+        store = EntityStore(db_path=tmp_path / "k.db")
+        store.upsert(
+            entity_type=TWITTER_TYPE, identity_key="x",
+            canonical_name="X", signals={"v": 1},
+            derived_authority=0.5, fetch_source="twitterapi.io",
+        )
+        e = store.get(TWITTER_TYPE, "x")
+        assert e is not None
+        store.delete(TWITTER_TYPE, "x")
+        # Entity row gone.
+        assert store.get(TWITTER_TYPE, "x") is None
+        # History row remains.
+        rows = list(store.history(e.entity_id))
+        assert len(rows) == 1
+
+
+class TestExcludedHostReturnsTaggedSignal:
+    """Issue: ``DomainRulesProvider.score`` returned None for excluded
+    hosts, so the audit log never recorded the exclusion.
+    overrides.py docstring promised a 0.45 Signal with ``excluded:
+    True``.  Fix: return the tagged signal.
+    """
+
+    def test_excluded_host_signal_is_tagged(self, tmp_path):
+        from ovp_pipeline.source_signals.domain_rules import DomainRulesProvider
+
+        f = tmp_path / "overrides.yaml"
+        f.write_text("""
+excluded_hosts:
+  - localhost
+""", encoding="utf-8")
+        provider = DomainRulesProvider(overrides_path=f)
+        sig = provider.score("http://localhost/foo", {})
+        assert sig is not None
+        assert sig.value == 0.45
+        assert sig.raw["excluded"] is True
+
+
+class TestScanGithubOwnerOnly:
+    """Issue: ``scan_github_mentions`` only matched ``owner/repo``
+    URLs, so a profile-only mention like
+    ``Visit https://github.com/karpathy`` was invisible to backfill,
+    and the karpathy github_user entity was never created from such
+    notes.  Fix: a parallel owner-only regex.
+    """
+
+    def test_bare_profile_url_is_picked_up(self, tmp_path):
+        f = tmp_path / "note.md"
+        f.write_text(
+            "I follow https://github.com/karpathy and also "
+            "https://github.com/karpathy/nanoGPT for research.",
+            encoding="utf-8",
+        )
+        result = scan_github_mentions(tmp_path)
+        repo_owners = {m.owner for m in result if m.repo is not None}
+        owner_only = {m.owner for m in result if m.repo is None}
+        # Bare profile triggers an owner-only mention.
+        assert "karpathy" in owner_only
+        # Repo URL still tracked separately.
+        assert "karpathy" in repo_owners
+
+    def test_profile_only_owner_with_no_repo_appears(self, tmp_path):
+        f = tmp_path / "note.md"
+        f.write_text("Profile: https://github.com/dotey", encoding="utf-8")
+        result = scan_github_mentions(tmp_path)
+        owner_only = [m for m in result if m.repo is None]
+        assert any(m.owner == "dotey" for m in owner_only)
+
+
+class TestSourceCoverageEntityResolved:
+    """Issue: ``collect_unrecognized_x_handles`` only consulted
+    authors.jsonl, so handles already resolvable via the entity
+    table (PR-E3) showed up as "unknown" noise in the dashboard.
+    Fix: accept ``entity_resolved`` set; treat those as known too.
+    """
+
+    def test_entity_resolved_handle_excluded(self, tmp_path):
+        from ovp_pipeline.commands.source_coverage import (
+            collect_unrecognized_x_handles,
+        )
+
+        # Build minimal knowledge.db with one source_authority row.
+        import sqlite3
+        db_path = tmp_path / "60-Logs" / "knowledge.db"
+        db_path.parent.mkdir(parents=True)
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute("""
+                CREATE TABLE source_authority (
+                    source_id TEXT PRIMARY KEY,
+                    authority REAL NOT NULL,
+                    signals_json TEXT NOT NULL,
+                    scored_at TEXT NOT NULL,
+                    scorer_version TEXT NOT NULL
+                )
+            """)
+            conn.execute(
+                "INSERT INTO source_authority VALUES "
+                "('https://x.com/karpathy/status/1', 0.7, '[]', '', '')"
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        # karpathy is NOT in authors.jsonl but IS in the entity-resolved
+        # set — must not appear as "unknown".
+        unknowns = collect_unrecognized_x_handles(
+            tmp_path, known_authors=set(),
+            entity_resolved={"karpathy"},
+        )
+        assert all(h != "karpathy" for h, _ in unknowns)
+
+    def test_entity_resolved_default_preserves_old_behavior(self, tmp_path):
+        # Pass entity_resolved=None → identical to pre-fix behavior.
+        from ovp_pipeline.commands.source_coverage import (
+            collect_unrecognized_x_handles,
+        )
+
+        import sqlite3
+        db_path = tmp_path / "60-Logs" / "knowledge.db"
+        db_path.parent.mkdir(parents=True)
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute("""
+                CREATE TABLE source_authority (
+                    source_id TEXT PRIMARY KEY,
+                    authority REAL NOT NULL,
+                    signals_json TEXT NOT NULL,
+                    scored_at TEXT NOT NULL,
+                    scorer_version TEXT NOT NULL
+                )
+            """)
+            conn.execute(
+                "INSERT INTO source_authority VALUES "
+                "('https://x.com/karpathy/status/1', 0.7, '[]', '', '')"
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        unknowns = collect_unrecognized_x_handles(
+            tmp_path, known_authors=set(),
+        )
+        # Without entity_resolved, karpathy IS unknown.
+        assert ("karpathy", 1) in unknowns
+
+
+class TestScoreSourcesDomainsOnlyHonorsOverrides:
+    """Issue: ``--domains-only`` hand-built ``DomainRulesProvider()`` /
+    ``AuthorRulesProvider()`` without the overrides paths, so a domain
+    upgraded via ``domain_overrides.yaml`` got the unknown-host
+    default 0.45 in offline mode.  Fix: reuse default_providers and
+    filter to non-network providers.
+    """
+
+    def test_domains_only_includes_domain_and_author_rules(self, tmp_path):
+        from ovp_pipeline.commands.score_sources import _build_providers
+
+        providers = _build_providers(tmp_path, domains_only=True)
+        names = {p.name for p in providers}
+        assert "domain_rules" in names
+        assert "author_rules" in names
+        # Network providers excluded.
+        assert "github_stars" not in names
+        assert "twitter_engagement" not in names
+
+    def test_domain_rules_carries_overrides_path(self, tmp_path):
+        # The domain_rules provider in --domains-only mode must have
+        # the overrides_path wired (otherwise yaml-defined domains
+        # don't apply).  We can't introspect the field name without
+        # depending on internals; check by behavior.
+        (tmp_path / "60-Logs").mkdir()
+        (tmp_path / "60-Logs" / "domain_overrides.yaml").write_text("""
+domains:
+  example.com:
+    authority: 0.91
+    bucket: canonical
+""", encoding="utf-8")
+        from ovp_pipeline.commands.score_sources import _build_providers
+
+        providers = _build_providers(tmp_path, domains_only=True)
+        domain_rules = next(p for p in providers if p.name == "domain_rules")
+        sig = domain_rules.score("https://example.com/x", {})
+        assert sig is not None
+        # The override would have been ignored if we'd hand-built the
+        # provider without overrides_path (would have returned 0.45).
+        assert sig.value == 0.91

--- a/tests/test_entity_layer_review_fixes.py
+++ b/tests/test_entity_layer_review_fixes.py
@@ -8,6 +8,7 @@ invariant exists.
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -322,6 +323,106 @@ excluded_hosts:
         assert sig is not None
         assert sig.value == 0.45
         assert sig.raw["excluded"] is True
+
+
+class TestScanGithubOwnerEndOfSentence:
+    """Issue: ``_GH_OWNER_RE`` lookahead missed sentence delimiters
+    (``.`` and ``,``), so a profile URL at end-of-clause prose
+    (``Visit github.com/karpathy.``) silently captured the trailing
+    period as part of the owner.  Fix: terminator class now includes
+    them, and the capture is non-greedy so it backtracks off the
+    delimiter.
+    """
+
+    def test_trailing_period_does_not_attach_to_owner(self, tmp_path):
+        f = tmp_path / "note.md"
+        f.write_text(
+            "Visit https://github.com/karpathy. Or follow him on X.",
+            encoding="utf-8",
+        )
+        result = scan_github_mentions(tmp_path)
+        owner_only = [m for m in result if m.repo is None]
+        owners = {m.owner for m in owner_only}
+        assert "karpathy" in owners
+        # The bug was capturing "karpathy." (with period).  Make sure
+        # the period is gone from the captured owner.
+        assert "karpathy." not in owners
+
+    def test_trailing_comma_does_not_attach_to_owner(self, tmp_path):
+        f = tmp_path / "note.md"
+        f.write_text(
+            "See https://github.com/karpathy, then https://github.com/dotey.",
+            encoding="utf-8",
+        )
+        result = scan_github_mentions(tmp_path)
+        owners = {m.owner for m in result if m.repo is None}
+        assert "karpathy" in owners
+        assert "dotey" in owners
+
+    def test_owner_regex_does_not_match_repo_urls(self, tmp_path):
+        # The repo URL must NEVER be picked up by the owner-only
+        # regex; otherwise we'd double-count owners that already have
+        # a repo mention on the same page.
+        f = tmp_path / "note.md"
+        f.write_text(
+            "Just https://github.com/karpathy/nanoGPT here, no profile URL.",
+            encoding="utf-8",
+        )
+        result = scan_github_mentions(tmp_path)
+        owner_only = [m for m in result if m.repo is None]
+        # No bare profile URL on this page → no owner-only mention.
+        assert owner_only == []
+
+
+class TestStoreDeleteSchemaSafe:
+    """Issue: ``delete`` was a write path that didn't call
+    ``init_schema``, contradicting the class docstring's "all writes
+    init the schema" contract.  An existing-but-uninitialized DB
+    file (touched by another tool, or partially written) would raise
+    OperationalError.  Fix: call init_schema at the top of delete.
+    """
+
+    def test_delete_on_empty_db_does_not_raise(self, tmp_path):
+        db = tmp_path / "exists-but-empty.db"
+        # Create the file with NO schema (e.g., another tool did this).
+        db.touch()
+        store = EntityStore(db_path=db)
+        # Pre-fix this raised sqlite3.OperationalError ("no such table").
+        # Post-fix it returns False cleanly.
+        assert store.delete("twitter_author", "x") is False
+
+
+class TestStoreReadOnlyURIIsPlatformSafe:
+    """Issue: hardcoded ``f"file:{path}?mode=ro"`` URI breaks on paths
+    with spaces, ``#``, or Windows backslashes.  Fix: use
+    ``Path.as_uri()`` for proper URL-encoding + absolute-path safety.
+    """
+
+    def test_path_with_spaces(self, tmp_path):
+        # Create a path with a space — a common case on macOS.
+        weird = tmp_path / "vault with spaces" / "knowledge.db"
+        store = EntityStore(db_path=weird)
+        # First write to create the DB at this weird path.
+        store.upsert(
+            entity_type="twitter_author", identity_key="x",
+            canonical_name="X", signals={}, derived_authority=0.5,
+            fetch_source="t",
+        )
+        # Read must not crash on the URI quoting of the space.
+        assert store.get("twitter_author", "x") is not None
+
+    def test_relative_path_resolved(self, tmp_path, monkeypatch):
+        # If a caller constructs Path("knowledge.db") (relative), the
+        # store must resolve it before generating the URI.
+        monkeypatch.chdir(tmp_path)
+        store = EntityStore(db_path=Path("knowledge.db"))
+        store.upsert(
+            entity_type="twitter_author", identity_key="rel",
+            canonical_name="Rel", signals={}, derived_authority=0.5,
+            fetch_source="t",
+        )
+        # Read via the relative path should still work.
+        assert store.get("twitter_author", "rel") is not None
 
 
 class TestScanGithubOwnerOnly:

--- a/tests/test_identity_merge.py
+++ b/tests/test_identity_merge.py
@@ -434,9 +434,23 @@ class TestStoreDelete:
         ok = store.delete(TWITTER_TYPE, "ghost")
         assert ok is True
         assert store.get(TWITTER_TYPE, "ghost") is None
-        # History rows for that entity_id are gone too.
+
+    def test_delete_preserves_history(self, tmp_path):
+        # Append-only contract on entity_signals_history (per the
+        # store.py module docstring).  ``delete`` removes the
+        # latest-snapshot row but the audit trail must persist —
+        # otherwise PR-F1's person → organization migration silently
+        # erases what we used to know about langchain back when we
+        # mis-classified it as a person.
+        store = EntityStore(db_path=tmp_path / "k.db")
+        _make_tw(store, "ghost", authority=0.4)
+        e = store.get(TWITTER_TYPE, "ghost")
+        assert e is not None
+        store.delete(TWITTER_TYPE, "ghost")
+        # Entity row gone, but history rows kept (forensic trail).
         rows = list(store.history(e.entity_id))
-        assert rows == []
+        assert len(rows) == 1
+        assert rows[0][2] == "twitterapi.io"   # fetch_source preserved
 
     def test_delete_nonexistent_returns_false(self, tmp_path):
         store = EntityStore(db_path=tmp_path / "k.db")

--- a/tests/test_source_authority_discovery.py
+++ b/tests/test_source_authority_discovery.py
@@ -221,7 +221,12 @@ domains:
         assert sig.value == 0.95
         assert sig.raw["source"] == "override"
 
-    def test_excluded_host_returns_none(self, tmp_path):
+    def test_excluded_host_returns_tagged_signal(self, tmp_path):
+        # Updated behavior (review fix): excluded hosts return a
+        # neutral 0.45 Signal carrying ``excluded=True`` in raw.
+        # Returning None previously meant the audit log silently
+        # dropped the exclusion, contradicting the overrides.py
+        # documented contract.
         f = tmp_path / "overrides.yaml"
         f.write_text("""
 excluded_hosts:
@@ -229,7 +234,12 @@ excluded_hosts:
 """, encoding="utf-8")
         p = DomainRulesProvider(overrides_path=f)
         sig = p.score("http://localhost/foo", {})
-        assert sig is None  # excluded
+        assert sig is not None
+        assert sig.raw.get("excluded") is True
+        assert sig.raw.get("bucket") == "excluded"
+        # Score is the neutral default — exclusion neither rewards
+        # nor punishes the source, just records the decision.
+        assert sig.value == 0.45
 
     def test_hardcoded_still_works_without_override_file(self, tmp_path):
         p = DomainRulesProvider(overrides_path=tmp_path / "no-such-file.yaml")


### PR DESCRIPTION
## Summary

Two passes of review found 12 issues spanning the entity store, identity merge, resolver, refresh wrapper, and three source-signal providers.  This PR fixes all 12 in one round.

## HIGH

| # | File | Fix |
|---|---|---|
| 1 | `refresh_source_authority.py:115-128` | Lock-steal race: wrap second `os.open` in try/except FileExistsError |
| 2 | `identity_merge.py` + `resolver.py` | Write `canonical_handle` back-link to gh + tw signals; resolver follows back-link to cover exact_handle / fuzzy merges (not just self_reported) |

## MEDIUM

| # | File | Fix |
|---|---|---|
| 3 | `store.py` | Read paths no longer create the DB file on fresh vault.  `_open_read` returns None on missing DB; schema initialized lazily on first write. |
| 4 | `score_sources.py` | `--domains-only` reuses `default_providers` and filters by name instead of hand-building stripped providers (so overrides + entity-store wiring stay applied). |
| 5 | `refresh_source_authority.py` | New `--migrate-existing` pass-through flag so launchd-only users get the PR-F1 reclassification automatically. |
| 6 | `store.py` | `delete` no longer cascades through `entity_signals_history` — append-only contract honored. |
| 7 | `domain_rules.py` | Excluded hosts return a tagged Signal (`excluded=True`, value=0.45) instead of None — audit log gets the record. |
| 8 | `scan.py` + `backfill_github.py` | Bare GitHub profile URLs (`github.com/<owner>` with no repo) now scanned + backfilled. |
| 9 | `source_coverage.py` | `unrecognized X handles` accepts `entity_resolved` set; CLI passes the union of twitter_author/person/organization handles so the dashboard surfaces only truly-unresolved long tail. |

## Tests

New file `tests/test_entity_layer_review_fixes.py` with **21 pinning tests**, one class per issue.  Each docstring carries the original review summary so the invariant can be traced back.

Updated tests:
- `test_delete_removes_row_and_history` → split into row-deletion + history-preservation
- `test_excluded_host_returns_none` → `test_excluded_host_returns_tagged_signal`

Suite: **1800 → 1821 (+21)**.  Lint clean on all touched files.

## What this PR does NOT change

- Nothing in the public API surface (no method signatures dropped or renamed).
- `person_canonical_handle` back-compat alias still in place from PR-F1's review-fix-pass-1.
- Existing `entities` rows on disk continue to work — the back-link writes happen on next merge run, not as a migration.

## Stack history

After this lands, the entity layer is in its **stable state**.  Next planned: PR-G1 / G2 / G3 (entity_aliases + extraction-time prime + auto-wikilink), then PR-H1 / H2 (Crystal layer with Louvain communities + LLM synthesis to `40-Resources/Crystals/`).  README + backlog will be updated in a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * GitHub profile URLs now detected alongside repository URLs for broader owner discovery

* **Improvements**
  * Concurrent refresh operations are now more robust with improved race condition handling
  * Entity resolution and linking improved for better accuracy
  * Added `--migrate-existing` flag for identity migration tasks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->