### PR TITLE
feat(m25.3): /ops/today hybrid cards on lifecycle vocabulary

### DIFF
--- a/src/ovp_pipeline/commands/_ui_renderers.py
+++ b/src/ovp_pipeline/commands/_ui_renderers.py
@@ -6664,11 +6664,21 @@ _TODAY_DIGEST_STYLE = ""
 
 
 def _render_today_digest_page(payload: dict) -> str:
-    """5-card today digest — the maintainer's "what happened today" view.
+    """M25.3: hybrid lifecycle cards for ``/ops/today``.
 
-    Replaces the old "open ``/ops`` and squint at recent activity"
-    workflow with five explicit cards (one per pipeline macro-stage)
-    that summarise *today's* audit events.
+    Five cards keyed on the lifecycle vocabulary (Received,
+    Extracted, Accepted, Synthesized, Needs Action).  Each card
+    shows TWO numbers per the M25 plan §M25.3 contract:
+
+    * Primary: current items in this state (from ``ops_state``).
+    * Secondary: today's evidence events (from ``audit_events``).
+
+    Primary CTA → ``/ops/items?state=…`` (no date param).
+    Secondary CTA → ``/ops/events?event_types=…&date=…``.
+
+    The two numbers are intentionally rendered as parallel rows,
+    not stacked or summed.  No "+N today" framing — the plan
+    forbids it because the sets aren't additive.
     """
     requested_pack = str(payload.get("requested_pack") or "")
     date = str(payload.get("date") or "")
@@ -6680,7 +6690,9 @@ def _render_today_digest_page(payload: dict) -> str:
             "<h2>Today digest unavailable</h2>"
             f"<p class='muted'>{escape(str(payload.get('reason') or 'unknown'))}</p>"
             "<p>Run <code>ovp-knowledge-index</code> to populate "
-            "<code>audit_events</code>.</p>"
+            "<code>audit_events</code> then <code>ovp-ops-state "
+            "--rebuild</code> to materialise the lifecycle "
+            "projection.</p>"
             "</section>"
         )
         return _layout(f"Today — {date}", body, requested_pack=requested_pack)
@@ -6690,19 +6702,21 @@ def _render_today_digest_page(payload: dict) -> str:
         _render_page_help(
             "Today digest",
             what=(
-                "Five-card summary of what the pipeline did today (UTC),"
-                " grouped by macro-stage: intake, absorb, synthesis,"
-                " governance, failures.  Counts come from"
-                " <code>audit_events</code>."
+                "Five lifecycle cards (Received, Extracted, Accepted,"
+                " Synthesized, Needs Action).  Each card shows the"
+                " current item count plus today's evidence activity."
+                "  Primary number reads <code>ops_state</code>;"
+                " secondary number reads <code>audit_events</code>."
             ),
             can=(
-                "Click <strong>See all N →</strong> on any card to drop"
-                " into <strong>/ops/events</strong> filtered to that day."
-                "  Use the prev/next pivots to step through history."
+                "Click the <strong>Open N items →</strong> link to drill"
+                " into all current items in that state.  Click the"
+                " <strong>View today's N events →</strong> link to drop"
+                " into the audit ledger filtered to today."
             ),
             effect=(
-                "All links read from the audit ledger.  This page mutates"
-                " nothing — it's a window onto the pipeline's day."
+                "Read-only.  Drilldowns navigate to /ops/items"
+                " (lifecycle) and /ops/events (forensic)."
             ),
         )
     )
@@ -6718,68 +6732,78 @@ def _render_today_digest_page(payload: dict) -> str:
         pivot_parts.append(f"<a href='{escape(next_path)}'>{escape(next_date)} →</a>")
     sections.append(f"<p class='muted'>{' · '.join(pivot_parts)}</p>")
     sections.append(
-        f"<p class='muted'>Audit events recorded on "
-        f"<strong>{escape(date)}</strong> (UTC).  Click "
-        f"<a href='/ops/timeline'>Timeline</a> for the multi-day view.</p>"
+        f"<p class='muted'>Lifecycle state — current backlog · today's"
+        f" activity recorded on <strong>{escape(date)}</strong> (UTC)."
+        f"  Click <a href='/ops/timeline'>Timeline</a> for the"
+        f" multi-day evidence view.</p>"
     )
-    # M23 BL-096: explicit "Regenerate digest now" affordance so an
-    # operator who drops articles mid-day can immediately trigger a
-    # new digest.  Input-hash gate (BL-095) keeps the cost bounded —
-    # unchanged inputs return the same body without an LLM call.
-    #
-    # M23.1: pass the page's ``date`` through so a past-date dispatch
-    # writes to the right ``YYYY-MM-DD-digest-daily.md`` file rather
-    # than UTC-today.
+
+    # M24.3 honest-zero applies to the projection itself: when
+    # ``ops_state`` doesn't exist yet (DAG step hasn't run), every
+    # card's primary number would be 0 — surface that explicitly so
+    # the operator doesn't read it as "no backlog".
+    lifecycle = payload.get("lifecycle_summary") or {}
+    if not lifecycle.get("available") and lifecycle.get("reason"):
+        sections.append(
+            "<div class='card' style='border-color:#c2410c;"
+            "background:#fef3e8;padding:0.75rem 1rem;margin:0.5rem 0'>"
+            "<strong>Lifecycle projection unavailable.</strong> "
+            f"<p class='muted small' style='margin:0.3rem 0 0'>"
+            f"{escape(str(lifecycle['reason']))}.  Card primary "
+            "numbers below will be 0 until this lands.</p>"
+            "</div>"
+        )
+
+    # M23 BL-096 regenerate-digest button stays.
     sections.append(
         _render_digest_regenerate_button(requested_pack, date=date)
     )
+
     sections.append("<div class='grid stats' style='margin-top:1rem'>")
     for card in cards:
         card_id = str(card.get("id") or "")
         label = str(card.get("label") or card_id)
-        total = int(card.get("total") or 0)
-        by_type = card.get("by_type") or {}
+        explainer = str(card.get("explainer") or "")
+        primary_count = int(card.get("primary_count") or 0)
+        event_count = int(card.get("event_count") or 0)
+        event_label = str(card.get("event_label") or "")
+        primary_href = str(card.get("primary_href") or "")
+        event_href = str(card.get("event_href") or "")
         samples = card.get("samples") or []
-        see_all_path = str(card.get("see_all_path") or "")
 
-        # Failures get the warn-tinted big number; empty totals fade to
-        # border-strong so they read as "nothing today" without
-        # distracting from cards that DO have activity.
-        warn_cls = " warn" if card_id == "failures" and total > 0 else ""
-        empty_style = "color:var(--border-strong)" if total == 0 else ""
+        # NeedsAction with non-zero gets the warn tint; primary
+        # of 0 fades the big number so it reads as "nothing in
+        # this state" without distracting.
+        warn_cls = (
+            " warn" if card_id == "NeedsAction" and primary_count > 0
+            else ""
+        )
+        empty_style = (
+            "color:var(--border-strong)" if primary_count == 0 else ""
+        )
 
-        # Type breakdown — top-N types as a tail line.
-        type_pills = ""
-        if by_type:
-            top = sorted(by_type.items(), key=lambda x: -x[1])[:_TODAY_CARD_TOP_TYPES_LIMIT]
-            type_pills = " · ".join(f"<code>{escape(t)}</code>×{n}" for t, n in top)
-
-        # M24.0 stop-gap: wrap each sample in an ``<a>`` when the
-        # payload builder gave us a real link target.  Long subject
-        # strings get ``text-overflow: ellipsis`` + ``title="…"``
-        # tooltip so the card stays inside its box even on dense
-        # days (previously a long article title overflowed the card
-        # into the Inbox area).
+        # Item samples block — each sample is one row from
+        # ``ops_state`` (NOT an event).
         sample_html = ""
         if samples:
             li_rows: list[str] = []
             for s in samples:
-                et = escape(
-                    str(s.get("event_type", ""))[:_TODAY_SAMPLE_EVENT_TYPE_MAX_CHARS]
-                )
-                subj_full = str(s.get("subject", ""))
-                subj_short = escape(subj_full[:_TODAY_SAMPLE_SUBJECT_MAX_CHARS])
-                path = str(s.get("path", "") or "")
+                item_id = str(s.get("item_id", ""))
+                kind = str(s.get("item_kind", ""))
+                href = str(s.get("path", "") or "")
+                short_id = escape(item_id[:_TODAY_SAMPLE_SUBJECT_MAX_CHARS])
+                kind_label = escape(kind[:_TODAY_SAMPLE_EVENT_TYPE_MAX_CHARS])
                 subject_html = (
-                    f"<a href='{escape(path)}' "
-                    f"title='{escape(subj_full)}'>{subj_short}</a>"
-                    if path
-                    else f"<span title='{escape(subj_full)}'>{subj_short}</span>"
+                    f"<a href='{escape(href)}' "
+                    f"title='{escape(item_id)}'>{short_id}</a>"
+                    if href
+                    else f"<span title='{escape(item_id)}'>{short_id}</span>"
                 )
                 li_rows.append(
                     "<li style='overflow:hidden;text-overflow:ellipsis;"
                     "white-space:nowrap'>"
-                    f"<span class='muted'>{et}</span> <strong>{subject_html}</strong>"
+                    f"<span class='muted'>{kind_label}</span> "
+                    f"<strong>{subject_html}</strong>"
                     "</li>"
                 )
             sample_html = (
@@ -6791,72 +6815,69 @@ def _render_today_digest_page(payload: dict) -> str:
                 + "</ul></div>"
             )
 
-        see_all_html = ""
-        if see_all_path and total > len(samples):
-            see_all_html = (
+        # Primary CTA — only render when there's something to drill
+        # into; otherwise the link would land on an empty page.
+        primary_cta = ""
+        if primary_count > 0 and primary_href:
+            primary_cta = (
                 "<div class='tiny' style='margin-top:.5rem'>"
-                f"<a href='{escape(see_all_path)}'>See all {total} →</a>"
+                f"<a href='{escape(primary_href)}'>"
+                f"Open {primary_count} item"
+                f"{'s' if primary_count != 1 else ''} →</a>"
                 "</div>"
             )
 
-        # M24.3 honest-zero: shared message across every surface so
-        # the wording stays consistent.  M24.4 will branch on the
-        # ops_state diagnosis instead of always returning the
-        # ambiguity, but the helper signature stays the same.
+        # Secondary CTA — only render when there are events to
+        # drill into.  Label uses per-state phrasing from the
+        # payload (e.g. "5 arrived today" / "3 extracted today").
+        secondary_cta = ""
+        if event_count > 0 and event_href:
+            secondary_cta = (
+                "<div class='tiny' style='margin-top:.3rem'>"
+                f"<a href='{escape(event_href)}' class='muted'>"
+                f"View today's {event_count} evidence "
+                f"event{'s' if event_count != 1 else ''} →</a>"
+                "</div>"
+            )
+
+        # Honest-zero footer applies when BOTH numbers are 0.
         zero_html = ""
-        if total == 0:
+        if primary_count == 0 and event_count == 0:
             zero_html = honest_zero_html(short=True)
+
+        # Secondary text always renders so the card always shows
+        # both numbers (or both zeros) — the M25 plan locks this:
+        # never collapse one number into the other.
+        secondary_text = (
+            f"<div class='muted tiny' style='margin-top:6px'>"
+            f"{escape(event_label)}</div>"
+            if event_label
+            else ""
+        )
+
+        explainer_html = (
+            f"<div class='muted tiny' style='margin-top:4px'>"
+            f"{escape(explainer)}</div>"
+            if explainer
+            else ""
+        )
 
         sections.append(
             "<div class='card' style='margin:0;overflow:hidden'>"
             f"<div class='muted tiny'>{escape(label)}</div>"
-            f"<div class='metric-num{warn_cls}' style='margin-top:4px;{empty_style}'>{total}</div>"
-            f"<div class='muted tiny' style='margin-top:6px'>{type_pills}</div>"
+            f"<div class='metric-num{warn_cls}' "
+            f"style='margin-top:4px;{empty_style}'>{primary_count}</div>"
+            f"<div class='muted tiny'>current item"
+            f"{'s' if primary_count != 1 else ''}</div>"
+            f"{secondary_text}"
+            f"{explainer_html}"
             f"{zero_html}"
             f"{sample_html}"
-            f"{see_all_html}"
+            f"{primary_cta}"
+            f"{secondary_cta}"
             "</div>"
         )
     sections.append("</div>")
-
-    # M24.4: passive lifecycle-backlog strip beneath the event cards.
-    # Five numbers, no clicks — answers "how many items are sitting
-    # in each lifecycle state right now?".  Orthogonal to the cards
-    # above (which count today's events).  M25 will rename the cards
-    # to this vocabulary; for M24 the two surfaces coexist so the
-    # operator can compare event flow with backlog at a glance.
-    lifecycle = payload.get("lifecycle_summary") or {}
-    if lifecycle.get("available"):
-        counts = lifecycle.get("counts") or {}
-        total = lifecycle.get("total", 0)
-        state_chips = "".join(
-            f"<span class='pill'>{escape(state)}: "
-            f"{int(counts.get(state, 0))}</span>"
-            for state in (
-                "Received", "Extracted", "Accepted",
-                "Synthesized", "NeedsAction",
-            )
-        )
-        sections.append(
-            "<section style='margin-top:1rem'>"
-            "<div class='muted tiny' style='margin-bottom:4px'>"
-            f"Lifecycle backlog "
-            f"<span class='muted'>· {int(total)} item"
-            f"{'s' if int(total) != 1 else ''} in scope</span>"
-            "</div>"
-            f"<div style='display:flex;gap:0.4rem;flex-wrap:wrap'>{state_chips}</div>"
-            "</section>"
-        )
-    elif lifecycle.get("reason"):
-        # Surface the explicit not-yet-built reason rather than
-        # silently dropping the section — honest-zero applies to
-        # the kernel's own readout too.
-        sections.append(
-            "<section style='margin-top:1rem'>"
-            "<div class='muted tiny'>Lifecycle backlog "
-            f"<span class='muted'>· {escape(str(lifecycle['reason']))}</span>"
-            "</div></section>"
-        )
 
     body = "".join(sections)
     return _layout(f"Today — {date}", body, requested_pack=requested_pack)

--- a/src/ovp_pipeline/ui/view_models.py
+++ b/src/ovp_pipeline/ui/view_models.py
@@ -3144,10 +3144,275 @@ _TODAY_CARD_LABELS: dict[str, str] = {
     "failures": "Failures",
 }
 
+# Legacy: kept for back-compat with anything that imported the
+# old card list shape.  Same content the previous TODAY_DIGEST_CARDS
+# carried; the M25.3 view model below uses ``M25_LIFECYCLE_CARDS``.
 TODAY_DIGEST_CARDS: tuple[tuple[str, str, tuple[str, ...]], ...] = tuple(
     (cat, _TODAY_CARD_LABELS[cat], _evt_for_category(cat))
     for cat in _EVT_CATEGORIES
 )
+
+
+# M25.3: hybrid cards keyed on lifecycle state.  Each card carries
+# both the primary (state count) and secondary (events-in-window
+# count) numbers per the M25 plan §M25.3.  The event-category
+# mapping below decides which event_types feed each card's
+# secondary number.  ``governance`` events live on both Accepted
+# (promote_concept) and NeedsAction (open contradictions); we
+# split that category at the event-type level so the secondary
+# counts don't double-count.
+M25_LIFECYCLE_CARD_DEFS: tuple[dict[str, Any], ...] = (
+    {
+        "id": "Received",
+        "label": "Received",
+        "explainer": (
+            "Items where evidence shows intake but no extraction "
+            "yet."
+        ),
+        "categories": ("intake",),
+        "secondary_verb": "arrived today",
+    },
+    {
+        "id": "Extracted",
+        "label": "Extracted",
+        "explainer": (
+            "Items where the absorber ran, producing candidates "
+            "waiting for promotion."
+        ),
+        "categories": ("absorb",),
+        # ``evergreen_auto_promoted`` and ``promote_concept`` move
+        # items to Accepted, not Extracted — exclude from secondary.
+        "exclude_event_types": (
+            "evergreen_auto_promoted",
+            "evergreen_created",
+        ),
+        "secondary_verb": "extracted today",
+    },
+    {
+        "id": "Accepted",
+        "label": "Accepted",
+        "explainer": (
+            "Items with a canonical artifact in the vault."
+        ),
+        # Accepted is the promote-event signal: auto-promote
+        # (absorb-cat) + operator promote (governance-cat).
+        "categories": (),
+        "include_event_types": (
+            "evergreen_auto_promoted",
+            "promote_concept",
+            "promotion",
+            "evergreen_created",
+            "source_archived_to_processed",
+        ),
+        "secondary_verb": "accepted today",
+    },
+    {
+        "id": "Synthesized",
+        "label": "Synthesized",
+        "explainer": (
+            "Items in clusters with a fresh synthesis crystal."
+        ),
+        "categories": ("synthesis",),
+        "secondary_verb": "synthesized today",
+    },
+    {
+        "id": "NeedsAction",
+        "label": "Needs Action",
+        "explainer": (
+            "Items blocked or waiting on operator action — "
+            "failures, open contradictions, stale review queues."
+        ),
+        "categories": ("failures",),
+        "secondary_verb": "new blockers today",
+    },
+)
+
+
+def _event_types_for_card(card: dict[str, Any]) -> tuple[str, ...]:
+    """Compose the event_type list for a hybrid card's secondary
+    count.  Starts from the card's declared categories, adds any
+    ``include_event_types``, removes any ``exclude_event_types``.
+    """
+    result: list[str] = []
+    seen: set[str] = set()
+    for cat in card.get("categories", ()):
+        for et in _evt_for_category(cat):
+            if et not in seen:
+                seen.add(et)
+                result.append(et)
+    for et in card.get("include_event_types", ()):
+        if et not in seen:
+            seen.add(et)
+            result.append(et)
+    excluded = set(card.get("exclude_event_types", ()))
+    return tuple(et for et in result if et not in excluded)
+
+
+def _build_m25_hybrid_cards(
+    db_path: Path,
+    *,
+    date_key: str,
+    requested_pack: str,
+    effective_pack: str,
+) -> list[dict[str, Any]]:
+    """Build the five M25 hybrid cards.
+
+    See ``build_today_digest_payload`` docstring for the shape /
+    contract.  Single sqlite connection so we don't reopen per
+    card.
+    """
+    cards: list[dict[str, Any]] = []
+    with sqlite3.connect(db_path) as conn:
+        has_ops_state = conn.execute(
+            "SELECT 1 FROM sqlite_master "
+            "WHERE type='table' AND name='ops_state'"
+        ).fetchone() is not None
+
+        for card_def in M25_LIFECYCLE_CARD_DEFS:
+            state = str(card_def["id"])
+            event_types = _event_types_for_card(card_def)
+
+            # ── Primary number + samples ──────────────────────
+            primary_count = 0
+            samples: list[dict[str, str]] = []
+            if has_ops_state:
+                primary_row = conn.execute(
+                    "SELECT COUNT(*) FROM ops_state "
+                    " WHERE pack = ? AND state = ?",
+                    (effective_pack, state),
+                ).fetchone()
+                primary_count = int(primary_row[0] or 0) if primary_row else 0
+
+                # Samples: 3 newest items per card, sourced from
+                # ``ops_state`` (M25 plan §M25.3 lock — samples
+                # come from items, not events).  NeedsAction is
+                # the one exception: oldest first so the operator
+                # sees the most-aged blockers.
+                order_dir = (
+                    "ASC" if state == "NeedsAction" else "DESC"
+                )
+                sample_rows = conn.execute(
+                    f"""
+                    SELECT item_kind, item_id, last_evidence_at
+                      FROM ops_state
+                     WHERE pack = ? AND state = ?
+                     ORDER BY last_evidence_at {order_dir}
+                     LIMIT ?
+                    """,
+                    (effective_pack, state, TODAY_CARD_SAMPLE_SIZE),
+                ).fetchall()
+
+                # Resolve source slugs to vault paths so samples link
+                # to real routes (mirrors the M25.2 lookup).
+                source_slugs = [
+                    str(r[1]) for r in sample_rows
+                    if r and r[0] == "source" and r[1]
+                ]
+                slug_to_path: dict[str, str] = {}
+                if source_slugs:
+                    has_pages = conn.execute(
+                        "SELECT 1 FROM sqlite_master "
+                        "WHERE type='table' AND name='pages_index'"
+                    ).fetchone()
+                    if has_pages is not None:
+                        placeholders = ",".join("?" * len(source_slugs))
+                        for slug, path in conn.execute(
+                            f"SELECT slug, path FROM pages_index "
+                            f" WHERE slug IN ({placeholders})",
+                            source_slugs,
+                        ).fetchall():
+                            if slug and path:
+                                slug_to_path[str(slug)] = str(path)
+
+                for kind, item_id, last_ts in sample_rows:
+                    kind_str = str(kind or "")
+                    item_id_str = str(item_id or "")
+                    source_path = (
+                        slug_to_path.get(item_id_str)
+                        if kind_str == "source"
+                        else ""
+                    )
+                    href = _items_primary_href(
+                        kind_str, item_id_str, effective_pack,
+                        source_path=source_path or "",
+                    )
+                    samples.append({
+                        "item_kind": kind_str,
+                        "item_id": item_id_str,
+                        "last_evidence_at": str(last_ts or ""),
+                        "path": href,
+                    })
+
+            # ── Secondary number (events-in-window) ───────────
+            event_count = 0
+            by_type: dict[str, int] = {}
+            if event_types:
+                placeholders = ",".join("?" for _ in event_types)
+                counts_rows = conn.execute(
+                    f"""
+                    SELECT event_type, COUNT(*) AS n
+                      FROM audit_events
+                     WHERE date(timestamp) = ?
+                       AND event_type IN ({placeholders})
+                     GROUP BY event_type
+                     ORDER BY n DESC
+                    """,
+                    (date_key, *event_types),
+                ).fetchall()
+                by_type = {row[0]: int(row[1]) for row in counts_rows}
+                event_count = sum(by_type.values())
+
+            # ── Hrefs ─────────────────────────────────────────
+            # Primary CTA → /ops/items.  Critically NO date param:
+            # the primary number is "all current items in this
+            # state", not date-windowed (M25 plan §M25.2/3 lock).
+            primary_href_parts = [f"state={quote(state, safe='')}"]
+            if requested_pack:
+                primary_href_parts.append(
+                    f"pack={quote(requested_pack, safe='')}"
+                )
+            primary_href = (
+                f"/ops/items?{'&'.join(primary_href_parts)}"
+            )
+
+            # Secondary CTA → /ops/events (M25.4 will swap to
+            # /ops/events/audit when that view ships).
+            secondary_href = ""
+            if event_types:
+                see_all_qs_parts = [
+                    f"date={quote(date_key, safe='')}",
+                    "limit=200",
+                    "event_types=" + quote(",".join(event_types), safe=""),
+                ]
+                secondary_href = _scoped_path(
+                    f"/ops/events?{'&'.join(see_all_qs_parts)}",
+                    pack_name=requested_pack,
+                )
+
+            # Per-state secondary label.  Fall back to the
+            # conservative "N evidence events today" when the
+            # default verb would be misleading.
+            secondary_verb = str(card_def.get("secondary_verb", ""))
+            secondary_label = (
+                f"{event_count} {secondary_verb}"
+                if secondary_verb
+                else f"{event_count} evidence events today"
+            )
+
+            cards.append({
+                "id": state,
+                "label": str(card_def["label"]),
+                "explainer": str(card_def.get("explainer", "")),
+                "primary_count": primary_count,
+                "primary_href": primary_href,
+                "event_count": event_count,
+                "event_label": secondary_label,
+                "event_href": secondary_href,
+                "event_by_type": by_type,
+                "event_types": list(event_types),
+                "samples": samples,
+            })
+    return cards
 
 # Cap on how many sample rows each ``/ops/today`` card surfaces.
 # Cards are skim-mode — operators click through to the per-stage page
@@ -3173,18 +3438,30 @@ def build_today_digest_payload(
     pack_name: str | None = None,
     target_date: str | None = None,
 ) -> dict[str, Any]:
-    """5-card today digest for the maintainer dashboard.
+    """M25.3 hybrid cards for ``/ops/today``.
 
-    Pre-BL-053 the maintainer's day started by visiting ``/ops`` (a
-    static dashboard) and ``/ops/timeline`` (a 14-day histogram with
-    samples).  Neither answered "what happened **today**" at a glance.
-    This payload groups today's audit events into 5 cards aligned
-    with the pipeline's 5 macro-stages — intake, absorb, synthesis,
-    governance, failures — each carrying total + breakdown +
-    clickable samples.
+    Five cards keyed on the lifecycle vocabulary
+    (Received / Extracted / Accepted / Synthesized / NeedsAction).
+    Each card carries two parallel numbers per the M25 plan
+    §M25.3:
+
+    * **Primary** — items currently in this state, read from
+      ``ops_state``.  Primary CTA targets ``/ops/items?state=…``
+      with NO date param (cards count "current items", not
+      date-windowed; adding date would break card-N === page-N).
+    * **Secondary** — evidence events for this state in the
+      operator's date window, read from ``audit_events``.
+      Secondary CTA targets ``/ops/events?event_types=…&date=…``
+      (M25.4 will move this to ``/ops/events/audit`` to honor
+      raw-audit semantics).
+
+    Samples come from ``ops_state`` rows, not event rows — the
+    plan locks this so the visible items match what the primary
+    number counted.
 
     ``target_date`` accepts ``YYYY-MM-DD`` for back-dated views
-    (defaults to today UTC).
+    (defaults to today UTC).  The date affects the SECONDARY
+    number only; the primary number is "right now", not historic.
     """
     from datetime import datetime, timezone
     requested_pack = pack_name or ""
