### PR TITLE
feat(m25.5): vocabulary alignment regression tests + stale comment fix

### DIFF
--- a/src/ovp_pipeline/commands/_digests_list_page.py
+++ b/src/ovp_pipeline/commands/_digests_list_page.py
@@ -35,9 +35,11 @@ CALENDAR_WINDOW_DAYS = 30
 
 # M24.0 stop-gap: pull intake event_types from the single canonical
 # registry (``event_evidence_registry``) so the calendar, the
-# ``/ops/today`` Intake card, and the M23 digest's Layer 0 all
-# classify the same way.  Before this, three independent lists
-# drifted and same-day counts disagreed across surfaces.
+# ``/ops/today`` Received card's secondary count, and the M23
+# digest's Layer 0 all classify the same way.  Before this, three
+# independent lists drifted and same-day counts disagreed across
+# surfaces.  M25.3 renamed the card from "Intake" → "Received";
+# the underlying evidence category stays ``intake``.
 from ..event_evidence_registry import event_types_for_category
 
 _INTAKE_EVENT_TYPES = event_types_for_category("intake")

--- a/tests/test_m25_vocabulary_alignment.py
+++ b/tests/test_m25_vocabulary_alignment.py
@@ -16,9 +16,6 @@ state-card label — fails CI loudly.
 
 from __future__ import annotations
 
-import pytest
-
-
 # ── State-label vocabulary lock ──────────────────────────────────
 
 
@@ -31,8 +28,11 @@ def test_m25_card_def_ids_use_the_five_locked_states():
 
     ids = [c["id"] for c in M25_LIFECYCLE_CARD_DEFS]
     assert ids == [
-        "Received", "Extracted", "Accepted",
-        "Synthesized", "NeedsAction",
+        "Received",
+        "Extracted",
+        "Accepted",
+        "Synthesized",
+        "NeedsAction",
     ]
 
 
@@ -78,7 +78,6 @@ def test_digests_calendar_legend_uses_audit_evidence_phrase():
     misleading "quiet day" to the honest "no audit evidence" with
     the three-cause ambiguity.  M25 keeps this — regression guard
     that the legend doesn't get reduced back to "quiet day"."""
