### PR TITLE
feat(intake): URL preservation + URL-dedup + deprecate deep-dive layer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,6 +156,7 @@ ovp-backfill-provenance = "ovp_pipeline.commands.backfill_provenance:main"
 ovp-refresh-source-authority = "ovp_pipeline.commands.refresh_source_authority:main"
 ovp-refresh-entities = "ovp_pipeline.commands.refresh_entities:main"
 ovp-embedding-dedup = "ovp_pipeline.commands.embedding_dedup:main"
+ovp-dedup-cleanup = "ovp_pipeline.commands.dedup_cleanup:main"
 ovp-backup-db = "ovp_pipeline.commands.backup_db:main"
 
 [project.entry-points."ovp.packs"]

--- a/src/ovp_pipeline/auto_article_processor.py
+++ b/src/ovp_pipeline/auto_article_processor.py
@@ -520,9 +520,30 @@ aliases: []
 
 
 class AutoArticleProcessor:
-    """全自动文章处理器"""
+    """全自动文章处理器
 
-    def __init__(self, vault_dir: Path, logger: PipelineLogger, txn: TransactionManager):
+    BL-058 follow-up (C2, 2026-05-06): the legacy 13-section
+    LLM-driven deep-dive layer is deprecated.  In the default mode
+    (``skip_deep_dive=True``) the processor does intake-only work
+    — parse raw, download images, run lifecycle archive — and
+    leaves knowledge extraction to ``auto_evergreen_extractor``
+    running v2 absorb directly on the raw.  This matches the flow
+    ``auto_github_processor`` already uses post-BL-066.
+
+    The 13-section path stays gated behind
+    ``skip_deep_dive=False`` (or the ``--keep-deep-dive`` CLI flag)
+    for callers that haven't migrated.  It will be removed once no
+    caller relies on it.
+    """
+
+    def __init__(
+        self,
+        vault_dir: Path,
+        logger: PipelineLogger,
+        txn: TransactionManager,
+        *,
+        skip_deep_dive: bool = True,
+    ):
         self.layout = VaultLayout.from_vault(vault_dir)
         self.vault_dir = self.layout.vault_dir
         self.raw_dir = self.layout.raw_dir
@@ -532,6 +553,10 @@ class AutoArticleProcessor:
         self.txn = txn
         self.llm = None
         self.article_processor = None
+        # C2: when True, ``process_single_file`` short-circuits
+        # before the LLM ``generate_interpretation`` call and just
+        # lets the lifecycle layer move the raw to 03-Processed.
+        self.skip_deep_dive = skip_deep_dive
 
     def _extract_source_date(self, file_path: Path) -> datetime:
         match = re.match(r"^(\d{4}-\d{2}-\d{2})_", file_path.name)
@@ -623,15 +648,19 @@ class AutoArticleProcessor:
     def _finalize_lifecycle_source(self, working_path: Path, result: dict, dry_run: bool = False) -> Path | None:
         if dry_run:
             return None
+        # C2: ``intake_only`` is a success — raw was parsed, no
+        # deep-dive was generated, and the file should still be
+        # archived to 03-Processed so absorb v2 can pick it up.
+        success_statuses = {"completed", "intake_only"}
         if lifecycle_is_under(working_path, self.layout.pinboard_dir):
-            if result["status"] == "completed" and working_path.exists():
+            if result["status"] in success_statuses and working_path.exists():
                 archived = archive_pinboard_source(self.layout, working_path)
                 result["source_path"] = str(archived)
                 return archived
             return None
         if not lifecycle_is_under(working_path, self.processing_dir):
             return None
-        if result["status"] == "completed":
+        if result["status"] in success_statuses:
             archived = self._archive_source_to_processed(working_path)
             result["source_path"] = str(archived)
             return archived
@@ -640,6 +669,56 @@ class AutoArticleProcessor:
             result["source_path"] = str(restored)
             return restored
         return None
+
+    def _check_url_dedup(self, source: Path) -> dict | None:
+        """Return a ``skipped_dedup`` result dict when ``source``'s URL
+        already appears in ``50-Inbox/03-Processed/``; ``None`` otherwise.
+
+        Pre-fix, intake had no URL-level guard — the same Twitter
+        thread re-clipped from Reader landed as a fresh raw every
+        time, and absorb burned LLM cycles re-extracting identical
+        bodies.  The 8 confirmed duplicates in the 2026-05-06 census
+        each represent one of these cases.
+
+        Note: only checks the active ``03-Processed`` tree, not the
+        ``70-Archive`` archive.  A user who archived a prior copy
+        and explicitly wants to re-process the URL gets through.
+        """
+        try:
+            text = source.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return None
+        from .source_dedup import _extract_source_url, find_existing_by_url
+        url = _extract_source_url(text)
+        if not url:
+            return None
+        existing = find_existing_by_url(self.vault_dir, url)
+        if existing is None:
+            return None
+        # Don't flag a self-match — the same file already living in
+        # 03-Processed isn't a dup of itself.
+        try:
+            if existing.resolve() == source.resolve():
+                return None
+        except OSError:
+            pass
+        self.logger.log("source_dedup_skipped", {
+            "source": str(source),
+            "url": url,
+            "existing": str(existing),
+        })
+        return {
+            "file": str(source),
+            "status": "skipped_dedup",
+            "output_path": None,
+            "tokens_used": 0,
+            "images_downloaded": 0,
+            "error": None,
+            "dedup": {
+                "url": url,
+                "existing": str(existing.relative_to(self.vault_dir)),
+            },
+        }
 
     def process_single_source(self, file_path: Path, dry_run: bool = False) -> dict:
         """Process one source while honoring the same lifecycle as inbox runs."""
@@ -660,6 +739,15 @@ class AutoArticleProcessor:
                 },
             }
             return result
+
+        # URL-dedup gate runs BEFORE any filesystem moves so a
+        # detected duplicate leaves ``50-Inbox/01-Raw`` (or wherever
+        # the source currently sits) untouched.  The user can then
+        # delete it manually or re-clip with a different URL.
+        dedup_result = self._check_url_dedup(source)
+        if dedup_result is not None:
+            dedup_result["source_lifecycle"] = {"zone": zone, "would_move": False}
+            return dedup_result
 
         working_path = source
         try:
@@ -923,13 +1011,32 @@ class AutoArticleProcessor:
                     print(f"Warning: could not upsert candidate '{d.proposed_slug}': {e}")
         return upserted
 
