### PR TITLE
fix(knowledge_index): preserve community/contradiction crystals across rebuild

### DIFF
--- a/src/ovp_pipeline/knowledge_index.py
+++ b/src/ovp_pipeline/knowledge_index.py
@@ -229,6 +229,45 @@ TRUTH_PROJECTION_TABLE_COLUMNS: dict[str, tuple[str, ...]] = {
 }
 
 
+# Canonical State tables that the index rebuild does NOT recompute
+# from pages_index — they are independently materialized by LLM
+# synthesis (community_crystals + contradiction_crystals).  They must
+# be carried across a knowledge-index rebuild for ALL packs (no
+# ``exclude_pack`` filter), otherwise rebuilding silently wipes the
+# LLM-synthesized corpus and the user pays to regenerate it.
+#
+# ``crystal_scores`` is intentionally NOT in this list — it is a true
+# Projection over ``community_crystals``/``contradiction_crystals``
+# and is rebuilt deterministically by ``rebuild_crystal_scores`` later
+# in the index pipeline.  Preserving it here would only get
+# overwritten by the rebuild call.
+INDEPENDENT_CANONICAL_TABLE_COLUMNS: dict[str, tuple[str, ...]] = {
+    "community_crystals": (
+        "pack",
+        "cluster_id",
+        "body_md",
+        "source_evergreen_slugs_json",
+        "synthesized_at",
+        "llm_model",
+        "prompt_version",
+        "superseded_by_synthesized_at",
+    ),
+    "contradiction_crystals": (
+        "pack",
+        "contradiction_id",
+        "subject_key",
+        "body_md",
+        "positive_claim_ids_json",
+        "negative_claim_ids_json",
+        "source_object_ids_json",
+        "synthesized_at",
+        "llm_model",
+        "prompt_version",
+        "superseded_by_synthesized_at",
+    ),
+}
+
+
 def _truth_pack_name(pack_name: str | None = None) -> str:
     return str(pack_name or DEFAULT_WORKFLOW_PACK_NAME)
 
@@ -314,6 +353,31 @@ def _preserve_existing_truth_rows(
                 rows,
             )
             preserved_packs.update(str(row[0]) for row in rows if row and row[0])
