### PR TITLE
feat(m26 BL-103a): staleness zero reasons + top-line freshness verdict on /ops/today

### DIFF
--- a/src/ovp_pipeline/commands/_ui_renderers.py
+++ b/src/ovp_pipeline/commands/_ui_renderers.py
@@ -6681,6 +6681,45 @@ _TS_DISPLAY_LEN = 19
 _TODAY_DIGEST_STYLE = ""
 
 
+def _render_staleness_banner(staleness: dict) -> str:
+    """BL-103a top-line freshness verdict.  Answers "can I trust
+    these numbers?" BEFORE the operator reads any count — a zero (or
+    any number) is meaningless if the audit sync or the lifecycle
+    projection is behind.  ``unknown`` never implies freshness."""
+    if not staleness:
+        return ""
+    summary = str(staleness.get("summary") or "unknown")
+    detail = str(staleness.get("detail") or "")
+    if summary == "current":
+        icon, word, style = (
+            "✓",
+            "Projections current",
+            "border-left:3px solid var(--ok,#3a7);"
+            "background:var(--ok-bg,#f0f7f2)",
+        )
+    elif summary == "unknown":
+        icon, word, style = (
+            "?",
+            "Run status unknown",
+            "border-left:3px solid var(--border-strong,#999);"
+            "background:var(--card-bg,#f6f6f6)",
+        )
+    else:  # audit_sync_stale | projection_stale
+        icon, word, style = (
+            "⚠",
+            "Stale — refresh before trusting today's numbers",
+            "border-left:3px solid var(--warn,#c70);"
+            "background:var(--warn-bg,#fdf4e8)",
+        )
+    return (
+        f"<section class='card' style='margin:0 0 .6rem;{style}'>"
+        f"<strong>{icon} {escape(word)}</strong>"
+        f"<div class='muted tiny' style='margin-top:2px'>"
+        f"{escape(detail)}</div>"
+        "</section>"
+    )
+
+
 def _render_today_digest_page(payload: dict) -> str:
     """M25.7: ``/ops/today`` split into two clearly-separated zones.
 
@@ -6747,6 +6786,12 @@ def _render_today_digest_page(payload: dict) -> str:
                 " (lifecycle) and /ops/events/audit (forensic)."
             ),
         )
+    )
+
+    # BL-103a: top-line freshness verdict — the operator must know
+    # whether the numbers below are current before reading them.
+    sections.append(
+        _render_staleness_banner(payload.get("staleness") or {})
     )
 
     lifecycle = payload.get("lifecycle_summary") or {}

--- a/src/ovp_pipeline/ui/view_models.py
+++ b/src/ovp_pipeline/ui/view_models.py
@@ -3137,6 +3137,7 @@ from ..audit_identity import (
     audit_slug_for_column,
 )
 from ..audit_time import local_day as _audit_local_day
+from ..audit_time import parse_audit_ts as _parse_audit_ts
 from ..event_evidence_registry import (
     CATEGORIES as _EVT_CATEGORIES,
     event_types_for_category as _evt_for_category,
@@ -3612,6 +3613,151 @@ DEFAULT_RUNS_INDEX_LIMIT = 30
 # full run on the live vault (~3h) with comfortable headroom.
 RUNS_STALE_AFTER_HOURS = 6
 
+# Clock-skew slack when comparing timestamps from different
+# producers (event_emitter UTC vs PipelineLogger naive-local, plus
+# ops_state.refreshed_at).  Below this delta we call it "current"
+# rather than flag a spurious staleness.
+_STALENESS_SLACK_SECONDS = 120
+
+
+def _jsonl_latest_ts(jsonl_path: Path):
+    """Newest audit timestamp in ``pipeline.jsonl`` WITHOUT a full
+    read (BL-108 debt): the log is append-only so the last non-empty
+    line is the newest event.  Tail ~64KB, walk lines from the end,
+    return the first that parses.  None if unreadable/unparseable."""
+    try:
+        size = jsonl_path.stat().st_size
+    except OSError:
+        return None
+    if size == 0:
+        return None
+    try:
+        with open(jsonl_path, "rb") as fh:
+            fh.seek(max(0, size - 65536))
+            tail = fh.read().decode("utf-8", "ignore")
+    except OSError:
+        return None
+    for line in reversed(tail.splitlines()):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except ValueError:
+            continue
+        if not isinstance(row, dict):
+            continue
+        ts = row.get("timestamp") or row.get("ts")
+        parsed = _parse_audit_ts(str(ts or ""))
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def compute_today_staleness(
+    vault_dir: Path | str, *, pack: str
+) -> dict[str, Any]:
+    """BL-103a: can the operator trust the daily numbers, or is a
+    sync / projection rebuild outstanding?
+
+    Two cheap, telemetry-free signals:
+
+    * ``audit_sync_stale`` — ``pipeline.jsonl`` has a newer event
+      than the newest row in ``knowledge.db.audit_events`` (the
+      JSONL ledger advanced but the sync hasn't run).
+    * ``projection_stale`` — ``ops_state`` was last refreshed BEFORE
+      the newest synced audit row (audit is current but the
+      lifecycle projection hasn't been rebuilt to reflect it).
+
+    ``None`` for either flag means "could not determine" — the UI
+    must say "run status unknown", never imply freshness it can't
+    prove.
+    """
+    db_path = _db_path(vault_dir)
+    jsonl_path = db_path.with_name("pipeline.jsonl")
+
+    db_latest = None
+    projection_at = None
+    if db_path.exists():
+        try:
+            with sqlite3.connect(db_path) as conn:
+                row = conn.execute(
+                    "SELECT MAX(timestamp) FROM audit_events"
+                ).fetchone()
+                if row and row[0]:
+                    db_latest = _parse_audit_ts(str(row[0]))
+                has_ops = conn.execute(
+                    "SELECT 1 FROM sqlite_master "
+                    "WHERE type='table' AND name='ops_state'"
+                ).fetchone()
+                if has_ops:
+                    prow = conn.execute(
+                        "SELECT MAX(refreshed_at) FROM ops_state "
+                        " WHERE pack = ?",
+                        (pack,),
+                    ).fetchone()
+                    if prow and prow[0]:
+                        projection_at = _parse_audit_ts(str(prow[0]))
+        except sqlite3.Error:
+            pass
+
+    jsonl_latest = _jsonl_latest_ts(jsonl_path)
+    slack = _dt.timedelta(seconds=_STALENESS_SLACK_SECONDS)
+
+    # audit_sync_stale
+    if jsonl_latest is None:
+        audit_sync_stale: bool | None = None
+    elif db_latest is None:
+        # JSONL has events but nothing is synced.
+        audit_sync_stale = True
+    else:
+        audit_sync_stale = jsonl_latest > db_latest + slack
+
+    # projection_stale
+    if db_latest is None:
+        projection_stale: bool | None = None
+    elif projection_at is None:
+        # audit synced but no projection materialized yet.
+        projection_stale = True
+    else:
+        projection_stale = projection_at < db_latest - slack
+
+    if audit_sync_stale:
+        summary = "audit_sync_stale"
+        detail = (
+            "pipeline.jsonl has newer events than knowledge.db — run "
+            "`ovp-refresh-ops` before trusting today's counts."
+        )
+    elif projection_stale:
+        summary = "projection_stale"
+        detail = (
+            "audit is synced but the lifecycle projection is older "
+            "than it — run `ovp-ops-state --rebuild` (or "
+            "`ovp-refresh-ops`)."
+        )
+    elif audit_sync_stale is None or projection_stale is None:
+        summary = "unknown"
+        detail = (
+            "Could not determine freshness (missing pipeline.jsonl "
+            "or knowledge.db); run status unknown."
+        )
+    else:
+        summary = "current"
+        detail = "Audit and lifecycle projection are current."
+
+    def _iso(dt: Any) -> str:
+        return dt.isoformat() if dt is not None else ""
+
+    return {
+        "summary": summary,
+        "detail": detail,
+        "audit_sync_stale": audit_sync_stale,
+        "projection_stale": projection_stale,
+        "jsonl_latest": _iso(jsonl_latest),
+        "db_latest": _iso(db_latest),
+        "projection_at": _iso(projection_at),
+    }
+
 
 def build_today_digest_payload(
     vault_dir: Path | str,
@@ -3696,6 +3842,9 @@ def build_today_digest_payload(
     lifecycle_summary = _read_lifecycle_summary(
         vault_dir, pack=requested_pack
     )
+    staleness = compute_today_staleness(
+        vault_dir, pack=effective_pack
+    )
 
     return {
         "screen": "ops/today",
@@ -3707,6 +3856,7 @@ def build_today_digest_payload(
         "next_date_path": _date_path(next_date),
         "cards": cards,
         "lifecycle_summary": lifecycle_summary,
+        "staleness": staleness,
         "available": True,
     }
 

--- a/tests/test_m26_staleness.py
+++ b/tests/test_m26_staleness.py
@@ -1,0 +1,151 @@
+"""M26 BL-103a — staleness zero reasons on /ops/today.
+
+A number (especially a zero) on the daily page is meaningless if
+the operator can't tell whether it is current.  These lock the two
+telemetry-free signals:
+
+* ``audit_sync_stale`` — pipeline.jsonl advanced past
+  knowledge.db.audit_events.
+* ``projection_stale`` — ops_state was refreshed before the newest
+  synced audit row.
+
+``unknown`` must never imply freshness.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from ovp_pipeline.commands._ui_renderers import _render_staleness_banner
+from ovp_pipeline.ui.view_models import (
+    build_today_digest_payload,
+    compute_today_staleness,
+)
+
+PACK = "research-tech"
+
+_AUDIT_SCHEMA = """
+CREATE TABLE audit_events (
+    source_log TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    slug TEXT NOT NULL DEFAULT '',
+    session_id TEXT NOT NULL DEFAULT '',
+    timestamp TEXT NOT NULL DEFAULT '',
+    payload_json TEXT NOT NULL
+);
+"""
+_OPS_SCHEMA = """
+CREATE TABLE ops_state (
+    pack TEXT NOT NULL, item_kind TEXT NOT NULL, item_id TEXT NOT NULL,
+    state TEXT NOT NULL, sub_state TEXT, last_evidence_at TEXT,
+    evidence_event_types_json TEXT NOT NULL DEFAULT '[]',
+    needs_action_reason TEXT, refreshed_at TEXT NOT NULL,
+    PRIMARY KEY (pack, item_kind, item_id)
+);
+"""
+
+
+def _db(
+    tmp_path: Path,
+    *,
+    audit_max: str | None,
+    refreshed_at: str | None,
+    with_ops: bool = True,
+) -> Path:
+    db = tmp_path / "60-Logs" / "knowledge.db"
+    db.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db)
+    conn.executescript(_AUDIT_SCHEMA)
+    if audit_max:
+        conn.execute(
+            "INSERT INTO audit_events VALUES (?,?,?,?,?,?)",
+            ("pipeline.jsonl", "article_intake_only", "s", "x", audit_max, "{}"),
+        )
+    if with_ops:
+        conn.executescript(_OPS_SCHEMA)
+        if refreshed_at:
+            conn.execute(
+                "INSERT INTO ops_state VALUES (?,?,?,?,?,?,?,?,?)",
+                (PACK, "source", "s1", "Received", None, "", "[]", None, refreshed_at),
+            )
+    conn.commit()
+    conn.close()
+    return tmp_path
+
+
+def _jsonl(tmp_path: Path, ts: str) -> None:
+    p = tmp_path / "60-Logs" / "pipeline.jsonl"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps({"event_type": "article_intake_only", "timestamp": ts}) + "\n")
+
+
+def test_current_when_jsonl_and_projection_keep_up(tmp_path):
+    v = _db(tmp_path, audit_max="2026-05-10T10:00:00", refreshed_at="2026-05-10T10:01:00")
+    _jsonl(tmp_path, "2026-05-10T10:00:30")
+    s = compute_today_staleness(v, pack=PACK)
+    assert s["summary"] == "current"
+    assert s["audit_sync_stale"] is False
+    assert s["projection_stale"] is False
+
+
+def test_audit_sync_stale_when_jsonl_ahead(tmp_path):
+    v = _db(tmp_path, audit_max="2026-05-10T10:00:00", refreshed_at="2026-05-10T10:00:10")
+    _jsonl(tmp_path, "2026-05-10T15:00:00")  # 5h newer than synced DB
+    s = compute_today_staleness(v, pack=PACK)
+    assert s["audit_sync_stale"] is True
+    assert s["summary"] == "audit_sync_stale"
+    assert "ovp-refresh-ops" in s["detail"]
+
+
+def test_projection_stale_when_ops_state_behind_audit(tmp_path):
+    v = _db(tmp_path, audit_max="2026-05-10T12:00:00", refreshed_at="2026-05-09T08:00:00")
+    _jsonl(tmp_path, "2026-05-10T12:00:00")  # in sync with DB
+    s = compute_today_staleness(v, pack=PACK)
+    assert s["audit_sync_stale"] is False
+    assert s["projection_stale"] is True
+    assert s["summary"] == "projection_stale"
+
+
+def test_unknown_when_no_db(tmp_path):
+    # no knowledge.db, no pipeline.jsonl
+    s = compute_today_staleness(tmp_path, pack=PACK)
+    assert s["summary"] == "unknown"
+    assert s["audit_sync_stale"] is None
+    assert s["projection_stale"] is None
+
+
+def test_unsynced_when_db_empty_but_jsonl_has_events(tmp_path):
+    v = _db(tmp_path, audit_max=None, refreshed_at=None)
+    _jsonl(tmp_path, "2026-05-10T10:00:00")
+    s = compute_today_staleness(v, pack=PACK)
+    assert s["audit_sync_stale"] is True
+
+
+def test_projection_stale_when_audit_synced_no_ops_state(tmp_path):
+    v = _db(tmp_path, audit_max="2026-05-10T10:00:00", refreshed_at=None, with_ops=False)
+    _jsonl(tmp_path, "2026-05-10T10:00:00")
+    s = compute_today_staleness(v, pack=PACK)
+    assert s["audit_sync_stale"] is False
+    assert s["projection_stale"] is True
+
+
+def test_payload_carries_staleness(tmp_path):
+    v = _db(tmp_path, audit_max="2026-05-10T10:00:00", refreshed_at="2026-05-10T10:00:30")
+    _jsonl(tmp_path, "2026-05-10T10:00:10")
+    payload = build_today_digest_payload(v, pack_name=PACK, target_date="2026-05-10")
+    assert "staleness" in payload
+    assert payload["staleness"]["summary"] == "current"
+
+
+def test_banner_render_states():
+    cur = _render_staleness_banner({"summary": "current", "detail": "ok"})
+    assert "Projections current" in cur
+    stale = _render_staleness_banner(
+        {"summary": "audit_sync_stale", "detail": "run ovp-refresh-ops"}
+    )
+    assert "Stale" in stale and "ovp-refresh-ops" in stale
+    unk = _render_staleness_banner({"summary": "unknown", "detail": "?"})
+    assert "Run status unknown" in unk
+    assert _render_staleness_banner({}) == ""


