### PR TITLE
fix(m24): unified audit-identity normalization (lifecycle counts now trustworthy)

### DIFF
--- a/src/ovp_pipeline/audit_identity.py
+++ b/src/ovp_pipeline/audit_identity.py
@@ -1,0 +1,200 @@
+"""Unified audit-event identity normalization (M24 correctness fix).
+
+Background
+----------
+
+Historically the lifecycle kernel only indexed audit evidence by
+three payload keys: ``slug``, ``object_id``, ``cluster_id``.  But
+the dominant real-vault producers never used those keys:
+
+* ``evergreen_auto_promoted`` (10k+ rows on the operator vault)
+  carries ``concept`` + ``mutation.slug`` / ``mutation.target_slug``
+  + a ``source`` deep-dive filename + a ``path``.
+* ``source_*`` / ``absorb_route_decision`` carry only ``source``
+  (a full file path).
+* ``article_processed`` / ``candidates_upserted`` /
+  ``article_intake_only`` carry only ``file`` (a bare filename).
+
+Net effect: ~13k kernel-relevant events were *identity-less* to
+the kernel, so Received / Extracted / Accepted were systematically
+under-counted and the bulk of attribution fell through to the
+``objects``-table projection path rather than the audit evidence.
+
+This module is the single source of truth for "given an audit
+payload, what object / source / cluster identities does it carry".
+``knowledge_index._infer_audit_slug`` (writes the
+``audit_events.slug`` column) and ``ops_lifecycle._build_audit_index``
+(builds the in-memory inverted index) both call into here so the
+two cannot drift apart again.
+
+Hard boundary
+-------------
+
+Source-class identities (``source`` / ``file`` / ``path``) MUST
+NOT be mixed into the object index, and object-class identities
+(``concept`` / ``mutation.*``) MUST NOT be mixed into the source
+slug column.  Source lifecycle and object lifecycle are distinct
+ledgers; cross-contaminating them would make one pollute the
+other's counts.  The three extractor functions below are
+deliberately separate and never share inputs.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .identity import canonicalize_note_id
+
+
+# ── Nested-payload walk ────────────────────────────────────────────
+
+
+def collect_string_values(node: Any, keys: tuple[str, ...]) -> set[str]:
+    """Return every non-empty string value whose key is in ``keys``,
+    at ANY depth of a parsed-JSON tree.
+
+    Mirrors the legacy SQL ``LIKE`` fallback semantics — that scan
+    matched nested mentions (``{"mutation": {"object_id": "…"}}``)
+    because it scanned the whole JSON text.  The in-memory index
+    must preserve that or evidence rows silently disappear.
+    """
+    found: set[str] = set()
+
+    def _walk(value: Any) -> None:
+        if isinstance(value, dict):
+            for k, v in value.items():
+                if k in keys and isinstance(v, str) and v:
+                    found.add(v)
+                _walk(v)
+        elif isinstance(value, list):
+            for item in value:
+                _walk(item)
+
+    _walk(node)
+    return found
+
+
+# Object-class payload keys.  ``concept`` is the promoted slug;
+# ``mutation.slug`` / ``mutation.target_slug`` cover the
+# promote-vs-merge fork (a merge re-points to an existing slug).
+_OBJECT_KEYS: tuple[str, ...] = (
+    "object_id",
+    "concept",
+    "slug",  # only meaningful inside object-shaped payloads; the
+    # source slug column is derived separately below so this does
+    # not leak source identities into the object index.
+    "target_slug",
+)
+
+# Source-class payload keys.  These are file paths / filenames,
+# never object slugs.
+_SOURCE_KEYS: tuple[str, ...] = (
+    "source",
+    "file",
+    "path",
+    "source_path",
+)
+
+_CLUSTER_KEYS: tuple[str, ...] = ("cluster_id",)
+
+
+def _basename_no_ext(value: str) -> str:
+    """Strip directory + a single trailing ``.md``.  Keeps the
+    pipeline suffixes (``_深度解读`` / ``_原文``) intact — merging
+    raw vs deep-dive artifacts of one logical source is a separate
+    product decision, not something this normalizer should do
+    silently."""
+    tail = value.replace("\\", "/").rsplit("/", 1)[-1]
+    if tail.endswith(".md"):
+        tail = tail[:-3]
+    return tail
+
+
+def audit_object_ids(payload: dict[str, Any]) -> set[str]:
+    """Object-class identities for the kernel ``by_object_id`` index.
+
+    Indexes BOTH the verbatim value and its canonicalized form so a
+    lookup keyed on ``objects.object_id`` (already canonical) hits
+    regardless of whether the producer wrote canonical or raw.
+    Source / file keys are intentionally excluded — see the module
+    docstring's hard boundary.
+    """
+    out: set[str] = set()
+    # ``mutation`` is a nested dict on promote/merge events; the
+    # nested walk picks ``object_id`` / ``slug`` / ``target_slug``
+    # / ``concept`` from any depth.
+    for raw in collect_string_values(payload, _OBJECT_KEYS):
+        raw = raw.strip()
+        if not raw:
+            continue
+        out.add(raw)
+        canon = canonicalize_note_id(raw)
+        if canon:
+            out.add(canon)
+    return out
+
+
+def audit_cluster_ids(payload: dict[str, Any]) -> set[str]:
+    """Cluster-class identities for the kernel ``by_cluster_id``
+    index (nested-aware)."""
+    return {
+        c.strip()
+        for c in collect_string_values(payload, _CLUSTER_KEYS)
+        if c.strip()
+    }
+
+
+def audit_slug_for_column(payload: dict[str, Any]) -> str:
+    """The single value for the ``audit_events.slug`` column —
+    a SOURCE-class identity used by source-lifecycle discovery
+    (``SELECT DISTINCT slug FROM audit_events``).
+
+    Priority:
+
+    1. Explicit ``slug`` (already the intended key).
+    2. Single-element ``targets`` list (legacy deep-dive callers).
+    3. ``source`` / ``file`` / ``path`` / ``source_path`` —
+       basename, ``.md`` stripped, canonicalized.  This is the fix:
+       previously these produced an empty slug column so the
+       source lifecycle never saw the event.
+    4. ``target_path`` — returned RAW (not canonicalized).  The
+       lint ``check_zone_boundary`` rule matches by this exact key
+       and a path.stem collapse would break it
+       (e.g. ``30-Projects/*/Plan.md``).  Preserved verbatim from
+       the pre-existing ``_infer_audit_slug`` contract.
+
+    Object-class keys (``concept`` / ``mutation.*``) are NOT
+    consulted here — those belong only in the object index.
+    """
+    slug = payload.get("slug")
+    if isinstance(slug, str) and slug.strip():
+        return canonicalize_note_id(slug.strip())
+
+    targets = payload.get("targets")
+    if (
+        isinstance(targets, list)
+        and len(targets) == 1
+        and isinstance(targets[0], str)
+        and targets[0].strip()
+    ):
+        return canonicalize_note_id(targets[0].strip())
+
+    for key in _SOURCE_KEYS:
+        val = payload.get(key)
+        if isinstance(val, str) and val.strip():
+            return canonicalize_note_id(_basename_no_ext(val.strip()))
+
+    target_path = payload.get("target_path")
+    if isinstance(target_path, str) and target_path.strip():
+        # RAW — lint zone-boundary contract (do not canonicalize).
+        return target_path
+
+    return ""
+
+
+__all__ = [
+    "audit_cluster_ids",
+    "audit_object_ids",
+    "audit_slug_for_column",
+    "collect_string_values",
+]

--- a/src/ovp_pipeline/audit_identity.py
+++ b/src/ovp_pipeline/audit_identity.py
@@ -74,15 +74,19 @@ def collect_string_values(node: Any, keys: tuple[str, ...]) -> set[str]:
     return found
 
 
-# Object-class payload keys.  ``concept`` is the promoted slug;
-# ``mutation.slug`` / ``mutation.target_slug`` cover the
-# promote-vs-merge fork (a merge re-points to an existing slug).
+# Object-class payload keys that are UNAMBIGUOUS at any depth.
+# Deliberately excludes a bare ``slug``: the M24.2-era source
+# producers (``absorb_pending_upsert`` / ``candidates_upserted`` /
+# ``community_crystal_synthesized``) carry a top-level ``slug``
+# that is the SOURCE slug, not an object id.  Sweeping ``slug``
+# via the blind nested walk would contaminate ``by_object_id``
+# with source identities (codex review on PR #247).  The
+# object-class ``mutation.slug`` is recovered explicitly from the
+# ``mutation`` dict below instead, so it is captured without the
+# ambiguous top-level sweep.
 _OBJECT_KEYS: tuple[str, ...] = (
     "object_id",
     "concept",
-    "slug",  # only meaningful inside object-shaped payloads; the
-    # source slug column is derived separately below so this does
-    # not leak source identities into the object index.
     "target_slug",
 )
 
@@ -119,11 +123,21 @@ def audit_object_ids(payload: dict[str, Any]) -> set[str]:
     Source / file keys are intentionally excluded — see the module
     docstring's hard boundary.
     """
+    candidates: set[str] = set(
+        collect_string_values(payload, _OBJECT_KEYS)
+    )
+    # ``mutation.slug`` is object-class ONLY in the mutation
+    # context (promote/merge).  Extract it precisely from the
+    # ``mutation`` dict rather than via the blind walk so a
+    # top-level source ``slug`` never enters here.
+    mutation = payload.get("mutation")
+    if isinstance(mutation, dict):
+        m_slug = mutation.get("slug")
+        if isinstance(m_slug, str) and m_slug.strip():
+            candidates.add(m_slug)
+
     out: set[str] = set()
-    # ``mutation`` is a nested dict on promote/merge events; the
-    # nested walk picks ``object_id`` / ``slug`` / ``target_slug``
-    # / ``concept`` from any depth.
-    for raw in collect_string_values(payload, _OBJECT_KEYS):
+    for raw in candidates:
         raw = raw.strip()
         if not raw:
             continue

--- a/src/ovp_pipeline/knowledge_index.py
+++ b/src/ovp_pipeline/knowledge_index.py
@@ -19,6 +19,7 @@ from .concept_registry import ConceptRegistry, ResolutionAction
 from .event_emitter import iter_for_index
 from .graph.frontmatter import FrontmatterParser, NoteMetadata
 from .graph.link_parser import LinkParser
+from .audit_identity import audit_slug_for_column
 from .identity import canonicalize_note_id
 from .packs.loader import DEFAULT_WORKFLOW_PACK_NAME
 from .projection_lifecycle import close_projection_repair_marker, write_projection_repair_marker
@@ -888,22 +889,20 @@ def _collect_raw_rows(layout: VaultLayout) -> list[tuple[str, str, str, str]]:
 
 
 def _infer_audit_slug(payload: dict[str, object]) -> str:
-    slug = payload.get("slug")
-    if isinstance(slug, str) and slug:
-        return canonicalize_note_id(slug)
+    """Value for the ``audit_events.slug`` column.
 
-    targets = payload.get("targets")
-    if isinstance(targets, list) and len(targets) == 1 and isinstance(targets[0], str):
-        return canonicalize_note_id(targets[0])
-
-    # promotion / zone_violation events carry a `target_path`; index it as-is
-    # (vault-relative when the caller passed a relative path) so that lint
-    # check_zone_boundary can match by the same key without the lossy
-    # path.stem collision (e.g. 30-Projects/*/Plan.md).
-    target_path = payload.get("target_path")
-    if isinstance(target_path, str) and target_path:
-        return target_path
-    return ""
+    M24 audit-identity normalization (PR-B): delegates to the
+    shared ``audit_identity.audit_slug_for_column`` so this and the
+    lifecycle kernel's index cannot drift.  The new behavior over
+    the legacy slug/targets/target_path-only logic: ``source`` /
+    ``file`` / ``path`` now produce a non-empty slug column, so the
+    ~13k historical source-class events (``source_archived_to_processed``,
+    ``article_processed``, ``article_intake_only``,
+    ``absorb_route_decision``) finally become visible to source
+    lifecycle discovery.  ``target_path`` still returns raw for the
+    lint zone-boundary contract.
+    """
+    return audit_slug_for_column(payload)
 
 
 def _collect_reuse_rows(

--- a/src/ovp_pipeline/ops_lifecycle.py
+++ b/src/ovp_pipeline/ops_lifecycle.py
@@ -294,10 +294,16 @@ def _fetch_audit_rows(
     single-item path used by ``ovp-lifecycle-show``), fall back to
     the SQL LIKE scan that was the original implementation.
 
-    The fallback is still correct; it's just slow at scale.
-    Adding the index for one-shot lookups would force callers to
-    pay the index-build cost (a few seconds) for a single
-    classification, which would make the CLI feel sluggish.
+    The single-item fallback (``audit_index is None``, e.g.
+    ``ovp-lifecycle-show``) MUST agree with the bulk path.  PR-B
+    codex review caught that the old SQL fallback only matched
+    ``"object_id"`` literals, so an object whose evidence used
+    ``concept`` / ``mutation.slug`` / ``mutation.target_slug``
+    showed evidence in a bulk rebuild but "missing" in a one-off
+    lookup.  The fallback now does a COARSE ``LIKE %value%`` to
+    bound the candidate set, then confirms membership through the
+    SAME shared ``audit_object_ids`` / ``audit_cluster_ids``
+    helpers the index uses — zero drift, by construction.
     """
     if audit_index is not None:
         if slug:
