### PR TITLE
feat(m25.7): split /ops/today into two zones + Recent Topics honest-zero

### DIFF
--- a/src/ovp_pipeline/commands/_ui_renderers.py
+++ b/src/ovp_pipeline/commands/_ui_renderers.py
@@ -6682,21 +6682,27 @@ _TODAY_DIGEST_STYLE = ""
 
 
 def _render_today_digest_page(payload: dict) -> str:
-    """M25.3: hybrid lifecycle cards for ``/ops/today``.
+    """M25.7: ``/ops/today`` split into two clearly-separated zones.
 
-    Five cards keyed on the lifecycle vocabulary (Received,
-    Extracted, Accepted, Synthesized, Needs Action).  Each card
-    shows TWO numbers per the M25 plan §M25.3 contract:
+    M25.6 dogfood found that the M25.3 hybrid card conflated two
+    things with different date-sensitivity inside ONE card, so
+    changing ``?date=`` looked like nothing happened (the big
+    primary numbers dominate the visual and never move with the
+    date; only small secondary lines do).  M25.7 splits the page:
 
-    * Primary: current items in this state (from ``ops_state``).
-    * Secondary: today's evidence events (from ``audit_events``).
+    * **Zone A — Current backlog.**  Five lifecycle-state cards
+      with the primary count from ``ops_state``.  A snapshot of
+      *right now*.  Explicitly labeled "not affected by the date
+      below".  Primary CTA → ``/ops/items?state=…`` (no date).
 
-    Primary CTA → ``/ops/items?state=…`` (no date param).
-    Secondary CTA → ``/ops/events?event_types=…&date=…``.
+    * **Zone B — Activity on <date>.**  The date pivot lives here,
+      visually attached to the only content it governs.  Per-state
+      evidence counts from ``audit_events`` for the selected date.
+      Secondary CTA → ``/ops/events/audit?…&date=…``.
 
