### PR TITLE
feat(m26 BL-105): intake cohort view — Flow by intake day

### DIFF
--- a/src/ovp_pipeline/commands/_ui_renderers.py
+++ b/src/ovp_pipeline/commands/_ui_renderers.py
@@ -6720,6 +6720,84 @@ def _render_staleness_banner(staleness: dict) -> str:
     )
 
 
+def _render_intake_cohort_zone(cohort: dict, date: str) -> str:
+    """BL-105 "Flow by intake day" zone.  Distinct from Activity:
+    Activity counts what the system DID on the event day; this
+    follows the sources whose intake STARTED on this day to where
+    they are now.  The copy says so — BL-100 forbids making the
+    operator infer which timestamp a number uses."""
+    if not cohort or not cohort.get("available"):
+        reason = escape(str((cohort or {}).get("reason") or ""))
+        body = (
+            f"<p class='muted tiny'>{reason}</p>" if reason else
+            "<p class='muted tiny'>No intake-cohort data.</p>"
+        )
+        return (
+            "<section class='card' style='margin:.6rem 0 0'>"
+            "<div class='muted tiny'>Flow by intake day</div>"
+            f"{body}</section>"
+        )
+    size = int(cohort.get("cohort_size") or 0)
+    dist = cohort.get("distribution") or {}
+    untracked = int(cohort.get("untracked") or 0)
+    stalled = int(cohort.get("stalled") or 0)
+    stall_days = int(cohort.get("stall_days") or 7)
+    oldest = int(cohort.get("oldest_age_days") or 0)
+
+    if size == 0:
+        return (
+            "<section class='card' style='margin:.6rem 0 0'>"
+            "<div class='muted tiny'>Flow by intake day — "
+            f"{escape(date)}</div>"
+            "<p class='muted tiny' style='margin-top:4px'>No sources"
+            " first entered intake on this day.  (This is the"
+            " intake-time axis, not the event-time Activity above.)"
+            "</p></section>"
+        )
+
+    parts = []
+    for st in ("Received", "Extracted", "Accepted", "Synthesized", "NeedsAction"):
+        n = int(dist.get(st) or 0)
+        if n:
+            parts.append(f"{n} {escape(st)}")
+    if untracked:
+        parts.append(f"{untracked} Untracked")
+    distribution_line = " · ".join(parts) if parts else "no current state"
+
+    stalled_html = (
+        f"<span class='warn'> · {stalled} stalled "
+        f"(&gt;{stall_days}d in Received/Extracted)</span>"
+        if stalled
+        else ""
+    )
+
+    sample_rows = ""
+    for s in cohort.get("samples") or []:
+        sample_rows += (
+            "<div class='tiny' style='margin-top:2px'>"
+            f"<a href='{escape(str(s.get('href') or '#'))}'>"
+            f"{escape(str(s.get('slug') or ''))}</a> "
+            f"<span class='muted'>→ {escape(str(s.get('state') or ''))}"
+            f" · {int(s.get('age_days') or 0)}d old</span></div>"
+        )
+
+    return (
+        "<section class='card' style='margin:.6rem 0 0'>"
+        f"<div class='muted tiny'>Flow by intake day — {escape(date)}"
+        " <span style='opacity:.7'>(where the sources first saved"
+        " this day are now — NOT the event-time Activity above)</span>"
+        "</div>"
+        f"<div style='margin-top:4px'><strong>{size}</strong> "
+        f"source{'s' if size != 1 else ''} first entered intake on "
+        f"{escape(date)}</div>"
+        f"<div class='muted tiny' style='margin-top:2px'>"
+        f"now: {distribution_line}{stalled_html} · oldest {oldest}d"
+        "</div>"
+        f"{sample_rows}"
+        "</section>"
+    )
+
+
 def _render_today_digest_page(payload: dict) -> str:
     """M25.7: ``/ops/today`` split into two clearly-separated zones.
 
@@ -7009,6 +7087,14 @@ def _render_today_digest_page(payload: dict) -> str:
             "</div>"
         )
     activity_sections.append("</div></section>")
+
+    # BL-105: New Intake (intake-time axis) sits with the other
+    # date-driven content, clearly separated from Activity.
+    activity_sections.append(
+        _render_intake_cohort_zone(
+            payload.get("intake_cohort") or {}, date
+        )
+    )
 
     # M25.7 fix: Activity FIRST (date pivot near top — no
     # scroll-hunting after prev/next), Current backlog SECOND.

--- a/src/ovp_pipeline/ui/view_models.py
+++ b/src/ovp_pipeline/ui/view_models.py
@@ -3759,6 +3759,153 @@ def compute_today_staleness(
     }
 
 
+# A cohort source still sitting in Received/Extracted older than
+# this is "stalled" — intake happened but the pipeline never moved
+# it forward.  One week covers the normal manual-absorb cadence.
+_INTAKE_STALL_DAYS = 7
+
+
+def build_intake_cohort_payload(
+    vault_dir: Path | str, *, date_key: str, pack: str
+) -> dict[str, Any]:
+    """BL-105: "Flow by intake day".  For the sources whose FIRST
+    durable intake (operator-local day) is ``date_key``, show where
+    they are *now* — current ``ops_state`` distribution, age, and
+    how many stalled in Received/Extracted.
+
+    Answers the operator's actual question — "what happened to the
+    articles I saved that day?" — which Activity (event-day) cannot:
+    a source saved on the 10th but absorbed on the 16th shows up in
+    the 10th's cohort here, but in the 16th's Activity there.
+
+    Identity + pack scoping reuse the BL-101 helpers; needs only
+    intake-class audit evidence + current ``ops_state`` (both exist
+    post-PR-B), so it ships before the BL-103b stage ledger.
+    """
+    from ..ops_lifecycle import ALL_STATES
+
+    db_path = _db_path(vault_dir)
+    base: dict[str, Any] = {
+        "screen": "ops/intake-cohort",
+        "date": date_key,
+        "requested_pack": pack,
+        "available": False,
+        "reason": "",
+        "cohort_size": 0,
+        "distribution": {s: 0 for s in ALL_STATES},
+        "untracked": 0,
+        "stalled": 0,
+        "stall_days": _INTAKE_STALL_DAYS,
+        "oldest_age_days": 0,
+        "samples": [],
+    }
+    if not db_path.exists():
+        base["reason"] = "knowledge_index has not been built yet"
+        return base
+
+    intake_types = tuple(_evt_for_category("intake"))
+    if not intake_types:
+        base["available"] = True
+        return base
+    effective_pack = pack or PRIMARY_PACK_NAME
+
+    # Earliest intake instant per source identity, across ALL
+    # history — we can only know a source's cohort day by proving it
+    # had no earlier intake.  (Full intake-subset scan; BL-108
+    # streaming is the perf follow-up, not a blocker here.)
+    earliest: dict[str, Any] = {}
+    state_by_id: dict[str, str] = {}
+    with sqlite3.connect(db_path) as conn:
+        et_ph = ",".join("?" for _ in intake_types)
+        for ts, slug, pj in conn.execute(
+            f"SELECT timestamp, slug, payload_json FROM audit_events "
+            f" WHERE event_type IN ({et_ph})",
+            intake_types,
+        ):
+            parsed = _parse_audit_ts(str(ts or ""))
+            if parsed is None:
+                continue
+            try:
+                payload = json.loads(pj or "{}")
+            except ValueError:
+                payload = {}
+            if not isinstance(payload, dict):
+                payload = {}
+            rp = _audit_row_pack(payload)
+            if rp is None:
+                if effective_pack != PRIMARY_PACK_NAME:
+                    continue
+            elif rp != effective_pack:
+                continue
+            ident = _source_identity(str(slug or ""), payload)
+            if not ident:
+                continue
+            cur = earliest.get(ident)
+            if cur is None or parsed < cur:
+                earliest[ident] = parsed
+
+        cohort = {
+            sid: ts
+            for sid, ts in earliest.items()
+            if ts.astimezone().date().isoformat() == date_key
+        }
+        has_ops = conn.execute(
+            "SELECT 1 FROM sqlite_master "
+            "WHERE type='table' AND name='ops_state'"
+        ).fetchone()
+        if has_ops and cohort:
+            ids = list(cohort)
+            for i in range(0, len(ids), 400):
+                chunk = ids[i : i + 400]
+                ph = ",".join("?" for _ in chunk)
+                for iid, st in conn.execute(
+                    f"SELECT item_id, state FROM ops_state "
+                    f" WHERE pack = ? AND item_kind = 'source' "
+                    f"   AND item_id IN ({ph})",
+                    (effective_pack, *chunk),
+                ):
+                    state_by_id[str(iid)] = str(st)
+
+    now = _dt.datetime.now(_dt.timezone.utc)
+    dist = {s: 0 for s in ALL_STATES}
+    untracked = 0
+    stalled = 0
+    ages: list[int] = []
+    samples: list[dict[str, Any]] = []
+    for sid, ts in sorted(cohort.items(), key=lambda kv: kv[1]):
+        st = state_by_id.get(sid)
+        age = (now - ts).days
+        ages.append(age)
+        if st in dist:
+            dist[st] += 1
+        else:
+            untracked += 1
+        if st in ("Received", "Extracted") and age > _INTAKE_STALL_DAYS:
+            stalled += 1
+        if len(samples) < TODAY_CARD_SAMPLE_SIZE:
+            samples.append({
+                "slug": sid,
+                "state": st or "Untracked",
+                "intake_at": ts.astimezone().isoformat(),
+                "age_days": age,
+                "href": _scoped_path(
+                    f"/ops/items?state={quote(st or '', safe='')}",
+                    pack_name=pack,
+                ),
+            })
+
+    base.update(
+        available=True,
+        cohort_size=len(cohort),
+        distribution=dist,
+        untracked=untracked,
+        stalled=stalled,
+        oldest_age_days=max(ages) if ages else 0,
+        samples=samples,
+    )
+    return base
+
+
 def build_today_digest_payload(
     vault_dir: Path | str,
     *,
@@ -3845,6 +3992,9 @@ def build_today_digest_payload(
     staleness = compute_today_staleness(
         vault_dir, pack=effective_pack
     )
+    intake_cohort = build_intake_cohort_payload(
+        vault_dir, date_key=date_key, pack=effective_pack
+    )
 
     return {
         "screen": "ops/today",
@@ -3857,6 +4007,7 @@ def build_today_digest_payload(
         "cards": cards,
         "lifecycle_summary": lifecycle_summary,
         "staleness": staleness,
+        "intake_cohort": intake_cohort,
         "available": True,
     }
 

--- a/tests/test_m26_intake_cohort.py
+++ b/tests/test_m26_intake_cohort.py
@@ -1,0 +1,162 @@
+"""M26 BL-105 — "Flow by intake day" cohort view.
+
+Answers "what happened to the articles I saved that day?" — the
+operator's actual question, which event-time Activity cannot. A
+source counts in cohort D iff its EARLIEST intake (operator-local
+day) is D; the view then shows where those sources are now.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from ovp_pipeline.commands._ui_renderers import _render_intake_cohort_zone
+from ovp_pipeline.ui.view_models import (
+    build_intake_cohort_payload,
+    build_today_digest_payload,
+)
+
+PACK = "research-tech"
+
+_AUDIT = """
+CREATE TABLE audit_events (
+    source_log TEXT NOT NULL, event_type TEXT NOT NULL,
+    slug TEXT NOT NULL DEFAULT '', session_id TEXT NOT NULL DEFAULT '',
+    timestamp TEXT NOT NULL DEFAULT '', payload_json TEXT NOT NULL
+);
+"""
+_OPS = """
+CREATE TABLE ops_state (
+    pack TEXT NOT NULL, item_kind TEXT NOT NULL, item_id TEXT NOT NULL,
+    state TEXT NOT NULL, sub_state TEXT, last_evidence_at TEXT,
+    evidence_event_types_json TEXT NOT NULL DEFAULT '[]',
+    needs_action_reason TEXT, refreshed_at TEXT NOT NULL,
+    PRIMARY KEY (pack, item_kind, item_id)
+);
+"""
+
+
+def _vault(tmp_path: Path, audit_rows, ops_rows=None) -> Path:
+    db = tmp_path / "60-Logs" / "knowledge.db"
+    db.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db)
+    conn.executescript(_AUDIT)
+    conn.executemany("INSERT INTO audit_events VALUES (?,?,?,?,?,?)", audit_rows)
+    conn.executescript(_OPS)
+    if ops_rows:
+        conn.executemany("INSERT INTO ops_state VALUES (?,?,?,?,?,?,?,?,?)", ops_rows)
+    conn.commit()
+    conn.close()
+    return tmp_path
+
+
+def _ev(et, slug, ts, payload=None):
+    return ("pipeline.jsonl", et, slug, "s", ts, json.dumps(payload or {}))
+
+
+def _ops(slug, state, refreshed="2026-05-16T00:00:00"):
+    return (PACK, "source", slug, state, None, "", "[]", None, refreshed)
+
+
+def test_cohort_membership_by_earliest_intake_day(tmp_path):
+    """B was first seen on 01-01 then again on 05-10 — its cohort is
+    01-01, NOT 05-10.  A first seen 05-10 → cohort 05-10."""
+    v = _vault(
+        tmp_path,
+        [
+            _ev("article_intake_only", "src-a", "2026-05-10T09:00:00"),
+            _ev("article_intake_only", "src-b", "2026-01-01T09:00:00"),
+            _ev("source_staged_for_processing", "src-b", "2026-05-10T09:00:00"),
+        ],
+        [_ops("src-a", "Extracted"), _ops("src-b", "Accepted")],
+    )
+    c10 = build_intake_cohort_payload(v, date_key="2026-05-10", pack=PACK)
+    assert c10["cohort_size"] == 1  # only src-a
+    assert c10["distribution"]["Extracted"] == 1
+    c01 = build_intake_cohort_payload(v, date_key="2026-01-01", pack=PACK)
+    assert c01["cohort_size"] == 1  # only src-b
+    assert c01["distribution"]["Accepted"] == 1
+
+
+def test_untracked_when_no_ops_state_row(tmp_path):
+    v = _vault(
+        tmp_path,
+        [_ev("article_intake_only", "src-x", "2026-05-10T09:00:00")],
+        [],  # no ops_state rows
+    )
+    c = build_intake_cohort_payload(v, date_key="2026-05-10", pack=PACK)
+    assert c["cohort_size"] == 1
+    assert c["untracked"] == 1
+    assert sum(c["distribution"].values()) == 0
+
+
+def test_stalled_counts_old_received_extracted(tmp_path):
+    """A source intaken months ago and still Received is stalled."""
+    v = _vault(
+        tmp_path,
+        [_ev("article_intake_only", "src-old", "2026-01-01T09:00:00")],
+        [_ops("src-old", "Received")],
+    )
+    c = build_intake_cohort_payload(v, date_key="2026-01-01", pack=PACK)
+    assert c["cohort_size"] == 1
+    assert c["stalled"] == 1
+    assert c["oldest_age_days"] > c["stall_days"]
+
+
+def test_pack_scoping(tmp_path):
+    v = _vault(
+        tmp_path,
+        [
+            _ev("article_intake_only", "src-rt", "2026-05-10T09:00:00", {"pack": "research-tech"}),
+            _ev("article_intake_only", "src-leg", "2026-05-10T09:00:00"),
+            _ev("article_intake_only", "src-oth", "2026-05-10T09:00:00", {"pack": "other"}),
+        ],
+        [_ops("src-rt", "Received"), _ops("src-leg", "Received")],
+    )
+    c = build_intake_cohort_payload(v, date_key="2026-05-10", pack="research-tech")
+    assert c["cohort_size"] == 2  # rt + legacy, not other
+
+
+def test_unavailable_without_db(tmp_path):
+    c = build_intake_cohort_payload(tmp_path, date_key="2026-05-10", pack=PACK)
+    assert c["available"] is False
+    assert "knowledge_index" in c["reason"]
+
+
+def test_payload_carries_intake_cohort(tmp_path):
+    v = _vault(
+        tmp_path,
+        [_ev("article_intake_only", "src-a", "2026-05-10T09:00:00")],
+        [_ops("src-a", "Extracted")],
+    )
+    payload = build_today_digest_payload(v, pack_name=PACK, target_date="2026-05-10")
+    assert "intake_cohort" in payload
+    assert payload["intake_cohort"]["cohort_size"] == 1
+
+
+def test_zone_render_distinguishes_from_activity(tmp_path):
+    v = _vault(
+        tmp_path,
+        [_ev("article_intake_only", "src-a", "2026-05-10T09:00:00")],
+        [_ops("src-a", "Extracted")],
+    )
+    c = build_intake_cohort_payload(v, date_key="2026-05-10", pack=PACK)
+    html = _render_intake_cohort_zone(c, "2026-05-10")
+    assert "Flow by intake day" in html
+    assert "<strong>1</strong> source" in html
+    assert "first entered intake on 2026-05-10" in html
+    assert "Extracted" in html
+    # BL-100: copy must say this is NOT the event-time Activity
+    assert "Activity" in html
+
+
+def test_zone_render_empty_and_unavailable():
+    empty = _render_intake_cohort_zone({"available": True, "cohort_size": 0}, "2026-05-10")
+    assert "No sources first entered intake" in empty
+    unavail = _render_intake_cohort_zone(
+        {"available": False, "reason": "knowledge_index has not been built yet"},
+        "2026-05-10",
+    )
+    assert "knowledge_index" in unavail


