### PR TITLE
feat(bl-086): Reader /chat page (M21b step 1, synchronous v1)

### DIFF
--- a/src/ovp_pipeline/commands/_chat_page.py
+++ b/src/ovp_pipeline/commands/_chat_page.py
@@ -125,23 +125,46 @@ def _render_transcript_body(text: str) -> str:
             continue
         if current_role is None:
             continue
-        if in_block_comment:
-            if "-->" in raw:
-                in_block_comment = False
-            continue
-        if "<!--" in raw and "-->" not in raw:
-            in_block_comment = True
-            continue
-        # Strip inline single-line comments (the manifest snapshot).
-        if "<!--" in raw and "-->" in raw:
-            stripped = raw.split("<!--", 1)[0]
-            if stripped.strip():
-                current_buffer.append(stripped)
-            continue
-        current_buffer.append(raw)
+        stripped, in_block_comment = _strip_html_comments(raw, in_block_comment)
+        if stripped.strip() or current_buffer:
+            current_buffer.append(stripped)
     sections.append(_flush_block(current_role, current_buffer))
-    title_html = f"<h1>{escape(title_line)}</h1>" if title_line else "<h1>Inquiry</h1>"
+    # h2 not h1: the page-shell already carries "Ask the vault" as
+    # the primary h1 (CodeRabbit M).
+    title_html = (
+        f"<h2 class='chat-title'>{escape(title_line)}</h2>"
+        if title_line
+        else "<h2 class='chat-title'>Inquiry</h2>"
+    )
     return title_html + "\n".join(s for s in sections if s)
+
+
+def _strip_html_comments(line: str, in_block: bool) -> tuple[str, bool]:
+    """Strip ``<!-- ... -->`` ranges from ``line`` in place.
+
+    Preserves prose on the same line as a comment marker — both
+    before and after — so the manifest comment doesn't take its
+    surrounding text down with it (CodeRabbit High).  Returns the
+    cleaned line plus the new in-block state.
+    """
+    result = line
+    if in_block:
+        # Resume after a previous block-opening line.
+        if "-->" in result:
+            result = result.split("-->", 1)[1]
+            in_block = False
+        else:
+            return "", True
+    # Strip every fully-closed pair.
+    while "<!--" in result and "-->" in result:
+        start = result.index("<!--")
+        end = result.index("-->", start) + len("-->")
+        result = result[:start] + result[end:]
+    # Open-ended comment — keep the prefix, swallow the rest.
+    if "<!--" in result and "-->" not in result:
+        result = result.split("<!--", 1)[0]
+        in_block = True
+    return result, in_block
 
 
 def _flush_block(role: str | None, lines: list[str]) -> str:
@@ -203,9 +226,22 @@ def render_chat_page_body(
     )
     profile_options = _profile_options(vault_dir, profile)
 
-    # Visibility toggle copy per M21 plan.
+    # Visibility toggle copy per M21 plan.  Disabled on existing
+    # sessions because run_turn doesn't accept a visibility change
+    # on a follow-up (CodeRabbit M — avoid the impression that
+    # toggling can flip a session's index status mid-conversation).
+    existing_session = fm is not None
     visibility_indexed_checked = " checked" if visibility == "indexed" else ""
     visibility_unindexed_checked = " checked" if visibility == "unindexed" else ""
+    visibility_disabled = " disabled" if existing_session else ""
+    visibility_lock_note = (
+        '<p class="muted small">'
+        "Visibility is locked once a session starts — start a new "
+        "inquiry to choose a different mode."
+        "</p>"
+        if existing_session
+        else ""
+    )
 
     error_block = ""
     if error_message:
