### PR TITLE
feat(ui): expand ops nav, daily timeline, lineage card on /note

### DIFF
--- a/src/ovp_pipeline/commands/_ui_renderers.py
+++ b/src/ovp_pipeline/commands/_ui_renderers.py
@@ -1309,6 +1309,26 @@ def _render_note_page(
     )
 
 
+# Lineage-card CSS pulled to a module-level constant so the
+# render function doesn't ship a multi-line literal in the middle
+# of its body.  Scope is intentionally local — promoting these
+# styles to ``_layout`` would make them load on every page even
+# when the lineage card isn't rendered.
+_LINEAGE_CARD_STYLE = (
+    "<style>"
+    ".lineage-flow{display:flex;flex-direction:column;gap:.4rem}"
+    ".lineage-row{padding:.5rem .7rem;border-left:3px solid #c9bfae;"
+    "background:#fbf9f5;border-radius:0 4px 4px 0}"
+    ".lineage-row.you{border-left-color:#1c5e1c;background:#eef5e7}"
+    ".lineage-row h3{margin:.1rem 0;font-size:.95rem}"
+    ".lineage-row ul{margin:.2rem 0 .2rem 1.2rem}"
+    ".lineage-row .muted{color:#71675d;font-size:.82rem}"
+    ".lineage-arrow{color:#a59b8c;text-align:center;font-size:.9rem;"
+    "padding:.1rem 0}"
+    "</style>"
+)
+
+
 def _render_lineage_card(
     lineage: dict | None, *, requested_pack: str = "",
 ) -> str:
@@ -1345,17 +1365,7 @@ def _render_lineage_card(
 
     blocks: list[str] = [
         "<section class='card'><h2>Lineage</h2>",
-        "<style>"
-        ".lineage-flow{display:flex;flex-direction:column;gap:.4rem}"
-        ".lineage-row{padding:.5rem .7rem;border-left:3px solid #c9bfae;"
-        "background:#fbf9f5;border-radius:0 4px 4px 0}"
-        ".lineage-row.you{border-left-color:#1c5e1c;background:#eef5e7}"
-        ".lineage-row h3{margin:.1rem 0;font-size:.95rem}"
-        ".lineage-row ul{margin:.2rem 0 .2rem 1.2rem}"
-        ".lineage-row .muted{color:#71675d;font-size:.82rem}"
-        ".lineage-arrow{color:#a59b8c;text-align:center;font-size:.9rem;"
-        "padding:.1rem 0}"
-        "</style>",
+        _LINEAGE_CARD_STYLE,
         "<div class='lineage-flow'>",
         f"<div class='lineage-row you'>{header}</div>",
     ]
@@ -4877,6 +4887,42 @@ def _render_pulse_fragment() -> str:
     )
 
 
