### PR TITLE
fix(m24 PR-A): pipeline absorb falls back to intake sources post-BL-029

### DIFF
--- a/src/ovp_pipeline/step_contracts.py
+++ b/src/ovp_pipeline/step_contracts.py
@@ -185,6 +185,16 @@ class AbsorbStepResult(StepResult):
     results: list[dict] = field(default_factory=list)
     input_artifact: dict | None = None
     total_evergreen: int = 0  # post-run population (filled by dispatcher)
+    # PR-A BL-029 quality→absorb fallback markers.  Set when the
+    # pipeline quality artifact qualified 0 files (post-BL-029 the
+    # quality stage only scans the removed deep-dive layer) but
+    # absorb fell back to its own recent-target discovery against
+    # 50-Inbox/03-Processed intake sources.  First-class fields so
+    # the fallback is auditable in run reports / typed consumers,
+    # not silently dropped by ``to_typed_step_result``.
+    bl029_intake_fallback: bool = False
+    fallback_reason: str | None = None
+    fallback_intake_targets: int = 0
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/ovp_pipeline/unified_pipeline_enhanced.py
+++ b/src/ovp_pipeline/unified_pipeline_enhanced.py
@@ -2602,13 +2602,36 @@ class EnhancedPipeline:
             # we do NOT widen the quality checker into a
             # general intake scanner — intake sources are not
             # deep-dive quality artifacts.
+            # codex PR #248 P1: probe ONLY 03-Processed intake
+            # sources — NOT ``_collect_absorb_targets(recent=N)``,
+            # which also returns ``20-Areas/*/Topics/*_深度解读.md``
+            # deep-dives.  If a vault still has deep-dives that
+            # FAILED quality, the artifact is empty for that
+            # reason; falling back on those would bypass the
+            # quality gate.  ``_collect_processed_github_sources``
+            # (BL-071-widened, despite the legacy name) returns
+            # exactly the intake-only + github sources under
+            # 50-Inbox/03-Processed and nothing else — so the
+            # fallback is strictly the BL-029 empty-scan case.
             try:
+                from datetime import datetime as _dt
+                from datetime import timedelta as _td
+                from datetime import timezone as _tz
+
                 from .auto_evergreen_extractor import (
-                    _collect_absorb_targets,
+                    _collect_processed_github_sources,
                 )
 
-                intake_targets = _collect_absorb_targets(
-                    self.layout, recent=recent_days
+                _now = _dt.now(_tz.utc)
+                _cutoff = _now - _td(days=recent_days)
+                _months = {
+                    (_now - _td(days=d)).strftime("%Y-%m")
+                    for d in range(recent_days)
+                }
+                intake_targets = _collect_processed_github_sources(
+                    self.layout,
+                    month_names=_months,
+                    cutoff=_cutoff,
                 )
             except Exception:  # noqa: BLE001 — probe is best-effort
                 intake_targets = []
@@ -2618,16 +2641,51 @@ class EnhancedPipeline:
                     "\n⚠️  Quality artifact qualified 0 files "
                     "(post-BL-029 the quality stage only scans the "
                     "removed deep-dive layer).  Falling back to "
-                    f"absorb --recent {recent_days}: "
                     f"{len(intake_targets)} eligible intake source"
                     f"{'s' if len(intake_targets) != 1 else ''} "
-                    "in 03-Processed."
+                    "in 03-Processed (deep-dives are NOT included; "
+                    "the quality gate is not bypassed)."
                 )
