### PR TITLE
feat(map): retrofit /map to use the D3 force solver

### DIFF
--- a/src/ovp_pipeline/commands/_graph_visualizers.py
+++ b/src/ovp_pipeline/commands/_graph_visualizers.py
@@ -1,21 +1,23 @@
 """Interactive graph visualisations for the maintainer surface.
 
-Today this module hosts the cluster-detail force-directed graph used
-by ``/ops/cluster?id=...``.  The same JS module is reusable on
-``/map`` (currently static SVG with server-computed positions); we
-defer that retrofit to a separate PR so the cluster viz can ship
-without disturbing reader-side rendering.
+Hosts the D3-force layout used by both ``/ops/cluster?id=...``
+(``render_cluster_force_graph``) and the reader-side ``/map``
+(``render_graph_map_force_graph``).  The two call sites differ
+only in the empty-state copy and the kind of payload they hand
+in; the actual drawing / drag / zoom / legend behaviour is shared
+through the private ``_render_force_graph_section`` helper.
 
 This is the first external JS dependency in the codebase: D3 v7 is
 loaded from ``unpkg.com``.  The tradeoff: building a smooth force-
 layout + drag/zoom + edge-encoding solver inline would be 200+ lines
 of vanilla JS and still lack D3-quality interactions.  D3 is ~280 KB,
-cached after first hit, and only loads on the cluster-detail page.
+cached after first hit and shared across the two pages that use it.
 
 Data flow:
     payload (Python dict)
-      → render_cluster_force_graph(payload) builds SVG container
-        plus a <script type="application/json"> block carrying
+      → public renderer (cluster vs map) flattens to ``{nodes, edges}``
+      → ``_render_force_graph_section`` builds SVG container plus a
+        ``<script type="application/json">`` block carrying
         ``{nodes, edges, edge_kinds, object_kinds}``
       → bootstrap script (inline) parses the JSON and feeds D3-force
       → user sees nodes circles + edge lines, can drag / zoom /
@@ -75,24 +77,23 @@ def _edge_payload(edge: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def render_cluster_force_graph(payload: dict[str, Any]) -> str:
-    """Return an HTML section: SVG mount + JSON data + D3 bootstrap.
+def _render_force_graph_section(
+    nodes_data: list[dict[str, Any]],
+    edges_data: list[dict[str, Any]],
+    *,
+    title: str,
+    intro: str,
+    empty_message: str,
+    aria_label: str,
+) -> str:
+    """Inner helper — build the SVG mount + JSON data + bootstrap.
 
-    The caller (``_render_cluster_detail_page``) injects this after
-    the cluster header card.  The existing tabular ``Members`` and
-    ``Internal Edges`` sections stay below as the printable /
-    accessibility fallback.
+    Both ``render_cluster_force_graph`` (single cluster) and
+    ``render_graph_map_force_graph`` (multi-cluster reader map)
+    funnel through here.  DOM ids stay ``cluster-graph-*`` because
+    they are internal CSS/JS handles — renaming would churn the
+    bootstrap string for no user-visible benefit.
     """
-    cluster = payload.get("cluster") or {}
-    member_links = cluster.get("member_links") or []
-    edges = payload.get("edges") or []
-
-    nodes_data = [_node_payload(member) for member in member_links]
-    edges_data = [_edge_payload(edge) for edge in edges]
-
-    # Distinct edge kinds and object kinds drive legend chips +
-    # ordinal colour scales in the bootstrap.  Sort for stable
-    # display order.
     edge_kinds = sorted({e["edge_kind"] for e in edges_data})
     object_kinds = sorted({n["object_kind"] for n in nodes_data if n["object_kind"]})
 
@@ -108,25 +109,19 @@ def render_cluster_force_graph(payload: dict[str, Any]) -> str:
     }
 
     # JSON-in-HTML escape: ``</`` would close the surrounding script
