### PR TITLE
feat: add evidence sidecar for card and unit search

### DIFF
--- a/crates/ovp-cli/src/commands/console_cmd.rs
+++ b/crates/ovp-cli/src/commands/console_cmd.rs
@@ -5,7 +5,7 @@
 use std::path::PathBuf;
 
 use ovp_console::{write_console, write_ops_pages};
-use ovp_index::{build_index, write_index};
+use ovp_index::{build_evidence, build_index, write_evidence, write_index};
 
 use crate::CliError;
 
@@ -17,10 +17,21 @@ pub struct ConsoleArgs {
 pub fn run(args: ConsoleArgs) -> Result<(), CliError> {
     let model = build_index(&args.vault_root, &args.date, None).map_err(CliError::Io)?;
     let index_rel = write_index(&args.vault_root, &model).map_err(CliError::Io)?;
+    let evidence = build_evidence(&args.vault_root, &args.date, &model).map_err(CliError::Io)?;
+    let evidence_rel = write_evidence(&args.vault_root, &evidence).map_err(CliError::Io)?;
     let console_rel = write_console(&args.vault_root, &model).map_err(CliError::Io)?;
     let ops_pages = write_ops_pages(&args.vault_root, &model).map_err(CliError::Io)?;
-    println!("console [{}]: {}", args.date, args.vault_root.join(&console_rel).display());
+    println!(
+        "console [{}]: {}",
+        args.date,
+        args.vault_root.join(&console_rel).display()
+    );
     println!("  index refreshed: {index_rel}");
+    println!(
+        "  evidence refreshed: {evidence_rel} (cards={} units={})",
+        evidence.cards.len(),
+        evidence.units.len()
+    );
     for p in &ops_pages {
         println!("  ops page: {p}");
     }

--- a/crates/ovp-cli/src/commands/daily.rs
+++ b/crates/ovp-cli/src/commands/daily.rs
@@ -19,7 +19,7 @@ use ovp_daily::{
     RunStatus,
 };
 use ovp_domain::VaultLayout;
-use ovp_index::{build_index, write_index};
+use ovp_index::{build_evidence, build_index, write_evidence, write_index};
 use ovp_enrich::github::{
     enrich_github_repos, parse_github_repo_url, FixtureGitHubFetch, GitHubFetch,
 };
@@ -305,6 +305,8 @@ pub fn run(args: DailyArgs) -> Result<(), CliError> {
     let model = build_index(&args.vault_root, &args.date, Some(&args.run_id))
         .map_err(CliError::Io)?;
     let index_rel = write_index(&args.vault_root, &model).map_err(CliError::Io)?;
+    let evidence = build_evidence(&args.vault_root, &args.date, &model).map_err(CliError::Io)?;
+    let evidence_rel = write_evidence(&args.vault_root, &evidence).map_err(CliError::Io)?;
     let console_rel = write_console(&args.vault_root, &model).map_err(CliError::Io)?;
     let _ops_pages = write_ops_pages(&args.vault_root, &model).map_err(CliError::Io)?;
 
@@ -336,7 +338,7 @@ pub fn run(args: DailyArgs) -> Result<(), CliError> {
         "  done: {} processed, {failed} failed, {} skipped (report: {report_rel})",
         daily.processed.len(), daily.skipped
     );
-    println!("  index: {index_rel} · console: {console_rel}");
+    println!("  index: {index_rel} · evidence: {evidence_rel} · console: {console_rel}");
 
     if failed > 0 {
         // Honest retry guidance: a 3rd failure means the source is now

--- a/crates/ovp-cli/src/commands/index_cmd.rs
+++ b/crates/ovp-cli/src/commands/index_cmd.rs
@@ -5,7 +5,10 @@
 
 use std::path::PathBuf;
 
-use ovp_index::{build_index, read_index, run_query, write_index, Query, QueryKind};
+use ovp_index::{
+    build_evidence, build_index, read_evidence, read_index, run_evidence_query, run_query,
+    write_evidence, write_index, Query, QueryKind,
+};
 
 use crate::CliError;
 
@@ -17,8 +20,16 @@ pub struct IndexArgs {
 pub fn run_index(args: IndexArgs) -> Result<(), CliError> {
     let model = build_index(&args.vault_root, &args.date, None).map_err(CliError::Io)?;
     let rel = write_index(&args.vault_root, &model).map_err(CliError::Io)?;
+    let evidence = build_evidence(&args.vault_root, &args.date, &model).map_err(CliError::Io)?;
+    let evidence_rel = write_evidence(&args.vault_root, &evidence).map_err(CliError::Io)?;
     let t = &model.totals;
     println!("index [{}]: {rel}", args.date);
+    println!(
+        "  evidence: {evidence_rel} (cards={} units={} warnings={})",
+        evidence.cards.len(),
+        evidence.units.len(),
+        evidence.warnings.len()
+    );
     println!(
         "  sources={} (queued={} processed={} failed={} blocked={} needs_content={} dup={})",
         t.sources, t.queued, t.processed, t.failed, t.blocked, t.needs_content, t.duplicates
@@ -47,17 +58,33 @@ pub fn run_find(args: FindArgs) -> Result<(), CliError> {
         Some("packs") => Some(QueryKind::Packs),
         Some("claims") => Some(QueryKind::Claims),
         Some("runs") => Some(QueryKind::Runs),
+        Some("cards") => Some(QueryKind::Cards),
+        Some("units") => Some(QueryKind::Units),
         Some(other) => {
             return Err(CliError::Io(format!(
-                "unknown --kind `{other}` (sources|packs|claims|runs)"
+                "unknown --kind `{other}` (sources|packs|claims|runs|cards|units)"
             )))
         }
     };
-    let query = Query { kind, status: args.status, date: args.date, term: args.term };
-    let hits = run_query(&model, &query);
+    let query = Query {
+        kind,
+        status: args.status,
+        date: args.date,
+        term: args.term,
+    };
+    let hits = match kind {
+        Some(QueryKind::Cards | QueryKind::Units) => {
+            let evidence = read_evidence(&args.vault_root).map_err(CliError::Io)?;
+            run_evidence_query(&evidence, &query, 200)
+        }
+        _ => run_query(&model, &query),
+    };
 
     if args.json {
-        println!("{}", serde_json::to_string_pretty(&hits).map_err(|e| CliError::Io(e.to_string()))?);
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&hits).map_err(|e| CliError::Io(e.to_string()))?
+        );
         return Ok(());
     }
     if hits.is_empty() {

--- a/crates/ovp-cli/src/main.rs
+++ b/crates/ovp-cli/src/main.rs
@@ -263,14 +263,15 @@ enum Cmd {
         date: Option<String>,
     },
     /// PRODUCT — query the read model: list/search/filter sources, reader
-    /// packs, crystal claims, and runs. `ovp-next find --vault-root V chunks`
+    /// packs, crystal claims, runs, and deep evidence cards/units.
+    /// `ovp-next find --vault-root V chunks`
     /// or `--kind sources --status blocked`. Run `index` (or `daily`) first.
     Find {
         #[arg(long)]
         vault_root: PathBuf,
         /// Case-insensitive substring over titles/URLs/paths/cards/claims.
         term: Option<String>,
-        /// Restrict to one kind: sources|packs|claims|runs.
+        /// Restrict to one kind: sources|packs|claims|runs|cards|units.
         #[arg(long)]
         kind: Option<String>,
         /// Status filter (queued|processed|failed|blocked|needs_content|

--- a/crates/ovp-cli/tests/m31_e2e.rs
+++ b/crates/ovp-cli/tests/m31_e2e.rs
@@ -184,8 +184,8 @@ fn full_daily_workflow_capture_to_console_with_crystal_and_retry() {
     assert_eq!(md_files(&vault.join("50-Inbox/02-Pinboard")).len(), 1, "bare bookmark left");
     for state in [
         ".ovp/daily-runs.jsonl", ".ovp/intake.jsonl", ".ovp/pinboard-sync.jsonl",
-        ".ovp/reports/daily-e2e.json", ".ovp/index/index.json", ".ovp/console/index.html",
-        "60-Logs/pipeline.jsonl",
+        ".ovp/reports/daily-e2e.json", ".ovp/index/index.json", ".ovp/index/evidence.json",
+        ".ovp/console/index.html", "60-Logs/pipeline.jsonl",
     ] {
         assert!(vault.join(state).exists(), "missing {state}");
     }
@@ -274,6 +274,16 @@ fn full_daily_workflow_capture_to_console_with_crystal_and_retry() {
         "find", "--vault-root", vault.to_str().unwrap(), "chunk",
     ]));
     assert!(stdout.contains("The Chunk Problem"), "{stdout}");
+    let stdout = run_ok(bin().args([
+        "find", "--vault-root", vault.to_str().unwrap(),
+        "--kind", "cards", "structurally neutral",
+    ]));
+    assert!(stdout.contains("[card") && stdout.contains("Card for The Chunk Problem"), "{stdout}");
+    let stdout = run_ok(bin().args([
+        "find", "--vault-root", vault.to_str().unwrap(),
+        "--kind", "units", "structurally neutral",
+    ]));
+    assert!(stdout.contains("[unit") && stdout.contains("A chunk is structurally neutral"), "{stdout}");
 
     // === Failure → retry → blocked: a source with NO cassettes. ===
     std::fs::write(

--- a/crates/ovp-index/src/evidence.rs
+++ b/crates/ovp-index/src/evidence.rs
@@ -1,0 +1,298 @@
+use std::path::Path;
+
+use ovp_domain::reader::Card;
+use ovp_domain::units::Unit;
+use ovp_intake::vaultops::rel_to;
+use serde::{Deserialize, Serialize};
+
+use crate::model::IndexModel;
+
+pub const EVIDENCE_SCHEMA: &str = "ovp.index.evidence/v1";
+const EVIDENCE_FILE: &str = ".ovp/index/evidence.json";
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EvidenceModel {
+    pub schema: String,
+    pub date: String,
+    pub cards: Vec<CardEvidenceRow>,
+    pub units: Vec<UnitEvidenceRow>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<EvidenceWarning>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CardEvidenceRow {
+    pub id: String,
+    pub pack_dir: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_sha256: Option<String>,
+    pub source_title: String,
+    pub title: String,
+    pub content: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unit_type: Option<String>,
+    #[serde(default)]
+    pub cited_unit_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct UnitEvidenceRow {
+    pub id: String,
+    pub pack_dir: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_sha256: Option<String>,
+    pub source_title: String,
+    pub unit_id: String,
+    pub text: String,
+    pub quote: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line: Option<usize>,
+    pub attribution: String,
+    pub modality: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EvidenceWarning {
+    pub pack_dir: String,
+    pub file: String,
+    pub reason: String,
+}
+
+pub fn build_evidence(
+    vault_root: &Path,
+    date: &str,
+    index: &IndexModel,
+) -> Result<EvidenceModel, String> {
+    let mut cards = Vec::new();
+    let mut units = Vec::new();
+    let mut warnings = Vec::new();
+
+    for pack in &index.packs {
+        let pack_path = vault_root.join(&pack.pack_dir);
+        let cards_path = pack_path.join("cards.json");
+        match read_json::<Vec<Card>>(&cards_path) {
+            Ok(pack_cards) => {
+                for (idx, card) in pack_cards.into_iter().enumerate() {
+                    cards.push(CardEvidenceRow {
+                        id: format!("card:{}:{idx}", pack.pack_dir),
+                        pack_dir: pack.pack_dir.clone(),
+                        source_sha256: pack.source_sha256.clone(),
+                        source_title: pack.title.clone(),
+                        title: card.title,
+                        content: card.content,
+                        unit_type: card.unit_type,
+                        cited_unit_ids: card.cited_unit_ids,
+                    });
+                }
+            }
+            Err(reason) => warnings.push(EvidenceWarning {
+                pack_dir: pack.pack_dir.clone(),
+                file: "cards.json".into(),
+                reason,
+            }),
+        }
+
+        let units_path = pack_path.join("units.accepted.json");
+        match read_json::<Vec<Unit>>(&units_path) {
+            Ok(pack_units) => {
+                for unit in pack_units {
+                    units.push(UnitEvidenceRow {
+                        id: format!("unit:{}:{}", pack.pack_dir, unit.id),
+                        pack_dir: pack.pack_dir.clone(),
+                        source_sha256: pack.source_sha256.clone(),
+                        source_title: pack.title.clone(),
+                        unit_id: unit.id,
+                        text: unit.text,
+                        quote: unit.evidence.quote,
+                        line: unit.evidence.location.map(|loc| loc.line),
+                        attribution: enum_str(&unit.attribution),
+                        modality: enum_str(&unit.modality),
+                    });
+                }
+            }
+            Err(reason) => warnings.push(EvidenceWarning {
+                pack_dir: pack.pack_dir.clone(),
+                file: "units.accepted.json".into(),
+                reason,
+            }),
+        }
+    }
+
+    cards.sort_by(|a, b| a.id.cmp(&b.id));
+    units.sort_by(|a, b| a.id.cmp(&b.id));
+    warnings.sort_by(|a, b| {
+        (a.pack_dir.as_str(), a.file.as_str()).cmp(&(b.pack_dir.as_str(), b.file.as_str()))
+    });
+
+    Ok(EvidenceModel {
+        schema: EVIDENCE_SCHEMA.into(),
+        date: date.into(),
+        cards,
+        units,
+        warnings,
+    })
+}
+
+pub fn write_evidence(vault_root: &Path, evidence: &EvidenceModel) -> Result<String, String> {
+    let target = vault_root.join(EVIDENCE_FILE);
+    if let Some(parent) = target.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("creating {}: {e}", parent.display()))?;
+    }
+    let body =
+        serde_json::to_string_pretty(evidence).map_err(|e| format!("serializing evidence: {e}"))?;
+    std::fs::write(&target, format!("{body}\n"))
+        .map_err(|e| format!("writing {}: {e}", target.display()))?;
+    Ok(rel_to(vault_root, &target))
+}
+
+pub fn read_evidence(vault_root: &Path) -> Result<EvidenceModel, String> {
+    let path = vault_root.join(EVIDENCE_FILE);
+    let raw = std::fs::read_to_string(&path).map_err(|e| {
+        format!(
+            "reading {}: {e} (run `ovp-next index --vault-root …` to build it)",
+            path.display()
+        )
+    })?;
+    serde_json::from_str(&raw).map_err(|e| format!("parsing {}: {e}", path.display()))
+}
+
+fn read_json<T: serde::de::DeserializeOwned>(path: &Path) -> Result<T, String> {
+    let raw =
+        std::fs::read_to_string(path).map_err(|e| format!("reading {}: {e}", path.display()))?;
+    serde_json::from_str(&raw).map_err(|e| format!("parsing {}: {e}", path.display()))
+}
+
+fn enum_str<T: serde::Serialize>(v: &T) -> String {
+    serde_json::to_value(v)
+        .ok()
+        .and_then(|j| j.as_str().map(String::from))
+        .unwrap_or_else(|| "unknown".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use crate::evidence::{build_evidence, read_evidence, write_evidence, EVIDENCE_SCHEMA};
+    use crate::model::{IndexModel, OpsState, PackRow, Totals};
+
+    fn index_with_pack(pack_dir: &str) -> IndexModel {
+        IndexModel {
+            schema: "ovp.index/v2".into(),
+            date: "2026-07-06".into(),
+            run_id: None,
+            totals: Totals::default(),
+            sources: vec![],
+            packs: vec![PackRow {
+                pack_dir: pack_dir.into(),
+                title: "Agent Memory Systems".into(),
+                date: Some("2026-07-06".into()),
+                units: 1,
+                cards: 1,
+                json_repaired: false,
+                card_titles: vec!["Memory as state".into()],
+                source_sha256: Some("sha-a".into()),
+            }],
+            claims: vec![],
+            runs: vec![],
+            ops: OpsState::default(),
+        }
+    }
+
+    fn write_pack(vault: &std::path::Path, pack_dir: &str) {
+        let dir = vault.join(pack_dir);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(
+            dir.join("cards.json"),
+            r#"[
+              {
+                "title": "Memory as state",
+                "content": "Agent memory should be treated as persistent state, not a transient prompt trick.",
+                "unit_type": "claim",
+                "cited_unit_ids": ["u-001-abcd"]
+              }
+            ]"#,
+        )
+        .unwrap();
+        fs::write(
+            dir.join("units.accepted.json"),
+            r#"[
+              {
+                "id": "u-001-abcd",
+                "kind": "assertion",
+                "subtype": "claim",
+                "text": "Agent memory is persistent state.",
+                "evidence": {
+                  "ref_id": "p001.s001",
+                  "quote": "Agent memory should be treated as persistent state.",
+                  "location": {
+                    "byte_start": 0,
+                    "byte_end": 49,
+                    "line": 12,
+                    "match_kind": "exact"
+                  }
+                },
+                "attribution": "author",
+                "modality": "asserted",
+                "arguments": [],
+                "status": "accepted",
+                "issues": []
+              }
+            ]"#,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn builds_cards_and_units_from_reader_pack_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pack_dir = "40-Resources/Reader/agent-memory";
+        write_pack(tmp.path(), pack_dir);
+
+        let evidence =
+            build_evidence(tmp.path(), "2026-07-06", &index_with_pack(pack_dir)).unwrap();
+
+        assert_eq!(evidence.schema, EVIDENCE_SCHEMA);
+        assert_eq!(evidence.cards.len(), 1);
+        assert_eq!(
+            evidence.cards[0].id,
+            "card:40-Resources/Reader/agent-memory:0"
+        );
+        assert_eq!(evidence.cards[0].source_title, "Agent Memory Systems");
+        assert_eq!(
+            evidence.cards[0].content,
+            "Agent memory should be treated as persistent state, not a transient prompt trick."
+        );
+        assert_eq!(evidence.cards[0].cited_unit_ids, vec!["u-001-abcd"]);
+
+        assert_eq!(evidence.units.len(), 1);
+        assert_eq!(
+            evidence.units[0].id,
+            "unit:40-Resources/Reader/agent-memory:u-001-abcd"
+        );
+        assert_eq!(evidence.units[0].unit_id, "u-001-abcd");
+        assert_eq!(
+            evidence.units[0].quote,
+            "Agent memory should be treated as persistent state."
+        );
+        assert_eq!(evidence.units[0].line, Some(12));
+    }
+
+    #[test]
+    fn evidence_sidecar_round_trips_as_json_projection() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pack_dir = "40-Resources/Reader/agent-memory";
+        write_pack(tmp.path(), pack_dir);
+        let evidence =
+            build_evidence(tmp.path(), "2026-07-06", &index_with_pack(pack_dir)).unwrap();
+
+        let rel = write_evidence(tmp.path(), &evidence).unwrap();
+        let read_back = read_evidence(tmp.path()).unwrap();
+
+        assert_eq!(rel, ".ovp/index/evidence.json");
+        assert_eq!(read_back.schema, EVIDENCE_SCHEMA);
+        assert_eq!(read_back.cards[0].title, "Memory as state");
+        assert_eq!(read_back.units[0].text, "Agent memory is persistent state.");
+    }
+}

--- a/crates/ovp-index/src/lib.rs
+++ b/crates/ovp-index/src/lib.rs
@@ -18,12 +18,17 @@
 //! where a different backend would slot in.
 
 pub mod build;
+pub mod evidence;
 pub mod model;
 pub mod query;
+pub mod score;
 
 pub use build::{build_index, read_index, write_index};
+pub use evidence::{build_evidence, read_evidence, write_evidence, EvidenceModel};
 pub use model::{
     BlockedSource, ClaimRow, ClaimStatus, IndexModel, OpsState, PackRow, RunRow, RunStats,
     SourceRow, SourceStatus, Totals, INDEX_SCHEMA,
 };
-pub use query::{claim_status_str, run_query, source_status_str, Hit, Query, QueryKind};
+pub use query::{
+    claim_status_str, run_evidence_query, run_query, source_status_str, Hit, Query, QueryKind,
+};

--- a/crates/ovp-index/src/query.rs
+++ b/crates/ovp-index/src/query.rs
@@ -3,7 +3,9 @@
 
 use serde::Serialize;
 
+use crate::evidence::EvidenceModel;
 use crate::model::{ClaimStatus, IndexModel, SourceStatus};
+use crate::score::lexical_score;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum QueryKind {
@@ -11,6 +13,8 @@ pub enum QueryKind {
     Packs,
     Claims,
     Runs,
+    Cards,
+    Units,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -102,7 +106,11 @@ pub fn run_query(model: &IndexModel, q: &Query) -> Vec<Hit> {
                     p.title,
                     p.cards,
                     p.units,
-                    if p.json_repaired { " [json-repaired]" } else { "" }
+                    if p.json_repaired {
+                        " [json-repaired]"
+                    } else {
+                        ""
+                    }
                 ),
                 path: Some(format!("{}/reader.md", p.pack_dir)),
             });
@@ -124,7 +132,12 @@ pub fn run_query(model: &IndexModel, q: &Query) -> Vec<Hit> {
             if !c.sources.is_empty() {
                 line.push_str(&format!(" ({} sources)", c.sources.len()));
             }
-            hits.push(Hit { kind: "claim".into(), status: status.into(), line, path: None });
+            hits.push(Hit {
+                kind: "claim".into(),
+                status: status.into(),
+                line,
+                path: None,
+            });
         }
     }
 
@@ -151,6 +164,108 @@ pub fn run_query(model: &IndexModel, q: &Query) -> Vec<Hit> {
     hits
 }
 
+pub fn run_evidence_query(evidence: &EvidenceModel, q: &Query, limit: usize) -> Vec<Hit> {
+    let status_ok = |s: &str| q.status.as_deref().map(|want| want == s).unwrap_or(true);
+    let kind_ok = |k: QueryKind| q.kind.map(|want| want == k).unwrap_or(true);
+    let term = q.term.as_deref().unwrap_or("");
+    let mut scored: Vec<(f64, String, Hit)> = Vec::new();
+
+    if q.date.is_some() {
+        return Vec::new();
+    }
+
+    if kind_ok(QueryKind::Cards) && status_ok("card") {
+        for card in &evidence.cards {
+            let score = match q.term.as_deref() {
+                None => 1.0,
+                Some(_) => lexical_score(
+                    term,
+                    &[
+                        &card.source_title,
+                        &card.title,
+                        &card.content,
+                        &card.pack_dir,
+                    ],
+                ),
+            };
+            if score <= 0.0 {
+                continue;
+            }
+            scored.push((
+                score,
+                card.id.clone(),
+                Hit {
+                    kind: "card".into(),
+                    status: "card".into(),
+                    line: format!(
+                        "{} — {}{}",
+                        card.source_title,
+                        card.title,
+                        preview_suffix(&card.content)
+                    ),
+                    path: Some(format!("{}/reader.md", card.pack_dir)),
+                },
+            ));
+        }
+    }
+
+    if kind_ok(QueryKind::Units) && status_ok("unit") {
+        for unit in &evidence.units {
+            let line_str = unit.line.map(|n| format!(" line {n}")).unwrap_or_default();
+            let score = match q.term.as_deref() {
+                None => 1.0,
+                Some(_) => lexical_score(
+                    term,
+                    &[&unit.source_title, &unit.text, &unit.quote, &unit.pack_dir],
+                ),
+            };
+            if score <= 0.0 {
+                continue;
+            }
+            scored.push((
+                score,
+                unit.id.clone(),
+                Hit {
+                    kind: "unit".into(),
+                    status: "unit".into(),
+                    line: format!(
+                        "{}{} — {}{}",
+                        unit.source_title,
+                        line_str,
+                        unit.text,
+                        preview_suffix(&unit.quote)
+                    ),
+                    path: Some(format!("{}/reader.md", unit.pack_dir)),
+                },
+            ));
+        }
+    }
+
+    scored.sort_by(|a, b| {
+        b.0.partial_cmp(&a.0)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.1.cmp(&b.1))
+    });
+    scored
+        .into_iter()
+        .take(limit)
+        .map(|(_, _, hit)| hit)
+        .collect()
+}
+
+fn preview_suffix(s: &str) -> String {
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+    let preview: String = trimmed.chars().take(160).collect();
+    if trimmed.chars().count() > 160 {
+        format!(" — {preview}...")
+    } else {
+        format!(" — {preview}")
+    }
+}
+
 pub fn source_status_str(s: SourceStatus) -> &'static str {
     match s {
         SourceStatus::Queued => "queued",
@@ -169,5 +284,83 @@ pub fn claim_status_str(s: ClaimStatus) -> &'static str {
         ClaimStatus::Superseded => "superseded",
         ClaimStatus::Retracted => "retracted",
         ClaimStatus::Caveated => "caveated",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::evidence::{CardEvidenceRow, EvidenceModel, UnitEvidenceRow, EVIDENCE_SCHEMA};
+    use crate::query::{run_evidence_query, Query, QueryKind};
+
+    fn evidence() -> EvidenceModel {
+        EvidenceModel {
+            schema: EVIDENCE_SCHEMA.into(),
+            date: "2026-07-06".into(),
+            cards: vec![CardEvidenceRow {
+                id: "card:40-Resources/Reader/a:0".into(),
+                pack_dir: "40-Resources/Reader/a".into(),
+                source_sha256: Some("sha-a".into()),
+                source_title: "Agent Memory Systems".into(),
+                title: "Memory as state".into(),
+                content: "Agent memory should be treated as persistent state.".into(),
+                unit_type: Some("claim".into()),
+                cited_unit_ids: vec!["u-001".into()],
+            }],
+            units: vec![UnitEvidenceRow {
+                id: "unit:40-Resources/Reader/a:u-001".into(),
+                pack_dir: "40-Resources/Reader/a".into(),
+                source_sha256: Some("sha-a".into()),
+                source_title: "Agent Memory Systems".into(),
+                unit_id: "u-001".into(),
+                text: "代理记忆是持久状态。".into(),
+                quote: "Agent memory should be treated as persistent state.".into(),
+                line: Some(12),
+                attribution: "author".into(),
+                modality: "asserted".into(),
+            }],
+            warnings: vec![],
+        }
+    }
+
+    #[test]
+    fn evidence_query_searches_card_content() {
+        let hits = run_evidence_query(
+            &evidence(),
+            &Query {
+                kind: Some(QueryKind::Cards),
+                term: Some("persistent state".into()),
+                ..Default::default()
+            },
+            10,
+        );
+
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].kind, "card");
+        assert!(hits[0].line.contains("Memory as state"));
+        assert_eq!(
+            hits[0].path.as_deref(),
+            Some("40-Resources/Reader/a/reader.md")
+        );
+    }
+
+    #[test]
+    fn evidence_query_searches_cjk_units_and_returns_stable_path() {
+        let hits = run_evidence_query(
+            &evidence(),
+            &Query {
+                kind: Some(QueryKind::Units),
+                term: Some("记忆".into()),
+                ..Default::default()
+            },
+            10,
+        );
+
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].kind, "unit");
+        assert!(hits[0].line.contains("代理记忆"));
+        assert_eq!(
+            hits[0].path.as_deref(),
+            Some("40-Resources/Reader/a/reader.md")
+        );
     }
 }

--- a/crates/ovp-index/src/score.rs
+++ b/crates/ovp-index/src/score.rs
@@ -1,0 +1,111 @@
+use std::collections::BTreeSet;
+
+pub fn tokenize_for_search(input: &str) -> Vec<String> {
+    let mut out: BTreeSet<String> = BTreeSet::new();
+    let mut ascii = String::new();
+    let mut cjk_run = String::new();
+
+    let flush_ascii = |buf: &mut String, out: &mut BTreeSet<String>| {
+        if !buf.is_empty() {
+            out.insert(std::mem::take(buf));
+        }
+    };
+    let flush_cjk = |buf: &mut String, out: &mut BTreeSet<String>| {
+        let chars: Vec<char> = buf.chars().collect();
+        match chars.len() {
+            0 => {}
+            1 => {
+                out.insert(chars[0].to_string());
+            }
+            _ => {
+                for pair in chars.windows(2) {
+                    out.insert(pair.iter().collect());
+                }
+            }
+        }
+        buf.clear();
+    };
+
+    for ch in input.chars() {
+        if ch.is_ascii_alphanumeric() {
+            flush_cjk(&mut cjk_run, &mut out);
+            ascii.push(ch.to_ascii_lowercase());
+        } else if is_cjk(ch) {
+            flush_ascii(&mut ascii, &mut out);
+            cjk_run.push(ch);
+        } else {
+            flush_ascii(&mut ascii, &mut out);
+            flush_cjk(&mut cjk_run, &mut out);
+        }
+    }
+    flush_ascii(&mut ascii, &mut out);
+    flush_cjk(&mut cjk_run, &mut out);
+    out.into_iter().collect()
+}
+
+pub fn lexical_score(query: &str, fields: &[&str]) -> f64 {
+    let q = query.trim();
+    if q.is_empty() || fields.is_empty() {
+        return 0.0;
+    }
+    let q_lower = q.to_lowercase();
+    let q_tokens = tokenize_for_search(q);
+    if q_tokens.is_empty() {
+        return 0.0;
+    }
+
+    let mut score = 0.0;
+    for field in fields {
+        let f_lower = field.to_lowercase();
+        if f_lower.contains(&q_lower) {
+            score += 10.0;
+        }
+        let f_tokens: BTreeSet<String> = tokenize_for_search(field).into_iter().collect();
+        for token in &q_tokens {
+            if f_tokens.contains(token) {
+                score += 1.0;
+            }
+        }
+    }
+    score
+}
+
+fn is_cjk(ch: char) -> bool {
+    matches!(
+        ch as u32,
+        0x3400..=0x4DBF
+            | 0x4E00..=0x9FFF
+            | 0xF900..=0xFAFF
+            | 0x20000..=0x2A6DF
+            | 0x2A700..=0x2B73F
+            | 0x2B740..=0x2B81F
+            | 0x2B820..=0x2CEAF
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::score::{lexical_score, tokenize_for_search};
+
+    #[test]
+    fn tokenizes_ascii_words_and_cjk_bigrams() {
+        let tokens = tokenize_for_search("Agent memory 代理记忆系统");
+
+        assert!(tokens.contains(&"agent".to_string()));
+        assert!(tokens.contains(&"memory".to_string()));
+        assert!(tokens.contains(&"代理".to_string()));
+        assert!(tokens.contains(&"理记".to_string()));
+        assert!(tokens.contains(&"记忆".to_string()));
+    }
+
+    #[test]
+    fn scores_ascii_and_cjk_matches_above_misses() {
+        let ascii = lexical_score("agent memory", &["Agent memory systems"]);
+        let cjk = lexical_score("记忆", &["代理记忆系统"]);
+        let miss = lexical_score("polymarket", &["Agent memory systems"]);
+
+        assert!(ascii > miss);
+        assert!(cjk > miss);
+        assert_eq!(lexical_score("", &["Agent memory systems"]), 0.0);
+    }
+}


### PR DESCRIPTION
## Summary
- add rebuildable .ovp/index/evidence.json sidecar over reader cards and accepted units
- wire index/daily/console to refresh the sidecar
- let find query deep evidence via --kind cards and --kind units

## Verification
- cargo metadata --no-deps --format-version 1
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- bash scripts/check_architecture.sh
- target/debug/ovp-next index --vault-root "$HOME/Documents/ovp-vault" --date 2026-07-06
- target/debug/ovp-next find --vault-root "$HOME/Documents/ovp-vault" --kind cards memory
- target/debug/ovp-next find --vault-root "$HOME/Documents/ovp-vault" --kind units memory
- target/debug/ovp-next find --vault-root "$HOME/Documents/ovp-vault" --kind units 记忆

## Data hygiene
No .run, .ovp, live cassettes, raw eval artifacts, or scratch scripts are included.