-                fb = self._run_absorb_workflow_direct(
-                    dry_run=dry_run,
-                    recent=recent_days,
-                    record_item_ledger=True,
-                )
+                # codex PR #248 P1: run absorb SCOPED to exactly the
+                # discovered intake targets via the same staging
+                # mechanism the ``normalized_files`` path uses —
+                # never the broad ``recent`` workflow, which would
+                # also pull in QC-failed 20-Areas deep-dives.
+                self.layout.logs_dir.mkdir(parents=True, exist_ok=True)
+                with tempfile.TemporaryDirectory(
+                    prefix="absorb-bl029-fallback-",
+                    dir=str(self.layout.logs_dir),
+                ) as staging_dir:
+                    staging_path = Path(staging_dir)
+                    staged_sources: dict[str, str] = {}
+                    used_targets: set[Path] = set()
+                    for src_path in intake_targets:
+                        source = Path(src_path)
+                        target = staging_path / source.name
+                        if target.exists() or target in used_targets:
+                            stem, suffix = source.stem, source.suffix
+                            counter = 2
+                            while True:
+                                cand = staging_path / f"{stem}-{counter}{suffix}"
+                                if not cand.exists() and cand not in used_targets:
+                                    target = cand
+                                    break
+                                counter += 1
+                        used_targets.add(target)
+                        staged_sources[str(target)] = str(source)
+                        try:
+                            target.symlink_to(source)
+                        except OSError:
+                            target.write_text(
+                                source.read_text(encoding="utf-8"),
+                                encoding="utf-8",
+                            )
+                    fb = self._run_absorb_workflow_direct(
+                        directory=staging_path,
+                        dry_run=dry_run,
+                        staged_sources=staged_sources,
+                        record_item_ledger=not dry_run,
+                    )
                 fb_payload = (
                     fb.to_dict()
                     if hasattr(fb, "to_dict")

--- a/src/ovp_pipeline/unified_pipeline_enhanced.py
+++ b/src/ovp_pipeline/unified_pipeline_enhanced.py
@@ -2588,6 +2588,68 @@ class EnhancedPipeline:
             ]
 
         if normalized_files is not None and not normalized_files:
