### PR TITLE
fix(obs P1): stamp projections with built_at/run_id, show data age everywhere

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1507,6 +1507,7 @@ dependencies = [
 name = "ovp-index"
 version = "2.0.1"
 dependencies = [
+ "chrono",
  "ovp-daily",
  "ovp-domain",
  "ovp-intake",
@@ -1640,6 +1641,7 @@ dependencies = [
 name = "ovp-server"
 version = "2.0.1"
 dependencies = [
+ "chrono",
  "ovp-domain",
  "ovp-index",
  "ovp-intake",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ clap = { version = "4", features = ["derive"] }
 sha2 = "0.10"
 tempfile = "3"
 serde_yaml = "0.9"
+chrono = { version = "0.4", features = ["serde"] }
 # Live LLM transport. Only compiled when a crate opts in via its own
 # `anthropic`-style feature (optional dep). Blocking + rustls so there is
 # no async runtime and no system OpenSSL dependency.

--- a/console-ui/src/components/ui.tsx
+++ b/console-ui/src/components/ui.tsx
@@ -1,7 +1,49 @@
 /** Small DS-conformant building blocks shared by the portal pages. */
-import type { ReactNode } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import { useI18n, type MsgKey } from '../i18n';
+import { ageParts } from '../lib/derive';
 import type { SourceStatus } from '../lib/types';
+
+/** Muted "as of <built_at> · N min ago" freshness stamp, derived client-side
+ * from the projection's build instant and a ticking clock. Every surface that
+ * shows counts renders one, so a stale number can never read like a fresh one.
+ * Absent/unparseable `built_at` (pre-P1 index) → "unknown age". Bilingual via
+ * the age.* keys. The clock ticks on an interval (default 30s) so a left-open
+ * tab's label converges without a reload. */
+export function AgeLabel({
+  builtAt,
+  tickMs = 30_000,
+}: {
+  builtAt?: string | null;
+  tickMs?: number;
+}) {
+  const { t } = useI18n();
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), tickMs);
+    return () => clearInterval(id);
+  }, [tickMs]);
+
+  const a = ageParts(builtAt, now);
+  if (a.unknown) {
+    return <span className="muted tiny age-label">{t('age.unknown')}</span>;
+  }
+  const rel =
+    a.unit === 'now'
+      ? t('age.now')
+      : a.unit === 'minute'
+        ? t('age.minutes', { n: a.value })
+        : a.unit === 'hour'
+          ? t('age.hours', { n: a.value })
+          : t('age.days', { n: a.value });
+  // The instant is a machine timestamp — show it verbatim (mono), the relative
+  // phrase is the human-readable half.
+  return (
+    <span className="muted tiny age-label" title={a.builtAt ?? undefined}>
+      {t('age.stamp', { instant: a.builtAt ?? '', rel })}
+    </span>
+  );
+}
 
 /** Semantic status pill (DS extension #2). */
 export function StatusPill({ status }: { status: SourceStatus }) {

--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -21,6 +21,17 @@ export const en = {
   'common.whatIsThisPage': 'What is this page?',
   'common.day': 'dogfood day',
 
+  // data-freshness label (P1): "as of <instant> · N min ago". Every surface
+  // that shows counts stamps the projection's build instant so a stale number
+  // never reads like a fresh one.
+  'age.asOf': 'as of {instant}',
+  'age.now': 'just now',
+  'age.minutes': '{n} min ago',
+  'age.hours': '{n} hr ago',
+  'age.days': '{n} d ago',
+  'age.unknown': 'unknown age',
+  'age.stamp': 'as of {instant} · {rel}',
+
   // concept tooltips — plain-language one-liners for the pipeline vocabulary
   // (operator finding: durable/caveated and unit/card need explaining
   // wherever the pills render).
@@ -273,6 +284,8 @@ export const en = {
   'system.vaultRoot': 'vault',
   'system.schema': 'index schema',
   'system.indexDate': 'index date',
+  'system.builtAt': 'built',
+  'system.runId': 'run id',
   'system.counts': 'counts',
   'system.countsLine': '{sources} sources · {packs} packs · {claims} claims',
   'system.noIndex': 'no index built — run `ovp2 index`',

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -21,6 +21,16 @@ export const zh: Record<keyof typeof en, string> = {
   'common.whatIsThisPage': '这是什么页？',
   'common.day': '试用第',
 
+  // 数据新鲜度标签（P1）：“截至 <时刻> · N 分钟前”。凡展示计数的界面都标注
+  // 构建时刻，陈旧数字不再伪装成最新。
+  'age.asOf': '截至 {instant}',
+  'age.now': '刚刚',
+  'age.minutes': '{n} 分钟前',
+  'age.hours': '{n} 小时前',
+  'age.days': '{n} 天前',
+  'age.unknown': '时间未知',
+  'age.stamp': '截至 {instant} · {rel}',
+
   // concept tooltips
   'concept.durableTip': '已验证：每条引文均逐字核对过原文',
   'concept.caveatedTip': '未验证：有价值但证据未完全过关，需带着怀疑使用',
@@ -252,6 +262,8 @@ export const zh: Record<keyof typeof en, string> = {
   'system.vaultRoot': 'vault 路径',
   'system.schema': '索引 schema',
   'system.indexDate': '索引日期',
+  'system.builtAt': '构建时刻',
+  'system.runId': '运行 id',
   'system.counts': '统计',
   'system.countsLine': '{sources} 源 · {packs} 阅读包 · {claims} 主张',
   'system.noIndex': '索引未构建——运行 `ovp2 index`',

--- a/console-ui/src/lib/derive.test.ts
+++ b/console-ui/src/lib/derive.test.ts
@@ -1,0 +1,57 @@
+/** Freshness-label derivation unit tests (vitest, node env): the age helper is
+ * pure — the ticking clock is injected — so buckets and the unknown/clamp rules
+ * are asserted deterministically. This is the P1 "numbers lie" guard: a stale
+ * projection derives a visibly-older age than a fresh one. */
+import { describe, expect, it } from 'vitest';
+import { ageParts } from './derive';
+
+const BUILT = '2026-07-09T00:00:00Z';
+const BUILT_MS = Date.parse(BUILT);
+
+describe('ageParts', () => {
+  it('reports "just now" under a minute', () => {
+    const a = ageParts(BUILT, BUILT_MS + 30_000);
+    expect(a.unknown).toBe(false);
+    expect(a.unit).toBe('now');
+    expect(a.value).toBe(0);
+    expect(a.builtAt).toBe(BUILT);
+    expect(a.seconds).toBe(30);
+  });
+
+  it('buckets minutes, hours and days', () => {
+    expect(ageParts(BUILT, BUILT_MS + 5 * 60_000)).toMatchObject({
+      unit: 'minute',
+      value: 5,
+    });
+    expect(ageParts(BUILT, BUILT_MS + 3 * 3_600_000)).toMatchObject({
+      unit: 'hour',
+      value: 3,
+    });
+    expect(ageParts(BUILT, BUILT_MS + 2 * 86_400_000)).toMatchObject({
+      unit: 'day',
+      value: 2,
+    });
+  });
+
+  it('flags unknown for absent or unparseable built_at', () => {
+    expect(ageParts(null, BUILT_MS)).toMatchObject({ unknown: true, builtAt: null });
+    expect(ageParts(undefined, BUILT_MS)).toMatchObject({ unknown: true });
+    expect(ageParts('not-a-date', BUILT_MS)).toMatchObject({ unknown: true });
+  });
+
+  it('clamps negative age (clock skew) to zero', () => {
+    // "now" is BEFORE built_at — a slight skew must not read as negative.
+    const a = ageParts(BUILT, BUILT_MS - 5_000);
+    expect(a.seconds).toBe(0);
+    expect(a.unit).toBe('now');
+  });
+
+  it('distinguishes a stale projection from a fresh one', () => {
+    const fresh = ageParts(BUILT, BUILT_MS + 10_000);
+    const stale = ageParts(BUILT, BUILT_MS + 6 * 3_600_000);
+    // The whole point of P1: the numbers no longer render identically.
+    expect(fresh.seconds).toBeLessThan(stale.seconds);
+    expect(fresh.unit).toBe('now');
+    expect(stale.unit).toBe('hour');
+  });
+});

--- a/console-ui/src/lib/derive.ts
+++ b/console-ui/src/lib/derive.ts
@@ -293,3 +293,50 @@ export function countBy<T, K>(items: T[], key: (item: T) => K): Map<K, number> {
   }
   return counts;
 }
+
+// ------------------------------------------------------------------ freshness
+
+/** The pieces a freshness label needs, derived client-side from a projection's
+ * `built_at` and the current wall clock. `unit`/`value` name a coarse bucket
+ * (seconds → just now, minutes, hours, days) so the i18n layer can render
+ * "N min ago" bilingually WITHOUT owning the arithmetic. `unknown` is true when
+ * `built_at` is absent (pre-P1 index) or unparseable — the label then reads
+ * "unknown age" rather than fabricating a 0. */
+export interface AgeParts {
+  unknown: boolean;
+  /** RFC3339 instant, echoed for the "as of <built_at>" prefix (null when unknown). */
+  builtAt: string | null;
+  /** Whole seconds since built_at, clamped at 0 (0 when unknown). */
+  seconds: number;
+  /** Coarse bucket for the relative phrase. */
+  unit: 'now' | 'minute' | 'hour' | 'day';
+  /** The count for `unit` (e.g. 5 for "5 min ago"); 0 for the 'now' bucket. */
+  value: number;
+}
+
+const MINUTE = 60;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+/** Derive the age of a projection built at `builtAt` as of `nowMs`. Pure: the
+ * ticking clock is injected so the helper is deterministic under test. */
+export function ageParts(
+  builtAt: string | null | undefined,
+  nowMs: number,
+): AgeParts {
+  if (!builtAt) {
+    return { unknown: true, builtAt: null, seconds: 0, unit: 'now', value: 0 };
+  }
+  const builtMs = Date.parse(builtAt);
+  if (Number.isNaN(builtMs)) {
+    return { unknown: true, builtAt: null, seconds: 0, unit: 'now', value: 0 };
+  }
+  // Clamp at 0 so a small clock skew never shows a negative age.
+  const seconds = Math.max(0, Math.floor((nowMs - builtMs) / 1000));
+  if (seconds < MINUTE) return { unknown: false, builtAt, seconds, unit: 'now', value: 0 };
+  if (seconds < HOUR)
+    return { unknown: false, builtAt, seconds, unit: 'minute', value: Math.floor(seconds / MINUTE) };
+  if (seconds < DAY)
+    return { unknown: false, builtAt, seconds, unit: 'hour', value: Math.floor(seconds / HOUR) };
+  return { unknown: false, builtAt, seconds, unit: 'day', value: Math.floor(seconds / DAY) };
+}

--- a/console-ui/src/lib/types.ts
+++ b/console-ui/src/lib/types.ts
@@ -239,6 +239,11 @@ export interface SettingsPayload {
   vault_root: string;
   schema_version: string | null;
   index_date: string | null;
+  /** P1 provenance: the projection's build instant, its producer run id, and
+   * the server-computed age. Null when no index is built yet. */
+  built_at: string | null;
+  run_id: string | null;
+  age_seconds: number | null;
   counts: SettingsCounts | null;
   llm_configured: boolean;
   ask_limits: AskLimits;
@@ -299,7 +304,14 @@ export interface Totals {
 export interface IndexModel {
   schema: string;
   date: string;
+  /** Wall-clock build instant (UTC RFC3339). Absent on pre-P1 indexes — the
+   * UI then shows "unknown age". */
+  built_at?: string | null;
   run_id?: string;
+  /** Server-computed seconds since `built_at` (spliced into /api/model). The
+   * client ticks its own age from `built_at`; this is the server's reading at
+   * fetch time. */
+  age_seconds?: number | null;
   totals: Totals;
   sources: SourceRow[];
   packs: PackRow[];

--- a/console-ui/src/model.tsx
+++ b/console-ui/src/model.tsx
@@ -31,17 +31,36 @@ export function ModelProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     let cancelled = false;
-    fetchModel()
-      .then((model) => {
-        if (!cancelled) setState({ model, error: null, loading: false });
-      })
-      .catch((err: unknown) => {
-        if (!cancelled) {
-          setState({ model: null, error: String(err), loading: false });
-        }
-      });
+
+    // Revalidate WITHOUT flashing the loading gate: the server model
+    // auto-freshens on index.json's mtime, so a revalidation is cheap and a
+    // left-open tab should converge to fresh on its own. A failed refetch keeps
+    // the last good model rather than blanking the page.
+    const load = (initial: boolean) => {
+      fetchModel()
+        .then((model) => {
+          if (!cancelled) setState({ model, error: null, loading: false });
+        })
+        .catch((err: unknown) => {
+          if (cancelled) return;
+          // Only the FIRST load surfaces an error; later refetch failures leave
+          // the last successful model in place (transient blip, not a reset).
+          if (initial) setState({ model: null, error: String(err), loading: false });
+        });
+    };
+
+    load(true);
+
+    // Refetch on tab focus + a slow 60s poll — enough to converge, cheap
+    // enough not to hammer (the server model is already mtime-cached).
+    const onFocus = () => load(false);
+    window.addEventListener('focus', onFocus);
+    const timer = setInterval(() => load(false), 60_000);
+
     return () => {
       cancelled = true;
+      window.removeEventListener('focus', onFocus);
+      clearInterval(timer);
     };
   }, []);
 

--- a/console-ui/src/pages/KnowledgePage.tsx
+++ b/console-ui/src/pages/KnowledgePage.tsx
@@ -13,7 +13,7 @@
 import { Link, Navigate, useLocation, useSearchParams } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import KnowledgeGraph from '../components/KnowledgeGraph';
-import { EmptyState, ModelGate, PageHelp } from '../components/ui';
+import { AgeLabel, EmptyState, ModelGate, PageHelp } from '../components/ui';
 import { useI18n } from '../i18n';
 import { fetchThemes } from '../lib/api';
 import { isMiscTheme, themeWall, type ThemeGroup } from '../lib/derive';
@@ -172,6 +172,9 @@ export default function KnowledgePage() {
       {model && (
         <>
           <h1 style={{ marginTop: '1rem' }}>{t('knowledge.title')}</h1>
+          <p className="muted sm" style={{ marginTop: '-2px' }}>
+            <AgeLabel builtAt={model.built_at} />
+          </p>
           {anchor && (
             <div className="portal-note tiny">
               {t('knowledge.unknownClaim', { id: anchor })}

--- a/console-ui/src/pages/LibraryPage.tsx
+++ b/console-ui/src/pages/LibraryPage.tsx
@@ -2,7 +2,7 @@
  * navigation over three dimensions (collection × month × status), month-
  * grouped rows, all state URL-parameterized: /library?c=&m=&status=. */
 import { Link, useSearchParams } from 'react-router-dom';
-import { EmptyState, ModelGate, PageHelp, StatusPill } from '../components/ui';
+import { AgeLabel, EmptyState, ModelGate, PageHelp, StatusPill } from '../components/ui';
 import { useI18n, type MsgKey } from '../i18n';
 import {
   collectionOf,
@@ -167,6 +167,9 @@ export default function LibraryPage() {
       {model && (
         <>
           <h1 style={{ marginTop: '1rem' }}>{t('library.title')}</h1>
+          <p className="muted sm" style={{ marginTop: '-2px' }}>
+            <AgeLabel builtAt={model.built_at} />
+          </p>
           <PageHelp>{t('library.help')}</PageHelp>
           <LibraryBody model={model} />
         </>

--- a/console-ui/src/pages/MonitorPage.tsx
+++ b/console-ui/src/pages/MonitorPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { AgeLabel } from '../components/ui';
 import { fetchModel } from '../lib/api';
 import type { IndexModel } from '../lib/types';
 
@@ -67,9 +68,15 @@ export default function MonitorPage() {
           {live ? '● CONNECTED' : '○ OFFLINE'}
         </span>
         {model && (
-          <span className="text-xs text-slate-500">
-            index {model.date}
-            {model.run_id && ` · ${model.run_id.slice(0, 12)}…`}
+          <span className="flex items-center gap-2 text-xs text-slate-500">
+            <span>
+              index {model.date}
+              {model.run_id && ` · ${model.run_id.slice(0, 12)}…`}
+            </span>
+            {/* "connected" ≠ "fresh": the socket may be live while the model on
+                disk is hours old. Show the model AGE next to the dot so the two
+                signals can't be conflated (P1). */}
+            <AgeLabel builtAt={model.built_at} />
           </span>
         )}
       </div>

--- a/console-ui/src/pages/SystemPage.tsx
+++ b/console-ui/src/pages/SystemPage.tsx
@@ -10,7 +10,7 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import AttentionCard from '../components/AttentionCard';
-import { EmptyState, ModelGate, PageHelp } from '../components/ui';
+import { AgeLabel, EmptyState, ModelGate, PageHelp } from '../components/ui';
 import { useI18n } from '../i18n';
 import { fetchSettings } from '../lib/api';
 import { attentionSources } from '../lib/derive';
@@ -208,6 +208,16 @@ function SettingsSection() {
           <dt>{t('system.indexDate')}</dt>
           <dd className="mono tiny">
             {settings.index_date ?? t('system.noIndex')}
+          </dd>
+          {/* P1: the projection's BUILD INSTANT + live age, so `index_date`
+              (a day string) can no longer stand in for freshness. */}
+          <dt>{t('system.builtAt')}</dt>
+          <dd className="tiny">
+            <AgeLabel builtAt={settings.built_at} />
+          </dd>
+          <dt>{t('system.runId')}</dt>
+          <dd className="mono tiny">
+            {settings.run_id ?? t('system.noIndex')}
           </dd>
           <dt>{t('system.counts')}</dt>
           <dd className="tiny">

--- a/console-ui/src/pages/TodayPage.tsx
+++ b/console-ui/src/pages/TodayPage.tsx
@@ -8,7 +8,7 @@
 import { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import AttentionCard from '../components/AttentionCard';
-import { ClaimPill, EmptyState, ModelGate, PageHelp } from '../components/ui';
+import { AgeLabel, ClaimPill, EmptyState, ModelGate, PageHelp } from '../components/ui';
 import { useI18n } from '../i18n';
 import {
   attentionSources,
@@ -191,6 +191,10 @@ export default function TodayPage() {
             {stats.dogfoodDay > 0 && (
               <> · {t('common.day')} {stats.dogfoodDay}</>
             )}
+            {' · '}
+            {/* P1: the build INSTANT + age, so three runs one day differ and a
+                stale count never reads like a fresh one. */}
+            <AgeLabel builtAt={model.built_at} />
           </p>
           <PageHelp>{t('today.help')}</PageHelp>
           {stats.todayRuns.length === 0 && (

--- a/crates/ovp-cli/src/commands/console_cmd.rs
+++ b/crates/ovp-cli/src/commands/console_cmd.rs
@@ -5,7 +5,7 @@
 use std::path::PathBuf;
 
 use ovp_console::{write_console, write_ops_pages};
-use ovp_index::{build_evidence, build_index, write_evidence, write_index};
+use ovp_index::{build_evidence, build_index_at, now_rfc3339, write_evidence, write_index};
 
 use crate::CliError;
 
@@ -15,7 +15,12 @@ pub struct ConsoleArgs {
 }
 
 pub fn run(args: ConsoleArgs) -> Result<(), CliError> {
-    let model = build_index(&args.vault_root, &args.date, None).map_err(CliError::Io)?;
+    // Stamp the instant once, and name the producer `console-<built_at>` so an
+    // ad-hoc console rebuild is never a silently-anonymous projection.
+    let built_at = now_rfc3339();
+    let run_id = format!("console-{built_at}");
+    let model = build_index_at(&args.vault_root, &args.date, Some(&run_id), &built_at)
+        .map_err(CliError::Io)?;
     let index_rel = write_index(&args.vault_root, &model).map_err(CliError::Io)?;
     let evidence = build_evidence(&args.vault_root, &args.date, &model).map_err(CliError::Io)?;
     let evidence_rel = write_evidence(&args.vault_root, &evidence).map_err(CliError::Io)?;

--- a/crates/ovp-cli/src/commands/crystal_review_session.rs
+++ b/crates/ovp-cli/src/commands/crystal_review_session.rs
@@ -978,6 +978,7 @@ mod tests {
         ovp_index::model::IndexModel {
             schema: "test".into(),
             date: "2026-07-07".into(),
+            built_at: None,
             run_id: None,
             totals: Default::default(),
             sources: vec![],

--- a/crates/ovp-cli/src/commands/daily.rs
+++ b/crates/ovp-cli/src/commands/daily.rs
@@ -563,6 +563,7 @@ mod tests {
         ovp_index::IndexModel {
             schema: "test".into(),
             date: "2026-07-10".into(),
+            built_at: None,
             run_id: None,
             totals: Default::default(),
             sources: vec![],

--- a/crates/ovp-cli/tests/m31_e2e.rs
+++ b/crates/ovp-cli/tests/m31_e2e.rs
@@ -310,6 +310,14 @@ fn full_daily_workflow_capture_to_console_with_crystal_and_retry() {
     assert!(console.contains("Benchmark Maxxing"));
     assert!(console.contains("待补内容"), "needs-content surfaced bilingually");
 
+    // P1 provenance: the daily path stamps the wall-clock instant AND passes
+    // its own run id through — a stale projection can no longer render like a
+    // fresh one, and the number's producer is always named.
+    let idx = read_index(&vault).unwrap();
+    assert_eq!(idx.run_id.as_deref(), Some("daily-e2e"), "daily run id kept");
+    let built = idx.built_at.expect("daily path stamps built_at");
+    assert!(built.starts_with(|c: char| c.is_ascii_digit()) && built.contains('T'), "RFC3339: {built}");
+
     // === Run 2: idempotence. Same inputs → nothing new. ===
     let stdout = run_ok(bin().args([
         "daily",
@@ -380,6 +388,17 @@ fn full_daily_workflow_capture_to_console_with_crystal_and_retry() {
     let console = std::fs::read_to_string(vault.join(".ovp/console/index.html")).unwrap();
     assert!(console.contains("e2e-1"), "durable claim on console");
     assert!(console.contains("持久化"), "bilingual durable pill");
+
+    // P1 provenance on the standalone console path: it rebuilds the index with
+    // a `console-<built_at>` producer marker (never a silently-None run_id) and
+    // stamps the wall-clock instant.
+    let console_idx = read_index(&vault).unwrap();
+    let console_built = console_idx.built_at.clone().expect("console path stamps built_at");
+    assert_eq!(
+        console_idx.run_id.as_deref(),
+        Some(format!("console-{console_built}").as_str()),
+        "console path synthesizes a console-<built_at> marker",
+    );
 
     let stdout = run_ok(bin().args([
         "find", "--vault-root", vault.to_str().unwrap(),

--- a/crates/ovp-console/src/ops.rs
+++ b/crates/ovp-console/src/ops.rs
@@ -45,9 +45,9 @@ fn ops_header(model: &IndexModel) -> String {
 <style>{CSS}</style></head>
 <body><main>
 <h1>OVP Ops <span class="zh">运维面板</span></h1>
-<p class="sub">built {date} · <a href="index.html">← console</a> · <a href="audit.html">audit</a> · <a href="candidates.html">candidates</a></p>
+<p class="sub">built {built} · <a href="index.html">← console</a> · <a href="audit.html">audit</a> · <a href="candidates.html">candidates</a></p>
 "##,
-        date = esc(&model.date),
+        built = esc(model.built_at.as_deref().unwrap_or(&model.date)),
     )
 }
 
@@ -172,9 +172,9 @@ fn audit_header(model: &IndexModel) -> String {
 <style>{CSS}</style></head>
 <body><main>
 <h1>OVP Audit <span class="zh">审计时间线</span></h1>
-<p class="sub">built {date} · <a href="index.html">← console</a> · <a href="ops.html">ops</a> · <a href="candidates.html">candidates</a></p>
+<p class="sub">built {built} · <a href="index.html">← console</a> · <a href="ops.html">ops</a> · <a href="candidates.html">candidates</a></p>
 "##,
-        date = esc(&model.date),
+        built = esc(model.built_at.as_deref().unwrap_or(&model.date)),
     )
 }
 
@@ -211,9 +211,9 @@ fn candidates_header(model: &IndexModel) -> String {
 <style>{CSS}</style></head>
 <body><main>
 <h1>OVP Candidates <span class="zh">待审候选</span></h1>
-<p class="sub">built {date} · <a href="index.html">← console</a> · <a href="ops.html">ops</a> · <a href="audit.html">audit</a></p>
+<p class="sub">built {built} · <a href="index.html">← console</a> · <a href="ops.html">ops</a> · <a href="audit.html">audit</a></p>
 "##,
-        date = esc(&model.date),
+        built = esc(model.built_at.as_deref().unwrap_or(&model.date)),
     )
 }
 

--- a/crates/ovp-console/src/render.rs
+++ b/crates/ovp-console/src/render.rs
@@ -36,12 +36,14 @@ fn header(model: &IndexModel) -> String {
 <style>{CSS}</style></head>
 <body><main>
 <h1>OVP Console <span class="zh">工作台</span></h1>
-<p class="sub">read model built {date}{run} · product state only · regenerate: <code>ovp2 console --vault-root …</code></p>
+<p class="sub">read model built {built}{run} · product state only · regenerate: <code>ovp2 console --vault-root …</code></p>
 <div class="strip">
 {queued}{processed}{failed}{blocked}{needs}{packs}{durable}{caveated}
 </div>
 "##,
-        date = esc(&model.date),
+        // Prefer the wall-clock instant so multiple runs the same day are
+        // distinguishable; fall back to the day string on pre-P1 indexes.
+        built = esc(model.built_at.as_deref().unwrap_or(&model.date)),
         run = model
             .run_id
             .as_deref()
@@ -331,6 +333,7 @@ mod tests {
         IndexModel {
             schema: "ovp.index/v1".into(),
             date: "2026-06-09".into(),
+            built_at: Some("2026-06-09T08:30:00Z".into()),
             run_id: Some("daily-2026-06-09".into()),
             totals: Totals { sources: 2, processed: 1, blocked: 1, packs: 1, claims_durable: 1, claims_caveated: 1, runs: 1, ..Default::default() },
             sources: vec![
@@ -431,6 +434,9 @@ mod tests {
         assert!(html.contains("opinion_as_fact"));
         // Runs table links the report file.
         assert!(html.contains(".ovp/reports/daily-2026-06-09.json"));
+        // P1: the header shows the wall-clock BUILD INSTANT, not the day
+        // string, so multiple runs the same day are distinguishable.
+        assert!(html.contains("read model built 2026-06-09T08:30:00Z"), "instant in header");
         // Deterministic.
         assert_eq!(html, render_console(&model()));
     }
@@ -440,6 +446,7 @@ mod tests {
         let empty = IndexModel {
             schema: "ovp.index/v1".into(),
             date: "2026-06-09".into(),
+            built_at: None,
             run_id: None,
             totals: Totals::default(),
             sources: vec![],
@@ -452,6 +459,8 @@ mod tests {
         assert!(html.contains("Nothing needs attention"));
         assert!(html.contains("No runs recorded yet"));
         assert!(html.contains("No crystal store yet"));
+        // Pre-P1 index (built_at None) → header falls back to the day string.
+        assert!(html.contains("read model built 2026-06-09 "), "fallback to date");
     }
 
     #[test]

--- a/crates/ovp-index/Cargo.toml
+++ b/crates/ovp-index/Cargo.toml
@@ -13,6 +13,8 @@ ovp-daily = { path = "../ovp-daily" }
 ovp-intake = { path = "../ovp-intake" }
 serde = { workspace = true }
 serde_json = { workspace = true }
+chrono = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+chrono = { workspace = true }

--- a/crates/ovp-index/src/build.rs
+++ b/crates/ovp-index/src/build.rs
@@ -27,11 +27,39 @@ use crate::model::{
     RunStats, SourceRow, SourceStatus, Totals,
 };
 
-/// Build the full read model. `date`/`run_id` only stamp the header.
+/// UTC wall-clock instant as RFC3339 — the `built_at` stamp. The one
+/// non-deterministic input to the index build; tests that need determinism
+/// stamp `date` and use [`build_index_at`] to inject a fixed instant instead.
+pub fn now_rfc3339() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let dur = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    chrono::DateTime::<chrono::Utc>::from(UNIX_EPOCH + dur)
+        .to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+/// Build the full read model. `date` stamps the deterministic day header;
+/// `run_id` names which run produced this projection, falling back to an
+/// `index-<built_at>` marker so the field is never silently `None`. `built_at`
+/// is stamped unconditionally with the wall-clock instant so a stale
+/// projection never renders identically to a fresh one.
 pub fn build_index(
     vault_root: &Path,
     date: &str,
     run_id: Option<&str>,
+) -> Result<IndexModel, String> {
+    build_index_at(vault_root, date, run_id, &now_rfc3339())
+}
+
+/// Testable core of [`build_index`] with an injected `built_at` instant so a
+/// test can assert the stamp deterministically. When `run_id` is `None`, the
+/// projection synthesizes `index-<built_at>` so it always names a producer.
+pub fn build_index_at(
+    vault_root: &Path,
+    date: &str,
+    run_id: Option<&str>,
+    built_at: &str,
 ) -> Result<IndexModel, String> {
     let layout = VaultLayout::new();
 
@@ -71,10 +99,18 @@ pub fn build_index(
 
     let ops = build_ops_state(&sources, &runs, date);
 
+    // Never silently None: an ad-hoc `index`/`console` build with no run to
+    // name still gets an `index-<built_at>` marker so every projection can be
+    // traced to the moment it was built.
+    let run_id = run_id
+        .map(String::from)
+        .unwrap_or_else(|| format!("index-{built_at}"));
+
     Ok(IndexModel {
         schema: INDEX_SCHEMA.into(),
         date: date.into(),
-        run_id: run_id.map(String::from),
+        built_at: Some(built_at.into()),
+        run_id: Some(run_id),
         totals,
         sources,
         packs,

--- a/crates/ovp-index/src/evidence.rs
+++ b/crates/ovp-index/src/evidence.rs
@@ -188,6 +188,7 @@ mod tests {
         IndexModel {
             schema: "ovp.index/v2".into(),
             date: "2026-07-06".into(),
+            built_at: None,
             run_id: None,
             totals: Totals::default(),
             sources: vec![],

--- a/crates/ovp-index/src/lib.rs
+++ b/crates/ovp-index/src/lib.rs
@@ -23,7 +23,9 @@ pub mod model;
 pub mod query;
 pub mod score;
 
-pub use build::{build_index, failed_reader_attempt, read_index, write_index};
+pub use build::{
+    build_index, build_index_at, failed_reader_attempt, now_rfc3339, read_index, write_index,
+};
 pub use evidence::{EvidenceModel, build_evidence, evidence_path, read_evidence, write_evidence};
 pub use model::{
     BlockedSource, ClaimRow, ClaimStatus, INDEX_SCHEMA, IndexModel, OpsState, PackRow, RunRow,

--- a/crates/ovp-index/src/model.rs
+++ b/crates/ovp-index/src/model.rs
@@ -168,6 +168,13 @@ pub struct IndexModel {
     pub schema: String,
     /// Date the model was built (caller-provided; keeps rebuilds deterministic).
     pub date: String,
+    /// Wall-clock build instant (UTC RFC3339). Unlike `date` (a day string,
+    /// deterministic on purpose) this is a true instant, so three runs on the
+    /// same day are distinguishable and a stale projection no longer renders
+    /// identically to a fresh one. Serde-additive: pre-P1 indexes deserialize
+    /// with `None` and every surface shows "unknown age".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub built_at: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub run_id: Option<String>,
     pub totals: Totals,

--- a/crates/ovp-index/tests/index_build.rs
+++ b/crates/ovp-index/tests/index_build.rs
@@ -9,7 +9,8 @@ use ovp_daily::{
     DAILY_SCHEMA, DailyRunRecord, RunReport, RunStatus as DailyStatus, append_daily_record,
 };
 use ovp_index::{
-    ClaimStatus, Query, QueryKind, SourceStatus, build_index, read_index, run_query, write_index,
+    ClaimStatus, Query, QueryKind, SourceStatus, build_index, build_index_at, read_index,
+    run_query, write_index,
 };
 use ovp_intake::{INTAKE_SCHEMA, IntakeAction, IntakeRecord, append_intake_record, hex_sha256};
 
@@ -535,20 +536,77 @@ fn persisted_index_is_deterministic_and_rebuildable() {
     let root = dir.path();
     build_fixture_vault(root);
 
-    let model = build_index(root, "2026-06-09", None).unwrap();
+    // `built_at` is the ONE non-deterministic field (wall-clock, P1): pin it
+    // via `build_index_at` so the "delete → rebuild → byte-identical" story
+    // still holds for everything else. In production the instant advances on
+    // every rebuild by design — that is what makes a stale projection
+    // distinguishable from a fresh one.
+    let model = build_index_at(root, "2026-06-09", None, "2026-06-09T00:00:00Z").unwrap();
     let rel = write_index(root, &model).unwrap();
     assert_eq!(rel, ".ovp/index/index.json");
     let first = std::fs::read_to_string(root.join(&rel)).unwrap();
 
     // The rebuild story: delete the projection, rebuild, byte-identical.
     std::fs::remove_file(root.join(&rel)).unwrap();
-    let model2 = build_index(root, "2026-06-09", None).unwrap();
+    let model2 = build_index_at(root, "2026-06-09", None, "2026-06-09T00:00:00Z").unwrap();
     write_index(root, &model2).unwrap();
     let second = std::fs::read_to_string(root.join(&rel)).unwrap();
     assert_eq!(first, second, "projection must be deterministic");
 
     let loaded = read_index(root).unwrap();
     assert_eq!(loaded, model2);
+}
+
+#[test]
+fn build_index_stamps_built_at_and_synthesizes_a_run_id() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    build_fixture_vault(root);
+
+    // No run to name (the ad-hoc `index` command path): built_at is stamped
+    // with the wall clock and run_id is never silently None — it falls back to
+    // the `index-<built_at>` marker.
+    let model = build_index(root, "2026-06-09", None).unwrap();
+    let built = model.built_at.expect("built_at stamped unconditionally");
+    assert!(
+        chrono::DateTime::parse_from_rfc3339(&built).is_ok(),
+        "built_at is RFC3339: {built}"
+    );
+    assert_eq!(
+        model.run_id.as_deref(),
+        Some(format!("index-{built}").as_str()),
+        "index path synthesizes an index-<built_at> marker",
+    );
+    // `date` stays the deterministic day header — unchanged by the stamp.
+    assert_eq!(model.date, "2026-06-09");
+}
+
+#[test]
+fn build_index_passes_through_a_caller_run_id() {
+    // The daily path supplies its own run id — build_index must keep it and
+    // still stamp built_at.
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    build_fixture_vault(root);
+
+    let model = build_index(root, "2026-06-09", Some("daily-2026-06-09")).unwrap();
+    assert_eq!(model.run_id.as_deref(), Some("daily-2026-06-09"));
+    assert!(model.built_at.is_some(), "built_at still stamped");
+}
+
+#[test]
+fn build_index_at_pins_built_at_for_deterministic_tests() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    build_fixture_vault(root);
+
+    let a = build_index_at(root, "2026-06-09", None, "2026-06-09T12:00:00Z").unwrap();
+    let b = build_index_at(root, "2026-06-09", None, "2026-06-09T12:00:00Z").unwrap();
+    assert_eq!(a, b, "same injected built_at → identical projection");
+    assert_eq!(a.built_at.as_deref(), Some("2026-06-09T12:00:00Z"));
+    // The console command's marker shape, verified end-to-end via the CLI in
+    // its own test; here we assert the synth rule for an injected instant.
+    assert_eq!(a.run_id.as_deref(), Some("index-2026-06-09T12:00:00Z"));
 }
 
 #[test]

--- a/crates/ovp-memory/src/ask.rs
+++ b/crates/ovp-memory/src/ask.rs
@@ -481,6 +481,7 @@ mod tests {
         IndexModel {
             schema: INDEX_SCHEMA.into(),
             date: "2026-07-06".into(),
+            built_at: None,
             run_id: None,
             totals: Totals::default(),
             sources: vec![],

--- a/crates/ovp-memory/src/working_memory.rs
+++ b/crates/ovp-memory/src/working_memory.rs
@@ -154,6 +154,7 @@ mod tests {
         IndexModel {
             schema: "ovp.index/v2".into(),
             date: "2026-06-15".into(),
+            built_at: None,
             run_id: None,
             totals: Totals::default(),
             sources: vec![],

--- a/crates/ovp-server/Cargo.toml
+++ b/crates/ovp-server/Cargo.toml
@@ -14,4 +14,5 @@ ovp-memory = { path = "../ovp-memory" }
 ovp-llm = { path = "../ovp-llm" }
 serde.workspace = true
 serde_json.workspace = true
+chrono = { workspace = true }
 tiny_http = "0.12"

--- a/crates/ovp-server/src/graph.rs
+++ b/crates/ovp-server/src/graph.rs
@@ -1701,6 +1701,7 @@ mod tests {
         IndexModel {
             schema: "ovp.index/v2".into(),
             date: "2026-07-09".into(),
+            built_at: None,
             run_id: None,
             totals: Totals::default(),
             sources: cases

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -470,7 +470,7 @@ fn handle_find(state: &AppState, url: &str) -> Response<std::io::Cursor<Vec<u8>>
 
     let hits = run_query(&model, &query);
     let body = serde_json::to_string(&hits).unwrap_or_else(|_| "[]".into());
-    json_response(200, &body)
+    json_stamped(200, &body, Some(&model))
 }
 
 fn handle_search(state: &AppState, url: &str) -> Response<std::io::Cursor<Vec<u8>>> {
@@ -483,11 +483,14 @@ fn handle_search(state: &AppState, url: &str) -> Response<std::io::Cursor<Vec<u8
         let Some(term) = term.filter(|t| !t.trim().is_empty()) else {
             return json_response(400, r#"{"error":"subgraph search requires q"}"#);
         };
-        let records = load_active_records(state);
+        // One model read for the whole handler: the subgraph is joined against
+        // the ledger records AND the index, so both halves must reflect the
+        // same freshness — the stamp pairs them.
         let model = state.current_model();
+        let records = load_active_records(state);
         let resp = graph::search_subgraph(&records, model.as_ref(), term.trim());
         let body = serde_json::to_string(&resp).unwrap_or_else(|_| "{}".into());
-        return json_response(200, &body);
+        return json_stamped(200, &body, model.as_ref());
     }
 
     let model = match state.current_model() {
@@ -502,17 +505,21 @@ fn handle_search(state: &AppState, url: &str) -> Response<std::io::Cursor<Vec<u8
     };
     let hits = run_query(&model, &query);
     let body = serde_json::to_string(&hits).unwrap_or_else(|_| "[]".into());
-    json_response(200, &body)
+    json_stamped(200, &body, Some(&model))
 }
 
 fn handle_themes(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
+    // Read the model ONCE up front so the theme counts (from the live ledger)
+    // ship with the projection stamp they were paired against — the client can
+    // see both halves came from the same freshness.
+    let model = state.current_model();
     let records = load_active_records(state);
     let themes: Vec<serde_json::Value> = graph::theme_counts(&records)
         .into_iter()
         .map(|(theme, count)| serde_json::json!({ "theme": theme, "count": count }))
         .collect();
     let body = serde_json::to_string(&themes).unwrap_or_else(|_| "[]".into());
-    json_response(200, &body)
+    json_stamped(200, &body, model.as_ref())
 }
 
 fn handle_model(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
@@ -520,8 +527,18 @@ fn handle_model(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
         Some(m) => m,
         None => return json_response(503, r#"{"error":"index not available"}"#),
     };
-    let body = serde_json::to_string(&model).unwrap_or_else(|_| "{}".into());
-    json_response(200, &body)
+    // The IndexModel already carries `built_at`/`run_id`; splice in the
+    // server-computed `age_seconds` (now - built_at) so the client need not
+    // trust its own clock, and echo the same three as headers.
+    let mut value = serde_json::to_value(&model).unwrap_or_else(|_| serde_json::json!({}));
+    if let Some(obj) = value.as_object_mut() {
+        obj.insert(
+            "age_seconds".into(),
+            serde_json::json!(age_seconds(model.built_at.as_deref())),
+        );
+    }
+    let body = serde_json::to_string(&value).unwrap_or_else(|_| "{}".into());
+    json_stamped(200, &body, Some(&model))
 }
 
 fn load_active_records(state: &AppState) -> Vec<DurableRecord> {
@@ -556,6 +573,11 @@ fn load_active_records(state: &AppState) -> Vec<DurableRecord> {
 fn handle_graph(state: &AppState, url: &str) -> Response<std::io::Cursor<Vec<u8>>> {
     let query = parse_query_string(url);
 
+    // Read the model ONCE for the whole handler (torn-read fix): every scope
+    // joins the live ledger records against this projection, so a single read
+    // pairs both halves at one freshness and the stamp reflects that pairing.
+    let model = state.current_model();
+
     // Portal v2 scoped-component API (design §4) — one KnowledgeGraph
     // component, three scopes:
     //   scope=neighborhood&source=<sha>  this source → citing claims →
@@ -576,7 +598,6 @@ fn handle_graph(state: &AppState, url: &str) -> Response<std::io::Cursor<Vec<u8>
                     );
                 };
                 let records = load_active_records(state);
-                let model = state.current_model();
                 // Evidence sidecar feeds the memory-layer card nodes (B5).
                 let evidence = state.current_evidence();
                 graph::source_neighborhood(&records, model.as_ref(), evidence.as_ref(), sha)
@@ -595,7 +616,6 @@ fn handle_graph(state: &AppState, url: &str) -> Response<std::io::Cursor<Vec<u8>
                     hops: graph::MAX_HOPS,
                 };
                 let records = load_active_records(state);
-                let model = state.current_model();
                 graph::build_graph(&records, model.as_ref(), &params)
             }
             "theme" => {
@@ -603,7 +623,6 @@ fn handle_graph(state: &AppState, url: &str) -> Response<std::io::Cursor<Vec<u8>
                     return json_response(400, r#"{"error":"scope=theme requires theme=<theme>"}"#);
                 };
                 let records = load_active_records(state);
-                let model = state.current_model();
                 graph::theme_subgraph(&records, model.as_ref(), theme)
             }
             other => {
@@ -616,7 +635,7 @@ fn handle_graph(state: &AppState, url: &str) -> Response<std::io::Cursor<Vec<u8>
         return match result {
             Ok(resp) => {
                 let body = serde_json::to_string(&resp).unwrap_or_else(|_| "{}".into());
-                json_response(200, &body)
+                json_stamped(200, &body, model.as_ref())
             }
             Err(e) => {
                 let body = serde_json::json!({ "error": e.message });
@@ -634,12 +653,11 @@ fn handle_graph(state: &AppState, url: &str) -> Response<std::io::Cursor<Vec<u8>
     };
 
     let records = load_active_records(state);
-    let model = state.current_model();
 
     match graph::build_graph(&records, model.as_ref(), &params) {
         Ok(resp) => {
             let body = serde_json::to_string(&resp).unwrap_or_else(|_| "{}".into());
-            json_response(200, &body)
+            json_stamped(200, &body, model.as_ref())
         }
         Err(e) => {
             let body = serde_json::json!({ "error": e.message });
@@ -655,6 +673,11 @@ fn handle_claim(state: &AppState, url: &str) -> Response<std::io::Cursor<Vec<u8>
         return json_response(400, r#"{"error":"missing claim id"}"#);
     }
 
+    // Read the model BEFORE the ledger records so a claim's citations resolve
+    // their source metadata against the SAME freshness the claim came from
+    // (torn-read fix): the auto-freshen keeps them paired, and the stamp on the
+    // response lets the client see the pairing.
+    let model = state.current_model();
     let records = load_active_records(state);
     let rec = records
         .iter()
@@ -664,7 +687,6 @@ fn handle_claim(state: &AppState, url: &str) -> Response<std::io::Cursor<Vec<u8>
         None => return json_response(404, r#"{"error":"claim not found"}"#),
     };
 
-    let model = state.current_model();
     let source_lookup: HashMap<String, &ovp_index::SourceRow> = model
         .as_ref()
         .map(|m| m.sources.iter().map(|s| (s.sha256.clone(), s)).collect())
@@ -731,7 +753,7 @@ fn handle_claim(state: &AppState, url: &str) -> Response<std::io::Cursor<Vec<u8>
         "strength": format!("{:?}", rec.strength).to_lowercase(),
         "citations": citations,
     });
-    json_response(200, &body.to_string())
+    json_stamped(200, &body.to_string(), model.as_ref())
 }
 
 /// GET /api/source/<sha256> — JSON for the portal's three-layer source
@@ -931,6 +953,13 @@ fn handle_settings(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
         "vault_root": state.vault_root.display().to_string(),
         "schema_version": model.as_ref().map(|m| m.schema.clone()),
         "index_date": model.as_ref().map(|m| m.date.clone()),
+        // Provenance stamp (P1): the wall-clock build instant, its run id, and
+        // the server-computed age. The System page shows "as of <built_at> ·
+        // N min ago" so `index_date` (a day string) can no longer stand in for
+        // freshness.
+        "built_at": model.as_ref().and_then(|m| m.built_at.clone()),
+        "run_id": model.as_ref().and_then(|m| m.run_id.clone()),
+        "age_seconds": model.as_ref().and_then(|m| age_seconds(m.built_at.as_deref())),
         "counts": model.as_ref().map(|m| serde_json::json!({
             "sources": m.totals.sources,
             "packs": m.totals.packs,
@@ -943,7 +972,7 @@ fn handle_settings(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
         },
         "version": env!("CARGO_PKG_VERSION"),
     });
-    json_response(200, &body.to_string())
+    json_stamped(200, &body.to_string(), model.as_ref())
 }
 
 /// The request headers `POST /api/ask` validates — the endpoint triggers
@@ -1455,6 +1484,46 @@ fn json_response(status: u16, body: &str) -> Response<std::io::Cursor<Vec<u8>>> 
         .with_status_code(status)
 }
 
+/// Seconds since an RFC3339 `built_at` instant, per the server's wall clock.
+/// `None` when the stamp is absent (pre-P1 index) or unparseable — the client
+/// then shows "unknown age" rather than a fabricated 0. Clamped at 0 so a
+/// slight clock skew never reports a negative age.
+fn age_seconds(built_at: Option<&str>) -> Option<i64> {
+    let built = chrono::DateTime::parse_from_rfc3339(built_at?).ok()?;
+    Some((chrono::Utc::now().timestamp() - built.timestamp()).max(0))
+}
+
+/// `json_response` plus provenance HEADERS (`X-OVP-Built-At`, `X-OVP-Run-Id`,
+/// `X-OVP-Age-Seconds`) — so array-bodied routes (`/api/find|search|graph|
+/// claim|themes`) still echo which build answered. Absent fields are omitted;
+/// the header set is the client's pairing signal that ledger reads and model
+/// reads in one handler came from the same freshness.
+fn json_stamped(
+    status: u16,
+    body: &str,
+    model: Option<&IndexModel>,
+) -> Response<std::io::Cursor<Vec<u8>>> {
+    let mut resp = json_response(status, body);
+    if let Some(m) = model {
+        if let Some(built) = m.built_at.as_deref()
+            && let Ok(h) = Header::from_bytes("X-OVP-Built-At", built.as_bytes())
+        {
+            resp.add_header(h);
+        }
+        if let Some(run) = m.run_id.as_deref()
+            && let Ok(h) = Header::from_bytes("X-OVP-Run-Id", run.as_bytes())
+        {
+            resp.add_header(h);
+        }
+        if let Some(age) = age_seconds(m.built_at.as_deref())
+            && let Ok(h) = Header::from_bytes("X-OVP-Age-Seconds", age.to_string().as_bytes())
+        {
+            resp.add_header(h);
+        }
+    }
+    resp
+}
+
 fn text_response(status: u16, body: &str) -> Response<std::io::Cursor<Vec<u8>>> {
     let data = body.as_bytes().to_vec();
     let header = Header::from_bytes("Content-Type", "text/plain; charset=utf-8").unwrap();
@@ -1756,7 +1825,11 @@ mod tests {
         let model = IndexModel {
             schema: "ovp.index/v2".into(),
             date: "2026-07-09".into(),
-            run_id: None,
+            // Provenance stamp present so the P1 echo tests have a value; the
+            // instant is fixed 1s in the past so `age_seconds` is a small,
+            // stable, non-negative number.
+            built_at: Some("2026-07-09T00:00:00Z".into()),
+            run_id: Some("daily-2026-07-09".into()),
             totals: Totals {
                 sources: 1,
                 processed: 1,
@@ -2149,6 +2222,10 @@ mod tests {
         );
         assert_eq!(v["schema_version"], "ovp.index/v2");
         assert_eq!(v["index_date"], "2026-07-09");
+        // P1 provenance: the instant, its producer, and a non-negative age.
+        assert_eq!(v["built_at"], "2026-07-09T00:00:00Z");
+        assert_eq!(v["run_id"], "daily-2026-07-09");
+        assert!(v["age_seconds"].as_i64().unwrap() >= 0, "age is present and non-negative");
         assert_eq!(v["counts"]["sources"], 1);
         assert_eq!(v["counts"]["packs"], 1);
         assert!(v["counts"]["claims"].is_u64());
@@ -2179,10 +2256,70 @@ mod tests {
         let v = body_json(resp);
         assert!(v["schema_version"].is_null());
         assert!(v["index_date"].is_null());
+        // No index → provenance is uniformly null (client shows "unknown age").
+        assert!(v["built_at"].is_null());
+        assert!(v["run_id"].is_null());
+        assert!(v["age_seconds"].is_null());
         assert!(v["counts"].is_null());
         assert_eq!(v["llm_configured"], false);
 
         let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Value of a response header, case-insensitive, or `None`.
+    fn header_of(resp: &Response<std::io::Cursor<Vec<u8>>>, name: &str) -> Option<String> {
+        resp.headers()
+            .iter()
+            .find(|h| h.field.as_str().as_str().eq_ignore_ascii_case(name))
+            .map(|h| h.value.as_str().to_string())
+    }
+
+    #[test]
+    fn model_endpoint_carries_built_at_run_id_and_age() {
+        let vault = portal_vault("model-provenance", "50-Inbox/03-Processed/good.md", "body\n");
+        let st = state(vault.clone(), None);
+
+        let resp = dispatch(&st, Method::Get, "/api/model", "");
+        assert_eq!(resp.status_code(), 200);
+        // Provenance headers pair the body with the build that produced it.
+        assert_eq!(header_of(&resp, "X-OVP-Built-At").as_deref(), Some("2026-07-09T00:00:00Z"));
+        assert_eq!(header_of(&resp, "X-OVP-Run-Id").as_deref(), Some("daily-2026-07-09"));
+        assert!(header_of(&resp, "X-OVP-Age-Seconds").is_some(), "age header present");
+
+        let v = body_json(resp);
+        assert_eq!(v["built_at"], "2026-07-09T00:00:00Z");
+        assert_eq!(v["run_id"], "daily-2026-07-09");
+        assert!(v["age_seconds"].as_i64().unwrap() >= 0, "server-computed age spliced in");
+
+        let _ = std::fs::remove_dir_all(vault.parent().unwrap());
+    }
+
+    #[test]
+    fn claim_endpoint_resolves_a_fresh_sources_metadata_without_a_dangling_citation() {
+        // Torn-read guard: a claim cites case `good`, whose pack links source
+        // `aaaa1111`, which is present in the freshly-loaded index. handle_claim
+        // reads the model ONCE (before the ledger) so the citation joins the
+        // SAME freshness — the source title/url/sha resolve, never a dangling
+        // citation. write_ledger's claim `a` cites case `good`, unit `u-001`.
+        let vault = portal_vault("claim-torn-read", "50-Inbox/03-Processed/good.md", "body\n");
+        write_ledger(&vault);
+        let st = state(vault.clone(), None);
+
+        let resp = dispatch(&st, Method::Get, "/api/claim/a", "");
+        assert_eq!(resp.status_code(), 200);
+        // Response is paired with the projection it resolved against.
+        assert_eq!(header_of(&resp, "X-OVP-Built-At").as_deref(), Some("2026-07-09T00:00:00Z"));
+        let v = body_json(resp);
+        assert_eq!(v["claim_id"], "a");
+        let cit = &v["citations"][0];
+        assert_eq!(cit["case_id"], "good");
+        // The fresh source's metadata resolved from the SAME-freshness index —
+        // NOT a dangling citation (case `good` → sha aaaa1111 via the pack).
+        assert_eq!(cit["source_sha256"], "aaaa1111", "source sha resolved from the index");
+        assert_eq!(cit["source_title"], "Good Article", "source title resolved");
+        assert_eq!(cit["source_url"], "https://example.com/good");
+
+        let _ = std::fs::remove_dir_all(vault.parent().unwrap());
     }
 
     #[test]
@@ -2751,6 +2888,7 @@ mod tests {
         IndexModel {
             schema: "ovp.index/v2".into(),
             date: date.into(),
+            built_at: Some(format!("{date}T00:00:00Z")),
             run_id: None,
             totals: Totals::default(),
             sources: vec![],


### PR DESCRIPTION
P1 of the observability remediation — kills the 'numbers lie' class (queued=211 impersonating fresh truth).

- **Projection provenance**: IndexModel carries built_at (UTC RFC3339 wall-clock) + run_id populated on ALL build paths (daily passes its id; index/console synthesize one). Serde-additive.
- **Server echoes freshness**: /api/model + /api/settings carry built_at/run_id/age_seconds; find/search/graph/claim/themes carry X-OVP-Built-At/Run-Id/Age-Seconds headers. Torn-read fix: graph/claim/search read current_model() ONCE per handler (claim before the ledger) so both halves share one freshness — test: claim citing a freshly-rebuilt source has no dangling citation.
- **Per-surface age labels**: ticking bilingual 'as of … N min ago' on Today/Library/Knowledge/System; Monitor's ● CONNECTED now shows model age (connected ≠ fresh).
- **SPA revalidation**: ModelProvider refetches on window-focus + 60s poll, keeping last-good on failure — a left-open tab converges to fresh without a manual reload.

Forward-merged main (P0): index exports unioned, derive tests split into two files. 903 workspace tests, clippy -D warnings, arch check, tsc+vite+vitest (21 tests). Codex gate on the pre-merge P1 was clean.