@@ -318,30 +324,34 @@ def _fetch_audit_rows(
             (slug,),
         ).fetchall()
         return [(r[0], r[1] or "", r[2] or "{}") for r in rows]
-    if object_id:
-        # Payload-based match.  Use a LIKE on the JSON literal — robust
-        # enough for the kernel's classification needs.
-        needle = f'"object_id": "{object_id}"'
-        needle_alt = f'"object_id":"{object_id}"'
+
+    if object_id or cluster_id:
+        target = object_id or cluster_id
+        # Coarse candidate fetch: any row mentioning the id string
+        # anywhere in the payload.  The authoritative include/
+        # exclude decision is delegated to the shared helper so
+        # this can never diverge from ``_build_audit_index``.
         rows = conn.execute(
             "SELECT event_type, timestamp, payload_json "
             "  FROM audit_events "
-            " WHERE payload_json LIKE ? OR payload_json LIKE ? "
+            " WHERE payload_json LIKE ? "
             " ORDER BY timestamp DESC",
-            (f"%{needle}%", f"%{needle_alt}%"),
+            (f"%{target}%",),
         ).fetchall()
-        return [(r[0], r[1] or "", r[2] or "{}") for r in rows]
-    if cluster_id:
-        needle = f'"cluster_id": "{cluster_id}"'
-        needle_alt = f'"cluster_id":"{cluster_id}"'
-        rows = conn.execute(
-            "SELECT event_type, timestamp, payload_json "
-            "  FROM audit_events "
-            " WHERE payload_json LIKE ? OR payload_json LIKE ? "
-            " ORDER BY timestamp DESC",
-            (f"%{needle}%", f"%{needle_alt}%"),
-        ).fetchall()
-        return [(r[0], r[1] or "", r[2] or "{}") for r in rows]
+        out: list[tuple[str, str, str]] = []
+        for et, ts, pj in rows:
+            pj = pj or "{}"
+            try:
+                payload = json.loads(pj)
+            except (TypeError, ValueError):
+                continue
+            if not isinstance(payload, dict):
+                continue
+            if object_id and object_id in audit_object_ids(payload):
+                out.append((et or "", ts or "", pj))
+            elif cluster_id and cluster_id in audit_cluster_ids(payload):
+                out.append((et or "", ts or "", pj))
+        return out
     return []
 
 