-    # block early when the data ever contained that substring.  Same
-    # mitigation graph/visualize.py and the workbench renderer use.
+    # block early when the data ever contained that substring.
     payload_json = json.dumps(graph_payload).replace("</", "<\\/")
 
     if not nodes_data:
         return (
-            "<section class='card'><h2>Force-Directed View</h2>"
-            "<p class='muted'>No members in this cluster — the graph "
-            "view is hidden until the cluster has at least one "
-            "member.</p></section>"
+            f"<section class='card'><h2>{escape(title)}</h2>"
+            f"<p class='muted'>{escape(empty_message)}</p></section>"
         )
 
     return (
         "<section class='card cluster-graph'>"
-        "<h2>Force-Directed View</h2>"
-        "<p class='muted'>Drag a node to pin it (double-click to "
-        "release).  Wheel zooms; drag the background pans.  Click "
-        "an edge-kind chip to fade non-matching edges.  Click a "
-        "node to open its object detail.</p>"
+        f"<h2>{escape(title)}</h2>"
+        f"<p class='muted'>{escape(intro)}</p>"
         f"<style>{_FORCE_GRAPH_CSS}</style>"
         "<div class='cluster-graph-toolbar'>"
         "<span class='muted'>Filter edges:</span>"
@@ -137,7 +132,7 @@ def render_cluster_force_graph(payload: dict[str, Any]) -> str:
         "<svg id='cluster-graph-svg' "
         f"viewBox='0 0 800 {GRAPH_VIEWPORT_HEIGHT}' "
         "preserveAspectRatio='xMidYMid meet' role='img' "
-        "aria-label='Cluster force-directed graph'>"
+        f"aria-label='{escape(aria_label)}'>"
         "<defs><marker id='cluster-arrow' viewBox='0 -5 10 10' "
         "refX='15' refY='0' markerWidth='7' markerHeight='7' "
         "orient='auto'><path d='M0,-5L10,0L0,5' fill='#9f9088'/>"
@@ -151,6 +146,71 @@ def render_cluster_force_graph(payload: dict[str, Any]) -> str:
         f"<script src='{escape(_D3_CDN)}' defer></script>"
         f"<script>{_FORCE_GRAPH_BOOTSTRAP}</script>"
         "</section>"
+    )
+
+
+def render_cluster_force_graph(payload: dict[str, Any]) -> str:
+    """Return an HTML section: SVG mount + JSON data + D3 bootstrap.
+
+    The caller (``_render_cluster_detail_page``) injects this after
+    the cluster header card.  The existing tabular ``Members`` and
+    ``Internal Edges`` sections stay below as the printable /
+    accessibility fallback.
+    """
+    cluster = payload.get("cluster") or {}
+    member_links = cluster.get("member_links") or []
+    edges = payload.get("edges") or []
+    return _render_force_graph_section(
+        nodes_data=[_node_payload(member) for member in member_links],
+        edges_data=[_edge_payload(edge) for edge in edges],
+        title="Force-Directed View",
+        intro=(
+            "Drag a node to pin it (double-click to release).  "
+            "Wheel zooms; drag the background pans.  Click an "
+            "edge-kind chip to fade non-matching edges.  Click a "
+            "node to open its object detail."
+        ),
+        empty_message=(
+            "No members in this cluster — the graph view is hidden "
+            "until the cluster has at least one member."
+        ),
+        aria_label="Cluster force-directed graph",
+    )
+
+
+def render_graph_map_force_graph(payload: dict[str, Any]) -> str:
+    """``/map`` reader-side force-directed view.
+
+    Unlike ``render_cluster_force_graph``, the input is a flat
+    ``{nodes, edges}`` covering every cluster the map is showing —
+    cluster identity is not visually encoded (the force solver
+    naturally pulls densely-connected nodes together; cluster-
+    specific drill-in is on ``/ops/cluster?id=...``).
+
+    Pre-computed orbital ``x`` / ``y`` on the ``/map`` payload are
+    intentionally ignored — the D3 force solver re-lays the graph
+    on every page load.  This is the whole point of the retrofit:
+    static positions stop reflecting graph topology as the corpus
+    grows.
+    """
+    nodes = payload.get("nodes") or []
+    edges = payload.get("edges") or []
+    return _render_force_graph_section(
+        nodes_data=[_node_payload(node) for node in nodes],
+        edges_data=[_edge_payload(edge) for edge in edges],
+        title="Knowledge Graph",
+        intro=(
+            "Drag a node to pin it (double-click to release).  "
+            "Wheel zooms; drag the background pans.  Click an "
+            "edge-kind chip to fade non-matching edges.  Click a "
+            "node to open its object page."
+        ),
+        empty_message=(
+            "No nodes in scope — try widening the search query, "
+            "removing the per-cluster cap, or seeding the graph "
+            "via ``ovp-knowledge-index``."
+        ),
+        aria_label="Knowledge graph force-directed view",
     )
 
 

