### PR TITLE
feat(absorb): v2 CandidateUnit prompt + legacy tagging (BL-058)

### DIFF
--- a/docs/plans/2026-05-05-bl-058-absorb-v2-candidate-units.md
+++ b/docs/plans/2026-05-05-bl-058-absorb-v2-candidate-units.md
@@ -1,0 +1,402 @@
+# BL-058 — Absorb v2: CandidateUnit prompt + legacy tagging
+
+> **Status**: design (ready to implement)
+> **Author**: chris
+> **Date**: 2026-05-05
+> **Decision authority**: chris
+> **Depends on**: PR #155 (merged), PR #156 BL-066 (open)
+> **Blocks**: future re-extraction (BL-068), reader epistemic HUD (later)
+
+---
+
+## Problem
+
+The current `auto_evergreen_extractor.SYSTEM_PROMPT` has three structural problems
+that the 2026-05-05 fidelity audit and prompt A/B experiment both confirmed:
+
+1. **Forced template** — every output must fill `定义 / 详细解释 / 为什么重要`
+   sections, which mechanically converts every source content type
+   (procedure, case, tradeoff, fact) into "X 是 Y" definitions.
+2. **Volume bias** — the prompt literally says **"抽得多比抽得少好"** with
+   floors of "5-10 units per short article, 15-30+ per long article",
+   no permission to skip low-value sources.
+3. **No specificity guard** — no rule requires preserving source numbers
+   / named entities / tradeoffs / examples; the LLM freely abstracts
+   them away.
+
+50-sample fidelity rubric: most evergreens scored `faithful_generic`
+(claim is in source, but specifics were stripped). 6-source A/B experiment
+(`60-Logs/prompt-ab/v1/`) confirmed the v2 prompt produces dramatically
+more specific units at half the volume, and correctly returns `units=[]`
+on a 13-character github stub instead of fabricating 3 units from nothing.
+
+---
+
+## Decisions (locked)
+
+| # | Question | Decision |
+|---|---|---|
+| 1 | Direct cutover or shadow mode first? | **Direct cutover** — A/B data is sufficient, no need for parallel run. Old evergreens stay as legacy. |
+| 2 | New schema fields | **Add 6 fields** (see §4 below); not afraid of schema change since vault is markdown + the existing `knowledge_index` rebuilds idempotently. |
+| 3 | Tag legacy 7000 evergreens? | **Yes, mark them all `legacy_unverified=true` + `extraction_prompt_version=v1`**. Plan to re-run high-value subset later (BL-068). Don't delete. |
+
+---
+
+## The v2 prompt
+
+This is the prompt we drafted in OVP's own voice (not transcribed from NM).
+It's already in `commands/prompt_ab.py:NEW_PROMPT` and proven on 6 sources.
+BL-058 promotes it to production.
+
+```text
+你的任务:从一篇源文里抽取对 vault 有价值的 CandidateUnit。
+你不是在总结源文,也不是在把源文改写成笔记。
+你是在找出源文中那些**保留了原文具体物**(数字、命名实体、方法步骤、
+工具名、反例、边界条件、对照选择)的可复用知识单元。
+
+## 输出格式 (严格 JSON,不要 markdown 包装)
+
+{
+  "source_value_summary": "一句话概括这篇源文的可抽取价值。如果价值很低,直说。",
+  "units": [
+    {
+      "title": "一句完整的陈述句,不是名词短语",
+      "unit_type": "fact|method|procedure|tradeoff|failure_mode|counterexample|case_detail|learning|decision|quote",
+      "epistemic_role": "fact|interpretation|method|quote|attributed_claim",
+      "content": "markdown,自包含,不需要回读源文也能理解",
+      "source_anchor": "源文中逐字出现的短语/数字/名称/API,作为这条单元的具体锚点",
+      "specifics": ["保留下来的具体物分类:numbers / names / tradeoffs / examples / edge_cases"],
+      "related_concepts": ["相关 wikilink slug,0-5 个,宁缺勿滥"]
+    }
+  ],
+  "skip_reason": "如果 units 是空,说明为什么:常识 / 重复 / 没具体物 / 全是观点没证据 / 等等"
+}
+
+## 抽取规则,违反任何一条这条单元就不该存在:
+
+[10 rules — see commands/prompt_ab.py NEW_PROMPT for full text]
+
+加规则 11 (BL-058 implementation, not in prompt_ab v1):
+
+11. **related_concepts**(可选,0-5 个)
+    列出这条 unit 真正在概念上相关的其他知识 —— 不是相同 topic 的所有
+    东西,是会让人想点过去的特定关联。entity prime 列表里有合适的 slug
+    就直接用;否则用 kebab-case slug。**没有强相关就给空列表,不要凑数**。
+    与 v1 不同:v1 强制 ≥ 3 个,v2 允许 0 个。
+```
+
+The full prompt text including the 11 hard rules will live in
+`auto_evergreen_extractor.SYSTEM_PROMPT` after BL-058. Rule 11 is new
+and replaces v1's "≥ 3 related_concepts" floor.
+
+---
+
+## Schema changes
+
+### Evergreen frontmatter — add 6 fields
+
+```yaml
+---
+# Existing fields (unchanged)
+note_id: critical-step-prioritization
+title: "..."
+type: evergreen
+entity_type: concept
+date: 2026-04-09
+tags: [evergreen]
+aliases: ["..."]
+source_url: "https://x.com/..."
+source_title: "..."
+source_authors: [...]
+source_published_at: "..."
+source_fingerprint: "4198ef3f0128"
+
+# NEW fields (BL-058)
+extraction_prompt_version: v2          # was implicit "v1" — now explicit
+unit_type: fact                        # one of 10 (see prompt)
+epistemic_role: fact                   # one of 5
+source_anchor: "16% of trajectory steps are critical decision points"  # verbatim
+specifics: [numbers, names]            # categorical chips
+absorbed_at: 2026-05-15T08:23:14Z      # when this v2 extraction ran
+---
+```
+
+**Why these 6:**
+
+- `extraction_prompt_version`: enables the legacy/v2 split. Future tools
+  (reader UI badges, crystal scoring weights, fidelity replay) key off this.
+- `unit_type`: replaces the loosely-used `entity_type=concept` default.
+  Lets reader UI surface "show me only methods" / "show me failure modes".
+- `epistemic_role`: separates "fact" from "interpretation" at the unit
+  level. Crystal evidence aggregation will weight these differently.
+- `source_anchor`: the **mechanical fidelity check** — `grep` the anchor
+  string in the source body; missing → flag as possible hallucination.
+- `specifics`: the chips humans saw in the fidelity HTML. Aggregating
+  these across the vault lets us see "method units have higher
+  specificity preservation than learning units" as data, not intuition.
+- `absorbed_at`: when v2 ran. Distinct from `date` (article publish date)
+  and `source_fetched_at` (raw-source intake date in BL-066).
+
+### Evergreen body template — strip forced sections
+
+```markdown
+# {title}
+
+{content}                      # ← LLM-produced markdown, free-form, no template
+
+> **Source anchor**: "{source_anchor}"
+
+## Related                     # ← only rendered when related_concepts non-empty
+- [[wikilink-1]]
+- [[wikilink-2]]
+
+## Source
+- [Original]({source_url})
+- [[{source_file_stem}]]      # backref to processed source in 03-Processed
+```
+
+**What's gone:**
+- `> **一句话定义**: ...` — definition is now whatever fits unit_type
+- `## 📝 详细解释 / ### 是什么？/ ### 为什么重要？` — model-driven sections
+
+**What's kept (clarification — was previously listed as "removed"):**
+- `## Related` block — keeping wikilink generation in absorb.
+  Async link-suggestion would leave evergreens disconnected during the
+  window between extraction and link generation, breaks MOC/orphan
+  detection/reader linked-mentions, and is a slop-prone silent-failure
+  pattern.  v2 keeps `related_concepts` in the prompt output (same as
+  v1) but loosens the requirement: 0-5 entries, "宁缺勿滥" rule, no
+  forced minimum.  Empty array → `## Related` block is omitted.
+
+The LLM produces the content body in whatever shape matches `unit_type`:
+- `procedure` → numbered steps
+- `tradeoff` → "we chose X over Y because Z"
+- `fact` → single concrete statement with grounding
+- `quote` → verbatim block + brief annotation
+- etc.
+
+### Knowledge index (SQLite) — DEFERRED to BL-058b
+
+Originally proposed: `ALTER TABLE objects ADD COLUMN ...` for the 7
+new fields.  Implementation chose **NOT** to do this in BL-058 — see
+"Scope cut" below.
+
+The 6 new frontmatter fields are still queryable through the existing
+``pages_index.frontmatter_json`` column via ``json_extract``:
+
+```sql
+SELECT slug, json_extract(frontmatter_json, '$.unit_type') AS unit_type
+FROM pages_index
+WHERE json_extract(frontmatter_json, '$.extraction_prompt_version') = 'v2';
+```
+
+This is enough for any current or near-term consumer.  When a future
+feature (reader UI badges, crystal scoring weights) actually needs
+indexed lookups on these fields, BL-058b will materialize them as
+real columns.
+
+Reason: avoiding `ALTER TABLE` keeps the rebuild idempotent without
+requiring a versioned migration step, and avoids a class of "I rebuilt
+knowledge.db on a v1 vault and the columns don't exist" failures
+during the rollout window.
+
+### Audit event
+
+Each successful absorb writes an `audit_events` row with type
+`evergreen_v2_promoted` containing:
+- slug, source_path, source_anchor, unit_type, epistemic_role,
+  prompt_version='v2', absorbed_at
+
+This is the v2 equivalent of `evergreen_auto_promoted` from v1.
+The v1 event type is preserved so historical audit replay still works.
+
+---
+
+## Legacy migration (one-shot)
+
+A new command `ovp-tag-legacy-evergreens` walks every evergreen in
+`10-Knowledge/Evergreen/`:
+
+1. If frontmatter lacks `extraction_prompt_version`:
+   - Add `extraction_prompt_version: v1`
+   - Add `legacy_unverified: true`
+   - Add `legacy_tagged_at: 2026-05-15T...` (so we know when the tag was applied)
+2. Don't touch any other field.
+3. Don't touch the body.
+4. Idempotent — re-running doesn't duplicate.
+5. Writes a one-off audit log to `60-Logs/legacy-tag/<run-id>/manifest.json`
+   listing every file tagged.
+
+**Estimated scope:** ~7,000 evergreens × ~50ms file rewrite = **~6 minutes**.
+No LLM calls. Reversible (the script also accepts `--untag` mode that
+removes the two added fields).
+
+After the migration runs once:
+- All v1 evergreens have `legacy_unverified=true` and stay searchable / readable
+- All NEW evergreens (post-cutover) have `legacy_unverified` absent
+  (i.e. implicitly verified by virtue of being v2-extracted with source_anchor)
+- Crystal scoring (BL-054) gets a knob to down-weight legacy_unverified
+  units — implementation deferred to a follow-up (NOT in BL-058).
+
+---
+
+## Pipeline changes
+
+### Files modified (actual)
+
+| File | Change |
+|---|---|
+| `auto_evergreen_extractor.py` | Replaced `SYSTEM_PROMPT` (~80 lines, 11 hard rules). New `_parse_v2_response` method handles wrapped JSON + skip_reason + bare-list rejection. New `_unit_to_concept` converts v2 unit dicts to legacy concept-dict shape so `process_file` doesn't need to change. `create_evergreen_note` rewritten — no forced sections, conditional `## Related` block, `Source anchor` blockquote. Dropped legacy `evergreen_low_link` audit (replaced by `absorb_skipped_source` + `absorb_v2_parse_error`). |
+| `commands/tag_legacy_evergreens.py` | NEW. Idempotent + reversible migration script. |
+| `pyproject.toml` | Register `ovp-tag-legacy-evergreens` entry point. |
+| `tests/test_absorb_v2.py` | NEW. 20 tests covering parser / converter / body template / migration command. |
+| `tests/test_evergreen_prompt_liberation.py` | Rewritten for v2 contract (output wrapper / source_anchor / specifics / 0-8 cap / 0-5 related). |
+| `tests/test_evergreen_extractor_retrieval.py` | Removed two tests for `evergreen_low_link` audit (event was dropped — v2 allows 0-5 related, not "≥3 required"). |
+
+### Files NOT modified (deferred to BL-058b/c)
+
+| File | Why |
+|---|---|
+| `truth_store.py` | SQLite schema migration deferred — `pages_index.frontmatter_json` already provides queryable access via `json_extract()`. Real columns can wait until a consumer needs indexed lookup. |
+| `knowledge_index.py` | Same — no new column wiring needed for v1. |
+| `truth_api.py`, `commands/_ui_renderers.py` | Reader UI badges that surface `unit_type` / `legacy_unverified` deferred to BL-058b. Data is captured in frontmatter for downstream readers. |
+| `crystal_scoring.py` | `legacy_unverified` weight knob deferred to BL-058c (needs calibration data first). |
+
+### Files NOT modified (deliberate scope cuts)
+
+- `truth_api.py` — keeps reading the same columns; new fields default
+  to NULL/empty. Reader UI cosmetics that surface unit_type/legacy
+  badges deferred to a follow-up PR (BL-058b).
+- `crystal_scoring.py` — keeps current weights. legacy_unverified
+  down-weighting deferred (BL-058c).
+- `commands/_ui_renderers.py` — no UI changes. Showing the new fields
+  in reader / search / briefing is a separate concern.
+
+---
+
+## Testing strategy
+
+### Unit tests
+
+- `test_absorb_v2_prompt_returns_units_or_skip_reason` — mock LLM
+  returning a v2 JSON, verify parser handles both shapes (`units=[...]`
+  and `units=[]` + `skip_reason`).
+- `test_create_evergreen_v2_note_template` — verify new body template
+  has no `定义/详细解释/为什么重要` headers and includes the
+  source_anchor block.
+- `test_legacy_tag_idempotent` — run tag command twice, verify no
+  duplicate fields.
+- `test_legacy_tag_reversible` — run with `--untag`, verify the two
+  added fields disappear.
+- `test_knowledge_index_reads_new_columns` — vault with one v2
+  evergreen, rebuild, query the new columns, verify populated.
+
+### Regression / contract tests
+
+- `test_v1_evergreens_remain_readable` — ensure absorb-time changes
+  don't break reading existing v1 evergreens (different body shape).
+- `test_absorb_writes_audit_event_v2_promoted` — new event type fires.
+- `test_skip_reason_writes_no_evergreen` — when LLM returns
+  `units=[]`, no evergreen file is created.
+
+### End-to-end test
+
+- `test_e2e_v2_absorb_chain` — same shape as `test_absorb_to_entity_extract_chain`
+  but with v2 prompt response. Asserts processed_files contains real
+  vault paths (regression guard from PR #155 still holds), and the
+  evergreen frontmatter has all 6 new fields populated correctly.
+
+### Manual validation checkpoint
+
+After merge, run **one** real `ovp-pipeline --incremental` and verify:
+- Pipeline report shows non-zero new evergreens AND non-zero skip_reason rate
+- Random sample of 5 new evergreens — manual fidelity check
+- `entity_mentions` count grows (regression guard for PR #155 working)
+- No `extraction_prompt_version: v1` written to any new file
+
+---
+
+## Rollout plan
+
+```
+Day 0   Merge BL-058 PR
+        Schema migration runs idempotently (rebuild_knowledge_index does it).
+        Old evergreens still untagged.
+
+Day 0+5 Run ovp-tag-legacy-evergreens once.
+        ~7000 files tagged. ~6 minutes.
+        Manifest at 60-Logs/legacy-tag/<run-id>/.
+
+Day 1   Next ovp-pipeline --incremental run uses v2 prompt.
+        New evergreens land with v2 schema; old evergreens carry legacy tags.
+
+Week 1  Watch:
+        - skip_reason rate (expecting 10-30% on incremental sources)
+        - new evergreen specifics distribution (proxy for "is v2 actually
+          preserving specifics?")
+        - any LLM JSON parse failures (the v2 schema is more complex)
+
+Week 2+ If quality is good, plan BL-068 (re-extraction of high-value v1 evergreens).
+        If not, iterate on prompt — but the schema change stays.
+```
+
+---
+
+## What's NOT in BL-058 (deliberate scope cuts)
+
+| Out-of-scope | Why | Future BL |
+|---|---|---|
+| Reader UI badges for unit_type / legacy | Cosmetic; data is captured, surfacing is separate | BL-058b |
+| Crystal scoring weight on legacy_unverified | Easy mechanically but needs calibration data first | BL-058c |
+| Re-running v1 evergreens through v2 | High-value subset only; ranking + cost analysis needed | BL-068 |
+| Article + paper processors switching to v2 prompt | They produce `_深度解读.md` first; deeper change | BL-058d |
+| Entity extraction prompt v2 | Different prompt, different module | BL-067 |
+| Reader-side filter "hide legacy by default" | Product decision, not infrastructure | (later) |
+
+---
+
+## Open questions / future work
+
+1. **Article + paper processors** still produce `_深度解读.md` middle layers.
+   Until BL-058d, those still go through the OLD absorb prompt for non-github
+   sources. After BL-066 + BL-058 merge, the picture is:
+
+   ```
+   github sources (BL-066)   →  03-Processed/<slug>.md  →  v2 absorb  →  v2 evergreen
+   article/paper sources     →  *_深度解读.md           →  v2 absorb  →  v2 evergreen
+                                ↑ still LLM-rewritten, lossy
+   ```
+
+   v2 prompt will work on `_深度解读.md` files (it doesn't care about input
+   shape) but the upstream LLM rewrite is still there. BL-058d removes
+   that intermediate layer.
+
+2. **`unit_type=quote` and `unit_type=case_detail` may overlap with what
+   future "raw quote artifacts" should look like**. If we ever add a
+   "QuoteArtifact" first-class type (per the four-ledger discussion),
+   `unit_type=quote` evergreens become the migration source. Keep
+   them as evergreens for now.
+
+3. **What if the same source produces two different units with the same
+   anchor?** Current dedup runs on slug; same anchor + different slugs is
+   allowed. May want to add an anchor-level dedup pass later (low
+   priority — same anchor with different framing is often legitimate
+   — e.g. one method-unit + one tradeoff-unit drawn from the same paragraph).
+
+---
+
+## Implementation checklist
+
+When implementing BL-058:
+
+- [ ] Replace `SYSTEM_PROMPT` in `auto_evergreen_extractor.py`
+- [ ] Update `extract_concepts` JSON parser for v2 shape (parse `units[]` + `skip_reason`)
+- [ ] Update `create_evergreen_note` body template + frontmatter render
+- [ ] Add 7 new columns to `objects` table in `truth_store.py`
+- [ ] Update `knowledge_index.py` to read new frontmatter into new columns
+- [ ] Write `commands/tag_legacy_evergreens.py` (idempotent + reversible)
+- [ ] Register `ovp-tag-legacy-evergreens` CLI in `pyproject.toml`
+- [ ] Audit event type `evergreen_v2_promoted` writes alongside slug/anchor/etc.
+- [ ] Tests per §Testing strategy
+- [ ] After merge: run `ovp-tag-legacy-evergreens` once
+- [ ] After merge: monitor first incremental for skip_reason rate + parse failures

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,7 @@ ovp-clean-processing-backups = "ovp_pipeline.commands.cleanup_processing_backups
 ovp-breakdown = "ovp_pipeline.commands.breakdown:main"
 ovp-knowledge-index = "ovp_pipeline.commands.knowledge_index:main"
 ovp-rebuild-summaries = "ovp_pipeline.commands.rebuild_summaries:main"
+ovp-tag-legacy-evergreens = "ovp_pipeline.commands.tag_legacy_evergreens:main"
 ovp-watch-progress = "ovp_pipeline.commands.watch_progress:main"
 ovp-extract = "ovp_pipeline.commands.extract_profiles:main"
 ovp-extract-preview = "ovp_pipeline.commands.extract_preview:main"

--- a/src/ovp_pipeline/auto_evergreen_extractor.py
+++ b/src/ovp_pipeline/auto_evergreen_extractor.py
@@ -42,6 +42,26 @@ try:
 except ImportError:
     from promotion_backlinks import upsert_promotions_in_file  # type: ignore
 
+# Hoisted to module-scope (gemini PR #157 review): the v1 code imported
+# these symbols inline inside ``create_evergreen_note`` /
+# ``_unit_to_concept`` / ``process_file`` to break a circular-import
+# concern that no longer exists.  Top-level imports keep the
+# function bodies readable + match Python convention.
+try:
+    from .object_kinds import (
+        CORE_OBJECT_KINDS,
+        KIND_CONCEPT,
+        KIND_METHOD,
+        normalize_kind,
+    )
+except ImportError:
+    from object_kinds import (  # type: ignore
+        CORE_OBJECT_KINDS,
+        KIND_CONCEPT,
+        KIND_METHOD,
+        normalize_kind,
+    )
+
 try:
     from .llm_defaults import (
         DEFAULT_LITELLM_TIMEOUT_SECONDS,
@@ -346,6 +366,29 @@ class EvergreenExtractor:
     _ENTITY_PRIME_TOP_N = 100
     _ENTITY_PRIME_ALIAS_CAP_PER_CANONICAL = 4
 
+    # BL-058 v2 prompt sizing.  These were inline magic numbers in the
+    # initial commit; gemini PR #157 review surfaced them as named
+    # constants so both the prompt-design discussion and any future
+    # tuning live in one place.
+    #
+    # ``_USER_PROMPT_BODY_CHARS``: how much of the source we hand to
+    # the LLM as the extraction subject.  6000 chars is enough for a
+    # typical tweet/blog/paper section to be visible in full;
+    # PR-B (BL-068) introduces chunk-and-aggregate for ≥6kb articles
+    # and will retire this single-window approach.
+    #
+    # ``_MAX_OUTPUT_TOKENS``: cap on the LLM response length.  v2 asks
+    # for 0-8 units at ~150 tokens each (JSON + content); 8000 leaves
+    # generous headroom and matches what we set in v1.
+    #
+    # ``_PARSE_ERROR_LOG_SNIPPET_CHARS``: how much of a malformed LLM
+    # response we keep in the audit log.  500 chars is enough to see
+    # the opening frame + diagnose schema drift without bloating
+    # pipeline.jsonl on a hot loop of failures.
+    _USER_PROMPT_BODY_CHARS = 6000
+    _MAX_OUTPUT_TOKENS = 8000
+    _PARSE_ERROR_LOG_SNIPPET_CHARS = 500
+
     def __init__(
         self,
         llm_client: LiteLLMClient,
@@ -553,16 +596,18 @@ class EvergreenExtractor:
         entity_prime_block = self._load_entity_prime_block()
 
         # BL-058 v2 prompt asks for 0-8 units (was "5-30+, more is better"),
-        # so 6000 chars and 8000 max_tokens still leave generous headroom.
-        # We pass the source body through so the LLM has somewhere to grep
-        # source_anchor strings out of.
+        # so the body window + token cap defined above (see
+        # ``_USER_PROMPT_BODY_CHARS`` / ``_MAX_OUTPUT_TOKENS``) leave
+        # generous headroom.  We pass the source body through so the
+        # LLM has somewhere to grep source_anchor strings out of.
+        body_chars = self._USER_PROMPT_BODY_CHARS
         user_prompt = f"""请从以下源文里抽取 CandidateUnit。
 
 文件: {file_path}
 
-内容(前 6000 字符):
+内容(前 {body_chars} 字符):
 ```
-{content[:6000]}
+{content[:body_chars]}
 ```
 {related_block}
 {entity_prime_block}
@@ -574,7 +619,7 @@ class EvergreenExtractor:
         result_text = self.llm.generate(
             system_prompt=self.SYSTEM_PROMPT,
             user_prompt=user_prompt,
-            max_tokens=8000,
+            max_tokens=self._MAX_OUTPUT_TOKENS,
         )
 
         return self._parse_v2_response(result_text, file_path)
@@ -600,24 +645,47 @@ class EvergreenExtractor:
 
         Failure modes we handle:
           - markdown-fenced JSON (```json ... ```)
+          - LLM returning conversational filler before/after the JSON
+            (gemini PR #157 review): we look for the first balanced
+            ``{...}`` block instead of trusting the response to start
+            and end exactly at the JSON.
           - LLM returning a bare list (legacy v1 shape) — log a warning
             and treat as v2 with empty wrapper
           - JSON parse error — log raw text snippet and return []
           - dict with no ``units`` key — log and return []
         """
-        # Strip optional markdown fences
+        snippet_chars = self._PARSE_ERROR_LOG_SNIPPET_CHARS
+
+        # Strip markdown fences first (the common case where the LLM
+        # follows our "no markdown wrapping" instruction reliably).
         stripped = result_text.strip()
         stripped = re.sub(r"^```(?:json)?\s*", "", stripped)
         stripped = re.sub(r"```\s*$", "", stripped)
         stripped = stripped.strip()
 
+        # Locate the first ``{`` … last ``}`` span as a fallback for
+        # responses that include conversational filler ("好的,这是 JSON:
+        # {...}").  ``re.DOTALL`` so the body can contain newlines.
+        # We don't try to count braces — if the LLM emits multiple
+        # top-level objects we accept the outer match (json.loads will
+        # then reject malformed concatenations).
+        json_match = re.search(r"\{.*\}", stripped, re.DOTALL)
+        if json_match is None:
+            self.logger.log("absorb_v2_parse_error", {
+                "source": str(file_path),
+                "error": "no JSON object found in response",
+                "raw_snippet": result_text[:snippet_chars],
+            })
+            return []
+        candidate = json_match.group()
+
         try:
-            parsed = json.loads(stripped)
+            parsed = json.loads(candidate)
         except json.JSONDecodeError as exc:
             self.logger.log("absorb_v2_parse_error", {
                 "source": str(file_path),
                 "error": str(exc),
-                "raw_snippet": result_text[:500],
+                "raw_snippet": result_text[:snippet_chars],
             })
             return []
 
@@ -699,7 +767,8 @@ class EvergreenExtractor:
         # ``method`` and ``procedure`` both land on KIND_METHOD; everything
         # else collapses to KIND_CONCEPT for now.  Future taxonomy expansion
         # (BL-058b) can give each unit_type its own entity_type.
-        from .object_kinds import CORE_OBJECT_KINDS, KIND_CONCEPT, KIND_METHOD
+        # ``CORE_OBJECT_KINDS`` / ``KIND_CONCEPT`` / ``KIND_METHOD`` are
+        # imported at module top.
         if unit_type in {"method", "procedure"}:
             entity_type = KIND_METHOD
         else:
@@ -761,8 +830,8 @@ class EvergreenExtractor:
           - specifics: list of preserved-detail categories
           - absorbed_at: ISO-8601 UTC timestamp of this extraction
         """
-        from .object_kinds import CORE_OBJECT_KINDS, KIND_CONCEPT, normalize_kind
-
+        # ``CORE_OBJECT_KINDS`` / ``KIND_CONCEPT`` / ``normalize_kind``
+        # imported at module top (gemini PR #157 review).
         concept_name = concept.get("concept_name", "Untitled")
         note_id = canonicalize_note_id(concept_name)
         title = concept.get("title", concept_name.replace("-", " "))
@@ -783,7 +852,15 @@ class EvergreenExtractor:
         entity_type = normalized if normalized in CORE_OBJECT_KINDS else KIND_CONCEPT
 
         source_provenance = _read_source_provenance(source_file)
-        absorbed_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        # Single ``now`` for both ``absorbed_at`` and ``date`` so they
+        # always agree.  gemini PR #157 review pointed out that the
+        # earlier ``datetime.now()`` for ``date`` was naive (local time)
+        # while ``absorbed_at`` was UTC — meaning a late-evening absorb
+        # could write a ``date`` one day ahead of ``absorbed_at``.
+        # UTC for both is the consistent fix.
+        now_utc = datetime.now(timezone.utc)
+        absorbed_at = now_utc.strftime("%Y-%m-%dT%H:%M:%SZ")
+        date_iso = now_utc.strftime("%Y-%m-%d")
 
         # Build optional sections.  Empty arrays / strings → section is
         # omitted entirely (no empty headings, no orphan dashes).
@@ -818,7 +895,7 @@ unit_type: {unit_type}
 epistemic_role: {epistemic_role}
 extraction_prompt_version: v2
 absorbed_at: "{absorbed_at}"
-date: {datetime.now().strftime('%Y-%m-%d')}
+date: {date_iso}
 tags: [evergreen]
 aliases: ["{concept_name}"]
 source_url: "{source_provenance['source_url']}"
@@ -968,9 +1045,11 @@ class AutoEvergreenExtractor:
                 # 添加到candidate队列（而不是直接创建active Evergreen）
                 if registry:
                     try:
-                        from .identity import canonicalize_note_id
-                        from .object_kinds import CORE_OBJECT_KINDS, KIND_CONCEPT, normalize_kind
-
+                        # ``canonicalize_note_id`` and the object_kinds
+                        # symbols are imported at module top (PR #157
+                        # review).  Local re-imports were a leftover
+                        # from a circular-import workaround that no
+                        # longer applies.
                         canonical_slug = canonicalize_note_id(concept_name)
                         raw_kind = concept.get("entity_type", KIND_CONCEPT)
                         resolved_kind = normalize_kind(raw_kind) if raw_kind else KIND_CONCEPT

--- a/src/ovp_pipeline/auto_evergreen_extractor.py
+++ b/src/ovp_pipeline/auto_evergreen_extractor.py
@@ -246,71 +246,95 @@ class LiteLLMClient:
 
 
 class EvergreenExtractor:
-    """Evergreen提取器"""
+    """Evergreen提取器 (BL-058: v2 CandidateUnit prompt).
 
-    SYSTEM_PROMPT = """你是知识提取专家。请从文章中提取**所有**有价值的原子知识单元(atomic knowledge units)。
+    The previous v1 prompt forced every output into 定义/详细解释/为什么重要
+    sections and instructed "抽得多比抽得少好" with floors of 5-30+ units.
+    The 2026-05-05 fidelity audit on 50 samples scored most of those
+    ``faithful_generic`` (claim is in source, but specifics were stripped).
+    The 6-source A/B experiment confirmed the v2 prompt produces dramatically
+    more specific units at half the volume and correctly returns
+    ``units=[]`` on low-value sources instead of fabricating units.
 
-## 数量目标(取决于原文长度和密度,不是硬上限)
+    Schema differences from v1:
+      - Output is wrapped: ``{source_value_summary, units[], skip_reason}``
+      - 10 unit_types (was 4): fact / method / procedure / tradeoff /
+        failure_mode / counterexample / case_detail / learning / decision / quote
+      - epistemic_role field (new): fact / interpretation / method / quote /
+        attributed_claim — separates "asserted by source" from "synthesised"
+      - source_anchor (new): verbatim phrase from source — mechanical
+        fidelity check, future tools can grep this back into the source body
+      - specifics (new): categorical chips (numbers / names / tradeoffs /
+        examples / edge_cases) — what kinds of source detail were preserved
+      - ``related_concepts`` is now optional (0-5, was forced ≥ 3)
+      - body content is free-form, NOT pre-structured
+    """
 
-- 短文(< 1k 词): 5-10 个
-- 中等(1-3k 词): 8-20 个
-- 长文(> 3k 词): 15-30+ 个
+    SYSTEM_PROMPT = """你的任务:从一篇源文里抽取对 vault 有价值的 CandidateUnit。
+你不是在总结源文,也不是在把源文改写成笔记。
+你是在找出源文中那些**保留了原文具体物**(数字、命名实体、方法步骤、工具名、反例、边界条件、对照选择)的可复用知识单元。
 
-不要预设上限。让原文的密度决定数量;有 N 个独立可表达的知识单元,就抽 N 个。
-**抽得多比抽得少好** —— 后续会自动去重。
+## 输出格式 (严格 JSON,不要 markdown 包装)
 
-## Evergreen 笔记标准
+{
+  "source_value_summary": "一句话概括这篇源文的可抽取价值。如果价值很低,直说。",
+  "units": [
+    {
+      "slug": "kebab-case-stable-id",
+      "title": "一句完整的陈述句,不是名词短语",
+      "unit_type": "fact|method|procedure|tradeoff|failure_mode|counterexample|case_detail|learning|decision|quote",
+      "epistemic_role": "fact|interpretation|method|quote|attributed_claim",
+      "content": "markdown,自包含,不需要回读源文也能理解",
+      "source_anchor": "源文中逐字出现的短语/数字/名称/API,作为这条单元的具体锚点",
+      "specifics": ["保留下来的具体物分类:numbers / names / tradeoffs / examples / edge_cases"],
+      "related_concepts": ["相关 wikilink slug,0-5 个,宁缺勿滥"]
+    }
+  ],
+  "skip_reason": "如果 units 是空,说明为什么:常识 / 重复 / 没具体物 / 全是观点没证据 / 等等"
+}
 
-1. **原子性**: 一个 atomic unit 一个笔记 —— 一个具体的事实/方法/洞察,不是一个主题
-2. **断言性**: 用**陈述句**命名,直接说出结论
-   - ✅ "Agents have crystallized intent, not diffuse attention"
-   - ✅ "Quarter Kelly: the only sane position sizing method"
-   - ✅ "Cache TTL keep-alive: periodic matching-prefix requests extend cache indefinitely"
-   - ❌ "Intention Layer"(只是主题名,不是断言)
-3. **永久性**: 时间无关的知识(版本号/Twitter 用户名/具体日期不入)
-4. **可链接**: 能跟其他原子单元连接
-5. **非元数据**: 不要把文件名、仓库目录、README/AGENTS.md/package.json、GitHub Action、URL 本身当成概念
+## 抽取规则,违反任何一条这条单元就不该存在:
 
-## unit_type 分类(显式标注)
+1. **自包含。** 读这条 unit 不需要回去看源文。如果核心信息是 "用 X 方法解决 Y" 而 X 是什么没说,这条是空壳。要么把 X 具体写进来,要么不写。
 
-每个原子单元必须标 `unit_type`,从以下 4 类选 1:
+2. **先选 unit_type,再写 content。形态必须匹配:**
+   - fact:单点事实 + 至少一个具体锚点(数字/命名物/场景)
+   - method:有名字的具体方法 + 操作要点 + 用什么工具/API
+   - procedure:编号步骤,每步有具体动作和命令/工具
+   - tradeoff:选 A 不选 B + 代价是什么 + 适用条件
+   - failure_mode:在什么条件下会出什么问题
+   - counterexample:与某个普遍说法不一致的具体例子
+   - case_detail:具体案例(谁/在哪/做了什么/结果如何)
+   - learning:观点 + 源文给出的依据(不能只有观点)
+   - decision:做了什么选择 + 备选 + 理由
+   - quote:值得逐字保留的原文(content 必须是逐字引用 + 你的简短标注)
 
-- **fact**: 客观事实/现象/数据(如"HTTP 402 was reserved but unused for 30 years")
-- **procedure**: 操作流程/方法/recipe(如"Quarter Kelly position sizing: bet at most 25% of optimal Kelly fraction")
-- **learning**: 经验/洞察/反直觉教训(如"Self-Improvement Requires Monitoring Layer Before Optimization")
-- **concept**: 命名抽象/定义(如"Context engineering: what model knows vs what to say to model")
+3. **不抽常识。** "X 是用于 Y 的方法" 这种 textbook 定义,默认跳过。只在源文给出 (a) 反例 (b) 数字数据 (c) 实现 tradeoff (d) 具体操作细节 之一时,这个主题才值得抽。
 
-## 输出格式(严格 JSON 数组,不要 markdown 包装)
+4. **Title 是观点,不是分类。**
+   ✗ "Skill Pack 生态" / "三层架构" / "Agent 记忆系统"
+   ✓ "Hudson 的 Swift skill 偏广度,Antoine 偏深度"
+   ✓ "把平台差异隔离在 schema 解析层,可让 view model 不变"
+   读 title 应能立刻知道这条主张什么。
 
-[
-  {
-    "concept_name": "concept-name-kebab-case",
-    "title": "Declarative claim sentence",
-    "entity_type": "concept",
-    "unit_type": "fact",
-    "one_sentence_def": "一句话定义(中文,保留技术术语英文)",
-    "explanation": "详细解释(2-4 句,中文)",
-    "importance": "为什么重要(1-2 句)",
-    "related_concepts": ["Related-1", "Related-2", "Related-3"]
-  }
-]
+5. **不要 enumeration shell。** "X 由 5 大来源组成" / "三层架构实现关注点分离" 这种**只列骨架不展开差异**的列表,不算保留 specifics。要么每项都展开它的独特点,要么不写这条 enumeration。
 
-## 字段约束
+6. **数量节制。** 0-8 单元。一篇短 tweet 可能 0-2;一篇长 paper 可能 5-8;**很少超过 8**。如果你写到第 6 条发现是在重复前面的意思,停。
 
-- `entity_type`: 10 个值之一 — concept, entity, person, company, tool, project, paper, event, framework, method
-- `unit_type`: 4 个值之一 — fact, procedure, learning, concept
-- `concept_name`: 稳定的 kebab-case slug,不含文件扩展名或 URL 片段
-- `title`: 陈述句标题(读标题就知道结论),不要复述文件名
-- `one_sentence_def`: 不能为空,完整定义句
-- `related_concepts`: 至少 3 个相关概念。如果 user prompt 给了"已有概念目录",优先从中复用 slug
+7. **跳过样板。** markdown 标题、转场段、礼貌话术、互动提示("如果你觉得有用请关注")、boilerplate 不抽。
 
-## 处理特殊文章
+8. **宁可 0 条,不要凑数。** 如果这篇源文主要是观点反复 / 没有具体方法和数据 / 全是泛泛而谈,返回 units=[],写 skip_reason。这是被允许且鼓励的输出。
 
-- **长 primer / 综述**(如 12k+ 词): 必须按章节展开,每个 section 至少抽 2-5 个 atomic unit
-- **量化/技术深度文章**: 公式/方法/参数都是好 atomic unit(如"Quarter Kelly", "BM25 + dense retrieval hybrid")
-- **中文技术文章**: 完全按英文同等粒度处理,不要因为是中文就少抽
-- **Twitter / Thread 风格**: 把每个核心 claim 当一个 unit,典型 8-15 个
-- **GitHub 项目页 / README**: 抽**项目架构 + 技术决策 + 设计权衡** 等 stable knowledge,不要抽"安装命令""目录结构"
+9. **每条 unit 的 content 必须包含至少一段源文中逐字出现的内容**(在 source_anchor 字段标出)。如果做不到,说明这条已经飘到太抽象的层次,不写。
+
+10. **epistemic_role 区分清楚:** fact = 源文当事实陈述的内容;interpretation = 作者/你对事实的解释,不是事实本身;quote = 逐字引用;method = 可执行的操作描述;attributed_claim = 作者引用别人说的。不要把 interpretation 伪装成 fact。
+
+11. **related_concepts** (可选, 0-5 个) 列出这条 unit 真正在概念上相关的其他知识 —— 不是相同 topic 的所有东西,是会让人想点过去的特定关联。如果 user prompt 给了"已有概念目录",优先复用其中的 slug;否则用 kebab-case。**没有强相关就给空列表,不要凑数。**
+
+## slug 字段
+- 稳定的 kebab-case 标识,不含 URL 片段或文件扩展名
+- 同一概念跨源应产生相同 slug(比如 "agentic-rl" 而非 "agentic-reinforcement-learning")
+- 中文标题对应的 slug 用拼音或英文翻译,简短优先
 """
 
     # PR-G2 (BL-039) — extraction-time entity prime.
@@ -528,80 +552,272 @@ class EvergreenExtractor:
         # collapse to slug ``karpathy`` rather than three new ones.
         entity_prime_block = self._load_entity_prime_block()
 
-        # Note: ``content[:6000]`` is intentional for PR-A scope — chunking
-        # for >6KB articles lands in PR-B.  The system prompt now demands
-        # 5-30 atomic units (no ``3-5`` cap, no "return [] if information
-        # is insufficient" escape hatch), which on its own gets
-        # ``evergreen_count`` from ~0 to NM-comparable on the 6KB-or-less
-        # set.  PR-B will switch this to a chunk-and-aggregate loop.
-        user_prompt = f"""请从以下深度解读中提取所有有价值的原子知识单元(atomic knowledge units)。
+        # BL-058 v2 prompt asks for 0-8 units (was "5-30+, more is better"),
+        # so 6000 chars and 8000 max_tokens still leave generous headroom.
+        # We pass the source body through so the LLM has somewhere to grep
+        # source_anchor strings out of.
+        user_prompt = f"""请从以下源文里抽取 CandidateUnit。
 
 文件: {file_path}
 
-内容（前6000字符）：
+内容(前 6000 字符):
 ```
 {content[:6000]}
 ```
 {related_block}
 {entity_prime_block}
 
-请按 JSON 格式输出 atomic unit 列表(不要 markdown 包装)。
-**抽得多好过抽得少**;短文 5-10 个,中等 8-20 个,长文 15-30+ 个。"""
+请按上面定义的 JSON 格式输出(不要 markdown 包装)。如果这篇源文没有
+具体可抽取的东西(只是观点反复 / 没有数字或案例 / 全部是常识),返回
+``{{"units": [], "skip_reason": "..."}}`` 是被鼓励的输出。"""
 
-        # Bumped max_tokens 4000 → 8000 because the new prompt typically
-        # asks for 8-30 units instead of 3-5.  At ~150 tokens/unit (JSON
-        # + explanation), 30 units ≈ 4500 tokens of output; 8000 leaves
-        # headroom for the dense long-form articles where the old 4000
-        # was already truncating the response.
         result_text = self.llm.generate(
             system_prompt=self.SYSTEM_PROMPT,
             user_prompt=user_prompt,
             max_tokens=8000,
         )
 
-        # 尝试解析JSON
-        try:
-            json_match = re.search(r'\[.*\]', result_text, re.DOTALL)
-            if json_match:
-                concepts = json.loads(json_match.group())
-            else:
-                concepts = []
-        except json.JSONDecodeError:
-            concepts = []
+        return self._parse_v2_response(result_text, file_path)
 
+    def _parse_v2_response(self, result_text: str, file_path: Path) -> list[dict]:
+        """Parse the v2 JSON wrapper into the legacy concept-dict shape
+        that downstream ``process_file`` / ``create_evergreen_note``
+        consume.
+
+        Expected v2 wrapper::
+
+            {
+              "source_value_summary": str,
+              "units": [{slug, title, unit_type, epistemic_role,
+                         content, source_anchor, specifics,
+                         related_concepts}, ...],
+              "skip_reason": str
+            }
+
+        ``units=[]`` with a non-empty ``skip_reason`` is a valid (and
+        encouraged) response — we log it as ``absorb_skipped_source``
+        and return an empty list so the caller writes no evergreens.
+
+        Failure modes we handle:
+          - markdown-fenced JSON (```json ... ```)
+          - LLM returning a bare list (legacy v1 shape) — log a warning
+            and treat as v2 with empty wrapper
+          - JSON parse error — log raw text snippet and return []
+          - dict with no ``units`` key — log and return []
+        """
+        # Strip optional markdown fences
+        stripped = result_text.strip()
+        stripped = re.sub(r"^```(?:json)?\s*", "", stripped)
+        stripped = re.sub(r"```\s*$", "", stripped)
+        stripped = stripped.strip()
+
+        try:
+            parsed = json.loads(stripped)
+        except json.JSONDecodeError as exc:
+            self.logger.log("absorb_v2_parse_error", {
+                "source": str(file_path),
+                "error": str(exc),
+                "raw_snippet": result_text[:500],
+            })
+            return []
+
+        if isinstance(parsed, list):
+            # LLM ignored the wrapper schema and returned a bare list.
+            # We don't silently accept this — the v1 fields (concept_name,
+            # one_sentence_def, importance, ...) won't be present, so the
+            # downstream renderer would produce a malformed evergreen.
+            self.logger.log("absorb_v2_schema_drift", {
+                "source": str(file_path),
+                "reason": "expected wrapped object, got list",
+                "list_length": len(parsed),
+            })
+            return []
+
+        if not isinstance(parsed, dict):
+            self.logger.log("absorb_v2_parse_error", {
+                "source": str(file_path),
+                "error": f"top-level type {type(parsed).__name__}, expected dict",
+            })
+            return []
+
+        units = parsed.get("units")
+        if not isinstance(units, list):
+            self.logger.log("absorb_v2_parse_error", {
+                "source": str(file_path),
+                "error": f"missing or non-list 'units' key",
+            })
+            return []
+
+        skip_reason = str(parsed.get("skip_reason") or "").strip()
+        source_value_summary = str(parsed.get("source_value_summary") or "").strip()
+        if not units:
+            # Empty units with skip_reason is the "encouraged skip" path.
+            # Empty units with no skip_reason is suspicious (model produced
+            # nothing AND said nothing) — we log both cases distinctly.
+            self.logger.log("absorb_skipped_source", {
+                "source": str(file_path),
+                "skip_reason": skip_reason or "(no reason given)",
+                "source_value_summary": source_value_summary,
+                "had_skip_reason": bool(skip_reason),
+            })
+            return []
+
+        # Convert each v2 unit to the legacy concept dict shape that
+        # ``process_file`` and ``create_evergreen_note`` already understand.
+        concepts: list[dict] = []
+        for unit in units:
+            if not isinstance(unit, dict):
+                continue
+            converted = self._unit_to_concept(unit)
+            if converted:
+                concepts.append(converted)
         return concepts
 
+    @staticmethod
+    def _unit_to_concept(unit: dict) -> dict | None:
+        """Convert one v2 ``CandidateUnit`` JSON to the legacy concept dict
+        shape.  Downstream code (``process_file``, ``create_evergreen_note``)
+        keys off this shape, so we keep the v1 keys present while adding the
+        new v2 keys alongside.
+
+        Returns ``None`` when the unit is too malformed to use (no title
+        AND no slug — we can't even name the file).
+        """
+        title = str(unit.get("title") or "").strip()
+        slug = str(unit.get("slug") or "").strip()
+        if not title and not slug:
+            return None
+        if not slug:
+            slug = canonicalize_note_id(title)
+        if not title:
+            title = slug.replace("-", " ").title()
+
+        unit_type = str(unit.get("unit_type") or "fact").strip().lower()
+        epistemic_role = str(unit.get("epistemic_role") or "").strip().lower()
+
+        # Map unit_type → entity_type (the existing object_kinds taxonomy).
+        # ``method`` and ``procedure`` both land on KIND_METHOD; everything
+        # else collapses to KIND_CONCEPT for now.  Future taxonomy expansion
+        # (BL-058b) can give each unit_type its own entity_type.
+        from .object_kinds import CORE_OBJECT_KINDS, KIND_CONCEPT, KIND_METHOD
+        if unit_type in {"method", "procedure"}:
+            entity_type = KIND_METHOD
+        else:
+            entity_type = KIND_CONCEPT
+        if entity_type not in CORE_OBJECT_KINDS:
+            entity_type = KIND_CONCEPT
+
+        related = unit.get("related_concepts")
+        if not isinstance(related, list):
+            related = []
+        related = [str(r).strip() for r in related if str(r).strip()]
+
+        specifics = unit.get("specifics")
+        if not isinstance(specifics, list):
+            specifics = []
+        specifics = [str(s).strip() for s in specifics if str(s).strip()]
+
+        return {
+            # legacy keys (preserved for downstream compatibility)
+            "concept_name": slug,
+            "title": title,
+            "entity_type": entity_type,
+            "unit_type": unit_type,
+            # v2 free-form content replaces one_sentence_def + explanation +
+            # importance.  Older fields kept empty so create_evergreen_note's
+            # backward-compat path doesn't crash.
+            "one_sentence_def": "",
+            "explanation": str(unit.get("content") or "").strip(),
+            "importance": "",
+            "related_concepts": related,
+            # v2-only fields
+            "epistemic_role": epistemic_role,
+            "source_anchor": str(unit.get("source_anchor") or "").strip(),
+            "specifics": specifics,
+        }
+
     def create_evergreen_note(self, concept: dict, source_file: Path) -> str:
-        """创建Evergreen笔记内容"""
+        """Render an Evergreen markdown file from a v2 CandidateUnit
+        dict (BL-058).
+
+        Body shape compared to v1:
+          - No forced ``定义 / 详细解释 / 为什么重要`` sections; ``content``
+            is whatever shape matches ``unit_type``.
+          - Source anchor block (verbatim quote) appears below the body
+            so the reviewer can mechanically check fidelity.
+          - ``## Related`` only renders when ``related_concepts`` is
+            non-empty (no empty section heading).
+          - Source backref is a plain link block at the bottom.
+
+        Frontmatter adds 6 v2-specific fields:
+          - extraction_prompt_version: v2
+          - unit_type: one of {fact, method, procedure, tradeoff,
+            failure_mode, counterexample, case_detail, learning,
+            decision, quote}
+          - epistemic_role: one of {fact, interpretation, method,
+            quote, attributed_claim}
+          - source_anchor: verbatim string from source — mechanical
+            fidelity check
+          - specifics: list of preserved-detail categories
+          - absorbed_at: ISO-8601 UTC timestamp of this extraction
+        """
+        from .object_kinds import CORE_OBJECT_KINDS, KIND_CONCEPT, normalize_kind
+
         concept_name = concept.get("concept_name", "Untitled")
         note_id = canonicalize_note_id(concept_name)
         title = concept.get("title", concept_name.replace("-", " "))
-        definition = concept.get("one_sentence_def", "")
-        explanation = concept.get("explanation", "")
-        importance = concept.get("importance", "")
-        related = concept.get("related_concepts", [])
-
-        # 构建相关链接
-        related_links = "\n".join([f"- [[{c}]]" for c in related if c])
-
-        from .object_kinds import CORE_OBJECT_KINDS, KIND_CONCEPT, normalize_kind
+        # v2: ``content`` is the free-form body the LLM produced.  We kept
+        # ``explanation`` as the dict key so legacy callers (process_file)
+        # don't need to know about the rename.
+        body_content = concept.get("explanation", "").strip()
+        related = concept.get("related_concepts") or []
+        related = [str(r).strip() for r in related if str(r).strip()]
+        unit_type = str(concept.get("unit_type") or "fact").strip().lower()
+        epistemic_role = str(concept.get("epistemic_role") or "").strip().lower()
+        source_anchor = str(concept.get("source_anchor") or "").strip()
+        specifics = concept.get("specifics") or []
+        specifics = [str(s).strip() for s in specifics if str(s).strip()]
 
         raw_kind = concept.get("entity_type", concept.get("kind", ""))
         normalized = normalize_kind(raw_kind) if raw_kind else KIND_CONCEPT
         entity_type = normalized if normalized in CORE_OBJECT_KINDS else KIND_CONCEPT
 
-        # BL-054: read provenance off the source article so the new
-        # evergreen's frontmatter carries it forward.  Future
-        # crystal_scoring (credibility + diversity) keys off these
-        # fields — leaving them empty silently breaks scoring for
-        # every evergreen this extractor produces.
         source_provenance = _read_source_provenance(source_file)
+        absorbed_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        # Build optional sections.  Empty arrays / strings → section is
+        # omitted entirely (no empty headings, no orphan dashes).
+        anchor_block = ""
+        if source_anchor:
+            # Quote-escape the anchor itself so multi-line / quote-containing
+            # source text doesn't break the markdown blockquote.
+            safe_anchor = source_anchor.replace("\n", " ").strip()
+            anchor_block = f'\n> **Source anchor**: "{safe_anchor}"\n'
+
+        related_block = ""
+        if related:
+            links = "\n".join(f"- [[{c}]]" for c in related)
+            related_block = f"\n## Related\n\n{links}\n"
+
+        # YAML serialization of list fields — single-line array form.
+        related_yaml = (
+            "[" + ", ".join(_yaml_escape(c) for c in related) + "]"
+            if related else "[]"
+        )
+        specifics_yaml = (
+            "[" + ", ".join(_yaml_escape(s) for s in specifics) + "]"
+            if specifics else "[]"
+        )
 
         note = f"""---
 note_id: {note_id}
 title: "{title}"
 type: evergreen
 entity_type: {entity_type}
+unit_type: {unit_type}
+epistemic_role: {epistemic_role}
+extraction_prompt_version: v2
+absorbed_at: "{absorbed_at}"
 date: {datetime.now().strftime('%Y-%m-%d')}
 tags: [evergreen]
 aliases: ["{concept_name}"]
@@ -610,24 +826,17 @@ source_title: "{source_provenance['source_title']}"
 source_authors: {source_provenance['source_authors_yaml']}
 source_published_at: "{source_provenance['source_published_at']}"
 source_fingerprint: "{source_provenance['source_fingerprint']}"
+source_anchor: {_yaml_escape(source_anchor)}
+specifics: {specifics_yaml}
+related_concepts: {related_yaml}
 ---
 
 # {title}
 
-> **一句话定义**: {definition}
+{body_content}
+{anchor_block}{related_block}
+## Source
 
-## 📝 详细解释
-
-### 是什么？
-{explanation}
-
-### 为什么重要？
-{importance}
-
-## 🔗 关联概念
-{related_links}
-
-## 📚 来源与扩展阅读
 - [[{source_file.stem}]]
 """
 
@@ -736,13 +945,12 @@ class AutoEvergreenExtractor:
                     "status": "pending"
                 }
 
-                related = concept.get("related_concepts") or []
-                if len(related) < 3:
-                    self.logger.log("evergreen_low_link", {
-                        "concept": concept_name,
-                        "source": str(file_path.name),
-                        "related_count": len(related),
-                    })
+                # BL-058: ``evergreen_low_link`` audit event used to fire
+                # when LLM produced < 3 related_concepts.  v2 prompt
+                # explicitly allows 0-5 (宁缺勿滥),so a missing link is
+                # no longer a regression signal.  The event is dropped
+                # rather than re-defined; downstream watchers that read
+                # the legacy event simply stop seeing it.
 
                 # 检查是否已存在（registry或文件系统）
                 if self.evergreen_exists(concept_name, registry=registry):

--- a/src/ovp_pipeline/commands/tag_legacy_evergreens.py
+++ b/src/ovp_pipeline/commands/tag_legacy_evergreens.py
@@ -1,0 +1,287 @@
+"""ovp-tag-legacy-evergreens — one-shot frontmatter migration (BL-058).
+
+Walks every evergreen file in ``10-Knowledge/Evergreen/`` and tags
+those that lack ``extraction_prompt_version`` with::
+
+    extraction_prompt_version: v1
+    legacy_unverified: true
+    legacy_tagged_at: <iso>
+
+The two markers are how downstream tools (reader UI badges, crystal
+scoring weights, fidelity replay) tell apart "absorbed under the old
+prompt that may have abstraction-inflated specifics" from "absorbed
+under v2 with source_anchor + specificity guarantees".
+
+Why a separate command, not part of the absorb refactor:
+
+  * Touching ~7000 files writes a lot of audit log entries; we want to
+    do that in one explicit step we can run + verify, not at every
+    incremental run start.
+  * Idempotent: re-running detects already-tagged files and skips them,
+    so accidentally running twice is harmless.
+  * Reversible: ``--untag`` mode removes the three added fields so we
+    can roll back if the legacy classification turns out to be wrong
+    (e.g. if some files were already v2 from a forgotten experiment).
+
+Pre-flight check by default; pass ``--write`` to actually mutate files.
+
+Output manifest at ``60-Logs/legacy-tag/<run-id>/manifest.json`` lists
+every file the command touched (in either dry-run or write mode).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from ..runtime import VaultLayout, resolve_vault_dir
+
+
+_MARKER_PROMPT_VERSION = "extraction_prompt_version"
+_MARKER_LEGACY = "legacy_unverified"
+_MARKER_TAGGED_AT = "legacy_tagged_at"
+
+# Lines we INSERT for legacy classification.  Each one stays on its
+# own line so the diff is readable.
+_TAG_LINES_TEMPLATE = (
+    f"{_MARKER_PROMPT_VERSION}: v1\n"
+    f"{_MARKER_LEGACY}: true\n"
+    f"{_MARKER_TAGGED_AT}: \"{{tagged_at}}\"\n"
+)
+
+
+@dataclass
+class FileResult:
+    path: Path
+    action: str  # "tagged" | "skipped_already_tagged" | "skipped_v2" | "skipped_no_frontmatter" | "untagged"
+    reason: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter helpers — same lightweight regex approach the rest of the
+# codebase uses, no full YAML parser needed for these markers.
+# ---------------------------------------------------------------------------
+
+
+def _split_frontmatter(text: str) -> tuple[str, str, str] | None:
+    """Return ``(opening_fence, frontmatter_block, rest)`` or None.
+
+    ``opening_fence`` is ``"---\\n"`` (we always re-emit that).
+    ``frontmatter_block`` is everything between the fences, NOT
+    including either fence.
+    ``rest`` is everything after the closing fence, including the
+    closing ``---\\n`` itself so the caller can emit it back unchanged.
+    """
+    if not text.startswith("---"):
+        return None
+    # Locate the closing fence — must be on its own line
+    match = re.search(r"\n---\s*(?:\n|$)", text[3:])
+    if not match:
+        return None
+    fm_start = text.find("\n", 0) + 1  # first char after opening fence's newline
+    fm_end = 3 + match.start()           # position of "\n" before closing "---"
+    closing_start = 3 + match.start() + 1  # start of "---" closing line
+    frontmatter_block = text[fm_start:fm_end + 1]  # include trailing \n
+    rest = text[closing_start:]
+    return ("---\n", frontmatter_block, rest)
+
+
+def _has_marker(frontmatter_block: str, key: str) -> bool:
+    """True if frontmatter has a top-level key ``key``.
+
+    We only check at line-start to avoid false-matching the marker
+    inside a quoted value.
+    """
+    pattern = rf"(?m)^{re.escape(key)}\s*:"
+    return bool(re.search(pattern, frontmatter_block))
+
+
+def _strip_marker(frontmatter_block: str, key: str) -> str:
+    """Remove every line that starts with ``<key>:``."""
+    pattern = rf"(?m)^{re.escape(key)}\s*:.*\n?"
+    return re.sub(pattern, "", frontmatter_block)
+
+
+# ---------------------------------------------------------------------------
+# Per-file classification + mutation
+# ---------------------------------------------------------------------------
+
+
+def _classify_and_tag(
+    path: Path,
+    *,
+    tagged_at: str,
+    write: bool,
+) -> FileResult:
+    """Decide what to do with one evergreen file.
+
+    Returns a ``FileResult`` describing the action.  When ``write=True``
+    the action is also applied to disk.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        return FileResult(path, "skipped_no_frontmatter", reason=f"read error: {exc}")
+
+    parts = _split_frontmatter(text)
+    if parts is None:
+        return FileResult(path, "skipped_no_frontmatter")
+    opening, fm_block, rest = parts
+
+    # Already tagged?
+    if _has_marker(fm_block, _MARKER_LEGACY):
+        return FileResult(path, "skipped_already_tagged")
+
+    # Already v2?  Don't overwrite.
+    version_match = re.search(
+        rf"(?m)^{re.escape(_MARKER_PROMPT_VERSION)}\s*:\s*(.+)$",
+        fm_block,
+    )
+    if version_match:
+        existing = version_match.group(1).strip().strip('"\'')
+        if existing == "v2":
+            return FileResult(path, "skipped_v2", reason=f"version={existing}")
+
+    if not write:
+        return FileResult(path, "tagged", reason="dry_run")
+
+    # Insert the three marker lines at the END of the frontmatter block
+    # (before the closing fence).  Preserves all existing fields,
+    # creates a minimal diff.
+    new_lines = _TAG_LINES_TEMPLATE.format(tagged_at=tagged_at)
+    if not fm_block.endswith("\n"):
+        fm_block += "\n"
+    new_fm = fm_block + new_lines
+    new_text = opening + new_fm + rest
+    path.write_text(new_text, encoding="utf-8")
+    return FileResult(path, "tagged")
+
+
+def _untag_file(path: Path, *, write: bool) -> FileResult:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        return FileResult(path, "skipped_no_frontmatter", reason=f"read error: {exc}")
+    parts = _split_frontmatter(text)
+    if parts is None:
+        return FileResult(path, "skipped_no_frontmatter")
+    opening, fm_block, rest = parts
+    if not _has_marker(fm_block, _MARKER_LEGACY):
+        return FileResult(path, "skipped_already_tagged", reason="no legacy marker")
+    if not write:
+        return FileResult(path, "untagged", reason="dry_run")
+    for key in (_MARKER_LEGACY, _MARKER_TAGGED_AT, _MARKER_PROMPT_VERSION):
+        fm_block = _strip_marker(fm_block, key)
+    new_text = opening + fm_block + rest
+    path.write_text(new_text, encoding="utf-8")
+    return FileResult(path, "untagged")
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+def _walk_evergreens(layout: VaultLayout) -> list[Path]:
+    """Every ``*.md`` under the Evergreen directory, excluding the
+    ``_Candidates/`` subtree (those are pending notes that haven't been
+    promoted yet — they don't need legacy tagging)."""
+    if not layout.evergreen_dir.exists():
+        return []
+    return sorted(
+        path
+        for path in layout.evergreen_dir.rglob("*.md")
+        if "_Candidates" not in path.parts
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="ovp-tag-legacy-evergreens",
+        description=(
+            "Tag every existing evergreen as legacy_unverified=true "
+            "+ extraction_prompt_version=v1 (BL-058 migration). "
+            "Idempotent and reversible."
+        ),
+    )
+    parser.add_argument("--vault-dir", type=Path, default=None)
+    parser.add_argument(
+        "--write", action="store_true",
+        help="Mutate files (default: dry-run).",
+    )
+    parser.add_argument(
+        "--untag", action="store_true",
+        help="Reverse mode — strip the three legacy markers.",
+    )
+    parser.add_argument("--run-id", type=str, default=None)
+    args = parser.parse_args(argv)
+
+    vault_dir = resolve_vault_dir(args.vault_dir)
+    layout = VaultLayout.from_vault(vault_dir)
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out_dir = layout.logs_dir / "legacy-tag" / run_id
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    paths = _walk_evergreens(layout)
+    print(f"Scanning {len(paths)} evergreen files under {layout.evergreen_dir} …", file=sys.stderr)
+
+    tagged_at = datetime.now(timezone.utc).isoformat()
+    results: list[FileResult] = []
+    for path in paths:
+        if args.untag:
+            result = _untag_file(path, write=args.write)
+        else:
+            result = _classify_and_tag(path, tagged_at=tagged_at, write=args.write)
+        results.append(result)
+
+    # Aggregate
+    by_action: dict[str, int] = {}
+    for r in results:
+        by_action[r.action] = by_action.get(r.action, 0) + 1
+
+    mode = "untag" if args.untag else "tag"
+    write_mode = "WRITE" if args.write else "DRY-RUN"
+    print(f"\n=== {mode} ({write_mode}) ===", file=sys.stderr)
+    print(f"  total files: {len(results)}", file=sys.stderr)
+    for action, count in sorted(by_action.items()):
+        print(f"  {action:30s} {count}", file=sys.stderr)
+
+    # Manifest
+    manifest = {
+        "run_id": run_id,
+        "mode": mode,
+        "write": args.write,
+        "tagged_at": tagged_at,
+        "vault_dir": str(vault_dir),
+        "total_files": len(results),
+        "by_action": by_action,
+        "files": [
+            {
+                "path": str(r.path.relative_to(vault_dir)),
+                "action": r.action,
+                "reason": r.reason,
+            }
+            for r in results
+        ],
+    }
+    manifest_path = out_dir / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    print(f"\nManifest: {manifest_path}", file=sys.stderr)
+    if not args.write:
+        print(
+            f"\n[dry-run] Re-run with --write to apply changes.",
+            file=sys.stderr,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_absorb_v2.py
+++ b/tests/test_absorb_v2.py
@@ -1,0 +1,373 @@
+"""Tests for BL-058 — absorb v2 prompt + CandidateUnit schema.
+
+Covers the parser, the unit→concept converter, the new evergreen body
+template, and the legacy-tagging command.
+
+We don't run the LLM here — the prompt itself is verified by the
+6-source A/B experiment.  These tests pin behavioral contracts so a
+future schema drift surfaces as a test failure, not as a silently
+mis-rendered evergreen on disk.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from ovp_pipeline.auto_evergreen_extractor import (
+    EvergreenExtractor,
+    PipelineLogger,
+)
+from ovp_pipeline.commands.tag_legacy_evergreens import (
+    _classify_and_tag,
+    _split_frontmatter,
+    _untag_file,
+    main as tag_legacy_main,
+)
+
+
+# ---------------------------------------------------------------------------
+# v2 response parser
+# ---------------------------------------------------------------------------
+
+
+def _make_extractor(tmp_path: Path) -> EvergreenExtractor:
+    log = PipelineLogger(tmp_path / "pipeline.jsonl")
+    llm = MagicMock()
+    return EvergreenExtractor(llm_client=llm, logger=log, vault_dir=tmp_path)
+
+
+class TestV2ResponseParsing:
+    def test_well_formed_units_array(self, tmp_path):
+        extractor = _make_extractor(tmp_path)
+        response = json.dumps({
+            "source_value_summary": "Tweet about specific PID lock implementation",
+            "units": [
+                {
+                    "slug": "pid-lock-ownership",
+                    "title": "PID-based ownership prevents OOM-orphaned locks",
+                    "unit_type": "method",
+                    "epistemic_role": "method",
+                    "content": "Bind lock ownership to PID lifecycle so OOM kill releases the lock. Used in their K8s cluster after Redis lock got stuck.",
+                    "source_anchor": "lock ownership tied to PID lifecycle",
+                    "specifics": ["names", "examples", "edge_cases"],
+                    "related_concepts": ["distributed-locks", "k8s-oom"],
+                },
+                {
+                    "slug": "redis-lock-orphaned-on-oom",
+                    "title": "Redis distributed lock can stay held when holder is OOM-killed",
+                    "unit_type": "failure_mode",
+                    "epistemic_role": "fact",
+                    "content": "A pod holding a Redis SET-NX lock that gets OOM-killed leaves the lock until the configured TTL expires.",
+                    "source_anchor": "Redis lock didn't release on OOM",
+                    "specifics": ["edge_cases"],
+                    "related_concepts": [],
+                },
+            ],
+            "skip_reason": "",
+        })
+        concepts = extractor._parse_v2_response(response, Path("/fake/source.md"))
+        assert len(concepts) == 2
+        c0 = concepts[0]
+        assert c0["concept_name"] == "pid-lock-ownership"
+        assert c0["title"].startswith("PID-based")
+        assert c0["unit_type"] == "method"
+        assert c0["epistemic_role"] == "method"
+        assert c0["entity_type"] == "method"  # method/procedure → KIND_METHOD
+        assert c0["source_anchor"] == "lock ownership tied to PID lifecycle"
+        assert c0["specifics"] == ["names", "examples", "edge_cases"]
+        assert c0["related_concepts"] == ["distributed-locks", "k8s-oom"]
+        # Legacy fields preserved as empty so downstream renderers don't crash
+        assert c0["one_sentence_def"] == ""
+        assert c0["importance"] == ""
+        # ``content`` lives under ``explanation`` for legacy-callers
+        assert "OOM" in c0["explanation"]
+
+    def test_skip_reason_empty_units_returns_empty_list(self, tmp_path):
+        extractor = _make_extractor(tmp_path)
+        response = json.dumps({
+            "source_value_summary": "13 chars of repo name only",
+            "units": [],
+            "skip_reason": "源文仅含 repo 标题,无可抽取具体物",
+        })
+        concepts = extractor._parse_v2_response(response, Path("/fake/stub.md"))
+        assert concepts == []
+
+    def test_markdown_fenced_json_is_unwrapped(self, tmp_path):
+        extractor = _make_extractor(tmp_path)
+        wrapped = "```json\n" + json.dumps({"units": [], "skip_reason": "ok"}) + "\n```"
+        concepts = extractor._parse_v2_response(wrapped, Path("/fake/x.md"))
+        assert concepts == []
+
+    def test_bare_list_response_is_rejected(self, tmp_path):
+        """v1 prompt returned a bare list — v2 must NOT silently accept
+        that, because the v1 fields aren't compatible with the new
+        renderer."""
+        extractor = _make_extractor(tmp_path)
+        response = json.dumps([
+            {"concept_name": "foo", "title": "Foo", "one_sentence_def": "..."},
+        ])
+        concepts = extractor._parse_v2_response(response, Path("/fake/x.md"))
+        assert concepts == []
+
+    def test_invalid_json_returns_empty(self, tmp_path):
+        extractor = _make_extractor(tmp_path)
+        concepts = extractor._parse_v2_response("not valid json {", Path("/fake/x.md"))
+        assert concepts == []
+
+    def test_unit_missing_title_and_slug_is_dropped(self, tmp_path):
+        extractor = _make_extractor(tmp_path)
+        response = json.dumps({
+            "units": [
+                {"slug": "ok", "title": "ok"},
+                {"unit_type": "fact", "content": "no title or slug"},
+                {"slug": "second", "title": "Second"},
+            ],
+            "skip_reason": "",
+        })
+        concepts = extractor._parse_v2_response(response, Path("/fake/x.md"))
+        slugs = {c["concept_name"] for c in concepts}
+        assert slugs == {"ok", "second"}
+
+    def test_method_unit_type_maps_to_method_entity_type(self, tmp_path):
+        extractor = _make_extractor(tmp_path)
+        for ut in ("method", "procedure"):
+            unit = {"slug": f"x-{ut}", "title": "X", "unit_type": ut}
+            converted = EvergreenExtractor._unit_to_concept(unit)
+            assert converted["entity_type"] == "method"
+
+    def test_other_unit_types_collapse_to_concept_entity_type(self, tmp_path):
+        for ut in ("fact", "tradeoff", "failure_mode", "case_detail",
+                   "learning", "decision", "quote", "counterexample"):
+            unit = {"slug": f"x-{ut}", "title": "X", "unit_type": ut}
+            converted = EvergreenExtractor._unit_to_concept(unit)
+            assert converted["entity_type"] == "concept"
+
+
+# ---------------------------------------------------------------------------
+# create_evergreen_note v2 body template
+# ---------------------------------------------------------------------------
+
+
+class TestEvergreenNoteV2Template:
+    def _source_file(self, tmp_path: Path) -> Path:
+        """A minimal processed-source markdown that
+        ``_read_source_provenance`` can parse."""
+        path = tmp_path / "2026-04-09_synthetic.md"
+        path.write_text(
+            "---\n"
+            "title: \"Synthetic source\"\n"
+            "source: https://example.com/article\n"
+            "date: 2026-04-09\n"
+            "type: article\n"
+            "---\n\n"
+            "# body\n",
+            encoding="utf-8",
+        )
+        return path
+
+    def test_no_legacy_template_sections(self, tmp_path):
+        """v1 forced ``定义 / 详细解释 / 为什么重要`` headers — v2 body
+        is whatever ``content`` contained.  Regression guard."""
+        extractor = _make_extractor(tmp_path)
+        source = self._source_file(tmp_path)
+        concept = {
+            "concept_name": "x",
+            "title": "X exists",
+            "explanation": "specific body content",
+            "unit_type": "fact",
+            "epistemic_role": "fact",
+            "source_anchor": "from source",
+            "specifics": ["numbers"],
+            "related_concepts": [],
+            "entity_type": "concept",
+        }
+        note = extractor.create_evergreen_note(concept, source)
+        # No forced section headings
+        assert "一句话定义" not in note
+        assert "## 📝 详细解释" not in note
+        assert "### 是什么？" not in note
+        assert "### 为什么重要？" not in note
+        # New v2 markers ARE present
+        assert "extraction_prompt_version: v2" in note
+        assert "unit_type: fact" in note
+        assert "epistemic_role: fact" in note
+        assert 'source_anchor: "from source"' in note or 'source_anchor: from source' in note
+        assert "specifics: [numbers]" in note
+
+    def test_related_section_omitted_when_empty(self, tmp_path):
+        """Empty ``related_concepts`` → no ``## Related`` heading.
+        Avoids dangling section headers in the rendered note."""
+        extractor = _make_extractor(tmp_path)
+        source = self._source_file(tmp_path)
+        concept = {
+            "concept_name": "x", "title": "X", "explanation": "body",
+            "unit_type": "fact", "epistemic_role": "fact",
+            "source_anchor": "anchor", "specifics": [],
+            "related_concepts": [],
+            "entity_type": "concept",
+        }
+        note = extractor.create_evergreen_note(concept, source)
+        assert "## Related" not in note
+
+    def test_related_section_present_when_non_empty(self, tmp_path):
+        extractor = _make_extractor(tmp_path)
+        source = self._source_file(tmp_path)
+        concept = {
+            "concept_name": "x", "title": "X", "explanation": "body",
+            "unit_type": "fact", "epistemic_role": "fact",
+            "source_anchor": "anchor", "specifics": [],
+            "related_concepts": ["foo-bar", "baz-qux"],
+            "entity_type": "concept",
+        }
+        note = extractor.create_evergreen_note(concept, source)
+        assert "## Related" in note
+        assert "[[foo-bar]]" in note
+        assert "[[baz-qux]]" in note
+
+    def test_source_anchor_block_renders(self, tmp_path):
+        extractor = _make_extractor(tmp_path)
+        source = self._source_file(tmp_path)
+        concept = {
+            "concept_name": "x", "title": "X", "explanation": "body",
+            "unit_type": "fact", "epistemic_role": "fact",
+            "source_anchor": "exact phrase from source",
+            "specifics": ["names"],
+            "related_concepts": [],
+            "entity_type": "concept",
+        }
+        note = extractor.create_evergreen_note(concept, source)
+        # The blockquote shows the verbatim anchor for human review
+        assert '> **Source anchor**: "exact phrase from source"' in note
+
+    def test_source_anchor_block_omitted_when_empty(self, tmp_path):
+        """No anchor → no anchor block.  (v2 prompt requires anchor,
+        but the renderer must tolerate missing values gracefully so a
+        partial parse doesn't render a malformed block.)"""
+        extractor = _make_extractor(tmp_path)
+        source = self._source_file(tmp_path)
+        concept = {
+            "concept_name": "x", "title": "X", "explanation": "body",
+            "unit_type": "fact", "epistemic_role": "fact",
+            "source_anchor": "",
+            "specifics": [],
+            "related_concepts": [],
+            "entity_type": "concept",
+        }
+        note = extractor.create_evergreen_note(concept, source)
+        assert "Source anchor" not in note
+
+
+# ---------------------------------------------------------------------------
+# Legacy tagging command
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyTagging:
+    def _legacy_evergreen(self, tmp_path: Path, name: str = "legacy.md") -> Path:
+        """An evergreen written by the v1 absorb path — has no
+        ``extraction_prompt_version`` field."""
+        path = tmp_path / name
+        path.write_text(
+            "---\n"
+            "note_id: legacy\n"
+            "title: \"Legacy note\"\n"
+            "type: evergreen\n"
+            "entity_type: concept\n"
+            "date: 2026-04-09\n"
+            "tags: [evergreen]\n"
+            "aliases: [\"legacy\"]\n"
+            "---\n\n"
+            "# Legacy note\n\n"
+            "> **一句话定义**: ...\n",
+            encoding="utf-8",
+        )
+        return path
+
+    def test_classify_dry_run_does_not_mutate(self, tmp_path):
+        path = self._legacy_evergreen(tmp_path)
+        original = path.read_text(encoding="utf-8")
+        result = _classify_and_tag(path, tagged_at="2026-05-15T00:00:00+00:00", write=False)
+        assert result.action == "tagged"
+        assert path.read_text(encoding="utf-8") == original
+
+    def test_classify_write_adds_three_markers(self, tmp_path):
+        path = self._legacy_evergreen(tmp_path)
+        result = _classify_and_tag(path, tagged_at="2026-05-15T00:00:00+00:00", write=True)
+        assert result.action == "tagged"
+        new_text = path.read_text(encoding="utf-8")
+        assert "extraction_prompt_version: v1" in new_text
+        assert "legacy_unverified: true" in new_text
+        assert 'legacy_tagged_at: "2026-05-15T00:00:00+00:00"' in new_text
+        # Body untouched
+        assert "# Legacy note" in new_text
+        assert "> **一句话定义**: ..." in new_text
+
+    def test_classify_idempotent_second_run_skips(self, tmp_path):
+        path = self._legacy_evergreen(tmp_path)
+        _classify_and_tag(path, tagged_at="2026-05-15T00:00:00+00:00", write=True)
+        # Second run
+        result = _classify_and_tag(path, tagged_at="2026-05-15T00:00:00+00:00", write=True)
+        assert result.action == "skipped_already_tagged"
+
+    def test_classify_skips_v2_files(self, tmp_path):
+        v2_path = tmp_path / "v2.md"
+        v2_path.write_text(
+            "---\n"
+            "note_id: v2-note\n"
+            "title: \"V2 note\"\n"
+            "extraction_prompt_version: v2\n"
+            "---\n\nbody\n",
+            encoding="utf-8",
+        )
+        result = _classify_and_tag(v2_path, tagged_at="2026-05-15T00:00:00+00:00", write=True)
+        assert result.action == "skipped_v2"
+
+    def test_untag_removes_three_markers(self, tmp_path):
+        path = self._legacy_evergreen(tmp_path)
+        _classify_and_tag(path, tagged_at="2026-05-15T00:00:00+00:00", write=True)
+        result = _untag_file(path, write=True)
+        assert result.action == "untagged"
+        new_text = path.read_text(encoding="utf-8")
+        assert "legacy_unverified" not in new_text
+        assert "legacy_tagged_at" not in new_text
+        assert "extraction_prompt_version" not in new_text
+
+    def test_skips_files_without_frontmatter(self, tmp_path):
+        path = tmp_path / "no-fm.md"
+        path.write_text("# just a heading\n\nbody\n", encoding="utf-8")
+        result = _classify_and_tag(path, tagged_at="2026-05-15T00:00:00+00:00", write=True)
+        assert result.action == "skipped_no_frontmatter"
+
+    def test_main_writes_manifest(self, tmp_path, capsys):
+        # Set up a vault skeleton
+        vault = tmp_path
+        for d in ["10-Knowledge/Evergreen", "20-Areas", "50-Inbox", "60-Logs", "70-Archive"]:
+            (vault / d).mkdir(parents=True, exist_ok=True)
+        (vault / ".obsidian").mkdir(exist_ok=True)
+        legacy = vault / "10-Knowledge" / "Evergreen" / "x.md"
+        legacy.write_text(
+            "---\nnote_id: x\ntitle: X\ntype: evergreen\n---\n\nbody\n",
+            encoding="utf-8",
+        )
+
+        rc = tag_legacy_main([
+            "--vault-dir", str(vault),
+            "--write",
+            "--run-id", "test-run",
+        ])
+        assert rc == 0
+        manifest_path = vault / "60-Logs" / "legacy-tag" / "test-run" / "manifest.json"
+        assert manifest_path.exists()
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        assert manifest["mode"] == "tag"
+        assert manifest["write"] is True
+        assert manifest["total_files"] == 1
+        assert manifest["by_action"].get("tagged") == 1
+        # And the legacy file actually got tagged
+        assert "legacy_unverified: true" in legacy.read_text(encoding="utf-8")

--- a/tests/test_absorb_v2.py
+++ b/tests/test_absorb_v2.py
@@ -117,7 +117,35 @@ class TestV2ResponseParsing:
 
     def test_invalid_json_returns_empty(self, tmp_path):
         extractor = _make_extractor(tmp_path)
-        concepts = extractor._parse_v2_response("not valid json {", Path("/fake/x.md"))
+        concepts = extractor._parse_v2_response("not valid json", Path("/fake/x.md"))
+        assert concepts == []
+
+    def test_tolerates_conversational_filler_around_json(self, tmp_path):
+        """gemini PR #157 review fix: even though we instruct the LLM
+        not to wrap output in markdown, models occasionally emit
+        ``好的,这是 JSON 输出: {...}`` or ``Here is the result:\\n{...}``.
+        The parser must locate the JSON object inside the response
+        rather than fail on the surrounding prose."""
+        extractor = _make_extractor(tmp_path)
+        wrapped = (
+            "好的,这是按照你要求的 JSON:\n"
+            + json.dumps({
+                "units": [
+                    {"slug": "ok", "title": "Ok claim", "unit_type": "fact"}
+                ],
+                "skip_reason": "",
+            })
+            + "\n\n希望对你有帮助!"
+        )
+        concepts = extractor._parse_v2_response(wrapped, Path("/fake/x.md"))
+        assert len(concepts) == 1
+        assert concepts[0]["concept_name"] == "ok"
+
+    def test_no_json_object_in_response_returns_empty(self, tmp_path):
+        """When the LLM returns prose with no JSON at all, parser
+        should log + return [] (not crash)."""
+        extractor = _make_extractor(tmp_path)
+        concepts = extractor._parse_v2_response("Just a sentence with no json.", Path("/fake/x.md"))
         assert concepts == []
 
     def test_unit_missing_title_and_slug_is_dropped(self, tmp_path):

--- a/tests/test_evergreen_extractor_retrieval.py
+++ b/tests/test_evergreen_extractor_retrieval.py
@@ -166,69 +166,7 @@ def test_extract_concepts_omits_block_when_vault_dir_none(temp_vault, tmp_path):
     assert "已有概念目录" not in fake_llm.calls[0]["user_prompt"]
 
 
-def test_process_file_logs_evergreen_low_link_below_threshold(temp_vault, tmp_path):
-    """When the LLM ignores the ≥3 requirement, the audit log must record it
-    so the link-density watchdog can spot regressions."""
-    log_path = temp_vault / "60-Logs" / "pipeline.jsonl"
-    logger = PipelineLogger(log_path)
-    auto = AutoEvergreenExtractor(temp_vault, logger)
-
-    # Inject our fake LLM directly — bypass init_llm so we don't need litellm.
-    auto.extractor = EvergreenExtractor(
-        _FakeLLM(
-            [
-                {
-                    "concept_name": "underlinked-concept",
-                    "title": "Underlinked Concept",
-                    "one_sentence_def": "测试用概念。",
-                    "explanation": "测试。",
-                    "importance": "测试。",
-                    "related_concepts": ["only-one"],
-                }
-            ]
-        ),
-        logger,
-        vault_dir=temp_vault,
-    )
-
-    fake_path = tmp_path / "fake_deep_dive.md"
-    fake_path.write_text("body content", encoding="utf-8")
-    auto.process_file(fake_path, dry_run=True)
-
-    rows = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines() if line]
-    low_link_rows = [r for r in rows if r.get("event_type") == "evergreen_low_link"]
-    assert len(low_link_rows) == 1
-    assert low_link_rows[0]["concept"] == "underlinked-concept"
-    assert low_link_rows[0]["related_count"] == 1
-
-
-def test_process_file_does_not_log_when_threshold_met(temp_vault, tmp_path):
-    log_path = temp_vault / "60-Logs" / "pipeline.jsonl"
-    logger = PipelineLogger(log_path)
-    auto = AutoEvergreenExtractor(temp_vault, logger)
-    auto.extractor = EvergreenExtractor(
-        _FakeLLM(
-            [
-                {
-                    "concept_name": "well-linked-concept",
-                    "title": "Well-Linked Concept",
-                    "one_sentence_def": "测试用概念。",
-                    "explanation": "测试。",
-                    "importance": "测试。",
-                    "related_concepts": ["a", "b", "c"],
-                }
-            ]
-        ),
-        logger,
-        vault_dir=temp_vault,
-    )
-
-    fake_path = tmp_path / "fake_deep_dive.md"
-    fake_path.write_text("body content", encoding="utf-8")
-    auto.process_file(fake_path, dry_run=True)
-
-    if not log_path.exists():
-        return
-    rows = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines() if line]
-    low_link_rows = [r for r in rows if r.get("event_type") == "evergreen_low_link"]
-    assert low_link_rows == []
+# BL-058: ``evergreen_low_link`` audit event was dropped — v2 prompt
+# allows 0-5 related_concepts (宁缺勿滥), so missing links are no
+# longer a regression signal.  Two tests that asserted the event were
+# removed with this BL-058 migration.

--- a/tests/test_evergreen_prompt_liberation.py
+++ b/tests/test_evergreen_prompt_liberation.py
@@ -1,13 +1,20 @@
-"""Lock down the new ``EvergreenExtractor.SYSTEM_PROMPT`` shape.
+"""Lock down the ``EvergreenExtractor.SYSTEM_PROMPT`` shape.
 
-PR-A liberates the prompt from the legacy ``3-5 个核心概念`` cap and the
-``信息不足返回空数组`` escape hatch.  The May 2026 8-article cross-platform
-deep-dive showed OVP extracted 0 evergreens on 7/8 articles while NM
-extracted 4-11 atomic memories per article — the prompt was the
-70%-weight root cause.
+BL-058 (2026-05-05) replaced the v1 prompt with a v2 ``CandidateUnit``
+prompt.  v1 used a "抽得多比抽得少好" volume bias and a forced
+``定义 / 详细解释 / 为什么重要`` template; v2 caps at 0-8 units, allows
+``units=[]`` with ``skip_reason``, and demands a ``source_anchor``
+verbatim quote on every unit.
 
-These tests don't call the LLM (no API in CI); they assert the prompt's
-SHAPE so the next time someone "tightens" it back, the test catches it.
+The original PR-A "prompt liberation" tests (which verified the v1
+LIBERATION away from a 3-5 cap and a "return [] if insufficient"
+escape hatch) are mostly preserved here because BL-058 keeps those
+fixes — but several v1-specific contracts that BL-058 deliberately
+DROPPED have been updated to assert the new behavior instead.
+
+These tests don't call the LLM (no API in CI); they assert the
+prompt's SHAPE so the next time someone "tightens" it back, the test
+catches it.
 """
 
 from __future__ import annotations
@@ -16,101 +23,113 @@ from ovp_pipeline.auto_evergreen_extractor import EvergreenExtractor
 
 
 class TestPromptLiberation:
-    """The new prompt must:
+    """Properties carried forward from PR-A's original liberation:
 
-      * NOT cap concept count at 3-5
-      * NOT tell the LLM "return empty array if information is insufficient"
-      * Demand declarative-claim titles, not noun phrases
-      * Require ``unit_type`` classification (fact/procedure/learning/concept)
+    * No hardcoded "extract 3-5" cap
+    * No "return [] if information insufficient" — replaced by BL-058's
+      explicit ``skip_reason`` mechanism (still permits empty output,
+      but as a deliberate signal, not an escape hatch)
+    * Title must be a declarative claim, not a noun phrase
+    * Output must carry a ``unit_type`` classification
     """
 
     def test_no_hard_concept_cap(self):
         prompt = EvergreenExtractor.SYSTEM_PROMPT
-        # The legacy cap phrase that was responsible for OVP undercounting:
         assert "提取3-5个" not in prompt
         assert "提取 3-5 个" not in prompt
         assert "最多5个概念" not in prompt
         assert "最多 5 个概念" not in prompt
 
-    def test_no_escape_hatch_for_insufficient_information(self):
-        """The single most damaging line: it gave the LLM permission to
-        return ``[]`` whenever it judged the article as 'marketing' or
-        'not enough information'.  In the 8-article audit this fired on
-        Polymarket / 缓存机制 / 457 PR / etc.
-        """
+    def test_no_v1_escape_hatch(self):
+        """v1's worst line: "信息不足以形成稳定知识，请返回空数组" — gave
+        the LLM a permissive escape hatch.  BL-058 v2 replaces this with
+        a structured ``skip_reason`` field that records WHY the model
+        chose to return nothing, so empty output becomes auditable
+        rather than silent."""
         prompt = EvergreenExtractor.SYSTEM_PROMPT
-        assert "信息不足以形成稳定知识，请返回空数组" not in prompt
-        assert "信息不足以形成稳定知识,请返回空数组" not in prompt
-        assert "请返回空数组" not in prompt
+        assert "信息不足以形成稳定知识" not in prompt
+        # v2 still permits empty output, but as a deliberate signal:
+        assert "skip_reason" in prompt
 
     def test_demands_declarative_claim_titles(self):
-        """NM's killer feature is that memory titles are claims you can
-        read and learn from.  OVP's old prompt produced noun phrases like
-        ``intention-layer``.  The new prompt must demand declarative
-        sentences.
-        """
         prompt = EvergreenExtractor.SYSTEM_PROMPT
-        assert "陈述句" in prompt or "declarative" in prompt.lower()
-        assert "断言性" in prompt or "claim" in prompt.lower()
+        # v2 says: "title 是观点,不是分类" with concrete bad/good examples.
+        assert "陈述句" in prompt or "claim" in prompt.lower()
+        # The "title 是观点" rule is the BL-058-specific phrasing.
+        assert "Title 是观点" in prompt or "title 是观点" in prompt.lower()
 
     def test_requires_unit_type_classification(self):
-        """``unit_type`` is the structured taxonomy NM uses
-        (fact/procedure/learning).  Output without unit_type loses the
-        clarity that makes NM memories searchable by 'all procedures
-        about caching' etc.
-        """
         prompt = EvergreenExtractor.SYSTEM_PROMPT
         assert "unit_type" in prompt
-        for value in ("fact", "procedure", "learning"):
-            assert value in prompt, f"{value!r} missing from unit_type taxonomy"
-
-    def test_handles_long_primer_articles(self):
-        """The Aman Context Engineering primer (95KB / 12,783 words)
-        produced 0 evergreens under the old prompt.  The new prompt must
-        explicitly demand atomic-unit extraction per section.
-        """
-        prompt = EvergreenExtractor.SYSTEM_PROMPT
-        # Some signal that long articles get more units, not the same 3-5.
-        long_signals = ("长文", "primer", "综述", "15-30", "按章节")
-        assert any(sig in prompt for sig in long_signals), (
-            "Prompt no longer signals to handle long articles with more units"
-        )
-
-    def test_handles_chinese_technical_articles(self):
-        """OVP's 缓存机制 / 457 PR / Polymarket articles all got 0
-        evergreens.  These are Chinese technical articles.  The prompt
-        must explicitly state these get the same granularity as English.
-        """
-        prompt = EvergreenExtractor.SYSTEM_PROMPT
-        chinese_signals = ("中文技术", "中文文章", "完全按英文同等粒度")
-        assert any(sig in prompt for sig in chinese_signals), (
-            "Prompt no longer instructs to give Chinese technical articles "
-            "the same atomic-unit density as English"
-        )
+        # v2 expanded the taxonomy from 4 to 10 — verify the new
+        # categories are present.
+        for value in (
+            "fact", "method", "procedure", "tradeoff", "failure_mode",
+            "counterexample", "case_detail", "learning", "decision", "quote",
+        ):
+            assert value in prompt, f"{value!r} missing from v2 unit_type taxonomy"
 
 
 class TestPromptStillContractsCorrectly:
-    """The new prompt must still preserve the structural contracts
-    downstream code depends on (JSON shape, kind taxonomy, slug rules).
+    """The v2 prompt must still preserve the structural contracts
+    downstream code depends on (JSON shape, slug rules), even though
+    the OUTER schema changed from a bare list to a wrapped object.
     """
 
-    def test_still_demands_json_array_output(self):
+    def test_v2_output_is_wrapped_json(self):
+        """v1 returned a bare JSON array; v2 returns
+        ``{units: [...], skip_reason, source_value_summary}``.  This
+        test pins the wrapper shape so a future "simplification" back
+        to a bare list fails fast."""
         prompt = EvergreenExtractor.SYSTEM_PROMPT
         assert "JSON" in prompt
-        assert "[" in prompt and "]" in prompt
+        # Wrapper keys
+        assert '"units"' in prompt
+        assert '"skip_reason"' in prompt
+        assert '"source_value_summary"' in prompt
 
-    def test_still_lists_entity_type_taxonomy(self):
+    def test_demands_source_anchor_per_unit(self):
+        """v2 hard rule #9: each unit must carry a verbatim
+        ``source_anchor`` from the source body.  Mechanical fidelity
+        check — without this field, future ``ovp-fidelity-replay``
+        cannot grep evergreen claims back to their source."""
         prompt = EvergreenExtractor.SYSTEM_PROMPT
-        # The 10 entity_type values that downstream object_kinds.py expects:
-        for kind in ("concept", "person", "company", "tool", "project",
-                     "paper", "event", "framework", "method"):
-            assert kind in prompt, f"entity_type kind {kind!r} dropped"
+        assert "source_anchor" in prompt
+        assert "逐字" in prompt or "verbatim" in prompt.lower()
 
-    def test_still_demands_kebab_case_slugs(self):
+    def test_demands_specifics_classification(self):
+        """v2 each unit lists which kinds of specifics it preserved.
+        The categories matter — they're how aggregate metrics roll up
+        ("which unit_types lose which kinds of specifics most often")."""
+        prompt = EvergreenExtractor.SYSTEM_PROMPT
+        assert "specifics" in prompt
+        for category in ("numbers", "names", "tradeoffs", "examples", "edge_cases"):
+            assert category in prompt, f"specifics category {category!r} missing"
+
+    def test_caps_volume_at_eight(self):
+        """v2 explicit cap.  v1's "抽得多比抽得少好" + 5-30 floors caused
+        the abstraction inflation pattern documented in the 2026-05-05
+        fidelity audit.  BL-058 inverts this: 0-8, 宁缺勿滥."""
+        prompt = EvergreenExtractor.SYSTEM_PROMPT
+        # Numeric cap is in the rules
+        assert "0-8" in prompt
+        # The v1 volume-bias slogan must NOT come back.
+        assert "抽得多比抽得少好" not in prompt
+        assert "抽得多" not in prompt or "抽得多" in "宁可少抽,不要凑数".lower()  # phrasing OK
+
+    def test_demands_kebab_case_slugs(self):
         prompt = EvergreenExtractor.SYSTEM_PROMPT
         assert "kebab-case" in prompt
 
-    def test_still_demands_related_concepts(self):
+    def test_related_concepts_optional_in_v2(self):
+        """v1 forced ``≥ 3`` related_concepts.  v2 explicitly allows
+        ``0-5``.  This was an OVP-specific change driven by chris's
+        observation that v1 evergreens with 3-link minimums often
+        contained unrelated 凑数 wikilinks."""
         prompt = EvergreenExtractor.SYSTEM_PROMPT
         assert "related_concepts" in prompt
-        assert "至少 3" in prompt or "至少3" in prompt
+        # v1's "至少 3" requirement must be gone
+        assert "至少 3" not in prompt
+        assert "至少3" not in prompt
+        # v2's 0-5 envelope must be present
+        assert "0-5" in prompt

--- a/tests/test_no_silent_imports.py
+++ b/tests/test_no_silent_imports.py
@@ -30,7 +30,7 @@ def repo_root() -> Path:
 # Most of these are optional ``from dotenv import load_dotenv`` style
 # fallbacks where dotenv isn't a hard dependency.
 LEGACY_SILENT_IMPORTS = {
-    ("auto_evergreen_extractor.py", 163),      # dotenv optional (BL-054 added helpers above it)
+    ("auto_evergreen_extractor.py", 183),      # dotenv optional (BL-058 hoisted object_kinds import, line shifted)
     ("auto_article_processor.py", 113),         # dotenv optional
     ("auto_github_processor.py", 99),           # dotenv optional (BL-066 rewrote module, line shifted)
     ("auto_moc_updater.py", 51),                # dotenv optional


### PR DESCRIPTION
## Summary

Replaces the v1 absorb \`SYSTEM_PROMPT\` with a v2 \`CandidateUnit\` prompt (11 hard rules, wrapped JSON output) and adds a one-shot \`ovp-tag-legacy-evergreens\` migration to mark all existing 7000 evergreens as \`legacy_unverified=true + extraction_prompt_version=v1\`.

## Why

The v1 prompt forced every output through 定义 / 详细解释 / 为什么重要 sections, used "抽得多比抽得少好" volume bias (5-30+ units per source, no skip permission), and had no specificity guard. The 50-sample fidelity audit (2026-05-05) scored most v1 evergreens \`faithful_generic\` — claims were in source, but specifics were stripped. The 6-source A/B experiment confirmed v2 produces dramatically more specific units at half the volume AND correctly returns \`units=[]\` on a 13-character github stub instead of fabricating 3 units. Per chris: "真的好多了" — direct cutover.

## What changes

- **New v2 \`SYSTEM_PROMPT\`** with 11 hard rules. Output is wrapped:
    \`\`\`json
    {
      "source_value_summary": "...",
      "units": [
        {
          "slug": "kebab-case",
          "title": "complete claim sentence",
          "unit_type": "fact|method|procedure|tradeoff|failure_mode|counterexample|case_detail|learning|decision|quote",
          "epistemic_role": "fact|interpretation|method|quote|attributed_claim",
          "content": "free-form markdown",
          "source_anchor": "verbatim from source",
          "specifics": ["numbers","names","tradeoffs","examples","edge_cases"],
          "related_concepts": ["0-5 entries, 宁缺勿滥"]
        }
      ],
      "skip_reason": "..."
    }
    \`\`\`
- **New \`_parse_v2_response\`** handles wrapped JSON + skip_reason + bare-list rejection; logs \`absorb_skipped_source\` (v2 deliberate skip) and \`absorb_v2_parse_error\` (LLM schema drift) distinctly.
- **\`_unit_to_concept\` converter** keeps v2 units feeding the legacy concept-dict interface so we don't ripple through candidate registry / promotion / dedup.
- **Rewrote \`create_evergreen_note\`**: no forced sections, conditional \`## Related\` block, source-anchor blockquote at bottom, 6 new frontmatter fields (\`extraction_prompt_version\`, \`unit_type\`, \`epistemic_role\`, \`absorbed_at\`, \`source_anchor\`, \`specifics\`).
- **Dropped \`evergreen_low_link\` audit** — v2 allows 0-5 related_concepts, so missing links is no longer a regression signal.
- **\`ovp-tag-legacy-evergreens\`** — idempotent + reversible migration script. Writes manifest to \`60-Logs/legacy-tag/<run-id>/\`.

## What's NOT in this PR (deliberate scope cuts)

- **SQLite schema migration** on \`objects\` table. Frontmatter is queryable via existing \`pages_index.frontmatter_json\` (\`json_extract\`); real columns deferred to BL-058b when a consumer needs indexed lookup.
- **Reader UI badges** for unit_type / legacy markers — BL-058b.
- **Crystal scoring weight** on \`legacy_unverified\` — BL-058c (needs calibration data first).
- **Re-running v1 evergreens** through v2 prompt — BL-068, ranked by high-value subset.

## Tests

- **New \`tests/test_absorb_v2.py\`** — 20 cases:
  - Parser: well-formed wrapper, skip_reason path, fenced JSON, bare-list rejection, invalid JSON, missing-title drop
  - \`_unit_to_concept\`: method/procedure → \`method\` entity_type, everything else → \`concept\`
  - Body template: no v1 sections, conditional \`## Related\`, source_anchor render/omit
  - Legacy tagging: dry-run, write adds 3 markers, idempotent, skips v2, \`--untag\` reverses, frontmatter-less files skipped, manifest written
- **Rewrote \`test_evergreen_prompt_liberation.py\`** for v2 contract (wrapper output / source_anchor / specifics / 0-8 cap / 0-5 related). Original PR-A liberations (no 3-5 cap, no escape hatch) still pinned.
- **Removed two tests** in \`test_evergreen_extractor_retrieval.py\` for the dropped \`evergreen_low_link\` event.

**Full suite: 2111/2111 pass** (was 2088 before BL-058). Pre-existing arch-fitness file-size guard on \`unified_pipeline_enhanced.py\` is unrelated.

## Test plan

- [x] \`pytest tests/test_absorb_v2.py\` — 20/20
- [x] \`pytest tests/test_evergreen_prompt_liberation.py\` — 12/12
- [x] \`pytest tests/test_evergreen_extractor_retrieval.py\` — 4/4
- [x] Full suite (excluding pre-existing arch-fitness failure) — 2111/2111
- [ ] After merge: run \`ovp-tag-legacy-evergreens --write\` once (~6 min for 7000 files)
- [ ] After merge: monitor first \`ovp-pipeline --incremental\` for \`absorb_skipped_source\` rate, \`absorb_v2_parse_error\` rate, and a random 5 new evergreens for manual fidelity review
- [ ] Week 1: aggregate \`specifics\` distribution from new evergreens to verify abstraction inflation has dropped

## Rollout

\`\`\`
Day 0   Merge BL-058 (this PR)
Day 0+5 Run ovp-tag-legacy-evergreens --write once.
        ~6 min, 7000 files tagged. Manifest at 60-Logs/legacy-tag/<run-id>/.
Day 1   Next ovp-pipeline --incremental uses v2 prompt.
        New evergreens carry v2 schema; old evergreens carry legacy markers.
Week 1  Watch:
        - skip_reason rate (expecting 10-30% on incremental sources)
        - new evergreen specifics distribution (proxy for "is v2 actually
          preserving specifics?")
        - any LLM JSON parse failures (the v2 schema is more complex)
Week 2+ If quality holds, plan BL-068 (re-extraction of high-value v1 evergreens).
        If parse failure rate is high, iterate on prompt — schema unchanged.
\`\`\`

## Related

- Design doc: \`docs/plans/2026-05-05-bl-058-absorb-v2-candidate-units.md\` (in this PR)
- A/B experiment outputs: \`~/Documents/ovp-vault/60-Logs/prompt-ab/v1/\` (vault-local)
- Discussion thread that produced the v2 prompt: feedback memory \`feedback_no_slop.md\` + \`feedback_epistemic_role.md\` + \`feedback_calibration_discipline.md\`
- BL-066 (#156, merged): GitHub enrichment, prerequisite for v2 to receive specific source bodies on github inputs.