### PR TITLE
fix(absorb): remove dead init_llm() call (post-BL-029 regression)

### DIFF
--- a/src/ovp_pipeline/commands/absorb.py
+++ b/src/ovp_pipeline/commands/absorb.py
@@ -289,38 +289,62 @@ def run_source_lifecycle_for_absorb_targets(
     dry_run: bool,
     failures: list[dict[str, str]] | None = None,
 ) -> list[Path]:
+    """Drive raw sources through the intake lifecycle, returning the
+    archived 03-Processed paths to feed to absorb v2.
+
+    Post-BL-029 (commit ``bde1b8b``), :class:`AutoArticleProcessor`
+    is intake-only — the legacy 13-section LLM deep-dive layer is
+    gone, so ``process_single_file`` returns ``status="intake_only"``
+    instead of ``"completed"`` and never produces an ``output_path``.
+    The function calls ``process_single_source``, which:
+
+    * URL-dedups against the active staging chain (BL-058)
+    * Migrates Clippings → 01-Raw → 02-Processing
+    * Downloads remote images
+    * Parses frontmatter
+    * Archives to ``50-Inbox/03-Processed/YYYY-MM/``
+
+    The archived path *is* the absorb target — absorb v2 reads the
+    raw markdown directly via ``run_absorb_workflow``.  Files
+    already inside 03-Processed are pass-through (no lifecycle
+    needed).
+    """
     layout = VaultLayout.from_vault(vault_dir)
     logger = PipelineLogger(layout.pipeline_log)
     txn = TransactionManager(layout.transactions_dir)
-    clippings = ClippingsProcessor(layout.vault_dir, logger, txn)
     processor = AutoArticleProcessor(layout.vault_dir, logger, txn)
-    if not dry_run:
-        processor.init_llm()
 
-    deep_dive_targets: list[Path] = []
+    absorb_targets: list[Path] = []
     for target in targets:
         for source in _expand_markdown_sources(target):
-            working_source = source
-            if _is_under(source, layout.clippings_dir):
-                if dry_run:
-                    continue
-                working_source = _move_clipping_to_raw(layout, clippings, source)
-
             if dry_run:
                 continue
 
-            if _is_under(working_source, layout.raw_dir):
-                working_source = processor._stage_source_for_processing(working_source)
+            # Already archived → no lifecycle move needed.  This is
+            # the common case after BL-058 decoupled intake from
+            # absorb: operator runs ``ovp --incremental`` to stage
+            # sources, then ``ovp-absorb --file …`` (or --dir on
+            # 03-Processed/…) when ready to write evergreens.
+            if _is_under(source, layout.processed_dir):
+                absorb_targets.append(source)
+                continue
 
-            result = processor.process_single_file(working_source, dry_run=False)
-            if result.get("status") == "completed" and result.get("output_path"):
-                deep_dive_targets.append(Path(str(result["output_path"])))
-                if _is_under(working_source, layout.processing_dir):
-                    _safe_archive_source_to_processed(processor, logger, failures, working_source)
-            elif _is_under(working_source, layout.processing_dir) and working_source.exists():
-                _safe_restore_source_to_raw(processor, logger, failures, working_source)
+            result = processor.process_single_source(source, dry_run=False)
+            status = result.get("status") or ""
+            archived = result.get("source_path") or result.get("output_path")
+            if status in ("completed", "intake_only") and archived:
+                absorb_targets.append(Path(str(archived)))
+            elif failures is not None:
+                # Skipped (url-dedup) / errored — surface to caller so
+                # absorb's payload reports the partial result rather
+                # than silently dropping rows.
+                failures.append({
+                    "source": str(source),
+                    "status": status or "unknown",
+                    "error": str(result.get("error") or "no archive produced"),
+                })
 
-    return deep_dive_targets
+    return absorb_targets
 
 
 def _merge_absorb_payloads(payloads: list[dict]) -> dict:

--- a/tests/test_absorb_refine_commands.py
+++ b/tests/test_absorb_refine_commands.py
@@ -607,35 +607,34 @@ def test_absorb_file_and_dir_filters_direct_dir_to_deduped_deep_dives(temp_vault
     assert calls == [deep_dive]
 
 
-def test_source_lifecycle_archive_failure_is_reported_without_dropping_deep_dive(temp_vault, monkeypatch):
+def test_source_lifecycle_post_bl029_uses_archived_path_as_absorb_target(temp_vault, monkeypatch):
+    """Post-BL-029 ``AutoArticleProcessor`` is intake-only:
+    ``process_single_source`` returns ``status='intake_only'`` with
+    the archived 03-Processed path in ``source_path``.  The lifecycle
+    wrapper must pass that path through as the absorb target (no
+    deep-dive synthesis between)."""
     from ovp_pipeline.commands import absorb
     from ovp_pipeline.runtime import VaultLayout
 
     layout = VaultLayout.from_vault(temp_vault)
-    layout.processing_dir.mkdir(parents=True, exist_ok=True)
-    source = layout.processing_dir / "Article.md"
+    layout.raw_dir.mkdir(parents=True, exist_ok=True)
+    source = layout.raw_dir / "Article.md"
     source.write_text("# Article\n", encoding="utf-8")
-    deep_dive = temp_vault / "20-Areas" / "AI-Research" / "Topics" / "2026-04" / "Article_深度解读.md"
+    archived = layout.processed_dir / "2026-05" / "Article.md"
 
     class FakeAutoArticleProcessor:
         def __init__(self, vault_dir: Path, logger, txn):
             self.layout = VaultLayout.from_vault(vault_dir)
             self.logger = logger
 
-        def init_llm(self) -> None:
-            pass
-
-        def process_single_file(self, file_path: Path, *, dry_run: bool) -> dict:
+        def process_single_source(self, file_path: Path, *, dry_run: bool) -> dict:
             assert file_path == source
             assert dry_run is False
-            return {"status": "completed", "output_path": str(deep_dive)}
-
-        def _archive_source_to_processed(self, file_path: Path) -> Path:
-            assert file_path == source
-            raise OSError("archive denied")
-
-        def _restore_source_to_raw(self, file_path: Path) -> Path:
-            raise AssertionError("completed sources should not be restored")
+            return {
+                "status": "intake_only",
+                "output_path": None,
+                "source_path": str(archived),
+            }
 
     monkeypatch.setattr(absorb, "AutoArticleProcessor", FakeAutoArticleProcessor)
     failures: list[dict[str, str]] = []
@@ -647,11 +646,84 @@ def test_source_lifecycle_archive_failure_is_reported_without_dropping_deep_dive
         failures=failures,
     )
 
