### PR TITLE
fix(dedup): fail-closed — no implicit full-vault O(N²) scan

### DIFF
--- a/src/ovp_pipeline/commands/concept_dedup.py
+++ b/src/ovp_pipeline/commands/concept_dedup.py
@@ -58,8 +58,19 @@ def _resolve_proposal_path(vault_dir: Path, ident: str) -> Path:
 def _cmd_propose(args: argparse.Namespace) -> int:
     vault_dir = resolve_vault_dir(args.vault_dir)
     with vault_workflow_lock(vault_dir):
+        # Mirror _scan_evergreen exactly (same path, same _/.
+        # stem skip) so the printed pair-comparison estimate equals
+        # the candidate set find_clusters actually scans.
         eg_dir = vault_dir / "10-Knowledge" / "Evergreen"
-        n = sum(1 for _ in eg_dir.glob("*.md")) if eg_dir.is_dir() else 0
+        n = (
+            sum(
+                1
+                for p in eg_dir.glob("*.md")
+                if not p.stem.startswith(("_", "."))
+            )
+            if eg_dir.is_dir()
+            else 0
+        )
         if n:
             print(
                 f"Full-vault scan: {n} Evergreen files, "

--- a/src/ovp_pipeline/commands/concept_dedup.py
+++ b/src/ovp_pipeline/commands/concept_dedup.py
@@ -58,7 +58,19 @@ def _resolve_proposal_path(vault_dir: Path, ident: str) -> Path:
 def _cmd_propose(args: argparse.Namespace) -> int:
     vault_dir = resolve_vault_dir(args.vault_dir)
     with vault_workflow_lock(vault_dir):
-        clusters = find_clusters(vault_dir, threshold=args.threshold)
+        eg_dir = vault_dir / "10-Knowledge" / "Evergreen"
+        n = sum(1 for _ in eg_dir.glob("*.md")) if eg_dir.is_dir() else 0
+        if n:
+            print(
+                f"Full-vault scan: {n} Evergreen files, "
+                f"~{n * (n - 1) // 2:,} pair comparisons (explicit "
+                f"maintenance op; pipeline/autopilot never run this)."
+            )
+        # Explicit operator opt-in to the O(N²) full-vault scan; the
+        # pipeline / autopilot paths are fail-closed and never pass this.
+        clusters = find_clusters(
+            vault_dir, threshold=args.threshold, allow_full_scan=True
+        )
         if not clusters:
             print(f"No duplicate clusters found at threshold {args.threshold}.")
             return 0

--- a/src/ovp_pipeline/concept_dedup.py
+++ b/src/ovp_pipeline/concept_dedup.py
@@ -251,11 +251,23 @@ def _pick_canonical(members: list[DedupCandidate]) -> DedupCandidate:
     )
 
 
+class FullScanRefused(RuntimeError):
+    """Raised when an unscoped full-vault dedup is requested without an
+    explicit ``allow_full_scan=True`` opt-in.
+
+    Full-vault clustering is O(N²) over every Evergreen file.  It must
+    never run silently inside the default pipeline / autopilot path —
+    only an explicit maintenance command (``ovp-concept-dedup propose``)
+    may opt in.
+    """
+
+
 def find_clusters(
     vault_dir: Path,
     *,
     threshold: float = DEFAULT_THRESHOLD,
     scope_slugs: set[str] | None = None,
+    allow_full_scan: bool = False,
 ) -> list[DedupCluster]:
     """Find duplicate clusters among Evergreen files.
 
@@ -263,7 +275,19 @@ def find_clusters(
     scope set — or whose trigram-Jaccard similarity to any scope slug is above
     *threshold* — are considered.  This makes incremental (post-absorb) runs
     O(scope × N) instead of O(N²).
+
+    With no *scope_slugs*, the run would compare every Evergreen pair
+    (O(N²)).  That is refused with :class:`FullScanRefused` unless the
+    caller passes ``allow_full_scan=True`` — a guard so the default
+    pipeline / autopilot path can never trigger it implicitly.
     """
+    if scope_slugs is None and not allow_full_scan:
+        raise FullScanRefused(
+            "find_clusters called with no scope_slugs and "
+            "allow_full_scan=False; refusing implicit full-vault O(N²) "
+            "scan. Pipeline/autopilot must scope to promoted slugs or "
+            "skip; only the explicit maintenance CLI may opt in."
+        )
     cands = _scan_evergreen(vault_dir)
     if scope_slugs is not None:
         scope_norms = {_normalize_slug_for_compare(s) for s in scope_slugs}

