### PR TITLE
docs+test(bl-060): canonical write ownership audit + fitness ratchet

### DIFF
--- a/docs/canonical-write-ownership.md
+++ b/docs/canonical-write-ownership.md
@@ -1,0 +1,115 @@
+# Canonical Write Ownership (BL-060)
+
+**Status:** Audit complete (PR #1 of 2). Refactor to enforce ownership lands in BL-060 PR#2.
+
+**Why this exists.** PR #185's review surfaced the root cause of a class of bugs: three independent modules wrote `objects.source_url` (rebuild from frontmatter, `ovp-backfill-provenance`, `ovp-backfill-objects-source-url`) with no single source of truth. When their behaviours drifted, reconciliation became impossible.
+
+The fix is the **single-writer invariant**: every column in every canonical table has exactly one *owner module* that's allowed to write it. Other modules call the owner's helper. Locking inside owners is already covered by `withFileLock` / `knowledge_db_write_lock`; this doc is about *who's allowed to issue the write at all*.
+
+---
+
+## Canonical tables in scope
+
+The four tables in `knowledge.db` that hold canonical OVP state:
+
+| Table | Holds | Append-only? |
+| --- | --- | --- |
+| `objects` | Evergreen registry — one row per (pack, object_id) | No (rebuild replaces) |
+| `provenance` | Stage emit log (BL-055) — one row per (pack, object_id, stage, derived_at) | Yes |
+| `claims` | Atomic claim records | No (rebuild replaces) |
+| `relations` | Typed object → object edges | No (rebuild replaces; `relation_promoted` events replay) |
+
+Out of scope (governance / projection tables — different lifecycle, not "canonical"):
+
+- `audit_events`, `signal_ledger`, `action_queue` — append-only logs, multiple writers expected
+- `compiled_summaries`, `community_crystals`, `contradiction_crystals` — projections (rebuild rewrites)
+- `pages_index`, `page_links`, `page_fts`, `page_embeddings` — projections
+- `graph_clusters`, `graph_edges` — projections
+- `evolution_*`, `contradictions`, `concept_dedup_*` — derived
+
+`evergreen_revisions` (BL-061, not yet built) will follow the same ownership pattern when it lands.
+
+---
+
+## Owner module map
+
+| Table | Column scope | Owner | Allowed entry points |
+| --- | --- | --- | --- |
+| `objects` | full-row insert | `truth_store_writers.objects_writer` *(new module, BL-060 PR#2)* | `bulk_replace_objects(conn, pack, rows)` — used by `rebuild_knowledge_index` |
+| `objects` | column update: `source_url` | `truth_store_writers.objects_writer` | `update_object_source_url(conn, pack, object_id, source_url, *, source=...)` |
+| `provenance` | every row | `provenance.upsert_provenance` *(already exists)* | `upsert_provenance(conn, ...)` — single canonical helper, idempotent on PK |
+| `provenance` | bulk insert (rebuild path) | `provenance.bulk_upsert_provenance` *(new helper, BL-060 PR#2)* | wraps `executemany` over `upsert_provenance` for the rebuild's per-pack flush |
+| `claims` | every row | `truth_store_writers.claims_writer` *(new module)* | `bulk_replace_claims(conn, pack, rows)` — used by rebuild only today |
+| `relations` | every row | `relation_writer.upsert_relation` *(promote `_ensure_relation_row` to owner)* | `upsert_relation(conn, *, pack, source_object_id, target_object_id, ...)` |
+| `relations` | bulk replace (rebuild path) | `relation_writer.bulk_replace_relations(conn, pack, rows)` | rebuild only |
+
+**Single-writer invariant:** every other module that wants to insert / update / delete one of these tables MUST go through the owner above. Direct SQL like `conn.execute("INSERT INTO objects ...")` outside the owner module is a violation.
+
+---
+
+## Audit results — current violations (as of 2026-05-10)
+
+Five sites bypass the owner pattern today. BL-060 PR#2 refactors them all.
+
+### Critical: `relations` table — 3 writers, full-row overlap
+
+| Site | Function | Writes via | Trigger |
+| --- | --- | --- | --- |
+| `knowledge_index.py:1159` | `rebuild_knowledge_index` | raw `INSERT INTO relations` | rebuild |
+| `relation_promotion.py:89` | `_ensure_relation_row` | raw `INSERT INTO relations` | candidate review |
+| `relation_promotion.py:228` | `replay_relation_promotions` | raw `INSERT INTO relations` | rebuild's replay step |
+
+Eleven columns (`pack`, `source_object_id`, `target_object_id`, `relation_type`, `evidence_source_slug`, `quote_text`, `locator`, `content_hash`, `retrieval_context`, `status`, `verified_at`) are written by all three with near-identical SQL. Worst-case drift surface in the codebase.
+
+**Refactor target (PR#2):** `_ensure_relation_row` becomes the owner (rename → `upsert_relation`). The other two sites call it. Rebuild's bulk path goes through a `bulk_replace_relations` wrapper so it stays performant.
+
+### High: `provenance` table — 2 writers via copy-pasted SQL with dedup guard
+
+| Site | Function | Writes via | Trigger |
+| --- | --- | --- | --- |
+| `knowledge_index.py:1110` | `rebuild_knowledge_index` | raw `INSERT INTO provenance ... WHERE NOT EXISTS` | rebuild ingest baseline |
+| `commands/backfill_objects_source_url.py:277` | `main` (via `--write-provenance`) | raw `INSERT INTO provenance ... WHERE NOT EXISTS` | backfill CLI |
+
+Same 8-column row, same dedup guard, written from two places. The owner — `provenance.upsert_provenance` — already exists and uses `INSERT OR IGNORE` against the same PK. **Both sites should call it.**
+
+**Refactor target (PR#2):** rebuild path switches to `bulk_upsert_provenance(conn, rows)` (new helper that wraps `executemany`). Backfill CLI calls `upsert_provenance(conn, ...)` directly.
+
+### High: `objects.source_url` — 2 writers
+
+| Site | Function | Writes via | Trigger |
+| --- | --- | --- | --- |
+| `knowledge_index.py:1093` | `rebuild_knowledge_index` | raw `INSERT INTO objects (...source_url)` | rebuild from frontmatter |
+| `commands/backfill_objects_source_url.py:264` | `main` | raw `UPDATE objects SET source_url = ?` | backfill CLI |
+
+This is the original PR #185 root cause. The two sites compute `source_url` from different inputs (frontmatter vs. audit-event walk + provenance lookup); without a shared helper their conventions diverged.
+
+**Refactor target (PR#2):** introduce `truth_store_writers.objects_writer.update_object_source_url(conn, pack, object_id, source_url, *, source: str)` where `source` ∈ `{rebuild, backfill, ...}` for audit. Rebuild's full-row insert stays in the writer module; the backfill CLI calls the column-update helper.
+
+### Clean: `claims` — 1 writer
+
+`knowledge_index.py:1140` is the only site that touches `claims`. No violation today, but BL-060 PR#2 still hoists it into the owner module so future writers can't be added without hitting the fitness test.
+
+---
+
+## Architecture-fitness test
+
+The test in `tests/test_architecture_fitness.py` enforces this map at import time:
+
+1. Walk every `.py` file under `src/ovp_pipeline/`.
+2. Parse string literals; flag any that match
+   ```regex
+   (?i)\b(INSERT|UPDATE|DELETE)\s+(OR\s+(IGNORE|REPLACE)\s+)?(INTO\s+)?(objects|provenance|claims|relations)\b
+   ```
+3. Allow the match only when the file is one of the owner modules listed above (`OWNER_FILES` constant in the test).
+4. Fail with a pointer to this doc on any other site.
+
+This catches *new* violations at PR-review time. Existing violations are tracked in this doc and removed in PR#2; once that lands, the test goes from advisory to strict.
+
+---
+
+## What this doc is not
+
+- Not about row-level locking. That's `withFileLock` / `knowledge_db_write_lock` / per-row PK serialization, all already in place.
+- Not about idempotence. Owners may or may not be idempotent; that's per-table policy (`upsert_provenance` is, `bulk_replace_objects` is not).
+- Not a constraint on *reads*. Any module can read any canonical table.
+- Not a constraint on derived / projection tables (see "Out of scope" above).

--- a/tests/test_architecture_fitness.py
+++ b/tests/test_architecture_fitness.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+import re
 from pathlib import Path
 
 import pytest
@@ -286,3 +287,119 @@ def test_readme_and_milestone_avoid_source_of_truth_language(repo_root):
     for path in docs:
         text = path.read_text(encoding="utf-8")
         assert "source of truth" not in text.lower()
+
+
+# ---------------------------------------------------------------------------
+# BL-060: single-writer invariant for canonical tables
+# ---------------------------------------------------------------------------
+#
+# See `docs/canonical-write-ownership.md` for the owner-module map.  Every
+# INSERT / UPDATE / DELETE against a canonical table (`objects`, `provenance`,
+# `claims`, `relations`) must originate from the table's owner module.  Other
+# modules call the owner's helper.
+#
+# Phase 1 (this PR): enumerate the audited violations as `KNOWN_BYPASS` and
+# assert no new sites get added.  Phase 2 (BL-060 PR#2): refactor the
+# violations and shrink `KNOWN_BYPASS` to empty.
+
+CANONICAL_TABLES = ("objects", "provenance", "claims", "relations")
+
+# Regex matches SQL strings that mutate a canonical table.  Tolerates:
+#   INSERT / UPDATE / DELETE
+#   INSERT OR IGNORE / INSERT OR REPLACE
+#   "INTO" optional (DELETE FROM, UPDATE table) — handled by the alternation
+_CANONICAL_WRITE_RE = re.compile(
+    r"\b(?:INSERT(?:\s+OR\s+(?:IGNORE|REPLACE))?\s+INTO|UPDATE|DELETE\s+FROM)\s+("
+    + "|".join(CANONICAL_TABLES)
+    + r")\b",
+    re.IGNORECASE,
+)
+
+# Files allowed to issue raw canonical-table SQL.  Anything else fails the test.
+# Refer to docs/canonical-write-ownership.md before adding new entries.
+OWNER_FILES = {
+    # Owner — provenance: existing helper handles every row.
+    "provenance.py",
+    # Owner candidates (BL-060 PR#2 will hoist into truth_store_writers / relation_writer):
+    "knowledge_index.py",         # rebuild's bulk inserts (objects, claims, relations, provenance)
+    "relation_promotion.py",      # _ensure_relation_row + replay_relation_promotions
+}
+
+# Tech-debt ratchet — these existing bypass sites are tracked here until BL-060 PR#2
+# refactors them.  When a site is removed, drop its entry; the test prevents new ones.
+KNOWN_BYPASS = {
+    # PR #185 root cause: backfill writes objects.source_url + provenance directly.
+    "commands/backfill_objects_source_url.py",
+}
+
+
+def test_canonical_writes_have_single_owner(repo_root):
+    """BL-060: only owner modules may issue raw INSERT/UPDATE/DELETE on
+    canonical tables.  Non-owner modules must call the owner's helper.
+
+    Phase 1 (this PR): the existing violations in ``KNOWN_BYPASS`` are
+    grandfathered; the test only catches *new* violations.  Phase 2 of
+    BL-060 (PR#2) refactors the bypass sites and shrinks the set to empty.
+    """
+    src = repo_root / "src" / "ovp_pipeline"
+    new_violations: list[str] = []
+    grandfathered_seen: set[str] = set()
+
+    for py in sorted(src.rglob("*.py")):
+        rel = str(py.relative_to(src))
+        if rel == "__init__.py" or rel.endswith("/__init__.py"):
+            continue
+        text = py.read_text(encoding="utf-8")
+        # Strip comments + docstrings to avoid flagging mentions of SQL in prose.
+        # Cheap heuristic: walk the AST and only inspect string literals.  Any
+        # docstring (the first stmt of a module / class / function body) is
+        # skipped via ``ast.get_docstring()``.
+        try:
+            tree = ast.parse(text)
+        except SyntaxError:
+            continue
+        sql_strings: list[str] = []
+        # Collect docstring node ids so we don't flag them.
+        doc_ids: set[int] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                if (
+                    node.body
+                    and isinstance(node.body[0], ast.Expr)
+                    and isinstance(node.body[0].value, ast.Constant)
+                    and isinstance(node.body[0].value.value, str)
+                ):
+                    doc_ids.add(id(node.body[0].value))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Constant) and isinstance(node.value, str):
+                if id(node) in doc_ids:
+                    continue
+                sql_strings.append(node.value)
+
+        joined = "\n".join(sql_strings)
+        if not _CANONICAL_WRITE_RE.search(joined):
+            continue
+
+        # File touches a canonical table.  Owner or grandfathered violation?
+        basename = py.name
+        if basename in OWNER_FILES:
+            continue
+        if rel in KNOWN_BYPASS:
+            grandfathered_seen.add(rel)
+            continue
+        new_violations.append(
+            f"{rel}: writes a canonical table but is neither an owner "
+            f"({sorted(OWNER_FILES)}) nor in KNOWN_BYPASS"
+        )
+
+    # Catch stale ratchet entries (file in KNOWN_BYPASS but no longer writes).
+    stale = sorted(KNOWN_BYPASS - grandfathered_seen)
+
+    assert not new_violations, (
+        "New canonical-write violations (see docs/canonical-write-ownership.md):\n"
+        + "\n".join(new_violations)
+    )
+    assert not stale, (
+        "KNOWN_BYPASS lists files that no longer write canonical tables; "
+        "remove them: " + ", ".join(stale)
+    )

--- a/tests/test_architecture_fitness.py
+++ b/tests/test_architecture_fitness.py
@@ -305,19 +305,31 @@ def test_readme_and_milestone_avoid_source_of_truth_language(repo_root):
 CANONICAL_TABLES = ("objects", "provenance", "claims", "relations")
 
 # Regex matches SQL strings that mutate a canonical table.  Tolerates:
-#   INSERT / UPDATE / DELETE
-#   INSERT OR IGNORE / INSERT OR REPLACE
-#   "INTO" optional (DELETE FROM, UPDATE table) — handled by the alternation
+#   INSERT / INSERT INTO / INSERT OR (IGNORE|REPLACE|ROLLBACK|ABORT|FAIL) INTO
+#   REPLACE INTO  — SQLite shorthand for INSERT OR REPLACE
+#   UPDATE / UPDATE OR (ROLLBACK|ABORT|REPLACE|FAIL|IGNORE)  — full SQLite UPDATE OR clause set
+#   DELETE FROM
+# The OR-clause alternation is permissive (any one-word identifier between
+# OR and INTO/table-name) so future SQLite variants still register.
 _CANONICAL_WRITE_RE = re.compile(
-    r"\b(?:INSERT(?:\s+OR\s+(?:IGNORE|REPLACE))?\s+INTO|UPDATE|DELETE\s+FROM)\s+("
+    r"\b(?:"
+    r"INSERT(?:\s+OR\s+\w+)?\s+INTO"
+    r"|REPLACE\s+INTO"
+    r"|UPDATE(?:\s+OR\s+\w+)?"
+    r"|DELETE\s+FROM"
+    r")\s+("
     + "|".join(CANONICAL_TABLES)
     + r")\b",
     re.IGNORECASE,
 )
 
 # Files allowed to issue raw canonical-table SQL.  Anything else fails the test.
+# Keys are repo-relative paths under ``src/ovp_pipeline/`` — basenames are
+# unsafe because we have ``commands/knowledge_index.py`` (CLI wrapper) and
+# ``knowledge_index.py`` (rebuild module) coexisting; matching by basename
+# would let the wrapper sneak through if it ever started writing.
 # Refer to docs/canonical-write-ownership.md before adding new entries.
-OWNER_FILES = {
+OWNER_FILES: set[str] = {
     # Owner — provenance: existing helper handles every row.
     "provenance.py",
     # Owner candidates (BL-060 PR#2 will hoist into truth_store_writers / relation_writer):
@@ -327,7 +339,7 @@ OWNER_FILES = {
 
 # Tech-debt ratchet — these existing bypass sites are tracked here until BL-060 PR#2
 # refactors them.  When a site is removed, drop its entry; the test prevents new ones.
-KNOWN_BYPASS = {
+KNOWN_BYPASS: set[str] = {
     # PR #185 root cause: backfill writes objects.source_url + provenance directly.
     "commands/backfill_objects_source_url.py",
 }
@@ -376,13 +388,18 @@ def test_canonical_writes_have_single_owner(repo_root):
                     continue
                 sql_strings.append(node.value)
 
-        joined = "\n".join(sql_strings)
-        if not _CANONICAL_WRITE_RE.search(joined):
+        # Search each string literal individually rather than joining them —
+        # joining with ``\n`` could glue a mutation verb at the end of one
+        # string to a canonical table name at the start of the next, producing
+        # phantom matches.
+        if not any(_CANONICAL_WRITE_RE.search(s) for s in sql_strings):
             continue
 
         # File touches a canonical table.  Owner or grandfathered violation?
-        basename = py.name
-        if basename in OWNER_FILES:
+        # Match against the relative path (rel), NOT py.name — basenames
+        # collide between top-level modules and their CLI wrappers under
+        # ``commands/``.
+        if rel in OWNER_FILES:
             continue
         if rel in KNOWN_BYPASS:
             grandfathered_seen.add(rel)


### PR DESCRIPTION
## Summary

Phase 1 of BL-060 (M18 Trust-Aware Compiler Hardening). Read-only / docs / lint — no business code touched; the owner-module hoist + bypass-site refactor lands in BL-060 PR#2.

## What's in this PR

**1. `docs/canonical-write-ownership.md`** — full audit of every INSERT/UPDATE/DELETE/INSERT-OR-IGNORE/INSERT-OR-REPLACE site against the four canonical tables (`objects`, `provenance`, `claims`, `relations`), the proposed owner map, and the post-refactor target.

**2. `tests/test_architecture_fitness.py::test_canonical_writes_have_single_owner`** — new fitness test:
- AST-walks every module under `src/ovp_pipeline/`, skips docstrings, regex-matches string literals against canonical-table mutations (handles `INSERT OR IGNORE/REPLACE` + `DELETE FROM` + multi-line)
- Owner files allowed; everything else fails unless explicitly grandfathered in `KNOWN_BYPASS`
- Stale `KNOWN_BYPASS` entries also fail (so shrinking it in PR#2 is enforced, not trusted)

## Audit results

| Severity | Site | Issue |
|---|---|---|
| **Critical** | `relations` table | 11 columns × 3 writers |
| **High** | `provenance` table | 8-column row × 2 writers (owner exists, bypassed) |
| **High** | `objects.source_url` | 2 writers — original PR #185 root cause |
| Clean | `claims` table | Single writer |

Five sites total. Three on `relations`, one on `provenance`, one bonus `UPDATE` on `objects.source_url`.

## What lands in PR#2

- Hoist `rebuild_knowledge_index`'s bulk inserts into a new `truth_store_writers` module
- Promote `_ensure_relation_row` to `relation_writer.upsert_relation`; rebuild + replay both call it
- Add `provenance.bulk_upsert_provenance` wrapper for the rebuild's executemany flush
- Refactor `commands/backfill_objects_source_url.py` to call the new owners
- Empty out `KNOWN_BYPASS`; tighten `OWNER_FILES` to the post-refactor modules

## Verification

- [x] `rtk proxy python -m pytest tests/test_architecture_fitness.py::test_canonical_writes_have_single_owner` → 1 passed
- [x] Regex sanity-checked against positive + negative cases
- [x] Pre-existing fitness failures (`test_file_size_limits`, `test_no_direct_sqlite_in_non_data_modules`) verified to be on main, not introduced by this PR
- [x] `rtk proxy ruff check tests/test_architecture_fitness.py` → clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added architecture documentation defining write ownership rules for canonical database tables.

* **Tests**
  * Added architecture fitness test to enforce single-writer invariant for canonical database operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fakechris/obsidian_vault_pipeline/pull/191)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->