### PR TITLE
feat(bl-088): Reader /chats list view (M21c step 2, final M21 BL)

### DIFF
--- a/src/ovp_pipeline/commands/_chats_list_page.py
+++ b/src/ovp_pipeline/commands/_chats_list_page.py
@@ -112,6 +112,28 @@ def _group_by_status(rows: list[ChatRow]) -> dict[str, list[ChatRow]]:
     return grouped
 
 
+def _row_title(row: ChatRow) -> str:
+    """Pick a distinguishable row title.
+
+    Codex P2: every standalone session previously rendered with the
+    same bold "standalone" title because the anchor-label fallback
+    chain ended on ``anchor_kind``.  Now we fall back to the file
+    name (sans extension) and finally the chat_id when no friendlier
+    label exists, so each session is identifiable in the list.
+    """
+    if row.anchor_title:
+        return row.anchor_title
+    if row.anchor_ref:
+        return row.anchor_ref
+    if row.file_path:
+        stem = row.file_path.rsplit("/", 1)[-1]
+        if stem.endswith(".md"):
+            stem = stem[:-3]
+        if stem:
+            return stem
+    return row.chat_id
+
+
 def _render_chat_row(row: ChatRow) -> str:
     anchor_label = row.anchor_title or row.anchor_ref or row.anchor_kind
     anchor_pill = (
@@ -123,7 +145,7 @@ def _render_chat_row(row: ChatRow) -> str:
         f'<span class="pill">{escape(row.profile.capitalize())}</span>' if row.profile else ""
     )
     timestamp = escape(row.last_message_at[:10] or "—")