+            # PR-A (BL-029 quality→absorb fallback): the pipeline
+            # quality stage only scans the now-defunct
+            # ``20-Areas/*/Topics/<month>`` deep-dive layer, so
+            # post-BL-029 it qualifies nothing and absorb would
+            # skip forever — even though absorb v2 reads
+            # ``50-Inbox/03-Processed`` intake sources directly.
+            # Before giving up, probe absorb's OWN recent-target
+            # discovery (the same path standalone ``ovp-absorb
+            # --recent`` uses).  If eligible intake sources exist,
+            # fall back to the recent workflow instead of the
+            # ``no_qualified_files`` skip.  Per the agreed design
+            # we do NOT widen the quality checker into a
+            # general intake scanner — intake sources are not
+            # deep-dive quality artifacts.
+            try:
+                from .auto_evergreen_extractor import (
+                    _collect_absorb_targets,
+                )
+
+                intake_targets = _collect_absorb_targets(
+                    self.layout, recent=recent_days
+                )
+            except Exception:  # noqa: BLE001 — probe is best-effort
+                intake_targets = []
+
+            if intake_targets:
+                print(
+                    "\n⚠️  Quality artifact qualified 0 files "
+                    "(post-BL-029 the quality stage only scans the "
+                    "removed deep-dive layer).  Falling back to "
+                    f"absorb --recent {recent_days}: "
+                    f"{len(intake_targets)} eligible intake source"
+                    f"{'s' if len(intake_targets) != 1 else ''} "
+                    "in 03-Processed."
+                )
+                fb = self._run_absorb_workflow_direct(
+                    dry_run=dry_run,
+                    recent=recent_days,
+                    record_item_ledger=True,
+                )
+                fb_payload = (
+                    fb.to_dict()
+                    if hasattr(fb, "to_dict")
+                    else dict(fb)
+                )
+                # Tag the result so the run is auditable as the
+                # BL-029 fallback, not a normal quality-gated run.
+                fb_payload["bl029_intake_fallback"] = True
+                fb_payload["fallback_reason"] = (
+                    "quality_artifact_empty_post_bl029"
+                )
+                fb_payload["fallback_intake_targets"] = len(
+                    intake_targets
+                )
+                if input_artifact is not None:
+                    fb_payload["input_artifact"] = {
+                        "stage": input_artifact.get("stage"),
+                        "fingerprint": input_artifact.get("fingerprint"),
+                        "run_id": input_artifact.get("run_id"),
+                    }
+                return _to_absorb_result(fb_payload)
+
             print("\n⚠️  No qualified deep-dive files to absorb; skipping absorb stage")
             result = {
                 "success": True,

--- a/tests/test_pipeline_data_contracts.py
+++ b/tests/test_pipeline_data_contracts.py
@@ -268,11 +268,59 @@ class TestAbsorbStepResultContract:
         assert sorted(result["promoted_slugs"]) == ["a-深度解读", "b-深度解读"]
 
     def test_step_absorb_no_qualified_files_path(self, temp_vault):
+        # No intake sources in 03-Processed → the BL-029 fallback
+        # finds nothing → existing ``no_qualified_files`` skip
+        # still holds.
         pipeline = self._make_pipeline(temp_vault)
         result = pipeline.step_absorb(qualified_files=[])
         assert self.REQUIRED_KEYS <= result.keys()
         assert result["processed_files"] == []
         assert result["promoted_slugs"] == []
+        assert not result.get("bl029_intake_fallback")
+
+    def test_step_absorb_bl029_fallback_when_intake_sources_exist(
+        self, temp_vault
+    ):
+        """PR-A: pipeline absorb is called with
+        ``require_quality_artifact``-derived ``qualified_files=[]``
+        (post-BL-029 the quality stage only scans the removed
+        deep-dive layer).  When eligible intake sources exist in
+        50-Inbox/03-Processed, absorb must fall back to its own
+        recent-target discovery instead of the
+        ``no_qualified_files`` skip — otherwise post-BL-029 vaults
+        never absorb anything via the pipeline."""
+        from datetime import datetime, timezone
+
+        month = datetime.now(timezone.utc).strftime("%Y-%m")
+        proc_dir = (
+            temp_vault / "50-Inbox" / "03-Processed" / month
+        )
+        proc_dir.mkdir(parents=True, exist_ok=True)
+        src = proc_dir / "2026-05-16_example_source.md"
+        # Frontmatter with ``source:`` + body >200 chars →
+        # passes _is_intake_only_source_markdown.
+        src.write_text(
+            "---\ntitle: Example\nsource: https://example.com/x\n---\n\n"
+            + ("Real article body. " * 30),
+            encoding="utf-8",
+        )
+
+        pipeline = self._make_pipeline(temp_vault)
+        with patch(
+            "ovp_pipeline.unified_pipeline_enhanced.run_absorb_workflow",
+            return_value=self._canned_payload([src]),
+        ):
+            result = pipeline.step_absorb(qualified_files=[])
+
+        assert self.REQUIRED_KEYS <= result.keys()
+        # The skip path must NOT have been taken.
+        assert result.get("reason") != "no_qualified_files"
+        assert result.get("bl029_intake_fallback") is True
+        assert (
+            result.get("fallback_reason")
+            == "quality_artifact_empty_post_bl029"
+        )
+        assert result.get("fallback_intake_targets", 0) >= 1
 
     def test_step_absorb_quality_blocked_path(self, temp_vault):
         pipeline = self._make_pipeline(temp_vault)

--- a/tests/test_pipeline_data_contracts.py
+++ b/tests/test_pipeline_data_contracts.py
@@ -322,6 +322,34 @@ class TestAbsorbStepResultContract:
         )
         assert result.get("fallback_intake_targets", 0) >= 1
 
