### PR TITLE
feat(entities): auto-wikilink CLI ovp-link-entities (BL-040)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,7 @@ ovp-backfill-twitter-authors = "ovp_pipeline.commands.backfill_twitter_authors:m
 ovp-backfill-github = "ovp_pipeline.commands.backfill_github:main"
 ovp-merge-identities = "ovp_pipeline.commands.merge_identities:main"
 ovp-entity-aliases = "ovp_pipeline.commands.entity_aliases:main"
+ovp-link-entities = "ovp_pipeline.commands.link_entities:main"
 ovp-refresh-source-authority = "ovp_pipeline.commands.refresh_source_authority:main"
 ovp-refresh-entities = "ovp_pipeline.commands.refresh_entities:main"
 ovp-embedding-dedup = "ovp_pipeline.commands.embedding_dedup:main"

--- a/src/ovp_pipeline/commands/link_entities.py
+++ b/src/ovp_pipeline/commands/link_entities.py
@@ -1,0 +1,202 @@
+"""ovp-link-entities — auto-wikilink for evergreen body prose (BL-040).
+
+Walks ``10-Knowledge/Evergreen/**.md``, replaces canonical-entity
+mentions with ``[[canonical_handle]]`` Obsidian wikilinks, and
+generates ``10-Knowledge/Entity/<handle>.md`` stub pages for any
+canonicals that don't have a markdown page yet.
+
+Usage::
+
+    ovp-link-entities --vault-dir ~/Documents/ovp-vault                # apply
+    ovp-link-entities --vault-dir ~/Documents/ovp-vault --dry-run      # preview
+    ovp-link-entities --vault-dir ~/Documents/ovp-vault --scan-dir 20-Areas
+    ovp-link-entities --vault-dir ~/Documents/ovp-vault --no-stubs
+
+Idempotent: re-running the command on the rewritten output is a
+no-op because the new wikilinks land in the skip-regions list (the
+matcher won't touch text inside ``[[...]]``).
+
+Default scan target is ``10-Knowledge/Evergreen/``; pass
+``--scan-dir`` to point at a different subtree (multiple flags
+allowed).  Frontmatter, code blocks (fenced + inline), existing
+wikilinks, and existing markdown links are never touched.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from ..entities.aliases import (
+    build_alias_index,
+    collect_entity_aliases,
+)
+from ..entities.store import EntityStore
+from ..entities.aliases import KIND_DISPLAY_NAME
+from ..entities.wikilink import (
+    DEFAULT_LINKABLE_KINDS,
+    DEFAULT_MIN_ALIAS_LENGTH,
+    apply_wikilinks,
+    ensure_entity_stub_files,
+)
+
+
+_DEFAULT_SCAN_REL = Path("10-Knowledge") / "Evergreen"
+
+
+def _iter_target_files(vault_dir: Path, scan_rel: list[Path]):
+    """Yield every .md path under each ``scan_rel`` subtree, skipping
+    backup / cache dirs."""
+    skip_parts = frozenset({"__pycache__", "_backup", ".git"})
+    for rel in scan_rel:
+        root = vault_dir / rel
+        if not root.is_dir():
+            continue
+        for p in root.rglob("*.md"):
+            if any(part in skip_parts for part in p.parts):
+                continue
+            yield p
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Auto-wikilink canonical entities in evergreen prose",
+    )
+    parser.add_argument("--vault-dir", type=Path, default=Path.cwd())
+    parser.add_argument(
+        "--scan-dir", action="append", type=Path, default=None,
+        help=f"Subtree under vault to scan (relative).  "
+             f"Default: {_DEFAULT_SCAN_REL}.  Can be repeated.",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Preview replacements + stub creations without writing",
+    )
+    parser.add_argument(
+        "--no-stubs", action="store_true",
+        help="Skip creation of 10-Knowledge/Entity/<handle>.md "
+             "stub files (only do the in-place replacements)",
+    )
+    parser.add_argument(
+        "--quiet", action="store_true",
+        help="Print summary only, no per-file lines",
+    )
+    parser.add_argument(
+        "--include-display-names", action="store_true",
+        help="Also auto-link via display_name aliases (e.g., "
+             "'Andrej Karpathy' → karpathy).  Off by default — "
+             "display names are auto-derived from canonical_name "
+             "and trip on common English words like 'image'.",
+    )
+    parser.add_argument(
+        "--min-alias-length", type=int, default=DEFAULT_MIN_ALIAS_LENGTH,
+        help=f"Skip aliases shorter than this many chars "
+             f"(default {DEFAULT_MIN_ALIAS_LENGTH}). "
+             "Lower at your own risk: short aliases like 'ai' / "
+             "'ml' will linkify every occurrence.",
+    )
+    args = parser.parse_args(argv)
+
+    kinds = set(DEFAULT_LINKABLE_KINDS)
+    if args.include_display_names:
+        kinds.add(KIND_DISPLAY_NAME)
+    kinds = frozenset(kinds)
+
+    vault = args.vault_dir.resolve()
+    if not vault.is_dir():
+        print(f"vault not found: {vault}", file=sys.stderr)
+        return 2
+
+    scan_targets = args.scan_dir or [_DEFAULT_SCAN_REL]
+
+    # Build the alias index ONCE.  ~929 canonicals on the OVP vault,
+    # ~7000 evergreens to walk → 0.5s scan vs 0.5s × 7000 if rebuilt
+    # per file.
+    store = EntityStore(db_path=vault / "60-Logs" / "knowledge.db")
+    aliases = collect_entity_aliases(vault_dir=vault, entity_store=store)
+    alias_index = build_alias_index(aliases)
+
+    if not alias_index:
+        print("entity_aliases is empty — nothing to link.  "
+              "Run ovp-backfill-twitter-authors / ovp-backfill-github "
+              "first to populate the entity layer.", file=sys.stderr)
+        return 0
+
+    # ---- pass 1: rewrite evergreen bodies ----------------------------------
+
+    files_changed = 0
+    total_replacements = 0
+    canonicals_used: set[str] = set()
+    files_seen = 0
+    for path in _iter_target_files(vault, scan_targets):
+        files_seen += 1
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        result = apply_wikilinks(
+            text, alias_index,
+            kinds=kinds,
+            min_length=args.min_alias_length,
+        )
+        if result.n_replaced == 0:
+            continue
+        files_changed += 1
+        total_replacements += result.n_replaced
+        canonicals_used.update(result.canonicals_used)
+        if not args.quiet:
+            print(f"  {result.n_replaced:>3} → {path.relative_to(vault)}  "
+                  f"({len(result.canonicals_used)} canonicals)")
+        if args.dry_run:
+            continue
+        path.write_text(result.text, encoding="utf-8")
+
+    # ---- pass 2: stub creation ---------------------------------------------
+
+    stubs_created: list[Path] = []
+    if not args.no_stubs and canonicals_used:
+        # Pick the highest-precedence alias per canonical so the stub
+        # carries the right entity_type + authority.
+        rep: dict = {}
+        for alias_obj in alias_index.values():
+            if alias_obj.canonical_handle not in canonicals_used:
+                continue
+            existing = rep.get(alias_obj.canonical_handle)
+            if existing is None:
+                rep[alias_obj.canonical_handle] = alias_obj
+                continue
+            # Keep the one with higher authority for the stub.
+            existing_auth = existing.authority or 0.0
+            new_auth = alias_obj.authority or 0.0
+            if new_auth > existing_auth:
+                rep[alias_obj.canonical_handle] = alias_obj
+        stubs_created = ensure_entity_stub_files(
+            vault, rep, dry_run=args.dry_run,
+        )
+
+    # ---- summary -----------------------------------------------------------
+
+    print()
+    verb = "would change" if args.dry_run else "changed"
+    print(f"=== Summary ({verb}) ===")
+    print(f"  files scanned:        {files_seen}")
+    print(f"  files {verb}:         {files_changed}")
+    print(f"  total wikilinks:      {total_replacements}")
+    print(f"  unique canonicals:    {len(canonicals_used)}")
+    if stubs_created:
+        verb_stub = "would be created" if args.dry_run else "created"
+        print(f"  entity stub pages {verb_stub}: {len(stubs_created)}")
+        if not args.quiet:
+            for p in stubs_created[:20]:
+                print(f"    + {p.relative_to(vault)}")
+            if len(stubs_created) > 20:
+                print(f"    ... and {len(stubs_created) - 20} more")
+    if args.dry_run:
+        print()
+        print("--dry-run set; nothing was written.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ovp_pipeline/commands/link_entities.py
+++ b/src/ovp_pipeline/commands/link_entities.py
@@ -37,8 +37,9 @@ from ..entities.aliases import KIND_DISPLAY_NAME
 from ..entities.wikilink import (
     DEFAULT_LINKABLE_KINDS,
     DEFAULT_MIN_ALIAS_LENGTH,
-    apply_wikilinks,
+    apply_prepared_matcher,
     ensure_entity_stub_files,
+    prepare_matcher,
 )
 
 
@@ -47,14 +48,27 @@ _DEFAULT_SCAN_REL = Path("10-Knowledge") / "Evergreen"
 
 def _iter_target_files(vault_dir: Path, scan_rel: list[Path]):
     """Yield every .md path under each ``scan_rel`` subtree, skipping