@@ -3204,137 +3481,13 @@ def build_today_digest_payload(
             "reason": "knowledge_index has not been built yet",
         }
 
-    cards: list[dict[str, Any]] = []
-    with sqlite3.connect(db_path) as conn:
-        for card_id, card_label, event_types in TODAY_DIGEST_CARDS:
-            # CodeRabbit: SQL ``IN ()`` is invalid; if a registry
-            # category ever ships empty, emit a zero card without
-            # querying instead of crashing.
-            if not event_types:
-                cards.append({
-                    "id": card_id,
-                    "label": card_label,
-                    "total": 0,
-                    "by_type": {},
-                    "samples": [],
-                    "see_all_path": "",
-                    "event_types": [],
-                })
-                continue
-            placeholders = ",".join("?" for _ in event_types)
-            counts_rows = conn.execute(
-                f"""
-                SELECT event_type, COUNT(*) AS n
-                  FROM audit_events
-                 WHERE date(timestamp) = ?
-                   AND event_type IN ({placeholders})
-                 GROUP BY event_type
-                 ORDER BY n DESC
-                """,
-                (date_key, *event_types),
-            ).fetchall()
-            by_type = {row[0]: int(row[1]) for row in counts_rows}
-            total = sum(by_type.values())
-
-            # Sample rows — favour high-signal subjects (slug / source
-            # path / file) over raw event_type so the click-through is
-            # actionable.  Skip stage events that don't carry a slug.
-            #
-            # M24.0 stop-gap: also pull the object_id + source path
-            # so we can wrap each sample in a real link.  Previously
-            # samples rendered as plain ``<span>`` and the operator
-            # couldn't drill from "intake: 7" into the actual
-            # 7 articles.
-            sample_rows = conn.execute(
-                f"""
-                SELECT event_type,
-                       COALESCE(json_extract(payload_json, '$.slug'),
-                                json_extract(payload_json, '$.source'),
-                                json_extract(payload_json, '$.file'),
-                                json_extract(payload_json, '$.url'),
-                                slug) AS subject,
-                       json_extract(payload_json, '$.title') AS title,
-                       json_extract(payload_json, '$.object_id') AS object_id,
-                       json_extract(payload_json, '$.path') AS path,
-                       json_extract(payload_json, '$.source_path') AS source_path,
-                       timestamp
-                  FROM audit_events
-                 WHERE date(timestamp) = ?
-                   AND event_type IN ({placeholders})
-                 ORDER BY timestamp DESC
-                """,
-                (date_key, *event_types),
-            ).fetchall()
-            samples: list[dict[str, str]] = []
-            for event_type, subject, title, object_id, path, source_path, ts in sample_rows:
-                if not subject:
-                    continue
-                if len(samples) >= TODAY_CARD_SAMPLE_SIZE:
-                    break
-                # Pick the most-actionable link target:
-                #   object_id → ``/object?id=…``  (canonical view)
-                #   path / source_path → ``/note?path=…``  (raw markdown)
-                #   else → bare ``/ops/events?q=<slug>``  (forensic fallback)
-                sample_path = ""
-                if object_id:
-                    sample_path = _scoped_path(
-                        f"/object?id={quote(str(object_id), safe='')}",
-                        pack_name=requested_pack,
-                    )
-                elif path or source_path:
-                    note_path = str(path or source_path)
-                    sample_path = _scoped_path(
-                        f"/note?path={quote(note_path, safe='')}",
-                        pack_name=requested_pack,
-                    )
-                else:
-                    sample_path = _scoped_path(
-                        f"/ops/events?q={quote(str(subject), safe='')}",
-                        pack_name=requested_pack,
-                    )
-                samples.append({
-                    "event_type": str(event_type),
-                    "subject": str(subject),
-                    "title": str(title or subject),
-                    "timestamp": str(ts or ""),
-                    "path": sample_path,
-                })
-            # ``see_all_path`` deep-links into the event dossier
-            # filtered to this card's date + event types so the
-            # operator can drill from the card sample (5 rows) into
-            # the full audit list.  ``_scoped_path`` already appends
-            # ``pack=`` when ``pack_name`` is set, so we don't add
-            # it to ``see_all_qs`` ourselves — pre-fix doing both
-            # produced duplicate ``pack=`` query params.
-            #
-            # M24.0 stop-gap (2026-05-14): pass the card's
-            # ``event_types`` through as a comma-separated query
-            # param so ``/ops/events`` can filter to just those
-            # rows.  Previously this link dropped the filter and
-            # operators landed on a full audit dump — "See all 7"
-            # showed 100+ unrelated events, which was the most-
-            # complained-about lie on the page.
-            see_all_qs_parts = [
-                f"date={quote(date_key, safe='')}",
-                "limit=200",
-            ]
-            if event_types:
-                see_all_qs_parts.append(
-                    "event_types=" + quote(",".join(event_types), safe="")
-                )
-            see_all_qs = "&".join(see_all_qs_parts)
-            see_all_path = _scoped_path(
-                f"/ops/events?{see_all_qs}", pack_name=requested_pack
-            )
-            cards.append({
-                "id": card_id,
-                "label": card_label,
-                "total": total,
-                "by_type": by_type,
-                "samples": samples,
-                "see_all_path": see_all_path,
-                "event_types": list(event_types),
-            })
+    effective_pack = requested_pack or PRIMARY_PACK_NAME
+    cards: list[dict[str, Any]] = _build_m25_hybrid_cards(
+        db_path,
+        date_key=date_key,
+        requested_pack=requested_pack,
+        effective_pack=effective_pack,
+    )
 
     # Prev/next date pivots so the operator can step through history
     # without crafting query strings.  Always populated (the dossier