--- a/src/ovp_pipeline/commands/_ui_renderers.py
+++ b/src/ovp_pipeline/commands/_ui_renderers.py
@@ -27,7 +27,7 @@ from ..ui.view_models import (
     DEFAULT_CANDIDATE_BROWSER_LIMIT,
     build_runtime_home_payload,
 )
-from ._graph_visualizers import render_cluster_force_graph
+from ._graph_visualizers import render_cluster_force_graph, render_graph_map_force_graph
 
 
 _MARKDOWN_RENDERER = MarkdownIt("commonmark", {"breaks": True, "html": False}).enable("table")
@@ -3625,8 +3625,6 @@ def _render_graph_map_page(payload: dict, *, action_path: str = "/graph") -> str
         )
     else:
         cap_note = ""
-    show_all_qs = "&show_all=1" if "?" in action_path else "?show_all=1"
-    show_all_path = action_path
     if not show_all and truncated:
         # Append show_all=1 onto the same action; keep pack scope.
         prefix = action_path
@@ -3664,40 +3662,13 @@ def _render_graph_map_page(payload: dict, *, action_path: str = "/graph") -> str
         or "<li class='muted'>No graph clusters found yet.</li>"
     )
     notes = "".join(f"<li>{escape(note)}</li>" for note in payload["model_notes"])
