### PR TITLE
fix(m25.3): Accepted card double-counted paired/overlapping events

### DIFF
--- a/src/ovp_pipeline/ui/view_models.py
+++ b/src/ovp_pipeline/ui/view_models.py
@@ -3196,13 +3196,29 @@ M25_LIFECYCLE_CARD_DEFS: tuple[dict[str, Any], ...] = (
         ),
         # Accepted is the promote-event signal: auto-promote
         # (absorb-cat) + operator promote (governance-cat).
+        #
+        # Codex review on PR #237 caught two double-counting bugs
+        # that landed on main inside the M25.3 squash before the
+        # fix could ship.  This PR re-applies the fix:
+        #
+        #   * ``ovp-promote run`` emits BOTH ``promote_concept``
+        #     and ``promotion`` (M24.2 wired them as a pair for
+        #     different consumers — kernel reads promote_concept,
+        #     doctor mtime check reads promotion).  Counting both
+        #     turns one operator action into "2 accepted today".
+        #     Drop ``promotion``; ``promote_concept`` is the
+        #     canonical card-counting row.
+        #   * ``source_archived_to_processed`` is in the intake
+        #     category and counts on the Received card.  Per the
+        #     M24.1 doc fix (PR #230) it's a Received signal —
+        #     03-Processed is the absorber's INPUT, not its output.
+        #     Drop here so a single archival doesn't increment
+        #     both cards.
         "categories": (),
         "include_event_types": (
             "evergreen_auto_promoted",
             "promote_concept",
-            "promotion",
             "evergreen_created",
-            "source_archived_to_processed",
         ),
         "secondary_verb": "accepted today",
     },

--- a/tests/test_ui_timeline_and_lineage.py
+++ b/tests/test_ui_timeline_and_lineage.py
@@ -642,6 +642,73 @@ class TestBuildTodayDigestPayload:
         payload = build_today_digest_payload(tmp_path)
         assert "lifecycle_summary" in payload
 
+    def test_accepted_card_does_not_double_count_paired_events(self, tmp_path):
+        """Regression guard for codex review on PR #237:
+        ``ovp-promote run`` emits BOTH ``promote_concept`` and
+        ``promotion`` per operator action.  Accepted card must
+        count ONE per promotion, not two."""
+        import json
+        import sqlite3
+        from datetime import datetime, timezone
+        from ovp_pipeline.ui.view_models import build_today_digest_payload
+
+        db_path = tmp_path / "60-Logs" / "knowledge.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(db_path)
+        conn.executescript(_AUDIT_EVENTS_SCHEMA)
+        ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
+        # Seed one operator-promote pair.
+        conn.executemany(
+            "INSERT INTO audit_events VALUES (?, ?, ?, ?, ?, ?)",
+            [
+                ("pipeline.jsonl", "promote_concept", "obj-x", "s", ts,
+                 json.dumps({"slug": "obj-x"})),
+                ("pipeline.jsonl", "promotion", "obj-x", "s", ts,
+                 json.dumps({"target_path": "10-Knowledge/Evergreen/X.md"})),
+            ],
+        )
+        conn.commit()
+        conn.close()
+        payload = build_today_digest_payload(tmp_path)
+        accepted = next(c for c in payload["cards"] if c["id"] == "Accepted")
+        assert accepted["event_count"] == 1, (
+            "Accepted card double-counted the promote_concept + "
+            "promotion pair as 2 events.  Drop one from the "
+            "include_event_types."
+        )
+
+    def test_source_archived_does_not_double_count_across_cards(self, tmp_path):
+        """Regression guard for codex review on PR #237:
+        ``source_archived_to_processed`` is a Received signal
+        (M24.1 doc fix).  Including it in Accepted's
+        include_event_types would let one archival increment both
+        cards.  Verify it counts only on Received."""
+        import json
+        import sqlite3
+        from datetime import datetime, timezone
+        from ovp_pipeline.ui.view_models import build_today_digest_payload
+
+        db_path = tmp_path / "60-Logs" / "knowledge.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(db_path)
+        conn.executescript(_AUDIT_EVENTS_SCHEMA)
+        ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
+        conn.execute(
+            "INSERT INTO audit_events VALUES (?, ?, ?, ?, ?, ?)",
+            ("pipeline.jsonl", "source_archived_to_processed",
+             "src-y", "s", ts, "{}"),
+        )
+        conn.commit()
+        conn.close()
+        payload = build_today_digest_payload(tmp_path)
+        received = next(c for c in payload["cards"] if c["id"] == "Received")
+        accepted = next(c for c in payload["cards"] if c["id"] == "Accepted")
+        assert received["event_count"] == 1
+        assert accepted["event_count"] == 0, (
+            "source_archived_to_processed double-counted on the "
+            "Accepted card — drop it from Accepted's include list."
+        )
+
 
 class TestBuildRunsIndexPayload:
     def test_unavailable_when_db_missing(self, tmp_path):


### PR DESCRIPTION
## Summary

Re-applies the double-count fix that codex caught on PR #237. The fix was committed locally during the review pass but never reached origin before the squash-merge of #237 landed — a network race. Today's main carries the double-count bug; this PR closes it.

**Two double-counting sources on the Accepted card:**

1. `ovp-promote run` emits BOTH `promote_concept` AND `promotion` per single operator action. Both were in Accepted's include list → 1 promotion counted as 2.
2. `source_archived_to_processed` was in BOTH the intake category (Received card) and Accepted's include list → 1 archival incremented both cards.

**Fix:**
- Drop `promotion` from Accepted (still registered for the doctor mtime check; just off the card count).
- Drop `source_archived_to_processed` from Accepted (per M24.1 doc, it's a Received signal).

Accepted now counts only:
- `evergreen_auto_promoted` (auto-promote)
- `promote_concept` (operator-promote)
- `evergreen_created` (legacy fallback)

Two new regression tests prevent recurrence.

## Test plan

- [x] pytest tests/test_ui_timeline_and_lineage.py::TestBuildTodayDigestPayload — 10/10 pass.

Refs PR #237 codex review.