### PR TITLE
feat(m25.4): /ops/events/audit raw-audit view + reciprocal banners

### DIFF
--- a/src/ovp_pipeline/commands/_ui_renderers.py
+++ b/src/ovp_pipeline/commands/_ui_renderers.py
@@ -3922,11 +3922,29 @@ def _render_events_page(payload: dict) -> str:
             else "<p class='muted'>No open contradictions in the visible event scope.</p>"
         )
     )
+    # M25.4: reciprocal role banner naming this page as the timeline-
+    # projection view (NOT raw audit_events).  Pairs with the
+    # /ops/events/audit banner.  Pre-M25.4 the operator landed here
+    # from a card's secondary CTA and saw fewer rows than the card
+    # promised — different ledgers.
+    role_banner = (
+        "<div class='card' style='border-color:#9ca3af;"
+        "background:#f5f5f4;padding:0.75rem 1rem;margin:0.5rem 0'>"
+        "<strong>Timeline projection view.</strong> "
+        "<p class='muted small' style='margin:0.3rem 0 0'>"
+        "These rows are NOT raw <code>audit_events</code> — they "
+        "are derived events grouped by date and object.  For raw "
+        "audit evidence (the rows the Maintainer cards count) use "
+        "<a href='/ops/events/audit'>/ops/events/audit</a>."
+        "</p></div>"
+    )
+
     return _layout(
         "Event Dossier",
         "".join(
             [
                 "<h1>Event Dossier</h1>",
+                role_banner,
                 cross_surface_warning,
                 _render_page_help(
                     "Event dossier",
@@ -7040,6 +7058,127 @@ def _render_items_list_page(payload: dict) -> str:
     )
 
     body = "".join(head) + table_html + pager_html
+    return _layout(title, body, requested_pack=requested_pack)
+
+
+# M25.4: /ops/events/audit renderer.  Raw-audit-evidence view —
+# flat table of audit_events rows.  Card secondary CTAs target
+# this page so that ``View today's N evidence events →`` lands on
+# exactly N rows (card-N === page-N).  The pre-existing
+# /ops/events page renders timeline projections, which is a
+# different ledger; both pages carry reciprocal banners explaining
+# their respective roles.
+def _render_events_audit_page(payload: dict) -> str:
+    """Render the ``/ops/events/audit`` raw-audit-evidence table."""
+    requested_pack = str(payload.get("requested_pack") or "")
+    event_types = payload.get("event_types") or []
+    date_key = str(payload.get("date") or "")
+    total = int(payload.get("total") or 0)
+    rows = payload.get("rows") or []
+
+    title = "Audit evidence"
+
+    if not payload.get("available"):
+        reason = escape(str(payload.get("reason") or "unavailable"))
+        body = (
+            f"<h1>{escape(title)}</h1>"
+            "<div class='card' style='border-color:#9ca3af;"
+            "background:#f5f5f4;padding:0.75rem 1rem;margin:0.5rem 0'>"
+            f"<p class='muted small' style='margin:0'>{reason}</p>"
+            "</div>"
+        )
+        return _layout(title, body, requested_pack=requested_pack)
+
+    # Banner explaining the role + cross-link to /ops/events.
+    timeline_href = (
+        f"/ops/events?date={quote(date_key, safe='')}"
+        if date_key
+        else "/ops/events"
+    )
+    role_banner = (
+        "<div class='card' style='border-color:#9ca3af;"
+        "background:#f5f5f4;padding:0.75rem 1rem;margin-bottom:0.6rem'>"
+        "<strong>Raw audit evidence.</strong> "
+        "<p class='muted small' style='margin:0.3rem 0 0'>"
+        "These are the exact <code>audit_events</code> rows the "
+        "Maintainer card counted.  For timeline projections "
+        "(events grouped by date and object) use "
+        f"<a href='{escape(timeline_href)}'>/ops/events</a>."
+        "</p></div>"
+    )
+
+    # Filter summary.
+    filter_chips: list[str] = []
+    if event_types:
+        et_preview = ", ".join(event_types[:5])
+        if len(event_types) > 5:
+            et_preview += f" (+{len(event_types) - 5} more)"
+        filter_chips.append(
+            f"<span class='pill'>event_types: {escape(et_preview)}</span>"
+        )
+    if date_key:
+        filter_chips.append(
+            f"<span class='pill'>date: {escape(date_key)}</span>"
+        )
+    filter_html = ""
+    if filter_chips:
+        filter_html = (
+            "<div style='display:flex;gap:0.4rem;flex-wrap:wrap;"
+            "margin-bottom:0.6rem'>"
+            + "".join(filter_chips)
+            + "</div>"
+        )
+
+    head = [
+        f"<h1>{escape(title)}</h1>",
+        role_banner,
+        filter_html,
+        f"<p class='muted small'>"
+        f"{total} matching row{'s' if total != 1 else ''} "
+        f"(showing {len(rows)})"
+        f"</p>",
+    ]
+
+    if not rows:
+        head.append(honest_zero_html(short=True))
+        return _layout(
+            title, "".join(head), requested_pack=requested_pack
+        )
+
+    thead = (
+        "<thead><tr>"
+        "<th>Timestamp</th><th>Event type</th>"
+        "<th>Slug</th><th>Payload</th>"
+        "</tr></thead>"
+    )
+    body_rows: list[str] = []
+    for r in rows:
+        ts = escape(str(r.get("timestamp") or ""))
+        event_type = escape(str(r.get("event_type") or ""))
+        slug = escape(str(r.get("slug") or ""))
+        snippet = escape(str(r.get("payload_snippet") or ""))
+        full = escape(str(r.get("payload_full") or ""))
+        slug_cell = (
+            slug if slug else "<span class='muted'>—</span>"
+        )
+        body_rows.append(
+            "<tr>"
+            f"<td class='mono small'>{ts}</td>"
+            f"<td><code>{event_type}</code></td>"
+            f"<td>{slug_cell}</td>"
+            f"<td class='mono small' title='{full}' "
+            "style='max-width:50ch;overflow:hidden;"
+            f"text-overflow:ellipsis'>{snippet}</td>"
+            "</tr>"
+        )
+    table_html = (
+        "<table class='table' style='margin-top:0.6rem'>"
+        + thead
+        + "<tbody>" + "".join(body_rows) + "</tbody>"
+        + "</table>"
+    )
+
+    body = "".join(head) + table_html
     return _layout(title, body, requested_pack=requested_pack)
 
 

--- a/src/ovp_pipeline/commands/ui_server.py
+++ b/src/ovp_pipeline/commands/ui_server.py
@@ -47,6 +47,7 @@ from ..ui.view_models import (
     build_timeline_payload,
     build_today_digest_payload,
     build_items_list_payload,
+    build_events_audit_payload,
     build_runs_index_payload,
     build_run_detail_payload,
     build_topic_overview_payload,
@@ -106,6 +107,7 @@ from ._ui_renderers import (  # noqa: F401 — all renderers
     _render_timeline_page,
     _render_today_digest_page,
     _render_items_list_page,
+    _render_events_audit_page,
     _render_runs_index_page,
     _render_run_detail_page,
     _render_reuse_report_fragment,
@@ -1265,6 +1267,37 @@ def create_server(
                         self._write_json(payload)
                     else:
                         self._write_html(_render_items_list_page(payload))
+                    return
+                # M25.4: /ops/events/audit — raw audit_events table
+                # view.  Pairs with /ops/events (timeline
+                # projection).  Card secondary CTAs target this so
+                # card-N === audit-page-N by construction.
+                if path in ("/ops/events/audit", "/api/events/audit"):
+                    pack_name = query.get("pack", [""])[0] or None
+                    raw_event_types = query.get("event_types", [""])[0]
+                    event_types = tuple(
+                        t.strip()
+                        for t in raw_event_types.split(",")
+                        if t.strip()
+                    )
+                    date_key = query.get("date", [""])[0] or ""
+                    raw_limit = query.get("limit", [""])[0]
+                    limit = (
+                        int(raw_limit)
+                        if raw_limit.isdigit() and int(raw_limit) > 0
+                        else 200
+                    )
+                    payload = build_events_audit_payload(
+                        resolved_vault,
+                        event_types=event_types,
+                        date_key=date_key,
+                        pack_name=pack_name,
+                        limit=limit,
+                    )
+                    if path == "/api/events/audit":
+                        self._write_json(payload)
+                    else:
+                        self._write_html(_render_events_audit_page(payload))
                     return
                 # BL-053: by-run "runs" index
                 if path in ("/ops/runs", "/api/runs"):

--- a/src/ovp_pipeline/ui/view_models.py
+++ b/src/ovp_pipeline/ui/view_models.py
@@ -3397,11 +3397,18 @@ def _build_m25_hybrid_cards(
             # by construction.  The legacy /ops/events (timeline
             # projection) remains accessible from the audit page's
             # role banner.
+            #
+            # M25.4 (codex review on PR #239): set the URL limit to
+            # at LEAST the card's event_count so high-volume days
+            # don't silently truncate to 200 rows.  Clamp to the
+            # audit view's hard MAX so the URL stays bounded.
             secondary_href = ""
             if event_types:
+                target_limit = max(EVENTS_AUDIT_DEFAULT_LIMIT, event_count)
+                target_limit = min(target_limit, EVENTS_AUDIT_MAX_LIMIT)
                 see_all_qs_parts = [
                     f"date={quote(date_key, safe='')}",
-                    "limit=200",
+                    f"limit={target_limit}",
                     "event_types=" + quote(",".join(event_types), safe=""),
                 ]
                 secondary_href = _scoped_path(
@@ -3895,30 +3902,26 @@ def build_events_audit_payload(
             "limit": safe_limit,
         }
 
-    if not event_types_tup:
-        return {
-            "screen": "ops/events/audit",
-            "available": True,
-            "reason": "",
-            "event_types": [],
-            "date": date_key,
-            "requested_pack": requested_pack,
-            "rows": [],
-            "total": 0,
-            "limit": safe_limit,
-        }
-
-    placeholders = ",".join("?" for _ in event_types_tup)
-    params: list[object] = list(event_types_tup)
-    where = [f"event_type IN ({placeholders})"]
+    # M25.4 (codex review on PR #239): when no event_types filter
+    # is passed (operator landed here from the timeline-projection
+    # banner with no specific scope), show the N most-recent
+    # audit_events rows across ALL event_types so the page isn't
+    # empty.  The role banner explains the page's purpose; the
+    # default content has to be useful.
+    where: list[str] = []
+    params: list[object] = []
+    if event_types_tup:
+        placeholders = ",".join("?" for _ in event_types_tup)
+        where.append(f"event_type IN ({placeholders})")
+        params.extend(event_types_tup)
     if date_key:
         where.append("date(timestamp) = ?")
         params.append(date_key)
-    where_sql = " AND ".join(where)
+    where_sql = f"WHERE {' AND '.join(where)}" if where else ""
 
     with sqlite3.connect(db_path) as conn:
         total_row = conn.execute(
-            f"SELECT COUNT(*) FROM audit_events WHERE {where_sql}",
+            f"SELECT COUNT(*) FROM audit_events {where_sql}",
             params,
         ).fetchone()
         total = int(total_row[0] or 0) if total_row else 0
@@ -3926,7 +3929,7 @@ def build_events_audit_payload(
             f"""
             SELECT timestamp, event_type, slug, payload_json, source_log
               FROM audit_events
-             WHERE {where_sql}
+             {where_sql}
              ORDER BY timestamp DESC
              LIMIT ?
             """,

--- a/src/ovp_pipeline/ui/view_models.py
+++ b/src/ovp_pipeline/ui/view_models.py
@@ -3391,8 +3391,12 @@ def _build_m25_hybrid_cards(
                 f"/ops/items?{'&'.join(primary_href_parts)}"
             )
 
-            # Secondary CTA → /ops/events (M25.4 will swap to
-            # /ops/events/audit when that view ships).
+            # Secondary CTA → /ops/events/audit (M25.4).  This is
+            # the raw-audit-evidence view that reads the same SQL
+            # the card secondary count used, so card N === page N
+            # by construction.  The legacy /ops/events (timeline
+            # projection) remains accessible from the audit page's
+            # role banner.
             secondary_href = ""
             if event_types:
                 see_all_qs_parts = [
@@ -3401,7 +3405,7 @@ def _build_m25_hybrid_cards(
                     "event_types=" + quote(",".join(event_types), safe=""),
                 ]
                 secondary_href = _scoped_path(
-                    f"/ops/events?{'&'.join(see_all_qs_parts)}",
+                    f"/ops/events/audit?{'&'.join(see_all_qs_parts)}",
                     pack_name=requested_pack,
                 )
 
@@ -3834,6 +3838,132 @@ def _items_primary_href(
     # the item as plain text rather than a broken link.  M25.4
     # adds the raw-audit-evidence view that will pick this up.
     return ""
+
+
+# M25.4: /ops/events/audit page size.  Slightly larger than the
+# items list because raw audit rows are noisier; operators tend to
+# scan rather than click.
+EVENTS_AUDIT_DEFAULT_LIMIT = 200
+EVENTS_AUDIT_MAX_LIMIT = 2000
+
+
+def build_events_audit_payload(
+    vault_dir: Path | str,
+    *,
+    event_types: tuple[str, ...] | list[str] | None = None,
+    date_key: str = "",
+    pack_name: str | None = None,
+    limit: int = EVENTS_AUDIT_DEFAULT_LIMIT,
+) -> dict[str, Any]:
+    """M25.4: ``/ops/events/audit`` raw-audit-evidence view.
+
+    The M25 cards' SECONDARY count comes from a query against the
+    raw ``audit_events`` table.  ``/ops/events`` today renders
+    **timeline projections** (``list_timeline_events`` over dated
+    notes + contradictions) — a different ledger.  Pointing the
+    card's secondary CTA at that page resurrects the M24.0
+    two-ledger problem (card N != page N).
+
+    This view fixes the contract: it reads ``audit_events``
+    directly using the same SQL the card uses, so card N === page
+    N by construction.  Flat table, no timeline grouping.
+
+    Plan contract (locked in M25 §M25.4):
+    * ``event_types`` is the card's event_types list — required
+      so the page count matches what the card counted.
+    * ``date_key`` filters to that day.
+    * No pack filter on rows: ``audit_events`` doesn't carry a
+      pack column.  Pack-scoping is part of the routing context
+      (URL) but doesn't restrict rows returned.
+    """
+    requested_pack = pack_name or ""
+    event_types_tup = tuple(event_types or ())
+
+    safe_limit = max(1, min(int(limit or EVENTS_AUDIT_DEFAULT_LIMIT), EVENTS_AUDIT_MAX_LIMIT))
+
+    db_path = _db_path(vault_dir)
+    if not db_path.exists():
+        return {
+            "screen": "ops/events/audit",
+            "available": False,
+            "reason": "knowledge_index has not been built yet",
+            "event_types": list(event_types_tup),
+            "date": date_key,
+            "requested_pack": requested_pack,
+            "rows": [],
+            "total": 0,
+            "limit": safe_limit,
+        }
+
+    if not event_types_tup:
+        return {
+            "screen": "ops/events/audit",
+            "available": True,
+            "reason": "",
+            "event_types": [],
+            "date": date_key,
+            "requested_pack": requested_pack,
+            "rows": [],
+            "total": 0,
+            "limit": safe_limit,
+        }
+
+    placeholders = ",".join("?" for _ in event_types_tup)
+    params: list[object] = list(event_types_tup)
+    where = [f"event_type IN ({placeholders})"]
+    if date_key:
+        where.append("date(timestamp) = ?")
+        params.append(date_key)
+    where_sql = " AND ".join(where)
+
+    with sqlite3.connect(db_path) as conn:
+        total_row = conn.execute(
+            f"SELECT COUNT(*) FROM audit_events WHERE {where_sql}",
+            params,
+        ).fetchone()
+        total = int(total_row[0] or 0) if total_row else 0
+        rows = conn.execute(
+            f"""
+            SELECT timestamp, event_type, slug, payload_json, source_log
+              FROM audit_events
+             WHERE {where_sql}
+             ORDER BY timestamp DESC
+             LIMIT ?
+            """,
+            (*params, safe_limit),
+        ).fetchall()
+
+    audit_rows: list[dict[str, Any]] = []
+    for ts, event_type, slug, payload_json, source_log in rows:
+        # Snippet of payload — first 120 chars so the page doesn't
+        # flood with full JSON dumps.  Renderer adds a title=…
+        # tooltip carrying the full body for hover-inspection.
+        payload_str = str(payload_json or "")
+        snippet = (
+            payload_str[:117] + "…"
+            if len(payload_str) > 120
+            else payload_str
+        )
+        audit_rows.append({
+            "timestamp": str(ts or ""),
+            "event_type": str(event_type or ""),
+            "slug": str(slug or ""),
+            "payload_snippet": snippet,
+            "payload_full": payload_str,
+            "source_log": str(source_log or ""),
+        })
+
+    return {
+        "screen": "ops/events/audit",
+        "available": True,
+        "reason": "",
+        "event_types": list(event_types_tup),
+        "date": date_key,
+        "requested_pack": requested_pack,
+        "rows": audit_rows,
+        "total": total,
+        "limit": safe_limit,
+    }
 
 
 def build_digest_health_payload(vault_dir: Path | str) -> dict[str, Any]:

--- a/tests/test_events_audit.py
+++ b/tests/test_events_audit.py
@@ -1,0 +1,238 @@
+"""Tests for the M25.4 ``/ops/events/audit`` raw-audit-evidence view.
+
+The hard contract is **card N === audit-page N**: when a card on
+``/ops/today`` shows ``View today's 5 evidence events →``,
+clicking it must land on a page with exactly 5 rows.  Pre-M25.4
+the card's secondary CTA pointed at ``/ops/events`` (timeline
+projection), which is a different ledger — card and page disagreed.
+
+These tests lock:
+
+* Card-N === audit-page-N invariant for every state's secondary
+  number that's > 0.
+* Date filtering matches the card SQL: ``date(timestamp) = ?``.
+* Empty / missing-DB paths surface explicit reasons.
+* Renderer carries the role banner and the reciprocal link to
+  ``/ops/events``.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from ovp_pipeline.ui.view_models import (
+    EVENTS_AUDIT_DEFAULT_LIMIT,
+    EVENTS_AUDIT_MAX_LIMIT,
+    build_events_audit_payload,
+    build_today_digest_payload,
+)
+from ovp_pipeline.commands._ui_renderers import (
+    _render_events_audit_page,
+    _render_events_page,
+)
+
+
+_AUDIT_EVENTS_SCHEMA = """
+CREATE TABLE audit_events (
+    source_log TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    slug TEXT NOT NULL DEFAULT '',
+    session_id TEXT NOT NULL DEFAULT '',
+    timestamp TEXT NOT NULL DEFAULT '',
+    payload_json TEXT NOT NULL
+);
+"""
+
+
+def _seed_audit(tmp_path: Path, rows: list[tuple]) -> Path:
+    db_path = tmp_path / "60-Logs" / "knowledge.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.executescript(_AUDIT_EVENTS_SCHEMA)
+    conn.executemany(
+        "INSERT INTO audit_events VALUES (?, ?, ?, ?, ?, ?)", rows,
+    )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+# ── Availability / error paths ────────────────────────────────────
+
+
+def test_unavailable_when_db_missing(tmp_path):
+    payload = build_events_audit_payload(
+        tmp_path,
+        event_types=("article_intake_only",),
+        date_key="2026-05-13",
+    )
+    assert payload["available"] is False
+    assert "knowledge_index" in payload["reason"]
+
+
+def test_empty_event_types_returns_empty_available_page(tmp_path):
+    """No event_types in the URL → page renders cleanly with 0
+    rows.  Doesn't crash on SQL ``IN ()`` because the SQL is
+    skipped entirely."""
+    _seed_audit(tmp_path, [])
+    payload = build_events_audit_payload(
+        tmp_path, event_types=(), date_key="2026-05-13",
+    )
+    assert payload["available"] is True
+    assert payload["rows"] == []
+    assert payload["total"] == 0
+
+
+# ── Filtering ─────────────────────────────────────────────────────
+
+
+def test_event_type_filter_isolates_rows(tmp_path):
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
+    today_date = today[:10]
+    _seed_audit(tmp_path, [
+        ("pipeline.jsonl", "article_intake_only", "src-a", "s", today, "{}"),
+        ("pipeline.jsonl", "article_intake_only", "src-b", "s", today, "{}"),
+        ("pipeline.jsonl", "absorb_parse_error", "src-c", "s", today, "{}"),
+    ])
+    payload = build_events_audit_payload(
+        tmp_path,
+        event_types=("article_intake_only",),
+        date_key=today_date,
+    )
+    assert payload["total"] == 2
+    assert all(r["event_type"] == "article_intake_only" for r in payload["rows"])
+
+
+def test_date_filter_excludes_other_days(tmp_path):
+    today_iso = "2026-05-13T08:00:00"
+    other_iso = "2026-05-12T08:00:00"
+    _seed_audit(tmp_path, [
+        ("pipeline.jsonl", "article_intake_only", "src-a", "s", today_iso, "{}"),
+        ("pipeline.jsonl", "article_intake_only", "src-b", "s", other_iso, "{}"),
+    ])
+    payload = build_events_audit_payload(
+        tmp_path,
+        event_types=("article_intake_only",),
+        date_key="2026-05-13",
+    )
+    assert payload["total"] == 1
+
+
+# ── Card N === audit-page N contract ──────────────────────────────
+
+
+def test_card_n_equals_audit_page_n(tmp_path):
+    """The M25 hybrid card promises ``View today's N events →``
+    lands on exactly N rows.  Seed a mix of intake + failure events
+    and verify each card's secondary count matches its audit-page
+    total."""
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
+    today_date = today[:10]
+    rows = [
+        ("pipeline.jsonl", "article_intake_only", f"src-{i}", "s",
+         today, "{}")
+        for i in range(4)
+    ] + [
+        ("pipeline.jsonl", "absorb_parse_error", f"src-f{i}", "s",
+         today, "{}")
+        for i in range(2)
+    ]
+    _seed_audit(tmp_path, rows)
+    digest = build_today_digest_payload(tmp_path)
+
+    for card in digest["cards"]:
+        if card["event_count"] == 0 or not card["event_types"]:
+            continue
+        audit = build_events_audit_payload(
+            tmp_path,
+            event_types=tuple(card["event_types"]),
+            date_key=today_date,
+        )
+        assert audit["total"] == card["event_count"], (
+            f"Card N != audit page N for {card['id']}: "
+            f"card={card['event_count']} audit={audit['total']}"
+        )
+
+
+# ── Pagination ────────────────────────────────────────────────────
+
+
+def test_limit_clamped_to_max(tmp_path):
+    _seed_audit(tmp_path, [])
+    payload = build_events_audit_payload(
+        tmp_path,
+        event_types=("article_intake_only",),
+        date_key="2026-05-13",
+        limit=EVENTS_AUDIT_MAX_LIMIT * 10,
+    )
+    assert payload["limit"] == EVENTS_AUDIT_MAX_LIMIT
+
+
+def test_zero_limit_falls_back_to_default(tmp_path):
+    _seed_audit(tmp_path, [])
+    payload = build_events_audit_payload(
+        tmp_path,
+        event_types=("article_intake_only",),
+        date_key="2026-05-13",
+        limit=0,
+    )
+    assert payload["limit"] == EVENTS_AUDIT_DEFAULT_LIMIT
+
+
+# ── Renderer ──────────────────────────────────────────────────────
+
+
+def test_audit_renderer_carries_role_banner(tmp_path):
+    """Page must explain its role + link to /ops/events for the
+    timeline-projection view."""
+    today_iso = "2026-05-13T08:00:00"
+    _seed_audit(tmp_path, [
+        ("pipeline.jsonl", "article_intake_only", "src-a", "s", today_iso, "{}"),
+    ])
+    payload = build_events_audit_payload(
+        tmp_path,
+        event_types=("article_intake_only",),
+        date_key="2026-05-13",
+    )
+    html = _render_events_audit_page(payload)
+    assert "Raw audit evidence" in html
+    assert "/ops/events" in html  # link to timeline-projection page
+    # Filter chip surfaces the event_type so the page's scope is
+    # explicit.
+    assert "article_intake_only" in html
+
+
+def test_audit_renderer_shows_honest_zero_on_empty_match(tmp_path):
+    """When the filter matches zero rows, the page still renders
+    cleanly with the honest-zero footer rather than an empty
+    table."""
+    _seed_audit(tmp_path, [])
+    payload = build_events_audit_payload(
+        tmp_path,
+        event_types=("article_intake_only",),
+        date_key="2026-05-13",
+    )
+    html = _render_events_audit_page(payload)
+    # Honest-zero phrase.
+    assert "may mean" in html.lower() or "may mean" in html
+
+
+def test_events_dossier_carries_reciprocal_banner(tmp_path):
+    """``/ops/events`` (timeline-projection view) must carry the
+    reciprocal banner explaining it is NOT raw audit_events and
+    linking to /ops/events/audit.  Pairs with the audit page's
+    banner; together they remove the M24.0 two-ledger confusion."""
+    from ovp_pipeline.ui.view_models import build_event_dossier_payload
+
+    # An empty audit_events table is enough — we're checking the
+    # banner renders, not the dossier content.
+    _seed_audit(tmp_path, [])
+    payload = build_event_dossier_payload(tmp_path)
+    html = _render_events_page(payload)
+    assert "Timeline projection view" in html
+    assert "/ops/events/audit" in html

--- a/tests/test_events_audit.py
+++ b/tests/test_events_audit.py
@@ -75,17 +75,25 @@ def test_unavailable_when_db_missing(tmp_path):
     assert "knowledge_index" in payload["reason"]
 
 
-def test_empty_event_types_returns_empty_available_page(tmp_path):
-    """No event_types in the URL → page renders cleanly with 0
-    rows.  Doesn't crash on SQL ``IN ()`` because the SQL is
-    skipped entirely."""
-    _seed_audit(tmp_path, [])
+def test_empty_event_types_returns_recent_rows_across_all_types(tmp_path):
+    """M25.4 (codex review on PR #239): when the page is hit without
+    an event_types filter (e.g. operator landed here from the
+    timeline-projection banner), default to showing the N most
+    recent audit_events rows across ALL event_types rather than
+    a useless empty page."""
+    today_iso = "2026-05-13T08:00:00"
+    _seed_audit(tmp_path, [
+        ("pipeline.jsonl", "article_intake_only", "src-a", "s", today_iso, "{}"),
+        ("pipeline.jsonl", "absorb_parse_error", "src-b", "s", today_iso, "{}"),
+    ])
     payload = build_events_audit_payload(
-        tmp_path, event_types=(), date_key="2026-05-13",
+        tmp_path, event_types=(), date_key="",
     )
     assert payload["available"] is True
-    assert payload["rows"] == []
-    assert payload["total"] == 0
+    # Both seeded rows surface, despite no event_types filter.
+    assert payload["total"] == 2
+    types_in_rows = {r["event_type"] for r in payload["rows"]}
+    assert types_in_rows == {"article_intake_only", "absorb_parse_error"}
 
 
 # ── Filtering ─────────────────────────────────────────────────────
@@ -171,6 +179,35 @@ def test_limit_clamped_to_max(tmp_path):
         limit=EVENTS_AUDIT_MAX_LIMIT * 10,
     )
     assert payload["limit"] == EVENTS_AUDIT_MAX_LIMIT
+
+
+def test_card_secondary_href_carries_limit_above_event_count(tmp_path):
+    """M25.4 (codex review on PR #239): when a card has more than
+    the default 200 events, the secondary CTA URL must carry a
+    limit big enough to surface all rows — otherwise the audit
+    page silently truncates and the card-N === page-N contract
+    breaks for high-volume days."""
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
+    # Seed 250 intake rows — over the default 200 limit.
+    rows = [
+        ("pipeline.jsonl", "article_intake_only", f"src-{i:03d}", "s",
+         today, "{}")
+        for i in range(250)
+    ]
+    _seed_audit(tmp_path, rows)
+    digest = build_today_digest_payload(tmp_path)
+    received = next(c for c in digest["cards"] if c["id"] == "Received")
+    assert received["event_count"] == 250
+    href = received["event_href"]
+    # URL must carry limit >= 250 (or hit the audit MAX cap).
+    import re
+    match = re.search(r"limit=(\d+)", href)
+    assert match is not None
+    url_limit = int(match.group(1))
+    assert url_limit >= 250, (
+        f"Secondary CTA limit {url_limit} is below event_count 250 "
+        "— high-volume days will silently truncate"
+    )
 
 
 def test_zero_limit_falls_back_to_default(tmp_path):

--- a/tests/test_ui_timeline_and_lineage.py
+++ b/tests/test_ui_timeline_and_lineage.py
@@ -610,14 +610,15 @@ class TestBuildTodayDigestPayload:
                 f"(got {href!r})"
             )
 
-    def test_secondary_href_targets_ops_events_with_date_filter(self, tmp_path):
-        """Secondary CTA carries date= because the secondary count
-        IS date-windowed."""
+    def test_secondary_href_targets_events_audit_with_date_filter(self, tmp_path):
+        """M25.4: Secondary CTA targets /ops/events/audit (the new
+        raw-audit-evidence view) so card N === page N.  Carries
+        date= because the secondary count IS date-windowed."""
         from ovp_pipeline.ui.view_models import build_today_digest_payload
         _seed_run_db(tmp_path)
         payload = build_today_digest_payload(tmp_path)
         received = next(c for c in payload["cards"] if c["id"] == "Received")
-        assert received["event_href"].startswith("/ops/events?")
+        assert received["event_href"].startswith("/ops/events/audit?")
         assert "date=" in received["event_href"]
         assert "event_types=" in received["event_href"]
 


### PR DESCRIPTION
## Summary

Build the route the M25 hybrid card secondary CTAs target — the final piece for the card-N === drilldown-N contract.

**Why this PR exists:**
- Existing `/ops/events` renders timeline projections (`list_timeline_events`), NOT raw `audit_events`.
- Cards count raw `audit_events`.
- Card secondary CTA pointed at `/ops/events` showed fewer rows than the card counted — the M24.0 two-ledger problem.

**What ships:**
- `build_events_audit_payload` reads `audit_events` directly with the same SQL the cards use (card N === page N by construction).
- `_render_events_audit_page` flat table + role banner explaining its role + cross-link to `/ops/events`.
- Route `/ops/events/audit` + `/api/events/audit`.
- **Reciprocal banner** on the existing `/ops/events` page naming it as the timeline-projection view and linking back.
- M25.3 secondary CTA swapped from `/ops/events` to `/ops/events/audit`.

**Tests (10 new in `test_events_audit`):**
- Card-N === audit-page-N invariant across every state.
- Event-type + date filter isolation.
- Limit clamping.
- Both banners present (audit page + timeline page).
- Honest-zero footer on empty match.

## Test plan

- [x] pytest tests/test_events_audit.py — 10/10 pass.
- [x] Full suite — 2919 passed, 0 regressions.
- [ ] Manual: run `ovp-ui` against operator vault; click each card's "View today's N evidence events →"; confirm page row count matches card secondary count.

Refs `docs/plans/2026-05-14-m25-maintainer-control-plane.md` §M25.4. Closes the card-N === drilldown-N contract.