### PR TITLE
fix(absorb): key staged_sources by absolute path, not basename

### DIFF
--- a/src/ovp_pipeline/unified_pipeline_enhanced.py
+++ b/src/ovp_pipeline/unified_pipeline_enhanced.py
@@ -2330,6 +2330,7 @@ class EnhancedPipeline:
         completed_before: int = 0,
         failed_before: int = 0,
         staged_sources: dict[str, str] | None = None,
+        staging_dir: Path | None = None,
         record_item_ledger: bool = False,
     ):
         def _callback(event: dict[str, Any]) -> None:
@@ -2337,8 +2338,19 @@ class EnhancedPipeline:
             batch_done = int(event.get("files_done") or 0)
             batch_failed = int(event.get("files_failed") or 0)
             current_item = str(event.get("current_item") or event.get("file") or "").strip() or None
-            if record_item_ledger and current_item and staged_sources and current_item in staged_sources:
-                self._append_absorb_item_record(staged_sources[current_item], event)
+            # ``staged_sources`` is keyed by absolute staging path so two
+            # batch inputs with the same basename (e.g. two README.md
+            # files in different vault directories) don't collide.
+            # ``current_item`` from the absorb worker is a basename, so
+            # rejoin against the staging dir to get the lookup key.
+            staged_path_key: str | None = None
+            if current_item and staging_dir is not None:
+                staged_path_key = str(staging_dir / current_item)
+            if (
+                record_item_ledger and staged_path_key and staged_sources
+                and staged_path_key in staged_sources
+            ):
+                self._append_absorb_item_record(staged_sources[staged_path_key], event)
             work_units_done = completed_before + batch_done
             work_units_failed = failed_before + batch_failed
             progress_summary = (
@@ -2409,6 +2421,7 @@ class EnhancedPipeline:
                     completed_before=completed_before,
                     failed_before=failed_before,
                     staged_sources=staged_sources,
+                    staging_dir=directory if staged_sources else None,
                     record_item_ledger=record_item_ledger,
                 ),
             )
@@ -2448,12 +2461,17 @@ class EnhancedPipeline:
         # producing 0 mentions on every incremental run since PR #99
         # introduced staging.  See test_e2e_acceptance:
         # test_absorb_processed_files_are_vault_paths.
+        #
+        # ``staged_sources`` is keyed by absolute staging path (not
+        # basename) so two batch inputs sharing a basename — two
+        # ``README.md`` files in different vault directories, for
+        # example — round-trip back to the right vault path.
         if staged_sources:
             for item in results:
                 if isinstance(item, dict) and item.get("file"):
-                    name = Path(str(item["file"])).name
-                    if name in staged_sources:
-                        item["file"] = staged_sources[name]
+                    staged = str(item["file"])
+                    if staged in staged_sources:
+                        item["file"] = staged_sources[staged]
 
         promoted_slugs: list[str] = []
         processed_files: list[str] = []
@@ -2651,7 +2669,14 @@ class EnhancedPipeline:
                                     break
                                 counter += 1
                         used_targets.add(target)
-                        staged_sources[target.name] = str(source)
+                        # Key by absolute staging path so two inputs with
+                        # the same basename don't overwrite each other in
+                        # the dict.  The collision guard above already
+                        # gives them distinct ``-N`` filenames in staging,
+                        # but keying by full path makes the contract
+                        # explicit and survives any future change to
+                        # the rename logic.
+                        staged_sources[str(target)] = str(source)
                         try:
                             target.symlink_to(source)
                         except OSError:

--- a/tests/test_e2e_acceptance.py
+++ b/tests/test_e2e_acceptance.py
@@ -319,3 +319,85 @@ class TestPATCH1RegressionGuard:
             assert "absorb-qualified-" not in str(p), (
                 f"processed_files contains staging-dir path: {processed}"
             )
