### PR TITLE
feat(graph): rewrite knowledge graph on react-force-graph (2D zoom-LOD + rotatable 3D)

### DIFF
--- a/console-ui/package-lock.json
+++ b/console-ui/package-lock.json
@@ -9,10 +9,12 @@
       "version": "0.2.0",
       "dependencies": {
         "@types/d3-contour": "^3.0.6",
+        "@types/d3-force": "^3.0.10",
         "@types/three": "^0.185.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "d3-contour": "^4.0.2",
+        "d3-force": "^3.0.0",
         "d3-sankey": "^0.12.3",
         "d3-shape": "^3.2.0",
         "lucide-react": "^0.525.0",
@@ -1541,6 +1543,12 @@
         "@types/geojson": "*"
       }
     },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmmirror.com/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-path": {
       "version": "3.1.1",
       "resolved": "https://registry.npmmirror.com/@types/d3-path/-/d3-path-3.1.1.tgz",
@@ -2053,6 +2061,20 @@
       "resolved": "https://registry.npmmirror.com/d3-ease/-/d3-ease-3.0.1.tgz",
       "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
       "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
       "engines": {
         "node": ">=12"
       }

--- a/console-ui/package-lock.json
+++ b/console-ui/package-lock.json
@@ -10,11 +10,13 @@
       "dependencies": {
         "@types/d3-contour": "^3.0.6",
         "@types/d3-force": "^3.0.10",
+        "@types/d3-polygon": "^3.0.2",
         "@types/three": "^0.185.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "d3-contour": "^4.0.2",
         "d3-force": "^3.0.0",
+        "d3-polygon": "^3.0.1",
         "d3-sankey": "^0.12.3",
         "d3-shape": "^3.2.0",
         "lucide-react": "^0.525.0",
@@ -1556,6 +1558,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmmirror.com/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-sankey": {
       "version": "0.12.5",
       "resolved": "https://registry.npmmirror.com/@types/d3-sankey/-/d3-sankey-0.12.5.tgz",
@@ -2126,6 +2134,15 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmmirror.com/d3-path/-/d3-path-3.1.0.tgz",
       "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
       "license": "ISC",
       "engines": {
         "node": ">=12"

--- a/console-ui/package-lock.json
+++ b/console-ui/package-lock.json
@@ -19,6 +19,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-force-graph-2d": "^1.29.1",
+        "react-force-graph-3d": "^1.29.1",
         "react-router-dom": "^7.6.0",
         "tailwind-merge": "^3.3.0",
         "three": "^0.185.1"
@@ -269,6 +270,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmmirror.com/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1785,6 +1795,22 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/3d-force-graph": {
+      "version": "1.80.0",
+      "resolved": "https://registry.npmmirror.com/3d-force-graph/-/3d-force-graph-1.80.0.tgz",
+      "integrity": "sha512-tzI353gW1nXPpnC7VTa3JjMg+3cp77qOLUFO0vucPTfF+q5R6sQsNsIqVTbRIb7RSypn14nBa4yfkOe9ThxASw==",
+      "license": "MIT",
+      "dependencies": {
+        "accessor-fn": "1",
+        "kapsule": "^1.16",
+        "three": ">=0.179 <1",
+        "three-forcegraph": "1",
+        "three-render-objects": "^1.41"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/accessor-fn": {
       "version": "1.5.3",
       "resolved": "https://registry.npmmirror.com/accessor-fn/-/accessor-fn-1.5.3.tgz",
@@ -2230,6 +2256,18 @@
         "d3-interpolate": "1 - 3",
         "d3-selection": "2 - 3",
         "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-bind-mapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmmirror.com/data-bind-mapper/-/data-bind-mapper-1.0.3.tgz",
+      "integrity": "sha512-QmU3lyEnbENQPo0M1F9BMu4s6cqNNp8iJA+b/HP2sSb7pf3dxwF3+EP1eO69rwBfH9kFJ1apmzrtogAmVt2/Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "accessor-fn": "1"
       },
       "engines": {
         "node": ">=12"
@@ -2877,6 +2915,44 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/ngraph.events": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmmirror.com/ngraph.events/-/ngraph.events-1.4.0.tgz",
+      "integrity": "sha512-NeDGI4DSyjBNBRtA86222JoYietsmCXbs8CEB0dZ51Xeh4lhVl1y3wpWLumczvnha8sFQIW4E0vvVWwgmX2mGw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ngraph.forcelayout": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmmirror.com/ngraph.forcelayout/-/ngraph.forcelayout-3.3.1.tgz",
+      "integrity": "sha512-MKBuEh1wujyQHFTW57y5vd/uuEOK0XfXYxm3lC7kktjJLRdt/KEKEknyOlc6tjXflqBKEuYBBcu7Ax5VY+S6aw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ngraph.events": "^1.0.0",
+        "ngraph.merge": "^1.0.0",
+        "ngraph.random": "^1.0.0"
+      }
+    },
+    "node_modules/ngraph.graph": {
+      "version": "20.1.2",
+      "resolved": "https://registry.npmmirror.com/ngraph.graph/-/ngraph.graph-20.1.2.tgz",
+      "integrity": "sha512-W/G3GBR3Y5UxMLHTUCPP9v+pbtpzwuAEIqP5oZV+9IwgxAIEZwh+Foc60iPc1idlnK7Zxu0p3puxAyNmDvBd0Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ngraph.events": "^1.4.0"
+      }
+    },
+    "node_modules/ngraph.merge": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/ngraph.merge/-/ngraph.merge-1.0.0.tgz",
+      "integrity": "sha512-5J8YjGITUJeapsomtTALYsw7rFveYkM+lBj3QiYZ79EymQcuri65Nw3knQtFxQBU1r5iOaVRXrSwMENUPK62Vg==",
+      "license": "MIT"
+    },
+    "node_modules/ngraph.random": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/ngraph.random/-/ngraph.random-1.2.0.tgz",
+      "integrity": "sha512-4EUeAGbB2HWX9njd6bP6tciN6ByJfoaAvmVL9QTaZSeXrW46eNGA9GajiXiPBbvFqxUWFkEbyo6x5qsACUuVfA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/node-releases": {
       "version": "2.0.50",
       "resolved": "https://registry.npmmirror.com/node-releases/-/node-releases-2.0.50.tgz",
@@ -2935,6 +3011,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/polished": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmmirror.com/polished/-/polished-4.3.1.tgz",
+      "integrity": "sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/postcss": {
@@ -3023,6 +3111,23 @@
       "license": "MIT",
       "dependencies": {
         "force-graph": "^1.51",
+        "prop-types": "15",
+        "react-kapsule": "^2.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/react-force-graph-3d": {
+      "version": "1.29.1",
+      "resolved": "https://registry.npmmirror.com/react-force-graph-3d/-/react-force-graph-3d-1.29.1.tgz",
+      "integrity": "sha512-5Vp+PGpYnO+zLwgK2NvNqdXHvsWLrFzpDfJW1vUA1twjo9SPvXqfUYQrnRmAbD+K2tOxkZw1BkbH31l5b4TWHg==",
+      "license": "MIT",
+      "dependencies": {
+        "3d-force-graph": "^1.79",
         "prop-types": "15",
         "react-kapsule": "^2.5"
       },
@@ -3236,6 +3341,49 @@
       "resolved": "https://registry.npmmirror.com/three/-/three-0.185.1.tgz",
       "integrity": "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==",
       "license": "MIT"
+    },
+    "node_modules/three-forcegraph": {
+      "version": "1.43.4",
+      "resolved": "https://registry.npmmirror.com/three-forcegraph/-/three-forcegraph-1.43.4.tgz",
+      "integrity": "sha512-FtmiZP/T16ZQaHza3JDaDn0YTXFtg9e7pGnTeU8nzu0NNkx7MpWbF/GvmpbQsWHx3rukHtkRv1fTorLPB3FDEA==",
+      "license": "MIT",
+      "dependencies": {
+        "accessor-fn": "1",
+        "d3-array": "1 - 3",
+        "d3-force-3d": "2 - 3",
+        "d3-scale": "1 - 4",
+        "d3-scale-chromatic": "1 - 3",
+        "data-bind-mapper": "1",
+        "kapsule": "^1.16",
+        "ngraph.forcelayout": "3",
+        "ngraph.graph": "20",
+        "tinycolor2": "1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "three": ">=0.118.3"
+      }
+    },
+    "node_modules/three-render-objects": {
+      "version": "1.42.0",
+      "resolved": "https://registry.npmmirror.com/three-render-objects/-/three-render-objects-1.42.0.tgz",
+      "integrity": "sha512-KYfkPrYGEbIK8ChFocWqOF1aAN80FBUBWVYB8mB2oBpVuVN+52FvvngVYB5ieFANQu7Rt21rPYZ/xKaAgVWWRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tweenjs/tween.js": "18 - 25",
+        "accessor-fn": "1",
+        "float-tooltip": "^1.7",
+        "kapsule": "^1.16",
+        "polished": "4"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "three": ">=0.179"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",

--- a/console-ui/package-lock.json
+++ b/console-ui/package-lock.json
@@ -8,7 +8,6 @@
       "name": "ovp-console-ui",
       "version": "0.2.0",
       "dependencies": {
-        "@antv/g6": "^5.0.49",
         "@types/d3-contour": "^3.0.6",
         "@types/three": "^0.185.1",
         "class-variance-authority": "^0.7.1",
@@ -19,6 +18,7 @@
         "lucide-react": "^0.525.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-force-graph-2d": "^1.29.1",
         "react-router-dom": "^7.6.0",
         "tailwind-merge": "^3.3.0",
         "three": "^0.185.1"
@@ -35,253 +35,6 @@
         "typescript": "^5.6.0",
         "vite": "^6.0.0",
         "vitest": "^4.1.10"
-      }
-    },
-    "node_modules/@antv/algorithm": {
-      "version": "0.1.26",
-      "resolved": "https://registry.npmmirror.com/@antv/algorithm/-/algorithm-0.1.26.tgz",
-      "integrity": "sha512-DVhcFSQ8YQnMNW34Mk8BSsfc61iC1sAnmcfYoXTAshYHuU50p/6b7x3QYaGctDNKWGvi1ub7mPcSY0bK+aN0qg==",
-      "license": "MIT",
-      "dependencies": {
-        "@antv/util": "^2.0.13",
-        "tslib": "^2.0.0"
-      }
-    },
-    "node_modules/@antv/algorithm/node_modules/@antv/util": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmmirror.com/@antv/util/-/util-2.0.17.tgz",
-      "integrity": "sha512-o6I9hi5CIUvLGDhth0RxNSFDRwXeywmt6ExR4+RmVAzIi48ps6HUy+svxOCayvrPBN37uE6TAc2KDofRo0nK9Q==",
-      "license": "ISC",
-      "dependencies": {
-        "csstype": "^3.0.8",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@antv/component": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmmirror.com/@antv/component/-/component-2.1.11.tgz",
-      "integrity": "sha512-dTdz8VAd3rpjOaGEZTluz82mtzrP4XCtNlNQyrxY7VNRNcjtvpTLDn57bUL2lRu1T+iklKvgbE2llMriWkq9vQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@antv/g": "^6.1.11",
-        "@antv/scale": "^0.4.16",
-        "@antv/util": "^3.3.10",
-        "svg-path-parser": "^1.1.0"
-      }
-    },
-    "node_modules/@antv/event-emitter": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmmirror.com/@antv/event-emitter/-/event-emitter-0.1.3.tgz",
-      "integrity": "sha512-4ddpsiHN9Pd4UIlWuKVK1C4IiZIdbwQvy9i7DUSI3xNJ89FPUFt8lxDYj8GzzfdllV0NkJTRxnG+FvLk0llidg==",
-      "license": "MIT"
-    },
-    "node_modules/@antv/expr": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmmirror.com/@antv/expr/-/expr-1.0.2.tgz",
-      "integrity": "sha512-vrfdmPHkTuiS5voVutKl2l06w1ihBh9A8SFdQPEE+2KMVpkymzGOF1eWpfkbGZ7tiFE15GodVdhhHomD/hdIwg==",
-      "license": "MIT"
-    },
-    "node_modules/@antv/g": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmmirror.com/@antv/g/-/g-6.3.1.tgz",
-      "integrity": "sha512-WYEKqy86LHB2PzTmrZXrIsIe+3Epeds2f68zceQ+BJtRoGki7Sy4IhlC8LrUMztgfT1t3d/0L745NWZwITroKA==",
-      "license": "MIT",
-      "dependencies": {
-        "@antv/g-lite": "2.7.0",
-        "@antv/util": "^3.3.5",
-        "@babel/runtime": "^7.25.6",
-        "gl-matrix": "^3.4.3",
-        "html2canvas": "^1.4.1"
-      }
-    },
-    "node_modules/@antv/g-canvas": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmmirror.com/@antv/g-canvas/-/g-canvas-2.2.0.tgz",
-      "integrity": "sha512-h7zVBBo2aO64DuGKvq9sG+yTU3sCUb9DALCVm7nz8qGPs8hhLuFOkKPEzUDNfNYZGJUGzY8UDtJ3QRGRFcvEQg==",
-      "license": "MIT",
-      "dependencies": {
-        "@antv/g-lite": "2.7.0",
-        "@antv/g-math": "3.1.0",
-        "@antv/util": "^3.3.5",
-        "@babel/runtime": "^7.25.6",
-        "gl-matrix": "^3.4.3",
-        "tslib": "^2.5.3"
-      }
-    },
-    "node_modules/@antv/g-lite": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmmirror.com/@antv/g-lite/-/g-lite-2.7.0.tgz",
-      "integrity": "sha512-uSzgHYa5bwR5L2Au7/5tsOhFmXKZKLPBH90+Q9bP9teVs5VT4kOAi0isPSpDI8uhdDC2/VrfTWu5K9HhWI6FWw==",
-      "license": "MIT",
-      "dependencies": {
-        "@antv/g-math": "3.1.0",
-        "@antv/util": "^3.3.5",
-        "@antv/vendor": "^1.0.3",
-        "@babel/runtime": "^7.25.6",
-        "eventemitter3": "^5.0.1",
-        "gl-matrix": "^3.4.3",
-        "tslib": "^2.5.3"
-      }
-    },
-    "node_modules/@antv/g-math": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmmirror.com/@antv/g-math/-/g-math-3.1.0.tgz",
-      "integrity": "sha512-DtN1Gj/yI0UiK18nSBsZX8RK0LszGwqfb+cBYWgE+ddyTm8dZnW4tPUhV7QXePsS6/A5hHC+JFpAAK7OEGo5ZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@antv/util": "^3.3.5",
-        "@babel/runtime": "^7.25.6",
-        "gl-matrix": "^3.4.3",
-        "tslib": "^2.5.3"
-      }
-    },
-    "node_modules/@antv/g-plugin-dragndrop": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmmirror.com/@antv/g-plugin-dragndrop/-/g-plugin-dragndrop-2.1.1.tgz",
-      "integrity": "sha512-+aesDUJVQDs6UJ2bOBbDlaGAPCfHmU0MbrMTlQlfpwNplWueqtgVAZ3L57oZ2ZGHRWUHiRwZGPjXMBM3O2LELw==",
-      "license": "MIT",
-      "dependencies": {
-        "@antv/g-lite": "2.7.0",
-        "@antv/util": "^3.3.5",
-        "@babel/runtime": "^7.25.6",
-        "tslib": "^2.5.3"
-      }
-    },
-    "node_modules/@antv/g6": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmmirror.com/@antv/g6/-/g6-5.1.1.tgz",
-      "integrity": "sha512-50bXxMUf4mChyOv4ePVeWZLwotih9VunKfp0a++Wofv/wCyY8fb9+CV2wouIBCOZnd5ydBRA4NNaX9yLJzqa2w==",
-      "license": "MIT",
-      "dependencies": {
-        "@antv/algorithm": "^0.1.26",
-        "@antv/component": "^2.1.7",
-        "@antv/event-emitter": "^0.1.3",
-        "@antv/g": "^6.1.28",
-        "@antv/g-canvas": "^2.0.48",
-        "@antv/g-plugin-dragndrop": "^2.0.38",
-        "@antv/graphlib": "^2.0.4",
-        "@antv/hierarchy": "^0.7.1",
-        "@antv/layout": "^2.0.0",
-        "@antv/util": "^3.3.11",
-        "bubblesets-js": "^2.3.4"
-      }
-    },
-    "node_modules/@antv/graphlib": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmmirror.com/@antv/graphlib/-/graphlib-2.0.4.tgz",
-      "integrity": "sha512-zc/5oQlsdk42Z0ib1mGklwzhJ5vczLFiPa1v7DgJkTbgJ2YxRh9xdarf86zI49sKVJmgbweRpJs7Nu5bIiwv4w==",
-      "license": "MIT",
-      "dependencies": {
-        "@antv/event-emitter": "^0.1.3"
-      }
-    },
-    "node_modules/@antv/hierarchy": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmmirror.com/@antv/hierarchy/-/hierarchy-0.7.1.tgz",
-      "integrity": "sha512-7r22r+HxfcRZp79ZjGmsn97zgC1Iajrv0Mm9DIgx3lPfk+Kme2MG/+EKdZj1iEBsN0rJRzjWVPGL5YrBdVHchw==",
-      "license": "MIT"
-    },
-    "node_modules/@antv/layout": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmmirror.com/@antv/layout/-/layout-2.0.0.tgz",
-      "integrity": "sha512-aCZ3UdNc40SfT7meFV7QTADY2HCnc0DShVw56CJNTI6oExUIVU736grPuL5Dhb8/JrVaU4Y83QPN/P7KafBzlw==",
-      "license": "MIT",
-      "dependencies": {
-        "@antv/event-emitter": "^0.1.3",
-        "@antv/expr": "^1.0.2",
-        "@antv/graphlib": "^2.0.0",
-        "@antv/util": "^3.3.2",
-        "comlink": "^4.4.1",
-        "d3-force": "^3.0.0",
-        "d3-force-3d": "^3.0.5",
-        "d3-octree": "^1.0.2",
-        "d3-quadtree": "^3.0.1",
-        "dagre": "^0.8.5",
-        "ml-matrix": "^6.10.4",
-        "tslib": "^2.8.1"
-      }
-    },
-    "node_modules/@antv/scale": {
-      "version": "0.4.16",
-      "resolved": "https://registry.npmmirror.com/@antv/scale/-/scale-0.4.16.tgz",
-      "integrity": "sha512-5wg/zB5kXHxpTV5OYwJD3ja6R8yTiqIOkjOhmpEJiowkzRlbEC/BOyMvNUq5fqFIHnMCE9woO7+c3zxEQCKPjw==",
-      "license": "MIT",
-      "dependencies": {
-        "@antv/util": "^3.3.7",
-        "color-string": "^1.5.5",
-        "fecha": "^4.2.1"
-      }
-    },
-    "node_modules/@antv/util": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmmirror.com/@antv/util/-/util-3.3.11.tgz",
-      "integrity": "sha512-FII08DFM4ABh2q5rPYdr0hMtKXRgeZazvXaFYCs7J7uTcWDHUhczab2qOCJLNDugoj8jFag1djb7wS9ehaRYBg==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "gl-matrix": "^3.3.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@antv/vendor": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmmirror.com/@antv/vendor/-/vendor-1.0.11.tgz",
-      "integrity": "sha512-LmhPEQ+aapk3barntaiIxJ5VHno/Tyab2JnfdcPzp5xONh/8VSfed4bo/9xKo5HcUAEydko38vYLfj6lJliLiw==",
-      "license": "MIT AND ISC",
-      "dependencies": {
-        "@types/d3-array": "^3.2.1",
-        "@types/d3-color": "^3.1.3",
-        "@types/d3-dispatch": "^3.0.6",
-        "@types/d3-dsv": "^3.0.7",
-        "@types/d3-ease": "^3.0.2",
-        "@types/d3-fetch": "^3.0.7",
-        "@types/d3-force": "^3.0.10",
-        "@types/d3-format": "^3.0.4",
-        "@types/d3-geo": "^3.1.0",
-        "@types/d3-hierarchy": "^3.1.7",
-        "@types/d3-interpolate": "^3.0.4",
-        "@types/d3-path": "^3.1.0",
-        "@types/d3-quadtree": "^3.0.6",
-        "@types/d3-random": "^3.0.3",
-        "@types/d3-scale": "^4.0.9",
-        "@types/d3-scale-chromatic": "^3.1.0",
-        "@types/d3-shape": "^3.1.7",
-        "@types/d3-time": "^3.0.4",
-        "@types/d3-timer": "^3.0.2",
-        "d3-array": "^3.2.4",
-        "d3-color": "^3.1.0",
-        "d3-dispatch": "^3.0.1",
-        "d3-dsv": "^3.0.1",
-        "d3-ease": "^3.0.1",
-        "d3-fetch": "^3.0.1",
-        "d3-force": "^3.0.0",
-        "d3-force-3d": "^3.0.5",
-        "d3-format": "^3.1.0",
-        "d3-geo": "^3.1.1",
-        "d3-geo-projection": "^4.0.0",
-        "d3-hierarchy": "^3.1.2",
-        "d3-interpolate": "^3.0.1",
-        "d3-path": "^3.1.0",
-        "d3-quadtree": "^3.0.1",
-        "d3-random": "^3.0.1",
-        "d3-regression": "^1.3.10",
-        "d3-scale": "^4.0.2",
-        "d3-scale-chromatic": "^3.1.0",
-        "d3-shape": "^3.2.0",
-        "d3-time": "^3.1.0",
-        "d3-timer": "^3.0.1"
-      }
-    },
-    "node_modules/@antv/vendor/node_modules/d3-array": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmmirror.com/d3-array/-/d3-array-3.2.4.tgz",
-      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-      "license": "ISC",
-      "dependencies": {
-        "internmap": "1 - 2"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -516,15 +269,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmmirror.com/@babel/runtime/-/runtime-7.29.7.tgz",
-      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1777,12 +1521,6 @@
       "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
       "license": "MIT"
     },
