### PR TITLE
feat(m26 BL-106): digest acknowledges same-day intake cohorts

### DIFF
--- a/src/ovp_pipeline/commands/digest_handler.py
+++ b/src/ovp_pipeline/commands/digest_handler.py
@@ -332,7 +332,13 @@ register_handler("DIGEST", handle_digest, "Daily knowledge feedback brief.")
 
 def _is_no_data(inputs: DigestInputs) -> bool:
     """Layers 0 + 1 + 2 empty AND Layer 3 has no actionable signal."""
-    has_intake = inputs.intake.intake_events_processed > 0
+    # BL-106: a day where the operator saved articles is NOT
+    # "no data" even if absorb/synthesis hasn't run yet — the
+    # intake cohort (intake-time axis) must keep the digest honest.
+    has_intake = (
+        inputs.intake.intake_events_processed > 0
+        or inputs.intake.intake_cohort_sources > 0
+    )
     has_delta = bool(inputs.delta.new_evergreens or inputs.delta.updated_evergreens)
     has_connections = bool(
         inputs.connections.connected_community_crystals
@@ -473,16 +479,31 @@ def _build_digest_user_prompt_v2(inputs: DigestInputs, user_focus: str) -> str:
 
 
 def _render_layer0_for_prompt(layer: IntakeLayer) -> str:
+    cohort = int(layer.intake_cohort_sources or 0)
     if layer.intake_events_processed == 0:
-        return "(no intake events in this window)"
+        if cohort == 0:
+            return "(no intake activity in this window)"
+        # BL-106: saved-but-not-yet-processed must still be reported
+        # — otherwise a quiet manual-absorb day looks empty.
+        return (
+            f"- Sources first saved in window (intake-time): {cohort}\n"
+            "- No downstream intake events yet (absorb/synthesis "
+            "runs later — these are acknowledged, not lost)"
+        )
     chips = ", ".join(f"{k} ({n})" for k, n in layer.topic_distribution) or "(no topic distribution)"
     samples = "; ".join(layer.representative_samples) or "(no titles)"
     authors = ", ".join(layer.authors_or_sources) or "(no attributed sources)"
+    cohort_line = (
+        f"\n- Sources first saved in window (intake-time): {cohort}"
+        if cohort
+        else ""
+    )
     return (
         f"- Events processed: {layer.intake_events_processed}\n"
         f"- Topic distribution: {chips}\n"
         f"- Authors / sources: {authors}\n"
         f"- Representative titles: {samples}"
+        f"{cohort_line}"
     )
 
 

--- a/src/ovp_pipeline/digest_inputs.py
+++ b/src/ovp_pipeline/digest_inputs.py
@@ -43,6 +43,8 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Final, Iterable
 
+from ovp_pipeline.audit_identity import audit_slug_for_column
+from ovp_pipeline.audit_time import parse_audit_ts
 from ovp_pipeline.digest_config import (
     DigestConfig,
     load_digest_config,
@@ -84,6 +86,11 @@ class IntakeLayer:
     topic_distribution: tuple[tuple[str, int], ...]
     authors_or_sources: tuple[str, ...]
     representative_samples: tuple[str, ...]
+    # BL-106: distinct sources whose FIRST durable intake falls in
+    # the window (intake-time axis).  A day's digest must acknowledge
+    # articles saved that day even when absorb/synthesis runs later;
+    # ``intake_events_processed`` (event-time, raw rows) misses that.
+    intake_cohort_sources: int = 0
 
 
 @dataclass(frozen=True)
@@ -522,11 +529,63 @@ def _collect_layer0(
 
     topic_dist = _top_keyword_distribution(titles)
     samples = tuple(titles[:5])
+    cohort = _intake_cohort_count(
+        conn, window_start, window_end, config
+    )
     return IntakeLayer(
         intake_events_processed=len(rows),
         topic_distribution=topic_dist,
         authors_or_sources=tuple(sorted(authors)),
         representative_samples=samples,
+        intake_cohort_sources=cohort,
+    )
+
+
+def _intake_cohort_count(
+    conn: sqlite3.Connection,
+    window_start: datetime,
+    window_end: datetime,
+    config: DigestConfig,
+) -> int:
+    """BL-106: distinct sources whose EARLIEST intake event (all
+    history) lands in [window_start, window_end].
+
+    The lifecycle kernel derives state from cumulative evidence, so
+    a source's first intake event is the moment it entered the
+    pipeline — the intake-time axis BL-105 uses.  Scans the intake
+    subset (BL-108 streaming is the perf follow-up); identity via
+    the shared ``audit_slug_for_column`` so it matches the cards.
+    """
+    if not config.intake_event_types:
+        return 0
+    placeholders = ",".join("?" * len(config.intake_event_types))
+    try:
+        rows = conn.execute(
+            f"SELECT slug, payload_json, timestamp FROM audit_events "
+            f" WHERE event_type IN ({placeholders})",
+            tuple(config.intake_event_types),
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return 0
+    earliest: dict[str, datetime] = {}
+    for row in rows:
+        parsed = parse_audit_ts(str(row["timestamp"] or ""))
+        if parsed is None:
+            continue
+        slug = (row["slug"] or "").strip()
+        if not slug:
+            payload = _safe_json(row["payload_json"])
+            if isinstance(payload, dict):
+                slug = audit_slug_for_column(payload)
+        if not slug:
+            continue
+        cur = earliest.get(slug)
+        if cur is None or parsed < cur:
+            earliest[slug] = parsed
+    return sum(
+        1
+        for ts in earliest.values()
+        if window_start <= ts <= window_end
     )
 
 

--- a/tests/test_digest_handler.py
+++ b/tests/test_digest_handler.py
@@ -437,7 +437,7 @@ def test_build_user_prompt_omits_empty_data_gracefully(tmp_path: Path):
     assert "Layer 1 — Evergreen delta" in prompt
     assert "Layer 2 — Connections" in prompt
     assert "Layer 3 — Pipeline state" in prompt
-    assert "(no intake events in this window)" in prompt
+    assert "(no intake activity in this window)" in prompt
     assert "(no new or updated evergreens in this window)" in prompt
 
 

--- a/tests/test_digest_inputs.py
+++ b/tests/test_digest_inputs.py
@@ -267,6 +267,46 @@ def test_layer0_ignores_events_outside_window(vault, utc_config):
     assert result.intake.intake_events_processed == 0
 
 
+def test_layer0_cohort_counts_distinct_first_intake_sources(vault, utc_config):
+    """BL-106: intake_cohort_sources counts DISTINCT sources whose
+    EARLIEST intake is in the window — intake-time axis, de-duped —
+    not raw event-window rows."""
+    vault_dir, conn = vault
+    as_of = datetime(2026, 5, 13, 12, 0, tzinfo=ZoneInfo("UTC"))
+    # 3 fresh sources first saved in-window.
+    _seed_intake(conn, count=3, base_ts=as_of - timedelta(hours=2))
+    conn.close()
+    result = collect_digest_inputs(
+        vault_dir, "research-tech", as_of=as_of, config=utc_config
+    )
+    assert result.intake.intake_cohort_sources == 3
+
+
+def test_layer0_cohort_excludes_resaved_old_source(vault, utc_config):
+    """A source first intaken 3 days ago, re-touched in-window:
+    event-window count sees the in-window row, but the cohort must
+    NOT count it (its FIRST intake predates the window)."""
+    vault_dir, conn = vault
+    as_of = datetime(2026, 5, 13, 12, 0, tzinfo=ZoneInfo("UTC"))
+    old = (as_of - timedelta(days=3)).isoformat()
+    inwin = (as_of - timedelta(hours=1)).isoformat()
+    for ts in (old, inwin):
+        conn.execute(
+            "INSERT INTO audit_events VALUES (?, ?, ?, ?, ?, ?)",
+            ("pipeline.jsonl", "article_processed", "slug-old",
+             "s1", ts, json.dumps({"title": "Old source"})),
+        )
+    conn.commit()
+    conn.close()
+    result = collect_digest_inputs(
+        vault_dir, "research-tech", as_of=as_of, config=utc_config
+    )
+    # in-window event row is counted by the event-time layer …
+    assert result.intake.intake_events_processed == 1
+    # … but the cohort (intake-time, earliest) excludes it.
+    assert result.intake.intake_cohort_sources == 0
+
+
 def test_layer0_ignores_non_allowlist_event_types(vault, utc_config):
     """An audit row with event_type outside the allowlist doesn't
     inflate the Layer 0 count."""


### PR DESCRIPTION
## Summary

Sixth M26 slice (BL-106) — M23/M26 integration. The digest's Layer 0 counted raw intake event ROWS in the event-time window, so a day where the operator saved articles but absorb runs later looked empty and the daily digest silently dropped same-day saves.

- `IntakeLayer.intake_cohort_sources`: distinct sources whose **earliest** intake (all history, tz-correct via shared `audit_time.parse_audit_ts`; identity via `audit_slug_for_column`) lands in the window — intake-time axis, de-duped.
- Wired into the **honest-no-data gate** (saved-but-unprocessed ≠ "no data") and the **Layer 0 prompt** (reports the cohort; 0 events + >0 cohort explicitly says saves are acknowledged, not lost; empty-state copy → "(no intake activity …)" since "no events" ignored the cohort axis).

## Scope boundary (flagged)

The digest's Layer 0 window query still uses raw SQL `timestamp >=` string comparison over mixed ISO/`Z`/naive formats — the **same BL-102-class bug** `/ops/today` had. BL-106 deliberately does **not** expand into that; the cohort piggybacks the existing window contract. Real-vault digest currently reads 0 because of *that* pre-existing issue, not BL-106. Recommend a tracked follow-up: "digest window timestamp normalization" (BL-102 analog for the digest).

## Test plan

- [x] `test_digest_inputs.py` — cohort counts distinct first-intake sources in window; **excludes a re-saved old source** even though the event-window sees its in-window row (locks intake-time-vs-event-time distinction)
- [x] Updated empty-state assertion to the new, more accurate copy
- [x] Full digest suite green; full suite **3027 passed**, only the 2 pre-existing `test_architecture_fitness` failures
- [x] ruff/mypy net-neutral (pre-existing `field` F401 in digest_inputs left as-is)
- [ ] Real-vault dogfood blocked by the pre-existing digest-window tz bug (above) — BL-106 logic verified deterministically by unit tests instead

Next per plan: BL-107 / BL-108 (P2 tail), plus the digest-window follow-up if you want it tracked.

Plan: `docs/plans/2026-05-16-m26-daily-observability.md`