### PR TITLE
feat(tags): source tag facet — normalization + operator alias table + find/portal surfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2777,6 +2777,7 @@ dependencies = [
  "serde_yaml",
  "sha2",
  "tempfile",
+ "toml 0.8.2",
 ]
 
 [[package]]

--- a/console-ui/src/design/portal.css
+++ b/console-ui/src/design/portal.css
@@ -586,6 +586,29 @@ body {
   color: var(--warn-text);
   overflow-wrap: anywhere;
 }
+/* Clickable per-row tag chips (library facet shortcut). Muted until active
+   so a heavily tagged row doesn't out-shout the title. */
+.tag-chip {
+  display: inline-block;
+  margin-right: 0.35rem;
+  padding: 0 0.4rem;
+  border: 1px solid var(--border);
+  border-radius: var(--ovp-radius-pill);
+  background: transparent;
+  color: var(--muted);
+  font-size: var(--ovp-text-xs);
+  font-family: var(--ovp-font-mono);
+  cursor: pointer;
+}
+.tag-chip:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.tag-chip.active {
+  background: var(--accent-soft);
+  color: var(--accent);
+  border-color: var(--accent);
+}
 
 /* ---------- sections / footer timeline ---------- */
 .section {

--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -127,6 +127,8 @@ export const en = {
   'library.pinboard': 'Pinboard',
   'library.capture': 'Capture',
   'library.byMonth': 'By month',
+  'library.byTag': 'By tag',
+  'library.moreTags': 'more tags',
   'library.statusAll': 'All',
   'library.empty': 'No sources match the current filters.',
   'library.noDate': 'no date',

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -118,6 +118,8 @@ export const zh: Record<keyof typeof en, string> = {
   'library.pinboard': '书签',
   'library.capture': '捕获',
   'library.byMonth': '按月',
+  'library.byTag': '按标签',
+  'library.moreTags': '更多标签',
   'library.statusAll': '全部',
   'library.empty': '当前筛选下没有匹配的源。',
   'library.noDate': '无日期',

--- a/console-ui/src/lib/derive.ts
+++ b/console-ui/src/lib/derive.ts
@@ -324,6 +324,7 @@ export interface LibraryFilter {
   collection: Collection | null;
   month: string | null;
   status: string | null;
+  tag: string | null;
 }
 
 export function filterSources(
@@ -334,8 +335,20 @@ export function filterSources(
     (s) =>
       (filter.collection === null || collectionOf(s) === filter.collection) &&
       (filter.month === null || monthOf(s) === filter.month) &&
-      (filter.status === null || s.status === filter.status),
+      (filter.status === null || s.status === filter.status) &&
+      (filter.tag === null || (s.tags ?? []).includes(filter.tag)),
   );
+}
+
+/** Tag → source count over the whole library, count desc then name. */
+export function countTags(sources: SourceRow[]): [string, number][] {
+  const counts = new Map<string, number>();
+  for (const s of sources) {
+    for (const t of s.tags ?? []) {
+      counts.set(t, (counts.get(t) ?? 0) + 1);
+    }
+  }
+  return [...counts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
 }
 
 export interface MonthGroup {

--- a/console-ui/src/lib/types.ts
+++ b/console-ui/src/lib/types.ts
@@ -115,6 +115,9 @@ export interface SourceRow {
   pack_dir?: string;
   fail_count: number;
   last_reason?: string;
+  /** Canonical content tags (normalized + alias-resolved at index build).
+   * Absent on pre-tag indexes and on the redacted public model. */
+  tags?: string[];
 }
 
 export interface PackRow {

--- a/console-ui/src/pages/LibraryPage.tsx
+++ b/console-ui/src/pages/LibraryPage.tsx
@@ -33,7 +33,11 @@ function LibraryBody({ model }: { model: IndexModel }) {
   const collection = params.get('c') as Collection | null;
   const month = params.get('m');
   const status = params.get('status');
-  const tag = params.get('tag');
+  // Honor ?tag= only when the model actually carries tags — on a pre-tag
+  // index or the redacted public model a deep-linked tag would silently
+  // filter out every source under an invisible facet.
+  const tagCounts = countTags(model.sources);
+  const tag = tagCounts.length > 0 ? params.get('tag') : null;
 
   const setParam = (key: string, value: string | null) => {
     const next = new URLSearchParams(params);
@@ -76,7 +80,6 @@ function LibraryBody({ model }: { model: IndexModel }) {
   // deep-linked ?tag= never renders as an invisible filter). Hidden entirely
   // when the index carries no tags (pre-tag index or redacted public model).
   const TAG_FACET_LIMIT = 15;
-  const tagCounts = countTags(model.sources);
   const tagFacet = tagCounts.slice(0, TAG_FACET_LIMIT);
   if (tag && !tagFacet.some(([t]) => t === tag)) {
     const active = tagCounts.find(([t]) => t === tag);

--- a/console-ui/src/pages/LibraryPage.tsx
+++ b/console-ui/src/pages/LibraryPage.tsx
@@ -8,6 +8,7 @@ import { useI18n, type MsgKey } from '../i18n';
 import {
   collectionOf,
   countBy,
+  countTags,
   filterSources,
   groupByMonth,
   monthOf,
@@ -32,6 +33,7 @@ function LibraryBody({ model }: { model: IndexModel }) {
   const collection = params.get('c') as Collection | null;
   const month = params.get('m');
   const status = params.get('status');
+  const tag = params.get('tag');
 
   const setParam = (key: string, value: string | null) => {
     const next = new URLSearchParams(params);
@@ -66,8 +68,20 @@ function LibraryBody({ model }: { model: IndexModel }) {
       !STATIC_MODE && collection && COLLECTIONS.includes(collection) ? collection : null,
     month,
     status,
+    tag,
   });
   const groups = groupByMonth(filtered);
+
+  // Tag facet: top of the vocabulary by count (plus the active tag, so a
+  // deep-linked ?tag= never renders as an invisible filter). Hidden entirely
+  // when the index carries no tags (pre-tag index or redacted public model).
+  const TAG_FACET_LIMIT = 15;
+  const tagCounts = countTags(model.sources);
+  const tagFacet = tagCounts.slice(0, TAG_FACET_LIMIT);
+  if (tag && !tagFacet.some(([t]) => t === tag)) {
+    const active = tagCounts.find(([t]) => t === tag);
+    tagFacet.push(active ?? [tag, 0]);
+  }
 
   return (
     <div className="grid library">
@@ -122,6 +136,30 @@ function LibraryBody({ model }: { model: IndexModel }) {
             ))}
           </ul>
         </div>
+        {tagFacet.length > 0 && (
+          <div className="facet-group">
+            <h3>{t('library.byTag')}</h3>
+            <ul className="facet-list">
+              {tagFacet.map(([tg, n]) => (
+                <li key={tg}>
+                  <button
+                    type="button"
+                    className={tag === tg ? 'active' : ''}
+                    onClick={() => setParam('tag', tag === tg ? null : tg)}
+                  >
+                    <span>#{tg}</span>
+                    <span className="count">{n}</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+            {tagCounts.length > TAG_FACET_LIMIT && (
+              <p className="muted sm">
+                +{tagCounts.length - TAG_FACET_LIMIT} {t('library.moreTags')}
+              </p>
+            )}
+          </div>
+        )}
       </div>
 
       {/* list column */}
@@ -170,6 +208,16 @@ function LibraryBody({ model }: { model: IndexModel }) {
                       )}
                   </span>
                   <span className="meta">
+                    {(s.tags ?? []).map((tg) => (
+                      <button
+                        key={tg}
+                        type="button"
+                        className={`tag-chip${tag === tg ? ' active' : ''}`}
+                        onClick={() => setParam('tag', tag === tg ? null : tg)}
+                      >
+                        #{tg}
+                      </button>
+                    ))}
                     {s.date ?? ''} · {t(collectionLabel(collectionOf(s)))}
                   </span>
                 </div>

--- a/crates/ovp-api-projection/src/graph.rs
+++ b/crates/ovp-api-projection/src/graph.rs
@@ -1953,6 +1953,7 @@ mod tests {
                     pack_dir: Some(format!("40-Resources/Reader/{case}")),
                     fail_count: 0,
                     last_reason: None,
+                    tags: Vec::new(),
                 })
                 .collect(),
             packs: cases
@@ -2033,6 +2034,7 @@ mod tests {
             pack_dir: None,
             fail_count: 0,
             last_reason: None,
+            tags: Vec::new(),
         });
         let resp = source_neighborhood(&records, Some(&model), None, "freshsha").unwrap();
         assert_eq!(resp.nodes.len(), 1);
@@ -2082,6 +2084,7 @@ mod tests {
             pack_dir: Some("40-Resources/Reader/fresh".into()),
             fail_count: 0,
             last_reason: None,
+            tags: Vec::new(),
         });
         let evidence = evidence_for("fresh", "freshsha", 2);
         let resp =

--- a/crates/ovp-api-projection/src/redact.rs
+++ b/crates/ovp-api-projection/src/redact.rs
@@ -36,6 +36,10 @@ impl PublicView {
             s.last_run_id = None;
             s.fail_count = 0;
             s.pack_dir = s.pack_dir.as_deref().map(case_id).map(str::to_string);
+            // Tags are the operator's personal taxonomy — private by default.
+            // Publishing them is a deliberate future decision, not a side
+            // effect of the tag facet landing on the live portal.
+            s.tags.clear();
         }
         let public_shas: std::collections::HashSet<&str> =
             m.sources.iter().map(|s| s.sha256.as_str()).collect();
@@ -134,6 +138,7 @@ mod tests {
             pack_dir: Some("40-Resources/Reader/case".into()),
             fail_count: 3,
             last_reason: reason.map(String::from),
+            tags: vec!["agent".into()],
         }
     }
 
@@ -187,6 +192,8 @@ mod tests {
         assert!(m.sources[0].last_reason.is_none());
         assert!(m.sources[0].last_run_id.is_none());
         assert_eq!(m.sources[0].fail_count, 0);
+        // Personal taxonomy never ships publicly.
+        assert!(m.sources[0].tags.is_empty());
         // Only the durable claim survives, citing only the public case.
         assert_eq!(m.claims.len(), 1);
         assert_eq!(m.claims[0].claim_id, "d1");

--- a/crates/ovp-cli/src/commands/index_cmd.rs
+++ b/crates/ovp-cli/src/commands/index_cmd.rs
@@ -5,6 +5,7 @@
 
 use std::path::PathBuf;
 
+use ovp_domain::tags::{TagAliases, normalize_tag};
 use ovp_index::{
     build_evidence, build_index_with_progress, read_evidence, read_index, run_evidence_query,
     run_query, write_evidence, write_index, Query, QueryKind,
@@ -51,6 +52,7 @@ pub struct FindArgs {
     pub kind: Option<String>,
     pub status: Option<String>,
     pub date: Option<String>,
+    pub tag: Option<String>,
     pub json: bool,
 }
 
@@ -64,10 +66,22 @@ pub fn run_find(args: FindArgs) -> Result<(), CliError> {
         Some("runs") => Some(QueryKind::Runs),
         Some("cards") => Some(QueryKind::Cards),
         Some("units") => Some(QueryKind::Units),
+        Some("tags") => Some(QueryKind::Tags),
         Some(other) => {
             return Err(CliError::Io(format!(
-                "unknown --kind `{other}` (sources|packs|claims|runs|cards|units)"
+                "unknown --kind `{other}` (sources|packs|claims|runs|cards|units|tags)"
             )))
+        }
+    };
+    // A queried alias must find its canonical tag's sources, so the query
+    // tag runs through the same normalize+alias pipe the index rows did.
+    let tag = match args.tag.as_deref() {
+        None => None,
+        Some(raw) => {
+            let aliases = TagAliases::load(&args.vault_root).map_err(CliError::Io)?;
+            let normalized = normalize_tag(raw)
+                .ok_or_else(|| CliError::Io(format!("--tag {raw:?} normalizes to nothing")))?;
+            Some(aliases.resolve(&normalized).to_string())
         }
     };
     let query = Query {
@@ -75,6 +89,7 @@ pub fn run_find(args: FindArgs) -> Result<(), CliError> {
         status: args.status,
         date: args.date,
         term: args.term,
+        tag,
     };
     let hits = match kind {
         Some(QueryKind::Cards | QueryKind::Units) => {

--- a/crates/ovp-cli/src/main.rs
+++ b/crates/ovp-cli/src/main.rs
@@ -307,7 +307,8 @@ enum Cmd {
         vault_root: PathBuf,
         /// Case-insensitive substring over titles/URLs/paths/cards/claims.
         term: Option<String>,
-        /// Restrict to one kind: sources|packs|claims|runs|cards|units.
+        /// Restrict to one kind: sources|packs|claims|runs|cards|units|tags
+        /// (`tags` lists the canonical tag vocabulary with source counts).
         #[arg(long)]
         kind: Option<String>,
         /// Status filter (queued|processed|failed|blocked|needs_content|
@@ -317,6 +318,10 @@ enum Cmd {
         /// Date prefix filter (2026 / 2026-06 / 2026-06-09).
         #[arg(long)]
         date: Option<String>,
+        /// Canonical tag filter over sources (variant spellings and aliases
+        /// resolve via `.ovp/tags/aliases.toml` before matching).
+        #[arg(long)]
+        tag: Option<String>,
         /// Emit JSON instead of text.
         #[arg(long)]
         json: bool,
@@ -1375,6 +1380,7 @@ fn main() -> ExitCode {
             kind,
             status,
             date,
+            tag,
             json,
         } => commands::index_cmd::run_find(commands::index_cmd::FindArgs {
             vault_root,
@@ -1382,6 +1388,7 @@ fn main() -> ExitCode {
             kind,
             status,
             date,
+            tag,
             json,
         }),
         Cmd::Console { vault_root, date } => {

--- a/crates/ovp-console/src/render.rs
+++ b/crates/ovp-console/src/render.rs
@@ -348,6 +348,7 @@ mod tests {
                     pack_dir: Some("40-Resources/Reader/2026-06-09_Good Article-aaaa1111".into()),
                     fail_count: 0,
                     last_reason: None,
+                    tags: Vec::new(),
                 },
                 SourceRow {
                     sha256: "cccc".into(),
@@ -360,6 +361,7 @@ mod tests {
                     pack_dir: None,
                     fail_count: 3,
                     last_reason: Some("card synthesis did not parse".into()),
+                    tags: Vec::new(),
                 },
             ],
             packs: vec![PackRow {

--- a/crates/ovp-domain/Cargo.toml
+++ b/crates/ovp-domain/Cargo.toml
@@ -20,6 +20,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 sha2 = { workspace = true }
+toml = { workspace = true }
 
 [dev-dependencies]
 ovp-domain = { path = ".", features = ["testing"] }

--- a/crates/ovp-domain/src/lib.rs
+++ b/crates/ovp-domain/src/lib.rs
@@ -29,6 +29,10 @@ pub mod response;
 pub mod sinks;
 pub mod source_doc;
 pub mod sources;
+/// Tag vocabulary layer: deterministic normalization + the operator-owned
+/// alias table. Canonicalization happens at projection build only; raw
+/// frontmatter tags are never rewritten.
+pub mod tags;
 pub mod transforms;
 /// M14a experimental Grounded Unit extraction spike (parallel, deletable; not
 /// wired into the typed pipeline). See `docs/stage-m14a-grounded-units.md`.

--- a/crates/ovp-domain/src/tags.rs
+++ b/crates/ovp-domain/src/tags.rs
@@ -68,7 +68,10 @@ impl TagAliases {
     /// to its canonical, or a transitive chain (a canonical that is itself
     /// an alias) — chains would make resolution order-dependent.
     pub fn parse(text: &str) -> Result<Self, String> {
+        // deny_unknown_fields: a typo like `[alias]` must fail loud, not
+        // parse as an empty table that silently un-merges the vocabulary.
         #[derive(serde::Deserialize)]
+        #[serde(deny_unknown_fields)]
         struct File {
             #[serde(default)]
             aliases: BTreeMap<String, String>,
@@ -99,7 +102,7 @@ impl TagAliases {
                 ));
             }
         }
-        for canonical in map.values() {
+        for (alias, canonical) in &map {
             if map.contains_key(canonical) {
                 return Err(format!(
                     "tag aliases: {canonical:?} is both a canonical and an alias (chain); \
@@ -110,6 +113,18 @@ impl TagAliases {
                 return Err(format!(
                     "tag aliases: {canonical:?} is both a canonical and dropped; \
                      alias the variants to a kept tag or drop them directly"
+                ));
+            }
+            if drop.contains(alias) {
+                return Err(format!(
+                    "tag aliases: {alias:?} is both an alias and dropped; \
+                     pick one — drop wins would silently disable the merge"
+                ));
+            }
+            if BOILERPLATE_TAGS.contains(&canonical.as_str()) {
+                return Err(format!(
+                    "tag aliases: {alias:?} maps to boilerplate {canonical:?}; \
+                     capture-mechanism tags never surface as content facets"
                 ));
             }
         }
@@ -195,6 +210,20 @@ mod tests {
         let err = TagAliases::parse("drop = [\"tweet\"]\n[aliases]\n\"tweets\" = \"tweet\"\n")
             .unwrap_err();
         assert!(err.contains("dropped"), "{err}");
+        // An alias key in the drop list is ambiguous config — fail loud.
+        let err = TagAliases::parse("drop = [\"tweets\"]\n[aliases]\n\"tweets\" = \"tweet\"\n")
+            .unwrap_err();
+        assert!(err.contains("both an alias and dropped"), "{err}");
+    }
+
+    #[test]
+    fn parse_rejects_typo_sections_and_boilerplate_canonicals() {
+        // `[alias]` (typo) must not parse as an empty table.
+        assert!(TagAliases::parse("[alias]\n\"a\" = \"b\"\n").is_err());
+        // Aliasing onto a boilerplate capture tag can never surface.
+        let err =
+            TagAliases::parse("[aliases]\n\"clipping\" = \"clippings\"\n").unwrap_err();
+        assert!(err.contains("boilerplate"), "{err}");
     }
 
     #[test]

--- a/crates/ovp-domain/src/tags.rs
+++ b/crates/ovp-domain/src/tags.rs
@@ -1,0 +1,215 @@
+//! Tag vocabulary layer: deterministic normalization + the operator-owned
+//! alias table (`.ovp/tags/aliases.toml`).
+//!
+//! Ownership contract (docs/stage-tags): raw tags live in note frontmatter
+//! and are NEVER rewritten by the pipeline — canonicalization happens only
+//! when a projection is built. The alias table maps variant spellings to a
+//! canonical tag, so both already-ingested notes and future captures with
+//! any variant spelling converge without touching the source files.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+/// Tags the intake renderer stamps on every note it writes. They mark the
+/// capture mechanism, not the content, so no projection surfaces them.
+pub const BOILERPLATE_TAGS: &[&str] = &["clippings", "pinboard"];
+
+/// Deterministic tag normalization: trim, strip a leading `#`, lowercase,
+/// fold separators (whitespace/underscore/`/`) to `-`, collapse runs of `-`,
+/// strip leading/trailing `-`. Returns `None` when nothing survives.
+///
+/// Deliberately NOT here: plural folding, abbreviation expansion, semantic
+/// merges — those are corpus-dependent judgments and belong in the alias
+/// table, where the operator approves them.
+pub fn normalize_tag(raw: &str) -> Option<String> {
+    let mut out = String::with_capacity(raw.len());
+    let mut prev_dash = true; // suppress leading dashes
+    for c in raw.trim().trim_start_matches('#').chars() {
+        let folded: Option<char> = if c.is_whitespace() || c == '_' || c == '/' || c == '-' {
+            None
+        } else {
+            Some(c)
+        };
+        match folded {
+            Some(c) => {
+                for lc in c.to_lowercase() {
+                    out.push(lc);
+                }
+                prev_dash = false;
+            }
+            None => {
+                if !prev_dash {
+                    out.push('-');
+                    prev_dash = true;
+                }
+            }
+        }
+    }
+    while out.ends_with('-') {
+        out.pop();
+    }
+    if out.is_empty() { None } else { Some(out) }
+}
+
+/// The operator-approved alias table: normalized alias → normalized
+/// canonical, plus a `drop` list for capture-channel tags (e.g. a clipper's
+/// per-site tag) that should never surface as content facets. Loaded from
+/// `.ovp/tags/aliases.toml`; a missing file is an empty table (the mechanism
+/// is optional until the operator seeds it).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TagAliases {
+    map: BTreeMap<String, String>,
+    drop: std::collections::BTreeSet<String>,
+}
+
+impl TagAliases {
+    /// Parse the alias table from TOML text. Fail-loud on structural rot:
+    /// unparseable TOML, an alias that normalizes to nothing, an alias equal
+    /// to its canonical, or a transitive chain (a canonical that is itself
+    /// an alias) — chains would make resolution order-dependent.
+    pub fn parse(text: &str) -> Result<Self, String> {
+        #[derive(serde::Deserialize)]
+        struct File {
+            #[serde(default)]
+            aliases: BTreeMap<String, String>,
+            #[serde(default)]
+            drop: Vec<String>,
+        }
+        let file: File =
+            toml::from_str(text).map_err(|e| format!("tag aliases: invalid TOML: {e}"))?;
+        let mut drop = std::collections::BTreeSet::new();
+        for raw in &file.drop {
+            let d = normalize_tag(raw)
+                .ok_or_else(|| format!("tag aliases: drop entry {raw:?} normalizes to nothing"))?;
+            drop.insert(d);
+        }
+        let mut map = BTreeMap::new();
+        for (alias, canonical) in &file.aliases {
+            let a = normalize_tag(alias)
+                .ok_or_else(|| format!("tag aliases: alias {alias:?} normalizes to nothing"))?;
+            let c = normalize_tag(canonical).ok_or_else(|| {
+                format!("tag aliases: canonical {canonical:?} (for {alias:?}) normalizes to nothing")
+            })?;
+            if a == c {
+                return Err(format!("tag aliases: {alias:?} maps to itself"));
+            }
+            if map.insert(a.clone(), c).is_some() {
+                return Err(format!(
+                    "tag aliases: duplicate alias {a:?} after normalization"
+                ));
+            }
+        }
+        for canonical in map.values() {
+            if map.contains_key(canonical) {
+                return Err(format!(
+                    "tag aliases: {canonical:?} is both a canonical and an alias (chain); \
+                     point every alias directly at the final canonical"
+                ));
+            }
+            if drop.contains(canonical) {
+                return Err(format!(
+                    "tag aliases: {canonical:?} is both a canonical and dropped; \
+                     alias the variants to a kept tag or drop them directly"
+                ));
+            }
+        }
+        Ok(Self { map, drop })
+    }
+
+    /// Load the table from `<vault_root>/.ovp/tags/aliases.toml`. Missing
+    /// file → empty table; unreadable or invalid file → error (a present but
+    /// broken table must not silently un-merge the vocabulary).
+    pub fn load(vault_root: &Path) -> Result<Self, String> {
+        let path = vault_root.join(crate::vault_layout::VaultLayout.tag_aliases_file());
+        match std::fs::read_to_string(&path) {
+            Ok(text) => Self::parse(&text),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
+            Err(e) => Err(format!("reading {}: {e}", path.display())),
+        }
+    }
+
+    /// Canonical form of an already-normalized tag.
+    pub fn resolve<'a>(&'a self, normalized: &'a str) -> &'a str {
+        self.map.get(normalized).map(String::as_str).unwrap_or(normalized)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+}
+
+/// Raw frontmatter tags → sorted, deduped canonical tags: normalize, drop
+/// boilerplate, resolve aliases, apply the operator drop list. The one entry
+/// point projections use.
+pub fn canonical_tags<S: AsRef<str>>(raw: &[S], aliases: &TagAliases) -> Vec<String> {
+    let mut out: Vec<String> = raw
+        .iter()
+        .filter_map(|t| normalize_tag(t.as_ref()))
+        .filter(|t| !BOILERPLATE_TAGS.contains(&t.as_str()))
+        .filter(|t| !aliases.drop.contains(t))
+        .map(|t| aliases.resolve(&t).to_string())
+        .collect();
+    out.sort();
+    out.dedup();
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_folds_case_separators_and_hash() {
+        assert_eq!(normalize_tag("Claude_Code"), Some("claude-code".into()));
+        assert_eq!(normalize_tag("#AI  Agent"), Some("ai-agent".into()));
+        assert_eq!(normalize_tag("ai/agent"), Some("ai-agent".into()));
+        assert_eq!(normalize_tag("--open--source--"), Some("open-source".into()));
+        assert_eq!(normalize_tag("大模型"), Some("大模型".into()));
+    }
+
+    #[test]
+    fn normalize_rejects_empty() {
+        assert_eq!(normalize_tag(""), None);
+        assert_eq!(normalize_tag("  #- _ "), None);
+    }
+
+    #[test]
+    fn canonical_tags_drop_boilerplate_resolve_aliases_and_dedup() {
+        let aliases = TagAliases::parse("[aliases]\n\"ai-agents\" = \"agent\"\n").unwrap();
+        let got = canonical_tags(
+            &["clippings", "pinboard", "AI Agents", "agent", "Agent"],
+            &aliases,
+        );
+        assert_eq!(got, vec!["agent".to_string()]);
+    }
+
+    #[test]
+    fn drop_list_removes_channel_tags_and_rejects_dropped_canonicals() {
+        let t = TagAliases::parse("drop = [\"Twitter\"]\n[aliases]\n\"tweets\" = \"tweet\"\n")
+            .unwrap();
+        assert_eq!(canonical_tags(&["twitter", "tweets"], &t), vec!["tweet".to_string()]);
+        let err = TagAliases::parse("drop = [\"tweet\"]\n[aliases]\n\"tweets\" = \"tweet\"\n")
+            .unwrap_err();
+        assert!(err.contains("dropped"), "{err}");
+    }
+
+    #[test]
+    fn parse_rejects_chains_self_maps_and_bad_toml() {
+        assert!(TagAliases::parse("aliases = 3").is_err());
+        assert!(TagAliases::parse("[aliases]\n\"agent\" = \"Agent\"\n").is_err());
+        let chain = "[aliases]\n\"a\" = \"b\"\n\"b\" = \"c\"\n";
+        let err = TagAliases::parse(chain).unwrap_err();
+        assert!(err.contains("chain"), "{err}");
+    }
+
+    #[test]
+    fn parse_normalizes_both_sides_and_missing_section_is_empty() {
+        let t = TagAliases::parse("[aliases]\n\"AI_Agents\" = \"Agent\"\n").unwrap();
+        assert_eq!(t.resolve("ai-agents"), "agent");
+        assert!(TagAliases::parse("").unwrap().is_empty());
+    }
+}

--- a/crates/ovp-domain/src/vault_layout.rs
+++ b/crates/ovp-domain/src/vault_layout.rs
@@ -222,6 +222,12 @@ impl VaultLayout {
     pub fn crystal_store_dir(&self) -> &'static str {
         ".ovp/crystal"
     }
+
+    /// The operator-owned tag alias table (alias → canonical), applied at
+    /// projection build time only — raw frontmatter tags are never rewritten.
+    pub fn tag_aliases_file(&self) -> &'static str {
+        ".ovp/tags/aliases.toml"
+    }
 }
 
 /// Truncate to at most `max` characters on a char boundary (titles can be

--- a/crates/ovp-index/src/build.rs
+++ b/crates/ovp-index/src/build.rs
@@ -17,6 +17,7 @@ use ovp_daily::{MAX_FAILURES_BEFORE_BLOCKED, RunReport, RunStatus, read_daily_le
 use ovp_domain::VaultLayout;
 use ovp_domain::crystal::themes::{ThemesFile, UNCLASSIFIED_THEME};
 use ovp_domain::crystal::{CrystalStatus, ReviewEntry, StoreEvent, fold_ledger};
+use ovp_domain::tags::{TagAliases, canonical_tags};
 use ovp_domain::units::read_source_from_path;
 use ovp_intake::vaultops::{hex_sha256, read_jsonl, rel_to};
 use ovp_intake::{IntakeAction, read_intake_ledger};
@@ -106,6 +107,8 @@ pub fn build_index_at_with_progress(
     backfill_corpus_packs(vault_root, &layout, &mut sources, &mut packs)?;
     on_phase(&format!("hashed {} pack(s)", packs.len()));
     enrich_titles_from_packs(&mut sources, &packs);
+    let tagged = attach_tags(vault_root, &mut sources)?;
+    on_phase(&format!("tagged {tagged} source(s)"));
     let claims = build_claims(vault_root, &layout)?;
     on_phase(&format!("folded {} claim(s)", claims.len()));
 
@@ -230,6 +233,7 @@ fn build_sources(
                 pack_dir: None,
                 fail_count: 0,
                 last_reason: rec.note.clone(),
+                tags: Vec::new(),
             },
         );
     }
@@ -251,6 +255,7 @@ fn build_sources(
                 pack_dir: None,
                 fail_count: 0,
                 last_reason: None,
+                tags: Vec::new(),
             });
         entry.date = Some(rec.date.clone());
         entry.last_run_id = Some(rec.run_id.clone());
@@ -314,6 +319,7 @@ fn build_sources(
                     pack_dir: None,
                     fail_count: 0,
                     last_reason: None,
+                    tags: Vec::new(),
                 }
             });
         }
@@ -343,6 +349,30 @@ fn build_sources(
         .collect();
     sort_sources(&mut out);
     Ok(out)
+}
+
+/// Re-read each row's note frontmatter and attach canonical tags. The note's
+/// CURRENT frontmatter is the per-source tag truth (the operator edits it in
+/// place after ingest), so tags are re-derived on every build rather than
+/// copied from ledgers. Per-row read/parse failures are non-fatal — tags
+/// enrich a row, they never gate it — but a present-and-broken alias table
+/// is a hard error (a silently ignored table would un-merge the vocabulary).
+fn attach_tags(vault_root: &Path, rows: &mut [SourceRow]) -> Result<usize, String> {
+    let aliases = TagAliases::load(vault_root)?;
+    let mut tagged = 0;
+    for row in rows.iter_mut() {
+        let Some(rel) = row.rel_path.as_deref() else {
+            continue;
+        };
+        let Ok(doc) = read_source_from_path(&vault_root.join(rel)) else {
+            continue;
+        };
+        row.tags = canonical_tags(&doc.tags, &aliases);
+        if !row.tags.is_empty() {
+            tagged += 1;
+        }
+    }
+    Ok(tagged)
 }
 
 /// Canonical source-row order: status band, then title, then hash. Shared by
@@ -641,6 +671,7 @@ fn backfill_corpus_packs(
                     pack_dir: Some(packs[i].pack_dir.clone()),
                     fail_count: 0,
                     last_reason: None,
+                    tags: Vec::new(),
                 });
                 by_sha.insert(sha256.clone(), sources.len() - 1);
                 changed = true;
@@ -1178,6 +1209,7 @@ mod tests {
             pack_dir: None,
             fail_count: 3,
             last_reason: Some("boom".into()),
+            tags: Vec::new(),
         };
         let sources = vec![
             src("aaaa", SourceStatus::Blocked, "2026-06-30"), // 8 days stuck

--- a/crates/ovp-index/src/model.rs
+++ b/crates/ovp-index/src/model.rs
@@ -49,6 +49,12 @@ pub struct SourceRow {
     pub fail_count: usize,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_reason: Option<String>,
+    /// Canonical content tags: the note's CURRENT frontmatter tags (vault
+    /// frontmatter is the per-source truth, re-read at build) normalized +
+    /// alias-resolved via `.ovp/tags/aliases.toml`, boilerplate dropped.
+    /// Serde-additive: pre-tag indexes deserialize to empty.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/ovp-index/src/query.rs
+++ b/crates/ovp-index/src/query.rs
@@ -15,6 +15,10 @@ pub enum QueryKind {
     Runs,
     Cards,
     Units,
+    /// The tag vocabulary itself: one row per canonical tag with its source
+    /// count. Never included in the default all-kinds sweep — only an
+    /// explicit `--kind tags` lists it.
+    Tags,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -29,6 +33,11 @@ pub struct Query {
     /// Case-insensitive substring over titles, URLs, paths, card titles,
     /// claim text, themes, run ids.
     pub term: Option<String>,
+    /// Canonical tag filter (exact match after normalization). Tags are a
+    /// source-level axis: a tag filter restricts sources and excludes the
+    /// kinds that carry no tags (packs/claims/runs/cards/units), the same
+    /// way a date filter excludes claims.
+    pub tag: Option<String>,
 }
 
 /// One result row, kind-tagged, with a printable line and a link target.
@@ -61,13 +70,49 @@ pub fn run_query(model: &IndexModel, q: &Query) -> Vec<Hit> {
         Some(prefix) => d.is_some_and(|d| d.starts_with(prefix)),
     };
     let kind_ok = |k: QueryKind| q.kind.map(|want| want == k).unwrap_or(true);
+    // Normalized once so `--tag Claude_Code` matches the canonical form.
+    let tag = q.tag.as_deref().and_then(ovp_domain::tags::normalize_tag);
+    let tag_ok = |tags: &[String]| match &tag {
+        None => true,
+        Some(t) => tags.iter().any(|have| have == t),
+    };
 
     let mut hits = Vec::new();
+
+    // The vocabulary listing is explicit-only (never in the all-kinds sweep):
+    // one row per canonical tag over the status/date-filtered sources, count
+    // descending. `term` narrows by substring; a `--tag` filter is exact.
+    if q.kind == Some(QueryKind::Tags) {
+        let mut counts: std::collections::BTreeMap<&str, usize> = std::collections::BTreeMap::new();
+        for s in &model.sources {
+            if !status_ok(source_status_str(s.status)) || !date_ok(s.date.as_deref()) {
+                continue;
+            }
+            for t in &s.tags {
+                *counts.entry(t.as_str()).or_default() += 1;
+            }
+        }
+        let mut rows: Vec<(&str, usize)> = counts
+            .into_iter()
+            .filter(|(t, _)| matches(&[t]) && tag.as_deref().map(|want| *t == want).unwrap_or(true))
+            .collect();
+        rows.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(b.0)));
+        for (t, n) in rows {
+            hits.push(Hit {
+                kind: "tag".into(),
+                status: "tag".into(),
+                line: format!("{t} ({n})"),
+                path: None,
+                id: Some(t.to_string()),
+            });
+        }
+        return hits;
+    }
 
     if kind_ok(QueryKind::Sources) {
         for s in &model.sources {
             let status = source_status_str(s.status);
-            if !status_ok(status) || !date_ok(s.date.as_deref()) {
+            if !status_ok(status) || !date_ok(s.date.as_deref()) || !tag_ok(&s.tags) {
                 continue;
             }
             let title = s.title.as_deref().unwrap_or("(untitled)");
@@ -79,6 +124,9 @@ pub fn run_query(model: &IndexModel, q: &Query) -> Vec<Hit> {
             let mut line = format!("{title} [{status}]");
             if let Some(d) = &s.date {
                 line.push_str(&format!(" {d}"));
+            }
+            if !s.tags.is_empty() {
+                line.push_str(&format!(" #{}", s.tags.join(" #")));
             }
             if s.fail_count > 0 {
                 line.push_str(&format!(" fails={}", s.fail_count));
@@ -98,7 +146,8 @@ pub fn run_query(model: &IndexModel, q: &Query) -> Vec<Hit> {
 
     if kind_ok(QueryKind::Packs) {
         for p in &model.packs {
-            if !status_ok("pack") || !date_ok(p.date.as_deref()) {
+            // Packs/claims/runs carry no tags; a tag filter excludes them.
+            if tag.is_some() || !status_ok("pack") || !date_ok(p.date.as_deref()) {
                 continue;
             }
             let cards_joined = p.card_titles.join(" | ");
@@ -128,8 +177,8 @@ pub fn run_query(model: &IndexModel, q: &Query) -> Vec<Hit> {
     if kind_ok(QueryKind::Claims) {
         for c in &model.claims {
             let status = claim_status_str(c.status);
-            // Claims carry no date; a date filter excludes them.
-            if !status_ok(status) || q.date.is_some() {
+            // Claims carry no date or tags; either filter excludes them.
+            if !status_ok(status) || q.date.is_some() || tag.is_some() {
                 continue;
             }
             let theme = c.theme.as_deref().unwrap_or("");
@@ -152,7 +201,7 @@ pub fn run_query(model: &IndexModel, q: &Query) -> Vec<Hit> {
 
     if kind_ok(QueryKind::Runs) {
         for r in &model.runs {
-            if !status_ok("run") || !date_ok(Some(&r.date)) {
+            if tag.is_some() || !status_ok("run") || !date_ok(Some(&r.date)) {
                 continue;
             }
             if !matches(&[&r.run_id, &r.date]) {
@@ -180,7 +229,8 @@ pub fn run_evidence_query(evidence: &EvidenceModel, q: &Query, limit: usize) -> 
     let term = q.term.as_deref().unwrap_or("");
     let mut scored: Vec<(f64, String, Hit)> = Vec::new();
 
-    if q.date.is_some() {
+    // Evidence rows carry no date or tags; either filter excludes them.
+    if q.date.is_some() || q.tag.is_some() {
         return Vec::new();
     }
 

--- a/crates/ovp-index/src/query.rs
+++ b/crates/ovp-index/src/query.rs
@@ -70,8 +70,17 @@ pub fn run_query(model: &IndexModel, q: &Query) -> Vec<Hit> {
         Some(prefix) => d.is_some_and(|d| d.starts_with(prefix)),
     };
     let kind_ok = |k: QueryKind| q.kind.map(|want| want == k).unwrap_or(true);
-    // Normalized once so `--tag Claude_Code` matches the canonical form.
-    let tag = q.tag.as_deref().and_then(ovp_domain::tags::normalize_tag);
+    // Normalized once so `--tag Claude_Code` matches the canonical form. An
+    // explicit filter that normalizes to nothing (`tag=#`, whitespace) must
+    // match NOTHING — collapsing it to "no filter" would silently return
+    // every row.
+    let tag = match q.tag.as_deref() {
+        None => None,
+        Some(raw) => match ovp_domain::tags::normalize_tag(raw) {
+            Some(t) => Some(t),
+            None => return Vec::new(),
+        },
+    };
     let tag_ok = |tags: &[String]| match &tag {
         None => true,
         Some(t) => tags.iter().any(|have| have == t),

--- a/crates/ovp-index/tests/index_build.rs
+++ b/crates/ovp-index/tests/index_build.rs
@@ -817,3 +817,88 @@ fn empty_vault_builds_an_empty_model() {
     assert_eq!(model.totals.claims_durable, 0);
     assert_eq!(model.totals.runs, 0);
 }
+
+#[test]
+fn tags_are_read_from_current_frontmatter_normalized_and_alias_resolved() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    // Vault frontmatter is the per-source tag truth: raw variants + intake
+    // boilerplate in the note; the alias table merges `ai-agents` → `agent`.
+    place(
+        root,
+        "50-Inbox/01-Raw/2026-06/tagged.md",
+        "---\ntitle: Tagged Note\nsource: https://e.x/t\ntags:\n  - clippings\n  - pinboard\n  - AI Agents\n  - Claude_Code\n  - 大模型\n---\nbody\n",
+    );
+    place(
+        root,
+        ".ovp/tags/aliases.toml",
+        "[aliases]\n\"ai-agents\" = \"agent\"\n",
+    );
+    // A note with only boilerplate tags surfaces none.
+    place(
+        root,
+        "50-Inbox/01-Raw/2026-06/plain.md",
+        "---\ntitle: Plain Note\nsource: https://e.x/p\ntags:\n  - clippings\n---\nbody\n",
+    );
+
+    let model = build_index(root, "2026-06-09", None).unwrap();
+
+    let tagged = model
+        .sources
+        .iter()
+        .find(|s| s.title.as_deref() == Some("Tagged Note"))
+        .unwrap();
+    assert_eq!(tagged.tags, vec!["agent", "claude-code", "大模型"]);
+    let plain = model
+        .sources
+        .iter()
+        .find(|s| s.title.as_deref() == Some("Plain Note"))
+        .unwrap();
+    assert!(plain.tags.is_empty());
+
+    // Rebuild determinism holds with tags attached.
+    let again = build_index_at(root, "2026-06-09", None, "2026-06-09T00:00:00Z").unwrap();
+    let twice = build_index_at(root, "2026-06-09", None, "2026-06-09T00:00:00Z").unwrap();
+    assert_eq!(again, twice);
+
+    // A tag filter restricts sources (variant spelling normalizes before
+    // matching) and excludes tagless kinds instead of leaking them.
+    let hits = run_query(
+        &model,
+        &Query {
+            tag: Some("Claude_Code".into()),
+            ..Default::default()
+        },
+    );
+    assert_eq!(hits.len(), 1, "{hits:?}");
+    assert_eq!(hits[0].kind, "source");
+    assert!(hits[0].line.contains("#agent #claude-code"), "{}", hits[0].line);
+
+    // `--kind tags` lists the canonical vocabulary with counts, never the
+    // boilerplate capture tags.
+    let vocab = run_query(
+        &model,
+        &Query {
+            kind: Some(QueryKind::Tags),
+            ..Default::default()
+        },
+    );
+    let lines: Vec<&str> = vocab.iter().map(|h| h.line.as_str()).collect();
+    assert_eq!(lines, vec!["agent (1)", "claude-code (1)", "大模型 (1)"]);
+}
+
+#[test]
+fn broken_alias_table_fails_the_build_loudly() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    place(
+        root,
+        "50-Inbox/01-Raw/2026-06/x.md",
+        "---\ntitle: X\nsource: https://e.x/x\n---\nbody\n",
+    );
+    place(root, ".ovp/tags/aliases.toml", "[aliases]\n\"a\" = \"b\"\n\"b\" = \"c\"\n");
+
+    let err = build_index(root, "2026-06-09", None).unwrap_err();
+    assert!(err.contains("chain"), "{err}");
+}

--- a/crates/ovp-mcp/src/lib.rs
+++ b/crates/ovp-mcp/src/lib.rs
@@ -6,6 +6,7 @@ use std::io::{self, BufRead, Write};
 use std::path::PathBuf;
 
 use ovp_domain::VaultLayout;
+use ovp_domain::tags::{TagAliases, normalize_tag};
 use ovp_index::{read_index, run_query, IndexModel, Query, QueryKind};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -147,14 +148,15 @@ fn handle_tools_list() -> Result<Value, RpcError> {
         "tools": [
             {
                 "name": "find",
-                "description": "Query the OVP index: sources, packs, claims, runs. Filter by kind, status, date, or free-text term.",
+                "description": "Query the OVP index: sources, packs, claims, runs, tags. Filter by kind, status, date, tag, or free-text term.",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
                         "term": { "type": "string", "description": "Free-text search term" },
-                        "kind": { "type": "string", "enum": ["sources", "packs", "claims", "runs"] },
+                        "kind": { "type": "string", "enum": ["sources", "packs", "claims", "runs", "tags"] },
                         "status": { "type": "string" },
-                        "date": { "type": "string", "description": "Date prefix (YYYY or YYYY-MM or YYYY-MM-DD)" }
+                        "date": { "type": "string", "description": "Date prefix (YYYY or YYYY-MM or YYYY-MM-DD)" },
+                        "tag": { "type": "string", "description": "Canonical tag filter over sources (kind=tags lists the vocabulary)" }
                     }
                 }
             },
@@ -200,17 +202,29 @@ fn tool_find(state: &McpState, args: &Value) -> Result<Value, RpcError> {
     let model = state.load_model()
         .ok_or_else(|| RpcError { code: -32000, message: "Index not available".into() })?;
 
+    // A queried alias resolves to its canonical tag, same as `ovp2 find`.
+    // A broken alias table degrades to normalize-only here (a read tool
+    // should answer, not crash); `ovp2 index` is where breakage fails loud.
+    let tag = args.get("tag").and_then(|v| v.as_str()).map(|raw| {
+        let aliases = TagAliases::load(&state.vault_root).unwrap_or_default();
+        match normalize_tag(raw) {
+            Some(n) => aliases.resolve(&n).to_string(),
+            None => raw.to_string(),
+        }
+    });
     let query = Query {
         kind: args.get("kind").and_then(|v| v.as_str()).and_then(|k| match k {
             "sources" => Some(QueryKind::Sources),
             "packs" => Some(QueryKind::Packs),
             "claims" => Some(QueryKind::Claims),
             "runs" => Some(QueryKind::Runs),
+            "tags" => Some(QueryKind::Tags),
             _ => None,
         }),
         status: args.get("status").and_then(|v| v.as_str()).map(String::from),
         date: args.get("date").and_then(|v| v.as_str()).map(String::from),
         term: args.get("term").and_then(|v| v.as_str()).map(String::from),
+        tag,
     };
 
     let hits = run_query(&model, &query);
@@ -226,7 +240,7 @@ fn tool_search(state: &McpState, args: &Value) -> Result<Value, RpcError> {
         .ok_or_else(|| RpcError { code: -32000, message: "Index not available".into() })?;
 
     let term = args.get("query").and_then(|v| v.as_str()).map(String::from);
-    let query = Query { kind: None, status: None, date: None, term };
+    let query = Query { kind: None, status: None, date: None, term, tag: None };
     let hits = run_query(&model, &query);
     let text = serde_json::to_string_pretty(&hits).unwrap_or_else(|_| "[]".into());
 

--- a/crates/ovp-publish/src/lib.rs
+++ b/crates/ovp-publish/src/lib.rs
@@ -167,7 +167,7 @@ fn write_api_tree(
     write_json(&api.join("themes.json"), &bodies::themes_body(records))?;
     write_json(&api.join("flow.json"), &bodies::flow_body(public))?;
     write_json(&api.join("settings.json"), &bodies::settings_public_body(Some(public)))?;
-    let empty = Query { kind: None, status: None, date: None, term: None };
+    let empty = Query { kind: None, status: None, date: None, term: None, tag: None };
     write_json(&api.join("search-index.json"), &bodies::find_body(public, &empty))?;
     files += 5;
 
@@ -453,6 +453,7 @@ mod tests {
             pack_dir: Some("40-Resources/Reader/case1".into()),
             fail_count: 0,
             last_reason: None,
+            tags: Vec::new(),
         }
     }
 

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -633,17 +633,29 @@ fn handle_find(state: &AppState, url: &str) -> Response<std::io::Cursor<Vec<u8>>
     };
 
     let params = parse_query_string(url);
+    // Alias-resolve the tag param the same way `ovp2 find` does; a broken
+    // alias table degrades to normalize-only (a read endpoint should answer,
+    // not 500 — `ovp2 index` is where table breakage fails loud).
+    let tag = params.get("tag").map(|raw| {
+        let aliases = ovp_domain::tags::TagAliases::load(&state.vault_root).unwrap_or_default();
+        match ovp_domain::tags::normalize_tag(raw) {
+            Some(n) => aliases.resolve(&n).to_string(),
+            None => raw.clone(),
+        }
+    });
     let query = Query {
         kind: params.get("kind").and_then(|k| match k.as_str() {
             "sources" => Some(QueryKind::Sources),
             "packs" => Some(QueryKind::Packs),
             "claims" => Some(QueryKind::Claims),
             "runs" => Some(QueryKind::Runs),
+            "tags" => Some(QueryKind::Tags),
             _ => None,
         }),
         status: params.get("status").cloned(),
         date: params.get("date").cloned(),
         term: params.get("term").cloned(),
+        tag,
     };
 
     let body = bodies::find_body(&model, &query).to_string();
@@ -679,6 +691,7 @@ fn handle_search(state: &AppState, url: &str) -> Response<std::io::Cursor<Vec<u8
         status: None,
         date: None,
         term,
+        tag: None,
     };
     let body = bodies::find_body(&model, &query).to_string();
     json_stamped(200, &body, Some(&model))
@@ -1917,6 +1930,7 @@ mod tests {
                 pack_dir: Some("40-Resources/Reader/good".into()),
                 fail_count: 0,
                 last_reason: None,
+                tags: Vec::new(),
             }],
             packs: vec![PackRow {
                 pack_dir: "40-Resources/Reader/good".into(),
@@ -2434,6 +2448,7 @@ mod tests {
             pack_dir: None,
             fail_count: 0,
             last_reason: None,
+            tags: Vec::new(),
         }
     }
 


### PR DESCRIPTION
## What

First PR of the organization-axes plan (tags → themes → entities): surface the source tags that have been captured in note frontmatter all along but dropped at every projection.

- **`ovp-domain::tags`** — deterministic `normalize_tag` (case/separator/`#` folding; NO plural or semantic merges in code — those are operator judgments) + `TagAliases` from vault `.ovp/tags/aliases.toml`: `alias → canonical` plus a `drop` list for capture-channel tags. Fail-loud on chains, self-maps, typo sections (`deny_unknown_fields`), boilerplate canonicals, and dropped aliases.
- **Index build** — `SourceRow.tags` (serde-additive), re-read from each note's **current** frontmatter every build: vault frontmatter is the per-source tag truth, editable in Obsidian after ingest. Raw tags are never rewritten; the alias table absorbs variant spellings in already-ingested notes AND future captures, so no pinboard write-back or sync is ever needed.
- **Query surfaces** — `ovp2 find --tag X` (alias-resolved; excludes tagless kinds the way `--date` excludes claims; an invalid tag matches nothing) + `--kind tags` vocabulary listing with counts. Same params on `/api/find` and the MCP `find` tool.
- **Portal** — Library page gains a By-tag facet (`?tag=`, top-15 + active, gated on vocabulary presence) and clickable per-row tag chips.
- **Redaction** — `PublicView` clears tags: the personal taxonomy never ships to a published site unless that becomes a deliberate decision later.

## Real-vault verification

- 690/1264 sources tagged; 654-tag canonical vocabulary; index rebuild 2.1s (tag attachment re-reads ~1.3k notes).
- Seeded alias table (13 morphological pairs) verified live: agent 154→156, skill 34→38, ai-agent 21→30 merged.
- `find --tag Skills` (variant spelling + case) resolves to canonical `skill`, 38 hits.

## Gates

- 84 Rust test suites green (incl. new unit + integration tests: normalization, alias validation, drop list, build determinism with tags, tag filter/vocabulary queries, redaction).
- SPA: tsc + vite build + 34 vitest green.
- clippy clean.
- codex review: GATE PASS (0 P1); all 4 P2 findings fixed in the follow-up commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tag-based filtering to the library, command-line search, and API search.
  * Displayed source tags as clickable chips, with popular tags available as filter options.
  * Added tag vocabulary browsing with normalized counts and alias support.
  * Added English and Simplified Chinese labels for tag-related controls.

* **Bug Fixes**
  * Improved consistency by normalizing tag variants, removing boilerplate tags, and resolving aliases during indexing.
  * Invalid tag alias configurations now produce clear indexing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->