### PR TITLE
feat(m26 BL-104): Workflow Progress projection

### DIFF
--- a/src/ovp_pipeline/commands/_ui_renderers.py
+++ b/src/ovp_pipeline/commands/_ui_renderers.py
@@ -6798,6 +6798,49 @@ def _render_intake_cohort_zone(cohort: dict, date: str) -> str:
     )
 
 
+def _render_workflow_progress_zone(wp: dict, date: str) -> str:
+    """BL-104 "Workflow Progress" zone — items that ENTERED a state
+    on this day (transition-time axis).  Explicitly NOT the
+    event-row Activity and NOT the right-now Current backlog."""
+    if not wp or not wp.get("available"):
+        reason = escape(str((wp or {}).get("reason") or ""))
+        return (
+            "<section class='card' style='margin:.6rem 0 0'>"
+            "<div class='muted tiny'>Workflow progress</div>"
+            + (f"<p class='muted tiny'>{reason}</p>" if reason else "")
+            + "</section>"
+        )
+    moved = wp.get("moved") or {}
+    total = int(wp.get("total") or 0)
+    if total == 0:
+        return (
+            "<section class='card' style='margin:.6rem 0 0'>"
+            "<div class='muted tiny'>Workflow progress — "
+            f"{escape(date)}</div>"
+            "<p class='muted tiny' style='margin-top:4px'>No items"
+            " changed lifecycle state on this day.  (Transition-time"
+            " axis — not the event-row Activity, not the right-now"
+            " backlog.)</p></section>"
+        )
+    parts = []
+    for st in ("Received", "Extracted", "Accepted", "Synthesized", "NeedsAction"):
+        n = int(moved.get(st) or 0)
+        if n:
+            parts.append(f"{n} → {escape(st)}")
+    line = " · ".join(parts) if parts else "no transitions"
+    return (
+        "<section class='card' style='margin:.6rem 0 0'>"
+        f"<div class='muted tiny'>Workflow progress — {escape(date)}"
+        " <span style='opacity:.7'>(items that ENTERED a state this"
+        " day — not event rows, not the right-now backlog)</span>"
+        "</div>"
+        f"<div style='margin-top:4px'><strong>{total}</strong> "
+        f"item{'s' if total != 1 else ''} moved forward</div>"
+        f"<div class='muted tiny' style='margin-top:2px'>{line}</div>"
+        "</section>"
+    )
+
+
 def _render_today_digest_page(payload: dict) -> str:
     """M25.7: ``/ops/today`` split into two clearly-separated zones.
 
@@ -7113,6 +7156,13 @@ def _render_today_digest_page(payload: dict) -> str:
     activity_sections.append(
         _render_intake_cohort_zone(
             payload.get("intake_cohort") or {}, date
+        )
+    )
+    # BL-104: Workflow Progress (transition-time axis) joins the
+    # date-driven group, clearly separated from Activity + backlog.
+    activity_sections.append(
+        _render_workflow_progress_zone(
+            payload.get("workflow_progress") or {}, date
         )
     )
 

--- a/src/ovp_pipeline/ui/view_models.py
+++ b/src/ovp_pipeline/ui/view_models.py
@@ -4076,6 +4076,100 @@ def build_intake_cohort_payload(
     return base
 
 
+def build_workflow_progress_payload(
+    vault_dir: Path | str, *, date_key: str, pack: str
+) -> dict[str, Any]:
+    """BL-104: which items MOVED into a lifecycle state on this day.
+
+    Distinct from the other two date surfaces:
+
+    * **Activity** counts evidence ROWS on the event day.
+    * **Workflow Progress** (here) counts distinct ITEMS whose
+      EARLIEST qualifying evidence for a state lands on this day —
+      i.e. the day they *entered* that state ("16 sources moved
+      into Extracted today"), the transition-time axis.
+    * **Current Backlog** is the right-now snapshot.
+
+    Earliest-qualifying-evidence-day is a sound, storage-free proxy
+    for entry-into-state: the lifecycle kernel derives state from
+    cumulative evidence, so the first time an item has evidence of a
+    state's qualifying types is the day it reached that state.
+    Reuses BL-101 identity + BL-102 local-day + the card
+    event_type composition so it cannot drift from the cards.
+    """
+    db_path = _db_path(vault_dir)
+    base: dict[str, Any] = {
+        "screen": "ops/workflow-progress",
+        "date": date_key,
+        "requested_pack": pack,
+        "available": False,
+        "reason": "",
+        "moved": {},
+        "total": 0,
+        "samples": {},
+    }
+    if not db_path.exists():
+        base["reason"] = "knowledge_index has not been built yet"
+        return base
+
+    effective_pack = pack or PRIMARY_PACK_NAME
+    moved: dict[str, int] = {}
+    samples: dict[str, list[str]] = {}
+    with sqlite3.connect(db_path) as conn:
+        for card_def in M25_LIFECYCLE_CARD_DEFS:
+            state = str(card_def["id"])
+            ets = _event_types_for_card(card_def)
+            moved[state] = 0
+            samples[state] = []
+            if not ets:
+                continue
+            et_ph = ",".join("?" for _ in ets)
+            earliest: dict[str, Any] = {}
+            for ts, slug, pj in conn.execute(
+                f"SELECT timestamp, slug, payload_json FROM audit_events "
+                f" WHERE event_type IN ({et_ph})",
+                ets,
+            ):
+                parsed = _parse_audit_ts(str(ts or ""))
+                if parsed is None:
+                    continue
+                try:
+                    payload = json.loads(pj or "{}")
+                except ValueError:
+                    payload = {}
+                if not isinstance(payload, dict):
+                    payload = {}
+                rp = _audit_row_pack(payload)
+                if rp is None:
+                    if effective_pack != PRIMARY_PACK_NAME:
+                        continue
+                elif rp != effective_pack:
+                    continue
+                ident = _activity_item_identity(
+                    state, str(slug or ""), payload
+                )
+                if ident is None:
+                    continue
+                cur = earliest.get(ident)
+                if cur is None or parsed < cur:
+                    earliest[ident] = parsed
+            entered = sorted(
+                sid
+                for sid, ts in earliest.items()
+                if ts.astimezone().date().isoformat() == date_key
+            )
+            moved[state] = len(entered)
+            samples[state] = entered[:TODAY_CARD_SAMPLE_SIZE]
+
+    base.update(
+        available=True,
+        moved=moved,
+        total=sum(moved.values()),
+        samples=samples,
+    )
+    return base
+
+
 def build_today_digest_payload(
     vault_dir: Path | str,
     *,
@@ -4170,6 +4264,9 @@ def build_today_digest_payload(
     intake_cohort = build_intake_cohort_payload(
         vault_dir, date_key=date_key, pack=effective_pack
     )
+    workflow_progress = build_workflow_progress_payload(
+        vault_dir, date_key=date_key, pack=effective_pack
+    )
 
     # BL-103b: attach a zero-reason to every card showing 0 so the
     # operator can tell "did not run" from "ran, no output" from
@@ -4202,6 +4299,7 @@ def build_today_digest_payload(
         "lifecycle_summary": lifecycle_summary,
         "staleness": staleness,
         "intake_cohort": intake_cohort,
+        "workflow_progress": workflow_progress,
         "available": True,
     }
 

--- a/tests/test_m26_workflow_progress.py
+++ b/tests/test_m26_workflow_progress.py
@@ -1,0 +1,145 @@
+"""M26 BL-104 — Workflow Progress projection.
+
+Counts distinct ITEMS that ENTERED a lifecycle state on a day
+(earliest qualifying evidence == that day), the transition-time
+axis.  Distinct from Activity (event rows) and Current backlog
+(right-now).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from ovp_pipeline.commands._ui_renderers import _render_workflow_progress_zone
+from ovp_pipeline.ui.view_models import (
+    build_today_digest_payload,
+    build_workflow_progress_payload,
+)
+
+PACK = "research-tech"
+
+_AUDIT = """
+CREATE TABLE audit_events (
+    source_log TEXT NOT NULL, event_type TEXT NOT NULL,
+    slug TEXT NOT NULL DEFAULT '', session_id TEXT NOT NULL DEFAULT '',
+    timestamp TEXT NOT NULL DEFAULT '', payload_json TEXT NOT NULL
+);
+"""
+
+
+def _vault(tmp_path: Path, rows) -> Path:
+    db = tmp_path / "60-Logs" / "knowledge.db"
+    db.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db)
+    conn.executescript(_AUDIT)
+    conn.executemany("INSERT INTO audit_events VALUES (?,?,?,?,?,?)", rows)
+    conn.commit()
+    conn.close()
+    return tmp_path
+
+
+def _ev(et, slug, ts, payload=None):
+    return ("pipeline.jsonl", et, slug, "s", ts, json.dumps(payload or {}))
+
+
+def test_entered_state_on_earliest_evidence_day(tmp_path):
+    """src-a: intake 05-09, extraction 05-10 → Received entered
+    05-09, Extracted entered 05-10.  src-b: intake 05-10 only."""
+    v = _vault(
+        tmp_path,
+        [
+            _ev("article_intake_only", "src-a", "2026-05-09T09:00:00"),
+            _ev("candidates_upserted", "src-a", "2026-05-10T09:00:00"),
+            _ev("article_intake_only", "src-b", "2026-05-10T09:00:00"),
+        ],
+    )
+    d10 = build_workflow_progress_payload(v, date_key="2026-05-10", pack=PACK)
+    assert d10["moved"]["Received"] == 1  # src-b (src-a's Received was 05-09)
+    assert d10["moved"]["Extracted"] == 1  # src-a entered Extracted 05-10
+    d09 = build_workflow_progress_payload(v, date_key="2026-05-09", pack=PACK)
+    assert d09["moved"]["Received"] == 1  # src-a
+    assert d09["moved"]["Extracted"] == 0
+
+
+def test_distinct_items_not_event_rows(tmp_path):
+    """Many extraction rows for one source on D → 1 entered, not N."""
+    v = _vault(
+        tmp_path,
+        [
+            _ev("candidates_upserted", "src-a", "2026-05-10T09:00:00"),
+            _ev("candidates_upserted", "src-a", "2026-05-10T10:00:00"),
+            _ev("absorb_route_decision", "src-a", "2026-05-10T11:00:00"),
+        ],
+    )
+    d = build_workflow_progress_payload(v, date_key="2026-05-10", pack=PACK)
+    assert d["moved"]["Extracted"] == 1
+
+
+def test_accepted_uses_object_identity(tmp_path):
+    v = _vault(
+        tmp_path,
+        [
+            _ev("evergreen_auto_promoted", "", "2026-05-10T09:00:00", {"concept": "obj-1"}),
+            _ev("promote_concept", "", "2026-05-10T10:00:00", {"concept": "obj-1"}),
+            _ev("evergreen_auto_promoted", "", "2026-05-10T11:00:00", {"concept": "obj-2"}),
+        ],
+    )
+    d = build_workflow_progress_payload(v, date_key="2026-05-10", pack=PACK)
+    assert d["moved"]["Accepted"] == 2  # obj-1, obj-2 distinct
+
+
+def test_pack_scoping(tmp_path):
+    v = _vault(
+        tmp_path,
+        [
+            _ev("article_intake_only", "src-rt", "2026-05-10T09:00:00", {"pack": "research-tech"}),
+            _ev("article_intake_only", "src-leg", "2026-05-10T09:00:00"),
+            _ev("article_intake_only", "src-oth", "2026-05-10T09:00:00", {"pack": "other"}),
+        ],
+    )
+    d = build_workflow_progress_payload(v, date_key="2026-05-10", pack="research-tech")
+    assert d["moved"]["Received"] == 2  # rt + legacy, not other
+
+
+def test_unavailable_without_db(tmp_path):
+    d = build_workflow_progress_payload(tmp_path, date_key="2026-05-10", pack=PACK)
+    assert d["available"] is False
+    assert "knowledge_index" in d["reason"]
+
+
+def test_payload_carries_workflow_progress(tmp_path):
+    v = _vault(
+        tmp_path,
+        [_ev("candidates_upserted", "src-a", "2026-05-10T09:00:00")],
+    )
+    payload = build_today_digest_payload(v, pack_name=PACK, target_date="2026-05-10")
+    assert "workflow_progress" in payload
+    assert payload["workflow_progress"]["moved"]["Extracted"] == 1
+
+
+def test_zone_render_distinguishes_axes(tmp_path):
+    v = _vault(
+        tmp_path,
+        [_ev("candidates_upserted", "src-a", "2026-05-10T09:00:00")],
+    )
+    wp = build_workflow_progress_payload(v, date_key="2026-05-10", pack=PACK)
+    html = _render_workflow_progress_zone(wp, "2026-05-10")
+    assert "Workflow progress" in html
+    assert "<strong>1</strong> item" in html
+    assert "Extracted" in html
+    # BL-100: must say it is NOT event rows / right-now backlog
+    assert "not event rows" in html
+
+
+def test_zone_render_empty_and_unavailable():
+    empty = _render_workflow_progress_zone(
+        {"available": True, "total": 0, "moved": {}}, "2026-05-10"
+    )
+    assert "No items changed lifecycle state" in empty
+    unavail = _render_workflow_progress_zone(
+        {"available": False, "reason": "knowledge_index has not been built yet"},
+        "2026-05-10",
+    )
+    assert "knowledge_index" in unavail


