### PR TITLE
fix(clippings): recursive scan picks up Twitter subdir + collision dedupe

### DIFF
--- a/src/ovp_pipeline/clippings_processor.py
+++ b/src/ovp_pipeline/clippings_processor.py
@@ -246,16 +246,44 @@ class ClippingsProcessor:
         return filename.strip('-_')
 
     def scan_clippings(self) -> list[Path]:
-        """扫描Clippings目录"""
+        """Recursively scan ``Clippings/`` for ``.md`` files.
+
+        Pre-2026-05 the scan used non-recursive ``glob("*.md")`` which
+        silently ignored common subdirectory layouts such as
+        ``Clippings/Twitter/*.md`` (Pinboard's Twitter clip default
+        target).  18 Twitter clips sat unprocessed for weeks before
+        the gap was noticed during the BL-058 rollout.  ``rglob``
+        picks them up; the per-source-type signal (it came from a
+        Twitter subdir) is **not** preserved at this layer because
+        the source URL in frontmatter (``x.com/...``) is the
+        authoritative type signal — see ``source_authority.py``.
+        """
         if not self.clippings_dir.exists():
             return []
 
-        files = []
-        for f in self.clippings_dir.glob("*.md"):
-            if f.is_file():
-                files.append(f)
+        files: list[Path] = []
+        for f in self.clippings_dir.rglob("*.md"):
+            if not f.is_file():
+                continue
+            files.append(f)
 
         return sorted(files)
+
+    def _target_already_exists(self, new_name: str) -> bool:
+        """Avoid silently overwriting an existing file in 01-Raw or
+        03-Processed (any month).  Same basename across multiple
+        intake runs almost always means "user re-clipped the same
+        article" — we don't want to clobber the older copy without
+        explicit intent.
+        """
+        if (self.raw_dir / new_name).exists():
+            return True
+        processed = self.layout.processed_dir
+        if processed.exists():
+            for month in processed.iterdir():
+                if month.is_dir() and (month / new_name).exists():
+                    return True
+        return False
 
     def obsidian_move(self, source: Path, dest_dir: Path, new_name: str | None = None) -> bool:
         """使用obsidian move迁移文件（非mv）"""
@@ -324,6 +352,26 @@ class ClippingsProcessor:
             new_name = clipping_raw_name(file_path, self.sanitize_filename)
 
             file_info["new_name"] = new_name
+
+            # Dedupe guard: if the same basename already lives in
+            # 01-Raw (pending intake) or any 03-Processed/<YYYY-MM>/
+            # subdir, skip rather than silently overwrite.  This
+            # most commonly fires when a user re-clips the same
+            # article — we want the user to see the conflict, not
+            # lose the older copy.
+            if self._target_already_exists(new_name):
+                file_info["status"] = "skipped_collision"
+                file_info["reason"] = (
+                    f"{new_name} already present under 50-Inbox/01-Raw "
+                    f"or 50-Inbox/03-Processed; not overwriting"
+                )
+                results["skipped"] += 1
+                results["files"].append(file_info)
+                self.logger.log("clipping_collision_skipped", {
+                    "original": str(file_path.name),
+                    "new_name": new_name,
+                })
+                continue
 
             if dry_run:
                 file_info["status"] = "dry_run"

