### PR TITLE
feat(m23): BL-094 — digest data collector + preflight + digest.yaml config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
     "networkx>=3.0",
     "tomli>=1.0.0; python_version < '3.11'",
     "defusedxml>=0.7.1",
+    "tzlocal>=5.0",
 ]
 
 [project.optional-dependencies]

--- a/src/ovp_pipeline/data/digest_template.yaml
+++ b/src/ovp_pipeline/data/digest_template.yaml
@@ -1,0 +1,46 @@
+# OVP digest configuration template (M23 / BL-094).
+#
+# Copy to ``<vault>/.ovp/digest.yaml`` at the vault root and adjust to
+# match operator preferences.  ``.ovp/`` is gitignored so local
+# overrides stay local.
+#
+# Missing file → every value falls back to the defaults shown here.
+# Missing key → that key falls back to its default; other values are
+# preserved.  No silent rejection.
+
+# Operator-local timezone for the digest window boundaries.  Defaults
+# to system locale via ``tzlocal.get_localzone()``; override here to
+# pin behavior across machines.  IANA tz name (e.g. ``America/Los_Angeles``,
+# ``Asia/Shanghai``).  Empty string → resolve from system locale; if
+# that fails (no tzlocal, broken locale), fall back to UTC and log
+# once.
+tz: ""
+
+# Cluster size threshold at which a cluster is considered "ready for
+# synthesis".  Surfaces in Layer 3 (pipeline state).  Tune per vault
+# after running ``ovp-digest --histogram`` once enough data exists;
+# 5 is the conservative default.
+cluster_threshold: 5
+
+# Layer 0 intake event allowlist — which ``audit_events.event_type``
+# rows count as "operator fed something into the system today".
+# Adding a new source authority requires extending this list, otherwise
+# its intakes are silently uncounted.
+intake_event_types:
+  - article_processed
+  - source_archived_to_processed
+  - source_staged_for_processing
+  - clippings_batch_processed
+  - github_source_ingested
+  - arxiv_source_ingested
+
+# Maintainer page exposes a "Regenerate digest now" button (Stage 4 of
+# the M23 plan).  Defaults to true so operators who drop articles
+# mid-day can immediately see them reflected.  Input-hash gate
+# (Stage 3) keeps the cost bounded — same input → no LLM call.
+mid_day_regenerate_button: true
+
+# Idempotency gate: skip the LLM call when a digest for the current
+# window already exists with a matching input_hash.  Counts the skip
+# as a ``digest_skipped_no_change`` audit event.
+skip_unchanged: true

--- a/src/ovp_pipeline/digest_config.py
+++ b/src/ovp_pipeline/digest_config.py
@@ -31,10 +31,11 @@ What this module does NOT own
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import tzinfo
 from pathlib import Path
-from types import MappingProxyType
-from typing import Any, Final, Mapping
+from typing import Any, Final
 
 import yaml
 
@@ -107,7 +108,7 @@ def load_digest_config(vault_dir: Path | str | None) -> DigestConfig:
     return _coerce_config(merged)
 
 
-def resolve_timezone(cfg: DigestConfig):  # type: ignore[no-untyped-def]
+def resolve_timezone(cfg: DigestConfig) -> tzinfo:
     """Return a ``datetime.tzinfo`` for the configured timezone.
 
     Resolution order:

--- a/src/ovp_pipeline/digest_config.py
+++ b/src/ovp_pipeline/digest_config.py
@@ -1,0 +1,277 @@
+"""Digest configuration loader (M23 / BL-094).
+
+Mirrors :mod:`ovp_pipeline.llm_profiles` at the structural level: read
+``<vault>/.ovp/digest.yaml`` if present, fall back to bundled defaults
+from ``src/ovp_pipeline/data/digest_template.yaml`` otherwise.  Loader
+returns an immutable :class:`DigestConfig` so downstream callers can
+treat it as a value object.
+
+What this module owns
+---------------------
+
+* **Schema** — :class:`DigestConfig` (frozen dataclass) covering tz,
+  cluster threshold, intake allowlist, mid-day regenerate button toggle,
+  idempotency-gate toggle.
+* **Timezone resolution** — explicit IANA name from config wins; empty
+  string resolves via :func:`tzlocal.get_localzone` (soft import); final
+  fallback is UTC with a one-time warning log.
+
+What this module does NOT own
+-----------------------------
+
+* Window computation — :mod:`digest_inputs` builds
+  ``[window_start, window_end]`` from the resolved timezone + audit
+  history.  Config only supplies the *timezone*, not the window.
+* Layer-specific collectors — each layer is its own function in
+  :mod:`digest_inputs`.
+* Action mutations — Stage 4 / Stage 5 of the M23 plan add their own
+  audit-event emission helpers; this module is read-only.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Final, Mapping
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+# Vault-relative path the loader reads.  Mirrors the llm_profiles
+# convention so a single ``.ovp/`` directory holds every per-feature
+# override.
+_CONFIG_REL: Final[str] = ".ovp/digest.yaml"
+
+# Bundled template — used when the operator hasn't created an override.
+# Resolves relative to this file via ``importlib.resources`` so it
+# survives ``pip install`` package layouts.
+_TEMPLATE_REL: Final[str] = "data/digest_template.yaml"
+
+# Conservative per-vault default for the synthesis-ready threshold.
+# Re-evaluated once a vault accumulates enough graph_clusters rows
+# to run a histogram.
+_DEFAULT_CLUSTER_THRESHOLD: Final[int] = 5
+
+# Default audit-event allowlist for Layer 0.  Adding a new source
+# authority (GitHub Discussions, Hacker News, etc.) requires extending
+# this list AND updating the bundled template so new vaults pick up
+# the new event types automatically.
+_DEFAULT_INTAKE_EVENT_TYPES: Final[tuple[str, ...]] = (
+    "article_processed",
+    "source_archived_to_processed",
+    "source_staged_for_processing",
+    "clippings_batch_processed",
+    "github_source_ingested",
+    "arxiv_source_ingested",
+)
+
+
+@dataclass(frozen=True)
+class DigestConfig:
+    """Immutable per-vault digest configuration.
+
+    Fields match the YAML template 1:1 so operators can read either
+    artifact and understand the other.  ``intake_event_types`` is
+    wrapped in :class:`types.MappingProxyType` semantics by storing it
+    as a tuple — mutation is impossible at the language level.
+    """
+
+    tz: str = ""
+    cluster_threshold: int = _DEFAULT_CLUSTER_THRESHOLD
+    intake_event_types: tuple[str, ...] = _DEFAULT_INTAKE_EVENT_TYPES
+    mid_day_regenerate_button: bool = True
+    skip_unchanged: bool = True
+
+
+def load_digest_config(vault_dir: Path | str | None) -> DigestConfig:
+    """Return the digest config for ``vault_dir``.
+
+    Resolution order:
+
+    1. ``<vault>/.ovp/digest.yaml`` if it exists and parses cleanly.
+    2. Bundled :data:`_TEMPLATE_REL` as the source of defaults.
+    3. Hard-coded :class:`DigestConfig` defaults if neither file is
+       readable (defensive — should never trigger in practice).
+
+    Missing keys in the override fall through to template / default;
+    each layer is merged independently so an operator who pins only
+    ``tz`` keeps every other default.
+    """
+    template_data = _read_template_defaults()
+    override_data = _read_override(vault_dir)
+    merged: dict[str, Any] = {**template_data, **override_data}
+    return _coerce_config(merged)
+
+
+def resolve_timezone(cfg: DigestConfig):  # type: ignore[no-untyped-def]
+    """Return a ``datetime.tzinfo`` for the configured timezone.
+
+    Resolution order:
+
+    1. Explicit ``cfg.tz`` IANA name → :class:`zoneinfo.ZoneInfo`.
+    2. Empty ``cfg.tz`` → :func:`tzlocal.get_localzone` (soft import
+       — :mod:`tzlocal` is recommended but not required).
+    3. Soft-import fallback: ``datetime.now().astimezone().tzinfo``
+       (system-local but anonymous).
+    4. Last resort: :data:`datetime.timezone.utc` with a one-time
+       warning so operators notice their tz isn't being honored.
+
+    Returns a ``tzinfo`` — never raises.
+    """
+    from datetime import datetime, timezone
+    from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+    if cfg.tz:
+        try:
+            return ZoneInfo(cfg.tz)
+        except ZoneInfoNotFoundError:
+            logger.warning(
+                "digest_config: tz %r not found in IANA database; "
+                "falling back to system locale",
+                cfg.tz,
+            )
+
+    try:
+        import tzlocal  # type: ignore[import-not-found]
+
+        return tzlocal.get_localzone()
+    except ImportError:
+        # tzlocal not installed — try the stdlib path.
+        local = datetime.now().astimezone().tzinfo
+        if local is not None:
+            return local
+        logger.warning(
+            "digest_config: no tzlocal and no system tzinfo; falling back to UTC"
+        )
+        return timezone.utc
+    except Exception as exc:  # noqa: BLE001 — tzlocal can raise misc.
+        logger.warning(
+            "digest_config: tzlocal failed (%s); falling back to UTC", exc
+        )
+        return timezone.utc
+
+
+# ---------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------
+
+
+def _read_template_defaults() -> dict[str, Any]:
+    """Load the bundled template under ``data/``.  Empty dict on any
+    I/O failure — defensive, never raises."""
+    try:
+        from importlib.resources import files
+
+        text = files("ovp_pipeline").joinpath(_TEMPLATE_REL).read_text(encoding="utf-8")
+        parsed = yaml.safe_load(text) or {}
+        if isinstance(parsed, dict):
+            return parsed
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("digest_config: template read failed: %s", exc)
+    return {}
+
+
+def _read_override(vault_dir: Path | str | None) -> dict[str, Any]:
+    """Load ``<vault>/.ovp/digest.yaml`` if present.  Empty dict
+    when missing / unreadable / not a mapping."""
+    if vault_dir is None:
+        return {}
+    path = Path(vault_dir) / _CONFIG_REL
+    if not path.is_file():
+        return {}
+    try:
+        text = path.read_text(encoding="utf-8")
+        parsed = yaml.safe_load(text) or {}
+    except (OSError, yaml.YAMLError) as exc:
+        logger.warning(
+            "digest_config: override %s unreadable: %s; using defaults", path, exc
+        )
+        return {}
+    if not isinstance(parsed, dict):
+        logger.warning(
+            "digest_config: override %s root is not a mapping; using defaults", path
+        )
+        return {}
+    return parsed
+
+
+def _coerce_config(data: Mapping[str, Any]) -> DigestConfig:
+    """Build a :class:`DigestConfig` from a YAML-loaded mapping.
+
+    Type-tolerant: a scalar where a list is expected falls back to the
+    default; a non-bool where a bool is expected → coerced via truthiness
+    (matches YAML's permissive semantics).  Every coercion logs a
+    warning so operator typos surface.
+    """
+    tz = data.get("tz")
+    tz_str = str(tz) if isinstance(tz, str) else ""
+
+    cluster_threshold = _coerce_positive_int(
+        data.get("cluster_threshold"),
+        default=_DEFAULT_CLUSTER_THRESHOLD,
+        field_name="cluster_threshold",
+    )
+
+    intake_raw = data.get("intake_event_types")
+    if isinstance(intake_raw, (list, tuple)):
+        intake_clean = tuple(
+            str(item).strip() for item in intake_raw if isinstance(item, str) and item.strip()
+        )
+        if not intake_clean:
+            logger.warning(
+                "digest_config: intake_event_types resolved to empty list; using defaults"
+            )
+            intake_clean = _DEFAULT_INTAKE_EVENT_TYPES
+    else:
+        if intake_raw is not None:
+            logger.warning(
+                "digest_config: intake_event_types must be a list; using defaults"
+            )
+        intake_clean = _DEFAULT_INTAKE_EVENT_TYPES
+
+    mid_day_button = bool(data.get("mid_day_regenerate_button", True))
+    skip_unchanged = bool(data.get("skip_unchanged", True))
+
+    return DigestConfig(
+        tz=tz_str,
+        cluster_threshold=cluster_threshold,
+        intake_event_types=intake_clean,
+        mid_day_regenerate_button=mid_day_button,
+        skip_unchanged=skip_unchanged,
+    )
+
+
+def _coerce_positive_int(value: Any, *, default: int, field_name: str) -> int:
+    """Return a positive int or fall back to ``default`` with a warning."""
+    if isinstance(value, bool):
+        # bool is a subclass of int — reject explicitly so True doesn't
+        # become 1 silently for a numeric field.
+        logger.warning(
+            "digest_config: %s expected int, got bool %r; using default",
+            field_name,
+            value,
+        )
+        return default
+    if isinstance(value, int) and value > 0:
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = int(value.strip())
+            if parsed > 0:
+                return parsed
+        except ValueError:
+            pass
+    if value is not None:
+        logger.warning(
+            "digest_config: %s expected positive int, got %r; using default",
+            field_name,
+            value,
+        )
+    return default
+
+
+__all__ = ["DigestConfig", "load_digest_config", "resolve_timezone"]