-    backup / cache dirs."""
+    backup / cache dirs.
+
+    The skip-parts check runs against the path **relative to the
+    vault root** — ``p.parts`` would otherwise compare against the
+    absolute path, so a vault placed inside a directory called
+    e.g. ``_backup`` would silently skip every file.
+    """
     skip_parts = frozenset({"__pycache__", "_backup", ".git"})
+    vault_root = vault_dir.resolve()
     for rel in scan_rel:
         root = vault_dir / rel
         if not root.is_dir():
             continue
         for p in root.rglob("*.md"):
-            if any(part in skip_parts for part in p.parts):
+            try:
+                rel_p = p.resolve().relative_to(vault_root)
+            except ValueError:
+                # Symlink / mount oddity placed the file outside the
+                # vault — be conservative and skip.
+                continue
+            if any(part in skip_parts for part in rel_p.parts):
                 continue
             yield p
 
@@ -125,6 +139,14 @@ def main(argv: list[str] | None = None) -> int:
 
     # ---- pass 1: rewrite evergreen bodies ----------------------------------
 
+    # Pre-build the matcher ONCE outside the file loop.  Inside
+    # ``apply_wikilinks`` the filter + regex compilation costs ~5ms;
+    # at 7000 evergreens that's 35s of redundant work.  ``prepare_matcher``
+    # does the work once.
+    matcher = prepare_matcher(
+        alias_index, kinds=kinds, min_length=args.min_alias_length,
+    )
+
     files_changed = 0
     total_replacements = 0
     canonicals_used: set[str] = set()
@@ -133,13 +155,13 @@ def main(argv: list[str] | None = None) -> int:
         files_seen += 1
         try:
             text = path.read_text(encoding="utf-8")
-        except OSError:
+        except (OSError, UnicodeDecodeError):
+            # UnicodeDecodeError is NOT an OSError subclass — it
+            # would crash the scan on a binary file or one with
+            # non-UTF8 encoding.  Skip + continue so a single bad
+            # file doesn't take down the whole vault walk.
             continue
-        result = apply_wikilinks(
-            text, alias_index,
-            kinds=kinds,
-            min_length=args.min_alias_length,
-        )
+        result = apply_prepared_matcher(text, matcher)
         if result.n_replaced == 0:
             continue
         files_changed += 1

--- a/src/ovp_pipeline/entities/wikilink.py
+++ b/src/ovp_pipeline/entities/wikilink.py
@@ -178,6 +178,54 @@ def _normalize_for_lookup(matched: str) -> str:
     return matched.strip().lstrip("@").lower()
 
 
