### PR TITLE
feat(bl-071): 03-Processed sources are absorb-eligible (post-BL-058 chain end-to-end)

### DIFF
--- a/src/ovp_pipeline/auto_evergreen_extractor.py
+++ b/src/ovp_pipeline/auto_evergreen_extractor.py
@@ -1449,9 +1449,22 @@ class AutoEvergreenExtractor:
             return []
 
         # 处理深度解读文件 + BL-066 github-project 源(后者无 _深度解读 后缀)
+        # + BL-071 intake-only sources under 03-Processed (clippings,
+        # pinboard articles).  Same three-shape detection as
+        # ``_collect_absorb_targets(directory=...)`` so the two paths
+        # produce identical target sets — pre-BL-071 they drifted apart
+        # because ``process_directory`` skipped the broader detector,
+        # making ``--dir 03-Processed/.../<month>`` find zero targets
+        # for non-github sources (codex P2 #2).
+        is_processed_dir = _is_under_path(directory, self.layout.processed_dir)
         files = list(directory.glob("*_深度解读.md"))
         for candidate in directory.glob("*.md"):
-            if candidate not in files and _is_github_source_markdown(candidate):
+            if candidate in files:
+                continue
+            if _is_github_source_markdown(candidate):
+                files.append(candidate)
+                continue
+            if is_processed_dir and _is_intake_only_source_markdown(candidate):
                 files.append(candidate)
 
         results = []
@@ -1660,14 +1673,25 @@ def _collect_processed_github_sources(
     month_names: set[str] | None = None,
     cutoff: datetime | None = None,
 ) -> list[Path]:
-    """Scan ``50-Inbox/03-Processed/<YYYY-MM>/`` for github-source
-    markdowns (BL-066).  Used by the ``recent`` branch of
-    ``_collect_absorb_targets`` so github intakes flow into absorb on
-    the same schedule as deep-dives.
+    """Scan ``50-Inbox/03-Processed/<YYYY-MM>/`` for absorb-eligible
+    intake sources.  Used by the ``recent`` branch of
+    :func:`_collect_absorb_targets` so intake products flow into
+    absorb on the same schedule as deep-dives.
 
