### PR TITLE
feat(review): M35 hygiene phase 0 — decidable lane routing, self-contained entries, dedup, labeled regression set

### DIFF
--- a/crates/ovp-cli/src/commands/crystal_review_session.rs
+++ b/crates/ovp-cli/src/commands/crystal_review_session.rs
@@ -26,6 +26,16 @@ pub struct CrystalReviewSessionPrepareArgs {
 pub fn run_prepare(args: CrystalReviewSessionPrepareArgs) -> Result<(), CliError> {
     let review_path = args.vault_root.join(".ovp/crystal/review.json");
     let mut review = read_review_queue(&review_path)?;
+    // Human sessions review the Review lane only — source-scoped insights
+    // (single-source + Supported) are parked, not human debt (M35).
+    let parked = review
+        .iter()
+        .filter(|e| e.lane == ovp_domain::crystal::ReviewLane::SourceInsight)
+        .count();
+    review.retain(|e| e.lane == ovp_domain::crystal::ReviewLane::Review);
+    if parked > 0 {
+        println!("  ({parked} source-insight entr(ies) parked outside the human queue)");
+    }
     review.sort_by(|a, b| {
         (a.theme.as_str(), a.claim_id.as_str()).cmp(&(b.theme.as_str(), b.claim_id.as_str()))
     });
@@ -322,6 +332,23 @@ fn render_review_sheet(review: &[ReviewEntry]) -> String {
             entry.evidence_sufficient,
             entry.rationale.trim()
         ));
+        if entry.citations.is_empty() {
+            out.push_str(
+                "_No citations on this entry (pre-M35 queue) — regenerate the queue with a \
+                 replay `crystal-synth` run to populate them._\n\n",
+            );
+        } else {
+            out.push_str("Citations (copy into `revisions` for rewrite/split):\n\n");
+            for c in &entry.citations {
+                out.push_str(&format!(
+                    "- `{}` · `{}` — \"{}\"\n",
+                    c.case_id,
+                    c.unit_id,
+                    c.quote.trim()
+                ));
+            }
+            out.push('\n');
+        }
     }
     out
 }

--- a/crates/ovp-cli/src/commands/crystal_write.rs
+++ b/crates/ovp-cli/src/commands/crystal_write.rs
@@ -158,7 +158,9 @@ pub(crate) fn write_review_queue_with_collapsed(
     if !collapsed.is_empty() {
         body["collapsed"] = serde_json::json!(collapsed);
     }
-    std::fs::write(path, serde_json::to_string_pretty(&body).unwrap() + "\n")
+    let body = serde_json::to_string_pretty(&body)
+        .map_err(|e| CliError::Io(format!("serializing review queue: {e}")))?;
+    std::fs::write(path, body + "\n")
         .map_err(|e| CliError::Io(format!("writing review.json: {e}")))
 }
 

--- a/crates/ovp-cli/src/commands/crystal_write.rs
+++ b/crates/ovp-cli/src/commands/crystal_write.rs
@@ -144,11 +144,22 @@ pub fn read_review_queue(path: &std::path::Path) -> Result<Vec<ReviewEntry>, Cli
 }
 
 pub(crate) fn write_review_queue(path: &std::path::Path, review: &[ReviewEntry]) -> Result<(), CliError> {
-    std::fs::write(
-        path,
-        serde_json::to_string_pretty(&serde_json::json!({ "review": review })).unwrap() + "\n",
-    )
-    .map_err(|e| CliError::Io(format!("writing review.json: {e}")))
+    write_review_queue_with_collapsed(path, review, &[])
+}
+
+/// Write the queue plus the record of near-duplicate collapses performed this
+/// write (additive `collapsed` key; `read_review_queue` only reads `review`).
+pub(crate) fn write_review_queue_with_collapsed(
+    path: &std::path::Path,
+    review: &[ReviewEntry],
+    collapsed: &[ovp_domain::crystal::CollapsedDuplicate],
+) -> Result<(), CliError> {
+    let mut body = serde_json::json!({ "review": review });
+    if !collapsed.is_empty() {
+        body["collapsed"] = serde_json::json!(collapsed);
+    }
+    std::fs::write(path, serde_json::to_string_pretty(&body).unwrap() + "\n")
+        .map_err(|e| CliError::Io(format!("writing review.json: {e}")))
 }
 
 pub fn run(args: CrystalWriteArgs) -> Result<(), CliError> {
@@ -284,6 +295,11 @@ pub fn write_durable(inputs: WriteInputs) -> Result<WriteOutcome, CliError> {
                     strength: v.strength,
                     evidence_sufficient: v.evidence_sufficient,
                     rationale: v.rationale.clone(),
+                    citations: item.citations.clone(),
+                    lane: ovp_domain::crystal::review_lane(
+                        lint_of(&item.id).distinct_sources,
+                        Some(v),
+                    ),
                 });
             }
         }
