### PR TITLE
feat(reader): type-facet chip rail on /ops/objects

### DIFF
--- a/src/ovp_pipeline/commands/_ui_renderers.py
+++ b/src/ovp_pipeline/commands/_ui_renderers.py
@@ -2097,14 +2097,124 @@ def _render_library_home(payload: dict) -> str:
     return _layout("Knowledge Library", body, requested_pack=requested_pack)
 
 
+_TYPE_FACET_STYLE = """
+<style>
+.type-facet { display: flex; flex-wrap: wrap; gap: 6px; margin: 12px 0 16px 0; padding: 12px; background: #fafaf6; border: 1px solid #e7e1d8; border-radius: 6px; }
+.type-facet h3 { width: 100%; margin: 0 0 4px 0; font-size: 0.85rem; font-weight: 500; color: #71675d; }
+.type-facet a.chip {
+  display: inline-block; padding: 4px 10px; font-size: 0.85rem;
+  border: 1px solid #d6cfc4; border-radius: 14px; background: #fff;
+  color: #1f1a17; text-decoration: none;
+}
+.type-facet a.chip:hover { background: #f4dfd2; border-color: #9f4f24; }
+.type-facet a.chip.active { background: #9f4f24; color: #fff; border-color: #9f4f24; font-weight: 500; }
+.type-facet a.chip .count { color: #71675d; font-size: 0.78rem; margin-left: 4px; }
+.type-facet a.chip.active .count { color: #f4dfd2; }
+</style>
+"""
+
+
+def _render_type_facet(
+    kind_stats: list[dict],
+    *,
+    active_kind: str,
+    query: str,
+    requested_pack: str,
+    base_path: str = "/ops/objects",
+    top_n: int = 12,
+) -> str:
+    """Render the type-facet chip rail for ``/ops/objects`` and
+    similar Reader-side surfaces.
+
+    ``kind_stats`` is the ``list_object_kind_stats`` shape:
+    ``[{"object_kind": str, "count": int, ...}, ...]``.  Top-N
+    types by count are shown as clickable chips; an "All" chip
+    clears the filter.  The active kind is highlighted.
+    """
+    if not kind_stats:
+        return ""
+    from ..object_kinds import display_label
+    sorted_stats = sorted(
+        (s for s in kind_stats if s.get("object_kind")),
+        key=lambda s: -int(s.get("count") or 0),
+    )[:top_n]
+    if not sorted_stats:
+        return ""
+
+    def _href(kind: str) -> str:
+        params: list[str] = []
+        if query:
+            params.append(f"q={quote(query, safe='')}")
+        if kind:
+            params.append(f"kind={quote(kind, safe='')}")
+        if requested_pack:
+            params.append(f"pack={quote(requested_pack, safe='')}")
+        qs = ("?" + "&".join(params)) if params else ""
+        return f"{base_path}{qs}"
+
+    chips: list[str] = []
+    chips.append(
+        f"<a href='{escape(_href(''))}'"
+        + (" class='chip active'" if not active_kind else " class='chip'")
+        + ">All</a>"
+    )
+    for stat in sorted_stats:
+        kind = str(stat["object_kind"])
+        count = int(stat.get("count") or 0)
+        label = display_label(kind)
+        cls = "chip active" if kind == active_kind else "chip"
+        chips.append(
+            f"<a href='{escape(_href(kind))}' class='{cls}'>"
+            f"{escape(label)}<span class='count'>{count}</span>"
+            "</a>"
+        )
+    return (
+        f"{_TYPE_FACET_STYLE}"
+        "<div class='type-facet'>"
+        "<h3>Filter by type</h3>"
+        + "".join(chips)
+        + "</div>"
+    )
+
+
 def _render_objects_index(payload: dict) -> str:
     query = payload.get("query", "")
+    active_kind = str(payload.get("object_kind") or "")
     requested_pack = payload.get("requested_pack", "")
