### PR TITLE
feat(m24.4): lifecycle backlog strip on /ops/today (sourced from ops_state)

### DIFF
--- a/src/ovp_pipeline/commands/_ui_renderers.py
+++ b/src/ovp_pipeline/commands/_ui_renderers.py
@@ -6819,6 +6819,45 @@ def _render_today_digest_page(payload: dict) -> str:
         )
     sections.append("</div>")
 
+    # M24.4: passive lifecycle-backlog strip beneath the event cards.
+    # Five numbers, no clicks — answers "how many items are sitting
+    # in each lifecycle state right now?".  Orthogonal to the cards
+    # above (which count today's events).  M25 will rename the cards
+    # to this vocabulary; for M24 the two surfaces coexist so the
+    # operator can compare event flow with backlog at a glance.
+    lifecycle = payload.get("lifecycle_summary") or {}
+    if lifecycle.get("available"):
+        counts = lifecycle.get("counts") or {}
+        total = lifecycle.get("total", 0)
+        state_chips = "".join(
+            f"<span class='pill'>{escape(state)}: "
+            f"{int(counts.get(state, 0))}</span>"
+            for state in (
+                "Received", "Extracted", "Accepted",
+                "Synthesized", "NeedsAction",
+            )
+        )
+        sections.append(
+            "<section style='margin-top:1rem'>"
+            "<div class='muted tiny' style='margin-bottom:4px'>"
+            f"Lifecycle backlog "
+            f"<span class='muted'>· {int(total)} item"
+            f"{'s' if int(total) != 1 else ''} in scope</span>"
+            "</div>"
+            f"<div style='display:flex;gap:0.4rem;flex-wrap:wrap'>{state_chips}</div>"
+            "</section>"
+        )
+    elif lifecycle.get("reason"):
+        # Surface the explicit not-yet-built reason rather than
+        # silently dropping the section — honest-zero applies to
+        # the kernel's own readout too.
+        sections.append(
+            "<section style='margin-top:1rem'>"
+            "<div class='muted tiny'>Lifecycle backlog "
+            f"<span class='muted'>· {escape(str(lifecycle['reason']))}</span>"
+            "</div></section>"
+        )
+
     body = "".join(sections)
     return _layout(f"Today — {date}", body, requested_pack=requested_pack)
 

