### PR TITLE
perf(ops): drop dead tokenisation, memoise vault paths, batch deep-dive index

### DIFF
--- a/src/ovp_pipeline/_truth_helpers.py
+++ b/src/ovp_pipeline/_truth_helpers.py
@@ -328,6 +328,9 @@ def _rewrite_jsonl(path: Path, payloads: list[dict[str, Any]]) -> None:
             handle.write(json.dumps(payload, ensure_ascii=False) + "\n")
 
 
+_VAULT_DIR_NONE_SENTINEL = ""  # ``""`` means "fall back to env vars".
+
+
 @functools.lru_cache(maxsize=64)
 def _resolved_vault_dir_cached(vault_dir_str: str) -> Path:
     """Memoise ``resolve_vault_dir(...).resolve()`` per vault dir.
@@ -337,19 +340,31 @@ def _resolved_vault_dir_cached(vault_dir_str: str) -> Path:
     vault root, hitting ``realpath`` syscalls on every iteration.
     Caching by the ``str`` form of the vault path is enough — any
     given UI request runs against a single vault.
+
+    The empty string is a sentinel for ``None``; passing it in lets
+    ``resolve_vault_dir`` apply its ``OVP_VAULT_DIR`` / ``VAULT_DIR``
+    env-var fallback.  Pre-fix we naïvely ``str()``-coerced every
+    arg, which turned ``None`` into the literal path ``"None"`` and
+    silently broke that fallback.
     """
-    return resolve_vault_dir(vault_dir_str).resolve()
+    arg: Path | str | None = vault_dir_str or None
+    return resolve_vault_dir(arg).resolve()
 
 
 @functools.lru_cache(maxsize=8192)
-def _vault_relative_path_cached(vault_dir_str: str, path: str) -> str:
+def _vault_relative_path_cached(resolved_vault_str: str, path: str) -> str:
     """Memoised core: ``_vault_relative_path`` defers here once
     inputs have been coerced to ``str``.  Call frequency on the
     slow Ops pages is dominated by a small set of repeated paths
     (the same evergreen referenced by N events), so a 8 K-entry
     cache covers a full request without filling RAM.
+
+    ``resolved_vault_str`` is the *already-resolved* vault path —
+    the wrapper uses ``_resolved_vault_dir_cached`` to handle env-
+    var fallback before we get here, so this layer never has to
+    interpret ``None``.
     """
-    resolved = _resolved_vault_dir_cached(vault_dir_str)
+    resolved = Path(resolved_vault_str)
     candidate = Path(path)
     if not candidate.is_absolute():
         return path
@@ -359,8 +374,14 @@ def _vault_relative_path_cached(vault_dir_str: str, path: str) -> str:
         return path
 
 
-def _vault_relative_path(vault_dir: Path | str, path: str) -> str:
-    return _vault_relative_path_cached(str(vault_dir), str(path))
+def _vault_relative_path(vault_dir: Path | str | None, path: str) -> str:
+    # Resolve ``None`` via the env-var fallback before stringifying,
+    # otherwise ``str(None) == "None"`` would slip into the cache key
+    # and the lookup would silently treat ``"None"`` as a relative
+    # vault path.
+    cache_key = str(vault_dir) if vault_dir is not None else _VAULT_DIR_NONE_SENTINEL
+    resolved = _resolved_vault_dir_cached(cache_key)
+    return _vault_relative_path_cached(str(resolved), str(path))
 
 
 def _read_note_text(vault_dir: Path | str, relative_path: str) -> str:

--- a/src/ovp_pipeline/_truth_helpers.py
+++ b/src/ovp_pipeline/_truth_helpers.py
@@ -9,6 +9,7 @@ runtime / pack-resolution layers.
 from __future__ import annotations
 
 from datetime import datetime, timezone
+import functools
 import json
 import logging
 import re
@@ -327,8 +328,28 @@ def _rewrite_jsonl(path: Path, payloads: list[dict[str, Any]]) -> None:
             handle.write(json.dumps(payload, ensure_ascii=False) + "\n")
 
 
