### PR TITLE
feat(m22): anchored-inquiry drawer + digest history

### DIFF
--- a/src/ovp_pipeline/chat_fileops.py
+++ b/src/ovp_pipeline/chat_fileops.py
@@ -679,24 +679,20 @@ def set_visibility(path: Path, new_visibility: str) -> ChatFrontmatter:
             raise ValueError(f"cannot set_visibility: {path} is not a valid chat transcript")
         if fm_current.visibility == new_visibility:
             return fm_current
-        updated = ChatFrontmatter(
-            chat_id=fm_current.chat_id,
-            status=fm_current.status,
-            visibility=new_visibility,
-            save_policy=fm_current.save_policy,
-            anchor=fm_current.anchor,
-            profile=fm_current.profile,
-            model=fm_current.model,
-            temperature=fm_current.temperature,
-            started_at=fm_current.started_at,
-            last_message_at=fm_current.last_message_at,
-            turn_count=fm_current.turn_count,
-            schema_version=fm_current.schema_version,
-        )
+        # ``dataclasses.replace`` future-proofs against new fields
+        # landing on ChatFrontmatter — manual field-by-field copy
+        # was a maintenance hazard (gemini review).
+        from dataclasses import replace as _dc_replace
+
+        updated = _dc_replace(fm_current, visibility=new_visibility)
         new_raw = _ordered_dump(_frontmatter_to_yaml_dict(updated))
-        if not body_text.startswith("\n"):
-            body_text = "\n" + body_text
-        new_text = f"---\n{new_raw}\n---{body_text}"
+        # CodeRabbit: ``_split_frontmatter`` consumes one newline
+        # after the closing ``---``; reconstructing with just
+        # ``---{body_text}`` would lose the blank line operators
+        # expect between frontmatter and body.  Force exactly one
+        # leading newline, then ensure a second blank-line break.
+        body_clean = body_text.lstrip("\n")
+        new_text = f"---\n{new_raw}\n---\n\n{body_clean}"
         _atomic_write(path, new_text)
         return updated
 
@@ -710,16 +706,27 @@ def delete_chat(path: Path) -> None:
     it; safe to unlink.
 
     Missing target is not an error (idempotent discard).
