### PR TITLE
fix(daily): un-pin bad model replies + reclaim stale run locks (M32 Stage 0.5)

### DIFF
--- a/crates/ovp-cli/src/commands/crystal_synth.rs
+++ b/crates/ovp-cli/src/commands/crystal_synth.rs
@@ -109,8 +109,16 @@ fn call_and_parse<T>(
         .map_err(|e| CliError::Io(format!("crystal-synth: {stage} call failed: {e}")))?;
     match parse_reply_value(&reply.text) {
         Ok((_v, note)) => {
-            let parsed = parse(&reply.text)
-                .map_err(|d| CliError::Io(format!("crystal-synth: {stage} parse: {d}")))?;
+            let parsed = match parse(&reply.text) {
+                Ok(p) => p,
+                Err(d) => {
+                    // Valid JSON the stage parser rejects (e.g. no `claims`
+                    // array) pins a rerun just like unparseable JSON — forget
+                    // it too so the retry re-asks the model.
+                    client.invalidate(request);
+                    return Err(CliError::Io(format!("crystal-synth: {stage} parse: {d}")));
+                }
+            };
             let log = note.map(|_| RepairLog {
                 stage: stage.to_string(),
                 method: "parser-local: unescaped-backslash".to_string(),
@@ -131,13 +139,20 @@ fn call_and_parse<T>(
                         method: format!("model-repair (input defect: {defect})"),
                     }),
                 )),
-                _ => Err(CliError::Io(format!(
-                    "crystal-synth: {stage} JSON unrecoverable: {}",
-                    match defect {
-                        JsonDefect::Unrecoverable(d) => d,
-                        other => other.to_string(),
-                    }
-                ))),
+                _ => {
+                    // Forget the unrecoverable exchange under a recording
+                    // cache: a rerun must re-ask the model, not replay the
+                    // same unparseable reply forever. No-op for replay/fakes.
+                    client.invalidate(request);
+                    client.invalidate(&json_repair_request(&reply.text));
+                    Err(CliError::Io(format!(
+                        "crystal-synth: {stage} JSON unrecoverable: {}",
+                        match defect {
+                            JsonDefect::Unrecoverable(d) => d,
+                            other => other.to_string(),
+                        }
+                    )))
+                }
             }
         }
     }

--- a/crates/ovp-domain/src/reader/pipeline.rs
+++ b/crates/ovp-domain/src/reader/pipeline.rs
@@ -11,11 +11,11 @@ use std::path::Path;
 
 use ovp_llm::ModelClient;
 
-use crate::model_reply::RepairNote;
+use crate::model_reply::{json_repair_request, RepairNote};
 use crate::source_doc::SourceDoc;
-use crate::units::{run_unit_extraction_repaired, Unit};
+use crate::units::{critic_model_request, run_unit_extraction_repaired, unit_model_request, Unit};
 
-use super::cards::run_card_synthesis;
+use super::cards::{card_model_request, run_card_synthesis};
 use super::pack::{write_reader_pack, GroundingStatus, ReaderPack};
 
 /// Why a reader-pipeline run could not produce a pack.
@@ -76,6 +76,16 @@ pub fn run_reader_pipeline(
         ex.report.accepted_without_quote,
     ) {
         write_audit(out_dir, &run.base_reply, &run.critic_reply, "");
+        // The replies transported fine but their CONTENT is unusable. Under a
+        // recording cache they are already cassetted, and request keys are
+        // pure content hashes — every retry (tomorrow's daily, --retry-blocked)
+        // would replay the identical failure forever. Forget the whole
+        // extraction exchange (base + any JSON-repair keyed on the bad reply +
+        // critic) so the next attempt genuinely re-asks the model. No-op for
+        // replay/fake clients.
+        base_client.invalidate(&unit_model_request(source));
+        base_client.invalidate(&json_repair_request(&run.base_reply));
+        critic_client.invalidate(&critic_model_request(source, &run.base.units));
         return Err(ReaderPipelineError::TruthLayer(reason));
     }
 
@@ -118,6 +128,13 @@ pub fn run_reader_pipeline(
     } else {
         None
     };
+    if card_failure.is_some() {
+        // Same forgetting as the truth-layer gate: callers treat a card
+        // failure as a failed source and retry it — a cassetted bad card
+        // reply must not pin every retry to the identical failure.
+        card_client.invalidate(&card_model_request(&accepted));
+        card_client.invalidate(&json_repair_request(&synth.raw_reply));
+    }
 
     Ok(ReaderPipelineRun { pack, json_repairs, card_failure })
 }
