### PR TITLE
docs: M34 substrate hypotheses + product-pipeline map (system-design anchors)

### DIFF
--- a/docs/product-pipeline.md
+++ b/docs/product-pipeline.md
@@ -70,7 +70,7 @@ Legend — Auth: A=authority-writing, D=derived-writing. Cost: 0/L/$. Status: �
 | pinboard-sync | API/export → capture files + `pinboard-sync.jsonl` | A | 0 | ✅ | fetch-fail (retry next run) |
 | intake sweep | Clippings/00-Capture/02-Pinboard → 01-Raw, normalize | A | 0 | ✅ | needs_content · duplicate(parked) · thin/broken(flagged) |
 | dedup | URL + content-sha256 | A | 0 | ✅ | — (dupes parked, ledgered) |
-| web-fetch enrich | bare bookmarks → body | A | 0 | 🟡 wired, live unvalidated; enriched files land a day late (known bug) | fetch-fail → needs_content persists |
+| web-fetch enrich | bare bookmarks → body | A | 0 | 🟡 wired, live unvalidated; same-run vs next-run reader pickup needs fixture verification | fetch-fail → needs_content persists |
 | github enrich | repo URLs → README/metadata | A | 0 | 🟡 wired, live unvalidated | api-fail → unenriched, readable anyway |
 | image/attachment | download to attachments, source hash untouched | A | 0 | 🟡 wired (Phase 4.5), live unvalidated | 404/timeout behavior undefined — validate |
 | paper route | arXiv → dedicated reader? | — | — | ⬜ decision pending (M32 §11 A/B) | — |

--- a/docs/product-pipeline.md
+++ b/docs/product-pipeline.md
@@ -31,7 +31,12 @@ become a second, unverified truth store.
    - **Event ledgers** (`.ovp/*.jsonl`, `60-Logs/pipeline.jsonl`) — what happened, in order.
    - **Reader packs** (`40-Resources/Reader/<case>/`, esp. `units.accepted.json`) — the EVIDENCE
      authority. Claims cite into packs; deleting a pack severs citation chains. (Correction to the
-     "crystal ledger is the only authority" framing: packs are co-equal.)
+     "crystal ledger is the only authority" framing: packs are co-equal.) A pack is an evidence
+     *artifact*, not a ledger, so "append-only" is not a sufficient contract — its **integrity
+     contract** is: pack identity bound to (source content sha, run id); `units.accepted.json`
+     present and parseable; every crystal citation back-resolvable to a pack unit and its verbatim
+     quote; and `doctor` verifies the full claim→pack→unit→quote chain. A pack failing this
+     contract counts as evidence loss, not as a stale derived view.
    - **Crystal ledger** (`.ovp/crystal/ledger.jsonl`) — the durable-knowledge authority.
    Everything else — index, console, digest, working memory, vault projections, graphs, ask
    answers — is **derived: deletable, rebuildable, forbidden to flow back into authorities**.