-    The two numbers are intentionally rendered as parallel rows,
-    not stacked or summed.  No "+N today" framing — the plan
-    forbids it because the sets aren't additive.
+    The data contract (``build_today_digest_payload``) is
+    unchanged; this is purely presentational so card-N ===
+    drilldown-N still holds on both axes.
     """
     requested_pack = str(payload.get("requested_pack") or "")
     date = str(payload.get("date") or "")
@@ -6718,80 +6724,66 @@ def _render_today_digest_page(payload: dict) -> str:
     sections: list[str] = [_TODAY_DIGEST_STYLE]
     sections.append(
         _render_page_help(
-            "Today digest",
+            "Today",
             what=(
-                "Five lifecycle cards (Received, Extracted, Accepted,"
-                " Synthesized, Needs Action).  Each card shows the"
-                " current item count plus today's evidence activity."
-                "  Primary number reads <code>ops_state</code>;"
-                " secondary number reads <code>audit_events</code>."
+                "Two zones.  <strong>Current backlog</strong> is a"
+                " snapshot of how many items sit in each lifecycle"
+                " state right now (from <code>ops_state</code>) — it"
+                " does NOT change when you change the date."
+                "  <strong>Activity on &lt;date&gt;</strong> is the"
+                " evidence recorded on the selected day (from"
+                " <code>audit_events</code>) — this is what the date"
+                " selector governs."
             ),
             can=(
-                "Click the <strong>Open N items →</strong> link to drill"
-                " into all current items in that state.  Click the"
-                " <strong>View today's N events →</strong> link to drop"
-                " into the audit ledger filtered to today."
+                "In Current backlog, click <strong>Open N items"
+                " →</strong> to drill into all current items in a"
+                " state.  In Activity, use the date pivot and click"
+                " <strong>View N evidence events →</strong> to drop"
+                " into the raw audit ledger for that day."
             ),
             effect=(
                 "Read-only.  Drilldowns navigate to /ops/items"
-                " (lifecycle) and /ops/events (forensic)."
+                " (lifecycle) and /ops/events/audit (forensic)."
             ),
         )
     )
-    prev_path = str(payload.get("prev_date_path") or "")
-    next_path = str(payload.get("next_date_path") or "")
-    prev_date = str(payload.get("prev_date") or "")
-    next_date = str(payload.get("next_date") or "")
-    pivot_parts: list[str] = []
-    if prev_path:
-        pivot_parts.append(f"<a href='{escape(prev_path)}'>← {escape(prev_date)}</a>")
-    pivot_parts.append(f"<strong>Today: {escape(date)}</strong>")
-    if next_path:
-        pivot_parts.append(f"<a href='{escape(next_path)}'>{escape(next_date)} →</a>")
-    sections.append(f"<p class='muted'>{' · '.join(pivot_parts)}</p>")
-    sections.append(
-        f"<p class='muted'>Lifecycle state — current backlog · today's"
-        f" activity recorded on <strong>{escape(date)}</strong> (UTC)."
-        f"  Click <a href='/ops/timeline'>Timeline</a> for the"
-        f" multi-day evidence view.</p>"
+
+    lifecycle = payload.get("lifecycle_summary") or {}
+    projection_unavailable = (
+        not lifecycle.get("available") and lifecycle.get("reason")
     )
 
-    # M24.3 honest-zero applies to the projection itself: when
-    # ``ops_state`` doesn't exist yet (DAG step hasn't run), every
-    # card's primary number would be 0 — surface that explicitly so
-    # the operator doesn't read it as "no backlog".
-    lifecycle = payload.get("lifecycle_summary") or {}
-    if not lifecycle.get("available") and lifecycle.get("reason"):
+    # ── ZONE A — Current backlog (date-independent) ────────────────
+    sections.append(
+        "<section style='margin-top:1rem'>"
+        "<h2 style='margin-bottom:.2rem'>Current backlog</h2>"
+        "<p class='muted small' style='margin:0 0 .6rem'>"
+        "Snapshot of how many items are in each lifecycle state "
+        "<strong>right now</strong>.  Source: "
+        "<code>ops_state</code>.  "
+        "<span style='color:var(--accent,#c2410c)'>Not affected by "
+        "the date selector below.</span></p>"
+    )
+    if projection_unavailable:
         sections.append(
             "<div class='card' style='border-color:#c2410c;"
             "background:#fef3e8;padding:0.75rem 1rem;margin:0.5rem 0'>"
             "<strong>Lifecycle projection unavailable.</strong> "
             f"<p class='muted small' style='margin:0.3rem 0 0'>"
-            f"{escape(str(lifecycle['reason']))}.  Card primary "
-            "numbers below will be 0 until this lands.</p>"
+            f"{escape(str(lifecycle['reason']))}.  Backlog numbers "
+            "below will be 0 until this lands.</p>"
             "</div>"
         )
-
-    # M23 BL-096 regenerate-digest button stays.
-    sections.append(
-        _render_digest_regenerate_button(requested_pack, date=date)
-    )
-
-    sections.append("<div class='grid stats' style='margin-top:1rem'>")
+    sections.append("<div class='grid stats'>")
     for card in cards:
         card_id = str(card.get("id") or "")
         label = str(card.get("label") or card_id)
         explainer = str(card.get("explainer") or "")
         primary_count = int(card.get("primary_count") or 0)
-        event_count = int(card.get("event_count") or 0)
-        event_label = str(card.get("event_label") or "")
         primary_href = str(card.get("primary_href") or "")
-        event_href = str(card.get("event_href") or "")
         samples = card.get("samples") or []
 
-        # NeedsAction with non-zero gets the warn tint; primary
-        # of 0 fades the big number so it reads as "nothing in
-        # this state" without distracting.
         warn_cls = (
             " warn" if card_id == "NeedsAction" and primary_count > 0
             else ""
@@ -6800,8 +6792,6 @@ def _render_today_digest_page(payload: dict) -> str:
             "color:var(--border-strong)" if primary_count == 0 else ""
         )
 
-        # Item samples block — each sample is one row from
-        # ``ops_state`` (NOT an event).
         sample_html = ""
         if samples:
             li_rows: list[str] = []
@@ -6833,8 +6823,6 @@ def _render_today_digest_page(payload: dict) -> str:
                 + "</ul></div>"
             )
 
-        # Primary CTA — only render when there's something to drill
-        # into; otherwise the link would land on an empty page.
         primary_cta = ""
         if primary_count > 0 and primary_href:
             primary_cta = (
@@ -6845,33 +6833,12 @@ def _render_today_digest_page(payload: dict) -> str:
                 "</div>"
             )
 
-        # Secondary CTA — only render when there are events to
-        # drill into.  Label uses per-state phrasing from the
-        # payload (e.g. "5 arrived today" / "3 extracted today").
-        secondary_cta = ""
-        if event_count > 0 and event_href:
-            secondary_cta = (
-                "<div class='tiny' style='margin-top:.3rem'>"
-                f"<a href='{escape(event_href)}' class='muted'>"
-                f"View today's {event_count} evidence "
-                f"event{'s' if event_count != 1 else ''} →</a>"
-                "</div>"
-            )
-
-        # Honest-zero footer applies when BOTH numbers are 0.
+        # Honest-zero only when there is genuinely nothing in this
+        # state right now (and the projection IS available — if it
+        # isn't, the banner above already explained the 0).
         zero_html = ""
-        if primary_count == 0 and event_count == 0:
+        if primary_count == 0 and not projection_unavailable:
             zero_html = honest_zero_html(short=True)
-
-        # Secondary text always renders so the card always shows
-        # both numbers (or both zeros) — the M25 plan locks this:
-        # never collapse one number into the other.
-        secondary_text = (
-            f"<div class='muted tiny' style='margin-top:6px'>"
-            f"{escape(event_label)}</div>"
-            if event_label
-            else ""
-        )
 
         explainer_html = (
             f"<div class='muted tiny' style='margin-top:4px'>"
@@ -6887,15 +6854,105 @@ def _render_today_digest_page(payload: dict) -> str:
             f"style='margin-top:4px;{empty_style}'>{primary_count}</div>"
             f"<div class='muted tiny'>current item"
             f"{'s' if primary_count != 1 else ''}</div>"
-            f"{secondary_text}"
             f"{explainer_html}"
             f"{zero_html}"
             f"{sample_html}"
             f"{primary_cta}"
+            "</div>"
+        )
+    sections.append("</div></section>")
+
+    # ── ZONE B — Activity on <date> (date-driven) ──────────────────
+    prev_path = str(payload.get("prev_date_path") or "")
+    next_path = str(payload.get("next_date_path") or "")
+    prev_date = str(payload.get("prev_date") or "")
+    next_date = str(payload.get("next_date") or "")
+    pivot_parts: list[str] = []
+    if prev_path:
+        pivot_parts.append(
+            f"<a href='{escape(prev_path)}'>← {escape(prev_date)}</a>"
+        )
+    pivot_parts.append(
+        f"<strong>{escape(date)}</strong>"
+    )
+    if next_path:
+        pivot_parts.append(
+            f"<a href='{escape(next_path)}'>{escape(next_date)} →</a>"
+        )
+
+    sections.append(
+        "<section style='margin-top:1.8rem;border-top:2px solid "
+        "var(--border);padding-top:1rem'>"
+        f"<h2 style='margin-bottom:.2rem'>Activity on "
+        f"<span style='color:var(--accent,#c2410c)'>{escape(date)}"
+        "</span></h2>"
+        "<p class='muted small' style='margin:0 0 .5rem'>"
+        "Evidence events recorded on this UTC day.  Source: "
+        "<code>audit_events</code>.  "
+        "<strong>This is the zone the date selector controls</strong>"
+        " — change the day to see other days' flow.  "
+        "<a href='/ops/timeline'>Timeline</a> has the multi-day view."
+        "</p>"
+        f"<p class='muted' style='margin:0 0 .6rem'>"
+        f"{' · '.join(pivot_parts)}</p>"
+    )
+
+    # Regenerate-digest acts on the SELECTED date — belongs in this
+    # zone, not globally.
+    sections.append(
+        _render_digest_regenerate_button(requested_pack, date=date)
+    )
+
+    sections.append("<div class='grid stats' style='margin-top:.6rem'>")
+    for card in cards:
+        card_id = str(card.get("id") or "")
+        label = str(card.get("label") or card_id)
+        event_count = int(card.get("event_count") or 0)
+        event_label = str(card.get("event_label") or "")
+        event_href = str(card.get("event_href") or "")
+
+        warn_cls = (
+            " warn" if card_id == "NeedsAction" and event_count > 0
+            else ""
+        )
+        empty_style = (
+            "color:var(--border-strong)" if event_count == 0 else ""
+        )
+
+        secondary_cta = ""
+        if event_count > 0 and event_href:
+            secondary_cta = (
+                "<div class='tiny' style='margin-top:.4rem'>"
+                f"<a href='{escape(event_href)}'>"
+                f"View {event_count} evidence "
+                f"event{'s' if event_count != 1 else ''} →</a>"
+                "</div>"
+            )
+
+        # Per-state label e.g. "5 arrived today" / "3 extracted
+        # today".  When 0, the honest-zero footer carries the
+        # ambiguity instead.
+        label_html = (
+            f"<div class='muted tiny' style='margin-top:4px'>"
+            f"{escape(event_label)}</div>"
+            if event_label and event_count > 0
+            else ""
+        )
+        zero_html = honest_zero_html(short=True) if event_count == 0 else ""
+
+        sections.append(
+            "<div class='card' style='margin:0;overflow:hidden'>"
+            f"<div class='muted tiny'>{escape(label)}</div>"
+            f"<div class='metric-num{warn_cls}' "
+            f"style='margin-top:4px;{empty_style}'>{event_count}</div>"
+            f"<div class='muted tiny'>event"
+            f"{'s' if event_count != 1 else ''} on {escape(date)}</div>"
+            f"{label_html}"
+            f"{zero_html}"
             f"{secondary_cta}"
             "</div>"
         )
-    sections.append("</div>")
+    sections.append("</div></section>")
 
     body = "".join(sections)
     return _layout(f"Today — {date}", body, requested_pack=requested_pack)

--- a/src/ovp_pipeline/commands/reader_home.py
+++ b/src/ovp_pipeline/commands/reader_home.py
@@ -68,10 +68,54 @@ def _render_reader_home(payload: dict) -> str:
            "<code>ovp-synthesize-community-crystals</code> then "
            "<code>ovp-knowledge-index</code> to populate.</p>"
     )
-    recent_html = (
-        "".join(_recent_card(item) for item in recent_crystals)
-        or f"<p class='muted'>No topics synthesized in the last {recent_days} days.</p>"
-    )
+    # M25.7 honest-zero: an empty 7-day window is not "broken" —
+    # it usually means hundreds of crystals exist but the newest
+    # is older than the window.  Explain that + offer the action,
+    # the same doctrine M24.3 applied to every other zero surface.
+    if recent_crystals:
+        recent_html = "".join(_recent_card(item) for item in recent_crystals)
+    else:
+        rctx = payload.get("recent_context") or {}
+        total_active = int(rctx.get("total_active") or 0)
+        newest_at = str(rctx.get("newest_at") or "")
+        topics_href = str(rctx.get("topics_href") or _shell_href("/topics", requested_pack))
+        if total_active > 0:
+            newest_day = escape(newest_at[:10]) if newest_at else "unknown"
+            age_hint = ""
+            if newest_at:
+                try:
+                    from datetime import datetime, timezone
+
+                    newest_dt = datetime.fromisoformat(
+                        newest_at.replace("Z", "+00:00")
+                    )
+                    if newest_dt.tzinfo is None:
+                        newest_dt = newest_dt.replace(tzinfo=timezone.utc)
+                    days = (datetime.now(timezone.utc) - newest_dt).days
+                    age_hint = f" ({days} day{'s' if days != 1 else ''} ago)"
+                except (ValueError, TypeError):
+                    age_hint = ""
+            recent_html = (
+                "<p class='muted'>No topics synthesized in the last "
+                f"{recent_days} days — but this vault has "
+                f"<strong>{total_active}</strong> synthesized topic"
+                f"{'s' if total_active != 1 else ''} overall; the "
+                f"newest was synthesized <strong>{newest_day}</strong>"
+                f"{age_hint}.</p>"
+                "<p class='muted small'>This window is empty because "
+                "synthesis hasn't run recently, not because there's "
+                "nothing here.  Run "
+                "<code>ovp-synthesize-community-crystals</code> to "
+                "refresh, or "
+                f"<a href='{escape(topics_href)}'>browse all "
+                f"{total_active} topics →</a>.</p>"
+            )
+        else:
+            recent_html = (
+                "<p class='muted'>No topics synthesized yet.  Run "
+                "<code>ovp-synthesize-community-crystals</code> then "
+                "<code>ovp-knowledge-index</code> to populate.</p>"
+            )
     see_all_html = (
         f"<p class='muted'><a href='{escape(atlas_href)}'>See all "
         f"{atlas_top_n} featured topics →</a></p>"

--- a/src/ovp_pipeline/ui/view_models.py
+++ b/src/ovp_pipeline/ui/view_models.py
@@ -6154,6 +6154,8 @@ def build_reader_home_payload(
     # ``ovp-knowledge-index`` yet — show the empty-state hint instead.
     atlas = None
     recent_rows: list[tuple] = []
+    recent_total_active = 0
+    recent_newest_at = ""
     if db_path.exists():
         try:
             with sqlite3.connect(db_path) as conn:
@@ -6176,9 +6178,32 @@ def build_reader_home_payload(
                     """,
                     (pack, cutoff, READER_HOME_RECENT_CRYSTALS_LIMIT),
                 ).fetchall()