@@ -237,6 +254,121 @@ mod tests {
         assert!(matches!(err, ReaderPipelineError::TruthLayer(_)), "got {err:?}");
         assert!(dir.path().join("model-reply.units.txt").exists());
         assert!(!dir.path().join("reader.md").exists(), "no pack on truth-layer failure");
+    }
+
+    /// The dogfood retry scenario: day 1 the model returns unusable units
+    /// JSON, which a Record cache cassettes; day 2's retry must NOT replay the
+    /// pinned bad reply — the truth-layer gate invalidates it, so the retry
+    /// re-asks the model and succeeds. (Without the invalidation this test
+    /// fails: the second run replays "not json" and errors identically.)
+    #[test]
+    fn truth_layer_failure_invalidates_cassette_so_retry_reasks() {
+        use ovp_llm::{CacheMode, CachedModelClient};
+
+        /// Unit-extract requests get scripted replies in order; JSON-repair
+        /// requests always fail to repair (stay unparseable).
+        struct Scripted {
+            unit_replies: Vec<String>,
+            calls: usize,
+        }
+        impl ModelClient for Scripted {
+            fn call(&mut self, r: &ModelRequest) -> Result<ModelReply, CallError> {
+                let ns = r.cache_namespace.as_deref().unwrap_or("");
+                let text = if ns.starts_with("json_repair") {
+                    "still not json".to_string()
+                } else {
+                    let t = self.unit_replies[self.calls.min(self.unit_replies.len() - 1)].clone();
+                    self.calls += 1;
+                    t
+                };
+                Ok(ModelReply {
+                    model: "scripted".into(),
+                    text,
+                    stop_reason: StopReason::EndTurn,
+                    usage: Usage { input_tokens: 1, output_tokens: 1 },
+                })
+            }
+        }
+
+        let src = source();
+        let ex = crate::units::extract_units(&units_reply(), &src);
+        let unit_id = ex.accepted().next().expect("one accepted unit").id.clone();
+        let cards = format!(
+            r#"{{"cards":[{{"title":"Chunks are neutral","content":"A chunk is structurally neutral.","unit_type":"definition","cited_unit_ids":["{unit_id}"]}}]}}"#
+        );
+
+        let cache = tempfile::tempdir().unwrap();
+        let inner = Scripted { unit_replies: vec!["not json".into(), units_reply()], calls: 0 };
+        let mut base =
+            CachedModelClient::new(inner, cache.path(), "", CacheMode::Record).unwrap();
+        let mut critic = Canned("{}".into());
+        let mut cards_client = Canned(cards);
+
+        // Day 1: bad reply recorded → truth-layer failure (+ invalidation).
+        let dir1 = tempfile::tempdir().unwrap();
+        let err = run_reader_pipeline(&src, &mut base, &mut critic, &mut cards_client, dir1.path())
+            .expect_err("day 1 fails on unusable units JSON");
+        assert!(matches!(err, ReaderPipelineError::TruthLayer(_)), "got {err:?}");
+
+        // Day 2 (same cassette dir): the retry re-asks and succeeds.
+        let dir2 = tempfile::tempdir().unwrap();
+        let run = run_reader_pipeline(&src, &mut base, &mut critic, &mut cards_client, dir2.path())
+            .expect("day 2 retry re-asks the model instead of replaying the pin");
+        assert_eq!(run.pack.n_cards, 1);
+        assert!(run.card_failure.is_none());
+    }
+
+    /// Same pinning fix for the card stage: a card reply that yields 0 usable
+    /// cards is forgotten, so the retry gets a fresh card synthesis.
+    #[test]
+    fn card_failure_invalidates_cassette_so_retry_reasks() {
+        use ovp_llm::{CacheMode, CachedModelClient};
+
+        struct Scripted {
+            replies: Vec<String>,
+            calls: usize,
+        }
+        impl ModelClient for Scripted {
+            fn call(&mut self, _r: &ModelRequest) -> Result<ModelReply, CallError> {
+                let text = self.replies[self.calls.min(self.replies.len() - 1)].clone();
+                self.calls += 1;
+                Ok(ModelReply {
+                    model: "scripted".into(),
+                    text,
+                    stop_reason: StopReason::EndTurn,
+                    usage: Usage { input_tokens: 1, output_tokens: 1 },
+                })
+            }
+        }
+
+        let src = source();
+        let ex = crate::units::extract_units(&units_reply(), &src);
+        let unit_id = ex.accepted().next().expect("one accepted unit").id.clone();
+        let good_cards = format!(
+            r#"{{"cards":[{{"title":"Chunks are neutral","content":"A chunk is structurally neutral.","unit_type":"definition","cited_unit_ids":["{unit_id}"]}}]}}"#
+        );
+        // Parses fine but cites an unknown unit → 0 cards survive → card failure.
+        let bad_cards =
+            r#"{"cards":[{"title":"x","content":"y","cited_unit_ids":["u-999-deadbeef"]}]}"#
+                .to_string();
+
+        let cache = tempfile::tempdir().unwrap();
+        let inner = Scripted { replies: vec![bad_cards, good_cards], calls: 0 };
+        let mut cards_client =
+            CachedModelClient::new(inner, cache.path(), "", CacheMode::Record).unwrap();
+        let mut base = Canned(units_reply());
+        let mut critic = Canned("{}".into());
+
+        let dir1 = tempfile::tempdir().unwrap();
+        let run1 = run_reader_pipeline(&src, &mut base, &mut critic, &mut cards_client, dir1.path())
+            .expect("pipeline runs");
+        assert!(run1.card_failure.is_some(), "day 1: bad card reply is a card failure");
+
+        let dir2 = tempfile::tempdir().unwrap();
+        let run2 = run_reader_pipeline(&src, &mut base, &mut critic, &mut cards_client, dir2.path())
+            .expect("pipeline runs");
+        assert!(run2.card_failure.is_none(), "day 2: retry re-asked and got usable cards");
+        assert_eq!(run2.pack.n_cards, 1);
     }
 
     #[test]

