### PR TITLE
feat(measurement): fidelity-sample + prompt-ab CLIs for absorb v2 review

### DIFF
--- a/docs/plans/2026-05-05-workflow-review.md
+++ b/docs/plans/2026-05-05-workflow-review.md
@@ -1,0 +1,339 @@
+---
+tags:
+  - OVP
+  - Absorb
+  - Evergreen
+  - Dedup
+  - Entity-extraction
+people:
+  - chris
+projects:
+  - BL-058
+  - BL-059
+  - BL-060
+  - BL-061
+  - BL-062
+tools:
+  - Obsidian
+  - SQLite
+  - Pinboard
+  - MinHash
+---
+# 2026-05-05 — Workflow First-Principles Review
+
+> **目的**:把 OVP 增量管线的 13 个步骤(BASE + refine)逐个拷问一遍。每步必须答出"解决了什么 / 引入了什么 / 砍掉会坏什么 / 该留该砍该挪"。这份文档**只做 audit + decision,不动代码**。
+>
+> **触发**:今天讨论 BL-058(深度解读拆解)时发现"步骤是历史叠加的、没人重审过"。本次 review 把同样的拷问对所有步骤做一遍。
+>
+> **约束**:今天我们刚定下的核心原则 ——**质量永远高于速度,LLM 不许臆测、不许扩写源文没有的内容**(`feedback_no_slop.md`)。本 review 的所有 verdict 都以这条为锚。
+
+---
+
+## 0. 当前管线全景(从代码核实)
+
+源:`unified_pipeline_enhanced.py:459-477` 的 `BASE_PIPELINE_STEPS` + `OPTIONAL_PIPELINE_STEPS`。
+
+| # | Step | LLM? | 来源/落点 |
+|---|---|---|---|
+| 1 | `pinboard` | No | Pinboard API → `50-Inbox/02-Pinboard/` |
+| 2 | `pinboard_process` | No | `02-Pinboard/` → 路由到 `01-Raw/` |
+| 3 | `clippings` | No | `Clippings/*.md` → `50-Inbox/01-Raw/` |
+| 4 | `articles` (深度解读) | **Yes (heavy)** | `01-Raw/` → `40-Resources/Articles/*_深度解读.md` |
+| 5 | `quality` | **Yes** | 评分深度解读 → 决定是否进 absorb |
+| 6 | `fix_links` | No | 全 vault 扫描修 broken wikilinks |
+| 7 | `absorb` | **Yes (heavy)** | `*_深度解读.md` → `10-Knowledge/Evergreen/` |
+| 7b | `entity_extract` | **Yes** | 深度解读 → Entity NER |
+| 7c | `dedup` | No (embedding) | 本轮 absorb 产出 → MinHash 0.82 阈值合并 |
+| 8 | `note_type_normalize` | No | 全 vault 改写 frontmatter `type:` 字段 |
+| 9 | `registry_sync` | No | 全 vault 扫 6587 文件 → registry 表 |
+| 10 | `moc` | No | 重建 MOC 索引文件 |
+| 11 | `knowledge_index` | No | 重建 SQLite 派生表 |
+| (opt) | `refine` | **Yes** | cleanup + breakdown,批处理改写 evergreens |
+
+---
+
+## 1. Review 框架
+
+每步 4 问:
+
+```
+SOLVES:     这步解决了管线主链路上的什么具体问题?
+INTRODUCES: 这步引入了什么副作用 / fidelity 风险 / latency / coupling?
+SKIP TEST:  砍掉这步,具体哪个下游会坏?坏成什么样?用户感知到吗?
+VERDICT:    Keep | Refactor | Merge into <X> | Move to scheduled/on-demand | Remove
+```
+
+---
+
+## 2. 逐步审
+
+### Step 1 · `pinboard`
+
+- **SOLVES**:从 Pinboard API 拉新书签到 `02-Pinboard/`。这是 OVP 唯一的"主动获取入口",其它都是被动入站。
+- **INTRODUCES**:网络依赖(API 限速 / 鉴权失败会拖慢整条链路)。但本身 deterministic,无 LLM,无 fidelity 风险。
+- **SKIP TEST**:砍掉 → Pinboard 用户的新书签不会进 vault。**用户立即感知**。
+- **VERDICT**:**Keep**。但应**与 `pinboard_process` 评估合并**(见下)。**不该 blocking 在主管线**:网络抖动会卡住所有非 Pinboard 用户的增量。考虑改成"先尝试 fetch,失败 → log + 继续后续步骤,不阻断"。
+
+### Step 2 · `pinboard_process`
+
+- **SOLVES**:把 `02-Pinboard/` 里的原始 JSON/HTML 转成 markdown,路由到 `01-Raw/`。
+- **INTRODUCES**:无明显副作用,纯转换。
+- **SKIP TEST**:砍掉 → Pinboard 拉到的书签停在 `02-Pinboard/`,不进入主链路。
+- **VERDICT**:**Merge into `pinboard`**。"fetch + transform + route"逻辑上是一件事,拆两步只是历史。
+
+### Step 3 · `clippings`
+
+- **SOLVES**:把 `Clippings/*.md` 迁到 `50-Inbox/01-Raw/`,做文件名 sanitize。
+- **INTRODUCES**:
+  - **Bug 已确认**:`scan_clippings()` 用非递归 `glob("*.md")`,**16 个 Twitter clippings(在 `Clippings/Twitter/`)从未被处理**(`clippings_processor.py:248-258`)。
+  - 文件名碰撞无显式处理(同名文件直接覆盖)。
+- **SKIP TEST**:砍掉 → 用户拖到 `Clippings/` 的文章永远不会进入主链路。
+- **VERDICT**:**Refactor**。改 rglob + 加 dedupe + 名碰撞 skip+warn。本身保留。和 `pinboard*` 合成一个统一的"intake"概念阶段(见 §4)。
+
+### Step 4 · `articles` (深度解读) ⚠
+
+- **SOLVES**:把异构 source(Twitter/blog/PDF/RSS)用 LLM 重写成"标准化深度解读 markdown",理论上让下游 absorb 输入更整齐。
+- **INTRODUCES** ⚠⚠⚠:
+  - **核心 fidelity 风险**:absorb 的主输入是 LLM 重写过的版本,**任何 LLM 在重写时塞进的"幻觉论点"都会被 absorb 当真相**,污染 evergreen → crystal 整条链。
+  - 短内容被强行扩写(120 字 Twitter → 800 字"深度解读")—— 信息量不增,fidelity 反降。
+  - "解读 of 解读"问题:博客本身在解读他人观点时,这步会再 LLM 一遍。
+  - 跨步骤耦合:quality / absorb 都依赖这步的产物,改这步要回归测试三步。
+- **SKIP TEST**:砍掉 → absorb 直接读 raw source。**fidelity 提升**,但 absorb prompt 需要重新调(它现在是按"读结构化深度解读"的输入风格设计的)。
+- **VERDICT**:**Refactor — 已立项 BL-058**。
+  - 拆成 `normalize`(0 LLM,只整 frontmatter + 文件名)+ `interpret`(opt-in lens,默认关,**不喂 absorb**)。
+  - absorb 改读 raw source。
+  - 历史数据全员打 `derived_via_stage='absorb_from_interpretation'` 标签,reader UI 显示 legacy 横幅,crystal 评分降权 ×0.7。
+
+### Step 5 · `quality` ⚠
+
+- **SOLVES**:用 LLM 给"深度解读"打分(0-5),`>= 3.0` 才进 absorb,作为 fidelity 闸门。
+- **INTRODUCES**:
+  - **评估对象(深度解读)在 BL-058 后即将消失**,这步的存在意义随之蒸发。
+  - 它评的是"重写的语言流畅度",**不是 evergreen 对 source 的忠实度** — 跟我们关心的 fidelity 不是同一件事。
+  - LLM 评分主观性大,3.0 阈值 magic number 来源不清。
+- **SKIP TEST**:砍掉 → absorb 会处理所有源,包括"质量差"的源。但"差"的判定本身可疑。
+- **VERDICT**:**Refactor (重定义) + 时机绑定 BL-058**。
+  - 旧定义("评分深度解读")废除。
+  - 新定义("evergreen 对 source 的 fidelity 检查"):用 grep 校验 `attribution_evidence` 必须在 source body 中逐字出现 — **deterministic 检查,不再用 LLM 评分**。失败的 evergreen 进 review 队列。
+  - 这是 BL-058 的子项,跟着 absorb 改造一起做。
+
+### Step 6 · `fix_links`
+
+- **SOLVES**:全 vault 扫 broken wikilinks,改写到正确目标(只做 exact-match,不模糊匹配)。
+- **INTRODUCES**:
+  - **症状级处理**:broken links 多半来自 absorb / dedup / refine 改名时没回写引用。修这一步等于"在血迹上贴创可贴",根因在上游。
+  - 全 vault 扫 6587 文件,每次都跑 — latency 显著。
+  - exact-only 模式安全,但只能修能匹的;模糊的留下来等下次。
+- **SKIP TEST**:砍掉 → broken links 累积,reader UI 出现死链。但 dedup 已经会回写引用(`concept_dedup.py:apply_proposal`),fix_links 主要捕获的是非 dedup 路径产生的断链。
+- **VERDICT**:**Move to scheduled (daily)**。
+  - 每次 incremental 都跑 → daily cron。
+  - 同步立 BL 调查:**每周新产生的 broken links 来自哪个上游**?根因修了,这步使用率应该衰减。
+  - 长期目标:ensure absorb / dedup / refine 都正确回写,fix_links 退化成"罕见情况下的人工运维工具"。
+
+### Step 7 · `absorb` ⚠
+
+- **SOLVES**:从深度解读(BL-058 后:从 raw source)里抽取原子 evergreen,落到 `10-Knowledge/Evergreen/`。
+- **INTRODUCES**:
+  - 当前主输入是 LLM 重写过的"深度解读" → fidelity 风险见 Step 4。
+  - prompt 没有显式的 attribution chain 要求(BL-058 要补)—— 现在所有 evergreens 默认把 source URL 当 first-hand origin,即便源是 commentary。
+  - 长 source 切分逻辑放在这一步内部,跟"提取"语义混在一起。
+- **SKIP TEST**:砍掉 → 没有 evergreens 产出,主产物消失。**这是核心步骤**。
+- **VERDICT**:**Refactor — 已立项 BL-058**。
+  - 主输入改 raw source(BL-058a 后)。
+  - prompt 加三档 attribution rule(`self / <named entity> / unknown`),每条 claim 必带 `attribution_evidence` 字段(verbatim 短语,可 grep 校验)。
+  - 长文切分抽出成独立的 normalize 子步骤(确定性切分,非 LLM)。
+
+### Step 7b · `entity_extract` ⚠
+
+- **SOLVES**:从深度解读抽 PERSON/CONCEPT/TOOL/METHOD/SYSTEM/EVENT 实体 + Mentions 边。
+- **INTRODUCES**:
+  - 跟 `articles`/`absorb` 一样,**LLM 抽取没显式约束"实体名必须在 source body 出现"** — 模型可能补全成 wikidata 条目中的"全称",用户没写过。
+  - entity_type 推测同样是语义判断,要走 BL-058 同一套 attribution rule。
+  - 输入仍是深度解读,BL-058 后要切到 raw source。
+- **SKIP TEST**:砍掉 → 没有 typed entity 层,reader UI 的"按人/概念/工具浏览"消失,crystal 抽取里 entity 信号也消失。
+- **VERDICT**:**Refactor (跟随 BL-058)**。
+  - 输入切换 raw source。
+  - 加入 attribution_evidence 字段:每个 entity 必须能在 source body grep 到 surface form。
+  - entity_type 推测加约束:仅当源文显式上下文(称谓/职位/动作)能定型时才打类型,否则 `unknown`。
+
+### Step 7c · `dedup` ⚠
+
+- **SOLVES**:scope 限于"本轮 absorb 产出的 slugs"(`promoted_slugs`),用 MinHash + 阈值 0.82 找重复 evergreens,合并 + 回写 wikilinks。
+- **INTRODUCES**:
+  - **0.82 阈值 magic number,来源不清,无 false-positive 数据**(`concept_dedup.py:47`)。
+  - 合并不可逆 — 错合的概念回不来(虽然有 archive_applied_proposal 留底)。
+  - scope 限本轮看似安全,但跨轮的"等价 evergreens"永远不会被对齐(轮 A 产 X,轮 B 产 X' 相似度 0.85,本轮 dedup 看不到 X)。
+- **SKIP TEST**:砍掉 → evergreens 数量膨胀,同概念多文件,reader UI 出现"重复条目"。
+- **VERDICT**:**Refactor**。
+  - 立 BL 做"dedup threshold 校准实验":取过去 1 个月 dedup 决策样本,人评 100 条,出 precision/recall vs threshold 曲线。
+  - 把"跨轮全量 dedup"挪到 daily scheduled(目前只跑本轮,跨轮债务越积越大)。
+  - 当前 step 保留(本轮 dedup 抓住"absorb 同时产出的多条 paraphrase"是有价值的近场清理)。
+
+### Step 8 · `note_type_normalize` ⚠
+
+- **SOLVES**:把 frontmatter `type:` 字段统一到 8 种 canonical 值,原值存到 `original_note_type:`。
+- **INTRODUCES**:
+  - **每次跑都 normalize 905 条**(我刚刚 dry-run 看到的数字)—— 说明**新 evergreens 持续产出非 canonical type**。这是症状级修复,根因在上游(absorb 没在产出时就用 canonical type)。
+  - 全 vault 扫 + 改写,latency 不低。
+- **SKIP TEST**:砍掉 → frontmatter type 字段五花八门,downstream 查询(SQLite `objects.note_type`)要做 fuzzy match,reader 分类页混乱。
+- **VERDICT**:**Move to scheduled + 修上游**。
+  - 修 absorb prompt + entity_extract,让产出端就用 canonical type → 每日脏数据归零。
+  - 这步降级为 daily cron + alert("今日产生 N 条非 canonical,根因待查"),不在 incremental 主链路。
+  - 一次性 backfill migration 已经在历史里跑过,不需要每轮再做。
+
+### Step 9 · `registry_sync` ⚠
+
+- **SOLVES**:全 vault 扫 6587 文件,跟 SQLite `registry` 表比对,补/删 entries。
+- **INTRODUCES**:
+  - **120s timeout 易超**(刚才 dry-run 就超了,管线被阻断)。
+  - 全表扫,**O(N) 跟 vault 大小线性增长**,只会越来越慢。
+  - 跟其它步骤无强耦合 —— 不修 broken links、不改 evergreen、不动 absorb 输入。它就是在事后做"账实核对"。
+- **SKIP TEST**:砍掉 → registry 表会跟文件系统漂移(204 not in registry / 525 not in filesystem,即当前现状)。但管线核心产出(evergreen / crystal)不依赖 registry sync。
+- **VERDICT**:**Move to scheduled (daily) + 不阻断**。
+  - 完全踢出 incremental 主链路。
+  - daily cron 跑全表 reconcile,`--write` 模式。
+  - 增量主链路只做"本轮 absorb 产出的 slugs upsert",constant time。
+
+### Step 10 · `moc`
+
+- **SOLVES**:重建 MOC(Map of Content)文件 —— Obsidian 桌面端用的导航 markdown。
+- **INTRODUCES**:
+  - 全 vault 重建,**latency 跟 evergreen 数线性**。
+  - **可疑**:reader UI 已经从 SQLite 取数据(`/topics`/`/map`),MOC markdown 文件是不是只剩 Obsidian 桌面端用?如果是,这步对**线上产出无贡献**。
+- **SKIP TEST**:砍掉 → 用 Obsidian 桌面端打开 vault 的人会看到导航文件不更新。reader Web UI 不受影响。
+- **VERDICT**:**Move to scheduled** 或 **Decouple to on-demand**。
+  - 不该跑在 incremental 主链路。
+  - 立 BL 调查:还有哪些角色在用 MOC markdown?如果只剩 Obsidian 桌面端,改成 daily cron 或 `ovp-moc --rebuild` 手动触发。
+
+### Step 11 · `knowledge_index`
+
+- **SOLVES**:重建 `60-Logs/knowledge.db` 的派生表(truth projection / crystal_scores / 等)—— 这是 reader UI 和所有查询的底层。
+- **INTRODUCES**:
+  - 全量 rebuild 而非 incremental — vault 大了之后会变慢。
+  - 但已经做了 `INDEPENDENT_CANONICAL_TABLE_COLUMNS` 保护(BL-055),crystal / provenance 等不会被 rebuild 抹掉。
+- **SKIP TEST**:砍掉 → reader UI 看不到本轮新 evergreens。**用户立即感知**。
+- **VERDICT**:**Keep**。但立 BL 做"incremental rebuild":只 upsert 本轮新/改 slugs 进派生表,不 drop 重建。当前全量 rebuild 是债务但不紧急。
+
+### Step (opt) · `refine`
+
+- **SOLVES**:cleanup(去掉重复段落 / 修小错)+ breakdown(把超长 evergreens 拆成原子)。LLM 批处理。
+- **INTRODUCES**:
+  - 又一个 LLM 改写步骤 → fidelity 风险跟 articles 同源。
+  - 改写后的 evergreens 跟原 source 的关系变弱(改了一层模型抽,再改一层模型 refine)。
+  - 默认不在 incremental 跑(--with-refine 才开),已经是 opt-in。
+- **SKIP TEST**:砍掉 → 老 evergreens 不会被自动 refine。但手动 `ovp-cleanup` / `ovp-breakdown` 仍可调。
+- **VERDICT**:**Keep as opt-in,加 attribution check**。
+  - 已经是 OPTIONAL_PIPELINE_STEPS,默认不跑,OK。
+  - 但 LLM 改写时**必须保留 attribution chain**(改写后的内容仍能 grep 回 source body),否则等于在做隐式幻觉注入。
+  - 是 BL-058 attribution 规则的扩展应用对象。
+
+---
+
+## 3. 缺失的步骤
+
+review 不只问"砍哪些",也要问"缺哪些步骤导致了打补丁式的修复":
+
+| 缺失 | 现在被谁打补丁 | 应该是 |
+|---|---|---|
+| **attribution_evidence 校验** | 无(完全靠 LLM 自觉) | BL-058 引入,deterministic post-check,grep 不到即标红 review |
+| **fidelity replay** | 无 | 抽样 evergreen,从 source 重抽,diff,飘出阈值的进 review |
+| **inbox sweep** | 无,堆积无限 | 01-Raw 超 N 天没动 → archive 或 explicit-skip,避免无限堆积 |
+| **schema versioning** | `note_type_normalize` 全 vault 扫修 | frontmatter 字段加版本号,absorb 产出端就用 canonical,migrations 一次性 |
+| **broken-link root-cause logging** | `fix_links` 全扫修 | 每次产生 broken link 时 log 上游(哪个 step 哪条 evergreen 引入的),便于事后审 |
+| **incremental knowledge_index** | 全量 rebuild | 只 upsert 本轮 changed slugs,O(changed) 而非 O(vault) |
+
+---
+
+## 4. 重排后的目标管线
+
+按 review verdict 重组,主链路变得**更短、更纯、fidelity-first**:
+
+### 4.1 每次增量必须跑(blocking,串行)
+
+```
+intake          (合并 pinboard + pinboard_process + clippings;rglob + dedupe + sanitize)
+  ↓
+normalize       (新,0 LLM:frontmatter 校验/补齐 + 长文确定性切分;BL-058)
+  ↓
+absorb          (LLM,主输入 raw source,产出带 attribution chain 的 evergreens;BL-058)
+  ↓
+attribution_check  (新,deterministic:grep 校验 attribution_evidence;BL-058)
+  ↓
+entity_extract  (LLM,同 attribution rule;BL-058)
+  ↓
+dedup_local     (本轮 absorb 产出,scope 限本轮;立 BL 做 threshold 校准)
+  ↓
+knowledge_index_incremental  (新:只 upsert changed slugs;立 BL)
+```
+
+### 4.2 Daily scheduled(后台,非阻断)
+
+```
+fix_links              (全 vault broken-link 扫修)
+note_type_normalize    (兜底,主修上游;长期 905 → 0)
+registry_sync          (账实核对)
+dedup_global           (跨轮全量 dedup;立 BL)
+moc_rebuild            (调查后再决定是否保留)
+fidelity_replay_sample (新:抽 N 条 evergreen 重抽对比)
+```
+
+### 4.3 On-demand(显式 CLI,不在管线)
+
+```
+interpret      (BL-058:opt-in lens,纯人读,不喂下游)
+refine         (cleanup + breakdown,已是 OPTIONAL)
+inbox_sweep    (新:archive / skip 长期未处理 raw;立 BL)
+ovp-reabsorb   (BL-058:单条 evergreen 从 source 重抽,审核用)
+```
+
+---
+
+## 5. 与 BL-058 的关系
+
+BL-058 在 review 之前已经讨论清楚,本 review 把同样的拷问推到所有步骤后,反过来**确认 BL-058 是 review 框架的应用而非孤立改造**。
+
+BL-058 已覆盖:Step 4 (articles)、Step 5 (quality 重定义)、Step 7 (absorb)、Step 7b (entity_extract attribution)、新增 attribution_check / fidelity_replay。
+
+review 新发现需要立项的:Step 6 (fix_links 根因)、Step 7c (dedup threshold 校准 + 跨轮 dedup)、Step 8 (note_type 上游修)、Step 9 (registry_sync 出主链路)、Step 10 (moc 可疑性调查)、Step 11 (knowledge_index incremental)、新增 inbox_sweep / schema_versioning / broken-link root-cause logging。
+
+---
+
+## 6. 后续 BL 拆解建议
+
+review 出的 verdict 落到具体 BL,排在 BL-058 之后(避免改动叠加):
+
+| BL | 名 | 优先级 | 描述 |
+|---|---|---|---|
+| BL-058 | normalize / absorb / interpret 解耦 + attribution chain | P0(进行中) | 已讨论,出设计稿 |
+| BL-059 | registry_sync / moc / note_type_normalize 移出主链路 | P1 | 改成 daily scheduled,主链路 latency 降 |
+| BL-060 | fix_links 根因调查 + broken-link logging | P2 | 找出"每周谁制造 broken links",修上游 |
+| BL-061 | dedup threshold 校准实验 | P2 | 0.82 是否合理,出 precision/recall 数据 |
+| BL-062 | knowledge_index incremental rebuild | P2 | 主链路 O(N) → O(changed) |
+| BL-063 | intake 合并 (pinboard + pinboard_process + clippings) | P3 | 历史上的人为分割,合并降低概念负担 |
+| BL-064 | inbox_sweep + schema versioning | P3 | 从根源避免堆积和补丁式 normalize |
+| BL-065 | moc 必要性调查 + 可能下沉为 on-demand | P3 | 调研后决策,可能直接 remove |
+
+---
+
+## 7. 验证
+
+review 文档本身不动代码。验证手段是:
+
+1. 每条 verdict 必须能映射到一个具体的 BL,且 BL 描述跟 review 出的"INTRODUCES" 项对得上 ——**没有"凭印象重构"**。
+2. 用户(chris)审完此文档,可以对任一条 verdict 说"不同意/需要更多数据",我们再补 review。
+3. BL-058 完成后,回头跑一遍这份 review 的 §4.1 主链路,看 latency 和 fidelity 是不是符合预期(预期:latency 从 ~90 min 降到 ~30 min,fidelity 显著提升)。
+
+---
+
+## 附录 A:本次 review 用的代码核实点
+
+- `unified_pipeline_enhanced.py:459-477` — STEPS 定义
+- `unified_pipeline_enhanced.py:2046-2240` — `step_quality` 实现(走 `batch_quality_checker`)
+- `unified_pipeline_enhanced.py:2241-2282` — `step_fix_links` 实现(走 `migrate_broken_links --exact-only`)
+- `unified_pipeline_enhanced.py:2284-2303` — `step_registry_sync` 实现(120s timeout)
+- `unified_pipeline_enhanced.py:2835-2906` — `step_dedup` 实现(MinHash 0.82 阈值,scope 限本轮)
+- `unified_pipeline_enhanced.py:2908-2929` — `step_moc` 实现
+- `unified_pipeline_enhanced.py:2983-3011` — `step_note_type_normalize` 实现(单次 dry-run normalize 905 条)
+- `clippings_processor.py:248-258` — `scan_clippings` 非递归 bug
+- `concept_dedup.py:47` — DEFAULT_THRESHOLD = 0.82
+- pipeline-report-20260504-230057.md — 实际 dry-run latency / 输出

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,8 @@ ovp-refresh-entities = "ovp_pipeline.commands.refresh_entities:main"
 ovp-embedding-dedup = "ovp_pipeline.commands.embedding_dedup:main"
 ovp-dedup-cleanup = "ovp_pipeline.commands.dedup_cleanup:main"
 ovp-backup-db = "ovp_pipeline.commands.backup_db:main"
+ovp-fidelity-sample = "ovp_pipeline.commands.fidelity_sample:main"
+ovp-prompt-ab = "ovp_pipeline.commands.prompt_ab:main"
 
 [project.entry-points."ovp.packs"]
 default-knowledge = "ovp_pipeline.packs.default_knowledge:get_pack"

--- a/src/ovp_pipeline/commands/fidelity_sample.py
+++ b/src/ovp_pipeline/commands/fidelity_sample.py
@@ -71,29 +71,7 @@ from urllib.parse import urlparse
 
 import yaml
 
-from ..runtime import VaultLayout, resolve_vault_dir
-
-
-def _safe_json_for_script(obj: object) -> str:
-    """JSON-encode ``obj`` and escape chars that would break a literal
-    embed inside a ``<script>`` tag.
-
-    A naive ``json.dumps`` lets a sample body containing the literal
-    sequence ``</script>`` close the surrounding tag, breaking the
-    page (and giving content-side script-injection vibes).  The
-    OWASP-blessed fix is to escape ``<``/``>``/``&`` plus the JSON
-    line separators ``U+2028``/``U+2029`` to ``\\uXXXX`` — the result
-    is still valid JSON AND safe inside ``<script>…</script>``.
-    """
-    encoded = json.dumps(obj, ensure_ascii=False)
-    return (
-        encoded
-        .replace("<", "\\u003c")
-        .replace(">", "\\u003e")
-        .replace("&", "\\u0026")
-        .replace(" ", "\\u2028")
-        .replace(" ", "\\u2029")
-    )
+from ..runtime import VaultLayout, resolve_vault_dir, safe_json_for_script
 
 
 SOURCE_CATEGORIES = ("twitter", "github", "paper", "blog", "commentary", "other")
@@ -184,13 +162,17 @@ def _raw_body(text: str) -> str:
 # question marks, exclamations.  Kept narrow so we don't shred URLs/code.
 _SENTENCE_SPLIT = re.compile(r"(?<=[。！？；])\s+|(?<=[.!?])\s+(?=[A-Z一-鿿])")
 
+# Minimum claim length.  Anything shorter is almost always a list-marker
+# fragment ("1.", "2.") or a partial split that hasn't reattached.
+MIN_SENTENCE_CHARS = 8
+
 
 def _split_sentences(text: str) -> list[str]:
     text = text.strip()
     if not text:
         return []
     parts = [p.strip() for p in _SENTENCE_SPLIT.split(text)]
-    return [p for p in parts if len(p) >= 8]
+    return [p for p in parts if len(p) >= MIN_SENTENCE_CHARS]
 
 
 def _extract_claims(body: str) -> list[dict]:
@@ -257,15 +239,28 @@ def _section_body(body: str, headings: tuple[str, ...]) -> str:
 # Raw-source segmentation
 # ---------------------------------------------------------------------------
 
+# Paragraphs longer than this get split by sentence so the reviewer
+# pane doesn't drown in walls of prose.
+PARAGRAPH_SOFT_MAX = 600
+
+# When re-joining sentences into segments, flush once we cross this
+# many chars.  Keeps segments roughly readable-per-glance.
+SEGMENT_BUFFER_TARGET = 400
+
+# Below this length, an ASCII-only paragraph is structural noise
+# (markdown-table rows, image-only stubs).  CJK paragraphs of the
+# same length usually carry actual content so they're kept.
+MIN_ASCII_PARAGRAPH_CHARS = 20
+
 
 def _split_raw_segments(raw_body: str) -> list[dict]:
     """Split raw source body into reviewer-readable segments.
 
     Strategy:
     - First split on blank-line paragraph boundaries (\n\n+).
-    - For very long paragraphs (> 600 chars), further split by sentence
-      so a reviewer scanning the right pane doesn't drown in 1500-char
-      walls of prose.
+    - For very long paragraphs (> ``PARAGRAPH_SOFT_MAX`` chars),
+      further split by sentence so a reviewer scanning the right
+      pane doesn't drown in 1500-char walls of prose.
 
     Each segment is keyed by sequential index so the UI can scroll-
     target it.
@@ -275,21 +270,20 @@ def _split_raw_segments(raw_body: str) -> list[dict]:
     paragraphs = [p.strip() for p in re.split(r"\n\s*\n", raw_body) if p.strip()]
     segments: list[dict] = []
     for para in paragraphs:
-        # Skip image-only or very short structural paragraphs
-        if len(para) < 20 and not re.search(r"[一-鿿]", para):
+        if len(para) < MIN_ASCII_PARAGRAPH_CHARS and not re.search(r"[一-鿿]", para):
             continue
-        if len(para) <= 600:
+        if len(para) <= PARAGRAPH_SOFT_MAX:
             segments.append({"text": para})
             continue
         # Split long paragraphs by sentence
         sentences = _split_sentences(para)
         if not sentences:
-            segments.append({"text": para[:600] + "…"})
+            segments.append({"text": para[:PARAGRAPH_SOFT_MAX] + "…"})
             continue
         buf: list[str] = []
         buf_len = 0
         for s in sentences:
-            if buf_len + len(s) > 400 and buf:
+            if buf_len + len(s) > SEGMENT_BUFFER_TARGET and buf:
                 segments.append({"text": " ".join(buf)})
                 buf = [s]
                 buf_len = len(s)
@@ -1116,7 +1110,7 @@ def _render_html(samples: list[dict], *, run_id: str, vault_dir: Path) -> str:
     return (
         _HTML_TEMPLATE
         .replace("__RUN_ID__", html.escape(run_id))
-        .replace("__SAMPLES_JSON__", _safe_json_for_script(payload))
+        .replace("__SAMPLES_JSON__", safe_json_for_script(payload))
     )
 
 

--- a/src/ovp_pipeline/commands/fidelity_sample.py
+++ b/src/ovp_pipeline/commands/fidelity_sample.py
@@ -1,0 +1,1240 @@
+"""ovp-fidelity-sample — Build a stratified human-review web app for
+evergreen → source fidelity.
+
+Why this exists
+---------------
+Discussions on 2026-05-05 kept escalating from a normative principle
+("no slop") into a prescriptive diagnosis ("OVP IS slopping right now,
+must cut absorb immediately") without any measurement.  This tool makes
+that measurement cheap: stratified sample of evergreens, present each
+alongside the raw source body (when locally available), with claim-level
+rubric inline.
+
+What it produces
+----------------
+``60-Logs/fidelity-samples/<run_id>/checklist.html`` — single
+self-contained HTML page:
+
+    +-----------------------------------------------+
+    | Sample N / 50  [Prev] [Next]  [Export] [Import] |
+    +----------------------+------------------------+
+    | EVERGREEN            | RAW SOURCE             |
+    | (left, scrolls)      | (right, scrolls)       |
+    | • title / source     | • paragraph 1          |
+    | • claims:            | • paragraph 2 ⭐       |
+    |   ◯ faithful etc.    | • paragraph 3          |
+    |   notes [______]     | …                      |
+    +----------------------+------------------------+
+
+Click a claim → top-3 most-similar raw paragraphs get a relevance
+ribbon and the right pane scrolls to the first one.  Similarity is
+deterministic Jaccard over jieba-tokenized words.  No LLM judgment.
+
+LocalStorage auto-saves rubric edits.  Export/Import dump rubric state
+as JSON so reviews can be merged later.
+
+Stratification axes
+-------------------
+Source category, derived from source_url domain:
+    twitter   → x.com / twitter.com
+    github    → github.com / gist.github.com / *.github.io
+    paper     → arxiv.org / openreview / proceedings hosts / *.pdf URLs
+    blog      → anthropic.com / langchain / openai docs / etc
+    commentary→ simonwillison.net / martinfowler / personal blogs
+    other     → catch-all
+Floor of N per non-empty category so small ones still surface.
+
+The scoring rubric is intentionally narrow.  Per claim:
+    verdict ∈ {faithful, distorted, hallucinated, unverifiable}
+    note    free text
+Per sample:
+    overall_verdict (auto-suggested from per-claim worst case)
+    overall_note    free text
+
+We don't try to compute a single "quality score" — see
+feedback_calibration_discipline.md for why composite scores are a
+slop trap.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import random
+import re
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import urlparse
+
+import yaml
+
+from ..runtime import VaultLayout, resolve_vault_dir
+
+
+def _safe_json_for_script(obj: object) -> str:
+    """JSON-encode ``obj`` and escape chars that would break a literal
+    embed inside a ``<script>`` tag.
+
+    A naive ``json.dumps`` lets a sample body containing the literal
+    sequence ``</script>`` close the surrounding tag, breaking the
+    page (and giving content-side script-injection vibes).  The
+    OWASP-blessed fix is to escape ``<``/``>``/``&`` plus the JSON
+    line separators ``U+2028``/``U+2029`` to ``\\uXXXX`` — the result
+    is still valid JSON AND safe inside ``<script>…</script>``.
+    """
+    encoded = json.dumps(obj, ensure_ascii=False)
+    return (
+        encoded
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("&", "\\u0026")
+        .replace(" ", "\\u2028")
+        .replace(" ", "\\u2029")
+    )
+
+
+SOURCE_CATEGORIES = ("twitter", "github", "paper", "blog", "commentary", "other")
+
+_TWITTER_HOSTS = {"x.com", "twitter.com", "mobile.twitter.com"}
+_GITHUB_HOSTS = {"github.com", "gist.github.com"}
+_PAPER_HOSTS = {
+    "arxiv.org", "openreview.net", "papers.nips.cc", "aclanthology.org",
+    "proceedings.mlr.press", "papers.ssrn.com",
+}
+_PRIMARY_BLOG_HOSTS = {
+    "anthropic.com", "developers.openai.com", "blog.langchain.com",
+    "humanlayer.dev", "openai.com", "platform.openai.com",
+    "deepmind.google", "huggingface.co",
+}
+_COMMENTARY_HOSTS = {
+    "simonwillison.net", "martinfowler.com", "swyx.io", "thezvi.wordpress.com",
+}
+
+
+# ---------------------------------------------------------------------------
+# Source categorization
+# ---------------------------------------------------------------------------
+
+
+def _categorize_source(source_url: str) -> str:
+    if not source_url:
+        return "other"
+    try:
+        netloc = urlparse(source_url).netloc.lower()
+    except Exception:
+        return "other"
+    netloc = netloc[4:] if netloc.startswith("www.") else netloc
+    if netloc in _TWITTER_HOSTS:
+        return "twitter"
+    if netloc in _GITHUB_HOSTS or netloc.endswith(".github.io"):
+        return "github"
+    if netloc in _PAPER_HOSTS or source_url.lower().endswith(".pdf"):
+        return "paper"
+    if netloc in _PRIMARY_BLOG_HOSTS:
+        return "blog"
+    if netloc in _COMMENTARY_HOSTS:
+        return "commentary"
+    return "other"
+
+
+# ---------------------------------------------------------------------------
+# Markdown frontmatter / body
+# ---------------------------------------------------------------------------
+
+
+def _parse_frontmatter(text: str) -> dict | None:
+    if not text.startswith("---"):
+        return None
+    try:
+        end = text.index("---", 3)
+    except ValueError:
+        return None
+    try:
+        fm = yaml.safe_load(text[3:end])
+    except yaml.YAMLError:
+        return None
+    if not isinstance(fm, dict):
+        return None
+    return fm
+
+
+def _evergreen_body(text: str) -> str:
+    if not text.startswith("---"):
+        return text
+    try:
+        end = text.index("---", 3) + 3
+    except ValueError:
+        return text
+    return text[end:].lstrip("\n")
+
+
+def _raw_body(text: str) -> str:
+    """Strip frontmatter from a raw source markdown."""
+    return _evergreen_body(text)
+
+
+# ---------------------------------------------------------------------------
+# Claim extraction
+# ---------------------------------------------------------------------------
+
+# Sentence boundary characters — Chinese full stops, semicolons, EN periods,
+# question marks, exclamations.  Kept narrow so we don't shred URLs/code.
+_SENTENCE_SPLIT = re.compile(r"(?<=[。！？；])\s+|(?<=[.!?])\s+(?=[A-Z一-鿿])")
+
+
+def _split_sentences(text: str) -> list[str]:
+    text = text.strip()
+    if not text:
+        return []
+    parts = [p.strip() for p in _SENTENCE_SPLIT.split(text)]
+    return [p for p in parts if len(p) >= 8]
+
+
+def _extract_claims(body: str) -> list[dict]:
+    """Pull factual-ish claims out of the canonical evergreen layout.
+
+    Evergreens follow a stable template — definition quote, ``📝 详细解释``
+    section, ``为什么重要`` section, then wikilinks/source backrefs we
+    don't want to score.  We split each prose section by sentence and
+    label each claim with its source section so the reviewer can see
+    where it came from.
+    """
+    claims: list[dict] = []
+
+    # 1) Definition: the leading "> **定义**: ..." block, anywhere
+    # in the first ~10 lines.  Some older evergreens use "> 定义" or
+    # "> **Definition**".
+    def_match = re.search(
+        r"^>\s*(?:\*\*)?\s*(?:定义|Definition)\s*(?:\*\*)?\s*[:：]\s*(.+?)(?:\n\n|\Z)",
+        body, re.MULTILINE | re.DOTALL,
+    )
+    if def_match:
+        text = def_match.group(1).strip().replace("\n", " ")
+        if text:
+            claims.append({"section": "definition", "text": text})
+
+    # 2) Detailed explanation
+    detail = _section_body(body, ("📝 详细解释", "详细解释", "Detailed Explanation"))
+    for sentence in _split_sentences(detail):
+        claims.append({"section": "detail", "text": sentence})
+
+    # 3) Why it matters
+    why = _section_body(body, ("为什么重要", "Why it matters", "Why this matters"))
+    for sentence in _split_sentences(why):
+        claims.append({"section": "why", "text": sentence})
+
+    # If template detection failed (older / different layout), fall back
+    # to splitting the whole body by sentence so we still get something.
+    if not claims:
+        # skip wikilinks-only lines and headers
+        cleaned = re.sub(r"^#.*$", "", body, flags=re.MULTILINE)
+        cleaned = re.sub(r"^\s*-\s*\[\[.*?\]\].*$", "", cleaned, flags=re.MULTILINE)
+        for sentence in _split_sentences(cleaned):
+            claims.append({"section": "fallback", "text": sentence})
+
+    # Add stable claim ids
+    for i, c in enumerate(claims, start=1):
+        c["id"] = f"c{i}"
+    return claims
+
+
+def _section_body(body: str, headings: tuple[str, ...]) -> str:
+    """Return the prose body following any of the given headings, until
+    the next ``##`` heading or end of text."""
+    for h in headings:
+        # Match ``## <heading>`` line, capture until next ## or EOF.
+        pattern = rf"^##\s+{re.escape(h)}\s*\n(.*?)(?=^##\s|\Z)"
+        m = re.search(pattern, body, re.MULTILINE | re.DOTALL)
+        if m:
+            return m.group(1).strip()
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Raw-source segmentation
+# ---------------------------------------------------------------------------
+
+
+def _split_raw_segments(raw_body: str) -> list[dict]:
+    """Split raw source body into reviewer-readable segments.
+
+    Strategy:
+    - First split on blank-line paragraph boundaries (\n\n+).
+    - For very long paragraphs (> 600 chars), further split by sentence
+      so a reviewer scanning the right pane doesn't drown in 1500-char
+      walls of prose.
+
+    Each segment is keyed by sequential index so the UI can scroll-
+    target it.
+    """
+    if not raw_body:
+        return []
+    paragraphs = [p.strip() for p in re.split(r"\n\s*\n", raw_body) if p.strip()]
+    segments: list[dict] = []
+    for para in paragraphs:
+        # Skip image-only or very short structural paragraphs
+        if len(para) < 20 and not re.search(r"[一-鿿]", para):
+            continue
+        if len(para) <= 600:
+            segments.append({"text": para})
+            continue
+        # Split long paragraphs by sentence
+        sentences = _split_sentences(para)
+        if not sentences:
+            segments.append({"text": para[:600] + "…"})
+            continue
+        buf: list[str] = []
+        buf_len = 0
+        for s in sentences:
+            if buf_len + len(s) > 400 and buf:
+                segments.append({"text": " ".join(buf)})
+                buf = [s]
+                buf_len = len(s)
+            else:
+                buf.append(s)
+                buf_len += len(s)
+        if buf:
+            segments.append({"text": " ".join(buf)})
+    for i, seg in enumerate(segments):
+        seg["id"] = f"s{i + 1}"
+    return segments
+
+
+# ---------------------------------------------------------------------------
+# Similarity (claim ↔ segment)
+# ---------------------------------------------------------------------------
+
+# Tiny stopword list — Chinese function words plus a few English ones.
+# Big enough to cut noise, small enough that we don't overfit to one
+# corpus.
+_STOPWORDS = frozenset({
+    "的", "了", "和", "与", "或", "在", "是", "也", "都", "及", "等", "等等",
+    "为", "于", "对", "以", "从", "到", "把", "被", "让", "使", "如", "若",
+    "但", "而", "并", "且", "其", "之", "这", "那", "这个", "那个", "这些",
+    "那些", "我们", "他们", "你们", "可以", "可能", "应该", "需要", "通过",
+    "进行", "包括", "提供", "实现", "成为", "用于", "做", "有", "无", "没", "多", "少",
+    "the", "a", "an", "and", "or", "of", "in", "on", "to", "for", "with",
+    "is", "are", "was", "were", "be", "been", "being", "by", "as", "at",
+    "from", "this", "that", "these", "those", "it", "its", "you", "we",
+    "they", "their", "our", "i", "he", "she", "his", "her", "than", "then",
+    "but", "not", "no", "do", "does", "did", "have", "has", "had", "can",
+    "could", "should", "would", "will", "may", "might", "if", "so",
+})
+
+_TOKEN_PATTERN = re.compile(r"[A-Za-z0-9]+|[一-鿿]+")
+
+
+def _tokenize(text: str) -> set[str]:
+    """Tokenize mixed CN/EN text into a set of meaningful tokens.
+
+    For Chinese spans we prefer jieba; if jieba is not installed we
+    fall back to per-character segmentation (matches the optional-jieba
+    pattern in ``_truth_helpers.py``).  English/numeric is lowercased.
+    Stopwords and length-1 ASCII tokens are dropped.
+    """
+    try:
+        import jieba  # optional — gives much better CJK segmentation
+        cut = jieba.cut
+    except ImportError:
+        cut = None
+    tokens: set[str] = set()
+    for span in _TOKEN_PATTERN.findall(text):
+        if re.match(r"[一-鿿]+", span):
+            if cut is not None:
+                for tok in cut(span):
+                    tok = tok.strip()
+                    if not tok or tok in _STOPWORDS or len(tok) < 2:
+                        continue
+                    tokens.add(tok)
+            else:
+                # Per-char fallback: trigram-style CJK overlap is still
+                # useful for the Jaccard ribbon, just noisier.
+                for ch in span:
+                    tokens.add(ch)
+        else:
+            tok = span.lower()
+            if tok in _STOPWORDS or len(tok) < 2:
+                continue
+            tokens.add(tok)
+    return tokens
+
+
+def _jaccard(a: set[str], b: set[str]) -> float:
+    if not a or not b:
+        return 0.0
+    inter = len(a & b)
+    union = len(a | b)
+    return inter / union if union else 0.0
+
+
+def _attach_evidence(claims: list[dict], segments: list[dict], top_k: int = 3) -> None:
+    """Mutate each claim to add ``evidence`` = list of segment ids
+    (most-similar first) and a per-segment overlap score.
+
+    If the best score is < 0.05 we still return the top-k but mark
+    ``evidence_weak=True`` so the UI can render a "no strong match"
+    warning — that's exactly the signal a reviewer wants for a possible
+    hallucination.
+    """
+    if not segments:
+        for c in claims:
+            c["evidence"] = []
+            c["evidence_weak"] = True
+        return
+    seg_tokens = [(seg["id"], _tokenize(seg["text"])) for seg in segments]
+    for c in claims:
+        c_tokens = _tokenize(c["text"])
+        scored = [
+            (seg_id, _jaccard(c_tokens, t))
+            for seg_id, t in seg_tokens
+        ]
+        scored.sort(key=lambda x: x[1], reverse=True)
+        top = scored[:top_k]
+        c["evidence"] = [{"segment_id": sid, "score": round(score, 3)} for sid, score in top]
+        c["evidence_weak"] = (top[0][1] if top else 0.0) < 0.05
+
+
+# ---------------------------------------------------------------------------
+# Evergreen scan + raw source index
+# ---------------------------------------------------------------------------
+
+
+def _scan_evergreens(evergreen_dir: Path) -> list[dict]:
+    records: list[dict] = []
+    for path in sorted(evergreen_dir.rglob("*.md")):
+        if "_Candidates" in path.parts:
+            continue
+        text = path.read_text(encoding="utf-8")
+        fm = _parse_frontmatter(text)
+        if fm is None:
+            continue
+        records.append({
+            "path": path,
+            "slug": path.stem,
+            "title": fm.get("title") or path.stem,
+            "source_url": (fm.get("source_url") or "").strip(),
+            "source_fingerprint": fm.get("source_fingerprint") or "",
+            "date": str(fm.get("date") or ""),
+            "frontmatter": fm,
+            "body": _evergreen_body(text),
+            "category": _categorize_source((fm.get("source_url") or "").strip()),
+        })
+    return records
+
+
+def _build_processed_index(*roots: Path) -> dict[str, Path]:
+    """Return ``source_url -> raw_path`` index across one or more roots.
+
+    Filename-based matching against deep-dive stems is unreliable because
+    deep-dive titles get truncated and the underscore/space normalization
+    diverged across months.  Instead we read each raw source's
+    frontmatter ``source`` field (the URL written by intake) and key the
+    index by URL.
+
+    Roots scanned:
+      - ``50-Inbox/03-Processed/``  — articles that went through deep-dive
+      - ``70-Archive/Pinboard/``    — Pinboard captures (mostly tweets +
+                                       github, never get a deep-dive)
+    """
+    index: dict[str, Path] = {}
+    for root in roots:
+        if not root or not root.exists():
+            continue
+        for path in root.rglob("*.md"):
+            try:
+                text = path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue
+            fm = _parse_frontmatter(text)
+            if not fm:
+                continue
+            for key in ("source", "source_url", "url"):
+                value = fm.get(key)
+                if isinstance(value, str) and value.strip().startswith(("http://", "https://")):
+                    index.setdefault(value.strip(), path)
+                    break
+    return index
+
+
+def _find_raw_source(source_url: str, index: dict[str, Path]) -> Path | None:
+    if not source_url:
+        return None
+    return index.get(source_url.strip())
+
+
+# ---------------------------------------------------------------------------
+# Stratified sampling
+# ---------------------------------------------------------------------------
+
+
+def _stratified_sample(
+    records: list[dict],
+    *,
+    sample_size: int,
+    floor_per_category: int,
+    rng: random.Random,
+) -> list[dict]:
+    by_category: dict[str, list[dict]] = defaultdict(list)
+    for r in records:
+        by_category[r["category"]].append(r)
+
+    populated_categories = [c for c in SOURCE_CATEGORIES if by_category[c]]
+    if not populated_categories:
+        return []
+
+    allocations: dict[str, int] = {}
+    for category in populated_categories:
+        allocations[category] = min(floor_per_category, len(by_category[category]))
+
+    total_floor = sum(allocations.values())
+    remaining = max(0, sample_size - total_floor)
+    pool_size = sum(
+        max(0, len(by_category[c]) - allocations[c]) for c in populated_categories
+    )
+    if remaining and pool_size:
+        weights = {
+            c: max(0, len(by_category[c]) - allocations[c])
+            for c in populated_categories
+        }
+        raw = {c: remaining * w / pool_size for c, w in weights.items()}
+        floors = {c: int(v) for c, v in raw.items()}
+        leftover = remaining - sum(floors.values())
+        order = sorted(
+            populated_categories,
+            key=lambda c: (-(raw[c] - floors[c]), c),
+        )
+        for c in order[:leftover]:
+            floors[c] += 1
+        for c in populated_categories:
+            allocations[c] += floors[c]
+
+    sampled: list[dict] = []
+    for category in populated_categories:
+        pool = by_category[category]
+        n = min(allocations[category], len(pool))
+        if n <= 0:
+            continue
+        sampled.extend(rng.sample(pool, n))
+
+    rng.shuffle(sampled)
+    return sampled[:sample_size]
+
+
+# ---------------------------------------------------------------------------
+# HTML rendering
+# ---------------------------------------------------------------------------
+
+
+_HTML_TEMPLATE = """<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<title>OVP Fidelity Review — __RUN_ID__</title>
+<style>
+  :root {
+    --bg: #fafaf7;
+    --panel: #ffffff;
+    --border: #e0e0d8;
+    --accent: #c0392b;
+    --accent-soft: #f9e6e2;
+    --ok: #27ae60;
+    --warn: #d68910;
+    --neutral: #6b6b66;
+    --highlight: #fff7c2;
+    --weak: #f3eecf;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; height: 100%; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", "PingFang SC",
+                 "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
+    font-size: 14px;
+    line-height: 1.55;
+    color: #222;
+    background: var(--bg);
+  }
+  header {
+    position: sticky; top: 0; z-index: 10;
+    display: flex; align-items: center; gap: 12px;
+    padding: 10px 16px;
+    background: var(--panel);
+    border-bottom: 1px solid var(--border);
+  }
+  header h1 {
+    font-size: 14px; font-weight: 600; margin: 0; flex-shrink: 0;
+  }
+  header .nav {
+    display: flex; align-items: center; gap: 6px;
+  }
+  header button {
+    padding: 4px 10px; border: 1px solid var(--border);
+    background: var(--panel); border-radius: 4px; cursor: pointer;
+    font-size: 13px;
+  }
+  header button:hover { background: #f3f3ed; }
+  header .progress {
+    flex-grow: 1; display: flex; align-items: center; gap: 8px;
+  }
+  header .progress-bar {
+    flex-grow: 1; height: 4px; background: var(--border); border-radius: 2px;
+    overflow: hidden;
+  }
+  header .progress-bar > div {
+    height: 100%; background: var(--accent); width: 0%;
+    transition: width 0.2s;
+  }
+  header .meta { color: var(--neutral); font-size: 12px; }
+  .panes {
+    display: grid;
+    grid-template-columns: minmax(420px, 1fr) minmax(420px, 1fr);
+    gap: 0;
+    height: calc(100vh - 53px);
+  }
+  .pane {
+    overflow-y: auto; padding: 16px 20px;
+  }
+  .pane.left { border-right: 1px solid var(--border); background: var(--panel); }
+  .pane.right { background: var(--bg); }
+  .sample-meta {
+    margin-bottom: 16px; padding-bottom: 12px;
+    border-bottom: 1px solid var(--border);
+  }
+  .sample-meta h2 { margin: 0 0 6px 0; font-size: 18px; }
+  .sample-meta .meta-row {
+    color: var(--neutral); font-size: 12px;
+    margin: 2px 0;
+  }
+  .sample-meta a { color: var(--accent); text-decoration: none; }
+  .sample-meta a:hover { text-decoration: underline; }
+  .badge {
+    display: inline-block; padding: 1px 8px;
+    background: var(--accent-soft); color: var(--accent);
+    border-radius: 10px; font-size: 11px; font-weight: 500;
+  }
+  details.evergreen-body {
+    margin-bottom: 16px; padding: 8px 12px;
+    background: #fcfcf8; border: 1px solid var(--border); border-radius: 4px;
+  }
+  details.evergreen-body summary {
+    cursor: pointer; font-weight: 500; color: var(--neutral);
+  }
+  details.evergreen-body pre {
+    margin: 8px 0 0 0; padding: 0;
+    background: transparent; white-space: pre-wrap; word-wrap: break-word;
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", monospace;
+    font-size: 12px;
+  }
+  .claims-header {
+    margin-top: 8px; font-size: 13px; font-weight: 600; color: var(--neutral);
+    text-transform: uppercase; letter-spacing: 0.04em;
+  }
+  .claim {
+    margin: 12px 0; padding: 12px 14px;
+    border: 1px solid var(--border); border-radius: 5px;
+    background: #fdfdf8;
+    transition: background 0.15s, border-color 0.15s;
+  }
+  .claim.active {
+    border-color: var(--accent);
+    background: var(--accent-soft);
+  }
+  .claim .claim-section {
+    font-size: 11px; color: var(--neutral); text-transform: uppercase;
+    letter-spacing: 0.04em; margin-bottom: 4px;
+  }
+  .claim .claim-text {
+    cursor: pointer;
+    margin: 0 0 6px 0;
+    padding-right: 4px;
+  }
+  .claim .claim-text:hover { color: var(--accent); }
+  .claim .evidence-meta {
+    font-size: 11px; color: var(--neutral); margin-bottom: 8px;
+  }
+  .claim .evidence-meta.weak { color: var(--accent); font-weight: 500; }
+  .rubric { display: flex; flex-wrap: wrap; gap: 4px; margin: 6px 0; }
+  .rubric label {
+    display: inline-flex; align-items: center; gap: 3px;
+    padding: 2px 8px; border: 1px solid var(--border); border-radius: 12px;
+    font-size: 12px; cursor: pointer; user-select: none;
+    background: var(--panel);
+  }
+  .rubric label:hover { background: #eee; }
+  .rubric input[type=radio] { margin: 0; }
+  .rubric label.faithful_specific.checked { background: #e7f7ec; border-color: var(--ok); }
+  .rubric label.faithful_generic.checked  { background: #fff3cf; border-color: #d4a017; }
+  .rubric label.distorted.checked         { background: #fcecd1; border-color: var(--warn); }
+  .rubric label.hallucinated.checked      { background: var(--accent-soft); border-color: var(--accent); }
+  .rubric label.unverifiable.checked      { background: #ececec; border-color: var(--neutral); }
+  /* sample-summary uses simpler labels */
+  .rubric label.faithful.checked  { background: #e7f7ec; border-color: var(--ok); }
+  .rubric label.diluted.checked   { background: #fff3cf; border-color: #d4a017; }
+  .rubric label.partial.checked   { background: #fcecd1; border-color: var(--warn); }
+  /* specifics chips: multi-select, smaller */
+  .specifics {
+    display: flex; flex-wrap: wrap; gap: 4px; margin: 6px 0 4px 0;
+    align-items: center;
+  }
+  .specifics .label {
+    font-size: 11px; color: var(--neutral); margin-right: 4px;
+    text-transform: uppercase; letter-spacing: 0.04em;
+  }
+  .specifics label {
+    display: inline-flex; align-items: center; gap: 2px;
+    padding: 1px 7px; border: 1px solid var(--border); border-radius: 10px;
+    font-size: 11px; cursor: pointer; user-select: none;
+    background: var(--panel); color: var(--neutral);
+  }
+  .specifics label:hover { background: #eee; }
+  .specifics input[type=checkbox] { display: none; }
+  .specifics label.checked {
+    background: #fdecea; border-color: var(--accent); color: var(--accent);
+  }
+  .claim textarea {
+    width: 100%; min-height: 32px; padding: 4px 6px;
+    border: 1px solid var(--border); border-radius: 3px;
+    font-family: inherit; font-size: 12px; resize: vertical;
+  }
+  .summary {
+    margin-top: 24px; padding: 14px;
+    border: 1px solid var(--accent); border-radius: 5px;
+    background: var(--accent-soft);
+  }
+  .summary h3 { margin: 0 0 10px 0; font-size: 14px; }
+  .summary .tally {
+    display: grid; grid-template-columns: repeat(5, 1fr);
+    gap: 6px; margin: 10px 0; font-size: 12px;
+  }
+  .summary .tally div {
+    padding: 4px 8px; background: var(--panel); border-radius: 3px;
+    text-align: center;
+  }
+  .summary .tally strong { font-size: 16px; display: block; }
+  .summary textarea {
+    width: 100%; min-height: 50px; padding: 6px;
+    border: 1px solid var(--border); border-radius: 3px;
+    font-family: inherit; font-size: 12px;
+  }
+  .seg {
+    margin: 10px 0; padding: 10px 14px;
+    background: var(--panel); border: 1px solid var(--border);
+    border-left: 3px solid transparent;
+    border-radius: 3px;
+    white-space: pre-wrap; word-wrap: break-word;
+    font-size: 13px;
+  }
+  .seg.evidence-1 { border-left-color: var(--accent); background: var(--highlight); }
+  .seg.evidence-2 { border-left-color: var(--warn); background: #fff8e0; }
+  .seg.evidence-3 { border-left-color: var(--neutral); background: #fafadf; }
+  .seg .seg-meta {
+    font-size: 10px; color: var(--neutral); margin-bottom: 4px;
+    text-transform: uppercase; letter-spacing: 0.04em;
+  }
+  .seg .seg-meta .score { color: var(--accent); font-weight: 500; }
+  .raw-missing {
+    padding: 16px; background: #fff3e0; border: 1px solid var(--warn);
+    border-radius: 4px; color: #6e3a00;
+  }
+  .raw-missing a { color: var(--accent); }
+</style>
+</head>
+<body>
+<header>
+  <h1>OVP Fidelity Review</h1>
+  <div class="meta" id="run-id">__RUN_ID__</div>
+  <div class="progress">
+    <span class="meta" id="counter">0 / 0</span>
+    <div class="progress-bar"><div id="progress-bar-fill"></div></div>
+    <span class="meta" id="scored-count">0 scored</span>
+  </div>
+  <div class="nav">
+    <button id="prev-btn">← Prev</button>
+    <button id="next-btn">Next →</button>
+    <button id="export-btn" title="下载所有评分为 JSON">Export</button>
+    <button id="import-btn" title="加载之前导出的评分">Import</button>
+    <input type="file" id="import-input" accept=".json" style="display:none">
+  </div>
+</header>
+<main class="panes">
+  <section class="pane left" id="left-pane">
+    <div id="sample-content"></div>
+  </section>
+  <section class="pane right" id="right-pane">
+    <div id="raw-content"></div>
+  </section>
+</main>
+<script>
+const SAMPLES = __SAMPLES_JSON__;
+const RUN_ID = "__RUN_ID__";
+const STORAGE_KEY = "ovp-fidelity-" + RUN_ID;
+
+let currentIndex = 0;
+let rubric = loadRubric();
+
+function loadRubric() {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved) return JSON.parse(saved);
+  } catch (e) {}
+  return {};
+}
+
+function saveRubric() {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(rubric));
+  updateScoredCount();
+}
+
+function getSampleRubric(slug) {
+  if (!rubric[slug]) {
+    rubric[slug] = { claims: {}, overall: { verdict: "", note: "" } };
+  } else {
+    if (!rubric[slug].claims) rubric[slug].claims = {};
+    if (!rubric[slug].overall) rubric[slug].overall = { verdict: "", note: "" };
+  }
+  return rubric[slug];
+}
+
+function isSampleScored(slug) {
+  const r = rubric[slug];
+  if (!r) return false;
+  return Object.values(r.claims || {}).some(c => c.verdict);
+}
+
+function updateScoredCount() {
+  const n = SAMPLES.filter(s => isSampleScored(s.slug)).length;
+  document.getElementById("scored-count").textContent = `${n} scored`;
+  document.getElementById("progress-bar-fill").style.width = `${(n / SAMPLES.length) * 100}%`;
+}
+
+function renderSample(idx) {
+  const sample = SAMPLES[idx];
+  const r = getSampleRubric(sample.slug);
+  document.getElementById("counter").textContent = `${idx + 1} / ${SAMPLES.length}`;
+
+  const left = document.getElementById("sample-content");
+  const right = document.getElementById("raw-content");
+
+  // ---- left pane: meta + claims + summary ----
+  const meta = document.createElement("div");
+  meta.className = "sample-meta";
+  meta.innerHTML = `
+    <h2>${escapeHtml(sample.title)}</h2>
+    <div class="meta-row"><span class="badge">${sample.category}</span> &nbsp; <code>${sample.slug}</code></div>
+    <div class="meta-row">source: ${sample.source_url ? `<a href="${escapeAttr(sample.source_url)}" target="_blank">${escapeHtml(sample.source_url)}</a>` : "<em>(none)</em>"}</div>
+    <div class="meta-row">vault: <code>${escapeHtml(sample.path)}</code></div>
+  `;
+
+  const fullBody = document.createElement("details");
+  fullBody.className = "evergreen-body";
+  fullBody.innerHTML = `<summary>Evergreen full body (${sample.body.length} chars)</summary><pre>${escapeHtml(sample.body)}</pre>`;
+
+  const claimsHeader = document.createElement("div");
+  claimsHeader.className = "claims-header";
+  claimsHeader.textContent = `Claims (${sample.claims.length})`;
+
+  const VERDICTS = ["faithful_specific", "faithful_generic", "distorted", "hallucinated", "unverifiable"];
+  const SPECIFICS = ["numbers", "names", "tradeoffs", "examples", "edge_cases"];
+
+  const claimsBox = document.createElement("div");
+  for (const claim of sample.claims) {
+    // Migrate older single-tier "faithful" → "faithful_specific" so prior
+    // rubric data (if any) still renders.  All new entries default to
+    // empty verdict + empty dropped[].
+    const stored = r.claims[claim.id] || {};
+    const cr = {
+      verdict: stored.verdict === "faithful" ? "faithful_specific" : (stored.verdict || ""),
+      dropped: Array.isArray(stored.dropped) ? stored.dropped : [],
+      note: stored.note || "",
+    };
+    r.claims[claim.id] = cr;
+
+    const div = document.createElement("div");
+    div.className = "claim";
+    div.dataset.claimId = claim.id;
+    const evidenceLabel = claim.evidence_weak
+      ? `<span class="evidence-meta weak">⚠ no strong source match (best Jaccard ${claim.evidence[0] ? claim.evidence[0].score : 0})</span>`
+      : `<span class="evidence-meta">top match Jaccard ${claim.evidence[0] ? claim.evidence[0].score : 0}</span>`;
+    div.innerHTML = `
+      <div class="claim-section">${claim.section}</div>
+      <p class="claim-text">${escapeHtml(claim.text)}</p>
+      ${evidenceLabel}
+      <div class="rubric">
+        ${VERDICTS.map(v =>
+          `<label class="${v}${cr.verdict === v ? " checked" : ""}">
+             <input type="radio" name="verdict-${claim.id}" value="${v}" ${cr.verdict === v ? "checked" : ""}> ${v.replace("_", " ")}
+           </label>`
+        ).join("")}
+      </div>
+      <div class="specifics">
+        <span class="label">source had but claim dropped:</span>
+        ${SPECIFICS.map(d =>
+          `<label class="${cr.dropped.includes(d) ? "checked" : ""}">
+             <input type="checkbox" value="${d}" ${cr.dropped.includes(d) ? "checked" : ""}> ${d}
+           </label>`
+        ).join("")}
+      </div>
+      <textarea placeholder="note (optional)">${escapeHtml(cr.note || "")}</textarea>
+    `;
+    div.querySelector(".claim-text").addEventListener("click", () => focusEvidence(claim));
+    for (const inp of div.querySelectorAll(".rubric input[type=radio]")) {
+      inp.addEventListener("change", e => {
+        cr.verdict = e.target.value;
+        saveRubric();
+        for (const lab of div.querySelectorAll(".rubric label")) {
+          lab.classList.toggle("checked", lab.querySelector("input").checked);
+        }
+        updateTally(sample, r);
+      });
+    }
+    for (const inp of div.querySelectorAll(".specifics input[type=checkbox]")) {
+      inp.addEventListener("change", e => {
+        const v = e.target.value;
+        if (e.target.checked) {
+          if (!cr.dropped.includes(v)) cr.dropped.push(v);
+        } else {
+          cr.dropped = cr.dropped.filter(x => x !== v);
+        }
+        saveRubric();
+        e.target.parentElement.classList.toggle("checked", e.target.checked);
+      });
+    }
+    div.querySelector("textarea").addEventListener("input", e => {
+      cr.note = e.target.value;
+      saveRubric();
+    });
+    claimsBox.appendChild(div);
+  }
+
+  // Sample-level verdict labels.  ``diluted`` is the new bucket for
+  // "every claim faithful but multiple were faithful_generic" — the
+  // OVP-specific failure mode (abstraction inflation) we want to
+  // surface separately from "everything is fine" (faithful) and
+  // "some content was changed" (partial).
+  const OVERALL_VERDICTS = ["faithful", "diluted", "partial", "hallucinated", "unverifiable"];
+  const summary = document.createElement("div");
+  summary.className = "summary";
+  summary.innerHTML = `
+    <h3>Sample summary</h3>
+    <div class="tally" id="tally"></div>
+    <div class="rubric" id="overall-rubric">
+      ${OVERALL_VERDICTS.map(v =>
+        `<label class="${v}${r.overall.verdict === v ? " checked" : ""}">
+           <input type="radio" name="overall-verdict" value="${v}" ${r.overall.verdict === v ? "checked" : ""}> ${v}
+         </label>`
+      ).join("")}
+    </div>
+    <textarea id="overall-note" placeholder="overall note (optional)">${escapeHtml(r.overall.note || "")}</textarea>
+  `;
+
+  left.replaceChildren(meta, fullBody, claimsHeader, claimsBox, summary);
+
+  for (const inp of summary.querySelectorAll("input[type=radio]")) {
+    inp.addEventListener("change", e => {
+      r.overall.verdict = e.target.value;
+      saveRubric();
+      for (const lab of summary.querySelectorAll(".rubric label")) {
+        lab.classList.toggle("checked", lab.querySelector("input").checked);
+      }
+    });
+  }
+  summary.querySelector("textarea").addEventListener("input", e => {
+    r.overall.note = e.target.value;
+    saveRubric();
+  });
+  updateTally(sample, r);
+
+  // ---- right pane: raw segments ----
+  if (sample.segments && sample.segments.length) {
+    const frag = document.createDocumentFragment();
+    if (sample.raw_relpath) {
+      const meta = document.createElement("div");
+      meta.className = "meta-row";
+      meta.style.marginBottom = "12px";
+      meta.style.color = "var(--neutral)";
+      meta.style.fontSize = "12px";
+      meta.innerHTML = `Raw source: <code>${escapeHtml(sample.raw_relpath)}</code> &nbsp;·&nbsp; ${sample.segments.length} segments`;
+      frag.appendChild(meta);
+    }
+    for (const seg of sample.segments) {
+      const div = document.createElement("div");
+      div.className = "seg";
+      div.id = `seg-${seg.id}`;
+      div.innerHTML = `<div class="seg-meta">${seg.id}</div>${escapeHtml(seg.text)}`;
+      frag.appendChild(div);
+    }
+    right.replaceChildren(frag);
+  } else {
+    right.innerHTML = `
+      <div class="raw-missing">
+        <strong>Raw source not available locally.</strong><br>
+        Open the source URL in your browser to evaluate manually:<br>
+        ${sample.source_url ? `<a href="${escapeAttr(sample.source_url)}" target="_blank">${escapeHtml(sample.source_url)}</a>` : "<em>(no URL)</em>"}
+      </div>
+    `;
+  }
+  updateScoredCount();
+}
+
+function focusEvidence(claim) {
+  // clear all
+  for (const seg of document.querySelectorAll(".seg")) {
+    seg.classList.remove("evidence-1", "evidence-2", "evidence-3");
+  }
+  for (const c of document.querySelectorAll(".claim")) c.classList.remove("active");
+  const claimDiv = document.querySelector(`[data-claim-id="${claim.id}"]`);
+  if (claimDiv) claimDiv.classList.add("active");
+
+  if (!claim.evidence || !claim.evidence.length) return;
+  for (let i = 0; i < claim.evidence.length; i++) {
+    const seg = document.getElementById(`seg-${claim.evidence[i].segment_id}`);
+    if (!seg) continue;
+    seg.classList.add(`evidence-${i + 1}`);
+  }
+  // scroll first into view in right pane
+  const first = document.getElementById(`seg-${claim.evidence[0].segment_id}`);
+  if (first) {
+    first.scrollIntoView({ behavior: "smooth", block: "center" });
+  }
+}
+
+function updateTally(sample, r) {
+  const tally = document.getElementById("tally");
+  if (!tally) return;
+  const counts = {
+    faithful_specific: 0, faithful_generic: 0,
+    distorted: 0, hallucinated: 0, unverifiable: 0, unscored: 0,
+  };
+  const droppedCounts = { numbers: 0, names: 0, tradeoffs: 0, examples: 0, edge_cases: 0 };
+  for (const claim of sample.claims) {
+    const cr = r.claims[claim.id] || {};
+    const v = cr.verdict;
+    if (v) counts[v] = (counts[v] || 0) + 1;
+    else counts.unscored += 1;
+    for (const d of (cr.dropped || [])) {
+      droppedCounts[d] = (droppedCounts[d] || 0) + 1;
+    }
+  }
+  const droppedAny = Object.values(droppedCounts).some(n => n > 0);
+  const droppedRow = droppedAny
+    ? `<div class="meta" style="grid-column: 1/-1; padding-top: 4px; font-size: 11px;">
+         dropped: ${Object.entries(droppedCounts).filter(([_,n])=>n>0).map(([k,n])=>`${k} ×${n}`).join(", ")}
+       </div>`
+    : "";
+  tally.innerHTML = `
+    <div><strong>${counts.faithful_specific}</strong>specific</div>
+    <div><strong>${counts.faithful_generic}</strong>generic</div>
+    <div><strong>${counts.distorted}</strong>distorted</div>
+    <div><strong>${counts.hallucinated}</strong>halluc.</div>
+    <div><strong>${counts.unverifiable}</strong>unverif.</div>
+    ${droppedRow}
+  `;
+}
+
+function escapeHtml(s) {
+  return String(s == null ? "" : s)
+    .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+}
+function escapeAttr(s) { return escapeHtml(s); }
+
+document.getElementById("prev-btn").addEventListener("click", () => {
+  if (currentIndex > 0) { currentIndex -= 1; renderSample(currentIndex); }
+});
+document.getElementById("next-btn").addEventListener("click", () => {
+  if (currentIndex < SAMPLES.length - 1) { currentIndex += 1; renderSample(currentIndex); }
+});
+document.addEventListener("keydown", e => {
+  if (e.target.matches("textarea, input")) return;
+  if (e.key === "ArrowLeft" || e.key === "[") {
+    if (currentIndex > 0) { currentIndex -= 1; renderSample(currentIndex); }
+  } else if (e.key === "ArrowRight" || e.key === "]") {
+    if (currentIndex < SAMPLES.length - 1) { currentIndex += 1; renderSample(currentIndex); }
+  }
+});
+document.getElementById("export-btn").addEventListener("click", () => {
+  const blob = new Blob(
+    [JSON.stringify({ run_id: RUN_ID, exported_at: new Date().toISOString(), rubric }, null, 2)],
+    { type: "application/json" }
+  );
+  const a = document.createElement("a");
+  a.href = URL.createObjectURL(blob);
+  a.download = `fidelity-rubric-${RUN_ID}.json`;
+  a.click();
+});
+document.getElementById("import-btn").addEventListener("click", () => {
+  document.getElementById("import-input").click();
+});
+document.getElementById("import-input").addEventListener("change", async e => {
+  const file = e.target.files[0];
+  if (!file) return;
+  const text = await file.text();
+  try {
+    const parsed = JSON.parse(text);
+    if (parsed && parsed.rubric) {
+      if (!confirm("Replace current rubric with imported file?")) return;
+      rubric = parsed.rubric;
+      saveRubric();
+      renderSample(currentIndex);
+    }
+  } catch (err) {
+    alert("Import failed: " + err.message);
+  }
+});
+
+renderSample(currentIndex);
+</script>
+</body>
+</html>
+"""
+
+
+def _render_html(samples: list[dict], *, run_id: str, vault_dir: Path) -> str:
+    """Inline-render the single self-contained HTML."""
+    payload: list[dict] = []
+    for s in samples:
+        rel_evergreen = str(s["path"].relative_to(vault_dir))
+        rel_raw = (
+            str(s["raw_path"].relative_to(vault_dir))
+            if s.get("raw_path") is not None
+            else None
+        )
+        payload.append({
+            "slug": s["slug"],
+            "title": s["title"],
+            "category": s["category"],
+            "source_url": s["source_url"],
+            "source_fingerprint": s["source_fingerprint"],
+            "path": rel_evergreen,
+            "raw_relpath": rel_raw,
+            "body": s["body"],
+            "claims": s["claims"],
+            "segments": s["segments"],
+        })
+    return (
+        _HTML_TEMPLATE
+        .replace("__RUN_ID__", html.escape(run_id))
+        .replace("__SAMPLES_JSON__", _safe_json_for_script(payload))
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="ovp-fidelity-sample",
+        description=(
+            "Stratified-sample evergreens for human fidelity review. "
+            "Renders a self-contained HTML web app — open in any browser, "
+            "rubric auto-saves to LocalStorage, Export/Import via JSON."
+        ),
+    )
+    parser.add_argument("--vault-dir", type=Path, default=None)
+    parser.add_argument("--sample-size", type=int, default=50)
+    parser.add_argument("--floor-per-category", type=int, default=5)
+    parser.add_argument("--seed", type=int, default=None)
+    parser.add_argument("--run-id", type=str, default=None)
+    parser.add_argument("--out-dir", type=Path, default=None)
+
+    args = parser.parse_args(argv)
+
+    vault_dir = resolve_vault_dir(args.vault_dir)
+    layout = VaultLayout.from_vault(vault_dir)
+
+    rng = random.Random(args.seed) if args.seed is not None else random.Random()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out_dir = args.out_dir or (layout.logs_dir / "fidelity-samples" / run_id)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Scanning evergreens under {layout.evergreen_dir} …", file=sys.stderr)
+    records = _scan_evergreens(layout.evergreen_dir)
+    print(f"  found {len(records)} evergreens with parseable frontmatter", file=sys.stderr)
+
+    pinboard_archive = vault_dir / "70-Archive" / "Pinboard"
+    print("Indexing raw sources by source_url …", file=sys.stderr)
+    print(f"  scanning {layout.processed_dir}", file=sys.stderr)
+    print(f"  scanning {pinboard_archive}", file=sys.stderr)
+    processed_index = _build_processed_index(layout.processed_dir, pinboard_archive)
+    print(f"  indexed {len(processed_index)} raw sources by URL", file=sys.stderr)
+
+    print(f"Sampling {args.sample_size} (floor {args.floor_per_category} per category) …", file=sys.stderr)
+    samples = _stratified_sample(
+        records,
+        sample_size=args.sample_size,
+        floor_per_category=args.floor_per_category,
+        rng=rng,
+    )
+    print(f"  drew {len(samples)} samples", file=sys.stderr)
+
+    # Enrich each sample with claims, raw path, segments, evidence
+    print("Extracting claims and aligning evidence …", file=sys.stderr)
+    matched = 0
+    for sample in samples:
+        sample["claims"] = _extract_claims(sample["body"])
+        raw_path = _find_raw_source(sample["source_url"], processed_index)
+        sample["raw_path"] = raw_path
+        if raw_path and raw_path.exists():
+            try:
+                raw_text = raw_path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                raw_text = ""
+            sample["segments"] = _split_raw_segments(_raw_body(raw_text))
+            matched += 1
+        else:
+            sample["segments"] = []
+        _attach_evidence(sample["claims"], sample["segments"])
+    print(f"  raw source matched: {matched}/{len(samples)}", file=sys.stderr)
+
+    # Render
+    out_html = out_dir / "checklist.html"
+    out_html.write_text(
+        _render_html(samples, run_id=run_id, vault_dir=vault_dir),
+        encoding="utf-8",
+    )
+
+    manifest = {
+        "run_id": run_id,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "vault_dir": str(vault_dir),
+        "sample_size_requested": args.sample_size,
+        "sample_size_actual": len(samples),
+        "floor_per_category": args.floor_per_category,
+        "raw_source_match_count": matched,
+        "seed": args.seed,
+        "samples": [
+            {
+                "id": idx,
+                "slug": s["slug"],
+                "category": s["category"],
+                "path": str(s["path"].relative_to(vault_dir)),
+                "raw_path": (
+                    str(s["raw_path"].relative_to(vault_dir))
+                    if s["raw_path"] is not None else None
+                ),
+                "source_url": s["source_url"],
+                "source_fingerprint": s["source_fingerprint"],
+                "claim_count": len(s["claims"]),
+                "segment_count": len(s["segments"]),
+            }
+            for idx, s in enumerate(samples, start=1)
+        ],
+    }
+    out_json = out_dir / "manifest.json"
+    out_json.write_text(json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    print(f"\nWrote checklist HTML: {out_html}", file=sys.stderr)
+    print(f"Wrote manifest JSON:   {out_json}", file=sys.stderr)
+    print(
+        f"\nOpen in browser:\n  open {out_html}\n", file=sys.stderr,
+    )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ovp_pipeline/commands/prompt_ab.py
+++ b/src/ovp_pipeline/commands/prompt_ab.py
@@ -43,7 +43,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from ..llm_client import get_litellm_client
-from ..runtime import VaultLayout, resolve_vault_dir
+from ..runtime import VaultLayout, resolve_vault_dir, safe_json_for_script
 
 
 # ---------------------------------------------------------------------------
@@ -175,6 +175,13 @@ USER_TEMPLATE = """以下是源文 markdown(已去除 frontmatter)。请按你�
 """
 
 
+# Cap the body sent to the LLM so a runaway clipping (occasionally
+# hundreds of KB after Reader normalises a Substack post) can't blow
+# past the model's context window.  30 KB ≈ ~10k tokens which fits
+# comfortably under all production-tier providers.
+MAX_LLM_BODY_CHARS = 30000
+
+
 # ---------------------------------------------------------------------------
 # Source loading + body extraction
 # ---------------------------------------------------------------------------
@@ -255,7 +262,7 @@ def _call(llm_call, system: str, body: str) -> tuple[str, object]:
     exactly what the model emitted (including parse failures, which are
     themselves a quality signal).
     """
-    user = USER_TEMPLATE.format(body=body[:30000])  # cap to avoid context overflow
+    user = USER_TEMPLATE.format(body=body[:MAX_LLM_BODY_CHARS])
     try:
         raw = llm_call(system, user, 6000)
     except Exception as exc:
@@ -551,27 +558,11 @@ render(idx);
 """
 
 
-def _safe_json_for_script(obj: object) -> str:
-    """JSON-encode ``obj`` and escape chars that would break a literal
-    embed inside a ``<script>`` tag (mirrors the helper in
-    ``fidelity_sample.py``).
-    """
-    encoded = json.dumps(obj, ensure_ascii=False)
-    return (
-        encoded
-        .replace("<", "\\u003c")
-        .replace(">", "\\u003e")
-        .replace("&", "\\u0026")
-        .replace(" ", "\\u2028")
-        .replace(" ", "\\u2029")
-    )
-
-
 def _render_html(rows: list[dict], *, run_id: str) -> str:
     return (
         _HTML
         .replace("__RUN_ID__", run_id)
-        .replace("__DATA_JSON__", _safe_json_for_script(rows))
+        .replace("__DATA_JSON__", safe_json_for_script(rows))
     )
 
 
@@ -727,23 +718,18 @@ def main(argv: list[str] | None = None) -> int:
 
 
 def _extract_source_url(path: Path) -> str:
-    """Pull source_url / source from the file's frontmatter, if any."""
+    """Read ``path``'s frontmatter and return its canonical ``source:``
+    URL, if any.  Thin adapter over ``source_dedup.extract_source_url``
+    (the public helper that intake URL dedup also uses) so this CLI
+    can't drift from the field-recognition rules used by the rest of
+    the pipeline.
+    """
+    from ..source_dedup import extract_source_url, read_file_head
     try:
-        text = path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
+        text = read_file_head(path)
+    except OSError:
         return ""
-    if not text.startswith("---"):
-        return ""
-    try:
-        end = text.index("---", 3)
-    except ValueError:
-        return ""
-    fm_text = text[3:end]
-    for line in fm_text.splitlines():
-        m = re.match(r"^\s*(?:source|source_url|url)\s*:\s*\"?([^\"]+)\"?\s*$", line)
-        if m and m.group(1).startswith(("http://", "https://")):
-            return m.group(1).strip()
-    return ""
+    return extract_source_url(text) or ""
 
 
 if __name__ == "__main__":

--- a/src/ovp_pipeline/commands/prompt_ab.py
+++ b/src/ovp_pipeline/commands/prompt_ab.py
@@ -1,0 +1,750 @@
+"""ovp-prompt-ab — A/B-compare the old absorb prompt vs a v2 candidate
+prompt on the same set of source documents, render side-by-side HTML
+for human review.
+
+Why this exists
+---------------
+Fidelity sampling on 50 evergreens (2026-05-05) revealed that most are
+``faithful_generic`` — abstraction-inflated.  Comparison with NM showed
+the cause is structural (forced 定义/详细解释/为什么重要 template +
+"抽得多比抽得少好" volume bias in the SYSTEM_PROMPT).  Before we change
+the production absorb prompt, we want to verify on a handful of real
+sources that v2 actually produces less generic output.
+
+This tool runs both prompts against the same sources, collects raw JSON
+output, and renders a 3-pane HTML where each row shows:
+
+    [ source body ] [ old units ] [ new units ]
+
+so a reviewer can read the source once and judge both extractions.
+
+Outputs
+-------
+``60-Logs/prompt-ab/<run-id>/``
+    ├── manifest.json
+    ├── checklist.html         single-page review UI
+    ├── <source-stem>.old.json raw old-prompt response
+    └── <source-stem>.new.json raw new-prompt response
+
+The new prompt's intent is documented in v2 — we don't transcribe NM's
+prompt; we re-express the same goals (preserve specifics, allow empty
+output, drop forced template) in OVP's language.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from ..llm_client import get_litellm_client
+from ..runtime import VaultLayout, resolve_vault_dir
+
+
+# ---------------------------------------------------------------------------
+# Prompts
+# ---------------------------------------------------------------------------
+
+# Snapshot of the production prompt (auto_evergreen_extractor.SYSTEM_PROMPT
+# circa 2026-05-05).  We pin the text here rather than importing the
+# module because we want the experiment baseline to be stable even if
+# the production prompt evolves under us.
+OLD_PROMPT = """你是知识提取专家。请从文章中提取**所有**有价值的原子知识单元(atomic knowledge units)。
+
+## 数量目标(取决于原文长度和密度,不是硬上限)
+
+- 短文(< 1k 词): 5-10 个
+- 中等(1-3k 词): 8-20 个
+- 长文(> 3k 词): 15-30+ 个
+
+不要预设上限。让原文的密度决定数量;有 N 个独立可表达的知识单元,就抽 N 个。
+**抽得多比抽得少好** —— 后续会自动去重。
+
+## Evergreen 笔记标准
+
+1. **原子性**: 一个 atomic unit 一个笔记 —— 一个具体的事实/方法/洞察,不是一个主题
+2. **断言性**: 用**陈述句**命名,直接说出结论
+3. **永久性**: 时间无关的知识(版本号/Twitter 用户名/具体日期不入)
+4. **可链接**: 能跟其他原子单元连接
+5. **非元数据**: 不要把文件名、仓库目录、README/AGENTS.md/package.json、GitHub Action、URL 本身当成概念
+
+## unit_type 分类(显式标注)
+
+每个原子单元必须标 `unit_type`,从以下 4 类选 1:
+
+- **fact**: 客观事实/现象/数据
+- **procedure**: 操作流程/方法/recipe
+- **learning**: 经验/洞察/反直觉教训
+- **concept**: 命名抽象/定义
+
+## 输出格式(严格 JSON 数组,不要 markdown 包装)
+
+[
+  {
+    "concept_name": "concept-name-kebab-case",
+    "title": "Declarative claim sentence",
+    "entity_type": "concept",
+    "unit_type": "fact",
+    "one_sentence_def": "一句话定义(中文,保留技术术语英文)",
+    "explanation": "详细解释(2-4 句,中文)",
+    "importance": "为什么重要(1-2 句)",
+    "related_concepts": ["Related-1", "Related-2", "Related-3"]
+  }
+]
+"""
+
+# v2 prompt — written from scratch in OVP's voice.  Goals encoded:
+#   - allow empty output (skip_reason)
+#   - 0-8 cap, not 5-30
+#   - 10 unit_types including method / tradeoff / failure_mode /
+#     counterexample / case_detail (NM-inspired but redrafted)
+#   - source_anchor with verbatim requirement
+#   - explicit anti-rules: no enumeration shell, no Wikipedia-level
+#     definitions, no abstraction inflation
+#   - title must be a claim sentence not a category label
+NEW_PROMPT = """你的任务:从一篇源文里抽取对 vault 有价值的 CandidateUnit。
+你不是在总结源文,也不是在把源文改写成笔记。
+你是在找出源文中那些**保留了原文具体物**(数字、命名实体、方法步骤、
+工具名、反例、边界条件、对照选择)的可复用知识单元。
+
+## 输出格式(严格 JSON,不要 markdown 包装)
+
+{
+  "source_value_summary": "一句话概括这篇源文的可抽取价值。如果价值很低,直说。",
+  "units": [
+    {
+      "title": "一句完整的陈述句,不是名词短语",
+      "unit_type": "fact|method|procedure|tradeoff|failure_mode|counterexample|case_detail|learning|decision|quote",
+      "epistemic_role": "fact|interpretation|method|quote|attributed_claim",
+      "content": "markdown,自包含,不需要回读源文也能理解",
+      "source_anchor": "源文中逐字出现的短语/数字/名称/API,作为这条单元的具体锚点",
+      "specifics": ["保留下来的具体物分类:numbers / names / tradeoffs / examples / edge_cases"]
+    }
+  ],
+  "skip_reason": "如果 units 是空,说明为什么:常识 / 重复 / 没具体物 / 全是观点没证据 / 等等"
+}
+
+## 抽取规则,违反任何一条这条单元就不该存在:
+
+1. **自包含。** 读这条 unit 不需要回去看源文。如果核心信息是 "用 X 方法解决 Y" 而 X 是什么没说,这条是空壳。要么把 X 具体写进来,要么不写。
+
+2. **先选 unit_type,再写 content。形态必须匹配:**
+   - fact:单点事实 + 至少一个具体锚点(数字/命名物/场景)
+   - method:有名字的具体方法 + 操作要点 + 用什么工具/API
+   - procedure:编号步骤,每步有具体动作和命令/工具
+   - tradeoff:选 A 不选 B + 代价是什么 + 适用条件
+   - failure_mode:在什么条件下会出什么问题
+   - counterexample:与某个普遍说法不一致的具体例子
+   - case_detail:具体案例(谁/在哪/做了什么/结果如何)
+   - learning:观点 + 源文给出的依据(不能只有观点)
+   - decision:做了什么选择 + 备选 + 理由
+   - quote:值得逐字保留的原文(content 必须是逐字引用 + 你的简短标注)
+
+3. **不抽常识。** "X 是用于 Y 的方法" 这种 textbook 定义,默认跳过。只在源文给出 (a) 反例 (b) 数字数据 (c) 实现 tradeoff (d) 具体操作细节 之一时,这个主题才值得抽。
+
+4. **Title 是观点,不是分类。**
+   ✗ "Skill Pack 生态" / "三层架构" / "Agent 记忆系统"
+   ✓ "Hudson 的 Swift skill 偏广度,Antoine 偏深度"
+   ✓ "把平台差异隔离在 schema 解析层,可让 view model 不变"
+   读 title 应能立刻知道这条主张什么。
+
+5. **不要 enumeration shell。** "X 由 5 大来源组成" / "三层架构实现关注点分离" 这种**只列骨架不展开差异**的列表,不算保留 specifics。要么每项都展开它的独特点,要么不写这条 enumeration。
+
+6. **数量节制。** 0-8 单元。一篇短 tweet 可能 0-2;一篇长 paper 可能 5-8;**很少超过 8**。如果你写到第 6 条发现是在重复前面的意思,停。
+
+7. **跳过样板。** markdown 标题、转场段、礼貌话术、互动提示("如果你觉得有用请关注")、boilerplate 不抽。
+
+8. **宁可 0 条,不要凑数。** 如果这篇源文主要是观点反复 / 没有具体方法和数据 / 全是泛泛而谈,返回 units=[],写 skip_reason。这是被允许且鼓励的输出。
+
+9. **每条 unit 的 content 必须包含至少一段源文中逐字出现的内容**(在 source_anchor 字段标出)。如果做不到,说明这条已经飘到太抽象的层次,不写。
+
+10. **epistemic_role 区分清楚:** fact = 源文当事实陈述的内容;interpretation = 作者/你对事实的解释,不是事实本身;quote = 逐字引用;method = 可执行的操作描述;attributed_claim = 作者引用别人说的。不要把 interpretation 伪装成 fact。
+"""
+
+
+USER_TEMPLATE = """以下是源文 markdown(已去除 frontmatter)。请按你的规则抽取。
+
+```
+{body}
+```
+"""
+
+
+# ---------------------------------------------------------------------------
+# Source loading + body extraction
+# ---------------------------------------------------------------------------
+
+
+def _strip_frontmatter(text: str) -> str:
+    if not text.startswith("---"):
+        return text
+    try:
+        end = text.index("---", 3) + 3
+    except ValueError:
+        return text
+    return text[end:].lstrip("\n")
+
+
+def _word_count(text: str) -> int:
+    # rough — matches OLD_PROMPT's "短文/中等/长文" categories
+    chinese = len(re.findall(r"[一-鿿]", text))
+    english = len(re.findall(r"[A-Za-z]+", text))
+    return chinese + english
+
+
+@dataclass
+class SourceInput:
+    path: Path
+    rel_path: str
+    body: str
+    word_count: int
+
+
+def _safe_relpath(path: Path, vault_dir: Path) -> str:
+    """Return a vault-relative display path; fall back to the absolute
+    path when ``path`` lives outside the vault.
+
+    The CLI accepts absolute ``--source`` paths, but
+    ``Path.relative_to`` raises ``ValueError`` for paths outside
+    ``vault_dir`` — using it unconditionally crashed the run.
+    """
+    try:
+        return str(path.relative_to(vault_dir))
+    except ValueError:
+        return str(path)
+
+
+def _load_source(path: Path, vault_dir: Path) -> SourceInput | None:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    body = _strip_frontmatter(text)
+    return SourceInput(
+        path=path,
+        rel_path=_safe_relpath(path, vault_dir),
+        body=body,
+        word_count=_word_count(body),
+    )
+
+
+# ---------------------------------------------------------------------------
+# LLM invocation
+# ---------------------------------------------------------------------------
+
+
+def _parse_json_response(text: str) -> dict | list:
+    """Parse LLM JSON output, tolerating markdown code fences."""
+    s = text.strip()
+    # strip ```json ... ``` or ``` ... ``` wrappers
+    s = re.sub(r"^```(?:json)?\s*", "", s)
+    s = re.sub(r"```\s*$", "", s)
+    s = s.strip()
+    return json.loads(s)
+
+
+def _call(llm_call, system: str, body: str) -> tuple[str, object]:
+    """Invoke LLM, return (raw_text, parsed_or_error_dict).
+
+    Returns the raw response so the experiment can show the reviewer
+    exactly what the model emitted (including parse failures, which are
+    themselves a quality signal).
+    """
+    user = USER_TEMPLATE.format(body=body[:30000])  # cap to avoid context overflow
+    try:
+        raw = llm_call(system, user, 6000)
+    except Exception as exc:
+        return ("", {"error": str(exc), "stage": "llm_call"})
+    try:
+        parsed = _parse_json_response(raw)
+        return (raw, parsed)
+    except json.JSONDecodeError as exc:
+        return (raw, {"error": str(exc), "stage": "json_parse"})
+
+
+# ---------------------------------------------------------------------------
+# Normalize old/new outputs into a comparable shape for the UI
+# ---------------------------------------------------------------------------
+
+
+def _normalize_old(parsed) -> list[dict]:
+    """Old prompt returns a JSON array of concepts."""
+    if not isinstance(parsed, list):
+        return []
+    out = []
+    for c in parsed:
+        if not isinstance(c, dict):
+            continue
+        out.append({
+            "title": c.get("title") or c.get("concept_name", ""),
+            "unit_type": c.get("unit_type") or "concept",
+            "content": "\n\n".join(filter(None, [
+                c.get("one_sentence_def", "").strip(),
+                c.get("explanation", "").strip(),
+                f"**为什么重要:** {c.get('importance', '').strip()}" if c.get("importance") else "",
+            ])),
+            "extra": {
+                "concept_name": c.get("concept_name"),
+                "entity_type": c.get("entity_type"),
+                "related_concepts": c.get("related_concepts", []),
+            },
+        })
+    return out
+
+
+def _normalize_new(parsed) -> tuple[str, list[dict], str]:
+    """New prompt returns a JSON object with units + skip_reason."""
+    if not isinstance(parsed, dict):
+        return ("", [], "")
+    units = parsed.get("units") or []
+    out = []
+    for u in units:
+        if not isinstance(u, dict):
+            continue
+        out.append({
+            "title": u.get("title", ""),
+            "unit_type": u.get("unit_type", ""),
+            "epistemic_role": u.get("epistemic_role", ""),
+            "content": u.get("content", ""),
+            "source_anchor": u.get("source_anchor", ""),
+            "specifics": u.get("specifics", []),
+        })
+    return (
+        parsed.get("source_value_summary", ""),
+        out,
+        parsed.get("skip_reason", ""),
+    )
+
+
+# ---------------------------------------------------------------------------
+# HTML rendering (3-pane: source / old / new)
+# ---------------------------------------------------------------------------
+
+_HTML = r"""<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<title>OVP Prompt A/B — __RUN_ID__</title>
+<style>
+  :root {
+    --bg: #fafaf7; --panel: #fff; --border: #e0e0d8;
+    --old: #b7410e; --old-soft: #fdecea;
+    --new: #1f6f3f; --new-soft: #e7f7ec;
+    --src: #4a4a45; --neutral: #6b6b66;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; height: 100%; font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", "PingFang SC", "Microsoft YaHei", sans-serif; font-size: 13px; line-height: 1.5; color: #222; background: var(--bg); }
+  header {
+    position: sticky; top: 0; z-index: 10;
+    display: flex; align-items: center; gap: 12px;
+    padding: 8px 14px; background: var(--panel); border-bottom: 1px solid var(--border);
+  }
+  header h1 { font-size: 13px; font-weight: 600; margin: 0; flex-shrink: 0; }
+  header button { padding: 3px 10px; border: 1px solid var(--border); background: var(--panel); border-radius: 4px; cursor: pointer; font-size: 12px; }
+  header button:hover { background: #f3f3ed; }
+  header .meta { color: var(--neutral); font-size: 12px; }
+  header .progress { flex-grow: 1; }
+  .panes {
+    display: grid; grid-template-columns: 1.2fr 1fr 1fr; gap: 0;
+    height: calc(100vh - 45px);
+  }
+  .pane { overflow-y: auto; padding: 14px 18px; }
+  .pane.source { border-right: 1px solid var(--border); background: var(--panel); }
+  .pane.old    { border-right: 1px solid var(--border); background: var(--bg); }
+  .pane.new    { background: var(--bg); }
+  .pane h2 { margin: 0 0 12px 0; font-size: 13px; font-weight: 600; padding-bottom: 6px; border-bottom: 1px solid var(--border); }
+  .pane.old   h2 { color: var(--old); }
+  .pane.new   h2 { color: var(--new); }
+  .pane.source h2 { color: var(--src); }
+  .source-meta { font-size: 11px; color: var(--neutral); margin-bottom: 10px; }
+  .source-meta a { color: var(--old); text-decoration: none; }
+  .source-body {
+    background: #fcfcf8; border: 1px solid var(--border); border-radius: 4px;
+    padding: 10px 12px; white-space: pre-wrap; word-wrap: break-word;
+    font-size: 12px; max-height: calc(100vh - 200px); overflow-y: auto;
+  }
+  .summary-box {
+    margin-bottom: 12px; padding: 8px 12px;
+    background: var(--new-soft); border-left: 3px solid var(--new); border-radius: 3px;
+    font-size: 12px;
+  }
+  .summary-box.skip {
+    background: #fff3cf; border-left-color: #d4a017;
+  }
+  .unit {
+    margin: 0 0 10px 0; padding: 10px 12px;
+    background: var(--panel); border: 1px solid var(--border); border-radius: 4px;
+  }
+  .unit .ut-row {
+    display: flex; gap: 6px; margin-bottom: 6px; flex-wrap: wrap;
+    font-size: 11px; align-items: center;
+  }
+  .unit .badge {
+    padding: 1px 7px; border-radius: 9px; font-size: 10px;
+    background: var(--neutral); color: white;
+    text-transform: uppercase; letter-spacing: 0.04em;
+  }
+  .unit .badge.fact   { background: #5a7a9e; }
+  .unit .badge.method { background: #6f9143; }
+  .unit .badge.procedure { background: #6f9143; }
+  .unit .badge.learning  { background: #8a6a30; }
+  .unit .badge.tradeoff  { background: #b06f1c; }
+  .unit .badge.failure_mode { background: var(--old); }
+  .unit .badge.counterexample { background: var(--old); }
+  .unit .badge.case_detail { background: #4f6f8a; }
+  .unit .badge.decision { background: #7a4f8a; }
+  .unit .badge.concept { background: #999; }
+  .unit .badge.quote { background: #6b6b66; }
+  .unit .badge.epistemic { background: #b08055; }
+  .unit .title {
+    font-weight: 600; font-size: 13px; margin: 0 0 6px 0;
+  }
+  .unit .content {
+    font-size: 12px; color: #333;
+    white-space: pre-wrap; word-wrap: break-word;
+  }
+  .unit .anchor {
+    margin-top: 6px; padding: 4px 8px;
+    background: #fff7c2; border-left: 2px solid #d4a017;
+    font-size: 11px; font-style: italic; border-radius: 2px;
+  }
+  .unit .specifics {
+    margin-top: 4px; font-size: 11px; color: var(--neutral);
+  }
+  .unit .specifics .chip {
+    display: inline-block; padding: 0 6px; margin-right: 3px;
+    background: var(--old-soft); border-radius: 8px; color: var(--old);
+  }
+  .unit .extra {
+    margin-top: 6px; font-size: 11px; color: var(--neutral);
+  }
+  .empty { padding: 14px; color: var(--neutral); font-style: italic; text-align: center; }
+  .stats {
+    margin-bottom: 8px; padding: 6px 10px;
+    background: var(--panel); border-radius: 3px; font-size: 11px;
+    display: flex; gap: 14px; flex-wrap: wrap;
+  }
+  .stats strong { color: var(--src); }
+  .err {
+    padding: 10px; background: #fff3e0; border: 1px solid #d4a017;
+    border-radius: 3px; font-size: 11px; font-family: monospace;
+  }
+</style>
+</head>
+<body>
+<header>
+  <h1>OVP Prompt A/B</h1>
+  <span class="meta" id="run-id">__RUN_ID__</span>
+  <span class="progress meta" id="counter">0 / 0</span>
+  <button id="prev-btn">← Prev</button>
+  <button id="next-btn">Next →</button>
+  <span class="meta">←/→ to navigate</span>
+</header>
+<main class="panes">
+  <section class="pane source" id="src-pane"></section>
+  <section class="pane old" id="old-pane"></section>
+  <section class="pane new" id="new-pane"></section>
+</main>
+<script>
+const DATA = __DATA_JSON__;
+const RUN_ID = "__RUN_ID__";
+let idx = 0;
+
+function escapeHtml(s) {
+  return String(s == null ? "" : s)
+    .replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;")
+    .replace(/"/g,"&quot;").replace(/'/g,"&#39;");
+}
+
+function unitCard(u, side) {
+  const badges = [
+    u.unit_type ? `<span class="badge ${escapeHtml(u.unit_type)}">${escapeHtml(u.unit_type)}</span>` : "",
+    u.epistemic_role ? `<span class="badge epistemic">role: ${escapeHtml(u.epistemic_role)}</span>` : "",
+  ].filter(Boolean).join("");
+  const anchor = u.source_anchor
+    ? `<div class="anchor">⚓ <em>${escapeHtml(u.source_anchor)}</em></div>` : "";
+  const specifics = (u.specifics && u.specifics.length)
+    ? `<div class="specifics">specifics: ${u.specifics.map(s => `<span class="chip">${escapeHtml(s)}</span>`).join("")}</div>`
+    : "";
+  const extra = u.extra ? `<div class="extra">slug: <code>${escapeHtml(u.extra.concept_name||"")}</code> &middot; entity: ${escapeHtml(u.extra.entity_type||"")} &middot; related: ${(u.extra.related_concepts||[]).map(escapeHtml).join(", ") || "—"}</div>` : "";
+  return `
+    <div class="unit">
+      <div class="ut-row">${badges}</div>
+      <div class="title">${escapeHtml(u.title || "(no title)")}</div>
+      <div class="content">${escapeHtml(u.content || "")}</div>
+      ${anchor}
+      ${specifics}
+      ${extra}
+    </div>
+  `;
+}
+
+function render(i) {
+  const r = DATA[i];
+  document.getElementById("counter").textContent = `${i+1} / ${DATA.length}`;
+
+  // SOURCE pane
+  document.getElementById("src-pane").innerHTML = `
+    <h2>Source</h2>
+    <div class="source-meta">
+      <code>${escapeHtml(r.rel_path)}</code><br>
+      ${r.source_url ? `<a href="${escapeHtml(r.source_url)}" target="_blank">${escapeHtml(r.source_url)}</a><br>` : ""}
+      ${r.word_count} words &middot; ${r.body_chars} chars
+    </div>
+    <div class="source-body">${escapeHtml(r.body)}</div>
+  `;
+
+  // OLD pane
+  let oldHtml = `<h2>OLD prompt — ${r.old.units.length} units</h2>`;
+  oldHtml += `<div class="stats"><strong>${r.old.units.length}</strong> units extracted</div>`;
+  if (r.old.error) {
+    oldHtml += `<div class="err">${escapeHtml(JSON.stringify(r.old.error))}</div>`;
+  } else if (r.old.units.length === 0) {
+    oldHtml += `<div class="empty">(no units)</div>`;
+  } else {
+    oldHtml += r.old.units.map(u => unitCard(u, "old")).join("");
+  }
+  document.getElementById("old-pane").innerHTML = oldHtml;
+
+  // NEW pane
+  let newHtml = `<h2>NEW prompt — ${r.new.units.length} units</h2>`;
+  if (r.new.summary) {
+    newHtml += `<div class="summary-box">📋 <strong>summary:</strong> ${escapeHtml(r.new.summary)}</div>`;
+  }
+  if (r.new.skip_reason) {
+    newHtml += `<div class="summary-box skip">⏭ <strong>skip_reason:</strong> ${escapeHtml(r.new.skip_reason)}</div>`;
+  }
+  newHtml += `<div class="stats"><strong>${r.new.units.length}</strong> units extracted</div>`;
+  if (r.new.error) {
+    newHtml += `<div class="err">${escapeHtml(JSON.stringify(r.new.error))}</div>`;
+  } else if (r.new.units.length === 0 && !r.new.skip_reason) {
+    newHtml += `<div class="empty">(no units, no skip_reason — possibly LLM failed to follow schema)</div>`;
+  } else if (r.new.units.length === 0) {
+    newHtml += `<div class="empty">(model chose to skip — see reason above)</div>`;
+  } else {
+    newHtml += r.new.units.map(u => unitCard(u, "new")).join("");
+  }
+  document.getElementById("new-pane").innerHTML = newHtml;
+
+  // scroll all panes to top on switch
+  for (const id of ["src-pane","old-pane","new-pane"]) {
+    document.getElementById(id).scrollTop = 0;
+  }
+}
+
+document.getElementById("prev-btn").onclick = () => { if (idx>0) { idx--; render(idx); } };
+document.getElementById("next-btn").onclick = () => { if (idx<DATA.length-1) { idx++; render(idx); } };
+document.addEventListener("keydown", e => {
+  if (e.target.matches("textarea, input")) return;
+  if (e.key === "ArrowLeft" || e.key === "[") { if (idx>0) { idx--; render(idx); } }
+  else if (e.key === "ArrowRight" || e.key === "]") { if (idx<DATA.length-1) { idx++; render(idx); } }
+});
+render(idx);
+</script>
+</body>
+</html>
+"""
+
+
+def _safe_json_for_script(obj: object) -> str:
+    """JSON-encode ``obj`` and escape chars that would break a literal
+    embed inside a ``<script>`` tag (mirrors the helper in
+    ``fidelity_sample.py``).
+    """
+    encoded = json.dumps(obj, ensure_ascii=False)
+    return (
+        encoded
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("&", "\\u0026")
+        .replace(" ", "\\u2028")
+        .replace(" ", "\\u2029")
+    )
+
+
+def _render_html(rows: list[dict], *, run_id: str) -> str:
+    return (
+        _HTML
+        .replace("__RUN_ID__", run_id)
+        .replace("__DATA_JSON__", _safe_json_for_script(rows))
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="ovp-prompt-ab",
+        description=(
+            "Run old vs v2 absorb prompt against the same sources, "
+            "save raw JSON, render side-by-side HTML."
+        ),
+    )
+    parser.add_argument("--vault-dir", type=Path, default=None)
+    parser.add_argument(
+        "--source", action="append", type=Path, default=None,
+        help="Path to a source markdown (relative to vault or absolute). "
+             "Pass --source repeatedly. Required.",
+    )
+    parser.add_argument("--run-id", type=str, default=None)
+    parser.add_argument("--out-dir", type=Path, default=None)
+    args = parser.parse_args(argv)
+
+    vault_dir = resolve_vault_dir(args.vault_dir)
+    layout = VaultLayout.from_vault(vault_dir)
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out_dir = args.out_dir or (layout.logs_dir / "prompt-ab" / run_id)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    if not args.source:
+        print(
+            "error: at least one --source is required.\n"
+            "Suggestion: pick 6 covering short tweet / long tweet / "
+            "tech blog / opinion blog / paper / low-value article.",
+            file=sys.stderr,
+        )
+        return 2
+
+    # Resolve source paths
+    sources: list[SourceInput] = []
+    for raw in args.source:
+        p = raw if raw.is_absolute() else vault_dir / raw
+        if not p.exists():
+            print(f"warning: source not found, skipping: {p}", file=sys.stderr)
+            continue
+        s = _load_source(p, vault_dir)
+        if s:
+            sources.append(s)
+    if not sources:
+        print("error: no readable sources", file=sys.stderr)
+        return 2
+
+    # LLM client
+    client = get_litellm_client(vault_dir=vault_dir)
+    if client is None:
+        print("error: no LLM client available (no API key configured)", file=sys.stderr)
+        return 2
+    llm_call = client.call
+
+    print(f"running A/B on {len(sources)} sources …", file=sys.stderr)
+
+    rows: list[dict] = []
+    for s in sources:
+        print(f"  {s.rel_path} ({s.word_count} words) …", file=sys.stderr)
+        # OLD
+        old_raw, old_parsed = _call(llm_call, OLD_PROMPT, s.body)
+        if isinstance(old_parsed, dict) and "error" in old_parsed:
+            old_units = []
+            old_err = old_parsed
+        else:
+            old_units = _normalize_old(old_parsed)
+            old_err = None
+        # NEW
+        new_raw, new_parsed = _call(llm_call, NEW_PROMPT, s.body)
+        if isinstance(new_parsed, dict) and "error" in new_parsed:
+            new_summary, new_units, new_skip = "", [], ""
+            new_err = new_parsed
+        else:
+            new_summary, new_units, new_skip = _normalize_new(new_parsed)
+            new_err = None
+
+        # Save raw — suffix with a short hash of the absolute path so
+        # two ``--source`` files that share a basename (e.g. two
+        # different ``README.md``) don't clobber each other's outputs.
+        path_hash = hashlib.sha1(
+            str(s.path.resolve()).encode("utf-8")
+        ).hexdigest()[:8]
+        stem = f"{s.path.stem.replace('/', '_')}_{path_hash}"
+        (out_dir / f"{stem}.old.json").write_text(
+            json.dumps({"raw": old_raw, "parsed": old_parsed}, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        (out_dir / f"{stem}.new.json").write_text(
+            json.dumps({"raw": new_raw, "parsed": new_parsed}, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+        # Truncate body for embedding in HTML so the page doesn't balloon
+        body_for_ui = s.body if len(s.body) <= 12000 else s.body[:12000] + "\n\n[… truncated …]"
+        rows.append({
+            "rel_path": s.rel_path,
+            "source_url": _extract_source_url(s.path),
+            "word_count": s.word_count,
+            "body_chars": len(s.body),
+            "body": body_for_ui,
+            "old": {"units": old_units, "error": old_err},
+            "new": {"summary": new_summary, "units": new_units, "skip_reason": new_skip, "error": new_err},
+        })
+        print(f"      old: {len(old_units)} units{' [ERROR]' if old_err else ''}", file=sys.stderr)
+        print(f"      new: {len(new_units)} units{' [SKIP: '+new_skip[:60]+']' if new_skip else ''}{' [ERROR]' if new_err else ''}", file=sys.stderr)
+
+    # Manifest
+    manifest = {
+        "run_id": run_id,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "vault_dir": str(vault_dir),
+        "source_count": len(sources),
+        "sources": [
+            {
+                "rel_path": s.rel_path,
+                "word_count": s.word_count,
+                "old_unit_count": len(rows[i]["old"]["units"]),
+                "new_unit_count": len(rows[i]["new"]["units"]),
+                "new_skip_reason": rows[i]["new"]["skip_reason"],
+            }
+            for i, s in enumerate(sources)
+        ],
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8",
+    )
+
+    # HTML
+    html = _render_html(rows, run_id=run_id)
+    out_html = out_dir / "checklist.html"
+    out_html.write_text(html, encoding="utf-8")
+
+    # Summary
+    print("\n--- summary ---", file=sys.stderr)
+    print(f"  sources:        {len(sources)}", file=sys.stderr)
+    total_old = sum(len(r["old"]["units"]) for r in rows)
+    total_new = sum(len(r["new"]["units"]) for r in rows)
+    print(f"  old units:      {total_old}  (avg {total_old/len(sources):.1f}/source)", file=sys.stderr)
+    print(f"  new units:      {total_new}  (avg {total_new/len(sources):.1f}/source)", file=sys.stderr)
+    skip_count = sum(1 for r in rows if r["new"]["skip_reason"])
+    print(f"  new skipped:    {skip_count}/{len(sources)}", file=sys.stderr)
+    print(f"\n  HTML:     {out_html}", file=sys.stderr)
+    print(f"  Manifest: {out_dir / 'manifest.json'}", file=sys.stderr)
+    return 0
+
+
+def _extract_source_url(path: Path) -> str:
+    """Pull source_url / source from the file's frontmatter, if any."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return ""
+    if not text.startswith("---"):
+        return ""
+    try:
+        end = text.index("---", 3)
+    except ValueError:
+        return ""
+    fm_text = text[3:end]
+    for line in fm_text.splitlines():
+        m = re.match(r"^\s*(?:source|source_url|url)\s*:\s*\"?([^\"]+)\"?\s*$", line)
+        if m and m.group(1).startswith(("http://", "https://")):
+            return m.group(1).strip()
+    return ""
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ovp_pipeline/runtime.py
+++ b/src/ovp_pipeline/runtime.py
@@ -88,6 +88,31 @@ def split_markdown_frontmatter(text: str) -> tuple[dict[str, object], str]:
     return parsed, body
 
 
+def safe_json_for_script(obj: object) -> str:
+    """JSON-encode ``obj`` and escape characters that would break a
+    literal embed inside an HTML ``<script>`` tag.
+
+    A naive ``json.dumps(...)`` injected into ``<script>__DATA__</script>``
+    is hijack-prone: a payload string containing the literal sequence
+    ``</script>`` closes the surrounding tag.  The OWASP-blessed fix is
+    to escape ``<`` / ``>`` / ``&`` plus the JSON-legal-but-JS-line-
+    terminator characters U+2028 and U+2029 to ``\\uXXXX`` — the result
+    remains valid JSON AND is safe inside ``<script>…</script>``.
+
+    Used by the HTML-rendering review CLIs (``ovp-fidelity-sample``,
+    ``ovp-prompt-ab``).  Centralised here so a future fix reaches both.
+    """
+    encoded = json.dumps(obj, ensure_ascii=False)
+    return (
+        encoded
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("&", "\\u0026")
+        .replace(" ", "\\u2028")
+        .replace(" ", "\\u2029")
+    )
+
+
 def utc_now() -> datetime:
     """Return the current UTC datetime."""
     return datetime.now(timezone.utc)


### PR DESCRIPTION
## Summary

Adds the measurement tooling that the 2026-05-05 BL-058 first-principles audit calls for. The "absorb produces slop?" hypothesis needs human-evaluable artefacts before any architectural change — these CLIs provide that surface.

- **`ovp-fidelity-sample`**: stratified evergreen sampling + locally-available raw source pairing + Jaccard-ribbon highlighting + per-claim rubric, all in a single self-contained HTML page with LocalStorage rubric persistence and JSON Export/Import.
- **`ovp-prompt-ab`**: runs old + v2 absorb prompts against the same sources, renders 3-pane HTML (source | old units | new units) for side-by-side review.
- **`docs/plans/2026-05-05-workflow-review.md`**: 13-step pipeline first-principles audit (BASE + refine). Each step gets SOLVES / INTRODUCES / SKIP TEST / VERDICT.

## Codex pre-merge fixes (folded in)

| # | Severity | Where | Fix |
|---|---|---|---|
| 1 | P2 | both CLIs | XSS — `<script>` JSON injection now routed through `_safe_json_for_script` (escapes `<`/`>`/`&`/U+2028/U+2029) |
| 2 | P2 | `pyproject.toml` | `ovp-fidelity-sample` + `ovp-prompt-ab` registered under `[project.scripts]` |
| 3 | P2 | `fidelity_sample.py:_tokenize` | jieba is now optional with per-char CJK fallback (mirrors `_truth_helpers.py`) |
| 4 | P2 | `prompt_ab.py:_load_source` | absolute `--source` outside vault no longer crashes on `Path.relative_to` — uses `_safe_relpath` |
| 5 | P3 | `prompt_ab.py:main` | `<stem>.old.json` / `<stem>.new.json` stem suffixed with SHA-1 of abs path so two `README.md`s don't clobber each other |

## Test plan

- [x] `ruff check` clean on both CLIs
- [x] Both `--help` render
- [x] Smoke test: `_safe_json_for_script({'body': '<script>alert(1)</script>', 'sep': 'a b'})` — no raw `</` or U+2028 in output; helpers in both modules return identical output
- [ ] Full suite (running pre-merge to confirm nothing else broke)

## Out of scope

- End-to-end test invoking real LLM (would make the suite non-hermetic)
- Auto-discovery of source raws when only the evergreen is on disk — separate enhancement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `fidelity-sample` command for interactive claim evidence review, rating, and HTML checklist export
  * Added `prompt-ab` command for A/B testing extraction prompts with side-by-side visual comparison

* **Documentation**
  * Updated workflow audit plan documenting pipeline redesign targets, step-by-step verdicts, and task scheduling strategy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->