@@ -216,13 +252,18 @@ def render_chat_page_body(
     )
 
     chat_id_hidden = (
-        f'<input type="hidden" name="chat_id" value="{escape(fm.chat_id if fm else "")}" />'
-        if fm
-        else ""
+        f'<input type="hidden" name="chat_id" value="{escape(fm.chat_id)}" />' if fm else ""
     )
     anchor_hidden = (
         f'<input type="hidden" name="anchor" '
         f'value="{escape(f"{anchor_kind}:{anchor_ref}" if anchor_ref else "")}" />'
+    )
+    # Codex P2: carry the anchor title through the POST so a new
+    # session lands with its friendly title intact.
+    anchor_title_hidden = (
+        f'<input type="hidden" name="anchor_title" value="{escape(anchor_title)}" />'
+        if anchor_title
+        else ""
     )
 
     return f"""
@@ -237,17 +278,18 @@ def render_chat_page_body(
     {csrf_field}
     {chat_id_hidden}
     {anchor_hidden}
+    {anchor_title_hidden}
     <label class="block">
       <span class="muted small">Profile</span>
       <select name="profile">{profile_options}</select>
     </label>
     <label class="block visibility-toggle">
-      <input type="radio" name="visibility" value="indexed"{visibility_indexed_checked} />
+      <input type="radio" name="visibility" value="indexed"{visibility_indexed_checked}{visibility_disabled} />
       <strong>Index this inquiry</strong>
       <span class="muted small">Show up in /search and the binder's retrieval layer.</span>
     </label>
     <label class="block visibility-toggle">
-      <input type="radio" name="visibility" value="unindexed"{visibility_unindexed_checked} />
+      <input type="radio" name="visibility" value="unindexed"{visibility_unindexed_checked}{visibility_disabled} />
       <strong>Don't index or reuse this inquiry.</strong>
       <span class="muted small">
         OVP won't include this session in search, the inquiry list,
@@ -255,6 +297,7 @@ def render_chat_page_body(
         still receives the current request.
       </span>
     </label>
+    {visibility_lock_note}
     <label class="block">
       <span class="muted small">Your message</span>
       <textarea name="message" rows="5" required
@@ -277,3 +320,20 @@ def _new_anchor_badge(kind: str, ref: str, title: str) -> str:
 def chat_page_redirect_target(chat_id: str) -> str:
     """Where to send the browser after a successful POST."""
     return "/chat?" + urlencode({"id": chat_id})
+
+
+def parse_anchor_string(raw: str) -> tuple[str, str]:
+    """Split ``"<kind>:<ref>"`` (or bare ``<path>``) into a tuple.
+
+    Empty input → ``("standalone", "")``.  Single helper shared by
+    both the GET and POST handlers (CodeRabbit M — dedup).
+    """
+    cleaned = (raw or "").strip()
+    if not cleaned:
+        return "standalone", ""
+    if ":" not in cleaned:
+        return "note", cleaned
+    kind, _, ref = cleaned.partition(":")
+    kind = kind.strip() or "standalone"
+    ref = ref.strip()
+    return kind, ref

--- a/src/ovp_pipeline/commands/_chat_page.py
+++ b/src/ovp_pipeline/commands/_chat_page.py
@@ -1,0 +1,279 @@
+"""Reader ``/chat`` page renderer (M21b / BL-086).
+
+The Reader-side surface for anchored inquiry.  Wraps the M21a
+primitives (``chat_handler.run_turn``, ``chat_fileops.parse_chat``)
+in an HTML page + form so an operator can carry on an inquiry
+without dropping to the CLI.
+
+This module owns *only* the renderer; the route handlers live in
+:mod:`ovp_pipeline.commands.ui_server`.  Keeping them separate
+matches the existing ``_ui_renderers`` / ``ui_server`` split and
+lets the renderer be unit-tested without spinning up the server.
+
+What this v1 ships:
+
+* ``/chat`` page with composer + manifest card + transcript body
+* Synchronous POST submit (page refresh per turn).  SSE streaming
+  is deferred to a follow-up — the M21 plan calls it out, but the
+  chat_handler refactor needed to thread tokens through SSE is
+  larger than the BL-086 budget can absorb in one PR.
+
+Profile dropdown shows Fast / Balanced / Deep only — never raw
+provider strings.  Visibility toggle uses the honest copy from
+the M21 plan ("Don't index or reuse this inquiry").
+"""
+
+from __future__ import annotations
+
+from html import escape
+from pathlib import Path
+from urllib.parse import urlencode
+
+from ovp_pipeline.chat_fileops import ChatFrontmatter, parse_chat
+from ovp_pipeline.llm_profiles import load_profiles
+
+# Built-in profile order in the dropdown.  Custom profiles defined
+# in ``.ovp/llm_profiles.yaml`` show up by name after the
+# canonical three so an operator who added ``my-custom`` sees it
+# in the dropdown — but the plan's "no raw provider strings in
+# Reader UI" rule still holds because operators only see the
+# profile *name*, never provider/model.
+_CANONICAL_PROFILE_ORDER = ("fast", "balanced", "deep")
+
+
+def _profile_options(vault_dir: Path | str, current: str) -> str:
+    """Build the ``<option>`` list for the profile dropdown.
+
+    Canonical order first (Fast / Balanced / Deep when defined),
+    then any custom profiles sorted by name.  ``current`` is
+    pre-selected.
+    """
+    book = load_profiles(vault_dir)
+    names = list(book.profiles.keys())
+    canonical = [n for n in _CANONICAL_PROFILE_ORDER if n in names]
+    extras = sorted(n for n in names if n not in canonical)
+    ordered = canonical + extras
+    parts: list[str] = []
+    for name in ordered:
+        selected = " selected" if name == current else ""
+        label = name.capitalize() if name in _CANONICAL_PROFILE_ORDER else name
+        parts.append(f'<option value="{escape(name)}"{selected}>{escape(label)}</option>')
+    return "\n".join(parts)
+
+
+def _anchor_badge(fm: ChatFrontmatter | None) -> str:
+    """Small pill describing what the session is anchored to."""
+    if fm is None or fm.anchor.kind == "standalone":
+        return '<span class="pill ghost">Standalone (no anchor)</span>'
+    title = escape(fm.anchor.title or fm.anchor.path or fm.anchor.kind)
+    kind = escape(fm.anchor.kind)
+    return f'<span class="pill">{kind}: {title}</span>'
+
+
+def _render_manifest_card(fm: ChatFrontmatter | None) -> str:
+    """Collapsible 'Context anchored to ...' card."""
+    if fm is None:
+        return ""
+    title = escape(fm.anchor.title or fm.anchor.path or "this inquiry")
+    kind = escape(fm.anchor.kind)
+    profile_pill = escape(fm.profile.capitalize())
+    return (
+        '<details class="card chat-manifest" open>'
+        f"<summary>Context anchored to <strong>{title}</strong> "
+        f"<span class='pill ghost'>{kind}</span> "
+        f"<span class='pill'>{profile_pill}</span></summary>"
+        "<p class='muted'>"
+        "Each assistant turn is rebuilt from current vault state; "
+        "the inline <code>&lt;!-- context-manifest --&gt;</code> "
+        "comment is an audit snapshot, not a directive."
+        "</p>"
+        "</details>"
+    )
+
+
+def _render_transcript_body(text: str) -> str:
+    """Render the markdown body of a chat transcript as HTML.
+
+    Plain-text rendering preserved as ``<pre>``-style blocks under
+    explicit ``## User`` / ``## Assistant`` cards.  Real markdown
+    rendering (wikilinks, bold, etc.) is deferred — the plan
+    expects this, and the renderer in ``_ui_renderers.py`` already
+    has the wikilink helpers we'll wire up next.
+    """
+    if not text:
+        return "<p class='muted'>No turns yet — send the first message below.</p>"
+    sections: list[str] = []
+    current_role: str | None = None
+    current_buffer: list[str] = []
+    in_block_comment = False
+    title_line = ""
+    for raw in text.splitlines():
+        if raw.startswith("# "):
+            title_line = raw[2:].strip()
+            continue
+        if raw.startswith("## User ·"):
+            sections.append(_flush_block(current_role, current_buffer))
+            current_role = "user"
+            current_buffer = [raw]
+            in_block_comment = False
+            continue
+        if raw.startswith("## Assistant ·"):
+            sections.append(_flush_block(current_role, current_buffer))
+            current_role = "assistant"
+            current_buffer = [raw]
+            in_block_comment = False
+            continue
+        if current_role is None:
+            continue
+        if in_block_comment:
+            if "-->" in raw:
+                in_block_comment = False
+            continue
+        if "<!--" in raw and "-->" not in raw:
+            in_block_comment = True
+            continue
+        # Strip inline single-line comments (the manifest snapshot).
+        if "<!--" in raw and "-->" in raw:
+            stripped = raw.split("<!--", 1)[0]
+            if stripped.strip():
+                current_buffer.append(stripped)
+            continue
+        current_buffer.append(raw)
+    sections.append(_flush_block(current_role, current_buffer))
+    title_html = f"<h1>{escape(title_line)}</h1>" if title_line else "<h1>Inquiry</h1>"
+    return title_html + "\n".join(s for s in sections if s)
+
+
+def _flush_block(role: str | None, lines: list[str]) -> str:
+    if role is None or not lines:
+        return ""
+    header = lines[0]
+    body = "\n".join(lines[1:]).strip()
+    role_class = "chat-turn-user" if role == "user" else "chat-turn-assistant"
+    return (
+        f'<section class="card chat-turn {role_class}">'
+        f"<p class='muted small'>{escape(header[3:])}</p>"
+        f"<pre class='chat-body'>{escape(body)}</pre>"
+        "</section>"
+    )
+
+
+def render_chat_page_body(
+    vault_dir: Path | str,
+    *,
+    chat_id: str | None = None,
+    chat_path: Path | None = None,
+    anchor_kind: str = "standalone",
+    anchor_ref: str = "",
+    anchor_title: str = "",
+    profile: str = "balanced",
+    error_message: str = "",
+    csrf_token: str = "",
+) -> str:
+    """Render the body HTML for ``/chat``.
+
+    For an existing session, the transcript is loaded and the
+    composer prefills the same profile / visibility.  For a new
+    session, the composer offers the anchor pre-bound via the
+    ``?anchor=<kind>:<ref>`` query string from BL-087's entry
+    buttons (or operator-typed for a standalone chat).
+    """
+    fm: ChatFrontmatter | None = None
+    body_html = ""
+    if chat_path and chat_path.is_file():
+        fm = parse_chat(chat_path)
+        body_html = _render_transcript_body(chat_path.read_text(encoding="utf-8"))
+    elif chat_id:
+        # The route handler couldn't find the chat — render the
+        # error message but still surface the composer for retry.
+        error_message = error_message or f"Inquiry session {chat_id!r} not found."
+
+    if fm is not None:
+        anchor_kind = fm.anchor.kind
+        anchor_ref = fm.anchor.path
+        anchor_title = fm.anchor.title
+        profile = fm.profile or profile
+        visibility = fm.visibility
+    else:
+        visibility = "indexed"
+
+    manifest_card = _render_manifest_card(fm)
+    anchor_badge = (
+        _anchor_badge(fm) if fm else _new_anchor_badge(anchor_kind, anchor_ref, anchor_title)
+    )
+    profile_options = _profile_options(vault_dir, profile)
+
+    # Visibility toggle copy per M21 plan.
+    visibility_indexed_checked = " checked" if visibility == "indexed" else ""
+    visibility_unindexed_checked = " checked" if visibility == "unindexed" else ""
+
+    error_block = ""
+    if error_message:
+        error_block = f'<div class="card error">{escape(error_message)}</div>'
+
+    csrf_field = (
+        f'<input type="hidden" name="_csrf" value="{escape(csrf_token)}" />' if csrf_token else ""
+    )
+
+    chat_id_hidden = (
+        f'<input type="hidden" name="chat_id" value="{escape(fm.chat_id if fm else "")}" />'
+        if fm
+        else ""
+    )
+    anchor_hidden = (
+        f'<input type="hidden" name="anchor" '
+        f'value="{escape(f"{anchor_kind}:{anchor_ref}" if anchor_ref else "")}" />'
+    )
+
+    return f"""
+<header class="chat-header">
+  <h1>Ask the vault</h1>
+  {anchor_badge}
+</header>
+{manifest_card}
+{body_html}
+<section class="card chat-composer">
+  <form method="POST" action="/chat/message">
+    {csrf_field}
+    {chat_id_hidden}
+    {anchor_hidden}
+    <label class="block">
+      <span class="muted small">Profile</span>
+      <select name="profile">{profile_options}</select>
+    </label>
+    <label class="block visibility-toggle">
+      <input type="radio" name="visibility" value="indexed"{visibility_indexed_checked} />
+      <strong>Index this inquiry</strong>
+      <span class="muted small">Show up in /search and the binder's retrieval layer.</span>
+    </label>
+    <label class="block visibility-toggle">
+      <input type="radio" name="visibility" value="unindexed"{visibility_unindexed_checked} />
+      <strong>Don't index or reuse this inquiry.</strong>
+      <span class="muted small">
+        OVP won't include this session in search, the inquiry list,
+        or future context-binder retrieval. The selected LLM provider
+        still receives the current request.
+      </span>
+    </label>
+    <label class="block">
+      <span class="muted small">Your message</span>
+      <textarea name="message" rows="5" required
+        placeholder="Ask something about the anchored artifact, or any vault topic."></textarea>
+    </label>
+    <button type="submit" class="primary">Send</button>
+  </form>
+  {error_block}
+</section>
+"""
+
+
+def _new_anchor_badge(kind: str, ref: str, title: str) -> str:
+    if kind == "standalone" or not ref:
+        return '<span class="pill ghost">Standalone (no anchor)</span>'
+    display = escape(title or ref)
+    return f'<span class="pill">{escape(kind)}: {display}</span>'
+
+
+def chat_page_redirect_target(chat_id: str) -> str:
+    """Where to send the browser after a successful POST."""
+    return "/chat?" + urlencode({"id": chat_id})

--- a/src/ovp_pipeline/commands/_chat_page.py
+++ b/src/ovp_pipeline/commands/_chat_page.py
@@ -108,7 +108,10 @@ def _render_transcript_body(text: str) -> str:
     in_block_comment = False
     title_line = ""
     for raw in text.splitlines():
-        if raw.startswith("# "):
+        # H1 detection only applies *before* the first turn header.
+        # Once a User/Assistant section opens, a ``# heading`` line is
+        # part of the message body (CodeRabbit Major).
+        if current_role is None and raw.startswith("# "):
             title_line = raw[2:].strip()
             continue
         if raw.startswith("## User ·"):
@@ -190,6 +193,7 @@ def render_chat_page_body(
     anchor_ref: str = "",
     anchor_title: str = "",
     profile: str = "balanced",
+    visibility: str = "indexed",
     error_message: str = "",
     csrf_token: str = "",
 ) -> str:
@@ -218,7 +222,9 @@ def render_chat_page_body(
         profile = fm.profile or profile
         visibility = fm.visibility
     else:
-        visibility = "indexed"
+        # Preserve the caller-supplied visibility (e.g. from an
+        # error rerender that needs to keep the operator's choice).
+        visibility = visibility or "indexed"
 
     manifest_card = _render_manifest_card(fm)
     anchor_badge = (
@@ -265,6 +271,15 @@ def render_chat_page_body(
         if anchor_title
         else ""
     )
+    # CodeRabbit Major: disabled radios are NOT submitted with the
+    # form.  An unindexed session would otherwise lose its
+    # visibility on every follow-up turn.  The hidden field carries
+    # the value while the disabled radios serve only as visual cue.
+    visibility_hidden = (
+        f'<input type="hidden" name="visibility" value="{escape(visibility)}" />'
+        if existing_session
+        else ""
+    )
 
     return f"""
 <header class="chat-header">