--- a/src/ovp_pipeline/ops_lifecycle.py
+++ b/src/ovp_pipeline/ops_lifecycle.py
@@ -48,6 +48,11 @@ import sqlite3
 from dataclasses import dataclass
 from typing import Final, Iterator
 
+from .audit_identity import (
+    audit_cluster_ids,
+    audit_object_ids,
+    collect_string_values,
+)
 from .event_evidence_registry import classify
 
 
@@ -214,30 +219,12 @@ class _AuditIndex:
     by_cluster_id: dict[str, list[tuple[str, str, str]]]
 
 
-def _collect_string_values(node: object, keys: tuple[str, ...]) -> set[str]:
-    """Walk a parsed-JSON tree and return every string value
-    whose key is in ``keys``, at ANY depth.
-
-    Mirrors the SQL LIKE fallback's matching semantics — the
-    original kernel found nested ``object_id`` / ``cluster_id``
-    mentions (e.g. ``{"mutation": {"object_id": "..."}}``) because
-    LIKE scans the whole JSON text.  The bulk index must preserve
-    that or some evidence rows go missing from ``ops_state``.
-    """
-    found: set[str] = set()
-
-    def _walk(value: object) -> None:
-        if isinstance(value, dict):
-            for k, v in value.items():
-                if k in keys and isinstance(v, str) and v:
-                    found.add(v)
-                _walk(v)
-        elif isinstance(value, list):
-            for item in value:
-                _walk(item)
-
-    _walk(node)
-    return found
+# M24 PR-B: identity extraction moved to the shared
+# ``audit_identity`` module so this index and
+# ``knowledge_index._infer_audit_slug`` use ONE normalization and
+# cannot drift.  ``_collect_string_values`` kept as a thin
+# backward-compatible alias for any external importer / test.
+_collect_string_values = collect_string_values
 
 
 def _build_audit_index(conn: sqlite3.Connection) -> _AuditIndex:
@@ -245,11 +232,17 @@ def _build_audit_index(conn: sqlite3.Connection) -> _AuditIndex:
     so per-item lookups are O(1) hash lookups instead of full-table
     LIKE scans.
 
-    Matches the SQL LIKE fallback's semantics by walking the
-    payload tree at any depth — a row that mentions
-    ``object_id`` inside a nested mutation dict is still indexed
-    under that object_id.  Codex review on PR #243 flagged the
-    top-level-only version as a regression.
+    M24 PR-B audit-identity normalization: ``by_object_id`` now
+    keys on ``audit_identity.audit_object_ids`` (object_id +
+    concept + mutation.slug + mutation.target_slug, verbatim AND
+    canonicalized), recovering the ~10k historical
+    ``evergreen_auto_promoted`` events that carried ``concept`` /
+    ``mutation.*`` instead of ``object_id``.  ``by_slug`` keys on
+    the ``audit_events.slug`` column, which ``_infer_audit_slug``
+    now fills from ``source`` / ``file`` / ``path`` for
+    source-class events.  Source and object identities stay in
+    separate maps — the shared helper never mixes them (see
+    ``audit_identity`` module docstring).
     """
     by_slug: dict[str, list[tuple[str, str, str]]] = {}
     by_object_id: dict[str, list[tuple[str, str, str]]] = {}
@@ -268,16 +261,15 @@ def _build_audit_index(conn: sqlite3.Connection) -> _AuditIndex:
         record = (et, ts, pj)
         if slug:
             by_slug.setdefault(str(slug), []).append(record)
-        # Parse payload to discover object_id + cluster_id at any
-        # depth — the SQL LIKE fallback finds nested mentions
-        # too, so the index must match.
         try:
             payload = json.loads(pj)
         except (TypeError, ValueError):
             continue
-        for obj_id in _collect_string_values(payload, ("object_id",)):
+        if not isinstance(payload, dict):
+            continue
+        for obj_id in audit_object_ids(payload):
             by_object_id.setdefault(obj_id, []).append(record)
-        for cluster_id in _collect_string_values(payload, ("cluster_id",)):
+        for cluster_id in audit_cluster_ids(payload):
             by_cluster_id.setdefault(cluster_id, []).append(record)
     return _AuditIndex(
         by_slug=by_slug,

--- a/tests/test_audit_identity.py
+++ b/tests/test_audit_identity.py
@@ -94,6 +94,24 @@ def test_object_ids_excludes_source_and_file():
     assert audit_object_ids(payload) == set()
 
 
+def test_object_ids_excludes_top_level_source_slug():
+    """codex PR #247 P2-1: M24.2-era source producers
+    (``absorb_pending_upsert`` / ``candidates_upserted`` /
+    ``community_crystal_synthesized``) carry a TOP-LEVEL ``slug``
+    that is the SOURCE slug.  It must NOT be swept into the object
+    index — otherwise an object whose object_id equals that source
+    slug would consume source-only absorb evidence."""
+    payload = {
+        "slug": "2026-04-04-some-source",
+        "candidates": 3,
+        "source": "2026-04-04_some_source.md",
+    }
+    assert audit_object_ids(payload) == set()
+    # But object-context mutation.slug IS still recovered.
+    obj_payload = {"mutation": {"slug": "real-object", "action": "promote"}}
+    assert "real-object" in audit_object_ids(obj_payload)
+
+
 # ── audit_slug_for_column ──────────────────────────────────────────
 
 

--- a/tests/test_audit_identity.py
+++ b/tests/test_audit_identity.py
@@ -1,0 +1,159 @@
+"""Tests for the M24 PR-B audit-identity normalization layer.
+
+These lock the hard boundary the operator flagged: source/file
+identities must never leak into the object index, and object
+slugs must never leak into the source slug column.  Real-vault
+payload shapes (captured from the operator vault) are used so a
+regression that re-narrows the keying fails loudly.
+"""
+
+from __future__ import annotations
+
+from ovp_pipeline.audit_identity import (
+    audit_cluster_ids,
+    audit_object_ids,
+    audit_slug_for_column,
+    collect_string_values,
+)
+
+
+# ── collect_string_values (nested walk) ────────────────────────────
+
+
+def test_collect_finds_nested_values():
+    payload = {"mutation": {"object_id": "obj-x"}, "concept": "c1"}
+    assert collect_string_values(payload, ("object_id",)) == {"obj-x"}
+    assert collect_string_values(payload, ("concept",)) == {"c1"}
+
+
+def test_collect_walks_lists():
+    payload = {"items": [{"cluster_id": "a"}, {"cluster_id": "b"}]}
+    assert collect_string_values(payload, ("cluster_id",)) == {"a", "b"}
+
+
+def test_collect_ignores_non_string_and_empty():
+    payload = {"object_id": "", "n": 5, "nested": {"object_id": None}}
+    assert collect_string_values(payload, ("object_id",)) == set()
+
+
+# ── audit_object_ids ───────────────────────────────────────────────
+
+
+def test_object_ids_from_evergreen_auto_promoted_real_shape():
+    """The dominant historical producer (10k+ rows) — carries
+    ``concept`` + ``mutation.slug`` / ``mutation.target_slug``,
+    NOT ``object_id``.  Before PR-B these were invisible to the
+    object kernel."""
+    payload = {
+        "concept": "ai-video-production-workflow",
+        "source": "2026-04-02_liangdabiao_Seedance2_深度解读.md",
+        "path": "/Users/x/10-Knowledge/Evergreen/ai-video-production-workflow.md",
+        "mutation": {
+            "action": "promote",
+            "slug": "ai-video-production-workflow",
+            "target_slug": "ai-video-production-workflow",
+        },
+    }
+    ids = audit_object_ids(payload)
+    assert "ai-video-production-workflow" in ids
+
+
+def test_object_ids_recover_merge_target():
+    """promote-vs-merge fork: a merge re-points to a DIFFERENT
+    existing slug.  Both the original concept and the merge
+    target must be indexed."""
+    payload = {
+        "concept": "duplicate-idea",
+        "mutation": {
+            "action": "merge",
+            "slug": "duplicate-idea",
+            "target_slug": "canonical-idea",
+        },
+    }
+    ids = audit_object_ids(payload)
+    assert "duplicate-idea" in ids
+    assert "canonical-idea" in ids
+
+
+def test_object_ids_indexes_canonical_and_verbatim():
+    payload = {"object_id": "Some Mixed Case ID"}
+    ids = audit_object_ids(payload)
+    assert "Some Mixed Case ID" in ids  # verbatim
+    # canonical form also present so an objects.object_id lookup
+    # (already canonical) hits.
+    from ovp_pipeline.identity import canonicalize_note_id
+    assert canonicalize_note_id("Some Mixed Case ID") in ids
+
+
+def test_object_ids_excludes_source_and_file():
+    """HARD BOUNDARY: source/file must NOT enter the object index."""
+    payload = {
+        "source": "/Users/x/50-Inbox/03-Processed/2026-03/foo_原文.md",
+        "file": "2026-04-04_www.usebruno.com.md",
+    }
+    assert audit_object_ids(payload) == set()
+
+
+# ── audit_slug_for_column ──────────────────────────────────────────
+
+
+def test_slug_column_prefers_explicit_slug():
+    assert audit_slug_for_column({"slug": "MyNote"}) == "mynote"
+
+
+def test_slug_column_from_file_basename_real_shape():
+    """``article_processed`` / ``candidates_upserted`` /
+    ``article_intake_only`` carry only ``file`` — before PR-B this
+    produced an empty slug column so source lifecycle never saw
+    the event."""
+    s = audit_slug_for_column({"file": "2026-04-04_www.usebruno.com.md"})
+    assert s
+    # Same source filename → same slug (dedupe across the source's
+    # event stream).
+    assert s == audit_slug_for_column(
+        {"file": "2026-04-04_www.usebruno.com.md"}
+    )
+
+
+def test_slug_column_from_source_full_path():
+    """``source_archived_to_processed`` carries a full path."""
+    s = audit_slug_for_column({
+        "source": "/Users/x/50-Inbox/02-Processing/"
+        "2026-03-29_Dynamic_context_discovery_原文.md",
+    })
+    assert s
+    assert "/" not in s  # basename only, slugified
+
+
+def test_slug_column_target_path_returned_raw():
+    """Lint zone-boundary contract: ``target_path`` must NOT be
+    canonicalized — the rule matches by the exact key."""
+    raw = "30-Projects/Alpha/Plan.md"
+    assert audit_slug_for_column({"target_path": raw}) == raw
+
+
+def test_slug_column_does_not_consult_object_keys():
+    """HARD BOUNDARY: ``concept`` / ``mutation.*`` are object
+    identities — they must NOT become the source slug column."""
+    payload = {
+        "concept": "some-object-slug",
+        "mutation": {"slug": "some-object-slug"},
+    }
+    assert audit_slug_for_column(payload) == ""
+
+
+def test_slug_column_empty_when_no_identity():
+    assert audit_slug_for_column({"unrelated": "x"}) == ""
+
+
+# ── audit_cluster_ids ──────────────────────────────────────────────
+
+
+def test_cluster_ids_nested_aware():
+    assert audit_cluster_ids(
+        {"payload": {"cluster_id": "cluster::abc"}}
+    ) == {"cluster::abc"}
+
+
+def test_cluster_ids_empty_when_absent():
+    assert audit_cluster_ids({"slug": "x"}) == set()

--- a/tests/test_ops_lifecycle.py
+++ b/tests/test_ops_lifecycle.py
@@ -277,6 +277,51 @@ def test_audit_index_finds_nested_object_id_mention():
     assert state.sub_state is None
 
 
+def test_single_item_path_matches_bulk_for_concept_evidence():
+    """codex PR #247 P2-2: an object whose ONLY promote evidence
+    uses ``concept`` (no ``object_id``) — the dominant real-vault
+    ``evergreen_auto_promoted`` shape — must classify identically
+    via the bulk index AND the single-item SQL fallback
+    (``ovp-lifecycle-show``, audit_index=None).  Pre-fix the
+    fallback only LIKE-matched ``"object_id"`` so it reported the
+    object as missing/projected while bulk found it Accepted."""
+    from ovp_pipeline.ops_lifecycle import (
+        _build_audit_index,
+        lifecycle_state_of,
+    )
+
+    conn = _make_db()
+    _emit(conn, "evergreen_auto_promoted",
+          ts="2026-05-13T08:00:00+00:00",
+          payload={
+              "concept": "obj-concept-only",
+              "source": "2026-04-02_some_深度解读.md",
+              "mutation": {"action": "promote",
+                           "slug": "obj-concept-only",
+                           "target_slug": "obj-concept-only"},
+          })
+    conn.execute(
+        "INSERT INTO objects VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (PACK, "obj-concept-only", "evergreen", "C",
+         "10-Knowledge/Evergreen/C.md", "src-x", ""),
+    )
+    conn.commit()
+
+    bulk = lifecycle_state_of(
+        conn, "object", "obj-concept-only", pack=PACK,
+        audit_index=_build_audit_index(conn),
+    )
+    single = lifecycle_state_of(
+        conn, "object", "obj-concept-only", pack=PACK,
+        audit_index=None,
+    )
+    assert bulk is not None and single is not None
+    assert bulk.state == single.state == STATE_ACCEPTED
+    assert "evergreen_auto_promoted" in bulk.evidence
+    assert "evergreen_auto_promoted" in single.evidence
+    assert bulk.sub_state == single.sub_state
+
+
 def test_projected_substate_when_object_row_without_promote_event():
     """An ``objects`` row exists but no ``evergreen_auto_promoted`` or
     ``promote_concept`` audit row references the same object_id — the


