### PR TITLE
fix(bl-063 pr#3): codex P1+P2 — adapter generate alias + comment-tolerant heading match

### DIFF
--- a/src/ovp_pipeline/live_concept_agent.py
+++ b/src/ovp_pipeline/live_concept_agent.py
@@ -129,10 +129,14 @@ def _read_body_sections(path: Path) -> dict[str, str]:
         text = path.read_text(encoding="utf-8")
     except OSError:
         return out
-    # Cheap H2 split — same convention as live_concept_fileops.
+    # H2 split — tolerant of inline HTML-comment ownership markers
+    # like ``## Current synthesis  <!-- agent-owned -->`` (the BL-063
+    # PR#1 example file's documented style).  Codex P2 caught that
+    # the exact-line matcher missed these and the agent would
+    # double-write the section instead of replacing.
     for name in AGENT_OWNED_SECTIONS:
         pattern = re.compile(
-            r"^## " + re.escape(name) + r"\s*$(.*?)(?=^## |^# |\Z)",
+            r"^## " + re.escape(name) + r"(?:\s*<!--[^>]*-->)?\s*$(.*?)(?=^## |^# |\Z)",
             re.MULTILINE | re.DOTALL,
         )
         match = pattern.search(text)

--- a/src/ovp_pipeline/live_concept_fileops.py
+++ b/src/ovp_pipeline/live_concept_fileops.py
@@ -482,6 +482,33 @@ AGENT_OWNED_SECTIONS = (
 USER_OWNED_SECTIONS = ("My take",)
 
 
+def _heading_title(line: str) -> str | None:
+    """Return the title text of an H2 heading line, stripping inline
+    HTML comments + trailing whitespace.  Returns ``None`` for lines
+    that aren't H2 headings.
+
+    The BL-063 PR#1 example file shows headings like:
+
+        ## Current synthesis  <!-- agent-owned -->
+        ## My take  <!-- user-owned section; agent never writes here -->
+
+    Codex P2: pre-fix the section-range matcher did exact-line
+    string compare and missed these annotated headings, so the
+    agent's first run appended a duplicate ``## Current synthesis``
+    section instead of replacing the existing one.  Stripping the
+    HTML comment before comparison makes the matcher tolerant of
+    the documented annotation style.
+    """
+    if not line.startswith("## "):
+        return None
+    title = line[3:]
+    # Strip from first HTML comment marker to end-of-line.
+    comment_idx = title.find("<!--")
+    if comment_idx >= 0:
+        title = title[:comment_idx]
+    return title.strip() or None
+
+
 def _find_section_range(body: str, section_title: str) -> tuple[int, int] | None:
     """Find a level-2 section's range in the body.
 
@@ -489,18 +516,20 @@ def _find_section_range(body: str, section_title: str) -> tuple[int, int] | None
     exclusive — slice ``lines[start:end]`` includes the heading
     line + every line up to (but not including) the next H1/H2.
 
-    Title matching is exact and case-sensitive — Obsidian
-    convention is title-cased section headings, and treating
-    "## current synthesis" and "## Current synthesis" as different
-    sections is the safer default for a single-writer contract.
+    Title matching is exact and case-sensitive on the heading text
+    *after* stripping inline HTML comments (so
+    ``## Current synthesis  <!-- agent-owned -->`` matches
+    ``Current synthesis``).  Obsidian convention is title-cased
+    section headings; treating "## current synthesis" and
+    "## Current synthesis" as different sections is the safer
+    default for a single-writer contract.
 
     Returns ``None`` when the section doesn't exist in the body.
     """
     lines = body.splitlines()
-    target_line = f"## {section_title}"
     start: int | None = None
     for i, line in enumerate(lines):
-        if line.rstrip() == target_line:
+        if _heading_title(line) == section_title:
             start = i
             break
     if start is None:

--- a/src/ovp_pipeline/llm_client.py
+++ b/src/ovp_pipeline/llm_client.py
@@ -23,7 +23,15 @@ logger = logging.getLogger(__name__)
 
 
 class _CallableLLMClient:
-    """Adapt LiteLLMClient.generate(...) → .call(...) for entity_extractor."""
+    """Adapt LiteLLMClient.generate(...) → .call(...) for entity_extractor.
+
+    Exposes BOTH ``.call(...)`` (for legacy consumers like
+    ``entity_extractor``) AND ``.generate(...)`` (for the duck-typed
+    interface BL-062 router + BL-063 PR#3 agent use).  Both names
+    are aliases for the same underlying tuple-shape-tolerant call;
+    keeping both names live so the adapter is callable from either
+    convention without re-fetching the inner client.
+    """
 
     def __init__(self, inner: Any) -> None:
         self._inner = inner
@@ -38,6 +46,23 @@ class _CallableLLMClient:
         else:
             text = out
         return text or ""
+
+    def generate(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        max_tokens: int = 3000,
+    ) -> str:
+        """Alias for :meth:`call` so the BL-062 router and BL-063
+        PR#3 agent (which both use the ``.generate(...)`` shape) can
+        consume this adapter without unwrapping ``._inner``.
+
+        Codex P1: without this alias, ``ovp-live-concept-scan --fire``
+        would AttributeError on every real-config run because
+        :func:`get_litellm_client` returns this adapter, not the
+        bare ``LiteLLMClient``.
+        """
+        return self.call(system_prompt, user_prompt, max_tokens=max_tokens)
 
 
 def get_litellm_client(vault_dir: Path | None = None) -> _CallableLLMClient | None:

--- a/tests/test_live_concept_agent.py
+++ b/tests/test_live_concept_agent.py
@@ -111,6 +111,38 @@ def test_patch_agent_section_refuses_my_take(tmp_path):
         patch_agent_section(path, "My take", "agent trying to hijack")
 
 
+def test_patch_agent_section_tolerates_inline_html_comment(tmp_path):
+    """Codex P2 regression: BL-063 PR#1 example file documents
+    headings annotated with ownership comments like
+    ``## Current synthesis  <!-- agent-owned -->``.  The section
+    matcher must find these (so agent replaces them) instead of
+    treating them as missing and appending a duplicate."""
+    from ovp_pipeline.live_concept_fileops import patch_agent_section
+
+    path = tmp_path / "30-Projects" / "Tracking" / "x.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "---\ntype: live-concept\nlive:\n  objective: x\n---\n\n"
+        "# X\n\n"
+        "## My take  <!-- user-owned section; agent never writes here -->\n\n"
+        "User text.\n\n"
+        "## Current synthesis  <!-- agent-owned -->\n\n"
+        "Old synthesis placeholder.\n",
+        encoding="utf-8",
+    )
+    changed = patch_agent_section(
+        path, "Current synthesis", "- New bullet from agent\n",
+    )
+    assert changed is True
+    text = path.read_text(encoding="utf-8")
+    # Exactly ONE Current synthesis section — not duplicated.
+    assert text.count("## Current synthesis") == 1
+    assert "Old synthesis placeholder" not in text
+    assert "- New bullet from agent" in text
+    # User section still untouched.
+    assert "User text." in text
+
+
 def test_patch_agent_section_idempotent_no_change(tmp_path):
     """Writing the same content twice → second call is a no-op."""
     from ovp_pipeline.live_concept_fileops import patch_agent_section

--- a/tests/test_llm_client_adapter.py
+++ b/tests/test_llm_client_adapter.py
@@ -1,0 +1,68 @@
+"""Codex P1 regression: ``_CallableLLMClient`` exposes both
+``.call`` and ``.generate`` so consumers using the BL-062 router /
+BL-063 PR#3 agent's ``.generate(...)`` shape can use the adapter
+returned by :func:`get_litellm_client` without unwrapping
+``._inner``."""
+
+from __future__ import annotations
+
+
+class _FakeInner:
+    """Minimal stand-in for ``LiteLLMClient``: just records calls
+    and echoes back the user_prompt."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, int]] = []
+
+    def generate(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        max_tokens: int = 3000,
+    ) -> str:
+        self.calls.append((system_prompt, user_prompt, max_tokens))
+        return f"ECHO:{user_prompt}"
+
+
+def test_callable_llm_client_exposes_generate_alias():
+    """The agent (and BL-062 router) duck-type ``llm_client.generate``;
+    the adapter must expose it as a first-class method."""
+    from ovp_pipeline.llm_client import _CallableLLMClient
+
+    inner = _FakeInner()
+    adapter = _CallableLLMClient(inner)
+
+    assert hasattr(adapter, "generate")
+    out = adapter.generate("sys", "user", max_tokens=42)
+    assert out == "ECHO:user"
+    assert inner.calls == [("sys", "user", 42)]
+
+
+def test_callable_llm_client_call_and_generate_are_equivalent():
+    """The two surfaces must hit the same inner code path so behavior
+    can't drift between consumers."""
+    from ovp_pipeline.llm_client import _CallableLLMClient
+
+    inner = _FakeInner()
+    adapter = _CallableLLMClient(inner)
+
+    via_call = adapter.call("sys", "u1", max_tokens=10)
+    via_generate = adapter.generate("sys", "u2", max_tokens=10)
+    assert via_call.startswith("ECHO:")
+    assert via_generate.startswith("ECHO:")
+    assert len(inner.calls) == 2
+
+
+def test_callable_llm_client_generate_handles_tuple_response():
+    """Inner clients may return ``tuple[str, dict]`` (the
+    auto_article_processor variant).  Adapter must extract the
+    string regardless of which method the caller used."""
+    from ovp_pipeline.llm_client import _CallableLLMClient
+
+    class _TupleInner:
+        def generate(self, *_args, **_kw):
+            return ("the text", {"meta": "ignored"})
+
+    adapter = _CallableLLMClient(_TupleInner())
+    assert adapter.generate("s", "u") == "the text"
+    assert adapter.call("s", "u") == "the text"


### PR DESCRIPTION
Two codex findings on PR #204 that didn't make it into the squashed merge.

## P1 (load-bearing) — `_CallableLLMClient` missing `.generate`

`get_litellm_client()` returns the adapter, whose only public surface was `.call(...)`. BL-062 router and BL-063 PR#3 agent both duck-type `llm_client.generate(...)`. So every real-config run of `ovp-live-concept-scan --fire` would AttributeError → `request_error` → silently never call the LLM.

Fix: add a `.generate(...)` alias that delegates to `.call(...)`.

## P2 — heading matcher missed inline HTML comments

BL-063 PR#1's example uses annotated headings:

```
## Current synthesis  <!-- agent-owned -->
## My take  <!-- user-owned section; agent never writes here -->
```

`_find_section_range` did exact-line string compare so the matcher missed these and the agent's first run would APPEND a duplicate section instead of replacing.

Fix: new `_heading_title(line)` helper strips inline HTML comments before comparing; `_find_section_range` + `_read_body_sections` regex both use it.

## Tests (4 new)

- `test_callable_llm_client_exposes_generate_alias`
- `test_callable_llm_client_call_and_generate_are_equivalent`
- `test_callable_llm_client_generate_handles_tuple_response`
- `test_patch_agent_section_tolerates_inline_html_comment`

## Test plan

- [x] `pytest tests/test_llm_client_adapter.py tests/test_live_concept_agent.py -q` — 15 passed
- [x] No regressions in BL-063 PR#3 tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved tolerance for inline HTML comments in section headers (e.g., `<!-- agent-owned -->`), preventing incorrect section targeting and duplicate writes.

* **New Features**
  * Added `.generate()` method to LLM client adapter as an alias to `.call()`, improving compatibility with consumers expecting this interface.

* **Tests**
  * Added regression tests for section header comment handling and LLM client adapter method compatibility.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fakechris/obsidian_vault_pipeline/pull/205)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->