### PR TITLE
feat(github): DeepWiki/GitIngest enrichment, drop 13-section deep-dive (BL-066)

### DIFF
--- a/src/ovp_pipeline/auto_evergreen_extractor.py
+++ b/src/ovp_pipeline/auto_evergreen_extractor.py
@@ -958,17 +958,22 @@ def _reject_intake_source_target(layout: VaultLayout, path: Path) -> None:
 
 
 _GITHUB_SOURCE_FRONTMATTER_MARKER = "source_type: github-project"
+_GITHUB_SKIPPED_MARKER = "extraction_status: skipped"
 
 
 def _is_github_source_markdown(path: Path) -> bool:
     """Return True if ``path`` is a github-project source written by
-    auto_github_processor (BL-066).
+    auto_github_processor (BL-066) AND has a non-empty extracted body.
 
-    Detection is purely by frontmatter line — we don't parse YAML
-    because we read this on every absorb scan and want it cheap.  The
-    line ``source_type: github-project`` (with or without surrounding
-    quotes) appears in the frontmatter block written by
-    ``_build_frontmatter`` in auto_github_processor.
+    Detection is purely by frontmatter lines — we don't parse YAML
+    because we read this on every absorb scan and want it cheap.  Two
+    conditions must hold:
+
+    1. The marker ``source_type: github-project`` appears in the
+       frontmatter block (identifies the file as a BL-066 product).
+    2. The marker ``extraction_status: skipped`` does NOT appear —
+       skipped files exist as audit trail for empty-tier enrichments
+       and have no extractable body, so absorb must ignore them.
     """
     try:
         with open(path, "r", encoding="utf-8") as f:
@@ -981,7 +986,11 @@ def _is_github_source_markdown(path: Path) -> bool:
     # text that happens to contain the marker.
     end = head.find("---", 3)
     fm_block = head[:end] if end > 0 else head
-    return _GITHUB_SOURCE_FRONTMATTER_MARKER in fm_block
+    if _GITHUB_SOURCE_FRONTMATTER_MARKER not in fm_block:
+        return False
+    if _GITHUB_SKIPPED_MARKER in fm_block:
+        return False
+    return True
 
 
 def _collect_processed_github_sources(

--- a/src/ovp_pipeline/auto_evergreen_extractor.py
+++ b/src/ovp_pipeline/auto_evergreen_extractor.py
@@ -884,8 +884,11 @@ class AutoEvergreenExtractor:
         if not directory.exists():
             return []
 
-        # 只处理深度解读文件
+        # 处理深度解读文件 + BL-066 github-project 源(后者无 _深度解读 后缀)
         files = list(directory.glob("*_深度解读.md"))
+        for candidate in directory.glob("*.md"):
+            if candidate not in files and _is_github_source_markdown(candidate):
+                files.append(candidate)
 
         results = []
         for file_path in files:
@@ -954,6 +957,77 @@ def _reject_intake_source_target(layout: VaultLayout, path: Path) -> None:
             )
 
 
