### PR TITLE
fix(release): v2.0.1 — Linux artifacts on ubuntu-24.04, Intel-mac target dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Nothing yet.
 
+## [2.0.1] - 2026-07-10
+
+### Fixed
+- Release builds: Linux artifacts build on `ubuntu-24.04` (ort's prebuilt ONNX
+  Runtime needs glibc >= 2.38); the Intel-mac (`x86_64-apple-darwin`) target is
+  dropped from the prebuilt matrix (ort ships no ONNX prebuilts for it —
+  operator decision: unsupported; build from source without `embed`).
+
 ## [2.0.0] - 2026-07-10
 
 **OVP2 replaces OVP.** This release marks the merge of the Rust rewrite to

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1348,7 +1348,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-app"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "ovp-core",
  "ovp-domain",
@@ -1362,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-auto"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "ovp-app",
  "ovp-core",
@@ -1377,7 +1377,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-cli"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "clap",
  "ovp-app",
@@ -1409,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-console"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "ovp-domain",
  "ovp-index",
@@ -1418,7 +1418,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-core"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "ovp-core",
  "serde",
@@ -1428,7 +1428,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-daily"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "ovp-domain",
  "ovp-intake",
@@ -1440,7 +1440,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-domain"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "ovp-core",
  "ovp-domain",
@@ -1454,7 +1454,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-embed"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "fastembed",
  "serde",
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-enrich"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "ovp-domain",
  "reqwest",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-eval"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "ovp-app",
  "ovp-core",
@@ -1493,7 +1493,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-evolve"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "chrono",
  "serde",
@@ -1505,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-index"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "ovp-daily",
  "ovp-domain",
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-intake"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "ovp-domain",
  "reqwest",
@@ -1529,7 +1529,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-lint"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "ovp-app",
  "ovp-core",
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-llm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "reqwest",
  "serde",
@@ -1556,7 +1556,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-mcp"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "ovp-domain",
  "ovp-index",
@@ -1566,7 +1566,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-memory"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "ovp-domain",
  "ovp-index",
@@ -1577,7 +1577,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-query"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "ovp-app",
  "ovp-core",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-rag"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "ovp-core",
  "ovp-domain",
@@ -1606,7 +1606,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-review"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "ovp-app",
  "ovp-core",
@@ -1624,7 +1624,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-run"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "ovp-app",
  "ovp-core",
@@ -1638,7 +1638,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-server"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "ovp-domain",
  "ovp-index",
