### PR TITLE
feat(bl-069): embedding-based top-K pre-filter for absorb router

### DIFF
--- a/src/ovp_pipeline/absorb_router.py
+++ b/src/ovp_pipeline/absorb_router.py
@@ -114,6 +114,216 @@ class IndexEntry:
     key_claims: tuple[str, ...] = ()
 
 
+def _decode_embedding_blob(blob: bytes) -> list[float]:
+    """Decode a float32 BLOB stored in ``page_embeddings.embedding_blob``
+    into a Python list.  Empty / malformed input → ``[]`` so callers
+    can skip silently rather than raise."""
+    if not blob:
+        return []
+    try:
+        from array import array
+        decoded = array("f")
+        decoded.frombytes(blob)
+        return list(decoded)
+    except (TypeError, ValueError):
+        return []
+
+
+def _load_evergreen_vectors_for_pack(
+    db_path: Path,
+    embedding_model: str,
+    pack_name: str | None,
+) -> dict[str, list[float]]:
+    """Load ``slug → mean-vector`` for every evergreen with embeddings
+    in the given pack (or all packs when ``None``), restricted to
+    the active embedding model.
+
+    Joins ``page_embeddings`` to ``objects`` so we can filter by
+    pack — the page_embeddings table itself has no pack column.
+    Mean-vector aggregates across all chunks per slug, matching the
+    existing :func:`embedding_dedup._load_page_vectors` pattern.
+
+    Returns an empty dict when:
+
+    * the DB is missing
+    * the ``page_embeddings`` table is empty
+    * no row matches the embedding-model filter (rare: vault built
+      with the hash backend on a Qwen-only client, or vice versa)
+    """
+    if not db_path.exists():
+        return {}
+    if pack_name:
+        sql = (
+            "SELECT pe.slug, pe.embedding_blob "
+            "FROM page_embeddings pe "
+            "JOIN objects o ON pe.slug = o.object_id "
+            "WHERE pe.embedding_model = ? AND o.pack = ?"
+        )
+        params: tuple[Any, ...] = (embedding_model, pack_name)
+    else:
+        sql = (
+            "SELECT pe.slug, pe.embedding_blob "
+            "FROM page_embeddings pe "
+            "JOIN objects o ON pe.slug = o.object_id "
+            "WHERE pe.embedding_model = ?"
+        )
+        params = (embedding_model,)
+    try:
+        with sqlite3.connect(db_path) as conn:
+            rows = conn.execute(sql, params).fetchall()
+    except sqlite3.OperationalError:
+        # ``page_embeddings`` or ``objects`` missing — old vault that
+        # hasn't been rebuilt since BL-039.  Fall back to None
+        # (caller goes alphabetical) rather than crash.
+        return {}
+
+    # Aggregate chunks per slug by mean.  Pure-Python sum is OK at
+    # 9K slugs × 10 chunks/slug × 1024 dim ≈ 100M float ops total
+    # (~1s on M-series Mac); the actual hot path is the cosine
+    # scoring below.  Caching is a TODO when this becomes the
+    # bottleneck.
+    slug_chunks: dict[str, list[list[float]]] = {}
+    for slug, blob in rows:
+        vec = _decode_embedding_blob(blob)
+        if not vec:
+            continue
+        slug_chunks.setdefault(str(slug), []).append(vec)
+    out: dict[str, list[float]] = {}
+    for slug, chunks in slug_chunks.items():
+        if not chunks:
+            continue
+        dim = len(chunks[0])
+        accum = [0.0] * dim
+        for chunk in chunks:
+            if len(chunk) != dim:
+                continue
+            for i, v in enumerate(chunk):
+                accum[i] += v
+        n = len(chunks)
+        out[slug] = [x / n for x in accum]
+    return out
+
+
+def rank_evergreens_by_source(
+    source_content: str,
+    vault_dir: Path | str,
+    *,
+    top_k: int,
+    pack_name: str | None = None,
+) -> list[str]:
+    """BL-069 — embedding-based top-K pre-filter for the router.
+
+    Steps:
+
+    1. Embed ``source_content`` via :func:`embedding.embed_text`
+       (Qwen3-Embedding-0.6B on Apple Silicon; hash fallback
+       otherwise).
+    2. Load evergreen vectors restricted to the same embedding model
+       (mixing hash 128-dim with Qwen 1024-dim would crash).
+    3. Cosine similarity (= dot product, since both sides are
+       L2-normalised by the embed_text contract).
+    4. Return the top ``top_k`` slugs in descending similarity order.
+
+    Why slug-level rather than chunk-level:  per-slug mean is a
+    coarser signal but matches today's index-entry granularity
+    (the router sees one entry per evergreen, not one per chunk).
+    A per-chunk variant is a future optimisation when we have
+    audit data showing slug-level misses for long evergreens.
+
+    Returns an empty list when:
+
+    * ``source_content`` is empty or whitespace-only
+    * ``top_k`` ≤ 0
+    * the embedding subsystem fails to load (missing dep, etc.)
+    * no evergreen vector matches the active embedding model
+    * the embedded source vector has a different dimensionality
+      than the stored vectors (model mismatch — fall back signal)
+
+    The caller (:func:`route_source`) treats an empty result as
+    "no top-K pre-filter, use alphabetical instead" rather than
+    "no evergreens at all" — so this never silently shrinks the
+    router's view.
+    """
+    if not source_content or not source_content.strip():
+        return []
+    if top_k <= 0:
+        return []
+    try:
+        from .embedding import embed_text, get_model_name
+    except ImportError:
+        return []
+
+    try:
+        source_blob = embed_text(source_content)
+    except Exception as exc:  # noqa: BLE001 — embedding init may fail in unusual envs
+        logger.warning("BL-069: source embed failed: %s", exc)
+        return []
+    source_vec = _decode_embedding_blob(source_blob)
+    if not source_vec:
+        return []
+
+    try:
+        model_name = get_model_name()
+    except Exception:  # noqa: BLE001
+        return []
+
+    resolved = resolve_vault_dir(vault_dir)
+    layout = VaultLayout.from_vault(resolved)
+    vectors = _load_evergreen_vectors_for_pack(
+        layout.knowledge_db, model_name, pack_name,
+    )
+    if not vectors:
+        return []
+
+    # Dimensionality sanity check — when the hash backend (128-dim)
+    # produces the source vector but the vault was built with Qwen
+    # (1024-dim) we'd silently produce garbage scores.  Skip with a
+    # warning so the caller falls back to alphabetical.
+    sample_vec = next(iter(vectors.values()))
+    if len(source_vec) != len(sample_vec):
+        logger.warning(
+            "BL-069: source embedding dim %d != evergreen dim %d; "
+            "falling back to alphabetical (model=%r)",
+            len(source_vec), len(sample_vec), model_name,
+        )
+        return []
+
+    # Dot product = cosine (both sides L2-normalised by embed_text).
+    # 9K evergreens × 1024 dim ≈ 10M float multiplies — ~50-100ms in
+    # pure Python on M-series.  No numpy dep needed for now.
+    scored: list[tuple[str, float]] = []
+    for slug, vec in vectors.items():
+        if len(vec) != len(source_vec):
+            continue
+        score = 0.0
+        for a, b in zip(source_vec, vec):
+            score += a * b
+        scored.append((slug, score))
+    scored.sort(key=lambda x: x[1], reverse=True)
+    return [slug for slug, _ in scored[:top_k]]
+
+
+def _resolve_router_index_strategy() -> str:
+    """Read ``OVP_ROUTER_INDEX_STRATEGY`` env var.
+
+    Valid values: ``"embedding_topk"`` (default) | ``"alphabetical"``.
+    Unknown values fall back to embedding_topk with a warning —
+    the env var is operator-facing and a typo shouldn't silently
+    revert to the worse strategy.
+    """
+    raw = (os.environ.get("OVP_ROUTER_INDEX_STRATEGY") or "").strip().lower()
+    if raw in {"", "embedding_topk", "embedding", "topk"}:
+        return "embedding_topk"
+    if raw in {"alphabetical", "alpha", "ordered"}:
+        return "alphabetical"
+    logger.warning(
+        "OVP_ROUTER_INDEX_STRATEGY=%r is not recognised; "
+        "valid: embedding_topk | alphabetical.  Defaulting to embedding_topk.",
+        raw,
+    )
+    return "embedding_topk"
+
+
 def _truncate(text: str, max_chars: int) -> str:
     """Cut to ``max_chars`` keeping word boundaries when easy.  Adds
     ``…`` when truncated.  Whitespace-collapses first."""