-    def _augment_frontmatter(self, content: str, decisions: list, area: str,
-                              txn_id: str) -> str:
+    def _augment_frontmatter(
+        self, content: str, decisions: list, area: str, txn_id: str,
+        *,
+        raw_source_url: str = "",
+    ) -> str:
         """
         Augment article frontmatter with link resolution metadata.
 
         Adds: area, canonical_concepts, concept_candidates,
-              link_resolution_status, link_resolution_version, pipeline_run_id
+              link_resolution_status, link_resolution_version,
+              pipeline_run_id
+
+        URL-preservation contract (C1, 2026-05-06):
+          ``raw_source_url`` is the canonical source URL pulled from
+          the **raw clipping's** frontmatter (before LLM rewriting).
+          When non-empty, this method overwrites whatever the LLM
+          wrote into ``source:`` with that URL.  Pre-fix the LLM
+          freely regenerated the field, often picking the article
+          subtitle or institution name (e.g. ``"硅基时间系列 ·
+          1+1原生组织(一)"``) and dropping the real
+          ``https://mp.weixin.qq.com/s/...`` URL — so the deep-dive
+          could no longer be traced back to its origin.
+
+          We also stash the URL as a dedicated ``source_url`` field
+          (not just ``source``) so any future refactor that
+          regenerates ``source`` can't silently lose the URL again.
         """
         if not content.startswith("---"):
             return content
@@ -961,6 +1068,15 @@ class AutoArticleProcessor:
         fm_dict["link_resolution_status"] = "resolved"
         fm_dict["link_resolution_version"] = RESOLVER_VERSION
         fm_dict["pipeline_run_id"] = txn_id
+
+        # C1: force source URL preservation when the raw had one.
+        # ``source`` may have been set to a non-URL by the LLM; we
+        # overwrite it.  We also write the canonical ``source_url``
+        # field for downstream tools that prefer a typed contract
+        # over the polysemantic ``source``.
+        if raw_source_url:
+            fm_dict["source"] = raw_source_url
+            fm_dict["source_url"] = raw_source_url
 
         # Reconstruct frontmatter
         new_fm_lines = []
@@ -1039,6 +1155,24 @@ class AutoArticleProcessor:
                 result["status"] = "dry_run"
                 return result
 
+            # C2 (BL-058 follow-up): skip the legacy 13-section LLM
+            # rewrite entirely.  ``auto_evergreen_extractor`` running
+            # v2 absorb on the raw produces strictly better units
+            # (specifics-preserving, no abstraction inflation), and
+            # the lifecycle layer in ``process_single_source`` /
+            # ``process_inbox`` still moves the raw to 03-Processed
+            # so absorb can pick it up on the next run.  Returning
+            # ``intake_only`` short-circuits before the LLM call,
+            # link resolution, and the 20-Areas write.
+            if self.skip_deep_dive:
+                result["status"] = "intake_only"
+                self.logger.log("article_intake_only", {
+                    "file": str(file_path.name),
+                    "source_url": str(file_data.get("source") or ""),
+                    "reason": "skip_deep_dive (C2 default)",
+                })
+                return result
+
             if not self.article_processor:
                 result["status"] = "error"
                 result["error"] = "LLM not initialized"
@@ -1076,9 +1210,17 @@ class AutoArticleProcessor:
                 interpretation, article_stem, classification, txn_id
             )
 
-            # Augment frontmatter with resolution metadata
+            # Augment frontmatter with resolution metadata.
+            # C1: pass the raw source URL so the deep-dive's
+            # ``source:`` field gets the canonical URL, not whatever
+            # the LLM picked from the article subtitle.
+            raw_source_url = ""
+            raw_src = str(file_data.get("source") or "").strip()
+            if raw_src.startswith(("http://", "https://")):
+                raw_source_url = raw_src
             interpretation = self._augment_frontmatter(
-                interpretation, decisions, classification, txn_id
+                interpretation, decisions, classification, txn_id,
+                raw_source_url=raw_source_url,
             )
 
             # 确定输出路径
@@ -1194,7 +1336,10 @@ class AutoArticleProcessor:
             result = self.process_single_file(working_path, dry_run)
             results["files"].append(result)
 
-            if result["status"] == "completed":
+            # C2: ``intake_only`` rolls up under ``completed`` since
+            # the raw was successfully archived to 03-Processed and
+            # absorb v2 will produce evergreens on the next run.
+            if result["status"] in ("completed", "intake_only"):
                 results["completed"] += 1
                 results["total_tokens"] += result.get("tokens_used", 0)
                 self._finalize_lifecycle_source(working_path, result, dry_run=dry_run)
@@ -1232,6 +1377,16 @@ def main():
     parser.add_argument("--api-base", help="API Base URL")
     parser.add_argument("--vault-dir", type=Path, default=None, help="Vault根目录")
     parser.add_argument("--output-dir", type=Path, default=None, help="兼容旧入口，当前忽略")
+    parser.add_argument(
+        "--keep-deep-dive", action="store_true",
+        help=(
+            "Run the legacy 13-section LLM-driven deep-dive layer "
+            "(BL-058 follow-up: deprecated, off by default).  Off "
+            "is the new default — raw lands in 03-Processed and "
+            "absorb v2 produces evergreens directly, no abstraction "
+            "inflation."
+        ),
+    )
     args = parser.parse_args()
 
     layout = VaultLayout.from_vault(args.vault_dir or VAULT_DIR)
@@ -1245,14 +1400,23 @@ def main():
     logger.log("transaction_started", {"txn_id": txn_id, "type": "article-processing"})
 
     # 初始化处理器
-    processor = AutoArticleProcessor(layout.vault_dir, logger, txn)
+    processor = AutoArticleProcessor(
+        layout.vault_dir, logger, txn,
+        skip_deep_dive=not args.keep_deep_dive,
+    )
 
-    try:
-        processor.init_llm(api_key=args.api_key, api_base=args.api_base)
-        print(f"✓ LLM Client: {processor.llm.model}")
-    except Exception as e:
-        print(f"✗ {e}")
-        sys.exit(1)
+    # C2: skip-deep-dive mode does no LLM calls — don't fail the
+    # CLI on a missing API key in that case.  Init only when the
+    # legacy deep-dive path is opted in.
+    if not processor.skip_deep_dive:
+        try:
+            processor.init_llm(api_key=args.api_key, api_base=args.api_base)
+            print(f"✓ LLM Client: {processor.llm.model}")
+        except Exception as e:
+            print(f"✗ {e}")
+            sys.exit(1)
+    else:
+        print("✓ skip-deep-dive (intake-only mode, no LLM)")
 
     # 执行处理
     txn.step(txn_id, "process", "in_progress", "Processing articles")
@@ -1261,11 +1425,16 @@ def main():
         results = processor.process_inbox(dry_run=args.dry_run, batch_size=args.batch_size, txn_id=txn_id)
     elif args.process_single:
         result = processor.process_single_source(args.process_single, dry_run=args.dry_run)
+        # C2: ``intake_only`` rolls up under ``completed`` since
+        # absorb v2 will produce evergreens on the next run.
+        # ``skipped_dedup`` keeps its own bucket so it's visible
+        # in the summary line.
+        ok = result["status"] in ("completed", "intake_only")
         results = {
             "total": 1,
-            "completed": 1 if result["status"] == "completed" else 0,
+            "completed": 1 if ok else 0,
             "failed": 1 if result["status"] == "error" else 0,
-            "skipped": 1 if result["status"] == "skipped" else 0,
+            "skipped": 1 if result["status"] in ("skipped", "skipped_dedup") else 0,
             "total_tokens": result.get("tokens_used", 0)
         }
     elif args.single:

