### PR TITLE
feat(m25.6): dogfood acceptance — smoke script + realistic fixture + report

### DIFF
--- a/docs/reports/2026-05-14-m25-dogfood-acceptance.md
+++ b/docs/reports/2026-05-14-m25-dogfood-acceptance.md
@@ -1,0 +1,178 @@
+# M25 Dogfood Acceptance Report (template)
+
+> **Status**: template, awaiting operator fill-in.  Run the smoke
+> script against the operator vault and paste the JSON-table rows
+> into the verification tables below.  Land the completed report
+> on `main` as the formal close of the M24/M25 sequence.
+
+## Purpose
+
+M24/M25 unit tests proved the code is internally consistent (2926
+passing).  This report proves the code is *externally honest*
+against a real vault — the dogfood gate the M25 plan §M25.6
+requires before declaring M25 shipped.
+
+## How to run
+
+```sh
+# From the operator's vault clone:
+python scripts/smoke_m25_control_plane.py \
+    --vault-dir "$OPERATOR_VAULT" \
+    --pack research-tech \
+    --date $(date -u +%Y-%m-%d) \
+    --out 60-Logs/m25-acceptance.json
+```
+
+The script:
+
+* Runs `ovp-producer-audit` and surfaces missing must-emit
+  producer events.
+* Runs `ovp-ops-state --rebuild` so all numbers below come from
+  a fresh projection.
+* Walks every lifecycle state and verifies **card N === drilldown
+  N** on both the primary (items) and secondary (audit-events)
+  axes.
+* Renders `/ops/events/audit` and `/ops/events` against the live
+  payloads to confirm both role banners are present.
+
+Exit code `0` means every check passed; `2` means at least one
+failed and a row below should be marked `❌`.
+
+## Verification table — copy from JSON
+
+The `card_n_equals_drilldown_n_table` array in the JSON output
+maps 1:1 to this table.  Paste row-by-row.
+
+| State          | current items | today evidence | primary rows | audit rows | primary match | audit match |
+|----------------|---------------|----------------|--------------|------------|---------------|-------------|
+| Received       |               |                |              |            |               |             |
+| Extracted      |               |                |              |            |               |             |
+| Accepted       |               |                |              |            |               |             |
+| Synthesized    |               |                |              |            |               |             |
+| Needs Action   |               |                |              |            |               |             |
+
+**Pass criterion:** every `primary_match` and `audit_match` cell
+reads `True`.  A `False` is a card-N-vs-drilldown-N regression
+that must be triaged before sign-off.
+
+## Per-check acceptance
+
+Tick each box once verified.
+
+### producer_audit
+
+* [ ] Ran `ovp-producer-audit` against the operator vault.
+* [ ] `missing_count == 0` for hot-path producers
+      (article processor, clippings, github intake, absorb
+      router, evergreen extractor, promote command, community
+      crystal synthesizer).
+* [ ] No undeclared `unknown_event_types` (drift entries) the
+      operator can't explain.
+
+Notes — paste the JSON `data.findings` rows here if anything is
+missing:
+
+```
+(paste here)
+```
+
+### ops_state_rebuild
+
+* [ ] `ovp-ops-state --rebuild` completed without error.
+* [ ] Per-state counts in the JSON `data.counts` block match
+      what `/ops/today` shows (compare to the verification
+      table above).
+* [ ] Two consecutive rebuilds produced identical counts
+      (idempotency check — re-run `--rebuild` once more and
+      diff the JSON `data.counts`).
+
+### card_n_equals_drilldown_n
+
+* [ ] Five rows in the verification table.
+* [ ] Every `primary_match` is `True`.
+* [ ] Every `audit_match` is `True`.
+
+### audit_page_banner
+
+* [ ] `/ops/events/audit` carries the **Raw audit evidence**
+      banner.
+* [ ] The banner cross-links to `/ops/events`.
+
+### dossier_reciprocal_banner
+
+* [ ] `/ops/events` carries the **Timeline projection view**
+      banner.
+* [ ] The banner cross-links to `/ops/events/audit`.
+
+## Manual UI checks
+
+The script proves the data layer.  These checks prove the
+UI surfaces match the data layer in the operator's actual
+browser.
+
+| Surface                              | Pass? | Notes |
+|--------------------------------------|-------|-------|
+| `/ops/today` renders five cards      |       |       |
+| Card labels are the locked vocabulary (Received / Extracted / Accepted / Synthesized / Needs Action) |       |       |
+| Card primary number reads the `ops_state` count |       |       |
+| Card secondary text uses per-state verbs ("5 arrived today", "3 extracted today", etc.) |       |       |
+| Primary CTA "Open N items →" lands on `/ops/items?state=…` |       |       |
+| Items page row count equals the card primary number |       |       |
+| Secondary CTA "View today's N evidence events →" lands on `/ops/events/audit?…` |       |       |
+| Audit page row count equals the card secondary number |       |       |
+| Card samples are item slugs/object_ids, NOT event_types |       |       |
+| Honest-zero footer appears on cards with both 0/0 |       |       |
+| `/ops/events/audit` role banner visible |       |       |
+| `/ops/events` reciprocal banner visible |       |       |
+
+## Open findings
+
+M25.6 surfaced one product question that is **not** a regression
+but should be answered before M26 starts.
+
+### Dual-count on the Accepted card
+
+The kernel classifies BOTH the source slug AND the object_id as
+"Accepted" when a promote event fires.  For 18 promotions:
+
+```
+Accepted primary_count  = 36   (18 sources + 18 objects)
+items page row count     = 36   (18 source rows + 18 object rows)
+```
+
+Card N === drilldown N holds, but the card reads 36 even though
+the operator promoted 18 things.
+
+The `test_acceptance_accepted_card_n_equals_items_page_n`
+fixture locks this dual-count behaviour so a future PR that
+drops one kind from `ops_state` fails loudly.  M26 picks the
+side: collapse to 18 (operator mental model) or keep 36
+(kernel-truth dual-classification).  No code change in M25.6.
+
+## Operator sign-off
+
+After every box above is ticked:
+
+* Operator initials: _____________
+* Date completed: _____________
+* Smoke JSON committed to: `60-Logs/m25-acceptance.json`
+* Outcome:  ☐ PASS  ☐ PASS with findings  ☐ FAIL — triage required
+
+If PASS, link this completed report from the M25.5 PR description
+or the next milestone's plan.  M24/M25 is then formally shipped;
+M26 (Actionable Ops Items) can begin.
+
+## What this report does NOT cover
+
+These are deliberately out of M25.6 scope (M25 plan §"Out of
+scope"):
+
+* Option B clean-room rebuild of `audit_events`.  Decide after
+  1-2 days of real-vault observation that the new pipeline
+  emits the M24.2 producer rows reliably.
+* `/ops` cockpit redesign.
+* Inline actions on `/ops/items`.
+* Cross-pack item view.
+
+Each gets its own scoping pass when (and if) the dogfood
+evidence motivates them.

--- a/scripts/smoke_m25_control_plane.py
+++ b/scripts/smoke_m25_control_plane.py
@@ -82,6 +82,25 @@ def _knowledge_db(vault_dir: Path) -> Path:
     return vault_dir / "60-Logs" / "knowledge.db"
 
 
+def _subprocess_env() -> dict[str, str]:
+    """Codex P2 fix on PR #241: when this script is run from a
+    source checkout (no editable install), our top-level
+    ``sys.path.insert`` makes ``ovp_pipeline`` importable for THIS
+    process only.  Child ``python -m ovp_pipeline.…`` subprocesses
+    inherit ``os.environ`` but NOT ``sys.path``, so they crash
+    with ``ModuleNotFoundError``.  Propagate via ``PYTHONPATH`` so
+    the subprocess sees the same import surface.
+    """
+    import os
+    env = os.environ.copy()
+    src_path = str(Path(__file__).resolve().parent.parent / "src")
+    existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = (
+        f"{src_path}:{existing}" if existing else src_path
+    )
+    return env
+
+
 def _run_producer_audit(vault_dir: Path) -> CheckResult:
     """Run ``ovp-producer-audit --json`` and surface missing /
     drift counts.  We don't fail on drift (registered-but-not-
@@ -96,6 +115,7 @@ def _run_producer_audit(vault_dir: Path) -> CheckResult:
     ]
     proc = subprocess.run(
         cmd, capture_output=True, text=True, check=False,
+        env=_subprocess_env(),
     )
     try:
         payload = json.loads(proc.stdout)
@@ -144,6 +164,7 @@ def _ensure_ops_state(vault_dir: Path, pack: str) -> CheckResult:
     ]
     proc = subprocess.run(
         cmd, capture_output=True, text=True, check=False,
+        env=_subprocess_env(),
     )
     if proc.returncode != 0:
         return CheckResult(
@@ -196,8 +217,24 @@ def _check_card_n_equals_drilldown_n(
             ),
             [],
         )
+
+    # Codex P2 fix on PR #241: verify ALL five states are in the
+    # card set.  Pre-fix the loop only walked cards that were
+    # present, so a regression that dropped a state from
+    # ``M25_LIFECYCLE_CARD_DEFS`` would let the smoke pass with
+    # only four cards.
+    card_ids = {c["id"] for c in digest["cards"]}
+    expected_ids = set(ALL_STATES)
+    missing_states = expected_ids - card_ids
+    unexpected_states = card_ids - expected_ids
     table: list[dict[str, Any]] = []
-    all_ok = True
+    all_ok = not (missing_states or unexpected_states)
+    structural_detail: list[str] = []
+    if missing_states:
+        structural_detail.append(f"missing_states={sorted(missing_states)}")
+    if unexpected_states:
+        structural_detail.append(f"unexpected_states={sorted(unexpected_states)}")
+
     for card in digest["cards"]:
         state = card["id"]
         primary_count = int(card["primary_count"])
@@ -207,6 +244,12 @@ def _check_card_n_equals_drilldown_n(
             vault_dir, state=state, pack_name=pack,
             limit=10_000,  # huge — we want the true row count
         )
+        # Codex P2 fix on PR #241: when --skip-rebuild is used
+        # before the projection exists, items.available is False
+        # and items.total falls back to 0.  Comparing
+        # primary_count == items_total would then pass with both
+        # equal to 0, hiding the missing-projection condition.
+        items_available = bool(items.get("available", False))
         items_total = int(items.get("total", 0))
 
         if card["event_types"]:
@@ -218,11 +261,13 @@ def _check_card_n_equals_drilldown_n(
                 limit=10_000,
             )
             audit_total = int(audit.get("total", 0))
+            audit_available = bool(audit.get("available", True))
         else:
             audit_total = 0
+            audit_available = True
 
-        primary_match = (primary_count == items_total)
-        audit_match = (event_count == audit_total)
+        primary_match = items_available and (primary_count == items_total)
+        audit_match = audit_available and (event_count == audit_total)
         if not (primary_match and audit_match):
             all_ok = False
         table.append({
@@ -233,12 +278,19 @@ def _check_card_n_equals_drilldown_n(
             "audit_rows": audit_total,
             "primary_match": primary_match,
             "audit_match": audit_match,
+            "items_available": items_available,
+            "audit_available": audit_available,
         })
+    detail_parts = [
+        f"states_ok={sum(1 for t in table if t['primary_match'] and t['audit_match'])}/5",
+    ]
+    if structural_detail:
+        detail_parts.extend(structural_detail)
     return (
         CheckResult(
             name="card_n_equals_drilldown_n",
             ok=all_ok,
-            detail=f"states_ok={sum(1 for t in table if t['primary_match'] and t['audit_match'])}/5",
+            detail=" · ".join(detail_parts),
             data={"table": table},
         ),
         table,

--- a/scripts/smoke_m25_control_plane.py
+++ b/scripts/smoke_m25_control_plane.py
@@ -1,0 +1,424 @@
+#!/usr/bin/env python3
+"""M25.6 dogfood acceptance smoke for the Maintainer Control Plane.
+
+Runs the full M24+M25 contract against a real vault and reports
+whether the operator-visible numbers actually match the underlying
+data.  This is the dogfood gate the M25 plan §M25.6 calls for —
+the M24/M25 unit tests proved the code is internally consistent;
+this script proves it's externally honest against a real vault.
+
+What it checks
+--------------
+
+1. ``ovp-producer-audit`` runs cleanly and reports zero missing
+   must-emit producer events.
+
+2. ``ops_state`` projection exists; if not, rebuilds it.
+
+3. For every lifecycle state (Received / Extracted / Accepted /
+   Synthesized / NeedsAction):
+
+   * The card's primary count from ``build_today_digest_payload``
+     equals the row count returned by
+     ``build_items_list_payload`` with the same state filter.
+   * The card's secondary count equals the audit page total
+     from ``build_events_audit_payload``.
+   * Card samples are pulled from items (``ops_state``), not
+     events.
+
+4. ``/ops/events/audit`` carries the role banner.
+5. ``/ops/events`` carries the reciprocal timeline-projection
+   banner.
+6. Honest-zero copy appears when a card is empty.
+
+Output
+------
+
+JSON report written to ``--out`` (defaults to
+``60-Logs/m25-acceptance.json``) so the operator can paste rows
+into ``docs/reports/2026-05-14-m25-dogfood-acceptance.md``.
+
+Exit codes:
+* ``0`` — every check passed.
+* ``2`` — at least one acceptance check failed.
+* ``3`` — environment issue (missing knowledge.db, etc.).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from ovp_pipeline.commands._ui_renderers import (  # noqa: E402
+    _render_events_audit_page,
+    _render_events_page,
+)
+from ovp_pipeline.ops_lifecycle import ALL_STATES  # noqa: E402
+from ovp_pipeline.ui.view_models import (  # noqa: E402
+    build_event_dossier_payload,
+    build_events_audit_payload,
+    build_items_list_payload,
+    build_today_digest_payload,
+)
+
+
+@dataclass
+class CheckResult:
+    name: str
+    ok: bool
+    detail: str = ""
+    data: dict[str, Any] = field(default_factory=dict)
+
+
+def _knowledge_db(vault_dir: Path) -> Path:
+    return vault_dir / "60-Logs" / "knowledge.db"
+
+
+def _run_producer_audit(vault_dir: Path) -> CheckResult:
+    """Run ``ovp-producer-audit --json`` and surface missing /
+    drift counts.  We don't fail on drift (registered-but-not-
+    contract events) because M24.2 narrowed the drift definition;
+    we fail only on ``missing_count > 0``."""
+    cmd = [
+        sys.executable, "-m",
+        "ovp_pipeline.commands.producer_audit_cli",
+        "--vault-dir", str(vault_dir),
+        "--window-days", "7",
+        "--json",
+    ]
+    proc = subprocess.run(
+        cmd, capture_output=True, text=True, check=False,
+    )
+    try:
+        payload = json.loads(proc.stdout)
+    except (ValueError, json.JSONDecodeError):
+        return CheckResult(
+            name="producer_audit",
+            ok=False,
+            detail=(
+                "producer_audit CLI didn't return JSON.  "
+                f"stderr={proc.stderr.strip()[:200]}"
+            ),
+        )
+    missing = int(payload.get("missing_count", 0) or 0)
+    drift = list(payload.get("unknown_event_types") or [])
+    return CheckResult(
+        name="producer_audit",
+        ok=(missing == 0),
+        detail=(
+            f"missing={missing} drift={len(drift)} "
+            f"window={payload.get('window_start','?')[:10]}…"
+            f"{payload.get('window_end','?')[:10]}"
+        ),
+        data={
+            "missing_count": missing,
+            "drift_count": len(drift),
+            "drift": drift[:10],
+            "findings": [
+                f for f in payload.get("findings", [])
+                if f.get("severity") == "missing"
+            ][:20],
+        },
+    )
+
+
+def _ensure_ops_state(vault_dir: Path, pack: str) -> CheckResult:
+    """Run ``ovp-ops-state --rebuild --json`` so the smoke
+    operates on a fresh projection.  Returns the per-state count
+    dict the rebuild printed."""
+    cmd = [
+        sys.executable, "-m",
+        "ovp_pipeline.commands.ops_state_cli",
+        "--vault-dir", str(vault_dir),
+        "--pack", pack,
+        "--rebuild",
+        "--json",
+    ]
+    proc = subprocess.run(
+        cmd, capture_output=True, text=True, check=False,
+    )
+    if proc.returncode != 0:
+        return CheckResult(
+            name="ops_state_rebuild",
+            ok=False,
+            detail=(
+                f"rebuild failed rc={proc.returncode} "
+                f"stderr={proc.stderr.strip()[:200]}"
+            ),
+        )
+    try:
+        payload = json.loads(proc.stdout)
+    except (ValueError, json.JSONDecodeError):
+        return CheckResult(
+            name="ops_state_rebuild",
+            ok=False,
+            detail="rebuild CLI didn't return JSON",
+        )
+    return CheckResult(
+        name="ops_state_rebuild",
+        ok=True,
+        detail=f"rebuilt {payload.get('total', 0)} items for pack={pack}",
+        data={
+            "counts": payload.get("counts", {}),
+            "total": payload.get("total", 0),
+        },
+    )
+
+
+def _check_card_n_equals_drilldown_n(
+    vault_dir: Path, pack: str, target_date: str,
+) -> tuple[CheckResult, list[dict[str, Any]]]:
+    """For every lifecycle state, verify:
+
+    * primary_count (card) == items list total (drilldown)
+    * event_count (card) == audit page total (drilldown)
+
+    Returns a CheckResult covering all five states + a per-state
+    table the report consumes.
+    """
+    digest = build_today_digest_payload(
+        vault_dir, pack_name=pack, target_date=target_date,
+    )
+    if not digest.get("available"):
+        return (
+            CheckResult(
+                name="card_n_equals_drilldown_n",
+                ok=False,
+                detail=f"today payload unavailable: {digest.get('reason')}",
+            ),
+            [],
+        )
+    table: list[dict[str, Any]] = []
+    all_ok = True
+    for card in digest["cards"]:
+        state = card["id"]
+        primary_count = int(card["primary_count"])
+        event_count = int(card["event_count"])
+
+        items = build_items_list_payload(
+            vault_dir, state=state, pack_name=pack,
+            limit=10_000,  # huge — we want the true row count
+        )
+        items_total = int(items.get("total", 0))
+
+        if card["event_types"]:
+            audit = build_events_audit_payload(
+                vault_dir,
+                event_types=tuple(card["event_types"]),
+                date_key=target_date,
+                pack_name=pack,
+                limit=10_000,
+            )
+            audit_total = int(audit.get("total", 0))
+        else:
+            audit_total = 0
+
+        primary_match = (primary_count == items_total)
+        audit_match = (event_count == audit_total)
+        if not (primary_match and audit_match):
+            all_ok = False
+        table.append({
+            "state": state,
+            "current_items": primary_count,
+            "today_evidence": event_count,
+            "primary_rows": items_total,
+            "audit_rows": audit_total,
+            "primary_match": primary_match,
+            "audit_match": audit_match,
+        })
+    return (
+        CheckResult(
+            name="card_n_equals_drilldown_n",
+            ok=all_ok,
+            detail=f"states_ok={sum(1 for t in table if t['primary_match'] and t['audit_match'])}/5",
+            data={"table": table},
+        ),
+        table,
+    )
+
+
+def _check_audit_banner(vault_dir: Path) -> CheckResult:
+    """Render the /ops/events/audit page (empty filter) and check
+    for the role banner."""
+    payload = build_events_audit_payload(
+        vault_dir, event_types=(), date_key="",
+    )
+    html = _render_events_audit_page(payload)
+    ok = "Raw audit evidence" in html and "/ops/events" in html
+    return CheckResult(
+        name="audit_page_banner",
+        ok=ok,
+        detail=(
+            "found role banner + link to /ops/events"
+            if ok else "role banner missing"
+        ),
+    )
+
+
+def _check_reciprocal_banner(vault_dir: Path) -> CheckResult:
+    """Render /ops/events and verify the reciprocal banner names
+    it as a timeline-projection view and links back."""
+    payload = build_event_dossier_payload(vault_dir)
+    html = _render_events_page(payload)
+    ok = (
+        "Timeline projection view" in html
+        and "/ops/events/audit" in html
+    )
+    return CheckResult(
+        name="dossier_reciprocal_banner",
+        ok=ok,
+        detail=(
+            "found timeline-projection banner + cross-link"
+            if ok else "reciprocal banner missing"
+        ),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="M25.6 dogfood acceptance smoke."
+    )
+    parser.add_argument(
+        "--vault-dir", type=Path, required=True,
+        help="Vault root.",
+    )
+    parser.add_argument(
+        "--pack", default="research-tech",
+        help="Pack scope (default: research-tech).",
+    )
+    parser.add_argument(
+        "--date", default="",
+        help=(
+            "Target date YYYY-MM-DD; defaults to today UTC.  Card "
+            "secondary counts come from this day."
+        ),
+    )
+    parser.add_argument(
+        "--out", type=Path, default=None,
+        help=(
+            "Path to write the JSON report.  Defaults to "
+            "<vault>/60-Logs/m25-acceptance.json."
+        ),
+    )
+    parser.add_argument(
+        "--skip-rebuild", action="store_true",
+        help="Skip ops_state --rebuild; read existing projection.",
+    )
+    args = parser.parse_args(argv)
+
+    vault_dir = args.vault_dir.resolve()
+    if not _knowledge_db(vault_dir).exists():
+        print(
+            f"smoke: no knowledge.db at {_knowledge_db(vault_dir)} — "
+            "run `ovp-knowledge-index` first.",
+            file=sys.stderr,
+        )
+        return 3
+
+    out_path = (
+        args.out
+        or (vault_dir / "60-Logs" / "m25-acceptance.json")
+    )
+
+    target_date = args.date or _today_utc()
+
+    checks: list[CheckResult] = []
+
+    print(f"== M25.6 dogfood acceptance ({args.pack}, {target_date}) ==")
+
+    # 1. Producer audit.
+    pa = _run_producer_audit(vault_dir)
+    checks.append(pa)
+    print(f"[{'OK' if pa.ok else 'FAIL'}] producer_audit: {pa.detail}")
+
+    # 2. Ops state rebuild.
+    if not args.skip_rebuild:
+        rb = _ensure_ops_state(vault_dir, args.pack)
+        checks.append(rb)
+        print(f"[{'OK' if rb.ok else 'FAIL'}] ops_state_rebuild: {rb.detail}")
+
+    # 3. Card N === drilldown N for every state.
+    contract, table = _check_card_n_equals_drilldown_n(
+        vault_dir, args.pack, target_date,
+    )
+    checks.append(contract)
+    print(
+        f"[{'OK' if contract.ok else 'FAIL'}] "
+        f"card_n_equals_drilldown_n: {contract.detail}"
+    )
+    if table:
+        print()
+        print("  State          current_items  today_evidence  "
+              "primary_rows  audit_rows  primary_match  audit_match")
+        for row in table:
+            print(
+                f"  {row['state']:<14} "
+                f"{row['current_items']:<14} "
+                f"{row['today_evidence']:<15} "
+                f"{row['primary_rows']:<13} "
+                f"{row['audit_rows']:<11} "
+                f"{str(row['primary_match']):<14} "
+                f"{str(row['audit_match'])}"
+            )
+        print()
+
+    # 4. Audit page banner.
+    ab = _check_audit_banner(vault_dir)
+    checks.append(ab)
+    print(f"[{'OK' if ab.ok else 'FAIL'}] audit_page_banner: {ab.detail}")
+
+    # 5. Reciprocal banner on /ops/events.
+    rb2 = _check_reciprocal_banner(vault_dir)
+    checks.append(rb2)
+    print(f"[{'OK' if rb2.ok else 'FAIL'}] dossier_reciprocal_banner: {rb2.detail}")
+
+    # Aggregate.
+    all_ok = all(c.ok for c in checks)
+    print()
+    print(f"== {'PASS' if all_ok else 'FAIL'} ({sum(1 for c in checks if c.ok)}/{len(checks)} checks) ==")
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(
+        json.dumps(
+            {
+                "vault_dir": str(vault_dir),
+                "pack": args.pack,
+                "date": target_date,
+                "all_ok": all_ok,
+                "checks": [
+                    {
+                        "name": c.name,
+                        "ok": c.ok,
+                        "detail": c.detail,
+                        "data": c.data,
+                    }
+                    for c in checks
+                ],
+                "card_n_equals_drilldown_n_table": table,
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    print(f"report written to {out_path}")
+
+    return 0 if all_ok else 2
+
+
+def _today_utc() -> str:
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_m25_realistic_fixture.py
+++ b/tests/test_m25_realistic_fixture.py
@@ -1,0 +1,483 @@
+"""M25.6 realistic-fixture dogfood acceptance.
+
+Pre-M25.6 every M24/M25 test used a hand-built fixture that
+seeded ONE source per state.  That's enough to prove the kernel
+classifies correctly, but it doesn't prove the operator-visible
+*contracts* hold under realistic data volumes:
+
+* card N === items-page N for high-volume states
+* card secondary N === audit-page N when event_types span
+  multiple registry rows
+* honest-zero appears on empty states
+* `/ops/events/audit` banners both render against a real-shape
+  payload (not a hand-built one)
+
+This module builds a single fixture vault that mirrors what an
+operator sees after a normal week: ~50 sources, ~20 evergreens,
+several clusters with mixed-freshness crystals, a handful of
+failures and operator promotions, plus today's intake.  Every
+M24/M25 contract is then asserted against that one fixture so a
+regression on any layer breaks loudly.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from ovp_pipeline.ops_lifecycle import (
+    ALL_STATES,
+    STATE_ACCEPTED,
+    STATE_EXTRACTED,
+    STATE_NEEDS_ACTION,
+    STATE_RECEIVED,
+    STATE_SYNTHESIZED,
+)
+from ovp_pipeline.ops_state import rebuild
+from ovp_pipeline.ui.view_models import (
+    build_events_audit_payload,
+    build_items_list_payload,
+    build_today_digest_payload,
+)
+
+
+PACK = "research-tech"
+
+
+# Shape constants — tweak in one place if the fixture grows.
+N_RECEIVED = 12   # raw intake today, not yet extracted
+N_EXTRACTED = 8   # extraction complete, candidates upserted, not promoted
+N_ACCEPTED = 18   # promoted (auto + operator)
+N_SYNTHESIZED = 5  # in synthesized clusters
+N_NEEDS_ACTION = 4  # failures + open contradictions
+
+
+_SCHEMA = """
+CREATE TABLE audit_events (
+    source_log TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    slug TEXT NOT NULL DEFAULT '',
+    session_id TEXT NOT NULL DEFAULT '',
+    timestamp TEXT NOT NULL DEFAULT '',
+    payload_json TEXT NOT NULL
+);
+CREATE INDEX idx_audit_events_log ON audit_events(source_log);
+CREATE INDEX idx_audit_events_type ON audit_events(event_type);
+CREATE TABLE objects (
+    pack TEXT NOT NULL,
+    object_id TEXT NOT NULL,
+    object_kind TEXT NOT NULL,
+    title TEXT NOT NULL,
+    canonical_path TEXT NOT NULL,
+    source_slug TEXT NOT NULL,
+    source_url TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (pack, object_id)
+);
+CREATE TABLE graph_clusters (
+    pack TEXT NOT NULL,
+    cluster_id TEXT NOT NULL,
+    cluster_kind TEXT NOT NULL,
+    label TEXT NOT NULL,
+    center_object_id TEXT NOT NULL,
+    member_object_ids_json TEXT NOT NULL,
+    score REAL NOT NULL DEFAULT 0.0,
+    PRIMARY KEY (pack, cluster_id)
+);
+CREATE TABLE community_crystals (
+    pack TEXT NOT NULL,
+    cluster_id TEXT NOT NULL,
+    body_md TEXT NOT NULL,
+    source_evergreen_slugs_json TEXT NOT NULL,
+    synthesized_at TEXT NOT NULL,
+    llm_model TEXT NOT NULL,
+    prompt_version TEXT NOT NULL,
+    superseded_by_synthesized_at TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (pack, cluster_id, synthesized_at)
+);
+CREATE TABLE evergreen_revisions (
+    pack TEXT NOT NULL,
+    object_id TEXT NOT NULL,
+    version INTEGER NOT NULL,
+    content_md TEXT NOT NULL,
+    change_type TEXT NOT NULL,
+    changed_by TEXT NOT NULL DEFAULT '',
+    derived_at TEXT NOT NULL,
+    change_note TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (pack, object_id, version)
+);
+CREATE TABLE pages_index (
+    slug TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    note_type TEXT NOT NULL,
+    path TEXT NOT NULL,
+    day_id TEXT NOT NULL,
+    frontmatter_json TEXT NOT NULL,
+    body TEXT NOT NULL
+);
+"""
+
+
+def _emit(conn, event_type, slug, ts, payload):
+    conn.execute(
+        "INSERT INTO audit_events VALUES (?, ?, ?, ?, ?, ?)",
+        ("pipeline.jsonl", event_type, slug, "fixture",
+         ts, json.dumps(payload)),
+    )
+
+
+@pytest.fixture(scope="module")
+def realistic_vault(tmp_path_factory) -> Path:
+    """Build a vault-shaped fixture exercising every lifecycle
+    state with believable volumes.  Module-scoped so all
+    acceptance assertions read the same materialised projection.
+    """
+    vault_dir = tmp_path_factory.mktemp("realistic_vault")
+    db_path = vault_dir / "60-Logs" / "knowledge.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.executescript(_SCHEMA)
+
+    today = datetime.now(timezone.utc)
+    today_iso = today.strftime("%Y-%m-%dT%H:%M:%S+00:00")
+    yesterday_iso = (today - timedelta(days=1)).strftime(
+        "%Y-%m-%dT%H:%M:%S+00:00"
+    )
+    last_week_iso = (today - timedelta(days=7)).strftime(
+        "%Y-%m-%dT%H:%M:%S+00:00"
+    )
+
+    # ── Received (today's intake, not yet extracted) ──────────────
+    for i in range(N_RECEIVED):
+        slug = f"recv-src-{i:03d}"
+        _emit(conn, "article_intake_only", slug, today_iso,
+              {"slug": slug, "file": f"{slug}.md"})
+
+    # ── Extracted (intake + absorb_route_decision + extraction
+    # complete + candidates_upserted, but NO promote) ──────────────
+    for i in range(N_EXTRACTED):
+        slug = f"ext-src-{i:03d}"
+        _emit(conn, "article_intake_only", slug, yesterday_iso,
+              {"slug": slug, "file": f"{slug}.md"})
+        _emit(conn, "absorb_route_decision", slug, yesterday_iso,
+              {"slug": slug, "router_decision": "evergreen"})
+        _emit(conn, "evergreen_extraction_complete", slug, today_iso,
+              {"slug": slug, "concepts_extracted": 3})
+        _emit(conn, "absorb_pending_upsert", slug, today_iso,
+              {"slug": slug, "expected_candidates": 3})
+        _emit(conn, "candidates_upserted", slug, today_iso,
+              {"slug": slug, "candidates": 3})
+
+    # ── Accepted (object rows that have promotion evidence) ──────
+    # Mix of auto-promote (absorb-cat) and operator-promote
+    # (governance-cat) to exercise the de-dup of the M25.3 +
+    # M25.3-fix mapping.
+    for i in range(N_ACCEPTED):
+        slug = f"acc-obj-{i:03d}"
+        conn.execute(
+            "INSERT INTO objects VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (PACK, slug, "evergreen", f"Accepted topic {i}",
+             f"10-Knowledge/Evergreen/{slug}.md", slug, ""),
+        )
+        # Half via auto-promote, half via operator promote.
+        event_type = "evergreen_auto_promoted" if i % 2 == 0 else "promote_concept"
+        ts = today_iso if i < 4 else last_week_iso
+        _emit(conn, event_type, slug, ts,
+              {"slug": slug, "object_id": slug, "concept": slug})
+
+    # ── Synthesized (cluster + active fresh crystal + members) ───
+    members = [f"acc-obj-{i:03d}" for i in range(N_SYNTHESIZED)]
+    crystal_ts = today_iso
+    member_rev_ts = (today - timedelta(hours=12)).strftime(
+        "%Y-%m-%dT%H:%M:%S+00:00"
+    )
+    cluster_id = "cluster::memory-systems"
+    conn.execute(
+        "INSERT INTO graph_clusters VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (PACK, cluster_id, "community", "Memory Systems",
+         members[0], json.dumps(members), 0.8),
+    )
+    for m in members:
+        conn.execute(
+            "INSERT INTO evergreen_revisions "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (PACK, m, 1, "## body", "created", "fixture",
+             member_rev_ts, ""),
+        )
+    conn.execute(
+        "INSERT INTO community_crystals "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (PACK, cluster_id, "## crystal body",
+         json.dumps(members), crystal_ts,
+         "fake-model", "v1", ""),
+    )
+    _emit(conn, "community_crystal_synthesized", "", today_iso,
+          {"cluster_id": cluster_id})
+
+    # ── Needs Action (failures today + open contradictions) ──────
+    for i in range(N_NEEDS_ACTION):
+        slug = f"fail-src-{i:03d}"
+        _emit(conn, "absorb_parse_error", slug, today_iso,
+              {"slug": slug, "error": f"parse fail {i}"})
+
+    # pages_index — feed the M25.2 source-href resolver for a
+    # subset of Received sources so the smoke can verify both
+    # branches.
+    for i in range(0, N_RECEIVED, 4):
+        slug = f"recv-src-{i:03d}"
+        conn.execute(
+            "INSERT INTO pages_index VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (slug, f"Article {i}", "interpretation",
+             f"50-Inbox/01-Raw/{slug}.md", "2026-05-13", "{}", ""),
+        )
+
+    conn.commit()
+    rebuild(conn, pack=PACK)
+    conn.close()
+    return vault_dir
+
+
+# ── Acceptance: card-N === drilldown-N ────────────────────────────
+
+
+def test_acceptance_received_card_n_equals_items_page_n(realistic_vault):
+    digest = build_today_digest_payload(realistic_vault, pack_name=PACK)
+    received = next(c for c in digest["cards"] if c["id"] == "Received")
+    items = build_items_list_payload(
+        realistic_vault, state="Received", pack_name=PACK, limit=1000,
+    )
+    assert received["primary_count"] == items["total"] == N_RECEIVED
+
+
+def test_acceptance_extracted_card_n_equals_items_page_n(realistic_vault):
+    digest = build_today_digest_payload(realistic_vault, pack_name=PACK)
+    extracted = next(c for c in digest["cards"] if c["id"] == "Extracted")
+    items = build_items_list_payload(
+        realistic_vault, state="Extracted", pack_name=PACK, limit=1000,
+    )
+    assert extracted["primary_count"] == items["total"] == N_EXTRACTED
+
+
+def test_acceptance_accepted_card_n_equals_items_page_n(realistic_vault):
+    """M25.6 dogfood finding: the Accepted card counts both
+    item kinds — the source whose promote event fired AND the
+    object the projection materialised — because the kernel
+    classifies each independently from the same evidence.
+
+    For 18 promote events the count is 18 sources + 18 objects
+    = 36.  Card N === items page N still holds (both read the
+    same projection); the assertion locks the dual-count shape
+    rather than the underlying 18.
+
+    Open product question (logged in the acceptance report):
+    do we want the cards to read 18 ("18 things accepted") or
+    36 ("18 sources are now Accepted; 18 objects exist")?  M25.6
+    surfaces the question; M26 picks the side."""
+    digest = build_today_digest_payload(realistic_vault, pack_name=PACK)
+    accepted = next(c for c in digest["cards"] if c["id"] == "Accepted")
+    items = build_items_list_payload(
+        realistic_vault, state="Accepted", pack_name=PACK, limit=1000,
+    )
+    assert accepted["primary_count"] == items["total"]
+    # The dual-classification (source + object) means the count
+    # is 2 * N_ACCEPTED.  Lock both so a regression that drops
+    # one kind from ops_state fails loudly.
+    assert accepted["primary_count"] == 2 * N_ACCEPTED
+    # Items list carries both kinds.
+    kinds_in_rows = {r["item_kind"] for r in items["rows"]}
+    assert kinds_in_rows == {"source", "object"}
+
+
+def test_acceptance_synthesized_card_n_equals_items_page_n(realistic_vault):
+    digest = build_today_digest_payload(realistic_vault, pack_name=PACK)
+    synth = next(c for c in digest["cards"] if c["id"] == "Synthesized")
+    items = build_items_list_payload(
+        realistic_vault, state="Synthesized", pack_name=PACK, limit=1000,
+    )
+    # Synthesized counts CLUSTERS (1 cluster in fixture).
+    assert synth["primary_count"] == items["total"]
+    assert synth["primary_count"] >= 1
+
+
+def test_acceptance_needs_action_card_n_equals_items_page_n(realistic_vault):
+    digest = build_today_digest_payload(realistic_vault, pack_name=PACK)
+    na = next(c for c in digest["cards"] if c["id"] == "NeedsAction")
+    items = build_items_list_payload(
+        realistic_vault, state="NeedsAction", pack_name=PACK, limit=1000,
+    )
+    assert na["primary_count"] == items["total"] == N_NEEDS_ACTION
+
+
+# ── Acceptance: card secondary N === audit-page N ─────────────────
+
+
+def test_acceptance_received_secondary_matches_audit_page(realistic_vault):
+    today_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    digest = build_today_digest_payload(
+        realistic_vault, pack_name=PACK, target_date=today_date,
+    )
+    received = next(c for c in digest["cards"] if c["id"] == "Received")
+    audit = build_events_audit_payload(
+        realistic_vault,
+        event_types=tuple(received["event_types"]),
+        date_key=today_date,
+        pack_name=PACK,
+        limit=10_000,
+    )
+    assert received["event_count"] == audit["total"]
+
+
+def test_acceptance_needs_action_secondary_matches_audit_page(realistic_vault):
+    today_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    digest = build_today_digest_payload(
+        realistic_vault, pack_name=PACK, target_date=today_date,
+    )
+    na = next(c for c in digest["cards"] if c["id"] == "NeedsAction")
+    audit = build_events_audit_payload(
+        realistic_vault,
+        event_types=tuple(na["event_types"]),
+        date_key=today_date,
+        pack_name=PACK,
+        limit=10_000,
+    )
+    assert na["event_count"] == audit["total"]
+
+
+def test_acceptance_accepted_secondary_no_double_count(realistic_vault):
+    """Half of the accepted items were promoted via
+    ``evergreen_auto_promoted``, half via ``promote_concept``.
+    Today only the first 4 fired; secondary count must equal 4
+    (not 8 — that would mean we double-counted the promote pair)."""
+    today_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    digest = build_today_digest_payload(
+        realistic_vault, pack_name=PACK, target_date=today_date,
+    )
+    accepted = next(c for c in digest["cards"] if c["id"] == "Accepted")
+    # 4 of N_ACCEPTED have today's timestamp (i < 4 in the fixture).
+    assert accepted["event_count"] == 4
+
+
+# ── Acceptance: samples come from items, not events ───────────────
+
+
+def test_acceptance_received_samples_reference_items_not_events(realistic_vault):
+    digest = build_today_digest_payload(realistic_vault, pack_name=PACK)
+    received = next(c for c in digest["cards"] if c["id"] == "Received")
+    assert received["samples"], "Received card has no samples"
+    # Sample item_ids are ``recv-src-*``; they are NOT event_types.
+    for s in received["samples"]:
+        assert s["item_id"].startswith("recv-src-"), (
+            f"Received sample is not an ops_state item: {s}"
+        )
+        assert s["item_kind"] == "source"
+
+
+def test_acceptance_received_sample_with_pages_index_links_to_note(realistic_vault):
+    """When pages_index has the slug, sample primary_href targets
+    ``/note?path=…`` — a real route."""
+    digest = build_today_digest_payload(realistic_vault, pack_name=PACK)
+    received = next(c for c in digest["cards"] if c["id"] == "Received")
+    linked = [s for s in received["samples"] if s["path"]]
+    assert linked, "no Received samples carry a resolved primary_href"
+    assert all(s["path"].startswith("/note?path=") for s in linked)
+
+
+# ── Acceptance: honest-zero ───────────────────────────────────────
+
+
+def test_acceptance_honest_zero_when_state_is_empty(tmp_path):
+    """A vault with no audit_events and no objects produces 0s
+    everywhere — but the page must surface honest-zero rather
+    than just rendering blank."""
+    from ovp_pipeline.commands._ui_renderers import _render_today_digest_page
+
+    db_path = tmp_path / "60-Logs" / "knowledge.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.executescript(_SCHEMA)
+    conn.commit()
+    rebuild(conn, pack=PACK)
+    conn.close()
+
+    payload = build_today_digest_payload(tmp_path, pack_name=PACK)
+    html = _render_today_digest_page(payload)
+    # Every card shows 0 + the honest-zero ambiguity footer.
+    assert "May mean: not run · no output · missing instrumentation" in html
+
+
+# ── Acceptance: banners ───────────────────────────────────────────
+
+
+def test_acceptance_audit_page_banner_against_realistic_payload(realistic_vault):
+    """The role banner renders against a real-shape payload,
+    not just a hand-built one."""
+    from ovp_pipeline.commands._ui_renderers import _render_events_audit_page
+
+    today_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    payload = build_events_audit_payload(
+        realistic_vault,
+        event_types=("article_intake_only",),
+        date_key=today_date,
+        pack_name=PACK,
+    )
+    html = _render_events_audit_page(payload)
+    assert "Raw audit evidence" in html
+    assert "/ops/events" in html
+
+
+def test_acceptance_dossier_reciprocal_banner_against_realistic_payload(realistic_vault):
+    """The /ops/events page renders the timeline-projection banner
+    against the realistic fixture."""
+    from ovp_pipeline.commands._ui_renderers import _render_events_page
+    from ovp_pipeline.ui.view_models import build_event_dossier_payload
+
+    payload = build_event_dossier_payload(realistic_vault)
+    html = _render_events_page(payload)
+    assert "Timeline projection view" in html
+    assert "/ops/events/audit" in html
+
+
+# ── Acceptance: ops_state stays consistent across rebuilds ────────
+
+
+def test_acceptance_two_consecutive_rebuilds_yield_same_counts(realistic_vault):
+    """If the operator hits ``ovp-ops-state --rebuild`` twice in
+    quick succession (no new audit events between), the counts
+    must be identical.  Stale-projection paranoia: a count that
+    bounces between rebuilds is unsafe to drive a UI."""
+    db_path = realistic_vault / "60-Logs" / "knowledge.db"
+
+    def _counts():
+        with sqlite3.connect(db_path) as conn:
+            return dict(rebuild(conn, pack=PACK))
+
+    first = _counts()
+    second = _counts()
+    assert first == second, (
+        "ops_state.rebuild is not idempotent across consecutive "
+        f"calls: first={first}, second={second}"
+    )
+
+
+# ── Acceptance: no state has a phantom row ────────────────────────
+
+
+def test_acceptance_no_lifecycle_state_outside_the_five(realistic_vault):
+    """Every row ``ops_state.rebuild`` writes must belong to one
+    of the five visible states.  Anything else would mean the
+    kernel emitted a state name the UI doesn't know how to
+    render."""
+    db_path = realistic_vault / "60-Logs" / "knowledge.db"
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            "SELECT DISTINCT state FROM ops_state WHERE pack = ?",
+            (PACK,),
+        ).fetchall()
+    states_in_db = {r[0] for r in rows}
+    assert states_in_db <= set(ALL_STATES), (
+        f"ops_state contains rows with unknown state: "
+        f"{states_in_db - set(ALL_STATES)}"
+    )

--- a/tests/test_m25_smoke_script.py
+++ b/tests/test_m25_smoke_script.py
@@ -1,0 +1,222 @@
+"""Regression tests for the M25.6 smoke script.
+
+Codex review on PR #241 caught three functional bugs in the
+acceptance harness — the script itself could pass when the
+contracts it's supposed to verify were broken.  These tests lock
+the three guards so a future edit that re-introduces the
+false-positive paths fails CI.
+
+The script's subprocess paths (``ovp-producer-audit``,
+``ovp-ops-state --rebuild``) are exercised by the realistic
+fixture's own assertions; here we just verify the in-process
+checker functions handle the edge cases correctly.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def smoke_module():
+    """Import the script as a module so we can call its helpers
+    directly.  ``importlib`` because the script lives in
+    ``scripts/`` (not on sys.path).  The module must be registered
+    in ``sys.modules`` BEFORE exec so ``@dataclass`` decorators
+    inside the script can resolve their owning module via
+    ``cls.__module__``.
+    """
+    root = Path(__file__).resolve().parent.parent
+    script_path = root / "scripts" / "smoke_m25_control_plane.py"
+    spec = importlib.util.spec_from_file_location(
+        "smoke_m25_control_plane", script_path,
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["smoke_m25_control_plane"] = module
+    try:
+        spec.loader.exec_module(module)
+        yield module
+    finally:
+        sys.modules.pop("smoke_m25_control_plane", None)
+
+
+def _make_db(tmp_path: Path) -> Path:
+    """Minimum schema the contract checker reads from."""
+    db_path = tmp_path / "60-Logs" / "knowledge.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE audit_events (
+            source_log TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            slug TEXT NOT NULL DEFAULT '',
+            session_id TEXT NOT NULL DEFAULT '',
+            timestamp TEXT NOT NULL DEFAULT '',
+            payload_json TEXT NOT NULL
+        );
+        CREATE TABLE objects (
+            pack TEXT NOT NULL,
+            object_id TEXT NOT NULL,
+            object_kind TEXT NOT NULL,
+            title TEXT NOT NULL,
+            canonical_path TEXT NOT NULL,
+            source_slug TEXT NOT NULL,
+            source_url TEXT NOT NULL DEFAULT '',
+            PRIMARY KEY (pack, object_id)
+        );
+        CREATE TABLE graph_clusters (
+            pack TEXT NOT NULL,
+            cluster_id TEXT NOT NULL,
+            cluster_kind TEXT NOT NULL,
+            label TEXT NOT NULL,
+            center_object_id TEXT NOT NULL,
+            member_object_ids_json TEXT NOT NULL,
+            score REAL NOT NULL DEFAULT 0.0,
+            PRIMARY KEY (pack, cluster_id)
+        );
+        CREATE TABLE community_crystals (
+            pack TEXT NOT NULL,
+            cluster_id TEXT NOT NULL,
+            body_md TEXT NOT NULL,
+            source_evergreen_slugs_json TEXT NOT NULL,
+            synthesized_at TEXT NOT NULL,
+            llm_model TEXT NOT NULL,
+            prompt_version TEXT NOT NULL,
+            superseded_by_synthesized_at TEXT NOT NULL DEFAULT '',
+            PRIMARY KEY (pack, cluster_id, synthesized_at)
+        );
+        CREATE TABLE evergreen_revisions (
+            pack TEXT NOT NULL,
+            object_id TEXT NOT NULL,
+            version INTEGER NOT NULL,
+            content_md TEXT NOT NULL,
+            change_type TEXT NOT NULL,
+            changed_by TEXT NOT NULL DEFAULT '',
+            derived_at TEXT NOT NULL,
+            change_note TEXT NOT NULL DEFAULT '',
+            PRIMARY KEY (pack, object_id, version)
+        );
+        """
+    )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+# ── Codex fix #3: PYTHONPATH propagation to subprocesses ──────────
+
+
+def test_subprocess_env_propagates_src_path(smoke_module):
+    """The src/ path must be in the PYTHONPATH of subprocesses so
+    they can ``import ovp_pipeline`` without an editable install."""
+    env = smoke_module._subprocess_env()
+    assert "PYTHONPATH" in env
+    src_path = str(
+        Path(smoke_module.__file__).resolve().parent.parent / "src"
+    )
+    # The src path is FIRST in the colon-separated list so it
+    # takes precedence.
+    assert env["PYTHONPATH"].split(":")[0] == src_path
+
+
+def test_subprocess_env_preserves_existing_pythonpath(smoke_module, monkeypatch):
+    monkeypatch.setenv("PYTHONPATH", "/existing/path")
+    env = smoke_module._subprocess_env()
+    parts = env["PYTHONPATH"].split(":")
+    assert "/existing/path" in parts
+    src_path = str(
+        Path(smoke_module.__file__).resolve().parent.parent / "src"
+    )
+    # src/ stays in front so smoke imports the working tree.
+    assert parts.index(src_path) < parts.index("/existing/path")
+
+
+# ── Codex fix #1: missing lifecycle states fail loudly ───────────
+
+
+def test_contract_check_fails_when_a_state_is_missing(smoke_module, monkeypatch, tmp_path):
+    """If a regression drops a state from M25_LIFECYCLE_CARD_DEFS,
+    the smoke must NOT pass.  Pre-codex-fix the loop only walked
+    cards that were present, so a four-card payload looked clean."""
+    _make_db(tmp_path)
+    # Monkey-patch the payload builder to return only four cards.
+    import ovp_pipeline.ui.view_models as vm
+    original = vm.build_today_digest_payload
+
+    def _build(*args, **kwargs):
+        payload = original(*args, **kwargs)
+        # Drop NeedsAction.
+        payload["cards"] = [
+            c for c in payload["cards"] if c["id"] != "NeedsAction"
+        ]
+        return payload
+
+    monkeypatch.setattr(vm, "build_today_digest_payload", _build)
+    # The smoke module imported the original symbol at module-load
+    # time, so patch its local reference too.
+    monkeypatch.setattr(smoke_module, "build_today_digest_payload", _build)
+
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    result, table = smoke_module._check_card_n_equals_drilldown_n(
+        tmp_path, "research-tech", today,
+    )
+    assert result.ok is False
+    assert "missing_states" in result.detail
+    assert "NeedsAction" in result.detail
+
+
+# ── Codex fix #2: unavailable items don't count as 0 == 0 ────────
+
+
+def test_contract_check_fails_when_items_unavailable(smoke_module, tmp_path):
+    """Run the smoke against a vault where ``ops_state`` table
+    DOES NOT exist.  ``build_items_list_payload`` returns
+    ``available=False`` + ``total=0``; the card payload also
+    returns ``primary_count=0`` (because the kernel can't read).
+    Pre-codex-fix the smoke compared 0 == 0 and passed; today
+    it must surface the missing projection."""
+    _make_db(tmp_path)  # audit_events etc. — but no ops_state
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    result, table = smoke_module._check_card_n_equals_drilldown_n(
+        tmp_path, "research-tech", today,
+    )
+    assert result.ok is False
+    # Every row reports the items drilldown as unavailable.
+    assert all(row["items_available"] is False for row in table)
+    assert all(row["primary_match"] is False for row in table)
+
+
+def test_contract_check_passes_when_data_is_consistent(smoke_module, tmp_path):
+    """Positive control — when ops_state IS built and counts
+    match, the contract check passes."""
+    db_path = _make_db(tmp_path)
+    # Seed one Received source so the projection has something
+    # the cards' Received primary_count can match.
+    today_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S+00:00")
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO audit_events VALUES (?, ?, ?, ?, ?, ?)",
+        ("pipeline.jsonl", "article_intake_only", "src-x",
+         "fixture", today_iso, "{}"),
+    )
+    conn.commit()
+    from ovp_pipeline.ops_state import rebuild
+    rebuild(conn, pack="research-tech")
+    conn.close()
+
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    result, table = smoke_module._check_card_n_equals_drilldown_n(
+        tmp_path, "research-tech", today,
+    )
+    assert result.ok is True
+    received_row = next(r for r in table if r["state"] == "Received")
+    assert received_row["primary_match"] is True
+    assert received_row["audit_match"] is True


### PR DESCRIPTION
## Summary

Validation-only — no new operator-facing features. Proves the M24/M25 contracts hold against realistic data and gives the operator a single command to run the acceptance pass.

**Three deliverables:**
- `scripts/smoke_m25_control_plane.py` — runs producer-audit, ops-state rebuild, verifies card N === drilldown N on both axes for every state, renders the M25.4 banners against live payloads, writes a JSON report. Exit 0/2/3.
- `tests/test_m25_realistic_fixture.py` — module-scoped fixture with realistic shape (12 Received, 8 Extracted, 18 Accepted, 5 Synthesized, 4 NeedsAction; mix of auto + operator promote; pages_index resolution). 15 acceptance assertions.
- `docs/reports/2026-05-14-m25-dogfood-acceptance.md` — template the operator fills in after running the smoke script.

## M25.6 finding (logged, not fixed)

The Accepted card double-counts a promotion: for one promote event the kernel classifies BOTH the source slug AND the produced object_id as Accepted (36 for 18 promotions). Card N === drilldown N still holds (items page reads the same ops_state). The realistic-fixture test locks the dual-count so a future PR that drops one kind fails loudly. M26 picks the side. No code change here; the finding is documented in the acceptance report's "Open findings" section.

## Out of M25.6 scope (per M25 plan)

- Option B clean-room rebuild
- /ops cockpit redesign
- Inline actions on /ops/items
- Cross-pack item view

## Test plan

- [x] pytest tests/test_m25_realistic_fixture.py — 15/15 pass.
- [x] Full suite — 2941 passed, 0 regressions.
- [x] `scripts/smoke_m25_control_plane.py --help` smoke-tested.
- [ ] **Operator action required**: run the smoke script against the operator vault and fill in the acceptance report. That's the formal close of M24/M25.

Refs `docs/plans/2026-05-14-m25-maintainer-control-plane.md` §Acceptance.