### PR TITLE
fix(m24.1): wire ops_state into workflow profiles + refine ordering

### DIFF
--- a/src/ovp_pipeline/autopilot/daemon.py
+++ b/src/ovp_pipeline/autopilot/daemon.py
@@ -502,6 +502,29 @@ class AutoPilotDaemon:
         self._run_build_crystals()
         self._run_working_memory()
 
+    def _run_ops_state_refresh(self):
+        """M24.1: rebuild the lifecycle ``ops_state`` projection.
+
+        Reads ``audit_events`` + truth-projection tables that
+        ``_run_knowledge_index_refresh`` just rebuilt; must run
+        AFTER it.  Cheap rebuild (projection-only, no LLM); safe
+        to fire after every autopilot cycle.
+        """
+        cmd = [
+            sys.executable, "-m", "ovp_pipeline.commands.ops_state_cli",
+            "--vault-dir", str(self.vault_dir),
+            "--pack", self.pack.name,
+            "--rebuild",
+            "--json",
+        ]
+        try:
+            subprocess.run(
+                cmd, capture_output=True, cwd=str(self.vault_dir),
+                timeout=300,
+            )
+        except subprocess.TimeoutExpired:
+            self.log("⚠️ ops_state --rebuild 超时 (300s)")
+
     def _run_build_crystals(self):
         cmd = [
             sys.executable, "-m", "ovp_pipeline.commands.build_crystals",

--- a/src/ovp_pipeline/packs/research_tech/handlers.py
+++ b/src/ovp_pipeline/packs/research_tech/handlers.py
@@ -235,6 +235,22 @@ def build_stage_handlers(pack_name: str = "research-tech") -> list[StageHandlerS
             supports_autopilot=True,
         ),
         StageHandlerSpec(
+            name="ops_state",
+            pack=pack_name,
+            handler_kind="profile_stage",
+            runtime_adapter="autopilot_stage",
+            stage="ops_state",
+            entrypoint=(
+                "ovp_pipeline.workflow_handlers:run_autopilot_ops_state"
+            ),
+            description=(
+                "M24.1: refresh ops_state lifecycle projection "
+                "after autopilot knowledge_index"
+            ),
+            target_mode="single_note",
+            supports_autopilot=True,
+        ),
+        StageHandlerSpec(
             name="deep_dive_workflow",
             pack=pack_name,
             handler_kind="focused_action",

--- a/src/ovp_pipeline/packs/research_tech/shared.py
+++ b/src/ovp_pipeline/packs/research_tech/shared.py
@@ -145,6 +145,13 @@ def build_workflow_profiles() -> list[WorkflowProfile]:
                 "registry_sync",
                 "moc",
                 "knowledge_index",
+                # M24.1: lifecycle projection.  Reads what
+                # ``knowledge_index`` just rebuilt; must run
+                # AFTER it.  Missing from the profile pre-M25.6
+                # dogfood — caught when ``ops_state`` didn't
+                # rebuild on the live operator vault even though
+                # the step existed in BASE_PIPELINE_STEPS.
+                "ops_state",
             ],
         ),
         WorkflowProfile(
@@ -157,6 +164,10 @@ def build_workflow_profiles() -> list[WorkflowProfile]:
                 "dedup",
                 "moc",
                 "knowledge_index",
+                # M24.1: same reason as the full profile —
+                # autopilot also needs a fresh lifecycle
+                # projection at end of run.
+                "ops_state",
             ],
             supports_autopilot=True,
         ),

--- a/src/ovp_pipeline/unified_pipeline_enhanced.py
+++ b/src/ovp_pipeline/unified_pipeline_enhanced.py
@@ -527,7 +527,20 @@ def pipeline_steps(
 ) -> list[str]:
     steps = list(base_steps or BASE_PIPELINE_STEPS)
     if include_refine and "refine" not in steps:
-        steps.insert(-1, "refine")
+        # M24.1: refine writes data that ``knowledge_index`` then
+        # indexes, so refine MUST run before knowledge_index.
+        # Pre-M24.1 we inserted at ``-1`` (penultimate) because
+        # knowledge_index was the last step.  Today the last step
+        # is ``ops_state``, so inserting at -1 would put refine
+        # between knowledge_index and ops_state — wrong order.
+        # Find knowledge_index explicitly and insert before it.
+        try:
+            idx = steps.index("knowledge_index")
+            steps.insert(idx, "refine")
+        except ValueError:
+            # Profile doesn't include knowledge_index (e.g. a
+            # custom slice).  Fall back to inserting near the end.
+            steps.append("refine")
     return steps
 
 

--- a/src/ovp_pipeline/workflow_handlers.py
+++ b/src/ovp_pipeline/workflow_handlers.py
@@ -157,3 +157,13 @@ def run_autopilot_refine(*, daemon: Any, **_: Any) -> dict[str, Any]:
 def run_autopilot_knowledge_index(*, daemon: Any, **_: Any) -> dict[str, Any]:
     daemon._run_knowledge_index_refresh()
     return {"stage": "knowledge_index"}
+
+
+def run_autopilot_ops_state(*, daemon: Any, **_: Any) -> dict[str, Any]:
+    """M24.1: autopilot ``ops_state`` refresh — pairs with the
+    pipeline_step handler.  Runs after each autopilot cycle's
+    knowledge_index rebuild so the lifecycle projection stays
+    in sync with the truth tables that knowledge_index wrote.
+    """
+    daemon._run_ops_state_refresh()
+    return {"stage": "ops_state"}