-    node_lookup = {str(node["object_id"]): node for node in payload["nodes"]}
-
-    def node_x(node: dict) -> float:
-        return float(node.get("x") or 0)
-
-    def node_y(node: dict) -> float:
-        return float(node.get("y") or 0)
-
-    edge_lines = "".join(
-        "<line "
-        f"x1='{node_x(node_lookup[str(edge['source_object_id'])])}' "
-        f"y1='{node_y(node_lookup[str(edge['source_object_id'])])}' "
-        f"x2='{node_x(node_lookup[str(edge['target_object_id'])])}' "
-        f"y2='{node_y(node_lookup[str(edge['target_object_id'])])}' "
-        "stroke='#c7b8a6' stroke-width='1.4' stroke-opacity='0.7'>"
-        f"<title>{escape(edge['source_title'])} -> {escape(edge['target_title'])}: {escape(edge['edge_kind'])}</title>"
-        "</line>"
-        for edge in payload["edges"]
-        if str(edge["source_object_id"]) in node_lookup
-        and str(edge["target_object_id"]) in node_lookup
-    )
-    node_marks = "".join(
-        "<a "
-        f"href='{escape(str(node['path']))}' aria-label='{escape(str(node['title']))}'>"
-        f"<circle cx='{node_x(node)}' cy='{node_y(node)}' r='{node['radius']}' fill='#9f4f24' "
-        "stroke='#fffdfa' stroke-width='2'>"
-        f"<title>{escape(str(node['title']))} · {escape(str(node['kind_label']))} · {node['degree']} links</title>"
-        "</circle>"
-        f"<text x='{node_x(node)}' y='{node_y(node) + float(node['radius']) + _GRAPH_MAP_NODE_LABEL_Y_OFFSET}' "
-        "text-anchor='middle' font-size='12' fill='#3c332b'>"
-        f"{escape(str(node['title']))}</text>"
-        "</a>"
-        for node in payload["nodes"]
-    )
+    # The static-SVG path (server-computed orbital rings) is gone —
+    # ``render_graph_map_force_graph`` ignores ``payload["layout"]``
+    # and ``node["x"]``/``node["y"]`` on purpose; the D3 force solver
+    # re-lays the graph each load.  ``layout`` is kept on the payload
+    # for downstream consumers (none today) but unused here.
+    _ = layout
+    map_section = render_graph_map_force_graph(payload)
     return _layout(
         "Knowledge Graph",
         "".join(
@@ -3720,30 +3691,14 @@ def _render_graph_map_page(payload: dict, *, action_path: str = "/graph") -> str
                 f"<div class='card'><h2>Connections</h2><p>{payload['map_summary']['edge_count']}</p></div>",
                 f"<div class='card'><h2>Neighborhoods</h2><p>{payload['map_summary']['cluster_count']}</p></div>",
                 "</section>",
-                "<section class='card'>",
-                "<h2>Map</h2>",
-                f"<svg id='graph-map-canvas' viewBox='0 0 {layout['width']} {layout['height']}' "
-                "style='width:100%;height:auto;max-height:68vh;background:#fffdfa;border:1px solid #e7e1d8;border-radius:8px'>",
-                "<title>Knowledge graph map</title>",
-                "<desc>Interactive map of knowledge objects and their connections.</desc>",
-                # BL-051: labels overlap badly when every node renders one
-                # statically.  Hide labels by default, reveal on hover or
-                # focus.  Each node ``<a>`` carries an aria-label + svg
-                # ``<title>`` so accessibility tooling still has the name.
-                "<style>"
-                "#graph-map-canvas text { opacity: 0; transition: opacity 0.12s ease; pointer-events: none; }"
-                "#graph-map-canvas a:hover text, #graph-map-canvas a:focus text { opacity: 1; }"
-                "</style>",
-                edge_lines,
-                node_marks,
-                "</svg>",
-                "</section>",
+                map_section,
                 "<section class='grid two-col'>",
                 "<section class='card'><h2>How To Read This Map</h2>"
                 "<ul class='list-tight'>"
-                "<li>Each dot is a knowledge object you can open.</li>"
-                "<li>Lines show accepted graph relations from the local projection.</li>"
-                "<li>Nearby groups are reading neighborhoods, not canonical truth boundaries.</li>"
+                "<li>Each dot is a knowledge object you can open.  Click it to jump to the object page.</li>"
+                "<li>Lines show accepted graph relations from the local projection — drag a node to pin it, double-click to release.</li>"
+                "<li>Densely connected groups settle into neighborhoods, but those are reading hints, not canonical truth boundaries.</li>"
+                "<li>For a cluster-specific view with internal-edge detail, open one from <em>Neighborhoods</em> below.</li>"
                 "</ul></section>",
                 "<section class='card'><h2>Neighborhoods</h2>"
                 f"<p><a href='{escape(_shell_href('/ops/clusters', requested_pack))}'>Open Cluster Browser</a></p>"

--- a/src/ovp_pipeline/commands/_ui_renderers.py
+++ b/src/ovp_pipeline/commands/_ui_renderers.py
@@ -3608,7 +3608,10 @@ def _render_clusters_page(payload: dict, *, action_path: str = "/ops/clusters") 
 def _render_graph_map_page(payload: dict, *, action_path: str = "/graph") -> str:
     query = payload.get("query", "")
     requested_pack = payload.get("requested_pack", "")
-    layout = payload["layout"]
+    # Note: ``payload["layout"]`` is no longer read — the D3 force
+    # solver computes positions client-side.  ``build_graph_map_payload``
+    # still emits the field for shape stability but nothing on the
+    # server side consumes it after this commit.
     summary = payload["map_summary"]
     show_all = bool(summary.get("show_all"))
     member_cap = int(summary.get("member_cap") or 0)
@@ -3662,12 +3665,6 @@ def _render_graph_map_page(payload: dict, *, action_path: str = "/graph") -> str
         or "<li class='muted'>No graph clusters found yet.</li>"
     )
     notes = "".join(f"<li>{escape(note)}</li>" for note in payload["model_notes"])
-    # The static-SVG path (server-computed orbital rings) is gone —
-    # ``render_graph_map_force_graph`` ignores ``payload["layout"]``
-    # and ``node["x"]``/``node["y"]`` on purpose; the D3 force solver
-    # re-lays the graph each load.  ``layout`` is kept on the payload
-    # for downstream consumers (none today) but unused here.
-    _ = layout
     map_section = render_graph_map_force_graph(payload)
     return _layout(
         "Knowledge Graph",

--- a/tests/test_reader_scenarios.py
+++ b/tests/test_reader_scenarios.py
@@ -171,6 +171,15 @@ def test_reader_search_to_object(temp_vault):
 # ---------------------------------------------------------------------------
 
 def test_reader_graph_navigation(temp_vault):
+    """``/map`` post-D3-retrofit: ``/object?`` click-through paths
+    live in the inline JSON data block consumed by the D3 bootstrap,
+    not as ``href=`` attributes on the rendered HTML.  Pull one and
+    verify it loads — this preserves the original scenario intent
+    (reader can drill from the map into an object page) without
+    requiring a JS-aware browser harness.
+    """
+    import json
+
     _seed(temp_vault)
     server = create_server(temp_vault, host="127.0.0.1", port=0)
     port = server.server_address[1]
@@ -181,9 +190,17 @@ def test_reader_graph_navigation(temp_vault):
         assert st == 200
         assert "Knowledge" in graph
 
-        obj_links = _extract_hrefs(graph, "/object?")
-        assert obj_links, "/map page should contain at least one /object? link"
-        st, obj = _get(port, obj_links[0])
+        marker = "id='cluster-graph-data'>"
+        start = graph.index(marker) + len(marker)
+        end = graph.index("</script>", start)
+        data = json.loads(graph[start:end].replace("<\\/", "</"))
+        obj_paths = [
+            node["path"]
+            for node in data["nodes"]
+            if isinstance(node.get("path"), str) and node["path"].startswith("/object?")
+        ]
+        assert obj_paths, "/map JSON data should carry at least one /object? path"
+        st, obj = _get(port, obj_paths[0])
         assert st == 200
     finally:
         server.shutdown()

--- a/tests/test_reader_scenarios.py
+++ b/tests/test_reader_scenarios.py
@@ -200,7 +200,10 @@ def test_reader_graph_navigation(temp_vault):
             if isinstance(node.get("path"), str) and node["path"].startswith("/object?")
         ]
         assert obj_paths, "/map JSON data should carry at least one /object? path"
-        st, obj = _get(port, obj_paths[0])
+        # Body intentionally unused — only the status code matters
+        # for this scenario (the prior reader-side assertions covered
+        # /object page contents).
+        st, _ = _get(port, obj_paths[0])
         assert st == 200
     finally:
         server.shutdown()

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -221,14 +221,19 @@ def test_ui_server_map_route_serves_readable_map_entry(temp_vault):
 
     assert status == 200
     assert "Knowledge Graph" in body
-    assert "graph-map-canvas" in body
+    # Post-retrofit: ``/map`` mounts the D3 force solver from
+    # ``_graph_visualizers.py``.  The static-SVG canvas
+    # (``graph-map-canvas`` id, server-computed orbital positions)
+    # is gone; the new mount is the shared ``cluster-graph-svg``
+    # element + ``cluster-graph-data`` JSON block.
+    assert "cluster-graph-svg" in body
+    assert "cluster-graph-data" in body
+    assert "https://unpkg.com/d3@7" in body
     assert "Alpha" in body
     assert "Beta" in body
     assert "How To Read This Map" in body
     assert "Open Cluster Browser" in body
     assert "Showing the first 24 graph neighborhoods" in body
-    assert "<title>Knowledge graph map</title>" in body
-    assert "role='img'" not in body
     assert "action='/map'" in body
     assert "action='/ops/clusters'" not in body
     assert 'href="/">Library</a>' in body
@@ -244,7 +249,8 @@ def test_ui_server_graph_route_serves_visual_graph_mvp(temp_vault):
 
     assert status == 200
     assert "Knowledge Graph" in body
-    assert "graph-map-canvas" in body
+    assert "cluster-graph-svg" in body
+    assert "cluster-graph-data" in body
     assert "Alpha" in body
     assert "Beta" in body
     assert "Showing the first 24 graph neighborhoods" in body
@@ -693,7 +699,18 @@ def test_render_source_backlink_rail_skips_non_dict_items():
     assert "bad-data" not in html
 
 
-def test_render_graph_map_defaults_missing_coordinates():
+def test_render_graph_map_force_view_omits_static_coords():
+    """Post-retrofit ``/map`` mounts the D3 force solver.
+
+    The pre-retrofit assertion was that nodes without server-
+    computed ``x``/``y`` defaulted to ``0.0`` in the inline SVG
+    coordinates.  That whole code path is gone — the D3 solver
+    computes positions client-side, and the renderer hands it a
+    JSON payload with the raw nodes/edges.  Test pivots to:
+    nodes serialize into the ``cluster-graph-data`` JSON block,
+    no inline ``cx=``/``x1=`` coordinates leak through.
+    """
+    import json
     from ovp_pipeline.commands.ui_server import _render_graph_map_page
 
     html = _render_graph_map_page(
@@ -715,7 +732,7 @@ def test_render_graph_map_defaults_missing_coordinates():
                     "object_id": "a",
                     "path": "/object?id=a",
                     "title": "A",
-                    "radius": 8,
+                    "object_kind": "concept",
                     "kind_label": "Concept",
                     "degree": 1,
                 },
@@ -723,7 +740,7 @@ def test_render_graph_map_defaults_missing_coordinates():
                     "object_id": "b",
                     "path": "/object?id=b",
                     "title": "B",
-                    "radius": 8,
+                    "object_kind": "concept",
                     "kind_label": "Concept",
                     "degree": 1,
                 },