-    from pathlib import Path
     from ovp_pipeline.commands._digests_list_page import (
         _render_calendar_grid,
         CalendarCell,
@@ -103,14 +102,27 @@ def test_digests_calendar_legend_uses_audit_evidence_phrase():
 def test_ops_items_state_explainers_cover_every_state():
     """The /ops/items renderer prints a state-specific explainer
     paragraph below the H1.  Every state in M25_LIFECYCLE_CARD_DEFS
-    must have copy."""
-    from ovp_pipeline.commands._ui_renderers import _render_items_list_page
-    from ovp_pipeline.ui.view_models import M25_LIFECYCLE_CARD_DEFS
+    must produce that explainer in the rendered HTML.
 
-    for card in M25_LIFECYCLE_CARD_DEFS:
-        state = card["id"]
-        # Render the empty-state page for this state — explainer
-        # appears regardless of whether there are rows.
+    Codex review on PR #240 caught the original weak form of this
+    test: ``state in html`` always passes because the page H1
+    contains "Items · <state>".  The strong form checks for a
+    distinctive substring from each explainer paragraph.
+    """
+    from ovp_pipeline.commands._ui_renderers import _render_items_list_page
+
+    # Locked: one distinctive substring per state's explainer.
+    # Edit this dict when intentionally changing copy; CI flags
+    # accidental drift.
+    expected_phrases = {
+        "Received": "intake but no extraction",
+        "Extracted": "candidates waiting for promotion",
+        "Accepted": "canonical artifact in the vault",
+        "Synthesized": "fresh community crystal",
+        "NeedsAction": "failures, open contradictions",
+    }
+
+    for state, phrase in expected_phrases.items():
         payload = {
             "screen": "ops/items",
             "available": True,
@@ -125,8 +137,8 @@ def test_ops_items_state_explainers_cover_every_state():
             "prev_offset": None,
         }
         html = _render_items_list_page(payload)
-        assert state in html, (
-            f"/ops/items renderer does not name the state {state!r}"
+        assert phrase in html, (
+            f"/ops/items renderer missing the {state!r} explainer " f"phrase {phrase!r}"
         )
 
 
@@ -141,8 +153,11 @@ def test_state_labels_are_not_used_as_event_categories():
     from ovp_pipeline.event_evidence_registry import CATEGORIES
 
     state_labels = {
-        "Received", "Extracted", "Accepted",
-        "Synthesized", "NeedsAction",
+        "Received",
+        "Extracted",
+        "Accepted",
+        "Synthesized",
+        "NeedsAction",
     }
     leaked = state_labels & set(CATEGORIES)
     assert not leaked, (

--- a/tests/test_m25_vocabulary_alignment.py
+++ b/tests/test_m25_vocabulary_alignment.py
@@ -1,0 +1,151 @@
+"""Tests for M25.5 vocabulary alignment.
+
+M25 locked the five visible Maintainer states (Received,
+Extracted, Accepted, Synthesized, Needs Action) as the card
+vocabulary.  The underlying *evidence categories* (intake,
+absorb, synthesis, governance, failures) stay in the registry —
+those are classifications, not labels.
+
+These tests prevent vocabulary drift between the cards (state
+labels) and the supporting surfaces (digest body, /digests
+calendar legend, /ops/items page headings, etc.).  A future PR
+that renames a state label without updating the supporting
+surfaces — or that misuses an evidence-category word as a
+state-card label — fails CI loudly.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+# ── State-label vocabulary lock ──────────────────────────────────
+
+
+def test_m25_card_def_ids_use_the_five_locked_states():
+    """The card definition list must enumerate exactly the five
+    visible Maintainer states.  Adding a sixth (or renaming one)
+    requires updating ``docs/operational-lifecycle.md`` and this
+    test together."""
+    from ovp_pipeline.ui.view_models import M25_LIFECYCLE_CARD_DEFS
+
+    ids = [c["id"] for c in M25_LIFECYCLE_CARD_DEFS]
+    assert ids == [
+        "Received", "Extracted", "Accepted",
+        "Synthesized", "NeedsAction",
+    ]
+
+
+def test_m25_card_def_labels_match_operational_lifecycle_doc():
+    """Card labels are what the operator reads on the dashboard.
+    Locked: ``Received / Extracted / Accepted / Synthesized /
+    Needs Action`` (note the space in "Needs Action" — UI label,
+    not the kernel's ``NeedsAction`` enum)."""
+    from ovp_pipeline.ui.view_models import M25_LIFECYCLE_CARD_DEFS
+
+    labels = {c["id"]: c["label"] for c in M25_LIFECYCLE_CARD_DEFS}
+    assert labels["Received"] == "Received"
+    assert labels["Extracted"] == "Extracted"
+    assert labels["Accepted"] == "Accepted"
+    assert labels["Synthesized"] == "Synthesized"
+    # The kernel enum has no space; the display label does.
+    assert labels["NeedsAction"] == "Needs Action"
+
+
+# ── Per-state secondary verbs ────────────────────────────────────
+
+
+def test_per_state_secondary_verbs_locked():
+    """The per-state phrasing ("arrived today", "extracted today",
+    etc.) is what differentiates the M25 hybrid card from the
+    forbidden "+5 today" framing.  Lock the wording so future
+    edits stay deliberate."""
+    from ovp_pipeline.ui.view_models import M25_LIFECYCLE_CARD_DEFS
+
+    verbs = {c["id"]: c.get("secondary_verb", "") for c in M25_LIFECYCLE_CARD_DEFS}
+    assert verbs["Received"] == "arrived today"
+    assert verbs["Extracted"] == "extracted today"
+    assert verbs["Accepted"] == "accepted today"
+    assert verbs["Synthesized"] == "synthesized today"
+    assert verbs["NeedsAction"] == "new blockers today"
+
+
+# ── Surface-level alignment ──────────────────────────────────────
+
+
+def test_digests_calendar_legend_uses_audit_evidence_phrase():
+    """M24.3 changed the calendar's em-dash gloss from the
+    misleading "quiet day" to the honest "no audit evidence" with
+    the three-cause ambiguity.  M25 keeps this — regression guard
+    that the legend doesn't get reduced back to "quiet day"."""
+    from pathlib import Path
+    from ovp_pipeline.commands._digests_list_page import (
+        _render_calendar_grid,
+        CalendarCell,
+    )
+
+    cells = [
+        CalendarCell(
+            date="2026-05-13",
+            has_digest=False,
+            intake_count=0,
+            digest_href="",
+            explore_href="/ops/today?date=2026-05-13",
+        ),
+    ]
+    html = _render_calendar_grid(cells)
+    assert "no audit evidence" in html
+    # The three causes the honest-zero principle names.
+    for cause in ("not run", "no output", "missing instrumentation"):
+        assert cause in html
+
+
+def test_ops_items_state_explainers_cover_every_state():
+    """The /ops/items renderer prints a state-specific explainer
+    paragraph below the H1.  Every state in M25_LIFECYCLE_CARD_DEFS
+    must have copy."""
+    from ovp_pipeline.commands._ui_renderers import _render_items_list_page
+    from ovp_pipeline.ui.view_models import M25_LIFECYCLE_CARD_DEFS
+
+    for card in M25_LIFECYCLE_CARD_DEFS:
+        state = card["id"]
+        # Render the empty-state page for this state — explainer
+        # appears regardless of whether there are rows.
+        payload = {
+            "screen": "ops/items",
+            "available": True,
+            "state": state,
+            "pack": "research-tech",
+            "requested_pack": "",
+            "rows": [],
+            "total": 0,
+            "offset": 0,
+            "limit": 50,
+            "next_offset": None,
+            "prev_offset": None,
+        }
+        html = _render_items_list_page(payload)
+        assert state in html, (
+            f"/ops/items renderer does not name the state {state!r}"
+        )
+
+
+# ── Anti-regression: no state label leakage as event category ────
+
+
+def test_state_labels_are_not_used_as_event_categories():
+    """The five state labels (Received / Extracted / Accepted /
+    Synthesized / NeedsAction) must NOT appear as event_evidence
+    categories.  Categories stay at intake / absorb / synthesis /
+    governance / failures."""
+    from ovp_pipeline.event_evidence_registry import CATEGORIES
+
+    state_labels = {
+        "Received", "Extracted", "Accepted",
+        "Synthesized", "NeedsAction",
+    }
+    leaked = state_labels & set(CATEGORIES)
+    assert not leaked, (
+        f"State labels leaked into registry categories: {leaked}.  "
+        "Categories are evidence classifications, not state names."
+    )


### PR DESCRIPTION
## Summary

Lock the M25 vocabulary so future PRs can't drift away from the M25 plan's locks. Closes M25.5 — the final stage of the Maintainer Control Plane rewrite.

**What ships:**
- `tests/test_m25_vocabulary_alignment.py` — 6 regression tests:
  - Card IDs are exactly the five visible states.
  - Card labels match `docs/operational-lifecycle.md` (note the space in "Needs Action" UI label vs the `NeedsAction` enum).
  - Per-state secondary verbs locked ("arrived today" / "extracted today" / etc.). Forbids the rejected "+5 today" framing.
  - `/digests` calendar legend still uses the M24.3 honest-zero phrasing.
  - `/ops/items` renderer names every state in its explainer block.
  - State labels don't leak into `event_evidence_registry` categories.
- Stale comment fix in `_digests_list_page.py` (referenced an "Intake card" that was renamed in M25.3).

No operator-visible changes beyond the comment fix.

**M25 complete:**
- #235 — plan doc
- #236 — `/ops/items`
- #237 + #238 — `/ops/today` hybrid cards
- #239 — `/ops/events/audit` + reciprocal banners
- this PR — vocabulary lock

## Test plan

- [x] pytest tests/test_m25_vocabulary_alignment.py — 6/6 pass.
- [x] Full suite — 2926 passed, 0 regressions.

Refs `docs/plans/2026-05-14-m25-maintainer-control-plane.md` §M25.5.