### PR TITLE
feat(tags): tags-bootstrap — cold-start tagging without a curated vocabulary (T1)

### DIFF
--- a/crates/ovp-cli/src/commands/daily.rs
+++ b/crates/ovp-cli/src/commands/daily.rs
@@ -552,6 +552,31 @@ fn run_inner(
             );
         }
 
+    // Tag-bootstrap increment (T1, docs/stage-tags-product.md §2): classify
+    // sources that arrived untagged into the closed vocabulary. Best-effort —
+    // an error warns and never aborts the run; no themes.json → the call
+    // explains and exits 0 (bootstrap embeds nothing, so no surprise
+    // downloads). Uses daily's client kind: replay = deterministic floor
+    // only, live = cassette-cached classification. A second (cheap)
+    // projection rebuild surfaces fresh inferred tags this run instead of
+    // tomorrow.
+    match crate::commands::tags_bootstrap::run(crate::commands::tags_bootstrap::TagsBootstrapArgs {
+        vault_root: args.vault_root.clone(),
+        client_kind: args.client_kind,
+        cache_dir: None,
+        batch_size: 20,
+        max_new_per_batch: 2,
+        refresh: false,
+    }) {
+        Ok(n) if n > 0 => {
+            if let Err(e) = rebuild_projection(&args.vault_root, &args.date, &args.run_id) {
+                sayln!("  tags: projection refresh after bootstrap failed ({e}) — next rebuild will surface them");
+            }
+        }
+        Ok(_) => {}
+        Err(e) => sayln!("  tags: bootstrap skipped ({e})"),
+    }
+
     if failed > 0 {
         // Honest retry guidance: a 3rd failure means the source is now
         // BLOCKED, not silently retried.

--- a/crates/ovp-cli/src/commands/daily.rs
+++ b/crates/ovp-cli/src/commands/daily.rs
@@ -693,7 +693,7 @@ fn stale_theme_packs(
             .packs
             .iter()
             .filter(|p| {
-                let case_id = p.pack_dir.rsplit('/').next().unwrap_or(&p.pack_dir);
+                let case_id = ovp_domain::vault_layout::pack_case_id(&p.pack_dir);
                 !t.packs.contains_key(case_id)
             })
             .count(),

--- a/crates/ovp-cli/src/commands/mod.rs
+++ b/crates/ovp-cli/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub mod crystal_synth_ab;
 pub mod crystal_synth_llm;
 pub mod crystal_terrain;
 pub mod crystal_themes;
+pub mod tags_bootstrap;
 pub mod tags_suggest;
 pub mod crystal_write;
 pub mod console_cmd;

--- a/crates/ovp-cli/src/commands/tags_bootstrap.rs
+++ b/crates/ovp-cli/src/commands/tags_bootstrap.rs
@@ -1,0 +1,373 @@
+//! `tags-bootstrap` — cold-start tagging for vaults WITHOUT a curated tag
+//! vocabulary (the P1 md-only persona in `docs/stage-tags-product.md` §2).
+//!
+//! Two layers, both landing in `tags_inferred` (never frontmatter):
+//!
+//! 1. **Deterministic floor (0 tokens, always runs)**: the theme communities
+//!    (`crystal-themes`, required input) already carve any corpus into ~17
+//!    clusters with c-TF-IDF keywords. Community keywords seed the closed
+//!    vocabulary; every target source inherits its community's top keywords
+//!    as `method:"community"` inferred tags. Coarse but honest.
+//! 2. **LLM classification (`--client live`, cassette-cached)**: batched
+//!    sources are classified INTO the closed vocabulary (title + card
+//!    titles). The model may propose a few new names per batch; proposals
+//!    are normalized, alias-resolved, and admitted only if genuinely new —
+//!    then persisted in `vocabulary.toml` with `origin:"llm"` so the
+//!    operator can curate them. `method:"llm"` entries replace the floor.
+//!
+//! Targets = sources with NO operator tags and NO existing inferred entry
+//! (kNN backfill from `tags-suggest` outranks bootstrap; `--refresh` redoes
+//! bootstrap-method entries but never touches knn ones). Everything written
+//! is a projection; delete the files to reset.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use ovp_domain::tags::{
+    ClassifyInput, InferredTag, TAGS_INFERRED_SCHEMA, TagAliases, TagOrigin, TagVocabulary,
+    TagsInferredFile, canonical_tags, normalize_tag, parse_tag_classify, tag_classify_request,
+};
+use ovp_domain::vault_layout::VaultLayout;
+use ovp_index::read_index;
+
+use crate::CliError;
+use crate::commands::client::{ClientKind, build_client};
+use crate::commands::crystal_synth::call_and_parse;
+
+/// Fixed confidence bands (see `InferredTag.score` docs).
+const LLM_SCORE: f64 = 0.8;
+const FLOOR_SCORE: f64 = 0.4;
+/// Community keywords inherited by a floor-tagged source.
+const FLOOR_KEYWORDS: usize = 2;
+/// Community keywords contributed to the vocabulary per community.
+const VOCAB_KEYWORDS: usize = 3;
+
+pub struct TagsBootstrapArgs {
+    pub vault_root: PathBuf,
+    pub client_kind: ClientKind,
+    /// Cassette root for `tag_classify/v1`. Default:
+    /// `<vault-root>/.ovp/cassettes/tags`.
+    pub cache_dir: Option<PathBuf>,
+    /// Sources per classification call.
+    pub batch_size: usize,
+    /// New-name proposals admitted per batch.
+    pub max_new_per_batch: usize,
+    /// Redo bootstrap-method entries (knn entries are never touched).
+    pub refresh: bool,
+}
+
+/// Validate one batch's picks against the closed vocabulary (pure,
+/// unit-tested): picked names are normalized + alias-resolved; anything not
+/// in the vocabulary is DROPPED (rule 1 violations never enter the
+/// projection); `new_tags` are admitted (normalized, alias-resolved,
+/// deduped, capped) only if absent from the vocabulary. Returns
+/// (per-source canonical tags, admitted new names in admission order).
+pub(crate) fn validate_batch(
+    picks: &BTreeMap<usize, Vec<String>>,
+    new_tags: &[String],
+    vocabulary: &TagVocabulary,
+    aliases: &TagAliases,
+    max_new: usize,
+) -> (BTreeMap<usize, Vec<String>>, Vec<String>) {
+    let mut admitted: Vec<String> = Vec::new();
+    for raw in new_tags {
+        if admitted.len() >= max_new {
+            break;
+        }
+        let canon = match canonical_tags(&[raw.as_str()], aliases).pop() {
+            Some(c) => c,
+            None => continue,
+        };
+        if !vocabulary.contains(&canon) && !admitted.contains(&canon) {
+            admitted.push(canon);
+        }
+    }
+    let mut out = BTreeMap::new();
+    for (id, tags) in picks {
+        let mut kept: Vec<String> = tags
+            .iter()
+            .filter_map(|t| canonical_tags(&[t.as_str()], aliases).pop())
+            .filter(|t| vocabulary.contains(t))
+            .collect();
+        kept.sort();
+        kept.dedup();
+        kept.truncate(5);
+        out.insert(*id, kept);
+    }
+    (out, admitted)
+}
+
+pub fn run(args: TagsBootstrapArgs) -> Result<(), CliError> {
+    let layout = VaultLayout::new();
+    let model = read_index(&args.vault_root).map_err(|e| {
+        CliError::Io(format!("tags-bootstrap: {e} — run `ovp2 index` first"))
+    })?;
+    let themes_path = args
+        .vault_root
+        .join(layout.crystal_store_dir())
+        .join("themes.json");
+    let themes = match ovp_domain::crystal::themes::ThemesFile::load(&themes_path)
+        .map_err(CliError::Io)?
+    {
+        Some(t) => t,
+        None => {
+            println!(
+                "tags-bootstrap: no themes.json — run `ovp2 crystal-themes` first \
+                 (the theme communities are the deterministic vocabulary seed)."
+            );
+            return Ok(());
+        }
+    };
+    let aliases = TagAliases::load(&args.vault_root).map_err(CliError::Io)?;
+
+    // ---- Vocabulary: user tags ∪ community keywords ∪ persisted llm ----
+    let mut vocabulary = TagVocabulary::default();
+    for s in &model.sources {
+        for t in &s.tags {
+            vocabulary.insert(t.clone(), TagOrigin::User);
+        }
+    }
+    for c in &themes.communities {
+        for kw in c.keywords.iter().take(VOCAB_KEYWORDS) {
+            for canon in canonical_tags(&[kw.as_str()], &aliases) {
+                vocabulary.insert(canon, TagOrigin::Community);
+            }
+        }
+    }
+    for (name, origin) in TagVocabulary::load(&args.vault_root)
+        .map_err(CliError::Io)?
+        .iter()
+    {
+        if origin == TagOrigin::Llm {
+            vocabulary.insert(name.to_string(), TagOrigin::Llm);
+        }
+    }
+
+    // ---- Targets: untagged, not already covered (unless --refresh) ----
+    let mut inferred = TagsInferredFile::load(&args.vault_root)
+        .map_err(CliError::Io)?
+        .unwrap_or_else(|| TagsInferredFile {
+            schema: TAGS_INFERRED_SCHEMA.into(),
+            model: String::new(),
+            params: BTreeMap::new(),
+            entries: BTreeMap::new(),
+        });
+    fn case_of(pack_dir: &str) -> &str {
+        pack_dir.rsplit(['/', '\\']).next().unwrap_or(pack_dir)
+    }
+    let card_titles: BTreeMap<&str, &[String]> = model
+        .packs
+        .iter()
+        .map(|p| (case_of(&p.pack_dir), p.card_titles.as_slice()))
+        .collect();
+    struct Target<'a> {
+        sha: &'a str,
+        title: String,
+        cards: Vec<String>,
+        community: Option<i64>,
+    }
+    let mut targets: Vec<Target> = Vec::new();
+    for s in &model.sources {
+        if !s.tags.is_empty() {
+            continue;
+        }
+        let covered = inferred.entries.get(&s.sha256).is_some_and(|e| {
+            e.iter().any(|t| t.method == "knn" || t.method.is_empty())
+                || (!args.refresh && !e.is_empty())
+        });
+        if covered {
+            continue;
+        }
+        let Some(case) = s.pack_dir.as_deref().map(case_of) else {
+            continue;
+        };
+        targets.push(Target {
+            sha: &s.sha256,
+            title: s.title.clone().unwrap_or_else(|| case.to_string()),
+            cards: card_titles
+                .get(case)
+                .map(|c| c.to_vec())
+                .unwrap_or_default(),
+            community: themes.packs.get(case).copied().filter(|&id| {
+                id != ovp_domain::crystal::themes::UNCLASSIFIED_ID
+            }),
+        });
+    }
+    println!(
+        "tags-bootstrap: vocabulary {} tag(s), {} target source(s)",
+        vocabulary.len(),
+        targets.len()
+    );
+    if targets.is_empty() {
+        vocabulary.save(&args.vault_root).map_err(CliError::Io)?;
+        println!("tags-bootstrap: nothing to do (vocabulary refreshed).");
+        return Ok(());
+    }
+
+    // ---- Layer 1: deterministic community-keyword floor ----
+    let community_keywords: BTreeMap<i64, Vec<String>> = themes
+        .communities
+        .iter()
+        .map(|c| {
+            let kws: Vec<String> = c
+                .keywords
+                .iter()
+                .flat_map(|kw| canonical_tags(&[kw.as_str()], &aliases))
+                .take(FLOOR_KEYWORDS)
+                .collect();
+            (c.id, kws)
+        })
+        .collect();
+    let mut floored = 0usize;
+    for t in &targets {
+        let Some(kws) = t.community.and_then(|id| community_keywords.get(&id)) else {
+            continue;
+        };
+        if kws.is_empty() {
+            continue;
+        }
+        let size = themes
+            .communities
+            .iter()
+            .find(|c| Some(c.id) == t.community)
+            .map(|c| c.size)
+            .unwrap_or(0);
+        inferred.entries.insert(
+            t.sha.to_string(),
+            kws.iter()
+                .map(|k| InferredTag {
+                    tag: k.clone(),
+                    score: FLOOR_SCORE,
+                    support: size,
+                    method: "community".into(),
+                })
+                .collect(),
+        );
+        floored += 1;
+    }
+    println!("  floor: {floored}/{} target(s) inherit community keywords", targets.len());
+
+    // ---- Layer 2: LLM classification into the closed vocabulary ----
+    let mut classified = 0usize;
+    let mut admitted_total = 0usize;
+    if matches!(args.client_kind, ClientKind::Live) {
+        let cassette_dir = args
+            .cache_dir
+            .clone()
+            .unwrap_or_else(|| args.vault_root.join(".ovp/cassettes/tags"));
+        let mut client = build_client(ClientKind::Live, &cassette_dir)?;
+        for chunk in targets.chunks(args.batch_size.max(1)) {
+            let inputs: Vec<ClassifyInput> = chunk
+                .iter()
+                .enumerate()
+                .map(|(i, t)| ClassifyInput {
+                    id: i,
+                    title: t.title.clone(),
+                    card_titles: t.cards.iter().take(6).cloned().collect(),
+                })
+                .collect();
+            // Scoped so the name borrows end before `vocabulary.insert` below
+            // (the request owns its text; it keeps no references).
+            let req = {
+                let vocab_names: Vec<&str> = vocabulary.names().collect();
+                tag_classify_request(&vocab_names, &inputs, args.max_new_per_batch)
+            };
+            let (reply, _repair) =
+                call_and_parse(client.as_mut(), &req, "tag-classify", parse_tag_classify)?;
+            let (picks, admitted) = validate_batch(
+                &reply.picks,
+                &reply.new_tags,
+                &vocabulary,
+                &aliases,
+                args.max_new_per_batch,
+            );
+            for name in admitted {
+                vocabulary.insert(name, TagOrigin::Llm);
+                admitted_total += 1;
+            }
+            for (i, t) in chunk.iter().enumerate() {
+                let Some(tags) = picks.get(&i).filter(|v| !v.is_empty()) else {
+                    continue; // floor entry (if any) stays
+                };
+                inferred.entries.insert(
+                    t.sha.to_string(),
+                    tags.iter()
+                        .map(|tag| InferredTag {
+                            tag: tag.clone(),
+                            score: LLM_SCORE,
+                            support: 0,
+                            method: "llm".into(),
+                        })
+                        .collect(),
+                );
+                classified += 1;
+            }
+            sayln!("  [{classified}/{}] classified …", targets.len());
+        }
+        println!(
+            "  classify: {classified} source(s) tagged from the vocabulary, \
+             {admitted_total} new name(s) admitted"
+        );
+    } else {
+        println!(
+            "  classify: skipped (replay client) — the community floor is the \
+             0-token result; add `--client live` for vocabulary classification."
+        );
+    }
+
+    // ---- Persist (vocabulary first: inferred references its names) ----
+    let vocab_path = vocabulary.save(&args.vault_root).map_err(CliError::Io)?;
+    if inferred.model.is_empty() {
+        inferred.model = "tags-bootstrap".into();
+    }
+    inferred
+        .params
+        .insert("bootstrap_batch_size".into(), args.batch_size as f64);
+    let inferred_path = inferred.save(&args.vault_root).map_err(CliError::Io)?;
+    println!("  vocabulary: {} tag(s) → {vocab_path}", vocabulary.len());
+    println!("  inferred: → {inferred_path}");
+    println!("tags-bootstrap: done. Rebuild the index (`ovp2 index`) to surface inferred tags.");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vocab(names: &[&str]) -> TagVocabulary {
+        let mut v = TagVocabulary::default();
+        for n in names {
+            v.insert((*n).to_string(), TagOrigin::User);
+        }
+        v
+    }
+
+    #[test]
+    fn validate_drops_out_of_vocab_picks_and_resolves_aliases() {
+        let aliases = TagAliases::parse("[aliases]\n\"ai-agents\" = \"agent\"\n").unwrap();
+        let v = vocab(&["agent", "memory"]);
+        let picks = BTreeMap::from([(0usize, vec![
+            "AI Agents".to_string(),   // alias → agent (in vocab)
+            "Memory".to_string(),      // normalize → memory (in vocab)
+            "hallucinated".to_string(), // not in vocab → dropped
+        ])]);
+        let (kept, admitted) = validate_batch(&picks, &[], &v, &aliases, 2);
+        assert_eq!(kept[&0], vec!["agent", "memory"]);
+        assert!(admitted.is_empty());
+    }
+
+    #[test]
+    fn validate_caps_and_dedups_new_names() {
+        let aliases = TagAliases::parse("").unwrap();
+        let v = vocab(&["agent"]);
+        let new = vec![
+            "Agent".to_string(),      // already in vocab → not admitted
+            "KV Cache".to_string(),   // → kv-cache admitted
+            "kv_cache".to_string(),   // duplicate after normalize → skipped
+            "third".to_string(),      // over the cap of 1 remaining? cap=2 → admitted
+            "fourth".to_string(),     // over cap → dropped
+        ];
+        let (_, admitted) = validate_batch(&BTreeMap::new(), &new, &v, &aliases, 2);
+        assert_eq!(admitted, vec!["kv-cache", "third"]);
+    }
+}