+
+        # INDEPENDENT_CANONICAL_TABLE_COLUMNS rows are LLM-synthesized
+        # (or scored against synthesized rows) — they cannot be
+        # recomputed by the rebuild, so they must be carried over for
+        # ALL packs, including the current one.  Without this, every
+        # ``ovp-knowledge-index`` run silently wipes the crystal corpus
+        # and the user has to pay LLM cost to regenerate.
+        for table_name, columns in INDEPENDENT_CANONICAL_TABLE_COLUMNS.items():
+            column_sql = ", ".join(columns)
+            try:
+                rows = source_conn.execute(
+                    f"SELECT {column_sql} FROM {table_name} ORDER BY pack",
+                ).fetchall()
+            except sqlite3.OperationalError as exc:
+                error_text = str(exc).lower()
+                if "no such table" in error_text or "no such column" in error_text:
+                    continue
+                raise
+            if not rows:
+                continue
+            placeholders = ", ".join("?" for _ in columns)
+            dest_conn.executemany(
+                f"INSERT INTO {table_name} ({column_sql}) VALUES ({placeholders})",
+                rows,
+            )
 
         try:
             metadata_rows = source_conn.execute(

--- a/src/ovp_pipeline/knowledge_index.py
+++ b/src/ovp_pipeline/knowledge_index.py
@@ -332,52 +332,51 @@ def _preserve_existing_truth_rows(
         source_conn = sqlite3.connect(source_db_path)
     except sqlite3.DatabaseError:
         return
+    def _copy_table(
+        table_name: str,
+        columns: tuple[str, ...],
+        *,
+        where_excludes_current: bool,
+    ) -> list[tuple[Any, ...]]:
+        column_sql = ", ".join(columns)
+        if where_excludes_current:
+            sql = f"SELECT {column_sql} FROM {table_name} WHERE pack != ? ORDER BY pack"
+            params: tuple[Any, ...] = (exclude_pack,)
+        else:
+            sql = f"SELECT {column_sql} FROM {table_name} ORDER BY pack"
+            params = ()
+        try:
+            rows = source_conn.execute(sql, params).fetchall()
+        except sqlite3.OperationalError as exc:
+            error_text = str(exc).lower()
+            if "no such table" in error_text or "no such column" in error_text:
+                return []
+            raise
+        if not rows:
+            return []
+        placeholders = ", ".join("?" for _ in columns)
+        dest_conn.executemany(
+            f"INSERT INTO {table_name} ({column_sql}) VALUES ({placeholders})",
+            rows,
+        )
+        return rows
+
     try:
         for table_name, columns in TRUTH_PROJECTION_TABLE_COLUMNS.items():
-            column_sql = ", ".join(columns)
-            try:
-                rows = source_conn.execute(
-                    f"SELECT {column_sql} FROM {table_name} WHERE pack != ? ORDER BY pack",
-                    (exclude_pack,),
-                ).fetchall()
-            except sqlite3.OperationalError as exc:
-                error_text = str(exc).lower()
-                if "no such table" in error_text or "no such column" in error_text:
-                    continue
-                raise
-            if not rows:
-                continue
-            placeholders = ", ".join("?" for _ in columns)
-            dest_conn.executemany(
-                f"INSERT INTO {table_name} ({column_sql}) VALUES ({placeholders})",
-                rows,
-            )
+            rows = _copy_table(table_name, columns, where_excludes_current=True)
             preserved_packs.update(str(row[0]) for row in rows if row and row[0])
 
-        # INDEPENDENT_CANONICAL_TABLE_COLUMNS rows are LLM-synthesized
-        # (or scored against synthesized rows) — they cannot be
-        # recomputed by the rebuild, so they must be carried over for
-        # ALL packs, including the current one.  Without this, every
-        # ``ovp-knowledge-index`` run silently wipes the crystal corpus
-        # and the user has to pay LLM cost to regenerate.
+        # INDEPENDENT_CANONICAL_TABLE_COLUMNS rows are LLM-synthesized —
+        # they cannot be recomputed by the rebuild, so they must be
+        # carried over for ALL packs, including the current one.
+        # Without this, every ``ovp-knowledge-index`` run silently
+        # wipes the crystal corpus and the user has to pay LLM cost
+        # to regenerate.  Intentionally NOT updating ``preserved_packs``
+        # here: that set drives ``truth_projections`` metadata
+        # backfill, which only applies to packs that produce
+        # truth-projection rows; a crystal-only pack does not.
         for table_name, columns in INDEPENDENT_CANONICAL_TABLE_COLUMNS.items():
-            column_sql = ", ".join(columns)
-            try:
-                rows = source_conn.execute(
-                    f"SELECT {column_sql} FROM {table_name} ORDER BY pack",
-                ).fetchall()
-            except sqlite3.OperationalError as exc:
-                error_text = str(exc).lower()
-                if "no such table" in error_text or "no such column" in error_text:
-                    continue
-                raise
-            if not rows:
-                continue
-            placeholders = ", ".join("?" for _ in columns)
-            dest_conn.executemany(
-                f"INSERT INTO {table_name} ({column_sql}) VALUES ({placeholders})",
-                rows,
-            )
+            _copy_table(table_name, columns, where_excludes_current=False)
 
         try:
             metadata_rows = source_conn.execute(

--- a/tests/test_knowledge_index_preserves_crystals.py
+++ b/tests/test_knowledge_index_preserves_crystals.py
@@ -92,7 +92,7 @@ def _seed_crystals(db_path):
 
 
 def test_rebuild_preserves_community_crystals(temp_vault):
-    rebuild_knowledge_index(temp_vault)
+    rebuild_knowledge_index(temp_vault, pack_name=PACK)
     db_path = VaultLayout.from_vault(temp_vault).knowledge_db
     _seed_crystals(db_path)
     with sqlite3.connect(db_path) as conn:
@@ -101,7 +101,7 @@ def test_rebuild_preserves_community_crystals(temp_vault):
         ).fetchone()[0]
     assert before == 1
 
-    rebuild_knowledge_index(temp_vault)
+    rebuild_knowledge_index(temp_vault, pack_name=PACK)
 
     with sqlite3.connect(db_path) as conn:
         after = conn.execute(
@@ -116,11 +116,11 @@ def test_rebuild_preserves_community_crystals(temp_vault):
 
 
 def test_rebuild_preserves_contradiction_crystals(temp_vault):
-    rebuild_knowledge_index(temp_vault)
+    rebuild_knowledge_index(temp_vault, pack_name=PACK)
     db_path = VaultLayout.from_vault(temp_vault).knowledge_db
     _seed_crystals(db_path)
 
-    rebuild_knowledge_index(temp_vault)
+    rebuild_knowledge_index(temp_vault, pack_name=PACK)
 
     with sqlite3.connect(db_path) as conn:
         n = conn.execute(

--- a/tests/test_knowledge_index_preserves_crystals.py
+++ b/tests/test_knowledge_index_preserves_crystals.py
@@ -1,0 +1,145 @@
+"""Regression test: ``rebuild_knowledge_index`` must preserve the
+LLM-synthesized crystal corpus across runs.
+
+The pre-fix bug: ``_preserve_existing_truth_rows`` only carried the
+``TRUTH_PROJECTION_TABLE_COLUMNS`` set across the rebuild, and only for
+non-current packs.  ``community_crystals`` / ``contradiction_crystals``
+/ ``crystal_scores`` were not on that list, so every rebuild silently
+wiped them — costing the user an LLM re-synthesis bill.
+
+This test seeds rows for the current pack, runs a rebuild, and asserts
+the rows are still there.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+from ovp_pipeline.knowledge_index import rebuild_knowledge_index
+from ovp_pipeline.runtime import VaultLayout
+
+
+PACK = "research-tech"
+
+
+def _seed_crystals(db_path):
+    with sqlite3.connect(db_path) as conn:
+        # Seed a graph_clusters row so the rebuild_crystal_scores
+        # JOIN against community_crystals produces a row downstream.
+        # Without this, rebuild_crystal_scores filters out the
+        # crystal as "no matching cluster".
+        conn.execute(
+            """
+            INSERT INTO graph_clusters
+              (pack, cluster_id, cluster_kind, label, center_object_id,
+               member_object_ids_json, score)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                PACK, "cluster::a1", "louvain_community", "Vector search",
+                "ev-a", json.dumps(["ev-a", "ev-b"]), 0.0,
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO community_crystals
+              (pack, cluster_id, body_md, source_evergreen_slugs_json,
+               synthesized_at, llm_model, prompt_version,
+               superseded_by_synthesized_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                PACK, "cluster::a1", "## body\n\nVector search overview.",
+                json.dumps(["ev-a", "ev-b"]),
+                "2026-05-04T12:00:00+00:00",
+                "minimax-m2.7-highspeed", "v1", "",
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO contradiction_crystals
+              (pack, contradiction_id, subject_key, body_md,
+               positive_claim_ids_json, negative_claim_ids_json,
+               source_object_ids_json, synthesized_at, llm_model,
+               prompt_version, superseded_by_synthesized_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                PACK, "contradiction::c1", "RAG vs long context",
+                "## open question\n\nDoes long context replace RAG?",
+                json.dumps(["claim-pos"]), json.dumps(["claim-neg"]),
+                json.dumps(["obj-1"]),
+                "2026-05-04T12:01:00+00:00",
+                "minimax-m2.7-highspeed", "v1", "",
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO crystal_scores
+              (pack, crystal_kind, crystal_id, score,
+               size_norm, credibility_norm, contradiction_norm,
+               reuse_recency_norm, evergreen_recency_norm, computed_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                PACK, "community", "cluster::a1", 0.8,
+                0.6, 0.7, 0.0, 0.0, 0.5,
+                "2026-05-04T12:02:00+00:00",
+            ),
+        )
+        conn.commit()
+
+
+def test_rebuild_preserves_community_crystals(temp_vault):
+    rebuild_knowledge_index(temp_vault)
+    db_path = VaultLayout.from_vault(temp_vault).knowledge_db
+    _seed_crystals(db_path)
+    with sqlite3.connect(db_path) as conn:
+        before = conn.execute(
+            "SELECT COUNT(*) FROM community_crystals WHERE pack=?", (PACK,),
+        ).fetchone()[0]
+    assert before == 1
+
+    rebuild_knowledge_index(temp_vault)
+
+    with sqlite3.connect(db_path) as conn:
+        after = conn.execute(
+            "SELECT COUNT(*) FROM community_crystals WHERE pack=?", (PACK,),
+        ).fetchone()[0]
+        body = conn.execute(
+            "SELECT body_md FROM community_crystals WHERE pack=? AND cluster_id=?",
+            (PACK, "cluster::a1"),
+        ).fetchone()[0]
+    assert after == 1
+    assert "Vector search overview" in body
+
+
+def test_rebuild_preserves_contradiction_crystals(temp_vault):
+    rebuild_knowledge_index(temp_vault)
+    db_path = VaultLayout.from_vault(temp_vault).knowledge_db
+    _seed_crystals(db_path)
+
+    rebuild_knowledge_index(temp_vault)
+
+    with sqlite3.connect(db_path) as conn:
+        n = conn.execute(
+            "SELECT COUNT(*) FROM contradiction_crystals WHERE pack=?", (PACK,),
+        ).fetchone()[0]
+        subject = conn.execute(
+            "SELECT subject_key FROM contradiction_crystals "
+            "WHERE pack=? AND contradiction_id=?",
+            (PACK, "contradiction::c1"),
+        ).fetchone()[0]
+    assert n == 1
+    assert subject == "RAG vs long context"
+
+
+# Note: ``crystal_scores`` is a Projection, not Canonical State.  The
+# rebuild intentionally drops + re-derives it from the (now-preserved)
+# crystal rows, so a "scores-survived" test is brittle — the
+# truth_projection rebuild ALSO recomputes ``graph_clusters`` for the
+# current pack from the live page graph, and a synthetic test fixture
+# without real source pages will end up with an empty graph_clusters
+# regardless of whether crystal_scores was preserved.  Score rebuild
+# correctness is covered by ``test_crystal_scoring.py``.


### PR DESCRIPTION
## The bug

Every \`ovp-knowledge-index\` run silently wiped the LLM-synthesized crystal corpus.

\`_preserve_existing_truth_rows\` only carried \`TRUTH_PROJECTION_TABLE_COLUMNS\` rows across the rebuild — and only for non-current packs.  \`community_crystals\` and \`contradiction_crystals\` were not on that list, so each rebuild dropped a fresh empty schema on top of them.

Discovered today after a 632-row MiniMax synthesis pass (~$3 of LLM cost) vanished on the next \`ovp-knowledge-index\` run.  Without this fix, every index rebuild costs the user another synthesis run.

## Why these tables are different

\`community_crystals\` / \`contradiction_crystals\` are **Canonical State**, not Projections.  The body is LLM-synthesized; nothing in the rebuild pipeline can recompute it.  They have to be carried across.

\`crystal_scores\` is intentionally NOT preserved here: it IS a Projection over \`community_crystals\`, and \`rebuild_crystal_scores\` later in the same pipeline regenerates it deterministically.  Preserving it would just get overwritten.

## Tests

Two new regression tests in \`tests/test_knowledge_index_preserves_crystals.py\` that:
- seed \`community_crystals\` + \`contradiction_crystals\` rows under the current pack
- run \`rebuild_knowledge_index\` again
- assert the rows are still there with the original body / subject_key

Existing crystal-touching suites (38 tests in \`test_crystal_materializer\`/\`test_crystal_fts\`/\`test_curated_atlas\`) and \`test_knowledge_index\` (35 tests) still green.

## Test plan

- [ ] Verify on the production vault that re-running \`ovp-knowledge-index\` no longer empties \`community_crystals\` (the failure mode that motivated this PR)
- [ ] Confirm \`crystal_scores\` still rebuilds correctly after the rebuild (it's a Projection, so the score values themselves are recomputed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Knowledge database rebuilds now preserve AI-synthesized crystal data (community and contradiction insights), preventing silent loss during rebuilds.
* **Tests**
  * Added regression tests that verify crystal rows persist unchanged across knowledge-index rebuilds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->