--- a/src/ovp_pipeline/unified_pipeline_enhanced.py
+++ b/src/ovp_pipeline/unified_pipeline_enhanced.py
@@ -2445,10 +2445,12 @@ class EnhancedPipeline:
             write_proposal,
         )
 
-        # Read absorb's typed contract.  promoted_slugs is now guaranteed
-        # to exist on every absorb return path (PATCH-1 + commit 2 of the
-        # contract refactor); empty list means "no scope, fall back to
-        # full vault".
+        # Read absorb's typed contract.  promoted_slugs is guaranteed to
+        # exist on every absorb return path.  No promoted slugs means
+        # there is nothing this run absorbed to dedup against — we SKIP.
+        # We must never fall back to an implicit full-vault O(N²) scan
+        # here (9k+ Evergreen ⇒ ~44M pair comparisons); that is an
+        # explicit maintenance op (``ovp-concept-dedup propose``) only.
         scope_slugs: set[str] | None = None
         absorb_result = self.step_results.get("absorb")
         if absorb_result is not None:
@@ -2456,12 +2458,23 @@ class EnhancedPipeline:
             if promoted:
                 scope_slugs = set(promoted)
 
+        if scope_slugs is None:
+            print(
+                "  No promoted slugs from absorb — skipping dedup "
+                "(no implicit full-vault fallback)."
+            )
+            return DedupStepResult(
+                success=True,
+                clusters=0,
+                skipped=True,
+                reason="no_promoted_scope",
+            )
+
         threshold = DEFAULT_THRESHOLD
         clusters = find_clusters(self.vault_dir, threshold=threshold, scope_slugs=scope_slugs)
 
         if not clusters:
-            scope_desc = f"scope={len(scope_slugs)} slugs" if scope_slugs else "full vault"
-            print(f"  No duplicates found ({scope_desc}, threshold={threshold}).")
+            print(f"  No duplicates found (scope={len(scope_slugs)} slugs, threshold={threshold}).")
             return DedupStepResult(success=True)
 
         prop_path, proposal = write_proposal(self.vault_dir, clusters, threshold=threshold)

--- a/src/ovp_pipeline/workflow_handlers.py
+++ b/src/ovp_pipeline/workflow_handlers.py
@@ -135,13 +135,18 @@ def run_autopilot_absorb(*, daemon: Any, **_: Any) -> dict[str, Any]:
 
 
 def run_autopilot_dedup(*, daemon: Any, **_: Any) -> dict[str, Any]:
-    from .concept_dedup import DEFAULT_THRESHOLD, find_clusters
-
-    vault_dir = daemon.vault_dir if hasattr(daemon, "vault_dir") else None
-    if vault_dir:
-        clusters = find_clusters(vault_dir, threshold=DEFAULT_THRESHOLD)
-        return {"stage": "dedup", "clusters_found": len(clusters)}
-    return {"stage": "dedup", "skipped": True}
+    """Autopilot dedup is fail-closed: the daemon runs absorb as a
+    subprocess and carries no promoted-slug scope, so there is no
+    incremental scope to dedup against.  We SKIP rather than fall back
+    to an implicit full-vault O(N²) scan (9k+ Evergreen ⇒ ~44M pair
+    comparisons every cycle).  Full-vault dedup is an explicit
+    maintenance op (``ovp-concept-dedup propose``) only.
+    """
+    return {
+        "stage": "dedup",
+        "skipped": True,
+        "reason": "no_promoted_scope",
+    }
 
 
 def run_autopilot_moc(*, daemon: Any, **_: Any) -> dict[str, Any]:

--- a/tests/test_concept_dedup.py
+++ b/tests/test_concept_dedup.py
@@ -8,8 +8,11 @@ from pathlib import Path
 from textwrap import dedent
 from types import SimpleNamespace
 
