### PR TITLE
perf(knowledge-index): reuse unchanged embeddings — avoid recomputation (PR3)

### DIFF
--- a/src/ovp_pipeline/knowledge_index.py
+++ b/src/ovp_pipeline/knowledge_index.py
@@ -13,7 +13,7 @@ import math
 import re
 import sqlite3
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, cast
 
 from .concept_registry import ConceptRegistry, ResolutionAction
 from .event_emitter import iter_for_index
@@ -64,7 +64,7 @@ KNOWLEDGE_DB_PROJECTION_KIND = "knowledge_db"
 #
 # See ``ARCHITECTURE.md`` § Projection schema changes for the
 # review-side rules + PR checklist.
-KNOWLEDGE_DB_PROJECTION_SCHEMA_VERSION = 8
+KNOWLEDGE_DB_PROJECTION_SCHEMA_VERSION = 9
 
 
 _FTS_QUERY_SCRUB = re.compile(r"[^\w\u4e00-\u9fff]+", flags=re.UNICODE)
@@ -152,10 +152,14 @@ CREATE TABLE page_embeddings (
   chunk_text TEXT NOT NULL,
   embedding_blob BLOB NOT NULL,
   embedding_model TEXT NOT NULL,
+  chunk_hash TEXT NOT NULL DEFAULT '',
   PRIMARY KEY (slug, chunk_index)
 );
 
 CREATE INDEX idx_page_embeddings_slug ON page_embeddings(slug);
