### PR TITLE
chore: v2.0.0 — go/no-go GO, dogfood waiver recorded, PR flow retargets main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
+Nothing yet.
 
-- Semantic themes (LLM-grouped theme projection over Crystal claims) — in
-  progress.
-- `ovp2 doctor` now reports Python-era OVP artifacts left in a vault
-  (`60-Logs/knowledge.db`, legacy logs, old `.ovp/*.yaml` configs) as
-  informational findings with migration guidance.
+## [2.0.0] - 2026-07-10
+
+**OVP2 replaces OVP.** This release marks the merge of the Rust rewrite to
+`main` and the retirement of the Python pipeline. See
+[docs/ovp-to-ovp2.md](docs/ovp-to-ovp2.md) for the full story, key decisions,
+and migration guide. The final Python line is preserved frozen on the
+`legacy/python-main` branch (tag `legacy-python-final`).
+
+### Added
+- Semantic theme system: local multilingual embeddings (fastembed, pinned
+  paraphrase-multilingual-MiniLM) + deterministic Louvain communities +
+  c-TF-IDF keywords + optional LLM bilingual naming — replaces the hardcoded
+  keyword buckets; themes are a rebuildable projection (`.ovp/crystal/themes.json`).
+- `ovp2 crystal-themes` command; `embed` cargo feature (shipped in prebuilt
+  binaries); one-time model download with offline degradation to Unclassified.
+- `ovp2 doctor` legacy-artifact check (Python-era files reported as INFO with
+  migration guidance).
+- Dual license (MIT OR Apache-2.0), privacy & trust documentation, issue
+  templates, downgrade/rollback instructions.
 
 ### Changed