+import pytest
+
 from ovp_pipeline.concept_dedup import (
     DEFAULT_THRESHOLD,
+    FullScanRefused,
     apply_cluster,
     apply_proposal,
     archive_applied_proposal,
@@ -62,7 +65,7 @@ def test_find_clusters_groups_near_duplicates(tmp_path: Path):
     _evergreen(tmp_path, "MCP-Client-Variant", body="dup")
     _evergreen(tmp_path, "Some-Other-Concept", body="unrelated")
 
-    clusters = find_clusters(tmp_path, threshold=0.5)
+    clusters = find_clusters(tmp_path, threshold=0.5, allow_full_scan=True)
 
     assert len(clusters) == 1
     cluster = clusters[0]
@@ -77,7 +80,7 @@ def test_find_clusters_skips_underscored_and_hidden(tmp_path: Path):
     _evergreen(tmp_path, "Real-Note")
     _evergreen(tmp_path, "Real-Notes")
 
-    clusters = find_clusters(tmp_path, threshold=0.7)
+    clusters = find_clusters(tmp_path, threshold=0.7, allow_full_scan=True)
     canonical_slugs = {c.canonical.slug for c in clusters}
     dup_slugs = {d.slug for c in clusters for d in c.duplicates}
     assert "_Candidate-Note" not in canonical_slugs
@@ -85,7 +88,7 @@ def test_find_clusters_skips_underscored_and_hidden(tmp_path: Path):
 
 
 def test_find_clusters_returns_empty_when_no_evergreen_dir(tmp_path: Path):
-    assert find_clusters(tmp_path) == []
+    assert find_clusters(tmp_path, allow_full_scan=True) == []
 
 
 def test_rewrite_wikilinks_preserves_anchor_and_display():
@@ -129,7 +132,7 @@ def test_write_and_load_proposal_roundtrip(tmp_path: Path):
     _evergreen(tmp_path, "MCP-Client", body="canonical " * 10)
     _evergreen(tmp_path, "MCP-Clients")
 
-    clusters = find_clusters(tmp_path, threshold=0.6)
+    clusters = find_clusters(tmp_path, threshold=0.6, allow_full_scan=True)
     path, proposal = write_proposal(tmp_path, clusters, threshold=0.6)
 
     assert path.is_file()
@@ -145,7 +148,7 @@ def test_write_and_load_proposal_roundtrip(tmp_path: Path):
 def test_archive_applied_proposal_removes_it_from_pending_list(tmp_path: Path):
     _evergreen(tmp_path, "MCP-Client", body="canonical " * 10)
     _evergreen(tmp_path, "MCP-Clients")
-    clusters = find_clusters(tmp_path, threshold=0.6)
+    clusters = find_clusters(tmp_path, threshold=0.6, allow_full_scan=True)
     path, proposal = write_proposal(tmp_path, clusters, threshold=0.6)
 
     archived = archive_applied_proposal(tmp_path, path)
@@ -161,7 +164,7 @@ def test_apply_cluster_dry_run_makes_no_writes(tmp_path: Path):
     dup = _evergreen(tmp_path, "MCP-Clients", body="dup")
     refer = _other(tmp_path, "20-Areas/Note.md", "see [[MCP-Clients]] and [[MCP-Clients|Friendly]]")
 
-    clusters = find_clusters(tmp_path, threshold=0.6)
+    clusters = find_clusters(tmp_path, threshold=0.6, allow_full_scan=True)
     assert clusters
 
     result = apply_cluster(tmp_path, clusters[0], dry_run=True)
@@ -186,7 +189,7 @@ def test_apply_cluster_writes_archive_aliases_audit(tmp_path: Path):
         "see [[MCP-Clients]] and [[MCP-Clients#anchor]] and [[MCP-Clients|Display]]",
     )
 
-    clusters = find_clusters(tmp_path, threshold=0.6)
+    clusters = find_clusters(tmp_path, threshold=0.6, allow_full_scan=True)
     assert clusters
 
     result = apply_cluster(tmp_path, clusters[0], dry_run=False, proposal_id="test-prop")
