### PR TITLE
perf(ops/today): mtime-keyed payload cache for fast day-switching

### DIFF
--- a/src/ovp_pipeline/ui/view_models/_layer3.py
+++ b/src/ovp_pipeline/ui/view_models/_layer3.py
@@ -24,6 +24,22 @@ _TODAY_PAYLOAD_CACHE: "_OrderedDict[tuple, dict]" = _OrderedDict()
 _TODAY_PAYLOAD_CACHE_MAX = 48
 
 
+def _resolve_today_date_key(target_date: str | None) -> str:
+    """The /ops/today date bucket.
+
+    BL-102 consistency: Activity buckets by operator-LOCAL day, so
+    the default "today" must be the local day too — a UTC default is
+    off-by-one near midnight for every operator and made now()-seeded
+    tests wall-clock flaky.  Single source of truth so the cache
+    wrapper and the real builder cannot disagree on the key.
+    """
+    if target_date:
+        return target_date.strip()
+    from datetime import datetime
+
+    return datetime.now().astimezone().strftime("%Y-%m-%d")
+
+
 def build_today_digest_payload(
     vault_dir: Path | str,
     *,
@@ -37,8 +53,6 @@ def build_today_digest_payload(
     invalidates every cached date for that vault — repeated
     day-switching between rebuilds is O(1), correctness is unchanged.
     """
-    from datetime import datetime
-
     try:
         db_path = _db_path(vault_dir)
         if not db_path.exists():
@@ -46,10 +60,7 @@ def build_today_digest_payload(
             return _build_today_digest_payload_uncached(
                 vault_dir, pack_name=pack_name, target_date=target_date
             )
-        if target_date:
-            date_key = target_date.strip()
-        else:
-            date_key = datetime.now().astimezone().strftime("%Y-%m-%d")
+        date_key = _resolve_today_date_key(target_date)
         effective_pack = (pack_name or "") or PRIMARY_PACK_NAME
         mtime_ns = db_path.stat().st_mtime_ns
         key = (str(db_path), mtime_ns, date_key, effective_pack)
@@ -67,10 +78,14 @@ def build_today_digest_payload(
     payload = _build_today_digest_payload_uncached(
         vault_dir, pack_name=pack_name, target_date=target_date
     )
-    _TODAY_PAYLOAD_CACHE[key] = payload
+    # Store an isolated deep copy so the cached entry can never be
+    # mutated through any reference to the freshly-built payload
+    # (gemini review); return the fresh build to the caller, so the
+    # cold path does exactly one deepcopy, not two.
+    _TODAY_PAYLOAD_CACHE[key] = _copy.deepcopy(payload)
     while len(_TODAY_PAYLOAD_CACHE) > _TODAY_PAYLOAD_CACHE_MAX:
         _TODAY_PAYLOAD_CACHE.popitem(last=False)
-    return _copy.deepcopy(payload)
+    return payload
 
 
 def _build_today_digest_payload_uncached(
@@ -105,17 +120,8 @@ def _build_today_digest_payload_uncached(
     SECONDARY number only; the primary number is "right now", not
     historic.
     """
-    from datetime import datetime
-
     requested_pack = pack_name or ""
-    if target_date:
-        date_key = target_date.strip()
-    else:
-        # BL-102 consistency: Activity buckets by operator-LOCAL
-        # day, so the default "today" must be the local day too —
-        # a UTC default is off-by-one near midnight for every
-        # operator and made now()-seeded tests wall-clock flaky.
-        date_key = datetime.now().astimezone().strftime("%Y-%m-%d")
+    date_key = _resolve_today_date_key(target_date)
 
     db_path = _db_path(vault_dir)
     if not db_path.exists():

--- a/src/ovp_pipeline/ui/view_models/_layer3.py
+++ b/src/ovp_pipeline/ui/view_models/_layer3.py
@@ -2,15 +2,78 @@
 # ruff: noqa: F401, F403, F405  # deliberate package re-export shim (BL-110).
 from __future__ import annotations
 
+import copy as _copy
+from collections import OrderedDict as _OrderedDict
+
 from ._constants import *
 from ._layer0 import *
 from ._layer1 import *
 from ._layer2 import *
 
 
+# /ops/today day-switch performance: build_today_digest_payload runs
+# 6 heavy builders (each its own sqlite connect on a ~350MB db) with
+# no caching, so flipping back and forth between dates re-pays the
+# full cost every click.  The payload is a pure projection of
+# knowledge.db, so an atomic db rebuild (knowledge_index) or any
+# ops_state write changes the file's mtime — keying the cache on
+# (db_path, db_mtime_ns, date, pack) means a real data change busts
+# it (no staleness, the very failure mode this whole effort fought)
+# while repeated day navigation between rebuilds is served instantly.
+_TODAY_PAYLOAD_CACHE: "_OrderedDict[tuple, dict]" = _OrderedDict()
+_TODAY_PAYLOAD_CACHE_MAX = 48
 
 
 def build_today_digest_payload(
+    vault_dir: Path | str,
+    *,
+    pack_name: str | None = None,
+    target_date: str | None = None,
+) -> dict[str, Any]:
+    """mtime-keyed cache wrapper around the real builder.
+
+    The cache key embeds ``knowledge.db``'s ``st_mtime_ns``, so any
+    projection rebuild (atomic replace) or ops_state write
+    invalidates every cached date for that vault — repeated
+    day-switching between rebuilds is O(1), correctness is unchanged.
+    """
+    from datetime import datetime
+
+    try:
+        db_path = _db_path(vault_dir)
+        if not db_path.exists():
+            # Cheap "not built" path — nothing to cache.
+            return _build_today_digest_payload_uncached(
+                vault_dir, pack_name=pack_name, target_date=target_date
+            )
+        if target_date:
+            date_key = target_date.strip()
+        else:
+            date_key = datetime.now().astimezone().strftime("%Y-%m-%d")
+        effective_pack = (pack_name or "") or PRIMARY_PACK_NAME
+        mtime_ns = db_path.stat().st_mtime_ns
+        key = (str(db_path), mtime_ns, date_key, effective_pack)
+    except OSError:
+        # stat()/path race → bypass the cache, never fail the page.
+        return _build_today_digest_payload_uncached(
+            vault_dir, pack_name=pack_name, target_date=target_date
+        )
+
+    cached = _TODAY_PAYLOAD_CACHE.get(key)
+    if cached is not None:
+        _TODAY_PAYLOAD_CACHE.move_to_end(key)
+        return _copy.deepcopy(cached)
+
+    payload = _build_today_digest_payload_uncached(
+        vault_dir, pack_name=pack_name, target_date=target_date
+    )
+    _TODAY_PAYLOAD_CACHE[key] = payload
+    while len(_TODAY_PAYLOAD_CACHE) > _TODAY_PAYLOAD_CACHE_MAX:
+        _TODAY_PAYLOAD_CACHE.popitem(last=False)
+    return _copy.deepcopy(payload)
+
+
+def _build_today_digest_payload_uncached(
     vault_dir: Path | str,
     *,
     pack_name: str | None = None,
@@ -38,8 +101,9 @@ def build_today_digest_payload(
     number counted.
 
     ``target_date`` accepts ``YYYY-MM-DD`` for back-dated views
-    (defaults to today UTC).  The date affects the SECONDARY
-    number only; the primary number is "right now", not historic.
+    (defaults to the operator-local day).  The date affects the
+    SECONDARY number only; the primary number is "right now", not
+    historic.
     """
     from datetime import datetime
 

--- a/tests/test_ops_today_lifecycle.py
+++ b/tests/test_ops_today_lifecycle.py
@@ -168,3 +168,47 @@ def test_cards_are_independent_of_lifecycle_summary(tmp_path):
     assert na_card["event_count"] == 1  # 1 failure event today
     assert na_card["primary_count"] == 1  # 1 item in NeedsAction state
     assert payload["lifecycle_summary"]["counts"][STATE_NEEDS_ACTION] == 1
+
+
+def test_today_payload_cached_by_db_mtime(tmp_path, monkeypatch):
+    """Day-switch perf: a second call with the db unchanged is
+    served from cache (the 6 heavy builders do NOT re-run); a db
+    mtime change (rebuild / ops_state write) busts every cached
+    date so the payload can never go stale."""
+    import os
+
+    from ovp_pipeline.ui.view_models import _layer3
+
+    db_path = _make_db(tmp_path)
+    _seed_two_items(db_path)
+
+    calls = {"n": 0}
+    real = _layer3._build_today_digest_payload_uncached
+
+    def counting(*a, **kw):
+        calls["n"] += 1
+        return real(*a, **kw)
+
+    monkeypatch.setattr(_layer3, "_build_today_digest_payload_uncached", counting)
+    _layer3._TODAY_PAYLOAD_CACHE.clear()
+
+    p1 = build_today_digest_payload(tmp_path, pack_name=PACK)
+    assert calls["n"] == 1
+    p2 = build_today_digest_payload(tmp_path, pack_name=PACK)
+    assert calls["n"] == 1  # cache hit — builders NOT re-run
+    assert p2 == p1  # identical payload
+
+    # mutating the returned dict must not corrupt the cached copy
+    p2["cards"] = "tampered"
+    p3 = build_today_digest_payload(tmp_path, pack_name=PACK)
+    assert calls["n"] == 1
+    assert p3["cards"] != "tampered"
+
+    # a db write (atomic rebuild / ops_state) changes st_mtime_ns →
+    # cache busts → recompute, still correct.
+    st = db_path.stat()
+    os.utime(db_path, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000_000))
+    p4 = build_today_digest_payload(tmp_path, pack_name=PACK)
+    assert calls["n"] == 2  # cache busted by mtime change
+    na = next(c for c in p4["cards"] if c["id"] == "NeedsAction")
+    assert na["primary_count"] == 1  # data still correct post-bust


### PR DESCRIPTION
Operator-reported: flipping back and forth between dates on /ops/today is often very slow.

**Root cause**: `build_today_digest_payload` runs 6 heavy builders per request (each its own sqlite connect on the ~350MB knowledge.db; audit_events ~37k rows; M26 filters dates in Python), with **zero caching** — every day-switch re-pays the full cost, even revisiting a date.

**Fix**: mtime-keyed LRU cache wrapper.
- Key = `(db_path, knowledge.db st_mtime_ns, date, effective_pack)`. Any rebuild (knowledge_index atomic replace) or ops_state write changes `st_mtime_ns` → busts **every** cached date → a real data change can never be served stale; repeated day navigation between rebuilds is O(1).
- Bounded LRU (48); deepcopy on store+return (caller can't corrupt cache); db-missing / stat race bypass the cache.
- Behaviour-preserving: real builder unchanged, renamed `_build_today_digest_payload_uncached`; public API + package re-export identical.

Deliberately **minimal** — not touching the deeper levers (shared connection; `audit_events(timestamp)` index, which has projection-schema/migration blast radius). The cache alone fixes the user-visible symptom.

Note: `_layer3.py` also carries a tiny pre-existing WIP docstring fix ("operator-local day") inside the restructured function — can't be split out, benign, consistent with M26.

Tests: cache hit doesn't re-run the 6 builders; returned-dict mutation can't corrupt cache; `st_mtime_ns` change busts it and recompute is still correct. Full suite **3074 / 0**; zero new ruff/mypy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added caching layer for digest payload generation with automatic cache invalidation when underlying database changes.

* **Tests**
  * Added comprehensive regression tests to validate caching behavior, prevent mutations from corrupting cached data, and confirm proper cache invalidation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fakechris/obsidian_vault_pipeline/pull/275?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->