### PR TITLE
feat(knowledge): interactive 3D knowledge-terrain view (themescape)

### DIFF
--- a/console-ui/package-lock.json
+++ b/console-ui/package-lock.json
@@ -9,15 +9,19 @@
       "version": "0.2.0",
       "dependencies": {
         "@antv/g6": "^5.0.49",
+        "@types/d3-contour": "^3.0.6",
+        "@types/three": "^0.185.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "d3-contour": "^4.0.2",
         "d3-sankey": "^0.12.3",
         "d3-shape": "^3.2.0",
         "lucide-react": "^0.525.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.6.0",
-        "tailwind-merge": "^3.3.0"
+        "tailwind-merge": "^3.3.0",
+        "three": "^0.185.1"
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.1.0",
@@ -570,6 +574,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmmirror.com/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "license": "Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
@@ -1699,6 +1709,12 @@
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmmirror.com/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmmirror.com/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1766,6 +1782,16 @@
       "resolved": "https://registry.npmmirror.com/@types/d3-color/-/d3-color-3.1.3.tgz",
       "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
       "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmmirror.com/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/d3-dispatch": {
       "version": "3.0.7",
@@ -1960,6 +1986,32 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmmirror.com/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.185.1",
+      "resolved": "https://registry.npmmirror.com/@types/three/-/three-0.185.1.tgz",
+      "integrity": "sha512-db1xTb+EgYF2didW+eudSvVPtn75zo+fGsY8ShQrJY/B5ZBmC2Fiaykv3aImHAlCNEGuMPkPGXBJGLwzu5mC7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~1.1.1"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmmirror.com/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -2305,6 +2357,30 @@
       "resolved": "https://registry.npmmirror.com/d3-color/-/d3-color-3.1.0.tgz",
       "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
       "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmmirror.com/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour/node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmmirror.com/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -2769,6 +2845,12 @@
       "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
       "license": "MIT"
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmmirror.com/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmmirror.com/fsevents/-/fsevents-2.3.3.tgz",
@@ -3198,6 +3280,12 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/meshoptimizer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+      "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
+      "license": "MIT"
+    },
     "node_modules/ml-array-max": {
       "version": "2.0.0",
       "resolved": "https://registry.npmmirror.com/ml-array-max/-/ml-array-max-2.0.0.tgz",
@@ -3576,6 +3664,12 @@
       "dependencies": {
         "utrie": "^1.0.2"
       }
+    },
+    "node_modules/three": {
+      "version": "0.185.1",
+      "resolved": "https://registry.npmmirror.com/three/-/three-0.185.1.tgz",
+      "integrity": "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==",
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",

--- a/console-ui/package.json
+++ b/console-ui/package.json
@@ -11,15 +11,19 @@
   },
   "dependencies": {
     "@antv/g6": "^5.0.49",
+    "@types/d3-contour": "^3.0.6",
+    "@types/three": "^0.185.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "d3-contour": "^4.0.2",
     "d3-sankey": "^0.12.3",
     "d3-shape": "^3.2.0",
     "lucide-react": "^0.525.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.0",
-    "tailwind-merge": "^3.3.0"
+    "tailwind-merge": "^3.3.0",
+    "three": "^0.185.1"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.0",

--- a/console-ui/src/components/KnowledgeTerrain.tsx
+++ b/console-ui/src/components/KnowledgeTerrain.tsx
@@ -377,18 +377,18 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
     let tweening = false;
     const loop = () => {
       raf = requestAnimationFrame(loop);
-      // Re-sync every frame the requested mode differs from the applied one, so
-      // a mid-tween reversal (3D→2D→3D) redirects `want` AND refreshes the polar
-      // limit. Guarding on `!tweening` would leave maxPolarAngle at the old
-      // value, clamping the camera short of its target and never re-enabling
-      // controls.
-      if (modeRef.current !== appliedMode) {
-        tweening = true;
-        controls.enabled = false;
-        controls.maxPolarAngle = modeRef.current === '2d' ? 0.35 : Math.PI * 0.49;
-      }
+      // A change from the applied mode STARTS a tween; once tweening we drive it
+      // to completion off the CURRENTLY requested mode. Reversing 3D→2D→3D mid-
+      // tween returns to appliedMode, so the start test is false — but tweening
+      // is already true, and re-syncing the limit + target every frame from
+      // modeRef inside the block below still lands the camera correctly. Setting
+      // the limit only on the start test would strand it at the 2D clamp.
+      if (modeRef.current !== appliedMode) tweening = true;
       if (tweening) {
-        const want = modeRef.current === '2d' ? t2d : t3d;
+        const want3d = modeRef.current === '3d';
+        controls.enabled = false;
+        controls.maxPolarAngle = want3d ? Math.PI * 0.49 : 0.35;
+        const want = want3d ? t3d : t2d;
         camera.position.lerp(want, 0.12);
         camera.lookAt(controls.target);
         if (camera.position.distanceTo(want) < 1.5) {

--- a/console-ui/src/components/KnowledgeTerrain.tsx
+++ b/console-ui/src/components/KnowledgeTerrain.tsx
@@ -10,6 +10,7 @@
  */
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useI18n } from '../i18n';
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { CSS2DRenderer, CSS2DObject } from 'three/examples/jsm/renderers/CSS2DRenderer.js';
@@ -47,6 +48,7 @@ function glowTexture(): THREE.Texture {
 export default function KnowledgeTerrain({ height = 600 }: { height?: number }) {
   const wrapRef = useRef<HTMLDivElement>(null);
   const navigate = useNavigate();
+  const { t } = useI18n();
   const [data, setData] = useState<Terrain | null>(null);
   const [err, setErr] = useState<string | null>(null);
   const [mode, setMode] = useState<'3d' | '2d'>('3d');
@@ -69,11 +71,11 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
     fetch('/api/terrain')
       .then((r) => (r.ok ? r.json() : Promise.reject(new Error('not built'))))
       .then((d: Terrain) => !off && setData(d))
-      .catch(() => !off && setErr('Terrain not built yet — run `ovp2 crystal-terrain --vault-root <vault>`.'));
+      .catch(() => !off && setErr(t('knowledge.terrainNotBuilt')));
     return () => {
       off = true;
     };
-  }, []);
+  }, [t]);
 
   // Default the scrubber to "all" once months are known.
   useEffect(() => {
@@ -308,6 +310,7 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
       if (hoverSlot < 0) return;
       if (Math.hypot(e.clientX - downX, e.clientY - downY) > 5) return; // a drag, not a click
       const p = data.points[visibleIdx[hoverSlot]];
+      if (!p.sha) return; // pack not ledger-tracked → no source page to open
       navigate(`/library/${encodeURIComponent(p.sha)}`);
     };
     renderer.domElement.addEventListener('pointermove', pick);
@@ -399,7 +402,9 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
   return (
     <div ref={wrapRef} style={{ position: 'relative', width: '100%', height }}>
       <div style={{ position: 'absolute', top: 10, left: 12, zIndex: 2, color: 'rgba(233,230,224,0.6)', font: '12px system-ui', pointerEvents: 'none' }}>
-        {data ? `${data.point_count} notes · ${data.themes.length} themes · drag to orbit, scroll to zoom` : 'loading…'}
+        {data
+          ? t('knowledge.terrainHud', { notes: data.point_count, themes: data.themes.length })
+          : t('knowledge.terrainLoading')}
       </div>
       <button
         type="button"
@@ -425,7 +430,7 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
               setPlaying((p) => !p);
             }}
             style={{ cursor: 'pointer', background: 'none', border: 'none', color: '#7fd6e6', font: '13px system-ui' }}
-            aria-label={playing ? 'pause' : 'play'}
+            aria-label={playing ? t('knowledge.terrainPause') : t('knowledge.terrainPlay')}
           >
             {playing ? '⏸' : '▶'}
           </button>
@@ -441,7 +446,7 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
             style={{ flex: 1, accentColor: '#7fd6e6' }}
           />
           <span style={{ color: 'rgba(233,230,224,0.85)', font: '12px system-ui', minWidth: 92, textAlign: 'right' }}>
-            {atLatest ? 'all time' : months[monthIdx]}
+            {atLatest ? t('knowledge.terrainAllTime') : months[monthIdx]}
           </span>
         </div>
       )}

