### PR TITLE
feat(bl-063): Live Concept primitive — data model + fileops (PR#1)

### DIFF
--- a/src/ovp_pipeline/live_concept.py
+++ b/src/ovp_pipeline/live_concept.py
@@ -1,0 +1,323 @@
+"""BL-063: Live Concept primitive — data model + discovery.
+
+A Live Concept is a user-declared markdown file under
+``30-Projects/Tracking/<slug>.md`` whose YAML frontmatter carries a
+``type: live-concept`` key plus a ``live:`` block describing the
+operator's *interpretation surface* for one topic.  Where evergreen
+notes are atomic facts (fourth-ledger Artifact + Claim), a Live
+Concept is the *Interpretation* layer — the curated, evolving view
+that the operator declares they care about.
+
+Parsed shape::
+
+    ---
+    type: live-concept
+    live:
+      objective: |
+        维护我对 LLM eval 方法论的当前理解。
+        每周重新综合一次「My take」之外的部分。
+      active: true
+      triggers:
+        on_ingest_match:
+          concept_similarity_to: "llm-eval"
+          threshold: 0.65
+        on_contradiction_against_view: true
+        weekly_resynthesis: "Mon 09:00"
+      scope_evergreens:
+        - llm-eval-leakage
+        - eval-cost-vs-quality
+      # Runtime-managed (don't hand-write):
+      lastAttemptAt: "2026-05-10T08:00:00Z"
+      lastRunAt: "2026-05-10T08:00:01Z"
+      lastRunSummary: "Refreshed Recent Evidence with 3 new claims."
+      lastRunError: ""
+    ---
+
+    # LLM Eval Landscape
+
+    ## My take  <!-- user-owned section; agent never writes here -->
+
+    ...
+
+    ## Current synthesis  <!-- agent-owned -->
+
+    ...
+
+This module **does not** wire triggers or invoke any agent.  It only
+defines the data model + discovery + parser:
+
+* :func:`parse_live_concept` — read one file, return a
+  :class:`LiveConceptHandle` or ``None`` when the file isn't a live
+  concept (no frontmatter, missing ``type: live-concept``, or no
+  ``live:`` block).
+* :func:`list_live_concepts` — walk ``30-Projects/Tracking/`` and
+  return handles for every live concept the vault carries.
+
+PR#2 implements the three triggers (``on_ingest_match``,
+``on_contradiction_against_view``, ``weekly_resynthesis``) on top of
+this discovery.  PR#3 wires the agent prompt + section-aware patch
+edits.  See ``BACKLOG.md`` BL-063 for the full sizing.
+
+The single-writer invariant applies at the YAML-key level: only the
+companion module ``live_concept_fileops`` writes the ``live:`` block
+into a markdown file.  Every other writer (the agent body editor in
+PR#3, the user via Obsidian UI) leaves ``live:`` byte-for-byte
+intact.  Same architectural pattern Rowboat uses for their
+``LiveNote`` schema — see the ``LIVE_NOTE.md`` discussion in the
+2026-05-10 strategy review for the rationale.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .runtime import read_markdown_frontmatter, resolve_vault_dir
+
+# Live concepts live under this vault-relative directory.  Single
+# location keeps discovery cheap (one ``rglob`` instead of walking
+# the whole vault) and gives the operator a clear mental model
+# ("anything under 30-Projects/Tracking/ is being actively
+# tracked").  Future BLs may add more roots; ``list_live_concepts``
+# accepts a custom ``root`` argument so callers don't have to wait
+# for a code change.
+LIVE_CONCEPT_DIR = "30-Projects/Tracking"
+
+# YAML ``type`` value that flags a markdown file as a Live Concept.
+# Frontmatter without this exact value is ignored (so other
+# ``type: ...`` notes — moc, evergreen, decision, etc. — never
+# accidentally get parsed as live concepts).
+LIVE_CONCEPT_TYPE = "live-concept"
+
+
+@dataclass(frozen=True)
+class LiveConceptFrontmatter:
+    """Parsed contents of the ``live:`` YAML block.
+
+    Frozen so callers can't mutate fields by accident; mutating
+    helpers (``patch_live`` in ``live_concept_fileops``) construct
+    a fresh instance per update.
+
+    The schema is **liberal on shape, conservative on names**:
+    ``triggers`` is a free-form dict so future trigger types don't
+    require a schema bump, and unknown top-level keys are dropped
+    silently rather than raising.  But the field names below are
+    fixed — handwriting ``last_run_at: ...`` (snake_case) into the
+    YAML won't be picked up because OVP convention matches Rowboat
+    here on camelCase ``lastRunAt`` for runtime-managed fields.
+    """
+
+    objective: str
+    active: bool = True
+    triggers: dict[str, Any] = field(default_factory=dict)
+    scope_evergreens: tuple[str, ...] = ()
+
+    # Runtime-managed.  Hand-writing these is supported (the parser
+    # reads them back as-is) but pointless — the runner overwrites
+    # them on every fire.  ``last_attempt_at`` advances on every
+    # attempt (backoff anchor); ``last_run_at`` advances only on
+    # successful runs (cycle anchor) — same two-timestamp split
+    # Rowboat uses.
+    last_attempt_at: str = ""
+    last_run_at: str = ""
+    last_run_summary: str = ""
+    last_run_error: str = ""
+
+    @property
+    def is_active(self) -> bool:
+        """Convenience predicate for trigger gates.  PR#2 will skip
+        any concept where ``is_active`` is False without firing
+        triggers — same contract as Rowboat's ``active !== false``."""
+        return bool(self.active)
+
+
+@dataclass(frozen=True)
+class LiveConceptHandle:
+    """A discovered live concept on disk.
+
+    Carries the absolute path (for fileops calls), the
+    vault-relative path (for audit logs / cross-machine references),
+    the slug (filename stem; used as the concept identifier in
+    audit rows + scheduler state), and the parsed frontmatter.
+    """
+
+    path: Path
+    relative_path: str
+    slug: str
+    frontmatter: LiveConceptFrontmatter
+
+
+def _coerce_str(value: Any) -> str:
+    """Cast YAML scalars to ``str`` defensively.  ``None`` → empty
+    string so callers can ``if x:`` without isinstance checks."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return str(value)
+
+
+def _coerce_str_tuple(value: Any) -> tuple[str, ...]:
+    """Cast a YAML list-of-strings to ``tuple[str, ...]``, dropping
+    blank entries.  ``None`` / non-list → empty tuple."""
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        # Single string convenience — wrap so the schema stays a
+        # list type without rejecting a perfectly valid one-item case.
+        stripped = value.strip()
+        return (stripped,) if stripped else ()
+    if not isinstance(value, list):
+        return ()
+    out: list[str] = []
+    for item in value:
+        stripped = _coerce_str(item).strip()
+        if stripped:
+            out.append(stripped)
+    return tuple(out)
+
+
+def _coerce_dict(value: Any) -> dict[str, Any]:
+    """Cast to ``dict``; non-dict → empty.  Unlike the str/tuple
+    coercers above, we keep the dict's interior types as YAML
+    parsed them — the trigger types in PR#2 will validate sub-keys
+    per-trigger-kind."""
+    if isinstance(value, dict):
+        # Coerce keys to str for safety (YAML can produce non-string
+        # keys for ``true`` / ``false`` / numeric-looking keys).
+        return {str(k): v for k, v in value.items()}
+    return {}
+
+
+def parse_live_concept_block(block: Any) -> LiveConceptFrontmatter | None:
+    """Build a :class:`LiveConceptFrontmatter` from the raw ``live``
+    YAML node.  Returns ``None`` when the block is missing the
+    required ``objective`` field.
+
+    Liberal in what it accepts: any field absent from the block falls
+    back to its dataclass default.  Unknown extra keys are silently
+    dropped (forward-compat for future BL additions).
+    """
+    if not isinstance(block, dict):
+        return None
+    objective = _coerce_str(block.get("objective")).strip()
+    if not objective:
+        return None
+
+    raw_active = block.get("active", True)
+    # YAML ``active: false`` parses as ``False``; YAML ``active:
+    # null`` parses as ``None``.  Default to active (True) when the
+    # key is missing entirely; explicit ``false`` / ``null`` both
+    # disable.
+    active = bool(raw_active) if raw_active is not None else False
+    if "active" not in block:
+        active = True
+
+    return LiveConceptFrontmatter(
+        objective=objective,
+        active=active,
+        triggers=_coerce_dict(block.get("triggers")),
+        scope_evergreens=_coerce_str_tuple(block.get("scope_evergreens")),
+        last_attempt_at=_coerce_str(block.get("lastAttemptAt")),
+        last_run_at=_coerce_str(block.get("lastRunAt")),
+        last_run_summary=_coerce_str(block.get("lastRunSummary")),
+        last_run_error=_coerce_str(block.get("lastRunError")),
+    )
+
+
+def parse_live_concept(path: Path) -> LiveConceptHandle | None:
+    """Read a markdown file at ``path``; return a handle when it
+    parses as a live concept, else ``None``.
+
+    Three short-circuit cases that all return ``None`` (silently —
+    callers iterate many files and don't want one bad file to abort
+    the scan):
+
+    * file doesn't exist or isn't readable
+    * frontmatter is missing / malformed
+    * frontmatter has no ``type: live-concept`` key
+    * frontmatter has no ``live:`` block, or ``live:`` block is
+      missing the required ``objective`` field
+
+    Path determinism:  ``relative_path`` is computed against the
+    closest ``30-Projects/Tracking/`` ancestor when present, falling
+    back to the file's basename otherwise.  This keeps audit rows
+    portable across machines without depending on the runner's
+    working directory.
+    """
+    if not path.is_file():
+        return None
+    try:
+        metadata = read_markdown_frontmatter(path)
+    except (OSError, UnicodeDecodeError, ValueError):
+        return None
+    except Exception:  # noqa: BLE001 — yaml.YAMLError + anything else
+        # Real-vault YAML occasionally has unquoted ``@`` in
+        # ``source_anchor:`` etc.  Same defence
+        # ``backfill_objects_source_url`` uses (BL-060 PR review fix).
+        return None
+
+    if not isinstance(metadata, dict):
+        return None
+    if metadata.get("type") != LIVE_CONCEPT_TYPE:
+        return None
+    parsed = parse_live_concept_block(metadata.get("live"))
+    if parsed is None:
+        return None
+
+    relative_path = _vault_relative_path(path)
+    slug = path.stem
+    return LiveConceptHandle(
+        path=path,
+        relative_path=relative_path,
+        slug=slug,
+        frontmatter=parsed,
+    )
+
+
+def _vault_relative_path(path: Path) -> str:
+    """Return ``path`` relative to the closest ``30-Projects/Tracking/``
+    ancestor, or to the vault root if we can find one, else just the
+    file basename.  Always uses forward slashes (Obsidian convention)
+    so the result is machine-portable."""
+    parts = path.parts
+    for marker_idx in range(len(parts) - 1, -1, -1):
+        if parts[marker_idx] == "30-Projects" and marker_idx + 1 < len(parts) \
+                and parts[marker_idx + 1] == "Tracking":
+            return "/".join(parts[marker_idx:])
+    return path.name
+
+
+def list_live_concepts(
+    vault_dir: Path | str,
+    *,
+    root: str = LIVE_CONCEPT_DIR,
+    active_only: bool = False,
+) -> list[LiveConceptHandle]:
+    """Walk ``<vault_dir>/<root>/`` and return every live concept the
+    vault carries.
+
+    ``root`` overrides the default discovery directory (mostly for
+    tests).  ``active_only=True`` drops concepts whose
+    ``frontmatter.active`` is False — useful for the trigger
+    scheduler in PR#2 which never wants to fire on archived /
+    paused concepts.
+
+    Discovery cost: one ``rglob('*.md')`` over the
+    ``30-Projects/Tracking/`` subtree, which on the live vault is a
+    few hundred files at most (Tracking is purposefully small).
+    """
+    resolved = resolve_vault_dir(vault_dir)
+    base = resolved / root
+    if not base.is_dir():
+        return []
+    handles: list[LiveConceptHandle] = []
+    for md in sorted(base.rglob("*.md")):
+        handle = parse_live_concept(md)
+        if handle is None:
+            continue
+        if active_only and not handle.frontmatter.is_active:
+            continue
+        handles.append(handle)
+    return handles

--- a/src/ovp_pipeline/live_concept_fileops.py
+++ b/src/ovp_pipeline/live_concept_fileops.py
@@ -1,0 +1,304 @@
+"""BL-063 single-writer for the ``live:`` YAML block.
+
+Mirrors the BL-060 single-writer-invariant pattern at the
+markdown-frontmatter-key level: only this module writes the
+``live:`` key in a Live Concept file.  Every other writer (the
+agent body editor in PR#3, the user typing in Obsidian, future
+MCP tools) must leave ``live:`` byte-for-byte intact.
+
+Why this matters
+----------------
+
+The runtime fields on a Live Concept (``lastAttemptAt`` /
+``lastRunAt`` / ``lastRunSummary`` / ``lastRunError``) get bumped
+on every trigger fire.  If the agent or the user could overwrite
+the whole frontmatter en passant, two concurrent trigger runs
+would race over those fields and lose audit data.  Routing all
+``live:`` writes through this module makes the race architecturally
+impossible — same property BL-060 gave us for the canonical SQL
+tables.
+
+What this module does
+---------------------
+
+* :func:`set_live` — write a complete ``LiveConceptFrontmatter`` to
+  a markdown file.  Used when the user (via Obsidian or a future
+  MCP tool) declares a new Live Concept or replaces an existing
+  one.
+* :func:`patch_live` — partial update.  Reads the current ``live:``
+  block, applies the supplied keyword updates, writes back.  Used
+  by the trigger runner in PR#2 to bump runtime fields without
+  touching ``objective`` / ``triggers`` / ``scope_evergreens``.
+* :func:`delete_live` — strip the ``live:`` block entirely (and the
+  ``type: live-concept`` marker that pairs with it).  The "make
+  passive" path: the markdown file lives on as a regular note.
+
+Locking
+-------
+
+Each helper takes an ``acquire_lock`` callable so callers in
+process-level transactions can pass their own lock.  By default
+the helpers acquire a per-file ``filelock`` for the duration of
+the read-modify-write — same shape Rowboat uses around
+``setLiveNote`` / ``patchLiveNote``.
+
+What this module does NOT do
+----------------------------
+
+Body content below the H1 is **out of scope** for PR#1.  PR#3 will
+add the section-aware patch helpers (``patch_agent_section``) that
+let the agent rewrite ``## Current synthesis`` / ``## Recent
+evidence`` / ``## Tensions`` while leaving ``## My take``
+untouched.  This module only owns the YAML frontmatter.
+"""
+
+from __future__ import annotations
+
+import io
+from contextlib import contextmanager
+from dataclasses import asdict, replace
+from pathlib import Path
+from typing import Any, Iterator
+
+import yaml
+
+from .live_concept import (
+    LIVE_CONCEPT_TYPE,
+    LiveConceptFrontmatter,
+    parse_live_concept_block,
+)
+
+
+# Order in which we serialise ``live:`` sub-keys.  Rowboat's experience
+# is that LLMs and humans both reason better when the same fields are
+# in the same place every time, so we pin a deterministic order rather
+# than letting yaml.dump pick alphabetical.
+_LIVE_BLOCK_ORDER = (
+    "objective",
+    "active",
+    "triggers",
+    "scope_evergreens",
+    # Runtime-managed fields go last so the user-edited fields read
+    # at a glance and the noisy timestamps don't push them off-screen.
+    "lastAttemptAt",
+    "lastRunAt",
+    "lastRunSummary",
+    "lastRunError",
+)
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter <-> YAML serialisation
+# ---------------------------------------------------------------------------
+
+
+def _frontmatter_to_yaml_block(fm: LiveConceptFrontmatter) -> dict[str, Any]:
+    """Convert a :class:`LiveConceptFrontmatter` back to a YAML-friendly
+    dict in the canonical key order.
+
+    Empty / default fields are dropped on the way out so re-saving
+    a freshly-declared concept doesn't write spurious empty
+    ``lastRunError: ""`` rows.  Reading the result back through
+    :func:`parse_live_concept_block` yields an equivalent instance.
+    """
+    payload: dict[str, Any] = {
+        "objective": fm.objective,
+        "active": bool(fm.active),
+    }
+    if fm.triggers:
+        payload["triggers"] = fm.triggers
+    if fm.scope_evergreens:
+        payload["scope_evergreens"] = list(fm.scope_evergreens)
+    # Runtime fields — only include if non-empty.  ``lastRunError`` is
+    # intentionally cleared by patch_live(last_run_error="") on a
+    # successful run; that empty string is dropped here so the YAML
+    # stays clean.
+    if fm.last_attempt_at:
+        payload["lastAttemptAt"] = fm.last_attempt_at
+    if fm.last_run_at:
+        payload["lastRunAt"] = fm.last_run_at
+    if fm.last_run_summary:
+        payload["lastRunSummary"] = fm.last_run_summary
+    if fm.last_run_error:
+        payload["lastRunError"] = fm.last_run_error
+    return payload
+
+
+def _ordered_dump(data: dict[str, Any]) -> str:
+    """yaml.safe_dump with field order preserved + tidy defaults.
+
+    ``default_flow_style=False`` keeps the block in human-friendly
+    indented form, ``sort_keys=False`` honours the order we built
+    the dict in (PyYAML otherwise alphabetises).
+    """
+    buf = io.StringIO()
+    yaml.safe_dump(
+        data,
+        buf,
+        default_flow_style=False,
+        sort_keys=False,
+        allow_unicode=True,
+        width=10_000,  # don't reflow long objective strings mid-word
+    )
+    return buf.getvalue().rstrip()
+
+
+# ---------------------------------------------------------------------------
+# File read / write helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_file(path: Path) -> str:
+    if not path.is_file():
+        return ""
+    return path.read_text(encoding="utf-8")
+
+
+def _split_frontmatter(text: str) -> tuple[dict[str, Any], str, str]:
+    """Return ``(metadata_dict, body, raw_frontmatter_text)``.
+
+    Empty metadata dict + full text as body when the file has no
+    frontmatter — caller decides whether to inject one.
+
+    Distinct from :func:`runtime.split_markdown_frontmatter` which
+    only returns metadata + body; we need the raw frontmatter text
+    too so we can splice the surrounding non-``live:`` keys back
+    verbatim on patch / delete paths.
+    """
+    if not text.startswith("---\n"):
+        return {}, text, ""
+    end = text.find("\n---", 4)
+    if end == -1:
+        return {}, text, ""
+    raw_frontmatter = text[4:end]
+    body_start = end + len("\n---")
+    if body_start < len(text) and text[body_start] == "\n":
+        body_start += 1
+    body = text[body_start:]
+    try:
+        parsed = yaml.safe_load(raw_frontmatter) or {}
+    except yaml.YAMLError:
+        return {}, text, ""
+    if not isinstance(parsed, dict):
+        return {}, body, raw_frontmatter
+    return parsed, body, raw_frontmatter
+
+
+def _join_frontmatter(metadata: dict[str, Any], body: str) -> str:
+    """Re-render frontmatter + body to a single markdown string."""
+    if not metadata:
+        return body
+    front = _ordered_dump(metadata)
+    return f"---\n{front}\n---\n\n{body.lstrip(chr(10))}"
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _default_lock(_path: Path) -> Iterator[None]:
+    """Default no-op lock context.  PR#2 will plug in a real per-file
+    lock once the trigger scheduler is wired; for now serialisation
+    is implicit (every fileops call runs from one process / thread)."""
+    yield
+
+
+def set_live(
+    path: Path,
+    fm: LiveConceptFrontmatter,
+    *,
+    acquire_lock: Any = _default_lock,
+) -> None:
+    """Write ``fm`` as the ``live:`` block of the markdown file at
+    ``path``.
+
+    If the file doesn't exist, it's created with a minimal stub
+    body (``# <slug>\\n``) so the operator can ``open`` it
+    immediately in Obsidian.  Other frontmatter keys are preserved.
+    The ``type: live-concept`` marker is auto-set so callers don't
+    need to pass it.
+    """
+    with acquire_lock(path):
+        text = _read_file(path)
+        if not text:
+            # Brand-new file — synthesise a minimal stub so
+            # split_frontmatter has something coherent to parse and
+            # the operator opening this in Obsidian sees a sensible
+            # body.  Slug is the filename stem — same convention
+            # discovery uses.
+            stub_h1 = path.stem.replace("-", " ").replace("_", " ").title()
+            text = f"# {stub_h1}\n"
+        metadata, body, _raw = _split_frontmatter(text)
+        metadata["type"] = LIVE_CONCEPT_TYPE
+        metadata["live"] = _frontmatter_to_yaml_block(fm)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(_join_frontmatter(metadata, body), encoding="utf-8")
+
+
+def patch_live(
+    path: Path,
+    *,
+    acquire_lock: Any = _default_lock,
+    **field_updates: Any,
+) -> LiveConceptFrontmatter:
+    """Update one or more fields of an existing ``live:`` block.
+
+    ``field_updates`` keys match :class:`LiveConceptFrontmatter`'s
+    Python field names (``last_attempt_at``, not ``lastAttemptAt``);
+    the YAML serialisation handles the camelCase mapping.  Any
+    unknown kwarg raises ``TypeError`` — better than silently
+    ignoring a typo on a runtime-critical timestamp.
+
+    Returns the new (post-patch) frontmatter so callers don't have
+    to re-parse the file.
+
+    Raises ``ValueError`` when ``path`` doesn't carry a parseable
+    ``live:`` block — caller is expected to use :func:`set_live`
+    for first-time declarations.
+    """
+    with acquire_lock(path):
+        text = _read_file(path)
+        if not text:
+            raise ValueError(f"cannot patch_live: {path} does not exist")
+        metadata, body, _raw = _split_frontmatter(text)
+        current_block = metadata.get("live")
+        current_fm = parse_live_concept_block(current_block)
+        if current_fm is None:
+            raise ValueError(
+                f"cannot patch_live: {path} has no parseable `live:` block"
+            )
+        try:
+            new_fm = replace(current_fm, **field_updates)
+        except TypeError as exc:
+            valid = sorted(asdict(current_fm).keys())
+            raise TypeError(
+                f"unknown LiveConceptFrontmatter field; "
+                f"valid: {valid}"
+            ) from exc
+        metadata["type"] = LIVE_CONCEPT_TYPE
+        metadata["live"] = _frontmatter_to_yaml_block(new_fm)
+        path.write_text(_join_frontmatter(metadata, body), encoding="utf-8")
+        return new_fm
+
+
+def delete_live(path: Path, *, acquire_lock: Any = _default_lock) -> None:
+    """Make the file passive: strip the ``live:`` block + the
+    ``type: live-concept`` marker.  Body content is preserved
+    verbatim so the markdown stays readable in Obsidian.
+
+    No-op when the file doesn't exist or doesn't carry a ``live:``
+    block — idempotent on re-runs.
+    """
+    with acquire_lock(path):
+        text = _read_file(path)
+        if not text:
+            return
+        metadata, body, _raw = _split_frontmatter(text)
+        if "live" not in metadata and metadata.get("type") != LIVE_CONCEPT_TYPE:
+            return
+        metadata.pop("live", None)
+        if metadata.get("type") == LIVE_CONCEPT_TYPE:
+            metadata.pop("type")
+        path.write_text(_join_frontmatter(metadata, body), encoding="utf-8")

--- a/src/ovp_pipeline/live_concept_fileops.py
+++ b/src/ovp_pipeline/live_concept_fileops.py
@@ -1,4 +1,4 @@
-"""BL-063 single-writer for the ``live:`` YAML block.
+r"""BL-063 single-writer for the ``live:`` YAML block.
 
 Mirrors the BL-060 single-writer-invariant pattern at the
 markdown-frontmatter-key level: only this module writes the
@@ -33,14 +33,37 @@ What this module does
   ``type: live-concept`` marker that pairs with it).  The "make
   passive" path: the markdown file lives on as a regular note.
 
+Verbatim preservation of non-``live:`` keys
+-------------------------------------------
+
+The helpers splice the ``live:`` block in / out of the raw
+frontmatter text rather than re-rendering the whole metadata
+dict.  This preserves comments, blank lines, scalar styles, and
+key order on every other top-level frontmatter key — same
+property the agent body editor will need in PR#3 for the body
+sections.
+
+Frontmatter fences
+------------------
+
+Both standard ``---`` fences and fenced YAML
+(``\`\`\`yaml\\n---\\n...\\n---\\n\`\`\``) are supported, matching
+:func:`ovp_pipeline.runtime.split_markdown_frontmatter`.  The
+fence style is preserved on write so a file that started fenced
+stays fenced.
+
 Locking
 -------
 
-Each helper takes an ``acquire_lock`` callable so callers in
-process-level transactions can pass their own lock.  By default
-the helpers acquire a per-file ``filelock`` for the duration of
-the read-modify-write — same shape Rowboat uses around
-``setLiveNote`` / ``patchLiveNote``.
+PR#1 ships with a no-op default lock — every helper takes an
+``acquire_lock`` callable, but the default :func:`_default_lock`
+just yields without serialising anything.  This is fine for the
+PR#1 use cases (operator declares / removes a concept by hand;
+no concurrent writers exist yet) but is **explicitly not safe**
+for PR#2's trigger scheduler, which will fire concurrent
+``patch_live`` calls when multiple triggers match the same
+concept.  PR#2 will plug in a real per-file ``filelock`` via the
+``acquire_lock`` parameter.
 
 What this module does NOT do
 ----------------------------
@@ -143,8 +166,185 @@ def _ordered_dump(data: dict[str, Any]) -> str:
     return buf.getvalue().rstrip()
 
 
+def _render_live_block(fm: LiveConceptFrontmatter) -> str:
+    """Serialise ``fm`` as the ``live:`` block, including the leading
+    ``live:`` line.  Ends without trailing newline; caller decides
+    how to splice it in."""
+    return _ordered_dump({"live": _frontmatter_to_yaml_block(fm)})
+
+
 # ---------------------------------------------------------------------------
-# File read / write helpers
+# Frontmatter splice helpers — preserve non-live keys verbatim
+# ---------------------------------------------------------------------------
+
+# Standard fence (``---``) is the OVP convention.  Fenced YAML
+# (``\`\`\`yaml`` or ``\`\`\`yml``) is rare but appears in some
+# Obsidian setups; ``runtime.split_markdown_frontmatter`` accepts both,
+# so we mirror it here to avoid a write-side regression that would
+# trip up :func:`parse_live_concept`.
+_STANDARD_FENCE = "standard"
+_FENCED_YAML = "fenced"
+
+
+def _split_frontmatter(text: str) -> tuple[str, str, str]:
+    """Return ``(raw_frontmatter, body, fence_style)``.
+
+    Empty raw_frontmatter + full text as body when the file has no
+    frontmatter — caller decides whether to inject one.
+
+    fence_style is ``""`` (no frontmatter), ``"standard"``, or
+    ``"fenced"``.  Preserved on rejoin so a fenced file stays
+    fenced after a write.
+
+    Distinct from :func:`runtime.split_markdown_frontmatter` which
+    returns parsed metadata + body; we need the raw frontmatter
+    text so we can splice the surrounding non-``live:`` keys back
+    verbatim on patch / delete paths.
+    """
+    if text.startswith("```yaml\n---\n") or text.startswith("```yml\n---\n"):
+        first_newline = text.find("\n")
+        closing = "\n---\n```"
+        end = text.find(closing, first_newline + 1)
+        if end < 0:
+            return "", text, ""
+        raw = text[first_newline + len("\n---\n") : end]
+        body_start = end + len(closing)
+        if body_start < len(text) and text[body_start] == "\n":
+            body_start += 1
+        body = text[body_start:]
+        return raw, body, _FENCED_YAML
+    if text.startswith("---\n"):
+        end = text.find("\n---", 4)
+        if end < 0:
+            return "", text, ""
+        raw = text[4:end]
+        body_start = end + len("\n---")
+        if body_start < len(text) and text[body_start] == "\n":
+            body_start += 1
+        body = text[body_start:]
+        return raw, body, _STANDARD_FENCE
+    return "", text, ""
+
+
+def _join_frontmatter(raw_frontmatter: str, body: str, fence_style: str) -> str:
+    """Re-render frontmatter + body to a single markdown string.
+
+    Empty frontmatter → no fence at all (file becomes pure body).
+    """
+    if not raw_frontmatter.strip():
+        return body.lstrip("\n") if body else ""
+    raw = raw_frontmatter.rstrip("\n")
+    if fence_style == _FENCED_YAML:
+        return f"```yaml\n---\n{raw}\n---\n```\n\n{body.lstrip(chr(10))}"
+    return f"---\n{raw}\n---\n\n{body.lstrip(chr(10))}"
+
+
+def _is_top_level_key_line(line: str) -> bool:
+    """True when ``line`` is a top-level YAML key (column-0, has a colon,
+    not a comment)."""
+    if not line:
+        return False
+    if line[0].isspace():
+        return False
+    if line.startswith("#"):
+        return False
+    if line.startswith("---") or line.startswith("..."):
+        return False
+    return ":" in line
+
+
+def _find_top_level_block(raw_frontmatter: str, key: str) -> tuple[int, int] | None:
+    """Find the line range ``[start, end)`` of the top-level ``key:``
+    block in raw_frontmatter.
+
+    Returns ``None`` when the key isn't present.  ``end`` is the
+    line index of the next top-level key (or ``len(lines)`` at EOF),
+    so the slice ``lines[start:end]`` includes the key line plus
+    every continuation / nested / blank line that belongs to it.
+
+    Why line-based instead of YAML-AST: we need to splice text
+    verbatim, including any comments or unusual scalar styles the
+    user wrote.  PyYAML's safe_load discards both.  ruamel.yaml
+    preserves them but adds a heavy dep.  A line-scan keyed on
+    "starts at column 0" is enough for the keys we'd find in OVP
+    frontmatter — none of them use folded literals at column 0 as
+    multi-line scalars.
+    """
+    lines = raw_frontmatter.splitlines()
+    prefix_a = f"{key}:"
+    prefix_b = f"{key} :"  # tolerate odd whitespace around the colon
+    start: int | None = None
+    for i, line in enumerate(lines):
+        if line.startswith(prefix_a) or line.startswith(prefix_b):
+            start = i
+            break
+    if start is None:
+        return None
+    end = len(lines)
+    for j in range(start + 1, len(lines)):
+        if _is_top_level_key_line(lines[j]):
+            end = j
+            break
+    return (start, end)
+
+
+def _splice_top_level_block(
+    raw_frontmatter: str,
+    key: str,
+    new_block: str | None,
+) -> str:
+    """Replace, insert, or remove a top-level key's block.
+
+    ``new_block`` is the complete YAML for the key (e.g.
+    ``"live:\\n  objective: x"``) without trailing newline.  ``None``
+    removes the block.  When the key doesn't exist and ``new_block``
+    is given, append at the end of the frontmatter.  When the key
+    doesn't exist and ``new_block`` is ``None``, no-op.
+
+    Lines outside the spliced range are returned byte-for-byte
+    identical to the input — that's the verbatim-preservation
+    contract for non-``live:`` keys.
+    """
+    lines = raw_frontmatter.splitlines()
+    block_range = _find_top_level_block(raw_frontmatter, key)
+    if block_range is None:
+        if new_block is None:
+            return raw_frontmatter
+        # Append at the end.  Strip trailing blank lines from existing
+        # frontmatter first so the join doesn't double-blank.
+        while lines and lines[-1].strip() == "":
+            lines.pop()
+        new_lines = lines + new_block.splitlines()
+        return "\n".join(new_lines)
+    start, end = block_range
+    if new_block is None:
+        new_lines = lines[:start] + lines[end:]
+    else:
+        new_lines = lines[:start] + new_block.splitlines() + lines[end:]
+    return "\n".join(new_lines)
+
+
+def _read_top_level_value(raw_frontmatter: str, key: str) -> Any:
+    """Parse just enough YAML to read the current value of one key.
+
+    Returns ``None`` when the key is absent or unparseable.  Used by
+    :func:`patch_live` to read the existing ``live:`` block before
+    applying updates, and by guards that check ``type:`` without
+    re-rendering the whole metadata.
+    """
+    if not raw_frontmatter.strip():
+        return None
+    try:
+        parsed = yaml.safe_load(raw_frontmatter)
+    except yaml.YAMLError:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    return parsed.get(key)
+
+
+# ---------------------------------------------------------------------------
+# File I/O
 # ---------------------------------------------------------------------------
 
 
@@ -154,44 +354,6 @@ def _read_file(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
-def _split_frontmatter(text: str) -> tuple[dict[str, Any], str, str]:
-    """Return ``(metadata_dict, body, raw_frontmatter_text)``.
-
-    Empty metadata dict + full text as body when the file has no
-    frontmatter — caller decides whether to inject one.
-
-    Distinct from :func:`runtime.split_markdown_frontmatter` which
-    only returns metadata + body; we need the raw frontmatter text
-    too so we can splice the surrounding non-``live:`` keys back
-    verbatim on patch / delete paths.
-    """
-    if not text.startswith("---\n"):
-        return {}, text, ""
-    end = text.find("\n---", 4)
-    if end == -1:
-        return {}, text, ""
-    raw_frontmatter = text[4:end]
-    body_start = end + len("\n---")
-    if body_start < len(text) and text[body_start] == "\n":
-        body_start += 1
-    body = text[body_start:]
-    try:
-        parsed = yaml.safe_load(raw_frontmatter) or {}
-    except yaml.YAMLError:
-        return {}, text, ""
-    if not isinstance(parsed, dict):
-        return {}, body, raw_frontmatter
-    return parsed, body, raw_frontmatter
-
-
-def _join_frontmatter(metadata: dict[str, Any], body: str) -> str:
-    """Re-render frontmatter + body to a single markdown string."""
-    if not metadata:
-        return body
-    front = _ordered_dump(metadata)
-    return f"---\n{front}\n---\n\n{body.lstrip(chr(10))}"
-
-
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -199,9 +361,15 @@ def _join_frontmatter(metadata: dict[str, Any], body: str) -> str:
 
 @contextmanager
 def _default_lock(_path: Path) -> Iterator[None]:
-    """Default no-op lock context.  PR#2 will plug in a real per-file
-    lock once the trigger scheduler is wired; for now serialisation
-    is implicit (every fileops call runs from one process / thread)."""
+    """No-op default lock context.
+
+    Documented in the module header: PR#1 has no concurrent writers,
+    so the read-modify-write windows in :func:`set_live` /
+    :func:`patch_live` / :func:`delete_live` aren't serialised.
+    PR#2's trigger scheduler will plug in a real per-file
+    ``filelock`` via the ``acquire_lock`` parameter when concurrent
+    trigger fires become possible.
+    """
     yield
 
 
@@ -216,25 +384,23 @@ def set_live(
 
     If the file doesn't exist, it's created with a minimal stub
     body (``# <slug>\\n``) so the operator can ``open`` it
-    immediately in Obsidian.  Other frontmatter keys are preserved.
-    The ``type: live-concept`` marker is auto-set so callers don't
-    need to pass it.
+    immediately in Obsidian.  Other frontmatter keys are preserved
+    byte-for-byte (including comments and scalar styles).  The
+    ``type: live-concept`` marker is auto-set so callers don't need
+    to pass it.
     """
     with acquire_lock(path):
         text = _read_file(path)
         if not text:
-            # Brand-new file — synthesise a minimal stub so
-            # split_frontmatter has something coherent to parse and
-            # the operator opening this in Obsidian sees a sensible
-            # body.  Slug is the filename stem — same convention
-            # discovery uses.
             stub_h1 = path.stem.replace("-", " ").replace("_", " ").title()
             text = f"# {stub_h1}\n"
-        metadata, body, _raw = _split_frontmatter(text)
-        metadata["type"] = LIVE_CONCEPT_TYPE
-        metadata["live"] = _frontmatter_to_yaml_block(fm)
+        raw, body, fence = _split_frontmatter(text)
+        if not fence:
+            fence = _STANDARD_FENCE
+        raw = _splice_top_level_block(raw, "type", f"type: {LIVE_CONCEPT_TYPE}")
+        raw = _splice_top_level_block(raw, "live", _render_live_block(fm))
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(_join_frontmatter(metadata, body), encoding="utf-8")
+        path.write_text(_join_frontmatter(raw, body, fence), encoding="utf-8")
 
 
 def patch_live(
@@ -254,16 +420,29 @@ def patch_live(
     Returns the new (post-patch) frontmatter so callers don't have
     to re-parse the file.
 
-    Raises ``ValueError`` when ``path`` doesn't carry a parseable
-    ``live:`` block — caller is expected to use :func:`set_live`
-    for first-time declarations.
+    Raises ``ValueError`` when:
+
+    * ``path`` doesn't exist
+    * the file isn't marked ``type: live-concept`` (we refuse to
+      claim a non-live note even when it happens to carry a
+      ``live:`` key — caller is expected to use :func:`set_live`
+      for first-time declarations)
+    * the ``live:`` block is missing or unparseable
     """
     with acquire_lock(path):
         text = _read_file(path)
         if not text:
             raise ValueError(f"cannot patch_live: {path} does not exist")
-        metadata, body, _raw = _split_frontmatter(text)
-        current_block = metadata.get("live")
+        raw, body, fence = _split_frontmatter(text)
+        if not fence:
+            raise ValueError(
+                f"cannot patch_live: {path} has no frontmatter"
+            )
+        if _read_top_level_value(raw, "type") != LIVE_CONCEPT_TYPE:
+            raise ValueError(
+                f"cannot patch_live: {path} is not type: {LIVE_CONCEPT_TYPE}"
+            )
+        current_block = _read_top_level_value(raw, "live")
         current_fm = parse_live_concept_block(current_block)
         if current_fm is None:
             raise ValueError(
@@ -277,9 +456,8 @@ def patch_live(
                 f"unknown LiveConceptFrontmatter field; "
                 f"valid: {valid}"
             ) from exc
-        metadata["type"] = LIVE_CONCEPT_TYPE
-        metadata["live"] = _frontmatter_to_yaml_block(new_fm)
-        path.write_text(_join_frontmatter(metadata, body), encoding="utf-8")
+        raw = _splice_top_level_block(raw, "live", _render_live_block(new_fm))
+        path.write_text(_join_frontmatter(raw, body, fence), encoding="utf-8")
         return new_fm
 
 
@@ -288,17 +466,20 @@ def delete_live(path: Path, *, acquire_lock: Any = _default_lock) -> None:
     ``type: live-concept`` marker.  Body content is preserved
     verbatim so the markdown stays readable in Obsidian.
 
-    No-op when the file doesn't exist or doesn't carry a ``live:``
-    block — idempotent on re-runs.
+    No-op when the file doesn't exist or doesn't carry a
+    ``type: live-concept`` marker — idempotent on re-runs, and
+    refuses to strip a stray ``live:`` key from a non-live note
+    (that key isn't ours to remove).
     """
     with acquire_lock(path):
         text = _read_file(path)
         if not text:
             return
-        metadata, body, _raw = _split_frontmatter(text)
-        if "live" not in metadata and metadata.get("type") != LIVE_CONCEPT_TYPE:
+        raw, body, fence = _split_frontmatter(text)
+        if not fence:
             return
-        metadata.pop("live", None)
-        if metadata.get("type") == LIVE_CONCEPT_TYPE:
-            metadata.pop("type")
-        path.write_text(_join_frontmatter(metadata, body), encoding="utf-8")
+        if _read_top_level_value(raw, "type") != LIVE_CONCEPT_TYPE:
+            return
+        raw = _splice_top_level_block(raw, "live", None)
+        raw = _splice_top_level_block(raw, "type", None)
+        path.write_text(_join_frontmatter(raw, body, fence), encoding="utf-8")

--- a/tests/test_live_concept.py
+++ b/tests/test_live_concept.py
@@ -1,0 +1,432 @@
+"""BL-063 PR#1: Live Concept data model + discovery + fileops.
+
+Covers ``live_concept`` (parser + discovery) and
+``live_concept_fileops`` (single-writer for the ``live:`` block).
+
+PR#2 (triggers) and PR#3 (agent prompt) build on top of these
+primitives — no triggers / agent calls exercised here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# parse_live_concept_block — the YAML-block parser
+# ---------------------------------------------------------------------------
+
+
+def test_parse_block_minimal_objective_only():
+    from ovp_pipeline.live_concept import parse_live_concept_block
+
+    fm = parse_live_concept_block({"objective": "Track LLM evals."})
+    assert fm is not None
+    assert fm.objective == "Track LLM evals."
+    assert fm.is_active is True
+    assert fm.triggers == {}
+    assert fm.scope_evergreens == ()
+
+
+def test_parse_block_full_shape():
+    from ovp_pipeline.live_concept import parse_live_concept_block
+
+    fm = parse_live_concept_block({
+        "objective": "Track LLM evals.",
+        "active": True,
+        "triggers": {
+            "on_ingest_match": {"concept_similarity_to": "llm-eval"},
+            "weekly_resynthesis": "Mon 09:00",
+        },
+        "scope_evergreens": ["llm-eval-leakage", "eval-cost-vs-quality"],
+        "lastAttemptAt": "2026-05-10T08:00:00Z",
+        "lastRunAt": "2026-05-10T08:00:01Z",
+        "lastRunSummary": "Refreshed.",
+        "lastRunError": "",
+    })
+    assert fm is not None
+    assert fm.scope_evergreens == ("llm-eval-leakage", "eval-cost-vs-quality")
+    assert fm.last_attempt_at == "2026-05-10T08:00:00Z"
+    assert fm.triggers["on_ingest_match"]["concept_similarity_to"] == "llm-eval"
+
+
+def test_parse_block_rejects_missing_objective():
+    from ovp_pipeline.live_concept import parse_live_concept_block
+
+    assert parse_live_concept_block({}) is None
+    assert parse_live_concept_block({"objective": ""}) is None
+    assert parse_live_concept_block({"objective": "   "}) is None
+    assert parse_live_concept_block({"active": True}) is None
+
+
+def test_parse_block_explicit_false_active_disables():
+    """``active: false`` is the documented escape hatch — the
+    scheduler must skip it."""
+    from ovp_pipeline.live_concept import parse_live_concept_block
+
+    fm = parse_live_concept_block({"objective": "x", "active": False})
+    assert fm is not None
+    assert fm.is_active is False
+
+
+def test_parse_block_null_active_disables():
+    """``active: null`` is the YAML way to say "explicitly empty";
+    same as False — disables."""
+    from ovp_pipeline.live_concept import parse_live_concept_block
+
+    fm = parse_live_concept_block({"objective": "x", "active": None})
+    assert fm is not None
+    assert fm.is_active is False
+
+
+def test_parse_block_missing_active_defaults_true():
+    """When the key isn't there at all → active (the common case
+    after a fresh `set_live`)."""
+    from ovp_pipeline.live_concept import parse_live_concept_block
+
+    fm = parse_live_concept_block({"objective": "x"})
+    assert fm is not None
+    assert fm.is_active is True
+
+
+def test_parse_block_handles_single_string_scope():
+    """YAML ``scope_evergreens: foo`` (string instead of list) is
+    coerced to a one-tuple — be liberal on shape, conservative on
+    field names."""
+    from ovp_pipeline.live_concept import parse_live_concept_block
+
+    fm = parse_live_concept_block({
+        "objective": "x",
+        "scope_evergreens": "single-evergreen-slug",
+    })
+    assert fm is not None
+    assert fm.scope_evergreens == ("single-evergreen-slug",)
+
+
+def test_parse_block_drops_blank_scope_entries():
+    from ovp_pipeline.live_concept import parse_live_concept_block
+
+    fm = parse_live_concept_block({
+        "objective": "x",
+        "scope_evergreens": ["alpha", "", "beta", None, "  gamma  "],
+    })
+    assert fm is not None
+    assert fm.scope_evergreens == ("alpha", "beta", "gamma")
+
+
+def test_parse_block_rejects_non_dict_inputs():
+    from ovp_pipeline.live_concept import parse_live_concept_block
+
+    assert parse_live_concept_block(None) is None
+    assert parse_live_concept_block("not a dict") is None
+    assert parse_live_concept_block(["list"]) is None
+
+
+# ---------------------------------------------------------------------------
+# parse_live_concept — full file path
+# ---------------------------------------------------------------------------
+
+
+def _write_concept_file(tmp_path, slug, frontmatter_yaml, body="\n# Test body\n"):
+    path = tmp_path / "30-Projects" / "Tracking" / f"{slug}.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = f"---\n{frontmatter_yaml.strip()}\n---\n{body}"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_parse_full_file_returns_handle(tmp_path):
+    from ovp_pipeline.live_concept import parse_live_concept
+
+    path = _write_concept_file(
+        tmp_path, "llm-eval",
+        """type: live-concept
+live:
+  objective: Track LLM evals.
+  active: true
+  scope_evergreens:
+    - llm-eval-leakage""",
+    )
+    handle = parse_live_concept(path)
+    assert handle is not None
+    assert handle.slug == "llm-eval"
+    assert handle.relative_path == "30-Projects/Tracking/llm-eval.md"
+    assert handle.frontmatter.scope_evergreens == ("llm-eval-leakage",)
+
+
+def test_parse_rejects_file_without_type_marker(tmp_path):
+    """Frontmatter has a ``live:`` block but no ``type: live-concept``
+    — could be any other note type accidentally using the key.
+    Refuse to claim it."""
+    from ovp_pipeline.live_concept import parse_live_concept
+
+    path = _write_concept_file(
+        tmp_path, "notmine",
+        """type: evergreen
+live:
+  objective: this should not be treated as a live concept""",
+    )
+    assert parse_live_concept(path) is None
+
+
+def test_parse_rejects_file_without_live_block(tmp_path):
+    from ovp_pipeline.live_concept import parse_live_concept
+
+    path = _write_concept_file(
+        tmp_path, "noliveblock",
+        "type: live-concept",
+    )
+    assert parse_live_concept(path) is None
+
+
+def test_parse_rejects_file_with_no_frontmatter(tmp_path):
+    from ovp_pipeline.live_concept import parse_live_concept
+
+    path = tmp_path / "30-Projects" / "Tracking" / "no-fm.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("# Plain markdown\n\nNo frontmatter here.\n", encoding="utf-8")
+    assert parse_live_concept(path) is None
+
+
+def test_parse_returns_none_for_missing_file(tmp_path):
+    from ovp_pipeline.live_concept import parse_live_concept
+
+    assert parse_live_concept(tmp_path / "nonexistent.md") is None
+
+
+# ---------------------------------------------------------------------------
+# list_live_concepts — discovery
+# ---------------------------------------------------------------------------
+
+
+def test_list_walks_tracking_directory(tmp_path):
+    from ovp_pipeline.live_concept import list_live_concepts
+
+    _write_concept_file(tmp_path, "concept-a",
+        "type: live-concept\nlive:\n  objective: A")
+    _write_concept_file(tmp_path, "concept-b",
+        "type: live-concept\nlive:\n  objective: B")
+
+    handles = list_live_concepts(tmp_path)
+    slugs = sorted(h.slug for h in handles)
+    assert slugs == ["concept-a", "concept-b"]
+
+
+def test_list_skips_non_live_concept_files(tmp_path):
+    """Tracking directory may contain unrelated .md files (drafts,
+    indexes); discovery silently ignores them."""
+    from ovp_pipeline.live_concept import list_live_concepts
+
+    _write_concept_file(tmp_path, "live-one",
+        "type: live-concept\nlive:\n  objective: yes")
+    # A regular note in the same dir — must NOT appear in results.
+    plain = tmp_path / "30-Projects" / "Tracking" / "draft.md"
+    plain.write_text("---\ntype: note\n---\n\nDraft body.\n", encoding="utf-8")
+
+    handles = list_live_concepts(tmp_path)
+    assert [h.slug for h in handles] == ["live-one"]
+
+
+def test_list_returns_empty_on_missing_directory(tmp_path):
+    from ovp_pipeline.live_concept import list_live_concepts
+
+    # No 30-Projects/Tracking/ dir at all → empty list, no exception.
+    assert list_live_concepts(tmp_path) == []
+
+
+def test_list_active_only_filters_passive(tmp_path):
+    from ovp_pipeline.live_concept import list_live_concepts
+
+    _write_concept_file(tmp_path, "alive",
+        "type: live-concept\nlive:\n  objective: alive\n  active: true")
+    _write_concept_file(tmp_path, "paused",
+        "type: live-concept\nlive:\n  objective: paused\n  active: false")
+
+    all_handles = list_live_concepts(tmp_path)
+    assert sorted(h.slug for h in all_handles) == ["alive", "paused"]
+
+    active_only = list_live_concepts(tmp_path, active_only=True)
+    assert [h.slug for h in active_only] == ["alive"]
+
+
+# ---------------------------------------------------------------------------
+# fileops: set_live / patch_live / delete_live
+# ---------------------------------------------------------------------------
+
+
+def test_set_live_creates_file_when_missing(tmp_path):
+    from ovp_pipeline.live_concept import (
+        LiveConceptFrontmatter,
+        parse_live_concept,
+    )
+    from ovp_pipeline.live_concept_fileops import set_live
+
+    path = tmp_path / "30-Projects" / "Tracking" / "fresh.md"
+    set_live(
+        path,
+        LiveConceptFrontmatter(
+            objective="Track LLM evals.",
+            scope_evergreens=("eval-cost-vs-quality",),
+        ),
+    )
+    handle = parse_live_concept(path)
+    assert handle is not None
+    assert handle.frontmatter.objective == "Track LLM evals."
+    assert handle.frontmatter.scope_evergreens == ("eval-cost-vs-quality",)
+    # Stub body materialised so Obsidian shows something meaningful.
+    text = path.read_text(encoding="utf-8")
+    assert "# Fresh" in text
+
+
+def test_set_live_preserves_other_frontmatter_keys(tmp_path):
+    """When the file already has frontmatter (e.g. ``aliases``,
+    ``tags``), set_live must leave those keys alone — only touches
+    ``type`` and ``live``."""
+    from ovp_pipeline.live_concept import (
+        LiveConceptFrontmatter,
+        parse_live_concept,
+    )
+    from ovp_pipeline.live_concept_fileops import set_live
+
+    path = tmp_path / "30-Projects" / "Tracking" / "existing.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "---\ntags:\n  - llm\n  - eval\naliases:\n  - LLM Eval\n---\n\n"
+        "# Existing\n\nBody preserved.\n",
+        encoding="utf-8",
+    )
+    set_live(path, LiveConceptFrontmatter(objective="Track."))
+
+    text = path.read_text(encoding="utf-8")
+    assert "tags:" in text and "llm" in text and "eval" in text
+    assert "aliases:" in text and "LLM Eval" in text
+    assert "Body preserved." in text
+    handle = parse_live_concept(path)
+    assert handle is not None and handle.frontmatter.objective == "Track."
+
+
+def test_patch_live_updates_subset_keeps_rest(tmp_path):
+    from ovp_pipeline.live_concept import (
+        LiveConceptFrontmatter,
+        parse_live_concept,
+    )
+    from ovp_pipeline.live_concept_fileops import patch_live, set_live
+
+    path = tmp_path / "30-Projects" / "Tracking" / "patchable.md"
+    set_live(
+        path,
+        LiveConceptFrontmatter(
+            objective="Track LLM evals.",
+            scope_evergreens=("a", "b"),
+        ),
+    )
+    new_fm = patch_live(
+        path,
+        last_attempt_at="2026-05-10T08:00:00Z",
+        last_run_at="2026-05-10T08:00:01Z",
+        last_run_summary="Refreshed.",
+    )
+    # Patched fields updated.
+    assert new_fm.last_attempt_at == "2026-05-10T08:00:00Z"
+    assert new_fm.last_run_summary == "Refreshed."
+    # User-edited fields preserved.
+    assert new_fm.objective == "Track LLM evals."
+    assert new_fm.scope_evergreens == ("a", "b")
+    # Disk read-back agrees.
+    handle = parse_live_concept(path)
+    assert handle is not None
+    assert handle.frontmatter.last_run_summary == "Refreshed."
+
+
+def test_patch_live_rejects_unknown_field(tmp_path):
+    from ovp_pipeline.live_concept import LiveConceptFrontmatter
+    from ovp_pipeline.live_concept_fileops import patch_live, set_live
+
+    path = tmp_path / "30-Projects" / "Tracking" / "x.md"
+    set_live(path, LiveConceptFrontmatter(objective="x"))
+
+    with pytest.raises(TypeError, match=r"valid"):
+        patch_live(path, lastAttemptAt="2026-05-10")  # camelCase typo
+
+
+def test_patch_live_raises_on_missing_block(tmp_path):
+    from ovp_pipeline.live_concept_fileops import patch_live
+
+    path = tmp_path / "30-Projects" / "Tracking" / "noblock.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "---\ntype: note\n---\n\n# No live block\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match=r"no parseable"):
+        patch_live(path, last_run_at="2026-05-10")
+
+
+def test_delete_live_strips_block_keeps_body(tmp_path):
+    from ovp_pipeline.live_concept import LiveConceptFrontmatter, parse_live_concept
+    from ovp_pipeline.live_concept_fileops import delete_live, set_live
+
+    path = tmp_path / "30-Projects" / "Tracking" / "doomed.md"
+    set_live(path, LiveConceptFrontmatter(objective="x"))
+    # Append a body the operator would have hand-written.
+    body = "\n## My take\n\nMy real opinion lives here.\n"
+    path.write_text(path.read_text(encoding="utf-8") + body, encoding="utf-8")
+
+    delete_live(path)
+
+    text = path.read_text(encoding="utf-8")
+    assert "live:" not in text  # block stripped
+    assert "type: live-concept" not in text  # marker stripped
+    assert "My real opinion lives here." in text  # body preserved
+    # And it no longer parses as a live concept.
+    assert parse_live_concept(path) is None
+
+
+def test_delete_live_idempotent(tmp_path):
+    """No-op when the file isn't a live concept — delete twice is fine."""
+    from ovp_pipeline.live_concept_fileops import delete_live
+
+    path = tmp_path / "30-Projects" / "Tracking" / "plain.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("# Plain\n\nBody.\n", encoding="utf-8")
+    delete_live(path)
+    delete_live(path)  # second call also a no-op
+    assert path.read_text(encoding="utf-8") == "# Plain\n\nBody.\n"
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: set_live → parse_live_concept agrees
+# ---------------------------------------------------------------------------
+
+
+def test_round_trip_preserves_all_fields(tmp_path):
+    from ovp_pipeline.live_concept import (
+        LiveConceptFrontmatter,
+        parse_live_concept,
+    )
+    from ovp_pipeline.live_concept_fileops import set_live
+
+    original = LiveConceptFrontmatter(
+        objective="A multi-line\nobjective with newlines.",
+        active=True,
+        triggers={
+            "on_ingest_match": {
+                "concept_similarity_to": "llm-eval",
+                "threshold": 0.65,
+            },
+            "weekly_resynthesis": "Mon 09:00",
+        },
+        scope_evergreens=("alpha", "beta"),
+        last_run_at="2026-05-10T08:00:01Z",
+        last_run_summary="Synthesis refreshed.",
+    )
+    path = tmp_path / "30-Projects" / "Tracking" / "rt.md"
+    set_live(path, original)
+    handle = parse_live_concept(path)
+    assert handle is not None
+    rt = handle.frontmatter
+    assert rt.objective == original.objective
+    assert rt.scope_evergreens == original.scope_evergreens
+    assert rt.triggers == original.triggers
+    assert rt.last_run_at == original.last_run_at
+    assert rt.last_run_summary == original.last_run_summary

--- a/tests/test_live_concept.py
+++ b/tests/test_live_concept.py
@@ -350,12 +350,14 @@ def test_patch_live_rejects_unknown_field(tmp_path):
 
 
 def test_patch_live_raises_on_missing_block(tmp_path):
+    """File is marked ``type: live-concept`` but has no ``live:``
+    block (e.g. operator deleted it by hand).  Patch refuses."""
     from ovp_pipeline.live_concept_fileops import patch_live
 
     path = tmp_path / "30-Projects" / "Tracking" / "noblock.md"
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
-        "---\ntype: note\n---\n\n# No live block\n",
+        "---\ntype: live-concept\n---\n\n# No live block\n",
         encoding="utf-8",
     )
     with pytest.raises(ValueError, match=r"no parseable"):
@@ -397,6 +399,174 @@ def test_delete_live_idempotent(tmp_path):
 # ---------------------------------------------------------------------------
 # Round-trip: set_live → parse_live_concept agrees
 # ---------------------------------------------------------------------------
+
+
+def test_patch_live_rejects_file_without_type_marker(tmp_path):
+    """Codex review fix: a non-live note that happens to carry a
+    ``live:`` key is not ours to claim — patch_live must refuse
+    rather than silently flipping ``type:`` to ``live-concept``."""
+    from ovp_pipeline.live_concept_fileops import patch_live
+
+    path = tmp_path / "30-Projects" / "Tracking" / "stray.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "---\ntype: note\nlive:\n  objective: not yours to touch\n---\n\nbody\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match=r"not type"):
+        patch_live(path, last_run_at="2026-05-10")
+
+
+def test_delete_live_refuses_non_live_concept_file(tmp_path):
+    """Codex review fix: ``delete_live`` only acts on files marked
+    ``type: live-concept``; a stray ``live:`` key in a regular note
+    survives untouched."""
+    from ovp_pipeline.live_concept_fileops import delete_live
+
+    path = tmp_path / "30-Projects" / "Tracking" / "stray.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    original = (
+        "---\ntype: note\nlive:\n  objective: not yours to touch\n---\n\nbody\n"
+    )
+    path.write_text(original, encoding="utf-8")
+    delete_live(path)
+    assert path.read_text(encoding="utf-8") == original
+
+
+def test_set_live_preserves_yaml_comments_on_other_keys(tmp_path):
+    """Codex review fix: re-rendering the whole metadata dict would
+    drop comments on adjacent keys.  The splice-based writer leaves
+    them verbatim."""
+    from ovp_pipeline.live_concept import LiveConceptFrontmatter
+    from ovp_pipeline.live_concept_fileops import set_live
+
+    path = tmp_path / "30-Projects" / "Tracking" / "commented.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "---\n"
+        "# operator-managed tag block — keep as-is\n"
+        "tags:\n"
+        "  - llm  # primary topic\n"
+        "  - eval\n"
+        "---\n\n# Commented\n",
+        encoding="utf-8",
+    )
+    set_live(path, LiveConceptFrontmatter(objective="Track."))
+    text = path.read_text(encoding="utf-8")
+    assert "# operator-managed tag block — keep as-is" in text
+    assert "# primary topic" in text
+
+
+def test_patch_live_preserves_yaml_comments_on_other_keys(tmp_path):
+    """Same verbatim contract on the patch path."""
+    from ovp_pipeline.live_concept import (
+        LiveConceptFrontmatter,
+        parse_live_concept,
+    )
+    from ovp_pipeline.live_concept_fileops import patch_live, set_live
+
+    path = tmp_path / "30-Projects" / "Tracking" / "patched.md"
+    set_live(path, LiveConceptFrontmatter(objective="Track."))
+    # Operator inserts a comment + tag block by hand in Obsidian.
+    text = path.read_text(encoding="utf-8")
+    text = text.replace(
+        "type: live-concept\n",
+        "type: live-concept\n# user-curated tags below\ntags:\n  - llm  # primary\n",
+    )
+    path.write_text(text, encoding="utf-8")
+    patch_live(path, last_attempt_at="2026-05-10T08:00:00Z")
+    after = path.read_text(encoding="utf-8")
+    assert "# user-curated tags below" in after
+    assert "# primary" in after
+    handle = parse_live_concept(path)
+    assert handle is not None
+    assert handle.frontmatter.last_attempt_at == "2026-05-10T08:00:00Z"
+
+
+def test_set_live_handles_fenced_yaml_frontmatter(tmp_path):
+    """Codex review fix: ``runtime.split_markdown_frontmatter`` reads
+    fenced YAML; the fileops writer must round-trip it without
+    breaking parser symmetry."""
+    from ovp_pipeline.live_concept import (
+        LiveConceptFrontmatter,
+        parse_live_concept,
+    )
+    from ovp_pipeline.live_concept_fileops import patch_live, set_live
+
+    path = tmp_path / "30-Projects" / "Tracking" / "fenced.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "```yaml\n---\ntags:\n  - llm\n---\n```\n\n# Fenced\n",
+        encoding="utf-8",
+    )
+    set_live(path, LiveConceptFrontmatter(objective="Track."))
+    text = path.read_text(encoding="utf-8")
+    # Fence preserved.
+    assert text.startswith("```yaml\n---\n")
+    assert "\n---\n```\n" in text
+    # And patch_live can still drive the runtime fields.
+    patch_live(path, last_attempt_at="2026-05-10T08:00:00Z")
+    handle = parse_live_concept(path)
+    assert handle is not None
+    assert handle.frontmatter.last_attempt_at == "2026-05-10T08:00:00Z"
+
+
+def test_patch_live_uses_supplied_lock(tmp_path):
+    """The ``acquire_lock`` parameter is the future hook for PR#2's
+    trigger scheduler.  Verify it's actually entered/exited per call
+    so PR#2 can wire a real ``filelock`` without surprises."""
+    from contextlib import contextmanager
+
+    from ovp_pipeline.live_concept import LiveConceptFrontmatter
+    from ovp_pipeline.live_concept_fileops import patch_live, set_live
+
+    calls: list[str] = []
+
+    @contextmanager
+    def tracking_lock(_path):
+        calls.append("enter")
+        try:
+            yield
+        finally:
+            calls.append("exit")
+
+    path = tmp_path / "30-Projects" / "Tracking" / "locked.md"
+    set_live(
+        path,
+        LiveConceptFrontmatter(objective="Track."),
+        acquire_lock=tracking_lock,
+    )
+    patch_live(
+        path,
+        last_run_at="2026-05-10T08:00:00Z",
+        acquire_lock=tracking_lock,
+    )
+    # set_live + patch_live = two enter/exit pairs.
+    assert calls == ["enter", "exit", "enter", "exit"]
+
+
+def test_parse_block_triggers_non_dict_falls_back_to_empty(tmp_path):
+    """Coverage gap from codex review: ``triggers: "weekly"`` (a
+    string instead of a dict) must not crash — the parser is liberal
+    on shape per the schema."""
+    from ovp_pipeline.live_concept import parse_live_concept_block
+
+    fm = parse_live_concept_block({
+        "objective": "x",
+        "triggers": "weekly",  # malformed — not a dict
+    })
+    assert fm is not None
+    assert fm.triggers == {}
+
+
+def test_parse_block_active_quoted_string_truthy(tmp_path):
+    """``active: "true"`` (quoted, so YAML parses as a string)
+    coerces to truthy.  Same liberal-on-shape pattern."""
+    from ovp_pipeline.live_concept import parse_live_concept_block
+
+    fm = parse_live_concept_block({"objective": "x", "active": "true"})
+    assert fm is not None
+    assert fm.is_active is True
 
 
 def test_round_trip_preserves_all_fields(tmp_path):


