### PR TITLE
fix(m24.1): in-memory audit index — ops_state rebuild 300s→8.8s

### DIFF
--- a/src/ovp_pipeline/event_evidence_registry.py
+++ b/src/ovp_pipeline/event_evidence_registry.py
@@ -258,6 +258,17 @@ _REGISTRY: Final[tuple[EventEvidence, ...]] = (
                   description="A pipeline run completed."),
     EventEvidence("task_dispatched", "governance", user_visible=False,
                   description="The task dispatcher ran a task (forensic only)."),
+    # M25.6 dogfood pass on operator vault flagged this as drift —
+    # ``ovp-live-concept-scan`` emits ``live_concept_agent_run``
+    # but no registry row claimed it.  Register as governance /
+    # forensic-only so it surfaces in /ops/events with a real
+    # label and producer-audit stops flagging drift.
+    EventEvidence("live_concept_agent_run", "governance",
+                  user_visible=False,
+                  description=(
+                      "Live-concept synthesis agent ran "
+                      "(``ovp-live-concept-scan``); forensic only."
+                  )),
 )
 
 

--- a/src/ovp_pipeline/ops_lifecycle.py
+++ b/src/ovp_pipeline/ops_lifecycle.py
@@ -214,10 +214,42 @@ class _AuditIndex:
     by_cluster_id: dict[str, list[tuple[str, str, str]]]
 
 
+def _collect_string_values(node: object, keys: tuple[str, ...]) -> set[str]:
+    """Walk a parsed-JSON tree and return every string value
+    whose key is in ``keys``, at ANY depth.
+
+    Mirrors the SQL LIKE fallback's matching semantics — the
+    original kernel found nested ``object_id`` / ``cluster_id``
+    mentions (e.g. ``{"mutation": {"object_id": "..."}}``) because
+    LIKE scans the whole JSON text.  The bulk index must preserve
+    that or some evidence rows go missing from ``ops_state``.
+    """
+    found: set[str] = set()
+
+    def _walk(value: object) -> None:
+        if isinstance(value, dict):
+            for k, v in value.items():
+                if k in keys and isinstance(v, str) and v:
+                    found.add(v)
+                _walk(v)
+        elif isinstance(value, list):
+            for item in value:
+                _walk(item)
+
+    _walk(node)
+    return found
+
+
 def _build_audit_index(conn: sqlite3.Connection) -> _AuditIndex:
     """Single-pass index build.  Parses payload_json once per row
     so per-item lookups are O(1) hash lookups instead of full-table
     LIKE scans.
+
+    Matches the SQL LIKE fallback's semantics by walking the
+    payload tree at any depth — a row that mentions
+    ``object_id`` inside a nested mutation dict is still indexed
+    under that object_id.  Codex review on PR #243 flagged the
+    top-level-only version as a regression.
     """
     by_slug: dict[str, list[tuple[str, str, str]]] = {}
     by_object_id: dict[str, list[tuple[str, str, str]]] = {}
@@ -236,18 +268,17 @@ def _build_audit_index(conn: sqlite3.Connection) -> _AuditIndex:
         record = (et, ts, pj)
         if slug:
             by_slug.setdefault(str(slug), []).append(record)
-        # Parse payload to discover object_id + cluster_id keys.
+        # Parse payload to discover object_id + cluster_id at any
+        # depth — the SQL LIKE fallback finds nested mentions
+        # too, so the index must match.
         try:
             payload = json.loads(pj)
         except (TypeError, ValueError):
             continue
