### PR TITLE
fix(pipeline): guard the post-absorb knowledge-index full rebuild (PR4)

### DIFF
--- a/src/ovp_pipeline/autopilot/daemon.py
+++ b/src/ovp_pipeline/autopilot/daemon.py
@@ -493,14 +493,22 @@ class AutoPilotDaemon:
         今日条目），所以挂到每次 refresh 上也不会产生噪音。
         """
         # PR4: same shared decision the pipeline uses (no
-        # pipeline/autopilot fork).  The lightweight audit-sync +
-        # ops_state rebuild runs inside decide_knowledge_refresh;
-        # only escalate to the heavy rebuild on canonical-object
-        # evidence or an unknown/untrustworthy state (conservative:
-        # unknown ⇒ full).
+        # pipeline/autopilot fork).  Review P1: this method only runs
+        # AFTER an article passed quality, so the cycle just wrote a
+        # new ``20-Areas/..._深度解读.md`` (and ran absorb) — an
+        # indexed-source change every time.  The canonical-audit
+        # detector alone would let that interpretation page go
+        # silently stale in pages_index/page_fts, so the autopilot
+        # always reports local change evidence → full rebuild
+        # (matches the agreed "autopilot ingested an article ⇒ full"
+        # rule; the lightweight path is for the no-op pipeline case).
         from ..commands.refresh_ops import decide_knowledge_refresh
 
-        decision = decide_knowledge_refresh(self.vault_dir, self.pack.name)
+        decision = decide_knowledge_refresh(
+            self.vault_dir,
+            self.pack.name,
+            local_change_reason="autopilot_processed_article",
+        )
         if not decision.is_full:
             self.log(
                 "✓ knowledge_index: lightweight refresh sufficient "

--- a/src/ovp_pipeline/autopilot/daemon.py
+++ b/src/ovp_pipeline/autopilot/daemon.py
@@ -492,6 +492,31 @@ class AutoPilotDaemon:
         两者都是幂等的（Crystal 内容哈希相同则文件不变；Working Memory 覆盖
         今日条目），所以挂到每次 refresh 上也不会产生噪音。
         """
