### PR TITLE
feat(obs): live per-source activity feed in the portal + periodic count refresh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1507,6 +1507,7 @@ dependencies = [
 name = "ovp-index"
 version = "2.0.1"
 dependencies = [
+ "chrono",
  "ovp-daily",
  "ovp-domain",
  "ovp-intake",
@@ -1640,6 +1641,7 @@ dependencies = [
 name = "ovp-server"
 version = "2.0.1"
 dependencies = [
+ "chrono",
  "ovp-daily",
  "ovp-domain",
  "ovp-index",

--- a/console-ui/src/components/RunActivity.tsx
+++ b/console-ui/src/components/RunActivity.tsx
@@ -1,0 +1,126 @@
+/** Run activity — the portal's tail -f. Renders the live per-source feed from
+ * the heartbeat `recent[]` ring plus the running fraction/percent bar and the
+ * current source. Shown on the System page and expandable from the top
+ * RunBanner. It reads the shared /api/model state (already polled every ~12s
+ * while a run is `running`), so the feed refreshes at seconds-latency WITHOUT a
+ * separate endpoint — the per-source heartbeat write is the mechanism, not the
+ * coarse projection rebuild.
+ *
+ * On an idle/finished vault it shows the LAST run's feed until the next run, so
+ * a completed/failed/aborted run's final outcomes stay diagnosable. */
+import { useI18n, type MsgKey } from '../i18n';
+import { runActivity } from '../lib/derive';
+import type { RecentSource } from '../lib/types';
+import { useModel } from '../model';
+import { useNowTick } from './RunBanner';
+
+function FeedRow({ item }: { item: RecentSource }) {
+  const { t } = useI18n();
+  const ok = item.status === 'ok';
+  const label = ok
+    ? t('activity.ok', { title: item.title, units: item.units, cards: item.cards })
+    : item.reason
+      ? t('activity.failed', { title: item.title, reason: item.reason })
+      : t('activity.failedNoReason', { title: item.title });
+  return (
+    <li className={`run-activity-row ${ok ? 'ok' : 'failed'}`}>
+      <span className="run-activity-mark" aria-hidden="true">
+        {ok ? '✓' : '✗'}
+      </span>
+      <span className="run-activity-label">{label}</span>
+    </li>
+  );
+}
+
+/** The panel body. `useNowTick` keeps the "started {ago}" string honest while
+ * running without depending on a model refetch. */
+export default function RunActivity() {
+  const { t } = useI18n();
+  const { model } = useModel();
+  useNowTick(); // re-render so relative labels stay fresh
+  const act = runActivity(model);
+
+  // Nothing to show at all (fresh vault, no heartbeat).
+  if (act.status === null) return null;
+
+  const startedAgo = (() => {
+    const started = model?.ops?.last_run?.started_at;
+    if (!started) return '';
+    const mins = Math.max(0, Math.floor((Date.now() - Date.parse(started)) / 60000));
+    if (Number.isNaN(mins)) return '';
+    if (mins < 1) return t('banner.agoJustNow');
+    if (mins < 60) return t('banner.agoMinutes', { n: mins });
+    if (mins < 60 * 24) return t('banner.agoHours', { n: Math.floor(mins / 60) });
+    return t('banner.agoDays', { n: Math.floor(mins / (60 * 24)) });
+  })();
+
+  return (
+    <div className="run-activity">
+      {act.running ? (
+        <>
+          <div className="run-activity-head">
+            {act.processedSoFar != null && act.totalPlanned != null ? (
+              <span className="run-activity-fraction">
+                {t('activity.running', {
+                  done: act.processedSoFar,
+                  total: act.totalPlanned,
+                  pct: act.pct ?? 0,
+                  ago: startedAgo,
+                })}
+              </span>
+            ) : (
+              <span className="run-activity-fraction">{t('banner.running', { ago: startedAgo })}</span>
+            )}
+          </div>
+          {act.pct != null && (
+            <div
+              className="run-activity-bar"
+              role="progressbar"
+              aria-valuenow={act.pct}
+              aria-valuemin={0}
+              aria-valuemax={100}
+            >
+              <div className="run-activity-bar-fill" style={{ width: `${act.pct}%` }} />
+            </div>
+          )}
+          {act.current && (
+            <p className="run-activity-current sm muted">
+              {t('activity.current', { current: act.current })}
+            </p>
+          )}
+        </>
+      ) : (
+        <p className="sm muted run-activity-idle">
+          {act.status === 'completed' || act.status === 'failed' || act.status === 'aborted'
+            ? t('activity.finished', { ok: act.processed ?? 0, failed: act.failed ?? 0 })
+            : t('activity.idle')}
+          {act.error && ` — ${act.error}`}
+        </p>
+      )}
+
+      {act.recent.length === 0 ? (
+        <p className="sm muted">{t('activity.empty')}</p>
+      ) : (
+        <ul className="run-activity-feed">
+          {act.recent.map((item) => (
+            <FeedRow item={item} key={`${item.seq}-${item.at}`} />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+/** Section wrapper for the System page (a titled panel). */
+export function RunActivitySection() {
+  const { t } = useI18n();
+  const { model } = useModel();
+  // Hide the whole section only when there is genuinely no run to show.
+  if (runActivity(model).status === null) return null;
+  return (
+    <div className="section">
+      <h2>{t('activity.title' as MsgKey)}</h2>
+      <RunActivity />
+    </div>
+  );
+}

--- a/console-ui/src/components/RunBanner.tsx
+++ b/console-ui/src/components/RunBanner.tsx
@@ -12,8 +12,9 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useI18n } from '../i18n';
-import { isRunningWithProgress, lastRunBanner, type BannerLevel } from '../lib/derive';
+import { isRunningWithProgress, lastRunBanner, runActivity, type BannerLevel } from '../lib/derive';
 import { useModel } from '../model';
+import RunActivity from './RunActivity';
 
 /** Re-render tick so the age string advances. A minute is granular enough for
  * a wall-clock banner; the interval is cleared on unmount. */
@@ -39,8 +40,12 @@ export default function RunBanner() {
   const { model } = useModel();
   const navigate = useNavigate();
   const now = useNowTick();
+  const [expanded, setExpanded] = useState(false);
 
   const banner = lastRunBanner(model, now);
+  // The activity feed is worth expanding when there IS a run to show (a live
+  // run, or a just-finished one whose feed is still on the heartbeat).
+  const hasActivity = runActivity(model).status !== null;
 
   const ago = (): string => {
     const m = banner.ageMinutes;
@@ -102,29 +107,51 @@ export default function RunBanner() {
   const level = LEVEL_CLASS[banner.level];
 
   return (
-    <button
-      type="button"
-      className={`run-banner ${level}`}
-      onClick={() => navigate('/system')}
-      title={t('banner.viewSystem')}
-      aria-label={text}
-    >
-      <span className="run-banner-dot" />
-      <span className="run-banner-text">{text}</span>
-      {withProgress && (
-        <span
-          className="run-banner-progress"
-          role="progressbar"
-          aria-valuenow={progressPct}
-          aria-valuemin={0}
-          aria-valuemax={100}
+    <div className={`run-banner-wrap ${level}`}>
+      <div className="run-banner-bar">
+        <button
+          type="button"
+          className={`run-banner ${level}`}
+          onClick={() => navigate('/system')}
+          title={t('banner.viewSystem')}
+          aria-label={text}
         >
-          <span
-            className="run-banner-progress-fill"
-            style={{ width: `${progressPct}%` }}
-          />
-        </span>
+          <span className="run-banner-dot" />
+          <span className="run-banner-text">{text}</span>
+          {withProgress && (
+            <span
+              className="run-banner-progress"
+              role="progressbar"
+              aria-valuenow={progressPct}
+              aria-valuemin={0}
+              aria-valuemax={100}
+            >
+              <span
+                className="run-banner-progress-fill"
+                style={{ width: `${progressPct}%` }}
+              />
+            </span>
+          )}
+        </button>
+        {/* Expand the live per-source activity feed inline, without leaving the
+            current page — the operator's tail -f, one click away everywhere. */}
+        {hasActivity && (
+          <button
+            type="button"
+            className="run-banner-activity-toggle"
+            aria-expanded={expanded}
+            onClick={() => setExpanded((v) => !v)}
+            title={t('banner.activityToggle')}
+          >
+            {t('banner.activityToggle')} {expanded ? '▾' : '▸'}
+          </button>
+        )}
+      </div>
+      {expanded && hasActivity && (
+        <div className="run-banner-activity">
+          <RunActivity />
+        </div>
       )}
-    </button>
+    </div>
   );
 }

--- a/console-ui/src/design/portal.css
+++ b/console-ui/src/design/portal.css
@@ -165,27 +165,64 @@ body {
 }
 
 /* ---------- run-liveness banner: fixed top strip, every page ---------- */
-.run-banner {
+/* The sticky wrapper carries the top strip; the bar row holds the main
+   navigate-button plus the activity expand toggle, and the expandable feed
+   drops below it. */
+.run-banner-wrap {
   position: sticky;
   top: 0;
   z-index: 50;
   width: 100%;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+}
+.run-banner-bar {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+}
+.run-banner {
+  flex: 1 1 auto;
+  min-width: 0;
   display: flex;
   align-items: center;
   gap: 0.55rem;
   padding: 0.4rem 1.5rem;
   border: 0;
-  border-bottom: 1px solid var(--border);
   font-family: var(--ovp-font-mono);
   font-size: var(--ovp-text-xs);
   font-weight: 600;
   cursor: pointer;
   text-align: left;
-  background: var(--surface);
+  background: transparent;
   color: var(--muted);
   transition:
     background 200ms,
     color 200ms;
+}
+.run-banner-activity-toggle {
+  flex: 0 0 auto;
+  border: 0;
+  border-left: 1px solid var(--border);
+  background: transparent;
+  color: var(--muted);
+  font-family: var(--ovp-font-mono);
+  font-size: var(--ovp-text-xs);
+  font-weight: 600;
+  padding: 0.4rem 0.9rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.run-banner-activity-toggle:hover {
+  filter: brightness(0.98);
+  color: var(--fg);
+}
+.run-banner-activity {
+  max-height: 42vh;
+  overflow-y: auto;
+  padding: 0.5rem 1.5rem 0.75rem;
+  border-top: 1px solid var(--border);
+  background: var(--surface);
 }
 .run-banner:hover {
   filter: brightness(0.98);
@@ -239,6 +276,71 @@ body {
   border-radius: var(--ovp-radius-pill);
   background: currentColor;
   transition: width 0.4s ease;
+}
+
+/* ---------- run activity feed (the portal's tail -f) ---------- */
+.run-activity-head {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  font-family: var(--ovp-font-mono);
+  font-size: var(--ovp-text-sm);
+  font-weight: 600;
+}
+.run-activity-bar {
+  margin: 0.4rem 0;
+  width: 100%;
+  height: 6px;
+  border-radius: var(--ovp-radius-pill);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+  overflow: hidden;
+}
+.run-activity-bar-fill {
+  height: 100%;
+  border-radius: var(--ovp-radius-pill);
+  background: var(--accent);
+  transition: width 0.4s ease;
+}
+.run-activity-current {
+  margin: 0.15rem 0 0.4rem;
+}
+.run-activity-idle {
+  margin: 0 0 0.4rem;
+}
+.run-activity-feed {
+  list-style: none;
+  margin: 0.25rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.run-activity-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  padding: 0.2rem 0.35rem;
+  font-family: var(--ovp-font-mono);
+  font-size: var(--ovp-text-xs);
+  border-radius: var(--ovp-radius-sm, 4px);
+}
+.run-activity-row.failed {
+  background: color-mix(in srgb, var(--c-1, crimson) 8%, transparent);
+}
+.run-activity-mark {
+  flex: 0 0 auto;
+  font-weight: 700;
+}
+.run-activity-row.ok .run-activity-mark {
+  color: var(--c-3, green);
+}
+.run-activity-row.failed .run-activity-mark {
+  color: var(--c-1, crimson);
+}
+.run-activity-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* ---------- toggles (theme + language): text buttons in a pill ---------- */

--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -30,6 +30,18 @@ export const en = {
   'banner.agoHours': '{n}h ago',
   'banner.agoDays': '{n}d ago',
   'banner.viewSystem': 'View system status',
+  'banner.activityToggle': 'activity',
+
+  // live run activity feed (the portal's tail -f)
+  'activity.title': 'Run activity',
+  'activity.running': 'Run in progress · {done}/{total} · {pct}% · started {ago}',
+  'activity.current': 'Now: {current}',
+  'activity.idle': 'No run in progress. Showing the last run’s activity.',
+  'activity.empty': 'No per-source activity yet — the feed appears once the run starts processing sources.',
+  'activity.ok': '{title} — {units} units · {cards} cards',
+  'activity.failed': '{title} — {reason}',
+  'activity.failedNoReason': '{title} — failed',
+  'activity.finished': 'Finished: {ok} read · {failed} failed',
 
   // shared
   'common.loading': 'Loading…',

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -30,6 +30,18 @@ export const zh: Record<keyof typeof en, string> = {
   'banner.agoHours': '{n} 小时前',
   'banner.agoDays': '{n} 天前',
   'banner.viewSystem': '查看系统状态',
+  'banner.activityToggle': '活动',
+
+  // live run activity feed (the portal's tail -f)
+  'activity.title': '运行活动',
+  'activity.running': '运行中 · {done}/{total} · {pct}% · {ago}开始',
+  'activity.current': '当前：{current}',
+  'activity.idle': '当前没有运行。显示上一次运行的活动。',
+  'activity.empty': '暂无逐条活动 — 运行开始处理来源后即会显示。',
+  'activity.ok': '{title} — {units} 单元 · {cards} 卡片',
+  'activity.failed': '{title} — {reason}',
+  'activity.failedNoReason': '{title} — 失败',
+  'activity.finished': '已完成：{ok} 已读 · {failed} 失败',
 
   // shared
   'common.loading': '加载中…',

--- a/console-ui/src/lib/derive.test.ts
+++ b/console-ui/src/lib/derive.test.ts
@@ -5,9 +5,10 @@ import {
   healthLevel,
   isRunningWithProgress,
   lastRunBanner,
+  runActivity,
   STALE_AFTER_MS,
 } from './derive';
-import type { IndexModel, LastRunModel } from './types';
+import type { IndexModel, LastRunModel, RecentSource } from './types';
 
 const NOW = Date.parse('2026-07-12T12:00:00Z');
 
@@ -216,5 +217,72 @@ describe('healthLevel reconciliation', () => {
       status: 'completed',
     });
     expect(healthLevel(m, NOW)).toBe('ok');
+  });
+});
+
+describe('runActivity (live per-source feed)', () => {
+  const rec = (seq: number, status: 'ok' | 'failed'): RecentSource => ({
+    seq,
+    title: `Source ${seq}`,
+    status,
+    units: status === 'ok' ? 10 + seq : 0,
+    cards: status === 'ok' ? seq : 0,
+    reason: status === 'failed' ? 'no cassette' : undefined,
+    at: '2026-07-12T11:59:00Z',
+  });
+
+  it('returns the empty idle shape for a null model — panel never crashes', () => {
+    const a = runActivity(null);
+    expect(a.status).toBeNull();
+    expect(a.running).toBe(false);
+    expect(a.recent).toEqual([]);
+  });
+
+  it('exposes the running fraction + percent and the feed NEWEST FIRST', () => {
+    const m = model({
+      run_id: 'r',
+      started_at: '2026-07-12T11:50:00Z',
+      status: 'running',
+      processed_so_far: 3,
+      total_planned: 4,
+      current: 'Source 3',
+      recent: [rec(1, 'ok'), rec(2, 'failed'), rec(3, 'ok')],
+    });
+    const a = runActivity(m);
+    expect(a.running).toBe(true);
+    expect(a.processedSoFar).toBe(3);
+    expect(a.totalPlanned).toBe(4);
+    expect(a.pct).toBe(75);
+    expect(a.current).toBe('Source 3');
+    // Newest first: seq 3 leads, seq 1 trails.
+    expect(a.recent.map((r) => r.seq)).toEqual([3, 2, 1]);
+    // Both success AND failure surface.
+    expect(a.recent.find((r) => r.status === 'failed')?.reason).toBe('no cassette');
+  });
+
+  it('keeps a finished run’s feed + terminal counts for post-run diagnosis', () => {
+    const m = model({
+      run_id: 'r',
+      started_at: '2026-07-12T11:50:00Z',
+      ended_at: '2026-07-12T11:58:00Z',
+      status: 'completed',
+      processed: 8,
+      failed: 1,
+      recent: [rec(1, 'ok')],
+    });
+    const a = runActivity(m);
+    expect(a.running).toBe(false);
+    expect(a.processed).toBe(8);
+    expect(a.failed).toBe(1);
+    expect(a.recent).toHaveLength(1);
+  });
+
+  it('null pct when the heartbeat carries no fraction yet', () => {
+    const m = model({
+      run_id: 'r',
+      started_at: '2026-07-12T11:50:00Z',
+      status: 'running',
+    });
+    expect(runActivity(m).pct).toBeNull();
   });
 });

--- a/console-ui/src/lib/derive.ts
+++ b/console-ui/src/lib/derive.ts
@@ -6,6 +6,7 @@ import type {
   IndexModel,
   LastRunModel,
   PackRow,
+  RecentSource,
   RunRow,
   SourceRow,
 } from './types';
@@ -111,6 +112,69 @@ export function isRunningWithProgress(banner: LastRunBanner): boolean {
     banner.totalPlanned != null &&
     banner.totalPlanned > 0
   );
+}
+
+/** The live per-source activity feed — the portal's tail -f. Derived from the
+ * heartbeat `recent[]` ring plus the running fraction, so the "Run activity"
+ * panel (System page + expandable from the banner) can render:
+ *   - a fraction + percent bar while running,
+ *   - the current source,
+ *   - the last ~20 ✓/✗ per-source outcomes, NEWEST FIRST (so the freshest line
+ *     is at the top of the feed).
+ * Tolerates a null model / absent heartbeat (returns the empty idle shape) so
+ * the panel never crashes on a fresh vault. */
+export interface RunActivity {
+  status: LastRunModel['status'] | null;
+  running: boolean;
+  processedSoFar: number | null;
+  totalPlanned: number | null;
+  /** 0-100, null when there is no fraction to compute. */
+  pct: number | null;
+  current: string | null;
+  /** Terminal counts (present once the run finished). */
+  processed: number | null;
+  failed: number | null;
+  error: string | null;
+  /** Last ~20 outcomes, NEWEST FIRST. */
+  recent: RecentSource[];
+}
+
+export function runActivity(model: IndexModel | null): RunActivity {
+  const lr = model?.ops?.last_run ?? null;
+  if (!lr) {
+    return {
+      status: null,
+      running: false,
+      processedSoFar: null,
+      totalPlanned: null,
+      pct: null,
+      current: null,
+      processed: null,
+      failed: null,
+      error: null,
+      recent: [],
+    };
+  }
+  const processedSoFar = lr.processed_so_far ?? null;
+  const totalPlanned = lr.total_planned ?? null;
+  const pct =
+    processedSoFar != null && totalPlanned != null && totalPlanned > 0
+      ? Math.min(100, Math.round((processedSoFar / totalPlanned) * 100))
+      : null;
+  // Newest first for the feed; the ring is stored oldest→newest.
+  const recent = lr.recent ? [...lr.recent].reverse() : [];
+  return {
+    status: lr.status,
+    running: lr.status === 'running',
+    processedSoFar,
+    totalPlanned,
+    pct,
+    current: lr.current ?? null,
+    processed: lr.processed ?? null,
+    failed: lr.failed ?? null,
+    error: lr.error ?? null,
+    recent,
+  };
 }
 
 // ---------------------------------------------------------------- status dot

--- a/console-ui/src/lib/types.ts
+++ b/console-ui/src/lib/types.ts
@@ -302,7 +302,28 @@ export interface LastRunModel {
   total_planned?: number;
   /** LIVE in-run progress: the source just finished (title or rel path). */
   current?: string;
+  /** LIVE per-source activity ring (the portal's tail -f): the last ~20 source
+   * outcomes, oldest→newest, while `running`. Empty on terminal records. The
+   * "Run activity" panel renders the ✓/✗ feed from it. */
+  recent?: RecentSource[];
   error?: string;
+}
+
+/** One per-source outcome in the live activity feed — mirrors the heartbeat
+ * `recent[]`. Both success and failure appear so a run that starts failing is
+ * diagnosable from the portal without SSHing in to tail the log. */
+export interface RecentSource {
+  /** Monotonic 1-based sequence within the run. */
+  seq: number;
+  /** The source that finished (its vault-relative path / title). */
+  title: string;
+  status: 'ok' | 'failed';
+  units: number;
+  cards: number;
+  /** Failure reason (present only on `failed`). */
+  reason?: string;
+  /** UTC RFC3339 instant the source finished. */
+  at: string;
 }
 
 export interface OpsState {

--- a/console-ui/src/pages/LibraryPage.tsx
+++ b/console-ui/src/pages/LibraryPage.tsx
@@ -44,15 +44,13 @@ function LibraryBody({ model }: { model: IndexModel }) {
   const months = [...byMonth.keys()].filter((m) => m !== '').sort().reverse();
   const byStatus = countBy(model.sources, (s: SourceRow) => s.status as string);
 
-  // The QUEUED facet shows the LIVE 01-Raw backlog (server-spliced
-  // `queued_live`) — the authoritative-now figure that ticks down during a run —
-  // matching Monitor/System. Every other status stays projection-derived; only
-  // the queued pill needs between-refresh precision. Falls back to the
-  // projection count on a pre-overlay server (queued_live absent).
-  const statusCount = (s: string): number =>
-    s === 'queued' && model.queued_live != null
-      ? model.queued_live
-      : (byStatus.get(s) ?? 0);
+  // Facet counts are projection-derived so a pill count ALWAYS equals the
+  // number of rows selecting it renders (codex review P2): showing a live
+  // queued number here would disagree with filterSources over the same
+  // projection rows mid-run. The live 01-Raw backlog is surfaced as a
+  // standalone stat on Monitor/System and the run banner; the periodic
+  // mid-run projection refresh keeps these facet counts from going stale.
+  const statusCount = (s: string): number => byStatus.get(s) ?? 0;
 
   const filtered = filterSources(model.sources, {
     collection: collection && COLLECTIONS.includes(collection) ? collection : null,

--- a/console-ui/src/pages/LibraryPage.tsx
+++ b/console-ui/src/pages/LibraryPage.tsx
@@ -44,6 +44,16 @@ function LibraryBody({ model }: { model: IndexModel }) {
   const months = [...byMonth.keys()].filter((m) => m !== '').sort().reverse();
   const byStatus = countBy(model.sources, (s: SourceRow) => s.status as string);
 
+  // The QUEUED facet shows the LIVE 01-Raw backlog (server-spliced
+  // `queued_live`) — the authoritative-now figure that ticks down during a run —
+  // matching Monitor/System. Every other status stays projection-derived; only
+  // the queued pill needs between-refresh precision. Falls back to the
+  // projection count on a pre-overlay server (queued_live absent).
+  const statusCount = (s: string): number =>
+    s === 'queued' && model.queued_live != null
+      ? model.queued_live
+      : (byStatus.get(s) ?? 0);
+
   const filtered = filterSources(model.sources, {
     collection: collection && COLLECTIONS.includes(collection) ? collection : null,
     month,
@@ -118,7 +128,7 @@ function LibraryBody({ model }: { model: IndexModel }) {
               className={status === s ? 'active' : ''}
               onClick={() => setParam('status', status === s ? null : s)}
             >
-              {t(`sourceStatus.${s}` as MsgKey)} ({byStatus.get(s) ?? 0})
+              {t(`sourceStatus.${s}` as MsgKey)} ({statusCount(s)})
             </button>
           ))}
         </div>

--- a/console-ui/src/pages/SystemPage.tsx
+++ b/console-ui/src/pages/SystemPage.tsx
@@ -10,6 +10,7 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import AttentionCard from '../components/AttentionCard';
+import { RunActivitySection } from '../components/RunActivity';
 import { AgeLabel, EmptyState, ModelGate, PageHelp } from '../components/ui';
 import { useI18n } from '../i18n';
 import { fetchSettings } from '../lib/api';
@@ -281,6 +282,10 @@ export default function SystemPage() {
       <ModelGate loading={loading} error={error}>
         {model && (
           <>
+            {/* Live per-source activity feed (the portal's tail -f) sits at the
+                TOP of System: it's what the operator opens the page for while a
+                run is in flight. */}
+            <RunActivitySection />
             <RunsSection model={model} />
             <AttentionSection model={model} />
           </>

--- a/crates/ovp-cli/src/commands/daily.rs
+++ b/crates/ovp-cli/src/commands/daily.rs
@@ -16,10 +16,12 @@ use std::path::PathBuf;
 use ovp_console::{write_console, write_ops_pages};
 use ovp_daily::{
     plan_daily, read_daily_ledger, run_daily_with_progress, succeeded_hashes, DailyConfig,
-    DailyRunRecord, RunReport, RunStatus,
+    DailyRunRecord, RecentSource, RunReport, RunStatus, RECENT_RING_CAP,
 };
 use ovp_domain::VaultLayout;
-use ovp_index::{build_evidence, build_index, write_evidence, write_index};
+use ovp_index::{
+    build_evidence, build_index, build_index_with_progress, write_evidence, write_index,
+};
 use ovp_enrich::github::{
     enrich_github_repos, parse_github_repo_url, FixtureGitHubFetch, GitHubFetch,
 };
@@ -47,6 +49,11 @@ pub struct DailyArgs {
     pub run_id: String,
     pub dry_run: bool,
     pub max_sources: usize,
+    /// Rebuild the read-model projection (index/evidence/console) every N
+    /// processed sources DURING the run so the portal refreshes mid-run.
+    /// 0 = rebuild only at the end (old behavior). Debounced so a burst of
+    /// fast sources cannot thrash the rebuild.
+    pub refresh_every: usize,
     pub no_intake: bool,
     pub pinboard_fixture: Option<PathBuf>,
     pub pinboard_live: bool,
@@ -332,6 +339,21 @@ fn run_inner(
     // rewrites the heartbeat sidecar (`processed_so_far / total_planned ·
     // current`) so the portal banner ticks live instead of freezing at start.
     let mut processed_so_far = 0usize;
+    // Periodic mid-run projection refresh state. `refresh_every == 0` disables
+    // it entirely (rebuild only at the end — the old behavior). `last_refresh`
+    // debounces: the first eligible tick always fires; later ticks within
+    // `REFRESH_DEBOUNCE_SECS` of the previous rebuild are skipped so a burst of
+    // fast sources cannot thrash the ~10-30s rebuild.
+    let refresh_every = args.refresh_every;
+    let refresh_vault = args.vault_root.clone();
+    let refresh_date = args.date.clone();
+    let refresh_run_id = args.run_id.clone();
+    let mut last_refresh: Option<std::time::Instant> = None;
+    // The PORTAL'S TAIL -F: a bounded ring of the last `RECENT_RING_CAP` source
+    // outcomes, rewritten into the heartbeat sidecar per source. The operator
+    // watches this in the portal (seconds-latency) instead of `tail -f`-ing the
+    // log — success AND failure per source, with units/cards or the reason.
+    let mut recent_ring: Vec<RecentSource> = Vec::with_capacity(RECENT_RING_CAP);
     let mut on_source = |rec: &DailyRunRecord| {
         match rec.status {
             RunStatus::Succeeded => sayln!(
@@ -352,10 +374,58 @@ fn run_inner(
         // the run), naming the source just finished. A write failure is a warn,
         // never a run-abort — the reader work already succeeded.
         processed_so_far += 1;
+        // Push this source's outcome onto the live ring (bounded to the last
+        // RECENT_RING_CAP, oldest dropped) so the portal feed shows recent
+        // movement. Failures carry their reason; both statuses appear.
+        recent_ring.push(RecentSource {
+            seq: processed_so_far,
+            title: rec.source_path.clone(),
+            status: match rec.status {
+                RunStatus::Succeeded => "ok".into(),
+                RunStatus::Failed => "failed".into(),
+            },
+            units: rec.units,
+            cards: rec.cards,
+            reason: rec.reason.clone(),
+            at: ovp_daily::heartbeat::now_rfc3339_utc(),
+        });
+        if recent_ring.len() > RECENT_RING_CAP {
+            let overflow = recent_ring.len() - RECENT_RING_CAP;
+            recent_ring.drain(0..overflow);
+        }
         if let Some(hb) = heartbeat
-            && let Some(w) = hb.progress(processed_so_far, total_planned, Some(&rec.source_path))
+            && let Some(w) =
+                hb.progress(processed_so_far, total_planned, Some(&rec.source_path), &recent_ring)
         {
             sayln!("  warn {w}");
+        }
+        // Periodic projection refresh (SECONDARY — keeps the portal COUNTS
+        // fresh; the live per-source feed above is the real-time surface). Every
+        // Nth source, rebuild index/evidence/console from the ledgers-so-far so
+        // the Library facets, counts, and "as of" age go fresh MID-run instead
+        // of showing the pre-run projection for the whole run. Debounced so a
+        // burst of fast sources cannot thrash the ~10-30s rebuild. The
+        // end-of-run full rebuild below stays the final authoritative one.
+        let elapsed = last_refresh.map(|t| t.elapsed().as_secs());
+        match refresh_decision(refresh_every, processed_so_far, elapsed) {
+            RefreshDecision::Skip => {}
+            RefreshDecision::Debounced => sayln!(
+                "  refresh: skipped (debounced, <{}s since last)",
+                REFRESH_DEBOUNCE_SECS
+            ),
+            RefreshDecision::Rebuild => {
+                sayln!("  refresh: rebuilding projection at {processed_so_far} source(s)…");
+                match rebuild_projection(&refresh_vault, &refresh_date, &refresh_run_id) {
+                    Ok(()) => {
+                        last_refresh = Some(std::time::Instant::now());
+                        sayln!("  refresh: portal projection updated");
+                    }
+                    // A projection refresh is best-effort: log (flushed) and keep
+                    // running. The run's real work is done; a stale projection for
+                    // one more source is never worth aborting a multi-hour run.
+                    Err(e) => sayln!("  warn refresh failed (continuing): {e}"),
+                }
+            }
         }
     };
     let daily = run_daily_with_progress(&cfg, &work, &mut make_client, &mut on_source)
@@ -511,6 +581,70 @@ fn run_inner(
         msg.push(')');
         return Err(CliError::Gate(msg));
     }
+    Ok(())
+}
+
+/// Debounce window for the periodic mid-run projection refresh. A rebuild that
+/// would fire less than this many seconds after the previous one is skipped, so
+/// a burst of fast/small sources (each tripping the every-N counter) cannot
+/// thrash the ~10-30s rebuild. Chosen at 20s: comfortably shorter than a single
+/// reader source (minutes) so a normal cadence is never suppressed, long enough
+/// that a flurry of trivially-cheap sources collapses to one rebuild.
+const REFRESH_DEBOUNCE_SECS: u64 = 20;
+
+/// What to do with the periodic projection refresh after a source finishes.
+#[derive(Debug, PartialEq, Eq)]
+enum RefreshDecision {
+    /// Not an Nth source (or refreshing is disabled) — do nothing.
+    Skip,
+    /// An Nth source, but the previous rebuild was too recent — skip (debounce).
+    Debounced,
+    /// Rebuild the projection now.
+    Rebuild,
+}
+
+/// Decide whether the periodic projection refresh fires after `processed`
+/// sources. Pure/testable: `every == 0` disables it (rebuild only at the end —
+/// the old behavior); otherwise every Nth source is a candidate, and
+/// `elapsed_since_last` (seconds since the previous rebuild, `None` = never)
+/// debounces a candidate that would fire within [`REFRESH_DEBOUNCE_SECS`].
+fn refresh_decision(every: usize, processed: usize, elapsed_since_last: Option<u64>) -> RefreshDecision {
+    if every == 0 || processed == 0 || !processed.is_multiple_of(every) {
+        return RefreshDecision::Skip;
+    }
+    match elapsed_since_last {
+        Some(secs) if secs < REFRESH_DEBOUNCE_SECS => RefreshDecision::Debounced,
+        _ => RefreshDecision::Rebuild,
+    }
+}
+
+/// Rebuild ONLY the read-model projection artifacts (index.json, evidence.json,
+/// console, ops pages) from the ledgers-so-far and write them atomically. This
+/// is the exact write triple the end-of-run path uses, factored out so the
+/// PERIODIC mid-run refresh reuses it verbatim — no duplicated build logic.
+///
+/// It is a pure projection write: every artifact is fully rebuildable from the
+/// durable ledgers, and each writer already renames a temp over its target, so a
+/// crash mid-rebuild leaves the previous complete projection in place. Callers
+/// treat a failure as non-fatal (a warning), because a stale projection for one
+/// more source is never worth aborting a multi-hour run over.
+///
+/// Uses the progress variant of `build_index` so a mid-run rebuild is not silent
+/// on a large vault (it walks ~1000+ packs); the phase lines are prefixed so they
+/// are visibly the periodic refresh, not the terminal one.
+fn rebuild_projection(
+    vault_root: &std::path::Path,
+    date: &str,
+    run_id: &str,
+) -> Result<(), CliError> {
+    let mut on_phase = |line: &str| sayln!("    refresh: {line}");
+    let model = build_index_with_progress(vault_root, date, Some(run_id), &mut on_phase)
+        .map_err(CliError::Io)?;
+    write_index(vault_root, &model).map_err(CliError::Io)?;
+    let evidence = build_evidence(vault_root, date, &model).map_err(CliError::Io)?;
+    write_evidence(vault_root, &evidence).map_err(CliError::Io)?;
+    write_console(vault_root, &model).map_err(CliError::Io)?;
+    write_ops_pages(vault_root, &model).map_err(CliError::Io)?;
     Ok(())
 }
 
@@ -670,8 +804,65 @@ fn live_image_download() -> Result<Box<dyn ovp_enrich::image_download::ImageDown
 
 #[cfg(test)]
 mod tests {
-    use super::{drain_runs, run, stale_theme_packs, DailyArgs};
+    use super::{
+        drain_runs, rebuild_projection, refresh_decision, run, stale_theme_packs, DailyArgs,
+        RefreshDecision, REFRESH_DEBOUNCE_SECS,
+    };
     use crate::commands::client::ClientKind;
+
+    /// A mid-run refresh that fails MUST surface an `Err` the caller can catch
+    /// and log — the run loop turns it into a `warn` and keeps going, never a
+    /// `?` that aborts the run. Here the projection write target is squatted by
+    /// a DIRECTORY, so `write_index`'s atomic rename fails: `rebuild_projection`
+    /// returns `Err` rather than panicking, proving the non-fatal branch has a
+    /// real error to log. (The run loop consumes this Err in a `sayln!` warn.)
+    #[test]
+    fn rebuild_projection_failure_is_a_returned_error_not_a_panic() {
+        let tmp = tempfile::tempdir().unwrap();
+        let vault = tmp.path();
+        // Squat the index.json path with a directory so the write cannot rename
+        // a file over it.
+        std::fs::create_dir_all(vault.join(".ovp/index/index.json")).unwrap();
+        let res = rebuild_projection(vault, "2026-07-12", "daily-test");
+        assert!(res.is_err(), "a failed projection write must be a catchable Err");
+    }
+
+    #[test]
+    fn refresh_fires_every_nth_source() {
+        // N=2: sources 2, 4, 6 are candidates; 1, 3, 5 are not.
+        assert_eq!(refresh_decision(2, 1, None), RefreshDecision::Skip);
+        assert_eq!(refresh_decision(2, 2, None), RefreshDecision::Rebuild);
+        assert_eq!(refresh_decision(2, 3, None), RefreshDecision::Skip);
+        assert_eq!(refresh_decision(2, 4, None), RefreshDecision::Rebuild);
+    }
+
+    #[test]
+    fn refresh_every_zero_never_fires_mid_run() {
+        // N=0 preserves the OLD behavior: rebuild only at the end, never mid-run.
+        for n in 0..50 {
+            assert_eq!(
+                refresh_decision(0, n, None),
+                RefreshDecision::Skip,
+                "N=0 must never trigger a mid-run rebuild (source {n})"
+            );
+        }
+    }
+
+    #[test]
+    fn refresh_debounce_skips_a_too_soon_rebuild() {
+        // An Nth source whose previous rebuild was <debounce ago is skipped…
+        assert_eq!(
+            refresh_decision(2, 4, Some(REFRESH_DEBOUNCE_SECS - 1)),
+            RefreshDecision::Debounced
+        );
+        // …but once the debounce window has passed it rebuilds again.
+        assert_eq!(
+            refresh_decision(2, 4, Some(REFRESH_DEBOUNCE_SECS)),
+            RefreshDecision::Rebuild
+        );
+        // The very first eligible tick (no prior rebuild) always fires.
+        assert_eq!(refresh_decision(2, 2, None), RefreshDecision::Rebuild);
+    }
 
     #[test]
     fn drain_runs_is_ceiling_division() {
@@ -703,6 +894,7 @@ mod tests {
             run_id: "daily-2026-07-12".into(),
             dry_run: false,
             max_sources: 0,
+            refresh_every: 0,
             no_intake: true,
             pinboard_fixture: None,
             pinboard_live: false,

--- a/crates/ovp-cli/src/commands/daily.rs
+++ b/crates/ovp-cli/src/commands/daily.rs
@@ -414,15 +414,14 @@ fn run_inner(
                 REFRESH_DEBOUNCE_SECS
             ),
             RefreshDecision::Rebuild => {
+                // Stamp the attempt time BEFORE the rebuild so a persistently
+                // failing refresh (e.g. unwritable projection) still debounces
+                // — otherwise every eligible source retries a full ~1000-pack
+                // scan (codex review P2). Best-effort: log and keep running.
+                last_refresh = Some(std::time::Instant::now());
                 sayln!("  refresh: rebuilding projection at {processed_so_far} source(s)…");
                 match rebuild_projection(&refresh_vault, &refresh_date, &refresh_run_id) {
-                    Ok(()) => {
-                        last_refresh = Some(std::time::Instant::now());
-                        sayln!("  refresh: portal projection updated");
-                    }
-                    // A projection refresh is best-effort: log (flushed) and keep
-                    // running. The run's real work is done; a stale projection for
-                    // one more source is never worth aborting a multi-hour run.
+                    Ok(()) => sayln!("  refresh: portal projection updated"),
                     Err(e) => sayln!("  warn refresh failed (continuing): {e}"),
                 }
             }

--- a/crates/ovp-cli/src/main.rs
+++ b/crates/ovp-cli/src/main.rs
@@ -170,6 +170,14 @@ enum Cmd {
         /// OVP_RULES). 0 = unlimited.
         #[arg(long, default_value_t = 10)]
         max_sources: usize,
+        /// Rebuild the read-model projection (index/evidence/console) every N
+        /// processed sources DURING the run, so the portal's Library facets,
+        /// counts, and "as of" age refresh mid-run instead of showing the
+        /// pre-run projection for the whole (multi-hour) run. 0 = rebuild only
+        /// at the end (the old behavior). A debounce skips a rebuild that would
+        /// fire too soon after the previous one.
+        #[arg(long, default_value_t = 10)]
+        refresh_every: usize,
         /// Skip the capture/intake sweep phase.
         #[arg(long)]
         no_intake: bool,
@@ -1166,6 +1174,7 @@ fn main() -> ExitCode {
             run_id,
             dry_run,
             max_sources,
+            refresh_every,
             no_intake,
             pinboard_fixture,
             pinboard_live,
@@ -1199,6 +1208,7 @@ fn main() -> ExitCode {
                 run_id,
                 dry_run,
                 max_sources,
+                refresh_every,
                 no_intake,
                 pinboard_fixture,
                 pinboard_live,

--- a/crates/ovp-cli/tests/m31_e2e.rs
+++ b/crates/ovp-cli/tests/m31_e2e.rs
@@ -515,3 +515,76 @@ fn full_daily_workflow_capture_to_console_with_crystal_and_retry() {
     ]));
     assert!(stdout.contains("No Cassette") && stdout.contains("fails=3"), "{stdout}");
 }
+
+/// Periodic mid-run projection refresh (the stale-during-run fix). Two clippings
+/// with `--refresh-every 1` must rebuild the read-model projection MID-run
+/// (before the final end-of-run rebuild), so the portal's counts/facets go fresh
+/// during a long run instead of showing the pre-run projection for its whole
+/// duration. `--refresh-every 0` preserves the old behavior: no mid-run rebuild.
+#[test]
+fn daily_periodic_refresh_rebuilds_projection_mid_run() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cache_dir = tmp.path().join("cassettes");
+
+    // Two distinct clippings so a run processes >1 source; seed cassettes for
+    // each from the exact SourceDoc the binary will read.
+    let seed_two = |vault: &Path| {
+        std::fs::create_dir_all(vault.join("Clippings")).unwrap();
+        let a = vault.join("Clippings/Alpha.md");
+        let b = vault.join("Clippings/Beta.md");
+        std::fs::write(&a, clip_note("Alpha", "https://e.x/alpha", CLIP_BODY)).unwrap();
+        std::fs::write(&b, clip_note("Beta", "https://e.x/beta", PIN_BODY)).unwrap();
+        seed_cassettes(&cache_dir, &read_source_from_path(&a).unwrap(), CLIP_QUOTE, "Alpha unit.");
+        seed_cassettes(&cache_dir, &read_source_from_path(&b).unwrap(), PIN_QUOTE, "Beta unit.");
+    };
+
+    // --- refresh-every 1: a rebuild fires after EACH of the two sources. ---
+    let vault = tmp.path().join("vault-every1");
+    seed_two(&vault);
+    let stdout = run_ok(bin().args([
+        "daily",
+        "--vault-root", vault.to_str().unwrap(),
+        "--date", DATE,
+        "--run-id", "daily-refresh-1",
+        "--refresh-every", "1",
+        "--cache-dir", cache_dir.to_str().unwrap(),
+    ]));
+    // The mid-run rebuild log line proves the projection was refreshed DURING
+    // the run, not just at the end. With --refresh-every 1 the FIRST source
+    // rebuilds; the second source is a candidate too but finishes within the
+    // debounce window (two trivial cassette sources complete in well under 20s),
+    // so the debounce SKIPS it — exactly the anti-thrash behavior. So: at least
+    // one mid-run rebuild AND the debounce line for the suppressed candidate.
+    let mid_run_rebuilds = stdout.matches("refresh: portal projection updated").count();
+    assert!(
+        mid_run_rebuilds >= 1,
+        "expected >=1 mid-run projection rebuild with --refresh-every 1, got {mid_run_rebuilds}\n{stdout}"
+    );
+    assert!(
+        stdout.contains("refresh: skipped (debounced"),
+        "the second fast source must be debounced, not thrash a rebuild\n{stdout}"
+    );
+    // The end-of-run authoritative rebuild still wrote the projection.
+    assert!(vault.join(".ovp/index/index.json").exists(), "final index written");
+    assert!(vault.join(".ovp/evidence.json").exists() || vault.join(".ovp/index/evidence.json").exists(),
+        "evidence written");
+    assert!(vault.join(".ovp/console/index.html").exists(), "console written");
+
+    // --- refresh-every 0: OLD behavior — no mid-run rebuild, only the end. ---
+    let vault0 = tmp.path().join("vault-every0");
+    seed_two(&vault0);
+    let stdout0 = run_ok(bin().args([
+        "daily",
+        "--vault-root", vault0.to_str().unwrap(),
+        "--date", DATE,
+        "--run-id", "daily-refresh-0",
+        "--refresh-every", "0",
+        "--cache-dir", cache_dir.to_str().unwrap(),
+    ]));
+    assert!(
+        !stdout0.contains("refresh: portal projection updated"),
+        "N=0 must NOT rebuild mid-run (old behavior)\n{stdout0}"
+    );
+    // …but the end-of-run projection is still built.
+    assert!(vault0.join(".ovp/index/index.json").exists(), "final index still written at N=0");
+}

--- a/crates/ovp-daily/src/heartbeat.rs
+++ b/crates/ovp-daily/src/heartbeat.rs
@@ -244,6 +244,10 @@ pub struct HeartbeatGuard {
     pid: u32,
     /// Set once finalize runs — suppresses the abort write in Drop.
     finalized: bool,
+    /// The last activity ring written by `progress`, carried into the terminal
+    /// record so a completed/failed/aborted run KEEPS its per-source feed for
+    /// post-run diagnosis (codex review P1) instead of blanking it.
+    last_recent: std::cell::RefCell<Vec<RecentSource>>,
 }
 
 impl HeartbeatGuard {
@@ -281,6 +285,7 @@ impl HeartbeatGuard {
                 started_at,
                 pid,
                 finalized: false,
+                last_recent: std::cell::RefCell::new(Vec::new()),
             },
             warn,
         )
@@ -304,11 +309,11 @@ impl HeartbeatGuard {
             processed_so_far: None,
             total_planned: None,
             current: None,
-            // The activity ring is a live surface; the terminal summary counts
-            // are authoritative. The last progress write's ring stays on disk
-            // until this terminal write replaces it, so a failed/aborted run's
-            // final feed remains readable up to the moment of finalize.
-            recent: Vec::new(),
+            // Carry the last progress ring into the terminal record so the
+            // per-source feed survives finalize — a completed run keeps its
+            // outcomes, and a failed/aborted run's last entries ARE the
+            // diagnosis (codex review P1).
+            recent: self.last_recent.borrow().clone(),
             error,
         }
     }
@@ -352,6 +357,7 @@ impl HeartbeatGuard {
             recent: recent.to_vec(),
             error: None,
         };
+        *self.last_recent.borrow_mut() = recent.to_vec();
         write_last_run(&self.vault_root, &record)
             .err()
             .map(|e| format!("heartbeat: could not update in-run progress: {e}"))
@@ -524,6 +530,23 @@ mod tests {
         assert_eq!(rec.recent[1].reason.as_deref(), Some("boom"));
 
         assert!(guard.finalize_completed(RunCounts::default()).is_none());
+    }
+
+    #[test]
+    fn terminal_record_retains_the_activity_ring_for_diagnosis() {
+        // Codex P1: the feed must survive finalize — a failed run's last
+        // per-source outcomes ARE the diagnosis, not blanked on the way out.
+        let dir = tempfile::tempdir().unwrap();
+        let (guard, _) = HeartbeatGuard::start(dir.path(), "r");
+        let ring = vec![recent(1, "ok-one", "ok"), recent(2, "bad-two", "failed")];
+        assert!(guard.progress(2, 5, Some("bad-two"), &ring).is_none());
+        assert!(guard.finalize_failed("provider outage").is_none());
+
+        let rec = read_last_run(dir.path()).unwrap().unwrap();
+        assert_eq!(rec.status, LastRunStatus::Failed);
+        assert_eq!(rec.error.as_deref(), Some("provider outage"));
+        assert_eq!(rec.recent.len(), 2, "the feed survives finalize");
+        assert_eq!(rec.recent[1].status, "failed");
     }
 
     #[test]

--- a/crates/ovp-daily/src/heartbeat.rs
+++ b/crates/ovp-daily/src/heartbeat.rs
@@ -29,6 +29,40 @@ use ovp_domain::VaultLayout;
 
 pub const LAST_RUN_SCHEMA: &str = "ovp.daily.last-run/v1";
 
+/// How many recent per-source outcomes the heartbeat ring keeps. This is the
+/// portal's live "tail -f": the operator watching the run sees the last N
+/// sources succeed/fail with their unit/card counts (or failure reason), at the
+/// per-source write cadence (seconds), NOT gated on the coarse projection
+/// rebuild. 20 is enough to see recent movement without bloating the sidecar (a
+/// bounded ring — oldest entries drop off as new ones arrive).
+pub const RECENT_RING_CAP: usize = 20;
+
+/// One per-source outcome in the live activity ring. Populated from the
+/// `DailyRunRecord` the reader phase produces per source; both success AND
+/// failure appear so a run that starts failing is diagnosable from the portal
+/// (the last entries + the terminal `failed`/`aborted` error) without SSHing in
+/// to `tail -f` the log.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RecentSource {
+    /// Monotonic 1-based sequence within the run (== processed_so_far at write).
+    pub seq: usize,
+    /// The source just finished (its vault-relative path / title).
+    pub title: String,
+    /// `"ok"` | `"failed"` — matches the two `RunStatus` variants.
+    pub status: String,
+    /// Units extracted (0 on failure).
+    #[serde(default)]
+    pub units: usize,
+    /// Cards produced (0 on failure).
+    #[serde(default)]
+    pub cards: usize,
+    /// Failure reason (present only on `failed`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// Wall-clock instant the source finished (UTC, RFC3339).
+    pub at: String,
+}
+
 /// Terminal (and in-flight) run status surfaced by the heartbeat.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -85,6 +119,15 @@ pub struct LastRun {
     /// records.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub current: Option<String>,
+    /// LIVE per-source activity ring (the portal's tail -f): the last
+    /// [`RECENT_RING_CAP`] source outcomes, oldest→newest, rewritten per source
+    /// while `running`. Empty (skipped in JSON) on the initial `running` stamp
+    /// and on terminal records — the terminal summary is the authoritative
+    /// counts, but the LAST progress write's ring stays readable until then so a
+    /// failed/aborted run's final feed is the diagnosis. Serde-additive: an
+    /// older reader ignores it.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub recent: Vec<RecentSource>,
     /// Populated on `failed`; a short note on `aborted`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
@@ -225,6 +268,7 @@ impl HeartbeatGuard {
             processed_so_far: None,
             total_planned: None,
             current: None,
+            recent: Vec::new(),
             error: None,
         };
         let warn = write_last_run(vault_root, &record)
@@ -260,6 +304,11 @@ impl HeartbeatGuard {
             processed_so_far: None,
             total_planned: None,
             current: None,
+            // The activity ring is a live surface; the terminal summary counts
+            // are authoritative. The last progress write's ring stays on disk
+            // until this terminal write replaces it, so a failed/aborted run's
+            // final feed remains readable up to the moment of finalize.
+            recent: Vec::new(),
             error,
         }
     }
@@ -273,14 +322,17 @@ impl HeartbeatGuard {
     /// by an observability side-channel.
     ///
     /// `current` is the source just finished (title or rel path); `None` clears
-    /// it. Reusing `started_at`/`pid`/`run_id` keeps this the SAME run record,
-    /// only fresher — an older reader that ignores the new fields still sees a
-    /// valid `running` heartbeat that ages in real time.
+    /// it. `recent` is the caller's live activity ring (last [`RECENT_RING_CAP`]
+    /// outcomes, oldest→newest) — the portal's tail -f. Reusing
+    /// `started_at`/`pid`/`run_id` keeps this the SAME run record, only fresher —
+    /// an older reader that ignores the new fields still sees a valid `running`
+    /// heartbeat that ages in real time.
     pub fn progress(
         &self,
         processed_so_far: usize,
         total_planned: usize,
         current: Option<&str>,
+        recent: &[RecentSource],
     ) -> Option<String> {
         let record = LastRun {
             schema: LAST_RUN_SCHEMA.into(),
@@ -297,6 +349,7 @@ impl HeartbeatGuard {
             processed_so_far: Some(processed_so_far),
             total_planned: Some(total_planned),
             current: current.map(str::to_string),
+            recent: recent.to_vec(),
             error: None,
         };
         write_last_run(&self.vault_root, &record)
@@ -422,7 +475,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let (guard, _) = HeartbeatGuard::start(dir.path(), "r");
 
-        assert!(guard.progress(1, 3, Some("first source")).is_none());
+        assert!(guard.progress(1, 3, Some("first source"), &[]).is_none());
         let rec = read_last_run(dir.path()).unwrap().unwrap();
         assert_eq!(rec.status, LastRunStatus::Running);
         assert_eq!(rec.processed_so_far, Some(1));
@@ -433,7 +486,7 @@ mod tests {
         assert_eq!(rec.run_id, "r");
 
         // A later source advances the fraction and renames current.
-        assert!(guard.progress(2, 3, Some("second source")).is_none());
+        assert!(guard.progress(2, 3, Some("second source"), &[]).is_none());
         let rec = read_last_run(dir.path()).unwrap().unwrap();
         assert_eq!(rec.processed_so_far, Some(2));
         assert_eq!(rec.current.as_deref(), Some("second source"));
@@ -442,11 +495,42 @@ mod tests {
         assert!(guard.finalize_completed(RunCounts::default()).is_none());
     }
 
+    fn recent(seq: usize, title: &str, status: &str) -> RecentSource {
+        RecentSource {
+            seq,
+            title: title.into(),
+            status: status.into(),
+            units: if status == "ok" { 12 } else { 0 },
+            cards: if status == "ok" { 8 } else { 0 },
+            reason: (status == "failed").then(|| "boom".to_string()),
+            at: now_rfc3339_utc(),
+        }
+    }
+
+    #[test]
+    fn progress_carries_recent_activity_ring() {
+        let dir = tempfile::tempdir().unwrap();
+        let (guard, _) = HeartbeatGuard::start(dir.path(), "r");
+
+        // Two sources: one ok, one failed — both must appear in the ring.
+        let ring = vec![recent(1, "first", "ok"), recent(2, "second", "failed")];
+        assert!(guard.progress(2, 5, Some("second"), &ring).is_none());
+
+        let rec = read_last_run(dir.path()).unwrap().unwrap();
+        assert_eq!(rec.recent.len(), 2, "both outcomes surfaced live");
+        assert_eq!(rec.recent[0].status, "ok");
+        assert_eq!(rec.recent[0].units, 12);
+        assert_eq!(rec.recent[1].status, "failed");
+        assert_eq!(rec.recent[1].reason.as_deref(), Some("boom"));
+
+        assert!(guard.finalize_completed(RunCounts::default()).is_none());
+    }
+
     #[test]
     fn terminal_finalize_after_progress_drops_progress_fields() {
         let dir = tempfile::tempdir().unwrap();
         let (guard, _) = HeartbeatGuard::start(dir.path(), "r");
-        assert!(guard.progress(2, 5, Some("mid source")).is_none());
+        assert!(guard.progress(2, 5, Some("mid source"), &[]).is_none());
         let counts = RunCounts { processed: 5, queued_after: 40, ..Default::default() };
         assert!(guard.finalize_completed(counts).is_none());
         let rec = read_last_run(dir.path()).unwrap().unwrap();
@@ -464,7 +548,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         {
             let (guard, _) = HeartbeatGuard::start(dir.path(), "r");
-            assert!(guard.progress(3, 9, Some("chewing on this")).is_none());
+            assert!(guard.progress(3, 9, Some("chewing on this"), &[]).is_none());
             // Guard drops here WITHOUT finalize — the abort drop-guard must fire
             // even after live progress writes.
         }

--- a/crates/ovp-daily/src/lib.rs
+++ b/crates/ovp-daily/src/lib.rs
@@ -37,8 +37,8 @@ pub mod ledger;
 pub mod report;
 
 pub use heartbeat::{
-    read_last_run, write_last_run, HeartbeatGuard, LastRun, LastRunStatus, RunCounts,
-    LAST_RUN_SCHEMA,
+    read_last_run, write_last_run, HeartbeatGuard, LastRun, LastRunStatus, RecentSource, RunCounts,
+    LAST_RUN_SCHEMA, RECENT_RING_CAP,
 };
 pub use ledger::{
     append_daily_record, append_pipeline_event, failed_counts, read_daily_ledger,

--- a/crates/ovp-index/src/build.rs
+++ b/crates/ovp-index/src/build.rs
@@ -24,7 +24,7 @@ use serde::Deserialize;
 
 use crate::model::{
     BlockedSource, ClaimRow, ClaimStatus, INDEX_SCHEMA, IndexModel, LastRunModel, OpsState,
-    PackRow, RunRow, RunStats, SourceRow, SourceStatus, StuckSource, Totals,
+    PackRow, RecentSourceModel, RunRow, RunStats, SourceRow, SourceStatus, StuckSource, Totals,
 };
 
 /// UTC wall-clock instant as RFC3339 — the `built_at` stamp. The one
@@ -966,6 +966,19 @@ pub fn last_run_to_model(hb: ovp_daily::LastRun) -> LastRunModel {
         processed_so_far: hb.processed_so_far,
         total_planned: hb.total_planned,
         current: hb.current,
+        recent: hb
+            .recent
+            .into_iter()
+            .map(|r| RecentSourceModel {
+                seq: r.seq,
+                title: r.title,
+                status: r.status,
+                units: r.units,
+                cards: r.cards,
+                reason: r.reason,
+                at: r.at,
+            })
+            .collect(),
         error: hb.error,
     }
 }

--- a/crates/ovp-index/src/lib.rs
+++ b/crates/ovp-index/src/lib.rs
@@ -30,8 +30,8 @@ pub use build::{
 pub use evidence::{EvidenceModel, build_evidence, evidence_path, read_evidence, write_evidence};
 pub use model::{
     BlockedSource, ClaimRow, ClaimStatus, DAYS_STUCK_AMBER, DAYS_STUCK_RED, INDEX_SCHEMA,
-    IndexModel, LastRunModel, OpsState, PackRow, RunRow, RunStats, SourceRow, SourceStatus,
-    StuckSource, Totals,
+    IndexModel, LastRunModel, OpsState, PackRow, RecentSourceModel, RunRow, RunStats, SourceRow,
+    SourceStatus, StuckSource, Totals,
 };
 pub use query::{
     Hit, Query, QueryKind, claim_status_str, run_evidence_query, run_query, source_status_str,

--- a/crates/ovp-index/src/model.rs
+++ b/crates/ovp-index/src/model.rs
@@ -222,8 +222,31 @@ pub struct LastRunModel {
     /// LIVE in-run progress: the source just finished (title or rel path).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub current: Option<String>,
+    /// LIVE per-source activity ring (the portal's tail -f): the last ~20 source
+    /// outcomes, oldest→newest, while `running`. Empty on terminal records.
+    /// Mirrors the heartbeat `recent[]`; the SPA renders the ✓/✗ feed from it.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub recent: Vec<RecentSourceModel>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+}
+
+/// One per-source outcome surfaced into the read model — the SPA's live feed
+/// entry. Mirrors the heartbeat `RecentSource`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RecentSourceModel {
+    pub seq: usize,
+    pub title: String,
+    /// `"ok"` | `"failed"`.
+    pub status: String,
+    #[serde(default)]
+    pub units: usize,
+    #[serde(default)]
+    pub cards: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// Wall-clock instant the source finished (UTC, RFC3339).
+    pub at: String,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -3529,6 +3529,7 @@ mod tests {
             processed_so_far: None,
             total_planned: None,
             current: None,
+            recent: vec![],
             error: None,
         });
         ovp_index::write_index(&vault, &baked).unwrap();
@@ -3579,6 +3580,7 @@ mod tests {
             processed_so_far: None,
             total_planned: None,
             current: None,
+            recent: vec![],
             error: None,
         });
         ovp_index::write_index(&vault, &baked).unwrap();


### PR DESCRIPTION
The portal becomes your tail -f. Operator feedback: the running task showed 'one big run' with no per-task detail, per-source success/failure only visible in the log, and counts frozen 1-2h until end-of-run rebuild.

**Live activity feed (primary, per-source real-time):** the heartbeat sidecar (.ovp/last-run.json, written per source via the on_source hook, atomic) gains a bounded recent[] ring (last 20: {seq,title,status,units,cards,reason?,at}) + processed_so_far/total_planned/current. A RunActivity component renders the fraction + progress bar, current source, and the ✓/✗ per-source feed (newest-first) — at the top of System and expandable from the run banner on every page, polling 12s while running. A completed run keeps its final feed + counts; a failed/aborted heartbeat's last entries ARE the diagnosis (the ring now survives finalize — codex P1). No more tail -f.

**Periodic projection refresh (secondary, count freshness):** --refresh-every N (default 10, 0=end-only) rebuilds index/evidence/console mid-run via the exact end-of-run writers, 20s-debounced (stamped before the rebuild so a persistent failure can't thrash — codex P2), best-effort (a refresh failure logs and never aborts the run). Keeps Library/Today/Knowledge counts from going 1-2h stale.

Library queued facet stays projection-derived so a pill count always equals the rows selecting it renders (codex P2); the live backlog is a standalone stat on Monitor/System.

927 workspace tests, clippy -D warnings, arch check, tsc+vite+vitest (34). Codex gate: 1 P1 + 2 P2 all fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a live run activity feed showing current progress and per-source success or failure results.
  * Run banners now display progress, update elapsed time automatically, and can expand to show recent activity.
  * Added periodic projection refresh support to the daily command, configurable with `--refresh-every`.
  * Added English and Simplified Chinese translations for the new activity interface.

* **Bug Fixes**
  * Improved consistency of status counts displayed in the Library filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->