### PR TITLE
feat(obs P2): streaming progress in long loops + stuck-item aging + drain estimate

### DIFF
--- a/crates/ovp-auto/src/lib.rs
+++ b/crates/ovp-auto/src/lib.rs
@@ -105,9 +105,30 @@ impl AutoRun {
     /// a caller responsibility is what stops `ovp-auto` from duplicating the L4
     /// wiring; the sweep itself owns only discovery, the loop, lint, and the
     /// report.
-    pub fn sweep<F>(opts: &SweepOptions, mut make_inputs: F) -> Result<AutoReport, AutoError>
+    pub fn sweep<F>(opts: &SweepOptions, make_inputs: F) -> Result<AutoReport, AutoError>
     where
         F: FnMut(&Path) -> Result<RunCycleInputs, String>,
+    {
+        Self::sweep_with_progress(opts, make_inputs, |_, _, _| {})
+    }
+
+    /// [`sweep`](Self::sweep) with a per-file progress callback.
+    ///
+    /// `on_progress(i, total, label)` fires once per discovered input, in
+    /// discovery order, with a **1-based** index BEFORE that input runs — so a
+    /// watched auto-run streams `[i/total] <file>` and the last call reads
+    /// `[total/total]`. The sweep itself stays print-free (a leaf automation
+    /// crate); the CLI renders the flushed line. `total` counts every
+    /// discovered file, including the empty ones the loop then skips, so the
+    /// index sequence is contiguous.
+    pub fn sweep_with_progress<F, P>(
+        opts: &SweepOptions,
+        mut make_inputs: F,
+        mut on_progress: P,
+    ) -> Result<AutoReport, AutoError>
+    where
+        F: FnMut(&Path) -> Result<RunCycleInputs, String>,
+        P: FnMut(usize, usize, &str),
     {
         // Discover. Explicit existence check first so a typo'd inbox is loud
         // (a missing root otherwise walks to an empty list). Any I/O error while
@@ -123,12 +144,14 @@ impl AutoRun {
         })?;
 
         let cycle = RunCycle::new();
+        let total = files.len();
         let mut cycles = Vec::new();
         let mut skipped = Vec::new();
 
-        for (rel, content) in &files {
+        for (i, (rel, content)) in files.iter().enumerate() {
             let abs = opts.inbox_root.join(rel);
             let label = abs.display().to_string();
+            on_progress(i + 1, total, &label);
 
             if content.trim().is_empty() {
                 skipped.push(SkippedInput { input: label, reason: "empty markdown file".into() });
@@ -259,6 +282,39 @@ mod tests {
         assert!(!report.lint_passed, "corrupt canonical → lint error → gate fails");
         assert!(!report.succeeded(), "a failing lint gate fails the sweep");
         assert!(report.lint.findings.iter().any(|f| f.code == "canonical.unparseable"));
+    }
+
+    #[test]
+    fn progress_callback_fires_per_input_in_order() {
+        // Three discovered files → three callbacks with 1-based contiguous
+        // indices, all reporting the same total, in discovery order. Content is
+        // whitespace-only so no cycle runs (make_inputs stays unused) — the
+        // progress hook must still fire for every discovered file, including
+        // skipped ones.
+        let inbox = tempfile::tempdir().unwrap();
+        let vault = tempfile::tempdir().unwrap();
+        let canon = tempfile::tempdir().unwrap();
+        std::fs::write(inbox.path().join("a.md"), " ").unwrap();
+        std::fs::write(inbox.path().join("b.md"), " ").unwrap();
+        std::fs::write(inbox.path().join("c.md"), " ").unwrap();
+
+        let mut calls: Vec<(usize, usize, String)> = Vec::new();
+        let report = AutoRun::sweep_with_progress(
+            &opts(inbox.path(), vault.path(), canon.path(), Severity::Error),
+            unused_factory,
+            |i, total, label| calls.push((i, total, label.to_string())),
+        )
+        .unwrap();
+
+        assert_eq!(report.considered, 3);
+        assert_eq!(calls.len(), 3, "one callback per discovered file");
+        // 1-based, contiguous, constant total.
+        assert_eq!(calls.iter().map(|(i, _, _)| *i).collect::<Vec<_>>(), vec![1, 2, 3]);
+        assert!(calls.iter().all(|(_, t, _)| *t == 3), "total is constant");
+        // Order is discovery order (walk_markdown is sorted): a, b, c.
+        assert!(calls[0].2.ends_with("a.md"));
+        assert!(calls[1].2.ends_with("b.md"));
+        assert!(calls[2].2.ends_with("c.md"));
     }
 
     #[test]

--- a/crates/ovp-cli/src/commands/auto_run.rs
+++ b/crates/ovp-cli/src/commands/auto_run.rs
@@ -94,8 +94,13 @@ pub fn run(args: AutoRunArgs) -> Result<(), CliError> {
     // Per-file flushed progress: the sweep runs the full L4 cycle (LLM calls) on
     // each input and can take minutes per file, so stream `[i/total] <file>`
     // before each one — the sweep crate stays print-free (callback pattern).
+    // Progress goes to STDERR (never stdout) so `--json` keeps a clean,
+    // machine-parseable JSON document on stdout; also suppressed entirely in
+    // json mode to keep logs quiet for scripted callers.
     let mut on_progress = |i: usize, total: usize, label: &str| {
-        sayln!("  [{i}/{total}] {label}");
+        if !json {
+            sayln_err!("  [{i}/{total}] {label}");
+        }
     };
     let report = AutoRun::sweep_with_progress(&opts, make_inputs, &mut on_progress)
         .map_err(|e| CliError::Io(format!("auto-run: {e}")))?;

--- a/crates/ovp-cli/src/commands/auto_run.rs
+++ b/crates/ovp-cli/src/commands/auto_run.rs
@@ -91,8 +91,14 @@ pub fn run(args: AutoRunArgs) -> Result<(), CliError> {
     };
 
     let opts = SweepOptions { inbox_root, vault_root, canonical_root, lint_threshold };
-    let report =
-        AutoRun::sweep(&opts, make_inputs).map_err(|e| CliError::Io(format!("auto-run: {e}")))?;
+    // Per-file flushed progress: the sweep runs the full L4 cycle (LLM calls) on
+    // each input and can take minutes per file, so stream `[i/total] <file>`
+    // before each one — the sweep crate stays print-free (callback pattern).
+    let mut on_progress = |i: usize, total: usize, label: &str| {
+        sayln!("  [{i}/{total}] {label}");
+    };
+    let report = AutoRun::sweep_with_progress(&opts, make_inputs, &mut on_progress)
+        .map_err(|e| CliError::Io(format!("auto-run: {e}")))?;
 
     if json {
         let json = serde_json::to_string_pretty(&report)

--- a/crates/ovp-cli/src/commands/crystal_review_session.rs
+++ b/crates/ovp-cli/src/commands/crystal_review_session.rs
@@ -540,7 +540,19 @@ pub fn run_apply(args: CrystalReviewSessionApplyArgs) -> Result<(), CliError> {
     let mut client = build_client(args.client_kind, &cache_dir)?;
     let mut verdicts: Vec<ClaimStrengthVerdict> = Vec::new();
     let mut repairs: Vec<RepairLog> = Vec::new();
-    for chunk in revised.items.chunks(MAX_STRENGTH_CLAIMS_PER_CALL) {
+    // Each chunk is one live re-gate LLM call; stream a flushed heartbeat so a
+    // watched apply never looks hung.
+    let n_regate_chunks = revised
+        .items
+        .len()
+        .div_ceil(MAX_STRENGTH_CLAIMS_PER_CALL)
+        .max(1);
+    for (ci, chunk) in revised.items.chunks(MAX_STRENGTH_CLAIMS_PER_CALL).enumerate() {
+        sayln!(
+            "  [{}/{n_regate_chunks}] re-gating {} revision(s)",
+            ci + 1,
+            chunk.len()
+        );
         let sub = CrystalCandidate { items: chunk.to_vec() };
         let req = strength_request(&sub, &catalog);
         let (chunk_verdicts, log): (Vec<ClaimStrengthVerdict>, Option<RepairLog>) =

--- a/crates/ovp-cli/src/commands/crystal_synth.rs
+++ b/crates/ovp-cli/src/commands/crystal_synth.rs
@@ -426,8 +426,17 @@ pub(crate) fn run_stats(args: CrystalSynthArgs) -> Result<RunStats, CliError> {
             write_json(&args.work_dir.join("synth-batches.json"), &batches)?;
 
             // (c) Per-batch cross-source synthesis (model, cassette-replayable).
+            // Each batch is one live LLM call (minutes under load); stream a
+            // flushed heartbeat so a watched run never looks hung.
+            let n_batches = batches.len();
             let mut all_claims: Vec<CrystalClaim> = Vec::new();
-            for batch in &batches {
+            for (bi, batch) in batches.iter().enumerate() {
+                sayln!(
+                    "  [{}/{n_batches}] synthesizing cluster `{}` ({} case(s))",
+                    bi + 1,
+                    batch.claim_prefix(),
+                    batch.cases.len()
+                );
                 let req = crystal_synth_batch_request(&catalog, batch, args.max_units_per_case);
                 let (claims, log): (Vec<CrystalClaim>, Option<RepairLog>) =
                     call_and_parse(base.as_mut(), &req, "synth", |t| {
@@ -462,12 +471,22 @@ pub(crate) fn run_stats(args: CrystalSynthArgs) -> Result<RunStats, CliError> {
             }
 
             // (e) Chunked claim-strength verdicts (model, cassette-replayable).
+            let n_strength_chunks = grounded
+                .items
+                .len()
+                .div_ceil(MAX_STRENGTH_CLAIMS_PER_CALL)
+                .max(1);
             let mut verdicts: Vec<ClaimStrengthVerdict> = Vec::new();
             for (idx, chunk) in grounded
                 .items
                 .chunks(MAX_STRENGTH_CLAIMS_PER_CALL)
                 .enumerate()
             {
+                sayln!(
+                    "  [{}/{n_strength_chunks}] strength ({} claim(s))",
+                    idx + 1,
+                    chunk.len()
+                );
                 let req = strength_request(
                     &CrystalCandidate {
                         items: chunk.to_vec(),

--- a/crates/ovp-cli/src/commands/crystal_synth_ab.rs
+++ b/crates/ovp-cli/src/commands/crystal_synth_ab.rs
@@ -332,9 +332,12 @@ pub fn run_experiment(args: ExperimentArgs) -> Result<(), CliError> {
         embed_cache_dir: Some(embed_cache_dir.clone()),
     };
 
-    println!("\n=== arm A (batch) ===");
+    // Each arm is a full (possibly live) synth run — minutes to tens of
+    // minutes. Flush the arm banner so a watched experiment shows which arm is
+    // in flight; `run_stats` itself now streams per-batch/per-chunk progress.
+    sayln!("\n=== arm A (batch) — running ({} case slice) ===", slice.len());
     let a = run_stats(arm_args(ClusterMode::Batch, "arm-a"));
-    println!("\n=== arm B (llm) ===");
+    sayln!("\n=== arm B (llm) — running ({} case slice) ===", slice.len());
     let b = run_stats(arm_args(ClusterMode::Llm, "arm-b"));
 
     let reports = vec![

--- a/crates/ovp-cli/src/commands/crystal_themes.rs
+++ b/crates/ovp-cli/src/commands/crystal_themes.rs
@@ -237,11 +237,16 @@ fn embed_missing(docs: &[ThemeDoc], missing: &[usize]) -> Result<Option<Vec<Vec<
     };
     let texts: Vec<String> = missing.iter().map(|&i| docs[i].text.clone()).collect();
     let mut out = Vec::with_capacity(texts.len());
+    // Embedding is CPU-bound and the first cold run also downloads ~450MB —
+    // stream a flushed per-batch line so it never looks stalled. stderr is
+    // line-buffered and survives a kill under launchd.
+    let total = texts.len();
     for chunk in texts.chunks(64) {
         let batch = embedder
             .embed(chunk)
             .map_err(|e| CliError::Io(format!("crystal-themes: {e}")))?;
         out.extend(batch);
+        sayln_err!("  [{}/{total}] embedding …", out.len());
     }
     Ok(Some(out))
 }
@@ -393,9 +398,17 @@ pub fn run(args: CrystalThemesArgs) -> Result<(), CliError> {
     };
 
     // ---- Communities ----
+    // Louvain is deterministic and print-free (leaf crate); the CLI brackets
+    // the call with flushed coarse lines so the phase boundary is visible.
     let edges = knn_edges(&vectors, args.k, args.cosine_threshold);
+    sayln!(
+        "  clustering {} node(s) over {} kNN edge(s) …",
+        docs.len(),
+        edges.len()
+    );
     let labels = louvain_labels(docs.len(), &edges, args.resolution, args.seed);
     let n_communities = labels.iter().copied().max().map_or(0, |m| (m + 1).max(0)) as usize;
+    sayln!("  … {n_communities} community(ies)");
     let mut members: Vec<Vec<usize>> = vec![Vec::new(); n_communities];
     for (i, &l) in labels.iter().enumerate() {
         if l >= 0 {

--- a/crates/ovp-cli/src/commands/daily.rs
+++ b/crates/ovp-cli/src/commands/daily.rs
@@ -29,17 +29,12 @@ use ovp_intake::{sweep_intake, sync_pinboard, FixturePinboardFetch, IntakeConfig
 use crate::commands::client::{build_client, ClientKind};
 use crate::CliError;
 
-/// `println!` + explicit stdout flush. Daily runs are watched through nohup /
-/// pipes (block-buffered stdout) and the reader phase can run for hours; every
-/// phase header and per-source line must hit the log the moment it is printed —
-/// a healthy 46-minute run was once killed as "hung" because nothing showed.
-macro_rules! sayln {
-    ($($arg:tt)*) => {{
-        println!($($arg)*);
-        use std::io::Write as _;
-        let _ = std::io::stdout().flush();
-    }};
-}
+// `sayln!` (println + flush) now lives in `crate::progress` (shared across all
+// commands, re-exported crate-wide via `#[macro_export]`). Daily runs are
+// watched through nohup / pipes (block-buffered stdout) and the reader phase can
+// run for hours; every phase header and per-source line must hit the log the
+// moment it is printed — a healthy 46-minute run was once killed as "hung"
+// because nothing showed.
 
 pub struct DailyArgs {
     pub vault_root: PathBuf,
@@ -222,6 +217,20 @@ pub fn run(args: DailyArgs) -> Result<(), CliError> {
         "  plan: {} new source(s), {} skipped, {} blocked",
         work.todo.len(), work.skipped.len(), work.blocked.len()
     );
+    // Drain estimate — the operator is otherwise blind to how many runs the
+    // backlog needs to clear at the current cap. `daily` processes at most
+    // `--max-sources` per run, so ceil(queued / cap) runs remain (≈ that many
+    // days at the blessed 1 run/day). Only meaningful when the backlog exceeds
+    // one run's worth.
+    let queued = work.todo.len();
+    if let Some(runs) = drain_runs(queued, args.max_sources)
+        && runs > 1
+    {
+        sayln!(
+            "  drain: {queued} queued · --max-sources {} → ~{runs} run(s) (~{runs} day(s) at 1 run/day) to drain",
+            args.max_sources
+        );
+    }
     for item in &work.blocked {
         sayln!("    blocked ({} failures): {} — rerun with --retry-blocked after review",
             item.prior_failures, item.rel);
@@ -444,6 +453,19 @@ fn stale_theme_packs(
     Some(count)
 }
 
+/// Runs needed to drain `queued` sources at `cap` sources per run.
+///
+/// `ceil(queued / cap)`. Returns `None` when there is nothing to estimate —
+/// either `cap == 0` (no rate limit configured) or `queued == 0` (empty
+/// backlog). The caller only surfaces the line when the result is > 1 (a
+/// single-run backlog needs no drain story).
+fn drain_runs(queued: usize, cap: usize) -> Option<usize> {
+    if cap == 0 || queued == 0 {
+        return None;
+    }
+    Some(queued.div_ceil(cap))
+}
+
 fn build_pinboard_fetch(args: &DailyArgs) -> Result<Box<dyn PinboardFetch>, CliError> {
     if args.pinboard_live && args.pinboard_fixture.is_some() {
         return Err(CliError::Io("pass either --pinboard-fixture or --pinboard-live, not both".into()));
@@ -557,7 +579,27 @@ fn live_image_download() -> Result<Box<dyn ovp_enrich::image_download::ImageDown
 
 #[cfg(test)]
 mod tests {
-    use super::stale_theme_packs;
+    use super::{drain_runs, stale_theme_packs};
+
+    #[test]
+    fn drain_runs_is_ceiling_division() {
+        // Exact multiple → no partial run.
+        assert_eq!(drain_runs(16, 8), Some(2));
+        // Remainder rounds up (one extra run for the tail).
+        assert_eq!(drain_runs(17, 8), Some(3));
+        assert_eq!(drain_runs(1, 8), Some(1));
+        // Boundary: exactly one run's worth.
+        assert_eq!(drain_runs(8, 8), Some(1));
+    }
+
+    #[test]
+    fn drain_runs_none_when_nothing_to_estimate() {
+        // No rate limit configured.
+        assert_eq!(drain_runs(100, 0), None);
+        // Empty backlog.
+        assert_eq!(drain_runs(0, 8), None);
+        assert_eq!(drain_runs(0, 0), None);
+    }
 
     fn model_with_packs(dirs: &[&str]) -> ovp_index::IndexModel {
         ovp_index::IndexModel {

--- a/crates/ovp-cli/src/commands/index_cmd.rs
+++ b/crates/ovp-cli/src/commands/index_cmd.rs
@@ -6,8 +6,8 @@
 use std::path::PathBuf;
 
 use ovp_index::{
-    build_evidence, build_index, read_evidence, read_index, run_evidence_query, run_query,
-    write_evidence, write_index, Query, QueryKind,
+    build_evidence, build_index_with_progress, read_evidence, read_index, run_evidence_query,
+    run_query, write_evidence, write_index, Query, QueryKind,
 };
 
 use crate::CliError;
@@ -18,7 +18,11 @@ pub struct IndexArgs {
 }
 
 pub fn run_index(args: IndexArgs) -> Result<(), CliError> {
-    let model = build_index(&args.vault_root, &args.date, None).map_err(CliError::Io)?;
+    // Coarse phase lines (flushed) so a large-vault rebuild shows the
+    // scan/hash/fold boundaries instead of one silent pause under nohup.
+    let mut on_phase = |phase: &str| sayln!("  {phase}");
+    let model = build_index_with_progress(&args.vault_root, &args.date, None, &mut on_phase)
+        .map_err(CliError::Io)?;
     let rel = write_index(&args.vault_root, &model).map_err(CliError::Io)?;
     let evidence = build_evidence(&args.vault_root, &args.date, &model).map_err(CliError::Io)?;
     let evidence_rel = write_evidence(&args.vault_root, &evidence).map_err(CliError::Io)?;

--- a/crates/ovp-cli/src/main.rs
+++ b/crates/ovp-cli/src/main.rs
@@ -3,6 +3,8 @@ use std::process::ExitCode;
 
 use clap::{Parser, Subcommand};
 
+#[macro_use]
+mod progress;
 mod commands;
 
 #[derive(Debug)]

--- a/crates/ovp-cli/src/progress.rs
+++ b/crates/ovp-cli/src/progress.rs
@@ -1,0 +1,109 @@
+//! Flushed progress output for long-running CLI loops.
+//!
+//! Daily / crystal / index runs are watched through nohup, pipes, or launchd,
+//! where stdout is **block-buffered** — a `println!` inside a multi-minute
+//! per-item loop is invisible until the process exits (or its buffer fills).
+//! A healthy 46-minute run was once killed as "hung" because nothing showed.
+//!
+//! The fix is a write-then-flush say/sayln pair. These macros began life as a
+//! local macro in `daily.rs`; they now live here so every command (and the
+//! per-iteration streaming below) shares one blessed shape.
+//!
+//! stdout vs stderr: under launchd both are captured, but stderr is
+//! line-buffered and reaches the log sooner, so warnings / heartbeats that
+//! must survive a hard kill use the `*_err` variants.
+//!
+//! Leaf/domain crates must NOT print (see `check_architecture.sh` layering).
+//! When a long loop lives inside a library crate, thread a progress **callback**
+//! from the CLI — `run_daily_with_progress(on_source)` is the blessed shape —
+//! and let the CLI render the flushed `[i/total]` line via `sayln!` in the
+//! callback closure. `build_index_with_progress` and `AutoRun::sweep_with_progress`
+//! follow that pattern.
+
+use std::io::Write;
+
+/// `print!` + explicit stdout flush. No trailing newline (use for in-place
+/// status that a later [`sayln!`] completes).
+#[macro_export]
+macro_rules! say {
+    ($($arg:tt)*) => {{
+        print!($($arg)*);
+        let _ = std::io::Write::flush(&mut std::io::stdout());
+    }};
+}
+
+/// `println!` + explicit stdout flush. The workhorse for phase headers and
+/// per-item `[i/total] …` lines that must hit the log the moment they print.
+#[macro_export]
+macro_rules! sayln {
+    ($($arg:tt)*) => {{
+        println!($($arg)*);
+        let _ = std::io::Write::flush(&mut std::io::stdout());
+    }};
+}
+
+/// `eprint!` + explicit stderr flush. stderr is line-buffered under launchd, so
+/// this reaches the log soonest — use for heartbeats that must survive a kill.
+#[macro_export]
+macro_rules! say_err {
+    ($($arg:tt)*) => {{
+        eprint!($($arg)*);
+        let _ = std::io::Write::flush(&mut std::io::stderr());
+    }};
+}
+
+/// `eprintln!` + explicit stderr flush. For warnings and progress that must be
+/// visible even when stdout is buffered away by nohup/launchd.
+#[macro_export]
+macro_rules! sayln_err {
+    ($($arg:tt)*) => {{
+        eprintln!($($arg)*);
+        let _ = std::io::Write::flush(&mut std::io::stderr());
+    }};
+}
+
+/// Write `line` + newline to `w` and flush. This is the write-then-flush shape
+/// the say/sayln macros expand to, factored out so it can be unit-tested against
+/// an in-memory buffer (the macros themselves always target the real std
+/// streams and cannot be asserted directly). Exercised only by tests today.
+#[cfg_attr(not(test), allow(dead_code))]
+pub fn writeln_flushed<W: Write>(w: &mut W, line: &str) -> std::io::Result<()> {
+    writeln!(w, "{line}")?;
+    w.flush()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn writeln_flushed_writes_and_terminates() {
+        let mut buf: Vec<u8> = Vec::new();
+        writeln_flushed(&mut buf, "hello world").unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "hello world\n");
+    }
+
+    #[test]
+    fn writeln_flushed_flushes_a_tracking_writer() {
+        // A writer that records whether flush() was actually called — proves the
+        // helper does not merely buffer (the whole point under nohup/launchd).
+        struct Tracking {
+            bytes: Vec<u8>,
+            flushed: bool,
+        }
+        impl Write for Tracking {
+            fn write(&mut self, b: &[u8]) -> std::io::Result<usize> {
+                self.bytes.extend_from_slice(b);
+                Ok(b.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                self.flushed = true;
+                Ok(())
+            }
+        }
+        let mut w = Tracking { bytes: Vec::new(), flushed: false };
+        writeln_flushed(&mut w, "line").unwrap();
+        assert!(w.flushed, "writeln_flushed must flush the writer");
+        assert_eq!(String::from_utf8(w.bytes).unwrap(), "line\n");
+    }
+}

--- a/crates/ovp-console/src/ops.css
+++ b/crates/ovp-console/src/ops.css
@@ -25,4 +25,8 @@ tr:hover{background:rgba(79,195,247,.05)}
 code{font-size:.8rem;background:var(--card);padding:.1em .3em;border-radius:3px}
 .ok{color:var(--ok)}
 .bad{color:var(--bad)}
+p.warn{color:var(--warn);font-size:.85rem;margin-top:.3rem}
+.aging-ok{color:var(--ok)}
+.aging-amber{color:var(--warn);font-weight:600}
+.aging-red{color:var(--bad);font-weight:700}
 section{margin-bottom:2rem}

--- a/crates/ovp-console/src/ops.rs
+++ b/crates/ovp-console/src/ops.rs
@@ -2,7 +2,7 @@
 //! Pure HTML rendering from IndexModel (same as the main console — no JS,
 //! no runtime, rebuildable from index.json).
 
-use ovp_index::{ClaimStatus, IndexModel, SourceStatus};
+use ovp_index::{ClaimStatus, DAYS_STUCK_AMBER, DAYS_STUCK_RED, IndexModel, SourceStatus};
 
 use crate::{claim_status_label, source_status_label};
 
@@ -14,10 +14,23 @@ pub fn render_ops_page(model: &IndexModel) -> String {
     page.push_str(&health_section(model));
     page.push_str(&queue_section(model));
     page.push_str(&blocked_section(model));
+    page.push_str(&stuck_section(model));
     page.push_str(&recent_failures_section(model));
     page.push_str(&run_stats_section(model));
     page.push_str("</main></body></html>\n");
     page
+}
+
+/// Aging label + CSS class for a `days_stuck` value: fresh / amber (warn) /
+/// red (chronic). Returns `("", "")` when the age is unknown — the render then
+/// shows a neutral dash rather than a misleading "0d".
+fn aging(days: Option<usize>) -> (String, &'static str) {
+    match days {
+        None => (String::new(), ""),
+        Some(d) if d >= DAYS_STUCK_RED => (format!("{d}d"), "aging-red"),
+        Some(d) if d >= DAYS_STUCK_AMBER => (format!("{d}d"), "aging-amber"),
+        Some(d) => (format!("{d}d"), "aging-ok"),
+    }
 }
 
 pub fn render_audit_page(model: &IndexModel) -> String {
@@ -79,11 +92,21 @@ fn health_section(model: &IndexModel) -> String {
 
 fn queue_section(model: &IndexModel) -> String {
     let depth = model.ops.queue_depth;
+    let capped = model.ops.capped;
+    // "Backlog not draining" note: a capped last run with a non-empty queue is
+    // the visible signal the operator was blind to.
+    let capped_note = if capped > 0 {
+        format!(
+            r#"<p class="warn">last run capped {capped} source(s) — backlog not draining at the current --max-sources</p>"#
+        )
+    } else {
+        String::new()
+    };
     format!(
         r#"<section><h2>Queue <span class="zh">待处理队列</span></h2>
 <div class="metric">{depth}</div>
 <p>sources waiting for reader processing</p>
-</section>
+{capped_note}</section>
 "#,
     )
 }
@@ -95,15 +118,45 @@ fn blocked_section(model: &IndexModel) -> String {
         .into();
     }
     let mut out = String::from(
-        "<section><h2>Blocked <span class=\"zh\">阻塞来源</span></h2>\n<table><thead><tr><th>Source</th><th>Fails</th><th>Last Reason</th><th>Last Attempt</th></tr></thead><tbody>\n",
+        "<section><h2>Blocked <span class=\"zh\">阻塞来源</span></h2>\n<table><thead><tr><th>Source</th><th>Fails</th><th>Stuck</th><th>Last Reason</th><th>Last Attempt</th></tr></thead><tbody>\n",
     );
     for b in &model.ops.blocked_sources {
+        let (age_label, age_class) = aging(b.days_stuck);
+        let age_cell = if age_label.is_empty() {
+            "<td>—</td>".to_string()
+        } else {
+            format!("<td class=\"{age_class}\">{age_label}</td>")
+        };
         out.push_str(&format!(
-            "<tr><td>{title}</td><td>{fails}</td><td>{reason}</td><td>{date}</td></tr>\n",
+            "<tr><td>{title}</td><td>{fails}</td>{age_cell}<td>{reason}</td><td>{date}</td></tr>\n",
             title = esc(b.title.as_deref().unwrap_or(&b.sha256[..8])),
             fails = b.fail_count,
             reason = esc(b.last_reason.as_deref().unwrap_or("—")),
             date = esc(b.last_attempt.as_deref().unwrap_or("—")),
+        ));
+    }
+    out.push_str("</tbody></table></section>\n");
+    out
+}
+
+fn stuck_section(model: &IndexModel) -> String {
+    if model.ops.stuck_sources.is_empty() {
+        return String::new();
+    }
+    let mut out = String::from(
+        "<section><h2>Needs Content <span class=\"zh\">待补内容</span></h2>\n<table><thead><tr><th>Source</th><th>Stuck</th><th>First Seen</th></tr></thead><tbody>\n",
+    );
+    for s in &model.ops.stuck_sources {
+        let (age_label, age_class) = aging(s.days_stuck);
+        let age_cell = if age_label.is_empty() {
+            "<td>—</td>".to_string()
+        } else {
+            format!("<td class=\"{age_class}\">{age_label}</td>")
+        };
+        out.push_str(&format!(
+            "<tr><td>{title}</td>{age_cell}<td>{seen}</td></tr>\n",
+            title = esc(s.title.as_deref().unwrap_or(&s.sha256[..8])),
+            seen = esc(s.first_seen.as_deref().unwrap_or("—")),
         ));
     }
     out.push_str("</tbody></table></section>\n");

--- a/crates/ovp-console/src/ops.rs
+++ b/crates/ovp-console/src/ops.rs
@@ -95,7 +95,7 @@ fn queue_section(model: &IndexModel) -> String {
     let capped = model.ops.capped;
     // "Backlog not draining" note: a capped last run with a non-empty queue is
     // the visible signal the operator was blind to.
-    let capped_note = if capped > 0 {
+    let capped_note = if capped > 0 && depth > 0 {
         format!(
             r#"<p class="warn">last run capped {capped} source(s) — backlog not draining at the current --max-sources</p>"#
         )

--- a/crates/ovp-index/src/build.rs
+++ b/crates/ovp-index/src/build.rs
@@ -24,7 +24,7 @@ use serde::Deserialize;
 
 use crate::model::{
     BlockedSource, ClaimRow, ClaimStatus, INDEX_SCHEMA, IndexModel, OpsState, PackRow, RunRow,
-    RunStats, SourceRow, SourceStatus, Totals,
+    RunStats, SourceRow, SourceStatus, StuckSource, Totals,
 };
 
 /// Build the full read model. `date`/`run_id` only stamp the header.
@@ -32,6 +32,20 @@ pub fn build_index(
     vault_root: &Path,
     date: &str,
     run_id: Option<&str>,
+) -> Result<IndexModel, String> {
+    build_index_with_progress(vault_root, date, run_id, &mut |_| {})
+}
+
+/// [`build_index`] with a coarse phase callback. The projection is print-free
+/// (this is a domain crate); the CLI passes a callback that renders a flushed
+/// `"<phase> (N …)"` line per phase so `ovp2 index` on a large vault shows the
+/// scan/hash/backfill boundaries instead of one silent pause. Callbacks fire
+/// AFTER each phase completes, carrying its count for the operator.
+pub fn build_index_with_progress(
+    vault_root: &Path,
+    date: &str,
+    run_id: Option<&str>,
+    on_phase: &mut dyn FnMut(&str),
 ) -> Result<IndexModel, String> {
     let layout = VaultLayout::new();
 
@@ -41,12 +55,16 @@ pub fn build_index(
     let reports = read_reports(vault_root, &layout)?;
     let runs = runs_from_reports(vault_root, &reports);
     let moved = moved_map(&reports);
+    on_phase(&format!("read {} run report(s)", reports.len()));
 
     let mut sources = build_sources(vault_root, &layout, &moved)?;
+    on_phase(&format!("scanned {} source(s)", sources.len()));
     let mut packs = build_packs(vault_root, &layout, &sources)?;
     backfill_corpus_packs(vault_root, &layout, &mut sources, &mut packs)?;
+    on_phase(&format!("hashed {} pack(s)", packs.len()));
     enrich_titles_from_packs(&mut sources, &packs);
     let claims = build_claims(vault_root, &layout)?;
+    on_phase(&format!("folded {} claim(s)", claims.len()));
 
     let totals = Totals {
         sources: sources.len(),
@@ -69,7 +87,7 @@ pub fn build_index(
         runs: runs.len(),
     };
 
-    let ops = build_ops_state(&sources, &runs, date);
+    let ops = build_ops_state(&sources, &runs, &reports, date);
 
     Ok(IndexModel {
         schema: INDEX_SCHEMA.into(),
@@ -794,8 +812,13 @@ fn walk(dir: &Path, out: &mut Vec<std::path::PathBuf>) -> Result<(), String> {
     Ok(())
 }
 
-fn build_ops_state(sources: &[SourceRow], runs: &[RunRow], today: &str) -> OpsState {
-    let blocked_sources: Vec<BlockedSource> = sources
+fn build_ops_state(
+    sources: &[SourceRow],
+    runs: &[RunRow],
+    reports: &[(String, RunReport)],
+    today: &str,
+) -> OpsState {
+    let mut blocked_sources: Vec<BlockedSource> = sources
         .iter()
         .filter(|s| s.status == SourceStatus::Blocked)
         .map(|s| BlockedSource {
@@ -804,21 +827,67 @@ fn build_ops_state(sources: &[SourceRow], runs: &[RunRow], today: &str) -> OpsSt
             fail_count: s.fail_count,
             last_reason: s.last_reason.clone(),
             last_attempt: s.date.clone(),
+            // Aging: whole days since the last attempt. Chronic blocks (large
+            // days_stuck) are what the console/portal escalate amber→red.
+            days_stuck: s.date.as_deref().and_then(|d| days_between(d, today)),
         })
         .collect();
+    // Most-stuck first so the render escalates the worst offenders at the top.
+    blocked_sources.sort_by(|a, b| b.days_stuck.cmp(&a.days_stuck));
+
+    let mut stuck_sources: Vec<StuckSource> = sources
+        .iter()
+        .filter(|s| s.status == SourceStatus::NeedsContent)
+        .map(|s| StuckSource {
+            sha256: s.sha256.clone(),
+            title: s.title.clone(),
+            first_seen: s.date.clone(),
+            days_stuck: s.date.as_deref().and_then(|d| days_between(d, today)),
+        })
+        .collect();
+    stuck_sources.sort_by(|a, b| b.days_stuck.cmp(&a.days_stuck));
 
     let queue_depth = sources
         .iter()
         .filter(|s| s.status == SourceStatus::Queued)
         .count();
 
+    // "Backlog not draining" signal: the most recent run's capped count. Reports
+    // are sorted ascending by (date, seq) in read_reports, so the last is newest.
+    let capped = reports
+        .last()
+        .map(|(_, r)| r.reader.capped)
+        .unwrap_or(0);
+
     let run_stats = compute_run_stats(runs, today);
 
     OpsState {
         blocked_sources,
+        stuck_sources,
         queue_depth,
+        capped,
         run_stats,
     }
+}
+
+/// Whole days from `from` to `to` (both YYYY-MM-DD). `None` on unparseable
+/// input; `Some(0)` when equal or `to` precedes `from` (aging never goes
+/// negative). The build date is `to`; the source's last activity is `from`.
+fn days_between(from: &str, to: &str) -> Option<usize> {
+    let parse = |s: &str| -> Option<u32> {
+        let p: Vec<&str> = s.split('-').collect();
+        if p.len() != 3 {
+            return None;
+        }
+        match (p[0].parse::<i32>(), p[1].parse::<u32>(), p[2].parse::<u32>()) {
+            (Ok(y), Ok(m), Ok(d)) if (1..=12).contains(&m) && (1..=31).contains(&d) => {
+                Some(to_days(y, m, d))
+            }
+            _ => None,
+        }
+    };
+    let (a, b) = (parse(from)?, parse(to)?);
+    Some(b.saturating_sub(a) as usize)
 }
 
 fn compute_run_stats(runs: &[RunRow], today: &str) -> Option<RunStats> {
@@ -941,6 +1010,62 @@ fn is_leap(y: u32) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn days_between_counts_whole_days() {
+        assert_eq!(days_between("2026-07-01", "2026-07-08"), Some(7));
+        // Same day → 0 (a source attempted today is not "stuck").
+        assert_eq!(days_between("2026-07-08", "2026-07-08"), Some(0));
+        // Across a month boundary (June has 30 days).
+        assert_eq!(days_between("2026-06-28", "2026-07-02"), Some(4));
+        // Across a leap-year Feb (2024-02-29 exists).
+        assert_eq!(days_between("2024-02-27", "2024-03-01"), Some(3));
+    }
+
+    #[test]
+    fn days_between_never_negative_and_none_on_garbage() {
+        // `to` precedes `from` → clamped to 0, never underflows.
+        assert_eq!(days_between("2026-07-08", "2026-07-01"), Some(0));
+        // Unparseable inputs.
+        assert_eq!(days_between("not-a-date", "2026-07-08"), None);
+        assert_eq!(days_between("2026-07-08", ""), None);
+        assert_eq!(days_between("2026-13-01", "2026-07-08"), None);
+    }
+
+    #[test]
+    fn ops_state_ages_blocked_and_needs_content() {
+        let src = |sha: &str, status: SourceStatus, date: &str| SourceRow {
+            sha256: sha.into(),
+            status,
+            title: Some(format!("t-{sha}")),
+            url: None,
+            rel_path: None,
+            date: Some(date.into()),
+            last_run_id: None,
+            pack_dir: None,
+            fail_count: 3,
+            last_reason: Some("boom".into()),
+        };
+        let sources = vec![
+            src("aaaa", SourceStatus::Blocked, "2026-06-30"), // 8 days stuck
+            src("bbbb", SourceStatus::Blocked, "2026-07-06"), // 2 days stuck
+            src("cccc", SourceStatus::NeedsContent, "2026-07-01"), // 7 days
+            src("dddd", SourceStatus::Queued, "2026-07-08"),  // queue only
+        ];
+        let ops = build_ops_state(&sources, &[], &[], "2026-07-08");
+
+        assert_eq!(ops.queue_depth, 1);
+        // Blocked: aged, most-stuck first.
+        assert_eq!(ops.blocked_sources.len(), 2);
+        assert_eq!(ops.blocked_sources[0].sha256, "aaaa");
+        assert_eq!(ops.blocked_sources[0].days_stuck, Some(8));
+        assert_eq!(ops.blocked_sources[1].days_stuck, Some(2));
+        assert!(ops.blocked_sources[0].days_stuck >= Some(crate::model::DAYS_STUCK_RED));
+        // Needs-content aged separately.
+        assert_eq!(ops.stuck_sources.len(), 1);
+        assert_eq!(ops.stuck_sources[0].sha256, "cccc");
+        assert_eq!(ops.stuck_sources[0].days_stuck, Some(7));
+    }
 
     #[test]
     fn corpus_hash8_matches_only_the_legacy_prefix_shape() {

--- a/crates/ovp-index/src/lib.rs
+++ b/crates/ovp-index/src/lib.rs
@@ -23,11 +23,13 @@ pub mod model;
 pub mod query;
 pub mod score;
 
-pub use build::{build_index, failed_reader_attempt, read_index, write_index};
+pub use build::{
+    build_index, build_index_with_progress, failed_reader_attempt, read_index, write_index,
+};
 pub use evidence::{EvidenceModel, build_evidence, evidence_path, read_evidence, write_evidence};
 pub use model::{
-    BlockedSource, ClaimRow, ClaimStatus, INDEX_SCHEMA, IndexModel, OpsState, PackRow, RunRow,
-    RunStats, SourceRow, SourceStatus, Totals,
+    BlockedSource, ClaimRow, ClaimStatus, DAYS_STUCK_AMBER, DAYS_STUCK_RED, INDEX_SCHEMA,
+    IndexModel, OpsState, PackRow, RunRow, RunStats, SourceRow, SourceStatus, StuckSource, Totals,
 };
 pub use query::{
     Hit, Query, QueryKind, claim_status_str, run_evidence_query, run_query, source_status_str,

--- a/crates/ovp-index/src/model.rs
+++ b/crates/ovp-index/src/model.rs
@@ -144,7 +144,36 @@ pub struct BlockedSource {
     pub last_reason: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_attempt: Option<String>,
+    /// Whole days since `last_attempt` (build date − last_attempt). `None` when
+    /// the date is unknown/unparseable. The aging signal the console/portal use
+    /// to escalate chronic blocks visually (amber, then red past a threshold).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub days_stuck: Option<usize>,
 }
+
+/// A source stuck outside the reader trunk because it lacks fetchable content
+/// (a bare bookmark / needs-content flag that enrichment has not resolved).
+/// Distinct from `BlockedSource` (which is 3-strikes reader failure): a stuck
+/// source never entered the reader loop. Carries the same `days_stuck` aging
+/// so "needs content 12d" can escalate the same way.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct StuckSource {
+    pub sha256: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    /// First time this source was seen queued/flagged (the ledger date).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub first_seen: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub days_stuck: Option<usize>,
+}
+
+/// Days-stuck thresholds for visual escalation. A field, not a render — the
+/// portal/console decide the colors, but the amber→red boundary lives here so
+/// every surface agrees. `< AMBER` = fresh, `[AMBER, RED)` = amber (warn),
+/// `>= RED` = red (chronic).
+pub const DAYS_STUCK_AMBER: usize = 3;
+pub const DAYS_STUCK_RED: usize = 7;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RunStats {
@@ -159,7 +188,16 @@ pub struct RunStats {
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct OpsState {
     pub blocked_sources: Vec<BlockedSource>,
+    /// Needs-content sources aging in place (bare bookmarks enrichment has not
+    /// resolved). Ordered most-stuck first.
+    #[serde(default)]
+    pub stuck_sources: Vec<StuckSource>,
     pub queue_depth: usize,
+    /// Sources the most recent run left unprocessed because `--max-sources`
+    /// capped it. Non-zero with a non-empty queue = the backlog is not draining
+    /// — the "why is nothing moving" signal the operator was otherwise blind to.
+    #[serde(default)]
+    pub capped: usize,
     pub run_stats: Option<RunStats>,
 }
 


### PR DESCRIPTION
P2 of the observability remediation — no long operation is a silent black box anymore.

- **Shared progress helper**: sayln!/say!/sayln_err!/say_err! (flush) promoted out of daily.rs into a crate-wide progress module. stderr variants are line-buffered/live under launchd.
- **Streamed [i/total] per iteration** in every long LLM/embed/scan loop: crystal-synth batch+strength, crystal-synth-ab arms, crystal-themes embedding + Louvain start/end, index rebuild phases (build_index_with_progress callback — leaf crate stays print-free), crystal-review-session re-gate, auto-run sweep (progress → stderr, suppressed under --json so the JSON contract holds).
- **Drain estimate**: daily's plan phase prints 'N queued · --max-sources M → ~ceil(N/M) run(s) (~D days) to drain' — the math the operator was blind to.
- **Aging signal**: BlockedSource.days_stuck + StuckSource list for needs-content, OpsState.capped; the console renders amber→red for chronic stuck items and a 'backlog not draining' note (requires a nonempty queue).

Forward-merged P0+P1: composed the two build_index wrappers into one core (stamps built_at AND fires phase callbacks) with three thin wrappers, so P1's determinism test, P2's index progress, and P0's heartbeat all survive. 911 workspace tests, clippy -D warnings, arch check, tsc+vite+vitest (21). Codex gate: 2 findings fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live progress reporting for auto-runs, indexing, synthesis, reviews, embeddings, and clustering.
  * JSON output remains clean while progress is shown separately.
  * Added Ops dashboard visibility for aging blocked sources and items needing content.
  * Added warnings when capped runs leave backlog growth unresolved.
* **Bug Fixes**
  * Improved progress accuracy, including empty files and batched operations.
  * Added reliable, immediately flushed command-line status messages.
* **Style**
  * Added clearer warning and aging status indicators to the Ops dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->