### PR TITLE
feat(tags): tags-suggest — embedding merge proposals + kNN backfill (tags_inferred)

### DIFF
--- a/console-ui/src/design/portal.css
+++ b/console-ui/src/design/portal.css
@@ -609,6 +609,11 @@ body {
   color: var(--accent);
   border-color: var(--accent);
 }
+/* Machine-inferred tags: same affordance, visibly weaker claim. */
+.tag-chip.inferred {
+  border-style: dashed;
+  opacity: 0.75;
+}
 
 /* ---------- sections / footer timeline ---------- */
 .section {

--- a/console-ui/src/lib/derive.ts
+++ b/console-ui/src/lib/derive.ts
@@ -347,7 +347,10 @@ export function filterSources(
 export function countTags(sources: SourceRow[]): [string, number][] {
   const counts = new Map<string, number>();
   for (const s of sources) {
-    for (const t of [...(s.tags ?? []), ...(s.tags_inferred ?? [])]) {
+    for (const t of s.tags ?? []) {
+      counts.set(t, (counts.get(t) ?? 0) + 1);
+    }
+    for (const t of s.tags_inferred ?? []) {
       counts.set(t, (counts.get(t) ?? 0) + 1);
     }
   }

--- a/console-ui/src/lib/derive.ts
+++ b/console-ui/src/lib/derive.ts
@@ -336,15 +336,18 @@ export function filterSources(
       (filter.collection === null || collectionOf(s) === filter.collection) &&
       (filter.month === null || monthOf(s) === filter.month) &&
       (filter.status === null || s.status === filter.status) &&
-      (filter.tag === null || (s.tags ?? []).includes(filter.tag)),
+      (filter.tag === null ||
+        (s.tags ?? []).includes(filter.tag) ||
+        (s.tags_inferred ?? []).includes(filter.tag)),
   );
 }
 
-/** Tag → source count over the whole library, count desc then name. */
+/** Tag → source count over the whole library (operator + inferred — the
+ * facet filters on both), count desc then name. */
 export function countTags(sources: SourceRow[]): [string, number][] {
   const counts = new Map<string, number>();
   for (const s of sources) {
-    for (const t of s.tags ?? []) {
+    for (const t of [...(s.tags ?? []), ...(s.tags_inferred ?? [])]) {
       counts.set(t, (counts.get(t) ?? 0) + 1);
     }
   }

--- a/console-ui/src/lib/types.ts
+++ b/console-ui/src/lib/types.ts
@@ -118,6 +118,9 @@ export interface SourceRow {
   /** Canonical content tags (normalized + alias-resolved at index build).
    * Absent on pre-tag indexes and on the redacted public model. */
   tags?: string[];
+  /** Machine-inferred backfill tags (tags-suggest kNN vote). Present only
+   * while the source has no operator tags; rendered visibly weaker. */
+  tags_inferred?: string[];
 }
 
 export interface PackRow {

--- a/console-ui/src/pages/LibraryPage.tsx
+++ b/console-ui/src/pages/LibraryPage.tsx
@@ -226,6 +226,17 @@ function LibraryBody({ model }: { model: IndexModel }) {
                         #{tg}
                       </button>
                     ))}
+                    {(s.tags_inferred ?? []).map((tg) => (
+                      <button
+                        key={`~${tg}`}
+                        type="button"
+                        className={`tag-chip inferred${tag === tg ? ' active' : ''}`}
+                        title="inferred (tags-suggest)"
+                        onClick={() => setParam('tag', tag === tg ? null : tg)}
+                      >
+                        ~#{tg}
+                      </button>
+                    ))}
                     {s.date ?? ''} · {t(collectionLabel(collectionOf(s)))}
                   </span>
                 </div>

--- a/crates/ovp-api-projection/src/graph.rs
+++ b/crates/ovp-api-projection/src/graph.rs
@@ -1954,6 +1954,7 @@ mod tests {
                     fail_count: 0,
                     last_reason: None,
                     tags: Vec::new(),
+                    tags_inferred: Vec::new(),
                 })
                 .collect(),
             packs: cases
@@ -2035,6 +2036,7 @@ mod tests {
             fail_count: 0,
             last_reason: None,
             tags: Vec::new(),
+            tags_inferred: Vec::new(),
         });
         let resp = source_neighborhood(&records, Some(&model), None, "freshsha").unwrap();
         assert_eq!(resp.nodes.len(), 1);
@@ -2085,6 +2087,7 @@ mod tests {
             fail_count: 0,
             last_reason: None,
             tags: Vec::new(),
+            tags_inferred: Vec::new(),
         });
         let evidence = evidence_for("fresh", "freshsha", 2);
         let resp =

--- a/crates/ovp-api-projection/src/redact.rs
+++ b/crates/ovp-api-projection/src/redact.rs
@@ -40,6 +40,7 @@ impl PublicView {
             // Publishing them is a deliberate future decision, not a side
             // effect of the tag facet landing on the live portal.
             s.tags.clear();
+            s.tags_inferred.clear();
         }
         let public_shas: std::collections::HashSet<&str> =
             m.sources.iter().map(|s| s.sha256.as_str()).collect();
@@ -139,6 +140,7 @@ mod tests {
             fail_count: 3,
             last_reason: reason.map(String::from),
             tags: vec!["agent".into()],
+            tags_inferred: vec!["rust".into()],
         }
     }
 
@@ -192,8 +194,9 @@ mod tests {
         assert!(m.sources[0].last_reason.is_none());
         assert!(m.sources[0].last_run_id.is_none());
         assert_eq!(m.sources[0].fail_count, 0);
-        // Personal taxonomy never ships publicly.
+        // Personal taxonomy never ships publicly (operator or inferred).
         assert!(m.sources[0].tags.is_empty());
+        assert!(m.sources[0].tags_inferred.is_empty());
         // Only the durable claim survives, citing only the public case.
         assert_eq!(m.claims.len(), 1);
         assert_eq!(m.claims[0].claim_id, "d1");

--- a/crates/ovp-cli/src/commands/crystal_themes.rs
+++ b/crates/ovp-cli/src/commands/crystal_themes.rs
@@ -191,8 +191,10 @@ pub(crate) fn collect_docs(reader_root: &Path) -> Result<Vec<ThemeDoc>, CliError
 }
 
 /// Resolve vectors for every doc: cache first, embedder for the misses.