--- a/tests/test_autopilot_contracts.py
+++ b/tests/test_autopilot_contracts.py
@@ -63,13 +63,18 @@ def test_autopilot_success_path_runs_absorb_and_knowledge_index_after_moc(tmp_pa
     monkeypatch.setattr(daemon, "_run_absorb", lambda: order.append("absorb"))
     monkeypatch.setattr(daemon, "_run_moc_update", lambda: order.append("moc"))
     monkeypatch.setattr(daemon, "_run_knowledge_index_refresh", lambda: order.append("knowledge_index"))
+    # M24.1: autopilot also refreshes the lifecycle projection.
+    monkeypatch.setattr(daemon, "_run_ops_state_refresh", lambda: order.append("ops_state"))
 
     task = Task(id=1, source="inbox", file_path=str(vault / "50-Inbox" / "01-Raw" / "note.md"))
     result = daemon.process_task(task)
 
     assert result["success"] is True
-    assert result["stages"] == ["interpretation", "absorb", "dedup", "moc", "knowledge_index"]
-    assert order == ["absorb", "moc", "knowledge_index"]
+    assert result["stages"] == [
+        "interpretation", "absorb", "dedup", "moc",
+        "knowledge_index", "ops_state",
+    ]
+    assert order == ["absorb", "moc", "knowledge_index", "ops_state"]
 
 
 def test_autopilot_accepts_explicit_default_pack_profile(tmp_path):
@@ -86,7 +91,12 @@ def test_autopilot_accepts_explicit_default_pack_profile(tmp_path):
 
     assert daemon.pack.name == "default-knowledge"
     assert daemon.workflow_profile.name == "autopilot"
-    assert daemon.workflow_profile.stages == ["interpretation", "quality", "absorb", "dedup", "moc", "knowledge_index"]
+    assert daemon.workflow_profile.stages == [
+        "interpretation", "quality", "absorb", "dedup", "moc",
+        "knowledge_index",
+        # M24.1: lifecycle projection.
+        "ops_state",
+    ]
 
 
 def test_autopilot_accepts_explicit_research_tech_pack_profile(tmp_path):
@@ -103,7 +113,12 @@ def test_autopilot_accepts_explicit_research_tech_pack_profile(tmp_path):
 
     assert daemon.pack.name == "research-tech"
     assert daemon.workflow_profile.name == "autopilot"
-    assert daemon.workflow_profile.stages == ["interpretation", "quality", "absorb", "dedup", "moc", "knowledge_index"]
+    assert daemon.workflow_profile.stages == [
+        "interpretation", "quality", "absorb", "dedup", "moc",
+        "knowledge_index",
+        # M24.1: lifecycle projection.
+        "ops_state",
+    ]
 
 
 def test_autopilot_with_refine_runs_refine_before_knowledge_index(tmp_path, monkeypatch):
@@ -122,13 +137,20 @@ def test_autopilot_with_refine_runs_refine_before_knowledge_index(tmp_path, monk
     monkeypatch.setattr(daemon, "_run_moc_update", lambda: order.append("moc"))
     monkeypatch.setattr(daemon, "_run_refine", lambda: order.append("refine"))
     monkeypatch.setattr(daemon, "_run_knowledge_index_refresh", lambda: order.append("knowledge_index"))
+    # M24.1: autopilot also refreshes the lifecycle projection.
+    monkeypatch.setattr(daemon, "_run_ops_state_refresh", lambda: order.append("ops_state"))
 
     task = Task(id=1, source="inbox", file_path=str(vault / "50-Inbox" / "01-Raw" / "note.md"))
     result = daemon.process_task(task)
 
     assert result["success"] is True
-    assert result["stages"] == ["interpretation", "absorb", "dedup", "moc", "refine", "knowledge_index"]
-    assert order == ["absorb", "moc", "refine", "knowledge_index"]
+    # M24.1: refine still runs before knowledge_index (refine
+    # writes data knowledge_index indexes); ops_state runs after.
+    assert result["stages"] == [
+        "interpretation", "absorb", "dedup", "moc", "refine",
+        "knowledge_index", "ops_state",
+    ]
+    assert order == ["absorb", "moc", "refine", "knowledge_index", "ops_state"]
 
 
 def test_autopilot_uses_handler_registry_for_follow_up_stages(tmp_path, monkeypatch):
@@ -173,7 +195,11 @@ def test_autopilot_uses_handler_registry_for_follow_up_stages(tmp_path, monkeypa
     result = daemon.process_task(task)
 
     assert result["success"] is True
-    assert calls == ["interpretation", "quality", "absorb", "dedup", "moc", "knowledge_index"]
+    # M24.1: ops_state lands at the tail.
+    assert calls == [
+        "interpretation", "quality", "absorb", "dedup", "moc",
+        "knowledge_index", "ops_state",
+    ]
 
 
 def test_autopilot_knowledge_index_refresh_passes_pack(tmp_path, monkeypatch):

--- a/tests/test_default_knowledge_pack.py
+++ b/tests/test_default_knowledge_pack.py
@@ -40,4 +40,10 @@ def test_default_knowledge_full_profile_matches_current_stage_order():
         "registry_sync",
         "moc",
         "knowledge_index",
+        # M24.1: lifecycle projection step appended after
+        # knowledge_index.  M25.6 dogfood pass caught that it was
+        # missing from the workflow profile despite being in
+        # BASE_PIPELINE_STEPS — fix in
+        # ``packs/research_tech/shared.py``.
+        "ops_state",
     ]

--- a/tests/test_pack_runtime_e2e.py
+++ b/tests/test_pack_runtime_e2e.py
@@ -71,6 +71,11 @@ def test_research_tech_full_profile_runtime_e2e(tmp_path):
     _bind_success_step(pipeline, "registry_sync", calls)
     _bind_success_step(pipeline, "moc", calls)
     _bind_success_step(pipeline, "knowledge_index", calls)
+    # M24.1: lifecycle projection step appended after
+    # knowledge_index.  Bind a no-op so the e2e walks the full
+    # current stages list (research-tech's full profile now
+    # includes ``ops_state``).
+    _bind_success_step(pipeline, "ops_state", calls)
 
     steps = load_pack("research-tech").profile("full").stages
     results = pipeline.run_pipeline(steps=steps, batch_size=25, dry_run=False)
@@ -127,6 +132,9 @@ def test_default_knowledge_compatibility_runtime_from_step_e2e(tmp_path):
     _bind_success_step(pipeline, "registry_sync", calls)
     _bind_success_step(pipeline, "moc", calls)
     _bind_success_step(pipeline, "knowledge_index", calls)
+    # M24.1: same reason as above — default-knowledge reuses the
+    # research-tech profile, so the lifecycle step is here too.
+    _bind_success_step(pipeline, "ops_state", calls)
 
     full_steps = load_pack("default-knowledge").profile("full").stages
     sliced_steps = full_steps[full_steps.index("quality") :]

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -211,6 +211,8 @@ def test_build_execution_plan_includes_pinboard_process_for_history():
         "registry_sync",
         "moc",
         "knowledge_index",
+        # M24.1: lifecycle projection runs after knowledge_index.
+        "ops_state",
     ]
 
 
@@ -228,7 +230,9 @@ def test_build_execution_plan_includes_pinboard_process_for_recent_days():
     plan = build_execution_plan(args)
 
     assert "pinboard_process" in plan["steps"]
-    assert plan["steps"][-1] == "knowledge_index"
+    # M24.1: last step is now ops_state (lifecycle projection).
+    assert plan["steps"][-1] == "ops_state"
+    assert plan["steps"][-2] == "knowledge_index"
 
 
 def test_build_execution_plan_full_can_insert_refine_before_knowledge_index():
@@ -244,7 +248,9 @@ def test_build_execution_plan_full_can_insert_refine_before_knowledge_index():
 
     plan = build_execution_plan(args)
 
-    assert plan["steps"][-2:] == ["refine", "knowledge_index"]
+    # M24.1: refine runs BEFORE knowledge_index (refine writes
+    # data knowledge_index indexes); ops_state runs last.
+    assert plan["steps"][-3:] == ["refine", "knowledge_index", "ops_state"]
     assert "absorb" in plan["steps"]
 
 
@@ -263,7 +269,8 @@ def test_build_execution_plan_full_respects_from_step():
 
     assert plan["steps"][0] == "quality"
     assert "pinboard" not in plan["steps"]
-    assert plan["steps"][-2:] == ["refine", "knowledge_index"]
+    # M24.1: see comment on the can_insert_refine test above.
+    assert plan["steps"][-3:] == ["refine", "knowledge_index", "ops_state"]
 
 
 def test_build_execution_plan_incremental_includes_pinboard_and_defaults_recent_days():
@@ -283,7 +290,9 @@ def test_build_execution_plan_incremental_includes_pinboard_and_defaults_recent_
     plan = build_execution_plan(args)
 
     assert plan["steps"][:3] == ["pinboard", "pinboard_process", "clippings"]
-    assert plan["steps"][-1] == "knowledge_index"
+    # M24.1: ops_state is the new tail.
+    assert plan["steps"][-1] == "ops_state"
+    assert plan["steps"][-2] == "knowledge_index"
     assert plan["pinboard_days"] == 7
     assert plan["description"] == "Incremental pipeline (research-tech/full)"
 

--- a/tests/test_workflow_profile_alignment.py
+++ b/tests/test_workflow_profile_alignment.py
@@ -1,0 +1,76 @@
+"""Regression guard: workflow profile stages must include every
+step in ``BASE_PIPELINE_STEPS``.
+
+M25.6 dogfood pass on the operator vault caught a real bug — the
+new M24.1 ``ops_state`` step landed in ``BASE_PIPELINE_STEPS`` but
+the ``WorkflowProfile.stages`` list in
+``packs/research_tech/shared.py`` was not updated.  Profile takes
+precedence in ``_run_pipeline_locked``, so ``ops_state`` never
+actually ran during ``ovp --incremental`` and the projection on
+the live vault stayed stale.
+
+This module locks the contract so a future PR that adds a DAG
+step but forgets to wire it into the workflow profile fails CI
+loudly.
+"""
+
+from __future__ import annotations
+
+
+def test_research_tech_full_profile_includes_every_base_step():
+    """Every step in ``BASE_PIPELINE_STEPS`` MUST appear in the
+    ``full`` profile's stages list.  A step missing from the
+    profile silently runs nothing on ``ovp --full`` /
+    ``ovp --incremental``, which is the bug M25.6 caught."""
+    from ovp_pipeline.packs.loader import load_pack
+    from ovp_pipeline.unified_pipeline_enhanced import BASE_PIPELINE_STEPS
+
+    pack = load_pack("research-tech")
+    profiles = {p.name: p for p in pack.workflow_profiles()}
+    assert "full" in profiles
+
+    full_stages = set(profiles["full"].stages)
+    missing = set(BASE_PIPELINE_STEPS) - full_stages
+    assert not missing, (
+        f"WorkflowProfile 'full' is missing DAG steps {sorted(missing)}.  "
+        "Add them to ``packs/research_tech/shared.py::build_workflow_profiles``"
+        " so ``ovp --full`` and ``ovp --incremental`` actually run them."
+    )
+
+
+def test_research_tech_full_profile_stages_are_in_canonical_order():
+    """The order matters — ``ops_state`` reads what
+    ``knowledge_index`` just rebuilt, so it must run AFTER.
+    Lock the relative order so a re-order doesn't accidentally
+    flip the dependency."""
+    from ovp_pipeline.packs.loader import load_pack
+    from ovp_pipeline.unified_pipeline_enhanced import BASE_PIPELINE_STEPS
+
+    pack = load_pack("research-tech")
+    full = next(p for p in pack.workflow_profiles() if p.name == "full")
+    # Stage indices must be monotone in the base order.
+    base_index = {s: i for i, s in enumerate(BASE_PIPELINE_STEPS)}
+    indices = [base_index[s] for s in full.stages if s in base_index]
+    assert indices == sorted(indices), (
+        f"Profile 'full' stages out of order: got {full.stages}, "
+        f"canonical order is {BASE_PIPELINE_STEPS}"
+    )
+
+
+def test_autopilot_profile_includes_ops_state():
+    """Autopilot runtime also runs ops_state at end of cycle —
+    same reason as the full profile.  Lock it independently."""
+    from ovp_pipeline.packs.loader import load_pack
+
+    pack = load_pack("research-tech")
+    autopilot = next(
+        p for p in pack.workflow_profiles() if p.name == "autopilot"
+    )
+    assert "ops_state" in autopilot.stages, (
+        "Autopilot profile must run ops_state — without it the "
+        "projection gets stale after every autopilot cycle."
+    )
+    # Order: must come after knowledge_index.
+    ki_idx = autopilot.stages.index("knowledge_index")
+    os_idx = autopilot.stages.index("ops_state")
+    assert os_idx > ki_idx


### PR DESCRIPTION
## Summary

**M25.6 dogfood pass against the operator vault caught a real bug** — `ovp --incremental` finished cleanly (13/13 steps successful) but `ops_state` was missing from the executed step list. The lifecycle projection never rebuilt on the live vault; every M25 card primary number was stale by design.

**Root cause:** M24.1 added `ops_state` to `BASE_PIPELINE_STEPS` and registered the pack handler, but missed the `WorkflowProfile.stages` list in `packs/research_tech/shared.py`. Profile takes precedence in `_run_pipeline_locked`, so the step never ran.

This is exactly the kind of drift M25.6's dogfood gate was designed to surface.

## Three fixes

1. **Workflow profile stages** — both `full` and `autopilot` profiles now include `ops_state` after `knowledge_index`.
2. **`pipeline_steps(include_refine=True)`** — refine insertion used `steps.insert(-1, …)` (penultimate). Pre-M24.1 that landed refine before `knowledge_index`; today it would land between `knowledge_index` and `ops_state` (wrong: refine writes data knowledge_index indexes). Fixed to find `knowledge_index` explicitly.
3. **Autopilot ops_state** — added `_run_ops_state_refresh` daemon method, `run_autopilot_ops_state` handler, and matching `StageHandlerSpec` registration.

## Regression guard

`tests/test_workflow_profile_alignment.py` (3 cases) locks the contract:
- Every step in `BASE_PIPELINE_STEPS` must appear in the full profile.
- Profile stage order must be monotone with the canonical order.
- Autopilot profile must include `ops_state` after `knowledge_index`.

## Tests updated

`test_default_knowledge_pack`, `test_runtime_paths`, `test_pack_runtime_e2e`, `test_autopilot_contracts` — assertions that pinned old tail positions updated to expect the new tail.

5 pre-existing `test_digest_handler` failures (UTC-midnight rollover flake) are unrelated and reproduced on a clean main stash.

## Test plan

- [x] pytest tests/test_workflow_profile_alignment.py — 3/3 pass.
- [x] Full suite — 2944 passed, 5 failures all pre-existing and reproducible on main.
- [ ] Re-run `ovp --incremental` against the operator vault and verify `ops_state` step appears in the executed step list and the JSON includes `ops_state` in counts.

Refs M25.6 dogfood report (#241).