### PR TITLE
chore(release): bump version to 0.14.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "obsidian-vault-pipeline"
-version = "0.13.0"
+version = "0.14.0"
 description = "全自动Obsidian知识管理Pipeline - 生产级知识管理流水线"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Trivial version bump for the v0.14.0 tag.

Eight PRs landed since v0.13.0:

- #173 — drop legacy deep-dive layer (BL-029)
- #174 — /ops workbench IA Phase 1 (BL-053)
- #175 — type unification (BL-025/026)
- #176 — historical entity_type backfill (BL-030 Phase 1)
- #177 — type-facet chip rail on /ops/objects
- #178 — perf(ops): vault path memoisation + dead-tokenisation drop
- #179 — user-story-driven UX overhaul (BL-053 Phase 2)
- #180 — post-179 review fixes (4 medium findings)

Tag v0.14.0 will be cut from `main` after this merges.

Suite: 2259 tests passing.