--- a/src/ovp_pipeline/digest_inputs.py
+++ b/src/ovp_pipeline/digest_inputs.py
@@ -61,6 +61,15 @@ _CHANGE_NOTE_QUALITY_PASS_RATIO: Final[float] = 0.5
 # falsely flagging an empty Layer 1 as a missing-data error.
 _PREFLIGHT_RECENT_DAYS: Final[int] = 7
 
+# Module-level stopword set for Layer 0 keyword chips.  Recomputing
+# this on every digest run is wasted work — operator runs the digest
+# at least daily, the set never changes.  (gemini-code-assist nitpick)
+_LAYER0_STOPWORDS: Final[frozenset[str]] = frozenset({
+    "the", "and", "for", "with", "from", "this", "that", "your",
+    "into", "what", "how", "why", "are", "was", "were", "will",
+    "you", "can", "all", "any", "but", "not", "use", "via",
+})
+
 
 # ---------------------------------------------------------------
 # Public schema
@@ -525,16 +534,11 @@ def _top_keyword_distribution(titles: Iterable[str]) -> tuple[tuple[str, int], .
     for "memory (7), AI agents (3), operations (2)" style chips —
     a real topic model can replace this later.
     """
-    stopwords = {
-        "the", "and", "for", "with", "from", "this", "that", "your",
-        "into", "what", "how", "why", "are", "was", "were", "will",
-        "you", "can", "all", "any", "but", "not", "use", "via",
-    }
     counts: dict[str, int] = {}
     for title in titles:
         for raw in title.lower().split():
             token = "".join(ch for ch in raw if ch.isalnum() or ch in "-_")
-            if len(token) < 4 or token in stopwords:
+            if len(token) < 4 or token in _LAYER0_STOPWORDS:
                 continue
             counts[token] = counts.get(token, 0) + 1
     ordered = sorted(counts.items(), key=lambda x: (-x[1], x[0]))
@@ -860,9 +864,15 @@ def _collect_layer3(
     for cid, count in cluster_counts.items():
         synth_at = cluster_synth_at.get(cid, "")
         latest_ev = cluster_latest_evergreen.get(cid, "")
-        # Stale crystal = there IS a crystal but it predates the
-        # cluster's newest evergreen.
-        stale = bool(synth_at and latest_ev and latest_ev > synth_at)
+        # Codex / CodeRabbit review: ``knowledge.db`` stores some
+        # timestamps as ``...Z`` and others as ``...+00:00``; raw
+        # string compare is lexicographic and silently swaps the
+        # answer when the two formats meet.  Parse to datetimes and
+        # compare time-correctly.  Treat unparseable / empty values
+        # as "no signal", same as before.
+        synth_dt = _parse_iso(synth_at)
+        latest_dt = _parse_iso(latest_ev)
+        stale = bool(synth_dt and latest_dt and latest_dt > synth_dt)
         # No crystal at all = also "unsynthesized".
         no_crystal = not synth_at
         if no_crystal or stale:

--- a/src/ovp_pipeline/digest_inputs.py
+++ b/src/ovp_pipeline/digest_inputs.py
@@ -265,7 +265,7 @@ def collect_digest_inputs(
         conn.row_factory = sqlite3.Row
         preflight = _run_preflight(conn, window_start, window_end, config)
         intake = _collect_layer0(conn, window_start, window_end, config)
-        delta = _collect_layer1(conn, window_start, window_end, preflight)
+        delta = _collect_layer1(conn, pack, window_start, window_end, preflight)
         connections = _collect_layer2(conn, pack, delta)
         pipeline_state = _collect_layer3(conn, pack, config)
 
@@ -552,6 +552,7 @@ def _top_keyword_distribution(titles: Iterable[str]) -> tuple[tuple[str, int], .
 
 def _collect_layer1(
     conn: sqlite3.Connection,
+    pack: str,
     window_start: datetime,
     window_end: datetime,
     preflight: PreflightReport,
@@ -559,23 +560,29 @@ def _collect_layer1(
     if preflight.evergreen_revisions_table != "ok":
         return DeltaLayer((), ())
     try:
+        # Codex P2: ``objects`` is keyed by ``(pack, object_id)`` in
+        # multi-pack vaults; joining on object_id alone can pick a
+        # foreign-pack title.  Pack-scope both the revision filter
+        # and the objects join.
         rows = conn.execute(
             """
             SELECT er.object_id, er.version, er.change_type,
                    er.derived_at, er.change_note,
                    o.title
               FROM evergreen_revisions er
-              LEFT JOIN objects o ON o.object_id = er.object_id
-             WHERE er.derived_at >= ?
+              LEFT JOIN objects o
+                ON o.pack = er.pack AND o.object_id = er.object_id
+             WHERE er.pack = ?
+               AND er.derived_at >= ?
                AND er.derived_at <= ?
              ORDER BY er.derived_at DESC
             """,
-            (window_start.isoformat(), window_end.isoformat()),
+            (pack, window_start.isoformat(), window_end.isoformat()),
         ).fetchall()
     except sqlite3.OperationalError:
         return DeltaLayer((), ())
 
-    cluster_index = _build_cluster_membership_index(conn)
+    cluster_index = _build_cluster_membership_index(conn, pack=pack)
     new_rows: list[EvergreenDelta] = []
     updated_rows: list[EvergreenDelta] = []
 
@@ -634,19 +641,29 @@ def _format_change_summary(
     return f"v{version}: {change_type or 'changed'}"
 
 
-def _build_cluster_membership_index(conn: sqlite3.Connection) -> dict[str, str]:
-    """Return ``{object_id: cluster_id}`` for every clustered object.
+def _build_cluster_membership_index(
+    conn: sqlite3.Connection, *, pack: str
+) -> dict[str, str]:
+    """Return ``{object_id: cluster_id}`` for every clustered object
+    in ``pack``.
 
     ``graph_clusters.member_object_ids_json`` is a JSON array of
     object_ids per cluster.  We invert it once per collect call.  At
     expected scale (hundreds of clusters, thousands of objects), this
     is cheaper than per-row ``json_each`` joins.
+
+    Codex P2: this index is consumed by Layer 2/3 which compare
+    cluster ids against the **requested pack's** crystals; building
+    the index globally lets a foreign-pack cluster slip into the
+    answer in multi-pack vaults.  Scope to the requested pack at
+    the SQL boundary.
     """
     if _check_table_exists(conn, "graph_clusters") != "ok":
         return {}
     try:
         rows = conn.execute(
-            "SELECT cluster_id, member_object_ids_json FROM graph_clusters"
+            "SELECT cluster_id, member_object_ids_json FROM graph_clusters WHERE pack = ?",
+            (pack,),
         ).fetchall()
     except sqlite3.OperationalError:
         return {}
@@ -796,7 +813,7 @@ def _collect_layer3(
 
     # Build per-cluster aggregates from evergreen_revisions + the
     # cluster membership index, then compare against community_crystals.
-    membership = _build_cluster_membership_index(conn)
+    membership = _build_cluster_membership_index(conn, pack=pack)
     if not membership:
         return PipelineState(
             unsynthesized_evergreens=0,
@@ -806,12 +823,17 @@ def _collect_layer3(
         )
 
     try:
+        # Codex P2 sibling: pack-scope the aggregate so a multi-pack
+        # vault doesn't borrow another pack's revision history when
+        # counting unsynthesized evergreens.
         rows = conn.execute(
             """
             SELECT object_id, MAX(derived_at) AS latest_at
               FROM evergreen_revisions
+             WHERE pack = ?
              GROUP BY object_id
-            """
+            """,
+            (pack,),
         ).fetchall()
     except sqlite3.OperationalError:
         rows = []

--- a/src/ovp_pipeline/digest_inputs.py
+++ b/src/ovp_pipeline/digest_inputs.py
@@ -1,0 +1,987 @@
+"""Digest data collector + readiness preflight (M23 / BL-094).
+
+Replaces the crystal-only input collector from M20's
+:mod:`commands.digest_handler` with a four-layer schema:
+
+* **Layer 0** — today's intake from ``audit_events`` (acknowledgment)
+* **Layer 1** — evergreen delta from ``evergreen_revisions`` (the spine)
+* **Layer 2** — connection to existing crystals + contradictions
+* **Layer 3** — pipeline state with stale-crystal flag (backpressure)
+
+What this module owns
+---------------------
+
+* **Window resolution** — operator-local
+  ``[last_successful_digest_at, as_of]`` with local-day fallback.
+* **Preflight checks** — verifies ``knowledge.db`` has the rows each
+  layer needs *before* the handler builds a prompt.  Handler renders
+  degraded sections rather than crashing.
+* **Layer collectors** — deterministic SQL + audit-log reads, no LLM.
+* **Input hash** — stable identifier set hashed for Stage 3's
+  idempotency gate.
+
+What this module does NOT own
+-----------------------------
+
+* LLM prompt or call — :mod:`commands.digest_handler` consumes
+  :class:`DigestInputs` to build its prompt; Stage 3 swaps the
+  prompt body.
+* Audit-event emission for digest results — that's Stage 5's
+  ``digest_clicked_through`` / ``digest_question_acted_on``.
+* The handler's ``_today_utc_date()`` filename — Stage 3 swaps
+  that to operator-local.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Final, Iterable
+
+from ovp_pipeline.digest_config import (
+    DigestConfig,
+    load_digest_config,
+    resolve_timezone,
+)
+
+logger = logging.getLogger(__name__)
+
+
+_KNOWLEDGE_DB_REL: Final[str] = "60-Logs/knowledge.db"
+_CHANGE_NOTE_QUALITY_SAMPLE: Final[int] = 10
+_CHANGE_NOTE_QUALITY_MIN_LEN: Final[int] = 20
+_CHANGE_NOTE_QUALITY_PASS_RATIO: Final[float] = 0.5
+# How far back to look when checking "evergreen_revisions has recent rows".
+# Wider than the window so the preflight tolerates quiet days without
+# falsely flagging an empty Layer 1 as a missing-data error.
+_PREFLIGHT_RECENT_DAYS: Final[int] = 7
+
+
+# ---------------------------------------------------------------
+# Public schema
+# ---------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class IntakeLayer:
+    """Layer 0 — operator's intake in the window."""
+
+    intake_events_processed: int
+    topic_distribution: tuple[tuple[str, int], ...]
+    authors_or_sources: tuple[str, ...]
+    representative_samples: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class EvergreenDelta:
+    """One row from ``evergreen_revisions`` enriched with cluster
+    membership."""
+
+    object_id: str
+    title: str
+    version: int
+    change_type: str
+    derived_at: str  # ISO timestamp as stored
+    change_summary: str  # change_note when meaningful, else fallback
+    cluster_id: str  # empty when unclassified
+
+
+@dataclass(frozen=True)
+class DeltaLayer:
+    """Layer 1 — what materially changed in the window."""
+
+    new_evergreens: tuple[EvergreenDelta, ...]
+    updated_evergreens: tuple[EvergreenDelta, ...]
+
+
+@dataclass(frozen=True)
+class ConnectionLayer:
+    """Layer 2 — how the window connects to prior thinking."""
+
+    connected_community_crystals: tuple[tuple[str, str], ...]  # (cluster_id, label)
+    touched_contradictions: tuple[tuple[str, str], ...]  # (contradiction_id, subject)
+    recent_top_crystals: tuple[tuple[str, str, float], ...]  # (id, kind, score)
+
+
+@dataclass(frozen=True)
+class PipelineState:
+    """Layer 3 — backpressure visibility, with stale-crystal flag."""
+
+    unsynthesized_evergreens: int
+    last_synthesis_at: str  # ISO or empty
+    clusters_at_threshold: tuple[tuple[str, str, int, bool], ...]
+    # (cluster_id, label, evergreen_count, stale_crystal_flag)
+    open_contradictions_count: int
+
+
+@dataclass(frozen=True)
+class PreflightReport:
+    """Outcome of the data-readiness preflight.
+
+    Every check returns one of ``ok`` / ``degraded`` / ``unavailable``.
+    Handler reads this report to decide which sections render normally
+    vs. degraded vs. as honest "data not available" stubs.
+    """
+
+    evergreen_revisions_table: str
+    evergreen_revisions_recent: str
+    audit_events_layer0: str
+    change_note_quality: str
+    graph_clusters: str
+    community_crystals: str
+
+    def any_degraded(self) -> bool:
+        return any(
+            v != "ok"
+            for v in (
+                self.evergreen_revisions_table,
+                self.evergreen_revisions_recent,
+                self.audit_events_layer0,
+                self.change_note_quality,
+                self.graph_clusters,
+                self.community_crystals,
+            )
+        )
+
+
+@dataclass(frozen=True)
+class DigestInputs:
+    """Result of :func:`collect_digest_inputs`.
+
+    Frozen value object — every layer is a tuple-of-frozen-dataclass
+    so the entire snapshot is safe to pass across module boundaries
+    without defensive copies.
+    """
+
+    pack: str
+    window_start: datetime
+    window_end: datetime
+    tz_name: str
+    config: DigestConfig
+    preflight: PreflightReport
+    intake: IntakeLayer
+    delta: DeltaLayer
+    connections: ConnectionLayer
+    pipeline_state: PipelineState
+
+    def input_hash(self) -> str:
+        """Stage 3 idempotency-gate hash.
+
+        Includes only **stable identifiers** + window boundaries —
+        never wall-clock prose, never aggregate counts that drift
+        across runs.  Two runs within the same window with the same
+        underlying rows produce the same hash; cross-window runs
+        always differ.
+        """
+        return _compute_input_hash(self)
+
+
+# ---------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------
+
+
+def collect_digest_inputs(
+    vault_dir: Path | str,
+    pack: str,
+    *,
+    as_of: datetime | None = None,
+    config: DigestConfig | None = None,
+) -> DigestInputs:
+    """Build the full :class:`DigestInputs` for one digest run.
+
+    Parameters
+    ----------
+    vault_dir
+        Vault root.  ``knowledge.db`` resolves to
+        ``<vault>/60-Logs/knowledge.db``; ``audit_events`` is read
+        from there too.
+    pack
+        Pack name to filter crystals + contradictions by.  Layer 0/1
+        are pack-agnostic (audit events + revisions span the whole
+        vault).
+    as_of
+        Window end.  Defaults to ``datetime.now(tz)``.  Pass a
+        deterministic value in tests.
+    config
+        Pre-loaded :class:`DigestConfig`.  Resolves from
+        ``<vault>/.ovp/digest.yaml`` when omitted.
+
+    Returns a :class:`DigestInputs` whose preflight field encodes any
+    degraded layers; the handler decides how to render them.  Never
+    raises on data shape — only on caller mistakes (missing vault).
+    """
+    if config is None:
+        config = load_digest_config(vault_dir)
+    tz = resolve_timezone(config)
+    tz_name = _tz_display_name(tz)
+    if as_of is None:
+        as_of = datetime.now(tz)
+    elif as_of.tzinfo is None:
+        as_of = as_of.replace(tzinfo=tz)
+    else:
+        as_of = as_of.astimezone(tz)
+
+    db_path = Path(vault_dir) / _KNOWLEDGE_DB_REL
+
+    # Window resolution requires the DB — read last successful
+    # digest before any other query so a missing DB short-circuits
+    # cleanly to the local-day fallback.
+    window_start = _resolve_window_start(db_path, as_of)
+    window_end = as_of
+
+    if not db_path.is_file():
+        return _empty_inputs(
+            pack=pack,
+            window_start=window_start,
+            window_end=window_end,
+            tz_name=tz_name,
+            config=config,
+            preflight=PreflightReport(
+                evergreen_revisions_table="unavailable",
+                evergreen_revisions_recent="unavailable",
+                audit_events_layer0="unavailable",
+                change_note_quality="unavailable",
+                graph_clusters="unavailable",
+                community_crystals="unavailable",
+            ),
+        )
+
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        preflight = _run_preflight(conn, window_start, window_end, config)
+        intake = _collect_layer0(conn, window_start, window_end, config)
+        delta = _collect_layer1(conn, window_start, window_end, preflight)
+        connections = _collect_layer2(conn, pack, delta)
+        pipeline_state = _collect_layer3(conn, pack, config)
+
+    return DigestInputs(
+        pack=pack,
+        window_start=window_start,
+        window_end=window_end,
+        tz_name=tz_name,
+        config=config,
+        preflight=preflight,
+        intake=intake,
+        delta=delta,
+        connections=connections,
+        pipeline_state=pipeline_state,
+    )
+
+
+# ---------------------------------------------------------------
+# Window resolution
+# ---------------------------------------------------------------
+
+
+def _resolve_window_start(db_path: Path, as_of: datetime) -> datetime:
+    """Return the window start: last successful digest, else local-day
+    boundary containing ``as_of``.
+
+    Falls through to the local-day boundary on any read failure so
+    the first-ever digest run gets a sensible window.
+    """
+    last_successful = _read_last_successful_digest(db_path)
+    local_day = _local_day_boundary(as_of)
+    if last_successful is not None and last_successful >= local_day:
+        # Mid-day regeneration — start from the prior run.
+        return last_successful.astimezone(as_of.tzinfo)
+    return local_day
+
+
+def _read_last_successful_digest(db_path: Path) -> datetime | None:
+    """Read the most recent ``digest_generated`` audit event's
+    timestamp.  ``None`` when none exist or the table is missing."""
+    if not db_path.is_file():
+        return None
+    try:
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                """
+                SELECT timestamp FROM audit_events
+                 WHERE event_type = 'digest_generated'
+                 ORDER BY timestamp DESC
+                 LIMIT 1
+                """
+            ).fetchone()
+    except sqlite3.OperationalError:
+        return None
+    if not row or not row[0]:
+        return None
+    return _parse_iso(row[0])
+
+
+def _local_day_boundary(as_of: datetime) -> datetime:
+    """Midnight at the start of ``as_of``'s local day.
+
+    ``as_of`` must be tz-aware.  Returns a tz-aware datetime in the
+    same timezone.
+    """
+    if as_of.tzinfo is None:  # defensive — caller should have set it
+        raise ValueError("_local_day_boundary requires a tz-aware datetime")
+    return as_of.replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+# ---------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------
+
+
+def _run_preflight(
+    conn: sqlite3.Connection,
+    window_start: datetime,
+    window_end: datetime,
+    config: DigestConfig,
+) -> PreflightReport:
+    """Six checks, each returning ``ok`` / ``degraded`` / ``unavailable``.
+
+    The handler treats ``degraded`` as "render with caveat" and
+    ``unavailable`` as "render an honest skipped section".  None of
+    the checks raise — every failure path returns a status string.
+    """
+    table_status = _check_table_exists(conn, "evergreen_revisions")
+    if table_status != "ok":
+        evergreen_recent = "unavailable"
+        change_note = "unavailable"
+    else:
+        evergreen_recent = _check_evergreen_revisions_recent(conn)
+        change_note = _check_change_note_quality(conn)
+
+    audit_status = _check_audit_layer0(conn, window_start, window_end, config)
+    clusters_status = _check_table_nonempty(conn, "graph_clusters")
+    crystals_status = _check_table_nonempty(conn, "community_crystals")
+
+    return PreflightReport(
+        evergreen_revisions_table=table_status,
+        evergreen_revisions_recent=evergreen_recent,
+        audit_events_layer0=audit_status,
+        change_note_quality=change_note,
+        graph_clusters=clusters_status,
+        community_crystals=crystals_status,
+    )
+
+
+def _check_table_exists(conn: sqlite3.Connection, name: str) -> str:
+    row = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+        (name,),
+    ).fetchone()
+    return "ok" if row else "unavailable"
+
+
+def _check_table_nonempty(conn: sqlite3.Connection, name: str) -> str:
+    if _check_table_exists(conn, name) != "ok":
+        return "unavailable"
+    try:
+        count = conn.execute(f"SELECT COUNT(*) FROM {name}").fetchone()[0]
+    except sqlite3.OperationalError:
+        return "unavailable"
+    return "ok" if count > 0 else "degraded"
+
+
+def _check_evergreen_revisions_recent(conn: sqlite3.Connection) -> str:
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=_PREFLIGHT_RECENT_DAYS)).isoformat()
+    try:
+        count = conn.execute(
+            "SELECT COUNT(*) FROM evergreen_revisions WHERE derived_at >= ?",
+            (cutoff,),
+        ).fetchone()[0]
+    except sqlite3.OperationalError:
+        return "unavailable"
+    return "ok" if count > 0 else "degraded"
+
+
+def _check_change_note_quality(conn: sqlite3.Connection) -> str:
+    """Sample the N most recent non-empty ``change_note`` rows; pass
+    when ≥ 50% have meaningful text (≥ 20 chars and not a generic
+    ``lifecycle=…`` marker)."""
+    try:
+        rows = conn.execute(
+            """
+            SELECT change_note FROM evergreen_revisions
+             WHERE change_note IS NOT NULL AND change_note != ''
+             ORDER BY derived_at DESC
+             LIMIT ?
+            """,
+            (_CHANGE_NOTE_QUALITY_SAMPLE,),
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return "unavailable"
+    if not rows:
+        return "degraded"
+    meaningful = sum(1 for r in rows if _is_meaningful_change_note(r[0]))
+    return "ok" if meaningful / len(rows) >= _CHANGE_NOTE_QUALITY_PASS_RATIO else "degraded"
+
+
+def _is_meaningful_change_note(note: str) -> bool:
+    text = (note or "").strip()
+    if len(text) < _CHANGE_NOTE_QUALITY_MIN_LEN:
+        return False
+    # Skip generic markers the absorber emits when it has nothing
+    # human-readable to say.
+    generic_prefixes = ("lifecycle=", "auto:", "fixup:")
+    if any(text.startswith(p) for p in generic_prefixes):
+        return False
+    return True
+
+
+def _check_audit_layer0(
+    conn: sqlite3.Connection,
+    window_start: datetime,
+    window_end: datetime,
+    config: DigestConfig,
+) -> str:
+    if not config.intake_event_types:
+        return "degraded"
+    placeholders = ",".join("?" * len(config.intake_event_types))
+    try:
+        count = conn.execute(
+            f"""
+            SELECT COUNT(*) FROM audit_events
+             WHERE event_type IN ({placeholders})
+               AND timestamp >= ?
+               AND timestamp <= ?
+            """,
+            (
+                *config.intake_event_types,
+                window_start.isoformat(),
+                window_end.isoformat(),
+            ),
+        ).fetchone()[0]
+    except sqlite3.OperationalError:
+        return "unavailable"
+    return "ok" if count > 0 else "degraded"
+
+
+# ---------------------------------------------------------------
+# Layer 0 — intake
+# ---------------------------------------------------------------
+
+
+def _collect_layer0(
+    conn: sqlite3.Connection,
+    window_start: datetime,
+    window_end: datetime,
+    config: DigestConfig,
+) -> IntakeLayer:
+    if not config.intake_event_types:
+        return IntakeLayer(0, (), (), ())
+    placeholders = ",".join("?" * len(config.intake_event_types))
+    try:
+        rows = conn.execute(
+            f"""
+            SELECT slug, payload_json FROM audit_events
+             WHERE event_type IN ({placeholders})
+               AND timestamp >= ?
+               AND timestamp <= ?
+             ORDER BY timestamp DESC
+            """,
+            (
+                *config.intake_event_types,
+                window_start.isoformat(),
+                window_end.isoformat(),
+            ),
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return IntakeLayer(0, (), (), ())
+
+    titles: list[str] = []
+    authors: set[str] = set()
+    for row in rows:
+        slug = (row["slug"] or "").strip()
+        payload = _safe_json(row["payload_json"])
+        title = (
+            (payload.get("title") if isinstance(payload, dict) else None)
+            or slug
+            or ""
+        )
+        if title:
+            titles.append(title)
+        if isinstance(payload, dict):
+            author = payload.get("author") or payload.get("source_domain") or ""
+            if isinstance(author, str) and author.strip():
+                authors.add(author.strip())
+
+    topic_dist = _top_keyword_distribution(titles)
+    samples = tuple(titles[:5])
+    return IntakeLayer(
+        intake_events_processed=len(rows),
+        topic_distribution=topic_dist,
+        authors_or_sources=tuple(sorted(authors)),
+        representative_samples=samples,
+    )
+
+
+def _top_keyword_distribution(titles: Iterable[str]) -> tuple[tuple[str, int], ...]:
+    """Lightweight keyword counts.
+
+    Splits each title on whitespace, lowercases, drops stopwords and
+    short tokens, and returns the top 5 by frequency.  Good enough
+    for "memory (7), AI agents (3), operations (2)" style chips —
+    a real topic model can replace this later.
+    """
+    stopwords = {
+        "the", "and", "for", "with", "from", "this", "that", "your",
+        "into", "what", "how", "why", "are", "was", "were", "will",
+        "you", "can", "all", "any", "but", "not", "use", "via",
+    }
+    counts: dict[str, int] = {}
+    for title in titles:
+        for raw in title.lower().split():
+            token = "".join(ch for ch in raw if ch.isalnum() or ch in "-_")
+            if len(token) < 4 or token in stopwords:
+                continue
+            counts[token] = counts.get(token, 0) + 1
+    ordered = sorted(counts.items(), key=lambda x: (-x[1], x[0]))
+    return tuple(ordered[:5])
+
+
+# ---------------------------------------------------------------
+# Layer 1 — evergreen delta
+# ---------------------------------------------------------------
+
+
+def _collect_layer1(
+    conn: sqlite3.Connection,
+    window_start: datetime,
+    window_end: datetime,
+    preflight: PreflightReport,
+) -> DeltaLayer:
+    if preflight.evergreen_revisions_table != "ok":
+        return DeltaLayer((), ())
+    try:
+        rows = conn.execute(
+            """
+            SELECT er.object_id, er.version, er.change_type,
+                   er.derived_at, er.change_note,
+                   o.title
+              FROM evergreen_revisions er
+              LEFT JOIN objects o ON o.object_id = er.object_id
+             WHERE er.derived_at >= ?
+               AND er.derived_at <= ?
+             ORDER BY er.derived_at DESC
+            """,
+            (window_start.isoformat(), window_end.isoformat()),
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return DeltaLayer((), ())
+
+    cluster_index = _build_cluster_membership_index(conn)
+    new_rows: list[EvergreenDelta] = []
+    updated_rows: list[EvergreenDelta] = []
+
+    for row in rows:
+        oid = row["object_id"] or ""
+        version = int(row["version"] or 0)
+        change_type = (row["change_type"] or "").strip()
+        change_note = row["change_note"] or ""
+        derived_at = row["derived_at"] or ""
+        title = row["title"] or oid
+        cluster_id = cluster_index.get(oid, "")
+
+        change_summary = _format_change_summary(
+            change_note=change_note,
+            change_type=change_type,
+            version=version,
+            preflight=preflight,
+        )
+
+        delta = EvergreenDelta(
+            object_id=oid,
+            title=title,
+            version=version,
+            change_type=change_type,
+            derived_at=derived_at,
+            change_summary=change_summary,
+            cluster_id=cluster_id,
+        )
+
+        if version == 1 and change_type in {"created", "promote", "extract"}:
+            new_rows.append(delta)
+        else:
+            updated_rows.append(delta)
+
+    return DeltaLayer(
+        new_evergreens=tuple(new_rows),
+        updated_evergreens=tuple(updated_rows),
+    )
+
+
+def _format_change_summary(
+    *,
+    change_note: str,
+    change_type: str,
+    version: int,
+    preflight: PreflightReport,
+) -> str:
+    """When change_note quality is OK *and* this row has a meaningful
+    note, use it.  Otherwise fall back to ``v{n}: {change_type}`` so
+    the digest still surfaces what changed, just without prose."""
+    if (
+        preflight.change_note_quality == "ok"
+        and _is_meaningful_change_note(change_note)
+    ):
+        return change_note.strip()
+    return f"v{version}: {change_type or 'changed'}"
+
+
+def _build_cluster_membership_index(conn: sqlite3.Connection) -> dict[str, str]:
+    """Return ``{object_id: cluster_id}`` for every clustered object.
+
+    ``graph_clusters.member_object_ids_json`` is a JSON array of
+    object_ids per cluster.  We invert it once per collect call.  At
+    expected scale (hundreds of clusters, thousands of objects), this
+    is cheaper than per-row ``json_each`` joins.
+    """
+    if _check_table_exists(conn, "graph_clusters") != "ok":
+        return {}
+    try:
+        rows = conn.execute(
+            "SELECT cluster_id, member_object_ids_json FROM graph_clusters"
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return {}
+    index: dict[str, str] = {}
+    for row in rows:
+        members = _safe_json(row["member_object_ids_json"])
+        if isinstance(members, list):
+            for member in members:
+                if isinstance(member, str) and member:
+                    # First cluster wins on dup membership.
+                    index.setdefault(member, row["cluster_id"])
+    return index
+
+
+# ---------------------------------------------------------------
+# Layer 2 — connections
+# ---------------------------------------------------------------
+
+
+def _collect_layer2(
+    conn: sqlite3.Connection,
+    pack: str,
+    delta: DeltaLayer,
+) -> ConnectionLayer:
+    touched_clusters: set[str] = {
+        d.cluster_id for d in delta.new_evergreens if d.cluster_id
+    } | {d.cluster_id for d in delta.updated_evergreens if d.cluster_id}
+
+    connected_crystals: list[tuple[str, str]] = []
+    if touched_clusters:
+        placeholders = ",".join("?" * len(touched_clusters))
+        try:
+            rows = conn.execute(
+                f"""
+                SELECT cc.cluster_id, gc.label
+                  FROM community_crystals cc
+                  LEFT JOIN graph_clusters gc
+                    ON gc.pack = cc.pack AND gc.cluster_id = cc.cluster_id
+                 WHERE cc.pack = ?
+                   AND cc.cluster_id IN ({placeholders})
+                   AND cc.superseded_by_synthesized_at = ''
+                """,
+                (pack, *touched_clusters),
+            ).fetchall()
+            connected_crystals = [(r["cluster_id"], r["label"] or "") for r in rows]
+        except sqlite3.OperationalError:
+            connected_crystals = []
+
+    touched_evergreen_ids = {
+        d.object_id for d in delta.new_evergreens
+    } | {d.object_id for d in delta.updated_evergreens}
+
+    touched_contradictions: list[tuple[str, str]] = []
+    if touched_evergreen_ids:
+        try:
+            rows = conn.execute(
+                """
+                SELECT contradiction_id, subject_key, source_object_ids_json
+                  FROM contradiction_crystals
+                 WHERE pack = ?
+                   AND superseded_by_synthesized_at = ''
+                """,
+                (pack,),
+            ).fetchall()
+            for row in rows:
+                source_ids = _safe_json(row["source_object_ids_json"])
+                if isinstance(source_ids, list) and touched_evergreen_ids.intersection(
+                    str(s) for s in source_ids
+                ):
+                    touched_contradictions.append(
+                        (row["contradiction_id"], row["subject_key"] or "")
+                    )
+        except sqlite3.OperationalError:
+            touched_contradictions = []
+
+    recent_top: list[tuple[str, str, float]] = []
+    try:
+        rows = conn.execute(
+            """
+            SELECT crystal_id, crystal_kind, score FROM crystal_scores
+             WHERE pack = ?
+             ORDER BY score DESC
+             LIMIT 5
+            """,
+            (pack,),
+        ).fetchall()
+        recent_top = [
+            (r["crystal_id"], r["crystal_kind"], float(r["score"] or 0.0))
+            for r in rows
+        ]
+    except sqlite3.OperationalError:
+        recent_top = []
+
+    return ConnectionLayer(
+        connected_community_crystals=tuple(connected_crystals),
+        touched_contradictions=tuple(touched_contradictions),
+        recent_top_crystals=tuple(recent_top),
+    )
+
+
+# ---------------------------------------------------------------
+# Layer 3 — pipeline state
+# ---------------------------------------------------------------
+
+
+def _collect_layer3(
+    conn: sqlite3.Connection,
+    pack: str,
+    config: DigestConfig,
+) -> PipelineState:
+    """Aggregate: which clusters have evergreens newer than their last
+    synthesis?  A cluster with a crystal but newer evergreens counts
+    as unsynthesized (Codex review — stale-crystal flag)."""
+
+    last_synthesis = ""
+    try:
+        row = conn.execute(
+            """
+            SELECT MAX(synthesized_at) FROM community_crystals
+             WHERE pack = ? AND superseded_by_synthesized_at = ''
+            """,
+            (pack,),
+        ).fetchone()
+        last_synthesis = (row[0] or "") if row else ""
+    except sqlite3.OperationalError:
+        pass
+
+    open_contradictions = 0
+    try:
+        open_contradictions = conn.execute(
+            """
+            SELECT COUNT(*) FROM contradiction_crystals
+             WHERE pack = ? AND superseded_by_synthesized_at = ''
+            """,
+            (pack,),
+        ).fetchone()[0]
+    except sqlite3.OperationalError:
+        pass
+
+    if _check_table_exists(conn, "evergreen_revisions") != "ok":
+        return PipelineState(
+            unsynthesized_evergreens=0,
+            last_synthesis_at=last_synthesis,
+            clusters_at_threshold=(),
+            open_contradictions_count=open_contradictions,
+        )
+
+    # Build per-cluster aggregates from evergreen_revisions + the
+    # cluster membership index, then compare against community_crystals.
+    membership = _build_cluster_membership_index(conn)
+    if not membership:
+        return PipelineState(
+            unsynthesized_evergreens=0,
+            last_synthesis_at=last_synthesis,
+            clusters_at_threshold=(),
+            open_contradictions_count=open_contradictions,
+        )
+
+    try:
+        rows = conn.execute(
+            """
+            SELECT object_id, MAX(derived_at) AS latest_at
+              FROM evergreen_revisions
+             GROUP BY object_id
+            """
+        ).fetchall()
+    except sqlite3.OperationalError:
+        rows = []
+
+    cluster_counts: dict[str, int] = {}
+    cluster_latest_evergreen: dict[str, str] = {}
+    for row in rows:
+        cid = membership.get(row["object_id"], "")
+        if not cid:
+            continue
+        cluster_counts[cid] = cluster_counts.get(cid, 0) + 1
+        prior = cluster_latest_evergreen.get(cid, "")
+        if row["latest_at"] and row["latest_at"] > prior:
+            cluster_latest_evergreen[cid] = row["latest_at"]
+
+    # Per-cluster latest synthesis.
+    cluster_synth_at: dict[str, str] = {}
+    cluster_label: dict[str, str] = {}
+    try:
+        for row in conn.execute(
+            """
+            SELECT cc.cluster_id, MAX(cc.synthesized_at) AS latest_at,
+                   MAX(gc.label) AS label
+              FROM community_crystals cc
+              LEFT JOIN graph_clusters gc
+                ON gc.pack = cc.pack AND gc.cluster_id = cc.cluster_id
+             WHERE cc.pack = ? AND cc.superseded_by_synthesized_at = ''
+             GROUP BY cc.cluster_id
+            """,
+            (pack,),
+        ).fetchall():
+            cluster_synth_at[row["cluster_id"]] = row["latest_at"] or ""
+            cluster_label[row["cluster_id"]] = row["label"] or ""
+    except sqlite3.OperationalError:
+        pass
+
+    # Pick up labels for clusters with no community_crystal.
+    if _check_table_exists(conn, "graph_clusters") == "ok":
+        try:
+            for row in conn.execute(
+                "SELECT cluster_id, label FROM graph_clusters WHERE pack = ?",
+                (pack,),
+            ).fetchall():
+                cluster_label.setdefault(row["cluster_id"], row["label"] or "")
+        except sqlite3.OperationalError:
+            pass
+
+    unsynth_total = 0
+    at_threshold: list[tuple[str, str, int, bool]] = []
+    for cid, count in cluster_counts.items():
+        synth_at = cluster_synth_at.get(cid, "")
+        latest_ev = cluster_latest_evergreen.get(cid, "")
+        # Stale crystal = there IS a crystal but it predates the
+        # cluster's newest evergreen.
+        stale = bool(synth_at and latest_ev and latest_ev > synth_at)
+        # No crystal at all = also "unsynthesized".
+        no_crystal = not synth_at
+        if no_crystal or stale:
+            unsynth_total += count
+            if count >= config.cluster_threshold:
+                at_threshold.append(
+                    (cid, cluster_label.get(cid, ""), count, stale)
+                )
+
+    at_threshold.sort(key=lambda r: (-r[2], r[0]))
+    return PipelineState(
+        unsynthesized_evergreens=unsynth_total,
+        last_synthesis_at=last_synthesis,
+        clusters_at_threshold=tuple(at_threshold),
+        open_contradictions_count=open_contradictions,
+    )
+
+
+# ---------------------------------------------------------------
+# Input hash
+# ---------------------------------------------------------------
+
+
+def _compute_input_hash(inputs: DigestInputs) -> str:
+    """SHA-256 over stable identifiers + window boundaries.
+
+    Critical (codex review): the hash includes only data that
+    doesn't drift with wall-clock time.  Counts, sorted id sets,
+    window boundaries — yes.  Prose like "8 days ago" — never.
+    """
+    payload = {
+        "window_start": inputs.window_start.isoformat(),
+        "window_end": inputs.window_end.isoformat(),
+        "pack": inputs.pack,
+        "layer0_event_count": inputs.intake.intake_events_processed,
+        "layer0_samples": sorted(inputs.intake.representative_samples),
+        "layer1_new": sorted(d.object_id + "@v" + str(d.version) for d in inputs.delta.new_evergreens),
+        "layer1_updated": sorted(d.object_id + "@v" + str(d.version) for d in inputs.delta.updated_evergreens),
+        "layer2_connected": sorted(cid for cid, _ in inputs.connections.connected_community_crystals),
+        "layer2_contradictions": sorted(cid for cid, _ in inputs.connections.touched_contradictions),
+        "layer3_unsynth": inputs.pipeline_state.unsynthesized_evergreens,
+        "layer3_last_synth": inputs.pipeline_state.last_synthesis_at,
+        "layer3_at_threshold": sorted(cid for cid, _, _, _ in inputs.pipeline_state.clusters_at_threshold),
+        "layer3_open_contradictions": inputs.pipeline_state.open_contradictions_count,
+    }
+    canonical = json.dumps(payload, sort_keys=True, ensure_ascii=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------
+
+
+def _safe_json(blob: Any) -> Any:
+    if not blob:
+        return None
+    try:
+        return json.loads(blob)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return None
+
+
+def _parse_iso(raw: str) -> datetime | None:
+    """Permissive ISO-8601 parser.  Returns None on failure."""
+    raw = (raw or "").strip()
+    if not raw:
+        return None
+    # Z → +00:00 for fromisoformat compatibility.
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    try:
+        return datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+
+
+def _tz_display_name(tz: Any) -> str:
+    """Best-effort tz name for the digest frontmatter."""
+    for attr in ("key", "zone"):
+        name = getattr(tz, attr, None)
+        if isinstance(name, str) and name:
+            return name
+    try:
+        return str(tz)
+    except Exception:  # noqa: BLE001
+        return "UTC"
+
+
+def _empty_inputs(
+    *,
+    pack: str,
+    window_start: datetime,
+    window_end: datetime,
+    tz_name: str,
+    config: DigestConfig,
+    preflight: PreflightReport,
+) -> DigestInputs:
+    return DigestInputs(
+        pack=pack,
+        window_start=window_start,
+        window_end=window_end,
+        tz_name=tz_name,
+        config=config,
+        preflight=preflight,
+        intake=IntakeLayer(0, (), (), ()),
+        delta=DeltaLayer((), ()),
+        connections=ConnectionLayer((), (), ()),
+        pipeline_state=PipelineState(0, "", (), 0),
+    )
+
+
+__all__ = [
+    "ConnectionLayer",
+    "DeltaLayer",
+    "DigestInputs",
+    "EvergreenDelta",
+    "IntakeLayer",
+    "PipelineState",
+    "PreflightReport",
+    "collect_digest_inputs",
+]

--- a/tests/test_architecture_fitness.py
+++ b/tests/test_architecture_fitness.py
@@ -213,6 +213,11 @@ SQLITE_ALLOWED_MODULES = {
     "synthesis/_shared",
     "synthesis/_versioning",
     "ui/view_models",
+    # M23 / BL-094: digest input collector reads evergreen_revisions,
+    # audit_events, community_crystals, graph_clusters etc.  Data-
+    # layer aggregator over knowledge.db projections — same category
+    # as materializers/* and synthesis/_shared.
+    "digest_inputs",
 }
 
 

--- a/tests/test_digest_config.py
+++ b/tests/test_digest_config.py
@@ -1,0 +1,159 @@
+"""Tests for M23 / BL-094 — digest config loader + tz resolution."""
+
+from __future__ import annotations
+
+import logging
+from datetime import timezone
+from pathlib import Path
+
+import pytest
+import yaml
+
+from ovp_pipeline.digest_config import (
+    DigestConfig,
+    load_digest_config,
+    resolve_timezone,
+)
+
+
+# ── load_digest_config — defaults / overrides ──────────────────
+
+
+def test_load_returns_defaults_when_no_override(tmp_path: Path):
+    """Empty vault → bundled template defaults."""
+    cfg = load_digest_config(tmp_path)
+    # Template ships ``tz: ""`` so the loader resolves locally.
+    assert cfg.tz == ""
+    assert cfg.cluster_threshold == 5
+    assert cfg.mid_day_regenerate_button is True
+    assert cfg.skip_unchanged is True
+    assert "article_processed" in cfg.intake_event_types
+    assert "source_archived_to_processed" in cfg.intake_event_types
+
+
+def test_load_returns_defaults_when_vault_dir_none():
+    """Loader treats ``None`` like missing override."""
+    cfg = load_digest_config(None)
+    assert cfg.cluster_threshold == 5
+    assert isinstance(cfg.intake_event_types, tuple)
+
+
+def test_load_merges_override_with_defaults(tmp_path: Path):
+    """Operator pin → override; absent keys fall through to defaults."""
+    (tmp_path / ".ovp").mkdir()
+    (tmp_path / ".ovp" / "digest.yaml").write_text(
+        yaml.safe_dump({"tz": "America/Los_Angeles", "cluster_threshold": 8}),
+        encoding="utf-8",
+    )
+    cfg = load_digest_config(tmp_path)
+    assert cfg.tz == "America/Los_Angeles"
+    assert cfg.cluster_threshold == 8
+    # Untouched defaults still present.
+    assert cfg.mid_day_regenerate_button is True
+    assert "article_processed" in cfg.intake_event_types
+
+
+def test_load_full_override_replaces_intake_list(tmp_path: Path):
+    """A list override REPLACES, not appends — operator owns the
+    full list when they touch it."""
+    (tmp_path / ".ovp").mkdir()
+    (tmp_path / ".ovp" / "digest.yaml").write_text(
+        yaml.safe_dump({"intake_event_types": ["custom_event"]}),
+        encoding="utf-8",
+    )
+    cfg = load_digest_config(tmp_path)
+    assert cfg.intake_event_types == ("custom_event",)
+
+
+def test_load_tolerates_malformed_yaml(tmp_path: Path, caplog):
+    """Broken yaml → fall back to defaults, log warning, don't raise."""
+    (tmp_path / ".ovp").mkdir()
+    (tmp_path / ".ovp" / "digest.yaml").write_text(
+        "this: is: not: valid: yaml: ::", encoding="utf-8"
+    )
+    with caplog.at_level(logging.WARNING):
+        cfg = load_digest_config(tmp_path)
+    assert cfg.cluster_threshold == 5  # default
+    assert any("unreadable" in rec.message for rec in caplog.records)
+
+
+def test_load_tolerates_non_mapping_root(tmp_path: Path, caplog):
+    """A yaml list at root falls back to defaults."""
+    (tmp_path / ".ovp").mkdir()
+    (tmp_path / ".ovp" / "digest.yaml").write_text("- a\n- b\n", encoding="utf-8")
+    with caplog.at_level(logging.WARNING):
+        cfg = load_digest_config(tmp_path)
+    assert cfg.cluster_threshold == 5
+    assert any("not a mapping" in rec.message for rec in caplog.records)
+
+
+def test_load_rejects_bool_for_int_field(tmp_path: Path, caplog):
+    """``True`` in a numeric field falls back, not silently → 1."""
+    (tmp_path / ".ovp").mkdir()
+    (tmp_path / ".ovp" / "digest.yaml").write_text(
+        yaml.safe_dump({"cluster_threshold": True}), encoding="utf-8"
+    )
+    with caplog.at_level(logging.WARNING):
+        cfg = load_digest_config(tmp_path)
+    assert cfg.cluster_threshold == 5
+    assert any("bool" in rec.message for rec in caplog.records)
+
+
+def test_load_rejects_negative_cluster_threshold(tmp_path: Path):
+    """Negative threshold → fall back to default."""
+    (tmp_path / ".ovp").mkdir()
+    (tmp_path / ".ovp" / "digest.yaml").write_text(
+        yaml.safe_dump({"cluster_threshold": -3}), encoding="utf-8"
+    )
+    cfg = load_digest_config(tmp_path)
+    assert cfg.cluster_threshold == 5
+
+
+def test_load_empty_intake_list_falls_back(tmp_path: Path):
+    """Empty allowlist would silence every intake event → fall back
+    to defaults so an operator typo can't disable Layer 0."""
+    (tmp_path / ".ovp").mkdir()
+    (tmp_path / ".ovp" / "digest.yaml").write_text(
+        yaml.safe_dump({"intake_event_types": []}), encoding="utf-8"
+    )
+    cfg = load_digest_config(tmp_path)
+    assert "article_processed" in cfg.intake_event_types
+
+
+def test_config_is_immutable():
+    """Frozen dataclass + tuple sequence — no field assignment, no
+    list mutation possible."""
+    cfg = DigestConfig()
+    with pytest.raises(Exception):
+        cfg.cluster_threshold = 99  # type: ignore[misc]
+    with pytest.raises(AttributeError):
+        cfg.intake_event_types.append("hack")  # type: ignore[attr-defined]
+
+
+# ── resolve_timezone ───────────────────────────────────────────
+
+
+def test_resolve_explicit_iana_name_wins():
+    cfg = DigestConfig(tz="Asia/Shanghai")
+    tz = resolve_timezone(cfg)
+    name = getattr(tz, "key", None) or getattr(tz, "zone", None) or str(tz)
+    assert name == "Asia/Shanghai"
+
+
+def test_resolve_unknown_iana_name_falls_back(caplog):
+    """A typo'd IANA name → fall back to system locale + log warning."""
+    cfg = DigestConfig(tz="Not/A/Real/Zone")
+    with caplog.at_level(logging.WARNING):
+        tz = resolve_timezone(cfg)
+    assert tz is not None
+    assert any("not found" in rec.message for rec in caplog.records)
+
+
+def test_resolve_empty_tz_returns_system_local():
+    cfg = DigestConfig(tz="")
+    tz = resolve_timezone(cfg)
+    # System could be UTC or anything; just verify a usable tzinfo.
+    from datetime import datetime
+
+    now = datetime.now(tz)
+    assert now.utcoffset() is not None

--- a/tests/test_digest_inputs.py
+++ b/tests/test_digest_inputs.py
@@ -105,8 +105,21 @@ def _make_vault(tmp_path: Path) -> tuple[Path, sqlite3.Connection]:
 @pytest.fixture
 def vault(tmp_path: Path):
     """Yield (vault_dir, sqlite3.Connection).  Caller seeds rows
-    then runs ``collect_digest_inputs``."""
-    return _make_vault(tmp_path)
+    then runs ``collect_digest_inputs``.
+
+    Connection is closed in teardown so tests can stay short — they
+    don't have to remember ``conn.close()`` themselves (gemini-code-
+    assist resource-leak nit).  Closing an already-closed sqlite3
+    connection is a no-op.
+    """
+    vault_dir, conn = _make_vault(tmp_path)
+    try:
+        yield vault_dir, conn
+    finally:
+        try:
+            conn.close()
+        except Exception:  # noqa: BLE001 — defensive teardown
+            pass
 
 
 @pytest.fixture
@@ -408,7 +421,7 @@ def test_layer3_flags_stale_crystal_as_unsynthesized(vault, utc_config):
     assert result.pipeline_state.unsynthesized_evergreens == 6
     threshold_clusters = result.pipeline_state.clusters_at_threshold
     assert len(threshold_clusters) == 1
-    cid, label, count, stale = threshold_clusters[0]
+    cid, _label, count, stale = threshold_clusters[0]
     assert cid == "cluster::stale"
     assert stale is True
     assert count == 6
@@ -540,11 +553,12 @@ def test_input_hash_changes_when_data_changes(vault, utc_config):
     as_of = datetime(2026, 5, 13, 12, 0, tzinfo=ZoneInfo("UTC"))
     r1 = collect_digest_inputs(vault_dir, "research-tech", as_of=as_of, config=utc_config)
 
-    new_conn = sqlite3.connect(vault_dir / "60-Logs" / "knowledge.db")
+    # Reuse the fixture's open connection rather than opening a
+    # second handle that callers must remember to close (gemini-code-
+    # assist nit on resource leak).
     _seed_evergreen_revision(
-        new_conn, object_id="evg-new", version=1, change_type="created",
+        conn, object_id="evg-new", version=1, change_type="created",
         derived_at=as_of - timedelta(hours=1),
     )
-    new_conn.close()
     r2 = collect_digest_inputs(vault_dir, "research-tech", as_of=as_of, config=utc_config)
     assert r1.input_hash() != r2.input_hash()

--- a/tests/test_digest_inputs.py
+++ b/tests/test_digest_inputs.py
@@ -1,0 +1,550 @@
+"""Tests for M23 / BL-094 — digest input collector + preflight.
+
+Each test builds a focused in-memory ``knowledge.db`` fixture so the
+preflight + layer collectors are exercised against real SQL without
+spinning up the full ``ovp-knowledge-index`` build.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from ovp_pipeline.digest_config import DigestConfig
+from ovp_pipeline.digest_inputs import (
+    DigestInputs,
+    collect_digest_inputs,
+)
+
+
+# ── Schema + fixtures ──────────────────────────────────────────
+
+
+def _make_schema(conn: sqlite3.Connection) -> None:
+    """Minimal schema covering every table the collector reads."""
+    conn.executescript("""
+        CREATE TABLE audit_events (
+            source_log TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            slug TEXT,
+            session_id TEXT,
+            timestamp TEXT NOT NULL,
+            payload_json TEXT
+        );
+        CREATE TABLE evergreen_revisions (
+            pack TEXT NOT NULL,
+            object_id TEXT NOT NULL,
+            version INTEGER NOT NULL,
+            content_md TEXT NOT NULL,
+            change_type TEXT NOT NULL,
+            changed_by TEXT NOT NULL,
+            derived_at TEXT NOT NULL,
+            change_note TEXT
+        );
+        CREATE TABLE objects (
+            pack TEXT NOT NULL,
+            object_id TEXT NOT NULL,
+            object_kind TEXT NOT NULL,
+            title TEXT NOT NULL,
+            canonical_path TEXT,
+            source_slug TEXT,
+            source_url TEXT
+        );
+        CREATE TABLE graph_clusters (
+            pack TEXT NOT NULL,
+            cluster_id TEXT NOT NULL,
+            cluster_kind TEXT NOT NULL,
+            label TEXT,
+            center_object_id TEXT,
+            member_object_ids_json TEXT,
+            score REAL
+        );
+        CREATE TABLE community_crystals (
+            pack TEXT NOT NULL,
+            cluster_id TEXT NOT NULL,
+            body_md TEXT NOT NULL,
+            source_evergreen_slugs_json TEXT,
+            synthesized_at TEXT NOT NULL,
+            llm_model TEXT,
+            prompt_version TEXT,
+            superseded_by_synthesized_at TEXT NOT NULL DEFAULT ''
+        );
+        CREATE TABLE contradiction_crystals (
+            pack TEXT NOT NULL,
+            contradiction_id TEXT NOT NULL,
+            subject_key TEXT,
+            body_md TEXT NOT NULL,
+            source_object_ids_json TEXT,
+            synthesized_at TEXT NOT NULL,
+            superseded_by_synthesized_at TEXT NOT NULL DEFAULT ''
+        );
+        CREATE TABLE crystal_scores (
+            pack TEXT NOT NULL,
+            crystal_id TEXT NOT NULL,
+            crystal_kind TEXT NOT NULL,
+            score REAL NOT NULL
+        );
+    """)
+
+
+def _make_vault(tmp_path: Path) -> tuple[Path, sqlite3.Connection]:
+    db_path = tmp_path / "60-Logs" / "knowledge.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    _make_schema(conn)
+    conn.commit()
+    conn.close()
+    return tmp_path, sqlite3.connect(db_path)
+
+
+@pytest.fixture
+def vault(tmp_path: Path):
+    """Yield (vault_dir, sqlite3.Connection).  Caller seeds rows
+    then runs ``collect_digest_inputs``."""
+    return _make_vault(tmp_path)
+
+
+@pytest.fixture
+def utc_config() -> DigestConfig:
+    """Pinned-UTC config so tests don't depend on the host system tz."""
+    return DigestConfig(tz="UTC")
+
+
+def _seed_intake(conn: sqlite3.Connection, *, count: int, base_ts: datetime) -> None:
+    for i in range(count):
+        ts = (base_ts + timedelta(minutes=i)).isoformat()
+        payload = json.dumps({"title": f"Article on memory systems #{i}", "author": "alice"})
+        conn.execute(
+            "INSERT INTO audit_events VALUES (?, ?, ?, ?, ?, ?)",
+            ("pipeline.jsonl", "article_processed", f"slug-{i}", "s1", ts, payload),
+        )
+    conn.commit()
+
+
+def _seed_evergreen_revision(
+    conn: sqlite3.Connection,
+    *,
+    object_id: str,
+    version: int,
+    change_type: str,
+    derived_at: datetime,
+    change_note: str = "lifecycle=promote",
+    title: str = "",
+) -> None:
+    conn.execute(
+        "INSERT INTO evergreen_revisions VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            "research-tech",
+            object_id,
+            version,
+            "## " + object_id,
+            change_type,
+            "absorber",
+            derived_at.isoformat(),
+            change_note,
+        ),
+    )
+    if title:
+        conn.execute(
+            "INSERT INTO objects VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("research-tech", object_id, "evergreen", title, "", "", ""),
+        )
+    conn.commit()
+
+
+def _seed_cluster(
+    conn: sqlite3.Connection,
+    *,
+    cluster_id: str,
+    label: str,
+    members: list[str],
+) -> None:
+    conn.execute(
+        "INSERT INTO graph_clusters VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            "research-tech",
+            cluster_id,
+            "community",
+            label,
+            members[0] if members else "",
+            json.dumps(members),
+            1.0,
+        ),
+    )
+    conn.commit()
+
+
+def _seed_community_crystal(
+    conn: sqlite3.Connection,
+    *,
+    cluster_id: str,
+    synthesized_at: datetime,
+) -> None:
+    conn.execute(
+        "INSERT INTO community_crystals VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            "research-tech",
+            cluster_id,
+            "crystal body",
+            "[]",
+            synthesized_at.isoformat(),
+            "test-model",
+            "v1",
+            "",
+        ),
+    )
+    conn.commit()
+
+
+# ── Empty / missing DB ─────────────────────────────────────────
+
+
+def test_missing_db_returns_unavailable_preflight(tmp_path: Path, utc_config):
+    """No knowledge.db → every preflight row is unavailable; layers
+    are empty.  No exception."""
+    result = collect_digest_inputs(tmp_path, "research-tech", config=utc_config)
+    assert isinstance(result, DigestInputs)
+    assert result.preflight.evergreen_revisions_table == "unavailable"
+    assert result.preflight.community_crystals == "unavailable"
+    assert result.preflight.any_degraded()
+    assert result.intake.intake_events_processed == 0
+    assert result.delta.new_evergreens == ()
+    assert result.delta.updated_evergreens == ()
+
+
+def test_empty_db_runs_preflight_without_crashing(vault, utc_config):
+    vault_dir, conn = vault
+    conn.close()
+    result = collect_digest_inputs(vault_dir, "research-tech", config=utc_config)
+    # Tables exist but empty → degraded, not unavailable.
+    assert result.preflight.community_crystals == "degraded"
+    assert result.preflight.graph_clusters == "degraded"
+
+
+# ── Layer 0 — intake ───────────────────────────────────────────
+
+
+def test_layer0_counts_allowlisted_events_in_window(vault, utc_config):
+    vault_dir, conn = vault
+    as_of = datetime(2026, 5, 13, 12, 0, tzinfo=ZoneInfo("UTC"))
+    _seed_intake(conn, count=5, base_ts=as_of - timedelta(hours=2))
+    conn.close()
+    result = collect_digest_inputs(
+        vault_dir, "research-tech", as_of=as_of, config=utc_config
+    )
+    assert result.intake.intake_events_processed == 5
+    assert "memory" in dict(result.intake.topic_distribution)
+
+
+def test_layer0_ignores_events_outside_window(vault, utc_config):
+    """An event from 3 days ago is outside the local-day fallback
+    window (which is midnight today UTC → now)."""
+    vault_dir, conn = vault
+    as_of = datetime(2026, 5, 13, 12, 0, tzinfo=ZoneInfo("UTC"))
+    _seed_intake(conn, count=3, base_ts=as_of - timedelta(days=3))
+    conn.close()
+    result = collect_digest_inputs(
+        vault_dir, "research-tech", as_of=as_of, config=utc_config
+    )
+    assert result.intake.intake_events_processed == 0
+
+
+def test_layer0_ignores_non_allowlist_event_types(vault, utc_config):
+    """An audit row with event_type outside the allowlist doesn't
+    inflate the Layer 0 count."""
+    vault_dir, conn = vault
+    as_of = datetime(2026, 5, 13, 12, 0, tzinfo=ZoneInfo("UTC"))
+    ts = (as_of - timedelta(minutes=10)).isoformat()
+    conn.execute(
+        "INSERT INTO audit_events VALUES (?, ?, ?, ?, ?, ?)",
+        ("pipeline.jsonl", "task_dispatched", "s", "x", ts, "{}"),
+    )
+    conn.commit()
+    conn.close()
+    result = collect_digest_inputs(
+        vault_dir, "research-tech", as_of=as_of, config=utc_config
+    )
+    assert result.intake.intake_events_processed == 0
+
+
+# ── Layer 1 — evergreen delta ──────────────────────────────────
+
+
+def test_layer1_classifies_new_vs_updated(vault, utc_config):
+    """version=1 + change_type=created → new; version>1 → updated."""
+    vault_dir, conn = vault
+    as_of = datetime(2026, 5, 13, 12, 0, tzinfo=ZoneInfo("UTC"))
+    _seed_evergreen_revision(
+        conn, object_id="evg-a", version=1, change_type="created",
+        derived_at=as_of - timedelta(hours=1), title="A",
+    )
+    _seed_evergreen_revision(
+        conn, object_id="evg-b", version=3, change_type="updated",
+        derived_at=as_of - timedelta(minutes=30), title="B",
+    )
+    conn.close()
+    result = collect_digest_inputs(
+        vault_dir, "research-tech", as_of=as_of, config=utc_config
+    )
+    assert len(result.delta.new_evergreens) == 1
+    assert result.delta.new_evergreens[0].object_id == "evg-a"
+    assert len(result.delta.updated_evergreens) == 1
+    assert result.delta.updated_evergreens[0].object_id == "evg-b"
+
+
+def test_layer1_falls_back_on_generic_change_note(vault, utc_config):
+    """Default ``lifecycle=promote`` note fails the quality check;
+    summary falls back to ``v{n}: {change_type}``."""
+    vault_dir, conn = vault
+    as_of = datetime(2026, 5, 13, 12, 0, tzinfo=ZoneInfo("UTC"))
+    for i in range(10):
+        _seed_evergreen_revision(
+            conn,
+            object_id=f"evg-{i}",
+            version=1,
+            change_type="promote",
+            derived_at=as_of - timedelta(hours=1, minutes=i),
+            change_note="lifecycle=promote",
+            title=f"Title {i}",
+        )
+    conn.close()
+    result = collect_digest_inputs(
+        vault_dir, "research-tech", as_of=as_of, config=utc_config
+    )
+    assert result.preflight.change_note_quality == "degraded"
+    for delta in result.delta.new_evergreens:
+        assert delta.change_summary.startswith("v1:")
+
+
+def test_layer1_uses_meaningful_change_note(vault, utc_config):
+    """When the absorb router DOES emit prose, use it verbatim."""
+    vault_dir, conn = vault
+    as_of = datetime(2026, 5, 13, 12, 0, tzinfo=ZoneInfo("UTC"))
+    for i in range(10):
+        _seed_evergreen_revision(
+            conn,
+            object_id=f"evg-{i}",
+            version=1,
+            change_type="created",
+            derived_at=as_of - timedelta(hours=1, minutes=i),
+            change_note=f"Added evidence from {i} new sources on memory systems",
+        )
+    conn.close()
+    result = collect_digest_inputs(
+        vault_dir, "research-tech", as_of=as_of, config=utc_config
+    )
+    assert result.preflight.change_note_quality == "ok"
+    summary = result.delta.new_evergreens[0].change_summary
+    assert "evidence" in summary or "sources" in summary
+
+
+# ── Layer 2 — connections ──────────────────────────────────────
+
+
+def test_layer2_attaches_cluster_to_evergreen_revision(vault, utc_config):
+    """Cluster membership index joins evergreen_revisions to
+    community_crystals via cluster_id."""
+    vault_dir, conn = vault
+    as_of = datetime(2026, 5, 13, 12, 0, tzinfo=ZoneInfo("UTC"))
+    _seed_evergreen_revision(
+        conn, object_id="evg-mem-1", version=1, change_type="created",
+        derived_at=as_of - timedelta(hours=1), title="Memory note",
+    )
+    _seed_cluster(
+        conn,
+        cluster_id="cluster::memory",
+        label="memory-systems",
+        members=["evg-mem-1"],
+    )
+    _seed_community_crystal(
+        conn,
+        cluster_id="cluster::memory",
+        synthesized_at=as_of - timedelta(days=8),
+    )
+    conn.close()
+    result = collect_digest_inputs(
+        vault_dir, "research-tech", as_of=as_of, config=utc_config
+    )
+    assert ("cluster::memory", "memory-systems") in result.connections.connected_community_crystals
+    delta = result.delta.new_evergreens[0]
+    assert delta.cluster_id == "cluster::memory"
+
+
+# ── Layer 3 — pipeline state ───────────────────────────────────
+
+
+def test_layer3_flags_stale_crystal_as_unsynthesized(vault, utc_config):
+    """A cluster with a crystal but newer evergreens → stale flag,
+    counts as unsynthesized.  The bug Codex flagged."""
+    vault_dir, conn = vault
+    as_of = datetime(2026, 5, 13, 12, 0, tzinfo=ZoneInfo("UTC"))
+    # Cluster synthesized 8 days ago.
+    _seed_cluster(
+        conn,
+        cluster_id="cluster::stale",
+        label="stale-topic",
+        members=[f"evg-s-{i}" for i in range(6)],
+    )
+    _seed_community_crystal(
+        conn,
+        cluster_id="cluster::stale",
+        synthesized_at=as_of - timedelta(days=8),
+    )
+    # But 6 new evergreens landed since.
+    for i in range(6):
+        _seed_evergreen_revision(
+            conn, object_id=f"evg-s-{i}", version=1, change_type="created",
+            derived_at=as_of - timedelta(hours=2),
+        )
+    conn.close()
+    result = collect_digest_inputs(
+        vault_dir, "research-tech", as_of=as_of, config=utc_config
+    )
+    assert result.pipeline_state.unsynthesized_evergreens == 6
+    threshold_clusters = result.pipeline_state.clusters_at_threshold
+    assert len(threshold_clusters) == 1
+    cid, label, count, stale = threshold_clusters[0]
+    assert cid == "cluster::stale"
+    assert stale is True
+    assert count == 6
+
+
+def test_layer3_no_crystal_also_counts_as_unsynthesized(vault, utc_config):
+    """A cluster with no crystal at all is unsynthesized regardless
+    of staleness."""
+    vault_dir, conn = vault
+    as_of = datetime(2026, 5, 13, 12, 0, tzinfo=ZoneInfo("UTC"))
+    _seed_cluster(
+        conn, cluster_id="cluster::fresh", label="fresh-topic",
+        members=[f"evg-f-{i}" for i in range(5)],
+    )
+    for i in range(5):
+        _seed_evergreen_revision(
+            conn, object_id=f"evg-f-{i}", version=1, change_type="created",
+            derived_at=as_of - timedelta(hours=2),
+        )
+    conn.close()
+    result = collect_digest_inputs(
+        vault_dir, "research-tech", as_of=as_of, config=utc_config
+    )
+    assert result.pipeline_state.unsynthesized_evergreens == 5
+    cid, _, _, stale = result.pipeline_state.clusters_at_threshold[0]
+    assert cid == "cluster::fresh"
+    assert stale is False  # no crystal, not "stale"
+
+
+def test_layer3_threshold_respects_config(vault):
+    """A cluster with 3 evergreens is below the default 5 but above
+    a custom threshold of 2."""
+    vault_dir, conn = vault
+    as_of = datetime(2026, 5, 13, 12, 0, tzinfo=ZoneInfo("UTC"))
+    _seed_cluster(
+        conn, cluster_id="c", label="tiny",
+        members=[f"evg-{i}" for i in range(3)],
+    )
+    for i in range(3):
+        _seed_evergreen_revision(
+            conn, object_id=f"evg-{i}", version=1, change_type="created",
+            derived_at=as_of - timedelta(hours=2),
+        )
+    conn.close()
+    default_cfg = DigestConfig(tz="UTC", cluster_threshold=5)
+    custom_cfg = DigestConfig(tz="UTC", cluster_threshold=2)
+    r_default = collect_digest_inputs(vault_dir, "research-tech", as_of=as_of, config=default_cfg)
+    r_custom = collect_digest_inputs(vault_dir, "research-tech", as_of=as_of, config=custom_cfg)
+    assert r_default.pipeline_state.clusters_at_threshold == ()
+    assert len(r_custom.pipeline_state.clusters_at_threshold) == 1
+
+
+# ── Window resolution ──────────────────────────────────────────
+
+
+def test_window_falls_back_to_local_day_when_no_prior_digest(vault, utc_config):
+    """First-ever run: window_start = local-day midnight."""
+    vault_dir, conn = vault
+    conn.close()
+    as_of = datetime(2026, 5, 13, 14, 0, tzinfo=ZoneInfo("UTC"))
+    result = collect_digest_inputs(
+        vault_dir, "research-tech", as_of=as_of, config=utc_config
+    )
+    assert result.window_start.hour == 0
+    assert result.window_start.minute == 0
+    assert result.window_end == as_of
+
+
+def test_window_uses_last_successful_digest_when_recent(vault, utc_config):
+    """Prior digest from this morning → window starts from there
+    (mid-day regenerate covers only the gap)."""
+    vault_dir, conn = vault
+    as_of = datetime(2026, 5, 13, 16, 0, tzinfo=ZoneInfo("UTC"))
+    earlier = as_of - timedelta(hours=8)  # 08:00 same day
+    conn.execute(
+        "INSERT INTO audit_events VALUES (?, ?, ?, ?, ?, ?)",
+        (
+            "pipeline.jsonl",
+            "digest_generated",
+            "daily",
+            "s",
+            earlier.isoformat(),
+            "{}",
+        ),
+    )
+    conn.commit()
+    conn.close()
+    result = collect_digest_inputs(
+        vault_dir, "research-tech", as_of=as_of, config=utc_config
+    )
+    # window_start should equal earlier (within the same day).
+    assert result.window_start.replace(microsecond=0) == earlier.replace(microsecond=0)
+
+
+# ── input_hash ─────────────────────────────────────────────────
+
+
+def test_input_hash_stable_across_repeated_collects(vault, utc_config):
+    """Two collects against unchanged data → same hash.  The
+    idempotency gate that BL-095 will rely on."""
+    vault_dir, conn = vault
+    as_of = datetime(2026, 5, 13, 12, 0, tzinfo=ZoneInfo("UTC"))
+    _seed_evergreen_revision(
+        conn, object_id="evg-x", version=1, change_type="created",
+        derived_at=as_of - timedelta(hours=1),
+    )
+    conn.close()
+    r1 = collect_digest_inputs(vault_dir, "research-tech", as_of=as_of, config=utc_config)
+    r2 = collect_digest_inputs(vault_dir, "research-tech", as_of=as_of, config=utc_config)
+    assert r1.input_hash() == r2.input_hash()
+
+
+def test_input_hash_differs_across_windows(vault, utc_config):
+    """Same data, different as_of → different hash because window
+    boundaries are part of the hash payload."""
+    vault_dir, conn = vault
+    as_of_1 = datetime(2026, 5, 13, 12, 0, tzinfo=ZoneInfo("UTC"))
+    as_of_2 = datetime(2026, 5, 14, 12, 0, tzinfo=ZoneInfo("UTC"))
+    conn.close()
+    r1 = collect_digest_inputs(vault_dir, "research-tech", as_of=as_of_1, config=utc_config)
+    r2 = collect_digest_inputs(vault_dir, "research-tech", as_of=as_of_2, config=utc_config)
+    assert r1.input_hash() != r2.input_hash()
+
+
+def test_input_hash_changes_when_data_changes(vault, utc_config):
+    """Adding an evergreen revision should change the hash even
+    within the same window."""
+    vault_dir, conn = vault
+    as_of = datetime(2026, 5, 13, 12, 0, tzinfo=ZoneInfo("UTC"))
+    r1 = collect_digest_inputs(vault_dir, "research-tech", as_of=as_of, config=utc_config)
+
+    new_conn = sqlite3.connect(vault_dir / "60-Logs" / "knowledge.db")
+    _seed_evergreen_revision(
+        new_conn, object_id="evg-new", version=1, change_type="created",
+        derived_at=as_of - timedelta(hours=1),
+    )
+    new_conn.close()
+    r2 = collect_digest_inputs(vault_dir, "research-tech", as_of=as_of, config=utc_config)
+    assert r1.input_hash() != r2.input_hash()


### PR DESCRIPTION
## Summary

First implementation BL of the M23 digest redesign (plan PR #222).  Pure data layer — no LLM call, no handler changes yet.

- **New module `digest_inputs.py`** — collector for four-layer schema (intake / evergreen delta / connections / pipeline state).  Frozen ``DigestInputs`` value object.  Window is operator-local ``[last_successful_digest_at, as_of]`` with local-day fallback per Codex review.
- **Six-check preflight** — verifies ``knowledge.db`` has the rows each layer needs *before* the handler builds a prompt.  Returns per-check ``ok``/``degraded``/``unavailable`` so BL-095 can render per-section degradation instead of crashing.
- **New module `digest_config.py`** — DigestConfig frozen dataclass + ``load_digest_config(vault_dir)``.  Mirrors ``llm_profiles.yaml`` precedent (bundled template at ``data/digest_template.yaml``, override at ``<vault>/.ovp/digest.yaml``).
- **Tz resolution** via tzlocal → stdlib zoneinfo → UTC fallback.  Added ``tzlocal>=5.0`` to pyproject.
- **Layer 3 stale-crystal flag** (Codex review) — a cluster with a crystal whose ``synthesized_at`` predates its newest evergreen counts as unsynthesized.  Without this, weekly-stale crystals would mask clusters needing re-synthesis.
- **``input_hash()``** — SHA-256 over (window boundaries + sorted stable id sets).  No wall-clock prose drift.  BL-095's idempotency gate consumes this.

## Smoke against operator's real vault

```
window: 2026-05-13T00:00:00-07:00 → 2026-05-13T12:00:00-07:00
preflight:
  evergreen_revisions_table: ok
  evergreen_revisions_recent: ok
  audit_events_layer0: ok
  change_note_quality: degraded         ← confirms the plan's pre-check predicted lifecycle=promote boilerplate
  graph_clusters: ok
  community_crystals: ok
layer 0 (intake): 38 events
layer 1 (delta):  new=0 updated=0       ← honest: today's 38 articles haven't reached evergreen revisions yet
layer 3 (state):
  unsynthesized: 1
  last_synthesis: 2026-05-05T05:42:26    ← 8 days ago — synthesis lag now visible
```

## Test plan

- [x] 30 new tests pass (test_digest_config: 13, test_digest_inputs: 17).  Covers every preflight branch, both stale-crystal and no-crystal Layer 3 paths, window resolution (first-run vs mid-day regenerate), and input_hash stability + drift.
- [x] Full suite green: 2747 passed, 15 xfailed, 1 deselected (file-size limit — pre-existing on main).
- [x] Architecture fitness ``test_no_direct_sqlite_in_non_data_modules``: ``digest_inputs`` added to allowlist (legitimate data-layer aggregator, same category as ``materializers/*``).  Pre-existing failures in 9 other modules unchanged — separate tech-debt items.

## What's NOT in this PR

- BL-095: prompt v2 + idempotency gate (next PR — consumes ``DigestInputs``).
- BL-096: Reader integration + mid-day regenerate button.
- BL-097: ``digest_clicked_through`` instrumentation + ``/ops/digest-health``.
- BL-098 / BL-099: claims/relations timestamps + POST action buttons (deferred to M23.1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable digest settings (timezone, event allowlist, cluster threshold, LLM-control flags) with vault overrides.
  * Robust digest input collection from the local knowledge DB with layered aggregation, windowing, and stable input hashing.

* **Documentation**
  * Added a digest configuration template documenting customization and override behavior.

* **Tests**
  * New tests for config loading, timezone resolution, input collection, preflight modes, idempotency, and windowing.
  * Architecture tests now permit the digest inputs module to access SQLite.

* **Chores**
  * Added tzlocal dependency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fakechris/obsidian_vault_pipeline/pull/223)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->