### PR TITLE
feat(bl-081): LLM profile loader (M21a step 1)

### DIFF
--- a/src/ovp_pipeline/data/llm_profiles_template.yaml
+++ b/src/ovp_pipeline/data/llm_profiles_template.yaml
@@ -1,0 +1,54 @@
+# OVP LLM profiles template (M21 / BL-081).
+#
+# Copy to ``.ovp/llm_profiles.yaml`` at the vault root and adjust to
+# the providers / models / limits you actually want.  ``.ovp/`` is
+# gitignored so secrets and per-vault overrides stay local.
+#
+# Three abstract profiles map to real provider/model pairs.  The
+# Reader UI surfaces the abstract names (Fast / Balanced / Deep)
+# only — raw provider/model strings stay out of chrome.  Operators
+# who need a custom profile add a new entry here and reference it
+# via ``ovp-ask --profile <name>`` on the CLI.
+#
+# Cost-per-1k fields are informational — used by the /chats list
+# view (BL-088) to show a friendly dollar estimate.  Cap enforcement
+# counts tokens via the audit-events ledger, not dollars.
+#
+# Missing or unreadable: the loader falls back to a single
+# ``balanced`` profile sourced from the AUTO_VAULT_* env vars.
+# Legacy vaults see no behavioural change.
+
+profiles:
+  fast:
+    provider: anthropic
+    model: MiniMax-M2.7-highspeed
+    api_base: https://api.minimaxi.com/anthropic
+    max_tokens: 1500
+    temperature: 0.6
+    cost_per_1k_in: 0.0001
+    cost_per_1k_out: 0.0003
+  balanced:
+    provider: anthropic
+    model: claude-sonnet-4-6
+    max_tokens: 4000
+    temperature: 0.7
+    cost_per_1k_in: 0.003
+    cost_per_1k_out: 0.015
+  deep:
+    provider: anthropic
+    model: claude-opus-4-7
+    max_tokens: 6000
+    temperature: 0.7
+    cost_per_1k_in: 0.015
+    cost_per_1k_out: 0.075
+
+default_for:
+  chat: balanced
+  extraction: fast
+  digest: balanced
+  router: fast
+
+limits:
+  chat_input_tokens_per_request: 16000
+  chat_output_tokens_per_request: 4000
+  chat_daily_tokens_per_pack: 200000

--- a/src/ovp_pipeline/data/models_template.md
+++ b/src/ovp_pipeline/data/models_template.md
@@ -1,0 +1,50 @@
+---
+type: documentation
+schema_version: 1
+---
+
+# Models — operator notes
+
+<!-- Plain-English notes on **when to use which profile** in
+     `.ovp/llm_profiles.yaml`.  This file is documentation only —
+     never parsed by OVP.  Edit when your model lineup changes. -->
+
+## When I reach for each profile
+
+### Fast
+
+Use when latency and cost matter more than reasoning depth.
+
+- Background extraction (the absorb pipeline routes here by default)
+- Single-fact lookups
+- "Did you cover X?" sanity checks while drafting
+
+### Balanced
+
+Default for anchored inquiry (`ovp-ask`).  The middle of the
+quality/cost curve.
+
+- Reader-side chat from `/note` and `/object`
+- Daily digest synthesis
+- Anything where I want to see citations + nuance but don't want
+  to wait 30s
+
+### Deep
+
+Reach for it explicitly.
+
+- Architecture / design conversations
+- Multi-page synthesis where the prompt is dense
+- Anything I'd otherwise hand to Opus directly
+
+## When I add a custom profile
+
+If I need a new provider, model, or cost tier, I add the entry to
+`.ovp/llm_profiles.yaml` and refer to it via `ovp-ask --profile
+<name>` on the CLI.  The Reader UI dropdown stays Fast / Balanced /
+Deep — custom profiles are operator-only.
+
+## Switching providers
+
+Editing `.ovp/llm_profiles.yaml` is enough; no restart needed.
+The loader's mtime cache picks the new file up on the next call.

--- a/src/ovp_pipeline/llm_profiles.py
+++ b/src/ovp_pipeline/llm_profiles.py
@@ -37,6 +37,7 @@ import logging
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
+from types import MappingProxyType
 from typing import Final, Mapping
 
 import yaml
@@ -44,9 +45,11 @@ import yaml
 from ovp_pipeline.llm_defaults import (
     DEFAULT_MINIMAX_API_BASE,
     DEFAULT_MINIMAX_MODEL,
+    normalize_model_for_api_base,
     resolve_api_base,
     resolve_api_key,
 )
+from ovp_pipeline.runtime import resolve_vault_dir
 
 logger = logging.getLogger(__name__)
 
@@ -63,17 +66,25 @@ DEFAULT_USE_CASES: Final[tuple[str, ...]] = (
     "router",
 )
 
+# Per-field defaults — referenced both by :class:`ProfileConfig` and
+# the yaml parser so the two stay in sync (CodeRabbit M2).
+_DEFAULT_MAX_TOKENS: Final[int] = 4000
+_DEFAULT_TEMPERATURE: Final[float] = 0.7
+_DEFAULT_API_TYPE: Final[str] = "anthropic"
+
 # Built-in defaults — used when ``.ovp/llm_profiles.yaml`` is
 # missing.  Three abstract tiers; only the Balanced tier is
 # materialised from env vars so legacy vaults keep working.  Fast
 # and Deep need explicit yaml entries to point at real providers.
 _FALLBACK_PROFILE_NAME: Final[str] = "balanced"
-_FALLBACK_USE_CASE_MAP: Final[Mapping[str, str]] = {
-    "chat": "balanced",
-    "extraction": "balanced",
-    "digest": "balanced",
-    "router": "balanced",
-}
+_FALLBACK_USE_CASE_MAP: Final[Mapping[str, str]] = MappingProxyType(
+    {
+        "chat": "balanced",
+        "extraction": "balanced",
+        "digest": "balanced",
+        "router": "balanced",
+    }
+)
 
 # Per-pack-per-day input+output token cap.  Conservative default
 # the operator can raise in yaml after watching real usage.
@@ -95,11 +106,11 @@ class ProfileConfig:
     name: str
     provider: str
     model: str
