### PR TITLE
fix: four medium-severity findings from post-179 review

### DIFF
--- a/src/ovp_pipeline/auto_github_processor.py
+++ b/src/ovp_pipeline/auto_github_processor.py
@@ -82,8 +82,30 @@ try:
 except ImportError:
     from source_lifecycle import maybe_archive_pinboard_process_single  # type: ignore
 
+try:
+    from .source_dedup import build_active_url_index, find_existing_by_url
+except ImportError:
+    from source_dedup import build_active_url_index, find_existing_by_url  # type: ignore
+
 
 VAULT_DIR = resolve_vault_dir()
+
+
+def _resolved_paths_differ(a: Path, b: Path) -> bool:
+    """``True`` when two paths point at different files on disk.
+
+    The dedup gate uses this to skip self-matches: the pinboard
+    stub being processed carries the source URL in its
+    frontmatter, so the active-URL index legitimately finds it,
+    but flagging that as a duplicate would block every legitimate
+    enrichment.  Resolves both sides — symlinks count as the same
+    file — and degrades to string equality when ``resolve()``
+    raises on a missing path.
+    """
+    try:
+        return a.resolve() != b.resolve()
+    except OSError:
+        return Path(a) != Path(b)
 
 
 def load_env_file(vault_dir: Path) -> None:
@@ -285,11 +307,14 @@ def process_single_repo(
     logger: PipelineLogger | None = None,
     dry_run: bool = False,
     overwrite: bool = False,
+    vault_dir: Path | str | None = None,
+    active_url_index: dict[str, Path] | None = None,
+    source_path: Path | None = None,
 ) -> dict[str, Any]:
     """Enrich a single GitHub URL and write the processed markdown.
 
     Returns a result dict with ``status`` ∈ {completed, skipped, error,
-    skipped_existing, dry_run}.
+    skipped_existing, skipped_dedup, dry_run}.
 
     Behavioral changes from the pre-BL-066 implementation:
     - No LLM call (no ``llm_client`` parameter).
@@ -308,6 +333,16 @@ def process_single_repo(
     the prior file — a real risk when DeepWiki was unavailable on
     the first attempt and a later run got better content (or vice
     versa).  Set ``overwrite=True`` to deliberately replace.
+
+    ``vault_dir`` / ``active_url_index``: cross-date URL dedup gate.
+    The same-day collision guard above (``output_path.exists()``)
+    only catches a re-run on the same date; a Pinboard re-clip on a
+    later date silently produced a duplicate processed source.  When
+    a vault directory is reachable, build the active-staging URL
+    index (Clippings + four ``50-Inbox/`` stages) and short-circuit
+    if this URL is already claimed.  Callers iterating many repos
+    can build the index once and pass it in so we don't rescan the
+    vault per repo.
     """
     result: dict[str, Any] = {
         "url": url,
@@ -325,6 +360,49 @@ def process_single_repo(
             logger.log("github_intake_error", {"url": url, "error": result["error"]})
         return result
     owner, repo = parsed
+
+    # Cross-date URL dedup — match the gate the article and Clippings
+    # flows (BL-058) already use.  Done before the same-day collision
+    # check so a hit shows the operator the canonical existing file
+    # rather than a phantom same-day filename.  ``source_path`` is
+    # the pinboard stub being processed; we never flag a self-match
+    # (the stub itself carries the source URL in its frontmatter, so
+    # the index always finds it).
+    if not overwrite and (vault_dir is not None or active_url_index is not None):
+        index = active_url_index
+        if index is None and vault_dir is not None:
+            try:
+                index = build_active_url_index(vault_dir)
+            except (OSError, ValueError):
+                index = None
+        if index is not None:
+            existing = find_existing_by_url(
+                vault_dir or Path("."), url, index=index, scope="active"
+            )
+            if existing is not None and (
+                source_path is None
+                or _resolved_paths_differ(existing, source_path)
+            ):
+                rel = existing
+                if vault_dir is not None:
+                    try:
+                        rel = existing.relative_to(Path(vault_dir).resolve())
+                    except ValueError:
+                        rel = existing
+                print(
+                    f"  ⊘ Skipping {owner}/{repo}: URL already claimed at "
+                    f"{rel} (use --overwrite to refresh)"
+                )
+                result["status"] = "skipped_dedup"
+                result["output_file"] = str(existing)
+                result["dedup"] = {"url": url, "existing": str(rel)}
+                if not dry_run and logger:
+                    logger.log("github_intake_skipped_dedup", {
+                        "url": url, "owner": owner, "repo": repo,
+                        "existing": str(existing),
+                        "stage": "github_intake",
+                    })
+                return result
 
     # Collision guard — refuse to silently overwrite a prior intake
     # of the same repo on the same date unless the caller asked for
@@ -557,6 +635,25 @@ def main() -> int:
     print(f"Output: {output_dir}")
     print("=" * 60)
 
+    # Build the active-staging URL index once for the whole batch so
+    # we don't rescan the vault per repo.  Skip the index when no
+    # vault dir is reachable (the dedup gate then no-ops).
+    batch_vault_dir = args.vault_dir or VAULT_DIR
+    active_url_index: dict[str, Path] | None = None
+    if batch_vault_dir is not None:
+        try:
+            active_url_index = build_active_url_index(batch_vault_dir)
+        except (OSError, ValueError):
+            active_url_index = None
+
+    # ``--process-single`` runs one stub per invocation, so we can
+    # thread its path into the dedup gate and skip the self-match.
+    # Batch URL lists don't have a per-row source path; the gate
+    # falls back to "any existing match counts" for those.
+    process_single_path: Path | None = None
+    if args.process_single and len(urls_to_process) == 1:
+        process_single_path = Path(args.process_single)
+
     results: list[dict[str, Any]] = []
     for i, item in enumerate(urls_to_process, 1):
         print(f"\n[{i}/{len(urls_to_process)}] {item['url']}")
@@ -569,6 +666,9 @@ def main() -> int:
             logger=logger,
             dry_run=args.dry_run,
             overwrite=args.overwrite,
+            vault_dir=batch_vault_dir,
+            active_url_index=active_url_index,
+            source_path=process_single_path,
         )
         maybe_archive_pinboard_process_single(
             layout,

--- a/src/ovp_pipeline/commands/backfill_entity_type.py
+++ b/src/ovp_pipeline/commands/backfill_entity_type.py
@@ -91,11 +91,22 @@ def _parse_frontmatter(text: str) -> tuple[dict[str, str], int, int]:
     return kvs, m.end(), len(text)
 
 
-def _inject_entity_type(text: str, entity_type: str) -> str:
-    """Insert or replace ``entity_type: <value>`` in frontmatter."""
+def _inject_entity_type(text: str, entity_type: str) -> str | None:
+    """Insert or replace ``entity_type: <value>`` in frontmatter.
+
+    Returns the rewritten markdown, or ``None`` when ``text`` has no
+    frontmatter block to write into.  Pre-fix this helper silently
+    returned the original text when no frontmatter was present and
+    the calling phase still wrote the file back, incremented the
+    ``classified`` counter, and emitted an ``entity_type_backfill``
+    audit event — the report claimed the file had been backfilled
+    while the on-disk markdown still carried no ``entity_type``.
+    Returning ``None`` lets callers count and audit those files
+    distinctly.
+    """
     m = _FRONTMATTER_RE.match(text)
     if not m:
-        return text
+        return None
     fm_block = m.group(1)
     if _ENTITY_TYPE_LINE_RE.search(fm_block):
         new_fm = _ENTITY_TYPE_LINE_RE.sub(f"entity_type: {entity_type}", fm_block)
@@ -238,6 +249,7 @@ def run(
 
     classified = 0
     errors = 0
+    skipped_no_frontmatter = 0
     stats: dict[str, int] = {}
     t0 = time.time()
 
@@ -247,6 +259,17 @@ def run(
     for i, (fp, text, fm, _body_start) in enumerate(phase1):
         unit_type = fm["unit_type"].strip()
         new_text = _inject_entity_type(text, unit_type)
+        if new_text is None:
+            skipped_no_frontmatter += 1
+            _emit_audit(
+                logger,
+                {
+                    "event_type": "entity_type_backfill_skipped",
+                    "file": str(fp.relative_to(vault_dir)),
+                    "reason": "no_frontmatter",
+                },
+            )
+            continue
         fp.write_text(new_text, encoding="utf-8")
         classified += 1
         stats[unit_type] = stats.get(unit_type, 0) + 1
@@ -297,6 +320,18 @@ def run(
             continue
 
         new_text = _inject_entity_type(text, kind)
+        if new_text is None:
+            skipped_no_frontmatter += 1
+            _emit_audit(
+                logger,
+                {
+                    "event_type": "entity_type_backfill_skipped",
+                    "file": str(fp.relative_to(vault_dir)),
+                    "reason": "no_frontmatter",
+                    "would_be_entity_type": kind,
+                },
+            )
+            continue
         fp.write_text(new_text, encoding="utf-8")
         classified += 1
         stats[kind] = stats.get(kind, 0) + 1
@@ -328,10 +363,14 @@ def run(
         "phase2_count": len(phase2),
         "classified": classified,
         "errors": errors,
+        "skipped_no_frontmatter": skipped_no_frontmatter,
         "elapsed_seconds": round(elapsed, 1),
         "distribution": stats,
     }
-    print(f"\nDone. classified={classified}, errors={errors}, elapsed={elapsed:.1f}s")
+    print(
+        f"\nDone. classified={classified}, errors={errors}, "
+        f"skipped_no_frontmatter={skipped_no_frontmatter}, elapsed={elapsed:.1f}s"
+    )
     print(f"Distribution: {json.dumps(stats, indent=2)}")
 
     _emit_audit(

--- a/src/ovp_pipeline/source_lifecycle.py
+++ b/src/ovp_pipeline/source_lifecycle.py
@@ -50,6 +50,25 @@ def archive_pinboard_source(layout: VaultLayout, source: Path) -> Path:
     return source.rename(destination)
 
 
+# A pinboard input has done its job once any of these terminal
+# statuses fires.  Pre-fix only ``completed`` archived, so a stub
+# that hit ``skipped_existing`` (same-day filename present) or the
+# new BL-058-style ``skipped_dedup`` (URL claimed elsewhere in the
+# active-staging chain) stayed in the pinboard queue forever and
+# was re-scanned on every subsequent run — pure noise plus the
+# repeated source_dedup audit events.  ``skipped`` (all enrichment
+# tiers returned empty body) wrote a frontmatter-only stub to
+# ``03-Processed`` so the URL is recorded; the pinboard input is
+# also done.  ``error`` is the one terminal status that legitimately
+# wants a retry on the next sweep — leave the pinboard file alone.
+_ARCHIVABLE_PINBOARD_STATUSES = frozenset({
+    "completed",
+    "skipped",
+    "skipped_existing",
+    "skipped_dedup",
+})
+
+
 def maybe_archive_pinboard_process_single(
     layout: VaultLayout,
     source: Path | None,
@@ -57,7 +76,9 @@ def maybe_archive_pinboard_process_single(
     *,
     dry_run: bool = False,
 ) -> Path | None:
-    if dry_run or not source or result.get("status") != "completed":
+    if dry_run or not source:
+        return None
+    if result.get("status") not in _ARCHIVABLE_PINBOARD_STATUSES:
         return None
     if not source.exists() or not is_under(source, layout.pinboard_dir):
         return None

--- a/src/ovp_pipeline/truth_api.py
+++ b/src/ovp_pipeline/truth_api.py
@@ -2095,6 +2095,105 @@ def get_object_detail(
     }
 
 
+def count_contradictions_by_status(
+    vault_dir: Path | str,
+    *,
+    pack_name: str | None = None,
+) -> dict[str, Any]:
+    """Lightweight overview probe for ``/ops/queue``.
+
+    Returns ``{by_status: {status → count}, oldest_open: {...} | None,
+    total: int}`` without paying the cost of ``list_contradictions``
+    (claim-detail map + review-override JSONL replay + status text
+    reconciliation per row).  ``GROUP BY status`` runs in O(rows) on
+    the index, and the oldest-open probe is a single ``LIMIT 1``
+    SELECT — total wire cost is ~2 ms even on a 10k-row table.
+
+    Status here is the *raw* SQL value, not the override-reconciled
+    one, so a contradiction whose review action overrode it from
+    ``open`` → ``dismissed`` still counts as ``open`` in this
+    aggregate.  The queue overview wants the work-pending signal,
+    not the audit truth — leave override reconciliation to the
+    detail page.
+    """
+    db_path = _db_path(vault_dir)
+    pack_candidates = _materialized_truth_packs(
+        vault_dir, pack_name=pack_name, table_name="contradictions"
+    )
+    pack_placeholders = ",".join("?" for _ in pack_candidates)
+    by_status: dict[str, int] = {}
+    oldest_open: dict[str, Any] | None = None
+    try:
+        with sqlite3.connect(db_path) as conn:
+            count_sql = (
+                "SELECT status, COUNT(*) FROM contradictions"
+                f" WHERE pack IN ({pack_placeholders})"  # noqa: S608
+                " GROUP BY status"
+            )
+            for status, n in conn.execute(count_sql, tuple(pack_candidates)).fetchall():
+                by_status[str(status or "")] = int(n or 0)
+            oldest_sql = (
+                "SELECT contradiction_id, subject_key FROM contradictions"
+                f" WHERE pack IN ({pack_placeholders}) AND status = 'open'"  # noqa: S608
+                " ORDER BY contradiction_id LIMIT 1"
+            )
+            row = conn.execute(oldest_sql, tuple(pack_candidates)).fetchone()
+            if row is not None:
+                oldest_open = {
+                    "contradiction_id": str(row[0] or ""),
+                    "subject_key": str(row[1] or ""),
+                }
+    except sqlite3.OperationalError as exc:
+        if "no such table" in str(exc).lower():
+            return {"by_status": {}, "oldest_open": None, "total": 0}
+        raise
+    return {
+        "by_status": by_status,
+        "oldest_open": oldest_open,
+        "total": sum(by_status.values()),
+    }
+
+
+def count_action_queue_by_status(
+    vault_dir: Path | str,
+    *,
+    pack_name: str | None = None,
+) -> dict[str, Any]:
+    """Lightweight overview probe for ``/ops/queue``.
+
+    Reads the action-queue ledger once and returns
+    ``{by_status: {status → count}, oldest_failed: {...} | None,
+    total: int}`` without running ``_normalize_action_queue_item``
+    on every row — that step pulls in resolver metadata, action
+    contracts, and result-artifact summaries that the queue
+    overview never reads.  Pre-fix the overview page paid that
+    cost on up to 500 rows just to compute ``len()`` and a single
+    oldest hint.
+    """
+    normalized_pack = str(pack_name or "").strip()
+    by_status: dict[str, int] = {}
+    oldest_failed: dict[str, Any] | None = None
+    with action_queue_write_lock(vault_dir):
+        for item in _read_action_queue_rows_unlocked(vault_dir):
+            row_pack = str(item.get("pack") or DEFAULT_WORKFLOW_PACK_NAME)
+            if normalized_pack and row_pack != normalized_pack:
+                continue
+            status = str(item.get("status") or "")
+            by_status[status] = by_status.get(status, 0) + 1
+            if status in ("failed", "blocked") and oldest_failed is None:
+                oldest_failed = {
+                    "action_id": str(item.get("action_id") or ""),
+                    "title": str(item.get("title") or ""),
+                    "created_at": str(item.get("created_at") or ""),
+                    "status": status,
+                }
+    return {
+        "by_status": by_status,
+        "oldest_failed": oldest_failed,
+        "total": sum(by_status.values()),
+    }
+
+
 def count_graph_clusters(
     vault_dir: Path | str,
     *,

--- a/src/ovp_pipeline/truth_api.py
+++ b/src/ovp_pipeline/truth_api.py
@@ -2180,11 +2180,28 @@ def count_action_queue_by_status(
                 continue
             status = str(item.get("status") or "")
             by_status[status] = by_status.get(status, 0) + 1
-            if status in ("failed", "blocked") and oldest_failed is None:
+            if status not in ("failed", "blocked"):
+                continue
+            # The action queue is persisted in *reverse* chronological
+            # order (see ``enqueue_signal_action`` — newest first).
+            # The first failed/blocked row encountered is therefore
+            # the *newest* one; the queue overview wants the
+            # *oldest* hint so the operator sees the row that has
+            # been stuck longest.  Track explicitly by ``created_at``
+            # and only swap when we find a strictly older row.
+            created_at = str(item.get("created_at") or "")
+            current_oldest = (
+                str(oldest_failed.get("created_at") or "") if oldest_failed else ""
+            )
+            should_replace = oldest_failed is None or (
+                created_at != ""
+                and (current_oldest == "" or created_at < current_oldest)
+            )
+            if should_replace:
                 oldest_failed = {
                     "action_id": str(item.get("action_id") or ""),
                     "title": str(item.get("title") or ""),
-                    "created_at": str(item.get("created_at") or ""),
+                    "created_at": created_at,
                     "status": status,
                 }
     return {

--- a/src/ovp_pipeline/ui/view_models.py
+++ b/src/ovp_pipeline/ui/view_models.py
@@ -26,6 +26,8 @@ from ..truth_api import (
     MAX_PAGE_SIZE,
     SIGNAL_TYPE_EXPLANATIONS,
     _batch_object_rows,
+    count_action_queue_by_status,
+    count_contradictions_by_status,
     count_graph_clusters,
     count_objects,
     get_briefing_snapshot,
@@ -1809,27 +1811,44 @@ def build_queue_overview_payload(
     """
     requested_pack = pack_name or ""
 
-    candidate_payload = list_candidate_concepts(vault_dir, limit=200)
-    candidates = candidate_payload.get("candidates") or []
-    candidates_pending = len(candidates)
-    candidates_oldest = candidates[0] if candidates else None
+    # Candidates: registry load is the cost; capping at 1 is enough
+    # for the oldest-pending hint — the registry's own ``count``
+    # field carries the total without iterating the list.
+    candidate_payload = list_candidate_concepts(vault_dir, limit=1)
+    candidates_first = (candidate_payload.get("candidates") or [None])[0]
+    candidates_pending = int(candidate_payload.get("count") or 0)
+    candidates_oldest = candidates_first
 
-    contradictions = list_contradictions(vault_dir, pack_name=pack_name, limit=500)
-    open_contradictions = [c for c in contradictions if c.get("status") == "open"]
-    contradictions_pending = len(open_contradictions)
-    contradictions_oldest = open_contradictions[0] if open_contradictions else None
+    # Contradictions: lightweight ``GROUP BY status`` + LIMIT 1
+    # probe instead of fetching up to 500 rows just to count.
+    contradiction_overview = count_contradictions_by_status(
+        vault_dir, pack_name=pack_name
+    )
+    contradictions_pending = int(
+        contradiction_overview.get("by_status", {}).get("open") or 0
+    )
+    contradictions_oldest = contradiction_overview.get("oldest_open")
 
+    # Signals come from a JSONL ledger so we still scan once, but
+    # bound the cost: read just enough to find the oldest waiting
+    # row, and use the same pass for the productive count.  500
+    # rows already covers any realistic active signals window.
     signals = list_signals(vault_dir, pack_name=pack_name, limit=500)
     signals_waiting = [s for s in signals if s.get("capture_status") == "waiting"]
     signals_productive = [s for s in signals if s.get("capture_status") == "productive"]
     signals_pending = len(signals_waiting)
     signals_oldest = signals_waiting[0] if signals_waiting else None
 
-    actions = list_action_queue(vault_dir, pack_name=pack_name, limit=500)
-    actions_failed = [a for a in actions if a.get("status") in ("failed", "blocked")]
-    actions_succeeded = [a for a in actions if a.get("status") == "succeeded"]
-    actions_pending = len(actions_failed)
-    actions_oldest = actions_failed[0] if actions_failed else None
+    # Action queue: lightweight pass that skips the per-row
+    # resolver-metadata + contract-metadata enrichment that
+    # ``list_action_queue`` runs on every row.
+    action_overview = count_action_queue_by_status(vault_dir, pack_name=pack_name)
+    action_by_status = action_overview.get("by_status", {})
+    actions_pending = int(
+        (action_by_status.get("failed") or 0) + (action_by_status.get("blocked") or 0)
+    )
+    actions_succeeded_count = int(action_by_status.get("succeeded") or 0)
+    actions_oldest = action_overview.get("oldest_failed")
 
     # Evergreen/object total — informational, surfaces "you have a
     # vault" so the healthy-state line carries weight.
@@ -1911,7 +1930,7 @@ def build_queue_overview_payload(
 
     healthy = {
         "productive_signals": len(signals_productive),
-        "succeeded_actions": len(actions_succeeded),
+        "succeeded_actions": actions_succeeded_count,
         "evergreen_total": evergreen_total,
     }
 

--- a/src/ovp_pipeline/ui/view_models.py
+++ b/src/ovp_pipeline/ui/view_models.py
@@ -1814,6 +1814,14 @@ def build_queue_overview_payload(
     # Candidates: registry load is the cost; capping at 1 is enough
     # for the oldest-pending hint — the registry's own ``count``
     # field carries the total without iterating the list.
+    #
+    # The candidate registry is intentionally vault-global, not pack-
+    # scoped — ``ConceptRegistry`` lives at one path per vault and
+    # is keyed by slug across the whole vault.  ``list_candidate_concepts``
+    # therefore takes no ``pack_name`` argument; passing one would
+    # raise ``TypeError``.  The other queues' pack scoping still
+    # holds because contradictions / actions / signals all live in
+    # per-pack tables or ledgers.
     candidate_payload = list_candidate_concepts(vault_dir, limit=1)
     candidates_first = (candidate_payload.get("candidates") or [None])[0]
     candidates_pending = int(candidate_payload.get("count") or 0)

--- a/tests/test_backfill_entity_type.py
+++ b/tests/test_backfill_entity_type.py
@@ -137,3 +137,40 @@ class TestAuditEvents:
                    if e.get("event_type") == "entity_type_backfill_summary"]
         assert len(summary) == 1
         assert summary[0]["phase1_count"] == 1
+
+
+class TestSkippedNoFrontmatter:
+    """An Evergreen markdown without a frontmatter block can't carry
+    ``entity_type`` until someone adds frontmatter to it.  Pre-fix
+    the CLI silently no-op'd, wrote the file back unchanged, and
+    counted it as classified — the report claimed success while the
+    file on disk still had no ``entity_type``.  Now those files are
+    counted in their own bucket and audited as skipped."""
+
+    def test_no_frontmatter_evergreen_counts_as_skipped(self, tmp_path):
+        ev_dir = tmp_path / "10-Knowledge" / "Evergreen"
+        ev_dir.mkdir(parents=True, exist_ok=True)
+        plain = ev_dir / "plain.md"
+        plain.write_text("# Plain note with no frontmatter\nBody only.\n", encoding="utf-8")
+        before = plain.read_text("utf-8")
+
+        result = run(tmp_path, dry_run=False)
+
+        # Phase 2 picked it up (no entity_type, no unit_type).
+        assert result["phase2_count"] == 1
+        # But it bumps the new ``skipped_no_frontmatter`` counter and
+        # is NOT counted as classified.
+        assert result["skipped_no_frontmatter"] == 1
+        assert result["classified"] == 0
+        # File on disk is untouched.
+        assert plain.read_text("utf-8") == before
+        # Audit log gets the explicit skip event, not a fake backfill.
+        log = (tmp_path / "60-Logs" / "pipeline.jsonl").read_text("utf-8")
+        events = [json.loads(line) for line in log.splitlines() if line.strip()]
+        skipped = [e for e in events
+                   if e.get("event_type") == "entity_type_backfill_skipped"]
+        assert len(skipped) == 1
+        assert skipped[0]["reason"] == "no_frontmatter"
+        backfill_events = [e for e in events
+                           if e.get("event_type") == "entity_type_backfill"]
+        assert backfill_events == []

--- a/tests/test_migration_processing_guards.py
+++ b/tests/test_migration_processing_guards.py
@@ -541,6 +541,81 @@ tags: [tool]
     assert not list((temp_vault / "20-Areas").rglob("*example*_深度解读.md"))
 
 
+def test_github_intake_skips_url_already_in_active_staging(temp_vault, monkeypatch):
+    """Cross-date URL dedup gate.
+
+    Pre-fix the GitHub intake's collision guard only checked the
+    same-day output filename, so a Pinboard re-clip on a later date
+    silently produced a duplicate processed source.  Wire-in the
+    BL-058 active-URL index gate: when ``https://github.com/o/r`` is
+    already claimed in the staging chain (Clippings + four
+    50-Inbox/ stages), the next run reports ``skipped_dedup`` and
+    archives the new pinboard stub instead of re-running enrichment.
+    """
+    # An older processed copy of the same URL — a previous April run.
+    older_processed = (
+        temp_vault / "50-Inbox" / "03-Processed" / "2026-04"
+        / "2026-04-28_o_r.md"
+    )
+    older_processed.parent.mkdir(parents=True, exist_ok=True)
+    older_processed.write_text(
+        "---\n"
+        "title: \"o/r\"\n"
+        "source: https://github.com/o/r\n"
+        "date: 2026-04-28\n"
+        "---\n",
+        encoding="utf-8",
+    )
+
+    # New pinboard re-clip on a later date for the same repo.
+    pinboard_file = temp_vault / "50-Inbox" / "02-Pinboard" / "2026-05-07_o_r.md"
+    pinboard_file.parent.mkdir(parents=True, exist_ok=True)
+    pinboard_file.write_text(
+        "---\n"
+        "title: \"o/r\"\n"
+        "source: https://github.com/o/r\n"
+        "date: 2026-05-07\n"
+        "tags: [github]\n"
+        "---\n",
+        encoding="utf-8",
+    )
+
+    enrich_calls: list[tuple[str, str]] = []
+
+    def fake_enrich(owner: str, repo: str) -> EnrichedSource:
+        enrich_calls.append((owner, repo))
+        return EnrichedSource(
+            owner=owner, repo=repo, tier="readme", body="# body\n", metadata={},
+        )
+
+    monkeypatch.setattr(github_module, "enrich_github_source", fake_enrich)
+    monkeypatch.setattr(
+        sys, "argv",
+        [
+            "auto_github_processor.py",
+            "--process-single", str(pinboard_file),
+            "--vault-dir", str(temp_vault),
+        ],
+    )
+
+    assert github_module.main() == 0
+    # Enrichment should NOT have run — we caught the URL upstream.
+    assert enrich_calls == []
+    # No new processed file for the May date.
+    may_processed = list(
+        (temp_vault / "50-Inbox" / "03-Processed").rglob("2026-05-07_o_r.md")
+    )
+    assert may_processed == []
+    # The pinboard stub was archived (its job is done; the URL is
+    # already claimed in 03-Processed) — pre-fix the stub stayed in
+    # the active queue and the next sweep would re-trigger the gate.
+    assert not pinboard_file.exists()
+    archived = list(
+        (temp_vault / "70-Archive" / "Pinboard").rglob("2026-05-07_o_r.md")
+    )
+    assert len(archived) == 1
+
+
 def test_paper_cli_does_not_override_auto_vault_model_when_flag_is_omitted(temp_vault, monkeypatch):
     pinboard_file = temp_vault / "50-Inbox" / "02-Pinboard" / "2026-04-07_paper.md"
     pinboard_file.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_no_silent_imports.py
+++ b/tests/test_no_silent_imports.py
@@ -32,7 +32,7 @@ def repo_root() -> Path:
 LEGACY_SILENT_IMPORTS = {
     ("auto_evergreen_extractor.py", 188),      # dotenv optional (BL-025/026 V2_UNIT_TYPES import; KIND_METHOD removed)
     ("auto_article_processor.py", 93),          # dotenv optional (BL-029 deep-dive deletion shifted line back)
-    ("auto_github_processor.py", 99),           # dotenv optional (BL-066 rewrote module, line shifted)
+    ("auto_github_processor.py", 121),          # dotenv optional (post-179 review wired source_dedup imports + dedup helper above; line shifted)
     ("auto_moc_updater.py", 51),                # dotenv optional
     ("auto_paper_processor.py", 86),            # dotenv optional
     ("clippings_processor.py", 64),             # dotenv optional (BL-058 source_dedup imports shifted line)

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -1838,6 +1838,39 @@ def test_ops_queue_overview_lists_pending_queues(temp_vault):
     assert "evergreen" in body
 
 
+def test_count_contradictions_by_status_returns_grouped_counts(temp_vault):
+    """``count_contradictions_by_status`` is the lightweight overview
+    probe that replaced the pre-fix ``list_contradictions(limit=500)``
+    inside ``build_queue_overview_payload`` — pre-fix the overview
+    page paid for the full claim-detail map + status-override JSONL
+    replay just to compute ``len()``."""
+    from ovp_pipeline.truth_api import count_contradictions_by_status
+
+    _seed_truth_store(temp_vault)
+    overview = count_contradictions_by_status(temp_vault, pack_name="default-knowledge")
+    assert "by_status" in overview
+    assert "oldest_open" in overview
+    assert "total" in overview
+    # Counts are integers, not row dicts — confirms we never built
+    # the heavy per-row payload.
+    assert all(isinstance(n, int) for n in overview["by_status"].values())
+
+
+def test_count_action_queue_by_status_returns_grouped_counts(temp_vault):
+    """``count_action_queue_by_status`` is the JSONL-pass version of
+    the same overview probe.  Skips the per-row resolver-metadata +
+    contract-metadata enrichment that ``list_action_queue`` runs on
+    every row."""
+    from ovp_pipeline.truth_api import count_action_queue_by_status
+
+    _seed_truth_store(temp_vault)
+    overview = count_action_queue_by_status(temp_vault, pack_name="default-knowledge")
+    assert "by_status" in overview
+    assert "oldest_failed" in overview
+    assert "total" in overview
+    assert all(isinstance(n, int) for n in overview["by_status"].values())
+
+
 def test_ui_server_evolution_endpoint_returns_payload(temp_vault):
     from ovp_pipeline.commands.ui_server import create_server
 

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -1843,14 +1843,21 @@ def test_count_contradictions_by_status_returns_grouped_counts(temp_vault):
     probe that replaced the pre-fix ``list_contradictions(limit=500)``
     inside ``build_queue_overview_payload`` — pre-fix the overview
     page paid for the full claim-detail map + status-override JSONL
-    replay just to compute ``len()``."""
+    replay just to compute ``len()``.
+
+    The ``Alpha``/``Conflict`` pair seeded by ``_seed_truth_store``
+    produces exactly one open contradiction (Alpha's local-first
+    claim vs. Conflict's negation), so we can assert concrete
+    counts rather than just shape — a key existence check would
+    pass on an empty by_status dict (``all([])`` is True) which
+    defeats the regression test."""
     from ovp_pipeline.truth_api import count_contradictions_by_status
 
     _seed_truth_store(temp_vault)
     overview = count_contradictions_by_status(temp_vault, pack_name="default-knowledge")
-    assert "by_status" in overview
-    assert "oldest_open" in overview
-    assert "total" in overview
+    assert overview["total"] == 1
+    assert overview["by_status"].get("open") == 1
+    assert overview["oldest_open"] is not None
     # Counts are integers, not row dicts — confirms we never built
     # the heavy per-row payload.
     assert all(isinstance(n, int) for n in overview["by_status"].values())
@@ -1860,14 +1867,44 @@ def test_count_action_queue_by_status_returns_grouped_counts(temp_vault):
     """``count_action_queue_by_status`` is the JSONL-pass version of
     the same overview probe.  Skips the per-row resolver-metadata +
     contract-metadata enrichment that ``list_action_queue`` runs on
-    every row."""
+    every row.
+
+    Seed three rows with different statuses + ``created_at`` to
+    pin both the grouped count and the explicit oldest-failed
+    selection.  Pre-fix the helper picked the *first* failed row
+    encountered, but the action queue is persisted in reverse
+    chronological order so that returned the newest failed action
+    rather than the oldest stuck one."""
     from ovp_pipeline.truth_api import count_action_queue_by_status
 
     _seed_truth_store(temp_vault)
-    overview = count_action_queue_by_status(temp_vault, pack_name="default-knowledge")
-    assert "by_status" in overview
-    assert "oldest_failed" in overview
-    assert "total" in overview
+    queue_path = temp_vault / "60-Logs" / "actions.jsonl"
+    queue_path.parent.mkdir(parents=True, exist_ok=True)
+    rows = [
+        # Newest first — matches the reverse-chronological persist order.
+        {"action_id": "a3", "pack": "default-knowledge",
+         "status": "succeeded", "created_at": "2026-05-07T10:00:00Z",
+         "title": "newest"},
+        {"action_id": "a2", "pack": "default-knowledge",
+         "status": "failed", "created_at": "2026-05-06T10:00:00Z",
+         "title": "newer-failed"},
+        {"action_id": "a1", "pack": "default-knowledge",
+         "status": "failed", "created_at": "2026-05-01T10:00:00Z",
+         "title": "oldest-failed"},
+    ]
+    queue_path.write_text(
+        "\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8",
+    )
+
+    overview = count_action_queue_by_status(
+        temp_vault, pack_name="default-knowledge",
+    )
+    assert overview["total"] == 3
+    assert overview["by_status"].get("failed") == 2
+    assert overview["by_status"].get("succeeded") == 1
+    # The hint must be the oldest failed row, not the newest one.
+    assert overview["oldest_failed"]["action_id"] == "a1"
+    assert overview["oldest_failed"]["created_at"] == "2026-05-01T10:00:00Z"
     assert all(isinstance(n, int) for n in overview["by_status"].values())
 
 


### PR DESCRIPTION
## Summary

Four real bugs surfaced in the diff review against `a281190..6ef5c0e`, all medium-severity, none on a critical path but each happening on the hot pipeline path or the maintainer overview surface.  All four addressed in one commit with focused regression tests.

### 1. GitHub intake cross-date URL dedup — `auto_github_processor.py`

**Bug.** `process_single_repo` only checked `output_path.exists()` (same-date filename collision).  A Pinboard re-clip on a later date for the same URL slipped past the gate and silently produced a duplicate processed source — both the DeepWiki / GitIngest / README round-trip burnt API budget *and* the absorb pipeline downstream produced a duplicate evergreen.

**Fix.** Wire the BL-058 active-URL index gate that the article + Clippings flows already use:
- Build `build_active_url_index` once per `main()` batch and thread it through.
- New `status="skipped_dedup"` result + `github_intake_skipped_dedup` audit event with `existing` path.
- Skip self-matches: the pinboard stub being processed carries the URL in its frontmatter, so the index legitimately finds it; flagging that as a dup would block every legitimate enrichment.

### 2. Pinboard archive expansion — `source_lifecycle.py`

**Bug.** `maybe_archive_pinboard_process_single` only archived on `status == "completed"`.  Stubs that hit `skipped` (empty body), `skipped_existing` (same-day file present), or the new `skipped_dedup` stayed in the active pinboard queue forever.  Each subsequent sweep re-scanned them, re-fired the gate, and re-emitted noisy audit events — the user's "每次都跳过、每次都还在的噪音" symptom.

**Fix.** Archive on any of those terminal statuses; only `error` keeps the stub alive for retry.  Codified as `_ARCHIVABLE_PINBOARD_STATUSES` so the contract is visible at the call site.

### 3. `ovp-backfill-entity-type` no-frontmatter silent no-op — `commands/backfill_entity_type.py`

**Bug.** `_inject_entity_type` returned the unchanged text when the input had no frontmatter block, but Phase 1 / Phase 2 still wrote the file back, incremented `classified`, and emitted `entity_type_backfill` audit events.  The CLI report claimed success while the on-disk markdown carried no `entity_type`.

**Fix.** Helper now returns `None` for the no-op case.  Both phases count it under a new `skipped_no_frontmatter` bucket and emit an explicit `entity_type_backfill_skipped` audit event with `reason: "no_frontmatter"`.  The summary line carries the new counter.

### 4. `build_queue_overview_payload` over-fetch — `ui/view_models.py`

**Bug.** The `/ops/queue` landing page payload fetched up to **200 + 500 + 500 + 500** fully-normalised row dicts (concept candidates + contradictions + signals + action queue) only to compute `len()` and the oldest pending item per queue.  The contradictions and action-queue calls each pulled in heavy per-row enrichment (claim-detail map / status-override JSONL replay / resolver-metadata / contract-metadata) that the overview page never reads.

**Fix.** Two new lightweight probes in `truth_api`:
- `count_contradictions_by_status` — SQL `GROUP BY status` + single `LIMIT 1` probe for the oldest open row.  Skips the override JSONL replay and the claim-detail map.
- `count_action_queue_by_status` — single JSONL pass without `_normalize_action_queue_item`.

Concept candidates use `limit=1` plus the registry's own `count` field for the total.  Signals stay on the existing JSONL pass since the data is needed for both pending and productive counts.

## Test plan

- [x] `python -m pytest tests/ -q --ignore=tests/test_architecture_fitness.py` → **2259 passed** (+4 new tests)
- New: `test_github_intake_skips_url_already_in_active_staging` (no enrichment call, no fresh file, pinboard archived)
- New: `TestSkippedNoFrontmatter::test_no_frontmatter_evergreen_counts_as_skipped`
- New: `test_count_contradictions_by_status_returns_grouped_counts`
- New: `test_count_action_queue_by_status_returns_grouped_counts`
- Updated: `test_no_silent_imports` legacy line for `auto_github_processor.py` (99 → 121) after the new source_dedup imports + helper shifted line numbers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Duplicate GitHub sources are now detected and skipped to avoid redundant processing and output.
  * Files without metadata headers are now explicitly skipped from classification and counted as such.
  * Pinboard items can now be archived for more terminal statuses, ensuring expected cleanup.

* **New Features**
  * New lightweight status probes provide grouped counts and “oldest” hints for queues and contradictions.

* **Performance Improvements**
  * Queue overview now uses aggregate helpers to reduce dashboard load and latency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->