### PR TITLE
feat(portal): B2 — three-layer source detail, /api/source/:sha, neighborhood KnowledgeGraph

### DIFF
--- a/console-ui/src/components/KnowledgeGraph.tsx
+++ b/console-ui/src/components/KnowledgeGraph.tsx
@@ -160,7 +160,7 @@ export default function KnowledgeGraph({
             labelText: (d: { id?: string }) =>
               nodeById.get(d.id ?? '')?.label ?? '',
             labelFill: tokens.text,
-            labelFontSize: 11,
+            labelFontSize: 10,
             labelFontFamily:
               "'IBM Plex Sans', 'IBM Plex Sans SC', system-ui, sans-serif",
             labelBackground: true,
@@ -169,7 +169,7 @@ export default function KnowledgeGraph({
             labelBackgroundRadius: 4,
             labelPadding: [1, 4],
             labelPlacement: 'bottom',
-            labelMaxWidth: 180,
+            labelMaxWidth: 130,
             labelWordWrap: true,
             labelMaxLines: 2,
           },
@@ -189,9 +189,9 @@ export default function KnowledgeGraph({
         },
         layout: {
           type: 'd3-force',
-          link: { distance: 70, strength: 0.7 },
-          collide: { radius: 26, strength: 1.1 },
-          manyBody: { strength: -160 },
+          link: { distance: 110, strength: 0.7 },
+          collide: { radius: 48, strength: 1.1 },
+          manyBody: { strength: -300 },
           velocityDecay: 0.68,
           alphaDecay: 0.04,
         },

--- a/console-ui/src/components/KnowledgeGraph.tsx
+++ b/console-ui/src/components/KnowledgeGraph.tsx
@@ -241,7 +241,9 @@ export default function KnowledgeGraph({
       cleanup?.();
     };
     // themeVersion intentionally re-runs this effect: same data, new tokens.
-  }, [data, id, navigate, themeVersion]);
+    // scope must be a dep: flipping away from 'neighborhood' unmounts the
+    // container, and only a re-run destroys the old graph instance.
+  }, [data, id, navigate, scope, themeVersion]);
 
   if (scope !== 'neighborhood') {
     return (

--- a/console-ui/src/components/KnowledgeGraph.tsx
+++ b/console-ui/src/components/KnowledgeGraph.tsx
@@ -1,0 +1,311 @@
+/** KnowledgeGraph — the scoped graph component (design §4, KMEM pattern).
+ * One component, three scopes, one rendering engine:
+ *
+ *   scope='neighborhood' id=<source sha>  → this source, citing claims,
+ *                                           sibling sources (B2, live)
+ *   scope='global'                        → knowledge-page graph view (B3)
+ *   scope='theme'        id=<theme>       → theme detail rail (B3)
+ *
+ * All colors are read from the DS custom properties (--graph-*, --c-*,
+ * --accent, --text…) at render time, and the graph re-renders when
+ * `data-theme` flips (MutationObserver on <html>). Interactions: click →
+ * in-component info card; double-click → navigate (source → /library/:sha,
+ * claim → /knowledge#<claim_id> placeholder anchor until B3). Embedded
+ * height defaults to ~360px with an expand-to-fullscreen toggle.
+ *
+ * @antv/g6 (~1MB min) loads via dynamic import so portal pages stay light —
+ * same policy as the lazy legacy /graph route. */
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useI18n } from '../i18n';
+import { fetchSourceNeighborhood } from '../lib/api';
+import type { GraphNode, GraphResponse } from '../lib/types';
+import { EmptyState } from './ui';
+
+export type KnowledgeGraphScope = 'neighborhood' | 'global' | 'theme';
+
+export interface KnowledgeGraphProps {
+  scope: KnowledgeGraphScope;
+  /** neighborhood: source sha256 · theme: theme name · global: unused. */
+  id?: string;
+  /** Embedded height in px (default 360). */
+  height?: number;
+}
+
+const DEFAULT_HEIGHT = 360;
+
+/** DS tokens resolved from the live theme — read at render time so the
+ * graph always matches `data-theme`. */
+interface DsTokens {
+  link: string;
+  linkHi: string;
+  text: string;
+  muted: string;
+  surface: string;
+  accent: string;
+  community: string[];
+}
+
+function readTokens(): DsTokens {
+  const cs = getComputedStyle(document.documentElement);
+  const v = (name: string) => cs.getPropertyValue(name).trim();
+  return {
+    link: v('--graph-link'),
+    linkHi: v('--graph-link-hi'),
+    text: v('--text'),
+    muted: v('--muted'),
+    surface: v('--surface'),
+    accent: v('--accent'),
+    community: [1, 2, 3, 4, 5, 6, 7, 8].map((n) => v(`--c-${n}`)),
+  };
+}
+
+/** Node fill by entity kind (mockup: sources --c-1, claims --c-3, units
+ * --c-2 — the community palette read for the ACTIVE theme). */
+function nodeFill(type: string, t: DsTokens): string {
+  if (type === 'source') return t.community[0];
+  if (type === 'claim') return t.community[2];
+  return t.community[1];
+}
+
+function nodeSize(n: GraphNode, isFocus: boolean): number {
+  if (isFocus) return 22;
+  if (n.type === 'source') return 12 + 8 * (n.importance ?? 0);
+  return 10 + 12 * (n.importance ?? 0);
+}
+
+export default function KnowledgeGraph({
+  scope,
+  id,
+  height = DEFAULT_HEIGHT,
+}: KnowledgeGraphProps) {
+  const { t } = useI18n();
+  const navigate = useNavigate();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [data, setData] = useState<GraphResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<GraphNode | null>(null);
+  const [fullscreen, setFullscreen] = useState(false);
+  // Bumped when <html data-theme> mutates → graph rebuilds with new tokens.
+  const [themeVersion, setThemeVersion] = useState(0);
+
+  useEffect(() => {
+    const observer = new MutationObserver(() => setThemeVersion((v) => v + 1));
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['data-theme'],
+    });
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    if (scope !== 'neighborhood' || !id) return;
+    let cancelled = false;
+    setData(null);
+    setError(null);
+    fetchSourceNeighborhood(id)
+      .then((resp) => {
+        if (!cancelled) setData(resp);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [scope, id]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || !data || data.nodes.length === 0) return;
+
+    let destroyed = false;
+    let cleanup: (() => void) | undefined;
+
+    void import('@antv/g6').then(({ Graph, NodeEvent, CanvasEvent }) => {
+      if (destroyed || !containerRef.current) return;
+      const tokens = readTokens();
+      const focusId = id ? `source:${id}` : null;
+      const nodeById = new Map(data.nodes.map((n) => [n.id, n]));
+
+      const graph = new Graph({
+        container,
+        animation: false,
+        autoResize: true,
+        padding: 16,
+        autoFit: 'view',
+        data: {
+          nodes: data.nodes.map((n) => ({
+            id: n.id,
+            data: n as unknown as Record<string, unknown>,
+          })),
+          edges: data.edges.map((e, i) => ({
+            id: `e${i}`,
+            source: e.source,
+            target: e.target,
+            data: { type: e.type },
+          })),
+        },
+        node: {
+          style: {
+            size: (d: { id?: string }) => {
+              const n = nodeById.get(d.id ?? '');
+              return n ? nodeSize(n, n.id === focusId) : 10;
+            },
+            fill: (d: { id?: string }) =>
+              nodeFill(nodeById.get(d.id ?? '')?.type ?? '', tokens),
+            fillOpacity: 0.92,
+            lineWidth: (d: { id?: string }) => (d.id === focusId ? 1.5 : 0),
+            stroke: tokens.accent,
+            labelText: (d: { id?: string }) =>
+              nodeById.get(d.id ?? '')?.label ?? '',
+            labelFill: tokens.text,
+            labelFontSize: 11,
+            labelFontFamily:
+              "'IBM Plex Sans', 'IBM Plex Sans SC', system-ui, sans-serif",
+            labelBackground: true,
+            labelBackgroundFill: tokens.surface,
+            labelBackgroundOpacity: 0.85,
+            labelBackgroundRadius: 4,
+            labelPadding: [1, 4],
+            labelPlacement: 'bottom',
+            labelMaxWidth: 180,
+            labelWordWrap: true,
+            labelMaxLines: 2,
+          },
+          state: {
+            selected: {
+              stroke: tokens.linkHi,
+              lineWidth: 2,
+            },
+          },
+        },
+        edge: {
+          style: {
+            stroke: tokens.link,
+            lineWidth: 1,
+            strokeOpacity: 0.9,
+          },
+        },
+        layout: {
+          type: 'd3-force',
+          link: { distance: 70, strength: 0.7 },
+          collide: { radius: 26, strength: 1.1 },
+          manyBody: { strength: -160 },
+          velocityDecay: 0.68,
+          alphaDecay: 0.04,
+        },
+        behaviors: ['zoom-canvas', 'drag-canvas', 'drag-element'],
+      });
+
+      let lastSelected: string | null = null;
+      const targetId = (evt: unknown): string =>
+        (evt as { target: { id: string } }).target.id;
+
+      graph.on(NodeEvent.CLICK, (evt: unknown) => {
+        const nodeId = targetId(evt);
+        if (lastSelected && lastSelected !== nodeId) {
+          graph.setElementState(lastSelected, []).catch(() => {});
+        }
+        graph.setElementState(nodeId, ['selected']).catch(() => {});
+        lastSelected = nodeId;
+        setSelected(nodeById.get(nodeId) ?? null);
+      });
+      graph.on(CanvasEvent.CLICK, () => {
+        if (lastSelected) {
+          graph.setElementState(lastSelected, []).catch(() => {});
+          lastSelected = null;
+        }
+        setSelected(null);
+      });
+      graph.on(NodeEvent.DBLCLICK, (evt: unknown) => {
+        const nodeId = targetId(evt);
+        if (nodeId.startsWith('source:')) {
+          navigate(`/library/${nodeId.slice('source:'.length)}`);
+        } else if (nodeId.startsWith('claim:')) {
+          // Knowledge page is a B3 placeholder; the anchor carries the claim.
+          navigate(`/knowledge#${nodeId.slice('claim:'.length)}`);
+        }
+      });
+
+      graph.render().catch((err: unknown) => {
+        // Destroyed mid-render (StrictMode double-mount) is expected noise.
+        if (!graph.destroyed) console.error('knowledge graph render failed', err);
+      });
+
+      cleanup = () => graph.destroy();
+    });
+
+    return () => {
+      destroyed = true;
+      cleanup?.();
+    };
+    // themeVersion intentionally re-runs this effect: same data, new tokens.
+  }, [data, id, navigate, themeVersion]);
+
+  if (scope !== 'neighborhood') {
+    return (
+      <EmptyState>
+        <p>{t('graph.b3')}</p>
+      </EmptyState>
+    );
+  }
+
+  const kindLabel = (type: string) =>
+    type === 'claim'
+      ? t('graph.kindClaim')
+      : type === 'source'
+        ? t('graph.kindSource')
+        : t('graph.kindUnit');
+
+  return (
+    <div
+      className={`graph-embed${fullscreen ? ' fullscreen' : ''}`}
+      style={fullscreen ? undefined : { height }}
+    >
+      {error && (
+        <EmptyState>
+          <p>{t('graph.error')}</p>
+        </EmptyState>
+      )}
+      {!error && data && data.nodes.length === 0 && (
+        <EmptyState>
+          <p>{t('graph.empty')}</p>
+        </EmptyState>
+      )}
+      {!error && !data && <div className="graph-note">{t('graph.loading')}</div>}
+      {!error && data && data.nodes.length > 0 && (
+        <>
+          <div ref={containerRef} className="graph-canvas" />
+          <button
+            type="button"
+            className="graph-expand"
+            onClick={() => setFullscreen((f) => !f)}
+          >
+            {fullscreen ? t('graph.exitFullscreen') : t('graph.fullscreen')}
+          </button>
+          {data.truncated && (
+            <div className="graph-note graph-truncated">
+              {t('graph.truncated')}
+            </div>
+          )}
+          {selected && (
+            <div className="graph-info">
+              <div className="graph-info-kind">
+                <span className="pill">{kindLabel(selected.type)}</span>
+                {selected.strength && (
+                  <span className="tiny muted"> {selected.strength}</span>
+                )}
+              </div>
+              <div className="graph-info-title">{selected.label}</div>
+              {selected.theme && (
+                <div className="tiny muted">{selected.theme}</div>
+              )}
+              <div className="tiny muted">{t('graph.openHint')}</div>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/console-ui/src/design/portal.css
+++ b/console-ui/src/design/portal.css
@@ -542,6 +542,288 @@ body {
   overflow-wrap: anywhere;
 }
 
+/* ---------- source detail: two-column drill-down (B2) ---------- */
+.grid.two-col {
+  grid-template-columns: minmax(0, 2.1fr) minmax(280px, 1fr);
+  align-items: start;
+  margin-top: 1.25rem;
+}
+@media (max-width: 780px) {
+  .grid.two-col {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* tab row: text links, not boxed tabs */
+.tab-row {
+  display: flex;
+  gap: 1.1rem;
+  align-items: baseline;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 0.5rem;
+  margin-bottom: 1rem;
+}
+.tab-row button {
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  font-weight: 500;
+  font-size: var(--ovp-text-sm);
+  cursor: pointer;
+  padding: 0;
+}
+.tab-row button:hover {
+  text-decoration: underline;
+}
+.tab-row button.active {
+  color: var(--accent);
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 6px;
+}
+
+/* memory cards */
+.mem-card .mem-title {
+  font-weight: 600;
+  margin-bottom: 0.3rem;
+}
+.mem-card p {
+  margin-bottom: 0;
+  font-size: var(--ovp-text-sm);
+  color: var(--text-soft);
+}
+
+/* grounded units */
+.unit-row {
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+  border-radius: var(--ovp-radius-md);
+  padding: 0.7rem 0.85rem;
+  margin-bottom: 0.7rem;
+  display: flex;
+  gap: 0.9rem;
+  align-items: baseline;
+}
+.unit-row blockquote {
+  margin: 0;
+  flex: 1;
+  min-width: 0;
+  font-family: var(--ovp-font-mono);
+  font-size: var(--ovp-text-xs);
+  line-height: 1.55;
+  color: var(--text-soft);
+}
+.line-anchor {
+  border: 0;
+  background: transparent;
+  padding: 0;
+  cursor: pointer;
+  font-family: var(--ovp-font-mono);
+  font-size: var(--ovp-text-xs);
+  font-weight: 600;
+  color: var(--accent);
+  white-space: nowrap;
+}
+.line-anchor:hover {
+  text-decoration: underline;
+}
+
+/* markdown reading view (~720px measure + line-number gutter) */
+.md-preview {
+  max-width: calc(720px + 3.2rem);
+}
+.md-row {
+  display: grid;
+  grid-template-columns: 2.6rem minmax(0, 1fr);
+  gap: 0.6rem;
+  border-radius: var(--ovp-radius-input);
+  transition: background 300ms;
+}
+.md-row .gut {
+  font-family: var(--ovp-font-mono);
+  font-size: 0.68rem;
+  color: var(--muted);
+  text-align: right;
+  padding-top: 0.45em;
+  user-select: none;
+}
+.md-row.md-hit {
+  background: var(--accent-soft);
+}
+.md-block {
+  min-width: 0;
+}
+.md-block h2 {
+  margin-top: 0.25rem;
+}
+.md-block p,
+.md-block li {
+  font-size: var(--ovp-text-sm);
+  line-height: 1.65;
+}
+.md-block ul,
+.md-block ol {
+  margin: 0 0 0.9rem;
+  padding-left: 1.4rem;
+}
+.md-block pre {
+  font-family: var(--ovp-font-mono);
+  font-size: var(--ovp-text-xs);
+  background: var(--code-bg);
+  color: var(--code-text);
+  border: 1px solid var(--border);
+  border-radius: var(--ovp-radius-input);
+  padding: 0.8rem 1rem;
+  overflow-x: auto;
+  line-height: 1.5;
+  margin: 0 0 0.9rem;
+}
+.md-block pre.md-frontmatter {
+  color: var(--muted);
+}
+.md-block code {
+  font-family: var(--ovp-font-mono);
+  font-size: 0.9em;
+}
+.md-block p code,
+.md-block li code {
+  background: var(--code-bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0 0.25em;
+}
+.md-block blockquote {
+  margin: 0 0 0.9rem;
+  padding: 0.1rem 0 0.1rem 0.9rem;
+  border-left: 2px solid var(--border-strong);
+  color: var(--text-soft);
+  font-size: var(--ovp-text-sm);
+}
+.md-block hr {
+  border: 0;
+  border-top: 1px solid var(--border);
+  margin: 1rem 0;
+}
+.md-img-placeholder {
+  font-family: var(--ovp-font-mono);
+  font-size: var(--ovp-text-xs);
+  color: var(--muted);
+  border: 1px dashed var(--border-strong);
+  border-radius: var(--ovp-radius-input);
+  padding: 0.1rem 0.4rem;
+}
+.doc-note {
+  margin: 0.75rem 0;
+  color: var(--muted);
+}
+.doc-note.mono {
+  color: var(--warn-text);
+  overflow-wrap: anywhere;
+}
+
+/* ---------- knowledge graph component ---------- */
+.graph-embed {
+  position: relative;
+  border: 1px solid var(--border);
+  border-radius: var(--ovp-radius-md);
+  background: var(--graph-bg);
+  overflow: hidden;
+}
+.graph-embed.fullscreen {
+  position: fixed;
+  inset: 1.25rem;
+  z-index: 50;
+  height: auto;
+  box-shadow: var(--shadow-pop);
+}
+.graph-canvas {
+  position: absolute;
+  inset: 0;
+}
+.graph-expand {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  z-index: 2;
+  border: 1px solid var(--border);
+  border-radius: var(--ovp-radius-pill);
+  background: var(--surface);
+  color: var(--muted);
+  font-family: var(--ovp-font-mono);
+  font-size: var(--ovp-text-xs);
+  letter-spacing: 0.04em;
+  padding: 0.2rem 0.55rem;
+  cursor: pointer;
+}
+.graph-expand:hover {
+  color: var(--accent);
+}
+.graph-note {
+  padding: 0.9rem;
+  font-size: var(--ovp-text-sm);
+  color: var(--muted);
+}
+.graph-truncated {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  z-index: 2;
+  font-size: var(--ovp-text-xs);
+  padding: 0.35rem 0.6rem;
+}
+.graph-info {
+  position: absolute;
+  left: 0.5rem;
+  bottom: 0.5rem;
+  z-index: 2;
+  max-width: min(320px, calc(100% - 1rem));
+  border: 1px solid var(--border);
+  border-radius: var(--ovp-radius-md);
+  background: var(--surface);
+  padding: 0.6rem 0.75rem;
+  font-size: var(--ovp-text-sm);
+}
+.graph-info-kind {
+  margin-bottom: 0.3rem;
+}
+.graph-info-title {
+  font-weight: 600;
+  line-height: 1.35;
+  margin-bottom: 0.2rem;
+}
+.graph-embed .empty-state {
+  padding: 0.9rem;
+}
+.graph-caption {
+  font-size: var(--ovp-text-xs);
+  color: var(--muted);
+  margin-top: 0.5rem;
+}
+
+/* citing claims rail */
+.citing-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-size: var(--ovp-text-sm);
+}
+.citing-list li {
+  padding: 0.45rem 0;
+  border-bottom: 1px solid var(--border);
+  line-height: 1.45;
+}
+.citing-list li:last-child {
+  border-bottom: 0;
+}
+.citing-list a {
+  font-weight: 500;
+  color: var(--text);
+}
+.citing-list a:hover {
+  color: var(--accent);
+}
+
 /* ---------- empty state ---------- */
 .empty-state {
   font-size: var(--ovp-text-sm);

--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -51,7 +51,7 @@ export const en = {
   'today.attentionAction': 'Open source detail',
   'today.claimsSample': 'From the crystal store',
   'today.claimsSampleNote':
-    'A durable-first sample — per-day attribution lands in B2.',
+    'A durable-first sample — the crystal ledger records no dates, so per-day attribution is not derivable yet.',
   'today.claimSources': 'Sources',
   'today.strength': 'strength',
   'today.readToday': 'Read today',
@@ -78,7 +78,7 @@ export const en = {
   'library.empty': 'No sources match the current filters.',
   'library.noDate': 'no date',
 
-  // source detail (B1 stub)
+  // source detail
   'source.title': 'Source',
   'source.url': 'url',
   'source.date': 'date',
@@ -89,9 +89,39 @@ export const en = {
   'source.lastReason': 'last error',
   'source.notFound': 'No source with this id in the index.',
   'source.backToLibrary': 'Library',
-  'source.b2Empty': 'Memory & source view coming in B2.',
-  'source.b2EmptyDetail':
-    'The three-layer drill-down (memory cards, grounded units, original markdown, neighborhood graph) ships in phase B2.',
+  'source.loadError': 'Could not load the source detail — is the server running?',
+  'source.tabMemory': 'Memory',
+  'source.tabMemoryCounts': '{cards} cards · {units} units',
+  'source.tabSource': 'Source',
+  'source.groundedUnits': 'Grounded units',
+  'source.unitNoLine': 'no line anchor',
+  'source.noMemory':
+    'No memory yet — this source has no cards or grounded units in its reader pack.',
+  'source.evidenceMissing':
+    'Evidence index not built — run `ovp2 index` against this vault to load cards and units.',
+  'source.docEmpty': 'No markdown file on disk for this source.',
+  'source.docError': 'Could not read the source file: {error}',
+  'source.docTruncated':
+    'Preview truncated at 200 KB — open the file in the vault for the full text.',
+  'source.neighborhood': 'Neighborhood',
+  'source.neighborhoodCaption':
+    'This source → citing claims → sibling sources. Click a node for a summary, double-click to open it.',
+  'source.citingClaims': 'Citing claims',
+  'source.citingEmpty': 'No crystal claims cite this source yet.',
+  'source.citingEmptyHint': '→ Knowledge: how claims crystallize',
+
+  // knowledge graph component
+  'graph.loading': 'Loading graph…',
+  'graph.error': 'Could not load the graph.',
+  'graph.empty': 'No neighborhood yet — nothing cites this source.',
+  'graph.b3': 'Global and theme graph scopes land in B3.',
+  'graph.fullscreen': 'EXPAND',
+  'graph.exitFullscreen': 'CLOSE',
+  'graph.truncated': 'Neighborhood truncated — showing the strongest claims.',
+  'graph.kindClaim': 'claim',
+  'graph.kindSource': 'source',
+  'graph.kindUnit': 'unit',
+  'graph.openHint': 'Double-click to open.',
 
   // placeholders
   'placeholder.search': 'Search across sources, cards, units, claims and themes lands in B3.',

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -50,7 +50,8 @@ export const zh: Record<keyof typeof en, string> = {
     '这条捕获内容太薄无法阅读——补充正文后才能进入有据记忆。',
   'today.attentionAction': '打开资料详情',
   'today.claimsSample': '来自结晶库',
-  'today.claimsSampleNote': 'durable 优先的样本——按日归因将在 B2 落地。',
+  'today.claimsSampleNote':
+    'durable 优先的样本——结晶账本尚未记录日期，暂无法按日归因。',
   'today.claimSources': '来源',
   'today.strength': '强度',
   'today.readToday': '今日读完',
@@ -76,7 +77,7 @@ export const zh: Record<keyof typeof en, string> = {
   'library.empty': '当前筛选下没有匹配的源。',
   'library.noDate': '无日期',
 
-  // source detail (B1 stub)
+  // source detail
   'source.title': '资料',
   'source.url': '链接',
   'source.date': '日期',
@@ -87,9 +88,37 @@ export const zh: Record<keyof typeof en, string> = {
   'source.lastReason': '最近错误',
   'source.notFound': '索引中没有这个 id 对应的源。',
   'source.backToLibrary': '资料',
-  'source.b2Empty': '记忆与原文视图将在 B2 上线。',
-  'source.b2EmptyDetail':
-    '三层钻取（记忆卡片、接地单元、原文 markdown、邻域图谱）在 B2 期交付。',
+  'source.loadError': '无法加载资料详情——服务是否在运行？',
+  'source.tabMemory': '记忆',
+  'source.tabMemoryCounts': '{cards} 卡片 · {units} 单元',
+  'source.tabSource': '原文',
+  'source.groundedUnits': '接地单元',
+  'source.unitNoLine': '无行号锚点',
+  'source.noMemory': '还没有记忆——该源的阅读包中没有卡片或接地单元。',
+  'source.evidenceMissing':
+    '证据索引尚未构建——对该 vault 运行 `ovp2 index` 以加载卡片与单元。',
+  'source.docEmpty': '磁盘上没有该源的 markdown 文件。',
+  'source.docError': '无法读取原文文件：{error}',
+  'source.docTruncated': '预览在 200 KB 处截断——完整内容请在 vault 中打开原文件。',
+  'source.neighborhood': '关联图谱 · 邻域',
+  'source.neighborhoodCaption':
+    '本源 → 引用它的主张 → 兄弟源。单击节点看摘要，双击打开详情。',
+  'source.citingClaims': '结晶引用',
+  'source.citingEmpty': '暂无结晶主张引用本源。',
+  'source.citingEmptyHint': '→ 知识：了解结晶如何产生',
+
+  // knowledge graph component
+  'graph.loading': '图谱加载中…',
+  'graph.error': '无法加载图谱。',
+  'graph.empty': '暂无邻域——还没有内容引用本源。',
+  'graph.b3': '全局与主题作用域将在 B3 上线。',
+  'graph.fullscreen': '全屏',
+  'graph.exitFullscreen': '关闭',
+  'graph.truncated': '邻域已截断——仅显示最强的主张。',
+  'graph.kindClaim': '主张',
+  'graph.kindSource': '源',
+  'graph.kindUnit': '单元',
+  'graph.openHint': '双击打开详情。',
 
   // placeholders
   'placeholder.search': '跨源/卡片/单元/主张/主题的搜索将在 B3 上线。',

--- a/console-ui/src/lib/api.ts
+++ b/console-ui/src/lib/api.ts
@@ -4,6 +4,7 @@ import type {
   FlowData,
   GraphResponse,
   IndexModel,
+  SourceDetail,
   ThemeCount,
 } from './types';
 
@@ -59,4 +60,17 @@ export function fetchThemes(): Promise<ThemeCount[]> {
 
 export function fetchModel(): Promise<IndexModel> {
   return fetchJson<IndexModel>('/api/model');
+}
+
+/** Three-layer source detail: meta + memory + citing claims + raw md. */
+export function fetchSourceDetail(sha: string): Promise<SourceDetail> {
+  return fetchJson<SourceDetail>(`/api/source/${encodeURIComponent(sha)}`);
+}
+
+/** Source-centric neighborhood for the KnowledgeGraph component (design §4):
+ * this source → claims citing it → sibling sources. */
+export function fetchSourceNeighborhood(sha: string): Promise<GraphResponse> {
+  return fetchJson<GraphResponse>(
+    `/api/graph?scope=neighborhood&source=${encodeURIComponent(sha)}`,
+  );
 }

--- a/console-ui/src/lib/derive.ts
+++ b/console-ui/src/lib/derive.ts
@@ -89,12 +89,13 @@ export function attentionSources(model: IndexModel): SourceRow[] {
   );
 }
 
-/** Sample of claims for the Today page. ClaimRow has no date, its run_id
- * namespace (`run-*`) does not join to RunRow (`daily-*`), AND the index
- * projection sorts claims by (claim_id, claim) — so no recency order is
- * derivable in B1 (codex review P2). Present a durable-first sample and
- * label it as such; true "crystallized today" needs a date/run join key
- * on ClaimRow (B2 read-model change). */
+/** Sample of claims for the Today page — durable-first, labeled as such.
+ * B2 verdict on the codex-review P2: NO date is derivable. The crystal
+ * ledger (StoreEvent/DurableRecord) carries no date/written-at field,
+ * `default_run_id` is a content hash with deliberately no wall-clock, and
+ * review.json entries are dateless too — so "crystallized today" would be
+ * an invention. Real per-day attribution needs a ledger schema change
+ * (timestamped StoreEvent), tracked for a later phase. */
 export function claimsSample(model: IndexModel, n: number): ClaimRow[] {
   const rank = (c: ClaimRow) => (c.status === 'durable' ? 0 : 1);
   return model.claims

--- a/console-ui/src/lib/markdown.tsx
+++ b/console-ui/src/lib/markdown.tsx
@@ -1,0 +1,348 @@
+/** Markdown reading view for source bodies — a TS port (and extension) of
+ * the v1 escape-first mini renderer (ovp-console/src/md.rs).
+ *
+ * XSS approach: there is NO html-string pathway at all. The parser produces
+ * a block model, the renderer emits React elements, and every piece of
+ * source text stays a React TEXT node — React escapes it on render. No
+ * dangerouslySetInnerHTML anywhere, so a hostile clipping
+ * (`<script>…</script>`, `<img onerror=…>`) can never become live markup.
+ * Link URLs are additionally scheme-filtered (http/https/mailto/#) and
+ * images render as an alt-text placeholder — no remote loading (B2
+ * decision).
+ *
+ * Deliberately tiny: headings, paragraphs, fenced code, lists, blockquotes,
+ * links/bold/italic/inline-code, hr, YAML frontmatter. The portal renders
+ * vault notes for orientation, not fidelity — this keeps zero new
+ * dependencies and gives exact source-line tracking for unit anchors, which
+ * react-markdown would only approximate.
+ */
+import { useEffect, useRef, type ReactNode } from 'react';
+
+// ------------------------------------------------------------------ parser
+
+/** One rendered block; `line`..`end` are 1-based source line numbers. */
+export type MdBlock =
+  | { kind: 'heading'; line: number; end: number; level: number; text: string }
+  | { kind: 'para'; line: number; end: number; lines: string[] }
+  | { kind: 'code'; line: number; end: number; lang: string; text: string }
+  | { kind: 'quote'; line: number; end: number; lines: string[] }
+  | {
+      kind: 'list';
+      line: number;
+      end: number;
+      ordered: boolean;
+      items: { line: number; text: string }[];
+    }
+  | { kind: 'hr'; line: number; end: number }
+  | { kind: 'frontmatter'; line: number; end: number; text: string };
+
+const LIST_ITEM = /^\s{0,3}(?:([-*+])|(\d{1,9})[.)])\s+(.*)$/;
+const HR = /^ {0,3}(?:-{3,}|\*{3,}|_{3,})\s*$/;
+
+/** `## Title` → level 2. ATX only, requires the space (v1 parity). */
+function heading(line: string): { level: number; text: string } | null {
+  const m = /^(#{1,6}) (.*)$/.exec(line);
+  return m ? { level: m[1].length, text: m[2].trim() } : null;
+}
+
+export function parseMarkdown(md: string): MdBlock[] {
+  const lines = md.split('\n');
+  const blocks: MdBlock[] = [];
+  let i = 0;
+
+  // YAML frontmatter: only when the document opens with `---`.
+  if (lines[0]?.trim() === '---') {
+    let close = -1;
+    for (let j = 1; j < lines.length; j += 1) {
+      if (lines[j].trim() === '---') {
+        close = j;
+        break;
+      }
+    }
+    if (close > 0) {
+      blocks.push({
+        kind: 'frontmatter',
+        line: 1,
+        end: close + 1,
+        text: lines.slice(1, close).join('\n'),
+      });
+      i = close + 1;
+    }
+  }
+
+  while (i < lines.length) {
+    const line = lines[i];
+    const lineNo = i + 1;
+
+    if (line.trim() === '') {
+      i += 1;
+      continue;
+    }
+
+    // Fenced code — runs to the closing fence or EOF (v1: an unterminated
+    // fence is closed rather than swallowing the rest of the page).
+    if (line.trimStart().startsWith('```')) {
+      const lang = line.trimStart().slice(3).trim();
+      const body: string[] = [];
+      let j = i + 1;
+      while (j < lines.length && !lines[j].trimStart().startsWith('```')) {
+        body.push(lines[j]);
+        j += 1;
+      }
+      blocks.push({
+        kind: 'code',
+        line: lineNo,
+        end: Math.min(j + 1, lines.length),
+        lang,
+        text: body.join('\n'),
+      });
+      i = j + 1;
+      continue;
+    }
+
+    const h = heading(line);
+    if (h) {
+      blocks.push({ kind: 'heading', line: lineNo, end: lineNo, ...h });
+      i += 1;
+      continue;
+    }
+
+    if (HR.test(line)) {
+      blocks.push({ kind: 'hr', line: lineNo, end: lineNo });
+      i += 1;
+      continue;
+    }
+
+    if (line.startsWith('>')) {
+      const body: string[] = [];
+      let j = i;
+      while (j < lines.length && lines[j].startsWith('>')) {
+        body.push(lines[j].replace(/^> ?/, ''));
+        j += 1;
+      }
+      blocks.push({ kind: 'quote', line: lineNo, end: j, lines: body });
+      i = j;
+      continue;
+    }
+
+    const li = LIST_ITEM.exec(line);
+    if (li) {
+      const ordered = li[2] !== undefined;
+      const items: { line: number; text: string }[] = [];
+      let j = i;
+      while (j < lines.length) {
+        const m = LIST_ITEM.exec(lines[j]);
+        if (!m) break;
+        items.push({ line: j + 1, text: m[3] });
+        j += 1;
+      }
+      blocks.push({ kind: 'list', line: lineNo, end: j, ordered, items });
+      i = j;
+      continue;
+    }
+
+    // Paragraph: consecutive non-blank, non-structural lines.
+    const body: string[] = [line];
+    let j = i + 1;
+    while (
+      j < lines.length &&
+      lines[j].trim() !== '' &&
+      !lines[j].trimStart().startsWith('```') &&
+      !heading(lines[j]) &&
+      !lines[j].startsWith('>') &&
+      !LIST_ITEM.test(lines[j]) &&
+      !HR.test(lines[j])
+    ) {
+      body.push(lines[j]);
+      j += 1;
+    }
+    blocks.push({ kind: 'para', line: lineNo, end: j, lines: body });
+    i = j;
+  }
+
+  return blocks;
+}
+
+// ------------------------------------------------------------------ inline
+
+/** Only these link targets become <a>; everything else renders as text.
+ * Relative/anchor targets are fine — `javascript:` and friends are not. */
+export function safeLinkHref(url: string): string | null {
+  const trimmed = url.trim();
+  if (/^(https?:|mailto:)/i.test(trimmed)) return trimmed;
+  if (trimmed.startsWith('#') || trimmed.startsWith('/')) return trimmed;
+  if (!/^[a-z][a-z0-9+.-]*:/i.test(trimmed) && trimmed !== '') return trimmed;
+  return null;
+}
+
+const INLINE =
+  /(!\[[^\]]*\]\([^)]*\))|(\[[^\]]+\]\([^)]*\))|(`[^`]+`)|(\*\*[^*]+\*\*)|(\*[^*\s][^*]*\*)/;
+
+/** Source text → React nodes. Text stays text nodes (React escapes it). */
+export function renderInline(text: string, keyPrefix = 'i'): ReactNode[] {
+  const out: ReactNode[] = [];
+  let rest = text;
+  let k = 0;
+  while (rest.length > 0) {
+    const m = INLINE.exec(rest);
+    if (!m || m.index === undefined) {
+      out.push(rest);
+      break;
+    }
+    if (m.index > 0) out.push(rest.slice(0, m.index));
+    const token = m[0];
+    const key = `${keyPrefix}-${k}`;
+    k += 1;
+
+    if (m[1]) {
+      // Image → alt-text placeholder; no remote loading in B2.
+      const alt = /^!\[([^\]]*)\]/.exec(token)?.[1] ?? '';
+      out.push(
+        <span key={key} className="md-img-placeholder">
+          [image{alt ? `: ${alt}` : ''}]
+        </span>,
+      );
+    } else if (m[2]) {
+      const lm = /^\[([^\]]+)\]\(([^)]*)\)$/.exec(token);
+      const label = lm?.[1] ?? token;
+      const href = safeLinkHref(lm?.[2] ?? '');
+      if (href) {
+        out.push(
+          <a key={key} href={href} target="_blank" rel="noreferrer">
+            {renderInline(label, key)}
+          </a>,
+        );
+      } else {
+        out.push(label);
+      }
+    } else if (m[3]) {
+      out.push(<code key={key}>{token.slice(1, -1)}</code>);
+    } else if (m[4]) {
+      out.push(
+        <strong key={key}>{renderInline(token.slice(2, -2), key)}</strong>,
+      );
+    } else {
+      out.push(<em key={key}>{renderInline(token.slice(1, -1), key)}</em>);
+    }
+    rest = rest.slice(m.index + token.length);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------- renderer
+
+function blockBody(block: MdBlock, key: string): ReactNode {
+  switch (block.kind) {
+    case 'heading': {
+      const inner = renderInline(block.text, key);
+      // Page structure owns h1; source headings start at h2 (v1 parity).
+      if (block.level === 1) return <h2>{inner}</h2>;
+      if (block.level === 2) return <h3>{inner}</h3>;
+      return <h4>{inner}</h4>;
+    }
+    case 'para':
+      return (
+        <p>
+          {block.lines.map((l, n) => (
+            <span key={`${key}-l${n}`}>
+              {n > 0 && <br />}
+              {renderInline(l, `${key}-l${n}`)}
+            </span>
+          ))}
+        </p>
+      );
+    case 'code':
+      return (
+        <pre data-lang={block.lang || undefined}>
+          <code>{block.text}</code>
+        </pre>
+      );
+    case 'quote':
+      return (
+        <blockquote>
+          {block.lines.map((l, n) => (
+            <span key={`${key}-q${n}`}>
+              {n > 0 && <br />}
+              {renderInline(l, `${key}-q${n}`)}
+            </span>
+          ))}
+        </blockquote>
+      );
+    case 'list': {
+      const items = block.items.map((it, n) => (
+        <li key={`${key}-it${n}`}>{renderInline(it.text, `${key}-it${n}`)}</li>
+      ));
+      return block.ordered ? <ol>{items}</ol> : <ul>{items}</ul>;
+    }
+    case 'hr':
+      return <hr />;
+    case 'frontmatter':
+      return (
+        <pre className="md-frontmatter">
+          <code>{block.text}</code>
+        </pre>
+      );
+  }
+}
+
+export interface MarkdownViewProps {
+  markdown: string;
+  /** Source lines that grounded units anchor to — get a gutter `L<n>` mark. */
+  anchoredLines?: ReadonlySet<number>;
+  /** Line to scroll to and highlight (set when a unit anchor is clicked). */
+  highlightLine?: number | null;
+}
+
+/** The ~720px-measure reading view with a line-number gutter. Blocks whose
+ * source range contains an anchored line get a gutter mark; the highlight
+ * line scrolls into view and flashes the containing block. */
+export function MarkdownView({
+  markdown,
+  anchoredLines,
+  highlightLine,
+}: MarkdownViewProps) {
+  const blocks = parseMarkdown(markdown);
+  const rowRefs = useRef<Map<number, HTMLDivElement>>(new Map());
+
+  useEffect(() => {
+    if (highlightLine == null) return;
+    const idx = blocks.findIndex(
+      (b) => b.line <= highlightLine && highlightLine <= b.end,
+    );
+    if (idx >= 0) {
+      rowRefs.current
+        .get(idx)
+        ?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+    // blocks derive from markdown; the ref map is rebuilt on each render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [highlightLine, markdown]);
+
+  return (
+    <div className="md-preview">
+      {blocks.map((b, idx) => {
+        const anchor = anchoredLines
+          ? [...anchoredLines].find((l) => b.line <= l && l <= b.end)
+          : undefined;
+        const hit =
+          highlightLine != null &&
+          b.line <= highlightLine &&
+          highlightLine <= b.end;
+        return (
+          <div
+            key={`b${b.line}`}
+            className={`md-row${hit ? ' md-hit' : ''}`}
+            id={anchor != null ? `L${anchor}` : undefined}
+            ref={(el) => {
+              if (el) rowRefs.current.set(idx, el);
+              else rowRefs.current.delete(idx);
+            }}
+          >
+            <span className="gut">{anchor != null ? `L${anchor}` : ''}</span>
+            <div className="md-block">{blockBody(b, `b${b.line}`)}</div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/console-ui/src/lib/markdown.tsx
+++ b/console-ui/src/lib/markdown.tsx
@@ -16,7 +16,7 @@
  * dependencies and gives exact source-line tracking for unit anchors, which
  * react-markdown would only approximate.
  */
-import { useEffect, useRef, type ReactNode } from 'react';
+import { useEffect, useMemo, useRef, type ReactNode } from 'react';
 
 // ------------------------------------------------------------------ parser
 
@@ -46,7 +46,11 @@ function heading(line: string): { level: number; text: string } | null {
 }
 
 export function parseMarkdown(md: string): MdBlock[] {
-  const lines = md.split('\n');
+  // CRLF sources (Windows-authored clippings): strip the trailing \r so
+  // trim-based matches (frontmatter fence, hr, headings) see clean lines.
+  const lines = md
+    .split('\n')
+    .map((l) => (l.endsWith('\r') ? l.slice(0, -1) : l));
   const blocks: MdBlock[] = [];
   let i = 0;
 
@@ -301,7 +305,9 @@ export function MarkdownView({
   anchoredLines,
   highlightLine,
 }: MarkdownViewProps) {
-  const blocks = parseMarkdown(markdown);
+  // Parsing walks the whole document — memoize per markdown string so
+  // unrelated re-renders (highlight changes, anchor sets) don't re-parse.
+  const blocks = useMemo(() => parseMarkdown(markdown), [markdown]);
   const rowRefs = useRef<Map<number, HTMLDivElement>>(new Map());
 
   useEffect(() => {

--- a/console-ui/src/lib/types.ts
+++ b/console-ui/src/lib/types.ts
@@ -135,6 +135,44 @@ export interface ClaimRow {
   lane?: string;
 }
 
+// ---- /api/source/:sha (B2 source detail) ----
+
+export interface MemoryCard {
+  title: string;
+  content: string;
+}
+
+export interface MemoryUnit {
+  unit_id: string;
+  text: string;
+  quote: string;
+  line: number | null;
+  attribution: string;
+}
+
+export interface SourceMemory {
+  /** False when the vault has no evidence sidecar (pre-M31) — the page
+   * shows a "run ovp2 index" hint instead of an empty memory layer. */
+  evidence_available: boolean;
+  cards: MemoryCard[];
+  units: MemoryUnit[];
+}
+
+export interface SourceDocPayload {
+  /** Raw markdown text (JSON data — rendered client-side, never as HTML). */
+  markdown: string | null;
+  /** True when the body was cut at the server's 200KB cap. */
+  truncated: boolean;
+  error: string | null;
+}
+
+export interface SourceDetail {
+  source: SourceRow;
+  memory: SourceMemory;
+  citing_claims: ClaimRow[];
+  doc: SourceDocPayload;
+}
+
 export interface BlockedSource {
   sha256: string;
   title?: string;

--- a/console-ui/src/pages/SourceDetailPage.tsx
+++ b/console-ui/src/pages/SourceDetailPage.tsx
@@ -1,104 +1,299 @@
-/** Source detail `/library/:sha` — B1 stub: meta card from SourceRow plus a
- * guided empty state. The real three-layer drill-down (memory cards,
- * grounded units, markdown reading view, neighborhood graph) is phase B2. */
+/** Source detail `/library/:sha` — the three-layer drill-down (design §3.2):
+ * header meta, [Memory | Source md] tabs, grounded units with `L<n> →`
+ * anchors into the markdown reading view, and a right rail with the
+ * neighborhood KnowledgeGraph and citing crystal claims. Data comes from
+ * /api/source/:sha; the markdown is rendered client-side by the escape-first
+ * renderer in lib/markdown.tsx (raw text never becomes HTML). */
+import { useEffect, useMemo, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
-import { EmptyState, ModelGate, StatusPill } from '../components/ui';
+import KnowledgeGraph from '../components/KnowledgeGraph';
+import { ClaimPill, EmptyState, StatusPill } from '../components/ui';
 import { useI18n } from '../i18n';
+import { fetchSourceDetail } from '../lib/api';
 import { collectionOf } from '../lib/derive';
-import { useModel } from '../model';
+import { MarkdownView } from '../lib/markdown';
+import type { ClaimRow, SourceDetail } from '../lib/types';
+
+type Tab = 'memory' | 'source';
+
+interface DetailState {
+  detail: SourceDetail | null;
+  status: 'loading' | 'ready' | 'notFound' | 'error';
+}
+
+function useSourceDetail(sha: string | undefined): DetailState {
+  const [state, setState] = useState<DetailState>({
+    detail: null,
+    status: 'loading',
+  });
+
+  useEffect(() => {
+    if (!sha) {
+      setState({ detail: null, status: 'notFound' });
+      return;
+    }
+    let cancelled = false;
+    setState({ detail: null, status: 'loading' });
+    fetchSourceDetail(sha)
+      .then((detail) => {
+        if (!cancelled) setState({ detail, status: 'ready' });
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setState({
+            detail: null,
+            status: String(err).includes(': 404') ? 'notFound' : 'error',
+          });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [sha]);
+
+  return state;
+}
+
+function CitingClaims({ claims }: { claims: ClaimRow[] }) {
+  const { t } = useI18n();
+  if (claims.length === 0) {
+    return (
+      <EmptyState>
+        <p>{t('source.citingEmpty')}</p>
+        <Link className="tiny" to="/knowledge">
+          {t('source.citingEmptyHint')}
+        </Link>
+      </EmptyState>
+    );
+  }
+  return (
+    <ul className="citing-list">
+      {claims.map((c) => (
+        <li key={c.claim_id}>
+          {(c.status === 'durable' || c.status === 'caveated') && (
+            <ClaimPill status={c.status} />
+          )}{' '}
+          <Link to={`/knowledge#${c.claim_id}`}>{c.claim}</Link>
+        </li>
+      ))}
+    </ul>
+  );
+}
 
 export default function SourceDetailPage() {
   const { t } = useI18n();
-  const { model, error, loading } = useModel();
   const { sha } = useParams<{ sha: string }>();
+  const { detail, status } = useSourceDetail(sha);
+  const [tab, setTab] = useState<Tab>('memory');
+  const [highlightLine, setHighlightLine] = useState<number | null>(null);
 
-  const source = model?.sources.find((s) => s.sha256 === sha);
+  const anchoredLines = useMemo(
+    () =>
+      new Set(
+        (detail?.memory.units ?? [])
+          .map((u) => u.line)
+          .filter((l): l is number => l != null),
+      ),
+    [detail],
+  );
+
+  const jumpToLine = (line: number) => {
+    setTab('source');
+    setHighlightLine(line);
+  };
+
+  if (status === 'loading') {
+    return <div className="portal-note">{t('common.loading')}</div>;
+  }
+  if (status === 'error') {
+    return <div className="portal-note">{t('source.loadError')}</div>;
+  }
+  if (status === 'notFound' || !detail) {
+    return (
+      <>
+        <div className="crumbs">
+          <Link to="/library">{t('source.backToLibrary')}</Link> / {sha}
+        </div>
+        <EmptyState>
+          <p>{t('source.notFound')}</p>
+        </EmptyState>
+      </>
+    );
+  }
+
+  const { source, memory, citing_claims: citing, doc } = detail;
+  const title = source.title ?? source.sha256;
 
   return (
-    <ModelGate loading={loading} error={error}>
-      {model && (
-        <>
-          <div className="crumbs">
-            <Link to="/library">{t('source.backToLibrary')}</Link> /{' '}
-            {source?.title ?? sha}
+    <>
+      <div className="crumbs">
+        <Link to="/library">{t('source.backToLibrary')}</Link> / {title}
+      </div>
+
+      <div className="src-head">
+        <h1 style={{ marginBottom: '0.25rem' }}>{title}</h1>
+        <StatusPill status={source.status} />
+      </div>
+
+      <dl className="meta-rows">
+        {source.url && (
+          <>
+            <dt>{t('source.url')}</dt>
+            <dd>
+              <a className="mono tiny" href={source.url} target="_blank" rel="noreferrer">
+                {source.url}
+              </a>
+            </dd>
+          </>
+        )}
+        {source.date && (
+          <>
+            <dt>{t('source.date')}</dt>
+            <dd className="mono tiny">{source.date}</dd>
+          </>
+        )}
+        <dt>{t('source.origin')}</dt>
+        <dd className="tiny">{t(`library.${collectionOf(source)}`)}</dd>
+        {source.rel_path && (
+          <>
+            <dt>{t('source.location')}</dt>
+            <dd className="mono tiny">{source.rel_path}</dd>
+          </>
+        )}
+        {source.last_run_id && (
+          <>
+            <dt>{t('source.lastRun')}</dt>
+            <dd className="mono tiny">{source.last_run_id}</dd>
+          </>
+        )}
+        {source.fail_count > 0 && (
+          <>
+            <dt>{t('source.failCount')}</dt>
+            <dd className="mono tiny">{source.fail_count}</dd>
+          </>
+        )}
+        {source.last_reason && (
+          <>
+            <dt>{t('source.lastReason')}</dt>
+            <dd className="mono tiny">{source.last_reason}</dd>
+          </>
+        )}
+      </dl>
+
+      <div className="grid two-col">
+        {/* main column: Memory | Source tabs */}
+        <div>
+          <div className="tab-row">
+            <button
+              type="button"
+              className={tab === 'memory' ? 'active' : ''}
+              onClick={() => setTab('memory')}
+            >
+              {t('source.tabMemory')}{' '}
+              <span className="muted">
+                (
+                {t('source.tabMemoryCounts', {
+                  cards: memory.cards.length,
+                  units: memory.units.length,
+                })}
+                )
+              </span>
+            </button>
+            <button
+              type="button"
+              className={tab === 'source' ? 'active' : ''}
+              onClick={() => setTab('source')}
+            >
+              {t('source.tabSource')} <span className="mono muted tiny">md</span>
+            </button>
           </div>
-          {!source ? (
-            <EmptyState>
-              <p>{t('source.notFound')}</p>
-            </EmptyState>
-          ) : (
+
+          {tab === 'memory' && (
             <>
-              <div className="src-head">
-                <h1 style={{ marginBottom: '0.25rem' }}>
-                  {source.title ?? source.sha256}
-                </h1>
-                <StatusPill status={source.status} />
-              </div>
-              <dl className="meta-rows">
-                {source.url && (
-                  <>
-                    <dt>{t('source.url')}</dt>
-                    <dd>
-                      <a
-                        className="mono tiny"
-                        href={source.url}
-                        target="_blank"
-                        rel="noreferrer"
-                      >
-                        {source.url}
-                      </a>
-                    </dd>
-                  </>
-                )}
-                {source.date && (
-                  <>
-                    <dt>{t('source.date')}</dt>
-                    <dd className="mono tiny">{source.date}</dd>
-                  </>
-                )}
-                <dt>{t('source.origin')}</dt>
-                <dd className="tiny">
-                  {t(`library.${collectionOf(source)}`)}
-                </dd>
-                {source.rel_path && (
-                  <>
-                    <dt>{t('source.location')}</dt>
-                    <dd className="mono tiny">{source.rel_path}</dd>
-                  </>
-                )}
-                {source.last_run_id && (
-                  <>
-                    <dt>{t('source.lastRun')}</dt>
-                    <dd className="mono tiny">{source.last_run_id}</dd>
-                  </>
-                )}
-                {source.fail_count > 0 && (
-                  <>
-                    <dt>{t('source.failCount')}</dt>
-                    <dd className="mono tiny">{source.fail_count}</dd>
-                  </>
-                )}
-                {source.last_reason && (
-                  <>
-                    <dt>{t('source.lastReason')}</dt>
-                    <dd className="mono tiny">{source.last_reason}</dd>
-                  </>
-                )}
-              </dl>
-              <div className="section">
-                <div className="card">
-                  <EmptyState>
-                    <p>
-                      <strong>{t('source.b2Empty')}</strong>
-                    </p>
-                    <p>{t('source.b2EmptyDetail')}</p>
-                  </EmptyState>
+              {memory.cards.map((card, i) => (
+                <div className="card mem-card" key={`c${i}`}>
+                  <div className="mem-title">{card.title}</div>
+                  <p>{card.content}</p>
                 </div>
-              </div>
+              ))}
+              {memory.cards.length === 0 && memory.units.length === 0 && (
+                <EmptyState>
+                  <p>
+                    {memory.evidence_available
+                      ? t('source.noMemory')
+                      : t('source.evidenceMissing')}
+                  </p>
+                </EmptyState>
+              )}
+              {memory.units.length > 0 && (
+                <div className="section">
+                  <h3>{t('source.groundedUnits')}</h3>
+                  {memory.units.map((unit) => (
+                    <div className="unit-row" key={unit.unit_id}>
+                      <blockquote>“{unit.quote}”</blockquote>
+                      {unit.line != null ? (
+                        <button
+                          type="button"
+                          className="line-anchor"
+                          onClick={() => jumpToLine(unit.line as number)}
+                        >
+                          L{unit.line} →
+                        </button>
+                      ) : (
+                        <span className="tiny muted">
+                          {t('source.unitNoLine')}
+                        </span>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
             </>
           )}
-        </>
-      )}
-    </ModelGate>
+
+          {tab === 'source' && (
+            <>
+              {doc.error && (
+                <div className="doc-note mono tiny">
+                  {t('source.docError', { error: doc.error })}
+                </div>
+              )}
+              {!doc.error && doc.markdown == null && (
+                <EmptyState>
+                  <p>{t('source.docEmpty')}</p>
+                </EmptyState>
+              )}
+              {doc.markdown != null && (
+                <>
+                  <MarkdownView
+                    markdown={doc.markdown}
+                    anchoredLines={anchoredLines}
+                    highlightLine={highlightLine}
+                  />
+                  {doc.truncated && (
+                    <div className="doc-note tiny muted">
+                      {t('source.docTruncated')}
+                    </div>
+                  )}
+                </>
+              )}
+            </>
+          )}
+        </div>
+
+        {/* right rail: neighborhood graph + citing claims */}
+        <div>
+          <div className="card">
+            <h3 style={{ marginBottom: '0.6rem' }}>{t('source.neighborhood')}</h3>
+            <KnowledgeGraph scope="neighborhood" id={source.sha256} height={360} />
+            <div className="graph-caption">{t('source.neighborhoodCaption')}</div>
+          </div>
+          <div className="card">
+            <h3 style={{ marginBottom: '0.6rem' }}>{t('source.citingClaims')}</h3>
+            <CitingClaims claims={citing} />
+          </div>
+        </div>
+      </div>
+    </>
   );
 }

--- a/console-ui/src/pages/SourceDetailPage.tsx
+++ b/console-ui/src/pages/SourceDetailPage.tsx
@@ -5,7 +5,7 @@
  * /api/source/:sha; the markdown is rendered client-side by the escape-first
  * renderer in lib/markdown.tsx (raw text never becomes HTML). */
 import { useEffect, useMemo, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams, useSearchParams } from 'react-router-dom';
 import KnowledgeGraph from '../components/KnowledgeGraph';
 import { ClaimPill, EmptyState, StatusPill } from '../components/ui';
 import { useI18n } from '../i18n';
@@ -84,7 +84,21 @@ export default function SourceDetailPage() {
   const { t } = useI18n();
   const { sha } = useParams<{ sha: string }>();
   const { detail, status } = useSourceDetail(sha);
-  const [tab, setTab] = useState<Tab>('memory');
+  // Tab is URL-parameterized (?tab=source) — shareable deep links, same
+  // rule as the Library facets (design §5).
+  const [searchParams, setSearchParams] = useSearchParams();
+  const tab: Tab = searchParams.get('tab') === 'source' ? 'source' : 'memory';
+  const setTab = (next: Tab) => {
+    setSearchParams(
+      (prev) => {
+        const p = new URLSearchParams(prev);
+        if (next === 'source') p.set('tab', 'source');
+        else p.delete('tab');
+        return p;
+      },
+      { replace: true },
+    );
+  };
   const [highlightLine, setHighlightLine] = useState<number | null>(null);
 
   const anchoredLines = useMemo(

--- a/crates/ovp-server/src/graph.rs
+++ b/crates/ovp-server/src/graph.rs
@@ -825,6 +825,132 @@ fn neighborhood_response(
     })
 }
 
+/// Source-centric neighborhood for the portal's KnowledgeGraph component
+/// (design §4, `scope=neighborhood&source=<sha>`): the source node, claims
+/// citing it, and the sibling sources those claims also draw from. Units are
+/// deliberately excluded — the source detail page shows them as text; the
+/// graph tells the claim/sibling story. Cards are not modeled in the graph.
+///
+/// A source known to the index but cited by no claim returns a single-node
+/// graph (the page still shows the component with an empty-neighborhood
+/// hint); an entirely unknown sha is a 404.
+pub fn source_neighborhood(
+    records: &[DurableRecord],
+    model: Option<&IndexModel>,
+    sha: &str,
+) -> Result<GraphResponse, GraphError> {
+    let mut base = build_base(records, model);
+    add_related_edges(&mut base);
+    compute_degrees(&mut base);
+    assign_clusters(&mut base);
+    compute_importance(&mut base, records);
+
+    let focus_id = format!("source:{sha}");
+
+    // Claims citing this source, importance-ranked so a hub source keeps its
+    // strongest claims under the node cap.
+    let mut citing: Vec<&String> = base
+        .claim_sources
+        .iter()
+        .filter(|(_, srcs)| srcs.contains(&focus_id))
+        .map(|(claim, _)| claim)
+        .collect();
+    citing.sort_by(|a, b| {
+        let ia = base.nodes.get(*a).map(|n| n.importance).unwrap_or(0.0);
+        let ib = base.nodes.get(*b).map(|n| n.importance).unwrap_or(0.0);
+        ib.partial_cmp(&ia)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.cmp(b))
+    });
+
+    if citing.is_empty() && !base.nodes.contains_key(&focus_id) {
+        // Not in the crystal graph at all — fall back to the index so a
+        // freshly processed (or blocked) source still gets its focus node.
+        let Some(src) = model.and_then(|m| m.sources.iter().find(|s| s.sha256 == sha)) else {
+            return Err(GraphError::not_found(&format!("source not found: {sha}")));
+        };
+        let node = GNode {
+            id: focus_id.clone(),
+            node_type: "source".into(),
+            label: src.title.clone().unwrap_or_else(|| sha.to_string()),
+            theme: None,
+            strength: None,
+            url: src.url.clone(),
+            degree: 0,
+            cluster: 0,
+            importance: 1.0,
+            hit: false,
+            provenance: None,
+        };
+        return Ok(GraphResponse {
+            mode: GraphMode::Neighborhood.as_str().into(),
+            nodes: vec![node],
+            edges: Vec::new(),
+            communities: Vec::new(),
+            total_nodes: base.nodes.len() + 1,
+            truncated: false,
+        });
+    }
+
+    // Keep focus + claims + their sibling sources under the shared cap.
+    let mut kept: BTreeSet<&str> = BTreeSet::new();
+    kept.insert(focus_id.as_str());
+    let mut truncated = false;
+    for claim in &citing {
+        let srcs = &base.claim_sources[claim.as_str()];
+        // +1 for the claim itself; siblings may already be kept.
+        let new_sources = srcs.iter().filter(|s| !kept.contains(s.as_str())).count();
+        if kept.len() + 1 + new_sources > MAX_NEIGHBORHOOD_NODES {
+            truncated = true;
+            break;
+        }
+        kept.insert(claim.as_str());
+        for s in srcs {
+            kept.insert(s.as_str());
+        }
+    }
+
+    let mut nodes: Vec<GNode> = base
+        .nodes
+        .values()
+        .filter(|n| kept.contains(n.id.as_str()))
+        .cloned()
+        .collect();
+    sort_by_importance(&mut nodes);
+
+    // Bipartite claim→source edges (`cites`): the units in between are
+    // collapsed for this compact view.
+    let mut edges: Vec<GEdge> = Vec::new();
+    for (claim, srcs) in &base.claim_sources {
+        if !kept.contains(claim.as_str()) {
+            continue;
+        }
+        for s in srcs {
+            if kept.contains(s.as_str()) {
+                edges.push(GEdge {
+                    source: claim.clone(),
+                    target: s.clone(),
+                    edge_type: "cites".into(),
+                    weight: None,
+                });
+            }
+        }
+    }
+
+    let claim_refs: Vec<&GNode> = nodes.iter().filter(|n| n.node_type == "claim").collect();
+    let communities = build_communities(&claim_refs);
+    let total_nodes = base.nodes.len();
+
+    Ok(GraphResponse {
+        mode: GraphMode::Neighborhood.as_str().into(),
+        nodes,
+        edges,
+        communities,
+        total_nodes,
+        truncated,
+    })
+}
+
 pub const MAX_SEARCH_HITS: usize = 40;
 const MAX_SEARCH_CONTEXT: usize = 80;
 
@@ -1216,6 +1342,125 @@ mod tests {
         ];
         let resp = build_graph(&records, None, &params(GraphMode::Overview)).unwrap();
         assert_eq!(resp.communities[0].label, "t1 / t2");
+    }
+
+    /// Index model mapping `(case_id, sha, title)` triples to sources+packs
+    /// so build_base resolves `source:<sha>` node ids.
+    fn model_for_cases(cases: &[(&str, &str, &str)]) -> IndexModel {
+        use ovp_index::{OpsState, PackRow, SourceRow, SourceStatus, Totals};
+        IndexModel {
+            schema: "ovp.index/v2".into(),
+            date: "2026-07-09".into(),
+            run_id: None,
+            totals: Totals::default(),
+            sources: cases
+                .iter()
+                .map(|(case, sha, title)| SourceRow {
+                    sha256: (*sha).into(),
+                    status: SourceStatus::Processed,
+                    title: Some((*title).into()),
+                    url: None,
+                    rel_path: None,
+                    date: None,
+                    last_run_id: None,
+                    pack_dir: Some(format!("40-Resources/Reader/{case}")),
+                    fail_count: 0,
+                    last_reason: None,
+                })
+                .collect(),
+            packs: cases
+                .iter()
+                .map(|(case, sha, title)| PackRow {
+                    pack_dir: format!("40-Resources/Reader/{case}"),
+                    title: (*title).into(),
+                    date: None,
+                    units: 0,
+                    cards: 0,
+                    json_repaired: false,
+                    card_titles: vec![],
+                    source_sha256: Some((*sha).into()),
+                })
+                .collect(),
+            claims: vec![],
+            runs: vec![],
+            ops: OpsState::default(),
+        }
+    }
+
+    #[test]
+    fn source_neighborhood_returns_citing_claims_and_sibling_sources() {
+        let records = sample_records();
+        let model = model_for_cases(&[
+            ("case1", "sha1", "Source One"),
+            ("case2", "sha2", "Source Two"),
+            ("case9", "sha9", "Source Nine"),
+        ]);
+        let resp = source_neighborhood(&records, Some(&model), "sha1").unwrap();
+        assert_eq!(resp.mode, "neighborhood");
+
+        let ids: HashSet<&str> = resp.nodes.iter().map(|n| n.id.as_str()).collect();
+        // Focus source, its citing claims a/b/c, and the sibling source of
+        // claim a (case2 → sha2).
+        assert!(ids.contains("source:sha1"));
+        assert!(ids.contains("claim:a"));
+        assert!(ids.contains("claim:b"));
+        assert!(ids.contains("claim:c"));
+        assert!(ids.contains("source:sha2"));
+        // Unrelated claim d and its source never enter the neighborhood.
+        assert!(!ids.contains("claim:d"));
+        assert!(!ids.contains("source:case9"));
+        assert!(!ids.contains("source:sha9"));
+        // No unit nodes in this compact view.
+        assert!(resp.nodes.iter().all(|n| n.node_type != "unit"));
+
+        // Edges are bipartite claim→source `cites`, endpoints all kept.
+        assert!(!resp.edges.is_empty());
+        for e in &resp.edges {
+            assert_eq!(e.edge_type, "cites");
+            assert!(e.source.starts_with("claim:"));
+            assert!(e.target.starts_with("source:"));
+            assert!(ids.contains(e.source.as_str()));
+            assert!(ids.contains(e.target.as_str()));
+        }
+        assert!(
+            resp.edges
+                .iter()
+                .any(|e| e.source == "claim:a" && e.target == "source:sha2"),
+            "sibling edge missing"
+        );
+    }
+
+    #[test]
+    fn source_neighborhood_uncited_source_is_single_node() {
+        let records = sample_records();
+        let mut model = model_for_cases(&[("case1", "sha1", "Source One")]);
+        // A source the index knows but no crystal claim cites.
+        model.sources.push(ovp_index::SourceRow {
+            sha256: "freshsha".into(),
+            status: ovp_index::SourceStatus::Processed,
+            title: Some("Fresh Source".into()),
+            url: None,
+            rel_path: None,
+            date: None,
+            last_run_id: None,
+            pack_dir: None,
+            fail_count: 0,
+            last_reason: None,
+        });
+        let resp = source_neighborhood(&records, Some(&model), "freshsha").unwrap();
+        assert_eq!(resp.nodes.len(), 1);
+        assert_eq!(resp.nodes[0].id, "source:freshsha");
+        assert_eq!(resp.nodes[0].label, "Fresh Source");
+        assert!(resp.edges.is_empty());
+        assert!(!resp.truncated);
+    }
+
+    #[test]
+    fn source_neighborhood_unknown_sha_is_404() {
+        let records = sample_records();
+        let model = model_for_cases(&[("case1", "sha1", "Source One")]);
+        let err = source_neighborhood(&records, Some(&model), "nope").unwrap_err();
+        assert_eq!(err.status, 404);
     }
 
     #[test]

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -39,13 +39,22 @@ pub struct ServeConfig {
     pub viz_dir: Option<PathBuf>,
 }
 
+/// Evidence sidecar cache. `Unloaded` (never attempted) is distinct from
+/// `Loaded(None)` (attempted, legitimately absent — pre-M31 vaults): without
+/// the distinction an absent sidecar would re-stat/re-read on EVERY
+/// /api/source request. `/api/refresh` re-attempts by writing `Loaded(...)`.
+enum EvidenceCache {
+    Unloaded,
+    Loaded(Option<EvidenceModel>),
+}
+
 struct AppState {
     vault_root: PathBuf,
     layout: VaultLayout,
     model: RwLock<Option<IndexModel>>,
     /// Card/unit bodies for the /api/source/:sha memory layer — lazy-loaded
     /// like the index model, refreshed together on /api/refresh.
-    evidence: RwLock<Option<EvidenceModel>>,
+    evidence: RwLock<EvidenceCache>,
     viz_dir: Option<PathBuf>,
 }
 
@@ -70,14 +79,14 @@ impl AppState {
     fn current_evidence(&self) -> Option<EvidenceModel> {
         {
             let guard = self.evidence.read().unwrap();
-            if guard.is_some() {
-                return guard.clone();
+            if let EvidenceCache::Loaded(ev) = &*guard {
+                return ev.clone();
             }
         }
-        let fresh = read_evidence(&self.vault_root).ok()?;
+        let fresh = read_evidence(&self.vault_root).ok();
         let mut guard = self.evidence.write().unwrap();
-        *guard = Some(fresh.clone());
-        Some(fresh)
+        *guard = EvidenceCache::Loaded(fresh.clone());
+        fresh
     }
 
     fn refresh_model(&self) {
@@ -87,7 +96,10 @@ impl AppState {
         }
         // Reload the evidence sidecar too; it may legitimately be absent
         // (pre-M31 vaults) — the source API then reports it as unavailable.
-        *self.evidence.write().unwrap() = read_evidence(&self.vault_root).ok();
+        // Marking the load COMPLETED (even when absent) is what stops
+        // current_evidence from re-reading disk on every request.
+        *self.evidence.write().unwrap() =
+            EvidenceCache::Loaded(read_evidence(&self.vault_root).ok());
     }
 
     fn console_dir(&self) -> PathBuf {
@@ -103,7 +115,7 @@ pub fn run_server(config: ServeConfig) -> Result<(), String> {
         vault_root: config.vault_root,
         layout: VaultLayout::new(),
         model: RwLock::new(None),
-        evidence: RwLock::new(None),
+        evidence: RwLock::new(EvidenceCache::Unloaded),
         viz_dir: config.viz_dir,
     });
 
@@ -512,9 +524,11 @@ fn read_source_doc(
     let Some(rel) = rel_path else {
         return (None, false, None);
     };
-    // rel_path comes from our own index, but never trust a path with parent
-    // components or an absolute root anyway.
-    if rel.contains("..") || std::path::Path::new(rel).is_absolute() {
+    // rel_path comes from our own index, but never trust it anyway: reject
+    // parent components and absolute roots — including Windows prefixes
+    // (`C:\…`, `\\srv\share`) that `is_absolute()` misses on Unix and that
+    // would make `Path::join` discard the vault root entirely.
+    if !is_plain_relative(rel) {
         return (None, false, Some("source path rejected".into()));
     }
     let recorded = state.vault_root.join(rel);
@@ -829,7 +843,7 @@ mod tests {
             vault_root: vault,
             layout: VaultLayout::new(),
             model: RwLock::new(None),
-            evidence: RwLock::new(None),
+            evidence: RwLock::new(EvidenceCache::Unloaded),
             viz_dir,
         }
     }
@@ -1168,6 +1182,20 @@ mod tests {
         let resp = handle_source_api(&st, "/api/source/aaaa1111");
         assert_eq!(resp.status_code(), 200); // meta still served
         let v = body_json(resp);
+        assert!(v["doc"]["markdown"].is_null());
+        assert_eq!(v["doc"]["error"], "source path rejected");
+
+        let _ = std::fs::remove_dir_all(vault.parent().unwrap());
+    }
+
+    #[test]
+    fn source_api_rejects_windows_absolute_rel_path() {
+        // `C:\evil` is NOT absolute per is_absolute() on Unix, but on a
+        // Windows host Path::join would discard the vault root — rejected.
+        let vault = portal_vault("source-win-abs", "C:\\evil", "body\n");
+        let st = state(vault.clone(), None);
+
+        let v = body_json(handle_source_api(&st, "/api/source/aaaa1111"));
         assert!(v["doc"]["markdown"].is_null());
         assert_eq!(v["doc"]["error"], "source path rejected");
 

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -4,7 +4,8 @@
 //! Serves the portal SPA at the site root (deployed `.ovp/console/app/` or
 //! the `--viz-dir` overlay; see `resolve_static` for the precedence rule),
 //! legacy generated console pages by exact filename, and JSON API endpoints
-//! (`/api/find`, `/api/search`, `/api/graph`, `/api/claim/:id`, `/api/flow`).
+//! (`/api/find`, `/api/search`, `/api/graph`, `/api/claim/:id`,
+//! `/api/source/:sha`, `/api/flow`).
 //! Uses `tiny_http` to avoid any async runtime dependency.
 
 mod graph;
@@ -16,9 +17,16 @@ use std::sync::{Arc, RwLock};
 use ovp_domain::VaultLayout;
 use ovp_domain::crystal::{CrystalStatus, DurableRecord, StoreEvent, fold_ledger};
 use ovp_domain::units::Unit;
-use ovp_index::{IndexModel, Query, QueryKind, read_index, run_query};
+use ovp_index::{
+    EvidenceModel, IndexModel, Query, QueryKind, read_evidence, read_index, run_query,
+};
 use ovp_intake::read_jsonl;
 use tiny_http::{Header, Method, Response, Server};
+
+/// Cap for source markdown shipped in the /api/source payload — beyond this
+/// the response truncates with an explicit flag instead of shipping megabytes
+/// of JSON (same limit the v1 server-rendered page used).
+pub const MAX_SOURCE_DOC_BYTES: usize = 200 * 1024;
 
 pub struct ServeConfig {
     pub vault_root: PathBuf,
@@ -35,6 +43,9 @@ struct AppState {
     vault_root: PathBuf,
     layout: VaultLayout,
     model: RwLock<Option<IndexModel>>,
+    /// Card/unit bodies for the /api/source/:sha memory layer — lazy-loaded
+    /// like the index model, refreshed together on /api/refresh.
+    evidence: RwLock<Option<EvidenceModel>>,
     viz_dir: Option<PathBuf>,
 }
 
@@ -56,11 +67,27 @@ impl AppState {
         Some(fresh)
     }
 
+    fn current_evidence(&self) -> Option<EvidenceModel> {
+        {
+            let guard = self.evidence.read().unwrap();
+            if guard.is_some() {
+                return guard.clone();
+            }
+        }
+        let fresh = read_evidence(&self.vault_root).ok()?;
+        let mut guard = self.evidence.write().unwrap();
+        *guard = Some(fresh.clone());
+        Some(fresh)
+    }
+
     fn refresh_model(&self) {
         if let Ok(m) = read_index(&self.vault_root) {
             let mut guard = self.model.write().unwrap();
             *guard = Some(m);
         }
+        // Reload the evidence sidecar too; it may legitimately be absent
+        // (pre-M31 vaults) — the source API then reports it as unavailable.
+        *self.evidence.write().unwrap() = read_evidence(&self.vault_root).ok();
     }
 
     fn console_dir(&self) -> PathBuf {
@@ -76,6 +103,7 @@ pub fn run_server(config: ServeConfig) -> Result<(), String> {
         vault_root: config.vault_root,
         layout: VaultLayout::new(),
         model: RwLock::new(None),
+        evidence: RwLock::new(None),
         viz_dir: config.viz_dir,
     });
 
@@ -115,6 +143,7 @@ pub fn run_server(config: ServeConfig) -> Result<(), String> {
             (Method::Get, "/api/flow") => handle_flow(&state),
             (Method::Get, "/api/themes") => handle_themes(&state),
             (Method::Get, p) if p.starts_with("/api/claim/") => handle_claim(&state, &path),
+            (Method::Get, p) if p.starts_with("/api/source/") => handle_source_api(&state, &path),
             (Method::Get, _) => serve_static(&state, &path),
             _ => text_response(405, "Method Not Allowed"),
         };
@@ -217,7 +246,40 @@ fn load_active_records(state: &AppState) -> Vec<DurableRecord> {
 }
 
 fn handle_graph(state: &AppState, url: &str) -> Response<std::io::Cursor<Vec<u8>>> {
-    let params = match graph::GraphParams::from_query(&parse_query_string(url)) {
+    let query = parse_query_string(url);
+
+    // Portal v2 scoped-component API (design §4): `scope=neighborhood&
+    // source=<sha>` returns the source-centric neighborhood (this source →
+    // claims citing it → sibling sources). `scope=global|theme` land in B3 —
+    // unknown scopes fail loud, never guess.
+    if let Some(scope) = query.get("scope") {
+        if scope != "neighborhood" {
+            let body = serde_json::json!({
+                "error": format!("unknown scope: {scope} (only scope=neighborhood is available; global/theme land in B3)"),
+            });
+            return json_response(400, &body.to_string());
+        }
+        let Some(sha) = query.get("source").filter(|s| !s.is_empty()) else {
+            return json_response(
+                400,
+                r#"{"error":"scope=neighborhood requires source=<sha256>"}"#,
+            );
+        };
+        let records = load_active_records(state);
+        let model = state.current_model();
+        return match graph::source_neighborhood(&records, model.as_ref(), sha) {
+            Ok(resp) => {
+                let body = serde_json::to_string(&resp).unwrap_or_else(|_| "{}".into());
+                json_response(200, &body)
+            }
+            Err(e) => {
+                let body = serde_json::json!({ "error": e.message });
+                json_response(e.status, &body.to_string())
+            }
+        };
+    }
+
+    let params = match graph::GraphParams::from_query(&query) {
         Ok(p) => p,
         Err(e) => {
             let body = serde_json::json!({ "error": e.message });
@@ -324,6 +386,140 @@ fn handle_claim(state: &AppState, url: &str) -> Response<std::io::Cursor<Vec<u8>
         "citations": citations,
     });
     json_response(200, &body.to_string())
+}
+
+/// GET /api/source/<sha256> — JSON for the portal's three-layer source
+/// detail page (B2): full SourceRow meta, the memory layer (cards + grounded
+/// units from the evidence sidecar), crystal claims citing this source, and
+/// the raw source markdown (size-capped, traversal-safe). The markdown is
+/// DATA in a JSON string — the client renders it safely; nothing here emits
+/// HTML.
+fn handle_source_api(state: &AppState, url: &str) -> Response<std::io::Cursor<Vec<u8>>> {
+    let model = match state.current_model() {
+        Some(m) => m,
+        None => return json_response(503, r#"{"error":"index not available"}"#),
+    };
+
+    let raw = url.split('?').next().unwrap_or(url);
+    let sha = url_decode(
+        raw.strip_prefix("/api/source/")
+            .unwrap_or("")
+            .trim_end_matches('/'),
+    );
+    if sha.is_empty() {
+        return json_response(400, r#"{"error":"missing source sha"}"#);
+    }
+
+    let Some(source) = model.sources.iter().find(|s| s.sha256 == sha) else {
+        let body = serde_json::json!({ "error": format!("source not found: {sha}") });
+        return json_response(404, &body.to_string());
+    };
+
+    // Memory layer: evidence rows keyed by the source sha or its pack dir.
+    let evidence = state.current_evidence();
+    let evidence_available = evidence.is_some();
+    let pack_dir = source.pack_dir.as_deref();
+    let belongs = |row_sha: Option<&str>, row_pack: &str| {
+        row_sha == Some(sha.as_str()) || pack_dir == Some(row_pack)
+    };
+    let cards: Vec<serde_json::Value> = evidence
+        .as_ref()
+        .map(|ev| {
+            ev.cards
+                .iter()
+                .filter(|c| belongs(c.source_sha256.as_deref(), &c.pack_dir))
+                .map(|c| serde_json::json!({ "title": c.title, "content": c.content }))
+                .collect()
+        })
+        .unwrap_or_default();
+    let units: Vec<serde_json::Value> = evidence
+        .as_ref()
+        .map(|ev| {
+            ev.units
+                .iter()
+                .filter(|u| belongs(u.source_sha256.as_deref(), &u.pack_dir))
+                .map(|u| {
+                    serde_json::json!({
+                        "unit_id": u.unit_id,
+                        "text": u.text,
+                        "quote": u.quote,
+                        "line": u.line,
+                        "attribution": u.attribution,
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // Crystal layer: ClaimRow.sources holds case ids (last pack_dir segment).
+    let case_id = pack_dir.and_then(graph::last_path_segment);
+    let mut citing: Vec<&ovp_index::ClaimRow> = match case_id {
+        Some(case) => model
+            .claims
+            .iter()
+            .filter(|c| c.sources.iter().any(|s| s == case))
+            .collect(),
+        None => Vec::new(),
+    };
+    citing.sort_by_key(|c| {
+        (
+            match c.status {
+                ovp_index::ClaimStatus::Durable => 0u8,
+                ovp_index::ClaimStatus::Caveated => 1,
+                _ => 2,
+            },
+            c.claim_id.clone(),
+        )
+    });
+
+    let (markdown, truncated, doc_error) = read_source_doc(state, source.rel_path.as_deref());
+
+    let body = serde_json::json!({
+        "source": source,
+        "memory": {
+            "evidence_available": evidence_available,
+            "cards": cards,
+            "units": units,
+        },
+        "citing_claims": citing,
+        "doc": {
+            "markdown": markdown,
+            "truncated": truncated,
+            "error": doc_error,
+        },
+    });
+    json_response(200, &body.to_string())
+}
+
+/// Read the source markdown from the vault, capped at MAX_SOURCE_DOC_BYTES.
+/// All failure modes become an explicit error string — the endpoint always
+/// answers.
+fn read_source_doc(
+    state: &AppState,
+    rel_path: Option<&str>,
+) -> (Option<String>, bool, Option<String>) {
+    let Some(rel) = rel_path else {
+        return (None, false, None);
+    };
+    // rel_path comes from our own index, but never trust a path with parent
+    // components or an absolute root anyway.
+    if rel.contains("..") || std::path::Path::new(rel).is_absolute() {
+        return (None, false, Some("source path rejected".into()));
+    }
+    match std::fs::read_to_string(state.vault_root.join(rel)) {
+        Ok(mut text) => {
+            let truncated = text.len() > MAX_SOURCE_DOC_BYTES;
+            if truncated {
+                let mut cut = MAX_SOURCE_DOC_BYTES;
+                while cut > 0 && !text.is_char_boundary(cut) {
+                    cut -= 1;
+                }
+                text.truncate(cut);
+            }
+            (Some(text), truncated, None)
+        }
+        Err(e) => (None, false, Some(format!("{rel}: {e}"))),
+    }
 }
 
 fn handle_flow(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
@@ -583,6 +779,7 @@ mod tests {
             vault_root: vault,
             layout: VaultLayout::new(),
             model: RwLock::new(None),
+            evidence: RwLock::new(None),
             viz_dir,
         }
     }
@@ -690,6 +887,208 @@ mod tests {
         assert!(is_not_found(resolve_static(&st, "/viz/graph")));
 
         let _ = std::fs::remove_dir_all(&root);
+    }
+
+    fn body_json(resp: Response<std::io::Cursor<Vec<u8>>>) -> serde_json::Value {
+        use std::io::Read;
+        let mut out = Vec::new();
+        resp.into_reader().read_to_end(&mut out).unwrap();
+        serde_json::from_slice(&out).expect("response body must be valid JSON")
+    }
+
+    /// Vault with one processed source (hostile markdown body), its pack,
+    /// evidence sidecar (one card + one grounded unit) and one claim citing
+    /// the case — the /api/source three-layer fixture.
+    fn portal_vault(name: &str, rel_path: &str, body: &str) -> PathBuf {
+        use ovp_index::evidence::{CardEvidenceRow, UnitEvidenceRow};
+        use ovp_index::{
+            ClaimRow, ClaimStatus, EvidenceModel, OpsState, PackRow, SourceRow, SourceStatus,
+            Totals,
+        };
+        let root = temp_root(name);
+        let vault = root.join("vault");
+        std::fs::create_dir_all(vault.join("50-Inbox/03-Processed")).unwrap();
+        std::fs::write(vault.join("50-Inbox/03-Processed/good.md"), body).unwrap();
+
+        let model = IndexModel {
+            schema: "ovp.index/v2".into(),
+            date: "2026-07-09".into(),
+            run_id: None,
+            totals: Totals {
+                sources: 1,
+                processed: 1,
+                packs: 1,
+                ..Default::default()
+            },
+            sources: vec![SourceRow {
+                sha256: "aaaa1111".into(),
+                status: SourceStatus::Processed,
+                title: Some("Good Article".into()),
+                url: Some("https://example.com/good".into()),
+                rel_path: Some(rel_path.into()),
+                date: Some("2026-07-09".into()),
+                last_run_id: None,
+                pack_dir: Some("40-Resources/Reader/good".into()),
+                fail_count: 0,
+                last_reason: None,
+            }],
+            packs: vec![PackRow {
+                pack_dir: "40-Resources/Reader/good".into(),
+                title: "Good Article".into(),
+                date: Some("2026-07-09".into()),
+                units: 1,
+                cards: 1,
+                json_repaired: false,
+                card_titles: vec!["Card One".into()],
+                source_sha256: Some("aaaa1111".into()),
+            }],
+            claims: vec![ClaimRow {
+                claim_id: "c01".into(),
+                claim: "Filesystem works as memory.".into(),
+                theme: Some("memory".into()),
+                status: ClaimStatus::Durable,
+                sources: vec!["good".into()],
+                strength: Some("supported".into()),
+                run_id: None,
+                lane: None,
+            }],
+            runs: vec![],
+            ops: OpsState::default(),
+        };
+        ovp_index::write_index(&vault, &model).unwrap();
+
+        let evidence = EvidenceModel {
+            schema: "ovp.index.evidence/v1".into(),
+            date: "2026-07-09".into(),
+            cards: vec![CardEvidenceRow {
+                id: "card:40-Resources/Reader/good:0".into(),
+                pack_dir: "40-Resources/Reader/good".into(),
+                source_sha256: Some("aaaa1111".into()),
+                source_title: "Good Article".into(),
+                title: "Card One".into(),
+                content: "Body of card one.".into(),
+                unit_type: None,
+                cited_unit_ids: vec!["u-001".into()],
+            }],
+            units: vec![UnitEvidenceRow {
+                id: "unit:40-Resources/Reader/good:u-001".into(),
+                pack_dir: "40-Resources/Reader/good".into(),
+                source_sha256: Some("aaaa1111".into()),
+                source_title: "Good Article".into(),
+                unit_id: "u-001".into(),
+                text: "The unit text.".into(),
+                quote: "the exact quote".into(),
+                line: Some(14),
+                attribution: "author".into(),
+                modality: "asserted".into(),
+            }],
+            warnings: vec![],
+        };
+        ovp_index::write_evidence(&vault, &evidence).unwrap();
+        vault
+    }
+
+    #[test]
+    fn source_api_returns_three_layers_as_json_data() {
+        // Hostile markdown must pass through as DATA in the JSON payload —
+        // never HTML-escaped (the client renders it safely), never live.
+        let vault = portal_vault(
+            "source-api",
+            "50-Inbox/03-Processed/good.md",
+            "# Heading\n\nbody with <script>alert(1)</script>\n",
+        );
+        let st = state(vault.clone(), None);
+
+        let resp = handle_source_api(&st, "/api/source/aaaa1111");
+        assert_eq!(resp.status_code(), 200);
+        let ct = resp
+            .headers()
+            .iter()
+            .find(|h| {
+                h.field
+                    .as_str()
+                    .as_str()
+                    .eq_ignore_ascii_case("content-type")
+            })
+            .map(|h| h.value.as_str().to_string());
+        assert_eq!(ct.as_deref(), Some("application/json; charset=utf-8"));
+
+        let v = body_json(resp);
+        assert_eq!(v["source"]["sha256"], "aaaa1111");
+        assert_eq!(v["source"]["title"], "Good Article");
+        assert_eq!(v["memory"]["evidence_available"], true);
+        assert_eq!(v["memory"]["cards"][0]["title"], "Card One");
+        assert_eq!(v["memory"]["units"][0]["unit_id"], "u-001");
+        assert_eq!(v["memory"]["units"][0]["line"], 14);
+        assert_eq!(v["citing_claims"][0]["claim_id"], "c01");
+        assert_eq!(v["citing_claims"][0]["status"], "durable");
+        // The XSS payload survives as a JSON string, exactly as written.
+        let md = v["doc"]["markdown"].as_str().unwrap();
+        assert!(md.contains("<script>alert(1)</script>"));
+        assert!(!md.contains("&lt;script&gt;"));
+        assert_eq!(v["doc"]["truncated"], false);
+        assert!(v["doc"]["error"].is_null());
+
+        // Unknown sha → JSON 404, not HTML.
+        let missing = handle_source_api(&st, "/api/source/deadbeef");
+        assert_eq!(missing.status_code(), 404);
+        let v = body_json(missing);
+        assert!(v["error"].as_str().unwrap().contains("deadbeef"));
+
+        // Missing sha segment → 400.
+        assert_eq!(handle_source_api(&st, "/api/source/").status_code(), 400);
+
+        let _ = std::fs::remove_dir_all(vault.parent().unwrap());
+    }
+
+    #[test]
+    fn source_api_rejects_traversal_paths() {
+        let vault = portal_vault("source-traversal", "../secret.md", "body\n");
+        // A secret OUTSIDE the vault that `..` would reach.
+        std::fs::write(vault.parent().unwrap().join("secret.md"), "TOP SECRET").unwrap();
+        let st = state(vault.clone(), None);
+
+        let resp = handle_source_api(&st, "/api/source/aaaa1111");
+        assert_eq!(resp.status_code(), 200); // meta still served
+        let v = body_json(resp);
+        assert!(v["doc"]["markdown"].is_null());
+        assert_eq!(v["doc"]["error"], "source path rejected");
+
+        let _ = std::fs::remove_dir_all(vault.parent().unwrap());
+    }
+
+    #[test]
+    fn source_api_truncates_oversized_markdown() {
+        let big = "x".repeat(MAX_SOURCE_DOC_BYTES + 100);
+        let vault = portal_vault("source-big", "50-Inbox/03-Processed/good.md", &big);
+        let st = state(vault.clone(), None);
+
+        let v = body_json(handle_source_api(&st, "/api/source/aaaa1111"));
+        assert_eq!(v["doc"]["truncated"], true);
+        assert_eq!(
+            v["doc"]["markdown"].as_str().unwrap().len(),
+            MAX_SOURCE_DOC_BYTES
+        );
+
+        let _ = std::fs::remove_dir_all(vault.parent().unwrap());
+    }
+
+    #[test]
+    fn source_api_without_evidence_reports_unavailable() {
+        let vault = portal_vault(
+            "source-no-evidence",
+            "50-Inbox/03-Processed/good.md",
+            "body\n",
+        );
+        std::fs::remove_file(vault.join(".ovp/index/evidence.json")).unwrap();
+        let st = state(vault.clone(), None);
+
+        let v = body_json(handle_source_api(&st, "/api/source/aaaa1111"));
+        assert_eq!(v["memory"]["evidence_available"], false);
+        assert!(v["memory"]["cards"].as_array().unwrap().is_empty());
+        assert!(v["memory"]["units"].as_array().unwrap().is_empty());
+
+        let _ = std::fs::remove_dir_all(vault.parent().unwrap());
     }
 
     #[test]

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -130,28 +130,39 @@ pub fn run_server(config: ServeConfig) -> Result<(), String> {
     for request in server.incoming_requests() {
         let path = request.url().to_string();
         let method = request.method().clone();
-
-        let resp = match (method, path.as_str()) {
-            (Method::Get, "/api/refresh") => {
-                state.refresh_model();
-                json_response(200, r#"{"ok":true}"#)
-            }
-            (Method::Get, p) if p.starts_with("/api/find") => handle_find(&state, &path),
-            (Method::Get, p) if p.starts_with("/api/search") => handle_search(&state, &path),
-            (Method::Get, "/api/model") => handle_model(&state),
-            (Method::Get, p) if p.starts_with("/api/graph") => handle_graph(&state, &path),
-            (Method::Get, "/api/flow") => handle_flow(&state),
-            (Method::Get, "/api/themes") => handle_themes(&state),
-            (Method::Get, p) if p.starts_with("/api/claim/") => handle_claim(&state, &path),
-            (Method::Get, p) if p.starts_with("/api/source/") => handle_source_api(&state, &path),
-            (Method::Get, _) => serve_static(&state, &path),
-            _ => text_response(405, "Method Not Allowed"),
-        };
-
+        let resp = dispatch(&state, method, &path);
         let _ = request.respond(resp);
     }
 
     Ok(())
+}
+
+/// Route one request. Extracted from the accept loop so routing is unit
+/// testable. Matching runs on the path WITHOUT the query string (so exact
+/// routes like `/api/model?x=1` still hit their handler); handlers get the
+/// full url and parse their own params. Anything under `/api/` that matches
+/// no route is a JSON 404 — it must never fall through to the SPA shell.
+fn dispatch(state: &AppState, method: Method, url: &str) -> Response<std::io::Cursor<Vec<u8>>> {
+    let path = url.split('?').next().unwrap_or(url);
+    match (method, path) {
+        (Method::Get, "/api/refresh") => {
+            state.refresh_model();
+            json_response(200, r#"{"ok":true}"#)
+        }
+        (Method::Get, p) if p.starts_with("/api/find") => handle_find(state, url),
+        (Method::Get, p) if p.starts_with("/api/search") => handle_search(state, url),
+        (Method::Get, "/api/model") => handle_model(state),
+        (Method::Get, p) if p.starts_with("/api/graph") => handle_graph(state, url),
+        (Method::Get, "/api/flow") => handle_flow(state),
+        (Method::Get, "/api/themes") => handle_themes(state),
+        (Method::Get, p) if p.starts_with("/api/claim/") => handle_claim(state, url),
+        (Method::Get, p) if p.starts_with("/api/source/") => handle_source_api(state, url),
+        (Method::Get, p) if p == "/api" || p.starts_with("/api/") => {
+            json_response(404, r#"{"error":"unknown api route"}"#)
+        }
+        (Method::Get, _) => serve_static(state, url),
+        _ => text_response(405, "Method Not Allowed"),
+    }
 }
 
 fn handle_find(state: &AppState, url: &str) -> Response<std::io::Cursor<Vec<u8>>> {
@@ -506,7 +517,15 @@ fn read_source_doc(
     if rel.contains("..") || std::path::Path::new(rel).is_absolute() {
         return (None, false, Some("source path rejected".into()));
     }
-    match std::fs::read_to_string(state.vault_root.join(rel)) {
+    let recorded = state.vault_root.join(rel);
+    let path = if recorded.is_file() {
+        recorded
+    } else if let Some(moved) = lifecycle_moved_path(state, rel) {
+        moved
+    } else {
+        recorded
+    };
+    match std::fs::read_to_string(&path) {
         Ok(mut text) => {
             let truncated = text.len() > MAX_SOURCE_DOC_BYTES;
             if truncated {
@@ -520,6 +539,24 @@ fn read_source_doc(
         }
         Err(e) => (None, false, Some(format!("{rel}: {e}"))),
     }
+}
+
+/// Lifecycle-move fallback: `SourceRow.rel_path` records the INTAKE location
+/// (`50-Inbox/01-Raw/<month>/…`), but the daily lifecycle step moves
+/// processed sources to `50-Inbox/03-Processed/<month>/…` keeping the same
+/// trailing subpath. When the recorded path misses and sits under the raw
+/// inbox dir, retry the processed dir — both directory names come from
+/// `VaultLayout`, never hardcoded here. `rel` is already traversal-checked
+/// by the caller. Returns the candidate only when it actually exists.
+fn lifecycle_moved_path(state: &AppState, rel: &str) -> Option<PathBuf> {
+    let raw_prefix = format!("{}/", state.layout.inbox_raw_dir());
+    let rest = rel.strip_prefix(&raw_prefix)?;
+    let (month, file) = rest.split_once('/')?;
+    let candidate = state
+        .vault_root
+        .join(state.layout.processed_dir(month))
+        .join(file);
+    candidate.is_file().then_some(candidate)
 }
 
 fn handle_flow(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
@@ -1039,6 +1076,63 @@ mod tests {
         assert_eq!(handle_source_api(&st, "/api/source/").status_code(), 400);
 
         let _ = std::fs::remove_dir_all(vault.parent().unwrap());
+    }
+
+    #[test]
+    fn source_api_follows_lifecycle_move_raw_to_processed() {
+        // rel_path records the intake location, but the daily lifecycle step
+        // moved the file to the processed dir (same month + filename). The
+        // doc must still resolve — via VaultLayout, not the stale path.
+        let vault = portal_vault(
+            "source-moved",
+            "50-Inbox/01-Raw/2026-06/good.md",
+            "unused body\n",
+        );
+        assert!(!vault.join("50-Inbox/01-Raw/2026-06/good.md").exists());
+        std::fs::create_dir_all(vault.join("50-Inbox/03-Processed/2026-06")).unwrap();
+        std::fs::write(
+            vault.join("50-Inbox/03-Processed/2026-06/good.md"),
+            "# Moved\n\nlifecycle-moved body\n",
+        )
+        .unwrap();
+
+        let st = state(vault.clone(), None);
+        let v = body_json(handle_source_api(&st, "/api/source/aaaa1111"));
+        let md = v["doc"]["markdown"].as_str().expect("markdown resolved");
+        assert!(md.contains("lifecycle-moved body"));
+        assert!(v["doc"]["error"].is_null());
+
+        let _ = std::fs::remove_dir_all(vault.parent().unwrap());
+    }
+
+    #[test]
+    fn unknown_api_routes_are_json_404_not_spa() {
+        // With an SPA overlay present, a bad /api/* path used to fall through
+        // to the extensionless-client-route rule and answer 200 + index.html.
+        let root = temp_root("api-404");
+        let vault = root.join("vault");
+        std::fs::create_dir_all(vault.join(".ovp/console")).unwrap();
+        let overlay = root.join("dist");
+        std::fs::create_dir_all(&overlay).unwrap();
+        std::fs::write(overlay.join("index.html"), "spa").unwrap();
+        let st = state(vault, Some(overlay));
+
+        for path in ["/api/nonexistent", "/api", "/api/", "/api/nope?x=1"] {
+            let resp = dispatch(&st, Method::Get, path);
+            assert_eq!(resp.status_code(), 404, "path {path}");
+            let v = body_json(resp);
+            assert_eq!(v["error"], "unknown api route", "path {path}");
+        }
+
+        // Non-API client routes still reach the SPA shell…
+        assert_eq!(dispatch(&st, Method::Get, "/library").status_code(), 200);
+        // …exact API routes keep working even with a query string…
+        let resp = dispatch(&st, Method::Get, "/api/refresh?x=1");
+        assert_eq!(resp.status_code(), 200);
+        // …and non-GET stays 405.
+        assert_eq!(dispatch(&st, Method::Post, "/api/model").status_code(), 405);
+
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]


### PR DESCRIPTION
## What (stacked on #297)
Phase B2 of the portal v2 design (docs/design/portal-v2-product-design.md §3.2 + §4):

- **/api/source/:sha**: full SourceRow + memory (cards/units from the evidence sidecar, lazy RwLock cache reset by /api/refresh) + citing claims (join key = last pack_dir segment ∈ ClaimRow.sources — 406/406 claim cases resolve on the real vault) + source markdown (200KB char-boundary cap, traversal-rejected).
- **/api/graph?scope=neighborhood&source=<sha>**: focus source + citing claims + sibling sources, bipartite cites edges, node-capped; global/theme scopes 400 with 'lands in B3'.
- **SourceDetailPage (full)**: breadcrumb, meta, Memory tab (cards + grounded units with L<n> anchors that switch tab and scroll-highlight the exact line), Source tab = md reading view, citing-claims rail, embedded neighborhood graph. Tabs URL-addressable (?tab=source).
- **KnowledgeGraph component**: {scope, id, height} prop surface for all three scopes (neighborhood live now); DS-token colors re-read on data-theme mutation, so the graph re-themes with the LIGHT/DARK toggle.
- **Md renderer**: v1's escape-first renderer ported to TS — zero new deps, no HTML-string pathway (parser → block model → React elements), scheme-filtered links, images as alt-text placeholders, exact per-block source-line ranges for the L<n> anchors.
- **ClaimRow date verdict**: NOT derivable — crystal ledger StoreEvent/DurableRecord carries no timestamp by design (content-hash run ids). Today-page note updated to say so honestly; real 'crystallized today' needs a timestamped ledger event (backlog).

## Tests
Workspace 732 passed (7 new server tests: XSS-as-data, traversal, truncation, no-evidence, graph scopes); clippy -D warnings clean; arch check OK; tsc + vite build green (G6 stays lazy-chunked).

Codex gate: PASS (no findings). Screenshots vs the real vault in the B2 worktree .run/portal-v2-b2/.