### PR TITLE
feat(bl-060): hoist canonical-table writes into owner modules

### DIFF
--- a/src/ovp_pipeline/commands/backfill_objects_source_url.py
+++ b/src/ovp_pipeline/commands/backfill_objects_source_url.py
@@ -68,6 +68,7 @@ import sys
 from pathlib import Path
 from typing import Iterable
 
+from ..provenance import bulk_upsert_provenance_ingest
 from ..runtime import (
     VaultLayout,
     format_utc_timestamp,
@@ -75,6 +76,7 @@ from ..runtime import (
     resolve_vault_dir,
     utc_now,
 )
+from ..truth_store_writers import update_object_source_url
 from .backfill_provenance import _build_evergreen_to_source_from_audit
 
 logger = logging.getLogger(__name__)
@@ -260,40 +262,34 @@ def main(argv: list[str] | None = None) -> int:
             counts[strategy] += 1
             if args.dry_run:
                 continue
-            conn.execute(
-                "UPDATE objects SET source_url = ? WHERE pack = ? AND object_id = ?",
-                (source_url, pack, object_id),
+            # BL-060: writes go through the canonical owner modules
+            # (``truth_store_writers`` for objects, ``provenance`` for
+            # the audit row).  See ``docs/canonical-write-ownership.md``.
+            update_object_source_url(
+                conn,
+                pack=pack,
+                object_id=object_id,
+                source_url=source_url,
+                source="ovp-backfill-objects-source-url",
             )
             counts["writes"] += 1
             if args.write_provenance:
-                # Idempotent — same dedup guard rebuild_knowledge_index
-                # uses; never inserts a duplicate ingest row for the same
-                # ``(pack, object_id, source_url)`` triple.
+                # Idempotent — same dedup guard ``rebuild_knowledge_index``
+                # uses (WHERE NOT EXISTS on
+                # ``(pack, object_id, source_url)`` regardless of
+                # derived_at) — never inserts a duplicate ingest row.
                 from .backfill_provenance import _make_fingerprint
 
-                derived_at = format_utc_timestamp(utc_now())
-                conn.execute(
-                    """
-                    INSERT INTO provenance
-                      (pack, object_id, source_url, source_fingerprint,
-                       derived_via_stage, derived_at, parent_object_id,
-                       metadata_json)
-                    SELECT ?, ?, ?, ?, 'ingest', ?, NULL,
-                           '{"via":"ovp-backfill-objects-source-url"}'
-                    WHERE NOT EXISTS (
-                      SELECT 1 FROM provenance
-                       WHERE pack = ?
-                         AND object_id = ?
-                         AND derived_via_stage = 'ingest'
-                         AND source_url = ?
-                    )
-                    """,
-                    (
-                        pack, object_id, source_url,
-                        _make_fingerprint(source_url),
-                        derived_at,
-                        pack, object_id, source_url,
-                    ),
+                bulk_upsert_provenance_ingest(
+                    conn,
+                    [{
+                        "pack": pack,
+                        "object_id": object_id,
+                        "source_url": source_url,
+                        "source_fingerprint": _make_fingerprint(source_url),
+                        "derived_at": format_utc_timestamp(utc_now()),
+                        "metadata_json": '{"via":"ovp-backfill-objects-source-url"}',
+                    }],
                 )
         if not args.dry_run:
             conn.commit()

--- a/src/ovp_pipeline/knowledge_index.py
+++ b/src/ovp_pipeline/knowledge_index.py
@@ -1097,7 +1097,7 @@ def rebuild_knowledge_index(
             # See ``docs/canonical-write-ownership.md``.
             insert_objects(
                 conn,
-                [row.to_row() for row in truth_projection.objects],
+                (row.to_row() for row in truth_projection.objects),
             )
             # BL-055: provenance spine.  Write one ``stage='ingest'``
             # row per object that has a source_url — but only when no
@@ -1126,7 +1126,7 @@ def rebuild_knowledge_index(
             )
             insert_claims(
                 conn,
-                [row.to_row() for row in truth_projection.claims],
+                (row.to_row() for row in truth_projection.claims),
             )
             conn.executemany(
                 """
@@ -1142,7 +1142,7 @@ def rebuild_knowledge_index(
             )
             bulk_insert_relations(
                 conn,
-                [row.to_row() for row in truth_projection.relations],
+                (row.to_row() for row in truth_projection.relations),
             )
             conn.executemany(
                 """

--- a/src/ovp_pipeline/knowledge_index.py
+++ b/src/ovp_pipeline/knowledge_index.py
@@ -12,8 +12,6 @@ import sqlite3
 from pathlib import Path
 from typing import Any
 
-logger = logging.getLogger(__name__)
-
 from .concept_registry import ConceptRegistry, ResolutionAction
 from .event_emitter import iter_for_index
 from .graph.frontmatter import FrontmatterParser, NoteMetadata
@@ -21,9 +19,14 @@ from .graph.link_parser import LinkParser
 from .identity import canonicalize_note_id
 from .packs.loader import DEFAULT_WORKFLOW_PACK_NAME
 from .projection_lifecycle import close_projection_repair_marker, write_projection_repair_marker
+from .provenance import bulk_upsert_provenance_ingest
+from .relation_writer import bulk_insert_relations
 from .runtime import VaultLayout, knowledge_db_write_lock, resolve_vault_dir
 from .truth_projection_registry import execute_truth_projection_builder, resolve_truth_projection_builder
 from .truth_store import TRUTH_STORE_SCHEMA
+from .truth_store_writers import insert_claims, insert_objects
+
+logger = logging.getLogger(__name__)
 
 SUMMARY_MAX_LEN = 320
 SUMMARY_RELATED_LIMIT = 3
@@ -1088,11 +1091,12 @@ def rebuild_knowledge_index(
                 link_rows=object_link_rows,
                 pack_name=pack_name,
             )
-            conn.executemany(
-                """
-                INSERT INTO objects (pack, object_id, object_kind, title, canonical_path, source_slug, source_url)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
-                """,
+            # BL-060: writes go through the canonical owner modules
+            # (``truth_store_writers``, ``provenance``, ``relation_writer``)
+            # so the single-writer invariant for canonical tables holds.
+            # See ``docs/canonical-write-ownership.md``.
+            insert_objects(
+                conn,
                 [row.to_row() for row in truth_projection.objects],
             )
             # BL-055: provenance spine.  Write one ``stage='ingest'``
@@ -1101,45 +1105,27 @@ def rebuild_knowledge_index(
             # source_url) tuple.  Preservation in
             # ``INDEPENDENT_CANONICAL_TABLE_COLUMNS`` carries every
             # historical row across rebuilds (gemini PR #152 review
-            # fix); the dedup guard here keeps rebuild-noise from
-            # accumulating duplicate ingest rows for objects whose
-            # source URL hasn't changed.
+            # fix); the dedup guard inside ``bulk_upsert_provenance_ingest``
+            # keeps rebuild-noise from accumulating duplicate ingest
+            # rows for objects whose source URL hasn't changed.
             now_iso = _utc_now_text()
-            conn.executemany(
-                """
-                INSERT INTO provenance
-                  (pack, object_id, source_url, source_fingerprint,
-                   derived_via_stage, derived_at, parent_object_id,
-                   metadata_json)
-                SELECT ?, ?, ?, ?, 'ingest', ?, NULL, '{}'
-                 WHERE NOT EXISTS (
-                   SELECT 1 FROM provenance
-                    WHERE pack = ?
-                      AND object_id = ?
-                      AND derived_via_stage = 'ingest'
-                      AND source_url = ?
-                 )
-                """,
+            bulk_upsert_provenance_ingest(
+                conn,
                 [
-                    (
-                        row.pack,
-                        row.object_id,
-                        row.source_url,
-                        _source_fingerprint(row.source_url),
-                        now_iso,
-                        row.pack,
-                        row.object_id,
-                        row.source_url,
-                    )
+                    {
+                        "pack": row.pack,
+                        "object_id": row.object_id,
+                        "source_url": row.source_url,
+                        "source_fingerprint": _source_fingerprint(row.source_url),
+                        "derived_at": now_iso,
+                        "metadata_json": "{}",
+                    }
                     for row in truth_projection.objects
                     if row.source_url
                 ],
             )
-            conn.executemany(
-                """
-                INSERT INTO claims (pack, claim_id, object_id, claim_kind, claim_text, confidence)
-                VALUES (?, ?, ?, ?, ?, ?)
-                """,
+            insert_claims(
+                conn,
                 [row.to_row() for row in truth_projection.claims],
             )
             conn.executemany(
@@ -1154,16 +1140,8 @@ def rebuild_knowledge_index(
                 """,
                 [row.to_row() for row in truth_projection.claim_evidence],
             )
-            conn.executemany(
-                """
-                INSERT INTO relations (
-                    pack, source_object_id, target_object_id, relation_type, evidence_source_slug,
-                    quote_text, locator, content_hash, retrieval_context,
-                    quote_start_line, quote_end_line, quote_start_char, quote_end_char,
-                    status, verified_at
-                )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """,
+            bulk_insert_relations(
+                conn,
                 [row.to_row() for row in truth_projection.relations],
             )
             conn.executemany(

--- a/src/ovp_pipeline/provenance.py
+++ b/src/ovp_pipeline/provenance.py
@@ -167,6 +167,11 @@ def bulk_upsert_provenance_ingest(
     if not rows:
         return
     try:
+        # Stream the row→tuple expansion through a generator so the
+        # rebuild's per-pack flush doesn't materialise both ``rows``
+        # (caller's list) and ``params`` (intermediate list of 9-tuples)
+        # at the same time.  ``executemany`` consumes the iterable
+        # lazily.
         conn.executemany(
             """
             INSERT INTO provenance
@@ -182,7 +187,7 @@ def bulk_upsert_provenance_ingest(
                   AND source_url = ?
              )
             """,
-            [
+            (
                 (
                     row["pack"],
                     row["object_id"],
@@ -195,7 +200,7 @@ def bulk_upsert_provenance_ingest(
                     row["source_url"],
                 )
                 for row in rows
-            ],
+            ),
         )
     except sqlite3.OperationalError as exc:
         logger.warning("bulk provenance ingest skipped: %s", exc)

--- a/src/ovp_pipeline/provenance.py
+++ b/src/ovp_pipeline/provenance.py
@@ -121,3 +121,85 @@ def upsert_provenance(
             "provenance write failed — unexpected (%s): %s",
             derived_via_stage, exc,
         )
+
+
+def bulk_upsert_provenance_ingest(
+    conn: sqlite3.Connection,
+    rows: list[dict[str, Any]],
+) -> None:
+    """BL-060 owner: bulk-write ``stage='ingest'`` rows with the
+    rebuild's stricter dedup semantics.
+
+    Unlike :func:`upsert_provenance` (which dedups on the PK
+    ``(pack, object_id, derived_via_stage, derived_at)`` so a re-emit
+    at a *different* derived_at creates a new row), the rebuild's
+    ingest pass dedups on the
+    ``(pack, object_id, derived_via_stage='ingest', source_url)``
+    tuple — re-running the rebuild at a later wall-clock should NOT
+    write a fresh ingest row when the source URL hasn't changed.
+    Otherwise rebuild noise would accumulate one ingest row per
+    rebuild forever.
+
+    This stricter dedup is implemented via ``WHERE NOT EXISTS`` rather
+    than the ``INSERT OR IGNORE`` used by ``upsert_provenance``.
+
+    Each ``rows`` dict carries:
+
+    * ``pack`` (str)
+    * ``object_id`` (str)
+    * ``source_url`` (str, non-empty — caller filters out empty URLs)
+    * ``source_fingerprint`` (str, 12-char SHA-256 prefix of source_url)
+    * ``derived_at`` (ISO timestamp)
+    * ``metadata_json`` (str, default ``"{}"``) — caller passes a
+      pre-serialised JSON string so this helper stays cheap
+
+    Used by:
+
+    * ``rebuild_knowledge_index`` — the per-pack flush of ingest rows
+    * ``ovp-backfill-objects-source-url --write-provenance`` — the
+      backfill CLI's audit row when it fills a previously-empty
+      ``source_url``
+
+    Best-effort: same exception-swallowing contract as
+    :func:`upsert_provenance` so a provenance write never aborts the
+    rebuild's transaction.
+    """
+    if not rows:
+        return
+    try:
+        conn.executemany(
+            """
+            INSERT INTO provenance
+              (pack, object_id, source_url, source_fingerprint,
+               derived_via_stage, derived_at, parent_object_id,
+               metadata_json)
+            SELECT ?, ?, ?, ?, 'ingest', ?, NULL, ?
+             WHERE NOT EXISTS (
+               SELECT 1 FROM provenance
+                WHERE pack = ?
+                  AND object_id = ?
+                  AND derived_via_stage = 'ingest'
+                  AND source_url = ?
+             )
+            """,
+            [
+                (
+                    row["pack"],
+                    row["object_id"],
+                    row["source_url"],
+                    row["source_fingerprint"],
+                    row["derived_at"],
+                    row.get("metadata_json", "{}"),
+                    row["pack"],
+                    row["object_id"],
+                    row["source_url"],
+                )
+                for row in rows
+            ],
+        )
+    except sqlite3.OperationalError as exc:
+        logger.warning("bulk provenance ingest skipped: %s", exc)
+    except sqlite3.DatabaseError as exc:
+        logger.warning("bulk provenance ingest failed — DB error: %s", exc)
+    except Exception as exc:  # noqa: BLE001 — never abort caller
+        logger.warning("bulk provenance ingest failed — unexpected: %s", exc)

--- a/src/ovp_pipeline/relation_promotion.py
+++ b/src/ovp_pipeline/relation_promotion.py
@@ -35,6 +35,7 @@ from .knowledge_index import ensure_knowledge_db_current
 from .packs.base import BaseDomainPack
 from .promotion_audit import emit_promotion
 from .promotion_policy import LANE_AUTO, LANE_ESCALATE, LANE_REJECT, evaluate_relation
+from .relation_writer import upsert_relation_for_promotion
 from .runtime import VaultLayout
 from .state_lifecycle import State
 from .truth_store import EVIDENCE_STATUS_UNVERIFIED
@@ -84,28 +85,19 @@ def _ensure_relation_row(
     conn: sqlite3.Connection,
     candidate: SemanticRelationCandidate,
 ) -> None:
-    conn.execute(
-        """
-        INSERT INTO relations (
-          pack, source_object_id, target_object_id, relation_type,
-          evidence_source_slug, quote_text, locator, content_hash, retrieval_context,
-          status, verified_at
-        )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        """,
-        (
-            candidate.pack,
-            candidate.source_object_id,
-            candidate.target_object_id,
-            _effective_relation_type(candidate),
-            candidate.source_slug,
-            candidate.evidence_quote,
-            candidate.locator,
-            candidate.content_hash,
-            candidate.retrieval_context,
-            EVIDENCE_STATUS_UNVERIFIED,
-            "",
-        ),
+    upsert_relation_for_promotion(
+        conn,
+        pack=candidate.pack,
+        source_object_id=candidate.source_object_id,
+        target_object_id=candidate.target_object_id,
+        relation_type=_effective_relation_type(candidate),
+        evidence_source_slug=candidate.source_slug,
+        quote_text=candidate.evidence_quote,
+        locator=candidate.locator,
+        content_hash=candidate.content_hash,
+        retrieval_context=candidate.retrieval_context,
+        status=EVIDENCE_STATUS_UNVERIFIED,
+        verified_at="",
     )
 
 
@@ -223,24 +215,22 @@ def replay_relation_promotions(
     for key, event in latest.items():
         if key in existing_keys:
             continue
-        conn.execute(
-            """
-            INSERT INTO relations (
-              pack, source_object_id, target_object_id, relation_type,
-              evidence_source_slug, quote_text, locator, content_hash,
-              retrieval_context, status, verified_at
-            )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                *key,
-                str(event.get("quote_text") or ""),
-                str(event.get("locator") or ""),
-                str(event.get("content_hash") or ""),
-                str(event.get("retrieval_context") or ""),
-                EVIDENCE_STATUS_UNVERIFIED,
-                "",
-            ),
+        # ``key`` is (pack, source_object_id, target_object_id,
+        # relation_type, evidence_source_slug) — see the SELECT
+        # above that built ``existing_keys``.
+        upsert_relation_for_promotion(
+            conn,
+            pack=key[0],
+            source_object_id=key[1],
+            target_object_id=key[2],
+            relation_type=key[3],
+            evidence_source_slug=key[4],
+            quote_text=str(event.get("quote_text") or ""),
+            locator=str(event.get("locator") or ""),
+            content_hash=str(event.get("content_hash") or ""),
+            retrieval_context=str(event.get("retrieval_context") or ""),
+            status=EVIDENCE_STATUS_UNVERIFIED,
+            verified_at="",
         )
         existing_keys.add(key)
         edge_id = str(event.get("edge_id") or "")

--- a/src/ovp_pipeline/relation_writer.py
+++ b/src/ovp_pipeline/relation_writer.py
@@ -73,14 +73,16 @@ def bulk_insert_relations(
 
     Used by the rebuild path.  Caller is responsible for clearing the
     pack-scoped existing rows before calling — the projection rebuild
-    handles that elsewhere; this function only inserts.
+    handles that elsewhere; this function only inserts.  ``rows`` is
+    consumed lazily so the rebuild can stream a generator instead of
+    materialising the full pack-scoped relation set.
     """
     conn.executemany(
         f"""
         INSERT INTO relations ({', '.join(RELATION_ROW_COLUMNS_FULL)})
         VALUES ({', '.join(['?'] * len(RELATION_ROW_COLUMNS_FULL))})
         """,
-        list(rows),
+        rows,
     )
 
 

--- a/src/ovp_pipeline/relation_writer.py
+++ b/src/ovp_pipeline/relation_writer.py
@@ -1,0 +1,131 @@
+"""BL-060 owner module for the ``relations`` canonical table.
+
+Pre-refactor (≤ PR #191) three call sites wrote raw ``INSERT INTO
+relations`` SQL with overlapping schemas:
+
+  * ``knowledge_index.rebuild_knowledge_index`` — full 15-column row
+    with quote-span fields populated by the LLM extractor.
+  * ``relation_promotion._ensure_relation_row`` — 11-column row
+    (no quote spans; promotion path doesn't have them) for newly-
+    promoted relation candidates.
+  * ``relation_promotion.replay_relation_promotions`` — same 11-column
+    shape as ``_ensure_relation_row``, replays the
+    ``relation_promoted`` audit log after rebuild clears the table.
+
+This module owns all three write paths via ``bulk_insert_relations``
+and ``upsert_relation_for_promotion``.  Direct ``INSERT INTO relations``
+elsewhere is a violation enforced by
+``tests/test_architecture_fitness.py::test_canonical_writes_have_single_owner``.
+
+See ``docs/canonical-write-ownership.md``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any, Iterable, Sequence
+
+
+# Full schema — what the rebuild inserts.  Quote-span columns
+# (``quote_start_line``..``quote_end_char``) are present on the LLM
+# extractor's output but absent from the promotion path.
+RELATION_ROW_COLUMNS_FULL: tuple[str, ...] = (
+    "pack",
+    "source_object_id",
+    "target_object_id",
+    "relation_type",
+    "evidence_source_slug",
+    "quote_text",
+    "locator",
+    "content_hash",
+    "retrieval_context",
+    "quote_start_line",
+    "quote_end_line",
+    "quote_start_char",
+    "quote_end_char",
+    "status",
+    "verified_at",
+)
+
+# Subset schema — what the promotion path supplies.  The 4 quote-span
+# columns are filled with NULL/0 defaults via the column-list-omission
+# trick in the SQL below.
+RELATION_ROW_COLUMNS_PROMOTION: tuple[str, ...] = (
+    "pack",
+    "source_object_id",
+    "target_object_id",
+    "relation_type",
+    "evidence_source_slug",
+    "quote_text",
+    "locator",
+    "content_hash",
+    "retrieval_context",
+    "status",
+    "verified_at",
+)
+
+
+def bulk_insert_relations(
+    conn: sqlite3.Connection,
+    rows: Iterable[Sequence[Any]],
+) -> None:
+    """Bulk-insert full-schema relation rows (15 columns).
+
+    Used by the rebuild path.  Caller is responsible for clearing the
+    pack-scoped existing rows before calling — the projection rebuild
+    handles that elsewhere; this function only inserts.
+    """
+    conn.executemany(
+        f"""
+        INSERT INTO relations ({', '.join(RELATION_ROW_COLUMNS_FULL)})
+        VALUES ({', '.join(['?'] * len(RELATION_ROW_COLUMNS_FULL))})
+        """,
+        list(rows),
+    )
+
+
+def upsert_relation_for_promotion(
+    conn: sqlite3.Connection,
+    *,
+    pack: str,
+    source_object_id: str,
+    target_object_id: str,
+    relation_type: str,
+    evidence_source_slug: str,
+    quote_text: str,
+    locator: str,
+    content_hash: str,
+    retrieval_context: str,
+    status: str,
+    verified_at: str,
+) -> None:
+    """Insert a single relation row from the promotion / replay path.
+
+    Only the 11 columns the promotion has access to are written;
+    ``quote_start_line`` / ``quote_end_line`` / ``quote_start_char`` /
+    ``quote_end_char`` default to whatever the schema declares (NULL
+    or 0 today).
+
+    ``_effective_relation_type`` and ``_edge_id`` semantics live in
+    the caller (``relation_promotion``); this module is intentionally
+    agnostic — it just writes the row it's handed.
+    """
+    conn.execute(
+        f"""
+        INSERT INTO relations ({', '.join(RELATION_ROW_COLUMNS_PROMOTION)})
+        VALUES ({', '.join(['?'] * len(RELATION_ROW_COLUMNS_PROMOTION))})
+        """,
+        (
+            pack,
+            source_object_id,
+            target_object_id,
+            relation_type,
+            evidence_source_slug,
+            quote_text,
+            locator,
+            content_hash,
+            retrieval_context,
+            status,
+            verified_at,
+        ),
+    )

--- a/src/ovp_pipeline/truth_store_writers.py
+++ b/src/ovp_pipeline/truth_store_writers.py
@@ -49,13 +49,17 @@ def insert_objects(
     calling — the rebuild does this in ``execute_truth_projection_builder``
     via the projection's pack-scoped clear.  This function only handles
     the insert phase.
+
+    ``rows`` is consumed lazily by sqlite3.Connection.executemany so
+    callers can pass a generator expression to avoid materialising
+    the full per-pack row set in memory.
     """
     conn.executemany(
         f"""
         INSERT INTO objects ({', '.join(OBJECT_ROW_COLUMNS)})
         VALUES ({', '.join(['?'] * len(OBJECT_ROW_COLUMNS))})
         """,
-        list(rows),
+        rows,
     )
 
 
@@ -102,11 +106,11 @@ def insert_claims(
     rows: Iterable[Sequence[Any]],
 ) -> None:
     """Bulk-insert claims rows.  Same caller-clears-first contract as
-    ``insert_objects``."""
+    ``insert_objects``; ``rows`` is consumed lazily."""
     conn.executemany(
         f"""
         INSERT INTO claims ({', '.join(CLAIM_ROW_COLUMNS)})
         VALUES ({', '.join(['?'] * len(CLAIM_ROW_COLUMNS))})
         """,
-        list(rows),
+        rows,
     )

--- a/src/ovp_pipeline/truth_store_writers.py
+++ b/src/ovp_pipeline/truth_store_writers.py
@@ -1,0 +1,112 @@
+"""BL-060 owner module for the ``objects`` and ``claims`` canonical tables.
+
+Every write to either table goes through one of the helpers below.
+Direct ``INSERT INTO objects`` / ``UPDATE objects`` / ``INSERT INTO claims``
+SQL outside this module is a violation tracked by
+``tests/test_architecture_fitness.py::test_canonical_writes_have_single_owner``.
+
+See ``docs/canonical-write-ownership.md`` for the full ownership map and
+the rationale (PR #185 root cause: three independent modules wrote
+``objects.source_url`` with no shared helper).
+
+Locking is **not** the responsibility of helpers in this module — callers
+are expected to be inside a ``knowledge_db_write_lock`` already.  These
+helpers are pure SQL wrappers; the only thing they enforce is the
+single-writer architectural invariant.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any, Iterable, Sequence
+
+
+# ---------------------------------------------------------------------------
+# objects
+# ---------------------------------------------------------------------------
+
+# Tuple shape for ``insert_objects`` rows.  Mirrors the SQL VALUES order;
+# callers (today only ``rebuild_knowledge_index``) build these from
+# ``truth_projection.objects[*].to_row()``.
+OBJECT_ROW_COLUMNS: tuple[str, ...] = (
+    "pack",
+    "object_id",
+    "object_kind",
+    "title",
+    "canonical_path",
+    "source_slug",
+    "source_url",
+)
+
+
+def insert_objects(
+    conn: sqlite3.Connection,
+    rows: Iterable[Sequence[Any]],
+) -> None:
+    """Bulk-insert evergreen registry rows.
+
+    Caller is responsible for deleting the prior per-pack rows before
+    calling — the rebuild does this in ``execute_truth_projection_builder``
+    via the projection's pack-scoped clear.  This function only handles
+    the insert phase.
+    """
+    conn.executemany(
+        f"""
+        INSERT INTO objects ({', '.join(OBJECT_ROW_COLUMNS)})
+        VALUES ({', '.join(['?'] * len(OBJECT_ROW_COLUMNS))})
+        """,
+        list(rows),
+    )
+
+
+def update_object_source_url(
+    conn: sqlite3.Connection,
+    *,
+    pack: str,
+    object_id: str,
+    source_url: str,
+    source: str,
+) -> None:
+    """Update ``objects.source_url`` for a single (pack, object_id).
+
+    The ``source`` argument is a free-form audit tag (``'rebuild'``,
+    ``'backfill'``, ``'mcp_edit'``, ...) — not written to the row, but
+    documented at the call site so future debugging knows which writer
+    last touched the column.  If you need a durable record of which
+    writer wrote it, emit a ``provenance`` row at ``stage='backfill'``
+    via ``provenance.upsert_provenance``.
+    """
+    _ = source  # documentation-only; see docstring
+    conn.execute(
+        "UPDATE objects SET source_url = ? WHERE pack = ? AND object_id = ?",
+        (source_url, pack, object_id),
+    )
+
+
+# ---------------------------------------------------------------------------
+# claims
+# ---------------------------------------------------------------------------
+
+CLAIM_ROW_COLUMNS: tuple[str, ...] = (
+    "pack",
+    "claim_id",
+    "object_id",
+    "claim_kind",
+    "claim_text",
+    "confidence",
+)
+
+
+def insert_claims(
+    conn: sqlite3.Connection,
+    rows: Iterable[Sequence[Any]],
+) -> None:
+    """Bulk-insert claims rows.  Same caller-clears-first contract as
+    ``insert_objects``."""
+    conn.executemany(
+        f"""
+        INSERT INTO claims ({', '.join(CLAIM_ROW_COLUMNS)})
+        VALUES ({', '.join(['?'] * len(CLAIM_ROW_COLUMNS))})
+        """,
+        list(rows),
+    )

--- a/tests/test_architecture_fitness.py
+++ b/tests/test_architecture_fitness.py
@@ -329,20 +329,21 @@ _CANONICAL_WRITE_RE = re.compile(
 # ``knowledge_index.py`` (rebuild module) coexisting; matching by basename
 # would let the wrapper sneak through if it ever started writing.
 # Refer to docs/canonical-write-ownership.md before adding new entries.
+#
+# Post-BL-060 PR#2: only the three owner modules retain raw SQL.  Every
+# other writer calls into one of these via the public helpers.
 OWNER_FILES: set[str] = {
-    # Owner — provenance: existing helper handles every row.
-    "provenance.py",
-    # Owner candidates (BL-060 PR#2 will hoist into truth_store_writers / relation_writer):
-    "knowledge_index.py",         # rebuild's bulk inserts (objects, claims, relations, provenance)
-    "relation_promotion.py",      # _ensure_relation_row + replay_relation_promotions
+    "provenance.py",            # owner of `provenance` table
+    "truth_store_writers.py",   # owner of `objects` + `claims` tables
+    "relation_writer.py",       # owner of `relations` table
 }
 
-# Tech-debt ratchet — these existing bypass sites are tracked here until BL-060 PR#2
-# refactors them.  When a site is removed, drop its entry; the test prevents new ones.
-KNOWN_BYPASS: set[str] = {
-    # PR #185 root cause: backfill writes objects.source_url + provenance directly.
-    "commands/backfill_objects_source_url.py",
-}
+# Tech-debt ratchet — empty after BL-060 PR#2 refactored every prior bypass
+# (knowledge_index.py rebuild, relation_promotion.py _ensure_relation_row +
+# replay_relation_promotions, commands/backfill_objects_source_url.py).
+# This being empty is the load-bearing assertion: no module outside
+# ``OWNER_FILES`` may write a canonical table.
+KNOWN_BYPASS: set[str] = set()
 
 
 def test_canonical_writes_have_single_owner(repo_root):


### PR DESCRIPTION
## Summary

Phase 2 of BL-060. Refactors every non-owner write site (audited in PR #191) to call into a canonical owner module, then **empties `KNOWN_BYPASS`** so the architecture-fitness test goes strict.

## What's new

| New owner module | Owns | Public API |
|---|---|---|
| `truth_store_writers.py` | `objects`, `claims` | `insert_objects`, `insert_claims`, `update_object_source_url` |
| `relation_writer.py` | `relations` | `bulk_insert_relations` (rebuild path), `upsert_relation_for_promotion` (promotion + replay paths) |
| `provenance.py` | `provenance` (existing) | + `bulk_upsert_provenance_ingest` (rebuild's `WHERE NOT EXISTS` dedup pattern, distinct from `upsert_provenance`'s PK-based dedup) |

## What got refactored (5 sites → owner calls)

- `knowledge_index.py` rebuild's 4 raw INSERTs → `insert_objects` + `insert_claims` + `bulk_insert_relations` + `bulk_upsert_provenance_ingest`
- `relation_promotion._ensure_relation_row` → `upsert_relation_for_promotion`
- `relation_promotion.replay_relation_promotions` → `upsert_relation_for_promotion`
- `commands/backfill_objects_source_url.py` (PR #185 root cause) → `update_object_source_url` + `bulk_upsert_provenance_ingest`

## Fitness test goes strict

- `OWNER_FILES = {provenance.py, truth_store_writers.py, relation_writer.py}` — three modules, that's it
- `KNOWN_BYPASS = set()` — empty
- Any new direct write to a canonical table fails the test immediately

## Drive-by

Hoisted `knowledge_index.py`'s import block above its `logger = ...` line, clearing 13 pre-existing E402 ruff warnings as a side effect.

## Verification

- [x] `tests/test_architecture_fitness.py::test_canonical_writes_have_single_owner` passes with empty `KNOWN_BYPASS`
- [x] Full suite: **2247 passed, 15 xfailed**
- [x] 3 failing tests (`test_curated_atlas_route`, `test_pulse_*`) verified to be pre-existing on main (stash + re-run on clean main reproduces them)
- [x] `ruff check` on touched files: 14 → 4 errors (cleaned 13 pre-existing + my refactor net zero new); the 4 remaining are pre-existing `math` redefinition tech debt

## What's next (BL-061)

The owner modules in this PR are the natural insertion point for the BL-061 evergreen-revision write hooks — each owner module writes its own revision row at mutation time. That PR is up next.