--- a/src/ovp_pipeline/ui/view_models.py
+++ b/src/ovp_pipeline/ui/view_models.py
@@ -3353,6 +3353,18 @@ def build_today_digest_payload(
             return ""
         return _scoped_path(f"/ops/today?date={quote(d, safe='')}", pack_name=requested_pack)
 
+    # M24.4: pull the per-pack lifecycle distribution from
+    # ``ops_state`` when the projection exists.  This is a *passive*
+    # readout — five numbers, no new drilldown route — that surfaces
+    # the kernel's truth alongside the existing time-windowed cards.
+    # Cards continue to count today's audit_events; the lifecycle
+    # summary answers a different (orthogonal) question: "how many
+    # items are sitting in each state right now?".  M25 will rename
+    # the cards onto this vocabulary; for M24 the two coexist.
+    lifecycle_summary = _read_lifecycle_summary(
+        vault_dir, pack=requested_pack
+    )
+
     return {
         "screen": "ops/today",
         "requested_pack": requested_pack,
@@ -3362,7 +3374,63 @@ def build_today_digest_payload(
         "prev_date_path": _date_path(prev_date),
         "next_date_path": _date_path(next_date),
         "cards": cards,
+        "lifecycle_summary": lifecycle_summary,
         "available": True,
+    }
+
+
+def _read_lifecycle_summary(
+    vault_dir: Path | str,
+    *,
+    pack: str,
+) -> dict[str, Any]:
+    """Read the five-state lifecycle distribution from ``ops_state``.
+
+    Returns ``{"available": False, "reason": ...}`` when the
+    projection table doesn't exist yet (e.g. the ``ops_state`` DAG
+    step hasn't run).  Returns ``{"available": True, "counts": {…}}``
+    otherwise.
+
+    Keeping this in ``view_models`` rather than calling
+    ``ops_state.counts_from_projection`` directly avoids ``view_models``
+    accidentally creating the table on a vault that hasn't run the
+    DAG yet — we read what's there; we don't write.
+    """
+    from ..ops_lifecycle import ALL_STATES
+
+    db_path = _db_path(vault_dir)
+    if not db_path.exists():
+        return {"available": False, "reason": "knowledge_index has not been built yet"}
+
+    effective_pack = pack or PRIMARY_PACK_NAME
+    try:
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                "SELECT 1 FROM sqlite_master "
+                "WHERE type='table' AND name='ops_state'"
+            ).fetchone()
+            if row is None:
+                return {
+                    "available": False,
+                    "reason": "ops_state projection not built yet — run `ovp-ops-state --rebuild`",
+                }
+            rows = conn.execute(
+                "SELECT state, COUNT(*) FROM ops_state "
+                " WHERE pack = ? GROUP BY state",
+                (effective_pack,),
+            ).fetchall()
+    except sqlite3.OperationalError as exc:
+        return {"available": False, "reason": f"ops_state read failed: {exc}"}
+
+    counts: dict[str, int] = {s: 0 for s in ALL_STATES}
+    for state, count in rows:
+        if state in counts:
+            counts[state] = int(count)
+    return {
+        "available": True,
+        "pack": effective_pack,
+        "counts": counts,
+        "total": sum(counts.values()),
     }
 
 

--- a/tests/test_ops_today_lifecycle.py
+++ b/tests/test_ops_today_lifecycle.py
@@ -1,0 +1,164 @@
+"""Tests for M24.4 lifecycle_summary on ``/ops/today``.
+
+The cards continue to count today's audit_events (intake / absorb /
+synthesis / governance / failures — the M24.0 stop-gap vocabulary).
+The new ``lifecycle_summary`` payload field exposes the orthogonal
+"how many items are sitting in each lifecycle state right now"
+question, sourced from the ``ops_state`` projection that M24.1
+builds.
+
+Tests cover three regimes:
+
+* ``ops_state`` table doesn't exist → the payload surfaces an
+  explicit "projection not built yet" reason rather than silently
+  returning zero counts.
+* ``ops_state`` table exists but the requested pack has no rows
+  → ``counts`` has every state with value 0; ``available`` is True.
+* ``ops_state`` table exists with rows for the pack → ``counts``
+  matches what ``ops_state.rebuild`` wrote.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+from ovp_pipeline.ops_lifecycle import (
+    ALL_STATES,
+    STATE_ACCEPTED,
+    STATE_NEEDS_ACTION,
+    STATE_RECEIVED,
+)
+from ovp_pipeline.ops_state import rebuild
+from ovp_pipeline.ui.view_models import build_today_digest_payload
+
+
+PACK = "research-tech"
+
+
+_AUDIT_EVENTS_SCHEMA = """
+CREATE TABLE audit_events (
+    source_log TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    slug TEXT NOT NULL DEFAULT '',
+    session_id TEXT NOT NULL DEFAULT '',
+    timestamp TEXT NOT NULL DEFAULT '',
+    payload_json TEXT NOT NULL
+);
+"""
+
+
+def _make_db(tmp_path: Path) -> Path:
+    db_path = tmp_path / "60-Logs" / "knowledge.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.executescript(_AUDIT_EVENTS_SCHEMA)
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def _seed_two_items(db_path: Path) -> None:
+    """One Received source + one NeedsAction source (different slugs).
+
+    Wires through ``ops_state.rebuild`` so the projection is whatever
+    the kernel would derive from the audit log — keeps the test
+    honest about the kernel/projection contract.
+    """
+    today = datetime.now(timezone.utc).isoformat()
+    conn = sqlite3.connect(db_path)
+    conn.executemany(
+        "INSERT INTO audit_events VALUES (?, ?, ?, ?, ?, ?)",
+        [
+            ("pipeline.jsonl", "article_intake_only", "src-1",
+             "sess", today, "{}"),
+            ("pipeline.jsonl", "absorb_parse_error", "src-2",
+             "sess", today, "{}"),
+        ],
+    )
+    conn.commit()
+    rebuild(conn, pack=PACK)
+    conn.close()
+
+
+# ── ops_state table absent ────────────────────────────────────────
+
+
+def test_lifecycle_summary_unavailable_when_projection_missing(tmp_path):
+    """``audit_events`` exists but ``ops_state`` table has not been
+    built — payload must say so explicitly."""
+    _make_db(tmp_path)  # audit_events only
+    payload = build_today_digest_payload(tmp_path, pack_name=PACK)
+    summary = payload.get("lifecycle_summary") or {}
+    assert summary.get("available") is False
+    assert "ops_state" in (summary.get("reason") or "")
+
+
+def test_lifecycle_summary_unavailable_when_db_missing(tmp_path):
+    """No ``knowledge.db`` at all — the cards already short-circuit,
+    and the lifecycle summary must match."""
+    payload = build_today_digest_payload(tmp_path, pack_name=PACK)
+    assert payload["available"] is False
+    # When the DB is missing, build_today_digest_payload returns
+    # early before the lifecycle_summary helper runs.  The absence
+    # of the field is the contract.
+    assert "lifecycle_summary" not in payload
+
+
+# ── projection present + populated ────────────────────────────────
+
+
+def test_lifecycle_summary_returns_kernel_counts(tmp_path):
+    db_path = _make_db(tmp_path)
+    _seed_two_items(db_path)
+    payload = build_today_digest_payload(tmp_path, pack_name=PACK)
+    summary = payload["lifecycle_summary"]
+    assert summary["available"] is True
+    assert summary["pack"] == PACK
+    counts = summary["counts"]
+    assert set(counts.keys()) == set(ALL_STATES)
+    assert counts[STATE_RECEIVED] == 1
+    assert counts[STATE_NEEDS_ACTION] == 1
+    assert summary["total"] == 2
+
+
+def test_lifecycle_summary_empty_pack_returns_zero_counts(tmp_path):
+    """``ops_state`` exists but no rows for the requested pack →
+    every state is present with count 0, ``available`` is True."""
+    db_path = _make_db(tmp_path)
+    _seed_two_items(db_path)
+    payload = build_today_digest_payload(
+        tmp_path, pack_name="some-other-pack"
+    )
+    summary = payload["lifecycle_summary"]
+    assert summary["available"] is True
+    assert all(summary["counts"][s] == 0 for s in ALL_STATES)
+    assert summary["total"] == 0
+
+
+def test_lifecycle_summary_counts_match_projection_directly(tmp_path):
+    """The summary count must equal what ``ops_state.rebuild``
+    returned.  Regression guard against the view-model drifting from
+    the projection's own count helper."""
+    db_path = _make_db(tmp_path)
+    _seed_two_items(db_path)
+    # Re-rebuild and capture the counts.
+    with sqlite3.connect(db_path) as conn:
+        rebuild_counts = rebuild(conn, pack=PACK)
+    payload = build_today_digest_payload(tmp_path, pack_name=PACK)
+    assert payload["lifecycle_summary"]["counts"] == rebuild_counts
+
+
+def test_cards_are_independent_of_lifecycle_summary(tmp_path):
+    """Cards count today's events; lifecycle_summary counts items in
+    each state.  An NeedsAction item (failure event) must still
+    count on the failures card AND the NeedsAction lifecycle
+    bucket — they're orthogonal, not duplicates."""
+    db_path = _make_db(tmp_path)
+    _seed_two_items(db_path)
+    payload = build_today_digest_payload(tmp_path, pack_name=PACK)
+    failures_card = next(c for c in payload["cards"] if c["id"] == "failures")
+    assert failures_card["total"] == 1  # 1 failure event today
+    assert payload["lifecycle_summary"]["counts"][STATE_NEEDS_ACTION] == 1


### PR DESCRIPTION
## Summary

Passive five-state lifecycle readout below the existing event cards on `/ops/today`. Cards still count today's audit_events; the new strip counts items by current lifecycle state from the `ops_state` projection M24.1 built. Two orthogonal surfaces, same page.

**Changes:**
- `view_models._read_lifecycle_summary` reads from `ops_state` table; surfaces explicit "projection not built yet" reason when the table is absent.
- `build_today_digest_payload` attaches `lifecycle_summary` to its return payload.
- `_render_today_page` renders five chips beneath the existing card row.
- `tests/test_ops_today_lifecycle.py` — 6 cases.

**Why both surfaces stay:**
Cards count *events in a date window*. An item Received last week emits no events today; it should not vanish from the operator's mental model. The lifecycle strip counts *items by current state* — same item, different question. M25 renames the cards onto the lifecycle vocabulary deliberately; M24 leaves the swap unfired.

**Locks honored:**
- No new routes.
- No card renames.
- Honest-zero applies to the strip too (explicit reason when projection missing).

## Test plan

- [x] pytest tests/test_ops_today_lifecycle.py — 6/6 pass.
- [x] Full suite — 2857 passed, 0 regressions.
- [ ] Manual: run `ovp-ops-state --rebuild` on operator vault, open `/ops/today`, confirm strip renders; reset projection table, confirm strip surfaces the "not built yet" reason.

Refs PR #231 (kernel), `docs/plans/2026-05-14-m24-lifecycle-contract-layer.md` §M24.4.