+# Timeline / Lineage UI strings — pulled out for translation /
+# constant-vs-magic-number hygiene.  Body copy is intentionally
+# Chinese to match the rest of the maintainer surface.
+_TIMELINE_NEW_EVERGREENS_LABEL = "新增 evergreens"
+_TIMELINE_ERROR_SAMPLE_HEADING = "Errors / skips"
+# Cap the per-error row's ``subject`` rendering so a 2KB JSON dump
+# doesn't blow out the day card.  140 covers most "absorb_parse_error
+# on /Users/chris/.../<long-path>.md" cases without truncation.
+_TIMELINE_ERROR_SUBJECT_MAX_CHARS = 140
+
+# Day-card CSS pulled to a module-level constant so
+# ``_render_timeline_page`` doesn't ship a multi-line literal in the
+# middle of its body.  Inline rather than promoted to ``_layout`` —
+# the styles are scoped to one route, lifting them globally would
+# pollute every other page's CSS.
+_TIMELINE_DAY_CARD_STYLE = (
+    "<style>"
+    ".day-card{border:1px solid #ded6cd;border-radius:8px;"
+    "padding:1rem;margin-bottom:1.2rem;background:#fbf9f5}"
+    ".day-card h2{margin:0 0 .3rem 0;font-size:1.1rem}"
+    ".day-meta{color:#71675d;font-size:.85rem;margin-bottom:.7rem}"
+    ".event-grid{display:grid;grid-template-columns:repeat(auto-fit,"
+    "minmax(220px,1fr));gap:.4rem;margin-bottom:.7rem}"
+    ".event-grid .pill{background:#ede7df;padding:.18rem .55rem;"
+    "border-radius:4px;font-size:.85rem}"
+    ".event-grid .pill.error{background:#f5d7d4;color:#761b15}"
+    ".event-grid .pill.highlight{background:#dde9d3;color:#2c5316}"
+    ".samples{margin:.4rem 0}"
+    ".samples h3{font-size:.95rem;margin:.4rem 0 .2rem 0}"
+    ".samples ul{margin:.1rem 0 .4rem 1.2rem}"
+    ".errors li{color:#761b15;font-family:ui-monospace,monospace;"
+    "font-size:.8rem;margin-bottom:.2rem}"
+    "</style>"
+)
+
+
 def _render_timeline_page(payload: dict) -> str:
     """Daily digest of audit events.
 
@@ -4912,30 +4958,7 @@ def _render_timeline_page(payload: dict) -> str:
         )
         return _layout("Timeline", body, requested_pack=requested_pack)
 
-    highlighted = set(payload.get("highlighted_types") or [])
-
-    # CSS for compact day cards.
-    style = (
-        "<style>"
-        ".day-card{border:1px solid #ded6cd;border-radius:8px;"
-        "padding:1rem;margin-bottom:1.2rem;background:#fbf9f5}"
-        ".day-card h2{margin:0 0 .3rem 0;font-size:1.1rem}"
-        ".day-meta{color:#71675d;font-size:.85rem;margin-bottom:.7rem}"
-        ".event-grid{display:grid;grid-template-columns:repeat(auto-fit,"
-        "minmax(220px,1fr));gap:.4rem;margin-bottom:.7rem}"
-        ".event-grid .pill{background:#ede7df;padding:.18rem .55rem;"
-        "border-radius:4px;font-size:.85rem}"
-        ".event-grid .pill.error{background:#f5d7d4;color:#761b15}"
-        ".event-grid .pill.highlight{background:#dde9d3;color:#2c5316}"
-        ".samples{margin:.4rem 0}"
-        ".samples h3{font-size:.95rem;margin:.4rem 0 .2rem 0}"
-        ".samples ul{margin:.1rem 0 .4rem 1.2rem}"
-        ".errors li{color:#761b15;font-family:ui-monospace,monospace;"
-        "font-size:.8rem;margin-bottom:.2rem}"
-        "</style>"
-    )
-
-    sections: list[str] = [style]
+    sections: list[str] = [_TIMELINE_DAY_CARD_STYLE]
     sections.append(
         f"<p class='muted'>Showing the last {window} days of "
         f"<code>audit_events</code>.  {len(days)} day(s) with activity.</p>"
@@ -4981,7 +5004,7 @@ def _render_timeline_page(payload: dict) -> str:
                 for s in samples
             )
             samples_html = (
-                f"<div class='samples'><h3>新增 evergreens "
+                f"<div class='samples'><h3>{_TIMELINE_NEW_EVERGREENS_LABEL} "
                 f"(sample {len(samples)} of {by_type.get('evergreen_auto_promoted', 0)})</h3>"
                 f"<ul>{items}</ul></div>"
             )
@@ -4991,12 +5014,14 @@ def _render_timeline_page(payload: dict) -> str:
             items = "".join(
                 "<li>[{type}] <strong>{subject}</strong></li>".format(
                     type=escape(str(e.get("event_type", ""))),
-                    subject=escape(str(e.get("subject", ""))[:140]),
+                    subject=escape(
+                        str(e.get("subject", ""))[:_TIMELINE_ERROR_SUBJECT_MAX_CHARS]
+                    ),
                 )
                 for e in errors
             )
             errors_html = (
-                f"<div class='samples errors'><h3>Errors / skips "
+                f"<div class='samples errors'><h3>{_TIMELINE_ERROR_SAMPLE_HEADING} "
                 f"(sample {len(errors)})</h3><ul>{items}</ul></div>"
             )
 

--- a/src/ovp_pipeline/commands/_ui_renderers.py
+++ b/src/ovp_pipeline/commands/_ui_renderers.py
@@ -126,17 +126,35 @@ def _reader_nav_items(requested_pack: str = "") -> list[tuple[str, str]]:
 
 
 def _ops_nav_items(requested_pack: str = "") -> list[tuple[str, str]]:
-    """Maintainer shell nav.  Each item is a real landing page; the
-    dashboard at ``/ops`` aggregates the long tail of fragments
-    (candidates / actions queue / runtime cards) so they don't need
-    their own top-level link yet."""
-    return [
+    """Maintainer shell nav.
+
+    The BL-050 nav opened at five items (Overview / Contradictions /
+    Signals / Pulse / Audit) but the maintainer surface ships a
+    dozen+ landing pages — every other surface was reachable only by
+    typing the URL.  The expanded list here surfaces the day-to-day
+    paths a reviewer hits ("what changed today", "review pending
+    candidates", "browse the canonical evergreens"), and keeps the
+    research-only entries (clusters, deep-dives, production) gated
+    on ``_shell_supports_research_nav`` so a non-research pack
+    doesn't see broken links.
+    """
+    items: list[tuple[str, str]] = [
         ("Overview", "/ops"),
-        ("Contradictions", "/ops/contradictions"),
-        ("Signals", "/ops/signals"),
+        ("Timeline", "/ops/timeline"),
         ("Pulse", "/ops/pulse"),
         ("Audit", "/ops/events"),
+        ("Evergreens", "/ops/objects"),
+        ("Candidates", "/ops/candidates"),
+        ("Actions", "/ops/actions"),
+        ("Contradictions", "/ops/contradictions"),
+        ("Signals", "/ops/signals"),
     ]
+    if _shell_supports_research_nav(requested_pack):
+        items.extend([
+            ("Clusters", "/ops/clusters"),
+            ("Deep-dives", "/ops/deep-dives"),
+        ])
+    return items
 
 
 # Kept as a thin alias so existing renderers that import the symbol
@@ -1265,6 +1283,10 @@ def _render_note_page(
         f'<a href="{escape(str(item["href"]))}">{escape(str(item["label"]))}</a>'
         for item in section_nav_items
     )
+    lineage_html = _render_lineage_card(
+        payload.get("lineage") if payload else None,
+        requested_pack=requested_pack,
+    )
     operator_rail_card = _render_operator_rail(payload or {})
     return _layout(
         f"Markdown Note: {relative_path}",
@@ -1277,6 +1299,7 @@ def _render_note_page(
             + operator_rail_card
             + (f"<nav class='subnav'>{section_nav}</nav>" if section_nav else "")
             + f"{frontmatter_html}"
+            + f"{lineage_html}"
             + f"{provenance_html}"
             + f"{production_chain_html}"
             + f"{_render_compiled_sections(remaining_sections)}"
@@ -1284,6 +1307,157 @@ def _render_note_page(
         ),
         requested_pack=requested_pack,
     )
+
+
+def _render_lineage_card(
+    lineage: dict | None, *, requested_pack: str = "",
+) -> str:
+    """Render the BL-058 raw-source ↔ evergreens ↔ crystals chain.
+
+    Returns ``""`` when ``lineage`` is ``None`` (note isn't an
+    evergreen or 03-Processed source) so the surrounding template
+    can interpolate it without a conditional.
+
+    Visual model — single vertical card with three or four arrows
+    depending on direction:
+
+      Raw source  →  N evergreens  →  M clusters  →  K crystals
+
+    The arrow blocks each link to a real surface so the operator
+    can drill down without copy-pasting paths.
+    """
+    if not lineage:
+        return ""
+
+    raw = lineage.get("raw_source")
+    evergreens = lineage.get("evergreens") or []
+    clusters = lineage.get("clusters") or []
+    crystals = lineage.get("crystals") or []
+    kind = str(lineage.get("kind") or "")
+
+    # Top "current node" indicator — different copy depending on
+    # whether the user is looking at the source or one of the
+    # downstream evergreens.
+    if kind == "raw_source":
+        header = "<strong>You are here:</strong> raw source intake"
+    else:
+        header = "<strong>You are here:</strong> evergreen"
+
+    blocks: list[str] = [
+        "<section class='card'><h2>Lineage</h2>",
+        "<style>"
+        ".lineage-flow{display:flex;flex-direction:column;gap:.4rem}"
+        ".lineage-row{padding:.5rem .7rem;border-left:3px solid #c9bfae;"
+        "background:#fbf9f5;border-radius:0 4px 4px 0}"
+        ".lineage-row.you{border-left-color:#1c5e1c;background:#eef5e7}"
+        ".lineage-row h3{margin:.1rem 0;font-size:.95rem}"
+        ".lineage-row ul{margin:.2rem 0 .2rem 1.2rem}"
+        ".lineage-row .muted{color:#71675d;font-size:.82rem}"
+        ".lineage-arrow{color:#a59b8c;text-align:center;font-size:.9rem;"
+        "padding:.1rem 0}"
+        "</style>",
+        "<div class='lineage-flow'>",
+        f"<div class='lineage-row you'>{header}</div>",
+    ]
+
+    # ── Raw source row ─────────────────────────────────────────
+    if raw:
+        path = escape(str(raw.get("path") or ""))
+        slug = escape(str(raw.get("slug") or ""))
+        href = str(raw.get("note_href") or "")
+        link = (
+            f"<a href='{escape(href)}'>{slug}</a>" if href else slug
+        )
+        archived_note = (
+            "" if path
+            else " <span class='muted'>(archived — only stem available)</span>"
+        )
+        blocks.append("<div class='lineage-arrow'>↑ derived from</div>")
+        blocks.append(
+            "<div class='lineage-row'>"
+            "<h3>Raw source</h3>"
+            f"<div>{link}{archived_note}</div>"
+            f"<div class='muted'>{path}</div>"
+            "</div>"
+        )
+
+    # ── Evergreens row ─────────────────────────────────────────
+    if evergreens:
+        items = "".join(
+            "<li><a href='{href}'>{title}</a> "
+            "<span class='muted'><code>{slug}</code></span></li>".format(
+                href=escape(str(eg.get("note_href", ""))),
+                title=escape(str(eg.get("title", "(untitled)"))),
+                slug=escape(str(eg.get("slug", ""))),
+            )
+            for eg in evergreens
+        )
+        blocks.append(
+            "<div class='lineage-arrow'>"
+            f"↓ produced {len(evergreens)} evergreen(s)"
+            "</div>"
+            "<div class='lineage-row'>"
+            "<h3>Evergreens</h3>"
+            f"<ul>{items}</ul>"
+            "</div>"
+        )
+
+    # ── Clusters row ───────────────────────────────────────────
+    if clusters:
+        items = "".join(
+            "<li><a href='{href}'>{label}</a> "
+            "<span class='muted'>{n} members</span></li>".format(
+                href=escape(str(cl.get("crystal_note_href", "") or cl.get("cluster_href", ""))),
+                label=escape(str(cl.get("label", "(untitled)"))),
+                n=int(cl.get("member_count", 0)),
+            )
+            for cl in clusters
+        )
+        blocks.append(
+            "<div class='lineage-arrow'>"
+            f"↓ grouped into {len(clusters)} cluster(s)"
+            "</div>"
+            "<div class='lineage-row'>"
+            "<h3>Clusters (Louvain communities)</h3>"
+            f"<ul>{items}</ul>"
+            "</div>"
+        )
+
+    # ── Crystals row ───────────────────────────────────────────
+    if crystals:
+        items = "".join(
+            "<li><a href='{href}'>{label}</a> "
+            "<span class='muted'>[{kind}]</span></li>".format(
+                href=escape(str(cr.get("note_href", ""))),
+                label=escape(str(cr.get("label", "(untitled)"))),
+                kind=escape(str(cr.get("kind", ""))),
+            )
+            for cr in crystals
+        )
+        blocks.append(
+            "<div class='lineage-arrow'>"
+            f"↓ synthesized into {len(crystals)} crystal(s)"
+            "</div>"
+            "<div class='lineage-row'>"
+            "<h3>Crystals</h3>"
+            f"<ul>{items}</ul>"
+            "</div>"
+        )
+
+    # If only the "you are here" row exists (no upstream / downstream
+    # links) tell the user that explicitly so the empty card doesn't
+    # look broken.
+    has_chain = bool(raw or evergreens or clusters or crystals)
+    if not has_chain:
+        blocks.append(
+            "<div class='lineage-row muted'>"
+            "<em>No lineage links found yet — re-run "
+            "<code>ovp-knowledge-index</code> after absorb / synthesis.</em>"
+            "</div>"
+        )
+
+    blocks.append("</div></section>")
+    return "".join(blocks)
 
 
 def _render_search_page(payload: dict) -> str:
@@ -4701,6 +4875,143 @@ def _render_pulse_fragment() -> str:
         "})();</script>"
         "</section>"
     )
+
+
+def _render_timeline_page(payload: dict) -> str:
+    """Daily digest of audit events.
+
+    Sister to ``/ops/pulse`` (live tail) and ``/ops/events``
+    (object-keyed dossier).  Pulse shows what's happening now;
+    Events lets you drill down per object; Timeline answers the
+    operator's day-to-day "what got created / went wrong today
+    or yesterday" question without making them grep
+    ``60-Logs/pipeline.jsonl`` themselves.
+    """
+    requested_pack = str(payload.get("requested_pack") or "")
+    window = int(payload.get("window_days") or 14)
+    days = payload.get("days") or []
+
+    if not payload.get("available", True):
+        body = (
+            "<section class='card'>"
+            "<h2>Timeline unavailable</h2>"
+            f"<p class='muted'>{escape(str(payload.get('reason') or 'unknown'))}</p>"
+            "<p>Run <code>ovp-knowledge-index</code> to populate "
+            "<code>audit_events</code>.</p>"
+            "</section>"
+        )
+        return _layout("Timeline", body, requested_pack=requested_pack)
+
+    if not days:
+        body = (
+            "<section class='card'>"
+            f"<h2>No events in the last {window} days</h2>"
+            "<p class='muted'>The pipeline hasn't run in this window — "
+            "check <code>60-Logs/pipeline.jsonl</code> for last activity.</p>"
+            "</section>"
+        )
+        return _layout("Timeline", body, requested_pack=requested_pack)
+
+    highlighted = set(payload.get("highlighted_types") or [])
+
+    # CSS for compact day cards.
+    style = (
+        "<style>"
+        ".day-card{border:1px solid #ded6cd;border-radius:8px;"
+        "padding:1rem;margin-bottom:1.2rem;background:#fbf9f5}"
+        ".day-card h2{margin:0 0 .3rem 0;font-size:1.1rem}"
+        ".day-meta{color:#71675d;font-size:.85rem;margin-bottom:.7rem}"
+        ".event-grid{display:grid;grid-template-columns:repeat(auto-fit,"
+        "minmax(220px,1fr));gap:.4rem;margin-bottom:.7rem}"
+        ".event-grid .pill{background:#ede7df;padding:.18rem .55rem;"
+        "border-radius:4px;font-size:.85rem}"
+        ".event-grid .pill.error{background:#f5d7d4;color:#761b15}"
+        ".event-grid .pill.highlight{background:#dde9d3;color:#2c5316}"
+        ".samples{margin:.4rem 0}"
+        ".samples h3{font-size:.95rem;margin:.4rem 0 .2rem 0}"
+        ".samples ul{margin:.1rem 0 .4rem 1.2rem}"
+        ".errors li{color:#761b15;font-family:ui-monospace,monospace;"
+        "font-size:.8rem;margin-bottom:.2rem}"
+        "</style>"
+    )
+
+    sections: list[str] = [style]
+    sections.append(
+        f"<p class='muted'>Showing the last {window} days of "
+        f"<code>audit_events</code>.  {len(days)} day(s) with activity.</p>"
+    )
+    for day in days:
+        date = escape(str(day.get("date", "")))
+        total = int(day.get("total", 0))
+        by_type = day.get("by_type") or {}
+        samples = day.get("samples") or []
+        errors = day.get("errors") or []
+
+        # Sort by-type counts: highlighted ones first (in their canonical
+        # order), then everything else by frequency.
+        ordered_pills: list[tuple[str, int, bool, bool]] = []
+        seen: set[str] = set()
+        for t in payload.get("highlighted_types") or []:
+            if t in by_type:
+                ordered_pills.append((t, by_type[t], True, "error" in t or "broken" in t))
+                seen.add(t)
+        for t, n in sorted(by_type.items(), key=lambda x: -x[1]):
+            if t in seen:
+                continue
+            ordered_pills.append((t, n, False, False))
+
+        pills_html = "".join(
+            "<span class='pill {cls}'>{type}: <strong>{n}</strong></span>".format(
+                cls=("error" if is_error else ("highlight" if is_highlight else "")),
+                type=escape(t),
+                n=n,
+            )
+            for t, n, is_highlight, is_error in ordered_pills
+        )
+
+        samples_html = ""
+        if samples:
+            items = "".join(
+                "<li><a href='{href}'>{title}</a> <span class='muted'>"
+                "<code>{slug}</code></span></li>".format(
+                    href=escape(str(s.get("note_href", ""))),
+                    title=escape(str(s.get("title", "(untitled)"))),
+                    slug=escape(str(s.get("slug", ""))),
+                )
+                for s in samples
+            )
+            samples_html = (
+                f"<div class='samples'><h3>新增 evergreens "
+                f"(sample {len(samples)} of {by_type.get('evergreen_auto_promoted', 0)})</h3>"
+                f"<ul>{items}</ul></div>"
+            )
+
+        errors_html = ""
+        if errors:
+            items = "".join(
+                "<li>[{type}] <strong>{subject}</strong></li>".format(
+                    type=escape(str(e.get("event_type", ""))),
+                    subject=escape(str(e.get("subject", ""))[:140]),
+                )
+                for e in errors
+            )
+            errors_html = (
+                f"<div class='samples errors'><h3>Errors / skips "
+                f"(sample {len(errors)})</h3><ul>{items}</ul></div>"
+            )
+
+        sections.append(
+            "<section class='day-card'>"
+            f"<h2>{date}</h2>"
+            f"<div class='day-meta'>{total} events</div>"
+            f"<div class='event-grid'>{pills_html}</div>"
+            f"{samples_html}"
+            f"{errors_html}"
+            "</section>"
+        )
+
+    body = "".join(sections)
+    return _layout("Timeline", body, requested_pack=requested_pack)
 
 
 def _render_pulse_page() -> str:

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -938,24 +938,17 @@ def create_server(
                         _render_workbench_page(object_id=object_id, requested_pack=pack_name)
                     )
                     return
-                if path == "/ops/timeline":
+                if path in ("/ops/timeline", "/api/timeline"):
                     pack_name = query.get("pack", [""])[0] or None
                     raw_days = query.get("days", [""])[0]
                     days = int(raw_days) if raw_days.isdigit() else None
                     payload = build_timeline_payload(
                         resolved_vault, pack_name=pack_name, days=days,
                     )
-                    self._write_html(_render_timeline_page(payload))
-                    return
-                if path == "/api/timeline":
-                    pack_name = query.get("pack", [""])[0] or None
-                    raw_days = query.get("days", [""])[0]
-                    days = int(raw_days) if raw_days.isdigit() else None
-                    self._write_json(
-                        build_timeline_payload(
-                            resolved_vault, pack_name=pack_name, days=days,
-                        )
-                    )
+                    if path == "/api/timeline":
+                        self._write_json(payload)
+                    else:
+                        self._write_html(_render_timeline_page(payload))
                     return
                 if path == "/ops/pulse":
                     self._write_html(_render_pulse_page())

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -42,6 +42,7 @@ from ..ui.view_models import (
     build_search_payload,
     build_signal_browser_payload,
     build_stale_summary_browser_payload,
+    build_timeline_payload,
     build_topic_overview_payload,
 )
 from ..truth_api import (
@@ -95,6 +96,7 @@ from ._ui_renderers import (  # noqa: F401 — all renderers
     _render_production_browser_page,
     _render_pulse_fragment,
     _render_pulse_page,
+    _render_timeline_page,
     _render_reuse_report_fragment,
     _render_run_history_card,
     _render_runtime_card,
@@ -934,6 +936,25 @@ def create_server(
                     pack_name = query.get("pack", [""])[0] or ""
                     self._write_html(
                         _render_workbench_page(object_id=object_id, requested_pack=pack_name)
+                    )
+                    return
+                if path == "/ops/timeline":
+                    pack_name = query.get("pack", [""])[0] or None
+                    raw_days = query.get("days", [""])[0]
+                    days = int(raw_days) if raw_days.isdigit() else None
+                    payload = build_timeline_payload(
+                        resolved_vault, pack_name=pack_name, days=days,
+                    )
+                    self._write_html(_render_timeline_page(payload))
+                    return
+                if path == "/api/timeline":
+                    pack_name = query.get("pack", [""])[0] or None
+                    raw_days = query.get("days", [""])[0]
+                    days = int(raw_days) if raw_days.isdigit() else None
+                    self._write_json(
+                        build_timeline_payload(
+                            resolved_vault, pack_name=pack_name, days=days,
+                        )
                     )
                     return
                 if path == "/ops/pulse":

--- a/src/ovp_pipeline/ui/view_models.py
+++ b/src/ovp_pipeline/ui/view_models.py
@@ -63,6 +63,24 @@ from ..truth_api import (
 
 DEFAULT_CANDIDATE_BROWSER_LIMIT = 25
 DEFAULT_EVENT_DOSSIER_LIMIT = 25
+DEFAULT_TIMELINE_DAYS = 14
+DEFAULT_TIMELINE_SAMPLE_SIZE = 6
+# Audit event types that the operator-facing timeline highlights
+# above the long-tail ``by_type`` histogram.  Order matters: the
+# renderer prints these blocks top-to-bottom so a quick "new
+# evergreens / errors / sources processed" scan reads naturally.
+TIMELINE_HIGHLIGHTED_TYPES = (
+    "evergreen_auto_promoted",
+    "github_intake_completed",
+    "article_processed",
+    "absorb_skipped_source",
+    "absorb_parse_error",
+    "absorb_schema_drift",
+    "github_intake_error",
+    "broken_link",
+    "community_crystal_synthesized",
+    "contradiction_crystal_synthesized",
+)
 DEFAULT_TRACEABILITY_BROWSER_LIMIT = 15
 DEFAULT_GRAPH_MAP_LIMIT = 24
 # BL-051: cap each cluster at 3 members in the visual map (~96 nodes
@@ -2795,6 +2813,149 @@ def build_topic_overview_payload(
     return payload
 
 
+def build_timeline_payload(
+    vault_dir: Path | str,
+    *,
+    pack_name: str | None = None,
+    days: int | None = None,
+) -> dict[str, Any]:
+    """Daily digest of ``audit_events`` for the maintainer dashboard.
+
+    Pre-fix the maintainer side had ``/ops/pulse`` (live tail) and
+    ``/ops/events`` (object-keyed dossier) but no "what got created
+    today / yesterday / last week" view.  This payload groups the
+    last ``days`` days of audit events by date, surfaces the highest-
+    signal event types per day (new evergreens, github intake,
+    absorb errors, crystal synthesis), and samples a handful of
+    affected slugs so the user can click straight through to a
+    specific note from the dashboard.
+
+    Returns ``{"days": [{date, total, by_type: {...},
+    samples: [{slug, title, path}], errors: [{type, slug, snippet}]}]}``
+    in reverse-chronological order.
+    """
+    from datetime import datetime, timedelta, timezone
+    requested_pack = pack_name or ""
+    window = max(1, days if days is not None else DEFAULT_TIMELINE_DAYS)
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=window)).strftime("%Y-%m-%d")
+
+    db_path = _db_path(vault_dir)
+    if not db_path.exists():
+        return {
+            "screen": "ops/timeline",
+            "requested_pack": requested_pack,
+            "window_days": window,
+            "days": [],
+            "available": False,
+            "reason": "knowledge_index has not been built yet",
+        }
+
+    days_map: dict[str, dict[str, Any]] = {}
+    with sqlite3.connect(db_path) as conn:
+        # Per-day, per-type counts.  ``date()`` rolls a UTC ISO
+        # timestamp into ``YYYY-MM-DD`` — the same key the renderer
+        # uses to header each section.
+        rows = conn.execute(
+            """
+            SELECT date(timestamp) AS day, event_type, COUNT(*) AS n
+              FROM audit_events
+             WHERE date(timestamp) >= ?
+             GROUP BY day, event_type
+            """,
+            (cutoff,),
+        ).fetchall()
+        for day, event_type, count in rows:
+            if not day:
+                continue
+            bucket = days_map.setdefault(day, {
+                "date": day, "total": 0, "by_type": {},
+                "samples": [], "errors": [],
+            })
+            bucket["by_type"][event_type] = int(count)
+            bucket["total"] += int(count)
+
+        # Sample evergreens promoted today/yesterday/etc — give the
+        # user a clickable list rather than a bare count.
+        sample_rows = conn.execute(
+            """
+            SELECT date(timestamp) AS day,
+                   json_extract(payload_json, '$.slug') AS slug,
+                   json_extract(payload_json, '$.title') AS title
+              FROM audit_events
+             WHERE event_type = 'evergreen_auto_promoted'
+               AND date(timestamp) >= ?
+             ORDER BY timestamp DESC
+            """,
+            (cutoff,),
+        ).fetchall()
+        for day, slug, title in sample_rows:
+            if not day or not slug:
+                continue
+            bucket = days_map.get(day)
+            if bucket is None:
+                continue
+            if len(bucket["samples"]) >= DEFAULT_TIMELINE_SAMPLE_SIZE:
+                continue
+            note_path = f"10-Knowledge/Evergreen/{slug}.md"
+            bucket["samples"].append({
+                "slug": str(slug),
+                "title": str(title or slug),
+                "note_href": _scoped_path(
+                    f"/note?path={quote(note_path, safe='')}",
+                    pack_name=requested_pack,
+                ),
+            })
+
+        # Error / skip events get their own short list — these are
+        # the things the maintainer most often opens the dashboard
+        # to chase down.
+        error_types = (
+            "absorb_parse_error", "absorb_schema_drift",
+            "absorb_skipped_source", "broken_link",
+            "github_intake_error",
+        )
+        placeholders = ",".join("?" for _ in error_types)
+        error_rows = conn.execute(
+            f"""
+            SELECT date(timestamp) AS day, event_type,
+                   COALESCE(json_extract(payload_json, '$.source'),
+                            json_extract(payload_json, '$.slug'),
+                            slug) AS subject,
+                   substr(payload_json, 1, 200) AS snippet
+              FROM audit_events
+             WHERE event_type IN ({placeholders})
+               AND date(timestamp) >= ?
+             ORDER BY timestamp DESC
+            """,
+            (*error_types, cutoff),
+        ).fetchall()
+        for day, event_type, subject, snippet in error_rows:
+            if not day:
+                continue
+            bucket = days_map.get(day)
+            if bucket is None:
+                continue
+            if len(bucket["errors"]) >= DEFAULT_TIMELINE_SAMPLE_SIZE:
+                continue
+            bucket["errors"].append({
+                "event_type": str(event_type),
+                "subject": str(subject or "(unspecified)"),
+                "snippet": str(snippet or ""),
+            })
+
+    days_sorted = sorted(
+        days_map.values(), key=lambda d: d["date"], reverse=True,
+    )
+    return {
+        "screen": "ops/timeline",
+        "requested_pack": requested_pack,
+        "window_days": window,
+        "days": days_sorted,
+        "available": True,
+        "highlighted_types": list(TIMELINE_HIGHLIGHTED_TYPES),
+    }
+
+
 def _escape_like(value: str) -> str:
     return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
@@ -4834,6 +4995,256 @@ def build_search_payload(
     }
 
 
+def _compute_v2_lineage(
+    vault_dir: Path | str,
+    note_path: str,
+    requested_pack: str,
+) -> dict[str, Any] | None:
+    """Compute the BL-058 raw-source ↔ evergreens ↔ crystals chain
+    for the note at ``note_path``.
+
+    Pre-fix the only lineage signal was ``production_chain`` (the
+    legacy deep-dive era data flow).  v2 evergreens come from raw
+    GitHub/article sources in ``50-Inbox/03-Processed`` rather than
+    deep-dives, so the operator had no UI to answer "which raw
+    source did this evergreen come from?" or "which evergreens
+    came from this raw source?".  This payload fills that gap.
+
+    Returns ``None`` when the note isn't an evergreen or a raw
+    intake source — the caller suppresses the card in that case
+    so non-applicable notes (MOCs, atlas pages, …) don't render
+    an empty section.
+
+    Shape::
+
+        {
+          "kind": "evergreen" | "raw_source",
+          "raw_source": {"slug", "path", "note_href"} | None,
+          "evergreens": [{slug, title, note_href}, ...],
+          "clusters": [{cluster_id, label, member_count, cluster_href}, ...],
+          "crystals": [{kind, crystal_id, label, note_href}, ...],
+        }
+    """
+    rel = str(note_path).replace("\\", "/").lstrip("./")
+    is_evergreen = rel.startswith("10-Knowledge/Evergreen/") and rel.endswith(".md")
+    is_raw_source = rel.startswith("50-Inbox/03-Processed/") and rel.endswith(".md")
+    if not (is_evergreen or is_raw_source):
+        return None
+
+    vault_root = Path(vault_dir).resolve()
+    abs_path = vault_root / rel
+    if not abs_path.exists():
+        return None
+
+    db_path = _db_path(vault_dir)
+    if not db_path.exists():
+        return None
+
+    raw_stem: str | None = None
+    target_evergreen_slugs: list[str] = []
+
+    if is_evergreen:
+        # Parse the body's ``## Source`` block to find the raw source
+        # wikilink.  Frontmatter doesn't yet carry a ``source_path``
+        # field for v2 evergreens (BL-058 deferred that to BL-058b),
+        # so the wikilink in the rendered body is the only durable
+        # back-reference we can rely on without a schema migration.
+        try:
+            text = abs_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            return None
+        m = re.search(
+            r"##\s*Source\s*\n+\s*-\s*\[\[([^\]]+)\]\]",
+            text, flags=re.MULTILINE,
+        )
+        if m:
+            raw_stem = m.group(1).strip()
+        else:
+            # Older v1 evergreens: scan body for any wikilink targeting
+            # the 03-Processed area (less reliable but keeps the lineage
+            # card useful for legacy notes too).
+            m = re.search(r"\[\[([^\]]*?(?:_深度解读|github|article))\]\]", text)
+            if m:
+                raw_stem = m.group(1).strip()
+        own_slug = abs_path.stem
+        if own_slug:
+            target_evergreen_slugs.append(own_slug)
+    else:
+        # Raw source — ``raw_stem`` is the file's basename without ``.md``.
+        raw_stem = abs_path.stem
+
+    sibling_evergreens: list[dict[str, str]] = []
+    clusters: list[dict[str, Any]] = []
+    crystals: list[dict[str, Any]] = []
+
+    with sqlite3.connect(db_path) as conn:
+        if raw_stem:
+            # Find all evergreens whose ``## Source`` block links back
+            # to this raw stem.  ``pages_index.body`` is exactly the
+            # markdown body so a ``LIKE`` against the wikilink token
+            # works even before BL-058b adds a typed ``source_stem``
+            # column.  Limit pulls keep the payload bounded for raw
+            # sources that produced 10+ units (the AGI / crewAI cases).
+            try:
+                rows = conn.execute(
+                    """
+                    SELECT slug, title FROM pages_index
+                     WHERE note_type = 'evergreen'
+                       AND body LIKE ?
+                     ORDER BY slug
+                     LIMIT 50
+                    """,
+                    (f"%[[{raw_stem}]]%",),
+                ).fetchall()
+            except sqlite3.OperationalError:
+                rows = []
+            for slug, title in rows:
+                sibling_evergreens.append({
+                    "slug": str(slug),
+                    "title": str(title or slug),
+                    "note_href": _scoped_path(
+                        f"/note?path={quote(f'10-Knowledge/Evergreen/{slug}.md', safe='')}",
+                        pack_name=requested_pack,
+                    ),
+                })
+                if slug not in target_evergreen_slugs:
+                    target_evergreen_slugs.append(str(slug))
+
+        # Forward chain: clusters that contain any of our evergreen
+        # slugs.  ``member_object_ids_json`` is a JSON array of object
+        # ids that match the evergreen slug.
+        if target_evergreen_slugs:
+            try:
+                cluster_rows = conn.execute(
+                    """
+                    SELECT cluster_id, label, member_object_ids_json
+                      FROM graph_clusters
+                     WHERE cluster_kind = 'louvain_community'
+                    """
+                ).fetchall()
+            except sqlite3.OperationalError:
+                cluster_rows = []
+            slug_set = set(target_evergreen_slugs)
+            for cluster_id, label, members_json in cluster_rows:
+                try:
+                    members = set(json.loads(members_json or "[]"))
+                except json.JSONDecodeError:
+                    continue
+                hit = members & slug_set
+                if not hit:
+                    continue
+                from ..synthesis._shared import crystal_safe_id
+                safe_id = crystal_safe_id("community", str(cluster_id))
+                clusters.append({
+                    "cluster_id": str(cluster_id),
+                    "label": str(label or "(untitled)"),
+                    "member_count": len(members),
+                    "matched": sorted(hit),
+                    "cluster_href": _scoped_path(
+                        f"/ops/cluster?id={quote(str(cluster_id), safe='')}",
+                        pack_name=requested_pack,
+                    ),
+                    "crystal_note_href": _scoped_path(
+                        f"/note?path=40-Resources/Crystals/{safe_id}.md",
+                        pack_name=requested_pack,
+                    ),
+                })
+
+            # Crystals — community first, contradictions second.
+            try:
+                crystal_rows = conn.execute(
+                    """
+                    SELECT cluster_id, source_evergreen_slugs_json
+                      FROM community_crystals
+                     WHERE superseded_by_synthesized_at = ''
+                    """
+                ).fetchall()
+            except sqlite3.OperationalError:
+                crystal_rows = []
+            for cluster_id, slugs_json in crystal_rows:
+                try:
+                    slugs = set(json.loads(slugs_json or "[]"))
+                except json.JSONDecodeError:
+                    continue
+                if not (slugs & slug_set):
+                    continue
+                from ..synthesis._shared import crystal_safe_id
+                safe_id = crystal_safe_id("community", str(cluster_id))
+                crystals.append({
+                    "kind": "community_crystal",
+                    "crystal_id": str(cluster_id),
+                    "label": str(cluster_id),
+                    "note_href": _scoped_path(
+                        f"/note?path=40-Resources/Crystals/{safe_id}.md",
+                        pack_name=requested_pack,
+                    ),
+                })
+            try:
+                contra_rows = conn.execute(
+                    """
+                    SELECT contradiction_id, subject_key, source_object_ids_json
+                      FROM contradiction_crystals
+                     WHERE superseded_by_synthesized_at = ''
+                    """
+                ).fetchall()
+            except sqlite3.OperationalError:
+                contra_rows = []
+            for contradiction_id, subject_key, source_ids_json in contra_rows:
+                try:
+                    sources = set(json.loads(source_ids_json or "[]"))
+                except json.JSONDecodeError:
+                    continue
+                if not (sources & slug_set):
+                    continue
+                from ..synthesis._shared import crystal_safe_id
+                safe_id = crystal_safe_id("contradiction", str(contradiction_id))
+                crystals.append({
+                    "kind": "contradiction_crystal",
+                    "crystal_id": str(contradiction_id),
+                    "label": str(subject_key or contradiction_id),
+                    "note_href": _scoped_path(
+                        f"/note?path=40-Resources/Crystals/{safe_id}.md",
+                        pack_name=requested_pack,
+                    ),
+                })
+
+    raw_source_info: dict[str, str] | None = None
+    if raw_stem:
+        # Locate the raw source file under 03-Processed.  The basename
+        # → path mapping is unambiguous because Phase A's output filenames
+        # are already disambiguated by ``<date>_<owner>_<repo>``.
+        candidates = list(
+            (vault_root / "50-Inbox" / "03-Processed").rglob(f"{raw_stem}.md")
+        )
+        if candidates:
+            rel_target = candidates[0].relative_to(vault_root)
+            raw_source_info = {
+                "slug": raw_stem,
+                "path": str(rel_target),
+                "note_href": _scoped_path(
+                    f"/note?path={quote(str(rel_target), safe='')}",
+                    pack_name=requested_pack,
+                ),
+            }
+        else:
+            # File may have been archived already (Phase A re-process
+            # moves the legacy deep-dive into 70-Archive).  Surface the
+            # stem so the user can grep for it.
+            raw_source_info = {
+                "slug": raw_stem,
+                "path": "",
+                "note_href": "",
+            }
+
+    return {
+        "kind": "evergreen" if is_evergreen else "raw_source",
+        "raw_source": raw_source_info,
+        "evergreens": sibling_evergreens,
+        "clusters": sorted(clusters, key=lambda c: -int(c.get("member_count", 0))),
+        "crystals": crystals,
+    }
+
+
 def build_note_page_payload(
     vault_dir: Path | str,
     *,
@@ -5005,6 +5416,12 @@ def build_note_page_payload(
         "provenance": provenance,
         "inbound_capture": inbound_capture,
         "production_chain": production_chain,
+        # BL-058 follow-up — raw source ↔ evergreens ↔ clusters ↔ crystals
+        # chain.  ``None`` for notes that aren't an evergreen or
+        # 03-Processed source so the renderer can suppress the card.
+        "lineage": _compute_v2_lineage(
+            vault_dir, note_path, requested_pack,
+        ),
         "operator_rail": [
             _operator_action(
                 "Production Browser",

--- a/src/ovp_pipeline/ui/view_models.py
+++ b/src/ovp_pipeline/ui/view_models.py
@@ -81,6 +81,24 @@ TIMELINE_HIGHLIGHTED_TYPES = (
     "community_crystal_synthesized",
     "contradiction_crystal_synthesized",
 )
+# Subset of the highlighted types that the renderer pulls into the
+# per-day "errors / skips" sample list.  These are the failure modes
+# the maintainer most often opens the dashboard to chase down.
+TIMELINE_ERROR_EVENT_TYPES = (
+    "absorb_parse_error",
+    "absorb_schema_drift",
+    "absorb_skipped_source",
+    "broken_link",
+    "github_intake_error",
+)
+# Trim error-row payload snippets so the dashboard doesn't dump
+# multi-KB JSON dumps onto the page.  200 chars is enough to see the
+# error class + filename without burying the rest of the day card.
+TIMELINE_SNIPPET_CHARS = 200
+# Cap on sibling-evergreen count returned by ``_compute_v2_lineage``
+# so a popular raw source (one that produced 20+ units) doesn't
+# render a wall of links on every per-evergreen lineage card.
+LINEAGE_SIBLING_EVERGREEN_LIMIT = 50
 DEFAULT_TRACEABILITY_BROWSER_LIMIT = 15
 DEFAULT_GRAPH_MAP_LIMIT = 24
 # BL-051: cap each cluster at 3 members in the visual map (~96 nodes
@@ -2908,26 +2926,23 @@ def build_timeline_payload(
 
         # Error / skip events get their own short list — these are
         # the things the maintainer most often opens the dashboard
-        # to chase down.
-        error_types = (
-            "absorb_parse_error", "absorb_schema_drift",
-            "absorb_skipped_source", "broken_link",
-            "github_intake_error",
-        )
-        placeholders = ",".join("?" for _ in error_types)
+        # to chase down.  Types live in ``TIMELINE_ERROR_EVENT_TYPES``
+        # so the SQL ``IN`` clause stays in sync with downstream
+        # consumers (e.g. the renderer's "error" pill colouring).
+        placeholders = ",".join("?" for _ in TIMELINE_ERROR_EVENT_TYPES)
         error_rows = conn.execute(
             f"""
             SELECT date(timestamp) AS day, event_type,
                    COALESCE(json_extract(payload_json, '$.source'),
                             json_extract(payload_json, '$.slug'),
                             slug) AS subject,
-                   substr(payload_json, 1, 200) AS snippet
+                   substr(payload_json, 1, {TIMELINE_SNIPPET_CHARS}) AS snippet
               FROM audit_events
              WHERE event_type IN ({placeholders})
                AND date(timestamp) >= ?
              ORDER BY timestamp DESC
             """,
-            (*error_types, cutoff),
+            (*TIMELINE_ERROR_EVENT_TYPES, cutoff),
         ).fetchall()
         for day, event_type, subject, snippet in error_rows:
             if not day:
@@ -5079,25 +5094,61 @@ def _compute_v2_lineage(
 
     with sqlite3.connect(db_path) as conn:
         if raw_stem:
-            # Find all evergreens whose ``## Source`` block links back
-            # to this raw stem.  ``pages_index.body`` is exactly the
-            # markdown body so a ``LIKE`` against the wikilink token
-            # works even before BL-058b adds a typed ``source_stem``
-            # column.  Limit pulls keep the payload bounded for raw
-            # sources that produced 10+ units (the AGI / crewAI cases).
+            # First-choice strategy: query the indexed ``page_links``
+            # table where each row is one resolved wikilink.  Cheap
+            # JOIN, scales linearly with the in-degree of the target.
             try:
                 rows = conn.execute(
                     """
-                    SELECT slug, title FROM pages_index
-                     WHERE note_type = 'evergreen'
-                       AND body LIKE ?
-                     ORDER BY slug
-                     LIMIT 50
+                    SELECT pi.slug, pi.title
+                      FROM page_links pl
+                      JOIN pages_index pi ON pi.slug = pl.source_slug
+                     WHERE pi.note_type = 'evergreen'
+                       AND (pl.target_slug = ? OR pl.target_raw = ?)
+                     ORDER BY pi.slug
+                     LIMIT ?
                     """,
-                    (f"%[[{raw_stem}]]%",),
+                    (raw_stem, raw_stem, LINEAGE_SIBLING_EVERGREEN_LIMIT),
                 ).fetchall()
             except sqlite3.OperationalError:
                 rows = []
+            # Fallback: ``page_links`` only stores rows whose target
+            # was resolvable to a slug already in ``pages_index``.  The
+            # file scanner (knowledge_index.py:1062) drops unresolved
+            # wikilinks entirely — and raw intake sources in
+            # ``50-Inbox/03-Processed`` are NOT scanned into
+            # ``pages_index`` (only Evergreen / Atlas / 20-Areas are),
+            # so the ``## Source`` link to a raw-source basename like
+            # ``2026-04-28_neuphonic_neutts`` produces zero
+            # ``page_links`` rows.  The body-LIKE scan below recovers
+            # those cases.  Once BL-058b adds a typed ``source_stem``
+            # column to ``pages_index`` (or a typed ``source_path``
+            # field to evergreen frontmatter that knowledge_index
+            # surfaces), this fallback can be removed.
+            if not rows:
+                # ``ESCAPE`` lets the LIKE pattern carry literal ``%``
+                # / ``_`` / ``\`` characters in raw stems without false
+                # positives.  Trigram-FTS would be faster but
+                # ``page_fts`` strips brackets when tokenising so
+                # phrase-matching ``[[<stem>]]`` doesn't beat LIKE.
+                escaped = (
+                    raw_stem.replace("\\", "\\\\")
+                            .replace("%", "\\%")
+                            .replace("_", "\\_")
+                )
+                try:
+                    rows = conn.execute(
+                        """
+                        SELECT slug, title FROM pages_index
+                         WHERE note_type = 'evergreen'
+                           AND body LIKE ? ESCAPE '\\'
+                         ORDER BY slug
+                         LIMIT ?
+                        """,
+                        (f"%[[{escaped}]]%", LINEAGE_SIBLING_EVERGREEN_LIMIT),
+                    ).fetchall()
+                except sqlite3.OperationalError:
+                    rows = []
             for slug, title in rows:
                 sibling_evergreens.append({
                     "slug": str(slug),

--- a/tests/test_ui_timeline_and_lineage.py
+++ b/tests/test_ui_timeline_and_lineage.py
@@ -1,0 +1,489 @@
+"""Tests for the BL-058 follow-up UI surfaces:
+
+* ``build_timeline_payload`` — daily digest of ``audit_events``
+  surfaced at ``/ops/timeline``.
+* ``_compute_v2_lineage`` (via ``build_note_page_payload``) — raw
+  source ↔ evergreens ↔ clusters ↔ crystals chain card on
+  ``/note?path=...``.
+* ``_render_lineage_card`` — HTML output checks.
+* ``_render_timeline_page`` — HTML output checks for empty / data
+  / unavailable states.
+* ``_ops_nav_items`` — confirms the post-BL-050 nav now exposes the
+  routes that previously lived only in URLs.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from ovp_pipeline.commands._ui_renderers import (
+    _ops_nav_items,
+    _render_lineage_card,
+    _render_timeline_page,
+)
+from ovp_pipeline.ui.view_models import (
+    build_note_page_payload,
+    build_timeline_payload,
+)
+
+
+# ---------------------------------------------------------------------------
+# Nav expansion
+# ---------------------------------------------------------------------------
+
+
+class TestOpsNav:
+    def test_includes_timeline_and_evergreens(self):
+        items = dict(_ops_nav_items(""))
+        # Pre-fix: only Overview/Contradictions/Signals/Pulse/Audit.
+        # Post-fix: those + Timeline + Evergreens + Candidates etc.
+        for label in ("Timeline", "Pulse", "Audit", "Evergreens",
+                      "Candidates", "Actions", "Contradictions", "Signals"):
+            assert label in items, f"{label!r} missing from ops nav"
+        assert items["Timeline"] == "/ops/timeline"
+        assert items["Evergreens"] == "/ops/objects"
+
+    def test_research_only_entries_gated(self, monkeypatch):
+        # Research-pack items show only when the active pack supports
+        # the research shell.  Pre-fix users saw broken links to
+        # ``/ops/clusters`` etc. on packs that didn't support graph
+        # synthesis.
+        from ovp_pipeline.commands import _ui_renderers
+        monkeypatch.setattr(
+            _ui_renderers, "_shell_supports_research_nav", lambda _p: False,
+        )
+        items = dict(_ops_nav_items(""))
+        assert "Clusters" not in items
+        assert "Deep-dives" not in items
+
+        monkeypatch.setattr(
+            _ui_renderers, "_shell_supports_research_nav", lambda _p: True,
+        )
+        items_research = dict(_ops_nav_items(""))
+        assert items_research["Clusters"] == "/ops/clusters"
+        assert items_research["Deep-dives"] == "/ops/deep-dives"
+
+
+# ---------------------------------------------------------------------------
+# Timeline payload + renderer
+# ---------------------------------------------------------------------------
+
+
+_AUDIT_EVENTS_SCHEMA = """
+CREATE TABLE audit_events (
+  source_log TEXT NOT NULL,
+  event_type TEXT NOT NULL,
+  slug TEXT NOT NULL DEFAULT '',
+  session_id TEXT NOT NULL DEFAULT '',
+  timestamp TEXT NOT NULL DEFAULT '',
+  payload_json TEXT NOT NULL
+);
+CREATE INDEX idx_audit_events_log ON audit_events(source_log);
+CREATE INDEX idx_audit_events_type ON audit_events(event_type);
+"""
+
+
+def _seed_audit_db(tmp_path: Path) -> Path:
+    db_path = tmp_path / "60-Logs" / "knowledge.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.executescript(_AUDIT_EVENTS_SCHEMA)
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
+    yesterday = (
+        datetime.now(timezone.utc) - timedelta(days=1)
+    ).strftime("%Y-%m-%dT%H:%M:%S")
+    rows = [
+        # Today: 3 evergreen promotions + 1 absorb error.
+        ("pipeline.jsonl", "evergreen_auto_promoted", "", "s1", today,
+         json.dumps({"slug": "alpha", "title": "Alpha"})),
+        ("pipeline.jsonl", "evergreen_auto_promoted", "", "s1", today,
+         json.dumps({"slug": "beta", "title": "Beta"})),
+        ("pipeline.jsonl", "evergreen_auto_promoted", "", "s1", today,
+         json.dumps({"slug": "gamma", "title": "Gamma"})),
+        ("pipeline.jsonl", "absorb_parse_error", "", "s1", today,
+         json.dumps({"source": "/path/to/source.md", "error": "JSON decode"})),
+        # Yesterday: 2 github intakes.
+        ("pipeline.jsonl", "github_intake_completed", "", "s0", yesterday,
+         json.dumps({"url": "https://github.com/a/b", "tier": "deepwiki"})),
+        ("pipeline.jsonl", "github_intake_completed", "", "s0", yesterday,
+         json.dumps({"url": "https://github.com/c/d", "tier": "gitingest"})),
+    ]
+    conn.executemany(
+        "INSERT INTO audit_events VALUES (?, ?, ?, ?, ?, ?)", rows,
+    )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+class TestBuildTimelinePayload:
+    def test_empty_db_returns_unavailable(self, tmp_path):
+        # No knowledge.db at all → graceful degradation, not a crash.
+        payload = build_timeline_payload(tmp_path)
+        assert payload["screen"] == "ops/timeline"
+        assert payload["available"] is False
+        assert payload["days"] == []
+
+    def test_groups_events_by_day(self, tmp_path):
+        _seed_audit_db(tmp_path)
+        payload = build_timeline_payload(tmp_path, days=7)
+        assert payload["available"] is True
+        # Today + yesterday — exactly 2 days with activity.
+        assert len(payload["days"]) == 2
+        # Reverse chronological — today first.
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        assert payload["days"][0]["date"] == today
+        assert payload["days"][0]["total"] == 4
+        assert payload["days"][0]["by_type"]["evergreen_auto_promoted"] == 3
+        assert payload["days"][0]["by_type"]["absorb_parse_error"] == 1
+
+    def test_attaches_evergreen_samples_with_clickable_paths(self, tmp_path):
+        _seed_audit_db(tmp_path)
+        payload = build_timeline_payload(tmp_path, days=7)
+        today = payload["days"][0]
+        # 3 promoted today → up to DEFAULT_TIMELINE_SAMPLE_SIZE samples.
+        assert {s["slug"] for s in today["samples"]} == {"alpha", "beta", "gamma"}
+        # Each sample carries an /note?path= href the renderer can click.
+        for s in today["samples"]:
+            assert s["note_href"].startswith("/note?path=")
+            assert "10-Knowledge%2FEvergreen" in s["note_href"]
+
+    def test_attaches_error_samples(self, tmp_path):
+        _seed_audit_db(tmp_path)
+        payload = build_timeline_payload(tmp_path, days=7)
+        today = payload["days"][0]
+        assert any(
+            e["event_type"] == "absorb_parse_error" for e in today["errors"]
+        )
+        # Subject pulled from payload_json.source field
+        err = next(e for e in today["errors"] if e["event_type"] == "absorb_parse_error")
+        assert "/path/to/source.md" in err["subject"]
+
+
+class TestRenderTimelinePage:
+    def test_renders_unavailable_state(self):
+        html = _render_timeline_page({
+            "screen": "ops/timeline", "requested_pack": "", "window_days": 14,
+            "days": [], "available": False, "reason": "test",
+        })
+        assert "Timeline unavailable" in html
+        assert "ovp-knowledge-index" in html
+
+    def test_renders_empty_window(self):
+        html = _render_timeline_page({
+            "screen": "ops/timeline", "requested_pack": "", "window_days": 7,
+            "days": [], "available": True,
+        })
+        assert "No events in the last 7 days" in html
+
+    def test_renders_day_card_with_pills_and_samples(self):
+        payload = {
+            "screen": "ops/timeline",
+            "requested_pack": "",
+            "window_days": 7,
+            "available": True,
+            "highlighted_types": ["evergreen_auto_promoted", "absorb_parse_error"],
+            "days": [{
+                "date": "2026-05-06",
+                "total": 5,
+                "by_type": {
+                    "evergreen_auto_promoted": 3,
+                    "absorb_parse_error": 1,
+                    "moc_updated": 1,
+                },
+                "samples": [
+                    {"slug": "alpha", "title": "Alpha title",
+                     "note_href": "/note?path=10-Knowledge%2FEvergreen%2Falpha.md"},
+                ],
+                "errors": [
+                    {"event_type": "absorb_parse_error",
+                     "subject": "bad.md", "snippet": "..."},
+                ],
+            }],
+        }
+        html = _render_timeline_page(payload)
+        assert "2026-05-06" in html
+        assert "5 events" in html
+        # Highlighted types render with .highlight / .error CSS class
+        assert "highlight" in html  # evergreen_auto_promoted
+        assert "error" in html      # absorb_parse_error
+        # Sample evergreen link present
+        assert "Alpha title" in html
+        assert "/note?path=10-Knowledge%2FEvergreen%2Falpha.md" in html
+        # Error subject present
+        assert "bad.md" in html
+
+
+# ---------------------------------------------------------------------------
+# Lineage card via build_note_page_payload + _render_lineage_card
+# ---------------------------------------------------------------------------
+
+
+_PAGES_INDEX_SCHEMA = """
+CREATE TABLE pages_index (
+  slug TEXT PRIMARY KEY,
+  title TEXT NOT NULL,
+  note_type TEXT NOT NULL,
+  path TEXT NOT NULL,
+  day_id TEXT NOT NULL,
+  frontmatter_json TEXT NOT NULL,
+  body TEXT NOT NULL
+);
+CREATE TABLE graph_clusters (
+  pack TEXT NOT NULL,
+  cluster_id TEXT NOT NULL,
+  cluster_kind TEXT NOT NULL,
+  label TEXT NOT NULL,
+  center_object_id TEXT NOT NULL,
+  member_object_ids_json TEXT NOT NULL,
+  score REAL NOT NULL DEFAULT 0.0,
+  PRIMARY KEY (pack, cluster_id)
+);
+CREATE TABLE community_crystals (
+  pack TEXT NOT NULL, cluster_id TEXT NOT NULL, body_md TEXT NOT NULL,
+  source_evergreen_slugs_json TEXT NOT NULL, synthesized_at TEXT NOT NULL,
+  llm_model TEXT NOT NULL, prompt_version TEXT NOT NULL,
+  superseded_by_synthesized_at TEXT NOT NULL DEFAULT '',
+  PRIMARY KEY (pack, cluster_id, synthesized_at)
+);
+CREATE TABLE contradiction_crystals (
+  pack TEXT NOT NULL, contradiction_id TEXT NOT NULL,
+  subject_key TEXT NOT NULL, body_md TEXT NOT NULL,
+  positive_claim_ids_json TEXT NOT NULL, negative_claim_ids_json TEXT NOT NULL,
+  source_object_ids_json TEXT NOT NULL, synthesized_at TEXT NOT NULL,
+  llm_model TEXT NOT NULL, prompt_version TEXT NOT NULL,
+  superseded_by_synthesized_at TEXT NOT NULL DEFAULT '',
+  PRIMARY KEY (pack, contradiction_id, synthesized_at)
+);
+"""
+
+
+def _seed_lineage_vault(tmp_path: Path) -> Path:
+    """Build a minimal vault: 1 raw source + 2 evergreens linking back
+    to it + 1 cluster + 1 community crystal."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    # Raw source
+    raw_dir = vault / "50-Inbox" / "03-Processed" / "2026-04"
+    raw_dir.mkdir(parents=True)
+    raw_path = raw_dir / "2026-04-28_neuphonic_neutts.md"
+    raw_path.write_text(
+        "---\nsource_type: github-project\n---\n\n# NeuTTS\n",
+        encoding="utf-8",
+    )
+    # Two evergreens that link back via ## Source
+    eg_dir = vault / "10-Knowledge" / "Evergreen"
+    eg_dir.mkdir(parents=True)
+    for slug, title in [
+        ("neutts-perth-watermarking", "NeuTTS Perth watermarking"),
+        ("neutts-voice-cloning-3-15s", "NeuTTS voice cloning 3-15s"),
+    ]:
+        (eg_dir / f"{slug}.md").write_text(
+            f"---\nnote_id: {slug}\ntitle: \"{title}\"\n"
+            f"extraction_prompt_version: v2\n---\n\n"
+            f"# {title}\n\nbody\n\n"
+            f"## Source\n\n- [[2026-04-28_neuphonic_neutts]]\n",
+            encoding="utf-8",
+        )
+
+    db_path = vault / "60-Logs" / "knowledge.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.executescript(_PAGES_INDEX_SCHEMA)
+    # Index the two evergreens — body must contain the wikilink so the
+    # LIKE query in _compute_v2_lineage finds them.
+    for slug, title in [
+        ("neutts-perth-watermarking", "NeuTTS Perth watermarking"),
+        ("neutts-voice-cloning-3-15s", "NeuTTS voice cloning 3-15s"),
+    ]:
+        conn.execute(
+            "INSERT INTO pages_index VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (slug, title, "evergreen",
+             str(eg_dir / f"{slug}.md"), "2026-05-06",
+             "{}",
+             f"# {title}\n\nbody\n\n## Source\n\n- [[2026-04-28_neuphonic_neutts]]\n"),
+        )
+    # One cluster containing both evergreens.
+    conn.execute(
+        "INSERT INTO graph_clusters VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("research-tech", "cluster::tts1", "louvain_community",
+         "TTS / voice cloning", "neutts-perth-watermarking",
+         json.dumps(["neutts-perth-watermarking", "neutts-voice-cloning-3-15s"]),
+         2.0),
+    )
+    # One community crystal.
+    conn.execute(
+        "INSERT INTO community_crystals VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        ("research-tech", "cluster::tts1",
+         "## body",
+         json.dumps(["neutts-perth-watermarking", "neutts-voice-cloning-3-15s"]),
+         "2026-05-06T00:00:00Z", "m", "v1", ""),
+    )
+    conn.commit()
+    conn.close()
+    return vault
+
+
+class TestLineageFromEvergreen:
+    def test_evergreen_traces_back_to_raw_source(self, tmp_path, monkeypatch):
+        vault = _seed_lineage_vault(tmp_path)
+        # Patch out get_note_provenance/traceability/inbound_capture
+        # because those want a fully populated knowledge_index — we
+        # only care about the new ``lineage`` field.
+        from ovp_pipeline.ui import view_models as vm
+        monkeypatch.setattr(vm, "get_note_provenance",
+                            lambda *a, **k: {"original_source_note": None,
+                                              "derived_deep_dives": []})
+        monkeypatch.setattr(vm, "get_note_traceability",
+                            lambda *a, **k: {
+                                "note": {"title": "x", "path": "x"},
+                                "source_notes": [], "deep_dives": [],
+                                "objects": [], "atlas_pages": [],
+                                "counts": {"deep_dives": 0, "objects": 0,
+                                            "atlas_pages": 0},
+                                "stage_label": "", "chain_status": "",
+                                "chain_summary": "", "missing_stages": [],
+                            })
+        monkeypatch.setattr(vm, "get_note_inbound_capture_summary",
+                            lambda *a, **k: {"summary": "", "items": []})
+
+        payload = build_note_page_payload(
+            vault,
+            note_path="10-Knowledge/Evergreen/neutts-perth-watermarking.md",
+        )
+        lineage = payload["lineage"]
+        assert lineage is not None
+        assert lineage["kind"] == "evergreen"
+        assert lineage["raw_source"]["slug"] == "2026-04-28_neuphonic_neutts"
+        assert lineage["raw_source"]["path"] == \
+            "50-Inbox/03-Processed/2026-04/2026-04-28_neuphonic_neutts.md"
+        # Sibling evergreens — both notes that link to the same raw source
+        slugs = [eg["slug"] for eg in lineage["evergreens"]]
+        assert "neutts-perth-watermarking" in slugs
+        assert "neutts-voice-cloning-3-15s" in slugs
+        # Cluster present
+        assert len(lineage["clusters"]) == 1
+        assert lineage["clusters"][0]["label"] == "TTS / voice cloning"
+        # Crystal present
+        assert len(lineage["crystals"]) == 1
+        assert lineage["crystals"][0]["kind"] == "community_crystal"
+
+    def test_raw_source_traces_forward_to_evergreens(self, tmp_path, monkeypatch):
+        vault = _seed_lineage_vault(tmp_path)
+        from ovp_pipeline.ui import view_models as vm
+        monkeypatch.setattr(vm, "get_note_provenance",
+                            lambda *a, **k: {"original_source_note": None,
+                                              "derived_deep_dives": []})
+        monkeypatch.setattr(vm, "get_note_traceability",
+                            lambda *a, **k: {
+                                "note": {"title": "x", "path": "x"},
+                                "source_notes": [], "deep_dives": [],
+                                "objects": [], "atlas_pages": [],
+                                "counts": {"deep_dives": 0, "objects": 0,
+                                            "atlas_pages": 0},
+                                "stage_label": "", "chain_status": "",
+                                "chain_summary": "", "missing_stages": [],
+                            })
+        monkeypatch.setattr(vm, "get_note_inbound_capture_summary",
+                            lambda *a, **k: {"summary": "", "items": []})
+
+        payload = build_note_page_payload(
+            vault,
+            note_path="50-Inbox/03-Processed/2026-04/2026-04-28_neuphonic_neutts.md",
+        )
+        lineage = payload["lineage"]
+        assert lineage is not None
+        assert lineage["kind"] == "raw_source"
+        # Raw source row points back at itself
+        assert lineage["raw_source"]["slug"] == "2026-04-28_neuphonic_neutts"
+        # Forward chain — both evergreens
+        assert len(lineage["evergreens"]) == 2
+        # Same cluster + crystal
+        assert len(lineage["clusters"]) == 1
+        assert len(lineage["crystals"]) == 1
+
+    def test_non_evergreen_non_raw_returns_none(self, tmp_path, monkeypatch):
+        vault = _seed_lineage_vault(tmp_path)
+        # An MOC / atlas page is neither — lineage should be None so the
+        # renderer suppresses the card.
+        moc_dir = vault / "10-Knowledge" / "Atlas"
+        moc_dir.mkdir(parents=True)
+        (moc_dir / "moc.md").write_text("# MOC\n", encoding="utf-8")
+        from ovp_pipeline.ui import view_models as vm
+        monkeypatch.setattr(vm, "get_note_provenance",
+                            lambda *a, **k: {"original_source_note": None,
+                                              "derived_deep_dives": []})
+        monkeypatch.setattr(vm, "get_note_traceability",
+                            lambda *a, **k: {
+                                "note": {"title": "x", "path": "x"},
+                                "source_notes": [], "deep_dives": [],
+                                "objects": [], "atlas_pages": [],
+                                "counts": {"deep_dives": 0, "objects": 0,
+                                            "atlas_pages": 0},
+                                "stage_label": "", "chain_status": "",
+                                "chain_summary": "", "missing_stages": [],
+                            })
+        monkeypatch.setattr(vm, "get_note_inbound_capture_summary",
+                            lambda *a, **k: {"summary": "", "items": []})
+
+        payload = build_note_page_payload(
+            vault, note_path="10-Knowledge/Atlas/moc.md",
+        )
+        assert payload["lineage"] is None
+
+
+class TestRenderLineageCard:
+    def test_none_returns_empty_string(self):
+        assert _render_lineage_card(None) == ""
+
+    def test_evergreen_chain_renders_all_blocks(self):
+        html = _render_lineage_card({
+            "kind": "evergreen",
+            "raw_source": {
+                "slug": "2026-04-28_neuphonic_neutts",
+                "path": "50-Inbox/03-Processed/2026-04/2026-04-28_neuphonic_neutts.md",
+                "note_href": "/note?path=...",
+            },
+            "evergreens": [
+                {"slug": "a", "title": "A", "note_href": "/note?a"},
+                {"slug": "b", "title": "B", "note_href": "/note?b"},
+            ],
+            "clusters": [
+                {"cluster_id": "cluster::aa", "label": "Topic A",
+                 "member_count": 5, "matched": ["a"],
+                 "cluster_href": "/ops/cluster?id=...",
+                 "crystal_note_href": "/note?path=40-Resources..."},
+            ],
+            "crystals": [
+                {"kind": "community_crystal", "crystal_id": "cluster::aa",
+                 "label": "cluster::aa", "note_href": "/note?path=..."},
+            ],
+        })
+        assert "Lineage" in html
+        assert "Raw source" in html
+        assert "2026-04-28_neuphonic_neutts" in html
+        assert "Evergreens" in html
+        assert "Clusters" in html
+        assert "Topic A" in html
+        assert "Crystals" in html
+        assert "produced 2 evergreen(s)" in html
+        assert "grouped into 1 cluster(s)" in html
+        assert "synthesized into 1 crystal(s)" in html
+
+    def test_archived_raw_source_shows_muted_note(self):
+        # When the raw source can't be located on disk (archived) the
+        # card still renders the stem with a hint.
+        html = _render_lineage_card({
+            "kind": "evergreen",
+            "raw_source": {"slug": "old-source", "path": "", "note_href": ""},
+            "evergreens": [],
+            "clusters": [],
+            "crystals": [],
+        })
+        assert "old-source" in html
+        assert "archived" in html


### PR DESCRIPTION
## Summary

Three additions to make the post-BL-050 maintainer dashboard usable again, plus surface the BL-058 raw-source ↔ evergreens ↔ crystals chain.

### A — Ops nav expansion

After BL-050 split shells, ops nav had 5 items but ~12 landing pages.  Now exposes Timeline / Pulse / Audit / Evergreens / Candidates / Actions / Contradictions / Signals as common-tier; Clusters / Deep-dives gated on ``_shell_supports_research_nav``.

### B — `/ops/timeline` daily digest

Sister to ``/ops/pulse`` (live tail) and ``/ops/events`` (object-keyed dossier).  Groups ``audit_events`` by date, shows per-day event-type histogram + clickable evergreens promoted + recent errors / skips.  ``/api/timeline`` returns the JSON.

### C — Lineage card on `/note?path=`

For v2 evergreens or 03-Processed sources, shows the chain ``Raw source ↑↓ Evergreens ↓ Clusters ↓ Crystals``.  Parses the ``## Source`` wikilink for raw-source back-references (no frontmatter-schema migration required), then queries ``pages_index`` / ``graph_clusters`` / ``community_crystals`` / ``contradiction_crystals``.  Card suppresses for MOCs / atlas pages.

## Test plan

- [x] 15 new tests in ``tests/test_ui_timeline_and_lineage.py``
- [x] Live render smoke against ovp-vault: nav has Timeline link, ``/ops/timeline`` returns 13.5KB HTML, ``/note?path=…craft-agents-oss-permission-modes.md`` traces back to 6 sibling evergreens + 2 clusters
- [x] Full suite: 2207/2207 (was 2192 + 15)

## Out of scope (BL-058b)

- Backfill ``pages_index.frontmatter_json`` with v2 fields so SQL ``json_extract`` filters work — current lineage computer parses bodies instead.
- Typed ``source_stem`` column to replace the body-LIKE sibling-evergreen lookup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded maintainer shell navigation with new routes: Timeline, Evergreens, Candidates, and Actions.
  * Added timeline page featuring a daily digest of audit events with event samples and error handling.
  * Integrated lineage visualization in note pages, depicting data flow through the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->