### PR TITLE
feat(m23): BL-097 — digest click instrumentation + /ops/digest-health

### DIFF
--- a/src/ovp_pipeline/commands/_ui_renderers.py
+++ b/src/ovp_pipeline/commands/_ui_renderers.py
@@ -397,6 +397,98 @@ def _render_chat_drawer_shell() -> str:
     return render_drawer_shell()
 
 
+def _render_digest_health_page(payload: dict) -> str:
+    """Render ``/ops/digest-health`` — M23 BL-097.
+
+    Three plain panels: skip rate, intake reflection rate, click-
+    through breakdown.  Reads from ``build_digest_health_payload``.
+    """
+    if not payload.get("available", True):
+        body = (
+            "<section class='card'>"
+            "<h2>Digest health unavailable</h2>"
+            f"<p class='muted'>{escape(str(payload.get('reason') or 'unknown'))}</p>"
+            "<p>Run <code>ovp-knowledge-index</code> to populate "
+            "<code>audit_events</code>.</p>"
+            "</section>"
+        )
+        return _layout("Digest health", body)
+
+    def _pct(rate: object) -> str:
+        if rate is None:
+            return "—"
+        return f"{float(rate) * 100:.0f}%"
+
+    generated = int(payload.get("generated_count") or 0)
+    skipped = int(payload.get("skipped_count") or 0)
+    total = int(payload.get("total_attempts") or 0)
+    skip_rate = payload.get("skip_rate")
+    intake_rows = list(payload.get("intake_rows") or [])
+    intake_rate = payload.get("intake_reflection_rate")
+    click_breakdown = dict(payload.get("click_breakdown") or {})
+
+    skip_panel = (
+        "<section class='card'>"
+        "<h2>Idempotency gate (skip rate)</h2>"
+        f"<p class='metric-num'>{_pct(skip_rate)}</p>"
+        f"<p class='muted small'>{skipped} skipped / {total} digest attempts. "
+        "High is good — the input-hash gate is cutting redundant LLM calls.</p>"
+        "</section>"
+    )
+
+    if intake_rate is None:
+        intake_body = (
+            "<p class='muted'>No active days yet "
+            "(a day with ≥ 3 article_processed audit events).</p>"
+        )
+    else:
+        active = sum(1 for r in intake_rows if r["active_day"])
+        reflected = sum(1 for r in intake_rows if r["active_day"] and r["reflected"])
+        intake_body = (
+            f"<p class='metric-num'>{_pct(intake_rate)}</p>"
+            f"<p class='muted small'>"
+            f"{reflected} of {active} active days had Layer 0 surface their intake. "
+            "Target: 100%.</p>"
+        )
+    intake_panel = (
+        f"<section class='card'><h2>Intake reflection rate</h2>{intake_body}</section>"
+    )
+
+    if not click_breakdown:
+        click_body = (
+            "<p class='muted'>No clicks recorded yet. "
+            "Digests need to be regenerated since BL-097 landed for the "
+            "wrap to take effect.</p>"
+        )
+    else:
+        rows = sorted(click_breakdown.items(), key=lambda x: -x[1])
+        total_clicks = sum(click_breakdown.values())
+        rows_html = "".join(
+            f"<tr><td>{escape(action)}</td><td>{count}</td></tr>"
+            for action, count in rows
+        )
+        click_body = (
+            f"<p class='metric-num'>{total_clicks}</p>"
+            "<table class='kv' style='margin-top:.5rem'>"
+            "<tr><th>Action shape</th><th>Clicks</th></tr>"
+            f"{rows_html}"
+            "</table>"
+        )
+    click_panel = (
+        f"<section class='card'><h2>Click-through breakdown</h2>{click_body}</section>"
+    )
+
+    body = (
+        "<h1>Digest health</h1>"
+        f"<p class='muted'>{generated} digest{'s' if generated != 1 else ''} generated, "
+        f"{skipped} skipped (input-hash matched a prior run).</p>"
+        + skip_panel
+        + intake_panel
+        + click_panel
+    )
+    return _layout("Digest health", body)
+
+
 def _render_digest_regenerate_button(requested_pack: str) -> str:
     """Render the "Regenerate digest now" button on ``/ops/today``.
 

--- a/src/ovp_pipeline/commands/digest_handler.py
+++ b/src/ovp_pipeline/commands/digest_handler.py
@@ -231,6 +231,13 @@ def handle_digest(ctx: TaskContext) -> TaskResult:
         sys_prompt, user_prompt, max_tokens=1200,
     )
     composed = (composed or "").strip()
+    # M23 BL-097: wrap outbound maintainer links so click-through
+    # lands an audit event for /ops/digest-health.  Idempotent —
+    # an already-wrapped link survives a second pass unchanged.
+    composed = _wrap_digest_links(
+        composed,
+        day=inputs.window_end.date().isoformat(),
+    )
 
     body_md = _render_body(inputs, composed, new_hash, ctx)
     emit(
@@ -641,6 +648,74 @@ def _build_sources_section(inputs: DigestInputs) -> str:
                 parts.append(f"- [[{label}|⚠ {label}]]")
         parts.append("")
     return "\n".join(parts) + "\n"
+
+
+# M23 BL-097: which URL prefixes should rewrite through /digest/click.
+# We only wrap the maintainer + note surfaces the digest's
+# "Worth doing next" section actually emits; static assets and
+# external URLs pass through unchanged.
+_WRAP_PREFIXES: tuple[str, ...] = (
+    "/ops/queue/",
+    "/ops/cluster",
+    "/ops/today",
+    "/ops/contradictions",
+    "/note?path=",
+)
+
+
+def _digest_action_shape(url: str) -> str:
+    """Classify a digest outbound link for audit-event reporting.
+
+    Keeps the shape vocabulary closed — ``/ops/digest-health`` and
+    the success-metrics computation (BL-097) read these strings
+    directly, so adding a new shape requires a deliberate code change
+    rather than silently appearing in stats.
+    """
+    if url.startswith("/ops/queue/contradictions") or url.startswith("/ops/contradictions"):
+        return "resolve_contradiction"
+    if url.startswith("/ops/cluster"):
+        return "run_synthesis"
+    if url.startswith("/note?path="):
+        return "read_source"
+    if url.startswith("/ops/today"):
+        return "review_today"
+    return "other"
+
+
+_MD_LINK_RE = re.compile(r"\[([^\]]+)\]\((/[^)]+)\)")
+
+
+def _wrap_digest_links(markdown: str, *, day: str) -> str:
+    """Rewrite outbound maintainer links to flow through ``/digest/click``.
+
+    Markdown links like ``[Resolve contradiction](/ops/queue/contradictions?status=open)``
+    become ``[Resolve contradiction](/digest/click?to=…&action=resolve_contradiction&day=YYYY-MM-DD)``
+    so a click lands a ``digest_clicked_through`` audit event before
+    redirecting to the original target.
+
+    Idempotent: links already pointing at ``/digest/click`` are left
+    alone so re-running the handler (e.g. mid-day regenerate) doesn't
+    double-wrap them.  Links to prefixes not in ``_WRAP_PREFIXES``
+    (external URLs, anchors, etc.) pass through unchanged.
+    """
+    from urllib.parse import quote
+
+    def _rewrite(match: re.Match[str]) -> str:
+        label = match.group(1)
+        href = match.group(2)
+        if href.startswith("/digest/click"):
+            return match.group(0)
+        if not any(href.startswith(p) for p in _WRAP_PREFIXES):
+            return match.group(0)
+        action = _digest_action_shape(href)
+        wrapped = (
+            f"/digest/click?to={quote(href, safe='')}"
+            f"&action={quote(action, safe='')}"
+            f"&day={quote(day, safe='')}"
+        )
+        return f"[{label}]({wrapped})"
+
+    return _MD_LINK_RE.sub(_rewrite, markdown)
 
 
 def _safe_wikilink(value: Any) -> str:

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -1212,6 +1212,12 @@ def create_server(
                         object_id=object_id or None,
                     )
                     return
+                if path == "/digest/click":
+                    self._handle_digest_click(query)
+                    return
+                if path == "/ops/digest-health":
+                    self._handle_digest_health()
+                    return
                 if path == "/chat":
                     self._handle_chat_page_get(query, csrf_token)
                     return
@@ -1841,6 +1847,89 @@ def create_server(
                 return
 
             self._write_json({"ok": True, "action": action, "chat_id": chat_id})
+
+        # ── M23 BL-097: click-through tracking ───────────────────
+
+        def _handle_digest_click(self, query: dict[str, list[str]]) -> None:
+            """Record a digest outbound click + redirect to the target.
+
+            The digest handler (BL-097) rewrites maintainer links in
+            the rendered body to flow through here so we can audit
+            *what operators actually act on* from each digest.
+
+            ``to``    — vault-relative URL to redirect to.  MUST be a
+                        local path (``/...``); external URLs are
+                        rejected so this can't be used as an open
+                        redirect.
+            ``action``— closed-vocabulary shape from
+                        ``_digest_action_shape`` (resolve_contradiction,
+                        run_synthesis, read_source, review_today, other).
+            ``day``   — operator-local YYYY-MM-DD of the digest this
+                        link came from.  Joins click-through stats
+                        back to the originating digest.
+            """
+            from ..event_emitter import emit
+
+            to = (query.get("to", [""])[0] or "").strip()
+            action = (query.get("action", [""])[0] or "other").strip()
+            day = (query.get("day", [""])[0] or "").strip()
+
+            # Open-redirect defense — only local paths allowed.
+            if not to.startswith("/") or to.startswith("//"):
+                self.send_error(400, "digest click: to must be a local path")
+                return
+            # Strip control chars defensively before logging the URL.
+            if any(ord(ch) < 32 for ch in to):
+                self.send_error(400, "digest click: invalid characters in to")
+                return
+
+            try:
+                emit(
+                    resolved_vault,
+                    "pipeline.jsonl",
+                    "digest_clicked_through",
+                    {
+                        "to": to,
+                        "action": action,
+                        "day": day,
+                    },
+                )
+            except Exception:  # noqa: BLE001 — audit must never block UX
+                # Log via stderr and continue — a click should redirect
+                # even if the audit writer hiccups.
+                logger_name = "ui_server"
+                print(
+                    f"[{logger_name}] digest_clicked_through emit failed",
+                    file=sys.stderr,
+                )
+
+            self._redirect(to)
+
+        def _handle_digest_health(self) -> None:
+            """Render /ops/digest-health — three metric panels.
+
+            All three read from ``audit_events`` (rebuilt from
+            ``pipeline.jsonl`` by ``ovp-knowledge-index``); no new
+            DB schema.
+
+            * **Skip rate** = digest_skipped_no_change / total digest
+              attempts.  High skip rate is *good* — the input-hash gate
+              is working.
+            * **Intake reflection rate** = of digest_generated rows
+              where the same day had ≥ 3 article_processed events,
+              what fraction surfaced layer0_events > 0.  Target:
+              100% — every active day should have its intake
+              acknowledged.
+            * **Click-through breakdown** — counts of
+              digest_clicked_through grouped by ``action``.  Pure
+              count for now; rate requires "digest view" tracking
+              that doesn't exist yet (separate follow-up).
+            """
+            from ..ui.view_models import build_digest_health_payload
+            from ._ui_renderers import _render_digest_health_page
+
+            payload = build_digest_health_payload(resolved_vault)
+            self._write_html(_render_digest_health_page(payload))
 
         # ── M23 BL-096: mid-day digest regenerate ────────────────
 

--- a/src/ovp_pipeline/ui/view_models.py
+++ b/src/ovp_pipeline/ui/view_models.py
@@ -3346,6 +3346,116 @@ def build_today_digest_payload(
     }
 
 
+def build_digest_health_payload(vault_dir: Path | str) -> dict[str, Any]:
+    """``/ops/digest-health`` payload — three metric panels (M23 / BL-097).
+
+    Reads only ``audit_events``; no new schema.  Returns the data
+    shape the renderer consumes — empty / "no data" states are
+    explicit so the page doesn't render bogus zeros as authoritative.
+    """
+    db_path = _db_path(vault_dir)
+    if not db_path.exists():
+        return {
+            "screen": "ops/digest-health",
+            "available": False,
+            "reason": "knowledge_index has not been built yet",
+        }
+
+    with sqlite3.connect(db_path) as conn:
+        # Skip rate
+        try:
+            generated = conn.execute(
+                "SELECT COUNT(*) FROM audit_events WHERE event_type='digest_generated'"
+            ).fetchone()[0]
+            skipped = conn.execute(
+                "SELECT COUNT(*) FROM audit_events WHERE event_type='digest_skipped_no_change'"
+            ).fetchone()[0]
+        except sqlite3.OperationalError:
+            generated = 0
+            skipped = 0
+        total_attempts = generated + skipped
+        skip_rate = (skipped / total_attempts) if total_attempts else None
+
+        # Intake reflection — per generated digest, did Layer 0
+        # surface intake when the day had ≥ 3 article_processed events?
+        intake_rows: list[dict[str, Any]] = []
+        try:
+            digests = conn.execute(
+                """
+                SELECT payload_json, timestamp FROM audit_events
+                 WHERE event_type='digest_generated'
+                 ORDER BY timestamp DESC LIMIT 60
+                """,
+            ).fetchall()
+            for payload_json, ts in digests:
+                try:
+                    payload = json.loads(payload_json or "{}")
+                except (TypeError, ValueError, json.JSONDecodeError):
+                    payload = {}
+                if not isinstance(payload, dict):
+                    continue
+                day_key = (payload.get("window_end") or ts or "")[:10]
+                if not day_key:
+                    continue
+                layer0 = int(payload.get("layer0_events") or 0)
+                # Same-day article_processed count from audit_events.
+                article_count = conn.execute(
+                    """
+                    SELECT COUNT(*) FROM audit_events
+                     WHERE event_type IN (
+                       'article_processed', 'source_archived_to_processed'
+                     ) AND timestamp LIKE ?
+                    """,
+                    (day_key + "%",),
+                ).fetchone()[0]
+                intake_rows.append({
+                    "day": day_key,
+                    "layer0_events": layer0,
+                    "article_count_for_day": article_count,
+                    "active_day": article_count >= 3,
+                    "reflected": layer0 > 0,
+                })
+        except sqlite3.OperationalError:
+            intake_rows = []
+
+        active_days = [r for r in intake_rows if r["active_day"]]
+        reflected_active = [r for r in active_days if r["reflected"]]
+        intake_reflection_rate = (
+            len(reflected_active) / len(active_days) if active_days else None
+        )
+
+        # Click-through breakdown
+        click_breakdown: dict[str, int] = {}
+        try:
+            rows = conn.execute(
+                """
+                SELECT payload_json FROM audit_events
+                 WHERE event_type='digest_clicked_through'
+                """,
+            ).fetchall()
+            for (payload_json,) in rows:
+                try:
+                    payload = json.loads(payload_json or "{}")
+                except (TypeError, ValueError, json.JSONDecodeError):
+                    payload = {}
+                action = str(payload.get("action") or "other") if isinstance(payload, dict) else "other"
+                click_breakdown[action] = click_breakdown.get(action, 0) + 1
+        except sqlite3.OperationalError:
+            click_breakdown = {}
+
+    return {
+        "screen": "ops/digest-health",
+        "available": True,
+        "generated_count": generated,
+        "skipped_count": skipped,
+        "total_attempts": total_attempts,
+        "skip_rate": skip_rate,
+        "intake_rows": intake_rows,
+        "intake_reflection_rate": intake_reflection_rate,
+        "click_breakdown": click_breakdown,
+    }
+
+
 def build_runs_index_payload(
     vault_dir: Path | str,
     *,

--- a/tests/test_digest_bl097.py
+++ b/tests/test_digest_bl097.py
@@ -1,0 +1,236 @@
+"""Tests for M23 / BL-097 — digest instrumentation + /ops/digest-health.
+
+Covers:
+* ``_wrap_digest_links`` rewrites maintainer markdown links through
+  ``/digest/click`` while leaving non-maintainer URLs alone.
+* ``_digest_action_shape`` returns the closed vocabulary the
+  /ops/digest-health metrics rely on.
+* ``build_digest_health_payload`` reads ``audit_events`` and computes
+  skip rate + intake-reflection rate + click-through breakdown.
+* ``_render_digest_health_page`` renders all three panels and
+  handles the "no data yet" stubs honestly.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from ovp_pipeline.commands._ui_renderers import _render_digest_health_page
+from ovp_pipeline.commands.digest_handler import (
+    _digest_action_shape,
+    _wrap_digest_links,
+)
+from ovp_pipeline.ui.view_models import build_digest_health_payload
+
+
+# ── _wrap_digest_links ─────────────────────────────────────────────
+
+
+def test_wrap_rewrites_ops_queue_link():
+    md = "Click [Resolve →](/ops/queue/contradictions?status=open) for more."
+    out = _wrap_digest_links(md, day="2026-05-13")
+    assert "/digest/click?to=" in out
+    assert "action=resolve_contradiction" in out
+    assert "day=2026-05-13" in out
+    # Label text preserved.
+    assert "[Resolve →]" in out
+    # Original URL is URL-encoded inside `to=`.
+    assert "%2Fops%2Fqueue%2Fcontradictions%3Fstatus%3Dopen" in out
+
+
+def test_wrap_rewrites_cluster_link_with_run_synthesis_action():
+    md = "[Open cluster →](/ops/cluster?id=cluster::memory-systems)"
+    out = _wrap_digest_links(md, day="2026-05-13")
+    assert "action=run_synthesis" in out
+
+
+def test_wrap_rewrites_note_path_link_with_read_source_action():
+    md = "[Source](/note?path=10-Knowledge/Evergreen/test.md)"
+    out = _wrap_digest_links(md, day="2026-05-13")
+    assert "action=read_source" in out
+
+
+def test_wrap_preserves_external_urls():
+    """https/external links pass through unchanged — only OVP
+    internal maintainer + note links get wrapped."""
+    md = "Reference: [paper](https://example.com/paper.pdf)"
+    out = _wrap_digest_links(md, day="2026-05-13")
+    assert out == md
+
+
+def test_wrap_preserves_anchor_links():
+    """In-page anchors pass through — they're not navigation."""
+    md = "See [section below](#summary) for context."
+    out = _wrap_digest_links(md, day="2026-05-13")
+    assert out == md
+
+
+def test_wrap_is_idempotent():
+    """Already-wrapped links survive a second pass unchanged."""
+    md = "[Resolve →](/ops/queue/contradictions?status=open)"
+    first = _wrap_digest_links(md, day="2026-05-13")
+    second = _wrap_digest_links(first, day="2026-05-13")
+    assert first == second
+
+
+def test_wrap_skips_non_maintainer_ops_paths():
+    """``/ops/`` paths NOT in the wrap allowlist (e.g.
+    ``/ops/runs``) pass through.  Keeps the vocabulary closed."""
+    md = "[Runs](/ops/runs)"
+    out = _wrap_digest_links(md, day="2026-05-13")
+    assert out == md
+
+
+# ── _digest_action_shape ───────────────────────────────────────────
+
+
+@pytest.mark.parametrize("url,expected", [
+    ("/ops/queue/contradictions?status=open", "resolve_contradiction"),
+    ("/ops/contradictions", "resolve_contradiction"),
+    ("/ops/cluster?id=foo", "run_synthesis"),
+    ("/note?path=10-Knowledge/Evergreen/x.md", "read_source"),
+    ("/ops/today", "review_today"),
+    ("/something-else", "other"),
+])
+def test_action_shape_vocabulary(url, expected):
+    assert _digest_action_shape(url) == expected
+
+
+# ── Health payload ─────────────────────────────────────────────────
+
+
+def _make_audit_db(tmp_path: Path) -> Path:
+    db_path = tmp_path / "60-Logs" / "knowledge.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.executescript("""
+        CREATE TABLE audit_events (
+            source_log TEXT, event_type TEXT, slug TEXT, session_id TEXT,
+            timestamp TEXT, payload_json TEXT
+        );
+    """)
+    conn.commit()
+    conn.close()
+    return tmp_path
+
+
+def _seed_audit(
+    vault: Path, event_type: str, *, payload: dict | None = None, day: str | None = None
+) -> None:
+    db_path = vault / "60-Logs" / "knowledge.db"
+    ts = (day or datetime.now(timezone.utc).strftime("%Y-%m-%d")) + "T12:00:00+00:00"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO audit_events VALUES (?, ?, ?, ?, ?, ?)",
+        ("pipeline.jsonl", event_type, "", "s", ts, json.dumps(payload or {})),
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_health_unavailable_when_no_db(tmp_path: Path):
+    payload = build_digest_health_payload(tmp_path)
+    assert payload["available"] is False
+
+
+def test_health_skip_rate_high_when_gate_works(tmp_path: Path):
+    vault = _make_audit_db(tmp_path)
+    # 1 generated, 4 skipped → skip rate = 80%.
+    _seed_audit(vault, "digest_generated", payload={"layer0_events": 5, "window_end": "2026-05-13"})
+    for _ in range(4):
+        _seed_audit(vault, "digest_skipped_no_change", payload={"input_hash": "h"})
+    payload = build_digest_health_payload(vault)
+    assert payload["generated_count"] == 1
+    assert payload["skipped_count"] == 4
+    assert payload["total_attempts"] == 5
+    assert payload["skip_rate"] == pytest.approx(0.8)
+
+
+def test_health_intake_reflection_rate_computed_per_active_day(tmp_path: Path):
+    """Active day = ≥ 3 article_processed events.  Reflected =
+    digest_generated for that day had layer0_events > 0."""
+    vault = _make_audit_db(tmp_path)
+    day = "2026-05-13"
+    # 3 article_processed on this day → active.
+    for i in range(3):
+        _seed_audit(vault, "article_processed", day=day)
+    # Digest_generated for this day with layer0_events > 0 → reflected.
+    _seed_audit(vault, "digest_generated", payload={
+        "layer0_events": 3, "window_end": day,
+    })
+    payload = build_digest_health_payload(vault)
+    assert payload["intake_reflection_rate"] == pytest.approx(1.0)
+
+
+def test_health_intake_reflection_misses_when_layer0_zero(tmp_path: Path):
+    vault = _make_audit_db(tmp_path)
+    day = "2026-05-13"
+    for i in range(3):
+        _seed_audit(vault, "article_processed", day=day)
+    # Digest generated but layer0 came back 0 → reflected=False.
+    _seed_audit(vault, "digest_generated", payload={
+        "layer0_events": 0, "window_end": day,
+    })
+    payload = build_digest_health_payload(vault)
+    assert payload["intake_reflection_rate"] == pytest.approx(0.0)
+
+
+def test_health_inactive_days_excluded(tmp_path: Path):
+    """A day with < 3 articles doesn't count toward the rate either way."""
+    vault = _make_audit_db(tmp_path)
+    day = "2026-05-13"
+    _seed_audit(vault, "article_processed", day=day)  # only 1
+    _seed_audit(vault, "digest_generated", payload={
+        "layer0_events": 0, "window_end": day,
+    })
+    payload = build_digest_health_payload(vault)
+    # No active days → rate is None (honest), not zero.
+    assert payload["intake_reflection_rate"] is None
+
+
+def test_health_click_breakdown_groups_by_action(tmp_path: Path):
+    vault = _make_audit_db(tmp_path)
+    _seed_audit(vault, "digest_clicked_through", payload={"action": "resolve_contradiction"})
+    _seed_audit(vault, "digest_clicked_through", payload={"action": "resolve_contradiction"})
+    _seed_audit(vault, "digest_clicked_through", payload={"action": "run_synthesis"})
+    payload = build_digest_health_payload(vault)
+    assert payload["click_breakdown"] == {
+        "resolve_contradiction": 2, "run_synthesis": 1,
+    }
+
+
+# ── Renderer ───────────────────────────────────────────────────────
+
+
+def test_render_health_page_renders_three_panels(tmp_path: Path):
+    payload = build_digest_health_payload(_make_audit_db(tmp_path))
+    html = _render_digest_health_page(payload)
+    assert "Idempotency gate" in html
+    assert "Intake reflection rate" in html
+    assert "Click-through breakdown" in html
+
+
+def test_render_health_page_handles_unavailable():
+    html = _render_digest_health_page({"available": False, "reason": "knowledge_index has not been built yet"})
+    assert "Digest health unavailable" in html
+    assert "ovp-knowledge-index" in html
+
+
+def test_render_health_page_shows_no_clicks_message_when_empty(tmp_path: Path):
+    payload = build_digest_health_payload(_make_audit_db(tmp_path))
+    html = _render_digest_health_page(payload)
+    assert "No clicks recorded yet" in html
+
+
+def test_render_health_page_renders_click_breakdown_table(tmp_path: Path):
+    vault = _make_audit_db(tmp_path)
+    _seed_audit(vault, "digest_clicked_through", payload={"action": "resolve_contradiction"})
+    payload = build_digest_health_payload(vault)
+    html = _render_digest_health_page(payload)
+    assert "resolve_contradiction" in html