--- a/crates/ovp-intake/src/vaultops.rs
+++ b/crates/ovp-intake/src/vaultops.rs
@@ -143,9 +143,9 @@ pub fn rel_to(root: &Path, p: &Path) -> String {
 /// Single-writer guard for the vault's product state. Two overlapping runs
 /// (cron + manual) would double-spend LLM calls, append duplicate records,
 /// and race `safe_move`'s check-then-rename — so every mutating command takes
-/// this lock first. `create_new` is atomic; the file holds the PID for
-/// diagnosis. Released on drop; a crash leaves a stale lock that the error
-/// message tells the operator how to clear.
+/// this lock first. `create_new` is atomic; the file holds the owning PID.
+/// Released on drop; a lock stranded by a crash (Drop never ran) is reclaimed
+/// automatically once the owning process is verifiably gone.
 #[derive(Debug)]
 pub struct RunLock {
     path: PathBuf,
@@ -158,17 +158,118 @@ impl RunLock {
             std::fs::create_dir_all(parent)
                 .map_err(|e| format!("creating {}: {e}", parent.display()))?;
         }
-        match OpenOptions::new().write(true).create_new(true).open(&path) {
-            Ok(mut f) => {
-                let _ = writeln!(f, "{}", std::process::id());
-                Ok(Self { path })
+        match Self::try_create(&path) {
+            Ok(lock) => Ok(lock),
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                // Stale-lock recovery: release is Drop-only, so a crash or
+                // Ctrl-C (default SIGINT runs no destructors) strands the lock
+                // and would block every later run until manual deletion. If
+                // the recorded owner is verifiably dead, reclaim it — but ONLY
+                // under the exclusive reclaim guard: every deletion of
+                // run.lock happens with the guard held and after re-checking
+                // staleness, so a racer that already re-created a fresh lock
+                // can never have it deleted out from under it (the other
+                // racer loses the guard and takes the in-progress error).
+                if Self::owner_is_dead(&path) {
+                    if let Some(lock) = Self::reclaim_under_guard(&path) {
+                        return Ok(lock);
+                    }
+                }
+                Err(format!(
+                    "another OVP run appears to be in progress (lock file {}); \
+                     if no run is active, delete the lock file and retry",
+                    path.display()
+                ))
             }
-            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Err(format!(
-                "another OVP run appears to be in progress (lock file {}); \
-                 if no run is active, delete the lock file and retry",
-                path.display()
-            )),
             Err(e) => Err(format!("acquiring {}: {e}", path.display())),
+        }
+    }
+
+    /// One atomic `create_new` attempt, stamping this process's PID.
+    fn try_create(path: &Path) -> std::io::Result<Self> {
+        let mut f = OpenOptions::new().write(true).create_new(true).open(path)?;
+        let _ = writeln!(f, "{}", std::process::id());
+        Ok(Self { path: path.to_path_buf() })
+    }
+
+    /// Reclaim a stale lock while holding the exclusive reclaim guard. Returns
+    /// `None` when the guard is contested or the lock turned out to be fresh
+    /// on the re-check — the caller falls back to the in-progress error.
+    fn reclaim_under_guard(path: &Path) -> Option<Self> {
+        let guard = path.with_extension("lock.reclaim");
+        if !Self::claim_guard(&guard) {
+            return None;
+        }
+        // Re-check under the guard: the stale lock may have been reclaimed
+        // and replaced by a live owner between our probe and winning the guard.
+        let lock = if Self::owner_is_dead(path) {
+            eprintln!(
+                "ovp: reclaiming stale run lock {} (owning process is gone)",
+                path.display()
+            );
+            let _ = std::fs::remove_file(path);
+            Self::try_create(path).ok()
+        } else {
+            None
+        };
+        let _ = std::fs::remove_file(&guard);
+        lock
+    }
+
+    /// Atomically claim the reclaim guard (PID-stamped like the lock). A guard
+    /// stranded by a crash mid-reclaim is itself reclaimed by the same
+    /// dead-owner rule: removal + ONE `create_new` retry — the create is
+    /// atomic, so exactly one racer wins it.
+    fn claim_guard(guard: &Path) -> bool {
+        fn stamp(mut f: std::fs::File) -> bool {
+            let _ = writeln!(f, "{}", std::process::id());
+            true
+        }
+        match OpenOptions::new().write(true).create_new(true).open(guard) {
+            Ok(f) => stamp(f),
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                if !Self::owner_is_dead(guard) {
+                    return false;
+                }
+                let _ = std::fs::remove_file(guard);
+                match OpenOptions::new().write(true).create_new(true).open(guard) {
+                    Ok(f) => stamp(f),
+                    Err(_) => false,
+                }
+            }
+            Err(_) => false,
+        }
+    }
+
+    /// True only when the lock file names a PID that is verifiably no longer
+    /// running. Conservative on every uncertainty (unreadable file, no PID,
+    /// probe failure, non-unix): treat the owner as alive and keep refusing —
+    /// the manual-deletion instruction in the error still applies.
+    fn owner_is_dead(path: &Path) -> bool {
+        let Some(pid) = std::fs::read_to_string(path)
+            .ok()
+            .and_then(|s| s.trim().parse::<u32>().ok())
+            .filter(|p| *p > 0)
+        else {
+            return false;
+        };
+        #[cfg(unix)]
+        {
+            // `kill -0` probes liveness without signaling; exit 0 = alive.
+            // (A live process owned by another user also reports non-zero,
+            // but a vault lock under $HOME is always same-user.)
+            std::process::Command::new("kill")
+                .arg("-0")
+                .arg(pid.to_string())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .status()
+                .map(|s| !s.success())
+                .unwrap_or(false)
+        }
+        #[cfg(not(unix))]
+        {
+            false
         }
     }
 }