### PR DESCRIPTION
## Summary

PR #1 of 3 for BL-063 (M19 — Live Concept Interpretation Surface). Lands the **data layer** that PR#2 (triggers) and PR#3 (agent prompt + section-aware edits) build on top of. Shippable on its own — no production code path references the new modules yet, but the parser + fileops are independently testable and the schema is locked in.

## Why Live Concept exists

OVP today maintains the **Artifact + Claim** ledgers (evergreens + provenance + claims). The four-ledger model `Artifact / Claim / Interpretation / Commitment` (saved in operator memory) has **Interpretation** as the missing 4th — there's no surface where "my current view of topic X" lives that auto-synthesises against new evidence. Live Concepts are that surface: declarative `30-Projects/Tracking/<slug>.md` files where the agent maintains synthesis sections while the user owns `## My take`.

## What's in this PR

| File | What |
|---|---|
| `src/ovp_pipeline/live_concept.py` | `LiveConceptFrontmatter` + `LiveConceptHandle` dataclasses, `parse_live_concept_block`, `parse_live_concept`, `list_live_concepts` |
| `src/ovp_pipeline/live_concept_fileops.py` | Single-writer for the `live:` YAML key — `set_live` / `patch_live` / `delete_live`. Same architectural pattern as BL-060 (canonical SQL tables) but at the frontmatter-key level |
| `tests/test_live_concept.py` | 26 tests across block parser, file parser, discovery, fileops, round-trip |

