### PR TITLE
feat: verify ask evidence citations

### DIFF
--- a/crates/ovp-cli/src/commands/ask.rs
+++ b/crates/ovp-cli/src/commands/ask.rs
@@ -6,10 +6,10 @@
 use std::path::PathBuf;
 
 use ovp_index::{read_evidence, read_index};
-use ovp_memory::ask::{AskArgs, ask_with_optional_evidence};
+use ovp_memory::ask::{ask_with_optional_evidence, AskArgs};
 
+use crate::commands::client::{build_client, ClientKind};
 use crate::CliError;
-use crate::commands::client::{ClientKind, build_client};
 
 pub struct AskCliArgs {
     pub vault_root: PathBuf,
@@ -17,6 +17,7 @@ pub struct AskCliArgs {
     pub client_kind: ClientKind,
     pub cache_dir: Option<PathBuf>,
     pub save: bool,
+    pub strict_ask: bool,
 }
 
 pub fn run(args: AskCliArgs) -> Result<(), CliError> {
@@ -54,6 +55,21 @@ pub fn run(args: AskCliArgs) -> Result<(), CliError> {
     if let Some(path) = &result.chat_file {
         let rel = path.strip_prefix(&args.vault_root).unwrap_or(path);
         eprintln!("\n(saved to {})", rel.display());
+    }
+    if let Some(report) = &result.verification {
+        eprintln!("verified citations: {}/{}", report.verified, report.cited);
+        if !report.missing.is_empty() {
+            eprintln!("missing citations: {}", report.missing.join(", "));
+        }
+        if !report.warnings.is_empty() {
+            eprintln!("citation warnings: {}", report.warnings.join(", "));
+        }
+        if args.strict_ask && (report.cited == 0 || report.verified < report.cited) {
+            return Err(CliError::Gate(format!(
+                "strict ask citation verification failed: verified {}/{}",
+                report.verified, report.cited
+            )));
+        }
     }
     eprintln!("({} context hits)", result.context_hits);
 

--- a/crates/ovp-cli/src/main.rs
+++ b/crates/ovp-cli/src/main.rs
@@ -343,6 +343,9 @@ enum Cmd {
         /// Save the Q&A to `.ovp/chats/<timestamp>.md`.
         #[arg(long)]
         save: bool,
+        /// Fail if the answer has no citations or cites ids not present in the supplied evidence.
+        #[arg(long)]
+        strict_ask: bool,
     },
     /// PRODUCT — health checks over OVP vault state: ledger↔fs consistency,
     /// orphan packs, stale index, crystal integrity, disk usage. Exits non-zero
@@ -1010,7 +1013,7 @@ fn main() -> ExitCode {
             let date = date.unwrap_or_else(today_iso);
             commands::digest::run(commands::digest::DigestArgs { vault_root, date, no_llm })
         }
-        Cmd::Ask { vault_root, question, client, cache_dir, save } => {
+        Cmd::Ask { vault_root, question, client, cache_dir, save, strict_ask } => {
             use commands::client::ClientKind;
             let client_kind = match client {
                 ClientKindArg::Replay => ClientKind::Replay,
@@ -1022,6 +1025,7 @@ fn main() -> ExitCode {
                 client_kind,
                 cache_dir,
                 save,
+                strict_ask,
             })
         }
         Cmd::Doctor { vault_root, fix, json } => {

--- a/crates/ovp-cli/tests/m31_e2e.rs
+++ b/crates/ovp-cli/tests/m31_e2e.rs
@@ -89,11 +89,15 @@ fn bin() -> Command {
 }
 
 fn run_ok(cmd: &mut Command) -> String {
+    run_ok_full(cmd).0
+}
+
+fn run_ok_full(cmd: &mut Command) -> (String, String) {
     let out = cmd.output().expect("binary runs");
     let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
     let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
     assert!(out.status.success(), "expected success.\nstdout:\n{stdout}\nstderr:\n{stderr}");
-    stdout
+    (stdout, stderr)
 }
 
 fn run_fail(cmd: &mut Command) -> (String, String) {
@@ -290,8 +294,14 @@ fn full_daily_workflow_capture_to_console_with_crystal_and_retry() {
     let ask_question = "What does OVP say about structurally neutral chunks?";
     let model = read_index(&vault).unwrap();
     let evidence = read_evidence(&vault).unwrap();
+    let cited_unit_id = evidence
+        .units
+        .iter()
+        .find(|unit| unit.quote == CLIP_QUOTE)
+        .map(|unit| unit.id.clone())
+        .expect("clip unit evidence");
     let mut rec = CachedModelClient::new(
-        Canned("OVP ask uses evidence cards and units.".into()),
+        Canned(format!("OVP ask uses evidence cards and units [unit:{cited_unit_id}].")),
         &cache_dir,
         "seed",
         CacheMode::Record,
@@ -305,12 +315,37 @@ fn full_daily_workflow_capture_to_console_with_crystal_and_retry() {
         &vault,
     )
     .unwrap();
-    let stdout = run_ok(bin().args([
+    let (stdout, stderr) = run_ok_full(bin().args([
         "ask", "--vault-root", vault.to_str().unwrap(),
         "--cache-dir", cache_dir.to_str().unwrap(),
         ask_question,
     ]));
-    assert!(stdout.contains("OVP ask uses evidence cards and units."), "{stdout}");
+    assert!(stdout.contains("OVP ask uses evidence cards and units"), "{stdout}");
+    assert!(stderr.contains("verified citations: 1/1"), "{stderr}");
+
+    let strict_question = "Give a strict answer about chunks.";
+    let mut rec = CachedModelClient::new(
+        Canned("This answer has no citation.".into()),
+        &cache_dir,
+        "seed",
+        CacheMode::Record,
+    )
+    .unwrap();
+    ask_with_evidence(
+        &model,
+        &evidence,
+        &mut rec,
+        &AskArgs { question: strict_question.into(), ..Default::default() },
+        &vault,
+    )
+    .unwrap();
+    let (_stdout, stderr) = run_fail(bin().args([
+        "ask", "--vault-root", vault.to_str().unwrap(),
+        "--cache-dir", cache_dir.to_str().unwrap(),
+        "--strict-ask",
+        strict_question,
+    ]));
+    assert!(stderr.contains("strict ask citation verification failed"), "{stderr}");
 
     // === Failure → retry → blocked: a source with NO cassettes. ===
     std::fs::write(

--- a/crates/ovp-memory/src/ask.rs
+++ b/crates/ovp-memory/src/ask.rs
@@ -15,6 +15,8 @@ use ovp_index::score::lexical_score;
 use ovp_llm::{ModelClient, ModelMessage, ModelRequest};
 use serde::{Deserialize, Serialize};
 
+use crate::verify::{verify_answer, VerificationReport};
+
 pub struct AskArgs {
     pub question: String,
     pub max_context_hits: usize,
@@ -22,6 +24,7 @@ pub struct AskArgs {
     pub max_tokens: u32,
     pub model_name: String,
     pub save_chat: bool,
+    pub verify_citations: bool,
 }
 
 impl Default for AskArgs {
@@ -33,6 +36,7 @@ impl Default for AskArgs {
             max_tokens: 2048,
             model_name: "claude-sonnet-4-20250514".into(),
             save_chat: false,
+            verify_citations: true,
         }
     }
 }
@@ -80,6 +84,7 @@ pub struct AskResult {
     pub answer: String,
     pub context_hits: usize,
     pub evidence: Vec<EvidenceItem>,
+    pub verification: Option<VerificationReport>,
     pub chat_file: Option<PathBuf>,
 }
 
@@ -143,6 +148,11 @@ pub fn ask_with_optional_evidence(
     };
 
     let reply = client.call(&request).map_err(|e| format!("ask LLM: {e}"))?;
+    let verification = if args.verify_citations {
+        Some(verify_answer(&reply.text, &evidence_items))
+    } else {
+        None
+    };
 
     let chat_file = if args.save_chat {
         let ts = chrono_like_timestamp();
@@ -154,11 +164,12 @@ pub fn ask_with_optional_evidence(
             std::fs::create_dir_all(parent).map_err(|e| format!("create chats dir: {e}"))?;
         }
         let chat_content = format!(
-            "# Ask — {}\n\n**Q:** {}\n\n**A:** {}\n\n---\n\n## Evidence\n\n{}\n\nContext hits: {context_hits}\n",
+            "# Ask — {}\n\n**Q:** {}\n\n**A:** {}\n\n---\n\n## Evidence\n\n{}\n\n## Verification\n\n{}\n\nContext hits: {context_hits}\n",
             ts,
             args.question,
             reply.text,
-            render_evidence_markdown(&evidence_items)
+            render_evidence_markdown(&evidence_items),
+            render_verification_markdown(verification.as_ref())
         );
         std::fs::write(&chat_path, chat_content).map_err(|e| format!("write chat: {e}"))?;
         Some(chat_path)
@@ -170,6 +181,7 @@ pub fn ask_with_optional_evidence(
         answer: reply.text,
         context_hits,
         evidence: evidence_items,
+        verification,
         chat_file,
     })
 }
@@ -354,6 +366,27 @@ fn render_evidence_markdown(items: &[EvidenceItem]) -> String {
     out
 }
 
+fn render_verification_markdown(report: Option<&VerificationReport>) -> String {
+    match report {
+        None => "not run".into(),
+        Some(report) => format!(
+            "verified citations: {}/{}\nmissing: {}\nwarnings: {}",
+            report.verified,
+            report.cited,
+            empty_dash(&report.missing),
+            empty_dash(&report.warnings)
+        ),
+    }
+}
+
+fn empty_dash(items: &[String]) -> String {
+    if items.is_empty() {
+        "-".into()
+    } else {
+        items.join(", ")
+    }
+}
+
 fn evidence_kind_label(kind: EvidenceKind) -> &'static str {
     match kind {
         EvidenceKind::Unit => "unit",
@@ -390,16 +423,17 @@ fn chrono_like_timestamp() -> String {
 mod tests {
     use std::sync::{Arc, Mutex};
 
-    use ovp_index::evidence::{CardEvidenceRow, EVIDENCE_SCHEMA, EvidenceModel, UnitEvidenceRow};
+    use ovp_index::evidence::{CardEvidenceRow, EvidenceModel, UnitEvidenceRow, EVIDENCE_SCHEMA};
     use ovp_index::model::{
-        ClaimRow, ClaimStatus, INDEX_SCHEMA, IndexModel, OpsState, PackRow, Totals,
+        ClaimRow, ClaimStatus, IndexModel, OpsState, PackRow, Totals, INDEX_SCHEMA,
     };
     use ovp_llm::{CallError, ModelClient, ModelReply, ModelRequest, StopReason, Usage};
 
-    use crate::ask::{AskArgs, EvidenceKind, EvidenceQuotas, ask_with_evidence, assemble_evidence};
+    use crate::ask::{ask_with_evidence, assemble_evidence, AskArgs, EvidenceKind, EvidenceQuotas};
 
     struct CapturingClient {
         request: Arc<Mutex<Option<ModelRequest>>>,
+        reply_text: String,
     }
 
     impl ModelClient for CapturingClient {
@@ -407,7 +441,7 @@ mod tests {
             *self.request.lock().unwrap() = Some(request.clone());
             Ok(ModelReply {
                 model: request.model.clone(),
-                text: "answer".into(),
+                text: self.reply_text.clone(),
                 stop_reason: StopReason::EndTurn,
                 usage: Usage {
                     input_tokens: 1,
@@ -483,6 +517,7 @@ mod tests {
         let captured = Arc::new(Mutex::new(None));
         let mut client = CapturingClient {
             request: captured.clone(),
+            reply_text: "answer".into(),
         };
         let args = AskArgs {
             question: "How should agent memory be treated?".into(),
@@ -501,26 +536,20 @@ mod tests {
 
         assert_eq!(result.context_hits, 3);
         assert_eq!(result.evidence.len(), 3);
-        assert!(
-            result
-                .evidence
-                .iter()
-                .any(|item| item.kind == EvidenceKind::Claim && item.id == "claim-memory-1")
-        );
-        assert!(
-            result
-                .evidence
-                .iter()
-                .any(|item| item.kind == EvidenceKind::Card
-                    && item.id == "card:40-Resources/Reader/memory:0")
-        );
-        assert!(
-            result
-                .evidence
-                .iter()
-                .any(|item| item.kind == EvidenceKind::Unit
-                    && item.id == "unit:40-Resources/Reader/memory:u-001")
-        );
+        assert!(result
+            .evidence
+            .iter()
+            .any(|item| item.kind == EvidenceKind::Claim && item.id == "claim-memory-1"));
+        assert!(result
+            .evidence
+            .iter()
+            .any(|item| item.kind == EvidenceKind::Card
+                && item.id == "card:40-Resources/Reader/memory:0"));
+        assert!(result
+            .evidence
+            .iter()
+            .any(|item| item.kind == EvidenceKind::Unit
+                && item.id == "unit:40-Resources/Reader/memory:u-001"));
         let request = captured.lock().unwrap().clone().unwrap();
         assert_eq!(request.cache_namespace.as_deref(), Some("ask/v2"));
         let user = match &request.messages[0] {
@@ -542,6 +571,34 @@ mod tests {
             "{user}"
         );
         assert!(user.contains("line 42"), "{user}");
+    }
+
+    #[test]
+    fn ask_result_verifies_answer_citations_against_supplied_evidence() {
+        let captured = Arc::new(Mutex::new(None));
+        let mut client = CapturingClient {
+            request: captured,
+            reply_text: "Memory persists [unit:unit:40-Resources/Reader/memory:u-001].".into(),
+        };
+        let args = AskArgs {
+            question: "How should agent memory be treated?".into(),
+            max_context_hits: 10,
+            ..Default::default()
+        };
+
+        let result = ask_with_evidence(
+            &model(),
+            &evidence(),
+            &mut client,
+            &args,
+            std::path::Path::new("."),
+        )
+        .unwrap();
+
+        let report = result.verification.expect("verification report");
+        assert_eq!(report.cited, 1);
+        assert_eq!(report.verified, 1);
+        assert!(report.missing.is_empty());
     }
 
     #[test]
@@ -586,11 +643,9 @@ mod tests {
             },
         );
 
-        assert!(
-            items
-                .iter()
-                .any(|item| item.kind == EvidenceKind::Card && item.body.contains("长期状态"))
-        );
+        assert!(items
+            .iter()
+            .any(|item| item.kind == EvidenceKind::Card && item.body.contains("长期状态")));
         assert!(items.iter().any(|item| {
             item.kind == EvidenceKind::Unit
                 && item

--- a/crates/ovp-memory/src/lib.rs
+++ b/crates/ovp-memory/src/lib.rs
@@ -6,4 +6,5 @@
 
 pub mod ask;
 pub mod digest;
+pub mod verify;
 pub mod working_memory;

--- a/crates/ovp-memory/src/verify.rs
+++ b/crates/ovp-memory/src/verify.rs
@@ -1,0 +1,214 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+
+use crate::ask::{EvidenceItem, EvidenceKind};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VerificationReport {
+    pub cited: usize,
+    pub verified: usize,
+    pub missing: Vec<String>,
+    pub warnings: Vec<String>,
+}
+
+pub fn verify_answer(answer: &str, evidence: &[EvidenceItem]) -> VerificationReport {
+    let citations = extract_citations(answer);
+    let mut warnings = Vec::new();
+    if citations.is_empty() {
+        warnings.push("no_citations".to_string());
+    }
+
+    let evidence_by_citation = evidence
+        .iter()
+        .map(|item| (citation_key(item), item))
+        .collect::<BTreeMap<_, _>>();
+
+    let mut verified = 0usize;
+    let mut missing = Vec::new();
+    for citation in &citations {
+        match evidence_by_citation.get(citation) {
+            None => missing.push(citation.clone()),
+            Some(item) if item_is_verifiable(item) => verified += 1,
+            Some(item) => {
+                missing.push(citation.clone());
+                warnings.push(unverifiable_warning(citation, item.kind));
+            }
+        }
+    }
+
+    VerificationReport {
+        cited: citations.len(),
+        verified,
+        missing,
+        warnings,
+    }
+}
+
+fn extract_citations(answer: &str) -> Vec<String> {
+    let mut out = BTreeSet::new();
+    let mut rest = answer;
+    while let Some(start) = rest.find('[') {
+        let after_start = &rest[start + 1..];
+        let Some(end) = after_start.find(']') else {
+            break;
+        };
+        let candidate = after_start[..end].trim();
+        if is_citation_candidate(candidate) {
+            out.insert(candidate.to_string());
+        }
+        rest = &after_start[end + 1..];
+    }
+    out.into_iter().collect()
+}
+
+fn is_citation_candidate(candidate: &str) -> bool {
+    !candidate.is_empty()
+        && matches!(
+            candidate.split_once(':').map(|(prefix, _)| prefix),
+            Some("unit" | "card" | "claim")
+        )
+}
+
+fn citation_key(item: &EvidenceItem) -> String {
+    format!("{}:{}", kind_label(item.kind), item.id)
+}
+
+fn kind_label(kind: EvidenceKind) -> &'static str {
+    match kind {
+        EvidenceKind::Unit => "unit",
+        EvidenceKind::Card => "card",
+        EvidenceKind::Claim => "claim",
+    }
+}
+
+fn item_is_verifiable(item: &EvidenceItem) -> bool {
+    match item.kind {
+        EvidenceKind::Unit => item
+            .quote
+            .as_deref()
+            .is_some_and(|quote| !quote.trim().is_empty()),
+        EvidenceKind::Card => card_cites_unit(item),
+        EvidenceKind::Claim => true,
+    }
+}
+
+fn card_cites_unit(item: &EvidenceItem) -> bool {
+    item.body.lines().any(|line| {
+        line.strip_prefix("Cites:")
+            .is_some_and(|cites| !cites.trim().is_empty())
+    })
+}
+
+fn unverifiable_warning(citation: &str, kind: EvidenceKind) -> String {
+    match kind {
+        EvidenceKind::Unit => format!("unit_without_quote:{citation}"),
+        EvidenceKind::Card => format!("card_without_cited_units:{citation}"),
+        EvidenceKind::Claim => format!("claim_unverifiable:{citation}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ask::{EvidenceItem, EvidenceKind};
+    use crate::verify::verify_answer;
+
+    fn evidence() -> Vec<EvidenceItem> {
+        vec![
+            EvidenceItem {
+                id: "unit:40-Resources/Reader/memory:u-1".into(),
+                kind: EvidenceKind::Unit,
+                title: "Agent Memory line 12".into(),
+                body: "Text: Agent memory persists.".into(),
+                quote: Some("Agent memory persists across sessions.".into()),
+                path: Some("40-Resources/Reader/memory/reader.md".into()),
+            },
+            EvidenceItem {
+                id: "card:40-Resources/Reader/memory:0".into(),
+                kind: EvidenceKind::Card,
+                title: "Agent Memory - Memory as state".into(),
+                body: "Content: Memory is state.\nCites: u-1".into(),
+                quote: None,
+                path: Some("40-Resources/Reader/memory/reader.md".into()),
+            },
+            EvidenceItem {
+                id: "claim-memory-1".into(),
+                kind: EvidenceKind::Claim,
+                title: "durable claim theme=memory".into(),
+                body: "Claim: Agent memory is persistent state.".into(),
+                quote: None,
+                path: None,
+            },
+        ]
+    }
+
+    #[test]
+    fn verifies_cited_unit_when_quote_backed_evidence_was_supplied() {
+        let report = verify_answer(
+            "Memory persists across sessions [unit:unit:40-Resources/Reader/memory:u-1].",
+            &evidence(),
+        );
+
+        assert_eq!(report.cited, 1);
+        assert_eq!(report.verified, 1);
+        assert!(report.missing.is_empty());
+        assert!(report.warnings.is_empty());
+    }
+
+    #[test]
+    fn citation_ids_may_contain_spaces_from_pack_directories() {
+        let evidence = vec![EvidenceItem {
+            id: "unit:40-Resources/Reader/2026-06-09_The Chunk Problem-359a9830:u-1".into(),
+            kind: EvidenceKind::Unit,
+            title: "The Chunk Problem line 1".into(),
+            body: "Text: A chunk is structurally neutral.".into(),
+            quote: Some("A chunk is a structurally neutral container.".into()),
+            path: Some(
+                "40-Resources/Reader/2026-06-09_The Chunk Problem-359a9830/reader.md".into(),
+            ),
+        }];
+
+        let report = verify_answer(
+            "Chunks are neutral [unit:unit:40-Resources/Reader/2026-06-09_The Chunk Problem-359a9830:u-1].",
+            &evidence,
+        );
+
+        assert_eq!(report.cited, 1);
+        assert_eq!(report.verified, 1);
+        assert!(report.missing.is_empty());
+    }
+
+    #[test]
+    fn reports_unknown_citation_ids_as_missing() {
+        let report = verify_answer(
+            "This cites evidence that was not supplied [unit:missing].",
+            &evidence(),
+        );
+
+        assert_eq!(report.cited, 1);
+        assert_eq!(report.verified, 0);
+        assert_eq!(report.missing, vec!["unit:missing"]);
+    }
+
+    #[test]
+    fn verifies_present_card_and_claim_citations() {
+        let report = verify_answer(
+            "Cards summarize breadth [card:card:40-Resources/Reader/memory:0], while claims carry synthesis [claim:claim-memory-1].",
+            &evidence(),
+        );
+
+        assert_eq!(report.cited, 2);
+        assert_eq!(report.verified, 2);
+        assert!(report.missing.is_empty());
+    }
+
+    #[test]
+    fn no_citations_is_not_an_error_but_is_warned() {
+        let report = verify_answer("The context is insufficient to answer.", &evidence());
+
+        assert_eq!(report.cited, 0);
+        assert_eq!(report.verified, 0);
+        assert!(report.missing.is_empty());
+        assert_eq!(report.warnings, vec!["no_citations"]);
+    }
+}

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -93,11 +93,22 @@ ovp-next console --vault-root "$VAULT"                     # rebuild console (+i
 ovp-next find --vault-root "$VAULT" <term>                 # search everything
 ovp-next find --vault-root "$VAULT" --kind sources --status needs_content
 ovp-next find --vault-root "$VAULT" --kind claims --status durable
+ovp-next find --vault-root "$VAULT" --kind cards "agent memory"
+ovp-next find --vault-root "$VAULT" --kind units "verbatim quote"
 ovp-next find --vault-root "$VAULT" --kind runs --date 2026-06
+ovp-next ask --vault-root "$VAULT" --client live "What does the vault say about agent memory?"
+ovp-next ask --vault-root "$VAULT" --client live --strict-ask "What evidence supports that?"
 ```
 
 Pinboard without live credentials: export from <https://pinboard.in/export/>
 (JSON) and use `--fixture`. The note format and dedup are identical to live.
+
+`ask` uses the rebuilt evidence sidecar (`.ovp/index/evidence.json`) plus the
+Crystal claim rows. It prints a verification summary such as
+`verified citations: 2/2` after the answer. `--strict-ask` exits non-zero when
+the answer has no citations or cites ids that were not supplied as evidence.
+This is deterministic citation verification, not a semantic proof of every
+sentence in the answer.
 
 ## 4. Crystal (durable claims) on the vault store
 

--- a/docs/product-pipeline.md
+++ b/docs/product-pipeline.md
@@ -126,7 +126,7 @@ console/graph`.
 | project --write | `10-Knowledge/Crystal/*.md` (machine-managed marker) | 0 | ✅ |
 | digest | `.ovp/digests/<date>.md` — ops digest (new packs/blocked/claim counts) | 0 today · $ optional (`render_llm_digest` exists, unwired) | ✅ plain |
 | working-memory | `.ovp/working-memory.md` | 0 today | ✅ |
-| ask / find | on-demand answers — **retrieval-constrained, NOT truth-gated yet**: `ask` feeds index hits into the prompt and prints the model answer; no post-answer citation parser / quote verifier exists. Calling it citation-gated requires building that verifier (gap, §6) | $/0 | 🟡 |
+| ask / find | on-demand answers. `find` is deterministic lexical search over the read model and evidence sidecar. `ask/v2` is retrieval-constrained over claims + cards + units and runs a deterministic citation verifier after the model answer: cited evidence ids must be among the blocks supplied to the model; unit citations must retain quote-backed evidence; card citations must retain cited units. Strict mode can fail an uncited/unverified answer. This is **citation verification, not whole-answer semantic truth-gating**. | $/0 | 🟡 |
 | serve / MCP | localhost UI · MCP tools (find/search/status + shallow doctor only; no ask/project/crystal-status) | 0 | ✅ minimal |
 
 Boundary: these can be deleted and rebuilt at any time and MUST NOT write back into authorities.
@@ -161,7 +161,7 @@ Do not conflate what `daily` does TODAY with the mature scheduler — the gap is
 | per ingest | intake → dedup → enrich(fixture-gated) → reader → lifecycle move → ledgers ✅ | same, with live-validated enrich + paper route |
 | daily | report → index → console → plain digest → working-memory | + **incremental crystal-synth on dirty groups** (entry conditions below) + doctor summary |
 | weekly | — (manual) | recluster (churn-bounded) → dirty-community resynth → **review-queue session** |
-| on demand | ask · find · project · serve · MCP · compare-run ✅ | same, with truth-gated ask |
+| on demand | ask · find · project · serve · MCP · compare-run ✅ | same, with deeper answer verification |
 | on prompt change | evolve candidate → AB → cassette replay gate ✅ | same |
 
 **Entry conditions before auto-synth joins the daily tier** (it does NOT get scheduled by
@@ -191,7 +191,8 @@ designed and doctor-visible. Until all five hold, crystal-synth stays a manual c
 P0 (product doesn't hold long-term without): scheduler tiers (§4) · Stage 3a 994-corpus synth
 run/signoff · review-queue loop with weekly cadence · doctor crystal-integrity checks.
 P1: incremental dirty-group synth · cost report · minimal lineage (dedup/strengthen) ·
-**ask truth-gating** (post-answer citation parser + quote verifier — until then `ask` is
-retrieval-constrained only) · **MCP mature surface** (ask/project/crystal-status; deep doctor) ·
+**ask semantic verifier** (the shipped deterministic citation verifier checks evidence ids and
+quote-backed unit presence; it does not yet prove every answer sentence is semantically entailed) ·
+**MCP mature surface** (ask/project/crystal-status; deep doctor) ·
 web-fetch same-run fix · UTC→local date · live validation of enrich paths · paper-route A/B.
 Gated on M34 experiment: everything in G5-undecided, supersede-by-subject, contradiction.


### PR DESCRIPTION
## Summary
- add deterministic ask citation verification over supplied evidence ids
- print verification summaries from `ovp-next ask` and add `--strict-ask` gate mode
- update operator/product docs to describe citation verification boundaries

## Verification
- `cargo metadata --no-deps --format-version 1`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `bash scripts/check_architecture.sh`