-    "node_modules/@types/d3-color": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmmirror.com/@types/d3-color/-/d3-color-3.1.3.tgz",
-      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
-      "license": "MIT"
-    },
     "node_modules/@types/d3-contour": {
       "version": "3.0.6",
       "resolved": "https://registry.npmmirror.com/@types/d3-contour/-/d3-contour-3.0.6.tgz",
@@ -1793,85 +1531,11 @@
         "@types/geojson": "*"
       }
     },
-    "node_modules/@types/d3-dispatch": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
-      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-dsv": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
-      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-ease": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmmirror.com/@types/d3-ease/-/d3-ease-3.0.2.tgz",
-      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-fetch": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
-      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-dsv": "*"
-      }
-    },
-    "node_modules/@types/d3-force": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmmirror.com/@types/d3-force/-/d3-force-3.0.10.tgz",
-      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-format": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmmirror.com/@types/d3-format/-/d3-format-3.0.4.tgz",
-      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-geo": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmmirror.com/@types/d3-geo/-/d3-geo-3.1.0.tgz",
-      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/geojson": "*"
-      }
-    },
-    "node_modules/@types/d3-hierarchy": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmmirror.com/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
-      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-interpolate": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmmirror.com/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
-      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-color": "*"
-      }
-    },
     "node_modules/@types/d3-path": {
       "version": "3.1.1",
       "resolved": "https://registry.npmmirror.com/@types/d3-path/-/d3-path-3.1.1.tgz",
       "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-quadtree": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmmirror.com/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
-      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-random": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmmirror.com/@types/d3-random/-/d3-random-3.0.3.tgz",
-      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/d3-sankey": {
@@ -1901,41 +1565,15 @@
         "@types/d3-path": "^1"
       }
     },
-    "node_modules/@types/d3-scale": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmmirror.com/@types/d3-scale/-/d3-scale-4.0.9.tgz",
-      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-time": "*"
-      }
-    },
-    "node_modules/@types/d3-scale-chromatic": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmmirror.com/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
-      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
-      "license": "MIT"
-    },
     "node_modules/@types/d3-shape": {
       "version": "3.1.8",
       "resolved": "https://registry.npmmirror.com/@types/d3-shape/-/d3-shape-3.1.8.tgz",
       "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/d3-path": "*"
       }
-    },
-    "node_modules/@types/d3-time": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmmirror.com/@types/d3-time/-/d3-time-3.0.4.tgz",
-      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-timer": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmmirror.com/@types/d3-timer/-/d3-timer-3.0.2.tgz",
-      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
-      "license": "MIT"
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
@@ -2147,6 +1785,15 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/accessor-fn": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmmirror.com/accessor-fn/-/accessor-fn-1.5.3.tgz",
+      "integrity": "sha512-rkAofCwe/FvYFUlMB0v0gWmhqtfAtV1IUkdPbfhTUyYniu5LrC0A0UJkTH0Jv3S8SvwkmfuAlY+mQIJATdocMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmmirror.com/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2155,15 +1802,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/base64-arraybuffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmmirror.com/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
-      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
       }
     },
     "node_modules/baseline-browser-mapping": {
@@ -2177,6 +1815,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bezier-js": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmmirror.com/bezier-js/-/bezier-js-6.1.4.tgz",
+      "integrity": "sha512-PA0FW9ZpcHbojUCMu28z9Vg/fNkwTj5YhusSAjHHDfHDGLxJ6YUKrAN2vk1fP2MMOxVw4Oko16FMlRGVBGqLKg==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/Pomax/bezierjs/blob/master/FUNDING.md"
       }
     },
     "node_modules/browserslist": {
@@ -2213,12 +1861,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/bubblesets-js": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmmirror.com/bubblesets-js/-/bubblesets-js-2.3.4.tgz",
-      "integrity": "sha512-DyMjHmpkS2+xcFNtyN00apJYL3ESdp9fTrkDr5+9Qg/GPqFmcWgGsK1akZnttE1XFxJ/VMy4DNNGMGYtmFp1Sg==",
-      "license": "MIT"
-    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001800",
       "resolved": "https://registry.npmmirror.com/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
@@ -2239,6 +1881,18 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas-color-tracker": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmmirror.com/canvas-color-tracker/-/canvas-color-tracker-1.3.2.tgz",
+      "integrity": "sha512-ryQkDX26yJ3CXzb3hxUVNlg1NKE4REc5crLBq661Nxzr8TNd236SaEf2ffYLXyI5tSABSeguHLqcVq4vf9L3Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "tinycolor2": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/chai": {
       "version": "6.2.2",
@@ -2271,37 +1925,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmmirror.com/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT"
-    },
-    "node_modules/color-string": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmmirror.com/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
-    },
-    "node_modules/comlink": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmmirror.com/comlink/-/comlink-4.4.2.tgz",
-      "integrity": "sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmmirror.com/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmmirror.com/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -2322,19 +1945,11 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/css-line-break": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmmirror.com/css-line-break/-/css-line-break-2.1.0.tgz",
-      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
-      "license": "MIT",
-      "dependencies": {
-        "utrie": "^1.0.2"
-      }
-    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmmirror.com/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -2394,26 +2009,14 @@
         "node": ">=12"
       }
     },
-    "node_modules/d3-dsv": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmmirror.com/d3-dsv/-/d3-dsv-3.0.1.tgz",
-      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
       "license": "ISC",
       "dependencies": {
-        "commander": "7",
-        "iconv-lite": "0.6",
-        "rw": "1"
-      },
-      "bin": {
-        "csv2json": "bin/dsv2json.js",
-        "csv2tsv": "bin/dsv2dsv.js",
-        "dsv2dsv": "bin/dsv2dsv.js",
-        "dsv2json": "bin/dsv2json.js",
-        "json2csv": "bin/json2dsv.js",
-        "json2dsv": "bin/json2dsv.js",
-        "json2tsv": "bin/json2dsv.js",
-        "tsv2csv": "bin/dsv2dsv.js",
-        "tsv2json": "bin/dsv2json.js"
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
       },
       "engines": {
         "node": ">=12"
@@ -2424,32 +2027,6 @@
       "resolved": "https://registry.npmmirror.com/d3-ease/-/d3-ease-3.0.1.tgz",
       "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
       "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-fetch": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmmirror.com/d3-fetch/-/d3-fetch-3.0.1.tgz",
-      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-dsv": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-force": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmmirror.com/d3-force/-/d3-force-3.0.0.tgz",
-      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-dispatch": "1 - 3",
-        "d3-quadtree": "1 - 3",
-        "d3-timer": "1 - 3"
-      },
       "engines": {
         "node": ">=12"
       }
@@ -2474,48 +2051,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmmirror.com/d3-format/-/d3-format-3.1.2.tgz",
       "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-geo": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmmirror.com/d3-geo/-/d3-geo-3.1.1.tgz",
-      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2.5.0 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-geo-projection": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmmirror.com/d3-geo-projection/-/d3-geo-projection-4.0.0.tgz",
-      "integrity": "sha512-p0bK60CEzph1iqmnxut7d/1kyTmm3UWtPlwdkM31AU+LW+BXazd5zJdoCn7VFxNCHXRngPHRnsNn5uGjLRGndg==",
-      "license": "ISC",
-      "dependencies": {
-        "commander": "7",
-        "d3-array": "1 - 3",
-        "d3-geo": "1.12.0 - 3"
-      },
-      "bin": {
-        "geo2svg": "bin/geo2svg.js",
-        "geograticule": "bin/geograticule.js",
-        "geoproject": "bin/geoproject.js",
-        "geoquantize": "bin/geoquantize.js",
-        "geostitch": "bin/geostitch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-hierarchy": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmmirror.com/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
-      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -2556,21 +2091,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/d3-random": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmmirror.com/d3-random/-/d3-random-3.0.1.tgz",
-      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-regression": {
-      "version": "1.3.10",
-      "resolved": "https://registry.npmmirror.com/d3-regression/-/d3-regression-1.3.10.tgz",
-      "integrity": "sha512-PF8GWEL70cHHWpx2jUQXc68r1pyPHIA+St16muk/XRokETzlegj5LriNKg7o4LR0TySug4nHYPJNNRz/W+/Niw==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/d3-sankey": {
       "version": "0.12.3",
@@ -2626,6 +2146,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-shape": {
       "version": "3.2.0",
       "resolved": "https://registry.npmmirror.com/d3-shape/-/d3-shape-3.2.0.tgz",
@@ -2671,14 +2200,39 @@
         "node": ">=12"
       }
     },
-    "node_modules/dagre": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmmirror.com/dagre/-/dagre-0.8.5.tgz",
-      "integrity": "sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==",
-      "license": "MIT",
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
       "dependencies": {
-        "graphlib": "^2.1.8",
-        "lodash": "^4.17.15"
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/debug": {
@@ -2799,12 +2353,6 @@
         "@types/estree": "^1.0.0"
       }
     },
-    "node_modules/eventemitter3": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmmirror.com/eventemitter3/-/eventemitter3-5.0.4.tgz",
-      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
-      "license": "MIT"
-    },
     "node_modules/expect-type": {
       "version": "1.4.0",
       "resolved": "https://registry.npmmirror.com/expect-type/-/expect-type-1.4.0.tgz",
@@ -2814,12 +2362,6 @@
       "engines": {
         "node": ">=12.0.0"
       }
-    },
-    "node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmmirror.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -2839,17 +2381,51 @@
         }
       }
     },
-    "node_modules/fecha": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmmirror.com/fecha/-/fecha-4.2.3.tgz",
-      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
-      "license": "MIT"
-    },
     "node_modules/fflate": {
       "version": "0.8.3",
       "resolved": "https://registry.npmmirror.com/fflate/-/fflate-0.8.3.tgz",
       "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "license": "MIT"
+    },
+    "node_modules/float-tooltip": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmmirror.com/float-tooltip/-/float-tooltip-1.7.5.tgz",
+      "integrity": "sha512-/kXzuDnnBqyyWyhDMH7+PfP8J/oXiAavGzcRxASOMRHFuReDtofizLLJsf7nnDLAfEaMW4pVWaXrAjtnglpEkg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-selection": "2 - 3",
+        "kapsule": "^1.16",
+        "preact": "10"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/force-graph": {
+      "version": "1.51.4",
+      "resolved": "https://registry.npmmirror.com/force-graph/-/force-graph-1.51.4.tgz",
+      "integrity": "sha512-TdJ2KbkoiDQ7NIRx8IPGD0mAXXpLhamS7c+b7W98b0MHG7lphnda1VOQX/98UDTsttIAdH4TcP0l0MauSnLK8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@tweenjs/tween.js": "18 - 25",
+        "accessor-fn": "1",
+        "bezier-js": "3 - 6",
+        "canvas-color-tracker": "^1.3",
+        "d3-array": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-force-3d": "2 - 3",
+        "d3-scale": "1 - 4",
+        "d3-scale-chromatic": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-zoom": "2 - 3",
+        "float-tooltip": "^1.7",
+        "index-array-by": "1",
+        "kapsule": "^1.16",
+        "lodash-es": "4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -2876,12 +2452,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/gl-matrix": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmmirror.com/gl-matrix/-/gl-matrix-3.4.4.tgz",
-      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
-      "license": "MIT"
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmmirror.com/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -2889,38 +2459,13 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/graphlib": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmmirror.com/graphlib/-/graphlib-2.1.8.tgz",
-      "integrity": "sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==",
+    "node_modules/index-array-by": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmmirror.com/index-array-by/-/index-array-by-1.4.2.tgz",
+      "integrity": "sha512-SP23P27OUKzXWEC/TOyWlwLviofQkCSCKONnc62eItjp69yCZZPqDQtr3Pw5gJDnPeUMqExmKydNZaJO0FU9pw==",
       "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.15"
-      }
-    },
-    "node_modules/html2canvas": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmmirror.com/html2canvas/-/html2canvas-1.4.1.tgz",
-      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
-      "license": "MIT",
-      "dependencies": {
-        "css-line-break": "^2.1.0",
-        "text-segmentation": "^1.0.3"
-      },
       "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmmirror.com/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
+        "node": ">=12"
       }
     },
     "node_modules/internmap": {
@@ -2929,17 +2474,14 @@
       "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
       "license": "ISC"
     },
