### PR TITLE
fix(clusters): attach big-community singletons to nearest sub-group

### DIFF
--- a/src/ovp_pipeline/packs/research_tech/truth_projection.py
+++ b/src/ovp_pipeline/packs/research_tech/truth_projection.py
@@ -251,21 +251,28 @@ def _split_if_too_big(
         for idx, sub in enumerate(sized_sub_lists)
         for member in sub
     }
+    # Walk the induced sub-graph's incident edges instead of the full
+    # ``pair_weights`` dict so the cost is O(singletons × singleton_degree)
+    # rather than O(singletons × |pair_weights|).  ``sub_graph`` already
+    # holds only edges among parent-community members.
     for singleton in singletons:
         weight_per_sub: dict[int, float] = {}
-        for (src, tgt), weight in pair_weights.items():
-            if src == singleton and tgt in sub_member_index:
-                idx = sub_member_index[tgt]
-                weight_per_sub[idx] = weight_per_sub.get(idx, 0.0) + weight
-            elif tgt == singleton and src in sub_member_index:
-                idx = sub_member_index[src]
-                weight_per_sub[idx] = weight_per_sub.get(idx, 0.0) + weight
-        if weight_per_sub:
-            best_idx = max(weight_per_sub, key=weight_per_sub.get)
-        else:
-            best_idx = 0
+        for _src, neighbour, data in sub_graph.edges(singleton, data=True):
+            idx = sub_member_index.get(neighbour)
+            if idx is None:
+                continue
+            weight_per_sub[idx] = (
+                weight_per_sub.get(idx, 0.0) + data.get("weight", 1.0)
+            )
+        best_idx = (
+            max(weight_per_sub, key=weight_per_sub.get)
+            if weight_per_sub else 0
+        )
         sized_sub_lists[best_idx].append(singleton)
-        sized_sub_lists[best_idx].sort()
+    # Sort once at the end — the loop above could append to the same
+    # list multiple times, and pre-fix it re-sorted on every singleton.
+    for sub in sized_sub_lists:
+        sub.sort()
     return sized_sub_lists
 
 

