### PR TITLE
feat(bl-062): wire route_source into extractor as shadow mode (PR#3)

### DIFF
--- a/src/ovp_pipeline/auto_evergreen_extractor.py
+++ b/src/ovp_pipeline/auto_evergreen_extractor.py
@@ -622,7 +622,14 @@ class EvergreenExtractor:
         or a registry/import failure.
         """
         try:
-            from .absorb_router import route_source
+            # Match the relative-vs-absolute import fallback the rest
+            # of this file uses (see lines 30-44) so a direct
+            # ``python3 auto_evergreen_extractor.py`` invocation
+            # doesn't ImportError.
+            try:
+                from .absorb_router import route_source
+            except ImportError:
+                from absorb_router import route_source  # type: ignore[no-redef]
 
             route_source(
                 self.llm,

--- a/src/ovp_pipeline/auto_evergreen_extractor.py
+++ b/src/ovp_pipeline/auto_evergreen_extractor.py
@@ -345,6 +345,8 @@ class EvergreenExtractor:
         llm_client: LiteLLMClient,
         logger: PipelineLogger,
         vault_dir: Path | None = None,
+        *,
+        enable_router_shadow: bool | None = None,
     ):
         self.llm = llm_client
         self.logger = logger
@@ -354,6 +356,28 @@ class EvergreenExtractor:
         # data — so the prompt block silently disappears on a fresh
         # vault.
         self._entity_prime_block: str | None = None
+
+        # BL-062 PR#3: shadow-mode router.  When enabled, every
+        # ``extract_concepts`` call ALSO issues a Pass 1 router call
+        # (in addition to the legacy v2 monolithic extract) and emits
+        # an ``absorb_route_decision`` audit row.  The router decision
+        # is NOT yet used to drive extraction — that's a future PR
+        # once we have audit data showing the router's parse rate +
+        # decision quality on the live vault.
+        #
+        # Cost: shadow mode roughly **doubles** the per-source LLM
+        # spend (one extra Pass 1 call) since the router and v2
+        # extractor both fire.  Default off; set
+        # ``OVP_ABSORB_ROUTER_SHADOW=1`` (or pass
+        # ``enable_router_shadow=True``) to opt in for measurement
+        # runs.  Constructor argument wins over env var.
+        if enable_router_shadow is None:
+            self.enable_router_shadow = (
+                os.environ.get("OVP_ABSORB_ROUTER_SHADOW", "").strip().lower()
+                in {"1", "true", "yes", "on"}
+            )
+        else:
+            self.enable_router_shadow = bool(enable_router_shadow)
 
     def _load_entity_prime_block(self) -> str:
         """Render the top-N entity aliases into a compact prompt block.
@@ -571,6 +595,15 @@ class EvergreenExtractor:
 具体可抽取的东西(只是观点反复 / 没有数字或案例 / 全部是常识),返回
 ``{{"units": [], "skip_reason": "..."}}`` 是被鼓励的输出。"""
 
+        # BL-062 PR#3: shadow-mode router.  Runs *before* the legacy
+        # v2 extract so the router sees the same content; failures
+        # are swallowed inside ``route_source`` (audit-only contract)
+        # so this can never affect the legacy path.  Cost: one extra
+        # LLM call per source — see ``__init__`` docstring on
+        # ``enable_router_shadow``.
+        if self.enable_router_shadow:
+            self._run_router_shadow(file_path=file_path, content=content)
+
         result_text = self.llm.generate(
             system_prompt=self.SYSTEM_PROMPT,
             user_prompt=user_prompt,
@@ -578,6 +611,35 @@ class EvergreenExtractor:
         )
 
         return self._parse_v2_response(result_text, file_path)
+
+    def _run_router_shadow(self, *, file_path: Path, content: str) -> None:
+        """Issue a Pass 1 router call alongside the legacy v2 extract.
+
+        Best-effort: any exception caught here is logged via
+        ``absorb_router_shadow_error`` and swallowed.  ``route_source``
+        already has its own audit-on-failure contract, so the only
+        thing that should escape is a programming bug in this wrapper
+        or a registry/import failure.
+        """
+        try:
+            from .absorb_router import route_source
+
+            route_source(
+                self.llm,
+                source_path=str(file_path),
+                source_content=content,
+                pipeline_logger=self.logger,
+                vault_dir=self.vault_dir,
+                # ``pack_name=None`` matches the legacy extractor's
+                # cross-pack search semantics.  Future PRs may want
+                # pack-scoped routing for multi-pack vaults.
+                pack_name=None,
+            )
+        except Exception as exc:  # noqa: BLE001 — shadow must never break legacy path
+            self.logger.log("absorb_router_shadow_error", {
+                "source": str(file_path),
+                "error": str(exc),
+            })
 
     def _parse_v2_response(self, result_text: str, file_path: Path) -> list[dict]:
         """Parse the v2 JSON wrapper into the legacy concept-dict shape

--- a/tests/test_absorb_router_shadow.py
+++ b/tests/test_absorb_router_shadow.py
@@ -1,0 +1,279 @@
+"""BL-062 PR#3: shadow-mode integration of ``route_source`` into
+``EvergreenExtractor``.
+
+The shadow flag (``enable_router_shadow`` constructor arg, or
+``OVP_ABSORB_ROUTER_SHADOW`` env var) makes every
+``extract_concepts`` call ALSO issue a Pass 1 router call alongside
+the legacy v2 monolithic extract.  The router's decision is logged
+via ``absorb_route_decision`` audit but is NOT yet used to drive
+extraction — that's a future PR.
+
+These tests verify the shadow integration:
+
+* default-off contract — no extra LLM call when flag is off
+* on contract — router runs, audit row emitted
+* env var enables when constructor arg is None
+* router failures must NOT break legacy extraction (best-effort)
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+_GOLDEN_ROUTER_RESPONSE = json.dumps({
+    "source_value_summary": "Article on LLM eval methodology.",
+    "updates": [{
+        "slug": "llm-eval-leakage",
+        "rationale": "Source paragraphs cover test contamination.",
+        "evidence_segments": ["para 5"],
+    }],
+    "creates": [],
+    "skip_reason": "",
+})
+
+# Legacy v2 extract response shape — minimal valid wrapper.  We use
+# this for every "v2 call should still happen" assertion below.
+_GOLDEN_LEGACY_RESPONSE = json.dumps({
+    "source_value_summary": "x",
+    "units": [],
+    "skip_reason": "no extractable units",
+})
+
+
+def _make_extractor(tmp_path: Path, *, llm_responses: list[str], **kwargs):
+    """Build an extractor with a scripted MagicMock LLM client.
+
+    ``llm_responses`` is a queue of strings ``llm.generate(...)``
+    returns in order.  Test asserts call count after the run.
+    """
+    from ovp_pipeline.auto_evergreen_extractor import (
+        EvergreenExtractor,
+        PipelineLogger,
+    )
+
+    log = PipelineLogger(tmp_path / "pipeline.jsonl")
+    llm = MagicMock()
+    llm.generate.side_effect = list(llm_responses)
+    return EvergreenExtractor(
+        llm_client=llm, logger=log, vault_dir=tmp_path, **kwargs,
+    ), llm, log
+
+
+def _read_audit_events(log_file: Path) -> list[dict]:
+    if not log_file.exists():
+        return []
+    return [json.loads(line) for line in log_file.read_text(
+        encoding="utf-8"
+    ).splitlines() if line.strip()]
+
+
+# ---------------------------------------------------------------------------
+# Default off: no extra LLM call
+# ---------------------------------------------------------------------------
+
+
+def test_shadow_off_by_default_no_extra_llm_call(tmp_path, monkeypatch):
+    """No ``OVP_ABSORB_ROUTER_SHADOW`` env, no constructor arg →
+    shadow is OFF.  ``extract_concepts`` calls ``llm.generate``
+    exactly once (legacy v2 only)."""
+    monkeypatch.delenv("OVP_ABSORB_ROUTER_SHADOW", raising=False)
+
+    extractor, llm, _log = _make_extractor(
+        tmp_path, llm_responses=[_GOLDEN_LEGACY_RESPONSE],
+    )
+    assert extractor.enable_router_shadow is False
+
+    extractor.extract_concepts(tmp_path / "x.md", "body")
+
+    assert llm.generate.call_count == 1
+
+
+def test_shadow_constructor_arg_overrides_env(tmp_path, monkeypatch):
+    """Explicit ``enable_router_shadow=False`` wins even when env says yes."""
+    monkeypatch.setenv("OVP_ABSORB_ROUTER_SHADOW", "1")
+
+    extractor, _llm, _log = _make_extractor(
+        tmp_path,
+        llm_responses=[_GOLDEN_LEGACY_RESPONSE],
+        enable_router_shadow=False,
+    )
+    assert extractor.enable_router_shadow is False
+
+
+# ---------------------------------------------------------------------------
+# Shadow on: router runs alongside, audit row emitted
+# ---------------------------------------------------------------------------
+
+
+def test_shadow_on_runs_router_alongside_legacy(tmp_path, monkeypatch):
+    """When shadow is on, ``llm.generate`` is called twice per source
+    (router + legacy) and an ``absorb_route_decision`` audit row is
+    appended to the pipeline log."""
+    monkeypatch.delenv("OVP_ABSORB_ROUTER_SHADOW", raising=False)
+
+    extractor, llm, log = _make_extractor(
+        tmp_path,
+        # Order: router runs FIRST (our wrapper invokes it before the
+        # legacy call), then legacy v2.
+        llm_responses=[_GOLDEN_ROUTER_RESPONSE, _GOLDEN_LEGACY_RESPONSE],
+        enable_router_shadow=True,
+    )
+
+    extractor.extract_concepts(tmp_path / "x.md", "body about LLM evals")
+
+    assert llm.generate.call_count == 2
+
+    audit_rows = _read_audit_events(log.log_file)
+    route_rows = [r for r in audit_rows if r.get("event_type") == "absorb_route_decision"]
+    assert len(route_rows) == 1
+    row = route_rows[0]
+    assert row["status"] == "ok"
+    assert row["update_slugs"] == ["llm-eval-leakage"]
+    assert row["prompt_version"] == "v2_router"
+
+
+def test_shadow_env_var_enables_when_constructor_arg_is_none(tmp_path, monkeypatch):
+    """Setting ``OVP_ABSORB_ROUTER_SHADOW=1`` and not passing the
+    constructor arg → shadow is ON (env-var fallback path)."""
+    monkeypatch.setenv("OVP_ABSORB_ROUTER_SHADOW", "1")
+
+    extractor, llm, _log = _make_extractor(
+        tmp_path,
+        llm_responses=[_GOLDEN_ROUTER_RESPONSE, _GOLDEN_LEGACY_RESPONSE],
+    )
+    assert extractor.enable_router_shadow is True
+
+    extractor.extract_concepts(tmp_path / "x.md", "body")
+    assert llm.generate.call_count == 2
+
+
+@pytest.mark.parametrize("env_value", ["0", "false", "no", "off", ""])
+def test_shadow_falsy_env_values_keep_shadow_off(tmp_path, monkeypatch, env_value):
+    """Falsy / explicit-no env values → shadow stays off."""
+    monkeypatch.setenv("OVP_ABSORB_ROUTER_SHADOW", env_value)
+
+    extractor, _llm, _log = _make_extractor(
+        tmp_path, llm_responses=[_GOLDEN_LEGACY_RESPONSE],
+    )
+    assert extractor.enable_router_shadow is False
+
+
+# ---------------------------------------------------------------------------
+# Best-effort: shadow failures cannot break legacy extraction
+# ---------------------------------------------------------------------------
+
+
+def test_shadow_router_parse_failure_does_not_break_legacy(tmp_path, monkeypatch):
+    """Router LLM returns garbage → router emits parse_error audit
+    AND legacy v2 still runs end-to-end."""
+    monkeypatch.delenv("OVP_ABSORB_ROUTER_SHADOW", raising=False)
+
+    extractor, llm, log = _make_extractor(
+        tmp_path,
+        # Router gets unusable response; legacy still gets valid.
+        llm_responses=["I can't help with that.", _GOLDEN_LEGACY_RESPONSE],
+        enable_router_shadow=True,
+    )
+
+    # Should NOT raise.
+    units = extractor.extract_concepts(tmp_path / "x.md", "body")
+    assert isinstance(units, list)
+    assert llm.generate.call_count == 2
+
+    audit = _read_audit_events(log.log_file)
+    parse_errors = [
+        r for r in audit
+        if r.get("event_type") == "absorb_route_decision"
+        and r.get("status") == "parse_error"
+    ]
+    assert len(parse_errors) == 1
+
+
+def test_shadow_router_llm_exception_does_not_break_legacy(tmp_path, monkeypatch):
+    """LLM raising on the FIRST (router) call must not abort the
+    second (legacy) call.  ``MagicMock.side_effect`` consumes one
+    side-effect per call, and an exception counts as a side-effect
+    consumed."""
+    monkeypatch.delenv("OVP_ABSORB_ROUTER_SHADOW", raising=False)
+
+    extractor, llm, log = _make_extractor(
+        tmp_path,
+        llm_responses=[],
+        enable_router_shadow=True,
+    )
+    # Custom side_effect: first call raises (router), second call
+    # returns the legacy response.
+    llm.generate.side_effect = [
+        RuntimeError("simulated rate limit"),
+        _GOLDEN_LEGACY_RESPONSE,
+    ]
+
+    units = extractor.extract_concepts(tmp_path / "x.md", "body")
+    assert isinstance(units, list)
+    assert llm.generate.call_count == 2
+
+    audit = _read_audit_events(log.log_file)
+    parse_errors = [
+        r for r in audit
+        if r.get("event_type") == "absorb_route_decision"
+        and r.get("status") == "parse_error"
+    ]
+    assert len(parse_errors) == 1
+    assert "simulated rate limit" in parse_errors[0]["error"]
+
+
+def test_shadow_unexpected_exception_logs_shadow_error(tmp_path, monkeypatch):
+    """If something inside the shadow path raises *outside*
+    ``route_source``'s own contract (e.g. import/registry failure
+    that escapes the helper), the wrapper's outer ``except`` catches
+    it, emits ``absorb_router_shadow_error``, and lets the legacy
+    extract proceed.
+
+    Simulated by monkey-patching ``absorb_router.route_source`` to
+    raise — the wrapper imports it lazily inside ``_run_router_shadow``
+    so the patch is picked up.
+    """
+    monkeypatch.delenv("OVP_ABSORB_ROUTER_SHADOW", raising=False)
+
+    def _broken_route_source(*args, **kwargs):
+        # Accept the same call signature ``_run_router_shadow`` uses
+        # (one positional ``llm_client`` + several kwargs) so the
+        # raise inside the function is what the wrapper sees, not a
+        # TypeError before that.
+        raise RuntimeError("simulated registry failure")
+
+    monkeypatch.setattr(
+        "ovp_pipeline.absorb_router.route_source",
+        _broken_route_source,
+    )
+
+    extractor, llm, log = _make_extractor(
+        tmp_path,
+        llm_responses=[_GOLDEN_LEGACY_RESPONSE],
+        enable_router_shadow=True,
+    )
+
+    # Legacy extraction should still complete.
+    units = extractor.extract_concepts(tmp_path / "x.md", "body")
+    assert isinstance(units, list)
+    # Legacy still issued exactly one call (router was bypassed
+    # because route_source raised inside the wrapper's try block).
+    assert llm.generate.call_count == 1
+
+    audit = _read_audit_events(log.log_file)
+    shadow_errors = [
+        r for r in audit
+        if r.get("event_type") == "absorb_router_shadow_error"
+    ]
+    assert len(shadow_errors) == 1
+    assert "simulated registry failure" in shadow_errors[0]["error"]


### PR DESCRIPTION
## Summary

PR #3 of 3 for BL-062. Wires Pass 1 routing into `EvergreenExtractor.extract_concepts` as **shadow mode** — the router runs alongside the legacy v2 extract, emits its decision to audit_events, but does NOT yet drive extraction. **Default off**; opt in via env var or constructor arg.

This is conservative staged rollout. Before the router *replaces* v2 extract we want audit data showing:
- router parse-error rate on real sources (target < 1%)
- update-vs-create rate (sanity check)
- decision quality vs eventual concept_dedup outcomes

Post-BL-062 PRs will read those metrics, build Pass 2 per-target extractors, and flip the default.

## Public-API change

```python
class EvergreenExtractor:
    def __init__(
        self,
        llm_client,
        logger,
        vault_dir=None,
        *,
        enable_router_shadow: bool | None = None,  # NEW
    ):
        ...
```

- `enable_router_shadow=None` (default) → reads `OVP_ABSORB_ROUTER_SHADOW` env var
- `enable_router_shadow=True` / `False` → wins over env
- truthy env values: `1` / `true` / `yes` / `on` (case-insensitive)

## Behavior with shadow on

Each `extract_concepts` call:
1. Issues Pass 1 router call via `absorb_router.route_source` (returns + logs decision)
2. Issues legacy v2 LLM call (unchanged)
3. Returns the legacy result (unchanged) — router decision is **fire-and-forget telemetry**

`_run_router_shadow` wraps the call in a try/except that emits `absorb_router_shadow_error` if anything escapes `route_source`'s own audit-on-failure contract (registry/import failure, programming bug). Legacy extraction is never affected.

## Cost note

Shadow mode roughly **doubles** the per-source LLM spend. Documented in `__init__` docstring. Default off so vanilla absorb runs are unaffected.

## Test coverage (12 new)

| Layer | # | What |
|---|---|---|
| Default off | 2 | No env + no arg → 1 LLM call; `False` arg wins over env |
| Shadow on | 4 | Env=1 → 2 calls + audit row; `True` arg → same; 5-way parametrize over falsy env values stays off |
| Failure handling | 3 | Router parse error / LLM raise / `route_source` raise — all emit audit, legacy still completes |

## Verification

- [x] 87 tests pass across all extractor + router suites combined
- [x] Full suite: **2297 passed, 15 xfailed** (3 pre-existing failures reproduce on `main`)
- [x] `ruff check` zero new errors

## What's next

BL-062 closes here. Next milestone work is BL-063 (Live Concept primitive). The post-BL-062 follow-ups (read shadow metrics, build Pass 2, flip default) are **not** new BLs — they're the natural continuation we'll size after a few weeks of shadow-mode data on the live vault.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional router shadowing capability that executes alongside standard extraction. Enable via constructor parameter or environment variable for best-effort processing.

* **Tests**
  * Added comprehensive test coverage for shadow mode functionality, including success paths, error isolation, and extraction continuity validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fakechris/obsidian_vault_pipeline/pull/196)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->