### PR TITLE
feat(synthesis): --skip-existing for resumable crystal batches

### DIFF
--- a/src/ovp_pipeline/commands/synthesize_community_crystals.py
+++ b/src/ovp_pipeline/commands/synthesize_community_crystals.py
@@ -54,6 +54,13 @@ def main(argv: list[str] | None = None) -> int:
         help="Synthesize only the named cluster_id(s).  Can be repeated.",
     )
     parser.add_argument(
+        "--skip-existing", action="store_true",
+        help="Skip communities that already have at least one row in "
+             "the community_crystals table.  Use to resume a long "
+             "batch after interruption without re-paying LLM cost on "
+             "already-completed crystals.",
+    )
+    parser.add_argument(
         "--dry-run", action="store_true",
         help="Run the LLM and report what would be written, "
              "but skip the markdown + DB writes.",
@@ -96,6 +103,7 @@ def main(argv: list[str] | None = None) -> int:
         top_k=args.top_k,
         limit_communities=args.limit_communities,
         only_cluster_ids=only,
+        skip_existing=args.skip_existing,
         dry_run=args.dry_run,
     )
 

--- a/src/ovp_pipeline/commands/synthesize_contradiction_crystals.py
+++ b/src/ovp_pipeline/commands/synthesize_contradiction_crystals.py
@@ -48,6 +48,12 @@ def main(argv: list[str] | None = None) -> int:
         help="Synthesize only the named contradiction_id(s).  Can be repeated.",
     )
     parser.add_argument(
+        "--skip-existing", action="store_true",
+        help="Skip contradictions that already have at least one row "
+             "in the contradiction_crystals table.  Use to resume a "
+             "long batch after interruption.",
+    )
+    parser.add_argument(
         "--dry-run", action="store_true",
         help="Run the LLM and report what would be written, "
              "but skip the markdown + DB writes.",
@@ -89,6 +95,7 @@ def main(argv: list[str] | None = None) -> int:
         pack_name=args.pack,
         only_contradiction_ids=only,
         limit=args.limit,
+        skip_existing=args.skip_existing,
         dry_run=args.dry_run,
     )
 

