### PR TITLE
fix(obs P0): run-liveness heartbeat — unattended crashes are now visible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1640,6 +1640,7 @@ dependencies = [
 name = "ovp-server"
 version = "2.0.1"
 dependencies = [
+ "ovp-daily",
  "ovp-domain",
  "ovp-index",
  "ovp-intake",

--- a/console-ui/src/components/RunBanner.tsx
+++ b/console-ui/src/components/RunBanner.tsx
@@ -17,7 +17,7 @@ import { useModel } from '../model';
 
 /** Re-render tick so the age string advances. A minute is granular enough for
  * a wall-clock banner; the interval is cleared on unmount. */
-function useNowTick(intervalMs = 60_000): number {
+export function useNowTick(intervalMs = 60_000): number {
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
     const id = window.setInterval(() => setNow(Date.now()), intervalMs);

--- a/console-ui/src/components/RunBanner.tsx
+++ b/console-ui/src/components/RunBanner.tsx
@@ -1,0 +1,97 @@
+/** Fixed top strip surfacing run-liveness (OVP2 observability P0). Rendered by
+ * the Shell above every page. It reflects `.ovp/last-run.json`:
+ *   green  — completed recently ("Last run: completed 2h ago · 8 read · 180 queued")
+ *   amber  — stale (older than the schedule interval) or no runs yet
+ *   red    — the last run FAILED / ABORTED (with the short error)
+ * Clicking navigates to the System page.
+ *
+ * Age is computed client-side from started_at/ended_at + Date.now and ticks on
+ * an interval, so it stays honest without refetching the model. It renders even
+ * when the model is null/empty — a stalled vault is exactly when the operator
+ * most needs to see it — so it never sits behind the model's loading gate. */
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useI18n } from '../i18n';
+import { lastRunBanner, type BannerLevel } from '../lib/derive';
+import { useModel } from '../model';
+
+/** Re-render tick so the age string advances. A minute is granular enough for
+ * a wall-clock banner; the interval is cleared on unmount. */
+function useNowTick(intervalMs = 60_000): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = window.setInterval(() => setNow(Date.now()), intervalMs);
+    return () => window.clearInterval(id);
+  }, [intervalMs]);
+  return now;
+}
+
+/** Banner level → the status-light color class the CSS already defines. */
+const LEVEL_CLASS: Record<BannerLevel, string> = {
+  ok: 'ok',
+  stale: 'attention',
+  failed: 'failed',
+  none: 'muted',
+};
+
+export default function RunBanner() {
+  const { t } = useI18n();
+  const { model } = useModel();
+  const navigate = useNavigate();
+  const now = useNowTick();
+
+  const banner = lastRunBanner(model, now);
+
+  const ago = (): string => {
+    const m = banner.ageMinutes;
+    if (m == null) return '';
+    if (m < 1) return t('banner.agoJustNow');
+    if (m < 60) return t('banner.agoMinutes', { n: m });
+    if (m < 60 * 24) return t('banner.agoHours', { n: Math.floor(m / 60) });
+    return t('banner.agoDays', { n: Math.floor(m / (60 * 24)) });
+  };
+
+  const shortError = (): string => {
+    if (!banner.error) return '';
+    const e = banner.error.length > 120
+      ? `${banner.error.slice(0, 117)}…`
+      : banner.error;
+    return ` — ${e}`;
+  };
+
+  let text: string;
+  if (banner.level === 'none') {
+    text = t('banner.none');
+  } else if (banner.status === 'failed') {
+    text = t('banner.failed', { ago: ago(), error: shortError() });
+  } else if (banner.status === 'aborted') {
+    text = t('banner.aborted', { ago: ago(), error: shortError() });
+  } else if (banner.level === 'stale') {
+    text = t('banner.stale', { ago: ago() });
+  } else if (banner.status === 'running') {
+    text = t('banner.running', { ago: ago() });
+  } else if (banner.processed != null && banner.queuedAfter != null) {
+    text = t('banner.completedCounts', {
+      ago: ago(),
+      read: banner.processed,
+      queued: banner.queuedAfter,
+    });
+  } else {
+    text = t('banner.completed', { ago: ago() });
+  }
+
+  const level = LEVEL_CLASS[banner.level];
+
+  return (
+    <button
+      type="button"
+      className={`run-banner ${level}`}
+      onClick={() => navigate('/system')}
+      title={t('banner.viewSystem')}
+      aria-label={text}
+    >
+      <span className="run-banner-dot" />
+      <span className="run-banner-text">{text}</span>
+    </button>
+  );
+}

--- a/console-ui/src/components/Shell.tsx
+++ b/console-ui/src/components/Shell.tsx
@@ -10,6 +10,7 @@ import { useEffect, useState } from 'react';
 import { NavLink, Outlet, useLocation } from 'react-router-dom';
 import { useI18n } from '../i18n';
 import { healthLevel } from '../lib/derive';
+import { useNowTick } from './RunBanner';
 import { useModel } from '../model';
 import { useTheme } from '../theme';
 import RunBanner from './RunBanner';