--- a/tests/test_clippings_recursive_scan.py
+++ b/tests/test_clippings_recursive_scan.py
@@ -1,0 +1,128 @@
+"""Tests for the recursive Clippings scan + collision dedupe.
+
+Pre-2026-05 the scan was non-recursive ``glob("*.md")`` and silently
+ignored ``Clippings/Twitter/*.md`` (Pinboard's Twitter clip target),
+leaving 18 Twitter clips unprocessed for weeks.  These tests pin the
+fix so the bug can't reappear.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ovp_pipeline.clippings_processor import ClippingsProcessor
+from ovp_pipeline.unified_pipeline_enhanced import (
+    PipelineLogger,
+    TransactionManager,
+)
+
+
+def _make_processor(temp_vault: Path) -> ClippingsProcessor:
+    logger = PipelineLogger(temp_vault / "60-Logs" / "pipeline.jsonl")
+    txn_dir = temp_vault / "60-Logs" / "transactions"
+    txn_dir.mkdir(parents=True, exist_ok=True)
+    txn = TransactionManager(txn_dir)
+    return ClippingsProcessor(temp_vault, logger, txn)
+
+
+class TestRecursiveScan:
+    def test_picks_up_twitter_subdirectory(self, temp_vault):
+        """The pre-fix non-recursive ``glob("*.md")`` left Twitter clips
+        in the unprocessed limbo this test is the regression guard for."""
+        clippings = temp_vault / "Clippings"
+        clippings.mkdir(parents=True, exist_ok=True)
+        twitter = clippings / "Twitter"
+        twitter.mkdir()
+
+        # Top-level clip
+        (clippings / "top_level.md").write_text("---\ntitle: top\n---\nbody\n", encoding="utf-8")
+        # Twitter subdir clips
+        (twitter / "BTCdayu - AI investing.md").write_text(
+            "---\ntitle: AI investing\nsource: https://x.com/BTCdayu/status/123\n---\nbody\n",
+            encoding="utf-8",
+        )
+        (twitter / "@HiTw93 - GEO.md").write_text(
+            "---\ntitle: GEO\nsource: https://x.com/HiTw93/status/456\n---\nbody\n",
+            encoding="utf-8",
+        )
+
+        processor = _make_processor(temp_vault)
+        found = processor.scan_clippings()
+
+        names = {p.name for p in found}
+        assert "top_level.md" in names
+        assert "BTCdayu - AI investing.md" in names
+        assert "@HiTw93 - GEO.md" in names
+        assert len(found) == 3
+
+    def test_empty_clippings_dir_returns_empty(self, temp_vault):
+        # No Clippings dir at all
+        if (temp_vault / "Clippings").exists():
+            import shutil
+            shutil.rmtree(temp_vault / "Clippings")
+        processor = _make_processor(temp_vault)
+        assert processor.scan_clippings() == []
+
+
+class TestCollisionDedupe:
+    def test_skips_when_target_already_in_raw(self, temp_vault, monkeypatch):
+        clippings = temp_vault / "Clippings"
+        clippings.mkdir(parents=True, exist_ok=True)
+        clip = clippings / "duplicate_article.md"
+        clip.write_text(
+            "---\ntitle: dup\nsource: https://example.com/a\n---\nbody\n",
+            encoding="utf-8",
+        )
+        # Pre-existing target in 01-Raw with the SAME sanitized name
+        raw_dir = temp_vault / "50-Inbox" / "01-Raw"
+        raw_dir.mkdir(parents=True, exist_ok=True)
+        # ClippingsProcessor sanitizes the name and the date prefix
+        # might shift between runs, so we plant whatever
+        # ``clipping_raw_name`` would produce.
+        from ovp_pipeline.clippings_processor import clipping_raw_name
+        processor = _make_processor(temp_vault)
+        target_name = clipping_raw_name(clip, processor.sanitize_filename)
+        (raw_dir / target_name).write_text("# pre-existing copy\n", encoding="utf-8")
+
+        # Mock obsidian_move so we can detect whether the processor
+        # tried to overwrite (it shouldn't).
+        called = {"count": 0}
+        def fake_move(*_args, **_kwargs):
+            called["count"] += 1
+            return True
+        monkeypatch.setattr(processor, "obsidian_move", fake_move)
+
+        result = processor.process_clippings(dry_run=False)
+
+        assert result["scanned"] == 1
+        assert result["skipped"] == 1
+        assert result["migrated"] == 0
+        # obsidian_move must NOT have been invoked for the colliding file.
+        assert called["count"] == 0
+        # Pre-existing target file is still there, untouched.
+        assert (raw_dir / target_name).read_text(encoding="utf-8") == "# pre-existing copy\n"
+
+    def test_skips_when_target_already_in_processed_month(self, temp_vault, monkeypatch):
+        clippings = temp_vault / "Clippings"
+        clippings.mkdir(parents=True, exist_ok=True)
+        clip = clippings / "already_processed.md"
+        clip.write_text(
+            "---\ntitle: x\nsource: https://example.com/x\n---\nbody\n",
+            encoding="utf-8",
+        )
+        # Pre-existing target in a 03-Processed month folder
+        processed_month = temp_vault / "50-Inbox" / "03-Processed" / "2026-04"
+        processed_month.mkdir(parents=True, exist_ok=True)
+        from ovp_pipeline.clippings_processor import clipping_raw_name
+        processor = _make_processor(temp_vault)
+        target_name = clipping_raw_name(clip, processor.sanitize_filename)
+        (processed_month / target_name).write_text("# already absorbed\n", encoding="utf-8")
+
+        called = {"count": 0}
+        monkeypatch.setattr(processor, "obsidian_move", lambda *a, **k: (called.update({"count": called["count"] + 1}), True)[1])
+
+        result = processor.process_clippings(dry_run=False)
+        assert result["skipped"] == 1
+        assert called["count"] == 0


### PR DESCRIPTION
## Summary

\`ClippingsProcessor.scan_clippings\` used non-recursive \`glob(\"*.md\")\` which silently skipped \`Clippings/Twitter/*.md\` — Pinboard's default Twitter clip target.  18 Twitter clips sat unprocessed for weeks before BL-058 surfaced the gap.

Switches to \`rglob\` and adds a collision-dedupe guard so the user doesn't silently lose a re-clipped article.

## What changes

- \`scan_clippings\` → \`rglob(\"*.md\")\`. Per-source-type (Twitter / Substack / etc.) is **not** preserved at this layer — the source URL in frontmatter is the authoritative type signal for \`source_authority.py\`.
- New \`_target_already_exists(new_name)\` check: if same sanitized basename already lives under \`50-Inbox/01-Raw/\` or any \`50-Inbox/03-Processed/<YYYY-MM>/\` subdir, the migration is skipped with \`status=skipped_collision\` and a \`clipping_collision_skipped\` audit event is logged. No silent overwrite.

## Tests (4 new cases)

- Twitter subdir IS picked up (regression guard for the original bug)
- Empty/missing Clippings dir returns []
- Collision in 01-Raw skips, \`obsidian_move\` not called, original target untouched
- Collision in 03-Processed/<month>/ also skips

## Test plan

- [x] \`pytest tests/test_clippings_recursive_scan.py\` — 4/4
- [ ] After merge: run \`ovp-pipeline --incremental --vault-dir ~/Documents/ovp-vault\` to process the 18 unprocessed Twitter clips that have been sitting in \`Clippings/Twitter/\` for weeks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clipping discovery now recursively scans all subdirectories within the clippings folder to find markdown files, including nested directories.
  * Added collision detection to prevent duplicate processing: when a clipping's target filename already exists, processing is skipped to avoid overwriting existing files.

* **Tests**
  * Added regression test suite covering recursive discovery and duplicate collision detection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->