### PR TITLE
feat: route ask through evidence context

### DIFF
--- a/crates/ovp-cli/src/commands/ask.rs
+++ b/crates/ovp-cli/src/commands/ask.rs
@@ -5,11 +5,11 @@
 
 use std::path::PathBuf;
 
-use ovp_index::read_index;
-use ovp_memory::ask::{ask, AskArgs};
+use ovp_index::{read_evidence, read_index};
+use ovp_memory::ask::{AskArgs, ask_with_optional_evidence};
 
-use crate::commands::client::{build_client, ClientKind};
 use crate::CliError;
+use crate::commands::client::{ClientKind, build_client};
 
 pub struct AskCliArgs {
     pub vault_root: PathBuf,
@@ -21,6 +21,13 @@ pub struct AskCliArgs {
 
 pub fn run(args: AskCliArgs) -> Result<(), CliError> {
     let model = read_index(&args.vault_root).map_err(|e| CliError::Io(e.to_string()))?;
+    let evidence = match read_evidence(&args.vault_root) {
+        Ok(evidence) => Some(evidence),
+        Err(e) => {
+            eprintln!("warning: evidence sidecar unavailable; using claims-only ask context. {e}");
+            None
+        }
+    };
 
     let cassette_root = args
         .cache_dir
@@ -33,8 +40,14 @@ pub fn run(args: AskCliArgs) -> Result<(), CliError> {
         ..Default::default()
     };
 
-    let result =
-        ask(&model, client.as_mut(), &ask_args, &args.vault_root).map_err(CliError::Io)?;
+    let result = ask_with_optional_evidence(
+        &model,
+        evidence.as_ref(),
+        client.as_mut(),
+        &ask_args,
+        &args.vault_root,
+    )
+    .map_err(CliError::Io)?;
 
     println!("{}", result.answer);
 

--- a/crates/ovp-cli/src/main.rs
+++ b/crates/ovp-cli/src/main.rs
@@ -329,7 +329,7 @@ enum Cmd {
         no_llm: bool,
     },
     /// PRODUCT — retrieval-augmented Q&A over OVP product state. Queries
-    /// the JSON index for context, sends to LLM, prints a cited answer.
+    /// the evidence index for claim/card/unit context, sends to LLM, prints a cited answer.
     /// Ephemeral reuse surface — never enters ledger.
     Ask {
         #[arg(long)]

--- a/crates/ovp-cli/tests/m31_e2e.rs
+++ b/crates/ovp-cli/tests/m31_e2e.rs
@@ -15,10 +15,12 @@ use ovp_domain::units::{
     critic_model_request, extract_units, read_source_from_path, unit_model_request, Unit,
 };
 use ovp_domain::SourceDoc;
+use ovp_index::{read_evidence, read_index};
 use ovp_llm::{
     CacheMode, CachedModelClient, CallError, ModelClient, ModelReply, ModelRequest, StopReason,
     Usage,
 };
+use ovp_memory::ask::{ask_with_evidence, AskArgs};
 
 const DATE: &str = "2026-06-09";
 
@@ -284,6 +286,31 @@ fn full_daily_workflow_capture_to_console_with_crystal_and_retry() {
         "--kind", "units", "structurally neutral",
     ]));
     assert!(stdout.contains("[unit") && stdout.contains("A chunk is structurally neutral"), "{stdout}");
+
+    let ask_question = "What does OVP say about structurally neutral chunks?";
+    let model = read_index(&vault).unwrap();
+    let evidence = read_evidence(&vault).unwrap();
+    let mut rec = CachedModelClient::new(
+        Canned("OVP ask uses evidence cards and units.".into()),
+        &cache_dir,
+        "seed",
+        CacheMode::Record,
+    )
+    .unwrap();
+    ask_with_evidence(
+        &model,
+        &evidence,
+        &mut rec,
+        &AskArgs { question: ask_question.into(), ..Default::default() },
+        &vault,
+    )
+    .unwrap();
+    let stdout = run_ok(bin().args([
+        "ask", "--vault-root", vault.to_str().unwrap(),
+        "--cache-dir", cache_dir.to_str().unwrap(),
+        ask_question,
+    ]));
+    assert!(stdout.contains("OVP ask uses evidence cards and units."), "{stdout}");
 
     // === Failure → retry → blocked: a source with NO cassettes. ===
     std::fs::write(

--- a/crates/ovp-memory/src/ask.rs
+++ b/crates/ovp-memory/src/ask.rs
@@ -1,20 +1,24 @@
 //! `ask` — retrieval-augmented Q&A over OVP product state.
 //!
-//! Pipeline: query (JSON index substring) → context assembly (reader card
-//! titles + crystal claims) → LLM → cited answer.
+//! Pipeline: lexical retrieval over durable claims + reader cards + accepted
+//! units → context assembly with evidence ids → LLM → cited answer.
 //!
 //! Ephemeral reuse surface: answers are NOT durable truth, NOT in ledger.
 //! Optionally persisted to `.ovp/chats/<timestamp>.md` for session continuity.
 
 use std::path::{Path, PathBuf};
 
+use ovp_index::evidence::EvidenceModel;
 use ovp_index::model::IndexModel;
-use ovp_index::query::{run_query, Query};
+use ovp_index::query::claim_status_str;
+use ovp_index::score::lexical_score;
 use ovp_llm::{ModelClient, ModelMessage, ModelRequest};
+use serde::{Deserialize, Serialize};
 
 pub struct AskArgs {
     pub question: String,
     pub max_context_hits: usize,
+    pub evidence_quotas: EvidenceQuotas,
     pub max_tokens: u32,
     pub model_name: String,
     pub save_chat: bool,
@@ -25,6 +29,7 @@ impl Default for AskArgs {
         Self {
             question: String::new(),
             max_context_hits: 20,
+            evidence_quotas: EvidenceQuotas::default(),
             max_tokens: 2048,
             model_name: "claude-sonnet-4-20250514".into(),
             save_chat: false,
@@ -32,9 +37,49 @@ impl Default for AskArgs {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceKind {
+    Unit,
+    Card,
+    Claim,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EvidenceItem {
+    pub id: String,
+    pub kind: EvidenceKind,
+    pub title: String,
+    pub body: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub quote: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EvidenceQuotas {
+    pub units: usize,
+    pub cards: usize,
+    pub claims: usize,
+    pub max_chars: usize,
+}
+
+impl Default for EvidenceQuotas {
+    fn default() -> Self {
+        Self {
+            units: 8,
+            cards: 4,
+            claims: 4,
+            max_chars: 24_000,
+        }
+    }
+}
+
 pub struct AskResult {
     pub answer: String,
     pub context_hits: usize,
+    pub evidence: Vec<EvidenceItem>,
     pub chat_file: Option<PathBuf>,
 }
 
@@ -44,22 +89,47 @@ pub fn ask(
     args: &AskArgs,
     vault_root: &Path,
 ) -> Result<AskResult, String> {
-    let query = Query { term: Some(args.question.clone()), ..Default::default() };
-    let hits = run_query(model, &query);
-    let context_hits = hits.len().min(args.max_context_hits);
+    ask_with_optional_evidence(model, None, client, args, vault_root)
+}
 
-    let mut context = String::new();
-    for hit in hits.iter().take(args.max_context_hits) {
-        context.push_str(&format!("[{}] {}\n", hit.kind, hit.line));
+pub fn ask_with_evidence(
+    model: &IndexModel,
+    evidence: &EvidenceModel,
+    client: &mut dyn ModelClient,
+    args: &AskArgs,
+    vault_root: &Path,
+) -> Result<AskResult, String> {
+    ask_with_optional_evidence(model, Some(evidence), client, args, vault_root)
+}
+
+pub fn ask_with_optional_evidence(
+    model: &IndexModel,
+    evidence: Option<&EvidenceModel>,
+    client: &mut dyn ModelClient,
+    args: &AskArgs,
+    vault_root: &Path,
+) -> Result<AskResult, String> {
+    let mut quotas = args.evidence_quotas;
+    if args.max_context_hits == 0 {
+        quotas.units = 0;
+        quotas.cards = 0;
+        quotas.claims = 0;
     }
+    let mut evidence_items = assemble_evidence(model, evidence, &args.question, quotas);
+    if args.max_context_hits > 0 && evidence_items.len() > args.max_context_hits {
+        evidence_items.truncate(args.max_context_hits);
+    }
+    let context_hits = evidence_items.len();
+    let context = render_evidence_context(&evidence_items);
 
     let system = "You are a knowledge assistant for OVP (Obsidian Vault Pipeline). \
-        Answer questions using ONLY the provided context from the index. \
-        Cite sources when possible using [kind] markers. \
-        If the context doesn't contain enough information, say so.".to_string();
+        Answer questions using ONLY the provided claim/card/unit evidence context. \
+        Cite evidence ids in square brackets. \
+        If evidence is insufficient, say what is missing. Do not invent citations."
+        .to_string();
 
     let user_msg = format!(
-        "Context from OVP index ({context_hits} hits):\n\n{context}\n\n---\n\nQuestion: {}",
+        "Context from OVP evidence index ({context_hits} hits):\n\n{context}\n\n---\n\nQuestion: {}",
         args.question
     );
 
@@ -69,20 +139,26 @@ pub fn ask(
         messages: vec![ModelMessage::User { content: user_msg }],
         max_tokens: args.max_tokens,
         temperature: Some(0.4),
-        cache_namespace: Some("ask/v1".into()),
+        cache_namespace: Some("ask/v2".into()),
     };
 
     let reply = client.call(&request).map_err(|e| format!("ask LLM: {e}"))?;
 
     let chat_file = if args.save_chat {
         let ts = chrono_like_timestamp();
-        let chat_path = vault_root.join(".ovp").join("chats").join(format!("{ts}.md"));
+        let chat_path = vault_root
+            .join(".ovp")
+            .join("chats")
+            .join(format!("{ts}.md"));
         if let Some(parent) = chat_path.parent() {
             std::fs::create_dir_all(parent).map_err(|e| format!("create chats dir: {e}"))?;
         }
         let chat_content = format!(
-            "# Ask — {}\n\n**Q:** {}\n\n**A:** {}\n\n---\n\nContext hits: {context_hits}\n",
-            ts, args.question, reply.text
+            "# Ask — {}\n\n**Q:** {}\n\n**A:** {}\n\n---\n\n## Evidence\n\n{}\n\nContext hits: {context_hits}\n",
+            ts,
+            args.question,
+            reply.text,
+            render_evidence_markdown(&evidence_items)
         );
         std::fs::write(&chat_path, chat_content).map_err(|e| format!("write chat: {e}"))?;
         Some(chat_path)
@@ -90,7 +166,217 @@ pub fn ask(
         None
     };
 
-    Ok(AskResult { answer: reply.text, context_hits, chat_file })
+    Ok(AskResult {
+        answer: reply.text,
+        context_hits,
+        evidence: evidence_items,
+        chat_file,
+    })
+}
+
+#[derive(Debug)]
+struct ScoredEvidence {
+    score: f64,
+    tier: u8,
+    item: EvidenceItem,
+}
+
+pub fn assemble_evidence(
+    model: &IndexModel,
+    evidence: Option<&EvidenceModel>,
+    question: &str,
+    quotas: EvidenceQuotas,
+) -> Vec<EvidenceItem> {
+    if quotas.max_chars == 0 || (quotas.units + quotas.cards + quotas.claims) == 0 {
+        return Vec::new();
+    }
+
+    let mut claims = Vec::new();
+    let mut cards = Vec::new();
+    let mut units = Vec::new();
+
+    for claim in &model.claims {
+        let theme = claim.theme.as_deref().unwrap_or("");
+        let score = lexical_score(question, &[&claim.claim_id, &claim.claim, theme]);
+        if score <= 0.0 {
+            continue;
+        }
+        let status = claim_status_str(claim.status);
+        claims.push(ScoredEvidence {
+            score,
+            tier: 0,
+            item: EvidenceItem {
+                id: claim.claim_id.clone(),
+                kind: EvidenceKind::Claim,
+                title: format!("{status} claim{}", optional_theme_suffix(theme)),
+                body: format!(
+                    "Claim: {}\nSources: {}",
+                    claim.claim,
+                    claim.sources.join(",")
+                ),
+                quote: None,
+                path: None,
+            },
+        });
+    }
+
+    if let Some(evidence) = evidence {
+        for card in &evidence.cards {
+            let score = lexical_score(
+                question,
+                &[&card.id, &card.source_title, &card.title, &card.content],
+            );
+            if score <= 0.0 {
+                continue;
+            }
+            cards.push(ScoredEvidence {
+                score,
+                tier: 1,
+                item: EvidenceItem {
+                    id: card.id.clone(),
+                    kind: EvidenceKind::Card,
+                    title: format!("{} — {}", card.source_title, card.title),
+                    body: format!(
+                        "Content: {}\nCites: {}",
+                        clip_chars(&card.content, 1_200),
+                        card.cited_unit_ids.join(",")
+                    ),
+                    quote: None,
+                    path: Some(format!("{}/reader.md", card.pack_dir)),
+                },
+            });
+        }
+
+        for unit in &evidence.units {
+            let score = lexical_score(
+                question,
+                &[&unit.id, &unit.source_title, &unit.text, &unit.quote],
+            );
+            if score <= 0.0 {
+                continue;
+            }
+            let line = unit.line.map(|n| format!(" line {n}")).unwrap_or_default();
+            units.push(ScoredEvidence {
+                score,
+                tier: 2,
+                item: EvidenceItem {
+                    id: unit.id.clone(),
+                    kind: EvidenceKind::Unit,
+                    title: format!("{}{}", unit.source_title, line),
+                    body: format!(
+                        "Text: {}\nAttribution: {}\nModality: {}",
+                        unit.text, unit.attribution, unit.modality
+                    ),
+                    quote: Some(unit.quote.clone()),
+                    path: Some(format!("{}/reader.md", unit.pack_dir)),
+                },
+            });
+        }
+    }
+
+    sort_scored(&mut claims);
+    sort_scored(&mut cards);
+    sort_scored(&mut units);
+
+    claims.truncate(quotas.claims);
+    cards.truncate(quotas.cards);
+    units.truncate(quotas.units);
+
+    let mut rows = Vec::new();
+    rows.extend(claims);
+    rows.extend(cards);
+    rows.extend(units);
+    rows.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.tier.cmp(&b.tier))
+            .then_with(|| a.item.id.cmp(&b.item.id))
+    });
+
+    let mut out = Vec::new();
+    let mut used_chars = 0usize;
+    for row in rows {
+        let rendered_len = render_evidence_block(&row.item).len();
+        if used_chars > 0 && used_chars + rendered_len > quotas.max_chars {
+            continue;
+        }
+        used_chars += rendered_len;
+        out.push(row.item);
+    }
+    out
+}
+
+fn sort_scored(rows: &mut [ScoredEvidence]) {
+    rows.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.tier.cmp(&b.tier))
+            .then_with(|| a.item.id.cmp(&b.item.id))
+    });
+}
+
+pub fn render_evidence_context(items: &[EvidenceItem]) -> String {
+    let mut context = String::new();
+    for item in items {
+        context.push_str(&render_evidence_block(item));
+        context.push('\n');
+    }
+    context
+}
+
+fn render_evidence_block(item: &EvidenceItem) -> String {
+    let kind = evidence_kind_label(item.kind);
+    let mut out = format!("[{kind}:{}] {}\n{}\n", item.id, item.title, item.body);
+    if let Some(quote) = &item.quote {
+        out.push_str(&format!("Quote: {quote}\n"));
+    }
+    if let Some(path) = &item.path {
+        out.push_str(&format!("Path: {path}\n"));
+    }
+    out
+}
+
+fn render_evidence_markdown(items: &[EvidenceItem]) -> String {
+    if items.is_empty() {
+        return "(none)".into();
+    }
+    let mut out = String::new();
+    for item in items {
+        let kind = evidence_kind_label(item.kind);
+        let path = item.path.as_deref().unwrap_or("");
+        out.push_str(&format!(
+            "- `[{kind}:{}]` {} {}\n",
+            item.id, item.title, path
+        ));
+    }
+    out
+}
+
+fn evidence_kind_label(kind: EvidenceKind) -> &'static str {
+    match kind {
+        EvidenceKind::Unit => "unit",
+        EvidenceKind::Card => "card",
+        EvidenceKind::Claim => "claim",
+    }
+}
+
+fn optional_theme_suffix(theme: &str) -> String {
+    if theme.is_empty() {
+        String::new()
+    } else {
+        format!(" theme={theme}")
+    }
+}
+
+fn clip_chars(input: &str, max_chars: usize) -> String {
+    if input.chars().count() <= max_chars {
+        return input.to_string();
+    }
+    let mut clipped: String = input.chars().take(max_chars.saturating_sub(1)).collect();
+    clipped.push_str("...");
+    clipped
 }
 
 fn chrono_like_timestamp() -> String {
@@ -98,4 +384,219 @@ fn chrono_like_timestamp() -> String {
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default();
     format!("{}", now.as_secs())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use ovp_index::evidence::{CardEvidenceRow, EVIDENCE_SCHEMA, EvidenceModel, UnitEvidenceRow};
+    use ovp_index::model::{
+        ClaimRow, ClaimStatus, INDEX_SCHEMA, IndexModel, OpsState, PackRow, Totals,
+    };
+    use ovp_llm::{CallError, ModelClient, ModelReply, ModelRequest, StopReason, Usage};
+
+    use crate::ask::{AskArgs, EvidenceKind, EvidenceQuotas, ask_with_evidence, assemble_evidence};
+
+    struct CapturingClient {
+        request: Arc<Mutex<Option<ModelRequest>>>,
+    }
+
+    impl ModelClient for CapturingClient {
+        fn call(&mut self, request: &ModelRequest) -> Result<ModelReply, CallError> {
+            *self.request.lock().unwrap() = Some(request.clone());
+            Ok(ModelReply {
+                model: request.model.clone(),
+                text: "answer".into(),
+                stop_reason: StopReason::EndTurn,
+                usage: Usage {
+                    input_tokens: 1,
+                    output_tokens: 1,
+                },
+            })
+        }
+    }
+
+    fn model() -> IndexModel {
+        IndexModel {
+            schema: INDEX_SCHEMA.into(),
+            date: "2026-07-06".into(),
+            run_id: None,
+            totals: Totals::default(),
+            sources: vec![],
+            packs: vec![PackRow {
+                pack_dir: "40-Resources/Reader/memory".into(),
+                title: "Agent Memory Systems".into(),
+                date: Some("2026-07-06".into()),
+                units: 1,
+                cards: 1,
+                json_repaired: false,
+                card_titles: vec!["Memory as state".into()],
+                source_sha256: Some("sha-a".into()),
+            }],
+            claims: vec![ClaimRow {
+                claim_id: "claim-memory-1".into(),
+                claim: "Agent memory should be treated as persistent state.".into(),
+                theme: Some("memory".into()),
+                status: ClaimStatus::Durable,
+                sources: vec!["40-Resources/Reader/memory".into()],
+                strength: Some("supported".into()),
+                run_id: Some("run-1".into()),
+            }],
+            runs: vec![],
+            ops: OpsState::default(),
+        }
+    }
+
+    fn evidence() -> EvidenceModel {
+        EvidenceModel {
+            schema: EVIDENCE_SCHEMA.into(),
+            date: "2026-07-06".into(),
+            cards: vec![CardEvidenceRow {
+                id: "card:40-Resources/Reader/memory:0".into(),
+                pack_dir: "40-Resources/Reader/memory".into(),
+                source_sha256: Some("sha-a".into()),
+                source_title: "Agent Memory Systems".into(),
+                title: "Memory as state".into(),
+                content: "Agent memory is durable state, not transient prompt text.".into(),
+                unit_type: Some("claim".into()),
+                cited_unit_ids: vec!["u-001".into()],
+            }],
+            units: vec![UnitEvidenceRow {
+                id: "unit:40-Resources/Reader/memory:u-001".into(),
+                pack_dir: "40-Resources/Reader/memory".into(),
+                source_sha256: Some("sha-a".into()),
+                source_title: "Agent Memory Systems".into(),
+                unit_id: "u-001".into(),
+                text: "Agent memory is durable state.".into(),
+                quote: "Agent memory is durable state, not transient prompt text.".into(),
+                line: Some(42),
+                attribution: "author".into(),
+                modality: "asserted".into(),
+            }],
+            warnings: vec![],
+        }
+    }
+
+    #[test]
+    fn ask_prompt_includes_claim_card_and_unit_evidence_context() {
+        let captured = Arc::new(Mutex::new(None));
+        let mut client = CapturingClient {
+            request: captured.clone(),
+        };
+        let args = AskArgs {
+            question: "How should agent memory be treated?".into(),
+            max_context_hits: 10,
+            ..Default::default()
+        };
+
+        let result = ask_with_evidence(
+            &model(),
+            &evidence(),
+            &mut client,
+            &args,
+            std::path::Path::new("."),
+        )
+        .unwrap();
+
+        assert_eq!(result.context_hits, 3);
+        assert_eq!(result.evidence.len(), 3);
+        assert!(
+            result
+                .evidence
+                .iter()
+                .any(|item| item.kind == EvidenceKind::Claim && item.id == "claim-memory-1")
+        );
+        assert!(
+            result
+                .evidence
+                .iter()
+                .any(|item| item.kind == EvidenceKind::Card
+                    && item.id == "card:40-Resources/Reader/memory:0")
+        );
+        assert!(
+            result
+                .evidence
+                .iter()
+                .any(|item| item.kind == EvidenceKind::Unit
+                    && item.id == "unit:40-Resources/Reader/memory:u-001")
+        );
+        let request = captured.lock().unwrap().clone().unwrap();
+        assert_eq!(request.cache_namespace.as_deref(), Some("ask/v2"));
+        let user = match &request.messages[0] {
+            ovp_llm::ModelMessage::User { content } => content,
+            ovp_llm::ModelMessage::Assistant { .. } => panic!("expected user message"),
+        };
+
+        assert!(user.contains("[claim:claim-memory-1]"), "{user}");
+        assert!(
+            user.contains("[card:card:40-Resources/Reader/memory:0]"),
+            "{user}"
+        );
+        assert!(
+            user.contains("[unit:unit:40-Resources/Reader/memory:u-001]"),
+            "{user}"
+        );
+        assert!(
+            user.contains("Agent memory is durable state, not transient prompt text."),
+            "{user}"
+        );
+        assert!(user.contains("line 42"), "{user}");
+    }
+
+    #[test]
+    fn evidence_assembly_retrieves_cjk_card_and_unit_content() {
+        let evidence = EvidenceModel {
+            schema: EVIDENCE_SCHEMA.into(),
+            date: "2026-07-06".into(),
+            cards: vec![CardEvidenceRow {
+                id: "card:40-Resources/Reader/cjk:0".into(),
+                pack_dir: "40-Resources/Reader/cjk".into(),
+                source_sha256: Some("sha-cjk".into()),
+                source_title: "代理记忆系统".into(),
+                title: "记忆作为状态".into(),
+                content: "代理记忆系统把用户信息保存为长期状态。".into(),
+                unit_type: Some("claim".into()),
+                cited_unit_ids: vec!["u-cn-1".into()],
+            }],
+            units: vec![UnitEvidenceRow {
+                id: "unit:40-Resources/Reader/cjk:u-cn-1".into(),
+                pack_dir: "40-Resources/Reader/cjk".into(),
+                source_sha256: Some("sha-cjk".into()),
+                source_title: "代理记忆系统".into(),
+                unit_id: "u-cn-1".into(),
+                text: "代理记忆系统保存长期状态。".into(),
+                quote: "代理记忆系统把用户信息保存为长期状态。".into(),
+                line: Some(7),
+                attribution: "author".into(),
+                modality: "asserted".into(),
+            }],
+            warnings: vec![],
+        };
+
+        let items = assemble_evidence(
+            &model(),
+            Some(&evidence),
+            "记忆",
+            EvidenceQuotas {
+                claims: 0,
+                cards: 4,
+                units: 4,
+                max_chars: 24_000,
+            },
+        );
+
+        assert!(
+            items
+                .iter()
+                .any(|item| item.kind == EvidenceKind::Card && item.body.contains("长期状态"))
+        );
+        assert!(items.iter().any(|item| {
+            item.kind == EvidenceKind::Unit
+                && item
+                    .quote
+                    .as_deref()
+                    .is_some_and(|q| q.contains("用户信息"))
+        }));
+    }
 }


### PR DESCRIPTION
## Summary
- add ask_with_evidence over durable claims, reader cards, and accepted units
- include stable evidence markers in ask prompts for the future verifier seam
- wire CLI ask to require/read .ovp/index/evidence.json
- extend M31 e2e with a replayed ask command path

## Verification
- cargo metadata --no-deps --format-version 1
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- bash scripts/check_architecture.sh

## Stack
This PR is stacked on #285 because it depends on the evidence sidecar API. After #285 lands, retarget this PR to codex/rust-migration.

## Data hygiene
No .run, .ovp, live cassettes, raw eval artifacts, or scratch scripts are included.