### PR TITLE
feat: prepare crystal review sessions

### DIFF
--- a/crates/ovp-cli/src/commands/crystal_review_session.rs
+++ b/crates/ovp-cli/src/commands/crystal_review_session.rs
@@ -1,0 +1,165 @@
+use std::path::PathBuf;
+
+use ovp_domain::crystal::{ReviewAction, ReviewDecision, ReviewEntry};
+
+use crate::commands::crystal_write::read_review_queue;
+use crate::CliError;
+
+pub struct CrystalReviewSessionPrepareArgs {
+    pub vault_root: PathBuf,
+    pub batch: usize,
+    pub out: PathBuf,
+}
+
+pub fn run_prepare(args: CrystalReviewSessionPrepareArgs) -> Result<(), CliError> {
+    let review_path = args.vault_root.join(".ovp/crystal/review.json");
+    let mut review = read_review_queue(&review_path)?;
+    review.sort_by(|a, b| {
+        (a.theme.as_str(), a.claim_id.as_str()).cmp(&(b.theme.as_str(), b.claim_id.as_str()))
+    });
+    review.truncate(args.batch);
+
+    std::fs::create_dir_all(&args.out)
+        .map_err(|e| CliError::Io(format!("creating {}: {e}", args.out.display())))?;
+    std::fs::write(
+        args.out.join("selected-claim-ids.txt"),
+        selected_ids(&review),
+    )
+    .map_err(|e| CliError::Io(format!("writing selected ids: {e}")))?;
+    std::fs::write(
+        args.out.join("review-sheet.md"),
+        render_review_sheet(&review),
+    )
+    .map_err(|e| CliError::Io(format!("writing review sheet: {e}")))?;
+    std::fs::write(
+        args.out.join("decisions.template.json"),
+        render_decisions_template(&review)?,
+    )
+    .map_err(|e| CliError::Io(format!("writing decisions template: {e}")))?;
+
+    println!(
+        "crystal-review session prepare: {} claim(s) -> {}",
+        review.len(),
+        args.out.display()
+    );
+    println!("  review-sheet.md");
+    println!("  decisions.template.json");
+    println!("  selected-claim-ids.txt");
+    Ok(())
+}
+
+fn selected_ids(review: &[ReviewEntry]) -> String {
+    let mut out = String::new();
+    for entry in review {
+        out.push_str(&entry.claim_id);
+        out.push('\n');
+    }
+    out
+}
+
+fn render_review_sheet(review: &[ReviewEntry]) -> String {
+    let mut out = String::from("# Crystal Review Session\n\n");
+    if review.is_empty() {
+        out.push_str("_No review entries selected._\n");
+        return out;
+    }
+    for (idx, entry) in review.iter().enumerate() {
+        out.push_str(&format!(
+            "## {}. `{}` [{}] - {}\n\n{}\n\n_strength: {:?} | evidence_sufficient: {}_\n\n{}\n\n",
+            idx + 1,
+            entry.claim_id,
+            entry.theme,
+            final_class_label(entry),
+            entry.claim.trim(),
+            entry.strength,
+            entry.evidence_sufficient,
+            entry.rationale.trim()
+        ));
+    }
+    out
+}
+
+fn final_class_label(entry: &ReviewEntry) -> String {
+    format!("{:?}", entry.final_class)
+}
+
+fn render_decisions_template(review: &[ReviewEntry]) -> Result<String, CliError> {
+    let decisions: Vec<ReviewDecision> = review
+        .iter()
+        .map(|entry| ReviewDecision {
+            claim_id: entry.claim_id.clone(),
+            action: ReviewAction::KeepCaveated,
+            revisions: Vec::new(),
+            note: "TODO: rewrite | split | keep_caveated | reject".into(),
+        })
+        .collect();
+    serde_json::to_string_pretty(&decisions)
+        .map(|body| format!("{body}\n"))
+        .map_err(|e| CliError::Io(format!("serializing decisions template: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use serde_json::json;
+
+    use crate::commands::crystal_review_session::{run_prepare, CrystalReviewSessionPrepareArgs};
+
+    #[test]
+    fn crystal_review_session_prepare_writes_deterministic_batch_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let vault = tmp.path().join("vault");
+        let store = vault.join(".ovp/crystal");
+        fs::create_dir_all(&store).unwrap();
+        fs::write(
+            store.join("review.json"),
+            serde_json::to_string_pretty(&json!({
+                "review": [
+                    {
+                        "claim_id": "z",
+                        "claim": "z claim",
+                        "theme": "zeta",
+                        "final_class": "caveated",
+                        "strength": "supported",
+                        "evidence_sufficient": true,
+                        "rationale": "z rationale"
+                    },
+                    {
+                        "claim_id": "a",
+                        "claim": "a claim",
+                        "theme": "alpha",
+                        "final_class": "caveated",
+                        "strength": "supported",
+                        "evidence_sufficient": true,
+                        "rationale": "a rationale"
+                    }
+                ]
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        let out = tmp.path().join("session");
+
+        run_prepare(CrystalReviewSessionPrepareArgs {
+            vault_root: vault,
+            batch: 1,
+            out: out.clone(),
+        })
+        .unwrap();
+
+        assert_eq!(
+            fs::read_to_string(out.join("selected-claim-ids.txt")).unwrap(),
+            "a\n"
+        );
+        let sheet = fs::read_to_string(out.join("review-sheet.md")).unwrap();
+        assert!(sheet.contains("a claim"), "{sheet}");
+        assert!(!sheet.contains("z claim"), "{sheet}");
+        let template = fs::read_to_string(out.join("decisions.template.json")).unwrap();
+        assert!(template.contains(r#""claim_id": "a""#), "{template}");
+        assert!(
+            template.contains(r#""action": "keep_caveated""#),
+            "{template}"
+        );
+    }
+}

--- a/crates/ovp-cli/src/commands/crystal_synth.rs
+++ b/crates/ovp-cli/src/commands/crystal_synth.rs
@@ -362,6 +362,7 @@ pub fn run(args: CrystalSynthArgs) -> Result<(), CliError> {
         store: paths.store.clone(),
         run_id: args.run_id.clone(),
         header,
+        processed_review_ids: std::collections::BTreeSet::new(),
     })?;
 
     // --- Summary (mirrors crystal-write). ---

--- a/crates/ovp-cli/src/commands/crystal_write.rs
+++ b/crates/ovp-cli/src/commands/crystal_write.rs
@@ -5,6 +5,7 @@
 //! review file (NEVER durable truth), and renders a human-readable `crystal.md`.
 //! No model call, no vault write, no graph.
 
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 
 use ovp_domain::crystal::{
@@ -42,6 +43,7 @@ pub struct WriteInputs {
     pub store: PathBuf,
     pub run_id: Option<String>,
     pub header: CrystalHeader,
+    pub processed_review_ids: BTreeSet<String>,
 }
 
 /// What a durable write produced (returned so callers can print their own summary).
@@ -57,6 +59,27 @@ pub struct WriteOutcome {
     pub review: usize,
     pub ledger_path: PathBuf,
     pub crystal_md_path: PathBuf,
+}
+
+pub fn merge_review_queue(
+    existing: Vec<ReviewEntry>,
+    processed_ids: &BTreeSet<String>,
+    new_entries: Vec<ReviewEntry>,
+) -> Vec<ReviewEntry> {
+    let mut by_id: BTreeMap<String, ReviewEntry> = BTreeMap::new();
+    for entry in existing {
+        if !processed_ids.contains(&entry.claim_id) {
+            by_id.insert(entry.claim_id.clone(), entry);
+        }
+    }
+    for entry in new_entries {
+        by_id.insert(entry.claim_id.clone(), entry);
+    }
+    let mut merged: Vec<_> = by_id.into_values().collect();
+    merged.sort_by(|a, b| {
+        (a.theme.as_str(), a.claim_id.as_str()).cmp(&(b.theme.as_str(), b.claim_id.as_str()))
+    });
+    merged
 }
 
 /// Build the grounding index by reading `<packs_dir>/<case>/units.accepted.json`.
@@ -104,6 +127,30 @@ fn read_ledger(path: &std::path::Path) -> Result<Vec<StoreEvent>, CliError> {
     Ok(events)
 }
 
+pub fn read_review_queue(path: &std::path::Path) -> Result<Vec<ReviewEntry>, CliError> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| CliError::Io(format!("reading review queue {}: {e}", path.display())))?;
+    let value: serde_json::Value = serde_json::from_str(&text)
+        .map_err(|e| CliError::Io(format!("parsing review queue {}: {e}", path.display())))?;
+    let entries = value
+        .get("review")
+        .cloned()
+        .unwrap_or_else(|| serde_json::Value::Array(Vec::new()));
+    serde_json::from_value(entries)
+        .map_err(|e| CliError::Io(format!("parsing review entries {}: {e}", path.display())))
+}
+
+fn write_review_queue(path: &std::path::Path, review: &[ReviewEntry]) -> Result<(), CliError> {
+    std::fs::write(
+        path,
+        serde_json::to_string_pretty(&serde_json::json!({ "review": review })).unwrap() + "\n",
+    )
+    .map_err(|e| CliError::Io(format!("writing review.json: {e}")))
+}
+
 pub fn run(args: CrystalWriteArgs) -> Result<(), CliError> {
     let candidate: CrystalCandidate = serde_json::from_str(
         &std::fs::read_to_string(&args.candidate)
@@ -129,6 +176,7 @@ pub fn run(args: CrystalWriteArgs) -> Result<(), CliError> {
         store: args.store.clone(),
         run_id: args.run_id.clone(),
         header,
+        processed_review_ids: BTreeSet::new(),
     })?;
 
     println!("crystal-write: run_id={}", out.run_id);
@@ -150,7 +198,15 @@ pub fn run(args: CrystalWriteArgs) -> Result<(), CliError> {
 /// (idempotent by `claim_key`), record caveated/reject in `review.json`, and
 /// render `crystal.md`. Refuses loudly on any gate gap. Reused by `crystal-synth`.
 pub fn write_durable(inputs: WriteInputs) -> Result<WriteOutcome, CliError> {
-    let WriteInputs { candidate, verdicts, index, store, run_id: run_id_override, header } = inputs;
+    let WriteInputs {
+        candidate,
+        verdicts,
+        index,
+        store,
+        run_id: run_id_override,
+        header,
+        processed_review_ids,
+    } = inputs;
     let report = lint_candidate(&candidate, &index);
     let scores = score_candidate(&report);
     let claim_ids: Vec<String> = candidate.items.iter().map(|c| c.id.clone()).collect();
@@ -274,15 +330,15 @@ pub fn write_durable(inputs: WriteInputs) -> Result<WriteOutcome, CliError> {
         .filter(|r| r.status == ovp_domain::crystal::CrystalStatus::Active)
         .cloned()
         .collect();
-    let md = render_crystal_md(&header, &active_now, &review);
+    let review_path = store.join("review.json");
+    let existing_review = read_review_queue(&review_path)?;
+    let merged_review = merge_review_queue(existing_review, &processed_review_ids, review.clone());
+
+    let md = render_crystal_md(&header, &active_now, &merged_review);
     let crystal_md_path = store.join("crystal.md");
     std::fs::write(&crystal_md_path, md)
         .map_err(|e| CliError::Io(format!("writing crystal.md: {e}")))?;
-    std::fs::write(
-        store.join("review.json"),
-        serde_json::to_string_pretty(&serde_json::json!({"review": review})).unwrap() + "\n",
-    )
-    .map_err(|e| CliError::Io(format!("writing review.json: {e}")))?;
+    write_review_queue(&review_path, &merged_review)?;
 
     Ok(WriteOutcome {
         run_id,
@@ -293,4 +349,50 @@ pub fn write_durable(inputs: WriteInputs) -> Result<WriteOutcome, CliError> {
         ledger_path,
         crystal_md_path,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use ovp_domain::crystal::{FinalClass, StrengthClass};
+
+    use super::{merge_review_queue, ReviewEntry};
+
+    fn entry(id: &str, theme: &str) -> ReviewEntry {
+        ReviewEntry {
+            claim_id: id.into(),
+            claim: format!("claim {id}"),
+            theme: theme.into(),
+            final_class: FinalClass::Caveated,
+            strength: StrengthClass::Supported,
+            evidence_sufficient: true,
+            rationale: format!("rationale {id}"),
+        }
+    }
+
+    #[test]
+    fn crystal_review_preserves_unprocessed_queue() {
+        let existing = vec![entry("a", "t1"), entry("b", "t1"), entry("c", "t2")];
+        let processed = BTreeSet::from(["a".to_string()]);
+        let new_entries = vec![entry("d", "t3")];
+
+        let merged = merge_review_queue(existing, &processed, new_entries);
+        let ids: Vec<_> = merged.iter().map(|entry| entry.claim_id.as_str()).collect();
+
+        assert_eq!(ids, vec!["b", "c", "d"]);
+    }
+
+    #[test]
+    fn crystal_review_merge_prefers_new_entries_on_duplicate_ids() {
+        let existing = vec![entry("a", "old")];
+        let processed = BTreeSet::new();
+        let new_entries = vec![entry("a", "new")];
+
+        let merged = merge_review_queue(existing, &processed, new_entries);
+
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].claim_id, "a");
+        assert_eq!(merged[0].theme, "new");
+    }
 }

--- a/crates/ovp-cli/src/commands/mod.rs
+++ b/crates/ovp-cli/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod compare_run;
 pub mod copy_probe;
 pub mod crystal_lint;
 pub mod crystal_review;
+pub mod crystal_review_session;
 pub mod crystal_synth;
 pub mod crystal_write;
 pub mod console_cmd;

--- a/crates/ovp-cli/src/main.rs
+++ b/crates/ovp-cli/src/main.rs
@@ -504,6 +504,17 @@ enum Cmd {
         #[arg(long, default_value = ".run/m25/revised-candidate.json")]
         out: PathBuf,
     },
+    /// PRODUCT — prepare a bounded human review session from the vault-local
+    /// Crystal review queue. Writes a review sheet, decisions template, and
+    /// selected ids. This does not run the strength gate or write durable truth.
+    CrystalReviewSession {
+        #[arg(long)]
+        vault_root: PathBuf,
+        #[arg(long, default_value_t = 20)]
+        batch: usize,
+        #[arg(long)]
+        out: PathBuf,
+    },
     /// DIAGNOSTIC — experimental/eval harness; not a product path.
     /// M14b (experimental): classify the OBJECTS that M14a.8 accepted Units talk
     /// about into LOCAL ReferentCandidates and write a review pack to `--out`.
@@ -1072,6 +1083,14 @@ fn main() -> ExitCode {
         Cmd::CrystalReview { candidate, decisions, out } => {
             use commands::crystal_review::CrystalReviewArgs;
             commands::crystal_review::run(CrystalReviewArgs { candidate, decisions, out })
+        }
+        Cmd::CrystalReviewSession { vault_root, batch, out } => {
+            use commands::crystal_review_session::CrystalReviewSessionPrepareArgs;
+            commands::crystal_review_session::run_prepare(CrystalReviewSessionPrepareArgs {
+                vault_root,
+                batch,
+                out,
+            })
         }
         Cmd::ExtractReferents { units, out, cache_dir, client } => {
             use commands::client::ClientKind;

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -127,6 +127,22 @@ ovp-next console --vault-root "$VAULT"     # claims appear under Crystal · 结�
 `40-Resources/Reader/`. Daily packs already write `units.accepted.json` in
 exactly the layout the gates expect.
 
+Prepare a bounded review session for caveated claims:
+
+```bash
+ovp-next crystal-review-session \
+  --vault-root "$VAULT" \
+  --batch 20 \
+  --out .run/review-session-$(date +%Y%m%d)
+```
+
+This writes `review-sheet.md`, `decisions.template.json`, and
+`selected-claim-ids.txt`. The command does not decide durability and does not
+write the Crystal ledger. Rewrites/splits must still carry full citations and
+re-enter the normal strength gate + `crystal-write` path. `crystal-write`
+preserves unprocessed `review.json` entries when new caveated claims are
+written, so a small review batch no longer erases the rest of the queue.
+
 ## 5. Recovery / rebuild
 
 Everything under `.ovp/index/` and `.ovp/console/` is a derived projection:

--- a/docs/product-pipeline.md
+++ b/docs/product-pipeline.md
@@ -101,7 +101,7 @@ from KMEM: their memory is a self-contained summary; our unit is an evidence-anc
 
 | Pipeline | In → Out | Auth | Cost | Status | Failure states |
 |---|---|---|---|---|---|
-| review-queue | caveated/reject → human decision → revised candidate → RE-GATE | A (via write) | 0+human | 🟡 `crystal-review` exists, NOT in the loop — **unbounded-growth rot vector** (6 caveated already) | stale queue (needs weekly SLA) |
+| review-queue | caveated/reject → human decision → revised candidate → RE-GATE | A (via write) | 0+human | 🟡 queue preservation + bounded `crystal-review-session` prepare shipped; turnkey apply→strength→write chain still pending | stale queue (needs weekly SLA) |
 | lineage: dedup/strengthen | new claims vs active (text+citation overlap+grouping) | A (via write) | 0/$ | ⬜ near-term, minimal form | wrong-merge (conservative default: append) |
 | supersede | strengthened claim replaces old, `superseded_by` | A | 0 | ⬜ mid-term | — |
 | contradiction | opposing claims, same subject | A | $ | ⬜ long-term; needs stable subject — **M34 experiment decides** | — |
@@ -189,7 +189,7 @@ designed and doctor-visible. Until all five hold, crystal-synth stays a manual c
 ## 6. Gap list — current → mature (the actionable part)
 
 P0 (product doesn't hold long-term without): scheduler tiers (§4) · Stage 3a 994-corpus synth
-run/signoff · review-queue loop with weekly cadence · doctor crystal-integrity checks.
+run/signoff · review-queue apply loop with weekly cadence · doctor crystal-integrity checks.
 P1: incremental dirty-group synth · cost report · minimal lineage (dedup/strengthen) ·
 **ask semantic verifier** (the shipped deterministic citation verifier checks evidence ids and
 quote-backed unit presence; it does not yet prove every answer sentence is semantically entailed) ·


### PR DESCRIPTION
## Summary
- preserve unprocessed Crystal review queue entries when writing new caveated claims
- add `crystal-review-session` to prepare bounded human review batches
- document the current review-session boundary and remaining apply loop gap

## Verification
- `cargo metadata --no-deps --format-version 1`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `bash scripts/check_architecture.sh`
- smoke: `ovp-next crystal-review-session --vault-root ~/Documents/ovp-vault --batch 20 --out .run/m34-review-session-20260706`

## Notes
- no `.run/`, live cassettes, KMEM scripts, or eval artifacts are committed
- the command prepares review files only; rewrite/split decisions still re-enter strength + `crystal-write`