@@ -735,13 +752,24 @@ def test_render_graph_map_defaults_missing_coordinates():
                     "source_title": "A",
                     "target_title": "B",
                     "edge_kind": "related",
+                    "weight": 1.0,
                 }
             ],
         }
     )
 
-    assert "cx='0.0'" in html
-    assert "x1='0.0'" in html
+    assert "cluster-graph-svg" in html
+    assert "cluster-graph-data" in html
+    # No leftover inline coord attributes from the removed static-SVG path.
+    assert "cx='0.0'" not in html
+    assert "x1='0.0'" not in html
+    # The JSON data block must carry both seeded nodes so D3 has
+    # something to lay out.
+    start = html.index("id='cluster-graph-data'>") + len("id='cluster-graph-data'>")
+    end = html.index("</script>", start)
+    data = json.loads(html[start:end].replace("<\\/", "</"))
+    assert {n["id"] for n in data["nodes"]} == {"a", "b"}
+    assert len(data["edges"]) == 1
 
 
 def test_ui_server_ops_route_renders_runtime_state_card(temp_vault):


### PR DESCRIPTION
## Summary

Retrofits `/map` (and `/graph`) to use the D3-force layout already powering `/ops/cluster?id=...`. Replaces the pre-existing static SVG with server-computed orbital positions — that layout stopped reflecting graph topology as the vault grew (730 clusters collapse into a spiral).

