### PR TITLE
fix(knowledge-index): bounded-flush rebuild (PR2b, supersedes #269)

### DIFF
--- a/src/ovp_pipeline/knowledge_index.py
+++ b/src/ovp_pipeline/knowledge_index.py
@@ -1052,6 +1052,11 @@ def _chunk_page_body(
 # takes it as an in-process argument.
 _PAGE_FLUSH_BATCH = 200
 _EMBED_FLUSH_BATCH = 128
+# Timeline events are flushed independently of the page batch: a
+# single page can emit many events (e.g. a long changelog), so a
+# page-boundary-only flush could let timeline_batch grow unbounded
+# between page flushes.
+_TIMELINE_FLUSH_BATCH = 500
 
 
 def _flush_pages(
@@ -1538,6 +1543,8 @@ def rebuild_knowledge_index(
                 if meta.note_id in known_slugs:
                     object_page_rows.append(page_row)
                 timeline_batch.extend(_extract_timeline_events(meta, body))
+                if len(timeline_batch) >= _TIMELINE_FLUSH_BATCH:
+                    timeline_events_indexed += _flush_timeline(conn, timeline_batch)
                 for chunk_index, (section_title, chunk_text) in enumerate(
                     _chunk_page_body(body, meta.title)
                 ):

--- a/src/ovp_pipeline/knowledge_index.py
+++ b/src/ovp_pipeline/knowledge_index.py
@@ -1044,6 +1044,72 @@ def _chunk_page_body(
     return capped
 
 
+# Bounded-flush batch sizes for the rebuild loop.  The rebuild must
+# not hold every page body + every embedding blob in a Python list at
+# once (observed: 10k+ pages, 31k+ chunks, 332MB db) — rows are
+# flushed to the DB in capped batches.  Only the (smaller) object-slug
+# subset is retained in memory, because the truth-projection builder
+# takes it as an in-process argument.
+_PAGE_FLUSH_BATCH = 200
+_EMBED_FLUSH_BATCH = 128
+
+
+def _flush_pages(
+    conn: sqlite3.Connection,
+    page_batch: list[tuple],
+    fts_batch: list[tuple],
+) -> int:
+    """Insert a page batch into ``pages_index`` + ``page_fts`` and
+    clear the batches.  Returns the number of pages flushed."""
+    if not page_batch:
+        return 0
+    conn.executemany(
+        """
+        INSERT INTO pages_index (slug, title, note_type, path, day_id, frontmatter_json, body)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        page_batch,
+    )
+    conn.executemany(
+        "INSERT INTO page_fts (slug, title, body) VALUES (?, ?, ?)",
+        fts_batch,
+    )
+    n = len(page_batch)
+    page_batch.clear()
+    fts_batch.clear()
+    return n
+
+
+def _flush_timeline(conn: sqlite3.Connection, timeline_batch: list[tuple]) -> int:
+    if not timeline_batch:
+        return 0
+    conn.executemany(
+        """
+        INSERT INTO timeline_events (slug, event_date, event_type, heading, payload_json)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        timeline_batch,
+    )
+    n = len(timeline_batch)
+    timeline_batch.clear()
+    return n
+
+
+def _flush_embeddings(conn: sqlite3.Connection, embed_batch: list[tuple]) -> int:
+    if not embed_batch:
+        return 0
+    conn.executemany(
+        """
+        INSERT INTO page_embeddings (slug, chunk_index, section_title, chunk_text, embedding_blob, embedding_model)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        embed_batch,
+    )
+    n = len(embed_batch)
+    embed_batch.clear()
+    return n
+
+
 def _embed_text(text: str) -> bytes:
     """Delegate to the semantic embedding backend (Qwen3-Embedding MLX or hash fallback)."""
     return _embed_text_semantic(text)
@@ -1438,28 +1504,44 @@ def rebuild_knowledge_index(
                     authority_log,
                 )
             _preserve_existing_truth_rows(layout.knowledge_db, conn, exclude_pack=truth_pack)
-            page_rows = []
-            timeline_rows = []
-            embedding_rows = []
+            # Bounded rebuild: stream pages / FTS / timeline / embeddings
+            # to the DB in capped batches instead of accumulating every
+            # body and every embedding blob in Python lists.  Only the
+            # object-slug subset (``object_page_rows``) is retained,
+            # because the truth-projection builder consumes it as an
+            # in-process argument (see the ``execute_truth_projection_builder``
+            # call below).  This is the PR2b memory-safety floor; the
+            # second full-body FTS list and the full ``embedding_rows``
+            # accumulation are gone.
+            page_batch: list[tuple] = []
+            fts_batch: list[tuple] = []
+            timeline_batch: list[tuple] = []
+            embed_batch: list[tuple] = []
+            object_page_rows: list[tuple] = []
+            pages_indexed = 0
+            timeline_events_indexed = 0
+            embedding_chunks_indexed = 0
             for meta in deduped_page_metadata_items:
                 file_path = Path(meta.path)
                 body = _split_frontmatter_body(file_path.read_text(encoding="utf-8"))
-                page_rows.append(
-                    (
-                        meta.note_id,
-                        meta.title,
-                        meta.note_type,
-                        str(file_path),
-                        meta.day_id,
-                        json.dumps(meta.to_dict(), ensure_ascii=False),
-                        body,
-                    )
+                page_row = (
+                    meta.note_id,
+                    meta.title,
+                    meta.note_type,
+                    str(file_path),
+                    meta.day_id,
+                    json.dumps(meta.to_dict(), ensure_ascii=False),
+                    body,
                 )
-                timeline_rows.extend(_extract_timeline_events(meta, body))
+                page_batch.append(page_row)
+                fts_batch.append((meta.note_id, meta.title, body))
+                if meta.note_id in known_slugs:
+                    object_page_rows.append(page_row)
+                timeline_batch.extend(_extract_timeline_events(meta, body))
                 for chunk_index, (section_title, chunk_text) in enumerate(
                     _chunk_page_body(body, meta.title)
                 ):
-                    embedding_rows.append(
+                    embed_batch.append(
                         (
                             meta.note_id,
                             chunk_index,
@@ -1469,18 +1551,15 @@ def rebuild_knowledge_index(
                             get_model_name(),
                         )
                     )
+                    if len(embed_batch) >= _EMBED_FLUSH_BATCH:
+                        embedding_chunks_indexed += _flush_embeddings(conn, embed_batch)
+                if len(page_batch) >= _PAGE_FLUSH_BATCH:
+                    pages_indexed += _flush_pages(conn, page_batch, fts_batch)
+                    timeline_events_indexed += _flush_timeline(conn, timeline_batch)
 
-            conn.executemany(
-                """
-                INSERT INTO pages_index (slug, title, note_type, path, day_id, frontmatter_json, body)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
-                """,
-                page_rows,
-            )
-            conn.executemany(
-                "INSERT INTO page_fts (slug, title, body) VALUES (?, ?, ?)",
-                [(slug, title, body) for slug, title, _, _, _, _, body in page_rows],
-            )
+            pages_indexed += _flush_pages(conn, page_batch, fts_batch)
+            timeline_events_indexed += _flush_timeline(conn, timeline_batch)
+            embedding_chunks_indexed += _flush_embeddings(conn, embed_batch)
 
             link_rows = []
             for meta in deduped_page_metadata_items:
@@ -1509,7 +1588,8 @@ def rebuild_knowledge_index(
                 link_rows,
             )
 
-            object_page_rows = [row for row in page_rows if row[0] in known_slugs]
+            # object_page_rows was retained incrementally during the
+            # bounded page loop above (slug ∈ known_slugs).
             object_link_rows = [row for row in link_rows if row[0] in known_slugs]
             projection_spec, truth_projection = execute_truth_projection_builder(
                 vault_dir=resolved_vault,
@@ -1662,13 +1742,7 @@ def rebuild_knowledge_index(
                 raw_rows,
             )
 
-            conn.executemany(
-                """
-                INSERT INTO timeline_events (slug, event_date, event_type, heading, payload_json)
-                VALUES (?, ?, ?, ?, ?)
-                """,
-                timeline_rows,
-            )
+            # timeline_events were streamed in the bounded page loop.
 
             audit_rows = _collect_audit_rows(layout)
             conn.executemany(
@@ -1690,13 +1764,7 @@ def rebuild_knowledge_index(
                 """,
                 reuse_rows,
             )
-            conn.executemany(
-                """
-                INSERT INTO page_embeddings (slug, chunk_index, section_title, chunk_text, embedding_blob, embedding_model)
-                VALUES (?, ?, ?, ?, ?, ?)
-                """,
-                embedding_rows,
-            )
+            # page_embeddings were streamed in the bounded page loop.
 
             entity_mention_rows = _collect_entity_mention_rows(
                 resolved_vault, link_rows, known_slugs
@@ -1797,13 +1865,13 @@ def rebuild_knowledge_index(
             return {
                 "db_path": str(layout.knowledge_db),
                 "projection_pack": truth_pack,
-                "pages_indexed": len(page_rows),
+                "pages_indexed": pages_indexed,
                 "links_indexed": len(link_rows),
                 "raw_records_indexed": len(raw_rows),
-                "timeline_events_indexed": len(timeline_rows),
+                "timeline_events_indexed": timeline_events_indexed,
                 "audit_events_indexed": len(audit_rows),
                 "reuse_events_indexed": len(reuse_rows),
-                "embedding_chunks_indexed": len(embedding_rows),
+                "embedding_chunks_indexed": embedding_chunks_indexed,
                 "objects_indexed": len(truth_projection.objects),
                 "claims_indexed": len(truth_projection.claims),
                 "relations_indexed": len(truth_projection.relations),

--- a/tests/test_knowledge_index_bounded_flush.py
+++ b/tests/test_knowledge_index_bounded_flush.py
@@ -98,3 +98,31 @@ def test_truth_projection_still_produced_after_bounded_flush(temp_vault, monkeyp
 
     assert result["objects_indexed"] == objects
     assert objects > 0
+
+
+def test_high_event_density_page_flushes_timeline_independently(
+    temp_vault, monkeypatch
+):
+    """A single page can emit many timeline events; timeline must
+    flush on its own size, not only at the page-batch boundary, so
+    timeline_batch cannot grow unbounded between page flushes."""
+    monkeypatch.setattr(knowledge_index, "_TIMELINE_FLUSH_BATCH", 10)
+    monkeypatch.setattr(knowledge_index, "_PAGE_FLUSH_BATCH", 1000)
+
+    # 60 dated headings on ONE page => 60 heading_date events (+1
+    # page_date), far above the forced timeline batch of 10, while
+    # the page batch never fills — only the independent timeline
+    # flush can keep the batch bounded.
+    headings = "\n".join(f"## 2026-{m:02d}\nnote {m}" for m in range(1, 13)) * 5
+    _evergreen(temp_vault, "changelog", headings)
+
+    result = rebuild_knowledge_index(temp_vault)
+    db_path = VaultLayout.from_vault(temp_vault).knowledge_db
+
+    with sqlite3.connect(db_path) as conn:
+        timeline = conn.execute(
+            "SELECT COUNT(*) FROM timeline_events WHERE slug = 'changelog'"
+        ).fetchone()[0]
+
+    assert timeline > 10  # exceeded the forced batch
+    assert result["timeline_events_indexed"] == timeline

--- a/tests/test_knowledge_index_bounded_flush.py
+++ b/tests/test_knowledge_index_bounded_flush.py
@@ -1,0 +1,100 @@
+"""PR2b — knowledge-index bounded-flush rebuild.
+
+The rebuild no longer accumulates every page body + every embedding
+blob in Python lists.  Rows stream to the DB in capped batches; only
+the object-slug subset is retained for the truth-projection builder.
+These lock: counts still match the DB across multiple flush batches,
+long bodies still produce only capped chunks, and the truth
+projection is still produced (the retention trap did not break it).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from ovp_pipeline import knowledge_index
+from ovp_pipeline.knowledge_index import _MAX_CHUNK_CHARS, rebuild_knowledge_index
+from ovp_pipeline.runtime import VaultLayout
+
+
+def _evergreen(vault, slug: str, body: str) -> None:
+    p = vault / "10-Knowledge" / "Evergreen" / f"{slug}.md"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(
+        f"---\nnote_id: {slug}\ntitle: {slug.replace('-', ' ').title()}\n"
+        f"type: evergreen\ndate: 2026-05-17\n---\n\n# {slug}\n\n{body}\n",
+        encoding="utf-8",
+    )
+
+
+def test_bounded_flush_multi_batch_counts_match_db(temp_vault, monkeypatch):
+    """With batch sizes forced below the page/chunk count, the loop
+    flushes several times — stats must still equal the DB row counts."""
+    monkeypatch.setattr(knowledge_index, "_PAGE_FLUSH_BATCH", 2)
+    monkeypatch.setattr(knowledge_index, "_EMBED_FLUSH_BATCH", 2)
+
+    for i in range(7):
+        _evergreen(
+            temp_vault,
+            f"concept-{i}",
+            f"## Overview\nBody for concept {i}.\n\n## Detail\nMore on {i}.",
+        )
+
+    result = rebuild_knowledge_index(temp_vault)
+    db_path = VaultLayout.from_vault(temp_vault).knowledge_db
+
+    with sqlite3.connect(db_path) as conn:
+        pages = conn.execute("SELECT COUNT(*) FROM pages_index").fetchone()[0]
+        fts = conn.execute("SELECT COUNT(*) FROM page_fts").fetchone()[0]
+        embeds = conn.execute("SELECT COUNT(*) FROM page_embeddings").fetchone()[0]
+        timeline = conn.execute("SELECT COUNT(*) FROM timeline_events").fetchone()[0]
+
+    assert result["pages_indexed"] == 7 == pages == fts
+    assert result["embedding_chunks_indexed"] == embeds
+    assert result["timeline_events_indexed"] == timeline
+    assert embeds > 0  # streamed across multiple flush batches
+
+
+def test_long_body_chunks_all_capped_in_db(temp_vault):
+    """An un-sectioned long body must not produce an over-cap chunk
+    row in page_embeddings."""
+    _evergreen(temp_vault, "huge-note", "word " * (_MAX_CHUNK_CHARS))  # ~5x cap
+    _evergreen(temp_vault, "small-note", "short body")
+
+    rebuild_knowledge_index(temp_vault)
+    db_path = VaultLayout.from_vault(temp_vault).knowledge_db
+
+    with sqlite3.connect(db_path) as conn:
+        lengths = [
+            len(r[0])
+            for r in conn.execute(
+                "SELECT chunk_text FROM page_embeddings WHERE slug = 'huge-note'"
+            ).fetchall()
+        ]
+
+    assert lengths, "huge-note should have produced embedding chunks"
+    assert len(lengths) > 1
+    assert all(n <= _MAX_CHUNK_CHARS for n in lengths)
+
+
+def test_truth_projection_still_produced_after_bounded_flush(temp_vault, monkeypatch):
+    """Retaining only the object-slug subset must still feed the
+    truth-projection builder — objects/claims/graph stay populated."""
+    monkeypatch.setattr(knowledge_index, "_PAGE_FLUSH_BATCH", 1)
+
+    for i in range(3):
+        _evergreen(
+            temp_vault,
+            f"obj-{i}",
+            f"## Definition\nObject {i} is a thing.\n\n"
+            f"Related to [[obj-{(i + 1) % 3}]].",
+        )
+
+    result = rebuild_knowledge_index(temp_vault)
+    db_path = VaultLayout.from_vault(temp_vault).knowledge_db
+
+    with sqlite3.connect(db_path) as conn:
+        objects = conn.execute("SELECT COUNT(*) FROM objects").fetchone()[0]
+
+    assert result["objects_indexed"] == objects
+    assert objects > 0


### PR DESCRIPTION
fix(knowledge-index): bounded-flush rebuild (PR2b)

Supersedes #269 (auto-closed when its stacked base branch
fix/ki-chunk-cap was deleted on #268 merge). Rebased onto main;
PR2a is already in main via #268. Net change here is PR2b only.

The rebuild accumulated every page body, a second full-body list
for page_fts, every timeline row, and every embedding blob in
Python lists before a single bulk insert. At scale (10k+ pages,
31k+ chunks, 332MB db) those live simultaneously — the largest
memory source in the pipeline.

Restructured the page loop to stream in capped batches:

- pages_index + page_fts written from a single per-page batch
  (the duplicate full-body FTS comprehension is gone).
- timeline_events streamed, flushed both at the page-batch
  boundary AND independently on its own size (_TIMELINE_FLUSH_BATCH
  = 500) so a high-event-density page can't grow it unbounded
  (gemini review follow-up).
- page_embeddings streamed in their own capped batch — the single
  biggest memory source no longer accumulates.
- stats come from counters, not len() of retired lists.

Truth-projection trap handled explicitly: the builder takes
object_page_rows / object_link_rows as in-process arguments, so
only the object-slug subset is RETAINED (built incrementally as
slug in known_slugs). Everything else streams to the DB and is
dropped. object_link_rows / link_rows unchanged.

Same transaction, same atomic replace, identical row contents and
ordering semantics — behaviour-preserving.

Batch sizes: _PAGE_FLUSH_BATCH=200, _EMBED_FLUSH_BATCH=128,
_TIMELINE_FLUSH_BATCH=500.

Tests: multi-batch flush stats == DB row counts; long
un-sectioned body yields only capped chunk rows; truth projection
still produces objects after subset-only retention; high
event-density page flushes timeline independently. Full suite
3048 passed / 0 failed.
