### PR TITLE
feat(m24.3): honest-zero messaging across surfaces

### DIFF
--- a/src/ovp_pipeline/commands/_digests_list_page.py
+++ b/src/ovp_pipeline/commands/_digests_list_page.py
@@ -254,11 +254,17 @@ def _render_calendar_grid(cells: list[CalendarCell]) -> str:
     blank_html = "<div class='cal-cell cal-cell-blank'></div>" * leading_blanks
     cells_html = "".join(_cell_html(c) for c in cells)
 
+    # M24.3 honest-zero: "quiet day" used to be a single-word gloss
+    # but a quiet day really means "no audit evidence" — which has
+    # three possible upstream causes (didn't run, ran with no
+    # output, missing instrumentation).  Don't promise diagnosis.
     legend = (
         "<p class='muted small' style='margin-top:0.4rem'>"
         "✓ digest exists · "
         "N = intake events (click to inspect day) · "
-        "— = quiet day"
+        "— = no audit evidence "
+        "<span class='muted'>(may mean: not run · no output · "
+        "missing instrumentation)</span>"
         "</p>"
     )
     # Calendar styles live in /static/ovp-digests-calendar.css (gemini

--- a/src/ovp_pipeline/commands/_ui_renderers.py
+++ b/src/ovp_pipeline/commands/_ui_renderers.py
@@ -21,6 +21,7 @@ import yaml
 from markdown_it import MarkdownIt
 
 from ..identity import canonicalize_note_id
+from ..ops_honest_zero import honest_zero_html
 from ..pack_resolution import iter_compatible_packs
 from ..packs.loader import PRIMARY_PACK_NAME
 from ..runtime import VaultLayout
@@ -6798,20 +6799,13 @@ def _render_today_digest_page(payload: dict) -> str:
                 "</div>"
             )
 
-        # M24.0 honest-zero: when a card has zero evidence, don't
-        # fabricate a reason (could be not_run, ran_no_output, or
-        # missing instrumentation — three different upstream causes
-        # collapsed into one observation).  M24's lifecycle kernel
-        # will replace this with a real diagnosis; for now we name
-        # the ambiguity instead of guessing.
+        # M24.3 honest-zero: shared message across every surface so
+        # the wording stays consistent.  M24.4 will branch on the
+        # ops_state diagnosis instead of always returning the
+        # ambiguity, but the helper signature stays the same.
         zero_html = ""
         if total == 0:
-            zero_html = (
-                "<p class='muted tiny' style='margin-top:6px'>"
-                "No evidence in this window. "
-                "May mean: not run · no output · missing instrumentation."
-                "</p>"
-            )
+            zero_html = honest_zero_html(short=True)
 
         sections.append(
             "<div class='card' style='margin:0;overflow:hidden'>"

--- a/src/ovp_pipeline/commands/digest_handler.py
+++ b/src/ovp_pipeline/commands/digest_handler.py
@@ -622,7 +622,14 @@ def _render_no_data_body(inputs: DigestInputs) -> str:
     # ``ovp-knowledge-index`` simply hasn't built the audit_events
     # table yet.
     if preflight.audit_events_layer0 == "ok":
-        intake_line = "No new intake in this window."
+        # M24.3 honest-zero: the audit-events table is fine, but
+        # "no intake" here still has three possible upstream causes
+        # (producer didn't run, ran with no rows, missing
+        # instrumentation).  Don't fabricate a single one.
+        from ..ops_honest_zero import HONEST_ZERO_SHORT
+        intake_line = (
+            f"No new intake in this window.  _{HONEST_ZERO_SHORT}_"
+        )
     else:
         intake_line = (
             "Intake data unavailable — the audit_events table is "

--- a/src/ovp_pipeline/ops_honest_zero.py
+++ b/src/ovp_pipeline/ops_honest_zero.py
@@ -1,0 +1,79 @@
+"""Honest-zero messaging (M24.3, 2026-05-14).
+
+Tiny shared module so every surface that can display a zero count
+says the same true thing about what the zero means.  The doc that
+defines this principle is ``docs/operational-lifecycle.md``
+§Honest-zero.
+
+A zero count on a Maintainer surface can mean three different
+upstream things — three causes that collapse into one observation:
+
+* **not run** — the producer didn't fire today.
+* **no output** — the producer fired and emitted zero rows.
+* **missing instrumentation** — the producer ran successfully but
+  doesn't emit the audit row we're counting (M24.2 producer-audit
+  gap).
+
+Until M24.2 lands, no surface can distinguish the three.  This
+module's job is to keep us honest about that ambiguity rather than
+fabricate a single diagnosis.
+
+After M24.2, callers will branch on the actual diagnosis the
+``ops_state`` projection + producer-audit registry expose; the
+``UNKNOWN_*`` phrasing here will narrow naturally.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+
+HONEST_ZERO_SHORT: Final[str] = (
+    "May mean: not run · no output · missing instrumentation."
+)
+
+HONEST_ZERO_LONG: Final[str] = (
+    "No evidence in this window.  This can mean three different "
+    "upstream things — the producer didn't run today, it ran and "
+    "emitted nothing, or it ran successfully but the audit row "
+    "we count is missing (M24.2 will close this gap).  Until then, "
+    "do not infer a single cause from a zero count."
+)
+
+
+def honest_zero_html(*, short: bool = True, css_class: str = "muted tiny") -> str:
+    """Return an HTML fragment surfacing the honest-zero message.
+
+    Default is the short single-line form ``HONEST_ZERO_SHORT``,
+    suitable for cards and inline footers.  ``short=False`` returns
+    the long-form paragraph for empty-page banners.
+    """
+    text = HONEST_ZERO_SHORT if short else HONEST_ZERO_LONG
+    css = css_class.strip() or "muted tiny"
+    if short:
+        return (
+            f"<p class='{css}' style='margin-top:6px'>{text}</p>"
+        )
+    return (
+        f"<div class='card' style='border-color:#9ca3af;"
+        f"background:#f5f5f4;padding:0.75rem 1rem;margin:0.5rem 0'>"
+        f"<p class='{css}' style='margin:0'>{text}</p></div>"
+    )
+
+
+def honest_zero_markdown() -> str:
+    """Markdown-formatted honest-zero footer for digest bodies.
+
+    The daily digest uses this when a Layer renders zero items so
+    the operator gets the same explanation the UI cards already
+    surface.
+    """
+    return f"\n\n_{HONEST_ZERO_SHORT}_\n"
+
+
+__all__ = [
+    "HONEST_ZERO_LONG",
+    "HONEST_ZERO_SHORT",
+    "honest_zero_html",
+    "honest_zero_markdown",
+]

--- a/tests/test_ops_honest_zero.py
+++ b/tests/test_ops_honest_zero.py
@@ -1,0 +1,71 @@
+"""Tests for the honest-zero messaging helper (M24.3).
+
+The whole point of centralising this module is so the wording stays
+the same across every surface — a regression that drops the
+ambiguity from one surface but not another would be hard to spot
+manually.  These tests lock the phrase + lock the cross-surface
+consistency.
+"""
+
+from __future__ import annotations
+
+from ovp_pipeline.ops_honest_zero import (
+    HONEST_ZERO_LONG,
+    HONEST_ZERO_SHORT,
+    honest_zero_html,
+    honest_zero_markdown,
+)
+
+
+def test_short_phrase_names_the_three_causes():
+    """The short form must mention all three upstream causes so the
+    operator sees the ambiguity at a glance.  Adding a fourth cause
+    requires a code change here — make it deliberate."""
+    assert "not run" in HONEST_ZERO_SHORT
+    assert "no output" in HONEST_ZERO_SHORT
+    assert "missing instrumentation" in HONEST_ZERO_SHORT
+
+
+def test_short_phrase_is_one_line():
+    assert "\n" not in HONEST_ZERO_SHORT
+
+
+def test_long_phrase_extends_the_short_one():
+    """The long-form banner must contain every cause the short one
+    surfaces — otherwise the empty-page banner says something less
+    honest than the inline card footer."""
+    for cause in ("didn't run", "emitted nothing", "audit row"):
+        assert cause in HONEST_ZERO_LONG
+
+
+def test_html_short_renders_a_paragraph():
+    html = honest_zero_html(short=True)
+    assert html.startswith("<p")
+    assert HONEST_ZERO_SHORT in html
+    assert "muted tiny" in html
+
+
+def test_html_long_renders_a_card_banner():
+    html = honest_zero_html(short=False)
+    assert "<div" in html
+    assert HONEST_ZERO_LONG in html
+
+
+def test_html_respects_custom_css_class():
+    html = honest_zero_html(short=True, css_class="custom-style")
+    assert "custom-style" in html
+    assert "muted tiny" not in html
+
+
+def test_html_empty_css_class_falls_back():
+    """Empty/whitespace css_class must not produce a class='' attr —
+    fall back to the sensible default."""
+    html = honest_zero_html(short=True, css_class="   ")
+    assert "muted tiny" in html
+
+
+def test_markdown_is_italic_wrapped():
+    md = honest_zero_markdown()
+    assert HONEST_ZERO_SHORT in md
+    assert md.strip().startswith("_")
+    assert md.strip().endswith("_")


### PR DESCRIPTION
## Summary

Centralise the honest-zero phrase into `ops_honest_zero.py` and wire it into every surface that can show a zero count.

**New code:**
- `src/ovp_pipeline/ops_honest_zero.py` — single source of truth for the "may mean: not run · no output · missing instrumentation" wording.
- `tests/test_ops_honest_zero.py` — 8 cases locking the wording + cross-surface consistency.

**Sites wired:**
- `/ops/today` cards — switched from inline string to shared helper.
- Daily digest body (no-data path) — adds honest-zero footer to "No new intake" stub.
- `/digests` calendar legend — em-dash gloss now reads honestly ("no audit evidence (may mean: ...)").

**Why:**
A zero count has three different upstream causes (didn't run, ran with no output, missing instrumentation) that look identical from the count alone. Until M24.2 lands the producer audit, no surface can distinguish them. Naming the ambiguity is more honest than picking one.

## Test plan

- [x] pytest tests/test_ops_honest_zero.py — 8/8 pass.
- [x] Full suite — 2835 passed, 0 regressions.
- [ ] Manual: open /ops/today on a quiet day, confirm card footers; open /digests, hover the em-dash legend; trigger a no-data digest via empty vault and confirm body footer.

Refs `docs/operational-lifecycle.md` §Honest-zero, PR #230 (design), PR #231 (kernel).