## What changed

- **`_graph_visualizers.py`**: extracted the SVG mount + JSON data block + bootstrap into a private `_render_force_graph_section`. `render_cluster_force_graph` and the new `render_graph_map_force_graph` are now thin wrappers that supply title / intro / empty-state copy. DOM ids stay `cluster-graph-*` (internal handles; renaming would churn the bootstrap for no UX gain).
- **`_render_graph_map_page`**: deletes the static-SVG block and calls `render_graph_map_force_graph(payload)` instead. Surrounding cards (Stats, How To Read, Neighborhoods, Model Notes) stay.
- **`payload['layout']`** and per-node `x`/`y` are intentionally unused — D3 re-lays the graph client-side on every load.

## What the user sees

- Drag pins a node; double-click releases. Wheel zooms; drag bg pans. Click a node → `/object?id=...`. Click an edge-kind chip → fades non-matching edges.
- Densely-connected groups settle into visible neighborhoods naturally.
- For a cluster-specific drill-in, the Neighborhoods list still links into `/ops/cluster?id=...`.

## Test changes

- `test_render_graph_map_force_view_omits_static_coords` replaces the pre-retrofit `test_render_graph_map_defaults_missing_coordinates` (which asserted `cx='0.0'` defaults from the static-SVG path). Now parses the inline JSON data block.
- `test_reader_graph_navigation`: pulls `/object?` paths from the JSON data block instead of from rendered `href=` attrs. Scenario intent (reader drills from /map into an object page) still verified end-to-end.
- Pre-existing F841 dead vars (`show_all_qs`, `show_all_path`) cleaned up as a drive-by.

## Verification

- [x] `rtk proxy python -m pytest tests/ -q --ignore=tests/test_architecture_fitness.py` → **2240 passed, 15 xfailed**
- [x] `rtk proxy ruff check` clean (1 pre-existing `workbench_path` warning in another function unrelated to this change)
- [ ] Browser smoke (you'll need to restart the local server first, pid 32284 is on stale pre-#183 code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Graph map and cluster pages now use a shared interactive force-graph renderer with draggable/pinnable nodes.

* **Documentation**
  * Updated Graph Map guidance to explain interactive behavior and neighborhood interpretation.

* **Tests**
  * UI and reader scenario tests updated to validate embedded graph JSON and client-side rendering/interaction.

* **Accessibility**
  * SVG aria labels and empty-state messages improved for clearer screen-reader output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->