### PR TITLE
feat(m23.1): /digests calendar grid + past-date regenerate

### DIFF
--- a/src/ovp_pipeline/commands/_digests_list_page.py
+++ b/src/ovp_pipeline/commands/_digests_list_page.py
@@ -1,29 +1,51 @@
-"""Reader ``/digests`` list view (M22 / BL-093).
+"""Reader ``/digests`` list view (M22 / BL-093 + M23.1 calendar).
 
 Daily digest history.  The home page surfaces only the latest
 digest; this page lists *all* digests under
-``40-Resources/Generated/digests/`` in reverse-chronological
-order so the operator can step through past days.
+``40-Resources/Generated/digests/`` and adds a 30-day calendar
+grid showing per-day digest existence + intake activity.
 
-Each entry links to the same ``/note?path=…`` markdown render
-the home card already opens; this module only adds the index
-(date + teaser + open link) and the prev/next neighbour nav
-that's missing once you're inside one of those notes.
+Calendar interactions:
+* ``✓ <date>``       → digest exists; click opens ``/note?path=…``
+* ``<date> · N ev``  → no digest, N intake events that day; click
+                       goes to ``/ops/today?date=<date>`` which has
+                       a "Regenerate digest for this day" button
+* ``<date>  —``      → no audit events either (genuinely quiet);
+                       click goes to ``/ops/today?date=<date>`` so
+                       the operator can verify
 
