### PR TITLE
fix(daily): live per-source progress — a silent 46-minute run was misdiagnosed as hung today

### DIFF
--- a/crates/ovp-cli/src/commands/crystal_synth_llm.rs
+++ b/crates/ovp-cli/src/commands/crystal_synth_llm.rs
@@ -166,6 +166,9 @@ fn write_jsonl<T: Serialize>(report: &mut std::fs::File, line: &T) -> Result<(),
 
 fn write_seed_line(report: &mut std::fs::File, line: &SeedReport) -> Result<(), CliError> {
     println!("  l3[{}]: {}", line.seed, line.outcome);
+    // A sweep is long-running and usually watched through nohup/pipes, where
+    // stdout is block-buffered — flush so the per-seed line shows live.
+    let _ = std::io::stdout().flush();
     write_jsonl(report, line)
 }
 
@@ -408,6 +411,7 @@ fn flush_strength_wave(
         "  l3[wave {wave:03}]: {} claim(s) → {calls} strength call(s), {durable_routed} durable-routed",
         ids.len()
     );
+    let _ = std::io::stdout().flush(); // live under nohup/pipes (see write_seed_line)
     write_jsonl(
         report,
         &WaveReport {

--- a/crates/ovp-cli/src/commands/daily.rs
+++ b/crates/ovp-cli/src/commands/daily.rs
@@ -15,8 +15,8 @@ use std::path::PathBuf;
 
 use ovp_console::{write_console, write_ops_pages};
 use ovp_daily::{
-    plan_daily, read_daily_ledger, run_daily, succeeded_hashes, DailyConfig, RunReport,
-    RunStatus,
+    plan_daily, read_daily_ledger, run_daily_with_progress, succeeded_hashes, DailyConfig,
+    DailyRunRecord, RunReport, RunStatus,
 };
 use ovp_domain::VaultLayout;
 use ovp_index::{build_evidence, build_index, write_evidence, write_index};
@@ -28,6 +28,18 @@ use ovp_intake::{sweep_intake, sync_pinboard, FixturePinboardFetch, IntakeConfig
 
 use crate::commands::client::{build_client, ClientKind};
 use crate::CliError;
+
+/// `println!` + explicit stdout flush. Daily runs are watched through nohup /
+/// pipes (block-buffered stdout) and the reader phase can run for hours; every
+/// phase header and per-source line must hit the log the moment it is printed —
+/// a healthy 46-minute run was once killed as "hung" because nothing showed.
+macro_rules! sayln {
+    ($($arg:tt)*) => {{
+        println!($($arg)*);
+        use std::io::Write as _;
+        let _ = std::io::stdout().flush();
+    }};
+}
 
 pub struct DailyArgs {
     pub vault_root: PathBuf,
@@ -83,7 +95,7 @@ pub fn run(args: DailyArgs) -> Result<(), CliError> {
     };
 
     let mut report = RunReport::new(&args.run_id, &args.date);
-    println!("daily [{}]: vault {}", args.date, args.vault_root.display());
+    sayln!("daily [{}]: vault {}", args.date, args.vault_root.display());
 
     // Phase 1 — pinboard capture (optional). Inherits the first-sync flood
     // guard: an unfiltered sync with >500 NEW bookmarks fails this phase
@@ -98,12 +110,12 @@ pub fn run(args: DailyArgs) -> Result<(), CliError> {
         };
         let outcome = sync_pinboard(&intake_cfg, fetch.as_mut(), args.dry_run, &opts)
             .map_err(CliError::Io)?;
-        println!(
+        sayln!(
             "  pinboard: {} fetched, {} new note(s), {} known ({})",
             outcome.fetched, outcome.new_notes.len(), outcome.skipped_known, outcome.origin
         );
         if outcome.guard_would_abort {
-            println!(
+            sayln!(
                 "  WARNING: a REAL run would ABORT at the pinboard phase — {} new bookmark(s) \
                  exceed the {}-note first-sync guard; pass --pinboard-since or --pinboard-max \
                  (or run `ovp2 pinboard-sync --yes-all` once, deliberately)",
@@ -120,7 +132,7 @@ pub fn run(args: DailyArgs) -> Result<(), CliError> {
     if !args.no_intake {
         let done = succeeded_hashes(&read_daily_ledger(&ledger_path).map_err(CliError::Io)?);
         let sweep = sweep_intake(&intake_cfg, &done, args.dry_run).map_err(CliError::Io)?;
-        println!(
+        sayln!(
             "  intake: {} ingested, {} duplicate(s), {} needs-content, {} unparseable{}{}",
             sweep.ingested.len(), sweep.duplicates.len(), sweep.needs_content.len(),
             sweep.unparseable.len(),
@@ -156,14 +168,14 @@ pub fn run(args: DailyArgs) -> Result<(), CliError> {
             );
             let enriched = results.iter().filter(|r| r.updated).count();
             let failed = results.iter().filter(|r| !r.updated).count();
-            println!(
+            sayln!(
                 "  enrich: {} needs-content URL(s), {} enriched, {} failed",
                 needs_content_items.len(), enriched, failed,
             );
             for r in &results {
                 if !r.updated
                     && let Some(err) = &r.fetch.error {
-                        println!("    skip {}: {err}", r.url);
+                        sayln!("    skip {}: {err}", r.url);
                     }
             }
         }
@@ -189,14 +201,14 @@ pub fn run(args: DailyArgs) -> Result<(), CliError> {
             );
             let written = results.iter().filter(|r| r.written).count();
             let failed = results.iter().filter(|r| !r.written).count();
-            println!(
+            sayln!(
                 "  github: {} repo URL(s), {} enriched, {} failed",
                 github_items.len(), written, failed,
             );
             for r in &results {
                 if !r.written
                     && let Some(err) = &r.fetch.error {
-                        println!("    skip {}/{}: {err}", r.owner, r.repo);
+                        sayln!("    skip {}/{}: {err}", r.owner, r.repo);
                     }
             }
         }
@@ -206,25 +218,25 @@ pub fn run(args: DailyArgs) -> Result<(), CliError> {
     let ledger = read_daily_ledger(&ledger_path).map_err(CliError::Io)?;
     let work = plan_daily(&inbox, &args.vault_root, &ledger, args.retry_blocked)
         .map_err(CliError::Io)?;
-    println!(
+    sayln!(
         "  plan: {} new source(s), {} skipped, {} blocked",
         work.todo.len(), work.skipped.len(), work.blocked.len()
     );
     for item in &work.blocked {
-        println!("    blocked ({} failures): {} — rerun with --retry-blocked after review",
+        sayln!("    blocked ({} failures): {} — rerun with --retry-blocked after review",
             item.prior_failures, item.rel);
     }
     if args.dry_run {
         for item in &work.todo {
-            println!("  would process: {} ({})", item.rel, &item.sha256[..8]);
+            sayln!("  would process: {} ({})", item.rel, &item.sha256[..8]);
         }
         if dry_run_pending_ingest > 0 {
-            println!(
+            sayln!(
                 "  note: {dry_run_pending_ingest} capture(s) above would ALSO be ingested into \
                  01-Raw and then planned on a real run (dry-run intake moves nothing)"
             );
         }
-        println!("  dry-run: nothing written.");
+        sayln!("  dry-run: nothing written.");
         return Ok(());
     }
 
@@ -243,30 +255,32 @@ pub fn run(args: DailyArgs) -> Result<(), CliError> {
         retry_blocked: args.retry_blocked,
     };
     let planned = work.todo.len();
-    let daily = run_daily(&cfg, &work, &mut make_client).map_err(CliError::Io)?;
+    // Live per-source progress: the reader phase is the long one (up to hours
+    // at high --max-sources), so each ok/FAIL line prints — flushed — the
+    // moment its source finishes, not after run_daily returns.
+    let mut on_source = |rec: &DailyRunRecord| match rec.status {
+        RunStatus::Succeeded => sayln!(
+            "  ok   {} → {} (units={} cards={}){}",
+            rec.source_path,
+            rec.pack_dir.as_deref().unwrap_or("?"),
+            rec.units,
+            rec.cards,
+            rec.moved_to.as_deref().map(|m| format!(" moved→{m}")).unwrap_or_default(),
+        ),
+        RunStatus::Failed => sayln!(
+            "  FAIL {} — {}",
+            rec.source_path,
+            rec.reason.as_deref().unwrap_or("unknown")
+        ),
+    };
+    let daily = run_daily_with_progress(&cfg, &work, &mut make_client, &mut on_source)
+        .map_err(CliError::Io)?;
 
-    for rec in &daily.processed {
-        match rec.status {
-            RunStatus::Succeeded => println!(
-                "  ok   {} → {} (units={} cards={}){}",
-                rec.source_path,
-                rec.pack_dir.as_deref().unwrap_or("?"),
-                rec.units,
-                rec.cards,
-                rec.moved_to.as_deref().map(|m| format!(" moved→{m}")).unwrap_or_default(),
-            ),
-            RunStatus::Failed => println!(
-                "  FAIL {} — {}",
-                rec.source_path,
-                rec.reason.as_deref().unwrap_or("unknown")
-            ),
-        }
-    }
     for w in &daily.lifecycle_warnings {
-        println!("  warn {w}");
+        sayln!("  warn {w}");
     }
     if daily.capped > 0 {
-        println!(
+        sayln!(
             "  capped: {} source(s) left for the next run (--max-sources {})",
             daily.capped, cfg.max_sources
         );
@@ -305,7 +319,7 @@ pub fn run(args: DailyArgs) -> Result<(), CliError> {
                     }
                 }
                 if total_images > 0 {
-                    println!(
+                    sayln!(
                         "  images: {} found, {} downloaded across {} pack(s)",
                         total_images, total_downloaded, succeeded_packs.len()
                     );
@@ -335,7 +349,7 @@ pub fn run(args: DailyArgs) -> Result<(), CliError> {
         let content = ovp_memory::digest::render_plain_digest(&data);
         if let Ok(dpath) = ovp_memory::digest::write_digest(&args.vault_root, &args.date, &content) {
             let drel = dpath.strip_prefix(&args.vault_root).unwrap_or(&dpath).display();
-            println!("  digest: {drel}");
+            sayln!("  digest: {drel}");
         }
     }
 
@@ -348,23 +362,23 @@ pub fn run(args: DailyArgs) -> Result<(), CliError> {
         let wm_content = ovp_memory::working_memory::build_working_memory(&model, &wm_args);
         if let Ok(wm_path) = ovp_memory::working_memory::write_working_memory(&args.vault_root, &wm_content) {
             let wm_rel = wm_path.strip_prefix(&args.vault_root).unwrap_or(&wm_path).display();
-            println!("  working-memory: {wm_rel}");
+            sayln!("  working-memory: {wm_rel}");
         }
     }
 
     let failed = daily.failed();
-    println!(
+    sayln!(
         "  done: {} processed, {failed} failed, {} skipped (report: {report_rel})",
         daily.processed.len(), daily.skipped
     );
-    println!("  index: {index_rel} · evidence: {evidence_rel} · console: {console_rel}");
+    sayln!("  index: {index_rel} · evidence: {evidence_rel} · console: {console_rel}");
 
     // Semantic-theme staleness HINT (never an action): daily must not
     // auto-run crystal-themes — a cold model cache means a surprise ~450MB
     // download — but the operator should know when new packs are unthemed.
     if let Some(n) = stale_theme_packs(&args.vault_root, &model)
         && n > 0 {
-            println!(
+            sayln!(
                 "  themes: {n} pack(s) not in .ovp/crystal/themes.json — run `ovp2 crystal-themes` to re-theme"
             );
         }

--- a/crates/ovp-daily/src/lib.rs
+++ b/crates/ovp-daily/src/lib.rs
@@ -183,6 +183,23 @@ pub fn run_daily<F>(
 where
     F: FnMut() -> Result<Box<dyn ModelClient>, String>,
 {
+    run_daily_with_progress(cfg, work, make_client, &mut |_| {})
+}
+
+/// [`run_daily`] with a live progress hook: `on_source` is invoked exactly once
+/// per attempted source — succeeded or failed — immediately after that source
+/// finishes (record durable, lifecycle move done) and BEFORE the next source
+/// starts. A reader batch can run for hours; without this hook the caller has
+/// nothing to show the operator until the whole run returns.
+pub fn run_daily_with_progress<F>(
+    cfg: &DailyConfig,
+    work: &DailyWork,
+    make_client: &mut F,
+    on_source: &mut dyn FnMut(&DailyRunRecord),
+) -> Result<DailyReport, String>
+where
+    F: FnMut() -> Result<Box<dyn ModelClient>, String>,
+{
     let layout = VaultLayout::new();
     let ledger_path = cfg.vault_root.join(layout.daily_ledger());
     let log_path = cfg.vault_root.join(layout.pipeline_log());
@@ -212,6 +229,7 @@ where
             record.moved_to = move_to_processed(cfg, &layout, item, &log_path,
                 &mut daily_report.lifecycle_warnings);
         }
+        on_source(&record);
         daily_report.processed.push(record);
     }
     Ok(daily_report)

--- a/crates/ovp-daily/tests/daily_loop.rs
+++ b/crates/ovp-daily/tests/daily_loop.rs
@@ -8,7 +8,7 @@
 use std::path::Path;
 
 use ovp_daily::{
-    plan_daily, read_daily_ledger, run_daily, DailyConfig, RunStatus,
+    plan_daily, read_daily_ledger, run_daily, run_daily_with_progress, DailyConfig, RunStatus,
 };
 use ovp_llm::{CallError, ModelClient, ModelReply, ModelRequest, StopReason, Usage};
 
@@ -218,6 +218,55 @@ fn max_sources_caps_a_run_loudly() {
     let report = run_daily(&c, &work, &mut factory).unwrap();
     assert_eq!(report.processed.len(), 1);
     assert_eq!(report.capped, 2);
+}
+
+#[test]
+fn progress_hook_fires_once_per_source_in_order_with_final_record() {
+    // The operator-visibility contract behind `ovp2 daily`'s live ok/FAIL
+    // lines: the hook fires exactly once per attempted source (succeeded AND
+    // failed), in processing order, with the finished record — lifecycle move
+    // already reflected — so the CLI can print each line as it happens instead
+    // of after an hours-long batch.
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write_vault_with_inbox(root, &[("a", BODY), ("b", BODY2)]);
+
+    let work = plan_daily(&root.join("50-Inbox/01-Raw"), root, &[], false).unwrap();
+    assert_eq!(work.todo.len(), 2);
+
+    // a.md succeeds (canned trunk replies), b.md fails at the base stage.
+    let card_reply = format!(
+        r#"{{"cards":[{{"title":"t","content":"A chunk is structurally neutral.","cited_unit_ids":["{}"]}}]}}"#,
+        accepted_unit_id()
+    );
+    let mut factory = factory_for(vec![
+        units_reply(), "{}".into(), card_reply, // a: base, critic, cards
+        "not json".into(), "{}".into(), "{}".into(), // b: fails at base
+    ]);
+
+    let mut seen: Vec<(String, RunStatus, Option<String>)> = Vec::new();
+    let report = run_daily_with_progress(&cfg(root), &work, &mut factory, &mut |rec| {
+        seen.push((rec.source_path.clone(), rec.status, rec.moved_to.clone()));
+    })
+    .unwrap();
+
+    assert_eq!(seen.len(), report.processed.len(), "one hook call per attempted source");
+    assert_eq!(seen[0].0, "50-Inbox/01-Raw/a.md");
+    assert_eq!(seen[0].1, RunStatus::Succeeded);
+    assert_eq!(
+        seen[0].2.as_deref(),
+        Some("50-Inbox/03-Processed/2026-06/a.md"),
+        "lifecycle move already visible at hook time"
+    );
+    assert_eq!(seen[1].0, "50-Inbox/01-Raw/b.md");
+    assert_eq!(seen[1].1, RunStatus::Failed);
+    assert_eq!(seen[1].2, None);
+    // The hook sees the SAME records the report carries, in the same order.
+    for (call, rec) in seen.iter().zip(&report.processed) {
+        assert_eq!(call.0, rec.source_path);
+        assert_eq!(call.1, rec.status);
+        assert_eq!(call.2, rec.moved_to);
+    }
 }
 
 #[test]


### PR DESCRIPTION
run_daily printed all per-source ok/FAIL lines only after the whole reader phase returned — hours of silence at high --max-sources, and block-buffered stdout under nohup hid even the end-of-run lines. A healthy catch-up run was killed today on that false signal.

- ovp-daily: run_daily_with_progress(on_source hook) fires once per attempted source, right after its ledger record is durable + lifecycle move done (moved_to visible in the printed line); run_daily wraps with a no-op hook — zero churn for existing callers.
- CLI: sayln! (println + flush) on every phase/progress line; the hook prints the identical ok/FAIL format live; duplicate end-of-run loop removed.
- Same audit applied to the L3 sweep's per-seed/per-wave lines (flush added).

Tests: hook-order/content test; 873 workspace tests, clippy -D warnings, arch check. Codex gate: PASS (no findings).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live progress updates for daily processing, including per-source success and failure statuses.
  * Progress output now appears immediately during long-running operations, including sweep, enrichment, downloads, and digest generation.

* **Bug Fixes**
  * Improved output behavior when running commands through pipes or background processes, ensuring logs and JSONL results are visible without delay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->