### PR TITLE
feat(m26 BL-107): ovp-refresh-ops rebuild-metadata watermark (closes #250)

### DIFF
--- a/src/ovp_pipeline/commands/refresh_ops.py
+++ b/src/ovp_pipeline/commands/refresh_ops.py
@@ -17,12 +17,19 @@ manual:
    graph projection rebuild, low memory).
 3. ``ops_state.rebuild`` — re-derive the lifecycle projection.
 4. Print the state diff (before → after, conserved-total check).
-5. Inspect the just-synced audit window for canonical-object
-   evidence (``evergreen_auto_promoted`` / ``promote_concept``).
+5. Inspect for canonical-object evidence
+   (``evergreen_auto_promoted`` / ``promote_concept`` /
+   ``evergreen_created``) NEWER than the last successful full
+   rebuild (BL-107 / issue #250 — the ``truth_projections.built_at``
+   watermark; falls back to a time window only when no rebuild has
+   ever run).
    * none → print "full knowledge rebuild NOT needed".
    * present → print an explicit WARNING that canonical objects
      changed and a projection / full rebuild may be warranted,
      and exit non-zero so a wrapper script can branch on it.
+   Idempotent: once the operator runs the full rebuild the
+   watermark advances past the evidence, so a subsequent
+   candidates-only refresh stops nagging (the issue #250 fix).
 
 Read-only over markdown; the only writes are to the derived
 ``knowledge.db`` (audit_events + ops_state), exactly what the
@@ -101,17 +108,58 @@ def _row_pack(payload_json: str) -> str | None:
     return str(pack) if pack else None
 
 
+def _last_rebuild_watermark(conn: sqlite3.Connection, pack: str) -> datetime | None:
+    """BL-107 / issue #250: timestamp of the last SUCCESSFUL full
+    canonical (truth/object) projection rebuild for ``pack``.
+
+    ``truth_projections.built_at`` is stamped only by the full
+    ``ovp-knowledge-index`` truth-projection rebuild — NOT by
+    ``ops_state.rebuild`` and NOT by ``sync_audit_events_from_jsonl``
+    (verified: neither writes that table).  So it is exactly "the
+    moment canonical objects were last re-derived", which is the
+    correct idempotency watermark.  ``ops_state.refreshed_at`` was
+    rejected for #250 precisely because it advances on a
+    lifecycle-only refresh and would suppress a real warning before
+    a canonical rebuild handled it.
+
+    None when never rebuilt / table absent → caller falls back to
+    the time-window heuristic (safe default for fresh vaults).
+    """
+    try:
+        row = conn.execute(
+            "SELECT MAX(built_at) FROM truth_projections " " WHERE pack = ?",
+            (pack,),
+        ).fetchone()
+    except sqlite3.OperationalError:
+        return None
+    if not row or not row[0]:
+        return None
+    return _parse_audit_ts(str(row[0]))
+
+
 def _canonical_evidence_since(
     conn: sqlite3.Connection, window_minutes: int, pack: str
 ) -> dict[str, int]:
-    """Count canonical-object audit events for ``pack`` in the window.
+    """Count UNHANDLED canonical-object audit events for ``pack``.
+
+    BL-107 / issue #250 — idempotency: the lower bound is the last
+    successful full rebuild watermark, NOT merely "the last
+    ``window_minutes``".  A promote that a prior
+    ``ovp-knowledge-index`` rebuild already absorbed is older than
+    the watermark and is NOT re-flagged, so a second candidates-only
+    refresh after a handled promote stops nagging (exit 0).  When no
+    rebuild has ever run (no watermark) we fall back to the
+    ``window_minutes`` heuristic — the pre-BL-107 behaviour, still
+    safe for fresh vaults.  The watermark path is also strictly more
+    correct than the window for a stale unhandled promote: a
+    5-day-old promote never rebuilt is still newer than the
+    watermark and is correctly flagged, whereas a 180m window would
+    have missed it.
 
     Timestamps are parsed in Python rather than compared
     lexicographically in SQL — audit rows mix ISO ``T`` and
     space-separated formats, and a string compare across that
-    boundary misclassifies rows (false positives that wrongly
-    trigger the heavy rebuild path).  We only need "did any land",
-    so precision beyond the parse is unnecessary.
+    boundary misclassifies rows.
 
     Evidence is scoped to ``pack``: a recent ``promote_concept`` for a
     DIFFERENT pack must not make this command tell wrappers the
@@ -119,7 +167,11 @@ def _canonical_evidence_since(
     recorded pack are kept (conservative — never suppress a real
     warning just because an old row lacks the field).
     """
-    cutoff = datetime.now(timezone.utc) - timedelta(minutes=int(window_minutes))
+    watermark = _last_rebuild_watermark(conn, pack)
+    if watermark is not None:
+        cutoff = watermark
+    else:
+        cutoff = datetime.now(timezone.utc) - timedelta(minutes=int(window_minutes))
     placeholders = ",".join("?" * len(_CANONICAL_OBJECT_EVENTS))
     rows = conn.execute(
         f"""
@@ -205,7 +257,9 @@ def main(argv: list[str] | None = None) -> int:
     # 3. rebuild ops_state projection
     with sqlite3.connect(str(db_path)) as conn:
         after_counts = rebuild_ops_state(conn, pack=args.pack)
-        # 5. canonical-object evidence detection
+        # 5. canonical-object evidence detection (gated on the last
+        #    successful full-rebuild watermark — BL-107 / #250)
+        watermark = _last_rebuild_watermark(conn, args.pack)
         canonical = _canonical_evidence_since(conn, args.canonical_window_minutes, args.pack)
 
     after = {s: int(after_counts.get(s, 0)) for s in ALL_STATES}
@@ -225,6 +279,12 @@ def main(argv: list[str] | None = None) -> int:
         "after_total": after_total,
         "canonical_object_evidence": canonical,
         "heavier_rebuild_needed": heavier_needed,
+        "rebuild_watermark": (watermark.isoformat() if watermark is not None else ""),
+        "watermark_source": (
+            "last_full_rebuild"
+            if watermark is not None
+            else f"window_{args.canonical_window_minutes}m"
+        ),
     }
 
     if args.json:
@@ -241,19 +301,27 @@ def main(argv: list[str] | None = None) -> int:
             f"{('+' if after_total - before_total >= 0 else '') + str(after_total - before_total):>8}"
         )
         print()
