### PR TITLE
fix(crystals): surface source_diversity in atlas explanation; emit crystal reuse events

### DIFF
--- a/src/ovp_pipeline/commands/_ui_renderers.py
+++ b/src/ovp_pipeline/commands/_ui_renderers.py
@@ -2632,6 +2632,7 @@ def _render_curated_atlas_page(payload: dict) -> str:
             breakdown = (
                 f"size {float(entry.get('size_norm', 0)):.2f} · "
                 f"credibility {float(entry.get('credibility_norm', 0)):.2f} · "
+                f"source-diversity {float(entry.get('source_diversity_norm', 0)):.2f} · "
                 f"contradiction {float(entry.get('contradiction_norm', 0)):.2f} · "
                 f"reuse-recency {float(entry.get('reuse_recency_norm', 0)):.2f} · "
                 f"evergreen-recency {float(entry.get('evergreen_recency_norm', 0)):.2f}"

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -117,6 +117,77 @@ from ._ui_renderers import (  # noqa: F401 — all renderers
 )
 
 
+_CRYSTAL_NOTE_PREFIX = "40-Resources/Crystals/"
+
+
+def _crystal_kind_and_id_from_note_path(relative_path: str) -> tuple[str, str] | None:
+    """Reverse-derive ``(crystal_kind, crystal_id)`` from a Reader
+    note path under ``40-Resources/Crystals/``.
+
+    File-name conventions (mirrors ``synthesis/_versioning.py`` +
+    ``synthesis/contradiction_crystal.py``):
+
+      * community crystal:    ``<safe-id>.md`` →
+            crystal_kind = ``community_crystal``,
+            crystal_id   = ``cluster::<safe-id>``
+      * contradiction crystal: ``contradiction-<safe-id>.md`` →
+            crystal_kind = ``contradiction_crystal``,
+            crystal_id   = ``contradiction::<safe-id>``
+
+    Returns ``None`` for anything else so the caller short-circuits
+    without writing a stray reuse event.
+    """
+    rel = relative_path.replace("\\", "/").lstrip("./")
+    if not rel.startswith(_CRYSTAL_NOTE_PREFIX):
+        return None
+    stem = rel[len(_CRYSTAL_NOTE_PREFIX):]
+    if not stem.endswith(".md"):
+        return None
+    stem = stem[:-len(".md")]
+    if not stem:
+        return None
+    if stem.startswith("contradiction-"):
+        safe_id = stem[len("contradiction-"):]
+        if not safe_id:
+            return None
+        return ("contradiction_crystal", f"contradiction::{safe_id}")
+    return ("community_crystal", f"cluster::{stem}")
+
+
+def _maybe_emit_crystal_note_reuse(
+    vault_dir, relative_path: str, pack_name: str | None,
+) -> None:
+    """Best-effort: when a Reader ``/note?path=`` request resolves a
+    synthesized-crystal markdown, write a ``reuse_events`` row so
+    ``crystal_scoring._reuse_recency_signal`` has a producer.
+
+    Pre-fix, the only producer for crystal-kind reuse events was
+    test-fixture seeds, so the ``reuse_recency_norm`` weight in the
+    default scoring formula contributed exactly zero in production
+    no matter how often a topic was opened.
+    """
+    derived = _crystal_kind_and_id_from_note_path(relative_path)
+    if derived is None:
+        return
+    try:
+        from ..reuse_emitter import emit_crystal_reuse_events
+        emit_crystal_reuse_events(
+            vault_dir,
+            pack=(pack_name or DEFAULT_PACK_NAME),
+            crystals=[derived],
+            surface="reader_note",
+            consumer_ref=relative_path,
+        )
+    except Exception as exc:  # noqa: BLE001 — best-effort instrumentation
+        # Log so a regression in the emitter doesn't get
+        # swallowed silently — see test_no_silent_imports.
+        print(
+            f"[ui_server] crystal reuse-event emission failed for "
+            f"/note?path={relative_path}: {exc}",
+            file=sys.stderr,
+        )
+
+
 def _parse_optional_int(query: dict[str, list[str]], key: str) -> int | None:
     """Read an optional integer query param.  Returns ``None`` for an
     absent / empty / non-numeric value so the downstream payload
@@ -754,6 +825,12 @@ def create_server(
                     _, markdown = _read_vault_note(resolved_vault, relative_path)
                     payload = build_note_page_payload(
                         resolved_vault, note_path=relative_path, pack_name=pack_name
+                    )
+                    # BL-058 follow-up: when the note is a synthesized
+                    # crystal, emit a reuse event so crystal_scoring's
+                    # ``reuse_recency_norm`` has a producer.  Best-effort.
+                    _maybe_emit_crystal_note_reuse(
+                        resolved_vault, relative_path, pack_name,
                     )
                     self._write_html(
                         _render_note_page(resolved_vault, relative_path, markdown, payload)

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -155,7 +155,7 @@ def _crystal_kind_and_id_from_note_path(relative_path: str) -> tuple[str, str] |
 
 
 def _maybe_emit_crystal_note_reuse(
-    vault_dir, relative_path: str, pack_name: str | None,
+    vault_dir: Path | str, relative_path: str, pack_name: str | None,
 ) -> None:
     """Best-effort: when a Reader ``/note?path=`` request resolves a
     synthesized-crystal markdown, write a ``reuse_events`` row so

--- a/src/ovp_pipeline/reuse_emitter.py
+++ b/src/ovp_pipeline/reuse_emitter.py
@@ -319,12 +319,14 @@ def emit_crystal_reuse_events(
     production regardless of actual user activity.
 
     ``crystals`` is an iterable of ``(crystal_kind, crystal_id)``
-    tuples where ``crystal_kind`` is one of the
-    ``_CRYSTAL_REUSE_KINDS`` values
-    (``community_crystal`` / ``contradiction_crystal``).  We
-    write the event directly without any objects-table resolution
-    so this function works even before any of the
-    ``crystal_scoring`` plumbing has run.
+    tuples where ``crystal_kind`` is one of the values in the
+    function-local ``valid_kinds`` set (``community_crystal`` /
+    ``contradiction_crystal``).  These match the ``object_kind``
+    values ``crystal_scoring._reuse_recency_signal`` filters on
+    (see ``crystal_scoring._CRYSTAL_REUSE_KINDS``).  We write the
+    event directly without any objects-table resolution so this
+    function works even before any of the ``crystal_scoring``
+    plumbing has run.
 
     ``evidence_present`` and ``provenance_clean`` are pinned to
     1/1 — every crystal currently in the table is by definition

--- a/src/ovp_pipeline/reuse_emitter.py
+++ b/src/ovp_pipeline/reuse_emitter.py
@@ -298,6 +298,77 @@ def emit_reuse_events(
     return emitted
 
 
+def emit_crystal_reuse_events(
+    vault_dir: Path | str,
+    *,
+    pack: str,
+    crystals: Iterable[tuple[str, str]],
+    surface: str,
+    consumer_ref: str = "",
+    session_id: str | None = None,
+    extra_payload: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    """Emit reuse events for synthesized crystals.
+
+    Crystals don't live in the ``objects`` table — they live in
+    ``community_crystals`` / ``contradiction_crystals`` — so the
+    standard ``emit_reuse_events*`` resolvers can't reach them.
+    Without a producer, ``crystal_scoring._reuse_recency_signal``
+    permanently reads ``reuse_events`` rows that never get written
+    and the ``reuse_recency_norm`` signal stays cold-zero in
+    production regardless of actual user activity.
+
+    ``crystals`` is an iterable of ``(crystal_kind, crystal_id)``
+    tuples where ``crystal_kind`` is one of the
+    ``_CRYSTAL_REUSE_KINDS`` values
+    (``community_crystal`` / ``contradiction_crystal``).  We
+    write the event directly without any objects-table resolution
+    so this function works even before any of the
+    ``crystal_scoring`` plumbing has run.
+
+    ``evidence_present`` and ``provenance_clean`` are pinned to
+    1/1 — every crystal currently in the table is by definition
+    a "trusted" synthesis (LLM-produced from canonical objects with
+    full lineage) so the credibility-of-the-feedback signal is on
+    for the same reason a query that hits a green-circle evergreen
+    counts as trusted reuse.
+    """
+    valid_kinds = {"community_crystal", "contradiction_crystal"}
+    seen: set[tuple[str, str]] = set()
+    rows: list[tuple[str, str]] = []
+    for kind, crystal_id in crystals:
+        kind_str = str(kind or "")
+        id_str = str(crystal_id or "")
+        if kind_str not in valid_kinds or not id_str:
+            continue
+        key = (kind_str, id_str)
+        if key in seen:
+            continue
+        seen.add(key)
+        rows.append(key)
+    if not rows:
+        return []
+
+    emitted: list[dict[str, Any]] = []
+    for kind_str, id_str in rows:
+        emitted.append(
+            _write_event(
+                vault_dir,
+                pack=pack,
+                object_id=id_str,
+                object_kind=kind_str,
+                source_slug="",
+                surface=surface,
+                consumer_ref=consumer_ref,
+                evidence_present=True,
+                provenance_clean=True,
+                session_id=session_id,
+                extra_payload=extra_payload,
+            )
+        )
+    return emitted
+
+
 def emit_reuse_events_for_object_ids(
     vault_dir: Path | str,
     *,

--- a/src/ovp_pipeline/synthesis/curated_atlas.py
+++ b/src/ovp_pipeline/synthesis/curated_atlas.py
@@ -71,6 +71,13 @@ class CuratedEntry:
     contradiction_norm: float
     reuse_recency_norm: float
     evergreen_recency_norm: float
+    # BL-054: source-diversity is a 0.20-weighted signal in the
+    # default scoring formula, but it was missing from the entry
+    # plumbing — the markdown breakdown / atlas HTML / /topics
+    # JSON all rendered "size + credibility + contradiction +
+    # reuse + recency" leaving a 20% gap in the displayed
+    # explanation that didn't add up to the final ``score``.
+    source_diversity_norm: float
     teaser: str
     source_slugs: tuple[str, ...]
 
@@ -159,7 +166,7 @@ def _load_top_n(
         SELECT cs.crystal_id, 'community' AS kind, gc.label,
                cs.score, cs.size_norm, cs.credibility_norm,
                cs.contradiction_norm, cs.reuse_recency_norm,
-               cs.evergreen_recency_norm,
+               cs.evergreen_recency_norm, cs.source_diversity_norm,
                cc.body_md, cc.source_evergreen_slugs_json
           FROM crystal_scores cs
           JOIN community_crystals cc
@@ -179,8 +186,8 @@ def _load_top_n(
             "crystal_id": r[0], "kind": r[1], "label": r[2],
             "score": r[3], "size_norm": r[4], "credibility_norm": r[5],
             "contradiction_norm": r[6], "reuse_recency_norm": r[7],
-            "evergreen_recency_norm": r[8],
-            "body_md": r[9], "source_slugs_json": r[10],
+            "evergreen_recency_norm": r[8], "source_diversity_norm": r[9],
+            "body_md": r[10], "source_slugs_json": r[11],
         })
 
     # Contradiction crystals — different body table; ``label`` is
@@ -190,7 +197,7 @@ def _load_top_n(
         SELECT cs.crystal_id, 'contradiction' AS kind, cc.subject_key,
                cs.score, cs.size_norm, cs.credibility_norm,
                cs.contradiction_norm, cs.reuse_recency_norm,
-               cs.evergreen_recency_norm,
+               cs.evergreen_recency_norm, cs.source_diversity_norm,
                cc.body_md, cc.source_object_ids_json
           FROM crystal_scores cs
           JOIN contradiction_crystals cc
@@ -208,8 +215,8 @@ def _load_top_n(
             "crystal_id": r[0], "kind": r[1], "label": r[2],
             "score": r[3], "size_norm": r[4], "credibility_norm": r[5],
             "contradiction_norm": r[6], "reuse_recency_norm": r[7],
-            "evergreen_recency_norm": r[8],
-            "body_md": r[9], "source_slugs_json": r[10],
+            "evergreen_recency_norm": r[8], "source_diversity_norm": r[9],
+            "body_md": r[10], "source_slugs_json": r[11],
         })
 
     rows.sort(key=lambda r: -r["score"])
@@ -255,6 +262,7 @@ def build_curated_atlas(
             contradiction_norm=float(row["contradiction_norm"]),
             reuse_recency_norm=float(row["reuse_recency_norm"]),
             evergreen_recency_norm=float(row["evergreen_recency_norm"]),
+            source_diversity_norm=float(row.get("source_diversity_norm", 0.0)),
             teaser=_extract_teaser(row["body_md"] or ""),
             source_slugs=slugs,
         ))
@@ -357,6 +365,7 @@ def render_curated_atlas_markdown(atlas: CuratedAtlas) -> str:
             f"- score breakdown: "
             f"size {entry.size_norm:.2f} · "
             f"credibility {entry.credibility_norm:.2f} · "
+            f"source-diversity {entry.source_diversity_norm:.2f} · "
             f"contradiction {entry.contradiction_norm:.2f} · "
             f"reuse-recency {entry.reuse_recency_norm:.2f} · "
             f"evergreen-recency {entry.evergreen_recency_norm:.2f}",

--- a/src/ovp_pipeline/ui/view_models.py
+++ b/src/ovp_pipeline/ui/view_models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import math
 import re
 import sqlite3
@@ -8,6 +9,8 @@ from collections import Counter
 from pathlib import Path
 from typing import Any
 from urllib.parse import quote
+
+logger = logging.getLogger(__name__)
 
 from ..assembly_recipe_registry import describe_assembly_recipe_contract
 from ..governance_registry import describe_governance_contract
@@ -4447,6 +4450,7 @@ def build_curated_atlas_payload(
                 "score": round(entry.score, 4),
                 "size_norm": round(entry.size_norm, 3),
                 "credibility_norm": round(entry.credibility_norm, 3),
+                "source_diversity_norm": round(entry.source_diversity_norm, 3),
                 "contradiction_norm": round(entry.contradiction_norm, 3),
                 "reuse_recency_norm": round(entry.reuse_recency_norm, 3),
                 "evergreen_recency_norm": round(entry.evergreen_recency_norm, 3),
@@ -4459,6 +4463,34 @@ def build_curated_atlas_payload(
                 ),
             }
         )
+
+    # Emit one reuse event per displayed crystal so the
+    # ``reuse_recency_norm`` signal in ``crystal_scoring`` actually
+    # has a producer.  Pre-fix the signal stayed cold-zero because no
+    # surface ever wrote ``reuse_events`` rows with
+    # ``object_kind in ('community_crystal', 'contradiction_crystal')``.
+    # Best-effort — a JSONL-append failure must not block the
+    # /topics page from rendering.
+    if entries:
+        try:
+            from ..reuse_emitter import emit_crystal_reuse_events
+            emit_crystal_reuse_events(
+                vault_dir,
+                pack=pack,
+                crystals=[
+                    (
+                        f"{entry['crystal_kind']}_crystal",
+                        str(entry["crystal_id"]),
+                    )
+                    for entry in entries
+                ],
+                surface="atlas",
+                consumer_ref=f"top_n={atlas.top_n}",
+            )
+        except Exception as exc:  # noqa: BLE001 — best-effort instrumentation
+            logger.warning(
+                "crystal reuse-event emission failed for /topics: %s", exc,
+            )
 
     return {
         "screen": "atlas/curated",

--- a/tests/test_crystal_note_reuse.py
+++ b/tests/test_crystal_note_reuse.py
@@ -1,0 +1,117 @@
+"""Tests for the BL-058 follow-up: crystal-note reuse-event emit.
+
+The Reader's ``/note?path=40-Resources/Crystals/<id>.md`` route now
+emits a ``reuse_events`` row keyed by ``object_kind=community_crystal``
+or ``contradiction_crystal``, so ``crystal_scoring._reuse_recency_signal``
+finally has a producer.  Pre-fix the only producer was test-fixture
+seeds and the signal stayed cold-zero in production.
+
+Two layers:
+
+1. ``_crystal_kind_and_id_from_note_path`` — pure path parser.
+2. ``_maybe_emit_crystal_note_reuse`` — best-effort emit; non-crystal
+   paths are no-ops and emitter failures don't bubble up.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Path → (kind, id) parser
+# ---------------------------------------------------------------------------
+
+
+class TestCrystalKindAndIdFromNotePath:
+    @pytest.mark.parametrize("path, expected", [
+        # Community crystal lives at 40-Resources/Crystals/<safe-id>.md.
+        (
+            "40-Resources/Crystals/abc12345.md",
+            ("community_crystal", "cluster::abc12345"),
+        ),
+        # Contradiction crystal has the ``contradiction-`` prefix on
+        # the filename — round-trips back to the ``contradiction::``
+        # crystal_id.
+        (
+            "40-Resources/Crystals/contradiction-xy789.md",
+            ("contradiction_crystal", "contradiction::xy789"),
+        ),
+        # Leading ``./`` is tolerated.
+        (
+            "./40-Resources/Crystals/foo-bar.md",
+            ("community_crystal", "cluster::foo-bar"),
+        ),
+    ])
+    def test_recognises_crystal_paths(self, path, expected):
+        from ovp_pipeline.commands.ui_server import (
+            _crystal_kind_and_id_from_note_path,
+        )
+        assert _crystal_kind_and_id_from_note_path(path) == expected
+
+    @pytest.mark.parametrize("path", [
+        # Anywhere outside 40-Resources/Crystals/ → no emit.
+        "10-Knowledge/Evergreen/some-note.md",
+        "20-Areas/AI/note.md",
+        "60-Logs/pipeline.jsonl",
+        # The directory itself, no filename → no emit.
+        "40-Resources/Crystals/",
+        # Wrong extension.
+        "40-Resources/Crystals/abc.txt",
+        # Just the contradiction-prefix with empty stem.
+        "40-Resources/Crystals/contradiction-.md",
+        # Empty.
+        "",
+    ])
+    def test_rejects_non_crystal_paths(self, path):
+        from ovp_pipeline.commands.ui_server import (
+            _crystal_kind_and_id_from_note_path,
+        )
+        assert _crystal_kind_and_id_from_note_path(path) is None
+
+
+# ---------------------------------------------------------------------------
+# Best-effort emit — non-crystal paths are no-ops, errors don't bubble
+# ---------------------------------------------------------------------------
+
+
+class TestMaybeEmitCrystalNoteReuse:
+    def test_emits_reuse_event_for_crystal_path(self, temp_vault):
+        from ovp_pipeline.commands.ui_server import (
+            _maybe_emit_crystal_note_reuse,
+        )
+
+        _maybe_emit_crystal_note_reuse(
+            temp_vault,
+            "40-Resources/Crystals/abcdef.md",
+            pack_name="research-tech",
+        )
+        # JSONL append went through.
+        log = temp_vault / "60-Logs" / "reuse-events.jsonl"
+        assert log.exists(), "reuse-events.jsonl should be written"
+        events = [json.loads(line) for line in log.read_text("utf-8").splitlines()]
+        assert len(events) == 1
+        e = events[0]
+        assert e["object_kind"] == "community_crystal"
+        assert e["object_id"] == "cluster::abcdef"
+        assert e["surface"] == "reader_note"
+        assert e["consumer_ref"] == "40-Resources/Crystals/abcdef.md"
+
+    def test_no_op_for_non_crystal_path(self, temp_vault):
+        from ovp_pipeline.commands.ui_server import (
+            _maybe_emit_crystal_note_reuse,
+        )
+
+        _maybe_emit_crystal_note_reuse(
+            temp_vault,
+            "10-Knowledge/Evergreen/regular.md",
+            pack_name="research-tech",
+        )
+        log = temp_vault / "60-Logs" / "reuse-events.jsonl"
+        # Either the file doesn't exist or it's empty — but no crystal
+        # row was written.
+        if log.exists():
+            content = log.read_text("utf-8").strip()
+            assert content == "" or "object_kind" not in content

--- a/tests/test_curated_atlas.py
+++ b/tests/test_curated_atlas.py
@@ -328,6 +328,7 @@ class TestRenderCuratedAtlasMarkdown:
             label="L", score=0.5,
             size_norm=0.5, credibility_norm=0.5, contradiction_norm=0.5,
             reuse_recency_norm=0.0, evergreen_recency_norm=0.5,
+            source_diversity_norm=0.5,
             teaser="Teaser sentence.", source_slugs=("a",),
         )])
         md = render_curated_atlas_markdown(atlas)
@@ -348,6 +349,7 @@ class TestRenderCuratedAtlasMarkdown:
             score=0.789,
             size_norm=0.95, credibility_norm=0.78, contradiction_norm=0.50,
             reuse_recency_norm=0.0, evergreen_recency_norm=0.81,
+            source_diversity_norm=0.62,
             teaser="The teaser sentence.", source_slugs=("a", "b"),
         )])
         md = render_curated_atlas_markdown(atlas)
@@ -356,6 +358,12 @@ class TestRenderCuratedAtlasMarkdown:
         # Score breakdown line shows every signal value.
         assert "size 0.95" in md
         assert "credibility 0.78" in md
+        # BL-058 follow-up: source_diversity is a 20%-weighted signal
+        # in the default formula and must be visible in the
+        # human-readable explanation, otherwise the breakdown doesn't
+        # add up to ``score`` and the user has no way to ask "why is
+        # this topic ranked here".
+        assert "source-diversity 0.62" in md
         assert "contradiction 0.50" in md
         # Teaser appears in the body.
         assert "The teaser sentence." in md
@@ -369,6 +377,7 @@ class TestRenderCuratedAtlasMarkdown:
             label="Memory: stored vs emergent", score=0.65,
             size_norm=0.4, credibility_norm=0.3, contradiction_norm=1.0,
             reuse_recency_norm=0.0, evergreen_recency_norm=0.5,
+            source_diversity_norm=0.4,
             teaser="The contradiction teaser.",
             source_slugs=("a", "b"),
         )])

--- a/tests/test_reuse_events.py
+++ b/tests/test_reuse_events.py
@@ -251,6 +251,46 @@ def test_emit_reuse_events_marks_untrusted_when_broken_link_recent(temp_vault):
     assert events[0]["trusted"] == 0
 
 
+def test_emit_crystal_reuse_events_writes_jsonl_with_crystal_kinds(temp_vault):
+    """BL-058 follow-up: ``crystal_scoring._reuse_recency_signal``
+    reads ``reuse_events`` rows with
+    ``object_kind in {community_crystal, contradiction_crystal}``
+    but no surface emitted any.  ``emit_crystal_reuse_events``
+    bypasses the objects-table resolver (crystals don't live there)
+    and writes the row directly so the signal has a real producer.
+    """
+    from ovp_pipeline.reuse_emitter import emit_crystal_reuse_events
+
+    events = emit_crystal_reuse_events(
+        temp_vault,
+        pack="research-tech",
+        crystals=[
+            ("community_crystal", "cluster::aaa"),
+            ("contradiction_crystal", "contradiction::bbb"),
+            # Duplicate — must be deduped to a single event.
+            ("community_crystal", "cluster::aaa"),
+            # Invalid kind — silently dropped.
+            ("not_a_crystal", "ignore"),
+            # Empty id — dropped.
+            ("community_crystal", ""),
+        ],
+        surface="atlas",
+        consumer_ref="top_n=30",
+    )
+    assert len(events) == 2
+    by_id = {e["object_id"]: e for e in events}
+    assert by_id["cluster::aaa"]["object_kind"] == "community_crystal"
+    assert by_id["contradiction::bbb"]["object_kind"] == "contradiction_crystal"
+    # ``trusted`` is pinned to 1 because every crystal in the table
+    # is by definition a synthesized artifact with full lineage.
+    for e in events:
+        assert e["evidence_present"] == 1
+        assert e["provenance_clean"] == 1
+        assert e["trusted"] == 1
+        assert e["surface"] == "atlas"
+        assert e["consumer_ref"] == "top_n=30"
+
+
 def test_extract_cited_slugs_orders_and_deduplicates():
     from ovp_pipeline.reuse_emitter import extract_cited_slugs
 


### PR DESCRIPTION
## Summary

Two related gaps in the M14 crystal-scoring feedback loop, fixed together because they touch the same atlas / crystal-scoring chain.

### 1. Atlas score breakdown didn't add up

``crystal_scoring`` weights ``source_diversity_norm`` at 20% (BL-054), but the breakdown rendered to users on /topics, the markdown export, and the JSON payload only listed:

    size + credibility + contradiction + reuse + recency

That's 80% of the weights — the displayed explanation couldn't reconcile with the final ``score``.  Threaded ``source_diversity_norm`` through ``CuratedEntry`` → SELECT → markdown renderer → /topics JSON → HTML breakdown.

### 2. Crystal reuse_events had no producer

``crystal_scoring._reuse_recency_signal`` reads rows with ``object_kind in {community_crystal, contradiction_crystal}`` but ``reuse_emitter`` only resolves via the ``objects`` table (crystals don't live there).  Net result in production: the 15%-weighted reuse-recency signal was always zero.

- New ``emit_crystal_reuse_events`` writes the row directly with the crystal's own ``object_id``.
- ``build_curated_atlas_payload`` emits one event per displayed crystal (``surface="atlas"``).
- The Reader's ``/note?path=40-Resources/Crystals/<id>.md`` route emits a single event (``surface="reader_note"``).  New ``_crystal_kind_and_id_from_note_path`` reverse-derives ``(kind, id)`` from the on-disk filename.

Both emit sites are best-effort and logged so a JSONL append failure can't crash the page render or trip the no-silent-import ratchet.

## Test plan

- [x] New ``tests/test_crystal_note_reuse.py`` (9 tests) — pure path parser + positive/negative emit
- [x] ``test_emit_crystal_reuse_events_writes_jsonl_with_crystal_kinds`` — emitter dedupe/validation/trusted-flag
- [x] ``test_curated_atlas`` updated for ``source_diversity_norm`` field; pins ``source-diversity 0.62`` in the breakdown line
- [x] Full suite: 2146/2146

Review: BL-058 follow-up — second batch medium findings (atlas explanation + reuse-feedback producer).