### PR TITLE
docs: mark M13 substrate shipped + legacy crystal archiver

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -33,7 +33,7 @@ Rule: historical plans and vault research notes feed this file; they do not over
 | M12 Extraction-Time Entity Prime And Auto-Wikilink | Done | entity_aliases view, LLM extractor primed with known entities, auto-wikilink CLI (BL-038/039/040, PRs #126–#128) |
 | M13 Synthesis Layer (Crystal) | Done | Louvain communities + LLM-synthesized community crystals + contradiction crystals + append-only versioning (BL-041/042/043/044, PRs #130-#133) |
 
-## Recently Shipped (PRs #98–#133)
+## Recently Shipped (PRs #98–#136)
 
 | PR | What shipped |
 | --- | --- |
@@ -63,6 +63,10 @@ Rule: historical plans and vault research notes feed this file; they do not over
 | #131 | Community Crystal MVP (BL-042, M13): `ovp-synthesize-community-crystals` + `community_crystals` table; MiniMax-M2.7-highspeed default; append-only PK |
 | #132 | Contradiction crystals (BL-043, M13): `ovp-synthesize-contradiction-crystals` + `contradiction_crystals` table; deliberately preserves tension as "open question" crystal; resolved contradictions skipped |
 | #133 | Crystal append-only versioning (BL-044, M13): `superseded_by_synthesized_at` on both crystal tables; archive helper moves prior live markdown to `70-Archive/Crystals/<safe-id>/<ts>.md`; `ovp-list-crystals` surfaces version chains |
+| #134 | M13 review-pass: microsecond synth_at PK collision fix; `commit_crystal_version` reorders DB-then-FS for atomicity; Louvain edge weight aggregation; contradiction one-sided guard; vault containment guard; `synthesis/_shared.py` decoupling |
+| #135 | `--skip-existing` flag on both crystal CLIs for resumable batches |
+| #136 | Renderer fixes: machine-appended `## 相关笔记` section + visible sampling disclosure for big communities + `ovp-rerender-crystals` CLI (no-LLM format refresh) |
+| (production rebuild, no PR) | Targeted M13 substrate landed on `~/Documents/ovp-vault`: schema 3→5, 329 Louvain communities, 329 community crystals + 1 contradiction crystal, 8 entity stubs, 107 wikilinks across 88 evergreens, 4 legacy briefing crystals archived to `70-Archive/Crystals/Legacy/`. ~$1.50 LLM cost, ~3h wall time |
 
 ## Active Backlog
 

--- a/MILESTONE.md
+++ b/MILESTONE.md
@@ -49,7 +49,7 @@ Three target tiers:
 | **M10 Operational Knowledge Layer** | **Later** | action types on objects, permission + contract, cross-entity aggregation, decision memory |
 | **M11 Source Authority And Cross-Source Identity** | **Done** | typed source-authority providers (D1/D2/D3), entity layer (twitter_author / github_project / github_user / person / organization), runtime resolver, refresh wrapper, db backup (PRs #112–#124) |
 | **M12 Extraction-Time Entity Prime And Auto-Wikilink** | **Done** | entity_aliases view (PR #126), LLM extractor primed with known entities (PR #127), `ovp-link-entities` auto-wikilink CLI (PR #128) — closes the loop from "we know who Karpathy is" to "the next ingest run uses that knowledge" (BL-038, BL-039, BL-040) |
-| **M13 Synthesis Layer (Crystal)** | **Done** | Louvain community detection (PR #130), community Crystal MVP (PR #131), contradiction crystals (PR #132), append-only versioning + `ovp-list-crystals` (PR #133) — closes the gap with NM 0.8's synthesis tier (BL-041, BL-042, BL-043, BL-044) |
+| **M13 Synthesis Layer (Crystal)** | **Done** | Louvain community detection (PR #130), community Crystal MVP (PR #131), contradiction crystals (PR #132), append-only versioning + `ovp-list-crystals` (PR #133), atomicity / aggregation / decoupling review-pass (PR #134), `--skip-existing` resumable batches (PR #135), renderer with sampling disclosure + `## 相关笔记` + `ovp-rerender-crystals` (PR #136) — substrate shipped on production vault: 329 Louvain communities, 329 community crystals + 1 contradiction crystal, ~$1.50 LLM cost (BL-041, BL-042, BL-043, BL-044) |
 
 ## Active Backlog Alignment
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Current milestone sequence:
 | M10 Operational Knowledge Layer | Later | action types, permissions, cross-entity aggregation, decision memory |
 | M11 Source Authority And Cross-Source Identity | Done | typed source-authority providers, entity layer (twitter_author / github_project / github_user / person / organization), runtime resolver, refresh wrapper, db backup (PRs #112–#124) |
 | M12 Extraction-Time Entity Prime And Auto-Wikilink | Done | entity_aliases view, LLM extractor primed with known entities, auto-wikilink CLI (PRs #126–#128) |
-| M13 Synthesis Layer (Crystal) | Done | Louvain communities + LLM-synthesized crystals + contradiction crystals + append-only versioning (PRs #130–#133, closes the L3 gap with NM 0.8) |
+| M13 Synthesis Layer (Crystal) | Done | Louvain communities + LLM-synthesized crystals + contradiction crystals + append-only versioning + sampling-aware renderer (PRs #130–#136); production substrate shipped on the OVP vault (329 community crystals, 1 contradiction crystal). Curated read model deferred to M15 → M14 sequence after architecture-language cleanup. |
 
 Recent major changes (PRs #98–#124):
 

--- a/scripts/archive_legacy_briefing_crystals.py
+++ b/scripts/archive_legacy_briefing_crystals.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""One-shot archiver for the legacy briefing-crystal files that
+predate the BL-042 ``community_crystals`` table.
+
+Usage::
+
+    python scripts/archive_legacy_briefing_crystals.py [--vault-dir PATH]
+
+Background:
+    Before M13, ``materializers/crystal.py`` produced "briefing
+    crystals" (operator briefing snapshots) into
+    ``40-Resources/Crystals/crystal-<YYYY-MM-DD>-<sha>.md``.  M13's
+    BL-042 introduced a different surface — LLM-synthesized
+    *community crystals* — using the same directory but a different
+    filename pattern (``<sha>.md``, no date prefix).  The two
+    surfaces are conceptually distinct; mixing them in the live
+    directory pollutes UI counts and operator understanding.
+
+    This script moves every ``crystal-<YYYY-...>-<sha>.md`` legacy
+    file to ``70-Archive/Crystals/Legacy/`` so the live directory
+    holds only M13 substrate output.  Idempotent: re-running with
+    no remaining legacy files is a no-op.
+
+The script is committed (rather than left as a shell ``mv``) so the
+migration is reproducible and auditable in git history.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument(
+        "--vault-dir", type=Path, default=Path.cwd(),
+        help="Vault root (default: cwd).",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Print what would move; touch nothing.",
+    )
+    args = parser.parse_args(argv)
+
+    vault = args.vault_dir.resolve()
+    live = vault / "40-Resources" / "Crystals"
+    archive = vault / "70-Archive" / "Crystals" / "Legacy"
+
+    candidates = sorted(live.glob("crystal-2026-*-*.md"))
+    if not candidates:
+        print("no legacy briefing crystals to archive (no-op)")
+        return 0
+
+    if not args.dry_run:
+        archive.mkdir(parents=True, exist_ok=True)
+    moved = 0
+    for src in candidates:
+        dst = archive / src.name
+        if dst.exists():
+            print(f"  skip (already archived): {src.name}")
+            continue
+        if args.dry_run:
+            print(f"  would move: {src.name} -> 70-Archive/Crystals/Legacy/")
+        else:
+            shutil.move(str(src), str(dst))
+            print(f"  moved: {src.name} -> 70-Archive/Crystals/Legacy/")
+        moved += 1
+    verb = "would archive" if args.dry_run else "archived"
+    print(f"\n{verb} {moved} legacy briefing crystals")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes M13 by reflecting what's actually on disk + DB on the production vault.

- **BACKLOG / MILESTONE / README** now mark M13 Done across the full PR #130-#136 sequence (previously only #130-#133). Adds the production-rebuild line: 329 Louvain communities, 329 community crystals + 1 contradiction crystal, ~\$1.50 MiniMax cost, ~3h wall time.
- **scripts/archive_legacy_briefing_crystals.py** records the one-shot migration that moved 4 legacy \`crystal-2026-04-*-*.md\` files from \`40-Resources/Crystals/\` to \`70-Archive/Crystals/Legacy/\`. Idempotent + \`--dry-run\` previews.
- **README** notes the curated read model is deferred to M15 → M14 sequence (architecture-language cleanup must land first so product UI doesn't fossilize the old four-layer framing).

## Test plan

- [x] Migration script tested live: 4 files moved, target directory created, re-run is no-op
- [x] No code in main package changed; CI passes by default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated backlog, milestone, and readme files to reflect recently shipped work through PR #136, including synthesis layer enhancements and production updates.

* **Chores**
  * Added internal script for archiving legacy briefing files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->