### PR TITLE
feat(m25.2): /ops/items minimal route — lifecycle drilldown

### DIFF
--- a/src/ovp_pipeline/commands/_ui_renderers.py
+++ b/src/ovp_pipeline/commands/_ui_renderers.py
@@ -6862,6 +6862,166 @@ def _render_today_digest_page(payload: dict) -> str:
     return _layout(f"Today — {date}", body, requested_pack=requested_pack)
 
 
+# M25.2: /ops/items renderer.  Lifecycle-state drilldown that the
+# M25 hybrid card primary CTAs target.  Read-only in v1 — no inline
+# actions yet; that's a separate scoping pass per the M25 plan.
+def _render_items_list_page(payload: dict) -> str:
+    """Render the ``/ops/items?state=…`` table.
+
+    Single-table view, paginated.  Carries an honest-zero footer
+    when the projection isn't built or the bucket is empty.
+    """
+    requested_pack = str(payload.get("requested_pack") or "")
+    state = str(payload.get("state") or "")
+    total = int(payload.get("total") or 0)
+    rows = payload.get("rows") or []
+    offset = int(payload.get("offset") or 0)
+    limit = int(payload.get("limit") or 0)
+
+    title = f"Items · {state or 'unknown state'}"
+
+    if not payload.get("available"):
+        reason = escape(str(payload.get("reason") or "unavailable"))
+        body = (
+            f"<h1>{escape(title)}</h1>"
+            "<div class='card' style='border-color:#9ca3af;"
+            "background:#f5f5f4;padding:0.75rem 1rem;margin:0.5rem 0'>"
+            f"<p class='muted small' style='margin:0'>{reason}</p>"
+            "</div>"
+        )
+        return _layout(title, body, requested_pack=requested_pack)
+
+    # State-explanation banner so the operator knows what set of
+    # items this page lists.  Mirrors the per-state vocabulary the
+    # M25 cards expose.
+    state_explainer = {
+        "Received": (
+            "Items where evidence shows intake but no extraction yet."
+        ),
+        "Extracted": (
+            "Items where the interpreter / absorber ran, producing"
+            " candidates waiting for promotion."
+        ),
+        "Accepted": (
+            "Items that have a canonical artifact in the vault."
+        ),
+        "Synthesized": (
+            "Items in clusters with a fresh community crystal."
+        ),
+        "NeedsAction": (
+            "Items blocked or waiting on operator action — failures,"
+            " open contradictions, or stale review queues."
+        ),
+    }.get(state, "")
+
+    head = [
+        f"<h1>{escape(title)}</h1>",
+    ]
+    if state_explainer:
+        head.append(
+            f"<p class='muted'>{escape(state_explainer)}</p>"
+        )
+    head.append(
+        f"<p class='muted small'>"
+        f"{total} item{'s' if total != 1 else ''} in this state · "
+        f"showing {len(rows)} starting at offset {offset}"
+        f"</p>"
+    )
+
+    if not rows:
+        head.append(honest_zero_html(short=True))
+        return _layout(
+            title, "".join(head), requested_pack=requested_pack
+        )
+
+    # Table.
+    thead = (
+        "<thead><tr>"
+        "<th>Item</th><th>Kind</th><th>Sub-state</th>"
+        "<th>Last evidence</th><th>Recent evidence types</th>"
+        "</tr></thead>"
+    )
+
+    body_rows: list[str] = []
+    for item in rows:
+        item_id = str(item.get("item_id") or "")
+        kind = str(item.get("item_kind") or "")
+        sub = str(item.get("sub_state") or "")
+        last_ts = str(item.get("last_evidence_at") or "")
+        evt_types = item.get("evidence_types") or []
+        href = str(item.get("primary_href") or "")
+        na_reason = str(item.get("needs_action_reason") or "")
+
+        if href:
+            id_cell = (
+                f"<a href='{escape(href)}'>{escape(item_id)}</a>"
+            )
+        else:
+            id_cell = escape(item_id)
+        if na_reason:
+            id_cell += (
+                f"<div class='muted tiny'>"
+                f"Needs action: {escape(na_reason)}</div>"
+            )
+
+        sub_cell = (
+            f"<span class='pill muted'>{escape(sub)}</span>"
+            if sub
+            else "<span class='muted'>—</span>"
+        )
+        evt_cell = (
+            "<span class='muted'>—</span>" if not evt_types else
+            " ".join(
+                f"<span class='pill'>{escape(str(e))}</span>"
+                for e in evt_types
+            )
+        )
+        body_rows.append(
+            "<tr>"
+            f"<td>{id_cell}</td>"
+            f"<td><span class='muted small'>{escape(kind)}</span></td>"
+            f"<td>{sub_cell}</td>"
+            f"<td><span class='muted small mono'>{escape(last_ts) or '—'}</span></td>"
+            f"<td>{evt_cell}</td>"
+            "</tr>"
+        )
+
+    table_html = (
+        "<table class='table' style='margin-top:0.6rem'>"
+        + thead
+        + "<tbody>" + "".join(body_rows) + "</tbody>"
+        + "</table>"
+    )
+
+    # Pagination footer.
+    pack_qs = (
+        f"&pack={quote(requested_pack, safe='')}" if requested_pack else ""
+    )
+
+    def _page_link(offset_value: int, label: str) -> str:
+        return (
+            f"<a href='/ops/items?state={quote(state, safe='')}"
+            f"&offset={offset_value}&limit={limit}{pack_qs}'>"
+            f"{escape(label)}</a>"
+        )
+
+    prev_offset = payload.get("prev_offset")
+    next_offset = payload.get("next_offset")
+    pager_parts: list[str] = []
+    if prev_offset is not None:
+        pager_parts.append(_page_link(int(prev_offset), "← Previous"))
+    if next_offset is not None:
+        pager_parts.append(_page_link(int(next_offset), "Next →"))
+    pager_html = (
+        f"<p style='margin-top:0.8rem'>{' · '.join(pager_parts)}</p>"
+        if pager_parts
+        else ""
+    )
+
+    body = "".join(head) + table_html + pager_html
+    return _layout(title, body, requested_pack=requested_pack)
+
+
 # Runs index table rules now live in /static/ovp-pages.css.
 _RUNS_INDEX_STYLE = ""
 

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -46,6 +46,7 @@ from ..ui.view_models import (
     build_stale_summary_browser_payload,
     build_timeline_payload,
     build_today_digest_payload,
+    build_items_list_payload,
     build_runs_index_payload,
     build_run_detail_payload,
     build_topic_overview_payload,
@@ -104,6 +105,7 @@ from ._ui_renderers import (  # noqa: F401 — all renderers
     _render_queue_overview_page,
     _render_timeline_page,
     _render_today_digest_page,
+    _render_items_list_page,
     _render_runs_index_page,
     _render_run_detail_page,
     _render_reuse_report_fragment,
@@ -1235,6 +1237,34 @@ def create_server(
                         self._write_json(payload)
                     else:
                         self._write_html(_render_today_digest_page(payload))
+                    return
+                # M25.2: /ops/items?state=<state>[&offset=…&limit=…]
+                # is the lifecycle drilldown M25 cards target.
+                # ``date=`` is intentionally NOT a filter — the
+                # primary card number is "all current items", not
+                # date-windowed (see M25 plan §M25.2/3).
+                if path in ("/ops/items", "/api/items"):
+                    pack_name = query.get("pack", [""])[0] or None
+                    state = query.get("state", [""])[0] or ""
+                    raw_offset = query.get("offset", ["0"])[0]
+                    raw_limit = query.get("limit", [""])[0]
+                    offset = int(raw_offset) if raw_offset.isdigit() else 0
+                    limit = (
+                        int(raw_limit)
+                        if raw_limit.isdigit() and int(raw_limit) > 0
+                        else 50
+                    )
+                    payload = build_items_list_payload(
+                        resolved_vault,
+                        state=state,
+                        pack_name=pack_name,
+                        offset=offset,
+                        limit=limit,
+                    )
+                    if path == "/api/items":
+                        self._write_json(payload)
+                    else:
+                        self._write_html(_render_items_list_page(payload))
                     return
                 # BL-053: by-run "runs" index
                 if path in ("/ops/runs", "/api/runs"):

--- a/src/ovp_pipeline/ui/view_models.py
+++ b/src/ovp_pipeline/ui/view_models.py
@@ -3434,6 +3434,197 @@ def _read_lifecycle_summary(
     }
 
 
+# M25.2: /ops/items default page size.  Cards drill into this view
+# carrying state= and optional pack=; the page paginates the rest.
+ITEMS_LIST_DEFAULT_LIMIT = 50
+ITEMS_LIST_MAX_LIMIT = 500
+
+
+def build_items_list_payload(
+    vault_dir: Path | str,
+    *,
+    state: str,
+    pack_name: str | None = None,
+    offset: int = 0,
+    limit: int = ITEMS_LIST_DEFAULT_LIMIT,
+) -> dict[str, Any]:
+    """M25.2: ``/ops/items?state=<state>`` payload.
+
+    Reads ``ops_state`` (built by M24.1's ``ovp-ops-state``) and
+    returns the items currently in ``state``.  This is the route
+    the M25 hybrid card primary CTA targets, so card N === page N
+    is a hard contract: both numbers come from the same projection
+    table with the same pack filter.
+
+    No ``date=`` filter — the primary card number is "all current
+    items in this state", not date-windowed.  The plan doc locks
+    this in §M25.2 / M25.3 acceptance.
+    """
+    from ..ops_lifecycle import ALL_STATES
+
+    requested_pack = pack_name or ""
+    state = state.strip()
+    if state not in ALL_STATES:
+        return {
+            "screen": "ops/items",
+            "available": False,
+            "reason": (
+                f"unknown state {state!r}; expected one of "
+                f"{ALL_STATES}"
+            ),
+            "state": state,
+            "requested_pack": requested_pack,
+            "rows": [],
+            "total": 0,
+            "offset": offset,
+            "limit": limit,
+        }
+
+    safe_limit = max(1, min(int(limit or ITEMS_LIST_DEFAULT_LIMIT), ITEMS_LIST_MAX_LIMIT))
+    safe_offset = max(0, int(offset or 0))
+
+    db_path = _db_path(vault_dir)
+    if not db_path.exists():
+        return {
+            "screen": "ops/items",
+            "available": False,
+            "reason": "knowledge_index has not been built yet",
+            "state": state,
+            "requested_pack": requested_pack,
+            "rows": [],
+            "total": 0,
+            "offset": safe_offset,
+            "limit": safe_limit,
+        }
+
+    effective_pack = requested_pack or PRIMARY_PACK_NAME
+    try:
+        with sqlite3.connect(db_path) as conn:
+            # Guard: ops_state may not exist yet (M24.1 DAG step
+            # hasn't run).  Surface explicitly rather than crash.
+            row = conn.execute(
+                "SELECT 1 FROM sqlite_master "
+                "WHERE type='table' AND name='ops_state'"
+            ).fetchone()
+            if row is None:
+                return {
+                    "screen": "ops/items",
+                    "available": False,
+                    "reason": (
+                        "ops_state projection not built yet — run "
+                        "`ovp-ops-state --rebuild`"
+                    ),
+                    "state": state,
+                    "requested_pack": requested_pack,
+                    "rows": [],
+                    "total": 0,
+                    "offset": safe_offset,
+                    "limit": safe_limit,
+                }
+
+            total_row = conn.execute(
+                "SELECT COUNT(*) FROM ops_state "
+                " WHERE pack = ? AND state = ?",
+                (effective_pack, state),
+            ).fetchone()
+            total = int(total_row[0] or 0) if total_row else 0
+
+            # M25.2: NeedsAction surfaces oldest-first so the
+            # operator can attack the most-aged blockers first.
+            # Every other state surfaces newest-first.
+            order_dir = (
+                "ASC" if state == "NeedsAction" else "DESC"
+            )
+            rows = conn.execute(
+                f"""
+                SELECT item_kind, item_id, sub_state,
+                       last_evidence_at, evidence_event_types_json,
+                       needs_action_reason
+                  FROM ops_state
+                 WHERE pack = ? AND state = ?
+                 ORDER BY last_evidence_at {order_dir}
+                 LIMIT ? OFFSET ?
+                """,
+                (effective_pack, state, safe_limit, safe_offset),
+            ).fetchall()
+    except sqlite3.OperationalError as exc:
+        return {
+            "screen": "ops/items",
+            "available": False,
+            "reason": f"ops_state read failed: {exc}",
+            "state": state,
+            "requested_pack": requested_pack,
+            "rows": [],
+            "total": 0,
+            "offset": safe_offset,
+            "limit": safe_limit,
+        }
+
+    items: list[dict[str, Any]] = []
+    for kind, item_id, sub_state, last_evidence_at, evt_json, na_reason in rows:
+        try:
+            evt_types = json.loads(evt_json) if evt_json else []
+        except (TypeError, ValueError):
+            evt_types = []
+        # Top-3 evidence types for the row preview; rest are
+        # available on the item's drilldown (out of scope for v1).
+        evt_preview = list(evt_types)[:3] if isinstance(evt_types, list) else []
+        items.append({
+            "item_kind": str(kind or ""),
+            "item_id": str(item_id or ""),
+            "sub_state": str(sub_state) if sub_state else "",
+            "last_evidence_at": str(last_evidence_at or ""),
+            "evidence_types": evt_preview,
+            "needs_action_reason": str(na_reason) if na_reason else "",
+            "primary_href": _items_primary_href(kind, item_id, effective_pack),
+        })
+
+    has_more = safe_offset + len(items) < total
+    next_offset = safe_offset + safe_limit if has_more else None
+    prev_offset = max(0, safe_offset - safe_limit) if safe_offset > 0 else None
+
+    return {
+        "screen": "ops/items",
+        "available": True,
+        "state": state,
+        "pack": effective_pack,
+        "requested_pack": requested_pack,
+        "rows": items,
+        "total": total,
+        "offset": safe_offset,
+        "limit": safe_limit,
+        "next_offset": next_offset,
+        "prev_offset": prev_offset,
+    }
+
+
+def _items_primary_href(item_kind: str | None, item_id: str | None, pack: str) -> str:
+    """Map (kind, id) → the canonical drilldown URL.
+
+    * ``source``  → ``/note?path=…`` is impossible without a path;
+      fall back to ``/ops/events/audit?slug=…`` (raw audit row
+      view) so the operator can at least see the evidence trail.
+      M25.4 builds the audit-evidence view.
+    * ``object``  → ``/object?id=…``  (existing route).
+    * ``cluster`` → ``/ops/cluster?id=…`` (existing route).
+    """
+    if not item_id:
+        return ""
+    kind = (item_kind or "").lower()
+    pack_qs = f"&pack={quote(pack, safe='')}" if pack else ""
+    if kind == "object":
+        return f"/object?id={quote(str(item_id), safe='')}{pack_qs}"
+    if kind == "cluster":
+        return f"/ops/cluster?id={quote(str(item_id), safe='')}{pack_qs}"
+    # source — point at the future raw-audit view; M25.4 will
+    # build it.  Until then this 404s, which is honest about the
+    # gap.
+    return (
+        f"/ops/events/audit?slug={quote(str(item_id), safe='')}"
+        + pack_qs
+    )
+
+
 def build_digest_health_payload(vault_dir: Path | str) -> dict[str, Any]:
     """``/ops/digest-health`` payload — three metric panels (M23 / BL-097).
 

--- a/src/ovp_pipeline/ui/view_models.py
+++ b/src/ovp_pipeline/ui/view_models.py
@@ -3547,6 +3547,35 @@ def build_items_list_payload(
                 """,
                 (effective_pack, state, safe_limit, safe_offset),
             ).fetchall()
+
+            # M25.2 (codex review on PR #236): source-kind items
+            # don't have a known canonical drilldown route yet
+            # (the M25.4 ``/ops/events/audit`` view doesn't exist
+            # until that PR lands).  Resolve source slugs to their
+            # real file paths via ``pages_index`` so the primary
+            # link points at ``/note?path=…`` — a route that
+            # exists.  Sources we can't resolve fall through to an
+            # unlinked cell.
+            source_slugs = [
+                str(r[1]) for r in rows
+                if r and r[0] == "source" and r[1]
+            ]
+            slug_to_path: dict[str, str] = {}
+            if source_slugs:
+                page_row = conn.execute(
+                    "SELECT 1 FROM sqlite_master "
+                    "WHERE type='table' AND name='pages_index'"
+                ).fetchone()
+                if page_row is not None:
+                    placeholders = ",".join("?" * len(source_slugs))
+                    page_rows = conn.execute(
+                        f"SELECT slug, path FROM pages_index "
+                        f" WHERE slug IN ({placeholders})",
+                        source_slugs,
+                    ).fetchall()
+                    slug_to_path = {
+                        str(s): str(p) for s, p in page_rows if s and p
+                    }
     except sqlite3.OperationalError as exc:
         return {
             "screen": "ops/items",
@@ -3569,14 +3598,22 @@ def build_items_list_payload(
         # Top-3 evidence types for the row preview; rest are
         # available on the item's drilldown (out of scope for v1).
         evt_preview = list(evt_types)[:3] if isinstance(evt_types, list) else []
+        kind_str = str(kind or "")
+        item_id_str = str(item_id or "")
+        resolved_source_path = (
+            slug_to_path.get(item_id_str) if kind_str == "source" else ""
+        )
         items.append({
-            "item_kind": str(kind or ""),
-            "item_id": str(item_id or ""),
+            "item_kind": kind_str,
+            "item_id": item_id_str,
             "sub_state": str(sub_state) if sub_state else "",
             "last_evidence_at": str(last_evidence_at or ""),
             "evidence_types": evt_preview,
             "needs_action_reason": str(na_reason) if na_reason else "",
-            "primary_href": _items_primary_href(kind, item_id, effective_pack),
+            "primary_href": _items_primary_href(
+                kind_str, item_id_str, effective_pack,
+                source_path=resolved_source_path,
+            ),
         })
 
     has_more = safe_offset + len(items) < total
@@ -3598,13 +3635,21 @@ def build_items_list_payload(
     }
 
 
-def _items_primary_href(item_kind: str | None, item_id: str | None, pack: str) -> str:
+def _items_primary_href(
+    item_kind: str | None,
+    item_id: str | None,
+    pack: str,
+    *,
+    source_path: str = "",
+) -> str:
     """Map (kind, id) → the canonical drilldown URL.
 
-    * ``source``  → ``/note?path=…`` is impossible without a path;
-      fall back to ``/ops/events/audit?slug=…`` (raw audit row
-      view) so the operator can at least see the evidence trail.
-      M25.4 builds the audit-evidence view.
+    * ``source``  → ``/note?path=<vault-relative-path>`` when the
+      caller resolved the path via ``pages_index``; otherwise
+      empty string (renderer falls back to a plain non-link cell).
+      We DON'T link to the future M25.4 ``/ops/events/audit``
+      route because that doesn't exist yet — clicking would 404
+      (codex review on PR #236 flagged this).
     * ``object``  → ``/object?id=…``  (existing route).
     * ``cluster`` → ``/ops/cluster?id=…`` (existing route).
     """
@@ -3616,13 +3661,12 @@ def _items_primary_href(item_kind: str | None, item_id: str | None, pack: str) -
         return f"/object?id={quote(str(item_id), safe='')}{pack_qs}"
     if kind == "cluster":
         return f"/ops/cluster?id={quote(str(item_id), safe='')}{pack_qs}"
-    # source — point at the future raw-audit view; M25.4 will
-    # build it.  Until then this 404s, which is honest about the
-    # gap.
-    return (
-        f"/ops/events/audit?slug={quote(str(item_id), safe='')}"
-        + pack_qs
-    )
+    if kind == "source" and source_path:
+        return f"/note?path={quote(str(source_path), safe='')}"
+    # No known drilldown — return empty so the renderer surfaces
+    # the item as plain text rather than a broken link.  M25.4
+    # adds the raw-audit-evidence view that will pick this up.
+    return ""
 
 
 def build_digest_health_payload(vault_dir: Path | str) -> dict[str, Any]:

--- a/tests/test_ops_items.py
+++ b/tests/test_ops_items.py
@@ -322,3 +322,50 @@ def test_row_carries_evidence_event_types(tmp_path):
     )
     row = payload["rows"][0]
     assert "article_intake_only" in row["evidence_types"]
+
+
+def test_source_row_with_no_pages_index_has_empty_href(tmp_path):
+    """Source items WITHOUT a matching ``pages_index`` row must
+    fall back to no link rather than pointing at the unbuilt
+    M25.4 audit route — clicking that would 404.  Regression
+    guard for the codex P2 on PR #236."""
+    db_path = _make_db(tmp_path)
+    _seed(db_path, received=1)
+    payload = build_items_list_payload(
+        tmp_path, state="Received", pack_name=PACK
+    )
+    row = payload["rows"][0]
+    assert row["item_kind"] == "source"
+    assert row["primary_href"] == "", (
+        "source rows without a resolved path must render unlinked"
+    )
+
+
+def test_source_row_with_pages_index_links_to_note_route(tmp_path):
+    """When ``pages_index`` has the slug, the primary href points at
+    the existing ``/note?path=…`` route."""
+    db_path = _make_db(tmp_path)
+    _seed(db_path, received=1)
+    # Seed pages_index manually with a matching slug.
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE pages_index (slug TEXT PRIMARY KEY, "
+        "title TEXT NOT NULL, note_type TEXT NOT NULL, "
+        "path TEXT NOT NULL, day_id TEXT NOT NULL, "
+        "frontmatter_json TEXT NOT NULL, body TEXT NOT NULL)"
+    )
+    conn.execute(
+        "INSERT INTO pages_index VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("src-r-000", "Test", "interpretation",
+         "20-Areas/AI-Research/foo.md", "2026-05-13", "{}", ""),
+    )
+    conn.commit()
+    conn.close()
+    payload = build_items_list_payload(
+        tmp_path, state="Received", pack_name=PACK
+    )
+    src_row = next(
+        r for r in payload["rows"] if r["item_id"] == "src-r-000"
+    )
+    assert src_row["primary_href"].startswith("/note?path=")
+    assert "foo.md" in src_row["primary_href"]

--- a/tests/test_ops_items.py
+++ b/tests/test_ops_items.py
@@ -1,0 +1,324 @@
+"""Tests for the M25.2 ``/ops/items`` route.
+
+The view this PR builds is the drilldown the M25 hybrid card primary
+CTAs target.  The hard contract is **card N === page N**: both the
+card primary count and the items list read from the same
+``ops_state`` table with the same pack filter, so the operator
+clicking ``Open 47 items →`` lands on exactly 47 rows.
+
+These tests lock the contract:
+
+* Unknown state → explicit "unavailable" + readable reason.
+* Missing ``ops_state`` table → explicit reason, no crash.
+* State filter works.
+* Pagination metadata (offset / limit / next / prev) is correct.
+* Sort direction inverts for NeedsAction (oldest-first; M25 plan
+  open issue locked in).
+* No ``date=`` filter — primary cards count "current" items and a
+  date filter would break the card-N === page-N contract.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from ovp_pipeline.ops_lifecycle import (
+    ALL_STATES,
+    STATE_ACCEPTED,
+    STATE_NEEDS_ACTION,
+    STATE_RECEIVED,
+)
+from ovp_pipeline.ops_state import rebuild
+from ovp_pipeline.ui.view_models import (
+    ITEMS_LIST_DEFAULT_LIMIT,
+    ITEMS_LIST_MAX_LIMIT,
+    build_items_list_payload,
+)
+
+
+PACK = "research-tech"
+
+
+_AUDIT_SCHEMA = """
+CREATE TABLE audit_events (
+    source_log TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    slug TEXT NOT NULL DEFAULT '',
+    session_id TEXT NOT NULL DEFAULT '',
+    timestamp TEXT NOT NULL DEFAULT '',
+    payload_json TEXT NOT NULL
+);
+"""
+
+
+def _make_db(tmp_path: Path) -> Path:
+    db_path = tmp_path / "60-Logs" / "knowledge.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.executescript(_AUDIT_SCHEMA)
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def _seed(db_path: Path, *, received: int = 0, failures: int = 0) -> None:
+    """Seed ``received`` Received sources + ``failures`` NeedsAction
+    sources, then rebuild the projection."""
+    base = datetime(2026, 5, 13, 8, 0, tzinfo=timezone.utc)
+    conn = sqlite3.connect(db_path)
+    for i in range(received):
+        ts = (base.replace(minute=i % 60)).isoformat()
+        conn.execute(
+            "INSERT INTO audit_events VALUES (?, ?, ?, ?, ?, ?)",
+            ("pipeline.jsonl", "article_intake_only",
+             f"src-r-{i:03d}", "sess", ts, "{}"),
+        )
+    for j in range(failures):
+        ts = (base.replace(minute=(j + 30) % 60)).isoformat()
+        conn.execute(
+            "INSERT INTO audit_events VALUES (?, ?, ?, ?, ?, ?)",
+            ("pipeline.jsonl", "absorb_parse_error",
+             f"src-f-{j:03d}", "sess", ts, "{}"),
+        )
+    conn.commit()
+    rebuild(conn, pack=PACK)
+    conn.close()
+
+
+# ── Unavailable / error paths ─────────────────────────────────────
+
+
+def test_unknown_state_returns_unavailable_reason(tmp_path):
+    payload = build_items_list_payload(
+        tmp_path, state="GarbageState", pack_name=PACK
+    )
+    assert payload["available"] is False
+    assert "unknown state" in payload["reason"]
+    assert payload["rows"] == []
+
+
+def test_missing_db_returns_unavailable_reason(tmp_path):
+    payload = build_items_list_payload(
+        tmp_path, state="Received", pack_name=PACK
+    )
+    assert payload["available"] is False
+    assert "knowledge_index" in payload["reason"]
+
+
+def test_missing_projection_table_returns_unavailable_reason(tmp_path):
+    _make_db(tmp_path)  # audit_events only — no ops_state
+    payload = build_items_list_payload(
+        tmp_path, state="Received", pack_name=PACK
+    )
+    assert payload["available"] is False
+    assert "ops_state" in payload["reason"]
+
+
+# ── Happy path + contract ─────────────────────────────────────────
+
+
+def test_returns_rows_for_state(tmp_path):
+    db_path = _make_db(tmp_path)
+    _seed(db_path, received=3)
+    payload = build_items_list_payload(
+        tmp_path, state="Received", pack_name=PACK
+    )
+    assert payload["available"] is True
+    assert payload["state"] == "Received"
+    assert payload["total"] == 3
+    assert len(payload["rows"]) == 3
+    for row in payload["rows"]:
+        assert row["item_kind"] == "source"
+        assert row["item_id"].startswith("src-r-")
+
+
+def test_card_count_equals_page_count_contract(tmp_path):
+    """The M25 hybrid card promises ``Open N items →`` lands on
+    exactly N rows.  The audit projection must agree with what the
+    cards report — same table, same pack filter."""
+    from ovp_pipeline.ui.view_models import _read_lifecycle_summary
+
+    db_path = _make_db(tmp_path)
+    _seed(db_path, received=4, failures=2)
+
+    summary = _read_lifecycle_summary(tmp_path, pack=PACK)
+    received_card_count = summary["counts"]["Received"]
+
+    payload = build_items_list_payload(
+        tmp_path, state="Received", pack_name=PACK,
+        limit=ITEMS_LIST_MAX_LIMIT,
+    )
+    assert payload["total"] == received_card_count
+
+
+def test_state_filter_isolates_rows(tmp_path):
+    db_path = _make_db(tmp_path)
+    _seed(db_path, received=2, failures=3)
+    received = build_items_list_payload(
+        tmp_path, state="Received", pack_name=PACK
+    )
+    failures = build_items_list_payload(
+        tmp_path, state="NeedsAction", pack_name=PACK
+    )
+    received_ids = {r["item_id"] for r in received["rows"]}
+    failure_ids = {r["item_id"] for r in failures["rows"]}
+    assert not received_ids & failure_ids
+    assert received["total"] == 2
+    assert failures["total"] == 3
+
+
+def test_unfamiliar_pack_returns_empty_but_available(tmp_path):
+    db_path = _make_db(tmp_path)
+    _seed(db_path, received=2)
+    payload = build_items_list_payload(
+        tmp_path, state="Received", pack_name="some-other-pack"
+    )
+    assert payload["available"] is True
+    assert payload["total"] == 0
+    assert payload["rows"] == []
+
+
+# ── Pagination ────────────────────────────────────────────────────
+
+
+def test_pagination_offset_limit(tmp_path):
+    db_path = _make_db(tmp_path)
+    _seed(db_path, received=10)
+    page1 = build_items_list_payload(
+        tmp_path, state="Received", pack_name=PACK,
+        offset=0, limit=4,
+    )
+    page2 = build_items_list_payload(
+        tmp_path, state="Received", pack_name=PACK,
+        offset=4, limit=4,
+    )
+    page3 = build_items_list_payload(
+        tmp_path, state="Received", pack_name=PACK,
+        offset=8, limit=4,
+    )
+    assert page1["total"] == 10
+    assert len(page1["rows"]) == 4
+    assert len(page2["rows"]) == 4
+    assert len(page3["rows"]) == 2  # only 2 left
+    assert page1["next_offset"] == 4
+    assert page2["next_offset"] == 8
+    assert page3["next_offset"] is None  # final page
+
+    # All rows distinct across pages.
+    all_ids = (
+        [r["item_id"] for r in page1["rows"]]
+        + [r["item_id"] for r in page2["rows"]]
+        + [r["item_id"] for r in page3["rows"]]
+    )
+    assert len(all_ids) == len(set(all_ids))
+
+
+def test_prev_offset_set_when_paginated(tmp_path):
+    db_path = _make_db(tmp_path)
+    _seed(db_path, received=8)
+    middle = build_items_list_payload(
+        tmp_path, state="Received", pack_name=PACK,
+        offset=4, limit=2,
+    )
+    assert middle["prev_offset"] == 2
+    assert middle["next_offset"] == 6
+
+
+def test_limit_clamped_to_max(tmp_path):
+    db_path = _make_db(tmp_path)
+    _seed(db_path, received=1)
+    payload = build_items_list_payload(
+        tmp_path, state="Received", pack_name=PACK,
+        limit=ITEMS_LIST_MAX_LIMIT * 10,
+    )
+    assert payload["limit"] == ITEMS_LIST_MAX_LIMIT
+
+
+def test_invalid_limit_falls_back_to_default(tmp_path):
+    """``limit=0`` is treated as "not provided" — falls back to the
+    default rather than rendering an empty page."""
+    db_path = _make_db(tmp_path)
+    _seed(db_path, received=1)
+    payload = build_items_list_payload(
+        tmp_path, state="Received", pack_name=PACK,
+        limit=0,
+    )
+    assert payload["limit"] == ITEMS_LIST_DEFAULT_LIMIT
+
+
+# ── Sort direction ────────────────────────────────────────────────
+
+
+def test_needs_action_sorts_oldest_first(tmp_path):
+    """NeedsAction surfaces oldest-blocker-first per the M25 plan
+    open issue — operator wants to attack stale blockers first."""
+    db_path = _make_db(tmp_path)
+    _seed(db_path, failures=4)
+    payload = build_items_list_payload(
+        tmp_path, state="NeedsAction", pack_name=PACK
+    )
+    timestamps = [r["last_evidence_at"] for r in payload["rows"]]
+    assert timestamps == sorted(timestamps), (
+        "NeedsAction rows must be ASC-sorted (oldest first)"
+    )
+
+
+def test_received_sorts_newest_first(tmp_path):
+    db_path = _make_db(tmp_path)
+    _seed(db_path, received=4)
+    payload = build_items_list_payload(
+        tmp_path, state="Received", pack_name=PACK
+    )
+    timestamps = [r["last_evidence_at"] for r in payload["rows"]]
+    assert timestamps == sorted(timestamps, reverse=True), (
+        "Received rows must be DESC-sorted (newest first)"
+    )
+
+
+# ── Row shape ─────────────────────────────────────────────────────
+
+
+def test_row_carries_primary_href_for_object(tmp_path):
+    """The renderer needs a clickable target; ``primary_href`` is
+    that.  Object-kind items must point at ``/object?id=…``."""
+    db_path = _make_db(tmp_path)
+    # Insert a fake object row + matching ops_state row directly.
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE objects (pack TEXT, object_id TEXT, "
+        "object_kind TEXT, title TEXT, canonical_path TEXT, "
+        "source_slug TEXT, source_url TEXT DEFAULT '', "
+        "PRIMARY KEY (pack, object_id))"
+    )
+    conn.execute(
+        "INSERT INTO objects VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (PACK, "obj-x", "evergreen", "Foo",
+         "10-Knowledge/Evergreen/Foo.md", "src-x", ""),
+    )
+    conn.commit()
+    rebuild(conn, pack=PACK)
+    conn.close()
+    payload = build_items_list_payload(
+        tmp_path, state="Accepted", pack_name=PACK
+    )
+    obj_row = next(
+        (r for r in payload["rows"] if r["item_kind"] == "object"),
+        None,
+    )
+    assert obj_row is not None, "expected an object row in Accepted"
+    assert obj_row["primary_href"].startswith("/object?id=obj-x")
+
+
+def test_row_carries_evidence_event_types(tmp_path):
+    db_path = _make_db(tmp_path)
+    _seed(db_path, received=1)
+    payload = build_items_list_payload(
+        tmp_path, state="Received", pack_name=PACK
+    )
+    row = payload["rows"][0]
+    assert "article_intake_only" in row["evidence_types"]


### PR DESCRIPTION
## Summary

M25.2 builds the drilldown the M25 hybrid card primary CTAs target. Without it the cards landing in M25.3 have nowhere to go.

**What ships:**
- `build_items_list_payload` reading `ops_state` filtered by state + pack, returning paginated rows.
- `_render_items_list_page` table view with state-explainer banner, per-state vocabulary, pagination, honest-zero footer.
- `/ops/items?state=…[&offset=…&limit=…]` + `/api/items` JSON variant.

**Contract locks (per M25 plan §M25.2):**
- **No date param.** Primary card number is "all current items", not date-windowed. Drilldown must match the card count.
- **NeedsAction sorts oldest-first.** Operator wants to attack stale blockers first.
- **Honest-zero everywhere.** Missing DB / missing projection / unknown state each surface an explicit reason.

15 new tests cover: unknown state, missing DB, missing projection, state-filter isolation, the card-N === page-N contract, pack scoping, pagination, sort-direction invariants, row shape.

Read-only in v1. No inline promote/synthesize actions yet.

## Test plan

- [x] pytest tests/test_ops_items.py — 15/15 pass.
- [x] Full suite — 2900 passed, 0 regressions.
- [ ] Manual: run `ovp-ui` against operator vault; hit `/ops/items?state=Received`; confirm rows render; click an item; confirm primary_href routing.

Refs `docs/plans/2026-05-14-m25-maintainer-control-plane.md` §M25.2.