### PR TITLE
fix(portal): Library queued facet is live again + honest snapshot note

### DIFF
--- a/console-ui/src/design/portal.css
+++ b/console-ui/src/design/portal.css
@@ -1516,3 +1516,5 @@ body {
   color: var(--muted);
   font-size: var(--ovp-text-sm);
 }
+
+.facet-snapshot { color: var(--muted); font-size: 0.85em; }

--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -129,6 +129,7 @@ export const en = {
   'library.byMonth': 'By month',
   'library.statusAll': 'All',
   'library.empty': 'No sources match the current filters.',
+  'library.queuedSnapshotHint': 'Live 01-Raw backlog; the number after · is the last projection snapshot (updates as the run refreshes it).',
   'library.noDate': 'no date',
 
   // source detail

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -120,6 +120,7 @@ export const zh: Record<keyof typeof en, string> = {
   'library.byMonth': '按月',
   'library.statusAll': '全部',
   'library.empty': '当前筛选下没有匹配的源。',
+  'library.queuedSnapshotHint': '实时 01-Raw 待处理数；· 后是上次投影快照(随运行刷新更新)。',
   'library.noDate': '无日期',
 
   // source detail

--- a/console-ui/src/pages/LibraryPage.tsx
+++ b/console-ui/src/pages/LibraryPage.tsx
@@ -44,13 +44,19 @@ function LibraryBody({ model }: { model: IndexModel }) {
   const months = [...byMonth.keys()].filter((m) => m !== '').sort().reverse();
   const byStatus = countBy(model.sources, (s: SourceRow) => s.status as string);
 
-  // Facet counts are projection-derived so a pill count ALWAYS equals the
-  // number of rows selecting it renders (codex review P2): showing a live
-  // queued number here would disagree with filterSources over the same
-  // projection rows mid-run. The live 01-Raw backlog is surfaced as a
-  // standalone stat on Monitor/System and the run banner; the periodic
-  // mid-run projection refresh keeps these facet counts from going stale.
-  const statusCount = (s: string): number => byStatus.get(s) ?? 0;
+  // The QUEUED facet shows the LIVE 01-Raw backlog (`queued_live`, ticks
+  // down per source during a run) — operators watch this number, and a
+  // frozen projection value here reads as "stuck". Every other status stays
+  // projection-derived. When the live count differs from the projection's
+  // queued row count (mid-run, between refreshes), the pill shows both so
+  // the number is live AND honest about the row list it filters:
+  // "queued 53 · 175 snapshot".
+  const projectionQueued = byStatus.get('queued') ?? 0;
+  const liveQueued = model.queued_live ?? projectionQueued;
+  const statusCount = (st: string): number =>
+    st === 'queued' ? liveQueued : (byStatus.get(st) ?? 0);
+  const queuedSnapshotNote =
+    liveQueued !== projectionQueued ? projectionQueued : null;
 
   const filtered = filterSources(model.sources, {
     collection: collection && COLLECTIONS.includes(collection) ? collection : null,
@@ -127,6 +133,12 @@ function LibraryBody({ model }: { model: IndexModel }) {
               onClick={() => setParam('status', status === s ? null : s)}
             >
               {t(`sourceStatus.${s}` as MsgKey)} ({statusCount(s)})
+              {s === 'queued' && queuedSnapshotNote != null && (
+                <span className="facet-snapshot" title={t('library.queuedSnapshotHint')}>
+                  {' '}
+                  · {queuedSnapshotNote}
+                </span>
+              )}
             </button>
           ))}
         </div>


### PR DESCRIPTION
The operator watches the Library queued facet; a prior over-correction made it projection-derived (for pill==list consistency), so it showed a frozen 175 while the live backlog was 53 — reads as broken. The pill now shows queued_live (ticks down per source), and when it differs from the projection's queued row count between mid-run refreshes it appends '· <snapshot>' with a tooltip, so the number is LIVE and honest about the row list it filters (addresses the codex consistency concern without sacrificing liveness). 927 tests, tsc+vite+vitest green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Library status filters now show the live queued-item count.
  * When the live count differs from the latest snapshot, the queued status displays both values with an explanatory hint.
  * Added English and Simplified Chinese translations for the new queued-item guidance.

* **Style**
  * Added styling for snapshot count details in the Library interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->