### PR TITLE
docs(m24.1): operational-lifecycle vocabulary + lifecycle contract plan

### DIFF
--- a/docs/operational-lifecycle.md
+++ b/docs/operational-lifecycle.md
@@ -1,0 +1,231 @@
+# Operational Lifecycle (M24.1)
+
+> **Status**: design lock, 2026-05-14.  This is the vocabulary M24
+> (Lifecycle Contract Layer) and M25 (Maintainer Control Plane)
+> build against.  Anything that disagrees with this doc — code,
+> UI labels, prompts, registry rows — is wrong and gets fixed.
+
+## Why this document exists
+
+The M24.0 event-evidence registry (PR #229) collapsed three drifted
+intake allowlists into one.  It classifies *evidence*: when an audit
+row of type `T` lands, what bucket does that row belong to?
+
+That solved a real bug — same day reading 27 / 7 / many across three
+surfaces — but it did **not** answer:
+
+* What is the current state of *this specific source* / *this specific
+  evergreen* / *this specific cluster*?
+* If a card reads "0 Synthesized today", is that because (a) synthesis
+  didn't run, (b) it ran and emitted nothing, or (c) the producer
+  exists but the audit event is missing?
+* When the operator clicks a card, which underlying items are they
+  drilling into — events, or *the things events describe*?
+
+Those questions are about **lifecycle truth**, not evidence
+classification.  This document defines the lifecycle vocabulary.
+M24.1 wires it into a kernel (`ops_lifecycle.py`).  M24.2 fixes the
+producer audit so the kernel has clean evidence to read.  M25 builds
+the Maintainer Control Plane on top.
+
+## The five visible states (Maintainer Control Plane vocabulary)
+
+These are the states the Maintainer surface in M25 will name.  Every
+operator-visible item — a source, an evergreen, a cluster — sits in
+exactly one of these five states at any moment.  The labels are
+locked; M25 designs the cards around them, M24 builds the kernel that
+derives them.
+
+### 1. Received
+
+> *"Something landed in the vault."*
+
+Raw material entered, but no extraction has been attempted yet.
+Concretely: a markdown file in `50-Inbox/01-Raw/`, a clippings batch
+member that was split, or a source-authority entry pulled by an
+intake processor — *before* the interpret/absorb stage runs on it.
+
+**Evidence that puts an item here:** intake-category audit rows
+(`article_intake_only`, `source_staged_for_processing`,
+`clippings_processed`, `github_intake_completed`, …) where the source
+has not yet emitted any absorb-stage event.
+
+**Visible to operator:** yes (primary card).
+
+### 2. Extracted
+
+> *"The interpreter ran and produced something the absorber will read."*
+
+The interpret/absorb stage has emitted at least one structured artifact
+(a deep-dive article, a parsed `evergreen_candidate` row, a routed
+absorb decision) for the source — but no *accepted* canonical
+artifact exists yet.  Equivalent to the operator's mental model of
+"we tried to understand it; the next step is keep / merge / reject".
+
+**Evidence:** absorb-category audit rows (`absorb_route_decision`,
+`evergreen_extraction_complete`, `candidates_upserted`,
+`absorb_completed`) without a downstream `evergreen_auto_promoted`
+or operator promote action against the same source/object.
+
+**Visible to operator:** yes (primary card; this is where the
+review-queue work lives).
+
+### 3. Accepted
+
+> *"A canonical artifact exists in the vault for this item."*
+
+An evergreen has been promoted (auto or by operator), or the source
+has been archived to `03-Processed` because every extracted artifact
+reached a canonical form.  The item is no longer a candidate; it
+exists in `10-Knowledge/Evergreen/` and is reachable from MOCs / the
+graph.
+
+**Evidence:** `evergreen_auto_promoted`, `promote_concept`,
+`source_archived_to_processed` (after intake completed), or a
+canonical-write event in the registry projection.
+
+**Visible to operator:** yes (primary card).
+
+### 4. Synthesized
+
+> *"A higher-order artifact summarising / connecting this item exists
+> and is fresh."*
+
+A community crystal, contradiction crystal, MOC update, or other
+synthesis-stage artifact references the item *and* is not stale
+relative to the item's most recent canonical revision.  "Stale" is
+defined the way M23's digest already defines it: `MAX(revision.derived_at
+WHERE cluster_id = C) > crystal.synthesized_at`.
+
+**Evidence:** `community_crystal_synthesized`,
+`contradiction_crystal_synthesized`, `moc_updated`,
+`moc_update_complete` — *plus* the freshness check against the
+item's revisions.
+
+**Visible to operator:** yes (primary card).
+
+### 5. Needs Action
+
+> *"Something is wrong, blocked, or waiting on the operator."*
+
+Failure evidence is the most obvious source — `absorb_parse_error`,
+`broken_link`, `pipeline_partial_failure`, `command_timeout` — but
+the bucket also covers *governance-required* items: contradictions
+without a resolution, candidates aged past a review SLA, evergreens
+flagged for human review.
+
+**Evidence:** failures-category rows, governance-category rows that
+imply an open ask (`candidate_review_action` with action=`needs_review`,
+unresolved contradictions, …).
+
+**Visible to operator:** yes (primary card; this is the surface the
+operator should be able to scan first thing in the morning).
+
+## The two internal evidence states (not cards)
+
+These exist in the kernel so it can reason about lifecycle precisely,
+but they never become Maintainer Control Plane cards.  They are
+debugging vocabulary, not workflow vocabulary.
+
+### A. Prepared
+
+> *"The producer believes it has done its work, but no canonical
+> writer has consumed the output yet."*
+
+Example: `evergreen_extraction_complete` fired, but the
+`candidates_upserted` row that should follow is missing.  In the
+five-state model this still appears as "Extracted" externally; the
+**Prepared** sub-state lets the kernel say *"the producer thinks it
+finished, the downstream stage hasn't picked it up yet"* — useful for
+M24.2 producer-audit diagnostics, useless on a Maintainer card.
+
+### B. Projected
+
+> *"A derived/projected row claims the item reached state X, but the
+> primary evidence we'd expect to find is missing."*
+
+Example: the registry projection has a row saying an evergreen exists
+at `10-Knowledge/Evergreen/Foo.md`, but `audit_events` shows no
+`evergreen_auto_promoted` for that path.  Either the audit row was
+never written (M24.2 producer gap) or the projection was written by
+a path the kernel doesn't know about (likely a manual edit / vault
+hand-touch).
+
+**Projected** lets the kernel surface honest disagreements between
+the evidence ledger and the derived projections — without those
+disagreements bleeding into the operator's card view.
+
+## Relationship to M24.0's five evidence categories
+
+The M24.0 registry's categories (`intake`, `absorb`, `synthesis`,
+`governance`, `failures`) are **how each audit row is classified**.
+The five visible states above are **what an item's current position
+in the workflow is**.
+
+The mapping isn't 1:1:
+
+| Evidence category | Contributes to lifecycle state |
+|---|---|
+| `intake`     | Received (always); Accepted via `source_archived_to_processed` |
+| `absorb`     | Extracted (always); Accepted via `evergreen_auto_promoted` |
+| `synthesis`  | Synthesized (when fresh); otherwise no state change |
+| `governance` | Accepted (via `promote_concept`), Needs Action (via review actions) |
+| `failures`   | Needs Action (always) |
+
+Two implications:
+
+* A single audit row can transition an item across states (a
+  `promote_concept` row moves an item from Extracted → Accepted).
+* The kernel must derive lifecycle state from the **set** of evidence
+  rows about an item, not from any single row.  This is why M24.1
+  needs a kernel module rather than a per-event classifier.
+
+## Honest-zero principle
+
+When any surface (digest layer, ops card, drilldown) reads a zero
+count, the displayed text must make the **ambiguity of zero** legible:
+
+> 0 Synthesized today
+> *may mean: synthesis didn't run · ran with no output · instrumentation gap*
+
+The kernel makes this honest by separating:
+
+* **Zero with evidence of a run** — producer emitted "completed" but
+  no per-item rows.  Surface as "ran with no output".
+* **Zero with no run evidence** — no producer-level audit row.
+  Surface as "didn't run today".
+* **Zero with run evidence but a known producer gap** — M24.2
+  audit identifies the missing producer.  Surface as
+  "instrumentation gap".
+
+M24 builds the first two; M24.2 unlocks the third.  Until then the
+default surface message is the conservative "may mean: not run · no
+output · missing instrumentation", which is honest but uninformative
+— better than fabricated diagnosis.
+
+## What this document does **not** decide
+
+* **Card labels.** Today's Maintainer surface uses `Absorb /
+  Governance / Synthesis`.  Those labels stay through M24.  M25
+  renames them to the five-state vocabulary above; that rename is
+  the M25 scope, not M24.
+* **Producer-audit results.** Which producers emit which audit rows,
+  and where the gaps are, is M24.2's deliverable.
+* **`/ops/items` URL contract.** M25 designs `/ops/items` as the
+  primary item-drilldown route.  M24 keeps `/ops/events` as the
+  drilldown surface (M24.0 stop-gap behavior) and adds the
+  honest-zero footer.
+
+## Glossary
+
+* **Item** — the unit a Maintainer card counts.  Usually a source,
+  an evergreen, or a cluster.  Never an audit row.
+* **Evidence row** — an `audit_events` row.  Classified by category
+  via `event_evidence_registry` (M24.0); contributes to lifecycle
+  state via `ops_lifecycle` (M24.1).
+* **Projection** — a derived row in `knowledge.db` (e.g. an
+  `objects` row, a `truth_projection` row) that summarises evidence.
+  Projections can disagree with evidence; **Projected** captures
+  exactly that disagreement.
+* **Producer** — any module that writes audit rows.  Auditing them
+  is M24.2's scope.

--- a/docs/operational-lifecycle.md
+++ b/docs/operational-lifecycle.md
@@ -74,14 +74,19 @@ review-queue work lives).
 
 > *"A canonical artifact exists in the vault for this item."*
 
-An evergreen has been promoted (auto or by operator), or the source
-has been archived to `03-Processed` because every extracted artifact
-reached a canonical form.  The item is no longer a candidate; it
-exists in `10-Knowledge/Evergreen/` and is reachable from MOCs / the
-graph.
+An evergreen has been promoted (auto or by operator), so a
+canonical artifact exists in `10-Knowledge/Evergreen/` and is
+reachable from MOCs / the graph.
 
-**Evidence:** `evergreen_auto_promoted`, `promote_concept`,
-`source_archived_to_processed` (after intake completed), or a
+> **Important:** `source_archived_to_processed` is NOT an Accepted
+> signal.  That event fires when a raw markdown file moves into
+> `50-Inbox/03-Processed/`, which is the *input* to the absorb
+> stage, not the output.  Many archived sources still need
+> extraction + promotion; counting that event as Accepted would
+> hide work waiting for the absorber.  Accepted requires a
+> downstream `evergreen_auto_promoted` or `promote_concept` row.
+
+**Evidence:** `evergreen_auto_promoted`, `promote_concept`, or a
 canonical-write event in the registry projection.
 
 **Visible to operator:** yes (primary card).
@@ -166,7 +171,7 @@ The mapping isn't 1:1:
 
 | Evidence category | Contributes to lifecycle state |
 |---|---|
-| `intake`     | Received (always); Accepted via `source_archived_to_processed` |
+| `intake`     | Received (always) — `source_archived_to_processed` stays at Received because 03-Processed is the absorber's *input*, not its output |
 | `absorb`     | Extracted (always); Accepted via `evergreen_auto_promoted` |
 | `synthesis`  | Synthesized (when fresh); otherwise no state change |
 | `governance` | Accepted (via `promote_concept`), Needs Action (via review actions) |

--- a/docs/plans/2026-05-14-m24-lifecycle-contract-layer.md
+++ b/docs/plans/2026-05-14-m24-lifecycle-contract-layer.md
@@ -1,0 +1,308 @@
+# M24 — Lifecycle Contract Layer
+
+> **Renamed from "Pipeline Reset"**, 2026-05-14.  The new name matches
+> what M24 actually does: it adds a contract layer over the existing
+> producers, it does not rewrite them.  The full rewrite lives in
+> M25 (Maintainer Control Plane) and is conditional on M24's evidence.
+
+## Context
+
+M23 shipped the daily-knowledge-feedback digest.  Three structural
+problems surfaced within the first week:
+
+1. **Three drifted intake allowlists.**  `/ops/today`, `/digests`
+   calendar, and the M23 digest's Layer 0 each maintained their own
+   list of which `audit_event` types counted as "intake".  The same
+   day rendered 27 / 7 / many across the three surfaces.
+2. **Card-totals vs drilldown ledgers mismatch.**  `/ops/today` counts
+   raw `audit_events`; `/ops/events` shows timeline projections.  Two
+   different ledgers — the "See all N →" link from a card landed the
+   operator on a list whose count did not match the card.
+3. **Fabricated reasons for zero counts.**  Several places surfaced
+   "No new intake today" when in fact the producer hadn't run,
+   conflating "ran and produced nothing" with "didn't run".
+
+M24.0 (PR #229, merged) shipped the **event-evidence registry**:
+single source of truth for evidence classification, no scope drift,
+no truth claims.  That fixed (1) and partially fixed (2).
+
+M24.1–M24.4 build on top to fix (2) fully and dismantle (3).  The
+deliverable is a **lifecycle contract layer** — a kernel and a
+projection that together let every surface answer:
+
+* "What state is this item in right now?"
+* "What evidence are we using to claim that?"
+* "If the count is 0, why?"
+
+The Maintainer Control Plane rewrite (M25) consumes this layer; it
+does not replace it.  If M25 slips, M24 still stands on its own —
+the existing cards keep working, just with honest zeros and a
+consistent ledger.
+
+## Scope locks (Maintainer reset constraints)
+
+User locked these on 2026-05-13 and they apply to the full M24/M25
+sequence (≈ 4–6 weeks):
+
+* **No new operator-facing features** during M24/M25 except the
+  M24.0 stop-gap (already shipped).
+* **No card renames in M24.**  `Absorb / Governance / Synthesis`
+  stay; M25 renames them to the five-state vocabulary in
+  `docs/operational-lifecycle.md`.
+* **No new dashboards in M24.**  Existing surfaces gain honest-zero
+  footers + consistent drilldowns; nothing new is added.
+* **Registry classifies evidence, not truth.**  The lifecycle kernel
+  derives truth from evidence; the kernel is the only module that
+  makes truth claims.
+* **No fabricated reasons for zero.**  Zero counts surface the
+  ambiguity (see `docs/operational-lifecycle.md` §Honest-zero).
+* **Producer audit (M24.2) is hot-path-only first.**  ≈ 7 producers
+  on the article / clippings / github intake → absorb → promote
+  path, not the full 20+ producer set.
+* **Don't lock the Option B re-run yet.**  Design for it (kernel
+  works with rebuilt evidence too), decide after clean-room run.
+* **File names are locked.**
+  * `event_evidence_registry.py` (already shipped).
+  * `ops_lifecycle.py` (M24.1; *not* `pipeline_truth.py`,
+    *not* `lifecycle_engine.py`).
+  * `ops_state.py` for the Maintainer-readable projection
+    (M24.1).
+
+## Five stages
+
+M24.1 — kernel + projection (this milestone covers M24.1 in detail;
+M24.2/3/4 are sketched here and get their own plan docs once M24.1
+lands).
+
+| Stage | What ships | Gate to next |
+|---|---|---|
+| M24.1 | `ops_lifecycle.py` kernel + `ops_state.py` projection + tests | kernel passes 5-state classification on a known fixture vault |
+| M24.2 | Producer audit (hot-path 7) + repair PRs | every hot-path producer emits the audit row the kernel expects |
+| M24.3 | Honest-zero on every surface (digest + cards + drilldowns) | zero counts on `/ops/today`, `/digests`, daily digest, drilldowns all carry the ambiguity footer |
+| M24.4 | `/ops/today` cards read from `ops_state` projection (not from raw `audit_events`) | card N === drilldown N for every card |
+| M24.5 (optional) | Clean-room rebuild (Option B) of `audit_events` from primary evidence | only if M24.2/3/4 reveal large gaps |
+
+---
+
+## M24.1 — Kernel + projection (this plan)
+
+### Goal
+
+A module `ops_lifecycle.py` that, given a vault's `knowledge.db`,
+returns each item's current lifecycle state from
+`docs/operational-lifecycle.md`'s five-state vocabulary.  A second
+module `ops_state.py` that materialises a Maintainer-readable view
+of those states, refreshed on the same cadence the existing index
+already runs (`ovp-knowledge-index`).
+
+After M24.1 lands:
+
+* Code can ask `lifecycle_state_of(item)` → one of `Received |
+  Extracted | Accepted | Synthesized | NeedsAction`, with an
+  evidence trail.
+* `ops_state` is queryable like any other projection table.
+* No operator-visible surface changes yet.  M24.3 wires the surfaces.
+
+### Stage 1.A — `ops_lifecycle.py` kernel
+
+**Location:** `src/ovp_pipeline/ops_lifecycle.py` (top-level module,
+not under `commands/` — it is platform code, the same as
+`event_evidence_registry.py`).
+
+**Public surface (locked):**
+
+```python
+@dataclass(frozen=True)
+class LifecycleState:
+    item_id: str            # source slug, object_id, or cluster_id
+    item_kind: str          # "source" | "object" | "cluster"
+    state: str              # "Received"|"Extracted"|"Accepted"|"Synthesized"|"NeedsAction"
+    sub_state: str | None   # "Prepared"|"Projected" or None
+    evidence: tuple[str, ...]  # event_type strings, newest first
+    last_evidence_at: str   # ISO timestamp of newest evidence row
+    needs_action_reason: str | None  # populated when state=="NeedsAction"
+
+def lifecycle_state_of(conn, item_kind, item_id) -> LifecycleState | None
+def lifecycle_states_for_kind(conn, item_kind) -> Iterator[LifecycleState]
+def lifecycle_counts(conn) -> dict[str, int]  # state → count, for cards
+```
+
+**Rules (these are the contract, not implementation hints):**
+
+* The kernel reads only from `audit_events`, `objects`,
+  `evergreen_revisions`, `community_crystals`,
+  `contradiction_crystals`, and `graph_clusters`.  No reading from
+  markdown, no calling out to producers.
+* The state derivation function is **pure** given those tables —
+  same inputs, same output, always.  No `datetime.now()` inside
+  the kernel; freshness checks take an `as_of` argument.
+* Classification of each evidence row goes through
+  `event_evidence_registry.classify()` — the kernel never hardcodes
+  event_type strings.
+* When evidence is inconsistent (e.g. registry projection says
+  Accepted but no `evergreen_auto_promoted` row exists), the kernel
+  sets `sub_state="Projected"` and surfaces the disagreement in
+  `evidence`.  It never silently picks one ledger over the other.
+
+**Tests (`tests/test_ops_lifecycle.py`):**
+
+* Fixture vault with one source per state.
+  * `received_only.md` — only intake events.
+  * `extracted_only.md` — intake + absorb_route_decision.
+  * `extracted_prepared.md` — intake + extraction_complete, no
+    upsert (Prepared internal sub-state).
+  * `accepted.md` — intake + extraction + promote.
+  * `synthesized_fresh.md` — accepted + community_crystal fresh.
+  * `synthesized_stale.md` — accepted + community_crystal older
+    than newest revision (state should be Accepted, not
+    Synthesized).
+  * `needs_action_failure.md` — failure-category event.
+  * `needs_action_governance.md` — open contradiction.
+  * `projected_no_promote.md` — `objects` row exists but no
+    `evergreen_auto_promoted` event (sub_state Projected).
+* Assert state, sub_state, evidence ordering, last_evidence_at.
+* Assert `lifecycle_counts` matches.
+
+### Stage 1.B — `ops_state.py` projection
+
+**Location:** `src/ovp_pipeline/ops_state.py`.
+
+**Schema (new table in `knowledge.db`):**
+
+```sql
+CREATE TABLE ops_state (
+    pack TEXT NOT NULL,
+    item_kind TEXT NOT NULL,        -- "source"|"object"|"cluster"
+    item_id TEXT NOT NULL,
+    state TEXT NOT NULL,            -- five-state vocabulary
+    sub_state TEXT,                 -- "Prepared"|"Projected" or NULL
+    last_evidence_at TEXT NOT NULL,
+    evidence_event_types_json TEXT NOT NULL,
+    needs_action_reason TEXT,
+    refreshed_at TEXT NOT NULL,
+    PRIMARY KEY (pack, item_kind, item_id)
+);
+CREATE INDEX ops_state_by_state ON ops_state(pack, state);
+CREATE INDEX ops_state_by_last_evidence ON ops_state(pack, last_evidence_at DESC);
+```
+
+**Refresh entrypoint:** `ovp-ops-state --rebuild [--pack research-tech]`.
+Reuses the same orchestration `ovp-knowledge-index` uses; lands on
+the existing post-pipeline DAG step list, not a new cron.
+
+**Rules:**
+
+* Full rebuild only in M24.1.  Incremental refresh ships in M24.4 if
+  needed.
+* Idempotent.  Calling `--rebuild` twice yields byte-identical rows.
+* Adds **one** new step to the unified pipeline DAG, after
+  `knowledge_index`, gated on `--full`.  No new scheduler.
+
+**Tests (`tests/test_ops_state.py`):**
+
+* Build the same fixture vault as `test_ops_lifecycle`.
+* Run `ovp-ops-state --rebuild`.
+* Assert row count, state distribution, idempotency.
+* Assert that the projection answer matches the kernel answer for
+  every item (the projection cannot lie about state relative to the
+  kernel).
+
+### Stage 1.C — CLI surface
+
+Two new entry points in `pyproject.toml`:
+
+```
+ovp-ops-state = "ovp_pipeline.commands.ops_state_cli:main"
+ovp-lifecycle-show = "ovp_pipeline.commands.ops_state_cli:show_main"
+```
+
+* `ovp-ops-state --rebuild` — runs the projection rebuild.
+* `ovp-ops-state --show-counts [--pack P]` — prints the
+  five-state count distribution.  Same data the M25 cards will
+  read.
+* `ovp-lifecycle-show <kind> <id>` — prints the kernel's full
+  evidence trail for one item.  Debugging surface for M24.2.
+
+### Stage 1.D — DAG wiring
+
+Add one step to `unified_pipeline_enhanced.py`:
+
+```python
+("ops_state", "Rebuild ops_state projection"),
+```
+
+* Runs after `knowledge_index`.
+* `--check` validates that `ops_state` schema is current.
+* `--dry-run` reports row counts without writing.
+
+### Stage 1.E — Audit-event additions (M24.1 scope, minimal)
+
+The kernel needs **one** new audit row that doesn't exist today, to
+make the Prepared internal sub-state observable:
+
+* `absorb_pending_upsert` — fired by `auto_evergreen_extractor` when
+  extraction completes but the candidate hasn't been upserted yet.
+
+Adding this row is in scope for M24.1 because the kernel design
+depends on it.  Registering the event_type in the registry (`absorb`
+category, `user_visible=False`) is part of the same PR.
+
+No other producer changes in M24.1.  Producer-audit at scale lives
+in M24.2.
+
+### Non-goals for M24.1
+
+* **No surface changes.**  `/ops/today`, `/digests`, daily digest
+  bodies are unchanged.  M24.3 wires them.
+* **No card renames.**  M25's job.
+* **No `/ops/items` route.**  M25's job.
+* **No removal of `event_types_filter=...` query param.**  The M24.0
+  drilldown stays.
+
+---
+
+## Risks + mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Kernel disagrees with reality on real operator vault (lifecycle states are wrong) | Fixture-vault tests cover every state and sub-state.  After lands, run `ovp-lifecycle-show` against the live vault on a sample of 20 items, spot-check by hand. |
+| `ops_state` rebuild is slow on large vaults | Rebuild is full-table for M24.1; benchmark on the operator vault before claiming done.  Incremental refresh waits for M24.4 only if the full rebuild times out. |
+| `absorb_pending_upsert` row leaks into Maintainer surfaces | Registered with `user_visible=False`.  Tested in `tests/test_event_evidence_registry.py`. |
+| Option B clean-room rebuild becomes necessary mid-M24 | Kernel is pure and reads only schema-stable tables.  A rebuild of `audit_events` from primary evidence yields a kernel answer using the same code path — no kernel changes needed for Option B. |
+| Producer audit (M24.2) reveals so many gaps that the kernel reports widespread `Projected` sub-state | Acceptable.  That **is** the diagnostic M24.2 needs.  Surface it; do not paper over it. |
+
+## Open issues to flag (post-Stage-1)
+
+* **Cross-pack lifecycle.**  Does an evergreen promoted into one pack
+  but referenced in another count as Accepted in both?  Default
+  answer: state is per-pack, evidence is read pack-scoped.  Lock
+  this in `ops_lifecycle.py` docstring when the kernel lands.
+* **NeedsAction priority ordering.**  Today multiple
+  failure/governance rows can pile up on one item.  The kernel
+  returns *all* in `evidence`; M25 decides the display order.  Not
+  M24.1's call.
+* **Time-window scoping for cards.**  Cards today show "today's"
+  counts.  `ops_state` carries `last_evidence_at` — the M24.4 card
+  query reads `WHERE last_evidence_at >= :window_start`.  Window
+  semantics inherit M23's digest config (operator-local day).
+
+## Acceptance checklist (M24.1)
+
+* [ ] `docs/operational-lifecycle.md` merged on main.
+* [ ] `src/ovp_pipeline/ops_lifecycle.py` + tests merged.
+* [ ] `src/ovp_pipeline/ops_state.py` + tests merged.
+* [ ] `event_evidence_registry` knows `absorb_pending_upsert`.
+* [ ] `auto_evergreen_extractor` emits `absorb_pending_upsert` when
+      extraction completes without an upsert.
+* [ ] `ovp-ops-state --rebuild` runs on the operator vault under 30s
+      (full rebuild, ~50k audit rows).
+* [ ] `ovp-lifecycle-show source 2026-05-12-some-article` returns a
+      sensible evidence trail.
+* [ ] Full `pytest` run stays green (modulo the two known pre-existing
+      architecture-fitness failures).
+
+---
+
+*Plan author: Claude (M24.1).  User-locked constraints captured.
+Per scope-lock: ship M24.1, then re-plan M24.2 against M24.1's
+real-vault output, not against this doc's assumptions.*

--- a/docs/plans/2026-05-14-m24-lifecycle-contract-layer.md
+++ b/docs/plans/2026-05-14-m24-lifecycle-contract-layer.md
@@ -121,11 +121,31 @@ class LifecycleState:
     evidence: tuple[str, ...]  # event_type strings, newest first
     last_evidence_at: str   # ISO timestamp of newest evidence row
     needs_action_reason: str | None  # populated when state=="NeedsAction"
+    pack: str               # pack scope this classification is valid for
 
-def lifecycle_state_of(conn, item_kind, item_id) -> LifecycleState | None
-def lifecycle_states_for_kind(conn, item_kind) -> Iterator[LifecycleState]
-def lifecycle_counts(conn) -> dict[str, int]  # state → count, for cards
+def lifecycle_state_of(
+    conn, item_kind, item_id, *, pack: str, as_of: str = "",
+) -> LifecycleState | None
+def lifecycle_states_for_kind(
+    conn, item_kind, *, pack: str, as_of: str = "",
+) -> Iterator[LifecycleState]
+def lifecycle_counts(
+    conn, *, pack: str, as_of: str = "",
+) -> dict[str, int]
 ```
