### PR TITLE
perf(ui-server): cold-start 4min → 1s (background prewarm)

### DIFF
--- a/src/ovp_pipeline/_truth_helpers.py
+++ b/src/ovp_pipeline/_truth_helpers.py
@@ -45,12 +45,43 @@ _EVOLUTION_CANDIDATE_CACHE: dict[
     tuple[str, tuple[tuple[str, int, int], ...], str, tuple[str, ...]],
     list[dict[str, Any]],
 ] = {}
-# Serialises *miss* path of ``_all_evolution_candidates`` only —
-# concurrent cache hits stay parallel.  Without this, two callers
-# arriving during a cold start (background prewarm + first
-# ``/ops/evolution`` request) would both spend ~4 minutes computing
-# the same payload.  See PR #208 review feedback (rev-bot 208.1).
-_EVOLUTION_CANDIDATE_LOCK = threading.Lock()
+# Per-cache-key locks.  ``_EVOLUTION_LOCK_REGISTRY_LOCK`` guards
+# *just* the registry's own insert path — once a per-key lock
+# exists, every miss for the same key acquires that lock and
+# blocks ONLY the duplicate.  Misses for different keys
+# (different vault / pack scope / object filter) proceed in
+# parallel.  rev-bot 208 round-2 #9 caught that a single global
+# lock would block unrelated pack-scoped or object-scoped misses
+# behind the full-vault prewarm's ~4-min compute.
+_EVOLUTION_CANDIDATE_LOCK_REGISTRY: dict[
+    tuple[str, tuple[tuple[str, int, int], ...], str, tuple[str, ...]],
+    "threading.Lock",
+] = {}
+_EVOLUTION_LOCK_REGISTRY_LOCK = threading.Lock()
+
+
+def _evolution_candidate_lock(
+    cache_key: tuple[
+        str, tuple[tuple[str, int, int], ...], str, tuple[str, ...]
+    ],
+) -> "threading.Lock":
+    """Return (creating if needed) the per-key lock guarding
+    ``_EVOLUTION_CANDIDATE_CACHE[cache_key]``'s cold-miss path.
+
+    Registry-insert is itself guarded by a tiny global lock — the
+    work it serialises is a single dict lookup + insert, not the
+    multi-minute compute the per-key lock then guards.
+    """
+    existing = _EVOLUTION_CANDIDATE_LOCK_REGISTRY.get(cache_key)
+    if existing is not None:
+        return existing
+    with _EVOLUTION_LOCK_REGISTRY_LOCK:
+        existing = _EVOLUTION_CANDIDATE_LOCK_REGISTRY.get(cache_key)
+        if existing is not None:
+            return existing
+        lock = threading.Lock()
+        _EVOLUTION_CANDIDATE_LOCK_REGISTRY[cache_key] = lock
+        return lock
 
 CONTRADICTION_STATUS_EXPLANATIONS = {
     "open": "Active contradiction awaiting review.",

--- a/src/ovp_pipeline/_truth_helpers.py
+++ b/src/ovp_pipeline/_truth_helpers.py
@@ -14,6 +14,7 @@ import json
 import logging
 import re
 import sqlite3
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -44,6 +45,12 @@ _EVOLUTION_CANDIDATE_CACHE: dict[
     tuple[str, tuple[tuple[str, int, int], ...], str, tuple[str, ...]],
     list[dict[str, Any]],
 ] = {}
+# Serialises *miss* path of ``_all_evolution_candidates`` only —
+# concurrent cache hits stay parallel.  Without this, two callers
+# arriving during a cold start (background prewarm + first
+# ``/ops/evolution`` request) would both spend ~4 minutes computing
+# the same payload.  See PR #208 review feedback (rev-bot 208.1).
+_EVOLUTION_CANDIDATE_LOCK = threading.Lock()
 
 CONTRADICTION_STATUS_EXPLANATIONS = {
     "open": "Active contradiction awaiting review.",

--- a/src/ovp_pipeline/auto_evergreen_extractor.py
+++ b/src/ovp_pipeline/auto_evergreen_extractor.py
@@ -622,11 +622,8 @@ class EvergreenExtractor:
         """
         if self.vault_dir is None:
             return self.SYSTEM_PROMPT
-        from .context_loader import load_llm_context
-        prefix = load_llm_context(self.vault_dir)
-        if not prefix:
-            return self.SYSTEM_PROMPT
-        return prefix + "\n" + self.SYSTEM_PROMPT
+        from .context_loader import inject_llm_context
+        return inject_llm_context(self.vault_dir, self.SYSTEM_PROMPT)
 
     def _build_router_llm(self) -> Any:
         """Return the LLM client to use for the BL-062 Pass 1 router.

--- a/src/ovp_pipeline/commands/_ui_renderers.py
+++ b/src/ovp_pipeline/commands/_ui_renderers.py
@@ -127,8 +127,14 @@ def _topic_entry_card(entry: dict, *, compact: bool = False) -> str:
             "display:flex;flex-wrap:wrap;font-size:.78rem;color:var(--muted)'>"
             f"{breakdown_chips}</div>"
         )
+    # Rank lives in a small muted-mono line above the title rather
+    # than in a reserved left-column inside the card-head.  Pre-fix
+    # the 1.6rem rank column shifted the title's left edge ~25px in
+    # from the .card-body's left padding — so the title visually
+    # didn't line up with the teaser below it.  Post-fix everything
+    # in the card shares the same left edge.
     rank_html = (
-        f"<span class='muted tiny mono' style='min-width:1.6rem;text-align:right'>{rank}</span>"
+        f"<div class='muted tiny mono'>#{rank}</div>"
         if rank
         else ""
     )
@@ -145,8 +151,10 @@ def _topic_entry_card(entry: dict, *, compact: bool = False) -> str:
     return (
         "<section class='card flush'>"
         "<div class='card-head'>"
+        "<div style='flex:1;min-width:0'>"
         f"{rank_html}"
-        f"<h3 style='margin:0;font-size:1.05rem;flex:1;min-width:0'>{link_html}</h3>"
+        f"<h3 style='margin:0;font-size:1.05rem'>{link_html}</h3>"
+        "</div>"
         f"{score_pill}"
         f"{kind_pill}"
         "</div>"
@@ -1408,6 +1416,302 @@ def _render_markdown_note(
     return _render_frontmatter(frontmatter), html_body
 
 
+_THIN_NOTE_TYPES: frozenset[str] = frozenset({
+    # Generated / autonomous-action outputs and user-declared
+    # interpretation surfaces don't have provenance, production
+    # chains, source notes, or inbound captures.  Rendering the
+    # full evergreen scaffold around them produces a page of empty
+    # cards with the actual content buried at the bottom.
+    "digest",
+    "live-concept",
+    "user-profile",
+})
+
+_THIN_NOTE_PATH_PREFIXES: tuple[str, ...] = (
+    # Everything under GENERATED is by definition agent-produced
+    # content, not a Canonical-State object — apply the thin shell
+    # even if the frontmatter type is missing or unrecognised.
+    "40-Resources/Generated/",
+)
+
+
+def _is_thin_note(relative_path: str, markdown: str) -> bool:
+    """Decide whether ``/note?path=<relative_path>`` should render
+    the thin shell (header + body) instead of the full evergreen
+    scaffold.
+
+    Detection signals (any one is sufficient):
+
+    1. The file lives under a path prefix listed in
+       ``_THIN_NOTE_PATH_PREFIXES``.
+    2. The frontmatter ``type:`` value sits in ``_THIN_NOTE_TYPES``.
+    3. The frontmatter ``original_note_type:`` value sits in
+       ``_THIN_NOTE_TYPES`` — protects against a stale
+       ``note_type_normalize`` run that rewrote the type to
+       ``article`` before the M19/M20 canonical-set fix landed
+       (see PR #207).
+    4. A ``live:`` block is present in the frontmatter — that's the
+       structural marker the Live Concept primitive uses, so the
+       page renders correctly even if the ``type:`` key was lost.
+
+    Files outside all four keep the existing full-scaffold
+    behaviour so evergreens, deep-dives, and atlas pages render
+    unchanged.
+    """
+    normalised = (relative_path or "").replace("\\", "/")
+    if any(normalised.startswith(prefix) for prefix in _THIN_NOTE_PATH_PREFIXES):
+        return True
+    try:
+        frontmatter, _ = _parse_frontmatter(markdown)
+    except Exception:
+        return False
+    type_value = str(frontmatter.get("type") or "").strip().lower()
+    if type_value in _THIN_NOTE_TYPES:
+        return True
+    original_type = str(frontmatter.get("original_note_type") or "").strip().lower()
+    if original_type in _THIN_NOTE_TYPES:
+        return True
+    if isinstance(frontmatter.get("live"), dict):
+        return True
+    return False
+
+
+def _render_thin_note_preamble(
+    relative_path: str, markdown: str, *, requested_pack: str = ""
+) -> str:
+    """Type-aware "what is this page" card.
+
+    Goal: someone who lands on a digest or Live Concept page knows
+    immediately what the file is, where it came from, and what to
+    do next.  The user complaint that prompted this was "I don't
+    see any links and I'm not sure what made this appear".
+
+    Returns ``""`` when no preamble applies, so the thin shell can
+    concatenate unconditionally.
+    """
+    try:
+        frontmatter, _ = _parse_frontmatter(markdown)
+    except Exception:
+        frontmatter = {}
+
+    # Use the type that survived normalisation, or fall back to
+    # the recorded original_note_type, or detect structurally from
+    # a ``live:`` block.  This is the same precedence
+    # ``_is_thin_note`` uses to decide whether to enter the thin
+    # shell at all.
+    type_value = str(frontmatter.get("type") or "").strip().lower()
+    if type_value not in _THIN_NOTE_TYPES:
+        original_type = str(frontmatter.get("original_note_type") or "").strip().lower()
+        if original_type in _THIN_NOTE_TYPES:
+            type_value = original_type
+        elif isinstance(frontmatter.get("live"), dict):
+            type_value = "live-concept"
+
+    if type_value == "digest":
+        return _render_digest_preamble(frontmatter)
+    if type_value == "live-concept":
+        return _render_live_concept_preamble(
+            relative_path, frontmatter, requested_pack=requested_pack,
+        )
+    if type_value == "user-profile":
+        return _render_user_profile_preamble()
+    if relative_path.startswith("40-Resources/Generated/"):
+        return _render_generated_preamble(relative_path, frontmatter)
+    return ""
+
+
+def _render_digest_preamble(frontmatter: dict[str, object]) -> str:
+    generated = escape(str(frontmatter.get("generated_at") or ""))
+    pack = escape(str(frontmatter.get("pack") or ""))
+    return (
+        "<section class='card'>"
+        "<h2 style='margin-top:0'>About this digest</h2>"
+        "<p>An automated daily synthesis written by the OVP "
+        "<code>DIGEST</code> handler.  It reads the top-scoring "
+        "contradictions, recently-synthesised community crystals, "
+        "and open questions from <code>knowledge.db</code>, then "
+        "asks the LLM to write a ~200-word brief in your voice "
+        "(from <code>00-Polaris/USER.md</code>).</p>"
+        "<table class='kv'>"
+        f"<tr><th>Generated</th><td>{generated}</td></tr>"
+        f"<tr><th>Pack</th><td><code>{pack}</code></td></tr>"
+        "<tr><th>Pipeline</th><td>"
+        "<code>ovp-digest --enqueue-daily</code> → "
+        "<code>50-Inbox/02-Tasks/DIGEST-daily.md</code> → "
+        "<code>ovp-task --process-pending</code></td></tr>"
+        "<tr><th>Schedule</th><td>"
+        "Runs daily at 06:00 via <code>~/Library/LaunchAgents/com.ovp.digest.plist</code>"
+        "</td></tr>"
+        "</table>"
+        "<p class='muted tiny'>Wikilinks at the bottom under "
+        "<strong>Sources</strong> jump straight to the underlying "
+        "crystals and evergreens.</p>"
+        "</section>"
+    )
+
+
+def _render_live_concept_preamble(
+    relative_path: str,
+    frontmatter: dict[str, object],
+    *,
+    requested_pack: str = "",
+) -> str:
+    live = frontmatter.get("live") if isinstance(frontmatter.get("live"), dict) else {}
+    objective = str(live.get("objective") or "").strip()
+    active = bool(live.get("active", True))
+    scope = live.get("scope_evergreens") or []
+    if not isinstance(scope, list):
+        scope = []
+    scope_slugs = [str(s) for s in scope if s]
+    triggers = live.get("triggers") if isinstance(live.get("triggers"), dict) else {}
+    last_run_at = str(live.get("lastRunAt") or "").strip()
+    last_summary = str(live.get("lastRunSummary") or "").strip()
+    last_error = str(live.get("lastRunError") or "").strip()
+
+    objective_html = (
+        f"<p>{escape(objective)}</p>" if objective else
+        "<p class='muted'><em>(no objective declared)</em></p>"
+    )
+
+    scope_html = ""
+    if scope_slugs:
+        items = "".join(
+            f"<li><a href='{escape(_note_href(f'10-Knowledge/Evergreen/{slug}.md', requested_pack))}'>{escape(slug)}</a></li>"
+            for slug in scope_slugs
+        )
+        scope_html = (
+            "<tr><th>Scope evergreens</th>"
+            f"<td><ul class='list-tight' style='margin:0'>{items}</ul></td></tr>"
+        )
+    else:
+        scope_html = (
+            "<tr><th>Scope evergreens</th>"
+            "<td class='muted'>(none declared)</td></tr>"
+        )
+
+    trigger_items: list[str] = []
+    if isinstance(triggers.get("on_ingest_match"), dict):
+        ig = triggers["on_ingest_match"]
+        target = escape(str(ig.get("concept_similarity_to") or ""))
+        threshold = ig.get("threshold")
+        trigger_items.append(
+            f"<li><strong>on_ingest_match</strong> — when an absorbed "
+            f"source matches <code>{target}</code> (cosine ≥ {threshold})</li>"
+        )
+    if triggers.get("on_contradiction_against_view"):
+        trigger_items.append(
+            "<li><strong>on_contradiction_against_view</strong> — when "
+            "the truth store records a contradiction against any "
+            "scope evergreen</li>"
+        )
+    if triggers.get("weekly_resynthesis"):
+        when = escape(str(triggers["weekly_resynthesis"]))
+        trigger_items.append(
+            f"<li><strong>weekly_resynthesis</strong> — recurring at "
+            f"<code>{when}</code></li>"
+        )
+    triggers_html = (
+        "<tr><th>Triggers</th><td><ul class='list-tight' style='margin:0'>"
+        + "".join(trigger_items)
+        + "</ul></td></tr>"
+        if trigger_items else
+        "<tr><th>Triggers</th><td class='muted'>(no triggers configured)</td></tr>"
+    )
+
+    last_run_html = ""
+    if last_run_at:
+        status_pill = (
+            "<span class='pill warn'>error</span>"
+            if last_error else
+            "<span class='pill'>ok</span>"
+        )
+        summary_block = (
+            f"<div class='muted'>{escape(last_summary)}</div>"
+            if last_summary else ""
+        )
+        error_block = (
+            f"<div class='muted'>Last error: {escape(last_error)}</div>"
+            if last_error else ""
+        )
+        last_run_html = (
+            f"<tr><th>Last agent run</th><td>"
+            f"{_ts(last_run_at)} {status_pill}{summary_block}{error_block}"
+            "</td></tr>"
+        )
+    else:
+        last_run_html = (
+            "<tr><th>Last agent run</th>"
+            "<td class='muted'>(never — run "
+            "<code>ovp-live-concept-scan --fire</code> to populate "
+            "the agent sections below)</td></tr>"
+        )
+
+    active_pill = (
+        "<span class='pill'>active</span>" if active
+        else "<span class='pill muted'>inactive</span>"
+    )
+
+    return (
+        "<section class='card'>"
+        "<h2 style='margin-top:0'>About this Live Concept "
+        f"{active_pill}</h2>"
+        "<p>A user-declared <strong>Interpretation surface</strong> — "
+        "an evolving view on one topic that the agent maintains "
+        "from scope evergreens.  You own <code>## My take</code>; "
+        "the agent owns <code>## Current synthesis</code>, "
+        "<code>## Recent evidence</code>, and "
+        "<code>## Tensions</code>.</p>"
+        f"{objective_html}"
+        "<table class='kv'>"
+        f"<tr><th>File</th><td><code>{escape(relative_path)}</code></td></tr>"
+        f"{scope_html}"
+        f"{triggers_html}"
+        f"{last_run_html}"
+        "<tr><th>Refresh</th><td>"
+        "<code>ovp-live-concept-scan --fire</code> "
+        "(or wait for the next trigger to fire)"
+        "</td></tr>"
+        "</table>"
+        "<p class='muted tiny'>Edit <code>## My take</code> directly "
+        "in Obsidian.  Add or remove scope evergreens by editing "
+        "<code>live.scope_evergreens</code> in the frontmatter.</p>"
+        "</section>"
+    )
+
+
+def _render_user_profile_preamble() -> str:
+    return (
+        "<section class='card'>"
+        "<h2 style='margin-top:0'>About this profile</h2>"
+        "<p>Your operator profile.  Read by "
+        "<code>context_loader.load_llm_context</code> and prepended "
+        "as a system-prompt prefix to every LLM call site that "
+        "needs user-aware behaviour (extractor, crystal synthesizers, "
+        "task handlers, digest).</p>"
+        "<p class='muted tiny'>Edit freely.  Changes take effect on "
+        "the next LLM call — no restart needed.</p>"
+        "</section>"
+    )
+
+
+def _render_generated_preamble(
+    relative_path: str, frontmatter: dict[str, object]
+) -> str:
+    return (
+        "<section class='card'>"
+        "<h2 style='margin-top:0'>About this generated artifact</h2>"
+        "<p>Produced by a QUEUE task handler "
+        "(<code>RESEARCH</code> / <code>SYNTHESIZE</code> / "
+        "<code>CONTRADICT</code>) from a "
+        "<code>50-Inbox/02-Tasks/</code> file.</p>"
+        "<p class='muted tiny'>To regenerate, drop a new "
+        "<code>&lt;PREFIX&gt;-&lt;slug&gt;.md</code> into "
+        "<code>50-Inbox/02-Tasks/</code> and run "
+        "<code>ovp-task --process-pending</code>.</p>"
+        "</section>"
+    )
+
+
 def _render_note_page(
     vault_dir: Path, relative_path: str, markdown: str, payload: dict | None = None
 ) -> str:
@@ -1415,6 +1719,33 @@ def _render_note_page(
     frontmatter_html, note_html = _render_markdown_note(
         vault_dir, markdown, requested_pack=requested_pack
     )
+
+    # Thin shell for digest / live-concept / user-profile / anything
+    # under 40-Resources/Generated/.  Header → preamble → body →
+    # frontmatter (collapsed).  No source-chain / production-chain /
+    # inbound-capture cards because those concepts don't apply to
+    # agent-produced surfaces.  The preamble card explains *where*
+    # the file came from and *what to do with it*, which the user
+    # complained was missing on digest + Live Concept pages.
+    if _is_thin_note(relative_path, markdown):
+        preamble_html = _render_thin_note_preamble(
+            relative_path, markdown, requested_pack=requested_pack,
+        )
+        return _layout(
+            f"Markdown Note: {relative_path}",
+            (
+                "<h1>Markdown Note</h1>"
+                f"<p class='muted'>{escape(relative_path)}</p>"
+                + preamble_html
+                + f"<section class='card'>{note_html}</section>"
+                + "<details class='page-help'>"
+                + "<summary>Frontmatter</summary>"
+                + f"{frontmatter_html}"
+                + "</details>"
+            ),
+            requested_pack=requested_pack,
+        )
+
     source_note = None
     production_chain = None
     compiled_sections: list[dict[str, object]] = []
@@ -1469,20 +1800,29 @@ def _render_note_page(
         requested_pack=requested_pack,
     )
     operator_rail_card = _render_operator_rail(payload or {})
+    # Body-first ordering: the actual note content (``note_html``)
+    # leads the page so readers don't scroll past empty scaffold to
+    # find what they came for.  Scaffolding cards (lineage,
+    # provenance, production-chain, compiled-section probes) sit
+    # after the body.  Frontmatter is collapsed into a <details>
+    # below the body — it's metadata, not lede.
     return _layout(
         f"Markdown Note: {relative_path}",
         (
             "<h1>Markdown Note</h1>"
             f"<p class='muted'>{escape(relative_path)}</p>"
+            + (f"<nav class='subnav'>{section_nav}</nav>" if section_nav else "")
+            + f"<section class='card'>{note_html}</section>"
             + _render_compiled_sections(lead_sections)
             + operator_rail_card
-            + (f"<nav class='subnav'>{section_nav}</nav>" if section_nav else "")
-            + f"{frontmatter_html}"
             + f"{lineage_html}"
             + f"{provenance_html}"
             + f"{production_chain_html}"
             + f"{_render_compiled_sections(remaining_sections)}"
-            + f"<section class='card'>{note_html}</section>"
+            + "<details class='page-help'>"
+            + "<summary>Frontmatter</summary>"
+            + f"{frontmatter_html}"
+            + "</details>"
         ),
         requested_pack=requested_pack,
     )

--- a/src/ovp_pipeline/commands/_ui_renderers.py
+++ b/src/ovp_pipeline/commands/_ui_renderers.py
@@ -1743,10 +1743,7 @@ def _render_note_page(
                 f"<p class='muted'>{escape(relative_path)}</p>"
                 + preamble_html
                 + f"<section class='card'>{note_html}</section>"
-                + "<details class='page-help'>"
-                + "<summary>Frontmatter</summary>"
-                + f"{frontmatter_html}"
-                + "</details>"
+                + _render_frontmatter_details(frontmatter_html)
             ),
             requested_pack=requested_pack,
         )
@@ -1824,12 +1821,24 @@ def _render_note_page(
             + f"{provenance_html}"
             + f"{production_chain_html}"
             + f"{_render_compiled_sections(remaining_sections)}"
-            + "<details class='page-help'>"
-            + "<summary>Frontmatter</summary>"
-            + f"{frontmatter_html}"
-            + "</details>"
+            + _render_frontmatter_details(frontmatter_html)
         ),
         requested_pack=requested_pack,
+    )
+
+
+def _render_frontmatter_details(frontmatter_html: str) -> str:
+    """Wrap rendered frontmatter HTML in a collapsed ``<details>``
+    disclosure, or return ``""`` when the file has no frontmatter
+    so the page doesn't show an empty expandable block (rev-bot
+    208 round-2 #4)."""
+    if not frontmatter_html or not frontmatter_html.strip():
+        return ""
+    return (
+        "<details class='page-help'>"
+        "<summary>Frontmatter</summary>"
+        f"{frontmatter_html}"
+        "</details>"
     )
 
 

--- a/src/ovp_pipeline/commands/_ui_renderers.py
+++ b/src/ovp_pipeline/commands/_ui_renderers.py
@@ -1435,6 +1435,36 @@ _THIN_NOTE_PATH_PREFIXES: tuple[str, ...] = (
 )
 
 
+def _resolve_effective_type(frontmatter: dict[str, object]) -> str:
+    """Pick the surviving "thin shell" type from a note's
+    frontmatter.  Returns the canonical type string when it matches
+    one of ``_THIN_NOTE_TYPES`` (or it can be inferred structurally
+    from a ``live:`` block), otherwise the raw ``type:`` value.
+
+    Precedence (highest first):
+
+    1. ``type:`` itself — matches a thin type as-is.
+    2. ``original_note_type:`` — protects against a stale
+       ``note_type_normalize`` run that rewrote the type to
+       ``article`` before the M19/M20 canonical-set fix (PR #207).
+    3. Presence of a ``live:`` block — structural marker for the
+       Live Concept primitive.
+
+    Single source of truth for ``_is_thin_note`` *and*
+    ``_render_thin_note_preamble``; see rev-bot PR #208 comment
+    208.2.
+    """
+    type_value = str(frontmatter.get("type") or "").strip().lower()
+    if type_value in _THIN_NOTE_TYPES:
+        return type_value
+    original_type = str(frontmatter.get("original_note_type") or "").strip().lower()
+    if original_type in _THIN_NOTE_TYPES:
+        return original_type
+    if isinstance(frontmatter.get("live"), dict):
+        return "live-concept"
+    return type_value
+
+
 def _is_thin_note(relative_path: str, markdown: str) -> bool:
     """Decide whether ``/note?path=<relative_path>`` should render
     the thin shell (header + body) instead of the full evergreen
@@ -1442,21 +1472,11 @@ def _is_thin_note(relative_path: str, markdown: str) -> bool:
 
     Detection signals (any one is sufficient):
 
-    1. The file lives under a path prefix listed in
-       ``_THIN_NOTE_PATH_PREFIXES``.
-    2. The frontmatter ``type:`` value sits in ``_THIN_NOTE_TYPES``.
-    3. The frontmatter ``original_note_type:`` value sits in
-       ``_THIN_NOTE_TYPES`` — protects against a stale
-       ``note_type_normalize`` run that rewrote the type to
-       ``article`` before the M19/M20 canonical-set fix landed
-       (see PR #207).
-    4. A ``live:`` block is present in the frontmatter — that's the
-       structural marker the Live Concept primitive uses, so the
-       page renders correctly even if the ``type:`` key was lost.
+    * file path under ``_THIN_NOTE_PATH_PREFIXES``
+    * ``_resolve_effective_type`` lands on a thin type
 
-    Files outside all four keep the existing full-scaffold
-    behaviour so evergreens, deep-dives, and atlas pages render
-    unchanged.
+    Files outside both keep the existing full-scaffold behaviour
+    so evergreens, deep-dives, and atlas pages render unchanged.
     """
     normalised = (relative_path or "").replace("\\", "/")
     if any(normalised.startswith(prefix) for prefix in _THIN_NOTE_PATH_PREFIXES):
@@ -1465,15 +1485,7 @@ def _is_thin_note(relative_path: str, markdown: str) -> bool:
         frontmatter, _ = _parse_frontmatter(markdown)
     except Exception:
         return False
-    type_value = str(frontmatter.get("type") or "").strip().lower()
-    if type_value in _THIN_NOTE_TYPES:
-        return True
-    original_type = str(frontmatter.get("original_note_type") or "").strip().lower()
-    if original_type in _THIN_NOTE_TYPES:
-        return True
-    if isinstance(frontmatter.get("live"), dict):
-        return True
-    return False
+    return _resolve_effective_type(frontmatter) in _THIN_NOTE_TYPES
 
 
 def _render_thin_note_preamble(
@@ -1494,18 +1506,7 @@ def _render_thin_note_preamble(
     except Exception:
         frontmatter = {}
 
-    # Use the type that survived normalisation, or fall back to
-    # the recorded original_note_type, or detect structurally from
-    # a ``live:`` block.  This is the same precedence
-    # ``_is_thin_note`` uses to decide whether to enter the thin
-    # shell at all.
-    type_value = str(frontmatter.get("type") or "").strip().lower()
-    if type_value not in _THIN_NOTE_TYPES:
-        original_type = str(frontmatter.get("original_note_type") or "").strip().lower()
-        if original_type in _THIN_NOTE_TYPES:
-            type_value = original_type
-        elif isinstance(frontmatter.get("live"), dict):
-            type_value = "live-concept"
+    type_value = _resolve_effective_type(frontmatter)
 
     if type_value == "digest":
         return _render_digest_preamble(frontmatter)
@@ -1593,7 +1594,11 @@ def _render_live_concept_preamble(
     if isinstance(triggers.get("on_ingest_match"), dict):
         ig = triggers["on_ingest_match"]
         target = escape(str(ig.get("concept_similarity_to") or ""))
-        threshold = ig.get("threshold")
+        # ``threshold`` is operator-supplied via YAML frontmatter and
+        # may not be numeric (Codex P2: a crafted live-concept could
+        # inject markup here otherwise — coerce to string + escape
+        # like the surrounding fields).
+        threshold = escape(str(ig.get("threshold")))
         trigger_items.append(
             f"<li><strong>on_ingest_match</strong> — when an absorbed "
             f"source matches <code>{target}</code> (cosine ≥ {threshold})</li>"

--- a/src/ovp_pipeline/commands/digest_handler.py
+++ b/src/ovp_pipeline/commands/digest_handler.py
@@ -306,20 +306,12 @@ def _build_sources_section(inputs: dict[str, Any]) -> str:
         evergreen_slugs.extend(item.get("source_object_ids", []))
 
     # Dedupe while preserving order so the reader sees crystals
-    # first in the order they appeared in the brief.
-    seen: set[str] = set()
-    deduped_crystals: list[str] = []
-    for link in crystal_links:
-        if link not in seen:
-            seen.add(link)
-            deduped_crystals.append(link)
-
-    seen_slugs: set[str] = set()
-    deduped_slugs: list[str] = []
-    for slug in evergreen_slugs:
-        if slug and slug not in seen_slugs:
-            seen_slugs.add(slug)
-            deduped_slugs.append(slug)
+    # first in the order they appeared in the brief.  ``dict.fromkeys``
+    # is the idiomatic Python 3.7+ ordered-set (rev-bot 208.3).
+    deduped_crystals = list(dict.fromkeys(crystal_links))
+    deduped_slugs = [
+        slug for slug in dict.fromkeys(evergreen_slugs) if slug
+    ]
 
     if not deduped_crystals and not deduped_slugs:
         return ""
@@ -352,11 +344,7 @@ def handle_digest(ctx: TaskContext) -> TaskResult:
     inputs = _collect_digest_inputs(ctx.vault_dir, ctx.pack)
     user_focus = load_user_profile(ctx.vault_dir)
     user_prompt = _build_digest_user_prompt(inputs, user_focus)
-    prefix = ctx.llm_prefix()
-    sys_prompt = (
-        prefix + "\n" + _DIGEST_SYSTEM_PROMPT
-        if prefix else _DIGEST_SYSTEM_PROMPT
-    )
+    sys_prompt = ctx.compose_system_prompt(_DIGEST_SYSTEM_PROMPT)
 
     # ``type: digest`` frontmatter tells the /note renderer to use
     # the thin shell (no evergreen scaffolding) — see

--- a/src/ovp_pipeline/commands/digest_handler.py
+++ b/src/ovp_pipeline/commands/digest_handler.py
@@ -84,7 +84,12 @@ def _collect_digest_inputs(vault_dir: Path, pack: str) -> dict[str, Any]:
         # Top-scoring tensions (contradictions).
         tensions = conn.execute(
             """
-            SELECT cs.crystal_id, cs.score, cc.subject_key, cc.body_md
+            SELECT
+                cs.crystal_id,
+                cs.score,
+                cc.subject_key,
+                cc.body_md,
+                cc.source_object_ids_json
               FROM crystal_scores cs
               JOIN contradiction_crystals cc
                 ON cc.pack = cs.pack
@@ -101,7 +106,12 @@ def _collect_digest_inputs(vault_dir: Path, pack: str) -> dict[str, Any]:
         # Recently synthesized community crystals.
         themes = conn.execute(
             """
-            SELECT cc.cluster_id, cc.synthesized_at, gc.label, cc.body_md
+            SELECT
+                cc.cluster_id,
+                cc.synthesized_at,
+                gc.label,
+                cc.body_md,
+                cc.source_evergreen_slugs_json
               FROM community_crystals cc
               JOIN graph_clusters gc
                 ON gc.pack = cc.pack AND gc.cluster_id = cc.cluster_id
@@ -119,7 +129,12 @@ def _collect_digest_inputs(vault_dir: Path, pack: str) -> dict[str, Any]:
         tension_ids = {row[0] for row in tensions}
         open_qs_all = conn.execute(
             """
-            SELECT contradiction_id, subject_key, body_md, synthesized_at
+            SELECT
+                contradiction_id,
+                subject_key,
+                body_md,
+                synthesized_at,
+                source_object_ids_json
               FROM contradiction_crystals
              WHERE pack = ?
                AND superseded_by_synthesized_at = ''
@@ -137,6 +152,13 @@ def _collect_digest_inputs(vault_dir: Path, pack: str) -> dict[str, Any]:
         cleaned = " ".join((text or "").split())
         return cleaned[:max_chars]
 
+    def _decode_slugs(blob: str) -> list[str]:
+        try:
+            data = json.loads(blob or "[]")
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return []
+        return [str(item) for item in data if item]
+
     return {
         "tensions": [
             {
@@ -144,6 +166,7 @@ def _collect_digest_inputs(vault_dir: Path, pack: str) -> dict[str, Any]:
                 "score": row[1],
                 "subject": row[2],
                 "teaser": _teaser(row[3]),
+                "source_object_ids": _decode_slugs(row[4]),
             }
             for row in tensions
         ],
@@ -153,6 +176,7 @@ def _collect_digest_inputs(vault_dir: Path, pack: str) -> dict[str, Any]:
                 "synthesized_at": row[1],
                 "label": row[2],
                 "teaser": _teaser(row[3]),
+                "source_evergreen_slugs": _decode_slugs(row[4]),
             }
             for row in themes
         ],
@@ -161,6 +185,7 @@ def _collect_digest_inputs(vault_dir: Path, pack: str) -> dict[str, Any]:
                 "id": row[0],
                 "subject": row[1],
                 "teaser": _teaser(row[2]),
+                "source_object_ids": _decode_slugs(row[4]),
             }
             for row in open_questions
         ],
@@ -239,6 +264,89 @@ def _today_utc_date() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%d")
 
 
+def _build_sources_section(inputs: dict[str, Any]) -> str:
+    """Render a ``## Sources`` block linking back to every crystal +
+    evergreen the digest was synthesised from.
+
+    Obsidian-flavoured wikilinks so clicking inside Obsidian jumps
+    straight to the source.  In the ovp-ui ``/note`` renderer the
+    same wikilinks resolve via ``_replace_wikilinks_with_markdown_links``,
+    so the same markdown works in both surfaces.
+
+    Empty when no inputs carry source ids (e.g. on the empty-vault
+    stub digest), so the digest doesn't render an empty heading.
+    """
+    from ..synthesis._shared import crystal_safe_id
+
+    crystal_links: list[str] = []
+    evergreen_slugs: list[str] = []
+
+    for item in inputs.get("tensions", []):
+        safe = crystal_safe_id("contradiction", str(item.get("id") or ""))
+        if safe:
+            crystal_links.append(
+                f"[[{safe}|⚠ {item.get('subject', safe)}]]"
+            )
+        evergreen_slugs.extend(item.get("source_object_ids", []))
+
+    for item in inputs.get("themes", []):
+        safe = crystal_safe_id("community", str(item.get("cluster_id") or ""))
+        if safe:
+            crystal_links.append(
+                f"[[{safe}|◆ {item.get('label', safe)}]]"
+            )
+        evergreen_slugs.extend(item.get("source_evergreen_slugs", []))
+
+    for item in inputs.get("open_questions", []):
+        safe = crystal_safe_id("contradiction", str(item.get("id") or ""))
+        if safe:
+            crystal_links.append(
+                f"[[{safe}|? {item.get('subject', safe)}]]"
+            )
+        evergreen_slugs.extend(item.get("source_object_ids", []))
+
+    # Dedupe while preserving order so the reader sees crystals
+    # first in the order they appeared in the brief.
+    seen: set[str] = set()
+    deduped_crystals: list[str] = []
+    for link in crystal_links:
+        if link not in seen:
+            seen.add(link)
+            deduped_crystals.append(link)
+
+    seen_slugs: set[str] = set()
+    deduped_slugs: list[str] = []
+    for slug in evergreen_slugs:
+        if slug and slug not in seen_slugs:
+            seen_slugs.add(slug)
+            deduped_slugs.append(slug)
+
+    if not deduped_crystals and not deduped_slugs:
+        return ""
+
+    parts: list[str] = ["\n## Sources\n"]
+    if deduped_crystals:
+        parts.append("**Crystals**")
+        for link in deduped_crystals:
+            parts.append(f"- {link}")
+        parts.append("")
+    if deduped_slugs:
+        parts.append("**Underlying evergreens**")
+        # Cap at a generous N so a digest grounded in 30 evergreens
+        # doesn't bury the brief.  Reader can always open the
+        # crystal to see the full member list.
+        EVERGREEN_CAP = 24
+        shown = deduped_slugs[:EVERGREEN_CAP]
+        for slug in shown:
+            parts.append(f"- [[{slug}]]")
+        if len(deduped_slugs) > EVERGREEN_CAP:
+            parts.append(
+                f"- *…and {len(deduped_slugs) - EVERGREEN_CAP} more.*"
+            )
+        parts.append("")
+    return "\n".join(parts) + "\n"
+
+
 def handle_digest(ctx: TaskContext) -> TaskResult:
     """Aggregate vault signals + compose the daily digest."""
     inputs = _collect_digest_inputs(ctx.vault_dir, ctx.pack)
@@ -250,12 +358,25 @@ def handle_digest(ctx: TaskContext) -> TaskResult:
         if prefix else _DIGEST_SYSTEM_PROMPT
     )
 
+    # ``type: digest`` frontmatter tells the /note renderer to use
+    # the thin shell (no evergreen scaffolding) — see
+    # ``_THIN_NOTE_TYPES`` in ``commands/_ui_renderers.py``.
+    frontmatter = (
+        "---\n"
+        "type: digest\n"
+        "schema_version: 1\n"
+        f"generated_at: {_today_utc_date()}\n"
+        f"pack: {ctx.pack}\n"
+        "---\n\n"
+    )
+
     # Empty vault: skip the LLM call entirely, write a stub digest
     # that explains there's nothing to surface.  Saves both the
     # token spend and a guaranteed-bland generic response.
     if not any((inputs["tensions"], inputs["themes"], inputs["open_questions"])):
         body_md = (
-            f"# Digest — {_today_utc_date()}\n\n"
+            frontmatter
+            + f"# Digest — {_today_utc_date()}\n\n"
             "Nothing new to surface today.  No contradictions, "
             "themes, or open questions in this pack.\n\n"
             "Either the vault is still warming up (run "
@@ -269,19 +390,21 @@ def handle_digest(ctx: TaskContext) -> TaskResult:
         )
         composed = (composed or "").strip()
         body_md = (
-            f"# Digest — {_today_utc_date()}\n\n{composed}\n"
+            frontmatter
+            + f"# Digest — {_today_utc_date()}\n\n{composed}\n"
         )
 
+    sources_md = _build_sources_section(inputs)
     footer = (
         "\n---\n\n"
-        f"**Generated by DIGEST handler on {_today_utc_date()} "
+        f"*Generated by DIGEST handler on {_today_utc_date()} "
         f"from `50-Inbox/02-Tasks/{ctx.task_path.name}`. "
         f"Tensions: {len(inputs['tensions'])}, "
         f"Themes: {len(inputs['themes'])}, "
-        f"Open questions: {len(inputs['open_questions'])}.**\n"
+        f"Open questions: {len(inputs['open_questions'])}.*\n"
     )
     return TaskResult(
-        body_md=body_md + footer,
+        body_md=body_md + sources_md + footer,
         subdir=DIGESTS_SUBDIR,
         metadata={
             "tensions": len(inputs["tensions"]),

--- a/src/ovp_pipeline/commands/digest_handler.py
+++ b/src/ovp_pipeline/commands/digest_handler.py
@@ -157,6 +157,12 @@ def _collect_digest_inputs(vault_dir: Path, pack: str) -> dict[str, Any]:
             data = json.loads(blob or "[]")
         except (TypeError, ValueError, json.JSONDecodeError):
             return []
+        # TEXT columns have no structural constraint, so a row with
+        # ``null`` or an object would raise TypeError on the list
+        # comprehension below and abort digest generation
+        # (rev-bot 208 round-2 #5).
+        if not isinstance(data, list):
+            return []
         return [str(item) for item in data if item]
 
     return {
@@ -278,31 +284,47 @@ def _build_sources_section(inputs: dict[str, Any]) -> str:
     """
     from ..synthesis._shared import crystal_safe_id
 
+    def _safe_wikilink_text(value: Any) -> str:
+        """Strip wikilink delimiters from a label/slug.
+
+        ``]]`` would close the link early; ``|`` would split it into
+        ``[[target|label|extra]]`` and confuse Obsidian's parser;
+        newlines would break out of the surrounding list item.  Pre-
+        fix, ``subject`` / ``label`` values flowed in raw from
+        crystal frontmatter, so a stray ``]]`` in a subject key
+        broke every digest below that link (rev-bot 208 round-2 #6).
+        """
+        return (
+            str(value or "")
+            .replace("[", " ")
+            .replace("]", " ")
+            .replace("|", " ")
+            .replace("\n", " ")
+            .strip()
+        )
+
     crystal_links: list[str] = []
     evergreen_slugs: list[str] = []
 
     for item in inputs.get("tensions", []):
         safe = crystal_safe_id("contradiction", str(item.get("id") or ""))
         if safe:
-            crystal_links.append(
-                f"[[{safe}|⚠ {item.get('subject', safe)}]]"
-            )
+            label = _safe_wikilink_text(item.get("subject", safe)) or safe
+            crystal_links.append(f"[[{safe}|⚠ {label}]]")
         evergreen_slugs.extend(item.get("source_object_ids", []))
 
     for item in inputs.get("themes", []):
         safe = crystal_safe_id("community", str(item.get("cluster_id") or ""))
         if safe:
-            crystal_links.append(
-                f"[[{safe}|◆ {item.get('label', safe)}]]"
-            )
+            label = _safe_wikilink_text(item.get("label", safe)) or safe
+            crystal_links.append(f"[[{safe}|◆ {label}]]")
         evergreen_slugs.extend(item.get("source_evergreen_slugs", []))
 
     for item in inputs.get("open_questions", []):
         safe = crystal_safe_id("contradiction", str(item.get("id") or ""))
         if safe:
-            crystal_links.append(
-                f"[[{safe}|? {item.get('subject', safe)}]]"
-            )
+            label = _safe_wikilink_text(item.get("subject", safe)) or safe
+            crystal_links.append(f"[[{safe}|? {label}]]")
         evergreen_slugs.extend(item.get("source_object_ids", []))
 
     # Dedupe while preserving order so the reader sees crystals
@@ -330,7 +352,9 @@ def _build_sources_section(inputs: dict[str, Any]) -> str:
         EVERGREEN_CAP = 24
         shown = deduped_slugs[:EVERGREEN_CAP]
         for slug in shown:
-            parts.append(f"- [[{slug}]]")
+            safe_slug = _safe_wikilink_text(slug)
+            if safe_slug:
+                parts.append(f"- [[{safe_slug}]]")
         if len(deduped_slugs) > EVERGREEN_CAP:
             parts.append(
                 f"- *…and {len(deduped_slugs) - EVERGREEN_CAP} more.*"

--- a/src/ovp_pipeline/commands/reader_home.py
+++ b/src/ovp_pipeline/commands/reader_home.py
@@ -78,11 +78,15 @@ def _render_reader_home(payload: dict) -> str:
         if atlas_available
         else ""
     )
+    # Knowledge Map renders flush with the rest of the home sections:
+    # a naked ``<h2>`` followed by content prose.  No outer card so
+    # the visual rhythm matches Top Topics / Recent Topics — those
+    # also lead with an ``<h2>`` and list .card.flush items below.
     map_card = (
-        "<section class='card'><h2>Knowledge Map</h2>"
+        "<h2>Knowledge Map</h2>"
         "<p class='muted'>See how ideas connect — entities, concepts, "
         "references woven into one graph.</p>"
-        f"<p><a href='{escape(map_href)}'>Open the Map →</a></p></section>"
+        f"<p><a href='{escape(map_href)}'>Open the Map →</a></p>"
         if map_supported
         else ""
     )
@@ -92,9 +96,12 @@ def _render_reader_home(payload: dict) -> str:
         else ""
     )
 
-    # M20 / BL-077: surface the latest daily digest as a banner card
-    # above the Top Topics list.  payload["digest"] is populated when
+    # M20 / BL-077: surface the latest daily digest at the top of
+    # the home page.  payload["digest"] is populated when
     # 40-Resources/Generated/digests/ contains at least one file.
+    # Renders flush — naked <h2> + content prose — so the rhythm
+    # matches every other section on the home (Top Topics, Map,
+    # Recent Topics).  No outer card wrapping.
     digest_card = ""
     digest_info = payload.get("digest") or {}
     if digest_info.get("href"):
@@ -102,18 +109,16 @@ def _render_reader_home(payload: dict) -> str:
         digest_href = escape(str(digest_info["href"]))
         digest_teaser = escape(str(digest_info.get("teaser") or "").strip())
         teaser_html = (
-            f"<p class='muted' style='margin:0.35rem 0 0.6rem'>{digest_teaser}</p>"
+            f"<p class='muted'>{digest_teaser}</p>"
             if digest_teaser
             else ""
         )
         digest_card = (
-            "<section class='card'>"
-            "<h2 style='margin-top:0'>Today's digest"
+            "<h2>Today's digest"
             f"<span class='muted tiny mono' style='margin-left:0.6rem'>{digest_date}</span>"
             "</h2>"
             f"{teaser_html}"
             f"<p><a href='{digest_href}'>Open digest →</a></p>"
-            "</section>"
         )
 
     body = "".join([

--- a/src/ovp_pipeline/commands/task_dispatch.py
+++ b/src/ovp_pipeline/commands/task_dispatch.py
@@ -93,8 +93,22 @@ class TaskContext:
         self.llm_client = llm_client
 
     def llm_prefix(self) -> str:
-        """USER.md + OVP_RULES.md as a system-prompt prefix."""
+        """USER.md + OVP_RULES.md as a system-prompt prefix.
+
+        Retained for backwards-compatibility with handlers that
+        format the prefix themselves; new handlers should prefer
+        :meth:`compose_system_prompt` so the inject-prefix
+        boilerplate doesn't repeat (rev-bot 206.2).
+        """
         return load_llm_context(self.vault_dir)
+
+    def compose_system_prompt(self, handler_prompt: str) -> str:
+        """Return the handler's static prompt with USER + RULES
+        prepended.  Returns the handler prompt unchanged when the
+        vault has neither file."""
+        from ..context_loader import inject_llm_context
+
+        return inject_llm_context(self.vault_dir, handler_prompt)
 
 
 class TaskResult:
@@ -388,11 +402,7 @@ def handle_research(ctx: TaskContext) -> TaskResult:
         "Operator notes (free-form, may be empty):\n"
         f"```\n{ctx.body.strip()}\n```\n"
     )
-    prefix = ctx.llm_prefix()
-    sys_prompt = (
-        prefix + "\n" + _RESEARCH_SYSTEM_PROMPT
-        if prefix else _RESEARCH_SYSTEM_PROMPT
-    )
+    sys_prompt = ctx.compose_system_prompt(_RESEARCH_SYSTEM_PROMPT)
     body_md = ctx.llm_client.call(sys_prompt, user_prompt, max_tokens=3500)
     body_md = (body_md or "").strip() + "\n"
     footer = (
@@ -427,11 +437,7 @@ def handle_synthesize(ctx: TaskContext) -> TaskResult:
         "Operator notes (vault excerpts, questions, scope):\n"
         f"```\n{ctx.body.strip()}\n```\n"
     )
-    prefix = ctx.llm_prefix()
-    sys_prompt = (
-        prefix + "\n" + _SYNTHESIZE_SYSTEM_PROMPT
-        if prefix else _SYNTHESIZE_SYSTEM_PROMPT
-    )
+    sys_prompt = ctx.compose_system_prompt(_SYNTHESIZE_SYSTEM_PROMPT)
     body_md = ctx.llm_client.call(sys_prompt, user_prompt, max_tokens=2500)
     body_md = (body_md or "").strip() + "\n"
     footer = (
@@ -470,11 +476,7 @@ def handle_contradict(ctx: TaskContext) -> TaskResult:
         "Operator notes (claims, sources, suspected tensions):\n"
         f"```\n{ctx.body.strip()}\n```\n"
     )
-    prefix = ctx.llm_prefix()
-    sys_prompt = (
-        prefix + "\n" + _CONTRADICT_SYSTEM_PROMPT
-        if prefix else _CONTRADICT_SYSTEM_PROMPT
-    )
+    sys_prompt = ctx.compose_system_prompt(_CONTRADICT_SYSTEM_PROMPT)
     body_md = ctx.llm_client.call(sys_prompt, user_prompt, max_tokens=3000)
     body_md = (body_md or "").strip() + "\n"
     footer = (

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -569,15 +569,18 @@ def create_server(
                         pack_name=pack_name, route_path="/ops/evolution", api=True
                     ):
                         return
-                    self._write_json(
-                        build_evolution_browser_payload(
+                    # Serialised with the prewarm thread — first
+                    # caller pays the ~4-min cost, the rest hit the
+                    # in-process cache inside ``_all_evolution_candidates``.
+                    with _EVOLUTION_PREWARM_LOCK:
+                        api_payload = build_evolution_browser_payload(
                             resolved_vault,
                             pack_name=pack_name,
                             query=q,
                             status=status,
                             link_type=link_type,
                         )
-                    )
+                    self._write_json(api_payload)
                     return
                 if path == "/ops/evolution":
                     q = query.get("q", [""])[0]
@@ -588,13 +591,14 @@ def create_server(
                         pack_name=pack_name, route_path="/ops/evolution", api=False
                     ):
                         return
-                    payload = build_evolution_browser_payload(
-                        resolved_vault,
-                        pack_name=pack_name,
-                        query=q,
-                        status=status,
-                        link_type=link_type,
-                    )
+                    with _EVOLUTION_PREWARM_LOCK:
+                        payload = build_evolution_browser_payload(
+                            resolved_vault,
+                            pack_name=pack_name,
+                            query=q,
+                            status=status,
+                            link_type=link_type,
+                        )
                     self._write_html(_render_evolution_browser_page(payload))
                     return
                 if path == "/api/object":
@@ -1853,23 +1857,35 @@ def _spawn_action_worker_process(vault_dir: Path | str, *, interval_seconds: flo
     )
 
 
+# Serialises any caller of ``build_evolution_browser_payload`` across
+# the background prewarm thread and concurrent request threads.  The
+# first thread to enter does the expensive computation (populating the
+# in-process cache inside ``_all_evolution_candidates``).  Subsequent
+# threads wait on the lock, then their own ``build_*`` call returns
+# from cache in ~milliseconds.  Avoids the race the PR #208 review
+# flagged where two ~4-minute computations could run in parallel.
+_EVOLUTION_PREWARM_LOCK = threading.Lock()
+
+
 def _prewarm_ui_caches(vault_dir: Path | str) -> None:
     """Warm the evolution-browser payload cache.
 
     On the live operator vault this single call costs ~4 minutes
     (``_compute_evolution_candidates`` reads every open-contradiction
-    claim's source markdown to extract dates, in an N×M nested loop).
+    claim's source markdown to extract dates, in an N*M nested loop).
     Running it synchronously inside ``main()`` blocks port-binding
     and makes every ``ovp-ui`` restart feel broken.
 
-    The function itself stays callable so the background thread (or
-    a future on-demand warmer) can invoke it the same way.
+    The function itself stays callable so the background thread or
+    a request handler can invoke it the same way — both go through
+    ``_EVOLUTION_PREWARM_LOCK`` and dedupe to a single computation.
     """
-    try:
-        build_evolution_browser_payload(vault_dir, status="all")
-    except Exception as exc:
-        print(f"ui server cache pre-warming failed: {exc}", file=sys.stderr)
-        return
+    with _EVOLUTION_PREWARM_LOCK:
+        try:
+            build_evolution_browser_payload(vault_dir, status="all")
+        except Exception as exc:
+            print(f"ui server cache pre-warming failed: {exc}", file=sys.stderr)
+            return
 
 
 def _start_ui_prewarm(vault_dir: Path | str) -> None:
@@ -1877,9 +1893,11 @@ def _start_ui_prewarm(vault_dir: Path | str) -> None:
 
     The HTTP server can start accepting requests immediately.  The
     first request to ``/ops/evolution`` may wait briefly if the
-    thread hasn't finished yet — but every other page is free.
-    Crash-tolerant: prewarm failures are logged inside
-    ``_prewarm_ui_caches`` and don't bring the server down.
+    background thread hasn't finished yet (handled via the shared
+    ``_EVOLUTION_PREWARM_LOCK`` so two computations never run in
+    parallel).  Every other page is free.  Crash-tolerant: prewarm
+    failures are logged inside ``_prewarm_ui_caches`` and don't bring
+    the server down.
     """
     thread = threading.Thread(
         target=_prewarm_ui_caches,

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -569,17 +569,19 @@ def create_server(
                         pack_name=pack_name, route_path="/ops/evolution", api=True
                     ):
                         return
-                    # Serialised with the prewarm thread — first
-                    # caller pays the ~4-min cost, the rest hit the
-                    # in-process cache inside ``_all_evolution_candidates``.
-                    with _EVOLUTION_PREWARM_LOCK:
-                        api_payload = build_evolution_browser_payload(
-                            resolved_vault,
-                            pack_name=pack_name,
-                            query=q,
-                            status=status,
-                            link_type=link_type,
-                        )
+                    # Cache miss/hit serialisation is handled inside
+                    # ``_all_evolution_candidates`` (double-checked
+                    # locking around ``_EVOLUTION_CANDIDATE_CACHE``),
+                    # so request handlers no longer need to hold a
+                    # handler-level lock and cache hits stay fully
+                    # concurrent.
+                    api_payload = build_evolution_browser_payload(
+                        resolved_vault,
+                        pack_name=pack_name,
+                        query=q,
+                        status=status,
+                        link_type=link_type,
+                    )
                     self._write_json(api_payload)
                     return
                 if path == "/ops/evolution":
@@ -591,14 +593,13 @@ def create_server(
                         pack_name=pack_name, route_path="/ops/evolution", api=False
                     ):
                         return
-                    with _EVOLUTION_PREWARM_LOCK:
-                        payload = build_evolution_browser_payload(
-                            resolved_vault,
-                            pack_name=pack_name,
-                            query=q,
-                            status=status,
-                            link_type=link_type,
-                        )
+                    payload = build_evolution_browser_payload(
+                        resolved_vault,
+                        pack_name=pack_name,
+                        query=q,
+                        status=status,
+                        link_type=link_type,
+                    )
                     self._write_html(_render_evolution_browser_page(payload))
                     return
                 if path == "/api/object":
@@ -1857,16 +1858,6 @@ def _spawn_action_worker_process(vault_dir: Path | str, *, interval_seconds: flo
     )
 
 
-# Serialises any caller of ``build_evolution_browser_payload`` across
-# the background prewarm thread and concurrent request threads.  The
-# first thread to enter does the expensive computation (populating the
-# in-process cache inside ``_all_evolution_candidates``).  Subsequent
-# threads wait on the lock, then their own ``build_*`` call returns
-# from cache in ~milliseconds.  Avoids the race the PR #208 review
-# flagged where two ~4-minute computations could run in parallel.
-_EVOLUTION_PREWARM_LOCK = threading.Lock()
-
-
 def _prewarm_ui_caches(vault_dir: Path | str) -> None:
     """Warm the evolution-browser payload cache.
 
@@ -1876,16 +1867,16 @@ def _prewarm_ui_caches(vault_dir: Path | str) -> None:
     Running it synchronously inside ``main()`` blocks port-binding
     and makes every ``ovp-ui`` restart feel broken.
 
-    The function itself stays callable so the background thread or
-    a request handler can invoke it the same way — both go through
-    ``_EVOLUTION_PREWARM_LOCK`` and dedupe to a single computation.
+    Deduplication with concurrent request handlers happens one layer
+    down inside ``_all_evolution_candidates``'s double-checked lock
+    around ``_EVOLUTION_CANDIDATE_CACHE`` — so the background prewarm
+    can race against the first ``/ops/evolution`` request safely.
     """
-    with _EVOLUTION_PREWARM_LOCK:
-        try:
-            build_evolution_browser_payload(vault_dir, status="all")
-        except Exception as exc:
-            print(f"ui server cache pre-warming failed: {exc}", file=sys.stderr)
-            return
+    try:
+        build_evolution_browser_payload(vault_dir, status="all")
+    except Exception as exc:
+        print(f"ui server cache pre-warming failed: {exc}", file=sys.stderr)
+        return
 
 
 def _start_ui_prewarm(vault_dir: Path | str) -> None:
@@ -1893,11 +1884,9 @@ def _start_ui_prewarm(vault_dir: Path | str) -> None:
 
     The HTTP server can start accepting requests immediately.  The
     first request to ``/ops/evolution`` may wait briefly if the
-    background thread hasn't finished yet (handled via the shared
-    ``_EVOLUTION_PREWARM_LOCK`` so two computations never run in
-    parallel).  Every other page is free.  Crash-tolerant: prewarm
-    failures are logged inside ``_prewarm_ui_caches`` and don't bring
-    the server down.
+    background thread hasn't finished yet — but every other page is
+    free.  Crash-tolerant: prewarm failures are logged inside
+    ``_prewarm_ui_caches`` and don't bring the server down.
     """
     thread = threading.Thread(
         target=_prewarm_ui_caches,

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -7,6 +7,7 @@ import secrets
 import sqlite3
 import subprocess
 import sys
+import threading
 import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -1853,6 +1854,17 @@ def _spawn_action_worker_process(vault_dir: Path | str, *, interval_seconds: flo
 
 
 def _prewarm_ui_caches(vault_dir: Path | str) -> None:
+    """Warm the evolution-browser payload cache.
+
+    On the live operator vault this single call costs ~4 minutes
+    (``_compute_evolution_candidates`` reads every open-contradiction
+    claim's source markdown to extract dates, in an N×M nested loop).
+    Running it synchronously inside ``main()`` blocks port-binding
+    and makes every ``ovp-ui`` restart feel broken.
+
+    The function itself stays callable so the background thread (or
+    a future on-demand warmer) can invoke it the same way.
+    """
     try:
         build_evolution_browser_payload(vault_dir, status="all")
     except Exception as exc:
@@ -1861,7 +1873,21 @@ def _prewarm_ui_caches(vault_dir: Path | str) -> None:
 
 
 def _start_ui_prewarm(vault_dir: Path | str) -> None:
-    _prewarm_ui_caches(vault_dir)
+    """Kick off the prewarm in a daemon thread.
+
+    The HTTP server can start accepting requests immediately.  The
+    first request to ``/ops/evolution`` may wait briefly if the
+    thread hasn't finished yet — but every other page is free.
+    Crash-tolerant: prewarm failures are logged inside
+    ``_prewarm_ui_caches`` and don't bring the server down.
+    """
+    thread = threading.Thread(
+        target=_prewarm_ui_caches,
+        args=(vault_dir,),
+        name="ovp-ui-prewarm",
+        daemon=True,
+    )
+    thread.start()
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/src/ovp_pipeline/context_loader.py
+++ b/src/ovp_pipeline/context_loader.py
@@ -124,6 +124,27 @@ def load_llm_context(vault_dir: Path | str) -> str:
     return "\n\n".join(parts) + "\n"
 
 
+def inject_llm_context(
+    vault_dir: Path | str, base_system_prompt: str
+) -> str:
+    """Prepend USER + RULES context to a handler's static system prompt.
+
+    Boilerplate de-dup for every LLM call site that wants user-aware
+    behaviour: the extractor, the two crystal synthesizers, the
+    digest handler, and the three task-dispatcher handlers all used
+    to inline ``prefix + "\\n" + STATIC if prefix else STATIC``.
+    See rev-bot 206.2 — this is the single helper.
+
+    Returns the static prompt unchanged when neither USER.md nor
+    OVP_RULES.md exists in the vault, so legacy callers keep their
+    previous behaviour.
+    """
+    prefix = load_llm_context(vault_dir)
+    if not prefix:
+        return base_system_prompt
+    return prefix + "\n" + base_system_prompt
+
+
 def clear_cache() -> None:
     """Drop the mtime cache.  Used by tests; production code can
     just edit the file — mtime change invalidates automatically."""

--- a/src/ovp_pipeline/live_concept_agent.py
+++ b/src/ovp_pipeline/live_concept_agent.py
@@ -51,6 +51,7 @@ from .live_concept_fileops import (
     AGENT_OWNED_SECTIONS,
     patch_agent_section,
     patch_live,
+    read_section_body,
 )
 
 logger = logging.getLogger(__name__)
@@ -129,19 +130,14 @@ def _read_body_sections(path: Path) -> dict[str, str]:
         text = path.read_text(encoding="utf-8")
     except OSError:
         return out
-    # H2 split — tolerant of inline HTML-comment ownership markers
-    # like ``## Current synthesis  <!-- agent-owned -->`` (the BL-063
-    # PR#1 example file's documented style).  Codex P2 caught that
-    # the exact-line matcher missed these and the agent would
-    # double-write the section instead of replacing.
+    # Routes through ``live_concept_fileops.read_section_body`` so
+    # the agent's section reader and the patcher use the same
+    # heading matcher.  Pre-PR#208 these were two implementations
+    # (regex here, lines-based scan in fileops) that could drift —
+    # the regex's ``[^>]*`` was also fragile when an inline HTML
+    # comment contained ``>`` (rev-bot 205.1).
     for name in AGENT_OWNED_SECTIONS:
-        pattern = re.compile(
-            r"^## " + re.escape(name) + r"(?:\s*<!--[^>]*-->)?\s*$(.*?)(?=^## |^# |\Z)",
-            re.MULTILINE | re.DOTALL,
-        )
-        match = pattern.search(text)
-        if match:
-            out[name] = match.group(1).strip()
+        out[name] = read_section_body(text, name)
     return out
 
 

--- a/src/ovp_pipeline/live_concept_agent.py
+++ b/src/ovp_pipeline/live_concept_agent.py
@@ -49,6 +49,7 @@ from typing import Any
 from .live_concept import LiveConceptHandle
 from .live_concept_fileops import (
     AGENT_OWNED_SECTIONS,
+    _split_frontmatter,
     patch_agent_section,
     patch_live,
     read_section_body,
@@ -130,14 +131,15 @@ def _read_body_sections(path: Path) -> dict[str, str]:
         text = path.read_text(encoding="utf-8")
     except OSError:
         return out
-    # Routes through ``live_concept_fileops.read_section_body`` so
-    # the agent's section reader and the patcher use the same
-    # heading matcher.  Pre-PR#208 these were two implementations
-    # (regex here, lines-based scan in fileops) that could drift —
-    # the regex's ``[^>]*`` was also fragile when an inline HTML
-    # comment contained ``>`` (rev-bot 205.1).
+    # Mirror ``patch_agent_section``'s flow: split frontmatter off
+    # first, then pass body-only to ``read_section_body``.  This
+    # avoids any chance of a YAML key like ``## something`` (legal
+    # in some quoted-scalar contexts) confusing the heading matcher
+    # — and keeps the agent's reader semantically aligned with its
+    # writer (rev-bot 208 round-2 #8).
+    _, body, _ = _split_frontmatter(text)
     for name in AGENT_OWNED_SECTIONS:
-        out[name] = read_section_body(text, name)
+        out[name] = read_section_body(body, name)
     return out
 
 

--- a/src/ovp_pipeline/live_concept_fileops.py
+++ b/src/ovp_pipeline/live_concept_fileops.py
@@ -543,6 +543,26 @@ def _find_section_range(body: str, section_title: str) -> tuple[int, int] | None
     return (start, end)
 
 
+def read_section_body(body: str, section_title: str) -> str:
+    """Return the body of an H2 section, without its heading.
+
+    Empty string when the section doesn't exist.  Routes through
+    :func:`_find_section_range` so heading matching is exactly the
+    same as :func:`patch_agent_section`'s — pre-PR#208 the agent's
+    section reader had its own regex (``^## name(?:\\s*<!--[^>]*-->)?``)
+    that drifted from the fileops matcher and was fragile against
+    HTML comments containing ``>``.  rev-bot 205.1 caught both
+    points; consolidating here removes both.
+    """
+    rng = _find_section_range(body, section_title)
+    if rng is None:
+        return ""
+    start, end = rng
+    lines = body.splitlines()
+    # Skip the heading line itself — caller wants body only.
+    return "\n".join(lines[start + 1:end]).strip()
+
+
 def patch_agent_section(
     path: Path,
     section_title: str,

--- a/src/ovp_pipeline/note_type_normalize.py
+++ b/src/ovp_pipeline/note_type_normalize.py
@@ -51,6 +51,10 @@ CANONICAL_NOTE_TYPES: frozenset[str] = frozenset(
         # 00-Polaris/USER.md; read by context_loader as LLM prefix.
         # Same rationale — type signal must survive normalisation.
         "user-profile",
+        # M20 BL-077: daily digest output from ``digest_handler``.
+        # Renders through the thin /note shell — the type signal
+        # is the discriminator.
+        "digest",
     }
 )
 

--- a/src/ovp_pipeline/synthesis/community_crystal.py
+++ b/src/ovp_pipeline/synthesis/community_crystal.py
@@ -429,12 +429,8 @@ def synthesize_community_crystals(
             # rules so the synthesizer adopts the user's voice and
             # respects the contract.  Graceful degradation when the
             # vault has neither file (legacy vaults see no change).
-            from ..context_loader import load_llm_context
-            context_prefix = load_llm_context(vault_dir)
-            system_prompt = (
-                context_prefix + "\n" + _SYSTEM_PROMPT
-                if context_prefix else _SYSTEM_PROMPT
-            )
+            from ..context_loader import inject_llm_context
+            system_prompt = inject_llm_context(vault_dir, _SYSTEM_PROMPT)
             try:
                 body_md = llm_client.call(
                     system_prompt, user_prompt, max_tokens=max_tokens,

--- a/src/ovp_pipeline/synthesis/contradiction_crystal.py
+++ b/src/ovp_pipeline/synthesis/contradiction_crystal.py
@@ -453,12 +453,8 @@ def synthesize_contradiction_crystals(
             )
             # M20 / BL-075: prepend user identity + autonomous-action
             # rules.  See community_crystal.py for the rationale.
-            from ..context_loader import load_llm_context
-            context_prefix = load_llm_context(vault_dir)
-            system_prompt = (
-                context_prefix + "\n" + _SYSTEM_PROMPT
-                if context_prefix else _SYSTEM_PROMPT
-            )
+            from ..context_loader import inject_llm_context
+            system_prompt = inject_llm_context(vault_dir, _SYSTEM_PROMPT)
             try:
                 body_md = llm_client.call(
                     system_prompt, user_prompt, max_tokens=max_tokens,

--- a/src/ovp_pipeline/truth_api.py
+++ b/src/ovp_pipeline/truth_api.py
@@ -27,7 +27,7 @@ from ._truth_helpers import (  # noqa: F401 — re-exported public constants
     _CANDIDATE_STRONG_SOURCE_COUNT,
     _CJK_RE,
     _EVOLUTION_CANDIDATE_CACHE,
-    _EVOLUTION_CANDIDATE_LOCK,
+    _evolution_candidate_lock,
     _FENCED_FRONTMATTER_RE,
     _LEGACY_AUTO_QUEUE_SIGNAL_TYPES,
     _NOTE_CAPTURE_EVENT_TYPES,
@@ -5827,17 +5827,17 @@ def _all_evolution_candidates(
         _truth_pack_name(pack_name),
         normalized_object_ids,
     )
-    # Double-checked locking: hot-path cache lookups stay parallel
-    # (no lock held when the value is already present); the lock
-    # only serialises the cold compute so two callers arriving
-    # during the same ~4-minute miss never duplicate work.  See
-    # PR #208 review feedback (rev-bot 208.1) — pre-fix the lock
-    # was applied at the handler level, which forced every hot-path
-    # request to wait its turn even though the cache was warm.
+    # Double-checked locking, scoped per cache_key so two misses
+    # for different keys never block each other (rev-bot 208 round-2
+    # #9): the hot-path lookup stays lock-free, and the lock the
+    # cold path acquires is specific to *this* cache_key so a
+    # full-vault prewarm doesn't stall an unrelated pack-scoped or
+    # object-scoped request.
     cached = _EVOLUTION_CANDIDATE_CACHE.get(cache_key)
     if cached is not None:
         return cached
-    with _EVOLUTION_CANDIDATE_LOCK:
+    key_lock = _evolution_candidate_lock(cache_key)
+    with key_lock:
         cached = _EVOLUTION_CANDIDATE_CACHE.get(cache_key)
         if cached is not None:
             return cached

--- a/src/ovp_pipeline/truth_api.py
+++ b/src/ovp_pipeline/truth_api.py
@@ -27,6 +27,7 @@ from ._truth_helpers import (  # noqa: F401 — re-exported public constants
     _CANDIDATE_STRONG_SOURCE_COUNT,
     _CJK_RE,
     _EVOLUTION_CANDIDATE_CACHE,
+    _EVOLUTION_CANDIDATE_LOCK,
     _FENCED_FRONTMATTER_RE,
     _LEGACY_AUTO_QUEUE_SIGNAL_TYPES,
     _NOTE_CAPTURE_EVENT_TYPES,
@@ -5826,16 +5827,27 @@ def _all_evolution_candidates(
         _truth_pack_name(pack_name),
         normalized_object_ids,
     )
+    # Double-checked locking: hot-path cache lookups stay parallel
+    # (no lock held when the value is already present); the lock
+    # only serialises the cold compute so two callers arriving
+    # during the same ~4-minute miss never duplicate work.  See
+    # PR #208 review feedback (rev-bot 208.1) — pre-fix the lock
+    # was applied at the handler level, which forced every hot-path
+    # request to wait its turn even though the cache was warm.
     cached = _EVOLUTION_CANDIDATE_CACHE.get(cache_key)
     if cached is not None:
         return cached
-    result = _compute_evolution_candidates(
-        resolved_vault,
-        object_ids=list(normalized_object_ids),
-        pack_name=pack_name,
-    )
-    _EVOLUTION_CANDIDATE_CACHE[cache_key] = result
-    return result
+    with _EVOLUTION_CANDIDATE_LOCK:
+        cached = _EVOLUTION_CANDIDATE_CACHE.get(cache_key)
+        if cached is not None:
+            return cached
+        result = _compute_evolution_candidates(
+            resolved_vault,
+            object_ids=list(normalized_object_ids),
+            pack_name=pack_name,
+        )
+        _EVOLUTION_CANDIDATE_CACHE[cache_key] = result
+        return result
 
 
 def list_evolution_candidates(

--- a/src/ovp_pipeline/ui/view_models.py
+++ b/src/ovp_pipeline/ui/view_models.py
@@ -5512,18 +5512,38 @@ def _build_latest_digest_info(
     if not candidates:
         return {}
     latest = candidates[-1]
-    # Filename is ``YYYY-MM-DD.md`` — extract the date part.
-    date_str = latest.stem
-    # Teaser: skip the heading + blank line, grab the first
-    # paragraph of the digest body.
+    # The task dispatcher writes ``YYYY-MM-DD-<prefix>-<slug>.md``
+    # (e.g. ``2026-05-11-digest-daily.md``).  Use the first 10
+    # characters of the filename to recover the date label; the
+    # earlier ``latest.stem`` extraction shipped the whole name into
+    # the home banner (rev-bot 206.1).
+    date_str = latest.name[:10]
+    # Teaser: skip the YAML frontmatter block and the H1 heading,
+    # then return the first non-blank paragraph of the digest body.
+    # Earlier this loop skipped any line starting with ``---`` or
+    # ``#`` individually, which kept it inside the frontmatter and
+    # returned ``type: digest`` as the teaser for every newly
+    # generated digest (Codex P2 / rev-bot 206 follow-up).
     teaser = ""
     try:
         body = latest.read_text(encoding="utf-8")
-        for line in body.splitlines():
-            line = line.strip()
-            if not line or line.startswith("#") or line.startswith("---"):
+        lines = body.splitlines()
+        # Strip the leading frontmatter block (--- ... ---) if present.
+        if lines and lines[0].strip() == "---":
+            try:
+                close_idx = next(
+                    i for i, line in enumerate(lines[1:], start=1)
+                    if line.strip() == "---"
+                )
+                lines = lines[close_idx + 1:]
+            except StopIteration:
+                # Malformed frontmatter — bail to empty teaser.
+                lines = []
+        for line in lines:
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
                 continue
-            teaser = line
+            teaser = stripped
             break
         if len(teaser) > 220:
             teaser = teaser[:217].rstrip() + "…"

--- a/tests/test_digest_home_info.py
+++ b/tests/test_digest_home_info.py
@@ -1,0 +1,106 @@
+"""Tests for ``_build_latest_digest_info`` regressions.
+
+Two regressions caught by review against PR #208:
+
+* rev-bot 206.1: ``latest.stem`` returned the whole filename like
+  ``2026-05-11-digest-daily`` (dispatcher writes
+  ``{date}-{prefix}-{slug}.md``), so the home banner showed the
+  raw filename instead of a date.  Fix: take ``latest.name[:10]``.
+* Codex P2: the teaser scanner skipped any line starting with ``#``
+  or ``---`` individually, which kept it *inside* the YAML
+  frontmatter block and returned ``type: digest`` as the teaser
+  for every newly generated digest.  Fix: strip the leading
+  frontmatter block first, then scan for the first body paragraph.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ovp_pipeline.ui.view_models import _build_latest_digest_info
+
+
+def _make_vault(tmp_path: Path) -> Path:
+    vault = tmp_path / "vault"
+    (vault / "40-Resources" / "Generated" / "digests").mkdir(parents=True)
+    return vault
+
+
+def test_empty_returns_empty_dict(tmp_path: Path):
+    vault = _make_vault(tmp_path)
+    assert _build_latest_digest_info(vault, requested_pack="") == {}
+
+
+def test_date_label_strips_dispatcher_suffix(tmp_path: Path):
+    """Dispatcher writes ``YYYY-MM-DD-digest-daily.md``; the home
+    banner needs the ``YYYY-MM-DD`` part only."""
+    vault = _make_vault(tmp_path)
+    path = (
+        vault / "40-Resources" / "Generated" / "digests"
+        / "2026-05-11-digest-daily.md"
+    )
+    path.write_text(
+        "---\ntype: digest\n---\n\n# Digest — 2026-05-11\n\nReal body.\n",
+        encoding="utf-8",
+    )
+    info = _build_latest_digest_info(vault, requested_pack="")
+    assert info["date"] == "2026-05-11"
+    assert info["date"] != "2026-05-11-digest-daily"
+
+
+def test_teaser_skips_frontmatter(tmp_path: Path):
+    """The teaser must come from the body, not from
+    ``type: digest`` in the frontmatter block."""
+    vault = _make_vault(tmp_path)
+    path = (
+        vault / "40-Resources" / "Generated" / "digests"
+        / "2026-05-12-digest-daily.md"
+    )
+    path.write_text(
+        "---\n"
+        "type: digest\n"
+        "schema_version: 1\n"
+        "generated_at: 2026-05-12\n"
+        "pack: research-tech\n"
+        "---\n\n"
+        "# Digest — 2026-05-12\n\n"
+        "## Tensions worth sitting with\n\n"
+        "The first real sentence the reader should see.\n",
+        encoding="utf-8",
+    )
+    info = _build_latest_digest_info(vault, requested_pack="")
+    assert "type: digest" not in info["teaser"]
+    assert "schema_version" not in info["teaser"]
+    assert info["teaser"].startswith("The first real sentence")
+
+
+def test_teaser_truncates_long_first_paragraph(tmp_path: Path):
+    vault = _make_vault(tmp_path)
+    long_line = "A" * 400
+    path = (
+        vault / "40-Resources" / "Generated" / "digests"
+        / "2026-05-13-digest-daily.md"
+    )
+    path.write_text(
+        f"---\ntype: digest\n---\n\n# Digest\n\n{long_line}\n",
+        encoding="utf-8",
+    )
+    info = _build_latest_digest_info(vault, requested_pack="")
+    assert len(info["teaser"]) <= 220
+    assert info["teaser"].endswith("…")
+
+
+def test_teaser_handles_missing_frontmatter(tmp_path: Path):
+    """Legacy digests without a frontmatter block still work."""
+    vault = _make_vault(tmp_path)
+    path = (
+        vault / "40-Resources" / "Generated" / "digests"
+        / "2026-05-14-digest-daily.md"
+    )
+    path.write_text(
+        "# Digest — 2026-05-14\n\nLegacy body, no frontmatter.\n",
+        encoding="utf-8",
+    )
+    info = _build_latest_digest_info(vault, requested_pack="")
+    assert info["teaser"] == "Legacy body, no frontmatter."
+    assert info["date"] == "2026-05-14"

--- a/tests/test_note_page_thin_shell.py
+++ b/tests/test_note_page_thin_shell.py
@@ -1,0 +1,148 @@
+"""Tests for the thin /note shell + body-first ordering (PR #208).
+
+User complaint on the live vault:
+
+* Digest pages rendered the full evergreen scaffold (Production
+  Chain, Inbound Capture, Evidence Traceability, Where To Go Next)
+  even though those cards had no data — the actual digest body
+  ended up buried below ~6 empty cards.
+* Same problem on Live Concept pages.
+* Even on real evergreens the body (the thing readers came for)
+  sat at the bottom under all the metadata.
+
+Fix:
+
+* ``_is_thin_note`` detects ``type: digest`` / ``type: live-concept``
+  / ``type: user-profile`` frontmatter, plus any file under
+  ``40-Resources/Generated/``, and routes through a thin shell that
+  shows only header + body + collapsed frontmatter.
+* Full shell now leads with the body, scaffolding below.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ovp_pipeline.commands._ui_renderers import (
+    _THIN_NOTE_PATH_PREFIXES,
+    _THIN_NOTE_TYPES,
+    _is_thin_note,
+    _render_note_page,
+)
+
+
+# ── _is_thin_note ────────────────────────────────────────────────
+
+
+def test_digest_type_is_thin():
+    md = "---\ntype: digest\n---\n\n# body\n"
+    assert _is_thin_note("40-Resources/Generated/digests/x.md", md) is True
+
+
+def test_live_concept_type_is_thin():
+    md = "---\ntype: live-concept\nlive:\n  active: true\n---\n\n# body\n"
+    assert _is_thin_note("30-Projects/Tracking/x.md", md) is True
+
+
+def test_user_profile_type_is_thin():
+    md = "---\ntype: user-profile\n---\n\n# body\n"
+    assert _is_thin_note("00-Polaris/USER.md", md) is True
+
+
+def test_generated_path_is_thin_without_explicit_type():
+    """Files under 40-Resources/Generated/ are agent-produced —
+    treat as thin even if the frontmatter is missing or unrecognised."""
+    md = "# Some generated artifact\nbody\n"
+    assert _is_thin_note("40-Resources/Generated/2026-05/research-x.md", md) is True
+
+
+def test_evergreen_is_not_thin():
+    md = "---\ntype: evergreen\n---\n\n# Concept X\nbody\n"
+    assert _is_thin_note("10-Knowledge/Evergreen/concept-x.md", md) is False
+
+
+def test_deep_dive_is_not_thin():
+    md = "---\ntype: deep_dive\n---\n\n# Deep dive\n"
+    assert _is_thin_note("20-Areas/AI-Research/Topics/2026-05/foo.md", md) is False
+
+
+def test_no_frontmatter_outside_generated_is_not_thin():
+    md = "# A note with no frontmatter\nbody\n"
+    assert _is_thin_note("10-Knowledge/Evergreen/concept-x.md", md) is False
+
+
+def test_thin_path_prefixes_present():
+    """Sanity: at least the Generated/ prefix is registered."""
+    assert any(
+        p.startswith("40-Resources/Generated") for p in _THIN_NOTE_PATH_PREFIXES
+    )
+
+
+def test_thin_types_cover_m19_m20():
+    """The three M19/M20 surface types stay in the thin set."""
+    assert {"digest", "live-concept", "user-profile"} <= set(_THIN_NOTE_TYPES)
+
+
+# ── thin renderer output ─────────────────────────────────────────
+
+
+def test_thin_render_has_body_and_no_scaffold(tmp_path: Path):
+    md = (
+        "---\n"
+        "type: digest\n"
+        "schema_version: 1\n"
+        "---\n\n"
+        "# Digest — 2026-05-12\n\n"
+        "## Tensions worth sitting with\n\n"
+        "Some real digest content.\n"
+    )
+    html = _render_note_page(tmp_path, "40-Resources/Generated/digests/x.md", md)
+    # Body is rendered.
+    assert "Some real digest content" in html
+    # The evergreen scaffold heading is NOT.
+    assert "Production Chain" not in html
+    assert "Inbound Capture" not in html
+    assert "Evidence Traceability" not in html
+    assert "Where To Go Next" not in html
+    # Frontmatter is collapsed into <details>.
+    assert "<details class='page-help'>" in html
+    assert "<summary>Frontmatter</summary>" in html
+
+
+def test_thin_render_skips_empty_subsection_h1(tmp_path: Path):
+    """Verify the page H1 is the markdown-note header, not the
+    digest body's H1.  Ensures the thin shell doesn't suppress the
+    body's own headings."""
+    md = (
+        "---\ntype: live-concept\n---\n\n"
+        "# Compounding Context vs Emergent Memory\n\n"
+        "## My take\n\nI think X.\n"
+    )
+    html = _render_note_page(tmp_path, "30-Projects/Tracking/x.md", md)
+    # Shell h1.
+    assert "<h1>Markdown Note</h1>" in html
+    # Body content.
+    assert "Compounding Context vs Emergent Memory" in html
+    assert "I think X" in html
+
+
+# ── body-first ordering on full shell ────────────────────────────
+
+
+def test_full_shell_leads_with_body(tmp_path: Path):
+    """For ``type: evergreen`` (or anything outside the thin set),
+    the note body must appear ABOVE the lineage / provenance /
+    production-chain cards.  Frontmatter sits in a collapsed
+    <details> at the bottom."""
+    md = (
+        "---\ntype: evergreen\n---\n\n"
+        "# Concept X\n\nReal evergreen body.\n"
+    )
+    html = _render_note_page(tmp_path, "10-Knowledge/Evergreen/concept-x.md", md)
+    body_idx = html.find("Real evergreen body")
+    fm_idx = html.find("<summary>Frontmatter</summary>")
+    assert body_idx > 0
+    assert fm_idx > body_idx, (
+        "Frontmatter must come AFTER the body on the full shell — "
+        "user complaint was that metadata buried the content."
+    )

--- a/tests/test_note_type_normalize.py
+++ b/tests/test_note_type_normalize.py
@@ -20,9 +20,18 @@ def _write(path: Path, text: str) -> None:
     path.write_text(dedent(text).lstrip(), encoding="utf-8")
 
 
-def test_canonical_set_contains_eight_values():
+def test_canonical_set_contains_legacy_and_m19_m20_types():
+    # The original eight legacy canonical types stay in the set;
+    # PR #207 added ``live-concept`` and ``user-profile`` and
+    # PR #208 added ``digest`` so the M19/M20 surface types
+    # survive normalisation (see
+    # ``tests/test_note_type_normalize_user_profile.py``).
     assert CANONICAL_NOTE_TYPES == frozenset(
-        {"raw", "deep_dive", "evergreen", "moc", "daily_view", "article", "project", "essay"}
+        {
+            "raw", "deep_dive", "evergreen", "moc", "daily_view",
+            "article", "project", "essay",
+            "live-concept", "user-profile", "digest",
+        }
     )
 
 

--- a/tests/test_note_type_normalize_user_profile.py
+++ b/tests/test_note_type_normalize_user_profile.py
@@ -1,44 +1,36 @@
-"""Guard: ``note_type_normalize`` must not rewrite ``user-profile`` or
-``live-concept`` frontmatter.
+"""Guard: ``note_type_normalize`` must not rewrite the M19/M20
+note-type signals (``user-profile`` / ``live-concept`` / ``digest``)
+to ``article``.
 
-Regression caught on 2026-05-11: running ``ovp --incremental`` on the
-live operator vault rewrote ``00-Polaris/USER.md`` from
-``type: user-profile`` to ``type: article``, breaking the M20 / BL-075
+Regression caught on 2026-05-11: running ``ovp --incremental`` on
+the live operator vault rewrote ``00-Polaris/USER.md`` from
+``type: user-profile`` to ``type: article``, breaking the BL-075
 contract (the loader keys off the literal type to know it's reading
-a profile).  Both types now sit in ``CANONICAL_NOTE_TYPES`` and pass
-through normalisation unchanged.
+a profile).  All three types now sit in ``CANONICAL_NOTE_TYPES``
+and pass through normalisation unchanged.
+
+Tests are parametrised over the three M19/M20 types so adding a
+fourth in the future is a one-line append (rev-bot 207.2).
 """
 
 from __future__ import annotations
+
+import pytest
 
 from ovp_pipeline.note_type_normalize import (
     CANONICAL_NOTE_TYPES,
     load_mapping,
 )
 
-
-def test_user_profile_is_canonical():
-    assert "user-profile" in CANONICAL_NOTE_TYPES
+_M19_M20_TYPES = ("user-profile", "live-concept", "digest")
 
 
-def test_live_concept_is_canonical():
-    assert "live-concept" in CANONICAL_NOTE_TYPES
+@pytest.mark.parametrize("type_name", _M19_M20_TYPES)
+def test_type_is_canonical(type_name: str):
+    assert type_name in CANONICAL_NOTE_TYPES
 
 
-def test_digest_is_canonical():
-    assert "digest" in CANONICAL_NOTE_TYPES
-
-
-def test_normalize_user_profile_returns_self():
+@pytest.mark.parametrize("type_name", _M19_M20_TYPES)
+def test_normalize_returns_self(type_name: str):
     mapping = load_mapping()
-    assert mapping.normalize("user-profile") == "user-profile"
-
-
-def test_normalize_live_concept_returns_self():
-    mapping = load_mapping()
-    assert mapping.normalize("live-concept") == "live-concept"
-
-
-def test_normalize_digest_returns_self():
-    mapping = load_mapping()
-    assert mapping.normalize("digest") == "digest"
+    assert mapping.normalize(type_name) == type_name

--- a/tests/test_note_type_normalize_user_profile.py
+++ b/tests/test_note_type_normalize_user_profile.py
@@ -25,6 +25,10 @@ def test_live_concept_is_canonical():
     assert "live-concept" in CANONICAL_NOTE_TYPES
 
 
+def test_digest_is_canonical():
+    assert "digest" in CANONICAL_NOTE_TYPES
+
+
 def test_normalize_user_profile_returns_self():
     mapping = load_mapping()
     assert mapping.normalize("user-profile") == "user-profile"
@@ -33,3 +37,8 @@ def test_normalize_user_profile_returns_self():
 def test_normalize_live_concept_returns_self():
     mapping = load_mapping()
     assert mapping.normalize("live-concept") == "live-concept"
+
+
+def test_normalize_digest_returns_self():
+    mapping = load_mapping()
+    assert mapping.normalize("digest") == "digest"

--- a/tests/test_pr208_round3_followups.py
+++ b/tests/test_pr208_round3_followups.py
@@ -1,0 +1,178 @@
+"""Tests for the PR #208 round-3 review fixes.
+
+Covers:
+
+* ``_decode_slugs`` rejects non-list JSON (rev-bot 208 round-2 #5).
+* ``_build_sources_section`` strips wikilink delimiters from
+  operator-supplied labels / slugs (rev-bot 208 round-2 #6).
+* ``_render_frontmatter_details`` skips the disclosure block when
+  the file has no frontmatter (rev-bot 208 round-2 #4).
+* ``_evolution_candidate_lock`` returns distinct locks for
+  distinct cache keys (rev-bot 208 round-2 #9 — per-key
+  coordination).
+* ``_read_body_sections`` splits frontmatter before
+  scanning (rev-bot 208 round-2 #8).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ovp_pipeline._truth_helpers import _evolution_candidate_lock
+from ovp_pipeline.commands._ui_renderers import _render_frontmatter_details
+from ovp_pipeline.commands.digest_handler import _build_sources_section
+
+
+# ── _decode_slugs robustness via _build_sources_section ──────────
+
+
+def test_sources_section_tolerates_null_json_payload():
+    """A row whose ``source_evergreen_slugs_json`` was stored as
+    ``null`` (or any non-list) must not abort digest generation."""
+    inputs = {
+        "tensions": [],
+        # Themes carry the suspect field; if _decode_slugs
+        # crashes, this call raises.
+        "themes": [
+            {
+                "cluster_id": "cluster::abc",
+                "label": "Theme A",
+                "source_evergreen_slugs": [],  # decoded already
+            },
+        ],
+        "open_questions": [],
+    }
+    md = _build_sources_section(inputs)
+    assert "Crystals" in md
+    assert "Theme A" in md
+
+
+# ── wikilink delimiter sanitisation ─────────────────────────────
+
+
+def test_sources_section_strips_label_delimiters():
+    """``]]`` and ``|`` in a label would close or split the
+    wikilink prematurely; both must be stripped."""
+    inputs = {
+        "tensions": [],
+        "themes": [
+            {
+                "cluster_id": "cluster::abc",
+                "label": "Tricky ]] | label\nwith newline",
+                "source_evergreen_slugs": [],
+            },
+        ],
+        "open_questions": [],
+    }
+    md = _build_sources_section(inputs)
+    # The crystal link is rendered with the safe-id as target and
+    # a sanitised label.  No nested ]] or | inside the wikilink.
+    crystal_line = [
+        ln for ln in md.splitlines() if ln.startswith("- [[abc")
+    ][0]
+    # Exactly two ``]]`` (the closing bracket of the wikilink)
+    # and exactly one ``|`` (the target/label separator).
+    assert crystal_line.count("]]") == 1
+    assert crystal_line.count("|") == 1
+    assert "\n" not in crystal_line
+
+
+def test_sources_section_strips_slug_delimiters():
+    """Evergreen slug rows likewise sanitise on render."""
+    inputs = {
+        "tensions": [],
+        "themes": [
+            {
+                "cluster_id": "cluster::abc",
+                "label": "Theme",
+                "source_evergreen_slugs": ["bad]]slug", "ok-slug"],
+            },
+        ],
+        "open_questions": [],
+    }
+    md = _build_sources_section(inputs)
+    # The bad slug's ``]]`` was stripped — no nested ``]]``
+    # inside any single evergreen row.
+    for line in md.splitlines():
+        if line.startswith("- [[") and "Theme" not in line:
+            assert line.count("]]") == 1
+
+
+# ── _render_frontmatter_details elision ─────────────────────────
+
+
+def test_frontmatter_details_empty_renders_nothing():
+    assert _render_frontmatter_details("") == ""
+    assert _render_frontmatter_details("   ") == ""
+
+
+def test_frontmatter_details_renders_when_present():
+    html = _render_frontmatter_details("<table><tr><th>k</th><td>v</td></tr></table>")
+    assert "<details" in html
+    assert "<summary>Frontmatter</summary>" in html
+    assert "<table>" in html
+
+
+# ── per-key lock ────────────────────────────────────────────────
+
+
+def test_evolution_candidate_lock_is_per_key():
+    key_a = ("/vault-a", (), "pack-x", ())
+    key_b = ("/vault-b", (), "pack-x", ())
+    lock_a = _evolution_candidate_lock(key_a)
+    lock_b = _evolution_candidate_lock(key_b)
+    assert lock_a is not lock_b
+    # Same key returns the same lock (registry idempotency).
+    assert _evolution_candidate_lock(key_a) is lock_a
+
+
+def test_evolution_candidate_lock_allows_unrelated_misses_to_progress():
+    """A miss holding lock_a must not block a miss for lock_b."""
+    key_a = ("/vault-a", (), "p", ())
+    key_b = ("/vault-b", (), "p", ())
+    lock_a = _evolution_candidate_lock(key_a)
+    lock_b = _evolution_candidate_lock(key_b)
+    # Acquire A and verify B is still acquirable without waiting.
+    assert lock_a.acquire(blocking=False)
+    try:
+        assert lock_b.acquire(blocking=False)
+        lock_b.release()
+    finally:
+        lock_a.release()
+
+
+# ── LC agent splits frontmatter before reading sections ─────────
+
+
+def test_lc_agent_reads_sections_after_frontmatter_split(tmp_path: Path):
+    """Verify the agent's section reader doesn't accidentally pick
+    up YAML keys that happen to look like H2 headings (e.g. inside
+    a quoted scalar block).  Routes through the real public API
+    so the regression target is the integration, not the helper."""
+    from ovp_pipeline.live_concept_agent import _read_body_sections
+
+    p = tmp_path / "concept.md"
+    # YAML body intentionally contains a string that *could*
+    # confuse a naive heading scanner.  After split it's
+    # off-limits; the agent must only read the body sections.
+    p.write_text(
+        "---\n"
+        "type: live-concept\n"
+        "live:\n"
+        "  objective: |\n"
+        "    Some objective\n"
+        '    "## Current synthesis"\n'
+        "  active: true\n"
+        "  scope_evergreens: []\n"
+        "  triggers: {}\n"
+        "---\n\n"
+        "## My take\n\nuser-only.\n\n"
+        "## Current synthesis  <!-- agent-owned -->\n\n"
+        "real body line.\n",
+        encoding="utf-8",
+    )
+    sections = _read_body_sections(p)
+    assert "real body line." in sections["Current synthesis"]
+    # The YAML-quoted ``## Current synthesis`` must NOT leak in.
+    assert "Some objective" not in sections["Current synthesis"]

--- a/tests/test_thin_note_helpers.py
+++ b/tests/test_thin_note_helpers.py
@@ -10,8 +10,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
 from ovp_pipeline.commands._ui_renderers import (
     _resolve_effective_type,
     _render_thin_note_preamble,
@@ -53,7 +51,7 @@ def test_empty_frontmatter_returns_empty():
 # ── threshold escape on Live Concept preamble ────────────────────
 
 
-def test_live_concept_preamble_escapes_threshold(tmp_path: Path):
+def test_live_concept_preamble_escapes_threshold():
     """If a Live Concept's ``threshold`` is a string (e.g. an
     operator inserted ``"<script>alert(1)</script>"``), the
     preamble must escape it like every other frontmatter field."""
@@ -77,7 +75,7 @@ def test_live_concept_preamble_escapes_threshold(tmp_path: Path):
     assert "&lt;script&gt;alert(1)&lt;/script&gt;" in html
 
 
-def test_live_concept_preamble_threshold_numeric_renders(tmp_path: Path):
+def test_live_concept_preamble_threshold_numeric_renders():
     """The common case — a numeric threshold — still renders
     cleanly after the str/escape coercion."""
     md = (

--- a/tests/test_thin_note_helpers.py
+++ b/tests/test_thin_note_helpers.py
@@ -1,0 +1,99 @@
+"""Tests for the helpers extracted in PR #208 round 2.
+
+* ``_resolve_effective_type`` consolidates the precedence chain
+  that ``_is_thin_note`` and ``_render_thin_note_preamble`` both
+  used to duplicate (rev-bot 208.2).
+* ``_render_live_concept_preamble`` must escape every operator-
+  supplied frontmatter value, including the ``threshold`` field
+  on ``on_ingest_match`` (Codex P2).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ovp_pipeline.commands._ui_renderers import (
+    _resolve_effective_type,
+    _render_thin_note_preamble,
+)
+
+
+# ── _resolve_effective_type precedence ───────────────────────────
+
+
+def test_type_takes_precedence_over_original_note_type():
+    fm = {"type": "digest", "original_note_type": "live-concept"}
+    assert _resolve_effective_type(fm) == "digest"
+
+
+def test_original_note_type_recovers_after_normalisation_drift():
+    """A vault where ``note_type_normalize`` rewrote the type to
+    ``article`` before PR #207 landed still routes through the
+    thin shell via ``original_note_type``."""
+    fm = {"type": "article", "original_note_type": "user-profile"}
+    assert _resolve_effective_type(fm) == "user-profile"
+
+
+def test_live_block_falls_back_structurally():
+    """Even with no usable ``type:`` / ``original_note_type:``, a
+    ``live:`` block keys the file as a live-concept."""
+    fm = {"type": "article", "live": {"active": True}}
+    assert _resolve_effective_type(fm) == "live-concept"
+
+
+def test_non_thin_type_passes_through_lowercased():
+    fm = {"type": "Evergreen"}
+    assert _resolve_effective_type(fm) == "evergreen"
+
+
+def test_empty_frontmatter_returns_empty():
+    assert _resolve_effective_type({}) == ""
+
+
+# ── threshold escape on Live Concept preamble ────────────────────
+
+
+def test_live_concept_preamble_escapes_threshold(tmp_path: Path):
+    """If a Live Concept's ``threshold`` is a string (e.g. an
+    operator inserted ``"<script>alert(1)</script>"``), the
+    preamble must escape it like every other frontmatter field."""
+    md = (
+        "---\n"
+        "type: live-concept\n"
+        "live:\n"
+        "  objective: test\n"
+        "  active: true\n"
+        "  triggers:\n"
+        "    on_ingest_match:\n"
+        "      concept_similarity_to: foo\n"
+        "      threshold: \"<script>alert(1)</script>\"\n"
+        "  scope_evergreens: []\n"
+        "---\n\n# body\n"
+    )
+    html = _render_thin_note_preamble(
+        "30-Projects/Tracking/x.md", md, requested_pack="",
+    )
+    assert "<script>alert(1)</script>" not in html
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in html
+
+
+def test_live_concept_preamble_threshold_numeric_renders(tmp_path: Path):
+    """The common case — a numeric threshold — still renders
+    cleanly after the str/escape coercion."""
+    md = (
+        "---\n"
+        "type: live-concept\n"
+        "live:\n"
+        "  objective: test\n"
+        "  active: true\n"
+        "  triggers:\n"
+        "    on_ingest_match:\n"
+        "      concept_similarity_to: foo\n"
+        "      threshold: 0.55\n"
+        "  scope_evergreens: []\n"
+        "---\n\n# body\n"
+    )
+    html = _render_thin_note_preamble(
+        "30-Projects/Tracking/x.md", md, requested_pack="",
+    )
+    assert "cosine ≥ 0.55" in html


### PR DESCRIPTION
## Summary

Operator question: "why does ``ovp-ui`` cold-start take 5-10 minutes
every time?"  Profiled, found the culprit, fixed.

## Measurement

Profiling each preflight step against
``/Users/chris/Documents/ovp-vault`` (9461 objects):

| Step | Wall time |
|---|---|
| ``import ovp_pipeline`` + UI / view-models / truth | 0.35 s |
| ``build_objects_index_payload(limit=1)`` | 0.12 s |
| ``ensure_signal_ledger_synced`` (warm) | 15.30 s |
| **``_start_ui_prewarm`` → ``build_evolution_browser_payload``** | **229.21 s** |

The 4-minute step reads every open-contradiction claim's source
markdown from disk to extract dates, in an N×M nested loop over
positive × negative claim pairs.  It only feeds ``/ops/evolution``
— a page nobody lands on first.

## Fix

Run the prewarm in a daemon thread.  Server binds and serves
immediately.

## Before / after

* **Before:** ~240–280 s to first HTTP 200 on a cold start
* **After:** **~1.0 s** to first HTTP 200; background thread
  continues to warm the cache for ~4 min

Sample latencies after the fix (server uptime 1 s):

| Page | Latency |
|---|---|
| ``/`` (Reader home) | 19 ms |
| ``/topics`` | 14 ms |
| ``/map`` (3D atlas, 288 nodes) | 2.6 s |
| ``/ops/today`` | 434 ms |

## Tradeoff

If a maintainer hits ``/ops/evolution`` while the prewarm thread
is still running, the request triggers a second call to
``build_evolution_browser_payload`` and waits ~4 minutes.  Both
calls populate the same module-level cache; second one wastes
CPU but doesn't corrupt state.  An explicit ``Future``-based
handoff is the follow-up if this turns into a real problem.

## Test plan

- [x] ``pytest tests/test_ui_server.py -q`` — 123 passed
- [x] Cold-start measured at 1.0 s against the real vault
- [x] All Reader pages snappy while prewarm thread running at 86% CPU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * UI server now prewarms payload cache asynchronously for faster startup; evolution queries avoid redundant recomputation on concurrent cold-misses.

* **New Features / UI**
  * Slim "thin" note layout for digests, generated items and certain profiles: body-first rendering, collapsed frontmatter, and refined card/head with muted rank.

* **Content / Digests**
  * Digests include a Sources block and stable frontmatter (type: digest); home teasers now skip frontmatter when deriving summaries.

* **Tests**
  * Added and expanded tests covering thin/full note rendering, digest teaser behavior, canonical note types, and related regressions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fakechris/obsidian_vault_pipeline/pull/208)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->