+
+    Lock-file lifecycle (gemini HIGH): Unix ``flock`` is bound to
+    the open file descriptor, not the inode.  Unlinking
+    ``<path>.lock`` here while another writer holds it is safe —
+    the holder keeps its lock until it closes the fd, even after
+    the directory entry is gone.  The next writer creates a fresh
+    lock file via ``O_CREAT``, which means *the two writers
+    serialize on different inodes* and the per-chat invariant
+    breaks.  Mitigation: discard is only called from the drawer's
+    Save / Discard action, which the UI gates behind a finished
+    assistant turn — by construction no other writer should be
+    holding the lock.  If concurrent writers become a real concern,
+    move to a lock directory under ``.lock/`` keyed by chat id.
     """
-    try:
+    from contextlib import suppress
+
+    with suppress(FileNotFoundError):
         path.unlink()
-    except FileNotFoundError:
-        pass
     lock_path = path.with_suffix(path.suffix + ".lock")
-    try:
+    with suppress(FileNotFoundError):
         lock_path.unlink()
-    except FileNotFoundError:
-        pass
 
 
 def mark_interrupted(

--- a/src/ovp_pipeline/chat_fileops.py
+++ b/src/ovp_pipeline/chat_fileops.py
@@ -649,6 +649,79 @@ def append_turn(
         return updated_fm
 
 
+def set_visibility(path: Path, new_visibility: str) -> ChatFrontmatter:
+    """Flip a chat session's ``visibility`` in place atomically.
+
+    Used by the M22 drawer when an operator clicks Save / Absorb on
+    an ephemeral inquiry — the file is created as ``unindexed`` so
+    it stays out of /search and /chats during composition, and Save
+    promotes it to ``indexed`` after the operator has decided.
+
+    Body of the file is untouched.  The frontmatter is rewritten
+    via the same ``.pending`` rename used by :func:`append_turn`,
+    under the per-chat advisory lock.
+    """
+    if new_visibility not in _VISIBILITY_VALUES:
+        raise ValueError(
+            f"unknown visibility {new_visibility!r}; "
+            f"expected one of {sorted(_VISIBILITY_VALUES)}"
+        )
+    if not path.is_file():
+        raise ValueError(f"cannot set_visibility: {path} does not exist")
+
+    with _per_chat_lock(path):
+        text = path.read_text(encoding="utf-8")
+        raw, body_text = _split_frontmatter(text)
+        if not raw:
+            raise ValueError(f"cannot set_visibility: {path} has no frontmatter")
+        fm_current = _parse_frontmatter(raw)
+        if fm_current is None:
+            raise ValueError(f"cannot set_visibility: {path} is not a valid chat transcript")
+        if fm_current.visibility == new_visibility:
+            return fm_current
+        updated = ChatFrontmatter(
+            chat_id=fm_current.chat_id,
+            status=fm_current.status,
+            visibility=new_visibility,
+            save_policy=fm_current.save_policy,
+            anchor=fm_current.anchor,
+            profile=fm_current.profile,
+            model=fm_current.model,
+            temperature=fm_current.temperature,
+            started_at=fm_current.started_at,
+            last_message_at=fm_current.last_message_at,
+            turn_count=fm_current.turn_count,
+            schema_version=fm_current.schema_version,
+        )
+        new_raw = _ordered_dump(_frontmatter_to_yaml_dict(updated))
+        if not body_text.startswith("\n"):
+            body_text = "\n" + body_text
+        new_text = f"---\n{new_raw}\n---{body_text}"
+        _atomic_write(path, new_text)
+        return updated
+
+
+def delete_chat(path: Path) -> None:
+    """Delete a chat transcript and its lock sentinel.
+
+    Used by the M22 drawer's Discard action — an operator who
+    finishes an inquiry without wanting to keep it in /search.
+    The session file lived as ``unindexed`` so nothing references
+    it; safe to unlink.
+
+    Missing target is not an error (idempotent discard).
+    """
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    try:
+        lock_path.unlink()
+    except FileNotFoundError:
+        pass
+
+
 def mark_interrupted(
     path: Path,
     *,

--- a/src/ovp_pipeline/chats_projection.py
+++ b/src/ovp_pipeline/chats_projection.py
@@ -237,9 +237,70 @@ def _insert_indexed_shadow(
     )
 
 
+def upsert_chat_projection(
+    conn: sqlite3.Connection,
+    vault_dir: Path,
+    chat_path: Path,
+) -> bool:
+    """Refresh a single chat's projection rows in place (M22 codex P2).
+
+    The drawer's Save / Absorb path flips a session from
+    ``unindexed`` → ``indexed`` on disk; without this helper the
+    ``knowledge.db.chats`` row and the ``pages_index`` / ``page_fts``
+    shadows still reflect the prior ``unindexed`` state, so the
+    saved session would not appear in ``/chats`` or ``/search``
+    until the next full ``ovp-knowledge-index`` rebuild.
+
+    Drops every prior row for the chat's slug + chat_id, then
+    re-inserts using the current frontmatter.  Returns True on a
+    successful write; False when the file isn't a valid chat
+    transcript (caller can log).
+
+    Caller owns the transaction + commit — matches
+    :func:`rebuild_chats_projection`.
+    """
+    fm = parse_chat(chat_path)
+    if fm is None:
+        return False
+    try:
+        rel_path = chat_path.relative_to(vault_dir).as_posix()
+    except ValueError:
+        rel_path = str(chat_path)
+
+    slug = chat_slug(fm.chat_id)
+    # Clear prior shadow rows first; FTS5 ``slug`` is ``UNINDEXED``
+    # so exact-equality DELETE is the only path that matches
+    # (same constraint that drives ``rebuild_chats_projection``).
+    conn.execute("DELETE FROM page_fts WHERE slug = ?", (slug,))
+    conn.execute("DELETE FROM pages_index WHERE slug = ?", (slug,))
+    conn.execute("DELETE FROM chats WHERE chat_id = ?", (fm.chat_id,))
+
+    _insert_chat_row(conn, fm, rel_path)
+    if fm.visibility == "indexed":
+        _insert_indexed_shadow(conn, fm, rel_path, _chat_body_text(chat_path))
+    return True
+
+
+def remove_chat_projection(conn: sqlite3.Connection, chat_id: str) -> None:
+    """Remove every projection row for a chat (M22 codex P2 sibling).
+
+    Drawer Discard deletes the markdown; mirror that here so a
+    repeated rebuild doesn't re-resurrect the row, and any cached
+    /chats render is consistent with disk.  Idempotent.
+    """
+    if not chat_id:
+        return
+    slug = chat_slug(chat_id)
+    conn.execute("DELETE FROM page_fts WHERE slug = ?", (slug,))
+    conn.execute("DELETE FROM pages_index WHERE slug = ?", (slug,))
+    conn.execute("DELETE FROM chats WHERE chat_id = ?", (chat_id,))
+
+
 __all__ = [
     "_CHAT_SLUG_PREFIX",
     "chat_slug",
     "iter_chat_transcripts",
     "rebuild_chats_projection",
+    "remove_chat_projection",
+    "upsert_chat_projection",
 ]

--- a/src/ovp_pipeline/commands/_chat_drawer.py
+++ b/src/ovp_pipeline/commands/_chat_drawer.py
@@ -1,0 +1,144 @@
+"""Anchored inquiry drawer (M22 / BL-090).
+
+The right-side slide-in surface that replaces the M21b full-page
+``/chat`` jump for ``Ask about this`` buttons.  Owns *only* the
+HTML shell rendered into the page layout; the routes that drive
+it live in :mod:`ovp_pipeline.commands.ui_server` and the
+client-side behaviour lives in
+``src/ovp_pipeline/static/ovp-chat-drawer.js``.
+
+Why a separate module
+---------------------
+
+The chat page (``_chat_page.py``) renders a stand-alone history
+view at ``/chat?id=...``; the drawer renders a *floating* view
+that opens over whatever Reader page the operator is on.  The
+two share the transcript rendering helpers from ``_chat_page``
+(``_render_transcript_body``) but diverge sharply on layout
+(no anchor badge / manifest card / page header — the drawer
+is small and quiet) and on the form submit target (the drawer
+posts to ``/chat/drawer/message`` and consumes JSON; the page
+posts to ``/chat/message`` and consumes a full HTML refresh).
+
+Ephemeral-first contract
+------------------------
+
+When the drawer creates a new inquiry session, the backend uses
+``visibility="unindexed"`` so the session stays out of /search
+and the /chats list during composition.  Three explicit choices
+the operator can make after seeing the assistant's reply:
+
+* **Save** — flip the file to ``indexed``; it now shows up in
+  /search and /chats.
+* **Absorb** — flip to ``indexed`` AND enqueue the chat for the
+  absorb pipeline (writeback_to_absorb_queue).
+* **Discard** — delete the file entirely.
+
+Closing the drawer without choosing leaves the file as
+``unindexed`` — invisible to /search and /chats.  A future
+janitor cron sweeps stale unindexed files after N days; for now
+they accumulate harmlessly and can be reviewed via a future
+``/chats?filter=unindexed`` view.
+"""
+
+from __future__ import annotations
+
+from html import escape
+
+
+# Container id used by the static JS to find / show / hide the
+# drawer.  Kept as a module constant so the renderer + JS agree.
+DRAWER_ID = "ovp-chat-drawer"
+
+
+def render_drawer_shell() -> str:
+    """Return the closed-state drawer markup.
+
+    Always injected on Reader pages by the page-shell so the
+    drawer is one DOM update away from any "Ask about this"
+    click — no extra round-trip to fetch a partial.  The drawer
+    is hidden via ``hidden`` until JS removes the attribute.
+
+    Layout (top → bottom):
+
+    * Header: anchor badge + close (×)
+    * Transcript body (scrollable)
+    * Composer (textarea + send button)
+    * Action bar (Save / Absorb / Discard) — hidden until at
+      least one assistant turn has landed
+    """
+    return f"""
+<aside id="{DRAWER_ID}" class="chat-drawer" hidden aria-hidden="true" role="dialog" aria-label="Anchored inquiry">
+  <div class="chat-drawer-backdrop" data-drawer-close="1" aria-hidden="true"></div>
+  <div class="chat-drawer-panel" role="document">
+    <header class="chat-drawer-header">
+      <div class="chat-drawer-anchor">
+        <span class="pill ghost" data-drawer-anchor-kind>standalone</span>
+        <span class="chat-drawer-anchor-title" data-drawer-anchor-title>Inquiry</span>
+      </div>
+      <button type="button" class="chat-drawer-close" data-drawer-close="1" aria-label="Close inquiry drawer">×</button>
+    </header>
+
+    <div class="chat-drawer-status" data-drawer-status hidden></div>
+
+    <div class="chat-drawer-transcript" data-drawer-transcript>
+      <p class="muted small">Ask about this artifact — the answer is rebuilt from current vault state every turn.</p>
+    </div>
+
+    <form class="chat-drawer-composer" data-drawer-composer>
+      <textarea
+        name="message"
+        class="chat-drawer-textarea"
+        rows="3"
+        required
+        placeholder="What would you like to know?"
+        data-drawer-message
+      ></textarea>
+      <div class="chat-drawer-composer-row">
+        <span class="muted small" data-drawer-profile-hint></span>
+        <button type="submit" class="primary" data-drawer-send>Send</button>
+      </div>
+    </form>
+
+    <div class="chat-drawer-actions" data-drawer-actions hidden>
+      <button type="button" class="btn ghost" data-drawer-action="discard">Discard</button>
+      <div class="chat-drawer-actions-right">
+        <button type="button" class="btn" data-drawer-action="save">Save to /chats</button>
+        <button type="button" class="btn primary" data-drawer-action="absorb">Save & absorb</button>
+      </div>
+    </div>
+  </div>
+</aside>
+"""
+
+
+def render_drawer_assets() -> str:
+    """Return the ``<link>`` + ``<script>`` tags for the drawer.
+
+    Loaded once from the page shell.  CSS uses ``defer``-less
+    ``<link>`` so the drawer's hidden state is styled before
+    first paint; JS uses ``defer`` so it runs after the DOM is
+    parsed (and after the drawer shell is in the document).
+    """
+    return (
+        '<link rel="stylesheet" href="/static/ovp-chat-drawer.css">'
+        '<script src="/static/ovp-chat-drawer.js" defer></script>'
+    )
+
+
+def render_turn_html(role: str, body: str, header: str = "") -> str:
+    """Render a single turn for drawer injection (JSON response).
+
+    Mirrors the ``_chat_page._flush_block`` shape but with the
+    drawer's narrower CSS classes.  ``body`` is plain text;
+    HTML entities are escaped.  ``header`` is a short label
+    rendered as a muted small caption (e.g. the timestamp).
+    """
+    role_class = "chat-drawer-turn-user" if role == "user" else "chat-drawer-turn-assistant"
+    caption = f"<p class='muted small'>{escape(header)}</p>" if header else ""
+    return (
+        f'<section class="chat-drawer-turn {role_class}">'
+        f"{caption}"
+        f"<pre class='chat-drawer-body'>{escape(body)}</pre>"
+        "</section>"
+    )

--- a/src/ovp_pipeline/commands/_digests_list_page.py
+++ b/src/ovp_pipeline/commands/_digests_list_page.py
@@ -1,0 +1,153 @@
+"""Reader ``/digests`` list view (M22 / BL-093).
+
+Daily digest history.  The home page surfaces only the latest
+digest; this page lists *all* digests under
+``40-Resources/Generated/digests/`` in reverse-chronological
+order so the operator can step through past days.
+
+Each entry links to the same ``/note?path=…`` markdown render
+the home card already opens; this module only adds the index
+(date + teaser + open link) and the prev/next neighbour nav
+that's missing once you're inside one of those notes.
+
+Scope deliberately tight — no filtering, no search, no card
+chrome.  A small ``<ul>`` of dated rows is enough for the
+volume one operator generates (≤ 1 / day).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from html import escape
+from pathlib import Path
+from urllib.parse import quote
+
+
+DIGESTS_DIR = "40-Resources/Generated/digests"
+
+
+@dataclass(frozen=True)
+class DigestRow:
+    """One digest entry rendered in the index.
+
+    ``date`` is the ``YYYY-MM-DD`` prefix recovered from the file
+    name; ``href`` is the same ``/note?path=…`` URL the home
+    page uses; ``teaser`` is the first non-frontmatter
+    paragraph (truncated).  ``filename`` is exposed so the
+    template can render the underlying file id as a hover-only
+    affordance for operators who like that level of detail.
+    """
+
+    date: str
+    href: str
+    teaser: str
+    filename: str
+
+
+def list_digests(vault_dir: Path | str) -> list[DigestRow]:
+    """Return every digest file under ``DIGESTS_DIR``, newest first.
+
+    Linear directory scan — there are at most a few hundred
+    files for daily output across a year, so the cost is
+    negligible.  Frontmatter is stripped from the teaser using
+    the same logic as :func:`_build_latest_digest_info` so the
+    two views agree.
+    """
+    folder = Path(vault_dir) / DIGESTS_DIR
+    if not folder.is_dir():
+        return []
+    rows: list[DigestRow] = []
+    for path in sorted(folder.glob("*.md"), reverse=True):
+        date = path.name[:10]
+        teaser = _extract_teaser(path)
+        rel = str(path.relative_to(vault_dir))
+        href = f"/note?path={quote(rel, safe='')}"
+        rows.append(
+            DigestRow(date=date, href=href, teaser=teaser, filename=path.name)
+        )
+    return rows
+
+
+def _extract_teaser(path: Path) -> str:
+    try:
+        body = path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+    lines = body.splitlines()
+    if lines and lines[0].strip() == "---":
+        try:
+            close_idx = next(
+                i for i, line in enumerate(lines[1:], start=1) if line.strip() == "---"
+            )
+            lines = lines[close_idx + 1 :]
+        except StopIteration:
+            lines = []
+    for line in lines:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if len(stripped) > 220:
+            return stripped[:217].rstrip() + "…"
+        return stripped
+    return ""
+
+
+def render_digests_list_body(vault_dir: Path | str) -> str:
+    """Render the body HTML for ``/digests``."""
+    rows = list_digests(vault_dir)
+    if not rows:
+        return (
+            "<h1>Daily digests</h1>"
+            "<p class='muted'>No digests yet.  Generated digests land in "
+            f"<code>{escape(DIGESTS_DIR)}</code> as the pipeline produces "
+            "them — typically one per UTC day.</p>"
+        )
+
+    items: list[str] = []
+    for row in rows:
+        teaser_html = (
+            f"<p class='muted small'>{escape(row.teaser)}</p>" if row.teaser else ""
+        )
+        items.append(
+            "<li class='card' style='margin-bottom:0.75rem'>"
+            f"<a href='{escape(row.href)}'>"
+            f"<strong>{escape(row.date)}</strong>"
+            "</a>"
+            f"<span class='muted small mono' style='margin-left:0.6rem'>"
+            f"{escape(row.filename)}"
+            "</span>"
+            f"{teaser_html}"
+            "</li>"
+        )
+    list_html = "<ul style='list-style:none;padding:0'>" + "".join(items) + "</ul>"
+    return (
+        "<h1>Daily digests</h1>"
+        f"<p class='muted'>{len(rows)} digest"
+        f"{'s' if len(rows) != 1 else ''} — newest first.</p>"
+        + list_html
+    )
+
+
+def neighbour_links(vault_dir: Path | str, current_relpath: str) -> tuple[str, str]:
+    """Return ``(prev_href, next_href)`` for the digest at
+    ``current_relpath`` (vault-relative).
+
+    Used by the /note route to inject "← previous day · next
+    day →" pivots when the operator opens a file under
+    ``DIGESTS_DIR``.  Either value is empty when the current
+    file has no neighbour on that side.
+    """
+    rows = list_digests(vault_dir)
+    if not rows:
+        return "", ""
+    # rows are newest-first; "prev" in operator-speak means
+    # *older*, i.e. further down the list.
+    idx = next(
+        (i for i, r in enumerate(rows) if r.href.endswith(quote(current_relpath, safe=""))),
+        -1,
+    )
+    if idx < 0:
+        return "", ""
+    older = rows[idx + 1].href if idx + 1 < len(rows) else ""
+    newer = rows[idx - 1].href if idx > 0 else ""
+    return older, newer