--- a/src/ovp_pipeline/packs/research_tech/truth_projection.py
+++ b/src/ovp_pipeline/packs/research_tech/truth_projection.py
@@ -219,14 +219,54 @@ def _split_if_too_big(
     sub_communities = louvain_communities(
         sub_graph, weight="weight", seed=_LOUVAIN_SEED,
     )
-    sub_lists = [sorted(c) for c in sub_communities if len(c) >= 2]
+    sized_sub_lists: list[list[str]] = []
+    singletons: list[str] = []
+    for sub_community in sub_communities:
+        sub_sorted = sorted(sub_community)
+        if len(sub_sorted) >= 2:
+            sized_sub_lists.append(sub_sorted)
+        else:
+            singletons.extend(sub_sorted)
     # If Louvain returns a single sub-community equal to the input,
     # the community has no internal structure to surface — keep it
     # whole rather than emit a rename.  Same when no sub-community
     # passes the size-≥-2 filter.
-    if len(sub_lists) <= 1:
+    if not sized_sub_lists or (
+        len(sized_sub_lists) == 1 and not singletons
+    ):
         return [sorted(members)]
-    return sub_lists
+    # Pre-fix: ``[sorted(c) for c in sub_communities if len(c) >= 2]``
+    # silently dropped every singleton, so a >50 parent community
+    # could lose 5–10 members from ``graph_clusters`` and any
+    # downstream ``community_total`` count would be off by that
+    # many.  Singletons by Louvain definition have no strong
+    # affinity to any sub-community, but they DO belong to the
+    # parent community — so we attach each one to whichever
+    # sized sub-community has the highest summed edge weight to it.
+    # Falls back to the first sized sub-community when the
+    # singleton has no internal edges at all (Louvain placed it
+    # alone for the modularity penalty, not the connectivity).
+    sub_member_index: dict[str, int] = {
+        member: idx
+        for idx, sub in enumerate(sized_sub_lists)
+        for member in sub
+    }
+    for singleton in singletons:
+        weight_per_sub: dict[int, float] = {}
+        for (src, tgt), weight in pair_weights.items():
+            if src == singleton and tgt in sub_member_index:
+                idx = sub_member_index[tgt]
+                weight_per_sub[idx] = weight_per_sub.get(idx, 0.0) + weight
+            elif tgt == singleton and src in sub_member_index:
+                idx = sub_member_index[src]
+                weight_per_sub[idx] = weight_per_sub.get(idx, 0.0) + weight
+        if weight_per_sub:
+            best_idx = max(weight_per_sub, key=weight_per_sub.get)
+        else:
+            best_idx = 0
+        sized_sub_lists[best_idx].append(singleton)
+        sized_sub_lists[best_idx].sort()
+    return sized_sub_lists
 
 
 def _build_graph_seeds(

--- a/tests/test_louvain_communities.py
+++ b/tests/test_louvain_communities.py
@@ -215,6 +215,67 @@ class TestDetectCommunities:
         if len(result) == 1:
             assert sorted(result[0]) == sorted(big)
 
+    def test_split_attaches_singletons_to_nearest_subcommunity(self):
+        """Pre-fix the splitter dropped any sub-Louvain singleton from
+        the output (``len(c) >= 2`` filter), so a >50-member parent
+        could lose a handful of members from ``graph_clusters`` and
+        downstream coverage / total counts would silently undercount.
+
+        New behaviour: each singleton attaches to whichever sized
+        sub-community has the most weighted edges to it.  The
+        sub-community count goes up by ≥1 over its members but every
+        original member appears somewhere in the output.
+        """
+        from ovp_pipeline.packs.research_tech.truth_projection import (
+            _split_if_too_big,
+        )
+
+        # Build a 60-node graph that Louvain will split into two
+        # tight sub-communities (a-half, b-half) plus a singleton ``s``
+        # that has weak ties to BOTH halves but is closer to the
+        # b-half.  Without singleton attach, ``s`` disappears from
+        # the output.
+        a_half = {f"a{i}" for i in range(28)}
+        b_half = {f"b{i}" for i in range(28)}
+        singleton = "s"
+        members = a_half | b_half | {singleton}
+        assert len(members) == 57  # > _SPLIT_THRESHOLD (50)
+
+        pair_weights: dict[tuple[str, str], float] = {}
+        # Strong intra-half edges so Louvain finds the two halves.
+        for halves in (a_half, b_half):
+            sorted_half = sorted(halves)
+            for i in range(len(sorted_half)):
+                for j in range(i + 1, len(sorted_half)):
+                    pair_weights[(sorted_half[i], sorted_half[j])] = 5.0
+        # Weak edges from ``s`` to both halves; the b-half edge is
+        # heavier so the singleton-attach must pick b-half.
+        pair_weights[("a0", singleton)] = 0.1
+        pair_weights[(singleton, "b0")] = 0.5
+        pair_weights[(singleton, "b1")] = 0.5
+
+        result = _split_if_too_big(members, pair_weights)
+
+        all_returned = {member for sub in result for member in sub}
+        assert singleton in all_returned, (
+            "singleton was dropped — pre-fix behaviour where "
+            "``len(c) >= 2`` filtered out sub-Louvain singletons"
+        )
+        assert all_returned == members, (
+            "every original member must appear in exactly one "
+            "sub-community"
+        )
+
+        # Singleton landed with the b-half (heavier weighted ties).
+        sub_with_singleton = next(sub for sub in result if singleton in sub)
+        b_overlap = len(set(sub_with_singleton) & b_half)
+        a_overlap = len(set(sub_with_singleton) & a_half)
+        assert b_overlap > a_overlap, (
+            "singleton should attach to the sub-community with "
+            "heavier weighted ties (b-half), got "
+            f"a_overlap={a_overlap} b_overlap={b_overlap}"
+        )
+
     def test_deterministic_with_seed(self):
         # Louvain is order-sensitive.  The fixed seed in the
         # production helper means the same edge set yields the same


### PR DESCRIPTION
## Summary

The big-community splitter dropped sub-Louvain singletons via a ``len(c) >= 2`` filter, so a >50-member parent that split into a few sub-groups plus a handful of singletons silently lost those singletons from ``graph_clusters``.  Coverage and total counts undercounted accordingly.

## How the fix is shaped

When sub-Louvain returns ≥ 1 sub-community of size ≥ 2 AND ≥ 1 singleton:

- Attach each singleton to whichever sized sub-community has the highest summed weighted edges to it.
- Fall back to the first sized sub-community when the singleton has no internal edges at all (Louvain isolated it on modularity grounds, not disconnection).

Every original parent-community member now appears in exactly one output sub-community.

The whole-community-kept and single-sub-community paths keep their existing behaviour.

## Test plan

- [x] New ``test_split_attaches_singletons_to_nearest_subcommunity`` — pins the attach logic + heaviest-tie selection
- [x] ``tests/test_louvain_communities.py`` 11/11
- [x] Full suite: 2134/2134

Review: BL-058 follow-up — second batch low/medium finding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graph clustering to better preserve all members when splitting large communities, reducing data loss.
  * Enhanced attachment of isolated nodes to nearest clusters based on connection strength for more accurate results.

* **Tests**
  * Added test coverage for singleton node handling in graph clustering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->