-/// `Ok(None)` = a graceful skip (reason already printed).
-fn resolve_vectors(
+/// `Ok(None)` = a graceful skip (reason already printed). `pub(crate)`:
+/// `tags-suggest` shares the cache/embedder plumbing (messages still say
+/// crystal-themes — same model, same cache, same degradation contract).
+pub(crate) fn resolve_vectors(
     docs: &[ThemeDoc],
     cache_dir: &Path,
 ) -> Result<Option<Vec<Vec<f32>>>, CliError> {

--- a/crates/ovp-cli/src/commands/mod.rs
+++ b/crates/ovp-cli/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub mod crystal_synth_ab;
 pub mod crystal_synth_llm;
 pub mod crystal_terrain;
 pub mod crystal_themes;
+pub mod tags_suggest;
 pub mod crystal_write;
 pub mod console_cmd;
 pub mod daily;

--- a/crates/ovp-cli/src/commands/tags_suggest.rs
+++ b/crates/ovp-cli/src/commands/tags_suggest.rs
@@ -1,0 +1,436 @@
+//! `tags-suggest` — deterministic tag-curation proposals over the embedding
+//! layer. Two outputs, both projections, neither ever auto-applied:
+//!
+//! 1. **Merge candidates** (`.ovp/tags/proposals.md`): every canonical tag is
+//!    embedded as "tag name + sample titles of sources carrying it"; pairs
+//!    above a cosine threshold become alias proposals (canonical = the
+//!    higher-count member). The operator reviews the report and pastes
+//!    accepted lines into `.ovp/tags/aliases.toml` — the pipeline proposes,
+//!    the operator disposes (same contract as crystal-review).
+//!
+//! 2. **Backfill** (`.ovp/tags/inferred.json`): sources with NO operator tags
+//!    get tags voted by their k nearest tagged neighbors in pack-embedding
+//!    space (similarity-weighted vote, support + share thresholds). Reuses
+//!    the SAME pack vectors `crystal-themes` caches, so a themed vault runs
+//!    this with zero new embeddings. The index attaches these as
+//!    `tags_inferred`, never mixed into operator tags.
+//!
+//! No LLM anywhere. Degradation contract mirrors crystal-themes: missing
+//! embed feature/model with a cold cache → explain and exit 0.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use ovp_domain::tags::{InferredTag, TAGS_INFERRED_SCHEMA, TagsInferredFile};
+use ovp_domain::vault_layout::VaultLayout;
+use ovp_embed::knn::cosine;
+use ovp_embed::{EMBED_MODEL_ID, document_text};
+use ovp_index::read_index;
+
+use crate::CliError;
+use crate::commands::crystal_themes::{ThemeDoc, collect_docs, resolve_vectors};
+
+/// Sample titles embedded alongside a tag name (the short-tag disambiguation
+/// trick: "rust" alone is ambiguous; "rust + 3 article titles" is not).
+const TAG_SAMPLE_TITLES: usize = 3;
+/// Merge pairs at or above this cosine are marked STRONG in the report.
+const STRONG_MERGE: f64 = 0.90;
+/// Cap on reported merge pairs; the count of anything beyond it is logged
+/// (no silent truncation).
+const MAX_MERGE_PROPOSALS: usize = 100;
+
+pub struct TagsSuggestArgs {
+    pub vault_root: PathBuf,
+    /// Cosine floor for a merge proposal to enter the report.
+    pub merge_threshold: f64,
+    /// Neighbors consulted per untagged source.
+    pub knn: usize,
+    /// Minimum share of neighbor similarity weight a tag needs (0..1).
+    pub vote_threshold: f64,
+    /// Minimum number of neighbors carrying the tag.
+    pub min_support: usize,
+    /// Cap on inferred tags per source.
+    pub max_tags: usize,
+}
+
+impl Default for TagsSuggestArgs {
+    fn default() -> Self {
+        Self {
+            vault_root: PathBuf::new(),
+            merge_threshold: 0.75,
+            knn: 10,
+            vote_threshold: 0.35,
+            min_support: 2,
+            max_tags: 5,
+        }
+    }
+}
+
+/// One tag's neighbor vote on one source (pure, unit-tested): neighbors are
+/// `(similarity, tags)` pairs, already the k nearest. A tag wins when its
+/// similarity-weighted share ≥ `vote_threshold` AND ≥ `min_support` distinct
+/// neighbors carry it. Ties broken by tag name for determinism.
+pub(crate) fn vote_tags(
+    neighbors: &[(f64, &[String])],
+    vote_threshold: f64,
+    min_support: usize,
+    max_tags: usize,
+) -> Vec<InferredTag> {
+    let total: f64 = neighbors.iter().map(|(s, _)| s.max(0.0)).sum();
+    if total <= 0.0 {
+        return Vec::new();
+    }
+    let mut weight: BTreeMap<&str, (f64, usize)> = BTreeMap::new();
+    for (sim, tags) in neighbors {
+        for tag in *tags {
+            let e = weight.entry(tag.as_str()).or_insert((0.0, 0));
+            e.0 += sim.max(0.0);
+            e.1 += 1;
+        }
+    }
+    let mut out: Vec<InferredTag> = weight
+        .into_iter()
+        .filter_map(|(tag, (w, support))| {
+            let score = w / total;
+            (score >= vote_threshold && support >= min_support).then(|| InferredTag {
+                tag: tag.to_string(),
+                score: (score * 1000.0).round() / 1000.0,
+                support,
+            })
+        })
+        .collect();
+    out.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.tag.cmp(&b.tag))
+    });
+    out.truncate(max_tags);
+    out
+}
+
+/// One proposed merge, evidence attached.
+#[derive(Debug, PartialEq)]
+pub(crate) struct MergeProposal {
+    /// Lower-count member — the proposed alias.
+    pub(crate) alias: String,
+    pub(crate) alias_count: usize,
+    /// Higher-count member — the proposed canonical.
+    pub(crate) canonical: String,
+    pub(crate) canonical_count: usize,
+    pub(crate) cosine: f64,
+}
+
+/// Two tags on mostly the SAME sources are co-occurring (related topics on
+/// one article), not spelling variants — true synonyms almost never co-occur
+/// on one item, because nobody tags an article `agent` AND `agents`. Their
+/// embed texts also share sample titles, which inflates cosine to ~1.0, so
+/// without this suppression the report leads with same-article noise.
+/// Overlap = |A∩B| / min(|A|,|B|); at or above this the pair is suppressed.
+const CO_OCCURRENCE_OVERLAP: f64 = 0.5;
+
+/// Pairwise merge candidates over per-tag vectors (pure, unit-tested).
+/// `tags` = (name, source indices carrying it). Canonical = higher count;
+/// ties by name (lexicographically smaller wins). Returns (proposals,
+/// suppressed co-occurrence pair count).
+pub(crate) fn merge_proposals(
+    tags: &[(String, Vec<usize>)],
+    vectors: &[Vec<f32>],
+    threshold: f64,
+) -> (Vec<MergeProposal>, usize) {
+    let sets: Vec<std::collections::BTreeSet<usize>> = tags
+        .iter()
+        .map(|(_, srcs)| srcs.iter().copied().collect())
+        .collect();
+    let mut out = Vec::new();
+    let mut suppressed = 0usize;
+    for i in 0..tags.len() {
+        for j in (i + 1)..tags.len() {
+            let sim = cosine(&vectors[i], &vectors[j]);
+            if sim < threshold {
+                continue;
+            }
+            let inter = sets[i].intersection(&sets[j]).count();
+            let min = sets[i].len().min(sets[j].len()).max(1);
+            if inter as f64 / min as f64 >= CO_OCCURRENCE_OVERLAP {
+                suppressed += 1;
+                continue;
+            }
+            let (ni, nj) = (tags[i].1.len(), tags[j].1.len());
+            let (a, c) = if ni < nj || (ni == nj && tags[i].0 > tags[j].0) {
+                (i, j)
+            } else {
+                (j, i)
+            };
+            out.push(MergeProposal {
+                alias: tags[a].0.clone(),
+                alias_count: tags[a].1.len(),
+                canonical: tags[c].0.clone(),
+                canonical_count: tags[c].1.len(),
+                cosine: (sim * 1000.0).round() / 1000.0,
+            });
+        }
+    }
+    out.sort_by(|a, b| {
+        b.cosine
+            .partial_cmp(&a.cosine)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.alias.cmp(&b.alias))
+    });
+    (out, suppressed)
+}
+
+pub fn run(args: TagsSuggestArgs) -> Result<(), CliError> {
+    if !args.merge_threshold.is_finite() || !args.vote_threshold.is_finite() {
+        return Err(CliError::Io(
+            "tags-suggest: thresholds must be finite numbers".into(),
+        ));
+    }
+    let layout = VaultLayout::new();
+    let model = read_index(&args.vault_root).map_err(|e| {
+        CliError::Io(format!(
+            "tags-suggest: {e} — run `ovp2 index` first (the tag vocabulary and \
+             source↔pack joins come from the read model)"
+        ))
+    })?;
+    let reader_root = args.vault_root.join(layout.reader_root());
+    let embed_cache_dir = args.vault_root.join(".ovp/cache/embeddings");
+
+    // ---- Join sources ↔ pack docs (case_id = pack_dir basename) ----
+    let docs = collect_docs(&reader_root)?;
+    let case_of = |pack_dir: &str| -> String {
+        pack_dir
+            .rsplit(['/', '\\'])
+            .next()
+            .unwrap_or(pack_dir)
+            .to_string()
+    };
+    let mut doc_idx: BTreeMap<String, usize> = BTreeMap::new();
+    for (i, d) in docs.iter().enumerate() {
+        doc_idx.insert(d.case_id.clone(), i);
+    }
+    // (doc index, sha256, tags) for every source joined to a pack.
+    let mut tagged: Vec<(usize, &str, &[String])> = Vec::new();
+    let mut untagged: Vec<(usize, &str)> = Vec::new();
+    for s in &model.sources {
+        let Some(idx) = s
+            .pack_dir
+            .as_deref()
+            .and_then(|p| doc_idx.get(&case_of(p)))
+        else {
+            continue;
+        };
+        if s.tags.is_empty() {
+            untagged.push((*idx, s.sha256.as_str()));
+        } else {
+            tagged.push((*idx, s.sha256.as_str(), s.tags.as_slice()));
+        }
+    }
+    if tagged.is_empty() {
+        println!(
+            "tags-suggest: no tagged sources in the index — nothing to learn from. \
+             Tag some sources (pinboard or frontmatter), rebuild the index, retry."
+        );
+        return Ok(());
+    }
+    println!(
+        "tags-suggest: {} tagged / {} untagged source(s) joined to packs",
+        tagged.len(),
+        untagged.len()
+    );
+
+    // ---- Pack vectors (warm from crystal-themes; embeds only the misses) ----
+    let Some(vectors) = resolve_vectors(&docs, &embed_cache_dir)? else {
+        return Ok(()); // graceful skip, reason already printed
+    };
+
+    // ---- Backfill: kNN vote for every untagged source ----
+    let mut entries: BTreeMap<String, Vec<InferredTag>> = BTreeMap::new();
+    for (idx, sha) in &untagged {
+        let mut sims: Vec<(f64, &[String])> = tagged
+            .iter()
+            .map(|(t_idx, _, tags)| (cosine(&vectors[*idx], &vectors[*t_idx]), *tags))
+            .collect();
+        sims.sort_by(|(sa, _), (sb, _)| sb.partial_cmp(sa).unwrap_or(std::cmp::Ordering::Equal));
+        sims.truncate(args.knn);
+        let voted = vote_tags(&sims, args.vote_threshold, args.min_support, args.max_tags);
+        if !voted.is_empty() {
+            entries.insert((*sha).to_string(), voted);
+        }
+    }
+    let covered = entries.len();
+    let inferred = TagsInferredFile {
+        schema: TAGS_INFERRED_SCHEMA.into(),
+        model: EMBED_MODEL_ID.into(),
+        params: BTreeMap::from([
+            ("knn".into(), args.knn as f64),
+            ("vote_threshold".into(), args.vote_threshold),
+            ("min_support".into(), args.min_support as f64),
+            ("max_tags".into(), args.max_tags as f64),
+        ]),
+        entries,
+    };
+    let inferred_path = inferred.save(&args.vault_root).map_err(CliError::Io)?;
+    println!(
+        "  backfill: {covered}/{} untagged source(s) received inferred tags → {inferred_path}",
+        untagged.len()
+    );
+
+    // ---- Merge candidates over the tag vocabulary ----
+    // Vocabulary + carrying-source indices + up-to-3 sample titles per tag.
+    let mut vocab: BTreeMap<&str, (Vec<usize>, Vec<&str>)> = BTreeMap::new();
+    for (src_idx, s) in model.sources.iter().enumerate() {
+        for t in &s.tags {
+            let e = vocab.entry(t.as_str()).or_default();
+            e.0.push(src_idx);
+            if e.1.len() < TAG_SAMPLE_TITLES
+                && let Some(title) = s.title.as_deref()
+            {
+                e.1.push(title);
+            }
+        }
+    }
+    let tag_docs: Vec<ThemeDoc> = vocab
+        .iter()
+        .map(|(tag, (_, titles))| {
+            let text = document_text(tag, &titles.join(" | "), 1500);
+            let sha = ovp_embed::cache::text_sha256(&text);
+            ThemeDoc {
+                case_id: format!("tag:{tag}"),
+                title: (*tag).to_string(),
+                text,
+                sha,
+            }
+        })
+        .collect();
+    let Some(tag_vectors) = resolve_vectors(&tag_docs, &embed_cache_dir)? else {
+        return Ok(());
+    };
+    let counts: Vec<(String, Vec<usize>)> = vocab
+        .iter()
+        .map(|(tag, (srcs, _))| ((*tag).to_string(), srcs.clone()))
+        .collect();
+    let (mut proposals, suppressed) =
+        merge_proposals(&counts, &tag_vectors, args.merge_threshold);
+    let dropped = proposals.len().saturating_sub(MAX_MERGE_PROPOSALS);
+    proposals.truncate(MAX_MERGE_PROPOSALS);
+
+    // ---- Human-review report ----
+    let mut report = String::new();
+    report.push_str(&format!(
+        "# Tag curation proposals — {}\n\nGenerated by `ovp2 tags-suggest` \
+         (model {EMBED_MODEL_ID}, merge cosine ≥ {}, kNN {} / vote ≥ {} / support ≥ {}).\n\
+         NOTHING here is applied automatically: review, then paste accepted lines into\n\
+         `.ovp/tags/aliases.toml` and rebuild with `ovp2 index`.\n\n",
+        model.date, args.merge_threshold, args.knn, args.vote_threshold, args.min_support
+    ));
+    report.push_str(&format!(
+        "## Merge candidates ({}{}; {suppressed} co-occurrence pair(s) suppressed — \
+         tags sharing most sources are related topics, not variants)\n\n\
+         | cosine | alias (count) | → canonical (count) |\n|---|---|---|\n",
+        proposals.len(),
+        if dropped > 0 {
+            format!(", {dropped} more below the display cap")
+        } else {
+            String::new()
+        }
+    ));
+    for p in &proposals {
+        report.push_str(&format!(
+            "| {:.3}{} | {} ({}) | {} ({}) |\n",
+            p.cosine,
+            if p.cosine >= STRONG_MERGE { " ★" } else { "" },
+            p.alias,
+            p.alias_count,
+            p.canonical,
+            p.canonical_count
+        ));
+    }
+    report.push_str("\n### Paste-ready block (edit before use)\n\n```toml\n[aliases]\n");
+    for p in &proposals {
+        report.push_str(&format!("# cosine {:.3}\n\"{}\" = \"{}\"\n", p.cosine, p.alias, p.canonical));
+    }
+    report.push_str("```\n");
+    report.push_str(&format!(
+        "\n## Backfill\n\n{covered}/{} untagged sources received inferred tags \
+         (`.ovp/tags/inferred.json`); they surface as `tags_inferred`, never as \
+         operator tags. Regenerate anytime; delete the file to turn backfill off.\n",
+        untagged.len()
+    ));
+    let report_path = args.vault_root.join(layout.tags_proposals_file());
+    if let Some(parent) = report_path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| CliError::Io(format!("creating {}: {e}", parent.display())))?;
+    }
+    std::fs::write(&report_path, report)
+        .map_err(|e| CliError::Io(format!("writing {}: {e}", report_path.display())))?;
+    println!(
+        "  merges: {} candidate pair(s) → {}",
+        proposals.len(),
+        report_path.display()
+    );
+    println!("tags-suggest: done. Rebuild the index (`ovp2 index`) to surface inferred tags.");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tags(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn vote_requires_share_and_support() {
+        let a = tags(&["agent", "rust"]);
+        let b = tags(&["agent"]);
+        let c = tags(&["python"]);
+        let neighbors: Vec<(f64, &[String])> = vec![(0.9, &a), (0.8, &b), (0.5, &c)];
+        let got = vote_tags(&neighbors, 0.35, 2, 5);
+        // agent: share (0.9+0.8)/2.2 ≈ 0.77, support 2 → wins.
+        // rust: support 1 → out. python: share 0.5/2.2 ≈ 0.23 → out.
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].tag, "agent");
+        assert_eq!(got[0].support, 2);
+    }
+
+    #[test]
+    fn vote_is_empty_on_zero_weight_and_caps_output() {
+        let a = tags(&["x", "y", "z"]);
+        assert!(vote_tags(&[(0.0, &a)], 0.1, 1, 5).is_empty());
+        let got = vote_tags(&[(1.0, &a), (1.0, &a)], 0.1, 1, 2);
+        assert_eq!(got.len(), 2);
+    }
+
+    #[test]
+    fn merge_canonical_is_higher_count_and_sorted_by_cosine() {
+        let t = vec![
+            ("agent".to_string(), (0..150).collect::<Vec<usize>>()),
+            ("agents".to_string(), vec![200, 201]),
+            ("python".to_string(), (300..314).collect()),
+        ];
+        // agent ≈ agents (disjoint sources); python orthogonal.
+        let v = vec![vec![1.0, 0.0], vec![0.99, 0.14], vec![0.0, 1.0]];
+        let (got, suppressed) = merge_proposals(&t, &v, 0.75);
+        assert_eq!(suppressed, 0);
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].alias, "agents");
+        assert_eq!(got[0].canonical, "agent");
+        assert!(got[0].cosine >= 0.98);
+    }
+
+    #[test]
+    fn merge_suppresses_co_occurring_pairs() {
+        // Two singleton tags on the SAME source: near-1.0 cosine (shared
+        // sample titles) but co-occurrence, not synonymy — suppressed.
+        let t = vec![
+            ("思考".to_string(), vec![7]),
+            ("内容创作".to_string(), vec![7]),
+        ];
+        let v = vec![vec![1.0, 0.0], vec![0.999, 0.04]];
+        let (got, suppressed) = merge_proposals(&t, &v, 0.75);
+        assert!(got.is_empty());
+        assert_eq!(suppressed, 1);
+    }
+}