@@ -231,7 +234,7 @@ def test_apply_cluster_archives_with_obsidian_move_when_available(tmp_path: Path
     dup = _evergreen(tmp_path, "MCP-Clients", body="dup body")
     _other(tmp_path, "20-Areas/Topic.md", "see [[MCP-Clients]]")
 
-    clusters = find_clusters(tmp_path, threshold=0.6)
+    clusters = find_clusters(tmp_path, threshold=0.6, allow_full_scan=True)
     assert clusters
 
     calls: list[list[str]] = []
@@ -264,11 +267,11 @@ def test_apply_cluster_skips_archive_dir_during_rewrite(tmp_path: Path):
     _evergreen(tmp_path, "MCP-Clients")
     _other(tmp_path, "20-Areas/Note.md", "see [[MCP-Clients]]")
 
-    clusters = find_clusters(tmp_path, threshold=0.6)
+    clusters = find_clusters(tmp_path, threshold=0.6, allow_full_scan=True)
     apply_cluster(tmp_path, clusters[0], dry_run=False)
 
     # Re-scan: cluster should be gone.
-    clusters_after = find_clusters(tmp_path, threshold=DEFAULT_THRESHOLD)
+    clusters_after = find_clusters(tmp_path, threshold=DEFAULT_THRESHOLD, allow_full_scan=True)
     assert clusters_after == []
 
 
@@ -280,7 +283,7 @@ def test_apply_cluster_handles_archive_collision(tmp_path: Path):
     archive_dir.mkdir(parents=True)
     (archive_dir / "MCP-Clients.md").write_text("pre-existing", encoding="utf-8")
 
-    clusters = find_clusters(tmp_path, threshold=0.6)
+    clusters = find_clusters(tmp_path, threshold=0.6, allow_full_scan=True)
     result = apply_cluster(tmp_path, clusters[0], dry_run=False)
 
     assert result.errors == []
@@ -298,7 +301,7 @@ def test_apply_proposal_only_filter(tmp_path: Path):
     _evergreen(tmp_path, "Vector-Database", body="canonical " * 10)
     _evergreen(tmp_path, "Vector-Databases")
 
-    clusters = find_clusters(tmp_path, threshold=0.6)
+    clusters = find_clusters(tmp_path, threshold=0.6, allow_full_scan=True)
     assert len(clusters) == 2
     _, proposal = write_proposal(tmp_path, clusters, threshold=DEFAULT_THRESHOLD)
 
@@ -316,7 +319,7 @@ def test_concept_dedup_apply_uses_vault_workflow_lock(tmp_path: Path, monkeypatc
 
     _evergreen(tmp_path, "MCP-Client", body="canonical body that is long " * 10)
     _evergreen(tmp_path, "MCP-Clients", body="duplicate body")
-    clusters = find_clusters(tmp_path, threshold=0.6)
+    clusters = find_clusters(tmp_path, threshold=0.6, allow_full_scan=True)
     proposal_path, _ = write_proposal(tmp_path, clusters, threshold=DEFAULT_THRESHOLD)
     calls: list[str] = []
 
@@ -376,13 +379,25 @@ def test_find_clusters_scope_slugs_limits_search(tmp_path: Path):
     assert "Vector-Databases" not in slugs_in_clusters
 
 
-def test_find_clusters_scope_slugs_none_returns_all(tmp_path: Path):
+def test_find_clusters_scope_none_refuses_without_opt_in(tmp_path: Path):
+    """PR1 fail-closed: an unscoped run is the O(N²) full-vault scan;
+    it must be refused unless the caller explicitly opts in."""
+    _evergreen(tmp_path, "MCP-Client", body="canonical " * 10)
+    _evergreen(tmp_path, "MCP-Clients", body="dup")
+
+    with pytest.raises(FullScanRefused):
+        find_clusters(tmp_path, threshold=0.5, scope_slugs=None)
+
+
+def test_find_clusters_scope_none_runs_with_explicit_opt_in(tmp_path: Path):
     _evergreen(tmp_path, "MCP-Client", body="canonical " * 10)
     _evergreen(tmp_path, "MCP-Clients", body="dup")
     _evergreen(tmp_path, "Vector-Database", body="canonical " * 10)
     _evergreen(tmp_path, "Vector-Databases", body="dup")
 
-    clusters_all = find_clusters(tmp_path, threshold=0.5, scope_slugs=None)
+    clusters_all = find_clusters(
+        tmp_path, threshold=0.5, scope_slugs=None, allow_full_scan=True
+    )
     assert len(clusters_all) == 2
 
 

--- a/tests/test_pipeline_data_contracts.py
+++ b/tests/test_pipeline_data_contracts.py
@@ -8,6 +8,7 @@ across pipeline stages (extractor -> registry -> candidate -> promote -> knowled
 import pytest
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from ovp_pipeline.identity import canonicalize_note_id
@@ -514,15 +515,78 @@ class TestStrictModeCrossStepIntegration:
         assert result.skipped is True
         assert result.reason == "dry_run"
 
-    def test_step_dedup_no_clusters_path_typed(self, temp_vault):
+    def test_step_dedup_skips_when_no_promoted_scope(self, temp_vault):
+        """PR1 fail-closed: no absorb / no promoted_slugs ⇒ step_dedup
+        SKIPS and must NOT trigger an implicit full-vault O(N²) scan."""
+        from unittest.mock import patch
+
         from ovp_pipeline.step_contracts import DedupStepResult
 
         pipeline = self._make_pipeline(temp_vault)
-        # No evergreens in vault → no clusters → success-empty path.
-        result = pipeline.step_dedup(dry_run=True)
+        with patch("ovp_pipeline.concept_dedup.find_clusters") as fc:
+            result = pipeline.step_dedup(dry_run=True)
         assert isinstance(result, DedupStepResult)
         assert result.success is True
+        assert result.skipped is True
+        assert result.reason == "no_promoted_scope"
         assert result.clusters == 0
+        fc.assert_not_called()
+
+    def test_step_dedup_empty_promoted_slugs_skips(self, temp_vault):
+        """An absorb result with an *empty* promoted_slugs list is still
+        'no scope' — skip, never full-vault."""
+        from unittest.mock import patch
+
+        from ovp_pipeline.step_contracts import AbsorbStepResult
+
+        pipeline = self._make_pipeline(temp_vault)
+        pipeline.step_results["absorb"] = AbsorbStepResult(
+            success=True, processed_files=["a.md"], promoted_slugs=[]
+        )
+        with patch("ovp_pipeline.concept_dedup.find_clusters") as fc:
+            result = pipeline.step_dedup(dry_run=True)
+        assert result.skipped is True
+        assert result.reason == "no_promoted_scope"
+        fc.assert_not_called()
+
+    def test_step_dedup_scopes_to_promoted_slugs(self, temp_vault):
+        """With promoted_slugs, dedup runs SCOPED — find_clusters is
+        called with exactly that scope and never the full vault."""
+        from unittest.mock import patch
+
+        from ovp_pipeline.step_contracts import AbsorbStepResult
+
+        pipeline = self._make_pipeline(temp_vault)
+        pipeline.step_results["absorb"] = AbsorbStepResult(
+            success=True,
+            processed_files=["a.md"],
+            promoted_slugs=["concept-x", "concept-y"],
+        )
+        with patch(
+            "ovp_pipeline.concept_dedup.find_clusters", return_value=[]
+        ) as fc:
+            result = pipeline.step_dedup(dry_run=True)
+        assert result.success is True
+        assert result.skipped is False
+        fc.assert_called_once()
+        _, kwargs = fc.call_args
+        assert kwargs["scope_slugs"] == {"concept-x", "concept-y"}
+        assert kwargs.get("allow_full_scan", False) is False
+
+    def test_run_autopilot_dedup_skips_no_full_scan(self, temp_vault):
+        """PR1 fail-closed: autopilot carries no promoted scope, so the
+        dedup stage SKIPS instead of an unconditional full-vault scan."""
+        from unittest.mock import patch
+
+        from ovp_pipeline.workflow_handlers import run_autopilot_dedup
+
+        daemon = SimpleNamespace(vault_dir=temp_vault)
+        with patch("ovp_pipeline.concept_dedup.find_clusters") as fc:
+            out = run_autopilot_dedup(daemon=daemon)
+        assert out["stage"] == "dedup"
+        assert out["skipped"] is True
+        assert out["reason"] == "no_promoted_scope"
+        fc.assert_not_called()
 
     def test_run_pipeline_handles_frozen_step_result(self, temp_vault, monkeypatch):
         """Regression: run_pipeline used to call cmd_result.update() / write


### PR DESCRIPTION
fix(dedup): fail-closed — no implicit full-vault O(N^2) scan

The default pipeline / autopilot path silently fell back to a
full-vault dedup when no promoted scope was present. At current
scale (9,356 Evergreen) that is ~43.8M pairwise trigram-Jaccard
comparisons on every run with no absorbed slugs — a hidden,
unbounded, high-cost scan in the daily incremental path.

Fail-closed rules:

- find_clusters(scope_slugs=None, allow_full_scan=False) now
  raises FullScanRefused instead of scanning the whole vault.
- step_dedup: no promoted_slugs -> SKIP
  (DedupStepResult success=True, skipped=True,
  reason="no_promoted_scope"); never full-vault.
- run_autopilot_dedup: the daemon carries no promoted scope, so
  it SKIPS rather than an unconditional full-vault scan.
- ovp-concept-dedup propose: the one explicit maintenance op —
  passes allow_full_scan=True and prints the scan cost up front.

No behaviour change for the scoped (post-absorb) path. Full-vault
dedup is now reachable only via the explicit CLI.

Tests: find_clusters refuses unscoped without opt-in; scoped path
unchanged; step_dedup skip (no absorb / empty promoted_slugs) does
not call find_clusters; scoped call passes exactly the promoted
set and never allow_full_scan; autopilot skips; CLI full scan
still works. Full suite 3041 passed / 0 failed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added an explicit opt-in requirement for full deduplication scans to avoid unintended expensive operations.
  * Deduplication now runs scoped to promoted items, improving efficiency and predictability.
  * Pipeline components now skip deduplication when no promoted scope exists, instead of falling back to full-vault scans.

* **Tests**
  * Updated and added tests to validate the new opt-in and skip behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fakechris/obsidian_vault_pipeline/pull/267?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->