### PR TITLE
fix(observability): detect a dead 'running' heartbeat via PID liveness

### DIFF
--- a/crates/ovp-cli/src/commands/schedule.rs
+++ b/crates/ovp-cli/src/commands/schedule.rs
@@ -1178,18 +1178,32 @@ fn status_with(
     match ovp_daily::read_last_run(&meta.vault_root) {
         Ok(Some(hb)) => {
             let when = hb.ended_at.as_deref().unwrap_or(hb.started_at.as_str());
-            let status = match hb.status {
+            // Liveness-adjusted: a `running` record whose process is gone is
+            // reported as STALLED, not "running" (it never finalized).
+            let stalled = hb.is_stalled();
+            let status = match hb.effective_status() {
                 ovp_daily::LastRunStatus::Completed => "completed",
                 ovp_daily::LastRunStatus::Failed => "FAILED",
+                ovp_daily::LastRunStatus::Aborted if stalled => "STALLED (process gone)",
                 ovp_daily::LastRunStatus::Aborted => "ABORTED",
                 ovp_daily::LastRunStatus::Running => "running",
             };
             println!("  last run:  {status} at {when} ({})", hb.run_id);
-            match hb.status {
+            match hb.effective_status() {
                 ovp_daily::LastRunStatus::Failed | ovp_daily::LastRunStatus::Aborted => {
+                    let reason = if stalled {
+                        Some(format!(
+                            "process (pid {}) is gone; stalled at {}/{}",
+                            hb.pid,
+                            hb.processed_so_far.unwrap_or(0),
+                            hb.total_planned.unwrap_or(0)
+                        ))
+                    } else {
+                        hb.error.clone()
+                    };
                     println!(
-                        "  WARN: the last run did not complete ({status}){} — check the schedule log and rerun `ovp2 daily`",
-                        hb.error.as_deref().map(|e| format!(": {e}")).unwrap_or_default()
+                        "  WARN: the last run did not complete ({status}){} — rerun `ovp2 daily`",
+                        reason.map(|e| format!(": {e}")).unwrap_or_default()
                     );
                 }
                 _ => {}

--- a/crates/ovp-cli/src/commands/schedule.rs
+++ b/crates/ovp-cli/src/commands/schedule.rs
@@ -1179,9 +1179,12 @@ fn status_with(
         Ok(Some(hb)) => {
             let when = hb.ended_at.as_deref().unwrap_or(hb.started_at.as_str());
             // Liveness-adjusted: a `running` record whose process is gone is
-            // reported as STALLED, not "running" (it never finalized).
-            let stalled = hb.is_stalled();
-            let status = match hb.effective_status() {
+            // reported as STALLED, not "running" (it never finalized). Compute
+            // it ONCE — effective_status() probes the pid (spawns `kill`).
+            let effective = hb.effective_status();
+            let stalled =
+                hb.status == ovp_daily::LastRunStatus::Running && effective == ovp_daily::LastRunStatus::Aborted;
+            let status = match effective {
                 ovp_daily::LastRunStatus::Completed => "completed",
                 ovp_daily::LastRunStatus::Failed => "FAILED",
                 ovp_daily::LastRunStatus::Aborted if stalled => "STALLED (process gone)",
@@ -1189,7 +1192,7 @@ fn status_with(
                 ovp_daily::LastRunStatus::Running => "running",
             };
             println!("  last run:  {status} at {when} ({})", hb.run_id);
-            match hb.effective_status() {
+            match effective {
                 ovp_daily::LastRunStatus::Failed | ovp_daily::LastRunStatus::Aborted => {
                     let reason = if stalled {
                         Some(format!(

--- a/crates/ovp-daily/src/heartbeat.rs
+++ b/crates/ovp-daily/src/heartbeat.rs
@@ -219,6 +219,55 @@ pub fn write_last_run(vault_root: &Path, record: &LastRun) -> Result<(), String>
         .map_err(|e| format!("renaming {} → {}: {e}", tmp.display(), target.display()))
 }
 
+/// Is `pid` a live process? Probes with `kill -0` (no signal sent; exit 0 =
+/// alive). Conservative: if the probe itself can't run, assume ALIVE so a real
+/// run is never falsely reported dead. `pid == 0` (unset) is treated as not a
+/// real owner. Same primitive `RunLock` uses to reclaim stale locks.
+pub fn pid_alive(pid: u32) -> bool {
+    if pid == 0 {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        std::process::Command::new("kill")
+            .arg("-0")
+            .arg(pid.to_string())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(true)
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}
+
+impl LastRun {
+    /// The status ACCOUNTING FOR LIVENESS. A record still stamped `running`
+    /// whose process is gone was killed hard enough that no destructor ran
+    /// (SIGKILL / power loss / OOM), so the drop-guard never wrote a terminal
+    /// status — it is really `aborted`. Every LIVE surface (portal run-activity,
+    /// `schedule status`, `doctor`) must display THIS, not the raw field, or a
+    /// dead run shows as "in progress" forever (the pid was stored for exactly
+    /// this check).
+    pub fn effective_status(&self) -> LastRunStatus {
+        if self.status == LastRunStatus::Running && !pid_alive(self.pid) {
+            LastRunStatus::Aborted
+        } else {
+            self.status
+        }
+    }
+
+    /// True when [`effective_status`](Self::effective_status) downgraded a
+    /// `running` record to `aborted` because its process is gone.
+    pub fn is_stalled(&self) -> bool {
+        self.status == LastRunStatus::Running
+            && self.effective_status() == LastRunStatus::Aborted
+    }
+}
+
 /// Read the heartbeat if present. `Ok(None)` on a fresh vault (no file yet);
 /// `Err` only on a present-but-unparseable file (corruption should be loud).
 pub fn read_last_run(vault_root: &Path) -> Result<Option<LastRun>, String> {
@@ -405,6 +454,52 @@ impl Drop for HeartbeatGuard {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn running_record(pid: u32) -> LastRun {
+        LastRun {
+            schema: "ovp.daily.last-run/v1".into(),
+            run_id: "daily-x".into(),
+            started_at: "2026-07-13T03:40:55Z".into(),
+            status: LastRunStatus::Running,
+            ended_at: None,
+            pid,
+            processed: None,
+            failed: None,
+            blocked: None,
+            capped: None,
+            queued_after: None,
+            processed_so_far: Some(65),
+            total_planned: Some(80),
+            current: None,
+            recent: vec![],
+            error: None,
+        }
+    }
+
+    #[test]
+    fn effective_status_downgrades_dead_running_to_aborted() {
+        // Our own pid is alive -> stays running.
+        let live = running_record(std::process::id());
+        assert_eq!(live.effective_status(), LastRunStatus::Running);
+        assert!(!live.is_stalled());
+
+        // pid 0 (unset) is treated as not a real owner -> stalled -> aborted.
+        let dead = running_record(0);
+        assert_eq!(dead.effective_status(), LastRunStatus::Aborted);
+        assert!(dead.is_stalled());
+
+        // A terminal record's liveness is irrelevant — never downgraded.
+        let mut done = running_record(0);
+        done.status = LastRunStatus::Completed;
+        assert_eq!(done.effective_status(), LastRunStatus::Completed);
+        assert!(!done.is_stalled());
+    }
+
+    #[test]
+    fn pid_alive_true_for_self_false_for_zero() {
+        assert!(pid_alive(std::process::id()));
+        assert!(!pid_alive(0));
+    }
 
     #[test]
     fn rfc3339_formats_epoch_and_a_known_instant() {

--- a/crates/ovp-index/src/build.rs
+++ b/crates/ovp-index/src/build.rs
@@ -949,9 +949,12 @@ fn days_between(from: &str, to: &str) -> Option<usize> {
 pub fn last_run_to_model(hb: ovp_daily::LastRun) -> LastRunModel {
     // Use the LIVENESS-adjusted status: a `running` record whose process is
     // gone (SIGKILL/power-loss/OOM — no finalize ran) is really aborted, so the
-    // portal shows "stalled" instead of "in progress" forever.
-    let stalled = hb.is_stalled();
-    let status = match hb.effective_status() {
+    // portal shows "stalled" instead of "in progress" forever. Compute it ONCE —
+    // effective_status() probes the pid (spawns `kill`).
+    let effective = hb.effective_status();
+    let stalled =
+        hb.status == ovp_daily::LastRunStatus::Running && effective == ovp_daily::LastRunStatus::Aborted;
+    let status = match effective {
         ovp_daily::LastRunStatus::Running => "running",
         ovp_daily::LastRunStatus::Completed => "completed",
         ovp_daily::LastRunStatus::Failed => "failed",

--- a/crates/ovp-index/src/build.rs
+++ b/crates/ovp-index/src/build.rs
@@ -947,11 +947,27 @@ fn days_between(from: &str, to: &str) -> Option<usize> {
 /// status keeps the model self-describing for the static console pages and the
 /// SPA alike.
 pub fn last_run_to_model(hb: ovp_daily::LastRun) -> LastRunModel {
-    let status = match hb.status {
+    // Use the LIVENESS-adjusted status: a `running` record whose process is
+    // gone (SIGKILL/power-loss/OOM — no finalize ran) is really aborted, so the
+    // portal shows "stalled" instead of "in progress" forever.
+    let stalled = hb.is_stalled();
+    let status = match hb.effective_status() {
         ovp_daily::LastRunStatus::Running => "running",
         ovp_daily::LastRunStatus::Completed => "completed",
         ovp_daily::LastRunStatus::Failed => "failed",
         ovp_daily::LastRunStatus::Aborted => "aborted",
+    };
+    // Explain the downgrade so the UI/operator sees WHY a run at 65/80 stopped.
+    let error = if stalled {
+        Some(format!(
+            "run stopped without finishing — its process (pid {}) is gone (killed/crashed/slept); \
+             it stalled at {}/{}",
+            hb.pid,
+            hb.processed_so_far.unwrap_or(0),
+            hb.total_planned.unwrap_or(0)
+        ))
+    } else {
+        hb.error
     };
     LastRunModel {
         run_id: hb.run_id,
@@ -979,7 +995,7 @@ pub fn last_run_to_model(hb: ovp_daily::LastRun) -> LastRunModel {
                 at: r.at,
             })
             .collect(),
-        error: hb.error,
+        error,
     }
 }
 


### PR DESCRIPTION
## The bug (real dogfood defect)

The portal showed a daily run as **"in progress · 65/80 · 81% · started 11h ago"** forever. Root cause: the process (pid 49862) died ~9h ago (SIGKILL / OOM / crash — `caffeinate` was active, so not sleep). A hard kill runs **no destructors**, so `HeartbeatGuard`'s drop-to-`aborted` never fired and `.ovp/last-run.json` stayed `status: running`. The reader (`read_last_run` → `last_run_to_model`) just trusted the field — **the `pid` was stored for exactly this liveness check but nothing used it** (the enum comment even calls out the SIGKILL case).

## Fix

- `ovp-daily`: `pid_alive()` (`kill -0`, the same primitive `RunLock` uses to reclaim stale locks) + `LastRun::effective_status()` / `is_stalled()` — a `running` record whose process is gone is reported as `aborted`.
- `ovp-index` `last_run_to_model` (the portal's source of truth) and CLI `schedule status` now render the **effective** status + a reason (`run stopped without finishing — its process (pid N) is gone; stalled at X/Y`) instead of a frozen "in progress" banner.

Conservative: if the `kill -0` probe can't run, assume alive (never false-abort a live run); terminal records are never downgraded.

## Verified live
On the real vault, the stuck run now reads `aborted` via `/api/model` `ops.last_run` (restarted `serve` with the fixed binary; removed the stale dead-PID `run.lock`). `ovp-daily` 24 + `ovp-index` 16 tests, clippy clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved run status reporting using liveness checks to correctly interpret “last run” outcomes.
  * Stalled runs now display as **STALLED (process gone)** rather than generic aborted states.
  * Warning and error messaging now includes the missing process ID and progress counters when applicable; otherwise it uses the heartbeat’s stored error.
  * “Last run” details are now shown consistently with the liveness-adjusted status.
* **Tests**
  * Added unit tests covering liveness detection and stalled-run downgrading behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->