### PR TITLE
chore(release): bump version to 0.12.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "obsidian-vault-pipeline"
-version = "0.10.0"
+version = "0.12.0"
 description = "全自动Obsidian知识管理Pipeline - 生产级知识管理流水线"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Bump pyproject.toml from 0.10.0 → 0.12.0 ahead of tagging v0.12.0.

Accumulation since v0.11.0 / pyproject 0.10.0:

* M16 Reader / Maintainer split (BL-050, PR #150)
* M16 Reader vocabulary + map cleanup (BL-051, PR #151)
* M14 crystal scoring substrate fix + provenance spine (BL-054 / BL-055, PR #152)
* M14 stage emit hooks + maintainer vocab audit (BL-056 / BL-052, PR #153)

### Schema additions (back-compat)
* `objects.source_url` column
* `crystal_scores.source_diversity_norm` column
* `provenance` table (BL-055)
* `source_authority` table now wired into rebuild (BL-054)

### New CLIs
* `ovp-backfill-provenance`

No breaking API changes; existing callers and databases continue to work.
`rebuild_knowledge_index` repopulates everything correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.12.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->