### PR DESCRIPTION
## Summary

The lifecycle kernel only indexed audit evidence by `slug`/`object_id`/`cluster_id`, but the dominant real-vault producers never use those keys. ~13k kernel-relevant events were **identity-less to the kernel**, so Received/Extracted/Accepted were systematically under-counted and — worst of all — **failure events were invisible, pinning NeedsAction at 0 on every real vault**.

This is PR-B of the agreed 2-PR sequence (correctness first, behavior change second).

## Fix

New single normalization layer `src/ovp_pipeline/audit_identity.py` used by **both** `knowledge_index._infer_audit_slug` and `ops_lifecycle._build_audit_index` so they cannot drift:

- **object identity**: `object_id` + `concept` + `mutation.slug` + `mutation.target_slug` (verbatim + canonicalized)
- **source identity** (slug column): `source`/`file`/`path` → basename, `.md` stripped, canonicalized; `target_path` stays raw (lint zone-boundary contract preserved)
- **cluster identity**: `cluster_id` (nested-aware)

**Hard boundary** (operator-flagged): source/file never enters the object index; object slugs never enter the source slug column. Separate extractor functions that never share inputs.

## Real operator-vault before/after (no LLM cost)

| state | before | after | delta |
|---|---|---|---|
| Received | 276 | 2727 | +2451 |
| Extracted | 0 | 176 | +176 |
| Accepted | 9487 | 10493 | +1006 |
| Synthesized | 452 | 452 | +0 |
| **NeedsAction** | **0** | **125** | **+125 — failures finally visible** |
| TOTAL | 10215 | 13973 | |

slug-column coverage: ~0% → 60%. Internal consistency verified: source rows (3764) == distinct audit slugs (3764); object (9484) == objects table; cluster (725) == graph_clusters; no dup PKs.

## Test plan

- [x] New `test_audit_identity` (15 cases) — locks the hard boundary with real-vault payload shapes.
- [x] Focused kernel/index/synthesis suites: 122 passed.
- [x] Full sweep: 2963 passed. The 4 `test_digest_handler` failures are the pre-existing UTC-midnight `_seed_window_with_signal` flake — reproduced on a clean stash, unrelated.

PR-A (pipeline quality→absorb fallback) follows separately.