### PR TITLE
fix(portal): operator walkthrough round 1 — corpus-source backfill, Ask markdown, concept affordances, honest Unclassified

### DIFF
--- a/console-ui/package-lock.json
+++ b/console-ui/package-lock.json
@@ -29,7 +29,8 @@
         "@vitejs/plugin-react": "^4.5.0",
         "tailwindcss": "^4.1.0",
         "typescript": "^5.6.0",
-        "vite": "^6.0.0"
+        "vite": "^6.0.0",
+        "vitest": "^4.1.10"
       }
     },
     "node_modules/@antv/algorithm": {
@@ -1419,6 +1420,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.3.2",
       "resolved": "https://registry.npmmirror.com/@tailwindcss/node/-/node-4.3.2.tgz",
@@ -1736,6 +1744,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmmirror.com/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
       "resolved": "https://registry.npmmirror.com/@types/d3-array/-/d3-array-3.2.2.tgz",
@@ -1892,6 +1911,13 @@
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmmirror.com/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmmirror.com/@types/estree/-/estree-1.0.9.tgz",
@@ -1954,6 +1980,129 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmmirror.com/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmmirror.com/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmmirror.com/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmmirror.com/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmmirror.com/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmmirror.com/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmmirror.com/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/base64-arraybuffer": {
@@ -2038,6 +2187,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmmirror.com/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
@@ -2495,6 +2654,13 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmmirror.com/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.25.12",
       "resolved": "https://registry.npmmirror.com/esbuild/-/esbuild-0.25.12.tgz",
@@ -2547,11 +2713,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
       "resolved": "https://registry.npmmirror.com/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmmirror.com/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -3087,6 +3273,27 @@
         "node": ">=18"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmmirror.com/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmmirror.com/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmmirror.com/picocolors/-/picocolors-1.1.1.tgz",
@@ -3284,6 +3491,13 @@
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/simple-swizzle": {
       "version": "0.2.4",
       "resolved": "https://registry.npmmirror.com/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
@@ -3302,6 +3516,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmmirror.com/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmmirror.com/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/svg-path-parser": {
       "version": "1.1.0",
@@ -3349,6 +3577,23 @@
         "utrie": "^1.0.2"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmmirror.com/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmmirror.com/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmmirror.com/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -3364,6 +3609,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {
@@ -3506,6 +3761,113 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmmirror.com/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmmirror.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yallist": {

--- a/console-ui/package.json
+++ b/console-ui/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@antv/g6": "^5.0.49",
@@ -30,6 +31,7 @@
     "@vitejs/plugin-react": "^4.5.0",
     "tailwindcss": "^4.1.0",
     "typescript": "^5.6.0",
-    "vite": "^6.0.0"
+    "vite": "^6.0.0",
+    "vitest": "^4.1.10"
   }
 }

--- a/console-ui/src/components/KnowledgeGraph.tsx
+++ b/console-ui/src/components/KnowledgeGraph.tsx
@@ -29,6 +29,7 @@ import {
   fetchSourceNeighborhood,
   fetchThemeGraph,
 } from '../lib/api';
+import { isMiscTheme } from '../lib/derive';
 import type { GraphNode, GraphResponse } from '../lib/types';
 import { useModel } from '../model';
 import { EmptyState } from './ui';