+
+**Why `pack` is keyword-required:** the truth-projection tables
+(``objects``, ``graph_clusters``, ``community_crystals``) are all
+keyed by ``pack``, but ``audit_events`` is not.  Without a pack
+arg the kernel would silently merge evidence across packs when
+slugs / object_ids collide.  The pack kwarg forces every caller
+to be explicit about scope.
+
+**Why `as_of` is on every call:** freshness checks for the
+Synthesized state need a time anchor.  Putting ``as_of`` on the
+call (rather than inside the kernel) keeps the kernel pure for
+testing and lets ``ovp-ops-state --rebuild`` pass a stable
+boundary so two rebuilds in the same minute classify identically.
 
 **Rules (these are the contract, not implementation hints):**
 
@@ -194,7 +214,14 @@ the existing post-pipeline DAG step list, not a new cron.
 
 * Full rebuild only in M24.1.  Incremental refresh ships in M24.4 if
   needed.
-* Idempotent.  Calling `--rebuild` twice yields byte-identical rows.
+* **Content-idempotent.**  Calling `--rebuild` twice with no audit
+  change between calls produces byte-identical rows in every column
+  EXCEPT `refreshed_at` (which is set to the current rebuild time
+  on each call by design — it is the projection's "when did I last
+  look" stamp).  The test asserts equality on every column except
+  `refreshed_at`; production code consuming the projection should
+  treat `refreshed_at` as metadata, not as part of an item's
+  identity.
 * Adds **one** new step to the unified pipeline DAG, after
   `knowledge_index`, gated on `--full`.  No new scheduler.
 


### PR DESCRIPTION
## Summary

- `docs/operational-lifecycle.md` — locks the five visible Maintainer states (Received · Extracted · Accepted · Synthesized · Needs Action) plus two internal evidence sub-states (Prepared · Projected). This is the vocabulary M24 (Lifecycle Contract Layer) and M25 (Maintainer Control Plane) will build against.
- `docs/plans/2026-05-14-m24-lifecycle-contract-layer.md` — five-stage M24 plan. M24.1 detailed (kernel + projection + one new audit event + DAG step + two CLIs); M24.2–M24.4 sketched. Renamed from "Pipeline Reset" to match what the work actually is.

Locked constraints (from the planning conversation, captured in the doc):

- No new dashboards or lifecycle UI in M24.
- No card renames in M24 (M25 job).
- Registry classifies evidence, not truth — kernel derives truth.
- No fabricated reasons for zero counts (honest-zero principle).
- Producer audit (M24.2) is hot-path-only first (~7 producers, not 20+).
- File names locked: `ops_lifecycle.py`, `ops_state.py`.
- Don't lock Option B clean-room re-run yet — design for it, decide after M24.2/3/4 evidence.

No code changes in this PR — design docs only. Implementation PRs follow.

## Test plan

- [x] Docs render in GitHub markdown without broken anchors.
- [ ] Reviewer (codex) confirms the vocabulary matches the planning conversation's locks.
- [ ] No drift from M24.0 (the registry stop-gap, already on main).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced five operator-visible lifecycle states for item tracking
  * Added CLI commands for querying and displaying item lifecycle states

* **Documentation**
  * Added lifecycle vocabulary documentation with state definitions and evidence mappings
  * Added implementation plan documentation for lifecycle contract layer

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fakechris/obsidian_vault_pipeline/pull/230)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->