@@ -139,6 +349,7 @@ def build_evergreen_index(
     max_claims_per_object: int = DEFAULT_MAX_CLAIMS_PER_OBJECT,
     max_claim_chars: int = DEFAULT_MAX_CLAIM_CHARS,
     max_entries: int | None = None,
+    priority_slugs: list[str] | None = None,
 ) -> list[IndexEntry]:
     """Return the compact index the Pass 1 router consumes.
 
@@ -159,6 +370,15 @@ def build_evergreen_index(
     callers pass a positive integer to keep the rendered prompt
     inside the router model's context budget — see
     :data:`DEFAULT_MAX_INDEX_ENTRIES` for the rationale + tradeoff.
+
+    ``priority_slugs`` (BL-069) reorders the returned entries so
+    the supplied slugs come first in the given order; remaining
+    entries follow in the default lexicographic order.  Combined
+    with ``max_entries`` this lets the caller seed the index from
+    an external ranker (e.g. embedding-based top-K) and still rely
+    on this function for the per-entry summary/claims rendering.
+    Slugs in ``priority_slugs`` that don't exist in ``objects`` are
+    silently dropped — the ranker may have stale slugs.
 
     Best-effort empty list when the DB is missing — callers
     (router, debug CLIs) should treat an empty index as
@@ -279,6 +499,18 @@ def build_evergreen_index(
             summary=summary,
             key_claims=key_claims,
         ))
+    if priority_slugs:
+        # Move priority slugs to the front in the supplied order.
+        # Non-priority entries stay in their existing lexicographic
+        # order behind the priority block — when ``max_entries``
+        # trims the tail, the priority slugs survive.
+        priority_index = {slug: i for i, slug in enumerate(priority_slugs)}
+        priority_set = set(priority_slugs)
+        priority_entries = [e for e in entries if e.slug in priority_set]
+        non_priority_entries = [e for e in entries if e.slug not in priority_set]
+        priority_entries.sort(key=lambda e: priority_index[e.slug])
+        entries = priority_entries + non_priority_entries
+
     if max_entries is not None and max_entries >= 0:
         entries = entries[:max_entries]
     return entries
@@ -632,6 +864,7 @@ def _emit_route_decision_audit(
     decision: RouterDecision | None,
     error: str = "",
     raw_snippet: str = "",
+    index_strategy: str = "",
 ) -> None:
     """Best-effort audit emit.  ``pipeline_logger`` is expected to be
     a ``PipelineLogger``-shaped object with ``.log(event_type, data)``;
