### PR TITLE
feat(bl-083): two-layer context binder (M21a step 3)

### DIFF
--- a/src/ovp_pipeline/context_binder.py
+++ b/src/ovp_pipeline/context_binder.py
@@ -1,0 +1,679 @@
+"""Anchored inquiry context binder (M21a / BL-083).
+
+Two-layer binder for the M21 inquiry handler:
+
+* **Anchor layer** — built *once* per session.  Loads the artifact
+  the operator is reading (note / object / crystal / standalone),
+  plus the linked evergreens / cluster neighbours that flesh it
+  out.  Stable across the whole inquiry session.
+* **Retrieval layer** — rebuilt *per turn* from the user's current
+  question.  Wraps :func:`ovp_pipeline.discovery.discover_related`
+  (the same helper that powers ``ovp-query``) plus open
+  contradictions + crystal scores.  Does NOT reimplement RAG.
+
+The binder's job is **selection + budgeting**, not retrieval.  It
+picks the top-N items from each retrieval source within a
+per-turn budget, drops in priority order on overflow, and records
+every drop in the manifest's ``omitted_*`` fields.
+
+Token budgeting
+---------------
+
+The handler tells the binder its profile's input cap; the binder
+allocates roughly 60% to the anchor layer and 40% to retrieval,
+keeping the literal anchor body inviolate even under pressure.
+Token estimates are computed via a 4-chars-per-token proxy — fast
+and accurate enough to pick which items to drop.  BL-084's actual
+LLM call may use ``tiktoken`` for the precise count.
+
+Manifest as audit-only
+----------------------
+
+The :class:`ContextManifest` returned here is what gets serialised
+into the assistant turn's inline HTML comment.  It is **not**
+re-read by the binder on future turns — every turn rebuilds
+context fresh from current vault state.  Operators editing the
+markdown manifest don't change system behaviour, only what future
+audits show.
+
+Turn-history compression
+------------------------
+
+Rolling-window helpers (:func:`select_verbatim_window`,
+:func:`should_rebuild_summary`) live here so BL-084 can plug in
+its own LLM summary writer without re-deriving the policy.  The
+LLM summary call itself is BL-084's responsibility.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+from ovp_pipeline.context_loader import load_llm_context
+from ovp_pipeline.runtime import resolve_vault_dir
+
+logger = logging.getLogger(__name__)
+
+
+# ── Token-budget knobs (defaults match the M21 plan) ────────────
+
+
+# Fraction of the per-request input cap allocated to the anchor
+# layer before retrieval gets the remainder.  60% keeps the
+# artifact-under-discussion in dominant context even when the user
+# asks something with a lot of vault matches.
+ANCHOR_BUDGET_FRACTION: float = 0.6
+
+# Char-to-token proxy.  Real BPE depends on the tokenizer but
+# Anthropic + OpenAI both average ~4 ASCII chars / token.  CJK is
+# closer to 1.5 chars / token but we under-budget on purpose to
+# leave headroom.
+_CHARS_PER_TOKEN: int = 4
+
+# Conservative safety margin pulled off the top of the input cap
+# before splitting between anchor + retrieval.  Covers BL-075's
+# USER + RULES prefix and the system prompt frame the handler
+# adds before the manifest.
+SYSTEM_FRAME_MARGIN_TOKENS: int = 1500
+
+# Turn-history compression policy (plan reference: BL-083 section).
+TURN_HISTORY_VERBATIM_K: int = 4
+TURN_HISTORY_SUMMARY_MAX_TOKENS: int = 600
+
+
+# ── Anchor kinds ────────────────────────────────────────────────
+
+
+ANCHOR_KINDS: frozenset[str] = frozenset({"note", "object", "crystal", "standalone"})
+
+
+# ── Data model ──────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class AnchorContext:
+    """Fixed-per-session context grounded in one artifact.
+
+    For ``kind == "standalone"`` the operator opened ``/chat``
+    without an anchor; ``included_anchor`` is empty and the
+    retrieval layer carries the whole load.
+    """
+
+    kind: str
+    ref: str
+    included_anchor: str = ""
+    included_evergreens: tuple[str, ...] = ()
+    included_crystals: tuple[str, ...] = ()
+    token_estimate: int = 0
+
+
+@dataclass(frozen=True)
+class RetrievalContext:
+    """Per-turn context, rebuilt from the user's message."""
+
+    query: str
+    included_objects: tuple[str, ...] = ()
+    included_crystals: tuple[str, ...] = ()
+    included_contradictions: tuple[str, ...] = ()
+    token_estimate: int = 0
+
+
+@dataclass(frozen=True)
+class ContextManifest:
+    """Audit snapshot of what context backed an assistant turn.
+
+    Serialised into the inline ``<!-- context-manifest ... -->``
+    HTML comment via :func:`manifest_to_lines`.  Never re-read.
+    """
+
+    anchor: AnchorContext
+    retrieval: RetrievalContext
+    omitted_count: int = 0
+    omitted_reason: str = ""
+    token_estimate_total: int = 0
+    context_built_at: str = ""
+
+
+# ── Public API ─────────────────────────────────────────────────
+
+
+def estimate_tokens(text: str) -> int:
+    """Rough char-count proxy for token estimation.
+
+    Deliberately under-estimates so the budget has headroom.
+    Used for selection / budgeting only — the handler's real LLM
+    call may use a tokenizer-accurate count.
+    """
+    if not text:
+        return 0
+    return max(1, len(text) // _CHARS_PER_TOKEN)
+
+
+def split_budget(
+    profile_input_cap: int,
+    *,
+    turn_history_tokens: int = 0,
+    margin_tokens: int = SYSTEM_FRAME_MARGIN_TOKENS,
+) -> tuple[int, int]:
+    """Return (anchor_budget, retrieval_budget) given the profile cap.
+
+    Subtracts ``margin_tokens`` for the system prompt frame and
+    ``turn_history_tokens`` for the rolling turn-history window,
+    then splits the remainder ~60/40.  Returns ``(0, 0)`` when the
+    cap is too tight to leave any room — the handler then refuses
+    the request.
+    """
+    available = profile_input_cap - margin_tokens - max(0, turn_history_tokens)
+    if available <= 0:
+        return 0, 0
+    anchor_budget = int(available * ANCHOR_BUDGET_FRACTION)
+    retrieval_budget = available - anchor_budget
+    return anchor_budget, retrieval_budget
+
+
+def build_chat_context(
+    vault_dir: Path | str,
+    *,
+    anchor_kind: str,
+    anchor_ref: str,
+    user_message: str,
+    profile_input_cap: int,
+    turn_history_tokens: int = 0,
+) -> tuple[str, ContextManifest]:
+    """Build (system_prompt_body, manifest) for one inquiry turn.
+
+    Two-layer construction:
+
+    1. Anchor context (fixed-per-session shape, but built here
+       so the handler doesn't carry it through the binder
+       boundary): the artifact body + linked evergreens / cluster
+       neighbours.  See :func:`build_anchor_context`.
+    2. Retrieval context (per turn): wraps ``discover_related``
+       to pull FTS + semantic hits scoped to the user message.
+       See :func:`build_retrieval_context`.
+
+    ``system_prompt_body`` is what the handler concatenates after
+    BL-075's USER + RULES prefix (loaded inline here when the
+    handler hasn't already attached it; safe to dedup downstream).
+
+    Raises :class:`ValueError` for unknown ``anchor_kind``.
+    """
+    if anchor_kind not in ANCHOR_KINDS:
+        raise ValueError(
+            f"unknown anchor kind {anchor_kind!r}; " f"expected one of {sorted(ANCHOR_KINDS)}"
+        )
+
+    vault = resolve_vault_dir(vault_dir)
+    anchor_budget, retrieval_budget = split_budget(
+        profile_input_cap,
+        turn_history_tokens=turn_history_tokens,
+    )
+
+    anchor = build_anchor_context(
+        vault,
+        anchor_kind=anchor_kind,
+        anchor_ref=anchor_ref,
+        budget_tokens=anchor_budget,
+    )
+    retrieval = build_retrieval_context(
+        vault,
+        query=user_message,
+        budget_tokens=retrieval_budget,
+    )
+
+    omitted_count, omitted_reason = _summarise_omissions(
+        anchor,
+        retrieval,
+        anchor_budget,
+        retrieval_budget,
+    )
+    total_tokens = anchor.token_estimate + retrieval.token_estimate
+
+    manifest = ContextManifest(
+        anchor=anchor,
+        retrieval=retrieval,
+        omitted_count=omitted_count,
+        omitted_reason=omitted_reason,
+        token_estimate_total=total_tokens,
+        context_built_at=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    )
+
+    prefix = load_llm_context(vault)
+    system_prompt_body = _render_system_prompt(
+        prefix=prefix,
+        anchor=anchor,
+        retrieval=retrieval,
+    )
+    return system_prompt_body, manifest
+
+
+def manifest_to_lines(m: ContextManifest) -> list[str]:
+    """Serialise a manifest to the ``manifest_lines`` list that
+    :func:`ovp_pipeline.chat_fileops.append_turn` accepts.
+
+    Format matches the plan-doc example (``key: value`` lines that
+    render inside ``<!-- context-manifest ... -->``).
+    """
+    lines: list[str] = []
+    lines.append(f"context_built_at: {m.context_built_at}")
+    lines.append(f"token_estimate: {m.token_estimate_total}")
+    lines.append(f"anchor_kind: {m.anchor.kind}")
+    if m.anchor.ref:
+        lines.append(f"anchor_ref: {m.anchor.ref}")
+    if m.anchor.included_evergreens:
+        lines.append("included_evergreens:")
+        for slug in m.anchor.included_evergreens:
+            lines.append(f"  - {slug}")
+    if m.anchor.included_crystals:
+        lines.append("included_anchor_crystals:")
+        for slug in m.anchor.included_crystals:
+            lines.append(f"  - {slug}")
+    if m.retrieval.included_objects:
+        lines.append("retrieval_objects:")
+        for slug in m.retrieval.included_objects:
+            lines.append(f"  - {slug}")
+    if m.retrieval.included_crystals:
+        lines.append("retrieval_crystals:")
+        for slug in m.retrieval.included_crystals:
+            lines.append(f"  - {slug}")
+    if m.retrieval.included_contradictions:
+        lines.append("retrieval_contradictions:")
+        for slug in m.retrieval.included_contradictions:
+            lines.append(f"  - {slug}")
+    if m.omitted_count > 0:
+        lines.append("omitted_items:")
+        lines.append(f"  count: {m.omitted_count}")
+        lines.append(f"  reason: {m.omitted_reason}")
+    return lines
+
+
+# ── Anchor layer ───────────────────────────────────────────────
+
+
+def build_anchor_context(
+    vault_dir: Path | str,
+    *,
+    anchor_kind: str,
+    anchor_ref: str,
+    budget_tokens: int,
+) -> AnchorContext:
+    """Load the anchor artifact + linked evergreens within the budget.
+
+    The literal anchor body is always preserved (it's *what the
+    operator is reading*); cluster neighbours / evergreens are
+    dropped first when the budget is tight.
+
+    For ``standalone`` anchors, returns an empty context — the
+    operator's USER + RULES prefix is enough.
+
+    Loads are tolerant: a missing file produces an empty
+    ``included_anchor`` rather than raising, so the handler can
+    still answer (operator may have moved or renamed the file).
+    """
+    vault = resolve_vault_dir(vault_dir)
+    if anchor_kind == "standalone" or budget_tokens <= 0:
+        return AnchorContext(kind=anchor_kind, ref=anchor_ref)
+
+    body = _load_anchor_body(vault, anchor_kind, anchor_ref)
+    body_tokens = estimate_tokens(body)
+    if body_tokens > budget_tokens:
+        # Truncate but record — never drop the anchor entirely.
+        body = _truncate_to_tokens(body, budget_tokens)
+        body_tokens = estimate_tokens(body)
+
+    remaining = max(0, budget_tokens - body_tokens)
+    evergreens: tuple[str, ...] = ()
+    crystals: tuple[str, ...] = ()
+    if remaining > 0:
+        evergreens = _select_anchor_evergreens(
+            vault,
+            anchor_kind,
+            anchor_ref,
+            remaining,
+        )
+        crystals = _select_anchor_crystals(
+            vault,
+            anchor_kind,
+            anchor_ref,
+            remaining,
+        )
+
+    return AnchorContext(
+        kind=anchor_kind,
+        ref=anchor_ref,
+        included_anchor=body,
+        included_evergreens=evergreens,
+        included_crystals=crystals,
+        token_estimate=body_tokens,
+    )
+
+
+def _load_anchor_body(
+    vault: Path,
+    kind: str,
+    ref: str,
+) -> str:
+    """Return the body of the anchor artifact.
+
+    ``ref`` interpretation:
+    * ``note`` / ``object`` — vault-relative path.
+    * ``crystal`` — vault-relative path or crystal slug.
+
+    Returns ``""`` when the artifact can't be loaded — the handler
+    still answers from retrieval + USER + RULES.
+    """
+    if not ref:
+        return ""
+    candidate = vault / ref
+    if candidate.is_file():
+        try:
+            return candidate.read_text(encoding="utf-8")
+        except OSError as exc:
+            logger.debug(
+                "context_binder: failed to read anchor %s: %s",
+                candidate,
+                exc,
+            )
+            return ""
+    logger.debug(
+        "context_binder: anchor %s (kind=%s) not found at %s",
+        ref,
+        kind,
+        candidate,
+    )
+    return ""
+
+
+def _select_anchor_evergreens(
+    vault: Path,
+    kind: str,
+    ref: str,
+    budget_tokens: int,
+) -> tuple[str, ...]:
+    """Return slugs of evergreens the anchor links to.
+
+    Defensive against a missing knowledge.db — returns ``()``
+    rather than raising.  The actual list comes from the existing
+    discovery helpers, scoped to slugs that the anchor body
+    mentions.  Future BLs (#085 + projection rebuild) will wire
+    in the full evergreen-link join.
+    """
+    # First-version implementation: parse [[wikilink]] targets out
+    # of the anchor body — discovers links without needing the DB.
+    # The retrieval layer fills in semantically-related items the
+    # anchor doesn't explicitly link to.
+    if budget_tokens <= 0 or not ref:
+        return ()
+    body = _load_anchor_body(vault, kind, ref)
+    if not body:
+        return ()
+    import re as _re
+
+    found: list[str] = []
+    seen: set[str] = set()
+    for match in _re.finditer(r"\[\[([^\]|#]+?)(?:\|[^\]]+)?\]\]", body):
+        slug = match.group(1).strip()
+        if not slug or slug in seen:
+            continue
+        seen.add(slug)
+        found.append(slug)
+        # Char-count proxy: each evergreen reference costs a couple
+        # hundred tokens of body in the real prompt.  Bound the
+        # selection here based on the budget.
+        if len(found) * 200 >= budget_tokens:
+            break
+    return tuple(found)
+
+
+def _select_anchor_crystals(
+    vault: Path,
+    kind: str,
+    ref: str,
+    budget_tokens: int,
+) -> tuple[str, ...]:
+    """Crystal anchor neighbours.
+
+    Stub: returns ``()`` for v1.  BL-085's projection adds the
+    join over ``crystal_scores`` so the binder can surface the
+    top community / contradiction crystals adjacent to the
+    anchor.  Until that lands, the retrieval layer covers it.
+    """
+    return ()
+
+
+# ── Retrieval layer ────────────────────────────────────────────
+
+
+def build_retrieval_context(
+    vault_dir: Path | str,
+    *,
+    query: str,
+    budget_tokens: int,
+    top_k: int = 10,
+) -> RetrievalContext:
+    """Pull FTS + semantic hits for the user message.
+
+    Wraps :func:`ovp_pipeline.discovery.discover_related` — the
+    same helper that powers ``ovp-query``.  Returns at most
+    ``top_k`` slugs, trimmed further by ``budget_tokens``.
+
+    Defensive on missing knowledge.db: returns an empty context
+    rather than raising so the handler can still answer from the
+    anchor + system frame.
+    """
+    if budget_tokens <= 0 or not query.strip():
+        return RetrievalContext(query=query)
+
+    try:
+        from ovp_pipeline.discovery import discover_related
+
+        rows = discover_related(
+            resolve_vault_dir(vault_dir),
+            query,
+            engine="knowledge",
+            limit=top_k,
+        )
+    except Exception as exc:
+        # Don't take down the inquiry surface when the DB isn't
+        # ready — degrade to anchor-only.
+        logger.warning(
+            "context_binder: discover_related failed (%s); " "retrieval layer empty",
+            exc,
+        )
+        return RetrievalContext(query=query)
+
+    object_slugs: list[str] = []
+    crystal_slugs: list[str] = []
+    used_tokens = 0
+    # Rough estimate: each row contributes ~300 tokens of body to
+    # the prompt.  Bound by the budget.
+    per_row_tokens = 300
+    for row in rows:
+        slug = str(row.get("slug") or row.get("path") or "").strip()
+        if not slug:
+            continue
+        if used_tokens + per_row_tokens > budget_tokens:
+            break
+        # Some rows are crystals; classify by ``kind`` if present.
+        kind = str(row.get("kind") or row.get("object_kind") or "")
+        if "crystal" in kind:
+            crystal_slugs.append(slug)
+        else:
+            object_slugs.append(slug)
+        used_tokens += per_row_tokens
+
+    return RetrievalContext(
+        query=query,
+        included_objects=tuple(object_slugs),
+        included_crystals=tuple(crystal_slugs),
+        included_contradictions=(),  # filled in by BL-084 / BL-085
+        token_estimate=used_tokens,
+    )
+
+
+# ── Turn-history compression policy ────────────────────────────
+
+
+@dataclass(frozen=True)
+class TurnPair:
+    """One user/assistant pair from the turn history."""
+
+    user_body: str
+    assistant_body: str
+    turn_number: int
+
+
+def select_verbatim_window(
+    pairs: Iterable[TurnPair],
+    k: int = TURN_HISTORY_VERBATIM_K,
+) -> tuple[list[TurnPair], list[TurnPair]]:
+    """Split turn history into (older, recent) at the K boundary.
+
+    The most-recent ``k`` pairs go into the verbatim window
+    (kept as-is in the prompt); earlier pairs need a summary.
+    Empty history returns ``([], [])``.
+    """
+    pair_list = list(pairs)
+    if not pair_list:
+        return [], []
+    pair_list.sort(key=lambda p: p.turn_number)
+    if len(pair_list) <= k:
+        return [], pair_list
+    return pair_list[:-k], pair_list[-k:]
+
+
+def should_rebuild_summary(
+    cached_summary_through_turn: int,
+    older_pairs: list[TurnPair],
+) -> bool:
+    """Return True when the summary cache needs a refresh.
+
+    The cache stores the last-turn-number it summarised through;
+    when the verbatim window has slid (i.e. there are older pairs
+    whose turn_number exceeds the cached value), the summary needs
+    a new pass.  BL-084 owns the actual LLM call.
+    """
+    if not older_pairs:
+        return False
+    newest_older = max(p.turn_number for p in older_pairs)
+    return newest_older > cached_summary_through_turn
+
+
+# ── Internal: prompt rendering + omission summary ──────────────
+
+
+def _render_system_prompt(
+    *,
+    prefix: str,
+    anchor: AnchorContext,
+    retrieval: RetrievalContext,
+) -> str:
+    """Combine USER + RULES + anchor + retrieval into one prompt body.
+
+    Shape:
+
+    * BL-075 prefix (USER profile + autonomous-action rules)
+    * Anchor section (only when non-empty)
+    * Retrieval section (only when non-empty)
+
+    Empty sections are skipped so a standalone inquiry doesn't
+    waste tokens on placeholder headings.
+    """
+    parts: list[str] = []
+    if prefix:
+        parts.append(prefix.rstrip())
+    if anchor.included_anchor:
+        parts.append(
+            f"# Anchor — {anchor.kind}: {anchor.ref}\n\n" f"{anchor.included_anchor.rstrip()}"
+        )
+        if anchor.included_evergreens:
+            parts.append(
+                "## Linked evergreens\n\n"
+                + "\n".join(f"- [[{slug}]]" for slug in anchor.included_evergreens)
+            )
+    if (
+        retrieval.included_objects
+        or retrieval.included_crystals
+        or retrieval.included_contradictions
+    ):
+        bullets: list[str] = []
+        if retrieval.included_objects:
+            bullets.extend(f"- object: [[{slug}]]" for slug in retrieval.included_objects)
+        if retrieval.included_crystals:
+            bullets.extend(f"- crystal: [[{slug}]]" for slug in retrieval.included_crystals)
+        if retrieval.included_contradictions:
+            bullets.extend(
+                f"- contradiction: [[{slug}]]" for slug in retrieval.included_contradictions
+            )
+        parts.append("# Retrieval — vault hits for this turn\n\n" + "\n".join(bullets))
+    return "\n\n".join(parts) + ("\n" if parts else "")
+
+
+def _summarise_omissions(
+    anchor: AnchorContext,
+    retrieval: RetrievalContext,
+    anchor_budget: int,
+    retrieval_budget: int,
+) -> tuple[int, str]:
+    """Crude estimate of how many items were dropped due to budget.
+
+    The selectors return only what fit; this function compares the
+    realised counts against soft targets and surfaces a reason.
+    """
+    omitted = 0
+    reasons: list[str] = []
+    # Anchor pressure: if the body had to be truncated.
+    if anchor.token_estimate > 0 and anchor.token_estimate >= anchor_budget:
+        omitted += 1
+        reasons.append("anchor_truncated_to_budget")
+    # Retrieval pressure: if we filled near the budget, treat the
+    # tail as omitted.
+    if retrieval.token_estimate > 0 and retrieval.token_estimate >= retrieval_budget * 0.8:
+        omitted += 1
+        reasons.append("retrieval_budget_filled")
+    if not reasons:
+        return 0, ""
+    return omitted, ",".join(reasons)
+
+
+def _truncate_to_tokens(text: str, budget_tokens: int) -> str:
+    """Truncate ``text`` to roughly ``budget_tokens`` worth of chars.
+
+    Trims on a paragraph boundary when possible so a half-sentence
+    isn't passed to the LLM.
+    """
+    if budget_tokens <= 0:
+        return ""
+    max_chars = max(1, budget_tokens * _CHARS_PER_TOKEN)
+    if len(text) <= max_chars:
+        return text
+    truncated = text[:max_chars]
+    last_para = truncated.rfind("\n\n")
+    if last_para > max_chars // 2:
+        truncated = truncated[:last_para]
+    return truncated.rstrip() + "\n\n[truncated — anchor body exceeded budget]\n"
+
+
+__all__ = [
+    "ANCHOR_KINDS",
+    "ANCHOR_BUDGET_FRACTION",
+    "AnchorContext",
+    "ContextManifest",
+    "RetrievalContext",
+    "SYSTEM_FRAME_MARGIN_TOKENS",
+    "TURN_HISTORY_SUMMARY_MAX_TOKENS",
+    "TURN_HISTORY_VERBATIM_K",
+    "TurnPair",
+    "build_anchor_context",
+    "build_chat_context",
+    "build_retrieval_context",
+    "estimate_tokens",
+    "manifest_to_lines",
+    "select_verbatim_window",
+    "should_rebuild_summary",
+    "split_budget",
+]

--- a/src/ovp_pipeline/context_binder.py
+++ b/src/ovp_pipeline/context_binder.py
@@ -48,13 +48,14 @@ LLM summary call itself is BL-084's responsibility.
 from __future__ import annotations
 
 import logging
+import re
+from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterable
 
 from ovp_pipeline.context_loader import load_llm_context
-from ovp_pipeline.runtime import resolve_vault_dir
+from ovp_pipeline.runtime import resolve_vault_dir, split_markdown_frontmatter
 
 logger = logging.getLogger(__name__)
 
@@ -84,6 +85,15 @@ SYSTEM_FRAME_MARGIN_TOKENS: int = 1500
 TURN_HISTORY_VERBATIM_K: int = 4
 TURN_HISTORY_SUMMARY_MAX_TOKENS: int = 600
 
+# Token estimates per selected item.  Named to keep the budget math
+# explicit (CodeRabbit M — replace magic numbers).
+_TOKENS_PER_LINKED_EVERGREEN: int = 200
+_TOKENS_PER_RETRIEVAL_ROW: int = 300
+
+# Compiled once — used by ``_select_anchor_evergreens`` to harvest
+# ``[[wikilinks]]`` from the anchor body.
+_WIKILINK_RE = re.compile(r"\[\[([^\]|#]+?)(?:\|[^\]]+)?\]\]")
+
 
 # ── Anchor kinds ────────────────────────────────────────────────
 
@@ -112,14 +122,40 @@ class AnchorContext:
 
 
 @dataclass(frozen=True)
+class RetrievalHit:
+    """One vault hit selected for the retrieval layer.
+
+    ``slug`` + ``kind`` go into the manifest; ``title`` + ``snippet``
+    + ``path`` end up in the prompt body so the LLM sees actual
+    evidence text, not just a list of links (codex review P2).
+    """
+
+    slug: str
+    kind: str  # "object" | "crystal" | "contradiction"
+    title: str = ""
+    path: str = ""
+    snippet: str = ""
+
+
+@dataclass(frozen=True)
 class RetrievalContext:
     """Per-turn context, rebuilt from the user's message."""
 
     query: str
-    included_objects: tuple[str, ...] = ()
-    included_crystals: tuple[str, ...] = ()
-    included_contradictions: tuple[str, ...] = ()
+    hits: tuple[RetrievalHit, ...] = ()
     token_estimate: int = 0
+
+    @property
+    def included_objects(self) -> tuple[str, ...]:
+        return tuple(h.slug for h in self.hits if h.kind == "object")
+
+    @property
+    def included_crystals(self) -> tuple[str, ...]:
+        return tuple(h.slug for h in self.hits if h.kind == "crystal")
+
+    @property
+    def included_contradictions(self) -> tuple[str, ...]:
+        return tuple(h.slug for h in self.hits if h.kind == "contradiction")
 
 
 @dataclass(frozen=True)
@@ -329,12 +365,7 @@ def build_anchor_context(
     evergreens: tuple[str, ...] = ()
     crystals: tuple[str, ...] = ()
     if remaining > 0:
-        evergreens = _select_anchor_evergreens(
-            vault,
-            anchor_kind,
-            anchor_ref,
-            remaining,
-        )
+        evergreens = _select_anchor_evergreens(body, remaining)
         crystals = _select_anchor_crystals(
             vault,
             anchor_kind,
@@ -352,6 +383,45 @@ def build_anchor_context(
     )
 
 
+def _resolve_anchor_path(vault: Path, ref: str) -> Path | None:
+    """Resolve ``ref`` to an absolute path inside ``vault``, or ``None``.
+
+    Codex review P1: ``vault / "/etc/passwd"`` resolves to
+    ``/etc/passwd`` (absolute paths override the left operand) and
+    ``vault / "../etc/passwd"`` escapes the vault root.  Since
+    chat frontmatter stores ``anchor.path`` as an unchecked
+    string, a crafted session could otherwise read arbitrary
+    local files into the system prompt.  This helper:
+
+    * rejects absolute refs
+    * rejects refs whose resolved path doesn't sit under the
+      resolved vault root
+    * returns ``None`` on either failure so callers degrade
+      cleanly to "no anchor body" rather than raising
+    """
+    if not ref:
+        return None
+    candidate_rel = Path(ref)
+    if candidate_rel.is_absolute():
+        logger.warning(
+            "context_binder: rejecting absolute anchor ref %r",
+            ref,
+        )
+        return None
+    resolved_vault = vault.resolve()
+    candidate = (resolved_vault / candidate_rel).resolve()
+    try:
+        candidate.relative_to(resolved_vault)
+    except ValueError:
+        logger.warning(
+            "context_binder: rejecting out-of-vault anchor ref %r " "(resolved to %s)",
+            ref,
+            candidate,
+        )
+        return None
+    return candidate
+
+
 def _load_anchor_body(
     vault: Path,
     kind: str,
@@ -364,67 +434,58 @@ def _load_anchor_body(
     * ``crystal`` — vault-relative path or crystal slug.
 
     Returns ``""`` when the artifact can't be loaded — the handler
-    still answers from retrieval + USER + RULES.
+    still answers from retrieval + USER + RULES.  Strips
+    frontmatter before returning so the prompt budget reflects
+    real content, not YAML metadata (CodeRabbit M).
     """
-    if not ref:
+    candidate = _resolve_anchor_path(vault, ref)
+    if candidate is None:
         return ""
-    candidate = vault / ref
-    if candidate.is_file():
-        try:
-            return candidate.read_text(encoding="utf-8")
-        except OSError as exc:
-            logger.debug(
-                "context_binder: failed to read anchor %s: %s",
-                candidate,
-                exc,
-            )
-            return ""
-    logger.debug(
-        "context_binder: anchor %s (kind=%s) not found at %s",
-        ref,
-        kind,
-        candidate,
-    )
-    return ""
+    if not candidate.is_file():
+        logger.debug(
+            "context_binder: anchor %s (kind=%s) not found at %s",
+            ref,
+            kind,
+            candidate,
+        )
+        return ""
+    try:
+        raw = candidate.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger.debug(
+            "context_binder: failed to read anchor %s: %s",
+            candidate,
+            exc,
+        )
+        return ""
+    _, body = split_markdown_frontmatter(raw)
+    return body
 
 
 def _select_anchor_evergreens(
-    vault: Path,
-    kind: str,
-    ref: str,
+    body: str,
     budget_tokens: int,
 ) -> tuple[str, ...]:
-    """Return slugs of evergreens the anchor links to.
+    """Return slugs of evergreens the anchor body links to.
 
-    Defensive against a missing knowledge.db — returns ``()``
-    rather than raising.  The actual list comes from the existing
-    discovery helpers, scoped to slugs that the anchor body
-    mentions.  Future BLs (#085 + projection rebuild) will wire
-    in the full evergreen-link join.
+    First-version implementation: parses ``[[wikilink]]`` targets
+    out of the already-loaded anchor body — discovers links
+    without needing the DB.  The retrieval layer fills in
+    semantically-related items the anchor doesn't explicitly link
+    to.  CodeRabbit M: takes ``body`` directly to avoid the
+    redundant disk read.
     """
-    # First-version implementation: parse [[wikilink]] targets out
-    # of the anchor body — discovers links without needing the DB.
-    # The retrieval layer fills in semantically-related items the
-    # anchor doesn't explicitly link to.
-    if budget_tokens <= 0 or not ref:
+    if budget_tokens <= 0 or not body:
         return ()
-    body = _load_anchor_body(vault, kind, ref)
-    if not body:
-        return ()
-    import re as _re
-
     found: list[str] = []
     seen: set[str] = set()
-    for match in _re.finditer(r"\[\[([^\]|#]+?)(?:\|[^\]]+)?\]\]", body):
+    for match in _WIKILINK_RE.finditer(body):
         slug = match.group(1).strip()
         if not slug or slug in seen:
             continue
         seen.add(slug)
         found.append(slug)
-        # Char-count proxy: each evergreen reference costs a couple
-        # hundred tokens of body in the real prompt.  Bound the
-        # selection here based on the budget.
-        if len(found) * 200 >= budget_tokens:
+        if len(found) * _TOKENS_PER_LINKED_EVERGREEN >= budget_tokens:
             break
     return tuple(found)
 
@@ -481,36 +542,49 @@ def build_retrieval_context(
         # Don't take down the inquiry surface when the DB isn't
         # ready — degrade to anchor-only.
         logger.warning(
-            "context_binder: discover_related failed (%s); " "retrieval layer empty",
+            "context_binder: discover_related failed (%s); retrieval layer empty",
             exc,
         )
         return RetrievalContext(query=query)
 
-    object_slugs: list[str] = []
-    crystal_slugs: list[str] = []
+    hits: list[RetrievalHit] = []
     used_tokens = 0
-    # Rough estimate: each row contributes ~300 tokens of body to
-    # the prompt.  Bound by the budget.
-    per_row_tokens = 300
     for row in rows:
-        slug = str(row.get("slug") or row.get("path") or "").strip()
-        if not slug:
+        slug = str(row.get("slug") or "").strip()
+        path = str(row.get("path") or "").strip()
+        if not slug and not path:
             continue
-        if used_tokens + per_row_tokens > budget_tokens:
+        if not slug:
+            slug = path
+        if used_tokens + _TOKENS_PER_RETRIEVAL_ROW > budget_tokens:
             break
-        # Some rows are crystals; classify by ``kind`` if present.
-        kind = str(row.get("kind") or row.get("object_kind") or "")
-        if "crystal" in kind:
-            crystal_slugs.append(slug)
+        # Codex review P2: ``row['kind']`` is the *retrieval mode*
+        # (``lexical`` / ``semantic`` / ``fts``), not the object
+        # kind.  Use ``object_kind`` for classification — that's
+        # the annotation discover_related adds for crystals.
+        object_kind = str(row.get("object_kind") or "")
+        if "contradiction" in object_kind:
+            hit_kind = "contradiction"
+        elif "crystal" in object_kind:
+            hit_kind = "crystal"
         else:
-            object_slugs.append(slug)
-        used_tokens += per_row_tokens
+            hit_kind = "object"
+        snippet = str(row.get("snippet") or row.get("excerpt") or "").strip()
+        title = str(row.get("title") or slug).strip()
+        hits.append(
+            RetrievalHit(
+                slug=slug,
+                kind=hit_kind,
+                title=title,
+                path=path,
+                snippet=snippet,
+            )
+        )
+        used_tokens += _TOKENS_PER_RETRIEVAL_ROW
 
     return RetrievalContext(
         query=query,
-        included_objects=tuple(object_slugs),
-        included_crystals=tuple(crystal_slugs),
-        included_contradictions=(),  # filled in by BL-084 / BL-085
+        hits=tuple(hits),
         token_estimate=used_tokens,
     )
 
@@ -587,29 +661,25 @@ def _render_system_prompt(
     if prefix:
         parts.append(prefix.rstrip())
     if anchor.included_anchor:
-        parts.append(
-            f"# Anchor — {anchor.kind}: {anchor.ref}\n\n" f"{anchor.included_anchor.rstrip()}"
-        )
+        parts.append(f"# Anchor — {anchor.kind}: {anchor.ref}\n\n{anchor.included_anchor.rstrip()}")
         if anchor.included_evergreens:
             parts.append(
                 "## Linked evergreens\n\n"
                 + "\n".join(f"- [[{slug}]]" for slug in anchor.included_evergreens)
             )
-    if (
-        retrieval.included_objects
-        or retrieval.included_crystals
-        or retrieval.included_contradictions
-    ):
-        bullets: list[str] = []
-        if retrieval.included_objects:
-            bullets.extend(f"- object: [[{slug}]]" for slug in retrieval.included_objects)
-        if retrieval.included_crystals:
-            bullets.extend(f"- crystal: [[{slug}]]" for slug in retrieval.included_crystals)
-        if retrieval.included_contradictions:
-            bullets.extend(
-                f"- contradiction: [[{slug}]]" for slug in retrieval.included_contradictions
-            )
-        parts.append("# Retrieval — vault hits for this turn\n\n" + "\n".join(bullets))
+    if retrieval.hits:
+        # Codex review P2: emit the snippet / title / path text the
+        # retrieval stack returned — not just a list of [[slugs]] —
+        # so the LLM has actual evidence to reason over.
+        blocks: list[str] = []
+        for hit in retrieval.hits:
+            header = f"### {hit.kind}: {hit.title or hit.slug}"
+            ref_line = f"slug: [[{hit.slug}]]"
+            if hit.path:
+                ref_line += f"   ·   path: {hit.path}"
+            body_line = hit.snippet or "(no snippet)"
+            blocks.append(f"{header}\n\n{ref_line}\n\n{body_line}")
+        parts.append("# Retrieval — vault hits for this turn\n\n" + "\n\n".join(blocks))
     return "\n\n".join(parts) + ("\n" if parts else "")
 
 
@@ -626,8 +696,10 @@ def _summarise_omissions(
     """
     omitted = 0
     reasons: list[str] = []
-    # Anchor pressure: if the body had to be truncated.
-    if anchor.token_estimate > 0 and anchor.token_estimate >= anchor_budget:
+    # Anchor pressure: if the body was actually trimmed.  Strict
+    # ``>`` instead of ``>=`` (CodeRabbit) so an anchor that fits
+    # exactly doesn't read as truncated.
+    if anchor.token_estimate > 0 and anchor.token_estimate > anchor_budget:
         omitted += 1
         reasons.append("anchor_truncated_to_budget")
     # Retrieval pressure: if we filled near the budget, treat the
@@ -659,11 +731,12 @@ def _truncate_to_tokens(text: str, budget_tokens: int) -> str:
 
 
 __all__ = [
-    "ANCHOR_KINDS",
     "ANCHOR_BUDGET_FRACTION",
+    "ANCHOR_KINDS",
     "AnchorContext",
     "ContextManifest",
     "RetrievalContext",
+    "RetrievalHit",
     "SYSTEM_FRAME_MARGIN_TOKENS",
     "TURN_HISTORY_SUMMARY_MAX_TOKENS",
     "TURN_HISTORY_VERBATIM_K",

--- a/tests/test_context_binder.py
+++ b/tests/test_context_binder.py
@@ -14,6 +14,7 @@ from ovp_pipeline.context_binder import (
     AnchorContext,
     ContextManifest,
     RetrievalContext,
+    RetrievalHit,
     TurnPair,
     build_anchor_context,
     build_chat_context,
@@ -227,7 +228,7 @@ def test_manifest_to_lines_round_trips_core_fields():
     )
     retrieval = RetrievalContext(
         query="q",
-        included_objects=("obj-1",),
+        hits=(RetrievalHit(slug="obj-1", kind="object", title="Obj 1"),),
         token_estimate=300,
     )
     manifest = ContextManifest(
@@ -297,3 +298,152 @@ def test_should_rebuild_summary_when_window_slides():
     assert should_rebuild_summary(3, _pairs(5))
     assert not should_rebuild_summary(5, _pairs(5))
     assert not should_rebuild_summary(5, [])
+
+
+# ── codex P1 — path traversal ──────────────────────────────────
+
+
+def test_anchor_ref_absolute_path_rejected(tmp_path: Path):
+    """Codex P1 — anchor.path stored as an unchecked string must
+    not be allowed to read outside the vault.  Absolute refs are
+    rejected and degrade to empty body."""
+    # Pre-populate a "secret" file outside the vault.
+    secret = tmp_path.parent / "secret.txt"
+    secret.write_text("SHOULD-NOT-LEAK", encoding="utf-8")
+    try:
+        ctx = build_anchor_context(
+            tmp_path,
+            anchor_kind="note",
+            anchor_ref=str(secret),  # absolute path
+            budget_tokens=10_000,
+        )
+        assert ctx.included_anchor == ""
+    finally:
+        secret.unlink(missing_ok=True)
+
+
+def test_anchor_ref_dotdot_escape_rejected(tmp_path: Path):
+    """A relative ref that resolves outside the vault root also
+    degrades to empty body."""
+    outside = tmp_path.parent / "outside.txt"
+    outside.write_text("SHOULD-NOT-LEAK", encoding="utf-8")
+    try:
+        ctx = build_anchor_context(
+            tmp_path,
+            anchor_kind="note",
+            anchor_ref=f"../{outside.name}",
+            budget_tokens=10_000,
+        )
+        assert "SHOULD-NOT-LEAK" not in ctx.included_anchor
+        assert ctx.included_anchor == ""
+    finally:
+        outside.unlink(missing_ok=True)
+
+
+# ── codex P2 — retrieval snippet inclusion ─────────────────────
+
+
+def test_retrieval_hits_include_snippets_in_prompt(tmp_path: Path, monkeypatch):
+    """Codex P2 — retrieved evidence text (title + snippet) must
+    land in the prompt body, not just a list of [[slug]] links."""
+
+    def fake_discover(*args, **kwargs):
+        return [
+            {
+                "slug": "memory-emergence",
+                "path": "10-Knowledge/Evergreen/memory-emergence.md",
+                "title": "Memory emergence",
+                "snippet": "Emergent memory arises from cross-claim contradiction.",
+                "object_kind": "evergreen",
+                "kind": "lexical",  # retrieval *mode*, not object_kind
+                "score": 0.9,
+            }
+        ]
+
+    from ovp_pipeline import context_binder
+
+    monkeypatch.setattr("ovp_pipeline.discovery.discover_related", fake_discover)
+
+    body, _ = context_binder.build_chat_context(
+        tmp_path,
+        anchor_kind="standalone",
+        anchor_ref="",
+        user_message="how does memory emerge?",
+        profile_input_cap=16_000,
+    )
+    # Title + snippet must appear in the prompt body.
+    assert "Memory emergence" in body
+    assert "Emergent memory arises" in body
+
+
+# ── codex P2 — crystal classification via object_kind ─────────
+
+
+def test_crystal_hits_routed_to_included_crystals(tmp_path: Path, monkeypatch):
+    """Codex P2 — discover_related sets ``kind`` to the retrieval
+    mode (``lexical``/``semantic``); the object type comes from
+    ``object_kind``.  Crystal hits must classify as ``crystal``,
+    not ``object``."""
+
+    def fake_discover(*args, **kwargs):
+        return [
+            {
+                "slug": "cluster::abc",
+                "object_kind": "community_crystal",
+                "kind": "semantic",  # retrieval mode (wrong source)
+                "title": "Cluster — abc",
+                "snippet": "Body of the crystal.",
+            },
+            {
+                "slug": "contradiction-4ca412",
+                "object_kind": "contradiction_crystal",
+                "kind": "lexical",
+                "title": "Contradiction — 4ca412",
+                "snippet": "Conflicting claims.",
+            },
+            {
+                "slug": "ai-agent",
+                "object_kind": "evergreen",
+                "kind": "fts",
+                "title": "AI Agent",
+                "snippet": "An AI Agent is ...",
+            },
+        ]
+
+    from ovp_pipeline import context_binder
+
+    monkeypatch.setattr("ovp_pipeline.discovery.discover_related", fake_discover)
+
+    _, manifest = context_binder.build_chat_context(
+        tmp_path,
+        anchor_kind="standalone",
+        anchor_ref="",
+        user_message="memory emergence",
+        profile_input_cap=16_000,
+    )
+    assert manifest.retrieval.included_crystals == ("cluster::abc",)
+    assert manifest.retrieval.included_contradictions == ("contradiction-4ca412",)
+    assert manifest.retrieval.included_objects == ("ai-agent",)
+
+
+# ── CodeRabbit — frontmatter strip before token budgeting ─────
+
+
+def test_anchor_body_strips_frontmatter_before_budgeting(tmp_path: Path):
+    """Frontmatter shouldn't count against the anchor token budget.
+    Loading uses split_markdown_frontmatter so the body returned is
+    just the prose."""
+    note = tmp_path / "20-Areas/x.md"
+    note.parent.mkdir(parents=True)
+    note.write_text(
+        "---\ntype: article\ntitle: X\ndate: 2026-05-12\n---\n\n" "# X\n\nReal content.\n",
+        encoding="utf-8",
+    )
+    ctx = build_anchor_context(
+        tmp_path,
+        anchor_kind="note",
+        anchor_ref="20-Areas/x.md",
+        budget_tokens=10_000,
+    )
+    assert "Real content." in ctx.included_anchor
+    assert "type: article" not in ctx.included_anchor

--- a/tests/test_context_binder.py
+++ b/tests/test_context_binder.py
@@ -1,0 +1,299 @@
+"""Tests for M21a / BL-083 — two-layer context binder."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ovp_pipeline.context_binder import (
+    ANCHOR_BUDGET_FRACTION,
+    ANCHOR_KINDS,
+    SYSTEM_FRAME_MARGIN_TOKENS,
+    TURN_HISTORY_VERBATIM_K,
+    AnchorContext,
+    ContextManifest,
+    RetrievalContext,
+    TurnPair,
+    build_anchor_context,
+    build_chat_context,
+    build_retrieval_context,
+    estimate_tokens,
+    manifest_to_lines,
+    select_verbatim_window,
+    should_rebuild_summary,
+    split_budget,
+)
+
+# ── budgeting ──────────────────────────────────────────────────
+
+
+def test_estimate_tokens_returns_zero_for_empty():
+    assert estimate_tokens("") == 0
+
+
+def test_estimate_tokens_under_estimates_chars():
+    # 4 chars/token proxy → 1000 chars ≈ 250 tokens.
+    assert estimate_tokens("x" * 1000) == 250
+
+
+def test_split_budget_60_40_after_margin():
+    anchor, retrieval = split_budget(10_000)
+    available = 10_000 - SYSTEM_FRAME_MARGIN_TOKENS
+    assert anchor == int(available * ANCHOR_BUDGET_FRACTION)
+    assert retrieval == available - anchor
+
+
+def test_split_budget_subtracts_turn_history_tokens():
+    a1, r1 = split_budget(10_000, turn_history_tokens=0)
+    a2, r2 = split_budget(10_000, turn_history_tokens=2000)
+    assert a1 + r1 - 2000 == a2 + r2
+
+
+def test_split_budget_returns_zero_when_cap_too_tight():
+    assert split_budget(SYSTEM_FRAME_MARGIN_TOKENS // 2) == (0, 0)
+
+
+# ── standalone anchor ──────────────────────────────────────────
+
+
+def test_standalone_anchor_returns_empty_context(tmp_path: Path):
+    ctx = build_anchor_context(
+        tmp_path,
+        anchor_kind="standalone",
+        anchor_ref="",
+        budget_tokens=10_000,
+    )
+    assert ctx.kind == "standalone"
+    assert ctx.included_anchor == ""
+    assert ctx.included_evergreens == ()
+    assert ctx.token_estimate == 0
+
+
+def test_build_chat_context_rejects_unknown_anchor_kind(tmp_path: Path):
+    with pytest.raises(ValueError, match="unknown anchor kind"):
+        build_chat_context(
+            tmp_path,
+            anchor_kind="bogus",
+            anchor_ref="x",
+            user_message="hi",
+            profile_input_cap=16_000,
+        )
+
+
+def test_anchor_kinds_locked_set():
+    assert ANCHOR_KINDS == frozenset({"note", "object", "crystal", "standalone"})
+
+
+# ── note anchor ────────────────────────────────────────────────
+
+
+def test_note_anchor_loads_body_within_budget(tmp_path: Path):
+    note = tmp_path / "20-Areas/note.md"
+    note.parent.mkdir(parents=True)
+    body = "# Note title\n\nSome content with [[evergreen-a]] and [[evergreen-b]]."
+    note.write_text(body, encoding="utf-8")
+
+    ctx = build_anchor_context(
+        tmp_path,
+        anchor_kind="note",
+        anchor_ref="20-Areas/note.md",
+        budget_tokens=10_000,
+    )
+    assert ctx.kind == "note"
+    assert ctx.ref == "20-Areas/note.md"
+    assert "Note title" in ctx.included_anchor
+    assert "evergreen-a" in ctx.included_evergreens
+    assert "evergreen-b" in ctx.included_evergreens
+
+
+def test_note_anchor_missing_file_returns_empty_body(tmp_path: Path):
+    """Missing anchor file degrades to empty body — the handler can
+    still answer from retrieval + USER + RULES."""
+    ctx = build_anchor_context(
+        tmp_path,
+        anchor_kind="note",
+        anchor_ref="20-Areas/nope.md",
+        budget_tokens=10_000,
+    )
+    assert ctx.included_anchor == ""
+    assert ctx.included_evergreens == ()
+
+
+def test_anchor_body_truncated_to_budget(tmp_path: Path):
+    note = tmp_path / "20-Areas/big.md"
+    note.parent.mkdir(parents=True)
+    # 40k chars ~= 10k tokens; budget 200 tokens means ~800 chars max.
+    note.write_text("A" * 40_000, encoding="utf-8")
+    ctx = build_anchor_context(
+        tmp_path,
+        anchor_kind="note",
+        anchor_ref="20-Areas/big.md",
+        budget_tokens=200,
+    )
+    # Body was truncated; never empty when source exists.
+    assert ctx.included_anchor
+    assert "[truncated" in ctx.included_anchor
+    assert ctx.token_estimate <= 250  # close to budget, not 10k
+
+
+def test_anchor_kind_propagated_to_manifest(tmp_path: Path):
+    """Even when the body is empty, the kind/ref round-trip."""
+    body, manifest = build_chat_context(
+        tmp_path,
+        anchor_kind="standalone",
+        anchor_ref="",
+        user_message="general question",
+        profile_input_cap=16_000,
+    )
+    assert manifest.anchor.kind == "standalone"
+    assert manifest.anchor.ref == ""
+
+
+# ── retrieval layer ────────────────────────────────────────────
+
+
+def test_empty_query_skips_retrieval(tmp_path: Path):
+    ctx = build_retrieval_context(tmp_path, query="", budget_tokens=10_000)
+    assert ctx.included_objects == ()
+    assert ctx.included_crystals == ()
+
+
+def test_zero_budget_skips_retrieval(tmp_path: Path):
+    ctx = build_retrieval_context(tmp_path, query="anything", budget_tokens=0)
+    assert ctx.included_objects == ()
+
+
+def test_missing_knowledge_db_returns_empty_retrieval(tmp_path: Path):
+    """Defensive: a vault without knowledge.db doesn't crash."""
+    ctx = build_retrieval_context(
+        tmp_path,
+        query="memory architecture",
+        budget_tokens=10_000,
+    )
+    # No DB → empty retrieval, but the call returns cleanly.
+    assert isinstance(ctx, RetrievalContext)
+    assert ctx.query == "memory architecture"
+
+
+# ── full build path ────────────────────────────────────────────
+
+
+def test_build_chat_context_returns_prompt_and_manifest(tmp_path: Path):
+    note = tmp_path / "20-Areas/x.md"
+    note.parent.mkdir(parents=True)
+    note.write_text("# X\n\nContent body.", encoding="utf-8")
+
+    body, manifest = build_chat_context(
+        tmp_path,
+        anchor_kind="note",
+        anchor_ref="20-Areas/x.md",
+        user_message="What does X say?",
+        profile_input_cap=16_000,
+    )
+    assert isinstance(manifest, ContextManifest)
+    assert "Content body." in body
+    assert manifest.context_built_at.endswith("Z")
+    assert manifest.anchor.kind == "note"
+    assert manifest.token_estimate_total > 0
+
+
+def test_build_chat_context_includes_user_profile_when_present(tmp_path: Path):
+    (tmp_path / "00-Polaris").mkdir()
+    (tmp_path / "00-Polaris/USER.md").write_text(
+        "# About Me\nI'm a researcher.\n",
+        encoding="utf-8",
+    )
+    body, _ = build_chat_context(
+        tmp_path,
+        anchor_kind="standalone",
+        anchor_ref="",
+        user_message="hi",
+        profile_input_cap=16_000,
+    )
+    assert "User Profile" in body or "researcher" in body
+
+
+# ── manifest_to_lines ──────────────────────────────────────────
+
+
+def test_manifest_to_lines_round_trips_core_fields():
+    anchor = AnchorContext(
+        kind="note",
+        ref="20-Areas/x.md",
+        included_anchor="body",
+        included_evergreens=("a", "b"),
+        token_estimate=200,
+    )
+    retrieval = RetrievalContext(
+        query="q",
+        included_objects=("obj-1",),
+        token_estimate=300,
+    )
+    manifest = ContextManifest(
+        anchor=anchor,
+        retrieval=retrieval,
+        token_estimate_total=500,
+        context_built_at="2026-05-12T11:00:00Z",
+    )
+    lines = manifest_to_lines(manifest)
+    joined = "\n".join(lines)
+    assert "context_built_at: 2026-05-12T11:00:00Z" in joined
+    assert "token_estimate: 500" in joined
+    assert "anchor_kind: note" in joined
+    assert "anchor_ref: 20-Areas/x.md" in joined
+    assert "- a" in joined
+    assert "- obj-1" in joined
+
+
+def test_manifest_to_lines_records_omissions():
+    manifest = ContextManifest(
+        anchor=AnchorContext(kind="note", ref="x.md"),
+        retrieval=RetrievalContext(query="q"),
+        omitted_count=3,
+        omitted_reason="token_budget",
+        token_estimate_total=0,
+        context_built_at="t",
+    )
+    lines = manifest_to_lines(manifest)
+    joined = "\n".join(lines)
+    assert "omitted_items:" in joined
+    assert "count: 3" in joined
+    assert "reason: token_budget" in joined
+
+
+# ── turn-history rolling window ────────────────────────────────
+
+
+def _pairs(*nums: int) -> list[TurnPair]:
+    return [TurnPair(user_body=f"u{n}", assistant_body=f"a{n}", turn_number=n) for n in nums]
+
+
+def test_select_verbatim_window_short_history():
+    older, recent = select_verbatim_window(_pairs(1, 2, 3))
+    assert older == []
+    assert [p.turn_number for p in recent] == [1, 2, 3]
+
+
+def test_select_verbatim_window_keeps_last_k():
+    older, recent = select_verbatim_window(_pairs(1, 2, 3, 4, 5, 6, 7))
+    assert [p.turn_number for p in recent] == [4, 5, 6, 7]
+    assert [p.turn_number for p in older] == [1, 2, 3]
+
+
+def test_select_verbatim_window_respects_custom_k():
+    older, recent = select_verbatim_window(_pairs(1, 2, 3, 4, 5), k=2)
+    assert [p.turn_number for p in recent] == [4, 5]
+    assert [p.turn_number for p in older] == [1, 2, 3]
+
+
+def test_verbatim_window_k_default_matches_plan():
+    assert TURN_HISTORY_VERBATIM_K == 4
+
+
+def test_should_rebuild_summary_when_window_slides():
+    """The cache stored a summary through turn-3; new older pair at
+    turn-5 means the window slid and the summary needs refresh."""
+    assert should_rebuild_summary(3, _pairs(5))
+    assert not should_rebuild_summary(5, _pairs(5))
+    assert not should_rebuild_summary(5, [])


### PR DESCRIPTION
## Summary

Third PR for M21a (Anchored Inquiry MVP).  Builds the binder that
unifies the artifact-under-discussion with per-turn retrieval into
a single prompt body + audit manifest.

* New: ``src/ovp_pipeline/context_binder.py``
* New: ``tests/test_context_binder.py`` — 24 tests.

## Design rules locked in

1. **Two layers, distinct lifecycles.** Anchor is fixed-per-session;
   retrieval rebuilds per turn from the user message.
2. **No parallel RAG stack.** Retrieval layer wraps
   ``discover_related`` — the same helper that powers ``ovp-query``.
3. **Anchor is inviolate.** When the budget is tight, retrieval
   hits drop first; the anchor body truncates with a marker but
   never disappears.
4. **Manifest is audit-only.** The binder never re-reads its own
   output.  Every turn rebuilds from current vault state.
5. **Degrades, never crashes.** Missing anchor file → empty body.
   Missing knowledge.db → empty retrieval.  The handler can still
   answer from USER + RULES.
6. **Turn-history policy lives here; LLM call belongs to BL-084.**
   ``select_verbatim_window`` + ``should_rebuild_summary`` carry
   the rolling-window logic; BL-084 plugs in the Fast-profile
   summariser.

## Test plan

- [x] ``rtk proxy python -m pytest tests/test_context_binder.py -q`` — 24 passed
- [x] ``ruff check`` + ``black --check`` clean

## Plan reference

``docs/plans/2026-05-12-m21-chat-surface.md`` — BL-083 detail at
``### BL-083 — Context binder (two-layer: anchor + retrieval)``.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Intelligent two-layer context builder that allocates per-turn token budgets, preserves prioritized anchor content, and adds budget-aware external retrieval with evidence snippets.
  * Vault-safe anchor loading with path confinement and graceful degradation for missing/unreadable sources.
  * Auditable manifest listing included items and omissions due to token limits; truncation preserves paragraph boundaries.

* **Tests**
  * Comprehensive end-to-end tests covering budgeting, anchor/retrieval behavior, security checks, omission reporting, and turn-history utilities.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fakechris/obsidian_vault_pipeline/pull/212)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->