--- a/src/ovp_pipeline/auto_article_processor.py
+++ b/src/ovp_pipeline/auto_article_processor.py
@@ -680,16 +680,27 @@ class AutoArticleProcessor:
         bodies.  The 8 confirmed duplicates in the 2026-05-06 census
         each represent one of these cases.
 
+        Scope: invoked from :meth:`process_single_source` only — not
+        from :meth:`process_inbox`.  Inbox files are post-intake (the
+        next pipeline stage), so applying URL dedup there would
+        short-circuit legitimate reprocessing.  The asymmetry is
+        intentional; pre-existing 03-Processed dups are handled by
+        ``ovp-dedup-cleanup``.
+
         Note: only checks the active ``03-Processed`` tree, not the
         ``70-Archive`` archive.  A user who archived a prior copy
         and explicitly wants to re-process the URL gets through.
         """
+        from .source_dedup import (
+            extract_source_url,
+            find_existing_by_url,
+            read_file_head,
+        )
         try:
-            text = source.read_text(encoding="utf-8", errors="replace")
+            text = read_file_head(source)
         except OSError:
             return None
-        from .source_dedup import _extract_source_url, find_existing_by_url
-        url = _extract_source_url(text)
+        url = extract_source_url(text)
         if not url:
             return None
         existing = find_existing_by_url(self.vault_dir, url)

--- a/src/ovp_pipeline/commands/dedup_cleanup.py
+++ b/src/ovp_pipeline/commands/dedup_cleanup.py
@@ -1,0 +1,138 @@
+"""ovp-dedup-cleanup — find duplicate raw sources by URL and archive
+all but the canonical copy.
+
+Why this CLI exists
+-------------------
+``source_dedup`` shuts the door at intake going forward, but the
+2026-05-06 census found 8 URLs already present in 2-3 raw files
+each (Reader re-clipping artefact).  Those duplicates each got a
+full absorb pass, producing redundant evergreens with the same
+body but different ``absorbed_at`` timestamps.
+
+This CLI surfaces the dups, picks one to keep (the largest by
+body size — most likely the most-fully-rendered copy), and moves
+the others into ``70-Archive/<date>_dedup-cleanup/`` so the next
+``ovp-knowledge-index`` rebuild drops them out of the active
+index.
+
+Operator workflow:
+
+    ovp-dedup-cleanup --vault-dir <vault>             # dry-run summary
+    ovp-dedup-cleanup --vault-dir <vault> --apply     # archive losers
+"""
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from ..runtime import VaultLayout, resolve_vault_dir
+from ..source_dedup import find_duplicate_groups
+
+
+def _archive_path(vault_dir: Path) -> Path:
+    today = datetime.now().strftime("%Y-%m-%d")
+    return vault_dir / "70-Archive" / f"{today}_dedup-cleanup"
+
+
+def _pick_canonical(paths: list[Path]) -> tuple[Path, list[Path]]:
+    """Choose which copy to keep.  Largest body size wins —
+    rationale: a partial Reader fetch typically truncates body, so
+    a 22 KB clip beats a 4 KB stub of the same URL.  Ties broken
+    alphabetically for determinism (so re-running the CLI on the
+    same vault picks the same winner)."""
+    sized = sorted(paths, key=lambda p: (-p.stat().st_size, str(p)))
+    return sized[0], sized[1:]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="ovp-dedup-cleanup",
+        description=(
+            "Find raws in 50-Inbox/03-Processed sharing a source URL "
+            "and archive all but the largest copy.  Dry-run by default; "
+            "pass --apply to actually move files."
+        ),
+    )
+    parser.add_argument("--vault-dir", type=Path, default=None)
+    parser.add_argument("--apply", action="store_true",
+                        help="Actually move the duplicates (default: dry-run)")
+    args = parser.parse_args(argv)
+
+    vault = resolve_vault_dir(args.vault_dir)
+    layout = VaultLayout.from_vault(vault)
+
+    groups = find_duplicate_groups(vault)
+    if not groups:
+        print("No duplicate URLs found in 50-Inbox/03-Processed.")
+        return 0
+
+    archive_dir = _archive_path(vault)
+    n_groups = len(groups)
+    n_to_archive = sum(len(paths) - 1 for paths in groups.values())
+    n_to_keep = n_groups
+    print(f"Found {n_groups} URL group(s) with duplicates "
+          f"({n_to_archive} extra files to archive, "
+          f"{n_to_keep} canonical files to keep)")
+    print()
+
+    # Initialize the audit logger up-front so a partially-completed
+    # move loop can't leave us re-stat()-ing files that already
+    # moved.  Each archive call writes its own pipeline.jsonl event,
+    # captured at move-time.
+    if args.apply:
+        from ..auto_evergreen_extractor import PipelineLogger
+        logger = PipelineLogger(layout.pipeline_log)
+    else:
+        logger = None
+
+    moved = 0
+    for url, paths in sorted(groups.items()):
+        canonical, losers = _pick_canonical(paths)
+        print(f"  URL: {url[:90]}")
+        try:
+            keep_size = canonical.stat().st_size
+        except OSError:
+            keep_size = 0
+        print(f"    KEEP   {canonical.relative_to(vault)} "
+              f"({keep_size} bytes)")
+        for loser in losers:
+            target = archive_dir / loser.relative_to(vault / "50-Inbox")
+            # Snapshot the size BEFORE the move so the audit event
+            # never re-stat()s a freshly-moved file.
+            try:
+                size = loser.stat().st_size
+            except OSError:
+                size = 0
+            verb = "ARCHIVE" if args.apply else "WOULD ARCHIVE"
+            print(f"    {verb}{' ':3s}{loser.relative_to(vault)} "
+                  f"({size} bytes) → {target.relative_to(vault)}")
+            if args.apply:
+                target.parent.mkdir(parents=True, exist_ok=True)
+                if target.exists():
+                    print("             ⊘ target already exists, deleting source")
+                    loser.unlink()
+                else:
+                    shutil.move(str(loser), str(target))
+                moved += 1
+                if logger is not None:
+                    logger.log("dedup_cleanup_archived", {
+                        "url": url,
+                        "archived_path": str(target.relative_to(vault)),
+                        "kept": str(canonical.relative_to(vault)),
+                        "size_bytes": size,
+                        "trigger": "ovp-dedup-cleanup",
+                    })
+        print()
+
+    if args.apply:
+        print(f"Moved {moved} duplicate(s) into {archive_dir.relative_to(vault)}")
+        return 0
+    print("Dry-run only — re-run with --apply to actually move files.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ovp_pipeline/commands/dedup_cleanup.py
+++ b/src/ovp_pipeline/commands/dedup_cleanup.py
@@ -111,16 +111,27 @@ def main(argv: list[str] | None = None) -> int:
                   f"({size} bytes) → {target.relative_to(vault)}")
             if args.apply:
                 target.parent.mkdir(parents=True, exist_ok=True)
-                if target.exists():
-                    print("             ⊘ target already exists, deleting source")
-                    loser.unlink()
-                else:
-                    shutil.move(str(loser), str(target))
+                # Don't silently unlink on collision — the existing
+                # target's bytes may differ (partial prior run, manual
+                # restore from archive, etc.).  Pick a unique target
+                # so we never lose data, and let the audit event
+                # record the actual on-disk path.
+                archived_target = target
+                counter = 1
+                while archived_target.exists():
+                    archived_target = target.with_name(
+                        f"{target.stem}__dup{counter}{target.suffix}"
+                    )
+                    counter += 1
+                if archived_target != target:
+                    print(f"             ⚠ target exists, archiving as "
+                          f"{archived_target.name}")
+                shutil.move(str(loser), str(archived_target))
                 moved += 1
                 if logger is not None:
                     logger.log("dedup_cleanup_archived", {
                         "url": url,
-                        "archived_path": str(target.relative_to(vault)),
+                        "archived_path": str(archived_target.relative_to(vault)),
                         "kept": str(canonical.relative_to(vault)),
                         "size_bytes": size,
                         "trigger": "ovp-dedup-cleanup",

--- a/src/ovp_pipeline/source_dedup.py
+++ b/src/ovp_pipeline/source_dedup.py
@@ -36,19 +36,32 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import Iterable
 
 # Frontmatter keys we recognize as the canonical source URL.  Order
 # matters: matches the precedence in
 # ``backfill_provenance.py:_canonical_source_url``.
 _SOURCE_URL_KEYS = ("source_url", "source", "url", "github", "twitter", "arxiv")
 
+# Frontmatter rarely exceeds ~1 KB; 3 KB is a safe upper bound that
+# still lets us reject bodies without slurping multi-MB raws.
+FRONTMATTER_SCAN_LIMIT = 3000
 
-def _extract_source_url(text: str) -> str | None:
+
+def read_file_head(path: Path, limit: int = FRONTMATTER_SCAN_LIMIT) -> str:
+    """Return the first ``limit`` chars of ``path`` (or fewer if the
+    file is shorter).  Used by the dedup index and intake URL gate to
+    avoid loading multi-MB clipped articles when only the frontmatter
+    needs inspection.
+    """
+    with path.open("r", encoding="utf-8", errors="replace") as fh:
+        return fh.read(limit)
+
+
+def extract_source_url(text: str) -> str | None:
     """Pull a ``source: <url>`` value from the frontmatter.  Returns
     ``None`` for files with no http/https URL in any recognized key.
     """
-    head = text[:3000]
+    head = text[:FRONTMATTER_SCAN_LIMIT]
     if not head.startswith("---"):
         return None
     fm_end = head.find("\n---", 3)
@@ -65,6 +78,11 @@ def _extract_source_url(text: str) -> str | None:
         if v.startswith(("http://", "https://")):
             return v
     return None
+
+
+# Backwards-compatible private alias kept so a partially-updated tree
+# doesn't ImportError; new callers should use ``extract_source_url``.
+_extract_source_url = extract_source_url
 
 
 def build_url_index(vault_dir: Path | str) -> dict[str, Path]:
@@ -84,10 +102,10 @@ def build_url_index(vault_dir: Path | str) -> dict[str, Path]:
     out: dict[str, Path] = {}
     for f in sorted(processed.rglob("*.md")):
         try:
-            text = f.read_text(encoding="utf-8", errors="replace")
+            text = read_file_head(f)
         except OSError:
             continue
-        url = _extract_source_url(text)
+        url = extract_source_url(text)
         if url and url not in out:
             out[url] = f
     return out
@@ -128,10 +146,10 @@ def find_duplicate_groups(
         return groups
     for f in sorted(processed.rglob("*.md")):
         try:
-            text = f.read_text(encoding="utf-8", errors="replace")
+            text = read_file_head(f)
         except OSError:
             continue
-        url = _extract_source_url(text)
+        url = extract_source_url(text)
         if url:
             groups.setdefault(url, []).append(f)
     return {u: paths for u, paths in groups.items() if len(paths) > 1}

--- a/src/ovp_pipeline/source_dedup.py
+++ b/src/ovp_pipeline/source_dedup.py
@@ -1,0 +1,137 @@
+"""URL-based source-dedup index.
+
+Scans ``50-Inbox/03-Processed/**/*.md`` for frontmatter ``source:``
+URLs and returns a ``url → path`` map.  Intake processors (article,
+clippings) consult this before writing a new raw to skip duplicate
+URLs that are already on disk.
+
+Why this exists
+---------------
+The pre-fix pipeline had no URL-level dedup.  ``unique_child`` only
+defends against filename collisions; ``source_fingerprint`` is a
+scoring signal, not a gate.  Real-world fallout: 8 confirmed
+duplicate URLs in 03-Processed at 2026-05-06 census time —
+the same Twitter thread re-clipped from Reader 2-3 times.
+
+Each duplicate triggered a fresh absorb run, producing redundant
+evergreens with identical bodies but different ``absorbed_at``
+timestamps and slightly different concept slugs.  This module
+shuts the door at intake, before any LLM cost is spent.
+
+Re-adding a URL the user explicitly wants:
+  * The dedup check looks ONLY at the active ``03-Processed`` tree,
+    NOT ``70-Archive``.  Archived raws are out of scope by design —
+    the user's "I cleared this and want a fresh take" workflow needs
+    to keep working.
+
+Out of scope:
+  * Body-content fingerprinting (two URLs that resolve to the same
+    article).  The ~1% overlap doesn't justify the SHA cost yet;
+    URL-level dedup catches the noisy case.
+  * Cross-domain canonicalization (``mp.weixin.qq.com/s/X`` vs the
+    same article re-shared on Substack).  Out of scope — the URLs
+    differ, treat as distinct sources.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Iterable
+
+# Frontmatter keys we recognize as the canonical source URL.  Order
+# matters: matches the precedence in
+# ``backfill_provenance.py:_canonical_source_url``.
+_SOURCE_URL_KEYS = ("source_url", "source", "url", "github", "twitter", "arxiv")
+
+
+def _extract_source_url(text: str) -> str | None:
+    """Pull a ``source: <url>`` value from the frontmatter.  Returns
+    ``None`` for files with no http/https URL in any recognized key.
+    """
+    head = text[:3000]
+    if not head.startswith("---"):
+        return None
+    fm_end = head.find("\n---", 3)
+    if fm_end == -1:
+        return None
+    fm = head[3:fm_end]
+    for key in _SOURCE_URL_KEYS:
+        m = re.search(rf"^{key}:\s*(.+)$", fm, re.MULTILINE)
+        if not m:
+            continue
+        v = m.group(1).strip().strip('"').strip("'")
+        # Strip trailing punctuation that some YAML emitters add.
+        v = v.rstrip(",").rstrip(")").rstrip("]")
+        if v.startswith(("http://", "https://")):
+            return v
+    return None
+
+
+def build_url_index(vault_dir: Path | str) -> dict[str, Path]:
+    """One-shot scan of ``50-Inbox/03-Processed/**/*.md`` returning
+    ``{source_url: raw_path}``.
+
+    The map is **first-write-wins** when two raws have the same URL —
+    the alphabetically first by relative path.  Callers don't rely
+    on which one wins because the dedup check is "any of them
+    exists" not "the canonical one is X".
+    """
+    vault = Path(vault_dir).resolve()
+    processed = vault / "50-Inbox" / "03-Processed"
+    if not processed.is_dir():
+        return {}
+
+    out: dict[str, Path] = {}
+    for f in sorted(processed.rglob("*.md")):
+        try:
+            text = f.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        url = _extract_source_url(text)
+        if url and url not in out:
+            out[url] = f
+    return out
+
+
+def find_existing_by_url(
+    vault_dir: Path | str,
+    url: str,
+    *,
+    index: dict[str, Path] | None = None,
+) -> Path | None:
+    """Return the ``03-Processed`` raw file whose ``source:``
+    matches ``url``, or ``None``.
+
+    Pass a pre-built ``index`` (from :func:`build_url_index`) for
+    batch operations.  A fresh ``index`` is built per call when
+    ``index`` is ``None`` — fine for one-off intake checks but
+    wasteful in a tight loop.
+    """
+    if index is None:
+        index = build_url_index(vault_dir)
+    return index.get(url)
+
+
+def find_duplicate_groups(
+    vault_dir: Path | str,
+) -> dict[str, list[Path]]:
+    """Return groups of paths that share a ``source:`` URL — i.e.
+    the duplicates already on disk.  Used by the cleanup CLI to
+    flag and archive everything but the canonical copy.
+
+    Excludes singletons; only groups with len ≥ 2 are returned.
+    """
+    vault = Path(vault_dir).resolve()
+    processed = vault / "50-Inbox" / "03-Processed"
+    groups: dict[str, list[Path]] = {}
+    if not processed.is_dir():
+        return groups
+    for f in sorted(processed.rglob("*.md")):
+        try:
+            text = f.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        url = _extract_source_url(text)
+        if url:
+            groups.setdefault(url, []).append(f)
+    return {u: paths for u, paths in groups.items() if len(paths) > 1}

