### PR TITLE
fix(promote): preserve v2 schema on candidate→evergreen (BL-058a)

### DIFF
--- a/src/ovp_pipeline/promote_candidates.py
+++ b/src/ovp_pipeline/promote_candidates.py
@@ -76,7 +76,27 @@ def evergreen_file_path(vault_dir: Path, slug: str) -> Path:
 
 
 def write_evergreen_file(vault_dir: Path, entry: ConceptEntry, dry_run: bool = True) -> Path | None:
-    """Write a formal Evergreen file for an active concept."""
+    """Write a formal Evergreen file for an active concept.
+
+    BL-058a (2026-05-05): when the candidate file carries v2
+    frontmatter (``extraction_prompt_version: v2``), we preserve every
+    field rather than rewriting frontmatter from scratch.  The v1 path
+    that rebuilt frontmatter stripped ``unit_type`` / ``source_anchor``
+    / ``specifics`` / ``epistemic_role`` because it didn't know they
+    existed — that bug shipped in the BL-058 PR and produced a batch of
+    "fake-v1" evergreens (v2 LLM ran but written with v1 schema) that
+    BL-058a now prevents.
+
+    Three concerns the candidate→evergreen handoff has to handle:
+
+    1. ``type:`` field flips ``candidate`` → ``evergreen``.
+    2. ``review_state`` field is dropped (only meaningful on candidates).
+    3. ``tags:`` swaps ``[candidate, ...]`` → ``[..., evergreen]``.
+
+    We also rewrite the trailing footer from
+    ``*Candidate concept - pending review*`` to the standard
+    ``*Promoted from candidate on YYYY-MM-DD*``.
+    """
     evergreen_path = evergreen_file_path(vault_dir, entry.slug)
     candidate_path = candidate_file_path(vault_dir, entry.slug)
 