### PR DESCRIPTION
## Summary

Second M26 slice (BL-103a). A number on `/ops/today` is meaningless if the operator can't tell whether it's current — the original complaint. Adds two **telemetry-free** staleness signals and a top-line verdict above the four zones.

- **`audit_sync_stale`** — `pipeline.jsonl` has a newer event than the newest `knowledge.db.audit_events` row (the sync hasn't run). Detected via a cheap tail-read of the append-only JSONL — does **not** add to the BL-108 full-read debt.
- **`projection_stale`** — `ops_state.refreshed_at` predates the newest synced audit row (audit current, projection not rebuilt).
- `compute_today_staleness()` returns both flags (`None` = unknown — never implies freshness), a summary, and a human detail with the exact fix command.
- `_render_staleness_banner` renders ✓ current / ⚠ stale / ? unknown as the **first** thing on the page (the plan's "read in ten seconds" top-line; seeds the BL-100 verdict).

## Dogfood evidence (live vault)

Immediately caught a real condition the operator had no way to see:

```
summary: audit_sync_stale
jsonl_latest:  2026-05-16T13:00:19+00:00
db_latest:     2026-05-16T06:29:00+00:00   (~6.5h behind)
projection_at: 2026-05-16T11:57:06+00:00
```

Live page now renders at top: `⚠ Stale — refresh before trusting today's numbers · pipeline.jsonl has newer events than knowledge.db — run ovp-refresh-ops`.

## Test plan

- [x] `tests/test_m26_staleness.py` — current / audit_sync_stale / projection_stale / unknown / db-empty-but-jsonl / audit-synced-no-ops-state / payload-carries-staleness / banner states
- [x] `test_ui_server` + M26 suites green (138 passed)
- [x] Broader related suite green; ruff/mypy net-neutral vs the file's pre-existing E402 debt
- [x] Live `/ops/today` dogfooded after restart — banner renders, flags real staleness

Next per plan sequence: BL-105 (intake cohort), then BL-103b.

Plan: `docs/plans/2026-05-16-m26-daily-observability.md`