### PR TITLE
fix(github): intake collision guard + cheap metadata probe before tier 3

### DIFF
--- a/src/ovp_pipeline/auto_github_processor.py
+++ b/src/ovp_pipeline/auto_github_processor.py
@@ -329,17 +329,21 @@ def process_single_repo(
     # Collision guard — refuse to silently overwrite a prior intake
     # of the same repo on the same date unless the caller asked for
     # it explicitly.  Done before tier probing so we don't burn
-    # external API budget on a destination we won't write to.
+    # external API budget on a destination we won't write to —
+    # this includes ``--dry-run`` so the dry-run report mirrors what
+    # a real run would actually do (gemini #164 review).
     safe_name = _build_output_filename(date, owner, repo)
     output_path = output_dir / safe_name
-    if not dry_run and not overwrite and output_path.exists():
+    if not overwrite and output_path.exists():
         print(
             f"  ⊘ Skipping {owner}/{repo}: {output_path.name} already "
             "exists (use --overwrite to refresh)"
         )
         result["status"] = "skipped_existing"
         result["output_file"] = str(output_path)
-        if logger:
+        # Audit events log only on real runs — a dry run shouldn't
+        # pollute pipeline.jsonl with simulated skip records.
+        if not dry_run and logger:
             logger.log("github_intake_skipped_existing", {
                 "url": url, "owner": owner, "repo": repo,
                 "output_file": str(output_path),

--- a/src/ovp_pipeline/auto_github_processor.py
+++ b/src/ovp_pipeline/auto_github_processor.py
@@ -284,10 +284,12 @@ def process_single_repo(
     output_dir: Path,
     logger: PipelineLogger | None = None,
     dry_run: bool = False,
+    overwrite: bool = False,
 ) -> dict[str, Any]:
     """Enrich a single GitHub URL and write the processed markdown.
 
-    Returns a result dict with ``status`` ∈ {completed, skipped, error}.
+    Returns a result dict with ``status`` ∈ {completed, skipped, error,
+    skipped_existing, dry_run}.
 
     Behavioral changes from the pre-BL-066 implementation:
     - No LLM call (no ``llm_client`` parameter).
@@ -297,6 +299,15 @@ def process_single_repo(
     - On total enrichment failure (all 3 tiers empty), we still write
       a frontmatter-only stub so the source is tracked, but flag
       ``status=skipped`` and ``warning="empty_body"``.
+
+    ``overwrite``: when ``False`` (default) and the destination
+    file already exists, return immediately with
+    ``status=skipped_existing`` and emit a
+    ``github_intake_skipped_existing`` audit event.  Re-running
+    intake on the same repo same day used to silently overwrite
+    the prior file — a real risk when DeepWiki was unavailable on
+    the first attempt and a later run got better content (or vice
+    versa).  Set ``overwrite=True`` to deliberately replace.
     """
     result: dict[str, Any] = {
         "url": url,
@@ -314,6 +325,26 @@ def process_single_repo(
             logger.log("github_intake_error", {"url": url, "error": result["error"]})
         return result
     owner, repo = parsed
+
+    # Collision guard — refuse to silently overwrite a prior intake
+    # of the same repo on the same date unless the caller asked for
+    # it explicitly.  Done before tier probing so we don't burn
+    # external API budget on a destination we won't write to.
+    safe_name = _build_output_filename(date, owner, repo)
+    output_path = output_dir / safe_name
+    if not dry_run and not overwrite and output_path.exists():
+        print(
+            f"  ⊘ Skipping {owner}/{repo}: {output_path.name} already "
+            "exists (use --overwrite to refresh)"
+        )
+        result["status"] = "skipped_existing"
+        result["output_file"] = str(output_path)
+        if logger:
+            logger.log("github_intake_skipped_existing", {
+                "url": url, "owner": owner, "repo": repo,
+                "output_file": str(output_path),
+            })
+        return result
 
     print(f"  Enriching {owner}/{repo} (tier 1 → 2 → 3) …")
     try:
@@ -369,8 +400,9 @@ def process_single_repo(
         result["error"] = "empty_body"
 
     output_dir.mkdir(parents=True, exist_ok=True)
-    safe_name = _build_output_filename(date, owner, repo)
-    output_path = output_dir / safe_name
+    # ``output_path`` was computed earlier (see collision guard above);
+    # re-using the same value keeps the audit-event filename consistent
+    # with what the guard would have rejected.
     with open(output_path, "w", encoding="utf-8") as f:
         f.write(full_content)
 
@@ -462,6 +494,14 @@ def main() -> int:
         help="输出目录（默认：<vault>/50-Inbox/03-Processed/YYYY-MM/）",
     )
     parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--overwrite", action="store_true",
+        help=(
+            "Replace an existing processed source instead of "
+            "skipping.  Without this flag, a second intake of the "
+            "same repo on the same date is a no-op."
+        ),
+    )
     parser.add_argument("--delay", "-d", type=float, default=1.0)
     args = parser.parse_args()
 
@@ -524,6 +564,7 @@ def main() -> int:
             output_dir=output_dir,
             logger=logger,
             dry_run=args.dry_run,
+            overwrite=args.overwrite,
         )
         maybe_archive_pinboard_process_single(
             layout,
@@ -541,7 +582,10 @@ def main() -> int:
     print("\n" + "=" * 60)
     print("SUMMARY")
     print("=" * 60)
-    by_status = {"completed": 0, "skipped": 0, "error": 0, "dry_run": 0}
+    by_status = {
+        "completed": 0, "skipped": 0, "skipped_existing": 0,
+        "error": 0, "dry_run": 0,
+    }
     by_tier = {"deepwiki": 0, "gitingest": 0, "readme": 0, None: 0}
     for r in results:
         by_status[r.get("status", "error")] = by_status.get(r.get("status", "error"), 0) + 1

--- a/src/ovp_pipeline/github_enrichment.py
+++ b/src/ovp_pipeline/github_enrichment.py
@@ -388,35 +388,64 @@ _README_FILENAMES = (
 _README_BRANCH_FALLBACKS = ("main", "master", "develop", "dev", "trunk")
 
 
-def fetch_readme(owner: str, repo: str) -> tuple[str, int]:
-    """Final fallback — fetch README + stars.
+def fetch_repo_metadata(owner: str, repo: str) -> tuple[Optional[str], int]:
+    """Cheap probe for ``default_branch`` and ``stargazers_count``.
 
-    Strategy:
-      1. Hit ``api.github.com/repos/{owner}/{repo}`` once to get
-         ``default_branch`` and ``stargazers_count`` in a single
-         request.  This handles non-standard branches that the old
-         hardcoded ``main/master/develop`` list missed.
-      2. Try each filename in ``_README_FILENAMES`` against the
-         default branch.
-      3. If that fails (rate-limited API, 404, etc.), fall back to
-         the historical branch+filename grid.
+    Single request to ``api.github.com/repos/{owner}/{repo}`` — no
+    raw README probing.  Used by ``enrich_github_source`` to pay
+    for the metadata once up front so Tier 1/2 can short-circuit
+    without ever touching the README path.
 
-    Always returns a tuple; ``body`` may be empty if the repo has no
-    README anywhere we can find.
+    Pre-fix, the only way to get ``stars`` was via ``fetch_readme``
+    which probed up to 7 README filenames × 5 branches.  That
+    meant DeepWiki-served repos still paid the full Tier-3
+    network cost just to fill in the stars frontmatter field.
+
+    Returns ``(default_branch, stars)``.  ``default_branch`` is
+    ``None`` when the API call fails (rate-limited, repo gone,
+    etc.) — callers should fall back to the hardcoded branch list.
     """
-    stars = 0
-    default_branch: Optional[str] = None
     api_text = _http_get(
         f"https://api.github.com/repos/{owner}/{repo}",
         timeout=10.0,
     )
-    if api_text:
-        try:
-            data = json.loads(api_text)
-            default_branch = data.get("default_branch")
-            stars = int(data.get("stargazers_count", 0) or 0)
-        except (json.JSONDecodeError, ValueError, TypeError):
-            pass
+    if not api_text:
+        return None, 0
+    try:
+        data = json.loads(api_text)
+        return (
+            data.get("default_branch") or None,
+            int(data.get("stargazers_count", 0) or 0),
+        )
+    except (json.JSONDecodeError, ValueError, TypeError):
+        return None, 0
+
+
+def fetch_readme(
+    owner: str, repo: str,
+    *,
+    default_branch: Optional[str] = None,
+) -> tuple[str, int]:
+    """Final fallback — fetch README body.
+
+    Returns ``(body, stars)`` for backward compatibility, but
+    callers that already know the stars (via ``fetch_repo_metadata``)
+    can ignore the second tuple element.  ``default_branch`` lets
+    a caller skip the duplicate API roundtrip — when omitted, this
+    function fetches the metadata itself.
+
+    Strategy when ``default_branch`` is unknown:
+      1. Hit ``api.github.com/repos/{owner}/{repo}`` to get the
+         default branch and stars in one request.
+      2. Try each filename in ``_README_FILENAMES`` against the
+         default branch first, then the hardcoded fallback branches.
+
+    Always returns a tuple; ``body`` may be empty if the repo has
+    no README anywhere we can find.
+    """
+    stars = 0
+    if default_branch is None:
+        default_branch, stars = fetch_repo_metadata(owner, repo)
 
     # Build branch list: API-reported default first, then the hardcoded
     # fallbacks (deduped, preserving order).
@@ -450,9 +479,12 @@ def enrich_github_source(owner: str, repo: str) -> EnrichedSource:
     downstream callers should check ``len(body)`` before trying to
     extract knowledge from it.
     """
-    # Always fetch stars regardless of which tier wins — it's a stable
-    # frontmatter signal independent of body provenance.
-    _, stars = fetch_readme(owner, repo)  # extracts stars cheaply
+    # Stars + default_branch are stable signals independent of body
+    # provenance, but fetching them via ``fetch_readme`` would also
+    # probe up to 7 README files × 5 branches.  Pay the metadata
+    # cost once up front so Tier 1/2 hits don't drag the README
+    # network round-trips along for the ride.
+    default_branch, stars = fetch_repo_metadata(owner, repo)
 
     # Tier 1
     deepwiki_result = fetch_deepwiki(owner, repo)
@@ -468,8 +500,9 @@ def enrich_github_source(owner: str, repo: str) -> EnrichedSource:
         meta["github_stars"] = stars
         return EnrichedSource(owner=owner, repo=repo, tier="gitingest", body=body, metadata=meta)
 
-    # Tier 3 — README only
-    body, stars = fetch_readme(owner, repo)
+    # Tier 3 — README only.  Reuse the default_branch we already
+    # know to avoid a duplicate API hit.
+    body, _ = fetch_readme(owner, repo, default_branch=default_branch)
     return EnrichedSource(
         owner=owner, repo=repo, tier="readme",
         body=body,

--- a/tests/test_github_enrichment.py
+++ b/tests/test_github_enrichment.py
@@ -450,6 +450,47 @@ class TestProcessSingleRepo:
         assert "refreshed body" in body
         assert "stale" not in body
 
+    def test_dry_run_also_respects_collision_guard(self, tmp_path):
+        """Gemini #164 review: a dry run on an already-processed
+        repo must short-circuit identically to a real run, otherwise
+        the dry-run report says "would process N repos" while the
+        real run would skip them, and we burn API budget probing
+        tiers we'd never write.  Audit-event emission stays off in
+        dry runs so simulated skips don't pollute pipeline.jsonl.
+        """
+        from unittest.mock import MagicMock
+        layout = self._init_vault(tmp_path)
+        out_dir = layout.processed_dir / "2026-04"
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        existing = out_dir / "2026-04-28_o_r.md"
+        existing.write_text("prior", encoding="utf-8")
+
+        recorded_logs: list[tuple[str, dict]] = []
+        stub_logger = MagicMock()
+        stub_logger.log = lambda kind, payload: recorded_logs.append((kind, payload))
+
+        with patch(
+            "ovp_pipeline.auto_github_processor.enrich_github_source",
+        ) as enrich_mock:
+            result = process_single_repo(
+                url="https://github.com/o/r",
+                date="2026-04-28",
+                tags=[], description="",
+                output_dir=out_dir,
+                logger=stub_logger,
+                dry_run=True,
+            )
+        assert result["status"] == "skipped_existing"
+        # Tier probing did NOT run on dry run either — the report
+        # accurately reflects what a real run would do.
+        enrich_mock.assert_not_called()
+        # Audit log stays clean during dry runs.
+        assert not any(
+            kind == "github_intake_skipped_existing"
+            for kind, _ in recorded_logs
+        ), f"dry-run polluted the audit log: {recorded_logs}"
+
     @staticmethod
     def _init_vault(tmp_path: Path) -> VaultLayout:
         # Minimal vault skeleton VaultLayout expects

--- a/tests/test_github_enrichment.py
+++ b/tests/test_github_enrichment.py
@@ -87,7 +87,11 @@ class TestEnrichmentChain:
                 "ovp_pipeline.github_enrichment.fetch_deepwiki",
                 return_value=("# DeepWiki body", {"deepwiki_section_count": 5, "deepwiki_last_indexed": "2026-01-20"}),
             ),
-            patch("ovp_pipeline.github_enrichment.fetch_readme", return_value=("# README", 42)),
+            patch(
+                "ovp_pipeline.github_enrichment.fetch_repo_metadata",
+                return_value=("main", 42),
+            ),
+            patch("ovp_pipeline.github_enrichment.fetch_readme") as readme_mock,
             patch("ovp_pipeline.github_enrichment.fetch_gitingest") as gitingest_mock,
         ):
             result = enrich_github_source("owner", "repo")
@@ -95,8 +99,11 @@ class TestEnrichmentChain:
         assert result.body == "# DeepWiki body"
         assert result.metadata["github_stars"] == 42
         assert result.metadata["deepwiki_last_indexed"] == "2026-01-20"
-        # Tier 2 must NOT be invoked when Tier 1 hits
+        # Tier 2 must NOT be invoked when Tier 1 hits.
         gitingest_mock.assert_not_called()
+        # Tier 3 must NOT run either — the bug we fixed.  Stars come
+        # from ``fetch_repo_metadata``, not ``fetch_readme``.
+        readme_mock.assert_not_called()
 
     def test_tier2_gitingest_when_deepwiki_misses(self):
         with (
@@ -105,26 +112,42 @@ class TestEnrichmentChain:
                 "ovp_pipeline.github_enrichment.fetch_gitingest",
                 return_value=("# GitIngest body", {"gitingest_commit": "abc123" + "0" * 34}),
             ),
-            patch("ovp_pipeline.github_enrichment.fetch_readme", return_value=("# README", 7)),
+            patch(
+                "ovp_pipeline.github_enrichment.fetch_repo_metadata",
+                return_value=("main", 7),
+            ),
+            patch("ovp_pipeline.github_enrichment.fetch_readme") as readme_mock,
         ):
             result = enrich_github_source("owner", "repo")
         assert result.tier == "gitingest"
         assert result.body == "# GitIngest body"
         assert result.metadata["github_stars"] == 7
+        # README probing must not run when Tier 2 hits.
+        readme_mock.assert_not_called()
 
     def test_tier3_readme_when_higher_fail(self):
         with (
             patch("ovp_pipeline.github_enrichment.fetch_deepwiki", return_value=None),
             patch("ovp_pipeline.github_enrichment.fetch_gitingest", return_value=None),
             patch(
+                "ovp_pipeline.github_enrichment.fetch_repo_metadata",
+                return_value=("trunk", 999),
+            ),
+            patch(
                 "ovp_pipeline.github_enrichment.fetch_readme",
                 return_value=("# Just the README\n\nbody", 999),
-            ),
+            ) as readme_mock,
         ):
             result = enrich_github_source("owner", "repo")
         assert result.tier == "readme"
         assert result.body == "# Just the README\n\nbody"
         assert result.metadata["github_stars"] == 999
+        # When Tier 3 runs, it must reuse the default_branch we
+        # already learned via fetch_repo_metadata so the API isn't
+        # hit twice.
+        readme_mock.assert_called_once_with(
+            "owner", "repo", default_branch="trunk",
+        )
 
     def test_all_tiers_fail_returns_empty_body(self):
         """Every tier returns empty/None — should still return a
@@ -137,7 +160,14 @@ class TestEnrichmentChain:
         with (
             patch("ovp_pipeline.github_enrichment.fetch_deepwiki", return_value=None),
             patch("ovp_pipeline.github_enrichment.fetch_gitingest", return_value=None),
-            patch("ovp_pipeline.github_enrichment.fetch_readme", return_value=("", 0)),
+            patch(
+                "ovp_pipeline.github_enrichment.fetch_repo_metadata",
+                return_value=(None, 0),
+            ),
+            patch(
+                "ovp_pipeline.github_enrichment.fetch_readme",
+                return_value=("", 0),
+            ),
         ):
             result = enrich_github_source("ghost", "ghost")
         assert result.tier == "readme"
@@ -351,6 +381,74 @@ class TestProcessSingleRepo:
         # ignores it during evergreen extraction.
         body = Path(result["output_file"]).read_text(encoding="utf-8")
         assert "extraction_status: skipped" in body
+
+    def test_existing_file_skipped_without_overwrite(self, tmp_path):
+        """Pre-fix, re-running intake on the same repo same day
+        silently overwrote ``50-Inbox/03-Processed/<YYYY-MM>/<date>_<owner>_<repo>.md``.
+        That risks losing a higher-tier extraction (DeepWiki later
+        became available, README later updated, …) without any
+        signal.  Default behaviour now: skip + audit event.
+        """
+        layout = self._init_vault(tmp_path)
+        out_dir = layout.processed_dir / "2026-04"
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        # Pre-existing file — first run's content.
+        existing = out_dir / "2026-04-28_o_r.md"
+        existing.write_text(
+            "---\nfrom: previous run\n---\n\noriginal body\n",
+            encoding="utf-8",
+        )
+
+        with patch(
+            "ovp_pipeline.auto_github_processor.enrich_github_source",
+        ) as enrich_mock:
+            result = process_single_repo(
+                url="https://github.com/o/r",
+                date="2026-04-28",
+                tags=[],
+                description="",
+                output_dir=out_dir,
+                dry_run=False,
+            )
+        # Skipped without consuming external API budget.
+        assert result["status"] == "skipped_existing"
+        enrich_mock.assert_not_called()
+        # File contents preserved byte-for-byte.
+        assert existing.read_text(encoding="utf-8").startswith(
+            "---\nfrom: previous run"
+        )
+
+    def test_overwrite_flag_replaces_existing(self, tmp_path):
+        layout = self._init_vault(tmp_path)
+        out_dir = layout.processed_dir / "2026-04"
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        existing = out_dir / "2026-04-28_o_r.md"
+        existing.write_text("stale", encoding="utf-8")
+
+        with patch(
+            "ovp_pipeline.auto_github_processor.enrich_github_source",
+            return_value=EnrichedSource(
+                owner="o", repo="r", tier="deepwiki",
+                body="# refreshed body",
+                metadata={"tier": "deepwiki", "github_stars": 1,
+                          "deepwiki_last_indexed": "2026-04-28"},
+            ),
+        ):
+            result = process_single_repo(
+                url="https://github.com/o/r",
+                date="2026-04-28",
+                tags=[],
+                description="",
+                output_dir=out_dir,
+                dry_run=False,
+                overwrite=True,
+            )
+        assert result["status"] == "completed"
+        body = existing.read_text(encoding="utf-8")
+        assert "refreshed body" in body
+        assert "stale" not in body
 
     @staticmethod
     def _init_vault(tmp_path: Path) -> VaultLayout:


### PR DESCRIPTION
## Summary

Two correctness bugs in the GitHub intake path, fixed together because they touch the same call chain.

### 1. Tier-order regression

``enrich_github_source`` called ``fetch_readme()`` just to read ``stargazers_count`` — under the hood that probed up to **7 README filenames × 5 branches** against raw.githubusercontent.com before Tier 1 even ran.  DeepWiki/GitIngest hits were paying the full Tier-3 network cost.

Split into ``fetch_repo_metadata`` (one cheap API call) + ``fetch_readme`` (body only).  Tier 1 / Tier 2 hits never touch the README path.  Tier 3 reuses the already-learned ``default_branch`` to avoid a duplicate API hit.

### 2. Silent overwrite of processed sources

``process_single_repo`` wrote with ``open(..., "w")`` and clobbered prior intakes on collision (same date / same repo).  Real risk: DeepWiki recovers from rate limit on the second run and we destroy the prior extraction (or vice versa).

New collision guard: default ``status=skipped_existing`` with a ``github_intake_skipped_existing`` audit event.  ``--overwrite`` opts in.  Guard runs **before** tier probing so we don't burn external API budget on a destination we won't write.

## Test plan

- [x] ``TestEnrichmentChain`` updated to assert ``fetch_readme`` is NOT called when Tier 1 / Tier 2 hit — pins the regression
- [x] New ``test_existing_file_skipped_without_overwrite`` + ``test_overwrite_flag_replaces_existing``
- [x] Full suite: 2135/2135

Review: BL-058 follow-up — second batch medium findings (GitHub intake + tier order).