+                # M25.7 honest-zero: when the 7-day window is empty,
+                # the operator needs to know WHY — a bare "no topics"
+                # reads as broken when in fact there are hundreds of
+                # crystals that are simply older than the window.
+                # Pull the active-crystal total + newest synthesized
+                # date so the renderer can explain instead of going
+                # silent (M25.6 dogfood finding: home looked broken
+                # on a vault whose newest crystal was 10 days old).
+                ctx_row = conn.execute(
+                    """
+                    SELECT COUNT(*), MAX(synthesized_at)
+                      FROM community_crystals
+                     WHERE pack = ?
+                       AND superseded_by_synthesized_at = ''
+                    """,
+                    (pack,),
+                ).fetchone()
+                recent_total_active = int(ctx_row[0] or 0) if ctx_row else 0
+                recent_newest_at = (
+                    str(ctx_row[1]) if ctx_row and ctx_row[1] else ""
+                )
         except sqlite3.DatabaseError:
             atlas = None
             recent_rows = []
+            recent_total_active = 0
+            recent_newest_at = ""
     if atlas is None:
         # Empty placeholder so downstream rendering shows the
         # ``run ovp-knowledge-index`` hint without special-casing.
@@ -6245,6 +6270,18 @@ def build_reader_home_payload(
         },
         "recent_crystals": recent_crystals,
         "recent_days": READER_HOME_RECENT_DAYS,