-Scope deliberately tight — no filtering, no search, no card
-chrome.  A small ``<ul>`` of dated rows is enough for the
-volume one operator generates (≤ 1 / day).
+The flat list below the grid stays unchanged for operators who
+prefer to scan filenames.
 """
 
 from __future__ import annotations
 
+import sqlite3
 from dataclasses import dataclass
+from datetime import date as date_cls
+from datetime import timedelta
 from html import escape
 from pathlib import Path
 from urllib.parse import quote
 
 
 DIGESTS_DIR = "40-Resources/Generated/digests"
+KNOWLEDGE_DB_REL = "60-Logs/knowledge.db"
+CALENDAR_WINDOW_DAYS = 30
+
+# The intake event types Layer 0 of the M23 digest counts.  Mirrors
+# the default ``DigestConfig.intake_event_types`` so the calendar
+# tells the operator the same story the digest body would (modulo
+# config overrides — the calendar always uses defaults, which is
+# fine because /digests is a Reader view, not a maintainer dial).
+_INTAKE_EVENT_TYPES = (
+    "article_processed",
+    "source_archived_to_processed",
+    "source_staged_for_processing",
+    "clippings_batch_processed",
+    "github_source_ingested",
+    "arxiv_source_ingested",
+)
 
 
 @dataclass(frozen=True)
@@ -92,16 +114,203 @@ def _extract_teaser(path: Path) -> str:
     return ""
 
 
+@dataclass(frozen=True)
+class CalendarCell:
+    """One day in the calendar grid.
+
+    Two boolean states drive the cell's class + click target:
+
+    * ``has_digest``    — a file ``YYYY-MM-DD-digest-daily.md`` exists
+    * ``intake_count``  — count of intake-event audit rows for the day
+                          in operator-local tz (today the calendar
+                          treats UTC and local as the same — the
+                          ``audit_events.timestamp`` strings start
+                          with ``YYYY-MM-DD`` regardless of suffix so
+                          a ``LIKE`` filter works without parsing).
+    """
+
+    date: str  # YYYY-MM-DD
+    has_digest: bool
+    intake_count: int
+    digest_href: str  # /note?path=... when has_digest else ""
+    explore_href: str  # /ops/today?date=...
+
+
+def build_calendar_cells(
+    vault_dir: Path | str,
+    *,
+    today: date_cls | None = None,
+    window_days: int = CALENDAR_WINDOW_DAYS,
+) -> list[CalendarCell]:
+    """Build the ``window_days``-day calendar window ending at ``today``.
+
+    Newest day last (so the natural left-to-right, top-to-bottom
+    grid reads chronologically).  Intake counts come from
+    ``audit_events``; missing knowledge.db → all zeros.
+    """
+    if today is None:
+        today = date_cls.today()
+    start = today - timedelta(days=window_days - 1)
+
+    digest_dates: dict[str, str] = {}
+    folder = Path(vault_dir) / DIGESTS_DIR
+    if folder.is_dir():
+        for path in folder.glob("*-digest-daily.md"):
+            d = path.name[:10]
+            try:
+                date_cls.fromisoformat(d)
+            except ValueError:
+                continue
+            try:
+                rel = str(path.relative_to(vault_dir))
+            except ValueError:
+                rel = str(path)
+            digest_dates[d] = f"/note?path={quote(rel, safe='')}"
+
+    intake_counts: dict[str, int] = {}
+    db_path = Path(vault_dir) / KNOWLEDGE_DB_REL
+    if db_path.is_file():
+        try:
+            with sqlite3.connect(db_path) as conn:
+                placeholders = ",".join("?" * len(_INTAKE_EVENT_TYPES))
+                rows = conn.execute(
+                    f"""
+                    SELECT substr(timestamp, 1, 10) AS day, COUNT(*) AS n
+                      FROM audit_events
+                     WHERE event_type IN ({placeholders})
+                       AND timestamp >= ?
+                       AND timestamp <  ?
+                     GROUP BY day
+                    """,
+                    (
+                        *_INTAKE_EVENT_TYPES,
+                        start.isoformat(),
+                        (today + timedelta(days=1)).isoformat(),
+                    ),
+                ).fetchall()
+                intake_counts = {row[0]: int(row[1]) for row in rows}
+        except sqlite3.OperationalError:
+            intake_counts = {}
+
+    cells: list[CalendarCell] = []
+    for offset in range(window_days):
+        d = (start + timedelta(days=offset)).isoformat()
+        cells.append(
+            CalendarCell(
+                date=d,
+                has_digest=d in digest_dates,
+                intake_count=int(intake_counts.get(d, 0)),
+                digest_href=digest_dates.get(d, ""),
+                explore_href=f"/ops/today?date={d}",
+            )
+        )
+    return cells
+
+
+def _render_calendar_grid(cells: list[CalendarCell]) -> str:
+    """Render the calendar grid + a small legend.
+
+    7-column grid (one column per weekday).  Newest day in the
+    bottom-right.  Each cell gets a CSS class encoding its state
+    so themes can recolour without touching this renderer.
+    """
+    if not cells:
+        return ""
+
+    # Pad the prefix so the first row aligns Monday → Sunday.  Use
+    # ISO weekday() (Mon=0..Sun=6).
+    first = date_cls.fromisoformat(cells[0].date)
+    leading_blanks = first.weekday()
+
+    def _cell_html(cell: CalendarCell) -> str:
+        date_short = cell.date[5:]  # MM-DD for readability
+        if cell.has_digest:
+            cls = "cal-cell cal-cell-has-digest"
+            inner = (
+                f"<a href='{escape(cell.digest_href)}'>"
+                f"<span class='cal-tick'>✓</span> "
+                f"<span class='cal-date'>{escape(date_short)}</span>"
+                "</a>"
+                f"<a href='{escape(cell.explore_href)}' "
+                f"class='cal-explore' title='Inspect this day in /ops/today'>↗</a>"
+            )
+        elif cell.intake_count > 0:
+            cls = "cal-cell cal-cell-has-intake"
+            inner = (
+                f"<a href='{escape(cell.explore_href)}'>"
+                f"<span class='cal-date'>{escape(date_short)}</span>"
+                f"<span class='cal-count'>{cell.intake_count}</span>"
+                "</a>"
+            )
+        else:
+            cls = "cal-cell cal-cell-empty"
+            inner = (
+                f"<a href='{escape(cell.explore_href)}'>"
+                f"<span class='cal-date'>{escape(date_short)}</span>"
+                "<span class='cal-count muted'>—</span>"
+                "</a>"
+            )
+        return f"<div class='{cls}'>{inner}</div>"
+
+    blank_html = "<div class='cal-cell cal-cell-blank'></div>" * leading_blanks
+    cells_html = "".join(_cell_html(c) for c in cells)
+
+    legend = (
+        "<p class='muted small' style='margin-top:0.4rem'>"
+        "✓ digest exists · "
+        "N = intake events (click to inspect day) · "
+        "— = quiet day"
+        "</p>"
+    )
+    return (
+        "<section style='margin:1rem 0'>"
+        "<style>"
+        ".cal-grid{display:grid;grid-template-columns:repeat(7,1fr);"
+        "gap:4px;margin-top:0.5rem}"
+        ".cal-cell{border:1px solid var(--border, #e5e5e5);border-radius:4px;"
+        "padding:6px 8px;min-height:48px;font-size:0.85rem;"
+        "display:flex;flex-direction:column;justify-content:space-between}"
+        ".cal-cell-blank{border:0}"
+        ".cal-cell a{text-decoration:none;color:inherit;display:block}"
+        ".cal-cell-has-digest{background:var(--accent-soft, #fef3e8);"
+        "border-color:var(--accent, #c2410c)}"
+        ".cal-cell-has-digest .cal-tick{color:var(--accent, #c2410c);"
+        "font-weight:600}"
+        ".cal-cell-has-intake{background:var(--muted-bg, #f6f6f6)}"
+        ".cal-cell-empty{opacity:0.55}"
+        ".cal-cell .cal-date{font-family:var(--ovp-font-mono, monospace);"
+        "font-size:0.85em}"
+        ".cal-cell .cal-count{float:right;font-size:0.8em;"
+        "color:var(--muted, #666)}"
+        ".cal-cell .cal-explore{float:right;font-size:0.85em;"
+        "color:var(--muted, #666)}"
+        "</style>"
+        f"<div class='cal-grid'>{blank_html}{cells_html}</div>"
+        f"{legend}"
+        "</section>"
+    )
+
+
 def render_digests_list_body(vault_dir: Path | str) -> str:
     """Render the body HTML for ``/digests``."""
     rows = list_digests(vault_dir)
+    cells = build_calendar_cells(vault_dir)
+    calendar_html = _render_calendar_grid(cells)
+
+    header = (
+        "<h1>Daily digests</h1>"
+        "<p class='muted'>Last 30 days at a glance — click any day "
+        "to open its digest or inspect the audit-event activity.</p>"
+        + calendar_html
+    )
+
     if not rows:
-        return (
-            "<h1>Daily digests</h1>"
-            "<p class='muted'>No digests yet.  Generated digests land in "
+        empty = (
+            "<p class='muted'>No digest files yet.  Generated digests land in "
             f"<code>{escape(DIGESTS_DIR)}</code> as the pipeline produces "
             "them — typically one per UTC day.</p>"
         )
+        return header + empty
 
     items: list[str] = []
     for row in rows:
@@ -121,9 +330,10 @@ def render_digests_list_body(vault_dir: Path | str) -> str:
         )
     list_html = "<ul style='list-style:none;padding:0'>" + "".join(items) + "</ul>"
     return (
-        "<h1>Daily digests</h1>"
-        f"<p class='muted'>{len(rows)} digest"
-        f"{'s' if len(rows) != 1 else ''} — newest first.</p>"
+        header
+        + "<h2 style='margin-top:1.5rem'>All digests</h2>"
+        + f"<p class='muted small'>{len(rows)} digest"
+        + f"{'s' if len(rows) != 1 else ''} — newest first.</p>"
         + list_html
     )
 

--- a/src/ovp_pipeline/commands/_digests_list_page.py
+++ b/src/ovp_pipeline/commands/_digests_list_page.py
@@ -262,29 +262,11 @@ def _render_calendar_grid(cells: list[CalendarCell]) -> str:
         "— = quiet day"
         "</p>"
     )
+    # Calendar styles live in /static/ovp-digests-calendar.css (gemini
+    # code review — embed-CSS was hurting cache + maintainability).
+    # Loaded by the page shell via _layout's stylesheet block.
     return (
         "<section style='margin:1rem 0'>"
-        "<style>"
-        ".cal-grid{display:grid;grid-template-columns:repeat(7,1fr);"
-        "gap:4px;margin-top:0.5rem}"
-        ".cal-cell{border:1px solid var(--border, #e5e5e5);border-radius:4px;"
-        "padding:6px 8px;min-height:48px;font-size:0.85rem;"
-        "display:flex;flex-direction:column;justify-content:space-between}"
-        ".cal-cell-blank{border:0}"
-        ".cal-cell a{text-decoration:none;color:inherit;display:block}"
-        ".cal-cell-has-digest{background:var(--accent-soft, #fef3e8);"
-        "border-color:var(--accent, #c2410c)}"
-        ".cal-cell-has-digest .cal-tick{color:var(--accent, #c2410c);"
-        "font-weight:600}"
-        ".cal-cell-has-intake{background:var(--muted-bg, #f6f6f6)}"
-        ".cal-cell-empty{opacity:0.55}"
-        ".cal-cell .cal-date{font-family:var(--ovp-font-mono, monospace);"
-        "font-size:0.85em}"
-        ".cal-cell .cal-count{float:right;font-size:0.8em;"
-        "color:var(--muted, #666)}"
-        ".cal-cell .cal-explore{float:right;font-size:0.85em;"
-        "color:var(--muted, #666)}"
-        "</style>"
         f"<div class='cal-grid'>{blank_html}{cells_html}</div>"
         f"{legend}"
         "</section>"

--- a/src/ovp_pipeline/commands/_ui_renderers.py
+++ b/src/ovp_pipeline/commands/_ui_renderers.py
@@ -492,26 +492,40 @@ def _render_digest_health_page(payload: dict) -> str:
     return _layout("Digest health", body)
 
 
-def _render_digest_regenerate_button(requested_pack: str) -> str:
+def _render_digest_regenerate_button(
+    requested_pack: str, *, date: str = ""
+) -> str:
     """Render the "Regenerate digest now" button on ``/ops/today``.
 
     POSTs to ``/ops/digest/regenerate`` which enqueues + dispatches
     a ``DIGEST-daily`` task synchronously.  With the M23 input-hash
     gate (BL-095), unchanged-data clicks return the prior body
     without an LLM call — operators get a cheap "fresh" button.