@@ -3353,14 +3506,12 @@ def build_today_digest_payload(
             return ""
         return _scoped_path(f"/ops/today?date={quote(d, safe='')}", pack_name=requested_pack)
 
-    # M24.4: pull the per-pack lifecycle distribution from
-    # ``ops_state`` when the projection exists.  This is a *passive*
-    # readout — five numbers, no new drilldown route — that surfaces
-    # the kernel's truth alongside the existing time-windowed cards.
-    # Cards continue to count today's audit_events; the lifecycle
-    # summary answers a different (orthogonal) question: "how many
-    # items are sitting in each state right now?".  M25 will rename
-    # the cards onto this vocabulary; for M24 the two coexist.
+    # M25.3: the M24.4 standalone lifecycle backlog strip is now
+    # collapsed INTO the cards above (primary number per card).
+    # We keep the ``lifecycle_summary`` payload field so the
+    # renderer can detect "projection not built yet" and surface
+    # an explicit reason banner — same honest-zero rule that
+    # already governs every other M24/M25 surface.
     lifecycle_summary = _read_lifecycle_summary(
         vault_dir, pack=requested_pack
     )

--- a/tests/test_ops_today_lifecycle.py
+++ b/tests/test_ops_today_lifecycle.py
@@ -159,6 +159,12 @@ def test_cards_are_independent_of_lifecycle_summary(tmp_path):
     db_path = _make_db(tmp_path)
     _seed_two_items(db_path)
     payload = build_today_digest_payload(tmp_path, pack_name=PACK)
-    failures_card = next(c for c in payload["cards"] if c["id"] == "failures")
-    assert failures_card["total"] == 1  # 1 failure event today
+    # M25.3: cards are now keyed on lifecycle states.  The
+    # NeedsAction card carries BOTH numbers — secondary count
+    # (today's failure events) and primary count (current items
+    # in NeedsAction).  The plan explicitly forbids collapsing
+    # them.
+    na_card = next(c for c in payload["cards"] if c["id"] == "NeedsAction")
+    assert na_card["event_count"] == 1  # 1 failure event today
+    assert na_card["primary_count"] == 1  # 1 item in NeedsAction state
     assert payload["lifecycle_summary"]["counts"][STATE_NEEDS_ACTION] == 1

--- a/tests/test_ui_timeline_and_lineage.py
+++ b/tests/test_ui_timeline_and_lineage.py
@@ -557,27 +557,69 @@ class TestBuildTodayDigestPayload:
         assert payload["available"] is False
         assert payload["cards"] == []
 
-    def test_groups_events_into_five_cards(self, tmp_path):
+    def test_returns_five_lifecycle_cards(self, tmp_path):
+        """M25.3: cards are keyed on lifecycle states, not event
+        categories.  Pre-M25 the IDs were
+        intake/absorb/synthesis/governance/failures; today they're
+        the lifecycle vocabulary."""
         from ovp_pipeline.ui.view_models import build_today_digest_payload
         _seed_run_db(tmp_path)
         payload = build_today_digest_payload(tmp_path)
         assert payload["available"] is True
-        # Five cards in canonical order.
         assert [c["id"] for c in payload["cards"]] == [
-            "intake", "absorb", "synthesis", "governance", "failures",
+            "Received", "Extracted", "Accepted",
+            "Synthesized", "NeedsAction",
         ]
-        # Intake card carries clippings_processed + article_intake_only events.
-        intake = payload["cards"][0]
-        assert intake["total"] >= 4  # 1 clippings_processed + 3 intake_only
-        assert intake["by_type"].get("clippings_processed") == 1
-        assert intake["by_type"].get("article_intake_only") == 3
-        # Failures card surfaces the absorb_parse_error.
-        failures = payload["cards"][-1]
-        assert failures["by_type"].get("absorb_parse_error") == 1
-        # Each card with non-zero total has at least one sample.
+
+    def test_received_card_counts_intake_events_as_secondary(self, tmp_path):
+        """The Received card's SECONDARY count picks up
+        clippings_processed + article_intake_only events from
+        today's audit log."""
+        from ovp_pipeline.ui.view_models import build_today_digest_payload
+        _seed_run_db(tmp_path)
+        payload = build_today_digest_payload(tmp_path)
+        received = next(c for c in payload["cards"] if c["id"] == "Received")
+        # Seeded: 1 clippings_processed + 3 article_intake_only.
+        assert received["event_count"] >= 4
+        assert received["event_label"] == f"{received['event_count']} arrived today"
+
+    def test_needs_action_card_counts_failures_as_secondary(self, tmp_path):
+        from ovp_pipeline.ui.view_models import build_today_digest_payload
+        _seed_run_db(tmp_path)
+        payload = build_today_digest_payload(tmp_path)
+        na = next(c for c in payload["cards"] if c["id"] == "NeedsAction")
+        # Seeded: 1 absorb_parse_error.
+        assert na["event_count"] == 1
+        assert "blockers today" in na["event_label"]
+
+    def test_primary_href_targets_ops_items_with_no_date_param(self, tmp_path):
+        """M25 plan §M25.3 hard lock: primary CTA links to
+        /ops/items?state=... and MUST NOT carry a date param —
+        the primary count is "all current items", not date-windowed.
+        Adding date would break card-N === page-N."""
+        from ovp_pipeline.ui.view_models import build_today_digest_payload
+        _seed_run_db(tmp_path)
+        payload = build_today_digest_payload(tmp_path)
         for card in payload["cards"]:
-            if card["total"] > 0:
-                assert card["samples"], f"{card['id']} has no samples"
+            href = card["primary_href"]
+            assert href.startswith("/ops/items?state="), (
+                f"{card['id']} primary_href must target /ops/items"
+            )
+            assert "date=" not in href, (
+                f"{card['id']} primary_href must NOT carry date= "
+                f"(got {href!r})"
+            )
+
+    def test_secondary_href_targets_ops_events_with_date_filter(self, tmp_path):
+        """Secondary CTA carries date= because the secondary count
+        IS date-windowed."""
+        from ovp_pipeline.ui.view_models import build_today_digest_payload
+        _seed_run_db(tmp_path)
+        payload = build_today_digest_payload(tmp_path)
+        received = next(c for c in payload["cards"] if c["id"] == "Received")
+        assert received["event_href"].startswith("/ops/events?")
+        assert "date=" in received["event_href"]
+        assert "event_types=" in received["event_href"]
 
     def test_target_date_overrides_today(self, tmp_path):
         from ovp_pipeline.ui.view_models import build_today_digest_payload
@@ -586,7 +628,19 @@ class TestBuildTodayDigestPayload:
         future = "2099-01-01"
         payload = build_today_digest_payload(tmp_path, target_date=future)
         assert payload["date"] == future
-        assert all(c["total"] == 0 for c in payload["cards"])
+        # Secondary counts (event_count) drop to 0; primary
+        # (current items in state) is independent of the date.
+        assert all(c["event_count"] == 0 for c in payload["cards"])
+
+    def test_payload_keeps_lifecycle_summary_for_renderer(self, tmp_path):
+        """The renderer surfaces an explicit ``projection not built``
+        banner when the lifecycle summary says so — keep the field
+        plumbed through even though the cards now consume it
+        directly."""
+        from ovp_pipeline.ui.view_models import build_today_digest_payload
+        _seed_run_db(tmp_path)
+        payload = build_today_digest_payload(tmp_path)
+        assert "lifecycle_summary" in payload
 
 
 class TestBuildRunsIndexPayload:


### PR DESCRIPTION
## Summary

Collapse the two coexisting surfaces (event-window cards + M24.4 lifecycle strip) into one set of five hybrid cards keyed on the lifecycle vocabulary. Implements the contract locked in the M25 plan §M25.3.

**Cards after this PR:**
- Five cards, labeled: Received · Extracted · Accepted · Synthesized · Needs Action.
- Each carries TWO parallel numbers (never summed, never collapsed):
  - **PRIMARY** — current items in this state, from `ops_state`.
  - **SECONDARY** — today's evidence events for this state, from `audit_events`.
- Primary CTA: "Open N items →" → `/ops/items?state=…` (no date param).
- Secondary CTA: "View today's N evidence events →" → `/ops/events?event_types=…&date=…`.
- Samples come from `ops_state` rows, not events.

**What got dropped (intentionally):**
- M24.4 standalone lifecycle backlog strip — folded into cards.
- Event-category card IDs — registry categories remain as evidence classifications, but cards now use lifecycle vocabulary.

**Honest-zero behaviour:**
- Missing `ops_state` → explicit banner names cause.
- Both numbers 0 → M24.3 ambiguity footer renders inline.

**Event-type → card mapping** (avoids double-counting; see commit message for full table).

## Test plan

- [x] pytest tests/test_ui_timeline_and_lineage.py tests/test_ops_today_lifecycle.py tests/test_ops_items.py — 49/49 pass.
- [x] Full suite — 2907 passed, 0 regressions.
- [ ] Manual: run `ovp-ui` against operator vault; confirm five lifecycle cards render; click primary CTA, confirm it lands on `/ops/items?state=…` with same N; click secondary CTA, confirm it lands on `/ops/events?…` with the events.

Refs `docs/plans/2026-05-14-m25-maintainer-control-plane.md` §M25.3, PR #236 (`/ops/items`).