@@ -119,10 +124,10 @@ console/graph`.
 | index rebuild | `.ovp/index/` read model | 0 | ✅ |
 | console | `.ovp/console/` bilingual UI + graph | 0 | ✅ |
 | project --write | `10-Knowledge/Crystal/*.md` (machine-managed marker) | 0 | ✅ |
-| digest | `.ovp/digests/<date>.md` | $ | ✅ |
-| working-memory | `.ovp/working-memory.md` | $ | ✅ |
-| ask / find | on-demand answers (citation-gated) | $/0 | ✅ |
-| serve / MCP | localhost UI · MCP tools | 0 | ✅ |
+| digest | `.ovp/digests/<date>.md` — ops digest (new packs/blocked/claim counts) | 0 today · $ optional (`render_llm_digest` exists, unwired) | ✅ plain |
+| working-memory | `.ovp/working-memory.md` | 0 today | ✅ |
+| ask / find | on-demand answers — **retrieval-constrained, NOT truth-gated yet**: `ask` feeds index hits into the prompt and prints the model answer; no post-answer citation parser / quote verifier exists. Calling it citation-gated requires building that verifier (gap, §6) | $/0 | 🟡 |
+| serve / MCP | localhost UI · MCP tools (find/search/status + shallow doctor only; no ask/project/crystal-status) | 0 | ✅ minimal |
 
 Boundary: these can be deleted and rebuilt at any time and MUST NOT write back into authorities.
 
@@ -149,13 +154,20 @@ suffices until proven otherwise). All pipelines idempotent + crash-resumable (Ru
 reclaim; append-only ledgers; cassette-resumable model calls). **Dirty-marking is the one
 incremental mechanism** shared by index/console/synth/recluster — no pipeline invents its own.
 
-| Tier | Runs |
-|---|---|
-| per ingest | intake → dedup → enrich → reader (new/changed only) → lifecycle move → ledgers |
-| daily | index → console → digest → small incremental synth (dirty groups) → doctor summary |
-| weekly | recluster (churn-bounded) → dirty-community resynth → **review-queue session** |
-| on demand | ask · find · project · serve · MCP · compare-run |
-| on prompt change | evolve candidate → AB → cassette replay gate |
+Do not conflate what `daily` does TODAY with the mature scheduler — the gap is the work:
+
+| Tier | **Current** (`ovp-next daily` today) | **Mature scheduler** (target) |
+|---|---|---|
+| per ingest | intake → dedup → enrich(fixture-gated) → reader → lifecycle move → ledgers ✅ | same, with live-validated enrich + paper route |
+| daily | report → index → console → plain digest → working-memory | + **incremental crystal-synth on dirty groups** (entry conditions below) + doctor summary |
+| weekly | — (manual) | recluster (churn-bounded) → dirty-community resynth → **review-queue session** |
+| on demand | ask · find · project · serve · MCP · compare-run ✅ | same, with truth-gated ask |
+| on prompt change | evolve candidate → AB → cassette replay gate ✅ | same |
+
+**Entry conditions before auto-synth joins the daily tier** (it does NOT get scheduled by
+default): Stage 3a merged (full-coverage batching) · `--strict-cluster-cap` on ·
+a per-run token budget cap · the dirty-group spec implemented · synth failure states
+designed and doctor-visible. Until all five hold, crystal-synth stays a manual command.
 
 ## 5. KMEM's 12 pipelines → OVP mapping
 
@@ -164,7 +176,7 @@ incremental mechanism** shared by index/console/synth/recluster — no pipeline 
 | kg-extraction | NOT foundational; candidate = grounded anchor projection (M34 arm C-lite) |
 | community-detection | embedding grouping for synthesis batching (G3) |
 | crystallization | crystal-synth + lint + strength + write (G3, gated) |
-| insight-detection | digest today; future claim-pattern detection |
+| insight-detection | **ops digest today** (new packs/blocked/counts — NOT cross-source pattern/contradiction/emerging-topic detection); claim-pattern detection is future work |
 | evolves | claim lifecycle (G4) |
 | memory-compaction | claim dedup/strengthen/supersede — evidence itself is NEVER compacted |
 | label-consolidation | tags/labels as projections, never authority |
@@ -179,5 +191,7 @@ incremental mechanism** shared by index/console/synth/recluster — no pipeline 
 P0 (product doesn't hold long-term without): scheduler tiers (§4) · Stage 3a full-coverage synth ·
 review-queue loop with weekly cadence · doctor crystal-integrity checks.
 P1: incremental dirty-group synth · cost report · minimal lineage (dedup/strengthen) ·
+**ask truth-gating** (post-answer citation parser + quote verifier — until then `ask` is
+retrieval-constrained only) · **MCP mature surface** (ask/project/crystal-status; deep doctor) ·
 web-fetch same-run fix · UTC→local date · live validation of enrich paths · paper-route A/B.
 Gated on M34 experiment: everything in G5-undecided, supersede-by-subject, contradiction.

--- a/docs/product-pipeline.md
+++ b/docs/product-pipeline.md
@@ -1,0 +1,183 @@
+# OVP Product Pipeline Map — the mature-system design anchor
+
+**Type:** System-design anchor. Sits between the product anchor
+([`stage-m32`](./stage-m32-python-retirement-and-product-definition.md): what OVP is and why) and
+the stage docs (how/when things shipped). [`stage-m34`](./stage-m34-knowledge-substrate-design.md)
+remains a HYPOTHESIS doc for the sensemaking group and does not override this map.
+**Answers exactly one question:** what does mature OVP run — per ingest, daily, weekly, on demand —
+and for each pipeline: input, output, authority-or-derived, cost class, failure states, status today.
+**Scope boundary:** single operator, single vault. Multi-user/multi-vault is out of scope for this map.
+**Date:** 2026-07-03.
+
+---
+
+## 1. The foundation (inverted vs KMEM)
+
+```
+KMEM:  memory → LLM entity graph → community → crystal/insight     (graph is the base)
+OVP:   source → quote-backed units → gated crystal claims          (truth is the base)
+       → every surface (search, digest, graph, notes, UI) DERIVES from it
+```
+
+Entity/graph/community may become a sensemaking layer (M34 experiment decides); they can never
+become a second, unverified truth store.
+
+## 2. Architecture principles (each is load-bearing; violations are review-blockers)
+
+1. **Explicit authority set — everything else is a projection.** Authorities (append-only /
+   never-overwrite; the backup set; the ONLY inputs disaster recovery needs):
+   - **Source files** in the vault — user-owned ground truth; OVP never rewrites content, only
+     moves with collision-safe, ledgered `safe_move`.
+   - **Event ledgers** (`.ovp/*.jsonl`, `60-Logs/pipeline.jsonl`) — what happened, in order.
+   - **Reader packs** (`40-Resources/Reader/<case>/`, esp. `units.accepted.json`) — the EVIDENCE
+     authority. Claims cite into packs; deleting a pack severs citation chains. (Correction to the
+     "crystal ledger is the only authority" framing: packs are co-equal.)
+   - **Crystal ledger** (`.ovp/crystal/ledger.jsonl`) — the durable-knowledge authority.
+   Everything else — index, console, digest, working memory, vault projections, graphs, ask
+   answers — is **derived: deletable, rebuildable, forbidden to flow back into authorities**.
+   *Projection is not truth. Digest is not truth. Working memory is not truth. An ask answer is
+   not truth.*
+2. **Read/write split.** Authorities are the write side (append-only). All user surfaces read
+   from derived read models rebuilt from authorities (`index` is the canonical rebuild). This is
+   what makes "what can I delete?" and "how do I recover?" trivial questions.
+3. **Every pipeline is idempotent, crash-resumable, and has ENUMERATED failure states** surfaced
+   in doctor + console. Learned the hard way (2026-07 review: cassette pinning, stale locks, torn
+   ledger lines, orphan packs — all "failure state nobody designed"). A pipeline without a
+   written failure table is not done.
+4. **Cost class is a pipeline property.** Three classes: `0` zero-token (fs/deterministic),
+   `L` local compute (embeddings), `$` LLM-spending. The daily loop's `$` spend is bounded and
+   reported (cost-report pipeline). New `$` pipelines need justification.
+5. **Contracts at group boundaries are versioned.** `units.accepted.json`, claim records, ledger
+   event schemas, index schema. Prompt changes already go through the evolution flow; artifact
+   schema changes get the same discipline (additive-preferred, version-marked).
+6. **Truth-gate invariants hold at every step:** `accepted_without_quote = 0`; nothing ungrounded
+   is written durable; every durable object traces to verbatim quote + line.
+
+## 3. Pipeline groups
+
+Legend — Auth: A=authority-writing, D=derived-writing. Cost: 0/L/$. Status: ✅ shipped ·
+🟡 partial · ⬜ missing.
+
+### G1 Capture / Intake — get material in, safely
+
+| Pipeline | In → Out | Auth | Cost | Status | Failure states |
+|---|---|---|---|---|---|
+| pinboard-sync | API/export → capture files + `pinboard-sync.jsonl` | A | 0 | ✅ | fetch-fail (retry next run) |
+| intake sweep | Clippings/00-Capture/02-Pinboard → 01-Raw, normalize | A | 0 | ✅ | needs_content · duplicate(parked) · thin/broken(flagged) |
+| dedup | URL + content-sha256 | A | 0 | ✅ | — (dupes parked, ledgered) |
+| web-fetch enrich | bare bookmarks → body | A | 0 | 🟡 wired, live unvalidated; enriched files land a day late (known bug) | fetch-fail → needs_content persists |
+| github enrich | repo URLs → README/metadata | A | 0 | 🟡 wired, live unvalidated | api-fail → unenriched, readable anyway |
+| image/attachment | download to attachments, source hash untouched | A | 0 | 🟡 wired (Phase 4.5), live unvalidated | 404/timeout behavior undefined — validate |
+| paper route | arXiv → dedicated reader? | — | — | ⬜ decision pending (M32 §11 A/B) | — |
+
+Principles: source identity stable · never overwrite user content · never lose data.
+
+### G2 Grounded Reader — source → verifiable units (the moat's first half)
+
+| Pipeline | In → Out | Auth | Cost | Status | Failure states |
+|---|---|---|---|---|---|
+| read-source | source → spans/lines → units → quote validation → critic repair → cards → pack | **A (packs)** | $ | ✅ (994/1012 on real corpus) | transport(retry-free via cassette) · truth-layer(unit/card json, 0-units, grounding) — bad replies un-pinned since Stage 0.5 · context_window · no_text_blocks |
+
+Requirements at maturity: every accepted unit has a verbatim, findable quote; attribution/modality
+preserved; the pack is a user-facing product, not intermediate data. This is where OVP diverges
+from KMEM: their memory is a self-contained summary; our unit is an evidence-anchored fragment.
+
+### G3 Crystal Truth — units → durable knowledge (the moat's second half)
+
+| Pipeline | In → Out | Auth | Cost | Status | Failure states |
+|---|---|---|---|---|---|
+| grouping | packs → clusters/communities | D | L (target) / 0 (today) | 🟡 keyword buckets falsified at scale; embeddings = M34 decided, S1 pending | cap-overflow (warned + strict gate since Stage 0) · title-fallback |
+| crystal-synth | clusters → candidate claims | D | $ | 🟡 works; full coverage needs Stage 3a map-reduce | unrecoverable JSON (un-pinned) · cluster truncation |
+| citation-lint | candidate → per-citation verbatim check | D | 0 | ✅ | defect → claim dropped, audited |
+| strength-judge | grounded claims → supported/caveated/reject | D | $ | ✅ (batched; chunking = Stage 3a) | incomplete coverage → fail-loud |
+| crystal-write | durable claims → ledger, append-only, idempotent | **A** | 0 | ✅ | — (gate unsatisfied = no write) |
+
+### G4 Review / Lifecycle — uncertainty and evolution, at the CLAIM layer
+
+| Pipeline | In → Out | Auth | Cost | Status | Failure states |
+|---|---|---|---|---|---|
+| review-queue | caveated/reject → human decision → revised candidate → RE-GATE | A (via write) | 0+human | 🟡 `crystal-review` exists, NOT in the loop — **unbounded-growth rot vector** (6 caveated already) | stale queue (needs weekly SLA) |
+| lineage: dedup/strengthen | new claims vs active (text+citation overlap+grouping) | A (via write) | 0/$ | ⬜ near-term, minimal form | wrong-merge (conservative default: append) |
+| supersede | strengthened claim replaces old, `superseded_by` | A | 0 | ⬜ mid-term | — |
+| contradiction | opposing claims, same subject | A | $ | ⬜ long-term; needs stable subject — **M34 experiment decides** | — |
+
+Rule: no entity ledger before the M34 verdict; lifecycle starts in its minimal viable form.
+
+### G5 Sensemaking — understand a corpus (decided vs undecided kept separate)
+
+Decided: embeddings-for-grouping (L) · communities for synthesis batching · crystal view ·
+search/ask/digest over the index · graph visualization over claims+evidence (✅ M33 console SPA).
+Undecided (M34 four-arm experiment): durable entities/anchors · promotion ladder ·
+entity-based lifecycle · query-time aggregation as the primary reuse surface (arm D).
+Default mature route until data says otherwise: `claims + evidence → index → find/ask/digest →
+console/graph`.
+
+### G6 Projection / Output — what the user touches daily (ALL derived)
+
+| Pipeline | Out | Cost | Status |
+|---|---|---|---|
+| index rebuild | `.ovp/index/` read model | 0 | ✅ |
+| console | `.ovp/console/` bilingual UI + graph | 0 | ✅ |
+| project --write | `10-Knowledge/Crystal/*.md` (machine-managed marker) | 0 | ✅ |
+| digest | `.ovp/digests/<date>.md` | $ | ✅ |
+| working-memory | `.ovp/working-memory.md` | $ | ✅ |
+| ask / find | on-demand answers (citation-gated) | $/0 | ✅ |
+| serve / MCP | localhost UI · MCP tools | 0 | ✅ |
+
+Boundary: these can be deleted and rebuilt at any time and MUST NOT write back into authorities.
+
+### G7 Ops / Maintenance — keep it runnable for years
+
+| Pipeline | Mature duty | Cost | Status |
+|---|---|---|---|
+| doctor | ledger↔fs consistency · orphan packs · stale index · **crystal integrity (claim→pack citation chains)** | 0 | 🟡 exists; crystal-chain + orphan checks to add |
+| retry/blocked | failed sources, 3-strikes, `--retry-blocked` (real retries since Stage 0.5) | 0 | ✅ |
+| evolution | prompt/parser/gate changes: candidate spec + AB + ledger + rollback | $ | ✅ |
+| cassette replay | regression: replay recorded model IO | 0 | ✅ |
+| cost report | per-run/per-pipeline token + wall-time + failure distribution | 0 | ⬜ |
+| periodic recluster | regroup for synthesis; NEVER silently rewrites truth | L | ⬜ (with dirty-marking) |
+| scheduler | the single entry that sequences everything below | 0 | ⬜ (today: manual `daily` + hand-run commands) |
+
+OVP maintenance ≠ KMEM compaction. Ours is: keep evidence chains intact · keep derived views
+rebuildable · keep failures explainable · keep prompt evolution rollbackable. Evidence is never
+compacted.
+
+## 4. Orchestration (the layer that makes it a product, not a CLI collection)
+
+Design: **batch, single-entry, tiered scheduling** — not a daemon (M32: cron over `daily`
+suffices until proven otherwise). All pipelines idempotent + crash-resumable (RunLock with stale
+reclaim; append-only ledgers; cassette-resumable model calls). **Dirty-marking is the one
+incremental mechanism** shared by index/console/synth/recluster — no pipeline invents its own.
+
+| Tier | Runs |
+|---|---|
+| per ingest | intake → dedup → enrich → reader (new/changed only) → lifecycle move → ledgers |
+| daily | index → console → digest → small incremental synth (dirty groups) → doctor summary |
+| weekly | recluster (churn-bounded) → dirty-community resynth → **review-queue session** |
+| on demand | ask · find · project · serve · MCP · compare-run |
+| on prompt change | evolve candidate → AB → cassette replay gate |
+
+## 5. KMEM's 12 pipelines → OVP mapping
+
+| KMEM | OVP counterpart |
+|---|---|
+| kg-extraction | NOT foundational; candidate = grounded anchor projection (M34 arm C-lite) |
+| community-detection | embedding grouping for synthesis batching (G3) |
+| crystallization | crystal-synth + lint + strength + write (G3, gated) |
+| insight-detection | digest today; future claim-pattern detection |
+| evolves | claim lifecycle (G4) |
+| memory-compaction | claim dedup/strengthen/supersede — evidence itself is NEVER compacted |
+| label-consolidation | tags/labels as projections, never authority |
+| unit-type-reclassification | unit/card type refinement via evolution flow |
+| decay-refresh | derived ranking scores in query/digest — no truth decay |
+| daily-briefing | digest + working-memory (G6) |
+| wm-refresh | working-memory projection (G6) |
+| rule/skill review | out of scope unless OVP extends to agent-ops |
+
+## 6. Gap list — current → mature (the actionable part)
+
+P0 (product doesn't hold long-term without): scheduler tiers (§4) · Stage 3a full-coverage synth ·
+review-queue loop with weekly cadence · doctor crystal-integrity checks.
+P1: incremental dirty-group synth · cost report · minimal lineage (dedup/strengthen) ·
+web-fetch same-run fix · UTC→local date · live validation of enrich paths · paper-route A/B.
+Gated on M34 experiment: everything in G5-undecided, supersede-by-subject, contradiction.

--- a/docs/stage-m32-python-retirement-and-product-definition.md
+++ b/docs/stage-m32-python-retirement-and-product-definition.md
@@ -171,6 +171,10 @@ workbench (human+LLM judged). The only prior result is the 20 curated cases (§2
 - [x] **RAG — lexical is the product; semantic embeddings deferred (not permanently cut).** Reuse
       surface = `ask` / `find` / `digest` over the JSON index (lexical). Add BM25+embedding+RRF
       only if daily query pain proves the need.
+      *(2026-07-02: the "revisit if proven" clause was exercised for the **synthesis grouping
+      layer** — 87% cluster-cap drop + 40% misc on the full corpus. See
+      [`stage-m34-knowledge-substrate-design.md`](./stage-m34-knowledge-substrate-design.md).
+      The query surface stays lexical.)*
 
 ## 8. Hygiene (refactor, not features — lower priority than migration)
 

--- a/docs/stage-m34-knowledge-substrate-design.md
+++ b/docs/stage-m34-knowledge-substrate-design.md
@@ -61,10 +61,10 @@ which is an identity question, which needs a similarity substrate.
 
 ### 2b. Hypotheses — require the §7 comparative experiment before ANY implementation
 
-- **H1 (entities):** an explicit identity layer improves the student product (browse, review,
-  trust) enough to justify its machinery. Counter-hypothesis: query-time LLM aggregation over a
-  good index (arm D) delivers the same product functions with no persistent identity at all —
-  current industry practice increasingly favors compute-at-read over precomputed structure, and
+- **H1 (entities):** an explicit identity layer improves the knowledge-work product (browse,
+  review, trust) enough to justify its machinery. Counter-hypothesis: query-time LLM aggregation
+  over a good index (arm D) delivers the same product functions with no persistent identity at all
+  — current industry practice increasingly favors compute-at-read over precomputed structure, and
   a well-prompted model may simply beat a rule ladder.
 - **H2 (ladder shape):** IF entities win, the T1–T4 ladder (§5) is the right shape — and even
   then, **projection-first**: anchors derived (rebuildable) from durable claims' citations,
@@ -103,12 +103,14 @@ L1 similarity (new)             embeddings over cases/units; soft structure; con
 L2 grouping   (new)             communities on the L1 kNN graph (deterministic label
                                 propagation, sort-based tie-breaks); EPHEMERAL — exists only
                                 to feed synthesis; rebuilt freely; never user-facing identity
-L3 identity   (new, slow)       grounded entities via the T1→T4 promotion ladder (§5):
+L3 identity   (hypothesis)      grounded entities via the T1→T4 promotion ladder (§5), only if
+                                the §7 experiment selects C-lite:
                                 cheap tiers (topics/common anchors) exist from day one at
                                 zero LLM cost; durable identity ONLY through the T4
                                 evidence gate; claims subject-bind progressively
-lifecycle     (redesign)        claim lineage = (subject, intent); strengthen / append /
-                                contradict; append-only ledger + superseded_by (§6)
+lifecycle     (hypothesis)      claim lineage = (subject, intent); strengthen / append /
+                                contradict; append-only ledger + superseded_by (§6), otherwise
+                                retrieval-based lineage stays the near-term mechanism
 ```
 
 Layer discipline (each layer is FORBIDDEN to do the next layer's job):
@@ -159,10 +161,13 @@ promotion *Tiers* within/toward L3. Do not conflate them.)
    including 中英 alias binding — is exclusively a T4 operation**, done only on co-mention evidence
    + embedding candidacy + judge, never model assertion alone. This is what makes T1/T2 safe at
    zero LLM cost: common sense needs no proof because low tiers assert no identity.
-2. **Genericity ceiling (deterministic).** A surface form whose document frequency exceeds a
-   corpus threshold (`AI`, `agent`, `context`, `模型`…) is capped at T1 forever and never enters
-   the candidate queue. Zero tokens, pure statistics — this is the guard KMEM lacks (its live
-   graph carries `context`/`Agent`/`Skills` as high-confidence entities; observed 2026-07-02).
+2. **Genericity ceiling (deterministic).** A naked, unqualified surface form whose document
+   frequency exceeds a corpus threshold (`AI`, `agent`, `context`, `模型`…) is capped at T1 and
+   never enters the candidate queue by itself. Scoped phrases, titles, code symbols, and
+   disambiguated anchors (`attention mechanism`, `agent architecture`, `memory system`,
+   `Attention Is All You Need`, `BGE-M3`) are scored separately and may progress to T2/T3 if their
+   own evidence supports it. Zero tokens, pure statistics — the guard is against promoting
+   undifferentiated generic words, not against core course/project concepts.
 3. **Graceful degradation of lifecycle by tier.** Claims may *display-reference* anchors of any
    tier from day one (navigation/aggregation work immediately); **supersede/contradict activate
    only when the subject is T4**. Until then, lineage falls back to soft dedup
@@ -181,11 +186,13 @@ on the 994-pack corpus; batch judging puts a full-corpus pass at ~5–15 LLM cal
 incremental daily path at amortized near-zero. LLM spend concentrates exclusively on high-value
 candidates at the T3→T4 boundary.
 
-**Relations need no extractor — the claim IS the edge.** A durable claim citing units under two
-anchors is an evidence-backed edge between them, by construction. The graph is
-entity–claim–entity with every edge quote-chained. KMEM must ask the LLM for
-`{relationships}` (unevidenced); OVP gets a stronger graph structurally, for free. A separate
-relation-extraction stage is a **non-goal** (§9).
+**Relation extraction remains unproven; C-lite tests whether claims can serve as edges.** In the
+candidate-C design, a durable claim citing units under two anchors can be projected as an
+evidence-backed edge between them. That would give an entity–claim–entity graph where every edge
+quote-chains through the claim, without a separate LLM relation extractor. Whether this provenance
+advantage creates enough user value versus KMEM-style relationship extraction is exactly what the
+§7 experiment must measure. A separate relation-extraction stage is a **non-goal** unless the
+experiment falsifies this assumption (§9).
 
 **Product surface:** users see three natural things — **Topics** (fast, allowed to be imperfect),
 **Crystals** (cross-source conclusions), **Evidence** (one click to the quote). "Durable
@@ -195,11 +202,11 @@ identity", tiers, and gates are internal mechanics, never user-facing vocabulary
 (person/org/tool… — metadata, not gate input; an open tag at most), relation extraction (see
 above), and merge/split governance UI (the append-only ledger records enough to build it later).
 
-This EXTENDS the moat rather than betraying it: "every durable thing traces to source quotes" now
-covers claims AND entities. The design sentence: **KMEM proved the product value of
-entity/community/crystal; OVP proves those can exist under quote-grounded, audit-first
-constraints** — fast tiers carry the product experience, earned identity carries the long-term
-trusted structure.
+If C-lite wins, it extends the moat rather than betraying it: "every durable thing traces to source
+quotes" would cover claims and anchors. The design sentence becomes: **KMEM demonstrates the
+product value of entity/community/crystal surfaces; OVP must prove those surfaces can exist under
+quote-grounded, audit-first constraints** — fast tiers carry the product experience, earned
+identity carries the long-term trusted structure.
 
 **Kill criterion:** if S2 (§7) fails human check the way M13 did, T3/T4 stay out (T1/T2 are
 harmless and keep working), this section is marked DEAD, and we document why bottom-up +
@@ -261,7 +268,7 @@ One experiment replaces the former S2/S3 mechanism-spikes. S1 is kept (it serves
   AND ≥3 genuinely bilingual communities. Baseline: keyword buckets on the same sample.
 
 - **S2′ — four-arm product comparison** on 50–100 real historical sources (papers, web, notes,
-  GitHub, 中文材料 — the student mix), artifacts under `.run/m34-spikes/`:
+  GitHub, 中文材料 — a general knowledge-work mix), artifacts under `.run/m34-spikes/`:
   - **A — KMEM-style:** memory → LLM entity/relations → community → crystal summary. Use the live
     Nowledge instance where its 0.9.1 stability allows; fall back to existing captures (M21/M26
     machinery) — sample size may shrink, record it.
@@ -275,7 +282,8 @@ One experiment replaces the former S2/S3 mechanism-spikes. S1 is kept (it serves
     LLM that aggregates "everything about X" / "what does this corpus say" on demand, answers
     verified through the existing citation gate. The "a good prompt beats a rule ladder"
     null-hypothesis arm.
-  - **Task-anchored metrics** (student tasks, reusing the M26 workbench pattern; human-judged):
+  - **Task-anchored metrics** (knowledge-work tasks, reusing the M26 workbench pattern;
+    human-judged):
     "这批资料讲了什么" comprehension speed/quality · important-concept recall vs a human
     reference list (precision AND recall) · wrong-merge count · unsupported-claim count ·
     crystal→quote traceability (one click, verbatim) · token cost per source and per query ·

--- a/docs/stage-m34-knowledge-substrate-design.md
+++ b/docs/stage-m34-knowledge-substrate-design.md
@@ -86,10 +86,12 @@ Derived from product functions, not from technology choices:
 | Claim lifecycle: supersede / contradiction | No — content-hash too strict, cosine too soft; needs "same subject, same intent" structure | **Yes** |
 | Grouping for synthesis | **Yes** — communities suffice; identity not required here | No |
 
-Conclusion: a **read-only reader** product needs no entities; a product that promises
-ask/digest/browse over a **continuously growing** library — ours, per the M32 product definition —
-cannot ship those functions without an identity layer. Entities are required by the product, not
-by the graph technology.
+What this table establishes — and its limit: a **read-only reader** product needs no entities,
+and several functions of a growing ask/digest/browse product plausibly want identity. But this is
+a **functional argument, not a product verdict**: arm D of the §7 experiment (query-time LLM
+aggregation over a good index, answers verified post-hoc) may deliver the same functions with no
+persistent identity at all. This table MOTIVATES hypothesis H1; it does not decide it. No agent
+may cite this section as justification for implementing an entity layer ahead of the §7 verdict.
 
 ## 4. The four-layer substrate
 
@@ -134,10 +136,11 @@ What M13/M14b actually falsified (0/3 on real models): **eager** extraction at i
 ontology** (MOC/Atlas/evergreen). What it did not test: entities subjected to the same evidence
 discipline that makes claims durable.
 
-**But "every entity must be earned" does not productize** (operator review, 2026-07-02): a student
-importing ONE lecture PDF must immediately see browsable topics; common-sense proper nouns
-(`Qdrant`, `BGE-M3`, `Attention Is All You Need`) must not wait for a ≥3-source gate; and judging
-every mention with an LLM explodes token cost. The answer is not loosening the durable gate — it
+**But "every entity must be earned" does not productize** (operator review, 2026-07-02): the
+target user is a **general knowledge worker** (the student is one archetype scenario, not the
+product boundary) — someone importing ONE document must immediately see browsable topics;
+common-sense proper nouns (`Qdrant`, `BGE-M3`, `Attention Is All You Need`) must not wait for a
+≥3-source gate; and judging every mention with an LLM explodes token cost. The answer is not loosening the durable gate — it
 is a **promotion ladder**. (Terminology: L0–L3 are the substrate *Layers*; T1–T4 below are the
 promotion *Tiers* within/toward L3. Do not conflate them.)
 
@@ -309,8 +312,10 @@ Failed arm → its layer is not built; this document is amended with the evidenc
 - MOC/Atlas/evergreen revival; eager ingest-time concept extraction; ConceptRegistry as authority.
 - Importing KMEM's KG/relations as a dependency (eval-only stays eval-only).
 - Vector DB service, graph DB, or any new daemon.
-- **A relation-extraction stage** — the claim is the edge (§5); LLM-asserted, unevidenced
-  `{relationships}` à la KMEM are structurally inferior to entity–claim–entity and are not built.
+- **A relation-extraction stage** — IF an anchor layer is ever built (§7 verdict pending), edges
+  come from claims (entity–claim–entity, quote-chained by construction) rather than a separate
+  LLM relation extractor. Whether that provenance advantage over KMEM-style `{relationships}`
+  translates into USER value is exactly what S2′ measures — it is not assumed here.
 - **Entity type taxonomy and merge/split governance UI in v1** (§5 cuts).
 - **Per-mention LLM judging** — LLM spend is confined to batched T3→T4 judgments.
 

--- a/docs/stage-m34-knowledge-substrate-design.md
+++ b/docs/stage-m34-knowledge-substrate-design.md
@@ -6,7 +6,9 @@ is the product anchor). NOT a feature epic; implementation is gated on the exper
 decisions from **hypotheses**. The entity ladder (§5) is a HYPOTHESIS — candidate design C —
 awaiting the §7 comparative experiment. Nothing in §5 may be implemented before that verdict.
 **Companions:** [`stage-m32-python-retirement-and-product-definition.md`](./stage-m32-python-retirement-and-product-definition.md) ·
-2026-07-02 full-corpus evidence in `.run/m32-stage123-20260702/` (gitignored, operator machine).
+[`product-pipeline.md`](./product-pipeline.md) (the mature-system pipeline map; this doc covers
+only its G5-undecided box) · 2026-07-02 full-corpus evidence in `.run/m32-stage123-20260702/`
+(gitignored, operator machine).
 
 > **Read this first.** This document re-opens "does OVP need entities?" — but its first draft
 > repeated the M7–M13 process failure: designing mechanism (ladders, invariants, ledgers) before

--- a/docs/stage-m34-knowledge-substrate-design.md
+++ b/docs/stage-m34-knowledge-substrate-design.md
@@ -1,0 +1,193 @@
+# Stage M34 — Knowledge Substrate Design: similarity · grouping · identity · lifecycle
+
+**Type:** Architecture design anchor (like [`stage-m32`](./stage-m32-python-retirement-and-product-definition.md)
+is the product anchor). NOT a feature epic; implementation is gated on the spikes in §7.
+**Status:** Direction operator-approved 2026-07-02. Spikes not yet run.
+**Companions:** [`stage-m32-python-retirement-and-product-definition.md`](./stage-m32-python-retirement-and-product-definition.md) ·
+2026-07-02 full-corpus evidence in `.run/m32-stage123-20260702/` (gitignored, operator machine).
+
+> **Read this first.** This document deliberately re-opens one settled-looking question — "does OVP
+> need entities?" — from first principles, at the operator's direction. The M13 demotion is NOT
+> re-litigated as a *method* verdict (eager, ungrounded ontology stays dead); §5 explains precisely
+> what is different this time and §7-S2 defines the experiment that decides it.
+
+---
+
+## 1. Why now — the evidence
+
+The 2026-07-02 full-corpus run (994/1012 reader packs) proved the current synthesis grouping is a
+pilot artifact, not an architecture:
+
+- **87% hard-dropped**: keyword buckets gave agents=335 / misc=403 / coding=96 vs
+  `max_cases_per_cluster=16` — ~866 of 994 cases were excluded from synthesis entirely.
+- **40% in `misc`**: the fixed 8-bucket English taxonomy cannot even fit today's corpus, let alone
+  the product scenario (a user's vault with **dozens to hundreds of concurrent topics**).
+- **Bilingual corpus**: Chinese and English sources on the same topic share almost no lexical
+  tokens — any lexical grouping fails across the language boundary.
+- Batching alone (Stage 3a) fixes *coverage*, not *quality*: batches inside `misc` are random
+  seatings of unrelated sources; cross-source synthesis over unrelated sources yields forced or
+  empty claims.
+
+Three problems raised in review turned out to be one architecture problem:
+**embeddings (similarity), entities (identity), and claim lifecycle (time)** — because
+supersede/contradiction detection requires deciding "are these two claims about the same thing",
+which is an identity question, which needs a similarity substrate.
+
+## 2. Decisions (operator-approved 2026-07-02)
+
+1. **Embeddings: YES** — local multilingual model (bge-m3 / multilingual-e5 class; runnable via
+   qmd/ollama), as **internal, rebuildable synthesis infrastructure**, NOT the query surface.
+   Vectors are content-hash cached on disk (same discipline as cassettes; provider swappable).
+   This exercises M32 §9's "deferred, not cut — revisit only if real usage proves the need"
+   clause: 87% drop + 40% misc IS the proof. M32 §7's "RAG — lexical is the product" stays true
+   for the **query/reuse surface** (`ask`/`find`/`digest` remain lexical).
+2. **Entities: YES, as *earned identity*** (§4 L3, §5) — gated the same way claims are. Eager
+   extraction, model-as-identity-authority, and ontology-first product surfaces stay dead.
+3. **Claim lifecycle**: lineage keyed by (subject, intent); strengthen / append / contradict
+   lanes; the store invariant migrates from batch-replay determinism to **event-sourced
+   auditability** (§6).
+4. **No vector DB service (qdrant etc.) for now** — in-memory kNN over cached vectors is enough at
+   10^3–10^4 cases. Same pain-proves-need discipline as the M31 NO-SQLite decision. Qdrant remains
+   the designated L1 backend IF scale proves the pain.
+
+## 3. First-principles: does a growing knowledge base need entities?
+
+Derived from product functions, not from technology choices:
+
+| Function | Can similarity (embeddings) deliver it? | Needs identity? |
+|---|---|---|
+| Aggregation: "everything about X" | No — similarity is soft, thresholded, non-referable; you cannot "click open" a similarity blob | **Yes** |
+| Stable navigation anchors | No — communities shift on every re-cluster; last month's "community #7" is gone | **Yes** |
+| Cross-language binding (中英 same thing) | Candidate signal only — cosine proximity is not sameness | **Yes** (evidence-adjudicated) |
+| Claim lifecycle: supersede / contradiction | No — content-hash too strict, cosine too soft; needs "same subject, same intent" structure | **Yes** |
+| Grouping for synthesis | **Yes** — communities suffice; identity not required here | No |
+
+Conclusion: a **read-only reader** product needs no entities; a product that promises
+ask/digest/browse over a **continuously growing** library — ours, per the M32 product definition —
+cannot ship those functions without an identity layer. Entities are required by the product, not
+by the graph technology.
+
+## 4. The four-layer substrate
+
+```
+L0 truth      (exists, FROZEN)  units: verbatim quote + line; fail-loud gate; the moat
+L1 similarity (new)             embeddings over cases/units; soft structure; content-hash
+                                cached; rebuildable at any time; carries NO identity, NO
+                                authority, writes NO product state
+L2 grouping   (new)             communities on the L1 kNN graph (deterministic label
+                                propagation, sort-based tie-breaks); EPHEMERAL — exists only
+                                to feed synthesis; rebuilt freely; never user-facing identity
+L3 identity   (new, slow)       grounded entities: mined bottom-up from repeated L1/L2
+                                cohesion; durable ONLY through the entity-write gate (§5);
+                                claims reference entities via subject binding
+lifecycle     (redesign)        claim lineage = (subject, intent); strengthen / append /
+                                contradict; append-only ledger + superseded_by (§6)
+```
+
+Layer discipline (each layer is FORBIDDEN to do the next layer's job):
+
+- **L1 must not name things.** Cosine similarity is never presented as "same as".
+- **L2 must not persist.** Communities are synthesis batching input; they never become browsable
+  product objects (that is L3's job, gated).
+- **L3 must not be eager.** No entity is minted at ingest time; entities emerge from repeated,
+  cross-source, quote-anchored mentions and pass a gate. The model proposes; evidence disposes.
+- **Execution layer (Stage 3a: sub-batching, reduce/dedup, chunked strength) is orthogonal** and
+  ships first — it is the machinery under ANY grouping mechanism (KMEM's "crystal from 3+ related
+  memories" is also a bounded group).
+
+## 5. Entities: earned identity, and the boundary with M13
+
+What M13/M14b actually falsified (0/3 on real models): **eager** extraction at ingest +
+**model-as-identity-authority** (no evidence gate) + **product surfaces stacked on the ungrounded
+ontology** (MOC/Atlas/evergreen). What it did not test: entities subjected to the same evidence
+discipline that makes claims durable. Claims earn durability (verbatim quote, ≥2 sources,
+strength gate, fail-loud); entities were never given the equivalent.
+
+**Entity-write gate (draft, to be calibrated in S2):** an entity candidate becomes durable only
+when ALL hold:
+
+- mentions in **≥3 sources**, each mention bound to a verbatim quote + line (the units already
+  carry these);
+- **stable surface forms** across time (not a one-week flash), aliases (incl. 中英) bound only by
+  co-mention evidence + embedding candidacy, never by model assertion alone;
+- passes an entity-strength judgment (model-assisted, evidence-quoted, same shape as
+  `crystal_strength`);
+- append-only entity ledger with full provenance (who/what/when/quotes), idempotent by entity key.
+
+This EXTENDS the moat rather than betraying it: "every durable thing traces to source quotes" now
+covers claims AND entities — a stronger differentiation vs KMEM, not a weaker one.
+
+**Kill criterion:** if S2 (§7) fails human check the way M13 did, entities stay out, this section
+is marked DEAD, and we document why bottom-up + evidence-gated was still not enough. The
+demotion of eager ontology is permanent either way.
+
+## 6. Incremental architecture + claim lifecycle
+
+Steady-state event flow (replaces "one global batch run" as the primary mode):
+
+```
+new source → units (L0) → embed (L1, cache) → incremental community assignment (L2)
+  → mark dirty communities (membership churn > threshold)
+  → re-synthesize ONLY dirty communities (Stage 3a machinery: batches → reduce → strength)
+  → lineage adjudication per output claim vs active claims of that community/subject:
+      same finding, more/better citations  → STRENGTHEN: append new version, mark old superseded_by
+      genuinely new finding                → APPEND
+      opposing finding, same subject       → CONTRADICT lane (M32's deferred contradiction
+                                             detection returns here as a lifecycle branch, not
+                                             a separate feature)
+  → append-only ledger; nothing is ever deleted or rewritten
+periodic full re-cluster = maintenance action (churn-bounded, never mid-day), not the daily path
+```
+
+**Invariant shift (stated explicitly):** today's guarantee is batch determinism via cassette
+replay. In the incremental world, global state depends on arrival order; the invariant becomes
+**event-sourced auditability** — every mutation is a ledger event; any lineage's history is
+replayable end-to-end; `accepted_without_quote=0` and the crystal gates hold at every step. This
+matches the existing append-only posture (OVP_RULES) and must be enforced by review going forward.
+
+**Lineage key problem** (the hard part, decided by S3): lineage = (subject entity, normalized
+intent). Until L3 exists, an interim lineage key of (community, claim-embedding proximity +
+citation overlap) is acceptable for strengthen/dedup but NOT for contradiction (too soft) — one
+more reason lifecycle depends on identity.
+
+## 7. Spikes — data decides, before any product code
+
+All three run offline on the real 994-pack corpus; artifacts under `.run/m34-spikes/` (never /tmp).
+
+- **S1 — community quality (L1/L2).** Embed 994 cases (title + representative units) → kNN →
+  deterministic communities. Accept iff: 20 sampled communities show **≥80% member topical
+  coherence** (human-judged) AND **≥3 genuinely bilingual communities** exist (中英 same-topic
+  sources actually co-clustered). Compare directly against keyword-bucket assignment on the same
+  sample.
+- **S2 — entity candidates (the M13 counterfactual).** Bottom-up mining: recurring quote-anchored
+  mention clusters across ≥3 sources → candidates with evidence chains. Accept iff **≥80% of 20
+  sampled candidates** are judged "a real thing worth aggregating by" AND alias binding (incl. one
+  中英 pair) is correct. Explicitly contrast with M13's 0/3: same corpus family, opposite method.
+- **S3 — claim lineage.** Take the 22 (repro) + 19 (capped full run) durable claims; simulate a
+  second synthesis pass; hand-label ground truth; measure lineage adjudication
+  (strengthen/append) accuracy — accept at **≥90%**. Contradiction lane is measured but not
+  gated (needs L3).
+
+Failed spike → the corresponding layer does not get built; this document is amended with the
+evidence. Passed spikes → Stage 3b (L1/L2 productization), Stage 3c (L3 + lifecycle), each a
+normal PR-gated stage.
+
+## 8. Execution order
+
+1. **Stage 3a (independent, ships first):** map-reduce execution layer — deterministic sub-batches
+   per cluster → per-batch `crystal_synth/v1` → deterministic citation-overlap dedup → chunked
+   strength (≤20 claims/call). Gives the current corpus a full-coverage crystal store NOW and is
+   the machinery under any future grouping. (A model `crystal_merge/v1` reduce is added only if
+   the deterministic dedup's residual duplicate rate proves the need — via the evolution flow.)
+2. **S1 → S2 → S3 spikes** (offline, no product writes).
+3. **Stage 3b:** replace keyword buckets with L1/L2 communities behind the same crystal-synth CLI.
+4. **Stage 3c:** L3 entity gate + lineage/supersede ledger semantics + contradiction lane.
+5. M32 Level-3 exit criterion #3 ("crystallize the full corpus") is satisfied by Stage 3a
+   coverage; quality re-crystallization after 3b is a product improvement, not a retirement gate.
+
+## 9. Non-goals (unchanged or newly explicit)
+
+- Query-surface semantic RAG (ask/find/digest stay lexical until query pain proves otherwise).
+- MOC/Atlas/evergreen revival; eager ingest-time concept extraction; ConceptRegistry as authority.
+- Importing KMEM's KG/relations as a dependency (eval-only stays eval-only).
+- Vector DB service, graph DB, or any new daemon.

--- a/docs/stage-m34-knowledge-substrate-design.md
+++ b/docs/stage-m34-knowledge-substrate-design.md
@@ -77,9 +77,10 @@ L1 similarity (new)             embeddings over cases/units; soft structure; con
 L2 grouping   (new)             communities on the L1 kNN graph (deterministic label
                                 propagation, sort-based tie-breaks); EPHEMERAL — exists only
                                 to feed synthesis; rebuilt freely; never user-facing identity
-L3 identity   (new, slow)       grounded entities: mined bottom-up from repeated L1/L2
-                                cohesion; durable ONLY through the entity-write gate (§5);
-                                claims reference entities via subject binding
+L3 identity   (new, slow)       grounded entities via the T1→T4 promotion ladder (§5):
+                                cheap tiers (topics/common anchors) exist from day one at
+                                zero LLM cost; durable identity ONLY through the T4
+                                evidence gate; claims subject-bind progressively
 lifecycle     (redesign)        claim lineage = (subject, intent); strengthen / append /
                                 contradict; append-only ledger + superseded_by (§6)
 ```
@@ -95,31 +96,80 @@ Layer discipline (each layer is FORBIDDEN to do the next layer's job):
   ships first — it is the machinery under ANY grouping mechanism (KMEM's "crystal from 3+ related
   memories" is also a bounded group).
 
-## 5. Entities: earned identity, and the boundary with M13
+## 5. Entities: a promotion ladder toward earned identity (revised 2026-07-02, operator review)
 
 What M13/M14b actually falsified (0/3 on real models): **eager** extraction at ingest +
 **model-as-identity-authority** (no evidence gate) + **product surfaces stacked on the ungrounded
 ontology** (MOC/Atlas/evergreen). What it did not test: entities subjected to the same evidence
-discipline that makes claims durable. Claims earn durability (verbatim quote, ≥2 sources,
-strength gate, fail-loud); entities were never given the equivalent.
+discipline that makes claims durable.
 
-**Entity-write gate (draft, to be calibrated in S2):** an entity candidate becomes durable only
-when ALL hold:
+**But "every entity must be earned" does not productize** (operator review, 2026-07-02): a student
+importing ONE lecture PDF must immediately see browsable topics; common-sense proper nouns
+(`Qdrant`, `BGE-M3`, `Attention Is All You Need`) must not wait for a ≥3-source gate; and judging
+every mention with an LLM explodes token cost. The answer is not loosening the durable gate — it
+is a **promotion ladder**. (Terminology: L0–L3 are the substrate *Layers*; T1–T4 below are the
+promotion *Tiers* within/toward L3. Do not conflate them.)
 
-- mentions in **≥3 sources**, each mention bound to a verbatim quote + line (the units already
-  carry these);
-- **stable surface forms** across time (not a one-week flash), aliases (incl. 中英) bound only by
-  co-mention evidence + embedding candidacy, never by model assertion alone;
-- passes an entity-strength judgment (model-assisted, evidence-quoted, same shape as
-  `crystal_strength`);
-- append-only entity ledger with full provenance (who/what/when/quotes), idempotent by entity key.
+| Tier | What | How it exists | Gate | Ledger | May subject-bind lifecycle? |
+|---|---|---|---|---|---|
+| T1 Topic | emergent browse/cluster labels | L1/L2 derived, ephemeral | none | no | no |
+| T2 Common Anchor | proper nouns, tools/models/papers/orgs, code symbols | deterministic mention mining + normalized-surface-form dedup | form heuristics only, zero LLM | no | no |
+| T3 Candidate | anchors accumulating cross-source, quote-backed mentions | auto-nominated by frequency/value filters | evidence pack assembled | not yet | no |
+| T4 Durable | identity anchors for Crystal lifecycle | batch entity-strength judge over evidence packs | strict (below) | append-only, idempotent | **yes** |
+
+**Three hard invariants across the ladder:**
+
+1. **Split-only below Durable.** T1–T3 are keyed by normalized surface form and may NEVER merge
+   across surface forms. Redundancy at low tiers is harmless ("LLM memory" and "agent memory" as
+   two topics is fine); a wrong merge is harmful and sticky. **Cross-surface-form merging —
+   including 中英 alias binding — is exclusively a T4 operation**, done only on co-mention evidence
+   + embedding candidacy + judge, never model assertion alone. This is what makes T1/T2 safe at
+   zero LLM cost: common sense needs no proof because low tiers assert no identity.
+2. **Genericity ceiling (deterministic).** A surface form whose document frequency exceeds a
+   corpus threshold (`AI`, `agent`, `context`, `模型`…) is capped at T1 forever and never enters
+   the candidate queue. Zero tokens, pure statistics — this is the guard KMEM lacks (its live
+   graph carries `context`/`Agent`/`Skills` as high-confidence entities; observed 2026-07-02).
+3. **Graceful degradation of lifecycle by tier.** Claims may *display-reference* anchors of any
+   tier from day one (navigation/aggregation work immediately); **supersede/contradict activate
+   only when the subject is T4**. Until then, lineage falls back to soft dedup
+   (community + citation overlap) for strengthen-only, as §6 already specifies. Binding is
+   progressive, never blocking.
+
+**T4 entity-write gate (draft, calibrated by S2):** mentions in ≥3 *independent* sources (same
+author/article syndicated ≠ independent), each mention bound to a verbatim quote + line; stable
+surface forms over time; evidence-bound aliases; passes a **batched** entity-strength judgment
+(20–50 candidates per call, evidence-quoted, same shape as `crystal_strength`; negative verdicts
+cached so rejected candidates are not re-judged); append-only entity ledger, idempotent by key.
+
+**Token budget (why this is affordable):** T1/T2 mining and dedup are deterministic (0 tokens);
+embeddings are local (0 API tokens); frequency/value filters cut ~30k units to O(10²) candidates
+on the 994-pack corpus; batch judging puts a full-corpus pass at ~5–15 LLM calls, and the
+incremental daily path at amortized near-zero. LLM spend concentrates exclusively on high-value
+candidates at the T3→T4 boundary.
+
+**Relations need no extractor — the claim IS the edge.** A durable claim citing units under two
+anchors is an evidence-backed edge between them, by construction. The graph is
+entity–claim–entity with every edge quote-chained. KMEM must ask the LLM for
+`{relationships}` (unevidenced); OVP gets a stronger graph structurally, for free. A separate
+relation-extraction stage is a **non-goal** (§9).
+
+**Product surface:** users see three natural things — **Topics** (fast, allowed to be imperfect),
+**Crystals** (cross-source conclusions), **Evidence** (one click to the quote). "Durable
+identity", tiers, and gates are internal mechanics, never user-facing vocabulary.
+
+**Cut from v1 (anti-over-engineering, operator-directed):** entity type taxonomy
+(person/org/tool… — metadata, not gate input; an open tag at most), relation extraction (see
+above), and merge/split governance UI (the append-only ledger records enough to build it later).
 
 This EXTENDS the moat rather than betraying it: "every durable thing traces to source quotes" now
-covers claims AND entities — a stronger differentiation vs KMEM, not a weaker one.
+covers claims AND entities. The design sentence: **KMEM proved the product value of
+entity/community/crystal; OVP proves those can exist under quote-grounded, audit-first
+constraints** — fast tiers carry the product experience, earned identity carries the long-term
+trusted structure.
 
-**Kill criterion:** if S2 (§7) fails human check the way M13 did, entities stay out, this section
-is marked DEAD, and we document why bottom-up + evidence-gated was still not enough. The
-demotion of eager ontology is permanent either way.
+**Kill criterion:** if S2 (§7) fails human check the way M13 did, T3/T4 stay out (T1/T2 are
+harmless and keep working), this section is marked DEAD, and we document why bottom-up +
+evidence-gated was still not enough. The demotion of eager ontology is permanent either way.
 
 ## 6. Incremental architecture + claim lifecycle
 
@@ -159,10 +209,17 @@ All three run offline on the real 994-pack corpus; artifacts under `.run/m34-spi
   coherence** (human-judged) AND **≥3 genuinely bilingual communities** exist (中英 same-topic
   sources actually co-clustered). Compare directly against keyword-bucket assignment on the same
   sample.
-- **S2 — entity candidates (the M13 counterfactual).** Bottom-up mining: recurring quote-anchored
-  mention clusters across ≥3 sources → candidates with evidence chains. Accept iff **≥80% of 20
-  sampled candidates** are judged "a real thing worth aggregating by" AND alias binding (incl. one
-  中英 pair) is correct. Explicitly contrast with M13's 0/3: same corpus family, opposite method.
+- **S2 — entity candidates (the M13 counterfactual).** Bottom-up mining through the T1→T3 funnel
+  (deterministic mining → genericity ceiling → frequency/value filters → evidence packs); batch
+  judge to T4. Accept iff ALL of:
+  (a) **precision** — ≥80% of 20 sampled T4 candidates judged "a real thing worth aggregating by";
+  (b) **recall** — against a human-built reference set (a person lists the identity anchors they
+  would expect from a sampled slice of the corpus BEFORE seeing system output), the funnel
+  recovers **≥70%**; precision-only would let the system flatter itself (operator requirement);
+  (c) alias binding correct, incl. at least one 中英 pair;
+  (d) **cold-start check** — on ONE single source (the student scenario), T1/T2 immediately
+  surface ≥80% of the topics/proper nouns a human lists for that source, with zero LLM calls.
+  Explicitly contrast with M13's 0/3: same corpus family, opposite method.
 - **S3 — claim lineage.** Take the 22 (repro) + 19 (capped full run) durable claims; simulate a
   second synthesis pass; hand-label ground truth; measure lineage adjudication
   (strengthen/append) accuracy — accept at **≥90%**. Contradiction lane is measured but not
@@ -191,3 +248,21 @@ normal PR-gated stage.
 - MOC/Atlas/evergreen revival; eager ingest-time concept extraction; ConceptRegistry as authority.
 - Importing KMEM's KG/relations as a dependency (eval-only stays eval-only).
 - Vector DB service, graph DB, or any new daemon.
+- **A relation-extraction stage** — the claim is the edge (§5); LLM-asserted, unevidenced
+  `{relationships}` à la KMEM are structurally inferior to entity–claim–entity and are not built.
+- **Entity type taxonomy and merge/split governance UI in v1** (§5 cuts).
+- **Per-mention LLM judging** — LLM spend is confined to batched T3→T4 judgments.
+
+## Appendix A — KMEM observed facts (2026-07-02 inspection; docs + API + live state)
+
+Recorded here because §2/§5 differentiation claims rest on them. KMEM (Nowledge Mem) pipeline:
+deterministic parse/chunk/index → LLM agent extracts 3–8 self-contained memories per source →
+entities are **post-processed** from `memory.title + memory.content` (NOT ingest-inline — note
+this matches our "never eager at ingest" principle; convergent evolution), with the LLM directly
+emitting `{name, type, description, aliases, relationships}`; dedup = FTS prefilter + LLM
+duplicate-verify + `lower(name)+entity_type` at the write layer; crystals are
+`MemoryNode(is_crystal=true)` linked `CRYSTALLIZED_FROM` source memories. **No quote/evidence-span
+storage anywhere — provenance is source/chunk- or memory-level, never verbatim-quote-level.**
+Live graph shows generic-entity pollution (`context`, `Agent`, `Skills` as high-confidence
+entities). Strengths to respect: fast, productized, rich graph, mature retrieval/visualization.
+The weakness OVP attacks: identity and claims without hard evidence chains.

--- a/docs/stage-m34-knowledge-substrate-design.md
+++ b/docs/stage-m34-knowledge-substrate-design.md
@@ -1,15 +1,24 @@
 # Stage M34 — Knowledge Substrate Design: similarity · grouping · identity · lifecycle
 
 **Type:** Architecture design anchor (like [`stage-m32`](./stage-m32-python-retirement-and-product-definition.md)
-is the product anchor). NOT a feature epic; implementation is gated on the spikes in §7.
-**Status:** Direction operator-approved 2026-07-02. Spikes not yet run.
+is the product anchor). NOT a feature epic; implementation is gated on the experiments in §7.
+**Status:** REVISED 2026-07-02 (second operator review): §2 now separates evidence-backed
+decisions from **hypotheses**. The entity ladder (§5) is a HYPOTHESIS — candidate design C —
+awaiting the §7 comparative experiment. Nothing in §5 may be implemented before that verdict.
 **Companions:** [`stage-m32-python-retirement-and-product-definition.md`](./stage-m32-python-retirement-and-product-definition.md) ·
 2026-07-02 full-corpus evidence in `.run/m32-stage123-20260702/` (gitignored, operator machine).
 
-> **Read this first.** This document deliberately re-opens one settled-looking question — "does OVP
-> need entities?" — from first principles, at the operator's direction. The M13 demotion is NOT
-> re-litigated as a *method* verdict (eager, ungrounded ontology stays dead); §5 explains precisely
-> what is different this time and §7-S2 defines the experiment that decides it.
+> **Read this first.** This document re-opens "does OVP need entities?" — but its first draft
+> repeated the M7–M13 process failure: designing mechanism (ladders, invariants, ledgers) before
+> proving product value. The operator caught it. The M13 demotion is NOT re-litigated as a
+> *method* verdict (eager, ungrounded ontology stays dead); §5 is now explicitly a **candidate
+> design**, and §7 defines the multi-arm experiment that decides between it, a KMEM-style route,
+> a no-entity route, and a query-time-aggregation route.
+>
+> **Process rule (learned twice now, M13 and this doc's first draft):** architecture docs must
+> separate evidence-backed decisions from hypotheses, and any new *persistent* state layer
+> requires a product-value experiment BEFORE design detail. Prefer projections (rebuildable
+> derived state) over ledgers until data proves statefulness is needed.
 
 ---
 
@@ -33,22 +42,35 @@ Three problems raised in review turned out to be one architecture problem:
 supersede/contradiction detection requires deciding "are these two claims about the same thing",
 which is an identity question, which needs a similarity substrate.
 
-## 2. Decisions (operator-approved 2026-07-02)
+## 2. Decisions vs hypotheses (revised 2026-07-02, second operator review)
+
+### 2a. Decisions — standing on existing evidence
 
 1. **Embeddings: YES** — local multilingual model (bge-m3 / multilingual-e5 class; runnable via
    qmd/ollama), as **internal, rebuildable synthesis infrastructure**, NOT the query surface.
    Vectors are content-hash cached on disk (same discipline as cassettes; provider swappable).
-   This exercises M32 §9's "deferred, not cut — revisit only if real usage proves the need"
-   clause: 87% drop + 40% misc IS the proof. M32 §7's "RAG — lexical is the product" stays true
-   for the **query/reuse surface** (`ask`/`find`/`digest` remain lexical).
-2. **Entities: YES, as *earned identity*** (§4 L3, §5) — gated the same way claims are. Eager
-   extraction, model-as-identity-authority, and ontology-first product surfaces stay dead.
-3. **Claim lifecycle**: lineage keyed by (subject, intent); strengthen / append / contradict
-   lanes; the store invariant migrates from batch-replay determinism to **event-sourced
-   auditability** (§6).
-4. **No vector DB service (qdrant etc.) for now** — in-memory kNN over cached vectors is enough at
-   10^3–10^4 cases. Same pain-proves-need discipline as the M31 NO-SQLite decision. Qdrant remains
-   the designated L1 backend IF scale proves the pain.
+   Evidence: 87% cap-drop + 40% misc + bilingual corpus — keyword grouping is falsified by data.
+   M32 §7's "RAG — lexical is the product" stays true for the query surface.
+2. **Stage 3a (map-reduce execution layer) ships** — needed under every candidate route.
+3. **No vector DB service** — pain-proves-need, same as NO-SQLite.
+4. **The claim-layer moat is NOT in question.** Quote-backed units + gated claims are shipped,
+   validated (M26 AB: 17/3/0, coverage 87% vs 58%, fewer factual issues), and research-aligned
+   (§X). Nothing in this document may weaken the existing gates.
+
+### 2b. Hypotheses — require the §7 comparative experiment before ANY implementation
+
+- **H1 (entities):** an explicit identity layer improves the student product (browse, review,
+  trust) enough to justify its machinery. Counter-hypothesis: query-time LLM aggregation over a
+  good index (arm D) delivers the same product functions with no persistent identity at all —
+  current industry practice increasingly favors compute-at-read over precomputed structure, and
+  a well-prompted model may simply beat a rule ladder.
+- **H2 (ladder shape):** IF entities win, the T1–T4 ladder (§5) is the right shape — and even
+  then, **projection-first**: anchors derived (rebuildable) from durable claims' citations,
+  upgraded to a stateful ledger only if projections prove insufficient.
+- **H3 (lifecycle-by-subject):** supersede/contradict need durable subjects. Near-term
+  counter-hypothesis: retrieval-based lineage (judge sees candidate duplicates + evidence at
+  synthesis time) covers strengthen/dedup without any identity layer; only contradiction —
+  already deferred — truly wants stable subjects.
 
 ## 3. First-principles: does a growing knowledge base need entities?
 
@@ -96,7 +118,14 @@ Layer discipline (each layer is FORBIDDEN to do the next layer's job):
   ships first — it is the machinery under ANY grouping mechanism (KMEM's "crystal from 3+ related
   memories" is also a bounded group).
 
-## 5. Entities: a promotion ladder toward earned identity (revised 2026-07-02, operator review)
+## 5. HYPOTHESIS — candidate design C: a promotion ladder toward earned identity
+
+> **Status: unproven.** This section is the detailed spec of candidate C in the §7 experiment —
+> kept because the invariants (split-only merging, genericity ceiling, graceful degradation) are
+> the interesting testable content. If C does not clearly beat B (no entities) in §7, this whole
+> section is marked DEAD. If it wins, implementation starts **projection-first**: anchors as a
+> rebuildable view derived from durable claims' citations — the append-only entity ledger below
+> is the LAST resort, not the starting point (see the header process rule).
 
 What M13/M14b actually falsified (0/3 on real models): **eager** extraction at ingest +
 **model-as-identity-authority** (no evidence gate) + **product surfaces stacked on the ungrounded
@@ -200,34 +229,60 @@ intent). Until L3 exists, an interim lineage key of (community, claim-embedding 
 citation overlap) is acceptable for strengthen/dedup but NOT for contradiction (too soft) — one
 more reason lifecycle depends on identity.
 
-## 7. Spikes — data decides, before any product code
+## 6.5 Research grounding — what the literature does and does not support
 
-All three run offline on the real 994-pack corpus; artifacts under `.run/m34-spikes/` (never /tmp).
+Supports the **shipped moat** (claim-level attribution + atomic verification): AIS
+(attributable-to-identified-sources framing), ALCE (citation quality must be *verified* — models'
+citations are routinely incomplete; exactly why our verbatim gate exists), FActScore (atomic-fact
+decomposition ≈ our units/claims), FEVER (claim+evidence is a mature, hard problem), GopherCite
+(verified quotes build trust; citation alone is not sufficient). Supports the **product value of
+the graph route** (KMEM/GraphRAG style): GraphRAG — entity/community summaries measurably help
+corpus-level sensemaking — while Microsoft's own discussions acknowledge the summary→source
+**traceability gap** (the exact weakness OVP attacks). Emerging but not settled: provenance-anchored
+KG extraction (e.g. AEVS: unprovenanced triples make faithfulness unverifiable).
 
-- **S1 — community quality (L1/L2).** Embed 994 cases (title + representative units) → kNN →
-  deterministic communities. Accept iff: 20 sampled communities show **≥80% member topical
-  coherence** (human-judged) AND **≥3 genuinely bilingual communities** exist (中英 same-topic
-  sources actually co-clustered). Compare directly against keyword-bucket assignment on the same
-  sample.
-- **S2 — entity candidates (the M13 counterfactual).** Bottom-up mining through the T1→T3 funnel
-  (deterministic mining → genericity ceiling → frequency/value filters → evidence packs); batch
-  judge to T4. Accept iff ALL of:
-  (a) **precision** — ≥80% of 20 sampled T4 candidates judged "a real thing worth aggregating by";
-  (b) **recall** — against a human-built reference set (a person lists the identity anchors they
-  would expect from a sampled slice of the corpus BEFORE seeing system output), the funnel
-  recovers **≥70%**; precision-only would let the system flatter itself (operator requirement);
-  (c) alias binding correct, incl. at least one 中英 pair;
-  (d) **cold-start check** — on ONE single source (the student scenario), T1/T2 immediately
-  surface ≥80% of the topics/proper nouns a human lists for that source, with zero LLM calls.
-  Explicitly contrast with M13's 0/3: same corpus family, opposite method.
-- **S3 — claim lineage.** Take the 22 (repro) + 19 (capped full run) durable claims; simulate a
-  second synthesis pass; hand-label ground truth; measure lineage adjudication
-  (strengthen/append) accuracy — accept at **≥90%**. Contradiction lane is measured but not
-  gated (needs L3).
+**What NO literature validates:** the specific
+`unit → claim → T1–T4 entity ladder → subject-keyed lifecycle` product structure. That chain is
+our hypothesis to prove, with data, in §7. The moat sentence, corrected accordingly:
+**the moat is claim-level attribution + evidence-verifiable synthesis + sensemaking — the entity
+ladder is one candidate implementation, not the moat itself.**
 
-Failed spike → the corresponding layer does not get built; this document is amended with the
-evidence. Passed spikes → Stage 3b (L1/L2 productization), Stage 3c (L3 + lifecycle), each a
-normal PR-gated stage.
+## 7. The comparative experiment — product value decides, before any product code
+
+One experiment replaces the former S2/S3 mechanism-spikes. S1 is kept (it serves every arm).
+
+- **S1 — grouping quality (unchanged, needed by ALL arms).** Embed 994 cases → kNN →
+  deterministic communities. Accept iff 20 sampled communities show ≥80% member topical coherence
+  AND ≥3 genuinely bilingual communities. Baseline: keyword buckets on the same sample.
+
+- **S2′ — four-arm product comparison** on 50–100 real historical sources (papers, web, notes,
+  GitHub, 中文材料 — the student mix), artifacts under `.run/m34-spikes/`:
+  - **A — KMEM-style:** memory → LLM entity/relations → community → crystal summary. Use the live
+    Nowledge instance where its 0.9.1 stability allows; fall back to existing captures (M21/M26
+    machinery) — sample size may shrink, record it.
+  - **B — OVP minimal (no entities):** units → gated claims → community crystals (Stage 3a
+    output). Retrieval-based lineage for dedup/strengthen. This arm mostly EXISTS already.
+  - **C-lite — grounded anchors as projection:** B + deterministic mention mining + genericity
+    ceiling + ONE batched judge pass → anchors derived from claim citations as a rebuildable
+    view. NO ladder state machine, NO entity ledger — the cheapest faithful slice of §5. (Testing
+    full C would require building it first — the exact trap this revision exists to avoid.)
+  - **D — query-time aggregation (no precomputed structure):** B's index + an agentic query-time
+    LLM that aggregates "everything about X" / "what does this corpus say" on demand, answers
+    verified through the existing citation gate. The "a good prompt beats a rule ladder"
+    null-hypothesis arm.
+  - **Task-anchored metrics** (student tasks, reusing the M26 workbench pattern; human-judged):
+    "这批资料讲了什么" comprehension speed/quality · important-concept recall vs a human
+    reference list (precision AND recall) · wrong-merge count · unsupported-claim count ·
+    crystal→quote traceability (one click, verbatim) · token cost per source and per query ·
+    does the graph/anchor layer actually help review & lookup vs D.
+  - **Decision rules:** C-lite not clearly > B → **no entity layer** (H1 dies; §5 marked DEAD).
+    D ≈ B/C on product value → prefer D's simplicity for reuse surfaces. A clearly wins user
+    value AND the grounding gap demonstrably doesn't hurt real use → swallow pride, reassess the
+    architecture-purity premium honestly. C-lite clearly wins on trusted-crystal / review /
+    evidence-lookback → THEN design durable anchors, projection-first (§5 becomes the spec
+    baseline; ledger still last-resort).
+
+Failed arm → its layer is not built; this document is amended with the evidence either way.
 
 ## 8. Execution order
 
@@ -236,9 +291,13 @@ normal PR-gated stage.
    strength (≤20 claims/call). Gives the current corpus a full-coverage crystal store NOW and is
    the machinery under any future grouping. (A model `crystal_merge/v1` reduce is added only if
    the deterministic dedup's residual duplicate rate proves the need — via the evolution flow.)
-2. **S1 → S2 → S3 spikes** (offline, no product writes).
-3. **Stage 3b:** replace keyword buckets with L1/L2 communities behind the same crystal-synth CLI.
-4. **Stage 3c:** L3 entity gate + lineage/supersede ledger semantics + contradiction lane.
+2. **S1** (grouping quality — needed by every arm), then **S2′ four-arm comparison** (offline,
+   no product writes). The experiment verdict decides which of B / C / D becomes Stage 3b+.
+3. **Stage 3b:** replace keyword buckets with L1/L2 communities behind the same crystal-synth CLI
+   (this much is safe under every arm that wins).
+4. **Stage 3c (CONDITIONAL on the S2′ verdict):** whichever of {nothing extra (B), projection
+   anchors (C-lite→C), query-time aggregation surface (D)} the data picked; ledger-backed L3 +
+   contradiction lane only after projections prove insufficient.
 5. M32 Level-3 exit criterion #3 ("crystallize the full corpus") is satisfied by Stage 3a
    coverage; quality re-crystallization after 3b is a product improvement, not a retirement gate.
 


### PR DESCRIPTION
## What (evolved over three operator reviews)

Two docs-only anchors that together answer the high-level system design:

1. **`docs/product-pipeline.md` — the mature-system pipeline map** (what mature OVP runs per ingest/daily/weekly/on-demand; per-pipeline input/output/authority-vs-derived/cost-class/failure-states/status). Key commitments: explicit authority set {source files, event ledgers, reader packs, crystal ledger} with a hard projection-never-writes-back boundary; read/write split; enumerated failure states as a definition-of-done; cost class per pipeline; review-queue as the append-only system's rot vector (weekly tier); batch single-entry tiered scheduler, dirty-marking as the one incremental mechanism; KMEM 12-pipeline mapping; actionable gap list.

2. **`docs/stage-m34-knowledge-substrate-design.md` — hypotheses for the ONE undecided box (G5 sensemaking identity layer).** Evidence-backed decisions (embeddings for grouping, Stage 3a, no vector DB, claim-layer moat untouched) separated from hypotheses; the T1–T4 entity ladder is candidate design C only; a four-arm task-anchored experiment (KMEM-style / no-entities / projection-anchors / query-time-aggregation) decides. Research grounding (AIS/ALCE/FActScore/FEVER/GopherCite/GraphRAG) included: it validates the shipped claim-level moat and the graph route's value — NOT our specific ladder chain.

Foundation, both docs: `source → quote-backed units → gated crystal claims`; graph/digest/notes/UI all derive from it. Process rule learned twice (M13, this doc's first draft): separate decisions from hypotheses; no new persistent state layer without a value experiment; projections over ledgers.