--- a/crates/ovp-cli/src/commands/tags_suggest.rs
+++ b/crates/ovp-cli/src/commands/tags_suggest.rs
@@ -66,6 +66,23 @@ impl Default for TagsSuggestArgs {
     }
 }
 
+/// A tag name as a valid TOML basic string — `normalize_tag` preserves
+/// quotes/backslashes, which would break the paste-ready block unescaped.
+pub(crate) fn toml_basic_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04X}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
 /// One tag's neighbor vote on one source (pure, unit-tested): neighbors are
 /// `(similarity, tags)` pairs, already the k nearest. A tag wins when its
 /// similarity-weighted share ≥ `vote_threshold` AND ≥ `min_support` distinct
@@ -181,10 +198,17 @@ pub(crate) fn merge_proposals(
 }
 
 pub fn run(args: TagsSuggestArgs) -> Result<(), CliError> {
-    if !args.merge_threshold.is_finite() || !args.vote_threshold.is_finite() {
-        return Err(CliError::Io(
-            "tags-suggest: thresholds must be finite numbers".into(),
-        ));
+    if !(-1.0..=1.0).contains(&args.merge_threshold) {
+        return Err(CliError::Io(format!(
+            "tags-suggest: --merge-threshold is a cosine, must be in [-1, 1] (got {})",
+            args.merge_threshold
+        )));
+    }
+    if !(0.0..=1.0).contains(&args.vote_threshold) {
+        return Err(CliError::Io(format!(
+            "tags-suggest: --vote-threshold is a share, must be in [0, 1] (got {})",
+            args.vote_threshold
+        )));
     }
     let layout = VaultLayout::new();
     let model = read_index(&args.vault_root).map_err(|e| {
@@ -270,11 +294,9 @@ pub fn run(args: TagsSuggestArgs) -> Result<(), CliError> {
         ]),
         entries,
     };
-    let inferred_path = inferred.save(&args.vault_root).map_err(CliError::Io)?;
-    println!(
-        "  backfill: {covered}/{} untagged source(s) received inferred tags → {inferred_path}",
-        untagged.len()
-    );
+    // NOT saved yet — both projections persist together at the end, so a
+    // graceful embedding skip below can never leave inferred.json from this
+    // run beside a proposals.md from an older one.
 
     // ---- Merge candidates over the tag vocabulary ----
     // Vocabulary + carrying-source indices + up-to-3 sample titles per tag.
@@ -304,8 +326,17 @@ pub fn run(args: TagsSuggestArgs) -> Result<(), CliError> {
         })
         .collect();
     let Some(tag_vectors) = resolve_vectors(&tag_docs, &embed_cache_dir)? else {
+        println!(
+            "tags-suggest: nothing written — tag-vocabulary embeddings unavailable \
+             (both projections persist together or not at all)."
+        );
         return Ok(());
     };
+    let inferred_path = inferred.save(&args.vault_root).map_err(CliError::Io)?;
+    println!(
+        "  backfill: {covered}/{} untagged source(s) received inferred tags → {inferred_path}",
+        untagged.len()
+    );
     let counts: Vec<(String, Vec<usize>)> = vocab
         .iter()
         .map(|(tag, (srcs, _))| ((*tag).to_string(), srcs.clone()))
@@ -348,7 +379,12 @@ pub fn run(args: TagsSuggestArgs) -> Result<(), CliError> {
     }
     report.push_str("\n### Paste-ready block (edit before use)\n\n```toml\n[aliases]\n");
     for p in &proposals {
-        report.push_str(&format!("# cosine {:.3}\n\"{}\" = \"{}\"\n", p.cosine, p.alias, p.canonical));
+        report.push_str(&format!(
+            "# cosine {:.3}\n{} = {}\n",
+            p.cosine,
+            toml_basic_string(&p.alias),
+            toml_basic_string(&p.canonical)
+        ));
     }
     report.push_str("```\n");
     report.push_str(&format!(
@@ -418,6 +454,16 @@ mod tests {
         assert_eq!(got[0].alias, "agents");
         assert_eq!(got[0].canonical, "agent");
         assert!(got[0].cosine >= 0.98);
+    }
+
+    #[test]
+    fn toml_basic_string_escapes_quotes_and_backslashes() {
+        assert_eq!(toml_basic_string("agent"), "\"agent\"");
+        assert_eq!(toml_basic_string("foo\"bar"), "\"foo\\\"bar\"");
+        assert_eq!(toml_basic_string("a\\b"), "\"a\\\\b\"");
+        // Round-trips through the real parser.
+        let line = format!("[aliases]\n{} = \"ok\"\n", toml_basic_string("foo\"bar"));
+        assert!(ovp_domain::tags::TagAliases::parse(&line).is_ok());
     }
 
     #[test]

--- a/crates/ovp-cli/src/commands/tags_suggest.rs
+++ b/crates/ovp-cli/src/commands/tags_suggest.rs
@@ -75,7 +75,9 @@ pub(crate) fn toml_basic_string(s: &str) -> String {
         match c {
             '"' => out.push_str("\\\""),
             '\\' => out.push_str("\\\\"),
-            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04X}", c as u32)),
+            c if (c as u32) < 0x20 || c == '\u{7f}' => {
+                out.push_str(&format!("\\u{:04X}", c as u32))
+            }
             c => out.push(c),
         }
     }
@@ -155,6 +157,11 @@ pub(crate) fn merge_proposals(
     vectors: &[Vec<f32>],
     threshold: f64,
 ) -> (Vec<MergeProposal>, usize) {
+    assert_eq!(
+        tags.len(),
+        vectors.len(),
+        "merge_proposals: one vector per tag"
+    );
     let sets: Vec<std::collections::BTreeSet<usize>> = tags
         .iter()
         .map(|(_, srcs)| srcs.iter().copied().collect())
@@ -270,11 +277,14 @@ pub fn run(args: TagsSuggestArgs) -> Result<(), CliError> {
 
     // ---- Backfill: kNN vote for every untagged source ----
     let mut entries: BTreeMap<String, Vec<InferredTag>> = BTreeMap::new();
+    let mut sims: Vec<(f64, &[String])> = Vec::with_capacity(tagged.len());
     for (idx, sha) in &untagged {
-        let mut sims: Vec<(f64, &[String])> = tagged
-            .iter()
-            .map(|(t_idx, _, tags)| (cosine(&vectors[*idx], &vectors[*t_idx]), *tags))
-            .collect();
+        sims.clear();
+        sims.extend(
+            tagged
+                .iter()
+                .map(|(t_idx, _, tags)| (cosine(&vectors[*idx], &vectors[*t_idx]), *tags)),
+        );
         sims.sort_by(|(sa, _), (sb, _)| sb.partial_cmp(sa).unwrap_or(std::cmp::Ordering::Equal));
         sims.truncate(args.knn);
         let voted = vote_tags(&sims, args.vote_threshold, args.min_support, args.max_tags);

--- a/crates/ovp-cli/src/main.rs
+++ b/crates/ovp-cli/src/main.rs
@@ -664,6 +664,30 @@ enum Cmd {
         #[arg(long, default_value_t = 42)]
         seed: u64,
     },
+    /// Propose tag curation over the embedding layer: merge candidates for
+    /// near-duplicate tags (→ .ovp/tags/proposals.md, paste into aliases.toml
+    /// after review) and kNN-voted backfill tags for untagged sources
+    /// (→ .ovp/tags/inferred.json, surfaced as tags_inferred). Deterministic,
+    /// no LLM; reuses the crystal-themes embedding cache. Run `index` first.
+    TagsSuggest {
+        #[arg(long)]
+        vault_root: PathBuf,
+        /// Cosine floor for a merge proposal to enter the report.
+        #[arg(long, default_value_t = 0.75)]
+        merge_threshold: f64,
+        /// Tagged neighbors consulted per untagged source.
+        #[arg(long, default_value_t = 10)]
+        knn_k: usize,
+        /// Minimum share of neighbor similarity weight a tag needs (0..1).
+        #[arg(long, default_value_t = 0.35)]
+        vote_threshold: f64,
+        /// Minimum number of neighbors carrying the tag.
+        #[arg(long, default_value_t = 2)]
+        min_support: usize,
+        /// Cap on inferred tags per source.
+        #[arg(long, default_value_t = 5)]
+        max_tags: usize,
+    },
     /// PRODUCT — reader/crystal trunk (the blessed path).
     /// M25 Crystal Review Workbench: apply human review decisions over caveated
     /// claims into a REVISED structured candidate. The decision authors a
@@ -1716,6 +1740,21 @@ fn main() -> ExitCode {
                 seed,
             })
         }
+        Cmd::TagsSuggest {
+            vault_root,
+            merge_threshold,
+            knn_k,
+            vote_threshold,
+            min_support,
+            max_tags,
+        } => commands::tags_suggest::run(commands::tags_suggest::TagsSuggestArgs {
+            vault_root,
+            merge_threshold,
+            knn: knn_k,
+            vote_threshold,
+            min_support,
+            max_tags,
+        }),
         Cmd::CrystalReview {
             candidate,
             decisions,

--- a/crates/ovp-console/src/render.rs
+++ b/crates/ovp-console/src/render.rs
@@ -349,6 +349,7 @@ mod tests {
                     fail_count: 0,
                     last_reason: None,
                     tags: Vec::new(),
+                    tags_inferred: Vec::new(),
                 },
                 SourceRow {
                     sha256: "cccc".into(),
@@ -362,6 +363,7 @@ mod tests {
                     fail_count: 3,
                     last_reason: Some("card synthesis did not parse".into()),
                     tags: Vec::new(),
+                    tags_inferred: Vec::new(),
                 },
             ],
             packs: vec![PackRow {

--- a/crates/ovp-domain/src/tags.rs
+++ b/crates/ovp-domain/src/tags.rs
@@ -174,6 +174,73 @@ impl TagAliases {
     }
 }
 
+pub const TAGS_INFERRED_SCHEMA: &str = "ovp.tags-inferred/v1";
+
+/// One machine-inferred tag on one source, with its evidence.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct InferredTag {
+    pub tag: String,
+    /// Share of neighbor similarity weight that voted for this tag (0..1).
+    pub score: f64,
+    /// Number of neighbors carrying the tag.
+    pub support: usize,
+}
+
+/// `.ovp/tags/inferred.json` — kNN-voted tags for sources that had NO
+/// operator tags at generation time. A rebuildable projection: regenerate
+/// with `tags-suggest`, delete freely. The index attaches these as
+/// `tags_inferred`, never mixing them into operator tags, and drops them for
+/// any source that has since gained real tags (self-healing staleness).
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct TagsInferredFile {
+    pub schema: String,
+    /// Embedding model the neighbor graph was built with.
+    pub model: String,
+    /// Generation parameters, recorded for auditability (k, thresholds…).
+    #[serde(default)]
+    pub params: BTreeMap<String, f64>,
+    /// source sha256 → inferred tags (score descending).
+    #[serde(default)]
+    pub entries: BTreeMap<String, Vec<InferredTag>>,
+}
+
+impl TagsInferredFile {
+    /// Load from the vault. Missing file → `None` (feature unused); a present
+    /// but unparseable file is an error — silently dropping every inferred
+    /// tag would read as "backfill vanished".
+    pub fn load(vault_root: &Path) -> Result<Option<Self>, String> {
+        let path = vault_root.join(crate::vault_layout::VaultLayout.tags_inferred_file());
+        let raw = match std::fs::read_to_string(&path) {
+            Ok(raw) => raw,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => return Err(format!("reading {}: {e}", path.display())),
+        };
+        let file: Self = serde_json::from_str(&raw)
+            .map_err(|e| format!("parsing {}: {e}", path.display()))?;
+        if file.schema != TAGS_INFERRED_SCHEMA {
+            return Err(format!(
+                "{}: unknown schema {:?} (expected {TAGS_INFERRED_SCHEMA:?})",
+                path.display(),
+                file.schema
+            ));
+        }
+        Ok(Some(file))
+    }
+
+    pub fn save(&self, vault_root: &Path) -> Result<String, String> {
+        let path = vault_root.join(crate::vault_layout::VaultLayout.tags_inferred_file());
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("creating {}: {e}", parent.display()))?;
+        }
+        let body = serde_json::to_string_pretty(self)
+            .map_err(|e| format!("serializing inferred tags: {e}"))?;
+        std::fs::write(&path, format!("{body}\n"))
+            .map_err(|e| format!("writing {}: {e}", path.display()))?;
+        Ok(path.display().to_string())
+    }
+}
+
 /// Raw frontmatter tags → sorted, deduped canonical tags: normalize, drop
 /// boilerplate, resolve aliases, apply the operator drop list. The one entry
 /// point projections use.

--- a/crates/ovp-domain/src/vault_layout.rs
+++ b/crates/ovp-domain/src/vault_layout.rs
@@ -228,6 +228,18 @@ impl VaultLayout {
     pub fn tag_aliases_file(&self) -> &'static str {
         ".ovp/tags/aliases.toml"
     }
+
+    /// Machine-inferred tags for untagged sources (`tags-suggest` output) —
+    /// a rebuildable projection, kept strictly apart from operator tags.
+    pub fn tags_inferred_file(&self) -> &'static str {
+        ".ovp/tags/inferred.json"
+    }
+
+    /// The human-review report `tags-suggest` writes: merge candidates with
+    /// evidence + a paste-ready `[aliases]` block. Never read by the pipeline.
+    pub fn tags_proposals_file(&self) -> &'static str {
+        ".ovp/tags/proposals.md"
+    }
 }
 
 /// Truncate to at most `max` characters on a char boundary (titles can be