-    assert targets == [deep_dive]
-    assert failures == [
-        {
-            "source": str(source),
-            "stage": "archive_to_processed",
-            "error": "archive denied",
-        }
-    ]
+    assert targets == [archived]
+    assert failures == []
+
+
+def test_source_lifecycle_records_failure_when_no_archive(temp_vault, monkeypatch):
+    """When intake fails (e.g. url-dedup skip, or processor error
+    leaves no archive), the source is reported in ``failures`` rather
+    than silently dropped — caller surfaces partial results."""
+    from ovp_pipeline.commands import absorb
+    from ovp_pipeline.runtime import VaultLayout
+
+    layout = VaultLayout.from_vault(temp_vault)
+    layout.raw_dir.mkdir(parents=True, exist_ok=True)
+    source = layout.raw_dir / "Article.md"
+    source.write_text("# Article\n", encoding="utf-8")
+
+    class FakeAutoArticleProcessor:
+        def __init__(self, vault_dir: Path, logger, txn):
+            self.layout = VaultLayout.from_vault(vault_dir)
+            self.logger = logger
+
+        def process_single_source(self, file_path: Path, *, dry_run: bool) -> dict:
+            return {
+                "status": "skipped",
+                "output_path": None,
+                "source_path": None,
+                "error": "url-dedup matched existing source",
+            }
+
+    monkeypatch.setattr(absorb, "AutoArticleProcessor", FakeAutoArticleProcessor)
+    failures: list[dict[str, str]] = []
+
+    targets = absorb.run_source_lifecycle_for_absorb_targets(
+        temp_vault,
+        [source],
+        dry_run=False,
+        failures=failures,
+    )
+
+    assert targets == []
+    assert len(failures) == 1
+    assert failures[0]["source"] == str(source)
+    assert failures[0]["status"] == "skipped"
+
+
+def test_source_lifecycle_passes_through_already_processed_files(temp_vault, monkeypatch):
+    """A file already in 03-Processed needs no lifecycle move — it
+    becomes the absorb target directly.  This is the common path
+    after ``ovp --incremental`` has staged sources but absorb hasn't
+    been run yet."""
+    from ovp_pipeline.commands import absorb
+    from ovp_pipeline.runtime import VaultLayout
+
+    layout = VaultLayout.from_vault(temp_vault)
+    processed = layout.processed_dir / "2026-05"
+    processed.mkdir(parents=True, exist_ok=True)
+    source = processed / "Article.md"
+    source.write_text("# Article\n", encoding="utf-8")
+
+    class FakeAutoArticleProcessor:
+        def __init__(self, vault_dir: Path, logger, txn):
+            self.layout = VaultLayout.from_vault(vault_dir)
+            self.logger = logger
+
+        def process_single_source(self, file_path: Path, *, dry_run: bool) -> dict:
+            raise AssertionError(
+                "already-processed sources must not re-run the intake lifecycle"
+            )
+
+    monkeypatch.setattr(absorb, "AutoArticleProcessor", FakeAutoArticleProcessor)
+    failures: list[dict[str, str]] = []
+
+    targets = absorb.run_source_lifecycle_for_absorb_targets(
+        temp_vault,
+        [source],
+        dry_run=False,
+        failures=failures,
+    )
+
+    assert targets == [source]
+    assert failures == []


### PR DESCRIPTION
## Summary

`commands/absorb.py:run_source_lifecycle_for_absorb_targets` was calling
`processor.init_llm()` — a method removed in commit bde1b8b (BL-029 deep-dive
layer drop, #173).  Every `ovp-absorb --file <intake_source>` invocation
crashed with `AttributeError`.

The bug was masked by tests that mock the lifecycle function entirely.  Found
while trying to verify BL-062 shadow router on live data.

## What changed

* Rewrote the lifecycle wrapper to call `process_single_source` (which
  handles the unified intake flow) instead of the removed `init_llm` +
  half-dead `process_single_file` + separate archive calls.
* Pass through files already in `03-Processed/` as direct absorb targets.
* Record failure rows when intake produces no archive (url-dedup skip etc.).
* Replaced one legacy mock-test with three focused cases.

## Test plan

- [x] `pytest tests/test_absorb_refine_commands.py -q` — 20 passed (was 19)
- [x] Architecture-fitness `test_canonical_writes_have_single_owner` green
- [x] Verified by attempting absorb on a 03-Processed file: lifecycle
      wrapper now runs cleanly (the downstream extractor guard is a
      separate issue — see note below)

## Known follow-up (out of scope)

`auto_evergreen_extractor._reject_intake_source_target` (line 1299) blocks any
path under `50-Inbox/` with `ValueError: absorb target is an intake source`.
That guard predates BL-058's "absorb v2 reads the raw directly" intent.  This
PR is necessary but not sufficient for end-to-end source absorb — it just
removes the immediate crash.  A follow-up PR needs to either remove that
guard or add a "source mode" code path.  For now `ovp-absorb` remains a
deep-dive-file-only entry point.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved source processing pipeline efficiency with streamlined intake lifecycle handling
  * Enhanced error handling with structured failure tracking and better information capture

* **Tests**
  * Expanded test coverage for source intake workflows, failure recording, and pass-through scenarios

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fakechris/obsidian_vault_pipeline/pull/199)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->