+        # M25.7 honest-zero context for the empty Recent Topics
+        # state.  ``total_active`` = crystals that exist regardless
+        # of age; ``newest_at`` = when the most recent one was
+        # synthesized.  The renderer uses these to explain an
+        # empty 7-day window instead of going silent.
+        "recent_context": {
+            "total_active": recent_total_active,
+            "newest_at": recent_newest_at,
+            "topics_href": _scoped_path(
+                "/topics", pack_name=requested_pack
+            ),
+        },
         "map_supported": _supports_research_shell(pack_name),
         "search_href": _scoped_path("/search", pack_name=requested_pack),
         "map_href": _scoped_path("/map", pack_name=requested_pack),

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -1803,7 +1803,9 @@ def test_ops_queue_legacy_paths_301_to_new_routes(temp_vault, legacy, canonical)
         ("/ops/queue/contradictions", "Contradictions"),
         ("/ops/queue/signals", "Signals"),
         ("/ops/queue/actions", "Action queue"),
-        ("/ops/today", "Today digest"),
+        # M25.7: page-help title is "Today" (the page is now two
+        # zones — Current backlog + Activity — not a single digest).
+        ("/ops/today", "Today"),
         ("/ops/timeline", "Timeline"),
         ("/ops/pulse", "Pulse"),
         ("/ops/events", "Event dossier"),


