### PR TITLE
fix(m24.2): wire the community_crystal_synthesized emit (Synthesized was unreachable)

### DIFF
--- a/src/ovp_pipeline/knowledge_index.py
+++ b/src/ovp_pipeline/knowledge_index.py
@@ -955,7 +955,19 @@ def _collect_audit_rows(layout: VaultLayout) -> list[tuple[str, str, str, str, s
                     str(payload.get("event_type") or "unknown"),
                     _infer_audit_slug(payload),
                     str(payload.get("session_id") or ""),
-                    str(payload.get("timestamp") or ""),
+                    # codex #246 P2: ``event_emitter.emit`` writes the
+                    # timestamp under ``ts``, while PipelineLogger
+                    # writes ``timestamp``.  Fall back to ``ts`` so
+                    # date-filtered consumers (/ops/today Activity
+                    # zone, /ops/events/audit?date=) see emit-based
+                    # rows (community_crystal_synthesized,
+                    # promote_concept, candidates_upserted, …)
+                    # instead of dropping them on an empty timestamp.
+                    str(
+                        payload.get("timestamp")
+                        or payload.get("ts")
+                        or ""
+                    ),
                     json.dumps(payload, ensure_ascii=False),
                 )
             )

--- a/src/ovp_pipeline/ops_lifecycle.py
+++ b/src/ovp_pipeline/ops_lifecycle.py
@@ -505,22 +505,44 @@ def lifecycle_state_of(
             best_event = event_type
             needs_action_reason = reason
 
-    # Apply freshness for Synthesized at the cluster level.
+    # Cluster Synthesized resolution.
     sub_state: str | None = None
-    if best_state == STATE_SYNTHESIZED and item_kind == ITEM_KIND_CLUSTER:
+    if item_kind == ITEM_KIND_CLUSTER:
         latest_synth, active = _crystal_for_cluster(conn, pack, item_id)
         newest_member_rev = _cluster_max_member_revision_ts(
             conn, pack, item_id
         )
-        if not active:
-            best_state = STATE_ACCEPTED
-        elif (
-            newest_member_rev
+        # A cluster is freshly synthesized when its crystal is
+        # active (not superseded) AND not stale relative to its
+        # member revisions.
+        crystal_fresh = bool(
+            active
             and latest_synth
-            and newest_member_rev > latest_synth
-        ):
-            # Crystal is stale relative to its inputs.
-            best_state = STATE_ACCEPTED
+            and (
+                not newest_member_rev
+                or newest_member_rev <= latest_synth
+            )
+        )
+        if best_state == STATE_SYNTHESIZED:
+            # An audit event said synthesized — demote only if the
+            # crystal is actually stale / superseded.
+            if not crystal_fresh:
+                best_state = STATE_ACCEPTED
+        elif crystal_fresh:
+            # M25.6 dogfood / codex #246 P1: projection-as-evidence.
+            # An active, fresh ``community_crystals`` row IS a
+            # synthesized cluster even when no
+            # ``community_crystal_synthesized`` audit event exists
+            # — e.g. crystals synthesized before the M24.2 emit was
+            # wired, or the ``--skip-existing`` resume path that
+            # never re-commits.  Without this, the operator vault's
+            # 576 pre-existing crystals stay at Synthesized=0
+            # forever unless every one is re-synthesized.  Mirrors
+            # the object ``Projected`` pattern: the projection
+            # asserts the state, the audit just didn't witness it.
+            best_state = STATE_SYNTHESIZED
+            if "community_crystal_synthesized" not in evidence_types:
+                sub_state = SUBSTATE_PROJECTED
 
     # Projected sub-state: object projection exists but no
     # ``evergreen_auto_promoted`` / ``promote_concept`` evidence.

--- a/src/ovp_pipeline/synthesis/community_crystal.py
+++ b/src/ovp_pipeline/synthesis/community_crystal.py
@@ -522,6 +522,41 @@ def synthesize_community_crystals(
                     "community_total": community_total,
                 },
             )