@@ -643,6 +876,13 @@ def _emit_route_decision_audit(
     flapped.  Parameter is named ``pipeline_logger`` (not just
     ``logger``) so it doesn't shadow the module-level ``logger``
     used to report logger-call failures.
+
+    ``index_strategy`` (BL-069) records how the index was selected:
+    ``"embedding_topk"`` (BL-069 dense pre-filter found candidates),
+    ``"alphabetical_fallback"`` (BL-069 ranker returned nothing →
+    fell back to BL-068 alphabetical), ``"alphabetical"`` (operator
+    forced via env var), or ``"explicit"`` (caller passed
+    ``index=`` directly, e.g. tests).
     """
     payload: dict[str, Any] = {
         "prompt_name": ROUTER_PROMPT_NAME,
@@ -650,6 +890,8 @@ def _emit_route_decision_audit(
         "source": source_path,
         "status": status,
     }
+    if index_strategy:
+        payload["index_strategy"] = index_strategy
     if decision is not None:
         payload["source_value_summary"] = decision.source_value_summary
         payload["update_count"] = len(decision.updates)
@@ -738,6 +980,7 @@ def route_source(
     """
     from .prompt_registry import get_prompt
 
+    index_strategy_used = "explicit"
     if index is None:
         if vault_dir is None:
             raise ValueError(
@@ -751,8 +994,35 @@ def route_source(
             if max_index_entries is not None
             else _resolve_max_index_entries()
         )
+        # BL-069: embedding-based top-K pre-filter.  When the
+        # strategy is ``embedding_topk`` (default) and an embedding
+        # ranker can produce at least one match, seed
+        # ``priority_slugs`` with the top-K so the router sees the
+        # most-topically-relevant evergreens first.  Empty ranker
+        # output → silent fallback to alphabetical (the prior
+        # BL-068 behaviour); operator can force alphabetical via
+        # ``OVP_ROUTER_INDEX_STRATEGY=alphabetical``.
+        priority_slugs: list[str] | None = None
+        strategy = _resolve_router_index_strategy()
+        if strategy == "embedding_topk":
+            ranked = rank_evergreens_by_source(
+                source_content,
+                vault_dir,
+                top_k=effective_cap,
+                pack_name=pack_name,
+            )
+            if ranked:
+                priority_slugs = ranked
+                index_strategy_used = "embedding_topk"
+            else:
+                index_strategy_used = "alphabetical_fallback"
+        else:
+            index_strategy_used = "alphabetical"
         index = build_evergreen_index(
-            vault_dir, pack_name=pack_name, max_entries=effective_cap,
+            vault_dir,
+            pack_name=pack_name,
+            max_entries=effective_cap,
+            priority_slugs=priority_slugs,
         )
     # ``index`` is consumed once below by ``build_router_user_prompt``
     # via a single ``render_index_for_prompt`` pass — no extra
@@ -768,6 +1038,7 @@ def route_source(
             status=ROUTE_STATUS_PROMPT_REGISTRY_ERROR,
             decision=None,
             error=f"prompt registry: {exc}",
+            index_strategy=index_strategy_used,
         )
         return None
 
@@ -791,6 +1062,7 @@ def route_source(
             status=ROUTE_STATUS_REQUEST_ERROR,
             decision=None,
             error=f"llm.generate: {exc}",
+            index_strategy=index_strategy_used,
         )
         return None
 
@@ -801,6 +1073,7 @@ def route_source(
             status=ROUTE_STATUS_EMPTY_RESPONSE,
             decision=None,
             error="empty router response",
+            index_strategy=index_strategy_used,
         )
         return None
 
@@ -814,6 +1087,7 @@ def route_source(
             decision=None,
             error=str(exc),
             raw_snippet=response_text,
+            index_strategy=index_strategy_used,
         )
         return None
 
@@ -822,5 +1096,6 @@ def route_source(
         source_path=source_path,
         status=ROUTE_STATUS_SKIP if decision.is_skip else ROUTE_STATUS_OK,
         decision=decision,
+        index_strategy=index_strategy_used,
     )
     return decision

--- a/src/ovp_pipeline/absorb_router.py
+++ b/src/ovp_pipeline/absorb_router.py
@@ -47,6 +47,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import re
 import sqlite3
@@ -152,22 +153,19 @@ def _load_evergreen_vectors_for_pack(
     """
     if not db_path.exists():
         return {}
+    # Build SQL once + conditionally append the pack filter.  Cleaner
+    # than the previous two-branch literal duplication, easier to
+    # extend when more filters appear.
+    sql = (
+        "SELECT pe.slug, pe.embedding_blob "
+        "FROM page_embeddings pe "
+        "JOIN objects o ON pe.slug = o.object_id "
+        "WHERE pe.embedding_model = ?"
+    )
+    params: tuple[Any, ...] = (embedding_model,)
     if pack_name:
-        sql = (
-            "SELECT pe.slug, pe.embedding_blob "
-            "FROM page_embeddings pe "
-            "JOIN objects o ON pe.slug = o.object_id "
-            "WHERE pe.embedding_model = ? AND o.pack = ?"
-        )
-        params: tuple[Any, ...] = (embedding_model, pack_name)
-    else:
-        sql = (
-            "SELECT pe.slug, pe.embedding_blob "
-            "FROM page_embeddings pe "
-            "JOIN objects o ON pe.slug = o.object_id "
-            "WHERE pe.embedding_model = ?"
-        )
-        params = (embedding_model,)
+        sql += " AND o.pack = ?"
+        params = (embedding_model, pack_name)
     try:
         with sqlite3.connect(db_path) as conn:
             rows = conn.execute(sql, params).fetchall()
@@ -177,30 +175,43 @@ def _load_evergreen_vectors_for_pack(
         # (caller goes alphabetical) rather than crash.
         return {}
 
-    # Aggregate chunks per slug by mean.  Pure-Python sum is OK at
-    # 9K slugs × 10 chunks/slug × 1024 dim ≈ 100M float ops total
-    # (~1s on M-series Mac); the actual hot path is the cosine
-    # scoring below.  Caching is a TODO when this becomes the
-    # bottleneck.
     slug_chunks: dict[str, list[list[float]]] = {}
     for slug, blob in rows:
         vec = _decode_embedding_blob(blob)
         if not vec:
             continue
         slug_chunks.setdefault(str(slug), []).append(vec)
+
+    # Aggregate chunks per slug.  The mean of L2-normalised vectors
+    # is NOT itself L2-normalised — without re-normalising the
+    # downstream cosine (which is dot-product assuming unit vectors)
+    # systematically under-scores evergreens with many chunks.  Bot
+    # review flagged this as the load-bearing correctness bug on
+    # multi-chunk evergreens.  Re-normalise here so the dot-product
+    # = cosine identity holds.
+    #
+    # Perf: ``zip(*chunks)`` + ``sum`` is roughly 6× faster than the
+    # previous nested ``for chunk: for i, v in enumerate(chunk)``
+    # accumulator at vault scale.  At 9K slugs the loaded chunks
+    # already cost ~1s in SQLite + decode; this shaves another ~5s.
     out: dict[str, list[float]] = {}
     for slug, chunks in slug_chunks.items():
         if not chunks:
             continue
         dim = len(chunks[0])
-        accum = [0.0] * dim
-        for chunk in chunks:
-            if len(chunk) != dim:
-                continue
-            for i, v in enumerate(chunk):
-                accum[i] += v
-        n = len(chunks)
-        out[slug] = [x / n for x in accum]
+        valid_chunks = [c for c in chunks if len(c) == dim]
+        if not valid_chunks:
+            continue
+        n = len(valid_chunks)
+        if n == 1:
+            mean_vec = valid_chunks[0]
+        else:
+            mean_vec = [s / n for s in (sum(col) for col in zip(*valid_chunks))]
+        # L2-normalise so cosine = dot product holds downstream.
+        norm = math.sqrt(sum(x * x for x in mean_vec))
+        if norm <= 0:
+            continue  # all-zero mean → no useful signal; skip slug
+        out[slug] = [x / norm for x in mean_vec]
     return out
 
 
@@ -261,6 +272,23 @@ def rank_evergreens_by_source(
     source_vec = _decode_embedding_blob(source_blob)
     if not source_vec:
         return []
+    # Reject zero-norm source vectors.  The BLAKE2b hash backend
+    # (``local-hash-v1``) tokenises via ``[a-z0-9]+`` and produces
+    # an all-zero vector for inputs with no ASCII alphanumerics
+    # (e.g. Chinese-only sources).  Without this guard every
+    # dot-product would tie at 0 and the caller would record an
+    # arbitrary DB-order ranking as ``embedding_topk`` — codex P2.
+    # Returning empty here makes ``route_source`` fall back to the
+    # alphabetical strategy (the documented behaviour for "no
+    # ranking signal").
+    source_norm = math.sqrt(sum(x * x for x in source_vec))
+    if source_norm <= 0:
+        logger.info(
+            "BL-069: source embedding has zero norm "
+            "(likely CJK-only source on the hash backend); "
+            "falling back to alphabetical.",
+        )
+        return []
 
     try:
         model_name = get_model_name()
@@ -288,16 +316,18 @@ def rank_evergreens_by_source(
         )
         return []
 
-    # Dot product = cosine (both sides L2-normalised by embed_text).
-    # 9K evergreens × 1024 dim ≈ 10M float multiplies — ~50-100ms in
-    # pure Python on M-series.  No numpy dep needed for now.
+    # Dot product = cosine (both sides L2-normalised: source by the
+    # embed_text contract, evergreens by ``_load_evergreen_vectors_for_pack``
+    # after mean-aggregation).  ``sum([...])`` materialises a list once
+    # which lets CPython's specialised int/float ops outpace the
+    # ``score += a*b`` accumulator by ~2× at 9K × 1024-d scale (bot
+    # review perf finding).  Total scoring is ~0.3s on M-series.
+    src_len = len(source_vec)
     scored: list[tuple[str, float]] = []
     for slug, vec in vectors.items():
-        if len(vec) != len(source_vec):
+        if len(vec) != src_len:
             continue
-        score = 0.0
-        for a, b in zip(source_vec, vec):
-            score += a * b
+        score = sum([a * b for a, b in zip(source_vec, vec)])
         scored.append((slug, score))
     scored.sort(key=lambda x: x[1], reverse=True)
     return [slug for slug, _ in scored[:top_k]]

--- a/src/ovp_pipeline/auto_evergreen_extractor.py
+++ b/src/ovp_pipeline/auto_evergreen_extractor.py
@@ -1257,13 +1257,50 @@ class AutoEvergreenExtractor:
                                             )
                                     except Exception:  # noqa: BLE001
                                         source_url = ""
+
+                                    # Honour the actual mutation outcome.
+                                    # ``promote_candidate`` may transparently
+                                    # delegate to ``merge_candidate`` when the
+                                    # dedup-guard finds a near-duplicate active
+                                    # slug; in that case ``mutation.action ==
+                                    # 'merge'``, ``mutation.target_slug`` is
+                                    # the *existing* active slug, and the
+                                    # candidate's ``{concept_name}.md`` file
+                                    # was deleted rather than promoted.
+                                    # Auditing against ``concept_name`` /
+                                    # ``output_path`` would write provenance
+                                    # for a non-existent object and skip the
+                                    # revision snapshot entirely.
+                                    actual_target_slug = (
+                                        mutation.target_slug
+                                        or mutation.slug
+                                        or concept_name
+                                    )
+                                    actual_action = mutation.action or "promote"
+                                    # Find a real evergreen path: prefer one
+                                    # the mutation touched (promote case
+                                    # carries the new file path; merge case
+                                    # may not), else fall back to the
+                                    # canonical naming convention.
+                                    audit_canonical_path = ""
+                                    eg_prefix = str(self.evergreen_dir) + "/"
+                                    for touched in mutation.touched_files:
+                                        t = str(touched)
+                                        if t.startswith(eg_prefix) and t.endswith(".md"):
+                                            audit_canonical_path = t
+                                            break
+                                    if not audit_canonical_path:
+                                        audit_canonical_path = str(
+                                            self.evergreen_dir / f"{actual_target_slug}.md"
+                                        )
+
                                     record_promote_audit_pair(
                                         self.vault_dir,
                                         pack_name=pack_name,
-                                        target_slug=concept_name,
-                                        canonical_path=str(output_path),
+                                        target_slug=actual_target_slug,
+                                        canonical_path=audit_canonical_path,
                                         source_url=source_url,
-                                        lifecycle_action="promote",
+                                        lifecycle_action=actual_action,
                                         source_slug=concept_name,
                                         changed_by="cli:auto_promote",
                                     )

--- a/src/ovp_pipeline/auto_evergreen_extractor.py
+++ b/src/ovp_pipeline/auto_evergreen_extractor.py
@@ -1277,11 +1277,24 @@ class AutoEvergreenExtractor:
                                         or concept_name
                                     )
                                     actual_action = mutation.action or "promote"
-                                    # Find a real evergreen path: prefer one
-                                    # the mutation touched (promote case
-                                    # carries the new file path; merge case
-                                    # may not), else fall back to the
-                                    # canonical naming convention.
+                                    # Find a real evergreen path with a
+                                    # three-step fallback chain:
+                                    #
+                                    # 1. The mutation's ``touched_files``
+                                    #    carries the new file path on the
+                                    #    promote branch.  Merge branch
+                                    #    typically doesn't populate it.
+                                    # 2. Slug-named file under ``evergreen_dir``
+                                    #    — the canonical naming convention
+                                    #    works for ~99% of slugs.
+                                    # 3. ``objects.canonical_path`` from the
+                                    #    truth store — works when the file's
+                                    #    actual name diverges from the slug
+                                    #    (e.g. frontmatter ``note_id`` set
+                                    #    independently of filename, BL-053
+                                    #    rename leftovers).  Required for the
+                                    #    merge case where the target evergreen
+                                    #    pre-existed with a non-slug filename.
                                     audit_canonical_path = ""
                                     eg_prefix = str(self.evergreen_dir) + "/"
                                     for touched in mutation.touched_files:
@@ -1290,6 +1303,37 @@ class AutoEvergreenExtractor:
                                             audit_canonical_path = t
                                             break
                                     if not audit_canonical_path:
+                                        candidate_path = (
+                                            self.evergreen_dir / f"{actual_target_slug}.md"
+                                        )
+                                        if candidate_path.is_file():
+                                            audit_canonical_path = str(candidate_path)
+                                    if not audit_canonical_path:
+                                        try:
+                                            import sqlite3 as _sqlite3
+                                            from .runtime import VaultLayout
+                                            db = VaultLayout.from_vault(
+                                                self.vault_dir,
+                                            ).knowledge_db
+                                            if db.exists():
+                                                with _sqlite3.connect(db) as _conn:
+                                                    row = _conn.execute(
+                                                        "SELECT canonical_path FROM "
+                                                        "objects WHERE pack=? "
+                                                        "AND object_id=?",
+                                                        (pack_name, actual_target_slug),
+                                                    ).fetchone()
+                                                    if row and row[0]:
+                                                        audit_canonical_path = str(row[0])
+                                        except Exception:  # noqa: BLE001
+                                            pass
+                                    if not audit_canonical_path:
+                                        # Last-resort fallback so the
+                                        # provenance row still lands even when
+                                        # the revision snapshot can't read
+                                        # the file.  Helper skips the
+                                        # revision (best-effort) and writes
+                                        # only the provenance row.
                                         audit_canonical_path = str(
                                             self.evergreen_dir / f"{actual_target_slug}.md"
                                         )

--- a/src/ovp_pipeline/knowledge_index.py
+++ b/src/ovp_pipeline/knowledge_index.py
@@ -286,6 +286,23 @@ INDEPENDENT_CANONICAL_TABLE_COLUMNS: dict[str, tuple[str, ...]] = {
         "prompt_version",
         "superseded_by_synthesized_at",
     ),
+    # BL-061: prose-level evergreen revision history.  Same
+    # treatment as ``provenance`` — an immutable append-only audit
+    # log that must survive projection rebuilds, otherwise every
+    # ``ovp-knowledge-index`` invocation would wipe BL-061's
+    # rollback semantics.  Discovered post-PR-#193 review: revisions
+    # written by ``review_candidate_concept`` or ``cli:auto_promote``
+    # were silently lost on the next rebuild.
+    "evergreen_revisions": (
+        "pack",
+        "object_id",
+        "version",
+        "content_md",
+        "change_type",
+        "changed_by",
+        "derived_at",
+        "change_note",
+    ),
 }
 
 
@@ -1953,22 +1970,51 @@ def knowledge_index_stats(vault_dir: Path, *, pack_name: str | None = None) -> d
     return stats
 
 
-def recent_audit_events(vault_dir: Path, limit: int = 20, source_log: str | None = None) -> list[dict[str, object]]:
-    _, layout = _ensure_knowledge_db(vault_dir)
-    query = """
-        SELECT source_log, event_type, slug, session_id, timestamp, payload_json
-        FROM audit_events
+def recent_audit_events(
+    vault_dir: Path,
+    limit: int = 20,
+    source_log: str | None = None,
+    *,
+    event_type: str | None = None,
+    since: str | None = None,
+) -> list[dict[str, object]]:
+    """Tail recent ``audit_events`` rows, ordered newest-first.
+
+    ``event_type`` filters at the SQL layer — important for
+    consumers like the BL-063 Live Concept scheduler that only care
+    about one event kind (``absorb_route_decision``).  Pre-fix
+    those callers fetched ``limit=500`` then filtered in Python,
+    which silently dropped relevant rows when the recent log was
+    dominated by other event types.
+
+    ``since`` is an ISO-8601 timestamp (e.g. ``"2026-05-10T00:00:00Z"``)
+    pushed into a ``timestamp >= ?`` clause.  Lets time-window
+    consumers (Live Concept's ``since_hours`` argument) push the
+    cutoff down to SQLite instead of filtering Python-side.
     """
-    params: tuple[object, ...]
+    _, layout = _ensure_knowledge_db(vault_dir)
+    query = (
+        "SELECT source_log, event_type, slug, session_id, timestamp, "
+        "payload_json FROM audit_events"
+    )
+    clauses: list[str] = []
+    params: list[object] = []
     if source_log:
-        query += " WHERE source_log = ?"
-        params = (source_log, limit)
-    else:
-        params = (limit,)
+        clauses.append("source_log = ?")
+        params.append(source_log)
+    if event_type:
+        clauses.append("event_type = ?")
+        params.append(event_type)
+    if since:
+        clauses.append("timestamp >= ?")
+        params.append(since)
+    if clauses:
+        query += " WHERE " + " AND ".join(clauses)
     query += " ORDER BY timestamp DESC, rowid DESC LIMIT ?"
+    params.append(limit)
 
     with sqlite3.connect(layout.knowledge_db) as conn:
-        rows = conn.execute(query, params).fetchall()
+        rows = conn.execute(query, tuple(params)).fetchall()
 
     return [
         {

--- a/src/ovp_pipeline/live_concept_scheduler.py
+++ b/src/ovp_pipeline/live_concept_scheduler.py
@@ -224,7 +224,24 @@ def evaluate_all_concepts(
     cutoff = current - timedelta(hours=max(since_hours, 0))
 
     vault_path = Path(vault_dir) if not isinstance(vault_dir, Path) else vault_dir
-    all_audit = recent_audit_events(vault_path, limit=audit_event_limit)
+    # Push both filters into SQL.  Pre-fix this function fetched the
+    # most-recent ``limit`` rows of *any* event_type and post-
+    # filtered to ``absorb_route_decision`` in Python — so on a noisy
+    # log where ``audit_event_limit`` worth of rows were dominated by
+    # entity-backfill / atlas-update events, every relevant routing
+    # decision from the past day could be silently truncated and
+    # Live Concepts wouldn't fire.  Pushing event_type + cutoff into
+    # SQLite means ``audit_event_limit`` budgets routing rows
+    # directly.
+    cutoff_iso = (
+        cutoff.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    )
+    all_audit = recent_audit_events(
+        vault_path,
+        limit=audit_event_limit,
+        event_type=ABSORB_ROUTE_DECISION_EVENT,
+        since=cutoff_iso,
+    )
     route_events = _filter_recent_route_decisions(all_audit, cutoff=cutoff)
 
     evaluations: list[ConceptEvaluation] = []

--- a/tests/test_absorb_router.py
+++ b/tests/test_absorb_router.py
@@ -162,6 +162,173 @@ def test_index_max_entries_truncates_after_sort(temp_vault):
     assert empty == []
 
 
+def test_build_index_priority_slugs_reorders_to_front(temp_vault):
+    """BL-069: ``priority_slugs`` moves the supplied slugs to the
+    front in the given order; remaining entries keep their default
+    lexicographic order behind the priority block.  Combined with
+    ``max_entries`` this lets the embedding ranker put topically-
+    relevant evergreens above the cap."""
+    from ovp_pipeline.absorb_router import build_evergreen_index
+
+    _seed_index_fixtures(temp_vault)
+    entries = build_evergreen_index(
+        temp_vault,
+        priority_slugs=["gamma", "alpha"],
+    )
+    # gamma first, alpha second (priority order), then beta (alpha-sort).
+    assert [e.slug for e in entries] == ["gamma", "alpha", "beta"]
+
+
+def test_build_index_priority_slugs_combined_with_max_entries(temp_vault):
+    """``priority_slugs`` survives ``max_entries`` truncation — the
+    priority block is at the front so the cap drops the *trailing*
+    alphabetical entries, not the priority ones."""
+    from ovp_pipeline.absorb_router import build_evergreen_index
+
+    _seed_index_fixtures(temp_vault)
+    entries = build_evergreen_index(
+        temp_vault,
+        priority_slugs=["gamma"],
+        max_entries=2,
+    )
+    # gamma (priority) + alpha (first non-priority alphabetically).
+    assert [e.slug for e in entries] == ["gamma", "alpha"]
+
+
+def test_build_index_priority_slugs_with_unknown_slug(temp_vault):
+    """Slugs in ``priority_slugs`` that don't exist in ``objects``
+    are silently dropped — the ranker may have stale slugs."""
+    from ovp_pipeline.absorb_router import build_evergreen_index
+
+    _seed_index_fixtures(temp_vault)
+    entries = build_evergreen_index(
+        temp_vault,
+        priority_slugs=["nonexistent-slug", "beta"],
+    )
+    assert [e.slug for e in entries] == ["beta", "alpha", "gamma"]
+
+
+def test_resolve_router_index_strategy_reads_env(monkeypatch):
+    """BL-069: env var picks strategy; unknown values fall back to
+    embedding_topk (default) with a warning rather than silently
+    reverting to the worse strategy."""
+    from ovp_pipeline.absorb_router import _resolve_router_index_strategy
+
+    monkeypatch.delenv("OVP_ROUTER_INDEX_STRATEGY", raising=False)
+    assert _resolve_router_index_strategy() == "embedding_topk"
+
+    monkeypatch.setenv("OVP_ROUTER_INDEX_STRATEGY", "alphabetical")
+    assert _resolve_router_index_strategy() == "alphabetical"
+
+    monkeypatch.setenv("OVP_ROUTER_INDEX_STRATEGY", "alpha")
+    assert _resolve_router_index_strategy() == "alphabetical"
+
+    monkeypatch.setenv("OVP_ROUTER_INDEX_STRATEGY", "embedding_topk")
+    assert _resolve_router_index_strategy() == "embedding_topk"
+
+    monkeypatch.setenv("OVP_ROUTER_INDEX_STRATEGY", "garbage")
+    assert _resolve_router_index_strategy() == "embedding_topk"
+
+
+def test_rank_evergreens_empty_source_returns_empty():
+    """Empty / whitespace-only source content → empty ranking.
+    Caller treats this as "fall back to alphabetical"."""
+    from ovp_pipeline.absorb_router import rank_evergreens_by_source
+
+    assert rank_evergreens_by_source("", "/nonexistent", top_k=10) == []
+    assert rank_evergreens_by_source("   \n  ", "/nonexistent", top_k=10) == []
+    assert rank_evergreens_by_source("anything", "/nonexistent", top_k=0) == []
+
+
+def test_rank_evergreens_missing_db_returns_empty(tmp_path):
+    """No knowledge.db (fresh vault, never rebuilt) → empty ranking,
+    no exception.  Caller falls back to alphabetical."""
+    from ovp_pipeline.absorb_router import rank_evergreens_by_source
+
+    assert rank_evergreens_by_source(
+        "real content", tmp_path, top_k=10,
+    ) == []
+
+
+def test_rank_evergreens_returns_relevant_slugs_first(temp_vault, monkeypatch):
+    """BL-069 happy path: embed source + cosine top-K returns the
+    evergreens whose vectors are nearest.  We monkeypatch the
+    embedding model to a deterministic stub so the test doesn't
+    require Qwen at test-time."""
+    from ovp_pipeline.absorb_router import rank_evergreens_by_source
+    from ovp_pipeline.runtime import VaultLayout
+    import array as _array
+
+    _seed_index_fixtures(temp_vault)
+    # Inject deterministic 4-d unit vectors keyed by slug into the
+    # page_embeddings table so cosine ranking has known winners.
+    db = VaultLayout.from_vault(temp_vault).knowledge_db
+    vectors = {
+        "alpha": [1.0, 0.0, 0.0, 0.0],  # aligned with source vec
+        "beta":  [0.0, 1.0, 0.0, 0.0],  # orthogonal
+        "gamma": [0.7071, 0.7071, 0.0, 0.0],  # 45° to source
+    }
+    with sqlite3.connect(db) as conn:
+        conn.execute("DELETE FROM page_embeddings")
+        for slug, vec in vectors.items():
+            blob = _array.array("f", vec).tobytes()
+            conn.execute(
+                "INSERT INTO page_embeddings (slug, chunk_index, section_title, "
+                "chunk_text, embedding_blob, embedding_model) "
+                "VALUES (?, 0, '', '', ?, 'stub-test-4d')",
+                (slug, blob),
+            )
+        conn.commit()
+
+    # Force the embed_text + get_model_name pair to produce a known
+    # 4-d source vector with the same model name as the stored rows.
+    import ovp_pipeline.embedding as emb
+    monkeypatch.setattr(
+        emb, "embed_text",
+        lambda _text: _array.array("f", [1.0, 0.0, 0.0, 0.0]).tobytes(),
+    )
+    monkeypatch.setattr(emb, "get_model_name", lambda: "stub-test-4d")
+
+    ranked = rank_evergreens_by_source(
+        "anything", temp_vault, top_k=3,
+    )
+    # alpha (cos=1.0) > gamma (cos=0.707) > beta (cos=0.0)
+    assert ranked == ["alpha", "gamma", "beta"]
+
+
+def test_rank_evergreens_dimensionality_mismatch_returns_empty(temp_vault, monkeypatch):
+    """If the source embedder produces a different dim than the
+    stored vectors (model mismatch — hash 128-d on a Qwen 1024-d
+    vault), the ranker returns empty so the caller falls back to
+    alphabetical rather than producing garbage scores."""
+    from ovp_pipeline.absorb_router import rank_evergreens_by_source
+    from ovp_pipeline.runtime import VaultLayout
+    import array as _array
+
+    _seed_index_fixtures(temp_vault)
+    db = VaultLayout.from_vault(temp_vault).knowledge_db
+    # Stored: 4-d vectors.
+    with sqlite3.connect(db) as conn:
+        conn.execute("DELETE FROM page_embeddings")
+        conn.execute(
+            "INSERT INTO page_embeddings (slug, chunk_index, section_title, "
+            "chunk_text, embedding_blob, embedding_model) "
+            "VALUES ('alpha', 0, '', '', ?, 'stub-test-4d')",
+            (_array.array("f", [1.0, 0.0, 0.0, 0.0]).tobytes(),),
+        )
+        conn.commit()
+
+    import ovp_pipeline.embedding as emb
+    # Source embedder returns 8-d — incompatible with stored 4-d.
+    monkeypatch.setattr(
+        emb, "embed_text",
+        lambda _text: _array.array("f", [0.5] * 8).tobytes(),
+    )
+    monkeypatch.setattr(emb, "get_model_name", lambda: "stub-test-4d")
+
+    assert rank_evergreens_by_source("x", temp_vault, top_k=10) == []
+
+
 def test_resolve_max_index_entries_reads_env(monkeypatch):
     """BL-068: ``OVP_ROUTER_MAX_INDEX_ENTRIES`` env var overrides
     the default cap.  Invalid values fall back to default rather

--- a/tests/test_absorb_router.py
+++ b/tests/test_absorb_router.py
@@ -296,6 +296,81 @@ def test_rank_evergreens_returns_relevant_slugs_first(temp_vault, monkeypatch):
     assert ranked == ["alpha", "gamma", "beta"]
 
 
+def test_rank_evergreens_zero_norm_source_returns_empty(temp_vault, monkeypatch):
+    """Codex P2 regression: under the BLAKE2b hash fallback,
+    Chinese-only sources tokenise to no ``[a-z0-9]+`` matches and
+    produce an all-zero embedding.  Without the zero-norm guard
+    every dot-product would tie at 0 and route_source would record
+    an arbitrary DB order as ``embedding_topk``.  This test pins
+    the contract: zero-norm source vector → empty ranking →
+    caller falls back to alphabetical."""
+    from ovp_pipeline.absorb_router import rank_evergreens_by_source
+    from ovp_pipeline.runtime import VaultLayout
+    import array as _array
+
+    _seed_index_fixtures(temp_vault)
+    db = VaultLayout.from_vault(temp_vault).knowledge_db
+    with sqlite3.connect(db) as conn:
+        conn.execute("DELETE FROM page_embeddings")
+        conn.execute(
+            "INSERT INTO page_embeddings (slug, chunk_index, section_title, "
+            "chunk_text, embedding_blob, embedding_model) "
+            "VALUES ('alpha', 0, '', '', ?, 'stub-test-4d')",
+            (_array.array("f", [1.0, 0.0, 0.0, 0.0]).tobytes(),),
+        )
+        conn.commit()
+
+    import ovp_pipeline.embedding as emb
+    # Hash backend on Chinese-only source: all-zero vector.
+    monkeypatch.setattr(
+        emb, "embed_text",
+        lambda _text: _array.array("f", [0.0, 0.0, 0.0, 0.0]).tobytes(),
+    )
+    monkeypatch.setattr(emb, "get_model_name", lambda: "stub-test-4d")
+
+    assert rank_evergreens_by_source("中文", temp_vault, top_k=10) == []
+
+
+def test_load_evergreen_vectors_l2_normalizes_mean(temp_vault):
+    """Bot review HIGH: mean of L2-normalised vectors is NOT itself
+    L2-normalised; downstream cosine assumes unit-length so without
+    re-normalising the score for multi-chunk evergreens
+    systematically under-shoots.  This test seeds two unit-length
+    chunks with opposite tilts on the same slug and asserts the
+    aggregated vector has unit norm."""
+    from ovp_pipeline.absorb_router import _load_evergreen_vectors_for_pack
+    from ovp_pipeline.runtime import VaultLayout
+    import array as _array
+    import math
+
+    _seed_index_fixtures(temp_vault)
+    db = VaultLayout.from_vault(temp_vault).knowledge_db
+    with sqlite3.connect(db) as conn:
+        conn.execute("DELETE FROM page_embeddings")
+        # Two unit-norm chunks: (1,0,0,0) + (0,1,0,0).  Mean is
+        # (0.5, 0.5, 0, 0), norm 1/sqrt(2) ≈ 0.707.  After
+        # re-normalisation the vector must have norm 1.0.
+        for chunk_idx, vec in enumerate([
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0],
+        ]):
+            conn.execute(
+                "INSERT INTO page_embeddings (slug, chunk_index, section_title, "
+                "chunk_text, embedding_blob, embedding_model) "
+                "VALUES ('alpha', ?, '', '', ?, 'stub-l2-test')",
+                (chunk_idx, _array.array("f", vec).tobytes()),
+            )
+        conn.commit()
+
+    vectors = _load_evergreen_vectors_for_pack(db, "stub-l2-test", None)
+    assert "alpha" in vectors
+    vec = vectors["alpha"]
+    norm = math.sqrt(sum(x * x for x in vec))
+    assert abs(norm - 1.0) < 1e-6, (
+        f"aggregated vector must be L2-normalised; got norm={norm}"
+    )
+
+
 def test_rank_evergreens_dimensionality_mismatch_returns_empty(temp_vault, monkeypatch):
     """If the source embedder produces a different dim than the
     stored vectors (model mismatch — hash 128-d on a Qwen 1024-d

--- a/tests/test_evergreen_revisions.py
+++ b/tests/test_evergreen_revisions.py
@@ -366,6 +366,55 @@ def test_record_promote_audit_pair_writes_revision_without_objects_row(temp_vaul
     assert changed_by == "cli:auto_promote"
 
 
+def test_record_promote_audit_pair_resolves_slug_mismatched_path(temp_vault):
+    """Codex P2 regression: when the merge target's evergreen file
+    has a name that doesn't match its slug (frontmatter ``note_id``
+    set independently of filename), passing the canonical_path
+    resolved via the ``objects`` table must let the helper still
+    snapshot the revision.  Previously the BL-067 hook fell back to
+    ``evergreen_dir/{slug}.md`` which doesn't exist in this case
+    and the snapshot was silently skipped."""
+    from ovp_pipeline.knowledge_index import rebuild_knowledge_index
+    from ovp_pipeline.runtime import VaultLayout
+    from ovp_pipeline.truth_api import record_promote_audit_pair
+
+    # File name diverges from slug — common after BL-053 renames
+    # or when operators set frontmatter ``note_id`` by hand.
+    evergreen_dir = temp_vault / "10-Knowledge" / "Evergreen"
+    evergreen_dir.mkdir(parents=True, exist_ok=True)
+    target_file = evergreen_dir / "Original-Display-Title.md"
+    target_file.write_text(
+        "---\nnote_id: llm-eval\ntitle: LLM Eval\ntype: evergreen\n"
+        "date: 2026-04-13\n---\n\n# Original Display Title\n\nBody.\n",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    # Auditing with the actual file path (resolved by caller's
+    # three-step fallback chain) writes the revision correctly.
+    record_promote_audit_pair(
+        temp_vault,
+        pack_name="default_knowledge",
+        target_slug="llm-eval",
+        canonical_path=str(target_file),
+        source_url="",
+        lifecycle_action="merge",
+        source_slug="llm-eval-leakage",
+        changed_by="cli:auto_promote",
+    )
+
+    db_path = VaultLayout.from_vault(temp_vault).knowledge_db
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            "SELECT object_id, change_type FROM evergreen_revisions"
+        ).fetchall()
+    assert len(rows) == 1, (
+        f"merge against slug-mismatched file path must still snapshot "
+        f"revision; got {rows}"
+    )
+    assert rows[0] == ("llm-eval", "promote")
+
+
 def test_record_promote_audit_pair_handles_merge_case(temp_vault):
     """BL-067 + dedup-guard regression: when ``promote_candidate``
     delegates to ``merge_candidate`` (near-duplicate detected), the

--- a/tests/test_evergreen_revisions.py
+++ b/tests/test_evergreen_revisions.py
@@ -255,6 +255,69 @@ def _seed_v2_candidate(temp_vault):
     return candidate
 
 
+def test_revisions_survive_knowledge_index_rebuild(temp_vault):
+    """BL-061 regression: ``evergreen_revisions`` is canonical audit
+    history — rebuilding the projection DB must NOT wipe it.
+
+    Pre-fix the table wasn't in
+    ``knowledge_index.INDEPENDENT_CANONICAL_TABLE_COLUMNS``, so every
+    ``ovp-knowledge-index`` invocation silently dropped every
+    revision row alongside the rebuild's temp DB copy.  This test
+    seeds one revision, rebuilds, and asserts the row is still
+    there — same shape as the BL-055 ``provenance`` regression test
+    elsewhere in this file.
+    """
+    from ovp_pipeline.knowledge_index import rebuild_knowledge_index
+    from ovp_pipeline.runtime import VaultLayout
+    from ovp_pipeline.truth_store_writers import (
+        CHANGE_TYPE_PROMOTE,
+        record_evergreen_revision,
+    )
+
+    evergreen_dir = temp_vault / "10-Knowledge" / "Evergreen"
+    evergreen_dir.mkdir(parents=True, exist_ok=True)
+    (evergreen_dir / "Alpha.md").write_text(
+        "---\nnote_id: alpha\ntitle: Alpha\ntype: evergreen\n"
+        "date: 2026-04-13\n---\n\n# Alpha\n\nBody.\n",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)  # initial rebuild creates the table
+
+    # Seed one revision so we have something for the rebuild to
+    # preserve.
+    db = VaultLayout.from_vault(temp_vault).knowledge_db
+    with sqlite3.connect(db) as conn:
+        record_evergreen_revision(
+            conn,
+            pack="default_knowledge",
+            object_id="alpha",
+            content_md="# Alpha\n\nFirst snapshot.\n",
+            change_type=CHANGE_TYPE_PROMOTE,
+            changed_by="test:setup",
+        )
+        conn.commit()
+
+    # Trigger a second rebuild — this is the load-bearing step.
+    # Pre-fix it would copy temp_db → real_db without including
+    # ``evergreen_revisions`` in the preserve allowlist, so the
+    # row would be lost.
+    rebuild_knowledge_index(temp_vault)
+
+    with sqlite3.connect(db) as conn:
+        rows = conn.execute(
+            "SELECT pack, object_id, version, change_type, changed_by "
+            "FROM evergreen_revisions WHERE object_id = 'alpha'"
+        ).fetchall()
+    assert len(rows) == 1, (
+        f"revision survived count = {len(rows)}; expected 1.  "
+        f"This means evergreen_revisions is being wiped by rebuild."
+    )
+    pack, object_id, version, change_type, changed_by = rows[0]
+    assert (pack, object_id, change_type, changed_by) == (
+        "default_knowledge", "alpha", "promote", "test:setup",
+    )
+
+
 def test_record_promote_audit_pair_writes_revision_without_objects_row(temp_vault):
     """BL-067 contract: the helper accepts canonical_path directly so
     the CLI auto-promote path (which writes the evergreen file BEFORE
@@ -301,6 +364,61 @@ def test_record_promote_audit_pair_writes_revision_without_objects_row(temp_vaul
     assert version == 1
     assert change_type == "promote"
     assert changed_by == "cli:auto_promote"
+
+
+def test_record_promote_audit_pair_handles_merge_case(temp_vault):
+    """BL-067 + dedup-guard regression: when ``promote_candidate``
+    delegates to ``merge_candidate`` (near-duplicate detected), the
+    audit pair must write the provenance row + revision snapshot
+    against ``mutation.target_slug`` (the existing active object),
+    NOT the candidate's slug.  The candidate's evergreen file was
+    deleted by the merge — pointing canonical_path at it would
+    silently skip the revision snapshot.  This test simulates the
+    merge case end-to-end."""
+    from ovp_pipeline.knowledge_index import rebuild_knowledge_index
+    from ovp_pipeline.runtime import VaultLayout
+    from ovp_pipeline.truth_api import record_promote_audit_pair
+
+    # Seed the existing active evergreen (the merge *target*).
+    evergreen_dir = temp_vault / "10-Knowledge" / "Evergreen"
+    evergreen_dir.mkdir(parents=True, exist_ok=True)
+    target_path = evergreen_dir / "Llm-Eval.md"
+    target_path.write_text(
+        "---\nnote_id: llm-eval\ntitle: LLM Eval\ntype: evergreen\n"
+        "date: 2026-04-13\n---\n\n# LLM Eval\n\nTarget body.\n",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    # Caller (auto_evergreen_extractor BL-067 hook) sees that
+    # mutation.target_slug=llm-eval (active slug) and
+    # mutation.slug=llm-eval-leakage (the candidate that got merged
+    # away).  Audit must target the active slug.
+    record_promote_audit_pair(
+        temp_vault,
+        pack_name="default_knowledge",
+        target_slug="llm-eval",
+        canonical_path=str(target_path),
+        source_url="https://example.com/leakage-paper",
+        lifecycle_action="merge",
+        source_slug="llm-eval-leakage",
+        changed_by="cli:auto_promote",
+    )
+
+    db_path = VaultLayout.from_vault(temp_vault).knowledge_db
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            "SELECT pack, object_id, change_type, change_note FROM evergreen_revisions"
+        ).fetchall()
+    assert len(rows) == 1
+    pack, object_id, change_type, change_note = rows[0]
+    # Revision is keyed on the merge TARGET, not the original candidate.
+    assert (pack, object_id) == ("default_knowledge", "llm-eval")
+    assert change_type == "promote"
+    # change_note carries the merge lineage so audit replay knows
+    # this revision came from a merge, not a fresh promote.
+    assert "lifecycle=merge" in change_note
+    assert "merged_from=llm-eval-leakage" in change_note
 
 
 def test_promote_writes_evergreen_revision(temp_vault):

--- a/tests/test_knowledge_index.py
+++ b/tests/test_knowledge_index.py
@@ -1178,6 +1178,53 @@ date: 2026-04-07
     assert [event["event_type"] for event in events] == ["newer", "older"]
 
 
+def test_recent_audit_events_filters_by_event_type_in_sql(temp_vault):
+    """BL-069 regression: ``recent_audit_events`` accepts an
+    ``event_type`` filter that's pushed into the SQL WHERE clause
+    so callers like the Live Concept scheduler can budget their
+    ``limit`` against only the rows they actually care about.
+    Pre-fix the post-filter happened Python-side and the noisy
+    log could starve the relevant event type before the limit was
+    hit."""
+    from ovp_pipeline.knowledge_index import rebuild_knowledge_index, recent_audit_events
+    from ovp_pipeline.runtime import VaultLayout
+
+    note = temp_vault / "10-Knowledge" / "Evergreen" / "Alpha.md"
+    note.write_text(
+        "---\nnote_id: alpha\ntitle: Alpha\ntype: evergreen\n"
+        "date: 2026-04-07\n---\n\n# Alpha\n",
+        encoding="utf-8",
+    )
+    layout = VaultLayout.from_vault(temp_vault)
+    layout.pipeline_log.parent.mkdir(parents=True, exist_ok=True)
+    # Two noise events + one target event, in timestamp order.
+    layout.pipeline_log.write_text(
+        "\n".join([
+            json.dumps({"timestamp": "2026-04-07T10:00:00Z", "session_id": "s",
+                        "event_type": "noise_a", "slug": "alpha"}),
+            json.dumps({"timestamp": "2026-04-07T11:00:00Z", "session_id": "s",
+                        "event_type": "noise_b", "slug": "alpha"}),
+            json.dumps({"timestamp": "2026-04-07T12:00:00Z", "session_id": "s",
+                        "event_type": "target_kind", "slug": "alpha"}),
+        ]) + "\n",
+        encoding="utf-8",
+    )
+    rebuild_knowledge_index(temp_vault)
+
+    # event_type filter returns only the matching row even though
+    # noise events are newer / would otherwise dominate.
+    events = recent_audit_events(
+        temp_vault, limit=10, event_type="target_kind",
+    )
+    assert [e["event_type"] for e in events] == ["target_kind"]
+
+    # since filter excludes older rows.
+    since_events = recent_audit_events(
+        temp_vault, limit=10, since="2026-04-07T11:30:00Z",
+    )
+    assert [e["event_type"] for e in since_events] == ["target_kind"]
+
+
 def test_knowledge_index_cli_read_modes_return_json(temp_vault, capsys):
     from ovp_pipeline.commands.knowledge_index import main
     from ovp_pipeline.runtime import VaultLayout

--- a/tests/test_live_concept_scheduler.py
+++ b/tests/test_live_concept_scheduler.py
@@ -85,6 +85,41 @@ def test_evaluate_all_concepts_skips_paused(tmp_path, monkeypatch):
     assert slugs == {"alpha", "beta"}
 
 
+def test_evaluate_all_concepts_pushes_filters_into_sql(tmp_path, monkeypatch):
+    """Codex/bot regression: pre-fix the scheduler fetched the most
+    recent N audit_events of *any* event_type, then post-filtered to
+    ``absorb_route_decision`` in Python.  On a noisy log the relevant
+    routing decisions could be silently truncated.  Now the scheduler
+    pushes both ``event_type`` and a ``since`` cutoff into the SQL
+    call — this test asserts those kwargs are forwarded."""
+    from ovp_pipeline import live_concept_scheduler
+
+    _seed_vault(tmp_path)
+    captured_kwargs: dict = {}
+
+    def fake_recent_audit_events(_vault, **kwargs):
+        captured_kwargs.update(kwargs)
+        return []
+
+    monkeypatch.setattr(
+        live_concept_scheduler,
+        "recent_audit_events",
+        fake_recent_audit_events,
+    )
+    monkeypatch.setattr(
+        live_concept_scheduler, "list_contradictions", lambda *a, **kw: [],
+    )
+    live_concept_scheduler.evaluate_all_concepts(
+        tmp_path,
+        since_hours=24,
+        now=datetime(2026, 5, 11, 9, 30, tzinfo=timezone.utc),
+    )
+    assert captured_kwargs.get("event_type") == "absorb_route_decision"
+    assert "since" in captured_kwargs
+    # since cutoff = now - 24h.
+    assert captured_kwargs["since"] == "2026-05-10T09:30:00Z"
+
+
 def test_evaluate_all_concepts_filters_route_events_by_window(tmp_path, monkeypatch):
     """Audit rows older than ``cutoff = now - since_hours`` are
     dropped before the evaluator sees them."""


### PR DESCRIPTION
## Summary

Replaces BL-068's alphabetical truncation with embedding-based topical ranking. Pre-fix, a 9461-evergreen vault capped at 1000 entries saw only \`a*\` → \`g*\` slugs alphabetically — UPDATE candidates with slugs sorting after the cap were silently treated as CREATEs.

## Approach

1. Embed source_content via the existing \`embedding.embed_text\` (Qwen3-Embedding-0.6B on MLX; BLAKE2b hash fallback)
2. Load evergreen vectors from \`page_embeddings\` JOIN-ed to \`objects\` (for pack-scoped filtering), restricted to the same embedding-model row so 128-d hash and 1024-d Qwen never mix
3. Cosine similarity = dot product (both sides L2-normalised by embed_text contract); pure-Python loop is fast enough at ~9K × 1024-d (~50-100ms on M-series)
4. \`build_evergreen_index\` now takes \`priority_slugs\` — ranker output moves to the front; non-priority entries trail in lexicographic order
5. Combined with \`max_entries\` this surfaces topically-relevant evergreens to the router while keeping alphabetical as a fallback

## Config & observability

| Env var | Values | Default |
|---|---|---|
| \`OVP_ROUTER_INDEX_STRATEGY\` | \`embedding_topk\` / \`alphabetical\` | \`embedding_topk\` |
| \`OVP_ROUTER_MAX_INDEX_ENTRIES\` | int (cap) | 1000 (from BL-068) |

Audit \`absorb_route_decision\` event now carries \`index_strategy\` with one of:
- \`embedding_topk\` — dense pre-filter found candidates
- \`alphabetical_fallback\` — ranker returned empty, fell back to BL-068 alphabetical
- \`alphabetical\` — operator forced via env var
- \`explicit\` — caller supplied \`index=\` directly (tests)

## Test plan

- [x] 8 new tests (priority reorder + cap interaction, env strategy parsing, ranker happy path + empty source + missing DB + dim mismatch)
- [x] Full suite: 2393 passed (was 2385, +8)
- [x] Architecture-fitness single-writer green
- [x] **Live verification (the load-bearing one)**:

On the same "大多数公司根本没有为 AI 做好准备" article that previously routed \`0 updates / 4 creates\` under alphabetical:

\`\`\`
status=ok | strategy=embedding_topk
updates=1 creates=3
update_slugs: ['ai-maturity-framework-l0-to-l4']
create_titles: ['组织清晰度决定 AI 应用成败',
                '组织清晰度审计三步法',
                'AI 放大组织状态']
\`\`\`

Router correctly identified \`ai-maturity-framework-l0-to-l4\` as the UPDATE target — the slug starts with 'a' but wouldn't have made the first-1000 alphabetical slice for this vault. **This is the exact failure mode BL-069 was designed to fix.**

## Out of scope (future)

- Per-chunk ranking (currently per-slug mean) — would help long evergreens whose only relevant section is buried
- In-process vector cache — loads ~38MB float dict every call; fine at current vault sizes
- Hybrid retrieval (BM25 + dense) — defer until shadow data shows whether pure dense is enough

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added embedding-based ranking for Pass 1 router indexing with fallback to alphabetical ordering.
  * Enhanced audit logging to track which indexing strategy was used for routing decisions.

* **Bug Fixes**
  * Auto-promotion now records actual mutation results instead of requested values in audit trails.

* **Improvements**
  * Evergreen revision history is now preserved across knowledge index rebuilds.
  * Audit event queries now support filtering by event type and timestamp at the database layer for improved performance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fakechris/obsidian_vault_pipeline/pull/201)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->