### PR TITLE
M33 follow-ups: gemini review fixes + --viz-dir overlay

### DIFF
--- a/console-ui/src/graph/CommunityLabels.tsx
+++ b/console-ui/src/graph/CommunityLabels.tsx
@@ -4,6 +4,12 @@ import { clusterColor } from '../lib/palette';
 import type { Community, GraphNode } from '../lib/types';
 import { MAX_HULLS, MIN_HULL_MEMBERS } from './g6/hulls';
 
+/** Top-N communities always get a label even when their disc is small on
+ * screen — the overview needs landmarks. */
+const LANDMARK_RANK_THRESHOLD = 6;
+/** Minimum on-screen disc radius (px) for a community to own a label. */
+const MIN_LABELED_DISC_RADIUS = 26;
+
 interface Anchor {
   community: Community;
   world: [number, number];
@@ -90,7 +96,11 @@ export default function CommunityLabels({
   const visible: { community: Community; x: number; y: number }[] = [];
   anchors.forEach(({ community, world }, rank) => {
     const discScreenR = (20 * Math.sqrt(community.size) + 34) * zoom;
-    if (discScreenR < 26 && rank >= 6) return;
+    if (
+      discScreenR < MIN_LABELED_DISC_RADIUS &&
+      rank >= LANDMARK_RANK_THRESHOLD
+    )
+      return;
     const screen = worldToScreen(world);
     if (!screen) return;
     const [x, y] = screen;

--- a/console-ui/src/graph/Legend.tsx
+++ b/console-ui/src/graph/Legend.tsx
@@ -3,6 +3,8 @@ import { clusterColor } from '../lib/palette';
 import { flyToNodes } from './controller';
 import type { Community, GraphNode } from '../lib/types';
 
+const MAX_LEGEND_COMMUNITIES = 12;
+
 interface Props {
   communities: Community[];
   nodes: GraphNode[];
@@ -30,7 +32,7 @@ export default function Legend({ communities, nodes }: Props) {
         Communities 社区
       </div>
       <ul className="space-y-0.5">
-        {communities.slice(0, 12).map((c) => (
+        {communities.slice(0, MAX_LEGEND_COMMUNITIES).map((c) => (
           <li key={c.id}>
             <button
               onClick={() => flyToNodes(memberIds.get(c.id) ?? [])}

--- a/console-ui/src/pages/ExplorePage.tsx
+++ b/console-ui/src/pages/ExplorePage.tsx
@@ -3,6 +3,8 @@ import { Link } from 'react-router-dom';
 import { fetchClaim, fetchFind, fetchSearchSubgraph } from '../lib/api';
 import type { ClaimDetail, FindHit, GraphNode } from '../lib/types';
 
+const MAX_OTHER_MATCHES = 20;
+
 export default function ExplorePage() {
   const [term, setTerm] = useState('');
   const [claims, setClaims] = useState<GraphNode[]>([]);
@@ -29,7 +31,9 @@ export default function ExplorePage() {
           fetchFind(q).catch(() => [] as FindHit[]),
         ]);
         setClaims(subgraph.nodes.filter((n) => n.hit));
-        setOthers(hits.filter((h) => h.kind !== 'claim').slice(0, 20));
+        setOthers(
+          hits.filter((h) => h.kind !== 'claim').slice(0, MAX_OTHER_MATCHES),
+        );
         setStatus(null);
       } catch {
         setStatus('Search failed 搜索失败');

--- a/console-ui/src/pages/MonitorPage.tsx
+++ b/console-ui/src/pages/MonitorPage.tsx
@@ -3,6 +3,7 @@ import { fetchModel } from '../lib/api';
 import type { IndexModel } from '../lib/types';
 
 const POLL_MS = 2000;
+const MAX_RECENT_RUNS = 15;
 
 // The old monitor listened to /api/sse, which was always a stub (tiny_http
 // is a sequential loop; it cannot stream). Polling /api/model and diffing
@@ -115,7 +116,7 @@ export default function MonitorPage() {
           </thead>
           <tbody>
             {(model?.runs ?? [])
-              .slice(-15)
+              .slice(-MAX_RECENT_RUNS)
               .reverse()
               .map((r) => (
                 <tr

--- a/crates/ovp-cli/src/commands/serve.rs
+++ b/crates/ovp-cli/src/commands/serve.rs
@@ -10,6 +10,7 @@ pub struct ServeArgs {
     pub vault_root: PathBuf,
     pub host: String,
     pub port: u16,
+    pub viz_dir: Option<PathBuf>,
 }
 
 pub fn run(args: ServeArgs) -> Result<(), CliError> {
@@ -17,6 +18,7 @@ pub fn run(args: ServeArgs) -> Result<(), CliError> {
         vault_root: args.vault_root,
         host: args.host,
         port: args.port,
+        viz_dir: args.viz_dir,
     };
     run_server(config).map_err(CliError::Io)
 }

--- a/crates/ovp-cli/src/main.rs
+++ b/crates/ovp-cli/src/main.rs
@@ -376,6 +376,10 @@ enum Cmd {
         /// Host to bind. Default: 127.0.0.1 (localhost only).
         #[arg(long, default_value = "127.0.0.1")]
         host: String,
+        /// Fallback dir for /viz/* SPA assets (e.g. <repo>/.ovp/console/viz).
+        /// Lets a dev checkout serve any vault without copying the build in.
+        #[arg(long)]
+        viz_dir: Option<PathBuf>,
     },
     /// PRODUCT — reader/crystal trunk (the blessed path).
     /// M22 Crystal pre-write gate: lint a structured-citation synthesis candidate
@@ -1018,8 +1022,13 @@ fn main() -> ExitCode {
         Cmd::Mcp { vault_root } => {
             commands::mcp::run(commands::mcp::McpArgs { vault_root })
         }
-        Cmd::Serve { vault_root, port, host } => {
-            commands::serve::run(commands::serve::ServeArgs { vault_root, host, port })
+        Cmd::Serve { vault_root, port, host, viz_dir } => {
+            commands::serve::run(commands::serve::ServeArgs {
+                vault_root,
+                host,
+                port,
+                viz_dir,
+            })
         }
         Cmd::CrystalLint { candidate, packs_dir, out, strength } => {
             use commands::crystal_lint::CrystalLintArgs;

--- a/crates/ovp-server/src/graph.rs
+++ b/crates/ovp-server/src/graph.rs
@@ -204,6 +204,13 @@ struct BaseGraph {
     claim_sources: BTreeMap<String, BTreeSet<String>>,
 }
 
+/// Last segment of a vault-relative dir string, tolerant of either
+/// separator: an index written on Windows carries `\`, which Unix
+/// `Path::file_name` would NOT treat as a separator.
+pub(crate) fn last_path_segment(dir: &str) -> Option<&str> {
+    dir.rsplit(['/', '\\']).next().filter(|s| !s.is_empty())
+}
+
 fn build_base(records: &[DurableRecord], model: Option<&IndexModel>) -> BaseGraph {
     let source_lookup: HashMap<&str, &ovp_index::SourceRow> = model
         .map(|m| m.sources.iter().map(|s| (s.sha256.as_str(), s)).collect())
@@ -212,13 +219,7 @@ fn build_base(records: &[DurableRecord], model: Option<&IndexModel>) -> BaseGrap
         .map(|m| {
             m.packs
                 .iter()
-                .filter_map(|p| {
-                    // Path::file_name, not rsplit('/'), so a Windows-written
-                    // index (backslash separators) still resolves case ids.
-                    let case =
-                        std::path::Path::new(&p.pack_dir).file_name()?.to_str()?;
-                    Some((case, p))
-                })
+                .filter_map(|p| Some((last_path_segment(&p.pack_dir)?, p)))
                 .collect()
         })
         .unwrap_or_default();
@@ -961,6 +962,11 @@ pub fn is_spa_route(relative: &str) -> bool {
     let Some(rest) = relative.strip_prefix("viz/") else {
         return false;
     };
+    // Malformed paths (absolute rest via `/viz//…`, empty segments) are not
+    // client routes — they must 404, not get a 200 SPA shell.
+    if rest.starts_with('/') || rest.contains("//") || rest.is_empty() {
+        return false;
+    }
     let last = rest.rsplit('/').next().unwrap_or(rest);
     !last.contains('.') || last.ends_with(".html")
 }
@@ -1261,5 +1267,21 @@ mod tests {
         assert!(!is_spa_route("viz/assets/graph-abc.js"));
         assert!(!is_spa_route("index.html"));
         assert!(!is_spa_route("ops.html"));
+        // Malformed / absolute-smuggling paths are not client routes.
+        assert!(!is_spa_route("viz//etc/hosts"));
+        assert!(!is_spa_route("viz/a//b"));
+        assert!(!is_spa_route("viz/"));
+    }
+
+    #[test]
+    fn last_path_segment_handles_both_separators() {
+        assert_eq!(last_path_segment("a/b/case-01"), Some("case-01"));
+        assert_eq!(
+            last_path_segment(r"40-Resources\Reader\case-01"),
+            Some("case-01")
+        );
+        assert_eq!(last_path_segment("case-01"), Some("case-01"));
+        assert_eq!(last_path_segment("a/b/"), None);
+        assert_eq!(last_path_segment(""), None);
     }
 }

--- a/crates/ovp-server/src/graph.rs
+++ b/crates/ovp-server/src/graph.rs
@@ -26,6 +26,12 @@ const MAX_COMMUNITIES: usize = 40;
 /// A community label needs this theme coverage to stand alone; below it we
 /// join the top-2 themes so the hull label doesn't overclaim.
 const DOMINANT_THEME_COVERAGE: f64 = 0.4;
+/// Node label truncation: claims and unit quotes are clipped for the graph
+/// payload (full text lives behind /api/claim/:id).
+const MAX_CLAIM_LABEL_LEN: usize = 80;
+const TRUNCATED_CLAIM_LABEL_LEN: usize = 77;
+const MAX_QUOTE_LABEL_LEN: usize = 60;
+const TRUNCATED_QUOTE_LABEL_LEN: usize = 57;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GraphMode {
@@ -206,7 +212,13 @@ fn build_base(records: &[DurableRecord], model: Option<&IndexModel>) -> BaseGrap
         .map(|m| {
             m.packs
                 .iter()
-                .filter_map(|p| Some((p.pack_dir.rsplit('/').next()?, p)))
+                .filter_map(|p| {
+                    // Path::file_name, not rsplit('/'), so a Windows-written
+                    // index (backslash separators) still resolves case ids.
+                    let case =
+                        std::path::Path::new(&p.pack_dir).file_name()?.to_str()?;
+                    Some((case, p))
+                })
                 .collect()
         })
         .unwrap_or_default();
@@ -220,8 +232,11 @@ fn build_base(records: &[DurableRecord], model: Option<&IndexModel>) -> BaseGrap
         nodes.entry(claim_id.clone()).or_insert_with(|| GNode {
             id: claim_id.clone(),
             node_type: "claim".into(),
-            label: if rec.claim.chars().count() > 80 {
-                format!("{}…", truncate_chars(&rec.claim, 77))
+            label: if rec.claim.chars().count() > MAX_CLAIM_LABEL_LEN {
+                format!(
+                    "{}…",
+                    truncate_chars(&rec.claim, TRUNCATED_CLAIM_LABEL_LEN)
+                )
             } else {
                 rec.claim.clone()
             },
@@ -240,8 +255,11 @@ fn build_base(records: &[DurableRecord], model: Option<&IndexModel>) -> BaseGrap
             nodes.entry(unit_id.clone()).or_insert_with(|| GNode {
                 id: unit_id.clone(),
                 node_type: "unit".into(),
-                label: if cit.quote.chars().count() > 60 {
-                    format!("{}…", truncate_chars(&cit.quote, 57))
+                label: if cit.quote.chars().count() > MAX_QUOTE_LABEL_LEN {
+                    format!(
+                        "{}…",
+                        truncate_chars(&cit.quote, TRUNCATED_QUOTE_LABEL_LEN)
+                    )
                 } else {
                     cit.quote.clone()
                 },

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -249,7 +249,10 @@ fn handle_claim(state: &AppState, url: &str) -> Response<std::io::Cursor<Vec<u8>
             m.packs
                 .iter()
                 .filter_map(|p| {
-                    let case = p.pack_dir.rsplit('/').next()?;
+                    // Path::file_name, not rsplit('/') — separator-agnostic.
+                    let case = std::path::Path::new(&p.pack_dir)
+                        .file_name()?
+                        .to_str()?;
                     Some((case.to_string(), p))
                 })
                 .collect()

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -21,12 +21,17 @@ pub struct ServeConfig {
     pub vault_root: PathBuf,
     pub host: String,
     pub port: u16,
+    /// Fallback directory for `/viz/*` assets (the SPA build output). When
+    /// the vault's `.ovp/console/viz/` misses, files are served from here —
+    /// so a dev checkout can serve ANY vault without copying the build in.
+    pub viz_dir: Option<PathBuf>,
 }
 
 struct AppState {
     vault_root: PathBuf,
     layout: VaultLayout,
     model: RwLock<Option<IndexModel>>,
+    viz_dir: Option<PathBuf>,
 }
 
 impl AppState {
@@ -68,6 +73,7 @@ pub fn run_server(config: ServeConfig) -> Result<(), String> {
         vault_root: config.vault_root,
         layout: VaultLayout::new(),
         model: RwLock::new(None),
+        viz_dir: config.viz_dir,
     });
 
     // Pre-load model
@@ -77,6 +83,17 @@ pub fn run_server(config: ServeConfig) -> Result<(), String> {
     eprintln!("  console: http://{bind}/");
     eprintln!("  API:     http://{bind}/api/find?term=...");
     eprintln!("  reload:  http://{bind}/api/refresh");
+    match &state.viz_dir {
+        Some(dir) => eprintln!("  viz:     overlay from {}", dir.display()),
+        None => {
+            if !state.console_dir().join("viz").join("index.html").exists() {
+                eprintln!(
+                    "  viz:     NOT DEPLOYED in this vault — pass --viz-dir \
+                     <repo>/.ovp/console/viz to serve the SPA build"
+                );
+            }
+        }
+    }
 
     for request in server.incoming_requests() {
         let path = request.url().to_string();
@@ -249,10 +266,7 @@ fn handle_claim(state: &AppState, url: &str) -> Response<std::io::Cursor<Vec<u8>
             m.packs
                 .iter()
                 .filter_map(|p| {
-                    // Path::file_name, not rsplit('/') — separator-agnostic.
-                    let case = std::path::Path::new(&p.pack_dir)
-                        .file_name()?
-                        .to_str()?;
+                    let case = graph::last_path_segment(&p.pack_dir)?;
                     Some((case.to_string(), p))
                 })
                 .collect()
@@ -369,12 +383,28 @@ fn serve_static(state: &AppState, url_path: &str) -> Response<std::io::Cursor<Ve
             Response::from_data(content).with_header(header).with_status_code(200)
         }
         Err(_) => {
+            // Viz overlay: /viz/* assets missing from the vault fall back to
+            // the configured SPA build dir (--viz-dir), so a dev checkout
+            // serves any vault without copying .ovp/console/viz into it.
+            if let Some(rest) = relative.strip_prefix("viz/") {
+                if let Some(content) = read_viz_overlay(state, rest) {
+                    let ct = content_type_for(relative);
+                    let header = Header::from_bytes("Content-Type", ct).unwrap();
+                    return Response::from_data(content)
+                        .with_header(header)
+                        .with_status_code(200);
+                }
+            }
             // SPA fallback: client-side routes like /viz/graph have no file
-            // on disk — serve the SPA shell and let the router take over.
+            // on disk — serve the SPA shell (vault first, then overlay) and
+            // let the router take over.
             if graph::is_spa_route(relative) {
-                if let Ok(content) =
-                    std::fs::read(console_dir.join("viz").join("index.html"))
-                {
+                let shell = std::fs::read(
+                    console_dir.join("viz").join("index.html"),
+                )
+                .ok()
+                .or_else(|| read_viz_overlay(state, "index.html"));
+                if let Some(content) = shell {
                     let header = Header::from_bytes(
                         "Content-Type",
                         "text/html; charset=utf-8",
@@ -388,6 +418,24 @@ fn serve_static(state: &AppState, url_path: &str) -> Response<std::io::Cursor<Ve
             text_response(404, "Not Found")
         }
     }
+}
+
+/// Read a `/viz/`-relative asset from the overlay build dir, if configured.
+/// `..` is already rejected by serve_static, but `rest` can still be
+/// absolute (`/viz//etc/passwd` → rest `/etc/passwd`) and `Path::join`
+/// DISCARDS the base for an absolute RHS — so only plain relative
+/// components are allowed through.
+fn read_viz_overlay(state: &AppState, rest: &str) -> Option<Vec<u8>> {
+    let dir = state.viz_dir.as_ref()?;
+    let rel = std::path::Path::new(rest);
+    if rel.is_absolute()
+        || rel
+            .components()
+            .any(|c| !matches!(c, std::path::Component::Normal(_)))
+    {
+        return None;
+    }
+    std::fs::read(dir.join(rel)).ok()
 }
 
 fn json_response(status: u16, body: &str) -> Response<std::io::Cursor<Vec<u8>>> {
@@ -459,5 +507,77 @@ fn hex_val(b: u8) -> u8 {
         b'a'..=b'f' => b - b'a' + 10,
         b'A'..=b'F' => b - b'A' + 10,
         _ => 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_root(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir()
+            .join(format!("ovp-server-test-{}-{name}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn state(vault: PathBuf, viz_dir: Option<PathBuf>) -> AppState {
+        AppState {
+            vault_root: vault,
+            layout: VaultLayout::new(),
+            model: RwLock::new(None),
+            viz_dir,
+        }
+    }
+
+    #[test]
+    fn viz_overlay_serves_assets_and_spa_shell_when_vault_misses() {
+        let root = temp_root("overlay");
+        let vault = root.join("vault");
+        std::fs::create_dir_all(vault.join(".ovp/console")).unwrap();
+        let overlay = root.join("viz-build");
+        std::fs::create_dir_all(overlay.join("assets")).unwrap();
+        std::fs::write(overlay.join("index.html"), "<html>spa</html>").unwrap();
+        std::fs::write(overlay.join("assets/app.js"), "js").unwrap();
+
+        let st = state(vault.clone(), Some(overlay));
+        // Asset missing in the vault → served from the overlay.
+        assert_eq!(serve_static(&st, "/viz/assets/app.js").status_code(), 200);
+        // Client-side route → SPA shell from the overlay.
+        assert_eq!(serve_static(&st, "/viz/graph").status_code(), 200);
+        // Legacy multi-page link → SPA shell too.
+        assert_eq!(serve_static(&st, "/viz/graph.html").status_code(), 200);
+        // Outside /viz/ the overlay must not apply.
+        assert_eq!(serve_static(&st, "/nope.html").status_code(), 404);
+        // Absolute-path smuggling: Path::join would swap in the RHS wholesale
+        // for `/viz//etc/...` — must be rejected, never read outside the
+        // overlay dir.
+        std::fs::write(root.join("secret.txt"), "nope").unwrap();
+        let abs = format!("/viz/{}", root.join("secret.txt").display());
+        assert_eq!(serve_static(&st, &abs).status_code(), 404);
+        assert_eq!(serve_static(&st, "/viz//etc/hosts").status_code(), 404);
+
+        // Vault copy wins over the overlay when present.
+        std::fs::create_dir_all(vault.join(".ovp/console/viz")).unwrap();
+        std::fs::write(
+            vault.join(".ovp/console/viz/index.html"),
+            "<html>vault</html>",
+        )
+        .unwrap();
+        assert_eq!(serve_static(&st, "/viz/index.html").status_code(), 200);
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn without_overlay_missing_viz_is_404() {
+        let root = temp_root("no-overlay");
+        let vault = root.join("vault");
+        std::fs::create_dir_all(vault.join(".ovp/console")).unwrap();
+        let st = state(vault, None);
+        assert_eq!(serve_static(&st, "/viz/assets/app.js").status_code(), 404);
+        assert_eq!(serve_static(&st, "/viz/graph").status_code(), 404);
+        let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/docs/stage-m33-viz-spa-rewrite.md
+++ b/docs/stage-m33-viz-spa-rewrite.md
@@ -53,8 +53,9 @@ claim <500ms 展开邻域；DetailPanel 带原文 quote；`?focus=` 深链可分
 ## 已知后续（非本阶段范围）
 - 静态 console（`crates/ovp-console`）的 Attention feed 可加
   `/viz/graph?focus=claim:<key>` 深链入口
-- viz 构建产物进真实 vault 目前靠手动复制到 `<vault>/.ovp/console/viz/`；
-  可考虑 `ovp-next console --with-viz` 或 serve 时兜底读 repo 产物
+- ~~viz 构建产物进真实 vault 靠手动复制~~ → 已解决（M33 follow-up）：
+  `ovp-next serve --viz-dir <repo>/.ovp/console/viz` 作为 /viz/* 的兜底
+  overlay，vault 内文件优先；无 flag 且 vault 缺 viz 时启动会提示
 - 真实 vault 语料还小（M32 全量跑完后再看社区/importance 分布是否需要调权）
 - G6 程序化 `zoomTo` 在 bubble-sets 挂载时偶发 landmark 报错（用户滚轮/拖拽
   不受影响）；升级 G6 时复查


### PR DESCRIPTION
Two follow-ups to #278:

**1. Gemini review fixes (76ba6f7c)** — these were pushed to the #278 branch but the push silently failed before merge, so they missed the merge commit. Cherry-picked here: separator-agnostic pack_dir case-id extraction (HIGH) + 11 magic-number→named-constant cleanups (MEDIUM).

**2. `ovp-next serve --viz-dir` (52cd1b35)** — closes the M33 known-gap "viz build must be manually copied into each vault": the flag registers the SPA build dir as a `/viz/*` fallback overlay (vault files win). Startup banner names the overlay or warns when a vault has no viz build.

Hardening from the local codex gate on this branch:
- P1 fixed: absolute-path smuggling via `/viz//etc/passwd` (`Path::join` discards the base for absolute RHS) — overlay reads reject non-Normal path components, and `is_spa_route` rejects malformed `//` paths instead of serving a 200 shell.
- P2 fixed: `Path::file_name` doesn't split `\` on Unix — `last_path_segment()` splits on both separators (graph.rs + handle_claim), with tests.

679 workspace tests + clippy -D warnings green; overlay verified e2e against a vault with no viz dir (SPA routes, shell, hashed assets all 200).