### PR TITLE
feat(bl-082): chat transcript schema + fileops (M21a step 2)

### DIFF
--- a/src/ovp_pipeline/chat_fileops.py
+++ b/src/ovp_pipeline/chat_fileops.py
@@ -1,0 +1,749 @@
+"""Inquiry transcript fileops (M21a / BL-082).
+
+Mirrors :mod:`ovp_pipeline.live_concept_fileops` at the
+markdown-frontmatter-key level: this module is the single writer
+for ``40-Resources/Chats/YYYY-MM/<topic-slug>-<short-hash>.md``.
+Every other writer (Obsidian, MCP tools, future merge utilities)
+must leave the transcript intact.
+
+What this module owns
+---------------------
+
+* **Path computation** — :func:`build_chat_path` derives the canonical
+  vault-relative location for a new inquiry session.
+* **Schema** — :class:`ChatFrontmatter` (frozen dataclass) +
+  :func:`render_initial_chat` for the empty-file initial state.
+* **Append-only turn writes** — :func:`append_turn` and
+  :func:`mark_interrupted` add ``## User · <ISO>`` /
+  ``## Assistant · <ISO> · turn-N`` sections without rewriting
+  earlier turns.  Each assistant turn carries an inline
+  ``<!-- context-manifest ... -->`` HTML comment as the
+  read-only audit snapshot recorded at the time of the call.
+* **Stream-safe atomic writes** — :func:`pending_chat_block` is
+  a context manager that buffers the assistant turn in memory and
+  flushes via a ``.pending`` rename, so a mid-stream crash never
+  leaves a torn transcript.
+
+What this module does NOT own
+-----------------------------
+
+* Token accounting — lives in the append-only ``audit_events``
+  ledger (BL-084 cost guardrail reads from there).  Frontmatter
+  carries ``turn_count`` + ``last_message_at`` only.
+* Visibility / FTS — the ``visibility`` field is just stored
+  here; BL-085 decides whether an indexed session writes the
+  ``pages_index`` / ``page_fts`` shadow rows.
+* Retrieval — :mod:`ovp_pipeline.context_binder` (BL-083) reads
+  *current* vault state on every turn; the manifest persisted
+  here is an audit snapshot, never re-read.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import logging
+import os
+import re
+import secrets
+import tempfile
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Final, Iterator
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+# Canonical vault-relative location for inquiry transcripts.  Lives
+# under ``40-Resources/`` (long-lived artifacts, not intake).
+CHATS_DIR: Final[str] = "40-Resources/Chats"
+
+# YAML ``type`` marker.  Frontmatter without this exact value isn't
+# treated as a chat — the same "type-as-tag" discipline the rest of
+# the vault uses.
+CHAT_TYPE: Final[str] = "chat"
+
+# Schema version of the frontmatter contract.  Bump when fields
+# change shape; the projection (BL-085) gates on this value.
+CHAT_SCHEMA_VERSION: Final[int] = 1
+
+# Hard cap on the markdown topic slug we synthesize from the first
+# user message / anchor title.  Filesystems happily take longer, but
+# long filenames make the operator's Obsidian file picker painful.
+_SLUG_MAX_LEN: Final[int] = 48
+
+# Hex length of the per-session disambiguator that follows the slug.
+# 6 chars = 24 bits = ~16M possible suffixes per (month, topic),
+# vanishingly unlikely to collide for the volumes M21 will see.
+_HASH_LEN: Final[int] = 6
+
+# Valid frontmatter values.  Kept here so BL-085's projection
+# constraint stays single-sourced with the fileops contract.
+_STATUS_VALUES: Final[frozenset[str]] = frozenset({"active", "pinned", "archived"})
+_VISIBILITY_VALUES: Final[frozenset[str]] = frozenset({"indexed", "unindexed"})
+_ANCHOR_KINDS: Final[frozenset[str]] = frozenset({"note", "object", "crystal", "standalone"})
+_SAVE_POLICY_VALUES: Final[frozenset[str]] = frozenset({"persistent", "ephemeral"})
+_ROLE_VALUES: Final[frozenset[str]] = frozenset({"user", "assistant"})
+_TURN_STATUS_VALUES: Final[frozenset[str]] = frozenset({"ok", "interrupted", "error"})
+
+
+# ---------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ChatAnchor:
+    """Inquiry anchor — what artifact the session is grounded in.
+
+    For ``kind == "standalone"`` the operator opened ``/chat``
+    without an anchor; ``path`` is ``""`` and ``title`` may be
+    empty.  For every other kind, ``path`` is vault-relative and
+    ``title`` mirrors the artifact's H1 (for display in the manifest
+    card and the ``/chats`` list view)."""
+
+    kind: str
+    path: str = ""
+    title: str = ""
+
+
+@dataclass(frozen=True)
+class ChatFrontmatter:
+    """Parsed view of an inquiry transcript's frontmatter."""
+
+    chat_id: str
+    status: str = "active"
+    visibility: str = "indexed"
+    save_policy: str = "persistent"
+    anchor: ChatAnchor = field(default_factory=lambda: ChatAnchor("standalone"))
+    profile: str = "balanced"
+    model: str = ""
+    temperature: float = 0.7
+    started_at: str = ""
+    last_message_at: str = ""
+    turn_count: int = 0
+    schema_version: int = CHAT_SCHEMA_VERSION
+
+
+# ---------------------------------------------------------------
+# Slug + path
+# ---------------------------------------------------------------
+
+
+_SLUG_REPLACE_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _slugify(text: str) -> str:
+    """Lower-case, dash-separated, ASCII-only slug.
+
+    Non-ASCII characters degrade to nothing rather than being
+    transliterated — operators typing in Chinese / Japanese still
+    get a usable session via the hash suffix.  Empty input falls
+    back to ``"inquiry"``.
+    """
+    if not text:
+        return "inquiry"
+    lowered = text.lower().strip()
+    ascii_only = lowered.encode("ascii", errors="ignore").decode("ascii")
+    collapsed = _SLUG_REPLACE_RE.sub("-", ascii_only).strip("-")
+    truncated = collapsed[:_SLUG_MAX_LEN].rstrip("-")
+    return truncated or "inquiry"
+
+
+def _short_hash(seed: str) -> str:
+    """Deterministic hex disambiguator computed from ``seed``.
+
+    Falls back to ``secrets.token_hex`` when ``seed`` is empty so
+    every chat path is unique even before the first turn lands.
+    """
+    if not seed:
+        return secrets.token_hex(_HASH_LEN // 2)
+    digest = hashlib.sha256(seed.encode("utf-8")).hexdigest()
+    return digest[:_HASH_LEN]
+
+
+def build_chat_path(
+    vault_dir: Path | str,
+    *,
+    started_at: datetime | None = None,
+    topic: str = "",
+    anchor_ref: str = "",
+) -> Path:
+    """Return ``<vault>/40-Resources/Chats/YYYY-MM/<slug>-<hash>.md``.
+
+    ``topic`` is typically the first user message; ``anchor_ref``
+    is the anchor path so two sessions on the same anchor (but in
+    different months) hash to distinct values.  The caller is
+    responsible for ensuring the resulting path is unique — see
+    :func:`ensure_unique_path`.
+    """
+    when = started_at or datetime.now(timezone.utc)
+    year_month = when.strftime("%Y-%m")
+    slug = _slugify(topic) if topic else _slugify(anchor_ref)
+    seed = f"{when.isoformat()}::{anchor_ref}::{topic}"
+    suffix = _short_hash(seed)
+    filename = f"{slug}-{suffix}.md"
+    return Path(vault_dir) / CHATS_DIR / year_month / filename
+
+
+def ensure_unique_path(path: Path) -> Path:
+    """Return ``path`` if it doesn't exist, else append ``-N`` until
+    a free filename is found.  Defends against the (rare) hash
+    collision + same-second start race."""
+    if not path.exists():
+        return path
+    stem = path.stem
+    suffix = path.suffix
+    parent = path.parent
+    for n in range(2, 1000):
+        candidate = parent / f"{stem}-{n}{suffix}"
+        if not candidate.exists():
+            return candidate
+    raise RuntimeError(f"could not find unique path under {parent}")
+
+
+# ---------------------------------------------------------------
+# Frontmatter <-> YAML
+# ---------------------------------------------------------------
+
+
+def _ordered_dump(data: dict[str, Any]) -> str:
+    buf = io.StringIO()
+    yaml.safe_dump(
+        data,
+        buf,
+        default_flow_style=False,
+        sort_keys=False,
+        allow_unicode=True,
+        width=10_000,
+    )
+    return buf.getvalue().rstrip()
+
+
+def _frontmatter_to_yaml_dict(fm: ChatFrontmatter) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "type": CHAT_TYPE,
+        "schema_version": fm.schema_version,
+        "chat_id": fm.chat_id,
+        "status": fm.status,
+        "visibility": fm.visibility,
+        "save_policy": fm.save_policy,
+        "anchor": {
+            "kind": fm.anchor.kind,
+            "path": fm.anchor.path,
+            "title": fm.anchor.title,
+        },
+        "profile": fm.profile,
+        "model": fm.model,
+        "temperature": fm.temperature,
+        "started_at": fm.started_at,
+        "last_message_at": fm.last_message_at,
+        "turn_count": fm.turn_count,
+    }
+    return payload
+
+
+def render_initial_chat(fm: ChatFrontmatter, title: str) -> str:
+    """Render the file body when an inquiry session is created.
+
+    Frontmatter + a single H1 ``# Chat — <title>``.  The first user
+    turn lands via :func:`append_turn`; there's no need to inject
+    an empty section here.
+    """
+    yaml_block = _ordered_dump(_frontmatter_to_yaml_dict(fm))
+    safe_title = (title or "untitled").strip()
+    return f"---\n{yaml_block}\n---\n\n# Chat — {safe_title}\n"
+
+
+def _split_frontmatter(text: str) -> tuple[str, str]:
+    """Return ``(raw_frontmatter, body)``.  Empty raw + full text as
+    body when the file has no frontmatter."""
+    if not text.startswith("---\n"):
+        return "", text
+    end = text.find("\n---", 4)
+    if end < 0:
+        return "", text
+    raw = text[4:end]
+    body_start = end + len("\n---")
+    if body_start < len(text) and text[body_start] == "\n":
+        body_start += 1
+    body = text[body_start:]
+    return raw, body
+
+
+def _read_top_level_value(raw: str, key: str) -> Any:
+    if not raw.strip():
+        return None
+    try:
+        parsed = yaml.safe_load(raw)
+    except yaml.YAMLError:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    return parsed.get(key)
+
+
+def parse_chat(path: Path) -> ChatFrontmatter | None:
+    """Read ``path`` and return a :class:`ChatFrontmatter`, or
+    ``None`` when the file isn't a chat transcript.
+
+    A file is considered a chat when it carries ``type: chat`` in
+    its frontmatter.  Anything else (regular notes, evergreens,
+    live concepts) yields ``None`` so callers don't need a separate
+    type check.
+    """
+    if not path.is_file():
+        return None
+    raw, _ = _split_frontmatter(path.read_text(encoding="utf-8"))
+    if not raw:
+        return None
+    if _read_top_level_value(raw, "type") != CHAT_TYPE:
+        return None
+    try:
+        parsed = yaml.safe_load(raw) or {}
+    except yaml.YAMLError:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+
+    anchor_blob = parsed.get("anchor") or {}
+    if not isinstance(anchor_blob, dict):
+        anchor_blob = {}
+    anchor_kind = str(anchor_blob.get("kind") or "standalone")
+    if anchor_kind not in _ANCHOR_KINDS:
+        anchor_kind = "standalone"
+    anchor = ChatAnchor(
+        kind=anchor_kind,
+        path=str(anchor_blob.get("path") or ""),
+        title=str(anchor_blob.get("title") or ""),
+    )
+
+    return ChatFrontmatter(
+        chat_id=str(parsed.get("chat_id") or "").strip(),
+        status=_coerce_enum(parsed.get("status"), _STATUS_VALUES, "active"),
+        visibility=_coerce_enum(parsed.get("visibility"), _VISIBILITY_VALUES, "indexed"),
+        save_policy=_coerce_enum(parsed.get("save_policy"), _SAVE_POLICY_VALUES, "persistent"),
+        anchor=anchor,
+        profile=str(parsed.get("profile") or "balanced"),
+        model=str(parsed.get("model") or ""),
+        temperature=_coerce_float(parsed.get("temperature"), 0.7),
+        started_at=str(parsed.get("started_at") or ""),
+        last_message_at=str(parsed.get("last_message_at") or ""),
+        turn_count=_coerce_int(parsed.get("turn_count"), 0),
+        schema_version=_coerce_int(parsed.get("schema_version"), CHAT_SCHEMA_VERSION),
+    )
+
+
+def _coerce_enum(value: object, allowed: frozenset[str], default: str) -> str:
+    if isinstance(value, str) and value in allowed:
+        return value
+    return default
+
+
+def _coerce_float(value: object, default: float) -> float:
+    if isinstance(value, bool):
+        return default
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value.strip())
+        except ValueError:
+            return default
+    return default
+
+
+def _coerce_int(value: object, default: int) -> int:
+    if isinstance(value, bool):
+        return default
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value.strip())
+        except ValueError:
+            return default
+    return default
+
+
+# ---------------------------------------------------------------
+# Session creation
+# ---------------------------------------------------------------
+
+
+def new_chat_id() -> str:
+    """Return ``"chat-<8hex>"`` — short, sortable, human-friendly."""
+    return f"chat-{secrets.token_hex(4)}"
+
+
+def create_chat_file(
+    vault_dir: Path | str,
+    *,
+    chat_id: str | None = None,
+    anchor: ChatAnchor | None = None,
+    profile: str = "balanced",
+    model: str = "",
+    temperature: float = 0.7,
+    visibility: str = "indexed",
+    save_policy: str = "persistent",
+    topic: str = "",
+    started_at: datetime | None = None,
+) -> tuple[Path, ChatFrontmatter]:
+    """Create a new inquiry transcript and return (path, frontmatter).
+
+    The file is created with zero turns; the operator's first
+    message lands via :func:`append_turn`.  ``topic`` shapes the
+    filename slug — pass the first 30-40 chars of the operator's
+    message, or the anchor title for new-from-Reader entry buttons.
+
+    Raises :class:`ValueError` for malformed inputs (unknown
+    anchor kind, bad visibility / status / save_policy).  The
+    fileops module enforces enum integrity at the boundary so
+    downstream code can trust whatever it reads back.
+    """
+    if anchor is None:
+        anchor = ChatAnchor("standalone")
+    if anchor.kind not in _ANCHOR_KINDS:
+        raise ValueError(
+            f"unknown anchor kind {anchor.kind!r}; " f"expected one of {sorted(_ANCHOR_KINDS)}"
+        )
+    if visibility not in _VISIBILITY_VALUES:
+        raise ValueError(
+            f"unknown visibility {visibility!r}; " f"expected one of {sorted(_VISIBILITY_VALUES)}"
+        )
+    if save_policy not in _SAVE_POLICY_VALUES:
+        raise ValueError(
+            f"unknown save_policy {save_policy!r}; "
+            f"expected one of {sorted(_SAVE_POLICY_VALUES)}"
+        )
+
+    when = started_at or datetime.now(timezone.utc)
+    cid = (chat_id or new_chat_id()).strip()
+    if not cid:
+        raise ValueError("chat_id cannot be empty")
+
+    fm = ChatFrontmatter(
+        chat_id=cid,
+        status="active",
+        visibility=visibility,
+        save_policy=save_policy,
+        anchor=anchor,
+        profile=profile,
+        model=model,
+        temperature=temperature,
+        started_at=when.isoformat().replace("+00:00", "Z"),
+        last_message_at=when.isoformat().replace("+00:00", "Z"),
+        turn_count=0,
+    )
+
+    seed_topic = topic or anchor.title or anchor.path or cid
+    raw_path = build_chat_path(
+        vault_dir,
+        started_at=when,
+        topic=seed_topic,
+        anchor_ref=anchor.path or cid,
+    )
+    path = ensure_unique_path(raw_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    title = anchor.title or topic or "untitled"
+    path.write_text(render_initial_chat(fm, title), encoding="utf-8")
+    return path, fm
+
+
+# ---------------------------------------------------------------
+# Turn append
+# ---------------------------------------------------------------
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _render_turn(
+    *,
+    role: str,
+    body: str,
+    timestamp: str,
+    turn_number: int | None,
+    status: str = "ok",
+    interruption_reason: str = "",
+    manifest_lines: list[str] | None = None,
+) -> str:
+    """Render one ``## User`` or ``## Assistant`` block as markdown.
+
+    ``manifest_lines`` is rendered as a ``<!-- context-manifest
+    ... -->`` HTML comment before the body — present on assistant
+    turns, omitted on user turns.  Interrupted assistant turns get
+    a ``status: interrupted, reason: <r>`` comment instead.
+    """
+    if role == "user":
+        header = f"## User · {timestamp}"
+    else:
+        suffix = f" · turn-{turn_number}" if turn_number is not None else ""
+        if status == "interrupted":
+            suffix += " · interrupted"
+        elif status == "error":
+            suffix += " · error"
+        header = f"## Assistant · {timestamp}{suffix}"
+
+    parts: list[str] = [header, ""]
+
+    if role == "assistant":
+        if status == "interrupted":
+            reason = interruption_reason or "client_disconnected"
+            parts.extend(
+                [
+                    f"<!-- status: interrupted, reason: {reason} -->",
+                    "",
+                ]
+            )
+        elif manifest_lines:
+            parts.append("<!-- context-manifest")
+            parts.extend(f"  {line}" for line in manifest_lines)
+            parts.extend(["-->", ""])
+
+    body_text = body.rstrip("\n")
+    if body_text:
+        parts.append(body_text)
+        parts.append("")
+    parts.append("")  # extra blank line between turns
+    return "\n".join(parts)
+
+
+def append_turn(
+    path: Path,
+    *,
+    role: str,
+    body: str,
+    timestamp: str | None = None,
+    turn_number: int | None = None,
+    status: str = "ok",
+    interruption_reason: str = "",
+    manifest_lines: list[str] | None = None,
+    update_frontmatter: bool = True,
+) -> ChatFrontmatter:
+    """Append a turn to ``path`` atomically.
+
+    Writes the new turn + an updated frontmatter (``turn_count``
+    increments by 1, ``last_message_at`` advances to ``timestamp``)
+    via a ``.pending`` rename so a crash never leaves a torn file.
+
+    Returns the post-write :class:`ChatFrontmatter`.
+
+    Raises :class:`ValueError` when:
+
+    * ``path`` doesn't exist or isn't a chat transcript
+    * ``role`` isn't ``"user"`` or ``"assistant"``
+    * ``status`` isn't ``"ok"`` / ``"interrupted"`` / ``"error"``
+    """
+    if role not in _ROLE_VALUES:
+        raise ValueError(f"unknown role {role!r}; expected one of {sorted(_ROLE_VALUES)}")
+    if status not in _TURN_STATUS_VALUES:
+        raise ValueError(
+            f"unknown turn status {status!r}; " f"expected one of {sorted(_TURN_STATUS_VALUES)}"
+        )
+    if not path.is_file():
+        raise ValueError(f"cannot append_turn: {path} does not exist")
+
+    text = path.read_text(encoding="utf-8")
+    raw, body_text = _split_frontmatter(text)
+    if not raw:
+        raise ValueError(f"cannot append_turn: {path} has no frontmatter")
+    if _read_top_level_value(raw, "type") != CHAT_TYPE:
+        raise ValueError(f"cannot append_turn: {path} is not type: {CHAT_TYPE}")
+    fm_current = parse_chat(path)
+    if fm_current is None:
+        raise ValueError(f"cannot append_turn: {path} frontmatter is malformed")
+
+    ts = (timestamp or _iso_now()).strip()
+    new_turn = _render_turn(
+        role=role,
+        body=body,
+        timestamp=ts,
+        turn_number=turn_number,
+        status=status,
+        interruption_reason=interruption_reason,
+        manifest_lines=manifest_lines,
+    )
+
+    updated_fm = fm_current
+    if update_frontmatter:
+        updated_fm = ChatFrontmatter(
+            chat_id=fm_current.chat_id,
+            status=fm_current.status,
+            visibility=fm_current.visibility,
+            save_policy=fm_current.save_policy,
+            anchor=fm_current.anchor,
+            profile=fm_current.profile,
+            model=fm_current.model,
+            temperature=fm_current.temperature,
+            started_at=fm_current.started_at,
+            last_message_at=ts,
+            turn_count=fm_current.turn_count + 1,
+            schema_version=fm_current.schema_version,
+        )
+        new_raw = _ordered_dump(_frontmatter_to_yaml_dict(updated_fm))
+    else:
+        new_raw = raw
+
+    if not body_text.endswith("\n"):
+        body_text = body_text + "\n"
+    new_body = body_text + new_turn
+    new_text = f"---\n{new_raw}\n---\n\n{new_body.lstrip(chr(10))}"
+
+    _atomic_write(path, new_text)
+    return updated_fm
+
+
+def mark_interrupted(
+    path: Path,
+    *,
+    partial_body: str,
+    turn_number: int | None = None,
+    reason: str = "client_disconnected",
+    timestamp: str | None = None,
+) -> ChatFrontmatter:
+    """Append a partial assistant turn with ``status: interrupted``.
+
+    Convenience wrapper around :func:`append_turn`.  The partial
+    text that streamed before the abort is preserved verbatim;
+    the operator can re-send via the same endpoint to retry and
+    a new ``status: ok`` assistant turn lands after the interrupted
+    one.
+    """
+    return append_turn(
+        path,
+        role="assistant",
+        body=partial_body,
+        timestamp=timestamp,
+        turn_number=turn_number,
+        status="interrupted",
+        interruption_reason=reason,
+        manifest_lines=None,
+    )
+
+
+# ---------------------------------------------------------------
+# Atomic write + pending block
+# ---------------------------------------------------------------
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    """Replace ``path`` atomically.
+
+    Writes to a sibling temp file in the same directory (so the
+    ``os.replace`` is a same-filesystem rename) then renames over
+    the target.  Same pattern the rest of OVP uses for canonical
+    file writes — keeps Obsidian's filewatch from seeing a partial
+    transcript.
+    """
+    directory = path.parent
+    directory.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(
+        prefix=path.stem + ".",
+        suffix=".tmp",
+        dir=directory,
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+@contextmanager
+def pending_chat_block(path: Path) -> Iterator["PendingChat"]:
+    """Buffer assistant tokens in memory; flush atomically on exit.
+
+    Yields a :class:`PendingChat` whose ``append`` method records
+    streamed tokens.  Two completion paths:
+
+    1. The context exits normally with ``pending.commit(...)`` —
+       ``append_turn`` writes the full assistant turn.
+    2. The context exits via an exception OR without ``commit`` —
+       ``mark_interrupted`` writes the partial buffer as a
+       ``status: interrupted`` turn.
+
+    The intentional design: at no point is the in-progress reply
+    visible to readers via the canonical markdown file.  The
+    operator sees streaming tokens via the SSE pipe (BL-086); the
+    transcript only ever shows committed turns.
+    """
+    state = PendingChat(path=path)
+    try:
+        yield state
+        if not state._committed:
+            # Context exited without commit — treat as interrupted.
+            mark_interrupted(
+                path,
+                partial_body=state.buffer,
+                turn_number=state.turn_number,
+                reason=state.reason or "no_commit",
+                timestamp=state.timestamp,
+            )
+    except BaseException:
+        try:
+            mark_interrupted(
+                path,
+                partial_body=state.buffer,
+                turn_number=state.turn_number,
+                reason=state.reason or "exception",
+                timestamp=state.timestamp,
+            )
+        except Exception:
+            logger.exception(
+                "chat_fileops: failed to write interrupted turn for %s",
+                path,
+            )
+        raise
+
+
+@dataclass
+class PendingChat:
+    """In-progress assistant turn buffer (see :func:`pending_chat_block`).
+
+    Not a public schema — exposed only as the value yielded by the
+    context manager.  Treat as an internal scratchpad.
+    """
+
+    path: Path
+    buffer: str = ""
+    turn_number: int | None = None
+    reason: str = ""
+    timestamp: str | None = None
+    _committed: bool = False
+
+    def append(self, token: str) -> None:
+        """Buffer streamed token text.  No I/O — fast hot path."""
+        if token:
+            self.buffer += token
+
+    def commit(
+        self,
+        *,
+        manifest_lines: list[str] | None = None,
+        timestamp: str | None = None,
+    ) -> ChatFrontmatter:
+        """Write the buffered turn as a ``status: ok`` assistant turn."""
+        ts = timestamp or self.timestamp
+        fm = append_turn(
+            self.path,
+            role="assistant",
+            body=self.buffer,
+            timestamp=ts,
+            turn_number=self.turn_number,
+            manifest_lines=manifest_lines,
+        )
+        self._committed = True
+        return fm

--- a/src/ovp_pipeline/chat_fileops.py
+++ b/src/ovp_pipeline/chat_fileops.py
@@ -282,18 +282,6 @@ def _split_frontmatter(text: str) -> tuple[str, str]:
     return raw, body
 
 
-def _read_top_level_value(raw: str, key: str) -> Any:
-    if not raw.strip():
-        return None
-    try:
-        parsed = yaml.safe_load(raw)
-    except yaml.YAMLError:
-        return None
-    if not isinstance(parsed, dict):
-        return None
-    return parsed.get(key)
-
-
 def parse_chat(path: Path) -> ChatFrontmatter | None:
     """Read ``path`` and return a :class:`ChatFrontmatter`, or
     ``None`` when the file isn't a chat transcript.

--- a/src/ovp_pipeline/chat_fileops.py
+++ b/src/ovp_pipeline/chat_fileops.py
@@ -40,6 +40,8 @@ What this module does NOT own
 
 from __future__ import annotations
 
+import errno
+import fcntl
 import hashlib
 import io
 import logging
@@ -80,6 +82,11 @@ _SLUG_MAX_LEN: Final[int] = 48
 # 6 chars = 24 bits = ~16M possible suffixes per (month, topic),
 # vanishingly unlikely to collide for the volumes M21 will see.
 _HASH_LEN: Final[int] = 6
+
+# Bound on ``ensure_unique_path`` retries.  A real collision past
+# the first dozen attempts is an operational signal — escalate
+# rather than spin forever (CodeRabbit M).
+_MAX_PATH_SUFFIX: Final[int] = 1000
 
 # Valid frontmatter values.  Kept here so BL-085's projection
 # constraint stays single-sourced with the fileops contract.
@@ -199,7 +206,7 @@ def ensure_unique_path(path: Path) -> Path:
     stem = path.stem
     suffix = path.suffix
     parent = path.parent
-    for n in range(2, 1000):
+    for n in range(2, _MAX_PATH_SUFFIX):
         candidate = parent / f"{stem}-{n}{suffix}"
         if not candidate.exists():
             return candidate
@@ -299,15 +306,30 @@ def parse_chat(path: Path) -> ChatFrontmatter | None:
     if not path.is_file():
         return None
     raw, _ = _split_frontmatter(path.read_text(encoding="utf-8"))
-    if not raw:
-        return None
-    if _read_top_level_value(raw, "type") != CHAT_TYPE:
+    return _parse_frontmatter(raw)
+
+
+def _parse_frontmatter(raw: str) -> ChatFrontmatter | None:
+    """Parse a frontmatter string into a :class:`ChatFrontmatter`.
+
+    Returns ``None`` when:
+
+    * raw is empty / blank
+    * yaml is malformed
+    * top-level isn't a mapping
+    * ``type:`` isn't :data:`CHAT_TYPE`
+
+    Single yaml.safe_load call — :func:`append_turn` reuses this on
+    a string it already split, avoiding the double-read CodeRabbit
+    flagged.
+    """
+    if not raw or not raw.strip():
         return None
     try:
-        parsed = yaml.safe_load(raw) or {}
+        parsed = yaml.safe_load(raw)
     except yaml.YAMLError:
         return None
-    if not isinstance(parsed, dict):
+    if not isinstance(parsed, dict) or parsed.get("type") != CHAT_TYPE:
         return None
 
     anchor_blob = parsed.get("anchor") or {}
@@ -435,8 +457,8 @@ def create_chat_file(
         profile=profile,
         model=model,
         temperature=temperature,
-        started_at=when.isoformat().replace("+00:00", "Z"),
-        last_message_at=when.isoformat().replace("+00:00", "Z"),
+        started_at=_to_iso_utc(when),
+        last_message_at=_to_iso_utc(when),
         turn_count=0,
     )
 
@@ -460,7 +482,23 @@ def create_chat_file(
 
 
 def _iso_now() -> str:
-    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    return _to_iso_utc(datetime.now(timezone.utc))
+
+
+def _to_iso_utc(when: datetime) -> str:
+    """Render ``when`` as an ISO-8601 UTC string with a ``Z`` suffix.
+
+    Tz-naive datetimes are assumed to be UTC (the OVP convention).
+    Tz-aware non-UTC datetimes are converted to UTC first so the
+    Z-suffix replacement actually applies (CodeRabbit catch — naive
+    or non-UTC inputs previously emitted offset strings inconsistent
+    with the schema's implicit UTC contract).
+    """
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=timezone.utc)
+    else:
+        when = when.astimezone(timezone.utc)
+    return when.isoformat().replace("+00:00", "Z")
 
 
 def _render_turn(
@@ -479,7 +517,23 @@ def _render_turn(
     ... -->`` HTML comment before the body — present on assistant
     turns, omitted on user turns.  Interrupted assistant turns get
     a ``status: interrupted, reason: <r>`` comment instead.
+
+    Codex review P2: a successful assistant turn (``role ==
+    "assistant" and status == "ok"``) MUST carry a non-empty
+    manifest.  This is the audit-snapshot contract — operators
+    can't later check what context backed a reply if the manifest
+    is missing.  Callers that have nothing to record should pass
+    an explicit single-line manifest like
+    ``["note: no retrieval context"]``.
     """
+    if role == "assistant" and status == "ok" and not manifest_lines:
+        raise ValueError(
+            "manifest_lines is required for successful assistant turns "
+            "(audit contract — pass an explicit single-line manifest "
+            'such as ["note: no retrieval context"] if there is '
+            "nothing to record)"
+        )
+
     if role == "user":
         header = f"## User · {timestamp}"
     else:
@@ -539,6 +593,13 @@ def append_turn(
     * ``path`` doesn't exist or isn't a chat transcript
     * ``role`` isn't ``"user"`` or ``"assistant"``
     * ``status`` isn't ``"ok"`` / ``"interrupted"`` / ``"error"``
+
+    Concurrent-append safety: the entire read-modify-write goes
+    under a per-chat advisory lock (``flock`` on a sibling
+    ``.lock`` file).  Two simultaneous appends serialise; both
+    turns land and ``turn_count`` reflects both.  Without this
+    lock the later writer would drop the earlier turn (codex
+    review P2).
     """
     if role not in _ROLE_VALUES:
         raise ValueError(f"unknown role {role!r}; expected one of {sorted(_ROLE_VALUES)}")
@@ -549,54 +610,55 @@ def append_turn(
     if not path.is_file():
         raise ValueError(f"cannot append_turn: {path} does not exist")
 
-    text = path.read_text(encoding="utf-8")
-    raw, body_text = _split_frontmatter(text)
-    if not raw:
-        raise ValueError(f"cannot append_turn: {path} has no frontmatter")
-    if _read_top_level_value(raw, "type") != CHAT_TYPE:
-        raise ValueError(f"cannot append_turn: {path} is not type: {CHAT_TYPE}")
-    fm_current = parse_chat(path)
-    if fm_current is None:
-        raise ValueError(f"cannot append_turn: {path} frontmatter is malformed")
+    with _per_chat_lock(path):
+        text = path.read_text(encoding="utf-8")
+        raw, body_text = _split_frontmatter(text)
+        if not raw:
+            raise ValueError(f"cannot append_turn: {path} has no frontmatter")
+        # Single yaml.safe_load via _parse_frontmatter — no double
+        # parse (CodeRabbit M).
+        fm_current = _parse_frontmatter(raw)
+        if fm_current is None:
+            raise ValueError(f"cannot append_turn: {path} is not a valid chat transcript")
 
-    ts = (timestamp or _iso_now()).strip()
-    new_turn = _render_turn(
-        role=role,
-        body=body,
-        timestamp=ts,
-        turn_number=turn_number,
-        status=status,
-        interruption_reason=interruption_reason,
-        manifest_lines=manifest_lines,
-    )
-
-    updated_fm = fm_current
-    if update_frontmatter:
-        updated_fm = ChatFrontmatter(
-            chat_id=fm_current.chat_id,
-            status=fm_current.status,
-            visibility=fm_current.visibility,
-            save_policy=fm_current.save_policy,
-            anchor=fm_current.anchor,
-            profile=fm_current.profile,
-            model=fm_current.model,
-            temperature=fm_current.temperature,
-            started_at=fm_current.started_at,
-            last_message_at=ts,
-            turn_count=fm_current.turn_count + 1,
-            schema_version=fm_current.schema_version,
+        ts = (timestamp or _iso_now()).strip()
+        new_turn = _render_turn(
+            role=role,
+            body=body,
+            timestamp=ts,
+            turn_number=turn_number,
+            status=status,
+            interruption_reason=interruption_reason,
+            manifest_lines=manifest_lines,
         )
-        new_raw = _ordered_dump(_frontmatter_to_yaml_dict(updated_fm))
-    else:
-        new_raw = raw
 
-    if not body_text.endswith("\n"):
-        body_text = body_text + "\n"
-    new_body = body_text + new_turn
-    new_text = f"---\n{new_raw}\n---\n\n{new_body.lstrip(chr(10))}"
+        updated_fm = fm_current
+        if update_frontmatter:
+            updated_fm = ChatFrontmatter(
+                chat_id=fm_current.chat_id,
+                status=fm_current.status,
+                visibility=fm_current.visibility,
+                save_policy=fm_current.save_policy,
+                anchor=fm_current.anchor,
+                profile=fm_current.profile,
+                model=fm_current.model,
+                temperature=fm_current.temperature,
+                started_at=fm_current.started_at,
+                last_message_at=ts,
+                turn_count=fm_current.turn_count + 1,
+                schema_version=fm_current.schema_version,
+            )
+            new_raw = _ordered_dump(_frontmatter_to_yaml_dict(updated_fm))
+        else:
+            new_raw = raw
 
-    _atomic_write(path, new_text)
-    return updated_fm
+        if not body_text.endswith("\n"):
+            body_text = body_text + "\n"
+        new_body = body_text + new_turn
+        new_text = f"---\n{new_raw}\n---\n\n{new_body.lstrip(chr(10))}"
+
+        _atomic_write(path, new_text)
+        return updated_fm
 
 
 def mark_interrupted(
@@ -630,6 +692,46 @@ def mark_interrupted(
 # ---------------------------------------------------------------
 # Atomic write + pending block
 # ---------------------------------------------------------------
+
+
+@contextmanager
+def _per_chat_lock(path: Path) -> Iterator[None]:
+    """Serialise concurrent appends against the same chat file.
+
+    Acquires an exclusive ``flock`` on ``<path>.lock`` (a sibling
+    sentinel file) so two threads / processes writing the same
+    transcript take turns rather than overwriting each other.
+    Codex review P2: without this, two simultaneous appends both
+    read the file at the same revision and one ``os.replace``
+    overwrites the other's turn.
+
+    Implementation notes:
+
+    * Lock file lives next to the transcript so it shares the
+      filesystem and lives in the same directory ownership.
+    * fcntl LOCK_EX blocks until the prior holder releases —
+      sufficient for the M21 use case (operator triggers one
+      append per UI action; UI debounce + per-chat lock is enough
+      to serialise legitimate concurrent calls and detect bugs
+      that fire two appends "simultaneously").
+    * Lock file is left in place after release — the next append
+      reuses it; cleanup is a future detail when archival lands.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            except OSError as exc:
+                if exc.errno not in (errno.ENOENT, errno.EBADF):
+                    raise
+    finally:
+        os.close(fd)
 
 
 def _atomic_write(path: Path, text: str) -> None:
@@ -693,19 +795,25 @@ def pending_chat_block(path: Path) -> Iterator["PendingChat"]:
                 timestamp=state.timestamp,
             )
     except BaseException:
-        try:
-            mark_interrupted(
-                path,
-                partial_body=state.buffer,
-                turn_number=state.turn_number,
-                reason=state.reason or "exception",
-                timestamp=state.timestamp,
-            )
-        except Exception:
-            logger.exception(
-                "chat_fileops: failed to write interrupted turn for %s",
-                path,
-            )
+        # Codex review P2: if the body already committed before
+        # raising, don't write a duplicate interrupted turn.  The
+        # commit already produced a status: ok turn + bumped
+        # turn_count; a second mark_interrupted here would duplicate
+        # the response and double the counter.
+        if not state._committed:
+            try:
+                mark_interrupted(
+                    path,
+                    partial_body=state.buffer,
+                    turn_number=state.turn_number,
+                    reason=state.reason or "exception",
+                    timestamp=state.timestamp,
+                )
+            except Exception:
+                logger.exception(
+                    "chat_fileops: failed to write interrupted turn for %s",
+                    path,
+                )
         raise
 
 

--- a/tests/test_chat_fileops.py
+++ b/tests/test_chat_fileops.py
@@ -1,0 +1,320 @@
+"""Tests for M21a / BL-082 — chat_fileops."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from ovp_pipeline.chat_fileops import (
+    CHAT_SCHEMA_VERSION,
+    CHAT_TYPE,
+    CHATS_DIR,
+    ChatAnchor,
+    ChatFrontmatter,
+    append_turn,
+    build_chat_path,
+    create_chat_file,
+    ensure_unique_path,
+    mark_interrupted,
+    new_chat_id,
+    parse_chat,
+    pending_chat_block,
+    render_initial_chat,
+)
+
+# ── path computation ────────────────────────────────────────────
+
+
+def test_build_chat_path_lives_under_40_resources(tmp_path: Path):
+    when = datetime(2026, 5, 12, 14, 0, 0, tzinfo=timezone.utc)
+    p = build_chat_path(
+        tmp_path,
+        started_at=when,
+        topic="memory architecture",
+        anchor_ref="40-Resources/Generated/digests/x.md",
+    )
+    rel = p.relative_to(tmp_path)
+    parts = rel.parts
+    assert parts[0:2] == ("40-Resources", "Chats")
+    assert parts[2] == "2026-05"
+    assert parts[3].endswith(".md")
+    # slug + 6 hex chars + extension
+    name = parts[3]
+    assert "memory-architecture" in name
+    # File name: <slug>-<6 hex>.md
+    stem = name[: -len(".md")]
+    suffix = stem.rsplit("-", 1)[-1]
+    assert len(suffix) == 6
+    assert all(c in "0123456789abcdef" for c in suffix)
+
+
+def test_build_chat_path_falls_back_to_anchor_when_topic_empty(tmp_path: Path):
+    when = datetime(2026, 5, 12, tzinfo=timezone.utc)
+    p = build_chat_path(
+        tmp_path,
+        started_at=when,
+        topic="",
+        anchor_ref="40-Resources/Generated/digests/daily.md",
+    )
+    assert "daily" in p.name or "digests" in p.name
+
+
+def test_build_chat_path_non_ascii_topic_degrades_gracefully(tmp_path: Path):
+    when = datetime(2026, 5, 12, tzinfo=timezone.utc)
+    p = build_chat_path(
+        tmp_path,
+        started_at=when,
+        topic="思考记忆架构",
+        anchor_ref="x.md",
+    )
+    # All-Chinese topic + ASCII-only slug → falls back to "inquiry"
+    assert p.name.startswith("inquiry-")
+
+
+def test_ensure_unique_path_collision_handling(tmp_path: Path):
+    target = tmp_path / "x.md"
+    target.write_text("already here", encoding="utf-8")
+    fresh = ensure_unique_path(target)
+    assert fresh != target
+    assert fresh.name == "x-2.md"
+
+
+# ── frontmatter render + parse ──────────────────────────────────
+
+
+def test_render_initial_chat_round_trips(tmp_path: Path):
+    fm = ChatFrontmatter(
+        chat_id="chat-test01",
+        anchor=ChatAnchor(kind="note", path="20-Areas/note.md", title="A note"),
+        profile="balanced",
+        model="anthropic/claude-sonnet-4-6",
+        started_at="2026-05-12T11:00:00Z",
+        last_message_at="2026-05-12T11:00:00Z",
+        turn_count=0,
+    )
+    md = render_initial_chat(fm, "A note")
+    assert "type: chat" in md
+    assert "chat_id: chat-test01" in md
+    assert "kind: note" in md
+    assert "# Chat — A note" in md
+
+    p = tmp_path / "x.md"
+    p.write_text(md, encoding="utf-8")
+    parsed = parse_chat(p)
+    assert parsed is not None
+    assert parsed.chat_id == "chat-test01"
+    assert parsed.anchor.kind == "note"
+    assert parsed.anchor.path == "20-Areas/note.md"
+    assert parsed.profile == "balanced"
+    assert parsed.turn_count == 0
+    assert parsed.schema_version == CHAT_SCHEMA_VERSION
+
+
+def test_parse_chat_rejects_non_chat_files(tmp_path: Path):
+    other = tmp_path / "x.md"
+    other.write_text("---\ntype: evergreen\ntitle: X\n---\n\nbody\n", encoding="utf-8")
+    assert parse_chat(other) is None
+
+
+def test_parse_chat_returns_none_for_missing_or_empty(tmp_path: Path):
+    assert parse_chat(tmp_path / "nope.md") is None
+    empty = tmp_path / "empty.md"
+    empty.write_text("", encoding="utf-8")
+    assert parse_chat(empty) is None
+
+
+def test_parse_chat_coerces_invalid_enums_to_defaults(tmp_path: Path):
+    """Frontmatter with an unknown ``status`` value falls back rather
+    than raising — keeps the reader robust to operator edits."""
+    p = tmp_path / "x.md"
+    p.write_text(
+        "---\ntype: chat\nchat_id: c1\nstatus: weird\nvisibility: bogus\n"
+        "anchor:\n  kind: not-a-kind\n  path: x\n  title: y\n---\n\n# body\n",
+        encoding="utf-8",
+    )
+    fm = parse_chat(p)
+    assert fm is not None
+    assert fm.status == "active"
+    assert fm.visibility == "indexed"
+    assert fm.anchor.kind == "standalone"
+
+
+# ── session creation ────────────────────────────────────────────
+
+
+def test_new_chat_id_format():
+    cid = new_chat_id()
+    assert cid.startswith("chat-")
+    assert len(cid) == len("chat-") + 8
+
+
+def test_create_chat_file_writes_initial_state(tmp_path: Path):
+    path, fm = create_chat_file(
+        tmp_path,
+        anchor=ChatAnchor(kind="note", path="20-Areas/note.md", title="Note"),
+        profile="balanced",
+        model="anthropic/claude-sonnet-4-6",
+        topic="What does the digest say about X",
+    )
+    assert path.exists()
+    assert path.relative_to(tmp_path).parts[0] == "40-Resources"
+    assert fm.chat_id.startswith("chat-")
+    assert fm.turn_count == 0
+    text = path.read_text(encoding="utf-8")
+    assert "type: chat" in text
+    assert f"chat_id: {fm.chat_id}" in text
+
+
+def test_create_chat_file_rejects_bad_anchor_kind(tmp_path: Path):
+    with pytest.raises(ValueError, match="anchor kind"):
+        create_chat_file(
+            tmp_path,
+            anchor=ChatAnchor(kind="bogus"),
+        )
+
+
+def test_create_chat_file_rejects_bad_visibility(tmp_path: Path):
+    with pytest.raises(ValueError, match="visibility"):
+        create_chat_file(tmp_path, visibility="private")
+
+
+# ── append_turn ────────────────────────────────────────────────
+
+
+def test_append_user_turn_increments_count(tmp_path: Path):
+    path, fm = create_chat_file(tmp_path)
+    assert fm.turn_count == 0
+    new_fm = append_turn(
+        path,
+        role="user",
+        body="Hello, vault.",
+        timestamp="2026-05-12T11:00:01Z",
+    )
+    assert new_fm.turn_count == 1
+    assert new_fm.last_message_at == "2026-05-12T11:00:01Z"
+    text = path.read_text(encoding="utf-8")
+    assert "## User · 2026-05-12T11:00:01Z" in text
+    assert "Hello, vault." in text
+
+
+def test_append_assistant_turn_carries_manifest(tmp_path: Path):
+    path, _ = create_chat_file(tmp_path)
+    new_fm = append_turn(
+        path,
+        role="assistant",
+        body="Looking at [[evergreen-x]] ...",
+        timestamp="2026-05-12T11:00:02Z",
+        turn_number=2,
+        manifest_lines=[
+            "context_built_at: 2026-05-12T11:00:01Z",
+            "token_estimate: 8421",
+            "included_anchor: 20-Areas/note.md",
+        ],
+    )
+    assert new_fm.turn_count == 1
+    text = path.read_text(encoding="utf-8")
+    assert "## Assistant · 2026-05-12T11:00:02Z · turn-2" in text
+    assert "<!-- context-manifest" in text
+    assert "context_built_at: 2026-05-12T11:00:01Z" in text
+    assert "Looking at [[evergreen-x]]" in text
+
+
+def test_append_turn_rejects_bad_role(tmp_path: Path):
+    path, _ = create_chat_file(tmp_path)
+    with pytest.raises(ValueError, match="role"):
+        append_turn(path, role="system", body="x")
+
+
+def test_append_turn_refuses_non_chat_file(tmp_path: Path):
+    other = tmp_path / "x.md"
+    other.write_text("---\ntype: evergreen\n---\n\nbody\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="not type: chat"):
+        append_turn(other, role="user", body="hi")
+
+
+def test_mark_interrupted_records_partial_text(tmp_path: Path):
+    path, _ = create_chat_file(tmp_path)
+    new_fm = mark_interrupted(
+        path,
+        partial_body="streamed so far ...",
+        turn_number=2,
+        reason="client_disconnected",
+        timestamp="2026-05-12T11:01:30Z",
+    )
+    assert new_fm.turn_count == 1
+    text = path.read_text(encoding="utf-8")
+    assert "· turn-2 · interrupted" in text
+    assert "status: interrupted" in text
+    assert "client_disconnected" in text
+    assert "streamed so far ..." in text
+
+
+# ── pending_chat_block — stream-safe atomic append ─────────────
+
+
+def test_pending_chat_block_commit_writes_turn(tmp_path: Path):
+    path, _ = create_chat_file(tmp_path)
+    with pending_chat_block(path) as pending:
+        pending.turn_number = 2
+        pending.timestamp = "2026-05-12T11:00:05Z"
+        pending.append("Hello ")
+        pending.append("world.")
+        pending.commit(
+            manifest_lines=["token_estimate: 42"],
+        )
+    text = path.read_text(encoding="utf-8")
+    assert "Hello world." in text
+    assert "## Assistant · 2026-05-12T11:00:05Z · turn-2" in text
+    assert "token_estimate: 42" in text
+
+
+def test_pending_chat_block_no_commit_marks_interrupted(tmp_path: Path):
+    path, _ = create_chat_file(tmp_path)
+    with pending_chat_block(path) as pending:
+        pending.turn_number = 2
+        pending.timestamp = "2026-05-12T11:00:05Z"
+        pending.reason = "client_disconnected"
+        pending.append("partial stream ")
+        # No commit() before exit
+    text = path.read_text(encoding="utf-8")
+    assert "· turn-2 · interrupted" in text
+    assert "partial stream" in text
+    assert "client_disconnected" in text
+
+
+def test_pending_chat_block_exception_marks_interrupted(tmp_path: Path):
+    path, _ = create_chat_file(tmp_path)
+
+    class Boom(RuntimeError):
+        pass
+
+    with pytest.raises(Boom):
+        with pending_chat_block(path) as pending:
+            pending.turn_number = 2
+            pending.timestamp = "2026-05-12T11:00:05Z"
+            pending.append("crashed mid-stream ")
+            raise Boom("network fell out")
+
+    text = path.read_text(encoding="utf-8")
+    assert "· turn-2 · interrupted" in text
+    assert "crashed mid-stream" in text
+
+
+# ── atomic write integrity ────────────────────────────────────
+
+
+def test_atomic_write_leaves_no_temp_files_on_success(tmp_path: Path):
+    path, _ = create_chat_file(tmp_path)
+    append_turn(path, role="user", body="x", timestamp="2026-05-12T11:01:00Z")
+    siblings = list(path.parent.iterdir())
+    # Only the canonical .md file should remain — no .tmp leftovers.
+    suffixes = {p.suffix for p in siblings}
+    assert ".tmp" not in suffixes
+
+
+def test_chats_dir_constant_matches_plan():
+    """Lock the path so future BL changes notice a relocation."""
+    assert CHATS_DIR == "40-Resources/Chats"
+    assert CHAT_TYPE == "chat"

--- a/tests/test_chat_fileops.py
+++ b/tests/test_chat_fileops.py
@@ -230,7 +230,7 @@ def test_append_turn_rejects_bad_role(tmp_path: Path):
 def test_append_turn_refuses_non_chat_file(tmp_path: Path):
     other = tmp_path / "x.md"
     other.write_text("---\ntype: evergreen\n---\n\nbody\n", encoding="utf-8")
-    with pytest.raises(ValueError, match="not type: chat"):
+    with pytest.raises(ValueError, match="not a valid chat transcript"):
         append_turn(other, role="user", body="hi")
 
 
@@ -309,7 +309,8 @@ def test_atomic_write_leaves_no_temp_files_on_success(tmp_path: Path):
     path, _ = create_chat_file(tmp_path)
     append_turn(path, role="user", body="x", timestamp="2026-05-12T11:01:00Z")
     siblings = list(path.parent.iterdir())
-    # Only the canonical .md file should remain — no .tmp leftovers.
+    # Only the canonical .md file + the .lock sentinel remain — no
+    # .tmp leftovers.
     suffixes = {p.suffix for p in siblings}
     assert ".tmp" not in suffixes
 
@@ -318,3 +319,145 @@ def test_chats_dir_constant_matches_plan():
     """Lock the path so future BL changes notice a relocation."""
     assert CHATS_DIR == "40-Resources/Chats"
     assert CHAT_TYPE == "chat"
+
+
+# ── codex P2 — concurrent append safety ───────────────────────
+
+
+def test_concurrent_appends_serialize_via_per_chat_lock(tmp_path: Path):
+    """Two threaded appends against the same chat must both land.
+
+    Codex review P2: without the per-chat ``flock``, the later
+    writer's ``os.replace`` would drop the earlier writer's turn.
+    The test fires two appends concurrently and asserts both
+    turns appear + ``turn_count`` ends at exactly 2.
+    """
+    import threading
+
+    path, _ = create_chat_file(tmp_path)
+
+    results: list[Exception | None] = [None, None]
+
+    def append_one(idx: int, label: str, ts: str) -> None:
+        try:
+            append_turn(
+                path,
+                role="user",
+                body=f"message-{label}",
+                timestamp=ts,
+            )
+        except Exception as exc:  # pragma: no cover - test failure
+            results[idx] = exc
+
+    t1 = threading.Thread(
+        target=append_one,
+        args=(0, "alpha", "2026-05-12T11:00:01Z"),
+    )
+    t2 = threading.Thread(
+        target=append_one,
+        args=(1, "beta", "2026-05-12T11:00:02Z"),
+    )
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    assert results == [None, None]
+    text = path.read_text(encoding="utf-8")
+    assert "message-alpha" in text
+    assert "message-beta" in text
+    fm = parse_chat(path)
+    assert fm is not None
+    assert fm.turn_count == 2
+
+
+# ── codex P2 — manifest required for assistant ok turn ────────
+
+
+def test_assistant_ok_turn_requires_manifest(tmp_path: Path):
+    """Codex P2 — audit contract: every successful assistant turn
+    must carry a non-empty manifest snapshot.  Skipping it would
+    leave the operator unable to audit which context backed the
+    reply."""
+    path, _ = create_chat_file(tmp_path)
+    with pytest.raises(ValueError, match="manifest_lines is required"):
+        append_turn(
+            path,
+            role="assistant",
+            body="answer",
+            turn_number=1,
+            # No manifest_lines passed
+        )
+
+
+def test_assistant_ok_turn_accepts_explicit_no_context_manifest(
+    tmp_path: Path,
+):
+    """Operators that have nothing meaningful to record can pass
+    a single-line manifest like ``["note: no retrieval context"]``
+    — keeps the audit trail honest without forcing real context."""
+    path, _ = create_chat_file(tmp_path)
+    append_turn(
+        path,
+        role="assistant",
+        body="standalone answer",
+        timestamp="2026-05-12T11:00:02Z",
+        turn_number=1,
+        manifest_lines=["note: no retrieval context"],
+    )
+    text = path.read_text(encoding="utf-8")
+    assert "no retrieval context" in text
+
+
+# ── codex P2 — no duplicate turn after commit ─────────────────
+
+
+def test_pending_block_no_duplicate_after_commit(tmp_path: Path):
+    """Codex P2 — if the body raises *after* ``pending.commit()``
+    succeeded, do NOT also write an interrupted turn.  The commit
+    already produced a status: ok turn + bumped turn_count.
+    Double-writing would duplicate the response."""
+    path, _ = create_chat_file(tmp_path)
+
+    class PostCommitFailure(RuntimeError):
+        pass
+
+    with pytest.raises(PostCommitFailure):
+        with pending_chat_block(path) as pending:
+            pending.turn_number = 1
+            pending.timestamp = "2026-05-12T11:00:05Z"
+            pending.append("real answer")
+            pending.commit(manifest_lines=["token_estimate: 10"])
+            raise PostCommitFailure("downstream blew up")
+
+    fm = parse_chat(path)
+    assert fm is not None
+    # Exactly one assistant turn, not two.
+    assert fm.turn_count == 1
+    text = path.read_text(encoding="utf-8")
+    assert text.count("## Assistant · 2026-05-12T11:00:05Z") == 1
+    assert "interrupted" not in text
+
+
+# ── CodeRabbit — UTC handling ─────────────────────────────────
+
+
+def test_naive_started_at_emits_utc_iso(tmp_path: Path):
+    """A naive datetime passed to ``create_chat_file`` is treated as
+    UTC, so ``started_at`` / ``last_message_at`` end with ``Z``."""
+    naive = datetime(2026, 5, 12, 11, 0, 0)  # no tzinfo
+    _, fm = create_chat_file(tmp_path, started_at=naive)
+    assert fm.started_at.endswith("Z")
+    assert fm.last_message_at.endswith("Z")
+    assert "+00:00" not in fm.started_at
+
+
+def test_non_utc_aware_started_at_normalises_to_utc(tmp_path: Path):
+    """A non-UTC tz-aware datetime is converted to UTC, not pasted
+    as ``+05:00`` (which would break the implicit-UTC schema)."""
+    from datetime import timedelta
+
+    nyc = timezone(timedelta(hours=-5))
+    when = datetime(2026, 5, 12, 6, 0, 0, tzinfo=nyc)  # 11:00 UTC
+    _, fm = create_chat_file(tmp_path, started_at=when)
+    assert fm.started_at == "2026-05-12T11:00:00Z"


### PR DESCRIPTION
## Summary

Second PR for M21a (Anchored Inquiry MVP).  Single-writer fileops
for inquiry transcripts.

* New: ``src/ovp_pipeline/chat_fileops.py``
* New: ``tests/test_chat_fileops.py`` — 22 tests.

## Design rules locked in

1. **Single writer.** Mirrors ``live_concept_fileops``: only this
   module writes to ``40-Resources/Chats/**.md``.  Operators and
   other tools may edit, but the append-turn / interrupt path
   stays here.
2. **Append-only at the turn level.** Earlier turns are never
   rewritten — supports auditability and lets Obsidian's filewatch
   stay quiet between turns.
3. **Atomic writes.** ``mkstemp`` + ``fsync`` + ``os.replace`` so
   a crash mid-flush never produces a torn transcript.
4. **Manifest is audit-only.** The inline ``<!-- context-manifest
   ... -->`` block is what got bound at the time of the turn — the
   BL-083 binder will never re-read it.
5. **NO token counts in frontmatter.** ``turn_count`` +
   ``last_message_at`` only; cost accounting lives in the
   ``audit_events`` ledger (BL-084).
6. **Enum coercion at the boundary.** ``parse_chat`` falls back
   to defaults on unknown values so an operator hand-edit can't
   crash the reader; ``create_chat_file`` raises on bad input so
   programmatic callers can't write garbage.

## Test plan

- [x] ``rtk proxy python -m pytest tests/test_chat_fileops.py -q`` — 22 passed
- [x] ``ruff check`` + ``black --check`` clean on new files

## Plan reference

``docs/plans/2026-05-12-m21-chat-surface.md`` — BL-082 detail at
``### BL-082 — Chat markdown schema``.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create and manage chat transcript files with month-based paths, ordered YAML frontmatter, deterministic unique filenames, and session creation (validated anchors, visibility, timestamps).
  * Streaming-safe assistant message buffering with atomic commits and optional context manifests; interruption marking for partial/failed streams.

* **Bug Fixes**
  * Graceful filename-collision handling and robust frontmatter parsing/coercion.

* **Tests**
  * Comprehensive end-to-end and concurrency tests covering streaming, interruptions, atomicity, and time handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fakechris/obsidian_vault_pipeline/pull/211)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->