--- a/tests/test_intake_dedup_and_url.py
+++ b/tests/test_intake_dedup_and_url.py
@@ -32,11 +32,7 @@ Why E2E (not unit-only):
 from __future__ import annotations
 
 import json
-import re
 from pathlib import Path
-from unittest.mock import patch
-
-import pytest
 
 
 # ---------------------------------------------------------------------------
@@ -301,9 +297,6 @@ class TestUrlIntakeDedup:
         not 70-Archive — so an archived URL is invisible to the
         dedup check by design.
         """
-        from ovp_pipeline.runtime import VaultLayout
-        layout = VaultLayout.from_vault(temp_vault)
-
         # Pretend an old copy was archived.
         archive_dir = temp_vault / "70-Archive" / "old"
         archive_dir.mkdir(parents=True)
@@ -332,7 +325,7 @@ class TestUrlIntakeDedup:
             _write_clipping(temp_vault, "second.md", url=url), dry_run=False,
         )
         log = (temp_vault / "60-Logs" / "pipeline.jsonl").read_text(encoding="utf-8")
-        events = [json.loads(l) for l in log.splitlines() if l.strip()]
+        events = [json.loads(line) for line in log.splitlines() if line.strip()]
         dedup_events = [
             e for e in events if e.get("event_type") == "source_dedup_skipped"
         ]

--- a/tests/test_intake_dedup_and_url.py
+++ b/tests/test_intake_dedup_and_url.py
@@ -1,0 +1,400 @@
+"""E2E tests for the BL-058 follow-up intake hardening:
+
+1. URL preservation through the deep-dive layer (C1).
+   When the legacy ``--keep-deep-dive`` flow runs, the resulting
+   markdown's frontmatter ``source:`` MUST be the raw clipping's
+   URL — not whatever the LLM wrote.
+
+2. Deep-dive layer is skipped by default (C2).
+   ``AutoArticleProcessor`` short-circuits before the LLM call,
+   leaves intake-only output, and the lifecycle still archives
+   the raw to ``50-Inbox/03-Processed/``.
+
+3. URL-based intake dedup.
+   When the same source URL is intaken twice, the second pass
+   emits ``source_dedup_skipped`` and leaves the new clipping
+   in place rather than producing a duplicate raw.
+
+4. ``source_dedup`` index correctness.
+   The URL→raw map handles the recognized frontmatter keys,
+   ignores quoted variants, skips files outside 03-Processed,
+   and surfaces dup groups for the cleanup CLI.
+
+Why E2E (not unit-only):
+   The original BL-058 abstraction-inflation bug shipped because
+   no test ran the full intake → deep-dive → frontmatter chain
+   together; the LLM-rewrites-frontmatter path stayed invisible
+   until users saw URLs disappearing months later.  These tests
+   pin the contract end-to-end so a future refactor that drops
+   ``raw_source_url`` again breaks here, not in production.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _write_clipping(
+    vault: Path, name: str, *, url: str, body: str = "Article body.\n",
+) -> Path:
+    """Drop a raw clipping under 50-Inbox/01-Raw/ with the standard
+    Reader-style frontmatter.  Returns the file path."""
+    raw_dir = vault / "50-Inbox" / "01-Raw"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    f = raw_dir / name
+    f.write_text(
+        f"""---
+title: "Article Title"
+source: "{url}"
+author: "[[clip-author]]"
+published: 2026-05-04
+created: 2026-05-04
+tags:
+  - "clippings"
+---
+
+{body}
+""",
+        encoding="utf-8",
+    )
+    return f
+
+
+def _make_processor(temp_vault: Path, *, skip_deep_dive: bool = True):
+    from ovp_pipeline.auto_article_processor import (
+        AutoArticleProcessor,
+        PipelineLogger,
+        TransactionManager,
+    )
+    from ovp_pipeline.runtime import VaultLayout
+
+    layout = VaultLayout.from_vault(temp_vault)
+    layout.logs_dir.mkdir(parents=True, exist_ok=True)
+    layout.transactions_dir.mkdir(parents=True, exist_ok=True)
+    logger = PipelineLogger(layout.pipeline_log)
+    txn = TransactionManager(layout.transactions_dir)
+    return AutoArticleProcessor(
+        layout.vault_dir, logger, txn,
+        skip_deep_dive=skip_deep_dive,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. C1: URL preservation through legacy deep-dive
+# ---------------------------------------------------------------------------
+
+
+class TestC1UrlPreservedInDeepDive:
+    """When the operator opts back into the legacy LLM deep-dive
+    layer (``--keep-deep-dive`` / ``skip_deep_dive=False``), the
+    resulting markdown's ``source:`` field MUST be the raw URL,
+    not whatever the LLM picked from the article subtitle.
+
+    Pre-fix the LLM regenerated the entire frontmatter freely and
+    often replaced the URL with a non-URL identifier (article
+    series name, institution name, …).  ``_augment_frontmatter``
+    now overwrites both ``source:`` and ``source_url:`` with the
+    raw URL, treating the LLM's value as untrusted.
+    """
+
+    def test_augment_overwrites_llm_source_with_raw_url(self):
+        from ovp_pipeline.auto_article_processor import (
+            AutoArticleProcessor, PipelineLogger, TransactionManager,
+        )
+        from ovp_pipeline.runtime import VaultLayout
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            (tmp_path / "60-Logs").mkdir()
+            (tmp_path / "10-Knowledge" / "Atlas").mkdir(parents=True)
+            layout = VaultLayout.from_vault(tmp_path)
+            logger = PipelineLogger(layout.pipeline_log)
+            txn = TransactionManager(layout.transactions_dir)
+            proc = AutoArticleProcessor(
+                tmp_path, logger, txn, skip_deep_dive=False,
+            )
+
+            # Mimic the LLM-generated deep-dive markdown — the
+            # bug shape is "source: <subtitle>" instead of the URL.
+            llm_output = (
+                "---\n"
+                'title: "硅基原子"\n'
+                'source: 硅基时间系列 · 1+1原生组织(一)\n'
+                'author: 蒋涛\n'
+                'date: 2026-05-04\n'
+                "---\n\n"
+                "# Body\n"
+            )
+
+            result = proc._augment_frontmatter(
+                llm_output,
+                decisions=[],
+                area="AI-Research",
+                txn_id="test-txn",
+                raw_source_url="https://mp.weixin.qq.com/s/GSTKPlO_tnIkzSJKgphC-g",
+            )
+            # Both ``source`` and the new ``source_url`` carry the URL.
+            assert "source: https://mp.weixin.qq.com/s/GSTKPlO_tnIkzSJKgphC-g" in result
+            assert "source_url: https://mp.weixin.qq.com/s/GSTKPlO_tnIkzSJKgphC-g" in result
+            # The subtitle no longer poses as ``source``.
+            assert "source: 硅基时间系列" not in result
+
+    def test_no_clobber_when_raw_has_no_url(self):
+        # If the raw didn't have a URL (rare, but possible for
+        # hand-written notes), don't overwrite — the LLM's
+        # best-effort guess is still better than empty.
+        from ovp_pipeline.auto_article_processor import (
+            AutoArticleProcessor, PipelineLogger, TransactionManager,
+        )
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            (tmp_path / "60-Logs").mkdir()
+            (tmp_path / "10-Knowledge" / "Atlas").mkdir(parents=True)
+            from ovp_pipeline.runtime import VaultLayout
+            layout = VaultLayout.from_vault(tmp_path)
+            logger = PipelineLogger(layout.pipeline_log)
+            txn = TransactionManager(layout.transactions_dir)
+            proc = AutoArticleProcessor(
+                tmp_path, logger, txn, skip_deep_dive=False,
+            )
+            llm_output = (
+                "---\n"
+                'title: "Note"\n'
+                'source: Anthropic Engineering Blog\n'
+                "---\n\n# Body\n"
+            )
+            result = proc._augment_frontmatter(
+                llm_output, decisions=[], area="AI-Research",
+                txn_id="t", raw_source_url="",
+            )
+            # LLM's best-effort ``source`` survives.
+            assert "source: Anthropic Engineering Blog" in result
+            # ``source_url`` not added when we have nothing to add.
+            assert "source_url:" not in result
+
+
+# ---------------------------------------------------------------------------
+# 2. C2: deep-dive skipped by default
+# ---------------------------------------------------------------------------
+
+
+class TestC2DeepDiveSkippedByDefault:
+    """Default behaviour: ``skip_deep_dive=True``.
+
+    ``process_single_file`` short-circuits before the LLM call.
+    The lifecycle layer still archives the raw into 03-Processed
+    so absorb v2 can pick it up on the next run.  No write to
+    ``20-Areas/<area>/Topics/`` happens.
+    """
+
+    def test_intake_only_status_skips_llm(self, temp_vault):
+        proc = _make_processor(temp_vault, skip_deep_dive=True)
+        # No init_llm — verifies the LLM path is never reached.
+        clip = _write_clipping(
+            temp_vault, "2026-05-04_test.md",
+            url="https://example.com/article",
+        )
+        # Stage manually since process_single_file expects a file
+        # under processing_dir (the lifecycle would do this in the
+        # full process_single_source path).
+        from ovp_pipeline.runtime import VaultLayout
+        layout = VaultLayout.from_vault(temp_vault)
+        layout.processing_dir.mkdir(parents=True, exist_ok=True)
+        target = layout.processing_dir / clip.name
+        clip.rename(target)
+
+        result = proc.process_single_file(target, dry_run=False)
+        assert result["status"] == "intake_only"
+        # No 20-Areas write.
+        topics_dir = temp_vault / "20-Areas" / "AI-Research" / "Topics"
+        if topics_dir.exists():
+            assert not list(topics_dir.rglob("*_深度解读.md"))
+
+    def test_intake_only_archives_raw_to_03_processed(self, temp_vault):
+        # Goes through the full ``process_single_source`` path —
+        # which moves clipping → raw → processing → archives the
+        # processing copy to 03-Processed.
+        proc = _make_processor(temp_vault, skip_deep_dive=True)
+        clip = _write_clipping(
+            temp_vault, "2026-05-04_clip.md",
+            url="https://example.com/clip",
+        )
+        result = proc.process_single_source(clip, dry_run=False)
+        assert result["status"] == "intake_only"
+        # Raw landed in 03-Processed under the right month dir.
+        archived = list(
+            (temp_vault / "50-Inbox" / "03-Processed").rglob(
+                "2026-05-04_clip.md"
+            )
+        )
+        assert len(archived) == 1, (
+            f"expected raw to be archived to 03-Processed, found {archived}"
+        )
+
+    def test_intake_only_preserves_source_url_in_archived_raw(self, temp_vault):
+        """Critical contract: the URL the user clipped MUST survive
+        the lifecycle move.  Otherwise the BL-058 abstraction
+        recurs from a different angle (we'd lose URLs at archive
+        time instead of at deep-dive time)."""
+        proc = _make_processor(temp_vault, skip_deep_dive=True)
+        url = "https://mp.weixin.qq.com/s/test123"
+        clip = _write_clipping(
+            temp_vault, "2026-05-04_wechat.md", url=url,
+        )
+        proc.process_single_source(clip, dry_run=False)
+        archived = next(
+            (temp_vault / "50-Inbox" / "03-Processed").rglob("2026-05-04_wechat.md")
+        )
+        text = archived.read_text(encoding="utf-8")
+        assert f'source: "{url}"' in text
+
+
+# ---------------------------------------------------------------------------
+# 3. URL-based dedup
+# ---------------------------------------------------------------------------
+
+
+class TestUrlIntakeDedup:
+    def test_same_url_second_intake_skipped(self, temp_vault):
+        proc = _make_processor(temp_vault, skip_deep_dive=True)
+        url = "https://example.com/dup-article"
+
+        # First intake — succeeds, raw lands in 03-Processed.
+        clip1 = _write_clipping(
+            temp_vault, "2026-05-04_first.md", url=url,
+        )
+        r1 = proc.process_single_source(clip1, dry_run=False)
+        assert r1["status"] == "intake_only"
+
+        # Second intake of the same URL — ``process_single_source``
+        # detects the existing 03-Processed copy and skips before
+        # any lifecycle moves.
+        clip2 = _write_clipping(
+            temp_vault, "2026-05-05_second.md", url=url,
+        )
+        r2 = proc.process_single_source(clip2, dry_run=False)
+        assert r2["status"] == "skipped_dedup"
+        assert r2["dedup"]["url"] == url
+        assert r2["dedup"]["existing"].endswith("2026-05-04_first.md")
+        # The would-be-duplicate clip stayed in 01-Raw — caller
+        # decides whether to delete or keep.
+        assert clip2.exists()
+
+    def test_archived_url_can_be_re_added(self, temp_vault):
+        """A user who archived a prior copy and explicitly wants
+        a fresh take must be able to re-clip the same URL.
+
+        The dedup index only checks active 03-Processed files,
+        not 70-Archive — so an archived URL is invisible to the
+        dedup check by design.
+        """
+        from ovp_pipeline.runtime import VaultLayout
+        layout = VaultLayout.from_vault(temp_vault)
+
+        # Pretend an old copy was archived.
+        archive_dir = temp_vault / "70-Archive" / "old"
+        archive_dir.mkdir(parents=True)
+        archived = archive_dir / "old.md"
+        archived.write_text(
+            '---\nsource: "https://example.com/archived"\n---\n\nbody\n',
+            encoding="utf-8",
+        )
+
+        proc = _make_processor(temp_vault, skip_deep_dive=True)
+        clip = _write_clipping(
+            temp_vault, "2026-05-04_fresh.md",
+            url="https://example.com/archived",
+        )
+        result = proc.process_single_source(clip, dry_run=False)
+        # Re-clip went through — archived copies don't block.
+        assert result["status"] == "intake_only"
+
+    def test_dedup_emits_audit_event(self, temp_vault):
+        proc = _make_processor(temp_vault, skip_deep_dive=True)
+        url = "https://example.com/audit-log-test"
+        proc.process_single_source(
+            _write_clipping(temp_vault, "first.md", url=url), dry_run=False,
+        )
+        proc.process_single_source(
+            _write_clipping(temp_vault, "second.md", url=url), dry_run=False,
+        )
+        log = (temp_vault / "60-Logs" / "pipeline.jsonl").read_text(encoding="utf-8")
+        events = [json.loads(l) for l in log.splitlines() if l.strip()]
+        dedup_events = [
+            e for e in events if e.get("event_type") == "source_dedup_skipped"
+        ]
+        assert len(dedup_events) == 1
+        assert dedup_events[0]["url"] == url
+
+
+# ---------------------------------------------------------------------------
+# 4. source_dedup module — pure unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestSourceDedupIndex:
+    def test_extract_source_url_handles_quoted_and_unquoted(self, tmp_path):
+        from ovp_pipeline.source_dedup import _extract_source_url
+        # Quoted
+        text = '---\nsource: "https://x.com/foo"\ntitle: t\n---\n\nbody\n'
+        assert _extract_source_url(text) == "https://x.com/foo"
+        # Unquoted
+        text = "---\nsource: https://x.com/bar\n---\n\nbody\n"
+        assert _extract_source_url(text) == "https://x.com/bar"
+        # Non-URL value → None
+        text = "---\nsource: Anthropic Engineering Blog\n---\n\nbody\n"
+        assert _extract_source_url(text) is None
+
+    def test_extract_recognizes_alt_keys(self):
+        from ovp_pipeline.source_dedup import _extract_source_url
+        for key in ("source_url", "url", "github", "twitter", "arxiv"):
+            text = f"---\n{key}: https://x.com/{key}\n---\n\nbody\n"
+            assert _extract_source_url(text) == f"https://x.com/{key}", \
+                f"failed for key: {key}"
+
+    def test_build_url_index_dedupes_by_first_seen(self, tmp_path):
+        from ovp_pipeline.source_dedup import build_url_index
+        processed = tmp_path / "50-Inbox" / "03-Processed" / "2026-05"
+        processed.mkdir(parents=True)
+        # Same URL in two files
+        (processed / "a.md").write_text(
+            '---\nsource: "https://x.com/dup"\n---\n\nbody\n', encoding="utf-8",
+        )
+        (processed / "b.md").write_text(
+            '---\nsource: "https://x.com/dup"\n---\n\nbody\n', encoding="utf-8",
+        )
+        idx = build_url_index(tmp_path)
+        # First-write-wins, ``a.md`` (sorted alphabetically) wins.
+        assert idx["https://x.com/dup"].name == "a.md"
+
+    def test_find_duplicate_groups_returns_only_groups(self, tmp_path):
+        from ovp_pipeline.source_dedup import find_duplicate_groups
+        processed = tmp_path / "50-Inbox" / "03-Processed" / "2026-05"
+        processed.mkdir(parents=True)
+        (processed / "a.md").write_text(
+            '---\nsource: "https://dup.com/x"\n---\n\nbody\n', encoding="utf-8",
+        )
+        (processed / "b.md").write_text(
+            '---\nsource: "https://dup.com/x"\n---\n\nbody\n', encoding="utf-8",
+        )
+        (processed / "unique.md").write_text(
+            '---\nsource: "https://unique.com/y"\n---\n\nbody\n', encoding="utf-8",
+        )
+        groups = find_duplicate_groups(tmp_path)
+        assert "https://dup.com/x" in groups
+        assert len(groups["https://dup.com/x"]) == 2
+        # Singletons are excluded from the cleanup target list.
+        assert "https://unique.com/y" not in groups

--- a/tests/test_migration_processing_guards.py
+++ b/tests/test_migration_processing_guards.py
@@ -207,7 +207,7 @@ OSGym: Scalable OS Infra for Computer Use Agents
 
     logger = ArticleLogger(temp_vault / "60-Logs" / "pipeline.jsonl")
     txn = ArticleTxn(temp_vault / "60-Logs" / "transactions")
-    processor = AutoArticleProcessor(temp_vault, logger, txn)
+    processor = AutoArticleProcessor(temp_vault, logger, txn, skip_deep_dive=False)
     processor.article_processor = SimpleNamespace(
         generate_interpretation=lambda **_: (_ for _ in ()).throw(AssertionError("LLM should not be called"))
     )
@@ -244,7 +244,7 @@ Example SDK
 
     logger = ArticleLogger(temp_vault / "60-Logs" / "pipeline.jsonl")
     txn = ArticleTxn(temp_vault / "60-Logs" / "transactions")
-    processor = AutoArticleProcessor(temp_vault, logger, txn)
+    processor = AutoArticleProcessor(temp_vault, logger, txn, skip_deep_dive=False)
     processor.article_processor = SimpleNamespace(
         generate_interpretation=lambda **kwargs: ("---\ntitle: Test\nsource: x\nauthor: y\ndate: 2026-04-07\ntype: article\ntags: []\nstatus: draft\n---\n\n# ok", {"tokens": 1}, "tools")
     )
@@ -299,7 +299,7 @@ Example SDK body
 
     logger = ArticleLogger(temp_vault / "60-Logs" / "pipeline.jsonl")
     txn = ArticleTxn(temp_vault / "60-Logs" / "transactions")
-    processor = AutoArticleProcessor(temp_vault, logger, txn)
+    processor = AutoArticleProcessor(temp_vault, logger, txn, skip_deep_dive=False)
     processor.article_processor = SimpleNamespace(
         generate_interpretation=lambda **kwargs: (
             "---\ntitle: Test\nsource: x\nauthor: y\ndate: 2026-04-07\ntype: article\ntags: []\nstatus: draft\n---\n\n# ok",
@@ -349,7 +349,7 @@ Raw clip body
 
     logger = ArticleLogger(temp_vault / "60-Logs" / "pipeline.jsonl")
     txn = ArticleTxn(temp_vault / "60-Logs" / "transactions")
-    processor = AutoArticleProcessor(temp_vault, logger, txn)
+    processor = AutoArticleProcessor(temp_vault, logger, txn, skip_deep_dive=False)
     processor.article_processor = SimpleNamespace(
         generate_interpretation=lambda **kwargs: (
             "---\ntitle: Test\nsource: x\nauthor: y\ndate: 2026-04-07\ntype: article\ntags: []\nstatus: draft\n---\n\n# ok",
@@ -438,7 +438,7 @@ Example body
 
     logger = ArticleLogger(temp_vault / "60-Logs" / "pipeline.jsonl")
     txn = ArticleTxn(temp_vault / "60-Logs" / "transactions")
-    processor = AutoArticleProcessor(temp_vault, logger, txn)
+    processor = AutoArticleProcessor(temp_vault, logger, txn, skip_deep_dive=False)
     processor.article_processor = SimpleNamespace(
         generate_interpretation=lambda **kwargs: (
             "---\ntitle: Test\nsource: x\nauthor: y\ndate: 2026-04-07\ntype: article\ntags: []\nstatus: draft\n---\n\n# ok",
@@ -484,7 +484,7 @@ Broken body
 
     logger = ArticleLogger(temp_vault / "60-Logs" / "pipeline.jsonl")
     txn = ArticleTxn(temp_vault / "60-Logs" / "transactions")
-    processor = AutoArticleProcessor(temp_vault, logger, txn)
+    processor = AutoArticleProcessor(temp_vault, logger, txn, skip_deep_dive=False)
     processor.article_processor = SimpleNamespace(
         generate_interpretation=lambda **kwargs: (_ for _ in ()).throw(RuntimeError("boom"))
     )
@@ -532,7 +532,7 @@ Body
 
     logger = ArticleLogger(temp_vault / "60-Logs" / "pipeline.jsonl")
     txn = ArticleTxn(temp_vault / "60-Logs" / "transactions")
-    processor = AutoArticleProcessor(temp_vault, logger, txn)
+    processor = AutoArticleProcessor(temp_vault, logger, txn, skip_deep_dive=False)
     processor.article_processor = SimpleNamespace(
         generate_interpretation=lambda **kwargs: (
             "---\ntitle: Test\nsource: x\nauthor: y\ndate: 2026-04-07\ntype: article\ntags: []\nstatus: draft\n---\n\n# ok",
@@ -587,7 +587,7 @@ Body
 
     logger = ArticleLogger(temp_vault / "60-Logs" / "pipeline.jsonl")
     txn = ArticleTxn(temp_vault / "60-Logs" / "transactions")
-    processor = AutoArticleProcessor(temp_vault, logger, txn)
+    processor = AutoArticleProcessor(temp_vault, logger, txn, skip_deep_dive=False)
     txn_id = txn.start("article-processing", "Batch progress")
 
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

Four root-cause fixes for the BL-058 follow-up data-loss bugs surfaced by the 2026-05-06 audit. The user reviewed all 50 abstraction-inflated v1 deep-dives and confirmed they should be archived; without these fixes the pipeline would keep generating new ones.

- **C1 — URL preservation**: `_augment_frontmatter` now overwrites the LLM-generated `source:` with the raw's `source_url`. The WeChat clip whose canonical URL got replaced by the article subtitle is the proximate trigger.
- **C2 — Deprecate deep-dive layer**: `AutoArticleProcessor` defaults to `skip_deep_dive=True`. Raw still lifecycles to `03-Processed`; absorb v2 picks it up directly (same flow `auto_github_processor` uses post-BL-066). Legacy LLM rewrite gated behind `--keep-deep-dive` / `skip_deep_dive=False`.
- **C3 — URL-level dedup**: New `source_dedup.py` module + `process_single_source` URL gate. Census found 8 URL groups with 2-3 raws each (Reader re-clipping artefact). Re-adding an archived URL still works — index only scans active `03-Processed`.
- **C4 — E2E coverage**: `tests/test_intake_dedup_and_url.py` adds 12 tests for the exact contracts (URL-survives-chain, intake-only-archives-raw, dedup-emits-audit-event).

## Cleanup CLI: `ovp-dedup-cleanup`

Archives the 9 existing duplicate raws (8 groups, one 3-way) into `70-Archive/2026-05-06_dedup-cleanup/`. Picks canonical by largest body size (partial Reader fetches truncate body). Dry-run by default; `--apply` actually moves. Each move emits a `dedup_cleanup_archived` event.

**Already applied on the live vault**: 9 raws moved, `dedup-cleanup` group now empty.

## Test plan

- [x] `test_intake_dedup_and_url.py`: 12/12 new
- [x] `test_migration_processing_guards.py`: 32/32 (8 updated to pass `skip_deep_dive=False` — they test legacy LLM rewrite specifically)
- [x] Full suite: 2219/2219
- [x] `ovp-dedup-cleanup --apply` ran clean on live vault (9 moves, 0 errors)
- [x] 9 `dedup_cleanup_archived` events present in `pipeline.jsonl`

## Out of scope (deferred)

- Body-content fingerprinting (two URLs that resolve to the same article). ~1% case, doesn't justify the SHA cost yet.
- `ovp-vault-integrity-check` periodic fsck CLI — separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ovp-dedup-cleanup` command to identify and archive duplicate articles by URL within processed inventory
  * Introduced intake-only mode (default) for streamlined article processing without deep-dive analysis
  * Implemented URL-based deduplication to prevent duplicate article ingestion
  * Added `--keep-deep-dive` CLI flag to enable legacy deep-dive processing
  * Enhanced source URL tracking and preservation across the processing pipeline

<!-- end of auto-generated comment: release notes by coderabbit.ai -->