### PR TITLE
fix(normalize): preserve user-profile + live-concept types

### DIFF
--- a/src/ovp_pipeline/note_type_normalize.py
+++ b/src/ovp_pipeline/note_type_normalize.py
@@ -41,6 +41,16 @@ CANONICAL_NOTE_TYPES: frozenset[str] = frozenset(
         "article",
         "project",
         "essay",
+        # M19 BL-063: user-declared interpretation surface.  Lives at
+        # 30-Projects/Tracking/<slug>.md; agent maintains the synthesis
+        # sections, user owns ``## My take``.  Must not be normalised
+        # to ``article`` (would erase the type signal the live-concept
+        # discovery walk depends on).
+        "live-concept",
+        # M20 BL-075: user profile + autonomous-action rules.  Lives at
+        # 00-Polaris/USER.md; read by context_loader as LLM prefix.
+        # Same rationale — type signal must survive normalisation.
+        "user-profile",
     }
 )
 

--- a/tests/test_note_type_normalize_user_profile.py
+++ b/tests/test_note_type_normalize_user_profile.py
@@ -1,0 +1,35 @@
+"""Guard: ``note_type_normalize`` must not rewrite ``user-profile`` or
+``live-concept`` frontmatter.
+
+Regression caught on 2026-05-11: running ``ovp --incremental`` on the
+live operator vault rewrote ``00-Polaris/USER.md`` from
+``type: user-profile`` to ``type: article``, breaking the M20 / BL-075
+contract (the loader keys off the literal type to know it's reading
+a profile).  Both types now sit in ``CANONICAL_NOTE_TYPES`` and pass
+through normalisation unchanged.
+"""
+
+from __future__ import annotations
+
+from ovp_pipeline.note_type_normalize import (
+    CANONICAL_NOTE_TYPES,
+    load_mapping,
+)
+
+
+def test_user_profile_is_canonical():
+    assert "user-profile" in CANONICAL_NOTE_TYPES
+
+
+def test_live_concept_is_canonical():
+    assert "live-concept" in CANONICAL_NOTE_TYPES
+
+
+def test_normalize_user_profile_returns_self():
+    mapping = load_mapping()
+    assert mapping.normalize("user-profile") == "user-profile"
+
+
+def test_normalize_live_concept_returns_self():
+    mapping = load_mapping()
+    assert mapping.normalize("live-concept") == "live-concept"


### PR DESCRIPTION
## Summary

Live-vault smoke test of M19 + M20 caught a regression where
``ovp --incremental`` rewrote ``00-Polaris/USER.md`` from
``type: user-profile`` → ``type: article`` and added an
``original_note_type: user-profile`` "migration" marker.

Same vulnerability for M19 ``30-Projects/Tracking/<slug>.md``
files declared as ``type: live-concept``.

## Root cause

``CANONICAL_NOTE_TYPES`` predates M19 / M20.  Anything not in
the set gets normalised to ``article`` (catch-all behaviour
documented in ``note_type_normalize.NormalizationMapping.normalize``).

Both ``live-concept`` and ``user-profile`` are real type signals:

- ``live_concept.parse_live_concept`` keys off the literal type
- USER.md's ``schema_version: 1`` contract assumes the type
  survives automated runs

## Fix

Two additions to ``CANONICAL_NOTE_TYPES`` so both types pass
through normalisation unchanged.  No behaviour change anywhere
else.

## Test plan

- [x] ``pytest tests/test_note_type_normalize_user_profile.py -q`` — 4/4
- [x] Reproduced the original bug on the live operator vault, applied
      the fix, re-ran ``ovp --incremental`` — USER.md type now
      survives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `user-profile` and `live-concept` as canonical note types for improved note type handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fakechris/obsidian_vault_pipeline/pull/207)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->