@@ -333,12 +349,20 @@ pub fn write_durable(inputs: WriteInputs) -> Result<WriteOutcome, CliError> {
     let review_path = store.join("review.json");
     let existing_review = read_review_queue(&review_path)?;
     let merged_review = merge_review_queue(existing_review, &processed_review_ids, review.clone());
+    // Near-duplicate collapse BEFORE the queue is written (decidable signals
+    // only; recorded in review.json, never silent). Pre-M35 entries without
+    // citations can never match and are left alone.
+    let (merged_review, collapsed) =
+        ovp_domain::crystal::collapse_review_duplicates(merged_review);
+    for c in &collapsed {
+        println!("  review-queue: collapsed near-duplicate {} into {} ({})", c.dropped, c.kept, c.reason);
+    }
 
     let md = render_crystal_md(&header, &active_now, &merged_review);
     let crystal_md_path = store.join("crystal.md");
     std::fs::write(&crystal_md_path, md)
         .map_err(|e| CliError::Io(format!("writing crystal.md: {e}")))?;
-    write_review_queue(&review_path, &merged_review)?;
+    write_review_queue_with_collapsed(&review_path, &merged_review, &collapsed)?;
 
     Ok(WriteOutcome {
         run_id,
@@ -368,6 +392,8 @@ mod tests {
             strength: StrengthClass::Supported,
             evidence_sufficient: true,
             rationale: format!("rationale {id}"),
+            citations: Vec::new(),
+            lane: Default::default(),
         }
     }
 

--- a/crates/ovp-cli/src/commands/project.rs
+++ b/crates/ovp-cli/src/commands/project.rs
@@ -77,11 +77,17 @@ pub fn run(args: ProjectArgs) -> Result<(), CliError> {
 }
 
 fn print_summary(active: &[&DurableRecord], review: &[ReviewEntry]) {
-    let n_caveated = review.iter().filter(|r| r.final_class == FinalClass::Caveated).count();
+    use ovp_domain::crystal::ReviewLane;
+    let n_caveated = review
+        .iter()
+        .filter(|r| r.final_class == FinalClass::Caveated && r.lane == ReviewLane::Review)
+        .count();
+    let n_parked = review.iter().filter(|r| r.lane == ReviewLane::SourceInsight).count();
     let n_reject = review.iter().filter(|r| r.final_class == FinalClass::Reject).count();
     println!("=== Projection Lanes ===");
     println!("  Durable (AUTO):     {} active claim(s)", active.len());
     println!("  Review (ESCALATE):  {} caveated claim(s) awaiting human review", n_caveated);
+    println!("  Source insights:    {} single-source claim(s) parked (not review debt)", n_parked);
     println!("  Reject:             {} claim(s) rejected", n_reject);
 }
 
@@ -105,11 +111,21 @@ fn print_durable_lane(active: &[&DurableRecord], verbose: bool) {
 }
 
 fn print_review_lane(review: &[ReviewEntry], verbose: bool) {
+    let parked = review
+        .iter()
+        .filter(|r| r.lane == ovp_domain::crystal::ReviewLane::SourceInsight)
+        .count();
     let caveated: Vec<&ReviewEntry> = review
         .iter()
-        .filter(|r| r.final_class == FinalClass::Caveated)
+        .filter(|r| {
+            r.final_class == FinalClass::Caveated
+                && r.lane == ovp_domain::crystal::ReviewLane::Review
+        })
         .collect();
     println!("--- Review Lane (ESCALATE — awaiting human decision) ---");
+    if parked > 0 {
+        println!("  ({parked} single-source insight(s) parked outside the human queue)");
+    }
     if caveated.is_empty() {
         println!("  (no caveated claims pending review)");
         return;

--- a/crates/ovp-console/src/ops.rs
+++ b/crates/ovp-console/src/ops.rs
@@ -218,27 +218,48 @@ fn candidates_header(model: &IndexModel) -> String {
 }
 
 fn caveated_claims(model: &IndexModel) -> String {
-    let caveated: Vec<_> = model
+    // The HUMAN queue is the Review lane only; single-source Supported claims
+    // (lane = source_insight) are parked per-source insights, not review debt.
+    let (insights, review): (Vec<_>, Vec<_>) = model
         .claims
         .iter()
         .filter(|c| c.status == ClaimStatus::Caveated)
-        .collect();
-    if caveated.is_empty() {
-        return "<section><p class=\"empty\">No caveated claims pending review. 无待审保留意见主张。</p></section>\n".into();
+        .partition(|c| c.lane.as_deref() == Some("source_insight"));
+    let mut out = String::new();
+    if review.is_empty() {
+        out.push_str("<section><p class=\"empty\">No caveated claims pending review. 无待审保留意见主张。</p></section>\n");
+    } else {
+        out.push_str(
+            "<section><h2>Caveated Claims <span class=\"zh\">保留意见主张</span></h2>\n<table><thead><tr><th>Theme</th><th>Claim</th><th>Strength</th></tr></thead><tbody>\n",
+        );
+        for c in &review {
+            let (_, _, class) = claim_status_label(c.status);
+            out.push_str(&format!(
+                "<tr class=\"lv-{class}\"><td>{theme}</td><td>{claim}</td><td>{strength}</td></tr>\n",
+                theme = esc(c.theme.as_deref().unwrap_or("—")),
+                claim = esc(&c.claim),
+                strength = esc(c.strength.as_deref().unwrap_or("—")),
+            ));
+        }
+        out.push_str("</tbody></table></section>\n");
     }
-    let mut out = String::from(
-        "<section><h2>Caveated Claims <span class=\"zh\">保留意见主张</span></h2>\n<table><thead><tr><th>Theme</th><th>Claim</th><th>Strength</th></tr></thead><tbody>\n",
-    );
-    for c in &caveated {
-        let (_, _, class) = claim_status_label(c.status);
+    if !insights.is_empty() {
         out.push_str(&format!(
-            "<tr class=\"lv-{class}\"><td>{theme}</td><td>{claim}</td><td>{strength}</td></tr>\n",
-            theme = esc(c.theme.as_deref().unwrap_or("—")),
-            claim = esc(&c.claim),
-            strength = esc(c.strength.as_deref().unwrap_or("—")),
+            "<section><h2>Source Insights <span class=\"zh\">单源洞见（待第二来源）</span></h2>\n\
+             <p class=\"empty\">{} grounded, Supported, single-source claim(s) — parked \
+             outside the review queue until more sources arrive. 已接地且判定成立，但仅有单一来源。</p>\n\
+             <details><summary>Show list · 展开</summary><table><thead><tr><th>Theme</th><th>Claim</th></tr></thead><tbody>\n",
+            insights.len()
         ));
+        for c in &insights {
+            out.push_str(&format!(
+                "<tr><td>{theme}</td><td>{claim}</td></tr>\n",
+                theme = esc(c.theme.as_deref().unwrap_or("—")),
+                claim = esc(&c.claim),
+            ));
+        }
+        out.push_str("</tbody></table></details></section>\n");
     }
-    out.push_str("</tbody></table></section>\n");
     out
 }
 

--- a/crates/ovp-console/src/render.rs
+++ b/crates/ovp-console/src/render.rs
@@ -378,6 +378,7 @@ mod tests {
                     sources: vec!["case-a".into(), "case-b".into()],
                     strength: Some("supported".into()),
                     run_id: Some("crystal-1".into()),
+                    lane: None,
                 },
                 ClaimRow {
                     claim_id: "c02".into(),
@@ -387,6 +388,7 @@ mod tests {
                     sources: vec![],
                     strength: Some("opinion_as_fact".into()),
                     run_id: None,
+                    lane: None,
                 },
             ],
             runs: vec![RunRow {

--- a/crates/ovp-domain/src/crystal.rs
+++ b/crates/ovp-domain/src/crystal.rs
@@ -676,10 +676,15 @@ pub fn collapse_review_duplicates(
     let cited_units = |e: &ReviewEntry| -> std::collections::BTreeSet<(String, String)> {
         e.citations.iter().map(|c| (c.case_id.clone(), c.unit_id.clone())).collect()
     };
+    struct CachedEntry {
+        entry: ReviewEntry,
+        units: std::collections::BTreeSet<(String, String)>,
+        tokens: std::collections::BTreeSet<String>,
+    }
 
     let mut sorted = entries;
     sorted.sort_by(|a, b| a.claim_id.cmp(&b.claim_id));
-    let mut kept: Vec<ReviewEntry> = Vec::new();
+    let mut kept: Vec<CachedEntry> = Vec::new();
     let mut collapsed: Vec<CollapsedDuplicate> = Vec::new();
     'outer: for e in sorted {
         let e_units = cited_units(&e);
@@ -689,26 +694,26 @@ pub fn collapse_review_duplicates(
             // Review entry must not be absorbed by an earlier-sorting parked
             // source-insight (or vice versa) — that would silently drop a
             // human-queue item. Only true same-disposition duplicates collapse.
-            if k.lane != e.lane || k.strength != e.strength || k.theme != e.theme {
+            if k.entry.lane != e.lane || k.entry.strength != e.strength || k.entry.theme != e.theme {
                 continue;
             }
-            if cited_units(k).intersection(&e_units).next().is_none() {
+            if k.units.intersection(&e_units).next().is_none() {
                 continue;
             }
-            let k_tokens = tokens(&k.claim);
-            let inter = k_tokens.intersection(&e_tokens).count();
-            let union = k_tokens.union(&e_tokens).count();
+            let inter = k.tokens.intersection(&e_tokens).count();
+            let union = k.tokens.len() + e_tokens.len() - inter;
             if union > 0 && (inter as f64) / (union as f64) >= 0.5 {
                 collapsed.push(CollapsedDuplicate {
-                    kept: k.claim_id.clone(),
+                    kept: k.entry.claim_id.clone(),
                     dropped: e.claim_id.clone(),
                     reason: "same theme + shared cited unit + claim-text jaccard >= 0.5".into(),
                 });
                 continue 'outer;
             }
         }
-        kept.push(e);
+        kept.push(CachedEntry { entry: e, units: e_units, tokens: e_tokens });
     }
+    let kept = kept.into_iter().map(|cached| cached.entry).collect();
     (kept, collapsed)
 }
 

--- a/crates/ovp-domain/src/crystal.rs
+++ b/crates/ovp-domain/src/crystal.rs
@@ -405,6 +405,42 @@ pub fn final_routing(provenance: ProvenanceClass, strength: Option<&ClaimStrengt
     }
 }
 
+/// The lane a NON-durable claim occupies. Decided by DECIDABLE structure only
+/// (distinct source count + the strength verdict) — never by wording
+/// heuristics (M35 review-hygiene rule): a single-source claim the judge
+/// already found Supported is not review debt, it is a source-scoped insight
+/// waiting for a second independent source. Evidence: 11 of the first
+/// 20-claim human review batch were exactly this shape.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewLane {
+    /// Needs a human decision (overreach / over-synthesis / opinion-as-fact /
+    /// insufficient evidence — anything the judge flagged, or a cross-source
+    /// claim that missed durable for a reason worth a call).
+    #[default]
+    Review,
+    /// Grounded + Supported but single-source: parked outside the human
+    /// queue, surfaced as a per-source insight until more sources arrive.
+    SourceInsight,
+}
+
+/// Route a non-durable claim to its review lane. Deterministic + total.
+pub fn review_lane(
+    distinct_sources: usize,
+    strength: Option<&ClaimStrengthVerdict>,
+) -> ReviewLane {
+    match strength {
+        Some(v)
+            if distinct_sources <= 1
+                && v.strength == StrengthClass::Supported
+                && v.evidence_sufficient =>
+        {
+            ReviewLane::SourceInsight
+        }
+        _ => ReviewLane::Review,
+    }
+}
+
 // ---- M23 minimal durable Crystal store ----
 //
 // Markdown/HTML is a VIEW; this is the truth layer. The store is an append-only
@@ -579,7 +615,9 @@ pub fn active_keys(events: &[StoreEvent]) -> std::collections::BTreeSet<String> 
 }
 
 /// A non-durable (caveated/reject) claim, with enough context to be read on its
-/// own — so a human reviewer does not have to re-open the candidate (M23 P2).
+/// own — so a human reviewer does not have to re-open the candidate (M23 P2;
+/// M35 made that literal: the entry carries its citations, so review sheets
+/// are self-contained and rewrite decisions can start from real evidence).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ReviewEntry {
     pub claim_id: String,
@@ -589,6 +627,89 @@ pub struct ReviewEntry {
     pub strength: StrengthClass,
     pub evidence_sufficient: bool,
     pub rationale: String,
+    /// The claim's citations (verbatim quotes). `default` so pre-M35 queues load.
+    #[serde(default)]
+    pub citations: Vec<Citation>,
+    /// Which queue this entry occupies (§`review_lane`). `default` = Review.
+    #[serde(default)]
+    pub lane: ReviewLane,
+}
+
+/// A near-duplicate collapse performed before the review queue is written —
+/// recorded (never silent) alongside the queue itself.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CollapsedDuplicate {
+    pub kept: String,
+    pub dropped: String,
+    pub reason: String,
+}
+
+/// Collapse near-duplicate review entries using DECIDABLE signals only:
+/// same theme + at least one shared cited (case_id, unit_id) + token-set
+/// Jaccard ≥ 0.5 over the claim text. Deterministic: entries are processed in
+/// claim_id order and the earliest id wins. Entries without citations (pre-M35
+/// queues) never match the shared-unit condition and are left alone.
+pub fn collapse_review_duplicates(
+    entries: Vec<ReviewEntry>,
+) -> (Vec<ReviewEntry>, Vec<CollapsedDuplicate>) {
+    fn tokens(s: &str) -> std::collections::BTreeSet<String> {
+        let mut out = std::collections::BTreeSet::new();
+        let mut cur = String::new();
+        for ch in s.chars() {
+            let is_cjk = ('\u{4E00}'..='\u{9FFF}').contains(&ch);
+            if ch.is_alphanumeric() && !is_cjk {
+                cur.extend(ch.to_lowercase());
+            } else {
+                if !cur.is_empty() {
+                    out.insert(std::mem::take(&mut cur));
+                }
+                if is_cjk {
+                    out.insert(ch.to_string());
+                }
+            }
+        }
+        if !cur.is_empty() {
+            out.insert(cur);
+        }
+        out
+    }
+    let cited_units = |e: &ReviewEntry| -> std::collections::BTreeSet<(String, String)> {
+        e.citations.iter().map(|c| (c.case_id.clone(), c.unit_id.clone())).collect()
+    };
+
+    let mut sorted = entries;
+    sorted.sort_by(|a, b| a.claim_id.cmp(&b.claim_id));
+    let mut kept: Vec<ReviewEntry> = Vec::new();
+    let mut collapsed: Vec<CollapsedDuplicate> = Vec::new();
+    'outer: for e in sorted {
+        let e_units = cited_units(&e);
+        let e_tokens = tokens(&e.claim);
+        for k in &kept {
+            // Never collapse ACROSS lanes or strength verdicts: a judge-flagged
+            // Review entry must not be absorbed by an earlier-sorting parked
+            // source-insight (or vice versa) — that would silently drop a
+            // human-queue item. Only true same-disposition duplicates collapse.
+            if k.lane != e.lane || k.strength != e.strength || k.theme != e.theme {
+                continue;
+            }
+            if cited_units(k).intersection(&e_units).next().is_none() {
+                continue;
+            }
+            let k_tokens = tokens(&k.claim);
+            let inter = k_tokens.intersection(&e_tokens).count();
+            let union = k_tokens.union(&e_tokens).count();
+            if union > 0 && (inter as f64) / (union as f64) >= 0.5 {
+                collapsed.push(CollapsedDuplicate {
+                    kept: k.claim_id.clone(),
+                    dropped: e.claim_id.clone(),
+                    reason: "same theme + shared cited unit + claim-text jaccard >= 0.5".into(),
+                });
+                continue 'outer;
+            }
+        }
+        kept.push(e);
+    }
+    (kept, collapsed)
 }
 
 /// Scope/policy header for a rendered Crystal view (M24). Counts are computed
@@ -610,14 +731,18 @@ pub fn render_crystal_md(
     review: &[ReviewEntry],
 ) -> String {
     let title = if header.title.trim().is_empty() { "Crystal" } else { header.title.trim() };
+    let n_insights = review.iter().filter(|e| e.lane == ReviewLane::SourceInsight).count();
+    let n_human = review.len() - n_insights;
     let mut m = format!("# {title} — durable knowledge\n\n");
     if !header.scope.trim().is_empty() {
         m.push_str(&format!("**Scope:** {}\n\n", header.scope.trim()));
     }
     m.push_str(&format!(
-        "**Durable claims:** {} · **Review (caveated/rejected, not durable):** {}\n\n",
+        "**Durable claims:** {} · **Review (caveated/rejected, not durable):** {} · \
+         **Source insights (parked, single-source):** {}\n\n",
         active.len(),
-        review.len()
+        n_human,
+        n_insights
     ));
     m.push_str(
         "**Evidence policy:** every durable claim is grounded — claim → cited accepted unit → \
@@ -643,11 +768,13 @@ pub fn render_crystal_md(
         }
         m.push_str("\n</details>\n\n");
     }
+    let (insights, human): (Vec<&ReviewEntry>, Vec<&ReviewEntry>) =
+        review.iter().partition(|e| e.lane == ReviewLane::SourceInsight);
     m.push_str("---\n\n## Review (NOT durable) — caveated / rejected\n\n");
-    if review.is_empty() {
-        m.push_str("_none_\n");
+    if human.is_empty() {
+        m.push_str("_none_\n\n");
     } else {
-        for e in review {
+        for e in human {
             m.push_str(&format!("### {} [{:?}] — {}\n\n", e.claim_id, e.final_class, e.theme));
             m.push_str(&format!("{}\n\n", e.claim.trim()));
             m.push_str(&format!(
@@ -655,6 +782,17 @@ pub fn render_crystal_md(
                 e.strength, e.evidence_sufficient, e.rationale.trim()
             ));
         }
+    }
+    if !insights.is_empty() {
+        m.push_str(&format!(
+            "---\n\n## Source insights (NOT durable, NOT awaiting review) — {}\n\n\
+             _Grounded, Supported, single-source — parked until more sources arrive._\n\n",
+            insights.len()
+        ));
+        for e in insights {
+            m.push_str(&format!("- **{}** [{}] {}\n", e.claim_id, e.theme, e.claim.trim()));
+        }
+        m.push('\n');
     }
     m
 }
@@ -1012,6 +1150,8 @@ mod tests {
             strength: StrengthClass::OverSynthesized,
             evidence_sufficient: false,
             rationale: "fuses single-source quotes into a universal".into(),
+            citations: Vec::new(),
+            lane: Default::default(),
         }];
         let md = render_crystal_md(&header, &[rec("ck-a", "c1")], &review);
         assert!(md.contains("Agent Memory — durable knowledge"));

--- a/crates/ovp-domain/tests/fixtures/review-hygiene-m35/claims.json
+++ b/crates/ovp-domain/tests/fixtures/review-hygiene-m35/claims.json
@@ -1,0 +1,554 @@
+{
+  "claims": [
+    {
+      "id": "agents-b002-3",
+      "claim": "The agent evaluation literature converges on a principle that directly measuring a few carefully chosen behaviors produces better results than adding large numbers of tests, and that correctness should be measured before efficiency.",
+      "theme": "Agents & agentic systems",
+      "citations": [
+        {
+          "case_id": "1a3a5a99-2026-03-26_How_we_build_evals_for_Deep_Agents_",
+          "unit_id": "u-005-a8952b39",
+          "quote": "Every eval is a vector that shifts the behavior of your agentic system."
+        },
+        {
+          "case_id": "1a3a5a99-2026-03-26_How_we_build_evals_for_Deep_Agents_",
+          "unit_id": "u-006-f2e902dc",
+          "quote": "More evals ≠ better agents."
+        },
+        {
+          "case_id": "1a3a5a99-2026-03-26_How_we_build_evals_for_Deep_Agents_",
+          "unit_id": "u-014-c9546d1a",
+          "quote": "Measuring correctness depends on what's being tested."
+        },
+        {
+          "case_id": "1a3a5a99-2026-03-26_How_we_build_evals_for_Deep_Agents_",
+          "unit_id": "u-015-3e4b1773",
+          "quote": "Once several models clear that bar, we move to efficiency."
+        }
+      ],
+      "strength": "over_synthesized",
+      "evidence_sufficient": false
+    },
+    {
+      "id": "agents-b002-5",
+      "claim": "The security paradigm for AI agents is shifting from model-centric gateways toward endpoint-level visibility and control, where agents actually perform actions with user permissions.",
+      "theme": "Agents & agentic systems",
+      "citations": [
+        {
+          "case_id": "1a915338-2026-05-14_jqdsouza_-_Introducing_Beacon_Endpoint_Telemetry_for_AI_Agent",
+          "unit_id": "u-003-36782661",
+          "quote": "The first generation of AI security centered on the model gateway. The next will move to the endpoint, where agents actually do the work."
+        },
+        {
+          "case_id": "1a915338-2026-05-14_jqdsouza_-_Introducing_Beacon_Endpoint_Telemetry_for_AI_Agent",
+          "unit_id": "u-005-a430294c",
+          "quote": "It's what an agent can do: use the user's tools, inherit their permissions, and change state inside sensitive environments."
+        },
+        {
+          "case_id": "1a915338-2026-05-14_jqdsouza_-_Introducing_Beacon_Endpoint_Telemetry_for_AI_Agent",
+          "unit_id": "u-018-18cf2001",
+          "quote": "Visibility comes before control. Teams cannot enforce configurations, gate sensitive actions, govern MCP access, or protect secrets until they know which agents are running, what permissions they have, and what actions they are taking."
+        }
+      ],
+      "strength": "supported",
+      "evidence_sufficient": true
+    },
+    {
+      "id": "agents-b002-6",
+      "claim": "Multi-agent team coordination commonly uses a lead-plus-teammates topology with shared task boards and file-based message passing, where each teammate runs as a separate process with its own isolated context.",
+      "theme": "Agents & agentic systems",
+      "citations": [
+        {
+          "case_id": "2232b72d-2026-03-29_Reverse-Engineering_Claude_Code_Agent_Teams________",
+          "unit_id": "u-000-d8a3f6a2",
+          "quote": "Claude Code (v2.1.47) ships with an experimental feature called Agent Teams: multiple Claude Code sessions coordinate on shared work through a lead-and-teammates topology."
+        },
+        {
+          "case_id": "2232b72d-2026-03-29_Reverse-Engineering_Claude_Code_Agent_Teams________",
+          "unit_id": "u-002-c02f8b8c",
+          "quote": "The entire coordination layer is file-based."
+        },
+        {
+          "case_id": "2232b72d-2026-03-29_Reverse-Engineering_Claude_Code_Agent_Teams________",
+          "unit_id": "u-012-5056fbe9",
+          "quote": "The lead's conversation history does NOT carry over. Each teammate starts fresh with only the spawn prompt as context."
+        }
+      ],
+      "strength": "overreach",
+      "evidence_sufficient": false
+    },
+    {
+      "id": "agents-b002-8",
+      "claim": "Agent failure modes include unauthorized compliance, information disclosure, destructive actions, and identity spoofing—often compounded when agents interact with each other and when they lack coherent stakeholder models.",
+      "theme": "Agents & agentic systems",
+      "citations": [
+        {
+          "case_id": "1914ffad-Agents_of_Chaos_",
+          "unit_id": "u-003-7cd91950",
+          "quote": "Observed behaviors include unauthorized compliance with non-owners, disclosure of sensitive information, execution of destructive system-level actions, denial-of-service conditions, uncontrolled resource consumption, identity spoofing vulnerabilities, cross-agent propagation of unsafe practices, and partial system takeover"
+        },
+        {
+          "case_id": "1914ffad-Agents_of_Chaos_",
+          "unit_id": "u-006-aadc4e45",
+          "quote": "Current agentic systems lack an explicit stakeholder model — a coherent representation of who they serve, who they interact with, who might be affected by their actions, and what obligations they have to each"
+        },
+        {
+          "case_id": "1914ffad-Agents_of_Chaos_",
+          "unit_id": "u-011-25823485",
+          "quote": "When agents interact with each other, individual failures compound and qualitatively new failure modes emerge"
+        }
+      ],
+      "strength": "supported",
+      "evidence_sufficient": true
+    },
+    {
+      "id": "agents-b003-2",
+      "claim": "The harness or infrastructure layer significantly affects agent performance — the same model can differ by 10–20 percentage points depending on runtime design — making it a key competitive differentiator rather than a mere implementation detail.",
+      "theme": "Agents & agentic systems",
+      "citations": [
+        {
+          "case_id": "3622b18d-2026-05-17_Agent_Runtime______________AI_______________________",
+          "unit_id": "u-006-cf89f647",
+          "quote": "同样的模型，有无针对性的 harness profile 可以差 10-20 个百分点"
+        },
+        {
+          "case_id": "3622b18d-2026-05-17_Agent_Runtime______________AI_______________________",
+          "unit_id": "u-007-0c1dd695",
+          "quote": "Harness 不是可选的性能优化，而是决定模型在 Agent 场景下能不能跑起来的关键层"
+        },
+        {
+          "case_id": "2edd556b-2026-03-29_Your_Agent_Needs_a_Harness_Not_a_Framework________",
+          "unit_id": "u-001-5af251f5",
+          "quote": "The LLM is the engine.\nTools are the peripherals.\nMemory is storage.\nBut what connects them?"
+        },
+        {
+          "case_id": "2fb35026-2026-05-07_Scaling_Managed_Agents_Decoupling_the_brain_from_the_hands_",
+          "unit_id": "u-005-fadaaf57",
+          "quote": "the \"brain\" (Claude and its harness) from both the \"hands\" (sandboxes and tools that perform actions)"
+        }
+      ],
+      "strength": "overreach",
+      "evidence_sufficient": false
+    },
+    {
+      "id": "agents-b003-7",
+      "claim": "Multi-agent systems should be decomposed by context needs rather than by role — most multi-agent designs fail because splitting by role instead of context leads to overlapping information needs and incompatible assumptions, particularly in parallel coding agents.",
+      "theme": "Agents & agentic systems",
+      "citations": [
+        {
+          "case_id": "2e3a828e-2026-05-04_Claude_Subagents_vs._Agent_Teams__clearly_explained_",
+          "unit_id": "u-002-020e19c2",
+          "quote": "The right mental model is context-centric decomposition."
+        },
+        {
+          "case_id": "2e3a828e-2026-05-04_Claude_Subagents_vs._Agent_Teams__clearly_explained_",
+          "unit_id": "u-015-255b8a9d",
+          "quote": "Most multi-agent designs fail because people split work by role instead of by context."
+        },
+        {
+          "case_id": "2e3a828e-2026-05-04_Claude_Subagents_vs._Agent_Teams__clearly_explained_",
+          "unit_id": "u-021-958e3c5a",
+          "quote": "One specific warning for coding: parallel agents writing code make incompatible assumptions."
+        },
+        {
+          "case_id": "2e3a828e-2026-05-04_Claude_Subagents_vs._Agent_Teams__clearly_explained_",
+          "unit_id": "u-014-127e5c8f",
+          "quote": "Ask what context does this subtask actually needs? If two subtasks need deeply overlapping information, they probably belong to the same agent."
+        }
+      ],
+      "strength": "supported",
+      "evidence_sufficient": true
+    },
+    {
+      "id": "agents-b003-8",
+      "claim": "Agent skills (natural-language procedural instructions) can be self-evolved using validation-gated editing that mirrors neural network training — bounded edits per step, score-based acceptance gates, and failure memory — yielding the biggest gains on procedural tasks where the model is capable but inconsistent.",
+      "theme": "Agents & agentic systems",
+      "citations": [
+        {
+          "case_id": "2f6c1324-2026-06-03_hooeem_-_I_want_to_create_self-evolving_agent_skills._",
+          "unit_id": "u-000-286920e9",
+          "quote": "a \"skill\" is just a block of natural-language instructions you hand an agent before it works: procedures, output rules, do's and don'ts."
+        },
+        {
+          "case_id": "2f6c1324-2026-06-03_hooeem_-_I_want_to_create_self-evolving_agent_skills._",
+          "unit_id": "u-002-d35999d7",
+          "quote": "it runs as a loop with four moving parts, and the loop deliberately mirrors how you would train a neural network"
+        },
+        {
+          "case_id": "2f6c1324-2026-06-03_hooeem_-_I_want_to_create_self-evolving_agent_skills._",
+          "unit_id": "u-003-2b3248bc",
+          "quote": "A bounded edit budget caps how much the skill can change in one step, so it improves gradually instead of being rewritten into something unrecognisable. the paper calls this the \"textual learning rate.\""
+        },
+        {
+          "case_id": "2f6c1324-2026-06-03_hooeem_-_I_want_to_create_self-evolving_agent_skills._",
+          "unit_id": "u-004-db2c41a8",
+          "quote": "A validation gate runs the edited skill on a held-out set and only accepts the edit if the score goes up. edits that fail are rejected and remembered, so the optimiser stops re-proposing them."
+        },
+        {
+          "case_id": "2f6c1324-2026-06-03_hooeem_-_I_want_to_create_self-evolving_agent_skills._",
+          "unit_id": "u-008-8d99ed81",
+          "quote": "the biggest gains land on procedural tasks. the ones where the model needs discipline about tool use and output format, not more raw knowledge. that tells you where SkillOpt earns its keep. tasks where the model is capable but sloppy."
+        }
+      ],
+      "strength": "supported",
+      "evidence_sufficient": true
+    },
+    {
+      "id": "agents-b004-2",
+      "claim": "Agents can learn at three distinct layers: model weights, harness configuration, and external context (instructions/skills), with the harness layer typically updated at the agent level rather than the model level.",
+      "theme": "Agents & agentic systems",
+      "citations": [
+        {
+          "case_id": "3f49b10e-2026-04-05_Continual_learning_for_AI_agents_",
+          "unit_id": "u-000-1609e84c",
+          "quote": "for AI agents, learning can happen at three distinct layers: the model, the harness, and the context"
+        },
+        {
+          "case_id": "3f49b10e-2026-04-05_Continual_learning_for_AI_agents_",
+          "unit_id": "u-001-20a647c5",
+          "quote": "Model: the model weights themselves"
+        },
+        {
+          "case_id": "3f49b10e-2026-04-05_Continual_learning_for_AI_agents_",
+          "unit_id": "u-002-43337d98",
+          "quote": "Harness: the harness around the model that powers all instances of the agent"
+        },
+        {
+          "case_id": "3f49b10e-2026-04-05_Continual_learning_for_AI_agents_",
+          "unit_id": "u-003-a998ebeb",
+          "quote": "Context: additional context (instructions, skills) that lives outside the harness"
+        },
+        {
+          "case_id": "3f49b10e-2026-04-05_Continual_learning_for_AI_agents_",
+          "unit_id": "u-011-88e7143d",
+          "quote": "in practice this is mostly done at the agent level"
+        }
+      ],
+      "strength": "supported",
+      "evidence_sufficient": true
+    },
+    {
+      "id": "agents-b004-4",
+      "claim": "The distinction between an SDK (primitives for building agentic software) and a harness (opinionated execution environment around a model) is a common architectural split, with both being valid and often used together.",
+      "theme": "Agents & agentic systems",
+      "citations": [
+        {
+          "case_id": "3f067764-2026-04-30_AgentOS_now_supports_Claude_Code__LangGraph__and_DSPy_",
+          "unit_id": "u-001-a41fab01",
+          "quote": "An SDK is a set of primitives for building agentic software."
+        },
+        {
+          "case_id": "3f067764-2026-04-30_AgentOS_now_supports_Claude_Code__LangGraph__and_DSPy_",
+          "unit_id": "u-003-e0c868f7",
+          "quote": "A harness is an opinionated execution environment around a model."
+        },
+        {
+          "case_id": "3f067764-2026-04-30_AgentOS_now_supports_Claude_Code__LangGraph__and_DSPy_",
+          "unit_id": "u-004-9fded0ad",
+          "quote": "Claude Code, Codex, and Cursor's background agent are all harnesses."
+        },
+        {
+          "case_id": "3f067764-2026-04-30_AgentOS_now_supports_Claude_Code__LangGraph__and_DSPy_",
+          "unit_id": "u-018-510c4da6",
+          "quote": "Both are valid and you'll often use both together."
+        }
+      ],
+      "strength": "supported",
+      "evidence_sufficient": true
+    },
+    {
+      "id": "agents-b004-5",
+      "claim": "Agent frameworks have historically been tightly coupled to specific patterns, making them brittle as patterns evolve, and production agent deployment requires durable orchestration with primitives for steps, retries, state, and observability.",
+      "theme": "Agents & agentic systems",
+      "citations": [
+        {
+          "case_id": "4bbb0ab3-2026-05-10_djfarrelly_-_Background_agents_are_here._Your_orchestration_i",
+          "unit_id": "u-001-fe76151c",
+          "quote": "Agent frameworks aren't libraries. They're bets on which agent pattern wins. When the pattern shifts, you don't refactor; you rewrite."
+        },
+        {
+          "case_id": "4bbb0ab3-2026-05-10_djfarrelly_-_Background_agents_are_here._Your_orchestration_i",
+          "unit_id": "u-005-49777638",
+          "quote": "If you coupled your infrastructure to any one of these patterns, you've already rebuilt at least twice. And you'll rebuild again."
+        },
+        {
+          "case_id": "4bbb0ab3-2026-05-10_djfarrelly_-_Background_agents_are_here._Your_orchestration_i",
+          "unit_id": "u-012-782bd690",
+          "quote": "Background agents aren't coming. They're here."
+        },
+        {
+          "case_id": "4bbb0ab3-2026-05-10_djfarrelly_-_Background_agents_are_here._Your_orchestration_i",
+          "unit_id": "u-023-df4e0390",
+          "quote": "When you have step.run(), step.invoke(), step.waitForEvent(), and step.sleep(), you can build things that don't fit neatly into any existing taxonomy"
+        }
+      ],
+      "strength": "overreach",
+      "evidence_sufficient": false
+    },
+    {
+      "id": "agents-b004-6",
+      "claim": "Governance and safety mechanisms for agents include deterministic policy enforcement before action execution, capability models that define sandbox boundaries, and emergency termination mechanisms, with failure modes typically defaulting to deny rather than allow.",
+      "theme": "Agents & agentic systems",
+      "citations": [
+        {
+          "case_id": "3eb72a30-2026-04-03_microsoft_agent-governance-toolkit_",
+          "unit_id": "u-014-dc827f16",
+          "quote": "The toolkit governs what agents do , not just what they say."
+        },
+        {
+          "case_id": "3eb72a30-2026-04-03_microsoft_agent-governance-toolkit_",
+          "unit_id": "u-015-171b4a97",
+          "quote": "Deterministic Policy Enforcement : Every agent action is evaluated against policies before execution with sub-millisecond latency (<0.1 ms)"
+        },
+        {
+          "case_id": "3eb72a30-2026-04-03_microsoft_agent-governance-toolkit_",
+          "unit_id": "u-003-c59a19cc",
+          "quote": "CapabilityModel : Defines the \"sandbox\" for an agent, including allowed_tools, blocked_patterns, and max_tool_calls"
+        },
+        {
+          "case_id": "3eb72a30-2026-04-03_microsoft_agent-governance-toolkit_",
+          "unit_id": "u-010-02cf88be",
+          "quote": "KillSwitch : Provides an emergency mechanism for instant agent termination"
+        },
+        {
+          "case_id": "3eb72a30-2026-04-03_microsoft_agent-governance-toolkit_",
+          "unit_id": "u-020-41a42c8c",
+          "quote": "Policy evaluation failures result in fail-closed behavior: if evaluation throws an exception, the action is matched (typically resulting in a \"deny\") by default"
+        }
+      ],
+      "strength": "supported",
+      "evidence_sufficient": true
+    },
+    {
+      "id": "agents-b004-7",
+      "claim": "Agentic thinking differs from reasoning thinking in that it optimizes for sustained effective action through environmental interaction rather than quality of internal deliberation before a final answer.",
+      "theme": "Agents & agentic systems",
+      "citations": [
+        {
+          "case_id": "49647420-2026-05-07_JustinLin610_-_From_Reasoning_Thinking_to_Agentic_Thinking_",
+          "unit_id": "u-001-5f963090",
+          "quote": "Reasoning thinking is usually judged by the quality of internal deliberation before a final answer: can the model solve the theorem, write the proof, produce the correct code, or pass the benchmark."
+        },
+        {
+          "case_id": "49647420-2026-05-07_JustinLin610_-_From_Reasoning_Thinking_to_Agentic_Thinking_",
+          "unit_id": "u-002-b2dd4850",
+          "quote": "Agentic thinking is about whether the model can keep making progress while interacting with an environment."
+        },
+        {
+          "case_id": "49647420-2026-05-07_JustinLin610_-_From_Reasoning_Thinking_to_Agentic_Thinking_",
+          "unit_id": "u-003-4f6050d5",
+          "quote": "The central question shifts from \"Can the model think long enough?\" to \"Can the model think in a way that sustains effective action?\""
+        },
+        {
+          "case_id": "49647420-2026-05-07_JustinLin610_-_From_Reasoning_Thinking_to_Agentic_Thinking_",
+          "unit_id": "u-015-b19e3b80",
+          "quote": "The deeper transition is from reasoning thinking to agentic thinking: from thinking longer to thinking in order to act."
+        }
+      ],
+      "strength": "supported",
+      "evidence_sufficient": true
+    },
+    {
+      "id": "agents-b005-2",
+      "claim": "Multi-agent systems fail when agents share the same memory and tone; successful multi-agent teams require isolation, distinct role boundaries, and clear handoffs rather than better prompting.",
+      "theme": "Agents & agentic systems",
+      "citations": [
+        {
+          "case_id": "55e1317e-2026-04-13_How_to_Build_a_Multi-Agent_Team_in_Hermes_",
+          "unit_id": "u-012-e888f2a0",
+          "quote": "multi-agent systems fail when everything shares the same memory and tone."
+        },
+        {
+          "case_id": "55e1317e-2026-04-13_How_to_Build_a_Multi-Agent_Team_in_Hermes_",
+          "unit_id": "u-010-90c78ad8",
+          "quote": "the leap from one agent to a real multi-agent team starts with isolation, not with better prompting."
+        },
+        {
+          "case_id": "55e1317e-2026-04-13_How_to_Build_a_Multi-Agent_Team_in_Hermes_",
+          "unit_id": "u-021-77a87019",
+          "quote": "the smartest multi-agent team is not the biggest one. It is the one with the clearest role boundaries."
+        },
+        {
+          "case_id": "55e1317e-2026-04-13_How_to_Build_a_Multi-Agent_Team_in_Hermes_",
+          "unit_id": "u-000-ea2aae05",
+          "quote": "They are isolated agent environments that can separate memory, sessions, skills, personality, configuration, cron state, and gateway behavior."
+        }
+      ],
+      "strength": "supported",
+      "evidence_sufficient": true
+    },
+    {
+      "id": "agents-b005-4",
+      "claim": "Infrastructure configuration alone can produce eval score differences comparable to model improvements; resource allocation and enforcement methodology can change what benchmarks actually measure.",
+      "theme": "Agents & agentic systems",
+      "citations": [
+        {
+          "case_id": "5c9f7366-2026-03-29_Quantifying_infrastructure_noise_in_agentic_coding_evals_",
+          "unit_id": "u-004-6e82594b",
+          "quote": "we've found that infrastructure configuration alone can produce differences that exceed those margins."
+        },
+        {
+          "case_id": "5c9f7366-2026-03-29_Quantifying_infrastructure_noise_in_agentic_coding_evals_",
+          "unit_id": "u-003-a093da2e",
+          "quote": "specifying resources isn't the same as enforcing them consistently. Moreover, we discovered that enforcement methodology can change what the benchmark ends up actually measuring."
+        },
+        {
+          "case_id": "5c9f7366-2026-03-29_Quantifying_infrastructure_noise_in_agentic_coding_evals_",
+          "unit_id": "u-005-717c4933",
+          "quote": "the gap between the most- and least-resourced setups on Terminal-Bench 2.0 was 6 percentage points (p < 0.01)."
+        },
+        {
+          "case_id": "5c9f7366-2026-03-29_Quantifying_infrastructure_noise_in_agentic_coding_evals_",
+          "unit_id": "u-018-ba130260",
+          "quote": "the boundary between \"model capability\" and \"infrastructure behavior\" is blurrier than a single benchmark score suggests."
+        }
+      ],
+      "strength": "supported",
+      "evidence_sufficient": true
+    },
+    {
+      "id": "agents-b005-5",
+      "claim": "Multiple agent architectures independently converge on a pattern of compressing lower-level context and delegating to sub-agents, with the main thread maintaining shared context rather than isolating subagent contexts.",
+      "theme": "Agents & agentic systems",
+      "citations": [
+        {
+          "case_id": "5481ca27-2026-03-12_RLM_Coding_Swarm_Agents_",
+          "unit_id": "u-002-91994cd4",
+          "quote": "The general idea of a thread is that rather than isolating subagent context, we genuinely want to share it with the main orchestration thread."
+        },
+        {
+          "case_id": "5481ca27-2026-03-12_RLM_Coding_Swarm_Agents_",
+          "unit_id": "u-010-184f21da",
+          "quote": "@cognition, @fundamental, and @ManusAI all operate on the same principles of think at a high level and delegate at a lower level, compressing the lower level context to something that is understandable by the agent doing the strategizing."
+        },
+        {
+          "case_id": "5481ca27-2026-03-12_RLM_Coding_Swarm_Agents_",
+          "unit_id": "u-008-679f2fba",
+          "quote": "Because we delegate simple tactical actions to threads, one at a time, it gives us an almost perfect boundary over which we can compress the context."
+        }
+      ],
+      "strength": "supported",
+      "evidence_sufficient": true
+    },
+    {
+      "id": "agents-b008-3",
+      "claim": "Skills should extend an agent's capabilities rather than compensate for missing core functionality.",
+      "theme": "Agents & agentic systems",
+      "citations": [
+        {
+          "case_id": "768aefe5-2026-05-17_Ctrl_Alt_Zaid_-_Fact_your_agent_should_not_need_a_skill_for_e",
+          "unit_id": "u-000-7a79a47d",
+          "quote": "If your agent needs a skill for everything, it is not ready."
+        },
+        {
+          "case_id": "768aefe5-2026-05-17_Ctrl_Alt_Zaid_-_Fact_your_agent_should_not_need_a_skill_for_e",
+          "unit_id": "u-012-64a8d570",
+          "quote": "Skills should extend the agent. They should not compensate for an empty core."
+        },
+        {
+          "case_id": "768aefe5-2026-05-17_Ctrl_Alt_Zaid_-_Fact_your_agent_should_not_need_a_skill_for_e",
+          "unit_id": "u-016-f1be91ea",
+          "quote": "A real agent needs to be useful before you install anything extra."
+        }
+      ],
+      "strength": "supported",
+      "evidence_sufficient": true
+    },
+    {
+      "id": "agents-b010-7",
+      "claim": "Skill systems where natural-language instruction files can be evolved through feedback loops—using bounded edits, validation gates, and held-out test sets—can transfer across models and harnesses, with larger gains on procedural tasks.",
+      "theme": "Agents & agentic systems",
+      "citations": [
+        {
+          "case_id": "a182db94-2026-06-01_I_want_to_create_self-evolving_agent_skills.-a182db94_",
+          "unit_id": "u-001-9e598dfc",
+          "quote": "SkillOpt treats that file as something you can train, like training a model, except the thing being trained is the text, not the weights."
+        },
+        {
+          "case_id": "a182db94-2026-06-01_I_want_to_create_self-evolving_agent_skills.-a182db94_",
+          "unit_id": "u-004-db2c41a8",
+          "quote": "A validation gate runs the edited skill on a held-out set and only accepts the edit if the score goes up."
+        },
+        {
+          "case_id": "a182db94-2026-06-01_I_want_to_create_self-evolving_agent_skills.-a182db94_",
+          "unit_id": "u-009-c3554874",
+          "quote": "because the output is plain text calling a frozen model, the authors report a trained skill transferred across settings: a spreadsheet skill trained inside the Codex harness moved to the Claude Code harness with a reported +59.7 point gain"
+        },
+        {
+          "case_id": "a182db94-2026-06-01_I_want_to_create_self-evolving_agent_skills.-a182db94_",
+          "unit_id": "u-008-8d99ed81",
+          "quote": "the biggest gains land on procedural tasks. the ones where the model needs discipline about tool use and output format, not more raw knowledge."
+        }
+      ],
+      "strength": "supported",
+      "evidence_sufficient": true
+    },
+    {
+      "id": "coding-b001-3",
+      "claim": "AI coding agents currently operate primarily at junior-to-senior engineer execution level, not at staff engineer strategic altitude, requiring human review for higher-order decisions.",
+      "theme": "Coding & software",
+      "citations": [
+        {
+          "case_id": "15286b55-2026-05-22_dhasandev_-_The_Software_Factory_Trap_",
+          "unit_id": "u-017-bce3f774",
+          "quote": "Current coding agents mostly operate at junior-to-senior altitude"
+        },
+        {
+          "case_id": "15286b55-2026-05-22_dhasandev_-_The_Software_Factory_Trap_",
+          "unit_id": "u-018-ef437c22",
+          "quote": "That altitude gap is where the babysitting tax lives. It is not that agents cannot write code. It is that every output still requires a human to perform the staff engineer check that the agent skipped"
+        }
+      ],
+      "strength": "supported",
+      "evidence_sufficient": true
+    },
+    {
+      "id": "coding-b001-4",
+      "claim": "AI amplifies existing team strengths and weaknesses rather than independently raising baseline quality, making underlying process quality critical.",
+      "theme": "Coding & software",
+      "citations": [
+        {
+          "case_id": "15286b55-2026-05-22_dhasandev_-_The_Software_Factory_Trap_",
+          "unit_id": "u-010-98204327",
+          "quote": "AI is an amplifier of whatever is already there. Strong teams get stronger. Weak processes get weaker faster"
+        },
+        {
+          "case_id": "4d399bdb-2026-02-22_How-I-Use-Claude-Code________",
+          "unit_id": "u-000-61659fc2",
+          "quote": "never let Claude write code until you've reviewed and approved a written plan"
+        },
+        {
+          "case_id": "4d399bdb-2026-02-22_How-I-Use-Claude-Code________",
+          "unit_id": "u-013-bd0152d1",
+          "quote": "This is the most distinctive part of my workflow, and the part where I add the most value"
+        }
+      ],
+      "strength": "over_synthesized",
+      "evidence_sufficient": false
+    },
+    {
+      "id": "coding-b001-5",
+      "claim": "Orchestrating AI agents at the workflow level (beyond individual coding sessions) can dramatically increase output, particularly for routine implementation work.",
+      "theme": "Coding & software",
+      "citations": [
+        {
+          "case_id": "0c7aead5-2026-04-30_An_open-source_spec_for_Codex_orchestration_Symphony._",
+          "unit_id": "u-007-198bf58a",
+          "quote": "we saw the number of landed PRs increase by 500% in the first three weeks"
+        },
+        {
+          "case_id": "0c7aead5-2026-04-30_An_open-source_spec_for_Codex_orchestration_Symphony._",
+          "unit_id": "u-011-5a2f9f02",
+          "quote": "Symphony decouples work from sessions and from pull requests"
+        },
+        {
+          "case_id": "0c7aead5-2026-04-30_An_open-source_spec_for_Codex_orchestration_Symphony._",
+          "unit_id": "u-016-daeabd07",
+          "quote": "Some problems still require engineers working directly with interactive Codex sessions, especially ambiguous problems or work that requires strong judgment and expertise"
+        }
+      ],
+      "strength": "overreach",
+      "evidence_sufficient": true
+    }
+  ]
+}

--- a/crates/ovp-domain/tests/fixtures/review-hygiene-m35/labels.json
+++ b/crates/ovp-domain/tests/fixtures/review-hygiene-m35/labels.json
@@ -1,0 +1,172 @@
+{
+  "labels": [
+    {
+      "id": "agents-b002-3",
+      "audit_action": "rewrite",
+      "tags": [
+        "single_source",
+        "overgeneralized_caught_by_judge"
+      ],
+      "expected_lane": "review"
+    },
+    {
+      "id": "agents-b002-5",
+      "audit_action": "keep_caveated",
+      "tags": [
+        "single_source"
+      ],
+      "expected_lane": "source_insight"
+    },
+    {
+      "id": "agents-b002-6",
+      "audit_action": "reject",
+      "tags": [
+        "single_source",
+        "overgeneralized_caught_by_judge",
+        "implementation_detail"
+      ],
+      "expected_lane": "review"
+    },
+    {
+      "id": "agents-b002-8",
+      "audit_action": "keep_caveated",
+      "tags": [
+        "single_source"
+      ],
+      "expected_lane": "source_insight"
+    },
+    {
+      "id": "agents-b003-2",
+      "audit_action": "rewrite",
+      "tags": [
+        "overgeneralized_caught_by_judge"
+      ],
+      "expected_lane": "review"
+    },
+    {
+      "id": "agents-b003-7",
+      "audit_action": "rewrite",
+      "tags": [
+        "single_source"
+      ],
+      "expected_lane": "source_insight"
+    },
+    {
+      "id": "agents-b003-8",
+      "audit_action": "reject",
+      "tags": [
+        "single_source",
+        "semantic_duplicate_pair"
+      ],
+      "expected_lane": "source_insight"
+    },
+    {
+      "id": "agents-b004-2",
+      "audit_action": "keep_caveated",
+      "tags": [
+        "single_source"
+      ],
+      "expected_lane": "source_insight"
+    },
+    {
+      "id": "agents-b004-4",
+      "audit_action": "keep_caveated",
+      "tags": [
+        "single_source"
+      ],
+      "expected_lane": "source_insight"
+    },
+    {
+      "id": "agents-b004-5",
+      "audit_action": "rewrite",
+      "tags": [
+        "single_source",
+        "overgeneralized_caught_by_judge"
+      ],
+      "expected_lane": "review"
+    },
+    {
+      "id": "agents-b004-6",
+      "audit_action": "keep_caveated",
+      "tags": [
+        "single_source"
+      ],
+      "expected_lane": "source_insight"
+    },
+    {
+      "id": "agents-b004-7",
+      "audit_action": "keep_caveated",
+      "tags": [
+        "single_source"
+      ],
+      "expected_lane": "source_insight"
+    },
+    {
+      "id": "agents-b005-2",
+      "audit_action": "keep_caveated",
+      "tags": [
+        "single_source"
+      ],
+      "expected_lane": "source_insight"
+    },
+    {
+      "id": "agents-b005-4",
+      "audit_action": "rewrite",
+      "tags": [
+        "single_source"
+      ],
+      "expected_lane": "source_insight"
+    },
+    {
+      "id": "agents-b005-5",
+      "audit_action": "keep_caveated",
+      "tags": [
+        "single_source"
+      ],
+      "expected_lane": "source_insight"
+    },
+    {
+      "id": "agents-b008-3",
+      "audit_action": "keep_caveated",
+      "tags": [
+        "single_source"
+      ],
+      "expected_lane": "source_insight"
+    },
+    {
+      "id": "agents-b010-7",
+      "audit_action": "keep_caveated",
+      "tags": [
+        "single_source",
+        "semantic_duplicate_pair"
+      ],
+      "expected_lane": "source_insight"
+    },
+    {
+      "id": "coding-b001-3",
+      "audit_action": "keep_caveated",
+      "tags": [
+        "single_source"
+      ],
+      "expected_lane": "source_insight"
+    },
+    {
+      "id": "coding-b001-4",
+      "audit_action": "rewrite",
+      "tags": [
+        "overgeneralized_caught_by_judge"
+      ],
+      "expected_lane": "review"
+    },
+    {
+      "id": "coding-b001-5",
+      "audit_action": "rewrite",
+      "tags": [
+        "single_source",
+        "overgeneralized_caught_by_judge"
+      ],
+      "expected_lane": "review"
+    }
+  ],
+  "note": "audit = 2026-07-06 AI suggestions (human-reviewed); expected_lane = decidable rule over real (distinct_sources, strength); semantic_duplicate_pair is EXPECTED NOT to collapse deterministically (0 shared units, jaccard 0.27) - it is lineage/judge territory"
+}

--- a/crates/ovp-domain/tests/review_hygiene_m35.rs
+++ b/crates/ovp-domain/tests/review_hygiene_m35.rs
@@ -1,0 +1,157 @@
+//! M35 review-hygiene regression set — the first 20 human-review-batch claims
+//! (real corpus data, 2026-07-06 audit), frozen as labeled fixtures.
+//!
+//! What this pins, deterministically and with ZERO model calls:
+//! - `review_lane` routes by decidable structure (distinct sources + strength
+//!   verdict): on this batch the human queue drops 20 → 6, and everything the
+//!   judge flagged (overreach / over_synthesized) STAYS in the human queue.
+//! - `collapse_review_duplicates` catches shared-evidence duplicates and — by
+//!   design — does NOT touch the semantic duplicate pair
+//!   (`agents-b003-8` / `agents-b010-7`): same idea, ZERO shared cited units,
+//!   token jaccard 0.27. That pair is lineage/judge territory (a strengthen
+//!   candidate), and collapsing it heuristically would violate the M35
+//!   decidability rule. The boundary is asserted, not glossed.
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+use ovp_domain::crystal::{
+    collapse_review_duplicates, review_lane, Citation, ClaimStrengthVerdict, FinalClass,
+    ReviewEntry, ReviewLane, StrengthClass,
+};
+
+fn fixture(name: &str) -> serde_json::Value {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/review-hygiene-m35")
+        .join(name);
+    serde_json::from_str(&std::fs::read_to_string(&path).unwrap_or_else(|e| {
+        panic!("reading {}: {e}", path.display());
+    }))
+    .expect("fixture parses")
+}
+
+struct Case {
+    id: String,
+    claim: String,
+    theme: String,
+    citations: Vec<Citation>,
+    strength: StrengthClass,
+    evidence_sufficient: bool,
+}
+
+fn load_cases() -> Vec<Case> {
+    fixture("claims.json")["claims"]
+        .as_array()
+        .expect("claims array")
+        .iter()
+        .map(|c| Case {
+            id: c["id"].as_str().unwrap().to_string(),
+            claim: c["claim"].as_str().unwrap().to_string(),
+            theme: c["theme"].as_str().unwrap().to_string(),
+            citations: c["citations"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|x| Citation {
+                    case_id: x["case_id"].as_str().unwrap().to_string(),
+                    unit_id: x["unit_id"].as_str().unwrap().to_string(),
+                    quote: x["quote"].as_str().unwrap().to_string(),
+                    claimed_line: None,
+                })
+                .collect(),
+            strength: serde_json::from_value(c["strength"].clone()).unwrap(),
+            evidence_sufficient: c["evidence_sufficient"].as_bool().unwrap(),
+        })
+        .collect()
+}
+
+fn verdict(case: &Case) -> ClaimStrengthVerdict {
+    ClaimStrengthVerdict {
+        claim_id: case.id.clone(),
+        strength: case.strength,
+        evidence_sufficient: case.evidence_sufficient,
+        rationale: String::new(),
+    }
+}
+
+fn distinct_sources(case: &Case) -> usize {
+    case.citations.iter().map(|c| c.case_id.as_str()).collect::<BTreeSet<_>>().len()
+}
+
+fn entry(case: &Case) -> ReviewEntry {
+    ReviewEntry {
+        claim_id: case.id.clone(),
+        claim: case.claim.clone(),
+        theme: case.theme.clone(),
+        final_class: FinalClass::Caveated,
+        strength: case.strength,
+        evidence_sufficient: case.evidence_sufficient,
+        rationale: String::new(),
+        citations: case.citations.clone(),
+        lane: review_lane(distinct_sources(case), Some(&verdict(case))),
+    }
+}
+
+#[test]
+fn lane_routing_matches_the_audited_labels_and_shrinks_the_human_queue() {
+    let cases = load_cases();
+    assert_eq!(cases.len(), 20, "the frozen batch");
+    let labels = fixture("labels.json");
+    let mut human_queue = 0usize;
+    for l in labels["labels"].as_array().unwrap() {
+        let id = l["id"].as_str().unwrap();
+        let case = cases.iter().find(|c| c.id == id).expect("label id in claims");
+        let lane = review_lane(distinct_sources(case), Some(&verdict(case)));
+        let expected = match l["expected_lane"].as_str().unwrap() {
+            "source_insight" => ReviewLane::SourceInsight,
+            _ => ReviewLane::Review,
+        };
+        assert_eq!(lane, expected, "lane for {id}");
+        if lane == ReviewLane::Review {
+            human_queue += 1;
+        }
+        // The core hygiene invariant: anything the judge flagged can NEVER be
+        // parked out of the human queue.
+        let judge_flagged = l["tags"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|t| t.as_str() == Some("overgeneralized_caught_by_judge"));
+        if judge_flagged {
+            assert_eq!(lane, ReviewLane::Review, "{id} was judge-flagged");
+        }
+    }
+    assert_eq!(human_queue, 6, "human queue shrinks 20 -> 6 on this batch");
+}
+
+#[test]
+fn collapse_leaves_the_real_batch_alone_including_the_semantic_duplicate_pair() {
+    let cases = load_cases();
+    let entries: Vec<ReviewEntry> = cases.iter().map(entry).collect();
+    let (kept, collapsed) = collapse_review_duplicates(entries);
+    assert!(
+        collapsed.is_empty(),
+        "no decidable duplicates in the real batch (the b003-8/b010-7 pair \
+         shares zero cited units — semantic, out of Phase-0 scope): {collapsed:?}"
+    );
+    assert_eq!(kept.len(), 20);
+}
+
+#[test]
+fn collapse_catches_a_cross_run_shared_evidence_duplicate() {
+    let cases = load_cases();
+    let mut entries: Vec<ReviewEntry> = cases.iter().map(entry).collect();
+    // Simulate a later run re-synthesizing nearly the same claim from the same
+    // evidence (different id, same citations, lightly reworded text).
+    let src = cases.iter().find(|c| c.id == "agents-b004-2").unwrap();
+    let mut dup = entry(src);
+    dup.claim_id = "agents-zz99-1".into();
+    dup.claim = format!("{} (restated)", src.claim);
+    entries.push(dup);
+
+    let (kept, collapsed) = collapse_review_duplicates(entries);
+    assert_eq!(collapsed.len(), 1, "exactly the injected duplicate collapses");
+    assert_eq!(collapsed[0].kept, "agents-b004-2");
+    assert_eq!(collapsed[0].dropped, "agents-zz99-1");
+    assert_eq!(kept.len(), 20);
+}

--- a/crates/ovp-index/src/build.rs
+++ b/crates/ovp-index/src/build.rs
@@ -460,7 +460,7 @@ fn build_claims(vault_root: &Path, layout: &VaultLayout) -> Result<Vec<ClaimRow>
             let sources: Vec<String> = {
                 let mut s: Vec<String> =
                     entry.citations.iter().map(|c| c.case_id.clone()).collect();
-                s.sort();
+                s.sort_unstable();
                 s.dedup();
                 s
             };

--- a/crates/ovp-index/src/build.rs
+++ b/crates/ovp-index/src/build.rs
@@ -444,6 +444,7 @@ fn build_claims(vault_root: &Path, layout: &VaultLayout) -> Result<Vec<ClaimRow>
             sources: rec.source_cases.clone(),
             strength: enum_str(&rec.strength),
             run_id: Some(rec.run_id.clone()),
+            lane: None,
         });
     }
 
@@ -456,14 +457,22 @@ fn build_claims(vault_root: &Path, layout: &VaultLayout) -> Result<Vec<ClaimRow>
         let file: ReviewFile = serde_json::from_str(&raw)
             .map_err(|e| format!("parsing {}/review.json: {e}", store.display()))?;
         for entry in file.review {
+            let sources: Vec<String> = {
+                let mut s: Vec<String> =
+                    entry.citations.iter().map(|c| c.case_id.clone()).collect();
+                s.sort();
+                s.dedup();
+                s
+            };
             claims.push(ClaimRow {
                 claim_id: entry.claim_id,
                 claim: entry.claim,
                 theme: (!entry.theme.is_empty()).then_some(entry.theme),
                 status: ClaimStatus::Caveated,
-                sources: Vec::new(),
+                sources,
                 strength: enum_str(&entry.strength),
                 run_id: None,
+                lane: enum_str(&entry.lane),
             });
         }
     }

--- a/crates/ovp-index/src/model.rs
+++ b/crates/ovp-index/src/model.rs
@@ -94,6 +94,10 @@ pub struct ClaimRow {
     pub strength: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub run_id: Option<String>,
+    /// Review lane for caveated claims (`review` | `source_insight`).
+    /// None for durable/superseded/retracted rows and pre-M35 indexes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lane: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/ovp-memory/src/ask.rs
+++ b/crates/ovp-memory/src/ask.rs
@@ -476,6 +476,7 @@ mod tests {
                 sources: vec!["40-Resources/Reader/memory".into()],
                 strength: Some("supported".into()),
                 run_id: Some("run-1".into()),
+                    lane: None,
             }],
             runs: vec![],
             ops: OpsState::default(),

--- a/crates/ovp-memory/src/working_memory.rs
+++ b/crates/ovp-memory/src/working_memory.rs
@@ -148,6 +148,7 @@ mod tests {
                 sources: vec!["case-a".into()],
                 strength: Some("supported".into()),
                 run_id: None,
+                lane: None,
             })
             .collect();
         IndexModel {

--- a/docs/review-failure-taxonomy.md
+++ b/docs/review-failure-taxonomy.md
@@ -1,0 +1,71 @@
+# Review-Queue Failure Taxonomy — and the decidability rule (M35)
+
+**Origin:** the first human review batch (20 of 120 caveated claims, 2026-07-06 AI-suggestion
+audit) was treated as a failure audit of the SYSTEM, not as 20 items to fill in. This doc fixes
+the taxonomy, the layer each failure class belongs to, and the iteration rule that keeps fixes
+from becoming a patch tower.
+
+## The decidability rule (how we choose between "harness rules" and "prompt/LLM")
+
+The choice is never "more rules vs more prompt". It is: **does this check have a decidable
+ground truth?**
+
+- **Decidable** (a quote is verbatim or not; distinct sources are 1 or 2; two claims cite the
+  same unit or not) → deterministic code. These are orthogonal AND-filters: independently
+  testable, they do not accumulate into a conflicting pile.
+- **Not decidable** (is this wording overbroad? is this an implementation detail?) → the LLM
+  judge — constrained by structured output, calibrated against a labeled set
+  (`crates/ovp-domain/tests/fixtures/review-hygiene-m35/`), versioned via the evolution flow.
+- **Never**: natural-language rule piles inside prompts ("don't say commonly/most/should") —
+  unfalsifiable, conflict-prone, unmeasurable. When tempted, either find the decidable proxy or
+  hand it to the judge and measure.
+
+History backs this: M7–M13 (rules doing the LLM's job) failed; the verbatim gate (LLM proposes,
+code disposes) is the moat; S2v3's good-prompt arm beat its rule-ladder arm.
+
+## The five failure classes and where each is fixed
+
+| # | Class | Example | Decidable? | Layer / fix |
+|---|---|---|---|---|
+| 1 | Single-source Supported claims occupying the human queue | 14 of the batch of 20 | YES (`distinct_sources` + verdict) | `review_lane()` routing: lane `source_insight`, parked outside the human queue until more sources arrive (this PR) |
+| 2 | Single-source observation worded as a universal law | "literature converges", `agents-b002-3` | Partially — **the judge already catches most** (that IS why they were caveated); residual wording quality | Routing puts judge-flagged items in the human queue (this PR); judge criteria upgrade = Phase 1 evolution candidate; synth prompt scope-discipline LAST, only if still needed |
+| 3 | Duplicates entering the queue | `agents-b003-8` vs `agents-b010-7` | **Split finding** — see below | Shared-evidence dups: deterministic `collapse_review_duplicates` (this PR). Semantic dups: lineage/judge, NOT Phase 0 |
+| 4 | Implementation detail promoted toward Crystal | `agents-b002-6` | NO | Judge classification (Phase 1). Note: on real data the judge had already marked it `overreach`, so it correctly stays in the human queue |
+| 5 | Review artifacts not self-contained (no citations) | reviewer had to dig in `.run/` | Tooling bug | `ReviewEntry.citations` + review-sheet rendering (this PR) |
+
+**The class-3 boundary discovery (recorded so nobody "fixes" it wrongly):** the audit's flagship
+duplicate pair shares **zero** cited units and has claim-text jaccard 0.27. It is the SAME idea
+supported by DIFFERENT evidence — which makes it a *strengthen/lineage* candidate (merging the
+two evidence sets makes a stronger claim), not a deduplication bug. A threshold loose enough to
+collapse it deterministically would be a wording heuristic in disguise. The regression test
+asserts it does NOT collapse.
+
+## The regression set
+
+`crates/ovp-domain/tests/fixtures/review-hygiene-m35/{claims.json,labels.json}` — the 20 real
+claims with citations + strength verdicts, labeled with audit actions, tags
+(`single_source`, `overgeneralized_caught_by_judge`, `implementation_detail`,
+`semantic_duplicate_pair`) and expected lanes. Tests
+(`crates/ovp-domain/tests/review_hygiene_m35.rs`) pin, with zero model calls:
+human queue 20 → 6 · judge-flagged items never parked · real batch has no decidable duplicates ·
+an injected cross-run shared-evidence duplicate collapses.
+
+## Iteration metrics (a change "worked" only if these move)
+
+Compared on the NEXT 20-item batch: human-queue review-yield (share of items getting a non-keep
+decision) ↑ · queue size ↓ · decidable duplicates in queue = 0 · durable-claim grounding
+unchanged (34→22 fixture untouched) · spot-check finds no valuable claim wrongly parked.
+
+## Phase 1 (gated — each one an evolution candidate, one surface at a time)
+
+1. `crystal_strength/v2`: overreach definition explicitly includes source-scope (single-source
+   evidence worded as a universal = overreach) + an `implementation_detail` classification.
+   Evaluated against the labeled 20.
+2. `crystal_synth/v2` scope-discipline wording — ONLY if the next batch still shows overbroad
+   generation after 1 lands.
+
+## Migration note
+
+Pre-M35 queue entries have no citations/lane (serde defaults keep them loading as lane=review).
+To populate: re-run the vault crystal-synth replay (cassettes make it free) — `write_durable`
+rebuilds `review.json` with citations + lanes.


### PR DESCRIPTION
## The methodology question this PR answers

The first 20-claim human review batch was treated as a **failure audit of the system**. The operator challenged the 'keep patching rules/prompts' iteration style; the answer is codified in `docs/review-failure-taxonomy.md`: **the choice is never rules-vs-LLM — it is whether the check has a decidable ground truth.** Decidable → deterministic code (orthogonal AND-filters, independently testable, no conflict pile). Not decidable → the judge, calibrated on labeled data, versioned via the evolution flow. Never → natural-language rule piles in prompts.

Everything in this PR is decidable. **Zero prompt changes, zero LLM calls in any test.**

## What ships

1. **`review_lane()`**: single-source + Supported + sufficient → `source_insight`, parked OUTSIDE the human queue; judge-flagged items always stay in review. **Real-batch effect: human queue 20 → 6.**
2. **`ReviewEntry.citations`** (serde-default, pre-M35 queues load unchanged): review sheets are self-contained; rewrite decisions start from real evidence.
3. **`collapse_review_duplicates()`**: same lane + strength + theme + shared cited unit + jaccard ≥0.5, earliest id wins, recorded in review.json. **Boundary discovery, tested:** the audit's flagship 'duplicate' pair shares ZERO cited units (jaccard 0.27) — it's a strengthen/lineage candidate, deliberately NOT collapsed.
4. Console candidates page + `crystal.md` + `project` summaries all partition human queue vs parked insights (codex review P1 + 3×P2 fixed: no cross-lane collapse can drop a judge-flagged item; no surface double-counts parked insights as review debt).
5. **Labeled regression set**: the 20 real claims + audit labels frozen (`crates/ovp-domain/tests/fixtures/review-hygiene-m35/`); 3 deterministic tests pin queue 20→6, judge-flagged-never-parked, no false-positive collapses, injected cross-run duplicate caught.

## Phase 1 (NOT in this PR, gated)

Judge criteria upgrade (`crystal_strength/v2`: source-scope overreach + implementation_detail) and synth prompt scope-discipline — each a separate evolution candidate, evaluated on the labeled set, only if the next batch's metrics still show the need.

## Migration

Rerun the vault crystal-synth replay (cassettes = free) to repopulate review.json with citations + lanes.

## Gates

716 tests (+3 suites incl. the new fixture suite) · clippy -D warnings clean · arch check pass · codex review: initial P1 (cross-lane collapse) + 3 P2s (surface count consistency) all fixed in-commit.