### PR TITLE
chore: version 0.23.0 — first prebuilt ovp2 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,7 +770,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "ovp-app"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "ovp-core",
  "ovp-domain",
@@ -784,7 +784,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-auto"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "ovp-app",
  "ovp-core",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-cli"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "clap",
  "ovp-app",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-console"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "ovp-domain",
  "ovp-index",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-core"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "ovp-core",
  "serde",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-daily"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "ovp-domain",
  "ovp-intake",
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-domain"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "ovp-core",
  "ovp-domain",
@@ -875,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-enrich"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "ovp-domain",
  "reqwest",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-eval"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "ovp-app",
  "ovp-core",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-evolve"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "chrono",
  "serde",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-index"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "ovp-daily",
  "ovp-domain",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-intake"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "ovp-domain",
  "reqwest",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-lint"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "ovp-app",
  "ovp-core",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-llm"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "reqwest",
  "serde",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-mcp"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "ovp-domain",
  "ovp-index",
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-memory"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "ovp-domain",
  "ovp-index",
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-query"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "ovp-app",
  "ovp-core",
@@ -1003,7 +1003,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-rag"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "ovp-core",
  "ovp-domain",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-review"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "ovp-app",
  "ovp-core",
@@ -1034,7 +1034,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-run"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "ovp-app",
  "ovp-core",
@@ -1048,7 +1048,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-server"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "ovp-domain",
  "ovp-index",
@@ -1062,7 +1062,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-stores"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "ovp-core",
  "ovp-domain",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.23.0"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"


### PR DESCRIPTION
Repo release lineage is at v0.22.0 (M28, Python era); the Rust workspace claimed 0.1.0 which would regress the tag history and collide with the 2026-era PyPI v0.1.0 tag. First prebuilt ovp2 release continues the lineage as v0.23.0; v2.0.0 is reserved for the merge-to-main milestone. Tag v0.23.0 follows after merge (cargo-dist requires tag == package version).