@@ -86,44 +106,21 @@ def write_evergreen_file(vault_dir: Path, entry: ConceptEntry, dry_run: bool = T
 
     evergreen_path.parent.mkdir(parents=True, exist_ok=True)
 
-    aliases = list(dict.fromkeys([alias for alias in entry.aliases if alias]))
-
-    body = f"""# {entry.title}
-
-> **定义**: {entry.definition}
-"""
+    candidate_text: str | None = None
     if candidate_path.exists():
         candidate_text = candidate_path.read_text(encoding="utf-8")
-        if candidate_text.startswith("---"):
-            parts = candidate_text.split("---", 2)
-            if len(parts) >= 3:
-                body = parts[2].strip()
-        body = body.replace("*Candidate concept - pending review*", "").strip()
-        if not body.startswith("# "):
-            body = f"# {entry.title}\n\n{body}".strip()
 
-    from .object_kinds import CORE_OBJECT_KINDS, KIND_CONCEPT, normalize_kind
-
-    normalized = normalize_kind(entry.kind) if entry.kind else KIND_CONCEPT
-    entity_type = normalized if normalized in CORE_OBJECT_KINDS else KIND_CONCEPT
-
-    frontmatter = f'''---
-note_id: {entry.slug}
-title: "{entry.title}"
-type: evergreen
-entity_type: {entity_type}
-date: {datetime.now().strftime("%Y-%m-%d")}
-tags: [{entry.area}, evergreen]
-aliases: [{", ".join(f'"{a}"' for a in aliases)}]
-area: {entry.area}
----
-
-{body}
-
----
-
-*Promoted from candidate on {datetime.now().strftime("%Y-%m-%d")}*
-'''
+    # Detect v2 candidate by frontmatter marker.  When present, run the
+    # in-place rewrite path that preserves every v2 field.
+    if (
+        candidate_text
+        and "extraction_prompt_version: v2" in candidate_text[:2048]
+    ):
+        content = _candidate_to_evergreen_v2(candidate_text, entry)
+    else:
+        # Pre-BL-058 candidates use the v1 template.  Keep the legacy
+        # rebuild path so historical promotions stay byte-stable.
+        content = _candidate_to_evergreen_v1(candidate_text, entry)
 
     from .workspace_promotion import WRITE_MODE_PROMOTION, enforce_zone_write
 
@@ -139,9 +136,128 @@ area: {entry.area}
         # callers that forgot to pass mode='promotion'.
         raise
 
-    evergreen_path.write_text(frontmatter, encoding="utf-8")
+    evergreen_path.write_text(content, encoding="utf-8")
     print(f"  Created: {evergreen_path}")
     return evergreen_path
+
+
+def _candidate_to_evergreen_v1(candidate_text: str | None, entry: ConceptEntry) -> str:
+    """Pre-BL-058 path: rebuild frontmatter from registry entry, body
+    is taken from the candidate file body if available.  Same byte
+    output as the v1 implementation."""
+    from .object_kinds import CORE_OBJECT_KINDS, KIND_CONCEPT, normalize_kind
+
+    aliases = list(dict.fromkeys([alias for alias in entry.aliases if alias]))
+
+    body = f"""# {entry.title}
+
+> **定义**: {entry.definition}
+"""
+    if candidate_text:
+        if candidate_text.startswith("---"):
+            parts = candidate_text.split("---", 2)
+            if len(parts) >= 3:
+                body = parts[2].strip()
+        body = body.replace("*Candidate concept - pending review*", "").strip()
+        if not body.startswith("# "):
+            body = f"# {entry.title}\n\n{body}".strip()
+
+    normalized = normalize_kind(entry.kind) if entry.kind else KIND_CONCEPT
+    entity_type = normalized if normalized in CORE_OBJECT_KINDS else KIND_CONCEPT
+
+    aliases_yaml = "[" + ", ".join(f'"{a}"' for a in aliases) + "]"
+    return f'''---
+note_id: {entry.slug}
+title: "{entry.title}"
+type: evergreen
+entity_type: {entity_type}
+date: {datetime.now().strftime("%Y-%m-%d")}
+tags: [{entry.area}, evergreen]
+aliases: {aliases_yaml}
+area: {entry.area}
+---
+
+{body}
+
+---
+
+*Promoted from candidate on {datetime.now().strftime("%Y-%m-%d")}*
+'''
+
+
+# Frontmatter lines that exist on candidates but NOT on evergreens.
+# We strip these on the candidate→evergreen handoff.
+_CANDIDATE_ONLY_FRONTMATTER_KEYS = ("review_state",)
+
+
+def _candidate_to_evergreen_v2(candidate_text: str, entry: ConceptEntry) -> str:
+    """BL-058a path: in-place rewrite that preserves every v2 field.
+
+    Three transformations:
+      1. ``type: candidate`` → ``type: evergreen``
+      2. Drop ``review_state:`` line entirely (only meaningful on candidates)
+      3. ``tags: [candidate, <area>]`` → ``tags: [<area>, evergreen]``
+
+    Body: replace the candidate footer with the evergreen footer.
+    Everything else (unit_type, epistemic_role, source_anchor,
+    specifics, related_concepts, absorbed_at, the body content with
+    ## Related and source-anchor block) is preserved verbatim.
+
+    We rewrite the YAML by line-level regex rather than full parse to
+    keep this dependency-free and to preserve any field ordering /
+    comments the candidate file already had.
+    """
+    parts = candidate_text.split("---", 2)
+    if len(parts) < 3:
+        # Defensive fallback — candidate has no closing fence (shouldn't
+        # happen for files _render_v2_candidate produced).  Pass the
+        # whole text through with the body footer rewrite.
+        body_only = candidate_text.replace(
+            "*Candidate concept - pending review*",
+            f"*Promoted from candidate on {datetime.now().strftime('%Y-%m-%d')}*",
+        )
+        return body_only
+
+    fm_block = parts[1]
+    body = parts[2]
+
+    # --- frontmatter rewrite ---
+    new_fm_lines: list[str] = []
+    for raw_line in fm_block.split("\n"):
+        line = raw_line.rstrip("\r")
+        # type field flip
+        if re.match(r"^\s*type\s*:\s*candidate\s*$", line):
+            new_fm_lines.append("type: evergreen")
+            continue
+        # tags rewrite
+        tags_match = re.match(r"^\s*tags\s*:\s*\[(.*)\]\s*$", line)
+        if tags_match:
+            raw_tags = [t.strip() for t in tags_match.group(1).split(",") if t.strip()]
+            kept = [t for t in raw_tags if t.strip().strip('"\'') != "candidate"]
+            if "evergreen" not in {t.strip('"\'') for t in kept}:
+                kept.append("evergreen")
+            new_fm_lines.append("tags: [" + ", ".join(kept) + "]")
+            continue
+        # drop candidate-only keys
+        drop = False
+        for key in _CANDIDATE_ONLY_FRONTMATTER_KEYS:
+            if re.match(rf"^\s*{re.escape(key)}\s*:", line):
+                drop = True
+                break
+        if drop:
+            continue
+        new_fm_lines.append(line)
+
+    new_fm = "\n".join(new_fm_lines)
+
+    # --- body footer rewrite ---
+    today = datetime.now().strftime("%Y-%m-%d")
+    new_body = body.replace(
+        "*Candidate concept - pending review*",
+        f"*Promoted from candidate on {today}*",
+    )
+
+    return f"---{new_fm}---{new_body}"
 
 
 def write_candidate_file(
@@ -152,7 +268,22 @@ def write_candidate_file(
     concept_data: dict | None = None,
     source_file: Path | None = None,
 ) -> Path | None:
-    """Write a candidate file in the _Candidates directory."""
+    """Write a candidate file in the _Candidates directory.
+
+    BL-058a (2026-05-05): when ``concept_data`` carries the v2
+    extraction fields (``unit_type``, ``epistemic_role``,
+    ``source_anchor``, ``specifics``), we render the candidate with v2
+    frontmatter + body so promotion to evergreen preserves them.
+
+    Detection rule for "this is a v2 concept": ``unit_type`` set to one
+    of the v2 vocab values, OR ``source_anchor`` non-empty, OR
+    ``specifics`` non-empty.  We don't rely on a single sentinel field
+    because v2 LLMs occasionally drop one or two optional fields.
+
+    Pre-BL-058a code path (v1 frontmatter + 定义/详细解释/为什么重要
+    sections) is kept as the fallback so legacy callers that don't
+    pass v2 fields keep working unchanged.
+    """
     candidates_dir = vault_dir / CANDIDATES_DIR
     candidate_path = candidate_file_path(vault_dir, entry.slug)
 
@@ -162,35 +293,203 @@ def write_candidate_file(
 
     candidates_dir.mkdir(parents=True, exist_ok=True)
 
-    aliases = list(dict.fromkeys([alias for alias in entry.aliases if alias]))
-    explanation = str((concept_data or {}).get("explanation", "")).strip()
-    importance = str((concept_data or {}).get("importance", "")).strip()
-    raw_related = (concept_data or {}).get("related_concepts", []) or []
-    related = []
-    for item in raw_related:
+    if _looks_like_v2_concept(concept_data):
+        content = _render_v2_candidate(entry, concept_data, source_file)
+    else:
+        content = _render_v1_candidate(entry, concept_data, source_file)
+
+    candidate_path.write_text(content, encoding="utf-8")
+    print(f"  Created candidate: {candidate_path}")
+    return candidate_path
+
+
+# v2 unit_type vocab — keep in sync with auto_evergreen_extractor's
+# SYSTEM_PROMPT.  Used to detect v2 candidate data shape.
+_V2_UNIT_TYPES = frozenset({
+    "fact", "method", "procedure", "tradeoff", "failure_mode",
+    "counterexample", "case_detail", "learning", "decision", "quote",
+})
+
+
+def _looks_like_v2_concept(concept_data: dict | None) -> bool:
+    """Return True if ``concept_data`` carries v2 extraction fields.
+
+    We accept the concept as v2 if any one of the three v2-only
+    discriminators is present and non-trivial.  Pre-v2 callers don't
+    set any of these.
+    """
+    if not concept_data:
+        return False
+    unit_type = str(concept_data.get("unit_type") or "").strip().lower()
+    if unit_type in _V2_UNIT_TYPES:
+        return True
+    if str(concept_data.get("source_anchor") or "").strip():
+        return True
+    specifics = concept_data.get("specifics")
+    if isinstance(specifics, list) and specifics:
+        return True
+    return False
+
+
+def _yaml_quote(value: str) -> str:
+    """Single-line YAML scalar with double-quote escape for safety.
+
+    Mirror of ``auto_evergreen_extractor._yaml_escape`` — duplicated to
+    keep ``promote_candidates`` free of cross-module imports.
+    """
+    if value is None:
+        return '""'
+    s = str(value)
+    if not s:
+        return '""'
+    if any(c in s for c in ':#"\'\\\n[]{}'):
+        escaped = s.replace("\\", "\\\\").replace('"', '\\"')
+        return f'"{escaped}"'
+    return s
+
+
+def _normalize_related(raw: object, exclude_slug: str) -> list[str]:
+    if not isinstance(raw, list):
+        return []
+    out: list[str] = []
+    for item in raw:
         normalized = canonicalize_note_id(str(item))
-        if normalized and normalized != entry.slug and normalized not in related:
-            related.append(normalized)
+        if normalized and normalized != exclude_slug and normalized not in out:
+            out.append(normalized)
+    return out
+
+
+def _render_v2_candidate(
+    entry: ConceptEntry,
+    concept_data: dict | None,
+    source_file: Path | None,
+) -> str:
+    """Render a v2 candidate file.
+
+    Frontmatter carries the 6 BL-058 fields (``extraction_prompt_version``,
+    ``unit_type``, ``epistemic_role``, ``absorbed_at``, ``source_anchor``,
+    ``specifics``).  Body is whatever ``content`` (v2 free-form markdown)
+    the LLM produced, plus a conditional ``## Related`` block, the
+    source-anchor blockquote, and the source backref.
+
+    Promotion (``write_evergreen_file``) is an in-place rewrite that
+    preserves all of these fields — see that function for the
+    candidate→evergreen handoff.
+    """
+    from datetime import timezone
+    from .object_kinds import CORE_OBJECT_KINDS, KIND_CONCEPT, KIND_METHOD, normalize_kind
+
+    data = concept_data or {}
+    aliases = list(dict.fromkeys([alias for alias in entry.aliases if alias]))
+
+    unit_type = str(data.get("unit_type") or "fact").strip().lower()
+    epistemic_role = str(data.get("epistemic_role") or "").strip().lower()
+    body_content = str(data.get("explanation") or "").strip()
+    source_anchor = str(data.get("source_anchor") or "").strip()
+    specifics_raw = data.get("specifics") or []
+    specifics = [str(s).strip() for s in specifics_raw if str(s).strip()] if isinstance(specifics_raw, list) else []
+    related = _normalize_related(data.get("related_concepts"), entry.slug)
+
+    # Map unit_type → entity_type using the same rule as the absorb
+    # extractor so a v2 candidate's frontmatter agrees with what the
+    # extractor's _unit_to_concept produced.
+    if unit_type in {"method", "procedure"}:
+        candidate_kind = KIND_METHOD
+    else:
+        normalized = normalize_kind(entry.kind) if entry.kind else KIND_CONCEPT
+        candidate_kind = normalized if normalized in CORE_OBJECT_KINDS else KIND_CONCEPT
+
+    now_utc = datetime.now(timezone.utc)
+    absorbed_at = now_utc.strftime("%Y-%m-%dT%H:%M:%SZ")
+    date_iso = now_utc.strftime("%Y-%m-%d")
+
+    related_block = ""
+    if related:
+        links = "\n".join(f"- [[{slug}]]" for slug in related)
+        related_block = f"\n## Related\n\n{links}\n"
+
+    anchor_block = ""
+    if source_anchor:
+        safe_anchor = source_anchor.replace("\n", " ").strip()
+        anchor_block = f'\n> **Source anchor**: "{safe_anchor}"\n'
+
+    source_link = ""
+    if source_file is not None:
+        source_link = f"\n## Source\n\n- [[{source_file.stem}]]\n"
+
+    aliases_yaml = "[" + ", ".join(f'"{a}"' for a in aliases) + "]"
+    related_yaml = "[" + ", ".join(_yaml_quote(c) for c in related) + "]" if related else "[]"
+    specifics_yaml = "[" + ", ".join(_yaml_quote(s) for s in specifics) + "]" if specifics else "[]"
+
+    return f"""---
+note_id: {entry.slug}
+title: "{entry.title}"
+type: candidate
+entity_type: {candidate_kind}
+unit_type: {unit_type}
+epistemic_role: {epistemic_role}
+extraction_prompt_version: v2
+absorbed_at: "{absorbed_at}"
+date: {date_iso}
+tags: [candidate, {entry.area}]
+aliases: {aliases_yaml}
+area: {entry.area}
+review_state: {entry.review_state}
+source_anchor: {_yaml_quote(source_anchor)}
+specifics: {specifics_yaml}
+related_concepts: {related_yaml}
+---
+
+# {entry.title}
+
+{body_content}
+{anchor_block}{related_block}{source_link}
+---
+
+*Candidate concept - pending review*
+"""
+
+
+def _render_v1_candidate(
+    entry: ConceptEntry,
+    concept_data: dict | None,
+    source_file: Path | None,
+) -> str:
+    """Render a candidate file using the pre-BL-058 v1 template.
+
+    Kept as a fallback so callers that don't pass v2 fields (legacy
+    backfills, manual promotion, the doctor's repair command, etc.)
+    keep producing the same output they did before.  All new
+    extraction paths should produce v2 candidates; if you find
+    yourself adding a v1 caller, ask whether it could carry v2
+    fields instead.
+    """
+    from .object_kinds import CORE_OBJECT_KINDS, KIND_CONCEPT, normalize_kind
+
+    data = concept_data or {}
+    aliases = list(dict.fromkeys([alias for alias in entry.aliases if alias]))
+    explanation = str(data.get("explanation", "")).strip()
+    importance = str(data.get("importance", "")).strip()
+    related = _normalize_related(data.get("related_concepts"), entry.slug)
 
     related_block = "\n".join(f"- [[{slug}]]" for slug in related) or "- 暂无"
     source_link = ""
     if source_file is not None:
         source_link = f"\n## 📚 来源\n- [[{source_file.stem}]]\n"
 
-    from .object_kinds import CORE_OBJECT_KINDS, KIND_CONCEPT, normalize_kind
-
     candidate_kind = normalize_kind(entry.kind) if entry.kind else KIND_CONCEPT
     if candidate_kind not in CORE_OBJECT_KINDS:
         candidate_kind = KIND_CONCEPT
 
-    frontmatter = f'''---
+    aliases_yaml = "[" + ", ".join(f'"{a}"' for a in aliases) + "]"
+    return f'''---
 note_id: {entry.slug}
 title: "{entry.title}"
 type: candidate
 entity_type: {candidate_kind}
 date: {datetime.now().strftime("%Y-%m-%d")}
 tags: [candidate, {entry.area}]
-aliases: [{", ".join(f'"{a}"' for a in aliases)}]
+aliases: {aliases_yaml}
 area: {entry.area}
 review_state: {entry.review_state}
 ---
@@ -213,10 +512,6 @@ review_state: {entry.review_state}
 
 *Candidate concept - pending review*
 '''
-
-    candidate_path.write_text(frontmatter, encoding="utf-8")
-    print(f"  Created candidate: {candidate_path}")
-    return candidate_path
 
 
 def delete_candidate_file(vault_dir: Path, slug: str, dry_run: bool = True) -> Path | None:

--- a/tests/test_no_silent_imports.py
+++ b/tests/test_no_silent_imports.py
@@ -42,7 +42,7 @@ LEGACY_SILENT_IMPORTS = {
     # We may tighten these in follow-up PRs but keep them here so the
     # ratchet test doesn't break.
     ("image_downloader.py", 213),
-    ("promote_candidates.py", 332),
+    ("promote_candidates.py", 627),  # BL-058a inserted v2 helpers, line shifted
     ("query_tool.py", 157),
     ("commands/backfill_entities.py", 214),     # pipeline.jsonl logger optional
     ("autopilot/daemon.py", 382),

--- a/tests/test_promote_v2_propagation.py
+++ b/tests/test_promote_v2_propagation.py
@@ -1,0 +1,345 @@
+"""Tests for BL-058a — promote path preserves v2 fields.
+
+The BL-058 PR (#157) shipped a v2 absorb prompt that produces
+``CandidateUnit`` JSON with ``unit_type`` / ``epistemic_role`` /
+``source_anchor`` / ``specifics`` / ``related_concepts``.  But
+``write_candidate_file`` and ``write_evergreen_file`` in
+``promote_candidates.py`` were NOT updated as part of #157, so v2
+extraction fields silently dropped on the candidate→evergreen
+handoff.  The first incremental run after #157 produced ~60 evergreens
+with v1 schema despite v2 LLM having run.
+
+This test suite pins the v2-preservation contract end-to-end so the
+bug can't recur.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from ovp_pipeline.concept_registry import ConceptEntry
+from ovp_pipeline.promote_candidates import (
+    _candidate_to_evergreen_v2,
+    _looks_like_v2_concept,
+    _render_v2_candidate,
+    write_candidate_file,
+    write_evergreen_file,
+)
+
+
+# ---------------------------------------------------------------------------
+# v2 detection
+# ---------------------------------------------------------------------------
+
+
+class TestV2ConceptDetection:
+    def test_unit_type_in_vocab_triggers_v2(self):
+        for ut in ("fact", "method", "tradeoff", "failure_mode", "case_detail"):
+            assert _looks_like_v2_concept({"unit_type": ut})
+
+    def test_unit_type_outside_vocab_does_not_trigger(self):
+        # "concept" is the v1 catchall, NOT in the v2 vocab
+        assert not _looks_like_v2_concept({"unit_type": "concept"})
+        assert not _looks_like_v2_concept({"unit_type": ""})
+
+    def test_source_anchor_alone_triggers_v2(self):
+        assert _looks_like_v2_concept({"source_anchor": "verbatim quote"})
+        assert not _looks_like_v2_concept({"source_anchor": ""})
+
+    def test_specifics_alone_triggers_v2(self):
+        assert _looks_like_v2_concept({"specifics": ["numbers", "names"]})
+        assert not _looks_like_v2_concept({"specifics": []})
+        assert not _looks_like_v2_concept({"specifics": None})
+
+    def test_pure_v1_concept_does_not_trigger(self):
+        # The exact shape v1 callers produce — no v2 fields anywhere
+        v1 = {
+            "concept_name": "x",
+            "title": "X",
+            "explanation": "...",
+            "importance": "...",
+            "related_concepts": ["a", "b", "c"],
+        }
+        assert not _looks_like_v2_concept(v1)
+
+
+# ---------------------------------------------------------------------------
+# v2 candidate rendering
+# ---------------------------------------------------------------------------
+
+
+class TestV2CandidateRendering:
+    def _entry(self) -> ConceptEntry:
+        return ConceptEntry(
+            slug="pid-lock-ownership",
+            title="PID-based ownership prevents OOM-orphaned locks",
+            definition="",
+            area="general",
+            aliases=["pid-lock-ownership"],
+            kind="concept",
+            review_state="auto",
+        )
+
+    def _v2_concept(self) -> dict:
+        return {
+            "title": "PID-based ownership prevents OOM-orphaned locks",
+            "unit_type": "method",
+            "epistemic_role": "method",
+            "explanation": "Bind lock ownership to PID lifecycle so OOM kill releases the lock.",
+            "source_anchor": "lock ownership tied to PID lifecycle",
+            "specifics": ["names", "examples", "edge_cases"],
+            "related_concepts": ["distributed-locks", "k8s-oom"],
+        }
+
+    def test_candidate_carries_all_v2_frontmatter_fields(self, tmp_path):
+        path = write_candidate_file(
+            tmp_path,
+            self._entry(),
+            dry_run=False,
+            concept_data=self._v2_concept(),
+            source_file=tmp_path / "fake-source.md",
+        )
+        content = path.read_text(encoding="utf-8")
+        assert "extraction_prompt_version: v2" in content
+        assert "unit_type: method" in content
+        assert "epistemic_role: method" in content
+        # _yaml_quote only adds quotes when the value has YAML-special chars
+        assert "source_anchor: lock ownership tied to PID lifecycle" in content
+        assert "specifics: [names, examples, edge_cases]" in content
+        assert "related_concepts: [distributed-locks, k8s-oom]" in content
+        # absorbed_at present and looks like an ISO-8601 UTC timestamp
+        assert 'absorbed_at: "20' in content and 'Z"' in content
+
+    def test_candidate_body_has_no_v1_template_sections(self, tmp_path):
+        path = write_candidate_file(
+            tmp_path, self._entry(),
+            dry_run=False,
+            concept_data=self._v2_concept(),
+            source_file=tmp_path / "fake-source.md",
+        )
+        content = path.read_text(encoding="utf-8")
+        assert "> **定义**" not in content
+        assert "## 📝 详细解释" not in content
+        assert "## 为什么重要" not in content
+        # v2 body markers ARE present
+        assert "## Related" in content
+        assert '> **Source anchor**: "lock ownership tied to PID lifecycle"' in content
+
+    def test_candidate_omits_related_section_when_empty(self, tmp_path):
+        concept = self._v2_concept()
+        concept["related_concepts"] = []
+        path = write_candidate_file(
+            tmp_path, self._entry(),
+            dry_run=False, concept_data=concept,
+            source_file=tmp_path / "fake-source.md",
+        )
+        content = path.read_text(encoding="utf-8")
+        assert "## Related" not in content
+        assert "related_concepts: []" in content
+
+    def test_v1_concept_falls_back_to_v1_template(self, tmp_path):
+        v1_concept = {
+            "concept_name": "old-style",
+            "title": "Old Style",
+            "one_sentence_def": "An old-style concept.",
+            "explanation": "Lots of details here.",
+            "importance": "Important because of reasons.",
+            "related_concepts": ["a", "b", "c"],
+        }
+        path = write_candidate_file(
+            tmp_path, self._entry(),
+            dry_run=False, concept_data=v1_concept,
+            source_file=tmp_path / "fake-source.md",
+        )
+        content = path.read_text(encoding="utf-8")
+        # v1 markers still present for backward compat
+        assert "> **定义**" in content
+        assert "## 📝 详细解释" in content
+        # v2 markers absent
+        assert "extraction_prompt_version: v2" not in content
+        assert "source_anchor:" not in content
+
+
+# ---------------------------------------------------------------------------
+# Candidate → evergreen handoff (v2 preservation)
+# ---------------------------------------------------------------------------
+
+
+class TestCandidateToEvergreenV2:
+    def _v2_candidate_text(self) -> str:
+        return """---
+note_id: pid-lock-ownership
+title: "PID-based ownership prevents OOM-orphaned locks"
+type: candidate
+entity_type: method
+unit_type: method
+epistemic_role: method
+extraction_prompt_version: v2
+absorbed_at: "2026-05-05T14:00:00Z"
+date: 2026-05-05
+tags: [candidate, general]
+aliases: ["pid-lock-ownership"]
+area: general
+review_state: auto
+source_anchor: "lock ownership tied to PID lifecycle"
+specifics: [names, examples]
+related_concepts: [distributed-locks]
+---
+
+# PID-based ownership prevents OOM-orphaned locks
+
+Bind lock ownership to PID lifecycle so OOM kill releases the lock.
+
+> **Source anchor**: "lock ownership tied to PID lifecycle"
+
+## Related
+
+- [[distributed-locks]]
+
+## Source
+
+- [[2026-05-05_some-source]]
+
+---
+
+*Candidate concept - pending review*
+"""
+
+    def _entry(self) -> ConceptEntry:
+        return ConceptEntry(
+            slug="pid-lock-ownership",
+            title="PID-based ownership prevents OOM-orphaned locks",
+            definition="",
+            area="general",
+            aliases=["pid-lock-ownership"],
+            kind="method",
+            review_state="auto",
+        )
+
+    def test_evergreen_inherits_v2_fields(self):
+        text = _candidate_to_evergreen_v2(self._v2_candidate_text(), self._entry())
+        assert "extraction_prompt_version: v2" in text
+        assert "unit_type: method" in text
+        assert "epistemic_role: method" in text
+        assert 'source_anchor: "lock ownership tied to PID lifecycle"' in text
+        assert "specifics: [names, examples]" in text
+        assert "related_concepts: [distributed-locks]" in text
+        # Body preserved
+        assert '> **Source anchor**: "lock ownership tied to PID lifecycle"' in text
+        assert "[[distributed-locks]]" in text
+
+    def test_type_flipped_to_evergreen(self):
+        text = _candidate_to_evergreen_v2(self._v2_candidate_text(), self._entry())
+        assert "type: evergreen" in text
+        # No leftover ``type: candidate``
+        assert "type: candidate" not in text
+
+    def test_review_state_dropped(self):
+        text = _candidate_to_evergreen_v2(self._v2_candidate_text(), self._entry())
+        assert "review_state:" not in text
+
+    def test_tags_swap_candidate_for_evergreen(self):
+        text = _candidate_to_evergreen_v2(self._v2_candidate_text(), self._entry())
+        # tag list contains evergreen, not candidate
+        import re
+        tags_match = re.search(r"^tags:\s*\[(.+)\]\s*$", text, re.MULTILINE)
+        assert tags_match is not None
+        tags = [t.strip().strip('"\'') for t in tags_match.group(1).split(",")]
+        assert "candidate" not in tags
+        assert "evergreen" in tags
+        assert "general" in tags  # area tag preserved
+
+    def test_footer_swaps_to_promoted(self):
+        text = _candidate_to_evergreen_v2(self._v2_candidate_text(), self._entry())
+        assert "*Candidate concept - pending review*" not in text
+        assert "*Promoted from candidate on" in text
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: write_evergreen_file routes v2 candidate to v2 path
+# ---------------------------------------------------------------------------
+
+
+class TestWriteEvergreenFileRouting:
+    def test_v2_candidate_produces_v2_evergreen(self, tmp_path):
+        # Build a vault skeleton + a v2 candidate file
+        for d in ["10-Knowledge/Evergreen", "10-Knowledge/Evergreen/_Candidates"]:
+            (tmp_path / d).mkdir(parents=True, exist_ok=True)
+        candidate_path = (
+            tmp_path / "10-Knowledge" / "Evergreen" / "_Candidates" / "pid-lock-ownership.md"
+        )
+        candidate_path.write_text(
+            TestCandidateToEvergreenV2()._v2_candidate_text(),
+            encoding="utf-8",
+        )
+
+        entry = ConceptEntry(
+            slug="pid-lock-ownership",
+            title="PID-based ownership prevents OOM-orphaned locks",
+            definition="",
+            area="general",
+            aliases=["pid-lock-ownership"],
+            kind="method",
+            review_state="auto",
+        )
+
+        evergreen_path = write_evergreen_file(tmp_path, entry, dry_run=False)
+        assert evergreen_path is not None
+        text = evergreen_path.read_text(encoding="utf-8")
+        # All v2 fields preserved
+        assert "extraction_prompt_version: v2" in text
+        assert "unit_type: method" in text
+        assert 'source_anchor: "lock ownership tied to PID lifecycle"' in text
+        # type flipped, review_state dropped, footer swapped
+        assert "type: evergreen" in text
+        assert "review_state:" not in text
+        assert "*Promoted from candidate on" in text
+
+    def test_v1_candidate_still_uses_legacy_template(self, tmp_path):
+        """Sanity check the v1 backward-compat path still works for
+        callers that don't yet produce v2 candidates."""
+        for d in ["10-Knowledge/Evergreen", "10-Knowledge/Evergreen/_Candidates"]:
+            (tmp_path / d).mkdir(parents=True, exist_ok=True)
+        candidate_path = (
+            tmp_path / "10-Knowledge" / "Evergreen" / "_Candidates" / "old-style.md"
+        )
+        candidate_path.write_text(
+            "---\n"
+            "note_id: old-style\n"
+            'title: "Old Style"\n'
+            "type: candidate\n"
+            "entity_type: concept\n"
+            "date: 2026-04-01\n"
+            "tags: [candidate, general]\n"
+            "aliases: [\"old-style\"]\n"
+            "area: general\n"
+            "review_state: auto\n"
+            "---\n\n"
+            "# Old Style\n\n"
+            "> **定义**: An old-style concept.\n\n"
+            "## 📝 详细解释\nLots of details.\n\n"
+            "---\n\n"
+            "*Candidate concept - pending review*\n",
+            encoding="utf-8",
+        )
+
+        entry = ConceptEntry(
+            slug="old-style",
+            title="Old Style",
+            definition="An old-style concept.",
+            area="general",
+            aliases=["old-style"],
+            kind="concept",
+            review_state="auto",
+        )
+        evergreen_path = write_evergreen_file(tmp_path, entry, dry_run=False)
+        text = evergreen_path.read_text(encoding="utf-8")
+        # v1 evergreen template — no v2 markers
+        assert "extraction_prompt_version" not in text
+        assert "source_anchor" not in text
+        # v1 markers ARE present
+        assert "type: evergreen" in text
+        assert "*Promoted from candidate on" in text


### PR DESCRIPTION
## Summary

BL-058 (#157) shipped a v2 absorb prompt that produces \`CandidateUnit\` JSON with \`unit_type\` / \`epistemic_role\` / \`source_anchor\` / \`specifics\` / \`related_concepts\`. But \`write_candidate_file\` and \`write_evergreen_file\` in \`promote_candidates.py\` were **not** updated as part of #157, so v2 fields silently dropped on the candidate→evergreen handoff. The first incremental run after #157 produced ~60 evergreens from v2 LLM extraction but written with v1 schema — none of the BL-058 design's promised frontmatter fields landed.

## Root cause

Two functions, both rebuilt frontmatter from scratch using only v1 fields:

- \`write_candidate_file\`: read \`explanation\`, \`importance\`, \`related_concepts\` from \`concept_data\`. Dropped \`unit_type\`, \`epistemic_role\`, \`source_anchor\`, \`specifics\`.
- \`write_evergreen_file\`: read body from candidate file (which had v1 template), rebuilt frontmatter with hardcoded v1 fields.

Net effect: v2 LLM ran ✅, v2 concept dict held all the right fields in memory ✅, then the promote path dropped them on disk.

## Fix

Both functions now branch:

- **\`write_candidate_file\`**: \`_looks_like_v2_concept\` detects v2 (unit_type in vocab OR non-empty source_anchor OR non-empty specifics). v2 path renders 6 new frontmatter fields + free-form body with conditional \`## Related\` and source_anchor blockquote. v1 path is byte-identical to pre-BL-058a output (legacy backfills keep working).
- **\`write_evergreen_file\`**: detects \`extraction_prompt_version: v2\` in the candidate file's frontmatter. v2 path is in-place rewrite preserving every field — only mutations are: \`type: candidate\` → \`type: evergreen\`, drop \`review_state:\` line, swap tags (\`candidate\` out, \`evergreen\` in), footer swap. Line-level regex so field ordering and any comments survive.

## Tests

New \`tests/test_promote_v2_propagation.py\` — 16 cases:

- **TestV2ConceptDetection** (5 cases): unit_type vocab triggers / v1 \`concept\` doesn't trigger / source_anchor alone triggers / specifics alone triggers / pure v1 doesn't trigger
- **TestV2CandidateRendering** (4 cases): all 6 frontmatter fields present / no v1 template sections / Related omitted when empty / v1 fallback works
- **TestCandidateToEvergreenV2** (5 cases): v2 fields inherited / type flip / review_state dropped / tags swap / footer swap
- **TestWriteEvergreenFileRouting** (2 cases): end-to-end v2 path / end-to-end v1 backward-compat

Bumped legacy line in \`test_no_silent_imports\` for the regex shift.

**Full suite: 2133/2133** (was 2113 before BL-058a).

## Cleanup of fake-v1 evergreens

The ~60 evergreens produced between BL-058 merge and this fix have v1 frontmatter (no \`extraction_prompt_version\` field). They will be picked up by \`ovp-tag-legacy-evergreens --write\` on the next run, since that command tags any evergreen lacking \`extraction_prompt_version\`. No special migration needed.

## Test plan

- [x] \`pytest tests/test_promote_v2_propagation.py\` — 16/16
- [x] \`pytest tests/\` — 2133/2133 (excluding pre-existing arch-fitness failure)
- [ ] After merge: re-run \`ovp-tag-legacy-evergreens --write\` to tag the ~60 fake-v1 evergreens
- [ ] After merge: trigger one absorb on a recent deep-dive and verify the new evergreen has v2 frontmatter end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added detection and handling for v2-format candidates during promotion.
  * Improved metadata preservation when promoting candidates to evergreen status.

* **Bug Fixes**
  * Enhanced compatibility with legacy v1 candidates during promotion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->