-    max_tokens: int = 4000
-    temperature: float = 0.7
+    max_tokens: int = _DEFAULT_MAX_TOKENS
+    temperature: float = _DEFAULT_TEMPERATURE
     api_base: str | None = None
     api_key: str | None = None
-    api_type: str = "anthropic"
+    api_type: str = _DEFAULT_API_TYPE
     cost_per_1k_in: float = 0.0
     cost_per_1k_out: float = 0.0
 
@@ -190,8 +201,8 @@ def load_profiles(vault_dir: Path | str | None = None) -> ProfileBook:
     limits = _parse_limits(data.get("limits") or {})
 
     return ProfileBook(
-        profiles=profiles,
-        default_for=default_for,
+        profiles=MappingProxyType(dict(profiles)),
+        default_for=MappingProxyType(dict(default_for)),
         limits=limits,
         source="yaml",
     )
@@ -231,16 +242,7 @@ def profile_for_use_case(
     book = load_profiles(vault_dir)
     profile_name = book.default_for.get(use_case)
     if profile_name is None or profile_name not in book.profiles:
-        # Conservative fallback: the first profile defined, which
-        # is "balanced" in both the fallback book and the M21 plan's
-        # example yaml.
-        if _FALLBACK_PROFILE_NAME in book.profiles:
-            return book.profiles[_FALLBACK_PROFILE_NAME]
-        # Edge case: operator yaml has profiles but none called
-        # "balanced".  Pick deterministically — sorted-name first —
-        # so two callers in the same vault agree.
-        first = sorted(book.profiles)[0]
-        return book.profiles[first]
+        return book.profiles[_pick_fallback_name(book.profiles)]
     return book.profiles[profile_name]
 
 
@@ -258,17 +260,35 @@ _CACHE: dict[Path, tuple[float, str]] = {}
 
 
 def _config_path(vault_dir: Path | str | None) -> Path:
-    base = Path(vault_dir) if vault_dir else Path.cwd()
-    return base / CONFIG_REL
+    """Resolve to an absolute path to the yaml config.
+
+    When ``vault_dir`` is ``None``, defer to :func:`resolve_vault_dir`
+    so CLI calls launched outside the vault still find the operator's
+    ``.ovp/llm_profiles.yaml`` (codex review P2) — the same resolver
+    every other ``ovp-*`` command uses.  Calling ``.resolve()`` keeps
+    the ``_CACHE`` key stable across ``os.chdir`` (CodeRabbit P1).
+    """
+    base = resolve_vault_dir(vault_dir)
+    return (base / CONFIG_REL).resolve()
 
 
 def _read_capped(path: Path) -> str:
     """Return ``path`` content or ``""`` when missing/unreadable."""
     try:
-        mtime = path.stat().st_mtime
+        st = path.stat()
     except OSError:
         return ""
 
+    if st.st_size > MAX_BYTES:
+        # Check size *before* slurping the file (CodeRabbit M3).
+        logger.warning(
+            "llm_profiles: %s exceeded %d bytes; using fallback",
+            path,
+            MAX_BYTES,
+        )
+        return ""
+
+    mtime = st.st_mtime
     cached = _CACHE.get(path)
     if cached is not None and cached[0] == mtime:
         return cached[1]
@@ -277,14 +297,6 @@ def _read_capped(path: Path) -> str:
         raw_bytes = path.read_bytes()
     except OSError as exc:
         logger.debug("llm_profiles: failed to read %s: %s", path, exc)
-        return ""
-
-    if len(raw_bytes) > MAX_BYTES:
-        logger.warning(
-            "llm_profiles: %s exceeded %d bytes; using fallback",
-            path,
-            MAX_BYTES,
-        )
         return ""
 
     try:
@@ -323,15 +335,22 @@ def _parse_profiles(
                 name,
             )
             continue
+        api_type = _coerce_optional_str(body.get("api_type")) or provider
         result[name] = ProfileConfig(
             name=name,
             provider=provider,
             model=model,
-            max_tokens=_coerce_int(body.get("max_tokens"), 4000),
-            temperature=_coerce_float(body.get("temperature"), 0.7),
+            max_tokens=_coerce_positive_int(
+                body.get("max_tokens"),
+                _DEFAULT_MAX_TOKENS,
+            ),
+            temperature=_coerce_float(
+                body.get("temperature"),
+                _DEFAULT_TEMPERATURE,
+            ),
             api_base=_coerce_optional_str(body.get("api_base")),
             api_key=_coerce_optional_str(body.get("api_key")),
-            api_type=str(body.get("api_type") or "anthropic"),
+            api_type=api_type,
             cost_per_1k_in=_coerce_float(
                 body.get("cost_per_1k_in"),
                 0.0,
@@ -367,27 +386,37 @@ def _parse_default_for(
     # Ensure every canonical use case has an entry — fall back to
     # the first available profile if the yaml didn't list it.
     if profiles:
-        first_profile = (
-            _FALLBACK_PROFILE_NAME if _FALLBACK_PROFILE_NAME in profiles else sorted(profiles)[0]
-        )
+        first_profile = _pick_fallback_name(profiles)
         for use_case in DEFAULT_USE_CASES:
             result.setdefault(use_case, first_profile)
     return result
+
+
+def _pick_fallback_name(profiles: Mapping[str, ProfileConfig]) -> str:
+    """Pick a deterministic fallback profile name (CodeRabbit M6).
+
+    Prefer ``balanced`` when present; otherwise the first profile
+    sorted by name so two callers in the same vault agree.  Caller
+    must guarantee ``profiles`` is non-empty.
+    """
+    if _FALLBACK_PROFILE_NAME in profiles:
+        return _FALLBACK_PROFILE_NAME
+    return sorted(profiles)[0]
 
 
 def _parse_limits(raw: object) -> ProfileLimits:
     if not isinstance(raw, Mapping):
         return ProfileLimits()
     return ProfileLimits(
-        chat_input_tokens_per_request=_coerce_int(
+        chat_input_tokens_per_request=_coerce_positive_int(
             raw.get("chat_input_tokens_per_request"),
             _FALLBACK_INPUT_CAP,
         ),
-        chat_output_tokens_per_request=_coerce_int(
+        chat_output_tokens_per_request=_coerce_positive_int(
             raw.get("chat_output_tokens_per_request"),
             _FALLBACK_OUTPUT_CAP,
         ),
-        chat_daily_tokens_per_pack=_coerce_int(
+        chat_daily_tokens_per_pack=_coerce_positive_int(
             raw.get("chat_daily_tokens_per_pack"),
             _FALLBACK_DAILY_TOKEN_CAP,
         ),
@@ -405,6 +434,19 @@ def _coerce_int(value: object, default: int) -> int:
         except ValueError:
             return default
     return default
+
+
+def _coerce_positive_int(value: object, default: int) -> int:
+    """Like :func:`_coerce_int`, but reject ``<= 0`` (CodeRabbit P1).
+
+    ``max_tokens: 0`` and ``chat_daily_tokens_per_pack: -1`` would
+    silently disable caps if accepted verbatim; falling back to the
+    default is safer than honoring nonsensical values.
+    """
+    coerced = _coerce_int(value, default)
+    if coerced <= 0:
+        return default
+    return coerced
 
 
 def _coerce_float(value: object, default: float) -> float:
@@ -432,31 +474,42 @@ def _fallback_book() -> ProfileBook:
 
     Legacy vaults without ``.ovp/llm_profiles.yaml`` still get a
     usable ``balanced`` profile so :func:`profile_for_use_case`
-    never raises.  Provider defaults to ``anthropic`` (matches
-    ``llm_defaults.DEFAULT_MINIMAX_MODEL``'s prefix); model defaults
-    to ``DEFAULT_MINIMAX_MODEL``.
+    never raises.  Model defaults to ``DEFAULT_MINIMAX_MODEL`` and
+    is routed through :func:`normalize_model_for_api_base` so the
+    ``minimax/<m>`` legacy shape (with the Anthropic-compatible
+    MiniMax endpoint as base) collapses to ``anthropic/<m>`` —
+    matching what existing ``LiteLLMClient`` consumers expect
+    (codex review P2).
     """
     api_key = resolve_api_key()
     api_base = resolve_api_base(default=DEFAULT_MINIMAX_API_BASE)
     raw_model = (os.environ.get("AUTO_VAULT_MODEL") or "").strip()
-    model = raw_model or DEFAULT_MINIMAX_MODEL
-    provider, _, bare_model = model.partition("/")
+    # Always run through the same normalizer LiteLLMClient uses so
+    # the fallback profile produces a model string downstream code
+    # actually accepts.
+    normalised = normalize_model_for_api_base(
+        raw_model or None,
+        api_type=_DEFAULT_API_TYPE,
+        api_base=api_base,
+        default_model=DEFAULT_MINIMAX_MODEL,
+    )
+    provider, _, bare_model = normalised.partition("/")
     if not bare_model:
-        bare_model, provider = provider, "anthropic"
+        bare_model, provider = provider, _DEFAULT_API_TYPE
 
     balanced = ProfileConfig(
         name=_FALLBACK_PROFILE_NAME,
         provider=provider,
         model=bare_model,
-        max_tokens=4000,
-        temperature=0.7,
+        max_tokens=_DEFAULT_MAX_TOKENS,
+        temperature=_DEFAULT_TEMPERATURE,
         api_base=api_base,
         api_key=api_key,
-        api_type="anthropic",
+        api_type=provider or _DEFAULT_API_TYPE,
     )
     return ProfileBook(
-        profiles={_FALLBACK_PROFILE_NAME: balanced},
-        default_for=dict(_FALLBACK_USE_CASE_MAP),
+        profiles=MappingProxyType({_FALLBACK_PROFILE_NAME: balanced}),
+        default_for=MappingProxyType(dict(_FALLBACK_USE_CASE_MAP)),
         limits=ProfileLimits(),
         source="fallback",
     )

--- a/src/ovp_pipeline/llm_profiles.py
+++ b/src/ovp_pipeline/llm_profiles.py
@@ -148,7 +148,7 @@ class ProfileBook:
     default_for: Mapping[str, str]
     limits: ProfileLimits
     source: str = "fallback"  # "yaml" | "fallback"
-    extras: Mapping[str, object] = field(default_factory=dict)
+    extras: Mapping[str, object] = field(default_factory=lambda: MappingProxyType({}))
 
 
 # ---------------------------------------------------------------

--- a/src/ovp_pipeline/llm_profiles.py
+++ b/src/ovp_pipeline/llm_profiles.py
@@ -1,0 +1,462 @@
+"""LLM profile loader (M21a / BL-081).
+
+Reads ``.ovp/llm_profiles.yaml`` and exposes typed access to the
+four built-in abstract profiles (Fast / Balanced / Deep, plus any
+custom profiles the operator adds) and per-use-case defaults.
+
+Why a separate config layer
+===========================
+
+Before M21 every LLM call site read ``AUTO_VAULT_API_KEY`` /
+``AUTO_VAULT_API_BASE`` / ``AUTO_VAULT_MODEL`` directly.  That
+worked when there was only one model — the absorb extractor.
+M21 introduces *cost / quality tiers*: chat uses Balanced, the
+background extractor uses Fast, deep synthesis uses Deep.  The
+Reader UI surfaces the abstract names; raw provider/model strings
+stay out of chrome.
+
+Design rules
+============
+
+1. **Graceful degradation.**  Missing or unreadable
+   ``.ovp/llm_profiles.yaml`` falls back to a single synthetic
+   ``balanced`` profile sourced from the existing ``AUTO_VAULT_*``
+   env vars (via :mod:`ovp_pipeline.llm_defaults`).  Legacy vaults
+   see no behavioural change.
+2. **No side effects.**  This module never writes.  All caching
+   is keyed to mtime so weekly edits propagate without restarts.
+3. **Frozen dataclasses.**  :class:`ProfileConfig` is immutable —
+   callers can't accidentally mutate the cached singleton.
+4. **Documentation is separate.**  ``00-Polaris/MODELS.md`` is
+   hand-authored operator notes — never parsed by this module.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Final, Mapping
+
+import yaml
+
+from ovp_pipeline.llm_defaults import (
+    DEFAULT_MINIMAX_API_BASE,
+    DEFAULT_MINIMAX_MODEL,
+    resolve_api_base,
+    resolve_api_key,
+)
+
+logger = logging.getLogger(__name__)
+
+CONFIG_REL: Final[str] = ".ovp/llm_profiles.yaml"
+
+# Cap on YAML file size — the config is human-edited and tiny in
+# practice (a few hundred bytes).  Defends against a runaway edit.
+MAX_BYTES: Final[int] = 32 * 1024
+
+DEFAULT_USE_CASES: Final[tuple[str, ...]] = (
+    "chat",
+    "extraction",
+    "digest",
+    "router",
+)
+
+# Built-in defaults — used when ``.ovp/llm_profiles.yaml`` is
+# missing.  Three abstract tiers; only the Balanced tier is
+# materialised from env vars so legacy vaults keep working.  Fast
+# and Deep need explicit yaml entries to point at real providers.
+_FALLBACK_PROFILE_NAME: Final[str] = "balanced"
+_FALLBACK_USE_CASE_MAP: Final[Mapping[str, str]] = {
+    "chat": "balanced",
+    "extraction": "balanced",
+    "digest": "balanced",
+    "router": "balanced",
+}
+
+# Per-pack-per-day input+output token cap.  Conservative default
+# the operator can raise in yaml after watching real usage.
+_FALLBACK_DAILY_TOKEN_CAP: Final[int] = 200_000
+_FALLBACK_INPUT_CAP: Final[int] = 16_000
+_FALLBACK_OUTPUT_CAP: Final[int] = 4_000
+
+
+@dataclass(frozen=True)
+class ProfileConfig:
+    """One row of ``.ovp/llm_profiles.yaml`` ``profiles:`` map.
+
+    ``cost_per_1k_in`` / ``cost_per_1k_out`` are informational
+    only — the BL-084 cost guardrail counts *tokens*, not dollars.
+    They're carried here so the ``/chats`` list view (BL-088) can
+    show a friendly dollar estimate.
+    """
+
+    name: str
+    provider: str
+    model: str
+    max_tokens: int = 4000
+    temperature: float = 0.7
+    api_base: str | None = None
+    api_key: str | None = None
+    api_type: str = "anthropic"
+    cost_per_1k_in: float = 0.0
+    cost_per_1k_out: float = 0.0
+
+    @property
+    def litellm_model(self) -> str:
+        """Return the provider-prefixed model string LiteLLM expects.
+
+        ``profiles.balanced.provider = anthropic`` + ``model =
+        claude-sonnet-4-6`` collapses to ``anthropic/claude-sonnet-4-6``.
+        Already-prefixed models pass through unchanged.
+        """
+        if "/" in self.model:
+            return self.model
+        return f"{self.provider}/{self.model}"
+
+
+@dataclass(frozen=True)
+class ProfileLimits:
+    """``limits:`` block from yaml.  Defaults match the M21 plan."""
+
+    chat_input_tokens_per_request: int = _FALLBACK_INPUT_CAP
+    chat_output_tokens_per_request: int = _FALLBACK_OUTPUT_CAP
+    chat_daily_tokens_per_pack: int = _FALLBACK_DAILY_TOKEN_CAP
+
+
+@dataclass(frozen=True)
+class ProfileBook:
+    """Parsed contents of ``.ovp/llm_profiles.yaml``.
+
+    Treat this as immutable; replace via :func:`load_profiles`
+    rather than mutating fields.
+    """
+
+    profiles: Mapping[str, ProfileConfig]
+    default_for: Mapping[str, str]
+    limits: ProfileLimits
+    source: str = "fallback"  # "yaml" | "fallback"
+    extras: Mapping[str, object] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------
+
+
+def load_profiles(vault_dir: Path | str | None = None) -> ProfileBook:
+    """Return the :class:`ProfileBook` for ``vault_dir``.
+
+    Falls back to a synthetic single-profile book derived from the
+    ``AUTO_VAULT_*`` env vars when ``.ovp/llm_profiles.yaml`` is
+    missing or unreadable.  Cached by mtime — editing the yaml
+    invalidates the cache automatically on the next call.
+    """
+    config_path = _config_path(vault_dir)
+    raw = _read_capped(config_path)
+    if not raw:
+        return _fallback_book()
+
+    try:
+        data = yaml.safe_load(raw) or {}
+    except yaml.YAMLError as exc:
+        logger.warning(
+            "llm_profiles: failed to parse %s: %s — using fallback",
+            config_path,
+            exc,
+        )
+        return _fallback_book()
+
+    if not isinstance(data, Mapping):
+        logger.warning(
+            "llm_profiles: top-level YAML must be a mapping; " "got %s — using fallback",
+            type(data).__name__,
+        )
+        return _fallback_book()
+
+    profiles = _parse_profiles(data.get("profiles") or {})
+    if not profiles:
+        logger.warning(
+            "llm_profiles: %s has no usable ``profiles:`` map — " "using fallback",
+            config_path,
+        )
+        return _fallback_book()
+
+    default_for = _parse_default_for(
+        data.get("default_for") or {},
+        profiles,
+    )
+    limits = _parse_limits(data.get("limits") or {})
+
+    return ProfileBook(
+        profiles=profiles,
+        default_for=default_for,
+        limits=limits,
+        source="yaml",
+    )
+
+
+def resolve_profile(
+    name: str,
+    *,
+    vault_dir: Path | str | None = None,
+) -> ProfileConfig:
+    """Return the named profile.
+
+    Raises :class:`KeyError` when ``name`` isn't defined.  Use
+    :func:`profile_for_use_case` if you want a default fallback.
+    """
+    book = load_profiles(vault_dir)
+    try:
+        return book.profiles[name]
+    except KeyError as exc:
+        raise KeyError(
+            f"llm_profiles: profile {name!r} not defined; " f"available: {sorted(book.profiles)}"
+        ) from exc
+
+
+def profile_for_use_case(
+    use_case: str,
+    *,
+    vault_dir: Path | str | None = None,
+) -> ProfileConfig:
+    """Return the profile assigned to ``use_case`` in ``default_for:``.
+
+    ``use_case`` is one of ``chat / extraction / digest / router``
+    (the canonical set in :data:`DEFAULT_USE_CASES`).  When the
+    yaml doesn't assign a profile for the use case, falls back to
+    ``balanced``.
+    """
+    book = load_profiles(vault_dir)
+    profile_name = book.default_for.get(use_case)
+    if profile_name is None or profile_name not in book.profiles:
+        # Conservative fallback: the first profile defined, which
+        # is "balanced" in both the fallback book and the M21 plan's
+        # example yaml.
+        if _FALLBACK_PROFILE_NAME in book.profiles:
+            return book.profiles[_FALLBACK_PROFILE_NAME]
+        # Edge case: operator yaml has profiles but none called
+        # "balanced".  Pick deterministically — sorted-name first —
+        # so two callers in the same vault agree.
+        first = sorted(book.profiles)[0]
+        return book.profiles[first]
+    return book.profiles[profile_name]
+
+
+def clear_cache() -> None:
+    """Drop the mtime cache.  Used by tests."""
+    _CACHE.clear()
+
+
+# ---------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------
+
+
+_CACHE: dict[Path, tuple[float, str]] = {}
+
+
+def _config_path(vault_dir: Path | str | None) -> Path:
+    base = Path(vault_dir) if vault_dir else Path.cwd()
+    return base / CONFIG_REL
+
+
+def _read_capped(path: Path) -> str:
+    """Return ``path`` content or ``""`` when missing/unreadable."""
+    try:
+        mtime = path.stat().st_mtime
+    except OSError:
+        return ""
+
+    cached = _CACHE.get(path)
+    if cached is not None and cached[0] == mtime:
+        return cached[1]
+
+    try:
+        raw_bytes = path.read_bytes()
+    except OSError as exc:
+        logger.debug("llm_profiles: failed to read %s: %s", path, exc)
+        return ""
+
+    if len(raw_bytes) > MAX_BYTES:
+        logger.warning(
+            "llm_profiles: %s exceeded %d bytes; using fallback",
+            path,
+            MAX_BYTES,
+        )
+        return ""
+
+    try:
+        text = raw_bytes.decode("utf-8")
+    except UnicodeDecodeError:
+        logger.warning(
+            "llm_profiles: %s is not valid UTF-8; using fallback",
+            path,
+        )
+        return ""
+
+    _CACHE[path] = (mtime, text)
+    return text
+
+
+def _parse_profiles(
+    raw: object,
+) -> Mapping[str, ProfileConfig]:
+    if not isinstance(raw, Mapping):
+        return {}
+    result: dict[str, ProfileConfig] = {}
+    for name, body in raw.items():
+        if not isinstance(name, str) or not name.strip():
+            continue
+        if not isinstance(body, Mapping):
+            logger.warning(
+                "llm_profiles: profile %r is not a mapping; skipped",
+                name,
+            )
+            continue
+        provider = str(body.get("provider") or "").strip()
+        model = str(body.get("model") or "").strip()
+        if not provider or not model:
+            logger.warning(
+                "llm_profiles: profile %r missing provider/model; skipped",
+                name,
+            )
+            continue
+        result[name] = ProfileConfig(
+            name=name,
+            provider=provider,
+            model=model,
+            max_tokens=_coerce_int(body.get("max_tokens"), 4000),
+            temperature=_coerce_float(body.get("temperature"), 0.7),
+            api_base=_coerce_optional_str(body.get("api_base")),
+            api_key=_coerce_optional_str(body.get("api_key")),
+            api_type=str(body.get("api_type") or "anthropic"),
+            cost_per_1k_in=_coerce_float(
+                body.get("cost_per_1k_in"),
+                0.0,
+            ),
+            cost_per_1k_out=_coerce_float(
+                body.get("cost_per_1k_out"),
+                0.0,
+            ),
+        )
+    return result
+
+
+def _parse_default_for(
+    raw: object,
+    profiles: Mapping[str, ProfileConfig],
+) -> Mapping[str, str]:
+    if not isinstance(raw, Mapping):
+        return dict(_FALLBACK_USE_CASE_MAP)
+    result: dict[str, str] = {}
+    for key, value in raw.items():
+        if not isinstance(key, str):
+            continue
+        if not isinstance(value, str):
+            continue
+        if value in profiles:
+            result[key] = value
+        else:
+            logger.warning(
+                "llm_profiles: default_for.%s references undefined " "profile %r; ignored",
+                key,
+                value,
+            )
+    # Ensure every canonical use case has an entry — fall back to
+    # the first available profile if the yaml didn't list it.
+    if profiles:
+        first_profile = (
+            _FALLBACK_PROFILE_NAME if _FALLBACK_PROFILE_NAME in profiles else sorted(profiles)[0]
+        )
+        for use_case in DEFAULT_USE_CASES:
+            result.setdefault(use_case, first_profile)
+    return result
+
+
+def _parse_limits(raw: object) -> ProfileLimits:
+    if not isinstance(raw, Mapping):
+        return ProfileLimits()
+    return ProfileLimits(
+        chat_input_tokens_per_request=_coerce_int(
+            raw.get("chat_input_tokens_per_request"),
+            _FALLBACK_INPUT_CAP,
+        ),
+        chat_output_tokens_per_request=_coerce_int(
+            raw.get("chat_output_tokens_per_request"),
+            _FALLBACK_OUTPUT_CAP,
+        ),
+        chat_daily_tokens_per_pack=_coerce_int(
+            raw.get("chat_daily_tokens_per_pack"),
+            _FALLBACK_DAILY_TOKEN_CAP,
+        ),
+    )
+
+
+def _coerce_int(value: object, default: int) -> int:
+    if isinstance(value, bool):
+        return default
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value.strip())
+        except ValueError:
+            return default
+    return default
+
+
+def _coerce_float(value: object, default: float) -> float:
+    if isinstance(value, bool):
+        return default
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value.strip())
+        except ValueError:
+            return default
+    return default
+
+
+def _coerce_optional_str(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _fallback_book() -> ProfileBook:
+    """Build a one-profile book from ``AUTO_VAULT_*`` env vars.
+
+    Legacy vaults without ``.ovp/llm_profiles.yaml`` still get a
+    usable ``balanced`` profile so :func:`profile_for_use_case`
+    never raises.  Provider defaults to ``anthropic`` (matches
+    ``llm_defaults.DEFAULT_MINIMAX_MODEL``'s prefix); model defaults
+    to ``DEFAULT_MINIMAX_MODEL``.
+    """
+    api_key = resolve_api_key()
+    api_base = resolve_api_base(default=DEFAULT_MINIMAX_API_BASE)
+    raw_model = (os.environ.get("AUTO_VAULT_MODEL") or "").strip()
+    model = raw_model or DEFAULT_MINIMAX_MODEL
+    provider, _, bare_model = model.partition("/")
+    if not bare_model:
+        bare_model, provider = provider, "anthropic"
+
+    balanced = ProfileConfig(
+        name=_FALLBACK_PROFILE_NAME,
+        provider=provider,
+        model=bare_model,
+        max_tokens=4000,
+        temperature=0.7,
+        api_base=api_base,
+        api_key=api_key,
+        api_type="anthropic",
+    )
+    return ProfileBook(
+        profiles={_FALLBACK_PROFILE_NAME: balanced},
+        default_for=dict(_FALLBACK_USE_CASE_MAP),
+        limits=ProfileLimits(),
+        source="fallback",
+    )

--- a/tests/test_llm_profiles.py
+++ b/tests/test_llm_profiles.py
@@ -1,0 +1,287 @@
+"""Tests for M21a / BL-081 — LLM profile loader."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from ovp_pipeline.llm_profiles import (
+    CONFIG_REL,
+    DEFAULT_USE_CASES,
+    ProfileConfig,
+    clear_cache,
+    load_profiles,
+    profile_for_use_case,
+    resolve_profile,
+)
+
+# ── fixtures ────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    clear_cache()
+    yield
+    clear_cache()
+
+
+@pytest.fixture
+def vault_with_yaml(tmp_path: Path) -> Path:
+    """Vault containing a realistic .ovp/llm_profiles.yaml."""
+    cfg = tmp_path / CONFIG_REL
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text(
+        """
+profiles:
+  fast:
+    provider: anthropic
+    model: MiniMax-M2.7-highspeed
+    api_base: https://api.minimaxi.com/anthropic
+    max_tokens: 1500
+    temperature: 0.6
+    cost_per_1k_in: 0.0001
+    cost_per_1k_out: 0.0003
+  balanced:
+    provider: anthropic
+    model: claude-sonnet-4-6
+    max_tokens: 4000
+    temperature: 0.7
+    cost_per_1k_in: 0.003
+    cost_per_1k_out: 0.015
+  deep:
+    provider: anthropic
+    model: claude-opus-4-7
+    max_tokens: 6000
+    temperature: 0.7
+    cost_per_1k_in: 0.015
+    cost_per_1k_out: 0.075
+
+default_for:
+  chat: balanced
+  extraction: fast
+  digest: balanced
+  router: fast
+
+limits:
+  chat_input_tokens_per_request: 16000
+  chat_output_tokens_per_request: 4000
+  chat_daily_tokens_per_pack: 200000
+""".lstrip(),
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+# ── parsing ────────────────────────────────────────────────────
+
+
+def test_load_profiles_parses_yaml(vault_with_yaml: Path):
+    book = load_profiles(vault_with_yaml)
+    assert book.source == "yaml"
+    assert set(book.profiles) == {"fast", "balanced", "deep"}
+    balanced = book.profiles["balanced"]
+    assert balanced.provider == "anthropic"
+    assert balanced.model == "claude-sonnet-4-6"
+    assert balanced.max_tokens == 4000
+    assert balanced.temperature == pytest.approx(0.7)
+    assert balanced.cost_per_1k_in == pytest.approx(0.003)
+
+
+def test_default_for_resolves_to_named_profile(vault_with_yaml: Path):
+    book = load_profiles(vault_with_yaml)
+    assert book.default_for["chat"] == "balanced"
+    assert book.default_for["extraction"] == "fast"
+    assert book.default_for["router"] == "fast"
+
+
+def test_limits_round_trip(vault_with_yaml: Path):
+    book = load_profiles(vault_with_yaml)
+    assert book.limits.chat_input_tokens_per_request == 16_000
+    assert book.limits.chat_output_tokens_per_request == 4_000
+    assert book.limits.chat_daily_tokens_per_pack == 200_000
+
+
+# ── public API ─────────────────────────────────────────────────
+
+
+def test_resolve_profile_returns_named(vault_with_yaml: Path):
+    cfg = resolve_profile("deep", vault_dir=vault_with_yaml)
+    assert isinstance(cfg, ProfileConfig)
+    assert cfg.name == "deep"
+    assert cfg.model == "claude-opus-4-7"
+
+
+def test_resolve_profile_raises_for_unknown(vault_with_yaml: Path):
+    with pytest.raises(KeyError, match="totally-bogus"):
+        resolve_profile("totally-bogus", vault_dir=vault_with_yaml)
+
+
+def test_profile_for_use_case_walks_default_for(vault_with_yaml: Path):
+    chat = profile_for_use_case("chat", vault_dir=vault_with_yaml)
+    extraction = profile_for_use_case("extraction", vault_dir=vault_with_yaml)
+    assert chat.name == "balanced"
+    assert extraction.name == "fast"
+
+
+def test_profile_for_use_case_falls_back_to_balanced_for_unknown_use(
+    vault_with_yaml: Path,
+):
+    """An unmapped use-case still returns the balanced profile so
+    callers don't have to do their own None-check."""
+    cfg = profile_for_use_case("unknown_use", vault_dir=vault_with_yaml)
+    assert cfg.name == "balanced"
+
+
+def test_litellm_model_collapses_provider_prefix(vault_with_yaml: Path):
+    cfg = resolve_profile("balanced", vault_dir=vault_with_yaml)
+    assert cfg.litellm_model == "anthropic/claude-sonnet-4-6"
+
+
+def test_default_use_cases_constant_is_canonical_four():
+    """Lock the canonical use-case set so future BL changes notice
+    when they add or remove a use case."""
+    assert DEFAULT_USE_CASES == ("chat", "extraction", "digest", "router")
+
+
+# ── fallback path ──────────────────────────────────────────────
+
+
+def test_missing_yaml_uses_fallback_balanced(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("AUTO_VAULT_MODEL", "anthropic/MiniMax-M2.7-highspeed")
+    monkeypatch.setenv("AUTO_VAULT_API_KEY", "test-key")
+    monkeypatch.setenv("AUTO_VAULT_API_BASE", "https://example/anthropic")
+
+    book = load_profiles(tmp_path)
+    assert book.source == "fallback"
+    assert set(book.profiles) == {"balanced"}
+    cfg = book.profiles["balanced"]
+    assert cfg.provider == "anthropic"
+    assert cfg.model == "MiniMax-M2.7-highspeed"
+    assert cfg.api_key == "test-key"
+    assert cfg.api_base == "https://example/anthropic"
+
+
+def test_profile_for_use_case_works_without_yaml(tmp_path: Path):
+    """The fallback book has a balanced profile assigned to every
+    canonical use case so legacy callers never get None back."""
+    cfg = profile_for_use_case("chat", vault_dir=tmp_path)
+    assert cfg.name == "balanced"
+
+
+def test_malformed_yaml_falls_back_silently(tmp_path: Path, caplog):
+    cfg = tmp_path / CONFIG_REL
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text(": : : not yaml", encoding="utf-8")
+
+    book = load_profiles(tmp_path)
+    assert book.source == "fallback"
+    # The warning got logged so the operator can find the broken config.
+    assert any("failed to parse" in record.getMessage() for record in caplog.records)
+
+
+def test_profiles_block_missing_provider_skipped(tmp_path: Path, caplog):
+    cfg = tmp_path / CONFIG_REL
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text(
+        """
+profiles:
+  broken:
+    model: anthropic/claude-sonnet-4-6
+  ok:
+    provider: anthropic
+    model: claude-sonnet-4-6
+""",
+        encoding="utf-8",
+    )
+    book = load_profiles(tmp_path)
+    assert book.source == "yaml"
+    assert "broken" not in book.profiles
+    assert "ok" in book.profiles
+
+
+def test_default_for_pointing_at_unknown_profile_warns(
+    tmp_path: Path,
+    caplog,
+):
+    cfg = tmp_path / CONFIG_REL
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text(
+        """
+profiles:
+  balanced:
+    provider: anthropic
+    model: claude-sonnet-4-6
+default_for:
+  chat: balanced
+  extraction: nonexistent
+""",
+        encoding="utf-8",
+    )
+    book = load_profiles(tmp_path)
+    assert book.default_for["chat"] == "balanced"
+    # nonexistent didn't make it through, but every canonical use
+    # case still has a value — falls back to balanced.
+    assert book.default_for["extraction"] == "balanced"
+    assert any("nonexistent" in record.getMessage() for record in caplog.records)
+
+
+def test_oversize_yaml_falls_back(tmp_path: Path, caplog):
+    cfg = tmp_path / CONFIG_REL
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_bytes(b"x" * (64 * 1024))  # 64 KB > MAX_BYTES
+    book = load_profiles(tmp_path)
+    assert book.source == "fallback"
+    assert any("exceeded" in r.getMessage() for r in caplog.records)
+
+
+# ── cache invalidation ────────────────────────────────────────
+
+
+def test_cache_invalidates_on_mtime_change(tmp_path: Path):
+    cfg = tmp_path / CONFIG_REL
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text(
+        """
+profiles:
+  balanced:
+    provider: anthropic
+    model: v1
+""".lstrip(),
+        encoding="utf-8",
+    )
+    first = resolve_profile("balanced", vault_dir=tmp_path)
+    assert first.model == "v1"
+
+    # APFS rounds mtime to the second on stressed CI runners.
+    time.sleep(1.1)
+    cfg.write_text(
+        """
+profiles:
+  balanced:
+    provider: anthropic
+    model: v2
+""".lstrip(),
+        encoding="utf-8",
+    )
+    second = resolve_profile("balanced", vault_dir=tmp_path)
+    assert second.model == "v2"
+
+
+# ── env-var pollution guard ───────────────────────────────────
+
+
+def test_explicit_yaml_overrides_env_vars(
+    vault_with_yaml: Path,
+    monkeypatch,
+):
+    """An operator with both AUTO_VAULT_* env vars *and* a yaml gets
+    the yaml — env vars are the fallback, not an override."""
+    monkeypatch.setenv("AUTO_VAULT_MODEL", "anthropic/MiniMax-M2.7-highspeed")
+    monkeypatch.setenv("AUTO_VAULT_API_KEY", "env-key")
+    cfg = resolve_profile("balanced", vault_dir=vault_with_yaml)
+    assert cfg.model == "claude-sonnet-4-6"
+    # api_key isn't auto-pulled from env into yaml-defined profiles —
+    # the LiteLLM client picks it up from the environment directly.
+    assert cfg.api_key is None

--- a/tests/test_llm_profiles.py
+++ b/tests/test_llm_profiles.py
@@ -285,3 +285,133 @@ def test_explicit_yaml_overrides_env_vars(
     # api_key isn't auto-pulled from env into yaml-defined profiles —
     # the LiteLLM client picks it up from the environment directly.
     assert cfg.api_key is None
+
+
+# ── codex P2 + CodeRabbit P1 / Major fixes ────────────────────
+
+
+def test_loader_honors_ovp_vault_dir_env(
+    vault_with_yaml: Path,
+    tmp_path: Path,
+    monkeypatch,
+):
+    """When launched outside the vault, ``load_profiles()`` with no
+    explicit ``vault_dir`` falls through to ``resolve_vault_dir``
+    which reads ``OVP_VAULT_DIR``.  Without this, the loader would
+    miss the operator's yaml and silently use the env-var fallback
+    (codex review P2)."""
+    monkeypatch.setenv("OVP_VAULT_DIR", str(vault_with_yaml))
+    # CWD is somewhere else (tmp_path).  No .ovp/ here.
+    monkeypatch.chdir(tmp_path)
+    book = load_profiles()
+    assert book.source == "yaml"
+    assert "fast" in book.profiles
+
+
+def test_minimax_legacy_fallback_normalises_model(tmp_path, monkeypatch):
+    """Legacy vault with ``AUTO_VAULT_MODEL=minimax/M2.7-highspeed``
+    + the standard MiniMax Anthropic base should normalise to
+    ``anthropic/M2.7-highspeed`` — matches what existing
+    LiteLLMClient consumers expect (codex review P2)."""
+    monkeypatch.delenv("OVP_VAULT_DIR", raising=False)
+    monkeypatch.delenv("VAULT_DIR", raising=False)
+    monkeypatch.setenv("AUTO_VAULT_MODEL", "minimax/M2.7-highspeed")
+    monkeypatch.setenv("AUTO_VAULT_API_BASE", "https://api.minimaxi.com/anthropic")
+    monkeypatch.chdir(tmp_path)
+    cfg = resolve_profile("balanced")
+    assert cfg.provider == "anthropic"
+    assert cfg.model == "M2.7-highspeed"
+    assert cfg.litellm_model == "anthropic/M2.7-highspeed"
+
+
+def test_profile_book_mappings_are_read_only(vault_with_yaml: Path):
+    """CodeRabbit Major — ``ProfileBook`` advertised immutability
+    but the inner mappings were plain dicts.  Now wrapped in
+    ``MappingProxyType``."""
+    book = load_profiles(vault_with_yaml)
+    with pytest.raises(TypeError):
+        book.profiles["injected"] = None  # type: ignore[index]
+    with pytest.raises(TypeError):
+        book.default_for["chat"] = "evil"  # type: ignore[index]
+
+
+def test_nonpositive_max_tokens_rejected(tmp_path: Path):
+    """CodeRabbit P1 — ``max_tokens: 0`` would disable output caps
+    if accepted verbatim.  Falls back to the default."""
+    cfg = tmp_path / CONFIG_REL
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text(
+        """
+profiles:
+  balanced:
+    provider: anthropic
+    model: claude-sonnet-4-6
+    max_tokens: 0
+    temperature: 0.7
+""",
+        encoding="utf-8",
+    )
+    book = load_profiles(tmp_path)
+    assert book.profiles["balanced"].max_tokens > 0
+
+
+def test_nonpositive_daily_cap_rejected(tmp_path: Path):
+    cfg = tmp_path / CONFIG_REL
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text(
+        """
+profiles:
+  balanced:
+    provider: anthropic
+    model: claude-sonnet-4-6
+limits:
+  chat_daily_tokens_per_pack: -1
+""",
+        encoding="utf-8",
+    )
+    book = load_profiles(tmp_path)
+    assert book.limits.chat_daily_tokens_per_pack > 0
+
+
+def test_api_type_defaults_to_provider(tmp_path: Path):
+    """CodeRabbit Major — operators switching to openai-style
+    providers shouldn't have to manually set ``api_type`` on every
+    profile.  When omitted, it derives from ``provider``."""
+    cfg = tmp_path / CONFIG_REL
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text(
+        """
+profiles:
+  custom-openai:
+    provider: openai
+    model: gpt-5
+  custom-anthropic:
+    provider: anthropic
+    model: claude-opus-4-7
+""",
+        encoding="utf-8",
+    )
+    book = load_profiles(tmp_path)
+    assert book.profiles["custom-openai"].api_type == "openai"
+    assert book.profiles["custom-anthropic"].api_type == "anthropic"
+
+
+def test_openai_provider_litellm_model_format(tmp_path: Path):
+    """CodeRabbit nitpick — exercise a non-Anthropic provider end
+    to end so provider-switch regressions don't pass unnoticed."""
+    cfg = tmp_path / CONFIG_REL
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text(
+        """
+profiles:
+  fast:
+    provider: openai
+    model: gpt-5-mini
+    api_base: https://api.openai.com/v1
+""",
+        encoding="utf-8",
+    )
+    cfg2 = resolve_profile("fast", vault_dir=tmp_path)
+    assert cfg2.provider == "openai"
+    assert cfg2.api_type == "openai"
+    assert cfg2.litellm_model == "openai/gpt-5-mini"


### PR DESCRIPTION
## Summary

First PR for M21a (Anchored Inquiry MVP).  Lands the LLM profile
config layer so subsequent BLs can target abstract tiers
(Fast/Balanced/Deep) instead of hard-coded provider strings.

* New: ``src/ovp_pipeline/llm_profiles.py`` — ``ProfileConfig``,
  ``ProfileLimits``, ``ProfileBook`` + ``load_profiles`` /
  ``resolve_profile`` / ``profile_for_use_case`` public API.
* New: ``src/ovp_pipeline/data/llm_profiles_template.yaml`` —
  copy-to-``.ovp/`` starter with all three tiers + per-pack limits.
* New: ``src/ovp_pipeline/data/models_template.md`` — hand-authored
  ``00-Polaris/MODELS.md`` template (operator notes; never parsed).
* New: ``tests/test_llm_profiles.py`` — 17 tests.

## Design rules locked in

1. **Graceful degradation.** Missing / malformed / oversize
   ``.ovp/llm_profiles.yaml`` falls back to a single ``balanced``
   profile sourced from the existing ``AUTO_VAULT_*`` env vars.
   Legacy vaults see zero behavioural change.
2. **Yaml wins when present.** Env vars are the fallback, not an
   override — a vault with both gets the yaml.
3. **Frozen dataclasses.** Callers can't mutate cached singletons.
4. **mtime cache.** Editing the yaml propagates without restart.
5. **Documentation is separate.** ``MODELS.md`` is hand-authored
   notes; never parsed by this module.
6. **No call sites switched.** Existing extractor / crystals /
   digest still read env vars directly.  BL-082..087 will migrate
   them; this PR ships the config layer in isolation.

## Test plan

- [x] ``rtk proxy python -m pytest tests/test_llm_profiles.py -q`` — 17 passed
- [x] ``ruff check`` + ``black --check`` clean on new files
- [x] Full pytest sweep — 2552 passed, 15 xfailed; the 2 architecture-fitness
      failures are pre-existing and unrelated (``test_file_size_limits`` +
      ``test_no_direct_sqlite_in_non_data_modules``, both on files I didn't touch)
- [x] mypy clean on the new module (the ``import yaml`` stub
      warning is pre-existing across the codebase)

## Plan reference

``docs/plans/2026-05-12-m21-chat-surface.md`` — BL-081 detail at
``### BL-081 — Provider config``.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduce LLM profile system with three presets (fast, balanced, deep), per-use-case defaults, provider/model mappings, and configurable token limits; deterministic safe fallbacks and cache-aware loading.

* **Documentation**
  * Add user guide explaining profiles, when to use each preset, how to add custom profiles, and provider-switching behavior.

* **Tests**
  * Add comprehensive tests for parsing, validation, fallbacks, cache invalidation, env var precedence, and format normalization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fakechris/obsidian_vault_pipeline/pull/210)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->