### PR TITLE
fix(m24.0): event-evidence registry stop-gap — three surfaces stop lying

### DIFF
--- a/src/ovp_pipeline/commands/_digests_list_page.py
+++ b/src/ovp_pipeline/commands/_digests_list_page.py
@@ -164,7 +164,11 @@ def build_calendar_cells(
 
     intake_counts: dict[str, int] = {}
     db_path = Path(vault_dir) / KNOWLEDGE_DB_REL
-    if db_path.is_file():
+    # CodeRabbit: guard against ``IN ()`` — if the registry ever
+    # ships an empty intake category (e.g. operator override yields
+    # zero types), the SQL would be invalid.  Skip the query and
+    # leave intake_counts empty.
+    if db_path.is_file() and _INTAKE_EVENT_TYPES:
         try:
             with sqlite3.connect(db_path) as conn:
                 placeholders = ",".join("?" * len(_INTAKE_EVENT_TYPES))

--- a/src/ovp_pipeline/commands/_digests_list_page.py
+++ b/src/ovp_pipeline/commands/_digests_list_page.py
@@ -33,19 +33,14 @@ DIGESTS_DIR = "40-Resources/Generated/digests"
 KNOWLEDGE_DB_REL = "60-Logs/knowledge.db"
 CALENDAR_WINDOW_DAYS = 30
 
-# The intake event types Layer 0 of the M23 digest counts.  Mirrors
-# the default ``DigestConfig.intake_event_types`` so the calendar
-# tells the operator the same story the digest body would (modulo
-# config overrides — the calendar always uses defaults, which is
-# fine because /digests is a Reader view, not a maintainer dial).
-_INTAKE_EVENT_TYPES = (
-    "article_processed",
-    "source_archived_to_processed",
-    "source_staged_for_processing",
-    "clippings_batch_processed",
-    "github_source_ingested",
-    "arxiv_source_ingested",
-)
+# M24.0 stop-gap: pull intake event_types from the single canonical
+# registry (``event_evidence_registry``) so the calendar, the
+# ``/ops/today`` Intake card, and the M23 digest's Layer 0 all
+# classify the same way.  Before this, three independent lists
+# drifted and same-day counts disagreed across surfaces.
+from ..event_evidence_registry import event_types_for_category
+
+_INTAKE_EVENT_TYPES = event_types_for_category("intake")
 
 
 @dataclass(frozen=True)

--- a/src/ovp_pipeline/commands/_ui_renderers.py
+++ b/src/ovp_pipeline/commands/_ui_renderers.py
@@ -3796,6 +3796,13 @@ def _render_events_page(payload: dict) -> str:
     event_types_filter = payload.get("event_types_filter") or []
     cross_surface_warning = ""
     if event_types_filter and payload.get("event_count", 0) == 0:
+        # CodeRabbit: pack-scope the backlink so the operator
+        # doesn't drop their ``?pack=`` context when clicking back
+        # to /ops/today.
+        today_href = _shell_href("/ops/today", requested_pack)
+        filter_chip = escape(", ".join(event_types_filter[:3])) + (
+            "…" if len(event_types_filter) > 3 else ""
+        )
         cross_surface_warning = (
             "<div class='card' style='border-color:#c2410c;"
             "background:#fef3e8;padding:0.75rem 1rem;margin-top:0.5rem'>"
@@ -3805,12 +3812,11 @@ def _render_events_page(payload: dict) -> str:
             "(intake / absorb / synthesis / governance / failures), but "
             "this <em>Event Dossier</em> is a timeline projection over "
             "dated notes &amp; contradictions.  The two ledgers track "
-            "different things, so <code>" + escape(", ".join(event_types_filter[:3]))
-            + ("…" if len(event_types_filter) > 3 else "")
-            + "</code> won't match a timeline row.  M24 / M25 will "
-            "unify these two surfaces; for now use the per-row links "
-            "on <a href='/ops/today'>/ops/today</a> to drill into the "
-            "actual source files."
+            f"different things, so <code>{filter_chip}</code> won't "
+            "match a timeline row.  M24 / M25 will unify these two "
+            f"surfaces; for now use the per-row links on "
+            f"<a href='{escape(today_href)}'>/ops/today</a> to drill "
+            "into the actual source files."
             "</p></div>"
         )
     lead_sections, remaining_sections = _split_lead_compiled_sections(
@@ -6778,7 +6784,7 @@ def _render_today_digest_page(payload: dict) -> str:
             sample_html = (
                 "<div style='margin-top:.6rem;padding-top:.6rem;"
                 "border-top:1px solid var(--border);max-width:100%'>"
-                f"<ul class='list-tight tiny' "
+                "<ul class='list-tight tiny' "
                 "style='list-style:none;padding-left:0;margin:0'>"
                 + "".join(li_rows)
                 + "</ul></div>"

--- a/src/ovp_pipeline/commands/_ui_renderers.py
+++ b/src/ovp_pipeline/commands/_ui_renderers.py
@@ -3784,6 +3784,35 @@ def _render_events_page(payload: dict) -> str:
     requested_pack = payload.get("requested_pack", "")
     assembly_contract_card = _render_assembly_contract_card(payload)
     operator_rail_card = _render_operator_rail(payload)
+    # M24.0 stop-gap: when a ``See all N →`` link from ``/ops/today``
+    # lands here with a non-empty ``event_types`` filter, warn the
+    # operator about the data-source mismatch.  ``/ops/today`` counts
+    # raw ``audit_events`` rows; this page is a *timeline projection*
+    # over dated notes / headings / contradictions.  The two never
+    # align row-for-row.  Without this banner the operator clicks
+    # "See all 27 →" and sees 0 rows and thinks something is broken
+    # — actually they're looking at a different ledger.  M25's
+    # ``/ops/items`` will unify the two surfaces.
+    event_types_filter = payload.get("event_types_filter") or []
+    cross_surface_warning = ""
+    if event_types_filter and payload.get("event_count", 0) == 0:
+        cross_surface_warning = (
+            "<div class='card' style='border-color:#c2410c;"
+            "background:#fef3e8;padding:0.75rem 1rem;margin-top:0.5rem'>"
+            "<strong>Heads up — this page can't show those rows.</strong>"
+            "<p class='muted small' style='margin:0.3rem 0 0'>"
+            "<code>/ops/today</code> counts raw <code>audit_events</code> "
+            "(intake / absorb / synthesis / governance / failures), but "
+            "this <em>Event Dossier</em> is a timeline projection over "
+            "dated notes &amp; contradictions.  The two ledgers track "
+            "different things, so <code>" + escape(", ".join(event_types_filter[:3]))
+            + ("…" if len(event_types_filter) > 3 else "")
+            + "</code> won't match a timeline row.  M24 / M25 will "
+            "unify these two surfaces; for now use the per-row links "
+            "on <a href='/ops/today'>/ops/today</a> to drill into the "
+            "actual source files."
+            "</p></div>"
+        )
     lead_sections, remaining_sections = _split_lead_compiled_sections(
         payload.get("compiled_sections", [])
     )
@@ -3891,6 +3920,7 @@ def _render_events_page(payload: dict) -> str:
         "".join(
             [
                 "<h1>Event Dossier</h1>",
+                cross_surface_warning,
                 _render_page_help(
                     "Event dossier",
                     what=(
@@ -6717,19 +6747,41 @@ def _render_today_digest_page(payload: dict) -> str:
             top = sorted(by_type.items(), key=lambda x: -x[1])[:_TODAY_CARD_TOP_TYPES_LIMIT]
             type_pills = " · ".join(f"<code>{escape(t)}</code>×{n}" for t, n in top)
 
+        # M24.0 stop-gap: wrap each sample in an ``<a>`` when the
+        # payload builder gave us a real link target.  Long subject
+        # strings get ``text-overflow: ellipsis`` + ``title="…"``
+        # tooltip so the card stays inside its box even on dense
+        # days (previously a long article title overflowed the card
+        # into the Inbox area).
         sample_html = ""
         if samples:
-            items = "".join(
-                "<li><span class='muted'>{type}</span> <strong>{subject}</strong></li>".format(
-                    type=escape(str(s.get("event_type", ""))[:_TODAY_SAMPLE_EVENT_TYPE_MAX_CHARS]),
-                    subject=escape(str(s.get("subject", ""))[:_TODAY_SAMPLE_SUBJECT_MAX_CHARS]),
+            li_rows: list[str] = []
+            for s in samples:
+                et = escape(
+                    str(s.get("event_type", ""))[:_TODAY_SAMPLE_EVENT_TYPE_MAX_CHARS]
                 )
-                for s in samples
-            )
+                subj_full = str(s.get("subject", ""))
+                subj_short = escape(subj_full[:_TODAY_SAMPLE_SUBJECT_MAX_CHARS])
+                path = str(s.get("path", "") or "")
+                subject_html = (
+                    f"<a href='{escape(path)}' "
+                    f"title='{escape(subj_full)}'>{subj_short}</a>"
+                    if path
+                    else f"<span title='{escape(subj_full)}'>{subj_short}</span>"
+                )
+                li_rows.append(
+                    "<li style='overflow:hidden;text-overflow:ellipsis;"
+                    "white-space:nowrap'>"
+                    f"<span class='muted'>{et}</span> <strong>{subject_html}</strong>"
+                    "</li>"
+                )
             sample_html = (
                 "<div style='margin-top:.6rem;padding-top:.6rem;"
-                "border-top:1px solid var(--border)'>"
-                f"<ul class='list-tight tiny'>{items}</ul></div>"
+                "border-top:1px solid var(--border);max-width:100%'>"
+                f"<ul class='list-tight tiny' "
+                "style='list-style:none;padding-left:0;margin:0'>"
+                + "".join(li_rows)
+                + "</ul></div>"
             )
 
         see_all_html = ""
@@ -6740,11 +6792,27 @@ def _render_today_digest_page(payload: dict) -> str:
                 "</div>"
             )
 
+        # M24.0 honest-zero: when a card has zero evidence, don't
+        # fabricate a reason (could be not_run, ran_no_output, or
+        # missing instrumentation — three different upstream causes
+        # collapsed into one observation).  M24's lifecycle kernel
+        # will replace this with a real diagnosis; for now we name
+        # the ambiguity instead of guessing.
+        zero_html = ""
+        if total == 0:
+            zero_html = (
+                "<p class='muted tiny' style='margin-top:6px'>"
+                "No evidence in this window. "
+                "May mean: not run · no output · missing instrumentation."
+                "</p>"
+            )
+
         sections.append(
-            "<div class='card' style='margin:0'>"
+            "<div class='card' style='margin:0;overflow:hidden'>"
             f"<div class='muted tiny'>{escape(label)}</div>"
             f"<div class='metric-num{warn_cls}' style='margin-top:4px;{empty_style}'>{total}</div>"
             f"<div class='muted tiny' style='margin-top:6px'>{type_pills}</div>"
+            f"{zero_html}"
             f"{sample_html}"
             f"{see_all_html}"
             "</div>"

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -798,6 +798,19 @@ def create_server(
                         evt_limit = None
                     if evt_limit is not None and evt_limit not in (25, 50, 100, 200):
                         evt_limit = None
+                    # M24.0 stop-gap: ``event_types`` is a
+                    # comma-separated allowlist forwarded by the
+                    # "See all N →" link on each ``/ops/today``
+                    # card.  Without this filter the drilldown
+                    # showed every event for the day; with it the
+                    # operator lands on exactly the rows the card
+                    # summed.
+                    event_types_raw = query.get("event_types", [""])[0] or ""
+                    event_types_filter = tuple(
+                        et.strip()
+                        for et in event_types_raw.split(",")
+                        if et.strip()
+                    )
                     payload = build_event_dossier_payload(
                         resolved_vault,
                         pack_name=pack_name,
@@ -805,6 +818,7 @@ def create_server(
                         limit=evt_limit,
                         from_date=from_date,
                         to_date=to_date,
+                        event_types_filter=event_types_filter,
                     )
                     self._write_html(_render_events_page(payload))
                     return

--- a/src/ovp_pipeline/data/digest_template.yaml
+++ b/src/ovp_pipeline/data/digest_template.yaml
@@ -24,15 +24,16 @@ cluster_threshold: 5
 
 # Layer 0 intake event allowlist — which ``audit_events.event_type``
 # rows count as "operator fed something into the system today".
-# Adding a new source authority requires extending this list, otherwise
-# its intakes are silently uncounted.
-intake_event_types:
-  - article_processed
-  - source_archived_to_processed
-  - source_staged_for_processing
-  - clippings_batch_processed
-  - github_source_ingested
-  - arxiv_source_ingested
+#
+# M24.0 stop-gap: the canonical default now comes from
+# ``src/ovp_pipeline/event_evidence_registry.py``; this list is the
+# operator override.  Leave it as an empty list (or omit) to inherit
+# the registry default — this is what new vaults should do.
+#
+# Override here only when you need to add a vault-specific source
+# authority that the registry doesn't ship.  Adding a new source
+# authority globally should land in the registry, not here.
+intake_event_types: []
 
 # Maintainer page exposes a "Regenerate digest now" button (Stage 4 of
 # the M23 plan).  Defaults to true so operators who drop articles

--- a/src/ovp_pipeline/digest_config.py
+++ b/src/ovp_pipeline/digest_config.py
@@ -57,18 +57,21 @@ _TEMPLATE_REL: Final[str] = "data/digest_template.yaml"
 # to run a histogram.
 _DEFAULT_CLUSTER_THRESHOLD: Final[int] = 5
 
-# Default audit-event allowlist for Layer 0.  Adding a new source
-# authority (GitHub Discussions, Hacker News, etc.) requires extending
-# this list AND updating the bundled template so new vaults pick up
-# the new event types automatically.
-_DEFAULT_INTAKE_EVENT_TYPES: Final[tuple[str, ...]] = (
-    "article_processed",
-    "source_archived_to_processed",
-    "source_staged_for_processing",
-    "clippings_batch_processed",
-    "github_source_ingested",
-    "arxiv_source_ingested",
-)
+# Default audit-event allowlist for Layer 0.
+#
+# M24.0 stop-gap (2026-05-14): pull from the single canonical
+# ``event_evidence_registry`` so the M23 digest, ``/ops/today``, and
+# the ``/digests`` calendar all classify the same way.  Before this,
+# three independently-curated lists drifted and the same day showed
+# 27 / 7 / many different intake counts.
+#
+# The registry lists only event types real producers emit (verified
+# against the operator vault on 2026-05-14).  Operator overrides in
+# ``<vault>/.ovp/digest.yaml`` still win — the registry only
+# provides the **default**.
+from .event_evidence_registry import event_types_for_category as _evt_for
+
+_DEFAULT_INTAKE_EVENT_TYPES: Final[tuple[str, ...]] = _evt_for("intake")
 
 
 @dataclass(frozen=True)

--- a/src/ovp_pipeline/event_evidence_registry.py
+++ b/src/ovp_pipeline/event_evidence_registry.py
@@ -1,0 +1,274 @@
+"""Event-type evidence registry (M24.0 stop-gap, 2026-05-14).
+
+STOP-GAP STATUS — please read before extending
+================================================
+
+This module is an **evidence-classification** layer for the legacy
+audit-event-driven surfaces (``/ops/today``, ``/digests`` calendar,
+``/ops/events``).  It exists for one reason: as of M23 we had three
+*different* event-type allowlists defining "intake" across three
+surfaces, so the same day showed 27 / 7 / many different counts.
+This registry collapses those three lists to one.
+
+It is **not** the final pipeline-truth model.  Product-level
+operational state (current lifecycle position of each source,
+why a number is 0, what action repairs it) MUST come from the
+``ops_lifecycle`` / ``ops_state`` modules that M24's Lifecycle
+Contract Layer and M25's Maintainer Control Plane will introduce.
+
+Hard rules for callers
+----------------------
+
+* This registry classifies *evidence*, not *truth*.  An event in
+  category X means "we observed an X-shaped row land in
+  ``audit_events``" — never "X happened" or "X is the current
+  state".
+* No card / page should fabricate a reason for a zero count from
+  this data.  An empty bucket means "no audit-event evidence" —
+  three different upstream causes (not run, ran no output, missing
+  instrumentation) collapse into that one observation.  M24
+  instrumentation repair plus ``ops_lifecycle`` will untangle the
+  three.
+* Legacy event types (``redo_deep_dive_archived``,
+  ``entity_type_backfill_v2_passthrough``, etc.) are marked
+  ``debug_only`` so they don't inflate primary cards but still
+  show up in the forensic ``/ops/events`` log.
+
+Categories (these mirror the 5-card maintainer surface today;
+they will be re-thought into the 5 visible lifecycle states under
+M25, but for the stop-gap we leave the surface labels alone).
+
+* ``intake``      — material entered the vault (Source layer)
+* ``absorb``      — Source → Candidate / Canonical (Absorb stage)
+* ``synthesis``   — Canonical → Crystal / contradiction
+* ``governance``  — human or governance-rule actions
+* ``failures``    — error evidence from any stage
+
+Naming note: the file is deliberately ``event_evidence_registry``,
+not ``pipeline_events``, so future contributors don't mistake it
+for the lifecycle model.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+
+@dataclass(frozen=True)
+class EventEvidence:
+    """One row in the registry.
+
+    ``category`` is one of the primary buckets; ``user_visible``
+    controls whether the event surfaces as evidence on Maintainer
+    primary cards.  Legacy events stay registered (so /ops/events
+    can label them) but with ``user_visible=False`` so they don't
+    drive the primary count.
+    """
+
+    event_type: str
+    category: str
+    user_visible: bool = True
+    legacy: bool = False
+    description: str = ""
+
+
+# Authoritative categorisation.  Built from the operator vault's
+# actual ``audit_events`` histogram on 2026-05-14 (47 distinct
+# event types) plus the M14–M23 emitters in source.  Adding a new
+# event_type producer requires adding a row here.
+_REGISTRY: Final[tuple[EventEvidence, ...]] = (
+    # ── intake ─────────────────────────────────────────────────
+    EventEvidence("article_processed", "intake",
+                  description="An article-shaped source finished its processor."),
+    EventEvidence("article_intake_only", "intake",
+                  description="A source was ingested without further processing."),
+    EventEvidence("clippings_processed", "intake",
+                  description="A web-clippings batch was parsed and split."),
+    EventEvidence("pinboard_process_file_completed", "intake",
+                  description="A pinboard archive entry was processed."),
+    EventEvidence("source_staged_for_processing", "intake",
+                  description="A raw source moved into the 02-Processing stage."),
+    EventEvidence("source_archived_to_processed", "intake",
+                  description="A processed source moved into 03-Processed (intake completed)."),
+    EventEvidence("github_intake_completed", "intake",
+                  description="A GitHub source-authority ingest finished."),
+    EventEvidence("source_dedup_skipped", "intake",
+                  description="A duplicate source was skipped at intake."),
+    EventEvidence("redo_source_processed", "intake",
+                  description="A previously processed source was reprocessed."),
+
+    # ── absorb ─────────────────────────────────────────────────
+    EventEvidence("absorb_completed", "absorb",
+                  description="An absorb pass finished without raising."),
+    EventEvidence("absorb_route_decision", "absorb",
+                  description="The router picked an absorb target for a source."),
+    EventEvidence("evergreen_auto_promoted", "absorb",
+                  description="An evergreen candidate was auto-promoted to canonical."),
+    EventEvidence("evergreen_extraction_complete", "absorb",
+                  description="Evergreen extraction finished for a source."),
+    EventEvidence("candidates_upserted", "absorb",
+                  description="Candidate rows were written to knowledge.db."),
+
+    # ── synthesis ──────────────────────────────────────────────
+    EventEvidence("community_crystal_synthesized", "synthesis",
+                  description="A community crystal was generated or refreshed."),
+    EventEvidence("contradiction_crystal_synthesized", "synthesis",
+                  description="A contradiction crystal was generated."),
+    EventEvidence("crystal_archived", "synthesis",
+                  description="A crystal was archived (superseded)."),
+    EventEvidence("moc_updated", "synthesis",
+                  description="A Map-of-Content page was updated."),
+    EventEvidence("moc_update_complete", "synthesis",
+                  description="MOC update batch finished."),
+
+    # ── governance ─────────────────────────────────────────────
+    EventEvidence("promote_concept", "governance",
+                  description="An operator (or auto-promote) promoted a concept."),
+    EventEvidence("concept_archived", "governance",
+                  description="A concept was archived by review."),
+    EventEvidence("concept_merged", "governance",
+                  description="Two concepts were merged by review."),
+    EventEvidence("dedup_cleanup_archived", "governance",
+                  description="Dedup cleanup archived a duplicate evergreen."),
+    EventEvidence("candidate_review_action", "governance",
+                  description="A reviewer accepted/rejected a candidate."),
+    EventEvidence("evolution_review_action", "governance",
+                  description="A reviewer acted on an evolution candidate."),
+    EventEvidence("contradictions_resolved", "governance",
+                  description="One or more contradictions were resolved."),
+    EventEvidence("quality_checked", "governance", user_visible=False,
+                  description="A quality check fired (high cardinality, debug-only)."),
+    EventEvidence("quality_check_complete", "governance", user_visible=False,
+                  description="A quality check batch finished."),
+    EventEvidence("article_abstained", "governance",
+                  description="The article processor declined to extract."),
+
+    # ── failures ───────────────────────────────────────────────
+    EventEvidence("absorb_parse_error", "failures",
+                  description="A source failed to parse during absorb."),
+    EventEvidence("absorb_schema_drift", "failures",
+                  description="Absorb output drifted from the schema."),
+    EventEvidence("absorb_skipped_source", "failures",
+                  description="Absorb skipped a source because of a guard."),
+    EventEvidence("broken_link", "failures",
+                  description="A wikilink target was missing."),
+    EventEvidence("github_intake_error", "failures",
+                  description="A GitHub source-authority ingest raised."),
+    EventEvidence("article_error", "failures",
+                  description="An article processor raised."),
+    EventEvidence("image_download_error", "failures",
+                  description="Image rewrite couldn't fetch a URL."),
+    EventEvidence("pipeline_partial_failure", "failures",
+                  description="A pipeline run completed with at least one step failing."),
+    EventEvidence("command_timeout", "failures",
+                  description="A CLI step exceeded its time budget."),
+    EventEvidence("evergreen_error", "failures",
+                  description="Evergreen processing raised."),
+    EventEvidence("evergreen_low_link", "failures", user_visible=False,
+                  description="An evergreen lacks enough inbound links (lint signal, not an error)."),
+
+    # ── legacy / debug-only ────────────────────────────────────
+    # These rows stay registered so /ops/events can label them with
+    # a real description instead of "Uncategorised audit event".
+    # ``user_visible=False`` keeps them off the primary cards.
+    EventEvidence("atlas_updated_from_registry", "governance",
+                  user_visible=False,
+                  description="Atlas index was rewritten from registry (high-volume, debug-only)."),
+    EventEvidence("entity_type_backfill_v2_passthrough", "governance",
+                  user_visible=False, legacy=True,
+                  description="Legacy M11 entity-type backfill no-op row."),
+    EventEvidence("entity_backfill_summary", "governance",
+                  user_visible=False, legacy=True,
+                  description="Legacy M11 entity-backfill summary."),
+    EventEvidence("redo_deep_dive_archived", "absorb",
+                  user_visible=False, legacy=True,
+                  description="Legacy BL-029 Deep Dive archival rows; producer removed."),
+    EventEvidence("file_moved", "governance", user_visible=False,
+                  description="A file moved between stage folders (high-volume)."),
+    EventEvidence("images_downloaded", "intake", user_visible=False,
+                  description="Image fetcher succeeded (per-source detail, debug-only)."),
+    EventEvidence("pinboard_process_file_started", "intake",
+                  user_visible=False,
+                  description="Pinboard processor entered a file (pairs with completed)."),
+    EventEvidence("source_restored_to_raw", "intake",
+                  user_visible=False,
+                  description="A processed source was rolled back to raw."),
+    EventEvidence("transaction_started", "governance", user_visible=False,
+                  description="A workflow transaction opened (forensic only)."),
+    EventEvidence("transaction_completed", "governance", user_visible=False,
+                  description="A workflow transaction closed (forensic only)."),
+    EventEvidence("command_started", "governance", user_visible=False,
+                  description="A CLI step started (forensic only)."),
+    EventEvidence("command_completed", "governance", user_visible=False,
+                  description="A CLI step completed (forensic only)."),
+    EventEvidence("pipeline_started", "governance", user_visible=False,
+                  description="A pipeline run started."),
+    EventEvidence("pipeline_completed", "governance", user_visible=False,
+                  description="A pipeline run completed."),
+    EventEvidence("task_dispatched", "governance", user_visible=False,
+                  description="The task dispatcher ran a task (forensic only)."),
+)
+
+
+_BY_TYPE: Final[dict[str, EventEvidence]] = {
+    e.event_type: e for e in _REGISTRY
+}
+
+CATEGORIES: Final[tuple[str, ...]] = (
+    "intake", "absorb", "synthesis", "governance", "failures",
+)
+
+
+def classify(event_type: str) -> EventEvidence | None:
+    """Return the registry entry for ``event_type``, or None if unregistered."""
+    return _BY_TYPE.get(event_type)
+
+
+def event_types_for_category(
+    category: str, *, include_legacy: bool = False
+) -> tuple[str, ...]:
+    """All registered event_types in ``category``.
+
+    Default excludes ``user_visible=False`` and ``legacy=True`` rows
+    so primary surfaces don't inflate their counts with high-volume
+    forensic / debug evidence (``atlas_updated_from_registry``,
+    ``quality_checked``, etc.).
+    """
+    return tuple(
+        e.event_type
+        for e in _REGISTRY
+        if e.category == category
+        and e.user_visible
+        and (include_legacy or not e.legacy)
+    )
+
+
+def all_event_types(*, include_legacy: bool = True) -> tuple[str, ...]:
+    """Every registered event_type, primary + legacy.
+
+    Used by ``/ops/events`` to know which rows have a registry
+    label.  Anything not registered shows up as
+    "uncategorised" in the forensic log.
+    """
+    return tuple(
+        e.event_type
+        for e in _REGISTRY
+        if include_legacy or not e.legacy
+    )
+
+
+def is_user_visible(event_type: str) -> bool:
+    """True when this event_type counts toward primary card totals."""
+    entry = _BY_TYPE.get(event_type)
+    return entry is not None and entry.user_visible
+
+
+__all__ = [
+    "CATEGORIES",
+    "EventEvidence",
+    "all_event_types",
+    "classify",
+    "event_types_for_category",
+    "is_user_visible",
+]

--- a/src/ovp_pipeline/event_evidence_registry.py
+++ b/src/ovp_pipeline/event_evidence_registry.py
@@ -211,9 +211,27 @@ _REGISTRY: Final[tuple[EventEvidence, ...]] = (
 )
 
 
-_BY_TYPE: Final[dict[str, EventEvidence]] = {
-    e.event_type: e for e in _REGISTRY
-}
+def _build_by_type_index(rows: tuple[EventEvidence, ...]) -> dict[str, EventEvidence]:
+    """Reject duplicate ``event_type`` keys at module-load time.
+
+    A duplicate would let ``classify`` silently return whichever
+    row appeared last in the registry — a quiet way for two
+    "single source of truth" rows to fight.  Fail loud (CodeRabbit
+    Major) so the contributor adding the duplicate sees it
+    immediately, not a year later when a count drifts.
+    """
+    index: dict[str, EventEvidence] = {}
+    for row in rows:
+        if row.event_type in index:
+            raise ValueError(
+                f"event_evidence_registry: duplicate event_type "
+                f"{row.event_type!r} — registry must have one entry per type"
+            )
+        index[row.event_type] = row
+    return index
+
+
+_BY_TYPE: Final[dict[str, EventEvidence]] = _build_by_type_index(_REGISTRY)
 
 CATEGORIES: Final[tuple[str, ...]] = (
     "intake", "absorb", "synthesis", "governance", "failures",
@@ -230,17 +248,30 @@ def event_types_for_category(
 ) -> tuple[str, ...]:
     """All registered event_types in ``category``.
 
-    Default excludes ``user_visible=False`` and ``legacy=True`` rows
-    so primary surfaces don't inflate their counts with high-volume
-    forensic / debug evidence (``atlas_updated_from_registry``,
-    ``quality_checked``, etc.).
+    Default (``include_legacy=False``) excludes ``user_visible=False``
+    and ``legacy=True`` rows so primary surfaces don't inflate their
+    counts with high-volume forensic / debug evidence
+    (``atlas_updated_from_registry``, ``quality_checked``, etc.).
+
+    ``include_legacy=True`` returns **every** row in ``category``,
+    legacy + non-user-visible included.  Used by ``/ops/events``
+    forensic view so it can classify rows that the primary cards
+    skip (CodeRabbit Major: previously the flag was a no-op because
+    the ``user_visible`` guard still ran, so debug-only legacy rows
+    stayed hidden even when explicitly requested).
     """
+    if include_legacy:
+        return tuple(
+            e.event_type
+            for e in _REGISTRY
+            if e.category == category
+        )
     return tuple(
         e.event_type
         for e in _REGISTRY
         if e.category == category
         and e.user_visible
-        and (include_legacy or not e.legacy)
+        and not e.legacy
     )
 
 

--- a/src/ovp_pipeline/ui/view_models.py
+++ b/src/ovp_pipeline/ui/view_models.py
@@ -3207,6 +3207,20 @@ def build_today_digest_payload(
     cards: list[dict[str, Any]] = []
     with sqlite3.connect(db_path) as conn:
         for card_id, card_label, event_types in TODAY_DIGEST_CARDS:
+            # CodeRabbit: SQL ``IN ()`` is invalid; if a registry
+            # category ever ships empty, emit a zero card without
+            # querying instead of crashing.
+            if not event_types:
+                cards.append({
+                    "id": card_id,
+                    "label": card_label,
+                    "total": 0,
+                    "by_type": {},
+                    "samples": [],
+                    "see_all_path": "",
+                    "event_types": [],
+                })
+                continue
             placeholders = ",".join("?" for _ in event_types)
             counts_rows = conn.execute(
                 f"""
@@ -3827,25 +3841,31 @@ def build_event_dossier_payload(
     effective_limit = DEFAULT_EVENT_DOSSIER_LIMIT if limit is None else limit
     normalized_from = (from_date or "").strip() or None
     normalized_to = (to_date or "").strip() or None
+    # M24.0 stop-gap: when an event_types filter is set, over-fetch
+    # so post-filter trim still has matches.  Filtering after the
+    # pre-limited fetch (CodeRabbit Major) would drop legitimately
+    # matching rows that happened to sit past the first
+    # ``effective_limit`` rows in the timeline.
+    query_limit = effective_limit or DEFAULT_EVENT_DOSSIER_LIMIT
+    if event_types_filter:
+        query_limit = max(query_limit, 1000)
     events = [
         _build_timeline_event_item(row)
         for row in list_timeline_events(
             vault_dir,
             pack_name=pack_name,
             query=query,
-            limit=effective_limit or DEFAULT_EVENT_DOSSIER_LIMIT,
+            limit=query_limit,
             from_date=normalized_from,
             to_date=normalized_to,
         )
     ]
-    # M24.0 stop-gap: filter to the event-types the upstream
-    # "See all N →" link asked about so the drilldown count
-    # matches the card count.  Filter post-query because
-    # ``list_timeline_events`` doesn't accept event_type today;
-    # extending it is M24's job.
     if event_types_filter:
         allowed = frozenset(event_types_filter)
         events = [e for e in events if e.get("event_type") in allowed]
+        # Trim back to caller's effective_limit after filtering.
+        if effective_limit and effective_limit > 0:
+            events = events[:effective_limit]
     provenance_map = get_object_provenance_map(
         vault_dir,
         [event["object_id"] for event in events],

--- a/src/ovp_pipeline/ui/view_models.py
+++ b/src/ovp_pipeline/ui/view_models.py
@@ -3121,68 +3121,32 @@ def build_timeline_payload(
 # BL-053: Ops workbench IA — by-day "today" digest + by-run "runs" index
 # ---------------------------------------------------------------------------
 
-# Per-card event-type buckets for ``/ops/today``.  These are
-# **inclusive** — an event listed in two cards (rare) gets counted in
-# both.  Card ordering is the rendering order.  Tweak when new
-# pipeline events land; the renderer reads the dict shape directly so
-# adding a card is purely a data change.
-TODAY_DIGEST_CARDS: tuple[tuple[str, str, tuple[str, ...]], ...] = (
-    (
-        "intake",
-        "Intake",
-        (
-            "clippings_processed",
-            "source_archived_to_processed",
-            "source_staged_for_processing",
-            "github_intake_completed",
-            "article_intake_only",
-            "source_dedup_skipped",
-        ),
-    ),
-    (
-        "absorb",
-        "Absorb",
-        (
-            "evergreen_auto_promoted",
-            "absorb_completed",
-            "candidates_upserted",
-        ),
-    ),
-    (
-        "synthesis",
-        "Synthesis",
-        (
-            "community_crystal_synthesized",
-            "contradiction_crystal_synthesized",
-            "crystal_archived",
-        ),
-    ),
-    (
-        "governance",
-        "Governance",
-        (
-            "promote_concept",
-            "concept_archived",
-            "concept_merged",
-            "dedup_cleanup_archived",
-            "candidate_review_action",
-            "evolution_review_action",
-            "contradictions_resolved",
-        ),
-    ),
-    (
-        "failures",
-        "Failures",
-        (
-            "absorb_parse_error",
-            "absorb_schema_drift",
-            "absorb_skipped_source",
-            "broken_link",
-            "github_intake_error",
-            "article_error",
-            "image_download_error",
-        ),
-    ),
+# Per-card event-type buckets for ``/ops/today``.
+#
+# M24.0 stop-gap (2026-05-14): card event_types are now sourced from
+# ``event_evidence_registry`` so the same lists drive the calendar
+# on ``/digests``, Layer 0 of the M23 digest, and these cards.
+# Previously three independent allowlists disagreed and the operator
+# saw 27 / 7 / many different counts for the same day.  The registry
+# excludes legacy / debug-only event types from the primary count by
+# default so high-volume forensic rows (``atlas_updated_from_registry``,
+# ``quality_checked``, etc.) don't drown the cards.
+from ..event_evidence_registry import (
+    CATEGORIES as _EVT_CATEGORIES,
+    event_types_for_category as _evt_for_category,
+)
+
+_TODAY_CARD_LABELS: dict[str, str] = {
+    "intake": "Intake",
+    "absorb": "Absorb",
+    "synthesis": "Synthesis",
+    "governance": "Governance",
+    "failures": "Failures",
+}
+
+TODAY_DIGEST_CARDS: tuple[tuple[str, str, tuple[str, ...]], ...] = tuple(
+    (cat, _TODAY_CARD_LABELS[cat], _evt_for_category(cat))
+    for cat in _EVT_CATEGORIES
 )
 
 # Cap on how many sample rows each ``/ops/today`` card surfaces.
@@ -3261,6 +3225,12 @@ def build_today_digest_payload(
             # Sample rows — favour high-signal subjects (slug / source
             # path / file) over raw event_type so the click-through is
             # actionable.  Skip stage events that don't carry a slug.
+            #
+            # M24.0 stop-gap: also pull the object_id + source path
+            # so we can wrap each sample in a real link.  Previously
+            # samples rendered as plain ``<span>`` and the operator
+            # couldn't drill from "intake: 7" into the actual
+            # 7 articles.
             sample_rows = conn.execute(
                 f"""
                 SELECT event_type,
@@ -3270,6 +3240,9 @@ def build_today_digest_payload(
                                 json_extract(payload_json, '$.url'),
                                 slug) AS subject,
                        json_extract(payload_json, '$.title') AS title,
+                       json_extract(payload_json, '$.object_id') AS object_id,
+                       json_extract(payload_json, '$.path') AS path,
+                       json_extract(payload_json, '$.source_path') AS source_path,
                        timestamp
                   FROM audit_events
                  WHERE date(timestamp) = ?
@@ -3279,16 +3252,38 @@ def build_today_digest_payload(
                 (date_key, *event_types),
             ).fetchall()
             samples: list[dict[str, str]] = []
-            for event_type, subject, title, ts in sample_rows:
+            for event_type, subject, title, object_id, path, source_path, ts in sample_rows:
                 if not subject:
                     continue
                 if len(samples) >= TODAY_CARD_SAMPLE_SIZE:
                     break
+                # Pick the most-actionable link target:
+                #   object_id → ``/object?id=…``  (canonical view)
+                #   path / source_path → ``/note?path=…``  (raw markdown)
+                #   else → bare ``/ops/events?q=<slug>``  (forensic fallback)
+                sample_path = ""
+                if object_id:
+                    sample_path = _scoped_path(
+                        f"/object?id={quote(str(object_id), safe='')}",
+                        pack_name=requested_pack,
+                    )
+                elif path or source_path:
+                    note_path = str(path or source_path)
+                    sample_path = _scoped_path(
+                        f"/note?path={quote(note_path, safe='')}",
+                        pack_name=requested_pack,
+                    )
+                else:
+                    sample_path = _scoped_path(
+                        f"/ops/events?q={quote(str(subject), safe='')}",
+                        pack_name=requested_pack,
+                    )
                 samples.append({
                     "event_type": str(event_type),
                     "subject": str(subject),
                     "title": str(title or subject),
                     "timestamp": str(ts or ""),
+                    "path": sample_path,
                 })
             # ``see_all_path`` deep-links into the event dossier
             # filtered to this card's date + event types so the
@@ -3297,12 +3292,23 @@ def build_today_digest_payload(
             # ``pack=`` when ``pack_name`` is set, so we don't add
             # it to ``see_all_qs`` ourselves — pre-fix doing both
             # produced duplicate ``pack=`` query params.
-            see_all_qs = "&".join(
-                [
-                    f"date={quote(date_key, safe='')}",
-                    "limit=200",
-                ]
-            )
+            #
+            # M24.0 stop-gap (2026-05-14): pass the card's
+            # ``event_types`` through as a comma-separated query
+            # param so ``/ops/events`` can filter to just those
+            # rows.  Previously this link dropped the filter and
+            # operators landed on a full audit dump — "See all 7"
+            # showed 100+ unrelated events, which was the most-
+            # complained-about lie on the page.
+            see_all_qs_parts = [
+                f"date={quote(date_key, safe='')}",
+                "limit=200",
+            ]
+            if event_types:
+                see_all_qs_parts.append(
+                    "event_types=" + quote(",".join(event_types), safe="")
+                )
+            see_all_qs = "&".join(see_all_qs_parts)
             see_all_path = _scoped_path(
                 f"/ops/events?{see_all_qs}", pack_name=requested_pack
             )
@@ -3814,6 +3820,7 @@ def build_event_dossier_payload(
     limit: int | None = None,
     from_date: str | None = None,
     to_date: str | None = None,
+    event_types_filter: tuple[str, ...] = (),
 ) -> dict[str, Any]:
     requested_pack = pack_name or ""
     research_shell_enabled = _supports_research_shell(pack_name)
@@ -3831,6 +3838,14 @@ def build_event_dossier_payload(
             to_date=normalized_to,
         )
     ]
+    # M24.0 stop-gap: filter to the event-types the upstream
+    # "See all N →" link asked about so the drilldown count
+    # matches the card count.  Filter post-query because
+    # ``list_timeline_events`` doesn't accept event_type today;
+    # extending it is M24's job.
+    if event_types_filter:
+        allowed = frozenset(event_types_filter)
+        events = [e for e in events if e.get("event_type") in allowed]
     provenance_map = get_object_provenance_map(
         vault_dir,
         [event["object_id"] for event in events],
@@ -4021,6 +4036,16 @@ def build_event_dossier_payload(
         "dates": dates,
         "cluster_sections": cluster_sections,
         "event_type_counts": dict(event_type_counts),
+        # M24.0 stop-gap: surface the filter so the renderer can warn
+        # when an incoming ``event_types=`` filter returns 0 rows
+        # because this page is a *timeline projection*, not a raw
+        # audit-event browser.  The ``/ops/today`` cards count raw
+        # audit_events; the timeline only contains dated note /
+        # heading / contradiction projections.  Without the warning,
+        # an operator clicks "See all 27 →" and sees 0 rows and
+        # thinks the data is wrong — actually the data sources just
+        # differ.  M25's ``/ops/items`` unifies them.
+        "event_types_filter": list(event_types_filter),
         "limit": effective_limit,
         "is_limited": effective_limit is not None,
         "from_date": normalized_from or "",

--- a/tests/test_digest_handler.py
+++ b/tests/test_digest_handler.py
@@ -144,12 +144,22 @@ def _make_knowledge_db(vault: Path) -> sqlite3.Connection:
 
 
 def _seed_window_with_signal(
-    vault: Path, *, as_of: datetime, evergreens: int = 2
+    vault: Path,
+    *,
+    as_of: datetime,
+    evergreens: int = 2,
+    offset_hours: int = 2,
 ) -> None:
-    """Seed enough rows that ``_is_no_data`` returns False."""
+    """Seed enough rows that ``_is_no_data`` returns False.
+
+    ``offset_hours`` controls how far back of ``as_of`` the seeds
+    land.  Default 2h matches the historical behavior; tests that
+    run against a live ``datetime.now`` should pass ``offset_hours=0``
+    so seeds don't cross into yesterday near UTC midnight.
+    """
     conn = _make_knowledge_db(vault)
     for i in range(evergreens):
-        ts = (as_of - timedelta(hours=2, minutes=i)).isoformat()
+        ts = (as_of - timedelta(hours=offset_hours, minutes=i)).isoformat()
         conn.execute(
             "INSERT INTO evergreen_revisions VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
             (
@@ -232,8 +242,12 @@ def test_calls_llm_with_v2_prompt_when_signal_present(tmp_path: Path):
     """With data, the handler calls the LLM exactly once with a
     prompt that mentions the v2 section headings."""
     vault = _make_vault(tmp_path)
-    as_of = datetime.now(timezone.utc) - timedelta(minutes=30)
-    _seed_window_with_signal(vault, as_of=as_of, evergreens=2)
+    # Anchor the seed close to "now" so it lives inside the handler's
+    # default local-day window regardless of wall-clock time.  Going
+    # back 2h would put seeds in yesterday when the suite runs in
+    # the 2h after UTC midnight.
+    now = datetime.now(timezone.utc)
+    _seed_window_with_signal(vault, as_of=now, evergreens=2, offset_hours=0)
     llm = _FakeLLM(
         "## Window's intake\nOne intake.\n\n## Worth doing next\nResolve.\n"
     )
@@ -257,7 +271,7 @@ def test_frontmatter_contains_preflight_block(tmp_path: Path):
     Reader / digest-health page can read per-section state."""
     vault = _make_vault(tmp_path)
     as_of = datetime.now(timezone.utc) - timedelta(minutes=30)
-    _seed_window_with_signal(vault, as_of=as_of)
+    _seed_window_with_signal(vault, as_of=as_of, offset_hours=0)
     llm = _FakeLLM("body")
     result = handle_digest(_ctx(vault, llm))
     assert "preflight:" in result.body_md
@@ -270,7 +284,7 @@ def test_audit_event_emitted_on_generate(tmp_path: Path):
     """``digest_generated`` lands in pipeline.jsonl with input_hash + layer counts."""
     vault = _make_vault(tmp_path)
     as_of = datetime.now(timezone.utc) - timedelta(minutes=30)
-    _seed_window_with_signal(vault, as_of=as_of)
+    _seed_window_with_signal(vault, as_of=as_of, offset_hours=0)
     llm = _FakeLLM("body")
     handle_digest(_ctx(vault, llm))
     log_path = vault / "60-Logs" / "pipeline.jsonl"
@@ -291,7 +305,7 @@ def test_idempotency_skips_llm_when_prior_hash_matches(tmp_path: Path):
     must NOT call the LLM and must emit digest_skipped_no_change."""
     vault = _make_vault(tmp_path)
     as_of = datetime.now(timezone.utc) - timedelta(minutes=30)
-    _seed_window_with_signal(vault, as_of=as_of)
+    _seed_window_with_signal(vault, as_of=as_of, offset_hours=0)
     llm1 = _FakeLLM("first")
     result1 = handle_digest(_ctx(vault, llm1))
     # Persist result1 to disk at the path the gate will look for.
@@ -319,7 +333,7 @@ def test_idempotency_calls_llm_when_data_changes(tmp_path: Path):
     and forces the LLM call."""
     vault = _make_vault(tmp_path)
     as_of = datetime.now(timezone.utc) - timedelta(minutes=30)
-    _seed_window_with_signal(vault, as_of=as_of, evergreens=1)
+    _seed_window_with_signal(vault, as_of=as_of, evergreens=1, offset_hours=0)
     llm1 = _FakeLLM("first body")
     result1 = handle_digest(_ctx(vault, llm1))
     _expected_output_path(vault).write_text(result1.body_md, encoding="utf-8")
@@ -348,7 +362,7 @@ def test_skip_unchanged_disabled_forces_llm(tmp_path: Path):
     """``skip_unchanged: false`` in config disables the gate."""
     vault = _make_vault(tmp_path)
     as_of = datetime.now(timezone.utc) - timedelta(minutes=30)
-    _seed_window_with_signal(vault, as_of=as_of)
+    _seed_window_with_signal(vault, as_of=as_of, offset_hours=0)
     (vault / ".ovp").mkdir(exist_ok=True)
     (vault / ".ovp" / "digest.yaml").write_text(
         "skip_unchanged: false\n", encoding="utf-8"
@@ -396,7 +410,7 @@ def test_user_focus_flows_into_v2_prompt(tmp_path: Path):
         "# About Me\nFocus: memory systems.\n", encoding="utf-8",
     )
     as_of = datetime.now(timezone.utc) - timedelta(minutes=30)
-    _seed_window_with_signal(vault, as_of=as_of)
+    _seed_window_with_signal(vault, as_of=as_of, offset_hours=0)
     llm = _FakeLLM("body")
     handle_digest(_ctx(vault, llm))
     _sys_prompt, user_prompt = llm.calls[0]

--- a/tests/test_event_evidence_registry.py
+++ b/tests/test_event_evidence_registry.py
@@ -68,6 +68,15 @@ def test_intake_includes_legacy_when_asked():
     with_legacy = event_types_for_category("intake", include_legacy=True)
     # ``include_legacy`` shouldn't drop any primary entries.
     assert set(primary) <= set(with_legacy)
+    # And it MUST actually add the legacy / non-user-visible rows
+    # the default excludes — otherwise the flag is a no-op
+    # (CodeRabbit Major caught this with the prior implementation).
+    # ``images_downloaded`` and ``pinboard_process_file_started``
+    # are intake-category, user_visible=False; ``include_legacy=True``
+    # must surface them.
+    assert "images_downloaded" not in primary
+    assert "images_downloaded" in with_legacy
+    assert "pinboard_process_file_started" in with_legacy
 
 
 # ── Failures stay separate ─────────────────────────────────────

--- a/tests/test_event_evidence_registry.py
+++ b/tests/test_event_evidence_registry.py
@@ -1,0 +1,148 @@
+"""Tests for the M24.0 stop-gap event-evidence registry.
+
+The registry's job is single source of truth for "which event_types
+belong to which Maintainer card."  Lock this in so the three
+surfaces (``/ops/today``, ``/digests`` calendar, ``/ops/events``)
+cannot drift again before M24 lifecycle work lands.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ovp_pipeline.event_evidence_registry import (
+    CATEGORIES,
+    EventEvidence,
+    all_event_types,
+    classify,
+    event_types_for_category,
+    is_user_visible,
+)
+
+
+# ── Schema ─────────────────────────────────────────────────────
+
+
+def test_categories_are_the_canonical_five():
+    """The visible Maintainer card vocabulary is locked.  Adding a
+    sixth category requires a code change here and a renderer change
+    — make it deliberate, not accidental."""
+    assert CATEGORIES == (
+        "intake", "absorb", "synthesis", "governance", "failures",
+    )
+
+
+def test_every_registered_event_has_a_known_category():
+    for et in all_event_types():
+        entry = classify(et)
+        assert entry is not None
+        assert entry.category in CATEGORIES
+
+
+# ── Intake list anchors the three surfaces ─────────────────────
+
+
+def test_intake_includes_real_producer_events():
+    """The events real producers emit in the operator vault must be
+    classified as intake.  This is the test that would have caught
+    the M23 default allowlist drift (``clippings_batch_processed``
+    etc. — names no producer ever emits)."""
+    intake = event_types_for_category("intake")
+    assert "article_processed" in intake
+    assert "source_archived_to_processed" in intake
+    assert "source_staged_for_processing" in intake
+    assert "github_intake_completed" in intake
+    assert "clippings_processed" in intake
+
+
+def test_intake_excludes_legacy_or_debug_only_by_default():
+    """High-volume forensic events like ``images_downloaded`` exist
+    but mustn't inflate the primary intake count."""
+    intake = event_types_for_category("intake")
+    assert "images_downloaded" not in intake
+    assert "pinboard_process_file_started" not in intake
+
+
+def test_intake_includes_legacy_when_asked():
+    primary = event_types_for_category("intake")
+    with_legacy = event_types_for_category("intake", include_legacy=True)
+    # ``include_legacy`` shouldn't drop any primary entries.
+    assert set(primary) <= set(with_legacy)
+
+
+# ── Failures stay separate ─────────────────────────────────────
+
+
+def test_failures_isolated_from_other_categories():
+    """A failure-class event must not also count as intake/absorb/
+    etc — otherwise the same row inflates two cards."""
+    fail = set(event_types_for_category("failures"))
+    for cat in ("intake", "absorb", "synthesis", "governance"):
+        other = set(event_types_for_category(cat))
+        overlap = fail & other
+        assert not overlap, f"failures overlap with {cat}: {overlap}"
+
+
+# ── Visibility flag ────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("user_visible_et", [
+    "article_processed",
+    "absorb_route_decision",
+    "promote_concept",
+    "absorb_parse_error",
+])
+def test_user_visible_events_count_for_primary_cards(user_visible_et):
+    assert is_user_visible(user_visible_et)
+
+
+@pytest.mark.parametrize("debug_et", [
+    "atlas_updated_from_registry",
+    "quality_checked",
+    "transaction_started",
+    "task_dispatched",
+])
+def test_debug_only_events_do_not_count_for_primary_cards(debug_et):
+    assert not is_user_visible(debug_et)
+
+
+def test_unregistered_event_type_returns_none():
+    assert classify("totally_made_up_event_2027") is None
+    assert is_user_visible("totally_made_up_event_2027") is False
+
+
+# ── Contract enforcement: all three downstream surfaces agree ──
+
+
+def test_today_card_event_types_come_from_registry():
+    """``TODAY_DIGEST_CARDS`` must read from the registry, not a
+    hardcoded list.  Defends against a future contributor pasting
+    a fourth allowlist into view_models.py."""
+    from ovp_pipeline.ui.view_models import TODAY_DIGEST_CARDS
+
+    for card_id, _label, event_types in TODAY_DIGEST_CARDS:
+        registry_set = set(event_types_for_category(card_id))
+        card_set = set(event_types)
+        assert card_set == registry_set, (
+            f"/ops/today {card_id} drifted from registry: "
+            f"missing={registry_set - card_set}, "
+            f"extra={card_set - registry_set}"
+        )
+
+
+def test_digests_calendar_intake_list_matches_registry():
+    """The ``/digests`` calendar's intake counter must use the same
+    registry list — this is the bug the user originally reported
+    (27 vs 7 on the same day)."""
+    from ovp_pipeline.commands._digests_list_page import _INTAKE_EVENT_TYPES
+
+    assert set(_INTAKE_EVENT_TYPES) == set(event_types_for_category("intake"))
+
+
+def test_digest_config_default_intake_matches_registry():
+    """M23 digest's Layer 0 default must match too."""
+    from ovp_pipeline.digest_config import _DEFAULT_INTAKE_EVENT_TYPES
+
+    assert set(_DEFAULT_INTAKE_EVENT_TYPES) == set(
+        event_types_for_category("intake")
+    )


### PR DESCRIPTION
Single canonical event-evidence registry: /ops/today cards, /digests calendar Layer 0, M23 digest Layer 0 default all read from one source. See all N → forwards event_types filter. Samples clickable + ellipsis. Honest zero stub. Banner on /ops/events when filter mismatches data source. Strict scope: no new dashboards, no lifecycle UI, no fabricated reasons for 0. 18 new tests pin the three surfaces. M24.0 — stop-gap before M24.1 lifecycle doc + plan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added event type filtering to the Event Dossier drilldown via `event_types` query parameter.
  * Added cross-surface warning banner when filtered results return no events.
  * Enhanced digest cards with clickable object links and improved empty-state messaging.

* **Bug Fixes**
  * Aligned event-counting logic across `/ops/today`, digest calendar, and Event Dossier to use a shared canonical classification system.

* **Tests**
  * Added comprehensive test suite validating event classification consistency across all surfaces.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fakechris/obsidian_vault_pipeline/pull/229)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->