+
+            # M24.2 gap fixed (M25.6 dogfood): the producer-audit
+            # contract declared ``community_crystal_synthesized``
+            # for this producer and the M24.1 kernel reads it to
+            # classify a cluster as Synthesized — but the emit was
+            # never wired here, so synthesis wrote crystals to the
+            # DB while the lifecycle "Synthesized" bucket stayed at
+            # 0 on every vault.  Emit it now, carrying ``cluster_id``
+            # at the payload top level so ``ops_lifecycle``'s audit
+            # index picks it up.
+            try:
+                from ..event_emitter import emit as _emit_audit
+
+                _emit_audit(
+                    vault_dir,
+                    "pipeline.jsonl",
+                    "community_crystal_synthesized",
+                    {
+                        "cluster_id": cluster_id,
+                        "synthesized_at": crystal.synthesized_at,
+                        "llm_model": crystal.llm_model,
+                        "prompt_version": crystal.prompt_version,
+                        "sample_size": len(crystal.source_evergreen_slugs),
+                    },
+                    pack=pack_name,
+                )
+            except Exception:  # noqa: BLE001
+                # Audit emit is best-effort: a logging failure must
+                # not sink a synthesis batch that already committed
+                # the crystal + provenance row.
+                logger.warning(
+                    "community_crystal_synthesized emit failed for "
+                    "cluster=%r (crystal already committed)",
+                    cluster_id,
+                )
         return out
     finally:
         conn.close()

--- a/tests/test_community_crystal.py
+++ b/tests/test_community_crystal.py
@@ -392,6 +392,42 @@ class TestSynthesizeEndToEnd:
         assert llm_model == "anthropic/MiniMax-M2.7-highspeed"
         assert prompt_version == CRYSTAL_PROMPT_VERSION
 
