### PR TITLE
feat(tags): tags-bootstrap — cold-start tagging without a curated vocabulary (T1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2777,6 +2777,7 @@ dependencies = [
  "serde_yaml",
  "sha2",
  "tempfile",
+ "toml 0.8.2",
 ]
 
 [[package]]

--- a/console-ui/src/design/portal.css
+++ b/console-ui/src/design/portal.css
@@ -609,6 +609,11 @@ body {
   color: var(--accent);
   border-color: var(--accent);
 }
+/* Machine-inferred tags: same affordance, visibly weaker claim. */
+.tag-chip.inferred {
+  border-style: dashed;
+  opacity: 0.75;
+}
 
 /* ---------- sections / footer timeline ---------- */
 .section {

--- a/console-ui/src/design/portal.css
+++ b/console-ui/src/design/portal.css
@@ -586,6 +586,29 @@ body {
   color: var(--warn-text);
   overflow-wrap: anywhere;
 }
+/* Clickable per-row tag chips (library facet shortcut). Muted until active
+   so a heavily tagged row doesn't out-shout the title. */
+.tag-chip {
+  display: inline-block;
+  margin-right: 0.35rem;
+  padding: 0 0.4rem;
+  border: 1px solid var(--border);
+  border-radius: var(--ovp-radius-pill);
+  background: transparent;
+  color: var(--muted);
+  font-size: var(--ovp-text-xs);
+  font-family: var(--ovp-font-mono);
+  cursor: pointer;
+}
+.tag-chip:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.tag-chip.active {
+  background: var(--accent-soft);
+  color: var(--accent);
+  border-color: var(--accent);
+}
 
 /* ---------- sections / footer timeline ---------- */
 .section {

--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -127,6 +127,8 @@ export const en = {
   'library.pinboard': 'Pinboard',
   'library.capture': 'Capture',
   'library.byMonth': 'By month',
+  'library.byTag': 'By tag',
+  'library.moreTags': 'more tags',
   'library.statusAll': 'All',
   'library.empty': 'No sources match the current filters.',
   'library.noDate': 'no date',

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -118,6 +118,8 @@ export const zh: Record<keyof typeof en, string> = {
   'library.pinboard': '书签',
   'library.capture': '捕获',
   'library.byMonth': '按月',
+  'library.byTag': '按标签',
+  'library.moreTags': '更多标签',
   'library.statusAll': '全部',
   'library.empty': '当前筛选下没有匹配的源。',
   'library.noDate': '无日期',

--- a/console-ui/src/lib/derive.ts
+++ b/console-ui/src/lib/derive.ts
@@ -336,15 +336,18 @@ export function filterSources(
       (filter.collection === null || collectionOf(s) === filter.collection) &&
       (filter.month === null || monthOf(s) === filter.month) &&
       (filter.status === null || s.status === filter.status) &&
-      (filter.tag === null || (s.tags ?? []).includes(filter.tag)),
+      (filter.tag === null ||
+        (s.tags ?? []).includes(filter.tag) ||
+        (s.tags_inferred ?? []).includes(filter.tag)),
   );
 }
 
-/** Tag → source count over the whole library, count desc then name. */
+/** Tag → source count over the whole library (operator + inferred — the
+ * facet filters on both), count desc then name. */
 export function countTags(sources: SourceRow[]): [string, number][] {
   const counts = new Map<string, number>();
   for (const s of sources) {
-    for (const t of s.tags ?? []) {
+    for (const t of [...(s.tags ?? []), ...(s.tags_inferred ?? [])]) {
       counts.set(t, (counts.get(t) ?? 0) + 1);
     }
   }

--- a/console-ui/src/lib/derive.ts
+++ b/console-ui/src/lib/derive.ts
@@ -324,6 +324,7 @@ export interface LibraryFilter {
   collection: Collection | null;
   month: string | null;
   status: string | null;
+  tag: string | null;
 }
 
 export function filterSources(
@@ -334,8 +335,20 @@ export function filterSources(
     (s) =>
       (filter.collection === null || collectionOf(s) === filter.collection) &&
       (filter.month === null || monthOf(s) === filter.month) &&
-      (filter.status === null || s.status === filter.status),
+      (filter.status === null || s.status === filter.status) &&
+      (filter.tag === null || (s.tags ?? []).includes(filter.tag)),
   );
+}
+
+/** Tag → source count over the whole library, count desc then name. */
+export function countTags(sources: SourceRow[]): [string, number][] {
+  const counts = new Map<string, number>();
+  for (const s of sources) {
+    for (const t of s.tags ?? []) {
+      counts.set(t, (counts.get(t) ?? 0) + 1);
+    }
+  }
+  return [...counts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
 }
 
 export interface MonthGroup {

--- a/console-ui/src/lib/types.ts
+++ b/console-ui/src/lib/types.ts
@@ -115,6 +115,9 @@ export interface SourceRow {
   pack_dir?: string;
   fail_count: number;
   last_reason?: string;
+  /** Canonical content tags (normalized + alias-resolved at index build).
+   * Absent on pre-tag indexes and on the redacted public model. */
+  tags?: string[];
 }
 
 export interface PackRow {

--- a/console-ui/src/lib/types.ts
+++ b/console-ui/src/lib/types.ts
@@ -118,6 +118,9 @@ export interface SourceRow {
   /** Canonical content tags (normalized + alias-resolved at index build).
    * Absent on pre-tag indexes and on the redacted public model. */
   tags?: string[];
+  /** Machine-inferred backfill tags (tags-suggest kNN vote). Present only
+   * while the source has no operator tags; rendered visibly weaker. */
+  tags_inferred?: string[];
 }
 
 export interface PackRow {

--- a/console-ui/src/pages/LibraryPage.tsx
+++ b/console-ui/src/pages/LibraryPage.tsx
@@ -33,7 +33,11 @@ function LibraryBody({ model }: { model: IndexModel }) {
   const collection = params.get('c') as Collection | null;
   const month = params.get('m');
   const status = params.get('status');
-  const tag = params.get('tag');
+  // Honor ?tag= only when the model actually carries tags — on a pre-tag
+  // index or the redacted public model a deep-linked tag would silently
+  // filter out every source under an invisible facet.
+  const tagCounts = countTags(model.sources);
+  const tag = tagCounts.length > 0 ? params.get('tag') : null;
 
   const setParam = (key: string, value: string | null) => {
     const next = new URLSearchParams(params);
@@ -76,7 +80,6 @@ function LibraryBody({ model }: { model: IndexModel }) {
   // deep-linked ?tag= never renders as an invisible filter). Hidden entirely
   // when the index carries no tags (pre-tag index or redacted public model).
   const TAG_FACET_LIMIT = 15;
-  const tagCounts = countTags(model.sources);
   const tagFacet = tagCounts.slice(0, TAG_FACET_LIMIT);
   if (tag && !tagFacet.some(([t]) => t === tag)) {
     const active = tagCounts.find(([t]) => t === tag);

--- a/console-ui/src/pages/LibraryPage.tsx
+++ b/console-ui/src/pages/LibraryPage.tsx
@@ -221,6 +221,17 @@ function LibraryBody({ model }: { model: IndexModel }) {
                         #{tg}
                       </button>
                     ))}
+                    {(s.tags_inferred ?? []).map((tg) => (
+                      <button
+                        key={`~${tg}`}
+                        type="button"
+                        className={`tag-chip inferred${tag === tg ? ' active' : ''}`}
+                        title="inferred (tags-suggest)"
+                        onClick={() => setParam('tag', tag === tg ? null : tg)}
+                      >
+                        ~#{tg}
+                      </button>
+                    ))}
                     {s.date ?? ''} · {t(collectionLabel(collectionOf(s)))}
                   </span>
                 </div>

--- a/console-ui/src/pages/LibraryPage.tsx
+++ b/console-ui/src/pages/LibraryPage.tsx
@@ -8,6 +8,7 @@ import { useI18n, type MsgKey } from '../i18n';
 import {
   collectionOf,
   countBy,
+  countTags,
   filterSources,
   groupByMonth,
   monthOf,
@@ -32,6 +33,7 @@ function LibraryBody({ model }: { model: IndexModel }) {
   const collection = params.get('c') as Collection | null;
   const month = params.get('m');
   const status = params.get('status');
+  const tag = params.get('tag');
 
   const setParam = (key: string, value: string | null) => {
     const next = new URLSearchParams(params);
@@ -66,8 +68,20 @@ function LibraryBody({ model }: { model: IndexModel }) {
       !STATIC_MODE && collection && COLLECTIONS.includes(collection) ? collection : null,
     month,
     status,
+    tag,
   });
   const groups = groupByMonth(filtered);
+
+  // Tag facet: top of the vocabulary by count (plus the active tag, so a
+  // deep-linked ?tag= never renders as an invisible filter). Hidden entirely
+  // when the index carries no tags (pre-tag index or redacted public model).
+  const TAG_FACET_LIMIT = 15;
+  const tagCounts = countTags(model.sources);
+  const tagFacet = tagCounts.slice(0, TAG_FACET_LIMIT);
+  if (tag && !tagFacet.some(([t]) => t === tag)) {
+    const active = tagCounts.find(([t]) => t === tag);
+    tagFacet.push(active ?? [tag, 0]);
+  }
 
   return (
     <div className="grid library">
@@ -122,6 +136,30 @@ function LibraryBody({ model }: { model: IndexModel }) {
             ))}
           </ul>
         </div>
+        {tagFacet.length > 0 && (
+          <div className="facet-group">
+            <h3>{t('library.byTag')}</h3>
+            <ul className="facet-list">
+              {tagFacet.map(([tg, n]) => (
+                <li key={tg}>
+                  <button
+                    type="button"
+                    className={tag === tg ? 'active' : ''}
+                    onClick={() => setParam('tag', tag === tg ? null : tg)}
+                  >
+                    <span>#{tg}</span>
+                    <span className="count">{n}</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+            {tagCounts.length > TAG_FACET_LIMIT && (
+              <p className="muted sm">
+                +{tagCounts.length - TAG_FACET_LIMIT} {t('library.moreTags')}
+              </p>
+            )}
+          </div>
+        )}
       </div>
 
       {/* list column */}
@@ -170,6 +208,16 @@ function LibraryBody({ model }: { model: IndexModel }) {
                       )}
                   </span>
                   <span className="meta">
+                    {(s.tags ?? []).map((tg) => (
+                      <button
+                        key={tg}
+                        type="button"
+                        className={`tag-chip${tag === tg ? ' active' : ''}`}
+                        onClick={() => setParam('tag', tag === tg ? null : tg)}
+                      >
+                        #{tg}
+                      </button>
+                    ))}
                     {s.date ?? ''} · {t(collectionLabel(collectionOf(s)))}
                   </span>
                 </div>

--- a/crates/ovp-api-projection/src/graph.rs
+++ b/crates/ovp-api-projection/src/graph.rs
@@ -1954,6 +1954,7 @@ mod tests {
                     fail_count: 0,
                     last_reason: None,
                     tags: Vec::new(),
+                    tags_inferred: Vec::new(),
                 })
                 .collect(),
             packs: cases
@@ -2035,6 +2036,7 @@ mod tests {
             fail_count: 0,
             last_reason: None,
             tags: Vec::new(),
+            tags_inferred: Vec::new(),
         });
         let resp = source_neighborhood(&records, Some(&model), None, "freshsha").unwrap();
         assert_eq!(resp.nodes.len(), 1);
@@ -2085,6 +2087,7 @@ mod tests {
             fail_count: 0,
             last_reason: None,
             tags: Vec::new(),
+            tags_inferred: Vec::new(),
         });
         let evidence = evidence_for("fresh", "freshsha", 2);
         let resp =

--- a/crates/ovp-api-projection/src/graph.rs
+++ b/crates/ovp-api-projection/src/graph.rs
@@ -1953,6 +1953,7 @@ mod tests {
                     pack_dir: Some(format!("40-Resources/Reader/{case}")),
                     fail_count: 0,
                     last_reason: None,
+                    tags: Vec::new(),
                 })
                 .collect(),
             packs: cases
@@ -2033,6 +2034,7 @@ mod tests {
             pack_dir: None,
             fail_count: 0,
             last_reason: None,
+            tags: Vec::new(),
         });
         let resp = source_neighborhood(&records, Some(&model), None, "freshsha").unwrap();
         assert_eq!(resp.nodes.len(), 1);
@@ -2082,6 +2084,7 @@ mod tests {
             pack_dir: Some("40-Resources/Reader/fresh".into()),
             fail_count: 0,
             last_reason: None,
+            tags: Vec::new(),
         });
         let evidence = evidence_for("fresh", "freshsha", 2);
         let resp =

--- a/crates/ovp-api-projection/src/redact.rs
+++ b/crates/ovp-api-projection/src/redact.rs
@@ -36,6 +36,10 @@ impl PublicView {
             s.last_run_id = None;
             s.fail_count = 0;
             s.pack_dir = s.pack_dir.as_deref().map(case_id).map(str::to_string);
+            // Tags are the operator's personal taxonomy — private by default.
+            // Publishing them is a deliberate future decision, not a side
+            // effect of the tag facet landing on the live portal.
+            s.tags.clear();
         }
         let public_shas: std::collections::HashSet<&str> =
             m.sources.iter().map(|s| s.sha256.as_str()).collect();
@@ -134,6 +138,7 @@ mod tests {
             pack_dir: Some("40-Resources/Reader/case".into()),
             fail_count: 3,
             last_reason: reason.map(String::from),
+            tags: vec!["agent".into()],
         }
     }
 
@@ -187,6 +192,8 @@ mod tests {
         assert!(m.sources[0].last_reason.is_none());
         assert!(m.sources[0].last_run_id.is_none());
         assert_eq!(m.sources[0].fail_count, 0);
+        // Personal taxonomy never ships publicly.
+        assert!(m.sources[0].tags.is_empty());
         // Only the durable claim survives, citing only the public case.
         assert_eq!(m.claims.len(), 1);
         assert_eq!(m.claims[0].claim_id, "d1");

--- a/crates/ovp-api-projection/src/redact.rs
+++ b/crates/ovp-api-projection/src/redact.rs
@@ -40,6 +40,7 @@ impl PublicView {
             // Publishing them is a deliberate future decision, not a side
             // effect of the tag facet landing on the live portal.
             s.tags.clear();
+            s.tags_inferred.clear();
         }
         let public_shas: std::collections::HashSet<&str> =
             m.sources.iter().map(|s| s.sha256.as_str()).collect();
@@ -139,6 +140,7 @@ mod tests {
             fail_count: 3,
             last_reason: reason.map(String::from),
             tags: vec!["agent".into()],
+            tags_inferred: vec!["rust".into()],
         }
     }
 
@@ -192,8 +194,9 @@ mod tests {
         assert!(m.sources[0].last_reason.is_none());
         assert!(m.sources[0].last_run_id.is_none());
         assert_eq!(m.sources[0].fail_count, 0);
-        // Personal taxonomy never ships publicly.
+        // Personal taxonomy never ships publicly (operator or inferred).
         assert!(m.sources[0].tags.is_empty());
+        assert!(m.sources[0].tags_inferred.is_empty());
         // Only the durable claim survives, citing only the public case.
         assert_eq!(m.claims.len(), 1);
         assert_eq!(m.claims[0].claim_id, "d1");

--- a/crates/ovp-cli/src/commands/crystal_themes.rs
+++ b/crates/ovp-cli/src/commands/crystal_themes.rs
@@ -191,8 +191,10 @@ pub(crate) fn collect_docs(reader_root: &Path) -> Result<Vec<ThemeDoc>, CliError
 }
 
 /// Resolve vectors for every doc: cache first, embedder for the misses.
-/// `Ok(None)` = a graceful skip (reason already printed).
-fn resolve_vectors(
+/// `Ok(None)` = a graceful skip (reason already printed). `pub(crate)`:
+/// `tags-suggest` shares the cache/embedder plumbing (messages still say
+/// crystal-themes — same model, same cache, same degradation contract).
+pub(crate) fn resolve_vectors(
     docs: &[ThemeDoc],
     cache_dir: &Path,
 ) -> Result<Option<Vec<Vec<f32>>>, CliError> {

--- a/crates/ovp-cli/src/commands/daily.rs
+++ b/crates/ovp-cli/src/commands/daily.rs
@@ -552,6 +552,31 @@ fn run_inner(
             );
         }
 
+    // Tag-bootstrap increment (T1, docs/stage-tags-product.md §2): classify
+    // sources that arrived untagged into the closed vocabulary. Best-effort —
+    // an error warns and never aborts the run; no themes.json → the call
+    // explains and exits 0 (bootstrap embeds nothing, so no surprise
+    // downloads). Uses daily's client kind: replay = deterministic floor
+    // only, live = cassette-cached classification. A second (cheap)
+    // projection rebuild surfaces fresh inferred tags this run instead of
+    // tomorrow.
+    match crate::commands::tags_bootstrap::run(crate::commands::tags_bootstrap::TagsBootstrapArgs {
+        vault_root: args.vault_root.clone(),
+        client_kind: args.client_kind,
+        cache_dir: None,
+        batch_size: 20,
+        max_new_per_batch: 2,
+        refresh: false,
+    }) {
+        Ok(n) if n > 0 => {
+            if let Err(e) = rebuild_projection(&args.vault_root, &args.date, &args.run_id) {
+                sayln!("  tags: projection refresh after bootstrap failed ({e}) — next rebuild will surface them");
+            }
+        }
+        Ok(_) => {}
+        Err(e) => sayln!("  tags: bootstrap skipped ({e})"),
+    }
+
     if failed > 0 {
         // Honest retry guidance: a 3rd failure means the source is now
         // BLOCKED, not silently retried.

--- a/crates/ovp-cli/src/commands/index_cmd.rs
+++ b/crates/ovp-cli/src/commands/index_cmd.rs
@@ -5,6 +5,7 @@
 
 use std::path::PathBuf;
 
+use ovp_domain::tags::{TagAliases, normalize_tag};
 use ovp_index::{
     build_evidence, build_index_with_progress, read_evidence, read_index, run_evidence_query,
     run_query, write_evidence, write_index, Query, QueryKind,
@@ -51,6 +52,7 @@ pub struct FindArgs {
     pub kind: Option<String>,
     pub status: Option<String>,
     pub date: Option<String>,
+    pub tag: Option<String>,
     pub json: bool,
 }
 
@@ -64,10 +66,22 @@ pub fn run_find(args: FindArgs) -> Result<(), CliError> {
         Some("runs") => Some(QueryKind::Runs),
         Some("cards") => Some(QueryKind::Cards),
         Some("units") => Some(QueryKind::Units),
+        Some("tags") => Some(QueryKind::Tags),
         Some(other) => {
             return Err(CliError::Io(format!(
-                "unknown --kind `{other}` (sources|packs|claims|runs|cards|units)"
+                "unknown --kind `{other}` (sources|packs|claims|runs|cards|units|tags)"
             )))
+        }
+    };
+    // A queried alias must find its canonical tag's sources, so the query
+    // tag runs through the same normalize+alias pipe the index rows did.
+    let tag = match args.tag.as_deref() {
+        None => None,
+        Some(raw) => {
+            let aliases = TagAliases::load(&args.vault_root).map_err(CliError::Io)?;
+            let normalized = normalize_tag(raw)
+                .ok_or_else(|| CliError::Io(format!("--tag {raw:?} normalizes to nothing")))?;
+            Some(aliases.resolve(&normalized).to_string())
         }
     };
     let query = Query {
@@ -75,6 +89,7 @@ pub fn run_find(args: FindArgs) -> Result<(), CliError> {
         status: args.status,
         date: args.date,
         term: args.term,
+        tag,
     };
     let hits = match kind {
         Some(QueryKind::Cards | QueryKind::Units) => {

--- a/crates/ovp-cli/src/commands/mod.rs
+++ b/crates/ovp-cli/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub mod crystal_synth_ab;
 pub mod crystal_synth_llm;
 pub mod crystal_terrain;
 pub mod crystal_themes;
+pub mod tags_suggest;
 pub mod crystal_write;
 pub mod console_cmd;
 pub mod daily;

--- a/crates/ovp-cli/src/commands/mod.rs
+++ b/crates/ovp-cli/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub mod crystal_synth_ab;
 pub mod crystal_synth_llm;
 pub mod crystal_terrain;
 pub mod crystal_themes;
+pub mod tags_bootstrap;
 pub mod tags_suggest;
 pub mod crystal_write;
 pub mod console_cmd;

--- a/crates/ovp-cli/src/commands/tags_bootstrap.rs
+++ b/crates/ovp-cli/src/commands/tags_bootstrap.rs
@@ -1,0 +1,373 @@
+//! `tags-bootstrap` — cold-start tagging for vaults WITHOUT a curated tag
+//! vocabulary (the P1 md-only persona in `docs/stage-tags-product.md` §2).
+//!
+//! Two layers, both landing in `tags_inferred` (never frontmatter):
+//!
+//! 1. **Deterministic floor (0 tokens, always runs)**: the theme communities
+//!    (`crystal-themes`, required input) already carve any corpus into ~17
+//!    clusters with c-TF-IDF keywords. Community keywords seed the closed
+//!    vocabulary; every target source inherits its community's top keywords
+//!    as `method:"community"` inferred tags. Coarse but honest.
+//! 2. **LLM classification (`--client live`, cassette-cached)**: batched
+//!    sources are classified INTO the closed vocabulary (title + card
+//!    titles). The model may propose a few new names per batch; proposals
+//!    are normalized, alias-resolved, and admitted only if genuinely new —
+//!    then persisted in `vocabulary.toml` with `origin:"llm"` so the
+//!    operator can curate them. `method:"llm"` entries replace the floor.
+//!
+//! Targets = sources with NO operator tags and NO existing inferred entry
+//! (kNN backfill from `tags-suggest` outranks bootstrap; `--refresh` redoes
+//! bootstrap-method entries but never touches knn ones). Everything written
+//! is a projection; delete the files to reset.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use ovp_domain::tags::{
+    ClassifyInput, InferredTag, TAGS_INFERRED_SCHEMA, TagAliases, TagOrigin, TagVocabulary,
+    TagsInferredFile, canonical_tags, normalize_tag, parse_tag_classify, tag_classify_request,
+};
+use ovp_domain::vault_layout::VaultLayout;
+use ovp_index::read_index;
+
+use crate::CliError;
+use crate::commands::client::{ClientKind, build_client};
+use crate::commands::crystal_synth::call_and_parse;
+
+/// Fixed confidence bands (see `InferredTag.score` docs).
+const LLM_SCORE: f64 = 0.8;
+const FLOOR_SCORE: f64 = 0.4;
+/// Community keywords inherited by a floor-tagged source.
+const FLOOR_KEYWORDS: usize = 2;
+/// Community keywords contributed to the vocabulary per community.
+const VOCAB_KEYWORDS: usize = 3;
+
+pub struct TagsBootstrapArgs {
+    pub vault_root: PathBuf,
+    pub client_kind: ClientKind,
+    /// Cassette root for `tag_classify/v1`. Default:
+    /// `<vault-root>/.ovp/cassettes/tags`.
+    pub cache_dir: Option<PathBuf>,
+    /// Sources per classification call.
+    pub batch_size: usize,
+    /// New-name proposals admitted per batch.
+    pub max_new_per_batch: usize,
+    /// Redo bootstrap-method entries (knn entries are never touched).
+    pub refresh: bool,
+}
+
+/// Validate one batch's picks against the closed vocabulary (pure,
+/// unit-tested): picked names are normalized + alias-resolved; anything not
+/// in the vocabulary is DROPPED (rule 1 violations never enter the
+/// projection); `new_tags` are admitted (normalized, alias-resolved,
+/// deduped, capped) only if absent from the vocabulary. Returns
+/// (per-source canonical tags, admitted new names in admission order).
+pub(crate) fn validate_batch(
+    picks: &BTreeMap<usize, Vec<String>>,
+    new_tags: &[String],
+    vocabulary: &TagVocabulary,
+    aliases: &TagAliases,
+    max_new: usize,
+) -> (BTreeMap<usize, Vec<String>>, Vec<String>) {
+    let mut admitted: Vec<String> = Vec::new();
+    for raw in new_tags {
+        if admitted.len() >= max_new {
+            break;
+        }
+        let canon = match canonical_tags(&[raw.as_str()], aliases).pop() {
+            Some(c) => c,
+            None => continue,
+        };
+        if !vocabulary.contains(&canon) && !admitted.contains(&canon) {
+            admitted.push(canon);
+        }
+    }
+    let mut out = BTreeMap::new();
+    for (id, tags) in picks {
+        let mut kept: Vec<String> = tags
+            .iter()
+            .filter_map(|t| canonical_tags(&[t.as_str()], aliases).pop())
+            .filter(|t| vocabulary.contains(t))
+            .collect();
+        kept.sort();
+        kept.dedup();
+        kept.truncate(5);
+        out.insert(*id, kept);
+    }
+    (out, admitted)
+}
+
+pub fn run(args: TagsBootstrapArgs) -> Result<(), CliError> {
+    let layout = VaultLayout::new();
+    let model = read_index(&args.vault_root).map_err(|e| {
+        CliError::Io(format!("tags-bootstrap: {e} — run `ovp2 index` first"))
+    })?;
+    let themes_path = args
+        .vault_root
+        .join(layout.crystal_store_dir())
+        .join("themes.json");
+    let themes = match ovp_domain::crystal::themes::ThemesFile::load(&themes_path)
+        .map_err(CliError::Io)?
+    {
+        Some(t) => t,
+        None => {
+            println!(
+                "tags-bootstrap: no themes.json — run `ovp2 crystal-themes` first \
+                 (the theme communities are the deterministic vocabulary seed)."
+            );
+            return Ok(());
+        }
+    };
+    let aliases = TagAliases::load(&args.vault_root).map_err(CliError::Io)?;
+
+    // ---- Vocabulary: user tags ∪ community keywords ∪ persisted llm ----
+    let mut vocabulary = TagVocabulary::default();
+    for s in &model.sources {
+        for t in &s.tags {
+            vocabulary.insert(t.clone(), TagOrigin::User);
+        }
+    }
+    for c in &themes.communities {
+        for kw in c.keywords.iter().take(VOCAB_KEYWORDS) {
+            for canon in canonical_tags(&[kw.as_str()], &aliases) {
+                vocabulary.insert(canon, TagOrigin::Community);
+            }
+        }
+    }
+    for (name, origin) in TagVocabulary::load(&args.vault_root)
+        .map_err(CliError::Io)?
+        .iter()
+    {
+        if origin == TagOrigin::Llm {
+            vocabulary.insert(name.to_string(), TagOrigin::Llm);
+        }
+    }
+
+    // ---- Targets: untagged, not already covered (unless --refresh) ----
+    let mut inferred = TagsInferredFile::load(&args.vault_root)
+        .map_err(CliError::Io)?
+        .unwrap_or_else(|| TagsInferredFile {
+            schema: TAGS_INFERRED_SCHEMA.into(),
+            model: String::new(),
+            params: BTreeMap::new(),
+            entries: BTreeMap::new(),
+        });
+    fn case_of(pack_dir: &str) -> &str {
+        pack_dir.rsplit(['/', '\\']).next().unwrap_or(pack_dir)
+    }
+    let card_titles: BTreeMap<&str, &[String]> = model
+        .packs
+        .iter()
+        .map(|p| (case_of(&p.pack_dir), p.card_titles.as_slice()))
+        .collect();
+    struct Target<'a> {
+        sha: &'a str,
+        title: String,
+        cards: Vec<String>,
+        community: Option<i64>,
+    }
+    let mut targets: Vec<Target> = Vec::new();
+    for s in &model.sources {
+        if !s.tags.is_empty() {
+            continue;
+        }
+        let covered = inferred.entries.get(&s.sha256).is_some_and(|e| {
+            e.iter().any(|t| t.method == "knn" || t.method.is_empty())
+                || (!args.refresh && !e.is_empty())
+        });
+        if covered {
+            continue;
+        }
+        let Some(case) = s.pack_dir.as_deref().map(case_of) else {
+            continue;
+        };
+        targets.push(Target {
+            sha: &s.sha256,
+            title: s.title.clone().unwrap_or_else(|| case.to_string()),
+            cards: card_titles
+                .get(case)
+                .map(|c| c.to_vec())
+                .unwrap_or_default(),
+            community: themes.packs.get(case).copied().filter(|&id| {
+                id != ovp_domain::crystal::themes::UNCLASSIFIED_ID
+            }),
+        });
+    }
+    println!(
+        "tags-bootstrap: vocabulary {} tag(s), {} target source(s)",
+        vocabulary.len(),
+        targets.len()
+    );
+    if targets.is_empty() {
+        vocabulary.save(&args.vault_root).map_err(CliError::Io)?;
+        println!("tags-bootstrap: nothing to do (vocabulary refreshed).");
+        return Ok(());
+    }
+
+    // ---- Layer 1: deterministic community-keyword floor ----
+    let community_keywords: BTreeMap<i64, Vec<String>> = themes
+        .communities
+        .iter()
+        .map(|c| {
+            let kws: Vec<String> = c
+                .keywords
+                .iter()
+                .flat_map(|kw| canonical_tags(&[kw.as_str()], &aliases))
+                .take(FLOOR_KEYWORDS)
+                .collect();
+            (c.id, kws)
+        })
+        .collect();
+    let mut floored = 0usize;
+    for t in &targets {
+        let Some(kws) = t.community.and_then(|id| community_keywords.get(&id)) else {
+            continue;
+        };
+        if kws.is_empty() {
+            continue;
+        }
+        let size = themes
+            .communities
+            .iter()
+            .find(|c| Some(c.id) == t.community)
+            .map(|c| c.size)
+            .unwrap_or(0);
+        inferred.entries.insert(
+            t.sha.to_string(),
+            kws.iter()
+                .map(|k| InferredTag {
+                    tag: k.clone(),
+                    score: FLOOR_SCORE,
+                    support: size,
+                    method: "community".into(),
+                })
+                .collect(),
+        );
+        floored += 1;
+    }
+    println!("  floor: {floored}/{} target(s) inherit community keywords", targets.len());
+
+    // ---- Layer 2: LLM classification into the closed vocabulary ----
+    let mut classified = 0usize;
+    let mut admitted_total = 0usize;
+    if matches!(args.client_kind, ClientKind::Live) {
+        let cassette_dir = args
+            .cache_dir
+            .clone()
+            .unwrap_or_else(|| args.vault_root.join(".ovp/cassettes/tags"));
+        let mut client = build_client(ClientKind::Live, &cassette_dir)?;
+        for chunk in targets.chunks(args.batch_size.max(1)) {
+            let inputs: Vec<ClassifyInput> = chunk
+                .iter()
+                .enumerate()
+                .map(|(i, t)| ClassifyInput {
+                    id: i,
+                    title: t.title.clone(),
+                    card_titles: t.cards.iter().take(6).cloned().collect(),
+                })
+                .collect();
+            // Scoped so the name borrows end before `vocabulary.insert` below
+            // (the request owns its text; it keeps no references).
+            let req = {
+                let vocab_names: Vec<&str> = vocabulary.names().collect();
+                tag_classify_request(&vocab_names, &inputs, args.max_new_per_batch)
+            };
+            let (reply, _repair) =
+                call_and_parse(client.as_mut(), &req, "tag-classify", parse_tag_classify)?;
+            let (picks, admitted) = validate_batch(
+                &reply.picks,
+                &reply.new_tags,
+                &vocabulary,
+                &aliases,
+                args.max_new_per_batch,
+            );
+            for name in admitted {
+                vocabulary.insert(name, TagOrigin::Llm);
+                admitted_total += 1;
+            }
+            for (i, t) in chunk.iter().enumerate() {
+                let Some(tags) = picks.get(&i).filter(|v| !v.is_empty()) else {
+                    continue; // floor entry (if any) stays
+                };
+                inferred.entries.insert(
+                    t.sha.to_string(),
+                    tags.iter()
+                        .map(|tag| InferredTag {
+                            tag: tag.clone(),
+                            score: LLM_SCORE,
+                            support: 0,
+                            method: "llm".into(),
+                        })
+                        .collect(),
+                );
+                classified += 1;
+            }
+            sayln!("  [{classified}/{}] classified …", targets.len());
+        }
+        println!(
+            "  classify: {classified} source(s) tagged from the vocabulary, \
+             {admitted_total} new name(s) admitted"
+        );
+    } else {
+        println!(
+            "  classify: skipped (replay client) — the community floor is the \
+             0-token result; add `--client live` for vocabulary classification."
+        );
+    }
+
+    // ---- Persist (vocabulary first: inferred references its names) ----
+    let vocab_path = vocabulary.save(&args.vault_root).map_err(CliError::Io)?;
+    if inferred.model.is_empty() {
+        inferred.model = "tags-bootstrap".into();
+    }
+    inferred
+        .params
+        .insert("bootstrap_batch_size".into(), args.batch_size as f64);
+    let inferred_path = inferred.save(&args.vault_root).map_err(CliError::Io)?;
+    println!("  vocabulary: {} tag(s) → {vocab_path}", vocabulary.len());
+    println!("  inferred: → {inferred_path}");
+    println!("tags-bootstrap: done. Rebuild the index (`ovp2 index`) to surface inferred tags.");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vocab(names: &[&str]) -> TagVocabulary {
+        let mut v = TagVocabulary::default();
+        for n in names {
+            v.insert((*n).to_string(), TagOrigin::User);
+        }
+        v
+    }
+
+    #[test]
+    fn validate_drops_out_of_vocab_picks_and_resolves_aliases() {
+        let aliases = TagAliases::parse("[aliases]\n\"ai-agents\" = \"agent\"\n").unwrap();
+        let v = vocab(&["agent", "memory"]);
+        let picks = BTreeMap::from([(0usize, vec![
+            "AI Agents".to_string(),   // alias → agent (in vocab)
+            "Memory".to_string(),      // normalize → memory (in vocab)
+            "hallucinated".to_string(), // not in vocab → dropped
+        ])]);
+        let (kept, admitted) = validate_batch(&picks, &[], &v, &aliases, 2);
+        assert_eq!(kept[&0], vec!["agent", "memory"]);
+        assert!(admitted.is_empty());
+    }
+
+    #[test]
+    fn validate_caps_and_dedups_new_names() {
+        let aliases = TagAliases::parse("").unwrap();
+        let v = vocab(&["agent"]);
+        let new = vec![
+            "Agent".to_string(),      // already in vocab → not admitted
+            "KV Cache".to_string(),   // → kv-cache admitted
+            "kv_cache".to_string(),   // duplicate after normalize → skipped
+            "third".to_string(),      // over the cap of 1 remaining? cap=2 → admitted
+            "fourth".to_string(),     // over cap → dropped
+        ];
+        let (_, admitted) = validate_batch(&BTreeMap::new(), &new, &v, &aliases, 2);
+        assert_eq!(admitted, vec!["kv-cache", "third"]);
+    }
+}

--- a/crates/ovp-cli/src/commands/tags_bootstrap.rs
+++ b/crates/ovp-cli/src/commands/tags_bootstrap.rs
@@ -183,7 +183,12 @@ pub fn run(args: TagsBootstrapArgs) -> Result<usize, CliError> {
     let aliases = TagAliases::load(&args.vault_root).map_err(CliError::Io)?;
 
     // ---- Vocabulary: user tags ∪ community keywords ∪ persisted llm ----
+    // Bans FIRST (they gate every insert), then user > community > llm.
+    let persisted = TagVocabulary::load(&args.vault_root).map_err(CliError::Io)?;
     let mut vocabulary = TagVocabulary::default();
+    for name in persisted.banned() {
+        vocabulary.ban(name.to_string());
+    }
     for s in &model.sources {
         for t in &s.tags {
             vocabulary.insert(t.clone(), TagOrigin::User);
@@ -196,10 +201,7 @@ pub fn run(args: TagsBootstrapArgs) -> Result<usize, CliError> {
             }
         }
     }
-    for (name, origin) in TagVocabulary::load(&args.vault_root)
-        .map_err(CliError::Io)?
-        .iter()
-    {
+    for (name, origin) in persisted.iter() {
         if origin == TagOrigin::Llm {
             vocabulary.insert(name.to_string(), TagOrigin::Llm);
         }
@@ -267,6 +269,8 @@ pub fn run(args: TagsBootstrapArgs) -> Result<usize, CliError> {
     }
 
     // ---- Layer 1: deterministic community-keyword floor ----
+    // Floor tags must be vocabulary members — a banned community keyword
+    // never reaches inferred.json.
     let community_keywords: BTreeMap<i64, Vec<String>> = themes
         .communities
         .iter()
@@ -275,6 +279,7 @@ pub fn run(args: TagsBootstrapArgs) -> Result<usize, CliError> {
                 .keywords
                 .iter()
                 .flat_map(|kw| canonical_tags(&[kw.as_str()], &aliases))
+                .filter(|kw| vocabulary.contains(kw))
                 .take(FLOOR_KEYWORDS)
                 .collect();
             (c.id, kws)
@@ -309,6 +314,15 @@ pub fn run(args: TagsBootstrapArgs) -> Result<usize, CliError> {
     }
     println!("  floor: {floored}/{} target(s) inherit community keywords", targets.len());
 
+    // Checkpoint the deterministic result BEFORE any fallible LLM work: a
+    // failed live pass must degrade to the zero-token floor, never to
+    // nothing (the floor is the whole point of the fallback contract).
+    vocabulary.save(&args.vault_root).map_err(CliError::Io)?;
+    if inferred.model.is_empty() {
+        inferred.model = "tags-bootstrap".into();
+    }
+    inferred.save(&args.vault_root).map_err(CliError::Io)?;
+
     // ---- Layer 2: LLM classification into the closed vocabulary ----
     let mut classified = 0usize;
     let mut admitted_total = 0usize;
@@ -335,9 +349,18 @@ pub fn run(args: TagsBootstrapArgs) -> Result<usize, CliError> {
                 tag_classify_request(&vocab_names, &inputs, args.max_new_per_batch)
             };
             let batch_len = inputs.len();
-            let (reply, _repair) = call_and_parse(client.as_mut(), &req, "tag-classify", |t| {
+            // A failed batch (API/parse/cassette) downgrades THIS run to
+            // whatever already landed — earlier batches + the persisted
+            // floor — instead of aborting with nothing saved.
+            let reply = match call_and_parse(client.as_mut(), &req, "tag-classify", |t| {
                 parse_tag_classify(t, batch_len)
-            })?;
+            }) {
+                Ok((reply, _repair)) => reply,
+                Err(e) => {
+                    sayln!("  classify: batch failed ({e}) — keeping the floor for its sources");
+                    continue;
+                }
+            };
             let (picks, admitted) = validate_batch(
                 &reply.picks,
                 &reply.new_tags,

--- a/crates/ovp-cli/src/commands/tags_bootstrap.rs
+++ b/crates/ovp-cli/src/commands/tags_bootstrap.rs
@@ -312,7 +312,30 @@ pub fn run(args: TagsBootstrapArgs) -> Result<usize, CliError> {
         );
         floored += 1;
     }
+    let unthemed = targets.iter().filter(|t| t.community.is_none()).count();
     println!("  floor: {floored}/{} target(s) inherit community keywords", targets.len());
+    if unthemed > 0 {
+        // No silent caps: noise/unthemed packs have no community keywords, and
+        // a wrong tag is worse than no tag — only the LLM pass covers them.
+        println!(
+            "  floor: {unthemed} target(s) in noise/unthemed packs get no deterministic \
+             floor (covered by `--client live` classification only)"
+        );
+    }
+
+    // A ban must also RETIRE what was inferred before it existed — scrub
+    // banned names out of every existing entry so `vocabulary.toml` curation
+    // takes effect on the next index build, not just on future runs. (Tags
+    // added below are vocabulary-validated, so they can never be banned.)
+    {
+        let banned: std::collections::BTreeSet<&str> = vocabulary.banned().collect();
+        if !banned.is_empty() {
+            for tags in inferred.entries.values_mut() {
+                tags.retain(|t| !banned.contains(t.tag.as_str()));
+            }
+            inferred.entries.retain(|_, v| !v.is_empty());
+        }
+    }
 
     // Checkpoint the deterministic result BEFORE any fallible LLM work: a
     // failed live pass must degrade to the zero-token floor, never to

--- a/crates/ovp-cli/src/commands/tags_bootstrap.rs
+++ b/crates/ovp-cli/src/commands/tags_bootstrap.rs
@@ -25,14 +25,18 @@ use std::path::PathBuf;
 
 use ovp_domain::tags::{
     ClassifyInput, InferredTag, TAGS_INFERRED_SCHEMA, TagAliases, TagOrigin, TagVocabulary,
-    TagsInferredFile, canonical_tags, normalize_tag, parse_tag_classify, tag_classify_request,
+    TagsInferredFile, canonical_tags, parse_tag_classify, tag_classify_request,
 };
 use ovp_domain::vault_layout::VaultLayout;
 use ovp_index::read_index;
 
+use ovp_embed::document_text;
+use ovp_embed::knn::cosine;
+
 use crate::CliError;
 use crate::commands::client::{ClientKind, build_client};
 use crate::commands::crystal_synth::call_and_parse;
+use crate::commands::crystal_themes::{ThemeDoc, resolve_vectors};
 
 /// Fixed confidence bands (see `InferredTag.score` docs).
 const LLM_SCORE: f64 = 0.8;
@@ -97,11 +101,69 @@ pub(crate) fn validate_batch(
     (out, admitted)
 }
 
-pub fn run(args: TagsBootstrapArgs) -> Result<(), CliError> {
+/// Cosine at or above which a proposed new name is a respelling of an
+/// existing vocabulary entry (design §2: generate-free → embed-map).
+const NEW_NAME_DEDUP_COSINE: f64 = 0.9;
+
+/// Drop proposed names that embed within [`NEW_NAME_DEDUP_COSINE`] of any
+/// existing vocabulary name. Embeddings are name-only texts through the
+/// shared cache; unavailable embedder + cold cache → ALL proposals dropped
+/// (with a printed reason) — the closed vocabulary never grows unverified.
+fn embed_dedup_new_names(
+    candidates: Vec<String>,
+    vocabulary: &TagVocabulary,
+    embed_cache_dir: &std::path::Path,
+) -> Result<Vec<String>, CliError> {
+    if candidates.is_empty() {
+        return Ok(candidates);
+    }
+    let docs: Vec<ThemeDoc> = vocabulary
+        .names()
+        .map(str::to_string)
+        .chain(candidates.iter().cloned())
+        .map(|name| {
+            let text = document_text(&name, "", 0);
+            let sha = ovp_embed::cache::text_sha256(&text);
+            ThemeDoc {
+                case_id: format!("tagname:{name}"),
+                title: name,
+                text,
+                sha,
+            }
+        })
+        .collect();
+    let Some(vectors) = resolve_vectors(&docs, embed_cache_dir)? else {
+        println!(
+            "  classify: {} new-name proposal(s) DISCARDED — embeddings unavailable, \
+             semantic dedup against the vocabulary is mandatory before admission",
+            candidates.len()
+        );
+        return Ok(Vec::new());
+    };
+    let n_vocab = vocabulary.len();
+    let mut kept = Vec::new();
+    for (i, name) in candidates.into_iter().enumerate() {
+        let v = &vectors[n_vocab + i];
+        let dup = vectors[..n_vocab]
+            .iter()
+            .any(|u| cosine(u, v) >= NEW_NAME_DEDUP_COSINE);
+        if dup {
+            println!("  classify: proposal {name:?} maps to an existing vocabulary tag — skipped");
+        } else {
+            kept.push(name);
+        }
+    }
+    Ok(kept)
+}
+
+/// Returns the number of sources whose inferred entries this run wrote —
+/// `daily` uses it to decide whether the projection needs a second rebuild.
+pub fn run(args: TagsBootstrapArgs) -> Result<usize, CliError> {
     let layout = VaultLayout::new();
     let model = read_index(&args.vault_root).map_err(|e| {
         CliError::Io(format!("tags-bootstrap: {e} — run `ovp2 index` first"))
     })?;
+    let embed_cache_dir = args.vault_root.join(".ovp/cache/embeddings");
     let themes_path = args
         .vault_root
         .join(layout.crystal_store_dir())
@@ -115,7 +177,7 @@ pub fn run(args: TagsBootstrapArgs) -> Result<(), CliError> {
                 "tags-bootstrap: no themes.json — run `ovp2 crystal-themes` first \
                  (the theme communities are the deterministic vocabulary seed)."
             );
-            return Ok(());
+            return Ok(0);
         }
     };
     let aliases = TagAliases::load(&args.vault_root).map_err(CliError::Io)?;
@@ -201,7 +263,7 @@ pub fn run(args: TagsBootstrapArgs) -> Result<(), CliError> {
     if targets.is_empty() {
         vocabulary.save(&args.vault_root).map_err(CliError::Io)?;
         println!("tags-bootstrap: nothing to do (vocabulary refreshed).");
-        return Ok(());
+        return Ok(0);
     }
 
     // ---- Layer 1: deterministic community-keyword floor ----
@@ -272,8 +334,10 @@ pub fn run(args: TagsBootstrapArgs) -> Result<(), CliError> {
                 let vocab_names: Vec<&str> = vocabulary.names().collect();
                 tag_classify_request(&vocab_names, &inputs, args.max_new_per_batch)
             };
-            let (reply, _repair) =
-                call_and_parse(client.as_mut(), &req, "tag-classify", parse_tag_classify)?;
+            let batch_len = inputs.len();
+            let (reply, _repair) = call_and_parse(client.as_mut(), &req, "tag-classify", |t| {
+                parse_tag_classify(t, batch_len)
+            })?;
             let (picks, admitted) = validate_batch(
                 &reply.picks,
                 &reply.new_tags,
@@ -281,6 +345,13 @@ pub fn run(args: TagsBootstrapArgs) -> Result<(), CliError> {
                 &aliases,
                 args.max_new_per_batch,
             );
+            // Semantic dedup: a proposal whose embedding sits within
+            // NEW_NAME_DEDUP_COSINE of an existing vocabulary name is a
+            // respelling, not a new tag (`agentic-systems` vs `ai-agents`).
+            // No embedder + cold cache → proposals are DISCARDED (conservative:
+            // the closed vocabulary must not grow unverified).
+            let admitted =
+                embed_dedup_new_names(admitted, &vocabulary, &embed_cache_dir)?;
             for name in admitted {
                 vocabulary.insert(name, TagOrigin::Llm);
                 admitted_total += 1;
@@ -327,7 +398,7 @@ pub fn run(args: TagsBootstrapArgs) -> Result<(), CliError> {
     println!("  vocabulary: {} tag(s) → {vocab_path}", vocabulary.len());
     println!("  inferred: → {inferred_path}");
     println!("tags-bootstrap: done. Rebuild the index (`ovp2 index`) to surface inferred tags.");
-    Ok(())
+    Ok(floored.max(classified))
 }
 
 #[cfg(test)]

--- a/crates/ovp-cli/src/commands/tags_suggest.rs
+++ b/crates/ovp-cli/src/commands/tags_suggest.rs
@@ -1,0 +1,436 @@
+//! `tags-suggest` — deterministic tag-curation proposals over the embedding
+//! layer. Two outputs, both projections, neither ever auto-applied:
+//!
+//! 1. **Merge candidates** (`.ovp/tags/proposals.md`): every canonical tag is
+//!    embedded as "tag name + sample titles of sources carrying it"; pairs
+//!    above a cosine threshold become alias proposals (canonical = the
+//!    higher-count member). The operator reviews the report and pastes
+//!    accepted lines into `.ovp/tags/aliases.toml` — the pipeline proposes,
+//!    the operator disposes (same contract as crystal-review).
+//!
+//! 2. **Backfill** (`.ovp/tags/inferred.json`): sources with NO operator tags
+//!    get tags voted by their k nearest tagged neighbors in pack-embedding
+//!    space (similarity-weighted vote, support + share thresholds). Reuses
+//!    the SAME pack vectors `crystal-themes` caches, so a themed vault runs
+//!    this with zero new embeddings. The index attaches these as
+//!    `tags_inferred`, never mixed into operator tags.
+//!
+//! No LLM anywhere. Degradation contract mirrors crystal-themes: missing
+//! embed feature/model with a cold cache → explain and exit 0.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use ovp_domain::tags::{InferredTag, TAGS_INFERRED_SCHEMA, TagsInferredFile};
+use ovp_domain::vault_layout::VaultLayout;
+use ovp_embed::knn::cosine;
+use ovp_embed::{EMBED_MODEL_ID, document_text};
+use ovp_index::read_index;
+
+use crate::CliError;
+use crate::commands::crystal_themes::{ThemeDoc, collect_docs, resolve_vectors};
+
+/// Sample titles embedded alongside a tag name (the short-tag disambiguation
+/// trick: "rust" alone is ambiguous; "rust + 3 article titles" is not).
+const TAG_SAMPLE_TITLES: usize = 3;
+/// Merge pairs at or above this cosine are marked STRONG in the report.
+const STRONG_MERGE: f64 = 0.90;
+/// Cap on reported merge pairs; the count of anything beyond it is logged
+/// (no silent truncation).
+const MAX_MERGE_PROPOSALS: usize = 100;
+
+pub struct TagsSuggestArgs {
+    pub vault_root: PathBuf,
+    /// Cosine floor for a merge proposal to enter the report.
+    pub merge_threshold: f64,
+    /// Neighbors consulted per untagged source.
+    pub knn: usize,
+    /// Minimum share of neighbor similarity weight a tag needs (0..1).
+    pub vote_threshold: f64,
+    /// Minimum number of neighbors carrying the tag.
+    pub min_support: usize,
+    /// Cap on inferred tags per source.
+    pub max_tags: usize,
+}
+
+impl Default for TagsSuggestArgs {
+    fn default() -> Self {
+        Self {
+            vault_root: PathBuf::new(),
+            merge_threshold: 0.75,
+            knn: 10,
+            vote_threshold: 0.35,
+            min_support: 2,
+            max_tags: 5,
+        }
+    }
+}
+
+/// One tag's neighbor vote on one source (pure, unit-tested): neighbors are
+/// `(similarity, tags)` pairs, already the k nearest. A tag wins when its
+/// similarity-weighted share ≥ `vote_threshold` AND ≥ `min_support` distinct
+/// neighbors carry it. Ties broken by tag name for determinism.
+pub(crate) fn vote_tags(
+    neighbors: &[(f64, &[String])],
+    vote_threshold: f64,
+    min_support: usize,
+    max_tags: usize,
+) -> Vec<InferredTag> {
+    let total: f64 = neighbors.iter().map(|(s, _)| s.max(0.0)).sum();
+    if total <= 0.0 {
+        return Vec::new();
+    }
+    let mut weight: BTreeMap<&str, (f64, usize)> = BTreeMap::new();
+    for (sim, tags) in neighbors {
+        for tag in *tags {
+            let e = weight.entry(tag.as_str()).or_insert((0.0, 0));
+            e.0 += sim.max(0.0);
+            e.1 += 1;
+        }
+    }
+    let mut out: Vec<InferredTag> = weight
+        .into_iter()
+        .filter_map(|(tag, (w, support))| {
+            let score = w / total;
+            (score >= vote_threshold && support >= min_support).then(|| InferredTag {
+                tag: tag.to_string(),
+                score: (score * 1000.0).round() / 1000.0,
+                support,
+            })
+        })
+        .collect();
+    out.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.tag.cmp(&b.tag))
+    });
+    out.truncate(max_tags);
+    out
+}
+
+/// One proposed merge, evidence attached.
+#[derive(Debug, PartialEq)]
+pub(crate) struct MergeProposal {
+    /// Lower-count member — the proposed alias.
+    pub(crate) alias: String,
+    pub(crate) alias_count: usize,
+    /// Higher-count member — the proposed canonical.
+    pub(crate) canonical: String,
+    pub(crate) canonical_count: usize,
+    pub(crate) cosine: f64,
+}
+
+/// Two tags on mostly the SAME sources are co-occurring (related topics on
+/// one article), not spelling variants — true synonyms almost never co-occur
+/// on one item, because nobody tags an article `agent` AND `agents`. Their
+/// embed texts also share sample titles, which inflates cosine to ~1.0, so
+/// without this suppression the report leads with same-article noise.
+/// Overlap = |A∩B| / min(|A|,|B|); at or above this the pair is suppressed.
+const CO_OCCURRENCE_OVERLAP: f64 = 0.5;
+
+/// Pairwise merge candidates over per-tag vectors (pure, unit-tested).
+/// `tags` = (name, source indices carrying it). Canonical = higher count;
+/// ties by name (lexicographically smaller wins). Returns (proposals,
+/// suppressed co-occurrence pair count).
+pub(crate) fn merge_proposals(
+    tags: &[(String, Vec<usize>)],
+    vectors: &[Vec<f32>],
+    threshold: f64,
+) -> (Vec<MergeProposal>, usize) {
+    let sets: Vec<std::collections::BTreeSet<usize>> = tags
+        .iter()
+        .map(|(_, srcs)| srcs.iter().copied().collect())
+        .collect();
+    let mut out = Vec::new();
+    let mut suppressed = 0usize;
+    for i in 0..tags.len() {
+        for j in (i + 1)..tags.len() {
+            let sim = cosine(&vectors[i], &vectors[j]);
+            if sim < threshold {
+                continue;
+            }
+            let inter = sets[i].intersection(&sets[j]).count();
+            let min = sets[i].len().min(sets[j].len()).max(1);
+            if inter as f64 / min as f64 >= CO_OCCURRENCE_OVERLAP {
+                suppressed += 1;
+                continue;
+            }
+            let (ni, nj) = (tags[i].1.len(), tags[j].1.len());
+            let (a, c) = if ni < nj || (ni == nj && tags[i].0 > tags[j].0) {
+                (i, j)
+            } else {
+                (j, i)
+            };
+            out.push(MergeProposal {
+                alias: tags[a].0.clone(),
+                alias_count: tags[a].1.len(),
+                canonical: tags[c].0.clone(),
+                canonical_count: tags[c].1.len(),
+                cosine: (sim * 1000.0).round() / 1000.0,
+            });
+        }
+    }
+    out.sort_by(|a, b| {
+        b.cosine
+            .partial_cmp(&a.cosine)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.alias.cmp(&b.alias))
+    });
+    (out, suppressed)
+}
+
+pub fn run(args: TagsSuggestArgs) -> Result<(), CliError> {
+    if !args.merge_threshold.is_finite() || !args.vote_threshold.is_finite() {
+        return Err(CliError::Io(
+            "tags-suggest: thresholds must be finite numbers".into(),
+        ));
+    }
+    let layout = VaultLayout::new();
+    let model = read_index(&args.vault_root).map_err(|e| {
+        CliError::Io(format!(
+            "tags-suggest: {e} — run `ovp2 index` first (the tag vocabulary and \
+             source↔pack joins come from the read model)"
+        ))
+    })?;
+    let reader_root = args.vault_root.join(layout.reader_root());
+    let embed_cache_dir = args.vault_root.join(".ovp/cache/embeddings");
+
+    // ---- Join sources ↔ pack docs (case_id = pack_dir basename) ----
+    let docs = collect_docs(&reader_root)?;
+    let case_of = |pack_dir: &str| -> String {
+        pack_dir
+            .rsplit(['/', '\\'])
+            .next()
+            .unwrap_or(pack_dir)
+            .to_string()
+    };
+    let mut doc_idx: BTreeMap<String, usize> = BTreeMap::new();
+    for (i, d) in docs.iter().enumerate() {
+        doc_idx.insert(d.case_id.clone(), i);
+    }
+    // (doc index, sha256, tags) for every source joined to a pack.
+    let mut tagged: Vec<(usize, &str, &[String])> = Vec::new();
+    let mut untagged: Vec<(usize, &str)> = Vec::new();
+    for s in &model.sources {
+        let Some(idx) = s
+            .pack_dir
+            .as_deref()
+            .and_then(|p| doc_idx.get(&case_of(p)))
+        else {
+            continue;
+        };
+        if s.tags.is_empty() {
+            untagged.push((*idx, s.sha256.as_str()));
+        } else {
+            tagged.push((*idx, s.sha256.as_str(), s.tags.as_slice()));
+        }
+    }
+    if tagged.is_empty() {
+        println!(
+            "tags-suggest: no tagged sources in the index — nothing to learn from. \
+             Tag some sources (pinboard or frontmatter), rebuild the index, retry."
+        );
+        return Ok(());
+    }
+    println!(
+        "tags-suggest: {} tagged / {} untagged source(s) joined to packs",
+        tagged.len(),
+        untagged.len()
+    );
+
+    // ---- Pack vectors (warm from crystal-themes; embeds only the misses) ----
+    let Some(vectors) = resolve_vectors(&docs, &embed_cache_dir)? else {
+        return Ok(()); // graceful skip, reason already printed
+    };
+
+    // ---- Backfill: kNN vote for every untagged source ----
+    let mut entries: BTreeMap<String, Vec<InferredTag>> = BTreeMap::new();
+    for (idx, sha) in &untagged {
+        let mut sims: Vec<(f64, &[String])> = tagged
+            .iter()
+            .map(|(t_idx, _, tags)| (cosine(&vectors[*idx], &vectors[*t_idx]), *tags))
+            .collect();
+        sims.sort_by(|(sa, _), (sb, _)| sb.partial_cmp(sa).unwrap_or(std::cmp::Ordering::Equal));
+        sims.truncate(args.knn);
+        let voted = vote_tags(&sims, args.vote_threshold, args.min_support, args.max_tags);
+        if !voted.is_empty() {
+            entries.insert((*sha).to_string(), voted);
+        }
+    }
+    let covered = entries.len();
+    let inferred = TagsInferredFile {
+        schema: TAGS_INFERRED_SCHEMA.into(),
+        model: EMBED_MODEL_ID.into(),
+        params: BTreeMap::from([
+            ("knn".into(), args.knn as f64),
+            ("vote_threshold".into(), args.vote_threshold),
+            ("min_support".into(), args.min_support as f64),
+            ("max_tags".into(), args.max_tags as f64),
+        ]),
+        entries,
+    };
+    let inferred_path = inferred.save(&args.vault_root).map_err(CliError::Io)?;
+    println!(
+        "  backfill: {covered}/{} untagged source(s) received inferred tags → {inferred_path}",
+        untagged.len()
+    );
+
+    // ---- Merge candidates over the tag vocabulary ----
+    // Vocabulary + carrying-source indices + up-to-3 sample titles per tag.
+    let mut vocab: BTreeMap<&str, (Vec<usize>, Vec<&str>)> = BTreeMap::new();
+    for (src_idx, s) in model.sources.iter().enumerate() {
+        for t in &s.tags {
+            let e = vocab.entry(t.as_str()).or_default();
+            e.0.push(src_idx);
+            if e.1.len() < TAG_SAMPLE_TITLES
+                && let Some(title) = s.title.as_deref()
+            {
+                e.1.push(title);
+            }
+        }
+    }
+    let tag_docs: Vec<ThemeDoc> = vocab
+        .iter()
+        .map(|(tag, (_, titles))| {
+            let text = document_text(tag, &titles.join(" | "), 1500);
+            let sha = ovp_embed::cache::text_sha256(&text);
+            ThemeDoc {
+                case_id: format!("tag:{tag}"),
+                title: (*tag).to_string(),
+                text,
+                sha,
+            }
+        })
+        .collect();
+    let Some(tag_vectors) = resolve_vectors(&tag_docs, &embed_cache_dir)? else {
+        return Ok(());
+    };
+    let counts: Vec<(String, Vec<usize>)> = vocab
+        .iter()
+        .map(|(tag, (srcs, _))| ((*tag).to_string(), srcs.clone()))
+        .collect();
+    let (mut proposals, suppressed) =
+        merge_proposals(&counts, &tag_vectors, args.merge_threshold);
+    let dropped = proposals.len().saturating_sub(MAX_MERGE_PROPOSALS);
+    proposals.truncate(MAX_MERGE_PROPOSALS);
+
+    // ---- Human-review report ----
+    let mut report = String::new();
+    report.push_str(&format!(
+        "# Tag curation proposals — {}\n\nGenerated by `ovp2 tags-suggest` \
+         (model {EMBED_MODEL_ID}, merge cosine ≥ {}, kNN {} / vote ≥ {} / support ≥ {}).\n\
+         NOTHING here is applied automatically: review, then paste accepted lines into\n\
+         `.ovp/tags/aliases.toml` and rebuild with `ovp2 index`.\n\n",
+        model.date, args.merge_threshold, args.knn, args.vote_threshold, args.min_support
+    ));
+    report.push_str(&format!(
+        "## Merge candidates ({}{}; {suppressed} co-occurrence pair(s) suppressed — \
+         tags sharing most sources are related topics, not variants)\n\n\
+         | cosine | alias (count) | → canonical (count) |\n|---|---|---|\n",
+        proposals.len(),
+        if dropped > 0 {
+            format!(", {dropped} more below the display cap")
+        } else {
+            String::new()
+        }
+    ));
+    for p in &proposals {
+        report.push_str(&format!(
+            "| {:.3}{} | {} ({}) | {} ({}) |\n",
+            p.cosine,
+            if p.cosine >= STRONG_MERGE { " ★" } else { "" },
+            p.alias,
+            p.alias_count,
+            p.canonical,
+            p.canonical_count
+        ));
+    }
+    report.push_str("\n### Paste-ready block (edit before use)\n\n```toml\n[aliases]\n");
+    for p in &proposals {
+        report.push_str(&format!("# cosine {:.3}\n\"{}\" = \"{}\"\n", p.cosine, p.alias, p.canonical));
+    }
+    report.push_str("```\n");
+    report.push_str(&format!(
+        "\n## Backfill\n\n{covered}/{} untagged sources received inferred tags \
+         (`.ovp/tags/inferred.json`); they surface as `tags_inferred`, never as \
+         operator tags. Regenerate anytime; delete the file to turn backfill off.\n",
+        untagged.len()
+    ));
+    let report_path = args.vault_root.join(layout.tags_proposals_file());
+    if let Some(parent) = report_path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| CliError::Io(format!("creating {}: {e}", parent.display())))?;
+    }
+    std::fs::write(&report_path, report)
+        .map_err(|e| CliError::Io(format!("writing {}: {e}", report_path.display())))?;
+    println!(
+        "  merges: {} candidate pair(s) → {}",
+        proposals.len(),
+        report_path.display()
+    );
+    println!("tags-suggest: done. Rebuild the index (`ovp2 index`) to surface inferred tags.");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tags(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn vote_requires_share_and_support() {
+        let a = tags(&["agent", "rust"]);
+        let b = tags(&["agent"]);
+        let c = tags(&["python"]);
+        let neighbors: Vec<(f64, &[String])> = vec![(0.9, &a), (0.8, &b), (0.5, &c)];
+        let got = vote_tags(&neighbors, 0.35, 2, 5);
+        // agent: share (0.9+0.8)/2.2 ≈ 0.77, support 2 → wins.
+        // rust: support 1 → out. python: share 0.5/2.2 ≈ 0.23 → out.
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].tag, "agent");
+        assert_eq!(got[0].support, 2);
+    }
+
+    #[test]
+    fn vote_is_empty_on_zero_weight_and_caps_output() {
+        let a = tags(&["x", "y", "z"]);
+        assert!(vote_tags(&[(0.0, &a)], 0.1, 1, 5).is_empty());
+        let got = vote_tags(&[(1.0, &a), (1.0, &a)], 0.1, 1, 2);
+        assert_eq!(got.len(), 2);
+    }
+
+    #[test]
+    fn merge_canonical_is_higher_count_and_sorted_by_cosine() {
+        let t = vec![
+            ("agent".to_string(), (0..150).collect::<Vec<usize>>()),
+            ("agents".to_string(), vec![200, 201]),
+            ("python".to_string(), (300..314).collect()),
+        ];
+        // agent ≈ agents (disjoint sources); python orthogonal.
+        let v = vec![vec![1.0, 0.0], vec![0.99, 0.14], vec![0.0, 1.0]];
+        let (got, suppressed) = merge_proposals(&t, &v, 0.75);
+        assert_eq!(suppressed, 0);
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].alias, "agents");
+        assert_eq!(got[0].canonical, "agent");
+        assert!(got[0].cosine >= 0.98);
+    }
+
+    #[test]
+    fn merge_suppresses_co_occurring_pairs() {
+        // Two singleton tags on the SAME source: near-1.0 cosine (shared
+        // sample titles) but co-occurrence, not synonymy — suppressed.
+        let t = vec![
+            ("思考".to_string(), vec![7]),
+            ("内容创作".to_string(), vec![7]),
+        ];
+        let v = vec![vec![1.0, 0.0], vec![0.999, 0.04]];
+        let (got, suppressed) = merge_proposals(&t, &v, 0.75);
+        assert!(got.is_empty());
+        assert_eq!(suppressed, 1);
+    }
+}

--- a/crates/ovp-cli/src/commands/tags_suggest.rs
+++ b/crates/ovp-cli/src/commands/tags_suggest.rs
@@ -66,6 +66,23 @@ impl Default for TagsSuggestArgs {
     }
 }
 
+/// A tag name as a valid TOML basic string — `normalize_tag` preserves
+/// quotes/backslashes, which would break the paste-ready block unescaped.
+pub(crate) fn toml_basic_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04X}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
 /// One tag's neighbor vote on one source (pure, unit-tested): neighbors are
 /// `(similarity, tags)` pairs, already the k nearest. A tag wins when its
 /// similarity-weighted share ≥ `vote_threshold` AND ≥ `min_support` distinct
@@ -181,10 +198,17 @@ pub(crate) fn merge_proposals(
 }
 
 pub fn run(args: TagsSuggestArgs) -> Result<(), CliError> {
-    if !args.merge_threshold.is_finite() || !args.vote_threshold.is_finite() {
-        return Err(CliError::Io(
-            "tags-suggest: thresholds must be finite numbers".into(),
-        ));
+    if !(-1.0..=1.0).contains(&args.merge_threshold) {
+        return Err(CliError::Io(format!(
+            "tags-suggest: --merge-threshold is a cosine, must be in [-1, 1] (got {})",
+            args.merge_threshold
+        )));
+    }
+    if !(0.0..=1.0).contains(&args.vote_threshold) {
+        return Err(CliError::Io(format!(
+            "tags-suggest: --vote-threshold is a share, must be in [0, 1] (got {})",
+            args.vote_threshold
+        )));
     }
     let layout = VaultLayout::new();
     let model = read_index(&args.vault_root).map_err(|e| {
@@ -270,11 +294,9 @@ pub fn run(args: TagsSuggestArgs) -> Result<(), CliError> {
         ]),
         entries,
     };
-    let inferred_path = inferred.save(&args.vault_root).map_err(CliError::Io)?;
-    println!(
-        "  backfill: {covered}/{} untagged source(s) received inferred tags → {inferred_path}",
-        untagged.len()
-    );
+    // NOT saved yet — both projections persist together at the end, so a
+    // graceful embedding skip below can never leave inferred.json from this
+    // run beside a proposals.md from an older one.
 
     // ---- Merge candidates over the tag vocabulary ----
     // Vocabulary + carrying-source indices + up-to-3 sample titles per tag.
@@ -304,8 +326,17 @@ pub fn run(args: TagsSuggestArgs) -> Result<(), CliError> {
         })
         .collect();
     let Some(tag_vectors) = resolve_vectors(&tag_docs, &embed_cache_dir)? else {
+        println!(
+            "tags-suggest: nothing written — tag-vocabulary embeddings unavailable \
+             (both projections persist together or not at all)."
+        );
         return Ok(());
     };
+    let inferred_path = inferred.save(&args.vault_root).map_err(CliError::Io)?;
+    println!(
+        "  backfill: {covered}/{} untagged source(s) received inferred tags → {inferred_path}",
+        untagged.len()
+    );
     let counts: Vec<(String, Vec<usize>)> = vocab
         .iter()
         .map(|(tag, (srcs, _))| ((*tag).to_string(), srcs.clone()))
@@ -348,7 +379,12 @@ pub fn run(args: TagsSuggestArgs) -> Result<(), CliError> {
     }
     report.push_str("\n### Paste-ready block (edit before use)\n\n```toml\n[aliases]\n");
     for p in &proposals {
-        report.push_str(&format!("# cosine {:.3}\n\"{}\" = \"{}\"\n", p.cosine, p.alias, p.canonical));
+        report.push_str(&format!(
+            "# cosine {:.3}\n{} = {}\n",
+            p.cosine,
+            toml_basic_string(&p.alias),
+            toml_basic_string(&p.canonical)
+        ));
     }
     report.push_str("```\n");
     report.push_str(&format!(
@@ -418,6 +454,16 @@ mod tests {
         assert_eq!(got[0].alias, "agents");
         assert_eq!(got[0].canonical, "agent");
         assert!(got[0].cosine >= 0.98);
+    }
+
+    #[test]
+    fn toml_basic_string_escapes_quotes_and_backslashes() {
+        assert_eq!(toml_basic_string("agent"), "\"agent\"");
+        assert_eq!(toml_basic_string("foo\"bar"), "\"foo\\\"bar\"");
+        assert_eq!(toml_basic_string("a\\b"), "\"a\\\\b\"");
+        // Round-trips through the real parser.
+        let line = format!("[aliases]\n{} = \"ok\"\n", toml_basic_string("foo\"bar"));
+        assert!(ovp_domain::tags::TagAliases::parse(&line).is_ok());
     }
 
     #[test]

--- a/crates/ovp-cli/src/commands/tags_suggest.rs
+++ b/crates/ovp-cli/src/commands/tags_suggest.rs
@@ -284,6 +284,21 @@ pub fn run(args: TagsSuggestArgs) -> Result<(), CliError> {
         }
     }
     let covered = entries.len();
+    // Merge, don't clobber: bootstrap-method entries (community/llm) survive
+    // for sources where kNN produced no vote — otherwise a P1 vault's first
+    // `tags-suggest` run (once a few operator tags exist) would erase every
+    // bootstrap tag that fails the vote thresholds. A fresh kNN vote for a
+    // sha replaces its old entry of any method.
+    if let Some(existing) = TagsInferredFile::load(&args.vault_root).map_err(CliError::Io)? {
+        for (sha, tags) in existing.entries {
+            let bootstrap = tags
+                .iter()
+                .any(|t| !t.method.is_empty() && t.method != "knn");
+            if bootstrap {
+                entries.entry(sha).or_insert(tags);
+            }
+        }
+    }
     let inferred = TagsInferredFile {
         schema: TAGS_INFERRED_SCHEMA.into(),
         model: EMBED_MODEL_ID.into(),

--- a/crates/ovp-cli/src/commands/tags_suggest.rs
+++ b/crates/ovp-cli/src/commands/tags_suggest.rs
@@ -113,6 +113,7 @@ pub(crate) fn vote_tags(
                 tag: tag.to_string(),
                 score: (score * 1000.0).round() / 1000.0,
                 support,
+                method: "knn".into(),
             })
         })
         .collect();

--- a/crates/ovp-cli/src/main.rs
+++ b/crates/ovp-cli/src/main.rs
@@ -664,6 +664,33 @@ enum Cmd {
         #[arg(long, default_value_t = 42)]
         seed: u64,
     },
+    /// Cold-start tagging for vaults without a curated vocabulary: theme
+    /// communities seed a closed vocabulary (.ovp/tags/vocabulary.toml) and a
+    /// deterministic keyword floor; `--client live` adds batched LLM
+    /// classification INTO that vocabulary (capped new-name proposals).
+    /// Output lands in tags_inferred, never frontmatter. Run `index` and
+    /// `crystal-themes` first.
+    TagsBootstrap {
+        #[arg(long)]
+        vault_root: PathBuf,
+        /// `replay` (default) = deterministic floor only; `live` adds the
+        /// cassette-cached classification pass.
+        #[arg(long, value_enum, default_value_t = ClientKindArg::Replay)]
+        client: ClientKindArg,
+        /// Cassette root for tag_classify/v1. Default:
+        /// `<vault-root>/.ovp/cassettes/tags`.
+        #[arg(long)]
+        cache_dir: Option<PathBuf>,
+        /// Sources per classification call.
+        #[arg(long, default_value_t = 20)]
+        batch_size: usize,
+        /// New-name proposals admitted per batch.
+        #[arg(long, default_value_t = 2)]
+        max_new_per_batch: usize,
+        /// Redo bootstrap-method entries (kNN entries are never touched).
+        #[arg(long)]
+        refresh: bool,
+    },
     /// Propose tag curation over the embedding layer: merge candidates for
     /// near-duplicate tags (→ .ovp/tags/proposals.md, paste into aliases.toml
     /// after review) and kNN-voted backfill tags for untagged sources
@@ -1738,6 +1765,28 @@ fn main() -> ExitCode {
                 cosine_threshold,
                 resolution,
                 seed,
+            })
+        }
+        Cmd::TagsBootstrap {
+            vault_root,
+            client,
+            cache_dir,
+            batch_size,
+            max_new_per_batch,
+            refresh,
+        } => {
+            use commands::client::ClientKind;
+            let client_kind = match client {
+                ClientKindArg::Replay => ClientKind::Replay,
+                ClientKindArg::Live => ClientKind::Live,
+            };
+            commands::tags_bootstrap::run(commands::tags_bootstrap::TagsBootstrapArgs {
+                vault_root,
+                client_kind,
+                cache_dir,
+                batch_size,
+                max_new_per_batch,
+                refresh,
             })
         }
         Cmd::TagsSuggest {

--- a/crates/ovp-cli/src/main.rs
+++ b/crates/ovp-cli/src/main.rs
@@ -1788,6 +1788,7 @@ fn main() -> ExitCode {
                 max_new_per_batch,
                 refresh,
             })
+            .map(|_| ())
         }
         Cmd::TagsSuggest {
             vault_root,

--- a/crates/ovp-cli/src/main.rs
+++ b/crates/ovp-cli/src/main.rs
@@ -307,7 +307,8 @@ enum Cmd {
         vault_root: PathBuf,
         /// Case-insensitive substring over titles/URLs/paths/cards/claims.
         term: Option<String>,
-        /// Restrict to one kind: sources|packs|claims|runs|cards|units.
+        /// Restrict to one kind: sources|packs|claims|runs|cards|units|tags
+        /// (`tags` lists the canonical tag vocabulary with source counts).
         #[arg(long)]
         kind: Option<String>,
         /// Status filter (queued|processed|failed|blocked|needs_content|
@@ -317,6 +318,10 @@ enum Cmd {
         /// Date prefix filter (2026 / 2026-06 / 2026-06-09).
         #[arg(long)]
         date: Option<String>,
+        /// Canonical tag filter over sources (variant spellings and aliases
+        /// resolve via `.ovp/tags/aliases.toml` before matching).
+        #[arg(long)]
+        tag: Option<String>,
         /// Emit JSON instead of text.
         #[arg(long)]
         json: bool,
@@ -1375,6 +1380,7 @@ fn main() -> ExitCode {
             kind,
             status,
             date,
+            tag,
             json,
         } => commands::index_cmd::run_find(commands::index_cmd::FindArgs {
             vault_root,
@@ -1382,6 +1388,7 @@ fn main() -> ExitCode {
             kind,
             status,
             date,
+            tag,
             json,
         }),
         Cmd::Console { vault_root, date } => {

--- a/crates/ovp-cli/src/main.rs
+++ b/crates/ovp-cli/src/main.rs
@@ -664,6 +664,30 @@ enum Cmd {
         #[arg(long, default_value_t = 42)]
         seed: u64,
     },
+    /// Propose tag curation over the embedding layer: merge candidates for
+    /// near-duplicate tags (→ .ovp/tags/proposals.md, paste into aliases.toml
+    /// after review) and kNN-voted backfill tags for untagged sources
+    /// (→ .ovp/tags/inferred.json, surfaced as tags_inferred). Deterministic,
+    /// no LLM; reuses the crystal-themes embedding cache. Run `index` first.
+    TagsSuggest {
+        #[arg(long)]
+        vault_root: PathBuf,
+        /// Cosine floor for a merge proposal to enter the report.
+        #[arg(long, default_value_t = 0.75)]
+        merge_threshold: f64,
+        /// Tagged neighbors consulted per untagged source.
+        #[arg(long, default_value_t = 10)]
+        knn_k: usize,
+        /// Minimum share of neighbor similarity weight a tag needs (0..1).
+        #[arg(long, default_value_t = 0.35)]
+        vote_threshold: f64,
+        /// Minimum number of neighbors carrying the tag.
+        #[arg(long, default_value_t = 2)]
+        min_support: usize,
+        /// Cap on inferred tags per source.
+        #[arg(long, default_value_t = 5)]
+        max_tags: usize,
+    },
     /// PRODUCT — reader/crystal trunk (the blessed path).
     /// M25 Crystal Review Workbench: apply human review decisions over caveated
     /// claims into a REVISED structured candidate. The decision authors a
@@ -1716,6 +1740,21 @@ fn main() -> ExitCode {
                 seed,
             })
         }
+        Cmd::TagsSuggest {
+            vault_root,
+            merge_threshold,
+            knn_k,
+            vote_threshold,
+            min_support,
+            max_tags,
+        } => commands::tags_suggest::run(commands::tags_suggest::TagsSuggestArgs {
+            vault_root,
+            merge_threshold,
+            knn: knn_k,
+            vote_threshold,
+            min_support,
+            max_tags,
+        }),
         Cmd::CrystalReview {
             candidate,
             decisions,

--- a/crates/ovp-console/src/render.rs
+++ b/crates/ovp-console/src/render.rs
@@ -349,6 +349,7 @@ mod tests {
                     fail_count: 0,
                     last_reason: None,
                     tags: Vec::new(),
+                    tags_inferred: Vec::new(),
                 },
                 SourceRow {
                     sha256: "cccc".into(),
@@ -362,6 +363,7 @@ mod tests {
                     fail_count: 3,
                     last_reason: Some("card synthesis did not parse".into()),
                     tags: Vec::new(),
+                    tags_inferred: Vec::new(),
                 },
             ],
             packs: vec![PackRow {

--- a/crates/ovp-console/src/render.rs
+++ b/crates/ovp-console/src/render.rs
@@ -348,6 +348,7 @@ mod tests {
                     pack_dir: Some("40-Resources/Reader/2026-06-09_Good Article-aaaa1111".into()),
                     fail_count: 0,
                     last_reason: None,
+                    tags: Vec::new(),
                 },
                 SourceRow {
                     sha256: "cccc".into(),
@@ -360,6 +361,7 @@ mod tests {
                     pack_dir: None,
                     fail_count: 3,
                     last_reason: Some("card synthesis did not parse".into()),
+                    tags: Vec::new(),
                 },
             ],
             packs: vec![PackRow {

--- a/crates/ovp-domain/Cargo.toml
+++ b/crates/ovp-domain/Cargo.toml
@@ -20,6 +20,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 sha2 = { workspace = true }
+toml = { workspace = true }
 
 [dev-dependencies]
 ovp-domain = { path = ".", features = ["testing"] }

--- a/crates/ovp-domain/prompts/tag_classify.md
+++ b/crates/ovp-domain/prompts/tag_classify.md
@@ -1,0 +1,20 @@
+# Tag classification (tag_classify/v1)
+
+You assign content tags to knowledge sources from a CLOSED vocabulary.
+
+Rules:
+1. For each source, pick 1–5 tags. Every picked tag MUST be copied verbatim
+   from the Vocabulary list — never invent, translate, re-spell, pluralize,
+   or reformat a vocabulary tag.
+2. Pick the most SPECIFIC applicable tags. Add a generic tag (like `ai`)
+   only when nothing more specific fits.
+3. If an important topic recurs in this batch and truly has no vocabulary
+   tag, you may propose it in the batch-level `new_tags` list (lowercase,
+   hyphenated, at most the number stated in the batch header). Do NOT use a
+   proposed tag in any source's `tags` — proposals are reviewed separately.
+4. A tag must describe the CONTENT, never the capture channel or format.
+5. Reply with JSON only, no prose:
+   `{"sources": [{"id": 0, "tags": ["..."]}, …], "new_tags": ["..."]}`
+   Every input source id must appear exactly once.
+
+## Batch

--- a/crates/ovp-domain/src/lib.rs
+++ b/crates/ovp-domain/src/lib.rs
@@ -29,6 +29,10 @@ pub mod response;
 pub mod sinks;
 pub mod source_doc;
 pub mod sources;
+/// Tag vocabulary layer: deterministic normalization + the operator-owned
+/// alias table. Canonicalization happens at projection build only; raw
+/// frontmatter tags are never rewritten.
+pub mod tags;
 pub mod transforms;
 /// M14a experimental Grounded Unit extraction spike (parallel, deletable; not
 /// wired into the typed pipeline). See `docs/stage-m14a-grounded-units.md`.

--- a/crates/ovp-domain/src/tags.rs
+++ b/crates/ovp-domain/src/tags.rs
@@ -68,7 +68,10 @@ impl TagAliases {
     /// to its canonical, or a transitive chain (a canonical that is itself
     /// an alias) — chains would make resolution order-dependent.
     pub fn parse(text: &str) -> Result<Self, String> {
+        // deny_unknown_fields: a typo like `[alias]` must fail loud, not
+        // parse as an empty table that silently un-merges the vocabulary.
         #[derive(serde::Deserialize)]
+        #[serde(deny_unknown_fields)]
         struct File {
             #[serde(default)]
             aliases: BTreeMap<String, String>,
@@ -99,7 +102,7 @@ impl TagAliases {
                 ));
             }
         }
-        for canonical in map.values() {
+        for (alias, canonical) in &map {
             if map.contains_key(canonical) {
                 return Err(format!(
                     "tag aliases: {canonical:?} is both a canonical and an alias (chain); \
@@ -110,6 +113,18 @@ impl TagAliases {
                 return Err(format!(
                     "tag aliases: {canonical:?} is both a canonical and dropped; \
                      alias the variants to a kept tag or drop them directly"
+                ));
+            }
+            if drop.contains(alias) {
+                return Err(format!(
+                    "tag aliases: {alias:?} is both an alias and dropped; \
+                     pick one — drop wins would silently disable the merge"
+                ));
+            }
+            if BOILERPLATE_TAGS.contains(&canonical.as_str()) {
+                return Err(format!(
+                    "tag aliases: {alias:?} maps to boilerplate {canonical:?}; \
+                     capture-mechanism tags never surface as content facets"
                 ));
             }
         }
@@ -195,6 +210,20 @@ mod tests {
         let err = TagAliases::parse("drop = [\"tweet\"]\n[aliases]\n\"tweets\" = \"tweet\"\n")
             .unwrap_err();
         assert!(err.contains("dropped"), "{err}");
+        // An alias key in the drop list is ambiguous config — fail loud.
+        let err = TagAliases::parse("drop = [\"tweets\"]\n[aliases]\n\"tweets\" = \"tweet\"\n")
+            .unwrap_err();
+        assert!(err.contains("both an alias and dropped"), "{err}");
+    }
+
+    #[test]
+    fn parse_rejects_typo_sections_and_boilerplate_canonicals() {
+        // `[alias]` (typo) must not parse as an empty table.
+        assert!(TagAliases::parse("[alias]\n\"a\" = \"b\"\n").is_err());
+        // Aliasing onto a boilerplate capture tag can never surface.
+        let err =
+            TagAliases::parse("[aliases]\n\"clipping\" = \"clippings\"\n").unwrap_err();
+        assert!(err.contains("boilerplate"), "{err}");
     }
 
     #[test]

--- a/crates/ovp-domain/src/tags.rs
+++ b/crates/ovp-domain/src/tags.rs
@@ -163,10 +163,16 @@ pub const TAGS_INFERRED_SCHEMA: &str = "ovp.tags-inferred/v1";
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct InferredTag {
     pub tag: String,
-    /// Share of neighbor similarity weight that voted for this tag (0..1).
+    /// Coarse confidence: kNN = neighbor-weight share (0..1); bootstrap
+    /// methods use fixed bands (llm 0.8, community floor 0.4).
     pub score: f64,
-    /// Number of neighbors carrying the tag.
+    /// kNN: number of neighbors carrying the tag; community floor: the
+    /// community size; llm: 0 (a judgment, not a vote).
     pub support: usize,
+    /// How this tag was inferred: `knn` | `community` | `llm`.
+    /// Serde-additive: pre-bootstrap files deserialize to `""` (= knn era).
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub method: String,
 }
 
 /// `.ovp/tags/inferred.json` — kNN-voted tags for sources that had NO
@@ -222,6 +228,216 @@ impl TagsInferredFile {
             .map_err(|e| format!("writing {}: {e}", path.display()))?;
         Ok(path.display().to_string())
     }
+}
+
+pub const TAGS_VOCABULARY_SCHEMA: &str = "ovp.tags-vocabulary/v1";
+
+/// Where a vocabulary entry came from. `User` and `Community` entries are
+/// re-derived on every bootstrap run; `Llm` entries are the one thing worth
+/// persisting (a reviewed-and-survived model proposal is not re-derivable).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TagOrigin {
+    /// Observed as an operator tag in the index.
+    User,
+    /// A theme community's c-TF-IDF keyword (the deterministic seed).
+    Community,
+    /// Survived the classifier's capped new-name budget + embedding dedup.
+    Llm,
+}
+
+/// `.ovp/tags/vocabulary.toml` — the CLOSED list the tag classifier may pick
+/// from: user tags ∪ community keywords ∪ surviving LLM proposals. A
+/// projection: `tags-bootstrap` rebuilds the user/community entries each run
+/// and carries the llm entries forward. The operator curates it in place
+/// (delete a line to ban a tag from future classification).
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct TagVocabulary {
+    entries: BTreeMap<String, TagOrigin>,
+}
+
+impl TagVocabulary {
+    /// Insert a normalized name; an existing entry keeps its origin (user
+    /// beats community beats llm because bootstrap inserts in that order).
+    pub fn insert(&mut self, name: String, origin: TagOrigin) {
+        self.entries.entry(name).or_insert(origin);
+    }
+
+    pub fn contains(&self, name: &str) -> bool {
+        self.entries.contains_key(name)
+    }
+
+    pub fn names(&self) -> impl Iterator<Item = &str> {
+        self.entries.keys().map(String::as_str)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&str, TagOrigin)> {
+        self.entries.iter().map(|(k, v)| (k.as_str(), *v))
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn parse(text: &str) -> Result<Self, String> {
+        #[derive(serde::Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct File {
+            schema: String,
+            #[serde(default)]
+            tags: BTreeMap<String, TagOrigin>,
+        }
+        let file: File =
+            toml::from_str(text).map_err(|e| format!("tag vocabulary: invalid TOML: {e}"))?;
+        if file.schema != TAGS_VOCABULARY_SCHEMA {
+            return Err(format!(
+                "tag vocabulary: unknown schema {:?} (expected {TAGS_VOCABULARY_SCHEMA:?})",
+                file.schema
+            ));
+        }
+        let mut entries = BTreeMap::new();
+        for (name, origin) in file.tags {
+            let n = normalize_tag(&name)
+                .ok_or_else(|| format!("tag vocabulary: {name:?} normalizes to nothing"))?;
+            entries.insert(n, origin);
+        }
+        Ok(Self { entries })
+    }
+
+    /// Missing file → empty (bootstrap seeds it); broken file → error.
+    pub fn load(vault_root: &Path) -> Result<Self, String> {
+        let path = vault_root.join(crate::vault_layout::VaultLayout.tags_vocabulary_file());
+        match std::fs::read_to_string(&path) {
+            Ok(text) => Self::parse(&text),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
+            Err(e) => Err(format!("reading {}: {e}", path.display())),
+        }
+    }
+
+    pub fn save(&self, vault_root: &Path) -> Result<String, String> {
+        let path = vault_root.join(crate::vault_layout::VaultLayout.tags_vocabulary_file());
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("creating {}: {e}", parent.display()))?;
+        }
+        let mut body = String::from(
+            "# Closed tag vocabulary — the classifier may only pick from this list.\n\
+             # Rebuilt by `ovp2 tags-bootstrap` (user/community entries re-derived,\n\
+             # llm entries carried forward). Delete a line to ban a tag.\n\
+             schema = \"ovp.tags-vocabulary/v1\"\n\n[tags]\n",
+        );
+        for (name, origin) in &self.entries {
+            let origin = match origin {
+                TagOrigin::User => "user",
+                TagOrigin::Community => "community",
+                TagOrigin::Llm => "llm",
+            };
+            body.push_str(&format!("\"{}\" = \"{origin}\"\n", name.replace('\\', "\\\\").replace('"', "\\\"")));
+        }
+        std::fs::write(&path, body).map_err(|e| format!("writing {}: {e}", path.display()))?;
+        Ok(path.display().to_string())
+    }
+}
+
+// ---- Classification model stage (`tag_classify/v1`) ----
+
+const TAG_CLASSIFY_TEMPLATE: &str = include_str!("../prompts/tag_classify.md");
+pub const TAG_CLASSIFY_PROMPT_ID: &str = "tag_classify/v1";
+const TAG_CLASSIFY_MODEL: &str = "claude-sonnet-4-6";
+const TAG_CLASSIFY_MAX_TOKENS: u32 = 2000;
+
+/// One source in a classification batch.
+pub struct ClassifyInput {
+    /// Batch-local id echoed back by the model.
+    pub id: usize,
+    pub title: String,
+    /// Card titles (the pack's synthesized surface) — the content signal.
+    pub card_titles: Vec<String>,
+}
+
+/// Build the batched classification request: the closed vocabulary + the
+/// batch's sources. Deterministic text → stable cassette keys.
+pub fn tag_classify_request(
+    vocabulary: &[&str],
+    sources: &[ClassifyInput],
+    max_new: usize,
+) -> ovp_llm::ModelRequest {
+    let marker = "## Batch";
+    let (system, _) = TAG_CLASSIFY_TEMPLATE
+        .split_once(marker)
+        .unwrap_or((TAG_CLASSIFY_TEMPLATE, ""));
+    let mut user = format!(
+        "{marker}\n\nAt most {max_new} `new_tags` for this whole batch.\n\nVocabulary: {}\n\nSources:\n",
+        vocabulary.join(", ")
+    );
+    for s in sources {
+        user.push_str(&format!("{}. {}", s.id, s.title));
+        if !s.card_titles.is_empty() {
+            user.push_str(&format!(" — {}", s.card_titles.join(" | ")));
+        }
+        user.push('\n');
+    }
+    ovp_llm::ModelRequest {
+        model: TAG_CLASSIFY_MODEL.to_string(),
+        system: Some(system.trim_end().to_string()),
+        messages: vec![ovp_llm::ModelMessage::User { content: user }],
+        max_tokens: TAG_CLASSIFY_MAX_TOKENS,
+        temperature: None,
+        cache_namespace: Some(TAG_CLASSIFY_PROMPT_ID.to_string()),
+    }
+}
+
+/// Parsed classification reply.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ClassifyReply {
+    /// Batch-local id → picked tag names (raw; caller validates vs vocab).
+    pub picks: BTreeMap<usize, Vec<String>>,
+    pub new_tags: Vec<String>,
+}
+
+/// Parse `{"sources":[{"id":0,"tags":[...]},…],"new_tags":[...]}`.
+pub fn parse_tag_classify(reply_text: &str) -> Result<ClassifyReply, String> {
+    let (value, _note) =
+        crate::model_reply::parse_reply_value(reply_text).map_err(|d| d.to_string())?;
+    let sources = value
+        .get("sources")
+        .and_then(|v| v.as_array())
+        .ok_or("missing `sources` array")?;
+    let mut picks = BTreeMap::new();
+    for s in sources {
+        let id = s
+            .get("id")
+            .and_then(|v| v.as_u64())
+            .ok_or("source missing numeric `id`")? as usize;
+        let tags: Vec<String> = s
+            .get("tags")
+            .and_then(|v| v.as_array())
+            .ok_or("source missing `tags` array")?
+            .iter()
+            .filter_map(|t| t.as_str())
+            .map(|t| t.trim().to_string())
+            .filter(|t| !t.is_empty())
+            .collect();
+        if picks.insert(id, tags).is_some() {
+            return Err(format!("duplicate source id {id}"));
+        }
+    }
+    let new_tags: Vec<String> = value
+        .get("new_tags")
+        .and_then(|v| v.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|t| t.as_str())
+                .map(|t| t.trim().to_string())
+                .filter(|t| !t.is_empty())
+                .collect()
+        })
+        .unwrap_or_default();
+    Ok(ClassifyReply { picks, new_tags })
 }
 
 /// Raw frontmatter tags → sorted, deduped canonical tags: normalize, drop
@@ -300,6 +516,52 @@ mod tests {
         let chain = "[aliases]\n\"a\" = \"b\"\n\"b\" = \"c\"\n";
         let err = TagAliases::parse(chain).unwrap_err();
         assert!(err.contains("chain"), "{err}");
+    }
+
+    #[test]
+    fn vocabulary_round_trips_and_first_origin_wins() {
+        let mut v = TagVocabulary::default();
+        v.insert("agent".into(), TagOrigin::User);
+        v.insert("agent".into(), TagOrigin::Llm); // ignored — user wins
+        v.insert("向量检索".into(), TagOrigin::Community);
+        let dir = tempfile::tempdir().unwrap();
+        v.save(dir.path()).unwrap();
+        let loaded = TagVocabulary::load(dir.path()).unwrap();
+        assert_eq!(loaded, v);
+        assert_eq!(loaded.iter().next(), Some(("agent", TagOrigin::User)));
+        // Missing file → empty; typo section → error.
+        assert!(TagVocabulary::load(tempfile::tempdir().unwrap().path()).unwrap().is_empty());
+        assert!(TagVocabulary::parse("schema = \"ovp.tags-vocabulary/v1\"\n[tag]\n").is_err());
+    }
+
+    #[test]
+    fn classify_reply_parses_and_rejects_duplicates() {
+        let ok = parse_tag_classify(
+            r#"{"sources":[{"id":0,"tags":["agent"," memory "]},{"id":1,"tags":[]}],"new_tags":["kv-cache"]}"#,
+        )
+        .unwrap();
+        assert_eq!(ok.picks[&0], vec!["agent", "memory"]);
+        assert!(ok.picks[&1].is_empty());
+        assert_eq!(ok.new_tags, vec!["kv-cache"]);
+        assert!(parse_tag_classify(r#"{"sources":[{"id":0,"tags":[]},{"id":0,"tags":[]}]}"#).is_err());
+        assert!(parse_tag_classify(r#"{"new_tags":[]}"#).is_err());
+    }
+
+    #[test]
+    fn classify_request_is_deterministic_and_carries_the_cap() {
+        let sources = vec![ClassifyInput {
+            id: 0,
+            title: "T".into(),
+            card_titles: vec!["c1".into(), "c2".into()],
+        }];
+        let a = tag_classify_request(&["agent", "memory"], &sources, 2);
+        let b = tag_classify_request(&["agent", "memory"], &sources, 2);
+        assert_eq!(a.messages, b.messages);
+        let ovp_llm::ModelMessage::User { content } = &a.messages[0] else {
+            panic!("expected a user message");
+        };
+        assert!(content.contains("At most 2 `new_tags`"), "{content}");
+        assert!(content.contains("0. T — c1 | c2"), "{content}");
     }
 
     #[test]

--- a/crates/ovp-domain/src/tags.rs
+++ b/crates/ovp-domain/src/tags.rs
@@ -157,6 +157,73 @@ impl TagAliases {
     }
 }
 
+pub const TAGS_INFERRED_SCHEMA: &str = "ovp.tags-inferred/v1";
+
+/// One machine-inferred tag on one source, with its evidence.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct InferredTag {
+    pub tag: String,
+    /// Share of neighbor similarity weight that voted for this tag (0..1).
+    pub score: f64,
+    /// Number of neighbors carrying the tag.
+    pub support: usize,
+}
+
+/// `.ovp/tags/inferred.json` — kNN-voted tags for sources that had NO
+/// operator tags at generation time. A rebuildable projection: regenerate
+/// with `tags-suggest`, delete freely. The index attaches these as
+/// `tags_inferred`, never mixing them into operator tags, and drops them for
+/// any source that has since gained real tags (self-healing staleness).
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct TagsInferredFile {
+    pub schema: String,
+    /// Embedding model the neighbor graph was built with.
+    pub model: String,
+    /// Generation parameters, recorded for auditability (k, thresholds…).
+    #[serde(default)]
+    pub params: BTreeMap<String, f64>,
+    /// source sha256 → inferred tags (score descending).
+    #[serde(default)]
+    pub entries: BTreeMap<String, Vec<InferredTag>>,
+}
+
+impl TagsInferredFile {
+    /// Load from the vault. Missing file → `None` (feature unused); a present
+    /// but unparseable file is an error — silently dropping every inferred
+    /// tag would read as "backfill vanished".
+    pub fn load(vault_root: &Path) -> Result<Option<Self>, String> {
+        let path = vault_root.join(crate::vault_layout::VaultLayout.tags_inferred_file());
+        let raw = match std::fs::read_to_string(&path) {
+            Ok(raw) => raw,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => return Err(format!("reading {}: {e}", path.display())),
+        };
+        let file: Self = serde_json::from_str(&raw)
+            .map_err(|e| format!("parsing {}: {e}", path.display()))?;
+        if file.schema != TAGS_INFERRED_SCHEMA {
+            return Err(format!(
+                "{}: unknown schema {:?} (expected {TAGS_INFERRED_SCHEMA:?})",
+                path.display(),
+                file.schema
+            ));
+        }
+        Ok(Some(file))
+    }
+
+    pub fn save(&self, vault_root: &Path) -> Result<String, String> {
+        let path = vault_root.join(crate::vault_layout::VaultLayout.tags_inferred_file());
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("creating {}: {e}", parent.display()))?;
+        }
+        let body = serde_json::to_string_pretty(self)
+            .map_err(|e| format!("serializing inferred tags: {e}"))?;
+        std::fs::write(&path, format!("{body}\n"))
+            .map_err(|e| format!("writing {}: {e}", path.display()))?;
+        Ok(path.display().to_string())
+    }
+}
+
 /// Raw frontmatter tags → sorted, deduped canonical tags: normalize, drop
 /// boilerplate, resolve aliases, apply the operator drop list. The one entry
 /// point projections use.

--- a/crates/ovp-domain/src/tags.rs
+++ b/crates/ovp-domain/src/tags.rs
@@ -249,18 +249,35 @@ pub enum TagOrigin {
 /// `.ovp/tags/vocabulary.toml` — the CLOSED list the tag classifier may pick
 /// from: user tags ∪ community keywords ∪ surviving LLM proposals. A
 /// projection: `tags-bootstrap` rebuilds the user/community entries each run
-/// and carries the llm entries forward. The operator curates it in place
-/// (delete a line to ban a tag from future classification).
+/// and carries the llm entries forward. Curation: deleting an `llm` line
+/// removes it permanently (not re-derivable); user/community entries would
+/// be re-derived on the next run, so banning those goes through the
+/// persistent `banned` list, which every insert respects.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct TagVocabulary {
     entries: BTreeMap<String, TagOrigin>,
+    banned: std::collections::BTreeSet<String>,
 }
 
 impl TagVocabulary {
     /// Insert a normalized name; an existing entry keeps its origin (user
     /// beats community beats llm because bootstrap inserts in that order).
+    /// Banned names never enter.
     pub fn insert(&mut self, name: String, origin: TagOrigin) {
+        if self.banned.contains(&name) {
+            return;
+        }
         self.entries.entry(name).or_insert(origin);
+    }
+
+    /// Ban a name from the vocabulary (persists across bootstrap runs).
+    pub fn ban(&mut self, name: String) {
+        self.entries.remove(&name);
+        self.banned.insert(name);
+    }
+
+    pub fn banned(&self) -> impl Iterator<Item = &str> {
+        self.banned.iter().map(String::as_str)
     }
 
     pub fn contains(&self, name: &str) -> bool {
@@ -289,6 +306,8 @@ impl TagVocabulary {
         struct File {
             schema: String,
             #[serde(default)]
+            banned: Vec<String>,
+            #[serde(default)]
             tags: BTreeMap<String, TagOrigin>,
         }
         let file: File =
@@ -299,13 +318,21 @@ impl TagVocabulary {
                 file.schema
             ));
         }
+        let mut banned = std::collections::BTreeSet::new();
+        for name in file.banned {
+            let n = normalize_tag(&name)
+                .ok_or_else(|| format!("tag vocabulary: banned {name:?} normalizes to nothing"))?;
+            banned.insert(n);
+        }
         let mut entries = BTreeMap::new();
         for (name, origin) in file.tags {
             let n = normalize_tag(&name)
                 .ok_or_else(|| format!("tag vocabulary: {name:?} normalizes to nothing"))?;
-            entries.insert(n, origin);
+            if !banned.contains(&n) {
+                entries.insert(n, origin);
+            }
         }
-        Ok(Self { entries })
+        Ok(Self { entries, banned })
     }
 
     /// Missing file → empty (bootstrap seeds it); broken file → error.
@@ -326,10 +353,23 @@ impl TagVocabulary {
         }
         let mut body = String::from(
             "# Closed tag vocabulary — the classifier may only pick from this list.\n\
-             # Rebuilt by `ovp2 tags-bootstrap` (user/community entries re-derived,\n\
-             # llm entries carried forward). Delete a line to ban a tag.\n\
-             schema = \"ovp.tags-vocabulary/v1\"\n\n[tags]\n",
+             # Rebuilt by `ovp2 tags-bootstrap`: user/community entries are re-derived\n\
+             # each run (deleting them does NOT stick — add the name to `banned`);\n\
+             # llm entries persist, so deleting an llm line removes it for good.\n\
+             schema = \"ovp.tags-vocabulary/v1\"\n",
         );
+        if self.banned.is_empty() {
+            body.push_str("banned = []\n\n[tags]\n");
+        } else {
+            body.push_str("banned = [\n");
+            for name in &self.banned {
+                body.push_str(&format!(
+                    "  \"{}\",\n",
+                    name.replace('\\', "\\\\").replace('"', "\\\"")
+                ));
+            }
+            body.push_str("]\n\n[tags]\n");
+        }
         for (name, origin) in &self.entries {
             let origin = match origin {
                 TagOrigin::User => "user",
@@ -399,8 +439,11 @@ pub struct ClassifyReply {
     pub new_tags: Vec<String>,
 }
 
-/// Parse `{"sources":[{"id":0,"tags":[...]},…],"new_tags":[...]}`.
-pub fn parse_tag_classify(reply_text: &str) -> Result<ClassifyReply, String> {
+/// Parse `{"sources":[{"id":0,"tags":[...]},…],"new_tags":[...]}` for a
+/// batch of ids `0..expected`. A missing, duplicate, or out-of-range id is a
+/// parse ERROR (not a silent gap) so `call_and_parse` invalidates the
+/// cassette entry and the retry re-asks the model.
+pub fn parse_tag_classify(reply_text: &str, expected: usize) -> Result<ClassifyReply, String> {
     let (value, _note) =
         crate::model_reply::parse_reply_value(reply_text).map_err(|d| d.to_string())?;
     let sources = value
@@ -413,6 +456,9 @@ pub fn parse_tag_classify(reply_text: &str) -> Result<ClassifyReply, String> {
             .get("id")
             .and_then(|v| v.as_u64())
             .ok_or("source missing numeric `id`")? as usize;
+        if id >= expected {
+            return Err(format!("source id {id} out of range (batch of {expected})"));
+        }
         let tags: Vec<String> = s
             .get("tags")
             .and_then(|v| v.as_array())
@@ -425,6 +471,12 @@ pub fn parse_tag_classify(reply_text: &str) -> Result<ClassifyReply, String> {
         if picks.insert(id, tags).is_some() {
             return Err(format!("duplicate source id {id}"));
         }
+    }
+    if picks.len() != expected {
+        return Err(format!(
+            "reply covers {}/{expected} batch ids — every input id must appear exactly once",
+            picks.len()
+        ));
     }
     let new_tags: Vec<String> = value
         .get("new_tags")
@@ -535,16 +587,37 @@ mod tests {
     }
 
     #[test]
-    fn classify_reply_parses_and_rejects_duplicates() {
+    fn classify_reply_parses_and_rejects_duplicates_gaps_and_strays() {
         let ok = parse_tag_classify(
             r#"{"sources":[{"id":0,"tags":["agent"," memory "]},{"id":1,"tags":[]}],"new_tags":["kv-cache"]}"#,
+            2,
         )
         .unwrap();
         assert_eq!(ok.picks[&0], vec!["agent", "memory"]);
         assert!(ok.picks[&1].is_empty());
         assert_eq!(ok.new_tags, vec!["kv-cache"]);
-        assert!(parse_tag_classify(r#"{"sources":[{"id":0,"tags":[]},{"id":0,"tags":[]}]}"#).is_err());
-        assert!(parse_tag_classify(r#"{"new_tags":[]}"#).is_err());
+        // Duplicate id, missing id, and out-of-range id are all parse errors.
+        assert!(
+            parse_tag_classify(r#"{"sources":[{"id":0,"tags":[]},{"id":0,"tags":[]}]}"#, 2)
+                .is_err()
+        );
+        assert!(parse_tag_classify(r#"{"sources":[{"id":0,"tags":[]}]}"#, 2).is_err());
+        assert!(parse_tag_classify(r#"{"sources":[{"id":5,"tags":[]}]}"#, 1).is_err());
+        assert!(parse_tag_classify(r#"{"new_tags":[]}"#, 0).is_err());
+    }
+
+    #[test]
+    fn vocabulary_bans_persist_and_block_reinsertion() {
+        let mut v = TagVocabulary::default();
+        v.insert("twitter".into(), TagOrigin::User);
+        v.ban("twitter".into());
+        v.insert("twitter".into(), TagOrigin::Community); // blocked
+        assert!(!v.contains("twitter"));
+        let dir = tempfile::tempdir().unwrap();
+        v.save(dir.path()).unwrap();
+        let loaded = TagVocabulary::load(dir.path()).unwrap();
+        assert!(loaded.banned().any(|b| b == "twitter"));
+        assert!(!loaded.contains("twitter"));
     }
 
     #[test]

--- a/crates/ovp-domain/src/tags.rs
+++ b/crates/ovp-domain/src/tags.rs
@@ -1,0 +1,215 @@
+//! Tag vocabulary layer: deterministic normalization + the operator-owned
+//! alias table (`.ovp/tags/aliases.toml`).
+//!
+//! Ownership contract (docs/stage-tags): raw tags live in note frontmatter
+//! and are NEVER rewritten by the pipeline — canonicalization happens only
+//! when a projection is built. The alias table maps variant spellings to a
+//! canonical tag, so both already-ingested notes and future captures with
+//! any variant spelling converge without touching the source files.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+/// Tags the intake renderer stamps on every note it writes. They mark the
+/// capture mechanism, not the content, so no projection surfaces them.
+pub const BOILERPLATE_TAGS: &[&str] = &["clippings", "pinboard"];
+
+/// Deterministic tag normalization: trim, strip a leading `#`, lowercase,
+/// fold separators (whitespace/underscore/`/`) to `-`, collapse runs of `-`,
+/// strip leading/trailing `-`. Returns `None` when nothing survives.
+///
+/// Deliberately NOT here: plural folding, abbreviation expansion, semantic
+/// merges — those are corpus-dependent judgments and belong in the alias
+/// table, where the operator approves them.
+pub fn normalize_tag(raw: &str) -> Option<String> {
+    let mut out = String::with_capacity(raw.len());
+    let mut prev_dash = true; // suppress leading dashes
+    for c in raw.trim().trim_start_matches('#').chars() {
+        let folded: Option<char> = if c.is_whitespace() || c == '_' || c == '/' || c == '-' {
+            None
+        } else {
+            Some(c)
+        };
+        match folded {
+            Some(c) => {
+                for lc in c.to_lowercase() {
+                    out.push(lc);
+                }
+                prev_dash = false;
+            }
+            None => {
+                if !prev_dash {
+                    out.push('-');
+                    prev_dash = true;
+                }
+            }
+        }
+    }
+    while out.ends_with('-') {
+        out.pop();
+    }
+    if out.is_empty() { None } else { Some(out) }
+}
+
+/// The operator-approved alias table: normalized alias → normalized
+/// canonical, plus a `drop` list for capture-channel tags (e.g. a clipper's
+/// per-site tag) that should never surface as content facets. Loaded from
+/// `.ovp/tags/aliases.toml`; a missing file is an empty table (the mechanism
+/// is optional until the operator seeds it).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TagAliases {
+    map: BTreeMap<String, String>,
+    drop: std::collections::BTreeSet<String>,
+}
+
+impl TagAliases {
+    /// Parse the alias table from TOML text. Fail-loud on structural rot:
+    /// unparseable TOML, an alias that normalizes to nothing, an alias equal
+    /// to its canonical, or a transitive chain (a canonical that is itself
+    /// an alias) — chains would make resolution order-dependent.
+    pub fn parse(text: &str) -> Result<Self, String> {
+        #[derive(serde::Deserialize)]
+        struct File {
+            #[serde(default)]
+            aliases: BTreeMap<String, String>,
+            #[serde(default)]
+            drop: Vec<String>,
+        }
+        let file: File =
+            toml::from_str(text).map_err(|e| format!("tag aliases: invalid TOML: {e}"))?;
+        let mut drop = std::collections::BTreeSet::new();
+        for raw in &file.drop {
+            let d = normalize_tag(raw)
+                .ok_or_else(|| format!("tag aliases: drop entry {raw:?} normalizes to nothing"))?;
+            drop.insert(d);
+        }
+        let mut map = BTreeMap::new();
+        for (alias, canonical) in &file.aliases {
+            let a = normalize_tag(alias)
+                .ok_or_else(|| format!("tag aliases: alias {alias:?} normalizes to nothing"))?;
+            let c = normalize_tag(canonical).ok_or_else(|| {
+                format!("tag aliases: canonical {canonical:?} (for {alias:?}) normalizes to nothing")
+            })?;
+            if a == c {
+                return Err(format!("tag aliases: {alias:?} maps to itself"));
+            }
+            if map.insert(a.clone(), c).is_some() {
+                return Err(format!(
+                    "tag aliases: duplicate alias {a:?} after normalization"
+                ));
+            }
+        }
+        for canonical in map.values() {
+            if map.contains_key(canonical) {
+                return Err(format!(
+                    "tag aliases: {canonical:?} is both a canonical and an alias (chain); \
+                     point every alias directly at the final canonical"
+                ));
+            }
+            if drop.contains(canonical) {
+                return Err(format!(
+                    "tag aliases: {canonical:?} is both a canonical and dropped; \
+                     alias the variants to a kept tag or drop them directly"
+                ));
+            }
+        }
+        Ok(Self { map, drop })
+    }
+
+    /// Load the table from `<vault_root>/.ovp/tags/aliases.toml`. Missing
+    /// file → empty table; unreadable or invalid file → error (a present but
+    /// broken table must not silently un-merge the vocabulary).
+    pub fn load(vault_root: &Path) -> Result<Self, String> {
+        let path = vault_root.join(crate::vault_layout::VaultLayout.tag_aliases_file());
+        match std::fs::read_to_string(&path) {
+            Ok(text) => Self::parse(&text),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
+            Err(e) => Err(format!("reading {}: {e}", path.display())),
+        }
+    }
+
+    /// Canonical form of an already-normalized tag.
+    pub fn resolve<'a>(&'a self, normalized: &'a str) -> &'a str {
+        self.map.get(normalized).map(String::as_str).unwrap_or(normalized)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+}
+
+/// Raw frontmatter tags → sorted, deduped canonical tags: normalize, drop
+/// boilerplate, resolve aliases, apply the operator drop list. The one entry
+/// point projections use.
+pub fn canonical_tags<S: AsRef<str>>(raw: &[S], aliases: &TagAliases) -> Vec<String> {
+    let mut out: Vec<String> = raw
+        .iter()
+        .filter_map(|t| normalize_tag(t.as_ref()))
+        .filter(|t| !BOILERPLATE_TAGS.contains(&t.as_str()))
+        .filter(|t| !aliases.drop.contains(t))
+        .map(|t| aliases.resolve(&t).to_string())
+        .collect();
+    out.sort();
+    out.dedup();
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_folds_case_separators_and_hash() {
+        assert_eq!(normalize_tag("Claude_Code"), Some("claude-code".into()));
+        assert_eq!(normalize_tag("#AI  Agent"), Some("ai-agent".into()));
+        assert_eq!(normalize_tag("ai/agent"), Some("ai-agent".into()));
+        assert_eq!(normalize_tag("--open--source--"), Some("open-source".into()));
+        assert_eq!(normalize_tag("大模型"), Some("大模型".into()));
+    }
+
+    #[test]
+    fn normalize_rejects_empty() {
+        assert_eq!(normalize_tag(""), None);
+        assert_eq!(normalize_tag("  #- _ "), None);
+    }
+
+    #[test]
+    fn canonical_tags_drop_boilerplate_resolve_aliases_and_dedup() {
+        let aliases = TagAliases::parse("[aliases]\n\"ai-agents\" = \"agent\"\n").unwrap();
+        let got = canonical_tags(
+            &["clippings", "pinboard", "AI Agents", "agent", "Agent"],
+            &aliases,
+        );
+        assert_eq!(got, vec!["agent".to_string()]);
+    }
+
+    #[test]
+    fn drop_list_removes_channel_tags_and_rejects_dropped_canonicals() {
+        let t = TagAliases::parse("drop = [\"Twitter\"]\n[aliases]\n\"tweets\" = \"tweet\"\n")
+            .unwrap();
+        assert_eq!(canonical_tags(&["twitter", "tweets"], &t), vec!["tweet".to_string()]);
+        let err = TagAliases::parse("drop = [\"tweet\"]\n[aliases]\n\"tweets\" = \"tweet\"\n")
+            .unwrap_err();
+        assert!(err.contains("dropped"), "{err}");
+    }
+
+    #[test]
+    fn parse_rejects_chains_self_maps_and_bad_toml() {
+        assert!(TagAliases::parse("aliases = 3").is_err());
+        assert!(TagAliases::parse("[aliases]\n\"agent\" = \"Agent\"\n").is_err());
+        let chain = "[aliases]\n\"a\" = \"b\"\n\"b\" = \"c\"\n";
+        let err = TagAliases::parse(chain).unwrap_err();
+        assert!(err.contains("chain"), "{err}");
+    }
+
+    #[test]
+    fn parse_normalizes_both_sides_and_missing_section_is_empty() {
+        let t = TagAliases::parse("[aliases]\n\"AI_Agents\" = \"Agent\"\n").unwrap();
+        assert_eq!(t.resolve("ai-agents"), "agent");
+        assert!(TagAliases::parse("").unwrap().is_empty());
+    }
+}

--- a/crates/ovp-domain/src/vault_layout.rs
+++ b/crates/ovp-domain/src/vault_layout.rs
@@ -222,6 +222,12 @@ impl VaultLayout {
     pub fn crystal_store_dir(&self) -> &'static str {
         ".ovp/crystal"
     }
+
+    /// The operator-owned tag alias table (alias → canonical), applied at
+    /// projection build time only — raw frontmatter tags are never rewritten.
+    pub fn tag_aliases_file(&self) -> &'static str {
+        ".ovp/tags/aliases.toml"
+    }
 }
 
 /// Truncate to at most `max` characters on a char boundary (titles can be

--- a/crates/ovp-domain/src/vault_layout.rs
+++ b/crates/ovp-domain/src/vault_layout.rs
@@ -228,6 +228,18 @@ impl VaultLayout {
     pub fn tag_aliases_file(&self) -> &'static str {
         ".ovp/tags/aliases.toml"
     }
+
+    /// Machine-inferred tags for untagged sources (`tags-suggest` output) —
+    /// a rebuildable projection, kept strictly apart from operator tags.
+    pub fn tags_inferred_file(&self) -> &'static str {
+        ".ovp/tags/inferred.json"
+    }
+
+    /// The human-review report `tags-suggest` writes: merge candidates with
+    /// evidence + a paste-ready `[aliases]` block. Never read by the pipeline.
+    pub fn tags_proposals_file(&self) -> &'static str {
+        ".ovp/tags/proposals.md"
+    }
 }
 
 /// Truncate to at most `max` characters on a char boundary (titles can be

--- a/crates/ovp-domain/src/vault_layout.rs
+++ b/crates/ovp-domain/src/vault_layout.rs
@@ -240,6 +240,12 @@ impl VaultLayout {
     pub fn tags_proposals_file(&self) -> &'static str {
         ".ovp/tags/proposals.md"
     }
+
+    /// The closed tag vocabulary the classifier picks from (`tags-bootstrap`
+    /// rebuilds user/community entries; llm entries persist; operator-curable).
+    pub fn tags_vocabulary_file(&self) -> &'static str {
+        ".ovp/tags/vocabulary.toml"
+    }
 }
 
 /// Truncate to at most `max` characters on a char boundary (titles can be

--- a/crates/ovp-index/src/build.rs
+++ b/crates/ovp-index/src/build.rs
@@ -17,7 +17,7 @@ use ovp_daily::{MAX_FAILURES_BEFORE_BLOCKED, RunReport, RunStatus, read_daily_le
 use ovp_domain::VaultLayout;
 use ovp_domain::crystal::themes::{ThemesFile, UNCLASSIFIED_THEME};
 use ovp_domain::crystal::{CrystalStatus, ReviewEntry, StoreEvent, fold_ledger};
-use ovp_domain::tags::{TagAliases, canonical_tags};
+use ovp_domain::tags::{TagAliases, TagsInferredFile, canonical_tags};
 use ovp_domain::units::read_source_from_path;
 use ovp_intake::vaultops::{hex_sha256, read_jsonl, rel_to};
 use ovp_intake::{IntakeAction, read_intake_ledger};
@@ -234,6 +234,7 @@ fn build_sources(
                 fail_count: 0,
                 last_reason: rec.note.clone(),
                 tags: Vec::new(),
+                tags_inferred: Vec::new(),
             },
         );
     }
@@ -256,6 +257,7 @@ fn build_sources(
                 fail_count: 0,
                 last_reason: None,
                 tags: Vec::new(),
+                tags_inferred: Vec::new(),
             });
         entry.date = Some(rec.date.clone());
         entry.last_run_id = Some(rec.run_id.clone());
@@ -320,6 +322,7 @@ fn build_sources(
                     fail_count: 0,
                     last_reason: None,
                     tags: Vec::new(),
+                    tags_inferred: Vec::new(),
                 }
             });
         }
@@ -359,6 +362,7 @@ fn build_sources(
 /// is a hard error (a silently ignored table would un-merge the vocabulary).
 fn attach_tags(vault_root: &Path, rows: &mut [SourceRow]) -> Result<usize, String> {
     let aliases = TagAliases::load(vault_root)?;
+    let inferred = TagsInferredFile::load(vault_root)?.unwrap_or_default();
     let mut tagged = 0;
     for row in rows.iter_mut() {
         let Some(rel) = row.rel_path.as_deref() else {
@@ -370,6 +374,13 @@ fn attach_tags(vault_root: &Path, rows: &mut [SourceRow]) -> Result<usize, Strin
         row.tags = canonical_tags(&doc.tags, &aliases);
         if !row.tags.is_empty() {
             tagged += 1;
+        } else if let Some(voted) = inferred.entries.get(&row.sha256) {
+            // Backfill applies ONLY while the source has no operator tags —
+            // hand-tagging a note silently retires its inferred tags on the
+            // next build. Inferred names re-run through the alias pipe so a
+            // later merge also heals stale inference output.
+            let names: Vec<&str> = voted.iter().map(|t| t.tag.as_str()).collect();
+            row.tags_inferred = canonical_tags(&names, &aliases);
         }
     }
     Ok(tagged)
@@ -672,6 +683,7 @@ fn backfill_corpus_packs(
                     fail_count: 0,
                     last_reason: None,
                     tags: Vec::new(),
+                    tags_inferred: Vec::new(),
                 });
                 by_sha.insert(sha256.clone(), sources.len() - 1);
                 changed = true;
@@ -1210,6 +1222,7 @@ mod tests {
             fail_count: 3,
             last_reason: Some("boom".into()),
             tags: Vec::new(),
+            tags_inferred: Vec::new(),
         };
         let sources = vec![
             src("aaaa", SourceStatus::Blocked, "2026-06-30"), // 8 days stuck

--- a/crates/ovp-index/src/build.rs
+++ b/crates/ovp-index/src/build.rs
@@ -17,6 +17,7 @@ use ovp_daily::{MAX_FAILURES_BEFORE_BLOCKED, RunReport, RunStatus, read_daily_le
 use ovp_domain::VaultLayout;
 use ovp_domain::crystal::themes::{ThemesFile, UNCLASSIFIED_THEME};
 use ovp_domain::crystal::{CrystalStatus, ReviewEntry, StoreEvent, fold_ledger};
+use ovp_domain::tags::{TagAliases, canonical_tags};
 use ovp_domain::units::read_source_from_path;
 use ovp_intake::vaultops::{hex_sha256, read_jsonl, rel_to};
 use ovp_intake::{IntakeAction, read_intake_ledger};
@@ -106,6 +107,8 @@ pub fn build_index_at_with_progress(
     backfill_corpus_packs(vault_root, &layout, &mut sources, &mut packs)?;
     on_phase(&format!("hashed {} pack(s)", packs.len()));
     enrich_titles_from_packs(&mut sources, &packs);
+    let tagged = attach_tags(vault_root, &mut sources)?;
+    on_phase(&format!("tagged {tagged} source(s)"));
     let claims = build_claims(vault_root, &layout)?;
     on_phase(&format!("folded {} claim(s)", claims.len()));
 
@@ -230,6 +233,7 @@ fn build_sources(
                 pack_dir: None,
                 fail_count: 0,
                 last_reason: rec.note.clone(),
+                tags: Vec::new(),
             },
         );
     }
@@ -251,6 +255,7 @@ fn build_sources(
                 pack_dir: None,
                 fail_count: 0,
                 last_reason: None,
+                tags: Vec::new(),
             });
         entry.date = Some(rec.date.clone());
         entry.last_run_id = Some(rec.run_id.clone());
@@ -314,6 +319,7 @@ fn build_sources(
                     pack_dir: None,
                     fail_count: 0,
                     last_reason: None,
+                    tags: Vec::new(),
                 }
             });
         }
@@ -343,6 +349,30 @@ fn build_sources(
         .collect();
     sort_sources(&mut out);
     Ok(out)
+}
+
+/// Re-read each row's note frontmatter and attach canonical tags. The note's
+/// CURRENT frontmatter is the per-source tag truth (the operator edits it in
+/// place after ingest), so tags are re-derived on every build rather than
+/// copied from ledgers. Per-row read/parse failures are non-fatal — tags
+/// enrich a row, they never gate it — but a present-and-broken alias table
+/// is a hard error (a silently ignored table would un-merge the vocabulary).
+fn attach_tags(vault_root: &Path, rows: &mut [SourceRow]) -> Result<usize, String> {
+    let aliases = TagAliases::load(vault_root)?;
+    let mut tagged = 0;
+    for row in rows.iter_mut() {
+        let Some(rel) = row.rel_path.as_deref() else {
+            continue;
+        };
+        let Ok(doc) = read_source_from_path(&vault_root.join(rel)) else {
+            continue;
+        };
+        row.tags = canonical_tags(&doc.tags, &aliases);
+        if !row.tags.is_empty() {
+            tagged += 1;
+        }
+    }
+    Ok(tagged)
 }
 
 /// Canonical source-row order: status band, then title, then hash. Shared by
@@ -641,6 +671,7 @@ fn backfill_corpus_packs(
                     pack_dir: Some(packs[i].pack_dir.clone()),
                     fail_count: 0,
                     last_reason: None,
+                    tags: Vec::new(),
                 });
                 by_sha.insert(sha256.clone(), sources.len() - 1);
                 changed = true;
@@ -1178,6 +1209,7 @@ mod tests {
             pack_dir: None,
             fail_count: 3,
             last_reason: Some("boom".into()),
+            tags: Vec::new(),
         };
         let sources = vec![
             src("aaaa", SourceStatus::Blocked, "2026-06-30"), // 8 days stuck

--- a/crates/ovp-index/src/model.rs
+++ b/crates/ovp-index/src/model.rs
@@ -49,6 +49,12 @@ pub struct SourceRow {
     pub fail_count: usize,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_reason: Option<String>,
+    /// Canonical content tags: the note's CURRENT frontmatter tags (vault
+    /// frontmatter is the per-source truth, re-read at build) normalized +
+    /// alias-resolved via `.ovp/tags/aliases.toml`, boilerplate dropped.
+    /// Serde-additive: pre-tag indexes deserialize to empty.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/ovp-index/src/model.rs
+++ b/crates/ovp-index/src/model.rs
@@ -55,6 +55,12 @@ pub struct SourceRow {
     /// Serde-additive: pre-tag indexes deserialize to empty.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tags: Vec<String>,
+    /// Machine-inferred tags (`tags-suggest` kNN vote, `.ovp/tags/inferred.json`)
+    /// — attached ONLY while the source has no operator tags, so a later
+    /// hand-tagging silently retires them. Kept strictly apart from `tags`;
+    /// surfaces render them visibly weaker (`~#tag`, dashed chips).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags_inferred: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/ovp-index/src/query.rs
+++ b/crates/ovp-index/src/query.rs
@@ -15,6 +15,10 @@ pub enum QueryKind {
     Runs,
     Cards,
     Units,
+    /// The tag vocabulary itself: one row per canonical tag with its source
+    /// count. Never included in the default all-kinds sweep — only an
+    /// explicit `--kind tags` lists it.
+    Tags,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -29,6 +33,11 @@ pub struct Query {
     /// Case-insensitive substring over titles, URLs, paths, card titles,
     /// claim text, themes, run ids.
     pub term: Option<String>,
+    /// Canonical tag filter (exact match after normalization). Tags are a
+    /// source-level axis: a tag filter restricts sources and excludes the
+    /// kinds that carry no tags (packs/claims/runs/cards/units), the same
+    /// way a date filter excludes claims.
+    pub tag: Option<String>,
 }
 
 /// One result row, kind-tagged, with a printable line and a link target.
@@ -61,13 +70,49 @@ pub fn run_query(model: &IndexModel, q: &Query) -> Vec<Hit> {
         Some(prefix) => d.is_some_and(|d| d.starts_with(prefix)),
     };
     let kind_ok = |k: QueryKind| q.kind.map(|want| want == k).unwrap_or(true);
+    // Normalized once so `--tag Claude_Code` matches the canonical form.
+    let tag = q.tag.as_deref().and_then(ovp_domain::tags::normalize_tag);
+    let tag_ok = |tags: &[String]| match &tag {
+        None => true,
+        Some(t) => tags.iter().any(|have| have == t),
+    };
 
     let mut hits = Vec::new();
+
+    // The vocabulary listing is explicit-only (never in the all-kinds sweep):
+    // one row per canonical tag over the status/date-filtered sources, count
+    // descending. `term` narrows by substring; a `--tag` filter is exact.
+    if q.kind == Some(QueryKind::Tags) {
+        let mut counts: std::collections::BTreeMap<&str, usize> = std::collections::BTreeMap::new();
+        for s in &model.sources {
+            if !status_ok(source_status_str(s.status)) || !date_ok(s.date.as_deref()) {
+                continue;
+            }
+            for t in &s.tags {
+                *counts.entry(t.as_str()).or_default() += 1;
+            }
+        }
+        let mut rows: Vec<(&str, usize)> = counts
+            .into_iter()
+            .filter(|(t, _)| matches(&[t]) && tag.as_deref().map(|want| *t == want).unwrap_or(true))
+            .collect();
+        rows.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(b.0)));
+        for (t, n) in rows {
+            hits.push(Hit {
+                kind: "tag".into(),
+                status: "tag".into(),
+                line: format!("{t} ({n})"),
+                path: None,
+                id: Some(t.to_string()),
+            });
+        }
+        return hits;
+    }
 
     if kind_ok(QueryKind::Sources) {
         for s in &model.sources {
             let status = source_status_str(s.status);
-            if !status_ok(status) || !date_ok(s.date.as_deref()) {
+            if !status_ok(status) || !date_ok(s.date.as_deref()) || !tag_ok(&s.tags) {
                 continue;
             }
             let title = s.title.as_deref().unwrap_or("(untitled)");
@@ -79,6 +124,9 @@ pub fn run_query(model: &IndexModel, q: &Query) -> Vec<Hit> {
             let mut line = format!("{title} [{status}]");
             if let Some(d) = &s.date {
                 line.push_str(&format!(" {d}"));
+            }
+            if !s.tags.is_empty() {
+                line.push_str(&format!(" #{}", s.tags.join(" #")));
             }
             if s.fail_count > 0 {
                 line.push_str(&format!(" fails={}", s.fail_count));
@@ -98,7 +146,8 @@ pub fn run_query(model: &IndexModel, q: &Query) -> Vec<Hit> {
 
     if kind_ok(QueryKind::Packs) {
         for p in &model.packs {
-            if !status_ok("pack") || !date_ok(p.date.as_deref()) {
+            // Packs/claims/runs carry no tags; a tag filter excludes them.
+            if tag.is_some() || !status_ok("pack") || !date_ok(p.date.as_deref()) {
                 continue;
             }
             let cards_joined = p.card_titles.join(" | ");
@@ -128,8 +177,8 @@ pub fn run_query(model: &IndexModel, q: &Query) -> Vec<Hit> {
     if kind_ok(QueryKind::Claims) {
         for c in &model.claims {
             let status = claim_status_str(c.status);
-            // Claims carry no date; a date filter excludes them.
-            if !status_ok(status) || q.date.is_some() {
+            // Claims carry no date or tags; either filter excludes them.
+            if !status_ok(status) || q.date.is_some() || tag.is_some() {
                 continue;
             }
             let theme = c.theme.as_deref().unwrap_or("");
@@ -152,7 +201,7 @@ pub fn run_query(model: &IndexModel, q: &Query) -> Vec<Hit> {
 
     if kind_ok(QueryKind::Runs) {
         for r in &model.runs {
-            if !status_ok("run") || !date_ok(Some(&r.date)) {
+            if tag.is_some() || !status_ok("run") || !date_ok(Some(&r.date)) {
                 continue;
             }
             if !matches(&[&r.run_id, &r.date]) {
@@ -180,7 +229,8 @@ pub fn run_evidence_query(evidence: &EvidenceModel, q: &Query, limit: usize) -> 
     let term = q.term.as_deref().unwrap_or("");
     let mut scored: Vec<(f64, String, Hit)> = Vec::new();
 
-    if q.date.is_some() {
+    // Evidence rows carry no date or tags; either filter excludes them.
+    if q.date.is_some() || q.tag.is_some() {
         return Vec::new();
     }
 

--- a/crates/ovp-index/src/query.rs
+++ b/crates/ovp-index/src/query.rs
@@ -81,9 +81,13 @@ pub fn run_query(model: &IndexModel, q: &Query) -> Vec<Hit> {
             None => return Vec::new(),
         },
     };
-    let tag_ok = |tags: &[String]| match &tag {
+    // Operator tags and inferred backfill are both matchable — the filter's
+    // job is recall; the row display keeps the provenance visible (`~#x`).
+    let tag_ok = |s: &crate::model::SourceRow| match &tag {
         None => true,
-        Some(t) => tags.iter().any(|have| have == t),
+        Some(t) => {
+            s.tags.iter().any(|have| have == t) || s.tags_inferred.iter().any(|have| have == t)
+        }
     };
 
     let mut hits = Vec::new();
@@ -92,25 +96,39 @@ pub fn run_query(model: &IndexModel, q: &Query) -> Vec<Hit> {
     // one row per canonical tag over the status/date-filtered sources, count
     // descending. `term` narrows by substring; a `--tag` filter is exact.
     if q.kind == Some(QueryKind::Tags) {
-        let mut counts: std::collections::BTreeMap<&str, usize> = std::collections::BTreeMap::new();
+        // (operator count, inferred count) per canonical tag.
+        let mut counts: std::collections::BTreeMap<&str, (usize, usize)> =
+            std::collections::BTreeMap::new();
         for s in &model.sources {
             if !status_ok(source_status_str(s.status)) || !date_ok(s.date.as_deref()) {
                 continue;
             }
             for t in &s.tags {
-                *counts.entry(t.as_str()).or_default() += 1;
+                counts.entry(t.as_str()).or_default().0 += 1;
+            }
+            for t in &s.tags_inferred {
+                counts.entry(t.as_str()).or_default().1 += 1;
             }
         }
-        let mut rows: Vec<(&str, usize)> = counts
+        let mut rows: Vec<(&str, (usize, usize))> = counts
             .into_iter()
             .filter(|(t, _)| matches(&[t]) && tag.as_deref().map(|want| *t == want).unwrap_or(true))
             .collect();
-        rows.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(b.0)));
-        for (t, n) in rows {
+        rows.sort_by(|a, b| {
+            (b.1.0 + b.1.1)
+                .cmp(&(a.1.0 + a.1.1))
+                .then_with(|| a.0.cmp(b.0))
+        });
+        for (t, (user, inferred)) in rows {
+            let line = if inferred > 0 {
+                format!("{t} ({user}, ~{inferred})")
+            } else {
+                format!("{t} ({user})")
+            };
             hits.push(Hit {
                 kind: "tag".into(),
                 status: "tag".into(),
-                line: format!("{t} ({n})"),
+                line,
                 path: None,
                 id: Some(t.to_string()),
             });
@@ -121,7 +139,7 @@ pub fn run_query(model: &IndexModel, q: &Query) -> Vec<Hit> {
     if kind_ok(QueryKind::Sources) {
         for s in &model.sources {
             let status = source_status_str(s.status);
-            if !status_ok(status) || !date_ok(s.date.as_deref()) || !tag_ok(&s.tags) {
+            if !status_ok(status) || !date_ok(s.date.as_deref()) || !tag_ok(s) {
                 continue;
             }
             let title = s.title.as_deref().unwrap_or("(untitled)");
@@ -136,6 +154,9 @@ pub fn run_query(model: &IndexModel, q: &Query) -> Vec<Hit> {
             }
             if !s.tags.is_empty() {
                 line.push_str(&format!(" #{}", s.tags.join(" #")));
+            }
+            if !s.tags_inferred.is_empty() {
+                line.push_str(&format!(" ~#{}", s.tags_inferred.join(" ~#")));
             }
             if s.fail_count > 0 {
                 line.push_str(&format!(" fails={}", s.fail_count));

--- a/crates/ovp-index/src/query.rs
+++ b/crates/ovp-index/src/query.rs
@@ -70,8 +70,17 @@ pub fn run_query(model: &IndexModel, q: &Query) -> Vec<Hit> {
         Some(prefix) => d.is_some_and(|d| d.starts_with(prefix)),
     };
     let kind_ok = |k: QueryKind| q.kind.map(|want| want == k).unwrap_or(true);
-    // Normalized once so `--tag Claude_Code` matches the canonical form.
-    let tag = q.tag.as_deref().and_then(ovp_domain::tags::normalize_tag);
+    // Normalized once so `--tag Claude_Code` matches the canonical form. An
+    // explicit filter that normalizes to nothing (`tag=#`, whitespace) must
+    // match NOTHING — collapsing it to "no filter" would silently return
+    // every row.
+    let tag = match q.tag.as_deref() {
+        None => None,
+        Some(raw) => match ovp_domain::tags::normalize_tag(raw) {
+            Some(t) => Some(t),
+            None => return Vec::new(),
+        },
+    };
     let tag_ok = |tags: &[String]| match &tag {
         None => true,
         Some(t) => tags.iter().any(|have| have == t),

--- a/crates/ovp-index/tests/index_build.rs
+++ b/crates/ovp-index/tests/index_build.rs
@@ -889,6 +889,65 @@ fn tags_are_read_from_current_frontmatter_normalized_and_alias_resolved() {
 }
 
 #[test]
+fn inferred_tags_attach_only_to_untagged_sources_and_match_the_filter() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    let untagged_sha = place(
+        root,
+        "50-Inbox/01-Raw/2026-06/untagged.md",
+        "---\ntitle: Untagged Note\nsource: https://e.x/u\n---\nbody\n",
+    );
+    let tagged_sha = place(
+        root,
+        "50-Inbox/01-Raw/2026-06/tagged.md",
+        "---\ntitle: Tagged Note\nsource: https://e.x/t\ntags:\n  - rust\n---\nbody\n",
+    );
+    // Inferred file covers BOTH shas: the untagged row gains tags_inferred;
+    // the tagged row must ignore its (stale) entry entirely.
+    place(
+        root,
+        ".ovp/tags/inferred.json",
+        &format!(
+            r#"{{"schema":"ovp.tags-inferred/v1","model":"m","entries":{{
+                "{untagged_sha}": [{{"tag":"agent","score":0.7,"support":3}}],
+                "{tagged_sha}": [{{"tag":"python","score":0.5,"support":2}}]
+            }}}}"#
+        ),
+    );
+
+    let model = build_index(root, "2026-06-09", None).unwrap();
+    let untagged = model.sources.iter().find(|s| s.sha256 == untagged_sha).unwrap();
+    assert!(untagged.tags.is_empty());
+    assert_eq!(untagged.tags_inferred, vec!["agent"]);
+    let tagged = model.sources.iter().find(|s| s.sha256 == tagged_sha).unwrap();
+    assert_eq!(tagged.tags, vec!["rust"]);
+    assert!(tagged.tags_inferred.is_empty(), "hand-tagging retires inference");
+
+    // The tag filter matches inferred tags; the line marks them `~#`.
+    let hits = run_query(
+        &model,
+        &Query {
+            tag: Some("agent".into()),
+            ..Default::default()
+        },
+    );
+    assert_eq!(hits.len(), 1);
+    assert!(hits[0].line.contains("~#agent"), "{}", hits[0].line);
+
+    // Vocabulary listing separates operator and inferred counts.
+    let vocab = run_query(
+        &model,
+        &Query {
+            kind: Some(QueryKind::Tags),
+            ..Default::default()
+        },
+    );
+    let lines: Vec<&str> = vocab.iter().map(|h| h.line.as_str()).collect();
+    assert_eq!(lines, vec!["agent (0, ~1)", "rust (1)"]);
+}
+
+#[test]
 fn broken_alias_table_fails_the_build_loudly() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();

--- a/crates/ovp-index/tests/index_build.rs
+++ b/crates/ovp-index/tests/index_build.rs
@@ -817,3 +817,88 @@ fn empty_vault_builds_an_empty_model() {
     assert_eq!(model.totals.claims_durable, 0);
     assert_eq!(model.totals.runs, 0);
 }
+
+#[test]
+fn tags_are_read_from_current_frontmatter_normalized_and_alias_resolved() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    // Vault frontmatter is the per-source tag truth: raw variants + intake
+    // boilerplate in the note; the alias table merges `ai-agents` → `agent`.
+    place(
+        root,
+        "50-Inbox/01-Raw/2026-06/tagged.md",
+        "---\ntitle: Tagged Note\nsource: https://e.x/t\ntags:\n  - clippings\n  - pinboard\n  - AI Agents\n  - Claude_Code\n  - 大模型\n---\nbody\n",
+    );
+    place(
+        root,
+        ".ovp/tags/aliases.toml",
+        "[aliases]\n\"ai-agents\" = \"agent\"\n",
+    );
+    // A note with only boilerplate tags surfaces none.
+    place(
+        root,
+        "50-Inbox/01-Raw/2026-06/plain.md",
+        "---\ntitle: Plain Note\nsource: https://e.x/p\ntags:\n  - clippings\n---\nbody\n",
+    );
+
+    let model = build_index(root, "2026-06-09", None).unwrap();
+
+    let tagged = model
+        .sources
+        .iter()
+        .find(|s| s.title.as_deref() == Some("Tagged Note"))
+        .unwrap();
+    assert_eq!(tagged.tags, vec!["agent", "claude-code", "大模型"]);
+    let plain = model
+        .sources
+        .iter()
+        .find(|s| s.title.as_deref() == Some("Plain Note"))
+        .unwrap();
+    assert!(plain.tags.is_empty());
+
+    // Rebuild determinism holds with tags attached.
+    let again = build_index_at(root, "2026-06-09", None, "2026-06-09T00:00:00Z").unwrap();
+    let twice = build_index_at(root, "2026-06-09", None, "2026-06-09T00:00:00Z").unwrap();
+    assert_eq!(again, twice);
+
+    // A tag filter restricts sources (variant spelling normalizes before
+    // matching) and excludes tagless kinds instead of leaking them.
+    let hits = run_query(
+        &model,
+        &Query {
+            tag: Some("Claude_Code".into()),
+            ..Default::default()
+        },
+    );
+    assert_eq!(hits.len(), 1, "{hits:?}");
+    assert_eq!(hits[0].kind, "source");
+    assert!(hits[0].line.contains("#agent #claude-code"), "{}", hits[0].line);
+
+    // `--kind tags` lists the canonical vocabulary with counts, never the
+    // boilerplate capture tags.
+    let vocab = run_query(
+        &model,
+        &Query {
+            kind: Some(QueryKind::Tags),
+            ..Default::default()
+        },
+    );
+    let lines: Vec<&str> = vocab.iter().map(|h| h.line.as_str()).collect();
+    assert_eq!(lines, vec!["agent (1)", "claude-code (1)", "大模型 (1)"]);
+}
+
+#[test]
+fn broken_alias_table_fails_the_build_loudly() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    place(
+        root,
+        "50-Inbox/01-Raw/2026-06/x.md",
+        "---\ntitle: X\nsource: https://e.x/x\n---\nbody\n",
+    );
+    place(root, ".ovp/tags/aliases.toml", "[aliases]\n\"a\" = \"b\"\n\"b\" = \"c\"\n");
+
+    let err = build_index(root, "2026-06-09", None).unwrap_err();
+    assert!(err.contains("chain"), "{err}");
+}

--- a/crates/ovp-mcp/src/lib.rs
+++ b/crates/ovp-mcp/src/lib.rs
@@ -6,6 +6,7 @@ use std::io::{self, BufRead, Write};
 use std::path::PathBuf;
 
 use ovp_domain::VaultLayout;
+use ovp_domain::tags::{TagAliases, normalize_tag};
 use ovp_index::{read_index, run_query, IndexModel, Query, QueryKind};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -147,14 +148,15 @@ fn handle_tools_list() -> Result<Value, RpcError> {
         "tools": [
             {
                 "name": "find",
-                "description": "Query the OVP index: sources, packs, claims, runs. Filter by kind, status, date, or free-text term.",
+                "description": "Query the OVP index: sources, packs, claims, runs, tags. Filter by kind, status, date, tag, or free-text term.",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
                         "term": { "type": "string", "description": "Free-text search term" },
-                        "kind": { "type": "string", "enum": ["sources", "packs", "claims", "runs"] },
+                        "kind": { "type": "string", "enum": ["sources", "packs", "claims", "runs", "tags"] },
                         "status": { "type": "string" },
-                        "date": { "type": "string", "description": "Date prefix (YYYY or YYYY-MM or YYYY-MM-DD)" }
+                        "date": { "type": "string", "description": "Date prefix (YYYY or YYYY-MM or YYYY-MM-DD)" },
+                        "tag": { "type": "string", "description": "Canonical tag filter over sources (kind=tags lists the vocabulary)" }
                     }
                 }
             },
@@ -200,17 +202,29 @@ fn tool_find(state: &McpState, args: &Value) -> Result<Value, RpcError> {
     let model = state.load_model()
         .ok_or_else(|| RpcError { code: -32000, message: "Index not available".into() })?;
 
+    // A queried alias resolves to its canonical tag, same as `ovp2 find`.
+    // A broken alias table degrades to normalize-only here (a read tool
+    // should answer, not crash); `ovp2 index` is where breakage fails loud.
+    let tag = args.get("tag").and_then(|v| v.as_str()).map(|raw| {
+        let aliases = TagAliases::load(&state.vault_root).unwrap_or_default();
+        match normalize_tag(raw) {
+            Some(n) => aliases.resolve(&n).to_string(),
+            None => raw.to_string(),
+        }
+    });
     let query = Query {
         kind: args.get("kind").and_then(|v| v.as_str()).and_then(|k| match k {
             "sources" => Some(QueryKind::Sources),
             "packs" => Some(QueryKind::Packs),
             "claims" => Some(QueryKind::Claims),
             "runs" => Some(QueryKind::Runs),
+            "tags" => Some(QueryKind::Tags),
             _ => None,
         }),
         status: args.get("status").and_then(|v| v.as_str()).map(String::from),
         date: args.get("date").and_then(|v| v.as_str()).map(String::from),
         term: args.get("term").and_then(|v| v.as_str()).map(String::from),
+        tag,
     };
 
     let hits = run_query(&model, &query);
@@ -226,7 +240,7 @@ fn tool_search(state: &McpState, args: &Value) -> Result<Value, RpcError> {
         .ok_or_else(|| RpcError { code: -32000, message: "Index not available".into() })?;
 
     let term = args.get("query").and_then(|v| v.as_str()).map(String::from);
-    let query = Query { kind: None, status: None, date: None, term };
+    let query = Query { kind: None, status: None, date: None, term, tag: None };
     let hits = run_query(&model, &query);
     let text = serde_json::to_string_pretty(&hits).unwrap_or_else(|_| "[]".into());
 

--- a/crates/ovp-publish/src/lib.rs
+++ b/crates/ovp-publish/src/lib.rs
@@ -454,6 +454,7 @@ mod tests {
             fail_count: 0,
             last_reason: None,
             tags: Vec::new(),
+            tags_inferred: Vec::new(),
         }
     }
 

--- a/crates/ovp-publish/src/lib.rs
+++ b/crates/ovp-publish/src/lib.rs
@@ -167,7 +167,7 @@ fn write_api_tree(
     write_json(&api.join("themes.json"), &bodies::themes_body(records))?;
     write_json(&api.join("flow.json"), &bodies::flow_body(public))?;
     write_json(&api.join("settings.json"), &bodies::settings_public_body(Some(public)))?;
-    let empty = Query { kind: None, status: None, date: None, term: None };
+    let empty = Query { kind: None, status: None, date: None, term: None, tag: None };
     write_json(&api.join("search-index.json"), &bodies::find_body(public, &empty))?;
     files += 5;
 
@@ -453,6 +453,7 @@ mod tests {
             pack_dir: Some("40-Resources/Reader/case1".into()),
             fail_count: 0,
             last_reason: None,
+            tags: Vec::new(),
         }
     }
 

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -1931,6 +1931,7 @@ mod tests {
                 fail_count: 0,
                 last_reason: None,
                 tags: Vec::new(),
+                tags_inferred: Vec::new(),
             }],
             packs: vec![PackRow {
                 pack_dir: "40-Resources/Reader/good".into(),
@@ -2449,6 +2450,7 @@ mod tests {
             fail_count: 0,
             last_reason: None,
             tags: Vec::new(),
+            tags_inferred: Vec::new(),
         }
     }
 

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -633,17 +633,29 @@ fn handle_find(state: &AppState, url: &str) -> Response<std::io::Cursor<Vec<u8>>
     };
 
     let params = parse_query_string(url);
+    // Alias-resolve the tag param the same way `ovp2 find` does; a broken
+    // alias table degrades to normalize-only (a read endpoint should answer,
+    // not 500 — `ovp2 index` is where table breakage fails loud).
+    let tag = params.get("tag").map(|raw| {
+        let aliases = ovp_domain::tags::TagAliases::load(&state.vault_root).unwrap_or_default();
+        match ovp_domain::tags::normalize_tag(raw) {
+            Some(n) => aliases.resolve(&n).to_string(),
+            None => raw.clone(),
+        }
+    });
     let query = Query {
         kind: params.get("kind").and_then(|k| match k.as_str() {
             "sources" => Some(QueryKind::Sources),
             "packs" => Some(QueryKind::Packs),
             "claims" => Some(QueryKind::Claims),
             "runs" => Some(QueryKind::Runs),
+            "tags" => Some(QueryKind::Tags),
             _ => None,
         }),
         status: params.get("status").cloned(),
         date: params.get("date").cloned(),
         term: params.get("term").cloned(),
+        tag,
     };
 
     let body = bodies::find_body(&model, &query).to_string();
@@ -679,6 +691,7 @@ fn handle_search(state: &AppState, url: &str) -> Response<std::io::Cursor<Vec<u8
         status: None,
         date: None,
         term,
+        tag: None,
     };
     let body = bodies::find_body(&model, &query).to_string();
     json_stamped(200, &body, Some(&model))
@@ -1917,6 +1930,7 @@ mod tests {
                 pack_dir: Some("40-Resources/Reader/good".into()),
                 fail_count: 0,
                 last_reason: None,
+                tags: Vec::new(),
             }],
             packs: vec![PackRow {
                 pack_dir: "40-Resources/Reader/good".into(),
@@ -2434,6 +2448,7 @@ mod tests {
             pack_dir: None,
             fail_count: 0,
             last_reason: None,
+            tags: Vec::new(),
         }
     }
 

--- a/docs/stage-tags-product.md
+++ b/docs/stage-tags-product.md
@@ -52,8 +52,10 @@ the theme communities already exist for any vault (`crystal-themes`:
 embeddings → Louvain → c-TF-IDF). Their per-community keywords ARE a
 candidate vocabulary: ~17 communities × top keywords ≈ 60–120 candidate tags,
 bilingual, corpus-derived, no LLM. Floor behavior with no LLM configured:
-every source inherits its community's top keyword(s) as `tags_inferred` —
-coarse but honest, and strictly better than nothing.
+every THEMED source inherits its community's top keyword(s) as
+`tags_inferred` — coarse but honest. Noise/unclassified packs (<5% on the
+validated recipe) deliberately get no floor (a wrong tag is worse than no
+tag; the run logs their count) and are covered by the LLM pass only.
 
 **LLM classification pass (optional, `--client live`, cassette-cached):**
 batched (~20 sources/call, same batching discipline as crystal-synth):

--- a/docs/stage-tags-product.md
+++ b/docs/stage-tags-product.md
@@ -1,0 +1,186 @@
+# Tags as a Product Surface — design anchor
+
+Status: direction approved by operator 2026-07-16. T0 shipped (PR #340 facet +
+plumbing, PR #341 tags-suggest). This doc designs T1–T3 and the two parallel
+tracks (theme deepening, Tier-0 URL entities). Nothing below is implemented
+unless marked shipped.
+
+## 0. Why this doc exists
+
+T0 was built against the operator's own vault: pinboard bookmarks with a
+curated 116-tag vocabulary seeding everything. **A general user has none of
+that.** They have a markdown folder — maybe sparse, sloppy frontmatter tags,
+maybe zero. KMEM-class products are friendly to that user because tags simply
+appear (LLM labels everything, reuse-prompted). Our answer must match that UX
+floor without inheriting its failure mode (KMEM live vocabulary: 30.7%
+singleton rate; unconstrained LLM tagging is the best-documented failure in
+this space — Karakeep/Readwise/Raindrop all converged on closed vocabularies).
+
+### Personas
+
+| Persona | Corpus | Tags today | T0 behavior |
+|---|---|---|---|
+| P0 curator (operator) | pinboard + clipper | curated vocabulary | full stack works |
+| P1 md-only | markdown folder | **zero tags** | nothing — no vocabulary, no kNN signal |
+| P2 casual | markdown + some frontmatter | sparse, sloppy | partial — alias pipe works, backfill weak |
+
+The product gap is P1/P2. T1 closes it.
+
+## 1. Principles (carried from the research round + M34 process rules)
+
+1. **Humans/code own the vocabulary; the LLM only classifies into it.**
+   Vocabulary *invention* is allowed only as capped proposals that are
+   embedding-deduped against existing names before entering.
+2. **The pipeline never rewrites note frontmatter.** One deliberate exception:
+   an explicit per-source USER action in the UI (accept an inferred tag / add
+   a tag) writes that note's frontmatter — that is the user editing their
+   vault through the product, identical in kind to an Obsidian edit.
+3. **Everything derived is a projection**: `aliases.toml` (operator judgments),
+   `inferred.json`, `vocabulary.toml`, proposals — all rebuildable, none
+   ledger-grade.
+4. **Provenance always visible**: user `#tag` vs inferred `~#tag`, everywhere.
+5. **Decidability rule**: normalization/dedup/counting = code; classification
+   into a closed vocabulary = LLM permitted (not decidable ground truth);
+   free-form generation = never.
+
+## 2. T1 — cold-start bootstrap (`tags-bootstrap`)
+
+Goal: a P1 vault gets useful tags with zero manual work, KMEM-equivalent UX.
+
+**Vocabulary seed without pinboard (deterministic floor, 0 tokens):**
+the theme communities already exist for any vault (`crystal-themes`:
+embeddings → Louvain → c-TF-IDF). Their per-community keywords ARE a
+candidate vocabulary: ~17 communities × top keywords ≈ 60–120 candidate tags,
+bilingual, corpus-derived, no LLM. Floor behavior with no LLM configured:
+every source inherits its community's top keyword(s) as `tags_inferred` —
+coarse but honest, and strictly better than nothing.
+
+**LLM classification pass (optional, `--client live`, cassette-cached):**
+batched (~20 sources/call, same batching discipline as crystal-synth):
+
+- input: source title + card titles + the candidate vocabulary (names only);
+- the model picks 1–5 tags per source **from the vocabulary**, and may propose
+  at most 2 new tag names per batch;
+- proposed new names are normalized, then embedding-matched against the
+  existing vocabulary — cosine ≥ 0.9 → silently mapped to the existing tag
+  (the Karakeep lesson: put reuse in the MATCHING layer, not the prompt);
+  genuinely new survivors enter `vocabulary.toml` marked `origin = "llm"`;
+- assignments land in `tags_inferred` — never frontmatter.
+
+**`vocabulary.toml`** (new, projection): the closed list the classifier is
+allowed to use = user tags observed in the index ∪ accepted community
+keywords ∪ surviving LLM proposals. P0's pinboard vocabulary is just the
+degenerate case where the first term dominates. Users curate it in the UI
+(T2) or ignore it.
+
+**Self-healing (already shipped, T1 inherits it):** hand-tagging a source
+retires its inferred tags on the next index build; inferred names re-run
+through the alias/drop pipe.
+
+Incremental: `daily` runs classification only for sources with no entry in
+`inferred.json` (content-hash keyed like every cassette).
+
+**KMEM comparison, honestly stated:** same surface UX (tags appear on
+everything automatically); different guarantees — closed-vocabulary
+classification with embedding-gated growth (they prompt-and-hope), provenance
+separation (they can't tell user tags from machine tags), self-healing
+retirement (their labels accrete forever).
+
+## 3. T2 — curation & browsing UI
+
+All live-server only; the published static site stays read-only with tags
+redacted (unchanged).
+
+1. **`/tags` page** (Library sub-surface): the vocabulary browser — every
+   canonical tag with user/inferred counts (`156 + ~129`), sort by count/name,
+   text filter, click-through to the filtered Library. Empty state explains
+   the bootstrap path.
+2. **Curation inbox** (`/tags` tab): renders merge proposals as decision
+   cards — “`ai-agents` → `agent` · cosine 0.93 · 9 vs 22 sources · sample
+   titles…” with **Accept / Reject**.
+   - Accept → `POST /api/tags/alias` appends to `aliases.toml` + triggers
+     reindex. Reject → recorded as an `ignore = [["a","b"], …]` pair in
+     `aliases.toml`; `tags-suggest` skips ignored pairs on future runs so
+     rejected proposals never resurface. One curation file holds all
+     judgments (accepts as aliases, rejects as ignores, drops as drops).
+   - `tags-suggest` additionally emits `proposals.json` next to the md report
+     (same data, machine-readable) for this UI.
+3. **Per-source tag editing** (SourceDetailPage):
+   - inferred chips get an accept affordance: `~#memory ✓` →
+     `POST /api/source/:sha/tags` inserts the tag into that note's
+     frontmatter (principle 1's sanctioned exception, live server only, the
+     server re-reads/writes YAML through the same parser the intake uses);
+   - an add-tag box with **autocomplete over the vocabulary, reuse-first**
+     (write-time prevention beats repair — the folksonomy literature's oldest
+     result); free entry allowed, normalized on save.
+4. **The acceptance loop is the cold-start engine**: every accepted tag
+   becomes kNN training signal on the next build, so P1 vaults converge from
+   "LLM-classified" toward "user-curated" exactly as fast as the user cares
+   to click.
+
+## 4. T3 — granularity & hierarchy
+
+The generic-tag problem, now measured twice: 13.1% of tagged sources carry
+ONLY top-decile-frequency tags, and the kNN backfill mirrors the skew
+(post-drop real-vault run: `ai ~444`, `agent ~403`).
+
+1. **Specificity score** (code): IDF over tag document-frequency. A source
+   whose tags are all top-decile is *generic-only* and joins the backfill
+   queue with a constraint: only vote tags with df below half the source's
+   current minimum — i.e. inference may only ADD specificity, never more
+   generality. (Extends the inferred channel to non-empty sources under this
+   one rule; provenance display unchanged.)
+2. **Implications** (Danbooru pattern): co-occurrence subsumption
+   (Schmitz: propose `specific ⇒ generic` when P(generic|specific) ≥ 0.7 and
+   P(specific|generic) ≤ 0.3) → proposed in the curation inbox → accepted
+   into an `[implications]` section of `aliases.toml`. Facets render a
+   two-level rollup (generic groups its specifics); search on the generic
+   still matches. Generic tags are never split or deleted.
+
+## 5. Parallel tracks (separate PRs, designed here for review)
+
+### 5a. Theme deepening (operator-approved earlier)
+
+- **Sub-communities**: within each top-level community, re-run Louvain on the
+  induced subgraph at higher resolution (~2.5); communities of ≥3 members
+  become children (`parent_id` in `themes.json`, schema-additive). Keyword
+  labels per child; bilingual LLM labels reuse the existing `theme_label/v1`
+  cassette path.
+- **Theme summaries**: per top-level theme, one batched LLM synthesis over
+  member card titles/claims WITH citations, passed through the existing
+  deterministic citation verifier before it enters `themes.json`
+  (`summary`, `summary_citations` fields). The literature's one validated
+  organizational structure (GraphRAG community summaries), built the
+  LazyGraphRAG way: cheap, projection, rebuildable.
+- **Surfaces**: ThemeDetailPage gains children navigation + the cited
+  summary; terrain legend groups by parent.
+
+### 5b. Tier-0 URL entities (operator-approved: ship deterministic tier only)
+
+- **Extraction** (index build, regex, zero LLM, zero network): from
+  `source_url` + markdown link targets in the note body —
+  `github:owner/repo`, `arxiv:2504.19413`, `doi:10.x/y`, `npm:pkg`,
+  `crates:pkg`, `pypi:pkg`, `hn:item`. URL normalization (strip www/trailing
+  slash/.git, arXiv version suffix) = the entire identity problem, solved by
+  construction.
+- **Projection**: `.ovp/entities/url-entities.json` — entity id → {kind,
+  canonical URL, mentioning source sha256s}. SourceRow gains nothing; the
+  file is joined at render time (keeps the index lean).
+- **Surfaces**: entity chips on SourceDetail ("repo appears in 7 sources"),
+  `/entity/:id` page (mentioning sources + citing claims via pack join),
+  `find --entity`. Publish: included — URLs are already public content,
+  unlike personal tags.
+- **Tier-1 (Wikidata) stays experiment-gated** per the M34 kill-criteria
+  design; nothing here builds toward it.
+
+## 6. Sequencing
+
+| Phase | Depends on | LLM cost | Personas served |
+|---|---|---|---|
+| T1 bootstrap | themes (shipped) | one-time batched classify + daily increment; 0-token floor exists | P1/P2 get the product |
+| T2 curation UI | T1 (proposals.json) | 0 | all |
+| T3 granularity | T2 inbox | 0 | P0 + matured P1 |
+| 5a theme deepening | none | ~17 label + ~17 summary calls, cassette-cached | all |
+| 5b URL entities | none | 0 | all (tech corpora especially) |
+
+T1 → T2 is the product-critical path. 5a/5b are parallel-friendly.


### PR DESCRIPTION
## What

T1 of `docs/stage-tags-product.md` (stacked: #340 ← #341 ← this): the P1 persona fix — a md-only vault with **zero tags** now gets useful tags with zero manual work, KMEM-equivalent UX under our constraints.

- **`vocabulary.toml`** — the CLOSED list the classifier picks from: user tags ∪ theme-community c-TF-IDF keywords ∪ surviving LLM proposals. Persistent `banned` list gates every insert AND retires already-inferred occurrences at persistence; llm entries delete permanently, user/community entries ban via the list (documented honestly).
- **Deterministic floor (0 tokens)** — every themed target source inherits its community's top keywords as `method:"community"` inferred tags; noise packs (<5%) are deliberately uncovered (wrong tag > no tag) and logged. The floor + vocabulary are **checkpointed before any fallible LLM work**; per-batch failures degrade to the floor, never erase it.
- **LLM classification (`--client live`, cassette-cached, 20/batch)** — picks 1–5 tags per source FROM the vocabulary; replies must cover the batch id set exactly (missing/dup/out-of-range = parse error → cassette invalidated → retry). ≤2 new names per batch admitted only after normalize + alias + **embedding dedup ≥0.9 against the vocabulary** (no embedder + cold cache → proposals discarded; the closed vocabulary never grows unverified). Proposals are unusable in their own batch.
- **`daily` increment** — after its projection rebuild, daily runs the bootstrap best-effort (replay = floor only, live = classify) and re-rebuilds when anything landed, so unattended P1/P2 vaults tag new content the same run it arrives.
- **Precedence** — targets = no operator tags AND no kNN entry; `tags-suggest` now merges instead of clobbering (bootstrap entries survive where kNN has no vote); hand-tagging retires everything (unchanged).

## Real-vault verification (MiniMax live endpoint)

98 leftover sources (post-kNN): 48 floor-tagged, 92–97 LLM-classified across 5 batches; admitted names across runs: `ai-economics`, `kv-cache-compression`, `dynamic-comic`, `outcome-loop`, `supermemory` — all genuinely new, none respellings (embed-dedup active). Spot-checks show specific-over-generic picks (`crypto/defi/prediction-market`, `p2p/real-time/webrtc`).

## Gates

84 Rust suites green; clippy clean; codex review ×3 rounds — final GATE PASS, all findings fixed (3 P1: clippy gate, embed-dedup, daily wiring; 5 P2: merge preservation, honest bans + retirement, strict batch parse, floor checkpoint, noise-pack honesty).