### PR TITLE
fix(portal): Library queued facet = one live number, drop the cryptic '· 61'

### DIFF
--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -129,7 +129,6 @@ export const en = {
   'library.byMonth': 'By month',
   'library.statusAll': 'All',
   'library.empty': 'No sources match the current filters.',
-  'library.queuedSnapshotHint': 'Live 01-Raw backlog; the number after · is the last projection snapshot (updates as the run refreshes it).',
   'library.noDate': 'no date',
 
   // source detail

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -120,7 +120,6 @@ export const zh: Record<keyof typeof en, string> = {
   'library.byMonth': '按月',
   'library.statusAll': '全部',
   'library.empty': '当前筛选下没有匹配的源。',
-  'library.queuedSnapshotHint': '实时 01-Raw 待处理数；· 后是上次投影快照(随运行刷新更新)。',
   'library.noDate': '无日期',
 
   // source detail

--- a/console-ui/src/pages/LibraryPage.tsx
+++ b/console-ui/src/pages/LibraryPage.tsx
@@ -51,12 +51,12 @@ function LibraryBody({ model }: { model: IndexModel }) {
   // queued row count (mid-run, between refreshes), the pill shows both so
   // the number is live AND honest about the row list it filters:
   // "queued 53 · 175 snapshot".
-  const projectionQueued = byStatus.get('queued') ?? 0;
-  const liveQueued = model.queued_live ?? projectionQueued;
+  // The queued facet shows the LIVE 01-Raw backlog (ticks down per source);
+  // every other status is projection-derived. One number, like every other
+  // facet — the projection-vs-live nuance is an internal detail, not a second
+  // figure on the chip.
   const statusCount = (st: string): number =>
-    st === 'queued' ? liveQueued : (byStatus.get(st) ?? 0);
-  const queuedSnapshotNote =
-    liveQueued !== projectionQueued ? projectionQueued : null;
+    st === 'queued' ? (model.queued_live ?? (byStatus.get('queued') ?? 0)) : (byStatus.get(st) ?? 0);
 
   const filtered = filterSources(model.sources, {
     collection: collection && COLLECTIONS.includes(collection) ? collection : null,
@@ -133,12 +133,6 @@ function LibraryBody({ model }: { model: IndexModel }) {
               onClick={() => setParam('status', status === s ? null : s)}
             >
               {t(`sourceStatus.${s}` as MsgKey)} ({statusCount(s)})
-              {s === 'queued' && queuedSnapshotNote != null && (
-                <span className="facet-snapshot" title={t('library.queuedSnapshotHint')}>
-                  {' '}
-                  · {queuedSnapshotNote}
-                </span>
-              )}
             </button>
           ))}
         </div>


### PR DESCRIPTION
The operator asked 'what do 55 and 61 mean' — the snapshot note I added to a facet chip (to satisfy a pill-vs-list-length consistency nit) was more confusing than the inconsistency it addressed. The queued chip now shows a single live number (the true 01-Raw backlog, ticks down per source) like every other facet. The projection-vs-live lag is an internal detail, not a second figure the operator has to decode. tsc+vite+vitest green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Simplified the queued item count shown in the Library status filter.
  * Removed the queued snapshot hint from the Library interface.
  * Updated English and Simplified Chinese translations to reflect the removed hint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->