### PR TITLE
feat(l3): default cluster mode = auto (llm on A/B GO), RESULTS recorded

### DIFF
--- a/crates/ovp-cli/src/main.rs
+++ b/crates/ovp-cli/src/main.rs
@@ -523,14 +523,17 @@ enum Cmd {
         /// if an internal batching bug would send an oversized request.
         #[arg(long)]
         strict_cluster_cap: bool,
-        /// L3: how synthesis inputs are grouped. `batch` (default) keeps the
-        /// deterministic themes/date batching; `llm` runs the coverage-first
-        /// sweep — one cluster_select/v1 call per uncovered pack picks 3..cap
-        /// case ids (or refuses), the superset guard skips clusters an active
-        /// claim already covers, then the UNCHANGED crystal_synth/v1 + gates +
-        /// idempotent write run per cluster. Needs cached embeddings
-        /// (`ovp2 crystal-themes` warms them).
-        #[arg(long, value_enum, default_value_t = ClusterModeArg::Batch)]
+        /// L3: how synthesis inputs are grouped. `llm` (default since the
+        /// 2026-07-10 A/B GO: 2.63x durable yield/synth call, 2.20 mean
+        /// sources, 42 vs cap-51 calls — all three pre-registered criteria)
+        /// runs the coverage-first sweep — one cluster_select/v1 call per
+        /// uncovered pack picks 3..cap case ids (or refuses), the superset
+        /// guard skips clusters an active claim already covers, then the
+        /// UNCHANGED crystal_synth/v1 + gates + idempotent write run per
+        /// wave. Needs cached embeddings (`ovp2 crystal-themes` warms them);
+        /// `batch` keeps the deterministic themes/date batching (and remains
+        /// the automatic fallback when embeddings are unavailable).
+        #[arg(long, value_enum, default_value_t = ClusterModeArg::Auto)]
         cluster_mode: ClusterModeArg,
         /// llm mode: per-run budget cap on cluster_select/v1 calls.
         #[arg(long, default_value_t = 25)]
@@ -975,9 +978,13 @@ enum ClientKindArg {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, clap::ValueEnum)]
 enum ClusterModeArg {
+    /// `llm` when the embed feature + warmed themes/embeddings are present,
+    /// else `batch` with a stderr note — the safe default everywhere.
+    Auto,
     /// Deterministic ≤cap batches (themes.json communities / date order).
     Batch,
-    /// L3 coverage-first LLM cluster selection (cluster_select/v1).
+    /// L3 coverage-first LLM cluster selection (cluster_select/v1) —
+    /// explicit choice fails loud when embeddings are unavailable.
     Llm,
 }
 