+
+CREATE INDEX idx_page_embeddings_hash
+  ON page_embeddings(chunk_hash, embedding_model);
 
 CREATE TABLE page_metrics (
   slug TEXT PRIMARY KEY,
@@ -332,6 +336,42 @@ def _migrate_7_to_8_chats(conn: sqlite3.Connection, vault_dir: Path) -> None:
     rebuild_chats_projection(conn, vault_dir=vault_dir)
 
 
+def _migrate_8_to_9_embedding_hash(conn: sqlite3.Connection, vault_dir: Path) -> None:
+    """PR3 — ``page_embeddings.chunk_hash`` for embedding reuse.
+
+    Pure additive: one new ``NOT NULL DEFAULT ''`` column on an
+    existing table plus a lookup index.  No re-projection — existing
+    rows keep ``chunk_hash=''`` which simply never matches a freshly
+    computed SHA-256, so the next full rebuild recomputes them once
+    and from then on the hash is populated and reuse kicks in.  The
+    ``IF NOT EXISTS`` / duplicate-column guard makes it idempotent
+    against a DB already at the v9 shape (e.g. built fresh from
+    ``SCHEMA``).
+    """
+    table_exists = conn.execute(
+        "SELECT 1 FROM sqlite_master "
+        "WHERE type='table' AND name='page_embeddings'"
+    ).fetchone()
+    if not table_exists:
+        # No page_embeddings (minimal/partial DB).  A real DB gets
+        # the v9-shaped table from the main SCHEMA on fresh build;
+        # nothing to migrate here.
+        return
+    cols = {
+        row[1]
+        for row in conn.execute("PRAGMA table_info(page_embeddings)").fetchall()
+    }
+    if "chunk_hash" not in cols:
+        conn.execute(
+            "ALTER TABLE page_embeddings "
+            "ADD COLUMN chunk_hash TEXT NOT NULL DEFAULT ''"
+        )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_page_embeddings_hash "
+        "ON page_embeddings(chunk_hash, embedding_model)"
+    )
+
+
 SCHEMA_MIGRATIONS: dict[int, SchemaMigration] = {
     6: SchemaMigration(
         from_version=6,
@@ -344,6 +384,12 @@ SCHEMA_MIGRATIONS: dict[int, SchemaMigration] = {
         kind=SchemaMigrationKind.ADDITIVE,
         reason="BL-085 — chats projection table",
         runner=_migrate_7_to_8_chats,
+    ),
+    8: SchemaMigration(
+        from_version=8,
+        kind=SchemaMigrationKind.ADDITIVE,
+        reason="PR3 — page_embeddings.chunk_hash for embedding reuse",
+        runner=_migrate_8_to_9_embedding_hash,
     ),
 }
 
@@ -1105,14 +1151,79 @@ def _flush_embeddings(conn: sqlite3.Connection, embed_batch: list[tuple]) -> int
         return 0
     conn.executemany(
         """
-        INSERT INTO page_embeddings (slug, chunk_index, section_title, chunk_text, embedding_blob, embedding_model)
-        VALUES (?, ?, ?, ?, ?, ?)
+        INSERT INTO page_embeddings (slug, chunk_index, section_title, chunk_text, embedding_blob, embedding_model, chunk_hash)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
         """,
         embed_batch,
     )
     n = len(embed_batch)
     embed_batch.clear()
     return n
+
+
+def _chunk_embed_hash(embed_input: str) -> str:
+    """Stable content hash of the exact text handed to the embedding
+    backend (``section_title\\nchunk_text``).  Same text + same model
+    ⇒ the prior embedding can be reused verbatim."""
+    return hashlib.sha256(embed_input.encode("utf-8")).hexdigest()
+
+
+class _EmbeddingReuseCache:
+    """Bounded reuse of prior embeddings across a rebuild.
+
+    The previous ``knowledge.db`` is still on disk while the temp DB
+    is built (the atomic replace happens last).  This opens it
+    read-only and looks a stored embedding up by
+    ``(chunk_hash, embedding_model)`` through the
+    ``idx_page_embeddings_hash`` index — no full-table load, so memory
+    stays bounded (the PR2b discipline).  A missing DB / table /
+    column makes every lookup miss, so the chunk is recomputed and
+    the cache self-heals on the next rebuild.
+    """
+
+    def __init__(self, old_db: Path) -> None:
+        self._conn: sqlite3.Connection | None = None
+        self.hits = 0
+        self.misses = 0
+        if not old_db.exists():
+            return
+        try:
+            conn = sqlite3.connect(f"file:{old_db}?mode=ro", uri=True)
+            cols = {
+                r[1]
+                for r in conn.execute(
+                    "PRAGMA table_info(page_embeddings)"
+                ).fetchall()
+            }
+            if "chunk_hash" not in cols:
+                conn.close()
+                return
+            self._conn = conn
+        except sqlite3.Error:
+            self._conn = None
+
+    def get(self, chunk_hash: str, model: str) -> bytes | None:
+        if self._conn is None or not chunk_hash:
+            self.misses += 1
+            return None
+        try:
+            row = self._conn.execute(
+                "SELECT embedding_blob FROM page_embeddings "
+                "WHERE chunk_hash = ? AND embedding_model = ? LIMIT 1",
+                (chunk_hash, model),
+            ).fetchone()
+        except sqlite3.Error:
+            row = None
+        if row is None:
+            self.misses += 1
+            return None
+        self.hits += 1
+        return cast("bytes", row[0])
+
+    def close(self) -> None:
+        if self._conn is not None:
+            self._conn.close()
+            self._conn = None
 
 
 def _embed_text(text: str) -> bytes:
@@ -1487,6 +1598,7 @@ def rebuild_knowledge_index(
         _remove_sqlite_artifacts(temp_db_path)
 
         conn = None
+        reuse_cache: _EmbeddingReuseCache | None = None
         try:
             conn = _initialize_database(temp_db_path)
             # BL-054: source_authority lives in its own module — make
@@ -1526,6 +1638,10 @@ def rebuild_knowledge_index(
             pages_indexed = 0
             timeline_events_indexed = 0
             embedding_chunks_indexed = 0
+            # PR3: reuse unchanged embeddings from the prior DB (still
+            # on disk until the atomic replace) instead of re-running
+            # the embedding backend for every chunk every rebuild.
+            reuse_cache = _EmbeddingReuseCache(layout.knowledge_db)
             for meta in deduped_page_metadata_items:
                 file_path = Path(meta.path)
                 body = _split_frontmatter_body(file_path.read_text(encoding="utf-8"))
@@ -1548,14 +1664,21 @@ def rebuild_knowledge_index(
                 for chunk_index, (section_title, chunk_text) in enumerate(
                     _chunk_page_body(body, meta.title)
                 ):
+                    embed_input = f"{section_title}\n{chunk_text}"
+                    chunk_hash = _chunk_embed_hash(embed_input)
+                    model_name = get_model_name()
+                    blob = reuse_cache.get(chunk_hash, model_name)
+                    if blob is None:
+                        blob = _embed_text(embed_input)
                     embed_batch.append(
                         (
                             meta.note_id,
                             chunk_index,
                             section_title,
                             chunk_text,
-                            _embed_text(f"{section_title}\n{chunk_text}"),
-                            get_model_name(),
+                            blob,
+                            model_name,
+                            chunk_hash,
                         )
                     )
                     if len(embed_batch) >= _EMBED_FLUSH_BATCH:
@@ -1567,6 +1690,8 @@ def rebuild_knowledge_index(
             pages_indexed += _flush_pages(conn, page_batch, fts_batch)
             timeline_events_indexed += _flush_timeline(conn, timeline_batch)
             embedding_chunks_indexed += _flush_embeddings(conn, embed_batch)
+            embedding_chunks_reused = reuse_cache.hits
+            reuse_cache.close()
 
             link_rows = []
             for meta in deduped_page_metadata_items:
@@ -1859,6 +1984,8 @@ def rebuild_knowledge_index(
 
             conn.commit()
         except Exception:
+            if reuse_cache is not None:
+                reuse_cache.close()
             if conn is not None:
                 conn.close()
             _remove_sqlite_artifacts(temp_db_path)
@@ -1879,6 +2006,7 @@ def rebuild_knowledge_index(
                 "audit_events_indexed": len(audit_rows),
                 "reuse_events_indexed": len(reuse_rows),
                 "embedding_chunks_indexed": embedding_chunks_indexed,
+                "embedding_chunks_reused": embedding_chunks_reused,
                 "objects_indexed": len(truth_projection.objects),
                 "claims_indexed": len(truth_projection.claims),
                 "relations_indexed": len(truth_projection.relations),

--- a/tests/test_knowledge_index.py
+++ b/tests/test_knowledge_index.py
@@ -1006,7 +1006,8 @@ date: 2026-04-07
     # BL-061: KNOWLEDGE_DB_PROJECTION_SCHEMA_VERSION bumped 6→7 to
     # materialise ``evergreen_revisions`` on existing vaults.
     # BL-085: bumped 7→8 to materialise the ``chats`` projection.
-    assert row[2] == 8
+    # PR3: bumped 8→9 for ``page_embeddings.chunk_hash``.
+    assert row[2] == 9
     assert row[3]
 
 
@@ -1077,7 +1078,7 @@ date: 2026-04-07
     # table on existing vaults.  BL-085 bumped 7 → 8 for the ``chats``
     # projection.  Each future BL that adds a canonical table will
     # keep bumping this constant; the test should track it.
-    assert markers[-1].projection_schema_version == 8
+    assert markers[-1].projection_schema_version == 9
     assert markers[-1].status == "closed"
     with sqlite3.connect(layout.knowledge_db) as conn:
         row = conn.execute(
@@ -1088,8 +1089,9 @@ date: 2026-04-07
             """
         ).fetchone()
     # M21 BL-085 bumped projection_schema_version 7 → 8 to ensure
-    # vaults rebuild when the chats projection lands.
-    assert row == (2, 8)
+    # vaults rebuild when the chats projection lands.  PR3 bumped
+    # 8 → 9 for page_embeddings.chunk_hash.
+    assert row == (2, 9)
 
 
 def test_ensure_knowledge_db_current_rebuilds_when_projection_schema_version_advances(temp_vault):
@@ -1139,8 +1141,8 @@ date: 2026-04-07
             """
         ).fetchone()
     # BL-061: see version-bump rationale above.  M21 BL-085 bumped
-    # to 8.
-    assert row == (1, 8)
+    # to 8.  PR3 bumped to 9 for page_embeddings.chunk_hash.
+    assert row == (1, 9)
 
 
 def test_recent_audit_events_returns_newest_rows_first(temp_vault):
@@ -1506,6 +1508,25 @@ Stable body.
         raise RuntimeError("boom")
 
     monkeypatch.setattr("ovp_pipeline.knowledge_index._embed_text", fail_embed)
+
+    # PR3: unchanged chunks are reused from the prior DB and never
+    # hit _embed_text.  Change the body so the chunk hash differs,
+    # forcing a recompute that exercises the failure path.
+    evergreen.write_text(
+        """---
+note_id: source-note
+title: Source Note
+type: evergreen
+date: 2026-04-10
+---
+
+# Source Note
+
+## Architecture
+Body changed — forces an embedding recompute.
+""",
+        encoding="utf-8",
+    )
 
     with pytest.raises(RuntimeError, match="boom"):
         rebuild_knowledge_index(temp_vault)

--- a/tests/test_knowledge_index_embedding_reuse.py
+++ b/tests/test_knowledge_index_embedding_reuse.py
@@ -1,0 +1,143 @@
+"""PR3 — embedding reuse via page_embeddings.chunk_hash.
+
+A rebuild used to re-run the embedding backend for every chunk every
+time.  Now an unchanged chunk (same embed text + same model) reuses
+the prior embedding from the still-on-disk DB; only changed chunks
+hit the backend.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from ovp_pipeline import knowledge_index
+from ovp_pipeline.knowledge_index import (
+    _migrate_8_to_9_embedding_hash,
+    rebuild_knowledge_index,
+)
+from ovp_pipeline.runtime import VaultLayout
+
+
+def _evergreen(vault, slug: str, body: str) -> None:
+    p = vault / "10-Knowledge" / "Evergreen" / f"{slug}.md"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(
+        f"---\nnote_id: {slug}\ntitle: {slug}\ntype: evergreen\n"
+        f"date: 2026-05-17\n---\n\n# {slug}\n\n## Body\n{body}\n",
+        encoding="utf-8",
+    )
+
+
+def _count_embed(monkeypatch) -> list[int]:
+    calls = [0]
+    real = knowledge_index._embed_text
+
+    def counting(text: str) -> bytes:
+        calls[0] += 1
+        return real(text)
+
+    monkeypatch.setattr(knowledge_index, "_embed_text", counting)
+    return calls
+
+
+def test_second_rebuild_reuses_all_unchanged_embeddings(temp_vault, monkeypatch):
+    _evergreen(temp_vault, "alpha", "stable content one")
+    _evergreen(temp_vault, "beta", "stable content two")
+
+    first = rebuild_knowledge_index(temp_vault)
+    assert first["embedding_chunks_indexed"] > 0
+    assert first["embedding_chunks_reused"] == 0  # no prior DB
+
+    calls = _count_embed(monkeypatch)
+    second = rebuild_knowledge_index(temp_vault)
+
+    assert calls[0] == 0  # every chunk reused, backend never called
+    assert second["embedding_chunks_reused"] == second["embedding_chunks_indexed"]
+    assert second["embedding_chunks_indexed"] == first["embedding_chunks_indexed"]
+
+
+def test_only_changed_chunks_are_recomputed(temp_vault, monkeypatch):
+    _evergreen(temp_vault, "alpha", "stable content one")
+    _evergreen(temp_vault, "beta", "stable content two")
+    first = rebuild_knowledge_index(temp_vault)
+
+    _evergreen(temp_vault, "beta", "CHANGED content two now different")
+
+    calls = _count_embed(monkeypatch)
+    second = rebuild_knowledge_index(temp_vault)
+
+    # alpha reused, beta recomputed — backend called, but not for all.
+    assert calls[0] >= 1
+    assert second["embedding_chunks_reused"] >= 1
+    assert second["embedding_chunks_reused"] < second["embedding_chunks_indexed"]
+    assert first["embedding_chunks_indexed"] == second["embedding_chunks_indexed"]
+
+
+def test_model_change_invalidates_reuse(temp_vault, monkeypatch):
+    _evergreen(temp_vault, "alpha", "stable content one")
+    rebuild_knowledge_index(temp_vault)
+
+    monkeypatch.setattr(
+        knowledge_index, "get_model_name", lambda: "different-model-v2"
+    )
+    calls = _count_embed(monkeypatch)
+    second = rebuild_knowledge_index(temp_vault)
+
+    assert second["embedding_chunks_reused"] == 0
+    assert calls[0] == second["embedding_chunks_indexed"]
+
+
+def test_migrate_8_to_9_adds_column_and_index(tmp_path):
+    db = tmp_path / "knowledge.db"
+    with sqlite3.connect(db) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE page_embeddings (
+              slug TEXT NOT NULL,
+              chunk_index INTEGER NOT NULL,
+              section_title TEXT NOT NULL,
+              chunk_text TEXT NOT NULL,
+              embedding_blob BLOB NOT NULL,
+              embedding_model TEXT NOT NULL,
+              PRIMARY KEY (slug, chunk_index)
+            );
+            """
+        )
+        _migrate_8_to_9_embedding_hash(conn, tmp_path)
+        conn.commit()
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(page_embeddings)")}
+        idx = {
+            r[0]
+            for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index' "
+                "AND tbl_name='page_embeddings'"
+            )
+        }
+        # idempotent: a second run must not raise
+        _migrate_8_to_9_embedding_hash(conn, tmp_path)
+
+    assert "chunk_hash" in cols
+    assert "idx_page_embeddings_hash" in idx
+
+
+def test_migrate_8_to_9_noop_when_table_absent(tmp_path):
+    db = tmp_path / "knowledge.db"
+    with sqlite3.connect(db) as conn:
+        conn.execute("CREATE TABLE pages_index (slug TEXT PRIMARY KEY)")
+        # must not raise even though page_embeddings does not exist
+        _migrate_8_to_9_embedding_hash(conn, tmp_path)
+
+
+def test_reuse_survives_into_db_rows(temp_vault):
+    _evergreen(temp_vault, "alpha", "persisted content")
+    rebuild_knowledge_index(temp_vault)
+    rebuild_knowledge_index(temp_vault)
+
+    db_path = VaultLayout.from_vault(temp_vault).knowledge_db
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            "SELECT chunk_hash FROM page_embeddings WHERE slug='alpha'"
+        ).fetchall()
+
+    assert rows
+    assert all(len(h[0]) == 64 for h in rows)  # sha256 hex


### PR DESCRIPTION
perf(knowledge-index): reuse unchanged embeddings — avoid recomputation (PR3)

KI Phase 2. Every rebuild re-ran the embedding backend for every
chunk, even when the chunk text was byte-identical to the prior
build. At scale (31k+ chunks) that is the dominant rebuild *compute*
cost and wall-time.

SCOPE — what this does and does NOT do (reviewer correction):

  * DOES: avoid recomputing embeddings for unchanged chunks. The
    saving is embedding *inference* (MLX forward passes) and the
    wall-time it costs — NOT model-load memory.
  * DOES NOT: avoid loading the MLX backend. The model is still
    lazy-loaded once per rebuild via
    _assert_embedding_consistent() -> get_model_name() /
    get_dimensions() at rebuild start (and the per-chunk
    get_model_name()). So peak RSS is not reduced by this PR;
    "second rebuild calls _embed_text() 0 times" is true but is a
    compute/wall-time win, not a memory-governance win.

  The genuine "100%-cache-hit rebuild never loads the model ->
  lower peak RSS" win needs a lightweight active-model-id/dim API
  that does not trigger _load_mlx_model(). Filed as a follow-up
  (BACKLOG: KI lightweight embedding-identity API); intentionally
  out of scope here.

Implementation:

- page_embeddings gains chunk_hash TEXT NOT NULL DEFAULT '' plus
  idx_page_embeddings_hash(chunk_hash, embedding_model).
- KNOWLEDGE_DB_PROJECTION_SCHEMA_VERSION 8 -> 9 with a registered
  ADDITIVE migration (_migrate_8_to_9_embedding_hash): ALTER ADD
  COLUMN + CREATE INDEX IF NOT EXISTS, idempotent, no-op when the
  table is absent (minimal/partial DBs), no re-projection. Old
  rows keep chunk_hash='' which never matches a fresh SHA-256, so
  they recompute once then populate — self-healing.
- chunk_hash = sha256 of the exact embed input
  (section_title\nchunk_text). On rebuild, _EmbeddingReuseCache
  opens the still-on-disk prior DB read-only and looks the blob up
  by (chunk_hash, embedding_model) through the index — the LOOKUP
  itself is bounded (no full-table load, PR2b discipline). Hit =>
  reuse blob, skip the inference. Miss / model change / missing
  column => embed.
- New stat: embedding_chunks_reused (additive; subset-key tests
  unaffected).

Behaviour-preserving: a rebuild still writes the same rows; only
the embedding values for unchanged chunks are carried over instead
of recomputed (same model => same vector).

Tests: second rebuild reuses all unchanged chunks (backend called
0 times); only changed chunks recompute; model change invalidates
all reuse; migration adds column+index, idempotent, no-op when
table absent; hash persisted as sha256. Version-tracking asserts
bumped 8->9; the db-preserve-on-failure test now mutates the body
so the failure path still exercises a recompute. Full suite 3058
passed / 0 failed.