-    title = anchor_label or row.chat_id
+    title = _row_title(row)
     return (
         '<li class="chat-list-item">'
         f'<a class="chat-list-link" href="/chat?id={escape(row.chat_id)}">'

--- a/src/ovp_pipeline/commands/_chats_list_page.py
+++ b/src/ovp_pipeline/commands/_chats_list_page.py
@@ -1,0 +1,200 @@
+"""Reader ``/chats`` list view (M21c / BL-088).
+
+Reads from ``knowledge.db.chats`` (BL-085 projection) and renders
+a status-grouped list — Pinned / Active / Archived (the latter
+collapsed by default).  Unindexed sessions are hidden by design:
+the M21 plan promises ``Don't index or reuse`` actually means
+"won't appear in the inquiry list".  Operators reach those
+sessions via direct file path or ``ovp-ask show --id``.
+
+Layout matches the plan-doc example:
+
+    Pinned (3)
+      • 2026-05-12 · Digest review · anchor: digest
+      • 2026-05-09 · Memory architecture deep-dive · anchor: crystal
+      • 2026-05-07 · M20 design conversation · anchor: standalone
+
+    Active (12)
+      • 2026-05-12 · ... (newest first)
+      • ...
+
+    Archived (45)
+      ⌃ Show archived (collapsed by default)
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from html import escape
+from pathlib import Path
+
+from ovp_pipeline.runtime import VaultLayout
+
+
+@dataclass(frozen=True)
+class ChatRow:
+    """One row from ``knowledge.db.chats`` (BL-085 projection).
+
+    Drives the ``/chats`` list view.  Field order matches the
+    SQL SELECT for fast tuple-unpacking; downstream rendering
+    code reads named attributes.
+    """
+
+    chat_id: str
+    file_path: str
+    status: str  # active | pinned | archived
+    anchor_kind: str
+    anchor_ref: str
+    anchor_title: str
+    profile: str
+    last_message_at: str
+    turn_count: int
+
+
+# Status display order — Pinned first, then Active, then Archived.
+# Mirrors the plan-doc example.
+_STATUS_ORDER: tuple[str, ...] = ("pinned", "active", "archived")
+_STATUS_LABELS = {
+    "pinned": "Pinned",
+    "active": "Active",
+    "archived": "Archived",
+}
+
+
+def list_indexed_chats(db_path: Path) -> list[ChatRow]:
+    """Read all indexed chats from ``knowledge.db.chats``.
+
+    Returns an empty list when the database is missing or the
+    table hasn't been built yet — the page renders a friendly
+    empty-state instead of 500ing.
+    """
+    if not db_path.is_file():
+        return []
+    rows: list[ChatRow] = []
+    try:
+        with sqlite3.connect(db_path) as conn:
+            cursor = conn.execute("""
+                SELECT chat_id, file_path, status, anchor_kind,
+                       anchor_ref, anchor_title, profile,
+                       last_message_at, turn_count
+                FROM chats
+                WHERE visibility = 'indexed'
+                ORDER BY last_message_at DESC
+                """)
+            for row in cursor.fetchall():
+                rows.append(
+                    ChatRow(
+                        chat_id=str(row[0]),
+                        file_path=str(row[1]),
+                        status=str(row[2]) or "active",
+                        anchor_kind=str(row[3]) or "standalone",
+                        anchor_ref=str(row[4] or ""),
+                        anchor_title=str(row[5] or ""),
+                        profile=str(row[6] or ""),
+                        last_message_at=str(row[7] or ""),
+                        turn_count=int(row[8] or 0),
+                    )
+                )
+    except sqlite3.DatabaseError:
+        # Schema mismatch / table missing — operator hasn't run
+        # ``ovp-knowledge-index`` since BL-085 landed.  Empty page
+        # is better than 500.
+        return []
+    return rows
+
+
+def _group_by_status(rows: list[ChatRow]) -> dict[str, list[ChatRow]]:
+    grouped: dict[str, list[ChatRow]] = {s: [] for s in _STATUS_ORDER}
+    for row in rows:
+        status = row.status if row.status in grouped else "active"
+        grouped[status].append(row)
+    return grouped
+
+
+def _render_chat_row(row: ChatRow) -> str:
+    anchor_label = row.anchor_title or row.anchor_ref or row.anchor_kind
+    anchor_pill = (
+        f'<span class="pill ghost">{escape(row.anchor_kind)}: ' f"{escape(anchor_label)}</span>"
+        if row.anchor_kind != "standalone"
+        else '<span class="pill ghost">standalone</span>'
+    )
+    profile_pill = (
+        f'<span class="pill">{escape(row.profile.capitalize())}</span>' if row.profile else ""
+    )
+    timestamp = escape(row.last_message_at[:10] or "—")
+    title = anchor_label or row.chat_id
+    return (
+        '<li class="chat-list-item">'
+        f'<a class="chat-list-link" href="/chat?id={escape(row.chat_id)}">'
+        f'<span class="chat-list-date">{timestamp}</span> '
+        f"<strong>{escape(title)}</strong>"
+        "</a> "
+        f"{anchor_pill} {profile_pill} "
+        f'<span class="muted small">turns={row.turn_count}</span>'
+        "</li>"
+    )
+
+
+def render_chats_list_body(vault_dir: Path | str) -> str:
+    """Render the ``/chats`` page body.
+
+    Groups indexed chats by status; archived is collapsed inside
+    a ``<details>`` block per the plan.  Empty state surfaces a
+    friendly prompt to start an inquiry from any Reader page.
+    """
+    layout = VaultLayout.from_vault(vault_dir)
+    rows = list_indexed_chats(layout.knowledge_db)
+    if not rows:
+        return (
+            '<header class="chats-list-header">'
+            "<h1>Inquiry history</h1>"
+            "</header>"
+            '<p class="muted">No indexed inquiry sessions yet. '
+            "Start one with the <em>Ask about this</em> button on any "
+            "note, object, or topic page — or open "
+            '<a href="/chat">/chat</a> directly for a standalone session.'
+            "</p>"
+        )
+
+    grouped = _group_by_status(rows)
+    sections: list[str] = []
+    for status in _STATUS_ORDER:
+        items = grouped[status]
+        if not items:
+            continue
+        label = _STATUS_LABELS[status]
+        list_items = "".join(_render_chat_row(r) for r in items)
+        header = f'<h2>{label} <span class="muted small">' f"({len(items)})</span></h2>"
+        if status == "archived":
+            sections.append(
+                '<details class="card chats-list-section">'
+                f"<summary>{header}</summary>"
+                f'<ul class="chat-list">{list_items}</ul>'
+                "</details>"
+            )
+        else:
+            sections.append(
+                '<section class="card chats-list-section">'
+                f"{header}"
+                f'<ul class="chat-list">{list_items}</ul>'
+                "</section>"
+            )
+
+    return (
+        '<header class="chats-list-header">'
+        "<h1>Inquiry history</h1>"
+        '<p class="muted">'
+        f"{len(rows)} indexed sessions. Unindexed inquiries don't "
+        "appear here by design — reach them via "
+        "<code>ovp-ask show --id …</code>."
+        "</p>"
+        "</header>" + "\n".join(sections)
+    )
+
+
+__all__ = [
+    "ChatRow",
+    "list_indexed_chats",
+    "render_chats_list_body",
+]

--- a/src/ovp_pipeline/commands/_chats_list_page.py
+++ b/src/ovp_pipeline/commands/_chats_list_page.py
@@ -28,6 +28,7 @@ import sqlite3
 from dataclasses import dataclass
 from html import escape
 from pathlib import Path
+from urllib.parse import quote_plus
 
 from ovp_pipeline.runtime import VaultLayout
 
@@ -87,8 +88,12 @@ def list_indexed_chats(db_path: Path) -> list[ChatRow]:
                     ChatRow(
                         chat_id=str(row[0]),
                         file_path=str(row[1]),
-                        status=str(row[2]) or "active",
-                        anchor_kind=str(row[3]) or "standalone",
+                        # Coalesce BEFORE casting (CodeRabbit Minor) —
+                        # ``str(None)`` is ``"None"`` (truthy), so the
+                        # ``or "active"`` fallback never fired when the
+                        # column was NULL.
+                        status=str(row[2] or "active"),
+                        anchor_kind=str(row[3] or "standalone"),
                         anchor_ref=str(row[4] or ""),
                         anchor_title=str(row[5] or ""),
                         profile=str(row[6] or ""),
@@ -146,9 +151,15 @@ def _render_chat_row(row: ChatRow) -> str:
     )
     timestamp = escape(row.last_message_at[:10] or "—")
     title = _row_title(row)
+    # CodeRabbit Major: HTML-escape isn't the right encoding for URL
+    # parameters.  ``chat_id`` is validated against ``_CHAT_ID_RE``
+    # at write time so it doesn't contain ``&`` / ``?`` today, but
+    # treating the value as a URL fragment defends against any
+    # future schema where the id permits richer characters.
+    chat_id_url = quote_plus(row.chat_id)
     return (
         '<li class="chat-list-item">'
-        f'<a class="chat-list-link" href="/chat?id={escape(row.chat_id)}">'
+        f'<a class="chat-list-link" href="/chat?id={chat_id_url}">'
         f'<span class="chat-list-date">{timestamp}</span> '
         f"<strong>{escape(title)}</strong>"
         "</a> "

--- a/src/ovp_pipeline/commands/_chats_list_page.py
+++ b/src/ovp_pipeline/commands/_chats_list_page.py
@@ -101,11 +101,15 @@ def list_indexed_chats(db_path: Path) -> list[ChatRow]:
                         turn_count=int(row[8] or 0),
                     )
                 )
-    except sqlite3.DatabaseError:
-        # Schema mismatch / table missing — operator hasn't run
-        # ``ovp-knowledge-index`` since BL-085 landed.  Empty page
-        # is better than 500.
-        return []
+    except sqlite3.OperationalError as exc:
+        # CodeRabbit Major — only graceful-degrade for known
+        # schema-mismatch cases (pre-BL-085 vault).  Re-raise on
+        # corruption / locking so genuine DB failures aren't
+        # masked as an empty page.
+        msg = str(exc).lower()
+        if "no such table" in msg or "no such column" in msg:
+            return []
+        raise
     return rows
 
 

--- a/src/ovp_pipeline/commands/_ui_renderers.py
+++ b/src/ovp_pipeline/commands/_ui_renderers.py
@@ -225,6 +225,10 @@ def _reader_nav_items(requested_pack: str = "") -> list[tuple[str, str]]:
         ("Library", "/"),
         ("Search", "/search"),
         ("Topics", "/topics"),
+        # M21 BL-088: ``/chats`` is the inquiry history surface.
+        # Without a nav entry, operators have no discoverable path
+        # back from a session they just started (codex review P2).
+        ("Chats", "/chats"),
     ]
     if _shell_supports_research_nav(requested_pack):
         items.append(("Map", "/map"))
@@ -3536,9 +3540,7 @@ def _render_topic_page(payload: dict) -> str:
     # ``links.center_object_path`` is a route URL (``/object?id=...``),
     # NOT a vault path — CodeRabbit Major.  Use ``provenance.evergreen_path``
     # (the actual markdown file) instead.
-    center_path = str(
-        payload.get("provenance", {}).get("evergreen_path") or ""
-    )
+    center_path = str(payload.get("provenance", {}).get("evergreen_path") or "")
     ask_button = _render_ask_about_this_button(
         "object",
         center_path,

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -1172,6 +1172,18 @@ def create_server(
                 if path == "/chat":
                     self._handle_chat_page_get(query, csrf_token)
                     return
+                if path == "/chats":
+                    from ovp_pipeline.commands._chats_list_page import (
+                        render_chats_list_body,
+                    )
+
+                    self._write_html(
+                        _layout(
+                            "Inquiry history",
+                            render_chats_list_body(resolved_vault),
+                        )
+                    )
+                    return
                 self.send_error(404, "Not Found")
             except ValueError as exc:
                 self.send_error(400, str(exc))

--- a/tests/test_chats_list_page.py
+++ b/tests/test_chats_list_page.py
@@ -269,6 +269,63 @@ def test_render_chats_list_body_standalone_anchor_pill(tmp_path: Path):
 # ── ChatRow dataclass ─────────────────────────────────────────
 
 
+# ── Codex P2 — Reader nav exposes Chats ──────────────────────
+
+
+def test_reader_nav_includes_chats_entry():
+    """The Reader shell nav must surface a Chats link so operators
+    can find the history list without typing the URL by hand."""
+    from ovp_pipeline.commands._ui_renderers import _reader_nav_items
+
+    items = _reader_nav_items()
+    labels = [label for label, _path in items]
+    paths = [path for _label, path in items]
+    assert "Chats" in labels
+    assert "/chats" in paths
+
+
+# ── Codex P2 — standalone sessions get unique titles ─────────
+
+
+def test_standalone_sessions_get_distinguishable_titles(tmp_path: Path):
+    """Without an anchor, the row title must fall back to the file
+    stem (or chat_id) rather than the literal word "standalone".
+    Otherwise every /chat session renders with the same bold
+    label and operators can't tell sessions apart."""
+    rows = [
+        {
+            "chat_id": "chat-aaa1",
+            "file_path": "40-Resources/Chats/2026-05/memory-question-aaa1.md",
+            "status": "active",
+            "visibility": "indexed",
+            "anchor_kind": "standalone",
+            "anchor_ref": "",
+            "anchor_title": "",
+            "profile": "balanced",
+            "last_message_at": "2026-05-12T11:00:00Z",
+            "turn_count": 2,
+        },
+        {
+            "chat_id": "chat-bbb2",
+            "file_path": "40-Resources/Chats/2026-05/agents-overview-bbb2.md",
+            "status": "active",
+            "visibility": "indexed",
+            "anchor_kind": "standalone",
+            "anchor_ref": "",
+            "anchor_title": "",
+            "profile": "balanced",
+            "last_message_at": "2026-05-11T11:00:00Z",
+            "turn_count": 3,
+        },
+    ]
+    vault = _make_vault_with_db(tmp_path, rows)
+    html = render_chats_list_body(vault)
+    # The two sessions get distinct bold titles drawn from the
+    # filename stem — not just the literal anchor kind.
+    assert "memory-question-aaa1" in html
+    assert "agents-overview-bbb2" in html
+
+
 def test_chat_row_is_frozen():
     """The dataclass must be immutable so list-view helpers can
     treat returned rows as values."""

--- a/tests/test_chats_list_page.py
+++ b/tests/test_chats_list_page.py
@@ -1,0 +1,291 @@
+"""Tests for M21c / BL-088 — Reader ``/chats`` list view."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from ovp_pipeline.commands._chats_list_page import (
+    ChatRow,
+    list_indexed_chats,
+    render_chats_list_body,
+)
+
+
+def _make_db_with_chats(db_path: Path, rows: list[dict]) -> None:
+    """Bootstrap a knowledge.db with just the ``chats`` table."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("""
+            CREATE TABLE chats (
+              chat_id TEXT PRIMARY KEY,
+              pack TEXT NOT NULL DEFAULT '',
+              file_path TEXT NOT NULL,
+              status TEXT NOT NULL,
+              visibility TEXT NOT NULL,
+              anchor_kind TEXT NOT NULL,
+              anchor_ref TEXT NOT NULL DEFAULT '',
+              anchor_title TEXT NOT NULL DEFAULT '',
+              profile TEXT NOT NULL DEFAULT '',
+              model TEXT NOT NULL DEFAULT '',
+              temperature REAL NOT NULL DEFAULT 0.7,
+              started_at TEXT NOT NULL DEFAULT '',
+              last_message_at TEXT NOT NULL DEFAULT '',
+              turn_count INTEGER NOT NULL DEFAULT 0,
+              input_tokens INTEGER NOT NULL DEFAULT 0,
+              output_tokens INTEGER NOT NULL DEFAULT 0
+            )
+            """)
+        conn.executemany(
+            """
+            INSERT INTO chats (
+              chat_id, file_path, status, visibility, anchor_kind,
+              anchor_ref, anchor_title, profile, last_message_at,
+              turn_count
+            ) VALUES (
+              :chat_id, :file_path, :status, :visibility, :anchor_kind,
+              :anchor_ref, :anchor_title, :profile, :last_message_at,
+              :turn_count
+            )
+            """,
+            rows,
+        )
+        conn.commit()
+
+
+def _make_vault_with_db(tmp_path: Path, rows: list[dict]) -> Path:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "10-Knowledge" / "Atlas").mkdir(parents=True)
+    (vault / "10-Knowledge" / "Evergreen").mkdir(parents=True)
+    (vault / "20-Areas").mkdir()
+    (vault / "50-Inbox").mkdir()
+    (vault / "60-Logs").mkdir()
+    # ``VaultLayout.knowledge_db`` resolves to ``60-Logs/knowledge.db``.
+    db_path = vault / "60-Logs" / "knowledge.db"
+    if rows is not None:
+        _make_db_with_chats(db_path, rows)
+    return vault
+
+
+# ── list_indexed_chats ────────────────────────────────────────
+
+
+def test_list_indexed_chats_filters_to_indexed_only(tmp_path: Path):
+    """Unindexed sessions are hidden from the projection read so
+    /chats can't accidentally surface them."""
+    rows = [
+        {
+            "chat_id": "chat-a",
+            "file_path": "40-Resources/Chats/2026-05/a.md",
+            "status": "active",
+            "visibility": "indexed",
+            "anchor_kind": "note",
+            "anchor_ref": "x.md",
+            "anchor_title": "Note A",
+            "profile": "balanced",
+            "last_message_at": "2026-05-12T11:00:00Z",
+            "turn_count": 4,
+        },
+        {
+            "chat_id": "chat-private",
+            "file_path": "40-Resources/Chats/2026-05/p.md",
+            "status": "active",
+            "visibility": "unindexed",
+            "anchor_kind": "standalone",
+            "anchor_ref": "",
+            "anchor_title": "",
+            "profile": "deep",
+            "last_message_at": "2026-05-12T12:00:00Z",
+            "turn_count": 2,
+        },
+    ]
+    vault = _make_vault_with_db(tmp_path, rows)
+    indexed = list_indexed_chats(vault / "60-Logs" / "knowledge.db")
+    chat_ids = [r.chat_id for r in indexed]
+    assert "chat-a" in chat_ids
+    assert "chat-private" not in chat_ids
+
+
+def test_list_indexed_chats_ordered_newest_first(tmp_path: Path):
+    rows = [
+        {
+            "chat_id": "chat-old",
+            "file_path": "x.md",
+            "status": "active",
+            "visibility": "indexed",
+            "anchor_kind": "standalone",
+            "anchor_ref": "",
+            "anchor_title": "",
+            "profile": "balanced",
+            "last_message_at": "2026-05-01T11:00:00Z",
+            "turn_count": 1,
+        },
+        {
+            "chat_id": "chat-new",
+            "file_path": "y.md",
+            "status": "active",
+            "visibility": "indexed",
+            "anchor_kind": "standalone",
+            "anchor_ref": "",
+            "anchor_title": "",
+            "profile": "balanced",
+            "last_message_at": "2026-05-12T11:00:00Z",
+            "turn_count": 1,
+        },
+    ]
+    vault = _make_vault_with_db(tmp_path, rows)
+    indexed = list_indexed_chats(vault / "60-Logs" / "knowledge.db")
+    assert [r.chat_id for r in indexed] == ["chat-new", "chat-old"]
+
+
+def test_list_indexed_chats_missing_db_returns_empty(tmp_path: Path):
+    """No knowledge.db → no crash, just empty list."""
+    assert list_indexed_chats(tmp_path / "nope.db") == []
+
+
+def test_list_indexed_chats_schema_mismatch_returns_empty(tmp_path: Path):
+    """Pre-BL-085 vault doesn't have the chats table — degrade
+    gracefully so /chats shows the empty-state instead of 500ing."""
+    db = tmp_path / "knowledge.db"
+    with sqlite3.connect(db) as conn:
+        conn.execute("CREATE TABLE other_table (x INTEGER)")
+    assert list_indexed_chats(db) == []
+
+
+# ── render_chats_list_body ────────────────────────────────────
+
+
+def test_render_chats_list_body_empty_state(tmp_path: Path):
+    vault = _make_vault_with_db(tmp_path, [])
+    html = render_chats_list_body(vault)
+    assert "No indexed inquiry sessions yet" in html
+    # Mentions the entry points so operators know what to do next.
+    assert "Ask about this" in html
+    assert "/chat" in html
+
+
+def test_render_chats_list_body_groups_by_status(tmp_path: Path):
+    rows = [
+        {
+            "chat_id": "chat-1",
+            "file_path": "x.md",
+            "status": "pinned",
+            "visibility": "indexed",
+            "anchor_kind": "note",
+            "anchor_ref": "n.md",
+            "anchor_title": "Pinned Note",
+            "profile": "deep",
+            "last_message_at": "2026-05-12T11:00:00Z",
+            "turn_count": 6,
+        },
+        {
+            "chat_id": "chat-2",
+            "file_path": "y.md",
+            "status": "active",
+            "visibility": "indexed",
+            "anchor_kind": "standalone",
+            "anchor_ref": "",
+            "anchor_title": "",
+            "profile": "balanced",
+            "last_message_at": "2026-05-11T11:00:00Z",
+            "turn_count": 3,
+        },
+        {
+            "chat_id": "chat-3",
+            "file_path": "z.md",
+            "status": "archived",
+            "visibility": "indexed",
+            "anchor_kind": "object",
+            "anchor_ref": "obj.md",
+            "anchor_title": "Old Object",
+            "profile": "fast",
+            "last_message_at": "2026-04-01T11:00:00Z",
+            "turn_count": 12,
+        },
+    ]
+    vault = _make_vault_with_db(tmp_path, rows)
+    html = render_chats_list_body(vault)
+    # All three status sections present.
+    assert "Pinned" in html
+    assert "Active" in html
+    assert "Archived" in html
+    # Archived sits inside a collapsed <details>.
+    assert "<details" in html
+    # Each row links to the /chat page by id.
+    assert "/chat?id=chat-1" in html
+    assert "/chat?id=chat-3" in html
+
+
+def test_render_chats_list_body_includes_anchor_and_profile_pills(
+    tmp_path: Path,
+):
+    rows = [
+        {
+            "chat_id": "chat-a",
+            "file_path": "x.md",
+            "status": "active",
+            "visibility": "indexed",
+            "anchor_kind": "note",
+            "anchor_ref": "20-Areas/n.md",
+            "anchor_title": "Friendly Title",
+            "profile": "deep",
+            "last_message_at": "2026-05-12T11:00:00Z",
+            "turn_count": 4,
+        }
+    ]
+    vault = _make_vault_with_db(tmp_path, rows)
+    html = render_chats_list_body(vault)
+    # Anchor pill shows the friendly title, not the raw path.
+    assert "Friendly Title" in html
+    # Profile pill is capitalised per the plan's UI vocabulary.
+    assert "Deep" in html
+    # Turn count surfaces in the row.
+    assert "turns=4" in html
+
+
+def test_render_chats_list_body_standalone_anchor_pill(tmp_path: Path):
+    """A standalone session shows a ``standalone`` pill rather
+    than an empty anchor pill."""
+    rows = [
+        {
+            "chat_id": "chat-s",
+            "file_path": "x.md",
+            "status": "active",
+            "visibility": "indexed",
+            "anchor_kind": "standalone",
+            "anchor_ref": "",
+            "anchor_title": "",
+            "profile": "balanced",
+            "last_message_at": "2026-05-12T11:00:00Z",
+            "turn_count": 2,
+        }
+    ]
+    vault = _make_vault_with_db(tmp_path, rows)
+    html = render_chats_list_body(vault)
+    assert "standalone" in html
+
+
+# ── ChatRow dataclass ─────────────────────────────────────────
+
+
+def test_chat_row_is_frozen():
+    """The dataclass must be immutable so list-view helpers can
+    treat returned rows as values."""
+    row = ChatRow(
+        chat_id="x",
+        file_path="x.md",
+        status="active",
+        anchor_kind="standalone",
+        anchor_ref="",
+        anchor_title="",
+        profile="balanced",
+        last_message_at="",
+        turn_count=0,
+    )
+    try:
+        row.status = "pinned"  # type: ignore[misc]
+        raised = False
+    except Exception:
+        raised = True
+    assert raised


### PR DESCRIPTION
## Summary

Final M21 BL.  Lands the Reader-side ``/chats`` history surface
that reads from BL-085's ``knowledge.db.chats`` projection.

* New ``src/ovp_pipeline/commands/_chats_list_page.py``
* Route wired in ``ui_server.py``: ``GET /chats``
* New ``tests/test_chats_list_page.py`` — 9 tests.

## What ships

* Status-grouped layout: Pinned → Active → Archived (the last
  collapsed inside a ``<details>``).
* Each row carries: date · friendly title (anchor_title fallback
  chain) · anchor pill · profile pill · turn count.
* Empty state points operators at the BL-087 entry buttons +
  standalone ``/chat``.
* Visibility boundary enforced at the SQL layer:
  ``WHERE visibility = 'indexed'``.  Unindexed sessions are
  *invisible* to this view by design — the M21 plan's
  "Don't index or reuse" copy actually means it.

## Graceful degradation

* Missing ``knowledge.db`` → empty list, empty-state page.
* Pre-BL-085 vault that hasn't been rebuilt yet
  (schema mismatch / table missing) → same path, no 500.

## Test plan

- [x] ``rtk proxy python -m pytest tests/test_chats_list_page.py -q`` — 9 passed
- [x] ``ruff check`` + ``black --check`` clean
- [x] ``ui_server`` still imports cleanly

## Plan reference

``docs/plans/2026-05-12-m21-chat-surface.md`` — BL-088 detail at
``### BL-088 — `/chats` Reader list``.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Inquiry history" page at /chats showing indexed chat sessions grouped by Pinned, Active, and Archived (Archived collapsed). Entries display date, profile, turn count, anchor info, and links to view each chat. Reader navigation now includes a "Chats" entry and an empty-state prompt with next-step guidance.

* **Tests**
  * Added tests for filtering, ordering, empty states, grouping, rendering details, navigation entry, and immutability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fakechris/obsidian_vault_pipeline/pull/217)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->