### PR TITLE
fix(pipeline): absorb stage-cache must not short-circuit the BL-029 intake fallback

### DIFF
--- a/src/ovp_pipeline/unified_pipeline_enhanced.py
+++ b/src/ovp_pipeline/unified_pipeline_enhanced.py
@@ -589,9 +589,10 @@ class EnhancedPipeline:
         if STAGE_CACHE_POLICIES.get(stage, STAGE_CACHE_DISABLED) != STAGE_CACHE_CHECKOUT:
             return None
         context = self._build_stage_artifact_context(stage, results=results)
-        if stage == "absorb" and int(
-            context.get("inputs", {}).get("qualified_file_count", 0)
-        ) == 0:
+        if (
+            stage == "absorb"
+            and context.get("inputs", {}).get("qualified_file_count", 0) == 0
+        ):
             # BL-029 cache-correctness: post-BL-029 `articles` is
             # intake-only and the pipeline quality stage qualifies
             # nothing (qualified_files == []), so absorb's REAL input

--- a/src/ovp_pipeline/unified_pipeline_enhanced.py
+++ b/src/ovp_pipeline/unified_pipeline_enhanced.py
@@ -589,6 +589,27 @@ class EnhancedPipeline:
         if STAGE_CACHE_POLICIES.get(stage, STAGE_CACHE_DISABLED) != STAGE_CACHE_CHECKOUT:
             return None
         context = self._build_stage_artifact_context(stage, results=results)