@@ -359,7 +360,11 @@ export default function KnowledgeGraph({
               </div>
               <div className="graph-info-title">{selected.label}</div>
               {selected.theme && (
-                <div className="tiny muted">{selected.theme}</div>
+                <div className="tiny muted">
+                  {isMiscTheme(selected.theme)
+                    ? t('theme.unclassified')
+                    : selected.theme}
+                </div>
               )}
               <div className="tiny muted">
                 {selected.type === 'card'

--- a/console-ui/src/components/ui.tsx
+++ b/console-ui/src/components/ui.tsx
@@ -15,8 +15,46 @@ export function StatusPill({ status }: { status: SourceStatus }) {
   );
 }
 
-export function ClaimPill({ status }: { status: 'durable' | 'caveated' }) {
-  return <span className={`pill ${status}`}>{status}</span>;
+/** i18n key of the one-line concept tooltip for a claim status or entity
+ * kind pill; null for kinds the vocabulary does not know (the server may
+ * grow new citation kinds — those pills just render without a tooltip). */
+export function conceptTipKey(kind: string): MsgKey | null {
+  switch (kind) {
+    case 'durable':
+      return 'concept.durableTip';
+    case 'caveated':
+      return 'concept.caveatedTip';
+    case 'claim':
+      return 'concept.claimTip';
+    case 'card':
+      return 'concept.cardTip';
+    case 'unit':
+      return 'concept.unitTip';
+    default:
+      return null;
+  }
+}
+
+/** durable/caveated claim pill. Carries the plain-language one-liner as a
+ * tooltip by default (operator finding: the vocabulary needs explaining
+ * where it appears); `title` overrides it. */
+export function ClaimPill({
+  status,
+  title,
+}: {
+  status: 'durable' | 'caveated';
+  title?: string;
+}) {
+  const { t } = useI18n();
+  const tipKey = conceptTipKey(status);
+  return (
+    <span
+      className={`pill ${status}`}
+      title={title ?? (tipKey ? t(tipKey) : undefined)}
+    >
+      {status}
+    </span>
+  );
 }
 
 /** Collapsible "What is this page?" help block (DS extension #4). */

--- a/console-ui/src/design/portal.css
+++ b/console-ui/src/design/portal.css
@@ -640,6 +640,13 @@ body {
   border-radius: var(--ovp-radius-input);
   transition: background 300ms;
 }
+/* gutterless variant (Ask answers — no source lines to anchor). */
+.md-preview.no-gut {
+  max-width: none;
+}
+.md-preview.no-gut .md-row {
+  grid-template-columns: minmax(0, 1fr);
+}
 .md-row .gut {
   font-family: var(--ovp-font-mono);
   font-size: 0.68rem;
@@ -1069,11 +1076,15 @@ body {
 .chat-a.chat-pending {
   font-size: var(--ovp-text-sm);
 }
+/* Answer bodies render through the markdown reading view (gutterless) —
+   the renderer owns whitespace, so no pre-wrap here. */
 .answer-text {
-  white-space: pre-wrap;
   font-size: var(--ovp-text-sm);
   line-height: 1.65;
   overflow-wrap: anywhere;
+}
+.answer-text .md-block > :last-child {
+  margin-bottom: 0;
 }
 .cite-marker {
   border: 0;

--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -21,6 +21,20 @@ export const en = {
   'common.whatIsThisPage': 'What is this page?',
   'common.day': 'dogfood day',
 
+  // concept tooltips — plain-language one-liners for the pipeline vocabulary
+  // (operator finding: durable/caveated and unit/card need explaining
+  // wherever the pills render).
+  'concept.durableTip':
+    'Verified: every quoted citation was checked against the source text',
+  'concept.caveatedTip':
+    "Unverified: promising but the evidence didn't fully check out — treat with skepticism",
+  'concept.claimTip':
+    'Claim: a cross-source conclusion — durable (verified) or caveated (unverified)',
+  'concept.cardTip':
+    'Card: a readable distillation — every statement traceable to a grounded unit',
+  'concept.unitTip':
+    'Unit: a verbatim excerpt with line numbers — the evidence itself',
+
   // source statuses
   'sourceStatus.processed': 'processed',
   'sourceStatus.queued': 'queued',
@@ -93,7 +107,12 @@ export const en = {
   'source.tabMemory': 'Memory',
   'source.tabMemoryCounts': '{cards} cards · {units} units',
   'source.tabSource': 'Source',
+  'source.cardsTitle': 'Cards',
+  'source.cardsHint':
+    'Readable distillations of this source — every statement traceable to a grounded unit below.',
   'source.groundedUnits': 'Grounded units',
+  'source.unitsHint':
+    'Verbatim excerpts with line numbers — the evidence itself.',
   'source.unitNoLine': 'no line anchor',
   'source.noMemory':
     'No memory yet — this source has no cards or grounded units in its reader pack.',
@@ -134,6 +153,8 @@ export const en = {
     'What the knowledge base currently believes, grouped by theme. Durable claims passed every evidence gate; caveated claims carry a known weakness and await review.',
   'knowledge.helpLayers':
     'Three layers ground every claim: the source (the original markdown), its memory (cards and quoted units with line anchors), and the crystal (cross-source claims citing those units). Click through any claim to verify the chain.',
+  'knowledge.helpLadder':
+    'The ladder in plain language: source text → unit (a verifiable excerpt) → card (a readable understanding) → claim (a cross-source conclusion, always either durable or caveated).',
   'knowledge.viewList': 'List',
   'knowledge.viewGraph': 'Graph',
   'knowledge.empty':
@@ -145,6 +166,12 @@ export const en = {
     'All claims, colored by community. Click a node for a summary, double-click to open its theme.',
   'knowledge.unknownClaim':
     'No active claim "{id}" — it may have been superseded or retracted.',
+
+  // theme naming — the synthesizer's 'misc' fallback bucket is displayed
+  // honestly (display layer ONLY: keys, URLs and data stay 'misc').
+  'theme.unclassified': 'Unclassified',
+  'theme.unclassifiedNote':
+    "Sources that didn't match any keyword bucket — automatic clustering is a planned improvement (M34).",
 
   // theme detail
   'theme.counts': 'durable {durable} · caveated {caveated}',

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -21,6 +21,13 @@ export const zh: Record<keyof typeof en, string> = {
   'common.whatIsThisPage': '这是什么页？',
   'common.day': '试用第',
 
+  // concept tooltips
+  'concept.durableTip': '已验证：每条引文均逐字核对过原文',
+  'concept.caveatedTip': '未验证：有价值但证据未完全过关，需带着怀疑使用',
+  'concept.claimTip': '主张：跨源结论——durable（已验证）或 caveated（未验证）',
+  'concept.cardTip': '卡片：可读的提炼——每句话都可追溯到接地单元',
+  'concept.unitTip': '单元：带行号的逐字摘录——证据本身',
+
   // source statuses
   'sourceStatus.processed': '已处理',
   'sourceStatus.queued': '待读',
@@ -92,7 +99,10 @@ export const zh: Record<keyof typeof en, string> = {
   'source.tabMemory': '记忆',
   'source.tabMemoryCounts': '{cards} 卡片 · {units} 单元',
   'source.tabSource': '原文',
+  'source.cardsTitle': '卡片',
+  'source.cardsHint': '本源的可读提炼——每句话都可追溯到下方的接地单元。',
   'source.groundedUnits': '接地单元',
+  'source.unitsHint': '带行号的逐字摘录——证据本身。',
   'source.unitNoLine': '无行号锚点',
   'source.noMemory': '还没有记忆——该源的阅读包中没有卡片或接地单元。',
   'source.evidenceMissing':
@@ -130,6 +140,8 @@ export const zh: Record<keyof typeof en, string> = {
     '知识库当前"相信"的内容，按主题分组。durable（持久）主张通过了全部证据门；caveated（存疑）主张带有已知弱点，等待复核。',
   'knowledge.helpLayers':
     '每条主张由三层支撑：原文（markdown 源文件）、记忆（卡片与带行号锚点的引文单元）、结晶（引用这些单元的跨源主张）。点进任意主张即可核查全链。',
+  'knowledge.helpLadder':
+    '一句话的阶梯：原文 → unit（可验证摘录）→ card（可读理解）→ claim（跨源结论，durable/caveated 二态）。',
   'knowledge.viewList': '列表',
   'knowledge.viewGraph': '图谱',
   'knowledge.empty': '结晶库还没有主张——对源运行结晶流程以构建知识层。',
@@ -138,6 +150,11 @@ export const zh: Record<keyof typeof en, string> = {
   'knowledge.ratioLine': '持久 {durable} · 存疑 {caveated}',
   'knowledge.graphCaption': '全部主张，按社区着色。单击节点看摘要，双击进入其主题。',
   'knowledge.unknownClaim': '没有活跃主张 "{id}"——它可能已被取代或撤回。',
+
+  // theme naming
+  'theme.unclassified': '未分类',
+  'theme.unclassifiedNote':
+    '未命中任何关键词分组的来源——自动聚类是计划中的改进（M34）。',
 
   // theme detail
   'theme.counts': '持久 {durable} · 存疑 {caveated}',

--- a/console-ui/src/lib/derive.ts
+++ b/console-ui/src/lib/derive.ts
@@ -199,6 +199,14 @@ export interface ThemeGroup {
   topClaim?: string;
 }
 
+/** The synthesizer's fallback bucket — sources that matched no keyword
+ * bucket land under 'misc' (key) / 'Miscellaneous' (description). The
+ * portal displays it honestly as "Unclassified" — DISPLAY LAYER ONLY: keys,
+ * URLs and index data keep the literal value. */
+export function isMiscTheme(theme: string | null | undefined): boolean {
+  return theme === 'misc' || theme === 'Miscellaneous';
+}
+
 /** Active claims only — the knowledge surface never lists superseded or
  * retracted claims (they remain reachable through the ledger/CLI). */
 export function activeClaims(claims: ClaimRow[]): ClaimRow[] {

--- a/console-ui/src/lib/markdown.test.tsx
+++ b/console-ui/src/lib/markdown.test.tsx
@@ -1,0 +1,112 @@
+/** Renderer unit tests (vitest, node env): assertions walk the ReactNode
+ * tree directly — no DOM. Focus is the InlineMarker hook contract, and
+ * especially that a marker can NEVER nest inside a link (<a><button/></a>
+ * is invalid markup with two competing navigations). */
+import { isValidElement, type ReactElement, type ReactNode } from 'react';
+import { describe, expect, it } from 'vitest';
+import { renderInline, type InlineMarker } from './markdown';
+
+/** Mirror of the Ask page tokenizer (requires the literal brackets). */
+const CITE_RE = /\[\s*((?:claim|card|unit):[^\]\n]+?)\s*\]/g;
+
+const citeMarker: InlineMarker = {
+  pattern: CITE_RE,
+  render: (m, key) => (
+    <button key={key} data-cite={m[1]}>
+      [1]
+    </button>
+  ),
+};
+
+/** Depth-first flatten of a ReactNode tree into elements and strings. */
+function flatten(node: ReactNode): (ReactElement | string)[] {
+  if (node == null || typeof node === 'boolean') return [];
+  if (Array.isArray(node)) return node.flatMap(flatten);
+  if (typeof node === 'string' || typeof node === 'number') {
+    return [String(node)];
+  }
+  if (isValidElement(node)) {
+    const { children } = node.props as { children?: ReactNode };
+    return [node, ...flatten(children)];
+  }
+  return [];
+}
+
+const tags = (nodes: ReactNode): unknown[] =>
+  flatten(nodes)
+    .filter((n): n is ReactElement => typeof n !== 'string')
+    .map((el) => el.type);
+
+const text = (nodes: ReactNode): string =>
+  flatten(nodes)
+    .filter((n): n is string => typeof n === 'string')
+    .join('');
+
+describe('renderInline marker hook', () => {
+  it('replaces citation tokens in plain text with marker nodes', () => {
+    const out = renderInline('grounded [claim:c01] here', 'k', citeMarker);
+    expect(tags(out)).toContain('button');
+    // Token replaced; the "[1]" seen here is the marker button's own label.
+    expect(text(out)).toBe('grounded [1] here');
+  });
+
+  it('never nests a marker inside a link label', () => {
+    // A bracket-less pattern CAN match inside a link label — the renderer
+    // must suppress it there so the anchor keeps single navigation.
+    const bare: InlineMarker = {
+      pattern: /claim:\w+/g,
+      render: (m, key) => <button key={key}>{m[0]}</button>,
+    };
+    const out = renderInline(
+      'see [claim:c01](/knowledge#c01) and claim:c02',
+      'k',
+      bare,
+    );
+    const anchors = flatten(out).filter(
+      (n): n is ReactElement => isValidElement(n) && n.type === 'a',
+    );
+    expect(anchors).toHaveLength(1);
+    const a = anchors[0] as ReactElement<{ href: string; children: ReactNode }>;
+    expect(a.props.href).toBe('/knowledge#c01');
+    // Inside the anchor: plain text only, no interactive marker.
+    expect(tags(a.props.children)).toHaveLength(0);
+    expect(text(a.props.children)).toBe('claim:c01');
+    // Outside the anchor the same pattern still fires.
+    const buttons = flatten(out).filter(
+      (n): n is ReactElement => isValidElement(n) && n.type === 'button',
+    );
+    expect(buttons).toHaveLength(1);
+  });
+
+  it('renders a citation-shaped link as a plain anchor (link wins)', () => {
+    // The Ask tokenizer needs brackets, and a link label can never contain
+    // `]` — so `[claim:c01](url)` is a LINK, not a marker. Documented
+    // precedence: the anchor renders, no button anywhere.
+    const out = renderInline(
+      'see [claim:c01](/knowledge#c01) for detail',
+      'k',
+      citeMarker,
+    );
+    expect(tags(out)).toContain('a');
+    expect(tags(out)).not.toContain('button');
+  });
+
+  it('still fires inside emphasis (valid nesting)', () => {
+    const out = renderInline('**bold [unit:u-1] evidence**', 'k', citeMarker);
+    const kinds = tags(out);
+    expect(kinds).toContain('strong');
+    expect(kinds).toContain('button');
+  });
+
+  it('leaves tokens as plain text when render returns null', () => {
+    const nullMarker: InlineMarker = { pattern: CITE_RE, render: () => null };
+    const out = renderInline('keep [claim:c01] literal', 'k', nullMarker);
+    expect(tags(out)).toHaveLength(0);
+    expect(text(out)).toBe('keep [claim:c01] literal');
+  });
+
+  it('renders unchanged when no marker is supplied', () => {
+    const out = renderInline('plain [claim:c01] text', 'k');
+    expect(text(out)).toBe('plain [claim:c01] text');
+  });
+});

--- a/console-ui/src/lib/markdown.tsx
+++ b/console-ui/src/lib/markdown.tsx
@@ -186,8 +186,10 @@ const INLINE =
  * on `pattern` (which MUST carry the `g` flag) and each match is handed to
  * `render`. Returning null leaves the token as plain text. The hook only
  * ever produces React elements from the caller — matched source text still
- * never becomes markup, so the XSS story is unchanged. Used by the Ask page
- * to turn `[kind:id]` citations into live markers inside markdown. */
+ * never becomes markup, so the XSS story is unchanged. Suppressed inside
+ * link labels: an interactive marker nested in an <a> would be invalid
+ * markup with double navigation. Used by the Ask page to turn `[kind:id]`
+ * citations into live markers inside markdown. */
 export interface InlineMarker {
   pattern: RegExp;
   render: (match: RegExpMatchArray, key: string) => ReactNode | null;
@@ -245,9 +247,13 @@ export function renderInline(
       const label = lm?.[1] ?? token;
       const href = safeLinkHref(lm?.[2] ?? '');
       if (href) {
+        // No marker hook inside a link label: an interactive marker nested
+        // in an anchor would be invalid markup with two competing
+        // navigations — a citation-shaped label renders as the link's plain
+        // text and the <a> keeps single-navigation semantics.
         out.push(
           <a key={key} href={href} target="_blank" rel="noreferrer">
-            {renderInline(label, key, marker)}
+            {renderInline(label, key)}
           </a>,
         );
       } else {

--- a/console-ui/src/lib/markdown.tsx
+++ b/console-ui/src/lib/markdown.tsx
@@ -182,18 +182,52 @@ export function safeLinkHref(url: string): string | null {
 const INLINE =
   /(!\[[^\]]*\]\([^)]*\))|(\[[^\]]+\]\([^)]*\))|(`[^`]+`)|(\*\*[^*]+\*\*)|(\*[^*\s][^*]*\*)/;
 
+/** Marker hook for the inline pass: plain-text runs are additionally split
+ * on `pattern` (which MUST carry the `g` flag) and each match is handed to
+ * `render`. Returning null leaves the token as plain text. The hook only
+ * ever produces React elements from the caller — matched source text still
+ * never becomes markup, so the XSS story is unchanged. Used by the Ask page
+ * to turn `[kind:id]` citations into live markers inside markdown. */
+export interface InlineMarker {
+  pattern: RegExp;
+  render: (match: RegExpMatchArray, key: string) => ReactNode | null;
+}
+
 /** Source text → React nodes. Text stays text nodes (React escapes it). */
-export function renderInline(text: string, keyPrefix = 'i'): ReactNode[] {
+export function renderInline(
+  text: string,
+  keyPrefix = 'i',
+  marker?: InlineMarker,
+): ReactNode[] {
   const out: ReactNode[] = [];
   let rest = text;
   let k = 0;
+  const pushPlain = (chunk: string) => {
+    if (chunk === '') return;
+    if (!marker) {
+      out.push(chunk);
+      return;
+    }
+    let last = 0;
+    // matchAll clones the regex — the shared pattern's lastIndex is safe.
+    for (const m of chunk.matchAll(marker.pattern)) {
+      const at = m.index ?? 0;
+      const node = marker.render(m, `${keyPrefix}-mk${k}`);
+      if (node == null) continue;
+      if (at > last) out.push(chunk.slice(last, at));
+      out.push(node);
+      k += 1;
+      last = at + m[0].length;
+    }
+    if (last < chunk.length) out.push(chunk.slice(last));
+  };
   while (rest.length > 0) {
     const m = INLINE.exec(rest);
     if (!m || m.index === undefined) {
-      out.push(rest);
+      pushPlain(rest);
       break;
     }
-    if (m.index > 0) out.push(rest.slice(0, m.index));
+    if (m.index > 0) pushPlain(rest.slice(0, m.index));
     const token = m[0];
     const key = `${keyPrefix}-${k}`;
     k += 1;
@@ -213,7 +247,7 @@ export function renderInline(text: string, keyPrefix = 'i'): ReactNode[] {
       if (href) {
         out.push(
           <a key={key} href={href} target="_blank" rel="noreferrer">
-            {renderInline(label, key)}
+            {renderInline(label, key, marker)}
           </a>,
         );
       } else {
@@ -223,10 +257,12 @@ export function renderInline(text: string, keyPrefix = 'i'): ReactNode[] {
       out.push(<code key={key}>{token.slice(1, -1)}</code>);
     } else if (m[4]) {
       out.push(
-        <strong key={key}>{renderInline(token.slice(2, -2), key)}</strong>,
+        <strong key={key}>{renderInline(token.slice(2, -2), key, marker)}</strong>,
       );
     } else {
-      out.push(<em key={key}>{renderInline(token.slice(1, -1), key)}</em>);
+      out.push(
+        <em key={key}>{renderInline(token.slice(1, -1), key, marker)}</em>,
+      );
     }
     rest = rest.slice(m.index + token.length);
   }
@@ -235,10 +271,10 @@ export function renderInline(text: string, keyPrefix = 'i'): ReactNode[] {
 
 // ---------------------------------------------------------------- renderer
 
-function blockBody(block: MdBlock, key: string): ReactNode {
+function blockBody(block: MdBlock, key: string, marker?: InlineMarker): ReactNode {
   switch (block.kind) {
     case 'heading': {
-      const inner = renderInline(block.text, key);
+      const inner = renderInline(block.text, key, marker);
       // Page structure owns h1; source headings start at h2 (v1 parity).
       if (block.level === 1) return <h2>{inner}</h2>;
       if (block.level === 2) return <h3>{inner}</h3>;
@@ -250,7 +286,7 @@ function blockBody(block: MdBlock, key: string): ReactNode {
           {block.lines.map((l, n) => (
             <span key={`${key}-l${n}`}>
               {n > 0 && <br />}
-              {renderInline(l, `${key}-l${n}`)}
+              {renderInline(l, `${key}-l${n}`, marker)}
             </span>
           ))}
         </p>
@@ -267,14 +303,16 @@ function blockBody(block: MdBlock, key: string): ReactNode {
           {block.lines.map((l, n) => (
             <span key={`${key}-q${n}`}>
               {n > 0 && <br />}
-              {renderInline(l, `${key}-q${n}`)}
+              {renderInline(l, `${key}-q${n}`, marker)}
             </span>
           ))}
         </blockquote>
       );
     case 'list': {
       const items = block.items.map((it, n) => (
-        <li key={`${key}-it${n}`}>{renderInline(it.text, `${key}-it${n}`)}</li>
+        <li key={`${key}-it${n}`}>
+          {renderInline(it.text, `${key}-it${n}`, marker)}
+        </li>
       ));
       return block.ordered ? <ol>{items}</ol> : <ul>{items}</ul>;
     }
@@ -295,6 +333,11 @@ export interface MarkdownViewProps {
   anchoredLines?: ReadonlySet<number>;
   /** Line to scroll to and highlight (set when a unit anchor is clicked). */
   highlightLine?: number | null;
+  /** False hides the line-number gutter column (chat answers — no source
+   * lines to anchor to). Default true: the source reading view. */
+  gutter?: boolean;
+  /** Inline marker hook — see InlineMarker (Ask citation markers). */
+  marker?: InlineMarker;
 }
 
 /** The ~720px-measure reading view with a line-number gutter. Blocks whose
@@ -304,6 +347,8 @@ export function MarkdownView({
   markdown,
   anchoredLines,
   highlightLine,
+  gutter = true,
+  marker,
 }: MarkdownViewProps) {
   // Parsing walks the whole document — memoize per markdown string so
   // unrelated re-renders (highlight changes, anchor sets) don't re-parse.
@@ -325,7 +370,7 @@ export function MarkdownView({
   }, [highlightLine, markdown]);
 
   return (
-    <div className="md-preview">
+    <div className={`md-preview${gutter ? '' : ' no-gut'}`}>
       {blocks.map((b, idx) => {
         const anchor = anchoredLines
           ? [...anchoredLines].find((l) => b.line <= l && l <= b.end)
@@ -344,8 +389,10 @@ export function MarkdownView({
               else rowRefs.current.delete(idx);
             }}
           >
-            <span className="gut">{anchor != null ? `L${anchor}` : ''}</span>
-            <div className="md-block">{blockBody(b, `b${b.line}`)}</div>
+            {gutter && (
+              <span className="gut">{anchor != null ? `L${anchor}` : ''}</span>
+            )}
+            <div className="md-block">{blockBody(b, `b${b.line}`, marker)}</div>
           </div>
         );
       })}

--- a/console-ui/src/pages/AskPage.tsx
+++ b/console-ui/src/pages/AskPage.tsx
@@ -12,18 +12,12 @@
  *
  * The textarea sets `data-omnibox-suppress` so the Shell's global ⌘K
  * handler leaves it alone while composing. */
-import {
-  useEffect,
-  useRef,
-  useState,
-  type KeyboardEvent,
-  type ReactNode,
-} from 'react';
+import { useEffect, useRef, useState, type KeyboardEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { EmptyState, PageHelp } from '../components/ui';
+import { EmptyState, PageHelp, conceptTipKey } from '../components/ui';
 import { useI18n, type MsgKey } from '../i18n';
 import { AskError, fetchChatMarkdown, fetchChats, postAsk } from '../lib/api';
-import { MarkdownView } from '../lib/markdown';
+import { MarkdownView, type InlineMarker } from '../lib/markdown';
 import type { AskCitation, AskResponse, ChatEntry } from '../lib/types';
 
 interface Turn {
@@ -52,7 +46,11 @@ function errorKeyFor(err: unknown): MsgKey {
   return 'ask.errGeneric';
 }
 
-/** Answer text with `[kind:id]` citations replaced by numbered markers. */
+/** Answer body rendered as markdown through the shared escape-first
+ * renderer (no HTML pathway, design §0.5) with `[kind:id]` citations turned
+ * into numbered markers via the renderer's inline marker hook — markers stay
+ * clickable INSIDE paragraphs, lists and emphasis. Tokens the server did not
+ * return as citations render as plain text (renderer default). */
 function AnswerText({
   answer,
   citations,
@@ -65,35 +63,34 @@ function AnswerText({
   onOpen: (cit: AskCitation) => void;
 }) {
   const index = new Map(citations.map((c, i) => [c.id, i]));
-  const nodes: ReactNode[] = [];
-  let last = 0;
-  let k = 0;
-  for (const m of answer.matchAll(CITE_RE)) {
-    const at = m.index ?? 0;
-    const i = index.get(m[1]);
-    if (i === undefined) continue; // not a returned citation — leave as text
-    if (at > last) nodes.push(answer.slice(last, at));
-    const cit = citations[i];
-    nodes.push(
-      <button
-        key={`m${k}`}
-        type="button"
-        className={`cite-marker${cit.verified ? '' : ' warn'}`}
-        onMouseEnter={() => onHover(cit.id)}
-        onMouseLeave={() => onHover(null)}
-        onFocus={() => onHover(cit.id)}
-        onBlur={() => onHover(null)}
-        onClick={() => onOpen(cit)}
-        title={cit.title ?? cit.id}
-      >
-        [{i + 1}]
-      </button>,
-    );
-    k += 1;
-    last = at + m[0].length;
-  }
-  nodes.push(answer.slice(last));
-  return <div className="answer-text">{nodes}</div>;
+  const marker: InlineMarker = {
+    pattern: CITE_RE,
+    render: (m, key) => {
+      const i = index.get(m[1]);
+      if (i === undefined) return null; // not a returned citation — plain text
+      const cit = citations[i];
+      return (
+        <button
+          key={key}
+          type="button"
+          className={`cite-marker${cit.verified ? '' : ' warn'}`}
+          onMouseEnter={() => onHover(cit.id)}
+          onMouseLeave={() => onHover(null)}
+          onFocus={() => onHover(cit.id)}
+          onBlur={() => onHover(null)}
+          onClick={() => onOpen(cit)}
+          title={cit.title ?? cit.id}
+        >
+          [{i + 1}]
+        </button>
+      );
+    },
+  };
+  return (
+    <div className="answer-text">
+      <MarkdownView markdown={answer} gutter={false} marker={marker} />
+    </div>
+  );
 }
 
 function CitationPanel({
@@ -115,33 +112,38 @@ function CitationPanel({
   }
   return (
     <div>
-      {citations.map((c, i) => (
-        <div
-          key={c.id}
-          className={`cite-entry${hoverId === c.id ? ' hover-hit' : ''}`}
-        >
-          <div className="cite-entry-top">
-            <span className="cite-num mono">[{i + 1}]</span>
-            <span className="pill">{c.kind}</span>
-            {!c.verified && (
-              <span className="pill unverified">{t('ask.unverified')}</span>
+      {citations.map((c, i) => {
+        const kindTip = conceptTipKey(c.kind);
+        return (
+          <div
+            key={c.id}
+            className={`cite-entry${hoverId === c.id ? ' hover-hit' : ''}`}
+          >
+            <div className="cite-entry-top">
+              <span className="cite-num mono">[{i + 1}]</span>
+              <span className="pill" title={kindTip ? t(kindTip) : undefined}>
+                {c.kind}
+              </span>
+              {!c.verified && (
+                <span className="pill unverified">{t('ask.unverified')}</span>
+              )}
+            </div>
+            <div className="cite-title">{c.title ?? c.id}</div>
+            {c.snippet && <blockquote>“{c.snippet}”</blockquote>}
+            {c.link_target ? (
+              <button
+                type="button"
+                className="cite-open tiny"
+                onClick={() => onOpen(c)}
+              >
+                {t('ask.openCitation')} →
+              </button>
+            ) : (
+              <span className="tiny muted">{t('ask.noLink')}</span>
             )}
           </div>
-          <div className="cite-title">{c.title ?? c.id}</div>
-          {c.snippet && <blockquote>“{c.snippet}”</blockquote>}
-          {c.link_target ? (
-            <button
-              type="button"
-              className="cite-open tiny"
-              onClick={() => onOpen(c)}
-            >
-              {t('ask.openCitation')} →
-            </button>
-          ) : (
-            <span className="tiny muted">{t('ask.noLink')}</span>
-          )}
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 }

--- a/console-ui/src/pages/KnowledgePage.tsx
+++ b/console-ui/src/pages/KnowledgePage.tsx
@@ -16,7 +16,7 @@ import KnowledgeGraph from '../components/KnowledgeGraph';
 import { EmptyState, ModelGate, PageHelp } from '../components/ui';
 import { useI18n } from '../i18n';
 import { fetchThemes } from '../lib/api';
-import { themeWall, type ThemeGroup } from '../lib/derive';
+import { isMiscTheme, themeWall, type ThemeGroup } from '../lib/derive';
 import type { IndexModel, ThemeCount } from '../lib/types';
 import { useModel } from '../model';
 
@@ -30,11 +30,16 @@ function ThemeCard({ group }: { group: ThemeGroup }) {
   const { t } = useI18n();
   const active = group.durable + group.caveated;
   const pct = active > 0 ? Math.round((group.durable / active) * 100) : 0;
+  // The 'misc' fallback bucket displays honestly as "Unclassified" — the
+  // link target keeps the literal theme key (display layer only).
+  const misc = isMiscTheme(group.theme);
   return (
     <Link className="theme-card" to={themePath(group.theme)}>
       <div className="theme-card-head">
         <span className="theme-card-name">
-          {group.theme || t('knowledge.untitledTheme')}
+          {misc
+            ? t('theme.unclassified')
+            : group.theme || t('knowledge.untitledTheme')}
         </span>
         <span className="theme-card-count mono">
           {t('knowledge.claimCount', { n: group.total })}
@@ -49,12 +54,20 @@ function ThemeCard({ group }: { group: ThemeGroup }) {
       >
         <span className="ratio-durable" style={{ width: `${pct}%` }} />
       </div>
-      <div className="theme-card-ratio tiny muted">
+      <div
+        className="theme-card-ratio tiny muted"
+        title={`durable — ${t('concept.durableTip')}\ncaveated — ${t('concept.caveatedTip')}`}
+      >
         {t('knowledge.ratioLine', {
           durable: group.durable,
           caveated: group.caveated,
         })}
       </div>
+      {misc && (
+        <p className="theme-card-ratio tiny muted">
+          {t('theme.unclassifiedNote')}
+        </p>
+      )}
       {group.topClaim && <p className="theme-card-snippet">{group.topClaim}</p>}
     </Link>
   );
@@ -168,6 +181,8 @@ export default function KnowledgePage() {
             {t('knowledge.help')}
             <br />
             {t('knowledge.helpLayers')}
+            <br />
+            {t('knowledge.helpLadder')}
           </PageHelp>
           <KnowledgeBody model={model} />
         </>

--- a/console-ui/src/pages/SourceDetailPage.tsx
+++ b/console-ui/src/pages/SourceDetailPage.tsx
@@ -224,6 +224,12 @@ export default function SourceDetailPage() {
 
           {tab === 'memory' && (
             <>
+              {memory.cards.length > 0 && (
+                <>
+                  <h3>{t('source.cardsTitle')}</h3>
+                  <p className="tiny muted">{t('source.cardsHint')}</p>
+                </>
+              )}
               {memory.cards.map((card, i) => (
                 <div className="card mem-card" key={`c${i}`}>
                   <div className="mem-title">{card.title}</div>
@@ -242,6 +248,7 @@ export default function SourceDetailPage() {
               {memory.units.length > 0 && (
                 <div className="section">
                   <h3>{t('source.groundedUnits')}</h3>
+                  <p className="tiny muted">{t('source.unitsHint')}</p>
                   {memory.units.map((unit) => (
                     <div className="unit-row" key={unit.unit_id}>
                       <blockquote>“{unit.quote}”</blockquote>

--- a/console-ui/src/pages/ThemeDetailPage.tsx
+++ b/console-ui/src/pages/ThemeDetailPage.tsx
@@ -11,7 +11,7 @@ import { Link, useLocation, useParams } from 'react-router-dom';
 import KnowledgeGraph from '../components/KnowledgeGraph';
 import { ClaimPill, EmptyState, ModelGate } from '../components/ui';
 import { useI18n } from '../i18n';
-import { sourcesByCase, themeClaims } from '../lib/derive';
+import { isMiscTheme, sourcesByCase, themeClaims } from '../lib/derive';
 import type { ClaimRow, IndexModel, SourceRow } from '../lib/types';
 import { useModel } from '../model';
 
@@ -159,15 +159,26 @@ export default function ThemeDetailPage() {
   const theme = rawTheme ?? '';
   const { model, error, loading } = useModel();
 
+  // 'misc' displays honestly as "Unclassified"; the route param and all
+  // claim data keep the literal theme key (display layer only).
+  const misc = isMiscTheme(theme);
+  const displayName = misc
+    ? t('theme.unclassified')
+    : theme || t('knowledge.untitledTheme');
+
   return (
     <ModelGate loading={loading} error={error}>
       {model && (
         <>
           <div className="crumbs">
-            <Link to="/knowledge">{t('nav.knowledge')}</Link> /{' '}
-            {theme || t('knowledge.untitledTheme')}
+            <Link to="/knowledge">{t('nav.knowledge')}</Link> / {displayName}
           </div>
-          <h1>{theme || t('knowledge.untitledTheme')}</h1>
+          <h1>{displayName}</h1>
+          {misc && (
+            <p className="muted tiny" style={{ marginTop: '-0.35rem' }}>
+              {t('theme.unclassifiedNote')}
+            </p>
+          )}
           <ThemeBody model={model} theme={theme} />
         </>
       )}

--- a/console-ui/src/pages/TodayPage.tsx
+++ b/console-ui/src/pages/TodayPage.tsx
@@ -8,10 +8,11 @@
 import { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import AttentionCard from '../components/AttentionCard';
-import { EmptyState, ModelGate, PageHelp } from '../components/ui';
+import { ClaimPill, EmptyState, ModelGate, PageHelp } from '../components/ui';
 import { useI18n } from '../i18n';
 import {
   attentionSources,
+  isMiscTheme,
   readToday,
   claimsSample,
   timeline,
@@ -98,7 +99,9 @@ function RecentClaims({ model }: { model: IndexModel }) {
       {claims.map((c) => (
         <div className="card" key={c.claim_id}>
           <div className="claim-top">
-            <span className={`pill ${c.status}`}>{c.status}</span>
+            {(c.status === 'durable' || c.status === 'caveated') && (
+              <ClaimPill status={c.status} />
+            )}
             {c.strength && (
               <span className="claim-meta">
                 {t('today.strength')}: {c.strength}
@@ -106,7 +109,11 @@ function RecentClaims({ model }: { model: IndexModel }) {
             )}
           </div>
           <p className="claim-text">{c.claim}</p>
-          {c.theme && <div className="claim-meta">{c.theme}</div>}
+          {c.theme && (
+            <div className="claim-meta">
+              {isMiscTheme(c.theme) ? t('theme.unclassified') : c.theme}
+            </div>
+          )}
         </div>
       ))}
     </div>

--- a/console-ui/vitest.config.ts
+++ b/console-ui/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+// Renderer unit tests run in plain node — assertions walk the ReactNode
+// tree, no DOM. A separate config (vitest prefers this file over
+// vite.config.ts) so tests skip the react/tailwind build plugins.
+export default defineConfig({
+  esbuild: { jsx: 'automatic' },
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.{ts,tsx}'],
+  },
+});

--- a/crates/ovp-domain/src/vault_layout.rs
+++ b/crates/ovp-domain/src/vault_layout.rs
@@ -84,9 +84,16 @@ impl VaultLayout {
         "50-Inbox/01-Raw"
     }
 
+    /// Root of the processed-inbox tree (all months, vault-relative). The
+    /// directory the index backfill sweeps when joining ledger-less corpus
+    /// packs back to their source files.
+    pub fn processed_root(&self) -> &'static str {
+        "50-Inbox/03-Processed"
+    }
+
     /// Processed-inbox directory for a given `YYYY-MM`.
     pub fn processed_dir(&self, month: &str) -> String {
-        format!("50-Inbox/03-Processed/{month}")
+        format!("{}/{month}", self.processed_root())
     }
 
     /// Where duplicate captures are parked (M31 intake): content/URL already
@@ -284,6 +291,7 @@ mod tests {
     fn inbox_dirs() {
         let l = VaultLayout::new();
         assert_eq!(l.inbox_raw_dir(), "50-Inbox/01-Raw");
+        assert_eq!(l.processed_root(), "50-Inbox/03-Processed");
         assert_eq!(l.processed_dir("2026-05"), "50-Inbox/03-Processed/2026-05");
     }
 

--- a/crates/ovp-index/src/build.rs
+++ b/crates/ovp-index/src/build.rs
@@ -42,7 +42,8 @@ pub fn build_index(
     let moved = moved_map(&reports);
 
     let mut sources = build_sources(vault_root, &layout, &moved)?;
-    let packs = build_packs(vault_root, &layout, &sources)?;
+    let mut packs = build_packs(vault_root, &layout, &sources)?;
+    backfill_corpus_packs(vault_root, &layout, &mut sources, &mut packs)?;
     enrich_titles_from_packs(&mut sources, &packs);
     let claims = build_claims(vault_root, &layout)?;
 
@@ -269,7 +270,15 @@ fn build_sources(
             }
         })
         .collect();
-    out.sort_by(|a, b| {
+    sort_sources(&mut out);
+    Ok(out)
+}
+
+/// Canonical source-row order: status band, then title, then hash. Shared by
+/// the ledger fold and the corpus backfill so appended rows keep the
+/// projection deterministic.
+fn sort_sources(rows: &mut [SourceRow]) {
+    rows.sort_by(|a, b| {
         (
             a.status,
             a.title.as_deref().unwrap_or(""),
@@ -281,7 +290,6 @@ fn build_sources(
                 b.sha256.as_str(),
             ))
     });
-    Ok(out)
 }
 
 /// All run reports, ordered oldest → newest. Collision-suffixed same-run-id
@@ -457,6 +465,165 @@ fn enrich_titles_from_packs(sources: &mut [SourceRow], packs: &[PackRow]) {
         if s.title.is_none() {
             if let Some(p) = s.pack_dir.as_deref().and_then(|d| by_pack.get(d)) {
                 s.title = Some(p.title.clone());
+            }
+        }
+    }
+}
+
+/// Skip hashing anything larger than this during the corpus backfill — real
+/// captures are small markdown files; hashing the odd huge export would
+/// dominate the index build for no join value.
+const MAX_BACKFILL_FILE_BYTES: u64 = 2 * 1024 * 1024;
+
+/// One 8-hex-prefix bucket of the candidate-file hash map. Two files with
+/// the same prefix but DIFFERENT full hashes make the prefix ambiguous:
+/// packs pointing at it stay unjoined rather than guessed.
+#[derive(Debug, PartialEq)]
+enum PrefixHit {
+    Unique { sha256: String, rel_path: String },
+    Ambiguous,
+}
+
+/// Corpus reader packs predate the daily ledgers, so `build_packs` finds no
+/// SourceRow to join them to — their Library rows, `/api/source/:sha` pages
+/// and Ask citation links were dead. Their dir names carry the join key:
+/// `<sha256-first-8-hex>-<date>_<title>`, where the 8-hex prefix hashes the
+/// source md now living under `50-Inbox/03-Processed/` (raw inbox as
+/// fallback). Hash the candidate files ONCE per build, join by prefix, and
+/// synthesize a Processed SourceRow when the ledgers know nothing about the
+/// hash. A synthesized row is recognizable by construction: `last_run_id`
+/// is None (every ledger-derived row has one) and `pack_dir` points at the
+/// corpus pack it was derived from.
+fn backfill_corpus_packs(
+    vault_root: &Path,
+    layout: &VaultLayout,
+    sources: &mut Vec<SourceRow>,
+    packs: &mut [PackRow],
+) -> Result<(), String> {
+    let unjoined: Vec<usize> = packs
+        .iter()
+        .enumerate()
+        .filter(|(_, p)| p.source_sha256.is_none() && corpus_hash8(&p.pack_dir).is_some())
+        .map(|(i, _)| i)
+        .collect();
+    if unjoined.is_empty() {
+        return Ok(()); // no corpus candidates → skip the vault walk entirely
+    }
+
+    let by_prefix = hash_candidate_files(vault_root, layout)?;
+    let mut known: std::collections::HashSet<String> =
+        sources.iter().map(|s| s.sha256.clone()).collect();
+    let mut appended = false;
+    for i in unjoined {
+        let Some(prefix) = corpus_hash8(&packs[i].pack_dir) else {
+            continue;
+        };
+        let Some(PrefixHit::Unique { sha256, rel_path }) = by_prefix.get(&prefix) else {
+            continue; // no candidate file, or an ambiguous prefix — never guess
+        };
+        packs[i].source_sha256 = Some(sha256.clone());
+        if known.insert(sha256.clone()) {
+            sources.push(SourceRow {
+                sha256: sha256.clone(),
+                status: SourceStatus::Processed,
+                title: Some(packs[i].title.clone()),
+                url: None,
+                rel_path: Some(rel_path.clone()),
+                date: corpus_date(&packs[i].pack_dir),
+                last_run_id: None, // no ledger record — the backfill provenance marker
+                pack_dir: Some(packs[i].pack_dir.clone()),
+                fail_count: 0,
+                last_reason: None,
+            });
+            appended = true;
+        }
+        // Hash already known from a ledger: join the pack only, never touch
+        // the ledger-derived row.
+    }
+    if appended {
+        sort_sources(sources);
+    }
+    Ok(())
+}
+
+/// `…/00044cfd-2026-05-07_Title` → `00044cfd`: the pack dir basename must
+/// start with EXACTLY 8 hex chars followed by `-`. Modern pack dirs
+/// (`<date>_<title>-<hash8>`) never match — their fifth char is already `-`.
+fn corpus_hash8(pack_dir: &str) -> Option<String> {
+    let name = pack_dir.rsplit('/').next().unwrap_or(pack_dir);
+    let bytes = name.as_bytes();
+    if bytes.len() > 8 && bytes[8] == b'-' && bytes[..8].iter().all(|b| b.is_ascii_hexdigit()) {
+        Some(name[..8].to_ascii_lowercase())
+    } else {
+        None
+    }
+}
+
+/// Date segment of a corpus pack dir (`<hash8>-<YYYY-MM-DD>_…`) — the same
+/// loose digits-and-dashes check `build_packs` applies to modern dir names.
+fn corpus_date(pack_dir: &str) -> Option<String> {
+    let name = pack_dir.rsplit('/').next().unwrap_or(pack_dir);
+    name.get(9..19)
+        .filter(|d| d.bytes().all(|b| b.is_ascii_digit() || b == b'-'))
+        .map(String::from)
+}
+
+/// Hash every candidate source md (processed tree first, then the raw inbox)
+/// into an 8-hex-prefix map. Built at most once per index build, and only
+/// when at least one unjoined corpus pack exists. `collect_markdown` walks
+/// in sorted order, so duplicate-content ties resolve deterministically.
+fn hash_candidate_files(
+    vault_root: &Path,
+    layout: &VaultLayout,
+) -> Result<HashMap<String, PrefixHit>, String> {
+    let mut map: HashMap<String, PrefixHit> = HashMap::new();
+    let roots = [
+        vault_root.join(layout.processed_root()),
+        vault_root.join(layout.inbox_raw_dir()),
+    ];
+    for root in roots {
+        if !root.is_dir() {
+            continue;
+        }
+        for path in collect_markdown(&root)? {
+            let meta = std::fs::metadata(&path)
+                .map_err(|e| format!("reading {}: {e}", path.display()))?;
+            if meta.len() > MAX_BACKFILL_FILE_BYTES {
+                continue;
+            }
+            let bytes =
+                std::fs::read(&path).map_err(|e| format!("reading {}: {e}", path.display()))?;
+            let sha = hex_sha256(&bytes);
+            let prefix = sha[..8].to_string();
+            insert_prefix_hit(&mut map, prefix, sha, rel_to(vault_root, &path));
+        }
+    }
+    Ok(map)
+}
+
+/// Pure insert step, split out because an 8-hex prefix collision cannot be
+/// forged in an on-disk fixture — the unit test drives this directly. Same
+/// full hash twice is duplicate CONTENT (first path wins); different full
+/// hashes poison the prefix as Ambiguous.
+fn insert_prefix_hit(
+    map: &mut HashMap<String, PrefixHit>,
+    prefix: String,
+    sha256: String,
+    rel_path: String,
+) {
+    use std::collections::hash_map::Entry;
+    match map.entry(prefix) {
+        Entry::Vacant(v) => {
+            v.insert(PrefixHit::Unique { sha256, rel_path });
+        }
+        Entry::Occupied(mut o) => {
+            if let PrefixHit::Unique {
+                sha256: existing, ..
+            } = o.get()
+            {
+                if existing != &sha256 {
+                    o.insert(PrefixHit::Ambiguous);
+                }
             }
         }
     }
@@ -694,4 +861,68 @@ fn from_days(total: u32) -> String {
 
 fn is_leap(y: u32) -> bool {
     y % 4 == 0 && (y % 100 != 0 || y % 400 == 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn corpus_hash8_matches_only_the_legacy_prefix_shape() {
+        // Legacy corpus dir: 8 hex + '-'.
+        assert_eq!(
+            corpus_hash8("40-Resources/Reader/00044cfd-2026-05-07_Claude_Code"),
+            Some("00044cfd".into())
+        );
+        // Uppercase hex normalizes to the hex_sha256 lowercase alphabet.
+        assert_eq!(
+            corpus_hash8("40-Resources/Reader/00044CFD-2026-05-07_X"),
+            Some("00044cfd".into())
+        );
+        // Modern pack dir (`<date>_<title>-<hash8>`): fifth char is '-'.
+        assert_eq!(
+            corpus_hash8("40-Resources/Reader/2026-06-09_Good Article-aaaa1111"),
+            None
+        );
+        // Nine leading hex chars → char 8 is hex, not '-'.
+        assert_eq!(corpus_hash8("40-Resources/Reader/00044cfd1-2026_X"), None);
+        // Non-hex within the prefix.
+        assert_eq!(corpus_hash8("40-Resources/Reader/00zz4cfd-2026_X"), None);
+        // Too short.
+        assert_eq!(corpus_hash8("00044cfd"), None);
+    }
+
+    #[test]
+    fn corpus_date_reads_the_segment_after_the_prefix() {
+        assert_eq!(
+            corpus_date("40-Resources/Reader/00044cfd-2026-05-07_Title"),
+            Some("2026-05-07".into())
+        );
+        assert_eq!(
+            corpus_date("40-Resources/Reader/00044cfd-notadate12"),
+            None
+        );
+        assert_eq!(corpus_date("40-Resources/Reader/00044cfd-"), None);
+    }
+
+    #[test]
+    fn ambiguous_prefix_is_poisoned_and_duplicate_content_keeps_first_path() {
+        let mut map = HashMap::new();
+        // Two files, same content hash → duplicate content, first path wins.
+        insert_prefix_hit(&mut map, "00044cfd".into(), "00044cfdaaaa".into(), "a.md".into());
+        insert_prefix_hit(&mut map, "00044cfd".into(), "00044cfdaaaa".into(), "b.md".into());
+        assert_eq!(
+            map.get("00044cfd"),
+            Some(&PrefixHit::Unique {
+                sha256: "00044cfdaaaa".into(),
+                rel_path: "a.md".into()
+            })
+        );
+        // A DIFFERENT full hash on the same prefix → ambiguous, never guess.
+        insert_prefix_hit(&mut map, "00044cfd".into(), "00044cfdbbbb".into(), "c.md".into());
+        assert_eq!(map.get("00044cfd"), Some(&PrefixHit::Ambiguous));
+        // Once poisoned, it stays poisoned.
+        insert_prefix_hit(&mut map, "00044cfd".into(), "00044cfdaaaa".into(), "a.md".into());
+        assert_eq!(map.get("00044cfd"), Some(&PrefixHit::Ambiguous));
+    }
 }

--- a/crates/ovp-index/src/build.rs
+++ b/crates/ovp-index/src/build.rs
@@ -491,9 +491,11 @@ enum PrefixHit {
 /// source md now living under `50-Inbox/03-Processed/` (raw inbox as
 /// fallback). Hash the candidate files ONCE per build, join by prefix, and
 /// synthesize a Processed SourceRow when the ledgers know nothing about the
-/// hash. A synthesized row is recognizable by construction: `last_run_id`
-/// is None (every ledger-derived row has one) and `pack_dir` points at the
-/// corpus pack it was derived from.
+/// hash. When the raw-inbox SCAN already made a queued row for the same
+/// bytes (file still in 01-Raw, no ledger record), that row is promoted to
+/// processed instead of duplicated. Backfilled rows are recognizable by
+/// construction: `last_run_id` is None (every ledger-derived row has one)
+/// and `pack_dir` points at the corpus pack they were joined to.
 fn backfill_corpus_packs(
     vault_root: &Path,
     layout: &VaultLayout,
@@ -511,9 +513,12 @@ fn backfill_corpus_packs(
     }
 
     let by_prefix = hash_candidate_files(vault_root, layout)?;
-    let mut known: std::collections::HashSet<String> =
-        sources.iter().map(|s| s.sha256.clone()).collect();
-    let mut appended = false;
+    let mut by_sha: HashMap<String, usize> = sources
+        .iter()
+        .enumerate()
+        .map(|(i, s)| (s.sha256.clone(), i))
+        .collect();
+    let mut changed = false;
     for i in unjoined {
         let Some(prefix) = corpus_hash8(&packs[i].pack_dir) else {
             continue;
@@ -522,25 +527,50 @@ fn backfill_corpus_packs(
             continue; // no candidate file, or an ambiguous prefix — never guess
         };
         packs[i].source_sha256 = Some(sha256.clone());
-        if known.insert(sha256.clone()) {
-            sources.push(SourceRow {
-                sha256: sha256.clone(),
-                status: SourceStatus::Processed,
-                title: Some(packs[i].title.clone()),
-                url: None,
-                rel_path: Some(rel_path.clone()),
-                date: corpus_date(&packs[i].pack_dir),
-                last_run_id: None, // no ledger record — the backfill provenance marker
-                pack_dir: Some(packs[i].pack_dir.clone()),
-                fail_count: 0,
-                last_reason: None,
-            });
-            appended = true;
+        match by_sha.get(sha256).copied() {
+            None => {
+                sources.push(SourceRow {
+                    sha256: sha256.clone(),
+                    status: SourceStatus::Processed,
+                    title: Some(packs[i].title.clone()),
+                    url: None,
+                    rel_path: Some(rel_path.clone()),
+                    date: corpus_date(&packs[i].pack_dir),
+                    last_run_id: None, // no ledger record — the backfill provenance marker
+                    pack_dir: Some(packs[i].pack_dir.clone()),
+                    fail_count: 0,
+                    last_reason: None,
+                });
+                by_sha.insert(sha256.clone(), sources.len() - 1);
+                changed = true;
+            }
+            Some(at) => {
+                // A raw-scan row (queued, no run id) is this same corpus file
+                // seen by the 01-Raw sweep — promote it to processed rather
+                // than leaving a pack-linked source stuck in the queue (its
+                // corpus case would otherwise be underivable). Ledger-derived
+                // rows (any last_run_id) stay untouched: the ledgers are the
+                // authority on lifecycle.
+                let row = &mut sources[at];
+                if row.last_run_id.is_none() && row.status == SourceStatus::Queued {
+                    row.status = SourceStatus::Processed;
+                    row.pack_dir = Some(packs[i].pack_dir.clone());
+                    // Preference rules: frontmatter title/url read by the raw
+                    // scan are richer than pack metadata — keep them and fill
+                    // only the gaps from the pack; rel_path stays (it points
+                    // at the bytes that were actually hashed).
+                    if row.title.is_none() {
+                        row.title = Some(packs[i].title.clone());
+                    }
+                    if row.date.is_none() {
+                        row.date = corpus_date(&packs[i].pack_dir);
+                    }
+                    changed = true;
+                }
+            }
         }
-        // Hash already known from a ledger: join the pack only, never touch
-        // the ledger-derived row.
     }
-    if appended {
+    if changed {
         sort_sources(sources);
     }
     Ok(())

--- a/crates/ovp-index/tests/index_build.rs
+++ b/crates/ovp-index/tests/index_build.rs
@@ -597,6 +597,91 @@ fn corpus_pack_joins_an_existing_ledger_row_without_duplicating_it() {
 }
 
 #[test]
+fn corpus_pack_promotes_a_raw_scan_queued_row() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    // Corpus source still sitting in 01-Raw: the raw sweep makes a QUEUED
+    // row for it before the backfill runs. The prefix join must PROMOTE that
+    // row (processed + pack link) — not skip it, and not duplicate it.
+    let sha = place(
+        root,
+        "50-Inbox/01-Raw/2026-05/corpus.md",
+        "---\ntitle: Raw Frontmatter Title\nsource: https://e.x/corpus\n---\ncorpus body\n",
+    );
+    let pack = write_pack(
+        root,
+        &format!("{}-2026-05-07_Corpus", &sha[..8]),
+        "Pack Title",
+        1,
+    );
+
+    let model = build_index(root, "2026-06-09", None).unwrap();
+
+    assert_eq!(model.totals.sources, 1, "promoted, not duplicated");
+    assert_eq!(model.totals.processed, 1);
+    assert_eq!(model.totals.queued, 0, "no pack-linked source stuck queued");
+    let row = model.sources.iter().find(|s| s.sha256 == sha).unwrap();
+    assert_eq!(row.status, SourceStatus::Processed);
+    assert_eq!(row.pack_dir.as_deref(), Some(pack.as_str()));
+    // Frontmatter metadata from the raw scan beats pack metadata.
+    assert_eq!(row.title.as_deref(), Some("Raw Frontmatter Title"));
+    assert_eq!(row.url.as_deref(), Some("https://e.x/corpus"));
+    assert_eq!(
+        row.rel_path.as_deref(),
+        Some("50-Inbox/01-Raw/2026-05/corpus.md")
+    );
+    // Gaps fill from the pack dir.
+    assert_eq!(row.date.as_deref(), Some("2026-05-07"));
+    assert_eq!(row.last_run_id, None, "still no ledger record");
+    let joined = model.packs.iter().find(|p| p.pack_dir == pack).unwrap();
+    assert_eq!(joined.source_sha256.as_deref(), Some(sha.as_str()));
+}
+
+#[test]
+fn corpus_pack_never_promotes_a_ledger_queued_row() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let intake_ledger = root.join(".ovp/intake.jsonl");
+
+    // Same shape, but the INTAKE ledger owns this row (queued, with a run
+    // id): the pack may join, the lifecycle must not move — the ledgers are
+    // the authority, only the daily run promotes ledgered sources.
+    let sha = place(
+        root,
+        "50-Inbox/01-Raw/2026-05/ledgered.md",
+        "ledgered corpus bytes",
+    );
+    append_intake_record(
+        &intake_ledger,
+        &intake_rec(
+            &sha,
+            IntakeAction::Ingested,
+            "Ledgered Piece",
+            "https://e.x/l",
+            "Clippings/Ledgered Piece.md",
+            Some("50-Inbox/01-Raw/2026-05/ledgered.md"),
+        ),
+    )
+    .unwrap();
+    let pack = write_pack(
+        root,
+        &format!("{}-2026-05-07_Ledgered", &sha[..8]),
+        "Ledgered Piece",
+        1,
+    );
+
+    let model = build_index(root, "2026-06-09", None).unwrap();
+
+    let row = model.sources.iter().find(|s| s.sha256 == sha).unwrap();
+    assert_eq!(row.status, SourceStatus::Queued, "ledger rows stay untouched");
+    assert_eq!(row.pack_dir, None);
+    assert_eq!(row.last_run_id.as_deref(), Some("daily-2026-06-09"));
+    let joined = model.packs.iter().find(|p| p.pack_dir == pack).unwrap();
+    assert_eq!(joined.source_sha256.as_deref(), Some(sha.as_str()));
+}
+
+#[test]
 fn corpus_backfill_skips_files_over_the_size_cap() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();

--- a/crates/ovp-index/tests/index_build.rs
+++ b/crates/ovp-index/tests/index_build.rs
@@ -499,6 +499,120 @@ fn persisted_index_is_deterministic_and_rebuildable() {
 }
 
 #[test]
+fn corpus_pack_hash_prefix_joins_and_synthesizes_a_source() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    // Corpus source: lives in 03-Processed, known to NO ledger. The pack dir
+    // carries the first 8 hex chars of the file's sha256 as its prefix.
+    let sha = place(
+        root,
+        "50-Inbox/03-Processed/2026-05/2026-05-07_Corpus_Article.md",
+        "corpus article body bytes",
+    );
+    let joined_pack = write_pack(
+        root,
+        &format!("{}-2026-05-07_Corpus Article", &sha[..8]),
+        "Corpus Article",
+        1,
+    );
+    // Corpus pack whose prefix matches no file on disk → must stay unjoined.
+    write_pack(root, "deadbeef-2026-05-08_No Source", "No Source", 1);
+
+    let model = build_index(root, "2026-06-09", None).unwrap();
+
+    let pack = model
+        .packs
+        .iter()
+        .find(|p| p.pack_dir == joined_pack)
+        .unwrap();
+    assert_eq!(pack.source_sha256.as_deref(), Some(sha.as_str()));
+
+    let src = model.sources.iter().find(|s| s.sha256 == sha).unwrap();
+    assert_eq!(src.status, SourceStatus::Processed);
+    assert_eq!(src.title.as_deref(), Some("Corpus Article"));
+    assert_eq!(
+        src.rel_path.as_deref(),
+        Some("50-Inbox/03-Processed/2026-05/2026-05-07_Corpus_Article.md")
+    );
+    assert_eq!(src.date.as_deref(), Some("2026-05-07"));
+    assert_eq!(src.pack_dir.as_deref(), Some(joined_pack.as_str()));
+    assert_eq!(src.last_run_id, None, "backfill rows carry no run id");
+
+    let orphan = model
+        .packs
+        .iter()
+        .find(|p| p.pack_dir.contains("deadbeef"))
+        .unwrap();
+    assert_eq!(orphan.source_sha256, None, "prefix without a file stays unjoined");
+    assert_eq!(model.totals.sources, 1, "no source invented for the orphan");
+}
+
+#[test]
+fn corpus_pack_joins_an_existing_ledger_row_without_duplicating_it() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let fx = build_fixture_vault(root);
+
+    // A corpus-named alias pack whose prefix hashes to the ledger-processed
+    // source: it must join the EXISTING row, not synthesize a second one,
+    // and the ledger-joined pack must stay exactly as the ledger said.
+    let alias_pack = write_pack(
+        root,
+        &format!("{}-2026-06-09_Alias Pack", &fx.processed_sha[..8]),
+        "Alias Pack",
+        1,
+    );
+
+    let model = build_index(root, "2026-06-09", Some("daily-2026-06-09")).unwrap();
+
+    assert_eq!(model.totals.sources, 7, "no synthesized duplicate row");
+    let alias = model
+        .packs
+        .iter()
+        .find(|p| p.pack_dir == alias_pack)
+        .unwrap();
+    assert_eq!(alias.source_sha256.as_deref(), Some(fx.processed_sha.as_str()));
+
+    // The ledger-joined pack is unchanged by the backfill pass.
+    let ledgered = model
+        .packs
+        .iter()
+        .find(|p| p.pack_dir.ends_with("2026-06-09_Good Article-aaaa1111"))
+        .unwrap();
+    assert_eq!(
+        ledgered.source_sha256.as_deref(),
+        Some(fx.processed_sha.as_str())
+    );
+    let processed = model
+        .sources
+        .iter()
+        .find(|s| s.sha256 == fx.processed_sha)
+        .unwrap();
+    assert_eq!(
+        processed.last_run_id.as_deref(),
+        Some("daily-2026-06-09"),
+        "ledger row untouched"
+    );
+}
+
+#[test]
+fn corpus_backfill_skips_files_over_the_size_cap() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    // 3 MB of markdown — over the 2 MB hashing cap, so never a candidate.
+    let big = "x".repeat(3 * 1024 * 1024);
+    let sha = place(root, "50-Inbox/03-Processed/2026-05/huge.md", &big);
+    write_pack(root, &format!("{}-2026-05-07_Huge", &sha[..8]), "Huge", 1);
+
+    let model = build_index(root, "2026-06-09", None).unwrap();
+    let pack = model.packs.iter().find(|p| p.pack_dir.contains("_Huge")).unwrap();
+    assert_eq!(pack.source_sha256, None, "oversized files are not hashed");
+    assert_eq!(model.totals.sources, 0);
+}
+
+#[test]
 fn empty_vault_builds_an_empty_model() {
     let dir = tempfile::tempdir().unwrap();
     let model = build_index(dir.path(), "2026-06-09", None).unwrap();


### PR DESCRIPTION
Four operator findings from the P.5-style walkthrough + 2 codex-gate P2s, all fixed:

1. **Corpus-pack backfill (root cause of dead Ask citations)**: 994 read-source-era packs had no source_sha256 — verified their dir-name 8-hex prefix = sha256[:8] of the source md; the index build now hashes inbox candidates once and joins them, synthesizing/promoting SourceRows (ambiguous prefixes never guessed; ledger rows never touched; raw-scan queued rows promoted with documented preference rules). Library grows from ~305 to ~1000 sources; /api/source and citation deep links work for the whole corpus.
2. **Ask answers render as markdown** via the escape-first renderer with an InlineMarker hook — citation markers stay clickable in paragraphs/lists/emphasis, suppressed inside link labels (no <a><button>> nesting; single navigation). First TS unit tests land (vitest, 6 tests, node-env ReactNode-tree assertions).
3. **Concept affordances**: durable/caveated pill tooltips, cards/units section explainers, knowledge-ladder help copy (原文→unit→card→claim), en/zh parity.
4. **Miscellaneous honesty**: displays as 'Unclassified 未分类' with the M34 clustering note — display layer only; the semantic-clustering replacement is speced separately (.run/theme-spike-20260709/REPORT.md).

Gates: 780 workspace tests, clippy -D warnings, arch check, tsc + vite build, npm test 6/6. Codex gate: PASS (2 P2s found, both fixed).