--- a/console-ui/src/components/KnowledgeTerrain.tsx
+++ b/console-ui/src/components/KnowledgeTerrain.tsx
@@ -1,0 +1,468 @@
+/**
+ * KnowledgeTerrain — an INTERACTIVE 3D "themescape" of the corpus (flomo-style).
+ * Fetches `/api/terrain` (2D layout of themed packs, built by
+ * `ovp2 crystal-terrain`), turns point density into a heightmapped terrain mesh
+ * (contour-line shader), scatters each source as a glowing point on the surface,
+ * floats theme labels on the peaks, and lets you ORBIT (drag), ZOOM (wheel), and
+ * CLICK a point to open its source. A 2D/3D toggle tilts the camera top-down;
+ * the timeline scrubber REPLAYS the terrain growing month by month. Its own dark
+ * "night map" regardless of app theme.
+ */
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import * as THREE from 'three';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { CSS2DRenderer, CSS2DObject } from 'three/examples/jsm/renderers/CSS2DRenderer.js';
+
+type TPoint = { id: string; sha: string; title: string; date: string; theme: string; x: number; y: number };
+type TTheme = { id: number; label: string; cx: number; cy: number; count: number };
+type Terrain = {
+  points: TPoint[];
+  themes: TTheme[];
+  bounds: [number, number, number, number];
+  point_count: number;
+};
+
+const SIZE = 220;
+const GRID = 150;
+const HEIGHT = 42;
+const SIGMA = 3.4;
+const FULL = '9999-99-99'; // cutoff meaning "everything"
+
+function glowTexture(): THREE.Texture {
+  const c = document.createElement('canvas');
+  c.width = c.height = 64;
+  const g = c.getContext('2d')!;
+  const grd = g.createRadialGradient(32, 32, 0, 32, 32, 32);
+  grd.addColorStop(0, 'rgba(180,225,245,1)');
+  grd.addColorStop(0.25, 'rgba(130,200,230,0.85)');
+  grd.addColorStop(1, 'rgba(130,200,230,0)');
+  g.fillStyle = grd;
+  g.fillRect(0, 0, 64, 64);
+  const t = new THREE.CanvasTexture(c);
+  t.needsUpdate = true;
+  return t;
+}
+
+export default function KnowledgeTerrain({ height = 600 }: { height?: number }) {
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const navigate = useNavigate();
+  const [data, setData] = useState<Terrain | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+  const [mode, setMode] = useState<'3d' | '2d'>('3d');
+  const modeRef = useRef(mode);
+  modeRef.current = mode;
+  const [hover, setHover] = useState<{ mx: number; my: number; p: TPoint } | null>(null);
+
+  const months = useMemo(() => {
+    if (!data) return [] as string[];
+    const set = new Set<string>();
+    for (const p of data.points) if (p.date) set.add(p.date.slice(0, 7));
+    return [...set].sort();
+  }, [data]);
+  const [monthIdx, setMonthIdx] = useState(0);
+  const [playing, setPlaying] = useState(false);
+  const applyCutoffRef = useRef<((cutoff: string) => void) | null>(null);
+
+  useEffect(() => {
+    let off = false;
+    fetch('/api/terrain')
+      .then((r) => (r.ok ? r.json() : Promise.reject(new Error('not built'))))
+      .then((d: Terrain) => !off && setData(d))
+      .catch(() => !off && setErr('Terrain not built yet — run `ovp2 crystal-terrain --vault-root <vault>`.'));
+    return () => {
+      off = true;
+    };
+  }, []);
+
+  // Default the scrubber to "all" once months are known.
+  useEffect(() => {
+    if (months.length) setMonthIdx(months.length - 1);
+  }, [months]);
+
+  // ---- three.js scene (built once per dataset) ----
+  useEffect(() => {
+    if (!data || !wrapRef.current) return;
+    const wrap = wrapRef.current;
+    let W = wrap.clientWidth;
+    const H = height;
+
+    const [minx, miny, maxx, maxy] = data.bounds;
+    const sx = (v: number) => ((v - minx) / Math.max(maxx - minx, 1e-6) - 0.5) * SIZE;
+    const sy = (v: number) => ((v - miny) / Math.max(maxy - miny, 1e-6) - 0.5) * SIZE;
+
+    // Separable Gaussian kernel for the KDE.
+    const kern: number[] = [];
+    const R = Math.ceil(SIGMA * 3);
+    for (let i = -R; i <= R; i++) kern.push(Math.exp(-(i * i) / (2 * SIGMA * SIGMA)));
+    const ksum = kern.reduce((a, b) => a + b, 0);
+    const blur = (src: Float32Array) => {
+      const h = new Float32Array(GRID * GRID);
+      for (let y = 0; y < GRID; y++)
+        for (let x = 0; x < GRID; x++) {
+          let s = 0;
+          for (let k = -R; k <= R; k++) s += src[y * GRID + Math.min(GRID - 1, Math.max(0, x + k))] * kern[k + R];
+          h[y * GRID + x] = s / ksum;
+        }
+      const o = new Float32Array(GRID * GRID);
+      for (let y = 0; y < GRID; y++)
+        for (let x = 0; x < GRID; x++) {
+          let s = 0;
+          for (let k = -R; k <= R; k++) s += h[Math.min(GRID - 1, Math.max(0, y + k)) * GRID + x] * kern[k + R];
+          o[y * GRID + x] = s / ksum;
+        }
+      return o;
+    };
+    const densityFor = (pts: TPoint[]) => {
+      const grid = new Float32Array(GRID * GRID);
+      for (const p of pts) {
+        const gx = Math.min(GRID - 1, Math.max(0, Math.round(((sx(p.x) / SIZE) + 0.5) * (GRID - 1))));
+        const gy = Math.min(GRID - 1, Math.max(0, Math.round(((sy(p.y) / SIZE) + 0.5) * (GRID - 1))));
+        grid[gy * GRID + gx] += 1;
+      }
+      return blur(grid);
+    };
+    // Fixed normalizer from the FULL corpus, so the terrain GROWS over the
+    // timeline instead of rescaling to full height at every step.
+    const fullDens = densityFor(data.points);
+    let fullMax = 1e-6;
+    for (const v of fullDens) fullMax = Math.max(fullMax, v);
+    const heightFn = (dens: Float32Array) => (wx: number, wz: number) => {
+      const fx = ((wx / SIZE) + 0.5) * (GRID - 1);
+      const fz = ((wz / SIZE) + 0.5) * (GRID - 1);
+      const x0 = Math.min(GRID - 1, Math.max(0, Math.floor(fx)));
+      const z0 = Math.min(GRID - 1, Math.max(0, Math.floor(fz)));
+      const x1 = Math.min(GRID - 1, x0 + 1);
+      const z1 = Math.min(GRID - 1, z0 + 1);
+      const tx = fx - x0;
+      const tz = fz - z0;
+      const a = dens[z0 * GRID + x0];
+      const b = dens[z0 * GRID + x1];
+      const c = dens[z1 * GRID + x0];
+      const d = dens[z1 * GRID + x1];
+      const v = a * (1 - tx) * (1 - tz) + b * tx * (1 - tz) + c * (1 - tx) * tz + d * tx * tz;
+      return (v / fullMax) * HEIGHT;
+    };
+
+    // ---- renderer / scene / camera ----
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color('#0d0f13');
+    scene.fog = new THREE.Fog('#0d0f13', SIZE * 0.9, SIZE * 2.2);
+    const camera = new THREE.PerspectiveCamera(45, W / H, 1, SIZE * 6);
+    camera.position.set(0, HEIGHT * 3.2, SIZE * 0.82);
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    renderer.setSize(W, H);
+    renderer.domElement.style.borderRadius = '12px';
+    renderer.domElement.style.display = 'block';
+    renderer.domElement.style.touchAction = 'none';
+    wrap.style.overscrollBehavior = 'none';
+    wrap.appendChild(renderer.domElement);
+
+    const labelRenderer = new CSS2DRenderer();
+    labelRenderer.setSize(W, H);
+    labelRenderer.domElement.style.cssText = 'position:absolute;top:0;left:0;pointer-events:none;';
+    wrap.appendChild(labelRenderer.domElement);
+
+    const controls = new OrbitControls(camera, renderer.domElement);
+    controls.enableDamping = true;
+    controls.dampingFactor = 0.08;
+    controls.maxPolarAngle = Math.PI * 0.49;
+    controls.minDistance = 40;
+    controls.maxDistance = SIZE * 1.8;
+    controls.target.set(0, 0, 0);
+
+    // ---- terrain mesh ----
+    const geo = new THREE.PlaneGeometry(SIZE, SIZE, GRID - 1, GRID - 1);
+    geo.rotateX(-Math.PI / 2);
+    const gpos = geo.attributes.position as THREE.BufferAttribute;
+    const terrainMat = new THREE.ShaderMaterial({
+      uniforms: {
+        uMaxH: { value: HEIGHT },
+        uLine: { value: new THREE.Color('#7fd6e6') },
+        uBase: { value: new THREE.Color('#0f151c') },
+        uPeak: { value: new THREE.Color('#183245') },
+      },
+      vertexShader: `varying float vH; void main(){ vH=position.y; gl_Position=projectionMatrix*modelViewMatrix*vec4(position,1.0); }`,
+      fragmentShader: `
+        uniform float uMaxH; uniform vec3 uLine; uniform vec3 uBase; uniform vec3 uPeak; varying float vH;
+        void main(){
+          float h=clamp(vH/uMaxH,0.0,1.0);
+          float g=h*26.0; float fp=fract(g); float dist=min(fp,1.0-fp);
+          float aa=fwidth(g)*1.3+1e-4; float edge=1.0-smoothstep(0.0,aa,dist);
+          vec3 terrain=mix(uBase,uPeak,h);
+          gl_FragColor=vec4(mix(terrain,uLine,edge*(0.3+0.7*h)),1.0);
+        }`,
+    });
+    scene.add(new THREE.Mesh(geo, terrainMat));
+
+    // ---- points (full-size buffer, drawn up to the visible count) ----
+    const pgeo = new THREE.BufferGeometry();
+    const parr = new Float32Array(data.points.length * 3);
+    pgeo.setAttribute('position', new THREE.BufferAttribute(parr, 3));
+    const pmat = new THREE.PointsMaterial({
+      size: 4.5, map: glowTexture(), transparent: true, depthWrite: false,
+      blending: THREE.AdditiveBlending, color: 0x9fd6ea, sizeAttenuation: true,
+    });
+    const points = new THREE.Points(pgeo, pmat);
+    points.frustumCulled = false;
+    scene.add(points);
+    const visibleIdx: number[] = []; // geometry slot -> data.points index
+
+    const mark = new THREE.Points(
+      new THREE.BufferGeometry().setAttribute('position', new THREE.BufferAttribute(new Float32Array(3), 3)),
+      new THREE.PointsMaterial({ size: 9, map: glowTexture(), transparent: true, depthWrite: false, blending: THREE.AdditiveBlending, color: 0xffffff }),
+    );
+    mark.visible = false;
+    scene.add(mark);
+
+    // ---- theme labels ----
+    const labelObjs = data.themes
+      .slice()
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 16)
+      .map((th) => {
+        const el = document.createElement('div');
+        el.textContent = th.label;
+        el.style.cssText =
+          'color:rgba(233,230,224,0.94);font:600 12px system-ui;text-shadow:0 1px 3px rgba(0,0,0,0.85);white-space:nowrap;';
+        const obj = new CSS2DObject(el);
+        scene.add(obj);
+        return { th, el, obj };
+      });
+
+    // ---- rebuild terrain/points/labels for a date cutoff ----
+    const applyCutoff = (cutoff: string) => {
+      const vis = data.points.filter((p) => !p.date || p.date <= cutoff);
+      const dens = densityFor(vis);
+      const hAt = heightFn(dens);
+      for (let i = 0; i < gpos.count; i++) gpos.setY(i, hAt(gpos.getX(i), gpos.getZ(i)));
+      gpos.needsUpdate = true;
+      geo.computeVertexNormals();
+
+      visibleIdx.length = 0;
+      vis.forEach((p) => {
+        const wx = sx(p.x);
+        const wz = sy(p.y);
+        const slot = visibleIdx.length;
+        parr[slot * 3] = wx;
+        parr[slot * 3 + 1] = hAt(wx, wz) + 1.6;
+        parr[slot * 3 + 2] = wz;
+        visibleIdx.push(data.points.indexOf(p));
+      });
+      pgeo.setDrawRange(0, vis.length);
+      pgeo.attributes.position.needsUpdate = true;
+
+      const seen = new Set(vis.map((p) => p.theme));
+      for (const l of labelObjs) {
+        if (seen.has(l.th.label)) {
+          l.el.style.display = '';
+          const wx = sx(l.th.cx);
+          const wz = sy(l.th.cy);
+          l.obj.position.set(wx, hAt(wx, wz) + 6, wz);
+        } else {
+          l.el.style.display = 'none';
+        }
+      }
+    };
+    applyCutoff(FULL);
+    applyCutoffRef.current = applyCutoff;
+
+    // ---- interaction (click-vs-drag) ----
+    const ray = new THREE.Raycaster();
+    ray.params.Points = { threshold: 2.4 };
+    const ndc = new THREE.Vector2();
+    let hoverSlot = -1;
+    let downX = 0;
+    let downY = 0;
+    const pick = (ev: PointerEvent) => {
+      const rect = renderer.domElement.getBoundingClientRect();
+      ndc.x = ((ev.clientX - rect.left) / rect.width) * 2 - 1;
+      ndc.y = -((ev.clientY - rect.top) / rect.height) * 2 + 1;
+      ray.setFromCamera(ndc, camera);
+      const hits = ray.intersectObject(points, false);
+      const hit = hits.find((h) => (h.index ?? -1) < visibleIdx.length);
+      if (hit) {
+        hoverSlot = hit.index ?? -1;
+        const p = data.points[visibleIdx[hoverSlot]];
+        mark.visible = true;
+        (mark.geometry.attributes.position as THREE.BufferAttribute).copyArray([
+          parr[hoverSlot * 3], parr[hoverSlot * 3 + 1], parr[hoverSlot * 3 + 2],
+        ]);
+        mark.geometry.attributes.position.needsUpdate = true;
+        setHover({ mx: ev.clientX - rect.left, my: ev.clientY - rect.top, p });
+        renderer.domElement.style.cursor = 'pointer';
+      } else {
+        hoverSlot = -1;
+        mark.visible = false;
+        setHover(null);
+        renderer.domElement.style.cursor = 'grab';
+      }
+    };
+    const onDown = (e: PointerEvent) => {
+      downX = e.clientX;
+      downY = e.clientY;
+    };
+    const onClick = (e: MouseEvent) => {
+      if (hoverSlot < 0) return;
+      if (Math.hypot(e.clientX - downX, e.clientY - downY) > 5) return; // a drag, not a click
+      const p = data.points[visibleIdx[hoverSlot]];
+      navigate(`/library/${encodeURIComponent(p.sha)}`);
+    };
+    renderer.domElement.addEventListener('pointermove', pick);
+    renderer.domElement.addEventListener('pointerdown', onDown);
+    renderer.domElement.addEventListener('click', onClick);
+
+    // ---- loop (tween camera only on 2D/3D switch) ----
+    let raf = 0;
+    const t3d = new THREE.Vector3(0, HEIGHT * 3.2, SIZE * 0.82);
+    const t2d = new THREE.Vector3(0, SIZE * 1.15, 0.001);
+    let appliedMode: '2d' | '3d' = '3d';
+    let tweening = false;
+    const loop = () => {
+      raf = requestAnimationFrame(loop);
+      if (modeRef.current !== appliedMode && !tweening) {
+        tweening = true;
+        controls.enabled = false;
+        controls.maxPolarAngle = modeRef.current === '2d' ? 0.35 : Math.PI * 0.49;
+      }
+      if (tweening) {
+        const want = modeRef.current === '2d' ? t2d : t3d;
+        camera.position.lerp(want, 0.12);
+        camera.lookAt(controls.target);
+        if (camera.position.distanceTo(want) < 1.5) {
+          camera.position.copy(want);
+          tweening = false;
+          appliedMode = modeRef.current;
+          controls.enabled = true;
+        }
+      }
+      controls.update();
+      renderer.render(scene, camera);
+      labelRenderer.render(scene, camera);
+    };
+    loop();
+
+    const ro = new ResizeObserver(() => {
+      W = wrap.clientWidth;
+      camera.aspect = W / H;
+      camera.updateProjectionMatrix();
+      renderer.setSize(W, H);
+      labelRenderer.setSize(W, H);
+    });
+    ro.observe(wrap);
+
+    return () => {
+      applyCutoffRef.current = null;
+      cancelAnimationFrame(raf);
+      ro.disconnect();
+      renderer.domElement.removeEventListener('pointermove', pick);
+      renderer.domElement.removeEventListener('pointerdown', onDown);
+      renderer.domElement.removeEventListener('click', onClick);
+      controls.dispose();
+      geo.dispose();
+      terrainMat.dispose();
+      pgeo.dispose();
+      pmat.dispose();
+      renderer.dispose();
+      wrap.removeChild(renderer.domElement);
+      wrap.removeChild(labelRenderer.domElement);
+      labelObjs.forEach((l) => l.obj.removeFromParent());
+    };
+  }, [data, height, navigate]);
+
+  // ---- drive the terrain from the scrubber ----
+  const atLatest = monthIdx >= months.length - 1;
+  useEffect(() => {
+    if (!applyCutoffRef.current || !months.length) return;
+    applyCutoffRef.current(atLatest ? FULL : `${months[monthIdx]}-31`);
+  }, [monthIdx, months, atLatest]);
+
+  // ---- play ----
+  useEffect(() => {
+    if (!playing || !months.length) return;
+    const id = window.setInterval(() => {
+      setMonthIdx((i) => {
+        if (i >= months.length - 1) {
+          setPlaying(false);
+          return i;
+        }
+        return i + 1;
+      });
+    }, 700);
+    return () => window.clearInterval(id);
+  }, [playing, months]);
+
+  if (err) return <div className="graph-caption" style={{ padding: '2rem 0' }}>{err}</div>;
+
+  return (
+    <div ref={wrapRef} style={{ position: 'relative', width: '100%', height }}>
+      <div style={{ position: 'absolute', top: 10, left: 12, zIndex: 2, color: 'rgba(233,230,224,0.6)', font: '12px system-ui', pointerEvents: 'none' }}>
+        {data ? `${data.point_count} notes · ${data.themes.length} themes · drag to orbit, scroll to zoom` : 'loading…'}
+      </div>
+      <button
+        type="button"
+        onClick={() => setMode((m) => (m === '3d' ? '2d' : '3d'))}
+        style={{ position: 'absolute', top: 10, right: 12, zIndex: 2, cursor: 'pointer', background: 'rgba(20,24,30,0.9)', color: '#e9e6e0', border: '1px solid rgba(120,180,205,0.4)', borderRadius: 8, padding: '5px 12px', font: '12px system-ui' }}
+      >
+        {mode === '3d' ? '2D' : '3D'}
+      </button>
+
+      {months.length > 1 && (
+        <div
+          style={{
+            position: 'absolute', bottom: 12, left: 16, right: 16, zIndex: 2,
+            display: 'flex', alignItems: 'center', gap: 12,
+            background: 'rgba(16,20,26,0.82)', border: '1px solid rgba(120,180,205,0.25)',
+            borderRadius: 10, padding: '7px 12px',
+          }}
+        >
+          <button
+            type="button"
+            onClick={() => {
+              if (atLatest) setMonthIdx(0);
+              setPlaying((p) => !p);
+            }}
+            style={{ cursor: 'pointer', background: 'none', border: 'none', color: '#7fd6e6', font: '13px system-ui' }}
+            aria-label={playing ? 'pause' : 'play'}
+          >
+            {playing ? '⏸' : '▶'}
+          </button>
+          <input
+            type="range"
+            min={0}
+            max={months.length - 1}
+            value={monthIdx}
+            onChange={(e) => {
+              setPlaying(false);
+              setMonthIdx(Number(e.target.value));
+            }}
+            style={{ flex: 1, accentColor: '#7fd6e6' }}
+          />
+          <span style={{ color: 'rgba(233,230,224,0.85)', font: '12px system-ui', minWidth: 92, textAlign: 'right' }}>
+            {atLatest ? 'all time' : months[monthIdx]}
+          </span>
+        </div>
+      )}
+
+      {hover && (
+        <div
+          style={{
+            position: 'absolute', zIndex: 3, pointerEvents: 'none',
+            left: Math.min(hover.mx + 14, (wrapRef.current?.clientWidth ?? 0) - 250),
+            top: hover.my + 14, maxWidth: 250,
+            background: 'rgba(18,22,28,0.96)', border: '1px solid rgba(120,180,205,0.4)',
+            borderRadius: 8, padding: '8px 10px', color: '#e9e6e0', font: '12px system-ui',
+            boxShadow: '0 8px 26px rgba(0,0,0,0.55)',
+          }}
+        >
+          <div style={{ color: '#7fd6e6', fontSize: 11, marginBottom: 3 }}>
+            {hover.p.theme}{hover.p.date ? ` · ${hover.p.date}` : ''}
+          </div>
+          <div style={{ lineHeight: 1.35 }}>{hover.p.title}</div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/console-ui/src/components/KnowledgeTerrain.tsx
+++ b/console-ui/src/components/KnowledgeTerrain.tsx
@@ -234,6 +234,12 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
         return { th, el, obj };
       });
 
+    // Interaction state, hoisted so `applyCutoff` can reset a stale hover when
+    // the visible set shrinks under it.
+    let hoverSlot = -1;
+    let downX = 0;
+    let downY = 0;
+
     // ---- rebuild terrain/points/labels for a date cutoff ----
     const applyCutoff = (cutoff: string) => {
       const vis = data.points.filter((p) => !p.date || p.date <= cutoff);
@@ -256,6 +262,12 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
       pgeo.setDrawRange(0, vis.length);
       pgeo.attributes.position.needsUpdate = true;
 
+      // The hovered/marked point may have just dropped out of the visible set;
+      // clear it so `onClick` can't read a now-out-of-range `visibleIdx` slot.
+      hoverSlot = -1;
+      mark.visible = false;
+      setHover(null);
+
       const seen = new Set(vis.map((p) => p.theme));
       for (const l of labelObjs) {
         if (seen.has(l.th.label)) {
@@ -275,13 +287,12 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
     const ray = new THREE.Raycaster();
     ray.params.Points = { threshold: 2.4 };
     const ndc = new THREE.Vector2();
-    let hoverSlot = -1;
-    let downX = 0;
-    let downY = 0;
     const pick = (ev: PointerEvent) => {
-      const rect = renderer.domElement.getBoundingClientRect();
-      ndc.x = ((ev.clientX - rect.left) / rect.width) * 2 - 1;
-      ndc.y = -((ev.clientY - rect.top) / rect.height) * 2 + 1;
+      // offsetX/Y are canvas-relative and reflow-free — avoids the layout
+      // thrash of getBoundingClientRect() on every pointermove. W/H track the
+      // canvas size via the ResizeObserver below.
+      ndc.x = (ev.offsetX / W) * 2 - 1;
+      ndc.y = -(ev.offsetY / H) * 2 + 1;
       ray.setFromCamera(ndc, camera);
       const hits = ray.intersectObject(points, false);
       const hit = hits.find((h) => (h.index ?? -1) < visibleIdx.length);
@@ -293,7 +304,7 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
           parr[hoverSlot * 3], parr[hoverSlot * 3 + 1], parr[hoverSlot * 3 + 2],
         ]);
         mark.geometry.attributes.position.needsUpdate = true;
-        setHover({ mx: ev.clientX - rect.left, my: ev.clientY - rect.top, p });
+        setHover({ mx: ev.offsetX, my: ev.offsetY, p });
         renderer.domElement.style.cursor = 'pointer';
       } else {
         hoverSlot = -1;
@@ -307,10 +318,10 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
       downY = e.clientY;
     };
     const onClick = (e: MouseEvent) => {
-      if (hoverSlot < 0) return;
+      if (hoverSlot < 0 || hoverSlot >= visibleIdx.length) return;
       if (Math.hypot(e.clientX - downX, e.clientY - downY) > 5) return; // a drag, not a click
       const p = data.points[visibleIdx[hoverSlot]];
-      if (!p.sha) return; // pack not ledger-tracked → no source page to open
+      if (!p?.sha) return; // pack not in the index → no /library page to open
       navigate(`/library/${encodeURIComponent(p.sha)}`);
     };
     renderer.domElement.addEventListener('pointermove', pick);
@@ -367,7 +378,15 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
       geo.dispose();
       terrainMat.dispose();
       pgeo.dispose();
+      // material.dispose() does NOT release its texture map — each glowTexture()
+      // is a separate GPU resource. Dispose points + mark geometry/material/map
+      // so remounts (List/Graph/Terrain tab switches) don't leak.
+      pmat.map?.dispose();
       pmat.dispose();
+      mark.geometry.dispose();
+      const markMat = mark.material as THREE.PointsMaterial;
+      markMat.map?.dispose();
+      markMat.dispose();
       renderer.dispose();
       wrap.removeChild(renderer.domElement);
       wrap.removeChild(labelRenderer.domElement);

--- a/console-ui/src/components/KnowledgeTerrain.tsx
+++ b/console-ui/src/components/KnowledgeTerrain.tsx
@@ -60,6 +60,7 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
   // Flag, not a message — translate at render so a locale toggle doesn't retrigger
   // the fetch effect (which would replace `data` and rebuild the whole scene).
   const [failed, setFailed] = useState(false);
+  const [webglFailed, setWebglFailed] = useState(false);
   const [mode, setMode] = useState<'3d' | '2d'>('3d');
   const modeRef = useRef(mode);
   modeRef.current = mode;
@@ -99,27 +100,41 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
     const H = height;
 
     const [minx, miny, maxx, maxy] = data.bounds;
-    const sx = (v: number) => ((v - minx) / Math.max(maxx - minx, 1e-6) - 0.5) * SIZE;
-    const sy = (v: number) => ((v - miny) / Math.max(maxy - miny, 1e-6) - 0.5) * SIZE;
+    // One uniform scale (max span) keeps the backend's aspect ratio — scaling
+    // each axis to SIZE independently would stretch a 100×50 layout to 220×220,
+    // distorting semantic angles/distances. Center the shorter axis.
+    const spanMax = Math.max(maxx - minx, maxy - miny, 1e-6);
+    const sx = (v: number) => ((v - minx) - (maxx - minx) / 2) / spanMax * SIZE;
+    const sy = (v: number) => ((v - miny) - (maxy - miny) / 2) / spanMax * SIZE;
 
     // Separable Gaussian kernel for the KDE.
     const kern: number[] = [];
     const R = Math.ceil(SIGMA * 3);
     for (let i = -R; i <= R; i++) kern.push(Math.exp(-(i * i) / (2 * SIGMA * SIGMA)));
     const ksum = kern.reduce((a, b) => a + b, 0);
+    // Zero-pad the separable Gaussian: SKIP out-of-range taps rather than
+    // clamping to the border cell. Clamping re-samples an edge point once per
+    // out-of-range tap (~22× inflation for a corner point), so it — not a real
+    // cluster — would set fullMax and flatten every genuine peak.
     const blur = (src: Float32Array) => {
       const h = new Float32Array(GRID * GRID);
       for (let y = 0; y < GRID; y++)
         for (let x = 0; x < GRID; x++) {
           let s = 0;
-          for (let k = -R; k <= R; k++) s += src[y * GRID + Math.min(GRID - 1, Math.max(0, x + k))] * kern[k + R];
+          for (let k = -R; k <= R; k++) {
+            const xx = x + k;
+            if (xx >= 0 && xx < GRID) s += src[y * GRID + xx] * kern[k + R];
+          }
           h[y * GRID + x] = s / ksum;
         }
       const o = new Float32Array(GRID * GRID);
       for (let y = 0; y < GRID; y++)
         for (let x = 0; x < GRID; x++) {
           let s = 0;
-          for (let k = -R; k <= R; k++) s += h[Math.min(GRID - 1, Math.max(0, y + k)) * GRID + x] * kern[k + R];
+          for (let k = -R; k <= R; k++) {
+            const yy = y + k;
+            if (yy >= 0 && yy < GRID) s += h[yy * GRID + x] * kern[k + R];
+          }
           o[y * GRID + x] = s / ksum;
         }
       return o;
@@ -162,7 +177,16 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
     const camera = new THREE.PerspectiveCamera(45, W / H, 1, SIZE * 6);
     camera.position.set(0, HEIGHT * 3.2, SIZE * 0.82);
 
-    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    // WebGLRenderer throws on clients where WebGL is unavailable/disabled
+    // (GPU-off browsers, locked-down webviews). Catch it so selecting Terrain
+    // shows a fallback message instead of unmounting the whole app.
+    let renderer: THREE.WebGLRenderer;
+    try {
+      renderer = new THREE.WebGLRenderer({ antialias: true });
+    } catch {
+      setWebglFailed(true);
+      return;
+    }
     renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
     renderer.setSize(W, H);
     renderer.domElement.style.borderRadius = '12px';
@@ -456,6 +480,12 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
     return (
       <div className="graph-caption" style={{ padding: '2rem 0' }}>
         {t('knowledge.terrainNotBuilt')}
+      </div>
+    );
+  if (webglFailed)
+    return (
+      <div className="graph-caption" style={{ padding: '2rem 0' }}>
+        {t('knowledge.terrainNoWebgl')}
       </div>
     );
 

--- a/console-ui/src/components/KnowledgeTerrain.tsx
+++ b/console-ui/src/components/KnowledgeTerrain.tsx
@@ -57,7 +57,9 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
   // their text without rebuilding the WebGL scene.
   const labelHandlesRef = useRef<{ el: HTMLDivElement; th: TTheme }[]>([]);
   const [data, setData] = useState<Terrain | null>(null);
-  const [err, setErr] = useState<string | null>(null);
+  // Flag, not a message — translate at render so a locale toggle doesn't retrigger
+  // the fetch effect (which would replace `data` and rebuild the whole scene).
+  const [failed, setFailed] = useState(false);
   const [mode, setMode] = useState<'3d' | '2d'>('3d');
   const modeRef = useRef(mode);
   modeRef.current = mode;
@@ -78,11 +80,11 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
     fetch('/api/terrain')
       .then((r) => (r.ok ? r.json() : Promise.reject(new Error('not built'))))
       .then((d: Terrain) => !off && setData(d))
-      .catch(() => !off && setErr(t('knowledge.terrainNotBuilt')));
+      .catch(() => !off && setFailed(true));
     return () => {
       off = true;
     };
-  }, [t]);
+  }, []);
 
   // Default the scrubber to "all" once months are known.
   useEffect(() => {
@@ -298,17 +300,19 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
     const ray = new THREE.Raycaster();
     ray.params.Points = { threshold: 2.4 };
     const ndc = new THREE.Vector2();
-    const pick = (ev: PointerEvent) => {
-      // offsetX/Y are canvas-relative and reflow-free — avoids the layout
-      // thrash of getBoundingClientRect() on every pointermove. W/H track the
-      // canvas size via the ResizeObserver below.
-      ndc.x = (ev.offsetX / W) * 2 - 1;
-      ndc.y = -(ev.offsetY / H) * 2 + 1;
+    // Raycast a visible-point slot from canvas-relative coords (offsetX/Y are
+    // reflow-free — no getBoundingClientRect layout thrash). Returns -1 on miss.
+    const slotAt = (offX: number, offY: number): number => {
+      ndc.x = (offX / W) * 2 - 1;
+      ndc.y = -(offY / H) * 2 + 1;
       ray.setFromCamera(ndc, camera);
       const hits = ray.intersectObject(points, false);
       const hit = hits.find((h) => (h.index ?? -1) < visibleIdx.length);
-      if (hit) {
-        hoverSlot = hit.index ?? -1;
+      return hit ? hit.index ?? -1 : -1;
+    };
+    const pick = (ev: PointerEvent) => {
+      hoverSlot = slotAt(ev.offsetX, ev.offsetY);
+      if (hoverSlot >= 0) {
         const p = data.points[visibleIdx[hoverSlot]];
         mark.visible = true;
         (mark.geometry.attributes.position as THREE.BufferAttribute).copyArray([
@@ -318,7 +322,6 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
         setHover({ mx: ev.offsetX, my: ev.offsetY, p });
         renderer.domElement.style.cursor = 'pointer';
       } else {
-        hoverSlot = -1;
         mark.visible = false;
         setHover(null);
         renderer.domElement.style.cursor = 'grab';
@@ -329,9 +332,12 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
       downY = e.clientY;
     };
     const onClick = (e: MouseEvent) => {
-      if (hoverSlot < 0 || hoverSlot >= visibleIdx.length) return;
       if (Math.hypot(e.clientX - downX, e.clientY - downY) > 5) return; // a drag, not a click
-      const p = data.points[visibleIdx[hoverSlot]];
+      // Raycast AT the click/tap point — a touch tap (or a click after wheel
+      // zoom) never fires pointermove, so hoverSlot would be stale or unset.
+      const slot = slotAt(e.offsetX, e.offsetY);
+      if (slot < 0 || slot >= visibleIdx.length) return;
+      const p = data.points[visibleIdx[slot]];
       if (!p?.sha) return; // pack not in the index → no /library page to open
       navigate(`/library/${encodeURIComponent(p.sha)}`);
     };
@@ -347,7 +353,12 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
     let tweening = false;
     const loop = () => {
       raf = requestAnimationFrame(loop);
-      if (modeRef.current !== appliedMode && !tweening) {
+      // Re-sync every frame the requested mode differs from the applied one, so
+      // a mid-tween reversal (3D→2D→3D) redirects `want` AND refreshes the polar
+      // limit. Guarding on `!tweening` would leave maxPolarAngle at the old
+      // value, clamping the camera short of its target and never re-enabling
+      // controls.
+      if (modeRef.current !== appliedMode) {
         tweening = true;
         controls.enabled = false;
         controls.maxPolarAngle = modeRef.current === '2d' ? 0.35 : Math.PI * 0.49;
@@ -441,7 +452,12 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
     [data],
   );
 
-  if (err) return <div className="graph-caption" style={{ padding: '2rem 0' }}>{err}</div>;
+  if (failed)
+    return (
+      <div className="graph-caption" style={{ padding: '2rem 0' }}>
+        {t('knowledge.terrainNotBuilt')}
+      </div>
+    );
 
   return (
     <div ref={wrapRef} style={{ position: 'relative', width: '100%', height }}>

--- a/console-ui/src/components/KnowledgeTerrain.tsx
+++ b/console-ui/src/components/KnowledgeTerrain.tsx
@@ -555,7 +555,11 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
           <div style={{ color: '#7fd6e6', fontSize: 11, marginBottom: 3 }}>
             {(() => {
               const th = themeById.get(hover.p.theme_id);
-              const name = th ? (lang === 'zh' ? th.label_zh : th.label) : hover.p.theme;
+              // Noise packs (theme_id < 0) are omitted from `themes`, so localize
+              // the unclassified label rather than falling back to English.
+              const name = th
+                ? (lang === 'zh' ? th.label_zh : th.label)
+                : t('knowledge.terrainUnclassified');
               return `${name}${hover.p.date ? ` · ${hover.p.date}` : ''}`;
             })()}
           </div>

--- a/console-ui/src/components/KnowledgeTerrain.tsx
+++ b/console-ui/src/components/KnowledgeTerrain.tsx
@@ -15,8 +15,8 @@ import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { CSS2DRenderer, CSS2DObject } from 'three/examples/jsm/renderers/CSS2DRenderer.js';
 
-type TPoint = { id: string; sha: string; title: string; date: string; theme: string; x: number; y: number };
-type TTheme = { id: number; label: string; cx: number; cy: number; count: number };
+type TPoint = { id: string; sha: string; title: string; date: string; theme: string; theme_id: number; x: number; y: number };
+type TTheme = { id: number; label: string; label_zh: string; cx: number; cy: number; count: number };
 type Terrain = {
   points: TPoint[];
   themes: TTheme[];
@@ -48,7 +48,14 @@ function glowTexture(): THREE.Texture {
 export default function KnowledgeTerrain({ height = 600 }: { height?: number }) {
   const wrapRef = useRef<HTMLDivElement>(null);
   const navigate = useNavigate();
-  const { t } = useI18n();
+  const { t, lang } = useI18n();
+  // Read inside the imperative three.js effect without making `lang` a build
+  // dep (a scene rebuild on every locale toggle would reset the camera).
+  const langRef = useRef(lang);
+  langRef.current = lang;
+  // Live handles to the floating theme labels so a locale toggle can rewrite
+  // their text without rebuilding the WebGL scene.
+  const labelHandlesRef = useRef<{ el: HTMLDivElement; th: TTheme }[]>([]);
   const [data, setData] = useState<Terrain | null>(null);
   const [err, setErr] = useState<string | null>(null);
   const [mode, setMode] = useState<'3d' | '2d'>('3d');
@@ -226,13 +233,14 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
       .slice(0, 16)
       .map((th) => {
         const el = document.createElement('div');
-        el.textContent = th.label;
+        el.textContent = langRef.current === 'zh' ? th.label_zh : th.label;
         el.style.cssText =
           'color:rgba(233,230,224,0.94);font:600 12px system-ui;text-shadow:0 1px 3px rgba(0,0,0,0.85);white-space:nowrap;';
         const obj = new CSS2DObject(el);
         scene.add(obj);
         return { th, el, obj };
       });
+    labelHandlesRef.current = labelObjs.map((l) => ({ el: l.el, th: l.th }));
 
     // Interaction state, hoisted so `applyCutoff` can reset a stale hover when
     // the visible set shrinks under it.
@@ -268,9 +276,12 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
       mark.visible = false;
       setHover(null);
 
-      const seen = new Set(vis.map((p) => p.theme));
+      // Key on community id, not the display label — two communities may share
+      // a label, and keying on the string would light both anchors when only
+      // one has visible points.
+      const seen = new Set(vis.map((p) => p.theme_id));
       for (const l of labelObjs) {
-        if (seen.has(l.th.label)) {
+        if (seen.has(l.th.id)) {
           l.el.style.display = '';
           const wx = sx(l.th.cx);
           const wz = sy(l.th.cy);
@@ -391,6 +402,7 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
       wrap.removeChild(renderer.domElement);
       wrap.removeChild(labelRenderer.domElement);
       labelObjs.forEach((l) => l.obj.removeFromParent());
+      labelHandlesRef.current = [];
     };
   }, [data, height, navigate]);
 
@@ -415,6 +427,19 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
     }, 700);
     return () => window.clearInterval(id);
   }, [playing, months]);
+
+  // ---- relabel the floating theme labels when the locale changes ----
+  useEffect(() => {
+    for (const l of labelHandlesRef.current) {
+      l.el.textContent = lang === 'zh' ? l.th.label_zh : l.th.label;
+    }
+  }, [lang, data]);
+
+  // Theme lookup for the localized tooltip (point carries only its community id).
+  const themeById = useMemo(
+    () => new Map((data?.themes ?? []).map((th) => [th.id, th] as const)),
+    [data],
+  );
 
   if (err) return <div className="graph-caption" style={{ padding: '2rem 0' }}>{err}</div>;
 
@@ -482,7 +507,11 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
           }}
         >
           <div style={{ color: '#7fd6e6', fontSize: 11, marginBottom: 3 }}>
-            {hover.p.theme}{hover.p.date ? ` · ${hover.p.date}` : ''}
+            {(() => {
+              const th = themeById.get(hover.p.theme_id);
+              const name = th ? (lang === 'zh' ? th.label_zh : th.label) : hover.p.theme;
+              return `${name}${hover.p.date ? ` · ${hover.p.date}` : ''}`;
+            })()}
           </div>
           <div style={{ lineHeight: 1.35 }}>{hover.p.title}</div>
         </div>

--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -203,6 +203,13 @@ export const en = {
   'knowledge.viewTerrain': 'Terrain',
   'knowledge.terrainCaption':
     'A themescape of the corpus: peaks are dense clusters (labelled by theme), each point a source. Hover a point to see the note. Built from the same embeddings as the themes.',
+  'knowledge.terrainHud': '{notes} notes · {themes} themes · drag to orbit, scroll to zoom',
+  'knowledge.terrainLoading': 'loading…',
+  'knowledge.terrainAllTime': 'all time',
+  'knowledge.terrainPlay': 'play',
+  'knowledge.terrainPause': 'pause',
+  'knowledge.terrainNotBuilt':
+    'Terrain not built yet — run `ovp2 crystal-terrain --vault-root <vault>`.',
   'knowledge.empty':
     'No claims in the crystal store yet — crystallize sources to build the knowledge layer.',
   'knowledge.untitledTheme': '(no theme)',

--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -210,6 +210,8 @@ export const en = {
   'knowledge.terrainPause': 'pause',
   'knowledge.terrainNotBuilt':
     'Terrain not built yet — run `ovp2 crystal-terrain --vault-root <vault>`.',
+  'knowledge.terrainNoWebgl':
+    'This 3D view needs WebGL, which is unavailable in this browser. Try the List or Graph view.',
   'knowledge.empty':
     'No claims in the crystal store yet — crystallize sources to build the knowledge layer.',
   'knowledge.untitledTheme': '(no theme)',

--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -212,6 +212,7 @@ export const en = {
     'Terrain not built yet — run `ovp2 crystal-terrain --vault-root <vault>`.',
   'knowledge.terrainNoWebgl':
     'This 3D view needs WebGL, which is unavailable in this browser. Try the List or Graph view.',
+  'knowledge.terrainUnclassified': 'Unclassified',
   'knowledge.empty':
     'No claims in the crystal store yet — crystallize sources to build the knowledge layer.',
   'knowledge.untitledTheme': '(no theme)',

--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -200,6 +200,9 @@ export const en = {
     'The ladder in plain language: source text → unit (a verifiable excerpt) → card (a readable understanding) → claim (a cross-source conclusion, always either durable or caveated).',
   'knowledge.viewList': 'List',
   'knowledge.viewGraph': 'Graph',
+  'knowledge.viewTerrain': 'Terrain',
+  'knowledge.terrainCaption':
+    'A themescape of the corpus: peaks are dense clusters (labelled by theme), each point a source. Hover a point to see the note. Built from the same embeddings as the themes.',
   'knowledge.empty':
     'No claims in the crystal store yet — crystallize sources to build the knowledge layer.',
   'knowledge.untitledTheme': '(no theme)',

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -197,6 +197,7 @@ export const zh: Record<keyof typeof en, string> = {
   'knowledge.terrainNotBuilt':
     '地形尚未生成——运行 `ovp2 crystal-terrain --vault-root <vault>`。',
   'knowledge.terrainNoWebgl': '该 3D 视图需要 WebGL，当前浏览器不可用。请改用列表或图谱视图。',
+  'knowledge.terrainUnclassified': '未分类',
   'knowledge.empty': '结晶库还没有主张——对源运行结晶流程以构建知识层。',
   'knowledge.untitledTheme': '（无主题）',
   'knowledge.claimCount': '{n} 条主张',

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -186,6 +186,9 @@ export const zh: Record<keyof typeof en, string> = {
     '一句话的阶梯：原文 → unit（可验证摘录）→ card（可读理解）→ claim（跨源结论，durable/caveated 二态）。',
   'knowledge.viewList': '列表',
   'knowledge.viewGraph': '图谱',
+  'knowledge.viewTerrain': '地形',
+  'knowledge.terrainCaption':
+    '语料的"知识地形":山峰是密集的聚类(按主题命名),每个点是一个源。悬停某点看那条笔记。与主题同源,基于同一套 embedding。',
   'knowledge.empty': '结晶库还没有主张——对源运行结晶流程以构建知识层。',
   'knowledge.untitledTheme': '（无主题）',
   'knowledge.claimCount': '{n} 条主张',

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -196,6 +196,7 @@ export const zh: Record<keyof typeof en, string> = {
   'knowledge.terrainPause': '暂停',
   'knowledge.terrainNotBuilt':
     '地形尚未生成——运行 `ovp2 crystal-terrain --vault-root <vault>`。',
+  'knowledge.terrainNoWebgl': '该 3D 视图需要 WebGL，当前浏览器不可用。请改用列表或图谱视图。',
   'knowledge.empty': '结晶库还没有主张——对源运行结晶流程以构建知识层。',
   'knowledge.untitledTheme': '（无主题）',
   'knowledge.claimCount': '{n} 条主张',

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -189,6 +189,13 @@ export const zh: Record<keyof typeof en, string> = {
   'knowledge.viewTerrain': '地形',
   'knowledge.terrainCaption':
     '语料的"知识地形":山峰是密集的聚类(按主题命名),每个点是一个源。悬停某点看那条笔记。与主题同源,基于同一套 embedding。',
+  'knowledge.terrainHud': '{notes} 条笔记 · {themes} 个主题 · 拖拽旋转,滚轮缩放',
+  'knowledge.terrainLoading': '加载中…',
+  'knowledge.terrainAllTime': '全部时间',
+  'knowledge.terrainPlay': '播放',
+  'knowledge.terrainPause': '暂停',
+  'knowledge.terrainNotBuilt':
+    '地形尚未生成——运行 `ovp2 crystal-terrain --vault-root <vault>`。',
   'knowledge.empty': '结晶库还没有主张——对源运行结晶流程以构建知识层。',
   'knowledge.untitledTheme': '（无主题）',
   'knowledge.claimCount': '{n} 条主张',

--- a/console-ui/src/pages/KnowledgePage.tsx
+++ b/console-ui/src/pages/KnowledgePage.tsx
@@ -11,9 +11,11 @@
  * so the hash resolves through the model and forwards to
  * /knowledge/theme/:t#<claim_id> where the card scrolls into view. */
 import { Link, Navigate, useLocation, useSearchParams } from 'react-router-dom';
-import { useEffect, useState } from 'react';
+import { lazy, Suspense, useEffect, useState } from 'react';
 import KnowledgeGraph from '../components/KnowledgeGraph';
-import KnowledgeTerrain from '../components/KnowledgeTerrain';
+// Terrain pulls in three.js (~500KB) — load it only when the Terrain tab is
+// selected so it stays out of the initial portal bundle.
+const KnowledgeTerrain = lazy(() => import('../components/KnowledgeTerrain'));
 import { AgeLabel, EmptyState, ModelGate, PageHelp } from '../components/ui';
 import { useI18n } from '../i18n';
 import { fetchThemes } from '../lib/api';
@@ -159,7 +161,9 @@ function KnowledgeBody({ model }: { model: IndexModel }) {
 
       {view === 'terrain' && (
         <>
-          <KnowledgeTerrain height={560} />
+          <Suspense fallback={<div className="legacy-loading">{t('common.loading')}</div>}>
+            <KnowledgeTerrain height={560} />
+          </Suspense>
           <div className="graph-caption">{t('knowledge.terrainCaption')}</div>
         </>
       )}

--- a/console-ui/src/pages/KnowledgePage.tsx
+++ b/console-ui/src/pages/KnowledgePage.tsx
@@ -13,6 +13,7 @@
 import { Link, Navigate, useLocation, useSearchParams } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import KnowledgeGraph from '../components/KnowledgeGraph';
+import KnowledgeTerrain from '../components/KnowledgeTerrain';
 import { AgeLabel, EmptyState, ModelGate, PageHelp } from '../components/ui';
 import { useI18n } from '../i18n';
 import { fetchThemes } from '../lib/api';
@@ -20,7 +21,7 @@ import { isMiscTheme, themeWall, type ThemeGroup } from '../lib/derive';
 import type { IndexModel, ThemeCount } from '../lib/types';
 import { useModel } from '../model';
 
-type View = 'list' | 'graph';
+type View = 'list' | 'graph' | 'terrain';
 
 function themePath(theme: string): string {
   return `/knowledge/theme/${encodeURIComponent(theme)}`;
@@ -76,13 +77,14 @@ function ThemeCard({ group }: { group: ThemeGroup }) {
 function KnowledgeBody({ model }: { model: IndexModel }) {
   const { t } = useI18n();
   const [params, setParams] = useSearchParams();
-  const view: View = params.get('view') === 'graph' ? 'graph' : 'list';
+  const rawView = params.get('view');
+  const view: View = rawView === 'graph' ? 'graph' : rawView === 'terrain' ? 'terrain' : 'list';
   const setView = (next: View) => {
     setParams(
       (prev) => {
         const p = new URLSearchParams(prev);
-        if (next === 'graph') p.set('view', 'graph');
-        else p.delete('view');
+        if (next === 'list') p.delete('view');
+        else p.set('view', next);
         return p;
       },
       { replace: true },
@@ -124,6 +126,13 @@ function KnowledgeBody({ model }: { model: IndexModel }) {
         >
           {t('knowledge.viewGraph')}
         </button>
+        <button
+          type="button"
+          className={view === 'terrain' ? 'active' : ''}
+          onClick={() => setView('terrain')}
+        >
+          {t('knowledge.viewTerrain')}
+        </button>
       </div>
 
       {view === 'list' && (
@@ -145,6 +154,13 @@ function KnowledgeBody({ model }: { model: IndexModel }) {
         <>
           <KnowledgeGraph scope="global" height={560} />
           <div className="graph-caption">{t('knowledge.graphCaption')}</div>
+        </>
+      )}
+
+      {view === 'terrain' && (
+        <>
+          <KnowledgeTerrain height={560} />
+          <div className="graph-caption">{t('knowledge.terrainCaption')}</div>
         </>
       )}
     </>

--- a/crates/ovp-cli/src/commands/crystal_terrain.rs
+++ b/crates/ovp-cli/src/commands/crystal_terrain.rs
@@ -42,17 +42,22 @@ struct TerrainPoint {
     title: String,
     /// `YYYY-MM-DD` parsed from the pack case_id, else "".
     date: String,
+    /// English theme label (fallback); the client localizes via `theme_id`.
     theme: String,
+    /// Community id — the STABLE key. Two communities may share a display label,
+    /// so the client keys visible-theme identity on this, not the label string.
+    theme_id: i64,
     x: f64,
     y: f64,
 }
 
-/// A community label, treating the unclassified bucket (negative id) as
-/// "Unclassified" rather than a raw "Cluster -1".
-fn theme_label(id: i64, labels: &BTreeMap<i64, String>) -> String {
+/// A community label, treating the unclassified bucket (negative id) as the
+/// caller-supplied localized "unclassified" string rather than a raw
+/// "Cluster -1". `labels` is the locale-specific community→label map.
+fn theme_label(id: i64, labels: &BTreeMap<i64, String>, unclassified: &str) -> String {
     labels.get(&id).cloned().unwrap_or_else(|| {
         if id < 0 {
-            "Unclassified".to_string()
+            unclassified.to_string()
         } else {
             format!("Cluster {id}")
         }
@@ -63,6 +68,9 @@ fn theme_label(id: i64, labels: &BTreeMap<i64, String>) -> String {
 struct TerrainTheme {
     id: i64,
     label: String,
+    /// Chinese label — the portal picks `label`/`label_zh` by active locale so
+    /// terrain labels + tooltips follow the rest of the UI.
+    label_zh: String,
     /// Centroid of the theme's points (peak/label anchor).
     cx: f64,
     cy: f64,
@@ -228,14 +236,27 @@ fn normalize(pos: &mut [(f64, f64)]) -> [f64; 4] {
         maxx = maxx.max(x);
         maxy = maxy.max(y);
     }
-    let sx = if maxx > minx { 100.0 / (maxx - minx) } else { 1.0 };
-    let sy = if maxy > miny { 100.0 / (maxy - miny) } else { 1.0 };
-    let s = sx.min(sy);
-    for p in pos.iter_mut() {
-        p.0 = (p.0 - minx) * s;
-        p.1 = (p.1 - miny) * s;
+    let spanx = maxx - minx;
+    let spany = maxy - miny;
+    // Single pack (or a collinear layout) has zero span on an axis. Scaling by
+    // that would pin every coordinate to 0, which the frontend maps to the map
+    // EDGE (-SIZE/2). Center degenerate axes at 50 and report a nonzero bound so
+    // the lone hill sits in the middle, not the corner.
+    let span = spanx.max(spany);
+    if span <= 1e-9 {
+        for p in pos.iter_mut() {
+            *p = (50.0, 50.0);
+        }
+        return [0.0, 0.0, 100.0, 100.0];
     }
-    [0.0, 0.0, (maxx - minx) * s, (maxy - miny) * s]
+    let s = 100.0 / span;
+    for p in pos.iter_mut() {
+        p.0 = if spanx > 1e-9 { (p.0 - minx) * s } else { 50.0 };
+        p.1 = if spany > 1e-9 { (p.1 - miny) * s } else { 50.0 };
+    }
+    let w = if spanx > 1e-9 { spanx * s } else { 100.0 };
+    let h = if spany > 1e-9 { spany * s } else { 100.0 };
+    [0.0, 0.0, w, h]
 }
 
 pub fn run(args: TerrainArgs) -> Result<(), CliError> {
@@ -257,6 +278,11 @@ pub fn run(args: TerrainArgs) -> Result<(), CliError> {
         .communities
         .iter()
         .map(|c| (c.id, c.label.clone()))
+        .collect();
+    let community_label_zh: BTreeMap<i64, String> = themes
+        .communities
+        .iter()
+        .map(|c| (c.id, c.label_zh.clone()))
         .collect();
 
     // Link sha (for /library/:sha) is the source CONTENT sha, joined from the
@@ -346,7 +372,8 @@ pub fn run(args: TerrainArgs) -> Result<(), CliError> {
             sha: sha.clone(),
             title: title.clone(),
             date: date.clone(),
-            theme: theme_label(*community, &community_label),
+            theme: theme_label(*community, &community_label, "Unclassified"),
+            theme_id: *community,
             x: *x,
             y: *y,
         })
@@ -365,7 +392,8 @@ pub fn run(args: TerrainArgs) -> Result<(), CliError> {
             let _ = ci;
             TerrainTheme {
                 id,
-                label: theme_label(id, &community_label),
+                label: theme_label(id, &community_label, "Unclassified"),
+                label_zh: theme_label(id, &community_label_zh, "未分类"),
                 cx: sx / n,
                 cy: sy / n,
                 count: members.len(),
@@ -475,6 +503,22 @@ mod tests {
                 assert!(d > 0.5, "islands {i},{j} too close: {d}");
             }
         }
+    }
+
+    #[test]
+    fn normalize_centers_degenerate_layouts() {
+        // Single point → centered, nonzero bound (not pinned to the edge).
+        let mut one = [(7.0, 7.0)];
+        let b = normalize(&mut one);
+        assert_eq!(one[0], (50.0, 50.0));
+        assert!(b[2] > 0.0 && b[3] > 0.0, "bound must be nonzero: {b:?}");
+        // Collinear on x (zero y-span) → y centered, x spread across the box.
+        let mut row = [(0.0, 5.0), (10.0, 5.0)];
+        let bb = normalize(&mut row);
+        assert_eq!(row[0].1, 50.0);
+        assert_eq!(row[1].1, 50.0);
+        assert!((row[0].0 - 0.0).abs() < 1e-9 && (row[1].0 - 100.0).abs() < 1e-9);
+        assert!(bb[3] > 0.0, "degenerate y-bound must be nonzero: {bb:?}");
     }
 
     #[test]

--- a/crates/ovp-cli/src/commands/crystal_terrain.rs
+++ b/crates/ovp-cli/src/commands/crystal_terrain.rs
@@ -1,12 +1,18 @@
 //! `crystal-terrain` — a "knowledge terrain" projection (themescape).
 //!
 //! Reuses the SAME semantic layer as `crystal-themes` (cached multilingual
-//! embeddings + the kNN graph + the community→label assignment in themes.json)
-//! and adds ONE thing that view lacks: a 2D position per pack. A deterministic
-//! force layout over the kNN graph pulls semantically-similar packs together, so
-//! communities fall out as spatial islands. The frontend renders density
-//! contours over these points (à la flomo's map) — peaks = dense clusters,
-//! labelled by the existing theme names.
+//! embeddings + the kNN-graph Louvain communities + the community→label
+//! assignment in themes.json) and adds ONE thing that view lacks: a 2D position
+//! per pack. Layout is TWO-LEVEL and only the coarse level is semantic. First,
+//! community centroids are placed by a deterministic force layout that attracts
+//! by cosine similarity, so related THEMES form adjacent islands (between-island
+//! distance is meaningful). Then, within an island, each pack sits at a radius
+//! set by how tightly it fits the theme centroid (tight → the peak, loose → the
+//! rim) at a fixed pseudo-random ANGLE. That angle is NOT a pairwise-kNN
+//! embedding, so within-island neighbor distance is not semantic — the islands
+//! and their density peaks are the signal, not fine pack-to-pack placement.
+//! The frontend renders density contours over these points (à la flomo's map) —
+//! peaks = dense theme clusters, labelled by the existing theme names.
 //!
 //! Output: `.ovp/crystal/terrain.json`, a rebuildable PROJECTION (never a
 //! ledger). Needs a WARM embedding cache; packs without a cached vector are
@@ -322,10 +328,19 @@ pub fn run(args: TerrainArgs) -> Result<(), CliError> {
         "crystal-terrain: placing {} pack(s) across their theme islands …",
         vectors.len()
     );
-    // Group member indices by community; compute per-community centroid.
+    // Group member indices by REAL community (id ≥ 0). Negative ids are the
+    // themes contract's noise/singleton bucket — NOT one community. Clustering
+    // them would build a synthetic "Unclassified" centroid that, on a sparse
+    // corpus, becomes the tallest peak. Collect them separately and scatter them
+    // as low-density background so they never form an island.
     let mut by_comm: BTreeMap<i64, Vec<usize>> = BTreeMap::new();
+    let mut noise: Vec<usize> = Vec::new();
     for (i, (_, _, _, _, c)) in meta.iter().enumerate() {
-        by_comm.entry(*c).or_default().push(i);
+        if *c < 0 {
+            noise.push(i);
+        } else {
+            by_comm.entry(*c).or_default().push(i);
+        }
     }
     let comm_ids: Vec<i64> = by_comm.keys().copied().collect();
     let centroids: Vec<Vec<f32>> = comm_ids
@@ -360,6 +375,28 @@ pub fn run(args: TerrainArgs) -> Result<(), CliError> {
             let r = radius * (1.0 - tight).sqrt(); // peak-concentrated
             let theta = std::f64::consts::TAU * rng.next_f64();
             pos[m] = (cx + r * theta.cos(), cy + r * theta.sin());
+        }
+    }
+    // Scatter noise packs uniformly across the islands' bounding box (a unit box
+    // if there are no real communities). Uniform spread = flat KDE = no peak.
+    if !noise.is_empty() {
+        let real: Vec<usize> = by_comm.values().flatten().copied().collect();
+        let (mut nx0, mut ny0, mut nx1, mut ny1) = (f64::MAX, f64::MAX, f64::MIN, f64::MIN);
+        for &m in &real {
+            nx0 = nx0.min(pos[m].0);
+            ny0 = ny0.min(pos[m].1);
+            nx1 = nx1.max(pos[m].0);
+            ny1 = ny1.max(pos[m].1);
+        }
+        if real.is_empty() {
+            (nx0, ny0, nx1, ny1) = (-1.0, -1.0, 1.0, 1.0);
+        }
+        let mut rng = Rng(SEED ^ 0x5EED_1FED_C0FF_EE00);
+        for &m in &noise {
+            pos[m] = (
+                nx0 + rng.next_f64() * (nx1 - nx0),
+                ny0 + rng.next_f64() * (ny1 - ny0),
+            );
         }
     }
     let bounds = normalize(&mut pos);

--- a/crates/ovp-cli/src/commands/crystal_terrain.rs
+++ b/crates/ovp-cli/src/commands/crystal_terrain.rs
@@ -1,0 +1,395 @@
+//! `crystal-terrain` — a "knowledge terrain" projection (themescape).
+//!
+//! Reuses the SAME semantic layer as `crystal-themes` (cached multilingual
+//! embeddings + the kNN graph + the community→label assignment in themes.json)
+//! and adds ONE thing that view lacks: a 2D position per pack. A deterministic
+//! force layout over the kNN graph pulls semantically-similar packs together, so
+//! communities fall out as spatial islands. The frontend renders density
+//! contours over these points (à la flomo's map) — peaks = dense clusters,
+//! labelled by the existing theme names.
+//!
+//! Output: `.ovp/crystal/terrain.json`, a rebuildable PROJECTION (never a
+//! ledger). Needs a WARM embedding cache; packs without a cached vector are
+//! skipped (no model download here — parity with `crystal-themes`'s cache path).
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use ovp_domain::VaultLayout;
+use ovp_embed::cache as embed_cache;
+use ovp_embed::{EMBED_DIM, EMBED_MODEL_ID};
+use serde::Serialize;
+
+use crate::commands::crystal_themes::collect_docs;
+use crate::CliError;
+
+/// Deterministic layout seed (reproducible terrain across rebuilds).
+const SEED: u64 = 42;
+
+pub struct TerrainArgs {
+    pub vault_root: std::path::PathBuf,
+}
+
+#[derive(Serialize)]
+struct TerrainPoint {
+    id: String,
+    /// Content sha of the source — links the point to its `/library/:sha` page.
+    sha: String,
+    title: String,
+    /// `YYYY-MM-DD` parsed from the pack case_id, else "".
+    date: String,
+    theme: String,
+    x: f64,
+    y: f64,
+}
+
+/// A community label, treating the unclassified bucket (negative id) as
+/// "Unclassified" rather than a raw "Cluster -1".
+fn theme_label(id: i64, labels: &BTreeMap<i64, String>) -> String {
+    labels.get(&id).cloned().unwrap_or_else(|| {
+        if id < 0 {
+            "Unclassified".to_string()
+        } else {
+            format!("Cluster {id}")
+        }
+    })
+}
+
+#[derive(Serialize)]
+struct TerrainTheme {
+    id: i64,
+    label: String,
+    /// Centroid of the theme's points (peak/label anchor).
+    cx: f64,
+    cy: f64,
+    count: usize,
+}
+
+#[derive(Serialize)]
+struct Terrain {
+    schema: &'static str,
+    model: String,
+    point_count: usize,
+    bounds: [f64; 4], // [minx, miny, maxx, maxy]
+    themes: Vec<TerrainTheme>,
+    points: Vec<TerrainPoint>,
+}
+
+/// case_id looks like `<sha8>-<YYYY-MM-DD>_<title…>`; pull the date.
+fn date_from_case_id(case_id: &str) -> String {
+    // after the first '-': "YYYY-MM-DD_..."
+    let after = case_id.split_once('-').map(|(_, a)| a).unwrap_or("");
+    let date = after.split('_').next().unwrap_or("");
+    // must look like a date
+    if date.len() == 10 && date.as_bytes().get(4) == Some(&b'-') {
+        date.to_string()
+    } else {
+        String::new()
+    }
+}
+
+/// Tiny deterministic PRNG (splitmix64) so the layout is reproducible without a
+/// rand dependency.
+struct Rng(u64);
+impl Rng {
+    fn next_f64(&mut self) -> f64 {
+        self.0 = self.0.wrapping_add(0x9E3779B97F4A7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
+        ((z ^ (z >> 31)) >> 11) as f64 / (1u64 << 53) as f64
+    }
+    fn unit(&mut self) -> f64 {
+        self.next_f64() * 2.0 - 1.0
+    }
+}
+
+/// Mean (L2-normalized) vector per community — the cluster's semantic center.
+fn centroid(members: &[usize], vectors: &[Vec<f32>], dim: usize) -> Vec<f32> {
+    let mut c = vec![0.0f32; dim];
+    for &m in members {
+        for (ci, vi) in c.iter_mut().zip(&vectors[m]) {
+            *ci += *vi;
+        }
+    }
+    let norm = c.iter().map(|v| v * v).sum::<f32>().sqrt().max(1e-6);
+    for v in &mut c {
+        *v /= norm;
+    }
+    c
+}
+
+/// Weighted Fruchterman–Reingold over the FEW community centroids: every pair
+/// attracts by cosine similarity (similar themes end up adjacent) and repels so
+/// they spread into separated islands. Tiny N → many iterations are free.
+fn layout_communities(centroids: &[Vec<f32>]) -> Vec<(f64, f64)> {
+    let n = centroids.len();
+    if n == 0 {
+        return vec![];
+    }
+    if n == 1 {
+        return vec![(0.0, 0.0)];
+    }
+    let mut rng = Rng(SEED);
+    // Seed on a circle so they start separated, then relax.
+    let mut pos: Vec<(f64, f64)> = (0..n)
+        .map(|i| {
+            let a = std::f64::consts::TAU * i as f64 / n as f64;
+            (a.cos() + 0.01 * rng.unit(), a.sin() + 0.01 * rng.unit())
+        })
+        .collect();
+    let k = 2.0; // target spacing between islands
+    let mut temp = 1.0;
+    for _ in 0..800 {
+        let mut disp = vec![(0.0f64, 0.0f64); n];
+        for i in 0..n {
+            for j in (i + 1)..n {
+                let dx = pos[i].0 - pos[j].0;
+                let dy = pos[i].1 - pos[j].1;
+                let d = (dx * dx + dy * dy).sqrt().max(1e-6);
+                let (ux, uy) = (dx / d, dy / d);
+                let repel = k * k / d;
+                // Attraction scaled by cosine similarity of the two centroids.
+                let sim = ovp_embed::knn::cosine(&centroids[i], &centroids[j]).max(0.0);
+                let attract = sim * d * d / k;
+                let f = repel - attract;
+                disp[i].0 += ux * f;
+                disp[i].1 += uy * f;
+                disp[j].0 -= ux * f;
+                disp[j].1 -= uy * f;
+            }
+        }
+        for i in 0..n {
+            let (dx, dy) = disp[i];
+            let d = (dx * dx + dy * dy).sqrt().max(1e-9);
+            let step = d.min(temp);
+            pos[i].0 += dx / d * step;
+            pos[i].1 += dy / d * step;
+        }
+        temp *= 0.995;
+    }
+    pos
+}
+
+/// Rescale positions into a stable [0,100] box (bounds reported for the client).
+fn normalize(pos: &mut [(f64, f64)]) -> [f64; 4] {
+    if pos.is_empty() {
+        return [0.0, 0.0, 100.0, 100.0];
+    }
+    let (mut minx, mut miny, mut maxx, mut maxy) = (f64::MAX, f64::MAX, f64::MIN, f64::MIN);
+    for &(x, y) in pos.iter() {
+        minx = minx.min(x);
+        miny = miny.min(y);
+        maxx = maxx.max(x);
+        maxy = maxy.max(y);
+    }
+    let sx = if maxx > minx { 100.0 / (maxx - minx) } else { 1.0 };
+    let sy = if maxy > miny { 100.0 / (maxy - miny) } else { 1.0 };
+    let s = sx.min(sy);
+    for p in pos.iter_mut() {
+        p.0 = (p.0 - minx) * s;
+        p.1 = (p.1 - miny) * s;
+    }
+    [0.0, 0.0, (maxx - minx) * s, (maxy - miny) * s]
+}
+
+pub fn run(args: TerrainArgs) -> Result<(), CliError> {
+    let layout = VaultLayout::new();
+    let reader_root = args.vault_root.join(layout.reader_root());
+    let store = args.vault_root.join(layout.crystal_store_dir());
+    let themes_path = store.join("themes.json");
+    let cache_dir = args.vault_root.join(".ovp/cache/embeddings");
+
+    let themes = ovp_domain::crystal::themes::ThemesFile::load(&themes_path)
+        .map_err(|e| CliError::Io(format!("crystal-terrain: reading themes.json: {e}")))?
+        .ok_or_else(|| {
+            CliError::Io(format!(
+                "crystal-terrain: no themes.json at {} — run `ovp2 crystal-themes` first",
+                themes_path.display()
+            ))
+        })?;
+    let community_label: BTreeMap<i64, String> = themes
+        .communities
+        .iter()
+        .map(|c| (c.id, c.label.clone()))
+        .collect();
+
+    // Keep only packs that are themed AND have a cached vector (no model here).
+    let docs = collect_docs(&reader_root)?;
+    let mut vectors: Vec<Vec<f32>> = Vec::new();
+    let mut meta: Vec<(String, String, String, String, i64)> = Vec::new(); // id,sha,title,date,community
+    for d in &docs {
+        let Some(&community) = themes.packs.get(&d.case_id) else {
+            continue;
+        };
+        let Some(vec) = embed_cache::load(&cache_dir, &d.sha, EMBED_MODEL_ID, EMBED_DIM) else {
+            continue;
+        };
+        vectors.push(vec);
+        meta.push((
+            d.case_id.clone(),
+            d.sha.clone(),
+            d.title.clone(),
+            date_from_case_id(&d.case_id),
+            community,
+        ));
+    }
+    if vectors.is_empty() {
+        println!(
+            "crystal-terrain: no themed packs with cached embeddings under {} — nothing to map.",
+            reader_root.display()
+        );
+        return Ok(());
+    }
+
+    println!(
+        "crystal-terrain: placing {} pack(s) across their theme islands …",
+        vectors.len()
+    );
+    // Group member indices by community; compute per-community centroid.
+    let mut by_comm: BTreeMap<i64, Vec<usize>> = BTreeMap::new();
+    for (i, (_, _, _, _, c)) in meta.iter().enumerate() {
+        by_comm.entry(*c).or_default().push(i);
+    }
+    let comm_ids: Vec<i64> = by_comm.keys().copied().collect();
+    let centroids: Vec<Vec<f32>> = comm_ids
+        .iter()
+        .map(|c| centroid(&by_comm[c], &vectors, EMBED_DIM))
+        .collect();
+    // Spread the communities into islands (similar themes adjacent).
+    let comm_pos = layout_communities(&centroids);
+
+    // Place each member around its island center: radius from how tightly it
+    // fits the theme (cosine to centroid — tight → near the peak, loose → rim),
+    // angle deterministic per id. Dense centers = the contour peaks.
+    let mut pos = vec![(0.0f64, 0.0f64); vectors.len()];
+    for (ci, &cid) in comm_ids.iter().enumerate() {
+        let members = &by_comm[&cid];
+        let (cx, cy) = comm_pos[ci];
+        let sims: Vec<f64> = members
+            .iter()
+            .map(|&m| ovp_embed::knn::cosine(&vectors[m], &centroids[ci]).clamp(-1.0, 1.0))
+            .collect();
+        let (mut lo, mut hi) = (f64::MAX, f64::MIN);
+        for &s in &sims {
+            lo = lo.min(s);
+            hi = hi.max(s);
+        }
+        let span = (hi - lo).max(1e-6);
+        // Island radius grows with member count (bigger themes = bigger hills).
+        let radius = 0.28 * (members.len() as f64).sqrt();
+        let mut rng = Rng(SEED ^ (cid as u64).wrapping_mul(0x9E3779B97F4A7C15));
+        for (mi, &m) in members.iter().enumerate() {
+            let tight = (sims[mi] - lo) / span; // 1 = closest to centroid
+            let r = radius * (1.0 - tight).sqrt(); // peak-concentrated
+            let theta = std::f64::consts::TAU * rng.next_f64();
+            pos[m] = (cx + r * theta.cos(), cy + r * theta.sin());
+        }
+    }
+    let bounds = normalize(&mut pos);
+
+    let points: Vec<TerrainPoint> = meta
+        .iter()
+        .zip(pos.iter())
+        .map(|((id, sha, title, date, community), (x, y))| TerrainPoint {
+            id: id.clone(),
+            sha: sha.clone(),
+            title: title.clone(),
+            date: date.clone(),
+            theme: theme_label(*community, &community_label),
+            x: *x,
+            y: *y,
+        })
+        .collect();
+    // Theme label anchor = the normalized island center.
+    let mut themes_out: Vec<TerrainTheme> = comm_ids
+        .iter()
+        .enumerate()
+        .map(|(ci, &id)| {
+            // Recompute the island center in normalized space from its members.
+            let members = &by_comm[&id];
+            let (sx, sy) = members
+                .iter()
+                .fold((0.0, 0.0), |(ax, ay), &m| (ax + pos[m].0, ay + pos[m].1));
+            let n = members.len().max(1) as f64;
+            let _ = ci;
+            TerrainTheme {
+                id,
+                label: theme_label(id, &community_label),
+                cx: sx / n,
+                cy: sy / n,
+                count: members.len(),
+            }
+        })
+        .collect();
+    themes_out.sort_by(|a, b| b.count.cmp(&a.count));
+
+    let terrain = Terrain {
+        schema: "ovp.crystal.terrain/v1",
+        model: EMBED_MODEL_ID.to_string(),
+        point_count: points.len(),
+        bounds,
+        themes: themes_out,
+        points,
+    };
+    write_terrain(&store, &terrain)?;
+    println!(
+        "crystal-terrain: {} point(s), {} theme(s) → {}",
+        terrain.point_count,
+        terrain.themes.len(),
+        store.join("terrain.json").display()
+    );
+    Ok(())
+}
+
+fn write_terrain(store: &Path, terrain: &Terrain) -> Result<(), CliError> {
+    std::fs::create_dir_all(store)
+        .map_err(|e| CliError::Io(format!("crystal-terrain: mkdir {}: {e}", store.display())))?;
+    let body = serde_json::to_string(terrain)
+        .map_err(|e| CliError::Io(format!("crystal-terrain: serialize: {e}")))?;
+    let path = store.join("terrain.json");
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, body)
+        .map_err(|e| CliError::Io(format!("crystal-terrain: write {}: {e}", tmp.display())))?;
+    std::fs::rename(&tmp, &path)
+        .map_err(|e| CliError::Io(format!("crystal-terrain: publish {}: {e}", path.display())))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn date_parse() {
+        assert_eq!(
+            date_from_case_id("00044cfd-2026-05-07_Claude_Code_x"),
+            "2026-05-07"
+        );
+        assert_eq!(date_from_case_id("nodate_title"), "");
+    }
+
+    #[test]
+    fn communities_spread_into_separated_islands() {
+        // Three orthogonal centroids (maximally dissimilar) must not overlap.
+        let centroids = vec![
+            vec![1.0f32, 0.0, 0.0],
+            vec![0.0f32, 1.0, 0.0],
+            vec![0.0f32, 0.0, 1.0],
+        ];
+        let pos = layout_communities(&centroids);
+        for i in 0..3 {
+            for j in (i + 1)..3 {
+                let d = ((pos[i].0 - pos[j].0).powi(2) + (pos[i].1 - pos[j].1).powi(2)).sqrt();
+                assert!(d > 0.5, "islands {i},{j} too close: {d}");
+            }
+        }
+    }
+
+    #[test]
+    fn centroid_is_normalized_mean() {
+        let vectors = vec![vec![1.0f32, 0.0], vec![0.0f32, 1.0]];
+        let c = centroid(&[0, 1], &vectors, 2);
+        let norm = (c[0] * c[0] + c[1] * c[1]).sqrt();
+        assert!((norm - 1.0).abs() < 1e-5, "centroid must be unit-norm: {norm}");
+    }
+}

--- a/crates/ovp-cli/src/commands/crystal_terrain.rs
+++ b/crates/ovp-cli/src/commands/crystal_terrain.rs
@@ -33,7 +33,10 @@ pub struct TerrainArgs {
 #[derive(Serialize)]
 struct TerrainPoint {
     id: String,
-    /// Content sha of the source — links the point to its `/library/:sha` page.
+    /// Content sha256 of the SOURCE file — links the point to its
+    /// `/library/:sha` page. Read from the daily ledger (not the embedding
+    /// cache key); empty when the pack isn't ledger-tracked, so the client
+    /// renders an unlinked point instead of a 404.
     sha: String,
     title: String,
     /// `YYYY-MM-DD` parsed from the pack case_id, else "".
@@ -75,17 +78,84 @@ struct Terrain {
     points: Vec<TerrainPoint>,
 }
 
-/// case_id looks like `<sha8>-<YYYY-MM-DD>_<title…>`; pull the date.
+/// Pull the `YYYY-MM-DD` out of a reader-pack case_id, wherever it sits: modern
+/// ids are `<YYYY-MM-DD>_<title>-<sha8>` (date first) and legacy ones are
+/// `<sha8>-<YYYY-MM-DD>_<title>` (date after the hash). Scanning byte windows
+/// handles both and is safe against multibyte title characters.
 fn date_from_case_id(case_id: &str) -> String {
-    // after the first '-': "YYYY-MM-DD_..."
-    let after = case_id.split_once('-').map(|(_, a)| a).unwrap_or("");
-    let date = after.split('_').next().unwrap_or("");
-    // must look like a date
-    if date.len() == 10 && date.as_bytes().get(4) == Some(&b'-') {
-        date.to_string()
-    } else {
-        String::new()
+    let b = case_id.as_bytes();
+    if b.len() < 10 {
+        return String::new();
     }
+    for i in 0..=b.len() - 10 {
+        let w = &b[i..i + 10];
+        if is_iso_date(w) {
+            // The window is all-ASCII by construction → direct String.
+            return String::from_utf8_lossy(w).into_owned();
+        }
+    }
+    String::new()
+}
+
+/// `YYYY-MM-DD` shape check on a 10-byte window (digits + `-` separators).
+fn is_iso_date(b: &[u8]) -> bool {
+    b.len() == 10
+        && b[4] == b'-'
+        && b[7] == b'-'
+        && b[..4].iter().all(u8::is_ascii_digit)
+        && b[5..7].iter().all(u8::is_ascii_digit)
+        && b[8..10].iter().all(u8::is_ascii_digit)
+}
+
+/// The 8-hex content-sha prefix baked into a reader-pack case_id. Legacy ids are
+/// `<sha8>-<date>_<title>` (leading token); modern ones are
+/// `<date>_<title>-<sha8>` (trailing token). Either way it's an 8-char hex token
+/// at one end, so we test both ends and skip the date/title in between.
+fn sha8_from_case_id(case_id: &str) -> Option<&str> {
+    let leading = case_id.split(['-', '_']).next();
+    let trailing = case_id.rsplit(['-', '_']).next();
+    [leading, trailing]
+        .into_iter()
+        .flatten()
+        .find(|tok| is_hex8(tok))
+}
+
+fn is_hex8(s: &str) -> bool {
+    s.len() == 8 && s.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+/// Map each 8-hex prefix → the one full source sha256 it identifies, from the
+/// index's source list (the exact set that has `/library/:sha` pages). A prefix
+/// shared by two distinct sources maps to `None` so a point never links to the
+/// wrong source. This is the sha `/library` expects — NOT the embedding-cache
+/// key `collect_docs` uses to load vectors.
+fn sha8_index(shas: &[String]) -> BTreeMap<String, Option<String>> {
+    let mut map: BTreeMap<String, Option<String>> = BTreeMap::new();
+    for full in shas {
+        if full.len() < 8 {
+            continue;
+        }
+        let key = full[..8].to_string();
+        map.entry(key)
+            .and_modify(|v| {
+                if v.as_deref() != Some(full.as_str()) {
+                    *v = None; // prefix collision → ambiguous, drop the link
+                }
+            })
+            .or_insert_with(|| Some(full.clone()));
+    }
+    map
+}
+
+/// Load the sha8 → full-sha map from the vault's index. A missing or unreadable
+/// index yields an empty map (all points render unlinked, no 404s).
+fn load_sha8_index(vault_root: &Path) -> BTreeMap<String, Option<String>> {
+    ovp_index::read_index(vault_root)
+        .map(|idx| {
+            let shas: Vec<String> = idx.sources.into_iter().map(|s| s.sha256).collect();
+            sha8_index(&shas)
+        })
+        .unwrap_or_default()
 }
 
 /// Tiny deterministic PRNG (splitmix64) so the layout is reproducible without a
@@ -214,10 +284,20 @@ pub fn run(args: TerrainArgs) -> Result<(), CliError> {
         .map(|c| (c.id, c.label.clone()))
         .collect();
 
+    // Link sha (for /library/:sha) is the source CONTENT sha, recovered from the
+    // 8-hex prefix in the case_id via the index — NOT `d.sha`, which is the
+    // embedding-cache key used to load the vector.
+    let sha8_map = load_sha8_index(&args.vault_root);
+    let link_sha = |case_id: &str| -> String {
+        sha8_from_case_id(case_id)
+            .and_then(|h| sha8_map.get(h).cloned().flatten())
+            .unwrap_or_default()
+    };
+
     // Keep only packs that are themed AND have a cached vector (no model here).
     let docs = collect_docs(&reader_root)?;
     let mut vectors: Vec<Vec<f32>> = Vec::new();
-    let mut meta: Vec<(String, String, String, String, i64)> = Vec::new(); // id,sha,title,date,community
+    let mut meta: Vec<(String, String, String, String, i64)> = Vec::new(); // id,link_sha,title,date,community
     for d in &docs {
         let Some(&community) = themes.packs.get(&d.case_id) else {
             continue;
@@ -228,7 +308,7 @@ pub fn run(args: TerrainArgs) -> Result<(), CliError> {
         vectors.push(vec);
         meta.push((
             d.case_id.clone(),
-            d.sha.clone(),
+            link_sha(&d.case_id),
             d.title.clone(),
             date_from_case_id(&d.case_id),
             community,
@@ -361,11 +441,54 @@ mod tests {
 
     #[test]
     fn date_parse() {
+        // Legacy: <sha8>-<date>_<title>
         assert_eq!(
             date_from_case_id("00044cfd-2026-05-07_Claude_Code_x"),
             "2026-05-07"
         );
+        // Modern (VaultLayout::reader_pack_dir): <date>_<title>-<sha8>
+        assert_eq!(
+            date_from_case_id("2026-05-07_Claude_Code_x-00044cfd"),
+            "2026-05-07"
+        );
+        // Multibyte title must not panic and still finds the date.
+        assert_eq!(
+            date_from_case_id("2026-05-07_知识地图-00044cfd"),
+            "2026-05-07"
+        );
         assert_eq!(date_from_case_id("nodate_title"), "");
+        assert_eq!(date_from_case_id("short"), "");
+    }
+
+    #[test]
+    fn sha8_extracted_from_both_pack_formats() {
+        // Legacy: sha8 leads.
+        assert_eq!(
+            sha8_from_case_id("00044cfd-2026-05-07_Claude_Code"),
+            Some("00044cfd")
+        );
+        // Modern: sha8 trails, even when the title contains '-'.
+        assert_eq!(
+            sha8_from_case_id("2026-05-07_Claude-Code-00044cfd"),
+            Some("00044cfd")
+        );
+        // No hex8 token → no link.
+        assert_eq!(sha8_from_case_id("2026-05-07_notes"), None);
+        // A date-looking leading token is not mistaken for a sha8.
+        assert_eq!(sha8_from_case_id("2026-05-07_x-deadbeef"), Some("deadbeef"));
+    }
+
+    #[test]
+    fn sha8_index_resolves_unique_and_drops_collisions() {
+        let a = "00044cfdf9e5000000000000000000000000000000000000000000000000aaaa";
+        let b = "84fbf6dc918ead0000000000000000000000000000000000000000000000bbbb";
+        // Two distinct sources sharing the same 8-hex prefix → ambiguous.
+        let c1 = "deadbeef1111000000000000000000000000000000000000000000000000cccc";
+        let c2 = "deadbeef2222000000000000000000000000000000000000000000000000dddd";
+        let map = sha8_index(&[a.into(), b.into(), c1.into(), c2.into()]);
+        assert_eq!(map.get("00044cfd"), Some(&Some(a.to_string())));
+        assert_eq!(map.get("84fbf6dc"), Some(&Some(b.to_string())));
+        assert_eq!(map.get("deadbeef"), Some(&None)); // collision → no link
     }
 
     #[test]

--- a/crates/ovp-cli/src/commands/crystal_terrain.rs
+++ b/crates/ovp-cli/src/commands/crystal_terrain.rs
@@ -18,6 +18,7 @@ use std::path::Path;
 use ovp_domain::VaultLayout;
 use ovp_embed::cache as embed_cache;
 use ovp_embed::{EMBED_DIM, EMBED_MODEL_ID};
+use ovp_index::PackRow;
 use serde::Serialize;
 
 use crate::commands::crystal_themes::collect_docs;
@@ -107,54 +108,28 @@ fn is_iso_date(b: &[u8]) -> bool {
         && b[8..10].iter().all(u8::is_ascii_digit)
 }
 
-/// The 8-hex content-sha prefix baked into a reader-pack case_id. Legacy ids are
-/// `<sha8>-<date>_<title>` (leading token); modern ones are
-/// `<date>_<title>-<sha8>` (trailing token). Either way it's an 8-char hex token
-/// at one end, so we test both ends and skip the date/title in between.
-fn sha8_from_case_id(case_id: &str) -> Option<&str> {
-    let leading = case_id.split(['-', '_']).next();
-    let trailing = case_id.rsplit(['-', '_']).next();
-    [leading, trailing]
-        .into_iter()
-        .flatten()
-        .find(|tok| is_hex8(tok))
-}
-
-fn is_hex8(s: &str) -> bool {
-    s.len() == 8 && s.bytes().all(|b| b.is_ascii_hexdigit())
-}
-
-/// Map each 8-hex prefix → the one full source sha256 it identifies, from the
-/// index's source list (the exact set that has `/library/:sha` pages). A prefix
-/// shared by two distinct sources maps to `None` so a point never links to the
-/// wrong source. This is the sha `/library` expects — NOT the embedding-cache
-/// key `collect_docs` uses to load vectors.
-fn sha8_index(shas: &[String]) -> BTreeMap<String, Option<String>> {
-    let mut map: BTreeMap<String, Option<String>> = BTreeMap::new();
-    for full in shas {
-        if full.len() < 8 {
-            continue;
+/// Map each reader-pack `case_id` (the `pack_dir` basename) → its SOURCE content
+/// sha256, from the index's pack list — the SAME join the portal's
+/// `sourcesByCase` uses. This is the sha `/library/:sha` serves; the
+/// embedding-cache key `collect_docs` uses to load vectors is a different hash.
+/// Packs the index has not recorded, and legacy packs with no source sha, are
+/// simply absent → the client renders an unlinked point (never a 404).
+fn source_shas_by_case(packs: &[PackRow]) -> BTreeMap<String, String> {
+    let mut map = BTreeMap::new();
+    for p in packs {
+        let Some(sha) = &p.source_sha256 else { continue };
+        if let Some(case_id) = Path::new(&p.pack_dir).file_name() {
+            map.insert(case_id.to_string_lossy().into_owned(), sha.clone());
         }
-        let key = full[..8].to_string();
-        map.entry(key)
-            .and_modify(|v| {
-                if v.as_deref() != Some(full.as_str()) {
-                    *v = None; // prefix collision → ambiguous, drop the link
-                }
-            })
-            .or_insert_with(|| Some(full.clone()));
     }
     map
 }
 
-/// Load the sha8 → full-sha map from the vault's index. A missing or unreadable
-/// index yields an empty map (all points render unlinked, no 404s).
-fn load_sha8_index(vault_root: &Path) -> BTreeMap<String, Option<String>> {
+/// Load the case_id → source-sha map from the vault's index. A missing or
+/// unreadable index yields an empty map (all points render unlinked, no 404s).
+fn load_source_shas(vault_root: &Path) -> BTreeMap<String, String> {
     ovp_index::read_index(vault_root)
-        .map(|idx| {
-            let shas: Vec<String> = idx.sources.into_iter().map(|s| s.sha256).collect();
-            sha8_index(&shas)
-        })
+        .map(|idx| source_shas_by_case(&idx.packs))
         .unwrap_or_default()
 }
 
@@ -284,15 +259,10 @@ pub fn run(args: TerrainArgs) -> Result<(), CliError> {
         .map(|c| (c.id, c.label.clone()))
         .collect();
 
-    // Link sha (for /library/:sha) is the source CONTENT sha, recovered from the
-    // 8-hex prefix in the case_id via the index — NOT `d.sha`, which is the
-    // embedding-cache key used to load the vector.
-    let sha8_map = load_sha8_index(&args.vault_root);
-    let link_sha = |case_id: &str| -> String {
-        sha8_from_case_id(case_id)
-            .and_then(|h| sha8_map.get(h).cloned().flatten())
-            .unwrap_or_default()
-    };
+    // Link sha (for /library/:sha) is the source CONTENT sha, joined from the
+    // index by case_id — NOT `d.sha`, which is the embedding-cache key used to
+    // load the vector.
+    let source_shas = load_source_shas(&args.vault_root);
 
     // Keep only packs that are themed AND have a cached vector (no model here).
     let docs = collect_docs(&reader_root)?;
@@ -308,7 +278,7 @@ pub fn run(args: TerrainArgs) -> Result<(), CliError> {
         vectors.push(vec);
         meta.push((
             d.case_id.clone(),
-            link_sha(&d.case_id),
+            source_shas.get(&d.case_id).cloned().unwrap_or_default(),
             d.title.clone(),
             date_from_case_id(&d.case_id),
             community,
@@ -460,35 +430,34 @@ mod tests {
         assert_eq!(date_from_case_id("short"), "");
     }
 
-    #[test]
-    fn sha8_extracted_from_both_pack_formats() {
-        // Legacy: sha8 leads.
-        assert_eq!(
-            sha8_from_case_id("00044cfd-2026-05-07_Claude_Code"),
-            Some("00044cfd")
-        );
-        // Modern: sha8 trails, even when the title contains '-'.
-        assert_eq!(
-            sha8_from_case_id("2026-05-07_Claude-Code-00044cfd"),
-            Some("00044cfd")
-        );
-        // No hex8 token → no link.
-        assert_eq!(sha8_from_case_id("2026-05-07_notes"), None);
-        // A date-looking leading token is not mistaken for a sha8.
-        assert_eq!(sha8_from_case_id("2026-05-07_x-deadbeef"), Some("deadbeef"));
+    fn pack(pack_dir: &str, sha: Option<&str>) -> PackRow {
+        PackRow {
+            pack_dir: pack_dir.into(),
+            title: "t".into(),
+            date: None,
+            units: 0,
+            cards: 0,
+            json_repaired: false,
+            card_titles: vec![],
+            source_sha256: sha.map(String::from),
+        }
     }
 
     #[test]
-    fn sha8_index_resolves_unique_and_drops_collisions() {
-        let a = "00044cfdf9e5000000000000000000000000000000000000000000000000aaaa";
-        let b = "84fbf6dc918ead0000000000000000000000000000000000000000000000bbbb";
-        // Two distinct sources sharing the same 8-hex prefix → ambiguous.
-        let c1 = "deadbeef1111000000000000000000000000000000000000000000000000cccc";
-        let c2 = "deadbeef2222000000000000000000000000000000000000000000000000dddd";
-        let map = sha8_index(&[a.into(), b.into(), c1.into(), c2.into()]);
-        assert_eq!(map.get("00044cfd"), Some(&Some(a.to_string())));
-        assert_eq!(map.get("84fbf6dc"), Some(&Some(b.to_string())));
-        assert_eq!(map.get("deadbeef"), Some(&None)); // collision → no link
+    fn source_shas_keyed_by_case_id_basename() {
+        let packs = vec![
+            // Nested pack_dir → key is the basename (the case_id).
+            pack("40-Resources/Reader/2026-05-07_a-1111", Some("sha_a")),
+            // Bare case_id also works.
+            pack("2026-05-08_b-2222", Some("sha_b")),
+            // Legacy pack with no source sha → absent (renders unlinked).
+            pack("40-Resources/Reader/2026-05-09_c-3333", None),
+        ];
+        let map = source_shas_by_case(&packs);
+        assert_eq!(map.get("2026-05-07_a-1111").map(String::as_str), Some("sha_a"));
+        assert_eq!(map.get("2026-05-08_b-2222").map(String::as_str), Some("sha_b"));
+        assert!(!map.contains_key("2026-05-09_c-3333"));
+        assert_eq!(map.len(), 2);
     }
 
     #[test]

--- a/crates/ovp-cli/src/commands/crystal_terrain.rs
+++ b/crates/ovp-cli/src/commands/crystal_terrain.rs
@@ -366,13 +366,23 @@ pub fn run(args: TerrainArgs) -> Result<(), CliError> {
             lo = lo.min(s);
             hi = hi.max(s);
         }
-        let span = (hi - lo).max(1e-6);
+        let range = hi - lo;
+        // Every member equally fits the centroid (any 2-member island, or ties):
+        // range is 0, so a normalized `tight` would be 0 for all and fling every
+        // point to the max radius — a ring with the label between two hills, not
+        // one peak. Treat them as equally tight (near the peak) with slight
+        // jitter instead.
+        let degenerate = range < 1e-6;
         // Island radius grows with member count (bigger themes = bigger hills).
         let radius = 0.28 * (members.len() as f64).sqrt();
         let mut rng = Rng(SEED ^ (cid as u64).wrapping_mul(0x9E3779B97F4A7C15));
         for (mi, &m) in members.iter().enumerate() {
-            let tight = (sims[mi] - lo) / span; // 1 = closest to centroid
-            let r = radius * (1.0 - tight).sqrt(); // peak-concentrated
+            let r = if degenerate {
+                radius * 0.15 * rng.next_f64() // clustered at the peak, lightly spread
+            } else {
+                let tight = (sims[mi] - lo) / range; // 1 = closest to centroid
+                radius * (1.0 - tight).sqrt() // peak-concentrated
+            };
             let theta = std::f64::consts::TAU * rng.next_f64();
             pos[m] = (cx + r * theta.cos(), cy + r * theta.sin());
         }

--- a/crates/ovp-cli/src/commands/crystal_themes.rs
+++ b/crates/ovp-cli/src/commands/crystal_themes.rs
@@ -83,11 +83,11 @@ pub struct CrystalThemesArgs {
 }
 
 /// One themable reader pack.
-struct ThemeDoc {
-    case_id: String,
-    title: String,
-    text: String,
-    sha: String,
+pub(crate) struct ThemeDoc {
+    pub(crate) case_id: String,
+    pub(crate) title: String,
+    pub(crate) text: String,
+    pub(crate) sha: String,
 }
 
 /// Strip reader.md presentation boilerplate before embedding — mirrors the
@@ -143,7 +143,7 @@ fn strip_trailing_em_tag(s: &str) -> &str {
 /// run-status.json / units.accepted.json, minus failed attempts), sorted by
 /// case_id. A missing reader root is an empty corpus (fresh vault), not an
 /// error — the degradation contract says never block.
-fn collect_docs(reader_root: &Path) -> Result<Vec<ThemeDoc>, CliError> {
+pub(crate) fn collect_docs(reader_root: &Path) -> Result<Vec<ThemeDoc>, CliError> {
     let entries = match std::fs::read_dir(reader_root) {
         Ok(entries) => entries,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),

--- a/crates/ovp-cli/src/commands/mod.rs
+++ b/crates/ovp-cli/src/commands/mod.rs
@@ -10,6 +10,7 @@ pub mod crystal_review_session;
 pub mod crystal_synth;
 pub mod crystal_synth_ab;
 pub mod crystal_synth_llm;
+pub mod crystal_terrain;
 pub mod crystal_themes;
 pub mod crystal_write;
 pub mod console_cmd;

--- a/crates/ovp-cli/src/main.rs
+++ b/crates/ovp-cli/src/main.rs
@@ -587,8 +587,10 @@ enum Cmd {
         experiment_seed: u64,
     },
     /// PRODUCT — build the knowledge-terrain projection (`.ovp/crystal/terrain.json`):
-    /// a 2D force layout of the themed packs over the kNN graph, for the portal's
-    /// terrain view. Reuses crystal-themes' embeddings + labels; warm cache only.
+    /// a 2D layout that places theme islands by a semantic force layout over
+    /// community centroids, then scatters each pack within its island by
+    /// theme-fit, for the portal's terrain view. Reuses crystal-themes'
+    /// embeddings + labels; warm cache only.
     CrystalTerrain {
         #[arg(long)]
         vault_root: PathBuf,

--- a/crates/ovp-cli/src/main.rs
+++ b/crates/ovp-cli/src/main.rs
@@ -591,6 +591,13 @@ enum Cmd {
     /// communities → c-TF-IDF keywords → bilingual labels. Rebuildable
     /// projection; never touches the crystal ledger. Offline/no-model runs
     /// skip gracefully (everything stays Unclassified).
+    /// PRODUCT — build the knowledge-terrain projection (`.ovp/crystal/terrain.json`):
+    /// a 2D force layout of the themed packs over the kNN graph, for the portal's
+    /// terrain view. Reuses crystal-themes' embeddings + labels; warm cache only.
+    CrystalTerrain {
+        #[arg(long)]
+        vault_root: PathBuf,
+    },
     CrystalThemes {
         #[arg(long)]
         vault_root: PathBuf,
@@ -1615,6 +1622,9 @@ fn main() -> ExitCode {
                     embed_cache_dir,
                 })
             }
+        }
+        Cmd::CrystalTerrain { vault_root } => {
+            commands::crystal_terrain::run(commands::crystal_terrain::TerrainArgs { vault_root })
         }
         Cmd::CrystalThemes {
             vault_root,

--- a/crates/ovp-cli/src/main.rs
+++ b/crates/ovp-cli/src/main.rs
@@ -586,11 +586,6 @@ enum Cmd {
         #[arg(long, default_value_t = 42)]
         experiment_seed: u64,
     },
-    /// Build the semantic display-theme projection (.ovp/crystal/themes.json)
-    /// over all reader packs: multilingual embeddings (cached) → Louvain
-    /// communities → c-TF-IDF keywords → bilingual labels. Rebuildable
-    /// projection; never touches the crystal ledger. Offline/no-model runs
-    /// skip gracefully (everything stays Unclassified).
     /// PRODUCT — build the knowledge-terrain projection (`.ovp/crystal/terrain.json`):
     /// a 2D force layout of the themed packs over the kNN graph, for the portal's
     /// terrain view. Reuses crystal-themes' embeddings + labels; warm cache only.
@@ -598,6 +593,11 @@ enum Cmd {
         #[arg(long)]
         vault_root: PathBuf,
     },
+    /// Build the semantic display-theme projection (.ovp/crystal/themes.json)
+    /// over all reader packs: multilingual embeddings (cached) → Louvain
+    /// communities → c-TF-IDF keywords → bilingual labels. Rebuildable
+    /// projection; never touches the crystal ledger. Offline/no-model runs
+    /// skip gracefully (everything stays Unclassified).
     CrystalThemes {
         #[arg(long)]
         vault_root: PathBuf,

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -614,6 +614,7 @@ fn dispatch(
         (Method::Get, "/api/flow") => handle_flow(state),
         (Method::Get, "/api/settings") => handle_settings(state),
         (Method::Get, "/api/themes") => handle_themes(state),
+        (Method::Get, "/api/terrain") => handle_terrain(state),
         (Method::Get, p) if p.starts_with("/api/claim/") => handle_claim(state, url),
         (Method::Get, p) if p.starts_with("/api/source/") => handle_source_api(state, url),
         (Method::Get, p) if p == "/api" || p.starts_with("/api/") => {
@@ -696,6 +697,21 @@ fn handle_themes(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
         .collect();
     let body = serde_json::to_string(&themes).unwrap_or_else(|_| "[]".into());
     json_stamped(200, &body, model.as_ref())
+}
+
+/// `GET /api/terrain` — the knowledge-terrain projection built by
+/// `ovp2 crystal-terrain` (`.ovp/crystal/terrain.json`), served raw. 404 with a
+/// hint when it hasn't been built yet.
+fn handle_terrain(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
+    let path = state.vault_root.join(".ovp/crystal/terrain.json");
+    match std::fs::read_to_string(&path) {
+        Ok(body) => json_stamped(200, &body, state.current_model().as_ref()),
+        Err(_) => json_stamped(
+            404,
+            "{\"error\":\"no terrain.json — run `ovp2 crystal-terrain --vault-root <v>`\"}",
+            None,
+        ),
+    }
 }
 
 fn handle_model(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -705,12 +705,22 @@ fn handle_themes(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
 fn handle_terrain(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
     let path = state.vault_root.join(".ovp/crystal/terrain.json");
     match std::fs::read_to_string(&path) {
-        Ok(body) => json_stamped(200, &body, state.current_model().as_ref()),
-        Err(_) => json_stamped(
+        // Terrain is generated independently of the index — do NOT stamp it with
+        // the index's built_at/run_id, or a lone `index build` would advertise
+        // false freshness for a stale terrain body.
+        Ok(body) => json_stamped(200, &body, None),
+        // Only a genuinely-absent file is "not built yet". Permission errors,
+        // invalid UTF-8, or a dir at the path are real faults — surface them as
+        // 500 (and log) rather than telling the operator to rebuild.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => json_stamped(
             404,
             "{\"error\":\"no terrain.json — run `ovp2 crystal-terrain --vault-root <v>`\"}",
             None,
         ),
+        Err(e) => {
+            eprintln!("handle_terrain: reading {}: {e}", path.display());
+            json_stamped(500, "{\"error\":\"terrain read failed\"}", None)
+        }
     }
 }
 

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -702,13 +702,41 @@ fn handle_themes(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
 /// `GET /api/terrain` — the knowledge-terrain projection built by
 /// `ovp2 crystal-terrain` (`.ovp/crystal/terrain.json`), served raw. 404 with a
 /// hint when it hasn't been built yet.
+/// Cheap contract check for `terrain.json`: parseable, `schema` is an
+/// `ovp.crystal.terrain*` string, and `points` is an array. Guards the client
+/// from a truncated/wrong-shaped projection that would crash the Terrain view.
+fn terrain_shape_ok(body: &str) -> bool {
+    serde_json::from_str::<serde_json::Value>(body)
+        .ok()
+        .filter(|v| {
+            v.get("schema")
+                .and_then(|s| s.as_str())
+                .is_some_and(|s| s.starts_with("ovp.crystal.terrain"))
+                && v.get("points").is_some_and(|p| p.is_array())
+        })
+        .is_some()
+}
+
 fn handle_terrain(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
     let path = state.vault_root.join(".ovp/crystal/terrain.json");
     match std::fs::read_to_string(&path) {
-        // Terrain is generated independently of the index — do NOT stamp it with
-        // the index's built_at/run_id, or a lone `index build` would advertise
-        // false freshness for a stale terrain body.
-        Ok(body) => json_stamped(200, &body, None),
+        // Validate the v1 shape before claiming 200: a truncated or wrong-shaped
+        // file (e.g. `{}`) would otherwise reach the client and crash the view on
+        // `data.points`. Terrain is generated independently of the index — do NOT
+        // stamp it with the index's built_at/run_id, or a lone `index build`
+        // would advertise false freshness for a stale terrain body.
+        Ok(body) if terrain_shape_ok(&body) => json_stamped(200, &body, None),
+        Ok(_) => {
+            eprintln!(
+                "handle_terrain: corrupt/incompatible terrain.json at {}",
+                path.display()
+            );
+            json_stamped(
+                500,
+                "{\"error\":\"terrain.json is corrupt — rebuild with `ovp2 crystal-terrain`\"}",
+                None,
+            )
+        }
         // Only a genuinely-absent file is "not built yet". Permission errors,
         // invalid UTF-8, or a dir at the path are real faults — surface them as
         // 500 (and log) rather than telling the operator to rebuild.
@@ -1844,6 +1872,19 @@ fn hex_val(b: u8) -> u8 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn terrain_shape_ok_gates_corrupt_projections() {
+        assert!(terrain_shape_ok(
+            r#"{"schema":"ovp.crystal.terrain/v1","points":[]}"#
+        ));
+        assert!(!terrain_shape_ok("{}")); // wrong shape
+        assert!(!terrain_shape_ok(r#"{"schema":"ovp.crystal.terrain/v1"}"#)); // no points
+        assert!(!terrain_shape_ok(r#"{"points":[]}"#)); // no schema
+        assert!(!terrain_shape_ok(r#"{"schema":"other","points":[]}"#)); // wrong schema
+        assert!(!terrain_shape_ok(r#"{"schema":"ovp.crystal.terrain/v1","points":{}}"#)); // points not array
+        assert!(!terrain_shape_ok("{truncated")); // unparseable
+    }
 
     fn temp_root(name: &str) -> PathBuf {
         let dir =


### PR DESCRIPTION
A flomo-style "map of your mind" for the Knowledge page — the corpus rendered as **3D terrain**: dense theme clusters become hills, each source a glowing point, labelled by theme. Built on the **same semantic layer** as the existing themes (embeddings + kNN + community labels), adding only a 2D layout — no new model, warm cache only.

## Pieces
- **`ovp2 crystal-terrain`**: reuses `crystal-themes`' cached embeddings + kNN + the `themes.json` community/label join; adds a 2-level force layout (communities spread into islands, members placed radially by similarity-to-centroid) → `.ovp/crystal/terrain.json` (rebuildable projection).
- **`/api/terrain`** serves it.
- **`KnowledgeTerrain.tsx`** (three.js): heightmapped terrain with a contour-line shader, glowing point cloud, floating theme labels, **OrbitControls** (drag-orbit / wheel-zoom), a **2D/3D** camera toggle, and a **timeline scrubber** that replays the terrain growing month by month. Hover a point → the note; **click → its `/library/:sha` source**. Knowledge page gains a List/Graph/**Terrain** toggle.

## vs flomo
Same spatial delight + scale (contours avoid the node-link hairball) + time-growth + 3D orbit. But ours keeps the moat flomo lacks: click drills into the **evidence chain** (claim→card→unit→line).

## Verified
Rendered live via headless Chrome (3D terrain, orbit, labels, timeline, "Unclassified" bucket). 5 Rust tests; `clippy -D warnings` clean; `console-ui` builds. Generated `terrain.json` on the real vault: 1070 sources · 25 themes.

Follow-ups (noted): wire `crystal-terrain` into `daily` for auto-refresh; richer within-cluster geometry (true UMAP).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Terrain view to the Knowledge page with interactive 2D/3D exploration, hover tooltips, highlighted points, and point-to-library navigation.
  * Added month-range scrubbing with play/pause (when multiple months are available) to animate growth over time, plus WebGL and fetch error states.
  * Added the `ovp2 crystal-terrain` CLI command (with `--vault-root`) to generate the terrain dataset.
  * Added `GET /api/terrain` to serve the generated terrain data to the UI.
  * Added English and Simplified Chinese UI text for the full Terrain experience (including “not built” and “no WebGL” messages).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->