### PR TITLE
fix(knowledge-index): hard-cap embedding chunk size (PR2a)

### DIFF
--- a/src/ovp_pipeline/knowledge_index.py
+++ b/src/ovp_pipeline/knowledge_index.py
@@ -972,7 +972,45 @@ def _collect_audit_rows(layout: VaultLayout) -> list[tuple[str, str, str, str, s
     return rows
 
 
-def _chunk_page_body(body: str, fallback_title: str) -> list[tuple[str, str]]:
+# A single embedding chunk is hard-capped: an un-sectioned page body
+# (no ``## `` headings) would otherwise become one chunk of the whole
+# body — observed up to ~903k chars — and be fed whole into the
+# embedding backend.  The cap bounds both memory and the embedded text.
+_MAX_CHUNK_CHARS = 3000
+_CHUNK_OVERLAP_CHARS = 200
+
+
+def _split_to_cap(text: str, max_chars: int, overlap: int) -> list[str]:
+    """Slice *text* into pieces no longer than *max_chars*, each
+    overlapping the previous by *overlap* chars so a concept split
+    across a boundary still embeds with local context.  Empty / blank
+    input yields no pieces."""
+    text = text.strip()
+    if not text:
+        return []
+    if len(text) <= max_chars:
+        return [text]
+    step = max(1, max_chars - max(0, overlap))
+    pieces: list[str] = []
+    start = 0
+    n = len(text)
+    while start < n:
+        piece = text[start : start + max_chars]
+        if piece.strip():
+            pieces.append(piece)
+        if start + max_chars >= n:
+            break
+        start += step
+    return pieces
+
+
+def _chunk_page_body(
+    body: str,
+    fallback_title: str,
+    *,
+    max_chunk_chars: int = _MAX_CHUNK_CHARS,
+    overlap_chars: int = _CHUNK_OVERLAP_CHARS,
+) -> list[tuple[str, str]]:
     sections: list[tuple[str, str]] = []
     current_title: str | None = None
     current_lines: list[str] = []
@@ -992,12 +1030,18 @@ def _chunk_page_body(body: str, fallback_title: str) -> list[tuple[str, str]]:
         sections.append((current_title, "\n".join(current_lines).strip()))
 
     if sections:
-        return sections
+        raw = sections
+    else:
+        normalized_body = body.strip()
+        if not normalized_body:
+            return []
+        raw = [(fallback_title, normalized_body)]
 
-    normalized_body = body.strip()
-    if not normalized_body:
-        return []
-    return [(fallback_title, normalized_body)]
+    capped: list[tuple[str, str]] = []
+    for title, text in raw:
+        for piece in _split_to_cap(text, max_chunk_chars, overlap_chars):
+            capped.append((title, piece))
+    return capped
 
 
 def _embed_text(text: str) -> bytes:

--- a/tests/test_knowledge_index_chunk_cap.py
+++ b/tests/test_knowledge_index_chunk_cap.py
@@ -1,0 +1,72 @@
+"""PR2a — knowledge-index embedding chunk size cap.
+
+A page body with no ``## `` headings used to become a single chunk of
+the entire body (observed ~903k chars) and be fed whole into the
+embedding backend.  ``_chunk_page_body`` now hard-caps every chunk.
+"""
+
+from __future__ import annotations
+
+from ovp_pipeline.knowledge_index import (
+    _MAX_CHUNK_CHARS,
+    _chunk_page_body,
+    _split_to_cap,
+)
+
+
+def test_empty_body_yields_no_chunks():
+    assert _chunk_page_body("", "Title") == []
+    assert _chunk_page_body("   \n  \n", "Title") == []
+
+
+def test_short_unsectioned_body_single_chunk_with_fallback_title():
+    chunks = _chunk_page_body("just a short body", "Fallback")
+    assert chunks == [("Fallback", "just a short body")]
+
+
+def test_unsectioned_long_body_is_split_and_each_chunk_capped():
+    body = "x" * (_MAX_CHUNK_CHARS * 5 + 123)
+    chunks = _chunk_page_body(body, "BigDoc")
+    assert len(chunks) > 1
+    for title, text in chunks:
+        assert title == "BigDoc"
+        assert len(text) <= _MAX_CHUNK_CHARS
+
+
+def test_section_titles_preserved_and_long_section_split():
+    long_section = "para. " * 2000  # well over the cap
+    body = f"## Intro\nshort intro text\n\n## Deep\n{long_section}"
+    chunks = _chunk_page_body(body, "FB")
+    titles = {t for t, _ in chunks}
+    assert "Intro" in titles
+    assert "Deep" in titles
+    # every Deep chunk respects the cap
+    deep = [c for t, c in chunks if t == "Deep"]
+    assert len(deep) > 1
+    assert all(len(c) <= _MAX_CHUNK_CHARS for c in deep)
+    # the short Intro stays a single chunk
+    intro = [c for t, c in chunks if t == "Intro"]
+    assert intro == ["short intro text"]
+
+
+def test_split_to_cap_overlaps_adjacent_pieces():
+    text = "abcdefghij" * 100  # 1000 chars
+    pieces = _split_to_cap(text, max_chars=300, overlap=50)
+    assert all(len(p) <= 300 for p in pieces)
+    assert len(pieces) > 1
+    # reconstruct with the known step; overlap means tail of piece i
+    # equals head of piece i+1.
+    step = 300 - 50
+    for i in range(len(pieces) - 1):
+        assert text[(i + 1) * step : (i + 1) * step + 50] == pieces[i + 1][:50]
+
+
+def test_split_to_cap_blank_input_no_pieces():
+    assert _split_to_cap("", 100, 10) == []
+    assert _split_to_cap("   ", 100, 10) == []
+
+
+def test_split_to_cap_zero_overlap_is_contiguous():
+    text = "0123456789" * 30  # 300 chars
+    pieces = _split_to_cap(text, max_chars=100, overlap=0)
+    assert pieces == [text[0:100], text[100:200], text[200:300]]


### PR DESCRIPTION
fix(knowledge-index): hard-cap embedding chunk size

A page body with no "## " headings became a SINGLE chunk of the
entire body (observed up to ~903k chars) and was fed whole into
the embedding backend — unbounded embedded text and the largest
single memory source in the rebuild.

_chunk_page_body now caps every chunk:

- heading split is unchanged; each resulting section (and the
  no-heading whole-body fallback) is further sliced by
  _split_to_cap to <= max_chunk_chars (default 3000), with a
  200-char overlap so a concept split across a boundary still
  embeds with local context.
- empty / blank body still yields no chunks.
- section / fallback titles are preserved on every piece.
- public signature unchanged (max_chunk_chars / overlap_chars are
  keyword-only with defaults); the single caller is untouched.

This is the chunk-size half of the Knowledge Index bounded-rebuild
work (PR2a). Bounded flush (PR2b) is separate.

Tests: empty body; short body; unsectioned long body split and
each piece capped; section titles preserved with a long section
split while a short section stays whole; overlap continuity;
zero-overlap contiguity. Full suite 3044 passed / 0 failed.