--- a/crates/ovp-index/src/build.rs
+++ b/crates/ovp-index/src/build.rs
@@ -17,7 +17,7 @@ use ovp_daily::{MAX_FAILURES_BEFORE_BLOCKED, RunReport, RunStatus, read_daily_le
 use ovp_domain::VaultLayout;
 use ovp_domain::crystal::themes::{ThemesFile, UNCLASSIFIED_THEME};
 use ovp_domain::crystal::{CrystalStatus, ReviewEntry, StoreEvent, fold_ledger};
-use ovp_domain::tags::{TagAliases, canonical_tags};
+use ovp_domain::tags::{TagAliases, TagsInferredFile, canonical_tags};
 use ovp_domain::units::read_source_from_path;
 use ovp_intake::vaultops::{hex_sha256, read_jsonl, rel_to};
 use ovp_intake::{IntakeAction, read_intake_ledger};
@@ -234,6 +234,7 @@ fn build_sources(
                 fail_count: 0,
                 last_reason: rec.note.clone(),
                 tags: Vec::new(),
+                tags_inferred: Vec::new(),
             },
         );
     }
@@ -256,6 +257,7 @@ fn build_sources(
                 fail_count: 0,
                 last_reason: None,
                 tags: Vec::new(),
+                tags_inferred: Vec::new(),
             });
         entry.date = Some(rec.date.clone());
         entry.last_run_id = Some(rec.run_id.clone());