-    "node_modules/is-any-array": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmmirror.com/is-any-array/-/is-any-array-3.0.0.tgz",
-      "integrity": "sha512-o4h+tylWykC4BD1vaejp6gDxoM13bwW8FGuNs4yIKpj8xbBJcRxJx8vZpq0dCr7ZDEfeKjmsi/euolKhX6f/ww==",
-      "license": "MIT"
-    },
-    "node_modules/is-arrayish": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmmirror.com/is-arrayish/-/is-arrayish-0.3.4.tgz",
-      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
-      "license": "MIT"
+    "node_modules/jerrypick": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmmirror.com/jerrypick/-/jerrypick-1.1.2.tgz",
+      "integrity": "sha512-YKnxXEekXKzhpf7CLYA0A+oDP8V0OhICNCr5lv96FvSsDEmrb0GKM776JgQvHTMjr7DTTPEVv/1Ciaw0uEWzBA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/jiti": {
       "version": "2.7.0",
@@ -2955,7 +2497,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmmirror.com/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsesc": {
@@ -2982,6 +2523,18 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/kapsule": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmmirror.com/kapsule/-/kapsule-1.16.3.tgz",
+      "integrity": "sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "4"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/lightningcss": {
@@ -3245,11 +2798,23 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/lodash": {
+    "node_modules/lodash-es": {
       "version": "4.18.1",
-      "resolved": "https://registry.npmmirror.com/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "resolved": "https://registry.npmmirror.com/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmmirror.com/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -3286,45 +2851,6 @@
       "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
       "license": "MIT"
     },
-    "node_modules/ml-array-max": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmmirror.com/ml-array-max/-/ml-array-max-2.0.0.tgz",
-      "integrity": "sha512-QQZ4kENwpWmyNb98UXRDFXrmtIXuXtt1+bSbda/2KA85+F+rrJP8hZk6QOkCQXM2Th9mUDYdq/PNByPdT9ID4A==",
-      "license": "MIT",
-      "dependencies": {
-        "is-any-array": "^3.0.0"
-      }
-    },
-    "node_modules/ml-array-min": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmmirror.com/ml-array-min/-/ml-array-min-2.0.0.tgz",
-      "integrity": "sha512-GRj6Ky6sW9vGL6yIjgsHmXZ9YgrdmcQ8nCxPqEGeKc6dkfYg1XDYxGFxADUjNuZyoCd5PUscWAS4N+cFaX6hFg==",
-      "license": "MIT",
-      "dependencies": {
-        "is-any-array": "^3.0.0"
-      }
-    },
-    "node_modules/ml-array-rescale": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmmirror.com/ml-array-rescale/-/ml-array-rescale-2.0.0.tgz",
-      "integrity": "sha512-2GGtKfSno94/kIloWGvpp/U5Q5vLvLrza+SAaGsLeo6Xj4mEbA6Gqx+oTfZFkxnd1grT2X007HfJNs3T5BsiVg==",
-      "license": "MIT",
-      "dependencies": {
-        "is-any-array": "^3.0.0",
-        "ml-array-max": "^2.0.0",
-        "ml-array-min": "^2.0.0"
-      }
-    },
-    "node_modules/ml-matrix": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmmirror.com/ml-matrix/-/ml-matrix-6.13.0.tgz",
-      "integrity": "sha512-QpV0UTUkglg6vPUgThKGBEtit2ac6habSoZ33bwI9rU0UHZLqw6G3ukTIE8zWiUF3sjK8YAlhx/o/b9layzH8A==",
-      "license": "MIT",
-      "dependencies": {
-        "is-any-array": "^3.0.0",
-        "ml-array-rescale": "^2.0.0"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmmirror.com/ms/-/ms-2.1.3.tgz",
@@ -3359,6 +2885,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmmirror.com/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/obug": {
@@ -3431,6 +2966,35 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/preact": {
+      "version": "10.29.7",
+      "resolved": "https://registry.npmmirror.com/preact/-/preact-10.29.7.tgz",
+      "integrity": "sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmmirror.com/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.7",
       "resolved": "https://registry.npmmirror.com/react/-/react-19.2.7.tgz",
@@ -3450,6 +3014,44 @@
       },
       "peerDependencies": {
         "react": "^19.2.7"
+      }
+    },
+    "node_modules/react-force-graph-2d": {
+      "version": "1.29.1",
+      "resolved": "https://registry.npmmirror.com/react-force-graph-2d/-/react-force-graph-2d-1.29.1.tgz",
+      "integrity": "sha512-1Rl/1Z3xy2iTHKj6a0jRXGyiI86xUti81K+jBQZ+Oe46csaMikp47L5AjrzA9hY9fNGD63X8ffrqnvaORukCuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "force-graph": "^1.51",
+        "prop-types": "15",
+        "react-kapsule": "^2.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmmirror.com/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-kapsule": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmmirror.com/react-kapsule/-/react-kapsule-2.6.0.tgz",
+      "integrity": "sha512-HzLJoYb1n1kfwjXbqFFcRR0EA6oPsJ64tNdDmCSaL/bz2o9wUZRSb0cMe//grLFeF9EVoL4CD/e6ozLyzEv+PQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jerrypick": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
       }
     },
     "node_modules/react-refresh": {
@@ -3545,18 +3147,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/rw": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmmirror.com/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmmirror.com/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT"
-    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmmirror.com/scheduler/-/scheduler-0.27.0.tgz",
@@ -3586,15 +3176,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmmirror.com/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
-      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
-      "license": "MIT",
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmmirror.com/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3617,12 +3198,6 @@
       "resolved": "https://registry.npmmirror.com/std-env/-/std-env-4.2.0.tgz",
       "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/svg-path-parser": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmmirror.com/svg-path-parser/-/svg-path-parser-1.1.0.tgz",
-      "integrity": "sha512-jGCUqcQyXpfe38R7RFfhrMyfXcBmpMNJI/B+4CE9/Unkh98UporAc461GTthv+TVDuZXsBx7/WiwJb1Oh4tt4A==",
       "license": "MIT"
     },
     "node_modules/tailwind-merge": {
@@ -3656,15 +3231,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/text-segmentation": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmmirror.com/text-segmentation/-/text-segmentation-1.0.3.tgz",
-      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
-      "license": "MIT",
-      "dependencies": {
-        "utrie": "^1.0.2"
-      }
-    },
     "node_modules/three": {
       "version": "0.185.1",
       "resolved": "https://registry.npmmirror.com/three/-/three-0.185.1.tgz",
@@ -3676,6 +3242,12 @@
       "resolved": "https://registry.npmmirror.com/tinybench/-/tinybench-2.9.0.tgz",
       "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmmirror.com/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
       "license": "MIT"
     },
     "node_modules/tinyexec": {
@@ -3719,7 +3291,9 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmmirror.com/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -3771,15 +3345,6 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
-      }
-    },
-    "node_modules/utrie": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmmirror.com/utrie/-/utrie-1.0.2.tgz",
-      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
-      "license": "MIT",
-      "dependencies": {
-        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/vite": {

--- a/console-ui/package.json
+++ b/console-ui/package.json
@@ -11,10 +11,12 @@
   },
   "dependencies": {
     "@types/d3-contour": "^3.0.6",
+    "@types/d3-force": "^3.0.10",
     "@types/three": "^0.185.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "d3-contour": "^4.0.2",
+    "d3-force": "^3.0.0",
     "d3-sankey": "^0.12.3",
     "d3-shape": "^3.2.0",
     "lucide-react": "^0.525.0",

--- a/console-ui/package.json
+++ b/console-ui/package.json
@@ -21,6 +21,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-force-graph-2d": "^1.29.1",
+    "react-force-graph-3d": "^1.29.1",
     "react-router-dom": "^7.6.0",
     "tailwind-merge": "^3.3.0",
     "three": "^0.185.1"

--- a/console-ui/package.json
+++ b/console-ui/package.json
@@ -10,7 +10,6 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@antv/g6": "^5.0.49",
     "@types/d3-contour": "^3.0.6",
     "@types/three": "^0.185.1",
     "class-variance-authority": "^0.7.1",
@@ -21,6 +20,7 @@
     "lucide-react": "^0.525.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-force-graph-2d": "^1.29.1",
     "react-router-dom": "^7.6.0",
     "tailwind-merge": "^3.3.0",
     "three": "^0.185.1"

--- a/console-ui/package.json
+++ b/console-ui/package.json
@@ -12,11 +12,13 @@
   "dependencies": {
     "@types/d3-contour": "^3.0.6",
     "@types/d3-force": "^3.0.10",
+    "@types/d3-polygon": "^3.0.2",
     "@types/three": "^0.185.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "d3-contour": "^4.0.2",
     "d3-force": "^3.0.0",
+    "d3-polygon": "^3.0.1",
     "d3-sankey": "^0.12.3",
     "d3-shape": "^3.2.0",
     "lucide-react": "^0.525.0",

--- a/console-ui/src/components/KnowledgeGraph.tsx
+++ b/console-ui/src/components/KnowledgeGraph.tsx
@@ -543,6 +543,31 @@ export default function KnowledgeGraph({
     fg?.cameraPosition(to, node, 600);
   };
 
+  // Legend click → fly to that community's centroid so you don't have to hunt
+  // for it (2D: center + zoom; 3D: pull the camera in on the cluster).
+  const focusCommunity = (cluster: number) => {
+    const pts = (graphData.nodes as FGNode[]).filter(
+      (n) => n.cluster === cluster && n.x != null,
+    );
+    if (!pts.length) return;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const fg = fgRef.current as any;
+    if (!fg) return;
+    const cx = pts.reduce((s, n) => s + (n.x ?? 0), 0) / pts.length;
+    const cy = pts.reduce((s, n) => s + (n.y ?? 0), 0) / pts.length;
+    setHoverId(null);
+    if (mode === '3d') {
+      const cz = pts.reduce((s, n) => s + (n.z ?? 0), 0) / pts.length;
+      const d = Math.hypot(cx, cy, cz) || 1;
+      const dist = 110;
+      const r = 1 + dist / d;
+      fg.cameraPosition({ x: cx * r, y: cy * r, z: cz * r }, { x: cx, y: cy, z: cz }, 700);
+    } else {
+      fg.centerAt(cx, cy, 600);
+      fg.zoom(Math.max(2.6, fg.zoom?.() ?? 2.6), 600);
+    }
+  };
+
   const empty = !error && data && data.nodes.length === 0;
   const communitiesForLegend =
     scope === 'global' ? (data?.communities ?? []).slice(0, 8) : [];
@@ -678,7 +703,13 @@ export default function KnowledgeGraph({
           {communitiesForLegend.length > 0 && (
             <div className="graph-legend">
               {communitiesForLegend.map((c) => (
-                <span key={c.id} className="graph-legend-item">
+                <button
+                  key={c.id}
+                  type="button"
+                  className="graph-legend-item"
+                  title={t('graph.focusCommunity')}
+                  onClick={() => focusCommunity(c.id)}
+                >
                   <span
                     className="graph-legend-dot"
                     style={{
@@ -689,7 +720,7 @@ export default function KnowledgeGraph({
                   <span className="tiny">
                     {isMiscTheme(c.label) ? t('theme.unclassified') : c.label}
                   </span>
-                </span>
+                </button>
               ))}
             </div>
           )}

--- a/console-ui/src/components/KnowledgeGraph.tsx
+++ b/console-ui/src/components/KnowledgeGraph.tsx
@@ -15,7 +15,7 @@
  * Colors come from the DS custom properties, re-read when `data-theme` flips.
  *
  * react-force-graph-2d loads lazily so portal pages stay light. */
-import { Suspense, lazy, useEffect, useMemo, useRef, useState } from 'react';
+import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useI18n } from '../i18n';
 import {
@@ -105,8 +105,29 @@ function shouldLabel(n: GraphNode, zoom: number, forced: boolean): boolean {
   return zoom >= LABEL_BASE_ZOOM * (1 - 0.7 * imp);
 }
 
-// react-force-graph mutates node objects with x/y at runtime.
-type FGNode = GraphNode & { x?: number; y?: number };
+// react-force-graph mutates node objects with x/y/z at runtime.
+type FGNode = GraphNode & { x?: number; y?: number; z?: number };
+
+/** react-force-graph-3d injects `nodeLabel` as tooltip innerHTML — escape it so
+ * a source title / claim containing markup can't run in the console origin. */
+function escapeHtml(s: string): string {
+  return s.replace(
+    /[&<>"']/g,
+    (c) =>
+      ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c] ?? c,
+  );
+}
+
+/** WebGL capability probe — gate the 3D toggle so a GPU-less browser doesn't
+ * throw while constructing the ForceGraph3D renderer and unmount the app. */
+function webglAvailable(): boolean {
+  try {
+    const c = document.createElement('canvas');
+    return !!(c.getContext('webgl2') || c.getContext('webgl'));
+  } catch {
+    return false;
+  }
+}
 
 export default function KnowledgeGraph({
   scope,
@@ -130,8 +151,12 @@ export default function KnowledgeGraph({
   const [hoverId, setHoverId] = useState<string | null>(null);
   const [fullscreen, setFullscreen] = useState(false);
   const [mode, setMode] = useState<'2d' | '3d'>('2d');
+  const [no3d, setNo3d] = useState(false);
   const [dims, setDims] = useState({ w: 0, h: height });
   const [themeVersion, setThemeVersion] = useState(0);
+  // One-shot auto-fit per dataset, so a click-focus or a user pan isn't yanked
+  // back by a later engine-stop.
+  const fittedRef = useRef(false);
 
   const tokens = useMemo(() => readTokens(), [themeVersion]);
   const focusId = scope === 'neighborhood' && id ? `source:${id}` : null;
@@ -213,13 +238,22 @@ export default function KnowledgeGraph({
     [data],
   );
 
-  // Loosen the default forces a touch so clusters breathe.
+  // Configure forces the moment the (lazy) graph instance mounts — a
+  // data-effect would run while the graph is still suspended (ref null) and
+  // never apply. Also fires when 2D/3D swaps to a fresh instance.
+  const setFg = useCallback((fg: unknown) => {
+    fgRef.current = fg;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const g = fg as any;
+    if (!g?.d3Force) return;
+    g.d3Force('charge')?.strength(-140);
+    g.d3Force('link')?.distance(38).strength(0.5);
+  }, []);
+
+  // New dataset → allow one auto-fit again.
   useEffect(() => {
-    const fg = fgRef.current;
-    if (!fg || !data) return;
-    fg.d3Force('charge')?.strength(-140);
-    fg.d3Force('link')?.distance(38).strength(0.5);
-  }, [data]);
+    fittedRef.current = false;
+  }, [data, mode]);
 
   const openNode = (n: GraphNode) => {
     if (n.type === 'source') {
@@ -307,13 +341,20 @@ export default function KnowledgeGraph({
   };
 
   // 3D: select + fly the camera to look at the node from a fixed distance.
-  const onNodeClick3D = (node: FGNode & { z?: number }) => {
+  const onNodeClick3D = (node: FGNode) => {
     setSelected(nodeById.get(node.id) ?? node);
-    const fg = fgRef.current;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const fg = fgRef.current as any;
     const { x = 0, y = 0, z = 0 } = node;
     const dist = 120;
-    const ratio = 1 + dist / (Math.hypot(x, y, z) || 1);
-    fg?.cameraPosition({ x: x * ratio, y: y * ratio, z: z * ratio }, node, 600);
+    const d = Math.hypot(x, y, z);
+    // A node at (or near) the origin can't be offset by scaling — the camera
+    // would land ON its look-at target. Pull back along +z instead.
+    const to =
+      d < 1e-3
+        ? { x: 0, y: 0, z: dist }
+        : { x: x * (1 + dist / d), y: y * (1 + dist / d), z: z * (1 + dist / d) };
+    fg?.cameraPosition(to, node, 600);
   };
 
   const empty = !error && data && data.nodes.length === 0;
@@ -348,13 +389,17 @@ export default function KnowledgeGraph({
           <Suspense fallback={<div className="graph-note">{t('graph.loading')}</div>}>
             {mode === '2d' ? (
               <ForceGraph2D
-                ref={fgRef}
+                ref={setFg}
                 width={dims.w || undefined}
                 height={dims.h || height}
                 graphData={graphData}
                 backgroundColor="transparent"
                 cooldownTicks={140}
-                onEngineStop={() => fgRef.current?.zoomToFit(400, 36)}
+                onEngineStop={() => {
+                  if (fittedRef.current) return;
+                  fittedRef.current = true;
+                  fgRef.current?.zoomToFit(400, 36);
+                }}
                 nodeRelSize={4}
                 nodeCanvasObjectMode={() => 'replace'}
                 nodeCanvasObject={drawNode}
@@ -379,7 +424,7 @@ export default function KnowledgeGraph({
               />
             ) : (
               <ForceGraph3D
-                ref={fgRef}
+                ref={setFg}
                 width={dims.w || undefined}
                 height={dims.h || height}
                 graphData={graphData}
@@ -387,7 +432,7 @@ export default function KnowledgeGraph({
                 nodeRelSize={4}
                 nodeColor={(n: FGNode) => scopedFill(scope, n, tokens)}
                 nodeVal={(n: FGNode) => 1 + 7 * (n.importance ?? 0)}
-                nodeLabel={(n: FGNode) => n.label}
+                nodeLabel={(n: FGNode) => escapeHtml(n.label)}
                 nodeOpacity={0.95}
                 linkColor={() => tokens.link}
                 linkOpacity={0.35}
@@ -400,7 +445,17 @@ export default function KnowledgeGraph({
             <button
               type="button"
               className="graph-expand"
-              onClick={() => setMode((m) => (m === '2d' ? '3d' : '2d'))}
+              onClick={() => {
+                setMode((m) => {
+                  // Probe WebGL before mounting ForceGraph3D — a GPU-less
+                  // browser would otherwise throw and unmount the app.
+                  if (m === '2d' && !webglAvailable()) {
+                    setNo3d(true);
+                    return '2d';
+                  }
+                  return m === '2d' ? '3d' : '2d';
+                });
+              }}
             >
               {mode === '2d' ? '3D' : '2D'}
             </button>
@@ -414,6 +469,9 @@ export default function KnowledgeGraph({
           </div>
           {data.truncated && (
             <div className="graph-note graph-truncated">{t('graph.truncated')}</div>
+          )}
+          {no3d && (
+            <div className="graph-note graph-truncated">{t('graph.no3d')}</div>
           )}
           {communitiesForLegend.length > 0 && (
             <div className="graph-legend">

--- a/console-ui/src/components/KnowledgeGraph.tsx
+++ b/console-ui/src/components/KnowledgeGraph.tsx
@@ -662,6 +662,7 @@ export default function KnowledgeGraph({
                 linkWidth={0.6}
                 onNodeHover={handleHover}
                 onNodeClick={onNodeClick3D}
+                onBackgroundClick={() => setSelected(null)}
               />
             )}
           </Suspense>
@@ -695,7 +696,7 @@ export default function KnowledgeGraph({
             <div className="graph-note graph-truncated">{t('graph.truncated')}</div>
           )}
           {no3d && (
-            <div className="graph-note graph-truncated">{t('graph.no3d')}</div>
+            <div className="graph-note graph-webgl-note">{t('graph.no3d')}</div>
           )}
           {mode === '3d' && !no3d && (
             <div className="graph-note graph-controls-hint">{t('graph.controls3d')}</div>

--- a/console-ui/src/components/KnowledgeGraph.tsx
+++ b/console-ui/src/components/KnowledgeGraph.tsx
@@ -16,6 +16,7 @@
  *
  * react-force-graph-2d loads lazily so portal pages stay light. */
 import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { forceCollide } from 'd3-force';
 import { useNavigate } from 'react-router-dom';
 import { useI18n } from '../i18n';
 import {
@@ -246,9 +247,18 @@ export default function KnowledgeGraph({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const g = fg as any;
     if (!g?.d3Force) return;
-    g.d3Force('charge')?.strength(-140);
-    g.d3Force('link')?.distance(38).strength(0.5);
-  }, []);
+    // Tight, well-spaced clusters: GENTLE repulsion (the old -140 blew clusters
+    // apart AND stretched each one), SHORT STRONG links so connected/related
+    // claims pull together, and a COLLIDE force so nodes sit close without
+    // overlapping. The default center force keeps the whole thing compact.
+    g.d3Force('charge')?.strength(-34).distanceMax(240);
+    g.d3Force('link')?.distance(16).strength(1);
+    g.d3Force(
+      'collide',
+      forceCollide((n: FGNode) => nodeRadius(n, n.id === focusId) + 2).strength(0.9),
+    );
+    g.d3ReheatSimulation?.();
+  }, [focusId]);
 
   // New dataset → allow one auto-fit again.
   useEffect(() => {
@@ -428,15 +438,25 @@ export default function KnowledgeGraph({
                 width={dims.w || undefined}
                 height={dims.h || height}
                 graphData={graphData}
-                backgroundColor={tokens.bg}
-                nodeRelSize={4}
-                nodeColor={(n: FGNode) => scopedFill(scope, n, tokens)}
-                nodeVal={(n: FGNode) => 1 + 7 * (n.importance ?? 0)}
+                backgroundColor="#0b0e15"
+                nodeRelSize={5}
+                nodeColor={(n: FGNode) =>
+                  n.id === hoverId ? tokens.linkHi : scopedFill(scope, n, tokens)
+                }
+                nodeVal={(n: FGNode) => 3 + 14 * (n.importance ?? 0)}
                 nodeLabel={(n: FGNode) => escapeHtml(n.label)}
-                nodeOpacity={0.95}
-                linkColor={() => tokens.link}
-                linkOpacity={0.35}
-                linkWidth={0.5}
+                nodeOpacity={1}
+                nodeResolution={12}
+                linkColor={(l: { source: FGNode; target: FGNode }) =>
+                  hoverId != null &&
+                  ((l.source as FGNode).id === hoverId ||
+                    (l.target as FGNode).id === hoverId)
+                    ? tokens.linkHi
+                    : '#5a6270'
+                }
+                linkOpacity={0.5}
+                linkWidth={0.6}
+                onNodeHover={(n: FGNode | null) => setHoverId(n?.id ?? null)}
                 onNodeClick={onNodeClick3D}
               />
             )}

--- a/console-ui/src/components/KnowledgeGraph.tsx
+++ b/console-ui/src/components/KnowledgeGraph.tsx
@@ -309,24 +309,85 @@ export default function KnowledgeGraph({
       ctx.strokeStyle = isSel || isHover ? tokens.linkHi : tokens.accent;
       ctx.stroke();
     }
+    ctx.globalAlpha = 1;
+    // Labels are drawn in a SEPARATE post pass (drawLabels) with a budget +
+    // collision so they never overlap into spaghetti at any zoom.
+  };
 
-    if (!dim && shouldLabel(node, zoom, isFocus || isSel || isHover)) {
-      const fontSize = Math.min(14 / zoom, r * 1.6 + 4 / zoom);
-      ctx.font = `${fontSize}px 'IBM Plex Sans', 'IBM Plex Sans SC', system-ui, sans-serif`;
-      const label =
-        node.label.length > 42 ? `${node.label.slice(0, 41)}…` : node.label;
+  // Second pass over ALL nodes: pick a bounded set of non-overlapping labels,
+  // ranked (forced first, then importance), so zooming in never floods the
+  // canvas with overlapping text. Runs each frame with the live zoom.
+  const drawLabels = (ctx: CanvasRenderingContext2D, zoom: number) => {
+    const forced = (n: FGNode) =>
+      n.id === focusId || n.id === selected?.id || n.id === hoverId;
+    const ranked = [...graphData.nodes].sort((a, b) => {
+      const fa = forced(a) ? 1 : 0;
+      const fb = forced(b) ? 1 : 0;
+      if (fa !== fb) return fb - fa;
+      return (b.importance ?? 0) - (a.importance ?? 0);
+    });
+    const placed: { x0: number; y0: number; x1: number; y1: number }[] = [];
+    let budget = fullscreen ? 40 : 22;
+    const fontSize = 12 / zoom; // constant on-screen size
+    ctx.font = `${fontSize}px 'IBM Plex Sans', 'IBM Plex Sans SC', system-ui, sans-serif`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'alphabetic';
+    const pad = 2 / zoom;
+    // Spend the budget on VISIBLE nodes: map each node to screen space via the
+    // current transform and skip off-canvas ones, so zooming into a region
+    // labels that region (not off-screen global hubs).
+    const m = ctx.getTransform();
+    const W = dims.w || m.a; // fallback if width unknown
+    const H = dims.h || m.d;
+    const onScreen = (x: number, y: number) => {
+      const sx = m.a * x + m.c * y + m.e;
+      const sy = m.b * x + m.d * y + m.f;
+      return sx >= -20 && sx <= W + 20 && sy >= -20 && sy <= H + 20;
+    };
+
+    for (const n of ranked) {
+      const isForced = forced(n);
+      if (!isForced) {
+        if (budget <= 0) break;
+        if (!onScreen(n.x ?? 0, n.y ?? 0)) continue;
+        if (!shouldLabel(n, zoom, false)) continue;
+        // On hover, only the hovered node's neighborhood keeps its labels.
+        if (
+          hoverId != null &&
+          !(adjacency.get(hoverId)?.has(n.id) ?? false)
+        )
+          continue;
+      }
+      const x = n.x ?? 0;
+      const y = n.y ?? 0;
+      const r = nodeRadius(n, n.id === focusId);
+      const label = n.label.length > 42 ? `${n.label.slice(0, 41)}…` : n.label;
       const tw = ctx.measureText(label).width;
-      const ly = y + r + fontSize * 0.9;
+      const ly = y + r + fontSize;
+      const box = {
+        x0: x - tw / 2 - pad,
+        y0: ly - fontSize - pad,
+        x1: x + tw / 2 + pad,
+        y1: ly + pad,
+      };
+      // Collision: skip a non-forced label that overlaps a placed one.
+      if (
+        !isForced &&
+        placed.some(
+          (p) => box.x0 < p.x1 && box.x1 > p.x0 && box.y0 < p.y1 && box.y1 > p.y0,
+        )
+      )
+        continue;
+      placed.push(box);
+      if (!isForced) budget -= 1;
+
       ctx.fillStyle = tokens.surface;
-      ctx.globalAlpha = dim ? 0.12 : 0.82;
-      ctx.fillRect(x - tw / 2 - 2 / zoom, ly - fontSize, tw + 4 / zoom, fontSize + 2 / zoom);
-      ctx.globalAlpha = dim ? 0.12 : 1;
-      ctx.textAlign = 'center';
-      ctx.textBaseline = 'alphabetic';
+      ctx.globalAlpha = 0.82;
+      ctx.fillRect(box.x0, box.y0, box.x1 - box.x0, box.y1 - box.y0);
+      ctx.globalAlpha = 1;
       ctx.fillStyle = tokens.text;
       ctx.fillText(label, x, ly - fontSize * 0.2);
     }
-    ctx.globalAlpha = 1;
   };
 
   const paintPointerArea = (
@@ -413,6 +474,7 @@ export default function KnowledgeGraph({
                 nodeRelSize={4}
                 nodeCanvasObjectMode={() => 'replace'}
                 nodeCanvasObject={drawNode}
+                onRenderFramePost={drawLabels}
                 nodePointerAreaPaint={paintPointerArea}
                 linkColor={(l: { source: FGNode; target: FGNode }) => {
                   const active =

--- a/console-ui/src/components/KnowledgeGraph.tsx
+++ b/console-ui/src/components/KnowledgeGraph.tsx
@@ -160,20 +160,17 @@ export default function KnowledgeGraph({
   const fittedRef = useRef(false);
   const hoverTimer = useRef<number | undefined>(undefined);
 
-  // Debounced hover: set immediately on a node (deduped), but delay CLEARING so
-  // the brief "null" as the cursor crosses the gap between two adjacent nodes is
-  // skipped — that null-flash made the highlight flip on/off (flicker).
+  // Hover-INTENT: apply the hover highlight only once the cursor SETTLES. Every
+  // node-enter/leave resets the timer, so sweeping the mouse fast across many
+  // nodes changes nothing — the highlight (and its dimming) only kicks in when
+  // you pause on a node (or in empty space), which is exactly when a focus
+  // effect is wanted. This is what kills the flicker, not removing the dim.
   const handleHover = useCallback((n: { id: string } | null) => {
-    if (n) {
-      if (hoverTimer.current) {
-        clearTimeout(hoverTimer.current);
-        hoverTimer.current = undefined;
-      }
-      setHoverId((prev) => (prev === n.id ? prev : n.id));
-    } else {
-      if (hoverTimer.current) clearTimeout(hoverTimer.current);
-      hoverTimer.current = window.setTimeout(() => setHoverId(null), 90);
-    }
+    if (hoverTimer.current) clearTimeout(hoverTimer.current);
+    const next = n?.id ?? null;
+    hoverTimer.current = window.setTimeout(() => {
+      setHoverId((prev) => (prev === next ? prev : next));
+    }, 120);
   }, []);
 
   const tokens = useMemo(() => readTokens(), [themeVersion]);
@@ -310,13 +307,15 @@ export default function KnowledgeGraph({
     const isHover = hoverId === node.id;
     const isNeighbor =
       hoverId != null && (adjacency.get(hoverId)?.has(node.id) ?? false);
+    // Dim the rest to focus the hovered neighborhood. Safe now that hover only
+    // engages after the cursor settles (handleHover) — it no longer flips as
+    // the mouse sweeps across.
+    const dim = hoverId != null && !isHover && !isNeighbor;
     const r = nodeRadius(node, isFocus);
     const x = node.x ?? 0;
     const y = node.y ?? 0;
 
-    // No global dimming: hover ADDS a ring on the node + its neighbors (and the
-    // linkColor pass brightens incident edges). Toggling every other node's
-    // opacity as the mouse moved was the flicker source.
+    ctx.globalAlpha = dim ? 0.15 : 1;
     ctx.beginPath();
     ctx.arc(x, y, r, 0, 2 * Math.PI);
     ctx.fillStyle = scopedFill(scope, node, tokens);
@@ -326,6 +325,7 @@ export default function KnowledgeGraph({
       ctx.strokeStyle = isSel || isHover || isNeighbor ? tokens.linkHi : tokens.accent;
       ctx.stroke();
     }
+    ctx.globalAlpha = 1;
     // Labels are drawn in a SEPARATE post pass (drawLabels) with a budget +
     // collision so they never overlap into spaghetti at any zoom.
   };
@@ -370,6 +370,8 @@ export default function KnowledgeGraph({
     for (const n of ranked) {
       const isForced = forced(n);
       if (!isForced) {
+        // While settled on a node, only the neighborhood (forced) is labelled.
+        if (hoverId != null) continue;
         if (budget <= 0) break;
         if (!onScreen(n.x ?? 0, n.y ?? 0)) continue;
         if (!shouldLabel(n, zoom, false)) continue;

--- a/console-ui/src/components/KnowledgeGraph.tsx
+++ b/console-ui/src/components/KnowledgeGraph.tsx
@@ -17,6 +17,7 @@
  * react-force-graph-2d loads lazily so portal pages stay light. */
 import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { forceCollide } from 'd3-force';
+import { polygonCentroid, polygonHull } from 'd3-polygon';
 import { useNavigate } from 'react-router-dom';
 import { useI18n } from '../i18n';
 import {
@@ -107,7 +108,43 @@ function shouldLabel(n: GraphNode, zoom: number, forced: boolean): boolean {
 }
 
 // react-force-graph mutates node objects with x/y/z at runtime.
-type FGNode = GraphNode & { x?: number; y?: number; z?: number };
+type FGNode = GraphNode & { x?: number; y?: number; z?: number; vx?: number; vy?: number };
+
+/** A custom d3 force that pulls every node toward its community's live centroid,
+ * so communities settle into DISTINCT spatial regions (clean, separated hulls)
+ * instead of intermixing. Weak enough that links still shape the within-cluster
+ * structure. */
+function clusterForce(strength: number) {
+  let nodes: FGNode[] = [];
+  const force = (alpha: number) => {
+    const cen = new Map<number, { x: number; y: number; n: number }>();
+    for (const nd of nodes) {
+      if (nd.cluster > 0) {
+        const c = cen.get(nd.cluster) ?? { x: 0, y: 0, n: 0 };
+        c.x += nd.x ?? 0;
+        c.y += nd.y ?? 0;
+        c.n += 1;
+        cen.set(nd.cluster, c);
+      }
+    }
+    for (const c of cen.values()) {
+      c.x /= c.n;
+      c.y /= c.n;
+    }
+    const k = strength * alpha;
+    for (const nd of nodes) {
+      const c = cen.get(nd.cluster);
+      if (c) {
+        nd.vx = (nd.vx ?? 0) + (c.x - (nd.x ?? 0)) * k;
+        nd.vy = (nd.vy ?? 0) + (c.y - (nd.y ?? 0)) * k;
+      }
+    }
+  };
+  force.initialize = (n: FGNode[]) => {
+    nodes = n;
+  };
+  return force;
+}
 
 /** react-force-graph-3d injects `nodeLabel` as tooltip innerHTML — escape it so
  * a source title / claim containing markup can't run in the console origin. */
@@ -271,8 +308,11 @@ export default function KnowledgeGraph({
       'collide',
       forceCollide((n: FGNode) => nodeRadius(n, n.id === focusId) + 2).strength(0.9),
     );
+    // Global scope colors by community — pull each community together so the
+    // hull blobs are compact + separated. Focused scopes have no communities.
+    g.d3Force('cluster', scope === 'global' ? clusterForce(0.22) : null);
     g.d3ReheatSimulation?.();
-  }, [focusId]);
+  }, [focusId, scope]);
 
   // New dataset → allow one auto-fit again.
   useEffect(() => {
@@ -300,6 +340,63 @@ export default function KnowledgeGraph({
         : type === 'card'
           ? t('graph.kindCard')
           : t('graph.kindUnit');
+
+  // Soft translucent community "blobs" behind the graph (global scope only), so
+  // same-cluster claims read as one group at a glance. A convex hull per
+  // community, expanded and smoothed, filled + stroked with the community color
+  // at low alpha. Drawn in the PRE pass so it sits behind edges + nodes.
+  const drawHulls = (ctx: CanvasRenderingContext2D, zoom: number) => {
+    if (scope !== 'global') return;
+    const byCluster = new Map<number, [number, number][]>();
+    for (const n of graphData.nodes) {
+      if (n.cluster > 0 && n.x != null && n.y != null) {
+        let arr = byCluster.get(n.cluster);
+        if (!arr) {
+          arr = [];
+          byCluster.set(n.cluster, arr);
+        }
+        arr.push([n.x, n.y]);
+      }
+    }
+    const pad = 16;
+    const mid = (a: [number, number], b: [number, number]): [number, number] => [
+      (a[0] + b[0]) / 2,
+      (a[1] + b[1]) / 2,
+    ];
+    ctx.lineJoin = 'round';
+    for (const [cluster, pts] of byCluster) {
+      if (pts.length < 3) continue;
+      const hull = polygonHull(pts);
+      if (!hull || hull.length < 3) continue;
+      const [cx, cy] = polygonCentroid(hull);
+      // Expand each vertex outward from the centroid so the blob wraps the
+      // nodes with breathing room.
+      const exp = hull.map(([x, y]) => {
+        const dx = x - cx;
+        const dy = y - cy;
+        const d = Math.hypot(dx, dy) || 1;
+        return [x + (dx / d) * pad, y + (dy / d) * pad] as [number, number];
+      });
+      const color = tokens.community[(cluster - 1) % tokens.community.length];
+      const nn = exp.length;
+      ctx.beginPath();
+      const start = mid(exp[nn - 1], exp[0]);
+      ctx.moveTo(start[0], start[1]);
+      for (let i = 0; i < nn; i++) {
+        const m = mid(exp[i], exp[(i + 1) % nn]);
+        ctx.quadraticCurveTo(exp[i][0], exp[i][1], m[0], m[1]);
+      }
+      ctx.closePath();
+      ctx.fillStyle = color;
+      ctx.globalAlpha = 0.1;
+      ctx.fill();
+      ctx.globalAlpha = 0.22;
+      ctx.lineWidth = 1.5 / zoom;
+      ctx.strokeStyle = color;
+      ctx.stroke();
+      ctx.globalAlpha = 1;
+    }
+  };
 
   const drawNode = (node: FGNode, ctx: CanvasRenderingContext2D, zoom: number) => {
     const isFocus = node.id === focusId;
@@ -492,6 +589,7 @@ export default function KnowledgeGraph({
                 nodeRelSize={4}
                 nodeCanvasObjectMode={() => 'replace'}
                 nodeCanvasObject={drawNode}
+                onRenderFramePre={drawHulls}
                 onRenderFramePost={drawLabels}
                 nodePointerAreaPaint={paintPointerArea}
                 linkColor={(l: { source: FGNode; target: FGNode }) => {
@@ -519,11 +617,11 @@ export default function KnowledgeGraph({
                 height={dims.h || height}
                 graphData={graphData}
                 backgroundColor="#0b0e15"
-                nodeRelSize={5}
+                nodeRelSize={4}
                 nodeColor={(n: FGNode) =>
                   n.id === hoverId ? tokens.linkHi : scopedFill(scope, n, tokens)
                 }
-                nodeVal={(n: FGNode) => 3 + 14 * (n.importance ?? 0)}
+                nodeVal={(n: FGNode) => 1.5 + 6 * (n.importance ?? 0)}
                 nodeLabel={(n: FGNode) => escapeHtml(n.label)}
                 nodeOpacity={1}
                 nodeResolution={12}

--- a/console-ui/src/components/KnowledgeGraph.tsx
+++ b/console-ui/src/components/KnowledgeGraph.tsx
@@ -28,8 +28,10 @@ import type { GraphNode, GraphResponse } from '../lib/types';
 import { useModel } from '../model';
 import { EmptyState } from './ui';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+/* eslint-disable @typescript-eslint/no-explicit-any */
 const ForceGraph2D = lazy(() => import('react-force-graph-2d')) as any;
+const ForceGraph3D = lazy(() => import('react-force-graph-3d')) as any;
+/* eslint-enable @typescript-eslint/no-explicit-any */
 
 export type KnowledgeGraphScope = 'neighborhood' | 'global' | 'theme';
 
@@ -54,6 +56,7 @@ interface DsTokens {
   muted: string;
   surface: string;
   accent: string;
+  bg: string;
   community: string[];
 }
 
@@ -67,6 +70,7 @@ function readTokens(): DsTokens {
     muted: v('--muted'),
     surface: v('--surface'),
     accent: v('--accent'),
+    bg: v('--graph-bg') || '#0d0f13',
     community: [1, 2, 3, 4, 5, 6, 7, 8].map((n) => v(`--c-${n}`)),
   };
 }
@@ -125,6 +129,7 @@ export default function KnowledgeGraph({
   const [selected, setSelected] = useState<GraphNode | null>(null);
   const [hoverId, setHoverId] = useState<string | null>(null);
   const [fullscreen, setFullscreen] = useState(false);
+  const [mode, setMode] = useState<'2d' | '3d'>('2d');
   const [dims, setDims] = useState({ w: 0, h: height });
   const [themeVersion, setThemeVersion] = useState(0);
 
@@ -301,6 +306,16 @@ export default function KnowledgeGraph({
     }
   };
 
+  // 3D: select + fly the camera to look at the node from a fixed distance.
+  const onNodeClick3D = (node: FGNode & { z?: number }) => {
+    setSelected(nodeById.get(node.id) ?? node);
+    const fg = fgRef.current;
+    const { x = 0, y = 0, z = 0 } = node;
+    const dist = 120;
+    const ratio = 1 + dist / (Math.hypot(x, y, z) || 1);
+    fg?.cameraPosition({ x: x * ratio, y: y * ratio, z: z * ratio }, node, 600);
+  };
+
   const empty = !error && data && data.nodes.length === 0;
   const communitiesForLegend =
     scope === 'global' ? (data?.communities ?? []).slice(0, 8) : [];
@@ -331,44 +346,72 @@ export default function KnowledgeGraph({
       {!error && data && data.nodes.length > 0 && (
         <>
           <Suspense fallback={<div className="graph-note">{t('graph.loading')}</div>}>
-            <ForceGraph2D
-              ref={fgRef}
-              width={dims.w || undefined}
-              height={dims.h || height}
-              graphData={graphData}
-              backgroundColor="transparent"
-              cooldownTicks={140}
-              onEngineStop={() => fgRef.current?.zoomToFit(400, 36)}
-              nodeRelSize={4}
-              nodeCanvasObjectMode={() => 'replace'}
-              nodeCanvasObject={drawNode}
-              nodePointerAreaPaint={paintPointerArea}
-              linkColor={(l: { source: FGNode; target: FGNode }) => {
-                const active =
+            {mode === '2d' ? (
+              <ForceGraph2D
+                ref={fgRef}
+                width={dims.w || undefined}
+                height={dims.h || height}
+                graphData={graphData}
+                backgroundColor="transparent"
+                cooldownTicks={140}
+                onEngineStop={() => fgRef.current?.zoomToFit(400, 36)}
+                nodeRelSize={4}
+                nodeCanvasObjectMode={() => 'replace'}
+                nodeCanvasObject={drawNode}
+                nodePointerAreaPaint={paintPointerArea}
+                linkColor={(l: { source: FGNode; target: FGNode }) => {
+                  const active =
+                    hoverId != null &&
+                    ((l.source as FGNode).id === hoverId ||
+                      (l.target as FGNode).id === hoverId);
+                  return active ? tokens.linkHi : tokens.link;
+                }}
+                linkWidth={(l: { source: FGNode; target: FGNode }) =>
                   hoverId != null &&
                   ((l.source as FGNode).id === hoverId ||
-                    (l.target as FGNode).id === hoverId);
-                return active ? tokens.linkHi : tokens.link;
-              }}
-              linkWidth={(l: { source: FGNode; target: FGNode }) =>
-                hoverId != null &&
-                ((l.source as FGNode).id === hoverId ||
-                  (l.target as FGNode).id === hoverId)
-                  ? 1.5
-                  : 0.6
-              }
-              onNodeHover={(n: FGNode | null) => setHoverId(n?.id ?? null)}
-              onNodeClick={onNodeClick}
-              onBackgroundClick={() => setSelected(null)}
-            />
+                    (l.target as FGNode).id === hoverId)
+                    ? 1.5
+                    : 0.6
+                }
+                onNodeHover={(n: FGNode | null) => setHoverId(n?.id ?? null)}
+                onNodeClick={onNodeClick}
+                onBackgroundClick={() => setSelected(null)}
+              />
+            ) : (
+              <ForceGraph3D
+                ref={fgRef}
+                width={dims.w || undefined}
+                height={dims.h || height}
+                graphData={graphData}
+                backgroundColor={tokens.bg}
+                nodeRelSize={4}
+                nodeColor={(n: FGNode) => scopedFill(scope, n, tokens)}
+                nodeVal={(n: FGNode) => 1 + 7 * (n.importance ?? 0)}
+                nodeLabel={(n: FGNode) => n.label}
+                nodeOpacity={0.95}
+                linkColor={() => tokens.link}
+                linkOpacity={0.35}
+                linkWidth={0.5}
+                onNodeClick={onNodeClick3D}
+              />
+            )}
           </Suspense>
-          <button
-            type="button"
-            className="graph-expand"
-            onClick={() => setFullscreen((f) => !f)}
-          >
-            {fullscreen ? t('graph.exitFullscreen') : t('graph.fullscreen')}
-          </button>
+          <div className="graph-controls">
+            <button
+              type="button"
+              className="graph-expand"
+              onClick={() => setMode((m) => (m === '2d' ? '3d' : '2d'))}
+            >
+              {mode === '2d' ? '3D' : '2D'}
+            </button>
+            <button
+              type="button"
+              className="graph-expand"
+              onClick={() => setFullscreen((f) => !f)}
+            >
+              {fullscreen ? t('graph.exitFullscreen') : t('graph.fullscreen')}
+            </button>
+          </div>
           {data.truncated && (
             <div className="graph-note graph-truncated">{t('graph.truncated')}</div>
           )}

--- a/console-ui/src/components/KnowledgeGraph.tsx
+++ b/console-ui/src/components/KnowledgeGraph.tsx
@@ -119,12 +119,12 @@ function escapeHtml(s: string): string {
   );
 }
 
-/** WebGL capability probe — gate the 3D toggle so a GPU-less browser doesn't
- * throw while constructing the ForceGraph3D renderer and unmount the app. */
+/** WebGL2 capability probe — gate the 3D toggle so a browser without it doesn't
+ * throw while constructing the ForceGraph3D renderer and unmount the app.
+ * three@0.185 dropped WebGL1, so a webgl1-only context must NOT pass. */
 function webglAvailable(): boolean {
   try {
-    const c = document.createElement('canvas');
-    return !!(c.getContext('webgl2') || c.getContext('webgl'));
+    return !!document.createElement('canvas').getContext('webgl2');
   } catch {
     return false;
   }
@@ -447,6 +447,7 @@ export default function KnowledgeGraph({
                 nodeLabel={(n: FGNode) => escapeHtml(n.label)}
                 nodeOpacity={1}
                 nodeResolution={12}
+                showNavInfo={false}
                 linkColor={(l: { source: FGNode; target: FGNode }) =>
                   hoverId != null &&
                   ((l.source as FGNode).id === hoverId ||
@@ -492,6 +493,9 @@ export default function KnowledgeGraph({
           )}
           {no3d && (
             <div className="graph-note graph-truncated">{t('graph.no3d')}</div>
+          )}
+          {mode === '3d' && !no3d && (
+            <div className="graph-note graph-controls-hint">{t('graph.controls3d')}</div>
           )}
           {communitiesForLegend.length > 0 && (
             <div className="graph-legend">

--- a/console-ui/src/components/KnowledgeGraph.tsx
+++ b/console-ui/src/components/KnowledgeGraph.tsx
@@ -158,6 +158,23 @@ export default function KnowledgeGraph({
   // One-shot auto-fit per dataset, so a click-focus or a user pan isn't yanked
   // back by a later engine-stop.
   const fittedRef = useRef(false);
+  const hoverTimer = useRef<number | undefined>(undefined);
+
+  // Debounced hover: set immediately on a node (deduped), but delay CLEARING so
+  // the brief "null" as the cursor crosses the gap between two adjacent nodes is
+  // skipped — that null-flash made the highlight flip on/off (flicker).
+  const handleHover = useCallback((n: { id: string } | null) => {
+    if (n) {
+      if (hoverTimer.current) {
+        clearTimeout(hoverTimer.current);
+        hoverTimer.current = undefined;
+      }
+      setHoverId((prev) => (prev === n.id ? prev : n.id));
+    } else {
+      if (hoverTimer.current) clearTimeout(hoverTimer.current);
+      hoverTimer.current = window.setTimeout(() => setHoverId(null), 90);
+    }
+  }, []);
 
   const tokens = useMemo(() => readTokens(), [themeVersion]);
   const focusId = scope === 'neighborhood' && id ? `source:${id}` : null;
@@ -291,25 +308,24 @@ export default function KnowledgeGraph({
     const isFocus = node.id === focusId;
     const isSel = selected?.id === node.id;
     const isHover = hoverId === node.id;
-    const dim =
-      hoverId != null &&
-      !isHover &&
-      !(adjacency.get(hoverId)?.has(node.id) ?? false);
+    const isNeighbor =
+      hoverId != null && (adjacency.get(hoverId)?.has(node.id) ?? false);
     const r = nodeRadius(node, isFocus);
     const x = node.x ?? 0;
     const y = node.y ?? 0;
 
-    ctx.globalAlpha = dim ? 0.12 : 1;
+    // No global dimming: hover ADDS a ring on the node + its neighbors (and the
+    // linkColor pass brightens incident edges). Toggling every other node's
+    // opacity as the mouse moved was the flicker source.
     ctx.beginPath();
     ctx.arc(x, y, r, 0, 2 * Math.PI);
     ctx.fillStyle = scopedFill(scope, node, tokens);
     ctx.fill();
-    if (isFocus || isSel || isHover) {
-      ctx.lineWidth = 1.5 / zoom;
-      ctx.strokeStyle = isSel || isHover ? tokens.linkHi : tokens.accent;
+    if (isFocus || isSel || isHover || isNeighbor) {
+      ctx.lineWidth = (isHover || isSel ? 1.6 : 1) / zoom;
+      ctx.strokeStyle = isSel || isHover || isNeighbor ? tokens.linkHi : tokens.accent;
       ctx.stroke();
     }
-    ctx.globalAlpha = 1;
     // Labels are drawn in a SEPARATE post pass (drawLabels) with a budget +
     // collision so they never overlap into spaghetti at any zoom.
   };
@@ -318,8 +334,14 @@ export default function KnowledgeGraph({
   // ranked (forced first, then importance), so zooming in never floods the
   // canvas with overlapping text. Runs each frame with the live zoom.
   const drawLabels = (ctx: CanvasRenderingContext2D, zoom: number) => {
+    // Hover LABELS the node + its neighbors (on top of the normal budget)
+    // rather than hiding everything else — hiding/showing the whole label set
+    // as the mouse moved was a flicker source.
     const forced = (n: FGNode) =>
-      n.id === focusId || n.id === selected?.id || n.id === hoverId;
+      n.id === focusId ||
+      n.id === selected?.id ||
+      n.id === hoverId ||
+      (hoverId != null && (adjacency.get(hoverId)?.has(n.id) ?? false));
     const ranked = [...graphData.nodes].sort((a, b) => {
       const fa = forced(a) ? 1 : 0;
       const fb = forced(b) ? 1 : 0;
@@ -351,12 +373,6 @@ export default function KnowledgeGraph({
         if (budget <= 0) break;
         if (!onScreen(n.x ?? 0, n.y ?? 0)) continue;
         if (!shouldLabel(n, zoom, false)) continue;
-        // On hover, only the hovered node's neighborhood keeps its labels.
-        if (
-          hoverId != null &&
-          !(adjacency.get(hoverId)?.has(n.id) ?? false)
-        )
-          continue;
       }
       const x = n.x ?? 0;
       const y = n.y ?? 0;
@@ -490,7 +506,7 @@ export default function KnowledgeGraph({
                     ? 1.5
                     : 0.6
                 }
-                onNodeHover={(n: FGNode | null) => setHoverId(n?.id ?? null)}
+                onNodeHover={handleHover}
                 onNodeClick={onNodeClick}
                 onBackgroundClick={() => setSelected(null)}
               />
@@ -519,7 +535,7 @@ export default function KnowledgeGraph({
                 }
                 linkOpacity={0.5}
                 linkWidth={0.6}
-                onNodeHover={(n: FGNode | null) => setHoverId(n?.id ?? null)}
+                onNodeHover={handleHover}
                 onNodeClick={onNodeClick3D}
               />
             )}

--- a/console-ui/src/components/KnowledgeGraph.tsx
+++ b/console-ui/src/components/KnowledgeGraph.tsx
@@ -1,27 +1,21 @@
-/** KnowledgeGraph — the scoped graph component (design §4, KMEM pattern).
- * One component, three scopes, one rendering engine:
+/** KnowledgeGraph — the scoped force-directed graph (design §4, KMEM pattern).
+ * One component, three scopes:
  *
- *   scope='neighborhood' id=<source sha>  → this source, its memory cards,
- *                                           citing claims, sibling sources
- *                                           (B2; cards added in B5)
- *   scope='global'                        → the overview/density graph —
- *                                           the Knowledge page graph view (B3)
- *   scope='theme'        id=<theme>       → the theme's claims + their
- *                                           sources — theme detail rail (B3)
+ *   scope='neighborhood' id=<source sha>  → this source + its citing claims +
+ *                                           sibling sources + memory cards
+ *   scope='global'                        → the overview graph, claims colored
+ *                                           by community
+ *   scope='theme'        id=<theme>       → the theme's claims + their sources
  *
- * All colors are read from the DS custom properties (--graph-*, --c-*,
- * --accent, --text…) at render time, and the graph re-renders when
- * `data-theme` flips (MutationObserver on <html>). Interactions: click →
- * in-component info card; double-click → navigate (source → /library/:sha,
- * claim → /knowledge#<claim_id> anchor). Sha-less legacy sources
- * (`source:<case_id>` nodes without an index page) never navigate — the
- * info card says so instead of routing to a 404 — and card nodes never
- * navigate either: they are the focus source's own memory, explained in
- * the info card (the Memory tab beside the graph has the full body).
- * Embedded height defaults to ~360px with an expand-to-fullscreen toggle.
+ * Rendered with react-force-graph-2d (canvas + d3-force). Over the old G6 view
+ * this adds: zoom-based LEVEL-OF-DETAIL (labels declutter as you zoom out and
+ * reveal as you zoom in, gated per-node by importance so hubs label first),
+ * hover-to-highlight-neighborhood, click-to-focus with an animated re-center,
+ * community coloring + legend, and an info card with an explicit open action.
+ * Colors come from the DS custom properties, re-read when `data-theme` flips.
  *
- * @antv/g6 (~1MB min) loads via dynamic import so portal pages stay light. */
-import { useEffect, useMemo, useRef, useState } from 'react';
+ * react-force-graph-2d loads lazily so portal pages stay light. */
+import { Suspense, lazy, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useI18n } from '../i18n';
 import {
@@ -34,6 +28,9 @@ import type { GraphNode, GraphResponse } from '../lib/types';
 import { useModel } from '../model';
 import { EmptyState } from './ui';
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const ForceGraph2D = lazy(() => import('react-force-graph-2d')) as any;
+
 export type KnowledgeGraphScope = 'neighborhood' | 'global' | 'theme';
 
 export interface KnowledgeGraphProps {
@@ -45,9 +42,11 @@ export interface KnowledgeGraphProps {
 }
 
 const DEFAULT_HEIGHT = 360;
+/** Base zoom at which a MAX-importance node reveals its label; leaves need to
+ * be zoomed in further. Below this the graph reads as a labelled constellation
+ * of only its most important nodes — the level-of-detail the old view lacked. */
+const LABEL_BASE_ZOOM = 1.9;
 
-/** DS tokens resolved from the live theme — read at render time so the
- * graph always matches `data-theme`. */
 interface DsTokens {
   link: string;
   linkHi: string;
@@ -72,17 +71,13 @@ function readTokens(): DsTokens {
   };
 }
 
-/** Node fill by entity kind (mockup: sources --c-1, claims --c-3, cards and
- * units --c-2 — the community palette read for the ACTIVE theme). */
 function nodeFill(type: string, t: DsTokens): string {
   if (type === 'source') return t.community[0];
   if (type === 'claim') return t.community[2];
-  // 'card' and 'unit' share the memory-layer color (--c-2).
-  return t.community[1];
+  return t.community[1]; // card + unit share the memory-layer color
 }
 
-/** Global scope colors claims by community (that's what the view is FOR);
- * the focused scopes color by entity kind. */
+/** Global scope colors claims by community; focused scopes color by kind. */
 function scopedFill(scope: KnowledgeGraphScope, n: GraphNode, t: DsTokens): string {
   if (scope === 'global' && n.cluster > 0) {
     return t.community[(n.cluster - 1) % t.community.length];
@@ -90,11 +85,24 @@ function scopedFill(scope: KnowledgeGraphScope, n: GraphNode, t: DsTokens): stri
   return nodeFill(n.type, t);
 }
 
-function nodeSize(n: GraphNode, isFocus: boolean): number {
-  if (isFocus) return 22;
-  if (n.type === 'source') return 12 + 8 * (n.importance ?? 0);
-  return 10 + 12 * (n.importance ?? 0);
+/** Node radius in graph units, driven by importance (focus node is largest). */
+function nodeRadius(n: GraphNode, isFocus: boolean): number {
+  if (isFocus) return 9;
+  const imp = n.importance ?? 0;
+  return n.type === 'source' ? 4 + 4 * imp : 3 + 6 * imp;
 }
+
+/** Per-node label LOD: an important (hub) node reveals its label at a lower
+ * zoom than a leaf, so zooming out declutters to just the backbone. `forced`
+ * (focus/selected/hovered) always labels. */
+function shouldLabel(n: GraphNode, zoom: number, forced: boolean): boolean {
+  if (forced) return true;
+  const imp = n.importance ?? 0;
+  return zoom >= LABEL_BASE_ZOOM * (1 - 0.7 * imp);
+}
+
+// react-force-graph mutates node objects with x/y at runtime.
+type FGNode = GraphNode & { x?: number; y?: number };
 
 export default function KnowledgeGraph({
   scope,
@@ -104,27 +112,26 @@ export default function KnowledgeGraph({
   const { t } = useI18n();
   const navigate = useNavigate();
   const { model } = useModel();
-  // Shas that actually have a /library/:sha page (handoff note 5): while
-  // the model is loading — or in a crystal-only vault — nothing navigates.
-  // The dblclick handler reads it through a ref so a model refresh does
-  // NOT destroy and rebuild the whole graph just to update navigability;
-  // the memoized set stays for render-time use (info-panel hint).
   const knownShas = useMemo(
     () => new Set((model?.sources ?? []).map((s) => s.sha256)),
     [model],
   );
-  const knownShasRef = useRef(knownShas);
-  useEffect(() => {
-    knownShasRef.current = knownShas;
-  }, [knownShas]);
-  const containerRef = useRef<HTMLDivElement>(null);
+
+  const wrapRef = useRef<HTMLDivElement>(null);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const fgRef = useRef<any>(null);
   const [data, setData] = useState<GraphResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [selected, setSelected] = useState<GraphNode | null>(null);
+  const [hoverId, setHoverId] = useState<string | null>(null);
   const [fullscreen, setFullscreen] = useState(false);
-  // Bumped when <html data-theme> mutates → graph rebuilds with new tokens.
+  const [dims, setDims] = useState({ w: 0, h: height });
   const [themeVersion, setThemeVersion] = useState(0);
 
+  const tokens = useMemo(() => readTokens(), [themeVersion]);
+  const focusId = scope === 'neighborhood' && id ? `source:${id}` : null;
+
+  // Rebuild with new tokens when the theme flips.
   useEffect(() => {
     const observer = new MutationObserver(() => setThemeVersion((v) => v + 1));
     observer.observe(document.documentElement, {
@@ -134,9 +141,19 @@ export default function KnowledgeGraph({
     return () => observer.disconnect();
   }, []);
 
+  // Track the container size so the canvas fills it (and refits on fullscreen).
   useEffect(() => {
-    // Scope → endpoint switch. neighborhood/theme without an id is a
-    // caller bug — surface it, don't fetch garbage.
+    const el = wrapRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver(() => {
+      setDims({ w: el.clientWidth, h: el.clientHeight });
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  // Scope → endpoint.
+  useEffect(() => {
     const request =
       scope === 'global'
         ? fetchGlobalGraph()
@@ -149,160 +166,68 @@ export default function KnowledgeGraph({
     setData(null);
     setError(null);
     setSelected(null);
+    setHoverId(null);
     if (!request) {
       setError(`KnowledgeGraph scope=${scope} requires id`);
       return;
     }
     request
-      .then((resp) => {
-        if (!cancelled) setData(resp);
-      })
-      .catch((err: unknown) => {
-        if (!cancelled) setError(String(err));
-      });
+      .then((resp) => !cancelled && setData(resp))
+      .catch((err: unknown) => !cancelled && setError(String(err)));
     return () => {
       cancelled = true;
     };
   }, [scope, id]);
 
-  useEffect(() => {
-    const container = containerRef.current;
-    if (!container || !data || data.nodes.length === 0) return;
-
-    let destroyed = false;
-    let cleanup: (() => void) | undefined;
-
-    void import('@antv/g6').then(({ Graph, NodeEvent, CanvasEvent }) => {
-      if (destroyed || !containerRef.current) return;
-      const tokens = readTokens();
-      const focusId =
-        scope === 'neighborhood' && id ? `source:${id}` : null;
-      const nodeById = new Map(data.nodes.map((n) => [n.id, n]));
-
-      const graph = new Graph({
-        container,
-        animation: false,
-        autoResize: true,
-        padding: 16,
-        autoFit: 'view',
-        data: {
-          nodes: data.nodes.map((n) => ({
-            id: n.id,
-            data: n as unknown as Record<string, unknown>,
-          })),
-          edges: data.edges.map((e, i) => ({
-            id: `e${i}`,
-            source: e.source,
-            target: e.target,
-            data: { type: e.type },
-          })),
-        },
-        node: {
-          style: {
-            size: (d: { id?: string }) => {
-              const n = nodeById.get(d.id ?? '');
-              return n ? nodeSize(n, n.id === focusId) : 10;
-            },
-            fill: (d: { id?: string }) => {
-              const n = nodeById.get(d.id ?? '');
-              return n ? scopedFill(scope, n, tokens) : tokens.muted;
-            },
-            fillOpacity: 0.92,
-            lineWidth: (d: { id?: string }) => (d.id === focusId ? 1.5 : 0),
-            stroke: tokens.accent,
-            labelText: (d: { id?: string }) =>
-              nodeById.get(d.id ?? '')?.label ?? '',
-            labelFill: tokens.text,
-            labelFontSize: 10,
-            labelFontFamily:
-              "'IBM Plex Sans', 'IBM Plex Sans SC', system-ui, sans-serif",
-            labelBackground: true,
-            labelBackgroundFill: tokens.surface,
-            labelBackgroundOpacity: 0.85,
-            labelBackgroundRadius: 4,
-            labelPadding: [1, 4],
-            labelPlacement: 'bottom',
-            labelMaxWidth: 130,
-            labelWordWrap: true,
-            labelMaxLines: 2,
-          },
-          state: {
-            selected: {
-              stroke: tokens.linkHi,
-              lineWidth: 2,
-            },
-          },
-        },
-        edge: {
-          style: {
-            stroke: tokens.link,
-            lineWidth: 1,
-            strokeOpacity: 0.9,
-          },
-        },
-        layout: {
-          type: 'd3-force',
-          link: { distance: 110, strength: 0.7 },
-          collide: { radius: 48, strength: 1.1 },
-          manyBody: { strength: -300 },
-          velocityDecay: 0.68,
-          alphaDecay: 0.04,
-        },
-        behaviors: ['zoom-canvas', 'drag-canvas', 'drag-element'],
-      });
-
-      let lastSelected: string | null = null;
-      const targetId = (evt: unknown): string =>
-        (evt as { target: { id: string } }).target.id;
-
-      graph.on(NodeEvent.CLICK, (evt: unknown) => {
-        const nodeId = targetId(evt);
-        if (lastSelected && lastSelected !== nodeId) {
-          graph.setElementState(lastSelected, []).catch(() => {});
-        }
-        graph.setElementState(nodeId, ['selected']).catch(() => {});
-        lastSelected = nodeId;
-        setSelected(nodeById.get(nodeId) ?? null);
-      });
-      graph.on(CanvasEvent.CLICK, () => {
-        if (lastSelected) {
-          graph.setElementState(lastSelected, []).catch(() => {});
-          lastSelected = null;
-        }
-        setSelected(null);
-      });
-      graph.on(NodeEvent.DBLCLICK, (evt: unknown) => {
-        const nodeId = targetId(evt);
-        if (nodeId.startsWith('source:')) {
-          // Sha-less legacy sources (`source:<case_id>`) have no
-          // /library/:sha page — never navigate to a 404.
-          const sha = nodeId.slice('source:'.length);
-          if (knownShasRef.current.has(sha)) navigate(`/library/${sha}`);
-        } else if (nodeId.startsWith('claim:')) {
-          // Node ids carry the ledger claim_key; portal anchors resolve the
-          // index claim_id — use the payload field, not the id suffix.
-          const claimId = nodeById.get(nodeId)?.claim_id ?? nodeId.slice('claim:'.length);
-          navigate(`/knowledge#${claimId}`);
-        }
-      });
-
-      graph.render().catch((err: unknown) => {
-        // Destroyed mid-render (StrictMode double-mount) is expected noise.
-        if (!graph.destroyed) console.error('knowledge graph render failed', err);
-      });
-
-      cleanup = () => graph.destroy();
-    });
-
-    return () => {
-      destroyed = true;
-      cleanup?.();
+  // Fresh node/link objects per dataset (react-force-graph owns their physics).
+  const graphData = useMemo(() => {
+    if (!data) return { nodes: [] as FGNode[], links: [] };
+    return {
+      nodes: data.nodes.map((n) => ({ ...n })) as FGNode[],
+      links: data.edges.map((e) => ({
+        source: e.source,
+        target: e.target,
+        type: e.type,
+        weight: e.weight,
+      })),
     };
-    // themeVersion intentionally re-runs this effect: same data, new tokens.
-    // scope must be a dep: switching scopes swaps the dataset, and only a
-    // re-run destroys the old graph instance. knownShas is read through a
-    // ref so a model refresh does NOT tear the graph down.
-  }, [data, id, scope, navigate, themeVersion]);
+  }, [data]);
+
+  // id → neighbor ids, for hover dimming.
+  const adjacency = useMemo(() => {
+    const m = new Map<string, Set<string>>();
+    for (const e of data?.edges ?? []) {
+      (m.get(e.source) ?? m.set(e.source, new Set()).get(e.source)!).add(e.target);
+      (m.get(e.target) ?? m.set(e.target, new Set()).get(e.target)!).add(e.source);
+    }
+    return m;
+  }, [data]);
+
+  const nodeById = useMemo(
+    () => new Map((data?.nodes ?? []).map((n) => [n.id, n])),
+    [data],
+  );
+
+  // Loosen the default forces a touch so clusters breathe.
+  useEffect(() => {
+    const fg = fgRef.current;
+    if (!fg || !data) return;
+    fg.d3Force('charge')?.strength(-140);
+    fg.d3Force('link')?.distance(38).strength(0.5);
+  }, [data]);
+
+  const openNode = (n: GraphNode) => {
+    if (n.type === 'source') {
+      const sha = n.id.slice('source:'.length);
+      if (knownShas.has(sha)) navigate(`/library/${sha}`);
+    } else if (n.type === 'claim') {
+      navigate(`/knowledge#${n.claim_id ?? n.id.slice('claim:'.length)}`);
+    }
+  };
+
+  const canOpen = (n: GraphNode) =>
+    n.type === 'claim' ||
+    (n.type === 'source' && knownShas.has(n.id.slice('source:'.length)));
 
   const kindLabel = (type: string) =>
     type === 'claim'
@@ -313,8 +238,76 @@ export default function KnowledgeGraph({
           ? t('graph.kindCard')
           : t('graph.kindUnit');
 
+  const drawNode = (node: FGNode, ctx: CanvasRenderingContext2D, zoom: number) => {
+    const isFocus = node.id === focusId;
+    const isSel = selected?.id === node.id;
+    const isHover = hoverId === node.id;
+    const dim =
+      hoverId != null &&
+      !isHover &&
+      !(adjacency.get(hoverId)?.has(node.id) ?? false);
+    const r = nodeRadius(node, isFocus);
+    const x = node.x ?? 0;
+    const y = node.y ?? 0;
+
+    ctx.globalAlpha = dim ? 0.12 : 1;
+    ctx.beginPath();
+    ctx.arc(x, y, r, 0, 2 * Math.PI);
+    ctx.fillStyle = scopedFill(scope, node, tokens);
+    ctx.fill();
+    if (isFocus || isSel || isHover) {
+      ctx.lineWidth = 1.5 / zoom;
+      ctx.strokeStyle = isSel || isHover ? tokens.linkHi : tokens.accent;
+      ctx.stroke();
+    }
+
+    if (!dim && shouldLabel(node, zoom, isFocus || isSel || isHover)) {
+      const fontSize = Math.min(14 / zoom, r * 1.6 + 4 / zoom);
+      ctx.font = `${fontSize}px 'IBM Plex Sans', 'IBM Plex Sans SC', system-ui, sans-serif`;
+      const label =
+        node.label.length > 42 ? `${node.label.slice(0, 41)}…` : node.label;
+      const tw = ctx.measureText(label).width;
+      const ly = y + r + fontSize * 0.9;
+      ctx.fillStyle = tokens.surface;
+      ctx.globalAlpha = dim ? 0.12 : 0.82;
+      ctx.fillRect(x - tw / 2 - 2 / zoom, ly - fontSize, tw + 4 / zoom, fontSize + 2 / zoom);
+      ctx.globalAlpha = dim ? 0.12 : 1;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'alphabetic';
+      ctx.fillStyle = tokens.text;
+      ctx.fillText(label, x, ly - fontSize * 0.2);
+    }
+    ctx.globalAlpha = 1;
+  };
+
+  const paintPointerArea = (
+    node: FGNode,
+    color: string,
+    ctx: CanvasRenderingContext2D,
+  ) => {
+    ctx.fillStyle = color;
+    ctx.beginPath();
+    ctx.arc(node.x ?? 0, node.y ?? 0, nodeRadius(node, node.id === focusId) + 2, 0, 2 * Math.PI);
+    ctx.fill();
+  };
+
+  const onNodeClick = (node: FGNode) => {
+    const n = nodeById.get(node.id) ?? node;
+    setSelected(n);
+    const fg = fgRef.current;
+    if (fg && node.x != null && node.y != null) {
+      fg.centerAt(node.x, node.y, 500);
+      fg.zoom(Math.max(2.4, fg.zoom()), 500);
+    }
+  };
+
+  const empty = !error && data && data.nodes.length === 0;
+  const communitiesForLegend =
+    scope === 'global' ? (data?.communities ?? []).slice(0, 8) : [];
+
   return (
     <div
+      ref={wrapRef}
       className={`graph-embed${fullscreen ? ' fullscreen' : ''}`}
       style={fullscreen ? undefined : { height }}
     >
@@ -323,7 +316,7 @@ export default function KnowledgeGraph({
           <p>{t('graph.error')}</p>
         </EmptyState>
       )}
-      {!error && data && data.nodes.length === 0 && (
+      {empty && (
         <EmptyState>
           <p>
             {scope === 'neighborhood'
@@ -337,7 +330,38 @@ export default function KnowledgeGraph({
       {!error && !data && <div className="graph-note">{t('graph.loading')}</div>}
       {!error && data && data.nodes.length > 0 && (
         <>
-          <div ref={containerRef} className="graph-canvas" />
+          <Suspense fallback={<div className="graph-note">{t('graph.loading')}</div>}>
+            <ForceGraph2D
+              ref={fgRef}
+              width={dims.w || undefined}
+              height={dims.h || height}
+              graphData={graphData}
+              backgroundColor="transparent"
+              cooldownTicks={140}
+              onEngineStop={() => fgRef.current?.zoomToFit(400, 36)}
+              nodeRelSize={4}
+              nodeCanvasObjectMode={() => 'replace'}
+              nodeCanvasObject={drawNode}
+              nodePointerAreaPaint={paintPointerArea}
+              linkColor={(l: { source: FGNode; target: FGNode }) => {
+                const active =
+                  hoverId != null &&
+                  ((l.source as FGNode).id === hoverId ||
+                    (l.target as FGNode).id === hoverId);
+                return active ? tokens.linkHi : tokens.link;
+              }}
+              linkWidth={(l: { source: FGNode; target: FGNode }) =>
+                hoverId != null &&
+                ((l.source as FGNode).id === hoverId ||
+                  (l.target as FGNode).id === hoverId)
+                  ? 1.5
+                  : 0.6
+              }
+              onNodeHover={(n: FGNode | null) => setHoverId(n?.id ?? null)}
+              onNodeClick={onNodeClick}
+              onBackgroundClick={() => setSelected(null)}
+            />
+          </Suspense>
           <button
             type="button"
             className="graph-expand"
@@ -346,8 +370,24 @@ export default function KnowledgeGraph({
             {fullscreen ? t('graph.exitFullscreen') : t('graph.fullscreen')}
           </button>
           {data.truncated && (
-            <div className="graph-note graph-truncated">
-              {t('graph.truncated')}
+            <div className="graph-note graph-truncated">{t('graph.truncated')}</div>
+          )}
+          {communitiesForLegend.length > 0 && (
+            <div className="graph-legend">
+              {communitiesForLegend.map((c) => (
+                <span key={c.id} className="graph-legend-item">
+                  <span
+                    className="graph-legend-dot"
+                    style={{
+                      background:
+                        tokens.community[(c.id - 1) % tokens.community.length],
+                    }}
+                  />
+                  <span className="tiny">
+                    {isMiscTheme(c.label) ? t('theme.unclassified') : c.label}
+                  </span>
+                </span>
+              ))}
             </div>
           )}
           {selected && (
@@ -366,17 +406,19 @@ export default function KnowledgeGraph({
                     : selected.theme}
                 </div>
               )}
-              <div className="tiny muted">
-                {selected.type === 'card'
-                  ? // Cards never navigate: they ARE this source's memory —
-                    // the full card body lives in the Memory tab beside the
-                    // graph.
-                    t('graph.cardHint')
-                  : selected.type === 'source' &&
-                      !knownShas.has(selected.id.slice('source:'.length))
-                    ? t('graph.noPage')
-                    : t('graph.openHint')}
-              </div>
+              {canOpen(selected) ? (
+                <button
+                  type="button"
+                  className="graph-info-open"
+                  onClick={() => openNode(selected)}
+                >
+                  {t('graph.open')}
+                </button>
+              ) : (
+                <div className="tiny muted">
+                  {selected.type === 'card' ? t('graph.cardHint') : t('graph.noPage')}
+                </div>
+              )}
             </div>
           )}
         </>

--- a/console-ui/src/components/KnowledgeTerrain.tsx
+++ b/console-ui/src/components/KnowledgeTerrain.tsx
@@ -32,15 +32,20 @@ const SIGMA = 3.4;
 const FULL = '9999-99-99'; // cutoff meaning "everything"
 
 function glowTexture(): THREE.Texture {
+  // 128px (was 64 → the points looked pixelated/mosaic when magnified) with a
+  // BRIGHT SHARP core and a quick soft falloff, so each source reads as a crisp
+  // bright dot rather than a fuzzy blob.
+  const S = 128;
   const c = document.createElement('canvas');
-  c.width = c.height = 64;
+  c.width = c.height = S;
   const g = c.getContext('2d')!;
-  const grd = g.createRadialGradient(32, 32, 0, 32, 32, 32);
-  grd.addColorStop(0, 'rgba(180,225,245,1)');
-  grd.addColorStop(0.25, 'rgba(130,200,230,0.85)');
-  grd.addColorStop(1, 'rgba(130,200,230,0)');
+  const grd = g.createRadialGradient(S / 2, S / 2, 0, S / 2, S / 2, S / 2);
+  grd.addColorStop(0, 'rgba(255,255,255,1)');
+  grd.addColorStop(0.14, 'rgba(215,238,252,0.98)');
+  grd.addColorStop(0.4, 'rgba(150,205,238,0.4)');
+  grd.addColorStop(1, 'rgba(150,205,238,0)');
   g.fillStyle = grd;
-  g.fillRect(0, 0, 64, 64);
+  g.fillRect(0, 0, S, S);
   const t = new THREE.CanvasTexture(c);
   t.needsUpdate = true;
   return t;
@@ -216,19 +221,23 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
     const terrainMat = new THREE.ShaderMaterial({
       uniforms: {
         uMaxH: { value: HEIGHT },
-        uLine: { value: new THREE.Color('#7fd6e6') },
-        uBase: { value: new THREE.Color('#0f151c') },
-        uPeak: { value: new THREE.Color('#183245') },
+        // Muted slate contour line (was loud cyan #7fd6e6 → looked busy/cheap)
+        // and a deeper, more neutral terrain gradient.
+        uLine: { value: new THREE.Color('#3d6076') },
+        uBase: { value: new THREE.Color('#0a0e13') },
+        uPeak: { value: new THREE.Color('#16232f') },
       },
       vertexShader: `varying float vH; void main(){ vH=position.y; gl_Position=projectionMatrix*modelViewMatrix*vec4(position,1.0); }`,
       fragmentShader: `
         uniform float uMaxH; uniform vec3 uLine; uniform vec3 uBase; uniform vec3 uPeak; varying float vH;
         void main(){
           float h=clamp(vH/uMaxH,0.0,1.0);
-          float g=h*26.0; float fp=fract(g); float dist=min(fp,1.0-fp);
+          // Fewer levels (16, was 26) and a MUCH subtler line so the terrain is a
+          // quiet backdrop and the glowing source points read as the foreground.
+          float g=h*16.0; float fp=fract(g); float dist=min(fp,1.0-fp);
           float aa=fwidth(g)*1.3+1e-4; float edge=1.0-smoothstep(0.0,aa,dist);
           vec3 terrain=mix(uBase,uPeak,h);
-          gl_FragColor=vec4(mix(terrain,uLine,edge*(0.3+0.7*h)),1.0);
+          gl_FragColor=vec4(mix(terrain,uLine,edge*(0.18+0.42*h)),1.0);
         }`,
     });
     scene.add(new THREE.Mesh(geo, terrainMat));
@@ -238,8 +247,8 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
     const parr = new Float32Array(data.points.length * 3);
     pgeo.setAttribute('position', new THREE.BufferAttribute(parr, 3));
     const pmat = new THREE.PointsMaterial({
-      size: 4.5, map: glowTexture(), transparent: true, depthWrite: false,
-      blending: THREE.AdditiveBlending, color: 0x9fd6ea, sizeAttenuation: true,
+      size: 3.8, map: glowTexture(), transparent: true, depthWrite: false,
+      blending: THREE.AdditiveBlending, color: 0xffffff, sizeAttenuation: true,
     });
     const points = new THREE.Points(pgeo, pmat);
     points.frustumCulled = false;

--- a/console-ui/src/components/KnowledgeTerrain.tsx
+++ b/console-ui/src/components/KnowledgeTerrain.tsx
@@ -528,7 +528,10 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
     );
 
   return (
-    <div ref={wrapRef} style={{ position: 'relative', width: '100%', height }}>
+    <div
+      ref={wrapRef}
+      style={{ position: 'relative', width: '100%', height, overflow: 'hidden' }}
+    >
       <div style={{ position: 'absolute', top: 10, left: 12, zIndex: 2, color: 'rgba(233,230,224,0.6)', font: '12px system-ui', pointerEvents: 'none' }}>
         {data
           ? t('knowledge.terrainHud', { notes: data.point_count, themes: data.themes.length })

--- a/console-ui/src/components/KnowledgeTerrain.tsx
+++ b/console-ui/src/components/KnowledgeTerrain.tsx
@@ -205,7 +205,10 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
 
     const labelRenderer = new CSS2DRenderer();
     labelRenderer.setSize(W, H);
-    labelRenderer.domElement.style.cssText = 'position:absolute;top:0;left:0;pointer-events:none;';
+    // overflow:hidden clips the floating theme labels to the terrain box (some
+    // project outside it behind the camera) WITHOUT clipping the React tooltip.
+    labelRenderer.domElement.style.cssText =
+      'position:absolute;top:0;left:0;width:100%;height:100%;overflow:hidden;pointer-events:none;';
     wrap.appendChild(labelRenderer.domElement);
 
     const controls = new OrbitControls(camera, renderer.domElement);
@@ -481,6 +484,17 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
 
   // ---- drive the terrain from the scrubber ----
   const atLatest = monthIdx >= months.length - 1;
+  const cutoff = atLatest || !months.length ? FULL : `${months[monthIdx]}-31`;
+  // Theme ids with at least one point visible at the current timeline cutoff —
+  // so the legend doesn't offer a future-only theme that would fly the camera
+  // to an empty spot.
+  const activeThemeIds = useMemo(() => {
+    const s = new Set<number>();
+    for (const p of data?.points ?? []) {
+      if (!p.date || p.date <= cutoff) s.add(p.theme_id);
+    }
+    return s;
+  }, [data, cutoff]);
   useEffect(() => {
     if (!applyCutoffRef.current || !months.length) return;
     applyCutoffRef.current(atLatest ? FULL : `${months[monthIdx]}-31`);
@@ -530,7 +544,7 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
   return (
     <div
       ref={wrapRef}
-      style={{ position: 'relative', width: '100%', height, overflow: 'hidden' }}
+      style={{ position: 'relative', width: '100%', height }}
     >
       <div style={{ position: 'absolute', top: 10, left: 12, zIndex: 2, color: 'rgba(233,230,224,0.6)', font: '12px system-ui', pointerEvents: 'none' }}>
         {data
@@ -550,6 +564,7 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
           }}
         >
           {[...data.themes]
+            .filter((th) => activeThemeIds.has(th.id))
             .sort((a, b) => b.count - a.count)
             .slice(0, 16)
             .map((th) => (

--- a/console-ui/src/components/KnowledgeTerrain.tsx
+++ b/console-ui/src/components/KnowledgeTerrain.tsx
@@ -9,9 +9,8 @@
  * "night map" regardless of app theme.
  */
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { useI18n } from '../i18n';
-import { terrainUrl } from '../lib/api';
+import { STATIC_MODE, terrainUrl } from '../lib/api';
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { CSS2DRenderer, CSS2DObject } from 'three/examples/jsm/renderers/CSS2DRenderer.js';
@@ -53,7 +52,6 @@ function glowTexture(): THREE.Texture {
 
 export default function KnowledgeTerrain({ height = 600 }: { height?: number }) {
   const wrapRef = useRef<HTMLDivElement>(null);
-  const navigate = useNavigate();
   const { t, lang } = useI18n();
   // Read inside the imperative three.js effect without making `lang` a build
   // dep (a scene rebuild on every locale toggle would reset the camera).
@@ -81,6 +79,10 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
   const [monthIdx, setMonthIdx] = useState(0);
   const [playing, setPlaying] = useState(false);
   const applyCutoffRef = useRef<((cutoff: string) => void) | null>(null);
+  // Imperative "fly the camera to this theme's cluster" — set by the three.js
+  // effect, called from the legend so you don't have to orbit around to find a
+  // cluster.
+  const focusThemeRef = useRef<((cx: number, cy: number) => void) | null>(null);
 
   useEffect(() => {
     let off = false;
@@ -373,13 +375,27 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
       if (slot < 0 || slot >= visibleIdx.length) return;
       const p = data.points[visibleIdx[slot]];
       if (!p?.sha) return; // pack not in the index → no /library page to open
-      navigate(`/library/${encodeURIComponent(p.sha)}`);
+      // Open in a NEW tab so the operator's tuned camera/timeline state survives
+      // (in-app navigation would unmount the terrain and reset it).
+      const path = `/library/${encodeURIComponent(p.sha)}`;
+      window.open(STATIC_MODE ? `#${path}` : path, '_blank', 'noopener');
     };
     renderer.domElement.addEventListener('pointermove', pick);
     renderer.domElement.addEventListener('pointerdown', onDown);
     renderer.domElement.addEventListener('click', onClick);
 
-    // ---- loop (tween camera only on 2D/3D switch) ----
+    // ---- legend-driven camera focus: fly to a theme's cluster centroid ----
+    let focusCam: THREE.Vector3 | null = null;
+    let focusTarget: THREE.Vector3 | null = null;
+    const focusTheme = (cx: number, cy: number) => {
+      const wx = sx(cx);
+      const wz = sy(cy);
+      focusTarget = new THREE.Vector3(wx, HEIGHT * 0.3, wz);
+      focusCam = new THREE.Vector3(wx, HEIGHT * 1.7, wz + SIZE * 0.3);
+    };
+    focusThemeRef.current = focusTheme;
+
+    // ---- loop (tween camera on 2D/3D switch or a legend focus) ----
     let raf = 0;
     const t3d = new THREE.Vector3(0, HEIGHT * 3.2, SIZE * 0.82);
     const t2d = new THREE.Vector3(0, SIZE * 1.15, 0.001);
@@ -407,6 +423,17 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
           appliedMode = modeRef.current;
           controls.enabled = true;
         }
+      } else if (focusCam && focusTarget) {
+        // Fly to the picked cluster; re-enable orbit once we arrive so you can
+        // look around it.
+        controls.enabled = false;
+        camera.position.lerp(focusCam, 0.12);
+        controls.target.lerp(focusTarget, 0.12);
+        if (camera.position.distanceTo(focusCam) < 1.5) {
+          focusCam = null;
+          focusTarget = null;
+          controls.enabled = true;
+        }
       }
       controls.update();
       renderer.render(scene, camera);
@@ -425,6 +452,7 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
 
     return () => {
       applyCutoffRef.current = null;
+      focusThemeRef.current = null;
       cancelAnimationFrame(raf);
       ro.disconnect();
       renderer.domElement.removeEventListener('pointermove', pick);
@@ -449,7 +477,7 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
       labelObjs.forEach((l) => l.obj.removeFromParent());
       labelHandlesRef.current = [];
     };
-  }, [data, height, navigate]);
+  }, [data, height]);
 
   // ---- drive the terrain from the scrubber ----
   const atLatest = monthIdx >= months.length - 1;
@@ -506,6 +534,42 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
           ? t('knowledge.terrainHud', { notes: data.point_count, themes: data.themes.length })
           : t('knowledge.terrainLoading')}
       </div>
+      {/* Clickable theme list — pick a cluster and the camera flies to it, so you
+          don't have to orbit around hunting for it. */}
+      {data && data.themes.length > 0 && (
+        <div
+          className="terrain-legend"
+          style={{
+            position: 'absolute', top: 34, left: 12, zIndex: 2,
+            maxHeight: Math.max(120, height - 96), overflowY: 'auto',
+            display: 'flex', flexDirection: 'column', gap: 1, maxWidth: '44%',
+            background: 'rgba(14,18,24,0.5)', borderRadius: 8, padding: '5px 6px',
+          }}
+        >
+          {[...data.themes]
+            .sort((a, b) => b.count - a.count)
+            .slice(0, 16)
+            .map((th) => (
+              <button
+                key={th.id}
+                type="button"
+                title={t('knowledge.terrainFocusTheme')}
+                onClick={() => {
+                  if (mode === '2d') setMode('3d');
+                  focusThemeRef.current?.(th.cx, th.cy);
+                }}
+                style={{
+                  cursor: 'pointer', textAlign: 'left', background: 'none', border: 'none',
+                  color: 'rgba(233,230,224,0.82)', font: '11px system-ui', padding: '2px 5px',
+                  borderRadius: 4, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+                }}
+              >
+                {(lang === 'zh' ? th.label_zh : th.label) || th.label}
+                <span style={{ opacity: 0.45 }}> · {th.count}</span>
+              </button>
+            ))}
+        </div>
+      )}
       <button
         type="button"
         onClick={() => setMode((m) => (m === '3d' ? '2d' : '3d'))}

--- a/console-ui/src/design/portal.css
+++ b/console-ui/src/design/portal.css
@@ -1009,6 +1009,16 @@ body {
 .graph-info-open:hover {
   border-color: var(--accent);
 }
+.graph-controls-hint {
+  position: absolute;
+  bottom: 0.35rem;
+  right: 0.6rem;
+  z-index: 2;
+  font-size: var(--ovp-text-xs);
+  color: rgba(233, 230, 224, 0.6);
+  pointer-events: none;
+  padding: 0;
+}
 .graph-legend {
   position: absolute;
   top: 0.5rem;

--- a/console-ui/src/design/portal.css
+++ b/console-ui/src/design/portal.css
@@ -969,6 +969,18 @@ body {
   font-size: var(--ovp-text-xs);
   padding: 0.35rem 0.6rem;
 }
+/* WebGL-unavailable note: bottom-CENTER so it never overlaps the bottom-left
+   truncation notice or the bottom-right 3D controls hint. */
+.graph-webgl-note {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 3;
+  font-size: var(--ovp-text-xs);
+  padding: 0.35rem 0.6rem;
+  text-align: center;
+}
 .graph-info {
   position: absolute;
   left: 0.5rem;

--- a/console-ui/src/design/portal.css
+++ b/console-ui/src/design/portal.css
@@ -1026,9 +1026,8 @@ body {
   z-index: 2;
   display: flex;
   flex-direction: column;
-  gap: 0.15rem;
+  gap: 0.05rem;
   max-width: 45%;
-  pointer-events: none;
 }
 .graph-legend-item {
   display: flex;
@@ -1038,6 +1037,18 @@ body {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  /* clickable → fly to the community */
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.1rem 0.3rem;
+  border-radius: 4px;
+  text-align: left;
+  max-width: 100%;
+}
+.graph-legend-item:hover {
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  color: var(--text);
 }
 .graph-legend-dot {
   width: 8px;

--- a/console-ui/src/design/portal.css
+++ b/console-ui/src/design/portal.css
@@ -927,6 +927,17 @@ body {
   position: absolute;
   inset: 0;
 }
+.graph-controls {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  z-index: 2;
+  display: flex;
+  gap: 0.35rem;
+}
+.graph-controls .graph-expand {
+  position: static;
+}
 .graph-expand {
   position: absolute;
   top: 0.5rem;

--- a/console-ui/src/design/portal.css
+++ b/console-ui/src/design/portal.css
@@ -1582,3 +1582,9 @@ body {
 }
 
 .facet-snapshot { color: var(--muted); font-size: 0.85em; }
+
+/* Terrain theme legend: click a theme to fly the camera to its cluster. */
+.terrain-legend button:hover {
+  background: rgba(120, 180, 205, 0.2);
+  color: #fff;
+}

--- a/console-ui/src/design/portal.css
+++ b/console-ui/src/design/portal.css
@@ -981,6 +981,49 @@ body {
 .graph-embed .empty-state {
   padding: 0.9rem;
 }
+/* react-force-graph renders its own <canvas>; keep it inside the rounded frame. */
+.graph-embed canvas {
+  display: block;
+}
+.graph-info-open {
+  margin-top: 0.4rem;
+  border: 1px solid var(--border);
+  border-radius: var(--ovp-radius-pill);
+  background: var(--surface);
+  color: var(--accent);
+  font-size: var(--ovp-text-xs);
+  padding: 0.2rem 0.6rem;
+  cursor: pointer;
+}
+.graph-info-open:hover {
+  border-color: var(--accent);
+}
+.graph-legend {
+  position: absolute;
+  top: 0.5rem;
+  left: 0.5rem;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  max-width: 45%;
+  pointer-events: none;
+}
+.graph-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  color: var(--muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.graph-legend-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
 .graph-caption {
   font-size: var(--ovp-text-xs);
   color: var(--muted);

--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -190,6 +190,7 @@ export const en = {
   'graph.kindUnit': 'unit',
   'graph.kindCard': 'card',
   'graph.openHint': 'Double-click to open.',
+  'graph.open': 'Open',
   'graph.noPage': 'Legacy source — no detail page in this vault.',
   'graph.cardHint':
     "This source's memory — the full card is in the Memory tab.",

--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -193,6 +193,7 @@ export const en = {
   'graph.open': 'Open',
   'graph.no3d': '3D needs WebGL, which is unavailable in this browser.',
   'graph.controls3d': 'Drag to rotate · scroll to zoom · right-drag to pan',
+  'graph.focusCommunity': 'Focus this community',
   'graph.noPage': 'Legacy source — no detail page in this vault.',
   'graph.cardHint':
     "This source's memory — the full card is in the Memory tab.",

--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -220,6 +220,7 @@ export const en = {
   'knowledge.terrainNoWebgl':
     'This 3D view needs WebGL, which is unavailable in this browser. Try the List or Graph view.',
   'knowledge.terrainUnclassified': 'Unclassified',
+  'knowledge.terrainFocusTheme': 'Fly to this cluster',
   'knowledge.empty':
     'No claims in the crystal store yet — crystallize sources to build the knowledge layer.',
   'knowledge.untitledTheme': '(no theme)',

--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -192,6 +192,7 @@ export const en = {
   'graph.openHint': 'Click for a summary, then Open.',
   'graph.open': 'Open',
   'graph.no3d': '3D needs WebGL, which is unavailable in this browser.',
+  'graph.controls3d': 'Drag to rotate · scroll to zoom · right-drag to pan',
   'graph.noPage': 'Legacy source — no detail page in this vault.',
   'graph.cardHint':
     "This source's memory — the full card is in the Memory tab.",

--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -171,7 +171,7 @@ export const en = {
     'Preview truncated at 200 KB — open the file in the vault for the full text.',
   'source.neighborhood': 'Neighborhood',
   'source.neighborhoodCaption':
-    'This source → its memory cards → citing claims → sibling sources. Click a node for a summary, double-click to open it.',
+    'This source → its memory cards → citing claims → sibling sources. Click a node for a summary and an open link; hover to highlight its neighborhood.',
   'source.citingClaims': 'Citing claims',
   'source.citingEmpty': 'No crystal claims cite this source yet.',
   'source.citingEmptyHint': '→ Knowledge: how claims crystallize',
@@ -189,8 +189,9 @@ export const en = {
   'graph.kindSource': 'source',
   'graph.kindUnit': 'unit',
   'graph.kindCard': 'card',
-  'graph.openHint': 'Double-click to open.',
+  'graph.openHint': 'Click for a summary, then Open.',
   'graph.open': 'Open',
+  'graph.no3d': '3D needs WebGL, which is unavailable in this browser.',
   'graph.noPage': 'Legacy source — no detail page in this vault.',
   'graph.cardHint':
     "This source's memory — the full card is in the Memory tab.",
@@ -224,7 +225,7 @@ export const en = {
   'knowledge.claimCount': '{n} claims',
   'knowledge.ratioLine': 'durable {durable} · caveated {caveated}',
   'knowledge.graphCaption':
-    'All claims, colored by community. Click a node for a summary, double-click to open its theme.',
+    'All claims, colored by community. Zoom in to reveal labels, hover to highlight a neighborhood, click for a summary. Toggle 3D to rotate.',
   'knowledge.unknownClaim':
     'No active claim "{id}" — it may have been superseded or retracted.',
 
@@ -243,7 +244,7 @@ export const en = {
   'theme.backToKnowledge': 'All themes',
   'theme.graph': 'Theme graph',
   'theme.graphCaption':
-    'This theme’s claims and the sources they cite. Click a node for a summary, double-click to open.',
+    'This theme’s claims and the sources they cite. Click a node for a summary and an open link; hover to highlight its neighborhood.',
 
   // search page + ⌘K overlay
   'search.title': 'Search',

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -177,6 +177,7 @@ export const zh: Record<keyof typeof en, string> = {
   'graph.kindUnit': '单元',
   'graph.kindCard': '卡片',
   'graph.openHint': '双击打开详情。',
+  'graph.open': '打开',
   'graph.noPage': '旧源——该 vault 中没有对应的详情页。',
   'graph.cardHint': '这是本源的记忆——完整卡片在"记忆"标签页。',
 

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -179,6 +179,7 @@ export const zh: Record<keyof typeof en, string> = {
   'graph.openHint': '单击看摘要，再点“打开”。',
   'graph.no3d': '3D 需要 WebGL，当前浏览器不可用。',
   'graph.controls3d': '拖拽旋转 · 滚轮缩放 · 右键平移',
+  'graph.focusCommunity': '聚焦这个社区',
   'graph.open': '打开',
   'graph.noPage': '旧源——该 vault 中没有对应的详情页。',
   'graph.cardHint': '这是本源的记忆——完整卡片在"记忆"标签页。',

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -158,7 +158,7 @@ export const zh: Record<keyof typeof en, string> = {
   'source.docTruncated': '预览在 200 KB 处截断——完整内容请在 vault 中打开原文件。',
   'source.neighborhood': '关联图谱 · 邻域',
   'source.neighborhoodCaption':
-    '本源 → 它的记忆卡片 → 引用它的主张 → 兄弟源。单击节点看摘要，双击打开详情。',
+    '本源 → 它的记忆卡片 → 引用它的主张 → 兄弟源。单击节点看摘要并打开；悬停高亮其邻域。',
   'source.citingClaims': '结晶引用',
   'source.citingEmpty': '暂无结晶主张引用本源。',
   'source.citingEmptyHint': '→ 知识：了解结晶如何产生',
@@ -176,7 +176,8 @@ export const zh: Record<keyof typeof en, string> = {
   'graph.kindSource': '源',
   'graph.kindUnit': '单元',
   'graph.kindCard': '卡片',
-  'graph.openHint': '双击打开详情。',
+  'graph.openHint': '单击看摘要，再点“打开”。',
+  'graph.no3d': '3D 需要 WebGL，当前浏览器不可用。',
   'graph.open': '打开',
   'graph.noPage': '旧源——该 vault 中没有对应的详情页。',
   'graph.cardHint': '这是本源的记忆——完整卡片在"记忆"标签页。',
@@ -207,7 +208,7 @@ export const zh: Record<keyof typeof en, string> = {
   'knowledge.untitledTheme': '（无主题）',
   'knowledge.claimCount': '{n} 条主张',
   'knowledge.ratioLine': '持久 {durable} · 存疑 {caveated}',
-  'knowledge.graphCaption': '全部主张，按社区着色。单击节点看摘要，双击进入其主题。',
+  'knowledge.graphCaption': '全部主张，按社区着色。放大显更多标签、悬停高亮邻域、单击看摘要，右上角可切 3D 旋转。',
   'knowledge.unknownClaim': '没有活跃主张 "{id}"——它可能已被取代或撤回。',
 
   // theme naming
@@ -223,7 +224,7 @@ export const zh: Record<keyof typeof en, string> = {
   'theme.empty': '没有活跃主张属于这个主题。',
   'theme.backToKnowledge': '全部主题',
   'theme.graph': '主题图谱',
-  'theme.graphCaption': '本主题的主张与其引用的源。单击节点看摘要，双击打开详情。',
+  'theme.graphCaption': '本主题的主张与其引用的源。单击节点看摘要并打开；悬停高亮其邻域。',
 
   // search page + ⌘K overlay
   'search.title': '搜索',

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -205,6 +205,7 @@ export const zh: Record<keyof typeof en, string> = {
     '地形尚未生成——运行 `ovp2 crystal-terrain --vault-root <vault>`。',
   'knowledge.terrainNoWebgl': '该 3D 视图需要 WebGL，当前浏览器不可用。请改用列表或图谱视图。',
   'knowledge.terrainUnclassified': '未分类',
+  'knowledge.terrainFocusTheme': '飞到这个聚类',
   'knowledge.empty': '结晶库还没有主张——对源运行结晶流程以构建知识层。',
   'knowledge.untitledTheme': '（无主题）',
   'knowledge.claimCount': '{n} 条主张',

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -178,6 +178,7 @@ export const zh: Record<keyof typeof en, string> = {
   'graph.kindCard': '卡片',
   'graph.openHint': '单击看摘要，再点“打开”。',
   'graph.no3d': '3D 需要 WebGL，当前浏览器不可用。',
+  'graph.controls3d': '拖拽旋转 · 滚轮缩放 · 右键平移',
   'graph.open': '打开',
   'graph.noPage': '旧源——该 vault 中没有对应的详情页。',
   'graph.cardHint': '这是本源的记忆——完整卡片在"记忆"标签页。',


### PR DESCRIPTION
## Why

The old AntV G6 graph had the operator's exact complaints: no real level-of-detail (every label drawn always, same density at 10 or 2000 nodes — only zoom in/out), it **threw away the server's community/importance data**, thin interaction, and a fixed style.

## What

Rewrote `KnowledgeGraph` on **react-force-graph** (canvas 2D + WebGL 3D, d3-force), same props/scopes (global · neighborhood · theme), addressing each complaint:

- **Zoom-based level-of-detail** (the big gap): labels declutter as you zoom out and reveal as you zoom in, gated **per-node by importance** so hubs label first (the thing Obsidian's own graph never shipped). Overview = a clean community constellation.
- **Community coloring + legend** — the server already computes clusters; the old view ignored them.
- **Hover** highlights a node's neighborhood + dims the rest; edges thicken.
- **Click** focuses with an animated re-center + an explicit **Open** action (source → /library/:sha, claim → /knowledge#id); legacy/card nodes explain instead of 404ing.
- **Rotatable 3D toggle** (react-force-graph-3d): drag to rotate, wheel zoom, right-drag pan — the pivotable 3D the operator wanted; labels on hover (no 3D clutter).
- Theme-aware, fullscreen, truncation note preserved.

Knowledge now has three complementary lenses: **2D (Obsidian-like LOD) / 3D (rotatable) / Terrain (themescape)**.

## Techniques borrowed (from the research)
Per-node importance-gated label LOD (Obsidian), hover-neighborhood highlight + animated focus (inkeep), color+legend communities over hulls (inkeep, cleaner). react-force-graph is what inkeep/open-knowledge uses.

## Bundle
`@antv/g6` removed (~1MB). react-force-graph-2d = 96K lazy chunk; 3D (three.js) = 696K lazy, only loaded when 3D is opened. Main chunk back to ~324K.

## Verified
Renders on the real vault across all three scopes (global/neighborhood/theme), 2D LOD declutters at overview zoom, community legend shows, 3D orbit works (headless Chrome).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upgraded the knowledge graph to a canvas-based 2D/3D force view with a WebGL2-gated mode toggle and fullscreen controls.
  * Added zoom-aware labels, hover-neighborhood highlighting (with dimming), click-to-focus navigation, a community legend, and an explicit **Open** button for eligible nodes.
* **Bug Fixes**
  * Improved responsiveness by syncing graph canvas sizing to the embed/container (including fullscreen) and preventing stale updates during navigation.
  * Refreshed empty/loading behavior for clearer states.
* **Localization**
  * Updated English and Simplified Chinese Knowledge Graph instructions/captions to match the new “click for summary, then Open” flow.
* **Style**
  * Refined Knowledge Terrain visuals (glow texture, shader tone, and point styling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->