@@ -1652,7 +1652,7 @@ dependencies = [
 
 [[package]]
 name = "ovp-stores"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "ovp-core",
  "ovp-domain",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.0.0"
+version = "2.0.1"
 edition = "2024"
 # 1.88 = the floor of the `embed` dep tree (ort 2.0.0-rc.12 / time 0.3.53),
 # which release builds enable (dist-workspace.toml `features`). Nothing pins an

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -9,8 +9,12 @@ cargo-dist-version = "0.32.0"
 ci = "github"
 # The installers to generate for each app
 installers = ["shell", "homebrew"]
-# Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu"]
+# Target platforms to build apps for (Rust target-triple syntax).
+# x86_64-apple-darwin was DROPPED after v2.0.0: the `embed` feature pulls in ort,
+# and pyke ships no prebuilt ONNX Runtime for Intel macs (v2.0.0 release run
+# 29096057755 failed there); compiling ONNX Runtime from source is not an
+# acceptable CI cost. Intel-mac users build from source — see docs/install.md.
+targets = ["aarch64-apple-darwin", "x86_64-unknown-linux-gnu"]
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"
 # Where to host releases
@@ -35,3 +39,11 @@ tap = "fakechris/homebrew-ovp2"
 # Name the generated formula after the product binary (`brew install
 # fakechris/ovp2/ovp2`), not the cargo package name (ovp-cli).
 formula = "ovp2"
+
+# ort's prebuilt libonnxruntime (pulled in by the `embed` feature) needs
+# glibc >= 2.38; the default runner's glibc is older and the link fails
+# (`undefined symbol: __isoc23_strtoll`). ubuntu-24.04 ships glibc 2.39.
+# This sets the glibc floor for the Linux prebuilt — documented in
+# docs/install.md.
+[dist.github-custom-runners]
+x86_64-unknown-linux-gnu = "ubuntu-24.04"

--- a/docs/install.md
+++ b/docs/install.md
@@ -32,11 +32,23 @@ end-to-end.
    install (`env -u HTTPS_PROXY -u HTTP_PROXY -u ALL_PROXY brew install
    fakechris/ovp2/ovp2`) or configure git's proxy explicitly.
 
-Verify either channel with `ovp2 --version` (→ `ovp2 0.23.0`).
+Verify either channel with `ovp2 --version` (→ `ovp2 2.0.1`).
 
-Targets: `aarch64-apple-darwin`, `x86_64-apple-darwin`,
-`x86_64-unknown-linux-gnu`. An npm wrapper (`npx ovp2` style, binary-download
-shim) is a possible future third channel; skipped for now.
+Prebuilt targets: `aarch64-apple-darwin` (Apple Silicon macOS) and
+`x86_64-unknown-linux-gnu` (Linux x86_64, **glibc ≥ 2.38** — ort's prebuilt
+ONNX Runtime demands it; release builds run on `ubuntu-24.04`, glibc 2.39).
+An npm wrapper (`npx ovp2` style, binary-download shim) is a possible future
+third channel; skipped for now.
+
+**No Intel-mac (`x86_64-apple-darwin`) prebuilt**: the bundled `embed`
+feature pulls in ONNX Runtime, which ships no prebuilt binaries for Intel
+macs (v2.0.0's Intel build failed on exactly that). Intel-mac users build
+from source WITHOUT `embed` (`cargo build --release --features
+anthropic,pinboard-live,web-fetch-live,github-live` — semantic themes then
+degrade gracefully to Unclassified, or run off a warmed embedding cache), or
+use v0.23.0 (the last release with an Intel prebuilt). On
+Linux distros older than glibc 2.38, likewise build from source, omitting
+`embed` if ort's downloaded ONNX Runtime rejects your glibc at link time.
 
 Prebuilt binaries are built with `features = ["anthropic", "pinboard-live",
 "web-fetch-live", "github-live"]`, so `--client live`, `--pinboard-live`, and
@@ -109,7 +121,7 @@ Artifacts are named after the cargo package (`ovp-cli-<target>.tar.xz`,
    version in lockstep); commit via the normal feature-branch → PR flow.
 2. Tag the release commit on `codex/rust-migration` (or `main` post-M32):
    `git tag vX.Y.Z && git push origin vX.Y.Z`.
-3. GitHub Actions (`release.yml`) builds all three targets, the shell
+3. GitHub Actions (`release.yml`) builds both prebuilt targets, the shell
    installer, the `ovp2.rb` formula and checksums, then creates the GitHub
    Release with everything attached. The workflow only triggers on version
    tags — normal pushes and PRs are untouched.


### PR DESCRIPTION
v2.0.0's tag build failed on 2/3 targets:
- **Linux**: ort's prebuilt ONNX Runtime needs glibc ≥ 2.38 (undefined `__isoc23_*` symbols on the default runner) → [dist.github-custom-runners] moves the build to ubuntu-24.04 (glibc 2.39); floor documented in install.md with a build-from-source fallback.
- **Intel mac**: pyke ships no ONNX prebuilts for x86_64-apple-darwin — **operator decision: unsupported**; dropped from the prebuilt matrix (source builds without `embed` remain possible; v0.23.0 was the last Intel prebuilt).

Version → 2.0.1 (dist requires tag == version); CHANGELOG entry added. `dist plan` verified: 2 targets, installer + formula. Gates: 825 tests, clippy -D warnings, arch check. After merge: tag v2.0.1 → artifacts → tap update. The v2.0.0 tag stays as the merge-milestone marker (its release run produced no artifacts).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the application to version 2.0.1.

* **Bug Fixes**
  * Linux prebuilt releases now require glibc 2.38 or newer.
  * Intel Mac prebuilt downloads are no longer available due to platform compatibility limitations.

* **Documentation**
  * Updated installation instructions and supported platform details.
  * Added guidance for Intel Mac users to build from source or use version 0.23.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->