## Schema

Two-part frontmatter:
- `type: live-concept` — flag that distinguishes from other `type:` notes (evergreen, moc, decision)
- `live:` block carrying:
  - `objective` (required, free-form natural language)
  - `active` (default true; `false`/`null` disables)
  - `triggers` (free-form dict; per-trigger validation deferred to PR#2 so future trigger types don't need a schema bump)
  - `scope_evergreens` (list of evergreen slugs this concept tracks)
  - Runtime fields: `lastAttemptAt` / `lastRunAt` / `lastRunSummary` / `lastRunError` (camelCase — matches Rowboat's LiveNote convention)

## Liberal-on-shape, conservative-on-names

- `scope_evergreens: foo` (string) is coerced to `("foo",)` 
- `lastRunAt` not `last_run_at` in YAML (camelCase pinned)
- Unknown extra keys silently dropped (forward-compat for future BLs)
- Missing required `objective` → parser returns `None` (silent skip — never raises during a vault scan)

## Test coverage (26 new)

| Layer | # | Highlights |
|---|---|---|
| Block parser | 8 | Minimal, full shape, missing objective, explicit-false/null active, missing-active-defaults-true, scope coercion, blank-entry filter, non-dict rejection |
| File parser | 5 | Full handle path, missing type marker, missing live block, no frontmatter, missing file |
| Discovery | 4 | Walks Tracking, skips non-live, empty for missing dir, `active_only` filter |
| Fileops | 8 | Set creates / preserves other keys / patch subset / unknown-field reject / no-block reject / delete strips / delete idempotent |
| Round-trip | 1 | set → parse agrees on every field |

## Verification

- [x] `rtk proxy python -m pytest tests/test_live_concept.py -q` → **26 passed in 0.12s**
- [x] `test_canonical_writes_have_single_owner` passes (new modules don't write canonical SQL)
- [x] Full suite: **2323 passed, 15 xfailed**. 3 pre-existing failures reproduce on `main`.
- [x] `ruff check` clean on touched files

## What's next

- **PR#2** wires the three triggers (`on_ingest_match` / `on_contradiction_against_view` / `weekly_resynthesis`). Includes a one-shot `ovp-live-concept-scan` CLI so user can trigger fires manually before autopilot picks it up.
- **PR#3** wires agent prompt + section-aware patch edits (agent rewrites `## Current synthesis` / `## Recent evidence` / `## Tensions` while leaving `## My take` byte-for-byte intact).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Live Concept system for tracking and managing project concepts with structured YAML metadata
  * Added parsing and automatic discovery of live concepts from markdown files with flexible filtering options
  * Implemented create, update, and delete operations for live concept records while preserving surrounding markdown content

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fakechris/obsidian_vault_pipeline/pull/197)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->