@@ -216,6 +317,59 @@ mod tests {
         let q = write_new(&p, "b").unwrap();
         assert_eq!(q, dir.path().join("note -2.md"));
         assert_eq!(std::fs::read_to_string(&p).unwrap(), "a");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_lock_reclaims_stale_lock_from_dead_process() {
+        let dir = tempfile::tempdir().unwrap();
+        // Fabricate a crash: a lock file naming a process that has exited.
+        let mut child = std::process::Command::new("true").spawn().unwrap();
+        let dead_pid = child.id();
+        child.wait().unwrap();
+        let lock_path = dir.path().join(".ovp/run.lock");
+        std::fs::create_dir_all(lock_path.parent().unwrap()).unwrap();
+        std::fs::write(&lock_path, format!("{dead_pid}\n")).unwrap();
+
+        let lock = RunLock::acquire(dir.path()).expect("stale lock is reclaimed");
+        assert!(
+            !lock_path.with_extension("lock.reclaim").exists(),
+            "reclaim guard is cleaned up"
+        );
+        drop(lock);
+        assert!(!lock_path.exists(), "reclaimed lock still releases on drop");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_lock_recovers_from_a_stranded_reclaim_guard() {
+        // Crash DURING a previous reclaim: both the lock and the reclaim
+        // guard are stranded with dead owners. Acquire must recover through
+        // both layers (guard reclaimed by the same dead-owner rule).
+        let dir = tempfile::tempdir().unwrap();
+        let mut child = std::process::Command::new("true").spawn().unwrap();
+        let dead_pid = child.id();
+        child.wait().unwrap();
+        let lock_path = dir.path().join(".ovp/run.lock");
+        std::fs::create_dir_all(lock_path.parent().unwrap()).unwrap();
+        std::fs::write(&lock_path, format!("{dead_pid}\n")).unwrap();
+        std::fs::write(lock_path.with_extension("lock.reclaim"), format!("{dead_pid}\n")).unwrap();
+
+        let _lock = RunLock::acquire(dir.path()).expect("recovers through stale lock AND guard");
+        assert!(!lock_path.with_extension("lock.reclaim").exists(), "guard cleaned up");
+    }
+
+    #[test]
+    fn run_lock_refuses_live_owner_and_unreadable_pid() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock_path = dir.path().join(".ovp/run.lock");
+        std::fs::create_dir_all(lock_path.parent().unwrap()).unwrap();
+        // Owner alive (this very process) → refuse.
+        std::fs::write(&lock_path, format!("{}\n", std::process::id())).unwrap();
+        RunLock::acquire(dir.path()).expect_err("live owner must refuse");
+        // Garbage content → conservative: refuse, never reclaim blindly.
+        std::fs::write(&lock_path, "not-a-pid\n").unwrap();
+        RunLock::acquire(dir.path()).expect_err("unreadable owner must refuse");
     }
 
     #[test]

--- a/crates/ovp-llm/src/cache.rs
+++ b/crates/ovp-llm/src/cache.rs
@@ -143,4 +143,18 @@ impl<C: ModelClient> ModelClient for CachedModelClient<C> {
             }
         }
     }