### PR DESCRIPTION
## Summary

Third M26 slice (BL-105) — the plan's highest user-value view. Answers "what happened to the articles I saved that day?", which event-time Activity structurally cannot: a source saved on the 10th but absorbed on the 16th appears in the 10th's **cohort** here but the 16th's **Activity** there.

- `build_intake_cohort_payload` — a source belongs to cohort D iff its **earliest** intake event (operator-local day, pack-scoped, reusing BL-101 identity) is D. Joins current `ops_state` → distribution (Received/Extracted/Accepted/NeedsAction/Untracked), age, and stalled count (>7d still in Received/Extracted).
- Needs only intake evidence + current `ops_state` (both exist post-PR-B) — ships before the heavy BL-103b stage ledger, per the plan sequence.
- Rendered as a distinct "Flow by intake day" zone on `/ops/today`, grouped with date-driven content; copy explicitly states it is **NOT** the event-time Activity (BL-100: never make the operator infer the timestamp axis).

## Dogfood evidence (live vault, 2026-05-10)

> Flow by intake day — 2026-05-10 — **38** sources first entered intake on 2026-05-10 — now: 9 Received · 26 Extracted · 1 Accepted · 2 NeedsAction · oldest 6d

`cohort_size 38` cross-checks the BL-101 distinct `Received=38` for that day — strong internal consistency.

## Test plan

- [x] `tests/test_m26_intake_cohort.py` — earliest-day cohort membership (re-intake doesn't re-cohort), untracked, stalled, pack scoping, unavailable, payload wiring, zone render incl. Activity-distinction copy
- [x] `test_ui_server` + M26 + broader related suites green (171 passed)
- [x] ruff/mypy net-neutral vs the file's pre-existing E402/F401 debt; new test file clean
- [x] Live `/ops/today` dogfooded after restart — zone renders, numbers coherent

Next per plan sequence: BL-103b (stage-run ledger + full zero taxonomy), then BL-104, BL-106, BL-107/108.

Plan: `docs/plans/2026-05-16-m26-daily-observability.md`