### PR TITLE
refactor(shared): consolidate crystal helpers + extract _permanent_redirect

### DIFF
--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -251,6 +251,35 @@ def create_server(
         def log_message(self, format: str, *args) -> None:  # pragma: no cover
             return
 
+        def _permanent_redirect(self, status: int, target: str) -> None:
+            """Send a permanent redirect with the standard headers.
+
+            The status-method-body contract here is load-bearing:
+
+              * ``301`` for GETs — browsers update bookmarks.
+              * ``308`` for POSTs — preserves method + body so a
+                form submission is reissued, not silently demoted
+                to a GET.
+
+            Pre-fix this 4-line response was copy-pasted across
+            three sites and a regression that swapped 308→301 on a
+            POST path would silently destroy form submissions.
+            ``Cache-Control: no-store`` is included on every
+            redirect so an upstream proxy can't shortcut the new
+            target.
+            """
+            self.send_response(status)
+            self.send_header("Location", target)
+            self.send_header("Cache-Control", "no-store")
+            self.end_headers()
+
+        def _legacy_target(self, parsed) -> str:
+            """Compose ``/ops/<same>?<query>`` for a legacy path."""
+            target = "/ops" + parsed.path
+            if parsed.query:
+                target = f"{target}?{parsed.query}"
+            return target
+
         def do_GET(self) -> None:  # noqa: N802
             parsed = urlparse(self.path)
             path = parsed.path
@@ -259,13 +288,7 @@ def create_server(
             # BL-050: legacy maintainer paths → 301 to /ops/<same>.
             # Preserves any existing query string verbatim.
             if path in _LEGACY_MAINTAINER_PATHS:
-                target = "/ops" + path
-                if parsed.query:
-                    target = f"{target}?{parsed.query}"
-                self.send_response(301)
-                self.send_header("Location", target)
-                self.send_header("Cache-Control", "no-store")
-                self.end_headers()
+                self._permanent_redirect(301, self._legacy_target(parsed))
                 return
 
             # BL-050: shell selection is decided by URL prefix.  The
@@ -600,10 +623,7 @@ def create_server(
                     target = "/api/topics" if path.startswith("/api/") else "/topics"
                     if parsed.query:
                         target = f"{target}?{parsed.query}"
-                    self.send_response(301)
-                    self.send_header("Location", target)
-                    self.send_header("Cache-Control", "no-store")
-                    self.end_headers()
+                    self._permanent_redirect(301, target)
                     return
                 if path == "/api/topics":
                     pack_name = query.get("pack", [""])[0] or None
@@ -968,13 +988,7 @@ def create_server(
             # BL-050: legacy maintainer POST paths → 308 to preserve
             # method + body during the redirect (301 would force GET).
             if path in _LEGACY_MAINTAINER_PATHS:
-                target = "/ops" + path
-                if parsed.query:
-                    target = f"{target}?{parsed.query}"
-                self.send_response(308)
-                self.send_header("Location", target)
-                self.send_header("Cache-Control", "no-store")
-                self.end_headers()
+                self._permanent_redirect(308, self._legacy_target(parsed))
                 return
 
             set_request_path(path)

--- a/src/ovp_pipeline/synthesis/_shared.py
+++ b/src/ovp_pipeline/synthesis/_shared.py
@@ -27,6 +27,54 @@ CRYSTAL_DIR_REL: Path = Path("40-Resources") / "Crystals"
 _OBJECTS_LOOKUP_CHUNK = 500
 
 
+def crystal_safe_id(crystal_kind: str, crystal_id: str) -> str:
+    """Translate a ``crystal_id`` into the on-disk filename stem.
+
+    Pre-fix this prefix-stripping logic was duplicated across
+    ``curated_atlas._crystal_safe_id``, ``community_crystal._safe_id``,
+    ``crystal_fts._community_safe_id`` / ``_contradiction_safe_id``,
+    and ``ui.view_models``'s inline ``_safe_id`` helper.  Single source
+    of truth here so a future rename of the ID format only edits one
+    file.
+
+    Conventions:
+      * ``community`` crystals: ``cluster::<digest>`` →
+        ``<digest>`` (file lives at ``<safe-id>.md``).
+      * ``contradiction`` crystals: ``contradiction::<digest>`` →
+        ``contradiction-<digest>`` (file lives at
+        ``contradiction-<safe-id>.md``, single-prefix convention so
+        the directory listing groups them).
+      * Anything else passes through unchanged — defensive default
+        matches the historical behaviour of the duplicated helpers.
+    """
+    if crystal_kind == "community" and crystal_id.startswith("cluster::"):
+        return crystal_id[len("cluster::"):]
+    if crystal_kind == "contradiction" and crystal_id.startswith("contradiction::"):
+        return f"contradiction-{crystal_id[len('contradiction::'):]}"
+    return crystal_id
+
+
+def related_notes_section(slugs: tuple[str, ...] | list[str]) -> str:
+    """Render the ``## 相关笔记`` block both crystal modules append
+    to their bodies.
+
+    Pre-fix this was duplicated between
+    ``community_crystal._related_notes_section`` and
+    ``contradiction_crystal._related_notes_section`` — identical
+    bodies, twice the surface area to keep in sync if the format
+    ever changes.
+
+    Source-note backlinks are deterministic by construction here
+    (the LLM used to drop them ~30% of the time when asked to cite
+    in prose), so the Obsidian backlink graph stays sane regardless
+    of prompt drift.
+    """
+    lines = ["## 相关笔记", ""]
+    for slug in slugs:
+        lines.append(f"- [[{slug}]]")
+    return "\n".join(lines)
+
+
 def strip_frontmatter(text: str) -> str:
     """Remove the YAML frontmatter block from an evergreen markdown.
 

--- a/src/ovp_pipeline/synthesis/_shared.py
+++ b/src/ovp_pipeline/synthesis/_shared.py
@@ -41,9 +41,9 @@ def crystal_safe_id(crystal_kind: str, crystal_id: str) -> str:
       * ``community`` crystals: ``cluster::<digest>`` →
         ``<digest>`` (file lives at ``<safe-id>.md``).
       * ``contradiction`` crystals: ``contradiction::<digest>`` →
-        ``contradiction-<digest>`` (file lives at
-        ``contradiction-<safe-id>.md``, single-prefix convention so
-        the directory listing groups them).
+        ``contradiction-<digest>`` (the returned safe-id already
+        carries the ``contradiction-`` prefix, so the on-disk
+        filename is ``<safe-id>.md`` — single prefix, not double).
       * Anything else passes through unchanged — defensive default
         matches the historical behaviour of the duplicated helpers.
     """

--- a/src/ovp_pipeline/synthesis/community_crystal.py
+++ b/src/ovp_pipeline/synthesis/community_crystal.py
@@ -27,20 +27,15 @@ from typing import Iterable, Protocol
 from ..projection_labels import frontmatter_projection_fields
 from ._shared import (
     CRYSTAL_DIR_REL,
+    crystal_safe_id,
     load_evergreen_bodies,
     load_objects_subset,
+    related_notes_section,
     strip_frontmatter,
 )
 from ._versioning import ARCHIVE_DIR_REL, commit_crystal_version
 
 logger = logging.getLogger(__name__)
-
-# Backwards-compat aliases for tests that imported the underscored
-# names before the helpers moved to ``_shared.py``.  External callers
-# should prefer the un-prefixed surface in ``_shared``.
-_strip_frontmatter = strip_frontmatter
-_load_evergreen_bodies = load_evergreen_bodies
-_load_objects_subset = load_objects_subset
 
 
 # ----- Constants ------------------------------------------------------
@@ -269,18 +264,13 @@ def _frontmatter(
 
 
 def _safe_id(cluster_id: str) -> str:
-    """Strip the ``cluster::`` prefix so the result is safe as a
-    filename (Windows refuses ``:``; macOS Finder rewrites it
-    silently).  The remainder is a 12-char SHA1 digest, safe by
-    construction.
+    """Thin shim over :func:`crystal_safe_id` for community crystals.
 
-    Used both for the live filename (``<safe-id>.md``) and the
-    archive subdirectory (``70-Archive/Crystals/<safe-id>/...``) —
-    one source of truth for the safe form.
+    Kept as a private helper so existing call sites stay readable —
+    the equivalent of ``crystal_safe_id("community", cluster_id)``
+    but with the kind already pinned.
     """
-    if cluster_id.startswith("cluster::"):
-        return cluster_id[len("cluster::"):]
-    return cluster_id
+    return crystal_safe_id("community", cluster_id)
 
 
 def _crystal_filename(cluster_id: str) -> str:
@@ -302,18 +292,10 @@ def _sampling_disclosure(*, sample_size: int, community_total: int) -> str:
     )
 
 
-def _related_notes_section(slugs: tuple[str, ...]) -> str:
-    """Machine-generated ``## 相关笔记`` section appended to every
-    crystal body.  Pre-fix wikilinks to source notes were optional
-    and the LLM dropped them ~30% of the time, breaking Obsidian
-    backlinks.  This section makes the source-note linkage
-    deterministic — the LLM can still cite naturally in prose,
-    but the backlink graph is no longer prompt-dependent.
-    """
-    lines = ["## 相关笔记", ""]
-    for slug in slugs:
-        lines.append(f"- [[{slug}]]")
-    return "\n".join(lines)
+# ``_related_notes_section`` lived here as a duplicate of
+# ``contradiction_crystal._related_notes_section``.  The shared
+# implementation lives in ``_shared.related_notes_section`` now;
+# call sites import that directly.
 
 
 def render_crystal_markdown(
@@ -335,7 +317,7 @@ def render_crystal_markdown(
         parts.append("")  # blank line between disclosure and body
     parts.append(crystal.body_md.rstrip())
     parts.append("")  # blank line between body and related-notes
-    parts.append(_related_notes_section(crystal.source_evergreen_slugs))
+    parts.append(related_notes_section(crystal.source_evergreen_slugs))
     return "\n".join(parts) + "\n"
 
 
@@ -426,13 +408,13 @@ def synthesize_community_crystals(
             decoded.append((cluster_id, label, picked, community_total))
             needed_object_ids.update(picked)
 
-        objects_by_id = _load_objects_subset(
+        objects_by_id = load_objects_subset(
             conn, pack_name, needed_object_ids,
         )
 
         out: list[CommunityCrystal] = []
         for cluster_id, label, picked, community_total in decoded:
-            evergreens = _load_evergreen_bodies(
+            evergreens = load_evergreen_bodies(
                 vault_dir, member_object_ids=picked,
                 objects_by_id=objects_by_id,
             )

--- a/src/ovp_pipeline/synthesis/contradiction_crystal.py
+++ b/src/ovp_pipeline/synthesis/contradiction_crystal.py
@@ -37,8 +37,10 @@ from typing import Protocol
 from ..projection_labels import frontmatter_projection_fields
 from ._shared import (
     CRYSTAL_DIR_REL,
+    crystal_safe_id,
     load_evergreen_bodies,
     load_objects_subset,
+    related_notes_section,
 )
 from ._versioning import ARCHIVE_DIR_REL, commit_crystal_version
 
@@ -305,16 +307,16 @@ def _frontmatter(crystal: ContradictionCrystal) -> str:
 
 
 def _safe_id(contradiction_id: str) -> str:
-    """Strips the unportable ``::`` prefix and prefixes
-    ``contradiction-`` so the directory listing makes the kind
-    obvious at a glance (community crystals at ``<sha>.md`` vs
-    contradiction crystals at ``contradiction-<sha>.md``).
-
-    Used both for the live filename (``<safe-id>.md``) and the
-    archive subdirectory (``70-Archive/Crystals/<safe-id>/...``).
+    """Thin shim over :func:`crystal_safe_id` for contradiction
+    crystals.  Single-prefix convention (``contradiction-<digest>``)
+    so the on-disk listing groups them next to community crystals
+    while staying visually distinct.
     """
     if contradiction_id.startswith("contradiction::"):
-        return f"contradiction-{contradiction_id[len('contradiction::'):]}"
+        return crystal_safe_id("contradiction", contradiction_id)
+    # Defensive: callers occasionally pass an already-stripped digest
+    # (e.g. archive subdirectory bookkeeping).  Preserve the historical
+    # prefixing behaviour so the archive layout doesn't shift.
     return f"contradiction-{contradiction_id}"
 
 
@@ -322,25 +324,12 @@ def _crystal_filename(contradiction_id: str) -> str:
     return _safe_id(contradiction_id) + ".md"
 
 
-def _related_notes_section(slugs: tuple[str, ...]) -> str:
-    """Machine-generated ``## 相关笔记`` section appended to every
-    contradiction crystal.  Same rationale as the community crystal
-    helper — keeps the source-note backlink graph deterministic
-    instead of relying on the LLM to consistently emit ``[[slug]]``
-    inside prose.
-    """
-    lines = ["## 相关笔记", ""]
-    for slug in slugs:
-        lines.append(f"- [[{slug}]]")
-    return "\n".join(lines)
-
-
 def render_crystal_markdown(crystal: ContradictionCrystal) -> str:
     return (
         _frontmatter(crystal)
         + crystal.body_md.rstrip()
         + "\n\n"
-        + _related_notes_section(crystal.source_object_ids)
+        + related_notes_section(crystal.source_object_ids)
         + "\n"
     )
 

--- a/src/ovp_pipeline/synthesis/crystal_fts.py
+++ b/src/ovp_pipeline/synthesis/crystal_fts.py
@@ -53,7 +53,7 @@ from __future__ import annotations
 import logging
 import sqlite3
 
-from ._shared import CRYSTAL_DIR_REL
+from ._shared import CRYSTAL_DIR_REL, crystal_safe_id
 
 logger = logging.getLogger(__name__)
 
@@ -76,12 +76,13 @@ _CONTRADICTION_NOTE_TYPE = "contradiction_crystal"
 
 
 def _community_safe_id(cluster_id: str) -> str:
-    if cluster_id.startswith("cluster::"):
-        return cluster_id[len("cluster::"):]
-    return cluster_id
+    return crystal_safe_id("community", cluster_id)
 
 
 def _contradiction_safe_id(contradiction_id: str) -> str:
+    # FTS slug uses the bare digest (no ``contradiction-`` filename
+    # prefix) so callers get ``contradiction:<digest>``, matching the
+    # historical surface that downstream UI code keys off.
     if contradiction_id.startswith("contradiction::"):
         return contradiction_id[len("contradiction::"):]
     return contradiction_id

--- a/src/ovp_pipeline/synthesis/curated_atlas.py
+++ b/src/ovp_pipeline/synthesis/curated_atlas.py
@@ -40,6 +40,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from ..projection_labels import frontmatter_projection_fields
+from ._shared import crystal_safe_id as _crystal_safe_id
 
 logger = logging.getLogger(__name__)
 
@@ -278,15 +279,9 @@ def build_curated_atlas(
 # ----- Markdown rendering -------------------------------------------------
 
 
-def _crystal_safe_id(kind: str, crystal_id: str) -> str:
-    """Translate a crystal_id into the on-disk filename prefix.
-    Mirrors ``community_crystal._safe_id`` / ``contradiction_crystal._safe_id``
-    without importing those modules (they own their own truth)."""
-    if kind == "community" and crystal_id.startswith("cluster::"):
-        return crystal_id[len("cluster::"):]
-    if kind == "contradiction" and crystal_id.startswith("contradiction::"):
-        return f"contradiction-{crystal_id[len('contradiction::'):]}"
-    return crystal_id
+# ``_crystal_safe_id`` is re-exported from ``_shared`` (pre-fix this
+# file held a copy of the same prefix-stripping logic — see
+# ``_shared.crystal_safe_id`` for the canonical home).
 
 
 def _crystal_wikilink(kind: str, crystal_id: str, *, label: str) -> str:

--- a/src/ovp_pipeline/ui/view_models.py
+++ b/src/ovp_pipeline/ui/view_models.py
@@ -4350,16 +4350,15 @@ def build_reader_home_payload(
             generated_at="",
         )
 
-    def _safe_id(crystal_id: str, crystal_kind: str = "community") -> str:
-        if crystal_kind == "community" and crystal_id.startswith("cluster::"):
-            return crystal_id[len("cluster::"):]
-        if crystal_kind == "contradiction" and crystal_id.startswith("contradiction::"):
-            return f"contradiction-{crystal_id[len('contradiction::'):]}"
-        return crystal_id
+    # Single source of truth for crystal_id → on-disk safe-id is
+    # ``synthesis._shared.crystal_safe_id``.  Imported lazily here to
+    # avoid pulling synthesis dependencies into ``view_models``'s
+    # module-load path.
+    from ..synthesis._shared import crystal_safe_id
 
     top_topics = []
     for entry in atlas.entries:
-        safe_id = _safe_id(entry.crystal_id, entry.crystal_kind)
+        safe_id = crystal_safe_id(entry.crystal_kind, entry.crystal_id)
         note_rel = str(CRYSTAL_DIR_REL / f"{safe_id}.md")
         top_topics.append({
             "rank": entry.rank,
@@ -4376,7 +4375,7 @@ def build_reader_home_payload(
     for cluster_id, synthesized_at, body_md, label in recent_rows:
         # Recent-crystals query is community-only by design (it joins
         # community_crystals + graph_clusters), so the kind is fixed.
-        safe_id = _safe_id(str(cluster_id), "community")
+        safe_id = crystal_safe_id("community", str(cluster_id))
         note_rel = str(CRYSTAL_DIR_REL / f"{safe_id}.md")
         recent_crystals.append({
             "label": str(label or "(untitled)"),
@@ -4431,14 +4430,13 @@ def build_curated_atlas_payload(
     with sqlite3.connect(db_path) as conn:
         atlas = build_curated_atlas(conn, pack=pack, top_n=requested_top_n)
 
+    # Lazy import — same pattern as the adjacent
+    # ``build_reader_home_payload`` helper.
+    from ..synthesis._shared import crystal_safe_id
+
     entries: list[dict[str, Any]] = []
     for entry in atlas.entries:
-        if entry.crystal_kind == "community" and entry.crystal_id.startswith("cluster::"):
-            safe_id = entry.crystal_id[len("cluster::"):]
-        elif entry.crystal_kind == "contradiction" and entry.crystal_id.startswith("contradiction::"):
-            safe_id = f"contradiction-{entry.crystal_id[len('contradiction::'):]}"
-        else:
-            safe_id = entry.crystal_id
+        safe_id = crystal_safe_id(entry.crystal_kind, entry.crystal_id)
         note_rel = str(CRYSTAL_DIR_REL / f"{safe_id}.md")
         entries.append(
             {

--- a/tests/test_community_crystal.py
+++ b/tests/test_community_crystal.py
@@ -11,13 +11,13 @@ import json
 import sqlite3
 from pathlib import Path
 
+from ovp_pipeline.synthesis._shared import strip_frontmatter as _strip_frontmatter
 from ovp_pipeline.synthesis.community_crystal import (
     CRYSTAL_DIR_REL,
     CRYSTAL_PROMPT_VERSION,
     CommunityCrystal,
     _crystal_filename,
     _select_top_members,
-    _strip_frontmatter,
     render_crystal_markdown,
     synthesize_community_crystals,
 )


### PR DESCRIPTION
## Summary

Four DRY refactors from the review.  Three larger ones (``_yaml_escape``, frontmatter parser, sha256 fingerprint) are deferred to dedicated PRs so this one keeps a bounded review surface.

### What changed

- **#6** — Removed BC aliases ``_strip_frontmatter`` / ``_load_evergreen_bodies`` / ``_load_objects_subset`` from ``synthesis/community_crystal``.  Internal callers and one test now import the canonical names from ``synthesis/_shared``.
- **#7** — Moved ``_related_notes_section`` (identical in both crystal modules) to ``_shared.related_notes_section``.
- **#8** — New ``_shared.crystal_safe_id(kind, crystal_id)``.  Five duplicated copies (``curated_atlas``, ``community_crystal``, ``contradiction_crystal``, ``crystal_fts`` ×2, ``ui.view_models`` inline) now route through it.
- **#15** — Extracted ``_permanent_redirect(status, target)`` helper in ``ui_server.py``.  Three copy-pasted sites (301 GET legacy, 301 ``/atlas/curated``, 308 POST legacy) collapse to one helper.  The load-bearing 301-vs-308 contract is documented on the helper.

### Out of scope

- ``_yaml_escape`` / ``_yaml_quote`` (#11), frontmatter parser (#12), sha256 fingerprint (#13) — wider blast radius, want their own fidelity sweep.

## Test plan

- [x] 156/156 in touched test files
- [x] Full suite: 2133/2133

Review: BL-058 follow-up — medium DRY findings #6, #7, #8, #15.