### PR DESCRIPTION
## Summary

Two operator-reported M25.6 dogfood findings, same root cause: a date-windowed number next to a date-independent number with no visual separation reads as "nothing changed / broken".

### 1. /ops/today zone split

M25.3's hybrid card mixed the primary count (current items, NOT date-windowed) with the secondary count (events on selected date) in ONE card. Changing `?date=` only moved the small secondary line; the big primary numbers never move → operator concluded the date selector did nothing.

Now two labeled zones:
- **Current backlog** — primary counts + samples + `/ops/items` CTA. Header: "Not affected by the date selector below."
- **Activity on `<date>`** — separated by a rule, owns the date pivot + regenerate button, event counts + `/ops/events/audit` CTA. Header: "This is the zone the date selector controls."

Data contract unchanged (purely presentational) — card-N === drilldown-N still holds. Verified on live vault: backlog 728/0/9487/0/0 stable across dates; activity 5/0/32/0/3 for 2026-05-04 vs 48/0/0/0/0 today.

### 2. Recent Topics honest-zero

`/` showed bare "No topics synthesized in the last 7 days" on a vault with **576 active crystals** (newest 10 days old). Now explains: total count, newest date + age, why the window is empty, and the action (`ovp-synthesize-community-crystals` / browse all). Same M24.3 honest-zero doctrine.

## Test plan

- [x] 59 reader-home + today tests pass.
- [x] Full sweep: 2949 passed (5 pre-existing UTC-midnight digest flakes unrelated).
- [x] Live operator vault: both zones render with correct date-sensitivity; Recent Topics empty state explains the 576-crystal context.

Refs M25.6 dogfood pass, operator feedback this session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Restructured Today digest page into a two-zone layout: current backlog (date-independent counts) and date-specific activity.
  * Enhanced Recent Topics empty state to display total topic count and newest synthesis date.

* **Improvements**
  * Clearer labeling indicating which data points are affected by date selection.
  * Reorganized page controls for improved usability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fakechris/obsidian_vault_pipeline/pull/244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->