### PR TITLE
chore(release): bump version to 0.15.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "obsidian-vault-pipeline"
-version = "0.14.0"
+version = "0.15.0"
 description = "全自动Obsidian知识管理Pipeline - 生产级知识管理流水线"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_unified_pipeline_version.py
+++ b/tests/test_unified_pipeline_version.py
@@ -17,4 +17,4 @@ def test_unified_pipeline_version_falls_back_to_pyproject_when_metadata_missing(
 
     monkeypatch.setattr(metadata, "version", missing_distribution)
 
-    assert _get_version() == "0.14.0"
+    assert _get_version() == "0.15.0"


### PR DESCRIPTION
Release v0.15.0 — cluster + object overhaul + tooling.

## What shipped since v0.14.0

| PR | What |
|---|---|
| #182 | `/ops/clusters` real pagination + `/ops/cluster?id=` D3 force viz + deep-dive sweep |
| #183 | `/object` Source chain card + `docs/page-ia-post-bl029.md` |
| #184 | `/map` D3 force-solver retrofit |
| #185 | `ovp-backfill-objects-source-url` CLI (94.7% live-vault resolution) |
| #186 | BL-056 closure — `stage='extract'` provenance hook |

## What still needs doing

- 15 deep-dive test fixtures still xfailed pending fixture migration to the post-BL-029 chain (separate PR)
- BL-057 provenance-lint enforcement (separate ticket)

## Test plan

- [x] `rtk proxy python -m pytest tests/ -q --ignore=tests/test_architecture_fitness.py` all green pre-bump
- [x] `tests/test_unified_pipeline_version.py` updated to assert "0.15.0"
- [ ] After merge: tag `v0.15.0` and restart local server to pick up the new code