@@ -27,8 +28,11 @@ const NAV = [
 function StatusLight() {
   const { t } = useI18n();
   const { model } = useModel();
+  // Tick so a heartbeat that crosses the staleness threshold flips the dot
+  // to red even on a portal left open with no other re-render (codex P2).
+  const now = useNowTick();
   if (!model) return null;
-  const level = healthLevel(model);
+  const level = healthLevel(model, now);
   const label = {
     ok: t('status.ok'),
     attention: t('status.attention'),

--- a/console-ui/src/components/Shell.tsx
+++ b/console-ui/src/components/Shell.tsx
@@ -12,6 +12,7 @@ import { useI18n } from '../i18n';
 import { healthLevel } from '../lib/derive';
 import { useModel } from '../model';
 import { useTheme } from '../theme';
+import RunBanner from './RunBanner';
 import SearchOmnibox from './SearchOmnibox';
 
 const NAV = [
@@ -121,6 +122,7 @@ export default function Shell() {
 
   return (
     <div className="portal">
+      <RunBanner />
       <div className="page">
         <div className="shell">
           <div className="shell-head">

--- a/console-ui/src/design/portal.css
+++ b/console-ui/src/design/portal.css
@@ -164,6 +164,66 @@ body {
   background: var(--c-6);
 }
 
+/* ---------- run-liveness banner: fixed top strip, every page ---------- */
+.run-banner {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.4rem 1.5rem;
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  font-family: var(--ovp-font-mono);
+  font-size: var(--ovp-text-xs);
+  font-weight: 600;
+  cursor: pointer;
+  text-align: left;
+  background: var(--surface);
+  color: var(--muted);
+  transition:
+    background 200ms,
+    color 200ms;
+}
+.run-banner:hover {
+  filter: brightness(0.98);
+}
+.run-banner .run-banner-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--ovp-radius-pill);
+  flex: 0 0 auto;
+  background: var(--muted);
+}
+.run-banner-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.run-banner.ok {
+  color: var(--c-3);
+  background: color-mix(in srgb, var(--c-3) 8%, var(--surface));
+}
+.run-banner.ok .run-banner-dot {
+  background: var(--c-3);
+}
+.run-banner.attention {
+  color: var(--warn-text);
+  background: var(--warn-bg);
+}
+.run-banner.attention .run-banner-dot {
+  background: var(--warn-border);
+}
+.run-banner.failed {
+  color: var(--c-6);
+  background: color-mix(in srgb, var(--c-6) 10%, var(--surface));
+}
+.run-banner.failed .run-banner-dot {
+  background: var(--c-6);
+}
+
 /* ---------- toggles (theme + language): text buttons in a pill ---------- */
 .seg-toggle {
   display: inline-flex;

--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -15,6 +15,20 @@ export const en = {
   'status.attention': 'attention',
   'status.failed': 'last run failed',
 
+  // run-liveness banner (fixed top strip, every page)
+  'banner.none': 'No runs yet',
+  'banner.completed': 'Last run: completed {ago}',
+  'banner.completedCounts': 'Last run: completed {ago} · {read} read · {queued} queued',
+  'banner.running': 'Run in progress · started {ago}',
+  'banner.stale': 'Last run: {ago} — the daily loop may be stalled',
+  'banner.failed': 'Last run: FAILED {ago}{error}',
+  'banner.aborted': 'Last run: ABORTED {ago}{error}',
+  'banner.agoJustNow': 'just now',
+  'banner.agoMinutes': '{n}m ago',
+  'banner.agoHours': '{n}h ago',
+  'banner.agoDays': '{n}d ago',
+  'banner.viewSystem': 'View system status',
+
   // shared
   'common.loading': 'Loading…',
   'common.error': 'Could not load the index model — is the server running against a vault?',

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -15,6 +15,20 @@ export const zh: Record<keyof typeof en, string> = {
   'status.attention': '需处理',
   'status.failed': '最近运行失败',
 
+  // run-liveness banner (fixed top strip, every page)
+  'banner.none': '尚无运行记录',
+  'banner.completed': '最近运行：已完成 {ago}',
+  'banner.completedCounts': '最近运行：已完成 {ago} · 阅读 {read} · 队列 {queued}',
+  'banner.running': '运行进行中 · 开始于 {ago}',
+  'banner.stale': '最近运行：{ago} —— 每日流程可能已停滞',
+  'banner.failed': '最近运行：失败 {ago}{error}',
+  'banner.aborted': '最近运行：中断 {ago}{error}',
+  'banner.agoJustNow': '刚刚',
+  'banner.agoMinutes': '{n} 分钟前',
+  'banner.agoHours': '{n} 小时前',
+  'banner.agoDays': '{n} 天前',
+  'banner.viewSystem': '查看系统状态',
+
   // shared
   'common.loading': '加载中…',
   'common.error': '无法加载索引模型——服务是否已连接 vault？',

--- a/console-ui/src/lib/derive.test.ts
+++ b/console-ui/src/lib/derive.test.ts
@@ -1,0 +1,147 @@
+/** Unit tests for the run-liveness banner derivation (OVP2 observability P0).
+ * Pure functions over the model + a passed-in wall clock — no DOM. */
+import { describe, expect, it } from 'vitest';
+import {
+  healthLevel,
+  lastRunBanner,
+  STALE_AFTER_MS,
+} from './derive';
+import type { IndexModel, LastRunModel } from './types';
+
+const NOW = Date.parse('2026-07-12T12:00:00Z');
+
+function model(lastRun: LastRunModel | null, overrides: Partial<IndexModel> = {}): IndexModel {
+  return {
+    schema: 'ovp.index/v2',
+    date: '2026-07-12',
+    totals: {
+      sources: 0,
+      queued: 0,
+      processed: 0,
+      failed: 0,
+      blocked: 0,
+      needs_content: 0,
+      unparseable: 0,
+      duplicates: 0,
+      packs: 0,
+      claims_durable: 0,
+      claims_caveated: 0,
+      runs: 0,
+    },
+    sources: [],
+    packs: [],
+    claims: [],
+    runs: [],
+    ops: { blocked_sources: [], queue_depth: 0, last_run: lastRun },
+    ...overrides,
+  };
+}
+
+describe('lastRunBanner', () => {
+  it('is "none" for a null model — the banner never hides behind an empty model', () => {
+    const b = lastRunBanner(null, NOW);
+    expect(b.level).toBe('none');
+    expect(b.status).toBeNull();
+    expect(b.ageMinutes).toBeNull();
+  });
+
+  it('is "none" when the model has no heartbeat', () => {
+    expect(lastRunBanner(model(null), NOW).level).toBe('none');
+  });
+
+  it('is green + ages for a recent completed run, with counts', () => {
+    const b = lastRunBanner(
+      model({
+        run_id: 'r',
+        started_at: '2026-07-12T09:50:00Z',
+        ended_at: '2026-07-12T10:00:00Z',
+        status: 'completed',
+        processed: 8,
+        queued_after: 180,
+      }),
+      NOW,
+    );
+    expect(b.level).toBe('ok');
+    expect(b.ageMinutes).toBe(120); // 10:00 → 12:00
+    expect(b.processed).toBe(8);
+    expect(b.queuedAfter).toBe(180);
+  });
+
+  it('is red for a failed run regardless of age, carrying the error', () => {
+    const b = lastRunBanner(
+      model({
+        run_id: 'r',
+        started_at: '2026-07-12T11:00:00Z',
+        ended_at: '2026-07-12T11:05:00Z',
+        status: 'failed',
+        error: 'ANTHROPIC_API_KEY expired',
+      }),
+      NOW,
+    );
+    expect(b.level).toBe('failed');
+    expect(b.status).toBe('failed');
+    expect(b.error).toBe('ANTHROPIC_API_KEY expired');
+  });
+
+  it('is red for an aborted run', () => {
+    const b = lastRunBanner(
+      model({
+        run_id: 'r',
+        started_at: '2026-07-12T11:00:00Z',
+        ended_at: '2026-07-12T11:30:00Z',
+        status: 'aborted',
+        error: 'panic',
+      }),
+      NOW,
+    );
+    expect(b.level).toBe('failed');
+    expect(b.status).toBe('aborted');
+  });
+
+  it('turns amber (stale) when a completed run is older than the schedule interval', () => {
+    const old = new Date(NOW - STALE_AFTER_MS - 60_000).toISOString();
+    const b = lastRunBanner(
+      model({ run_id: 'r', started_at: old, ended_at: old, status: 'completed' }),
+      NOW,
+    );
+    expect(b.level).toBe('stale');
+  });
+
+  it('treats a long-"running" run past the interval as stale (drop-guard never fired)', () => {
+    const old = new Date(NOW - STALE_AFTER_MS - 60_000).toISOString();
+    const b = lastRunBanner(
+      model({ run_id: 'r', started_at: old, status: 'running' }),
+      NOW,
+    );
+    expect(b.level).toBe('stale');
+  });
+});
+
+describe('healthLevel reconciliation', () => {
+  it('goes red when the heartbeat failed even if no per-source run failed', () => {
+    const m = model({
+      run_id: 'r',
+      started_at: '2026-07-12T11:00:00Z',
+      ended_at: '2026-07-12T11:05:00Z',
+      status: 'failed',
+      error: 'boom',
+    });
+    expect(healthLevel(m, NOW)).toBe('failed');
+  });
+
+  it('goes red on a stale heartbeat', () => {
+    const old = new Date(NOW - STALE_AFTER_MS - 60_000).toISOString();
+    const m = model({ run_id: 'r', started_at: old, ended_at: old, status: 'completed' });
+    expect(healthLevel(m, NOW)).toBe('failed');
+  });
+
+  it('is green when the heartbeat is fresh + completed and nothing needs attention', () => {
+    const m = model({
+      run_id: 'r',
+      started_at: '2026-07-12T11:50:00Z',
+      ended_at: '2026-07-12T11:55:00Z',
+      status: 'completed',
+    });
+    expect(healthLevel(m, NOW)).toBe('ok');
+  });
+});

--- a/console-ui/src/lib/derive.ts
+++ b/console-ui/src/lib/derive.ts
@@ -4,18 +4,103 @@
 import type {
   ClaimRow,
   IndexModel,
+  LastRunModel,
   PackRow,
   RunRow,
   SourceRow,
 } from './types';
 
+// ------------------------------------------------------ run-liveness heartbeat
+
+/** Default staleness window (ms): 26 hours — one 09:00 daily schedule interval
+ * (24h) plus slack. Beyond this the unattended loop is treated as stalled and
+ * the banner turns amber. Mirrors the doctor default. */
+export const STALE_AFTER_MS = 26 * 60 * 60 * 1000;
+
+export type BannerLevel = 'none' | 'ok' | 'stale' | 'failed';
+
+/** Everything the fixed portal banner needs, derived from the heartbeat and
+ * the CURRENT wall clock (passed in for testability + client-side ticking).
+ * Deliberately tolerates a null model — the banner must render even when the
+ * rest of the model is empty (fresh/failed vault), so a null model never hides
+ * it: it just shows the muted "no runs yet" state. */
+export interface LastRunBanner {
+  level: BannerLevel;
+  status: LastRunModel['status'] | null;
+  /** Whole minutes since the run's terminal (or start) instant. null when
+   * there is no run or the timestamp is unparseable. */
+  ageMinutes: number | null;
+  error: string | null;
+  processed: number | null;
+  queuedAfter: number | null;
+}
+
+/** The instant the banner ages from: the terminal time if the run ended, else
+ * its start (a still-running or hard-killed run ages from when it began). */
+function lastRunInstantMs(lr: LastRunModel): number | null {
+  const raw = lr.ended_at ?? lr.started_at;
+  const ms = Date.parse(raw);
+  return Number.isNaN(ms) ? null : ms;
+}
+
+export function lastRunBanner(
+  model: IndexModel | null,
+  nowMs: number,
+  staleAfterMs: number = STALE_AFTER_MS,
+): LastRunBanner {
+  const lr = model?.ops?.last_run ?? null;
+  if (!lr) {
+    return {
+      level: 'none',
+      status: null,
+      ageMinutes: null,
+      error: null,
+      processed: null,
+      queuedAfter: null,
+    };
+  }
+  const instant = lastRunInstantMs(lr);
+  const ageMinutes =
+    instant == null ? null : Math.max(0, Math.floor((nowMs - instant) / 60000));
+
+  let level: BannerLevel;
+  if (lr.status === 'failed' || lr.status === 'aborted') {
+    level = 'failed';
+  } else if (
+    instant != null &&
+    nowMs - instant > staleAfterMs
+  ) {
+    // A completed-but-old run, or a run still claiming "running" long past the
+    // schedule interval (it died without the drop-guard firing), is stale.
+    level = 'stale';
+  } else {
+    level = 'ok';
+  }
+
+  return {
+    level,
+    status: lr.status,
+    ageMinutes,
+    error: lr.error ?? null,
+    processed: lr.processed ?? null,
+    queuedAfter: lr.queued_after ?? null,
+  };
+}
+
 // ---------------------------------------------------------------- status dot
 
 export type HealthLevel = 'ok' | 'attention' | 'failed';
 
-/** Nav status dot: red when the most recent run failed, amber when operator
- * attention is pending (blocked / needs-content sources), green otherwise. */
-export function healthLevel(model: IndexModel): HealthLevel {
+/** Nav status dot: red when the most recent run failed/aborted/stale (from the
+ * heartbeat) OR when the most recent per-source run failed; amber when operator
+ * attention is pending (blocked / needs-content sources); green otherwise.
+ * `nowMs` lets the heartbeat staleness be evaluated at render time. */
+export function healthLevel(
+  model: IndexModel,
+  nowMs: number = Date.now(),
+): HealthLevel {
+  const banner = lastRunBanner(model, nowMs);
+  if (banner.level === 'failed' || banner.level === 'stale') return 'failed';
   const lastRun = model.runs[model.runs.length - 1];
   if (lastRun && lastRun.failed > 0) return 'failed';
   if (attentionCount(model) > 0) return 'attention';

--- a/console-ui/src/lib/types.ts
+++ b/console-ui/src/lib/types.ts
@@ -242,6 +242,9 @@ export interface SettingsPayload {
   counts: SettingsCounts | null;
   llm_configured: boolean;
   ask_limits: AskLimits;
+  /** Run-liveness heartbeat block (OVP2 observability P0); null on a fresh
+   * vault / pre-P0 index. Mirrors `model.ops.last_run`. */
+  last_run: LastRunModel | null;
   version: string;
 }
 
@@ -262,10 +265,32 @@ export interface RunStats {
   avg_processed_per_run: number;
 }
 
+export type LastRunStatus = 'running' | 'completed' | 'failed' | 'aborted';
+
+/** Run-liveness heartbeat (`.ovp/last-run.json`), surfaced into the read
+ * model. Age is computed client-side from started_at/ended_at + Date.now so
+ * the banner ticks without a refetch — the server ships no `minutes_since`. */
+export interface LastRunModel {
+  run_id: string;
+  /** UTC RFC3339. */
+  started_at: string;
+  /** UTC RFC3339; absent while `running`. */
+  ended_at?: string;
+  status: LastRunStatus;
+  processed?: number;
+  failed?: number;
+  blocked?: number;
+  capped?: number;
+  queued_after?: number;
+  error?: string;
+}
+
 export interface OpsState {
   blocked_sources: BlockedSource[];
   queue_depth: number;
   run_stats?: RunStats | null;
+  /** Null on a fresh vault (no runs yet) or a pre-P0 index. */
+  last_run?: LastRunModel | null;
 }
 
 export interface RunRow {

--- a/crates/ovp-cli/src/commands/daily.rs
+++ b/crates/ovp-cli/src/commands/daily.rs
@@ -80,7 +80,47 @@ pub struct DailyArgs {
     pub no_digest: bool,
 }
 
+/// Entry point. Wraps [`run_inner`] in the run-liveness heartbeat
+/// ([`HeartbeatGuard`]): the guard is armed the moment a real (non-dry) run
+/// starts, finalized `completed` / `failed` on the two clean exit paths, and
+/// left to its RAII `Drop` — which writes `status: aborted` — if the run
+/// panics or an error propagates out past the finalize. This is the OVP2
+/// observability P0: an unattended run that crashes before its end-of-run
+/// report is still visible in `.ovp/last-run.json`.
+///
+/// A dry run does no mutating work, takes no lock, and writes no heartbeat.
 pub fn run(args: DailyArgs) -> Result<(), CliError> {
+    if args.dry_run {
+        return run_inner(args, None);
+    }
+    let (guard, warn) = ovp_daily::HeartbeatGuard::start(&args.vault_root, &args.run_id);
+    if let Some(w) = warn {
+        sayln!("  warn {w}");
+    }
+    // Track counts across the inner run so a clean completion can finalize with
+    // real numbers. `finalize` is threaded through the Ok path; the Err path
+    // and any panic fall to `finalize_failed` / the Drop-guard's abort write.
+    let mut counts = ovp_daily::RunCounts::default();
+    match run_inner(args, Some(&mut counts)) {
+        Ok(()) => {
+            if let Some(w) = guard.finalize_completed(counts) {
+                sayln!("  warn {w}");
+            }
+            Ok(())
+        }
+        Err(e) => {
+            // Record the terminal failure with the operator-facing message,
+            // then re-propagate so the exit code and stderr are unchanged.
+            let _ = guard.finalize_failed(&e.to_string());
+            Err(e)
+        }
+    }
+}
+
+fn run_inner(
+    args: DailyArgs,
+    mut counts: Option<&mut ovp_daily::RunCounts>,
+) -> Result<(), CliError> {
     let layout = VaultLayout::new();
     let inbox = args.inbox.clone().unwrap_or_else(|| args.vault_root.join(layout.inbox_raw_dir()));
     let ledger_path = args.vault_root.join(layout.daily_ledger());
@@ -337,6 +377,21 @@ pub fn run(args: DailyArgs) -> Result<(), CliError> {
 
     let model = build_index(&args.vault_root, &args.date, Some(&args.run_id))
         .map_err(CliError::Io)?;
+
+    // Heartbeat counts: populated once the model is built so BOTH the clean
+    // completion and the failed-source (Gate) exit below finalize with real
+    // numbers. `queued_after` reads the rebuilt backlog gauge (post-run queue
+    // depth), not just this run's cap remainder.
+    if let Some(c) = counts.take() {
+        *c = ovp_daily::RunCounts {
+            processed: daily.processed.len(),
+            failed: daily.failed(),
+            blocked: daily.blocked,
+            capped: daily.capped,
+            queued_after: model.totals.queued,
+        };
+    }
+
     let index_rel = write_index(&args.vault_root, &model).map_err(CliError::Io)?;
     let evidence = build_evidence(&args.vault_root, &args.date, &model).map_err(CliError::Io)?;
     let evidence_rel = write_evidence(&args.vault_root, &evidence).map_err(CliError::Io)?;

--- a/crates/ovp-cli/src/commands/daily.rs
+++ b/crates/ovp-cli/src/commands/daily.rs
@@ -91,8 +91,18 @@ pub struct DailyArgs {
 /// A dry run does no mutating work, takes no lock, and writes no heartbeat.
 pub fn run(args: DailyArgs) -> Result<(), CliError> {
     if args.dry_run {
-        return run_inner(args, None);
+        return run_inner(args, None, None);
     }
+
+    // Acquire the run lock BEFORE arming the heartbeat. One mutating run at a
+    // time (cron + manual overlap would double-spend LLM calls and race the
+    // lifecycle moves). A contender that can't get the lock must NOT touch
+    // `.ovp/last-run.json` — otherwise it would write "running", then fail the
+    // acquire, then finalize itself "failed", clobbering the legitimate active
+    // run's heartbeat with a false failure. So the guard is only started once
+    // the lock is held.
+    let lock = ovp_intake::RunLock::acquire(&args.vault_root).map_err(CliError::Io)?;
+
     let (guard, warn) = ovp_daily::HeartbeatGuard::start(&args.vault_root, &args.run_id);
     if let Some(w) = warn {
         sayln!("  warn {w}");
@@ -101,7 +111,7 @@ pub fn run(args: DailyArgs) -> Result<(), CliError> {
     // real numbers. `finalize` is threaded through the Ok path; the Err path
     // and any panic fall to `finalize_failed` / the Drop-guard's abort write.
     let mut counts = ovp_daily::RunCounts::default();
-    match run_inner(args, Some(&mut counts)) {
+    match run_inner(args, Some(lock), Some(&mut counts)) {
         Ok(()) => {
             if let Some(w) = guard.finalize_completed(counts) {
                 sayln!("  warn {w}");
@@ -119,20 +129,16 @@ pub fn run(args: DailyArgs) -> Result<(), CliError> {
 
 fn run_inner(
     args: DailyArgs,
+    // The run lock, acquired by `run()` BEFORE the heartbeat (so a lock
+    // contender never writes a heartbeat). Held for the lifetime of this call.
+    // None only for dry runs, which take no lock.
+    _lock: Option<ovp_intake::RunLock>,
     mut counts: Option<&mut ovp_daily::RunCounts>,
 ) -> Result<(), CliError> {
     let layout = VaultLayout::new();
     let inbox = args.inbox.clone().unwrap_or_else(|| args.vault_root.join(layout.inbox_raw_dir()));
     let ledger_path = args.vault_root.join(layout.daily_ledger());
     let intake_cfg = IntakeConfig::new(args.vault_root.clone(), args.date.clone(), args.run_id.clone());
-
-    // One mutating run at a time (cron + manual overlap would double-spend
-    // LLM calls and race the lifecycle moves). Dry runs read only.
-    let _lock = if args.dry_run {
-        None
-    } else {
-        Some(ovp_intake::RunLock::acquire(&args.vault_root).map_err(CliError::Io)?)
-    };
 
     let mut report = RunReport::new(&args.run_id, &args.date);
     sayln!("daily [{}]: vault {}", args.date, args.vault_root.display());
@@ -612,7 +618,69 @@ fn live_image_download() -> Result<Box<dyn ovp_enrich::image_download::ImageDown
 
 #[cfg(test)]
 mod tests {
-    use super::stale_theme_packs;
+    use super::{run, stale_theme_packs, DailyArgs};
+    use crate::commands::client::ClientKind;
+
+    fn min_args(vault: std::path::PathBuf) -> DailyArgs {
+        DailyArgs {
+            vault_root: vault,
+            inbox: None,
+            cache_dir: None,
+            client_kind: ClientKind::Replay,
+            date: "2026-07-12".into(),
+            run_id: "daily-2026-07-12".into(),
+            dry_run: false,
+            max_sources: 0,
+            no_intake: true,
+            pinboard_fixture: None,
+            pinboard_live: false,
+            pinboard_since: None,
+            pinboard_max: None,
+            no_lifecycle: false,
+            retry_blocked: false,
+            web_fetch_fixture: None,
+            web_fetch_live: false,
+            github_fixture: None,
+            github_live: false,
+            no_images: true,
+            image_fixture: None,
+            image_live: false,
+            no_digest: true,
+        }
+    }
+
+    /// P2 regression: a contender that cannot get the run lock must NEVER touch
+    /// `.ovp/last-run.json` — otherwise it would clobber the active run's
+    /// legitimate "running" heartbeat with a false "failed". The lock is
+    /// acquired BEFORE the heartbeat guard is armed, so the contender errors
+    /// out first and the heartbeat is left exactly as the active run wrote it.
+    #[test]
+    fn lock_contender_does_not_clobber_active_heartbeat() {
+        let tmp = tempfile::tempdir().unwrap();
+        let vault = tmp.path().to_path_buf();
+
+        // Simulate the legitimate active run: hold the lock and write its
+        // "running" heartbeat.
+        let _held = ovp_intake::RunLock::acquire(&vault).expect("acquire lock");
+        let (active_guard, _) =
+            ovp_daily::HeartbeatGuard::start(&vault, "daily-active");
+        // Keep the active guard alive (its Drop would otherwise write aborted).
+        let active = ovp_daily::read_last_run(&vault).unwrap().unwrap();
+        assert_eq!(active.status, ovp_daily::LastRunStatus::Running);
+        assert_eq!(active.run_id, "daily-active");
+
+        // The contender cannot get the lock → errors, writes NOTHING.
+        let err = run(min_args(vault.clone()));
+        assert!(err.is_err(), "contender must fail to acquire the lock");
+
+        // The heartbeat is still the ACTIVE run's untouched "running" record.
+        let after = ovp_daily::read_last_run(&vault).unwrap().unwrap();
+        assert_eq!(after.status, ovp_daily::LastRunStatus::Running);
+        assert_eq!(after.run_id, "daily-active", "contender must not overwrite the heartbeat");
+
+        // Finalize the active run so its guard's Drop doesn't write aborted.
+        active_guard.finalize_completed(ovp_daily::RunCounts::default());
+    }
 
     fn model_with_packs(dirs: &[&str]) -> ovp_index::IndexModel {
         ovp_index::IndexModel {

--- a/crates/ovp-cli/src/commands/doctor.rs
+++ b/crates/ovp-cli/src/commands/doctor.rs
@@ -14,10 +14,17 @@ use ovp_index::{build_index, write_index};
 
 use crate::CliError;
 
+/// Default run-recency staleness threshold: 26 hours — one 09:00 daily
+/// schedule interval (24h) plus slack for a long reader batch. Beyond this the
+/// unattended loop is assumed stalled.
+pub const DEFAULT_RECENCY_HOURS: u64 = 26;
+
 pub struct DoctorArgs {
     pub vault_root: PathBuf,
     pub fix: bool,
     pub json: bool,
+    /// Override for the run-recency staleness threshold (hours).
+    pub since_hours: Option<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -58,6 +65,8 @@ pub fn run(args: DoctorArgs) -> Result<(), CliError> {
     check_orphan_packs(&args.vault_root, &layout, &mut findings);
     check_stale_index(&args.vault_root, &mut findings, args.fix);
     check_crystal_integrity(&args.vault_root, &mut findings);
+    let threshold_hours = args.since_hours.unwrap_or(DEFAULT_RECENCY_HOURS);
+    check_run_recency(&args.vault_root, &layout, now_unix_secs(), threshold_hours, &mut findings);
     check_disk_usage(&args.vault_root, &layout, &mut findings);
     check_legacy_artifacts(&args.vault_root, &mut findings);
 
@@ -364,6 +373,214 @@ fn check_crystal_integrity(vault_root: &Path, findings: &mut Vec<Finding>) {
     }
 }
 
+/// Run-recency + backlog check (OVP2 observability P0). Now that `daily` runs
+/// unattended, a run that crashes before its end-of-run report leaves the
+/// portal frozen with a green dot — so `doctor` must fail loudly when:
+///   * the heartbeat says `failed` or `aborted` (a crashed/aborted run), or
+///   * the last run (heartbeat `ended_at`/`started_at`, else the newest report
+///     file's mtime) is older than `threshold_hours`.
+///
+/// It also emits an INFO when the capped backlog is growing (heartbeat
+/// `queued_after` not shrinking vs the prior report's residual queue — a
+/// best-effort signal, never a failure).
+fn check_run_recency(
+    vault_root: &Path,
+    layout: &VaultLayout,
+    now_secs: i64,
+    threshold_hours: u64,
+    findings: &mut Vec<Finding>,
+) {
+    let threshold_secs = threshold_hours as i64 * 3600;
+    let hb = ovp_daily::read_last_run(vault_root).ok().flatten();
+
+    // 1) Terminal-status failures are unconditional FAILs regardless of age.
+    if let Some(rec) = &hb {
+        match rec.status {
+            ovp_daily::LastRunStatus::Failed => {
+                findings.push(Finding {
+                    check: "run-recency".into(),
+                    severity: Severity::Fail,
+                    message: format!(
+                        "last run FAILED ({}){}",
+                        rec.run_id,
+                        rec.error.as_deref().map(|e| format!(" — {e}")).unwrap_or_default()
+                    ),
+                    fixed: false,
+                });
+                return;
+            }
+            ovp_daily::LastRunStatus::Aborted => {
+                findings.push(Finding {
+                    check: "run-recency".into(),
+                    severity: Severity::Fail,
+                    message: format!(
+                        "last run ABORTED ({}) — the process died mid-run (panic/kill/provider error); \
+                         check the schedule log and rerun `ovp2 daily`",
+                        rec.run_id
+                    ),
+                    fixed: false,
+                });
+                return;
+            }
+            ovp_daily::LastRunStatus::Running | ovp_daily::LastRunStatus::Completed => {}
+        }
+    }
+
+    // 2) Age: heartbeat timestamp preferred (has wall-clock time), else newest
+    // report file mtime. A `running` heartbeat ages from `started_at`.
+    let hb_secs = hb.as_ref().and_then(|r| {
+        let ts = r.ended_at.as_deref().unwrap_or(r.started_at.as_str());
+        parse_rfc3339_utc(ts)
+    });
+    let report_secs = newest_report_mtime_secs(vault_root, layout);
+    let last_secs = match (hb_secs, report_secs) {
+        (Some(a), Some(b)) => Some(a.max(b)),
+        (a, b) => a.or(b),
+    };
+
+    match last_secs {
+        None => {
+            findings.push(Finding {
+                check: "run-recency".into(),
+                severity: Severity::Warn,
+                message: "no run recorded yet (no heartbeat, no reports)".into(),
+                fixed: false,
+            });
+        }
+        Some(ts) => {
+            let age = now_secs - ts;
+            if age > threshold_secs {
+                let hours = age / 3600;
+                findings.push(Finding {
+                    check: "run-recency".into(),
+                    severity: Severity::Fail,
+                    message: format!(
+                        "last run was ~{hours}h ago (> {threshold_hours}h) — the unattended loop may be \
+                         stalled; check `ovp2 schedule status` and the schedule log"
+                    ),
+                    fixed: false,
+                });
+            } else {
+                let hours = age.max(0) / 3600;
+                findings.push(Finding {
+                    check: "run-recency".into(),
+                    severity: Severity::Pass,
+                    message: format!("last run ~{hours}h ago (< {threshold_hours}h)"),
+                    fixed: false,
+                });
+            }
+        }
+    }
+
+    // 3) INFO: capped backlog growing (best-effort). Compare the heartbeat's
+    // post-run queue depth to the current queue depth on disk; a strictly
+    // larger live queue than the last recorded run's residual is a growing
+    // backlog worth surfacing, never a failure.
+    if let Some(rec) = &hb
+        && let Some(queued_after) = rec.queued_after
+    {
+        let live_queued = current_queue_depth(vault_root);
+        if live_queued > queued_after {
+            findings.push(Finding {
+                check: "run-backlog".into(),
+                severity: Severity::Info,
+                message: format!(
+                    "queue is growing: {live_queued} queued now vs {queued_after} after the last run \
+                     — capture is outpacing reading; raise --max-sources or run more often"
+                ),
+                fixed: false,
+            });
+        }
+    }
+}
+
+/// Newest mtime (unix secs) across `.ovp/reports/*.json`, if any.
+fn newest_report_mtime_secs(vault_root: &Path, layout: &VaultLayout) -> Option<i64> {
+    let dir = vault_root.join(layout.reports_dir());
+    let entries = std::fs::read_dir(&dir).ok()?;
+    let mut newest: Option<i64> = None;
+    for e in entries.flatten() {
+        let path = e.path();
+        if path.extension().is_none_or(|x| x != "json") {
+            continue;
+        }
+        if let Some(secs) = std::fs::metadata(&path)
+            .and_then(|m| m.modified())
+            .ok()
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| d.as_secs() as i64)
+        {
+            newest = Some(newest.map_or(secs, |n| n.max(secs)));
+        }
+    }
+    newest
+}
+
+/// Live queue depth on disk: markdown files sitting in `50-Inbox/01-Raw`. A
+/// cheap proxy for the backlog — the read model computes the same, but doctor
+/// stays index-independent here.
+fn current_queue_depth(vault_root: &Path) -> usize {
+    let inbox = vault_root.join(VaultLayout::new().inbox_raw_dir());
+    fn count_md(dir: &Path) -> usize {
+        let mut n = 0;
+        if let Ok(entries) = std::fs::read_dir(dir) {
+            for e in entries.flatten() {
+                let p = e.path();
+                let name = e.file_name();
+                if name.to_string_lossy().starts_with('.') {
+                    continue;
+                }
+                if p.is_dir() {
+                    n += count_md(&p);
+                } else if p.extension().is_some_and(|x| x == "md") {
+                    n += 1;
+                }
+            }
+        }
+        n
+    }
+    count_md(&inbox)
+}
+
+/// Parse an RFC3339 UTC timestamp (`YYYY-MM-DDTHH:MM:SSZ`, as the heartbeat
+/// writes) into unix seconds. Returns None on any shape it does not recognize
+/// (the recency check then falls back to report mtime).
+fn parse_rfc3339_utc(s: &str) -> Option<i64> {
+    let s = s.trim_end_matches('Z');
+    let (date, time) = s.split_once('T')?;
+    let mut dp = date.splitn(3, '-');
+    let y: i64 = dp.next()?.parse().ok()?;
+    let mo: i64 = dp.next()?.parse().ok()?;
+    let d: i64 = dp.next()?.parse().ok()?;
+    let mut tp = time.splitn(3, ':');
+    let h: i64 = tp.next()?.parse().ok()?;
+    let mi: i64 = tp.next()?.parse().ok()?;
+    let se: i64 = tp.next().unwrap_or("0").parse().ok()?;
+    if !(1..=12).contains(&mo) || !(1..=31).contains(&d) {
+        return None;
+    }
+    Some(days_from_civil(y, mo, d) * 86_400 + h * 3600 + mi * 60 + se)
+}
+
+/// Howard Hinnant's `days_from_civil` — days since the unix epoch.
+fn days_from_civil(y: i64, m: i64, d: i64) -> i64 {
+    let y = if m <= 2 { y - 1 } else { y };
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = y - era * 400;
+    let mp = (m + 9) % 12;
+    let doy = (153 * mp + 2) / 5 + d - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    era * 146_097 + doe - 719_468
+}
+
+fn now_unix_secs() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
 fn check_disk_usage(vault_root: &Path, layout: &VaultLayout, findings: &mut Vec<Finding>) {
     let dirs = [
         (".ovp", vault_root.join(".ovp")),
@@ -590,7 +807,101 @@ mod tests {
             vault_root: tmp.path().to_path_buf(),
             fix: false,
             json: false,
+            since_hours: None,
         });
         assert!(result.is_ok(), "INFO finding must not fail doctor: {result:?}");
+    }
+
+    // ---- run-recency (OVP2 observability P0) ----
+
+    fn recency_findings(
+        vault: &Path,
+        now: i64,
+        threshold: u64,
+    ) -> Vec<Finding> {
+        let layout = VaultLayout::new();
+        let mut f = Vec::new();
+        check_run_recency(vault, &layout, now, threshold, &mut f);
+        f
+    }
+
+    fn recency(f: &[Finding]) -> &Finding {
+        f.iter().find(|x| x.check == "run-recency").expect("a run-recency finding")
+    }
+
+    #[test]
+    fn recency_parses_rfc3339() {
+        assert_eq!(parse_rfc3339_utc("1970-01-01T00:00:00Z"), Some(0));
+        assert_eq!(parse_rfc3339_utc("2026-07-12T09:00:00Z"), Some(1_783_846_800));
+        assert_eq!(parse_rfc3339_utc("garbage"), None);
+    }
+
+    #[test]
+    fn recency_fails_on_failed_heartbeat() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (g, _) = ovp_daily::HeartbeatGuard::start(tmp.path(), "r");
+        g.finalize_failed("ANTHROPIC_API_KEY expired");
+        // now == same instant, well within threshold — but failed status FAILs.
+        let f = recency_findings(tmp.path(), now_unix_secs(), 26);
+        let r = recency(&f);
+        assert_eq!(r.severity, Severity::Fail);
+        assert!(r.message.contains("FAILED"));
+        assert!(r.message.contains("expired"));
+    }
+
+    #[test]
+    fn recency_fails_on_aborted_heartbeat() {
+        let tmp = tempfile::tempdir().unwrap();
+        {
+            let (_g, _) = ovp_daily::HeartbeatGuard::start(tmp.path(), "r");
+        } // drop → aborted
+        let f = recency_findings(tmp.path(), now_unix_secs(), 26);
+        let r = recency(&f);
+        assert_eq!(r.severity, Severity::Fail);
+        assert!(r.message.contains("ABORTED"));
+    }
+
+    #[test]
+    fn recency_passes_on_fresh_completed_heartbeat() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (g, _) = ovp_daily::HeartbeatGuard::start(tmp.path(), "r");
+        g.finalize_completed(ovp_daily::RunCounts::default());
+        // A completed run stamped ~now → well within any threshold.
+        let f = recency_findings(tmp.path(), now_unix_secs(), 26);
+        assert_eq!(recency(&f).severity, Severity::Pass);
+    }
+
+    #[test]
+    fn recency_fails_on_stale_completed_heartbeat() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (g, _) = ovp_daily::HeartbeatGuard::start(tmp.path(), "r");
+        g.finalize_completed(ovp_daily::RunCounts::default());
+        // Advance "now" 100h past the heartbeat write → stale.
+        let future = now_unix_secs() + 100 * 3600;
+        assert_eq!(recency_findings(tmp.path(), future, 26)[0].severity, Severity::Fail);
+    }
+
+    #[test]
+    fn recency_warns_when_no_run_at_all() {
+        let tmp = tempfile::tempdir().unwrap();
+        let f = recency_findings(tmp.path(), now_unix_secs(), 26);
+        assert_eq!(recency(&f).severity, Severity::Warn);
+    }
+
+    #[test]
+    fn backlog_info_when_queue_grows_past_last_run() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (g, _) = ovp_daily::HeartbeatGuard::start(tmp.path(), "r");
+        g.finalize_completed(ovp_daily::RunCounts { queued_after: 2, ..Default::default() });
+        // Five markdown sources now sit in the inbox → live queue 5 > 2.
+        let inbox = tmp.path().join("50-Inbox/01-Raw");
+        std::fs::create_dir_all(&inbox).unwrap();
+        for i in 0..5 {
+            std::fs::write(inbox.join(format!("s{i}.md")), "x").unwrap();
+        }
+        let f = recency_findings(tmp.path(), now_unix_secs(), 26);
+        let info = f.iter().find(|x| x.check == "run-backlog").expect("backlog info");
+        assert_eq!(info.severity, Severity::Info);
+        assert!(info.message.contains("growing"));
     }
 }

--- a/crates/ovp-cli/src/commands/doctor.rs
+++ b/crates/ovp-cli/src/commands/doctor.rs
@@ -391,7 +391,26 @@ fn check_run_recency(
     findings: &mut Vec<Finding>,
 ) {
     let threshold_secs = threshold_hours as i64 * 3600;
-    let hb = ovp_daily::read_last_run(vault_root).ok().flatten();
+
+    // A PRESENT-but-corrupt heartbeat is a hard FAIL, never a silent fallback:
+    // `.ok().flatten()` would treat a malformed file as absent and quietly fall
+    // back to report mtimes, so doctor could PASS while the latest failed or
+    // aborted run is unknowable. Absent (Ok(None)) is fine — a fresh vault.
+    let hb = match ovp_daily::read_last_run(vault_root) {
+        Ok(hb) => hb,
+        Err(e) => {
+            findings.push(Finding {
+                check: "run-recency".into(),
+                severity: Severity::Fail,
+                message: format!(
+                    ".ovp/last-run.json is present but unreadable/corrupt ({e}) — the last run's \
+                     status is unknowable; repair or remove it, then rerun `ovp2 daily`"
+                ),
+                fixed: false,
+            });
+            return;
+        }
+    };
 
     // 1) Terminal-status failures are unconditional FAILs regardless of age.
     if let Some(rec) = &hb {
@@ -886,6 +905,23 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let f = recency_findings(tmp.path(), now_unix_secs(), 26);
         assert_eq!(recency(&f).severity, Severity::Warn);
+    }
+
+    #[test]
+    fn recency_fails_loud_on_corrupt_heartbeat() {
+        let tmp = tempfile::tempdir().unwrap();
+        // A present-but-malformed last-run.json must FAIL, not silently fall
+        // back to report mtimes (which could let doctor PASS while the latest
+        // failed/aborted run is unknowable).
+        let hb = tmp.path().join(".ovp/last-run.json");
+        std::fs::create_dir_all(hb.parent().unwrap()).unwrap();
+        std::fs::write(&hb, b"{ not valid json").unwrap();
+        // A fresh report on disk would otherwise mask the corruption.
+        touch(tmp.path(), ".ovp/reports/daily-2026-07-12.json");
+        let f = recency_findings(tmp.path(), now_unix_secs(), 26);
+        let r = recency(&f);
+        assert_eq!(r.severity, Severity::Fail);
+        assert!(r.message.contains("corrupt"), "{}", r.message);
     }
 
     #[test]

--- a/crates/ovp-cli/src/commands/schedule.rs
+++ b/crates/ovp-cli/src/commands/schedule.rs
@@ -791,8 +791,44 @@ fn status_with(
         Err(_) => println!("  log:       {} (no log yet)", log.display()),
     }
 
-    // Last daily run + staleness, from the append-only ledger.
-    let ledger_path = meta.vault_root.join(".ovp/daily-runs.jsonl");
+    // Last run — PREFER the run-liveness heartbeat (`.ovp/last-run.json`, OVP2
+    // observability P0): it carries the terminal status of the most recent run,
+    // so an unattended run that FAILED or ABORTED before writing a report is
+    // still surfaced here. The append-only ledger's date is the fallback for a
+    // vault whose last successful run predates the heartbeat.
+    match ovp_daily::read_last_run(&meta.vault_root) {
+        Ok(Some(hb)) => {
+            let when = hb.ended_at.as_deref().unwrap_or(hb.started_at.as_str());
+            let status = match hb.status {
+                ovp_daily::LastRunStatus::Completed => "completed",
+                ovp_daily::LastRunStatus::Failed => "FAILED",
+                ovp_daily::LastRunStatus::Aborted => "ABORTED",
+                ovp_daily::LastRunStatus::Running => "running",
+            };
+            println!("  last run:  {status} at {when} ({})", hb.run_id);
+            match hb.status {
+                ovp_daily::LastRunStatus::Failed | ovp_daily::LastRunStatus::Aborted => {
+                    println!(
+                        "  WARN: the last run did not complete ({status}){} — check the schedule log and rerun `ovp2 daily`",
+                        hb.error.as_deref().map(|e| format!(": {e}")).unwrap_or_default()
+                    );
+                }
+                _ => {}
+            }
+        }
+        Ok(None) => report_last_run_from_ledger(&meta.vault_root, today),
+        Err(e) => {
+            println!("  WARN: cannot read .ovp/last-run.json: {e}");
+            report_last_run_from_ledger(&meta.vault_root, today);
+        }
+    }
+    Ok(())
+}
+
+/// Fallback last-run report from the append-only daily ledger (date only; no
+/// terminal status), used when the heartbeat file is absent or unreadable.
+fn report_last_run_from_ledger(vault_root: &Path, today: &str) {
+    let ledger_path = vault_root.join(".ovp/daily-runs.jsonl");
     match read_daily_ledger(&ledger_path) {
         Ok(records) => match last_run_date(&records) {
             Some(last) => {
@@ -808,7 +844,6 @@ fn status_with(
         },
         Err(e) => println!("  WARN: cannot read {}: {e}", ledger_path.display()),
     }
-    Ok(())
 }
 
 fn first_word_or<'a>(s: &'a str, fallback: &'a str) -> &'a str {

--- a/crates/ovp-cli/src/main.rs
+++ b/crates/ovp-cli/src/main.rs
@@ -385,6 +385,11 @@ enum Cmd {
         /// Emit JSON instead of text.
         #[arg(long)]
         json: bool,
+        /// Run-recency staleness threshold in HOURS (default 26 — one schedule
+        /// interval + slack). The recency check FAILs when the last run
+        /// (heartbeat or report) is older than this.
+        #[arg(long = "since")]
+        since_hours: Option<u64>,
     },
     /// PRODUCT — start the OVP MCP server (stdio JSON-RPC, synchronous).
     /// Exposes OVP tools (find/search/status/doctor) and resources
@@ -1331,10 +1336,12 @@ fn main() -> ExitCode {
             vault_root,
             fix,
             json,
+            since_hours,
         } => commands::doctor::run(commands::doctor::DoctorArgs {
             vault_root,
             fix,
             json,
+            since_hours,
         }),
         Cmd::Mcp { vault_root } => commands::mcp::run(commands::mcp::McpArgs { vault_root }),
         Cmd::Serve {

--- a/crates/ovp-daily/src/heartbeat.rs
+++ b/crates/ovp-daily/src/heartbeat.rs
@@ -150,8 +150,15 @@ pub fn write_last_run(vault_root: &Path, record: &LastRun) -> Result<(), String>
     }
     let body = serde_json::to_string_pretty(record)
         .map_err(|e| format!("serializing last-run heartbeat: {e}"))?;
-    std::fs::write(&target, format!("{body}\n"))
-        .map_err(|e| format!("writing {}: {e}", target.display()))
+    // Atomic overwrite: a reader (the live server) or a mid-write crash must
+    // never observe partial JSON. Write a sibling temp then rename over the
+    // target — rename is atomic on the same filesystem, so the file is always
+    // either the old complete record or the new complete record.
+    let tmp = target.with_extension(format!("json.tmp.{}", std::process::id()));
+    std::fs::write(&tmp, format!("{body}\n"))
+        .map_err(|e| format!("writing {}: {e}", tmp.display()))?;
+    std::fs::rename(&tmp, &target)
+        .map_err(|e| format!("renaming {} → {}: {e}", tmp.display(), target.display()))
 }
 
 /// Read the heartbeat if present. `Ok(None)` on a fresh vault (no file yet);

--- a/crates/ovp-daily/src/heartbeat.rs
+++ b/crates/ovp-daily/src/heartbeat.rs
@@ -1,0 +1,349 @@
+//! Run-liveness heartbeat (OVP2 observability P0) — `<vault>/.ovp/last-run.json`.
+//!
+//! Now that `daily` runs UNATTENDED (launchd/systemd `ovp2 schedule`), a run
+//! that CRASHES before it writes its end-of-run report is otherwise completely
+//! invisible: no report is written, the index/console are not rebuilt, and the
+//! portal stays byte-identical to yesterday with a green health dot. This
+//! heartbeat is the one thing the operator passively sees that ages by itself.
+//!
+//! Contract:
+//!   * `write_running` is called ONCE, at the very START of `daily`, before any
+//!     work — it stamps `status: running` with the pid so a stuck run is
+//!     distinguishable from a crashed one.
+//!   * a terminal write overwrites it: `completed` (with counts) on success,
+//!     `failed` (with the error string) on a handled error.
+//!   * the ABORT case — panic, SIGKILL, an error propagating out of `run()`
+//!     without an explicit finalize — is caught by [`HeartbeatGuard`], an RAII
+//!     drop-guard that, if it drops without `finalize`, writes `status: aborted`
+//!     so the file is never left saying "running" forever.
+//!
+//! Time is wall-clock (`SystemTime::now`) BY NATURE — a heartbeat that says
+//! "8 hours ago" must reflect real elapsed time, so this is deliberately NOT one
+//! of the determinism-pinned, caller-dated projections.
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use ovp_domain::VaultLayout;
+
+pub const LAST_RUN_SCHEMA: &str = "ovp.daily.last-run/v1";
+
+/// Terminal (and in-flight) run status surfaced by the heartbeat.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LastRunStatus {
+    /// Written at the start of the run; still in flight (or the process died
+    /// hard enough that even the drop-guard never ran — e.g. SIGKILL/power loss).
+    Running,
+    /// Finished cleanly (counts populated).
+    Completed,
+    /// A handled error ended the run (`error` populated).
+    Failed,
+    /// The command dropped without an explicit finalize — a panic or an error
+    /// propagating out of `run()`. The drop-guard wrote this.
+    Aborted,
+}
+
+/// The heartbeat document. Serde-additive: every field beyond the required
+/// three is optional so an older reader tolerates a newer file and vice versa.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LastRun {
+    pub schema: String,
+    pub run_id: String,
+    /// Wall-clock start (UTC, RFC3339).
+    pub started_at: String,
+    pub status: LastRunStatus,
+    /// Wall-clock terminal time (UTC, RFC3339); None while `running`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ended_at: Option<String>,
+    #[serde(default)]
+    pub pid: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub processed: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failed: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blocked: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capped: Option<usize>,
+    /// Sources still queued after this run (backlog gauge).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub queued_after: Option<usize>,
+    /// Populated on `failed`; a short note on `aborted`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Terminal counts captured on a clean completion.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RunCounts {
+    pub processed: usize,
+    pub failed: usize,
+    pub blocked: usize,
+    pub capped: usize,
+    pub queued_after: usize,
+}
+
+/// Current wall-clock instant as an RFC3339 UTC string (`YYYY-MM-DDTHH:MM:SSZ`).
+/// Deliberately wall-clock — a liveness heartbeat MUST age in real time.
+pub fn now_rfc3339_utc() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    format_rfc3339_utc(secs as i64)
+}
+
+/// Format unix seconds as an RFC3339 UTC timestamp. Pure/testable; the same
+/// civil-date arithmetic used elsewhere in the codebase, extended to seconds.
+pub fn format_rfc3339_utc(unix_secs: i64) -> String {
+    let days = unix_secs.div_euclid(86_400);
+    let rem = unix_secs.rem_euclid(86_400);
+    let (h, m, s) = (rem / 3600, (rem % 3600) / 60, rem % 60);
+    let (y, mo, d) = days_to_ymd(days);
+    format!("{y:04}-{mo:02}-{d:02}T{h:02}:{m:02}:{s:02}Z")
+}
+
+fn days_to_ymd(mut days: i64) -> (i32, u32, u32) {
+    let mut year: i32 = 1970;
+    loop {
+        let dy = if is_leap(year) { 366 } else { 365 };
+        if days < dy {
+            break;
+        }
+        days -= dy;
+        year += 1;
+    }
+    let months: [i64; 12] = [
+        31,
+        if is_leap(year) { 29 } else { 28 },
+        31, 30, 31, 30, 31, 31, 30, 31, 30, 31,
+    ];
+    let mut month: u32 = 1;
+    for m in months.iter() {
+        if days < *m {
+            return (year, month, (days + 1) as u32);
+        }
+        days -= *m;
+        month += 1;
+    }
+    (year, 12, 31)
+}
+
+fn is_leap(y: i32) -> bool {
+    (y % 4 == 0 && y % 100 != 0) || (y % 400 == 0)
+}
+
+fn last_run_path(vault_root: &Path) -> std::path::PathBuf {
+    vault_root.join(VaultLayout::new().last_run_file())
+}
+
+/// Overwrite the heartbeat file (create parent dirs as needed). Overwrite is
+/// correct: this is a single liveness snapshot, not a ledger.
+pub fn write_last_run(vault_root: &Path, record: &LastRun) -> Result<(), String> {
+    let target = last_run_path(vault_root);
+    if let Some(parent) = target.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("creating {}: {e}", parent.display()))?;
+    }
+    let body = serde_json::to_string_pretty(record)
+        .map_err(|e| format!("serializing last-run heartbeat: {e}"))?;
+    std::fs::write(&target, format!("{body}\n"))
+        .map_err(|e| format!("writing {}: {e}", target.display()))
+}
+
+/// Read the heartbeat if present. `Ok(None)` on a fresh vault (no file yet);
+/// `Err` only on a present-but-unparseable file (corruption should be loud).
+pub fn read_last_run(vault_root: &Path) -> Result<Option<LastRun>, String> {
+    let path = last_run_path(vault_root);
+    match std::fs::read_to_string(&path) {
+        Ok(raw) => serde_json::from_str(&raw)
+            .map(Some)
+            .map_err(|e| format!("parsing {}: {e}", path.display())),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(format!("reading {}: {e}", path.display())),
+    }
+}
+
+/// RAII heartbeat guard. Construct it at the start of `daily` (which writes the
+/// `running` record). Call [`HeartbeatGuard::finalize`] with a terminal status
+/// on every non-panicking exit path; if the guard is dropped WITHOUT a finalize
+/// — a panic, or `?` propagating an error past it — its `Drop` writes
+/// `status: aborted`, so the heartbeat is never stranded on "running".
+pub struct HeartbeatGuard {
+    vault_root: std::path::PathBuf,
+    run_id: String,
+    started_at: String,
+    pid: u32,
+    /// Set once finalize runs — suppresses the abort write in Drop.
+    finalized: bool,
+}
+
+impl HeartbeatGuard {
+    /// Stamp `status: running` and return the guard. A write failure here is a
+    /// warning, not a run-abort: the operator's day should not be blocked by an
+    /// observability side-channel. The caller prints the returned warning.
+    pub fn start(vault_root: &Path, run_id: &str) -> (Self, Option<String>) {
+        let started_at = now_rfc3339_utc();
+        let pid = std::process::id();
+        let record = LastRun {
+            schema: LAST_RUN_SCHEMA.into(),
+            run_id: run_id.into(),
+            started_at: started_at.clone(),
+            status: LastRunStatus::Running,
+            ended_at: None,
+            pid,
+            processed: None,
+            failed: None,
+            blocked: None,
+            capped: None,
+            queued_after: None,
+            error: None,
+        };
+        let warn = write_last_run(vault_root, &record)
+            .err()
+            .map(|e| format!("heartbeat: could not write last-run.json: {e}"));
+        (
+            Self {
+                vault_root: vault_root.to_path_buf(),
+                run_id: run_id.into(),
+                started_at,
+                pid,
+                finalized: false,
+            },
+            warn,
+        )
+    }
+
+    fn terminal(&self, status: LastRunStatus, counts: Option<RunCounts>, error: Option<String>) -> LastRun {
+        LastRun {
+            schema: LAST_RUN_SCHEMA.into(),
+            run_id: self.run_id.clone(),
+            started_at: self.started_at.clone(),
+            status,
+            ended_at: Some(now_rfc3339_utc()),
+            pid: self.pid,
+            processed: counts.map(|c| c.processed),
+            failed: counts.map(|c| c.failed),
+            blocked: counts.map(|c| c.blocked),
+            capped: counts.map(|c| c.capped),
+            queued_after: counts.map(|c| c.queued_after),
+            error,
+        }
+    }
+
+    /// Overwrite the heartbeat with `completed` + counts. Consumes the guard so
+    /// Drop cannot also fire an abort. Returns a warning string on write failure.
+    pub fn finalize_completed(mut self, counts: RunCounts) -> Option<String> {
+        self.finalized = true;
+        let record = self.terminal(LastRunStatus::Completed, Some(counts), None);
+        write_last_run(&self.vault_root, &record)
+            .err()
+            .map(|e| format!("heartbeat: could not finalize last-run.json (completed): {e}"))
+    }
+
+    /// Overwrite the heartbeat with `failed` + the error string. Consumes the
+    /// guard. Returns a warning string on write failure.
+    pub fn finalize_failed(mut self, error: &str) -> Option<String> {
+        self.finalized = true;
+        let record = self.terminal(LastRunStatus::Failed, None, Some(error.to_string()));
+        write_last_run(&self.vault_root, &record)
+            .err()
+            .map(|e| format!("heartbeat: could not finalize last-run.json (failed): {e}"))
+    }
+}
+
+impl Drop for HeartbeatGuard {
+    fn drop(&mut self) {
+        if self.finalized {
+            return;
+        }
+        // Reached only on an un-finalized exit: a panic unwinding through the
+        // guard, or an error propagating out of the daily command past it.
+        let record = self.terminal(
+            LastRunStatus::Aborted,
+            None,
+            Some("run ended without a terminal status (panic, kill, or error propagating out of daily)".into()),
+        );
+        // Best-effort: Drop must not panic. If this write fails the file stays
+        // on "running", which the reader still treats as stale/suspect.
+        let _ = write_last_run(&self.vault_root, &record);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rfc3339_formats_epoch_and_a_known_instant() {
+        assert_eq!(format_rfc3339_utc(0), "1970-01-01T00:00:00Z");
+        // 2026-07-12T09:00:00Z
+        assert_eq!(format_rfc3339_utc(1_783_846_800), "2026-07-12T09:00:00Z");
+    }
+
+    #[test]
+    fn start_writes_running_with_pid() {
+        let dir = tempfile::tempdir().unwrap();
+        let (guard, warn) = HeartbeatGuard::start(dir.path(), "daily-2026-07-12");
+        assert!(warn.is_none(), "clean start should not warn: {warn:?}");
+        let rec = read_last_run(dir.path()).unwrap().expect("heartbeat written");
+        assert_eq!(rec.status, LastRunStatus::Running);
+        assert_eq!(rec.run_id, "daily-2026-07-12");
+        assert!(rec.ended_at.is_none());
+        assert_eq!(rec.pid, std::process::id());
+        // Do NOT let the guard drop as aborted — finalize it.
+        assert!(guard.finalize_completed(RunCounts::default()).is_none());
+    }
+
+    #[test]
+    fn finalize_completed_overwrites_with_counts() {
+        let dir = tempfile::tempdir().unwrap();
+        let (guard, _) = HeartbeatGuard::start(dir.path(), "r");
+        let counts = RunCounts {
+            processed: 8,
+            failed: 0,
+            blocked: 1,
+            capped: 2,
+            queued_after: 180,
+        };
+        assert!(guard.finalize_completed(counts).is_none());
+        let rec = read_last_run(dir.path()).unwrap().unwrap();
+        assert_eq!(rec.status, LastRunStatus::Completed);
+        assert_eq!(rec.processed, Some(8));
+        assert_eq!(rec.queued_after, Some(180));
+        assert!(rec.ended_at.is_some());
+        assert!(rec.error.is_none());
+    }
+
+    #[test]
+    fn finalize_failed_records_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let (guard, _) = HeartbeatGuard::start(dir.path(), "r");
+        assert!(guard.finalize_failed("ANTHROPIC_API_KEY expired").is_none());
+        let rec = read_last_run(dir.path()).unwrap().unwrap();
+        assert_eq!(rec.status, LastRunStatus::Failed);
+        assert_eq!(rec.error.as_deref(), Some("ANTHROPIC_API_KEY expired"));
+    }
+
+    #[test]
+    fn drop_without_finalize_writes_aborted() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let (_guard, _) = HeartbeatGuard::start(dir.path(), "r");
+            // Simulate a panic / early-return: guard drops here WITHOUT finalize.
+        }
+        let rec = read_last_run(dir.path()).unwrap().unwrap();
+        assert_eq!(rec.status, LastRunStatus::Aborted, "drop-guard must catch the abort");
+        assert!(rec.error.is_some());
+        assert!(rec.ended_at.is_some());
+    }
+
+    #[test]
+    fn read_absent_is_none_not_error() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(read_last_run(dir.path()).unwrap(), None);
+    }
+}

--- a/crates/ovp-daily/src/lib.rs
+++ b/crates/ovp-daily/src/lib.rs
@@ -32,9 +32,14 @@ use ovp_domain::VaultLayout;
 use ovp_intake::vaultops::{hex_sha256, rel_to, safe_move};
 use ovp_llm::ModelClient;
 
+pub mod heartbeat;
 pub mod ledger;
 pub mod report;
 
+pub use heartbeat::{
+    read_last_run, write_last_run, HeartbeatGuard, LastRun, LastRunStatus, RunCounts,
+    LAST_RUN_SCHEMA,
+};
 pub use ledger::{
     append_daily_record, append_pipeline_event, failed_counts, read_daily_ledger,
     succeeded_hashes, DailyRunRecord, PipelineLogEvent, RunStatus, DAILY_SCHEMA,

--- a/crates/ovp-domain/src/vault_layout.rs
+++ b/crates/ovp-domain/src/vault_layout.rs
@@ -194,6 +194,16 @@ impl VaultLayout {
         ".ovp/index/index.json"
     }
 
+    /// Unconditional run-liveness heartbeat (OVP2 observability P0). Written at
+    /// the START of every `daily` invocation (`status: running`) and overwritten
+    /// with a terminal status (`completed` / `failed` / `aborted`) as the run
+    /// ends — so an unattended run that crashes before its end-of-run report is
+    /// still visible to the operator. Overwrite is CORRECT: it is a single
+    /// liveness snapshot, not an append-only ledger.
+    pub fn last_run_file(&self) -> &'static str {
+        ".ovp/last-run.json"
+    }
+
     /// The product console directory (static HTML over product state, M31).
     pub fn console_dir(&self) -> &'static str {
         ".ovp/console"

--- a/crates/ovp-index/src/build.rs
+++ b/crates/ovp-index/src/build.rs
@@ -823,19 +823,17 @@ fn build_ops_state(sources: &[SourceRow], runs: &[RunRow], today: &str) -> OpsSt
     }
 }
 
-/// Read the run-liveness heartbeat (`.ovp/last-run.json`) into the read-model
-/// shape. A corrupt file degrades to `None` (the projection must always build;
-/// `ovp2 doctor`/the CLI surface the corruption loudly), and an absent file on
-/// a fresh vault is `None` too.
-fn build_last_run(vault_root: &Path) -> Option<LastRunModel> {
-    let hb = ovp_daily::read_last_run(vault_root).ok().flatten()?;
+/// Map a raw heartbeat record to the read-model shape. Pure; the string
+/// status keeps the model self-describing for the static console pages and the
+/// SPA alike.
+pub fn last_run_to_model(hb: ovp_daily::LastRun) -> LastRunModel {
     let status = match hb.status {
         ovp_daily::LastRunStatus::Running => "running",
         ovp_daily::LastRunStatus::Completed => "completed",
         ovp_daily::LastRunStatus::Failed => "failed",
         ovp_daily::LastRunStatus::Aborted => "aborted",
     };
-    Some(LastRunModel {
+    LastRunModel {
         run_id: hb.run_id,
         started_at: hb.started_at,
         ended_at: hb.ended_at,
@@ -846,7 +844,28 @@ fn build_last_run(vault_root: &Path) -> Option<LastRunModel> {
         capped: hb.capped,
         queued_after: hb.queued_after,
         error: hb.error,
-    })
+    }
+}
+
+/// Read the run-liveness heartbeat (`.ovp/last-run.json`) LIVE into the
+/// read-model shape, PRESERVING errors. This is the fail-loud reader the
+/// server and `doctor` use so a corrupt/unreadable heartbeat is never silently
+/// treated as absent (that would hide the very failed/aborted run this feature
+/// exists to surface). `Ok(None)` = fresh vault (no file); `Err` = present but
+/// unparseable.
+pub fn read_last_run_model(vault_root: &Path) -> Result<Option<LastRunModel>, String> {
+    Ok(ovp_daily::read_last_run(vault_root)?.map(last_run_to_model))
+}
+
+/// Read the heartbeat for the BAKED projection. The projection must always
+/// build, so a corrupt file degrades to `None` here (the CLI/`doctor`/server
+/// surface the corruption loudly via [`read_last_run_model`]); an absent file
+/// on a fresh vault is `None` too. NOTE: the baked field is a build-time
+/// SNAPSHOT — it can say `running` forever if the process died before the
+/// phase-5 rebuild. Live surfaces (server `/api/*`, `doctor`, `schedule
+/// status`) must read the sidecar fresh, never trust this field.
+fn build_last_run(vault_root: &Path) -> Option<LastRunModel> {
+    read_last_run_model(vault_root).ok().flatten()
 }
 
 fn compute_run_stats(runs: &[RunRow], today: &str) -> Option<RunStats> {

--- a/crates/ovp-index/src/build.rs
+++ b/crates/ovp-index/src/build.rs
@@ -23,8 +23,8 @@ use ovp_intake::{IntakeAction, read_intake_ledger};
 use serde::Deserialize;
 
 use crate::model::{
-    BlockedSource, ClaimRow, ClaimStatus, INDEX_SCHEMA, IndexModel, OpsState, PackRow, RunRow,
-    RunStats, SourceRow, SourceStatus, Totals,
+    BlockedSource, ClaimRow, ClaimStatus, INDEX_SCHEMA, IndexModel, LastRunModel, OpsState,
+    PackRow, RunRow, RunStats, SourceRow, SourceStatus, Totals,
 };
 
 /// Build the full read model. `date`/`run_id` only stamp the header.
@@ -69,7 +69,8 @@ pub fn build_index(
         runs: runs.len(),
     };
 
-    let ops = build_ops_state(&sources, &runs, date);
+    let mut ops = build_ops_state(&sources, &runs, date);
+    ops.last_run = build_last_run(vault_root);
 
     Ok(IndexModel {
         schema: INDEX_SCHEMA.into(),
@@ -818,7 +819,34 @@ fn build_ops_state(sources: &[SourceRow], runs: &[RunRow], today: &str) -> OpsSt
         blocked_sources,
         queue_depth,
         run_stats,
+        last_run: None,
     }
+}
+
+/// Read the run-liveness heartbeat (`.ovp/last-run.json`) into the read-model
+/// shape. A corrupt file degrades to `None` (the projection must always build;
+/// `ovp2 doctor`/the CLI surface the corruption loudly), and an absent file on
+/// a fresh vault is `None` too.
+fn build_last_run(vault_root: &Path) -> Option<LastRunModel> {
+    let hb = ovp_daily::read_last_run(vault_root).ok().flatten()?;
+    let status = match hb.status {
+        ovp_daily::LastRunStatus::Running => "running",
+        ovp_daily::LastRunStatus::Completed => "completed",
+        ovp_daily::LastRunStatus::Failed => "failed",
+        ovp_daily::LastRunStatus::Aborted => "aborted",
+    };
+    Some(LastRunModel {
+        run_id: hb.run_id,
+        started_at: hb.started_at,
+        ended_at: hb.ended_at,
+        status: status.into(),
+        processed: hb.processed,
+        failed: hb.failed,
+        blocked: hb.blocked,
+        capped: hb.capped,
+        queued_after: hb.queued_after,
+        error: hb.error,
+    })
 }
 
 fn compute_run_stats(runs: &[RunRow], today: &str) -> Option<RunStats> {
@@ -941,6 +969,49 @@ fn is_leap(y: u32) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn last_run_none_when_no_heartbeat_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let model = build_index(tmp.path(), "2026-07-12", None).unwrap();
+        assert!(model.ops.last_run.is_none(), "fresh vault → no last_run");
+    }
+
+    #[test]
+    fn last_run_surfaces_completed_heartbeat() {
+        let tmp = tempfile::tempdir().unwrap();
+        let counts = ovp_daily::RunCounts {
+            processed: 8,
+            failed: 0,
+            blocked: 1,
+            capped: 2,
+            queued_after: 180,
+        };
+        let (guard, _) = ovp_daily::HeartbeatGuard::start(tmp.path(), "daily-2026-07-12");
+        assert!(guard.finalize_completed(counts).is_none());
+
+        let model = build_index(tmp.path(), "2026-07-12", None).unwrap();
+        let lr = model.ops.last_run.expect("heartbeat surfaced");
+        assert_eq!(lr.status, "completed");
+        assert_eq!(lr.run_id, "daily-2026-07-12");
+        assert_eq!(lr.processed, Some(8));
+        assert_eq!(lr.queued_after, Some(180));
+        assert!(lr.ended_at.is_some());
+        assert!(lr.error.is_none());
+    }
+
+    #[test]
+    fn last_run_surfaces_aborted_heartbeat() {
+        let tmp = tempfile::tempdir().unwrap();
+        {
+            let (_g, _) = ovp_daily::HeartbeatGuard::start(tmp.path(), "r");
+            // drop without finalize → aborted
+        }
+        let model = build_index(tmp.path(), "2026-07-12", None).unwrap();
+        let lr = model.ops.last_run.expect("aborted heartbeat surfaced");
+        assert_eq!(lr.status, "aborted");
+        assert!(lr.error.is_some());
+    }
 
     #[test]
     fn corpus_hash8_matches_only_the_legacy_prefix_shape() {

--- a/crates/ovp-index/src/lib.rs
+++ b/crates/ovp-index/src/lib.rs
@@ -23,7 +23,10 @@ pub mod model;
 pub mod query;
 pub mod score;
 
-pub use build::{build_index, failed_reader_attempt, read_index, write_index};
+pub use build::{
+    build_index, failed_reader_attempt, last_run_to_model, read_index, read_last_run_model,
+    write_index,
+};
 pub use evidence::{EvidenceModel, build_evidence, evidence_path, read_evidence, write_evidence};
 pub use model::{
     BlockedSource, ClaimRow, ClaimStatus, INDEX_SCHEMA, IndexModel, LastRunModel, OpsState,

--- a/crates/ovp-index/src/lib.rs
+++ b/crates/ovp-index/src/lib.rs
@@ -26,8 +26,8 @@ pub mod score;
 pub use build::{build_index, failed_reader_attempt, read_index, write_index};
 pub use evidence::{EvidenceModel, build_evidence, evidence_path, read_evidence, write_evidence};
 pub use model::{
-    BlockedSource, ClaimRow, ClaimStatus, INDEX_SCHEMA, IndexModel, OpsState, PackRow, RunRow,
-    RunStats, SourceRow, SourceStatus, Totals,
+    BlockedSource, ClaimRow, ClaimStatus, INDEX_SCHEMA, IndexModel, LastRunModel, OpsState,
+    PackRow, RunRow, RunStats, SourceRow, SourceStatus, Totals,
 };
 pub use query::{
     Hit, Query, QueryKind, claim_status_str, run_evidence_query, run_query, source_status_str,

--- a/crates/ovp-index/src/model.rs
+++ b/crates/ovp-index/src/model.rs
@@ -156,11 +156,44 @@ pub struct RunStats {
     pub avg_processed_per_run: f64,
 }
 
+/// Run-liveness heartbeat surfaced into the read model (OVP2 observability P0).
+/// Mirrors `.ovp/last-run.json`; `minutes_since` is deliberately NOT stored —
+/// the portal computes age client-side from `started_at`/`ended_at` + now, so
+/// the banner ages without a rebuild. Serde-additive: a pre-P0 index has no
+/// `last_run` field and deserializes to `None`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LastRunModel {
+    pub run_id: String,
+    /// Wall-clock start (UTC, RFC3339).
+    pub started_at: String,
+    /// Wall-clock terminal time (UTC, RFC3339); None while `running`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ended_at: Option<String>,
+    /// `running` | `completed` | `failed` | `aborted`.
+    pub status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub processed: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failed: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blocked: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capped: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub queued_after: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct OpsState {
     pub blocked_sources: Vec<BlockedSource>,
     pub queue_depth: usize,
     pub run_stats: Option<RunStats>,
+    /// The run-liveness heartbeat (`.ovp/last-run.json`) at build time. None on
+    /// a fresh vault (no runs yet) or a pre-P0 index.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_run: Option<LastRunModel>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/ovp-server/Cargo.toml
+++ b/crates/ovp-server/Cargo.toml
@@ -15,3 +15,6 @@ ovp-llm = { path = "../ovp-llm" }
 serde.workspace = true
 serde_json.workspace = true
 tiny_http = "0.12"
+
+[dev-dependencies]
+ovp-daily = { path = "../ovp-daily" }

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -20,8 +20,8 @@ use ovp_domain::crystal::themes::{ThemesFile, UNCLASSIFIED_THEME};
 use ovp_domain::crystal::{CrystalStatus, DurableRecord, StoreEvent, fold_ledger};
 use ovp_domain::units::Unit;
 use ovp_index::{
-    EvidenceModel, IndexModel, Query, QueryKind, evidence_path, read_evidence, read_index,
-    run_query,
+    EvidenceModel, IndexModel, LastRunModel, Query, QueryKind, evidence_path, read_evidence,
+    read_index, read_last_run_model, run_query,
 };
 use ovp_intake::read_jsonl;
 use ovp_llm::ModelClient;
@@ -203,6 +203,12 @@ struct AppState {
     /// Card/unit bodies for the /api/source/:sha memory layer — same
     /// mtime-keyed auto-reload as the model, keyed on `evidence.json`.
     evidence: RwLock<Cached<EvidenceModel>>,
+    /// The run-liveness heartbeat (`.ovp/last-run.json`), read LIVE (mtime
+    /// auto-reload) — NOT the baked `index.json` snapshot. The heartbeat is a
+    /// live sidecar: `daily` writes it before the index is rebuilt (and a crash
+    /// can leave the index's baked copy saying "running" forever), so every
+    /// server surface overlays THIS fresh value over `model.ops.last_run`.
+    last_run: RwLock<Cached<LastRunModel>>,
     viz_dir: Option<PathBuf>,
     ask_client: Option<AskClientFactory>,
     /// The /api/ask wall-clock guard — [`ask_guard_from_env`] unless
@@ -219,6 +225,33 @@ impl AppState {
 
     fn evidence_path(&self) -> PathBuf {
         evidence_path(&self.vault_root)
+    }
+
+    fn last_run_path(&self) -> PathBuf {
+        self.vault_root.join(self.layout.last_run_file())
+    }
+
+    /// The LIVE run-liveness heartbeat, mtime-freshened against
+    /// `.ovp/last-run.json`. This is the single source of truth for last-run
+    /// status on every API surface — never the baked `index.json` copy, which
+    /// can be a stale "running" snapshot from before a crash. A corrupt file
+    /// degrades to `None` here (the server must keep serving); `doctor` is the
+    /// fail-loud gate for corruption.
+    fn current_last_run(&self) -> Option<LastRunModel> {
+        let path = self.last_run_path();
+        freshen(&self.last_run, &path, || {
+            read_last_run_model(&self.vault_root).ok().flatten()
+        })
+    }
+
+    /// The index model with its `ops.last_run` field OVERLAID by the live
+    /// heartbeat sidecar — so `/api/model` (and the SPA banner reading it) never
+    /// sees a stale baked "running". Returns None only when there is no index
+    /// at all.
+    fn model_with_live_last_run(&self) -> Option<IndexModel> {
+        let mut model = self.current_model()?;
+        model.ops.last_run = self.current_last_run();
+        Some(model)
     }
 
     /// The cached index read-model, auto-freshened against `index.json`'s
@@ -253,6 +286,11 @@ impl AppState {
             &self.evidence,
             &self.evidence_path(),
             read_evidence(&self.vault_root).ok(),
+        );
+        force_reload(
+            &self.last_run,
+            &self.last_run_path(),
+            read_last_run_model(&self.vault_root).ok().flatten(),
         );
     }
 
@@ -315,6 +353,7 @@ pub fn run_server(config: ServeConfig) -> Result<(), String> {
         layout: VaultLayout::new(),
         model: RwLock::new(Cached::default()),
         evidence: RwLock::new(Cached::default()),
+        last_run: RwLock::new(Cached::default()),
         viz_dir: config.viz_dir,
         ask_client: config.ask_client,
         ask_timeout: config.ask_timeout.unwrap_or_else(ask_guard_from_env),
@@ -516,7 +555,9 @@ fn handle_themes(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
 }
 
 fn handle_model(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
-    let model = match state.current_model() {
+    // Overlay the LIVE heartbeat over the baked `ops.last_run` so the SPA banner
+    // never reads a stale "running" snapshot baked into index.json.
+    let model = match state.model_with_live_last_run() {
         Some(m) => m,
         None => return json_response(503, r#"{"error":"index not available"}"#),
     };
@@ -942,10 +983,11 @@ fn handle_settings(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
             "max_concurrent": state.ask_slots.max,
         },
         // Run-liveness heartbeat (OVP2 observability P0) so `schedule status`
-        // and any client read the same last-run block uniformly. Null on a
-        // fresh vault / pre-P0 index. The client derives age from
+        // and any client read the same last-run block uniformly. Read LIVE from
+        // `.ovp/last-run.json` (NOT the baked index snapshot, which can be a
+        // stale "running"). Null on a fresh vault. The client derives age from
         // started_at/ended_at + now — the server ships no `minutes_since`.
-        "last_run": model.as_ref().and_then(|m| m.ops.last_run.clone()),
+        "last_run": state.current_last_run(),
         "version": env!("CARGO_PKG_VERSION"),
     });
     json_response(200, &body.to_string())
@@ -1553,6 +1595,7 @@ mod tests {
             layout: VaultLayout::new(),
             model: RwLock::new(Cached::default()),
             evidence: RwLock::new(Cached::default()),
+            last_run: RwLock::new(Cached::default()),
             viz_dir,
             ask_client: None,
             // Fixed (not env-derived) so tests stay deterministic on
@@ -2902,6 +2945,86 @@ mod tests {
         // (absent-file stamp was None; a present file's stamp differs).
         ovp_index::write_index(&vault, &index_dated("2026-03-03")).unwrap();
         assert_eq!(st.current_model().unwrap().date, "2026-03-03");
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// P1 regression: the index bakes `ops.last_run` at build time, so a crash
+    /// after the heartbeat starts but before the index rebuild leaves the baked
+    /// copy saying "running" forever. The server MUST read the sidecar LIVE and
+    /// report the finalized status — never the stale baked snapshot.
+    #[test]
+    fn server_prefers_live_heartbeat_over_stale_baked_last_run() {
+        let root = temp_root("live-heartbeat-overlay");
+        let vault = root.join("vault");
+        std::fs::create_dir_all(&vault).unwrap();
+        let st = state(vault.clone(), None);
+
+        // Bake an index whose ops.last_run says "running" (the stale snapshot).
+        let mut baked = index_dated("2026-07-12");
+        baked.ops.last_run = Some(LastRunModel {
+            run_id: "daily-2026-07-12".into(),
+            started_at: "2026-07-12T09:00:00Z".into(),
+            ended_at: None,
+            status: "running".into(),
+            processed: None,
+            failed: None,
+            blocked: None,
+            capped: None,
+            queued_after: None,
+            error: None,
+        });
+        ovp_index::write_index(&vault, &baked).unwrap();
+
+        // On disk the run actually FINISHED — write a finalized sidecar.
+        let (g, _) = ovp_daily::HeartbeatGuard::start(&vault, "daily-2026-07-12");
+        g.finalize_completed(ovp_daily::RunCounts {
+            processed: 8,
+            queued_after: 180,
+            ..Default::default()
+        });
+
+        // /api/model overlays the live sidecar over the baked "running".
+        let live = st.model_with_live_last_run().unwrap();
+        let lr = live.ops.last_run.expect("live last_run present");
+        assert_eq!(lr.status, "completed", "must reflect the finalized sidecar, not baked 'running'");
+        assert_eq!(lr.processed, Some(8));
+
+        // /api/settings reads the same live value.
+        let resp = dispatch(&st, Method::Get, "/api/settings", "");
+        assert_eq!(resp.status_code(), 200);
+        let v = body_json(resp);
+        assert_eq!(v["last_run"]["status"], "completed");
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// A still-running index snapshot with NO sidecar (e.g. sidecar deleted)
+    /// overlays to None — the server never re-serves the stale baked value.
+    #[test]
+    fn live_overlay_nulls_baked_last_run_when_sidecar_absent() {
+        let root = temp_root("live-heartbeat-absent");
+        let vault = root.join("vault");
+        std::fs::create_dir_all(&vault).unwrap();
+        let st = state(vault.clone(), None);
+
+        let mut baked = index_dated("2026-07-12");
+        baked.ops.last_run = Some(LastRunModel {
+            run_id: "r".into(),
+            started_at: "2026-07-12T09:00:00Z".into(),
+            ended_at: None,
+            status: "running".into(),
+            processed: None,
+            failed: None,
+            blocked: None,
+            capped: None,
+            queued_after: None,
+            error: None,
+        });
+        ovp_index::write_index(&vault, &baked).unwrap();
+
+        let live = st.model_with_live_last_run().unwrap();
+        assert!(live.ops.last_run.is_none(), "no sidecar → live overlay is None, not the stale baked snapshot");
 
         let _ = std::fs::remove_dir_all(&root);
     }

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -941,6 +941,11 @@ fn handle_settings(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
             "timeout_secs": state.ask_timeout.as_secs(),
             "max_concurrent": state.ask_slots.max,
         },
+        // Run-liveness heartbeat (OVP2 observability P0) so `schedule status`
+        // and any client read the same last-run block uniformly. Null on a
+        // fresh vault / pre-P0 index. The client derives age from
+        // started_at/ended_at + now — the server ships no `minutes_since`.
+        "last_run": model.as_ref().and_then(|m| m.ops.last_run.clone()),
         "version": env!("CARGO_PKG_VERSION"),
     });
     json_response(200, &body.to_string())


### PR DESCRIPTION
P0 of the observability remediation: the most dangerous gap now that scheduled runs are live — a daily that crashes before writing its end-of-run report was completely invisible (portal identical to yesterday, green dot, doctor blind).

- **Heartbeat**: daily writes .ovp/last-run.json at start (running+pid, ATOMIC temp+rename) and finalizes completed/failed with counts; a RAII drop-guard writes 'aborted' if the process dies mid-run without finalizing — so it never sticks on 'running'. RunLock acquired BEFORE the guard, so an overlapping run can't clobber the active one's heartbeat.
- **Live, never baked**: the heartbeat is read fresh at serve time (mtime-reloaded sidecar), overlaid onto /api/model + /api/settings — NOT stored as truth in the index projection (which bakes at build time while status is still 'running'). This was codex's crux catch: the heartbeat itself had fallen into the snapshot-vs-live trap this effort exists to kill.
- **Portal banner**: fixed top strip on every page — green 'Last run: completed 2h ago · 8 read · 180 queued', amber '3 days ago', red 'FAILED/ABORTED — <error>'; age ticks client-side; status dot flips red on stale/failed heartbeat and now re-evaluates on the minute tick even on an idle open tab.
- **doctor**: FAILs on failed/aborted/stale heartbeat; a corrupt last-run.json FAILs loud (never silently falls back).

Tests: heartbeat lifecycle incl. aborted-path across all 3 layers, live-over-baked, lock-contender-no-clobber, corrupt-fails-doctor, banner/health vitest. 898 workspace tests, clippy -D warnings, arch check, tsc+vite+vitest. Codex gate: 2 rounds, 3+2 findings all fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a run-status banner across the portal showing completed, running, stale, failed, aborted, or unavailable run states.
  * Banner details include relative timing, processing counts, and error information, with a link to system status.
  * Run status now updates automatically while the portal remains open.
  * Added run heartbeat tracking for daily operations, including completion, failure, and interruption states.
  * System status and doctor checks now detect stale, failed, aborted, corrupt, or missing run records.
  * Added configurable doctor recency checks with the `--since` option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->