+
+    ``date`` (YYYY-MM-DD) is passed through as a hidden field for
+    past-date regenerate (M23.1).  Empty → today's UTC date.
     """
     pack_input = (
         f"<input type='hidden' name='pack' value='{escape(requested_pack)}' />"
         if requested_pack
         else ""
     )
+    date_input = (
+        f"<input type='hidden' name='date' value='{escape(date)}' />"
+        if date
+        else ""
+    )
+    label = (
+        f"Regenerate digest for {escape(date)}"
+        if date
+        else "Regenerate today's digest"
+    )
     return (
         "<form method='post' action='/ops/digest/regenerate' "
         "style='display:inline-block;margin:0.6rem 0 0.2rem 0'>"
         f"{pack_input}"
-        "<button type='submit' class='btn'>"
-        "Regenerate today's digest"
-        "</button>"
+        f"{date_input}"
+        f"<button type='submit' class='btn'>{label}</button>"
         " <span class='muted small'>"
         "Cheap — skips the LLM call when nothing changed since last run."
         "</span>"
@@ -6674,7 +6688,13 @@ def _render_today_digest_page(payload: dict) -> str:
     # operator who drops articles mid-day can immediately trigger a
     # new digest.  Input-hash gate (BL-095) keeps the cost bounded —
     # unchanged inputs return the same body without an LLM call.
-    sections.append(_render_digest_regenerate_button(requested_pack))
+    #
+    # M23.1: pass the page's ``date`` through so a past-date dispatch
+    # writes to the right ``YYYY-MM-DD-digest-daily.md`` file rather
+    # than UTC-today.
+    sections.append(
+        _render_digest_regenerate_button(requested_pack, date=date)
+    )
     sections.append("<div class='grid stats' style='margin-top:1rem'>")
     for card in cards:
         card_id = str(card.get("id") or "")

--- a/src/ovp_pipeline/commands/_ui_renderers.py
+++ b/src/ovp_pipeline/commands/_ui_renderers.py
@@ -573,6 +573,7 @@ def _layout(
     <link rel="stylesheet" href="/static/ovp-ui.css" />
     <link rel="stylesheet" href="/static/ovp-pages.css" />
     <link rel="stylesheet" href="/static/ovp-chat-drawer.css" />
+    <link rel="stylesheet" href="/static/ovp-digests-calendar.css" />
     <script src="/static/ovp-chat-drawer.js" defer></script>
     <style>
       /* Page-local additions only — anything reusable belongs in

--- a/src/ovp_pipeline/commands/digest_handler.py
+++ b/src/ovp_pipeline/commands/digest_handler.py
@@ -164,22 +164,80 @@ Hard rules:
 
 
 # ---------------------------------------------------------------
+# Target-date plumbing (M23.1: past-date regenerate)
+# ---------------------------------------------------------------
+
+
+_TARGET_DATE_RE = re.compile(r"-(\d{4}-\d{2}-\d{2})$")
+
+
+def _parse_target_date_from_slug(slug: str) -> str:
+    """Recover a ``YYYY-MM-DD`` suffix from a DIGEST task slug.
+
+    Today the default slug is ``daily`` (no date suffix → empty
+    string → handler runs against today).  The maintainer's
+    "Regenerate digest for this day" button enqueues
+    ``DIGEST-daily-2026-05-11.md`` so the dispatcher's slug
+    becomes ``daily-2026-05-11`` and this helper extracts the
+    date back out.
+    """
+    if not slug:
+        return ""
+    match = _TARGET_DATE_RE.search(slug)
+    return match.group(1) if match else ""
+
+
+def _as_of_for_target_date(config: DigestConfig, target_date: str) -> datetime | None:
+    """Translate ``"YYYY-MM-DD"`` into the ``as_of`` datetime
+    ``collect_digest_inputs`` expects.
+
+    Empty input → ``None`` so the collector defaults to wall-clock
+    now.  A real date → end-of-day in the configured tz so the
+    window resolution picks up the local-day boundary cleanly.
+    """
+    if not target_date:
+        return None
+    from ..digest_config import resolve_timezone
+
+    tz = resolve_timezone(config)
+    try:
+        when = datetime.strptime(target_date, "%Y-%m-%d")
+    except ValueError:
+        return None
+    return when.replace(hour=23, minute=59, second=59, tzinfo=tz)
+
+
+# ---------------------------------------------------------------
 # Handler entry point
 # ---------------------------------------------------------------
 
 
 def handle_digest(ctx: TaskContext) -> TaskResult:
-    """Compose one digest for ``ctx.pack`` against the current vault state."""
+    """Compose one digest for ``ctx.pack`` against the current vault state.
+
+    The slug may carry a target date as ``daily-YYYY-MM-DD`` (e.g.
+    ``DIGEST-daily-2026-05-11.md`` for regenerating 5/11).  Without a
+    suffix the digest runs against today's local-day window.
+    """
     config = load_digest_config(ctx.vault_dir)
-    inputs = collect_digest_inputs(ctx.vault_dir, ctx.pack, config=config)
+    target_date = _parse_target_date_from_slug(ctx.slug)
+    as_of = _as_of_for_target_date(config, target_date)
+    inputs = collect_digest_inputs(
+        ctx.vault_dir, ctx.pack, as_of=as_of, config=config,
+    )
     new_hash = inputs.input_hash()
+
+    # Filename the dispatcher will write under.  For a past-date
+    # regenerate, override so the file lands at the right
+    # ``YYYY-MM-DD-digest-daily.md``.
+    date_override = target_date if target_date else None
 
     # Idempotency gate — Stage 3 of the M23 plan.  Read any prior
     # digest at the expected filename; if its ``input_hash`` matches,
     # skip the LLM call and return the prior body verbatim so the
     # dispatcher's overwrite is a no-op rewrite.
     if config.skip_unchanged:
-        prior_path = _expected_output_path(ctx.vault_dir)
+        prior_path = _expected_output_path(ctx.vault_dir, date_str=date_override)
         prior_hash, prior_body = _read_prior_digest(prior_path)
         if prior_body and prior_hash == new_hash:
             emit(
@@ -202,6 +260,7 @@ def handle_digest(ctx: TaskContext) -> TaskResult:
                     "skipped_llm": True,
                     "reason": "no_change",
                 },
+                date_override=date_override,
             )
 
     # No-data path: when nothing meaningful changed, render an
@@ -225,6 +284,7 @@ def handle_digest(ctx: TaskContext) -> TaskResult:
                 "reason": "no_data",
                 **_layer_counts(inputs),
             },
+            date_override=date_override,
         )
 
     # Real digest — call the LLM with the structured input layers.
@@ -260,6 +320,7 @@ def handle_digest(ctx: TaskContext) -> TaskResult:
             "skipped_llm": False,
             **_layer_counts(inputs),
         },
+        date_override=date_override,
     )
 
 
@@ -761,13 +822,30 @@ def _build_footer(inputs: DigestInputs, ctx: TaskContext | None) -> str:
 # ---------------------------------------------------------------
 
 
-def _enqueue_daily(vault_dir: Path) -> Path:
-    """Drop ``DIGEST-daily.md`` into ``50-Inbox/02-Tasks/`` so the
-    next dispatcher run picks it up.  Idempotent — if today's task
-    file already exists, return its path without overwriting."""
+def _enqueue_daily(vault_dir: Path, *, target_date: str | None = None) -> Path:
+    """Drop ``DIGEST-daily[-YYYY-MM-DD].md`` into ``50-Inbox/02-Tasks/``
+    so the next dispatcher run picks it up.
+
+    Without ``target_date`` the file is ``DIGEST-daily.md`` and the
+    handler runs against today's local-day window (the M20 default).
+
+    With ``target_date="YYYY-MM-DD"`` the file is
+    ``DIGEST-daily-YYYY-MM-DD.md``.  The dispatcher splits that into
+    ``slug = "daily-YYYY-MM-DD"`` and the handler's
+    ``_parse_target_date_from_slug`` extracts the date back out.
+
+    Idempotent — if the task file already exists, return its path
+    without overwriting.  The dispatcher's "rate limit per UTC day"
+    counts task DISPATCHES, not task ENQUEUES, so re-enqueueing the
+    same task is cheap.
+    """
     folder = vault_dir / "50-Inbox" / "02-Tasks"
     folder.mkdir(parents=True, exist_ok=True)
-    target = folder / "DIGEST-daily.md"
+    if target_date:
+        filename = f"DIGEST-daily-{target_date}.md"
+    else:
+        filename = "DIGEST-daily.md"
+    target = folder / filename
     if target.exists():
         return target
     target.write_text(
@@ -808,10 +886,32 @@ def main(argv: list[str] | None = None) -> int:
         "--pack", default="research-tech",
         help="Pack name (default: research-tech).",
     )
+    parser.add_argument(
+        "--date", default="",
+        help=(
+            "Target date YYYY-MM-DD for past-date regenerate.  "
+            "Default: today.  Note: regenerated past-date digests "
+            "see today's crystal labels, not the labels that "
+            "existed on that date (the audit_events filter is "
+            "rigorous; the synthesis layer is best-effort)."
+        ),
+    )
     args = parser.parse_args(argv)
 
     if not any((args.enqueue_daily, args.run_now, args.show_latest)):
         parser.error("pass --enqueue-daily, --run-now, or --show-latest")
+
+    if args.date:
+        # Validate YYYY-MM-DD up front so a typo errors before any
+        # task file lands in 50-Inbox/02-Tasks/.
+        try:
+            datetime.strptime(args.date, "%Y-%m-%d")
+        except ValueError:
+            print(
+                f"error: --date {args.date!r} is not YYYY-MM-DD",
+                file=sys.stderr,
+            )
+            return 2
 
     vault = args.vault_dir.expanduser().resolve()
     if not vault.exists():
@@ -827,7 +927,7 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     if args.enqueue_daily or args.run_now:
-        task = _enqueue_daily(vault)
+        task = _enqueue_daily(vault, target_date=args.date or None)
         if args.run_now:
             try:
                 output = dispatch_task(vault, task, pack=args.pack)

--- a/src/ovp_pipeline/commands/digest_handler.py
+++ b/src/ovp_pipeline/commands/digest_handler.py
@@ -55,7 +55,7 @@ from pathlib import Path
 from typing import Any
 
 from ..context_loader import load_user_profile
-from ..digest_config import DigestConfig, load_digest_config
+from ..digest_config import DigestConfig, load_digest_config, resolve_timezone
 from ..digest_inputs import (
     ConnectionLayer,
     DeltaLayer,
@@ -197,8 +197,6 @@ def _as_of_for_target_date(config: DigestConfig, target_date: str) -> datetime |
     """
     if not target_date:
         return None