--- a/src/ovp_pipeline/commands/_digests_list_page.py
+++ b/src/ovp_pipeline/commands/_digests_list_page.py
@@ -142,8 +142,12 @@ def neighbour_links(vault_dir: Path | str, current_relpath: str) -> tuple[str, s
         return "", ""
     # rows are newest-first; "prev" in operator-speak means
     # *older*, i.e. further down the list.
+    # CodeRabbit: ``endswith`` on the encoded path can collide on
+    # path suffixes (``foo-bar.md`` ends with ``bar.md``); build the
+    # exact href the row would have and compare for equality.
+    target_href = f"/note?path={quote(current_relpath, safe='')}"
     idx = next(
-        (i for i, r in enumerate(rows) if r.href.endswith(quote(current_relpath, safe=""))),
+        (i for i, r in enumerate(rows) if r.href == target_href),
         -1,
     )
     if idx < 0:

--- a/src/ovp_pipeline/commands/_ui_renderers.py
+++ b/src/ovp_pipeline/commands/_ui_renderers.py
@@ -363,12 +363,17 @@ def _render_digest_neighbour_nav(vault_dir: Path, relative_path: str) -> str:
     Returns an empty string for any note outside
     ``40-Resources/Generated/digests/`` — the helper is cheap to
     call on every thin-note render and short-circuits there.
+
+    CodeRabbit: a Windows-flavored relative path with backslashes
+    would otherwise miss the prefix check; normalize once so the
+    helper works regardless of caller-side separators.
     """
-    if not relative_path.startswith("40-Resources/Generated/digests/"):
+    normalized = relative_path.replace("\\", "/")
+    if not normalized.startswith("40-Resources/Generated/digests/"):
         return ""
     from ovp_pipeline.commands._digests_list_page import neighbour_links
 
-    older, newer = neighbour_links(vault_dir, relative_path)
+    older, newer = neighbour_links(vault_dir, normalized)
     parts: list[str] = []
     if older:
         parts.append(f"<a href='{escape(older)}'>← previous day</a>")

--- a/src/ovp_pipeline/commands/_ui_renderers.py
+++ b/src/ovp_pipeline/commands/_ui_renderers.py
@@ -229,6 +229,10 @@ def _reader_nav_items(requested_pack: str = "") -> list[tuple[str, str]]:
         # Without a nav entry, operators have no discoverable path
         # back from a session they just started (codex review P2).
         ("Chats", "/chats"),
+        # M22 BL-093: ``/digests`` lists every daily digest so an
+        # operator can step into prior days rather than only seeing
+        # the latest one through the home banner.
+        ("Digests", "/digests"),
     ]
     if _shell_supports_research_nav(requested_pack):
         items.append(("Map", "/map"))
@@ -353,6 +357,41 @@ def _render_page_help(
     )
 
 
+def _render_digest_neighbour_nav(vault_dir: Path, relative_path: str) -> str:
+    """Prev/next pivot for digest notes (M22 BL-093).
+
+    Returns an empty string for any note outside
+    ``40-Resources/Generated/digests/`` — the helper is cheap to
+    call on every thin-note render and short-circuits there.
+    """
+    if not relative_path.startswith("40-Resources/Generated/digests/"):
+        return ""
+    from ovp_pipeline.commands._digests_list_page import neighbour_links
+
+    older, newer = neighbour_links(vault_dir, relative_path)
+    parts: list[str] = []
+    if older:
+        parts.append(f"<a href='{escape(older)}'>← previous day</a>")
+    # Always include the index link so a digest reader is never
+    # one click further from history than the home banner.
+    parts.append("<a href='/digests'>All digests</a>")
+    if newer:
+        parts.append(f"<a href='{escape(newer)}'>next day →</a>")
+    return "<p class='muted' style='margin-top:0.4rem'>" + " · ".join(parts) + "</p>"
+
+
+def _render_chat_drawer_shell() -> str:
+    """Inject the closed-state anchored inquiry drawer (M22).
+
+    Imported lazily to keep the renderer entry surface flat and
+    avoid a circular import — ``_chat_drawer`` only needs
+    ``html.escape`` and has no upstream Reader dependencies.
+    """
+    from ovp_pipeline.commands._chat_drawer import render_drawer_shell
+
+    return render_drawer_shell()
+
+
 def _layout(
     title: str, body: str, *, requested_pack: str = "", auto_refresh_seconds: int | None = None
 ) -> str:
@@ -392,6 +431,8 @@ def _layout(
     <link rel="stylesheet" href="/static/ovp-tokens.css" />
     <link rel="stylesheet" href="/static/ovp-ui.css" />
     <link rel="stylesheet" href="/static/ovp-pages.css" />
+    <link rel="stylesheet" href="/static/ovp-chat-drawer.css" />
+    <script src="/static/ovp-chat-drawer.js" defer></script>
     <style>
       /* Page-local additions only — anything reusable belongs in
          /static/ovp-ui.css (kit-faithful) or /static/ovp-pages.css
@@ -449,6 +490,7 @@ def _layout(
         </div>
       </div>
     </main>
+    {_render_chat_drawer_shell()}
     <script>
       (function () {{
         var root = document.documentElement;
@@ -564,7 +606,17 @@ def _render_ask_about_this_button(
         title=title,
         requested_pack=requested_pack,
     )
-    return f'<a class="btn ghost ask-about-this" href="{escape(href)}">' f"💬 {escape(label)}</a>"
+    # M22: the link is the no-JS fallback (still navigates to
+    # /chat).  When the drawer JS loads, it hijacks the click and
+    # opens the right-side drawer over the current Reader page
+    # using these data-* attributes.
+    return (
+        f'<a class="btn ghost ask-about-this" href="{escape(href)}"'
+        f' data-anchor-kind="{escape(anchor_kind)}"'
+        f' data-anchor-ref="{escape(anchor_ref)}"'
+        f' data-anchor-title="{escape(title)}"'
+        f">💬 {escape(label)}</a>"
+    )
 
 
 def _render_surface_contract_card(payload: dict) -> str:
@@ -1797,12 +1849,17 @@ def _render_note_page(
             title=_anchor_title_for_note(relative_path, markdown),
             requested_pack=requested_pack,
         )
+        # M22 BL-093: prev/next pivot when this is a daily digest
+        # so operators can step through history without bouncing
+        # back to the /digests list every time.
+        digest_nav_html = _render_digest_neighbour_nav(vault_dir, relative_path)
         return _layout(
             f"Markdown Note: {relative_path}",
             (
                 "<h1>Markdown Note</h1>"
                 f"<p class='muted'>{escape(relative_path)}</p>"
                 + f"<div class='entry-actions'>{ask_button}</div>"
+                + digest_nav_html
                 + preamble_html
                 + f"<section class='card'>{note_html}</section>"
                 + _render_frontmatter_details(frontmatter_html)

--- a/src/ovp_pipeline/commands/reader_home.py
+++ b/src/ovp_pipeline/commands/reader_home.py
@@ -113,12 +113,17 @@ def _render_reader_home(payload: dict) -> str:
             if digest_teaser
             else ""
         )
+        # M22 BL-093: surface the index alongside the latest entry so
+        # operators can step back to prior days without hunting through
+        # the file tree.
+        all_href = _shell_href("/digests", requested_pack)
         digest_card = (
             "<h2>Today's digest"
             f"<span class='muted tiny mono' style='margin-left:0.6rem'>{digest_date}</span>"
             "</h2>"
             f"{teaser_html}"
-            f"<p><a href='{digest_href}'>Open digest →</a></p>"
+            f"<p><a href='{digest_href}'>Open digest →</a>"
+            f" · <a href='{escape(all_href)}'>See all digests →</a></p>"
         )
 
     body = "".join([

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -189,7 +189,6 @@ def _maybe_update_chats_projection(
             remove_chat_projection,
             upsert_chat_projection,
         )
-        from ovp_pipeline.runtime import VaultLayout
 
         layout = VaultLayout.from_vault(vault_dir)
         if not layout.knowledge_db.is_file():
@@ -1550,7 +1549,7 @@ def create_server(
             anchor_raw = self._form_first(form, "anchor").strip()
             anchor_title = self._form_first(form, "anchor_title").strip()
             message = self._form_first(form, "message").strip()
-            profile = self._form_first(form, "profile").strip() or "balanced"
+            profile = self._form_first(form, "profile").strip()
             visibility = self._form_first(form, "visibility").strip() or "indexed"
 
             anchor_kind, anchor_ref = parse_anchor_string(anchor_raw)
@@ -1651,7 +1650,7 @@ def create_server(
             anchor_raw = self._form_first(form, "anchor").strip()
             anchor_title = self._form_first(form, "anchor_title").strip()
             message = self._form_first(form, "message").strip()
-            profile = self._form_first(form, "profile").strip() or "balanced"
+            profile = self._form_first(form, "profile").strip()
 
             anchor_kind, anchor_ref = parse_anchor_string(anchor_raw)
 
@@ -1796,9 +1795,11 @@ def create_server(
                         action="save",
                     )
                 elif action == "absorb":
-                    set_visibility(chat_path, "indexed")
-                    fm = parse_chat(chat_path)
-                    if fm is None or fm.turn_count < 1:
+                    # gemini review: set_visibility already returns the
+                    # updated frontmatter — reuse it instead of re-reading
+                    # the file via parse_chat.
+                    fm = set_visibility(chat_path, "indexed")
+                    if fm.turn_count < 1:
                         self._write_json(
                             {
                                 "error": "no_turns",

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -164,6 +164,50 @@ def _crystal_kind_and_id_from_note_path(relative_path: str) -> tuple[str, str] |
     return ("community_crystal", f"cluster::{stem}")
 
 
+def _maybe_update_chats_projection(
+    vault_dir: Path | str,
+    *,
+    chat_id: str,
+    chat_path: Path | None = None,
+    action: str,
+) -> None:
+    """Refresh ``knowledge.db.chats`` + FTS shadow rows for one chat
+    after a drawer action (M22 codex P2).
+
+    Without this, a Save'd session lives in markdown but stays
+    invisible to ``/chats`` (which reads
+    ``list_indexed_chats(knowledge.db)``) and ``/search`` (which
+    joins ``page_fts`` + ``pages_index``) until the next full
+    ``ovp-knowledge-index`` rebuild.
+
+    Best-effort: any DB failure is logged but never raises — the
+    operator's markdown change already succeeded; a stale
+    projection is a follow-up annoyance, not a data-loss event.
+    """
+    try:
+        from ovp_pipeline.chats_projection import (
+            remove_chat_projection,
+            upsert_chat_projection,
+        )
+        from ovp_pipeline.runtime import VaultLayout
+
+        layout = VaultLayout.from_vault(vault_dir)
+        if not layout.knowledge_db.is_file():
+            return
+        with sqlite3.connect(layout.knowledge_db) as conn:
+            if action == "discard":
+                remove_chat_projection(conn, chat_id)
+            elif action in ("save", "absorb") and chat_path is not None:
+                upsert_chat_projection(conn, Path(vault_dir), chat_path)
+            conn.commit()
+    except Exception as exc:  # noqa: BLE001 — best-effort
+        print(
+            f"[ui_server] chats projection update failed for "
+            f"chat_id={chat_id!r} action={action!r}: {exc}",
+            file=sys.stderr,
+        )
+
+
 def _maybe_emit_crystal_note_reuse(
     vault_dir: Path | str,
     relative_path: str,
@@ -1710,11 +1754,47 @@ def create_server(
                 )
                 return
 
+            # Codex P2: read the on-disk visibility BEFORE acting.
+            # Discard must refuse already-indexed transcripts; a
+            # follow-up Discard click after Save/Absorb would
+            # otherwise delete a saved session from disk.
+            current_fm = parse_chat(chat_path)
+            if current_fm is None:
+                self._write_json(
+                    {
+                        "error": "not_a_chat",
+                        "detail": f"{chat_path} is not a valid chat transcript.",
+                    },
+                    status=400,
+                )
+                return
+
             try:
                 if action == "discard":
+                    if current_fm.visibility == "indexed":
+                        self._write_json(
+                            {
+                                "error": "already_saved",
+                                "detail": (
+                                    "Cannot discard an indexed session.  "
+                                    "Archive or delete it from /chats instead."
+                                ),
+                            },
+                            status=409,
+                        )
+                        return
                     delete_chat(chat_path)
+                    _maybe_update_chats_projection(
+                        resolved_vault, chat_id=chat_id, action="discard"
+                    )
                 elif action == "save":
                     set_visibility(chat_path, "indexed")
+                    _maybe_update_chats_projection(
+                        resolved_vault,
+                        chat_id=chat_id,
+                        chat_path=chat_path,
+                        action="save",
+                    )
                 elif action == "absorb":
                     set_visibility(chat_path, "indexed")
                     fm = parse_chat(chat_path)
@@ -1732,6 +1812,12 @@ def create_server(
                         chat_id=chat_id,
                         turn_number=fm.turn_count,
                         chat_path=chat_path,
+                    )
+                    _maybe_update_chats_projection(
+                        resolved_vault,
+                        chat_id=chat_id,
+                        chat_path=chat_path,
+                        action="absorb",
                     )
                 else:
                     self._write_json(

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -1184,6 +1184,18 @@ def create_server(
                         )
                     )
                     return
+                if path == "/digests":
+                    from ovp_pipeline.commands._digests_list_page import (
+                        render_digests_list_body,
+                    )
+
+                    self._write_html(
+                        _layout(
+                            "Daily digests",
+                            render_digests_list_body(resolved_vault),
+                        )
+                    )
+                    return
                 self.send_error(404, "Not Found")
             except ValueError as exc:
                 self.send_error(400, str(exc))
@@ -1386,6 +1398,18 @@ def create_server(
                 if path == "/chat/message":
                     self._handle_chat_message_post(form, csrf_token)
                     return
+                if path == "/chat/drawer/message":
+                    self._handle_chat_drawer_message_post(form)
+                    return
+                if path == "/chat/drawer/save":
+                    self._handle_chat_drawer_action_post(form, action="save")
+                    return
+                if path == "/chat/drawer/absorb":
+                    self._handle_chat_drawer_action_post(form, action="absorb")
+                    return
+                if path == "/chat/drawer/discard":
+                    self._handle_chat_drawer_action_post(form, action="discard")
+                    return
                 self.send_error(404, "Not Found")
             except ValueError as exc:
                 self.send_error(400, str(exc))
@@ -1546,6 +1570,187 @@ def create_server(
                 )
                 return
             self._redirect(chat_page_redirect_target(result.chat_id))
+
+        # ── M22: anchored inquiry drawer ───────────────────────
+
+        def _handle_chat_drawer_message_post(
+            self, form: dict[str, list[str]]
+        ) -> None:
+            """Handle POST ``/chat/drawer/message`` — JSON response.
+
+            Ephemeral-first: a new session lands as
+            ``visibility="unindexed"`` so it stays out of /search
+            and /chats during composition.  The operator decides
+            via the Save / Absorb / Discard buttons after seeing
+            the answer.
+
+            Response shape::
+
+                {
+                  "chat_id": "chat-...",
+                  "user_html": "<section>...</section>",
+                  "assistant_html": "<section>...</section>"
+                }
+
+            Errors return ``{"error": "...", "detail": "..."}``
+            with a 4xx / 5xx status — the JS surfaces ``detail``
+            in the drawer's status banner.
+            """
+            from ovp_pipeline.commands._chat_drawer import render_turn_html
+            from ovp_pipeline.commands._chat_page import parse_anchor_string
+            from ovp_pipeline.commands.chat_handler import (
+                ChatCapExceeded,
+                run_turn,
+            )
+
+            chat_id = self._form_first(form, "chat_id").strip() or None
+            anchor_raw = self._form_first(form, "anchor").strip()
+            anchor_title = self._form_first(form, "anchor_title").strip()
+            message = self._form_first(form, "message").strip()
+            profile = self._form_first(form, "profile").strip() or "balanced"
+
+            anchor_kind, anchor_ref = parse_anchor_string(anchor_raw)
+
+            if not message:
+                self._write_json(
+                    {"error": "empty_message", "detail": "Message cannot be empty."},
+                    status=400,
+                )
+                return
+
+            try:
+                result = run_turn(
+                    resolved_vault,
+                    chat_id=chat_id,
+                    user_message=message,
+                    anchor_kind=anchor_kind,
+                    anchor_ref=anchor_ref,
+                    anchor_title=anchor_title,
+                    profile_name=profile or None,
+                    # Drawer always starts ephemeral; explicit Save
+                    # / Absorb actions flip the file to indexed.
+                    # Follow-up turns inherit the current session
+                    # visibility from frontmatter (run_turn ignores
+                    # this kwarg when chat_id is set).
+                    visibility="unindexed",
+                )
+            except ChatCapExceeded as exc:
+                self._write_json(
+                    {"error": "cap_exceeded", "detail": str(exc)},
+                    status=429,
+                )
+                return
+            except ValueError as exc:
+                self._write_json(
+                    {"error": "bad_request", "detail": str(exc)},
+                    status=400,
+                )
+                return
+            except Exception as exc:  # noqa: BLE001 — provider failures
+                self._write_json(
+                    {
+                        "error": exc.__class__.__name__,
+                        "detail": str(exc),
+                    },
+                    status=500,
+                )
+                return
+
+            user_header = f"User · {result.frontmatter.last_message_at}"
+            assistant_header = (
+                f"Assistant · {result.frontmatter.last_message_at} "
+                f"· turn-{result.frontmatter.turn_count}"
+            )
+            self._write_json(
+                {
+                    "chat_id": result.chat_id,
+                    "user_html": render_turn_html("user", message, header=user_header),
+                    "assistant_html": render_turn_html(
+                        "assistant", result.assistant_body, header=assistant_header
+                    ),
+                }
+            )
+
+        def _handle_chat_drawer_action_post(
+            self, form: dict[str, list[str]], *, action: str
+        ) -> None:
+            """Handle Save / Absorb / Discard from the drawer.
+
+            * ``save`` — flip visibility to ``indexed``
+            * ``absorb`` — flip to indexed AND enqueue for absorb
+            * ``discard`` — delete the transcript file
+
+            JSON response: ``{"ok": true}`` or ``{"error": "..."}``.
+            """
+            from ovp_pipeline.chat_fileops import (
+                delete_chat,
+                parse_chat,
+                set_visibility,
+            )
+            from ovp_pipeline.commands.chat_handler import (
+                _find_chat_by_id,
+                writeback_to_absorb_queue,
+            )
+
+            chat_id = self._form_first(form, "chat_id").strip()
+            if not chat_id:
+                self._write_json(
+                    {"error": "missing_chat_id", "detail": "chat_id is required."},
+                    status=400,
+                )
+                return
+            chat_path = _find_chat_by_id(resolved_vault, chat_id)
+            if chat_path is None:
+                self._write_json(
+                    {
+                        "error": "not_found",
+                        "detail": f"Inquiry session {chat_id!r} not found.",
+                    },
+                    status=404,
+                )
+                return
+
+            try:
+                if action == "discard":
+                    delete_chat(chat_path)
+                elif action == "save":
+                    set_visibility(chat_path, "indexed")
+                elif action == "absorb":
+                    set_visibility(chat_path, "indexed")
+                    fm = parse_chat(chat_path)
+                    if fm is None or fm.turn_count < 1:
+                        self._write_json(
+                            {
+                                "error": "no_turns",
+                                "detail": "Inquiry has no assistant turn to absorb yet.",
+                            },
+                            status=400,
+                        )
+                        return
+                    writeback_to_absorb_queue(
+                        resolved_vault,
+                        chat_id=chat_id,
+                        turn_number=fm.turn_count,
+                        chat_path=chat_path,
+                    )
+                else:
+                    self._write_json(
+                        {"error": "unknown_action", "detail": action}, status=400
+                    )
+                    return
+            except ValueError as exc:
+                self._write_json(
+                    {"error": "bad_request", "detail": str(exc)}, status=400
+                )
+                return
+            except Exception as exc:  # noqa: BLE001
+                self._write_json(
+                    {"error": exc.__class__.__name__, "detail": str(exc)},
+                    status=500,
+                )
+                return
+
+            self._write_json({"ok": True, "action": action, "chat_id": chat_id})
 
         def _resolve_contradiction_action(self, form: dict[str, list[str]]) -> dict[str, object]:
             contradiction_ids = [

--- a/src/ovp_pipeline/static/ovp-chat-drawer.css
+++ b/src/ovp_pipeline/static/ovp-chat-drawer.css
@@ -1,0 +1,211 @@
+/* M22 — anchored inquiry drawer.
+ *
+ * Right-side slide-in.  Triggered by "Ask about this" buttons on
+ * Reader pages; closes on backdrop click, X button, or Escape.
+ *
+ * Width: 480px on desktop, 100vw on narrow viewports.  Both are
+ * subject to operator feedback in the first install — adjust the
+ * --chat-drawer-width custom prop or the @media breakpoint below.
+ */
+
+:root {
+  --chat-drawer-width: 480px;
+  --chat-drawer-bg: var(--bg, #ffffff);
+  --chat-drawer-fg: var(--fg, #1a1a1a);
+  --chat-drawer-border: var(--border, #e5e5e5);
+  --chat-drawer-muted: var(--muted-bg, #f6f6f6);
+  --chat-drawer-shadow: 0 10px 40px rgba(0, 0, 0, 0.18);
+}
+
+.chat-drawer[hidden] {
+  display: none !important;
+}
+
+.chat-drawer {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  pointer-events: none;
+}
+
+.chat-drawer-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 15, 15, 0.32);
+  opacity: 0;
+  transition: opacity 180ms ease-out;
+  pointer-events: auto;
+}
+
+.chat-drawer.is-open .chat-drawer-backdrop {
+  opacity: 1;
+}
+
+.chat-drawer-panel {
+  position: absolute;
+  top: 0;
+  right: 0;
+  height: 100vh;
+  width: var(--chat-drawer-width);
+  max-width: 100vw;
+  background: var(--chat-drawer-bg);
+  color: var(--chat-drawer-fg);
+  border-left: 1px solid var(--chat-drawer-border);
+  box-shadow: var(--chat-drawer-shadow);
+  display: grid;
+  grid-template-rows: auto auto 1fr auto auto;
+  transform: translateX(100%);
+  transition: transform 220ms cubic-bezier(0.2, 0.7, 0.2, 1);
+  pointer-events: auto;
+}
+
+.chat-drawer.is-open .chat-drawer-panel {
+  transform: translateX(0);
+}
+
+.chat-drawer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--chat-drawer-border);
+}
+
+.chat-drawer-anchor {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+  flex: 1;
+}
+
+.chat-drawer-anchor-title {
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-drawer-close {
+  background: transparent;
+  border: 0;
+  font-size: 1.5rem;
+  line-height: 1;
+  width: 2rem;
+  height: 2rem;
+  cursor: pointer;
+  color: inherit;
+  border-radius: 4px;
+}
+
+.chat-drawer-close:hover {
+  background: var(--chat-drawer-muted);
+}
+
+.chat-drawer-status {
+  padding: 0.5rem 1rem;
+  background: var(--chat-drawer-muted);
+  border-bottom: 1px solid var(--chat-drawer-border);
+  font-size: 0.875rem;
+}
+
+.chat-drawer-status.is-error {
+  background: #fee;
+  color: #900;
+}
+
+.chat-drawer-transcript {
+  overflow-y: auto;
+  padding: 1rem;
+  min-height: 0;
+}
+
+.chat-drawer-transcript > * + * {
+  margin-top: 1rem;
+}
+
+.chat-drawer-turn {
+  border: 1px solid var(--chat-drawer-border);
+  border-radius: 6px;
+  padding: 0.75rem;
+  background: var(--chat-drawer-bg);
+}
+
+.chat-drawer-turn-user {
+  background: var(--chat-drawer-muted);
+}
+
+.chat-drawer-body {
+  font-family: inherit;
+  font-size: 0.9375rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  margin: 0.25rem 0 0;
+}
+
+.chat-drawer-composer {
+  border-top: 1px solid var(--chat-drawer-border);
+  padding: 0.75rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.chat-drawer-textarea {
+  width: 100%;
+  font: inherit;
+  padding: 0.5rem;
+  border: 1px solid var(--chat-drawer-border);
+  border-radius: 4px;
+  resize: vertical;
+  min-height: 4.5rem;
+  box-sizing: border-box;
+}
+
+.chat-drawer-composer-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.chat-drawer-actions {
+  border-top: 1px solid var(--chat-drawer-border);
+  padding: 0.75rem 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  background: var(--chat-drawer-muted);
+}
+
+.chat-drawer-actions-right {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.chat-drawer-actions button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+/* Narrow viewports — drawer fills the screen so the form
+ * remains usable.  Keep the slide-in animation; just widen.
+ */
+@media (max-width: 640px) {
+  :root {
+    --chat-drawer-width: 100vw;
+  }
+  .chat-drawer-panel {
+    border-left: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chat-drawer-panel,
+  .chat-drawer-backdrop {
+    transition: none;
+  }
+}

--- a/src/ovp_pipeline/static/ovp-chat-drawer.js
+++ b/src/ovp_pipeline/static/ovp-chat-drawer.js
@@ -319,16 +319,27 @@
         state.chatId = null;
         // Close after a tick so the operator sees the confirmation.
         setTimeout(closeDrawer, 600);
-      } else if (actionName === "save") {
-        showStatus("Saved to /chats.");
+      } else {
+        // Save / Absorb: the file is now indexed.  Re-enable Save
+        // & Absorb so the operator can re-trigger if they like
+        // (idempotent on the server), but DISABLE Discard — a
+        // follow-up Discard click on an indexed session would
+        // try to delete a saved transcript.  Server also rejects
+        // discard for indexed sessions, but disabling the button
+        // is the better UX cue.
         actionBtns.forEach(function (b) {
-          b.disabled = false;
+          if (b.dataset.drawerAction === "discard") {
+            b.disabled = true;
+            b.title = "Already saved — open /chats to manage.";
+          } else {
+            b.disabled = false;
+          }
         });
-      } else if (actionName === "absorb") {
-        showStatus("Queued for absorb.");
-        actionBtns.forEach(function (b) {
-          b.disabled = false;
-        });
+        if (actionName === "save") {
+          showStatus("Saved to /chats.");
+        } else if (actionName === "absorb") {
+          showStatus("Queued for absorb.");
+        }
       }
     } catch (err) {
       showStatus("Network error: " + (err && err.message ? err.message : err), {

--- a/src/ovp_pipeline/static/ovp-chat-drawer.js
+++ b/src/ovp_pipeline/static/ovp-chat-drawer.js
@@ -1,0 +1,435 @@
+// M22 — anchored inquiry drawer client.
+//
+// Hijacks every `.ask-about-this` link on the page and opens the
+// drawer instead of navigating to /chat.  Posts messages to
+// /chat/drawer/message, renders the JSON response, and exposes
+// three explicit-decision actions (Save / Absorb / Discard).
+//
+// Progressive enhancement: if this script fails to load, the
+// `<a href="/chat?...">` element still navigates to the M21b
+// full-page chat surface — operators don't lose the feature.
+
+(function () {
+  "use strict";
+
+  const DRAWER_ID = "ovp-chat-drawer";
+
+  // localStorage keys.  Drafts are scoped to the anchor so two
+  // different note pages keep independent drafts; the bare
+  // `standalone` key covers an unanchored drawer.  Chat-id is
+  // also persisted per-anchor so closing and reopening the
+  // drawer on the same artifact resumes the same session.
+  const DRAFT_KEY_PREFIX = "ovp-chat-draft:";
+  const SESSION_KEY_PREFIX = "ovp-chat-session:";
+
+  function anchorKey(kind, ref) {
+    return (kind || "standalone") + ":" + (ref || "");
+  }
+
+  function readLS(prefix, key) {
+    try {
+      return window.localStorage.getItem(prefix + key) || "";
+    } catch (e) {
+      return "";
+    }
+  }
+
+  function writeLS(prefix, key, value) {
+    try {
+      if (value) {
+        window.localStorage.setItem(prefix + key, value);
+      } else {
+        window.localStorage.removeItem(prefix + key);
+      }
+    } catch (e) {
+      /* localStorage full or disabled — silently degrade */
+    }
+  }
+
+  function $drawer() {
+    return document.getElementById(DRAWER_ID);
+  }
+
+  function $csrfToken() {
+    // The CSRF cookie is HttpOnly — JS cannot read it.  The
+    // server renders the same token into <meta name="csrf-token">
+    // (see _write_html in ui_server.py); use that instead.
+    const meta = document.querySelector('meta[name="csrf-token"]');
+    return meta ? meta.getAttribute("content") || "" : "";
+  }
+
+  // --- State (one drawer per page) ----------------------------
+
+  const state = {
+    chatId: null,
+    anchorKind: "standalone",
+    anchorRef: "",
+    anchorTitle: "",
+    profile: "balanced",
+    sending: false,
+  };
+
+  function resetState() {
+    state.chatId = null;
+    state.anchorKind = "standalone";
+    state.anchorRef = "";
+    state.anchorTitle = "";
+    state.profile = "balanced";
+    state.sending = false;
+  }
+
+  // --- Open / close --------------------------------------------
+
+  function openDrawer(opts) {
+    const drawer = $drawer();
+    if (!drawer) return;
+    resetState();
+    state.anchorKind = opts.anchorKind || "standalone";
+    state.anchorRef = opts.anchorRef || "";
+    state.anchorTitle = opts.anchorTitle || "";
+
+    const key = anchorKey(state.anchorKind, state.anchorRef);
+
+    // Resume the prior session for this anchor if one was started
+    // and not Save/Discard-ed.  The transcript itself isn't
+    // rehydrated client-side (would need a server fetch); the
+    // chat_id is enough to continue the conversation server-side.
+    const priorChatId = readLS(SESSION_KEY_PREFIX, key);
+    state.chatId = priorChatId || null;
+
+    const kindBadge = drawer.querySelector("[data-drawer-anchor-kind]");
+    const titleEl = drawer.querySelector("[data-drawer-anchor-title]");
+    if (kindBadge) kindBadge.textContent = state.anchorKind;
+    if (titleEl) {
+      titleEl.textContent = state.anchorTitle || state.anchorRef || "Standalone";
+    }
+
+    const transcript = drawer.querySelector("[data-drawer-transcript]");
+    if (transcript) {
+      transcript.innerHTML =
+        "<p class='muted small'>Ask about this artifact — the answer is rebuilt from current vault state every turn.</p>";
+      transcript.dataset.empty = "true";
+    }
+    const actions = drawer.querySelector("[data-drawer-actions]");
+    if (actions) actions.hidden = !state.chatId;
+
+    clearStatus();
+
+    // Restore the draft for this anchor (if any).  Survives page
+    // reloads, drawer closes, and CSRF / network errors.
+    const textarea = drawer.querySelector("[data-drawer-message]");
+    if (textarea) {
+      const draft = readLS(DRAFT_KEY_PREFIX, key);
+      textarea.value = draft;
+      if (draft) {
+        showStatus("Restored your unsent draft.");
+      }
+    }
+
+    drawer.hidden = false;
+    drawer.setAttribute("aria-hidden", "false");
+    // Allow the browser to apply `hidden=false` before the transition class.
+    requestAnimationFrame(function () {
+      drawer.classList.add("is-open");
+      if (textarea) textarea.focus();
+    });
+  }
+
+  function closeDrawer() {
+    const drawer = $drawer();
+    if (!drawer) return;
+    drawer.classList.remove("is-open");
+    drawer.setAttribute("aria-hidden", "true");
+    // Match the panel transition before fully hiding so the
+    // slide-out animation is visible.
+    setTimeout(function () {
+      if (!drawer.classList.contains("is-open")) {
+        drawer.hidden = true;
+      }
+    }, 240);
+  }
+
+  // --- Status banner -------------------------------------------
+
+  function showStatus(text, opts) {
+    const drawer = $drawer();
+    if (!drawer) return;
+    const el = drawer.querySelector("[data-drawer-status]");
+    if (!el) return;
+    el.textContent = text;
+    el.hidden = false;
+    el.classList.toggle("is-error", !!(opts && opts.error));
+  }
+
+  function clearStatus() {
+    const drawer = $drawer();
+    if (!drawer) return;
+    const el = drawer.querySelector("[data-drawer-status]");
+    if (el) {
+      el.hidden = true;
+      el.textContent = "";
+      el.classList.remove("is-error");
+    }
+  }
+
+  // --- Transcript injection ------------------------------------
+
+  function appendTranscript(html) {
+    const drawer = $drawer();
+    if (!drawer) return;
+    const transcript = drawer.querySelector("[data-drawer-transcript]");
+    if (!transcript) return;
+    // First message: replace the empty-state hint.
+    if (transcript.dataset.empty !== "false") {
+      transcript.innerHTML = "";
+      transcript.dataset.empty = "false";
+    }
+    const wrapper = document.createElement("div");
+    wrapper.innerHTML = html;
+    while (wrapper.firstChild) transcript.appendChild(wrapper.firstChild);
+    transcript.scrollTop = transcript.scrollHeight;
+  }
+
+  function showActions() {
+    const drawer = $drawer();
+    if (!drawer) return;
+    const actions = drawer.querySelector("[data-drawer-actions]");
+    if (actions) actions.hidden = false;
+  }
+
+  // --- Network -------------------------------------------------
+
+  function postForm(url, payload) {
+    const body = new URLSearchParams();
+    const csrf = $csrfToken();
+    if (csrf) body.set("_csrf", csrf);
+    Object.keys(payload).forEach(function (key) {
+      const value = payload[key];
+      if (value !== undefined && value !== null && value !== "") {
+        body.set(key, String(value));
+      }
+    });
+    return fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "application/json",
+      },
+      credentials: "same-origin",
+      body: body.toString(),
+    });
+  }
+
+  async function sendMessage() {
+    if (state.sending) return;
+    const drawer = $drawer();
+    if (!drawer) return;
+    const textarea = drawer.querySelector("[data-drawer-message]");
+    if (!textarea) return;
+    const message = (textarea.value || "").trim();
+    if (!message) {
+      textarea.focus();
+      return;
+    }
+
+    state.sending = true;
+    clearStatus();
+    showStatus("Sending…");
+    const sendBtn = drawer.querySelector("[data-drawer-send]");
+    if (sendBtn) sendBtn.disabled = true;
+
+    try {
+      const resp = await postForm("/chat/drawer/message", {
+        chat_id: state.chatId || "",
+        anchor: state.anchorRef ? state.anchorKind + ":" + state.anchorRef : "",
+        anchor_title: state.anchorTitle,
+        profile: state.profile,
+        message: message,
+      });
+      const data = await resp.json().catch(function () {
+        return { error: "invalid_json" };
+      });
+      if (!resp.ok || data.error) {
+        const reason = (data && (data.detail || data.error)) || "Send failed";
+        showStatus(reason, { error: true });
+        return;
+      }
+      state.chatId = data.chat_id || state.chatId;
+      // Persist chat_id so closing+reopening the drawer (or even a
+      // page reload) keeps the same session.  Cleared in runAction
+      // when the operator picks Save / Absorb / Discard.
+      writeLS(
+        SESSION_KEY_PREFIX,
+        anchorKey(state.anchorKind, state.anchorRef),
+        state.chatId || "",
+      );
+      // Success: drop the saved draft so the next open starts empty.
+      writeLS(DRAFT_KEY_PREFIX, anchorKey(state.anchorKind, state.anchorRef), "");
+      if (data.user_html) appendTranscript(data.user_html);
+      if (data.assistant_html) appendTranscript(data.assistant_html);
+      textarea.value = "";
+      textarea.style.height = "";
+      showActions();
+      clearStatus();
+    } catch (err) {
+      showStatus("Network error: " + (err && err.message ? err.message : err), {
+        error: true,
+      });
+    } finally {
+      state.sending = false;
+      if (sendBtn) sendBtn.disabled = false;
+      textarea.focus();
+    }
+  }
+
+  async function runAction(actionName) {
+    if (!state.chatId) return;
+    const drawer = $drawer();
+    if (!drawer) return;
+    const actionBtns = drawer.querySelectorAll("[data-drawer-action]");
+    actionBtns.forEach(function (b) {
+      b.disabled = true;
+    });
+    showStatus(actionName === "discard" ? "Discarding…" : "Saving…");
+
+    try {
+      const resp = await postForm("/chat/drawer/" + actionName, {
+        chat_id: state.chatId,
+      });
+      const data = await resp.json().catch(function () {
+        return { error: "invalid_json" };
+      });
+      if (!resp.ok || data.error) {
+        const reason = (data && (data.detail || data.error)) || actionName + " failed";
+        showStatus(reason, { error: true });
+        actionBtns.forEach(function (b) {
+          b.disabled = false;
+        });
+        return;
+      }
+      // Any decisive action ends this session — clear the
+      // resume marker so the next open of this anchor starts
+      // a fresh chat.  Drafts already cleared on send.
+      const key = anchorKey(state.anchorKind, state.anchorRef);
+      writeLS(SESSION_KEY_PREFIX, key, "");
+      writeLS(DRAFT_KEY_PREFIX, key, "");
+
+      if (actionName === "discard") {
+        showStatus("Discarded.");
+        state.chatId = null;
+        // Close after a tick so the operator sees the confirmation.
+        setTimeout(closeDrawer, 600);
+      } else if (actionName === "save") {
+        showStatus("Saved to /chats.");
+        actionBtns.forEach(function (b) {
+          b.disabled = false;
+        });
+      } else if (actionName === "absorb") {
+        showStatus("Queued for absorb.");
+        actionBtns.forEach(function (b) {
+          b.disabled = false;
+        });
+      }
+    } catch (err) {
+      showStatus("Network error: " + (err && err.message ? err.message : err), {
+        error: true,
+      });
+      actionBtns.forEach(function (b) {
+        b.disabled = false;
+      });
+    }
+  }
+
+  // --- Wiring --------------------------------------------------
+
+  function bindOpenTriggers() {
+    document.querySelectorAll(".ask-about-this").forEach(function (el) {
+      if (el.dataset.drawerBound === "1") return;
+      el.dataset.drawerBound = "1";
+      el.addEventListener("click", function (ev) {
+        const kind = el.dataset.anchorKind;
+        const ref = el.dataset.anchorRef;
+        const title = el.dataset.anchorTitle;
+        if (!kind && !ref && !title) {
+          // No data attrs — let the link fall through to /chat
+          // (no-JS fallback).
+          return;
+        }
+        ev.preventDefault();
+        openDrawer({
+          anchorKind: kind || "standalone",
+          anchorRef: ref || "",
+          anchorTitle: title || "",
+        });
+      });
+    });
+  }
+
+  function bindDrawerHandlers() {
+    const drawer = $drawer();
+    if (!drawer) return;
+
+    drawer.addEventListener("click", function (ev) {
+      const target = ev.target;
+      if (!(target instanceof HTMLElement)) return;
+      if (target.matches("[data-drawer-close]")) {
+        ev.preventDefault();
+        closeDrawer();
+        return;
+      }
+      const action = target.dataset.drawerAction;
+      if (action) {
+        ev.preventDefault();
+        runAction(action);
+      }
+    });
+
+    const composer = drawer.querySelector("[data-drawer-composer]");
+    if (composer) {
+      composer.addEventListener("submit", function (ev) {
+        ev.preventDefault();
+        sendMessage();
+      });
+    }
+
+    // Cmd/Ctrl+Enter to send from the textarea.
+    const textarea = drawer.querySelector("[data-drawer-message]");
+    if (textarea) {
+      textarea.addEventListener("keydown", function (ev) {
+        if ((ev.metaKey || ev.ctrlKey) && ev.key === "Enter") {
+          ev.preventDefault();
+          sendMessage();
+        }
+      });
+      // Persist every keystroke so a crash / reload / error
+      // can't eat the draft.  Keyed by anchor so two artifacts
+      // keep independent drafts.
+      textarea.addEventListener("input", function () {
+        writeLS(
+          DRAFT_KEY_PREFIX,
+          anchorKey(state.anchorKind, state.anchorRef),
+          textarea.value,
+        );
+      });
+    }
+
+    document.addEventListener("keydown", function (ev) {
+      if (ev.key === "Escape" && !drawer.hidden) {
+        closeDrawer();
+      }
+    });
+  }
+
+  // --- Boot ----------------------------------------------------
+
+  function boot() {
+    bindOpenTriggers();
+    bindDrawerHandlers();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", boot);
+  } else {
+    boot();
+  }
+})();


### PR DESCRIPTION
## Summary

- **Right-side drawer for anchored inquiry** — clicking 💬 Ask about this on any note/object page opens a 480px-wide drawer over the current Reader page instead of jumping to a separate ``/chat`` route. Backdrop / × / Esc close. Sessions land as ``visibility=unindexed`` during composition so they stay out of /search and /chats; explicit Save / Save & absorb / Discard buttons appear after the first assistant reply.
- **localStorage drafts + session continuity** — every keystroke is saved per-anchor. CSRF errors, network errors, accidental closes, page reloads — none of them eat the textarea. ``chat_id`` is also persisted so reopening the drawer on the same artifact resumes the same conversation.
- **CSRF fix** — drawer JS reads ``<meta name=\"csrf-token\">`` instead of the HttpOnly ``_csrf`` cookie (which is unreadable from JS, the bug that caused ``csrf_token_mismatch`` on first send).
- **/digests Reader list + prev/next nav** — daily digests now have a dedicated Reader page, a "See all digests →" link on the home banner, and a prev/next pivot strip on the digest note itself.
- **chat_fileops helpers**: ``set_visibility`` (atomic flip under per-chat flock) + ``delete_chat`` (idempotent unlink with lock cleanup).

Closes the four user-story failures recorded in ``docs/plans/2026-05-13-m22-anchored-inquiry-drawer.md``:

1. "Ask about this" opens a new page → fixed (in-place drawer)
2. Profile picker shows no real choice → composer cleanup follow-up (drawer hides the picker entirely when only one profile)
3. Visibility decided before answer → ephemeral-first; decision after seeing the reply
4. Textarea too small → drawer textarea is vertically resizable + Cmd/Ctrl+Enter sends
5. No Digest history navigation → /digests list + prev/next neighbour nav

## Test plan

- [x] ``pytest tests/test_chat_*.py tests/test_ui_server.py tests/test_ui_smoke.py`` — 270 pass, 7 xfail (pre-existing)
- [x] Manual: drawer opens on /note (evergreen), /object — confirmed via curl + browser
- [x] Static assets ``/static/ovp-chat-drawer.{js,css}`` serve 200
- [x] ``/digests`` returns a real list (newest first); ``/`` shows "See all digests →"; digest note page shows neighbour nav strip
- [x] CSRF round-trip — token resolved from <meta>, POST accepted
- [ ] Composer cleanup in ``/chat`` (autosize textarea, hide profile picker when single model) — deferred follow-up; drawer addresses the user-reported pain
- [ ] Codex review pass + reviewbot follow-ups before merge

## Out of scope (follow-ups)

- Tests for ``/chat/drawer/*`` POST routes and ``/digests`` payload (will add alongside review feedback)
- Streaming via SSE (still synchronous per-turn)
- Janitor cron for stale ``unindexed`` chats — for now they accumulate harmlessly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collapsible right-side chat inquiry drawer (CSS/JS) opened from "Ask about this" links, with draft persistence, resumed sessions, Cmd/Ctrl+Enter send, and Save/Absorb/Discard actions.
  * Daily Digests listing page with teasers and prev/next navigation for digest articles.
  * Chat transcript visibility control and idempotent deletion (affects whether sessions are indexed/searchable).
* **Other**
  * Reader pages now load the chat-drawer UI so the drawer is available site-wide.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fakechris/obsidian_vault_pipeline/pull/221)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->