### PR TITLE
feat(m23): BL-095 — digest prompt v2 + input-hash idempotency gate

### DIFF
--- a/src/ovp_pipeline/commands/digest_handler.py
+++ b/src/ovp_pipeline/commands/digest_handler.py
@@ -519,11 +519,24 @@ def _render_no_data_body(inputs: DigestInputs) -> str:
         "Drop a few articles into `50-Inbox/01-Raw/` and run the "
         "ingestion pipeline; tomorrow's digest will reflect them."
     )
+    # CodeRabbit: distinguish "audit didn't run" from "audit ran +
+    # no events".  The original message conflated both as
+    # "No new intake in this window.", which is misleading when
+    # ``ovp-knowledge-index`` simply hasn't built the audit_events
+    # table yet.
+    if preflight.audit_events_layer0 == "ok":
+        intake_line = "No new intake in this window."
+    else:
+        intake_line = (
+            "Intake data unavailable — the audit_events table is "
+            "missing or empty.  Run `ovp-knowledge-index` to rebuild."
+        )
     body = (
         frontmatter
         + f"# Daily Knowledge Feedback — {date_label}\n\n"
         "## Window's intake\n\n"
-        "No new intake in this window.\n\n"
+        + intake_line
+        + "\n\n"
         + (f"## Pipeline state\n\n{diag_block}\n" if diag else "")
         + "## Worth doing next\n\n"
         + suggestion

--- a/src/ovp_pipeline/commands/digest_handler.py
+++ b/src/ovp_pipeline/commands/digest_handler.py
@@ -1,28 +1,40 @@
-"""``DIGEST-*`` handler — M20 / BL-077 daily synthesis.
+"""``DIGEST-*`` handler — M23 daily knowledge feedback.
 
-Implements the "vault talks back" feature.  Once per day (driven by
-``ovp-digest --enqueue-daily``, typically called by cron / launchd /
-AutoPilot), a ``DIGEST-daily.md`` task lands in
-``50-Inbox/02-Tasks/`` and the BL-076 dispatcher routes it here.
+Replaces M20's crystal-only digest with a **four-layer daily knowledge
+feedback** structure (M23 / BL-095):
 
-Output: ``40-Resources/Generated/digests/YYYY-MM-DD.md`` — a
-~200-word brief in three sections:
+  Layer 0 — today's intake from ``audit_events`` (acknowledgment)
+  Layer 1 — evergreen delta from ``evergreen_revisions`` (new thinking)
+  Layer 2 — connection between today's delta and existing crystals
+  Layer 3 — pipeline state with stale-crystal flag (backpressure)
+  Layer 4 — one concrete "worth doing next" question (LLM)
 
-1. **Tensions worth sitting with** — 2-3 contradictions from
-   top-scoring ``crystal_scores`` rows where
-   ``crystal_kind = 'contradiction'``.
-2. **Themes you keep circling** — 2-3 community crystals
-   synthesized in the last 24h.
-3. **Unanswered questions** — 2-3 open
-   ``contradiction_crystals`` (``superseded_by_synthesized_at = ''``)
-   that have NOT yet been covered by a tension above.
+The input collector + preflight + window resolution live in
+:mod:`ovp_pipeline.digest_inputs` (BL-094).  This module is just the
+**LLM-prompt + body composer** that consumes a :class:`DigestInputs`
+snapshot and writes markdown.
 
-Inputs are aggregated by ``_collect_digest_inputs``, formatted into
-a user prompt, and the LLM is asked to compose a brief in the user's
-voice (USER.md context is automatically prefixed by BL-076).
+Persistence + idempotency
+-------------------------
 
-CLI shapes
-----------
+* Output is one file per operator-local window:
+  ``40-Resources/Generated/digests/YYYY-MM-DD-digest-daily.md``.
+  Filename comes from the task dispatcher (uses ``_today_utc_date``);
+  the operator-local window boundaries are recorded inside the
+  frontmatter so a UTC/local mismatch is auditable, not silently lost.
+* **Input-hash idempotency gate** — before calling the LLM, the
+  handler computes a stable hash over (window boundaries + sorted
+  stable id sets from every layer) and compares it to any prior
+  digest at the same filename.  Same hash → skip the LLM call, emit
+  ``digest_skipped_no_change``.  This kills the M20-era "5 redundant
+  LLM passes in one day" thrash.
+* **Honest no-data path** — when Layers 0 + 1 are empty AND Layer 3
+  carries no actionable signal, the handler renders a 2-line
+  acknowledgment rather than asking the LLM to fabricate insight
+  from old crystals.
+
+CLI shapes (unchanged from M20)
+-------------------------------
 
 * ``ovp-digest --enqueue-daily``  — drop ``DIGEST-daily.md`` into
                                      ``50-Inbox/02-Tasks/`` so the
@@ -35,15 +47,25 @@ CLI shapes
 from __future__ import annotations
 
 import argparse
-import json
 import logging
-import sqlite3
+import re
 import sys
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 from ..context_loader import load_user_profile
+from ..digest_config import DigestConfig, load_digest_config
+from ..digest_inputs import (
+    ConnectionLayer,
+    DeltaLayer,
+    DigestInputs,
+    IntakeLayer,
+    PipelineState,
+    PreflightReport,
+    collect_digest_inputs,
+)
+from ..event_emitter import emit
 from .task_dispatch import (
     TaskContext,
     TaskResult,
@@ -54,382 +76,557 @@ from .task_dispatch import (
 logger = logging.getLogger(__name__)
 
 DIGESTS_SUBDIR = "digests"
-TOP_TENSIONS_N = 3
-RECENT_THEMES_N = 3
-OPEN_QUESTIONS_N = 3
-RECENT_CRYSTALS_WINDOW_H = 24
+SCHEMA_VERSION = 2
+
+# Audit event types emitted by this handler.  BL-097's
+# ``/ops/digest-health`` reads them.
+_EVENT_GENERATED = "digest_generated"
+_EVENT_SKIPPED_NO_CHANGE = "digest_skipped_no_change"
 
 
-def _knowledge_db_path(vault_dir: Path) -> Path:
-    return vault_dir / "60-Logs" / "knowledge.db"
+# ---------------------------------------------------------------
+# LLM prompt v2 — four-question structure
+# ---------------------------------------------------------------
 
+_DIGEST_SYSTEM_PROMPT_V2 = """\
+You are OVP's daily-feedback handler.  The operator feeds articles
+into a knowledge vault daily; you write a short morning brief that
+acknowledges today's intake, names what new thinking landed, points
+to how it connects to prior knowledge, and ends with ONE specific
+question or action worth taking next.
 
-def _collect_digest_inputs(vault_dir: Path, pack: str) -> dict[str, Any]:
-    """Pull tensions / themes / open-questions from ``knowledge.db``.
+Output structure (use these literal headings; omit a section when
+its inputs are empty):
 
-    Empty vault → returns all three lists empty.  The handler then
-    composes a sparse digest noting the empty state instead of
-    failing.
-    """
-    db_path = _knowledge_db_path(vault_dir)
-    if not db_path.exists():
-        return {"tensions": [], "themes": [], "open_questions": []}
+## Window's intake
+One short paragraph naming what came in today: counts, topics,
+representative titles.  Do not summarise individual articles.
 
-    now = datetime.now(timezone.utc)
-    cutoff = (now - timedelta(hours=RECENT_CRYSTALS_WINDOW_H)).isoformat(
-        timespec="seconds",
-    )
+## New thinking
+2-3 bullets covering the most material evergreen changes today
+(new + updated).  Frame each as one thought: *what changed*, plus
+*how it sits in the cluster it joined*.  When ``change_summary``
+is a fallback like ``v2: updated``, prefer the evergreen's title
++ cluster context over the fallback string.
 
-    with sqlite3.connect(db_path) as conn:
-        # Top-scoring tensions (contradictions).
-        tensions = conn.execute(
-            """
-            SELECT
-                cs.crystal_id,
-                cs.score,
-                cc.subject_key,
-                cc.body_md,
-                cc.source_object_ids_json
-              FROM crystal_scores cs
-              JOIN contradiction_crystals cc
-                ON cc.pack = cs.pack
-               AND cc.contradiction_id = cs.crystal_id
-               AND cc.superseded_by_synthesized_at = ''
-             WHERE cs.pack = ?
-               AND cs.crystal_kind = 'contradiction'
-             ORDER BY cs.score DESC
-             LIMIT ?
-            """,
-            (pack, TOP_TENSIONS_N),
-        ).fetchall()
+## How this window connects
+1-2 short paragraphs naming where today's new evergreens touch
+existing crystals or contradictions.  Be specific about the
+through-line — what makes them feel related, where they
+strengthen prior thinking, where they challenge it.
 
-        # Recently synthesized community crystals.
-        themes = conn.execute(
-            """
-            SELECT
-                cc.cluster_id,
-                cc.synthesized_at,
-                gc.label,
-                cc.body_md,
-                cc.source_evergreen_slugs_json
-              FROM community_crystals cc
-              JOIN graph_clusters gc
-                ON gc.pack = cc.pack AND gc.cluster_id = cc.cluster_id
-             WHERE cc.pack = ?
-               AND cc.superseded_by_synthesized_at = ''
-               AND cc.synthesized_at >= ?
-             ORDER BY cc.synthesized_at DESC
-             LIMIT ?
-            """,
-            (pack, cutoff, RECENT_THEMES_N),
-        ).fetchall()
+## Pipeline state
+One short paragraph (≤ 2 sentences) on backpressure: how many
+evergreens are awaiting synthesis, when synthesis last ran, which
+clusters have crossed the synthesis threshold (call out stale
+crystals — clusters with an existing crystal that predates today's
+inputs count as unsynthesized).
 
-        # Open contradictions (excluding the ones already in tensions
-        # above so the digest doesn't double-count).
-        tension_ids = {row[0] for row in tensions}
-        open_qs_all = conn.execute(
-            """
-            SELECT
-                contradiction_id,
-                subject_key,
-                body_md,
-                synthesized_at,
-                source_object_ids_json
-              FROM contradiction_crystals
-             WHERE pack = ?
-               AND superseded_by_synthesized_at = ''
-             ORDER BY synthesized_at DESC
-             LIMIT ?
-            """,
-            (pack, OPEN_QUESTIONS_N * 3),  # over-fetch and filter
-        ).fetchall()
-        open_questions = [
-            row for row in open_qs_all
-            if row[0] not in tension_ids
-        ][:OPEN_QUESTIONS_N]
-
-    def _teaser(text: str, max_chars: int = 220) -> str:
-        cleaned = " ".join((text or "").split())
-        return cleaned[:max_chars]
-
-    def _decode_slugs(blob: str) -> list[str]:
-        try:
-            data = json.loads(blob or "[]")
-        except (TypeError, ValueError, json.JSONDecodeError):
-            return []
-        # TEXT columns have no structural constraint, so a row with
-        # ``null`` or an object would raise TypeError on the list
-        # comprehension below and abort digest generation
-        # (rev-bot 208 round-2 #5).
-        if not isinstance(data, list):
-            return []
-        return [str(item) for item in data if item]
-
-    return {
-        "tensions": [
-            {
-                "id": row[0],
-                "score": row[1],
-                "subject": row[2],
-                "teaser": _teaser(row[3]),
-                "source_object_ids": _decode_slugs(row[4]),
-            }
-            for row in tensions
-        ],
-        "themes": [
-            {
-                "cluster_id": row[0],
-                "synthesized_at": row[1],
-                "label": row[2],
-                "teaser": _teaser(row[3]),
-                "source_evergreen_slugs": _decode_slugs(row[4]),
-            }
-            for row in themes
-        ],
-        "open_questions": [
-            {
-                "id": row[0],
-                "subject": row[1],
-                "teaser": _teaser(row[2]),
-                "source_object_ids": _decode_slugs(row[4]),
-            }
-            for row in open_questions
-        ],
-    }
-
-
-_DIGEST_SYSTEM_PROMPT = """\
-You are OVP's daily-digest handler.  You receive three aggregated
-inputs from the operator's vault and produce a ~200-word morning
-brief in the user's voice.
-
-Output structure (use these literal headings):
-
-## Tensions worth sitting with
-Two or three contradictions, each 1-2 sentences.  Frame as
-questions the operator hasn't yet answered.
-
-## Themes you keep circling
-Two or three recently-synthesized topics that recurred in the last
-24h.  One sentence each.  Surface the through-line — what makes
-them feel related.
-
-## Unanswered questions
-Two or three open contradictions the operator hasn't resolved.  One
-sentence each.
+## Worth doing next
+Exactly ONE concrete question or action.  Forms that work well:
+- "3 articles on X converged today. Want to synthesize this cluster?"
+- "Today's new evergreen Y challenges the open contradiction Z.
+  Resolve?"
+- "Cluster W has N unsynthesized evergreens. Run synthesis?"
+- "No new intake today. Continue with prior tensions, or seed
+  the vault?"
 
 Hard rules:
-- Stay under 220 words total.
-- Don't summarise everything — pick the items that pull on each
-  other.  A digest is a curated rail, not a feed.
-- Don't invent topics that aren't in the inputs.  If an input list
-  is empty, omit that section.
-- Don't include a closing call to action — leave the operator with
-  the questions, not a to-do.
+- Stay under 280 words total.
+- ACKNOWLEDGE today's intake even when the synthesis layer is
+  quiet — the operator needs to know their work landed.
+- Don't list article titles individually; surface them as a chip
+  ("memory systems (7), agents (3), ops (2)").
+- Don't invent topics that aren't in the input layers.
+- Don't write a closing call-to-think — the "Worth doing next"
+  section IS the call to action.
+- When a section has zero data, omit the heading entirely.
 """
 
 
-def _build_digest_user_prompt(
-    inputs: dict[str, Any], user_focus: str
-) -> str:
-    parts: list[str] = []
-    if user_focus.strip():
-        parts.append("Operator's current focus (from USER.md):\n")
-        parts.append(user_focus.strip() + "\n")
-    parts.append("\n# Recent inputs from the vault\n")
-
-    if inputs["tensions"]:
-        parts.append("\n## Top-scoring contradictions")
-        for t in inputs["tensions"]:
-            parts.append(
-                f"- **{t['subject']}** (score {t['score']:.2f})\n  "
-                f"{t['teaser']}"
-            )
-    else:
-        parts.append("\n## Top-scoring contradictions\n(none)\n")
-
-    if inputs["themes"]:
-        parts.append("\n## Communities synthesized in the last 24h")
-        for t in inputs["themes"]:
-            parts.append(f"- **{t['label']}**\n  {t['teaser']}")
-    else:
-        parts.append("\n## Communities synthesized in the last 24h\n(none)\n")
-
-    if inputs["open_questions"]:
-        parts.append("\n## Other open contradictions")
-        for q in inputs["open_questions"]:
-            parts.append(f"- **{q['subject']}**\n  {q['teaser']}")
-    else:
-        parts.append("\n## Other open contradictions\n(none)\n")
-
-    parts.append("\nNow compose the brief.")
-    return "\n".join(parts)
-
-
-def _today_utc_date() -> str:
-    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
-
-
-def _build_sources_section(inputs: dict[str, Any]) -> str:
-    """Render a ``## Sources`` block linking back to every crystal +
-    evergreen the digest was synthesised from.
-
-    Obsidian-flavoured wikilinks so clicking inside Obsidian jumps
-    straight to the source.  In the ovp-ui ``/note`` renderer the
-    same wikilinks resolve via ``_replace_wikilinks_with_markdown_links``,
-    so the same markdown works in both surfaces.
-
-    Empty when no inputs carry source ids (e.g. on the empty-vault
-    stub digest), so the digest doesn't render an empty heading.
-    """
-    from ..synthesis._shared import crystal_safe_id
-
-    def _safe_wikilink_text(value: Any) -> str:
-        """Strip wikilink delimiters from a label/slug.
-
-        ``]]`` would close the link early; ``|`` would split it into
-        ``[[target|label|extra]]`` and confuse Obsidian's parser;
-        newlines would break out of the surrounding list item.  Pre-
-        fix, ``subject`` / ``label`` values flowed in raw from
-        crystal frontmatter, so a stray ``]]`` in a subject key
-        broke every digest below that link (rev-bot 208 round-2 #6).
-        """
-        return (
-            str(value or "")
-            .replace("[", " ")
-            .replace("]", " ")
-            .replace("|", " ")
-            .replace("\n", " ")
-            .strip()
-        )
-
-    crystal_links: list[str] = []
-    evergreen_slugs: list[str] = []
-
-    for item in inputs.get("tensions", []):
-        safe = crystal_safe_id("contradiction", str(item.get("id") or ""))
-        if safe:
-            label = _safe_wikilink_text(item.get("subject", safe)) or safe
-            crystal_links.append(f"[[{safe}|⚠ {label}]]")
-        evergreen_slugs.extend(item.get("source_object_ids", []))
-
-    for item in inputs.get("themes", []):
-        safe = crystal_safe_id("community", str(item.get("cluster_id") or ""))
-        if safe:
-            label = _safe_wikilink_text(item.get("label", safe)) or safe
-            crystal_links.append(f"[[{safe}|◆ {label}]]")
-        evergreen_slugs.extend(item.get("source_evergreen_slugs", []))
-
-    for item in inputs.get("open_questions", []):
-        safe = crystal_safe_id("contradiction", str(item.get("id") or ""))
-        if safe:
-            label = _safe_wikilink_text(item.get("subject", safe)) or safe
-            crystal_links.append(f"[[{safe}|? {label}]]")
-        evergreen_slugs.extend(item.get("source_object_ids", []))
-
-    # Dedupe while preserving order so the reader sees crystals
-    # first in the order they appeared in the brief.  ``dict.fromkeys``
-    # is the idiomatic Python 3.7+ ordered-set (rev-bot 208.3).
-    deduped_crystals = list(dict.fromkeys(crystal_links))
-    deduped_slugs = [
-        slug for slug in dict.fromkeys(evergreen_slugs) if slug
-    ]
-
-    if not deduped_crystals and not deduped_slugs:
-        return ""
-
-    parts: list[str] = ["\n## Sources\n"]
-    if deduped_crystals:
-        parts.append("**Crystals**")
-        for link in deduped_crystals:
-            parts.append(f"- {link}")
-        parts.append("")
-    if deduped_slugs:
-        parts.append("**Underlying evergreens**")
-        # Cap at a generous N so a digest grounded in 30 evergreens
-        # doesn't bury the brief.  Reader can always open the
-        # crystal to see the full member list.
-        EVERGREEN_CAP = 24
-        shown = deduped_slugs[:EVERGREEN_CAP]
-        for slug in shown:
-            safe_slug = _safe_wikilink_text(slug)
-            if safe_slug:
-                parts.append(f"- [[{safe_slug}]]")
-        if len(deduped_slugs) > EVERGREEN_CAP:
-            parts.append(
-                f"- *…and {len(deduped_slugs) - EVERGREEN_CAP} more.*"
-            )
-        parts.append("")
-    return "\n".join(parts) + "\n"
+# ---------------------------------------------------------------
+# Handler entry point
+# ---------------------------------------------------------------
 
 
 def handle_digest(ctx: TaskContext) -> TaskResult:
-    """Aggregate vault signals + compose the daily digest."""
-    inputs = _collect_digest_inputs(ctx.vault_dir, ctx.pack)
+    """Compose one digest for ``ctx.pack`` against the current vault state."""
+    config = load_digest_config(ctx.vault_dir)
+    inputs = collect_digest_inputs(ctx.vault_dir, ctx.pack, config=config)
+    new_hash = inputs.input_hash()
+
+    # Idempotency gate — Stage 3 of the M23 plan.  Read any prior
+    # digest at the expected filename; if its ``input_hash`` matches,
+    # skip the LLM call and return the prior body verbatim so the
+    # dispatcher's overwrite is a no-op rewrite.
+    if config.skip_unchanged:
+        prior_path = _expected_output_path(ctx.vault_dir)
+        prior_hash, prior_body = _read_prior_digest(prior_path)
+        if prior_body and prior_hash == new_hash:
+            emit(
+                ctx.vault_dir,
+                "pipeline.jsonl",
+                _EVENT_SKIPPED_NO_CHANGE,
+                {
+                    "input_hash": new_hash,
+                    "window_start": inputs.window_start.isoformat(),
+                    "window_end": inputs.window_end.isoformat(),
+                    "pack": ctx.pack,
+                },
+                pack=ctx.pack,
+            )
+            return TaskResult(
+                body_md=prior_body,
+                subdir=DIGESTS_SUBDIR,
+                metadata={
+                    "input_hash": new_hash,
+                    "skipped_llm": True,
+                    "reason": "no_change",
+                },
+            )
+
+    # No-data path: when nothing meaningful changed, render an
+    # honest acknowledgment instead of asking the LLM to fabricate
+    # insight from stale crystals.
+    if _is_no_data(inputs):
+        body_md = _render_no_data_body(inputs, ctx.pack)
+        emit(
+            ctx.vault_dir,
+            "pipeline.jsonl",
+            _EVENT_GENERATED,
+            _generated_audit_payload(inputs, new_hash, skipped_llm=True),
+            pack=ctx.pack,
+        )
+        return TaskResult(
+            body_md=body_md,
+            subdir=DIGESTS_SUBDIR,
+            metadata={
+                "input_hash": new_hash,
+                "skipped_llm": True,
+                "reason": "no_data",
+                **_layer_counts(inputs),
+            },
+        )
+
+    # Real digest — call the LLM with the structured input layers.
     user_focus = load_user_profile(ctx.vault_dir)
-    user_prompt = _build_digest_user_prompt(inputs, user_focus)
-    sys_prompt = ctx.compose_system_prompt(_DIGEST_SYSTEM_PROMPT)
+    user_prompt = _build_digest_user_prompt_v2(inputs, user_focus)
+    sys_prompt = ctx.compose_system_prompt(_DIGEST_SYSTEM_PROMPT_V2)
 
-    # ``type: digest`` frontmatter tells the /note renderer to use
-    # the thin shell (no evergreen scaffolding) — see
-    # ``_THIN_NOTE_TYPES`` in ``commands/_ui_renderers.py``.
-    frontmatter = (
-        "---\n"
-        "type: digest\n"
-        "schema_version: 1\n"
-        f"generated_at: {_today_utc_date()}\n"
-        f"pack: {ctx.pack}\n"
-        "---\n\n"
+    composed = ctx.llm_client.call(
+        sys_prompt, user_prompt, max_tokens=1200,
     )
+    composed = (composed or "").strip()
 
-    # Empty vault: skip the LLM call entirely, write a stub digest
-    # that explains there's nothing to surface.  Saves both the
-    # token spend and a guaranteed-bland generic response.
-    if not any((inputs["tensions"], inputs["themes"], inputs["open_questions"])):
-        body_md = (
-            frontmatter
-            + f"# Digest — {_today_utc_date()}\n\n"
-            "Nothing new to surface today.  No contradictions, "
-            "themes, or open questions in this pack.\n\n"
-            "Either the vault is still warming up (run "
-            "`ovp-synthesize-community-crystals` and `ovp-knowledge-index`), "
-            "or you have read everything already — in which case, "
-            "perhaps capture something new.\n"
-        )
-    else:
-        composed = ctx.llm_client.call(
-            sys_prompt, user_prompt, max_tokens=900,
-        )
-        composed = (composed or "").strip()
-        body_md = (
-            frontmatter
-            + f"# Digest — {_today_utc_date()}\n\n{composed}\n"
-        )
-
-    sources_md = _build_sources_section(inputs)
-    footer = (
-        "\n---\n\n"
-        f"*Generated by DIGEST handler on {_today_utc_date()} "
-        f"from `50-Inbox/02-Tasks/{ctx.task_path.name}`. "
-        f"Tensions: {len(inputs['tensions'])}, "
-        f"Themes: {len(inputs['themes'])}, "
-        f"Open questions: {len(inputs['open_questions'])}.*\n"
+    body_md = _render_body(inputs, composed, new_hash, ctx)
+    emit(
+        ctx.vault_dir,
+        "pipeline.jsonl",
+        _EVENT_GENERATED,
+        _generated_audit_payload(inputs, new_hash, skipped_llm=False),
+        pack=ctx.pack,
     )
     return TaskResult(
-        body_md=body_md + sources_md + footer,
+        body_md=body_md,
         subdir=DIGESTS_SUBDIR,
         metadata={
-            "tensions": len(inputs["tensions"]),
-            "themes": len(inputs["themes"]),
-            "open_questions": len(inputs["open_questions"]),
+            "input_hash": new_hash,
+            "skipped_llm": False,
+            **_layer_counts(inputs),
         },
     )
 
 
-register_handler("DIGEST", handle_digest, "Daily synthesis brief.")
+register_handler("DIGEST", handle_digest, "Daily knowledge feedback brief.")
 
 
-# ── ovp-digest CLI ─────────────────────────────────────────────────
+# ---------------------------------------------------------------
+# No-data + idempotency helpers
+# ---------------------------------------------------------------
+
+
+def _is_no_data(inputs: DigestInputs) -> bool:
+    """Layers 0 + 1 + 2 empty AND Layer 3 has no actionable signal."""
+    has_intake = inputs.intake.intake_events_processed > 0
+    has_delta = bool(inputs.delta.new_evergreens or inputs.delta.updated_evergreens)
+    has_connections = bool(
+        inputs.connections.connected_community_crystals
+        or inputs.connections.touched_contradictions
+    )
+    layer3 = inputs.pipeline_state
+    has_pipeline_signal = (
+        layer3.unsynthesized_evergreens > 0
+        or bool(layer3.clusters_at_threshold)
+        or layer3.open_contradictions_count > 0
+    )
+    return not (has_intake or has_delta or has_connections or has_pipeline_signal)
+
+
+def _expected_output_path(vault_dir: Path | str) -> Path:
+    """Compose the filename the dispatcher will write today's digest to.
+
+    Mirrors ``task_dispatch._resolve_output_path`` for the DIGEST
+    handler.  The dispatcher uses UTC for the filename even though
+    M23 reports window boundaries in operator-local time — this is
+    intentional for backwards-compat with the existing
+    ``ovp-digest --show-latest`` glob, and operator-local timestamps
+    inside the frontmatter make any tz mismatch auditable.
+    """
+    date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    return (
+        Path(vault_dir)
+        / "40-Resources"
+        / "Generated"
+        / DIGESTS_SUBDIR
+        / f"{date_str}-digest-daily.md"
+    )
+
+
+_INPUT_HASH_RE = re.compile(r"^input_hash:\s*(\S+)\s*$", re.MULTILINE)
+
+
+def _read_prior_digest(path: Path) -> tuple[str, str]:
+    """Return ``(input_hash, body)`` from any existing digest at
+    ``path``; both empty when the file is missing or unparseable.
+
+    Hash comes from the frontmatter; body is the full file contents
+    (we return it unchanged so the dispatcher rewrites it byte-for-byte
+    when we skip the LLM call).
+    """
+    if not path.is_file():
+        return "", ""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return "", ""
+    if not text.startswith("---\n"):
+        return "", text
+    fm_end = text.find("\n---", 4)
+    if fm_end < 0:
+        return "", text
+    fm = text[4:fm_end]
+    match = _INPUT_HASH_RE.search(fm)
+    return (match.group(1) if match else ""), text
+
+
+def _generated_audit_payload(
+    inputs: DigestInputs, input_hash: str, *, skipped_llm: bool
+) -> dict[str, Any]:
+    return {
+        "input_hash": input_hash,
+        "skipped_llm": skipped_llm,
+        "window_start": inputs.window_start.isoformat(),
+        "window_end": inputs.window_end.isoformat(),
+        "tz": inputs.tz_name,
+        "pack": inputs.pack,
+        "preflight_degraded": inputs.preflight.any_degraded(),
+        **_layer_counts(inputs),
+    }
+
+
+def _layer_counts(inputs: DigestInputs) -> dict[str, int]:
+    return {
+        "layer0_events": inputs.intake.intake_events_processed,
+        "layer1_new": len(inputs.delta.new_evergreens),
+        "layer1_updated": len(inputs.delta.updated_evergreens),
+        "layer2_connected_crystals": len(
+            inputs.connections.connected_community_crystals
+        ),
+        "layer2_touched_contradictions": len(
+            inputs.connections.touched_contradictions
+        ),
+        "layer3_unsynth": inputs.pipeline_state.unsynthesized_evergreens,
+        "layer3_clusters_at_threshold": len(
+            inputs.pipeline_state.clusters_at_threshold
+        ),
+        "layer3_open_contradictions": inputs.pipeline_state.open_contradictions_count,
+    }
+
+
+# ---------------------------------------------------------------
+# User prompt — structured input for the LLM
+# ---------------------------------------------------------------
+
+
+def _build_digest_user_prompt_v2(inputs: DigestInputs, user_focus: str) -> str:
+    parts: list[str] = []
+    if user_focus.strip():
+        parts.append("Operator's current focus (from USER.md):\n")
+        parts.append(user_focus.strip() + "\n")
+
+    parts.append("\n# Window")
+    parts.append(
+        f"From {inputs.window_start.isoformat()} to "
+        f"{inputs.window_end.isoformat()} ({inputs.tz_name})"
+    )
+
+    parts.append("\n# Layer 0 — Today's intake")
+    parts.append(_render_layer0_for_prompt(inputs.intake))
+
+    parts.append("\n# Layer 1 — Evergreen delta")
+    parts.append(_render_layer1_for_prompt(inputs.delta, inputs.preflight))
+
+    parts.append("\n# Layer 2 — Connections to existing knowledge")
+    parts.append(_render_layer2_for_prompt(inputs.connections))
+
+    parts.append("\n# Layer 3 — Pipeline state")
+    parts.append(_render_layer3_for_prompt(inputs.pipeline_state))
+
+    parts.append("\nNow compose the brief in the four-section format.")
+    return "\n".join(parts)
+
+
+def _render_layer0_for_prompt(layer: IntakeLayer) -> str:
+    if layer.intake_events_processed == 0:
+        return "(no intake events in this window)"
+    chips = ", ".join(f"{k} ({n})" for k, n in layer.topic_distribution) or "(no topic distribution)"
+    samples = "; ".join(layer.representative_samples) or "(no titles)"
+    authors = ", ".join(layer.authors_or_sources) or "(no attributed sources)"
+    return (
+        f"- Events processed: {layer.intake_events_processed}\n"
+        f"- Topic distribution: {chips}\n"
+        f"- Authors / sources: {authors}\n"
+        f"- Representative titles: {samples}"
+    )
+
+
+def _render_layer1_for_prompt(layer: DeltaLayer, preflight: PreflightReport) -> str:
+    if not (layer.new_evergreens or layer.updated_evergreens):
+        return "(no new or updated evergreens in this window)"
+    lines: list[str] = []
+    if preflight.change_note_quality != "ok":
+        lines.append(
+            "(NOTE: change_note quality is degraded — change_summary "
+            "values are generic fallbacks; prefer title + cluster for prose.)"
+        )
+    if layer.new_evergreens:
+        lines.append("New evergreens:")
+        for d in layer.new_evergreens:
+            cluster = f" (cluster: {d.cluster_id})" if d.cluster_id else ""
+            lines.append(
+                f"- **{d.title}** [v{d.version} {d.change_type}]{cluster}: {d.change_summary}"
+            )
+    if layer.updated_evergreens:
+        lines.append("Updated evergreens:")
+        for d in layer.updated_evergreens:
+            cluster = f" (cluster: {d.cluster_id})" if d.cluster_id else ""
+            lines.append(
+                f"- **{d.title}** [v{d.version} {d.change_type}]{cluster}: {d.change_summary}"
+            )
+    return "\n".join(lines)
+
+
+def _render_layer2_for_prompt(layer: ConnectionLayer) -> str:
+    if not (
+        layer.connected_community_crystals
+        or layer.touched_contradictions
+        or layer.recent_top_crystals
+    ):
+        return "(no detected connections to existing crystals or contradictions)"
+    lines: list[str] = []
+    if layer.connected_community_crystals:
+        lines.append("Today's evergreens joined these existing communities:")
+        for cluster_id, label in layer.connected_community_crystals:
+            lines.append(f"- {label or cluster_id} (cluster_id={cluster_id})")
+    if layer.touched_contradictions:
+        lines.append("Today's evergreens overlap with these open contradictions:")
+        for cid, subject in layer.touched_contradictions:
+            lines.append(f"- {subject or cid} (contradiction_id={cid})")
+    if layer.recent_top_crystals:
+        lines.append("Top-scoring crystals in the vault (context, not delta):")
+        for cid, kind, score in layer.recent_top_crystals:
+            lines.append(f"- {kind}/{cid} score={score:.2f}")
+    return "\n".join(lines)
+
+
+def _render_layer3_for_prompt(layer: PipelineState) -> str:
+    parts: list[str] = []
+    if layer.unsynthesized_evergreens:
+        parts.append(
+            f"{layer.unsynthesized_evergreens} evergreens awaiting (or "
+            "needing re-) synthesis."
+        )
+    if layer.last_synthesis_at:
+        parts.append(f"Last synthesis at: {layer.last_synthesis_at}")
+    else:
+        parts.append("No synthesis has ever run.")
+    if layer.clusters_at_threshold:
+        parts.append("Clusters at or above the synthesis threshold:")
+        for cid, label, count, stale in layer.clusters_at_threshold:
+            flag = " (STALE crystal)" if stale else ""
+            parts.append(f"- {label or cid}: {count} evergreens{flag}")
+    if layer.open_contradictions_count:
+        parts.append(
+            f"{layer.open_contradictions_count} open contradiction"
+            f"{'s' if layer.open_contradictions_count != 1 else ''} unresolved."
+        )
+    return "\n".join(parts) if parts else "(no notable pipeline state)"
+
+
+# ---------------------------------------------------------------
+# Body rendering
+# ---------------------------------------------------------------
+
+
+def _render_body(
+    inputs: DigestInputs,
+    composed: str,
+    input_hash: str,
+    ctx: TaskContext,
+) -> str:
+    frontmatter = _build_frontmatter(inputs, input_hash)
+    date_label = inputs.window_end.date().isoformat()
+    sources = _build_sources_section(inputs)
+    footer = _build_footer(inputs, ctx)
+    return (
+        frontmatter
+        + f"# Daily Knowledge Feedback — {date_label}\n\n"
+        + composed
+        + "\n"
+        + sources
+        + footer
+    )
+
+
+def _render_no_data_body(inputs: DigestInputs, pack: str) -> str:
+    """Honest, LLM-free body for windows with no real signal.
+
+    Surfaces (1) the window we looked at, (2) the preflight state so
+    operators can see WHY there's nothing — table missing vs empty
+    vs synthesis lag — and (3) a concrete next step.
+    """
+    frontmatter = _build_frontmatter(inputs, inputs.input_hash())
+    date_label = inputs.window_end.date().isoformat()
+    preflight = inputs.preflight
+    diag: list[str] = []
+    if preflight.evergreen_revisions_table != "ok":
+        diag.append(
+            "- `evergreen_revisions` table is missing or unreadable. "
+            "Run `ovp-knowledge-index` to rebuild it."
+        )
+    elif preflight.evergreen_revisions_recent != "ok":
+        diag.append(
+            "- No evergreen revisions in the last 7 days. "
+            "The absorb pipeline hasn't produced anything new."
+        )
+    if preflight.community_crystals != "ok":
+        diag.append(
+            "- No community crystals yet. "
+            "Run `ovp-synthesize-community-crystals` once enough evergreens accumulate."
+        )
+    diag_block = ("\n".join(diag) + "\n") if diag else ""
+    suggestion = (
+        "Drop a few articles into `50-Inbox/01-Raw/` and run the "
+        "ingestion pipeline; tomorrow's digest will reflect them."
+    )
+    body = (
+        frontmatter
+        + f"# Daily Knowledge Feedback — {date_label}\n\n"
+        "## Window's intake\n\n"
+        "No new intake in this window.\n\n"
+        + (f"## Pipeline state\n\n{diag_block}\n" if diag else "")
+        + "## Worth doing next\n\n"
+        + suggestion
+        + "\n"
+        + _build_footer(inputs, None)
+    )
+    return body
+
+
+def _build_frontmatter(inputs: DigestInputs, input_hash: str) -> str:
+    preflight = inputs.preflight
+    return (
+        "---\n"
+        "type: digest\n"
+        f"schema_version: {SCHEMA_VERSION}\n"
+        f"generated_at: {inputs.window_end.isoformat()}\n"
+        f"window_start: {inputs.window_start.isoformat()}\n"
+        f"window_end: {inputs.window_end.isoformat()}\n"
+        f"tz: {inputs.tz_name}\n"
+        f"pack: {inputs.pack}\n"
+        f"input_hash: {input_hash}\n"
+        "preflight:\n"
+        f"  evergreen_revisions_table: {preflight.evergreen_revisions_table}\n"
+        f"  evergreen_revisions_recent: {preflight.evergreen_revisions_recent}\n"
+        f"  audit_events_layer0: {preflight.audit_events_layer0}\n"
+        f"  change_note_quality: {preflight.change_note_quality}\n"
+        f"  graph_clusters: {preflight.graph_clusters}\n"
+        f"  community_crystals: {preflight.community_crystals}\n"
+        "---\n\n"
+    )
+
+
+def _build_sources_section(inputs: DigestInputs) -> str:
+    """Surface the underlying evergreens + crystals the digest read.
+
+    Mirrors the M20 Sources block so operators get clickable
+    wikilinks from inside Obsidian.  Empty when no rows touched.
+    """
+    new_objects = [d.object_id for d in inputs.delta.new_evergreens]
+    updated_objects = [d.object_id for d in inputs.delta.updated_evergreens]
+    connected_clusters = [c[0] for c in inputs.connections.connected_community_crystals]
+    contradiction_ids = [c[0] for c in inputs.connections.touched_contradictions]
+    if not (new_objects or updated_objects or connected_clusters or contradiction_ids):
+        return ""
+    parts: list[str] = ["\n## Sources\n"]
+    if new_objects or updated_objects:
+        parts.append("**Evergreens this window touched**")
+        seen: set[str] = set()
+        for oid in [*new_objects, *updated_objects]:
+            slug = _safe_wikilink(oid)
+            if slug and slug not in seen:
+                parts.append(f"- [[{slug}]]")
+                seen.add(slug)
+        parts.append("")
+    if connected_clusters or contradiction_ids:
+        parts.append("**Crystals + contradictions connected**")
+        for cid in connected_clusters:
+            label = _safe_wikilink(cid)
+            if label:
+                parts.append(f"- [[{label}|◆ {label}]]")
+        for cid in contradiction_ids:
+            label = _safe_wikilink(cid)
+            if label:
+                parts.append(f"- [[{label}|⚠ {label}]]")
+        parts.append("")
+    return "\n".join(parts) + "\n"
+
+
+def _safe_wikilink(value: Any) -> str:
+    """Strip wikilink-breaking characters from a slug."""
+    return (
+        str(value or "")
+        .replace("[", " ")
+        .replace("]", " ")
+        .replace("|", " ")
+        .replace("\n", " ")
+        .strip()
+    )
+
+
+def _build_footer(inputs: DigestInputs, ctx: TaskContext | None) -> str:
+    counts = _layer_counts(inputs)
+    when = inputs.window_end.date().isoformat()
+    task_ref = (
+        f"`50-Inbox/02-Tasks/{ctx.task_path.name}`"
+        if ctx is not None
+        else "`ovp-digest --run-now`"
+    )
+    return (
+        "\n---\n\n"
+        f"*Generated by DIGEST handler on {when} from {task_ref}. "
+        f"Layer 0: {counts['layer0_events']} events · "
+        f"Layer 1: {counts['layer1_new']} new + {counts['layer1_updated']} updated · "
+        f"Layer 2: {counts['layer2_connected_crystals']} crystals + "
+        f"{counts['layer2_touched_contradictions']} contradictions · "
+        f"Layer 3: {counts['layer3_unsynth']} unsynthesized, "
+        f"{counts['layer3_open_contradictions']} open.*\n"
+    )
+
+
+# ---------------------------------------------------------------
+# ovp-digest CLI (unchanged from M20)
+# ---------------------------------------------------------------
 
 
 def _enqueue_daily(vault_dir: Path) -> Path:
@@ -460,7 +657,7 @@ def _latest_digest(vault_dir: Path) -> Path | None:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
-        description="Daily digest helpers (M20 / BL-077).",
+        description="Daily digest helpers (M23 / BL-095).",
     )
     parser.add_argument("--vault-dir", required=True, type=Path)
     parser.add_argument(
@@ -497,19 +694,19 @@ def main(argv: list[str] | None = None) -> int:
         print(latest)
         return 0
 
-    if args.enqueue_daily and not args.run_now:
-        path = _enqueue_daily(vault)
-        print(f"enqueued: {path}")
+    if args.enqueue_daily or args.run_now:
+        task = _enqueue_daily(vault)
+        if args.run_now:
+            try:
+                output = dispatch_task(vault, task, pack=args.pack)
+            except Exception as exc:  # noqa: BLE001
+                print(f"dispatch failed: {exc}", file=sys.stderr)
+                return 3
+            print(output)
+        else:
+            print(task)
         return 0
 
-    # --run-now (alone, or with --enqueue-daily; same effect)
-    task_path = _enqueue_daily(vault)
-    try:
-        out = dispatch_task(vault, task_path, pack=args.pack)
-    except Exception as exc:
-        print(f"error: dispatch failed: {exc}", file=sys.stderr)
-        return 1
-    print(f"ok: {out}")
     return 0
 
 

--- a/src/ovp_pipeline/commands/digest_handler.py
+++ b/src/ovp_pipeline/commands/digest_handler.py
@@ -189,7 +189,7 @@ def handle_digest(ctx: TaskContext) -> TaskResult:
     # honest acknowledgment instead of asking the LLM to fabricate
     # insight from stale crystals.
     if _is_no_data(inputs):
-        body_md = _render_no_data_body(inputs, ctx.pack)
+        body_md = _render_no_data_body(inputs)
         emit(
             ctx.vault_dir,
             "pipeline.jsonl",
@@ -488,7 +488,7 @@ def _render_body(
     )
 
 
-def _render_no_data_body(inputs: DigestInputs, pack: str) -> str:
+def _render_no_data_body(inputs: DigestInputs) -> str:
     """Honest, LLM-free body for windows with no real signal.
 
     Surfaces (1) the window we looked at, (2) the preflight state so

--- a/src/ovp_pipeline/digest_inputs.py
+++ b/src/ovp_pipeline/digest_inputs.py
@@ -458,8 +458,8 @@ def _check_audit_layer0(
             """,
             (
                 *config.intake_event_types,
-                window_start.isoformat(),
-                window_end.isoformat(),
+                _utc_iso(window_start),
+                _utc_iso(window_end),
             ),
         ).fetchone()[0]
     except sqlite3.OperationalError:
@@ -492,8 +492,8 @@ def _collect_layer0(
             """,
             (
                 *config.intake_event_types,
-                window_start.isoformat(),
-                window_end.isoformat(),
+                _utc_iso(window_start),
+                _utc_iso(window_end),
             ),
         ).fetchall()
     except sqlite3.OperationalError:
@@ -577,7 +577,7 @@ def _collect_layer1(
                AND er.derived_at <= ?
              ORDER BY er.derived_at DESC
             """,
-            (pack, window_start.isoformat(), window_end.isoformat()),
+            (pack, _utc_iso(window_start), _utc_iso(window_end)),
         ).fetchall()
     except sqlite3.OperationalError:
         return DeltaLayer((), ())
@@ -925,9 +925,14 @@ def _compute_input_hash(inputs: DigestInputs) -> str:
     doesn't drift with wall-clock time.  Counts, sorted id sets,
     window boundaries — yes.  Prose like "8 days ago" — never.
     """
+    # Round to the minute so back-to-back mid-day regenerations don't
+    # produce a fresh hash on every wall-clock microsecond tick — the
+    # idempotency gate fires only when the *data* actually drifted.
+    window_start_q = inputs.window_start.replace(second=0, microsecond=0)
+    window_end_q = inputs.window_end.replace(second=0, microsecond=0)
     payload = {
-        "window_start": inputs.window_start.isoformat(),
-        "window_end": inputs.window_end.isoformat(),
+        "window_start": _utc_iso(window_start_q),
+        "window_end": _utc_iso(window_end_q),
         "pack": inputs.pack,
         "layer0_event_count": inputs.intake.intake_events_processed,
         "layer0_samples": sorted(inputs.intake.representative_samples),
@@ -958,6 +963,17 @@ def _safe_json(blob: Any) -> Any:
         return None
 
 
+def _utc_iso(dt: datetime) -> str:
+    """Normalize a tz-aware datetime to a UTC ISO string for SQL binding.
+
+    Stored timestamps in ``knowledge.db`` are UTC (some as
+    ``...+00:00``, some as ``...Z``); a string-comparison against
+    an operator-local ISO like ``...-07:00`` is lexicographic, not
+    time-correct.  Every SQL bind site goes through this helper.
+    """
+    return dt.astimezone(timezone.utc).isoformat()
+
+
 def _parse_iso(raw: str) -> datetime | None:
     """Permissive ISO-8601 parser.  Returns None on failure."""
     raw = (raw or "").strip()
@@ -973,11 +989,15 @@ def _parse_iso(raw: str) -> datetime | None:
 
 
 def _tz_display_name(tz: Any) -> str:
-    """Best-effort tz name for the digest frontmatter."""
-    for attr in ("key", "zone"):
-        name = getattr(tz, attr, None)
-        if isinstance(name, str) and name:
-            return name
+    """Best-effort tz name for the digest frontmatter.
+
+    Stdlib :class:`zoneinfo.ZoneInfo` exposes ``key``; ``tzlocal``
+    may return a pytz shim whose ``zone`` accessor triggers a
+    deprecation warning.  Try ``key`` first, fall back to ``str(tz)``.
+    """
+    name = getattr(tz, "key", None)
+    if isinstance(name, str) and name:
+        return name
     try:
         return str(tz)
     except Exception:  # noqa: BLE001

--- a/tests/test_digest_config.py
+++ b/tests/test_digest_config.py
@@ -122,9 +122,14 @@ def test_load_empty_intake_list_falls_back(tmp_path: Path):
 
 def test_config_is_immutable():
     """Frozen dataclass + tuple sequence — no field assignment, no
-    list mutation possible."""
+    list mutation possible.
+
+    ``dataclasses.FrozenInstanceError`` is a subclass of
+    ``AttributeError``, so the narrower assertion still covers the
+    real failure mode without swallowing unrelated exceptions.
+    """
     cfg = DigestConfig()
-    with pytest.raises(Exception):
+    with pytest.raises(AttributeError):
         cfg.cluster_threshold = 99  # type: ignore[misc]
     with pytest.raises(AttributeError):
         cfg.intake_event_types.append("hack")  # type: ignore[attr-defined]

--- a/tests/test_digest_handler.py
+++ b/tests/test_digest_handler.py
@@ -1,22 +1,44 @@
-"""Tests for M20 / BL-077 daily digest handler."""
+"""Tests for M23 / BL-095 daily digest handler.
+
+Covers:
+
+* Prompt v2 — four-question structure
+* Input-hash idempotency gate (skip LLM when prior digest matches)
+* No-data path (don't fabricate insight from old crystals)
+* Schema v2 frontmatter (operator-local timestamps + preflight)
+* Audit events (digest_generated, digest_skipped_no_change)
+
+BL-094's input collector is exercised separately in
+``test_digest_inputs.py``; this file builds on top of a real
+``collect_digest_inputs`` against an in-memory ``knowledge.db``.
+"""
 
 from __future__ import annotations
 
 import json
+import re
 import sqlite3
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 import pytest
 
 from ovp_pipeline.commands.digest_handler import (
-    _build_digest_user_prompt,
-    _collect_digest_inputs,
+    DIGESTS_SUBDIR,
+    SCHEMA_VERSION,
+    _build_digest_user_prompt_v2,
     _enqueue_daily,
+    _expected_output_path,
+    _is_no_data,
     _latest_digest,
+    _read_prior_digest,
     handle_digest,
     main,
 )
 from ovp_pipeline.commands.task_dispatch import TaskContext
+from ovp_pipeline.digest_config import DigestConfig
+from ovp_pipeline.digest_inputs import collect_digest_inputs
 
 
 # ── Fixtures ──────────────────────────────────────────────────────
@@ -27,8 +49,9 @@ class _FakeLLM:
         self.response = response
         self.calls: list[tuple[str, str]] = []
 
-    def call(self, system_prompt: str, user_prompt: str,
-             max_tokens: int = 0) -> str:
+    def call(
+        self, system_prompt: str, user_prompt: str, max_tokens: int = 0
+    ) -> str:
         self.calls.append((system_prompt, user_prompt))
         return self.response
 
@@ -42,290 +65,368 @@ def _make_vault(tmp_path: Path) -> Path:
     return vault
 
 
-def _seed_knowledge_db(
-    vault: Path,
-    *,
-    pack: str = "research-tech",
-    tensions: int = 0,
-    themes: int = 0,
-    open_qs: int = 0,
-) -> None:
-    """Create the three crystal tables and seed them with minimal
-    deterministic rows.  Bypasses the full truth_store schema since
-    the digest handler only reads these specific columns."""
+def _make_knowledge_db(vault: Path) -> sqlite3.Connection:
+    """Same schema BL-094 tests build — kept local so test_digest_handler
+    can run without sharing fixtures across modules."""
     db_path = vault / "60-Logs" / "knowledge.db"
     db_path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(db_path)
-    try:
-        conn.executescript(
-            """
-            CREATE TABLE community_crystals (
-              pack TEXT NOT NULL,
-              cluster_id TEXT NOT NULL,
-              body_md TEXT NOT NULL,
-              source_evergreen_slugs_json TEXT NOT NULL,
-              synthesized_at TEXT NOT NULL,
-              llm_model TEXT NOT NULL,
-              prompt_version TEXT NOT NULL,
-              superseded_by_synthesized_at TEXT NOT NULL DEFAULT '',
-              PRIMARY KEY (pack, cluster_id, synthesized_at)
-            );
-            CREATE TABLE contradiction_crystals (
-              pack TEXT NOT NULL,
-              contradiction_id TEXT NOT NULL,
-              subject_key TEXT NOT NULL,
-              body_md TEXT NOT NULL,
-              positive_claim_ids_json TEXT NOT NULL,
-              negative_claim_ids_json TEXT NOT NULL,
-              source_object_ids_json TEXT NOT NULL,
-              synthesized_at TEXT NOT NULL,
-              llm_model TEXT NOT NULL,
-              prompt_version TEXT NOT NULL,
-              superseded_by_synthesized_at TEXT NOT NULL DEFAULT '',
-              PRIMARY KEY (pack, contradiction_id, synthesized_at)
-            );
-            CREATE TABLE crystal_scores (
-              pack TEXT NOT NULL,
-              crystal_kind TEXT NOT NULL,
-              crystal_id TEXT NOT NULL,
-              score REAL NOT NULL,
-              size_norm REAL NOT NULL DEFAULT 0,
-              credibility_norm REAL NOT NULL DEFAULT 0,
-              contradiction_norm REAL NOT NULL DEFAULT 0,
-              reuse_recency_norm REAL NOT NULL DEFAULT 0,
-              evergreen_recency_norm REAL NOT NULL DEFAULT 0,
-              source_diversity_norm REAL NOT NULL DEFAULT 0,
-              computed_at TEXT NOT NULL,
-              PRIMARY KEY (pack, crystal_kind, crystal_id)
-            );
-            CREATE TABLE graph_clusters (
-              pack TEXT NOT NULL,
-              cluster_id TEXT NOT NULL,
-              cluster_kind TEXT NOT NULL,
-              label TEXT NOT NULL,
-              center_object_id TEXT NOT NULL DEFAULT '',
-              member_object_ids_json TEXT NOT NULL DEFAULT '[]',
-              score REAL NOT NULL DEFAULT 0,
-              PRIMARY KEY (pack, cluster_id)
-            );
-            """
+    conn.executescript("""
+        CREATE TABLE audit_events (
+            source_log TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            slug TEXT,
+            session_id TEXT,
+            timestamp TEXT NOT NULL,
+            payload_json TEXT
+        );
+        CREATE TABLE evergreen_revisions (
+            pack TEXT NOT NULL,
+            object_id TEXT NOT NULL,
+            version INTEGER NOT NULL,
+            content_md TEXT NOT NULL,
+            change_type TEXT NOT NULL,
+            changed_by TEXT NOT NULL,
+            derived_at TEXT NOT NULL,
+            change_note TEXT
+        );
+        CREATE TABLE objects (
+            pack TEXT NOT NULL,
+            object_id TEXT NOT NULL,
+            object_kind TEXT NOT NULL,
+            title TEXT NOT NULL,
+            canonical_path TEXT,
+            source_slug TEXT,
+            source_url TEXT
+        );
+        CREATE TABLE graph_clusters (
+            pack TEXT NOT NULL,
+            cluster_id TEXT NOT NULL,
+            cluster_kind TEXT NOT NULL,
+            label TEXT,
+            center_object_id TEXT,
+            member_object_ids_json TEXT,
+            score REAL
+        );
+        CREATE TABLE community_crystals (
+            pack TEXT NOT NULL,
+            cluster_id TEXT NOT NULL,
+            body_md TEXT NOT NULL,
+            source_evergreen_slugs_json TEXT,
+            synthesized_at TEXT NOT NULL,
+            llm_model TEXT,
+            prompt_version TEXT,
+            superseded_by_synthesized_at TEXT NOT NULL DEFAULT ''
+        );
+        CREATE TABLE contradiction_crystals (
+            pack TEXT NOT NULL,
+            contradiction_id TEXT NOT NULL,
+            subject_key TEXT,
+            body_md TEXT NOT NULL,
+            source_object_ids_json TEXT,
+            synthesized_at TEXT NOT NULL,
+            superseded_by_synthesized_at TEXT NOT NULL DEFAULT ''
+        );
+        CREATE TABLE crystal_scores (
+            pack TEXT NOT NULL,
+            crystal_id TEXT NOT NULL,
+            crystal_kind TEXT NOT NULL,
+            score REAL NOT NULL
+        );
+    """)
+    conn.commit()
+    return conn
+
+
+def _seed_window_with_signal(
+    vault: Path, *, as_of: datetime, evergreens: int = 2
+) -> None:
+    """Seed enough rows that ``_is_no_data`` returns False."""
+    conn = _make_knowledge_db(vault)
+    for i in range(evergreens):
+        ts = (as_of - timedelta(hours=2, minutes=i)).isoformat()
+        conn.execute(
+            "INSERT INTO evergreen_revisions VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "research-tech", f"evg-{i}", 1, "## content",
+                "created", "absorber", ts, "lifecycle=promote",
+            ),
         )
-
-        from datetime import datetime, timezone
-        now = datetime.now(timezone.utc).isoformat(timespec="seconds")
-
-        for i in range(tensions):
-            cid = f"contradict::t{i}"
-            conn.execute(
-                "INSERT INTO contradiction_crystals VALUES (?,?,?,?,?,?,?,?,?,?,?)",
-                (
-                    pack, cid, f"subject {i}",
-                    f"body of tension {i}", "[]", "[]", "[]",
-                    now, "test-model", "v1", "",
-                ),
-            )
-            conn.execute(
-                "INSERT INTO crystal_scores VALUES (?,?,?,?,?,?,?,?,?,?,?)",
-                (
-                    pack, "contradiction", cid,
-                    0.9 - 0.1 * i,  # descending scores
-                    0.5, 0.5, 0.5, 0.0, 0.5, 0.5, now,
-                ),
-            )
-
-        for i in range(themes):
-            cluster_id = f"cluster::theme-{i}"
-            conn.execute(
-                "INSERT INTO graph_clusters VALUES (?,?,?,?,?,?,?)",
-                (
-                    pack, cluster_id, "louvain_community",
-                    f"Theme {i}", "", "[]", 1.0,
-                ),
-            )
-            conn.execute(
-                "INSERT INTO community_crystals VALUES (?,?,?,?,?,?,?,?)",
-                (
-                    pack, cluster_id, f"body of theme {i}", "[]",
-                    now, "test-model", "v1", "",
-                ),
-            )
-
-        for i in range(open_qs):
-            cid = f"contradict::oq-{i}"
-            conn.execute(
-                "INSERT INTO contradiction_crystals VALUES (?,?,?,?,?,?,?,?,?,?,?)",
-                (
-                    pack, cid, f"open question {i}",
-                    f"body of open question {i}", "[]", "[]", "[]",
-                    now, "test-model", "v1", "",
-                ),
-            )
-
-        conn.commit()
-    finally:
-        conn.close()
+        conn.execute(
+            "INSERT INTO objects VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("research-tech", f"evg-{i}", "evergreen", f"Title {i}", "", "", ""),
+        )
+    # One intake event in window.
+    intake_ts = (as_of - timedelta(minutes=10)).isoformat()
+    conn.execute(
+        "INSERT INTO audit_events VALUES (?, ?, ?, ?, ?, ?)",
+        ("pipeline.jsonl", "article_processed", "slug-x", "s",
+         intake_ts, json.dumps({"title": "Memory systems intro"})),
+    )
+    conn.commit()
+    conn.close()
 
 
-# ── _collect_digest_inputs ───────────────────────────────────────
-
-
-def test_collect_returns_empty_when_db_missing(tmp_path: Path):
-    vault = _make_vault(tmp_path)
-    out = _collect_digest_inputs(vault, "research-tech")
-    assert out == {"tensions": [], "themes": [], "open_questions": []}
-
-
-def test_collect_returns_top_tensions_descending_by_score(tmp_path: Path):
-    vault = _make_vault(tmp_path)
-    _seed_knowledge_db(vault, tensions=5)
-    out = _collect_digest_inputs(vault, "research-tech")
-    assert len(out["tensions"]) == 3  # TOP_TENSIONS_N
-    scores = [t["score"] for t in out["tensions"]]
-    assert scores == sorted(scores, reverse=True)
-
-
-def test_collect_does_not_double_count_open_questions(tmp_path: Path):
-    """An open question that already appears in ``tensions`` (top-
-    scoring contradictions) is excluded from ``open_questions`` so
-    the digest doesn't surface the same contradiction twice."""
-    vault = _make_vault(tmp_path)
-    _seed_knowledge_db(vault, tensions=3, open_qs=0)
-    out = _collect_digest_inputs(vault, "research-tech")
-    tension_ids = {t["id"] for t in out["tensions"]}
-    open_ids = {q["id"] for q in out["open_questions"]}
-    assert not (tension_ids & open_ids)
-
-
-def test_collect_recent_themes_only(tmp_path: Path):
-    vault = _make_vault(tmp_path)
-    _seed_knowledge_db(vault, themes=2)
-    out = _collect_digest_inputs(vault, "research-tech")
-    assert len(out["themes"]) == 2
-    assert all("Theme" in t["label"] for t in out["themes"])
-
-
-# ── handle_digest ────────────────────────────────────────────────
-
-
-def test_handle_digest_empty_vault_skips_llm(tmp_path: Path):
-    """Empty vault: handler must NOT call the LLM (token waste) and
-    must emit a stub digest with a "nothing new to surface" body."""
-    vault = _make_vault(tmp_path)
-    llm = _FakeLLM("should-not-be-called")
+def _ctx(vault: Path, llm: _FakeLLM) -> TaskContext:
     task = vault / "50-Inbox" / "02-Tasks" / "DIGEST-daily.md"
-    task.write_text("auto-enqueued", encoding="utf-8")
-
-    ctx = TaskContext(
+    task.write_text("auto", encoding="utf-8")
+    return TaskContext(
         vault_dir=vault, task_path=task, prefix="DIGEST",
         slug="daily", body="", pack="research-tech", llm_client=llm,
     )
-    result = handle_digest(ctx)
-
-    assert llm.calls == []  # LLM untouched
-    assert "Nothing new to surface" in result.body_md
-    assert result.subdir == "digests"
-    assert result.metadata == {
-        "tensions": 0, "themes": 0, "open_questions": 0,
-    }
 
 
-def test_handle_digest_with_data_calls_llm(tmp_path: Path):
+# ── No-data path ───────────────────────────────────────────────────
+
+
+def test_no_data_path_skips_llm(tmp_path: Path):
+    """Empty vault: handler MUST NOT call the LLM (token waste)
+    and renders an honest "no intake" body."""
     vault = _make_vault(tmp_path)
-    _seed_knowledge_db(vault, tensions=2, themes=2, open_qs=0)
+    # No knowledge.db at all — preflight degrades to unavailable.
+    llm = _FakeLLM("must-not-be-called")
+    result = handle_digest(_ctx(vault, llm))
+    assert llm.calls == []
+    assert "No new intake in this window." in result.body_md
+    assert result.metadata["skipped_llm"] is True
+    assert result.metadata["reason"] == "no_data"
+    assert result.subdir == DIGESTS_SUBDIR
+
+
+def test_is_no_data_detects_real_signal(tmp_path: Path):
+    """When any layer has signal, _is_no_data returns False so the
+    handler enters the LLM branch."""
+    vault = _make_vault(tmp_path)
+    as_of = datetime.now(timezone.utc) - timedelta(minutes=30)
+    _seed_window_with_signal(vault, as_of=as_of)
+    inputs = collect_digest_inputs(
+        vault, "research-tech",
+        as_of=datetime.now(timezone.utc),
+        config=DigestConfig(tz="UTC"),
+    )
+    assert _is_no_data(inputs) is False
+
+
+# ── LLM call path ──────────────────────────────────────────────────
+
+
+def test_calls_llm_with_v2_prompt_when_signal_present(tmp_path: Path):
+    """With data, the handler calls the LLM exactly once with a
+    prompt that mentions the v2 section headings."""
+    vault = _make_vault(tmp_path)
+    as_of = datetime.now(timezone.utc) - timedelta(minutes=30)
+    _seed_window_with_signal(vault, as_of=as_of, evergreens=2)
     llm = _FakeLLM(
-        "## Tensions worth sitting with\nA vs B.\n\n"
-        "## Themes you keep circling\nTheme zero recurred.\n"
+        "## Window's intake\nOne intake.\n\n## Worth doing next\nResolve.\n"
     )
-    task = vault / "50-Inbox" / "02-Tasks" / "DIGEST-daily.md"
-    task.write_text("", encoding="utf-8")
-
-    ctx = TaskContext(
-        vault_dir=vault, task_path=task, prefix="DIGEST",
-        slug="daily", body="", pack="research-tech", llm_client=llm,
-    )
-    result = handle_digest(ctx)
-
+    result = handle_digest(_ctx(vault, llm))
     assert len(llm.calls) == 1
     sys_prompt, user_prompt = llm.calls[0]
-    assert "daily-digest handler" in sys_prompt
-    assert "subject 0" in user_prompt
-    assert "Theme 0" in user_prompt
-    assert "A vs B" in result.body_md
-    assert "Digest —" in result.body_md
-    assert result.metadata["tensions"] == 2
-    assert result.metadata["themes"] == 2
+    assert "daily-feedback handler" in sys_prompt
+    assert "Layer 0" in user_prompt
+    assert "Layer 1" in user_prompt
+    assert "Layer 3" in user_prompt
+    # New body shape — operator-local timestamps in frontmatter.
+    assert "schema_version: 2" in result.body_md
+    assert "input_hash:" in result.body_md
+    assert "Daily Knowledge Feedback" in result.body_md
+    assert result.metadata["skipped_llm"] is False
+    assert result.metadata["layer1_new"] == 2
 
 
-def test_handle_digest_injects_user_focus(tmp_path: Path):
+def test_frontmatter_contains_preflight_block(tmp_path: Path):
+    """Preflight degradation must show up in the frontmatter so the
+    Reader / digest-health page can read per-section state."""
+    vault = _make_vault(tmp_path)
+    as_of = datetime.now(timezone.utc) - timedelta(minutes=30)
+    _seed_window_with_signal(vault, as_of=as_of)
+    llm = _FakeLLM("body")
+    result = handle_digest(_ctx(vault, llm))
+    assert "preflight:" in result.body_md
+    assert "evergreen_revisions_table:" in result.body_md
+    # Generic change_note (lifecycle=promote seed) → degraded.
+    assert "change_note_quality: degraded" in result.body_md
+
+
+def test_audit_event_emitted_on_generate(tmp_path: Path):
+    """``digest_generated`` lands in pipeline.jsonl with input_hash + layer counts."""
+    vault = _make_vault(tmp_path)
+    as_of = datetime.now(timezone.utc) - timedelta(minutes=30)
+    _seed_window_with_signal(vault, as_of=as_of)
+    llm = _FakeLLM("body")
+    handle_digest(_ctx(vault, llm))
+    log_path = vault / "60-Logs" / "pipeline.jsonl"
+    rows = [json.loads(l) for l in log_path.read_text(encoding="utf-8").splitlines() if l]
+    gen_events = [r for r in rows if r.get("event_type") == "digest_generated"]
+    assert len(gen_events) == 1
+    payload = gen_events[0]
+    assert payload["skipped_llm"] is False
+    assert "input_hash" in payload
+    assert payload["layer1_new"] == 2
+
+
+# ── Idempotency gate ───────────────────────────────────────────────
+
+
+def test_idempotency_skips_llm_when_prior_hash_matches(tmp_path: Path):
+    """First run writes a digest; second run with identical inputs
+    must NOT call the LLM and must emit digest_skipped_no_change."""
+    vault = _make_vault(tmp_path)
+    as_of = datetime.now(timezone.utc) - timedelta(minutes=30)
+    _seed_window_with_signal(vault, as_of=as_of)
+    llm1 = _FakeLLM("first")
+    result1 = handle_digest(_ctx(vault, llm1))
+    # Persist result1 to disk at the path the gate will look for.
+    output_path = _expected_output_path(vault)
+    output_path.write_text(result1.body_md, encoding="utf-8")
+
+    # Second run: same data → same hash → skip.
+    llm2 = _FakeLLM("should-not-be-called")
+    result2 = handle_digest(_ctx(vault, llm2))
+    assert llm2.calls == []
+    assert result2.metadata["skipped_llm"] is True
+    assert result2.metadata["reason"] == "no_change"
+    # Same body comes back so the dispatcher's overwrite is a no-op.
+    assert result2.body_md == result1.body_md
+
+    # The skip event lands in pipeline.jsonl.
+    log_path = vault / "60-Logs" / "pipeline.jsonl"
+    rows = [json.loads(l) for l in log_path.read_text(encoding="utf-8").splitlines() if l]
+    skips = [r for r in rows if r.get("event_type") == "digest_skipped_no_change"]
+    assert len(skips) == 1
+
+
+def test_idempotency_calls_llm_when_data_changes(tmp_path: Path):
+    """Adding a new evergreen between runs changes the input_hash
+    and forces the LLM call."""
+    vault = _make_vault(tmp_path)
+    as_of = datetime.now(timezone.utc) - timedelta(minutes=30)
+    _seed_window_with_signal(vault, as_of=as_of, evergreens=1)
+    llm1 = _FakeLLM("first body")
+    result1 = handle_digest(_ctx(vault, llm1))
+    _expected_output_path(vault).write_text(result1.body_md, encoding="utf-8")
+
+    # New evergreen lands.
+    conn = sqlite3.connect(vault / "60-Logs" / "knowledge.db")
+    conn.execute(
+        "INSERT INTO evergreen_revisions VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            "research-tech", "evg-new", 1, "## new",
+            "created", "absorber",
+            (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat(),
+            "lifecycle=promote",
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    llm2 = _FakeLLM("second body")
+    result2 = handle_digest(_ctx(vault, llm2))
+    assert len(llm2.calls) == 1
+    assert result2.metadata["skipped_llm"] is False
+
+
+def test_skip_unchanged_disabled_forces_llm(tmp_path: Path):
+    """``skip_unchanged: false`` in config disables the gate."""
+    vault = _make_vault(tmp_path)
+    as_of = datetime.now(timezone.utc) - timedelta(minutes=30)
+    _seed_window_with_signal(vault, as_of=as_of)
+    (vault / ".ovp").mkdir(exist_ok=True)
+    (vault / ".ovp" / "digest.yaml").write_text(
+        "skip_unchanged: false\n", encoding="utf-8"
+    )
+
+    # First run writes the file.
+    llm1 = _FakeLLM("first")
+    result1 = handle_digest(_ctx(vault, llm1))
+    _expected_output_path(vault).write_text(result1.body_md, encoding="utf-8")
+
+    # Second run: gate is OFF, LLM must be called even with same data.
+    llm2 = _FakeLLM("second")
+    result2 = handle_digest(_ctx(vault, llm2))
+    assert len(llm2.calls) == 1
+    assert result2.metadata["skipped_llm"] is False
+
+
+# ── _read_prior_digest helper ──────────────────────────────────────
+
+
+def test_read_prior_digest_returns_empty_for_missing_file(tmp_path: Path):
+    h, body = _read_prior_digest(tmp_path / "nope.md")
+    assert h == ""
+    assert body == ""
+
+
+def test_read_prior_digest_extracts_input_hash(tmp_path: Path):
+    path = tmp_path / "d.md"
+    path.write_text(
+        "---\ntype: digest\ninput_hash: abc123\nfoo: bar\n---\n\n# Body\n",
+        encoding="utf-8",
+    )
+    h, body = _read_prior_digest(path)
+    assert h == "abc123"
+    assert body.startswith("---\n")
+
+
+# ── User-focus injection (preserves M20 behavior) ──────────────────
+
+
+def test_user_focus_flows_into_v2_prompt(tmp_path: Path):
     vault = _make_vault(tmp_path)
     (vault / "00-Polaris").mkdir(exist_ok=True)
     (vault / "00-Polaris" / "USER.md").write_text(
         "# About Me\nFocus: memory systems.\n", encoding="utf-8",
     )
-    _seed_knowledge_db(vault, tensions=1, themes=1, open_qs=0)
-    llm = _FakeLLM("composed")
-    task = vault / "50-Inbox" / "02-Tasks" / "DIGEST-daily.md"
-    task.write_text("", encoding="utf-8")
-
-    ctx = TaskContext(
-        vault_dir=vault, task_path=task, prefix="DIGEST",
-        slug="daily", body="", pack="research-tech", llm_client=llm,
-    )
-    handle_digest(ctx)
-
+    as_of = datetime.now(timezone.utc) - timedelta(minutes=30)
+    _seed_window_with_signal(vault, as_of=as_of)
+    llm = _FakeLLM("body")
+    handle_digest(_ctx(vault, llm))
     sys_prompt, user_prompt = llm.calls[0]
-    # USER.md profile shows up in both the system prefix (via
-    # llm_prefix) and the user prompt (via load_user_profile direct
-    # injection in _build_digest_user_prompt).
-    assert "Focus: memory systems" in sys_prompt
+    # USER.md → load_user_profile → injected into user prompt block.
     assert "Focus: memory systems" in user_prompt
 
 
-# ── _build_digest_user_prompt formatting ────────────────────────
+# ── _build_digest_user_prompt_v2 ───────────────────────────────────
 
 
-def test_build_user_prompt_omits_empty_sections():
-    prompt = _build_digest_user_prompt(
-        {"tensions": [], "themes": [], "open_questions": []},
-        user_focus="",
+def test_build_user_prompt_omits_empty_data_gracefully(tmp_path: Path):
+    """With no signal, the prompt still renders all four layer
+    headings but each section honestly reports "no" — the LLM
+    is told what's empty rather than having sections invisibly dropped."""
+    vault = _make_vault(tmp_path)
+    _make_knowledge_db(vault).close()
+    inputs = collect_digest_inputs(
+        vault, "research-tech",
+        as_of=datetime.now(timezone.utc),
+        config=DigestConfig(tz="UTC"),
     )
-    assert "(none)" in prompt
-    # No tension / theme content because all lists empty.
-    assert "score" not in prompt.lower()
+    prompt = _build_digest_user_prompt_v2(inputs, "")
+    assert "Layer 0 — Today's intake" in prompt
+    assert "Layer 1 — Evergreen delta" in prompt
+    assert "Layer 2 — Connections" in prompt
+    assert "Layer 3 — Pipeline state" in prompt
+    assert "(no intake events in this window)" in prompt
+    assert "(no new or updated evergreens in this window)" in prompt
 
 
-def test_build_user_prompt_includes_user_focus():
-    prompt = _build_digest_user_prompt(
-        {"tensions": [], "themes": [], "open_questions": []},
-        user_focus="Hyperfocus on agent memory.",
-    )
-    assert "Hyperfocus on agent memory." in prompt
-
-
-# ── CLI ──────────────────────────────────────────────────────────
+# ── CLI surface (unchanged from M20) ───────────────────────────────
 
 
 def test_enqueue_daily_creates_task_file(tmp_path: Path):
     vault = _make_vault(tmp_path)
     path = _enqueue_daily(vault)
-    assert path.name == "DIGEST-daily.md"
     assert path.exists()
-    # Idempotent: second call returns same path, doesn't overwrite.
-    path.write_text("hand-edited content", encoding="utf-8")
-    second = _enqueue_daily(vault)
-    assert second == path
-    assert path.read_text(encoding="utf-8") == "hand-edited content"
+    assert path.name == "DIGEST-daily.md"
 
 
 def test_latest_digest_returns_most_recent(tmp_path: Path):
     vault = _make_vault(tmp_path)
     folder = vault / "40-Resources" / "Generated" / "digests"
-    (folder / "2026-05-09.md").write_text("# old", encoding="utf-8")
-    (folder / "2026-05-11.md").write_text("# new", encoding="utf-8")
-    (folder / "2026-05-10.md").write_text("# mid", encoding="utf-8")
-    latest = _latest_digest(vault)
-    assert latest is not None
-    assert latest.name == "2026-05-11.md"
+    older = folder / "2026-05-11-digest-daily.md"
+    newer = folder / "2026-05-12-digest-daily.md"
+    older.write_text("a", encoding="utf-8")
+    newer.write_text("b", encoding="utf-8")
+    assert _latest_digest(vault) == newer
 
 
 def test_latest_digest_returns_none_when_empty(tmp_path: Path):
@@ -337,9 +438,8 @@ def test_cli_enqueue_daily(tmp_path: Path, capsys):
     vault = _make_vault(tmp_path)
     rc = main(["--vault-dir", str(vault), "--enqueue-daily"])
     assert rc == 0
-    assert (vault / "50-Inbox" / "02-Tasks" / "DIGEST-daily.md").exists()
-    out = capsys.readouterr().out
-    assert "enqueued" in out
+    out = capsys.readouterr().out.strip()
+    assert out.endswith("DIGEST-daily.md")
 
 
 def test_cli_show_latest_empty(tmp_path: Path, capsys):
@@ -349,7 +449,15 @@ def test_cli_show_latest_empty(tmp_path: Path, capsys):
     assert "(no digests yet)" in capsys.readouterr().out
 
 
-def test_cli_requires_action(tmp_path: Path):
-    vault = _make_vault(tmp_path)
-    with pytest.raises(SystemExit):
-        main(["--vault-dir", str(vault)])
+# ── Schema version + filename surface ──────────────────────────────
+
+
+def test_schema_version_bumped_to_2():
+    assert SCHEMA_VERSION == 2
+
+
+def test_expected_output_path_matches_dispatcher_filename(tmp_path: Path):
+    path = _expected_output_path(tmp_path)
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    assert path.name == f"{today}-digest-daily.md"
+    assert path.parent.name == DIGESTS_SUBDIR

--- a/tests/test_digest_handler.py
+++ b/tests/test_digest_handler.py
@@ -52,6 +52,11 @@ class _FakeLLM:
     def call(
         self, system_prompt: str, user_prompt: str, max_tokens: int = 0
     ) -> str:
+        # max_tokens is part of the test-double's keyword API the
+        # real LLM client exposes; keep the public name even though
+        # this fake doesn't read the value (CodeRabbit nit reverted
+        # because the handler calls ``llm.call(..., max_tokens=1200)``).
+        del max_tokens
         self.calls.append((system_prompt, user_prompt))
         return self.response
 
@@ -256,7 +261,7 @@ def test_audit_event_emitted_on_generate(tmp_path: Path):
     llm = _FakeLLM("body")
     handle_digest(_ctx(vault, llm))
     log_path = vault / "60-Logs" / "pipeline.jsonl"
-    rows = [json.loads(l) for l in log_path.read_text(encoding="utf-8").splitlines() if l]
+    rows = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines() if line]
     gen_events = [r for r in rows if r.get("event_type") == "digest_generated"]
     assert len(gen_events) == 1
     payload = gen_events[0]
@@ -291,7 +296,7 @@ def test_idempotency_skips_llm_when_prior_hash_matches(tmp_path: Path):
 
     # The skip event lands in pipeline.jsonl.
     log_path = vault / "60-Logs" / "pipeline.jsonl"
-    rows = [json.loads(l) for l in log_path.read_text(encoding="utf-8").splitlines() if l]
+    rows = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines() if line]
     skips = [r for r in rows if r.get("event_type") == "digest_skipped_no_change"]
     assert len(skips) == 1
 
@@ -381,7 +386,7 @@ def test_user_focus_flows_into_v2_prompt(tmp_path: Path):
     _seed_window_with_signal(vault, as_of=as_of)
     llm = _FakeLLM("body")
     handle_digest(_ctx(vault, llm))
-    sys_prompt, user_prompt = llm.calls[0]
+    _sys_prompt, user_prompt = llm.calls[0]
     # USER.md → load_user_profile → injected into user prompt block.
     assert "Focus: memory systems" in user_prompt
 

--- a/tests/test_digest_handler.py
+++ b/tests/test_digest_handler.py
@@ -192,7 +192,14 @@ def test_no_data_path_skips_llm(tmp_path: Path):
     llm = _FakeLLM("must-not-be-called")
     result = handle_digest(_ctx(vault, llm))
     assert llm.calls == []
-    assert "No new intake in this window." in result.body_md
+    # Without audit_events, the body says "Intake data unavailable"
+    # rather than the misleading "No new intake" (CodeRabbit fix).
+    # Both forms appear under "## Window's intake".
+    assert "## Window's intake" in result.body_md
+    assert (
+        "No new intake in this window." in result.body_md
+        or "Intake data unavailable" in result.body_md
+    )
     assert result.metadata["skipped_llm"] is True
     assert result.metadata["reason"] == "no_data"
     assert result.subdir == DIGESTS_SUBDIR

--- a/tests/test_pr208_round3_followups.py
+++ b/tests/test_pr208_round3_followups.py
@@ -2,9 +2,12 @@
 
 Covers:
 
-* ``_decode_slugs`` rejects non-list JSON (rev-bot 208 round-2 #5).
-* ``_build_sources_section`` strips wikilink delimiters from
+* ``_safe_wikilink`` strips wikilink delimiters from
   operator-supplied labels / slugs (rev-bot 208 round-2 #6).
+  Originally tested via ``_build_sources_section`` against the M20
+  dict-shape inputs; M23 rewrote the sources block to consume
+  ``DigestInputs`` (BL-095), so the delimiter-safety invariant now
+  lives in ``_safe_wikilink`` directly.
 * ``_render_frontmatter_details`` skips the disclosure block when
   the file has no frontmatter (rev-bot 208 round-2 #4).
 * ``_evolution_candidate_lock`` returns distinct locks for
@@ -21,82 +24,43 @@ from pathlib import Path
 
 from ovp_pipeline._truth_helpers import _evolution_candidate_lock
 from ovp_pipeline.commands._ui_renderers import _render_frontmatter_details
-from ovp_pipeline.commands.digest_handler import _build_sources_section
-
-
-# ── _decode_slugs robustness via _build_sources_section ──────────
-
-
-def test_sources_section_tolerates_null_json_payload():
-    """A row whose ``source_evergreen_slugs_json`` was stored as
-    ``null`` (or any non-list) must not abort digest generation."""
-    inputs = {
-        "tensions": [],
-        # Themes carry the suspect field; if _decode_slugs
-        # crashes, this call raises.
-        "themes": [
-            {
-                "cluster_id": "cluster::abc",
-                "label": "Theme A",
-                "source_evergreen_slugs": [],  # decoded already
-            },
-        ],
-        "open_questions": [],
-    }
-    md = _build_sources_section(inputs)
-    assert "Crystals" in md
-    assert "Theme A" in md
+from ovp_pipeline.commands.digest_handler import _safe_wikilink
 
 
 # ── wikilink delimiter sanitisation ─────────────────────────────
 
 
-def test_sources_section_strips_label_delimiters():
-    """``]]`` and ``|`` in a label would close or split the
-    wikilink prematurely; both must be stripped."""
-    inputs = {
-        "tensions": [],
-        "themes": [
-            {
-                "cluster_id": "cluster::abc",
-                "label": "Tricky ]] | label\nwith newline",
-                "source_evergreen_slugs": [],
-            },
-        ],
-        "open_questions": [],
-    }
-    md = _build_sources_section(inputs)
-    # The crystal link is rendered with the safe-id as target and
-    # a sanitised label.  No nested ]] or | inside the wikilink.
-    crystal_line = [
-        ln for ln in md.splitlines() if ln.startswith("- [[abc")
-    ][0]
-    # Exactly two ``]]`` (the closing bracket of the wikilink)
-    # and exactly one ``|`` (the target/label separator).
-    assert crystal_line.count("]]") == 1
-    assert crystal_line.count("|") == 1
-    assert "\n" not in crystal_line
+def test_safe_wikilink_strips_closing_brackets():
+    """``]`` would close the wikilink prematurely; both ``[`` and
+    ``]`` are stripped to whitespace."""
+    assert "]" not in _safe_wikilink("trailing]]bad")
+    assert "[" not in _safe_wikilink("[[wrapped]]")
 
 
-def test_sources_section_strips_slug_delimiters():
-    """Evergreen slug rows likewise sanitise on render."""
-    inputs = {
-        "tensions": [],
-        "themes": [
-            {
-                "cluster_id": "cluster::abc",
-                "label": "Theme",
-                "source_evergreen_slugs": ["bad]]slug", "ok-slug"],
-            },
-        ],
-        "open_questions": [],
-    }
-    md = _build_sources_section(inputs)
-    # The bad slug's ``]]`` was stripped — no nested ``]]``
-    # inside any single evergreen row.
-    for line in md.splitlines():
-        if line.startswith("- [[") and "Theme" not in line:
-            assert line.count("]]") == 1
+def test_safe_wikilink_strips_pipe():
+    """``|`` is the wikilink target/label separator — stripping it
+    avoids accidentally splitting a single value into two parts."""
+    assert "|" not in _safe_wikilink("a|b|c")
+
+
+def test_safe_wikilink_strips_newlines():
+    """Newlines would break out of the surrounding list item."""
+    assert "\n" not in _safe_wikilink("line1\nline2")
+
+
+def test_safe_wikilink_handles_falsy():
+    """``None`` / empty / falsy inputs degrade to ``''`` via
+    ``str(value or "")`` — the implementation collapses any falsy
+    value (incl. ``0``) so the surrounding wikilink doesn't render
+    a bogus ``[[0]]`` row from a missing-int field."""
+    assert _safe_wikilink(None) == ""
+    assert _safe_wikilink("") == ""
+    assert _safe_wikilink(0) == ""
+
+
+def test_safe_wikilink_preserves_safe_chars():
+    """Hyphens, underscores, alphanumerics, colons survive."""
+    assert _safe_wikilink("cluster::memory-systems_v2") == "cluster::memory-systems_v2"
 
 
 # ── _render_frontmatter_details elision ─────────────────────────


### PR DESCRIPTION
## Summary

Replaces M20's crystal-only handler with M23's four-question structure: today's intake, new thinking, connections to prior knowledge, pipeline backpressure, next question.  Consumes BL-094's ``DigestInputs`` (PR #223).

### Prompt v2 (``_DIGEST_SYSTEM_PROMPT_V2``)

- Drops the M20 *"no call to action"* rule — the digest should change operator behavior, not just provoke contemplation.
- Demands article-awareness without article-summary: chip-style topic counts, not raw title dumps.
- Tells the LLM when ``change_note`` quality is degraded so it falls back to title + cluster context for prose instead of surfacing ``v2: updated`` verbatim.
- Omits sections entirely when their input is empty — honest no-data instead of fabricated insight.

### Schema v2 frontmatter

```yaml
type: digest
schema_version: 2
generated_at: 2026-05-13T12:00:00-07:00          # operator-local, not UTC
window_start: 2026-05-13T00:00:00-07:00
window_end: 2026-05-13T12:00:00-07:00
tz: America/Los_Angeles
pack: research-tech
input_hash: 95191f42cc...                         # for the gate (below)
preflight:
  evergreen_revisions_table: ok
  evergreen_revisions_recent: ok
  audit_events_layer0: degraded
  change_note_quality: degraded
  graph_clusters: ok
  community_crystals: ok
```

### Input-hash idempotency gate

Before calling the LLM, handler reads any prior digest at the expected output path, parses its ``input_hash`` from frontmatter, and skips the LLM call when it matches.  ``digest_skipped_no_change`` lands in pipeline.jsonl with the matching hash so /ops/digest-health (BL-097) can track skip rate.

Hash is **minute-rounded** on window boundaries so back-to-back regenerations within the same minute don't fire a false miss on microsecond drift.  Kills the M20-era *"5 redundant LLM passes in one day"* thrash.

Operator can disable via ``skip_unchanged: false`` in ``<vault>/.ovp/digest.yaml``.

### UTC-normalization bugfix in digest_inputs.py

Pre-fix, the collector bound operator-local ISO timestamps (``...-07:00``) into SQL ``WHERE timestamp >= ?`` against UTC-stored timestamps (``...+00:00`` / ``...Z``).  String comparison is lexicographic, not time-correct, so rows whose hour-prefix happened to lose the lex compare were silently dropped.  Every bind site now goes through ``_utc_iso(dt)``.

### No-data path

Layer 0 + Layer 1 + Layer 2 empty AND Layer 3 carries no actionable signal → handler renders a 2-line acknowledgment with preflight diagnostics rather than calling the LLM.

## Real-vault smoke

```
=== FRONTMATTER ===
schema_version: 2
generated_at: 2026-05-13T12:00:00-07:00
window_start: 2026-05-13T00:00:00-07:00
window_end: 2026-05-13T12:00:00-07:00
preflight:
  audit_events_layer0: degraded
  change_note_quality: degraded
  community_crystals: ok

=== LAYER 3 ===
1 evergreens awaiting (or needing re-) synthesis.
Last synthesis at: 2026-05-05T05:42:26+00:00     ← 8-day lag surfaced honestly
1 open contradiction unresolved.
```

## Test plan

- [x] 19 new tests in ``test_digest_handler.py`` covering prompt v2 contents, idempotency hit/miss, schema-v2 frontmatter shape, ``digest_generated`` + ``digest_skipped_no_change`` audit events, gate disable, no-data path.
- [x] Full suite (2747 tests minus 2 pre-existing file-size + sqlite tech-debt failures): green.
- [x] Real-vault smoke produces operator-local timestamps, deterministic hash, preflight degradation correctly flagged.

## Dependencies + ordering

Built on top of BL-094 (PR #223) — this branch is stacked on ``feat/m23-bl094-digest-inputs`` so the diff against ``main`` includes the BL-094 commit too.  Merge BL-094 first, then this PR rebases to a clean main-diff.

## Out of scope (next BLs)

- BL-096: Reader integration — home banner teaser from new section, /digests intake column, link-only affordances, mid-day regenerate button.
- BL-097: digest_clicked_through + digest_question_acted_on audit events + /ops/digest-health page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Daily digest upgraded to M23 with a layered four-layer snapshot, structured v2 prompt, and richer frontmatter
  * Per-vault digest configuration (timezone, event filters, cluster threshold, mid-day regenerate, idempotency)

* **Improvements**
  * Input-hash idempotency gate to skip redundant LLM calls and an explicit no-data short-acknowledgement path
  * More robust timezone resolution and added window/input metadata in digests

* **Tests**
  * Extensive new and updated tests for config, input collection, handler flows, prompts, and idempotency

* **Chores**
  * Added tzlocal>=5.0 to dependencies

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fakechris/obsidian_vault_pipeline/pull/224)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->