+        # PR4: same shared decision the pipeline uses (no
+        # pipeline/autopilot fork).  The lightweight audit-sync +
+        # ops_state rebuild runs inside decide_knowledge_refresh;
+        # only escalate to the heavy rebuild on canonical-object
+        # evidence or an unknown/untrustworthy state (conservative:
+        # unknown ⇒ full).
+        from ..commands.refresh_ops import decide_knowledge_refresh
+
+        decision = decide_knowledge_refresh(self.vault_dir, self.pack.name)
+        if not decision.is_full:
+            self.log(
+                "✓ knowledge_index: lightweight refresh sufficient "
+                f"(reason={decision.reason}) — heavy rebuild skipped"
+            )
+            return
+
+        self.log(
+            f"↳ knowledge_index: full rebuild (reason={decision.reason}"
+            + (
+                f", canonical_evidence={decision.canonical_evidence_count}"
+                if decision.canonical_evidence_count
+                else ""
+            )
+            + ")"
+        )
         cmd = [
             sys.executable, "-m", "ovp_pipeline.commands.knowledge_index",
             "--vault-dir", str(self.vault_dir),

--- a/src/ovp_pipeline/commands/refresh_ops.py
+++ b/src/ovp_pipeline/commands/refresh_ops.py
@@ -42,11 +42,16 @@ import argparse
 import json
 import sqlite3
 import sys
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from ..audit_time import parse_audit_ts as _parse_audit_ts
-from ..knowledge_index import sync_audit_events_from_jsonl
+from ..knowledge_index import (
+    KNOWLEDGE_DB_PROJECTION_KIND,
+    KNOWLEDGE_DB_PROJECTION_SCHEMA_VERSION,
+    sync_audit_events_from_jsonl,
+)
 from ..ops_lifecycle import ALL_STATES
 from ..ops_state import rebuild as rebuild_ops_state
 from ..packs.loader import DEFAULT_WORKFLOW_PACK_NAME
@@ -192,6 +197,147 @@ def _canonical_evidence_since(
         key = str(et)
         found[key] = found.get(key, 0) + 1
     return found
+
+
+@dataclass(frozen=True)
+class RefreshDecision:
+    """Outcome of :func:`decide_knowledge_refresh`.
+
+    ``refresh_mode`` is the binary the pipeline / autopilot
+    knowledge_index step branches on:
+
+    * ``"audit_sync_only"`` — the lightweight path
+      (``sync_audit_events_from_jsonl`` + ``ops_state`` rebuild) ALREADY
+      RAN inside the decision and fully reflects this change; the
+      caller must NOT run the heavy ``rebuild_knowledge_index``.
+    * ``"full_rebuild"`` — the caller must run the full
+      ``rebuild_knowledge_index``.  Either canonical-object evidence
+      was detected, or the state was unknown/untrustworthy
+      (DB/metadata/schema/sync) — conservative by design: *unknown
+      ⇒ full rebuild*, never silently skip and let the projection go
+      stale.
+    """
+
+    refresh_mode: str
+    reason: str
+    canonical_evidence_count: int = 0
+    canonical_evidence: dict[str, int] = field(default_factory=dict)
+    watermark: str = ""
+    audit_sync_status: str = ""
+
+    @property
+    def is_full(self) -> bool:
+        return self.refresh_mode == "full_rebuild"
+
+
+def _projection_health(conn: sqlite3.Connection) -> str | None:
+    """Return a failure reason if the projection metadata is missing
+    or at a different schema version, else None.
+
+    A missing ``projection_metadata`` row / ``truth_projections``
+    table, or a schema-version mismatch, means audit-sync alone
+    cannot be trusted to leave a coherent projection — escalate to a
+    full rebuild (which is also what ``ensure_knowledge_db_current``
+    would do).
+    """
+    has_tp = conn.execute(
+        "SELECT 1 FROM sqlite_master "
+        "WHERE type='table' AND name='truth_projections'"
+    ).fetchone()
+    if not has_tp:
+        return "truth_projections_table_missing"
+    try:
+        row = conn.execute(
+            "SELECT projection_schema_version FROM projection_metadata "
+            "WHERE projection_kind = ?",
+            (KNOWLEDGE_DB_PROJECTION_KIND,),
+        ).fetchone()
+    except sqlite3.OperationalError:
+        return "projection_metadata_table_missing"
+    if row is None or row[0] is None:
+        return "projection_metadata_missing"
+    if int(row[0]) != int(KNOWLEDGE_DB_PROJECTION_SCHEMA_VERSION):
+        return (
+            f"projection_schema_mismatch"
+            f"(db={row[0]},expected={KNOWLEDGE_DB_PROJECTION_SCHEMA_VERSION})"
+        )
+    return None
+
+
+def decide_knowledge_refresh(
+    vault_dir: Path,
+    pack: str,
+    *,
+    force_full: bool = False,
+    canonical_window_minutes: int = 180,
+) -> RefreshDecision:
+    """Shared post-absorb refresh decision for the pipeline AND
+    autopilot knowledge_index step (single source of truth — no
+    pipeline/autopilot fork).
+
+    Conservative escalation — *unknown ⇒ full rebuild*:
+
+    1. ``force_full`` (operator ``--force-full-index``) → full.
+    2. ``knowledge.db`` missing → full (first build).
+    3. projection metadata missing / schema mismatch → full.
+    4. audit-sync did not reach ``synced`` → full (never decide on a
+       stale audit table).
+    5. canonical-object evidence (``_canonical_evidence_since``,
+       BL-107 watermark) present → full.
+    6. otherwise → ``audit_sync_only``: the lightweight audit-sync +
+       ``ops_state`` rebuild already ran here and fully reflects the
+       change; the heavy rebuild is NOT needed.
+
+    The lightweight work (audit-sync + ops_state rebuild) is executed
+    *inside* this function for the cases that reach step 5/6, so the
+    caller never double-runs it.
+    """
+    resolved = resolve_vault_dir(vault_dir)
+    db_path = _db_path(resolved)
+
+    if force_full:
+        return RefreshDecision("full_rebuild", "force_full_index")
+    if not db_path.is_file():
+        return RefreshDecision("full_rebuild", "knowledge_db_missing")
+
+    with sqlite3.connect(str(db_path)) as conn:
+        health = _projection_health(conn)
+    if health is not None:
+        return RefreshDecision("full_rebuild", health)
+
+    sync_payload = sync_audit_events_from_jsonl(resolved)
+    sync_status = str(sync_payload.get("status", "?"))
+    if sync_status != "synced":
+        return RefreshDecision(
+            "full_rebuild",
+            f"audit_sync_{sync_status}",
+            audit_sync_status=sync_status,
+        )
+
+    with sqlite3.connect(str(db_path)) as conn:
+        rebuild_ops_state(conn, pack=pack)
+        watermark = _last_rebuild_watermark(conn, pack)
+        canonical = _canonical_evidence_since(conn, canonical_window_minutes, pack)
+
+    wm = watermark.isoformat() if watermark is not None else ""
+    evidence_count = sum(canonical.values())
+    if canonical:
+        return RefreshDecision(
+            "full_rebuild",
+            "canonical_object_evidence",
+            canonical_evidence_count=evidence_count,
+            canonical_evidence=canonical,
+            watermark=wm,
+            audit_sync_status=sync_status,
+        )
+    return RefreshDecision(
+        "audit_sync_only",
+        "no_canonical_evidence",
+        canonical_evidence_count=0,
+        canonical_evidence={},
+        watermark=wm,
+        audit_sync_status=sync_status,
+    )
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/src/ovp_pipeline/commands/refresh_ops.py
+++ b/src/ovp_pipeline/commands/refresh_ops.py
@@ -269,6 +269,7 @@ def decide_knowledge_refresh(
     pack: str,
     *,
     force_full: bool = False,
+    local_change_reason: str | None = None,
     canonical_window_minutes: int = 180,
 ) -> RefreshDecision:
     """Shared post-absorb refresh decision for the pipeline AND
@@ -278,25 +279,43 @@ def decide_knowledge_refresh(
     Conservative escalation — *unknown ⇒ full rebuild*:
 
     1. ``force_full`` (operator ``--force-full-index``) → full.
-    2. ``knowledge.db`` missing → full (first build).
-    3. projection metadata missing / schema mismatch → full.
-    4. audit-sync did not reach ``synced`` → full (never decide on a
+    2. ``local_change_reason`` set → full.  The caller has
+       out-of-band evidence that an INDEXED source changed this run
+       (a new ``20-Areas/..._深度解读.md`` from articles, an Atlas/MOC
+       rewrite, a ``note_type`` frontmatter change, an absorb
+       promote, an entity-surface change …).  ``knowledge_index``
+       indexes a far wider surface than the canonical-object audit
+       events (Evergreen + Atlas + 20-Areas + Entity + registry +
+       entity-extraction log — see
+       ``EnhancedPipeline._knowledge_index_source_files``), so the
+       audit-event detector ALONE would let those changes go
+       silently stale in ``pages_index`` / ``page_fts`` /
+       ``page_embeddings`` / the truth projection.  This closes that
+       silent-correctness cliff.
+    3. ``knowledge.db`` missing → full (first build).
+    4. projection metadata missing / schema mismatch → full.
+    5. audit-sync did not reach ``synced`` → full (never decide on a
        stale audit table).
-    5. canonical-object evidence (``_canonical_evidence_since``,
+    6. canonical-object evidence (``_canonical_evidence_since``,
        BL-107 watermark) present → full.
-    6. otherwise → ``audit_sync_only``: the lightweight audit-sync +
-       ``ops_state`` rebuild already ran here and fully reflects the
-       change; the heavy rebuild is NOT needed.
+    7. otherwise → ``audit_sync_only``: the lightweight audit-sync
+       already ran here and fully reflects the change; the heavy
+       rebuild is NOT needed.
 
-    The lightweight work (audit-sync + ops_state rebuild) is executed
-    *inside* this function for the cases that reach step 5/6, so the
-    caller never double-runs it.
+    This function performs ONLY the audit-sync side effect (needed
+    for the canonical-evidence read).  It deliberately does NOT
+    rebuild ``ops_state`` — the dedicated ``ops_state`` DAG stage
+    (pipeline) / ``run_autopilot_ops_state`` (autopilot) runs right
+    after ``knowledge_index`` and owns that rebuild; doing it here
+    too was a redundant double-rebuild.
     """
     resolved = resolve_vault_dir(vault_dir)
     db_path = _db_path(resolved)
 
     if force_full:
         return RefreshDecision("full_rebuild", "force_full_index")
+    if local_change_reason:
+        return RefreshDecision("full_rebuild", local_change_reason)
     if not db_path.is_file():
         return RefreshDecision("full_rebuild", "knowledge_db_missing")
 
@@ -315,7 +334,6 @@ def decide_knowledge_refresh(
         )
 
     with sqlite3.connect(str(db_path)) as conn:
-        rebuild_ops_state(conn, pack=pack)
         watermark = _last_rebuild_watermark(conn, pack)
         canonical = _canonical_evidence_since(conn, canonical_window_minutes, pack)
 

--- a/src/ovp_pipeline/commands/refresh_ops.py
+++ b/src/ovp_pipeline/commands/refresh_ops.py
@@ -206,10 +206,12 @@ class RefreshDecision:
     ``refresh_mode`` is the binary the pipeline / autopilot
     knowledge_index step branches on:
 
-    * ``"audit_sync_only"`` — the lightweight path
-      (``sync_audit_events_from_jsonl`` + ``ops_state`` rebuild) ALREADY
-      RAN inside the decision and fully reflects this change; the
-      caller must NOT run the heavy ``rebuild_knowledge_index``.
+    * ``"audit_sync_only"`` — ``sync_audit_events_from_jsonl``
+      ALREADY RAN inside the decision; the caller must NOT run the
+      heavy ``rebuild_knowledge_index``.  The lifecycle ``ops_state``
+      projection is NOT rebuilt here — the dedicated ``ops_state``
+      DAG stage (``run_pipeline_ops_state``) / autopilot
+      ``run_autopilot_ops_state`` runs right after and owns it.
     * ``"full_rebuild"`` — the caller must run the full
       ``rebuild_knowledge_index``.  Either canonical-object evidence
       was detected, or the state was unknown/untrustworthy

--- a/src/ovp_pipeline/step_contracts.py
+++ b/src/ovp_pipeline/step_contracts.py
@@ -243,6 +243,11 @@ class KnowledgeIndexStepResult(StepResult):
     db_path: str = ""
     updated: bool = False
     db_mtime: float = 0.0
+    # PR4: which refresh path this step took and why.
+    # refresh_mode: "audit_sync_only" | "full_rebuild" | ""
+    refresh_mode: str = ""
+    canonical_evidence_count: int = 0
+    rebuild_watermark: str = ""
 
 
 # ---------------------------------------------------------------------------

--- a/src/ovp_pipeline/unified_pipeline_enhanced.py
+++ b/src/ovp_pipeline/unified_pipeline_enhanced.py
@@ -335,11 +335,17 @@ class EnhancedPipeline:
         """
         sr = self.step_results
 
+        # Only PER-RUN signals — never cumulative post-run totals
+        # (total_interpretations / total_entities are vault-wide
+        # population counts; using them would make every run on a
+        # non-empty vault report change and collapse the guard back
+        # to always-full).  produced / produced_files /
+        # note_type_changed / changed_files / promoted_slugs /
+        # mentions_extracted are all "this run did X" deltas.
         articles = sr.get("articles")
         if articles is not None and (
             articles.get("produced_files")
             or int(articles.get("produced", 0) or 0) > 0
-            or int(articles.get("total_interpretations", 0) or 0) > 0
         ):
             return "articles_produced_indexed_markdown"
 
@@ -360,10 +366,9 @@ class EnhancedPipeline:
             return "absorb_promoted_canonical_object"
 
         entity = sr.get("entity_extract")
-        if entity is not None and (
-            int(entity.get("mentions_extracted", 0) or 0) > 0
-            or int(entity.get("total_entities", 0) or 0) > 0
-        ):
+        if entity is not None and int(
+            entity.get("mentions_extracted", 0) or 0
+        ) > 0:
             return "entity_surface_changed"
 
         return None
@@ -2687,6 +2692,22 @@ class EnhancedPipeline:
         print("STEP 10: Refreshing Knowledge Index")
         print("="*60)
 
+        # A dry run must NOT trigger the heavy rebuild (gemini review:
+        # otherwise --dry-run could fire a ~20-min full rebuild).
+        # Mirror the skipped-result shape the other steps use.
+        if dry_run:
+            print("  ✓ knowledge_index (dry-run skipped)")
+            return _to_typed_step_result(
+                "knowledge_index",
+                {
+                    "success": True,
+                    "skipped": True,
+                    "reason": "dry_run",
+                    "updated": False,
+                    "db_path": str(self.layout.knowledge_db),
+                },
+            )
+
         # PR4: do not unconditionally run the heavy
         # rebuild_knowledge_index.  The shared decision
         # (decide_knowledge_refresh — same helper autopilot uses)
@@ -2696,59 +2717,59 @@ class EnhancedPipeline:
         # knowledge_index indexes far more than the canonical-object
         # audit events — (b) canonical-object audit evidence, or
         # (c) an untrustworthy/unknown state (conservative: unknown
-        # ⇒ full).  dry-run keeps the prior behaviour.
-        if not dry_run:
-            from .commands.refresh_ops import decide_knowledge_refresh
+        # ⇒ full).  dry-run already returned above.
+        from .commands.refresh_ops import decide_knowledge_refresh
 
-            local_reason = self._local_indexed_change_reason()
-            decision = decide_knowledge_refresh(
-                self.vault_dir,
-                self.workflow_pack_name,
-                force_full=self.force_full_index,
-                local_change_reason=local_reason,
+        local_reason = self._local_indexed_change_reason()
+        decision = decide_knowledge_refresh(
+            self.vault_dir,
+            self.workflow_pack_name,
+            force_full=self.force_full_index,
+            local_change_reason=local_reason,
+        )
+        self.logger.log(
+            "knowledge_index_refresh_decision",
+            {
+                "pack": self.workflow_pack_name,
+                "refresh_mode": decision.refresh_mode,
+                "reason": decision.reason,
+                "canonical_evidence_count": decision.canonical_evidence_count,
+                "canonical_evidence": decision.canonical_evidence,
+                "rebuild_watermark": decision.watermark,
+                "audit_sync_status": decision.audit_sync_status,
+            },
+        )
+        if not decision.is_full:
+            print(
+                "  ✓ Lightweight refresh sufficient "
+                f"(refresh_mode={decision.refresh_mode}, "
+                f"reason={decision.reason}). Heavy knowledge-index "
+                "rebuild skipped — audit-sync done here; the "
+                "dedicated ops_state stage rebuilds the lifecycle "
+                "projection next."
             )
-            self.logger.log(
-                "knowledge_index_refresh_decision",
+            return _to_typed_step_result(
+                "knowledge_index",
                 {
-                    "pack": self.workflow_pack_name,
-                    "refresh_mode": decision.refresh_mode,
+                    "success": True,
+                    "updated": False,
+                    "skipped": True,
                     "reason": decision.reason,
+                    "refresh_mode": decision.refresh_mode,
                     "canonical_evidence_count": decision.canonical_evidence_count,
-                    "canonical_evidence": decision.canonical_evidence,
                     "rebuild_watermark": decision.watermark,
-                    "audit_sync_status": decision.audit_sync_status,
+                    "db_path": str(self.layout.knowledge_db),
                 },
             )
-            if not decision.is_full:
-                print(
-                    "  ✓ Lightweight refresh sufficient "
-                    f"(refresh_mode={decision.refresh_mode}, "
-                    f"reason={decision.reason}). Heavy "
-                    "knowledge-index rebuild skipped — audit-sync + "
-                    "ops_state already reflect this change."
-                )
-                return _to_typed_step_result(
-                    "knowledge_index",
-                    {
-                        "success": True,
-                        "updated": False,
-                        "skipped": True,
-                        "reason": decision.reason,
-                        "refresh_mode": decision.refresh_mode,
-                        "canonical_evidence_count": decision.canonical_evidence_count,
-                        "rebuild_watermark": decision.watermark,
-                        "db_path": str(self.layout.knowledge_db),
-                    },
-                )
-            print(
-                f"  ↳ Full rebuild required (reason={decision.reason}"
-                + (
-                    f", canonical_evidence={decision.canonical_evidence_count}"
-                    if decision.canonical_evidence_count
-                    else ""
-                )
-                + ")."
+        print(
+            f"  ↳ Full rebuild required (reason={decision.reason}"
+            + (
+                f", canonical_evidence={decision.canonical_evidence_count}"
+                if decision.canonical_evidence_count
+                else ""
             )
+            + ")."
+        )
 
         cmd = [
             sys.executable, "-m", "ovp_pipeline.commands.knowledge_index",
@@ -2807,7 +2828,7 @@ class EnhancedPipeline:
         else:
             print(f"✗ Knowledge index refresh failed: {result.get('error', 'Unknown error')}")
 
-        if not dry_run and isinstance(result, dict):
+        if isinstance(result, dict):
             result.setdefault("refresh_mode", "full_rebuild")
             result.setdefault("reason", decision.reason)
             result.setdefault(

--- a/src/ovp_pipeline/unified_pipeline_enhanced.py
+++ b/src/ovp_pipeline/unified_pipeline_enhanced.py
@@ -169,6 +169,10 @@ class EnhancedPipeline:
         self.workflow_pack_name = DEFAULT_WORKFLOW_PACK_NAME
         self.workflow_profile_name = "full"
         self.run_mode = "custom"
+        # PR4: operator escape hatch — force the heavy
+        # rebuild_knowledge_index even when the shared decision would
+        # take the lightweight audit-sync-only path.
+        self.force_full_index = False
         # Contract mode: "strict" (default) raises on unknown fields,
         # "warn" emits StepContractWarning, "off" stores raw dicts.
         self.step_contract_mode: str = "strict"
@@ -2629,6 +2633,64 @@ class EnhancedPipeline:
         print("STEP 10: Refreshing Knowledge Index")
         print("="*60)
 
+        # PR4: do not unconditionally run the heavy
+        # rebuild_knowledge_index.  The shared decision
+        # (decide_knowledge_refresh — same helper autopilot uses)
+        # runs the lightweight audit-sync + ops_state rebuild and
+        # only escalates to the full rebuild on canonical-object
+        # evidence or an untrustworthy/unknown state (conservative:
+        # unknown ⇒ full).  dry-run keeps the prior behaviour.
+        if not dry_run:
+            from .commands.refresh_ops import decide_knowledge_refresh
+
+            decision = decide_knowledge_refresh(
+                self.vault_dir,
+                self.workflow_pack_name,
+                force_full=self.force_full_index,
+            )
+            self.logger.log(
+                "knowledge_index_refresh_decision",
+                {
+                    "pack": self.workflow_pack_name,
+                    "refresh_mode": decision.refresh_mode,
+                    "reason": decision.reason,
+                    "canonical_evidence_count": decision.canonical_evidence_count,
+                    "canonical_evidence": decision.canonical_evidence,
+                    "rebuild_watermark": decision.watermark,
+                    "audit_sync_status": decision.audit_sync_status,
+                },
+            )
+            if not decision.is_full:
+                print(
+                    "  ✓ Lightweight refresh sufficient "
+                    f"(refresh_mode={decision.refresh_mode}, "
+                    f"reason={decision.reason}). Heavy "
+                    "knowledge-index rebuild skipped — audit-sync + "
+                    "ops_state already reflect this change."
+                )
+                return _to_typed_step_result(
+                    "knowledge_index",
+                    {
+                        "success": True,
+                        "updated": False,
+                        "skipped": True,
+                        "reason": decision.reason,
+                        "refresh_mode": decision.refresh_mode,
+                        "canonical_evidence_count": decision.canonical_evidence_count,
+                        "rebuild_watermark": decision.watermark,
+                        "db_path": str(self.layout.knowledge_db),
+                    },
+                )
+            print(
+                f"  ↳ Full rebuild required (reason={decision.reason}"
+                + (
+                    f", canonical_evidence={decision.canonical_evidence_count}"
+                    if decision.canonical_evidence_count
+                    else ""
+                )
+                + ")."
+            )
+
         cmd = [
             sys.executable, "-m", "ovp_pipeline.commands.knowledge_index",
             "--vault-dir", str(self.vault_dir),
@@ -2685,6 +2747,14 @@ class EnhancedPipeline:
             self.run_command(working_memory_cmd, "knowledge_index", timeout=60)
         else:
             print(f"✗ Knowledge index refresh failed: {result.get('error', 'Unknown error')}")
+
+        if not dry_run and isinstance(result, dict):
+            result.setdefault("refresh_mode", "full_rebuild")
+            result.setdefault("reason", decision.reason)
+            result.setdefault(
+                "canonical_evidence_count", decision.canonical_evidence_count
+            )
+            result.setdefault("rebuild_watermark", decision.watermark)
 
         return _to_typed_step_result("knowledge_index", result)
 
@@ -3056,6 +3126,16 @@ def main():
                        help="初始化环境配置（交互式）")
     parser.add_argument("--check", action="store_true",
                        help="检查环境配置")
+    parser.add_argument(
+        "--force-full-index",
+        action="store_true",
+        help=(
+            "Force the heavy knowledge-index rebuild even when the "
+            "post-absorb decision would take the lightweight "
+            "audit-sync-only path (escape hatch; default is the "
+            "conservative auto decision)."
+        ),
+    )
 
     # Pinboard参数
     pinboard_group = parser.add_argument_group("Pinboard Options")
@@ -3133,6 +3213,7 @@ def main():
     txn = TransactionManager(layout.transactions_dir)
     pipeline = EnhancedPipeline(layout.vault_dir, logger, txn)
     pipeline.run_mode = "full" if args.full else ("incremental" if args.incremental else "custom")
+    pipeline.force_full_index = bool(getattr(args, "force_full_index", False))
 
     steps = execution_plan["steps"]
     pinboard_days = execution_plan["pinboard_days"]

--- a/src/ovp_pipeline/unified_pipeline_enhanced.py
+++ b/src/ovp_pipeline/unified_pipeline_enhanced.py
@@ -314,6 +314,60 @@ class EnhancedPipeline:
             files.append(extraction_log)
         return self._existing_files([path for path in files if "_Candidates" not in path.parts])
 
+    def _local_indexed_change_reason(self) -> str | None:
+        """PR4 / review P1: did THIS pipeline run change a file that
+        ``knowledge_index`` indexes (a far wider surface than the
+        canonical-object audit events)?
+
+        ``_knowledge_index_source_files`` indexes Evergreen + Atlas +
+        20-Areas + Entity + concept-registry + entity-extraction log.
+        A run can mutate any of those WITHOUT emitting
+        ``evergreen_auto_promoted`` / ``promote_concept`` /
+        ``evergreen_created`` (e.g. ``articles`` writes a new
+        ``20-Areas/..._深度解读.md``, ``moc`` rewrites Atlas,
+        ``note_type_normalize`` rewrites frontmatter).  The
+        canonical-audit detector alone would let those go silently
+        stale — so the pipeline reports its own per-run change
+        evidence and the shared decision escalates to a full rebuild.
+
+        Returns a short reason string when an indexed surface
+        changed this run, else None (defer to the audit detector).
+        """
+        sr = self.step_results
+
+        articles = sr.get("articles")
+        if articles is not None and (
+            articles.get("produced_files")
+            or int(articles.get("produced", 0) or 0) > 0
+            or int(articles.get("total_interpretations", 0) or 0) > 0
+        ):
+            return "articles_produced_indexed_markdown"
+
+        note_type = sr.get("note_type_normalize")
+        if note_type is not None and int(
+            note_type.get("note_type_changed", 0) or 0
+        ) > 0:
+            return "note_type_frontmatter_changed"
+
+        moc = sr.get("moc")
+        if moc is not None and (
+            moc.get("updated") or moc.get("changed_files")
+        ):
+            return "moc_atlas_changed"
+
+        absorb = sr.get("absorb")
+        if absorb is not None and absorb.get("promoted_slugs"):
+            return "absorb_promoted_canonical_object"
+
+        entity = sr.get("entity_extract")
+        if entity is not None and (
+            int(entity.get("mentions_extracted", 0) or 0) > 0
+            or int(entity.get("total_entities", 0) or 0) > 0
+        ):
+            return "entity_surface_changed"
+
+        return None
+
     def _stage_input_files(self, stage: str) -> list[Path]:
         if stage in {"quality", "fix_links"}:
             return self._existing_files(collect_quality_files(self.layout, all_areas=True))
@@ -2636,17 +2690,22 @@ class EnhancedPipeline:
         # PR4: do not unconditionally run the heavy
         # rebuild_knowledge_index.  The shared decision
         # (decide_knowledge_refresh — same helper autopilot uses)
-        # runs the lightweight audit-sync + ops_state rebuild and
-        # only escalates to the full rebuild on canonical-object
-        # evidence or an untrustworthy/unknown state (conservative:
-        # unknown ⇒ full).  dry-run keeps the prior behaviour.
+        # runs the lightweight audit-sync and only escalates to the
+        # full rebuild on (a) THIS run having changed an indexed
+        # source surface — review P1, the silent-staleness cliff:
+        # knowledge_index indexes far more than the canonical-object
+        # audit events — (b) canonical-object audit evidence, or
+        # (c) an untrustworthy/unknown state (conservative: unknown
+        # ⇒ full).  dry-run keeps the prior behaviour.
         if not dry_run:
             from .commands.refresh_ops import decide_knowledge_refresh
 
+            local_reason = self._local_indexed_change_reason()
             decision = decide_knowledge_refresh(
                 self.vault_dir,
                 self.workflow_pack_name,
                 force_full=self.force_full_index,
+                local_change_reason=local_reason,
             )
             self.logger.log(
                 "knowledge_index_refresh_decision",

--- a/tests/test_pipeline_rebuild_guard.py
+++ b/tests/test_pipeline_rebuild_guard.py
@@ -268,29 +268,63 @@ def test_local_indexed_change_reason_none_when_no_indexed_change(temp_vault):
     assert p._local_indexed_change_reason() is None
 
 
-def test_autopilot_passes_processed_article_reason():
-    """Autopilot's _run_knowledge_index_refresh only runs after an
-    article passed quality — it must always declare local change."""
-    import ovp_pipeline.autopilot.daemon as daemon
+def test_autopilot_invokes_decision_with_processed_article_reason():
+    """Runtime behaviour (not source text): the autopilot refresh
+    actually CALLS the shared helper with
+    local_change_reason='autopilot_processed_article' and, on a
+    non-full decision, returns without a heavy rebuild."""
+    from types import SimpleNamespace
 
-    src = Path(daemon.__file__).read_text(encoding="utf-8")
-    assert 'local_change_reason="autopilot_processed_article"' in src
+    import ovp_pipeline.autopilot.daemon as daemon_mod
+
+    light = refresh_ops.RefreshDecision("audit_sync_only", "no_canonical_evidence")
+    fake = SimpleNamespace(
+        vault_dir=Path("/tmp/does-not-matter"),
+        pack=SimpleNamespace(name=PACK),
+        log=lambda *_a, **_k: None,
+    )
+    with patch.object(
+        refresh_ops, "decide_knowledge_refresh", return_value=light
+    ) as dec:
+        daemon_mod.AutoPilotDaemon._run_knowledge_index_refresh(fake)
+
+    dec.assert_called_once()
+    _, kwargs = dec.call_args
+    assert kwargs.get("local_change_reason") == "autopilot_processed_article"
 
 
 # 5 ────────────────────────────────────────────────────────────────
-def test_pipeline_and_autopilot_share_one_decision(tmp_path):
-    """Both call sites import the SAME decide_knowledge_refresh —
-    asserting identity prevents a future pipeline/autopilot fork."""
-    from ovp_pipeline import unified_pipeline_enhanced as upe  # noqa: F401
-    import ovp_pipeline.autopilot.daemon as daemon  # noqa: F401
+def test_pipeline_and_autopilot_call_the_same_helper_at_runtime(temp_vault):
+    """Runtime no-fork proof: patch ONE object
+    (refresh_ops.decide_knowledge_refresh) and observe that BOTH the
+    pipeline step AND the autopilot refresh invoke that exact
+    object."""
+    from types import SimpleNamespace
 
-    # Both modules resolve the helper from commands.refresh_ops.
-    from ovp_pipeline.commands.refresh_ops import (
-        decide_knowledge_refresh as canonical,
-    )
+    import ovp_pipeline.autopilot.daemon as daemon_mod
 
-    src_pipeline = Path(upe.__file__).read_text(encoding="utf-8")
-    src_daemon = Path(daemon.__file__).read_text(encoding="utf-8")
-    assert "from .commands.refresh_ops import decide_knowledge_refresh" in src_pipeline
-    assert "from ..commands.refresh_ops import decide_knowledge_refresh" in src_daemon
-    assert canonical is refresh_ops.decide_knowledge_refresh
+    light = refresh_ops.RefreshDecision("audit_sync_only", "no_canonical_evidence")
+
+    with patch.object(
+        refresh_ops, "decide_knowledge_refresh", return_value=light
+    ) as dec:
+        # pipeline path
+        p = _make_pipeline(temp_vault)
+        result = p.step_knowledge_index(dry_run=False)
+        assert result.skipped is True
+        assert result.refresh_mode == "audit_sync_only"
+
+        # autopilot path
+        fake = SimpleNamespace(
+            vault_dir=temp_vault,
+            pack=SimpleNamespace(name=PACK),
+            log=lambda *_a, **_k: None,
+        )
+        daemon_mod.AutoPilotDaemon._run_knowledge_index_refresh(fake)
+
+    assert dec.call_count == 2  # one pipeline + one autopilot, same patched obj
+    pipeline_kwargs = dec.call_args_list[0].kwargs
+    assert pipeline_kwargs.get("local_change_reason") is None  # no steps ran
+    assert pipeline_kwargs.get("force_full") is False
+    autopilot_kwargs = dec.call_args_list[1].kwargs
+    assert autopilot_kwargs.get("local_change_reason") == "autopilot_processed_article"

--- a/tests/test_pipeline_rebuild_guard.py
+++ b/tests/test_pipeline_rebuild_guard.py
@@ -96,9 +96,7 @@ def _synced(_vault_dir):
 def test_no_canonical_evidence_takes_audit_sync_only(tmp_path):
     v = _vault(tmp_path)
     _emit(v, "candidates_upserted")
-    with patch.object(refresh_ops, "sync_audit_events_from_jsonl", _synced), patch.object(
-        refresh_ops, "rebuild_ops_state", return_value={}
-    ):
+    with patch.object(refresh_ops, "sync_audit_events_from_jsonl", _synced):
         d = decide_knowledge_refresh(v, PACK)
     assert d.refresh_mode == "audit_sync_only"
     assert d.is_full is False
@@ -110,14 +108,43 @@ def test_no_canonical_evidence_takes_audit_sync_only(tmp_path):
 def test_canonical_evidence_forces_full_rebuild(tmp_path):
     v = _vault(tmp_path)
     _emit(v, "evergreen_auto_promoted", payload={"pack": PACK})
-    with patch.object(refresh_ops, "sync_audit_events_from_jsonl", _synced), patch.object(
-        refresh_ops, "rebuild_ops_state", return_value={}
-    ):
+    with patch.object(refresh_ops, "sync_audit_events_from_jsonl", _synced):
         d = decide_knowledge_refresh(v, PACK)
     assert d.refresh_mode == "full_rebuild"
     assert d.is_full is True
     assert d.reason == "canonical_object_evidence"
     assert d.canonical_evidence_count == 1
+
+
+# P1 ───────────────────────────────────────────────────────────────
+def test_local_change_reason_forces_full_and_short_circuits(tmp_path):
+    """Review P1: an indexed-markdown change this run (e.g. a new
+    20-Areas interpretation) must force full rebuild even with NO
+    canonical-object audit evidence — and short-circuit before any
+    audit-sync work."""
+    v = _vault(tmp_path)
+    _emit(v, "candidates_upserted")  # NOT a canonical-object event
+    with patch.object(refresh_ops, "sync_audit_events_from_jsonl") as sync_mock:
+        d = decide_knowledge_refresh(
+            v, PACK, local_change_reason="articles_produced_indexed_markdown"
+        )
+    assert d.refresh_mode == "full_rebuild"
+    assert d.reason == "articles_produced_indexed_markdown"
+    sync_mock.assert_not_called()
+
+
+# P2 ───────────────────────────────────────────────────────────────
+def test_decide_does_not_rebuild_ops_state(tmp_path):
+    """Review P2: the dedicated ops_state DAG stage owns that
+    rebuild — decide_knowledge_refresh must NOT also run it."""
+    v = _vault(tmp_path)
+    _emit(v, "candidates_upserted")
+    with patch.object(
+        refresh_ops, "sync_audit_events_from_jsonl", _synced
+    ), patch.object(refresh_ops, "rebuild_ops_state") as ops_mock:
+        d = decide_knowledge_refresh(v, PACK)
+    assert d.refresh_mode == "audit_sync_only"
+    ops_mock.assert_not_called()
 
 
 # 3 ────────────────────────────────────────────────────────────────
@@ -172,6 +199,82 @@ def test_force_full_index_short_circuits(tmp_path):
     assert d.refresh_mode == "full_rebuild"
     assert d.reason == "force_full_index"
     sync_mock.assert_not_called()
+
+
+# P1 pipeline evidence detector ────────────────────────────────────
+def _make_pipeline(vault_dir):
+    from ovp_pipeline.auto_moc_updater import PipelineLogger
+    from ovp_pipeline.unified_pipeline_enhanced import (
+        EnhancedPipeline,
+        TransactionManager,
+    )
+
+    logger = PipelineLogger(vault_dir / "60-Logs" / "pipeline.jsonl")
+    txn_dir = vault_dir / "60-Logs" / "transactions"
+    txn_dir.mkdir(parents=True, exist_ok=True)
+    return EnhancedPipeline(vault_dir, logger, TransactionManager(txn_dir))
+
+
+def test_local_indexed_change_reason_detects_each_surface(temp_vault):
+    from ovp_pipeline.step_contracts import (
+        AbsorbStepResult,
+        ArticlesStepResult,
+        EntityExtractStepResult,
+        MocStepResult,
+        NoteTypeNormalizeStepResult,
+    )
+
+    p = _make_pipeline(temp_vault)
+    assert p._local_indexed_change_reason() is None  # nothing ran
+
+    p.step_results = {
+        "articles": ArticlesStepResult(success=True, produced_files=["a.md"])
+    }
+    assert p._local_indexed_change_reason() == "articles_produced_indexed_markdown"
+
+    p.step_results = {
+        "note_type_normalize": NoteTypeNormalizeStepResult(
+            success=True, note_type_changed=2
+        )
+    }
+    assert p._local_indexed_change_reason() == "note_type_frontmatter_changed"
+
+    p.step_results = {"moc": MocStepResult(success=True, updated=True)}
+    assert p._local_indexed_change_reason() == "moc_atlas_changed"
+
+    p.step_results = {
+        "absorb": AbsorbStepResult(success=True, promoted_slugs=["x"])
+    }
+    assert p._local_indexed_change_reason() == "absorb_promoted_canonical_object"
+
+    p.step_results = {
+        "entity_extract": EntityExtractStepResult(
+            success=True, mentions_extracted=3
+        )
+    }
+    assert p._local_indexed_change_reason() == "entity_surface_changed"
+
+
+def test_local_indexed_change_reason_none_when_no_indexed_change(temp_vault):
+    from ovp_pipeline.step_contracts import AbsorbStepResult, MocStepResult
+
+    p = _make_pipeline(temp_vault)
+    # absorb ran but promoted nothing; moc ran but changed nothing →
+    # defer to the canonical-audit detector (return None).
+    p.step_results = {
+        "absorb": AbsorbStepResult(success=True, promoted_slugs=[]),
+        "moc": MocStepResult(success=True, updated=False, changed_files=[]),
+    }
+    assert p._local_indexed_change_reason() is None
+
+
+def test_autopilot_passes_processed_article_reason():
+    """Autopilot's _run_knowledge_index_refresh only runs after an
+    article passed quality — it must always declare local change."""
+    import ovp_pipeline.autopilot.daemon as daemon
+
+    src = Path(daemon.__file__).read_text(encoding="utf-8")
+    assert 'local_change_reason="autopilot_processed_article"' in src
 
 
 # 5 ────────────────────────────────────────────────────────────────

--- a/tests/test_pipeline_rebuild_guard.py
+++ b/tests/test_pipeline_rebuild_guard.py
@@ -1,0 +1,193 @@
+"""PR4 — pipeline / autopilot knowledge_index full-rebuild guard.
+
+The default pipeline + autopilot no longer unconditionally run the
+heavy ``rebuild_knowledge_index``.  ``decide_knowledge_refresh`` runs
+the lightweight audit-sync + ops_state rebuild and only escalates to
+a full rebuild on canonical-object evidence or an unknown /
+untrustworthy state.  Conservative by design: *unknown ⇒ full*.
+
+Locks the operator-defined rule (5 required cases):
+1. no canonical evidence            → audit_sync_only, no full rebuild
+2. promote/object/relation evidence → full_rebuild
+3. audit sync error                 → full_rebuild (never silent skip)
+4. db / metadata / schema / force   → full_rebuild
+5. pipeline AND autopilot use the same decision
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+from ovp_pipeline.commands import refresh_ops
+from ovp_pipeline.commands.refresh_ops import decide_knowledge_refresh
+from ovp_pipeline.knowledge_index import (
+    KNOWLEDGE_DB_PROJECTION_KIND,
+    KNOWLEDGE_DB_PROJECTION_SCHEMA_VERSION,
+)
+
+PACK = "research-tech"
+
+_SCHEMA = """
+CREATE TABLE audit_events (
+    source_log TEXT NOT NULL, event_type TEXT NOT NULL,
+    slug TEXT NOT NULL DEFAULT '', session_id TEXT NOT NULL DEFAULT '',
+    timestamp TEXT NOT NULL DEFAULT '', payload_json TEXT NOT NULL
+);
+CREATE TABLE truth_projections (
+    pack TEXT NOT NULL, owner_pack TEXT NOT NULL DEFAULT '',
+    builder_name TEXT NOT NULL DEFAULT '', built_at TEXT NOT NULL
+);
+CREATE TABLE projection_metadata (
+    projection_kind TEXT PRIMARY KEY,
+    authority_schema_version INTEGER NOT NULL,
+    projection_schema_version INTEGER NOT NULL,
+    built_at TEXT NOT NULL
+);
+CREATE TABLE ops_state (
+    pack TEXT NOT NULL, item_kind TEXT NOT NULL, item_id TEXT NOT NULL,
+    state TEXT NOT NULL, sub_state TEXT, last_evidence_at TEXT,
+    evidence_event_types_json TEXT NOT NULL DEFAULT '[]',
+    needs_action_reason TEXT, refreshed_at TEXT NOT NULL,
+    PRIMARY KEY (pack, item_kind, item_id)
+);
+"""
+
+
+def _vault(tmp_path: Path, *, healthy: bool = True) -> Path:
+    db = tmp_path / "60-Logs" / "knowledge.db"
+    db.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db)
+    conn.executescript(_SCHEMA)
+    if healthy:
+        conn.execute(
+            "INSERT INTO projection_metadata VALUES (?, 1, ?, ?)",
+            (
+                KNOWLEDGE_DB_PROJECTION_KIND,
+                KNOWLEDGE_DB_PROJECTION_SCHEMA_VERSION,
+                "2026-05-17T00:00:00Z",
+            ),
+        )
+    conn.commit()
+    conn.close()
+    return tmp_path
+
+
+def _emit(vault: Path, et: str, *, ts: str | None = None, payload=None) -> None:
+    if ts is None:
+        ts = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+    db = vault / "60-Logs" / "knowledge.db"
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "INSERT INTO audit_events VALUES (?,?,?,?,?,?)",
+            ("pipeline.jsonl", et, "", "s", ts, json.dumps(payload or {})),
+        )
+        conn.commit()
+
+
+def _synced(_vault_dir):
+    return {"status": "synced"}
+
+
+# 1 ────────────────────────────────────────────────────────────────
+def test_no_canonical_evidence_takes_audit_sync_only(tmp_path):
+    v = _vault(tmp_path)
+    _emit(v, "candidates_upserted")
+    with patch.object(refresh_ops, "sync_audit_events_from_jsonl", _synced), patch.object(
+        refresh_ops, "rebuild_ops_state", return_value={}
+    ):
+        d = decide_knowledge_refresh(v, PACK)
+    assert d.refresh_mode == "audit_sync_only"
+    assert d.is_full is False
+    assert d.reason == "no_canonical_evidence"
+    assert d.canonical_evidence_count == 0
+
+
+# 2 ────────────────────────────────────────────────────────────────
+def test_canonical_evidence_forces_full_rebuild(tmp_path):
+    v = _vault(tmp_path)
+    _emit(v, "evergreen_auto_promoted", payload={"pack": PACK})
+    with patch.object(refresh_ops, "sync_audit_events_from_jsonl", _synced), patch.object(
+        refresh_ops, "rebuild_ops_state", return_value={}
+    ):
+        d = decide_knowledge_refresh(v, PACK)
+    assert d.refresh_mode == "full_rebuild"
+    assert d.is_full is True
+    assert d.reason == "canonical_object_evidence"
+    assert d.canonical_evidence_count == 1
+
+
+# 3 ────────────────────────────────────────────────────────────────
+def test_audit_sync_failure_forces_full_rebuild(tmp_path):
+    v = _vault(tmp_path)
+    with patch.object(
+        refresh_ops,
+        "sync_audit_events_from_jsonl",
+        lambda _v: {"status": "stale", "reason": "jsonl ahead"},
+    ):
+        d = decide_knowledge_refresh(v, PACK)
+    assert d.refresh_mode == "full_rebuild"
+    assert d.reason == "audit_sync_stale"
+    assert d.audit_sync_status == "stale"
+
+
+# 4 ────────────────────────────────────────────────────────────────
+def test_missing_db_forces_full_rebuild(tmp_path):
+    d = decide_knowledge_refresh(tmp_path, PACK)
+    assert d.refresh_mode == "full_rebuild"
+    assert d.reason == "knowledge_db_missing"
+
+
+def test_missing_projection_metadata_forces_full_rebuild(tmp_path):
+    v = _vault(tmp_path, healthy=False)  # no projection_metadata row
+    d = decide_knowledge_refresh(v, PACK)
+    assert d.refresh_mode == "full_rebuild"
+    assert d.reason == "projection_metadata_missing"
+
+
+def test_schema_mismatch_forces_full_rebuild(tmp_path):
+    v = _vault(tmp_path, healthy=False)
+    db = v / "60-Logs" / "knowledge.db"
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "INSERT INTO projection_metadata VALUES (?, 1, ?, ?)",
+            (KNOWLEDGE_DB_PROJECTION_KIND, 1, "2026-05-17T00:00:00Z"),
+        )
+        conn.commit()
+    d = decide_knowledge_refresh(v, PACK)
+    assert d.refresh_mode == "full_rebuild"
+    assert d.reason.startswith("projection_schema_mismatch")
+
+
+def test_force_full_index_short_circuits(tmp_path):
+    v = _vault(tmp_path)
+    # force_full must NOT even run the lightweight work
+    with patch.object(
+        refresh_ops, "sync_audit_events_from_jsonl"
+    ) as sync_mock:
+        d = decide_knowledge_refresh(v, PACK, force_full=True)
+    assert d.refresh_mode == "full_rebuild"
+    assert d.reason == "force_full_index"
+    sync_mock.assert_not_called()
+
+
+# 5 ────────────────────────────────────────────────────────────────
+def test_pipeline_and_autopilot_share_one_decision(tmp_path):
+    """Both call sites import the SAME decide_knowledge_refresh —
+    asserting identity prevents a future pipeline/autopilot fork."""
+    from ovp_pipeline import unified_pipeline_enhanced as upe  # noqa: F401
+    import ovp_pipeline.autopilot.daemon as daemon  # noqa: F401
+
+    # Both modules resolve the helper from commands.refresh_ops.
+    from ovp_pipeline.commands.refresh_ops import (
+        decide_knowledge_refresh as canonical,
+    )
+
+    src_pipeline = Path(upe.__file__).read_text(encoding="utf-8")
+    src_daemon = Path(daemon.__file__).read_text(encoding="utf-8")
+    assert "from .commands.refresh_ops import decide_knowledge_refresh" in src_pipeline
+    assert "from ..commands.refresh_ops import decide_knowledge_refresh" in src_daemon
+    assert canonical is refresh_ops.decide_knowledge_refresh

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -672,7 +672,16 @@ def test_step_knowledge_index_invokes_rebuild_command(tmp_path, monkeypatch):
 
     monkeypatch.setattr(pipeline, "run_command", fake_run_command)
 
