### PR TITLE
fix(tags): #340 bot-review follow-up (race-dropped by the squash merge)

### DIFF
--- a/console-ui/src/pages/LibraryPage.tsx
+++ b/console-ui/src/pages/LibraryPage.tsx
@@ -81,9 +81,11 @@ function LibraryBody({ model }: { model: IndexModel }) {
   // when the index carries no tags (pre-tag index or redacted public model).
   const TAG_FACET_LIMIT = 15;
   const tagFacet = tagCounts.slice(0, TAG_FACET_LIMIT);
+  let hiddenTagCount = Math.max(0, tagCounts.length - TAG_FACET_LIMIT);
   if (tag && !tagFacet.some(([t]) => t === tag)) {
     const active = tagCounts.find(([t]) => t === tag);
     tagFacet.push(active ?? [tag, 0]);
+    if (active) hiddenTagCount -= 1; // revealed below, no longer hidden
   }
 
   return (
@@ -156,9 +158,9 @@ function LibraryBody({ model }: { model: IndexModel }) {
                 </li>
               ))}
             </ul>
-            {tagCounts.length > TAG_FACET_LIMIT && (
+            {hiddenTagCount > 0 && (
               <p className="muted sm">
-                +{tagCounts.length - TAG_FACET_LIMIT} {t('library.moreTags')}
+                +{hiddenTagCount} {t('library.moreTags')}
               </p>
             )}
           </div>
@@ -216,7 +218,10 @@ function LibraryBody({ model }: { model: IndexModel }) {
                         key={tg}
                         type="button"
                         className={`tag-chip${tag === tg ? ' active' : ''}`}
-                        onClick={() => setParam('tag', tag === tg ? null : tg)}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setParam('tag', tag === tg ? null : tg);
+                        }}
                       >
                         #{tg}
                       </button>

--- a/crates/ovp-cli/src/commands/index_cmd.rs
+++ b/crates/ovp-cli/src/commands/index_cmd.rs
@@ -5,7 +5,7 @@
 
 use std::path::PathBuf;
 
-use ovp_domain::tags::{TagAliases, normalize_tag};
+use ovp_domain::tags::TagAliases;
 use ovp_index::{
     build_evidence, build_index_with_progress, read_evidence, read_index, run_evidence_query,
     run_query, write_evidence, write_index, Query, QueryKind,
@@ -79,9 +79,9 @@ pub fn run_find(args: FindArgs) -> Result<(), CliError> {
         None => None,
         Some(raw) => {
             let aliases = TagAliases::load(&args.vault_root).map_err(CliError::Io)?;
-            let normalized = normalize_tag(raw)
-                .ok_or_else(|| CliError::Io(format!("--tag {raw:?} normalizes to nothing")))?;
-            Some(aliases.resolve(&normalized).to_string())
+            Some(aliases.resolve_raw(raw).ok_or_else(|| {
+                CliError::Io(format!("--tag {raw:?} normalizes to nothing"))
+            })?)
         }
     };
     let query = Query {

--- a/crates/ovp-domain/src/tags.rs
+++ b/crates/ovp-domain/src/tags.rs
@@ -127,6 +127,15 @@ impl TagAliases {
                      capture-mechanism tags never surface as content facets"
                 ));
             }
+            // Boilerplate is filtered BEFORE alias resolution, so an alias
+            // keyed on it could never fire — dead config fails loud like
+            // every other structural-rot case here.
+            if BOILERPLATE_TAGS.contains(&alias.as_str()) {
+                return Err(format!(
+                    "tag aliases: {alias:?} is a boilerplate capture tag; it is \
+                     filtered before alias resolution, so this entry can never fire"
+                ));
+            }
         }
         Ok(Self { map, drop })
     }
@@ -146,6 +155,14 @@ impl TagAliases {
     /// Canonical form of an already-normalized tag.
     pub fn resolve<'a>(&'a self, normalized: &'a str) -> &'a str {
         self.map.get(normalized).map(String::as_str).unwrap_or(normalized)
+    }
+
+    /// Resolve a RAW user-supplied tag (query params, CLI flags): normalize,
+    /// then alias-resolve. `None` when nothing survives normalization — the
+    /// caller decides whether that is an error (CLI) or a match-nothing
+    /// passthrough (read endpoints). The one helper every query surface uses.
+    pub fn resolve_raw(&self, raw: &str) -> Option<String> {
+        normalize_tag(raw).map(|n| self.resolve(&n).to_string())
     }
 
     pub fn is_empty(&self) -> bool {

--- a/crates/ovp-mcp/src/lib.rs
+++ b/crates/ovp-mcp/src/lib.rs
@@ -6,7 +6,7 @@ use std::io::{self, BufRead, Write};
 use std::path::PathBuf;
 
 use ovp_domain::VaultLayout;
-use ovp_domain::tags::{TagAliases, normalize_tag};
+use ovp_domain::tags::TagAliases;
 use ovp_index::{read_index, run_query, IndexModel, Query, QueryKind};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -207,10 +207,7 @@ fn tool_find(state: &McpState, args: &Value) -> Result<Value, RpcError> {
     // should answer, not crash); `ovp2 index` is where breakage fails loud.
     let tag = args.get("tag").and_then(|v| v.as_str()).map(|raw| {
         let aliases = TagAliases::load(&state.vault_root).unwrap_or_default();
-        match normalize_tag(raw) {
-            Some(n) => aliases.resolve(&n).to_string(),
-            None => raw.to_string(),
-        }
+        aliases.resolve_raw(raw).unwrap_or_else(|| raw.to_string())
     });
     let query = Query {
         kind: args.get("kind").and_then(|v| v.as_str()).and_then(|k| match k {

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -638,10 +638,7 @@ fn handle_find(state: &AppState, url: &str) -> Response<std::io::Cursor<Vec<u8>>
     // not 500 — `ovp2 index` is where table breakage fails loud).
     let tag = params.get("tag").map(|raw| {
         let aliases = ovp_domain::tags::TagAliases::load(&state.vault_root).unwrap_or_default();
-        match ovp_domain::tags::normalize_tag(raw) {
-            Some(n) => aliases.resolve(&n).to_string(),
-            None => raw.clone(),
-        }
+        aliases.resolve_raw(raw).unwrap_or_else(|| raw.clone())
     });
     let query = Query {
         kind: params.get("kind").and_then(|k| match k.as_str() {


### PR DESCRIPTION
The #340 squash merge raced the final push and dropped this commit: TagAliases::resolve_raw shared by CLI/MCP/server, boilerplate alias keys fail loud, tag-chip stopPropagation, exact hidden-tag facet count. Tests green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved tag alias handling across search, CLI, and MCP queries for more consistent results.
  * Raw tag inputs are now normalized and resolved through configured aliases automatically.

* **Bug Fixes**
  * Corrected the “more tags” count when an active tag is outside the initially displayed list.
  * Prevented tag-chip clicks from triggering unintended navigation.
  * Added clearer errors for invalid or empty tag inputs.
  * Improved validation for unusable tag-alias configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->