+        if stage == "absorb" and int(
+            context.get("inputs", {}).get("qualified_file_count", 0)
+        ) == 0:
+            # BL-029 cache-correctness: post-BL-029 `articles` is
+            # intake-only and the pipeline quality stage qualifies
+            # nothing (qualified_files == []), so absorb's REAL input
+            # is the time-windowed 50-Inbox/03-Processed probe inside
+            # step_absorb()'s BL-029 fallback — which this
+            # quality-derived fingerprint cannot represent (it is the
+            # SAME constant for every empty-qualified run).  A
+            # stage-level checkout here short-circuits absorb forever
+            # and strands every new intake in Received.  Skip the
+            # checkout and let step_absorb() decide; absorb v2's
+            # per-item ledger cache keeps a genuinely-no-new-intake
+            # run cheap, so this is not a perf regression.
+            print(
+                "  ↳ absorb stage-cache checkout skipped "
+                "(quality qualified 0 — delegating to step_absorb "
+                "BL-029 03-Processed intake fallback)"
+            )
+            return None
         manifest = self._stage_artifact_store().load(
             stage,
             context["fingerprint"],
@@ -1521,9 +1542,16 @@ class EnhancedPipeline:
         return _to_typed_step_result("clippings", result)
 
     def step_articles(self, batch_size: int | None = None, dry_run: bool = False) -> "ArticlesStepResult":
-        """执行文章深度解读步骤"""
+        """Article INTAKE staging (post-BL-029).
+
+        The legacy 13-section LLM deep-dive generation is gone: this
+        step now only stages raw sources into 50-Inbox/03-Processed
+        for absorb v2.  ``Produced 0`` here means "no NEW sources to
+        stage", NOT "nothing happened" — evergreen/candidate creation
+        is absorb's job, not this step's.
+        """
         print("\n" + "="*60)
-        print("STEP 4: Generating Article Interpretations")
+        print("STEP 4: Article Intake (staging sources for absorb)")
         print("="*60)
 
         cmd = [

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -481,6 +481,33 @@ def test_run_pipeline_checkouts_cacheable_stage_artifact_without_dispatching_han
     assert "Cache hit" in step["output"]
 
 
+def _absorb_cache_pipeline(tmp_path):
+    """Shared setup for the absorb stage-cache regression tests:
+    a fresh EnhancedPipeline rooted at an empty temp vault."""
+    from ovp_pipeline.unified_pipeline_enhanced import PipelineLogger, TransactionManager
+    import ovp_pipeline.unified_pipeline_enhanced as pipeline_source
+
+    vault = tmp_path / "vault"
+    (vault / "60-Logs").mkdir(parents=True)
+    logger = PipelineLogger(vault / "60-Logs" / "pipeline.jsonl")
+    txn = TransactionManager(vault / "60-Logs" / "transactions")
+    return vault, pipeline_source.EnhancedPipeline(vault, logger, txn)
+
+
+def _write_absorb_manifest(pipeline, ctx, *, run_id):
+    pipeline._stage_artifact_store().write_completed(
+        stage="absorb",
+        fingerprint=ctx["fingerprint"],
+        input_digest=ctx["input_digest"],
+        algorithm_digest=ctx["algorithm_digest"],
+        run_id=run_id,
+        pack_name=pipeline.workflow_pack_name,
+        workflow_profile=pipeline.workflow_profile_name,
+        inputs=ctx["inputs"],
+        outputs=ctx["outputs"],
+    )
+
+
 def test_absorb_checkout_skipped_when_quality_qualified_zero(tmp_path):
     """BL-029 cache-correctness regression: post-BL-029 `articles` is
     intake-only and quality qualifies nothing, so absorb's stage
@@ -489,14 +516,7 @@ def test_absorb_checkout_skipped_when_quality_qualified_zero(tmp_path):
     in Received.  When qualified_file_count == 0 the checkout must be
     SKIPPED (return None) so step_absorb()'s 03-Processed fallback
     runs — even if a matching absorb manifest exists on disk."""
-    from ovp_pipeline.unified_pipeline_enhanced import PipelineLogger, TransactionManager
-    import ovp_pipeline.unified_pipeline_enhanced as pipeline_source
-
-    vault = tmp_path / "vault"
-    (vault / "60-Logs").mkdir(parents=True)
-    logger = PipelineLogger(vault / "60-Logs" / "pipeline.jsonl")
-    txn = TransactionManager(vault / "60-Logs" / "transactions")
-    pipeline = pipeline_source.EnhancedPipeline(vault, logger, txn)
+    _vault, pipeline = _absorb_cache_pipeline(tmp_path)
 
     # No quality artifact / no results → qualified_files == [] →
     # qualified_file_count == 0.
@@ -505,17 +525,7 @@ def test_absorb_checkout_skipped_when_quality_qualified_zero(tmp_path):
 
     # Even with a matching manifest written at that fingerprint, the
     # checkout must refuse to short-circuit absorb.
-    pipeline._stage_artifact_store().write_completed(
-        stage="absorb",
-        fingerprint=ctx["fingerprint"],
-        input_digest=ctx["input_digest"],
-        algorithm_digest=ctx["algorithm_digest"],
-        run_id="stale-empty-qualified-run",
-        pack_name=pipeline.workflow_pack_name,
-        workflow_profile=pipeline.workflow_profile_name,
-        inputs=ctx["inputs"],
-        outputs=ctx["outputs"],
-    )
+    _write_absorb_manifest(pipeline, ctx, run_id="stale-empty-qualified-run")
 
     assert pipeline._checkout_stage_artifact("absorb") is None
 
@@ -524,18 +534,10 @@ def test_absorb_checkout_honored_when_quality_qualified_nonzero(tmp_path):
     """Positive control: the fix only disables the empty-qualified
     case — when quality genuinely qualified files, the absorb
     stage-cache checkout still works."""
-    from ovp_pipeline.unified_pipeline_enhanced import PipelineLogger, TransactionManager
-    import ovp_pipeline.unified_pipeline_enhanced as pipeline_source
-
-    vault = tmp_path / "vault"
-    (vault / "60-Logs").mkdir(parents=True)
+    vault, pipeline = _absorb_cache_pipeline(tmp_path)
     qualified = vault / "20-Areas" / "Tools" / "Topics" / QUALITY_TEST_MONTH / "q_深度解读.md"
     qualified.parent.mkdir(parents=True, exist_ok=True)
     qualified.write_text("# q\n", encoding="utf-8")
-
-    logger = PipelineLogger(vault / "60-Logs" / "pipeline.jsonl")
-    txn = TransactionManager(vault / "60-Logs" / "transactions")
-    pipeline = pipeline_source.EnhancedPipeline(vault, logger, txn)
 
     results = {
         "quality": {
@@ -546,17 +548,7 @@ def test_absorb_checkout_honored_when_quality_qualified_nonzero(tmp_path):
     ctx = pipeline._build_stage_artifact_context("absorb", results=results)
     assert ctx["inputs"]["qualified_file_count"] == 1
 
-    pipeline._stage_artifact_store().write_completed(
-        stage="absorb",
-        fingerprint=ctx["fingerprint"],
-        input_digest=ctx["input_digest"],
-        algorithm_digest=ctx["algorithm_digest"],
-        run_id="prev",
-        pack_name=pipeline.workflow_pack_name,
-        workflow_profile=pipeline.workflow_profile_name,
-        inputs=ctx["inputs"],
-        outputs=ctx["outputs"],
-    )
+    _write_absorb_manifest(pipeline, ctx, run_id="prev")
 
     checked_out = pipeline._checkout_stage_artifact("absorb", results=results)
     assert checked_out is not None

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -481,6 +481,89 @@ def test_run_pipeline_checkouts_cacheable_stage_artifact_without_dispatching_han
     assert "Cache hit" in step["output"]
 
 
+def test_absorb_checkout_skipped_when_quality_qualified_zero(tmp_path):
+    """BL-029 cache-correctness regression: post-BL-029 `articles` is
+    intake-only and quality qualifies nothing, so absorb's stage
+    fingerprint is the SAME constant every run.  A stage-level
+    checkout there short-circuits absorb forever and strands intake
+    in Received.  When qualified_file_count == 0 the checkout must be
+    SKIPPED (return None) so step_absorb()'s 03-Processed fallback
+    runs — even if a matching absorb manifest exists on disk."""
+    from ovp_pipeline.unified_pipeline_enhanced import PipelineLogger, TransactionManager
+    import ovp_pipeline.unified_pipeline_enhanced as pipeline_source
+
+    vault = tmp_path / "vault"
+    (vault / "60-Logs").mkdir(parents=True)
+    logger = PipelineLogger(vault / "60-Logs" / "pipeline.jsonl")
+    txn = TransactionManager(vault / "60-Logs" / "transactions")
+    pipeline = pipeline_source.EnhancedPipeline(vault, logger, txn)
+
+    # No quality artifact / no results → qualified_files == [] →
+    # qualified_file_count == 0.
+    ctx = pipeline._build_stage_artifact_context("absorb")
+    assert ctx["inputs"]["qualified_file_count"] == 0
+
+    # Even with a matching manifest written at that fingerprint, the
+    # checkout must refuse to short-circuit absorb.
+    pipeline._stage_artifact_store().write_completed(
+        stage="absorb",
+        fingerprint=ctx["fingerprint"],
+        input_digest=ctx["input_digest"],
+        algorithm_digest=ctx["algorithm_digest"],
+        run_id="stale-empty-qualified-run",
+        pack_name=pipeline.workflow_pack_name,
+        workflow_profile=pipeline.workflow_profile_name,
+        inputs=ctx["inputs"],
+        outputs=ctx["outputs"],
+    )
+
+    assert pipeline._checkout_stage_artifact("absorb") is None
+
+
+def test_absorb_checkout_honored_when_quality_qualified_nonzero(tmp_path):
+    """Positive control: the fix only disables the empty-qualified
+    case — when quality genuinely qualified files, the absorb
+    stage-cache checkout still works."""
+    from ovp_pipeline.unified_pipeline_enhanced import PipelineLogger, TransactionManager
+    import ovp_pipeline.unified_pipeline_enhanced as pipeline_source
+
+    vault = tmp_path / "vault"
+    (vault / "60-Logs").mkdir(parents=True)
+    qualified = vault / "20-Areas" / "Tools" / "Topics" / QUALITY_TEST_MONTH / "q_深度解读.md"
+    qualified.parent.mkdir(parents=True, exist_ok=True)
+    qualified.write_text("# q\n", encoding="utf-8")
+
+    logger = PipelineLogger(vault / "60-Logs" / "pipeline.jsonl")
+    txn = TransactionManager(vault / "60-Logs" / "transactions")
+    pipeline = pipeline_source.EnhancedPipeline(vault, logger, txn)
+
+    results = {
+        "quality": {
+            "quality_stage_fingerprint": "qfp-test",
+            "quality_qualified_files": [str(qualified)],
+        }
+    }
+    ctx = pipeline._build_stage_artifact_context("absorb", results=results)
+    assert ctx["inputs"]["qualified_file_count"] == 1
+
+    pipeline._stage_artifact_store().write_completed(
+        stage="absorb",
+        fingerprint=ctx["fingerprint"],
+        input_digest=ctx["input_digest"],
+        algorithm_digest=ctx["algorithm_digest"],
+        run_id="prev",
+        pack_name=pipeline.workflow_pack_name,
+        workflow_profile=pipeline.workflow_profile_name,
+        inputs=ctx["inputs"],
+        outputs=ctx["outputs"],
+    )
+
+    checked_out = pipeline._checkout_stage_artifact("absorb", results=results)
+    assert checked_out is not None
+    assert checked_out["cache_hit"] is True
+    assert checked_out["stage_fingerprint"] == ctx["fingerprint"]
+
+
 def test_run_pipeline_does_not_skip_record_only_source_stage(tmp_path, monkeypatch):
     import ovp_pipeline.unified_pipeline_enhanced as pipeline_source
     from ovp_pipeline.unified_pipeline_enhanced import PipelineLogger, TransactionManager


### PR DESCRIPTION
fix(pipeline): absorb stage-cache must not short-circuit the BL-029 intake fallback

Operator-observed: lifecycle frozen — new 5/17+ sources stay in
Received, nothing advances, every incremental run logs
`Cache hit: absorb b2bad07e8a09`. Not a hung run and not a stale
index: absorb is short-circuited by its stage-level cache before
`step_absorb()` ever runs.

Root cause:

- Post-BL-029, `articles` is intake-only (auto_article_processor
  no longer generates 20-Areas deep-dives), so the pipeline
  quality stage qualifies nothing → `qualified_files == []`.
- `_stage_input_files("absorb")` / `_build_stage_artifact_context`
  derive absorb's fingerprint ONLY from
  `(quality_stage_fingerprint, qualified_files)`. With
  qualified_files empty that digest is the SAME constant every
  run (`b2bad07e8a09`).
- `_checkout_stage_artifact("absorb")` runs in `run_pipeline`
  BEFORE `step_absorb()`. It hits the constant-fingerprint
  manifest and returns a cache-hit, so `step_absorb()`'s BL-029
  fallback — which probes the time-windowed
  `50-Inbox/03-Processed` intake sources — never executes.
  Result: intake is stranded in Received indefinitely.

Fix (minimal, conservative — the "forbid checkout when quality
qualified 0" option, not a hand-rolled intake-target hash):

- In `_checkout_stage_artifact`, when stage == "absorb" and the
  context's `qualified_file_count == 0`, skip the stage-level
  checkout (return None) and log why. `step_absorb()` then runs
  and its BL-029 03-Processed fallback decides. absorb v2's
  per-item ledger cache keeps a genuinely-no-new-intake run
  cheap, so this is not a perf regression. A hashed intake-target
  key was rejected: the fallback window is time-relative
  (`now - recent_days`), so it could not stably cache anyway and
  would duplicate the discovery logic.
- Stage checkout is unchanged whenever quality genuinely
  qualified files (qualified_file_count > 0) — positive-control
  tested.
- Clarify `step_articles` copy: header is now "Article Intake
  (staging sources for absorb)" and the docstring states
  `Produced 0` means "no NEW sources to stage", not "nothing
  happened" (post-BL-029 it is intake staging, not deep-dive
  generation). This is what made the operator read the dashboard
  as "stuck".

Behaviour-preserving for the qualified>0 path; the empty-qualified
path now correctly delegates to step_absorb instead of skipping it
forever. Full suite 3073 passed / 0 failed; zero new ruff/mypy
(legacy file's pre-existing 98 mypy / 1 F401 unchanged).

Tests: absorb checkout SKIPPED when qualified_file_count == 0 even
with a matching manifest on disk; absorb checkout HONORED when
qualified_file_count > 0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved absorb stage behavior when no qualified files are detected by triggering fallback intake logic instead of using an empty cache artifact.
  * Clarified articles stage messaging to indicate "Produced 0" reflects no new sources staged.

* **Tests**
  * Added regression tests to verify absorb stage cache behavior with zero and nonzero qualified files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fakechris/obsidian_vault_pipeline/pull/274?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->