### PR TITLE
fix(post-merge): drawer markdown + layout + transcript rehydrate + digest labels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,11 @@ dependencies = [
     "tomli>=1.0.0; python_version < '3.11'",
     "defusedxml>=0.7.1",
     "tzlocal>=5.0",
+    # Direct import in commands/_ui_renderers.py and
+    # commands/_chat_drawer.py — was previously pulled in
+    # transitively; pin explicitly so a transitive drop doesn't
+    # silently break Reader rendering (CodeRabbit Major review).
+    "markdown-it-py>=2.2",
 ]
 
 [project.optional-dependencies]

--- a/src/ovp_pipeline/commands/_chat_drawer.py
+++ b/src/ovp_pipeline/commands/_chat_drawer.py
@@ -130,15 +130,32 @@ def render_turn_html(role: str, body: str, header: str = "") -> str:
     """Render a single turn for drawer injection (JSON response).
 
     Mirrors the ``_chat_page._flush_block`` shape but with the
-    drawer's narrower CSS classes.  ``body`` is plain text;
-    HTML entities are escaped.  ``header`` is a short label
+    drawer's narrower CSS classes.  ``header`` is a short label
     rendered as a muted small caption (e.g. the timestamp).
+
+    The assistant typically returns markdown (lists, bold, code,
+    links).  Render it through ``MarkdownIt`` with ``html=False``
+    so embedded HTML is treated as plain text — no XSS path even
+    when an upstream LLM emits ``<script>``.  User turns stay as
+    plain text wrapped in ``<pre>`` so the operator sees their
+    message exactly as typed.
     """
     role_class = "chat-drawer-turn-user" if role == "user" else "chat-drawer-turn-assistant"
     caption = f"<p class='muted small'>{escape(header)}</p>" if header else ""
+    if role == "user":
+        body_html = f"<pre class='chat-drawer-body'>{escape(body)}</pre>"
+    else:
+        from markdown_it import MarkdownIt
+
+        renderer = MarkdownIt("commonmark", {"breaks": True, "html": False}).enable("table")
+        body_html = (
+            "<div class='chat-drawer-body chat-drawer-body-md'>"
+            f"{renderer.render(body or '')}"
+            "</div>"
+        )
     return (
         f'<section class="chat-drawer-turn {role_class}">'
         f"{caption}"
-        f"<pre class='chat-drawer-body'>{escape(body)}</pre>"
+        f"{body_html}"
         "</section>"
     )

--- a/src/ovp_pipeline/commands/_chat_drawer.py
+++ b/src/ovp_pipeline/commands/_chat_drawer.py
@@ -45,10 +45,23 @@ from __future__ import annotations
 
 from html import escape
 
+from markdown_it import MarkdownIt
+
 
 # Container id used by the static JS to find / show / hide the
 # drawer.  Kept as a module constant so the renderer + JS agree.
 DRAWER_ID = "ovp-chat-drawer"
+
+
+# Module-level renderer instance (gemini + CodeRabbit review):
+# instantiating MarkdownIt is non-trivial, and the drawer's
+# rehydrate-on-open + per-turn rendering would otherwise build a
+# fresh one for every turn.  ``html=False`` blocks raw HTML
+# (defence-in-depth — the LLM is the only writer here, but a
+# compromised provider shouldn't be able to inject script tags).
+_MARKDOWN_RENDERER = MarkdownIt(
+    "commonmark", {"breaks": True, "html": False}
+).enable("table")
 
 
 def render_drawer_shell() -> str:
@@ -145,12 +158,9 @@ def render_turn_html(role: str, body: str, header: str = "") -> str:
     if role == "user":
         body_html = f"<pre class='chat-drawer-body'>{escape(body)}</pre>"
     else:
-        from markdown_it import MarkdownIt
-
-        renderer = MarkdownIt("commonmark", {"breaks": True, "html": False}).enable("table")
         body_html = (
             "<div class='chat-drawer-body chat-drawer-body-md'>"
-            f"{renderer.render(body or '')}"
+            f"{_MARKDOWN_RENDERER.render(body or '')}"
             "</div>"
         )
     return (

--- a/src/ovp_pipeline/commands/_ui_renderers.py
+++ b/src/ovp_pipeline/commands/_ui_renderers.py
@@ -382,7 +382,10 @@ def _render_digest_neighbour_nav(vault_dir: Path, relative_path: str) -> str:
     parts.append("<a href='/digests'>All digests</a>")
     if newer:
         parts.append(f"<a href='{escape(newer)}'>next day →</a>")
-    return "<p class='muted' style='margin-top:0.4rem'>" + " · ".join(parts) + "</p>"
+    # Inline span so the caller can lay this strip out on the same
+    # row as the "Ask about this" button without forcing a separate
+    # paragraph break.  Caller is responsible for vertical spacing.
+    return "<span class='muted small'>" + " · ".join(parts) + "</span>"
 
 
 def _render_chat_drawer_shell() -> str:
@@ -1976,14 +1979,24 @@ def _render_note_page(
         # M22 BL-093: prev/next pivot when this is a daily digest
         # so operators can step through history without bouncing
         # back to the /digests list every time.
+        # User feedback (2026-05-13): the "Ask about this" button
+        # and the digest prev/next strip were rendering on separate
+        # lines.  Lay them out as a single flex row so the page
+        # header stays compact.
         digest_nav_html = _render_digest_neighbour_nav(vault_dir, relative_path)
+        actions_row = (
+            "<div class='entry-actions' "
+            "style='display:flex;align-items:center;gap:0.75rem;flex-wrap:wrap'>"
+            f"{ask_button}"
+            f"{digest_nav_html}"
+            "</div>"
+        )
         return _layout(
             f"Markdown Note: {relative_path}",
             (
                 "<h1>Markdown Note</h1>"
                 f"<p class='muted'>{escape(relative_path)}</p>"
-                + f"<div class='entry-actions'>{ask_button}</div>"
-                + digest_nav_html
+                + actions_row
                 + preamble_html
                 + f"<section class='card'>{note_html}</section>"
                 + _render_frontmatter_details(frontmatter_html)

--- a/src/ovp_pipeline/commands/digest_handler.py
+++ b/src/ovp_pipeline/commands/digest_handler.py
@@ -151,7 +151,12 @@ Hard rules:
   quiet — the operator needs to know their work landed.
 - Don't list article titles individually; surface them as a chip
   ("memory systems (7), agents (3), ops (2)").
-- Don't invent topics that aren't in the input layers.
+- Don't invent topics, time ranges, or numbers that aren't in
+  the input layers above.  Never say "between midnight and 6 AM"
+  or similar — you don't have hour-of-day granularity.
+- When referring to a crystal/cluster, use the human label from
+  the input (e.g. "memory-systems"); do NOT print the raw hex id
+  (``cluster::caa2903bc202``) — that's noise to the reader.
 - Don't write a closing call-to-think — the "Worth doing next"
   section IS the call to action.
 - When a section has zero data, omit the heading entirely.
@@ -466,8 +471,9 @@ def _render_layer2_for_prompt(layer: ConnectionLayer) -> str:
             lines.append(f"- {subject or cid} (contradiction_id={cid})")
     if layer.recent_top_crystals:
         lines.append("Top-scoring crystals in the vault (context, not delta):")
-        for cid, kind, score in layer.recent_top_crystals:
-            lines.append(f"- {kind}/{cid} score={score:.2f}")
+        for cid, kind, score, label in layer.recent_top_crystals:
+            display = label or cid
+            lines.append(f"- {kind}: {display} score={score:.2f}")
     return "\n".join(lines)
 
 

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -164,6 +164,38 @@ def _crystal_kind_and_id_from_note_path(relative_path: str) -> tuple[str, str] |
     return ("community_crystal", f"cluster::{stem}")
 
 
+def _strip_html_comments_inline(line: str, in_block: bool) -> tuple[str, bool]:
+    """Remove every ``<!-- ... -->`` range from ``line``.
+
+    Returns ``(stripped, in_block_after)``.  Handles:
+      * a line entirely inside an open block (returns ``""``);
+      * a line that closes a block then opens another;
+      * multiple comments on the same line (gemini review fix);
+      * an open-ended comment that runs to EOL (start of block).
+    """
+    result = line
+    if in_block:
+        if "-->" in result:
+            result = result.split("-->", 1)[1]
+            in_block = False
+        else:
+            return "", True
+    # Strip every fully-closed pair on this line.
+    while True:
+        start = result.find("<!--")
+        if start < 0:
+            break
+        end = result.find("-->", start)
+        if end < 0:
+            # Comment opens but doesn't close → swallow tail,
+            # carry the block state into the next line.
+            result = result[:start]
+            in_block = True
+            break
+        result = result[:start] + result[end + len("-->") :]
+    return result, in_block
+
+
 def _render_drawer_turns_from_transcript(text: str) -> str:
     """Convert a saved transcript into drawer-shaped turn HTML.
 
@@ -173,13 +205,12 @@ def _render_drawer_turns_from_transcript(text: str) -> str:
     Strips ``<!-- context-manifest ... -->`` blocks from assistant
     bodies — those are audit snapshots, not prose.
     """
+    # Strip frontmatter using the renderer's existing helper rather
+    # than re-implementing the parse here (gemini review).
+    from ovp_pipeline.commands._ui_renderers import _parse_frontmatter
     from ovp_pipeline.commands._chat_drawer import render_turn_html
 
-    # Strip frontmatter.
-    if text.startswith("---\n"):
-        end = text.find("\n---\n", 4)
-        if end > 0:
-            text = text[end + 5 :]
+    _frontmatter, body_text = _parse_frontmatter(text)
 
     sections: list[str] = []
     current_role: str | None = None
@@ -196,22 +227,8 @@ def _render_drawer_turns_from_transcript(text: str) -> str:
                 render_turn_html(current_role, body, header=current_header)
             )
 
-    for raw in text.splitlines():
-        # Strip <!-- ... --> ranges; the manifest comment lives
-        # inside assistant turn bodies but should not display.
-        if in_block_comment:
-            if "-->" in raw:
-                raw = raw.split("-->", 1)[1]
-                in_block_comment = False
-            else:
-                continue
-        if "<!--" in raw and "-->" not in raw:
-            raw = raw.split("<!--", 1)[0]
-            in_block_comment = True
-        elif "<!--" in raw and "-->" in raw:
-            start = raw.index("<!--")
-            end = raw.index("-->", start) + len("-->")
-            raw = raw[:start] + raw[end:]
+    for raw in body_text.splitlines():
+        raw, in_block_comment = _strip_html_comments_inline(raw, in_block_comment)
         if raw.startswith("## User ·"):
             _flush()
             current_role = "user"
@@ -1715,7 +1732,6 @@ def create_server(
             chat_id is bogus or the file was discarded.
             """
             from ovp_pipeline.chat_fileops import parse_chat
-            from ovp_pipeline.commands._chat_drawer import render_turn_html
             from ovp_pipeline.commands.chat_handler import _find_chat_by_id
 
             chat_id = (query.get("id", [""])[0] or "").strip()

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -164,6 +164,73 @@ def _crystal_kind_and_id_from_note_path(relative_path: str) -> tuple[str, str] |
     return ("community_crystal", f"cluster::{stem}")
 
 
+def _render_drawer_turns_from_transcript(text: str) -> str:
+    """Convert a saved transcript into drawer-shaped turn HTML.
+
+    Parses the same ``## User · <ISO>`` / ``## Assistant · <ISO> · turn-N``
+    sections that ``_chat_page._render_transcript_body`` reads, but
+    emits the narrower drawer markup via ``render_turn_html``.
+    Strips ``<!-- context-manifest ... -->`` blocks from assistant
+    bodies — those are audit snapshots, not prose.
+    """
+    from ovp_pipeline.commands._chat_drawer import render_turn_html
+
+    # Strip frontmatter.
+    if text.startswith("---\n"):
+        end = text.find("\n---\n", 4)
+        if end > 0:
+            text = text[end + 5 :]
+
+    sections: list[str] = []
+    current_role: str | None = None
+    current_header = ""
+    current_lines: list[str] = []
+    in_block_comment = False
+
+    def _flush() -> None:
+        if current_role is None:
+            return
+        body = "\n".join(current_lines).strip()
+        if body or current_role == "user":
+            sections.append(
+                render_turn_html(current_role, body, header=current_header)
+            )
+
+    for raw in text.splitlines():
+        # Strip <!-- ... --> ranges; the manifest comment lives
+        # inside assistant turn bodies but should not display.
+        if in_block_comment:
+            if "-->" in raw:
+                raw = raw.split("-->", 1)[1]
+                in_block_comment = False
+            else:
+                continue
+        if "<!--" in raw and "-->" not in raw:
+            raw = raw.split("<!--", 1)[0]
+            in_block_comment = True
+        elif "<!--" in raw and "-->" in raw:
+            start = raw.index("<!--")
+            end = raw.index("-->", start) + len("-->")
+            raw = raw[:start] + raw[end:]
+        if raw.startswith("## User ·"):
+            _flush()
+            current_role = "user"
+            current_header = raw[3:].strip()
+            current_lines = []
+            continue
+        if raw.startswith("## Assistant ·"):
+            _flush()
+            current_role = "assistant"
+            current_header = raw[3:].strip()
+            current_lines = []
+            continue
+        if current_role is None:
+            continue
+        current_lines.append(raw)
+    _flush()
+    return "".join(sections)
+
+
 def _maybe_update_chats_projection(
     vault_dir: Path | str,
     *,
@@ -1218,6 +1285,9 @@ def create_server(
                 if path == "/ops/digest-health":
                     self._handle_digest_health()
                     return
+                if path == "/chat/drawer/transcript":
+                    self._handle_chat_drawer_transcript_get(query)
+                    return
                 if path == "/chat":
                     self._handle_chat_page_get(query, csrf_token)
                     return
@@ -1624,6 +1694,61 @@ def create_server(
             self._redirect(chat_page_redirect_target(result.chat_id))
 
         # ── M22: anchored inquiry drawer ───────────────────────
+
+        def _handle_chat_drawer_transcript_get(
+            self, query: dict[str, list[str]]
+        ) -> None:
+            """Return the prior turns of a chat as drawer HTML.
+
+            The drawer JS calls this on reopen when localStorage has
+            a ``chat_id`` cached for the current anchor — without
+            this fetch the operator would see an empty drawer after
+            a page refresh (M22 user feedback 2026-05-13: "chat
+            history disappeared, can't find it").
+
+            Response shape::
+
+                {"chat_id": "chat-...",
+                 "turns_html": "<section>…</section><section>…</section>"}
+
+            Errors: ``{"error": "not_found"}`` with 404 when the
+            chat_id is bogus or the file was discarded.
+            """
+            from ovp_pipeline.chat_fileops import parse_chat
+            from ovp_pipeline.commands._chat_drawer import render_turn_html
+            from ovp_pipeline.commands.chat_handler import _find_chat_by_id
+
+            chat_id = (query.get("id", [""])[0] or "").strip()
+            if not chat_id:
+                self._write_json(
+                    {"error": "missing_id", "detail": "id is required."},
+                    status=400,
+                )
+                return
+            chat_path = _find_chat_by_id(resolved_vault, chat_id)
+            if chat_path is None or not chat_path.is_file():
+                self._write_json(
+                    {"error": "not_found", "detail": f"chat_id {chat_id!r} not found."},
+                    status=404,
+                )
+                return
+            fm = parse_chat(chat_path)
+            if fm is None:
+                self._write_json(
+                    {"error": "not_a_chat", "detail": str(chat_path)},
+                    status=400,
+                )
+                return
+
+            text = chat_path.read_text(encoding="utf-8")
+            turns_html = _render_drawer_turns_from_transcript(text)
+            self._write_json(
+                {
+                    "chat_id": chat_id,
+                    "turn_count": fm.turn_count,
+                    "turns_html": turns_html,
+                }
+            )
 
         def _handle_chat_drawer_message_post(
             self, form: dict[str, list[str]]

--- a/src/ovp_pipeline/digest_inputs.py
+++ b/src/ovp_pipeline/digest_inputs.py
@@ -114,7 +114,11 @@ class ConnectionLayer:
 
     connected_community_crystals: tuple[tuple[str, str], ...]  # (cluster_id, label)
     touched_contradictions: tuple[tuple[str, str], ...]  # (contradiction_id, subject)
-    recent_top_crystals: tuple[tuple[str, str, float], ...]  # (id, kind, score)
+    recent_top_crystals: tuple[tuple[str, str, float, str], ...]
+    # (id, kind, score, label) — label is the human-readable
+    # name from ``graph_clusters.label`` (community) or
+    # ``contradiction_crystals.subject_key`` (contradiction).
+    # Empty string when no label is known.
 
 
 @dataclass(frozen=True)
@@ -739,19 +743,37 @@ def _collect_layer2(
         except sqlite3.OperationalError:
             touched_contradictions = []
 
-    recent_top: list[tuple[str, str, float]] = []
+    recent_top: list[tuple[str, str, float, str]] = []
+    # User feedback (2026-05-13): the digest body was referring to
+    # crystals by hex cluster_id ("clusters: caa2903bc202, ...")
+    # because we didn't pass labels to the LLM.  Join to
+    # graph_clusters / contradiction_crystals to surface the
+    # human-readable name alongside the id.
     try:
         rows = conn.execute(
             """
-            SELECT crystal_id, crystal_kind, score FROM crystal_scores
-             WHERE pack = ?
-             ORDER BY score DESC
+            SELECT cs.crystal_id,
+                   cs.crystal_kind,
+                   cs.score,
+                   COALESCE(gc.label, cc.subject_key, '') AS label
+              FROM crystal_scores cs
+              LEFT JOIN graph_clusters gc
+                ON gc.pack = cs.pack AND gc.cluster_id = cs.crystal_id
+              LEFT JOIN contradiction_crystals cc
+                ON cc.pack = cs.pack AND cc.contradiction_id = cs.crystal_id
+             WHERE cs.pack = ?
+             ORDER BY cs.score DESC
              LIMIT 5
             """,
             (pack,),
         ).fetchall()
         recent_top = [
-            (r["crystal_id"], r["crystal_kind"], float(r["score"] or 0.0))
+            (
+                r["crystal_id"],
+                r["crystal_kind"],
+                float(r["score"] or 0.0),
+                (r["label"] or "").strip(),
+            )
             for r in rows
         ]
     except sqlite3.OperationalError:

--- a/src/ovp_pipeline/static/ovp-chat-drawer.css
+++ b/src/ovp_pipeline/static/ovp-chat-drawer.css
@@ -141,8 +141,55 @@
   font-size: 0.9375rem;
   line-height: 1.45;
   white-space: pre-wrap;
-  word-wrap: break-word;
+  overflow-wrap: break-word;
   margin: 0.25rem 0 0;
+}
+
+/* Markdown-rendered assistant turn — typography matches the
+ * pre-wrapped user variant but lays out as real HTML so lists,
+ * bold, links, code, tables all read properly. */
+.chat-drawer-body-md {
+  white-space: normal;
+}
+.chat-drawer-body-md p,
+.chat-drawer-body-md ul,
+.chat-drawer-body-md ol,
+.chat-drawer-body-md pre {
+  margin: 0.4rem 0;
+}
+.chat-drawer-body-md ul,
+.chat-drawer-body-md ol {
+  padding-left: 1.25rem;
+}
+.chat-drawer-body-md code {
+  background: var(--chat-drawer-muted);
+  padding: 0.05rem 0.3rem;
+  border-radius: 3px;
+  font-size: 0.875em;
+}
+.chat-drawer-body-md pre {
+  background: var(--chat-drawer-muted);
+  padding: 0.5rem;
+  border-radius: 4px;
+  overflow-x: auto;
+}
+.chat-drawer-body-md pre code {
+  background: transparent;
+  padding: 0;
+}
+.chat-drawer-body-md a {
+  color: var(--accent, #c2410c);
+  text-decoration: underline;
+}
+.chat-drawer-body-md table {
+  border-collapse: collapse;
+  margin: 0.5rem 0;
+}
+.chat-drawer-body-md th,
+.chat-drawer-body-md td {
+  border: 1px solid var(--chat-drawer-border);
+  padding: 0.25rem 0.5rem;
+  text-align: left;
 }
 
 .chat-drawer-composer {

--- a/src/ovp_pipeline/static/ovp-chat-drawer.js
+++ b/src/ovp_pipeline/static/ovp-chat-drawer.js
@@ -115,6 +115,15 @@
 
     clearStatus();
 
+    // User feedback (2026-05-13): "chat history disappeared, can't
+    // find it after refresh".  When localStorage carries a chat_id,
+    // fetch and rehydrate the prior turns so the operator sees what
+    // they typed before.  The session file lives on disk as
+    // ``visibility=unindexed`` until Save / Absorb / Discard.
+    if (state.chatId) {
+      rehydrateTranscript(state.chatId);
+    }
+
     // Restore the draft for this anchor (if any).  Survives page
     // reloads, drawer closes, and CSRF / network errors.
     const textarea = drawer.querySelector("[data-drawer-message]");
@@ -173,6 +182,53 @@
   }
 
   // --- Transcript injection ------------------------------------
+
+  async function rehydrateTranscript(chatId) {
+    try {
+      const resp = await fetch(
+        "/chat/drawer/transcript?id=" + encodeURIComponent(chatId),
+        { credentials: "same-origin", headers: { Accept: "application/json" } },
+      );
+      const data = await resp.json().catch(function () {
+        return { error: "invalid_json" };
+      });
+      if (!resp.ok) {
+        if (resp.status === 404) {
+          // Saved as indexed, absorbed, or discarded since last
+          // open — drop the stale chat_id and act like a fresh
+          // session.
+          state.chatId = null;
+          const key = anchorKey(state.anchorKind, state.anchorRef);
+          writeLS(SESSION_KEY_PREFIX, key, "");
+          const actions = $drawer().querySelector("[data-drawer-actions]");
+          if (actions) actions.hidden = true;
+          return;
+        }
+        showStatus(
+          "Couldn't load prior turns: " + (data.detail || resp.status),
+          { error: true },
+        );
+        return;
+      }
+      const turns = data && data.turns_html;
+      if (turns) {
+        const drawer = $drawer();
+        const transcript = drawer && drawer.querySelector("[data-drawer-transcript]");
+        if (transcript) {
+          transcript.innerHTML = turns;
+          transcript.dataset.empty = "false";
+          transcript.scrollTop = transcript.scrollHeight;
+        }
+        const actions = drawer && drawer.querySelector("[data-drawer-actions]");
+        if (actions) actions.hidden = false;
+      }
+    } catch (err) {
+      showStatus(
+        "Couldn't load prior turns: " + (err && err.message ? err.message : err),
+        { error: true },
+      );
+    }
+  }
 
   function appendTranscript(html) {
     const drawer = $drawer();

--- a/tests/test_chat_drawer_rehydrate.py
+++ b/tests/test_chat_drawer_rehydrate.py
@@ -1,0 +1,114 @@
+"""Tests for the drawer-transcript-rehydrate endpoint (post-M22 fix).
+
+The drawer's localStorage caches ``chat_id`` per anchor so a
+page reload reopens the same session.  Before this endpoint, the
+transcript itself was lost on reopen — operators saw an empty
+drawer and thought their history had vanished.  This module pins
+the rehydrate contract so a future refactor doesn't quietly
+re-introduce the data-loss perception.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ovp_pipeline.chat_fileops import (
+    ChatAnchor,
+    append_turn,
+    create_chat_file,
+)
+from ovp_pipeline.commands.ui_server import _render_drawer_turns_from_transcript
+
+
+def test_renders_user_then_assistant_sections(tmp_path: Path):
+    """Two turns → two ``<section>`` blocks in document order."""
+    path, _fm = create_chat_file(
+        tmp_path,
+        anchor=ChatAnchor("note", "10-Knowledge/Evergreen/x.md", "X"),
+    )
+    append_turn(path, role="user", body="What's the gist of X?")
+    append_turn(
+        path,
+        role="assistant",
+        body="X argues that emergent memory beats designed.",
+        turn_number=1,
+        manifest_lines=["note: synthetic"],
+    )
+    text = path.read_text(encoding="utf-8")
+
+    html = _render_drawer_turns_from_transcript(text)
+    assert html.count("<section") == 2
+    # User comes before assistant.
+    assert html.index("chat-drawer-turn-user") < html.index(
+        "chat-drawer-turn-assistant"
+    )
+    assert "What&#x27;s the gist" in html or "What's the gist" in html
+    assert "emergent memory beats designed" in html
+
+
+def test_strips_manifest_comment_from_assistant_body(tmp_path: Path):
+    """The ``<!-- context-manifest -->`` audit snapshot must NOT
+    leak into the drawer body — it's metadata, not prose."""
+    path, _fm = create_chat_file(
+        tmp_path,
+        anchor=ChatAnchor("note", "x.md", "X"),
+    )
+    append_turn(path, role="user", body="ask")
+    append_turn(
+        path,
+        role="assistant",
+        body="real answer text",
+        turn_number=1,
+        manifest_lines=["anchor: note: x.md", "retrieval_hits: 0"],
+    )
+    text = path.read_text(encoding="utf-8")
+    html = _render_drawer_turns_from_transcript(text)
+    assert "context-manifest" not in html
+    assert "anchor: note" not in html
+    assert "real answer text" in html
+
+
+def test_renders_assistant_markdown_as_html(tmp_path: Path):
+    """Assistant turn body that contains markdown should produce
+    real HTML (lists, bold) in the drawer."""
+    path, _fm = create_chat_file(
+        tmp_path,
+        anchor=ChatAnchor("standalone"),
+    )
+    append_turn(path, role="user", body="give me a list")
+    body_md = "- one\n- two\n- **three**\n"
+    append_turn(
+        path,
+        role="assistant",
+        body=body_md,
+        turn_number=1,
+        manifest_lines=["note: synthetic"],
+    )
+    text = path.read_text(encoding="utf-8")
+    html = _render_drawer_turns_from_transcript(text)
+    # markdown_it produces a <ul> + <li> for the bullets
+    assert "<ul>" in html
+    assert "<li>" in html
+    assert "<strong>three</strong>" in html
+
+
+def test_empty_transcript_returns_empty_string(tmp_path: Path):
+    path, _fm = create_chat_file(tmp_path, anchor=ChatAnchor("standalone"))
+    text = path.read_text(encoding="utf-8")
+    html = _render_drawer_turns_from_transcript(text)
+    assert html == ""
+
+
+def test_renderer_tolerates_text_without_frontmatter():
+    """A pasted assistant transcript without YAML frontmatter
+    should still parse if it contains the ``## User`` / ``## Assistant``
+    headers."""
+    text = (
+        "## User · 2026-05-13T00:00:00Z\n\nask\n\n"
+        "## Assistant · 2026-05-13T00:00:01Z · turn-1\n\nbody\n"
+    )
+    html = _render_drawer_turns_from_transcript(text)
+    assert "chat-drawer-turn-user" in html
+    assert "chat-drawer-turn-assistant" in html

--- a/tests/test_digest_handler.py
+++ b/tests/test_digest_handler.py
@@ -207,13 +207,19 @@ def test_no_data_path_skips_llm(tmp_path: Path):
 
 def test_is_no_data_detects_real_signal(tmp_path: Path):
     """When any layer has signal, _is_no_data returns False so the
-    handler enters the LLM branch."""
+    handler enters the LLM branch.
+
+    Use a pinned mid-day ``as_of`` so the test isn't flaky when run
+    just after UTC midnight (where seed-2h would land before the
+    window's local-day start).
+    """
     vault = _make_vault(tmp_path)
-    as_of = datetime.now(timezone.utc) - timedelta(minutes=30)
-    _seed_window_with_signal(vault, as_of=as_of)
+    pinned_as_of = datetime(2026, 5, 13, 12, 0, tzinfo=timezone.utc)
+    seed_at = pinned_as_of - timedelta(minutes=30)
+    _seed_window_with_signal(vault, as_of=seed_at)
     inputs = collect_digest_inputs(
         vault, "research-tech",
-        as_of=datetime.now(timezone.utc),
+        as_of=pinned_as_of,
         config=DigestConfig(tz="UTC"),
     )
     assert _is_no_data(inputs) is False


### PR DESCRIPTION
## Summary

Four issues found in first-day use of the freshly-merged M22 drawer + M23 digest.

### 1. Drawer renders assistant markdown (was raw text in ``<pre>``)

Route assistant turns through ``MarkdownIt(commonmark, html=False)``; user turns stay in ``<pre>`` so the operator's input shows verbatim.  Drawer CSS gains a ``.chat-drawer-body-md`` block.

### 2. "Ask about this" + digest neighbour nav on the same row

Flex row with ``gap: 0.75rem``.  ``_render_digest_neighbour_nav`` now returns an inline ``<span>`` instead of a ``<p>``.

### 3. P0 — drawer rehydrates transcript after page refresh

User report: *"找不到聊天记录了！"* — the session file lived on disk as ``visibility=unindexed`` so ``/chats`` correctly hid it; the drawer's localStorage cached ``chat_id`` but never re-fetched the prior turns.  Data was safe but invisible.

- New ``GET /chat/drawer/transcript?id=<chat_id>`` returns ``{turns_html, turn_count, chat_id}``.  Parses ``## User`` / ``## Assistant`` headers, strips ``<!-- context-manifest -->`` audit blocks, emits drawer-shaped HTML.
- Drawer JS calls it whenever ``openDrawer`` sees a cached chat_id.  404 (saved/absorbed/discarded since) clears the stale cache cleanly.
- 5 new tests pin the contract.

### 4. Digest body quality

User reported the new digest body said *"between midnight and 6 AM"* (LLM hallucination — we don't have hour-of-day data) and listed crystals as raw hex ids (``caa2903bc202``) instead of labels.

- Layer 2 ``recent_top_crystals`` joins ``graph_clusters`` + ``contradiction_crystals`` to surface the human label.  Tuple shape grew to ``(id, kind, score, label)``; renderer falls back to id only when label is empty.
- Prompt v2 gains two hard rules: ban time-of-day fabrication; require human labels in body prose, never raw hex ids.

## Test plan

- [x] 85 digest + drawer tests green (5 new in ``test_chat_drawer_rehydrate.py``).
- [x] Full chat + UI suite green (235 + 5 = 240; 7 xfailed pre-existing).
- [x] Smoke against operator's vault: rehydrate endpoint returns the user's actual "lost" chat at ``chat-21f57d4c`` with markdown-rendered body and stripped manifest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drawer now restores prior chat transcripts and exposes an endpoint returning rendered transcript HTML.
  * Assistant turns render Markdown as formatted HTML; user turns remain plain text.

* **Bug Fixes**
  * Digest items prefer human-readable crystal/cluster labels.
  * System prompt tightened to reduce invented topics/details.

* **Style**
  * Chat-drawer styling improved for Markdown, code, links and tables; thin-shell header actions layout compacted.

* **Tests**
  * Added tests covering transcript rehydration and rendering behavior.

* **Chores**
  * Markdown renderer dependency pinned.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fakechris/obsidian_vault_pipeline/pull/227)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->