-    ``month_names`` filters which month dirs to scan; ``cutoff`` filters
-    by file mtime.  When both are None, returns all github sources
-    under processed_dir.
+    Despite the name (kept for backwards compat with older callers),
+    BL-071 widens the scan to BOTH:
+
+    * BL-066 github-project sources (:func:`_is_github_source_markdown`)
+    * BL-071 broader intake sources — clippings, pinboard articles,
+      hand-curated raws with a source URL
+      (:func:`_is_intake_only_source_markdown`)
+
+    Pre-BL-071 the ``--recent N`` branch silently ignored every
+    non-github intake (codex P2 #3).
+
+    ``month_names`` filters which month dirs to scan; ``cutoff``
+    filters by file mtime.  When both are ``None``, returns every
+    eligible source under processed_dir.
     """
     if not layout.processed_dir.exists():
         return []
@@ -1688,7 +1712,10 @@ def _collect_processed_github_sources(
                     continue
                 if modified_at < cutoff:
                     continue
-            if not _is_github_source_markdown(candidate):
+            if not (
+                _is_github_source_markdown(candidate)
+                or _is_intake_only_source_markdown(candidate)
+            ):
                 continue
             key = str(candidate.resolve())
             if key in seen:
@@ -1707,6 +1734,21 @@ def _collect_absorb_targets(
 ) -> list[Path]:
     if file_path:
         _reject_intake_source_target(layout, file_path)
+        # BL-071: when the single file lives under 03-Processed, run
+        # the eligibility filter so callers that auto-iterate (e.g.
+        # commands/absorb.py's per-file ``run_absorb_workflow``)
+        # don't waste a router LLM call on empty stubs / archive
+        # files / non-source notes (codex P2 #1).  Deep-dive files
+        # and BL-066 github sources are accepted as before.
+        if _is_under_path(file_path, layout.processed_dir):
+            name = file_path.name
+            is_deep_dive = name.endswith("_深度解读.md")
+            if not (
+                is_deep_dive
+                or _is_github_source_markdown(file_path)
+                or _is_intake_only_source_markdown(file_path)
+            ):
+                return []
         return [file_path]
     if directory:
         _reject_intake_source_target(layout, directory)

--- a/src/ovp_pipeline/auto_evergreen_extractor.py
+++ b/src/ovp_pipeline/auto_evergreen_extractor.py
@@ -1509,20 +1509,117 @@ def _is_under_path(path: Path, parent: Path) -> bool:
 
 
 def _reject_intake_source_target(layout: VaultLayout, path: Path) -> None:
+    """Block paths still in the work-in-progress intake stages.
+
+    Pre-BL-071 this also blocked ``50-Inbox/03-Processed/`` — but
+    that's the **post-BL-029 absorb input layer** by design.  BL-058
+    explicitly documents "absorb v2 reads the raw directly" and
+    BL-066's github intake already routes 03-Processed files through
+    absorb via :func:`_is_github_source_markdown`.  BL-071 generalises
+    that to every intake-only source under 03-Processed (clippings,
+    pinboard-staged articles, hand-curated raw files) so the
+    operator can run ``ovp-absorb --file 50-Inbox/03-Processed/.../X.md``
+    end-to-end without forcing a deep-dive synthesis step that no
+    longer exists.
+
+    The three stages that **stay blocked**:
+
+    * ``Clippings/`` — the Obsidian web-clipper landing zone.  Files
+      here haven't been renamed / image-resolved / dedup-checked yet.
+    * ``50-Inbox/01-Raw/`` — staged for intake but not yet processed.
+      Image download + frontmatter parse haven't run.
+    * ``50-Inbox/02-Processing/`` — currently being processed by
+      ``auto_article_processor``; absorb would race the move-to-
+      processed step.
+
+    03-Processed is the durable "ready for absorb" layer.  Absorb
+    against files there is allowed; the
+    :func:`_is_intake_only_source_markdown` filter still gates which
+    of them are absorb-eligible (empty intake stubs, deep-dives, and
+    archive-only files are skipped at the per-target check).
+    """
     for source_root in (
         layout.clippings_dir,
         layout.raw_dir,
         layout.processing_dir,
-        layout.processed_dir,
     ):
         if _is_under_path(path, source_root):
             raise ValueError(
-                f"absorb target is an intake source and must go through source lifecycle first: {path}"
+                "absorb target is an intake source and must go through "
+                f"source lifecycle first: {path}"
             )
 
 
 _GITHUB_SOURCE_FRONTMATTER_MARKER = "source_type: github-project"
 _GITHUB_SKIPPED_MARKER = "extraction_status: skipped"
+
+# BL-071: minimum body length for a 03-Processed source to be
+# considered absorb-eligible.  Empty intake stubs (the file was
+# created by the lifecycle move but the body was never resolved)
+# would otherwise waste a router LLM call to produce
+# ``units=[], skip_reason="empty"``.  ~200 chars is below any real
+# article's first paragraph; lower than that is almost certainly a
+# stub.
+_INTAKE_SOURCE_MIN_BODY_CHARS = 200
+
+
+def _is_intake_only_source_markdown(path: Path) -> bool:
+    """BL-071: return True when ``path`` is an intake-only source in
+    ``50-Inbox/03-Processed/`` that's worth running through absorb.
+
+    Detection rules:
+
+    * File must have ``---`` YAML frontmatter.
+    * Frontmatter must carry a ``source:`` URL (or ``source_url:``
+      via the BL-066 convention) — distinguishes intake products
+      from hand-written notes that happen to live under
+      ``03-Processed/`` for organisational reasons.
+    * Must NOT carry ``extraction_status: skipped`` — the BL-066
+      audit-trail marker for empty enrichments.
+    * Body must be longer than :data:`_INTAKE_SOURCE_MIN_BODY_CHARS`
+      so we don't waste router LLM calls on empty stubs.
+    * Filename must NOT match ``*_深度解读.md`` — those are the
+      legacy deep-dive layer (already handled by the ``targets``
+      glob in :func:`_collect_absorb_targets`).
+
+    Reads at most 8 KB to keep the per-file cost bounded — the
+    frontmatter + first-paragraph check fits comfortably.  Body
+    length check uses the truncated read; underestimates long
+    articles' length but never overestimates a stub's, so it stays
+    conservative on the "is this absorb-eligible?" side.
+    """
+    name = path.name
+    if name.endswith("_深度解读.md"):
+        return False
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            head = fh.read(8 * 1024)
+    except (OSError, UnicodeDecodeError):
+        return False
+    if not head.startswith("---"):
+        return False
+    fence_end = head.find("\n---", 3)
+    if fence_end < 0:
+        return False
+    fm_block = head[:fence_end]
+    body = head[fence_end + 4 :].lstrip()
+    if _GITHUB_SKIPPED_MARKER in fm_block:
+        return False
+    # Source URL field — accepts both ``source:`` (clippings,
+    # articles, pinboard) and ``source_url:`` (BL-066 github,
+    # paper).  Cheap substring check to avoid YAML-parsing every
+    # candidate.
+    has_source = (
+        "\nsource:" in fm_block
+        or fm_block.startswith("source:")
+        or "\nsource_url:" in fm_block
+        or fm_block.startswith("source_url:")
+    )
+    if not has_source:
+        return False
+    if len(body) < _INTAKE_SOURCE_MIN_BODY_CHARS:
+        return False
+    return True
 
 
 def _is_github_source_markdown(path: Path) -> bool:
@@ -1615,13 +1712,23 @@ def _collect_absorb_targets(
         _reject_intake_source_target(layout, directory)
         if not directory.exists():
             return []
-        # Pick up both the legacy deep-dive layer and BL-066 github
-        # sources that landed in the same staging dir (e.g. when
-        # absorb is invoked with ``--directory 50-Inbox/03-Processed``
-        # directly).
+        # Three target shapes are absorb-eligible:
+        # 1. Legacy deep-dive layer (``*_深度解读.md``) — pre-BL-029.
+        # 2. BL-066 github-project sources via the marker check.
+        # 3. BL-071 intake-only sources in 03-Processed (clippings,
+        #    pinboard-staged articles) that have a real body — the
+        #    "absorb v2 reads the raw directly" target shape from
+        #    BL-058's design.  Earlier intake stages stay blocked
+        #    by ``_reject_intake_source_target``.
+        is_processed_dir = _is_under_path(directory, layout.processed_dir)
         targets = sorted(directory.glob("*_深度解读.md"))
         for candidate in sorted(directory.glob("*.md")):
-            if candidate not in targets and _is_github_source_markdown(candidate):
+            if candidate in targets:
+                continue
+            if _is_github_source_markdown(candidate):
+                targets.append(candidate)
+                continue
+            if is_processed_dir and _is_intake_only_source_markdown(candidate):
                 targets.append(candidate)
         for target in targets:
             _reject_intake_source_target(layout, target)

--- a/tests/test_absorb_intake_source.py
+++ b/tests/test_absorb_intake_source.py
@@ -250,9 +250,8 @@ def test_collect_targets_directory_skips_intake_detection_outside_processed(tmp_
 
 def test_collect_targets_file_path_under_processed_is_allowed(tmp_path):
     """Single-file mode: ``ovp-absorb --file 50-Inbox/03-Processed/.../X.md``
-    no longer raises.  The eligibility check happens downstream
-    (extract_concepts), so this just verifies the reject guard
-    doesn't fire on the path."""
+    no longer raises.  When the file passes the eligibility filter,
+    it's returned as the single target."""
     from ovp_pipeline.auto_evergreen_extractor import _collect_absorb_targets
     from ovp_pipeline.runtime import VaultLayout
 
@@ -260,3 +259,122 @@ def test_collect_targets_file_path_under_processed_is_allowed(tmp_path):
     f = tmp_path / "50-Inbox" / "03-Processed" / "2026-05" / "x.md"
     _make_clipping(f)
     assert _collect_absorb_targets(layout, file_path=f) == [f]
+
+
+def test_collect_targets_file_path_skips_ineligible_processed_stub(tmp_path):
+    """Codex P2 #1 regression: single-file mode against an
+    ineligible 03-Processed file (empty stub, no source URL,
+    extraction_status:skipped) must return an empty target list
+    so the caller doesn't waste a router LLM call.  Pre-fix the
+    eligibility filter only ran in directory mode; single-file
+    passed any 03-Processed path straight through."""
+    from ovp_pipeline.auto_evergreen_extractor import _collect_absorb_targets
+    from ovp_pipeline.runtime import VaultLayout
+
+    layout = VaultLayout.from_vault(tmp_path)
+    stub = tmp_path / "50-Inbox" / "03-Processed" / "2026-05" / "stub.md"
+    stub.parent.mkdir(parents=True, exist_ok=True)
+    stub.write_text(
+        "---\ntitle: Stub\nsource: https://example.com\n---\n\n# Stub\n",
+        encoding="utf-8",
+    )
+    assert _collect_absorb_targets(layout, file_path=stub) == []
+
+
+def test_collect_targets_file_path_outside_processed_keeps_legacy_behaviour(tmp_path):
+    """Files outside 03-Processed (e.g. legacy ``20-Areas/.../topic_深度解读.md``)
+    don't go through the BL-071 eligibility filter — they're handled
+    by the deep-dive globs as before.  Pre-fix passed everything
+    through verbatim; post-fix this branch must still NOT filter
+    deep-dives."""
+    from ovp_pipeline.auto_evergreen_extractor import _collect_absorb_targets
+    from ovp_pipeline.runtime import VaultLayout
+
+    layout = VaultLayout.from_vault(tmp_path)
+    dd = tmp_path / "20-Areas" / "AI-Research" / "Topics" / "2026-05" / "x_深度解读.md"
+    dd.parent.mkdir(parents=True, exist_ok=True)
+    dd.write_text("---\ntitle: DD\n---\n\n# DD\n\n" + ("body " * 100), encoding="utf-8")
+    assert _collect_absorb_targets(layout, file_path=dd) == [dd]
+
+
+def test_process_directory_picks_up_intake_sources(tmp_path):
+    """Codex P2 #2 regression: ``run_absorb_workflow(directory=...)``
+    with no ``progress_callback`` routes through
+    ``AutoEvergreenExtractor.process_directory`` whose own scan
+    (pre-BL-071 fix) only saw deep-dives + github.  ``--dir
+    03-Processed/<month>/`` would silently process zero clippings.
+
+    This test exercises ``process_directory`` directly with mocked
+    ``process_file`` so we only assert the scan-set decision."""
+    from ovp_pipeline.auto_evergreen_extractor import AutoEvergreenExtractor
+    from ovp_pipeline.runtime import VaultLayout
+
+    month = tmp_path / "50-Inbox" / "03-Processed" / "2026-05"
+    month.mkdir(parents=True)
+    deep_dive = month / "a_深度解读.md"
+    deep_dive.write_text(
+        "---\ntitle: DD\n---\n\n# DD\n\n" + ("body " * 100), encoding="utf-8",
+    )
+    intake = month / "b_clipping.md"
+    _make_clipping(intake, body_chars=500)
+    stub = month / "c_stub.md"
+    stub.write_text(
+        "---\ntitle: Stub\nsource: https://example.com\n---\n\n# Stub\n",
+        encoding="utf-8",
+    )
+
+    class _Logger:
+        def log(self, *_a, **_kw):
+            pass
+
+    extractor = AutoEvergreenExtractor(tmp_path, _Logger())
+    scanned: list[str] = []
+
+    def fake_process_file(file_path, *, dry_run, auto_promote, promote_threshold):
+        scanned.append(file_path.name)
+        return {
+            "file": str(file_path),
+            "concepts_extracted": 0,
+            "candidates_added": 0,
+            "concepts_promoted": 0,
+            "concepts_created": 0,
+            "concepts_skipped": 0,
+        }
+
+    extractor.process_file = fake_process_file  # type: ignore[assignment]
+    extractor.process_directory(month)
+    # Stub is filtered out; deep-dive + clipping are processed.
+    assert sorted(scanned) == ["a_深度解读.md", "b_clipping.md"]
+
+
+def test_collect_processed_sources_includes_intake_in_recent_scan(tmp_path):
+    """Codex P2 #3 regression: ``_collect_processed_github_sources``
+    (used by ``--recent N``) used to filter exclusively by the
+    github detector.  Recent non-github intake sources were
+    invisible to the recent scan.  Now both detectors apply."""
+    from ovp_pipeline.auto_evergreen_extractor import _collect_processed_github_sources
+    from ovp_pipeline.runtime import VaultLayout
+
+    layout = VaultLayout.from_vault(tmp_path)
+    month = tmp_path / "50-Inbox" / "03-Processed" / "2026-05"
+    month.mkdir(parents=True)
+
+    github = month / "a_github.md"
+    github.write_text(
+        "---\nsource_type: github-project\nsource_url: https://github.com/x/y\n"
+        "---\n\n# Repo\n\n" + ("body " * 200), encoding="utf-8",
+    )
+    clipping = month / "b_clipping.md"
+    _make_clipping(clipping, body_chars=500)
+    deep_dive = month / "c_深度解读.md"
+    deep_dive.write_text(
+        "---\ntitle: DD\n---\n\n# DD\n\n" + ("body " * 100), encoding="utf-8",
+    )
+
+    sources = _collect_processed_github_sources(layout)
+    names = sorted(s.name for s in sources)
+    # github source + intake-only clipping picked up.  Deep-dive
+    # excluded — that's the legacy 20-Areas scan's job.
+    assert "a_github.md" in names
+    assert "b_clipping.md" in names
+    assert "c_深度解读.md" not in names

--- a/tests/test_absorb_intake_source.py
+++ b/tests/test_absorb_intake_source.py
@@ -1,0 +1,262 @@
+"""BL-071: 03-Processed intake sources are absorb-eligible.
+
+Before BL-071, ``_reject_intake_source_target`` blocked every path
+under ``50-Inbox/`` so ``ovp-absorb --file 03-Processed/...md``
+crashed with ``ValueError: absorb target is an intake source``.
+The post-BL-029 intent (per BL-058: "absorb v2 reads the raw
+directly") was never fully wired — only GitHub sources via
+:func:`_is_github_source_markdown` were allowed through.
+
+These tests pin the BL-071 contract:
+
+* Clippings/, 01-Raw/, 02-Processing/ stay blocked (work-in-
+  progress stages; running absorb here would race the lifecycle).
+* 03-Processed/ is allowed when the file passes
+  :func:`_is_intake_only_source_markdown` (has frontmatter +
+  source URL + non-trivial body + not a deep-dive).
+* Empty / no-source / deep-dive files under 03-Processed are
+  filtered out so we don't waste a router LLM call on them.
+* Directory scans + single-file absorb both honour the new policy.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _make_clipping(path: Path, *, body_chars: int = 1000) -> None:
+    """Write an intake-only clippings-style source file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    body = "Real article body. " * (max(body_chars, 20) // 20)
+    path.write_text(
+        "---\n"
+        'title: "Test Clipping"\n'
+        'source: "https://example.com/article"\n'
+        'created: 2026-05-10\n'
+        "tags:\n"
+        "  - clippings\n"
+        "---\n"
+        f"\n# Test Clipping\n\n{body}\n",
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# _reject_intake_source_target — narrower in BL-071
+# ---------------------------------------------------------------------------
+
+
+def test_reject_blocks_clippings_dir(tmp_path):
+    """Clippings/ is the web-clipper landing zone — files haven't
+    been renamed or had images resolved yet.  Block."""
+    import pytest
+    from ovp_pipeline.auto_evergreen_extractor import _reject_intake_source_target
+    from ovp_pipeline.runtime import VaultLayout
+
+    layout = VaultLayout.from_vault(tmp_path)
+    clipping = tmp_path / "Clippings" / "raw.md"
+    _make_clipping(clipping)
+    with pytest.raises(ValueError, match=r"intake source"):
+        _reject_intake_source_target(layout, clipping)
+
+
+def test_reject_blocks_raw_dir(tmp_path):
+    """50-Inbox/01-Raw is the pre-processing stage — block."""
+    import pytest
+    from ovp_pipeline.auto_evergreen_extractor import _reject_intake_source_target
+    from ovp_pipeline.runtime import VaultLayout
+
+    layout = VaultLayout.from_vault(tmp_path)
+    raw = tmp_path / "50-Inbox" / "01-Raw" / "x.md"
+    _make_clipping(raw)
+    with pytest.raises(ValueError, match=r"intake source"):
+        _reject_intake_source_target(layout, raw)
+
+
+def test_reject_blocks_processing_dir(tmp_path):
+    """50-Inbox/02-Processing is mid-flight — block."""
+    import pytest
+    from ovp_pipeline.auto_evergreen_extractor import _reject_intake_source_target
+    from ovp_pipeline.runtime import VaultLayout
+
+    layout = VaultLayout.from_vault(tmp_path)
+    processing = tmp_path / "50-Inbox" / "02-Processing" / "x.md"
+    _make_clipping(processing)
+    with pytest.raises(ValueError, match=r"intake source"):
+        _reject_intake_source_target(layout, processing)
+
+
+def test_reject_allows_processed_dir(tmp_path):
+    """BL-071: 03-Processed is the absorb-input layer by design.
+    The guard must NOT raise here — eligibility is decided by
+    :func:`_is_intake_only_source_markdown` at the per-target check."""
+    from ovp_pipeline.auto_evergreen_extractor import _reject_intake_source_target
+    from ovp_pipeline.runtime import VaultLayout
+
+    layout = VaultLayout.from_vault(tmp_path)
+    processed = tmp_path / "50-Inbox" / "03-Processed" / "2026-05" / "x.md"
+    _make_clipping(processed)
+    # Pre-BL-071 this would raise; the fix narrows the guard.
+    _reject_intake_source_target(layout, processed)  # no exception
+
+
+# ---------------------------------------------------------------------------
+# _is_intake_only_source_markdown — eligibility detector
+# ---------------------------------------------------------------------------
+
+
+def test_intake_source_eligible_with_source_and_body(tmp_path):
+    from ovp_pipeline.auto_evergreen_extractor import _is_intake_only_source_markdown
+
+    f = tmp_path / "ok.md"
+    _make_clipping(f, body_chars=500)
+    assert _is_intake_only_source_markdown(f) is True
+
+
+def test_intake_source_rejects_empty_stub(tmp_path):
+    """A 03-Processed file with frontmatter but a near-empty body
+    is an intake stub (lifecycle moved the file but body resolution
+    failed).  Not worth a router LLM call."""
+    from ovp_pipeline.auto_evergreen_extractor import _is_intake_only_source_markdown
+
+    f = tmp_path / "stub.md"
+    f.write_text(
+        "---\ntitle: Stub\nsource: https://example.com/a\n---\n\n# Stub\n",
+        encoding="utf-8",
+    )
+    assert _is_intake_only_source_markdown(f) is False
+
+
+def test_intake_source_rejects_no_source_url(tmp_path):
+    """A hand-written note that happens to live in 03-Processed
+    doesn't carry a ``source:`` URL — not an intake product."""
+    from ovp_pipeline.auto_evergreen_extractor import _is_intake_only_source_markdown
+
+    f = tmp_path / "handwritten.md"
+    f.write_text(
+        "---\ntitle: Hand-written\ntags:\n  - note\n---\n\n"
+        "# Hand-written\n\n" + ("This is my own note. " * 20) + "\n",
+        encoding="utf-8",
+    )
+    assert _is_intake_only_source_markdown(f) is False
+
+
+def test_intake_source_rejects_deep_dive_filename(tmp_path):
+    """Legacy deep-dive layer (``*_深度解读.md``) is handled by the
+    deep-dive glob in :func:`_collect_absorb_targets`; the intake-
+    only detector must NOT double-count them."""
+    from ovp_pipeline.auto_evergreen_extractor import _is_intake_only_source_markdown
+
+    f = tmp_path / "article_深度解读.md"
+    _make_clipping(f, body_chars=1000)
+    assert _is_intake_only_source_markdown(f) is False
+
+
+def test_intake_source_rejects_extraction_status_skipped(tmp_path):
+    """BL-066 audit-trail files for empty enrichments carry
+    ``extraction_status: skipped`` and have no extractable body —
+    same rule applies to the broader detector."""
+    from ovp_pipeline.auto_evergreen_extractor import _is_intake_only_source_markdown
+
+    f = tmp_path / "skipped.md"
+    f.write_text(
+        "---\ntitle: Skipped\nsource: https://example.com/a\n"
+        "extraction_status: skipped\n---\n\n# Skipped\n\n"
+        + ("Real body. " * 50) + "\n",
+        encoding="utf-8",
+    )
+    assert _is_intake_only_source_markdown(f) is False
+
+
+def test_intake_source_accepts_source_url_field_too(tmp_path):
+    """BL-066 uses ``source_url:`` instead of ``source:``; the
+    detector accepts both so github / paper intakes work."""
+    from ovp_pipeline.auto_evergreen_extractor import _is_intake_only_source_markdown
+
+    f = tmp_path / "github.md"
+    f.write_text(
+        "---\ntitle: Repo\nsource_url: https://github.com/x/y\n"
+        "---\n\n# Repo\n\n" + ("Repo body. " * 50) + "\n",
+        encoding="utf-8",
+    )
+    assert _is_intake_only_source_markdown(f) is True
+
+
+# ---------------------------------------------------------------------------
+# _collect_absorb_targets — directory mode picks up intake sources
+# ---------------------------------------------------------------------------
+
+
+def test_collect_targets_directory_picks_up_intake_and_deep_dive(tmp_path):
+    """When ``--dir 03-Processed/2026-05/`` is passed, both legacy
+    deep-dives AND BL-071 intake sources should be returned in
+    one list — the operator can absorb a whole month with one call."""
+    from ovp_pipeline.auto_evergreen_extractor import _collect_absorb_targets
+    from ovp_pipeline.runtime import VaultLayout
+
+    layout = VaultLayout.from_vault(tmp_path)
+    month = tmp_path / "50-Inbox" / "03-Processed" / "2026-05"
+    month.mkdir(parents=True)
+
+    # Legacy deep-dive.
+    deep_dive = month / "2026-05-10_article_深度解读.md"
+    deep_dive.write_text(
+        "---\ntitle: DD\ntype: deep_dive\n---\n\n# DD\n\n"
+        + ("body " * 100) + "\n",
+        encoding="utf-8",
+    )
+    # BL-071 intake-only source.
+    intake = month / "2026-05-10_clipping.md"
+    _make_clipping(intake, body_chars=500)
+    # Stub that should be filtered out.
+    stub = month / "2026-05-10_stub.md"
+    stub.write_text(
+        "---\ntitle: Stub\nsource: https://example.com\n---\n\n# Stub\n",
+        encoding="utf-8",
+    )
+
+    targets = _collect_absorb_targets(layout, directory=month)
+    names = sorted(t.name for t in targets)
+    assert "2026-05-10_article_深度解读.md" in names
+    assert "2026-05-10_clipping.md" in names
+    assert "2026-05-10_stub.md" not in names
+
+
+def test_collect_targets_directory_skips_intake_detection_outside_processed(tmp_path):
+    """Intake-only detection is gated to 03-Processed only.  A
+    ``--dir 20-Areas/AI-Research/Topics/2026-05/`` directory still
+    follows the legacy deep-dive glob (the BL-071 broader detector
+    isn't applied there)."""
+    from ovp_pipeline.auto_evergreen_extractor import _collect_absorb_targets
+    from ovp_pipeline.runtime import VaultLayout
+
+    layout = VaultLayout.from_vault(tmp_path)
+    topic = tmp_path / "20-Areas" / "AI-Research" / "Topics" / "2026-05"
+    topic.mkdir(parents=True)
+    deep_dive = topic / "2026-05-10_article_深度解读.md"
+    deep_dive.write_text(
+        "---\ntitle: DD\n---\n\n# DD\n\n" + ("body " * 100) + "\n",
+        encoding="utf-8",
+    )
+    # A clippings-style file at this path is NOT picked up — it
+    # shouldn't be in 20-Areas anyway.
+    clipping = topic / "2026-05-10_misplaced_clipping.md"
+    _make_clipping(clipping, body_chars=500)
+
+    targets = _collect_absorb_targets(layout, directory=topic)
+    names = sorted(t.name for t in targets)
+    assert names == ["2026-05-10_article_深度解读.md"]
+
+
+def test_collect_targets_file_path_under_processed_is_allowed(tmp_path):
+    """Single-file mode: ``ovp-absorb --file 50-Inbox/03-Processed/.../X.md``
+    no longer raises.  The eligibility check happens downstream
+    (extract_concepts), so this just verifies the reject guard
+    doesn't fire on the path."""
+    from ovp_pipeline.auto_evergreen_extractor import _collect_absorb_targets
+    from ovp_pipeline.runtime import VaultLayout
+
+    layout = VaultLayout.from_vault(tmp_path)
+    f = tmp_path / "50-Inbox" / "03-Processed" / "2026-05" / "x.md"
+    _make_clipping(f)
+    assert _collect_absorb_targets(layout, file_path=f) == [f]


### PR DESCRIPTION
## Summary

Closes the architectural gap from PR #199's note: BL-058 documented "absorb v2 reads the raw directly" but the implementation only allowed BL-066 github sources through; clippings / pinboard / hand-curated raws in 03-Processed/ still hit the \`_reject_intake_source_target\` guard.

**Before**: \`ovp-absorb --file 50-Inbox/03-Processed/X.md\` crashed with \`ValueError: absorb target is an intake source\`. The 38 sources \`ovp-pipeline --incremental\` staged were absorb-unreachable.

**After**: end-to-end \`source → absorb\` works on the raw markdown, no deep-dive synthesis required.

## Changes

| | Before | After |
|---|---|---|
| Reject guard blocks | Clippings + 01-Raw + 02-Processing + 03-Processed | Clippings + 01-Raw + 02-Processing |
| 03-Processed eligibility | Github sources only | Github + intake-only (clippings/articles/pinboard) + deep-dives |
| Detector | \`_is_github_source_markdown\` (single check) | + new \`_is_intake_only_source_markdown\` (frontmatter + source URL + body >= 200 chars + not deep-dive + not skipped) |
| Directory mode | deep-dives + github | deep-dives + github + intake-only (gated to 03-Processed only) |

## Test plan (13 new tests)

- [x] Reject-guard narrows correctly (Clippings/Raw/Processing blocked; Processed allowed)
- [x] Eligibility detector accepts/rejects correctly across 6 shapes (real article, empty stub, no-source handwritten note, deep-dive name, extraction_status:skipped, BL-066 source_url variant)
- [x] Directory mode picks up legacy + intake; gates broader detection to 03-Processed only
- [x] Single-file mode no longer raises
- [x] Full suite: 2416 passed (+13)

## Live verification — first-ever end-to-end source absorb

\`\`\`
$ OVP_ABSORB_ROUTER_SHADOW=1 OVP_ROUTER_MODEL=deepseek-v4-flash ... \\
    ovp-absorb --file 50-Inbox/03-Processed/2026-05/2026-05-10_How_We_Taught_Nowledge_Mem_to_Forget.md \\
    --auto-promote --promote-threshold 1
  concepts extracted: 4
  concepts promoted: 4
  files created: 4
\`\`\`

- 4 new evergreens written from the raw clipping (no deep-dive)
- BL-062 shadow router (BL-069 embedding_topk): \`status=ok\`, \`updates=2 creates=0\`
- BL-061 revision hook (BL-067 CLI path): 4 rows with \`changed_by='cli:auto_promote'\`
- BL-070 audit-sync surfaced everything in SQL in 1.2s

## Follow-ups (out of scope)

- Operator UX: \`ovp-absorb --recent N\` should also scan 03-Processed for intake-only sources (currently only 20-Areas deep-dives + 03-Processed github). One-line addition once we agree on the cutoff semantics.
- Pipeline integration: \`ovp-pipeline --incremental\` could add an \`absorb\` step that uses BL-071 sources. Currently absorb is a separate manual step post-BL-058 — by design, per the decoupled-intake-from-absorb narrative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended processing to include intake-only source markdown files from the processed directory, with eligibility requirements for source URLs and minimum content length.
  * Refined collection logic to gather intake sources alongside existing deep-dive and GitHub-project sources.

* **Tests**
  * Added comprehensive test suite validating intake-source eligibility and collection behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fakechris/obsidian_vault_pipeline/pull/203)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->