+
+    /// Drop the cassette + memo entry for `request`, so the next `call`
+    /// re-asks the inner client and re-records. Record mode only: a
+    /// `ReplayOnly` cache serves (possibly committed) fixtures that a failing
+    /// run must never be able to delete — there it stays a no-op.
+    fn invalidate(&mut self, request: &ModelRequest) {
+        if self.mode != CacheMode::Record {
+            return;
+        }
+        let namespace = self.namespace_for(request).to_string();
+        let key = request_key(request);
+        self.memo.remove(&Self::memo_key(&namespace, &key));
+        let _ = fs::remove_file(self.cassette_path(&namespace, &key));
+    }
 }

--- a/crates/ovp-llm/src/client.rs
+++ b/crates/ovp-llm/src/client.rs
@@ -50,6 +50,17 @@ impl std::error::Error for CallError {}
 /// `Send + Sync` so wrappers (cache, fanout, retry) can compose freely.
 pub trait ModelClient: Send + Sync {
     fn call(&mut self, request: &ModelRequest) -> Result<ModelReply, CallError>;
+
+    /// Forget any memoized reply for `request`. Pipelines call this when a
+    /// reply that *transported* fine turned out to carry UNUSABLE content
+    /// (parse failure, truth-layer violation, zero cards): under a recording
+    /// cache the bad reply is already cassetted and — request keys being pure
+    /// content hashes — every later retry would replay the identical failure
+    /// forever. Forgetting makes the next attempt genuinely re-ask the model.
+    ///
+    /// Default: no-op. Live/fake clients memoize nothing; replay-only caches
+    /// must NOT delete their (possibly committed) fixtures.
+    fn invalidate(&mut self, _request: &ModelRequest) {}
 }
 
 /// A client that errors on every call. Used as the inner client of a
@@ -132,6 +143,10 @@ impl<C: ModelClient> ModelClient for RetryingModelClient<C> {
             }
         }
     }
+
+    fn invalidate(&mut self, request: &ModelRequest) {
+        self.inner.invalidate(request);
+    }
 }
 
 /// A `ModelClient` wrapper that recovers from [`CallError::BudgetExhausted`] —
@@ -166,6 +181,10 @@ impl<C: ModelClient> ModelClient for BudgetEscalatingModelClient<C> {
             }
             other => other,
         }
+    }
+
+    fn invalidate(&mut self, request: &ModelRequest) {
+        self.inner.invalidate(request);
     }
 }
 

--- a/crates/ovp-llm/tests/clients.rs
+++ b/crates/ovp-llm/tests/clients.rs
@@ -150,3 +150,55 @@ fn cached_record_persists_across_instances() {
     let r = replay.call(&req("hi")).expect("replay finds disk cassette");
     assert_eq!(r.text, "recorded-value");
 }
