### PR TITLE
feat(bl-085): chats projection + visibility-aware FTS (M21c step 1)

### DIFF
--- a/src/ovp_pipeline/chats_projection.py
+++ b/src/ovp_pipeline/chats_projection.py
@@ -31,19 +31,31 @@ from ovp_pipeline.chat_fileops import CHATS_DIR, ChatFrontmatter, parse_chat
 logger = logging.getLogger(__name__)
 
 
-# Synthetic slug prefix for ``pages_index`` shadow rows.  Picked so
-# the chat-vs-note distinction is obvious in any join: ``slug LIKE
-# 'chat:%'`` is exactly the indexed-chat corpus.
-_CHAT_SLUG_PREFIX = "chat:"
+# Synthetic slug shape for ``pages_index`` shadow rows.  ``:`` would
+# be stripped by ``identity.canonicalize_note_id`` (the helper that
+# normalises every ``/note`` / ``/object`` route input), so a slug
+# like ``chat:chat-a7b3`` becomes ``chatchat-a7b3`` on lookup and the
+# session disappears from search-driven retrieval.  Codex review P2:
+# use the bare ``chat_id`` (which already starts with ``chat-``) so
+# the slug round-trips cleanly through canonicalisation.
+#
+# ``slug LIKE 'chat-%'`` is the indexed-chat corpus.  In practice
+# ``chat_id`` is ``chat-<8 hex>`` (BL-082 mint), so the collision
+# risk against operator-created notes is negligible; the projection
+# rebuild also walks the chats corpus exclusively, so a real note
+# happening to be named ``chat-abcd1234.md`` would be left alone.
+_CHAT_SLUG_PREFIX = "chat-"
 
 
 def chat_slug(chat_id: str) -> str:
     """Return the ``pages_index`` shadow-slug for a chat session.
 
-    ``chat-a7b3`` → ``chat:chat-a7b3``.  Always prefixed so the
-    indexed-chat corpus is trivially separable from regular pages.
+    The chat_id minted by :func:`chat_fileops.new_chat_id` already
+    starts with ``chat-``, so we just return it.  Survives
+    :func:`identity.canonicalize_note_id` so search-driven
+    retrieval round-trips cleanly (codex review P2).
     """
-    return f"{_CHAT_SLUG_PREFIX}{chat_id}"
+    return chat_id
 
 
 def iter_chat_transcripts(vault_dir: Path) -> Iterable[Path]:
@@ -110,15 +122,27 @@ def rebuild_chats_projection(
         "unindexed": 0,
         "skipped": 0,
     }
+    # Codex P1: FTS5 declares ``slug`` as ``UNINDEXED``, which
+    # means ``LIKE`` on that column doesn't actually match — a
+    # naive ``DELETE FROM page_fts WHERE slug LIKE 'chat-%'``
+    # leaves every prior chat row in place.  Read the explicit
+    # chat slugs from the projection table first, then delete
+    # each one by exact equality.  Visit ``page_fts`` BEFORE
+    # clearing ``chats`` so the slug list is still available.
+    prior_chat_slugs = [
+        chat_slug(row[0]) for row in conn.execute("SELECT chat_id FROM chats").fetchall()
+    ]
+    if prior_chat_slugs:
+        placeholders = ",".join("?" * len(prior_chat_slugs))
+        conn.execute(
+            f"DELETE FROM page_fts WHERE slug IN ({placeholders})",
+            prior_chat_slugs,
+        )
+        conn.execute(
+            f"DELETE FROM pages_index WHERE slug IN ({placeholders})",
+            prior_chat_slugs,
+        )
     conn.execute("DELETE FROM chats")
-    conn.execute(
-        "DELETE FROM pages_index WHERE slug LIKE ?",
-        (f"{_CHAT_SLUG_PREFIX}%",),
-    )
-    conn.execute(
-        "DELETE FROM page_fts WHERE slug LIKE ?",
-        (f"{_CHAT_SLUG_PREFIX}%",),
-    )
 
     for path in iter_chat_transcripts(vault_dir):
         fm = parse_chat(path)