@@ -320,6 +322,7 @@ fn build_sources(
                     fail_count: 0,
                     last_reason: None,
                     tags: Vec::new(),
+                    tags_inferred: Vec::new(),
                 }
             });
         }
@@ -359,6 +362,7 @@ fn build_sources(
 /// is a hard error (a silently ignored table would un-merge the vocabulary).
 fn attach_tags(vault_root: &Path, rows: &mut [SourceRow]) -> Result<usize, String> {
     let aliases = TagAliases::load(vault_root)?;
+    let inferred = TagsInferredFile::load(vault_root)?.unwrap_or_default();
     let mut tagged = 0;
     for row in rows.iter_mut() {
         let Some(rel) = row.rel_path.as_deref() else {
@@ -370,6 +374,13 @@ fn attach_tags(vault_root: &Path, rows: &mut [SourceRow]) -> Result<usize, Strin
         row.tags = canonical_tags(&doc.tags, &aliases);
         if !row.tags.is_empty() {
             tagged += 1;
+        } else if let Some(voted) = inferred.entries.get(&row.sha256) {
+            // Backfill applies ONLY while the source has no operator tags —
+            // hand-tagging a note silently retires its inferred tags on the
+            // next build. Inferred names re-run through the alias pipe so a
+            // later merge also heals stale inference output.
+            let names: Vec<&str> = voted.iter().map(|t| t.tag.as_str()).collect();
+            row.tags_inferred = canonical_tags(&names, &aliases);
         }
     }
     Ok(tagged)
@@ -672,6 +683,7 @@ fn backfill_corpus_packs(
                     fail_count: 0,
                     last_reason: None,
                     tags: Vec::new(),
+                    tags_inferred: Vec::new(),
                 });
                 by_sha.insert(sha256.clone(), sources.len() - 1);
                 changed = true;
@@ -1210,6 +1222,7 @@ mod tests {
             fail_count: 3,
             last_reason: Some("boom".into()),
             tags: Vec::new(),
+            tags_inferred: Vec::new(),
         };
         let sources = vec![
             src("aaaa", SourceStatus::Blocked, "2026-06-30"), // 8 days stuck

--- a/crates/ovp-index/src/model.rs
+++ b/crates/ovp-index/src/model.rs
@@ -55,6 +55,12 @@ pub struct SourceRow {
     /// Serde-additive: pre-tag indexes deserialize to empty.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tags: Vec<String>,
+    /// Machine-inferred tags (`tags-suggest` kNN vote, `.ovp/tags/inferred.json`)
+    /// — attached ONLY while the source has no operator tags, so a later
+    /// hand-tagging silently retires them. Kept strictly apart from `tags`;
+    /// surfaces render them visibly weaker (`~#tag`, dashed chips).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags_inferred: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/ovp-index/src/query.rs
+++ b/crates/ovp-index/src/query.rs
@@ -81,9 +81,13 @@ pub fn run_query(model: &IndexModel, q: &Query) -> Vec<Hit> {
             None => return Vec::new(),
         },
     };
-    let tag_ok = |tags: &[String]| match &tag {
+    // Operator tags and inferred backfill are both matchable — the filter's
+    // job is recall; the row display keeps the provenance visible (`~#x`).
+    let tag_ok = |s: &crate::model::SourceRow| match &tag {
         None => true,
-        Some(t) => tags.iter().any(|have| have == t),
+        Some(t) => {
+            s.tags.iter().any(|have| have == t) || s.tags_inferred.iter().any(|have| have == t)
+        }
     };
 
     let mut hits = Vec::new();
@@ -92,25 +96,39 @@ pub fn run_query(model: &IndexModel, q: &Query) -> Vec<Hit> {
     // one row per canonical tag over the status/date-filtered sources, count
     // descending. `term` narrows by substring; a `--tag` filter is exact.
     if q.kind == Some(QueryKind::Tags) {
-        let mut counts: std::collections::BTreeMap<&str, usize> = std::collections::BTreeMap::new();
+        // (operator count, inferred count) per canonical tag.
+        let mut counts: std::collections::BTreeMap<&str, (usize, usize)> =
+            std::collections::BTreeMap::new();
         for s in &model.sources {
             if !status_ok(source_status_str(s.status)) || !date_ok(s.date.as_deref()) {
                 continue;
             }
             for t in &s.tags {
-                *counts.entry(t.as_str()).or_default() += 1;
+                counts.entry(t.as_str()).or_default().0 += 1;
+            }
+            for t in &s.tags_inferred {
+                counts.entry(t.as_str()).or_default().1 += 1;
             }
         }
-        let mut rows: Vec<(&str, usize)> = counts
+        let mut rows: Vec<(&str, (usize, usize))> = counts
             .into_iter()
             .filter(|(t, _)| matches(&[t]) && tag.as_deref().map(|want| *t == want).unwrap_or(true))
             .collect();
-        rows.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(b.0)));
-        for (t, n) in rows {
+        rows.sort_by(|a, b| {
+            (b.1.0 + b.1.1)
+                .cmp(&(a.1.0 + a.1.1))
+                .then_with(|| a.0.cmp(b.0))
+        });
+        for (t, (user, inferred)) in rows {
+            let line = if inferred > 0 {
+                format!("{t} ({user}, ~{inferred})")
+            } else {
+                format!("{t} ({user})")
+            };
             hits.push(Hit {
                 kind: "tag".into(),
                 status: "tag".into(),
-                line: format!("{t} ({n})"),
+                line,
                 path: None,
                 id: Some(t.to_string()),
             });
@@ -121,7 +139,7 @@ pub fn run_query(model: &IndexModel, q: &Query) -> Vec<Hit> {
     if kind_ok(QueryKind::Sources) {
         for s in &model.sources {
             let status = source_status_str(s.status);
-            if !status_ok(status) || !date_ok(s.date.as_deref()) || !tag_ok(&s.tags) {
+            if !status_ok(status) || !date_ok(s.date.as_deref()) || !tag_ok(s) {
                 continue;
             }
             let title = s.title.as_deref().unwrap_or("(untitled)");
@@ -136,6 +154,9 @@ pub fn run_query(model: &IndexModel, q: &Query) -> Vec<Hit> {
             }
             if !s.tags.is_empty() {
                 line.push_str(&format!(" #{}", s.tags.join(" #")));
+            }
+            if !s.tags_inferred.is_empty() {
+                line.push_str(&format!(" ~#{}", s.tags_inferred.join(" ~#")));
             }
             if s.fail_count > 0 {
                 line.push_str(&format!(" fails={}", s.fail_count));

--- a/crates/ovp-index/tests/index_build.rs
+++ b/crates/ovp-index/tests/index_build.rs
@@ -889,6 +889,65 @@ fn tags_are_read_from_current_frontmatter_normalized_and_alias_resolved() {
 }
 
 #[test]
+fn inferred_tags_attach_only_to_untagged_sources_and_match_the_filter() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    let untagged_sha = place(
+        root,
+        "50-Inbox/01-Raw/2026-06/untagged.md",
+        "---\ntitle: Untagged Note\nsource: https://e.x/u\n---\nbody\n",
+    );
+    let tagged_sha = place(
+        root,
+        "50-Inbox/01-Raw/2026-06/tagged.md",
+        "---\ntitle: Tagged Note\nsource: https://e.x/t\ntags:\n  - rust\n---\nbody\n",
+    );
+    // Inferred file covers BOTH shas: the untagged row gains tags_inferred;
+    // the tagged row must ignore its (stale) entry entirely.
+    place(
+        root,
+        ".ovp/tags/inferred.json",
+        &format!(
+            r#"{{"schema":"ovp.tags-inferred/v1","model":"m","entries":{{
+                "{untagged_sha}": [{{"tag":"agent","score":0.7,"support":3}}],
+                "{tagged_sha}": [{{"tag":"python","score":0.5,"support":2}}]
+            }}}}"#
+        ),
+    );
+
+    let model = build_index(root, "2026-06-09", None).unwrap();
+    let untagged = model.sources.iter().find(|s| s.sha256 == untagged_sha).unwrap();
+    assert!(untagged.tags.is_empty());
+    assert_eq!(untagged.tags_inferred, vec!["agent"]);
+    let tagged = model.sources.iter().find(|s| s.sha256 == tagged_sha).unwrap();
+    assert_eq!(tagged.tags, vec!["rust"]);
+    assert!(tagged.tags_inferred.is_empty(), "hand-tagging retires inference");
+
+    // The tag filter matches inferred tags; the line marks them `~#`.
+    let hits = run_query(
+        &model,
+        &Query {
+            tag: Some("agent".into()),
+            ..Default::default()
+        },
+    );
+    assert_eq!(hits.len(), 1);
+    assert!(hits[0].line.contains("~#agent"), "{}", hits[0].line);
+
+    // Vocabulary listing separates operator and inferred counts.
+    let vocab = run_query(
+        &model,
+        &Query {
+            kind: Some(QueryKind::Tags),
+            ..Default::default()
+        },
+    );
+    let lines: Vec<&str> = vocab.iter().map(|h| h.line.as_str()).collect();
+    assert_eq!(lines, vec!["agent (0, ~1)", "rust (1)"]);
+}
+
+#[test]
 fn broken_alias_table_fails_the_build_loudly() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();

--- a/crates/ovp-publish/src/lib.rs
+++ b/crates/ovp-publish/src/lib.rs
@@ -454,6 +454,7 @@ mod tests {
             fail_count: 0,
             last_reason: None,
             tags: Vec::new(),
+            tags_inferred: Vec::new(),
         }
     }
 

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -1928,6 +1928,7 @@ mod tests {
                 fail_count: 0,
                 last_reason: None,
                 tags: Vec::new(),
+                tags_inferred: Vec::new(),
             }],
             packs: vec![PackRow {
                 pack_dir: "40-Resources/Reader/good".into(),
@@ -2446,6 +2447,7 @@ mod tests {
             fail_count: 0,
             last_reason: None,
             tags: Vec::new(),
+            tags_inferred: Vec::new(),
         }
     }
 

--- a/docs/stage-tags-product.md
+++ b/docs/stage-tags-product.md
@@ -1,0 +1,186 @@
+# Tags as a Product Surface — design anchor
+
+Status: direction approved by operator 2026-07-16. T0 shipped (PR #340 facet +
+plumbing, PR #341 tags-suggest). This doc designs T1–T3 and the two parallel
+tracks (theme deepening, Tier-0 URL entities). Nothing below is implemented
+unless marked shipped.
+
+## 0. Why this doc exists
+
+T0 was built against the operator's own vault: pinboard bookmarks with a
+curated 116-tag vocabulary seeding everything. **A general user has none of
+that.** They have a markdown folder — maybe sparse, sloppy frontmatter tags,
+maybe zero. KMEM-class products are friendly to that user because tags simply
+appear (LLM labels everything, reuse-prompted). Our answer must match that UX
+floor without inheriting its failure mode (KMEM live vocabulary: 30.7%
+singleton rate; unconstrained LLM tagging is the best-documented failure in
+this space — Karakeep/Readwise/Raindrop all converged on closed vocabularies).
+
+### Personas
+
+| Persona | Corpus | Tags today | T0 behavior |
+|---|---|---|---|
+| P0 curator (operator) | pinboard + clipper | curated vocabulary | full stack works |
+| P1 md-only | markdown folder | **zero tags** | nothing — no vocabulary, no kNN signal |
+| P2 casual | markdown + some frontmatter | sparse, sloppy | partial — alias pipe works, backfill weak |
+
+The product gap is P1/P2. T1 closes it.
+
+## 1. Principles (carried from the research round + M34 process rules)
+
+1. **Humans/code own the vocabulary; the LLM only classifies into it.**
+   Vocabulary *invention* is allowed only as capped proposals that are
+   embedding-deduped against existing names before entering.
+2. **The pipeline never rewrites note frontmatter.** One deliberate exception:
+   an explicit per-source USER action in the UI (accept an inferred tag / add
+   a tag) writes that note's frontmatter — that is the user editing their
+   vault through the product, identical in kind to an Obsidian edit.
+3. **Everything derived is a projection**: `aliases.toml` (operator judgments),
+   `inferred.json`, `vocabulary.toml`, proposals — all rebuildable, none
+   ledger-grade.
+4. **Provenance always visible**: user `#tag` vs inferred `~#tag`, everywhere.
+5. **Decidability rule**: normalization/dedup/counting = code; classification
+   into a closed vocabulary = LLM permitted (not decidable ground truth);
+   free-form generation = never.
+
+## 2. T1 — cold-start bootstrap (`tags-bootstrap`)
+
+Goal: a P1 vault gets useful tags with zero manual work, KMEM-equivalent UX.
+
+**Vocabulary seed without pinboard (deterministic floor, 0 tokens):**
+the theme communities already exist for any vault (`crystal-themes`:
+embeddings → Louvain → c-TF-IDF). Their per-community keywords ARE a
+candidate vocabulary: ~17 communities × top keywords ≈ 60–120 candidate tags,
+bilingual, corpus-derived, no LLM. Floor behavior with no LLM configured:
+every source inherits its community's top keyword(s) as `tags_inferred` —
+coarse but honest, and strictly better than nothing.
+
+**LLM classification pass (optional, `--client live`, cassette-cached):**
+batched (~20 sources/call, same batching discipline as crystal-synth):
+
+- input: source title + card titles + the candidate vocabulary (names only);
+- the model picks 1–5 tags per source **from the vocabulary**, and may propose
+  at most 2 new tag names per batch;
+- proposed new names are normalized, then embedding-matched against the
+  existing vocabulary — cosine ≥ 0.9 → silently mapped to the existing tag
+  (the Karakeep lesson: put reuse in the MATCHING layer, not the prompt);
+  genuinely new survivors enter `vocabulary.toml` marked `origin = "llm"`;
+- assignments land in `tags_inferred` — never frontmatter.
+
+**`vocabulary.toml`** (new, projection): the closed list the classifier is
+allowed to use = user tags observed in the index ∪ accepted community
+keywords ∪ surviving LLM proposals. P0's pinboard vocabulary is just the
+degenerate case where the first term dominates. Users curate it in the UI
+(T2) or ignore it.
+
+**Self-healing (already shipped, T1 inherits it):** hand-tagging a source
+retires its inferred tags on the next index build; inferred names re-run
+through the alias/drop pipe.
+
+Incremental: `daily` runs classification only for sources with no entry in
+`inferred.json` (content-hash keyed like every cassette).
+
+**KMEM comparison, honestly stated:** same surface UX (tags appear on
+everything automatically); different guarantees — closed-vocabulary
+classification with embedding-gated growth (they prompt-and-hope), provenance
+separation (they can't tell user tags from machine tags), self-healing
+retirement (their labels accrete forever).
+
+## 3. T2 — curation & browsing UI
+
+All live-server only; the published static site stays read-only with tags
+redacted (unchanged).
+
+1. **`/tags` page** (Library sub-surface): the vocabulary browser — every
+   canonical tag with user/inferred counts (`156 + ~129`), sort by count/name,
+   text filter, click-through to the filtered Library. Empty state explains
+   the bootstrap path.
+2. **Curation inbox** (`/tags` tab): renders merge proposals as decision
+   cards — “`ai-agents` → `agent` · cosine 0.93 · 9 vs 22 sources · sample
+   titles…” with **Accept / Reject**.
+   - Accept → `POST /api/tags/alias` appends to `aliases.toml` + triggers
+     reindex. Reject → recorded as an `ignore = [["a","b"], …]` pair in
+     `aliases.toml`; `tags-suggest` skips ignored pairs on future runs so
+     rejected proposals never resurface. One curation file holds all
+     judgments (accepts as aliases, rejects as ignores, drops as drops).
+   - `tags-suggest` additionally emits `proposals.json` next to the md report
+     (same data, machine-readable) for this UI.
+3. **Per-source tag editing** (SourceDetailPage):
+   - inferred chips get an accept affordance: `~#memory ✓` →
+     `POST /api/source/:sha/tags` inserts the tag into that note's
+     frontmatter (principle 1's sanctioned exception, live server only, the
+     server re-reads/writes YAML through the same parser the intake uses);
+   - an add-tag box with **autocomplete over the vocabulary, reuse-first**
+     (write-time prevention beats repair — the folksonomy literature's oldest
+     result); free entry allowed, normalized on save.
+4. **The acceptance loop is the cold-start engine**: every accepted tag
+   becomes kNN training signal on the next build, so P1 vaults converge from
+   "LLM-classified" toward "user-curated" exactly as fast as the user cares
+   to click.
+
+## 4. T3 — granularity & hierarchy
+
+The generic-tag problem, now measured twice: 13.1% of tagged sources carry
+ONLY top-decile-frequency tags, and the kNN backfill mirrors the skew
+(post-drop real-vault run: `ai ~444`, `agent ~403`).
+
+1. **Specificity score** (code): IDF over tag document-frequency. A source
+   whose tags are all top-decile is *generic-only* and joins the backfill
+   queue with a constraint: only vote tags with df below half the source's
+   current minimum — i.e. inference may only ADD specificity, never more
+   generality. (Extends the inferred channel to non-empty sources under this
+   one rule; provenance display unchanged.)
+2. **Implications** (Danbooru pattern): co-occurrence subsumption
+   (Schmitz: propose `specific ⇒ generic` when P(generic|specific) ≥ 0.7 and
+   P(specific|generic) ≤ 0.3) → proposed in the curation inbox → accepted
+   into an `[implications]` section of `aliases.toml`. Facets render a
+   two-level rollup (generic groups its specifics); search on the generic
+   still matches. Generic tags are never split or deleted.
+
+## 5. Parallel tracks (separate PRs, designed here for review)
+
+### 5a. Theme deepening (operator-approved earlier)
+
+- **Sub-communities**: within each top-level community, re-run Louvain on the
+  induced subgraph at higher resolution (~2.5); communities of ≥3 members
+  become children (`parent_id` in `themes.json`, schema-additive). Keyword
+  labels per child; bilingual LLM labels reuse the existing `theme_label/v1`
+  cassette path.
+- **Theme summaries**: per top-level theme, one batched LLM synthesis over
+  member card titles/claims WITH citations, passed through the existing
+  deterministic citation verifier before it enters `themes.json`
+  (`summary`, `summary_citations` fields). The literature's one validated
+  organizational structure (GraphRAG community summaries), built the
+  LazyGraphRAG way: cheap, projection, rebuildable.
+- **Surfaces**: ThemeDetailPage gains children navigation + the cited
+  summary; terrain legend groups by parent.
+
+### 5b. Tier-0 URL entities (operator-approved: ship deterministic tier only)
+
+- **Extraction** (index build, regex, zero LLM, zero network): from
+  `source_url` + markdown link targets in the note body —
+  `github:owner/repo`, `arxiv:2504.19413`, `doi:10.x/y`, `npm:pkg`,
+  `crates:pkg`, `pypi:pkg`, `hn:item`. URL normalization (strip www/trailing
+  slash/.git, arXiv version suffix) = the entire identity problem, solved by
+  construction.
+- **Projection**: `.ovp/entities/url-entities.json` — entity id → {kind,
+  canonical URL, mentioning source sha256s}. SourceRow gains nothing; the
+  file is joined at render time (keeps the index lean).
+- **Surfaces**: entity chips on SourceDetail ("repo appears in 7 sources"),
+  `/entity/:id` page (mentioning sources + citing claims via pack join),
+  `find --entity`. Publish: included — URLs are already public content,
+  unlike personal tags.
+- **Tier-1 (Wikidata) stays experiment-gated** per the M34 kill-criteria
+  design; nothing here builds toward it.
+
+## 6. Sequencing
+
+| Phase | Depends on | LLM cost | Personas served |
+|---|---|---|---|
+| T1 bootstrap | themes (shipped) | one-time batched classify + daily increment; 0-token floor exists | P1/P2 get the product |
+| T2 curation UI | T1 (proposals.json) | 0 | all |
+| T3 granularity | T2 inbox | 0 | P0 + matured P1 |
+| 5a theme deepening | none | ~17 label + ~17 summary calls, cassette-cached | all |
+| 5b URL entities | none | 0 | all (tech corpora especially) |
+
+T1 → T2 is the product-critical path. 5a/5b are parallel-friendly.


### PR DESCRIPTION
## What

Stage 2 of the tag plan (stacked on #340 — merge that first, then retarget/merge this). Deterministic and LLM-free, reusing the crystal-themes embedding cache: a themed vault backfills with **zero new pack embeddings**.

- **`ovp2 tags-suggest`**, two outputs, both projections, neither auto-applied:
  - **Merge candidates** → `.ovp/tags/proposals.md` (+ paste-ready `[aliases]` block, TOML-escaped). Each canonical tag is embedded as "name + 3 sample titles"; pairs ≥ cosine threshold are proposed with canonical = higher-count member. **Co-occurrence suppression**: tags sharing most of their sources are related topics, not spelling variants — true synonyms almost never co-occur on one item (and shared sample titles inflate their cosine to ~1.0). On the real vault this cut 427 noise pairs → 37 candidates, led by genuine cross-lingual merges (多模态→multimodal, 产品管理→product-management).
  - **Backfill** → `.ovp/tags/inferred.json`: sources with NO operator tags get tags voted by their k nearest tagged neighbors (similarity-weighted share ≥ 0.35, support ≥ 2, ≤ 5 tags). Both files persist together or not at all (graceful embedding skip can't leave them inconsistent).
- **`tags_inferred` surfacing**: index attaches inferred tags only while a source has no operator tags — hand-tagging retires inference on the next build; inferred names re-run through the alias/drop pipe so later vocabulary curation heals old output. `--tag` matches operator ∪ inferred; source lines mark them `~#x`; `--kind tags` shows "agent (156, ~129)". Portal renders dashed chips; facet counts include inferred. PublicView clears both.

## Real-vault verification

- 488/574 untagged sources gained inferred tags → untagged coverage gap 32% → 6.8%. Spot-check of `~#memory` hits: all genuinely memory articles.
- 12s cold run (643 tag texts embedded); warm-cache re-run instant.
- Known wart, by design: kNN learns the `twitter` channel tag (~244 inferred); the operator's pending `drop=["twitter"]` decision in aliases.toml removes both user and inferred occurrences on the next index build (inferred names run through the same canonical pipe).

## Gates

- 84 Rust suites green (new: vote thresholds/support, co-occurrence suppression, TOML escaping round-trip, inferred-attach integration incl. hand-tagging-retires-inference); SPA tsc + vite + vitest green; clippy clean.
- codex review: GATE PASS (0 P1); 3 P2s fixed (atomic dual-projection persist, threshold range validation, TOML escaping).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `tags-suggest` command to generate inferred tags and tag-merge proposals.
  * Library and source searches now recognize machine-inferred tags.
  * Tag listings show separate counts for manually assigned and inferred tags.
  * Inferred tags appear as visually distinct, lower-emphasis chips and can be used as filters.
* **Bug Fixes**
  * Inferred tags are excluded from public views to prevent unintended exposure.
* **Documentation**
  * Added a roadmap describing staged tag curation, browsing, and hierarchy features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->