### PR DESCRIPTION
## Summary

Fifth M26 slice (BL-104) — the third date-axis on `/ops/today`. Counts distinct **items that ENTERED a lifecycle state** on the day (earliest qualifying evidence == that day), the transition-time axis. Explicitly distinct from Activity (event rows on the event day) and Current backlog (right-now snapshot).

- `build_workflow_progress_payload`: per state, scan the state's card `event_types`, take earliest qualifying evidence per item identity (BL-101 identity + BL-102 local-day + pack scope), count identities whose earliest day == D.
- **Storage-free** transition proxy: the kernel derives state from cumulative evidence, so first-evidence-day == the day the item reached that state. Reuses the card `event_type` composition so it can't drift from the cards.
- New "Workflow progress" zone grouped with the date-driven content; copy explicitly states it is NOT event-row Activity and NOT the right-now backlog (BL-100).

## Dogfood evidence (live vault, 2026-05-10)

> 67 items moved forward — 38 → Received · 5 → Extracted · 23 → Accepted · 1 → NeedsAction

The Received **38** cross-checks BL-101 distinct Activity (38) and BL-105 intake cohort (38) for the same day — strong cross-slice consistency.

## Test plan

- [x] `tests/test_m26_workflow_progress.py` — earliest-evidence entry day, distinct-not-rows, object identity for Accepted, pack scoping, unavailable, payload wiring, zone render incl. axis-distinction copy, empty/unavailable
- [x] Full suite **3025 passed**; only the 2 pre-existing `test_architecture_fitness` failures (red on `main` before M26)
- [x] ruff/mypy net-neutral; new test file clean
- [x] Live `/ops/today` dogfooded after restart — zone renders, distinct from Activity/backlog

Next per plan sequence: BL-106 (digest uses intake cohorts), then BL-107/108.

Plan: `docs/plans/2026-05-16-m26-daily-observability.md`