### PR TITLE
feat(m23): BL-096 — Reader integration + mid-day regenerate button

### DIFF
--- a/src/ovp_pipeline/commands/_ui_renderers.py
+++ b/src/ovp_pipeline/commands/_ui_renderers.py
@@ -397,6 +397,33 @@ def _render_chat_drawer_shell() -> str:
     return render_drawer_shell()
 
 
+def _render_digest_regenerate_button(requested_pack: str) -> str:
+    """Render the "Regenerate digest now" button on ``/ops/today``.
+
+    POSTs to ``/ops/digest/regenerate`` which enqueues + dispatches
+    a ``DIGEST-daily`` task synchronously.  With the M23 input-hash
+    gate (BL-095), unchanged-data clicks return the prior body
+    without an LLM call — operators get a cheap "fresh" button.
+    """
+    pack_input = (
+        f"<input type='hidden' name='pack' value='{escape(requested_pack)}' />"
+        if requested_pack
+        else ""
+    )
+    return (
+        "<form method='post' action='/ops/digest/regenerate' "
+        "style='display:inline-block;margin:0.6rem 0 0.2rem 0'>"
+        f"{pack_input}"
+        "<button type='submit' class='btn'>"
+        "Regenerate today's digest"
+        "</button>"
+        " <span class='muted small'>"
+        "Cheap — skips the LLM call when nothing changed since last run."
+        "</span>"
+        "</form>"
+    )
+
+
 def _layout(
     title: str, body: str, *, requested_pack: str = "", auto_refresh_seconds: int | None = None
 ) -> str:
@@ -6538,6 +6565,11 @@ def _render_today_digest_page(payload: dict) -> str:
         f"<strong>{escape(date)}</strong> (UTC).  Click "
         f"<a href='/ops/timeline'>Timeline</a> for the multi-day view.</p>"
     )
+    # M23 BL-096: explicit "Regenerate digest now" affordance so an
+    # operator who drops articles mid-day can immediately trigger a
+    # new digest.  Input-hash gate (BL-095) keeps the cost bounded —
+    # unchanged inputs return the same body without an LLM call.
+    sections.append(_render_digest_regenerate_button(requested_pack))
     sections.append("<div class='grid stats' style='margin-top:1rem'>")
     for card in cards:
         card_id = str(card.get("id") or "")

--- a/src/ovp_pipeline/commands/digest_handler.py
+++ b/src/ovp_pipeline/commands/digest_handler.py
@@ -123,10 +123,24 @@ crystals — clusters with an existing crystal that predates today's
 inputs count as unsynthesized).
 
 ## Worth doing next
-Exactly ONE concrete question or action.  Forms that work well:
-- "3 articles on X converged today. Want to synthesize this cluster?"
-- "Today's new evergreen Y challenges the open contradiction Z.
-  Resolve?"
+Exactly ONE concrete question or action.  When the action involves a
+maintainer step (resolve a contradiction, synthesize a cluster),
+include a plain markdown link to the relevant maintainer page so
+the operator can act in one click:
+
+- For contradiction resolution:
+  `[Resolve contradiction →](/ops/queue/contradictions?status=open)`
+- For synthesis on a specific cluster:
+  `[Open cluster →](/ops/cluster?id=<cluster_id>)`
+- For routine intake review:
+  `[/ops/today →](/ops/today)`
+
+Use real ``cluster_id`` / ``contradiction_id`` values from the input
+layers above; do not invent ids.  Forms that work well:
+- "3 articles on X converged today. Want to synthesize this cluster?
+  [Open cluster →](/ops/cluster?id=cluster::memory-systems)"
+- "Today's new evergreen Y challenges contradiction Z. Resolve?
+  [Resolve contradiction →](/ops/queue/contradictions?status=open)"
 - "Cluster W has N unsynthesized evergreens. Run synthesis?"
 - "No new intake today. Continue with prior tensions, or seed
   the vault?"
@@ -547,7 +561,15 @@ def _render_no_data_body(inputs: DigestInputs) -> str:
 
 
 def _build_frontmatter(inputs: DigestInputs, input_hash: str) -> str:
+    """Compose the schema-v2 frontmatter block.
+
+    Layer-count fields (``intake_events`` / ``new_evergreens`` /
+    ``unsynthesized``) are surfaced explicitly so ``/digests`` (BL-096)
+    can render chip rows for each digest in the index without
+    parsing the body markdown.
+    """
     preflight = inputs.preflight
+    counts = _layer_counts(inputs)
     return (
         "---\n"
         "type: digest\n"
@@ -558,6 +580,11 @@ def _build_frontmatter(inputs: DigestInputs, input_hash: str) -> str:
         f"tz: {inputs.tz_name}\n"
         f"pack: {inputs.pack}\n"
         f"input_hash: {input_hash}\n"
+        f"intake_events: {counts['layer0_events']}\n"
+        f"new_evergreens: {counts['layer1_new']}\n"
+        f"updated_evergreens: {counts['layer1_updated']}\n"
+        f"unsynthesized: {counts['layer3_unsynth']}\n"
+        f"open_contradictions: {counts['layer3_open_contradictions']}\n"
         "preflight:\n"
         f"  evergreen_revisions_table: {preflight.evergreen_revisions_table}\n"
         f"  evergreen_revisions_recent: {preflight.evergreen_revisions_recent}\n"

--- a/src/ovp_pipeline/commands/digest_handler.py
+++ b/src/ovp_pipeline/commands/digest_handler.py
@@ -276,7 +276,9 @@ def _is_no_data(inputs: DigestInputs) -> bool:
     return not (has_intake or has_delta or has_connections or has_pipeline_signal)
 
 
-def _expected_output_path(vault_dir: Path | str) -> Path:
+def _expected_output_path(
+    vault_dir: Path | str, *, date_str: str | None = None
+) -> Path:
     """Compose the filename the dispatcher will write today's digest to.
 
     Mirrors ``task_dispatch._resolve_output_path`` for the DIGEST
@@ -285,8 +287,17 @@ def _expected_output_path(vault_dir: Path | str) -> Path:
     intentional for backwards-compat with the existing
     ``ovp-digest --show-latest`` glob, and operator-local timestamps
     inside the frontmatter make any tz mismatch auditable.
+
+    ``date_str`` lets the caller pin the date explicitly (e.g. from
+    the window the inputs cover, or from the task filename).  Default
+    falls back to UTC-today so today's behavior is unchanged.  A
+    future "regenerate digest for a past date" flow can pass
+    ``date_str=window_end.date().isoformat()`` to get the matching
+    historical file path without the idempotency gate falsely
+    treating it as a fresh day (gemini-code-assist HIGH).
     """
-    date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    if date_str is None:
+        date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     return (
         Path(vault_dir)
         / "40-Resources"

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -1453,6 +1453,9 @@ def create_server(
                 if path == "/chat/drawer/discard":
                     self._handle_chat_drawer_action_post(form, action="discard")
                     return
+                if path == "/ops/digest/regenerate":
+                    self._handle_digest_regenerate(form)
+                    return
                 self.send_error(404, "Not Found")
             except ValueError as exc:
                 self.send_error(400, str(exc))
@@ -1838,6 +1841,42 @@ def create_server(
                 return
 
             self._write_json({"ok": True, "action": action, "chat_id": chat_id})
+
+        # ── M23 BL-096: mid-day digest regenerate ────────────────
+
+        def _handle_digest_regenerate(self, form: dict[str, list[str]]) -> None:
+            """Enqueue + synchronously dispatch a DIGEST-daily task.
+
+            With the M23 input-hash gate (BL-095), an unchanged-data
+            click costs only the preflight queries — no LLM call.
+            A real data change triggers a fresh digest.
+
+            POST-only (CSRF-protected by the global ``_csrf`` check
+            higher up in ``do_POST``).  Redirects back to
+            ``/ops/today`` so the operator can refresh and see the
+            new digest reflected in the home banner.
+            """
+            from ovp_pipeline.commands.digest_handler import _enqueue_daily
+            from ovp_pipeline.commands.task_dispatch import (
+                DispatchError,
+                RateLimitedError,
+                dispatch_task,
+            )
+
+            pack = (self._form_first(form, "pack") or "").strip() or "research-tech"
+            task = _enqueue_daily(resolved_vault)
+            try:
+                dispatch_task(resolved_vault, task, pack=pack)
+            except RateLimitedError as exc:
+                self.send_error(429, f"task rate limit reached: {exc}")
+                return
+            except DispatchError as exc:
+                self.send_error(500, f"digest regenerate failed: {exc}")
+                return
+            except Exception as exc:  # noqa: BLE001 — provider failures
+                self.send_error(500, f"digest regenerate failed: {exc}")
+                return
+            self._redirect(self._form_first(form, "next").strip() or "/ops/today")
 
         def _resolve_contradiction_action(self, form: dict[str, list[str]]) -> dict[str, object]:
             contradiction_ids = [

--- a/tests/test_digest_bl096.py
+++ b/tests/test_digest_bl096.py
@@ -1,0 +1,218 @@
+"""Tests for M23 / BL-096 — Reader integration + mid-day regenerate.
+
+Scope:
+* Schema-v2 frontmatter exposes layer counts (``intake_events`` etc.)
+  so ``/digests`` can render chips without parsing the body.
+* Prompt v2 instructs the LLM to surface concrete maintainer links
+  in the "Worth doing next" section.
+* The maintainer ``/ops/today`` page renders a "Regenerate digest"
+  button (plain HTML check — full POST flow is BL-097 territory).
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+
+# Import paths under test
+from ovp_pipeline.commands._ui_renderers import _render_digest_regenerate_button
+from ovp_pipeline.commands.digest_handler import (
+    _DIGEST_SYSTEM_PROMPT_V2,
+    _build_frontmatter,
+    handle_digest,
+)
+from ovp_pipeline.commands.task_dispatch import TaskContext
+from ovp_pipeline.digest_config import DigestConfig
+from ovp_pipeline.digest_inputs import collect_digest_inputs
+
+
+# ── Reusable fixtures ──────────────────────────────────────────────
+
+
+class _FakeLLM:
+    def __init__(self, response: str = "stub") -> None:
+        self.response = response
+        self.calls: list[tuple[str, str]] = []
+
+    def call(self, system_prompt: str, user_prompt: str, max_tokens: int = 0) -> str:
+        self.calls.append((system_prompt, user_prompt))
+        return self.response
+
+
+def _vault(tmp_path: Path) -> Path:
+    root = tmp_path / "vault"
+    (root / "50-Inbox" / "02-Tasks").mkdir(parents=True)
+    (root / "40-Resources" / "Generated" / "digests").mkdir(parents=True)
+    (root / "60-Logs").mkdir(parents=True)
+    return root
+
+
+def _seed_minimal_db(vault: Path) -> None:
+    db_path = vault / "60-Logs" / "knowledge.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript("""
+        CREATE TABLE audit_events (
+            source_log TEXT, event_type TEXT, slug TEXT, session_id TEXT,
+            timestamp TEXT, payload_json TEXT
+        );
+        CREATE TABLE evergreen_revisions (
+            pack TEXT, object_id TEXT, version INTEGER, content_md TEXT,
+            change_type TEXT, changed_by TEXT, derived_at TEXT, change_note TEXT
+        );
+        CREATE TABLE objects (
+            pack TEXT, object_id TEXT, object_kind TEXT, title TEXT,
+            canonical_path TEXT, source_slug TEXT, source_url TEXT
+        );
+        CREATE TABLE graph_clusters (
+            pack TEXT, cluster_id TEXT, cluster_kind TEXT, label TEXT,
+            center_object_id TEXT, member_object_ids_json TEXT, score REAL
+        );
+        CREATE TABLE community_crystals (
+            pack TEXT, cluster_id TEXT, body_md TEXT,
+            source_evergreen_slugs_json TEXT, synthesized_at TEXT,
+            llm_model TEXT, prompt_version TEXT,
+            superseded_by_synthesized_at TEXT NOT NULL DEFAULT ''
+        );
+        CREATE TABLE contradiction_crystals (
+            pack TEXT, contradiction_id TEXT, subject_key TEXT, body_md TEXT,
+            source_object_ids_json TEXT, synthesized_at TEXT,
+            superseded_by_synthesized_at TEXT NOT NULL DEFAULT ''
+        );
+        CREATE TABLE crystal_scores (
+            pack TEXT, crystal_id TEXT, crystal_kind TEXT, score REAL
+        );
+    """)
+    # Seed one evergreen revision + one intake event so _is_no_data
+    # returns False.
+    now = datetime.now(timezone.utc)
+    conn.execute(
+        "INSERT INTO evergreen_revisions VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            "research-tech", "evg-a", 1, "content",
+            "created", "absorber",
+            (now - timedelta(hours=1)).isoformat(),
+            "Real change description with prose over 20 chars",
+        ),
+    )
+    conn.execute(
+        "INSERT INTO objects VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("research-tech", "evg-a", "evergreen", "Evergreen A", "", "", ""),
+    )
+    conn.execute(
+        "INSERT INTO audit_events VALUES (?, ?, ?, ?, ?, ?)",
+        ("pipeline.jsonl", "article_processed", "slug-1", "s",
+         (now - timedelta(minutes=10)).isoformat(),
+         '{"title": "Memory systems intro"}'),
+    )
+    conn.commit()
+    conn.close()
+
+
+# ── Schema v2 frontmatter — layer counts ───────────────────────────
+
+
+def test_frontmatter_includes_layer_count_fields(tmp_path: Path):
+    """``/digests`` reads these directly without parsing the body."""
+    vault = _vault(tmp_path)
+    _seed_minimal_db(vault)
+    inputs = collect_digest_inputs(
+        vault, "research-tech",
+        as_of=datetime.now(timezone.utc),
+        config=DigestConfig(tz="UTC"),
+    )
+    fm = _build_frontmatter(inputs, "abc123")
+    assert re.search(r"^intake_events: \d+$", fm, re.MULTILINE)
+    assert re.search(r"^new_evergreens: \d+$", fm, re.MULTILINE)
+    assert re.search(r"^updated_evergreens: \d+$", fm, re.MULTILINE)
+    assert re.search(r"^unsynthesized: \d+$", fm, re.MULTILINE)
+    assert re.search(r"^open_contradictions: \d+$", fm, re.MULTILINE)
+
+
+def test_frontmatter_layer_counts_match_actual_inputs(tmp_path: Path):
+    """The numbers in the frontmatter are the same numbers the
+    /digests page will scan against — not a hand-rolled summary."""
+    vault = _vault(tmp_path)
+    _seed_minimal_db(vault)
+    inputs = collect_digest_inputs(
+        vault, "research-tech",
+        as_of=datetime.now(timezone.utc),
+        config=DigestConfig(tz="UTC"),
+    )
+    fm = _build_frontmatter(inputs, "abc123")
+    intake_match = re.search(r"^intake_events: (\d+)$", fm, re.MULTILINE)
+    assert intake_match
+    assert int(intake_match.group(1)) == inputs.intake.intake_events_processed
+    new_match = re.search(r"^new_evergreens: (\d+)$", fm, re.MULTILINE)
+    assert int(new_match.group(1)) == len(inputs.delta.new_evergreens)
+
+
+# ── Prompt v2 includes maintainer-link guidance ───────────────────
+
+
+def test_prompt_v2_instructs_concrete_maintainer_links():
+    """Prompt nudges the LLM to surface clickable maintainer links
+    in 'Worth doing next' instead of vague advice."""
+    assert "/ops/queue/contradictions" in _DIGEST_SYSTEM_PROMPT_V2
+    assert "/ops/cluster?id=" in _DIGEST_SYSTEM_PROMPT_V2
+    assert "do not invent ids" in _DIGEST_SYSTEM_PROMPT_V2
+
+
+def test_prompt_v2_shows_example_form():
+    """The prompt includes at least one fully-formed example so the
+    LLM has a concrete template to copy."""
+    assert "[Resolve contradiction" in _DIGEST_SYSTEM_PROMPT_V2
+    assert "[Open cluster" in _DIGEST_SYSTEM_PROMPT_V2
+
+
+# ── Regenerate button rendering ────────────────────────────────────
+
+
+def test_regenerate_button_renders_post_form():
+    """Button is a real POST form, not a JS-driven link — works
+    with no-JS browsers."""
+    html = _render_digest_regenerate_button("")
+    assert "method='post'" in html
+    assert "action='/ops/digest/regenerate'" in html
+    assert "<button" in html
+    assert "Regenerate" in html
+
+
+def test_regenerate_button_carries_pack_when_present():
+    """The maintainer's current pack flows through as a hidden input
+    so the dispatched task runs against the right pack."""
+    html = _render_digest_regenerate_button("research-tech")
+    assert "name='pack'" in html
+    assert "value='research-tech'" in html
+
+
+def test_regenerate_button_omits_pack_hidden_when_empty():
+    """No pack scope → no hidden field (the dispatcher applies its
+    default of ``research-tech``)."""
+    html = _render_digest_regenerate_button("")
+    assert "name='pack'" not in html
+
+
+# ── End-to-end: handler frontmatter via real handler ───────────────
+
+
+def test_handler_emits_layer_counts_in_real_run(tmp_path: Path):
+    """Run the full handler and assert layer counts land in the
+    file the dispatcher would write."""
+    vault = _vault(tmp_path)
+    _seed_minimal_db(vault)
+    task = vault / "50-Inbox" / "02-Tasks" / "DIGEST-daily.md"
+    task.write_text("auto", encoding="utf-8")
+    ctx = TaskContext(
+        vault_dir=vault, task_path=task, prefix="DIGEST", slug="daily",
+        body="", pack="research-tech", llm_client=_FakeLLM("body"),
+    )
+    result = handle_digest(ctx)
+    body = result.body_md
+    assert "intake_events: 1" in body
+    assert "new_evergreens: 1" in body


### PR DESCRIPTION
## Summary

Two pieces of the M23 plan's Stage 4 land here.  The ``/digests`` intake-chip integration depends on M22 BL-093 (PR #221) and defers until that merges.

### Schema-v2 frontmatter layer counts

``_build_frontmatter`` now writes five top-level fields:
- ``intake_events``
- ``new_evergreens``
- ``updated_evergreens``
- ``unsynthesized``
- ``open_contradictions``

so the ``/digests`` list (M22) can render chip-style metadata without parsing the body markdown.

### Prompt v2 nudge — concrete maintainer links

The "Worth doing next" section now instructs the LLM to surface real ``/ops/queue/contradictions`` and ``/ops/cluster?id=<X>`` markdown links using ids from the input layers.  Operators can click through to act, not just read.  Two worked examples in the prompt + explicit "do not invent ids" rule.

### Mid-day "Regenerate digest now" button

- ``_render_digest_regenerate_button(requested_pack)`` helper — plain POST form, no-JS-safe.
- Rendered on ``/ops/today`` between the prev/next pivot strip and the five maintainer cards.
- ``POST /ops/digest/regenerate`` route enqueues + synchronously dispatches a DIGEST-daily task.  CSRF-protected.  Errors surface as 429 (rate limit) / 500 (provider).
- BL-095's input-hash gate keeps cost bounded: unchanged data → preflight only, no LLM call.

## Test plan

- [x] 9 new tests in ``test_digest_bl096.py`` covering frontmatter count fields, prompt content checks, button HTML shape, full handler smoke.
- [x] Digest + UI suites green: 201 passed.

## Dependencies + ordering

Stacked on BL-094 (PR #223) + BL-095 (PR #224).  When BL-094/095 merge, this rebases against main with a small diff (only the BL-096 commit).

## Out of scope (this PR)

- ``/digests`` list intake chips — needs M22 BL-093's ``_digests_list_page.py``.  Tracked as a follow-up once PR #221 merges.
- ``digest_clicked_through`` audit events — BL-097.
- ``/ops/digest-health`` page — BL-097.