@@ -279,6 +294,7 @@ def render_chat_page_body(
     {chat_id_hidden}
     {anchor_hidden}
     {anchor_title_hidden}
+    {visibility_hidden}
     <label class="block">
       <span class="muted small">Profile</span>
       <select name="profile">{profile_options}</select>

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -68,6 +68,7 @@ from ..truth_api import (
 from ._ui_renderers import (  # noqa: F401 — all renderers
     _append_query_param,
     _build_open_questions_payload,
+    _layout,
     _build_runtime_home_payload_from_query,
     _build_writing_prompts_payload,
     _event_matches_object,
@@ -126,7 +127,6 @@ from ._ui_renderers import (  # noqa: F401 — all renderers
     set_request_path,
 )
 
-
 _CRYSTAL_NOTE_PREFIX = "40-Resources/Crystals/"
 
 
@@ -150,14 +150,14 @@ def _crystal_kind_and_id_from_note_path(relative_path: str) -> tuple[str, str] |
     rel = relative_path.replace("\\", "/").lstrip("./")
     if not rel.startswith(_CRYSTAL_NOTE_PREFIX):
         return None
-    stem = rel[len(_CRYSTAL_NOTE_PREFIX):]
+    stem = rel[len(_CRYSTAL_NOTE_PREFIX) :]
     if not stem.endswith(".md"):
         return None
-    stem = stem[:-len(".md")]
+    stem = stem[: -len(".md")]
     if not stem:
         return None
     if stem.startswith("contradiction-"):
-        safe_id = stem[len("contradiction-"):]
+        safe_id = stem[len("contradiction-") :]
         if not safe_id:
             return None
         return ("contradiction_crystal", f"contradiction::{safe_id}")
@@ -165,7 +165,9 @@ def _crystal_kind_and_id_from_note_path(relative_path: str) -> tuple[str, str] |
 
 
 def _maybe_emit_crystal_note_reuse(
-    vault_dir: Path | str, relative_path: str, pack_name: str | None,
+    vault_dir: Path | str,
+    relative_path: str,
+    pack_name: str | None,
 ) -> None:
     """Best-effort: when a Reader ``/note?path=`` request resolves a
     synthesized-crystal markdown, write a ``reuse_events`` row so
@@ -181,6 +183,7 @@ def _maybe_emit_crystal_note_reuse(
         return
     try:
         from ..reuse_emitter import emit_crystal_reuse_events
+
         emit_crystal_reuse_events(
             vault_dir,
             pack=(pack_name or DEFAULT_PACK_NAME),
@@ -215,56 +218,58 @@ def _parse_optional_int(query: dict[str, list[str]], key: str) -> int | None:
 # A request to any of these gets a 301 redirect so existing bookmarks /
 # inline JS hrefs keep working.  ``/api/*`` paths are deliberately not
 # in the table — APIs are unchanged in this migration.
-_LEGACY_MAINTAINER_PATHS: frozenset[str] = frozenset({
-    "/candidates",
-    "/candidates/review",
-    "/candidates/fragment",
-    "/contradictions",
-    "/contradictions/resolve",
-    "/signals",
-    "/actions",
-    "/actions/run-next",
-    "/actions/run-batch",
-    "/actions/retry",
-    "/actions/dismiss",
-    "/actions/enqueue",
-    "/actions/fragment",
-    "/evolution",
-    "/evolution/review",
-    "/production",
-    "/pulse",
-    "/pulse/fragment",
-    "/pulse/stream",
-    "/events",
-    "/reuse/fragment",
-    "/open-questions/fragment",
-    "/writing-prompts/fragment",
-    "/summaries",
-    "/summaries/rebuild",
-    "/briefing",
-    "/briefing/fragment",
-    "/workbench",
-    "/clusters",
-    "/cluster",
-    "/objects",
-})
+_LEGACY_MAINTAINER_PATHS: frozenset[str] = frozenset(
+    {
+        "/candidates",
+        "/candidates/review",
+        "/candidates/fragment",
+        "/contradictions",
+        "/contradictions/resolve",
+        "/signals",
+        "/actions",
+        "/actions/run-next",
+        "/actions/run-batch",
+        "/actions/retry",
+        "/actions/dismiss",
+        "/actions/enqueue",
+        "/actions/fragment",
+        "/evolution",
+        "/evolution/review",
+        "/production",
+        "/pulse",
+        "/pulse/fragment",
+        "/pulse/stream",
+        "/events",
+        "/reuse/fragment",
+        "/open-questions/fragment",
+        "/writing-prompts/fragment",
+        "/summaries",
+        "/summaries/rebuild",
+        "/briefing",
+        "/briefing/fragment",
+        "/workbench",
+        "/clusters",
+        "/cluster",
+        "/objects",
+    }
+)
 
 
 # Suffix → Content-Type map for the /static/<path> endpoint.  Kept
 # narrow so the route can never be coaxed into serving arbitrary
 # files: any suffix not in this map returns 404.
 _STATIC_CONTENT_TYPES: dict[str, str] = {
-    ".css":   "text/css; charset=utf-8",
-    ".js":    "application/javascript; charset=utf-8",
-    ".svg":   "image/svg+xml",
+    ".css": "text/css; charset=utf-8",
+    ".js": "application/javascript; charset=utf-8",
+    ".svg": "image/svg+xml",
     ".woff2": "font/woff2",
-    ".woff":  "font/woff",
-    ".png":   "image/png",
-    ".jpg":   "image/jpeg",
-    ".jpeg":  "image/jpeg",
-    ".webp":  "image/webp",
-    ".ico":   "image/x-icon",
-    ".txt":   "text/plain; charset=utf-8",
+    ".woff": "font/woff",
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".webp": "image/webp",
+    ".ico": "image/x-icon",
+    ".txt": "text/plain; charset=utf-8",
 }
 
 
@@ -323,7 +328,7 @@ def create_server(
             # set_request_path() so static loads don't pollute the
             # Reader/Maintainer shell-selection thread-local.
             if path.startswith("/static/"):
-                self._serve_static(path[len("/static/"):])
+                self._serve_static(path[len("/static/") :])
                 return
 
             # BL-050: shell selection is decided by URL prefix.  The
@@ -335,7 +340,8 @@ def create_server(
                 if path == "/":
                     pack_name = query.get("pack", [""])[0] or None
                     payload = build_reader_home_payload(
-                        resolved_vault, pack_name=pack_name,
+                        resolved_vault,
+                        pack_name=pack_name,
                     )
                     self._write_html(_render_reader_home(payload))
                     return
@@ -437,9 +443,7 @@ def create_server(
                     # both — preferring ``object_kind`` — so existing
                     # bookmarks and chip-rail links keep filtering.
                     object_kind = (
-                        query.get("object_kind", [""])[0]
-                        or query.get("kind", [""])[0]
-                        or None
+                        query.get("object_kind", [""])[0] or query.get("kind", [""])[0] or None
                     )
                     pack_name = query.get("pack", [""])[0] or None
                     payload = build_objects_index_payload(
@@ -773,9 +777,7 @@ def create_server(
                     return
                 if path == "/ops/queue":
                     pack_name = query.get("pack", [""])[0] or None
-                    payload = build_queue_overview_payload(
-                        resolved_vault, pack_name=pack_name
-                    )
+                    payload = build_queue_overview_payload(resolved_vault, pack_name=pack_name)
                     self._write_html(_render_queue_overview_page(payload))
                     return
                 if path == "/api/production":
@@ -846,7 +848,9 @@ def create_server(
                         return
                     self._write_json(
                         build_graph_map_payload(
-                            resolved_vault, pack_name=pack_name, query=q,
+                            resolved_vault,
+                            pack_name=pack_name,
+                            query=q,
                             show_all=show_all,
                         )
                     )
@@ -860,7 +864,9 @@ def create_server(
                     ):
                         return
                     payload = build_graph_map_payload(
-                        resolved_vault, pack_name=pack_name, query=q,
+                        resolved_vault,
+                        pack_name=pack_name,
+                        query=q,
                         show_all=show_all,
                     )
                     self._write_html(_render_graph_atlas_page(payload, action_path="/graph"))
@@ -874,7 +880,9 @@ def create_server(
                     ):
                         return
                     payload = build_graph_map_payload(
-                        resolved_vault, pack_name=pack_name, query=q,
+                        resolved_vault,
+                        pack_name=pack_name,
+                        query=q,
                         show_all=show_all,
                     )
                     self._write_html(_render_graph_atlas_page(payload, action_path="/map"))
@@ -969,7 +977,9 @@ def create_server(
                     # crystal, emit a reuse event so crystal_scoring's
                     # ``reuse_recency_norm`` has a producer.  Best-effort.
                     _maybe_emit_crystal_note_reuse(
-                        resolved_vault, relative_path, pack_name,
+                        resolved_vault,
+                        relative_path,
+                        pack_name,
                     )
                     self._write_html(
                         _render_note_page(resolved_vault, relative_path, markdown, payload)
@@ -1062,7 +1072,9 @@ def create_server(
                     raw_days = query.get("days", [""])[0]
                     days = int(raw_days) if raw_days.isdigit() else None
                     payload = build_timeline_payload(
-                        resolved_vault, pack_name=pack_name, days=days,
+                        resolved_vault,
+                        pack_name=pack_name,
+                        days=days,
                     )
                     if path == "/api/timeline":
                         self._write_json(payload)
@@ -1089,7 +1101,9 @@ def create_server(
                     raw_limit = query.get("limit", [""])[0]
                     limit = int(raw_limit) if raw_limit.isdigit() else None
                     payload = build_runs_index_payload(
-                        resolved_vault, pack_name=pack_name, limit=limit,
+                        resolved_vault,
+                        pack_name=pack_name,
+                        limit=limit,
                     )
                     if path == "/api/runs":
                         self._write_json(payload)
@@ -1104,7 +1118,9 @@ def create_server(
                     txn_id = path.split("/", 3)[-1] if path.count("/") >= 3 else ""
                     pack_name = query.get("pack", [""])[0] or None
                     payload = build_run_detail_payload(
-                        resolved_vault, txn_id, pack_name=pack_name,
+                        resolved_vault,
+                        txn_id,
+                        pack_name=pack_name,
                     )
                     if is_api:
                         self._write_json(payload)
@@ -1152,6 +1168,9 @@ def create_server(
                         max_polls=max_polls,
                         object_id=object_id or None,
                     )
+                    return
+                if path == "/chat":
+                    self._handle_chat_page_get(query, csrf_token)
                     return
                 self.send_error(404, "Not Found")
             except ValueError as exc:
@@ -1230,7 +1249,8 @@ def create_server(
                         return
                     self._resolve_contradiction_action(form)
                     self._redirect(
-                        self._form_first(form, "next").strip() or "/ops/queue/contradictions?status=resolved"
+                        self._form_first(form, "next").strip()
+                        or "/ops/queue/contradictions?status=resolved"
                     )
                     return
                 if path == "/api/summaries/rebuild":
@@ -1351,6 +1371,9 @@ def create_server(
                     payload = self._dismiss_action(form)
                     self._redirect(str(payload["next_path"]))
                     return
+                if path == "/chat/message":
+                    self._handle_chat_message_post(form, csrf_token)
+                    return
                 self.send_error(404, "Not Found")
             except ValueError as exc:
                 self.send_error(400, str(exc))
@@ -1385,6 +1408,135 @@ def create_server(
             else:
                 self._write_html(_render_unsupported_route_page(route_path, requested_pack))
             return True
+
+        # ── BL-086: Reader /chat ───────────────────────────────
+
+        def _handle_chat_page_get(self, query: dict[str, list[str]], csrf: str) -> None:
+            """Render ``/chat?id=<chat_id>&anchor=<kind:ref>``.
+
+            For an existing session, the transcript is loaded.
+            For a new session, the composer pre-binds the anchor
+            passed by BL-087's entry buttons.
+            """
+            from ovp_pipeline.commands._chat_page import (
+                render_chat_page_body,
+            )
+            from ovp_pipeline.commands.chat_handler import _find_chat_by_id
+            from ovp_pipeline.commands._chat_page import _profile_options  # noqa: F401
+
+            chat_id = (query.get("id", [""])[0] or "").strip()
+            anchor_raw = (query.get("anchor", [""])[0] or "").strip()
+            anchor_title = (query.get("title", [""])[0] or "").strip()
+
+            chat_path = None
+            if chat_id:
+                chat_path = _find_chat_by_id(resolved_vault, chat_id)
+
+            anchor_kind = "standalone"
+            anchor_ref = ""
+            if anchor_raw and not chat_path:
+                if ":" in anchor_raw:
+                    anchor_kind, _, anchor_ref = anchor_raw.partition(":")
+                else:
+                    anchor_kind, anchor_ref = "note", anchor_raw
+
+            body = render_chat_page_body(
+                resolved_vault,
+                chat_id=chat_id or None,
+                chat_path=chat_path,
+                anchor_kind=anchor_kind,
+                anchor_ref=anchor_ref,
+                anchor_title=anchor_title,
+                csrf_token=csrf,
+            )
+            self._write_html(_layout("Ask the vault", body))
+
+        def _handle_chat_message_post(self, form: dict[str, list[str]], csrf: str) -> None:
+            """Handle POST ``/chat/message`` — runs one inquiry turn.
+
+            Synchronous v1: full page refresh after each turn.  SSE
+            streaming is a follow-up.
+            """
+            from ovp_pipeline.commands._chat_page import (
+                chat_page_redirect_target,
+                render_chat_page_body,
+            )
+            from ovp_pipeline.commands.chat_handler import (
+                ChatCapExceeded,
+                run_turn,
+            )
+
+            chat_id = self._form_first(form, "chat_id").strip() or None
+            anchor_raw = self._form_first(form, "anchor").strip()
+            message = self._form_first(form, "message").strip()
+            profile = self._form_first(form, "profile").strip() or "balanced"
+            visibility = self._form_first(form, "visibility").strip() or "indexed"
+
+            if not message:
+                self._write_html(
+                    _layout(
+                        "Ask the vault",
+                        render_chat_page_body(
+                            resolved_vault,
+                            chat_id=chat_id,
+                            error_message="Message cannot be empty.",
+                            csrf_token=csrf,
+                        ),
+                    ),
+                    status=400,
+                )
+                return
+
+            anchor_kind = "standalone"
+            anchor_ref = ""
+            if anchor_raw:
+                if ":" in anchor_raw:
+                    anchor_kind, _, anchor_ref = anchor_raw.partition(":")
+                else:
+                    anchor_kind, anchor_ref = "note", anchor_raw
+
+            try:
+                result = run_turn(
+                    resolved_vault,
+                    chat_id=chat_id,
+                    user_message=message,
+                    anchor_kind=anchor_kind,
+                    anchor_ref=anchor_ref,
+                    profile_name=profile if not chat_id else None,
+                    visibility=visibility,
+                )
+            except ChatCapExceeded as exc:
+                self._write_html(
+                    _layout(
+                        "Ask the vault",
+                        render_chat_page_body(
+                            resolved_vault,
+                            chat_id=chat_id,
+                            anchor_kind=anchor_kind,
+                            anchor_ref=anchor_ref,
+                            profile=profile,
+                            error_message=str(exc),
+                            csrf_token=csrf,
+                        ),
+                    ),
+                    status=429,
+                )
+                return
+            except ValueError as exc:
+                self._write_html(
+                    _layout(
+                        "Ask the vault",
+                        render_chat_page_body(
+                            resolved_vault,
+                            chat_id=chat_id,
+                            error_message=str(exc),
+                            csrf_token=csrf,
+                        ),
+                    ),
+                    status=400,
+                )
+                return
+            self._redirect(chat_page_redirect_target(result.chat_id))
 
         def _resolve_contradiction_action(self, form: dict[str, list[str]]) -> dict[str, object]:
             contradiction_ids = [
@@ -1800,10 +1952,7 @@ def create_server(
                 self._write_html("<h1>404</h1>", status=404)
                 return
             try:
-                resource = (
-                    importlib_resources.files("ovp_pipeline")
-                    .joinpath("static", asset_path)
-                )
+                resource = importlib_resources.files("ovp_pipeline").joinpath("static", asset_path)
                 body = resource.read_bytes()
             except (FileNotFoundError, IsADirectoryError, NotADirectoryError, OSError):
                 self._write_html("<h1>404</h1>", status=404)

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -1464,6 +1464,8 @@ def create_server(
                 run_turn,
             )
 
+            from ovp_pipeline.commands.chat_handler import _find_chat_by_id
+
             chat_id = self._form_first(form, "chat_id").strip() or None
             anchor_raw = self._form_first(form, "anchor").strip()
             anchor_title = self._form_first(form, "anchor_title").strip()
@@ -1475,17 +1477,22 @@ def create_server(
 
             def _render_error(status: int, error_message: str) -> None:
                 """Re-render the page with the operator's submitted
-                form state preserved (CodeRabbit Major)."""
+                form state preserved (CodeRabbit Major).  Looks up
+                the existing chat path so a follow-up error
+                rerender still shows the transcript."""
+                existing_path = _find_chat_by_id(resolved_vault, chat_id) if chat_id else None
                 self._write_html(
                     _layout(
                         "Ask the vault",
                         render_chat_page_body(
                             resolved_vault,
                             chat_id=chat_id,
+                            chat_path=existing_path,
                             anchor_kind=anchor_kind,
                             anchor_ref=anchor_ref,
                             anchor_title=anchor_title,
                             profile=profile,
+                            visibility=visibility,
                             error_message=error_message,
                             csrf_token=csrf,
                         ),

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -1419,10 +1419,10 @@ def create_server(
             passed by BL-087's entry buttons.
             """
             from ovp_pipeline.commands._chat_page import (
+                parse_anchor_string,
                 render_chat_page_body,
             )
             from ovp_pipeline.commands.chat_handler import _find_chat_by_id
-            from ovp_pipeline.commands._chat_page import _profile_options  # noqa: F401
 
             chat_id = (query.get("id", [""])[0] or "").strip()
             anchor_raw = (query.get("anchor", [""])[0] or "").strip()
@@ -1432,13 +1432,10 @@ def create_server(
             if chat_id:
                 chat_path = _find_chat_by_id(resolved_vault, chat_id)
 
-            anchor_kind = "standalone"
-            anchor_ref = ""
-            if anchor_raw and not chat_path:
-                if ":" in anchor_raw:
-                    anchor_kind, _, anchor_ref = anchor_raw.partition(":")
-                else:
-                    anchor_kind, anchor_ref = "note", anchor_raw
+            if chat_path:
+                anchor_kind, anchor_ref = "standalone", ""
+            else:
+                anchor_kind, anchor_ref = parse_anchor_string(anchor_raw)
 
             body = render_chat_page_body(
                 resolved_vault,
@@ -1459,6 +1456,7 @@ def create_server(
             """
             from ovp_pipeline.commands._chat_page import (
                 chat_page_redirect_target,
+                parse_anchor_string,
                 render_chat_page_body,
             )
             from ovp_pipeline.commands.chat_handler import (
@@ -1468,44 +1466,16 @@ def create_server(
 
             chat_id = self._form_first(form, "chat_id").strip() or None
             anchor_raw = self._form_first(form, "anchor").strip()
+            anchor_title = self._form_first(form, "anchor_title").strip()
             message = self._form_first(form, "message").strip()
             profile = self._form_first(form, "profile").strip() or "balanced"
             visibility = self._form_first(form, "visibility").strip() or "indexed"
 
-            if not message:
-                self._write_html(
-                    _layout(
-                        "Ask the vault",
-                        render_chat_page_body(
-                            resolved_vault,
-                            chat_id=chat_id,
-                            error_message="Message cannot be empty.",
-                            csrf_token=csrf,
-                        ),
-                    ),
-                    status=400,
-                )
-                return
+            anchor_kind, anchor_ref = parse_anchor_string(anchor_raw)
 
-            anchor_kind = "standalone"
-            anchor_ref = ""
-            if anchor_raw:
-                if ":" in anchor_raw:
-                    anchor_kind, _, anchor_ref = anchor_raw.partition(":")
-                else:
-                    anchor_kind, anchor_ref = "note", anchor_raw
-
-            try:
-                result = run_turn(
-                    resolved_vault,
-                    chat_id=chat_id,
-                    user_message=message,
-                    anchor_kind=anchor_kind,
-                    anchor_ref=anchor_ref,
-                    profile_name=profile if not chat_id else None,
-                    visibility=visibility,
-                )
-            except ChatCapExceeded as exc:
+            def _render_error(status: int, error_message: str) -> None:
+                """Re-render the page with the operator's submitted
+                form state preserved (CodeRabbit Major)."""
                 self._write_html(
                     _layout(
                         "Ask the vault",
@@ -1514,26 +1484,46 @@ def create_server(
                             chat_id=chat_id,
                             anchor_kind=anchor_kind,
                             anchor_ref=anchor_ref,
+                            anchor_title=anchor_title,
                             profile=profile,
-                            error_message=str(exc),
+                            error_message=error_message,
                             csrf_token=csrf,
                         ),
                     ),
-                    status=429,
+                    status=status,
                 )
+
+            if not message:
+                _render_error(400, "Message cannot be empty.")
+                return
+
+            try:
+                result = run_turn(
+                    resolved_vault,
+                    chat_id=chat_id,
+                    user_message=message,
+                    anchor_kind=anchor_kind,
+                    anchor_ref=anchor_ref,
+                    anchor_title=anchor_title,
+                    profile_name=profile or None,
+                    visibility=visibility,
+                )
+            except ChatCapExceeded as exc:
+                _render_error(429, str(exc))
                 return
             except ValueError as exc:
-                self._write_html(
-                    _layout(
-                        "Ask the vault",
-                        render_chat_page_body(
-                            resolved_vault,
-                            chat_id=chat_id,
-                            error_message=str(exc),
-                            csrf_token=csrf,
-                        ),
-                    ),
-                    status=400,
+                _render_error(400, str(exc))
+                return
+            except Exception as exc:  # noqa: BLE001 — codex P2
+                # Provider failures + ``litellm`` import errors raise
+                # generic RuntimeError / OSError / etc.  Render the
+                # page inline rather than 500-ing the request — the
+                # transcript already preserved the user turn so the
+                # operator can retry.
+                logger_name = exc.__class__.__name__
+                _render_error(
+                    500,
+                    f"Inquiry failed ({logger_name}): {exc}",
                 )
                 return
             self._redirect(chat_page_redirect_target(result.chat_id))

--- a/tests/test_chat_page.py
+++ b/tests/test_chat_page.py
@@ -215,3 +215,54 @@ def test_parse_anchor_string_bare_path_defaults_to_note():
 
 def test_parse_anchor_string_strips_whitespace():
     assert parse_anchor_string("  note : x  ") == ("note", "x")
+
+
+# ── CodeRabbit Major — H1 in body must not overwrite title ────
+
+
+def test_h1_inside_user_turn_does_not_overwrite_title(tmp_path: Path):
+    """A markdown-heavy reply that contains ``# Heading`` lines as
+    body content must NOT lose those lines and must NOT have the
+    transcript-title silently overwritten."""
+    chat = tmp_path / "x.md"
+    chat.write_text(
+        "---\ntype: chat\nchat_id: chat-abc\n---\n\n"
+        "# Original Inquiry Title\n\n"
+        "## User · 2026-05-12T11:00:00Z\n\n"
+        "# Some H1 inside user prose\n\nbody text.\n\n"
+        "## Assistant · 2026-05-12T11:00:01Z · turn-2\n\n"
+        "<!-- context-manifest\n  token_estimate: 5\n-->\n\n"
+        "# Heading inside reply\n\nReply body.\n\n",
+        encoding="utf-8",
+    )
+    html = render_chat_page_body(tmp_path, chat_path=chat)
+    # Title comes from the pre-turn H1 only.
+    assert "Original Inquiry Title" in html
+    # In-body H1s land in their respective turn bodies.
+    assert "Some H1 inside user prose" in html
+    assert "Heading inside reply" in html
+
+
+# ── CodeRabbit Major — hidden visibility carries through POST ──
+
+
+def test_existing_session_emits_hidden_visibility_field(tmp_path: Path):
+    """Disabled radio buttons aren't submitted with the form; the
+    hidden field is what actually carries ``visibility`` to the
+    POST handler on follow-ups."""
+    path, _ = create_chat_file(
+        tmp_path,
+        anchor=ChatAnchor(kind="standalone"),
+        visibility="unindexed",
+    )
+    html = render_chat_page_body(tmp_path, chat_path=path)
+    assert 'type="hidden" name="visibility" value="unindexed"' in html
+
+
+def test_render_chat_page_body_respects_visibility_kwarg(tmp_path: Path):
+    """An error rerender passes the operator's submitted visibility
+    back to the renderer; pre-existing-session paths still derive
+    from frontmatter."""
+    html = render_chat_page_body(tmp_path, visibility="unindexed")
+    assert 'value="unindexed" checked' in html
+    assert 'value="indexed" checked' not in html

--- a/tests/test_chat_page.py
+++ b/tests/test_chat_page.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from ovp_pipeline.chat_fileops import ChatAnchor, create_chat_file
 from ovp_pipeline.commands._chat_page import (
     _profile_options,
+    _strip_html_comments,
+    parse_anchor_string,
     render_chat_page_body,
 )
 
@@ -141,3 +143,75 @@ def test_visibility_toggle_preserves_unindexed_session(tmp_path: Path):
     html = render_chat_page_body(tmp_path, chat_path=path)
     assert 'value="unindexed" checked' in html
     assert 'value="indexed" checked' not in html
+
+
+def test_visibility_toggle_disabled_on_existing_session(tmp_path: Path):
+    """Once a session starts, visibility is locked — run_turn
+    ignores changes on follow-up turns, so the toggle is disabled
+    to avoid the impression you can flip it (CodeRabbit M)."""
+    path, _ = create_chat_file(
+        tmp_path,
+        anchor=ChatAnchor(kind="note", path="x.md"),
+    )
+    html = render_chat_page_body(tmp_path, chat_path=path)
+    assert "disabled" in html
+    assert "Visibility is locked" in html
+
+
+# ── Codex P2 — anchor_title round-trips through hidden field ───
+
+
+def test_new_anchored_chat_carries_anchor_title_as_hidden(tmp_path: Path):
+    """The friendly title from the GET URL must land as a hidden
+    field so the POST handler can persist it on creation."""
+    html = render_chat_page_body(
+        tmp_path,
+        anchor_kind="note",
+        anchor_ref="20-Areas/topic.md",
+        anchor_title="My Topic — explainer",
+    )
+    assert 'name="anchor_title"' in html
+    assert 'value="My Topic — explainer"' in html
+
+
+# ── CodeRabbit High — HTML comment stripping preserves prose ───
+
+
+def test_strip_html_comments_keeps_inline_prose():
+    """Single-line ``<!-- ... -->`` strips just the comment range
+    — content before AND after the comment is preserved
+    (CodeRabbit High)."""
+    cleaned, in_block = _strip_html_comments("before <!-- inline --> after", in_block=False)
+    assert cleaned == "before  after"
+    assert in_block is False
+
+
+def test_strip_html_comments_handles_multi_line_block():
+    open_line, in_block = _strip_html_comments("prefix <!-- start", in_block=False)
+    assert open_line == "prefix "
+    assert in_block is True
+    inside_line, in_block = _strip_html_comments("middle line", in_block=True)
+    assert inside_line == ""
+    assert in_block is True
+    close_line, in_block = _strip_html_comments("end --> suffix", in_block=True)
+    assert close_line == " suffix"
+    assert in_block is False
+
+
+# ── parse_anchor_string ────────────────────────────────────────
+
+
+def test_parse_anchor_string_empty_is_standalone():
+    assert parse_anchor_string("") == ("standalone", "")
+
+
+def test_parse_anchor_string_kind_colon_ref():
+    assert parse_anchor_string("note:20-Areas/x.md") == ("note", "20-Areas/x.md")
+
+
+def test_parse_anchor_string_bare_path_defaults_to_note():
+    assert parse_anchor_string("20-Areas/x.md") == ("note", "20-Areas/x.md")
+
+
+def test_parse_anchor_string_strips_whitespace():
+    assert parse_anchor_string("  note : x  ") == ("note", "x")

--- a/tests/test_chat_page.py
+++ b/tests/test_chat_page.py
@@ -1,0 +1,143 @@
+"""Tests for M21b / BL-086 — Reader ``/chat`` page renderer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ovp_pipeline.chat_fileops import ChatAnchor, create_chat_file
+from ovp_pipeline.commands._chat_page import (
+    _profile_options,
+    render_chat_page_body,
+)
+
+# ── renderer — standalone (new session) ────────────────────────
+
+
+def test_render_new_standalone_chat_has_composer(tmp_path: Path):
+    html = render_chat_page_body(tmp_path)
+    assert 'method="POST" action="/chat/message"' in html
+    assert "Standalone (no anchor)" in html
+    assert "<textarea" in html
+    # Visibility toggle copy from the plan must appear verbatim.
+    assert "Don't index or reuse this inquiry." in html
+    assert "selected LLM provider" in html
+
+
+def test_render_new_anchored_chat_carries_anchor(tmp_path: Path):
+    html = render_chat_page_body(
+        tmp_path,
+        anchor_kind="note",
+        anchor_ref="20-Areas/topic.md",
+        anchor_title="A topic",
+    )
+    assert 'value="note:20-Areas/topic.md"' in html
+    assert "A topic" in html
+
+
+def test_render_new_chat_does_not_include_manifest_card(tmp_path: Path):
+    """The manifest card only shows on existing sessions (it's the
+    audit summary of the prior turn's context, not a directive for
+    the next one)."""
+    html = render_chat_page_body(tmp_path)
+    assert "Context anchored to" not in html
+
+
+# ── renderer — existing session ────────────────────────────────
+
+
+def test_render_existing_chat_shows_manifest_and_turns(tmp_path: Path):
+    path, _ = create_chat_file(
+        tmp_path,
+        anchor=ChatAnchor(kind="note", path="20-Areas/x.md", title="X"),
+        topic="memory architecture",
+    )
+    # Append fake turns directly to the markdown so the renderer
+    # has something to display.  Tests of run_turn cover the
+    # round-trip.
+    path.write_text(
+        path.read_text(encoding="utf-8") + "\n## User · 2026-05-12T11:00:01Z\n\nHello vault.\n\n"
+        "## Assistant · 2026-05-12T11:00:02Z · turn-2\n\n"
+        "<!-- context-manifest\n  token_estimate: 10\n-->\n\n"
+        "Hi there.\n\n",
+        encoding="utf-8",
+    )
+    html = render_chat_page_body(tmp_path, chat_path=path)
+    assert "Context anchored to" in html
+    assert "Hello vault." in html
+    assert "Hi there." in html
+    # The literal manifest HTML comment block must not leak into
+    # the rendered transcript body (the explanatory <code> snippet
+    # in the manifest card is fine — it's escaped pedagogy, not
+    # raw audit data).
+    assert "token_estimate: 10" not in html
+    assert "<!-- context-manifest" not in html
+    # User vs assistant turn classes are distinct so CSS can style.
+    assert "chat-turn-user" in html
+    assert "chat-turn-assistant" in html
+
+
+def test_render_missing_chat_renders_error_block(tmp_path: Path):
+    html = render_chat_page_body(tmp_path, chat_id="chat-nope")
+    assert "not found" in html.lower()
+
+
+# ── profile dropdown ───────────────────────────────────────────
+
+
+def test_profile_options_orders_canonical_first(tmp_path: Path):
+    cfg = tmp_path / ".ovp" / "llm_profiles.yaml"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text(
+        """
+profiles:
+  my-custom:
+    provider: anthropic
+    model: claude-x
+  balanced:
+    provider: anthropic
+    model: claude-sonnet-4-6
+  deep:
+    provider: anthropic
+    model: claude-opus-4-7
+  fast:
+    provider: anthropic
+    model: MiniMax-M2.7-highspeed
+""",
+        encoding="utf-8",
+    )
+    options = _profile_options(tmp_path, current="balanced")
+    # Canonical three first, then custom.
+    assert options.index('value="fast"') < options.index('value="balanced"')
+    assert options.index('value="balanced"') < options.index('value="deep"')
+    assert options.index('value="deep"') < options.index('value="my-custom"')
+    # Selection persists.
+    assert 'value="balanced" selected' in options
+
+
+def test_profile_options_with_only_fallback_book(tmp_path: Path):
+    """A vault without ``.ovp/llm_profiles.yaml`` falls back to a
+    single 'balanced' profile from env vars.  The dropdown still
+    renders something."""
+    options = _profile_options(tmp_path, current="balanced")
+    assert 'value="balanced"' in options
+
+
+# ── visibility toggle ──────────────────────────────────────────
+
+
+def test_visibility_toggle_defaults_to_indexed_for_new_chats(tmp_path: Path):
+    html = render_chat_page_body(tmp_path)
+    # Indexed pre-selected; unindexed unselected.
+    assert 'value="indexed" checked' in html
+    assert 'value="unindexed" checked' not in html
+
+
+def test_visibility_toggle_preserves_unindexed_session(tmp_path: Path):
+    path, _ = create_chat_file(
+        tmp_path,
+        anchor=ChatAnchor(kind="standalone"),
+        visibility="unindexed",
+    )
+    html = render_chat_page_body(tmp_path, chat_path=path)
+    assert 'value="unindexed" checked' in html
+    assert 'value="indexed" checked' not in html


### PR DESCRIPTION
## Summary

First M21b PR.  Lands the Reader-side ``/chat`` page so an
operator can carry on an inquiry without dropping to the CLI.

* New: ``src/ovp_pipeline/commands/_chat_page.py``
* Routes wired in ``src/ovp_pipeline/commands/ui_server.py``
* New: ``tests/test_chat_page.py`` — 9 tests.

## What's in this PR

* ``GET /chat?id=<chat_id>`` — render existing session.
* ``GET /chat?anchor=<kind>:<ref>`` — new session pre-bound to
  anchor (BL-087's entry buttons will use this).
* ``POST /chat/message`` — runs one turn via ``run_turn``,
  redirects to ``/chat?id=<id>``.  ChatCapExceeded → 429,
  ValueError → 400, both render the page with the error inline.
* Profile dropdown — Fast / Balanced / Deep canonical first,
  then custom profiles.  Never raw provider/model.
* Visibility toggle — exact M21-plan copy: "Don't index or reuse
  this inquiry. The selected LLM provider still receives the
  current request."
* Manifest card on existing sessions.

## Scope reduction acknowledged

**SSE streaming is deferred to a follow-up PR.**  The plan calls
for streaming under BL-086.  The chat_handler refactor needed to
thread tokens through SSE is larger than this PR's budget can
absorb cleanly, and the synchronous full-page-refresh shape works
end to end today (same shape as M21a's CLI).  The Reader UI is
functional + auditable; streaming is a polish layer.

## Test plan

- [x] ``rtk proxy python -m pytest tests/test_chat_page.py -q`` — 9 passed
- [x] ``ruff check`` + ``black --check`` clean
- [x] ``ui_server`` still imports cleanly

## Plan reference

``docs/plans/2026-05-12-m21-chat-surface.md`` — BL-086 detail at
``### BL-086 — Reader /chat page + SSE``.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reader-facing chat page with transcript display, message composer, anchor parsing (kind:ref or bare note), optional anchor title, and post-submit redirect
  * Profile selection (canonical + custom) with default "balanced"
  * Anchor manifest card and anchor “pill” in composer

* **Bug Fixes**
  * Hidden HTML comment snapshots stripped from displayed transcripts
  * Missing-chat shows retry/error state

* **Behavior**
  * Visibility defaults to "indexed" for new chats; locked (disabled) for existing sessions with a hidden preserved value

* **Tests**
  * Comprehensive tests for rendering, anchoring, profiles, visibility, comment stripping, and parsing

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fakechris/obsidian_vault_pipeline/pull/214)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->