@@ -1358,6 +1365,26 @@ fn main() -> ExitCode {
             let cluster_mode = match cluster_mode {
                 ClusterModeArg::Batch => ClusterMode::Batch,
                 ClusterModeArg::Llm => ClusterMode::Llm,
+                // Auto = llm where the L3 prerequisites exist (embed build +
+                // a themes projection as the warmed-embeddings signal), else
+                // the deterministic batcher. Explicit --cluster-mode llm
+                // keeps its fail-loud contract.
+                ClusterModeArg::Auto => {
+                    let themes_present = vault_root
+                        .as_ref()
+                        .map(|v| v.join(".ovp/crystal/themes.json").is_file())
+                        .unwrap_or(false);
+                    if cfg!(feature = "embed") && themes_present {
+                        ClusterMode::Llm
+                    } else {
+                        eprintln!(
+                            "crystal-synth: auto cluster mode → batch (embed feature: {}, themes.json: {}) — run `ovp2 crystal-themes` with an embed build to enable llm clustering",
+                            cfg!(feature = "embed"),
+                            themes_present
+                        );
+                        ClusterMode::Batch
+                    }
+                }
             };
             if experiment {
                 commands::crystal_synth_ab::run_experiment(

--- a/docs/stage-l3-cluster-synthesis.md
+++ b/docs/stage-l3-cluster-synthesis.md
@@ -171,10 +171,24 @@ cache-dir config error; neighborhood ranking; theme = keywords never labels.
 (real store untouched, comparison.json metrics). All pre-existing batch-mode
 tests unchanged and green.
 
-## RESULTS (TODO — operator live run)
+## RESULTS — GO (2026-07-10, three rounds recorded)
 
-> Not yet run against the live model. Record once, then replays are free.
-> Baseline at design time: 1077 packs / 585 uncovered (54.3%).
+> Baseline: 1077 packs / 585 uncovered (54.3%). Slice = 30 packs, seed 42.
+> Three live rounds, full decision trail:
+>
+> - **Round 1**: arm B ABORTED whole-arm on one envelope-less cluster-select
+>   reply → fix #316 (parse garbage fails one seed, keeps sweeping; replay
+>   cache misses stay fatal to protect reproducibility).
+> - **Round 2**: arm B completed — yield 2.53 (2.36×) and sources 2.26 both
+>   PASSED, but total calls 52 vs the ≤51 cap: **criterion #3 missed by one
+>   call**. Decomposition showed the overage was per-cluster strength calls
+>   (15 for 79 claims) while batch mode chunks ≤20/call → fix #317
+>   (micro-batched strength waves, coverage lag bounded to one chunk). The
+>   pre-registered rule was honored: no flip on 2/3.
+> - **Round 3 (final, table below)**: all three criteria pass → default
+>   flipped to llm via a safe `auto` mode (llm when embed build + warmed
+>   themes exist, else batch with a stderr note; explicit `--cluster-mode
+>   llm` keeps fail-loud).
 
 ```bash
 # 0) one-time prep (warms embeddings + themes; skip if already fresh)
@@ -196,16 +210,16 @@ ovp2 crystal-synth --experiment \
 # 3) fill in this table from .ovp/l3-ab/comparison.json
 ```
 
-| metric | arm A (batch) | arm B (llm) |
-|---|---|---|
-| total LLM calls | TODO | TODO |
-| synth calls | TODO | TODO |
-| durable claims | TODO | TODO |
-| durable yield / synth call | TODO | TODO |
-| gate pass rate | TODO | TODO |
-| mean distinct sources / durable | TODO | TODO |
-| refusal rate | — | TODO |
-| uncovered before → after (slice) | — | TODO |
+| metric | arm A (batch) | arm B (llm) | criterion | verdict |
+|---|---|---|---|---|
+| total LLM calls | 17 | **42** | ≤ 3× A (51) | ✅ |
+| synth calls | 14 | 16 | — | — |
+| durable claims | 15 | **45** | — | 3.0× |
+| durable yield / synth call | 1.07 | **2.81** | ≥ 1.3× A (1.39) | ✅ 2.63× |
+| gate pass rate | 0.25 | **0.54** | — | 2.2× |
+| mean distinct sources / durable | 2.07 | **2.20** | ≥ A | ✅ |
+| refusal rate | — | 0.27 | — | healthy |
+| select / synth / strength split | 0/14/3 | 22/16/4 | — | — |
 
 Decision rule (pre-registered in `evolution/candidates/cluster_select-v1.json`):
 flip the default to llm only if arm B ≥ 1.3× durable yield per synth call AND


### PR DESCRIPTION
Round-3 A/B: **all three pre-registered criteria pass** — durable yield/synth 2.81 vs 1.07 (2.63×, required ≥1.3×), mean distinct sources 2.20 vs 2.07, total LLM calls 42 vs cap 51. Same 30 sources: 45 vs 15 durable claims; gate pass 0.54 vs 0.25; refusal 0.27.

Default flips through a safe `auto` mode: resolves to llm when the embed build + warmed themes.json exist, else batch with a stderr note pointing at `ovp2 crystal-themes`; explicit `--cluster-mode llm` keeps fail-loud. docs RESULTS section records the whole trail — round-1 abort (fixed #316), round-2's one-call miss honored as NO-FLIP per the rule (fixed #317), round-3 GO.

Gates: 848 workspace tests, clippy -D warnings, arch check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `Auto` cluster mode for crystal synthesis.
  * The default now automatically uses LLM-based clustering when warmed embeddings are available, otherwise falling back to deterministic batch clustering with a notice.
  * Updated command-line help to explain automatic cluster selection and coverage-first behavior.

* **Documentation**
  * Added recorded results, evaluation metrics, and A/B comparison outcomes for batch and LLM clustering.
  * Documented the safe automatic default and explicit LLM mode behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->