### PR TITLE
feat(crystal): L3 — LLM-shaped synthesis clusters with coverage-first sweep and A/B harness

### DIFF
--- a/crates/ovp-cli/src/commands/crystal_synth.rs
+++ b/crates/ovp-cli/src/commands/crystal_synth.rs
@@ -39,6 +39,17 @@ use crate::commands::{console_cmd, index_cmd};
 
 pub(crate) const MAX_STRENGTH_CLAIMS_PER_CALL: usize = 20;
 
+/// How synthesis inputs are grouped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClusterMode {
+    /// Deterministic ≤cap batches over themes.json communities (or date
+    /// order). The default — current behavior, byte-for-byte unchanged.
+    Batch,
+    /// L3 coverage-first sweep: `cluster_select/v1` proposes one cross-source
+    /// cluster per uncovered seed (or refuses). Needs cached embeddings.
+    Llm,
+}
+
 pub struct CrystalSynthArgs {
     pub reader_dir: Option<PathBuf>,
     pub vault_root: Option<PathBuf>,
@@ -67,16 +78,25 @@ pub struct CrystalSynthArgs {
     /// from synthesis). Default false — overflow is warned + recorded in
     /// warnings.json and the run proceeds on the capped slice.
     pub strict_cluster_cap: bool,
+    /// Batch (default) or the L3 LLM cluster-selection sweep.
+    pub cluster_mode: ClusterMode,
+    /// llm mode: per-run budget cap on `cluster_select/v1` calls.
+    pub max_seeds: usize,
+    /// llm mode: kNN neighborhood size offered alongside each seed.
+    pub neighborhood: usize,
+    /// llm mode: embedding cache root. Default:
+    /// `<vault-root>/.ovp/cache/embeddings` — required (flag or vault root).
+    pub embed_cache_dir: Option<PathBuf>,
 }
 
 /// Resolved paths after applying `--vault-root` precedence.
-struct Resolved {
-    reader_dir: PathBuf,
-    store: PathBuf,
-    cache_dir: PathBuf,
+pub(crate) struct Resolved {
+    pub(crate) reader_dir: PathBuf,
+    pub(crate) store: PathBuf,
+    pub(crate) cache_dir: PathBuf,
 }
 
-fn resolve_paths(args: &CrystalSynthArgs) -> Resolved {
+pub(crate) fn resolve_paths(args: &CrystalSynthArgs) -> Resolved {
     let layout = VaultLayout::new();
     let reader_dir = args
         .reader_dir
@@ -180,7 +200,58 @@ pub(crate) fn call_and_parse<T>(
     }
 }
 
+/// Per-run counters. `run` discards them; the L3 A/B experiment harness
+/// consumes them to build its comparison table.
+#[derive(Debug, Default, Clone, serde::Serialize)]
+pub(crate) struct RunStats {
+    pub mode: String,
+    pub synthesized: usize,
+    pub grounded: usize,
+    pub select_calls: usize,
+    pub synth_calls: usize,
+    pub strength_calls: usize,
+    pub refused: usize,
+    pub guarded: usize,
+    pub failed_seeds: usize,
+    pub durable_considered: usize,
+    pub durable_appended: usize,
+    pub review: usize,
+    /// Distinct-source count of each durable-routed claim (A/B metric).
+    pub durable_distinct_sources: Vec<usize>,
+    pub uncovered_before: Option<usize>,
+    pub uncovered_after: Option<usize>,
+}
+
+/// Distinct-source counts of the claims that route Durable (deterministic
+/// read-only preview over the SAME gate functions the write path uses).
+fn durable_source_counts(
+    grounded: &CrystalCandidate,
+    index: &ovp_domain::crystal::GroundingIndex,
+    verdicts: &[ClaimStrengthVerdict],
+) -> Vec<usize> {
+    use ovp_domain::crystal::{FinalClass, final_routing, lint_candidate, score_candidate};
+    let report = lint_candidate(grounded, index);
+    let scores = score_candidate(&report);
+    let mut out = Vec::new();
+    for item in &grounded.items {
+        let Some(score) = scores.iter().find(|s| s.claim_id == item.id) else {
+            continue;
+        };
+        let verdict = verdicts.iter().find(|v| v.claim_id == item.id);
+        if final_routing(score.class, verdict) == FinalClass::Durable
+            && let Some(lint) = report.claims.iter().find(|c| c.claim_id == item.id)
+        {
+            out.push(lint.distinct_sources);
+        }
+    }
+    out
+}
+
 pub fn run(args: CrystalSynthArgs) -> Result<(), CliError> {
+    run_stats(args).map(|_| ())
+}
+
+pub(crate) fn run_stats(args: CrystalSynthArgs) -> Result<RunStats, CliError> {
     // Validate --refresh prerequisites BEFORE any model calls or store writes,
     // so an invalid flag combination can never partially mutate the ledger.
     if args.refresh && (args.vault_root.is_none() || args.date.is_none()) {
@@ -197,6 +268,25 @@ pub fn run(args: CrystalSynthArgs) -> Result<(), CliError> {
         return Err(CliError::Gate(
             "crystal-synth: --max-units-per-case must be greater than 0".into(),
         ));
+    }
+    if args.cluster_mode == ClusterMode::Llm {
+        if args.max_seeds == 0 {
+            return Err(CliError::Gate(
+                "crystal-synth: --max-seeds must be greater than 0 in llm cluster mode".into(),
+            ));
+        }
+        if args.neighborhood == 0 {
+            return Err(CliError::Gate(
+                "crystal-synth: --neighborhood must be greater than 0 in llm cluster mode".into(),
+            ));
+        }
+        if args.embed_cache_dir.is_none() && args.vault_root.is_none() {
+            return Err(CliError::Io(
+                "crystal-synth: llm cluster mode needs an embedding cache — pass \
+                 --vault-root (uses <vault>/.ovp/cache/embeddings) or --embed-cache-dir"
+                    .into(),
+            ));
+        }
     }
     let paths = resolve_paths(&args);
     std::fs::create_dir_all(&args.work_dir).map_err(|e| {
@@ -226,22 +316,10 @@ pub fn run(args: CrystalSynthArgs) -> Result<(), CliError> {
         Some(p) => ThemesFile::load(p).map_err(|e| CliError::Io(format!("crystal-synth: {e}")))?,
         None => None,
     };
-    let clusters = match &themes {
-        Some(t) => clusters_from_themes(&catalog, t),
-        None => {
-            eprintln!(
-                "crystal-synth: no semantic themes available — run `ovp2 crystal-themes` \
-                 (falling back to deterministic date-ordered batches)"
-            );
-            clusters_date_ordered(&catalog, args.max_cases_per_cluster)
-        }
-    };
 
-    // Surface degraded inputs BEFORE any model call: (1) cases whose title fell
+    // Surface degraded inputs BEFORE any model call: cases whose title fell
     // back to the directory name (no reader.md heading / run-status source) —
-    // embedding text + theme labels degrade; (2) clusters larger than the cap.
-    // Stage 3a no longer excludes the overflow; it records deterministic
-    // sub-batches so full coverage is auditably preserved.
+    // embedding text + theme labels degrade (both modes read titles).
     let fallback_title_cases: Vec<String> = catalog
         .cases
         .iter()
@@ -256,122 +334,257 @@ pub fn run(args: CrystalSynthArgs) -> Result<(), CliError> {
             fallback_title_cases.join(", ")
         );
     }
-    let mut cluster_batching: Vec<serde_json::Value> = Vec::new();
-    for cluster in &clusters {
-        if cluster.cases.len() > args.max_cases_per_cluster {
-            let batches = cluster.cases.len().div_ceil(args.max_cases_per_cluster);
-            eprintln!(
-                "crystal-synth: WARNING: cluster `{}` has {} case(s) but the cap is {} — \
-                 Stage 3a will synthesize all cases across {} deterministic batch(es)",
-                cluster.key,
-                cluster.cases.len(),
-                args.max_cases_per_cluster,
-                batches
-            );
-            cluster_batching.push(serde_json::json!({
-                "cluster": cluster.key,
-                "cases": cluster.cases.len(),
-                "cap": args.max_cases_per_cluster,
-                "batches": batches,
-                "mode": "split_all_cases",
-            }));
-        }
-    }
-    let batches = cluster_batches(&clusters, args.max_cases_per_cluster);
-    // Always written (empty on a clean run), so a rerun in the same work dir
-    // can never leave a stale warning report behind.
-    write_json(
-        &args.work_dir.join("warnings.json"),
-        &serde_json::json!({
-            "fallback_title_cases": fallback_title_cases,
-            "cluster_cap_overflow": [],
-            "cluster_batching": cluster_batching,
-        }),
-    )?;
-    // Stage 3a interprets the strict cap as a per-request invariant, not a
-    // cluster-size gate: every synthesized batch must stay within the cap.
-    if args.strict_cluster_cap
-        && batches
-            .iter()
-            .any(|b| b.cases.len() > args.max_cases_per_cluster)
-    {
-        return Err(CliError::Gate(
-            "crystal-synth: internal error: synthesized batch exceeds strict cluster cap".into(),
-        ));
-    }
-    write_json(&args.work_dir.join("synth-batches.json"), &batches)?;
 
-    // (c) Per-batch cross-source synthesis (model, cassette-replayable). -----
+    // Grounding index over the canonical packs dir — shared by the grounded
+    // filter (both modes) and the L3 routing preview.
+    let index = synth_build_index(&packs_dir).map_err(synth_err)?;
     let mut base = build_client(args.client_kind, &paths.cache_dir)?;
     let mut repairs: Vec<RepairLog> = Vec::new();
-    let mut all_claims: Vec<CrystalClaim> = Vec::new();
-    for batch in &batches {
-        let req = crystal_synth_batch_request(&catalog, batch, args.max_units_per_case);
-        let (claims, log): (Vec<CrystalClaim>, Option<RepairLog>) =
-            call_and_parse(base.as_mut(), &req, "synth", |t| {
-                parse_synth_claims(t, &batch.claim_prefix())
-            })?;
-        if let Some(l) = log {
-            repairs.push(l);
+    let mut stats = RunStats {
+        mode: match args.cluster_mode {
+            ClusterMode::Batch => "batch".to_string(),
+            ClusterMode::Llm => "llm".to_string(),
+        },
+        ..RunStats::default()
+    };
+
+    let (grounded, deduped, verdicts, n_synthesized, n_dropped) = match args.cluster_mode {
+        ClusterMode::Batch => {
+            // (b) Deterministic clusters: semantic communities when available,
+            // else date-ordered cap-size batches. Unchanged Stage 3a behavior.
+            let clusters = match &themes {
+                Some(t) => clusters_from_themes(&catalog, t),
+                None => {
+                    eprintln!(
+                        "crystal-synth: no semantic themes available — run `ovp2 crystal-themes` \
+                         (falling back to deterministic date-ordered batches)"
+                    );
+                    clusters_date_ordered(&catalog, args.max_cases_per_cluster)
+                }
+            };
+            let mut cluster_batching: Vec<serde_json::Value> = Vec::new();
+            for cluster in &clusters {
+                if cluster.cases.len() > args.max_cases_per_cluster {
+                    let batches = cluster.cases.len().div_ceil(args.max_cases_per_cluster);
+                    eprintln!(
+                        "crystal-synth: WARNING: cluster `{}` has {} case(s) but the cap is {} — \
+                         Stage 3a will synthesize all cases across {} deterministic batch(es)",
+                        cluster.key,
+                        cluster.cases.len(),
+                        args.max_cases_per_cluster,
+                        batches
+                    );
+                    cluster_batching.push(serde_json::json!({
+                        "cluster": cluster.key,
+                        "cases": cluster.cases.len(),
+                        "cap": args.max_cases_per_cluster,
+                        "batches": batches,
+                        "mode": "split_all_cases",
+                    }));
+                }
+            }
+            let batches = cluster_batches(&clusters, args.max_cases_per_cluster);
+            // Always written (empty on a clean run), so a rerun in the same work
+            // dir can never leave a stale warning report behind.
+            write_json(
+                &args.work_dir.join("warnings.json"),
+                &serde_json::json!({
+                    "fallback_title_cases": fallback_title_cases,
+                    "cluster_cap_overflow": [],
+                    "cluster_batching": cluster_batching,
+                }),
+            )?;
+            // Stage 3a interprets the strict cap as a per-request invariant, not
+            // a cluster-size gate: every batch must stay within the cap.
+            if args.strict_cluster_cap
+                && batches
+                    .iter()
+                    .any(|b| b.cases.len() > args.max_cases_per_cluster)
+            {
+                return Err(CliError::Gate(
+                    "crystal-synth: internal error: synthesized batch exceeds strict cluster cap"
+                        .into(),
+                ));
+            }
+            write_json(&args.work_dir.join("synth-batches.json"), &batches)?;
+
+            // (c) Per-batch cross-source synthesis (model, cassette-replayable).
+            let mut all_claims: Vec<CrystalClaim> = Vec::new();
+            for batch in &batches {
+                let req = crystal_synth_batch_request(&catalog, batch, args.max_units_per_case);
+                let (claims, log): (Vec<CrystalClaim>, Option<RepairLog>) =
+                    call_and_parse(base.as_mut(), &req, "synth", |t| {
+                        parse_synth_claims(t, &batch.claim_prefix())
+                    })?;
+                if let Some(l) = log {
+                    repairs.push(l);
+                }
+                all_claims.extend(claims);
+            }
+            stats.synth_calls = batches.len();
+            let candidate = CrystalCandidate { items: all_claims };
+            write_json(&args.work_dir.join("candidate.json"), &candidate)?;
+            let n_synthesized = candidate.items.len();
+
+            // (d) Grounded filter — drop ungrounded claims (same linter).
+            let (grounded, dropped) = filter_grounded(&candidate, &index);
+            write_json(
+                &args.work_dir.join("candidate.grounded.pre-dedup.json"),
+                &grounded,
+            )?;
+            let n_dropped = dropped.len();
+            let (grounded, deduped) = dedup_exact_citation_sets(&grounded);
+            write_json(&args.work_dir.join("candidate.grounded.json"), &grounded)?;
+            write_json(&args.work_dir.join("deduped-claims.json"), &deduped)?;
+
+            if grounded.items.is_empty() {
+                return Err(CliError::Gate(format!(
+                    "crystal-synth: no grounded claims survived (synthesized={n_synthesized}, \
+                     dropped_ungrounded={n_dropped}). Nothing to write."
+                )));
+            }
+
+            // (e) Chunked claim-strength verdicts (model, cassette-replayable).
+            let mut verdicts: Vec<ClaimStrengthVerdict> = Vec::new();
+            for (idx, chunk) in grounded
+                .items
+                .chunks(MAX_STRENGTH_CLAIMS_PER_CALL)
+                .enumerate()
+            {
+                let req = strength_request(
+                    &CrystalCandidate {
+                        items: chunk.to_vec(),
+                    },
+                    &catalog,
+                );
+                let stage = format!("strength-b{:03}", idx + 1);
+                let (chunk_verdicts, log): (Vec<ClaimStrengthVerdict>, Option<RepairLog>) =
+                    call_and_parse(base.as_mut(), &req, &stage, parse_strength_verdicts)?;
+                if let Some(l) = log {
+                    repairs.push(l);
+                }
+                verdicts.extend(chunk_verdicts);
+                stats.strength_calls += 1;
+            }
+            write_json(&args.work_dir.join("strength.json"), &verdicts)?;
+
+            // Fail loud on incomplete coverage — a durable write needs 1:1.
+            let claim_ids: Vec<String> = grounded.items.iter().map(|c| c.id.clone()).collect();
+            let coverage = strength_coverage(&claim_ids, &verdicts);
+            if !coverage.complete() {
+                return Err(CliError::Gate(format!(
+                    "crystal-synth: strength verdicts incomplete — missing={:?} duplicate={:?} unknown={:?}. \
+                     A durable write requires exactly one verdict per grounded claim.",
+                    coverage.missing, coverage.duplicate, coverage.unknown
+                )));
+            }
+            println!(
+                "crystal-synth: batch mode: {} case(s) → {} cluster(s), {} synth batch(es)",
+                catalog.cases.len(),
+                clusters.len(),
+                batches.len()
+            );
+            (grounded, deduped, verdicts, n_synthesized, n_dropped)
         }
-        all_claims.extend(claims);
-    }
-    let candidate = CrystalCandidate { items: all_claims };
-    write_json(&args.work_dir.join("candidate.json"), &candidate)?;
-    let n_synthesized = candidate.items.len();
-
-    // (d) Grounded filter — drop ungrounded/defective claims (same linter). --
-    let index = synth_build_index(&packs_dir).map_err(synth_err)?;
-    let (grounded, dropped) = filter_grounded(&candidate, &index);
-    write_json(
-        &args.work_dir.join("candidate.grounded.pre-dedup.json"),
-        &grounded,
-    )?;
-    let n_dropped = dropped.len();
-    let (grounded, deduped) = dedup_exact_citation_sets(&grounded);
-    write_json(&args.work_dir.join("candidate.grounded.json"), &grounded)?;
-    write_json(&args.work_dir.join("deduped-claims.json"), &deduped)?;
-
-    if grounded.items.is_empty() {
-        return Err(CliError::Gate(format!(
-            "crystal-synth: no grounded claims survived (synthesized={n_synthesized}, \
-             dropped_ungrounded={n_dropped}). Nothing to write."
-        )));
-    }
-
-    // (e) Chunked claim-strength verdicts (model, cassette-replayable). ------
-    let mut verdicts: Vec<ClaimStrengthVerdict> = Vec::new();
-    for (idx, chunk) in grounded
-        .items
-        .chunks(MAX_STRENGTH_CLAIMS_PER_CALL)
-        .enumerate()
-    {
-        let req = strength_request(
-            &CrystalCandidate {
-                items: chunk.to_vec(),
-            },
-            &catalog,
-        );
-        let stage = format!("strength-b{:03}", idx + 1);
-        let (chunk_verdicts, log): (Vec<ClaimStrengthVerdict>, Option<RepairLog>) =
-            call_and_parse(base.as_mut(), &req, &stage, parse_strength_verdicts)?;
-        if let Some(l) = log {
-            repairs.push(l);
+        ClusterMode::Llm => {
+            // L3 coverage-first sweep. Only the GROUPING is model-shaped; the
+            // synth prompt, gates, and the durable write are byte-identical.
+            write_json(
+                &args.work_dir.join("warnings.json"),
+                &serde_json::json!({
+                    "fallback_title_cases": fallback_title_cases,
+                    "cluster_cap_overflow": [],
+                    "cluster_batching": [],
+                }),
+            )?;
+            let embed_cache_dir = args
+                .embed_cache_dir
+                .clone()
+                .or_else(|| {
+                    args.vault_root
+                        .as_ref()
+                        .map(|v| v.join(".ovp/cache/embeddings"))
+                })
+                .expect("validated above");
+            let cfg = crate::commands::crystal_synth_llm::SweepConfig {
+                max_seeds: args.max_seeds,
+                neighborhood: args.neighborhood,
+                max_cases_per_cluster: args.max_cases_per_cluster,
+                max_units_per_case: args.max_units_per_case,
+            };
+            let out = crate::commands::crystal_synth_llm::run_sweep(
+                &catalog,
+                &paths.reader_dir,
+                &index,
+                themes.as_ref(),
+                &paths.store,
+                &args.work_dir,
+                &embed_cache_dir,
+                base.as_mut(),
+                &cfg,
+            )?;
+            repairs.extend(out.repairs);
+            stats.select_calls = out.stats.select_calls;
+            stats.synth_calls = out.stats.synth_calls;
+            stats.strength_calls = out.stats.strength_calls;
+            stats.refused = out.stats.refused;
+            stats.guarded = out.stats.guarded;
+            stats.failed_seeds = out.stats.failed;
+            stats.uncovered_before = Some(out.stats.uncovered_before);
+            stats.uncovered_after = Some(out.stats.uncovered_after);
+            write_json(&args.work_dir.join("l3-sweep-stats.json"), &out.stats)?;
+            println!(
+                "crystal-synth: llm sweep: {} uncovered seed(s) → selected={} refused={} \
+                 guarded={} failed={} covered-mid-run={}{}",
+                out.stats.uncovered_before,
+                out.stats.selected,
+                out.stats.refused,
+                out.stats.guarded,
+                out.stats.failed,
+                out.stats.covered_mid_run,
+                if out.stats.budget_exhausted {
+                    " (—max-seeds budget exhausted; rerun to continue)"
+                } else {
+                    ""
+                }
+            );
+            println!(
+                "  coverage: {} → {} uncovered pack(s)",
+                out.stats.uncovered_before, out.stats.uncovered_after
+            );
+            let candidate = CrystalCandidate {
+                items: out.raw_claims,
+            };
+            write_json(&args.work_dir.join("candidate.json"), &candidate)?;
+            let n_synthesized = candidate.items.len();
+            let n_dropped = out.dropped_ungrounded.len();
+            write_json(&args.work_dir.join("candidate.grounded.json"), &out.grounded)?;
+            write_json(&args.work_dir.join("deduped-claims.json"), &out.deduped)?;
+            write_json(&args.work_dir.join("strength.json"), &out.verdicts)?;
+            if out.grounded.items.is_empty() {
+                // Refusals / guards everywhere are a first-class outcome for a
+                // coverage sweep — report and succeed (never a gate failure).
+                println!(
+                    "crystal-synth: llm sweep produced no grounded claims \
+                     (synthesized={n_synthesized}, dropped_ungrounded={n_dropped}) — \
+                     nothing to write. Per-seed outcomes: {}",
+                    args.work_dir.join("l3-sweep.jsonl").display()
+                );
+                stats.synthesized = n_synthesized;
+                return Ok(stats);
+            }
+            (
+                out.grounded,
+                out.deduped,
+                out.verdicts,
+                n_synthesized,
+                n_dropped,
+            )
         }
-        verdicts.extend(chunk_verdicts);
-    }
-    write_json(&args.work_dir.join("strength.json"), &verdicts)?;
-
-    // Fail loud on incomplete coverage — a durable write requires 1:1 verdicts.
-    let claim_ids: Vec<String> = grounded.items.iter().map(|c| c.id.clone()).collect();
-    let coverage = strength_coverage(&claim_ids, &verdicts);
-    if !coverage.complete() {
-        return Err(CliError::Gate(format!(
-            "crystal-synth: strength verdicts incomplete — missing={:?} duplicate={:?} unknown={:?}. \
-             A durable write requires exactly one verdict per grounded claim.",
-            coverage.missing, coverage.duplicate, coverage.unknown
-        )));
-    }
+    };
+    stats.synthesized = n_synthesized;
+    stats.grounded = grounded.items.len();
+    stats.durable_distinct_sources = durable_source_counts(&grounded, &index, &verdicts);
 
     let durable_provenance = count_durable_provenance(&grounded, &index);
 
@@ -394,10 +607,10 @@ pub fn run(args: CrystalSynthArgs) -> Result<(), CliError> {
     // --- Summary (mirrors crystal-write). ---
     println!("crystal-synth: run_id={}", outcome.run_id);
     println!(
-        "  collected: {} case(s) → {} cluster(s), {} synth batch(es)",
+        "  collected: {} case(s), {} synth call(s) [{}]",
         catalog.cases.len(),
-        clusters.len(),
-        batches.len()
+        stats.synth_calls,
+        stats.mode
     );
     println!(
         "  synthesized {n_synthesized} claim(s); dropped_ungrounded={n_dropped}; deduped={}; durable-provenance={durable_provenance}",
@@ -449,7 +662,10 @@ pub fn run(args: CrystalSynthArgs) -> Result<(), CliError> {
         console_cmd::run(console_cmd::ConsoleArgs { vault_root, date })?;
     }
 
-    Ok(())
+    stats.durable_considered = outcome.considered;
+    stats.durable_appended = outcome.appended;
+    stats.review = outcome.review;
+    Ok(stats)
 }
 
 fn write_json<T: serde::Serialize>(path: &std::path::Path, v: &T) -> Result<(), CliError> {
@@ -603,6 +819,10 @@ mod tests {
             date: None,
             strict: false,
             strict_cluster_cap: false,
+            cluster_mode: ClusterMode::Batch,
+            max_seeds: 25,
+            neighborhood: 12,
+            embed_cache_dir: None,
         };
 
         // First run: writes candidate.json + a durable ledger line + crystal.md.
@@ -734,6 +954,10 @@ mod tests {
             date: None,
             strict: false,
             strict_cluster_cap: true,
+            cluster_mode: ClusterMode::Batch,
+            max_seeds: 25,
+            neighborhood: 12,
+            embed_cache_dir: None,
         })
         .expect("split batches run");
 
@@ -807,6 +1031,10 @@ mod tests {
             date: None,
             strict: false,
             strict_cluster_cap: false,
+            cluster_mode: ClusterMode::Batch,
+            max_seeds: 25,
+            neighborhood: 12,
+            embed_cache_dir: None,
         })
         .unwrap_err();
         assert!(
@@ -835,6 +1063,10 @@ mod tests {
             date: None,
             strict: false,
             strict_cluster_cap: false,
+            cluster_mode: ClusterMode::Batch,
+            max_seeds: 25,
+            neighborhood: 12,
+            embed_cache_dir: None,
         }
     }
 

--- a/crates/ovp-cli/src/commands/crystal_synth.rs
+++ b/crates/ovp-cli/src/commands/crystal_synth.rs
@@ -348,7 +348,9 @@ pub(crate) fn run_stats(args: CrystalSynthArgs) -> Result<RunStats, CliError> {
         ..RunStats::default()
     };
 
-    let (grounded, deduped, verdicts, n_synthesized, n_dropped) = match args.cluster_mode {
+    let (grounded, deduped, verdicts, n_synthesized, n_dropped, collected_line) = match args
+        .cluster_mode
+    {
         ClusterMode::Batch => {
             // (b) Deterministic clusters: semantic communities when available,
             // else date-ordered cap-size batches. Unchanged Stage 3a behavior.
@@ -478,13 +480,13 @@ pub(crate) fn run_stats(args: CrystalSynthArgs) -> Result<RunStats, CliError> {
                     coverage.missing, coverage.duplicate, coverage.unknown
                 )));
             }
-            println!(
-                "crystal-synth: batch mode: {} case(s) → {} cluster(s), {} synth batch(es)",
+            let collected_line = format!(
+                "  collected: {} case(s) → {} cluster(s), {} synth batch(es)",
                 catalog.cases.len(),
                 clusters.len(),
                 batches.len()
             );
-            (grounded, deduped, verdicts, n_synthesized, n_dropped)
+            (grounded, deduped, verdicts, n_synthesized, n_dropped, collected_line)
         }
         ClusterMode::Llm => {
             // L3 coverage-first sweep. Only the GROUPING is model-shaped; the
@@ -573,12 +575,20 @@ pub(crate) fn run_stats(args: CrystalSynthArgs) -> Result<RunStats, CliError> {
                 stats.synthesized = n_synthesized;
                 return Ok(stats);
             }
+            let collected_line = format!(
+                "  collected: {} case(s); llm sweep: {} select / {} synth / {} strength call(s)",
+                catalog.cases.len(),
+                out.stats.select_calls,
+                out.stats.synth_calls,
+                out.stats.strength_calls
+            );
             (
                 out.grounded,
                 out.deduped,
                 out.verdicts,
                 n_synthesized,
                 n_dropped,
+                collected_line,
             )
         }
     };
@@ -606,12 +616,7 @@ pub(crate) fn run_stats(args: CrystalSynthArgs) -> Result<RunStats, CliError> {
 
     // --- Summary (mirrors crystal-write). ---
     println!("crystal-synth: run_id={}", outcome.run_id);
-    println!(
-        "  collected: {} case(s), {} synth call(s) [{}]",
-        catalog.cases.len(),
-        stats.synth_calls,
-        stats.mode
-    );
+    println!("{collected_line}");
     println!(
         "  synthesized {n_synthesized} claim(s); dropped_ungrounded={n_dropped}; deduped={}; durable-provenance={durable_provenance}",
         deduped.len()

--- a/crates/ovp-cli/src/commands/crystal_synth.rs
+++ b/crates/ovp-cli/src/commands/crystal_synth.rs
@@ -275,9 +275,24 @@ pub(crate) fn run_stats(args: CrystalSynthArgs) -> Result<RunStats, CliError> {
                 "crystal-synth: --max-seeds must be greater than 0 in llm cluster mode".into(),
             ));
         }
-        if args.neighborhood == 0 {
+        // cluster_select/v1 must accept 3..=cap case ids and the offered set is
+        // seed + neighborhood. Bounds that make every selection unsatisfiable
+        // (cap < 3, or fewer than 2 neighbors offered) would waste the whole
+        // select budget on guaranteed refusals/failures — refuse them up front.
+        if args.max_cases_per_cluster < 3 {
             return Err(CliError::Gate(
-                "crystal-synth: --neighborhood must be greater than 0 in llm cluster mode".into(),
+                "crystal-synth: --max-cases-per-cluster must be at least 3 in llm cluster mode \
+                 (cluster_select/v1 selects 3..=cap case ids; a smaller cap makes every \
+                 selection invalid)"
+                    .into(),
+            ));
+        }
+        if args.neighborhood < 2 {
+            return Err(CliError::Gate(
+                "crystal-synth: --neighborhood must be at least 2 in llm cluster mode \
+                 (each seed is offered seed + neighborhood case ids and a valid cluster \
+                 needs at least 3)"
+                    .into(),
             ));
         }
         if args.embed_cache_dir.is_none() && args.vault_root.is_none() {

--- a/crates/ovp-cli/src/commands/crystal_synth_ab.rs
+++ b/crates/ovp-cli/src/commands/crystal_synth_ab.rs
@@ -184,6 +184,22 @@ pub fn run_experiment(args: ExperimentArgs) -> Result<(), CliError> {
             "crystal-synth: --experiment-slice must be greater than 0".into(),
         ));
     }
+    // Arm B enforces these in run_stats, but by then arm A has already spent
+    // its (possibly live) budget — refuse impossible llm bounds before any arm.
+    if args.max_cases_per_cluster < 3 {
+        return Err(CliError::Gate(
+            "crystal-synth: --experiment needs --max-cases-per-cluster >= 3 \
+             (arm B's cluster_select/v1 selects 3..=cap case ids)"
+                .into(),
+        ));
+    }
+    if args.neighborhood < 2 {
+        return Err(CliError::Gate(
+            "crystal-synth: --experiment needs --neighborhood >= 2 \
+             (arm B offers seed + neighborhood and a valid cluster needs at least 3)"
+                .into(),
+        ));
+    }
     let embed_cache_dir = args
         .embed_cache_dir
         .clone()
@@ -276,6 +292,18 @@ pub fn run_experiment(args: ExperimentArgs) -> Result<(), CliError> {
     write_json(&args.work_dir.join("slice.json"), &slice)?;
 
     // ---- Arms: same packs, fresh stores, separate cassette dirs. ----
+    // The documented live-then-replay workflow reuses the work dir, so each
+    // arm's store must be recreated per run: a leftover ledger would mark the
+    // slice packs covered (arm B skips selection entirely) and contaminate
+    // every yield metric. The cassette dirs are deliberately PRESERVED —
+    // record once with `--client live`, replay offline forever after.
+    for name in ["arm-a", "arm-b"] {
+        let store = args.work_dir.join(name).join("store");
+        if store.exists() {
+            std::fs::remove_dir_all(&store)
+                .map_err(|e| CliError::Io(format!("clearing {}: {e}", store.display())))?;
+        }
+    }
     let arm_args = |mode: ClusterMode, name: &str| CrystalSynthArgs {
         reader_dir: Some(slice_dir.clone()),
         vault_root: None,
@@ -355,11 +383,23 @@ pub fn run_experiment(args: ExperimentArgs) -> Result<(), CliError> {
         "\n  comparison: {}",
         args.work_dir.join("comparison.json").display()
     );
+    // A failed arm is a failed experiment: the diagnostics above (table +
+    // comparison.json with ok=false and the error) are written first, then the
+    // failure propagates so callers/CI never mistake a broken run for data.
+    let mut failures: Vec<String> = Vec::new();
     if let Err(e) = &a {
         eprintln!("crystal-synth: experiment: arm A failed: {e:?}");
+        failures.push(format!("arm A (batch) failed: {e:?}"));
     }
     if let Err(e) = &b {
         eprintln!("crystal-synth: experiment: arm B failed: {e:?}");
+        failures.push(format!("arm B (llm) failed: {e:?}"));
+    }
+    if !failures.is_empty() {
+        return Err(CliError::Gate(format!(
+            "crystal-synth: experiment: {} (see comparison.json for the partial run)",
+            failures.join("; ")
+        )));
     }
     Ok(())
 }
@@ -560,7 +600,7 @@ mod tests {
         let sel_c = cluster_select_request(&digests["2026-06-03_c"], &neighborhood("2026-06-03_c"), 16);
         write_cassette(&cache_b, &sel_c, r#"{"refuse":true,"reason":"no cluster"}"#);
 
-        run_experiment(ExperimentArgs {
+        let mk_args = || ExperimentArgs {
             reader_dir: Some(reader.clone()),
             vault_root: None,
             store: Some(store.clone()),
@@ -574,8 +614,8 @@ mod tests {
             neighborhood: 12,
             max_cases_per_cluster: 16,
             max_units_per_case: 22,
-        })
-        .expect("experiment run");
+        };
+        run_experiment(mk_args()).expect("first experiment run");
 
         // The REAL store was only read — never created/written.
         assert!(!store.join("ledger.jsonl").exists());
@@ -601,6 +641,135 @@ mod tests {
         assert!(work.join("arm-a/store/ledger.jsonl").exists());
         assert!(work.join("arm-b/store/ledger.jsonl").exists());
         assert!(work.join("slice.json").exists());
+
+        // Replay purity: the documented live-then-replay workflow reuses the
+        // SAME work dir. The arm stores from the first run must not leak into
+        // the second (a leftover ledger marks the slice covered → arm B skips
+        // selection and every metric collapses). Same cassettes → the second
+        // run's metrics equal the first's, byte for byte.
+        run_experiment(mk_args()).expect("second experiment run (same work dir)");
+        let comparison2: Vec<serde_json::Value> = serde_json::from_str(
+            &std::fs::read_to_string(work.join("comparison.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            comparison2, comparison,
+            "replaying in the same work dir must reproduce the first run's metrics"
+        );
+    }
+
+    /// Arm A replays to success but arm B has no cassettes: the experiment
+    /// must still write diagnostics (comparison.json with ok=false + error)
+    /// and then PROPAGATE the failure — a broken run is never reported as Ok.
+    #[test]
+    fn failed_arm_propagates_error_after_writing_comparison() {
+        let tmp = tempfile::tempdir().unwrap();
+        let reader = tmp.path().join("reader");
+        let embed = tmp.path().join("embed-cache");
+        let store = tmp.path().join("real-store"); // empty → all uncovered
+        let work = tmp.path().join("work");
+        let cases = [
+            ("2026-06-01_a", "Alpha memory", "Alpha says memory is a scarce budget."),
+            ("2026-06-02_b", "Beta context", "Beta says context is a scarce budget."),
+        ];
+        let vecs: [[f32; 3]; 2] = [[1.0, 0.05, 0.0], [1.0, 0.0, 0.05]];
+        for ((case_id, title, body), v) in cases.iter().zip(vecs) {
+            write_pack(&reader, case_id, title, body);
+            seed_vector(&embed, &reader, case_id, title, v);
+        }
+        let catalog: UnitsCatalog =
+            ovp_domain::crystal::synth::collect_catalog(&reader).unwrap();
+        let ua = catalog.cases["2026-06-01_a"].units[0].unit_id.clone();
+        let ub = catalog.cases["2026-06-02_b"].units[0].unit_id.clone();
+
+        // ---- Arm A cassettes ONLY (arm B's select call will replay-miss). ----
+        let cache_a = work.join("cassettes-arm-a");
+        let clusters = clusters_date_ordered(&catalog, 16);
+        let batches = cluster_batches(&clusters, 16);
+        let synth_a = crystal_synth_batch_request(&catalog, &batches[0], 22);
+        let synth_a_reply = format!(
+            r#"{{"claims":[{{"id":"1","claim":"Alpha and Beta treat capacity as a scarce budget.","theme":"batch","citations":[
+                {{"case_id":"2026-06-01_a","unit_id":"{ua}","quote":"memory is a scarce budget"}},
+                {{"case_id":"2026-06-02_b","unit_id":"{ub}","quote":"context is a scarce budget"}}
+            ]}}]}}"#
+        );
+        write_cassette(&cache_a, &synth_a, &synth_a_reply);
+        let grounded_a = CrystalCandidate {
+            items: parse_synth_claims(&synth_a_reply, &batches[0].claim_prefix()).unwrap(),
+        };
+        write_cassette(
+            &cache_a,
+            &strength_request(&grounded_a, &catalog),
+            &format!(
+                r#"[{{"claim_id":"{}","strength":"supported","evidence_sufficient":true,"rationale":"ok"}}]"#,
+                grounded_a.items[0].id
+            ),
+        );
+
+        let err = run_experiment(ExperimentArgs {
+            reader_dir: Some(reader.clone()),
+            vault_root: None,
+            store: Some(store.clone()),
+            themes_file: None,
+            embed_cache_dir: Some(embed.clone()),
+            work_dir: work.clone(),
+            client_kind: ClientKind::Replay,
+            slice: 2,
+            seed: 42,
+            max_seeds: 0,
+            neighborhood: 12,
+            max_cases_per_cluster: 16,
+            max_units_per_case: 22,
+        })
+        .expect_err("a failed arm must fail the experiment");
+        assert!(matches!(err, CliError::Gate(_)), "{err:?}");
+        let msg = format!("{err:?}");
+        assert!(msg.contains("arm B"), "failure names the failed arm: {msg}");
+
+        // Diagnostics were written BEFORE the failure propagated.
+        let comparison: Vec<serde_json::Value> = serde_json::from_str(
+            &std::fs::read_to_string(work.join("comparison.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(comparison[0]["ok"], true, "{}", comparison[0]);
+        assert_eq!(comparison[1]["ok"], false, "{}", comparison[1]);
+        assert!(
+            !comparison[1]["error"].as_str().unwrap_or_default().is_empty(),
+            "arm B's error is recorded in comparison.json"
+        );
+    }
+
+    /// llm-arm bounds that make every cluster_select/v1 call unsatisfiable
+    /// are refused BEFORE any arm runs (arm A must never spend live budget
+    /// on an experiment whose arm B is doomed by construction).
+    #[test]
+    fn experiment_rejects_impossible_llm_bounds_before_any_arm() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mk = |cap: usize, neigh: usize| ExperimentArgs {
+            reader_dir: Some(tmp.path().join("reader")),
+            vault_root: None,
+            store: Some(tmp.path().join("real-store")),
+            themes_file: None,
+            embed_cache_dir: Some(tmp.path().join("embed-cache")),
+            work_dir: tmp.path().join("work"),
+            client_kind: ClientKind::Replay,
+            slice: 2,
+            seed: 42,
+            max_seeds: 0,
+            neighborhood: neigh,
+            max_cases_per_cluster: cap,
+            max_units_per_case: 22,
+        };
+        let err = run_experiment(mk(2, 12)).expect_err("cap < 3 must be refused");
+        assert!(matches!(err, CliError::Gate(_)), "{err:?}");
+        assert!(format!("{err:?}").contains("max-cases-per-cluster"));
+        let err = run_experiment(mk(16, 1)).expect_err("neighborhood < 2 must be refused");
+        assert!(matches!(err, CliError::Gate(_)), "{err:?}");
+        assert!(format!("{err:?}").contains("neighborhood"));
+        assert!(
+            !tmp.path().join("work").exists(),
+            "refused before creating the work dir or running any arm"
+        );
     }
 
     #[test]

--- a/crates/ovp-cli/src/commands/crystal_synth_ab.rs
+++ b/crates/ovp-cli/src/commands/crystal_synth_ab.rs
@@ -374,6 +374,234 @@ fn write_json<T: serde::Serialize>(path: &Path, v: &T) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeMap;
+
+    use ovp_domain::crystal::CrystalCandidate;
+    use ovp_domain::crystal::select::{CaseDigest, cluster_select_request, digest_from_reader_md};
+    use ovp_domain::crystal::synth::{
+        Cluster, UnitsCatalog, cluster_batches, crystal_synth_batch_request,
+        crystal_synth_request, parse_synth_claims, strength_request,
+    };
+    use ovp_domain::crystal::themes::clusters_date_ordered;
+    use ovp_domain::source_doc::SourceDoc;
+    use ovp_domain::units::{Unit, validate};
+    use ovp_embed::cache as embed_cache;
+    use ovp_embed::{EMBED_DIM, EMBED_HEAD_CHARS, EMBED_MODEL_ID, document_text};
+    use ovp_llm::request_key;
+
+    use crate::commands::crystal_synth_llm::resolve_catalog_vectors;
+    use crate::commands::crystal_themes::clean_reader_body;
+
+    fn write_pack(dir: &Path, case_id: &str, title: &str, body: &str) {
+        let case_dir = dir.join(case_id);
+        std::fs::create_dir_all(&case_dir).unwrap();
+        let raw = vec![serde_json::json!({
+            "kind": "assertion", "text": "t0", "evidence_ref": "p001",
+            "evidence_quote": body, "attribution": "author", "modality": "asserted", "arguments": []
+        })];
+        let ex = validate(
+            &raw,
+            &SourceDoc::article("T", "https://e/x", None, None, vec![], body),
+        );
+        let units: Vec<Unit> = ex.accepted().cloned().collect();
+        std::fs::write(
+            case_dir.join("units.accepted.json"),
+            serde_json::to_string_pretty(&units).unwrap(),
+        )
+        .unwrap();
+        std::fs::write(
+            case_dir.join("reader.md"),
+            format!("# {title}\n\n## 1. Key point  _fact_\n\n{body}\n"),
+        )
+        .unwrap();
+    }
+
+    fn seed_vector(embed_dir: &Path, reader_dir: &Path, case_id: &str, title: &str, v: [f32; 3]) {
+        let md = std::fs::read_to_string(reader_dir.join(case_id).join("reader.md")).unwrap();
+        let text = document_text(title, &clean_reader_body(&md), EMBED_HEAD_CHARS);
+        let sha = embed_cache::text_sha256(&text);
+        let norm = (v.iter().map(|x| x * x).sum::<f32>()).sqrt();
+        let mut full = vec![0.0f32; EMBED_DIM];
+        for (slot, x) in full.iter_mut().zip(v) {
+            *slot = x / norm;
+        }
+        embed_cache::store(embed_dir, &sha, EMBED_MODEL_ID, &full).unwrap();
+    }
+
+    fn write_cassette(cache_dir: &Path, req: &ovp_llm::ModelRequest, reply_text: &str) {
+        let ns = req.cache_namespace.as_deref().unwrap();
+        let dir = cache_dir.join(ns);
+        std::fs::create_dir_all(&dir).unwrap();
+        let reply = ovp_llm::ModelReply {
+            model: "canned".into(),
+            text: reply_text.to_string(),
+            stop_reason: ovp_llm::StopReason::EndTurn,
+            usage: ovp_llm::Usage {
+                input_tokens: 1,
+                output_tokens: 1,
+            },
+        };
+        std::fs::write(
+            dir.join(format!("{}.json", request_key(req))),
+            serde_json::to_string_pretty(&reply).unwrap(),
+        )
+        .unwrap();
+    }
+
+    /// Full replay experiment: three uncovered packs, arm A (one date-ordered
+    /// batch) vs arm B (select→synth→strength + covered + refusal), each from
+    /// its own cassette dir; both arms yield one durable claim.
+    #[test]
+    fn experiment_runs_both_arms_and_writes_comparison() {
+        let tmp = tempfile::tempdir().unwrap();
+        let reader = tmp.path().join("reader");
+        let embed = tmp.path().join("embed-cache");
+        let store = tmp.path().join("real-store"); // empty → all uncovered
+        let work = tmp.path().join("work");
+        let cases = [
+            ("2026-06-01_a", "Alpha memory", "Alpha says memory is a scarce budget."),
+            ("2026-06-02_b", "Beta context", "Beta says context is a scarce budget."),
+            ("2026-06-03_c", "Gamma bounds", "Gamma says retrieval must stay bounded."),
+        ];
+        let vecs: [[f32; 3]; 3] = [[1.0, 0.05, 0.0], [1.0, 0.0, 0.05], [0.9, 0.3, 0.0]];
+        for ((case_id, title, body), v) in cases.iter().zip(vecs) {
+            write_pack(&reader, case_id, title, body);
+            seed_vector(&embed, &reader, case_id, title, v);
+        }
+        let catalog: UnitsCatalog =
+            ovp_domain::crystal::synth::collect_catalog(&reader).unwrap();
+        let ua = catalog.cases["2026-06-01_a"].units[0].unit_id.clone();
+        let ub = catalog.cases["2026-06-02_b"].units[0].unit_id.clone();
+
+        // ---- Arm A cassettes (batch: one date-ordered batch of 3). ----
+        let cache_a = work.join("cassettes-arm-a");
+        let clusters = clusters_date_ordered(&catalog, 16);
+        assert_eq!(clusters.len(), 1);
+        let batches = cluster_batches(&clusters, 16);
+        let synth_a = crystal_synth_batch_request(&catalog, &batches[0], 22);
+        let synth_a_reply = format!(
+            r#"{{"claims":[{{"id":"1","claim":"Alpha and Beta treat capacity as a scarce budget.","theme":"batch","citations":[
+                {{"case_id":"2026-06-01_a","unit_id":"{ua}","quote":"memory is a scarce budget"}},
+                {{"case_id":"2026-06-02_b","unit_id":"{ub}","quote":"context is a scarce budget"}}
+            ]}}]}}"#
+        );
+        write_cassette(&cache_a, &synth_a, &synth_a_reply);
+        let grounded_a = CrystalCandidate {
+            items: parse_synth_claims(&synth_a_reply, &batches[0].claim_prefix()).unwrap(),
+        };
+        write_cassette(
+            &cache_a,
+            &strength_request(&grounded_a, &catalog),
+            &format!(
+                r#"[{{"claim_id":"{}","strength":"supported","evidence_sufficient":true,"rationale":"ok"}}]"#,
+                grounded_a.items[0].id
+            ),
+        );
+
+        // ---- Arm B cassettes (llm sweep). ----
+        let cache_b = work.join("cassettes-arm-b");
+        let vectors = resolve_catalog_vectors(&reader, &catalog, &embed).unwrap();
+        let digests: BTreeMap<String, CaseDigest> = catalog
+            .cases
+            .iter()
+            .map(|(id, case)| {
+                let md = std::fs::read_to_string(reader.join(id).join("reader.md")).unwrap();
+                (id.clone(), digest_from_reader_md(id, &case.title, &md))
+            })
+            .collect();
+        let neighborhood = |seed: &str| -> Vec<CaseDigest> {
+            let mut scored: Vec<(f64, &String)> = vectors
+                .iter()
+                .filter(|(id, _)| id.as_str() != seed)
+                .map(|(id, v)| (ovp_embed::knn::cosine(&vectors[seed], v), id))
+                .collect();
+            scored.sort_by(|(sa, ia), (sb, ib)| {
+                sb.partial_cmp(sa)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+                    .then(ia.cmp(ib))
+            });
+            scored
+                .into_iter()
+                .take(12)
+                .map(|(_, id)| digests[id].clone())
+                .collect()
+        };
+        let sel_a = cluster_select_request(&digests["2026-06-01_a"], &neighborhood("2026-06-01_a"), 16);
+        write_cassette(
+            &cache_b,
+            &sel_a,
+            r#"{"selected_case_ids":["2026-06-01_a","2026-06-02_b","2026-06-03_c"],"rationale":"budget framing"}"#,
+        );
+        let cluster = Cluster {
+            key: "l3-2026-06-01_a".into(),
+            theme: "cross-source".into(),
+            cases: cases.iter().map(|(id, _, _)| (*id).to_string()).collect(),
+        };
+        let synth_b = crystal_synth_request(&catalog, &cluster, 16, 22);
+        let synth_b_reply = format!(
+            r#"{{"claims":[{{"id":"1","claim":"Capacity is treated as a scarce budget across sources.","theme":"cross-source","citations":[
+                {{"case_id":"2026-06-01_a","unit_id":"{ua}","quote":"memory is a scarce budget"}},
+                {{"case_id":"2026-06-02_b","unit_id":"{ub}","quote":"context is a scarce budget"}}
+            ]}}]}}"#
+        );
+        write_cassette(&cache_b, &synth_b, &synth_b_reply);
+        let grounded_b = CrystalCandidate {
+            items: parse_synth_claims(&synth_b_reply, &cluster.key).unwrap(),
+        };
+        write_cassette(
+            &cache_b,
+            &strength_request(&grounded_b, &catalog),
+            &format!(
+                r#"[{{"claim_id":"{}","strength":"supported","evidence_sufficient":true,"rationale":"ok"}}]"#,
+                grounded_b.items[0].id
+            ),
+        );
+        // Seed b gets covered mid-run; seed c refuses.
+        let sel_c = cluster_select_request(&digests["2026-06-03_c"], &neighborhood("2026-06-03_c"), 16);
+        write_cassette(&cache_b, &sel_c, r#"{"refuse":true,"reason":"no cluster"}"#);
+
+        run_experiment(ExperimentArgs {
+            reader_dir: Some(reader.clone()),
+            vault_root: None,
+            store: Some(store.clone()),
+            themes_file: None,
+            embed_cache_dir: Some(embed.clone()),
+            work_dir: work.clone(),
+            client_kind: ClientKind::Replay,
+            slice: 3,
+            seed: 42,
+            max_seeds: 0,
+            neighborhood: 12,
+            max_cases_per_cluster: 16,
+            max_units_per_case: 22,
+        })
+        .expect("experiment run");
+
+        // The REAL store was only read — never created/written.
+        assert!(!store.join("ledger.jsonl").exists());
+        let comparison: Vec<serde_json::Value> = serde_json::from_str(
+            &std::fs::read_to_string(work.join("comparison.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(comparison.len(), 2);
+        let a = &comparison[0];
+        let b = &comparison[1];
+        assert_eq!((a["arm"].as_str(), a["mode"].as_str()), (Some("A"), Some("batch")));
+        assert_eq!(a["ok"], true, "{a}");
+        assert_eq!(a["synth_calls"], 1);
+        assert_eq!(a["durable"], 1);
+        assert_eq!(a["select_calls"], 0);
+        assert_eq!((b["arm"].as_str(), b["mode"].as_str()), (Some("B"), Some("llm")));
+        assert_eq!(b["ok"], true, "{b}");
+        assert_eq!(b["select_calls"], 2, "seed a + seed c (b covered mid-run)");
+        assert_eq!(b["durable"], 1);
+        assert_eq!(b["refusal_rate"], 0.5);
+        assert_eq!(b["mean_distinct_sources_per_durable"], 2.0);
+        // Both arms wrote their own fresh stores.
+        assert!(work.join("arm-a/store/ledger.jsonl").exists());
+        assert!(work.join("arm-b/store/ledger.jsonl").exists());
+        assert!(work.join("slice.json").exists());
+    }
 
     #[test]
     fn seeded_sample_is_deterministic_and_sorted() {

--- a/crates/ovp-cli/src/commands/crystal_synth_ab.rs
+++ b/crates/ovp-cli/src/commands/crystal_synth_ab.rs
@@ -1,0 +1,394 @@
+//! `crystal-synth --experiment` — the L3 A/B harness.
+//!
+//! Given a deterministic, seeded sample of UNCOVERED reader packs (packs not
+//! cited by any ACTIVE durable claim in the real store), materialize the
+//! slice into an isolated packs dir and run BOTH arms against the SAME packs:
+//!
+//!   arm A — `--cluster-mode batch` (current deterministic batching)
+//!   arm B — `--cluster-mode llm`   (L3 coverage-first selection sweep)
+//!
+//! Each arm gets its own work dir, its own FRESH store (yields comparable),
+//! and its own cassette dir — record once with `--client live`, replay
+//! offline forever after. The real vault store is only READ (for the
+//! uncovered set); nothing in the experiment ever writes to it.
+//!
+//! Output: a comparison table on stdout + `<work-dir>/comparison.json` with
+//! durable yield per synth call, gate pass rate, mean distinct sources per
+//! durable claim, refusal rate, and total LLM calls per arm.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use ovp_domain::crystal::CrystalStatus;
+use ovp_domain::crystal::synth::collect_catalog;
+use serde::Serialize;
+
+use crate::CliError;
+use crate::commands::client::ClientKind;
+use crate::commands::crystal_synth::{
+    ClusterMode, CrystalSynthArgs, RunStats, resolve_paths, run_stats,
+};
+use crate::commands::crystal_synth_llm::uncovered_seeds;
+use crate::commands::crystal_write::read_ledger;
+
+pub struct ExperimentArgs {
+    pub reader_dir: Option<PathBuf>,
+    pub vault_root: Option<PathBuf>,
+    pub store: Option<PathBuf>,
+    pub themes_file: Option<PathBuf>,
+    pub embed_cache_dir: Option<PathBuf>,
+    pub work_dir: PathBuf,
+    pub client_kind: ClientKind,
+    /// Sample size (uncovered packs) both arms run against.
+    pub slice: usize,
+    /// Sampling seed (deterministic slice — replays pick the same packs).
+    pub seed: u64,
+    /// Arm B `--max-seeds`; 0 = the slice size (every pack gets a chance).
+    pub max_seeds: usize,
+    pub neighborhood: usize,
+    pub max_cases_per_cluster: usize,
+    pub max_units_per_case: usize,
+}
+
+/// SplitMix64 — the same tiny deterministic generator ovp-embed's Louvain
+/// pins; no rand dependency.
+fn splitmix64(state: &mut u64) -> u64 {
+    *state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    let mut z = *state;
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
+}
+
+/// Seeded Fisher–Yates over the (sorted) input, truncated to `n`, re-sorted.
+/// Deterministic: same items + seed + n → same slice.
+pub(crate) fn seeded_sample(items: &[String], n: usize, seed: u64) -> Vec<String> {
+    let mut v = items.to_vec();
+    v.sort();
+    let mut s = seed;
+    for i in (1..v.len()).rev() {
+        let j = (splitmix64(&mut s) % (i as u64 + 1)) as usize;
+        v.swap(i, j);
+    }
+    v.truncate(n.min(v.len()));
+    v.sort();
+    v
+}
+
+/// One arm's row in the comparison table.
+#[derive(Debug, Serialize)]
+struct ArmReport {
+    arm: &'static str,
+    mode: &'static str,
+    ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+    total_llm_calls: usize,
+    select_calls: usize,
+    synth_calls: usize,
+    strength_calls: usize,
+    synthesized: usize,
+    grounded: usize,
+    durable: usize,
+    review: usize,
+    /// durable claims per synth call (the headline yield metric).
+    durable_yield_per_synth_call: f64,
+    /// durable / synthesized.
+    gate_pass_rate: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mean_distinct_sources_per_durable: Option<f64>,
+    /// refusals / select calls (arm B only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    refusal_rate: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    uncovered_before: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    uncovered_after: Option<usize>,
+}
+
+fn ratio(num: usize, den: usize) -> f64 {
+    if den == 0 { 0.0 } else { num as f64 / den as f64 }
+}
+
+fn arm_report(arm: &'static str, mode: &'static str, result: &Result<RunStats, CliError>) -> ArmReport {
+    match result {
+        Ok(s) => ArmReport {
+            arm,
+            mode,
+            ok: true,
+            error: None,
+            total_llm_calls: s.select_calls + s.synth_calls + s.strength_calls,
+            select_calls: s.select_calls,
+            synth_calls: s.synth_calls,
+            strength_calls: s.strength_calls,
+            synthesized: s.synthesized,
+            grounded: s.grounded,
+            durable: s.durable_distinct_sources.len(),
+            review: s.review,
+            durable_yield_per_synth_call: ratio(s.durable_distinct_sources.len(), s.synth_calls),
+            gate_pass_rate: ratio(s.durable_distinct_sources.len(), s.synthesized),
+            mean_distinct_sources_per_durable: if s.durable_distinct_sources.is_empty() {
+                None
+            } else {
+                Some(
+                    s.durable_distinct_sources.iter().sum::<usize>() as f64
+                        / s.durable_distinct_sources.len() as f64,
+                )
+            },
+            refusal_rate: (s.select_calls > 0).then(|| ratio(s.refused, s.select_calls)),
+            uncovered_before: s.uncovered_before,
+            uncovered_after: s.uncovered_after,
+        },
+        Err(e) => ArmReport {
+            arm,
+            mode,
+            ok: false,
+            error: Some(format!("{e:?}")),
+            total_llm_calls: 0,
+            select_calls: 0,
+            synth_calls: 0,
+            strength_calls: 0,
+            synthesized: 0,
+            grounded: 0,
+            durable: 0,
+            review: 0,
+            durable_yield_per_synth_call: 0.0,
+            gate_pass_rate: 0.0,
+            mean_distinct_sources_per_durable: None,
+            refusal_rate: None,
+            uncovered_before: None,
+            uncovered_after: None,
+        },
+    }
+}
+
+/// Copy one reader pack's product files into the slice dir.
+fn copy_pack(src_root: &Path, dst_root: &Path, case_id: &str) -> Result<(), CliError> {
+    let src = src_root.join(case_id);
+    let dst = dst_root.join(case_id);
+    std::fs::create_dir_all(&dst)
+        .map_err(|e| CliError::Io(format!("creating {}: {e}", dst.display())))?;
+    for name in ["units.accepted.json", "reader.md", "run-status.json"] {
+        let from = src.join(name);
+        if from.exists() {
+            std::fs::copy(&from, dst.join(name))
+                .map_err(|e| CliError::Io(format!("copying {}: {e}", from.display())))?;
+        }
+    }
+    Ok(())
+}
+
+pub fn run_experiment(args: ExperimentArgs) -> Result<(), CliError> {
+    if args.slice == 0 {
+        return Err(CliError::Gate(
+            "crystal-synth: --experiment-slice must be greater than 0".into(),
+        ));
+    }
+    let embed_cache_dir = args
+        .embed_cache_dir
+        .clone()
+        .or_else(|| {
+            args.vault_root
+                .as_ref()
+                .map(|v| v.join(".ovp/cache/embeddings"))
+        })
+        .ok_or_else(|| {
+            CliError::Io(
+                "crystal-synth: --experiment needs an embedding cache for arm B — pass \
+                 --vault-root or --embed-cache-dir"
+                    .into(),
+            )
+        })?;
+    // Resolve the REAL reader dir + store (read-only) through the same
+    // precedence crystal-synth uses.
+    let base = CrystalSynthArgs {
+        reader_dir: args.reader_dir.clone(),
+        vault_root: args.vault_root.clone(),
+        work_dir: args.work_dir.clone(),
+        store: args.store.clone(),
+        themes_file: args.themes_file.clone(),
+        client_kind: args.client_kind,
+        cache_dir: None,
+        max_cases_per_cluster: args.max_cases_per_cluster,
+        max_units_per_case: args.max_units_per_case,
+        run_id: None,
+        title: None,
+        scope: None,
+        not_claiming: None,
+        refresh: false,
+        date: None,
+        strict: false,
+        strict_cluster_cap: false,
+        cluster_mode: ClusterMode::Batch,
+        max_seeds: args.max_seeds,
+        neighborhood: args.neighborhood,
+        embed_cache_dir: Some(embed_cache_dir.clone()),
+    };
+    let paths = resolve_paths(&base);
+    std::fs::create_dir_all(&args.work_dir).map_err(|e| {
+        CliError::Io(format!(
+            "creating work dir {}: {e}",
+            args.work_dir.display()
+        ))
+    })?;
+
+    // The themes projection is optional but shared by both arms when present.
+    let themes_file: Option<PathBuf> = args
+        .themes_file
+        .clone()
+        .or_else(|| {
+            args.vault_root
+                .as_ref()
+                .map(|v| v.join(".ovp/crystal/themes.json"))
+        })
+        .filter(|p| p.exists());
+
+    // ---- Deterministic uncovered slice (real store is only READ). ----
+    let catalog =
+        collect_catalog(&paths.reader_dir).map_err(|e| CliError::Io(format!("crystal-synth: {e}")))?;
+    let events = read_ledger(&paths.store.join("ledger.jsonl"))?;
+    let mut covered: BTreeSet<String> = BTreeSet::new();
+    for r in ovp_domain::crystal::fold_ledger(&events) {
+        if r.status == CrystalStatus::Active {
+            covered.extend(r.source_cases);
+        }
+    }
+    let uncovered = uncovered_seeds(&catalog, &covered);
+    if uncovered.is_empty() {
+        println!("crystal-synth: experiment: no uncovered packs — nothing to compare.");
+        return Ok(());
+    }
+    let slice = seeded_sample(&uncovered, args.slice, args.seed);
+    println!(
+        "crystal-synth: experiment: {} uncovered pack(s) → slice of {} (seed {})",
+        uncovered.len(),
+        slice.len(),
+        args.seed
+    );
+    let slice_dir = args.work_dir.join("slice-packs");
+    if slice_dir.exists() {
+        std::fs::remove_dir_all(&slice_dir)
+            .map_err(|e| CliError::Io(format!("clearing {}: {e}", slice_dir.display())))?;
+    }
+    for case_id in &slice {
+        copy_pack(&paths.reader_dir, &slice_dir, case_id)?;
+    }
+    write_json(&args.work_dir.join("slice.json"), &slice)?;
+
+    // ---- Arms: same packs, fresh stores, separate cassette dirs. ----
+    let arm_args = |mode: ClusterMode, name: &str| CrystalSynthArgs {
+        reader_dir: Some(slice_dir.clone()),
+        vault_root: None,
+        work_dir: args.work_dir.join(name),
+        store: Some(args.work_dir.join(name).join("store")),
+        themes_file: themes_file.clone(),
+        client_kind: args.client_kind,
+        cache_dir: Some(args.work_dir.join(format!("cassettes-{name}"))),
+        max_cases_per_cluster: args.max_cases_per_cluster,
+        max_units_per_case: args.max_units_per_case,
+        run_id: None,
+        title: Some(format!("L3 experiment {name}")),
+        scope: None,
+        not_claiming: None,
+        refresh: false,
+        date: None,
+        strict: false,
+        strict_cluster_cap: false,
+        cluster_mode: mode,
+        max_seeds: if args.max_seeds == 0 {
+            slice.len()
+        } else {
+            args.max_seeds
+        },
+        neighborhood: args.neighborhood,
+        embed_cache_dir: Some(embed_cache_dir.clone()),
+    };
+
+    println!("\n=== arm A (batch) ===");
+    let a = run_stats(arm_args(ClusterMode::Batch, "arm-a"));
+    println!("\n=== arm B (llm) ===");
+    let b = run_stats(arm_args(ClusterMode::Llm, "arm-b"));
+
+    let reports = vec![
+        arm_report("A", "batch", &a),
+        arm_report("B", "llm", &b),
+    ];
+    write_json(&args.work_dir.join("comparison.json"), &reports)?;
+
+    println!("\n=== L3 A/B comparison (slice={}, seed={}) ===", slice.len(), args.seed);
+    println!(
+        "{:<4} {:<6} {:>9} {:>7} {:>6} {:>8} {:>8} {:>8} {:>12} {:>10} {:>10} {:>9}",
+        "arm", "mode", "llm-calls", "select", "synth", "strength", "synth'd", "durable",
+        "yield/synth", "gate-pass", "mean-srcs", "refusal"
+    );
+    for r in &reports {
+        if !r.ok {
+            println!(
+                "{:<4} {:<6} FAILED: {}",
+                r.arm,
+                r.mode,
+                r.error.as_deref().unwrap_or("?")
+            );
+            continue;
+        }
+        println!(
+            "{:<4} {:<6} {:>9} {:>7} {:>6} {:>8} {:>8} {:>8} {:>12.2} {:>10.2} {:>10} {:>9}",
+            r.arm,
+            r.mode,
+            r.total_llm_calls,
+            r.select_calls,
+            r.synth_calls,
+            r.strength_calls,
+            r.synthesized,
+            r.durable,
+            r.durable_yield_per_synth_call,
+            r.gate_pass_rate,
+            r.mean_distinct_sources_per_durable
+                .map(|m| format!("{m:.2}"))
+                .unwrap_or_else(|| "—".into()),
+            r.refusal_rate
+                .map(|m| format!("{m:.2}"))
+                .unwrap_or_else(|| "—".into()),
+        );
+    }
+    println!(
+        "\n  comparison: {}",
+        args.work_dir.join("comparison.json").display()
+    );
+    if let Err(e) = &a {
+        eprintln!("crystal-synth: experiment: arm A failed: {e:?}");
+    }
+    if let Err(e) = &b {
+        eprintln!("crystal-synth: experiment: arm B failed: {e:?}");
+    }
+    Ok(())
+}
+
+fn write_json<T: serde::Serialize>(path: &Path, v: &T) -> Result<(), CliError> {
+    let s = serde_json::to_string_pretty(v)
+        .map_err(|e| CliError::Io(format!("serializing {}: {e}", path.display())))?;
+    std::fs::write(path, format!("{s}\n"))
+        .map_err(|e| CliError::Io(format!("writing {}: {e}", path.display())))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seeded_sample_is_deterministic_and_sorted() {
+        let items: Vec<String> = (0..20).map(|i| format!("case-{i:02}")).collect();
+        let a = seeded_sample(&items, 5, 42);
+        let b = seeded_sample(&items, 5, 42);
+        assert_eq!(a, b, "same seed → same slice");
+        assert_eq!(a.len(), 5);
+        let mut sorted = a.clone();
+        sorted.sort();
+        assert_eq!(a, sorted, "slice is emitted sorted");
+        let c = seeded_sample(&items, 5, 7);
+        assert_ne!(a, c, "different seed → different slice (overwhelmingly)");
+        // n larger than the population → the whole (sorted) population.
+        let all = seeded_sample(&items, 100, 42);
+        assert_eq!(all, items);
+    }
+}

--- a/crates/ovp-cli/src/commands/crystal_synth_llm.rs
+++ b/crates/ovp-cli/src/commands/crystal_synth_llm.rs
@@ -605,6 +605,422 @@ mod tests {
         assert_eq!(all, vec!["near", "near-2", "far"], "k caps, order stable");
     }
 
+    // ---- e2e fixtures: the full `--cluster-mode llm` run over replay
+    // cassettes (no themes file → theme "cross-source"). ----
+
+    use crate::commands::client::ClientKind;
+    use crate::commands::crystal_synth::{ClusterMode, CrystalSynthArgs, run_stats};
+    use crate::commands::crystal_themes::clean_reader_body;
+    use ovp_domain::crystal::synth::collect_catalog;
+    use ovp_domain::source_doc::SourceDoc;
+    use ovp_domain::units::{Unit, validate};
+    use ovp_llm::request_key;
+    use std::path::Path;
+
+    /// Reader pack with real reader.md content (title + one card + body).
+    fn write_pack(dir: &Path, case_id: &str, title: &str, body: &str, quotes: &[&str]) {
+        let case_dir = dir.join(case_id);
+        std::fs::create_dir_all(&case_dir).unwrap();
+        let raw: Vec<_> = quotes
+            .iter()
+            .enumerate()
+            .map(|(i, q)| {
+                serde_json::json!({
+                    "kind": "assertion", "text": format!("t{i}"), "evidence_ref": "p001",
+                    "evidence_quote": q, "attribution": "author", "modality": "asserted", "arguments": []
+                })
+            })
+            .collect();
+        let ex = validate(
+            &raw,
+            &SourceDoc::article("T", "https://e/x", None, None, vec![], body),
+        );
+        let units: Vec<Unit> = ex.accepted().cloned().collect();
+        std::fs::write(
+            case_dir.join("units.accepted.json"),
+            serde_json::to_string_pretty(&units).unwrap(),
+        )
+        .unwrap();
+        std::fs::write(
+            case_dir.join("reader.md"),
+            format!("# {title}\n\n## 1. Key point of {title}  _fact_\n\n{body}\n"),
+        )
+        .unwrap();
+    }
+
+    /// Seed the embedding cache with a normalized EMBED_DIM vector for a
+    /// pack, keyed by the EXACT text derivation the sweep uses.
+    fn seed_vector(embed_dir: &Path, reader_dir: &Path, case_id: &str, title: &str, v: [f32; 3]) {
+        let md = std::fs::read_to_string(reader_dir.join(case_id).join("reader.md")).unwrap();
+        let text = document_text(title, &clean_reader_body(&md), EMBED_HEAD_CHARS);
+        let sha = embed_cache::text_sha256(&text);
+        let norm = (v.iter().map(|x| x * x).sum::<f32>()).sqrt();
+        let mut full = vec![0.0f32; EMBED_DIM];
+        for (slot, x) in full.iter_mut().zip(v) {
+            *slot = x / norm;
+        }
+        embed_cache::store(embed_dir, &sha, EMBED_MODEL_ID, &full).unwrap();
+    }
+
+    fn write_cassette(cache_dir: &Path, req: &ovp_llm::ModelRequest, reply_text: &str) {
+        let ns = req.cache_namespace.as_deref().unwrap();
+        let dir = cache_dir.join(ns);
+        std::fs::create_dir_all(&dir).unwrap();
+        let reply = ovp_llm::ModelReply {
+            model: "canned".into(),
+            text: reply_text.to_string(),
+            stop_reason: ovp_llm::StopReason::EndTurn,
+            usage: ovp_llm::Usage {
+                input_tokens: 1,
+                output_tokens: 1,
+            },
+        };
+        std::fs::write(
+            dir.join(format!("{}.json", request_key(req))),
+            serde_json::to_string_pretty(&reply).unwrap(),
+        )
+        .unwrap();
+    }
+
+    fn llm_args(reader: &Path, work: &Path, embed: &Path) -> CrystalSynthArgs {
+        CrystalSynthArgs {
+            reader_dir: Some(reader.to_path_buf()),
+            vault_root: None,
+            work_dir: work.to_path_buf(),
+            store: Some(work.join("store")),
+            themes_file: None,
+            client_kind: ClientKind::Replay,
+            cache_dir: Some(work.join("cassettes")),
+            max_cases_per_cluster: 16,
+            max_units_per_case: 22,
+            run_id: None,
+            title: Some("L3 Test".into()),
+            scope: None,
+            not_claiming: None,
+            refresh: false,
+            date: None,
+            strict: false,
+            strict_cluster_cap: false,
+            cluster_mode: ClusterMode::Llm,
+            max_seeds: 25,
+            neighborhood: 12,
+            embed_cache_dir: Some(embed.to_path_buf()),
+        }
+    }
+
+    /// The four-pack corpus every e2e test uses: a/b/c near one another, d
+    /// off-axis. Returns (reader_dir, embed_dir) under `root`.
+    const CASES: [(&str, &str, &str); 4] = [
+        (
+            "2026-06-01_a",
+            "Alpha memory systems",
+            "Alpha says agent memory is a scarce budget.",
+        ),
+        (
+            "2026-06-02_b",
+            "Beta context budgets",
+            "Beta says the context window is a scarce budget.",
+        ),
+        (
+            "2026-06-03_c",
+            "Gamma retrieval bounds",
+            "Gamma says retrieval must stay bounded.",
+        ),
+        (
+            "2026-06-04_d",
+            "Delta gardening notes",
+            "Delta says tomatoes need regular watering.",
+        ),
+    ];
+
+    fn seed_corpus(root: &Path) -> (std::path::PathBuf, std::path::PathBuf) {
+        let reader = root.join("reader");
+        let embed = root.join("embed-cache");
+        let vecs: [[f32; 3]; 4] = [
+            [1.0, 0.05, 0.0],
+            [1.0, 0.0, 0.05],
+            [0.9, 0.3, 0.0],
+            [0.0, 0.0, 1.0],
+        ];
+        for ((case_id, title, body), v) in CASES.iter().zip(vecs) {
+            write_pack(&reader, case_id, title, body, &[body]);
+            seed_vector(&embed, &reader, case_id, title, v);
+        }
+        (reader, embed)
+    }
+
+    /// Build the exact select request the sweep will issue for `seed`.
+    fn select_request_for(
+        reader: &Path,
+        embed: &Path,
+        catalog: &UnitsCatalog,
+        seed: &str,
+    ) -> ovp_llm::ModelRequest {
+        let vectors = resolve_catalog_vectors(reader, catalog, embed).unwrap();
+        let digests: BTreeMap<String, CaseDigest> = catalog
+            .cases
+            .iter()
+            .map(|(id, case)| {
+                let md =
+                    std::fs::read_to_string(reader.join(id).join("reader.md")).unwrap_or_default();
+                (id.clone(), digest_from_reader_md(id, &case.title, &md))
+            })
+            .collect();
+        let neighbor_ids = neighborhood_of(seed, &vectors, 12);
+        let neighbor_digests: Vec<CaseDigest> =
+            neighbor_ids.iter().map(|id| digests[id].clone()).collect();
+        cluster_select_request(&digests[seed], &neighbor_digests, 16)
+    }
+
+    #[test]
+    fn llm_e2e_selects_refuses_fails_and_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (reader, embed) = seed_corpus(tmp.path());
+        let work = tmp.path().join("work");
+        std::fs::create_dir_all(&work).unwrap();
+        let cache = work.join("cassettes");
+        let catalog = collect_catalog(&reader).unwrap();
+
+        // Seed a: selection [a, b, c] → synth → one claim citing a+b →
+        // durable → covers a and b mid-run.
+        let sel_a = select_request_for(&reader, &embed, &catalog, "2026-06-01_a");
+        write_cassette(
+            &cache,
+            &sel_a,
+            r#"{"selected_case_ids":["2026-06-01_a","2026-06-02_b","2026-06-03_c"],"rationale":"scarce-budget framing across sources"}"#,
+        );
+        let cluster = Cluster {
+            key: "l3-2026-06-01_a".into(),
+            theme: "cross-source".into(),
+            cases: vec![
+                "2026-06-01_a".into(),
+                "2026-06-02_b".into(),
+                "2026-06-03_c".into(),
+            ],
+        };
+        let synth_req = crystal_synth_request(&catalog, &cluster, 16, 22);
+        let ua = catalog.cases["2026-06-01_a"].units[0].unit_id.clone();
+        let ub = catalog.cases["2026-06-02_b"].units[0].unit_id.clone();
+        let synth_reply = format!(
+            r#"{{"claims":[{{"id":"1","claim":"Alpha and Beta both treat capacity as a scarce budget.","theme":"cross-source","citations":[
+                {{"case_id":"2026-06-01_a","unit_id":"{ua}","quote":"memory is a scarce budget"}},
+                {{"case_id":"2026-06-02_b","unit_id":"{ub}","quote":"context window is a scarce budget"}}
+            ]}}]}}"#
+        );
+        write_cassette(&cache, &synth_req, &synth_reply);
+        let grounded = CrystalCandidate {
+            items: parse_synth_claims(&synth_reply, &cluster.key).unwrap(),
+        };
+        let strength_req = strength_request(&grounded, &catalog);
+        write_cassette(
+            &cache,
+            &strength_req,
+            &format!(
+                r#"[{{"claim_id":"{}","strength":"supported","evidence_sufficient":true,"rationale":"both quotes state a scarce budget"}}]"#,
+                grounded.items[0].id
+            ),
+        );
+        // Seed b is covered mid-run (no cassette needed). Seed c: refusal.
+        let sel_c = select_request_for(&reader, &embed, &catalog, "2026-06-03_c");
+        write_cassette(
+            &cache,
+            &sel_c,
+            r#"{"refuse":true,"reason":"neighborhood is topically scattered"}"#,
+        );
+        // Seed d: a selection VIOLATION (id outside the offered set).
+        let sel_d = select_request_for(&reader, &embed, &catalog, "2026-06-04_d");
+        write_cassette(
+            &cache,
+            &sel_d,
+            r#"{"selected_case_ids":["2026-06-04_d","bogus-case","another-bogus"],"rationale":"?"}"#,
+        );
+
+        let stats = run_stats(llm_args(&reader, &work, &embed)).expect("first llm run");
+        assert_eq!(stats.mode, "llm");
+        assert_eq!(stats.select_calls, 3, "a, c, d (b covered mid-run)");
+        assert_eq!(stats.synth_calls, 1);
+        assert_eq!(stats.strength_calls, 1);
+        assert_eq!(stats.refused, 1);
+        assert_eq!(stats.failed_seeds, 1);
+        assert_eq!(stats.durable_appended, 1);
+        assert_eq!(stats.durable_distinct_sources, vec![2]);
+        assert_eq!(stats.uncovered_before, Some(4));
+        assert_eq!(
+            stats.uncovered_after,
+            Some(2),
+            "a+b covered by the new durable claim; c, d remain"
+        );
+
+        // Per-seed outcomes: one line each, in sweep order.
+        let jsonl = std::fs::read_to_string(work.join("l3-sweep.jsonl")).unwrap();
+        let lines: Vec<serde_json::Value> = jsonl
+            .lines()
+            .map(|l| serde_json::from_str(l).unwrap())
+            .collect();
+        let outcomes: Vec<(&str, &str)> = lines
+            .iter()
+            .map(|v| {
+                (
+                    v["seed"].as_str().unwrap(),
+                    v["outcome"].as_str().unwrap(),
+                )
+            })
+            .collect();
+        assert_eq!(
+            outcomes,
+            vec![
+                ("2026-06-01_a", "selected"),
+                ("2026-06-02_b", "covered"),
+                ("2026-06-03_c", "refused"),
+                ("2026-06-04_d", "failed"),
+            ]
+        );
+        assert!(lines[3]["error"].as_str().unwrap().contains("bogus-case"));
+        assert!(work.join("l3-sweep-stats.json").exists());
+        assert!(work.join("candidate.json").exists());
+
+        let ledger = std::fs::read_to_string(work.join("store/ledger.jsonl")).unwrap();
+        assert_eq!(ledger.lines().filter(|l| !l.trim().is_empty()).count(), 1);
+
+        // Second run: a+b now covered BY THE LEDGER → only c and d sweep;
+        // both replay to refusal/violation → 0 new ledger lines (idempotent).
+        let stats2 = run_stats(llm_args(&reader, &work, &embed)).expect("second llm run");
+        assert_eq!(stats2.uncovered_before, Some(2));
+        assert_eq!(stats2.select_calls, 2);
+        assert_eq!(stats2.synth_calls, 0, "no synth spend on a rerun");
+        assert_eq!(stats2.durable_appended, 0, "re-run adds nothing");
+        let ledger2 = std::fs::read_to_string(work.join("store/ledger.jsonl")).unwrap();
+        assert_eq!(ledger2.lines().filter(|l| !l.trim().is_empty()).count(), 1);
+    }
+
+    #[test]
+    fn superset_guard_blocks_before_the_synth_spend() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (reader, embed) = seed_corpus(tmp.path());
+        let work = tmp.path().join("work");
+        std::fs::create_dir_all(&work).unwrap();
+        let cache = work.join("cassettes");
+        let catalog = collect_catalog(&reader).unwrap();
+
+        // Pre-existing ACTIVE durable claim citing b, c, d → only a uncovered.
+        let store = work.join("store");
+        std::fs::create_dir_all(&store).unwrap();
+        let record = ovp_domain::crystal::DurableRecord {
+            claim_key: "ck-preexisting-000".into(),
+            claim_id: "old-1".into(),
+            claim: "b, c and d already synthesized".into(),
+            theme: "t".into(),
+            source_cases: vec![
+                "2026-06-02_b".into(),
+                "2026-06-03_c".into(),
+                "2026-06-04_d".into(),
+            ],
+            citations: vec![],
+            provenance_score: 0.9,
+            provenance_class: ovp_domain::crystal::ProvenanceClass::Durable,
+            strength: ovp_domain::crystal::StrengthClass::Supported,
+            strength_rationale: "r".into(),
+            final_class: FinalClass::Durable,
+            run_id: "run-old".into(),
+            status: CrystalStatus::Active,
+        };
+        let event = ovp_domain::crystal::StoreEvent {
+            op: ovp_domain::crystal::StoreOp::Write,
+            record,
+            supersedes: None,
+            reason: None,
+        };
+        std::fs::write(
+            store.join("ledger.jsonl"),
+            format!("{}\n", serde_json::to_string(&event).unwrap()),
+        )
+        .unwrap();
+
+        // Seed a's selection EXCLUDES the seed and re-picks the covered trio —
+        // exactly the case the guard exists for. No synth cassette exists, so
+        // reaching synthesis would fail the test loudly.
+        let sel_a = select_request_for(&reader, &embed, &catalog, "2026-06-01_a");
+        write_cassette(
+            &cache,
+            &sel_a,
+            r#"{"selected_case_ids":["2026-06-02_b","2026-06-03_c","2026-06-04_d"],"rationale":"the trio clusters"}"#,
+        );
+
+        let stats = run_stats(llm_args(&reader, &work, &embed)).expect("guarded run succeeds");
+        assert_eq!(stats.guarded, 1);
+        assert_eq!(stats.synth_calls, 0, "guard fires BEFORE the synth spend");
+        assert_eq!(stats.durable_appended, 0);
+        let jsonl = std::fs::read_to_string(work.join("l3-sweep.jsonl")).unwrap();
+        let line: serde_json::Value = serde_json::from_str(jsonl.lines().next().unwrap()).unwrap();
+        assert_eq!(line["outcome"], "guarded");
+        assert_eq!(line["guarded_by"], "ck-preexisting-000");
+        let ledger = std::fs::read_to_string(store.join("ledger.jsonl")).unwrap();
+        assert_eq!(
+            ledger.lines().filter(|l| !l.trim().is_empty()).count(),
+            1,
+            "ledger untouched"
+        );
+    }
+
+    #[test]
+    fn max_seeds_budget_caps_select_calls() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (reader, embed) = seed_corpus(tmp.path());
+        let work = tmp.path().join("work");
+        std::fs::create_dir_all(&work).unwrap();
+        let cache = work.join("cassettes");
+        let catalog = collect_catalog(&reader).unwrap();
+        // Only the FIRST seed gets a cassette; with --max-seeds 1 the sweep
+        // must stop before ever asking about the others.
+        let sel_a = select_request_for(&reader, &embed, &catalog, "2026-06-01_a");
+        write_cassette(&cache, &sel_a, r#"{"refuse":true,"reason":"nothing here"}"#);
+        let mut args = llm_args(&reader, &work, &embed);
+        args.max_seeds = 1;
+        let stats = run_stats(args).expect("budgeted run");
+        assert_eq!(stats.select_calls, 1);
+        assert_eq!(stats.refused, 1);
+        let sweep_stats: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(work.join("l3-sweep-stats.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(sweep_stats["budget_exhausted"], true);
+        assert_eq!(sweep_stats["uncovered_after"], 4, "nothing got covered");
+    }
+
+    #[cfg(not(feature = "embed"))]
+    #[test]
+    fn llm_mode_without_embeddings_fails_with_clear_remedy() {
+        let tmp = tempfile::tempdir().unwrap();
+        let reader = tmp.path().join("reader");
+        write_pack(
+            &reader,
+            "2026-06-01_a",
+            "Alpha",
+            "Alpha says memory is scarce.",
+            &["Alpha says memory is scarce."],
+        );
+        let work = tmp.path().join("work");
+        std::fs::create_dir_all(&work).unwrap();
+        // Empty embedding cache + no embed feature → loud, actionable error
+        // (llm mode is meaningless without neighborhoods — no graceful skip).
+        let err = run_stats(llm_args(&reader, &work, &tmp.path().join("empty-cache")))
+            .expect_err("must fail loud");
+        let msg = format!("{err:?}");
+        assert!(msg.contains("crystal-themes"), "remedy named: {msg}");
+        assert!(msg.contains("embed"), "{msg}");
+    }
+
+    #[test]
+    fn llm_mode_needs_vault_root_or_embed_cache_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let reader = tmp.path().join("reader");
+        let work = tmp.path().join("work");
+        let mut args = llm_args(&reader, &work, Path::new("unused"));
+        args.embed_cache_dir = None; // and vault_root is None
+        let err = run_stats(args).expect_err("must fail before any IO");
+        assert!(format!("{err:?}").contains("--embed-cache-dir"));
+    }
+
     #[test]
     fn cluster_theme_uses_seed_community_keywords_never_labels() {
         use ovp_domain::crystal::themes::{

--- a/crates/ovp-cli/src/commands/crystal_synth_llm.rs
+++ b/crates/ovp-cli/src/commands/crystal_synth_llm.rs
@@ -1,0 +1,639 @@
+//! `crystal-synth --cluster-mode llm` — the L3 coverage-first sweep.
+//!
+//!   uncovered packs (not cited by any ACTIVE durable claim), case_id order
+//!     → seed's kNN neighborhood from cached embeddings (cross-community)
+//!     → `cluster_select/v1`: pick 3..cap case ids for ONE claim-worthy
+//!       cross-source cluster, or REFUSE (a first-class answer)
+//!     → mechanical selection validation (offered set, ≥3, ≤cap) — a
+//!       violation fails THAT seed loudly (recorded) and the sweep continues
+//!     → superset guard: an active claim whose source_cases ⊇ the chosen set
+//!       skips the synth call; ditto a cluster already attempted this run
+//!     → EXISTING `crystal_synth/v1` + grounded filter + dedup + strength —
+//!       completely unchanged; gates and the ledger cannot drift
+//!     → seeds covered by claims routed durable this run drop out mid-sweep.
+//!
+//! Per-seed outcomes go to stdout AND `<work-dir>/l3-sweep.jsonl` (written
+//! incrementally, so even a failed run leaves evidence). The sweep only
+//! PROPOSES groupings — every claim still passes the untouched citation +
+//! provenance + strength gates before the idempotent durable write.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::io::Write as _;
+use std::path::Path;
+
+use ovp_domain::crystal::select::{
+    CaseDigest, ClusterSelection, cluster_select_request, digest_from_reader_md,
+    parse_cluster_selection, validate_selection,
+};
+use ovp_domain::crystal::synth::{
+    Cluster, UnitsCatalog, citation_signature, crystal_synth_request, parse_synth_claims,
+    parse_strength_verdicts, strength_request,
+};
+use ovp_domain::crystal::themes::ThemesFile;
+use ovp_domain::crystal::{
+    ClaimStrengthVerdict, CrystalCandidate, CrystalClaim, CrystalStatus, FinalClass,
+    GroundingIndex, final_routing, lint_candidate, score_candidate, strength_coverage,
+};
+use ovp_embed::cache as embed_cache;
+use ovp_embed::knn::cosine;
+use ovp_embed::{EMBED_DIM, EMBED_HEAD_CHARS, EMBED_MODEL_ID, document_text};
+use ovp_llm::ModelClient;
+use serde::Serialize;
+
+use crate::CliError;
+use crate::commands::crystal_synth::{RepairLog, call_and_parse};
+use crate::commands::crystal_themes::clean_reader_body;
+use crate::commands::crystal_write::read_ledger;
+
+/// Fallback synthesis-context theme when the seed maps to no community.
+const FALLBACK_THEME: &str = "cross-source";
+
+/// Sweep knobs (all operator-visible flags).
+pub(crate) struct SweepConfig {
+    /// Per-run LLM budget cap: at most this many `cluster_select/v1` calls.
+    pub max_seeds: usize,
+    /// kNN neighborhood size offered alongside the seed.
+    pub neighborhood: usize,
+    /// Cluster size cap (shared with batch mode's per-request cap).
+    pub max_cases_per_cluster: usize,
+    pub max_units_per_case: usize,
+}
+
+/// Sweep counters, serialized into the run report.
+#[derive(Debug, Default, Clone, Serialize)]
+pub(crate) struct SweepStats {
+    pub uncovered_before: usize,
+    pub uncovered_after: usize,
+    pub selected: usize,
+    pub refused: usize,
+    pub guarded: usize,
+    pub failed: usize,
+    pub covered_mid_run: usize,
+    /// True when `max_seeds` ran out with uncovered seeds still unattempted.
+    pub budget_exhausted: bool,
+    pub select_calls: usize,
+    pub synth_calls: usize,
+    pub strength_calls: usize,
+}
+
+/// Everything the shared crystal-synth tail (durable write + summary) needs.
+pub(crate) struct SweepOutcome {
+    /// Every claim the synth stage emitted (pre-gate) — `candidate.json`.
+    pub raw_claims: Vec<CrystalClaim>,
+    /// Grounded + deduped claims, accumulated across clusters.
+    pub grounded: CrystalCandidate,
+    pub verdicts: Vec<ClaimStrengthVerdict>,
+    pub deduped: Vec<ovp_domain::crystal::synth::DedupedClaim>,
+    pub dropped_ungrounded: Vec<String>,
+    pub stats: SweepStats,
+    pub repairs: Vec<RepairLog>,
+}
+
+/// One line of `l3-sweep.jsonl`.
+#[derive(Debug, Serialize)]
+struct SeedReport<'a> {
+    seed: &'a str,
+    outcome: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    selected: Option<&'a [String]>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rationale: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    guarded_by: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    claims: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    grounded: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    durable_routed: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    newly_covered: Option<Vec<String>>,
+}
+
+impl<'a> SeedReport<'a> {
+    fn new(seed: &'a str, outcome: &'static str) -> Self {
+        SeedReport {
+            seed,
+            outcome,
+            selected: None,
+            rationale: None,
+            reason: None,
+            error: None,
+            guarded_by: None,
+            claims: None,
+            grounded: None,
+            durable_routed: None,
+            newly_covered: None,
+        }
+    }
+}
+
+/// Resolve one embedding vector per catalog case from the content-addressed
+/// cache (the SAME text derivation `crystal-themes` uses, so a themes run
+/// warms this sweep). Missing vectors are embedded when the build carries the
+/// `embed` feature; otherwise the run fails with a clear remedy — llm cluster
+/// mode is meaningless without neighborhoods, so there is NO graceful skip
+/// here (unlike `crystal-themes`' degradation contract).
+pub(crate) fn resolve_catalog_vectors(
+    reader_dir: &Path,
+    catalog: &UnitsCatalog,
+    embed_cache_dir: &Path,
+) -> Result<BTreeMap<String, Vec<f32>>, CliError> {
+    let mut texts: BTreeMap<String, String> = BTreeMap::new();
+    for (case_id, case) in &catalog.cases {
+        let body = std::fs::read_to_string(reader_dir.join(case_id).join("reader.md"))
+            .unwrap_or_default();
+        texts.insert(
+            case_id.clone(),
+            document_text(&case.title, &clean_reader_body(&body), EMBED_HEAD_CHARS),
+        );
+    }
+    let mut vectors: BTreeMap<String, Vec<f32>> = BTreeMap::new();
+    let mut missing: Vec<&String> = Vec::new();
+    for (case_id, text) in &texts {
+        let sha = embed_cache::text_sha256(text);
+        match embed_cache::load(embed_cache_dir, &sha, EMBED_MODEL_ID, EMBED_DIM) {
+            Some(v) => {
+                vectors.insert(case_id.clone(), v);
+            }
+            None => missing.push(case_id),
+        }
+    }
+    if !missing.is_empty() {
+        embed_and_cache(&texts, &missing, embed_cache_dir, &mut vectors)?;
+    }
+    Ok(vectors)
+}
+
+#[cfg(feature = "embed")]
+fn embed_and_cache(
+    texts: &BTreeMap<String, String>,
+    missing: &[&String],
+    embed_cache_dir: &Path,
+    vectors: &mut BTreeMap<String, Vec<f32>>,
+) -> Result<(), CliError> {
+    eprintln!(
+        "crystal-synth: embedding {} pack(s) with {EMBED_MODEL_ID} for llm cluster mode",
+        missing.len()
+    );
+    let mut embedder = ovp_embed::embedder::Embedder::new(true).map_err(|e| {
+        CliError::Io(format!(
+            "crystal-synth: llm cluster mode needs the embedding model but it is \
+             unavailable ({e}). Warm the cache first: `ovp2 crystal-themes --vault-root ...` \
+             (embed-enabled build, online once)."
+        ))
+    })?;
+    let batch_texts: Vec<String> = missing.iter().map(|id| texts[id.as_str()].clone()).collect();
+    let mut out = Vec::with_capacity(batch_texts.len());
+    for chunk in batch_texts.chunks(64) {
+        let batch = embedder
+            .embed(chunk)
+            .map_err(|e| CliError::Io(format!("crystal-synth: embedding: {e}")))?;
+        out.extend(batch);
+    }
+    for (id, vector) in missing.iter().zip(out) {
+        let sha = embed_cache::text_sha256(&texts[id.as_str()]);
+        embed_cache::store(embed_cache_dir, &sha, EMBED_MODEL_ID, &vector)
+            .map_err(|e| CliError::Io(format!("crystal-synth: embedding cache: {e}")))?;
+        vectors.insert((*id).clone(), vector);
+    }
+    Ok(())
+}
+
+#[cfg(not(feature = "embed"))]
+fn embed_and_cache(
+    _texts: &BTreeMap<String, String>,
+    missing: &[&String],
+    embed_cache_dir: &Path,
+    _vectors: &mut BTreeMap<String, Vec<f32>>,
+) -> Result<(), CliError> {
+    Err(CliError::Io(format!(
+        "crystal-synth: llm cluster mode needs cached embeddings for every reader \
+         pack, but {} pack(s) have none under {} and this build lacks the `embed` \
+         feature. Warm the cache first (`ovp2 crystal-themes --vault-root ...` with \
+         an embed-enabled build) or rebuild with `--features embed`.",
+        missing.len(),
+        embed_cache_dir.display()
+    )))
+}
+
+/// The coverage-first seed order: catalog cases not cited by any ACTIVE
+/// durable claim, ascending case_id (BTreeMap order — deterministic).
+pub(crate) fn uncovered_seeds(catalog: &UnitsCatalog, covered: &BTreeSet<String>) -> Vec<String> {
+    catalog
+        .cases
+        .keys()
+        .filter(|id| !covered.contains(*id))
+        .cloned()
+        .collect()
+}
+
+/// Top-`k` neighbors of `seed` by cosine (desc; ties by ascending case_id).
+/// Cross-community by construction — the neighborhood never consults themes.
+fn neighborhood_of(
+    seed: &str,
+    vectors: &BTreeMap<String, Vec<f32>>,
+    k: usize,
+) -> Vec<String> {
+    let Some(sv) = vectors.get(seed) else {
+        return Vec::new();
+    };
+    let mut scored: Vec<(f64, &String)> = vectors
+        .iter()
+        .filter(|(id, _)| id.as_str() != seed)
+        .map(|(id, v)| (cosine(sv, v), id))
+        .collect();
+    scored.sort_by(|(sa, ia), (sb, ib)| {
+        sb.partial_cmp(sa)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(ia.cmp(ib))
+    });
+    scored.into_iter().take(k).map(|(_, id)| id.clone()).collect()
+}
+
+/// Synthesis-context theme for an L3 cluster: the SEED's community keywords
+/// when the themes projection maps it (deterministic — never the display
+/// label), else a fixed fallback. Presentation relabels cannot move cassette
+/// keys, same invariant as batch mode.
+fn cluster_theme(seed: &str, themes: Option<&ThemesFile>) -> String {
+    if let Some(t) = themes
+        && let Some(&cid) = t.packs.get(seed)
+        && let Some(c) = t.communities.iter().find(|c| c.id == cid)
+    {
+        return c.synth_theme();
+    }
+    FALLBACK_THEME.to_string()
+}
+
+/// Run the sweep. `index` is the grounding index over the canonical packs dir
+/// (already written by the caller); `store` is read for ACTIVE durable claims
+/// (coverage + superset guard) and never written here.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn run_sweep(
+    catalog: &UnitsCatalog,
+    reader_dir: &Path,
+    index: &GroundingIndex,
+    themes: Option<&ThemesFile>,
+    store: &Path,
+    work_dir: &Path,
+    embed_cache_dir: &Path,
+    client: &mut dyn ModelClient,
+    cfg: &SweepConfig,
+) -> Result<SweepOutcome, CliError> {
+    // ---- Coverage state from the ledger (read-only). ----
+    let events = read_ledger(&store.join("ledger.jsonl"))?;
+    let active: Vec<_> = ovp_domain::crystal::fold_ledger(&events)
+        .into_iter()
+        .filter(|r| r.status == CrystalStatus::Active)
+        .collect();
+    let mut covered: BTreeSet<String> = BTreeSet::new();
+    let mut active_source_sets: Vec<(String, BTreeSet<String>)> = Vec::new();
+    for r in &active {
+        covered.extend(r.source_cases.iter().cloned());
+        active_source_sets.push((
+            r.claim_key.clone(),
+            r.source_cases.iter().cloned().collect(),
+        ));
+    }
+    let seeds = uncovered_seeds(catalog, &covered);
+    let uncovered_before = seeds.len();
+
+    // ---- Neighborhood inputs: vectors + digests (both deterministic). ----
+    let vectors = resolve_catalog_vectors(reader_dir, catalog, embed_cache_dir)?;
+    let digests: BTreeMap<String, CaseDigest> = catalog
+        .cases
+        .iter()
+        .map(|(case_id, case)| {
+            let body = std::fs::read_to_string(reader_dir.join(case_id).join("reader.md"))
+                .unwrap_or_default();
+            (
+                case_id.clone(),
+                digest_from_reader_md(case_id, &case.title, &body),
+            )
+        })
+        .collect();
+
+    // ---- Sweep. ----
+    let report_path = work_dir.join("l3-sweep.jsonl");
+    let mut report = std::fs::File::create(&report_path)
+        .map_err(|e| CliError::Io(format!("creating {}: {e}", report_path.display())))?;
+    let mut write_line = |line: &SeedReport| -> Result<(), CliError> {
+        let s = serde_json::to_string(line).map_err(|e| CliError::Io(e.to_string()))?;
+        println!("  l3[{}]: {}", line.seed, line.outcome);
+        writeln!(report, "{s}").map_err(|e| CliError::Io(format!("l3-sweep.jsonl: {e}")))
+    };
+
+    let mut stats = SweepStats {
+        uncovered_before,
+        ..SweepStats::default()
+    };
+    let mut attempted_clusters: BTreeSet<Vec<String>> = BTreeSet::new();
+    let mut seen_signatures: BTreeSet<String> = BTreeSet::new();
+    let mut raw_claims: Vec<CrystalClaim> = Vec::new();
+    let mut grounded_all: Vec<CrystalClaim> = Vec::new();
+    let mut verdicts: Vec<ClaimStrengthVerdict> = Vec::new();
+    let mut deduped: Vec<ovp_domain::crystal::synth::DedupedClaim> = Vec::new();
+    let mut dropped_ungrounded: Vec<String> = Vec::new();
+    let mut repairs: Vec<RepairLog> = Vec::new();
+
+    for seed in &seeds {
+        if stats.select_calls >= cfg.max_seeds {
+            stats.budget_exhausted = true;
+            break;
+        }
+        // Seeds covered by claims written earlier in THIS run drop out.
+        if covered.contains(seed) {
+            stats.covered_mid_run += 1;
+            write_line(&SeedReport::new(seed, "covered"))?;
+            continue;
+        }
+        let neighbor_ids = neighborhood_of(seed, &vectors, cfg.neighborhood);
+        let neighbor_digests: Vec<CaseDigest> = neighbor_ids
+            .iter()
+            .filter_map(|id| digests.get(id).cloned())
+            .collect();
+        let offered: BTreeSet<String> = std::iter::once(seed.clone())
+            .chain(neighbor_ids.iter().cloned())
+            .collect();
+
+        // ---- cluster_select/v1 (budgeted). ----
+        let req = cluster_select_request(
+            &digests[seed],
+            &neighbor_digests,
+            cfg.max_cases_per_cluster,
+        );
+        stats.select_calls += 1;
+        let (selection, log) =
+            call_and_parse(client, &req, "cluster-select", parse_cluster_selection)?;
+        if let Some(l) = log {
+            repairs.push(l);
+        }
+        let (case_ids, rationale) = match selection {
+            ClusterSelection::Refused { reason } => {
+                stats.refused += 1;
+                let mut line = SeedReport::new(seed, "refused");
+                line.reason = Some(&reason);
+                write_line(&line)?;
+                continue;
+            }
+            ClusterSelection::Selected {
+                case_ids,
+                rationale,
+            } => (case_ids, rationale),
+        };
+
+        // ---- Mechanical validation: fail THIS seed loudly, keep sweeping. ----
+        let selected = match validate_selection(&offered, &case_ids, cfg.max_cases_per_cluster) {
+            Ok(ids) => ids,
+            Err(e) => {
+                stats.failed += 1;
+                // Under a recording cache, forget the bad exchange so a rerun
+                // re-asks the model instead of replaying the violation forever.
+                client.invalidate(&req);
+                let mut line = SeedReport::new(seed, "failed");
+                line.error = Some(&e);
+                write_line(&line)?;
+                continue;
+            }
+        };
+
+        // ---- Superset guard: never spend a synth call re-deriving a subset
+        // of an existing active claim's source set, or repeating a cluster
+        // already attempted this run. ----
+        if let Some((key, _)) = active_source_sets
+            .iter()
+            .find(|(_, sources)| selected.iter().all(|id| sources.contains(id)))
+        {
+            stats.guarded += 1;
+            let mut line = SeedReport::new(seed, "guarded");
+            line.selected = Some(&selected);
+            line.guarded_by = Some(key);
+            write_line(&line)?;
+            continue;
+        }
+        if attempted_clusters.contains(&selected) {
+            stats.guarded += 1;
+            let mut line = SeedReport::new(seed, "guarded");
+            line.selected = Some(&selected);
+            line.reason = Some("cluster already attempted this run");
+            write_line(&line)?;
+            continue;
+        }
+        attempted_clusters.insert(selected.clone());
+
+        // ---- EXISTING crystal_synth/v1 + gates, unchanged. ----
+        let cluster = Cluster {
+            key: format!("l3-{seed}"),
+            theme: cluster_theme(seed, themes),
+            cases: selected.clone(),
+        };
+        let synth_req = crystal_synth_request(
+            catalog,
+            &cluster,
+            cfg.max_cases_per_cluster,
+            cfg.max_units_per_case,
+        );
+        stats.synth_calls += 1;
+        let (claims, log): (Vec<CrystalClaim>, _) =
+            call_and_parse(client, &synth_req, "synth", |t| {
+                parse_synth_claims(t, &cluster.key)
+            })?;
+        if let Some(l) = log {
+            repairs.push(l);
+        }
+        let n_claims = claims.len();
+        raw_claims.extend(claims.clone());
+
+        // Grounded filter (same linter) + incremental exact-citation dedup.
+        let (cluster_grounded, cluster_dropped) = ovp_domain::crystal::synth::filter_grounded(
+            &CrystalCandidate { items: claims },
+            index,
+        );
+        dropped_ungrounded.extend(cluster_dropped);
+        let mut kept: Vec<CrystalClaim> = Vec::new();
+        for claim in cluster_grounded.items {
+            let sig = citation_signature(&claim.citations);
+            if seen_signatures.contains(&sig) {
+                let prior_id = grounded_all
+                    .iter()
+                    .chain(kept.iter())
+                    .find(|g| citation_signature(&g.citations) == sig)
+                    .map(|g| g.id.clone())
+                    .unwrap_or_default();
+                deduped.push(ovp_domain::crystal::synth::DedupedClaim {
+                    kept_claim_id: prior_id,
+                    dropped_claim_id: claim.id.clone(),
+                    reason: "exact_citation_set".to_string(),
+                });
+                continue;
+            }
+            seen_signatures.insert(sig);
+            kept.push(claim);
+        }
+        let n_grounded = kept.len();
+        if kept.is_empty() {
+            let mut line = SeedReport::new(seed, "selected");
+            line.selected = Some(&selected);
+            line.rationale = Some(&rationale);
+            line.claims = Some(n_claims);
+            line.grounded = Some(0);
+            write_line(&line)?;
+            stats.selected += 1;
+            continue;
+        }
+
+        // Strength for this cluster's grounded claims (1:1 or fail loud —
+        // same invariant the batch mode enforces globally).
+        let cluster_candidate = CrystalCandidate { items: kept };
+        let strength_req = strength_request(&cluster_candidate, catalog);
+        stats.strength_calls += 1;
+        let stage = format!("strength-{}", cluster.key);
+        let (cluster_verdicts, log): (Vec<ClaimStrengthVerdict>, _) =
+            call_and_parse(client, &strength_req, &stage, parse_strength_verdicts)?;
+        if let Some(l) = log {
+            repairs.push(l);
+        }
+        let ids: Vec<String> = cluster_candidate.items.iter().map(|c| c.id.clone()).collect();
+        let coverage = strength_coverage(&ids, &cluster_verdicts);
+        if !coverage.complete() {
+            return Err(CliError::Gate(format!(
+                "crystal-synth: strength verdicts incomplete for cluster {} — \
+                 missing={:?} duplicate={:?} unknown={:?}",
+                cluster.key, coverage.missing, coverage.duplicate, coverage.unknown
+            )));
+        }
+
+        // Deterministic routing preview: seeds cited by claims that will be
+        // written durable drop out of the remainder of the sweep.
+        let lint = lint_candidate(&cluster_candidate, index);
+        let scores = score_candidate(&lint);
+        let mut durable_routed = 0usize;
+        let mut newly_covered: Vec<String> = Vec::new();
+        for item in &cluster_candidate.items {
+            let class = scores
+                .iter()
+                .find(|s| s.claim_id == item.id)
+                .map(|s| s.class);
+            let verdict = cluster_verdicts.iter().find(|v| v.claim_id == item.id);
+            let routed = match class {
+                Some(c) => final_routing(c, verdict),
+                None => FinalClass::Reject,
+            };
+            if routed == FinalClass::Durable {
+                durable_routed += 1;
+                for c in &item.citations {
+                    if covered.insert(c.case_id.clone()) {
+                        newly_covered.push(c.case_id.clone());
+                    }
+                }
+            }
+        }
+        newly_covered.sort();
+        newly_covered.dedup();
+
+        grounded_all.extend(cluster_candidate.items);
+        verdicts.extend(cluster_verdicts);
+        stats.selected += 1;
+        let mut line = SeedReport::new(seed, "selected");
+        line.selected = Some(&selected);
+        line.rationale = Some(&rationale);
+        line.claims = Some(n_claims);
+        line.grounded = Some(n_grounded);
+        line.durable_routed = Some(durable_routed);
+        line.newly_covered = Some(newly_covered);
+        write_line(&line)?;
+    }
+
+    stats.uncovered_after = uncovered_seeds(catalog, &covered).len();
+    Ok(SweepOutcome {
+        raw_claims,
+        grounded: CrystalCandidate {
+            items: grounded_all,
+        },
+        verdicts,
+        deduped,
+        dropped_ungrounded,
+        stats,
+        repairs,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ovp_domain::crystal::synth::CatalogCase;
+
+    fn catalog_of(ids: &[&str]) -> UnitsCatalog {
+        let mut cat = UnitsCatalog::default();
+        for id in ids {
+            cat.cases.insert(
+                (*id).to_string(),
+                CatalogCase {
+                    title: format!("Title {id}"),
+                    units: vec![],
+                },
+            );
+        }
+        cat
+    }
+
+    #[test]
+    fn sweep_order_is_deterministic_case_id_ascending() {
+        let cat = catalog_of(&["c-b", "a-z", "b-m", "d-q"]);
+        let covered: BTreeSet<String> = ["b-m".to_string()].into_iter().collect();
+        let seeds = uncovered_seeds(&cat, &covered);
+        assert_eq!(seeds, vec!["a-z", "c-b", "d-q"], "sorted, covered dropped");
+        // Same inputs → same order, every time.
+        assert_eq!(seeds, uncovered_seeds(&cat, &covered));
+    }
+
+    #[test]
+    fn neighborhood_ranks_by_cosine_with_case_id_ties() {
+        let mut vectors: BTreeMap<String, Vec<f32>> = BTreeMap::new();
+        vectors.insert("seed".into(), vec![1.0, 0.0]);
+        vectors.insert("near".into(), vec![0.99, 0.14]);
+        vectors.insert("far".into(), vec![0.0, 1.0]);
+        // Exact tie with `near-2` → ascending case_id breaks it.
+        vectors.insert("near-2".into(), vec![0.99, 0.14]);
+        let n = neighborhood_of("seed", &vectors, 2);
+        assert_eq!(n, vec!["near", "near-2"]);
+        let all = neighborhood_of("seed", &vectors, 10);
+        assert_eq!(all, vec!["near", "near-2", "far"], "k caps, order stable");
+    }
+
+    #[test]
+    fn cluster_theme_uses_seed_community_keywords_never_labels() {
+        use ovp_domain::crystal::themes::{
+            LabelsProvenance, THEMES_SCHEMA, ThemeCommunity, ThemeParams,
+        };
+        let themes = ThemesFile {
+            schema: THEMES_SCHEMA.into(),
+            model: "m".into(),
+            params: ThemeParams {
+                k: 10,
+                cosine_threshold: 0.5,
+                resolution: 1.5,
+                seed: 42,
+                text_prefix: String::new(),
+                head_chars: 1500,
+            },
+            generated_from: "gf".into(),
+            packs: BTreeMap::from([("case-a".to_string(), 0)]),
+            communities: vec![ThemeCommunity {
+                id: 0,
+                label: "Pretty Display Label".into(),
+                label_zh: "展示名".into(),
+                keywords: vec!["memory".into(), "context".into()],
+                size: 1,
+            }],
+            labels_provenance: LabelsProvenance::Llm,
+        };
+        assert_eq!(cluster_theme("case-a", Some(&themes)), "memory · context");
+        assert_eq!(cluster_theme("unknown", Some(&themes)), FALLBACK_THEME);
+        assert_eq!(cluster_theme("case-a", None), FALLBACK_THEME);
+    }
+}

--- a/crates/ovp-cli/src/commands/crystal_synth_llm.rs
+++ b/crates/ovp-cli/src/commands/crystal_synth_llm.rs
@@ -341,15 +341,18 @@ pub(crate) fn run_sweep(
     let mut repairs: Vec<RepairLog> = Vec::new();
 
     for seed in &seeds {
-        if stats.select_calls >= cfg.max_seeds {
-            stats.budget_exhausted = true;
-            break;
-        }
-        // Seeds covered by claims written earlier in THIS run drop out.
+        // Seeds covered by claims written earlier in THIS run drop out. This
+        // check runs BEFORE the budget check: a final permitted selection that
+        // covers every remaining seed is a complete sweep, not an exhausted
+        // budget (and each covered seed still counts as covered_mid_run).
         if covered.contains(seed) {
             stats.covered_mid_run += 1;
             write_line(&SeedReport::new(seed, "covered"))?;
             continue;
+        }
+        if stats.select_calls >= cfg.max_seeds {
+            stats.budget_exhausted = true;
+            break;
         }
         let neighbor_ids = neighborhood_of(seed, &vectors, cfg.neighborhood);
         let neighbor_digests: Vec<CaseDigest> = neighbor_ids
@@ -1008,6 +1011,134 @@ mod tests {
         let msg = format!("{err:?}");
         assert!(msg.contains("crystal-themes"), "remedy named: {msg}");
         assert!(msg.contains("embed"), "{msg}");
+    }
+
+    /// Bounds that make every cluster_select/v1 call unsatisfiable (the
+    /// prompt demands 3..=cap ids from seed + neighborhood) must be refused
+    /// at validation time — before any IO or model spend.
+    #[test]
+    fn llm_mode_rejects_impossible_selection_bounds() {
+        let tmp = tempfile::tempdir().unwrap();
+        let reader = tmp.path().join("reader");
+        let work = tmp.path().join("work");
+
+        let mut args = llm_args(&reader, &work, Path::new("unused"));
+        args.max_cases_per_cluster = 2;
+        let err = run_stats(args).expect_err("cap < 3 must fail validation");
+        assert!(matches!(err, CliError::Gate(_)), "{err:?}");
+        assert!(format!("{err:?}").contains("at least 3"), "{err:?}");
+
+        let mut args = llm_args(&reader, &work, Path::new("unused"));
+        args.neighborhood = 1;
+        let err = run_stats(args).expect_err("neighborhood < 2 must fail validation");
+        assert!(matches!(err, CliError::Gate(_)), "{err:?}");
+        assert!(format!("{err:?}").contains("at least 2"), "{err:?}");
+
+        assert!(!work.exists(), "refused before any work-dir IO");
+    }
+
+    /// When the final permitted selection covers every remaining seed, the
+    /// sweep is COMPLETE — the covered check must run before the budget check
+    /// so the run never misreports budget_exhausted=true (or undercounts
+    /// covered_mid_run) with uncovered_after == 0.
+    #[test]
+    fn last_selection_covering_all_seeds_is_not_budget_exhausted() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (reader, embed) = seed_corpus(tmp.path());
+        let work = tmp.path().join("work");
+        std::fs::create_dir_all(&work).unwrap();
+        let cache = work.join("cassettes");
+        let catalog = collect_catalog(&reader).unwrap();
+
+        // Pre-existing ACTIVE claim covers d → uncovered seeds are a, b, c.
+        let store = work.join("store");
+        std::fs::create_dir_all(&store).unwrap();
+        let record = ovp_domain::crystal::DurableRecord {
+            claim_key: "ck-covers-d-000".into(),
+            claim_id: "old-1".into(),
+            claim: "d already synthesized".into(),
+            theme: "t".into(),
+            source_cases: vec!["2026-06-04_d".into()],
+            citations: vec![],
+            provenance_score: 0.9,
+            provenance_class: ovp_domain::crystal::ProvenanceClass::Durable,
+            strength: ovp_domain::crystal::StrengthClass::Supported,
+            strength_rationale: "r".into(),
+            final_class: FinalClass::Durable,
+            run_id: "run-old".into(),
+            status: CrystalStatus::Active,
+        };
+        let event = ovp_domain::crystal::StoreEvent {
+            op: ovp_domain::crystal::StoreOp::Write,
+            record,
+            supersedes: None,
+            reason: None,
+        };
+        std::fs::write(
+            store.join("ledger.jsonl"),
+            format!("{}\n", serde_json::to_string(&event).unwrap()),
+        )
+        .unwrap();
+
+        // Seed a (the ONLY permitted select call): the selection yields one
+        // durable claim citing a, b AND c — everything still uncovered.
+        let sel_a = select_request_for(&reader, &embed, &catalog, "2026-06-01_a");
+        write_cassette(
+            &cache,
+            &sel_a,
+            r#"{"selected_case_ids":["2026-06-01_a","2026-06-02_b","2026-06-03_c"],"rationale":"scarce-budget framing across sources"}"#,
+        );
+        let cluster = Cluster {
+            key: "l3-2026-06-01_a".into(),
+            theme: "cross-source".into(),
+            cases: vec![
+                "2026-06-01_a".into(),
+                "2026-06-02_b".into(),
+                "2026-06-03_c".into(),
+            ],
+        };
+        let synth_req = crystal_synth_request(&catalog, &cluster, 16, 22);
+        let ua = catalog.cases["2026-06-01_a"].units[0].unit_id.clone();
+        let ub = catalog.cases["2026-06-02_b"].units[0].unit_id.clone();
+        let uc = catalog.cases["2026-06-03_c"].units[0].unit_id.clone();
+        let synth_reply = format!(
+            r#"{{"claims":[{{"id":"1","claim":"All three sources treat capacity as a scarce, bounded budget.","theme":"cross-source","citations":[
+                {{"case_id":"2026-06-01_a","unit_id":"{ua}","quote":"memory is a scarce budget"}},
+                {{"case_id":"2026-06-02_b","unit_id":"{ub}","quote":"context window is a scarce budget"}},
+                {{"case_id":"2026-06-03_c","unit_id":"{uc}","quote":"retrieval must stay bounded"}}
+            ]}}]}}"#
+        );
+        write_cassette(&cache, &synth_req, &synth_reply);
+        let grounded = CrystalCandidate {
+            items: parse_synth_claims(&synth_reply, &cluster.key).unwrap(),
+        };
+        write_cassette(
+            &cache,
+            &strength_request(&grounded, &catalog),
+            &format!(
+                r#"[{{"claim_id":"{}","strength":"supported","evidence_sufficient":true,"rationale":"all three quotes state a bounded budget"}}]"#,
+                grounded.items[0].id
+            ),
+        );
+
+        let mut args = llm_args(&reader, &work, &embed);
+        args.max_seeds = 1; // exactly the one permitted call
+        let stats = run_stats(args).expect("budgeted run that covers everything");
+        assert_eq!(stats.select_calls, 1);
+        assert_eq!(stats.durable_appended, 1);
+        assert_eq!(stats.uncovered_after, Some(0), "the last call covered b and c");
+
+        let sweep: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(work.join("l3-sweep-stats.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            sweep["budget_exhausted"], false,
+            "a fully covered sweep is complete, not budget-exhausted: {sweep}"
+        );
+        assert_eq!(sweep["covered_mid_run"], 2, "b and c dropped out covered: {sweep}");
+        assert_eq!(sweep["uncovered_after"], 0, "{sweep}");
+        assert_eq!(sweep["selected"], 1, "{sweep}");
     }
 
     #[test]

