### PR TITLE
fix(crystals): scoring rebuild must not own the transaction

### DIFF
--- a/src/ovp_pipeline/commands/rescore_crystals.py
+++ b/src/ovp_pipeline/commands/rescore_crystals.py
@@ -60,6 +60,14 @@ def main(argv: list[str] | None = None) -> int:
             scores = rebuild_crystal_scores(
                 conn, vault_dir=vault, pack=args.pack,
             )
+            # ``rebuild_crystal_scores`` no longer commits — the
+            # caller owns the transaction so it can be safely composed
+            # inside ``rebuild_knowledge_index``.  This CLI is the
+            # standalone case so we commit here.
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
         finally:
             conn.close()
 

--- a/src/ovp_pipeline/synthesis/crystal_scoring.py
+++ b/src/ovp_pipeline/synthesis/crystal_scoring.py
@@ -462,13 +462,22 @@ def rebuild_crystal_scores(
     Idempotent: re-running with no input changes produces identical
     scores.  Operates entirely on derived state — no Canonical State
     is read or written.
+
+    Transaction policy: this function does NOT commit or rollback.
+    The caller owns the transaction.  Earlier versions called
+    ``conn.commit()`` / ``conn.rollback()`` internally, which was a
+    bug when invoked from inside ``rebuild_knowledge_index``'s outer
+    transaction: a scoring failure would roll back unrelated index
+    work (raw_data, audit_events, page_embeddings, …) before the
+    caller's ``except`` clause swallowed the error and kept going.
+    The CLI (``ovp-rescore-crystals``) is responsible for committing
+    after this returns.
     """
     community_index = _load_community_index(conn, pack)
     contradiction_index = _load_contradiction_index(conn, pack)
     if not community_index and not contradiction_index:
         # Nothing to score; clear stale rows for this pack and return.
         conn.execute("DELETE FROM crystal_scores WHERE pack = ?", (pack,))
-        conn.commit()
         return []
 
     source_credibility = _load_source_credibility(conn)
@@ -636,34 +645,31 @@ def rebuild_crystal_scores(
             signals=signals, computed_at=now_iso,
         ))
 
-    # Single transaction for atomicity.
-    try:
-        conn.execute("DELETE FROM crystal_scores WHERE pack = ?", (pack,))
-        conn.executemany(
-            """
-            INSERT INTO crystal_scores
-                (pack, crystal_kind, crystal_id, score,
-                 size_norm, credibility_norm, contradiction_norm,
-                 reuse_recency_norm, evergreen_recency_norm,
-                 source_diversity_norm,
-                 computed_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            [
-                (
-                    s.pack, s.crystal_kind, s.crystal_id, s.score,
-                    s.signals.size_norm, s.signals.credibility_norm,
-                    s.signals.contradiction_norm,
-                    s.signals.reuse_recency_norm,
-                    s.signals.evergreen_recency_norm,
-                    s.signals.source_diversity_norm,
-                    s.computed_at,
-                )
-                for s in out
-            ],
-        )
-        conn.commit()
-    except Exception:
-        conn.rollback()
-        raise
+    # DELETE+INSERT pair runs inside the caller's transaction.
+    # A failure here propagates the exception; if the caller has
+    # other pending writes it must decide rollback semantics.
+    conn.execute("DELETE FROM crystal_scores WHERE pack = ?", (pack,))
+    conn.executemany(
+        """
+        INSERT INTO crystal_scores
+            (pack, crystal_kind, crystal_id, score,
+             size_norm, credibility_norm, contradiction_norm,
+             reuse_recency_norm, evergreen_recency_norm,
+             source_diversity_norm,
+             computed_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        [
+            (
+                s.pack, s.crystal_kind, s.crystal_id, s.score,
+                s.signals.size_norm, s.signals.credibility_norm,
+                s.signals.contradiction_norm,
+                s.signals.reuse_recency_norm,
+                s.signals.evergreen_recency_norm,
+                s.signals.source_diversity_norm,
+                s.computed_at,
+            )
+            for s in out
+        ],
+    )
     return out

--- a/tests/test_crystal_scoring.py
+++ b/tests/test_crystal_scoring.py
@@ -389,6 +389,10 @@ class TestRebuildEndToEnd:
             rebuild_crystal_scores(
                 conn, vault_dir=vault, pack="research-tech",
             )
+            # The caller owns the transaction now (see crystal_scoring
+            # docstring): commit before closing so a fresh connection
+            # below can read what we just wrote.
+            conn.commit()
         finally:
             conn.close()
         conn = sqlite3.connect(db)
@@ -706,3 +710,67 @@ class TestArchitectureBoundary:
             assert s1.signals.contradiction_norm == s2.signals.contradiction_norm
             # Score within tolerance (only recency drifts).
             assert abs(s1.score - s2.score) < 1e-3
+
+
+class TestTransactionContract:
+    """Regression: ``rebuild_crystal_scores`` must NOT commit or
+    rollback on its own — the caller owns the transaction.
+
+    Pre-fix the function called ``conn.commit()`` on success and
+    ``conn.rollback()`` on failure.  When invoked inside
+    ``rebuild_knowledge_index``'s outer transaction (the production
+    path), a scoring failure would silently roll back unrelated
+    upstream writes (raw_data, audit_events, page_embeddings, …)
+    and the caller's ``except`` clause would swallow the error and
+    keep going, leaving the DB partially populated.
+    """
+
+    def test_uncommitted_writes_invisible_to_other_conn(self, tmp_path):
+        # rebuild_crystal_scores writes rows but does not commit.
+        # A separate connection must NOT see them.
+        vault, db = _build_seeded_vault(tmp_path)
+        conn1 = sqlite3.connect(db)
+        try:
+            scores = rebuild_crystal_scores(
+                conn1, vault_dir=vault, pack="research-tech",
+            )
+            assert len(scores) == 3
+            # Same-conn read sees pending writes.
+            same_conn_count = conn1.execute(
+                "SELECT COUNT(*) FROM crystal_scores"
+            ).fetchone()[0]
+            assert same_conn_count == 3
+            # Cross-conn read must not see uncommitted state.
+            conn2 = sqlite3.connect(db)
+            try:
+                cross_conn_count = conn2.execute(
+                    "SELECT COUNT(*) FROM crystal_scores"
+                ).fetchone()[0]
+            finally:
+                conn2.close()
+            assert cross_conn_count == 0, (
+                "rebuild_crystal_scores must not commit; the caller "
+                "owns the transaction so it can be safely composed "
+                "inside rebuild_knowledge_index's outer transaction."
+            )
+        finally:
+            conn1.close()
+
+    def test_caller_rollback_undoes_score_writes(self, tmp_path):
+        # If the caller rolls back, the score rows must vanish.
+        # Pre-fix the inner commit had already persisted them, so a
+        # caller rollback was a no-op — that's the bug class this
+        # test pins down.
+        vault, db = _build_seeded_vault(tmp_path)
+        conn = sqlite3.connect(db)
+        try:
+            rebuild_crystal_scores(
+                conn, vault_dir=vault, pack="research-tech",
+            )
+            conn.rollback()
+            n = conn.execute(
+                "SELECT COUNT(*) FROM crystal_scores"
+            ).fetchone()[0]
+            assert n == 0
+        finally:
+            conn.close()


### PR DESCRIPTION
## Summary

- ``rebuild_crystal_scores`` no longer calls ``conn.commit()`` / ``conn.rollback()`` — caller owns the transaction.
- Standalone CLI ``ovp-rescore-crystals`` now commits explicitly.
- New ``TestTransactionContract`` regression tests pin both halves: cross-connection invisibility before commit, and caller rollback undoes score writes.

## The bug

``rebuild_knowledge_index`` builds a single outer transaction across raw_data / audit_events / page_embeddings / entity_mentions / relations / evidence inserts, then invokes ``rebuild_crystal_scores`` and finally ``conn.commit()``.  The scoring function's own ``conn.rollback()`` (on failure) wiped every pending write; the caller's surrounding ``try/except`` swallowed the error and continued; the trailing ``conn.commit()`` committed an empty transaction.  Result: knowledge.db ended up missing the run's upstream writes with no failure signal at the rebuild boundary.

## Test plan

- [x] ``tests/test_crystal_scoring.py`` 40/40 (incl. 2 new regression tests)
- [x] ``tests/test_knowledge_index_preserves_crystals.py`` 2/2
- [x] Full suite (excluding pre-existing arch-fitness failure on ``unified_pipeline_enhanced.py``): 2135/2135

Review: BL-058 follow-up — critical finding #1, high #4.