+    def test_emits_community_crystal_synthesized_audit_event(self, tmp_path):
+        """M24.2 gap fixed (M25.6 dogfood): synthesis MUST emit the
+        ``community_crystal_synthesized`` audit event the M24.1
+        kernel reads to classify a cluster as Synthesized.  Before
+        the fix, synthesis wrote crystals to the DB but the
+        lifecycle Synthesized bucket stayed at 0 on every vault
+        because this event never fired."""
+        vault, db = _seed_vault(
+            tmp_path,
+            clusters=[("cluster::evt00001", "C1", ["a", "b"])],
+            objects=[("a", "A", "body a"), ("b", "B", "body b")],
+        )
+        llm = _StubLLM()
+        synthesize_community_crystals(
+            vault_dir=vault, llm_client=llm, db_path=db,
+        )
+        log_path = vault / "60-Logs" / "pipeline.jsonl"
+        assert log_path.exists(), "no pipeline.jsonl written"
+        rows = [
+            json.loads(line)
+            for line in log_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        synth_events = [
+            r for r in rows
+            if r.get("event_type") == "community_crystal_synthesized"
+        ]
+        assert len(synth_events) == 1, (
+            "synthesis did not emit community_crystal_synthesized"
+        )
+        payload = synth_events[0]
+        # cluster_id MUST be at the payload top level so the M24.1
+        # kernel's audit index picks it up.
+        assert payload.get("cluster_id") == "cluster::evt00001"
+        assert payload.get("sample_size") == 2
+
     def test_dry_run_skips_writes(self, tmp_path):
         vault, db = _seed_vault(
             tmp_path,

--- a/tests/test_ops_lifecycle.py
+++ b/tests/test_ops_lifecycle.py
@@ -345,6 +345,43 @@ def test_synthesized_fresh_crystal_classifies_as_synthesized():
     assert state.state == STATE_SYNTHESIZED
 
 
+def test_synthesized_from_crystal_projection_without_audit_event():
+    """codex #246 P1 / M25.6 dogfood: a cluster with an active,
+    fresh ``community_crystals`` row IS Synthesized even when NO
+    ``community_crystal_synthesized`` audit event exists (crystals
+    synthesized before the M24.2 emit was wired, or the
+    ``--skip-existing`` resume path).  The kernel treats the
+    projection as evidence and flags ``Projected`` sub-state
+    because the audit didn't witness it."""
+    conn = _make_db()
+    conn.execute(
+        "INSERT INTO graph_clusters VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (PACK, "cluster-noaudit", "community", "Memory",
+         "obj-1", json.dumps(["obj-1"]), 0.5),
+    )
+    conn.execute(
+        "INSERT INTO evergreen_revisions "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (PACK, "obj-1", 1, "## body", "created", "absorber",
+         "2026-05-10T08:00:00+00:00", ""),
+    )
+    conn.execute(
+        "INSERT INTO community_crystals "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (PACK, "cluster-noaudit", "## crystal body",
+         json.dumps(["obj-1"]),
+         "2026-05-11T08:00:00+00:00",
+         "fake-model", "v1", ""),
+    )
+    # NO community_crystal_synthesized audit event emitted.
+    state = lifecycle_state_of(
+        conn, "cluster", "cluster-noaudit", pack=PACK
+    )
+    assert state is not None
+    assert state.state == STATE_SYNTHESIZED
+    assert state.sub_state == SUBSTATE_PROJECTED
+
+
 def test_synthesized_stale_crystal_demotes_to_accepted():
     """If a cluster's newest revision is newer than its crystal, the
     crystal is stale and the cluster's state is Accepted, not


### PR DESCRIPTION
## Summary

M25.6 dogfood ("run synthesis, see if Synthesized populates") caught a **structural M24.2 bug**: the producer-audit contract declared `community_crystal_synthesizer → community_crystal_synthesized` and the M24.1 kernel reads that event to classify a cluster as Synthesized — but the emit was **never wired into the actual synthesizer**. M24.2 only added the absorb-side producers; the synthesis-side producer was a contract-only expectation with no implementation.

**Consequence:** `ovp-synthesize-community-crystals` wrote crystals to DB + markdown + provenance but emitted no audit event, so the kernel could never move ANY cluster into Synthesized. The lifecycle "Synthesized" bucket was structurally pinned at 0 on **every vault**. Operator vault: 576 crystals, Synthesized = 0.

**Fix:** emit `community_crystal_synthesized` in the synthesis loop after `commit_crystal_version`, with `cluster_id` at payload top level. Best-effort (try/except + warning) so a logging failure can't sink a batch that already committed.

## Verified end-to-end on the live operator vault

```
before:  Synthesized = 0  (producer never fired)
run:     ovp-synthesize-community-crystals --limit-communities 3
emit:    3 community_crystal_synthesized events (cluster_id top-level)
sync:    knowledge_index --audit-sync-only
rebuild: ovp-ops-state --rebuild
after:   Synthesized = 3   (exactly the 3 clusters synthesized)
```

## Also surfaced (operational, no code change)

Absorb has zero work because the **articles step runs `intake_only`** (no deep-dive generation) — that's why Extracted/Accepted have had no new flow since 5/10. Upstream pipeline config, not an M24/M25 defect. Documented for the acceptance report.

## Test plan

- [x] `test_community_crystal::test_emits_community_crystal_synthesized_audit_event` — asserts event fires with cluster_id + sample_size.
- [x] Full sweep: 2951 passed, 0 regressions.
- [x] Live operator vault: Synthesized 0 → 3 end-to-end.

Refs M25.6 dogfood pass, operator feedback this session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Audit events no longer dropped due to missing timestamp field; now uses fallback timestamp sources.

* **New Features**
  * Community crystal synthesis now emits audit events with metadata (cluster ID, model, sample size).
  * Cluster lifecycle state classification now recognizes synthesized status from crystal data without explicit audit events.

* **Tests**
  * Added tests for audit event emission and projection-based state classification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fakechris/obsidian_vault_pipeline/pull/246?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->