--- a/crates/ovp-cli/src/commands/crystal_themes.rs
+++ b/crates/ovp-cli/src/commands/crystal_themes.rs
@@ -97,7 +97,7 @@ struct ThemeDoc {
 /// evidence scaffolding, trailing `` `[u-… · line N]` `` unit refs, heading
 /// markers, and trailing `_definition_`-style card-kind tags. Deterministic,
 /// line-based, no regex.
-fn clean_reader_body(md: &str) -> String {
+pub(crate) fn clean_reader_body(md: &str) -> String {
     let mut out: Vec<&str> = Vec::new();
     for line in md.lines() {
         let s = line.trim();

--- a/crates/ovp-cli/src/commands/crystal_write.rs
+++ b/crates/ovp-cli/src/commands/crystal_write.rs
@@ -109,7 +109,7 @@ pub fn build_grounding_index(packs_dir: &std::path::Path) -> Result<GroundingInd
     Ok(index)
 }
 
-fn read_ledger(path: &std::path::Path) -> Result<Vec<StoreEvent>, CliError> {
+pub(crate) fn read_ledger(path: &std::path::Path) -> Result<Vec<StoreEvent>, CliError> {
     if !path.exists() {
         return Ok(Vec::new());
     }

--- a/crates/ovp-cli/src/commands/mod.rs
+++ b/crates/ovp-cli/src/commands/mod.rs
@@ -8,6 +8,8 @@ pub mod crystal_lint;
 pub mod crystal_review;
 pub mod crystal_review_session;
 pub mod crystal_synth;
+pub mod crystal_synth_ab;
+pub mod crystal_synth_llm;
 pub mod crystal_themes;
 pub mod crystal_write;
 pub mod console_cmd;

--- a/crates/ovp-cli/src/main.rs
+++ b/crates/ovp-cli/src/main.rs
@@ -523,6 +523,37 @@ enum Cmd {
         /// if an internal batching bug would send an oversized request.
         #[arg(long)]
         strict_cluster_cap: bool,
+        /// L3: how synthesis inputs are grouped. `batch` (default) keeps the
+        /// deterministic themes/date batching; `llm` runs the coverage-first
+        /// sweep — one cluster_select/v1 call per uncovered pack picks 3..cap
+        /// case ids (or refuses), the superset guard skips clusters an active
+        /// claim already covers, then the UNCHANGED crystal_synth/v1 + gates +
+        /// idempotent write run per cluster. Needs cached embeddings
+        /// (`ovp2 crystal-themes` warms them).
+        #[arg(long, value_enum, default_value_t = ClusterModeArg::Batch)]
+        cluster_mode: ClusterModeArg,
+        /// llm mode: per-run budget cap on cluster_select/v1 calls.
+        #[arg(long, default_value_t = 25)]
+        max_seeds: usize,
+        /// llm mode: kNN neighborhood size offered alongside each seed.
+        #[arg(long, default_value_t = 12)]
+        neighborhood: usize,
+        /// llm mode: embedding cache root. Default:
+        /// `<vault-root>/.ovp/cache/embeddings`.
+        #[arg(long)]
+        embed_cache_dir: Option<PathBuf>,
+        /// L3 A/B harness: sample a deterministic seeded slice of UNCOVERED
+        /// packs and run arm A (batch) vs arm B (llm) against the SAME packs
+        /// with fresh stores + separate cassette dirs; prints a comparison
+        /// table and writes comparison.json. The real store is only read.
+        #[arg(long)]
+        experiment: bool,
+        /// Experiment slice size (uncovered packs sampled).
+        #[arg(long, default_value_t = 30)]
+        experiment_slice: usize,
+        /// Experiment sampling seed.
+        #[arg(long, default_value_t = 42)]
+        experiment_seed: u64,
     },
     /// Build the semantic display-theme projection (.ovp/crystal/themes.json)
     /// over all reader packs: multilingual embeddings (cached) → Louvain
@@ -943,6 +974,14 @@ enum ClientKindArg {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, clap::ValueEnum)]
+enum ClusterModeArg {
+    /// Deterministic ≤cap batches (themes.json communities / date order).
+    Batch,
+    /// L3 coverage-first LLM cluster selection (cluster_select/v1).
+    Llm,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, clap::ValueEnum)]
 enum EvolveAction {
     Registry,
     Validate,
@@ -1302,32 +1341,67 @@ fn main() -> ExitCode {
             date,
             strict,
             strict_cluster_cap,
+            cluster_mode,
+            max_seeds,
+            neighborhood,
+            embed_cache_dir,
+            experiment,
+            experiment_slice,
+            experiment_seed,
         } => {
             use commands::client::ClientKind;
-            use commands::crystal_synth::CrystalSynthArgs;
+            use commands::crystal_synth::{ClusterMode, CrystalSynthArgs};
             let client_kind = match client {
                 ClientKindArg::Replay => ClientKind::Replay,
                 ClientKindArg::Live => ClientKind::Live,
             };
-            commands::crystal_synth::run(CrystalSynthArgs {
-                reader_dir,
-                vault_root,
-                work_dir,
-                store,
-                themes_file,
-                client_kind,
-                cache_dir,
-                max_cases_per_cluster,
-                max_units_per_case,
-                run_id,
-                title,
-                scope,
-                not_claiming,
-                refresh,
-                date,
-                strict,
-                strict_cluster_cap,
-            })
+            let cluster_mode = match cluster_mode {
+                ClusterModeArg::Batch => ClusterMode::Batch,
+                ClusterModeArg::Llm => ClusterMode::Llm,
+            };
+            if experiment {
+                commands::crystal_synth_ab::run_experiment(
+                    commands::crystal_synth_ab::ExperimentArgs {
+                        reader_dir,
+                        vault_root,
+                        store,
+                        themes_file,
+                        embed_cache_dir,
+                        work_dir,
+                        client_kind,
+                        slice: experiment_slice,
+                        seed: experiment_seed,
+                        max_seeds: 0, // per-arm default: the slice size
+                        neighborhood,
+                        max_cases_per_cluster,
+                        max_units_per_case,
+                    },
+                )
+            } else {
+                commands::crystal_synth::run(CrystalSynthArgs {
+                    reader_dir,
+                    vault_root,
+                    work_dir,
+                    store,
+                    themes_file,
+                    client_kind,
+                    cache_dir,
+                    max_cases_per_cluster,
+                    max_units_per_case,
+                    run_id,
+                    title,
+                    scope,
+                    not_claiming,
+                    refresh,
+                    date,
+                    strict,
+                    strict_cluster_cap,
+                    cluster_mode,
+                    max_seeds,
+                    neighborhood,
+                    embed_cache_dir,
+                })
+            }
         }
         Cmd::CrystalThemes {
             vault_root,

--- a/crates/ovp-domain/prompts/cluster_select.md
+++ b/crates/ovp-domain/prompts/cluster_select.md
@@ -1,0 +1,54 @@
+# Cluster selection prompt — cluster_select/v1
+
+You are scouting for **one cross-source synthesis cluster** inside a knowledge
+corpus. Below is a **seed** source (currently not covered by any durable
+claim) and its nearest **neighbors** by content similarity. Each entry is a
+compact digest: `case_id`, the source title, and its card titles.
+
+Your job: decide whether some of these sources — read together — could support
+at least ONE claim-worthy **cross-source** synthesis (a finding a careful
+reader could only state by drawing on several of these sources at once). If
+yes, pick the case ids that form that single, coherent cluster. If not,
+**refuse** — "no opportunity here" is a first-class, correct answer, and a
+refusal is strictly better than a forced grab-bag.
+
+## Rules
+
+1. Select between `min_cases` and `max_cases` distinct `case_id`s, copied
+   **verbatim** from the digests below. Never invent or edit an id.
+2. Prefer clusters that **include the seed** — it is the coverage target. You
+   may exclude the seed only when its neighbors form a genuinely stronger
+   cluster that the seed does not belong to.
+3. **Content diversity is mandatory.** The selected cases must approach a
+   shared question from different sources or angles. Do NOT select
+   near-duplicates of one another (same article re-clipped, translations of
+   one piece, serialized parts of one post) unless independent corroboration
+   is exactly the point — a cluster of rehashes yields a trivial claim.
+4. Pick ONE cluster only: the tightest claim-worthy subset, not "everything
+   vaguely related". Smaller and sharper beats larger and mushier.
+5. Refuse when: the neighborhood is topically scattered; fewer than
+   `min_cases` cases genuinely intersect; or the only common ground is too
+   generic to support a claim worth keeping.
+6. Output **only** JSON — no prose, no markdown fence.
+
+## Output shape
+
+Either a selection:
+
+```json
+{
+  "selected_case_ids": ["<case_id>", "<case_id>", "<case_id>"],
+  "rationale": "one sentence: the cross-source question this cluster can answer"
+}
+```
+
+or a refusal:
+
+```json
+{
+  "refuse": true,
+  "reason": "one sentence: why no claim-worthy cluster exists here"
+}
+```
+
+## Corpus

--- a/crates/ovp-domain/src/crystal.rs
+++ b/crates/ovp-domain/src/crystal.rs
@@ -33,6 +33,12 @@ use sha2::{Digest, Sha256};
 /// substrate.
 pub mod synth;
 
+/// L3 — `cluster_select/v1`: LLM-shaped synthesis clusters for
+/// `crystal-synth --cluster-mode llm`. Prompt builder + reply parsing +
+/// MECHANICAL selection validation; refusal is a first-class outcome.
+/// Never touches grounding, gates, or the ledger.
+pub mod select;
+
 /// Semantic display themes: the `themes.json` projection schema + helpers
 /// (majority-label lookup, synthesis grouping, bilingual `theme_label/v1`
 /// model stage). Rebuildable projection; never baked into the ledger.

--- a/crates/ovp-domain/src/crystal/select.rs
+++ b/crates/ovp-domain/src/crystal/select.rs
@@ -1,0 +1,335 @@
+//! `cluster_select/v1` — L3 LLM-shaped synthesis clusters (the model stage of
+//! `crystal-synth --cluster-mode llm`). One call per uncovered seed pack: the
+//! model reads the seed's digest plus its kNN neighborhood digests and either
+//! picks 3..cap case ids that form ONE claim-worthy cross-source cluster, or
+//! REFUSES ("no opportunity" is a first-class answer).
+//!
+//! Everything downstream of the selection is the EXISTING, unchanged pipeline:
+//! `crystal_synth/v1` + strength + gates + idempotent durable write. This
+//! module only proposes groupings; it can never touch grounding or the ledger.
+//! Selections are validated MECHANICALLY ([`validate_selection`]): ids must
+//! come from the offered set, ≥ [`MIN_CLUSTER_CASES`], ≤ cap — a violation
+//! fails that seed loudly (recorded) and the sweep continues.
+
+use std::collections::BTreeSet;
+
+use ovp_llm::{ModelMessage, ModelRequest};
+use serde::{Deserialize, Serialize};
+
+const SELECT_TEMPLATE: &str = include_str!("../../prompts/cluster_select.md");
+/// Cassette namespace + version marker for the cluster-selection stage.
+pub const CLUSTER_SELECT_PROMPT_ID: &str = "cluster_select/v1";
+const DEFAULT_MODEL: &str = "claude-sonnet-4-6";
+/// Selection replies are tiny (a handful of ids + one sentence).
+const SELECT_MAX_TOKENS: u32 = 1024;
+
+/// A durable cross-source claim needs at least this many distinct cases —
+/// the selection floor mirrors the synthesis goal, not the provenance gate
+/// (which needs ≥2): asking for 3+ gives the synth call room to keep a
+/// 2-source claim after one case contributes nothing.
+pub const MIN_CLUSTER_CASES: usize = 3;
+
+/// Compact digest of one reader pack as shown to the selector: id + title +
+/// card titles. Deliberately NO quotes/units — the selector shapes groups,
+/// the synth stage sees the evidence.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CaseDigest {
+    pub case_id: String,
+    pub title: String,
+    pub card_titles: Vec<String>,
+}
+
+/// Drop a trailing `_tag_` token (the reader card-kind italics:
+/// `_definition_`, `_fact_`, …) if present.
+fn strip_trailing_em_tag(s: &str) -> &str {
+    let trimmed = s.trim_end();
+    if let Some(last) = trimmed.rsplit_once(char::is_whitespace).map(|(_, l)| l)
+        && last.len() > 2
+        && last.starts_with('_')
+        && last.ends_with('_')
+    {
+        return trimmed[..trimmed.len() - last.len()].trim_end();
+    }
+    trimmed
+}
+
+/// Build a digest from a pack's resolved title + its `reader.md` body: the
+/// card titles are the `## ` headings (leading ordinal and trailing card-kind
+/// tag stripped). Deterministic, line-based; an empty/missing reader body
+/// yields an empty card list (the title still carries signal).
+pub fn digest_from_reader_md(case_id: &str, title: &str, reader_md: &str) -> CaseDigest {
+    let mut card_titles = Vec::new();
+    for line in reader_md.lines() {
+        let t = line.trim_start();
+        let Some(rest) = t.strip_prefix("## ") else {
+            continue;
+        };
+        // "## 3. Card heading  _definition_" → "Card heading".
+        let mut h = rest.trim();
+        if let Some((num, tail)) = h.split_once('.')
+            && !num.is_empty()
+            && num.bytes().all(|b| b.is_ascii_digit())
+        {
+            h = tail.trim_start();
+        }
+        let h = strip_trailing_em_tag(h);
+        if !h.is_empty() {
+            card_titles.push(h.to_string());
+        }
+    }
+    CaseDigest {
+        case_id: case_id.to_string(),
+        title: title.to_string(),
+        card_titles,
+    }
+}
+
+/// The model-input payload: seed + numbered neighbors + the size bounds.
+/// Serialized as pretty JSON into the user message so the request (and thus
+/// the cassette key) is a pure function of the digests and caps.
+#[derive(Debug, Clone, Serialize)]
+struct SelectInput<'a> {
+    min_cases: usize,
+    max_cases: usize,
+    seed: &'a CaseDigest,
+    neighbors: &'a [CaseDigest],
+}
+
+/// Build the selection `ModelRequest` for one seed (namespace =
+/// cluster_select/v1). `max_cases` is the synthesis cluster cap.
+pub fn cluster_select_request(
+    seed: &CaseDigest,
+    neighbors: &[CaseDigest],
+    max_cases: usize,
+) -> ModelRequest {
+    let marker = "## Corpus";
+    let (system, _) = SELECT_TEMPLATE
+        .split_once(marker)
+        .unwrap_or((SELECT_TEMPLATE, ""));
+    let input = SelectInput {
+        min_cases: MIN_CLUSTER_CASES,
+        max_cases,
+        seed,
+        neighbors,
+    };
+    let user = format!(
+        "{marker}\n\n{}\n",
+        serde_json::to_string_pretty(&input).unwrap_or_else(|_| "{}".to_string())
+    );
+    ModelRequest {
+        model: DEFAULT_MODEL.to_string(),
+        system: Some(system.trim_end().to_string()),
+        messages: vec![ModelMessage::User { content: user }],
+        max_tokens: SELECT_MAX_TOKENS,
+        temperature: None,
+        cache_namespace: Some(CLUSTER_SELECT_PROMPT_ID.to_string()),
+    }
+}
+
+/// The parsed selection reply. Refusal is a first-class outcome, not an error.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum ClusterSelection {
+    Selected {
+        case_ids: Vec<String>,
+        rationale: String,
+    },
+    Refused {
+        reason: String,
+    },
+}
+
+/// Parse a `cluster_select/v1` reply: either `{"selected_case_ids": [...],
+/// "rationale": "..."}` or `{"refuse": true, "reason": "..."}`. Ids are
+/// trimmed; empty ids are dropped here (mechanical set/size checks are
+/// [`validate_selection`]'s job). `Err(detail)` when neither shape is found.
+pub fn parse_cluster_selection(reply_text: &str) -> Result<ClusterSelection, String> {
+    let (value, _note) =
+        crate::model_reply::parse_reply_value(reply_text).map_err(|d| d.to_string())?;
+    if value.get("refuse").and_then(|v| v.as_bool()) == Some(true) {
+        let reason = value
+            .get("reason")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .unwrap_or("(no reason given)")
+            .to_string();
+        return Ok(ClusterSelection::Refused { reason });
+    }
+    let arr = value
+        .get("selected_case_ids")
+        .and_then(|v| v.as_array())
+        .ok_or("missing `selected_case_ids` array (and no `refuse: true`)")?;
+    let mut case_ids = Vec::with_capacity(arr.len());
+    for item in arr {
+        let Some(s) = item.as_str() else {
+            return Err("`selected_case_ids` must be an array of strings".to_string());
+        };
+        let s = s.trim();
+        if !s.is_empty() {
+            case_ids.push(s.to_string());
+        }
+    }
+    let rationale = value
+        .get("rationale")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .unwrap_or_default()
+        .to_string();
+    Ok(ClusterSelection::Selected {
+        case_ids,
+        rationale,
+    })
+}
+
+/// Mechanically validate a selection against the offered set and size bounds.
+/// Returns the sorted, deduplicated case ids on success. A violation is a
+/// per-seed failure (the caller records it and continues the sweep — it never
+/// aborts the run). Deterministic + total.
+pub fn validate_selection(
+    offered: &BTreeSet<String>,
+    selected: &[String],
+    max_cases: usize,
+) -> Result<Vec<String>, String> {
+    let mut ids: Vec<String> = selected.to_vec();
+    ids.sort();
+    ids.dedup();
+    let outside: Vec<&String> = ids.iter().filter(|id| !offered.contains(*id)).collect();
+    if !outside.is_empty() {
+        return Err(format!(
+            "selected id(s) not in the offered set: {}",
+            outside
+                .iter()
+                .map(|s| s.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+    if ids.len() < MIN_CLUSTER_CASES {
+        return Err(format!(
+            "selected {} distinct case(s); a cluster needs at least {MIN_CLUSTER_CASES}",
+            ids.len()
+        ));
+    }
+    if ids.len() > max_cases {
+        return Err(format!(
+            "selected {} distinct case(s); the cluster cap is {max_cases}",
+            ids.len()
+        ));
+    }
+    Ok(ids)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn digest(id: &str) -> CaseDigest {
+        CaseDigest {
+            case_id: id.to_string(),
+            title: format!("Title {id}"),
+            card_titles: vec![format!("Card of {id}")],
+        }
+    }
+
+    #[test]
+    fn digest_from_reader_md_extracts_card_titles() {
+        let md = "# Claude Code 源码解读\n\n\
+            > 12 cards · 26 grounded units\n\n\
+            ## 1. Agent Loop 是心脏  _definition_\n\nbody\n\n\
+            ## 2. 分层解耦\n\nbody\n\n\
+            ### not a card heading\n";
+        let d = digest_from_reader_md("c1", "Claude Code 源码解读", md);
+        assert_eq!(d.case_id, "c1");
+        assert_eq!(d.card_titles, vec!["Agent Loop 是心脏", "分层解耦"]);
+    }
+
+    #[test]
+    fn digest_survives_empty_reader_md() {
+        let d = digest_from_reader_md("c1", "T", "");
+        assert!(d.card_titles.is_empty());
+        assert_eq!(d.title, "T");
+    }
+
+    #[test]
+    fn request_carries_namespace_seed_and_neighbors() {
+        let seed = digest("seed-1");
+        let neighbors = vec![digest("n-1"), digest("n-2")];
+        let req = cluster_select_request(&seed, &neighbors, 16);
+        assert_eq!(req.cache_namespace.as_deref(), Some("cluster_select/v1"));
+        assert!(req.system.as_deref().unwrap().contains("cluster_select/v1"));
+        let ModelMessage::User { content } = &req.messages[0] else {
+            panic!()
+        };
+        assert!(content.contains("seed-1"));
+        assert!(content.contains("n-2"));
+        assert!(content.contains("\"max_cases\": 16"));
+        assert!(content.contains("\"min_cases\": 3"));
+    }
+
+    #[test]
+    fn request_is_a_pure_function_of_digests() {
+        let seed = digest("seed-1");
+        let n = vec![digest("n-1")];
+        let a = ovp_llm::request_key(&cluster_select_request(&seed, &n, 16));
+        let b = ovp_llm::request_key(&cluster_select_request(&seed, &n, 16));
+        assert_eq!(a, b);
+        let c = ovp_llm::request_key(&cluster_select_request(&seed, &n, 8));
+        assert_ne!(a, c, "cap is part of the request identity");
+    }
+
+    #[test]
+    fn parse_selected_and_refused_and_garbage() {
+        let sel = parse_cluster_selection(
+            r#"{"selected_case_ids":[" a ","b","c"],"rationale":"shared topic"}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            sel,
+            ClusterSelection::Selected {
+                case_ids: vec!["a".into(), "b".into(), "c".into()],
+                rationale: "shared topic".into()
+            }
+        );
+        let refused = parse_cluster_selection(r#"{"refuse":true,"reason":"scattered"}"#).unwrap();
+        assert_eq!(
+            refused,
+            ClusterSelection::Refused {
+                reason: "scattered".into()
+            }
+        );
+        // refuse:true with no reason still parses (reason placeholder).
+        let bare = parse_cluster_selection(r#"{"refuse":true}"#).unwrap();
+        assert!(matches!(bare, ClusterSelection::Refused { .. }));
+        // Neither shape → Err.
+        assert!(parse_cluster_selection(r#"{"claims":[]}"#).is_err());
+        // Non-string ids → Err.
+        assert!(parse_cluster_selection(r#"{"selected_case_ids":[1,2,3]}"#).is_err());
+    }
+
+    #[test]
+    fn validate_selection_enforces_set_and_bounds() {
+        let offered: BTreeSet<String> =
+            ["a", "b", "c", "d"].iter().map(|s| s.to_string()).collect();
+        // Happy path: sorted + deduped.
+        let ok = validate_selection(&offered, &["c".into(), "a".into(), "b".into(), "a".into()], 4)
+            .unwrap();
+        assert_eq!(ok, vec!["a", "b", "c"]);
+        // Outside the offered set.
+        let err = validate_selection(&offered, &["a".into(), "b".into(), "zzz".into()], 4)
+            .unwrap_err();
+        assert!(err.contains("zzz"), "{err}");
+        // Too few (dedup counts distinct ids).
+        let err =
+            validate_selection(&offered, &["a".into(), "a".into(), "b".into()], 4).unwrap_err();
+        assert!(err.contains("at least 3"), "{err}");
+        // Over the cap.
+        let err = validate_selection(
+            &offered,
+            &["a".into(), "b".into(), "c".into(), "d".into()],
+            3,
+        )
+        .unwrap_err();
+        assert!(err.contains("cap is 3"), "{err}");
+    }
+}

--- a/crates/ovp-domain/src/crystal/synth.rs
+++ b/crates/ovp-domain/src/crystal/synth.rs
@@ -528,7 +528,10 @@ pub struct DedupedClaim {
     pub reason: String,
 }
 
-fn citation_signature(citations: &[Citation]) -> String {
+/// Deterministic signature of a citation set (sorted, deduped). Public so the
+/// L3 sweep can dedup incrementally across clusters with the SAME identity the
+/// batch-mode `dedup_exact_citation_sets` uses.
+pub fn citation_signature(citations: &[Citation]) -> String {
     let mut parts: Vec<String> = citations
         .iter()
         .map(|c| {

--- a/docs/stage-l3-cluster-synthesis.md
+++ b/docs/stage-l3-cluster-synthesis.md
@@ -1,0 +1,195 @@
+# L3 — LLM-shaped synthesis clusters (`crystal-synth --cluster-mode llm`)
+
+Status: shipped on `feat/l3-cluster-synthesis` (2026-07-10). Follow-up to the
+semantic theme system (`stage-semantic-themes.md` §L3 follow-up); operator-
+approved KMEM-hybrid design. Default UNCHANGED: `--cluster-mode batch` keeps
+Stage 3a byte-for-byte — the A/B below decides any default flip.
+
+## Why
+
+Batch mode cuts themes.json communities into deterministic ≤cap batches and
+synthesizes each blindly: every pack gets exactly one shot inside whatever
+community Louvain put it in, boundary packs get grouped with weak partners,
+and the synth call is spent whether or not a claim-worthy cluster exists.
+Real-vault state at design time: **1077 packs with accepted units, 585 (54.3%)
+uncovered** — not cited by any ACTIVE durable claim. L3 replaces only the
+*grouping* decision with a model that may also say "no opportunity here".
+
+## Pipeline
+
+```
+coverage-first sweep: uncovered packs (not cited by any ACTIVE durable claim),
+                      ascending case_id (deterministic)
+  → seed's kNN neighborhood from cached embeddings
+    (ovp-embed content-cache; cross-community allowed; top --neighborhood=12 by cosine)
+  → NEW LLM call cluster_select/v1: seed + numbered neighbor digests
+    (title + card titles — never quotes), picks 3..cap diverse case_ids that
+    form ONE claim-worthy cross-source cluster, or REFUSES
+    ("no opportunity" is a first-class answer)
+  → mechanical validation: ids ⊆ offered set, ≥3, ≤cap
+    (violation = fail-loud on that seed, recorded, sweep continues)
+  → superset guard: an ACTIVE claim's source_cases ⊇ the chosen set → skip
+    (logged, no synth spend); ditto a cluster already attempted this run
+  → EXISTING crystal_synth/v1 + grounded filter + exact-citation dedup +
+    crystal_strength/v1 + provenance/strength gates + idempotent durable
+    write — completely unchanged
+  → seeds covered by claims routed durable this run drop out mid-sweep
+```
+
+Layer separation is the same as L2: the selector shapes GROUPS ONLY. It can
+never invent evidence (the synth prompt still only sees accepted units), never
+touch the gates, and never write. A worst-case selector costs synth calls; it
+cannot corrupt the ledger.
+
+## `cluster_select/v1` prompt contract
+
+- **Input** (pretty-JSON in the user message, so cassette keys are a pure
+  function of digests + caps): `{min_cases: 3, max_cases: <cap>, seed:
+  {case_id, title, card_titles}, neighbors: [<same shape>...]}`.
+- **Output**: strict JSON, either `{"selected_case_ids": [...], "rationale":
+  "..."}` or `{"refuse": true, "reason": "..."}`.
+- Instructions demand: ids copied verbatim from the offered digests; 3..cap
+  distinct cases; content diversity (different sources/angles — no
+  same-source rehash / translation / serialized-parts clusters unless
+  corroboration is the point); prefer including the seed but MAY exclude it
+  when the neighbors form a genuinely stronger cluster; ONE tight cluster,
+  not a grab-bag; refusal is explicitly framed as a good answer.
+- Registered as `prompt.cluster_select` in `evolution/components.json`;
+  candidate `evolution/candidates/cluster_select-v1.json` (passes
+  `ovp2 evolve validate --candidate ...`). Cassette namespace
+  `cluster_select/v1`, recorded/replayed like every other call.
+
+## Guard semantics
+
+- **Selection validation** (mechanical, `validate_selection`): selected ids
+  are deduped + sorted; every id must be in the offered set (seed +
+  neighbors); ≥3 and ≤cap distinct ids. A violation records outcome `failed`
+  for that seed (with the reason), invalidates the cassette under a recording
+  cache (a rerun re-asks), and the sweep continues. Infra failures (cassette
+  miss, unrecoverable JSON after one repair) stay run-fatal — same fail-loud
+  contract as batch mode.
+- **Superset guard**: before the synth spend, if any ACTIVE durable record's
+  `source_cases` ⊇ the selected set, outcome `guarded` (logs the guarding
+  `claim_key`). Note the guard can only fire on selections that exclude the
+  seed — a selection containing an uncovered seed is never a subset of an
+  active claim's sources. Repeat clusters within one run are also `guarded`.
+- **Mid-run coverage**: after each cluster's strength verdicts, claims are
+  routed with the SAME `final_routing` the write path uses; cases cited by
+  durable-routed claims join the covered set, and later seeds already covered
+  record outcome `covered` without spending budget.
+- **Budget**: `--max-seeds` (default 25) caps `cluster_select/v1` calls per
+  run; hitting it sets `budget_exhausted` in the stats (rerun to continue —
+  coverage state comes from the ledger, so sweeps are resumable and
+  idempotent).
+- **Zero grounded claims** is a SUCCESS in llm mode (refusals/guards
+  everywhere are a legitimate sweep result), still a gate error in batch mode.
+
+## Run report
+
+- stdout: one `l3[<seed>]: <outcome>` line per seed + sweep totals + coverage
+  delta (`N → M uncovered pack(s)`).
+- `<work-dir>/l3-sweep.jsonl` (written incrementally): per-seed
+  `{seed, outcome: selected|refused|guarded|failed|covered, selected?,
+  rationale?, reason?, error?, guarded_by?, claims?, grounded?,
+  durable_routed?, newly_covered?}`.
+- `<work-dir>/l3-sweep-stats.json`: counters incl. `uncovered_before/after`,
+  `select/synth/strength_calls`, `budget_exhausted`.
+- The usual artifacts (`candidate.json`, `candidate.grounded.json`,
+  `deduped-claims.json`, `strength.json`, `warnings.json`) are written in both
+  modes.
+
+## Requirements / degradation
+
+llm mode needs an embedding cache (`--vault-root` → `.ovp/cache/embeddings`,
+or `--embed-cache-dir`). Text derivation is IDENTICAL to `crystal-themes`
+(title + cleaned reader.md head, `EMBED_MODEL_ID`, cap 128), so a themes run
+warms the sweep. Missing vectors: embedded in `--features embed` builds,
+otherwise a **clear error naming the remedy** — llm mode is meaningless
+without neighborhoods, so there is deliberately NO graceful skip (unlike
+crystal-themes' degradation contract). Themes.json is optional: when present
+it only names the synthesis-context theme (seed community's deterministic
+c-TF-IDF keywords — never display labels); absent → `"cross-source"`.
+
+## A/B experiment harness (`--experiment`)
+
+`ovp2 crystal-synth --experiment` samples a deterministic seeded slice
+(`--experiment-slice`, `--experiment-seed`, SplitMix64 Fisher–Yates) of the
+UNCOVERED packs from the real store (READ-ONLY — the experiment never writes
+the vault store), materializes the slice into `<work>/slice-packs/`, and runs
+both arms against the SAME packs:
+
+| arm | mode | work dir | store | cassettes |
+|---|---|---|---|---|
+| A | batch | `<work>/arm-a` | fresh `<work>/arm-a/store` | `<work>/cassettes-arm-a` |
+| B | llm | `<work>/arm-b` | fresh `<work>/arm-b/store` | `<work>/cassettes-arm-b` |
+
+Arm B's `--max-seeds` defaults to the slice size. One `--client live` run
+records both cassette sets; every rerun replays offline. Output: comparison
+table on stdout + `<work>/comparison.json` with, per arm: **durable yield per
+synth call, gate pass rate, mean distinct sources per durable claim, refusal
+rate, total LLM calls** (select + synth + strength), synthesized/grounded/
+durable/review counts, and coverage delta (arm B).
+
+## Tests (fixture/replay only — no live calls)
+
+`ovp-domain` `crystal::select`: digest extraction (card titles, ordinal +
+`_tag_` stripping, CJK), request purity (cap in the key), parse
+selected/refused/garbage, validation bounds. `ovp-cli`
+`crystal_synth_llm`: sweep-order determinism; full e2e
+(selected/covered/refused/failed in one sweep + idempotent rerun adds 0);
+superset guard fires BEFORE the synth spend and leaves the ledger untouched;
+`--max-seeds` budget; missing-embeddings clear error; missing cache-dir
+config error; neighborhood ranking; theme = keywords never labels.
+`crystal_synth_ab`: seeded sample determinism; full two-arm replay experiment
+(real store untouched, comparison.json metrics). All pre-existing batch-mode
+tests unchanged and green.
+
+## RESULTS (TODO — operator live run)
+
+> Not yet run against the live model. Record once, then replays are free.
+> Baseline at design time: 1077 packs / 585 uncovered (54.3%).
+
+```bash
+# 0) one-time prep (warms embeddings + themes; skip if already fresh)
+ovp2 crystal-themes --vault-root ~/Documents/ovp-vault
+
+# 1) record the A/B once (30-pack slice, seeded) — LIVE calls
+OVP_LLM_NO_PROXY=1 ovp2 crystal-synth --experiment \
+  --vault-root ~/Documents/ovp-vault \
+  --work-dir ~/Documents/ovp-vault/.ovp/l3-ab \
+  --experiment-slice 30 --experiment-seed 42 \
+  --client live
+
+# 2) offline re-analysis any time (same slice, replayed cassettes)
+ovp2 crystal-synth --experiment \
+  --vault-root ~/Documents/ovp-vault \
+  --work-dir ~/Documents/ovp-vault/.ovp/l3-ab \
+  --experiment-slice 30 --experiment-seed 42
+
+# 3) fill in this table from .ovp/l3-ab/comparison.json
+```
+
+| metric | arm A (batch) | arm B (llm) |
+|---|---|---|
+| total LLM calls | TODO | TODO |
+| synth calls | TODO | TODO |
+| durable claims | TODO | TODO |
+| durable yield / synth call | TODO | TODO |
+| gate pass rate | TODO | TODO |
+| mean distinct sources / durable | TODO | TODO |
+| refusal rate | — | TODO |
+| uncovered before → after (slice) | — | TODO |
+
+Decision rule (pre-registered in `evolution/candidates/cluster_select-v1.json`):
+flip the default to llm only if arm B ≥ 1.3× durable yield per synth call AND
+≥ arm A on mean distinct sources AND total calls ≤ 3× arm A. Otherwise keep
+batch and iterate the prompt as `cluster_select/v2` through the evolution flow.
+
+After a GO, the production sweep is:
+
+```bash
+OVP_LLM_NO_PROXY=1 ovp2 crystal-synth --vault-root ~/Documents/ovp-vault \
+  --cluster-mode llm --max-seeds 25 --client live \
+  --refresh --date $(date +%F)
+# resumable: rerun until `coverage: N → M` stops moving or refusals dominate
+```

--- a/docs/stage-semantic-themes.md
+++ b/docs/stage-semantic-themes.md
@@ -140,8 +140,10 @@ config — expect to raise k/resolution around the next corpus doubling
   (`evolution/candidates/theme_label-v1.json`) and validated via
   `ovp2 evolve validate`; the deterministic keyword layer is the auditable
   fallback under every label.
-- **L3 follow-up (out of scope here)**: KMEM-style LLM-shaped synthesis
-  clusters — using claim lineage / relations rather than doc embeddings to
-  group synthesis inputs. The L2 projection deliberately keeps display
-  themes decoupled so L3 can replace the grouping without touching the
-  ledger or the portal.
+- **L3 follow-up — SHIPPED**: KMEM-hybrid LLM-shaped synthesis clusters
+  landed as `crystal-synth --cluster-mode llm` (`cluster_select/v1`,
+  coverage-first sweep over the L1 embedding cache, superset guard, refusal
+  as a first-class answer; batch default unchanged pending the A/B). See
+  `docs/stage-l3-cluster-synthesis.md`. The L2 projection stayed decoupled
+  exactly as planned: L3 replaced the grouping without touching the ledger
+  or the portal.

--- a/evolution/candidates/cluster_select-v1.json
+++ b/evolution/candidates/cluster_select-v1.json
@@ -1,0 +1,23 @@
+{
+  "kind": "ovp.evolution.candidate/v1",
+  "id": "cluster_select-v1",
+  "base_version": "none",
+  "target_version": "v1",
+  "surface": "prompt",
+  "component": "prompt.cluster_select",
+  "hypothesis": "Replacing deterministic <=cap batch-shaping with one small LLM call per uncovered seed (seed+kNN-neighbor digests -> pick 3..cap diverse case ids for ONE claim-worthy cross-source cluster, or refuse) raises durable yield per crystal_synth call and mean distinct sources per durable claim on the ~55%-uncovered real-vault backlog, WITHOUT touching the citation/provenance/strength gates (grouping-only change; the superset guard prevents re-deriving subsets of active claims). Refusal is a first-class output, so wasted synth calls on topically scattered neighborhoods drop instead of producing gate-rejected grab-bag claims.",
+  "predicted_delta": {
+    "durable_yield_per_synth_call": "arm B (llm) >= 1.3x arm A (batch) on the seeded uncovered slice",
+    "mean_distinct_sources_per_durable_claim": "arm B >= arm A",
+    "gate_pass_rate": "arm B >= arm A (selection quality shows up as fewer gate rejections, never as a loosened gate)",
+    "cost": "arm B total LLM calls <= 3x arm A on the same slice (select adds ~1 small call per seed; refusals save the synth+strength spend)"
+  },
+  "guardrails": {},
+  "eval_plan": {
+    "replay_set": "ovp2 crystal-synth --experiment: deterministic seeded slice of uncovered real-vault packs, arm A (batch) vs arm B (llm) on the SAME packs, cassettes recorded once under separate cache dirs (cassettes-arm-a / cassettes-arm-b), replayable offline; comparison.json carries the paired metrics",
+    "paired_sources": 30,
+    "soak": false
+  },
+  "rollback": "Default stays --cluster-mode batch (byte-for-byte unchanged); drop the llm flag from operator runbooks and remove prompt.cluster_select from evolution/components.json. The sweep writes only through the unchanged idempotent crystal-write core, so no ledger surgery is ever needed; l3-sweep.jsonl and the arm stores under the experiment work dir are disposable artifacts.",
+  "ablation_required": false
+}

--- a/evolution/components.json
+++ b/evolution/components.json
@@ -49,6 +49,13 @@
       "quality_buckets": ["crystal_provenance"]
     },
     {
+      "id": "prompt.cluster_select",
+      "surface": "prompt",
+      "current_version": "v1",
+      "file": "crates/ovp-domain/prompts/cluster_select.md",
+      "quality_buckets": ["crystal_provenance", "coverage"]
+    },
+    {
       "id": "prompt.theme_label",
       "surface": "prompt",
       "current_version": "v1",


### PR DESCRIPTION
The final layer of the KMEM-hybrid plan: cluster SHAPE is decided by the LLM, coverage and the citation gate stay ours.

- **`--cluster-mode llm`** (default `batch` unchanged — the pre-registered A/B decides any flip): coverage-first sweep over packs uncited by active durable claims → kNN neighborhood (ovp-embed cache, cross-community) → `cluster_select/v1` picks 3..cap diverse sources or REFUSES (first-class) → mechanical validation → source-set superset guard (no synth spend on covered clusters) → **unchanged** crystal_synth/v1 + gates + idempotent write.
- **cluster_select/v1** evolution candidate (validated); requests are a pure function of digests+caps; cluster theme = deterministic keywords (cassette-key invariant preserved).
- **`--experiment` A/B harness**: same deterministic slice through both arms, separate cassette dirs, per-arm stores reset on rerun (cassettes preserved → exact replay reproducibility, tested), failed arm = command error after diagnostics; comparison.json + table: durable yield/synth call, gate pass rate, distinct sources/claim, refusal rate, total calls. Pre-registered decision rule in the candidate: flip default only if B ≥1.3× yield AND ≥A diversity AND ≤3× calls.
- llm mode rejects impossible bounds (cap<3 / neighborhood<2) before spending anything; budget-exhaustion reporting correct when the last selection covers the remaining seeds.

Vault sanity (read-only): 585/1077 packs uncovered (54.3%) — the sweep's addressable market.

Gates: 845 workspace tests, clippy -D warnings, arch check, evolve validate. Codex gate: PASS (2 P1 + 2 P2 found, all fixed in df9914de).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an LLM-based cluster mode for coverage-first crystal synthesis.
  * Added configurable seed budgets, neighborhood sizes, and embedding caches.
  * Added an experiment mode comparing batch and LLM synthesis with detailed metrics.
  * Added structured selection, validation, refusal handling, and sweep reporting.

* **Documentation**
  * Documented the LLM synthesis workflow, configuration, outputs, requirements, and experiment process.
  * Updated semantic themes documentation to reflect L3 synthesis availability.

* **Tests**
  * Added coverage for deterministic sampling, validation, replayability, budget handling, guards, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->