--- a/crates/ovp-cli/src/commands/tags_bootstrap.rs
+++ b/crates/ovp-cli/src/commands/tags_bootstrap.rs
@@ -88,13 +88,11 @@ pub(crate) fn validate_batch(
     }
     let mut out = BTreeMap::new();
     for (id, tags) in picks {
-        let mut kept: Vec<String> = tags
-            .iter()
-            .filter_map(|t| canonical_tags(&[t.as_str()], aliases).pop())
+        // One batched canonicalization per source (it sorts + dedups).
+        let mut kept: Vec<String> = canonical_tags(tags, aliases)
+            .into_iter()
             .filter(|t| vocabulary.contains(t))
             .collect();
-        kept.sort();
-        kept.dedup();
         kept.truncate(5);
         out.insert(*id, kept);
     }
@@ -109,43 +107,55 @@ const NEW_NAME_DEDUP_COSINE: f64 = 0.9;
 /// existing vocabulary name. Embeddings are name-only texts through the
 /// shared cache; unavailable embedder + cold cache → ALL proposals dropped
 /// (with a printed reason) — the closed vocabulary never grows unverified.
+/// `memo` carries name→vector across batches so the (large, mostly static)
+/// vocabulary is resolved once per run, not once per proposal-bearing batch.
 fn embed_dedup_new_names(
     candidates: Vec<String>,
     vocabulary: &TagVocabulary,
     embed_cache_dir: &std::path::Path,
+    memo: &mut BTreeMap<String, Vec<f32>>,
 ) -> Result<Vec<String>, CliError> {
     if candidates.is_empty() {
         return Ok(candidates);
     }
-    let docs: Vec<ThemeDoc> = vocabulary
+    let missing: Vec<String> = vocabulary
         .names()
         .map(str::to_string)
         .chain(candidates.iter().cloned())
-        .map(|name| {
-            let text = document_text(&name, "", 0);
-            let sha = ovp_embed::cache::text_sha256(&text);
-            ThemeDoc {
-                case_id: format!("tagname:{name}"),
-                title: name,
-                text,
-                sha,
-            }
-        })
+        .filter(|n| !memo.contains_key(n))
         .collect();
-    let Some(vectors) = resolve_vectors(&docs, embed_cache_dir)? else {
-        println!(
-            "  classify: {} new-name proposal(s) DISCARDED — embeddings unavailable, \
-             semantic dedup against the vocabulary is mandatory before admission",
-            candidates.len()
-        );
-        return Ok(Vec::new());
-    };
-    let n_vocab = vocabulary.len();
-    let mut kept = Vec::new();
-    for (i, name) in candidates.into_iter().enumerate() {
-        let v = &vectors[n_vocab + i];
-        let dup = vectors[..n_vocab]
+    if !missing.is_empty() {
+        let docs: Vec<ThemeDoc> = missing
             .iter()
+            .map(|name| {
+                let text = document_text(name, "", 0);
+                let sha = ovp_embed::cache::text_sha256(&text);
+                ThemeDoc {
+                    case_id: format!("tagname:{name}"),
+                    title: name.clone(),
+                    text,
+                    sha,
+                }
+            })
+            .collect();
+        let Some(vectors) = resolve_vectors(&docs, embed_cache_dir)? else {
+            println!(
+                "  classify: {} new-name proposal(s) DISCARDED — embeddings unavailable, \
+                 semantic dedup against the vocabulary is mandatory before admission",
+                candidates.len()
+            );
+            return Ok(Vec::new());
+        };
+        for (name, v) in missing.into_iter().zip(vectors) {
+            memo.insert(name, v);
+        }
+    }
+    let mut kept = Vec::new();
+    for name in candidates {
+        let Some(v) = memo.get(&name) else { continue };
+        let dup = vocabulary
+            .names()
+            .filter_map(|u| memo.get(u))
             .any(|u| cosine(u, v) >= NEW_NAME_DEDUP_COSINE);
         if dup {
             println!("  classify: proposal {name:?} maps to an existing vocabulary tag — skipped");
@@ -194,12 +204,15 @@ pub fn run(args: TagsBootstrapArgs) -> Result<usize, CliError> {
             vocabulary.insert(t.clone(), TagOrigin::User);
         }
     }
-    for c in &themes.communities {
-        for kw in c.keywords.iter().take(VOCAB_KEYWORDS) {
-            for canon in canonical_tags(&[kw.as_str()], &aliases) {
-                vocabulary.insert(canon, TagOrigin::Community);
-            }
-        }
+    // Set-shaped, so one batched canonicalization over all keywords is fine
+    // (unlike the floor below, which must preserve c-TF-IDF rank order).
+    let community_kws: Vec<&str> = themes
+        .communities
+        .iter()
+        .flat_map(|c| c.keywords.iter().take(VOCAB_KEYWORDS).map(String::as_str))
+        .collect();
+    for canon in canonical_tags(&community_kws, &aliases) {
+        vocabulary.insert(canon, TagOrigin::Community);
     }
     for (name, origin) in persisted.iter() {
         if origin == TagOrigin::Llm {
@@ -216,9 +229,7 @@ pub fn run(args: TagsBootstrapArgs) -> Result<usize, CliError> {
             params: BTreeMap::new(),
             entries: BTreeMap::new(),
         });
-    fn case_of(pack_dir: &str) -> &str {
-        pack_dir.rsplit(['/', '\\']).next().unwrap_or(pack_dir)
-    }
+    use ovp_domain::vault_layout::pack_case_id as case_of;
     let card_titles: BTreeMap<&str, &[String]> = model
         .packs
         .iter()
@@ -355,6 +366,8 @@ pub fn run(args: TagsBootstrapArgs) -> Result<usize, CliError> {
             .clone()
             .unwrap_or_else(|| args.vault_root.join(".ovp/cassettes/tags"));
         let mut client = build_client(ClientKind::Live, &cassette_dir)?;
+        // name→vector memo shared across batches (vocabulary resolved once).
+        let mut name_vectors: BTreeMap<String, Vec<f32>> = BTreeMap::new();
         for chunk in targets.chunks(args.batch_size.max(1)) {
             let inputs: Vec<ClassifyInput> = chunk
                 .iter()
@@ -397,7 +410,7 @@ pub fn run(args: TagsBootstrapArgs) -> Result<usize, CliError> {
             // No embedder + cold cache → proposals are DISCARDED (conservative:
             // the closed vocabulary must not grow unverified).
             let admitted =
-                embed_dedup_new_names(admitted, &vocabulary, &embed_cache_dir)?;
+                embed_dedup_new_names(admitted, &vocabulary, &embed_cache_dir, &mut name_vectors)?;
             for name in admitted {
                 vocabulary.insert(name, TagOrigin::Llm);
                 admitted_total += 1;

--- a/crates/ovp-cli/src/commands/tags_bootstrap.rs
+++ b/crates/ovp-cli/src/commands/tags_bootstrap.rs
@@ -183,7 +183,12 @@ pub fn run(args: TagsBootstrapArgs) -> Result<usize, CliError> {
     let aliases = TagAliases::load(&args.vault_root).map_err(CliError::Io)?;
 
     // ---- Vocabulary: user tags ∪ community keywords ∪ persisted llm ----
+    // Bans FIRST (they gate every insert), then user > community > llm.
+    let persisted = TagVocabulary::load(&args.vault_root).map_err(CliError::Io)?;
     let mut vocabulary = TagVocabulary::default();
+    for name in persisted.banned() {
+        vocabulary.ban(name.to_string());
+    }
     for s in &model.sources {
         for t in &s.tags {
             vocabulary.insert(t.clone(), TagOrigin::User);
@@ -196,10 +201,7 @@ pub fn run(args: TagsBootstrapArgs) -> Result<usize, CliError> {
             }
         }
     }
-    for (name, origin) in TagVocabulary::load(&args.vault_root)
-        .map_err(CliError::Io)?
-        .iter()
-    {
+    for (name, origin) in persisted.iter() {
         if origin == TagOrigin::Llm {
             vocabulary.insert(name.to_string(), TagOrigin::Llm);
         }
@@ -267,6 +269,8 @@ pub fn run(args: TagsBootstrapArgs) -> Result<usize, CliError> {
     }
 
     // ---- Layer 1: deterministic community-keyword floor ----
+    // Floor tags must be vocabulary members — a banned community keyword
+    // never reaches inferred.json.
     let community_keywords: BTreeMap<i64, Vec<String>> = themes
         .communities
         .iter()
@@ -275,6 +279,7 @@ pub fn run(args: TagsBootstrapArgs) -> Result<usize, CliError> {
                 .keywords
                 .iter()
                 .flat_map(|kw| canonical_tags(&[kw.as_str()], &aliases))
+                .filter(|kw| vocabulary.contains(kw))
                 .take(FLOOR_KEYWORDS)
                 .collect();
             (c.id, kws)
@@ -309,6 +314,15 @@ pub fn run(args: TagsBootstrapArgs) -> Result<usize, CliError> {
     }
     println!("  floor: {floored}/{} target(s) inherit community keywords", targets.len());
 
+    // Checkpoint the deterministic result BEFORE any fallible LLM work: a
+    // failed live pass must degrade to the zero-token floor, never to
+    // nothing (the floor is the whole point of the fallback contract).
+    vocabulary.save(&args.vault_root).map_err(CliError::Io)?;
+    if inferred.model.is_empty() {
+        inferred.model = "tags-bootstrap".into();
+    }
+    inferred.save(&args.vault_root).map_err(CliError::Io)?;
+
     // ---- Layer 2: LLM classification into the closed vocabulary ----
     let mut classified = 0usize;
     let mut admitted_total = 0usize;
@@ -335,9 +349,18 @@ pub fn run(args: TagsBootstrapArgs) -> Result<usize, CliError> {
                 tag_classify_request(&vocab_names, &inputs, args.max_new_per_batch)
             };
             let batch_len = inputs.len();
-            let (reply, _repair) = call_and_parse(client.as_mut(), &req, "tag-classify", |t| {
+            // A failed batch (API/parse/cassette) downgrades THIS run to
+            // whatever already landed — earlier batches + the persisted
+            // floor — instead of aborting with nothing saved.
+            let reply = match call_and_parse(client.as_mut(), &req, "tag-classify", |t| {
                 parse_tag_classify(t, batch_len)
-            })?;
+            }) {
+                Ok((reply, _repair)) => reply,
+                Err(e) => {
+                    sayln!("  classify: batch failed ({e}) — keeping the floor for its sources");
+                    continue;
+                }
+            };
             let (picks, admitted) = validate_batch(
                 &reply.picks,
                 &reply.new_tags,

--- a/crates/ovp-cli/src/commands/tags_bootstrap.rs
+++ b/crates/ovp-cli/src/commands/tags_bootstrap.rs
@@ -312,7 +312,30 @@ pub fn run(args: TagsBootstrapArgs) -> Result<usize, CliError> {
         );
         floored += 1;
     }
+    let unthemed = targets.iter().filter(|t| t.community.is_none()).count();
     println!("  floor: {floored}/{} target(s) inherit community keywords", targets.len());
+    if unthemed > 0 {
+        // No silent caps: noise/unthemed packs have no community keywords, and
+        // a wrong tag is worse than no tag — only the LLM pass covers them.
+        println!(
+            "  floor: {unthemed} target(s) in noise/unthemed packs get no deterministic \
+             floor (covered by `--client live` classification only)"
+        );
+    }
+
+    // A ban must also RETIRE what was inferred before it existed — scrub
+    // banned names out of every existing entry so `vocabulary.toml` curation
+    // takes effect on the next index build, not just on future runs. (Tags
+    // added below are vocabulary-validated, so they can never be banned.)
+    {
+        let banned: std::collections::BTreeSet<&str> = vocabulary.banned().collect();
+        if !banned.is_empty() {
+            for tags in inferred.entries.values_mut() {
+                tags.retain(|t| !banned.contains(t.tag.as_str()));
+            }
+            inferred.entries.retain(|_, v| !v.is_empty());
+        }
+    }
 
     // Checkpoint the deterministic result BEFORE any fallible LLM work: a
     // failed live pass must degrade to the zero-token floor, never to

--- a/crates/ovp-cli/src/commands/tags_bootstrap.rs
+++ b/crates/ovp-cli/src/commands/tags_bootstrap.rs
@@ -25,14 +25,18 @@ use std::path::PathBuf;
 
 use ovp_domain::tags::{
     ClassifyInput, InferredTag, TAGS_INFERRED_SCHEMA, TagAliases, TagOrigin, TagVocabulary,
-    TagsInferredFile, canonical_tags, normalize_tag, parse_tag_classify, tag_classify_request,
+    TagsInferredFile, canonical_tags, parse_tag_classify, tag_classify_request,
 };
 use ovp_domain::vault_layout::VaultLayout;
 use ovp_index::read_index;
 
+use ovp_embed::document_text;
+use ovp_embed::knn::cosine;
+
 use crate::CliError;
 use crate::commands::client::{ClientKind, build_client};
 use crate::commands::crystal_synth::call_and_parse;
+use crate::commands::crystal_themes::{ThemeDoc, resolve_vectors};
 
 /// Fixed confidence bands (see `InferredTag.score` docs).
 const LLM_SCORE: f64 = 0.8;
@@ -97,11 +101,69 @@ pub(crate) fn validate_batch(
     (out, admitted)
 }
 
-pub fn run(args: TagsBootstrapArgs) -> Result<(), CliError> {
+/// Cosine at or above which a proposed new name is a respelling of an
+/// existing vocabulary entry (design §2: generate-free → embed-map).
+const NEW_NAME_DEDUP_COSINE: f64 = 0.9;
+
+/// Drop proposed names that embed within [`NEW_NAME_DEDUP_COSINE`] of any
+/// existing vocabulary name. Embeddings are name-only texts through the
+/// shared cache; unavailable embedder + cold cache → ALL proposals dropped
+/// (with a printed reason) — the closed vocabulary never grows unverified.
+fn embed_dedup_new_names(
+    candidates: Vec<String>,
+    vocabulary: &TagVocabulary,
+    embed_cache_dir: &std::path::Path,
+) -> Result<Vec<String>, CliError> {
+    if candidates.is_empty() {
+        return Ok(candidates);
+    }
+    let docs: Vec<ThemeDoc> = vocabulary
+        .names()
+        .map(str::to_string)
+        .chain(candidates.iter().cloned())
+        .map(|name| {
+            let text = document_text(&name, "", 0);
+            let sha = ovp_embed::cache::text_sha256(&text);
+            ThemeDoc {
+                case_id: format!("tagname:{name}"),
+                title: name,
+                text,
+                sha,
+            }
+        })
+        .collect();
+    let Some(vectors) = resolve_vectors(&docs, embed_cache_dir)? else {
+        println!(
+            "  classify: {} new-name proposal(s) DISCARDED — embeddings unavailable, \
+             semantic dedup against the vocabulary is mandatory before admission",
+            candidates.len()
+        );
+        return Ok(Vec::new());
+    };
+    let n_vocab = vocabulary.len();
+    let mut kept = Vec::new();
+    for (i, name) in candidates.into_iter().enumerate() {
+        let v = &vectors[n_vocab + i];
+        let dup = vectors[..n_vocab]
+            .iter()
+            .any(|u| cosine(u, v) >= NEW_NAME_DEDUP_COSINE);
+        if dup {
+            println!("  classify: proposal {name:?} maps to an existing vocabulary tag — skipped");
+        } else {
+            kept.push(name);
+        }
+    }
+    Ok(kept)
+}
+
+/// Returns the number of sources whose inferred entries this run wrote —
+/// `daily` uses it to decide whether the projection needs a second rebuild.
+pub fn run(args: TagsBootstrapArgs) -> Result<usize, CliError> {
     let layout = VaultLayout::new();
     let model = read_index(&args.vault_root).map_err(|e| {
         CliError::Io(format!("tags-bootstrap: {e} — run `ovp2 index` first"))
     })?;
+    let embed_cache_dir = args.vault_root.join(".ovp/cache/embeddings");
     let themes_path = args
         .vault_root
         .join(layout.crystal_store_dir())
@@ -115,7 +177,7 @@ pub fn run(args: TagsBootstrapArgs) -> Result<(), CliError> {
                 "tags-bootstrap: no themes.json — run `ovp2 crystal-themes` first \
                  (the theme communities are the deterministic vocabulary seed)."
             );
-            return Ok(());
+            return Ok(0);
         }
     };
     let aliases = TagAliases::load(&args.vault_root).map_err(CliError::Io)?;
@@ -201,7 +263,7 @@ pub fn run(args: TagsBootstrapArgs) -> Result<(), CliError> {
     if targets.is_empty() {
         vocabulary.save(&args.vault_root).map_err(CliError::Io)?;
         println!("tags-bootstrap: nothing to do (vocabulary refreshed).");
-        return Ok(());
+        return Ok(0);
     }
 
     // ---- Layer 1: deterministic community-keyword floor ----
@@ -272,8 +334,10 @@ pub fn run(args: TagsBootstrapArgs) -> Result<(), CliError> {
                 let vocab_names: Vec<&str> = vocabulary.names().collect();
                 tag_classify_request(&vocab_names, &inputs, args.max_new_per_batch)
             };
-            let (reply, _repair) =
-                call_and_parse(client.as_mut(), &req, "tag-classify", parse_tag_classify)?;
+            let batch_len = inputs.len();
+            let (reply, _repair) = call_and_parse(client.as_mut(), &req, "tag-classify", |t| {
+                parse_tag_classify(t, batch_len)
+            })?;
             let (picks, admitted) = validate_batch(
                 &reply.picks,
                 &reply.new_tags,
@@ -281,6 +345,13 @@ pub fn run(args: TagsBootstrapArgs) -> Result<(), CliError> {
                 &aliases,
                 args.max_new_per_batch,
             );
+            // Semantic dedup: a proposal whose embedding sits within
+            // NEW_NAME_DEDUP_COSINE of an existing vocabulary name is a
+            // respelling, not a new tag (`agentic-systems` vs `ai-agents`).
+            // No embedder + cold cache → proposals are DISCARDED (conservative:
+            // the closed vocabulary must not grow unverified).
+            let admitted =
+                embed_dedup_new_names(admitted, &vocabulary, &embed_cache_dir)?;
             for name in admitted {
                 vocabulary.insert(name, TagOrigin::Llm);
                 admitted_total += 1;
@@ -327,7 +398,7 @@ pub fn run(args: TagsBootstrapArgs) -> Result<(), CliError> {
     println!("  vocabulary: {} tag(s) → {vocab_path}", vocabulary.len());
     println!("  inferred: → {inferred_path}");
     println!("tags-bootstrap: done. Rebuild the index (`ovp2 index`) to surface inferred tags.");
-    Ok(())
+    Ok(floored.max(classified))
 }
 
 #[cfg(test)]

--- a/crates/ovp-cli/src/commands/tags_suggest.rs
+++ b/crates/ovp-cli/src/commands/tags_suggest.rs
@@ -294,6 +294,21 @@ pub fn run(args: TagsSuggestArgs) -> Result<(), CliError> {
         }
     }
     let covered = entries.len();
+    // Merge, don't clobber: bootstrap-method entries (community/llm) survive
+    // for sources where kNN produced no vote — otherwise a P1 vault's first
+    // `tags-suggest` run (once a few operator tags exist) would erase every
+    // bootstrap tag that fails the vote thresholds. A fresh kNN vote for a
+    // sha replaces its old entry of any method.
+    if let Some(existing) = TagsInferredFile::load(&args.vault_root).map_err(CliError::Io)? {
+        for (sha, tags) in existing.entries {
+            let bootstrap = tags
+                .iter()
+                .any(|t| !t.method.is_empty() && t.method != "knn");
+            if bootstrap {
+                entries.entry(sha).or_insert(tags);
+            }
+        }
+    }
     let inferred = TagsInferredFile {
         schema: TAGS_INFERRED_SCHEMA.into(),
         model: EMBED_MODEL_ID.into(),

--- a/crates/ovp-cli/src/commands/tags_suggest.rs
+++ b/crates/ovp-cli/src/commands/tags_suggest.rs
@@ -66,24 +66,7 @@ impl Default for TagsSuggestArgs {
     }
 }
 
-/// A tag name as a valid TOML basic string — `normalize_tag` preserves
-/// quotes/backslashes, which would break the paste-ready block unescaped.
-pub(crate) fn toml_basic_string(s: &str) -> String {
-    let mut out = String::with_capacity(s.len() + 2);
-    out.push('"');
-    for c in s.chars() {
-        match c {
-            '"' => out.push_str("\\\""),
-            '\\' => out.push_str("\\\\"),
-            c if (c as u32) < 0x20 || c == '\u{7f}' => {
-                out.push_str(&format!("\\u{:04X}", c as u32))
-            }
-            c => out.push(c),
-        }
-    }
-    out.push('"');
-    out
-}
+pub(crate) use ovp_domain::tags::toml_basic_string;
 
 /// One tag's neighbor vote on one source (pure, unit-tested): neighbors are
 /// `(similarity, tags)` pairs, already the k nearest. A tag wins when its
@@ -230,13 +213,7 @@ pub fn run(args: TagsSuggestArgs) -> Result<(), CliError> {
 
     // ---- Join sources ↔ pack docs (case_id = pack_dir basename) ----
     let docs = collect_docs(&reader_root)?;
-    let case_of = |pack_dir: &str| -> String {
-        pack_dir
-            .rsplit(['/', '\\'])
-            .next()
-            .unwrap_or(pack_dir)
-            .to_string()
-    };
+    let case_of = |pack_dir: &str| ovp_domain::vault_layout::pack_case_id(pack_dir).to_string();
     let mut doc_idx: BTreeMap<String, usize> = BTreeMap::new();
     for (i, d) in docs.iter().enumerate() {
         doc_idx.insert(d.case_id.clone(), i);

--- a/crates/ovp-cli/src/commands/tags_suggest.rs
+++ b/crates/ovp-cli/src/commands/tags_suggest.rs
@@ -115,6 +115,7 @@ pub(crate) fn vote_tags(
                 tag: tag.to_string(),
                 score: (score * 1000.0).round() / 1000.0,
                 support,
+                method: "knn".into(),
             })
         })
         .collect();

--- a/crates/ovp-cli/src/main.rs
+++ b/crates/ovp-cli/src/main.rs
@@ -664,6 +664,33 @@ enum Cmd {
         #[arg(long, default_value_t = 42)]
         seed: u64,
     },
+    /// Cold-start tagging for vaults without a curated vocabulary: theme
+    /// communities seed a closed vocabulary (.ovp/tags/vocabulary.toml) and a
+    /// deterministic keyword floor; `--client live` adds batched LLM
+    /// classification INTO that vocabulary (capped new-name proposals).
+    /// Output lands in tags_inferred, never frontmatter. Run `index` and
+    /// `crystal-themes` first.
+    TagsBootstrap {
+        #[arg(long)]
+        vault_root: PathBuf,
+        /// `replay` (default) = deterministic floor only; `live` adds the
+        /// cassette-cached classification pass.
+        #[arg(long, value_enum, default_value_t = ClientKindArg::Replay)]
+        client: ClientKindArg,
+        /// Cassette root for tag_classify/v1. Default:
+        /// `<vault-root>/.ovp/cassettes/tags`.
+        #[arg(long)]
+        cache_dir: Option<PathBuf>,
+        /// Sources per classification call.
+        #[arg(long, default_value_t = 20)]
+        batch_size: usize,
+        /// New-name proposals admitted per batch.
+        #[arg(long, default_value_t = 2)]
+        max_new_per_batch: usize,
+        /// Redo bootstrap-method entries (kNN entries are never touched).
+        #[arg(long)]
+        refresh: bool,
+    },
     /// Propose tag curation over the embedding layer: merge candidates for
     /// near-duplicate tags (→ .ovp/tags/proposals.md, paste into aliases.toml
     /// after review) and kNN-voted backfill tags for untagged sources
@@ -1738,6 +1765,28 @@ fn main() -> ExitCode {
                 cosine_threshold,
                 resolution,
                 seed,
+            })
+        }
+        Cmd::TagsBootstrap {
+            vault_root,
+            client,
+            cache_dir,
+            batch_size,
+            max_new_per_batch,
+            refresh,
+        } => {
+            use commands::client::ClientKind;
+            let client_kind = match client {
+                ClientKindArg::Replay => ClientKind::Replay,
+                ClientKindArg::Live => ClientKind::Live,
+            };
+            commands::tags_bootstrap::run(commands::tags_bootstrap::TagsBootstrapArgs {
+                vault_root,
+                client_kind,
+                cache_dir,
+                batch_size,
+                max_new_per_batch,
+                refresh,
             })
         }
         Cmd::TagsSuggest {

--- a/crates/ovp-cli/src/main.rs
+++ b/crates/ovp-cli/src/main.rs
@@ -1788,6 +1788,7 @@ fn main() -> ExitCode {
                 max_new_per_batch,
                 refresh,
             })
+            .map(|_| ())
         }
         Cmd::TagsSuggest {
             vault_root,

--- a/crates/ovp-domain/prompts/tag_classify.md
+++ b/crates/ovp-domain/prompts/tag_classify.md
@@ -1,0 +1,20 @@
+# Tag classification (tag_classify/v1)
+
+You assign content tags to knowledge sources from a CLOSED vocabulary.
+
+Rules:
+1. For each source, pick 1–5 tags. Every picked tag MUST be copied verbatim
+   from the Vocabulary list — never invent, translate, re-spell, pluralize,
+   or reformat a vocabulary tag.
+2. Pick the most SPECIFIC applicable tags. Add a generic tag (like `ai`)
+   only when nothing more specific fits.
+3. If an important topic recurs in this batch and truly has no vocabulary
+   tag, you may propose it in the batch-level `new_tags` list (lowercase,
+   hyphenated, at most the number stated in the batch header). Do NOT use a
+   proposed tag in any source's `tags` — proposals are reviewed separately.
+4. A tag must describe the CONTENT, never the capture channel or format.
+5. Reply with JSON only, no prose:
+   `{"sources": [{"id": 0, "tags": ["..."]}, …], "new_tags": ["..."]}`
+   Every input source id must appear exactly once.
+
+## Batch

--- a/crates/ovp-domain/src/tags.rs
+++ b/crates/ovp-domain/src/tags.rs
@@ -380,10 +380,7 @@ impl TagVocabulary {
         } else {
             body.push_str("banned = [\n");
             for name in &self.banned {
-                body.push_str(&format!(
-                    "  \"{}\",\n",
-                    name.replace('\\', "\\\\").replace('"', "\\\"")
-                ));
+                body.push_str(&format!("  {},\n", toml_basic_string(name)));
             }
             body.push_str("]\n\n[tags]\n");
         }
@@ -393,7 +390,7 @@ impl TagVocabulary {
                 TagOrigin::Community => "community",
                 TagOrigin::Llm => "llm",
             };
-            body.push_str(&format!("\"{}\" = \"{origin}\"\n", name.replace('\\', "\\\\").replace('"', "\\\"")));
+            body.push_str(&format!("{} = \"{origin}\"\n", toml_basic_string(name)));
         }
         std::fs::write(&path, body).map_err(|e| format!("writing {}: {e}", path.display()))?;
         Ok(path.display().to_string())
@@ -507,6 +504,27 @@ pub fn parse_tag_classify(reply_text: &str, expected: usize) -> Result<ClassifyR
         })
         .unwrap_or_default();
     Ok(ClassifyReply { picks, new_tags })
+}
+
+/// A tag name as a valid TOML basic string — normalized tags can still carry
+/// quotes/backslashes/control characters, which unescaped would break the
+/// vocabulary file and the paste-ready proposals block. One implementation
+/// for every writer.
+pub fn toml_basic_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            c if (c as u32) < 0x20 || c == '\u{7f}' => {
+                out.push_str(&format!("\\u{:04X}", c as u32))
+            }
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
 }
 
 /// Raw frontmatter tags → sorted, deduped canonical tags: normalize, drop

--- a/crates/ovp-domain/src/tags.rs
+++ b/crates/ovp-domain/src/tags.rs
@@ -266,18 +266,35 @@ pub enum TagOrigin {
 /// `.ovp/tags/vocabulary.toml` — the CLOSED list the tag classifier may pick
 /// from: user tags ∪ community keywords ∪ surviving LLM proposals. A
 /// projection: `tags-bootstrap` rebuilds the user/community entries each run
-/// and carries the llm entries forward. The operator curates it in place
-/// (delete a line to ban a tag from future classification).
+/// and carries the llm entries forward. Curation: deleting an `llm` line
+/// removes it permanently (not re-derivable); user/community entries would
+/// be re-derived on the next run, so banning those goes through the
+/// persistent `banned` list, which every insert respects.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct TagVocabulary {
     entries: BTreeMap<String, TagOrigin>,
+    banned: std::collections::BTreeSet<String>,
 }
 
 impl TagVocabulary {
     /// Insert a normalized name; an existing entry keeps its origin (user
     /// beats community beats llm because bootstrap inserts in that order).
+    /// Banned names never enter.
     pub fn insert(&mut self, name: String, origin: TagOrigin) {
+        if self.banned.contains(&name) {
+            return;
+        }
         self.entries.entry(name).or_insert(origin);
+    }
+
+    /// Ban a name from the vocabulary (persists across bootstrap runs).
+    pub fn ban(&mut self, name: String) {
+        self.entries.remove(&name);
+        self.banned.insert(name);
+    }
+
+    pub fn banned(&self) -> impl Iterator<Item = &str> {
+        self.banned.iter().map(String::as_str)
     }
 
     pub fn contains(&self, name: &str) -> bool {
@@ -306,6 +323,8 @@ impl TagVocabulary {
         struct File {
             schema: String,
             #[serde(default)]
+            banned: Vec<String>,
+            #[serde(default)]
             tags: BTreeMap<String, TagOrigin>,
         }
         let file: File =
@@ -316,13 +335,21 @@ impl TagVocabulary {
                 file.schema
             ));
         }
+        let mut banned = std::collections::BTreeSet::new();
+        for name in file.banned {
+            let n = normalize_tag(&name)
+                .ok_or_else(|| format!("tag vocabulary: banned {name:?} normalizes to nothing"))?;
+            banned.insert(n);
+        }
         let mut entries = BTreeMap::new();
         for (name, origin) in file.tags {
             let n = normalize_tag(&name)
                 .ok_or_else(|| format!("tag vocabulary: {name:?} normalizes to nothing"))?;
-            entries.insert(n, origin);
+            if !banned.contains(&n) {
+                entries.insert(n, origin);
+            }
         }
-        Ok(Self { entries })
+        Ok(Self { entries, banned })
     }
 
     /// Missing file → empty (bootstrap seeds it); broken file → error.
@@ -343,10 +370,23 @@ impl TagVocabulary {
         }
         let mut body = String::from(
             "# Closed tag vocabulary — the classifier may only pick from this list.\n\
-             # Rebuilt by `ovp2 tags-bootstrap` (user/community entries re-derived,\n\
-             # llm entries carried forward). Delete a line to ban a tag.\n\
-             schema = \"ovp.tags-vocabulary/v1\"\n\n[tags]\n",
+             # Rebuilt by `ovp2 tags-bootstrap`: user/community entries are re-derived\n\
+             # each run (deleting them does NOT stick — add the name to `banned`);\n\
+             # llm entries persist, so deleting an llm line removes it for good.\n\
+             schema = \"ovp.tags-vocabulary/v1\"\n",
         );
+        if self.banned.is_empty() {
+            body.push_str("banned = []\n\n[tags]\n");
+        } else {
+            body.push_str("banned = [\n");
+            for name in &self.banned {
+                body.push_str(&format!(
+                    "  \"{}\",\n",
+                    name.replace('\\', "\\\\").replace('"', "\\\"")
+                ));
+            }
+            body.push_str("]\n\n[tags]\n");
+        }
         for (name, origin) in &self.entries {
             let origin = match origin {
                 TagOrigin::User => "user",
@@ -416,8 +456,11 @@ pub struct ClassifyReply {
     pub new_tags: Vec<String>,
 }
 
-/// Parse `{"sources":[{"id":0,"tags":[...]},…],"new_tags":[...]}`.
-pub fn parse_tag_classify(reply_text: &str) -> Result<ClassifyReply, String> {
+/// Parse `{"sources":[{"id":0,"tags":[...]},…],"new_tags":[...]}` for a
+/// batch of ids `0..expected`. A missing, duplicate, or out-of-range id is a
+/// parse ERROR (not a silent gap) so `call_and_parse` invalidates the
+/// cassette entry and the retry re-asks the model.
+pub fn parse_tag_classify(reply_text: &str, expected: usize) -> Result<ClassifyReply, String> {
     let (value, _note) =
         crate::model_reply::parse_reply_value(reply_text).map_err(|d| d.to_string())?;
     let sources = value
@@ -430,6 +473,9 @@ pub fn parse_tag_classify(reply_text: &str) -> Result<ClassifyReply, String> {
             .get("id")
             .and_then(|v| v.as_u64())
             .ok_or("source missing numeric `id`")? as usize;
+        if id >= expected {
+            return Err(format!("source id {id} out of range (batch of {expected})"));
+        }
         let tags: Vec<String> = s
             .get("tags")
             .and_then(|v| v.as_array())
@@ -442,6 +488,12 @@ pub fn parse_tag_classify(reply_text: &str) -> Result<ClassifyReply, String> {
         if picks.insert(id, tags).is_some() {
             return Err(format!("duplicate source id {id}"));
         }
+    }
+    if picks.len() != expected {
+        return Err(format!(
+            "reply covers {}/{expected} batch ids — every input id must appear exactly once",
+            picks.len()
+        ));
     }
     let new_tags: Vec<String> = value
         .get("new_tags")
@@ -552,16 +604,37 @@ mod tests {
     }
 
     #[test]
-    fn classify_reply_parses_and_rejects_duplicates() {
+    fn classify_reply_parses_and_rejects_duplicates_gaps_and_strays() {
         let ok = parse_tag_classify(
             r#"{"sources":[{"id":0,"tags":["agent"," memory "]},{"id":1,"tags":[]}],"new_tags":["kv-cache"]}"#,
+            2,
         )
         .unwrap();
         assert_eq!(ok.picks[&0], vec!["agent", "memory"]);
         assert!(ok.picks[&1].is_empty());
         assert_eq!(ok.new_tags, vec!["kv-cache"]);
-        assert!(parse_tag_classify(r#"{"sources":[{"id":0,"tags":[]},{"id":0,"tags":[]}]}"#).is_err());
-        assert!(parse_tag_classify(r#"{"new_tags":[]}"#).is_err());
+        // Duplicate id, missing id, and out-of-range id are all parse errors.
+        assert!(
+            parse_tag_classify(r#"{"sources":[{"id":0,"tags":[]},{"id":0,"tags":[]}]}"#, 2)
+                .is_err()
+        );
+        assert!(parse_tag_classify(r#"{"sources":[{"id":0,"tags":[]}]}"#, 2).is_err());
+        assert!(parse_tag_classify(r#"{"sources":[{"id":5,"tags":[]}]}"#, 1).is_err());
+        assert!(parse_tag_classify(r#"{"new_tags":[]}"#, 0).is_err());
+    }
+
+    #[test]
+    fn vocabulary_bans_persist_and_block_reinsertion() {
+        let mut v = TagVocabulary::default();
+        v.insert("twitter".into(), TagOrigin::User);
+        v.ban("twitter".into());
+        v.insert("twitter".into(), TagOrigin::Community); // blocked
+        assert!(!v.contains("twitter"));
+        let dir = tempfile::tempdir().unwrap();
+        v.save(dir.path()).unwrap();
+        let loaded = TagVocabulary::load(dir.path()).unwrap();
+        assert!(loaded.banned().any(|b| b == "twitter"));
+        assert!(!loaded.contains("twitter"));
     }
 
     #[test]

--- a/crates/ovp-domain/src/tags.rs
+++ b/crates/ovp-domain/src/tags.rs
@@ -180,10 +180,16 @@ pub const TAGS_INFERRED_SCHEMA: &str = "ovp.tags-inferred/v1";
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct InferredTag {
     pub tag: String,
-    /// Share of neighbor similarity weight that voted for this tag (0..1).
+    /// Coarse confidence: kNN = neighbor-weight share (0..1); bootstrap
+    /// methods use fixed bands (llm 0.8, community floor 0.4).
     pub score: f64,
-    /// Number of neighbors carrying the tag.
+    /// kNN: number of neighbors carrying the tag; community floor: the
+    /// community size; llm: 0 (a judgment, not a vote).
     pub support: usize,
+    /// How this tag was inferred: `knn` | `community` | `llm`.
+    /// Serde-additive: pre-bootstrap files deserialize to `""` (= knn era).
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub method: String,
 }
 
 /// `.ovp/tags/inferred.json` — kNN-voted tags for sources that had NO
@@ -239,6 +245,216 @@ impl TagsInferredFile {
             .map_err(|e| format!("writing {}: {e}", path.display()))?;
         Ok(path.display().to_string())
     }
+}
+
+pub const TAGS_VOCABULARY_SCHEMA: &str = "ovp.tags-vocabulary/v1";
+
+/// Where a vocabulary entry came from. `User` and `Community` entries are
+/// re-derived on every bootstrap run; `Llm` entries are the one thing worth
+/// persisting (a reviewed-and-survived model proposal is not re-derivable).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TagOrigin {
+    /// Observed as an operator tag in the index.
+    User,
+    /// A theme community's c-TF-IDF keyword (the deterministic seed).
+    Community,
+    /// Survived the classifier's capped new-name budget + embedding dedup.
+    Llm,
+}
+
+/// `.ovp/tags/vocabulary.toml` — the CLOSED list the tag classifier may pick
+/// from: user tags ∪ community keywords ∪ surviving LLM proposals. A
+/// projection: `tags-bootstrap` rebuilds the user/community entries each run
+/// and carries the llm entries forward. The operator curates it in place
+/// (delete a line to ban a tag from future classification).
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct TagVocabulary {
+    entries: BTreeMap<String, TagOrigin>,
+}
+
+impl TagVocabulary {
+    /// Insert a normalized name; an existing entry keeps its origin (user
+    /// beats community beats llm because bootstrap inserts in that order).
+    pub fn insert(&mut self, name: String, origin: TagOrigin) {
+        self.entries.entry(name).or_insert(origin);
+    }
+
+    pub fn contains(&self, name: &str) -> bool {
+        self.entries.contains_key(name)
+    }
+
+    pub fn names(&self) -> impl Iterator<Item = &str> {
+        self.entries.keys().map(String::as_str)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&str, TagOrigin)> {
+        self.entries.iter().map(|(k, v)| (k.as_str(), *v))
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn parse(text: &str) -> Result<Self, String> {
+        #[derive(serde::Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct File {
+            schema: String,
+            #[serde(default)]
+            tags: BTreeMap<String, TagOrigin>,
+        }
+        let file: File =
+            toml::from_str(text).map_err(|e| format!("tag vocabulary: invalid TOML: {e}"))?;
+        if file.schema != TAGS_VOCABULARY_SCHEMA {
+            return Err(format!(
+                "tag vocabulary: unknown schema {:?} (expected {TAGS_VOCABULARY_SCHEMA:?})",
+                file.schema
+            ));
+        }
+        let mut entries = BTreeMap::new();
+        for (name, origin) in file.tags {
+            let n = normalize_tag(&name)
+                .ok_or_else(|| format!("tag vocabulary: {name:?} normalizes to nothing"))?;
+            entries.insert(n, origin);
+        }
+        Ok(Self { entries })
+    }
+
+    /// Missing file → empty (bootstrap seeds it); broken file → error.
+    pub fn load(vault_root: &Path) -> Result<Self, String> {
+        let path = vault_root.join(crate::vault_layout::VaultLayout.tags_vocabulary_file());
+        match std::fs::read_to_string(&path) {
+            Ok(text) => Self::parse(&text),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
+            Err(e) => Err(format!("reading {}: {e}", path.display())),
+        }
+    }
+
+    pub fn save(&self, vault_root: &Path) -> Result<String, String> {
+        let path = vault_root.join(crate::vault_layout::VaultLayout.tags_vocabulary_file());
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("creating {}: {e}", parent.display()))?;
+        }
+        let mut body = String::from(
+            "# Closed tag vocabulary — the classifier may only pick from this list.\n\
+             # Rebuilt by `ovp2 tags-bootstrap` (user/community entries re-derived,\n\
+             # llm entries carried forward). Delete a line to ban a tag.\n\
+             schema = \"ovp.tags-vocabulary/v1\"\n\n[tags]\n",
+        );
+        for (name, origin) in &self.entries {
+            let origin = match origin {
+                TagOrigin::User => "user",
+                TagOrigin::Community => "community",
+                TagOrigin::Llm => "llm",
+            };
+            body.push_str(&format!("\"{}\" = \"{origin}\"\n", name.replace('\\', "\\\\").replace('"', "\\\"")));
+        }
+        std::fs::write(&path, body).map_err(|e| format!("writing {}: {e}", path.display()))?;
+        Ok(path.display().to_string())
+    }
+}
+
+// ---- Classification model stage (`tag_classify/v1`) ----
+
+const TAG_CLASSIFY_TEMPLATE: &str = include_str!("../prompts/tag_classify.md");
+pub const TAG_CLASSIFY_PROMPT_ID: &str = "tag_classify/v1";
+const TAG_CLASSIFY_MODEL: &str = "claude-sonnet-4-6";
+const TAG_CLASSIFY_MAX_TOKENS: u32 = 2000;
+
+/// One source in a classification batch.
+pub struct ClassifyInput {
+    /// Batch-local id echoed back by the model.
+    pub id: usize,
+    pub title: String,
+    /// Card titles (the pack's synthesized surface) — the content signal.
+    pub card_titles: Vec<String>,
+}
+
+/// Build the batched classification request: the closed vocabulary + the
+/// batch's sources. Deterministic text → stable cassette keys.
+pub fn tag_classify_request(
+    vocabulary: &[&str],
+    sources: &[ClassifyInput],
+    max_new: usize,
+) -> ovp_llm::ModelRequest {
+    let marker = "## Batch";
+    let (system, _) = TAG_CLASSIFY_TEMPLATE
+        .split_once(marker)
+        .unwrap_or((TAG_CLASSIFY_TEMPLATE, ""));
+    let mut user = format!(
+        "{marker}\n\nAt most {max_new} `new_tags` for this whole batch.\n\nVocabulary: {}\n\nSources:\n",
+        vocabulary.join(", ")
+    );
+    for s in sources {
+        user.push_str(&format!("{}. {}", s.id, s.title));
+        if !s.card_titles.is_empty() {
+            user.push_str(&format!(" — {}", s.card_titles.join(" | ")));
+        }
+        user.push('\n');
+    }
+    ovp_llm::ModelRequest {
+        model: TAG_CLASSIFY_MODEL.to_string(),
+        system: Some(system.trim_end().to_string()),
+        messages: vec![ovp_llm::ModelMessage::User { content: user }],
+        max_tokens: TAG_CLASSIFY_MAX_TOKENS,
+        temperature: None,
+        cache_namespace: Some(TAG_CLASSIFY_PROMPT_ID.to_string()),
+    }
+}
+
+/// Parsed classification reply.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ClassifyReply {
+    /// Batch-local id → picked tag names (raw; caller validates vs vocab).
+    pub picks: BTreeMap<usize, Vec<String>>,
+    pub new_tags: Vec<String>,
+}
+
+/// Parse `{"sources":[{"id":0,"tags":[...]},…],"new_tags":[...]}`.
+pub fn parse_tag_classify(reply_text: &str) -> Result<ClassifyReply, String> {
+    let (value, _note) =
+        crate::model_reply::parse_reply_value(reply_text).map_err(|d| d.to_string())?;
+    let sources = value
+        .get("sources")
+        .and_then(|v| v.as_array())
+        .ok_or("missing `sources` array")?;
+    let mut picks = BTreeMap::new();
+    for s in sources {
+        let id = s
+            .get("id")
+            .and_then(|v| v.as_u64())
+            .ok_or("source missing numeric `id`")? as usize;
+        let tags: Vec<String> = s
+            .get("tags")
+            .and_then(|v| v.as_array())
+            .ok_or("source missing `tags` array")?
+            .iter()
+            .filter_map(|t| t.as_str())
+            .map(|t| t.trim().to_string())
+            .filter(|t| !t.is_empty())
+            .collect();
+        if picks.insert(id, tags).is_some() {
+            return Err(format!("duplicate source id {id}"));
+        }
+    }
+    let new_tags: Vec<String> = value
+        .get("new_tags")
+        .and_then(|v| v.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|t| t.as_str())
+                .map(|t| t.trim().to_string())
+                .filter(|t| !t.is_empty())
+                .collect()
+        })
+        .unwrap_or_default();
+    Ok(ClassifyReply { picks, new_tags })
 }
 
 /// Raw frontmatter tags → sorted, deduped canonical tags: normalize, drop
@@ -317,6 +533,52 @@ mod tests {
         let chain = "[aliases]\n\"a\" = \"b\"\n\"b\" = \"c\"\n";
         let err = TagAliases::parse(chain).unwrap_err();
         assert!(err.contains("chain"), "{err}");
+    }
+
+    #[test]
+    fn vocabulary_round_trips_and_first_origin_wins() {
+        let mut v = TagVocabulary::default();
+        v.insert("agent".into(), TagOrigin::User);
+        v.insert("agent".into(), TagOrigin::Llm); // ignored — user wins
+        v.insert("向量检索".into(), TagOrigin::Community);
+        let dir = tempfile::tempdir().unwrap();
+        v.save(dir.path()).unwrap();
+        let loaded = TagVocabulary::load(dir.path()).unwrap();
+        assert_eq!(loaded, v);
+        assert_eq!(loaded.iter().next(), Some(("agent", TagOrigin::User)));
+        // Missing file → empty; typo section → error.
+        assert!(TagVocabulary::load(tempfile::tempdir().unwrap().path()).unwrap().is_empty());
+        assert!(TagVocabulary::parse("schema = \"ovp.tags-vocabulary/v1\"\n[tag]\n").is_err());
+    }
+
+    #[test]
+    fn classify_reply_parses_and_rejects_duplicates() {
+        let ok = parse_tag_classify(
+            r#"{"sources":[{"id":0,"tags":["agent"," memory "]},{"id":1,"tags":[]}],"new_tags":["kv-cache"]}"#,
+        )
+        .unwrap();
+        assert_eq!(ok.picks[&0], vec!["agent", "memory"]);
+        assert!(ok.picks[&1].is_empty());
+        assert_eq!(ok.new_tags, vec!["kv-cache"]);
+        assert!(parse_tag_classify(r#"{"sources":[{"id":0,"tags":[]},{"id":0,"tags":[]}]}"#).is_err());
+        assert!(parse_tag_classify(r#"{"new_tags":[]}"#).is_err());
+    }
+
+    #[test]
+    fn classify_request_is_deterministic_and_carries_the_cap() {
+        let sources = vec![ClassifyInput {
+            id: 0,
+            title: "T".into(),
+            card_titles: vec!["c1".into(), "c2".into()],
+        }];
+        let a = tag_classify_request(&["agent", "memory"], &sources, 2);
+        let b = tag_classify_request(&["agent", "memory"], &sources, 2);
+        assert_eq!(a.messages, b.messages);
+        let ovp_llm::ModelMessage::User { content } = &a.messages[0] else {
+            panic!("expected a user message");
+        };
+        assert!(content.contains("At most 2 `new_tags`"), "{content}");
+        assert!(content.contains("0. T — c1 | c2"), "{content}");
     }
 
     #[test]

--- a/crates/ovp-domain/src/vault_layout.rs
+++ b/crates/ovp-domain/src/vault_layout.rs
@@ -240,6 +240,12 @@ impl VaultLayout {
     pub fn tags_proposals_file(&self) -> &'static str {
         ".ovp/tags/proposals.md"
     }
+
+    /// The closed tag vocabulary the classifier picks from (`tags-bootstrap`
+    /// rebuilds user/community entries; llm entries persist; operator-curable).
+    pub fn tags_vocabulary_file(&self) -> &'static str {
+        ".ovp/tags/vocabulary.toml"
+    }
 }
 
 /// Truncate to at most `max` characters on a char boundary (titles can be

--- a/crates/ovp-domain/src/vault_layout.rs
+++ b/crates/ovp-domain/src/vault_layout.rs
@@ -248,6 +248,14 @@ impl VaultLayout {
     }
 }
 
+/// Last path segment of a pack dir — the case_id that claim↔source↔theme
+/// joins key on. One shared implementation (both separators) so every
+/// consumer agrees; an inline `rsplit('/')` would silently miss Windows
+/// paths and break the join.
+pub fn pack_case_id(pack_dir: &str) -> &str {
+    pack_dir.rsplit(['/', '\\']).next().unwrap_or(pack_dir)
+}
+
 /// Truncate to at most `max` characters on a char boundary (titles can be
 /// long and multi-byte; a byte slice could panic mid-codepoint). Public so
 /// intake filename normalization (M31) agrees with pack-dir naming.

--- a/docs/stage-tags-product.md
+++ b/docs/stage-tags-product.md
@@ -52,8 +52,10 @@ the theme communities already exist for any vault (`crystal-themes`:
 embeddings → Louvain → c-TF-IDF). Their per-community keywords ARE a
 candidate vocabulary: ~17 communities × top keywords ≈ 60–120 candidate tags,
 bilingual, corpus-derived, no LLM. Floor behavior with no LLM configured:
-every source inherits its community's top keyword(s) as `tags_inferred` —
-coarse but honest, and strictly better than nothing.
+every THEMED source inherits its community's top keyword(s) as
+`tags_inferred` — coarse but honest. Noise/unclassified packs (<5% on the
+validated recipe) deliberately get no floor (a wrong tag is worse than no
+tag; the run logs their count) and are covered by the LLM pass only.
 
 **LLM classification pass (optional, `--client live`, cassette-cached):**
 batched (~20 sources/call, same batching discipline as crystal-synth):


### PR DESCRIPTION
Reopened as a fresh PR: #342 was auto-closed when its stacked base branch was deleted on the #341 merge. Same content, rebased onto main, plus the bot-review fixes (shared pack_case_id incl. daily's /-only variant, toml_basic_string moved to domain, batched canonical_tags, cross-batch name-vector memo for proposal dedup). Full description and verification: see #342. Gates: 84 Rust suites green, clippy clean, codex ×3 rounds final PASS.