--- a/src/ovp_pipeline/chats_projection.py
+++ b/src/ovp_pipeline/chats_projection.py
@@ -1,0 +1,221 @@
+"""Chats projection rebuild (M21c / BL-085).
+
+Sweeps ``40-Resources/Chats/**/*.md`` and writes:
+
+* one row per transcript to ``knowledge.db.chats`` (display / metadata)
+* for ``visibility = 'indexed'`` sessions only, a shadow row to
+  ``pages_index`` + a row to ``page_fts`` so the existing
+  ``/search`` (which is ``page_fts JOIN pages_index``) finds
+  session bodies.
+
+Unindexed sessions get the ``chats`` row only — never reach search,
+never reach the BL-083 retrieval layer.  This is the privacy
+boundary the M21 plan locked in.
+
+The projection is fully rebuildable: ``ovp-knowledge-index`` calls
+:func:`rebuild_chats_projection` after walking the directory,
+clearing prior rows first.  Like every other projection in
+OVP, no mutable state lives in the DB — everything derives from
+the markdown corpus.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from pathlib import Path
+from typing import Iterable
+
+from ovp_pipeline.chat_fileops import CHATS_DIR, ChatFrontmatter, parse_chat
+
+logger = logging.getLogger(__name__)
+
+
+# Synthetic slug prefix for ``pages_index`` shadow rows.  Picked so
+# the chat-vs-note distinction is obvious in any join: ``slug LIKE
+# 'chat:%'`` is exactly the indexed-chat corpus.
+_CHAT_SLUG_PREFIX = "chat:"
+
+
+def chat_slug(chat_id: str) -> str:
+    """Return the ``pages_index`` shadow-slug for a chat session.
+
+    ``chat-a7b3`` → ``chat:chat-a7b3``.  Always prefixed so the
+    indexed-chat corpus is trivially separable from regular pages.
+    """
+    return f"{_CHAT_SLUG_PREFIX}{chat_id}"
+
+
+def iter_chat_transcripts(vault_dir: Path) -> Iterable[Path]:
+    """Yield every chat transcript under ``40-Resources/Chats/``.
+
+    Skips ``.lock`` sentinel files (BL-082 fileops uses them for
+    per-chat concurrency) and ``.tmp`` partials.
+    """
+    chats_dir = vault_dir / CHATS_DIR
+    if not chats_dir.is_dir():
+        return
+    for path in chats_dir.rglob("*.md"):
+        if path.name.startswith("."):
+            continue
+        yield path
+
+
+def _chat_body_text(path: Path) -> str:
+    """Return just the prose under the YAML frontmatter.
+
+    Strips manifest comments and the H1 so what feeds FTS is the
+    operator's questions + the assistant's prose — which is what
+    operators search for.
+    """
+    text = path.read_text(encoding="utf-8")
+    if text.startswith("---\n"):
+        end = text.find("\n---\n", 4)
+        if end > 0:
+            text = text[end + 5 :]
+    # Strip multi-line HTML comments (manifest snapshots).
+    parts: list[str] = []
+    in_block = False
+    for line in text.splitlines():
+        if in_block:
+            if "-->" in line:
+                in_block = False
+            continue
+        if "<!--" in line and "-->" not in line:
+            in_block = True
+            continue
+        if "<!--" in line and "-->" in line:
+            # Single-line comment — drop in place.
+            continue
+        parts.append(line)
+    return "\n".join(parts).strip()
+
+
+def rebuild_chats_projection(
+    conn: sqlite3.Connection,
+    vault_dir: Path,
+) -> dict[str, int]:
+    """Rebuild every chats-related projection row.
+
+    Clears ``chats``, removes prior ``pages_index`` /  ``page_fts``
+    rows whose slug starts with ``chat:``, then walks the
+    transcript corpus.
+
+    Caller (``ovp-knowledge-index``) owns the transaction +
+    commit.  Returns a counts dict for the run report.
+    """
+    counts = {
+        "total": 0,
+        "indexed": 0,
+        "unindexed": 0,
+        "skipped": 0,
+    }
+    conn.execute("DELETE FROM chats")
+    conn.execute(
+        "DELETE FROM pages_index WHERE slug LIKE ?",
+        (f"{_CHAT_SLUG_PREFIX}%",),
+    )
+    conn.execute(
+        "DELETE FROM page_fts WHERE slug LIKE ?",
+        (f"{_CHAT_SLUG_PREFIX}%",),
+    )
+
+    for path in iter_chat_transcripts(vault_dir):
+        fm = parse_chat(path)
+        if fm is None:
+            counts["skipped"] += 1
+            logger.debug(
+                "chats_projection: skipping non-chat file %s",
+                path,
+            )
+            continue
+        try:
+            rel_path = path.relative_to(vault_dir).as_posix()
+        except ValueError:
+            rel_path = str(path)
+        _insert_chat_row(conn, fm, rel_path)
+        counts["total"] += 1
+        if fm.visibility == "indexed":
+            _insert_indexed_shadow(conn, fm, rel_path, _chat_body_text(path))
+            counts["indexed"] += 1
+        else:
+            counts["unindexed"] += 1
+
+    return counts
+
+
+def _insert_chat_row(
+    conn: sqlite3.Connection,
+    fm: ChatFrontmatter,
+    rel_path: str,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO chats (
+            chat_id, pack, file_path, status, visibility,
+            anchor_kind, anchor_ref, anchor_title,
+            profile, model, temperature,
+            started_at, last_message_at, turn_count,
+            input_tokens, output_tokens
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            fm.chat_id,
+            "",  # pack column reserved for future BLs
+            rel_path,
+            fm.status,
+            fm.visibility,
+            fm.anchor.kind,
+            fm.anchor.path,
+            fm.anchor.title,
+            fm.profile,
+            fm.model,
+            fm.temperature,
+            fm.started_at,
+            fm.last_message_at,
+            fm.turn_count,
+            0,  # input_tokens — lifetime totals filled by BL-085-2
+            0,  # output_tokens
+        ),
+    )
+
+
+def _insert_indexed_shadow(
+    conn: sqlite3.Connection,
+    fm: ChatFrontmatter,
+    rel_path: str,
+    body: str,
+) -> None:
+    """Insert ``pages_index`` + ``page_fts`` rows so /search finds
+    this indexed session.
+
+    The synthetic slug ``chat:<chat_id>`` keeps the indexed-chat
+    corpus trivially separable from regular notes.
+    """
+    slug = chat_slug(fm.chat_id)
+    title = (
+        fm.anchor.title or f"Inquiry — {fm.anchor.kind}: {fm.anchor.path}".rstrip(": ")
+        if fm.anchor.path
+        else fm.anchor.title or f"Inquiry {fm.chat_id}"
+    )
+    day_id = fm.last_message_at[:10] if fm.last_message_at else ""
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO pages_index (
+            slug, title, note_type, path, day_id, frontmatter_json, body
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (slug, title, "chat", rel_path, day_id, "{}", body),
+    )
+    conn.execute(
+        "INSERT INTO page_fts (slug, title, body) VALUES (?, ?, ?)",
+        (slug, title, body),
+    )
+
+
+__all__ = [
+    "_CHAT_SLUG_PREFIX",
+    "chat_slug",
+    "iter_chat_transcripts",
+    "rebuild_chats_projection",
+]

--- a/src/ovp_pipeline/knowledge_index.py
+++ b/src/ovp_pipeline/knowledge_index.py
@@ -154,6 +154,33 @@ CREATE TABLE entity_mentions (
 CREATE INDEX idx_entity_mentions_entity ON entity_mentions(entity_slug);
 CREATE INDEX idx_entity_mentions_source ON entity_mentions(source_slug);
 CREATE INDEX idx_entity_mentions_type ON entity_mentions(entity_type);
+
+-- M21 BL-085: ``chats`` is a *display / metadata* projection over
+-- the ``40-Resources/Chats/**/*.md`` corpus.  Lifetime token counts
+-- here are display derivatives only — daily-cap math in BL-084
+-- reads the append-only ``audit_events`` ledger, not this table.
+CREATE TABLE chats (
+  chat_id TEXT PRIMARY KEY,
+  pack TEXT NOT NULL DEFAULT '',
+  file_path TEXT NOT NULL,
+  status TEXT NOT NULL,            -- active | pinned | archived
+  visibility TEXT NOT NULL,        -- indexed | unindexed
+  anchor_kind TEXT NOT NULL,
+  anchor_ref TEXT NOT NULL DEFAULT '',
+  anchor_title TEXT NOT NULL DEFAULT '',
+  profile TEXT NOT NULL DEFAULT '',
+  model TEXT NOT NULL DEFAULT '',
+  temperature REAL NOT NULL DEFAULT 0.7,
+  started_at TEXT NOT NULL DEFAULT '',
+  last_message_at TEXT NOT NULL DEFAULT '',
+  turn_count INTEGER NOT NULL DEFAULT 0,
+  input_tokens INTEGER NOT NULL DEFAULT 0,
+  output_tokens INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX idx_chats_pack_last ON chats(pack, last_message_at DESC);
+CREATE INDEX idx_chats_visibility ON chats(visibility);
+CREATE INDEX idx_chats_status ON chats(status);
 """
 
 SCHEMA += "\n" + TRUTH_STORE_SCHEMA