+    def test_step_absorb_fallback_ignores_qc_failed_deep_dives(
+        self, temp_vault
+    ):
+        """codex PR #248 P1: a recent ``20-Areas`` deep-dive that
+        FAILED quality (so the artifact is empty for THAT reason,
+        not the BL-029 empty-scan) must NOT trigger the fallback.
+        Falling back on it would bypass the quality gate.  With
+        only a deep-dive present and no 03-Processed intake
+        source, the skip must hold."""
+        from datetime import datetime, timezone
+
+        month = datetime.now(timezone.utc).strftime("%Y-%m")
+        dd_dir = (
+            temp_vault / "20-Areas" / "AI-Research" / "Topics" / month
+        )
+        dd_dir.mkdir(parents=True, exist_ok=True)
+        (dd_dir / "qc_failed_深度解读.md").write_text(
+            "---\ntitle: QC failed\n---\n" + ("low quality. " * 30),
+            encoding="utf-8",
+        )
+
+        pipeline = self._make_pipeline(temp_vault)
+        result = pipeline.step_absorb(qualified_files=[])
+        # Skip preserved — the deep-dive is NOT a fallback target.
+        assert result.get("reason") == "no_qualified_files"
+        assert not result.get("bl029_intake_fallback")
+        assert result["processed_files"] == []
+
     def test_step_absorb_quality_blocked_path(self, temp_vault):
         pipeline = self._make_pipeline(temp_vault)
         result = pipeline.step_absorb(quality_score=2.5)

--- a/tests/test_step_contracts.py
+++ b/tests/test_step_contracts.py
@@ -181,6 +181,10 @@ class TestAbsorbContract:
         "qualified_files", "pending_qualified_files",
         "item_cache_hits", "item_cache_hit_files",
         "summary", "results", "input_artifact", "total_evergreen",
+        # PR-A BL-029 quality→absorb fallback markers (auditable
+        # first-class fields, not dropped by typed coercion).
+        "bl029_intake_fallback", "fallback_reason",
+        "fallback_intake_targets",
     }
 
     def test_absorb_contract_has_all_required_fields(self):


### PR DESCRIPTION
## Summary

PR-A of the agreed 2-PR sequence (PR-B #247 audit-identity normalization shipped first; this is the behavior fix).

**Problem:** the pipeline calls absorb with `require_quality_artifact=True`. The quality stage only globs `20-Areas/*/Topics/<month>/*.md` — the deep-dive layer **BL-029 deleted**. Post-BL-029 nothing writes there → quality qualifies 0 files → `step_absorb` returns `no_qualified_files` and skips. The pipeline absorb stage has been a no-op since BL-029, even though absorb v2 reads `50-Inbox/03-Processed` directly and standalone `ovp-absorb --recent` works fine.

**Fix (per agreed design — do NOT widen the quality checker):** at the skip point, probe absorb's own `_collect_absorb_targets(recent=N)` (the exact discovery `ovp-absorb --recent` uses). If eligible 03-Processed intake sources exist, fall back to `_run_absorb_workflow_direct(recent=N)`. If none, the original skip is preserved. Quality-gating intake sources would be wrong post-BL-029 — they aren't deep-dive quality artifacts.

**Auditability:** 3 first-class `AbsorbStepResult` fields (`bl029_intake_fallback`, `fallback_reason`, `fallback_intake_targets`) so the fallback is visible in run reports, not dropped by typed coercion. `test_step_contracts` field-set guard updated in lockstep.

## Real operator-vault (dry probe, no LLM cost)

Before PR-A: pipeline absorb skipped (qualified 0). After PR-A: discovers **86 eligible intake targets at recent=7** (159 at recent=10, 670 at recent=30). The actual absorb run is left as an operator cost decision (~1 LLM call/source) — this PR restores the flow, doesn't force it.

## Test plan

- [x] New `test_step_absorb_bl029_fallback_when_intake_sources_exist` — seeds a real 03-Processed source, asserts fallback fires + is tagged.
- [x] `test_step_absorb_no_qualified_files_path` hardened — skip still holds when NO intake sources exist.
- [x] `test_step_contracts` REQUIRED_KEYS updated for the 3 new fields.
- [x] Full sweep: 2943 passed. Deselected digest tests are pre-existing UTC-midnight flakes (reproduced on clean main).

Sequence complete: PR-B (#247 correctness) → PR-A (this, behavior).