### PR TITLE
fix(entities): M12 review-pass — path escape, CJK boundary, collision logging, docs

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -30,10 +30,10 @@ Rule: historical plans and vault research notes feed this file; they do not over
 | M9 Pack As Domain Ontology | Next | pack-defined object kind specs, typed relation constraints, schema registry, domain-specific extraction profiles |
 | M10 Operational Knowledge Layer | Later | action types on objects, permission + contract, cross-entity aggregation, decision memory |
 | M11 Source Authority And Cross-Source Identity | Done | typed source-authority providers, entity layer, runtime resolver, refresh wrapper, db backup (PRs #112–#124) |
-| M12 Extraction-Time Entity Prime And Auto-Wikilink | Next | entity_aliases view, LLM extractor primed with known entities, automatic wikilink generation (BL-038/039/040) |
+| M12 Extraction-Time Entity Prime And Auto-Wikilink | Done | entity_aliases view, LLM extractor primed with known entities, auto-wikilink CLI (BL-038/039/040, PRs #126–#128) |
 | M13 Synthesis Layer (Crystal) | Next | Louvain communities + LLM-synthesized crystals + contradiction crystals + append-only versioning (BL-041/042/043/044) |
 
-## Recently Shipped (PRs #98–#124)
+## Recently Shipped (PRs #98–#128)
 
 | PR | What shipped |
 | --- | --- |
@@ -55,6 +55,9 @@ Rule: historical plans and vault research notes feed this file; they do not over
 | #122 | `ovp-refresh-source-authority` chained entity refresh + launchd plist (PR-E5) |
 | #123 | `person` → `person + organization` split (PR-F1) — 54 → 37 person + 17 organization on real vault |
 | #124 | 12 entity-layer review fixes: read-side write side effects, identity merge backlinks, lock-steal race, append-only history, excluded-host signal, GitHub bare profile URLs, source_coverage entity-aware unknowns, score_sources --domains-only honors overrides |
+| #126 | `entity_aliases` view + `ovp-entity-aliases` CLI (BL-038, M12): unified read surface across authors.jsonl, author_overrides.yaml, entities table, github_user back-link |
+| #127 | Extraction-time entity prime in `auto_evergreen_extractor` (BL-039, M12): top-N canonicals injected into LLM user prompt so name variants collapse to one handle |
+| #128 | `ovp-link-entities` auto-wikilink CLI (BL-040, M12): scans evergreen prose, inserts `[[canonical_handle]]`, generates `10-Knowledge/Entity/<handle>.md` stubs; PreparedMatcher for batch reuse |
 
 ## Active Backlog
 
@@ -81,9 +84,9 @@ Rule: historical plans and vault research notes feed this file; they do not over
 | BL-035 | P1 | Later | Action types on objects: typed operations (review, decide, verify) with preconditions, postconditions, audit trail | M10 |
 | BL-036 | P2 | Later | Cross-entity aggregation: typed-mention index, property aggregation by kind | M10 |
 | BL-037 | P1 | Next | Body-level semantic dedup: use page_embeddings cosine similarity to detect paraphrastic clones (same concept, different slug names); slug-trigram-Jaccard cannot reach these | M5b, OVP_FIX_PLAN |
-| BL-038 | P0 | Next | entity_aliases view: union of `(canonical_handle, alias)` pairs from authors.jsonl + author_overrides.yaml + entities.{twitter_author,person,organization,github_user}.signals.aliases. Single read surface for the next two items. | M12 |
-| BL-039 | P0 | Next | Extraction-time entity prime: feed top-N entity_aliases entries into the auto_evergreen_extractor system prompt; LLM is told "if you see these, use the canonical handle, don't invent a new one". Resolves Karpathy / Andrej / @karpathy / 安德烈 → one entity. | M12 |
-| BL-040 | P1 | Next | Auto-wikilink: scan evergreen body for entity_aliases hits; auto-insert `[[canonical_handle]]` wikilinks; generate `10-Knowledge/Entity/<handle>.md` stubs for canonical entities that don't have a markdown page yet. | M12 |
+| BL-038 | P0 | Done | entity_aliases view + `ovp-entity-aliases` CLI (PR #126). Single read surface for BL-039/040. | M12 |
+| BL-039 | P0 | Done | Extraction-time entity prime in `auto_evergreen_extractor` (PR #127). Top-N entity_aliases injected into the LLM user prompt so name variants resolve to one canonical handle. | M12 |
+| BL-040 | P1 | Done | `ovp-link-entities` auto-wikilink CLI (PR #128). Walks `10-Knowledge/Evergreen/`, replaces alias hits with `[[canonical_handle]]`, generates `10-Knowledge/Entity/<handle>.md` stubs. | M12 |
 | BL-041 | P1 | Next | Louvain community detection over `relations` graph — replaces (or augments) the current 312 mechanical `graph_clusters` with semantically-meaningful communities. Closes the gap with NM 0.8's 41 communities. | M13 |
 | BL-042 | P0 | Next | Crystal MVP — for each Louvain community: pick top-K evergreens by authority, LLM-synthesize a single crystal markdown (frontmatter + body) into `40-Resources/Crystals/<community>.md`, persist lineage in a `crystals` table (community_id, source_evergreen_slugs, synthesized_at, llm_model, prompt_version). MiniMax-M2.7-highspeed for cost. | M13 |
 | BL-043 | P1 | Next | Contradiction crystals — for every cluster of evergreens flagged in the existing `contradictions` table, synthesize an "open question" crystal that lays out the X-vs-Y positions explicitly. Cheap LLM cost; very high signal. | M13 |

--- a/MILESTONE.md
+++ b/MILESTONE.md
@@ -48,7 +48,7 @@ Three target tiers:
 | **M9 Pack As Domain Ontology** | **Next** | pack-defined object kind specs, typed relation constraints, schema registry, domain-specific extraction profiles |
 | **M10 Operational Knowledge Layer** | **Later** | action types on objects, permission + contract, cross-entity aggregation, decision memory |
 | **M11 Source Authority And Cross-Source Identity** | **Done** | typed source-authority providers (D1/D2/D3), entity layer (twitter_author / github_project / github_user / person / organization), runtime resolver, refresh wrapper, db backup (PRs #112–#124) |
-| **M12 Extraction-Time Entity Prime And Auto-Wikilink** | **Next** | entity_aliases view, LLM extractor primed with known entities, automatic wikilink generation in evergreen body — closes the loop from "we know who Karpathy is" to "the next ingest run uses that knowledge" (BL-038, BL-039, BL-040) |
+| **M12 Extraction-Time Entity Prime And Auto-Wikilink** | **Done** | entity_aliases view (PR #126), LLM extractor primed with known entities (PR #127), `ovp-link-entities` auto-wikilink CLI (PR #128) — closes the loop from "we know who Karpathy is" to "the next ingest run uses that knowledge" (BL-038, BL-039, BL-040) |
 | **M13 Synthesis Layer (Crystal)** | **Next** | Louvain community detection over relations graph, LLM-synthesized crystals persisted to `40-Resources/Crystals/` with explicit lineage, contradiction crystals, append-only versioning — closes the gap with NM 0.8's synthesis tier (BL-041, BL-042, BL-043, BL-044) |
 
 ## Active Backlog Alignment

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Current milestone sequence:
 | M9 Pack As Domain Ontology | Next | pack-defined object kind specs, typed relation constraints, schema registry |
 | M10 Operational Knowledge Layer | Later | action types, permissions, cross-entity aggregation, decision memory |
 | M11 Source Authority And Cross-Source Identity | Done | typed source-authority providers, entity layer (twitter_author / github_project / github_user / person / organization), runtime resolver, refresh wrapper, db backup (PRs #112–#124) |
-| M12 Extraction-Time Entity Prime And Auto-Wikilink | Next | entity_aliases view, LLM extractor primed with known entities, auto-wikilink — the loop closer for the entity work shipped in M11 |
+| M12 Extraction-Time Entity Prime And Auto-Wikilink | Done | entity_aliases view, LLM extractor primed with known entities, auto-wikilink CLI (PRs #126–#128) |
 | M13 Synthesis Layer (Crystal) | Next | Louvain communities + LLM-synthesized crystals + contradiction crystals + append-only versioning (closes the L3 gap with NM 0.8) |
 
 Recent major changes (PRs #98–#124):

--- a/src/ovp_pipeline/entities/aliases.py
+++ b/src/ovp_pipeline/entities/aliases.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -73,6 +74,24 @@ _LOG_TRUNCATION_CHARS = 80
 # Fallback precedence rank when a source label isn't in the table.
 # Higher than every real entry so unknown sources lose ties cleanly.
 _FALLBACK_PRECEDENCE = 99
+
+# Allowlist for canonical_handle.  The handle is used as a markdown
+# filename (`10-Knowledge/Entity/<handle>.md`) AND as a wikilink
+# target (`[[<handle>]]`), so it must be safe in both contexts.
+# Reject anything that could escape the entity stub directory or
+# break wikilink syntax: `/`, `\`, `..`, `|`, `[`, `]`, `#`, whitespace.
+# Real handles (twitter / github / curated whitelist) all fit this
+# pattern; rejecting outliers is a feature, not a regression.
+_CANONICAL_SLUG_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_.-]*$")
+_CANONICAL_SLUG_MAX_LEN = 64
+
+
+def _is_safe_canonical_slug(s: str) -> bool:
+    if not s or len(s) > _CANONICAL_SLUG_MAX_LEN:
+        return False
+    if ".." in s:
+        return False
+    return bool(_CANONICAL_SLUG_RE.match(s))
 
 
 @dataclass(frozen=True, slots=True)
@@ -365,7 +384,24 @@ def collect_entity_aliases(
     out.extend(_load_jsonl_whitelist(authors_jsonl))
     out.extend(_load_yaml_overrides(author_overrides_yaml))
     out.extend(_load_entities(entity_store))
-    return out
+
+    # Drop rows whose canonical_handle would be unsafe to use as a
+    # filename or wikilink target.  We log dropped handles once each
+    # so an operator with a malformed authors.jsonl can spot it.
+    safe: list[EntityAlias] = []
+    rejected_handles: set[str] = set()
+    for row in out:
+        if _is_safe_canonical_slug(row.canonical_handle):
+            safe.append(row)
+            continue
+        if row.canonical_handle not in rejected_handles:
+            logger.warning(
+                "rejecting canonical_handle %r from %s: not a safe "
+                "filename/wikilink slug",
+                row.canonical_handle, row.source,
+            )
+            rejected_handles.add(row.canonical_handle)
+    return safe
 
 
 # Precedence for collision resolution: lower number = higher priority.
@@ -408,15 +444,20 @@ def build_alias_index(aliases: list[EntityAlias]) -> dict[str, EntityAlias]:
         if existing is None:
             by_alias[a.alias] = a
             continue
+        # Log every divergent canonical, regardless of which row wins.
+        # Pre-fix the warning only fired on replacement — a curated
+        # JSONL handle that beat a conflicting entity row was
+        # silently accepted, hiding a real ambiguity from operators.
+        if a.canonical_handle != existing.canonical_handle:
+            winner = a if _precedence(a) < _precedence(existing) else existing
+            logger.warning(
+                "alias %r resolves ambiguously: %s (%s, auth=%s) vs "
+                "%s (%s, auth=%s) — using %s",
+                a.alias,
+                a.canonical_handle, a.source, a.authority,
+                existing.canonical_handle, existing.source, existing.authority,
+                winner.canonical_handle,
+            )
         if _precedence(a) < _precedence(existing):
-            if a.canonical_handle != existing.canonical_handle:
-                logger.warning(
-                    "alias %r resolves ambiguously: %s (%s, auth=%s) vs "
-                    "%s (%s, auth=%s) — using %s",
-                    a.alias,
-                    a.canonical_handle, a.source, a.authority,
-                    existing.canonical_handle, existing.source, existing.authority,
-                    a.canonical_handle,
-                )
             by_alias[a.alias] = a
     return by_alias

--- a/src/ovp_pipeline/entities/wikilink.py
+++ b/src/ovp_pipeline/entities/wikilink.py
@@ -42,6 +42,7 @@ display names like ``歸藏`` and ``姚金刚`` round-trip cleanly.
 
 from __future__ import annotations
 
+import logging
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -53,6 +54,8 @@ from .aliases import (
     KIND_PRIMARY,
     EntityAlias,
 )
+
+logger = logging.getLogger(__name__)
 
 
 # Which alias_kinds are safe to auto-link.  ``KIND_DISPLAY_NAME`` is
@@ -148,18 +151,29 @@ def _is_in_skip(pos: int, skip: list[tuple[int, int]]) -> bool:
 # ---------------------------------------------------------------------------
 
 
+def _is_ascii(s: str) -> bool:
+    return all(ord(c) < 128 for c in s)
+
+
 def build_alias_pattern(alias_index: dict[str, EntityAlias]) -> re.Pattern[str]:
     """Compile a single regex covering every alias.
 
     Sorted longest-first so the regex engine's left-to-right
     alternation prefers the most specific match.  Word-boundary
-    behavior:
+    behaviour is split by alias script:
 
-      * left side — must NOT be preceded by a word character or ``@``
-        (so ``foo@karpathy`` doesn't match ``karpathy``, but
-        ``@karpathy`` standalone does)
-      * right side — must NOT be followed by a word character (so
-        ``karpathys`` doesn't match ``karpathy``)
+      * **ASCII aliases** — Unicode-aware ``\\w`` boundary on both sides.
+        ``foo@karpathy`` doesn't match ``karpathy`` (left side is
+        a word char), ``karpathys`` doesn't match ``karpathy``
+        (right side is a word char).
+
+      * **CJK / non-ASCII aliases** — ASCII-only boundary on both
+        sides.  Python's ``\\w`` treats CJK letters as word chars,
+        which would block the common case of CJK prose where the
+        alias has no whitespace neighbours (``我觉得歸藏写过这个``
+        — ``得`` is ``\\w``, so ``(?<!\\w)`` would fail).  The
+        ASCII-only boundary still rejects ``karpathy歸藏`` (``y``
+        is ASCII alpha) but accepts the natural CJK case.
 
     Returns a sentinel regex that never matches (alternation of
     nothing) when the index is empty.
@@ -167,11 +181,22 @@ def build_alias_pattern(alias_index: dict[str, EntityAlias]) -> re.Pattern[str]:
     if not alias_index:
         return re.compile(r"(?!x)x")        # never matches
     parts = sorted(alias_index.keys(), key=len, reverse=True)
-    escaped = [re.escape(p) for p in parts]
-    pattern = (
-        r"(?<![\w@])(?:" + "|".join(escaped) + r")(?!\w)"
-    )
-    return re.compile(pattern, re.IGNORECASE)
+    ascii_parts = [p for p in parts if _is_ascii(p)]
+    cjk_parts = [p for p in parts if not _is_ascii(p)]
+    branches: list[str] = []
+    if ascii_parts:
+        branches.append(
+            r"(?<![\w@])(?:"
+            + "|".join(re.escape(p) for p in ascii_parts)
+            + r")(?!\w)"
+        )
+    if cjk_parts:
+        branches.append(
+            r"(?<![A-Za-z0-9_@])(?:"
+            + "|".join(re.escape(p) for p in cjk_parts)
+            + r")(?![A-Za-z0-9_])"
+        )
+    return re.compile("|".join(branches), re.IGNORECASE)
 
 
 def _normalize_for_lookup(matched: str) -> str:
@@ -368,9 +393,25 @@ def ensure_entity_stub_files(
     entity_dir = vault_dir / _ENTITY_STUB_DIR
     if not dry_run:
         entity_dir.mkdir(parents=True, exist_ok=True)
+    # Resolve once for the path-escape guard below.  ``parents=True``
+    # makes mkdir succeed even if the dir already exists; resolve()
+    # on a missing dir works on every platform we ship to.
+    entity_dir_resolved = entity_dir.resolve()
     created: list[Path] = []
     for canonical, alias in canonicals.items():
         path = entity_dir / f"{canonical}.md"
+        # Defense in depth: collect_entity_aliases already filters
+        # canonical_handle through a slug allowlist, but if a future
+        # caller wires this function up with a different source we
+        # still refuse to write outside the entity stub directory.
+        try:
+            path.resolve().relative_to(entity_dir_resolved)
+        except ValueError:
+            logger.warning(
+                "refusing to write entity stub outside %s: canonical=%r",
+                entity_dir_resolved, canonical,
+            )
+            continue
         if path.exists():
             continue
         created.append(path)

--- a/tests/test_entity_aliases.py
+++ b/tests/test_entity_aliases.py
@@ -371,6 +371,125 @@ class TestBuildAliasIndex:
 # ---------------------------------------------------------------------------
 
 
+class TestCanonicalSlugSafety:
+    """The canonical_handle becomes both a markdown filename
+    (``10-Knowledge/Entity/<handle>.md``) and a wikilink target
+    (``[[<handle>]]``).  An attacker-controlled or malformed
+    authors.jsonl could otherwise inject path-traversal or break
+    wikilink syntax.  ``collect_entity_aliases`` filters out
+    unsafe handles at the boundary."""
+
+    def test_drops_path_traversal_canonical(self, tmp_path):
+        jsonl = tmp_path / "60-Logs" / "authors.jsonl"
+        _write_jsonl(
+            jsonl,
+            {"handle": "../../../etc/passwd", "authority": 0.9},
+            {"handle": "karpathy", "authority": 0.95},
+        )
+        out = collect_entity_aliases(
+            vault_dir=tmp_path,
+            entity_store=EntityStore(
+                db_path=tmp_path / "60-Logs" / "knowledge.db",
+            ),
+            authors_jsonl=jsonl,
+            author_overrides_yaml=tmp_path / "missing.yaml",
+        )
+        canonicals = {a.canonical_handle for a in out}
+        assert "karpathy" in canonicals
+        # The malicious handle is gone — would have escaped the
+        # entity stub directory if used as `<canonical>.md`.
+        assert "../../../etc/passwd" not in canonicals
+
+    def test_drops_wikilink_breaking_chars(self, tmp_path):
+        # `|`, `[`, `]`, `#`, `/` would break wikilink rendering
+        # (`[[handle]]`) or yield ambiguous filenames.
+        jsonl = tmp_path / "60-Logs" / "authors.jsonl"
+        _write_jsonl(
+            jsonl,
+            {"handle": "evil|alias"},
+            {"handle": "evil[name]"},
+            {"handle": "ev/il"},
+            {"handle": "evil#anchor"},
+            {"handle": "valid_one"},
+        )
+        out = collect_entity_aliases(
+            vault_dir=tmp_path,
+            entity_store=EntityStore(
+                db_path=tmp_path / "60-Logs" / "knowledge.db",
+            ),
+            authors_jsonl=jsonl,
+            author_overrides_yaml=tmp_path / "missing.yaml",
+        )
+        canonicals = {a.canonical_handle for a in out}
+        assert canonicals == {"valid_one"}
+
+    def test_accepts_real_world_handle_shapes(self, tmp_path):
+        # Twitter handles are alnum + underscore; github logins can
+        # carry hyphens; curated whitelist allows '.' (e.g.
+        # ``simon.willison``).  All must pass.
+        jsonl = tmp_path / "60-Logs" / "authors.jsonl"
+        _write_jsonl(
+            jsonl,
+            {"handle": "karpathy"},
+            {"handle": "op7418"},
+            {"handle": "simon-willison"},
+            {"handle": "simon.willison"},
+            {"handle": "user_name"},
+        )
+        out = collect_entity_aliases(
+            vault_dir=tmp_path,
+            entity_store=EntityStore(
+                db_path=tmp_path / "60-Logs" / "knowledge.db",
+            ),
+            authors_jsonl=jsonl,
+            author_overrides_yaml=tmp_path / "missing.yaml",
+        )
+        canonicals = {a.canonical_handle for a in out}
+        assert {"karpathy", "op7418", "simon-willison",
+                "simon.willison", "user_name"} <= canonicals
+
+
+class TestBuildAliasIndexCollisionLogging:
+    """The ambiguity warning must fire whenever two sources disagree
+    on canonical_handle for the same alias, regardless of which row
+    wins.  Pre-fix the warning only fired on replacement — a curated
+    JSONL handle that beat a conflicting entity row was silently
+    accepted, hiding the conflict from operators."""
+
+    def test_logs_when_winner_already_set(self, tmp_path, caplog):
+        import logging
+
+        # Order matters: a higher-precedence row is added FIRST so the
+        # later (lower-precedence) row never replaces it.  Pre-fix
+        # the warning was inside the replacement branch and never
+        # fired in this scenario.
+        from ovp_pipeline.entities.aliases import EntityAlias
+
+        rows = [
+            EntityAlias(
+                canonical_handle="winner",
+                canonical_entity_type="whitelist",
+                alias="shared", alias_kind=KIND_PRIMARY,
+                authority=0.9, source=SOURCE_WHITELIST_YAML,
+            ),
+            EntityAlias(
+                canonical_handle="loser",
+                canonical_entity_type="twitter_author",
+                alias="shared", alias_kind=KIND_PRIMARY,
+                authority=0.8, source=SOURCE_ENTITY_TWITTER,
+            ),
+        ]
+        with caplog.at_level(logging.WARNING,
+                             logger="ovp_pipeline.entities.aliases"):
+            index = build_alias_index(rows)
+        # Winner (yaml) is kept.
+        assert index["shared"].canonical_handle == "winner"
+        # Warning fired once with both sides + the winner identified.
+        msgs = [r.getMessage() for r in caplog.records]
+        assert any("ambiguously" in m and "winner" in m and "loser" in m
+                   for m in msgs)
+
+
 class TestEndToEnd:
     def test_full_union_includes_all_four_sources(self, tmp_path):
         # JSONL

--- a/tests/test_wikilink.py
+++ b/tests/test_wikilink.py
@@ -289,6 +289,51 @@ class TestApplyWikilinks:
         assert "[[op7418|歸藏]]" in result.text
         assert result.n_replaced == 1
 
+    def test_cjk_alias_matches_inside_cjk_prose(self):
+        # CJK prose has no whitespace boundary — Python's ``\w`` would
+        # treat ``得`` as a word char, blocking the match.  The
+        # CJK-specific ASCII-only boundary lets these match.
+        from ovp_pipeline.entities.aliases import KIND_EXPLICIT_ALIAS
+
+        index = _build_index(
+            _alias("op7418", "op7418"),
+            _alias("op7418", "歸藏", kind=KIND_EXPLICIT_ALIAS),
+        )
+        # No whitespace before or after the alias.
+        r1 = apply_wikilinks("我觉得歸藏写过这个", index)
+        assert "[[op7418|歸藏]]" in r1.text
+        # Surrounded by other CJK chars.
+        r2 = apply_wikilinks("看到歸藏的文章", index)
+        assert "[[op7418|歸藏]]" in r2.text
+
+    def test_cjk_alias_blocked_by_ascii_word_char(self):
+        # A CJK alias next to an ASCII letter is still rejected — the
+        # ``user歸藏`` case is almost certainly NOT a mention of the
+        # entity.  The CJK boundary uses ASCII-only word chars on
+        # both sides for exactly this reason.
+        from ovp_pipeline.entities.aliases import KIND_EXPLICIT_ALIAS
+
+        index = _build_index(
+            _alias("op7418", "歸藏", kind=KIND_EXPLICIT_ALIAS),
+        )
+        result = apply_wikilinks("user歸藏 inline", index)
+        assert "[[" not in result.text
+        assert result.n_replaced == 0
+
+    def test_ascii_alias_still_blocks_plural(self):
+        # The CJK split must NOT regress the ASCII boundary — adding
+        # any CJK alias to the index shouldn't relax the ASCII rule.
+        from ovp_pipeline.entities.aliases import KIND_EXPLICIT_ALIAS
+
+        index = _build_index(
+            _alias("karpathy", "karpathy"),
+            _alias("op7418", "歸藏", kind=KIND_EXPLICIT_ALIAS),
+        )
+        # ``karpathys`` must NOT match ``karpathy``; both branches
+        # of the new alternation must compose correctly.
+        result = apply_wikilinks("the karpathys talk", index)
+        assert "[[" not in result.text
+
 
 # ---------------------------------------------------------------------------
 # Stub generation
@@ -348,6 +393,24 @@ class TestEnsureEntityStubFiles:
             encoding="utf-8",
         )
         assert "authority:" not in body
+
+    def test_refuses_to_write_outside_entity_dir(self, tmp_path):
+        # Defense-in-depth: collect_entity_aliases is the primary
+        # filter, but if a future caller wires ensure_entity_stub_files
+        # up with an unfiltered dict, a path-traversal canonical must
+        # still NOT escape the entity stub directory.
+        rep = {
+            "../../../escaped": _alias(
+                "../../../escaped", "escaped",
+            ),
+            "karpathy": _alias("karpathy", "karpathy"),
+        }
+        created = ensure_entity_stub_files(tmp_path, rep)
+        # Only the safe handle was written.
+        assert len(created) == 1
+        assert created[0].name == "karpathy.md"
+        # No file was created outside the entity stub dir.
+        assert not (tmp_path.parent.parent / "escaped.md").exists()
 
 
 class TestPreparedMatcher:


### PR DESCRIPTION
## Summary

Four review follow-ups on M12 (PRs #126-#128).

- **HIGH** — Path traversal in entity stub generation. `canonical_handle` flowed unfiltered from `authors.jsonl` / `author_overrides.yaml` / entities table into `entity_dir / f\"{canonical}.md\"`, so a handle like `../../../etc/passwd` would have written outside the vault. Two layers of defense: `collect_entity_aliases()` rejects unsafe slugs at the boundary; `ensure_entity_stub_files()` resolves every output path and refuses anything outside the entity stub directory.
- **MEDIUM** — CJK alias boundary. The single `(?<![\\w@])...(?!\\w)` pattern used Python's Unicode-aware `\\w`, so a CJK alias like `歸藏` only matched when surrounded by whitespace. Split the pattern into ASCII and CJK branches: ASCII keeps the existing `\\w` boundary (so `karpathys` still won't match `karpathy`); CJK uses an ASCII-only boundary that is transparent to CJK chars (`我觉得歸藏写过` now matches) but still rejects `user歸藏`.
- **LOW** — Collision logging only fired on replacement. When a higher-precedence row arrived first, a later row with a different `canonical_handle` was silently discarded. Move the warning out of the replacement branch so any divergent canonical produces one warning regardless of order.
- **Docs sync** — README, BACKLOG, MILESTONE now mark M12 as Done with PR #126/#127/#128 references.

## Test plan

- [x] 66 M12 tests pass (4 new test classes covering each fix)
- [x] ruff clean on `src/ovp_pipeline/entities/` and the touched test files
- [x] End-to-end smoke: a malicious `authors.jsonl` with `handle: '../../../etc/passwd'` is filtered out, only the legitimate row flows through, and the structured warning fires