+@dataclass(frozen=True, slots=True)
+class PreparedMatcher:
+    """Pre-filtered + pre-compiled state for batch auto-wikilink runs.
+
+    ``apply_wikilinks`` filters the alias index and compiles the regex
+    on every call — fine for a one-shot, expensive when scanning
+    thousands of evergreens.  ``prepare_matcher`` builds the state
+    once; ``apply_prepared_matcher`` reuses it.
+    """
+
+    filtered_index: dict[str, EntityAlias]
+    pattern: re.Pattern[str]
+
+
+def _passes_length(alias: str, min_length: int) -> bool:
+    """Length floor with a CJK escape hatch: a 2-char Chinese name
+    like ``歸藏`` carries far more entropy than a 2-char English
+    bigram like ``ai``, so non-ASCII aliases bypass the floor."""
+    if len(alias) >= min_length:
+        return True
+    return any(ord(c) > 127 for c in alias)
+
+
+def prepare_matcher(
+    alias_index: dict[str, EntityAlias],
+    *,
+    kinds: frozenset[str] | set[str] | None = None,
+    min_length: int = DEFAULT_MIN_ALIAS_LENGTH,
+) -> PreparedMatcher:
+    """Pre-build the filter + regex once, for batch reuse.
+
+    ``ovp-link-entities`` walks ~7000 evergreens with ~929 canonicals;
+    re-filtering + re-compiling per file was a measurable cost.  Now
+    the CLI calls ``prepare_matcher`` once outside the loop and feeds
+    the result into ``apply_prepared_matcher`` per file.
+    """
+    if kinds is None:
+        kinds = DEFAULT_LINKABLE_KINDS
+    filtered = {
+        a: row for a, row in alias_index.items()
+        if row.alias_kind in kinds and _passes_length(a, min_length)
+    }
+    return PreparedMatcher(
+        filtered_index=filtered,
+        pattern=build_alias_pattern(filtered),
+    )
+
+
 def apply_wikilinks(
     text: str,
     alias_index: dict[str, EntityAlias],
@@ -203,31 +251,34 @@ def apply_wikilinks(
     of canonicals that got at least one link.  Idempotent on the
     rewritten output: running again is a no-op because the new
     wikilinks land in the skip regions.
+
+    Rebuilds the filter + regex on every call.  Batch callers
+    walking many files should use ``prepare_matcher`` +
+    ``apply_prepared_matcher`` to amortize the cost.
     """
     if not alias_index:
         return WikilinkResult(text=text, n_replaced=0, canonicals_used=set())
+    matcher = prepare_matcher(
+        alias_index, kinds=kinds, min_length=min_length,
+    )
+    return apply_prepared_matcher(text, matcher)
 
-    if kinds is None:
-        kinds = DEFAULT_LINKABLE_KINDS
 
-    def _passes_length(alias: str) -> bool:
-        """Length floor with a CJK escape hatch: a 2-char Chinese
-        name like ``歸藏`` carries far more entropy than a 2-char
-        English bigram like ``ai``, so non-ASCII aliases bypass
-        the floor."""
-        if len(alias) >= min_length:
-            return True
-        return any(ord(c) > 127 for c in alias)
+def apply_prepared_matcher(
+    text: str, matcher: PreparedMatcher,
+) -> WikilinkResult:
+    """Batch entry point: apply a pre-built matcher to one file.
 
-    filtered_index = {
-        a: row for a, row in alias_index.items()
-        if row.alias_kind in kinds and _passes_length(a)
-    }
-    if not filtered_index:
+    The matcher carries the filtered alias index + compiled regex,
+    both expensive to build.  Callers running over thousands of
+    files build the matcher once and call this per file.
+    """
+    if not matcher.filtered_index:
         return WikilinkResult(text=text, n_replaced=0, canonicals_used=set())
 
     skip = _find_skip_regions(text)
-    pattern = build_alias_pattern(filtered_index)
+    pattern = matcher.pattern
+    filtered_index = matcher.filtered_index
     n_replaced = 0
     used: set[str] = set()
 

--- a/src/ovp_pipeline/entities/wikilink.py
+++ b/src/ovp_pipeline/entities/wikilink.py
@@ -1,0 +1,329 @@
+"""Auto-wikilink: scan prose, replace canonical-entity mentions with
+``[[canonical_handle|original_text]]`` Obsidian wikilinks.
+
+Companion to ``entities/aliases.py`` (BL-038) and the extraction
+prime (BL-039).  This module is the **read-time wiring** that
+turns "the entity layer knows who Karpathy is" into "the evergreen
+notes link to the canonical entity page".
+
+Skip regions
+------------
+
+The replacer must NEVER touch:
+
+  * **Frontmatter** — the ``---``-delimited YAML block at the top of
+    every Obsidian note.  Wikilinks in frontmatter would corrupt
+    YAML parsing.
+  * **Fenced code blocks** (``` ``` `` / ``` ~~~ ```) — code is
+    literal; turning ``karpathy`` into a link inside a code sample
+    would silently break copy-paste.
+  * **Inline code** (`` `...` ``) — same.
+  * **Existing wikilinks** ``[[...]]`` — already linked, don't
+    double-link.
+  * **Existing markdown links** ``[text](url)`` — leave the user's
+    explicit link intact.
+
+Match semantics
+---------------
+
+Word-boundary regex with case-insensitive lookup.  For an alias
+that is itself the canonical (``karpathy`` → ``karpathy``), emit
+``[[karpathy]]``.  For any other alias (``Andrej Karpathy`` →
+``karpathy``), emit ``[[karpathy|Andrej Karpathy]]`` so Obsidian
+preserves the prose surface.
+
+Longest-first ordering: when multiple aliases match the same span
+(e.g., ``karpathy`` is a prefix of ``karpathy.ai``), the longer
+alias wins.
+
+CJK is supported via Python's default ``re.UNICODE`` semantics —
+display names like ``歸藏`` and ``姚金刚`` round-trip cleanly.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from .aliases import (
+    KIND_AT_HANDLE,
+    KIND_EXPLICIT_ALIAS,
+    KIND_GITHUB_LOGIN,
+    KIND_PRIMARY,
+    EntityAlias,
+)
+
+
+# Which alias_kinds are safe to auto-link.  ``KIND_DISPLAY_NAME`` is
+# deliberately EXCLUDED by default because it's auto-derived from
+# ``entity.canonical_name`` and trips on common English words —
+# e.g., a github_user with login ``image1`` and canonical_name
+# ``Image`` yields a ``display_name`` alias of ``image`` that would
+# rewrite every occurrence of "image" in evergreen prose.  Users
+# can opt in with the ``kinds=`` parameter; the default keeps the
+# auto-link surface to handles + explicit aliases.
+DEFAULT_LINKABLE_KINDS: frozenset[str] = frozenset({
+    KIND_PRIMARY,
+    KIND_AT_HANDLE,
+    KIND_EXPLICIT_ALIAS,
+    KIND_GITHUB_LOGIN,
+})
+
+# Minimum alias length we'll auto-link.  ``ai`` (2 chars) shouldn't
+# linkify every "AI" mention; ``xxx`` (3 chars) is ambiguous but
+# borderline-OK if the entity is real.  Set to 3 by default to err
+# on the safe side — users can lower it for niche use cases.
+DEFAULT_MIN_ALIAS_LENGTH = 3
+
+
+# Pre-compiled patterns for the skip-region scan.  Used in order;
+# results are merged into a single flat list of (start, end) ranges.
+_FRONTMATTER_RE = re.compile(r"\A---\n[\s\S]*?\n---\n")
+_FENCED_CODE_RE = re.compile(r"```[\s\S]*?```")
+_INLINE_CODE_RE = re.compile(r"`[^`\n]+`")
+_WIKILINK_RE = re.compile(r"\[\[[^\]\n]+\]\]")
+_MD_LINK_RE = re.compile(r"\[[^\]\n]+\]\([^)\n]+\)")
+
+
+@dataclass(frozen=True, slots=True)
+class WikilinkResult:
+    """One file's worth of replacement output."""
+
+    text: str            # the rewritten markdown
+    n_replaced: int      # how many alias hits were converted to wikilinks
+    canonicals_used: set[str]  # which canonical_handles got linked
+
+
+# ---------------------------------------------------------------------------
+# Skip regions
+# ---------------------------------------------------------------------------
+
+
+def _merge_ranges(ranges: list[tuple[int, int]]) -> list[tuple[int, int]]:
+    """Coalesce overlapping/adjacent ranges so the in-skip check is
+    a single pass instead of N regex hits per match."""
+    if not ranges:
+        return []
+    ranges = sorted(ranges)
+    merged = [ranges[0]]
+    for start, end in ranges[1:]:
+        last_start, last_end = merged[-1]
+        if start <= last_end:
+            merged[-1] = (last_start, max(last_end, end))
+        else:
+            merged.append((start, end))
+    return merged
+
+
+def _find_skip_regions(text: str) -> list[tuple[int, int]]:
+    """Identify char spans that the alias replacer must leave alone."""
+    ranges: list[tuple[int, int]] = []
+    fm = _FRONTMATTER_RE.match(text)
+    if fm is not None:
+        ranges.append((fm.start(), fm.end()))
+    # Fenced code first (bigger), then inline; merging dedupes.
+    for m in _FENCED_CODE_RE.finditer(text):
+        ranges.append((m.start(), m.end()))
+    for m in _INLINE_CODE_RE.finditer(text):
+        ranges.append((m.start(), m.end()))
+    for m in _WIKILINK_RE.finditer(text):
+        ranges.append((m.start(), m.end()))
+    for m in _MD_LINK_RE.finditer(text):
+        ranges.append((m.start(), m.end()))
+    return _merge_ranges(ranges)
+
+
+def _is_in_skip(pos: int, skip: list[tuple[int, int]]) -> bool:
+    # Linear scan — skip lists are tiny in practice (<50 ranges per
+    # evergreen).  Binary search would be premature optimization.
+    for s, e in skip:
+        if s <= pos < e:
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Alias pattern + replacement
+# ---------------------------------------------------------------------------
+
+
+def build_alias_pattern(alias_index: dict[str, EntityAlias]) -> re.Pattern[str]:
+    """Compile a single regex covering every alias.
+
+    Sorted longest-first so the regex engine's left-to-right
+    alternation prefers the most specific match.  Word-boundary
+    behavior:
+
+      * left side — must NOT be preceded by a word character or ``@``
+        (so ``foo@karpathy`` doesn't match ``karpathy``, but
+        ``@karpathy`` standalone does)
+      * right side — must NOT be followed by a word character (so
+        ``karpathys`` doesn't match ``karpathy``)
+
+    Returns a sentinel regex that never matches (alternation of
+    nothing) when the index is empty.
+    """
+    if not alias_index:
+        return re.compile(r"(?!x)x")        # never matches
+    parts = sorted(alias_index.keys(), key=len, reverse=True)
+    escaped = [re.escape(p) for p in parts]
+    pattern = (
+        r"(?<![\w@])(?:" + "|".join(escaped) + r")(?!\w)"
+    )
+    return re.compile(pattern, re.IGNORECASE)
+
+
+def _normalize_for_lookup(matched: str) -> str:
+    return matched.strip().lstrip("@").lower()
+
+
+def apply_wikilinks(
+    text: str,
+    alias_index: dict[str, EntityAlias],
+    *,
+    kinds: frozenset[str] | set[str] | None = None,
+    min_length: int = DEFAULT_MIN_ALIAS_LENGTH,
+) -> WikilinkResult:
+    """Rewrite ``text`` so canonical-entity mentions become wikilinks.
+
+    Parameters
+    ----------
+    kinds :
+        Which ``alias_kind`` values are safe to auto-link.  Default
+        is ``DEFAULT_LINKABLE_KINDS`` which excludes
+        ``display_name`` — see the constant's docstring for why.
+        Pass an explicit set to opt in to the noisier kinds.
+    min_length :
+        Skip aliases shorter than this many chars.  Default 3
+        prevents ``ai`` / ``ml`` from linking every occurrence of
+        those bigrams in evergreen prose.
+
+    Returns the rewritten text + a count of replacements + the set
+    of canonicals that got at least one link.  Idempotent on the
+    rewritten output: running again is a no-op because the new
+    wikilinks land in the skip regions.
+    """
+    if not alias_index:
+        return WikilinkResult(text=text, n_replaced=0, canonicals_used=set())
+
+    if kinds is None:
+        kinds = DEFAULT_LINKABLE_KINDS
+
+    def _passes_length(alias: str) -> bool:
+        """Length floor with a CJK escape hatch: a 2-char Chinese
+        name like ``歸藏`` carries far more entropy than a 2-char
+        English bigram like ``ai``, so non-ASCII aliases bypass
+        the floor."""
+        if len(alias) >= min_length:
+            return True
+        return any(ord(c) > 127 for c in alias)
+
+    filtered_index = {
+        a: row for a, row in alias_index.items()
+        if row.alias_kind in kinds and _passes_length(a)
+    }
+    if not filtered_index:
+        return WikilinkResult(text=text, n_replaced=0, canonicals_used=set())
+
+    skip = _find_skip_regions(text)
+    pattern = build_alias_pattern(filtered_index)
+    n_replaced = 0
+    used: set[str] = set()
+
+    def _replace(m: re.Match[str]) -> str:
+        nonlocal n_replaced
+        if _is_in_skip(m.start(), skip):
+            return m.group(0)
+        matched = m.group(0)
+        canonical_alias = filtered_index.get(_normalize_for_lookup(matched))
+        if canonical_alias is None:
+            return matched
+        canonical = canonical_alias.canonical_handle
+        used.add(canonical)
+        n_replaced += 1
+        # When the prose is already exactly the canonical, no alias
+        # piping needed — keeps the wikilink terse.
+        if _normalize_for_lookup(matched) == canonical:
+            return f"[[{canonical}]]"
+        return f"[[{canonical}|{matched}]]"
+
+    new_text = pattern.sub(_replace, text)
+    return WikilinkResult(text=new_text, n_replaced=n_replaced, canonicals_used=used)
+
+
+# ---------------------------------------------------------------------------
+# Entity stub generation
+# ---------------------------------------------------------------------------
+
+
+# Where the auto-wikilink targets live.  Existing OVP convention is
+# ``10-Knowledge/Entity/`` (already used by entity_registry).  We
+# create stubs only when missing — never overwrite a user's curated
+# entity page.
+_ENTITY_STUB_DIR = Path("10-Knowledge") / "Entity"
+
+
+def _render_stub_frontmatter(alias: EntityAlias) -> str:
+    """Render the minimal frontmatter for a stub entity page.
+
+    Kept narrow on purpose: enough fields for the page to render in
+    Obsidian + carry the canonical_handle for downstream tooling,
+    but nothing that pretends the user has reviewed the entity.
+    The ``stub: true`` flag tells the rest of OVP this is a
+    placeholder and a human hasn't curated the body yet.
+    """
+    parts = [
+        "---",
+        f"slug: {alias.canonical_handle}",
+        f"entity_type: {alias.canonical_entity_type}",
+        f"canonical_handle: {alias.canonical_handle}",
+    ]
+    if alias.authority is not None:
+        parts.append(f"authority: {alias.authority:.4f}")
+    parts.extend([
+        "stub: true",
+        'created_by: "ovp-link-entities"',
+        "tags: [entity, stub]",
+        "---",
+        "",
+        f"# {alias.canonical_handle}",
+        "",
+        "*Auto-generated entity stub.  Replace this body with curated content "
+        "when you have time — until then it serves as a wikilink target so "
+        "evergreen-body mentions don't dead-end.*",
+        "",
+    ])
+    return "\n".join(parts)
+
+
+def ensure_entity_stub_files(
+    vault_dir: Path,
+    canonicals: dict[str, EntityAlias],
+    *,
+    dry_run: bool = False,
+) -> list[Path]:
+    """Create ``10-Knowledge/Entity/<canonical>.md`` for each
+    canonical in ``canonicals`` that doesn't already have a
+    markdown page.
+
+    ``canonicals`` should be ``{canonical_handle: representative_alias}``
+    — one alias per canonical (the representative tells us the
+    entity_type + authority for the stub frontmatter).
+
+    Returns the list of paths that were created (or *would be*
+    created in dry-run).  Never overwrites an existing file.
+    """
+    entity_dir = vault_dir / _ENTITY_STUB_DIR
+    if not dry_run:
+        entity_dir.mkdir(parents=True, exist_ok=True)
+    created: list[Path] = []
+    for canonical, alias in canonicals.items():
+        path = entity_dir / f"{canonical}.md"
+        if path.exists():
+            continue
+        created.append(path)
+        if dry_run:
+            continue
+        path.write_text(_render_stub_frontmatter(alias), encoding="utf-8")
+    return created

--- a/tests/test_link_entities_cli.py
+++ b/tests/test_link_entities_cli.py
@@ -1,0 +1,92 @@
+"""Tests for the ``ovp-link-entities`` CLI iteration helpers.
+
+Focused on the two invariants surfaced in PR-128 review:
+  * ``UnicodeDecodeError`` on a binary file must NOT crash the scan
+  * Skip-parts (``__pycache__`` / ``_backup`` / ``.git``) must be
+    checked against the path RELATIVE to the vault root, not the
+    absolute path — otherwise a vault placed inside a directory
+    that happens to contain ``_backup`` gets silently skipped.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ovp_pipeline.commands.link_entities import _iter_target_files, main
+
+
+def _seed_authors_jsonl(tmp_path: Path) -> Path:
+    p = tmp_path / "60-Logs" / "authors.jsonl"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(
+        json.dumps({"handle": "karpathy", "authority": 0.95}) + "\n",
+        encoding="utf-8",
+    )
+    return p
+
+
+class TestIterTargetFilesSkipPartsRelative:
+    """The skip-parts check must apply to the path RELATIVE to the
+    vault root.  Pre-fix the absolute-path check would silently skip
+    every file when the vault sat inside an ancestor directory whose
+    name matched a skip token (e.g., a developer running from
+    ``~/_backup/ovp-vault``)."""
+
+    def test_vault_inside_backup_dir_still_yields(self, tmp_path):
+        # Construct a vault at <tmp_path>/_backup/vault/...
+        # so the absolute path includes ``_backup`` but the path
+        # relative to the vault root does not.
+        vault = tmp_path / "_backup" / "vault"
+        scan_dir = Path("10-Knowledge/Evergreen")
+        target = vault / scan_dir / "x.md"
+        target.parent.mkdir(parents=True)
+        target.write_text("body", encoding="utf-8")
+        out = list(_iter_target_files(vault, [scan_dir]))
+        # File yielded despite the ``_backup`` ancestor.
+        assert any(p == target for p in out)
+
+    def test_skip_parts_inside_vault_still_filtered(self, tmp_path):
+        # The legitimate skip case still works: a ``_backup`` dir
+        # *inside* the vault should be skipped.
+        vault = tmp_path / "vault"
+        scan_dir = Path("10-Knowledge/Evergreen")
+        good = vault / scan_dir / "real.md"
+        skipped = vault / scan_dir / "_backup" / "old.md"
+        good.parent.mkdir(parents=True)
+        skipped.parent.mkdir(parents=True)
+        good.write_text("body", encoding="utf-8")
+        skipped.write_text("body", encoding="utf-8")
+        out = list(_iter_target_files(vault, [scan_dir]))
+        names = {p.name for p in out}
+        assert "real.md" in names
+        assert "old.md" not in names
+
+
+class TestCliHandlesBinaryFiles:
+    """A binary file with .md extension (rare but possible — e.g.,
+    a corrupted save) raises ``UnicodeDecodeError`` from
+    ``read_text(encoding='utf-8')``.  That's NOT a subclass of
+    ``OSError``, so the pre-fix ``except OSError`` would miss it
+    and crash the whole CLI run."""
+
+    def test_binary_md_does_not_crash(self, tmp_path, capsys):
+        vault = tmp_path / "vault"
+        # Seed the entity layer so the CLI has aliases to work with.
+        _seed_authors_jsonl(vault)
+        scan_dir = Path("10-Knowledge/Evergreen")
+        # One legitimate utf-8 file…
+        good = vault / scan_dir / "good.md"
+        good.parent.mkdir(parents=True)
+        good.write_text("see karpathy talk", encoding="utf-8")
+        # …and one with non-utf8 bytes (a stray Latin-1 file someone
+        # dropped in the vault).
+        bad = vault / scan_dir / "bad.md"
+        bad.write_bytes(b"\xff\xfe binary garbage \x00\x01\x02")
+
+        rc = main(["--vault-dir", str(vault), "--no-stubs", "--quiet"])
+        assert rc == 0
+        # The good file got rewritten despite the bad one's presence.
+        assert "[[karpathy]]" in good.read_text(encoding="utf-8")
+        # The bad file was NOT touched (read failed, skipped).
+        assert bad.read_bytes().startswith(b"\xff\xfe")

--- a/tests/test_wikilink.py
+++ b/tests/test_wikilink.py
@@ -1,0 +1,350 @@
+"""Tests for entities/wikilink.py — auto-wikilink for evergreen prose (BL-040)."""
+
+from __future__ import annotations
+
+from ovp_pipeline.entities.aliases import (
+    KIND_AT_HANDLE,
+    KIND_DISPLAY_NAME,
+    KIND_PRIMARY,
+    SOURCE_ENTITY_PERSON,
+    SOURCE_WHITELIST_JSONL,
+    EntityAlias,
+)
+from ovp_pipeline.entities.wikilink import (
+    _find_skip_regions,
+    apply_wikilinks,
+    build_alias_pattern,
+    ensure_entity_stub_files,
+)
+
+
+def _alias(canonical: str, alias: str, *, kind: str = KIND_PRIMARY,
+           etype: str = "person", authority: float = 0.6,
+           source: str = SOURCE_ENTITY_PERSON) -> EntityAlias:
+    return EntityAlias(
+        canonical_handle=canonical,
+        canonical_entity_type=etype,
+        alias=alias,
+        alias_kind=kind,
+        authority=authority,
+        source=source,
+    )
+
+
+def _build_index(*aliases: EntityAlias) -> dict[str, EntityAlias]:
+    return {a.alias: a for a in aliases}
+
+
+# ---------------------------------------------------------------------------
+# Skip regions
+# ---------------------------------------------------------------------------
+
+
+class TestFindSkipRegions:
+    def test_frontmatter_at_top(self):
+        text = "---\nslug: x\n---\nbody karpathy\n"
+        skip = _find_skip_regions(text)
+        # Frontmatter spans from 0 to the closing ``---\n``.
+        assert any(s == 0 for s, _ in skip)
+        # The "body" portion is NOT in any skip range.
+        body_start = text.index("body")
+        assert not any(s <= body_start < e for s, e in skip)
+
+    def test_fenced_code_block(self):
+        text = "before\n```\nkarpathy\n```\nafter karpathy"
+        skip = _find_skip_regions(text)
+        # The fenced block is in skip; the second "karpathy" (after) is not.
+        first_kp = text.index("karpathy")
+        second_kp = text.rindex("karpathy")
+        assert any(s <= first_kp < e for s, e in skip)
+        assert not any(s <= second_kp < e for s, e in skip)
+
+    def test_inline_code(self):
+        text = "see `karpathy` and karpathy"
+        skip = _find_skip_regions(text)
+        first_kp = text.index("karpathy")
+        second_kp = text.rindex("karpathy")
+        assert any(s <= first_kp < e for s, e in skip)
+        assert not any(s <= second_kp < e for s, e in skip)
+
+    def test_existing_wikilink(self):
+        text = "[[karpathy]] and karpathy"
+        skip = _find_skip_regions(text)
+        first = text.index("[[")
+        # The whole [[karpathy]] is skipped.
+        assert any(s <= first < e for s, e in skip)
+        # The bare second "karpathy" is not.
+        second = text.rindex("karpathy")
+        assert not any(s <= second < e for s, e in skip)
+
+    def test_existing_markdown_link(self):
+        text = "see [Andrej](https://x.com/karpathy) here"
+        skip = _find_skip_regions(text)
+        # The whole `[Andrej](...)` is skipped.
+        link_start = text.index("[Andrej]")
+        link_end = text.index(")") + 1
+        assert any(s <= link_start and link_end <= e for s, e in skip)
+
+
+# ---------------------------------------------------------------------------
+# Pattern building + replacement
+# ---------------------------------------------------------------------------
+
+
+class TestBuildAliasPattern:
+    def test_empty_index_never_matches(self):
+        p = build_alias_pattern({})
+        assert p.search("any text") is None
+
+    def test_word_boundary_left_blocks_partial_prefix(self):
+        # "foo@karpathy" should NOT match the alias "karpathy" because
+        # the @ is glued to a word char on the left.
+        index = _build_index(_alias("karpathy", "karpathy"))
+        p = build_alias_pattern(index)
+        assert p.search("foo@karpathy") is None
+
+    def test_at_handle_left_boundary(self):
+        # "@karpathy" by itself MUST match the at_handle alias.
+        index = _build_index(_alias("karpathy", "@karpathy", kind=KIND_AT_HANDLE))
+        p = build_alias_pattern(index)
+        assert p.search("see @karpathy") is not None
+
+    def test_word_boundary_right_blocks_plural(self):
+        # "karpathys" should NOT match "karpathy" — would corrupt
+        # legitimate prose.
+        index = _build_index(_alias("karpathy", "karpathy"))
+        p = build_alias_pattern(index)
+        assert p.search("karpathys") is None
+
+    def test_longest_match_wins(self):
+        # "andrej karpathy" must beat "andrej" when both are aliases.
+        index = _build_index(
+            _alias("karpathy", "andrej karpathy", kind=KIND_DISPLAY_NAME),
+            _alias("andrej-other", "andrej"),
+        )
+        p = build_alias_pattern(index)
+        m = p.search("see andrej karpathy talk")
+        assert m is not None
+        assert m.group(0).lower() == "andrej karpathy"
+
+
+class TestApplyWikilinks:
+    def test_simple_replacement_uses_short_form(self):
+        # When the matched text is the canonical handle, no alias
+        # piping needed.
+        index = _build_index(_alias("karpathy", "karpathy"))
+        result = apply_wikilinks("see karpathy talk", index)
+        assert result.text == "see [[karpathy]] talk"
+        assert result.n_replaced == 1
+        assert result.canonicals_used == {"karpathy"}
+
+    def test_explicit_alias_uses_pipe_form(self):
+        # When the matched text differs from the canonical, preserve
+        # the prose surface via the |alias form.  Use an
+        # explicit_alias (curated, on the safe-by-default kinds list)
+        # rather than a display_name (default-excluded post-fix).
+        from ovp_pipeline.entities.aliases import KIND_EXPLICIT_ALIAS
+
+        index = _build_index(
+            _alias("karpathy", "karpathy"),
+            _alias("karpathy", "andrej karpathy", kind=KIND_EXPLICIT_ALIAS),
+        )
+        result = apply_wikilinks("Andrej Karpathy said it", index)
+        # Original case preserved inside the wikilink.
+        assert "[[karpathy|Andrej Karpathy]]" in result.text
+        assert result.n_replaced == 1
+
+    def test_at_handle_collapses_to_short_form(self):
+        # ``@karpathy`` and ``karpathy`` normalize to the same lookup
+        # key, so both prose forms produce the short ``[[karpathy]]``
+        # wikilink.  The ``@`` cue is dropped in favor of consistency
+        # with non-@ mentions of the same entity.  In Obsidian both
+        # render identically; keeping the short form makes the
+        # operation idempotent + the markdown cleaner.
+        index = _build_index(
+            _alias("karpathy", "karpathy"),
+            _alias("karpathy", "@karpathy", kind=KIND_AT_HANDLE),
+        )
+        result = apply_wikilinks("contact @karpathy for details", index)
+        assert "[[karpathy]]" in result.text
+        assert result.n_replaced == 1
+
+    def test_skips_inside_code_block(self):
+        index = _build_index(_alias("karpathy", "karpathy"))
+        text = (
+            "before karpathy\n"
+            "```\n"
+            "karpathy\n"
+            "```\n"
+            "after karpathy"
+        )
+        result = apply_wikilinks(text, index)
+        # Two replacements (before + after); the one inside ```...``` stays.
+        assert result.n_replaced == 2
+        assert "```\nkarpathy\n```" in result.text
+
+    def test_skips_inside_existing_wikilink(self):
+        index = _build_index(_alias("karpathy", "karpathy"))
+        text = "[[karpathy]] and karpathy"
+        result = apply_wikilinks(text, index)
+        # First occurrence stays (already linked), second gets linked.
+        assert result.n_replaced == 1
+        assert result.text == "[[karpathy]] and [[karpathy]]"
+
+    def test_skips_frontmatter(self):
+        index = _build_index(_alias("karpathy", "karpathy"))
+        text = "---\nslug: foo\nauthor: karpathy\n---\nbody karpathy"
+        result = apply_wikilinks(text, index)
+        # Replacement only happens in body.
+        assert result.n_replaced == 1
+        # Frontmatter "karpathy" is intact.
+        assert "author: karpathy" in result.text
+
+    def test_skips_existing_markdown_link(self):
+        index = _build_index(_alias("karpathy", "karpathy"))
+        text = "see [profile](https://x.com/karpathy) and karpathy"
+        result = apply_wikilinks(text, index)
+        # Markdown link untouched; bare "karpathy" linked.
+        assert "[profile](https://x.com/karpathy)" in result.text
+        assert result.n_replaced == 1
+
+    def test_idempotent(self):
+        # Running twice on the same input == running once.
+        index = _build_index(
+            _alias("karpathy", "karpathy"),
+            _alias("karpathy", "andrej karpathy", kind=KIND_DISPLAY_NAME),
+        )
+        original = "Andrej Karpathy and karpathy walked into a bar."
+        once = apply_wikilinks(original, index).text
+        twice = apply_wikilinks(once, index).text
+        assert once == twice
+
+    def test_empty_index_is_no_op(self):
+        result = apply_wikilinks("karpathy", {})
+        assert result.n_replaced == 0
+        assert result.text == "karpathy"
+
+    def test_display_name_filtered_by_default(self):
+        # The bug from the real-vault smoke run: a github_user with
+        # canonical_name "Image" auto-derives a display_name alias
+        # of "image" that would link every occurrence of the
+        # English word.  Default behavior MUST exclude display_names.
+        from ovp_pipeline.entities.aliases import KIND_DISPLAY_NAME
+
+        index = _build_index(
+            _alias("image1", "image1"),
+            _alias("image1", "image", kind=KIND_DISPLAY_NAME),
+        )
+        result = apply_wikilinks("see image generation wrapper", index)
+        # The English word stays untouched.
+        assert "[[image" not in result.text
+        assert result.text == "see image generation wrapper"
+
+    def test_display_name_opt_in_via_kinds(self):
+        # When the caller explicitly opts in to display_name linking,
+        # the rewrite happens.
+        from ovp_pipeline.entities.aliases import (
+            KIND_DISPLAY_NAME,
+            KIND_PRIMARY,
+        )
+
+        index = _build_index(
+            _alias("image1", "image1"),
+            _alias("image1", "image", kind=KIND_DISPLAY_NAME),
+        )
+        result = apply_wikilinks(
+            "see image generation wrapper", index,
+            kinds=frozenset({KIND_PRIMARY, KIND_DISPLAY_NAME}),
+        )
+        assert "[[image1|image]]" in result.text
+
+    def test_short_alias_filtered_by_min_length(self):
+        # "ai" is 2 chars — below the default min_length of 3.  Even
+        # if it's a real entity, auto-linking would corrupt every
+        # English mention of "AI".
+        index = _build_index(_alias("openai", "ai"))
+        result = apply_wikilinks("the ai industry boomed", index)
+        assert "[[" not in result.text
+
+    def test_min_length_can_be_overridden(self):
+        index = _build_index(_alias("openai", "ai"))
+        result = apply_wikilinks(
+            "the ai industry boomed", index, min_length=2,
+        )
+        # Lowering the floor lets the 2-char alias through.
+        assert result.n_replaced == 1
+
+    def test_cjk_alias_roundtrips(self):
+        # CJK alias as an explicit_alias (e.g., from authors.jsonl
+        # ``aliases: ["歸藏"]``) — must match correctly even though
+        # the prose has no whitespace boundary in the Western sense.
+        # Curated explicit_alias is on the safe-by-default kinds list.
+        from ovp_pipeline.entities.aliases import KIND_EXPLICIT_ALIAS
+
+        index = _build_index(
+            _alias("op7418", "op7418"),
+            _alias("op7418", "歸藏", kind=KIND_EXPLICIT_ALIAS),
+        )
+        result = apply_wikilinks("歸藏 写过这个", index)
+        assert "[[op7418|歸藏]]" in result.text
+        assert result.n_replaced == 1
+
+
+# ---------------------------------------------------------------------------
+# Stub generation
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureEntityStubFiles:
+    def test_creates_stub_for_missing_canonical(self, tmp_path):
+        rep = {
+            "karpathy": _alias("karpathy", "karpathy"),
+        }
+        created = ensure_entity_stub_files(tmp_path, rep)
+        assert len(created) == 1
+        body = created[0].read_text(encoding="utf-8")
+        assert "slug: karpathy" in body
+        assert "entity_type: person" in body
+        assert "stub: true" in body
+        assert "ovp-link-entities" in body
+
+    def test_does_not_overwrite_existing(self, tmp_path):
+        # Pre-create a curated entity page; the stub generator must
+        # NOT touch it (would silently overwrite the user's content).
+        entity_dir = tmp_path / "10-Knowledge" / "Entity"
+        entity_dir.mkdir(parents=True)
+        existing = entity_dir / "karpathy.md"
+        existing.write_text("CURATED CONTENT — DO NOT TOUCH", encoding="utf-8")
+
+        rep = {"karpathy": _alias("karpathy", "karpathy")}
+        created = ensure_entity_stub_files(tmp_path, rep)
+        assert created == []
+        # Existing content untouched.
+        assert existing.read_text(encoding="utf-8") == "CURATED CONTENT — DO NOT TOUCH"
+
+    def test_dry_run_does_not_write(self, tmp_path):
+        rep = {"karpathy": _alias("karpathy", "karpathy")}
+        created = ensure_entity_stub_files(tmp_path, rep, dry_run=True)
+        # Reports the path but doesn't create it.
+        assert len(created) == 1
+        assert not created[0].exists()
+
+    def test_renders_authority_when_present(self, tmp_path):
+        rep = {"karpathy": _alias("karpathy", "karpathy", authority=0.65)}
+        ensure_entity_stub_files(tmp_path, rep)
+        body = (tmp_path / "10-Knowledge" / "Entity" / "karpathy.md").read_text(
+            encoding="utf-8",
+        )
+        assert "authority: 0.65" in body
+
+    def test_omits_authority_when_none(self, tmp_path):
+        rep = {"foo": EntityAlias(
+            canonical_handle="foo", canonical_entity_type="whitelist",
+            alias="foo", alias_kind=KIND_PRIMARY, authority=None,
+            source=SOURCE_WHITELIST_JSONL,
+        )}
+        ensure_entity_stub_files(tmp_path, rep)
+        body = (tmp_path / "10-Knowledge" / "Entity" / "foo.md").read_text(
+            encoding="utf-8",
+        )
+        assert "authority:" not in body

--- a/tests/test_wikilink.py
+++ b/tests/test_wikilink.py
@@ -348,3 +348,58 @@ class TestEnsureEntityStubFiles:
             encoding="utf-8",
         )
         assert "authority:" not in body
+
+
+class TestPreparedMatcher:
+    """PR-128 review-fix invariant: ``prepare_matcher`` builds the
+    filter + compiled regex ONCE; ``apply_prepared_matcher`` reuses
+    them for batch runs.  Pre-fix the CLI's per-file ``apply_wikilinks``
+    re-did both on every iteration."""
+
+    def test_prepared_matcher_is_reusable(self):
+        from ovp_pipeline.entities.wikilink import (
+            PreparedMatcher,
+            apply_prepared_matcher,
+            prepare_matcher,
+        )
+
+        index = _build_index(_alias("karpathy", "karpathy"))
+        matcher = prepare_matcher(index)
+        assert isinstance(matcher, PreparedMatcher)
+        first = apply_prepared_matcher("see karpathy", matcher)
+        second = apply_prepared_matcher("karpathy again", matcher)
+        assert first.n_replaced == 1
+        assert second.n_replaced == 1
+
+    def test_prepared_matcher_filters_match_apply_wikilinks(self):
+        # Behavioral parity: prepare_matcher + apply_prepared_matcher
+        # must produce identical output to the one-shot apply_wikilinks
+        # path (otherwise batch callers diverge from interactive ones).
+        from ovp_pipeline.entities.aliases import KIND_DISPLAY_NAME
+        from ovp_pipeline.entities.wikilink import (
+            apply_prepared_matcher,
+            apply_wikilinks,
+            prepare_matcher,
+        )
+
+        index = _build_index(
+            _alias("karpathy", "karpathy"),
+            _alias("image1", "image", kind=KIND_DISPLAY_NAME),
+        )
+        text = "see karpathy and image processing"
+        one_shot = apply_wikilinks(text, index)
+        matcher = prepare_matcher(index)
+        batched = apply_prepared_matcher(text, matcher)
+        assert one_shot.text == batched.text
+        assert one_shot.n_replaced == batched.n_replaced
+
+    def test_empty_index_yields_empty_matcher(self):
+        from ovp_pipeline.entities.wikilink import (
+            apply_prepared_matcher,
+            prepare_matcher,
+        )
+
+        matcher = prepare_matcher({})
+        result = apply_prepared_matcher("any text", matcher)
+        assert result.n_replaced == 0
+        assert result.text == "any text"


### PR DESCRIPTION
## Summary

**PR-G3** — final slice of M12.  Closes the loop from PR-G1's \`entity_aliases\` view to actual \`[[canonical]]\` Obsidian wikilinks in evergreen prose, plus stub generation for canonicals that don't have a markdown page yet.

Stacked on **PR-G2 (#127)** — base set to \`feat/entity-extraction-prime\` so the diff shows only the G3 work.

## What changes

New module \`entities/wikilink.py\`:
- \`apply_wikilinks(text, alias_index, *, kinds, min_length)\` — rewrites markdown text, returns \`WikilinkResult(text, n_replaced, canonicals_used)\`
- \`ensure_entity_stub_files(vault_dir, canonicals)\` — creates \`10-Knowledge/Entity/<handle>.md\` stubs for canonicals without a page

New CLI \`ovp-link-entities\`:
\`\`\`
ovp-link-entities --vault-dir ~/Documents/ovp-vault                # apply
ovp-link-entities --vault-dir ~/Documents/ovp-vault --dry-run      # preview
ovp-link-entities --vault-dir ~/Documents/ovp-vault --scan-dir 20-Areas
ovp-link-entities --vault-dir ~/Documents/ovp-vault --no-stubs
ovp-link-entities --vault-dir ~/Documents/ovp-vault --include-display-names
ovp-link-entities --vault-dir ~/Documents/ovp-vault --min-alias-length 4
\`\`\`

## Skip regions

The replacer **never** touches:
- frontmatter (\`---...---\`)
- fenced code blocks (\`\`\`\`\`\`...\`\`\`\`\`\`)
- inline code (\`\`...\`\`)
- existing wikilinks \`[[...]]\` (idempotent re-runs)
- existing markdown links \`[text](url)\`

## Match semantics

| Surface form | Wikilink form | Why |
|---|---|---|
| \`karpathy\` | \`[[karpathy]]\` | matched text == canonical, terse |
| \`Andrej Karpathy\` | \`[[karpathy\\|Andrej Karpathy]]\` | preserves prose surface |
| \`@karpathy\` | \`[[karpathy]]\` | @-handle normalizes to bare; collapses to short form for idempotency |

CJK aliases (\`歸藏\` / \`姚金刚\`) round-trip cleanly via Python's default \`re.UNICODE\` semantics.

## Precision filters (the real-vault story)

Smoke run on 26 Clippings initially produced **878 wikilinks** with several junk patterns:

\`\`\`
"image generation"  → "[[image1|image]] generation"   ❌
"the AI industry"   → "the [[ai industry]]"           ❌
"chroma key"        → "[[chroma]] key"                ⚠
"mention skill"     → "[[mention]] skill"             ❌
\`\`\`

Two filters cut this to **378 wikilinks** with mostly correct hits:

1. **Default-exclude \`KIND_DISPLAY_NAME\`** — auto-derived display names like \`Image\` (canonical_name of github_user \`image1\`) trip on common English words.  Users opt in via \`--include-display-names\`.
2. **Min alias length 3 with CJK escape hatch** — kills \`ai\` / \`ml\` 2-char ASCII bigrams while letting \`歸藏\` / \`姚金刚\` through (non-ASCII chars carry more entropy per char).

Remaining false positives like \`mention\` / \`xxx\` / \`chroma\` are real entities with generic-word handles — the right fix is an entity-table audit pass, not more code-side filtering.  Users can vet via \`--dry-run\` before applying.

## Stub generation

For each canonical that gets at least one wikilink, ensures \`10-Knowledge/Entity/<canonical>.md\` exists with minimal frontmatter:

\`\`\`yaml
---
slug: karpathy
entity_type: person
canonical_handle: karpathy
authority: 0.6500
stub: true
created_by: "ovp-link-entities"
tags: [entity, stub]
---
\`\`\`

NEVER overwrites an existing curated entity page.

## Test plan

- [x] Skip regions: frontmatter / fenced code / inline / existing wikilink / existing md link
- [x] Pattern: empty index / left-boundary (\`foo@karpathy\` ≠ \`karpathy\`) / right-boundary (\`karpathys\` ≠ \`karpathy\`) / longest-match-wins
- [x] Replacement: short form / pipe form / @-collapse / skip-in-code / skip-in-wikilink / skip-in-frontmatter / skip-in-md-link / idempotent / empty-index / CJK roundtrip
- [x] Filters: display_name excluded by default / display_name opt-in / 2-char ASCII filtered / min_length override
- [x] Stubs: created when missing / does NOT overwrite / dry-run no-op / authority rendered / authority omitted when None
- [x] Full suite: **1877 passed**, lint clean
- [x] Real-vault dry-run: 26 files → 378 wikilinks (down from 878 pre-filter)

## Stack

- #126 PR-G1 — entity_aliases view (BL-038)
- #127 PR-G2 — extraction-time prime (BL-039)
- **This PR (PR-G3)** — auto-wikilink (BL-040)
- After this lands: M13 Crystal layer (BL-041..BL-044)