+_GITHUB_SOURCE_FRONTMATTER_MARKER = "source_type: github-project"
+
+
+def _is_github_source_markdown(path: Path) -> bool:
+    """Return True if ``path`` is a github-project source written by
+    auto_github_processor (BL-066).
+
+    Detection is purely by frontmatter line — we don't parse YAML
+    because we read this on every absorb scan and want it cheap.  The
+    line ``source_type: github-project`` (with or without surrounding
+    quotes) appears in the frontmatter block written by
+    ``_build_frontmatter`` in auto_github_processor.
+    """
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            head = f.read(2048)
+    except (OSError, UnicodeDecodeError):
+        return False
+    if not head.startswith("---"):
+        return False
+    # Stop scanning at the closing fence — don't false-match on body
+    # text that happens to contain the marker.
+    end = head.find("---", 3)
+    fm_block = head[:end] if end > 0 else head
+    return _GITHUB_SOURCE_FRONTMATTER_MARKER in fm_block
+
+
+def _collect_processed_github_sources(
+    layout: VaultLayout,
+    *,
+    month_names: set[str] | None = None,
+    cutoff: datetime | None = None,
+) -> list[Path]:
+    """Scan ``50-Inbox/03-Processed/<YYYY-MM>/`` for github-source
+    markdowns (BL-066).  Used by the ``recent`` branch of
+    ``_collect_absorb_targets`` so github intakes flow into absorb on
+    the same schedule as deep-dives.
+
+    ``month_names`` filters which month dirs to scan; ``cutoff`` filters
+    by file mtime.  When both are None, returns all github sources
+    under processed_dir.
+    """
+    if not layout.processed_dir.exists():
+        return []
+    out: list[Path] = []
+    seen: set[str] = set()
+    for month_dir in sorted(layout.processed_dir.iterdir()):
+        if not month_dir.is_dir():
+            continue
+        if month_names is not None and month_dir.name not in month_names:
+            continue
+        for candidate in sorted(month_dir.glob("*.md")):
+            if cutoff is not None:
+                try:
+                    modified_at = datetime.fromtimestamp(
+                        candidate.stat().st_mtime, tz=timezone.utc,
+                    )
+                except OSError:
+                    continue
+                if modified_at < cutoff:
+                    continue
+            if not _is_github_source_markdown(candidate):
+                continue
+            key = str(candidate.resolve())
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append(candidate)
+    return out
+
+
 def _collect_absorb_targets(
     layout: VaultLayout,
     *,
@@ -968,7 +1042,14 @@ def _collect_absorb_targets(
         _reject_intake_source_target(layout, directory)
         if not directory.exists():
             return []
+        # Pick up both the legacy deep-dive layer and BL-066 github
+        # sources that landed in the same staging dir (e.g. when
+        # absorb is invoked with ``--directory 50-Inbox/03-Processed``
+        # directly).
         targets = sorted(directory.glob("*_深度解读.md"))
+        for candidate in sorted(directory.glob("*.md")):
+            if candidate not in targets and _is_github_source_markdown(candidate):
+                targets.append(candidate)
         for target in targets:
             _reject_intake_source_target(layout, target)
         return targets
@@ -1004,6 +1085,18 @@ def _collect_absorb_targets(
                         continue
                     seen.add(key)
                     ordered.append(candidate)
+        # BL-066: also pick up github-project sources from
+        # 50-Inbox/03-Processed/<YYYY-MM>/ written by the new github
+        # intake.  These land outside 20-Areas so the deep-dive scan
+        # above misses them.
+        for candidate in _collect_processed_github_sources(
+            layout, month_names=month_names, cutoff=cutoff,
+        ):
+            key = str(candidate.resolve())
+            if key in seen:
+                continue
+            seen.add(key)
+            ordered.append(candidate)
         return ordered
     raise ValueError("one of file_path, directory, or recent must be provided")
 

--- a/src/ovp_pipeline/auto_github_processor.py
+++ b/src/ovp_pipeline/auto_github_processor.py
@@ -1,19 +1,50 @@
 #!/usr/bin/env python3
-"""
-Auto GitHub Processor - GitHub项目13节深度解读生成器
+"""auto_github_processor — GitHub project intake (BL-066).
 
-针对GitHub项目的特殊处理流程：
-1. 自动获取README和stars数
-2. 生成13节结构化深度解读
-3. 包含ASCII架构图和能力表格
-4. 自动归档到Tools/Topics/YYYY-MM/
+Replaces the previous "13-section deep-dive" LLM rewrite with a
+deterministic enrichment chain that fetches richer source material
+and writes it to ``50-Inbox/03-Processed/{YYYY-MM}/`` so absorb can
+read it directly.
+
+Pipeline integration:
+
+    pinboard_process step calls
+        ovp_pipeline.auto_github_processor --process-single <stub.md>
+
+    For each GitHub URL:
+
+        1. ``enrich_github_source(owner, repo)``
+           - Tier 1: DeepWiki (pre-rendered structured wiki)
+           - Tier 2: GitIngest (clone + concatenated docs)
+           - Tier 3: README from raw.githubusercontent.com
+        2. Write to ``50-Inbox/03-Processed/{YYYY-MM}/<date>_<owner>_<repo>.md``
+           with frontmatter:
+               source: https://github.com/<owner>/<repo>
+               source_type: github-project
+               source_tier: deepwiki | gitingest | readme
+               github_owner / github_repo / github_stars
+               source_fetched_at: <iso>
+               source_indexed_at: <DeepWiki last-indexed, if applicable>
+
+This step does NOT call any LLM — it is now pure intake.  Knowledge
+extraction happens later in absorb, which reads from the same
+``03-Processed/`` directory regardless of source type.
+
+Why we removed the 13-section deep-dive:
+    The 13-section template was an LLM-driven rewrite that forced
+    every repo into the same wiki shape (项目定位 / 技术架构 / 核心
+    能力 / etc.).  absorb would then re-flatten that wiki shape back
+    into atomic units — two LLM passes, both lossy and both
+    abstraction-inflating.  The fidelity audit on 2026-05-05 showed
+    most absorbed evergreens from this path were ``faithful_generic``
+    (the source had specifics, the deep-dive abstracted them away,
+    absorb amplified the loss).  Skipping the deep-dive entirely and
+    feeding richer raw material directly to absorb is strictly better.
 
 Usage:
-    python3 auto_github_processor.py --input github_urls.txt
-    python3 auto_github_processor.py --single https://github.com/owner/repo
-    python3 auto_github_processor.py --input urls.txt --dry-run
-
-输出: 20-Areas/Tools/Topics/YYYY-MM/YYYY-MM-DD_owner_repo_深度解读.md
+    python -m ovp_pipeline.auto_github_processor --single https://github.com/owner/repo
+    python -m ovp_pipeline.auto_github_processor --process-single <pinboard-stub.md>
+    python -m ovp_pipeline.auto_github_processor --input github_urls.txt
 """
 
 from __future__ import annotations
@@ -24,11 +55,9 @@ import os
 import re
 import sys
 import time
-from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
 
 try:
     from .runtime import VaultLayout, resolve_vault_dir
@@ -36,28 +65,17 @@ except ImportError:
     from runtime import VaultLayout, resolve_vault_dir  # type: ignore
 
 try:
-    from .llm_defaults import (
-        DEFAULT_LITELLM_TIMEOUT_SECONDS,
-        DEFAULT_MINIMAX_MODEL,
-        completion_with_litellm_policy,
-        normalize_model_for_api_base,
-        resolve_api_base,
-        resolve_api_key,
+    from .github_enrichment import (
+        EnrichedSource,
+        enrich_github_source,
+        parse_github_url,
     )
 except ImportError:
-    from llm_defaults import (  # type: ignore
-        DEFAULT_LITELLM_TIMEOUT_SECONDS,
-        DEFAULT_MINIMAX_MODEL,
-        completion_with_litellm_policy,
-        normalize_model_for_api_base,
-        resolve_api_base,
-        resolve_api_key,
+    from github_enrichment import (  # type: ignore
+        EnrichedSource,
+        enrich_github_source,
+        parse_github_url,
     )
-
-try:
-    from .markdown_generation import sanitize_generated_markdown
-except ImportError:
-    from markdown_generation import sanitize_generated_markdown  # type: ignore
 
 try:
     from .source_lifecycle import maybe_archive_pinboard_process_single
@@ -66,417 +84,388 @@ except ImportError:
 
 
 VAULT_DIR = resolve_vault_dir()
-DEFAULT_LAYOUT = VaultLayout.from_vault(VAULT_DIR)
-
-# ========== 配置 ==========
-OUTPUT_DIR = DEFAULT_LAYOUT.month_topics_dir("Tools")
-LOG_FILE = DEFAULT_LAYOUT.pipeline_log
 
 
 def load_env_file(vault_dir: Path) -> None:
-    """Load environment variables from the resolved vault root if available."""
+    """Load environment variables from the vault root if present.
+
+    Kept for backward compatibility with callers that expect this
+    function — enrichment itself doesn't need any API keys, but
+    callers may set vault-scoped vars here.
+    """
     env_file = vault_dir / ".env"
     if not env_file.exists():
         return
-
     try:
         from dotenv import load_dotenv
-
         load_dotenv(dotenv_path=env_file, override=True)
     except ImportError:
         pass
 
 
 def build_default_output_dir(vault_dir: Path | str | None = None) -> Path:
-    """Return the default GitHub output directory for a vault."""
-    return VaultLayout.from_vault(vault_dir).month_topics_dir("Tools")
+    """Default output directory for processed GitHub source markdowns.
+
+    Was ``20-Areas/Tools/Topics/YYYY-MM`` (deep-dive layer); now
+    ``50-Inbox/03-Processed/YYYY-MM`` (raw intake layer, alongside
+    article-processor output).  The change is BL-066: github intake
+    no longer produces a "deep-dive" — the enriched body IS the
+    processed source.
+    """
+    layout = VaultLayout.from_vault(vault_dir)
+    month = datetime.now().strftime("%Y-%m")
+    return layout.processed_dir / month
 
 
-@dataclass
-class GitHubRepo:
-    url: str
-    owner: str
-    repo: str
-    date: str
-    tags: list[str]
-    description: str
-    readme_content: str = ""
-    stars: int = 0
+# ---------------------------------------------------------------------------
+# Logging (kept minimal — pipeline_log gets the structured event)
+# ---------------------------------------------------------------------------
 
 
 class PipelineLogger:
-    """统一日志记录"""
+    """Append-only JSONL logger for github intake events."""
 
     def __init__(self, log_file: Path):
         self.log_file = log_file
-        self.session_id = f"{datetime.now().strftime('%Y%m%d-%H%M%S')}-{os.urandom(4).hex()}"
+        self.session_id = (
+            f"{datetime.now().strftime('%Y%m%d-%H%M%S')}-{os.urandom(4).hex()}"
+        )
 
-    def log(self, event_type: str, data: dict[str, Any]):
+    def log(self, event_type: str, data: dict[str, Any]) -> None:
         entry = {
             "timestamp": datetime.now().isoformat(),
             "session_id": self.session_id,
             "event_type": event_type,
-            **data
+            **data,
         }
         self.log_file.parent.mkdir(parents=True, exist_ok=True)
         with open(self.log_file, "a", encoding="utf-8") as f:
             f.write(json.dumps(entry, ensure_ascii=False) + "\n")
 
 
-class LiteLLMClient:
-    """LiteLLM client (参考spec-orch实现)"""
-
-    VALID_API_TYPES = ("anthropic", "openai")
-
-    def __init__(
-        self,
-        *,
-        model: str | None = None,
-        api_type: str = "anthropic",
-        api_key: str | None = None,
-        api_base: str | None = None,
-        temperature: float = 0.3,
-    ):
-        if api_type not in self.VALID_API_TYPES:
-            raise ValueError(f"api_type must be one of {self.VALID_API_TYPES}")
-        self.api_type = api_type
-        self._api_key = resolve_api_key(api_key)
-        self.api_base = resolve_api_base(api_base)
-        self.model = normalize_model_for_api_base(
-            model or os.environ.get("AUTO_VAULT_MODEL", DEFAULT_MINIMAX_MODEL),
-            api_type=api_type,
-            api_base=self.api_base,
-            default_model=DEFAULT_MINIMAX_MODEL,
-        )
-        self.temperature = temperature
-        self._total_calls = 0
-        self._total_tokens = 0
-
-        if not self._api_key:
-            raise ValueError("API key required. Set AUTO_VAULT_API_KEY or MINIMAX_API_KEY env var.")
-        try:
-            import litellm as litellm_module
-        except ImportError as exc:
-            raise ValueError("litellm is required. Install with: pip install litellm") from exc
-        self._litellm = litellm_module
-
-    def generate(
-        self,
-        system_prompt: str,
-        user_prompt: str,
-        max_tokens: int = 8000,
-    ) -> tuple[str, dict]:
-        kwargs: dict[str, Any] = {
-            "model": self.model,
-            "messages": [
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": user_prompt},
-            ],
-            "temperature": self.temperature,
-            "max_tokens": max_tokens,
-            "timeout": DEFAULT_LITELLM_TIMEOUT_SECONDS,
-        }
-        if self._api_key:
-            kwargs["api_key"] = self._api_key
-        if self.api_base:
-            kwargs["api_base"] = self.api_base
-
-        response = completion_with_litellm_policy(self._litellm.completion, kwargs)
-        self._total_calls += 1
-
-        content = response.choices[0].message.content or ""
-        usage = getattr(response, "usage", {})
-        tokens = getattr(usage, "total_tokens", 0) or 0
-        self._total_tokens += tokens
-
-        metadata = {
-            "model": self.model,
-            "tokens": tokens,
-            "finish_reason": response.choices[0].finish_reason,
-        }
-        return content, metadata
-
-    @property
-    def total_calls(self) -> int:
-        return self._total_calls
-
-    @property
-    def total_tokens(self) -> int:
-        return self._total_tokens
+# ---------------------------------------------------------------------------
+# Filename / frontmatter helpers
+# ---------------------------------------------------------------------------
 
 
-class GitHubDepthProcessor:
-    """GitHub项目13节深度解读生成器"""
-
-    SYSTEM_PROMPT = """你是专业的技术文档分析师，负责为GitHub项目创建13节深度解读。
-
-## 13节结构
-
-1. **一句话概述** (One-sentence Summary)
-   - 项目的核心定位和价值主张
-
-2. **项目定位** (Project Positioning)
-   - 在生态系统中的位置
-   - 目标用户群体
-
-3. **README中文简介** (README Summary)
-   - 翻译并提炼README核心内容
-
-4. **核心能力** (Core Capabilities)
-   - 表格形式：能力/说明/证据来源/置信度(1-5)
-
-5. **技术架构** (Technical Architecture)
-   - ASCII图表展示架构层次
-   - 模块之间的关系
-
-6. **关键模块映射** (Module Mapping)
-   - 主要组件及其职责
-
-7. **运行与开发方式** (Usage & Development)
-   - 快速开始指南
-   - 开发环境搭建
-
-8. **外部接口** (External Interfaces)
-   - API设计概览
-   - 集成点
-
-9. **数据流/控制流** (Data & Control Flow)
-   - 关键流程的ASCII图表
-
-10. **技术栈判断** (Technology Stack)
-    - 主要语言和框架
-    - 依赖分析
-
-11. **成熟度与风险** (Maturity & Risks)
-    - 维护状态评估
-    - 潜在风险点
-
-12. **关联概念** (Related Concepts)
-    - [[双括号链接]]到其他笔记
-    - 相关技术栈
-
-13. **页脚** (Footer)
-    - 参考链接
-    - 更新日期
-
-## 输出格式要求
-
-1. YAML frontmatter必须包含：
-   - title: 项目名称
-   - github: 完整URL
-   - owner: 仓库所有者
-   - repo: 仓库名
-   - date: 处理日期
-   - type: github-project
-   - tags: [tool, ai, ...]
-   - stars: star数量
-
-2. 技术架构和数据流必须用ASCII图表
-
-3. 核心能力表格必须有置信度列(1-5)
-
-4. 不确定的信息标注"未知"或"未说明"
-
-5. 无README时基于名称推断，但标注低置信度
-"""
-
-    def __init__(self, llm_client: LiteLLMClient):
-        self.llm = llm_client
-
-    def generate_depth_doc(self, repo: GitHubRepo) -> tuple[str, dict]:
-        user_prompt = f"""为以下GitHub项目创建13节深度解读：
-
-项目URL: {repo.url}
-Owner: {repo.owner}
-Repo: {repo.repo}
-日期: {repo.date}
-Tags: {', '.join(repo.tags)}
-描述: {repo.description}
-Stars: {repo.stars if repo.stars else '未知'}
-
-README内容:
-```
-{repo.readme_content[:8000] if repo.readme_content else '未获取README'}
-```
-
-请严格按照13节结构输出完整Markdown（从--- frontmatter开始）。"""
-
-        content, metadata = self.llm.generate(
-            system_prompt=self.SYSTEM_PROMPT,
-            user_prompt=user_prompt,
-            max_tokens=8000,
-        )
-        return sanitize_generated_markdown(content), metadata
+_FILENAME_SAFE = re.compile(r"[^A-Za-z0-9_\-]+")
 
 
-def fetch_github_readme(owner: str, repo: str) -> tuple[str, int]:
-    """获取GitHub项目README和stars数"""
-    import requests
-    import json
-
-    readme_content = ""
-    stars = 0
-
-    # 尝试获取README
-    branches = ["main", "master", "develop"]
-    for branch in branches:
-        for filename in ["README.md", "readme.md"]:
-            url = f"https://raw.githubusercontent.com/{owner}/{repo}/{branch}/{filename}"
-            try:
-                resp = requests.get(url, timeout=10)
-                if resp.status_code == 200:
-                    readme_content = resp.text
-                    break
-            except Exception:
-                continue
-        if readme_content:
-            break
-
-    # 获取stars数
-    try:
-        resp = requests.get(
-            f"https://api.github.com/repos/{owner}/{repo}",
-            headers={"Accept": "application/vnd.github.v3+json"},
-            timeout=10,
-        )
-        if resp.status_code == 200:
-            stars = resp.json().get("stargazers_count", 0)
-    except Exception:
-        pass
-
-    return readme_content, stars
+def _safe_segment(value: str) -> str:
+    """Make ``owner`` or ``repo`` safe for a filename without losing the
+    canonical github name.  Keep alphanumerics/underscore/hyphen, drop
+    everything else."""
+    out = _FILENAME_SAFE.sub("-", value).strip("-")
+    return out or "unknown"
 
 
-def parse_github_url(url: str) -> tuple[str, str] | None:
-    """解析GitHub URL提取owner和repo"""
-    parsed = urlparse(url)
-    if parsed.netloc not in ["github.com", "www.github.com"]:
-        return None
+def _build_output_filename(date: str, owner: str, repo: str) -> str:
+    """Match the article-processor convention: ``YYYY-MM-DD_<slug>.md``.
 
-    parts = parsed.path.strip("/").split("/")
-    if len(parts) < 2:
-        return None
+    No ``_深度解读`` suffix — this is a raw processed source, not a
+    deep-dive.  Frontmatter ``source_type: github-project`` is what
+    distinguishes it for absorb / index.
+    """
+    return f"{date}_{_safe_segment(owner)}_{_safe_segment(repo)}.md"
 
-    return parts[0], parts[1]
+
+def _yaml_escape(value: Any) -> str:
+    """Minimal YAML scalar escape — wrap in double-quotes when the
+    value contains characters that would confuse a YAML parser."""
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    s = str(value)
+    if not s:
+        return '""'
+    if any(c in s for c in ':#"\'\\\n[]{}'):
+        escaped = s.replace("\\", "\\\\").replace('"', '\\"')
+        return f'"{escaped}"'
+    return s
+
+
+def _build_frontmatter(
+    *,
+    title: str,
+    url: str,
+    owner: str,
+    repo: str,
+    date: str,
+    tags: list[str],
+    enriched: EnrichedSource,
+    fetched_at: str,
+) -> str:
+    """Render frontmatter for the processed github markdown."""
+    meta = enriched.metadata
+    fields: list[tuple[str, Any]] = [
+        ("title", title or f"{owner}/{repo}"),
+        ("source", url),
+        ("source_type", "github-project"),
+        ("source_tier", enriched.tier),
+        ("github_owner", owner),
+        ("github_repo", repo),
+    ]
+    if "github_stars" in meta:
+        fields.append(("github_stars", meta["github_stars"]))
+    fields.append(("source_fetched_at", fetched_at))
+
+    # Tier-specific metadata — flat, prefixed so they don't collide.
+    if enriched.tier == "deepwiki":
+        if meta.get("deepwiki_last_indexed"):
+            fields.append(("source_indexed_at", meta["deepwiki_last_indexed"]))
+        if meta.get("deepwiki_section_count") is not None:
+            fields.append(("deepwiki_section_count", meta["deepwiki_section_count"]))
+    elif enriched.tier == "gitingest":
+        if meta.get("gitingest_commit"):
+            fields.append(("gitingest_commit", meta["gitingest_commit"]))
+        if meta.get("gitingest_file_count") is not None:
+            fields.append(("gitingest_file_count", meta["gitingest_file_count"]))
+
+    fields.append(("date", date))
+    fields.append(("type", "raw"))
+    if tags:
+        fields.append(("tags", "[" + ", ".join(_yaml_escape(t) for t in tags) + "]"))
+
+    lines = ["---"]
+    for key, value in fields:
+        if key == "tags":
+            lines.append(f"{key}: {value}")
+        else:
+            lines.append(f"{key}: {_yaml_escape(value)}")
+    lines.append("---")
+    return "\n".join(lines)
+
+
+def _build_body_header(enriched: EnrichedSource, url: str) -> str:
+    """Short provenance preamble at the top of the body so a human
+    reader can see at a glance which tier this came from."""
+    lines = [
+        f"# {enriched.owner}/{enriched.repo}",
+        "",
+        f"_Source: [{url}]({url})_",
+        f"_Enrichment tier: **{enriched.tier}**_",
+    ]
+    meta = enriched.metadata
+    if enriched.tier == "deepwiki":
+        if meta.get("deepwiki_last_indexed"):
+            lines.append(f"_DeepWiki last indexed: {meta['deepwiki_last_indexed']}_")
+    elif enriched.tier == "gitingest":
+        if meta.get("gitingest_commit"):
+            lines.append(f"_GitIngest commit: `{meta['gitingest_commit'][:12]}`_")
+        if meta.get("gitingest_file_count"):
+            lines.append(f"_GitIngest files analyzed: {meta['gitingest_file_count']}_")
+    if "github_stars" in meta:
+        lines.append(f"_Stars: {meta['github_stars']}_")
+    lines.append("")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Core: process one URL
+# ---------------------------------------------------------------------------
 
 
 def process_single_repo(
+    *,
     url: str,
     date: str,
     tags: list[str],
     description: str,
-    llm_client: LiteLLMClient,
     output_dir: Path,
+    logger: PipelineLogger | None = None,
     dry_run: bool = False,
-) -> dict:
-    """处理单个GitHub项目"""
-    result = {
+) -> dict[str, Any]:
+    """Enrich a single GitHub URL and write the processed markdown.
+
+    Returns a result dict with ``status`` ∈ {completed, skipped, error}.
+
+    Behavioral changes from the pre-BL-066 implementation:
+    - No LLM call (no ``llm_client`` parameter).
+    - Output goes to ``50-Inbox/03-Processed/<YYYY-MM>/`` not
+      ``20-Areas/Tools/Topics/<YYYY-MM>/``.
+    - Filename has no ``_深度解读`` suffix.
+    - On total enrichment failure (all 3 tiers empty), we still write
+      a frontmatter-only stub so the source is tracked, but flag
+      ``status=skipped`` and ``warning="empty_body"``.
+    """
+    result: dict[str, Any] = {
         "url": url,
         "status": "pending",
         "output_file": None,
-        "tokens_used": 0,
+        "tier": None,
         "error": None,
     }
 
-    # 解析URL
     parsed = parse_github_url(url)
     if not parsed:
         result["status"] = "error"
         result["error"] = "Invalid GitHub URL"
+        if logger:
+            logger.log("github_intake_error", {"url": url, "error": result["error"]})
+        return result
+    owner, repo = parsed
+
+    print(f"  Enriching {owner}/{repo} (tier 1 → 2 → 3) …")
+    try:
+        enriched = enrich_github_source(owner, repo)
+    except Exception as exc:  # noqa: BLE001 — enrichment is best-effort
+        result["status"] = "error"
+        result["error"] = f"enrich_github_source failed: {exc}"
+        if logger:
+            logger.log("github_intake_error", {"url": url, "error": result["error"]})
         return result
 
-    owner, repo_name = parsed
+    result["tier"] = enriched.tier
+    print(f"  → tier: {enriched.tier}, body: {len(enriched.body)} chars")
 
-    # 获取README
-    print(f"  Fetching README for {owner}/{repo_name}...")
-    readme_content, stars = fetch_github_readme(owner, repo_name)
+    if dry_run:
+        result["status"] = "dry_run"
+        result["output_file"] = "(dry run)"
+        return result
 
-    repo = GitHubRepo(
+    fetched_at = datetime.now(timezone.utc).isoformat()
+    title = description.strip() if description else f"{owner}/{repo}"
+
+    frontmatter = _build_frontmatter(
+        title=title,
         url=url,
         owner=owner,
-        repo=repo_name,
+        repo=repo,
         date=date,
         tags=tags,
-        description=description,
-        readme_content=readme_content,
-        stars=stars,
+        enriched=enriched,
+        fetched_at=fetched_at,
     )
+    body_header = _build_body_header(enriched, url)
 
-    # 生成深度解读
-    print(f"  Generating 13-section depth document...")
-    processor = GitHubDepthProcessor(llm_client)
+    if enriched.body.strip():
+        full_content = f"{frontmatter}\n\n{body_header}\n{enriched.body}\n"
+        result_status = "completed"
+    else:
+        # All tiers returned empty body — still record the source, but
+        # mark as skipped so absorb won't try to extract from it.
+        full_content = (
+            f"{frontmatter}\n\n{body_header}\n"
+            "_All enrichment tiers returned empty content. "
+            "This source has been recorded but contains no extractable body._\n"
+        )
+        result_status = "skipped"
+        result["error"] = "empty_body"
 
-    try:
-        content, metadata = processor.generate_depth_doc(repo)
-        result["tokens_used"] = metadata.get("tokens", 0)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    safe_name = _build_output_filename(date, owner, repo)
+    output_path = output_dir / safe_name
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write(full_content)
 
-        if dry_run:
-            result["status"] = "dry_run"
-            result["output_file"] = "(dry run)"
-            return result
+    result["status"] = result_status
+    result["output_file"] = str(output_path)
+    print(f"  ✓ Wrote: {output_path}")
 
-        # 写入文件
-        output_dir.mkdir(parents=True, exist_ok=True)
-        safe_name = f"{date}_{owner}_{repo_name}_深度解读.md"
-        output_path = output_dir / safe_name
-
-        with open(output_path, "w", encoding="utf-8") as f:
-            f.write(content)
-
-        result["status"] = "completed"
-        result["output_file"] = str(output_path)
-        print(f"  ✓ Created: {output_path}")
-
-    except Exception as e:
-        result["status"] = "error"
-        result["error"] = str(e)
-        print(f"  ✗ Error: {e}")
-
+    if logger:
+        logger.log("github_intake_completed", {
+            "url": url,
+            "owner": owner,
+            "repo": repo,
+            "tier": enriched.tier,
+            "body_chars": len(enriched.body),
+            "output_file": str(output_path),
+            "status": result_status,
+        })
     return result
 
 
-def main():
-    parser = argparse.ArgumentParser(description="GitHub项目13节深度解读生成器")
-    parser.add_argument("--input", "-i", help="输入文件（每行一个GitHub URL）")
-    parser.add_argument("--single", "-s", help="单个GitHub URL")
-    parser.add_argument("--process-single", type=Path,
-                        help="处理单个 pinboard 书签文件，提取 URL 并深度解读")
-    parser.add_argument("--vault-dir", type=Path, default=None,
-                        help="Vault 根目录（默认: 当前工作目录）")
-    parser.add_argument("--output-dir", "-o", type=Path, default=None,
-                        help="输出目录（默认: <vault>/20-Areas/Tools/Topics/YYYY-MM）")
-    parser.add_argument("--model", "-m", default=None, help="LLM模型（默认读取 AUTO_VAULT_MODEL）")
-    parser.add_argument("--api-type", default="anthropic", choices=["anthropic", "openai"])
-    parser.add_argument("--api-key", help="API Key（或设置AUTO_VAULT_API_KEY环境变量）")
-    parser.add_argument("--api-base", help="API Base URL")
-    parser.add_argument("--dry-run", action="store_true", help="预览模式")
-    parser.add_argument("--delay", "-d", type=float, default=1.0, help="调用间隔（秒）")
+# ---------------------------------------------------------------------------
+# Pinboard stub parsing (used by --process-single)
+# ---------------------------------------------------------------------------
 
+
+def _parse_pinboard_stub(path: Path) -> dict[str, Any] | None:
+    """Read a pinboard-style stub and extract URL/title/date/tags.
+
+    The pinboard intake writes frontmatter like::
+
+        ---
+        title: "owner/repo"
+        source: https://github.com/owner/repo
+        date: 2026-04-28
+        tags: [github, agent]
+        ---
+
+    We do a light regex parse — the pinboard step writes deterministic
+    frontmatter so we don't need a full YAML parser here.
+    """
+    try:
+        content = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+    source_match = re.search(r"^source\s*:\s*(.+)$", content, re.MULTILINE)
+    if not source_match:
+        return None
+    title_match = re.search(r'^title\s*:\s*"?([^"\n]+?)"?\s*$', content, re.MULTILINE)
+    date_match = re.search(r"^date\s*:\s*(.+)$", content, re.MULTILINE)
+    tags_match = re.search(r"^tags\s*:\s*\[(.+?)\]", content, re.MULTILINE)
+
+    return {
+        "url": source_match.group(1).strip().strip('"'),
+        "title": title_match.group(1).strip() if title_match else "",
+        "date": (
+            date_match.group(1).strip() if date_match
+            else datetime.now().strftime("%Y-%m-%d")
+        ),
+        "tags": (
+            [t.strip().strip('"') for t in tags_match.group(1).split(",")]
+            if tags_match else []
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="ovp-github",
+        description=(
+            "GitHub source enrichment (DeepWiki → GitIngest → README). "
+            "Outputs to 50-Inbox/03-Processed/, NOT 20-Areas/Tools/Topics/."
+        ),
+    )
+    parser.add_argument("--input", "-i", help="文件路径，每行一个 GitHub URL")
+    parser.add_argument("--single", "-s", help="单个 GitHub URL")
+    parser.add_argument(
+        "--process-single", type=Path,
+        help="处理单个 pinboard 书签文件，提取 URL 并跑 enrichment",
+    )
+    parser.add_argument("--vault-dir", type=Path, default=None)
+    parser.add_argument(
+        "--output-dir", "-o", type=Path, default=None,
+        help="输出目录（默认：<vault>/50-Inbox/03-Processed/YYYY-MM/）",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--delay", "-d", type=float, default=1.0)
     args = parser.parse_args()
 
     if not any([args.input, args.single, args.process_single]):
         parser.print_help()
-        sys.exit(1)
+        return 1
 
     layout = VaultLayout.from_vault(args.vault_dir or VAULT_DIR)
     load_env_file(layout.vault_dir)
-    args.output_dir = Path(args.output_dir).expanduser().resolve() if args.output_dir else build_default_output_dir(layout.vault_dir)
+    output_dir = (
+        Path(args.output_dir).expanduser().resolve()
+        if args.output_dir else build_default_output_dir(layout.vault_dir)
+    )
+    logger = PipelineLogger(layout.pipeline_log)
 
-    # 初始化LLM
-    try:
-        llm_client = LiteLLMClient(
-            model=args.model,
-            api_type=args.api_type,
-            api_key=args.api_key,
-            api_base=args.api_base,
-        )
-        print(f"✓ LLM Client: {llm_client.model}")
-    except ValueError as e:
-        print(f"✗ {e}")
-        sys.exit(1)
-
-    # 构建URL列表
-    urls_to_process = []
+    # Build URL list
+    urls_to_process: list[dict[str, Any]] = []
     if args.single:
         urls_to_process.append({
             "url": args.single,
@@ -496,36 +485,22 @@ def main():
                         "description": "",
                     })
     elif args.process_single:
-        # 从 pinboard 文件读取 frontmatter 提取 URL
-        import re
-        content = args.process_single.read_text(encoding="utf-8")
-        source_match = re.search(r'^source:\s*(.+)$', content, re.MULTILINE)
-        title_match = re.search(r'^title:\s*"?(.+?)"?\s*$', content, re.MULTILINE)
-        date_match = re.search(r'^date:\s*(.+)$', content, re.MULTILINE)
-        tags_match = re.search(r'^tags:\s*\[(.+?)\]', content, re.MULTILINE)
-
-        if not source_match:
+        stub = _parse_pinboard_stub(args.process_single)
+        if not stub:
             print(f"❌ 无法从文件提取 source URL: {args.process_single}")
-            sys.exit(1)
-
-        source = source_match.group(1).strip()
-        title = title_match.group(1).strip() if title_match else None
-        date = date_match.group(1).strip() if date_match else datetime.now().strftime("%Y-%m-%d")
-        tags = [t.strip() for t in tags_match.group(1).split(",")] if tags_match else []
-
+            return 1
         urls_to_process.append({
-            "url": source,
-            "date": date,
-            "tags": tags,
-            "description": title or "",
+            "url": stub["url"],
+            "date": stub["date"],
+            "tags": stub["tags"],
+            "description": stub["title"],
         })
 
-    print(f"\nProcessing {len(urls_to_process)} GitHub repositories...")
-    print(f"Output: {args.output_dir}")
+    print(f"\nProcessing {len(urls_to_process)} GitHub repositories…")
+    print(f"Output: {output_dir}")
     print("=" * 60)
 
-    # 处理
-    results = []
+    results: list[dict[str, Any]] = []
     for i, item in enumerate(urls_to_process, 1):
         print(f"\n[{i}/{len(urls_to_process)}] {item['url']}")
         result = process_single_repo(
@@ -533,36 +508,41 @@ def main():
             date=item["date"],
             tags=item["tags"],
             description=item["description"],
-            llm_client=llm_client,
-            output_dir=args.output_dir,
+            output_dir=output_dir,
+            logger=logger,
             dry_run=args.dry_run,
         )
         maybe_archive_pinboard_process_single(
             layout,
-            args.process_single if args.process_single and len(urls_to_process) == 1 else None,
+            (
+                args.process_single
+                if args.process_single and len(urls_to_process) == 1 else None
+            ),
             result,
             dry_run=args.dry_run,
         )
         results.append(result)
-
         if i < len(urls_to_process):
             time.sleep(args.delay)
 
-    # 汇总
     print("\n" + "=" * 60)
     print("SUMMARY")
     print("=" * 60)
-    successful = sum(1 for r in results if r["status"] == "completed")
-    failed = sum(1 for r in results if r["status"] == "error")
-    total_tokens = sum(r.get("tokens_used", 0) for r in results)
+    by_status = {"completed": 0, "skipped": 0, "error": 0, "dry_run": 0}
+    by_tier = {"deepwiki": 0, "gitingest": 0, "readme": 0, None: 0}
+    for r in results:
+        by_status[r.get("status", "error")] = by_status.get(r.get("status", "error"), 0) + 1
+        by_tier[r.get("tier")] = by_tier.get(r.get("tier"), 0) + 1
+    print(f"Total: {len(results)}")
+    for status, n in by_status.items():
+        if n:
+            print(f"  {status:10s}: {n}")
+    print("Tier breakdown:")
+    for tier in ("deepwiki", "gitingest", "readme"):
+        print(f"  {tier:10s}: {by_tier.get(tier, 0)}")
 
-    print(f"Total: {len(results)} | Success: {successful} | Failed: {failed}")
-    print(f"Total Tokens: {total_tokens:,}")
-    print(f"Total Calls: {llm_client.total_calls}")
-
-    return 0 if failed == 0 else 1
+    return 0 if by_status["error"] == 0 else 1
 
 
 if __name__ == "__main__":
-    import json
     sys.exit(main())

--- a/src/ovp_pipeline/auto_github_processor.py
+++ b/src/ovp_pipeline/auto_github_processor.py
@@ -197,14 +197,21 @@ def _build_frontmatter(
     tags: list[str],
     enriched: EnrichedSource,
     fetched_at: str,
+    extraction_status: str = "completed",
 ) -> str:
-    """Render frontmatter for the processed github markdown."""
+    """Render frontmatter for the processed github markdown.
+
+    ``extraction_status`` defaults to ``completed``; pass ``skipped``
+    when all enrichment tiers returned empty so the absorb scanner
+    skips this file (see _is_github_source_markdown's status filter).
+    """
     meta = enriched.metadata
     fields: list[tuple[str, Any]] = [
         ("title", title or f"{owner}/{repo}"),
         ("source", url),
         ("source_type", "github-project"),
         ("source_tier", enriched.tier),
+        ("extraction_status", extraction_status),
         ("github_owner", owner),
         ("github_repo", repo),
     ]
@@ -329,6 +336,9 @@ def process_single_repo(
     fetched_at = datetime.now(timezone.utc).isoformat()
     title = description.strip() if description else f"{owner}/{repo}"
 
+    has_body = bool(enriched.body.strip())
+    extraction_status = "completed" if has_body else "skipped"
+
     frontmatter = _build_frontmatter(
         title=title,
         url=url,
@@ -338,15 +348,18 @@ def process_single_repo(
         tags=tags,
         enriched=enriched,
         fetched_at=fetched_at,
+        extraction_status=extraction_status,
     )
     body_header = _build_body_header(enriched, url)
 
-    if enriched.body.strip():
+    if has_body:
         full_content = f"{frontmatter}\n\n{body_header}\n{enriched.body}\n"
         result_status = "completed"
     else:
         # All tiers returned empty body — still record the source, but
-        # mark as skipped so absorb won't try to extract from it.
+        # frontmatter ``extraction_status: skipped`` makes absorb's
+        # _is_github_source_markdown reject this file so it isn't
+        # treated as a candidate for evergreen extraction.
         full_content = (
             f"{frontmatter}\n\n{body_header}\n"
             "_All enrichment tiers returned empty content. "

--- a/src/ovp_pipeline/github_enrichment.py
+++ b/src/ovp_pipeline/github_enrichment.py
@@ -381,36 +381,60 @@ def fetch_gitingest(owner: str, repo: str) -> Optional[tuple[str, dict]]:
 # ---------------------------------------------------------------------------
 
 
+_README_FILENAMES = (
+    "README.md", "readme.md", "Readme.md",
+    "README.markdown", "README.rst", "README.txt", "README",
+)
+_README_BRANCH_FALLBACKS = ("main", "master", "develop", "dev", "trunk")
+
+
 def fetch_readme(owner: str, repo: str) -> tuple[str, int]:
-    """Final fallback — same as the previous ``fetch_github_readme``.
+    """Final fallback — fetch README + stars.
+
+    Strategy:
+      1. Hit ``api.github.com/repos/{owner}/{repo}`` once to get
+         ``default_branch`` and ``stargazers_count`` in a single
+         request.  This handles non-standard branches that the old
+         hardcoded ``main/master/develop`` list missed.
+      2. Try each filename in ``_README_FILENAMES`` against the
+         default branch.
+      3. If that fails (rate-limited API, 404, etc.), fall back to
+         the historical branch+filename grid.
 
     Always returns a tuple; ``body`` may be empty if the repo has no
-    README on any default branch.
+    README anywhere we can find.
     """
-    body = ""
-    branches = ["main", "master", "develop"]
+    stars = 0
+    default_branch: Optional[str] = None
+    api_text = _http_get(
+        f"https://api.github.com/repos/{owner}/{repo}",
+        timeout=10.0,
+    )
+    if api_text:
+        try:
+            data = json.loads(api_text)
+            default_branch = data.get("default_branch")
+            stars = int(data.get("stargazers_count", 0) or 0)
+        except (json.JSONDecodeError, ValueError, TypeError):
+            pass
+
+    # Build branch list: API-reported default first, then the hardcoded
+    # fallbacks (deduped, preserving order).
+    branches: list[str] = []
+    seen: set[str] = set()
+    for branch in (default_branch, *_README_BRANCH_FALLBACKS):
+        if branch and branch not in seen:
+            seen.add(branch)
+            branches.append(branch)
+
     for branch in branches:
-        for filename in ["README.md", "readme.md"]:
+        for filename in _README_FILENAMES:
             url = f"https://raw.githubusercontent.com/{owner}/{repo}/{branch}/{filename}"
             text = _http_get(url, timeout=10.0)
             if text:
-                body = text
-                break
-        if body:
-            break
+                return text, stars
 
-    stars = 0
-    try:
-        api_text = _http_get(
-            f"https://api.github.com/repos/{owner}/{repo}",
-            timeout=10.0,
-        )
-        if api_text:
-            stars = int(json.loads(api_text).get("stargazers_count", 0) or 0)
-    except (json.JSONDecodeError, ValueError, TypeError):
-        pass
-
-    return body, stars
+    return "", stars
 
 
 # ---------------------------------------------------------------------------
@@ -456,7 +480,12 @@ def enrich_github_source(owner: str, repo: str) -> EnrichedSource:
 def parse_github_url(url: str) -> Optional[tuple[str, str]]:
     """Parse ``https://github.com/owner/repo`` into ``(owner, repo)``."""
     parsed = urlparse(url)
-    if parsed.netloc.lower().lstrip("www.") not in ("github.com",):
+    netloc = parsed.netloc.lower()
+    # ``str.lstrip(chars)`` strips a CHARACTER CLASS, not a prefix string —
+    # ``"wwwgithub.com".lstrip("www.")`` returns ``"github.com"`` and would
+    # incorrectly accept that as a github URL.  Use ``removeprefix`` so we
+    # only strip the literal ``www.`` prefix.
+    if netloc.removeprefix("www.") != "github.com":
         return None
     parts = [p for p in parsed.path.strip("/").split("/") if p]
     if len(parts) < 2:

--- a/src/ovp_pipeline/github_enrichment.py
+++ b/src/ovp_pipeline/github_enrichment.py
@@ -1,0 +1,468 @@
+"""3-tier enrichment for GitHub repo sources (BL-066).
+
+The previous github intake fetched only ``README.md`` + stars and then
+ran a 13-section LLM "深度解读" prompt to manufacture an article.  That
+template forced abstraction inflation (``项目定位``, ``技术架构``, …)
+and produced wiki-shaped output that absorb then had to re-flatten back
+into atomic units — two LLM passes, both lossy.
+
+This module replaces the README fetch with a 3-tier chain that returns
+a richer, *non-LLM-rewritten* body.  Downstream absorb reads the body
+directly with no intermediate template:
+
+    Tier 1  DeepWiki    pre-rendered structured wiki (Devin-indexed).
+                        ~70% coverage on our actual github URLs as of
+                        2026-05-05.  Highest quality when present —
+                        retains specific numbers, method names, model
+                        formats, etc.
+    Tier 2  GitIngest   clones the repo (depth=1) and concatenates the
+                        textual files.  Always works for any public
+                        repo; we filter to docs/markdown only so the
+                        body stays readable.
+    Tier 3  README      original behavior — fetch README.md from
+                        raw.githubusercontent.com.  Last-resort.
+
+Each tier returns a tuple ``(body_markdown, metadata)``; the caller
+decides which tier to use based on what's available.
+
+Why not Zread:
+    Tested 2026-05-05 — Cloudflare's bot protection serves a 403 with
+    JS challenge to server-side requests.  Headless-browser fetch is
+    out of scope; treat Zread as not-available.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from typing import Optional
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Result type
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class EnrichedSource:
+    """The output of ``enrich_github_source``.
+
+    ``body`` is markdown ready to drop into a ``50-Inbox/03-Processed``
+    file.  ``tier`` identifies which fallback was used so frontmatter
+    can record provenance.
+    """
+    owner: str
+    repo: str
+    tier: str  # "deepwiki" | "gitingest" | "readme"
+    body: str
+    metadata: dict = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — DeepWiki
+# ---------------------------------------------------------------------------
+
+DEEPWIKI_BASE = "https://deepwiki.com"
+
+# DeepWiki gates everything behind a SPA shell.  Real wiki pages contain
+# the literal string ``Last indexed`` in the HTML; an unindexed repo
+# returns the same shell with a "Loading…" placeholder and no
+# ``Last indexed`` marker.  This is the cheapest reliable detector.
+_DEEPWIKI_INDEXED_MARKER = "Last indexed"
+
+# Cap section count so a pathological wiki doesn't run away.  Real
+# DeepWikis we sampled have 8-25 sections; 60 is well above that.
+_DEEPWIKI_MAX_SECTIONS = 60
+
+
+def _http_get(url: str, timeout: float = 12.0) -> Optional[str]:
+    """GET a URL and return the response body, or None on any failure.
+
+    We deliberately swallow exceptions and return None — the caller is
+    a fallback chain, and any HTTP error means "try the next tier".
+    """
+    try:
+        req = urllib.request.Request(
+            url,
+            headers={"User-Agent": "ovp-github-enrichment/1.0"},
+        )
+        with urllib.request.urlopen(req, timeout=timeout) as response:
+            raw = response.read()
+            return raw.decode("utf-8", errors="ignore")
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError) as exc:
+        logger.debug("HTTP GET failed for %s: %s", url, exc)
+        return None
+    except Exception as exc:  # noqa: BLE001 — fallback chain, never raise
+        logger.debug("HTTP GET unexpected failure for %s: %s", url, exc)
+        return None
+
+
+def _is_deepwiki_indexed(html: str) -> bool:
+    return _DEEPWIKI_INDEXED_MARKER in html
+
+
+def _extract_deepwiki_section_paths(html: str, owner: str, repo: str) -> list[str]:
+    """Find the ordered list of section subpaths from the index page.
+
+    DeepWiki's nav includes hrefs like ``/<owner>/<repo>/1-overview``,
+    ``/<owner>/<repo>/1.1-installation``, etc.  We collect them in
+    document order, dedupe, and cap.
+    """
+    pattern = re.compile(
+        rf'href="(/{re.escape(owner)}/{re.escape(repo)}/([\w.-]+))"',
+    )
+    seen: set[str] = set()
+    paths: list[str] = []
+    for match in pattern.finditer(html):
+        path, slug = match.group(1), match.group(2)
+        # skip the bare repo path
+        if not slug or slug in seen:
+            continue
+        seen.add(slug)
+        paths.append(path)
+        if len(paths) >= _DEEPWIKI_MAX_SECTIONS:
+            break
+    return paths
+
+
+def _strip_deepwiki_chrome(html: str) -> str:
+    """Strip script/style and the SPA navigation chrome, leaving only
+    the article body.
+
+    DeepWiki's rendered HTML embeds the article between the section
+    title (e.g. "Overview Relevant source files README.md") and the
+    "Sources:" trailer near the end.  We extract everything in between
+    and run a hand-rolled HTML→markdown that's good enough for the
+    downstream absorb prompt to read.
+    """
+    # Drop scripts/styles entirely
+    html = re.sub(r"<script[^>]*>.*?</script>", "", html, flags=re.DOTALL)
+    html = re.sub(r"<style[^>]*>.*?</style>", "", html, flags=re.DOTALL)
+
+    # Hand-rolled tag-to-markdown — keeps it dependency-free.  We
+    # don't need perfect rendering; we need readable text with section
+    # structure intact so absorb can pick up specifics.
+    text = html
+    text = re.sub(r"<br\s*/?>", "\n", text, flags=re.IGNORECASE)
+    text = re.sub(r"<h1[^>]*>(.*?)</h1>", r"\n# \1\n", text, flags=re.DOTALL | re.IGNORECASE)
+    text = re.sub(r"<h2[^>]*>(.*?)</h2>", r"\n## \1\n", text, flags=re.DOTALL | re.IGNORECASE)
+    text = re.sub(r"<h3[^>]*>(.*?)</h3>", r"\n### \1\n", text, flags=re.DOTALL | re.IGNORECASE)
+    text = re.sub(r"<h4[^>]*>(.*?)</h4>", r"\n#### \1\n", text, flags=re.DOTALL | re.IGNORECASE)
+    text = re.sub(r"<h5[^>]*>(.*?)</h5>", r"\n##### \1\n", text, flags=re.DOTALL | re.IGNORECASE)
+    text = re.sub(r"<h6[^>]*>(.*?)</h6>", r"\n###### \1\n", text, flags=re.DOTALL | re.IGNORECASE)
+    text = re.sub(r"<li[^>]*>(.*?)</li>", r"- \1\n", text, flags=re.DOTALL | re.IGNORECASE)
+    text = re.sub(r"<code[^>]*>(.*?)</code>", r"`\1`", text, flags=re.DOTALL | re.IGNORECASE)
+    text = re.sub(r"<pre[^>]*>(.*?)</pre>", r"\n```\n\1\n```\n", text, flags=re.DOTALL | re.IGNORECASE)
+    # collapse remaining tags
+    text = re.sub(r"<[^>]+>", " ", text)
+    # decode common entities
+    text = (
+        text
+        .replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", '"')
+        .replace("&#39;", "'")
+        .replace("&#x27;", "'")
+        .replace("&nbsp;", " ")
+    )
+    # collapse runs of whitespace, preserve paragraph breaks
+    text = re.sub(r"[ \t]+", " ", text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
+
+
+def _isolate_deepwiki_main_content(text: str) -> str:
+    """Drop the SPA chrome (header/nav with 'Index your code with Devin'
+    etc.) so what remains is the article body.
+
+    Heuristic: real content begins at the first content marker we
+    can find — the 'Relevant source files' line, or the first level-2
+    heading.  Everything before that is nav.
+    """
+    # The most common content start
+    for marker in (
+        "Relevant source files",
+        "This document provides",
+        "What is",
+    ):
+        idx = text.find(marker)
+        if idx > 200:  # skip if marker is in the nav block
+            return text[idx:].strip()
+    # Fallback: drop everything up to the first ## heading
+    h2_match = re.search(r"^##\s", text, flags=re.MULTILINE)
+    if h2_match:
+        return text[h2_match.start():].strip()
+    return text
+
+
+def fetch_deepwiki(owner: str, repo: str) -> Optional[tuple[str, dict]]:
+    """Try to fetch a DeepWiki for ``{owner}/{repo}``.
+
+    Returns ``(body_markdown, metadata)`` if a real wiki exists.
+    Returns ``None`` when the repo isn't indexed.
+    """
+    index_url = f"{DEEPWIKI_BASE}/{owner}/{repo}"
+    index_html = _http_get(index_url)
+    if not index_html:
+        return None
+    if not _is_deepwiki_indexed(index_html):
+        return None
+
+    # Extract last-indexed date for metadata
+    last_indexed_match = re.search(
+        r"Last indexed[:\s]*([0-9]{1,2}\s+[A-Za-z]+\s+[0-9]{4})",
+        index_html,
+    )
+    last_indexed = last_indexed_match.group(1) if last_indexed_match else None
+
+    # Walk every section subpage.  We start with the index page itself
+    # (which renders the "Overview" section as visible text) and then
+    # follow each numbered subpath.
+    sections: list[tuple[str, str]] = []  # (slug, markdown_body)
+    main_text = _strip_deepwiki_chrome(index_html)
+    main_body = _isolate_deepwiki_main_content(main_text)
+    if main_body:
+        sections.append(("index", main_body))
+
+    section_paths = _extract_deepwiki_section_paths(index_html, owner, repo)
+    for sp in section_paths:
+        url = f"{DEEPWIKI_BASE}{sp}"
+        html = _http_get(url)
+        if not html:
+            continue
+        text = _strip_deepwiki_chrome(html)
+        body = _isolate_deepwiki_main_content(text)
+        if body:
+            slug = sp.rsplit("/", 1)[-1]
+            sections.append((slug, body))
+        # be polite — DeepWiki appears to throttle
+        time.sleep(0.4)
+
+    if not sections:
+        return None
+
+    # Concatenate sections.  We don't dedupe across sections — DeepWiki
+    # itself may repeat headers across pages, but that's the source's
+    # decision and absorb can ignore boilerplate.
+    body_parts = [f"_DeepWiki section: {slug}_\n\n{body}" for slug, body in sections]
+    body = "\n\n---\n\n".join(body_parts)
+
+    metadata = {
+        "tier": "deepwiki",
+        "deepwiki_url": index_url,
+        "deepwiki_section_count": len(sections),
+        "deepwiki_last_indexed": last_indexed,
+    }
+    return body, metadata
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 — GitIngest
+# ---------------------------------------------------------------------------
+
+
+# Filter the GitIngest content to docs / markdown / config.  The full
+# clone often hits 5-50MB of source code that absorb has no use for —
+# we want narrative documentation, not implementation details.
+_GITINGEST_DOC_PATTERNS = re.compile(
+    r"(README|CHANGELOG|HISTORY|TRAINING|ARCHITECTURE|DESIGN|"
+    r"CONTRIBUTING|ROADMAP|SECURITY|GOVERNANCE|API|GLOSSARY|"
+    r"AGENTS|CLAUDE|GUIDE|TUTORIAL|FAQ|NOTES|MIGRATION|UPGRADE|"
+    r"docs?/|documentation/|wiki/|examples?/[^/]+\.(md|rst))",
+    re.IGNORECASE,
+)
+
+# Hard upper bound on body size we'll inline into a vault markdown —
+# beyond this the file becomes unreadable in Obsidian and absorb is
+# unlikely to read past it anyway.
+_GITINGEST_MAX_BODY_CHARS = 60_000
+
+
+def _gitingest_filter_content(content: str) -> str:
+    """Keep only file blocks whose path matches a documentation pattern.
+
+    GitIngest output is structured as repeated::
+
+        ============================================================
+        FILE: <path>
+        ============================================================
+        <content>
+        ...
+
+    We split on the divider, keep documentation files, drop source
+    code.  This is heuristic but conservative.
+    """
+    parts = re.split(r"=+\s*\nFILE:\s*([^\n]+)\n=+\s*\n", content)
+    # parts is [pre, path1, body1, path2, body2, ...]
+    if len(parts) < 3:
+        return content[:_GITINGEST_MAX_BODY_CHARS]
+    kept: list[str] = []
+    for i in range(1, len(parts), 2):
+        path = parts[i].strip()
+        body = parts[i + 1] if i + 1 < len(parts) else ""
+        if not _GITINGEST_DOC_PATTERNS.search(path):
+            continue
+        kept.append(f"## File: {path}\n\n{body.strip()}")
+    if not kept:
+        # No docs found — fall back to the first file (usually README)
+        first_path = parts[1].strip()
+        first_body = parts[2] if len(parts) > 2 else ""
+        kept.append(f"## File: {first_path}\n\n{first_body.strip()}")
+    out = "\n\n---\n\n".join(kept)
+    if len(out) > _GITINGEST_MAX_BODY_CHARS:
+        out = out[:_GITINGEST_MAX_BODY_CHARS] + "\n\n_[truncated by enrichment cap]_"
+    return out
+
+
+def fetch_gitingest(owner: str, repo: str) -> Optional[tuple[str, dict]]:
+    """Clone the repo via the gitingest python package and assemble a
+    markdown body from its documentation files.
+
+    Returns ``None`` if gitingest is not installed or the clone fails.
+    """
+    try:
+        from gitingest import ingest  # type: ignore
+    except ImportError:
+        logger.warning(
+            "gitingest not installed — skipping Tier 2 (pip install gitingest)",
+        )
+        return None
+
+    url = f"https://github.com/{owner}/{repo}"
+    try:
+        summary, tree, content = ingest(url)
+    except Exception as exc:  # noqa: BLE001 — clone failures fall through
+        logger.warning("gitingest failed for %s: %s", url, exc)
+        return None
+
+    filtered = _gitingest_filter_content(content)
+
+    # Build the body: summary + tree + filtered content
+    body_parts = [
+        "_GitIngest summary:_",
+        summary.strip(),
+        "",
+        "## Directory tree",
+        "",
+        "```",
+        tree.strip(),
+        "```",
+        "",
+        "## Documentation files",
+        "",
+        filtered,
+    ]
+    body = "\n".join(body_parts)
+
+    # Pull the commit hash from the summary so the metadata is
+    # reproducible even if the repo moves.
+    commit_match = re.search(r"Commit:\s*([0-9a-f]{40})", summary)
+    file_count_match = re.search(r"Files analyzed:\s*(\d+)", summary)
+    metadata = {
+        "tier": "gitingest",
+        "gitingest_url": url,
+        "gitingest_commit": commit_match.group(1) if commit_match else None,
+        "gitingest_file_count": int(file_count_match.group(1)) if file_count_match else None,
+    }
+    return body, metadata
+
+
+# ---------------------------------------------------------------------------
+# Tier 3 — README + stars (existing behavior)
+# ---------------------------------------------------------------------------
+
+
+def fetch_readme(owner: str, repo: str) -> tuple[str, int]:
+    """Final fallback — same as the previous ``fetch_github_readme``.
+
+    Always returns a tuple; ``body`` may be empty if the repo has no
+    README on any default branch.
+    """
+    body = ""
+    branches = ["main", "master", "develop"]
+    for branch in branches:
+        for filename in ["README.md", "readme.md"]:
+            url = f"https://raw.githubusercontent.com/{owner}/{repo}/{branch}/{filename}"
+            text = _http_get(url, timeout=10.0)
+            if text:
+                body = text
+                break
+        if body:
+            break
+
+    stars = 0
+    try:
+        api_text = _http_get(
+            f"https://api.github.com/repos/{owner}/{repo}",
+            timeout=10.0,
+        )
+        if api_text:
+            stars = int(json.loads(api_text).get("stargazers_count", 0) or 0)
+    except (json.JSONDecodeError, ValueError, TypeError):
+        pass
+
+    return body, stars
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def enrich_github_source(owner: str, repo: str) -> EnrichedSource:
+    """Run the 3-tier chain and return the best body we can assemble.
+
+    Always returns an ``EnrichedSource``.  When all tiers fail (e.g.
+    repo deleted), ``body`` is empty and ``tier='readme'`` —
+    downstream callers should check ``len(body)`` before trying to
+    extract knowledge from it.
+    """
+    # Always fetch stars regardless of which tier wins — it's a stable
+    # frontmatter signal independent of body provenance.
+    _, stars = fetch_readme(owner, repo)  # extracts stars cheaply
+
+    # Tier 1
+    deepwiki_result = fetch_deepwiki(owner, repo)
+    if deepwiki_result is not None:
+        body, meta = deepwiki_result
+        meta["github_stars"] = stars
+        return EnrichedSource(owner=owner, repo=repo, tier="deepwiki", body=body, metadata=meta)
+
+    # Tier 2
+    gitingest_result = fetch_gitingest(owner, repo)
+    if gitingest_result is not None:
+        body, meta = gitingest_result
+        meta["github_stars"] = stars
+        return EnrichedSource(owner=owner, repo=repo, tier="gitingest", body=body, metadata=meta)
+
+    # Tier 3 — README only
+    body, stars = fetch_readme(owner, repo)
+    return EnrichedSource(
+        owner=owner, repo=repo, tier="readme",
+        body=body,
+        metadata={"tier": "readme", "github_stars": stars},
+    )
+
+
+def parse_github_url(url: str) -> Optional[tuple[str, str]]:
+    """Parse ``https://github.com/owner/repo`` into ``(owner, repo)``."""
+    parsed = urlparse(url)
+    if parsed.netloc.lower().lstrip("www.") not in ("github.com",):
+        return None
+    parts = [p for p in parsed.path.strip("/").split("/") if p]
+    if len(parts) < 2:
+        return None
+    repo = parts[1]
+    # strip .git suffix and any trailing tree/blob refs
+    if repo.endswith(".git"):
+        repo = repo[:-4]
+    return parts[0], repo

--- a/tests/test_github_enrichment.py
+++ b/tests/test_github_enrichment.py
@@ -1,0 +1,404 @@
+"""Tests for BL-066 — GitHub enrichment chain + 03-Processed integration.
+
+Covers:
+
+* The 3-tier fallback in ``enrich_github_source``
+* Parser robustness in ``parse_github_url``
+* That ``auto_github_processor.process_single_repo`` writes to
+  ``50-Inbox/03-Processed/<YYYY-MM>/`` with the right frontmatter
+  (no more ``_深度解读`` files for github sources)
+* That absorb's ``_collect_absorb_targets`` picks up the new path
+  via the ``source_type: github-project`` frontmatter marker
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from ovp_pipeline.github_enrichment import (
+    EnrichedSource,
+    enrich_github_source,
+    parse_github_url,
+)
+from ovp_pipeline.auto_github_processor import (
+    _build_frontmatter,
+    _build_output_filename,
+    _safe_segment,
+    process_single_repo,
+)
+from ovp_pipeline.auto_evergreen_extractor import (
+    _collect_absorb_targets,
+    _is_github_source_markdown,
+)
+from ovp_pipeline.runtime import VaultLayout
+
+
+# ---------------------------------------------------------------------------
+# parse_github_url
+# ---------------------------------------------------------------------------
+
+
+class TestParseGithubURL:
+    @pytest.mark.parametrize("url, expected", [
+        ("https://github.com/owner/repo", ("owner", "repo")),
+        ("https://github.com/owner/repo.git", ("owner", "repo")),
+        ("https://github.com/owner/repo/tree/main", ("owner", "repo")),
+        ("https://github.com/owner/repo/blob/main/file.py", ("owner", "repo")),
+        ("https://www.github.com/owner/repo", ("owner", "repo")),
+    ])
+    def test_valid_urls(self, url, expected):
+        assert parse_github_url(url) == expected
+
+    @pytest.mark.parametrize("url", [
+        "https://gitlab.com/owner/repo",
+        "https://github.com/owner",            # missing repo
+        "https://example.com/owner/repo",
+        "not-a-url",
+        "",
+    ])
+    def test_rejects_non_github(self, url):
+        assert parse_github_url(url) is None
+
+
+# ---------------------------------------------------------------------------
+# enrich_github_source — 3-tier fallback
+# ---------------------------------------------------------------------------
+
+
+class TestEnrichmentChain:
+    """Verify each tier wins when the higher tier fails.
+
+    We mock at the module-internal helpers so we exercise the actual
+    fallback logic in ``enrich_github_source``, not just the helpers.
+    """
+
+    def test_tier1_deepwiki_wins(self):
+        with (
+            patch(
+                "ovp_pipeline.github_enrichment.fetch_deepwiki",
+                return_value=("# DeepWiki body", {"deepwiki_section_count": 5, "deepwiki_last_indexed": "2026-01-20"}),
+            ),
+            patch("ovp_pipeline.github_enrichment.fetch_readme", return_value=("# README", 42)),
+            patch("ovp_pipeline.github_enrichment.fetch_gitingest") as gitingest_mock,
+        ):
+            result = enrich_github_source("owner", "repo")
+        assert result.tier == "deepwiki"
+        assert result.body == "# DeepWiki body"
+        assert result.metadata["github_stars"] == 42
+        assert result.metadata["deepwiki_last_indexed"] == "2026-01-20"
+        # Tier 2 must NOT be invoked when Tier 1 hits
+        gitingest_mock.assert_not_called()
+
+    def test_tier2_gitingest_when_deepwiki_misses(self):
+        with (
+            patch("ovp_pipeline.github_enrichment.fetch_deepwiki", return_value=None),
+            patch(
+                "ovp_pipeline.github_enrichment.fetch_gitingest",
+                return_value=("# GitIngest body", {"gitingest_commit": "abc123" + "0" * 34}),
+            ),
+            patch("ovp_pipeline.github_enrichment.fetch_readme", return_value=("# README", 7)),
+        ):
+            result = enrich_github_source("owner", "repo")
+        assert result.tier == "gitingest"
+        assert result.body == "# GitIngest body"
+        assert result.metadata["github_stars"] == 7
+
+    def test_tier3_readme_when_higher_fail(self):
+        with (
+            patch("ovp_pipeline.github_enrichment.fetch_deepwiki", return_value=None),
+            patch("ovp_pipeline.github_enrichment.fetch_gitingest", return_value=None),
+            patch(
+                "ovp_pipeline.github_enrichment.fetch_readme",
+                return_value=("# Just the README\n\nbody", 999),
+            ),
+        ):
+            result = enrich_github_source("owner", "repo")
+        assert result.tier == "readme"
+        assert result.body == "# Just the README\n\nbody"
+        assert result.metadata["github_stars"] == 999
+
+    def test_all_tiers_fail_returns_empty_body(self):
+        """Every tier returns empty/None — should still return a
+        valid EnrichedSource with empty body, NOT raise.
+
+        Caller (``process_single_repo``) decides what to do with
+        empty body — it writes a stub-only markdown so the source is
+        still tracked.
+        """
+        with (
+            patch("ovp_pipeline.github_enrichment.fetch_deepwiki", return_value=None),
+            patch("ovp_pipeline.github_enrichment.fetch_gitingest", return_value=None),
+            patch("ovp_pipeline.github_enrichment.fetch_readme", return_value=("", 0)),
+        ):
+            result = enrich_github_source("ghost", "ghost")
+        assert result.tier == "readme"
+        assert result.body == ""
+
+
+# ---------------------------------------------------------------------------
+# Filename + frontmatter
+# ---------------------------------------------------------------------------
+
+
+class TestFilenameAndFrontmatter:
+    def test_filename_no_深度解读_suffix(self):
+        """BL-066: github sources are no longer deep-dives.  The
+        filename MUST NOT carry ``_深度解读``.  This test is the
+        regression guard against accidental reintroduction.
+        """
+        name = _build_output_filename("2026-04-28", "neuphonic", "neutts")
+        assert name == "2026-04-28_neuphonic_neutts.md"
+        assert "深度解读" not in name
+
+    @pytest.mark.parametrize("input_name, expected", [
+        ("ok-name", "ok-name"),
+        ("name with spaces", "name-with-spaces"),
+        ("name/with/slashes", "name-with-slashes"),
+        ("name.with.dots", "name-with-dots"),
+        ("---", "unknown"),  # all stripped → fallback
+    ])
+    def test_safe_segment(self, input_name, expected):
+        assert _safe_segment(input_name) == expected
+
+    def test_frontmatter_records_tier(self):
+        enriched = EnrichedSource(
+            owner="neuphonic", repo="neutts", tier="deepwiki",
+            body="# stuff",
+            metadata={
+                "tier": "deepwiki",
+                "deepwiki_last_indexed": "2026-01-20",
+                "deepwiki_section_count": 12,
+                "github_stars": 1543,
+            },
+        )
+        fm = _build_frontmatter(
+            title="neuphonic/neutts",
+            url="https://github.com/neuphonic/neutts",
+            owner="neuphonic", repo="neutts",
+            date="2026-04-28",
+            tags=["github", "tts"],
+            enriched=enriched,
+            fetched_at="2026-05-05T11:48:23Z",
+        )
+        # Required marker for absorb's frontmatter scanner
+        assert "source_type: github-project" in fm
+        assert "source_tier: deepwiki" in fm
+        assert "github_owner: neuphonic" in fm
+        assert "github_repo: neutts" in fm
+        assert "github_stars: 1543" in fm
+        assert "source_indexed_at:" in fm  # only present on deepwiki tier
+        assert "deepwiki_section_count: 12" in fm
+        assert "tags: [github, tts]" in fm
+
+    def test_frontmatter_omits_deepwiki_fields_for_other_tiers(self):
+        enriched = EnrichedSource(
+            owner="o", repo="r", tier="readme",
+            body="readme body",
+            metadata={"tier": "readme", "github_stars": 5},
+        )
+        fm = _build_frontmatter(
+            title="o/r", url="https://github.com/o/r",
+            owner="o", repo="r", date="2026-05-05",
+            tags=[], enriched=enriched,
+            fetched_at="2026-05-05T00:00:00Z",
+        )
+        assert "source_tier: readme" in fm
+        assert "source_indexed_at:" not in fm
+        assert "deepwiki_" not in fm
+
+
+# ---------------------------------------------------------------------------
+# process_single_repo — output location + content
+# ---------------------------------------------------------------------------
+
+
+class TestProcessSingleRepo:
+    def test_writes_to_03_processed_not_20_areas(self, tmp_path):
+        """The pre-BL-066 implementation wrote to
+        ``20-Areas/Tools/Topics/<YYYY-MM>/<slug>_深度解读.md``.
+        After BL-066 the path is
+        ``50-Inbox/03-Processed/<YYYY-MM>/<slug>.md``.
+
+        This test pins both ends of that change so a regression to
+        the deep-dive layer fails immediately.
+        """
+        layout = self._init_vault(tmp_path)
+        out_dir = layout.processed_dir / "2026-04"
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        with patch(
+            "ovp_pipeline.auto_github_processor.enrich_github_source",
+            return_value=EnrichedSource(
+                owner="o", repo="r", tier="deepwiki",
+                body="# enriched body\n\nspecific 42 fact",
+                metadata={"tier": "deepwiki", "github_stars": 100,
+                          "deepwiki_last_indexed": "2026-01-20"},
+            ),
+        ):
+            result = process_single_repo(
+                url="https://github.com/o/r",
+                date="2026-04-28",
+                tags=["github"],
+                description="o/r",
+                output_dir=out_dir,
+                dry_run=False,
+            )
+
+        assert result["status"] == "completed"
+        out_path = Path(result["output_file"])
+        # Lives in 50-Inbox/03-Processed
+        assert out_path.parent == out_dir
+        assert out_path.parent.parent.name == "03-Processed"
+        # Filename has no 深度解读
+        assert "_深度解读" not in out_path.name
+        # Body includes the enriched content
+        body = out_path.read_text(encoding="utf-8")
+        assert "specific 42 fact" in body
+        # And carries the marker absorb scans for
+        assert "source_type: github-project" in body
+        assert "source_tier: deepwiki" in body
+
+    def test_empty_body_status_skipped(self, tmp_path):
+        """When all 3 tiers return empty, the file is still written
+        (frontmatter only) but status is 'skipped' so absorb won't
+        try to extract from a stub."""
+        layout = self._init_vault(tmp_path)
+        out_dir = layout.processed_dir / "2026-04"
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        with patch(
+            "ovp_pipeline.auto_github_processor.enrich_github_source",
+            return_value=EnrichedSource(
+                owner="o", repo="r", tier="readme",
+                body="",  # all tiers empty
+                metadata={"tier": "readme", "github_stars": 0},
+            ),
+        ):
+            result = process_single_repo(
+                url="https://github.com/o/r",
+                date="2026-04-28",
+                tags=[],
+                description="",
+                output_dir=out_dir,
+                dry_run=False,
+            )
+        assert result["status"] == "skipped"
+        assert result["error"] == "empty_body"
+
+    @staticmethod
+    def _init_vault(tmp_path: Path) -> VaultLayout:
+        # Minimal vault skeleton VaultLayout expects
+        for d in [
+            "10-Knowledge/Evergreen", "20-Areas", "50-Inbox/03-Processed",
+            "60-Logs", "70-Archive",
+        ]:
+            (tmp_path / d).mkdir(parents=True, exist_ok=True)
+        (tmp_path / ".obsidian").mkdir(exist_ok=True)
+        return VaultLayout.from_vault(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# absorb integration — _is_github_source_markdown + collection
+# ---------------------------------------------------------------------------
+
+
+class TestAbsorbPicksUpGithubSources:
+    def test_is_github_source_markdown_detects_marker(self, tmp_path):
+        github_md = tmp_path / "github.md"
+        github_md.write_text(
+            "---\n"
+            "title: o/r\n"
+            "source: https://github.com/o/r\n"
+            "source_type: github-project\n"
+            "source_tier: deepwiki\n"
+            "---\n\n"
+            "body\n",
+            encoding="utf-8",
+        )
+        article_md = tmp_path / "article.md"
+        article_md.write_text(
+            "---\n"
+            "title: An article\n"
+            "type: article\n"
+            "---\n\n"
+            "body\n",
+            encoding="utf-8",
+        )
+        no_fm = tmp_path / "no_fm.md"
+        no_fm.write_text("just body\n", encoding="utf-8")
+
+        assert _is_github_source_markdown(github_md) is True
+        assert _is_github_source_markdown(article_md) is False
+        assert _is_github_source_markdown(no_fm) is False
+
+    def test_marker_must_be_in_frontmatter_not_body(self, tmp_path):
+        """The marker check must NOT match if the literal text
+        appears only in the body — that would let an article quoting
+        ``source_type: github-project`` accidentally trigger absorb's
+        github-source path."""
+        md = tmp_path / "tricky.md"
+        md.write_text(
+            "---\n"
+            "title: An article that mentions github stuff\n"
+            "type: article\n"
+            "---\n\n"
+            "Some body text mentioning source_type: github-project as a string.\n",
+            encoding="utf-8",
+        )
+        assert _is_github_source_markdown(md) is False
+
+    def test_collect_absorb_targets_recent_picks_up_github_processed(self, tmp_path):
+        """The recent-window scan must find github-source markdowns
+        in 50-Inbox/03-Processed/<YYYY-MM>/, not just deep-dives in
+        20-Areas/.../Topics/<YYYY-MM>/.
+        """
+        layout = TestProcessSingleRepo._init_vault(tmp_path)
+        from datetime import datetime, timezone
+        month = datetime.now(timezone.utc).strftime("%Y-%m")
+        gh_dir = layout.processed_dir / month
+        gh_dir.mkdir(parents=True, exist_ok=True)
+        gh_path = gh_dir / "2026-05-04_o_r.md"
+        gh_path.write_text(
+            "---\n"
+            "source: https://github.com/o/r\n"
+            "source_type: github-project\n"
+            "source_tier: deepwiki\n"
+            "---\n\n"
+            "# body\n",
+            encoding="utf-8",
+        )
+
+        targets = _collect_absorb_targets(layout, recent=7)
+        assert gh_path.resolve() in {t.resolve() for t in targets}
+
+    def test_collect_absorb_targets_directory_picks_up_github_md(self, tmp_path):
+        """When invoked with ``--directory <some-dir>``, absorb must
+        pick up both legacy ``_深度解读.md`` AND new github-source
+        markdowns in the same directory."""
+        layout = TestProcessSingleRepo._init_vault(tmp_path)
+        scratch = tmp_path / "scratch"
+        scratch.mkdir()
+
+        legacy = scratch / "2026-04-01_legacy_深度解读.md"
+        legacy.write_text("---\ntitle: legacy\n---\nbody\n", encoding="utf-8")
+
+        github = scratch / "2026-04-28_o_r.md"
+        github.write_text(
+            "---\n"
+            "source: https://github.com/o/r\n"
+            "source_type: github-project\n"
+            "---\nbody\n",
+            encoding="utf-8",
+        )
+
+        unrelated = scratch / "2026-04-28_random.md"
+        unrelated.write_text("---\ntitle: random\n---\nbody\n", encoding="utf-8")
+
+        targets = _collect_absorb_targets(layout, directory=scratch)
+        target_set = {t.resolve() for t in targets}
+        assert legacy.resolve() in target_set
+        assert github.resolve() in target_set
+        assert unrelated.resolve() not in target_set

--- a/tests/test_github_enrichment.py
+++ b/tests/test_github_enrichment.py
@@ -58,6 +58,12 @@ class TestParseGithubURL:
         "https://example.com/owner/repo",
         "not-a-url",
         "",
+        # CodeRabbit finding: lstrip("www.") is a character-class
+        # strip that incorrectly accepted URLs like "wwwgithub.com"
+        # because it would strip the leading "www" as individual chars.
+        # removeprefix("www.") fixes this.
+        "https://wwwgithub.com/owner/repo",
+        "https://github.com.evil.com/owner/repo",
     ])
     def test_rejects_non_github(self, url):
         assert parse_github_url(url) is None
@@ -136,6 +142,56 @@ class TestEnrichmentChain:
             result = enrich_github_source("ghost", "ghost")
         assert result.tier == "readme"
         assert result.body == ""
+
+
+class TestFetchReadmeUsesDefaultBranch:
+    """CodeRabbit finding: README probe was hardcoded to main/master/develop
+    and missed repos with non-standard default branches.  Verify the new
+    implementation queries GitHub API for ``default_branch`` first.
+    """
+
+    def test_uses_api_default_branch_first(self):
+        from ovp_pipeline.github_enrichment import fetch_readme
+        from unittest.mock import patch
+
+        captured_urls: list[str] = []
+
+        def fake_get(url, timeout=10.0):
+            captured_urls.append(url)
+            if "api.github.com/repos/" in url:
+                return '{"default_branch": "trunk", "stargazers_count": 42}'
+            if "/trunk/README.md" in url:
+                return "# Real README from trunk\n\nbody"
+            return None
+
+        with patch("ovp_pipeline.github_enrichment._http_get", side_effect=fake_get):
+            body, stars = fetch_readme("o", "r")
+
+        assert "Real README from trunk" in body
+        assert stars == 42
+        # API call must precede branch probes
+        assert captured_urls[0].startswith("https://api.github.com/repos/")
+        # default_branch was used
+        assert any("/trunk/README.md" in u for u in captured_urls)
+
+    def test_falls_back_to_hardcoded_branches_when_api_fails(self):
+        """If the GitHub API returns None (rate-limited, blocked,
+        offline), we still try main/master/develop."""
+        from ovp_pipeline.github_enrichment import fetch_readme
+        from unittest.mock import patch
+
+        def fake_get(url, timeout=10.0):
+            if "api.github.com" in url:
+                return None  # API down
+            if "/main/README.md" in url:
+                return "# fallback worked"
+            return None
+
+        with patch("ovp_pipeline.github_enrichment._http_get", side_effect=fake_get):
+            body, stars = fetch_readme("o", "r")
+
+        assert "fallback worked" in body
+        assert stars == 0  # API gave us nothing
 
 
 # ---------------------------------------------------------------------------
@@ -264,7 +320,11 @@ class TestProcessSingleRepo:
     def test_empty_body_status_skipped(self, tmp_path):
         """When all 3 tiers return empty, the file is still written
         (frontmatter only) but status is 'skipped' so absorb won't
-        try to extract from a stub."""
+        try to extract from a stub.
+
+        Frontmatter MUST contain ``extraction_status: skipped`` so the
+        absorb scanner rejects it (CodeRabbit finding).
+        """
         layout = self._init_vault(tmp_path)
         out_dir = layout.processed_dir / "2026-04"
         out_dir.mkdir(parents=True, exist_ok=True)
@@ -287,6 +347,10 @@ class TestProcessSingleRepo:
             )
         assert result["status"] == "skipped"
         assert result["error"] == "empty_body"
+        # Frontmatter must explicitly mark this as skipped so absorb
+        # ignores it during evergreen extraction.
+        body = Path(result["output_file"]).read_text(encoding="utf-8")
+        assert "extraction_status: skipped" in body
 
     @staticmethod
     def _init_vault(tmp_path: Path) -> VaultLayout:
@@ -333,6 +397,40 @@ class TestAbsorbPicksUpGithubSources:
         assert _is_github_source_markdown(github_md) is True
         assert _is_github_source_markdown(article_md) is False
         assert _is_github_source_markdown(no_fm) is False
+
+    def test_skipped_extraction_status_rejects_file(self, tmp_path):
+        """CodeRabbit finding: github sources with empty enrichment
+        bodies write ``extraction_status: skipped`` to frontmatter.
+        ``_is_github_source_markdown`` must return False for those so
+        absorb doesn't try to extract from a stub."""
+        skipped_md = tmp_path / "skipped.md"
+        skipped_md.write_text(
+            "---\n"
+            "title: o/r\n"
+            "source: https://github.com/o/r\n"
+            "source_type: github-project\n"
+            "source_tier: readme\n"
+            "extraction_status: skipped\n"
+            "---\n\n"
+            "_All enrichment tiers returned empty content._\n",
+            encoding="utf-8",
+        )
+        completed_md = tmp_path / "completed.md"
+        completed_md.write_text(
+            "---\n"
+            "title: o/r\n"
+            "source: https://github.com/o/r\n"
+            "source_type: github-project\n"
+            "source_tier: deepwiki\n"
+            "extraction_status: completed\n"
+            "---\n\n"
+            "# real body\n",
+            encoding="utf-8",
+        )
+
+        # Skipped file is rejected; completed file is accepted.
+        assert _is_github_source_markdown(skipped_md) is False
+        assert _is_github_source_markdown(completed_md) is True
 
     def test_marker_must_be_in_frontmatter_not_body(self, tmp_path):
         """The marker check must NOT match if the literal text

--- a/tests/test_migration_processing_guards.py
+++ b/tests/test_migration_processing_guards.py
@@ -19,7 +19,10 @@ from ovp_pipeline.auto_article_processor import (
     TransactionManager as ArticleTxn,
 )
 from ovp_pipeline.auto_evergreen_extractor import LiteLLMClient as EvergreenLiteLLMClient
-from ovp_pipeline.auto_github_processor import LiteLLMClient as GithubLiteLLMClient
+# BL-066 (2026-05-05): auto_github_processor no longer calls any LLM —
+# github intake is now a deterministic DeepWiki/GitIngest/README chain.
+# parse_github_url moved to github_enrichment but is re-exported.
+from ovp_pipeline.github_enrichment import EnrichedSource
 from ovp_pipeline.auto_github_processor import parse_github_url
 from ovp_pipeline.auto_paper_processor import LiteLLMClient as PaperLiteLLMClient, process_single_paper
 from ovp_pipeline.lint_checker import KnowledgeLinter
@@ -633,11 +636,10 @@ def test_processors_default_to_auto_vault_model_env(monkeypatch):
 
     article_client = ArticleLiteLLMClient()
     paper_client = PaperLiteLLMClient()
-    github_client = GithubLiteLLMClient()
+    # BL-066: github processor no longer instantiates an LLM client.
 
     assert article_client.model == "anthropic/MiniMax-M2.7-highspeed"
     assert paper_client.model == "anthropic/MiniMax-M2.7-highspeed"
-    assert github_client.model == "anthropic/MiniMax-M2.7-highspeed"
 
 
 def test_article_processor_defaults_api_base_from_shared_resolver(monkeypatch):
@@ -659,15 +661,19 @@ def test_processors_fall_back_to_minimax_api_key_env(monkeypatch):
     monkeypatch.setenv("AUTO_VAULT_API_BASE", "https://api.minimaxi.com/anthropic")
 
     paper_client = PaperLiteLLMClient()
-    github_client = GithubLiteLLMClient()
     article_client = ArticleLiteLLMClient()
+    # BL-066: github processor no longer instantiates an LLM client.
 
     assert paper_client._api_key == "minimax-key"
-    assert github_client._api_key == "minimax-key"
     assert article_client._api_key == "minimax-key"
 
 
-def test_github_cli_does_not_override_auto_vault_model_when_flag_is_omitted(temp_vault, monkeypatch):
+def test_github_main_runs_enrichment_on_process_single(temp_vault, monkeypatch):
+    """BL-066 replaces the old --model / LiteLLMClient path with a
+    deterministic enrichment chain.  This test pins the new shape:
+    main() reads the pinboard stub, calls enrich_github_source,
+    writes to 50-Inbox/03-Processed, and archives the stub.
+    """
     pinboard_file = temp_vault / "50-Inbox" / "02-Pinboard" / "2026-04-07_example.md"
     pinboard_file.parent.mkdir(parents=True, exist_ok=True)
     pinboard_file.write_text(
@@ -681,23 +687,19 @@ tags: [tool]
         encoding="utf-8",
     )
 
-    captured: dict[str, object] = {}
+    enrich_calls: list[tuple[str, str]] = []
 
-    class StubLLM:
-        def __init__(self, *, model=None, api_type="anthropic", api_key=None, api_base=None):
-            captured["model"] = model
-            self.model = "stub-model"
-            self.total_calls = 0
+    def fake_enrich(owner: str, repo: str) -> EnrichedSource:
+        enrich_calls.append((owner, repo))
+        return EnrichedSource(
+            owner=owner, repo=repo, tier="readme",
+            body="# stub README body for test\n",
+            metadata={"tier": "readme", "github_stars": 0},
+        )
 
-    monkeypatch.setattr(github_module, "LiteLLMClient", StubLLM)
+    monkeypatch.setattr(github_module, "enrich_github_source", fake_enrich)
     monkeypatch.setattr(
-        github_module,
-        "process_single_repo",
-        lambda **kwargs: {"status": "completed", "tokens_used": 0},
-    )
-    monkeypatch.setattr(
-        sys,
-        "argv",
+        sys, "argv",
         [
             "auto_github_processor.py",
             "--process-single",
@@ -708,9 +710,21 @@ tags: [tool]
     )
 
     assert github_module.main() == 0
-    assert captured["model"] is None
+    # Enrichment was invoked once for the right repo
+    assert enrich_calls == [("example", "repo")]
+    # Pinboard stub was archived (lifecycle handler still runs)
     assert not pinboard_file.exists()
     assert len(list((temp_vault / "70-Archive" / "Pinboard").glob("*/2026-04-07_example.md"))) == 1
+    # Output landed in 03-Processed, not 20-Areas/Tools/Topics
+    processed_files = list(
+        (temp_vault / "50-Inbox" / "03-Processed").rglob("2026-04-07_example_repo.md")
+    )
+    assert len(processed_files) == 1
+    body = processed_files[0].read_text(encoding="utf-8")
+    assert "source_type: github-project" in body
+    assert "source_tier: readme" in body
+    # No deep-dive file was created
+    assert not list((temp_vault / "20-Areas").rglob("*example*_深度解读.md"))
 
 
 def test_paper_cli_does_not_override_auto_vault_model_when_flag_is_omitted(temp_vault, monkeypatch):
@@ -783,7 +797,7 @@ def test_article_cli_summary_handles_results_without_queued_total(temp_vault, mo
 @pytest.mark.parametrize(("client_class", "patch_mode"), [
     (ArticleLiteLLMClient, "article"),
     (PaperLiteLLMClient, "module"),
-    (GithubLiteLLMClient, "module"),
+    # BL-066: github processor has no LiteLLMClient; covered by other tests.
 ])
 def test_litellm_clients_retry_transient_failures(monkeypatch, client_class, patch_mode):
     monkeypatch.setenv("AUTO_VAULT_API_KEY", "test-key")
@@ -828,7 +842,7 @@ def test_litellm_clients_retry_transient_failures(monkeypatch, client_class, pat
 @pytest.mark.parametrize(("client_class", "patch_mode"), [
     (ArticleLiteLLMClient, "article"),
     (PaperLiteLLMClient, "module"),
-    (GithubLiteLLMClient, "module"),
+    # BL-066: github processor has no LiteLLMClient; covered by other tests.
 ])
 def test_litellm_clients_pass_explicit_completion_timeout(monkeypatch, client_class, patch_mode):
     monkeypatch.setenv("AUTO_VAULT_API_KEY", "test-key")

--- a/tests/test_no_silent_imports.py
+++ b/tests/test_no_silent_imports.py
@@ -32,7 +32,7 @@ def repo_root() -> Path:
 LEGACY_SILENT_IMPORTS = {
     ("auto_evergreen_extractor.py", 163),      # dotenv optional (BL-054 added helpers above it)
     ("auto_article_processor.py", 113),         # dotenv optional
-    ("auto_github_processor.py", 82),           # dotenv optional
+    ("auto_github_processor.py", 99),           # dotenv optional (BL-066 rewrote module, line shifted)
     ("auto_moc_updater.py", 51),                # dotenv optional
     ("auto_paper_processor.py", 86),            # dotenv optional
     ("clippings_processor.py", 51),             # dotenv optional

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -178,7 +178,10 @@ def test_specialized_processors_derive_default_outputs_from_vault(tmp_path):
     paper_dir = paper_output_dir(vault)
 
     assert github_dir.is_absolute()
-    assert github_dir.parts[-3:-1] == ("Tools", "Topics")
+    # BL-066: github intake no longer produces deep-dives; output now
+    # lands in 50-Inbox/03-Processed/<YYYY-MM>/ alongside other
+    # processed sources.  Was ``20-Areas/Tools/Topics/<YYYY-MM>/``.
+    assert github_dir.parts[-3:-1] == ("50-Inbox", "03-Processed")
     assert paper_dir == (vault / "20-Areas" / "AI-Research" / "Papers").resolve()
 
 


### PR DESCRIPTION
## Summary

Replaces the previous "fetch README + run a 13-section LLM 深度解读" path for GitHub sources with a deterministic 3-tier enrichment chain (**DeepWiki → GitIngest → README**) and removes the LLM rewrite step entirely. The enriched body now lands in `50-Inbox/03-Processed/<YYYY-MM>/` so absorb reads it directly — one fewer LLM pass, no template-imposed abstraction inflation.

The DeepWiki/GitIngest chain was documented in \`skills/daily-ingestion.md\` (commit 065e471) but never implemented. This PR ships the missing tier.

## What changes

- **New \`github_enrichment.py\`** — 3-tier fallback chain with explicit tier metadata:
  - Tier 1 **DeepWiki**: probe \`Last indexed\` marker, walk numbered subpages, hand-rolled HTML→markdown. Verified ~70% coverage on a sample of 20 actual github URLs from the vault.
  - Tier 2 **GitIngest**: \`pip install gitingest\` clones depth=1, filters to docs/markdown only, caps at 60kB.
  - Tier 3 **README + stars**: previous behavior, last-resort fallback.
  - **Zread skipped** — Cloudflare blocks server-side fetch; out of scope.
- **Rewrite \`auto_github_processor.py\`**:
  - Delete \`GitHubDepthProcessor\` + the 13-section prompt.
  - Delete \`LiteLLMClient\` (no LLM in this module anymore).
  - \`process_single_repo\` writes to \`50-Inbox/03-Processed/<YYYY-MM>/<date>_<owner>_<repo>.md\` with frontmatter \`source_type: github-project\` + \`source_tier: deepwiki|gitingest|readme\` + provenance fields.
  - **No \`_深度解读\` suffix** — github intake is no longer a deep-dive.
- **Absorb input discovery (\`auto_evergreen_extractor.py\`)**:
  - New \`_is_github_source_markdown(path)\` — detects the frontmatter marker (frontmatter only, not body).
  - New \`_collect_processed_github_sources(layout, ...)\` — scans \`50-Inbox/03-Processed/<YYYY-MM>/\` filtered by month + cutoff.
  - \`_collect_absorb_targets\` and \`process_directory\` now scan **both** layers (legacy \`*_深度解读.md\` AND new github sources) so the cutover is transparent — github intakes flow into absorb on the same schedule as deep-dives.

## End-to-end verification

Live test on \`neuphonic/neutts\`: tier 1 wins → **29 DeepWiki sections / 249KB enriched body**, vs the 13-character "On-device TTS" stub the old README path produced. All specifics preserved (3-15s reference audio, Galaxy A25, neural audio codec, Q4/Q8 GGUF formats, etc.).

## Tests

- **New \`tests/test_github_enrichment.py\`** — 28 cases:
  - \`parse_github_url\` robustness (blob/tree/release URLs, \`.git\` suffix)
  - 3-tier fallback (each tier wins when higher tier fails)
  - All-tiers-fail returns empty body (not exception)
  - **Filename regression guard**: no \`_深度解读\` suffix
  - Frontmatter records correct tier-specific fields
  - \`process_single_repo\` writes to 03-Processed, NOT 20-Areas
  - Empty body produces \`status=skipped\` (absorb won't read stub)
  - \`_is_github_source_markdown\` matches frontmatter marker only (not body false-positives)
  - \`_collect_absorb_targets\` recent + directory branches pick up github sources alongside legacy deep-dives
- **Updated \`test_migration_processing_guards.py\`** — removed 5 references to the now-deleted \`GithubLiteLLMClient\`. Replaced one CLI test with \`test_github_main_runs_enrichment_on_process_single\` asserting the new shape (enrichment called, output in 03-Processed, no deep-dive created, pinboard stub archived).
- **Test infra ratchet bumps**: \`test_runtime_paths.py\` (expected output path), \`test_no_silent_imports.py\` (line shift).

**Full suite: 2088/2088 pass.** (The \`unified_pipeline_enhanced.py\` file-size guard in arch-fitness is a pre-existing failure unrelated to this PR — confirmed by stashing changes and re-running.)

## Test plan

- [x] \`pytest tests/test_github_enrichment.py\` — 28/28
- [x] \`pytest tests/test_migration_processing_guards.py\` — 32/32
- [x] Full suite (excluding pre-existing arch-fitness failure) — 2088/2088
- [x] Live smoke test on \`neuphonic/neutts\` confirms DeepWiki tier 1 wins, 249KB enriched body
- [ ] After merge: monitor first incremental run on real github captures; verify tier breakdown matches the 70% / ~25% / ~5% expectation
- [ ] Future: backfill 178 existing github stubs once the new chain proves stable

## Not in this PR (deliberate scope cuts)

- **No backfill** of the 178 existing github stubs in \`70-Archive/Pinboard\`. Once the new chain proves stable, a \`ovp-backfill-github-enrichment\` command can re-process them.
- **Legacy \`*_深度解读.md\` files left in place** — they're historical artifacts; absorb still reads them. Article + paper intakes still produce deep-dives until BL-058 lands.
- **Absorb prompt unchanged** — still the legacy \`SYSTEM_PROMPT\` with \`"抽得多比抽得少好"\` volume bias. BL-058 (next PR) will replace it with the v2 CandidateUnit prompt; at that point github sources flow through the same prompt as everything else, and the link from "rich enrichment body" to "specific candidate units" closes.

## Related

- \`docs/plans/2026-05-05-test-infra-retro.md\` (in #155) — context on how the prompt-quality investigation surfaced this gap.
- BL-058 (next): replace absorb \`SYSTEM_PROMPT\` with v2 CandidateUnit prompt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * GitHub repository intake pipeline enriches content using intelligent multi-source retrieval with automatic fallback
  * Processed GitHub sources are automatically integrated into the absorb workflow

* **Refactoring**
  * GitHub processing pipeline optimized and streamlined

* **Tests**
  * Added comprehensive test coverage for GitHub enrichment and absorb integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->