-def _vault_relative_path(vault_dir: Path | str, path: str) -> str:
-    resolved = resolve_vault_dir(vault_dir).resolve()
+@functools.lru_cache(maxsize=64)
+def _resolved_vault_dir_cached(vault_dir_str: str) -> Path:
+    """Memoise ``resolve_vault_dir(...).resolve()`` per vault dir.
+
+    Pre-fix every ``_vault_relative_path`` call (~14 K per
+    ``/ops/signals`` request) re-ran ``resolve()`` on the same
+    vault root, hitting ``realpath`` syscalls on every iteration.
+    Caching by the ``str`` form of the vault path is enough — any
+    given UI request runs against a single vault.
+    """
+    return resolve_vault_dir(vault_dir_str).resolve()
+
+
+@functools.lru_cache(maxsize=8192)
+def _vault_relative_path_cached(vault_dir_str: str, path: str) -> str:
+    """Memoised core: ``_vault_relative_path`` defers here once
+    inputs have been coerced to ``str``.  Call frequency on the
+    slow Ops pages is dominated by a small set of repeated paths
+    (the same evergreen referenced by N events), so a 8 K-entry
+    cache covers a full request without filling RAM.
+    """
+    resolved = _resolved_vault_dir_cached(vault_dir_str)
     candidate = Path(path)
     if not candidate.is_absolute():
         return path
@@ -336,6 +357,10 @@ def _vault_relative_path(vault_dir: Path | str, path: str) -> str:
         return str(candidate.resolve().relative_to(resolved))
     except ValueError:
         return path
+
+
+def _vault_relative_path(vault_dir: Path | str, path: str) -> str:
+    return _vault_relative_path_cached(str(vault_dir), str(path))
 
 
 def _read_note_text(vault_dir: Path | str, relative_path: str) -> str:

--- a/src/ovp_pipeline/concept_registry.py
+++ b/src/ovp_pipeline/concept_registry.py
@@ -407,7 +407,13 @@ class ConceptRegistry:
 
         self._rebuild_alias_index()
         self._build_surface_index()
-        self._precompute_tokens()  # Pre-compute tokens for faster search
+        # ``_precompute_tokens`` was dead weight — it tokenised every
+        # entry's title/slug/definition/aliases via jieba and cached
+        # them in ``self._token_cache``, but nothing else in the
+        # codebase ever read that cache.  On a 6 K-entry registry the
+        # precompute took ~7 seconds and dominated ``/ops/candidates``.
+        # Removed (BL-030 follow-up).  If a future similarity-search
+        # path needs tokens it can call ``_get_cached_tokens`` lazily.
         return self
 
     def save(self) -> None:

--- a/src/ovp_pipeline/truth_api.py
+++ b/src/ovp_pipeline/truth_api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 from collections import Counter
+import functools
 import hashlib
 import json
 import os