--- a/src/ovp_pipeline/synthesis/community_crystal.py
+++ b/src/ovp_pipeline/synthesis/community_crystal.py
@@ -294,6 +294,7 @@ def synthesize_community_crystals(
     top_k: int = DEFAULT_TOP_K_EVERGREENS,
     limit_communities: int | None = None,
     only_cluster_ids: set[str] | None = None,
+    skip_existing: bool = False,
     dry_run: bool = False,
     llm_model_label: str = "anthropic/MiniMax-M2.7-highspeed",
     max_tokens: int = DEFAULT_MAX_TOKENS,
@@ -304,6 +305,13 @@ def synthesize_community_crystals(
     in dry-run).  Failures on a single community log a warning and
     skip — they don't sink the batch, which matters when the LLM
     occasionally times out on 1 of 30 communities.
+
+    ``skip_existing=True`` skips communities that already have at
+    least one row in ``community_crystals``.  Designed for resuming
+    a long batch after Ctrl-C / crash / network blip — re-running
+    with the flag picks up exactly where the prior run stopped
+    instead of synthesizing v2 of every already-completed crystal
+    (which would waste LLM budget).
     """
     crystal_dir = (vault_dir / CRYSTAL_DIR_REL).resolve()
     if not dry_run:
@@ -321,6 +329,21 @@ def synthesize_community_crystals(
             only_cluster_ids=only_cluster_ids,
             limit_communities=limit_communities,
         )
+
+        if skip_existing:
+            # One query for the set of cluster_ids that already have
+            # at least one row in community_crystals.  Filter the
+            # cluster list before any LLM cost is incurred.
+            existing = {
+                row[0] for row in conn.execute(
+                    "SELECT DISTINCT cluster_id FROM community_crystals "
+                    "WHERE pack = ?",
+                    (pack_name,),
+                )
+            }
+            cluster_rows = [
+                row for row in cluster_rows if row[0] not in existing
+            ]
 
         # Decode + cap members up front so we know the exact set of
         # object_ids the loop will consume.  That set drives the

--- a/src/ovp_pipeline/synthesis/contradiction_crystal.py
+++ b/src/ovp_pipeline/synthesis/contradiction_crystal.py
@@ -337,6 +337,7 @@ def synthesize_contradiction_crystals(
     pack_name: str = "research-tech",
     only_contradiction_ids: set[str] | None = None,
     limit: int | None = None,
+    skip_existing: bool = False,
     dry_run: bool = False,
     llm_model_label: str = "anthropic/MiniMax-M2.7-highspeed",
     max_tokens: int = DEFAULT_MAX_TOKENS,
@@ -349,6 +350,11 @@ def synthesize_contradiction_crystals(
     targeted objects subset, then reuses the same connection for
     per-row INSERTs (committed individually for incremental
     durability on long batches).
+
+    ``skip_existing=True`` skips contradictions that already have at
+    least one row in ``contradiction_crystals``.  Designed for
+    resuming a long batch after interruption — see the matching
+    note in ``community_crystal.synthesize_community_crystals``.
     """
     crystal_dir = (vault_dir / CRYSTAL_DIR_REL).resolve()
     if not dry_run:
@@ -361,6 +367,18 @@ def synthesize_contradiction_crystals(
             only_contradiction_ids=only_contradiction_ids,
             limit=limit,
         )
+
+        if skip_existing:
+            existing = {
+                row[0] for row in conn.execute(
+                    "SELECT DISTINCT contradiction_id "
+                    "FROM contradiction_crystals WHERE pack = ?",
+                    (pack_name,),
+                )
+            }
+            contradictions = [
+                c for c in contradictions if c[0] not in existing
+            ]
 
         # Decode every contradiction's claim IDs up front so we can
         # batch the claims + objects lookups.  Skipping malformed

--- a/tests/test_community_crystal.py
+++ b/tests/test_community_crystal.py
@@ -437,6 +437,44 @@ class TestSynthesizeEndToEnd:
         # LLM was not called — we short-circuit before constructing the prompt.
         assert llm.calls == []
 
+    def test_skip_existing_resumes_without_resynthesizing(self, tmp_path):
+        # Resume invariant: a long batch interrupted halfway must
+        # be re-runnable WITHOUT paying LLM cost on the communities
+        # already done.  ``--skip-existing`` filters those out
+        # before the LLM is called.
+        vault, db = _seed_vault(
+            tmp_path,
+            clusters=[
+                ("cluster::done01", "C1", ["a"]),
+                ("cluster::done02", "C2", ["b"]),
+                ("cluster::todo01", "C3", ["c"]),
+            ],
+            objects=[
+                ("a", "A", "body a"),
+                ("b", "B", "body b"),
+                ("c", "C", "body c"),
+            ],
+        )
+        # Pre-seed two communities as "already synthesized" via the
+        # public synthesis path.
+        llm = _StubLLM()
+        synthesize_community_crystals(
+            vault_dir=vault, llm_client=llm, db_path=db,
+            only_cluster_ids={"cluster::done01", "cluster::done02"},
+        )
+        assert len(llm.calls) == 2
+
+        # Re-run with skip_existing — only the third community should
+        # incur an LLM call.
+        crystals = synthesize_community_crystals(
+            vault_dir=vault, llm_client=llm, db_path=db,
+            skip_existing=True,
+        )
+        # 1 new crystal, total LLM calls now 3 (not 5).
+        assert len(crystals) == 1
+        assert crystals[0].cluster_id == "cluster::todo01"
+        assert len(llm.calls) == 3
+
     def test_evergreen_path_outside_vault_is_skipped(self, tmp_path):
         # ``canonical_path`` comes from knowledge.db (derived state).
         # A corrupted/stale row could carry a path that escapes the

--- a/tests/test_contradiction_crystal.py
+++ b/tests/test_contradiction_crystal.py
@@ -450,6 +450,39 @@ class TestSynthesizeEndToEnd:
         assert crystals == []
         assert llm.calls == []
 
+    def test_skip_existing_resumes_without_resynthesizing(self, tmp_path):
+        # Resume invariant for contradiction crystals — see the
+        # matching note in test_community_crystal.py.
+        vault, db = _seed(
+            tmp_path,
+            objects=[("a", "A", "body"), ("b", "B", "body")],
+            claims=[
+                ("a::aa", "a", "page_summary", "X"),
+                ("b::bb", "b", "page_summary", "not X"),
+            ],
+            contradictions=[
+                ("contradiction::done", "x",
+                 ["a::aa"], ["b::bb"], "open"),
+                ("contradiction::todo", "y",
+                 ["a::aa"], ["b::bb"], "open"),
+            ],
+        )
+        llm = _StubLLM()
+        synthesize_contradiction_crystals(
+            vault_dir=vault, llm_client=llm, db_path=db,
+            only_contradiction_ids={"contradiction::done"},
+        )
+        assert len(llm.calls) == 1
+
+        # Re-run with skip_existing.
+        crystals = synthesize_contradiction_crystals(
+            vault_dir=vault, llm_client=llm, db_path=db,
+            skip_existing=True,
+        )
+        assert len(crystals) == 1
+        assert crystals[0].contradiction_id == "contradiction::todo"
+        assert len(llm.calls) == 2
+
     def test_skips_when_only_one_side_resolves(self, tmp_path):
         # A contradiction is by definition two-sided.  If positives
         # resolve but negatives don't (stale claim refs), the


### PR DESCRIPTION
## Summary

A 329-community Louvain pass takes ~2 hours of LLM time on the real OVP vault. Without resume support, any interruption (Ctrl-C, network blip, laptop sleep) means re-running creates v2 of every already-completed crystal — wasted LLM budget and spurious chain churn.

\`--skip-existing\` filters communities (or contradictions) that already have at least one row in the crystal table BEFORE the LLM call. Resume is safe and free.

## Test plan

- [x] \`test_skip_existing_resumes_without_resynthesizing\` on both crystal kinds — pre-seed N crystals, re-run with the flag, assert only un-completed ones get LLM calls
- [x] All 41 crystal tests pass
- [x] ruff clean