-    from ..digest_config import resolve_timezone
-
     tz = resolve_timezone(config)
     try:
         when = datetime.strptime(target_date, "%Y-%m-%d")

--- a/src/ovp_pipeline/commands/task_dispatch.py
+++ b/src/ovp_pipeline/commands/task_dispatch.py
@@ -120,12 +120,19 @@ class TaskResult:
         body_md: str,
         subdir: str = "",
         metadata: dict[str, Any] | None = None,
+        date_override: str | None = None,
     ) -> None:
         self.body_md = body_md
         # Override the default ``YYYY-MM/`` placement; e.g. digest
         # handler writes to ``digests/`` instead.
         self.subdir = subdir
         self.metadata = metadata or {}
+        # Override the ``YYYY-MM-DD`` prefix the dispatcher otherwise
+        # derives from UTC-today.  Set by the digest handler when
+        # operating on a past date so the file lands at
+        # ``YYYY-MM-DD-digest-daily.md`` (not today's date).  ``None``
+        # → default UTC-today behavior.
+        self.date_override = date_override
 
 
 _HANDLERS: dict[str, tuple[HandlerFn, str]] = {}
@@ -218,14 +225,32 @@ def _slugify_for_output(slug: str) -> str:
 
 
 def _resolve_output_path(
-    vault_dir: Path, prefix: str, slug: str, subdir: str
+    vault_dir: Path,
+    prefix: str,
+    slug: str,
+    subdir: str,
+    *,
+    date_override: str | None = None,
 ) -> Path:
+    """Compose the ``Generated/<subdir>/<date>-<prefix>-<slug>.md`` path.
+
+    ``date_override`` lets a handler write to a past or future
+    date (e.g. ``ovp-digest --date 2026-05-11``).  ``None`` keeps
+    the default UTC-today behavior.  When the override is set,
+    its month is also used for the ``YYYY-MM/`` subdir fallback
+    so a regenerated past digest doesn't land in this month's
+    folder.
+    """
     if subdir:
         base = vault_dir / GENERATED_REL / subdir
     else:
-        base = vault_dir / GENERATED_REL / _today_utc_month()
+        if date_override and len(date_override) >= 7:
+            base = vault_dir / GENERATED_REL / date_override[:7]
+        else:
+            base = vault_dir / GENERATED_REL / _today_utc_month()
     base.mkdir(parents=True, exist_ok=True)
-    fname = f"{_today_utc_date()}-{prefix.lower()}-{_slugify_for_output(slug)}.md"
+    date_str = date_override or _today_utc_date()
+    fname = f"{date_str}-{prefix.lower()}-{_slugify_for_output(slug)}.md"
     return base / fname
 
 
@@ -338,7 +363,10 @@ def dispatch_task(
         raise DispatchError(f"handler {prefix} failed: {exc}") from exc
     duration_ms = int((time.monotonic() - start) * 1000)
 
-    output_path = _resolve_output_path(vault_dir, prefix, slug, result.subdir)
+    output_path = _resolve_output_path(
+        vault_dir, prefix, slug, result.subdir,
+        date_override=result.date_override,
+    )
     output_path.write_text(result.body_md, encoding="utf-8")
 
     archived_path: Path | None = None

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -2081,11 +2081,19 @@ def create_server(
             click costs only the preflight queries — no LLM call.
             A real data change triggers a fresh digest.
 
+            Optional ``date`` form field selects a past day for
+            regenerate (M23.1).  The handler reads ``audit_events``
+            filtered to that day in operator-local tz; the synthesis
+            layer is still pulled from the *current* knowledge.db
+            (not a historical snapshot).
+
             POST-only (CSRF-protected by the global ``_csrf`` check
-            higher up in ``do_POST``).  Redirects back to
-            ``/ops/today`` so the operator can refresh and see the
-            new digest reflected in the home banner.
+            higher up in ``do_POST``).  Redirects back to the
+            referrer (or ``/ops/today``) so the operator can refresh
+            and see the new digest.
             """
+            from datetime import datetime
+
             from ovp_pipeline.commands.digest_handler import _enqueue_daily
             from ovp_pipeline.commands.task_dispatch import (
                 DispatchError,
@@ -2094,7 +2102,16 @@ def create_server(
             )
 
             pack = (self._form_first(form, "pack") or "").strip() or "research-tech"
-            task = _enqueue_daily(resolved_vault)
+            date_str = (self._form_first(form, "date") or "").strip()
+            if date_str:
+                try:
+                    datetime.strptime(date_str, "%Y-%m-%d")
+                except ValueError:
+                    self.send_error(
+                        400, f"date {date_str!r} is not YYYY-MM-DD"
+                    )
+                    return
+            task = _enqueue_daily(resolved_vault, target_date=date_str or None)
             try:
                 dispatch_task(resolved_vault, task, pack=pack)
             except RateLimitedError as exc:
@@ -2106,7 +2123,16 @@ def create_server(
             except Exception as exc:  # noqa: BLE001 — provider failures
                 self.send_error(500, f"digest regenerate failed: {exc}")
                 return
-            self._redirect(self._form_first(form, "next").strip() or "/ops/today")
+            # Default redirect: when a past date was regenerated,
+            # send the operator back to that day's view (or /digests
+            # if they came from the calendar).  Otherwise /ops/today.
+            next_target = self._form_first(form, "next").strip()
+            if not next_target:
+                if date_str:
+                    next_target = f"/ops/today?date={date_str}"
+                else:
+                    next_target = "/ops/today"
+            self._redirect(next_target)
 
         def _resolve_contradiction_action(self, form: dict[str, list[str]]) -> dict[str, object]:
             contradiction_ids = [

--- a/src/ovp_pipeline/static/ovp-digests-calendar.css
+++ b/src/ovp_pipeline/static/ovp-digests-calendar.css
@@ -1,0 +1,69 @@
+/* M23.1 — /digests calendar grid.
+ *
+ * Renders the 30-day calendar grid on /digests.  Loaded once by
+ * the page shell so the styles can be browser-cached instead of
+ * re-shipped inline with every render (gemini code review).
+ */
+
+.cal-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 4px;
+  margin-top: 0.5rem;
+}
+
+.cal-cell {
+  border: 1px solid var(--border, #e5e5e5);
+  border-radius: 4px;
+  padding: 6px 8px;
+  min-height: 48px;
+  font-size: 0.85rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.cal-cell-blank {
+  border: 0;
+}
+
+.cal-cell a {
+  text-decoration: none;
+  color: inherit;
+  display: block;
+}
+
+.cal-cell-has-digest {
+  background: var(--accent-soft, #fef3e8);
+  border-color: var(--accent, #c2410c);
+}
+
+.cal-cell-has-digest .cal-tick {
+  color: var(--accent, #c2410c);
+  font-weight: 600;
+}
+
+.cal-cell-has-intake {
+  background: var(--muted-bg, #f6f6f6);
+}
+
+.cal-cell-empty {
+  opacity: 0.55;
+}
+
+.cal-cell .cal-date {
+  font-family: var(--ovp-font-mono, monospace);
+  font-size: 0.85em;
+}
+
+.cal-cell .cal-count {
+  float: right;
+  font-size: 0.8em;
+  color: var(--muted, #666);
+}
+
+.cal-cell .cal-explore {
+  float: right;
+  font-size: 0.85em;
+  color: var(--muted, #666);
+}

--- a/tests/test_digest_calendar.py
+++ b/tests/test_digest_calendar.py
@@ -54,31 +54,35 @@ def _seed_intake(conn: sqlite3.Connection, day: str, count: int) -> None:
 # ── Slug parsing ────────────────────────────────────────────────
 
 
+# Slug parser is a shape-only regex; ``_as_of_for_target_date`` is
+# what catches calendar-invalid dates like 2026-13-01.  Split the
+# two responsibilities into two clearly-named tests so the
+# parametrize stops mixing happy-path and shape-only-bad cases
+# (gemini code-review nit on the prior single-table form).
 @pytest.mark.parametrize(
     "slug,expected",
     [
         ("daily", ""),
-        ("daily-2026-05-11", "2026-05-11"),
-        ("daily-2026-12-31", "2026-12-31"),
         ("daily-foo", ""),
         ("", ""),
-        ("daily-2026-13-01", ""),  # bad month — handler validates downstream
+        ("daily-2026-05-11", "2026-05-11"),
+        ("daily-2026-12-31", "2026-12-31"),
     ],
 )
-def test_parse_target_date_from_slug(slug, expected):
-    # The regex only checks shape, not date validity — that's the
-    # handler's job via _as_of_for_target_date.  Bad-month case
-    # should pass the regex but fail the strptime later.
-    result = _parse_target_date_from_slug(slug)
-    if expected:
-        assert result == expected
-    else:
-        # Bad-month case (2026-13-01) returns the matched string;
-        # strptime catches it.  Empty / no-suffix returns "".
-        if slug == "daily-2026-13-01":
-            assert result == "2026-13-01"
-        else:
-            assert result == ""
+def test_parse_target_date_extracts_or_returns_empty(slug, expected):
+    """Happy path: well-formed suffix → date string; missing or
+    malformed suffix → empty string."""
+    assert _parse_target_date_from_slug(slug) == expected
+
+
+def test_parse_target_date_passes_shape_but_invalid_calendar_dates():
+    """The regex only checks shape (``\\d{4}-\\d{2}-\\d{2}``); a bad
+    calendar date like 2026-13-01 still matches the shape, and
+    downstream ``_as_of_for_target_date`` is where it gets caught.
+    Documented here so the contract is clear."""
+    assert _parse_target_date_from_slug("daily-2026-13-01") == "2026-13-01"
+    # The validation gate that catches it:
+    assert _as_of_for_target_date(DigestConfig(tz="UTC"), "2026-13-01") is None
 
 
 def test_as_of_for_target_date_invalid_returns_none():

--- a/tests/test_digest_calendar.py
+++ b/tests/test_digest_calendar.py
@@ -1,0 +1,228 @@
+"""Tests for the M23.1 /digests calendar grid + past-date regenerate."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from ovp_pipeline.commands._digests_list_page import (
+    build_calendar_cells,
+    render_digests_list_body,
+)
+from ovp_pipeline.commands.digest_handler import (
+    _as_of_for_target_date,
+    _enqueue_daily,
+    _parse_target_date_from_slug,
+)
+from ovp_pipeline.digest_config import DigestConfig
+
+
+def _make_vault(tmp_path: Path) -> Path:
+    """Vault skeleton with the directories the calendar reads."""
+    (tmp_path / "40-Resources" / "Generated" / "digests").mkdir(parents=True)
+    (tmp_path / "50-Inbox" / "02-Tasks").mkdir(parents=True)
+    (tmp_path / "60-Logs").mkdir(parents=True)
+    return tmp_path
+
+
+def _make_audit_db(vault: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(vault / "60-Logs" / "knowledge.db")
+    conn.executescript("""
+        CREATE TABLE audit_events (
+            source_log TEXT, event_type TEXT, slug TEXT, session_id TEXT,
+            timestamp TEXT, payload_json TEXT
+        );
+    """)
+    conn.commit()
+    return conn
+
+
+def _seed_intake(conn: sqlite3.Connection, day: str, count: int) -> None:
+    for i in range(count):
+        ts = f"{day}T{i:02d}:30:00+00:00"
+        conn.execute(
+            "INSERT INTO audit_events VALUES (?, ?, ?, ?, ?, ?)",
+            ("pipeline.jsonl", "article_processed", f"s-{i}", "x", ts, "{}"),
+        )
+    conn.commit()
+
+
+# ── Slug parsing ────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "slug,expected",
+    [
+        ("daily", ""),
+        ("daily-2026-05-11", "2026-05-11"),
+        ("daily-2026-12-31", "2026-12-31"),
+        ("daily-foo", ""),
+        ("", ""),
+        ("daily-2026-13-01", ""),  # bad month — handler validates downstream
+    ],
+)
+def test_parse_target_date_from_slug(slug, expected):
+    # The regex only checks shape, not date validity — that's the
+    # handler's job via _as_of_for_target_date.  Bad-month case
+    # should pass the regex but fail the strptime later.
+    result = _parse_target_date_from_slug(slug)
+    if expected:
+        assert result == expected
+    else:
+        # Bad-month case (2026-13-01) returns the matched string;
+        # strptime catches it.  Empty / no-suffix returns "".
+        if slug == "daily-2026-13-01":
+            assert result == "2026-13-01"
+        else:
+            assert result == ""
+
+
+def test_as_of_for_target_date_invalid_returns_none():
+    cfg = DigestConfig(tz="UTC")
+    assert _as_of_for_target_date(cfg, "2026-13-01") is None
+    assert _as_of_for_target_date(cfg, "") is None
+
+
+def test_as_of_for_target_date_returns_end_of_day_in_tz():
+    cfg = DigestConfig(tz="UTC")
+    as_of = _as_of_for_target_date(cfg, "2026-05-11")
+    assert as_of is not None
+    assert as_of.year == 2026
+    assert as_of.month == 5
+    assert as_of.day == 11
+    assert as_of.hour == 23
+
+
+# ── _enqueue_daily ───────────────────────────────────────────────
+
+
+def test_enqueue_daily_default_filename(tmp_path: Path):
+    vault = _make_vault(tmp_path)
+    p = _enqueue_daily(vault)
+    assert p.name == "DIGEST-daily.md"
+
+
+def test_enqueue_daily_with_target_date(tmp_path: Path):
+    vault = _make_vault(tmp_path)
+    p = _enqueue_daily(vault, target_date="2026-05-11")
+    assert p.name == "DIGEST-daily-2026-05-11.md"
+
+
+def test_enqueue_daily_is_idempotent(tmp_path: Path):
+    vault = _make_vault(tmp_path)
+    p1 = _enqueue_daily(vault, target_date="2026-05-11")
+    p1.write_text("modified", encoding="utf-8")
+    p2 = _enqueue_daily(vault, target_date="2026-05-11")
+    assert p1 == p2
+    assert p2.read_text() == "modified"  # didn't overwrite
+
+
+# ── Calendar cells ───────────────────────────────────────────────
+
+
+def test_calendar_window_default_size(tmp_path: Path):
+    vault = _make_vault(tmp_path)
+    cells = build_calendar_cells(vault, today=date(2026, 5, 13))
+    assert len(cells) == 30
+    # Newest day last → chronological reading order.
+    assert cells[-1].date == "2026-05-13"
+    assert cells[0].date == "2026-04-14"
+
+
+def test_calendar_marks_existing_digests(tmp_path: Path):
+    vault = _make_vault(tmp_path)
+    (vault / "40-Resources/Generated/digests" / "2026-05-12-digest-daily.md").write_text(
+        "stub", encoding="utf-8"
+    )
+    cells = build_calendar_cells(vault, today=date(2026, 5, 13))
+    has_digest = {c.date: c.has_digest for c in cells}
+    assert has_digest["2026-05-12"] is True
+    assert has_digest["2026-05-11"] is False
+    assert has_digest["2026-05-13"] is False
+
+
+def test_calendar_counts_intake_per_day(tmp_path: Path):
+    vault = _make_vault(tmp_path)
+    conn = _make_audit_db(vault)
+    _seed_intake(conn, "2026-05-12", 5)
+    _seed_intake(conn, "2026-05-10", 2)
+    conn.close()
+    cells = build_calendar_cells(vault, today=date(2026, 5, 13))
+    counts = {c.date: c.intake_count for c in cells}
+    assert counts["2026-05-12"] == 5
+    assert counts["2026-05-10"] == 2
+    assert counts["2026-05-11"] == 0
+
+
+def test_calendar_ignores_non_intake_event_types(tmp_path: Path):
+    vault = _make_vault(tmp_path)
+    conn = _make_audit_db(vault)
+    conn.execute(
+        "INSERT INTO audit_events VALUES (?, ?, ?, ?, ?, ?)",
+        (
+            "pipeline.jsonl",
+            "task_dispatched",
+            "x",
+            "s",
+            "2026-05-12T12:00:00+00:00",
+            "{}",
+        ),
+    )
+    conn.commit()
+    conn.close()
+    cells = build_calendar_cells(vault, today=date(2026, 5, 13))
+    counts = {c.date: c.intake_count for c in cells}
+    assert counts["2026-05-12"] == 0
+
+
+def test_calendar_handles_missing_db(tmp_path: Path):
+    vault = _make_vault(tmp_path)
+    cells = build_calendar_cells(vault, today=date(2026, 5, 13))
+    assert all(c.intake_count == 0 for c in cells)
+
+
+# ── Body rendering ──────────────────────────────────────────────
+
+
+def test_render_body_includes_calendar_section(tmp_path: Path):
+    vault = _make_vault(tmp_path)
+    html = render_digests_list_body(vault)
+    assert "Last 30 days at a glance" in html
+    assert "cal-grid" in html
+
+
+def test_render_body_marks_digest_cells_with_tick(tmp_path: Path):
+    vault = _make_vault(tmp_path)
+    (vault / "40-Resources/Generated/digests" / "2026-05-12-digest-daily.md").write_text(
+        "stub", encoding="utf-8"
+    )
+    html = render_digests_list_body(vault)
+    assert "cal-cell-has-digest" in html
+    assert "✓" in html
+
+
+def test_render_body_marks_intake_cells_with_count(tmp_path: Path):
+    vault = _make_vault(tmp_path)
+    conn = _make_audit_db(vault)
+    # Seed today (calendar's "newest day") so the test is
+    # deterministic against the page's date.today() rendering.
+    today_iso = date.today().isoformat()
+    _seed_intake(conn, today_iso, 7)
+    conn.close()
+    html = render_digests_list_body(vault)
+    assert "cal-cell-has-intake" in html
+    assert "7</span>" in html
+
+
+def test_render_body_empty_vault_keeps_calendar(tmp_path: Path):
+    """Even with no digest files, the calendar grid + window
+    label should render — the operator can still click days to
+    inspect /ops/today."""
+    vault = _make_vault(tmp_path)
+    html = render_digests_list_body(vault)
+    assert "Last 30 days at a glance" in html
+    assert "No digest files yet" in html