@@ -4713,10 +4714,29 @@ def _deep_dive_object_map(vault_dir: Path | str) -> dict[str, list[dict[str, str
     return result
 
 
-def _promoted_deep_dives_for_object(vault_dir: Path | str, object_id: str) -> list[dict[str, str]]:
-    db_path = _db_path(vault_dir)
-    resolved_vault = resolve_vault_dir(vault_dir)
-    with sqlite3.connect(db_path) as conn:
+@functools.lru_cache(maxsize=4)
+def _promoted_deep_dive_index_cached(
+    db_path_str: str, vault_dir_str: str, db_mtime_ns: int,
+) -> tuple[
+    tuple[tuple[str, str, str], ...],  # deep dive rows: (slug, title, relative_path)
+    dict[str, frozenset[str]],          # target_slug → frozenset of source_names
+]:
+    """Heavy half of ``_promoted_deep_dives_for_object`` cached per
+    ``knowledge.db`` mtime.
+
+    The events-page renderer calls the per-object helper N times
+    (one per event in the dossier), and previously each call
+    re-ran the same two SQL queries + JSON-parsed every
+    ``evergreen_auto_promoted`` payload (~10 K rows on the live
+    vault).  With the cache, the parse runs once per
+    ``ovp-knowledge-index`` rebuild — `mtime_ns` invalidates
+    the cache when the DB changes.
+
+    ``maxsize=4`` is plenty: usually a single vault per process,
+    occasionally two during pack swaps.
+    """
+    resolved_vault = resolve_vault_dir(vault_dir_str)
+    with sqlite3.connect(db_path_str) as conn:
         deep_dive_rows = conn.execute(
             """
             SELECT slug, title, note_type, path
@@ -4733,7 +4753,9 @@ def _promoted_deep_dives_for_object(vault_dir: Path | str, object_id: str) -> li
             """
         ).fetchall()
 
-    promoted_source_names: set[str] = set()
+    # Build the target_slug → source_names index in one pass so each
+    # per-object lookup is O(1) instead of re-scanning the audit log.
+    by_target: dict[str, set[str]] = {}
     for (payload_json,) in audit_rows:
         try:
             payload = json.loads(payload_json)
@@ -4743,13 +4765,32 @@ def _promoted_deep_dives_for_object(vault_dir: Path | str, object_id: str) -> li
             payload.get("mutation", {}).get("target_slug") or payload.get("concept") or ""
         ).strip()
         source_name = str(payload.get("source") or "").strip()
-        if target_slug == object_id and source_name:
-            promoted_source_names.add(source_name)
+        if target_slug and source_name:
+            by_target.setdefault(target_slug, set()).add(source_name)
 
+    deep_dive_normalised = tuple(
+        (str(slug), str(title), _vault_relative_path(resolved_vault, path))
+        for slug, title, _note_type, path in deep_dive_rows
+    )
+    by_target_frozen = {k: frozenset(v) for k, v in by_target.items()}
+    return deep_dive_normalised, by_target_frozen
+
+
+def _promoted_deep_dives_for_object(vault_dir: Path | str, object_id: str) -> list[dict[str, str]]:
+    db_path = _db_path(vault_dir)
+    try:
+        db_mtime_ns = db_path.stat().st_mtime_ns
+    except OSError:
+        db_mtime_ns = 0
+    deep_dive_rows, by_target = _promoted_deep_dive_index_cached(
+        str(db_path), str(vault_dir), db_mtime_ns,
+    )
+    promoted_source_names = by_target.get(object_id) or frozenset()
+    if not promoted_source_names:
+        return []
     items: list[dict[str, str]] = []
     seen_slugs: set[str] = set()
-    for slug, title, _note_type, path in deep_dive_rows:
-        relative_path = _vault_relative_path(resolved_vault, path)
+    for slug, title, relative_path in deep_dive_rows:
         if Path(relative_path).name not in promoted_source_names:
             continue
         if slug in seen_slugs:
@@ -4757,8 +4798,8 @@ def _promoted_deep_dives_for_object(vault_dir: Path | str, object_id: str) -> li
         seen_slugs.add(slug)
         items.append(
             {
-                "slug": str(slug),
-                "title": str(title),
+                "slug": slug,
+                "title": title,
                 "note_type": "deep_dive",
                 "path": relative_path,
             }


### PR DESCRIPTION
## Summary

Three slow Ops pages were taking 3-5s per render on the live 9K-evergreen vault. All came back to redundant work being re-done per request.

## Results (warm-cache p50 over 2 runs)

| Page | Before | After | Δ |
|---|---|---|---|
| `/ops/candidates` | 5.5s | **2.1s** | −62% |
| `/ops/events` | 3.3s | **1.0s** | −69% |
| `/ops/signals` | 2.9s | **1.5s** | −48% |
| `/ops/clusters` | 2.4s | **1.6s** | −33% |
| `/ops/objects` | 0.4s | **0.05s** | −88% |

## Fixes

### 1. `ConceptRegistry._precompute_tokens` was dead weight
`load()` ran jieba CJK tokenisation on every entry's title/slug/definition/aliases and cached results in `_token_cache`. `grep -rn _token_cache _get_cached_tokens` turned up zero readers. On 6K entries that ate ~7s per load. Removed the call from `load()`; helpers stay for future lazy use.

### 2. Memoise `_vault_relative_path`
Called ~14K times per `/ops/signals` render with 80%+ redundant inputs. Split into `_resolved_vault_dir_cached` (per-vault) + `_vault_relative_path_cached` (per (vault, path) tuple, maxsize=8192).

### 3. Cache the audit-events parse for events
`_promoted_deep_dives_for_object` re-parsed all ~10K `evergreen_auto_promoted` payloads × 25 calls per page = 250K JSON parses. New `_promoted_deep_dive_index_cached` builds a `target_slug → source_names` index ONCE per `knowledge.db` rebuild, keyed on the file mtime so an `ovp-knowledge-index` rebuild invalidates naturally. Per-object lookup becomes O(1).

## Cache invalidation
- `_resolved_vault_dir_cached` — vault paths don't move; process restart clears
- `_vault_relative_path_cached` — keyed on (vault, path) string tuple; LRU evicts
- `_promoted_deep_dive_index_cached` — keyed on DB mtime_ns; rebuild bumps it

## Test plan

- [x] Full suite: 2239 / 2239
- [x] `ruff check` on changed files unchanged from main (22 pre-existing warnings, no new ones)
- [x] Live `ovp-ui` smoke per page, warm-run times above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced overhead in path resolution operations through optimized caching
  * Streamlined registry initialization for faster startup
  * Accelerated traceability lookups with enhanced caching strategies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->