-    result = pipeline.step_knowledge_index(dry_run=True)
+    # dry-run must NOT trigger the heavy rebuild (gemini review):
+    # returns a skipped result, invokes no command.
+    dry = pipeline.step_knowledge_index(dry_run=True)
+    assert dry["success"] is True
+    assert dry["skipped"] is True
+    assert invocations == []
+
+    # Real run, no knowledge.db → decision = full_rebuild
+    # (knowledge_db_missing) → the rebuild command runs, well-formed.
+    result = pipeline.step_knowledge_index(dry_run=False)
 
     assert result["success"] is True
     rebuild = next(


### PR DESCRIPTION
fix(pipeline): guard the post-absorb knowledge-index full rebuild (PR4)

step_knowledge_index (ovp --full) AND autopilot
_run_knowledge_index_refresh unconditionally ran the heavy
rebuild_knowledge_index (~482MB RSS / 20+ min on the operator
vault) even when absorb produced only candidates and the full
rebuild re-derives nothing. The codified lightweight rule already
existed in ovp-refresh-ops but the DAG/daemon never consulted it.

Shared decision (no pipeline/autopilot fork):

  commands.refresh_ops.decide_knowledge_refresh(vault, pack,
      *, force_full=False, canonical_window_minutes=180)
  -> RefreshDecision(refresh_mode, reason,
       canonical_evidence_count, canonical_evidence,
       watermark, audit_sync_status)

Reuses the existing, validated detectors verbatim
(_CANONICAL_OBJECT_EVENTS / _canonical_evidence_since /
_last_rebuild_watermark, the BL-107 #250 watermark) — NOT a
rewrite. Conservative escalation, *unknown => full rebuild*:

  1. force_full (operator --force-full-index)   -> full
  2. knowledge.db missing                        -> full
  3. projection_metadata missing / schema bump   -> full
  4. audit-sync != "synced"                      -> full
  5. canonical-object evidence present           -> full
  6. otherwise                                   -> audit_sync_only

For 5/6 the lightweight audit-sync + ops_state rebuild runs INSIDE
the decision (caller never double-runs it). For 1-4 it
short-circuits before doing any lightweight work and the caller
runs the full rebuild (which does its own audit load). The
audit_sync_only path skips rebuild_knowledge_index entirely.

Observability: step_knowledge_index emits a
knowledge_index_refresh_decision event to pipeline.jsonl
(-> audit_events, visible on /ops) with refresh_mode + reason +
canonical_evidence + watermark; the autopilot logs the same.
KnowledgeIndexStepResult gains refresh_mode /
canonical_evidence_count / rebuild_watermark (reason is on the
base contract). dry-run keeps the prior behaviour.

CLI: ovp --force-full-index escape hatch, threaded to
EnhancedPipeline.force_full_index.

Tests (the 5 operator-required cases): no canonical evidence ->
audit_sync_only, no full rebuild; promote evidence -> full;
audit-sync failure -> full (never silent skip); db/metadata/schema
missing + force_full -> full (force short-circuits before any
lightweight work); pipeline and autopilot resolve the SAME helper
(source-level no-fork assertion). Full suite 3066 passed / 0
failed; zero new ruff/mypy (3 pre-existing F401 unrelated).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--force-full-index` command-line option allowing operators to force a complete knowledge index rebuild when necessary.

* **Performance Improvements**
  * System now intelligently determines when a lightweight index refresh is sufficient and skips unnecessary full rebuilds, reducing operation time for routine updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fakechris/obsidian_vault_pipeline/pull/273?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->