### PR TITLE
feat(viz): unified claim/source perspective toggle across graph + terrain

### DIFF
--- a/console-ui/src/components/KnowledgeGraph.tsx
+++ b/console-ui/src/components/KnowledgeGraph.tsx
@@ -25,7 +25,7 @@ import {
   fetchSourceNeighborhood,
   fetchThemeGraph,
 } from '../lib/api';
-import { isMiscTheme } from '../lib/derive';
+import { isMiscTheme, themeRoute } from '../lib/derive';
 import type { GraphNode, GraphResponse } from '../lib/types';
 import { useModel } from '../model';
 import { EmptyState } from './ui';
@@ -43,6 +43,9 @@ export interface KnowledgeGraphProps {
   id?: string;
   /** Embedded height in px (default 360). */
   height?: number;
+  /** Global scope only: claim- vs source-centric overview (the portal's shared
+   * perspective toggle). Ignored by neighborhood/theme scopes. */
+  persp?: 'claim' | 'source';
 }
 
 const DEFAULT_HEIGHT = 360;
@@ -171,6 +174,7 @@ export default function KnowledgeGraph({
   scope,
   id,
   height = DEFAULT_HEIGHT,
+  persp = 'claim',
 }: KnowledgeGraphProps) {
   const { t } = useI18n();
   const navigate = useNavigate();
@@ -238,7 +242,7 @@ export default function KnowledgeGraph({
   useEffect(() => {
     const request =
       scope === 'global'
-        ? fetchGlobalGraph()
+        ? fetchGlobalGraph(400, persp)
         : id
           ? scope === 'neighborhood'
             ? fetchSourceNeighborhood(id)
@@ -259,7 +263,7 @@ export default function KnowledgeGraph({
     return () => {
       cancelled = true;
     };
-  }, [scope, id]);
+  }, [scope, id, persp]);
 
   // Fresh node/link objects per dataset (react-force-graph owns their physics).
   const graphData = useMemo(() => {
@@ -324,7 +328,11 @@ export default function KnowledgeGraph({
       const sha = n.id.slice('source:'.length);
       if (knownShas.has(sha)) navigate(`/library/${sha}`);
     } else if (n.type === 'claim') {
-      navigate(`/knowledge#${n.claim_id ?? n.id.slice('claim:'.length)}`);
+      // Straight to the claim's theme page, anchored to the claim card. Using
+      // the node's own `theme` skips the /knowledge# bounce (and its
+      // dead-end when a claim has no theme — themeRoute routes '' too).
+      const claimId = n.claim_id ?? n.id.slice('claim:'.length);
+      navigate(`${themeRoute(n.theme)}#${claimId}`);
     }
   };
 
@@ -518,6 +526,12 @@ export default function KnowledgeGraph({
 
   const onNodeClick = (node: FGNode) => {
     const n = nodeById.get(node.id) ?? node;
+    // Single click opens (matches the Terrain view's one-click-to-source). Only
+    // non-openable nodes (e.g. focus-tier units) fall back to select + zoom.
+    if (canOpen(n)) {
+      openNode(n);
+      return;
+    }
     setSelected(n);
     const fg = fgRef.current;
     if (fg && node.x != null && node.y != null) {
@@ -526,9 +540,14 @@ export default function KnowledgeGraph({
     }
   };
 
-  // 3D: select + fly the camera to look at the node from a fixed distance.
+  // 3D: single click opens too; non-openable nodes select + fly the camera.
   const onNodeClick3D = (node: FGNode) => {
-    setSelected(nodeById.get(node.id) ?? node);
+    const n = nodeById.get(node.id) ?? node;
+    if (canOpen(n)) {
+      openNode(n);
+      return;
+    }
+    setSelected(n);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const fg = fgRef.current as any;
     const { x = 0, y = 0, z = 0 } = node;

--- a/console-ui/src/components/KnowledgeTerrain.tsx
+++ b/console-ui/src/components/KnowledgeTerrain.tsx
@@ -11,11 +11,17 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useI18n } from '../i18n';
 import { STATIC_MODE, terrainUrl } from '../lib/api';
+import { activeClaims, sourcesByCase, themeRoute } from '../lib/derive';
+import { useModel } from '../model';
+import type { IndexModel } from '../lib/types';
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { CSS2DRenderer, CSS2DObject } from 'three/examples/jsm/renderers/CSS2DRenderer.js';
 
-type TPoint = { id: string; sha: string; title: string; date: string; theme: string; theme_id: number; x: number; y: number };
+// A rendered point is either a source (has `sha`, opens /library) or — in the
+// claim perspective — a claim (has `claim_id`, opens its theme page). The two
+// share the same buffer/hover/label machinery; only the click target differs.
+type TPoint = { id: string; sha: string; title: string; date: string; theme: string; theme_id: number; x: number; y: number; claim_id?: string };
 type TTheme = { id: number; label: string; label_zh: string; cx: number; cy: number; count: number };
 type Terrain = {
   points: TPoint[];
@@ -23,6 +29,45 @@ type Terrain = {
   bounds: [number, number, number, number];
   point_count: number;
 };
+
+/** Claim perspective of the terrain: each active claim placed at the centroid
+ * of its cited sources' positions, with a small deterministic golden-angle
+ * nudge so co-located claims don't fully overlap. The land + theme labels stay
+ * source-derived — claims simply scatter on the same corpus landscape. Returns
+ * null until the model loads; claims with no positioned source are dropped. */
+function buildClaimTerrain(data: Terrain | null, model: IndexModel | null): Terrain | null {
+  if (!data || !model) return null;
+  const byCase = sourcesByCase(model);
+  const posBySha = new Map(data.points.map((p) => [p.sha, p]));
+  const themeIdByLabel = new Map(data.themes.map((th) => [th.label, th.id]));
+  const [minx, miny, maxx, maxy] = data.bounds;
+  const jitter = Math.max(maxx - minx, maxy - miny, 1e-6) * 0.008;
+  const GOLDEN = 2.399963229728653; // radians — spreads indices around a ring
+
+  const points: TPoint[] = [];
+  activeClaims(model.claims).forEach((c, i) => {
+    const srcPts = c.sources
+      .map((caseId) => byCase.get(caseId)?.sha256)
+      .map((sha) => (sha ? posBySha.get(sha) : undefined))
+      .filter((p): p is TPoint => !!p);
+    if (srcPts.length === 0) return;
+    const cx = srcPts.reduce((s, p) => s + p.x, 0) / srcPts.length;
+    const cy = srcPts.reduce((s, p) => s + p.y, 0) / srcPts.length;
+    const theme = c.theme ?? '';
+    points.push({
+      id: `claim:${c.claim_id}`,
+      sha: '',
+      claim_id: c.claim_id,
+      title: c.claim,
+      date: '',
+      theme,
+      theme_id: themeIdByLabel.get(theme) ?? -1,
+      x: cx + Math.cos(i * GOLDEN) * jitter,
+      y: cy + Math.sin(i * GOLDEN) * jitter,
+    });
+  });
+  return { points, themes: data.themes, bounds: data.bounds, point_count: points.length };
+}
 
 const SIZE = 220;
 const GRID = 150;
@@ -50,9 +95,16 @@ function glowTexture(): THREE.Texture {
   return t;
 }
 
-export default function KnowledgeTerrain({ height = 600 }: { height?: number }) {
+export default function KnowledgeTerrain({
+  height = 600,
+  persp = 'source',
+}: {
+  height?: number;
+  persp?: 'claim' | 'source';
+}) {
   const wrapRef = useRef<HTMLDivElement>(null);
   const { t, lang } = useI18n();
+  const { model } = useModel();
   // Read inside the imperative three.js effect without making `lang` a build
   // dep (a scene rebuild on every locale toggle would reset the camera).
   const langRef = useRef(lang);
@@ -70,12 +122,18 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
   modeRef.current = mode;
   const [hover, setHover] = useState<{ mx: number; my: number; p: TPoint } | null>(null);
 
+  // The rendered dataset: source points as fetched, or claims placed on the same
+  // landscape. Everything below (scene, HUD, legend, timeline) reads `render`;
+  // `data` stays the source terrain that both modes are derived from.
+  const claimData = useMemo(() => buildClaimTerrain(data, model), [data, model]);
+  const render = persp === 'claim' ? claimData : data;
+
   const months = useMemo(() => {
-    if (!data) return [] as string[];
+    if (!render) return [] as string[];
     const set = new Set<string>();
-    for (const p of data.points) if (p.date) set.add(p.date.slice(0, 7));
+    for (const p of render.points) if (p.date) set.add(p.date.slice(0, 7));
     return [...set].sort();
-  }, [data]);
+  }, [render]);
   const [monthIdx, setMonthIdx] = useState(0);
   const [playing, setPlaying] = useState(false);
   const applyCutoffRef = useRef<((cutoff: string) => void) | null>(null);
@@ -102,7 +160,9 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
 
   // ---- three.js scene (built once per dataset) ----
   useEffect(() => {
-    if (!data || !wrapRef.current) return;
+    if (!render || !wrapRef.current) return;
+    // Alias so the source/claim datasets share one imperative body verbatim.
+    const data = render;
     const wrap = wrapRef.current;
     let W = wrap.clientWidth;
     const H = height;
@@ -377,10 +437,15 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
       const slot = slotAt(e.offsetX, e.offsetY);
       if (slot < 0 || slot >= visibleIdx.length) return;
       const p = data.points[visibleIdx[slot]];
-      if (!p?.sha) return; // pack not in the index → no /library page to open
-      // Open in a NEW tab so the operator's tuned camera/timeline state survives
-      // (in-app navigation would unmount the terrain and reset it).
-      const path = `/library/${encodeURIComponent(p.sha)}`;
+      // Claim points open their theme page; source points open /library. Both in
+      // a NEW tab so the operator's tuned camera/timeline state survives (in-app
+      // navigation would unmount the terrain and reset it).
+      const path = p.claim_id
+        ? themeRoute(p.theme)
+        : p.sha
+          ? `/library/${encodeURIComponent(p.sha)}`
+          : null;
+      if (!path) return;
       window.open(STATIC_MODE ? `#${path}` : path, '_blank', 'noopener');
     };
     renderer.domElement.addEventListener('pointermove', pick);
@@ -480,7 +545,7 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
       labelObjs.forEach((l) => l.obj.removeFromParent());
       labelHandlesRef.current = [];
     };
-  }, [data, height]);
+  }, [render, height]);
 
   // ---- drive the terrain from the scrubber ----
   const atLatest = monthIdx >= months.length - 1;
@@ -490,11 +555,11 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
   // to an empty spot.
   const activeThemeIds = useMemo(() => {
     const s = new Set<number>();
-    for (const p of data?.points ?? []) {
+    for (const p of render?.points ?? []) {
       if (!p.date || p.date <= cutoff) s.add(p.theme_id);
     }
     return s;
-  }, [data, cutoff]);
+  }, [render, cutoff]);
   useEffect(() => {
     if (!applyCutoffRef.current || !months.length) return;
     applyCutoffRef.current(atLatest ? FULL : `${months[monthIdx]}-31`);
@@ -520,12 +585,12 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
     for (const l of labelHandlesRef.current) {
       l.el.textContent = lang === 'zh' ? l.th.label_zh : l.th.label;
     }
-  }, [lang, data]);
+  }, [lang, render]);
 
   // Theme lookup for the localized tooltip (point carries only its community id).
   const themeById = useMemo(
-    () => new Map((data?.themes ?? []).map((th) => [th.id, th] as const)),
-    [data],
+    () => new Map((render?.themes ?? []).map((th) => [th.id, th] as const)),
+    [render],
   );
 
   if (failed)
@@ -547,13 +612,13 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
       style={{ position: 'relative', width: '100%', height }}
     >
       <div style={{ position: 'absolute', top: 10, left: 12, zIndex: 2, color: 'rgba(233,230,224,0.6)', font: '12px system-ui', pointerEvents: 'none' }}>
-        {data
-          ? t('knowledge.terrainHud', { notes: data.point_count, themes: data.themes.length })
+        {render
+          ? t('knowledge.terrainHud', { notes: render.point_count, themes: render.themes.length })
           : t('knowledge.terrainLoading')}
       </div>
       {/* Clickable theme list — pick a cluster and the camera flies to it, so you
           don't have to orbit around hunting for it. */}
-      {data && data.themes.length > 0 && (
+      {render && render.themes.length > 0 && (
         <div
           className="terrain-legend"
           style={{
@@ -563,7 +628,7 @@ export default function KnowledgeTerrain({ height = 600 }: { height?: number }) 
             background: 'rgba(14,18,24,0.5)', borderRadius: 8, padding: '5px 6px',
           }}
         >
-          {[...data.themes]
+          {[...render.themes]
             .filter((th) => activeThemeIds.has(th.id))
             .sort((a, b) => b.count - a.count)
             .slice(0, 16)

--- a/console-ui/src/design/portal.css
+++ b/console-ui/src/design/portal.css
@@ -762,6 +762,14 @@ body {
   text-underline-offset: 6px;
 }
 
+/* Perspective switch (claim/source) — a .seg-toggle pill pushed to the right
+   end of the view-tab row, vertically centered against the baseline-aligned
+   tab buttons so it costs no extra vertical space. */
+.tab-row .persp-toggle {
+  margin-left: auto;
+  align-self: center;
+}
+
 /* memory cards */
 .mem-card .mem-title {
   font-weight: 600;

--- a/console-ui/src/design/portal.css
+++ b/console-ui/src/design/portal.css
@@ -762,11 +762,25 @@ body {
   text-underline-offset: 6px;
 }
 
-/* Perspective switch (claim/source) — a .seg-toggle pill pushed to the right
-   end of the view-tab row, vertically centered against the baseline-aligned
-   tab buttons so it costs no extra vertical space. */
-.tab-row .persp-toggle {
-  margin-left: auto;
+/* View bar: the tab-row (left) and the claim/source perspective switch (right)
+   share one line. The switch is a SIBLING of .tab-row — nesting it inside would
+   let `.tab-row button.active` (accent text + underline) clobber the seg-toggle
+   pill, painting accent text on the accent fill (invisible). The bar owns the
+   underline so it still spans the full width. */
+.knowledge-viewbar {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 1rem;
+}
+.knowledge-viewbar .tab-row {
+  border-bottom: 0;
+  margin-bottom: 0;
+}
+.knowledge-viewbar .persp-toggle {
   align-self: center;
 }
 

--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -209,6 +209,12 @@ export const en = {
   'knowledge.viewList': 'List',
   'knowledge.viewGraph': 'Graph',
   'knowledge.viewTerrain': 'Terrain',
+  'knowledge.perspClaim': 'Claims',
+  'knowledge.perspSource': 'Sources',
+  'knowledge.perspNodeClaim':
+    'Each point is a claim — a cross-source conclusion. Click to open its theme.',
+  'knowledge.perspNodeSource':
+    'Each point is a source — an original document. Click to open it.',
   'knowledge.terrainCaption':
     'A themescape of the corpus: peaks are dense clusters (labelled by theme), each point a source. Hover a point to see the note. Built from the same embeddings as the themes.',
   'knowledge.terrainHud': '{notes} notes · {themes} themes · drag to orbit, scroll to zoom',

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -195,6 +195,10 @@ export const zh: Record<keyof typeof en, string> = {
   'knowledge.viewList': '列表',
   'knowledge.viewGraph': '图谱',
   'knowledge.viewTerrain': '地形',
+  'knowledge.perspClaim': '主张',
+  'knowledge.perspSource': '原文',
+  'knowledge.perspNodeClaim': '每个点是一条主张(跨来源结论)。单击打开它所属主题。',
+  'knowledge.perspNodeSource': '每个点是一篇原文(原始文档)。单击打开它。',
   'knowledge.terrainCaption':
     '语料的"知识地形":山峰是密集的聚类(按主题命名),每个点是一个源。悬停某点看那条笔记。与主题同源,基于同一套 embedding。',
   'knowledge.terrainHud': '{notes} 条笔记 · {themes} 个主题 · 拖拽旋转,滚轮缩放',

--- a/console-ui/src/lib/api.ts
+++ b/console-ui/src/lib/api.ts
@@ -134,9 +134,16 @@ export function fetchSourceNeighborhood(sha: string): Promise<GraphResponse> {
 /** Global scope for the KnowledgeGraph component: the overview/density graph
  * (claims + community metadata). Capped so the embedded view stays snappy —
  * the response flags truncation. */
-export function fetchGlobalGraph(limit = 400): Promise<GraphResponse> {
-  if (STATIC_MODE) return fetchJson<GraphResponse>(`${API}/graph/global.json`);
-  return fetchJson<GraphResponse>(`/api/graph?scope=global&limit=${limit}`);
+export function fetchGlobalGraph(
+  limit = 400,
+  persp: 'claim' | 'source' = 'claim',
+): Promise<GraphResponse> {
+  if (STATIC_MODE) {
+    const file = persp === 'source' ? 'global-source' : 'global';
+    return fetchJson<GraphResponse>(`${API}/graph/${file}.json`);
+  }
+  const p = persp === 'source' ? '&persp=source' : '';
+  return fetchJson<GraphResponse>(`/api/graph?scope=global&limit=${limit}${p}`);
 }
 
 /** Theme scope for the KnowledgeGraph component: the theme's claims + the

--- a/console-ui/src/lib/derive.ts
+++ b/console-ui/src/lib/derive.ts
@@ -379,7 +379,27 @@ export interface ThemeGroup {
  * portal displays it honestly as "Unclassified" — DISPLAY LAYER ONLY: keys,
  * URLs and index data keep the literal value. */
 export function isMiscTheme(theme: string | null | undefined): boolean {
-  return theme === 'misc' || theme === 'Miscellaneous';
+  // '' / nullish is the "no theme" bucket — display it as Unclassified too,
+  // so graph clicks and the wall card on unthemed claims read honestly.
+  return theme == null || theme === '' || theme === 'misc' || theme === 'Miscellaneous';
+}
+
+/** Route segment for the "no theme" bucket ('' theme key). A real theme is
+ * never this literal, so it round-trips without colliding — and unthemed
+ * claims/cards get a routable landing page instead of dead-ending on an empty
+ * `/knowledge/theme/` segment (which falls through to the catch-all redirect). */
+export const UNTHEMED_SEGMENT = '~none';
+
+/** Theme key → `/knowledge/theme/...` route, encoding the empty bucket as the
+ * routable sentinel above. */
+export function themeRoute(theme: string | null | undefined): string {
+  const key = theme ?? '';
+  return `/knowledge/theme/${key === '' ? UNTHEMED_SEGMENT : encodeURIComponent(key)}`;
+}
+
+/** Inverse of {@link themeRoute} for a decoded `:theme` route param. */
+export function themeFromRoute(param: string | null | undefined): string {
+  return param == null || param === UNTHEMED_SEGMENT ? '' : param;
 }
 
 /** Active claims only — the knowledge surface never lists superseded or

--- a/console-ui/src/pages/KnowledgePage.tsx
+++ b/console-ui/src/pages/KnowledgePage.tsx
@@ -19,15 +19,12 @@ const KnowledgeTerrain = lazy(() => import('../components/KnowledgeTerrain'));
 import { AgeLabel, EmptyState, ModelGate, PageHelp } from '../components/ui';
 import { useI18n } from '../i18n';
 import { fetchThemes } from '../lib/api';
-import { isMiscTheme, themeWall, type ThemeGroup } from '../lib/derive';
+import { isMiscTheme, themeRoute, themeWall, type ThemeGroup } from '../lib/derive';
 import type { IndexModel, ThemeCount } from '../lib/types';
 import { useModel } from '../model';
 
 type View = 'list' | 'graph' | 'terrain';
-
-function themePath(theme: string): string {
-  return `/knowledge/theme/${encodeURIComponent(theme)}`;
-}
+type Persp = 'claim' | 'source';
 
 function ThemeCard({ group }: { group: ThemeGroup }) {
   const { t } = useI18n();
@@ -37,7 +34,7 @@ function ThemeCard({ group }: { group: ThemeGroup }) {
   // link target keeps the literal theme key (display layer only).
   const misc = isMiscTheme(group.theme);
   return (
-    <Link className="theme-card" to={themePath(group.theme)}>
+    <Link className="theme-card" to={themeRoute(group.theme)}>
       <div className="theme-card-head">
         <span className="theme-card-name">
           {misc
@@ -93,6 +90,21 @@ function KnowledgeBody({ model }: { model: IndexModel }) {
     );
   };
 
+  // Perspective (?persp=) is shared by BOTH the Graph and Terrain views: claim-
+  // vs source-centric. Default 'source' (documents — the more intuitive entry).
+  const persp: Persp = params.get('persp') === 'claim' ? 'claim' : 'source';
+  const setPersp = (next: Persp) => {
+    setParams(
+      (prev) => {
+        const p = new URLSearchParams(prev);
+        if (next === 'source') p.delete('persp');
+        else p.set('persp', next);
+        return p;
+      },
+      { replace: true },
+    );
+  };
+
   const [themes, setThemes] = useState<ThemeCount[]>([]);
   useEffect(() => {
     let cancelled = false;
@@ -135,6 +147,28 @@ function KnowledgeBody({ model }: { model: IndexModel }) {
         >
           {t('knowledge.viewTerrain')}
         </button>
+
+        {/* Perspective switch — shared by Graph + Terrain, right-aligned on the
+            view-tab row. The "what is a point" hint moves into each view's
+            caption below, so the switch itself costs no vertical space. */}
+        {(view === 'graph' || view === 'terrain') && (
+          <div className="seg-toggle persp-toggle" role="group">
+            <button
+              type="button"
+              className={persp === 'source' ? 'active' : ''}
+              onClick={() => setPersp('source')}
+            >
+              {t('knowledge.perspSource')}
+            </button>
+            <button
+              type="button"
+              className={persp === 'claim' ? 'active' : ''}
+              onClick={() => setPersp('claim')}
+            >
+              {t('knowledge.perspClaim')}
+            </button>
+          </div>
+        )}
       </div>
 
       {view === 'list' && (
@@ -154,17 +188,23 @@ function KnowledgeBody({ model }: { model: IndexModel }) {
 
       {view === 'graph' && (
         <>
-          <KnowledgeGraph scope="global" height={560} />
-          <div className="graph-caption">{t('knowledge.graphCaption')}</div>
+          <KnowledgeGraph scope="global" height={560} persp={persp} />
+          <div className="graph-caption">
+            {t(persp === 'claim' ? 'knowledge.perspNodeClaim' : 'knowledge.perspNodeSource')}{' '}
+            {t('knowledge.graphCaption')}
+          </div>
         </>
       )}
 
       {view === 'terrain' && (
         <>
           <Suspense fallback={<div className="legacy-loading">{t('common.loading')}</div>}>
-            <KnowledgeTerrain height={560} />
+            <KnowledgeTerrain height={560} persp={persp} />
           </Suspense>
-          <div className="graph-caption">{t('knowledge.terrainCaption')}</div>
+          <div className="graph-caption">
+            {t(persp === 'claim' ? 'knowledge.perspNodeClaim' : 'knowledge.perspNodeSource')}{' '}
+            {t('knowledge.terrainCaption')}
+          </div>
         </>
       )}
     </>
@@ -176,13 +216,15 @@ export default function KnowledgePage() {
   const { model, error, loading } = useModel();
   const location = useLocation();
 
-  // /knowledge#<claim_id> → the claim's theme page, anchor preserved.
+  // /knowledge#<claim_id> → the claim's theme page, anchor preserved. Forward
+  // whenever the claim resolves — an unthemed claim ('' theme) still lands on
+  // its (Unclassified) theme page via themeRoute rather than dead-ending here.
   const anchor = decodeURIComponent(location.hash.replace(/^#/, ''));
   if (anchor && model) {
     const claim = model.claims.find((c) => c.claim_id === anchor);
-    if (claim?.theme) {
+    if (claim) {
       return (
-        <Navigate to={`${themePath(claim.theme)}#${anchor}`} replace />
+        <Navigate to={`${themeRoute(claim.theme)}#${anchor}`} replace />
       );
     }
   }

--- a/console-ui/src/pages/KnowledgePage.tsx
+++ b/console-ui/src/pages/KnowledgePage.tsx
@@ -125,7 +125,8 @@ function KnowledgeBody({ model }: { model: IndexModel }) {
 
   return (
     <>
-      <div className="tab-row">
+      <div className="knowledge-viewbar">
+        <div className="tab-row">
         <button
           type="button"
           className={view === 'list' ? 'active' : ''}
@@ -147,10 +148,11 @@ function KnowledgeBody({ model }: { model: IndexModel }) {
         >
           {t('knowledge.viewTerrain')}
         </button>
+        </div>
 
-        {/* Perspective switch — shared by Graph + Terrain, right-aligned on the
-            view-tab row. The "what is a point" hint moves into each view's
-            caption below, so the switch itself costs no vertical space. */}
+        {/* Perspective switch — a SIBLING of .tab-row (not nested), so the
+            .tab-row button rules don't clobber the .seg-toggle contrast. Shares
+            the row; the "what is a point" hint lives in the caption below. */}
         {(view === 'graph' || view === 'terrain') && (
           <div className="seg-toggle persp-toggle" role="group">
             <button

--- a/console-ui/src/pages/ThemeDetailPage.tsx
+++ b/console-ui/src/pages/ThemeDetailPage.tsx
@@ -11,7 +11,7 @@ import { Link, useLocation, useParams } from 'react-router-dom';
 import KnowledgeGraph from '../components/KnowledgeGraph';
 import { ClaimPill, EmptyState, ModelGate } from '../components/ui';
 import { useI18n } from '../i18n';
-import { isMiscTheme, sourcesByCase, themeClaims } from '../lib/derive';
+import { isMiscTheme, sourcesByCase, themeClaims, themeFromRoute } from '../lib/derive';
 import type { ClaimRow, IndexModel, SourceRow } from '../lib/types';
 import { useModel } from '../model';
 
@@ -167,7 +167,9 @@ function ThemeBody({ model, theme }: { model: IndexModel; theme: string }) {
 export default function ThemeDetailPage() {
   const { t } = useI18n();
   const { theme: rawTheme } = useParams<{ theme: string }>();
-  const theme = rawTheme ?? '';
+  // The '' (no-theme) bucket travels as a sentinel segment — decode it back so
+  // themeClaims filters the unthemed claims and the page renders as Unclassified.
+  const theme = themeFromRoute(rawTheme);
   const { model, error, loading } = useModel();
 
   // 'misc' displays honestly as "Unclassified"; the route param and all

--- a/crates/ovp-api-projection/src/graph.rs
+++ b/crates/ovp-api-projection/src/graph.rs
@@ -48,6 +48,18 @@ impl GraphMode {
     }
 }
 
+/// Which entity the overview graph is built around. The two views over the same
+/// crystal (`?persp=`): `claim` (the default — the knowledge-statement network)
+/// and `source` (documents, linked when they are co-cited by a claim). The
+/// portal's Knowledge page toggles between them; both share one URL param with
+/// the Terrain view.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Perspective {
+    #[default]
+    Claim,
+    Source,
+}
+
 #[derive(Debug, Clone)]
 pub struct GraphParams {
     pub mode: GraphMode,
@@ -55,6 +67,9 @@ pub struct GraphParams {
     pub theme: Option<String>,
     pub focus: Option<String>,
     pub hops: usize,
+    /// Overview only: claim- vs source-centric layout. Ignored by
+    /// `neighborhood` (which always spans all three node types).
+    pub persp: Perspective,
 }
 
 impl GraphParams {
@@ -82,12 +97,20 @@ impl GraphParams {
             .and_then(|v| v.parse::<usize>().ok())
             .unwrap_or(MAX_HOPS)
             .clamp(1, MAX_HOPS);
+        let persp = match params.get("persp").map(String::as_str) {
+            None | Some("claim") => Perspective::Claim,
+            Some("source") => Perspective::Source,
+            Some(other) => {
+                return Err(GraphError::bad_request(&format!("unknown persp: {other}")))
+            }
+        };
         Ok(GraphParams {
             mode,
             limit,
             theme: params.get("theme").cloned(),
             focus,
             hops,
+            persp,
         })
     }
 }
@@ -197,7 +220,10 @@ pub fn build_graph(
     compute_importance(&mut base, records);
 
     match params.mode {
-        GraphMode::Overview => Ok(overview_response(base, params)),
+        GraphMode::Overview => Ok(match params.persp {
+            Perspective::Claim => overview_response(base, params),
+            Perspective::Source => source_overview_response(base, params),
+        }),
         GraphMode::Neighborhood => neighborhood_response(base, params),
     }
 }
@@ -718,6 +744,158 @@ fn overview_response(base: BaseGraph, params: &GraphParams) -> GraphResponse {
         total_nodes,
         truncated: matching > params.limit,
     }
+}
+
+/// Source perspective of the overview: nodes are the cited SOURCES (ranked by
+/// citing-claim count via `importance`, capped by `limit`), linked when two
+/// sources are co-cited by the same claim (weight = shared-claim count). The
+/// same crystal, seen document-first instead of statement-first — the portal's
+/// `?persp=source` toggle. Communities reuse the propagated cluster ids, labeled
+/// by the dominant theme among each cluster's citing claims.
+fn source_overview_response(base: BaseGraph, params: &GraphParams) -> GraphResponse {
+    let total_nodes = base.nodes.len();
+    let source_claims = source_claims_index(&base);
+
+    // Optional theme filter: keep a source only if some claim of that theme
+    // cites it (mirrors the claim overview's `theme` filter).
+    let theme_ok = |sid: &str| -> bool {
+        match &params.theme {
+            None => true,
+            Some(t) => source_claims
+                .get(sid)
+                .map(|claims| {
+                    claims.iter().any(|c| {
+                        base.nodes.get(c).and_then(|n| n.theme.as_deref()) == Some(t.as_str())
+                    })
+                })
+                .unwrap_or(false),
+        }
+    };
+
+    let mut sources: Vec<GNode> = base
+        .nodes
+        .values()
+        .filter(|n| n.node_type == "source")
+        .filter(|n| theme_ok(&n.id))
+        .cloned()
+        .collect();
+    sort_by_importance(&mut sources);
+    let matching = sources.len();
+    sources.truncate(params.limit);
+    let kept: HashSet<&str> = sources.iter().map(|n| n.id.as_str()).collect();
+
+    let edges = shared_claim_edges(&base.claim_sources, &kept);
+    let source_refs: Vec<&GNode> = sources.iter().collect();
+    let communities = build_source_communities(&source_refs, &source_claims, &base);
+
+    GraphResponse {
+        mode: GraphMode::Overview.as_str().into(),
+        nodes: sources,
+        edges,
+        communities,
+        total_nodes,
+        truncated: matching > params.limit,
+    }
+}
+
+/// Source↔source edges for the source perspective: two sources are linked when
+/// the same claim cites both; weight = number of such shared claims. Only edges
+/// among `kept` sources are emitted. Deterministic (sorted pair keys). A claim's
+/// cited-source set is small in practice, so per-claim pairwise is cheap.
+fn shared_claim_edges(
+    claim_sources: &BTreeMap<String, BTreeSet<String>>,
+    kept: &HashSet<&str>,
+) -> Vec<GEdge> {
+    let mut pair_weight: BTreeMap<(String, String), usize> = BTreeMap::new();
+    for srcs in claim_sources.values() {
+        // BTreeSet iterates sorted, so (i < j) already yields (a <= b).
+        let members: Vec<&String> = srcs.iter().filter(|s| kept.contains(s.as_str())).collect();
+        for i in 0..members.len() {
+            for j in (i + 1)..members.len() {
+                *pair_weight
+                    .entry((members[i].clone(), members[j].clone()))
+                    .or_default() += 1;
+            }
+        }
+    }
+    pair_weight
+        .into_iter()
+        .map(|((a, b), w)| GEdge {
+            source: a,
+            target: b,
+            edge_type: "related".into(),
+            weight: Some(w),
+        })
+        .collect()
+}
+
+/// Communities for the source perspective: group kept sources by their
+/// propagated cluster id (≥2 members), labeled by the dominant theme among the
+/// claims that cite them (same coverage rule as claim communities). `top_claims`
+/// carries the top source ids by importance — the field is a generic hull
+/// anchor, not claim-specific.
+fn build_source_communities(
+    sources: &[&GNode],
+    source_claims: &BTreeMap<String, Vec<String>>,
+    base: &BaseGraph,
+) -> Vec<Community> {
+    let mut by_cluster: BTreeMap<usize, Vec<&GNode>> = BTreeMap::new();
+    for n in sources {
+        if n.cluster > 0 {
+            by_cluster.entry(n.cluster).or_default().push(n);
+        }
+    }
+
+    let mut communities: Vec<Community> = Vec::new();
+    for (cluster, mut members) in by_cluster {
+        if members.len() < 2 {
+            continue;
+        }
+        members.sort_by(|a, b| {
+            b.importance
+                .partial_cmp(&a.importance)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.id.cmp(&b.id))
+        });
+
+        // Tally themes over the citing claims of every member source.
+        let mut theme_counts: BTreeMap<&str, usize> = BTreeMap::new();
+        for m in &members {
+            if let Some(claims) = source_claims.get(&m.id) {
+                for c in claims {
+                    if let Some(t) = base.nodes.get(c).and_then(|n| n.theme.as_deref()) {
+                        *theme_counts.entry(t).or_default() += 1;
+                    }
+                }
+            }
+        }
+        let total: usize = theme_counts.values().sum();
+        let mut themes: Vec<(&str, usize)> = theme_counts.into_iter().collect();
+        themes.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(b.0)));
+
+        let label = match themes.as_slice() {
+            [] => format!("community {cluster}"),
+            [(t, _)] => (*t).to_string(),
+            [(t1, c1), (t2, _), ..] => {
+                if total == 0 || (*c1 as f64) / (total as f64) < DOMINANT_THEME_COVERAGE {
+                    format!("{t1} / {t2}")
+                } else {
+                    (*t1).to_string()
+                }
+            }
+        };
+
+        communities.push(Community {
+            id: cluster,
+            label,
+            size: members.len(),
+            top_claims: members.iter().take(3).map(|m| m.id.clone()).collect(),
+        });
+    }
+
+    communities.sort_by(|a, b| b.size.cmp(&a.size).then_with(|| a.id.cmp(&b.id)));
+    communities.truncate(MAX_COMMUNITIES);
+    communities
 }
 
 fn neighborhood_response(
@@ -1469,6 +1647,7 @@ mod tests {
             theme: None,
             focus: None,
             hops: MAX_HOPS,
+            persp: Perspective::Claim,
         }
     }
 
@@ -1536,6 +1715,63 @@ mod tests {
             assert!(kept.contains(&e.source.as_str()));
             assert!(kept.contains(&e.target.as_str()));
         }
+    }
+
+    #[test]
+    fn from_query_parses_persp() {
+        let empty = std::collections::HashMap::new();
+        assert_eq!(GraphParams::from_query(&empty).unwrap().persp, Perspective::Claim);
+        let mut q = std::collections::HashMap::new();
+        q.insert("persp".to_string(), "source".to_string());
+        assert_eq!(GraphParams::from_query(&q).unwrap().persp, Perspective::Source);
+        q.insert("persp".to_string(), "bogus".to_string());
+        assert!(GraphParams::from_query(&q).is_err());
+    }
+
+    #[test]
+    fn source_overview_returns_sources_linked_by_shared_claims() {
+        let records = sample_records();
+        let mut p = params(GraphMode::Overview);
+        p.persp = Perspective::Source;
+        let resp = build_graph(&records, None, &p).unwrap();
+
+        // Nodes are all cited sources, ranked by citing-claim count.
+        assert!(resp.nodes.iter().all(|n| n.node_type == "source"));
+        assert_eq!(resp.nodes.len(), 3);
+        assert_eq!(resp.nodes[0].id, "source:case1", "case1 (cited by a,b,c) ranks first");
+        for w in resp.nodes.windows(2) {
+            assert!(w[0].importance >= w[1].importance);
+        }
+        assert_eq!(resp.total_nodes, 12, "total counts the full tri-partite graph");
+        assert!(!resp.truncated);
+
+        // Only claim `a` cites two sources → exactly one shared-claim edge.
+        assert_eq!(resp.edges.len(), 1);
+        let e = &resp.edges[0];
+        assert_eq!(e.edge_type, "related");
+        assert_eq!(e.weight, Some(1));
+        let mut pair = [e.source.as_str(), e.target.as_str()];
+        pair.sort();
+        assert_eq!(pair, ["source:case1", "source:case2"]);
+
+        // One community (case1 + case2 share a cluster), labeled by the dominant
+        // theme among their citing claims (alpha 3 : beta 1).
+        assert_eq!(resp.communities.len(), 1);
+        assert_eq!(resp.communities[0].size, 2);
+        assert_eq!(resp.communities[0].label, "alpha");
+    }
+
+    #[test]
+    fn source_overview_limit_truncates_and_drops_now_dangling_edges() {
+        let records = sample_records();
+        let mut p = params(GraphMode::Overview);
+        p.persp = Perspective::Source;
+        p.limit = 1;
+        let resp = build_graph(&records, None, &p).unwrap();
+        assert_eq!(resp.nodes.len(), 1);
+        assert!(resp.truncated);
+        // One kept source can't co-occur with another → no edges survive.
+        assert!(resp.edges.is_empty());
     }
 
     #[test]

--- a/crates/ovp-publish/src/lib.rs
+++ b/crates/ovp-publish/src/lib.rs
@@ -182,9 +182,23 @@ fn write_api_tree(
         theme: None,
         focus: None,
         hops: graph::MAX_HOPS,
+        persp: graph::Perspective::Claim,
     };
     if let Ok(g) = graph::build_graph(records, Some(public), &params) {
         write_json(&api.join("graph").join("global.json"), &serde_json::to_value(&g).unwrap_or_default())?;
+        files += 1;
+    }
+    // Source perspective of the same overview (the portal's ?persp=source
+    // toggle) — a second static file the SPA loads client-side.
+    let source_params = graph::GraphParams {
+        persp: graph::Perspective::Source,
+        ..params.clone()
+    };
+    if let Ok(g) = graph::build_graph(records, Some(public), &source_params) {
+        write_json(
+            &api.join("graph").join("global-source.json"),
+            &serde_json::to_value(&g).unwrap_or_default(),
+        )?;
         files += 1;
     }
     let mut themes_map = serde_json::Map::new();

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -823,12 +823,17 @@ fn handle_graph(state: &AppState, url: &str) -> Response<std::io::Cursor<Vec<u8>
                     .and_then(|v| v.parse::<usize>().ok())
                     .unwrap_or(graph::DEFAULT_OVERVIEW_LIMIT)
                     .max(1);
+                let persp = match query.get("persp").map(String::as_str) {
+                    Some("source") => graph::Perspective::Source,
+                    _ => graph::Perspective::Claim,
+                };
                 let params = graph::GraphParams {
                     mode: graph::GraphMode::Overview,
                     limit,
                     theme: None,
                     focus: None,
                     hops: graph::MAX_HOPS,
+                    persp,
                 };
                 let records = load_active_records(state);
                 graph::build_graph(&records, model.as_ref(), &params)


### PR DESCRIPTION
## Why

The Knowledge page offered two overview views drawn at **different granularities** — Graph = claim nodes, Terrain = source points — with different click behaviors. To a user they read as two unrelated things (see: "why is this source in a theme that doesn't match?"). And clicking a claim node in the graph appeared to do nothing.

## What

A shared **perspective switch** (`?persp=claim|source`, default `source`, URL-shareable) that **both** Graph and Terrain honor, so each view expresses the same crystal at a chosen granularity.

### Backend (`ovp-api-projection`, `ovp-server`, `ovp-publish`)
- New **source-perspective overview** in `graph.rs`: nodes = cited sources (ranked by citing-claim count), edges = **shared claims** (weight = co-citation count), communities labeled by the dominant citing-claim theme.
- `?persp=` param on `GraphParams::from_query`; live server reads it; publish emits an extra static `graph/global-source.json`.
- New unit tests for the source overview + `persp` parsing (29 graph tests pass, clippy clean).

### Terrain claim view (client-side)
- Each active claim is placed at the **centroid of its cited sources** on the same source-derived landscape — no backend or rebuild needed, and it works on the static site.

### Claim-click fix
- Single click on a claim node now **navigates straight to its theme page** (was a hidden two-step that dead-ended for un-themed claims). Empty-theme bucket made routable via a sentinel segment; the theme-wall card for it no longer dead-ends either.

### UI
- Switch renders as a `seg-toggle` pill on the view-tab row (no extra vertical space); the "what is a point" hint moved into each view's caption.

## Verification
- `tsc` + 34 SPA tests + `vite build` green.
- `cargo test -p ovp-api-projection` (graph) + `-p ovp-publish` green; `cargo clippy` clean on the three crates.
- Dogfooded live on the real vault (`ovp2 serve --port 8788`): `?persp=source` → 50 source nodes / 31 shared-claim edges / themed communities; `?persp=claim` → 50 claim nodes / 45 edges / 9 communities.

Note: repo has pre-existing `cargo fmt` drift across these files on `main`; I did not run `cargo fmt` to avoid unrelated reformatting — my additions match the surrounding style.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a perspective toggle for Knowledge Graph and Terrain views, allowing users to explore claims or sources.
  - Added source-centric graph visualization with related-source connections and community groupings.
  - Updated graph and terrain interactions to open relevant claim themes or source records directly.
  - Added localized English and Simplified Chinese labels for perspective views.

- **Bug Fixes**
  - Improved navigation and deep links for themed and unclassified claims.
  - Empty or missing themes are now consistently grouped as “Unclassified.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->