+    kind_stats = payload.get("kind_stats") or []
     items = "".join(
         f'<li><a href="{escape(_object_href(item["object_id"], item.get("object_path", "")))}">{escape(item["title"])}</a> '
         f'<span class="muted">({escape(item["object_id"])})</span></li>'
         for item in payload["items"]
     )
+
+    facet_html = _render_type_facet(
+        kind_stats,
+        active_kind=active_kind,
+        query=query,
+        requested_pack=requested_pack,
+        base_path="/ops/objects",
+    )
+
+    # Active filter banner — gives the reader a clear "you're seeing
+    # only X" signal + a one-click escape hatch.
+    filter_banner = ""
+    if active_kind:
+        from ..object_kinds import display_label
+        clear_href = "/ops/objects"
+        params: list[str] = []
+        if query:
+            params.append(f"q={quote(query, safe='')}")
+        if requested_pack:
+            params.append(f"pack={quote(requested_pack, safe='')}")
+        if params:
+            clear_href = f"{clear_href}?{'&'.join(params)}"
+        filter_banner = (
+            f"<p class='muted'>Filtered to type "
+            f"<strong>{escape(display_label(active_kind))}</strong>"
+            f" · <a href='{escape(clear_href)}'>clear filter</a></p>"
+        )
+
     return _layout(
         "Objects",
         (
@@ -2115,9 +2225,16 @@ def _render_objects_index(payload: dict) -> str:
                 if requested_pack
                 else ""
             )
+            + (
+                f"<input type='hidden' name='kind' value='{escape(active_kind)}' />"
+                if active_kind
+                else ""
+            )
             + f"<input type='text' name='q' value='{escape(query)}' placeholder='Search objects' /> "
             + "<button type='submit'>Search</button>"
             + "</form>"
+            + facet_html
+            + filter_banner
             + f"<p class='muted'>{payload['count']} objects in current page."
             + (f" Pack scope: {escape(requested_pack)}." if requested_pack else "")
             + "</p>"

--- a/src/ovp_pipeline/commands/_ui_renderers.py
+++ b/src/ovp_pipeline/commands/_ui_renderers.py
@@ -2113,6 +2113,34 @@ _TYPE_FACET_STYLE = """
 </style>
 """
 
+# Default chip-rail size for the type facet.  12 covers the common
+# CORE_OBJECT_KINDS set with one or two long-tail entries; the long
+# tail of rare kinds stays accessible via the search box / API.
+_TYPE_FACET_DEFAULT_LIMIT = 12
+
+
+def _build_objects_query_string(
+    *,
+    query: str = "",
+    object_kind: str = "",
+    requested_pack: str = "",
+) -> str:
+    """Shared query-string builder for ``/ops/objects`` URLs.
+
+    Centralises the q + kind + pack ordering so the type-facet chip
+    rail and the active-filter clear-link can't drift apart on URL
+    shape (e.g. param order, encoding) — both call sites used to
+    duplicate this logic with subtly different rules.
+    """
+    params: list[str] = []
+    if query:
+        params.append(f"q={quote(query, safe='')}")
+    if object_kind:
+        params.append(f"kind={quote(object_kind, safe='')}")
+    if requested_pack:
+        params.append(f"pack={quote(requested_pack, safe='')}")
+    return ("?" + "&".join(params)) if params else ""
+
 
 def _render_type_facet(
     kind_stats: list[dict],
@@ -2121,7 +2149,7 @@ def _render_type_facet(
     query: str,
     requested_pack: str,
     base_path: str = "/ops/objects",
-    top_n: int = 12,
+    top_n: int = _TYPE_FACET_DEFAULT_LIMIT,
 ) -> str:
     """Render the type-facet chip rail for ``/ops/objects`` and
     similar Reader-side surfaces.
@@ -2130,27 +2158,34 @@ def _render_type_facet(
     ``[{"object_kind": str, "count": int, ...}, ...]``.  Top-N
     types by count are shown as clickable chips; an "All" chip
     clears the filter.  The active kind is highlighted.
+
+    If ``active_kind`` is set but its row sits outside the top-N
+    slice, we splice it in so the operator can still see (and
+    click off) the active filter — otherwise the chip rail would
+    look as if no filter were applied.
     """
     if not kind_stats:
         return ""
     from ..object_kinds import display_label
-    sorted_stats = sorted(
+    ranked = sorted(
         (s for s in kind_stats if s.get("object_kind")),
         key=lambda s: -int(s.get("count") or 0),
-    )[:top_n]
+    )
+    sorted_stats = ranked[:top_n]
+    if active_kind and not any(
+        str(s.get("object_kind")) == active_kind for s in sorted_stats
+    ):
+        active_row = next(
+            (s for s in ranked if str(s.get("object_kind")) == active_kind),
+            None,
+        )
+        if active_row is not None:
+            sorted_stats = [*sorted_stats, active_row]
     if not sorted_stats:
         return ""
 
     def _href(kind: str) -> str:
-        params: list[str] = []
-        if query:
-            params.append(f"q={quote(query, safe='')}")
-        if kind:
-            params.append(f"kind={quote(kind, safe='')}")
-        if requested_pack:
-            params.append(f"pack={quote(requested_pack, safe='')}")
-        qs = ("?" + "&".join(params)) if params else ""
-        return f"{base_path}{qs}"
+        return f"{base_path}{_build_objects_query_string(query=query, object_kind=kind, requested_pack=requested_pack)}"
 
     chips: list[str] = []
     chips.append(
@@ -2197,18 +2232,15 @@ def _render_objects_index(payload: dict) -> str:
     )
 
     # Active filter banner — gives the reader a clear "you're seeing
-    # only X" signal + a one-click escape hatch.
+    # only X" signal + a one-click escape hatch.  Reuses the shared
+    # query-string builder so the clear-link can't drift from the
+    # chip-rail URLs.
     filter_banner = ""
     if active_kind:
         from ..object_kinds import display_label
-        clear_href = "/ops/objects"
-        params: list[str] = []
-        if query:
-            params.append(f"q={quote(query, safe='')}")
-        if requested_pack:
-            params.append(f"pack={quote(requested_pack, safe='')}")
-        if params:
-            clear_href = f"{clear_href}?{'&'.join(params)}"
+        clear_href = "/ops/objects" + _build_objects_query_string(
+            query=query, requested_pack=requested_pack
+        )
         filter_banner = (
             f"<p class='muted'>Filtered to type "
             f"<strong>{escape(display_label(active_kind))}</strong>"

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -389,12 +389,19 @@ def create_server(
                     limit = int(query.get("limit", ["100"])[0])
                     offset = int(query.get("offset", ["0"])[0])
                     q = query.get("q", [""])[0]
+                    # BL-030 follow-up: ``kind`` (alias of
+                    # ``object_kind``) lets the reader filter the
+                    # index to a single entity_type — fact / method /
+                    # tradeoff / etc.  The facet chip rail in the
+                    # rendered page builds these query strings.
+                    kind = query.get("kind", [""])[0] or None
                     pack_name = query.get("pack", [""])[0] or None
                     payload = build_objects_index_payload(
                         resolved_vault,
                         limit=limit,
                         offset=offset,
                         query=q,
+                        object_kind=kind,
                         pack_name=pack_name,
                     )
                     self._write_html(_render_objects_index(payload))

--- a/src/ovp_pipeline/packs/research_tech/truth_projection.py
+++ b/src/ovp_pipeline/packs/research_tech/truth_projection.py
@@ -372,12 +372,23 @@ def build_truth_projection(
     claim_evidence: list[ClaimEvidenceRow] = []
     compiled_summaries: list[CompiledSummaryRow] = []
 
-    from ...object_kinds import CORE_OBJECT_KINDS, normalize_kind
+    from ...object_kinds import (
+        CORE_OBJECT_KINDS,
+        V2_UNIT_TYPES,
+        normalize_kind,
+    )
 
     from ...object_kinds import KIND_CONCEPT
 
+    # BL-025/026 follow-up: accept v2 unit kinds in addition to
+    # core entity-side kinds so the truth_store ``objects.object_kind``
+    # column carries the rich post-backfill values (fact / tradeoff /
+    # learning / ...) instead of clamping back to ``concept``.  This
+    # is what surfaces them in the Reader-side type facet.
+    _accepted_kinds = CORE_OBJECT_KINDS | V2_UNIT_TYPES
+
     for slug, title, note_type, path, _day_id, _frontmatter_json, body in page_rows:
-        resolved_kind = note_type if note_type in CORE_OBJECT_KINDS else KIND_CONCEPT
+        resolved_kind = note_type if note_type in _accepted_kinds else KIND_CONCEPT
         # BL-054: pull source_url from frontmatter so credibility +
         # diversity signals can key off it.  Empty when the evergreen
         # has not been backfilled — the diversity helper treats that
@@ -390,7 +401,7 @@ def build_truth_projection(
                     et = fm.get("entity_type", "")
                     if isinstance(et, str) and et:
                         normalized = normalize_kind(et)
-                        if normalized in CORE_OBJECT_KINDS:
+                        if normalized in _accepted_kinds:
                             resolved_kind = normalized
                     su = fm.get("source_url", "")
                     if isinstance(su, str):


### PR DESCRIPTION
## Summary

Surfaces the BL-025/026 + BL-030 work to the user. Pre-this-PR the rich entity_type taxonomy lived only in frontmatter and SQL; nothing in the UI exposed it.

Three changes work together:

1. **`truth_projection.py`** accepts v2 unit kinds — pre-fix `resolved_kind` clamped to `CORE_OBJECT_KINDS` only, silently re-collapsing the BL-030 backfill values back to `concept` on the next `ovp-knowledge-index` rebuild. Now accepts `CORE_OBJECT_KINDS | V2_UNIT_TYPES`.

2. **`_render_objects_index`** renders a type-facet chip rail from `payload.kind_stats`. Top-12 types by count, each chip clickable with `?kind=<type>`. Active type highlighted; "All" chip clears.

3. **`/ops/objects?kind=<type>`** — the HTML route forwards `kind` into `build_objects_index_payload(object_kind=...)`. Pre-fix only `/api/objects` accepted it.

## Live shape after BL-030 + this PR

| entity_type | Count | What it is |
|---|---|---|
| concept | 6814 | v1 evergreens (LLM reclassify pending) |
| **fact** | 1414 | objective fact + anchor |
| method | 699 | named technique |
| procedure | 83 | numbered steps |
| **tradeoff** | 76 | choice + cost |
| **failure_mode** | 76 | how it breaks |
| tool | 71 | software tool/lib |
| **case_detail** | 65 | who/where/what/outcome |
| **learning** | 36 | insight + evidence |
| company | 29 | organization |
| **quote** | 23 | verbatim quote |
| counterexample | 21 | contradicts a claim |

Click "Tradeoff" → see 76 tradeoff-evergreens with proper Chinese/English titles, click through to full notes.

## Try it

```bash
OVP_VAULT_DIR=~/Documents/ovp-vault ovp-ui --port 8787
open http://127.0.0.1:8787/ops/objects
# Click any chip — "Fact", "Tradeoff", "Failure mode" — to filter
```

## Out of scope (follow-ups)

- Reader-side mirror at `/objects?kind=` — same UX, Reader shell instead of `/ops/`
- Multi-select chips for type × tag cross-filtering
- `/search?type=` integration with FTS5

## Test plan

- [x] Live `ovp-knowledge-index` rebuild populates the new kinds in `objects.object_kind`
- [x] `curl /ops/objects?kind=tradeoff` returns 76 entries with active "Tradeoff" chip + clear filter link
- [x] `ruff check` clean on changed files (no new errors)
- [x] Full suite **2239 / 2239**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added type-based filtering interface with visual chip controls on the objects page
  * Added active filter indicator banner with one-click clear functionality
  * Extended object type support for improved filtering coverage
  * Filter selections now persist in URLs for easy bookmarking and sharing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->