+        if watermark is not None:
+            scope_msg = f"since the last full rebuild " f"({watermark.isoformat()})"
+        else:
+            scope_msg = (
+                f"in the last {args.canonical_window_minutes}m " "(no prior full rebuild on record)"
+            )
         if heavier_needed:
             ev = ", ".join(f"{k}×{v}" for k, v in sorted(canonical.items()))
             print(
-                "  ⚠️  Canonical-object evidence detected in the "
-                f"last {args.canonical_window_minutes}m: {ev}.\n"
+                "  ⚠️  Canonical-object evidence detected "
+                f"{scope_msg}: {ev}.\n"
                 "      New / changed canonical objects are NOT fully "
                 "reflected by audit-sync alone — a projection or "
                 "full `ovp-knowledge-index` rebuild may be "
-                "warranted before trusting Accepted / Synthesized."
+                "warranted before trusting Accepted / Synthesized.\n"
+                "      (Once you run that rebuild this stops warning "
+                "— the watermark advances past this evidence.)"
             )
         else:
             print(
-                "  ✓ No canonical-object evidence in the window "
+                f"  ✓ No canonical-object evidence {scope_msg} "
                 "(candidates / source evidence only).\n"
                 "    Full `ovp-knowledge-index` rebuild NOT needed "
                 "— the lightweight path fully reflects this change."

--- a/tests/test_refresh_ops.py
+++ b/tests/test_refresh_ops.py
@@ -60,7 +60,21 @@ CREATE TABLE evergreen_revisions (
     changed_by TEXT NOT NULL DEFAULT '', derived_at TEXT NOT NULL,
     change_note TEXT NOT NULL DEFAULT '', PRIMARY KEY (pack, object_id, version)
 );
+CREATE TABLE truth_projections (
+    pack TEXT NOT NULL, owner_pack TEXT NOT NULL DEFAULT '',
+    builder_name TEXT NOT NULL DEFAULT '', built_at TEXT NOT NULL
+);
 """
+
+
+def _stamp_rebuild(conn, *, pack, built_at):
+    """BL-107: simulate a successful full ovp-knowledge-index
+    truth-projection rebuild for ``pack`` at ``built_at``."""
+    conn.execute(
+        "INSERT INTO truth_projections (pack, owner_pack, "
+        "builder_name, built_at) VALUES (?, ?, ?, ?)",
+        (pack, pack, "test", built_at),
+    )
 
 
 def _vault(tmp_path: Path) -> Path:
@@ -349,3 +363,89 @@ def test_main_total_conserved_when_only_state_moves(tmp_path, capsys):
     assert payload["after_total"] == sum(payload["after"].values())
     assert payload["after"]["Received"] >= 1
     assert payload["after"]["Extracted"] >= 1
+
+
+# ── BL-107 / issue #250: rebuild-watermark idempotency ─────────────
+
+
+def test_watermark_idempotent_promote_before_rebuild_not_flagged(tmp_path):
+    """The #250 fix: a promote that a later full rebuild already
+    absorbed is OLDER than the watermark → NOT re-flagged, so a
+    second candidates-only refresh stops nagging."""
+    v = _vault(tmp_path)
+    conn = sqlite3.connect(v / "60-Logs" / "knowledge.db")
+    _emit(
+        conn,
+        "promote_concept",
+        slug="obj-x",
+        ts="2026-05-10T08:00:00+00:00",
+        payload={"pack": PACK},
+    )
+    # operator ran the full rebuild AFTER the promote
+    _stamp_rebuild(conn, pack=PACK, built_at="2026-05-10T09:00:00+00:00")
+    conn.commit()
+    assert refresh_ops._canonical_evidence_since(conn, 180, PACK) == {}
+
+
+def test_watermark_promote_after_rebuild_is_flagged(tmp_path):
+    """A promote NEWER than the last full rebuild is unhandled →
+    flagged."""
+    v = _vault(tmp_path)
+    conn = sqlite3.connect(v / "60-Logs" / "knowledge.db")
+    _stamp_rebuild(conn, pack=PACK, built_at="2026-05-10T08:00:00+00:00")
+    _emit(
+        conn,
+        "promote_concept",
+        slug="obj-y",
+        ts="2026-05-10T09:00:00+00:00",
+        payload={"pack": PACK},
+    )
+    conn.commit()
+    found = refresh_ops._canonical_evidence_since(conn, 180, PACK)
+    assert found.get("promote_concept") == 1
+
+
+def test_watermark_beats_window_for_stale_unhandled_promote(tmp_path):
+    """Strictly more correct than the old window: a 5-day-old
+    promote never rebuilt is still newer than a 6-day-old watermark
+    → flagged, where a 180m window would have missed it."""
+    v = _vault(tmp_path)
+    conn = sqlite3.connect(v / "60-Logs" / "knowledge.db")
+    old_rebuild = (datetime.now(timezone.utc) - timedelta(days=6)).strftime(
+        "%Y-%m-%dT%H:%M:%S+00:00"
+    )
+    stale_promote = (datetime.now(timezone.utc) - timedelta(days=5)).strftime(
+        "%Y-%m-%dT%H:%M:%S+00:00"
+    )
+    _stamp_rebuild(conn, pack=PACK, built_at=old_rebuild)
+    _emit(conn, "evergreen_auto_promoted", slug="obj-z", ts=stale_promote, payload={"pack": PACK})
+    conn.commit()
+    found = refresh_ops._canonical_evidence_since(conn, 180, PACK)
+    assert found.get("evergreen_auto_promoted") == 1
+
+
+def test_no_watermark_falls_back_to_window(tmp_path):
+    """No truth_projections row (never rebuilt) → window heuristic,
+    the pre-BL-107 safe default."""
+    v = _vault(tmp_path)
+    conn = sqlite3.connect(v / "60-Logs" / "knowledge.db")
+    recent = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S+00:00")
+    _emit(conn, "promote_concept", slug="obj-r", ts=recent, payload={"pack": PACK})
+    conn.commit()
+    assert refresh_ops._last_rebuild_watermark(conn, PACK) is None
+    assert refresh_ops._canonical_evidence_since(conn, 180, PACK).get("promote_concept") == 1
+
+
+def test_watermark_is_pack_scoped(tmp_path):
+    """A different pack's rebuild must NOT suppress this pack's
+    unhandled promote."""
+    v = _vault(tmp_path)
+    conn = sqlite3.connect(v / "60-Logs" / "knowledge.db")
+    recent = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S+00:00")
+    # other pack rebuilt just now …
+    _stamp_rebuild(conn, pack="other-pack", built_at=recent)
+    # … but THIS pack has a fresh unhandled promote and no rebuild
+    _emit(conn, "promote_concept", slug="obj-p", ts=recent, payload={"pack": PACK})
+    conn.commit()
+    assert refresh_ops._last_rebuild_watermark(conn, PACK) is None
+    assert refresh_ops._canonical_evidence_since(conn, 180, PACK).get("promote_concept") == 1


### PR DESCRIPTION
## Summary

Closes #250 — the `ovp-refresh-ops` repeat-warn idempotency bug. Previously a promote within `--canonical-window-minutes` (default 180) re-flagged `exit 2` on every subsequent candidates-only refresh, even after the operator ran the full rebuild that handled it.

The watermark is the **last successful full canonical rebuild**: `truth_projections.built_at` for the pack. Verified that column is stamped **only** by the full `ovp-knowledge-index` truth-projection rebuild — **not** by `ops_state.rebuild`, **not** by `sync_audit_events_from_jsonl` — so it precisely means "canonical objects were re-derived at T". `ops_state.refreshed_at` was rejected for #250 exactly because it advances on a lifecycle-only refresh (false negative); this watermark cannot.

- **Zero schema change / zero new writes** — read-only over an existing column (BL-103b's lesson: no knowledge.db migration risk).
- `_canonical_evidence_since` gates on *newer-than-watermark*; falls back to the time window only when no rebuild has ever run (fresh-vault safe default).
- Strictly **more correct** than the old window: a 5-day-old unhandled promote is still newer than an older watermark and is flagged, where a 180m window missed it.
- Pack-scoped. Payload gains `rebuild_watermark` + `watermark_source`; messaging now says "since the last full rebuild (\<ts\>)" and notes the warning clears once you rebuild.

## Dogfood evidence (live vault)

> `research-tech` watermark `2026-05-15T06:34:40+00:00`; canonical evidence newer than it = `{}` — the 10146 historical `evergreen_auto_promoted` are all older than the watermark, correctly **not** re-flagged. The exact #250 symptom, fixed.

## Test plan

- [x] 5 new tests: promote-before-rebuild **not** flagged (the #250 fix), promote-after-rebuild flagged, watermark beats window for a stale unhandled promote, no-watermark→window fallback, watermark is pack-scoped
- [x] All 19 `test_refresh_ops` green; existing window-fallback tests unchanged (backward compatible)
- [x] Full suite **3033 passed**; only the 2 pre-existing `test_architecture_fitness` failures
- [x] ruff/black/mypy clean on changed files

Next per plan: BL-108 (audit JSONL streaming — the final P2).

Plan: `docs/plans/2026-05-16-m26-daily-observability.md`