@@ -1346,6 +1373,24 @@ def rebuild_knowledge_index(
             except Exception as exc:
                 logger.warning(
                     "crystal page_fts indexing skipped: %s", exc,
+                )
+
+            # M21 BL-085: rebuild chats projection.  Indexed sessions
+            # also land in pages_index + page_fts so /search finds
+            # them; unindexed sessions get a chats row only.  Best-
+            # effort — never block the primary index rebuild.
+            try:
+                from .chats_projection import rebuild_chats_projection
+                chats_counts = rebuild_chats_projection(
+                    conn, vault_dir=layout.vault_dir,
+                )
+                if chats_counts.get("total"):
+                    logger.debug(
+                        "chats projection rebuilt: %s", chats_counts,
+                    )
+            except Exception as exc:
+                logger.warning(
+                    "chats projection rebuild skipped: %s", exc,
                 )
 
             conn.commit()

--- a/src/ovp_pipeline/knowledge_index.py
+++ b/src/ovp_pipeline/knowledge_index.py
@@ -32,7 +32,7 @@ SUMMARY_MAX_LEN = 320
 SUMMARY_RELATED_LIMIT = 3
 AUTHORITY_SCHEMA_VERSION = 1
 KNOWLEDGE_DB_PROJECTION_KIND = "knowledge_db"
-KNOWLEDGE_DB_PROJECTION_SCHEMA_VERSION = 7
+KNOWLEDGE_DB_PROJECTION_SCHEMA_VERSION = 8
 
 
 _FTS_QUERY_SCRUB = re.compile(r"[^\w\u4e00-\u9fff]+", flags=re.UNICODE)
@@ -904,6 +904,17 @@ def _knowledge_db_supports_pack_schema(db_path: Path) -> bool:
             "source_slug",
             "confidence",
             "detection_method",
+        },
+        # M21 BL-085 — chats projection.  Required so existing
+        # vaults trigger a full rebuild when this code lands;
+        # without the table, ``/chats`` and the visibility-aware
+        # FTS would silently 500.  Schema version bumped to 8.
+        "chats": {
+            "chat_id",
+            "visibility",
+            "anchor_kind",
+            "status",
+            "file_path",
         },
     }
     try:

--- a/tests/test_chats_projection.py
+++ b/tests/test_chats_projection.py
@@ -73,7 +73,21 @@ def db_conn() -> sqlite3.Connection:
 
 def test_chat_slug_prefix_is_stable():
     assert chat_slug("chat-a7b3").startswith(_CHAT_SLUG_PREFIX)
-    assert chat_slug("chat-a7b3") == "chat:chat-a7b3"
+    # Codex P2: slug must survive canonicalize_note_id so search-
+    # driven retrieval lookups round-trip cleanly.  Using the raw
+    # chat_id avoids the colon-stripping issue with the previous
+    # ``chat:<id>`` shape.
+    assert chat_slug("chat-a7b3") == "chat-a7b3"
+
+
+def test_chat_slug_survives_canonicalize_note_id():
+    """The chosen slug shape must round-trip through the same
+    canonicaliser that ``/note`` and ``/object`` use; otherwise
+    search-driven retrieval can't find the indexed chat."""
+    from ovp_pipeline.identity import canonicalize_note_id
+
+    slug = chat_slug("chat-a7b3c2d1")
+    assert canonicalize_note_id(slug) == slug
 
 
 # ── iter_chat_transcripts ──────────────────────────────────────
@@ -118,14 +132,14 @@ def test_rebuild_indexed_session_writes_three_rows(tmp_path: Path, db_conn: sqli
     assert chats_rows == [(fm.chat_id, "active", "indexed", "note")]
 
     pages_rows = db_conn.execute(
-        "SELECT slug, note_type, title FROM pages_index " "WHERE slug LIKE 'chat:%'"
+        "SELECT slug, note_type, title FROM pages_index WHERE note_type = 'chat'"
     ).fetchall()
-    assert pages_rows == [(f"chat:{fm.chat_id}", "chat", "X")]
+    assert pages_rows == [(fm.chat_id, "chat", "X")]
 
     fts_match = db_conn.execute(
         "SELECT slug FROM page_fts WHERE page_fts MATCH 'searchable'"
     ).fetchall()
-    assert fts_match == [(f"chat:{fm.chat_id}",)]
+    assert fts_match == [(fm.chat_id,)]
 
 
 def test_rebuild_unindexed_session_writes_only_chats_row(
@@ -145,7 +159,7 @@ def test_rebuild_unindexed_session_writes_only_chats_row(
 
     assert db_conn.execute("SELECT COUNT(*) FROM chats").fetchone()[0] == 1
     assert (
-        db_conn.execute("SELECT COUNT(*) FROM pages_index WHERE slug LIKE 'chat:%'").fetchone()[0]
+        db_conn.execute("SELECT COUNT(*) FROM pages_index WHERE note_type = 'chat'").fetchone()[0]
         == 0
     )
     assert (
@@ -176,7 +190,7 @@ def test_rebuild_drops_orphan_pages_index_rows(tmp_path: Path, db_conn: sqlite3.
     append_turn(path, role="user", body="first question")
     rebuild_chats_projection(db_conn, tmp_path)
     assert (
-        db_conn.execute("SELECT COUNT(*) FROM pages_index WHERE slug LIKE 'chat:%'").fetchone()[0]
+        db_conn.execute("SELECT COUNT(*) FROM pages_index WHERE note_type = 'chat'").fetchone()[0]
         == 1
     )
 
@@ -186,7 +200,37 @@ def test_rebuild_drops_orphan_pages_index_rows(tmp_path: Path, db_conn: sqlite3.
     rebuild_chats_projection(db_conn, tmp_path)
     assert db_conn.execute("SELECT COUNT(*) FROM chats").fetchone()[0] == 0
     assert (
-        db_conn.execute("SELECT COUNT(*) FROM pages_index WHERE slug LIKE 'chat:%'").fetchone()[0]
+        db_conn.execute("SELECT COUNT(*) FROM pages_index WHERE note_type = 'chat'").fetchone()[0]
+        == 0
+    )
+
+
+def test_rebuild_clears_stale_page_fts_rows(tmp_path: Path, db_conn: sqlite3.Connection):
+    """Codex P1 — FTS5 declares ``slug`` UNINDEXED, so a naive
+    ``DELETE ... WHERE slug LIKE 'chat-%'`` doesn't match.  After
+    deleting a chat on disk, its ``page_fts`` row must still
+    disappear on the next rebuild; otherwise repeated rebuilds
+    accumulate stale hits."""
+    path, fm = create_chat_file(
+        tmp_path,
+        anchor=ChatAnchor(kind="note", path="x.md", title="X"),
+    )
+    append_turn(path, role="user", body="raretoken12345")
+    rebuild_chats_projection(db_conn, tmp_path)
+    assert (
+        db_conn.execute(
+            "SELECT COUNT(*) FROM page_fts WHERE page_fts MATCH 'raretoken12345'"
+        ).fetchone()[0]
+        == 1
+    )
+
+    # Delete the transcript and rebuild — stale FTS rows must go.
+    path.unlink()
+    rebuild_chats_projection(db_conn, tmp_path)
+    assert (
+        db_conn.execute(
+            "SELECT COUNT(*) FROM page_fts WHERE page_fts MATCH 'raretoken12345'"
+        ).fetchone()[0]
         == 0
     )
 

--- a/tests/test_chats_projection.py
+++ b/tests/test_chats_projection.py
@@ -1,0 +1,223 @@
+"""Tests for M21c / BL-085 — chats projection + visibility-aware FTS."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from ovp_pipeline.chat_fileops import (
+    ChatAnchor,
+    append_turn,
+    create_chat_file,
+)
+from ovp_pipeline.chats_projection import (
+    _CHAT_SLUG_PREFIX,
+    chat_slug,
+    iter_chat_transcripts,
+    rebuild_chats_projection,
+)
+
+
+def _make_schema(conn: sqlite3.Connection) -> None:
+    """Build the minimal pages_index + page_fts + chats schema the
+    projection rebuild touches.  Faster than spinning up the full
+    knowledge.db build for a focused test."""
+    conn.executescript("""
+        CREATE TABLE pages_index (
+          slug TEXT PRIMARY KEY,
+          title TEXT NOT NULL,
+          note_type TEXT NOT NULL,
+          path TEXT NOT NULL,
+          day_id TEXT NOT NULL,
+          frontmatter_json TEXT NOT NULL,
+          body TEXT NOT NULL
+        );
+        CREATE VIRTUAL TABLE page_fts USING fts5(
+          slug UNINDEXED,
+          title,
+          body,
+          tokenize='trigram'
+        );
+        CREATE TABLE chats (
+          chat_id TEXT PRIMARY KEY,
+          pack TEXT NOT NULL DEFAULT '',
+          file_path TEXT NOT NULL,
+          status TEXT NOT NULL,
+          visibility TEXT NOT NULL,
+          anchor_kind TEXT NOT NULL,
+          anchor_ref TEXT NOT NULL DEFAULT '',
+          anchor_title TEXT NOT NULL DEFAULT '',
+          profile TEXT NOT NULL DEFAULT '',
+          model TEXT NOT NULL DEFAULT '',
+          temperature REAL NOT NULL DEFAULT 0.7,
+          started_at TEXT NOT NULL DEFAULT '',
+          last_message_at TEXT NOT NULL DEFAULT '',
+          turn_count INTEGER NOT NULL DEFAULT 0,
+          input_tokens INTEGER NOT NULL DEFAULT 0,
+          output_tokens INTEGER NOT NULL DEFAULT 0
+        );
+        """)
+
+
+@pytest.fixture
+def db_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    _make_schema(conn)
+    return conn
+
+
+# ── chat_slug ──────────────────────────────────────────────────
+
+
+def test_chat_slug_prefix_is_stable():
+    assert chat_slug("chat-a7b3").startswith(_CHAT_SLUG_PREFIX)
+    assert chat_slug("chat-a7b3") == "chat:chat-a7b3"
+
+
+# ── iter_chat_transcripts ──────────────────────────────────────
+
+
+def test_iter_chat_transcripts_skips_non_chat_dirs(tmp_path: Path):
+    """Only files under ``40-Resources/Chats/`` are yielded."""
+    other = tmp_path / "20-Areas" / "note.md"
+    other.parent.mkdir(parents=True)
+    other.write_text("not a chat", encoding="utf-8")
+    create_chat_file(tmp_path, anchor=ChatAnchor(kind="standalone"))
+    paths = list(iter_chat_transcripts(tmp_path))
+    assert all("40-Resources/Chats/" in p.as_posix() for p in paths)
+    assert all(p.suffix == ".md" for p in paths)
+    assert other not in paths
+
+
+def test_iter_chat_transcripts_empty_vault_returns_nothing(tmp_path: Path):
+    assert list(iter_chat_transcripts(tmp_path)) == []
+
+
+# ── rebuild_chats_projection ───────────────────────────────────
+
+
+def test_rebuild_indexed_session_writes_three_rows(tmp_path: Path, db_conn: sqlite3.Connection):
+    """An indexed session lands in chats AND in pages_index +
+    page_fts so /search finds it."""
+    path, fm = create_chat_file(
+        tmp_path,
+        anchor=ChatAnchor(kind="note", path="20-Areas/x.md", title="X"),
+        visibility="indexed",
+    )
+    # Add a turn so there's content for FTS to index.
+    append_turn(path, role="user", body="searchable user question")
+
+    counts = rebuild_chats_projection(db_conn, tmp_path)
+    assert counts == {"total": 1, "indexed": 1, "unindexed": 0, "skipped": 0}
+
+    chats_rows = db_conn.execute(
+        "SELECT chat_id, status, visibility, anchor_kind FROM chats"
+    ).fetchall()
+    assert chats_rows == [(fm.chat_id, "active", "indexed", "note")]
+
+    pages_rows = db_conn.execute(
+        "SELECT slug, note_type, title FROM pages_index " "WHERE slug LIKE 'chat:%'"
+    ).fetchall()
+    assert pages_rows == [(f"chat:{fm.chat_id}", "chat", "X")]
+
+    fts_match = db_conn.execute(
+        "SELECT slug FROM page_fts WHERE page_fts MATCH 'searchable'"
+    ).fetchall()
+    assert fts_match == [(f"chat:{fm.chat_id}",)]
+
+
+def test_rebuild_unindexed_session_writes_only_chats_row(
+    tmp_path: Path, db_conn: sqlite3.Connection
+):
+    """An unindexed session lands in ``chats`` only — never in
+    ``pages_index`` or ``page_fts``."""
+    path, fm = create_chat_file(
+        tmp_path,
+        anchor=ChatAnchor(kind="standalone"),
+        visibility="unindexed",
+    )
+    append_turn(path, role="user", body="private question text")
+
+    counts = rebuild_chats_projection(db_conn, tmp_path)
+    assert counts == {"total": 1, "indexed": 0, "unindexed": 1, "skipped": 0}
+
+    assert db_conn.execute("SELECT COUNT(*) FROM chats").fetchone()[0] == 1
+    assert (
+        db_conn.execute("SELECT COUNT(*) FROM pages_index WHERE slug LIKE 'chat:%'").fetchone()[0]
+        == 0
+    )
+    assert (
+        db_conn.execute("SELECT COUNT(*) FROM page_fts WHERE page_fts MATCH 'private'").fetchone()[
+            0
+        ]
+        == 0
+    )
+
+
+def test_rebuild_is_idempotent(tmp_path: Path, db_conn: sqlite3.Connection):
+    """Two rebuilds in a row produce the same row count — no
+    duplicate ``chats`` / ``pages_index`` / ``page_fts`` entries."""
+    create_chat_file(tmp_path, anchor=ChatAnchor(kind="standalone"))
+    rebuild_chats_projection(db_conn, tmp_path)
+    rebuild_chats_projection(db_conn, tmp_path)
+    assert db_conn.execute("SELECT COUNT(*) FROM chats").fetchone()[0] == 1
+
+
+def test_rebuild_drops_orphan_pages_index_rows(tmp_path: Path, db_conn: sqlite3.Connection):
+    """When a session is deleted on disk, its ``chats`` /
+    ``pages_index`` / ``page_fts`` rows must disappear too —
+    derived state mirrors the markdown corpus."""
+    path, fm = create_chat_file(
+        tmp_path,
+        anchor=ChatAnchor(kind="note", path="x.md", title="X"),
+    )
+    append_turn(path, role="user", body="first question")
+    rebuild_chats_projection(db_conn, tmp_path)
+    assert (
+        db_conn.execute("SELECT COUNT(*) FROM pages_index WHERE slug LIKE 'chat:%'").fetchone()[0]
+        == 1
+    )
+
+    # Operator deletes the transcript via Obsidian.
+    path.unlink()
+
+    rebuild_chats_projection(db_conn, tmp_path)
+    assert db_conn.execute("SELECT COUNT(*) FROM chats").fetchone()[0] == 0
+    assert (
+        db_conn.execute("SELECT COUNT(*) FROM pages_index WHERE slug LIKE 'chat:%'").fetchone()[0]
+        == 0
+    )
+
+
+def test_rebuild_skips_non_chat_files(tmp_path: Path, db_conn: sqlite3.Connection):
+    """A stray .md file under the chats directory that isn't a real
+    transcript must skip rather than crash."""
+    stray = tmp_path / "40-Resources" / "Chats" / "stray.md"
+    stray.parent.mkdir(parents=True)
+    stray.write_text("---\ntype: note\n---\n\nstray\n", encoding="utf-8")
+    create_chat_file(tmp_path, anchor=ChatAnchor(kind="standalone"))
+
+    counts = rebuild_chats_projection(db_conn, tmp_path)
+    assert counts["total"] == 1
+    assert counts["skipped"] == 1
+
+
+def test_rebuild_clears_prior_chat_shadow_only(tmp_path: Path, db_conn: sqlite3.Connection):
+    """The rebuild must clear chat-prefix slugs only — regular
+    page rows in ``pages_index`` survive."""
+    db_conn.execute(
+        "INSERT INTO pages_index (slug, title, note_type, path, day_id, frontmatter_json, body) "
+        "VALUES ('regular-note', 'Regular', 'note', 'x.md', '', '{}', 'content')"
+    )
+    db_conn.execute(
+        "INSERT INTO page_fts (slug, title, body) " "VALUES ('regular-note', 'Regular', 'content')"
+    )
+    rebuild_chats_projection(db_conn, tmp_path)
+    assert (
+        db_conn.execute("SELECT COUNT(*) FROM pages_index WHERE slug = 'regular-note'").fetchone()[
+            0
+        ]
+        == 1
+    )


### PR DESCRIPTION
## Summary

First M21c PR.  Lands the knowledge.db projection that BL-088's
/chats list view consumes, plus the visibility-aware FTS shadow
that lets /search find indexed inquiry sessions.

* New ``chats`` table in ``knowledge_index.py`` SCHEMA.
* New ``src/ovp_pipeline/chats_projection.py``.
* Wired into ``rebuild_knowledge_index`` as a best-effort step.
* 9 tests.

## Design rules locked in

1. **Markdown is canonical; the DB is a projection.** The
   rebuild clears every chats-related row first then walks the
   ``40-Resources/Chats/**/*.md`` corpus.  An orphaned row from
   a deleted transcript disappears on the next sweep.
2. **Visibility boundary is enforced at write time.** Indexed
   sessions write three rows (chats + pages_index + page_fts);
   unindexed sessions write one (chats only).  /search and the
   BL-083 retrieval layer never see unindexed bodies.
3. **Lifetime token totals are display only.** Daily-cap math
   in BL-084 reads ``audit_events``, never this table.
4. **``chat:<chat_id>`` slug prefix** keeps the indexed-chat
   corpus trivially separable from regular pages.

## Test plan

- [x] ``rtk proxy python -m pytest tests/test_chats_projection.py -q`` — 9 passed
- [x] ``ruff check`` + ``black --check`` clean

## Plan reference

``docs/plans/2026-05-12-m21-chat-surface.md`` — BL-085 detail at
``### BL-085 — Projection table + visibility-aware FTS``.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat transcripts are now indexed and searchable in the knowledge base.
  * Visibility controls ensure only indexed sessions appear in search.
  * Chat metadata is automatically rebuilt and synchronized during knowledge index updates.

* **Improvements**
  * Rebuilds clean up stale shadow/index rows and preserve unrelated index entries.
  * Rebuild process is idempotent and robust to non-transcript files.

* **Tests**
  * Added end-to-end tests covering indexing, cleanup, idempotency, and edge cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fakechris/obsidian_vault_pipeline/pull/216)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->