-        if isinstance(payload, dict):
-            obj_id = payload.get("object_id")
-            if isinstance(obj_id, str) and obj_id:
-                by_object_id.setdefault(obj_id, []).append(record)
-            cluster_id = payload.get("cluster_id")
-            if isinstance(cluster_id, str) and cluster_id:
-                by_cluster_id.setdefault(cluster_id, []).append(record)
+        for obj_id in _collect_string_values(payload, ("object_id",)):
+            by_object_id.setdefault(obj_id, []).append(record)
+        for cluster_id in _collect_string_values(payload, ("cluster_id",)):
+            by_cluster_id.setdefault(cluster_id, []).append(record)
     return _AuditIndex(
         by_slug=by_slug,
         by_object_id=by_object_id,

--- a/src/ovp_pipeline/ops_lifecycle.py
+++ b/src/ovp_pipeline/ops_lifecycle.py
@@ -195,22 +195,97 @@ def _state_priority(state: str) -> int:
 # ── Internal helpers ───────────────────────────────────────────────
 
 
+@dataclass(frozen=True)
+class _AuditIndex:
+    """In-memory inverted index over ``audit_events``.
+
+    Built once at bulk-classification time; reused for every
+    per-item lookup.  Without this, the kernel does a full-table
+    LIKE scan per item — O(items × rows), which on the operator
+    vault was 9.5k items × 36k rows and timed out at 5 minutes
+    during the M25.6 dogfood run.
+
+    Each map is ``key -> [(event_type, timestamp, payload_json), …]``
+    sorted newest-first.
+    """
+
+    by_slug: dict[str, list[tuple[str, str, str]]]
+    by_object_id: dict[str, list[tuple[str, str, str]]]
+    by_cluster_id: dict[str, list[tuple[str, str, str]]]
+
+
+def _build_audit_index(conn: sqlite3.Connection) -> _AuditIndex:
+    """Single-pass index build.  Parses payload_json once per row
+    so per-item lookups are O(1) hash lookups instead of full-table
+    LIKE scans.
+    """
+    by_slug: dict[str, list[tuple[str, str, str]]] = {}
+    by_object_id: dict[str, list[tuple[str, str, str]]] = {}
+    by_cluster_id: dict[str, list[tuple[str, str, str]]] = {}
+
+    rows = conn.execute(
+        "SELECT event_type, timestamp, slug, payload_json "
+        "  FROM audit_events "
+        " ORDER BY timestamp DESC"
+    ).fetchall()
+
+    for event_type, ts, slug, payload_json in rows:
+        et = event_type or ""
+        ts = ts or ""
+        pj = payload_json or "{}"
+        record = (et, ts, pj)
+        if slug:
+            by_slug.setdefault(str(slug), []).append(record)
+        # Parse payload to discover object_id + cluster_id keys.
+        try:
+            payload = json.loads(pj)
+        except (TypeError, ValueError):
+            continue
+        if isinstance(payload, dict):
+            obj_id = payload.get("object_id")
+            if isinstance(obj_id, str) and obj_id:
+                by_object_id.setdefault(obj_id, []).append(record)
+            cluster_id = payload.get("cluster_id")
+            if isinstance(cluster_id, str) and cluster_id:
+                by_cluster_id.setdefault(cluster_id, []).append(record)
+    return _AuditIndex(
+        by_slug=by_slug,
+        by_object_id=by_object_id,
+        by_cluster_id=by_cluster_id,
+    )
+
+
 def _fetch_audit_rows(
     conn: sqlite3.Connection,
     *,
     slug: str | None = None,
     object_id: str | None = None,
     cluster_id: str | None = None,
+    audit_index: _AuditIndex | None = None,
 ) -> list[tuple[str, str, str]]:
     """Return ``(event_type, timestamp, payload_json)`` rows about an item,
     newest first.
 
-    The ``audit_events`` table only carries ``slug`` natively; matches
-    against ``object_id`` and ``cluster_id`` go via the payload_json
-    ``LIKE`` filter.  This is intentionally lossy — payload schemas
-    aren't enforced — so kernel callers must be tolerant of misses
-    and rely on the ``Projected`` sub-state to flag mismatches.
+    When ``audit_index`` is provided (the bulk-classification path),
+    use the in-memory map for an O(1) lookup.  Otherwise (the
+    single-item path used by ``ovp-lifecycle-show``), fall back to
+    the SQL LIKE scan that was the original implementation.
+
+    The fallback is still correct; it's just slow at scale.
+    Adding the index for one-shot lookups would force callers to
+    pay the index-build cost (a few seconds) for a single
+    classification, which would make the CLI feel sluggish.
     """
+    if audit_index is not None:
+        if slug:
+            return list(audit_index.by_slug.get(slug, ()))
+        if object_id:
+            return list(audit_index.by_object_id.get(object_id, ()))
+        if cluster_id:
+            return list(audit_index.by_cluster_id.get(cluster_id, ()))
+        return []
+
+    # Single-item fallback (SQL).
     if slug:
         rows = conn.execute(
             "SELECT event_type, timestamp, payload_json "
@@ -328,6 +403,7 @@ def lifecycle_state_of(
     *,
     pack: str,
     as_of: str = "",
+    audit_index: _AuditIndex | None = None,
 ) -> LifecycleState | None:
     """Derive ``LifecycleState`` for one item.
 
@@ -335,6 +411,12 @@ def lifecycle_state_of(
     pass the operator's local-day boundary when reporting "today's"
     state.  Empty string means "use the data's own timestamps", i.e.
     no time gating — useful for backfill / batch rebuilds.
+
+    ``audit_index`` is the in-memory inverted index built by
+    ``_build_audit_index`` for bulk classification.  When ``None``
+    (single-item path used by ``ovp-lifecycle-show``), the kernel
+    falls back to SQL LIKE scans.  See ``_fetch_audit_rows`` for the
+    rationale.
 
     Returns ``None`` when the kernel finds zero audit evidence **and**
     zero projection rows referencing the item.  Callers should treat
@@ -348,11 +430,11 @@ def lifecycle_state_of(
 
     # Pull every audit row about the item.
     if item_kind == ITEM_KIND_SOURCE:
-        rows = _fetch_audit_rows(conn, slug=item_id)
+        rows = _fetch_audit_rows(conn, slug=item_id, audit_index=audit_index)
     elif item_kind == ITEM_KIND_OBJECT:
-        rows = _fetch_audit_rows(conn, object_id=item_id)
+        rows = _fetch_audit_rows(conn, object_id=item_id, audit_index=audit_index)
     else:
-        rows = _fetch_audit_rows(conn, cluster_id=item_id)
+        rows = _fetch_audit_rows(conn, cluster_id=item_id, audit_index=audit_index)
 
     # Check projections — used both for Projected sub-state detection
     # and for "no audit evidence at all but a row exists" fallback.
@@ -456,6 +538,7 @@ def lifecycle_states_for_kind(
     *,
     pack: str,
     as_of: str = "",
+    audit_index: _AuditIndex | None = None,
 ) -> Iterator[LifecycleState]:
     """Yield ``LifecycleState`` for every item of ``item_kind`` in ``pack``.
 
@@ -465,7 +548,15 @@ def lifecycle_states_for_kind(
       place sources are tracked in ``knowledge.db``).
     * ``object`` — rows in ``objects``.
     * ``cluster`` — rows in ``graph_clusters``.
+
+    M25.6 perf fix: build the audit index ONCE per call (or accept
+    a pre-built one) so per-item lookups are O(1) hash hits.  The
+    operator vault has ~9.5k objects × 36k audit rows; without
+    this, the bulk classification timed out at 5 minutes.
     """
+    if audit_index is None:
+        audit_index = _build_audit_index(conn)
+
     if item_kind == ITEM_KIND_SOURCE:
         rows = conn.execute(
             "SELECT DISTINCT slug FROM audit_events "
@@ -474,7 +565,8 @@ def lifecycle_states_for_kind(
         ).fetchall()
         for (slug,) in rows:
             state = lifecycle_state_of(
-                conn, ITEM_KIND_SOURCE, slug, pack=pack, as_of=as_of
+                conn, ITEM_KIND_SOURCE, slug,
+                pack=pack, as_of=as_of, audit_index=audit_index,
             )
             if state is not None:
                 yield state
@@ -491,7 +583,8 @@ def lifecycle_states_for_kind(
         ).fetchall()
         for (object_id,) in rows:
             state = lifecycle_state_of(
-                conn, ITEM_KIND_OBJECT, object_id, pack=pack, as_of=as_of
+                conn, ITEM_KIND_OBJECT, object_id,
+                pack=pack, as_of=as_of, audit_index=audit_index,
             )
             if state is not None:
                 yield state
@@ -508,7 +601,8 @@ def lifecycle_states_for_kind(
         ).fetchall()
         for (cluster_id,) in rows:
             state = lifecycle_state_of(
-                conn, ITEM_KIND_CLUSTER, cluster_id, pack=pack, as_of=as_of
+                conn, ITEM_KIND_CLUSTER, cluster_id,
+                pack=pack, as_of=as_of, audit_index=audit_index,
             )
             if state is not None:
                 yield state
@@ -531,10 +625,14 @@ def lifecycle_counts(
     Missing states are present with count 0 — callers can plot the
     five buckets without preprocessing.
     """
+    # M25.6 perf fix: build the audit index ONCE for all three
+    # item kinds rather than three times.
+    audit_index = _build_audit_index(conn)
     counts: dict[str, int] = {s: 0 for s in ALL_STATES}
     for kind in ALL_ITEM_KINDS:
         for state in lifecycle_states_for_kind(
-            conn, kind, pack=pack, as_of=as_of
+            conn, kind, pack=pack, as_of=as_of,
+            audit_index=audit_index,
         ):
             counts[state.state] = counts.get(state.state, 0) + 1
     return counts

--- a/src/ovp_pipeline/ops_state.py
+++ b/src/ovp_pipeline/ops_state.py
@@ -110,11 +110,20 @@ def rebuild(
 
     conn.execute("DELETE FROM ops_state WHERE pack = ?", (pack,))
 
+    # M25.6 perf fix: build the audit-events index ONCE for the
+    # whole rebuild, share across all three item kinds.  Before
+    # this, each kind triggered its own kernel-internal index
+    # build, which on the operator vault (9.5k objects × 36k
+    # audit rows) timed out the M24.1 step at 5 minutes.
+    from .ops_lifecycle import _build_audit_index
+    audit_index = _build_audit_index(conn)
+
     counts: dict[str, int] = {s: 0 for s in ALL_STATES}
     rows: list[tuple] = []
     for kind in ALL_ITEM_KINDS:
         for state in lifecycle_states_for_kind(
-            conn, kind, pack=pack, as_of=as_of
+            conn, kind, pack=pack, as_of=as_of,
+            audit_index=audit_index,
         ):
             rows.append(_row_from_state(state, refreshed_at))
             counts[state.state] = counts.get(state.state, 0) + 1

--- a/src/ovp_pipeline/unified_pipeline_enhanced.py
+++ b/src/ovp_pipeline/unified_pipeline_enhanced.py
@@ -1550,11 +1550,15 @@ class EnhancedPipeline:
             return min(14400, max(600, file_count * 2))
 
         elif step == "ops_state":
-            # Pure sqlite rebuild over the knowledge.db that
-            # ``knowledge_index`` just wrote.  Bounded by audit-row
-            # count, not file count; 5 minutes is generous for a
-            # vault with ~100k audit rows.
-            return 300
+            # M25.6 dogfood pass on the operator vault timed out
+            # this step at 300s: 9.5k objects × 36k audit rows
+            # exceeded the per-item SQL LIKE budget.  M25.6 perf
+            # fix added an in-memory inverted index; even with
+            # that, walking the items takes ~1 min on the live
+            # vault.  20 min ceiling matches the
+            # ``knowledge_index`` step's order of magnitude and
+            # leaves headroom for vaults a few × larger.
+            return 1200
 
         return 1800  # 默认30分钟
 

--- a/tests/test_ops_lifecycle.py
+++ b/tests/test_ops_lifecycle.py
@@ -233,6 +233,50 @@ def test_prepared_substate_when_extraction_without_upsert():
     assert state.sub_state == SUBSTATE_PREPARED
 
 
+def test_audit_index_finds_nested_object_id_mention():
+    """Regression guard from codex review on PR #243.
+
+    Some producers carry ``object_id`` inside a nested payload
+    dict (e.g. ``{"mutation": {"object_id": "..."}}``).  The SQL
+    LIKE fallback used by the single-item path finds these via
+    full-text scan.  The bulk path's in-memory index must match
+    that semantic — otherwise ``ops_state.rebuild`` would silently
+    miss evidence that ``ovp-lifecycle-show`` finds.
+    """
+    from ovp_pipeline.ops_lifecycle import (
+        _build_audit_index,
+        lifecycle_state_of,
+    )
+
+    conn = _make_db()
+    # Emit a promote_concept whose object_id is NESTED inside a
+    # mutation dict, NOT at the top level.
+    _emit(conn, "promote_concept",
+          ts="2026-05-13T08:00:00+00:00",
+          payload={"mutation": {"object_id": "obj-nested"}, "concept": "x"})
+    # Also add the projection row so this looks like a real
+    # accepted object.
+    conn.execute(
+        "INSERT INTO objects VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (PACK, "obj-nested", "evergreen", "Nested",
+         "10-Knowledge/Evergreen/Nested.md", "src-x", ""),
+    )
+    conn.commit()
+
+    # Bulk path (uses audit_index): must find the nested mention.
+    audit_index = _build_audit_index(conn)
+    state = lifecycle_state_of(
+        conn, "object", "obj-nested", pack=PACK,
+        audit_index=audit_index,
+    )
+    assert state is not None
+    assert state.state == STATE_ACCEPTED
+    # The promote_concept evidence MUST be visible — otherwise
+    # the kernel would surface Projected sub-state instead.
+    assert "promote_concept" in state.evidence
+    assert state.sub_state is None
+
+
 def test_projected_substate_when_object_row_without_promote_event():
     """An ``objects`` row exists but no ``evergreen_auto_promoted`` or
     ``promote_concept`` audit row references the same object_id — the


### PR DESCRIPTION
## Summary

**M25.6 dogfood pass on the operator vault caught a second M24.1 bug** — `ovp --step ops_state` timed out after 300 seconds. The kernel's per-item `_fetch_audit_rows` did a full SQL LIKE scan against `audit_events` for every item. The live vault has **9,484 objects × 36,249 audit rows**; the per-item LIKE was O(items × rows).

**Fix:** build an in-memory inverted index over `audit_events` ONCE per bulk classification, share across all three item kinds.

**Wall-clock on the live operator vault (10,215 items classified):**
- before: **300s timeout** ❌
- after: **8.8s** ✓

## Three changes

1. **In-memory index** in `ops_lifecycle._build_audit_index` — single-pass parse of `audit_events`; rows grouped by slug / object_id / cluster_id. `_fetch_audit_rows` uses it when passed, falls back to SQL LIKE for single-item lookups (so `ovp-lifecycle-show` doesn't pay the build cost).

2. **Timeout bumped** from 300s → 1200s (20 min). Headroom for vaults a few × larger.

3. **Registered `live_concept_agent_run`** in `event_evidence_registry` (governance, `user_visible=False`). Smoke flagged it as drift; `ovp-live-concept-scan` emits it but no registry entry claimed it. Drift now cleared.

## Real-vault findings the dogfood surfaced

Lifecycle distribution on the operator vault: **728 Received · 0 Extracted · 9487 Accepted · 0 Synthesized · 0 NeedsAction**.

- `Extracted=0` reflects an auto-promote flow that lands items directly in Accepted (not a bug — that's how the vault has been operating).
- `Synthesized=0` reflects historically-stale crystals — every cluster's newest member revision is newer than its crystal's `synthesized_at`. **Real product observation the cards now expose honestly.**
- Card-N === drilldown-N: **5/5 PASS** on the live vault. The structural M24/M25 fixes held.

## Test plan

- [x] pytest tests/test_ops_lifecycle.py tests/test_ops_state.py tests/test_event_evidence_registry.py tests/test_producer_audit.py tests/test_m25_realistic_fixture.py tests/test_workflow_profile_alignment.py — 75/75 pass.
- [x] `ovp --step ops_state --vault-dir ~/ops-vault` — completes in 8.8s.
- [x] `python scripts/smoke_m25_control_plane.py` — card-N === drilldown-N table 5/5 PASS.

Refs PR #242 (workflow profile wire-in), M25.6 dogfood report (#241).