+
+    def test_absorb_handles_two_inputs_with_same_basename(
+        self, pipeline, temp_vault,
+    ):
+        """Two qualified files with the same basename in different
+        vault directories must round-trip back to their original
+        paths, not collapse onto one entry.
+
+        Pre-fix the staged_sources dict was keyed by basename, so a
+        second ``README.md`` overwrote the first.  After the staging
+        rename the second file lived at ``staging/README-2.md`` —
+        but the rewrite loop only matched ``README.md`` against the
+        dict and silently kept the staging path for the second
+        result, leaking another orphan path through to entity-extract.
+
+        Keying ``staged_sources`` by absolute staging path makes
+        both files round-trip cleanly even if every basename is
+        identical.
+        """
+        # Two source files with the SAME basename in different dirs.
+        dir_a = temp_vault / "20-Areas" / "AlphaTopic" / "Topics" / "2026-04"
+        dir_b = temp_vault / "20-Areas" / "BetaTopic" / "Topics" / "2026-04"
+        dir_a.mkdir(parents=True, exist_ok=True)
+        dir_b.mkdir(parents=True, exist_ok=True)
+        same_name = "shared_name_深度解读.md"
+        src_a = dir_a / same_name
+        src_b = dir_b / same_name
+        src_a.write_text(
+            "---\ntitle: A\ndate: 2026-04-09\n---\n\n# A body\n",
+            encoding="utf-8",
+        )
+        src_b.write_text(
+            "---\ntitle: B\ndate: 2026-04-09\n---\n\n# B body\n",
+            encoding="utf-8",
+        )
+
+        # Mock the inner workflow to echo back staging paths for
+        # whichever files showed up in the staging dir.
+        def fake_run_absorb_workflow(vault_dir, *, directory, **kwargs):
+            staged = sorted(p for p in directory.iterdir() if p.is_file())
+            return {
+                "mode": "absorb",
+                "summary": {
+                    "files_processed": len(staged),
+                    "concepts_promoted": len(staged),
+                    "errors": 0,
+                },
+                "results": [
+                    {
+                        "file": str(s),
+                        "concepts_extracted": 1,
+                        "candidates_added": 0,
+                        "concepts_promoted": 1,
+                        "concepts_created": 0,
+                        "concepts_skipped": 0,
+                        "concepts": [{
+                            "slug": canonicalize_note_id(s.stem),
+                            "status": "promoted_created",
+                        }],
+                    }
+                    for s in staged
+                ],
+                "source_scope": {},
+            }
+
+        with patch(
+            "ovp_pipeline.unified_pipeline_enhanced.run_absorb_workflow",
+            side_effect=fake_run_absorb_workflow,
+        ):
+            result = pipeline.step_absorb(
+                qualified_files=[str(src_a), str(src_b)],
+            )
+
+        assert isinstance(result, AbsorbStepResult)
+        # Both vault paths must come back, distinct, and pointing
+        # at the right files on disk.
+        processed = sorted(result.processed_files)
+        expected = sorted([str(src_a), str(src_b)])
+        assert processed == expected, (
+            f"basename collision dropped one of the inputs: "
+            f"got {processed!r}, expected {expected!r}"
+        )


### PR DESCRIPTION
## Summary

Fixes review finding #10: the basename-keyed ``staged_sources`` dict drops one of two qualified files when their basenames collide (two ``README.md`` from different vault directories, etc.).  Switching to absolute-staging-path keys makes the round-trip mapping unambiguous.

## What changed

- ``EnhancedPipeline._build_absorb_progress_callback`` now takes ``staging_dir`` and reconstructs the absolute key from the absorb worker's basename ``current_item`` before lookup.
- ``EnhancedPipeline.step_absorb`` rewrite loop drops the ``Path(item['file']).name`` strip and looks up the absolute path directly.
- ``staged_sources`` construction stores ``str(target)`` (absolute staging path) instead of ``target.name`` (basename).
- New ``test_absorb_handles_two_inputs_with_same_basename`` pins the exact scenario.

## Out of scope

Review #9 (``threading.local`` ambient shell selection in ``_ui_renderers``) is a 30+ callsite refactor — kept separate so this PR stays focused on the correctness bug.

## Test plan

- [x] ``tests/test_e2e_acceptance.py`` 7/7 (includes both the existing staging-path leak test and the new basename-collision regression test)
- [x] Full suite: 2134/2134

Review: BL-058 follow-up — medium #10.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced input processing to correctly handle multiple files sharing the same filename, preventing them from collapsing into a single entry when batching operations.
  * Improved progress tracking to maintain accurate file-level visibility across staged inputs.

* **Tests**
  * Added regression test verifying correct processing of duplicate filenames from different sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->