### PR DESCRIPTION
## Summary

User asked: *"5/12 之前，如果我想看，怎么generate呢？是否应该有个calendar view, 点击进去，至少能看到 event dossier 里那种信息，如果需要，进一步 generate digest？"*

Answer: yes — built.

### 30-day calendar grid on ``/digests``

7-column grid (newest day bottom-right).  Three cell states:

- **✓ MM-DD** — digest exists, click opens ``/note?path=...``
- **MM-DD · N** — no digest, N intake events that day, click goes to ``/ops/today?date=<d>``
- **MM-DD · —** — quiet day, click still opens ``/ops/today``

The flat newest-first list of digest files stays below the grid (operators who prefer filename-scanning still have it).

### Past-date generate plumbing

- ``ovp-digest --date YYYY-MM-DD`` CLI flag.
- ``_enqueue_daily(vault, target_date=...)`` writes ``DIGEST-daily-YYYY-MM-DD.md``.
- Handler's ``_parse_target_date_from_slug`` + ``_as_of_for_target_date`` thread the date into ``collect_digest_inputs(as_of=...)`` so Layer 0/1 filter to that day.
- ``TaskResult.date_override`` flows into ``_resolve_output_path`` so the file lands at the right filename (not UTC-today).
- ``POST /ops/digest/regenerate`` accepts an optional ``date`` field; the button on ``/ops/today?date=2026-05-11`` regenerates that day.

### Honest caveat (called out in CLI help + commit)

Regenerated past-date digests filter ``audit_events`` rigorously by the target date, but the synthesis layer (crystals, labels) comes from the **current** knowledge.db — not a historical snapshot.  Good for "what landed on this day"; not rigorous historical replay.

## Smoke against operator vault

```
=== /digests calendar cell counts ===
  4 cal-cell-has-digest
 12 cal-cell-has-intake
 18 cal-cell-empty
  2 cal-cell-blank   (leading weekday padding)

=== /ops/today?date=2026-05-11 button label ===
Regenerate digest for 2026-05-11
```

## Test plan

- [x] 20 new tests in ``test_digest_calendar.py`` covering slug parsing (6 parametrized), ``_as_of_for_target_date`` (2), ``_enqueue_daily`` filename + idempotency (3), calendar cells (5), rendering (3) + edge cases.
- [x] Existing digest + drawer suite (85 tests) untouched.
- [x] Smoke confirms past-date button labels correctly, calendar cells colour correctly, intake counts match operator vault.

## Dependencies

Stacked on PR #227 (post-merge fixes — markdown rendering + transcript rehydrate + digest label labels).  Rebases cleanly when #227 merges.