### PR DESCRIPTION
## Summary

Last v1 BL of the M23 redesign.  Wires three concrete metrics so the plan's success thresholds become measurable, not vibes.

### Click instrumentation

- **``_wrap_digest_links(markdown, day)``** — handler rewrites maintainer links (``/ops/queue/contradictions``, ``/ops/cluster?id=...``, ``/ops/today``, ``/note?path=...``) through ``/digest/click?to=...&action=<shape>&day=YYYY-MM-DD``.  External URLs + anchors untouched.  Idempotent.
- **``_digest_action_shape``** — closed vocabulary: ``resolve_contradiction``, ``run_synthesis``, ``read_source``, ``review_today``, ``other``.  Adding a shape requires a deliberate code change.
- **``GET /digest/click``** — emits ``digest_clicked_through`` with action + day + target, then 302s.  Open-redirect guarded.  Audit-emit failure logs but never blocks UX.

### ``/ops/digest-health`` page

Three panels read from ``audit_events`` only — no new schema:

1. **Skip rate** = ``digest_skipped_no_change / total_attempts``.  High is good.
2. **Intake reflection rate** = of ``digest_generated`` rows on active days (≥ 3 ``article_processed``), what fraction had ``layer0_events > 0``.  Target 100%.  Returns ``None`` honestly when no active days.
3. **Click-through breakdown** — counts grouped by ``action``.  Pure count for now; absolute-rate needs view tracking that's not yet plumbed.

## Test plan

- [x] 22 new tests in ``test_digest_bl097.py`` covering all six wrap branches, all five action shapes (parametrized), three intake-rate paths (positive/negative/null), and renderer state.
- [x] Full digest suite (94 tests) + UI suite (144 tests): green.

## Dependencies + ordering

Stacked on BL-094 (#223) + BL-095 (#224) + BL-096 (#225).

## Closes M23 v1

After this merges, the four-BL M23 v1 ship is complete:
- BL-094 data collector + preflight
- BL-095 prompt v2 + idempotency gate
- BL-096 mid-day regenerate button + frontmatter layer counts
- BL-097 click instrumentation + digest-health page

Deferred to M23.1:
- BL-098 claims/relations ``created_at`` migration (Layer 1 v2)
- BL-099 POST-driven action buttons
- /digests intake-chip integration (needs M22 PR #221 merged first)