+
+/// Returns scripted replies in order (last one repeats), counting calls.
+struct Scripted {
+    replies: Vec<&'static str>,
+    calls: usize,
+}
+
+impl ModelClient for Scripted {
+    fn call(&mut self, _r: &ModelRequest) -> Result<ModelReply, CallError> {
+        let text = self.replies[self.calls.min(self.replies.len() - 1)];
+        self.calls += 1;
+        Ok(reply(text))
+    }
+}
+
+#[test]
+fn record_invalidate_forgets_and_rerecords() {
+    // The retry-pinning fix: a recorded reply whose CONTENT proved unusable is
+    // invalidated, so the next call re-asks the inner client and re-records.
+    let tmp = tempfile::tempdir().unwrap();
+    let inner = Scripted { replies: vec!["bad-reply", "good-reply"], calls: 0 };
+    let mut cached =
+        CachedModelClient::new(inner, tmp.path(), "ns/v1", CacheMode::Record).unwrap();
+
+    let r = req("x");
+    assert_eq!(cached.call(&r).unwrap().text, "bad-reply");
+    assert_eq!(cached.call(&r).unwrap().text, "bad-reply", "pinned by the cassette");
+
+    cached.invalidate(&r);
+    assert_eq!(cached.call(&r).unwrap().text, "good-reply", "re-asked after invalidate");
+    assert_eq!(cached.call(&r).unwrap().text, "good-reply", "new reply re-recorded");
+}
+
+#[test]
+fn replay_only_invalidate_never_deletes_fixtures() {
+    let tmp = tempfile::tempdir().unwrap();
+    {
+        let mut inner = FixtureModelClient::new();
+        inner.insert(&req("hi"), reply("committed-fixture"));
+        let mut record =
+            CachedModelClient::new(inner, tmp.path(), "ns/v1", CacheMode::Record).unwrap();
+        record.call(&req("hi")).unwrap();
+    }
+
+    // A replay-only cache serves (possibly committed) fixtures; a failing run
+    // calling invalidate must not be able to delete them.
+    let mut replay =
+        CachedModelClient::new(NeverCallsClient, tmp.path(), "ns/v1", CacheMode::ReplayOnly)
+            .unwrap();
+    replay.invalidate(&req("hi"));
+    assert_eq!(replay.call(&req("hi")).unwrap().text, "committed-fixture");
+}


### PR DESCRIPTION
## What

The two P1s from the 2026-07-01 pre-dogfood deep review — both silently broke the daily loop's failure-recovery story on live runs. **Stacked on #280** (retarget/merge after it lands).

### 1. Bad-cassette pinning killed retry semantics

The live client records replies BEFORE downstream validation, and request keys are pure content hashes. A reply that transported fine but carried unusable content (truncated JSON, 0 units, grounding violation, 0 cards) was replayed verbatim by every retry — `daily`'s 3-strikes retries and `--retry-blocked` could never succeed; sources got blocked after 3 no-op attempts.

Fix: `ModelClient::invalidate(request)` (default no-op) + `CachedModelClient` impl = cassette+memo removal in **Record mode only** (ReplayOnly fixtures are untouchable — a failing test can never delete committed cassettes). Called at every content-failure gate:
- reader truth-layer gate (units + json-repair + critic requests)
- reader card-layer gate (cards + json-repair requests)
- crystal-synth: unrecoverable JSON **and** structurally-rejected valid JSON (codex P2)

Transport failures were never recorded, so their replay-resume behavior is unchanged — a retry still replays completed good stages for free and only re-asks the failed stage.

### 2. Stale run.lock blocked every later run

Release was Drop-only (Ctrl-C runs no destructors) and acquire never probed the recorded owner PID — one interrupted run blocked every subsequent `daily` until manual lock deletion.

Fix: on AlreadyExists, probe the owner (`kill -0`); a verifiably-dead owner is reclaimed **under an exclusive reclaim guard** with a staleness re-check, so all deletions of `run.lock` are serialized and a racer can never delete a freshly re-created lock (codex P1 on the first draft — fixed; the losing racer takes the in-progress error). A guard stranded mid-reclaim is recovered by the same dead-owner rule. Conservative on every uncertainty (unreadable PID / probe failure / non-unix): refuse, as before.

## Tests

+7: record-invalidate re-records / replay-invalidate never deletes fixtures; pipeline day-1-fail→day-2-retry-succeeds regression for truth-layer and card layer; RunLock stale reclaim / live-owner+garbage refuse / stranded-guard recovery.

## Gates

- `cargo test --workspace`: 689 passed
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `scripts/check_architecture.sh`: pass
- local codex review: initial P1 (guard race) + P2 (structural parse pinning) fixed in this commit