### PR TITLE
chore: sync Cargo.lock for ovp-publish deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2910,6 +2910,7 @@ dependencies = [
  "ovp-api-projection",
  "ovp-domain",
  "ovp-index",
+ "ovp-intake",
  "serde",
  "serde_json",
  "sha2",


### PR DESCRIPTION
One-line lockfile fixup: PR #336 added the `ovp-intake` dependency to `ovp-publish` (for the vault RunLock) but the regenerated `Cargo.lock` line wasn't committed, so a fresh `cargo build` on main shows a dirty tree. This commits the missing line.