-
-- Relicensed from MIT to dual **MIT OR Apache-2.0** (`LICENSE-MIT`,
-  `LICENSE-APACHE`). Vendored IBM Plex fonts remain under the SIL OFL 1.1.
+- Crystal-synth batching groups by semantic community (date-ordered fallback);
+  the 8 hardcoded keyword buckets are deleted.
+- Review-session defer triggers key on stable community identity, never
+  display labels.
+- MSRV raised to 1.88 (embed dependency tree).
 
 ## [0.23.0] - 2026-07-10
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1348,7 +1348,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-app"
-version = "0.23.0"
+version = "2.0.0"
 dependencies = [
  "ovp-core",
  "ovp-domain",
@@ -1362,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-auto"
-version = "0.23.0"
+version = "2.0.0"
 dependencies = [
  "ovp-app",
  "ovp-core",
@@ -1377,7 +1377,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-cli"
-version = "0.23.0"
+version = "2.0.0"
 dependencies = [
  "clap",
  "ovp-app",
@@ -1409,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-console"
-version = "0.23.0"
+version = "2.0.0"
 dependencies = [
  "ovp-domain",
  "ovp-index",
@@ -1418,7 +1418,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-core"
-version = "0.23.0"
+version = "2.0.0"
 dependencies = [
  "ovp-core",
  "serde",
@@ -1428,7 +1428,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-daily"
-version = "0.23.0"
+version = "2.0.0"
 dependencies = [
  "ovp-domain",
  "ovp-intake",
@@ -1440,7 +1440,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-domain"
-version = "0.23.0"
+version = "2.0.0"
 dependencies = [
  "ovp-core",
  "ovp-domain",
@@ -1454,7 +1454,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-embed"
-version = "0.23.0"
+version = "2.0.0"
 dependencies = [
  "fastembed",
  "serde",
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-enrich"
-version = "0.23.0"
+version = "2.0.0"
 dependencies = [
  "ovp-domain",
  "reqwest",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-eval"
-version = "0.23.0"
+version = "2.0.0"
 dependencies = [
  "ovp-app",
  "ovp-core",
@@ -1493,7 +1493,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-evolve"
-version = "0.23.0"
+version = "2.0.0"
 dependencies = [
  "chrono",
  "serde",
@@ -1505,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-index"
-version = "0.23.0"
+version = "2.0.0"
 dependencies = [
  "ovp-daily",
  "ovp-domain",
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-intake"
-version = "0.23.0"
+version = "2.0.0"
 dependencies = [
  "ovp-domain",
  "reqwest",
@@ -1529,7 +1529,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-lint"
-version = "0.23.0"
+version = "2.0.0"
 dependencies = [
  "ovp-app",
  "ovp-core",
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-llm"
-version = "0.23.0"
+version = "2.0.0"
 dependencies = [
  "reqwest",
  "serde",
@@ -1556,7 +1556,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-mcp"
-version = "0.23.0"
+version = "2.0.0"
 dependencies = [
  "ovp-domain",
  "ovp-index",
@@ -1566,7 +1566,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-memory"
-version = "0.23.0"
+version = "2.0.0"
 dependencies = [
  "ovp-domain",
  "ovp-index",
@@ -1577,7 +1577,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-query"
-version = "0.23.0"
+version = "2.0.0"
 dependencies = [
  "ovp-app",
  "ovp-core",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-rag"
-version = "0.23.0"
+version = "2.0.0"
 dependencies = [
  "ovp-core",
  "ovp-domain",
@@ -1606,7 +1606,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-review"
-version = "0.23.0"
+version = "2.0.0"
 dependencies = [
  "ovp-app",
  "ovp-core",
@@ -1624,7 +1624,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-run"
-version = "0.23.0"
+version = "2.0.0"
 dependencies = [
  "ovp-app",
  "ovp-core",
@@ -1638,7 +1638,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-server"
-version = "0.23.0"
+version = "2.0.0"
 dependencies = [
  "ovp-domain",
  "ovp-index",
@@ -1652,7 +1652,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-stores"
-version = "0.23.0"
+version = "2.0.0"
 dependencies = [
  "ovp-core",
  "ovp-domain",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.23.0"
+version = "2.0.0"
 edition = "2024"
 # 1.88 = the floor of the `embed` dep tree (ort 2.0.0-rc.12 / time 0.3.53),
 # which release builds enable (dist-workspace.toml `features`). Nothing pins an

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -285,6 +285,18 @@ M26 workbench 重判、双评审模型家族。
 
 ## Stage 5: Level-3 go/no-go + merge 回 main（全部依赖，~07-15 之后）
 
+> **GO — 2026-07-10（operator 决定，含两项书面豁免）**
+>
+> | # | Exit criterion | 状态 |
+> |---|---|---|
+> | 1 | 全量 corpus run 无 backlog | ✅ 1012 attempted / 994 ok；当前 211 queued 为 07-09 新入 pinboard 书签（滚动产品队列，非欠账） |
+> | 2 | 失败源全部分类/waive | ✅ docs/stage-m32-corpus-triage.md；operator 以 merge 决定签收其余 waiver |
+> | 3 | 全库 crystallize + 幂等 | ✅ 329 durable / replay 重跑 0 新增 |
+> | 4 | KMEM AB recorded verdict | ✅ docs/stage-m32-ab-real-sample.md；补跑项 operator 豁免 |
+> | 5 | ≥14 天 dogfood | ⚠ **WAIVED**（operator 2026-07-10）：5 天（07-06..07-10）全部成功、0 Python 回退，产品走查通过后 operator 决定不再等满 14 天 |
+> | 6 | 数据无丢失 | ✅ merge 不删除任何文件；vault md 原样；`60-Logs/knowledge.db` 实为 381MB（非计划假设的 0-byte）——按 Python 架构契约为可重建投影，原样留盘，doctor 标记为 legacy 产物待 operator 验证后自行处置 |
+> | #0 | 产品原型走查 | ✅ operator 2026-07-10 走查通过（"看起来可以，没有太大的问题"） |
+
 **Goal**: 按 M32 §3 六条 exit criteria 逐条验收，通过则执行 merge（= Python 正式退役）。
 **Go/no-go 清单**（六条全绿才 merge）:
 - [ ] 全量 corpus run 完成，无 backlog（Stage 2）


### PR DESCRIPTION
Operator decision 2026-07-10: merge today. Go/no-go table (with the dogfood 5/14-day waiver and the honest knowledge.db finding — 381MB projection, not 0-byte; left untouched, doctor-flagged) recorded in IMPLEMENTATION_PLAN. Version → 2.0.0 (the reserved merge-milestone number). AGENTS.md PR flow now targets main. After this merges: ff-only merge to main → tag v2.0.0 → release artifacts → tap update.