### PR TITLE
feat(entities): Tier-0 URL entities — deterministic github/arxiv/doi/npm index

### DIFF
--- a/console-ui/src/App.tsx
+++ b/console-ui/src/App.tsx
@@ -10,6 +10,8 @@ import LibraryPage from './pages/LibraryPage';
 import SearchPage from './pages/SearchPage';
 import SourceDetailPage from './pages/SourceDetailPage';
 import TagsPage from './pages/TagsPage';
+import EntitiesPage from './pages/EntitiesPage';
+import EntityDetailPage from './pages/EntityDetailPage';
 import SystemPage from './pages/SystemPage';
 import ThemeDetailPage from './pages/ThemeDetailPage';
 import TodayPage from './pages/TodayPage';
@@ -84,6 +86,8 @@ export default function App() {
           <Route path="/library" element={<LibraryPage />} />
           <Route path="/library/:sha" element={<SourceDetailPage />} />
           {!STATIC_MODE && <Route path="/tags" element={<TagsPage />} />}
+          <Route path="/entities" element={<EntitiesPage />} />
+          <Route path="/entity/:id" element={<EntityDetailPage />} />
           <Route path="/search" element={<SearchPage />} />
           <Route path="/knowledge" element={<KnowledgePage />} />
           <Route path="/knowledge/theme/:theme" element={<ThemeDetailPage />} />

--- a/console-ui/src/components/Shell.tsx
+++ b/console-ui/src/components/Shell.tsx
@@ -23,12 +23,14 @@ const NAV = STATIC_MODE
   ? ([
       { to: '/knowledge', key: 'nav.knowledge', end: false },
       { to: '/library', key: 'nav.library', end: false },
+      { to: '/entities', key: 'nav.entities', end: false },
       { to: '/search', key: 'nav.search', end: false },
     ] as const)
   : ([
       { to: '/', key: 'nav.today', end: true },
       { to: '/library', key: 'nav.library', end: false },
       { to: '/tags', key: 'nav.tags', end: false },
+      { to: '/entities', key: 'nav.entities', end: false },
       { to: '/search', key: 'nav.search', end: false },
       { to: '/knowledge', key: 'nav.knowledge', end: false },
       { to: '/ask', key: 'nav.ask', end: false },

--- a/console-ui/src/design/portal.css
+++ b/console-ui/src/design/portal.css
@@ -623,6 +623,22 @@ body {
   font-size: inherit;
   padding: 0 0 0 0.3rem;
 }
+/* URL entity chip: mono id + a small external-link-out arrow. */
+.entity-chip {
+  display: inline-flex;
+  align-items: center;
+  margin-right: 0.5rem;
+  font-family: var(--ovp-font-mono);
+  font-size: var(--ovp-text-xs);
+}
+.entity-out {
+  margin-left: 0.15rem;
+  color: var(--muted);
+  text-decoration: none;
+}
+.entity-out:hover {
+  color: var(--accent);
+}
 /* Add-tag input beside the chips — same scale as the chips it feeds. */
 .tag-add {
   border: 1px solid var(--border);

--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -6,6 +6,22 @@ export const en = {
   'nav.today': 'Today',
   'nav.library': 'Library',
   'nav.tags': 'Tags',
+  'nav.entities': 'Entities',
+
+  // entities (Tier-0 URL entities)
+  'entities.title': 'Entities',
+  'entities.help':
+    'Machine-verified referents pulled from links in your sources — GitHub repos, arXiv papers, packages. Ranked by how many sources mention each. Deterministic, no LLM.',
+  'entities.all': 'All',
+  'entities.filter': 'Filter entities…',
+  'entities.empty': 'No URL entities found in your sources yet.',
+  'entities.sources': 'sources',
+  'entities.url': 'URL',
+  'entities.kind': 'Kind',
+  'entities.mentionedIn': 'Mentioned in',
+  'entities.citingClaims': 'Claims from these sources',
+  'entities.noClaims': 'No durable claims cite these sources yet.',
+  'entities.notFound': 'Entity not found.',
   'nav.search': 'Search',
   'nav.knowledge': 'Knowledge',
   'nav.ask': 'Ask',

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -6,6 +6,22 @@ export const zh: Record<keyof typeof en, string> = {
   'nav.today': '今天',
   'nav.library': '资料',
   'nav.tags': '标签',
+  'nav.entities': '实体',
+
+  // entities (Tier-0 URL 实体)
+  'entities.title': '实体',
+  'entities.help':
+    '从来源的链接里抽取的机器可验证实体——GitHub 仓库、arXiv 论文、软件包。按被多少来源提及排序。确定性,无 LLM。',
+  'entities.all': '全部',
+  'entities.filter': '筛选实体…',
+  'entities.empty': '来源里还没有 URL 实体。',
+  'entities.sources': '个来源',
+  'entities.url': '链接',
+  'entities.kind': '类型',
+  'entities.mentionedIn': '被这些来源提及',
+  'entities.citingClaims': '这些来源支撑的论断',
+  'entities.noClaims': '还没有持久论断引用这些来源。',
+  'entities.notFound': '实体不存在。',
   'nav.search': '搜索',
   'nav.knowledge': '知识',
   'nav.ask': '对话',

--- a/console-ui/src/lib/api.ts
+++ b/console-ui/src/lib/api.ts
@@ -2,6 +2,7 @@ import type {
   AskResponse,
   ChatEntry,
   ClaimDetail,
+  ClaimRow,
   FindHit,
   FlowData,
   GraphResponse,
@@ -297,4 +298,70 @@ export function postSourceTags(
   tags: string[],
 ): Promise<{ ok: boolean; changed: boolean; sha?: string }> {
   return postJson(`/api/source/${encodeURIComponent(sha)}/tags`, { tags });
+}
+
+// ---- Tier-0 URL entities (docs/stage-tags-product.md §5b) ----
+
+export interface EntityRow {
+  id: string;
+  kind: string;
+  url: string;
+  count: number;
+}
+
+export interface EntitySource {
+  sha256: string;
+  title?: string;
+  date?: string;
+}
+
+export interface EntityDetail {
+  id: string;
+  kind: string | null;
+  url: string | null;
+  sources: EntitySource[];
+  citing_claims: ClaimRow[];
+}
+
+/** GET /api/entities — the URL entity index, most-mentioned first. Static
+ * mode reads the snapshotted `entities.json`. */
+export function fetchEntities(): Promise<EntityRow[]> {
+  const path = STATIC_MODE ? `${API}/entities.json` : '/api/entities';
+  return fetchJson<{ entities: EntityRow[] }>(path).then((d) => d.entities ?? []);
+}
+
+/** GET /api/entity/:id — one entity's mentioning sources + citing claims. */
+export function fetchEntity(id: string): Promise<EntityDetail> {
+  if (STATIC_MODE) {
+    // Published per-entity files are named with the same safe-component rule
+    // the publisher uses (`:` and `/` → `_`).
+    const safe = id.replace(/[^A-Za-z0-9._-]/g, '_');
+    return fetchJson<EntityDetail>(`${API}/entity/${safe}.json`);
+  }
+  return fetchJson<EntityDetail>(`/api/entity/${encodeURIComponent(id)}`);
+}
+
+/** Reconstruct the external URL from an entity id (client-side mirror of the
+ * server's `url_for_id`, for chips that don't fetch the detail). */
+export function entityUrl(id: string): string | null {
+  const [kind, key] = [id.slice(0, id.indexOf(':')), id.slice(id.indexOf(':') + 1)];
+  if (!key) return null;
+  switch (kind) {
+    case 'github':
+      return `https://github.com/${key}`;
+    case 'arxiv':
+      return `https://arxiv.org/abs/${key}`;
+    case 'doi':
+      return `https://doi.org/${key}`;
+    case 'npm':
+      return `https://www.npmjs.com/package/${key}`;
+    case 'crates':
+      return `https://crates.io/crates/${key}`;
+    case 'pypi':
+      return `https://pypi.org/project/${key}`;
+    case 'hn':
+      return `https://news.ycombinator.com/item?id=${key}`;
+    default:
+      return null;
+  }
 }

--- a/console-ui/src/lib/api.ts
+++ b/console-ui/src/lib/api.ts
@@ -333,10 +333,10 @@ export function fetchEntities(): Promise<EntityRow[]> {
 /** GET /api/entity/:id — one entity's mentioning sources + citing claims. */
 export function fetchEntity(id: string): Promise<EntityDetail> {
   if (STATIC_MODE) {
-    // Published per-entity files are named with the same safe-component rule
-    // the publisher uses (`:` and `/` → `_`).
-    const safe = id.replace(/[^A-Za-z0-9._-]/g, '_');
-    return fetchJson<EntityDetail>(`${API}/entity/${safe}.json`);
+    // Published per-entity files are base64url(id) — reversible + collision-
+    // free, matching the publisher's `entity_filename`. Entity ids are ascii.
+    const b64 = btoa(id).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    return fetchJson<EntityDetail>(`${API}/entity/${b64}.json`);
   }
   return fetchJson<EntityDetail>(`/api/entity/${encodeURIComponent(id)}`);
 }

--- a/console-ui/src/lib/types.ts
+++ b/console-ui/src/lib/types.ts
@@ -121,6 +121,9 @@ export interface SourceRow {
   /** Machine-inferred backfill tags (tags-suggest kNN vote). Present only
    * while the source has no operator tags; rendered visibly weaker. */
   tags_inferred?: string[];
+  /** Tier-0 URL entity ids this source mentions (`github:owner/repo`,
+   * `arxiv:2504.19413`). Public content — present on the published model too. */
+  entities?: string[];
 }
 
 export interface PackRow {

--- a/console-ui/src/pages/EntitiesPage.tsx
+++ b/console-ui/src/pages/EntitiesPage.tsx
@@ -1,0 +1,87 @@
+/** Entities `/entities` — the Tier-0 URL entity index: machine-verified
+ * referents (github repos, arxiv papers, packages) ranked by how many of your
+ * sources mention them. The cross-source count is the value ("this repo
+ * appears in 7 things I've read"). Deterministic, no LLM. */
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { entityUrl, fetchEntities, type EntityRow } from '../lib/api';
+import { EmptyState, PageHelp } from '../components/ui';
+import { useI18n } from '../i18n';
+
+const KINDS = ['all', 'github', 'arxiv', 'doi', 'npm', 'crates', 'pypi', 'hn'];
+
+export default function EntitiesPage() {
+  const { t } = useI18n();
+  const [rows, setRows] = useState<EntityRow[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [kind, setKind] = useState('all');
+  const [filter, setFilter] = useState('');
+
+  useEffect(() => {
+    fetchEntities()
+      .then(setRows)
+      .catch((e: Error) => setError(e.message));
+  }, []);
+
+  const needle = filter.trim().toLowerCase();
+  const shown = (rows ?? []).filter(
+    (r) => (kind === 'all' || r.kind === kind) && (!needle || r.id.toLowerCase().includes(needle)),
+  );
+
+  return (
+    <>
+      <h1 style={{ marginTop: '1rem' }}>{t('entities.title')}</h1>
+      <PageHelp>{t('entities.help')}</PageHelp>
+      {error && <p className="fail-note">{error}</p>}
+
+      <div className="filter-row">
+        {KINDS.map((k) => (
+          <button
+            key={k}
+            type="button"
+            className={kind === k ? 'active' : ''}
+            onClick={() => setKind(k)}
+          >
+            {k === 'all' ? t('entities.all') : k}
+          </button>
+        ))}
+      </div>
+      <input
+        type="search"
+        value={filter}
+        placeholder={t('entities.filter')}
+        onChange={(e) => setFilter(e.target.value)}
+        style={{ margin: '0.6rem 0' }}
+      />
+
+      {rows && shown.length === 0 && (
+        <EmptyState>
+          <p>{t('entities.empty')}</p>
+        </EmptyState>
+      )}
+      <div className="row-list">
+        {shown.map((r) => (
+          <div className="row" key={r.id}>
+            <span className="row-main">
+              <Link to={`/entity/${encodeURIComponent(r.id)}`}>@{r.id}</Link>
+              {entityUrl(r.id) && (
+                <a
+                  href={entityUrl(r.id)!}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="entity-out"
+                  title={entityUrl(r.id)!}
+                >
+                  ↗
+                </a>
+              )}
+            </span>
+            <span className="meta">
+              {r.count} {t('entities.sources')}
+            </span>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/console-ui/src/pages/EntityDetailPage.tsx
+++ b/console-ui/src/pages/EntityDetailPage.tsx
@@ -15,13 +15,20 @@ export default function EntityDetailPage() {
 
   useEffect(() => {
     if (!id) return;
+    let cancelled = false;
     setStatus('loading');
     fetchEntity(id)
       .then((d) => {
+        if (cancelled) return;
         setDetail(d);
         setStatus('ready');
       })
-      .catch(() => setStatus('error'));
+      .catch(() => {
+        if (!cancelled) setStatus('error');
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [id]);
 
   return (

--- a/console-ui/src/pages/EntityDetailPage.tsx
+++ b/console-ui/src/pages/EntityDetailPage.tsx
@@ -1,0 +1,97 @@
+/** Entity detail `/entity/:id` — one URL entity: its external link, the
+ * sources that mention it, and the durable/caveated claims those sources
+ * cite. The reverse of a SourceDetail entity chip. */
+import { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { fetchEntity, type EntityDetail } from '../lib/api';
+import { ClaimPill, EmptyState, ModelGate } from '../components/ui';
+import { useI18n } from '../i18n';
+
+export default function EntityDetailPage() {
+  const { t } = useI18n();
+  const { id } = useParams<{ id: string }>();
+  const [detail, setDetail] = useState<EntityDetail | null>(null);
+  const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
+
+  useEffect(() => {
+    if (!id) return;
+    setStatus('loading');
+    fetchEntity(id)
+      .then((d) => {
+        setDetail(d);
+        setStatus('ready');
+      })
+      .catch(() => setStatus('error'));
+  }, [id]);
+
+  return (
+    <ModelGate loading={status === 'loading'} error={status === 'error' ? t('entities.notFound') : null}>
+      {detail && (
+        <>
+          <div className="crumbs">
+            <Link to="/entities">{t('entities.title')}</Link> / @{detail.id}
+          </div>
+          <div className="src-head">
+            <h1 style={{ marginBottom: '0.25rem' }}>@{detail.id}</h1>
+          </div>
+          <dl className="meta-rows">
+            {detail.url && (
+              <>
+                <dt>{t('entities.url')}</dt>
+                <dd>
+                  <a className="mono tiny" href={detail.url} target="_blank" rel="noreferrer">
+                    {detail.url}
+                  </a>
+                </dd>
+              </>
+            )}
+            {detail.kind && (
+              <>
+                <dt>{t('entities.kind')}</dt>
+                <dd className="tiny">{detail.kind}</dd>
+              </>
+            )}
+          </dl>
+
+          <div className="section">
+            <h2>
+              {t('entities.mentionedIn')} ({detail.sources.length})
+            </h2>
+            <div className="row-list">
+              {detail.sources.map((s) => (
+                <div className="row" key={s.sha256}>
+                  <span className="row-main">
+                    <Link to={`/library/${s.sha256}`}>{s.title ?? s.sha256}</Link>
+                  </span>
+                  <span className="meta">{s.date ?? ''}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="section">
+            <h2>
+              {t('entities.citingClaims')} ({detail.citing_claims.length})
+            </h2>
+            {detail.citing_claims.length === 0 ? (
+              <EmptyState>
+                <p>{t('entities.noClaims')}</p>
+              </EmptyState>
+            ) : (
+              <ul className="citing-list">
+                {detail.citing_claims.map((c) => (
+                  <li key={c.claim_id}>
+                    {(c.status === 'durable' || c.status === 'caveated') && (
+                      <ClaimPill status={c.status} />
+                    )}{' '}
+                    <Link to={`/knowledge#${c.claim_id}`}>{c.claim}</Link>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </>
+      )}
+    </ModelGate>
+  );
+}

--- a/console-ui/src/pages/SourceDetailPage.tsx
+++ b/console-ui/src/pages/SourceDetailPage.tsx
@@ -9,7 +9,7 @@ import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import KnowledgeGraph from '../components/KnowledgeGraph';
 import { ClaimPill, EmptyState, StatusPill } from '../components/ui';
 import { useI18n } from '../i18n';
-import { fetchSourceDetail, fetchTags, postSourceTags, STATIC_MODE } from '../lib/api';
+import { entityUrl, fetchSourceDetail, fetchTags, postSourceTags, STATIC_MODE } from '../lib/api';
 import { collectionOf } from '../lib/derive';
 import { MarkdownView } from '../lib/markdown';
 import type { ClaimRow, SourceDetail, SourceRow } from '../lib/types';
@@ -306,6 +306,29 @@ export default function SourceDetailPage() {
                 }
               }}
             />
+          </>
+        )}
+        {(source.entities ?? []).length > 0 && (
+          <>
+            <dt>{t('entities.title')}</dt>
+            <dd>
+              {(source.entities ?? []).map((id) => (
+                <span key={id} className="entity-chip">
+                  <Link to={`/entity/${encodeURIComponent(id)}`}>@{id}</Link>
+                  {entityUrl(id) && (
+                    <a
+                      href={entityUrl(id)!}
+                      target="_blank"
+                      rel="noreferrer"
+                      title={entityUrl(id)!}
+                      className="entity-out"
+                    >
+                      ↗
+                    </a>
+                  )}
+                </span>
+              ))}
+            </dd>
           </>
         )}
         {source.last_run_id && (

--- a/crates/ovp-api-projection/src/bodies.rs
+++ b/crates/ovp-api-projection/src/bodies.rs
@@ -48,6 +48,79 @@ pub fn find_body(model: &IndexModel, query: &Query) -> Value {
     serde_json::to_value(&hits).unwrap_or_else(|_| json!([]))
 }
 
+/// `/api/entities` — the Tier-0 URL entity index, one row per entity id with
+/// its kind, external URL, and mention count, most-mentioned first. Derived
+/// entirely from `SourceRow.entities` (no sidecar), so live and publish agree.
+pub fn entities_body(model: &IndexModel) -> Value {
+    let mut counts: HashMap<&str, usize> = HashMap::new();
+    for s in &model.sources {
+        for e in &s.entities {
+            *counts.entry(e.as_str()).or_default() += 1;
+        }
+    }
+    let mut rows: Vec<(&str, usize)> = counts.into_iter().collect();
+    rows.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(b.0)));
+    let entities: Vec<Value> = rows
+        .into_iter()
+        .filter_map(|(id, count)| {
+            Some(json!({
+                "id": id,
+                "kind": ovp_domain::url_entities::kind_of_id(id)?,
+                "url": ovp_domain::url_entities::url_for_id(id)?,
+                "count": count,
+            }))
+        })
+        .collect();
+    json!({ "entities": entities })
+}
+
+/// `/api/entity/:id` — one entity: its external URL + the sources that mention
+/// it (title/sha for linking) + the durable/caveated claims those sources
+/// cite (via pack join). `None` when the id mentions no source (→ 404).
+pub fn entity_body(model: &IndexModel, id: &str) -> Option<Value> {
+    let id_lc = id.to_lowercase();
+    let sources: Vec<&SourceRow> = model
+        .sources
+        .iter()
+        .filter(|s| s.entities.iter().any(|e| *e == id_lc))
+        .collect();
+    if sources.is_empty() {
+        return None;
+    }
+    // Claims whose cited case_ids join to any mentioning source's pack.
+    let cases: std::collections::HashSet<String> = sources
+        .iter()
+        .filter_map(|s| s.pack_dir.as_deref().and_then(last_path_segment))
+        .map(str::to_string)
+        .collect();
+    let mut claims: Vec<&ClaimRow> = model
+        .claims
+        .iter()
+        .filter(|c| c.sources.iter().any(|s| cases.contains(s)))
+        .collect();
+    claims.sort_by_key(|c| {
+        (
+            match c.status {
+                ClaimStatus::Durable => 0u8,
+                ClaimStatus::Caveated => 1,
+                _ => 2,
+            },
+            c.claim_id.clone(),
+        )
+    });
+    Some(json!({
+        "id": id_lc,
+        "kind": ovp_domain::url_entities::kind_of_id(&id_lc),
+        "url": ovp_domain::url_entities::url_for_id(&id_lc),
+        "sources": sources.iter().map(|s| json!({
+            "sha256": s.sha256,
+            "title": s.title,
+            "date": s.date,
+        })).collect::<Vec<_>>(),
+        "citing_claims": claims,
+    }))
+}
+
 /// `/api/settings` — the PUBLIC subset only. Drops `vault_root`, `llm_configured`,
 /// `ask_limits`, the last-run heartbeat, and live-queued backlog; keeps schema,
 /// date, provenance stamp, and the public counts. The live server has its own

--- a/crates/ovp-api-projection/src/bodies.rs
+++ b/crates/ovp-api-projection/src/bodies.rs
@@ -93,9 +93,13 @@ pub fn entity_body(model: &IndexModel, id: &str) -> Option<Value> {
         .filter_map(|s| s.pack_dir.as_deref().and_then(last_path_segment))
         .map(str::to_string)
         .collect();
+    // Only durable/caveated claims — the endpoint contract + UI describe
+    // active knowledge; a superseded/retracted claim rendered without a pill
+    // would read as current.
     let mut claims: Vec<&ClaimRow> = model
         .claims
         .iter()
+        .filter(|c| matches!(c.status, ClaimStatus::Durable | ClaimStatus::Caveated))
         .filter(|c| c.sources.iter().any(|s| cases.contains(s)))
         .collect();
     claims.sort_by_key(|c| {

--- a/crates/ovp-api-projection/src/graph.rs
+++ b/crates/ovp-api-projection/src/graph.rs
@@ -1955,6 +1955,7 @@ mod tests {
                     last_reason: None,
                     tags: Vec::new(),
                     tags_inferred: Vec::new(),
+                    entities: Vec::new(),
                 })
                 .collect(),
             packs: cases
@@ -2037,6 +2038,7 @@ mod tests {
             last_reason: None,
             tags: Vec::new(),
             tags_inferred: Vec::new(),
+            entities: Vec::new(),
         });
         let resp = source_neighborhood(&records, Some(&model), None, "freshsha").unwrap();
         assert_eq!(resp.nodes.len(), 1);
@@ -2088,6 +2090,7 @@ mod tests {
             last_reason: None,
             tags: Vec::new(),
             tags_inferred: Vec::new(),
+            entities: Vec::new(),
         });
         let evidence = evidence_for("fresh", "freshsha", 2);
         let resp =

--- a/crates/ovp-api-projection/src/redact.rs
+++ b/crates/ovp-api-projection/src/redact.rs
@@ -141,6 +141,7 @@ mod tests {
             last_reason: reason.map(String::from),
             tags: vec!["agent".into()],
             tags_inferred: vec!["rust".into()],
+            entities: vec!["github:owner/repo".into()],
         }
     }
 
@@ -197,6 +198,8 @@ mod tests {
         // Personal taxonomy never ships publicly (operator or inferred).
         assert!(m.sources[0].tags.is_empty());
         assert!(m.sources[0].tags_inferred.is_empty());
+        // URL entities are public content (unlike personal tags) — they survive.
+        assert_eq!(m.sources[0].entities, vec!["github:owner/repo".to_string()]);
         // Only the durable claim survives, citing only the public case.
         assert_eq!(m.claims.len(), 1);
         assert_eq!(m.claims[0].claim_id, "d1");

--- a/crates/ovp-cli/src/commands/index_cmd.rs
+++ b/crates/ovp-cli/src/commands/index_cmd.rs
@@ -53,6 +53,7 @@ pub struct FindArgs {
     pub status: Option<String>,
     pub date: Option<String>,
     pub tag: Option<String>,
+    pub entity: Option<String>,
     pub json: bool,
 }
 
@@ -67,9 +68,10 @@ pub fn run_find(args: FindArgs) -> Result<(), CliError> {
         Some("cards") => Some(QueryKind::Cards),
         Some("units") => Some(QueryKind::Units),
         Some("tags") => Some(QueryKind::Tags),
+        Some("entities") => Some(QueryKind::Entities),
         Some(other) => {
             return Err(CliError::Io(format!(
-                "unknown --kind `{other}` (sources|packs|claims|runs|cards|units|tags)"
+                "unknown --kind `{other}` (sources|packs|claims|runs|cards|units|tags|entities)"
             )))
         }
     };
@@ -90,6 +92,7 @@ pub fn run_find(args: FindArgs) -> Result<(), CliError> {
         date: args.date,
         term: args.term,
         tag,
+        entity: args.entity,
     };
     let hits = match kind {
         Some(QueryKind::Cards | QueryKind::Units) => {

--- a/crates/ovp-cli/src/main.rs
+++ b/crates/ovp-cli/src/main.rs
@@ -307,8 +307,8 @@ enum Cmd {
         vault_root: PathBuf,
         /// Case-insensitive substring over titles/URLs/paths/cards/claims.
         term: Option<String>,
-        /// Restrict to one kind: sources|packs|claims|runs|cards|units|tags
-        /// (`tags` lists the canonical tag vocabulary with source counts).
+        /// Restrict to one kind: sources|packs|claims|runs|cards|units|tags|
+        /// entities (`tags`/`entities` list the vocabulary with source counts).
         #[arg(long)]
         kind: Option<String>,
         /// Status filter (queued|processed|failed|blocked|needs_content|

--- a/crates/ovp-cli/src/main.rs
+++ b/crates/ovp-cli/src/main.rs
@@ -322,6 +322,10 @@ enum Cmd {
         /// resolve via `.ovp/tags/aliases.toml` before matching).
         #[arg(long)]
         tag: Option<String>,
+        /// URL entity id filter over sources (`github:owner/repo`,
+        /// `arxiv:2504.19413`). `--kind entities` lists the entity index.
+        #[arg(long)]
+        entity: Option<String>,
         /// Emit JSON instead of text.
         #[arg(long)]
         json: bool,
@@ -1432,6 +1436,7 @@ fn main() -> ExitCode {
             status,
             date,
             tag,
+            entity,
             json,
         } => commands::index_cmd::run_find(commands::index_cmd::FindArgs {
             vault_root,
@@ -1440,6 +1445,7 @@ fn main() -> ExitCode {
             status,
             date,
             tag,
+            entity,
             json,
         }),
         Cmd::Console { vault_root, date } => {

--- a/crates/ovp-console/src/render.rs
+++ b/crates/ovp-console/src/render.rs
@@ -350,6 +350,7 @@ mod tests {
                     last_reason: None,
                     tags: Vec::new(),
                     tags_inferred: Vec::new(),
+                    entities: Vec::new(),
                 },
                 SourceRow {
                     sha256: "cccc".into(),
@@ -364,6 +365,7 @@ mod tests {
                     last_reason: Some("card synthesis did not parse".into()),
                     tags: Vec::new(),
                     tags_inferred: Vec::new(),
+                    entities: Vec::new(),
                 },
             ],
             packs: vec![PackRow {

--- a/crates/ovp-domain/src/lib.rs
+++ b/crates/ovp-domain/src/lib.rs
@@ -33,6 +33,9 @@ pub mod sources;
 /// alias table. Canonicalization happens at projection build only; raw
 /// frontmatter tags are never rewritten.
 pub mod tags;
+/// Tier-0 URL entities: machine-verifiable referents (github/arxiv/doi/npm/…)
+/// whose identity is a registry URL — deterministic extraction, no LLM.
+pub mod url_entities;
 pub mod transforms;
 /// M14a experimental Grounded Unit extraction spike (parallel, deletable; not
 /// wired into the typed pipeline). See `docs/stage-m14a-grounded-units.md`.

--- a/crates/ovp-domain/src/url_entities.rs
+++ b/crates/ovp-domain/src/url_entities.rs
@@ -130,20 +130,26 @@ fn candidate_urls(text: &str) -> impl Iterator<Item = &str> {
 }
 
 /// Inline `arXiv:NNNN.NNNNN` mentions (case-insensitive), version suffix
-/// stripped — the paper id even when no arxiv.org URL is present.
+/// stripped — the paper id even when no arxiv.org URL is present. Scans the
+/// ORIGINAL bytes (the `arxiv:` needle is pure ASCII, so a case-insensitive
+/// byte match yields offsets into `text` directly — no lowercased-copy
+/// offsets that would misalign after a non-ASCII char).
 fn arxiv_inline_ids(text: &str) -> impl Iterator<Item = String> + '_ {
-    let lower = text.to_lowercase();
+    const NEEDLE: &[u8] = b"arxiv:";
     let bytes = text.as_bytes();
     let mut positions = Vec::new();
-    let mut from = 0;
-    while let Some(rel) = lower[from..].find("arxiv:") {
-        let at = from + rel + "arxiv:".len();
-        positions.push(at);
-        from = at;
+    let mut i = 0;
+    while i + NEEDLE.len() <= bytes.len() {
+        if bytes[i..i + NEEDLE.len()].eq_ignore_ascii_case(NEEDLE) {
+            positions.push(i + NEEDLE.len());
+            i += NEEDLE.len();
+        } else {
+            i += 1;
+        }
     }
     positions
         .into_iter()
-        .filter_map(move |at| normalize_arxiv_id(std::str::from_utf8(&bytes[at..]).ok()?))
+        .filter_map(move |at| normalize_arxiv_id(text.get(at..)?))
 }
 
 /// Parse one already-trimmed URL into an entity, or `None`.
@@ -229,6 +235,11 @@ fn parse_url(url: &str) -> Option<UrlEntity> {
             })
         }
         "news.ycombinator.com" => {
+            // Only the /item route names a story/comment; /user?id=… is a
+            // profile, not an item entity.
+            if segs.first() != Some(&"item") {
+                return None;
+            }
             let id = url.split("id=").nth(1)?;
             let id: String = id.chars().take_while(|c| c.is_ascii_digit()).collect();
             if id.is_empty() {
@@ -327,6 +338,16 @@ mod tests {
         assert_eq!(entities.len(), 1);
         assert_eq!(entities[0].id, "github:owner/repo");
         assert_eq!(entities[0].url, "https://github.com/owner/repo");
+    }
+
+    #[test]
+    fn hn_requires_item_route_and_arxiv_inline_after_non_ascii() {
+        // /user is a profile, not an item.
+        assert!(ids("", "https://news.ycombinator.com/user?id=12345").is_empty());
+        assert_eq!(ids("", "https://news.ycombinator.com/item?id=42"), vec!["hn:42"]);
+        // Inline arXiv mention preceded by a multi-byte char: the byte offset
+        // must land on the original string, not a lowercased copy.
+        assert_eq!(ids("", "论文 arXiv:2504.19413 见"), vec!["arxiv:2504.19413"]);
     }
 
     #[test]

--- a/crates/ovp-domain/src/url_entities.rs
+++ b/crates/ovp-domain/src/url_entities.rs
@@ -151,8 +151,11 @@ fn parse_url(url: &str) -> Option<UrlEntity> {
     let rest = url
         .strip_prefix("https://")
         .or_else(|| url.strip_prefix("http://"))?;
-    let rest = rest.strip_prefix("www.").unwrap_or(rest);
-    let (host, path) = rest.split_once('/').unwrap_or((rest, ""));
+    let (host_raw, path) = rest.split_once('/').unwrap_or((rest, ""));
+    // Hostnames are case-insensitive; lowercase before matching so
+    // `GitHub.com` / `WWW.ARXIV.ORG` resolve like their canonical forms.
+    let host_lc = host_raw.to_lowercase();
+    let host = host_lc.strip_prefix("www.").unwrap_or(&host_lc);
     // Strip query + fragment from the whole path.
     let path = path.split(['?', '#']).next().unwrap_or(path);
     let segs: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();

--- a/crates/ovp-domain/src/url_entities.rs
+++ b/crates/ovp-domain/src/url_entities.rs
@@ -1,0 +1,334 @@
+//! Tier-0 URL entities (docs/stage-tags-product.md §5b): machine-verifiable
+//! referents whose identity IS a registry URL, so extraction is deterministic
+//! string matching — no LLM, no network, ~100% precision. A GitHub repo, an
+//! arXiv paper, a DOI, an npm/crates/PyPI package, a Hacker News item: the
+//! author already did the "linking" by pasting the URL.
+//!
+//! Deliberately NOT here: open entity extraction (people/orgs/concepts) or
+//! Wikidata linking — those stay behind the M34 navigation experiment.
+
+use std::collections::BTreeMap;
+
+/// The registry a URL entity belongs to. `as_str` is the id prefix.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum EntityKind {
+    Github,
+    Arxiv,
+    Doi,
+    Npm,
+    Crates,
+    Pypi,
+    Hn,
+}
+
+impl EntityKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            EntityKind::Github => "github",
+            EntityKind::Arxiv => "arxiv",
+            EntityKind::Doi => "doi",
+            EntityKind::Npm => "npm",
+            EntityKind::Crates => "crates",
+            EntityKind::Pypi => "pypi",
+            EntityKind::Hn => "hn",
+        }
+    }
+}
+
+/// One extracted entity mention. `id` = `<kind>:<normalized-key>` (the stable
+/// identity); `url` = a canonical https URL for the external link.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UrlEntity {
+    pub id: String,
+    pub kind: EntityKind,
+    pub url: String,
+}
+
+/// Reconstruct the canonical external URL from an entity id (`kind:key`).
+/// The whole reverse index (entity → sources) is derivable from the
+/// `SourceRow.entities` forward lists PLUS this — no sidecar file needed.
+pub fn url_for_id(id: &str) -> Option<String> {
+    let (kind, key) = id.split_once(':')?;
+    if key.is_empty() {
+        return None;
+    }
+    Some(match kind {
+        "github" => format!("https://github.com/{key}"),
+        "arxiv" => format!("https://arxiv.org/abs/{key}"),
+        "doi" => format!("https://doi.org/{key}"),
+        "npm" => format!("https://www.npmjs.com/package/{key}"),
+        "crates" => format!("https://crates.io/crates/{key}"),
+        "pypi" => format!("https://pypi.org/project/{key}"),
+        "hn" => format!("https://news.ycombinator.com/item?id={key}"),
+        _ => return None,
+    })
+}
+
+/// The kind prefix of an entity id (`github:owner/repo` → `github`).
+pub fn kind_of_id(id: &str) -> Option<&str> {
+    id.split_once(':').map(|(k, _)| k)
+}
+
+/// GitHub first-path segments that are site features, not repo owners.
+const GITHUB_RESERVED: &[&str] = &[
+    "about", "apps", "collections", "contact", "customer-stories", "dashboard", "enterprise",
+    "explore", "features", "issues", "join", "login", "marketplace", "new", "notifications",
+    "orgs", "pricing", "pulls", "readme", "security", "settings", "site", "sponsors", "stars",
+    "team", "topics", "watching", "codespaces", "search", "trending",
+    // Asset/CDN paths, not repo owners (the `github.com/user-attachments/assets/…`
+    // image host that shows up all over pasted markdown).
+    "user-attachments", "assets", "raw", "gist",
+];
+
+/// GitHub repo-name segment that is really a sub-route captured as the 2nd
+/// segment (bare `github.com/owner` links sometimes trail one of these).
+const GITHUB_NON_REPO: &[&str] = &["followers", "following", "repositories", "stars", "sponsors"];
+
+/// Extract every URL entity mentioned by a source: its own `source_url` plus
+/// every link/bare-URL/`arXiv:id` in the body. Deduped by id, sorted.
+pub fn extract(source_url: &str, body: &str) -> Vec<UrlEntity> {
+    let mut found: BTreeMap<String, UrlEntity> = BTreeMap::new();
+    for raw in candidate_urls(source_url).chain(candidate_urls(body)) {
+        if let Some(e) = parse_url(raw) {
+            found.entry(e.id.clone()).or_insert(e);
+        }
+    }
+    for id in arxiv_inline_ids(source_url).chain(arxiv_inline_ids(body)) {
+        let e = UrlEntity {
+            url: format!("https://arxiv.org/abs/{id}"),
+            id: format!("arxiv:{id}"),
+            kind: EntityKind::Arxiv,
+        };
+        found.entry(e.id.clone()).or_insert(e);
+    }
+    found.into_values().collect()
+}
+
+/// Yield each `http(s)://…` substring, trimmed at the first delimiter and of
+/// trailing sentence punctuation. Deterministic, allocation-light.
+fn candidate_urls(text: &str) -> impl Iterator<Item = &str> {
+    let mut rest = text;
+    std::iter::from_fn(move || {
+        loop {
+            let start = rest.find("http")?;
+            let after = &rest[start..];
+            if after.starts_with("http://") || after.starts_with("https://") {
+                let end = after
+                    .find(|c: char| c.is_whitespace() || "<>()[]{}\"'`|\\".contains(c))
+                    .unwrap_or(after.len());
+                let url = after[..end].trim_end_matches(['.', ',', ';', ':', '!', '?']);
+                rest = &after[end..];
+                if !url.is_empty() {
+                    return Some(url);
+                }
+            } else {
+                // "http" not followed by a scheme — advance past it.
+                rest = &after[4..];
+            }
+        }
+    })
+}
+
+/// Inline `arXiv:NNNN.NNNNN` mentions (case-insensitive), version suffix
+/// stripped — the paper id even when no arxiv.org URL is present.
+fn arxiv_inline_ids(text: &str) -> impl Iterator<Item = String> + '_ {
+    let lower = text.to_lowercase();
+    let bytes = text.as_bytes();
+    let mut positions = Vec::new();
+    let mut from = 0;
+    while let Some(rel) = lower[from..].find("arxiv:") {
+        let at = from + rel + "arxiv:".len();
+        positions.push(at);
+        from = at;
+    }
+    positions
+        .into_iter()
+        .filter_map(move |at| normalize_arxiv_id(std::str::from_utf8(&bytes[at..]).ok()?))
+}
+
+/// Parse one already-trimmed URL into an entity, or `None`.
+fn parse_url(url: &str) -> Option<UrlEntity> {
+    let rest = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))?;
+    let rest = rest.strip_prefix("www.").unwrap_or(rest);
+    let (host, path) = rest.split_once('/').unwrap_or((rest, ""));
+    // Strip query + fragment from the whole path.
+    let path = path.split(['?', '#']).next().unwrap_or(path);
+    let segs: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+
+    match host {
+        "github.com" => {
+            let owner = segs.first()?.to_lowercase();
+            let repo = segs.get(1)?.to_lowercase();
+            let repo = repo.strip_suffix(".git").unwrap_or(&repo).to_string();
+            if GITHUB_RESERVED.contains(&owner.as_str())
+                || GITHUB_NON_REPO.contains(&repo.as_str())
+                || owner.is_empty()
+                || repo.is_empty()
+            {
+                return None;
+            }
+            Some(UrlEntity {
+                url: format!("https://github.com/{owner}/{repo}"),
+                id: format!("github:{owner}/{repo}"),
+                kind: EntityKind::Github,
+            })
+        }
+        "arxiv.org" => {
+            // /abs/<id> or /pdf/<id>(.pdf)
+            let idx = segs.iter().position(|s| *s == "abs" || *s == "pdf")?;
+            let raw = segs.get(idx + 1)?.strip_suffix(".pdf").unwrap_or(segs[idx + 1]);
+            let id = normalize_arxiv_id(raw)?;
+            Some(UrlEntity {
+                url: format!("https://arxiv.org/abs/{id}"),
+                id: format!("arxiv:{id}"),
+                kind: EntityKind::Arxiv,
+            })
+        }
+        "doi.org" | "dx.doi.org" => {
+            let key = path.trim_start_matches('/');
+            if !key.starts_with("10.") {
+                return None;
+            }
+            let key = key.to_lowercase();
+            Some(UrlEntity {
+                url: format!("https://doi.org/{key}"),
+                id: format!("doi:{key}"),
+                kind: EntityKind::Doi,
+            })
+        }
+        "npmjs.com" => {
+            let idx = segs.iter().position(|s| *s == "package")?;
+            let pkg = pkg_key(&segs[idx + 1..])?;
+            Some(UrlEntity {
+                url: format!("https://www.npmjs.com/package/{pkg}"),
+                id: format!("npm:{pkg}"),
+                kind: EntityKind::Npm,
+            })
+        }
+        "crates.io" => {
+            let idx = segs.iter().position(|s| *s == "crates")?;
+            let pkg = pkg_key(&segs[idx + 1..])?;
+            Some(UrlEntity {
+                url: format!("https://crates.io/crates/{pkg}"),
+                id: format!("crates:{pkg}"),
+                kind: EntityKind::Crates,
+            })
+        }
+        "pypi.org" => {
+            let idx = segs.iter().position(|s| *s == "project")?;
+            let pkg = pkg_key(&segs[idx + 1..])?;
+            Some(UrlEntity {
+                url: format!("https://pypi.org/project/{pkg}"),
+                id: format!("pypi:{pkg}"),
+                kind: EntityKind::Pypi,
+            })
+        }
+        "news.ycombinator.com" => {
+            let id = url.split("id=").nth(1)?;
+            let id: String = id.chars().take_while(|c| c.is_ascii_digit()).collect();
+            if id.is_empty() {
+                return None;
+            }
+            Some(UrlEntity {
+                url: format!("https://news.ycombinator.com/item?id={id}"),
+                id: format!("hn:{id}"),
+                kind: EntityKind::Hn,
+            })
+        }
+        _ => None,
+    }
+}
+
+/// npm/crates/pypi package key: first segment (scoped `@org/pkg` keeps both),
+/// lowercased. `None` when empty.
+fn pkg_key(segs: &[&str]) -> Option<String> {
+    let first = segs.first()?;
+    if first.starts_with('@') {
+        let scope = first.to_lowercase();
+        let name = segs.get(1).map(|s| s.to_lowercase());
+        return name.map(|n| format!("{scope}/{n}"));
+    }
+    (!first.is_empty()).then(|| first.to_lowercase())
+}
+
+/// Normalize an arXiv id: `2504.19413`, `2504.19413v2` → `2504.19413`.
+/// Requires the modern `NNNN.NNNNN` shape (4 digits · dot · 4–5 digits).
+fn normalize_arxiv_id(raw: &str) -> Option<String> {
+    let head: String = raw
+        .chars()
+        .take_while(|c| c.is_ascii_digit() || *c == '.')
+        .collect();
+    let (a, b) = head.split_once('.')?;
+    if a.len() == 4 && (4..=5).contains(&b.len()) && b.chars().all(|c| c.is_ascii_digit()) {
+        Some(format!("{a}.{b}"))
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ids(source_url: &str, body: &str) -> Vec<String> {
+        extract(source_url, body).into_iter().map(|e| e.id).collect()
+    }
+
+    #[test]
+    fn github_variants_normalize_to_one_id() {
+        let body = "see [repo](https://github.com/AI4Finance-Foundation/FinGPT/tree/main) \
+                    and https://github.com/ai4finance-foundation/fingpt.git and \
+                    <https://www.github.com/AI4Finance-Foundation/FinGPT?tab=readme>.";
+        assert_eq!(ids("", body), vec!["github:ai4finance-foundation/fingpt"]);
+    }
+
+    #[test]
+    fn github_reserved_and_bare_paths_are_rejected() {
+        let body = "https://github.com/features/actions https://github.com/sponsors/x \
+                    https://github.com/torvalds https://github.com/orgs/rust-lang \
+                    https://github.com/user-attachments/assets/abc-123";
+        assert!(ids("", body).is_empty());
+    }
+
+    #[test]
+    fn arxiv_url_and_inline_and_version_collapse() {
+        let body = "https://arxiv.org/pdf/2504.19413v2.pdf and arXiv:2504.19413 and \
+                    https://arxiv.org/abs/2501.13956";
+        assert_eq!(ids("", body), vec!["arxiv:2501.13956", "arxiv:2504.19413"]);
+    }
+
+    #[test]
+    fn packages_doi_hn_and_scoped() {
+        let body = "https://www.npmjs.com/package/@openai/agents \
+                    https://crates.io/crates/serde \
+                    https://pypi.org/project/requests/ \
+                    https://doi.org/10.1145/3583780.3615036 \
+                    https://news.ycombinator.com/item?id=42007321";
+        assert_eq!(
+            ids("", body),
+            vec![
+                "crates:serde",
+                "doi:10.1145/3583780.3615036",
+                "hn:42007321",
+                "npm:@openai/agents",
+                "pypi:requests",
+            ]
+        );
+    }
+
+    #[test]
+    fn source_url_self_entity_and_non_entities_ignored() {
+        let entities = extract("https://github.com/owner/repo", "a plain https://example.com/x link");
+        assert_eq!(entities.len(), 1);
+        assert_eq!(entities[0].id, "github:owner/repo");
+        assert_eq!(entities[0].url, "https://github.com/owner/repo");
+    }
+
+    #[test]
+    fn markdown_paren_boundary_and_trailing_punct() {
+        let body = "(https://github.com/a/b), then https://arxiv.org/abs/1234.56789.";
+        assert_eq!(ids("", body), vec!["arxiv:1234.56789", "github:a/b"]);
+    }
+}

--- a/crates/ovp-index/src/build.rs
+++ b/crates/ovp-index/src/build.rs
@@ -235,6 +235,7 @@ fn build_sources(
                 last_reason: rec.note.clone(),
                 tags: Vec::new(),
                 tags_inferred: Vec::new(),
+                entities: Vec::new(),
             },
         );
     }
@@ -258,6 +259,7 @@ fn build_sources(
                 last_reason: None,
                 tags: Vec::new(),
                 tags_inferred: Vec::new(),
+                entities: Vec::new(),
             });
         entry.date = Some(rec.date.clone());
         entry.last_run_id = Some(rec.run_id.clone());
@@ -323,6 +325,7 @@ fn build_sources(
                     last_reason: None,
                     tags: Vec::new(),
                     tags_inferred: Vec::new(),
+                    entities: Vec::new(),
                 }
             });
         }
@@ -396,6 +399,13 @@ fn attach_tags(vault_root: &Path, rows: &mut [SourceRow]) -> Result<usize, Strin
             let names: Vec<&str> = voted.iter().map(|t| t.tag.as_str()).collect();
             row.tags_inferred = canonical_tags(&names, &aliases);
         }
+        // Tier-0 URL entities from the SAME per-source read (no extra I/O):
+        // the reverse index (entity → sources) is derived on demand from
+        // these forward lists, so nothing else is persisted.
+        row.entities = ovp_domain::url_entities::extract(&doc.source_url, &doc.body_markdown)
+            .into_iter()
+            .map(|e| e.id)
+            .collect();
     }
     Ok(tagged)
 }
@@ -698,6 +708,7 @@ fn backfill_corpus_packs(
                     last_reason: None,
                     tags: Vec::new(),
                     tags_inferred: Vec::new(),
+                    entities: Vec::new(),
                 });
                 by_sha.insert(sha256.clone(), sources.len() - 1);
                 changed = true;
@@ -1237,6 +1248,7 @@ mod tests {
             last_reason: Some("boom".into()),
             tags: Vec::new(),
             tags_inferred: Vec::new(),
+            entities: Vec::new(),
         };
         let sources = vec![
             src("aaaa", SourceStatus::Blocked, "2026-06-30"), // 8 days stuck

--- a/crates/ovp-index/src/model.rs
+++ b/crates/ovp-index/src/model.rs
@@ -61,6 +61,13 @@ pub struct SourceRow {
     /// surfaces render them visibly weaker (`~#tag`, dashed chips).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tags_inferred: Vec<String>,
+    /// Tier-0 URL entity ids this source mentions (`github:owner/repo`,
+    /// `arxiv:2504.19413`, …), extracted deterministically from the note's
+    /// URL + body. Forward list for the SourceDetail chips + `find --entity`;
+    /// the reverse index (entity → sources) lives in the entities projection.
+    /// Serde-additive: pre-entity indexes deserialize to empty.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub entities: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/ovp-index/src/query.rs
+++ b/crates/ovp-index/src/query.rs
@@ -19,6 +19,9 @@ pub enum QueryKind {
     /// count. Never included in the default all-kinds sweep — only an
     /// explicit `--kind tags` lists it.
     Tags,
+    /// The URL entity index: one row per entity id with its mention count.
+    /// Explicit-only, like `tags`.
+    Entities,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -38,6 +41,9 @@ pub struct Query {
     /// kinds that carry no tags (packs/claims/runs/cards/units), the same
     /// way a date filter excludes claims.
     pub tag: Option<String>,
+    /// URL entity id filter (`github:owner/repo`), exact match over a
+    /// source's `entities`. Source-level like `tag`: excludes tagless kinds.
+    pub entity: Option<String>,
 }
 
 /// One result row, kind-tagged, with a printable line and a link target.
@@ -89,8 +95,47 @@ pub fn run_query(model: &IndexModel, q: &Query) -> Vec<Hit> {
             s.tags.iter().any(|have| have == t) || s.tags_inferred.iter().any(|have| have == t)
         }
     };
+    // Entity ids are already lowercase from extraction; lowercase the query
+    // so `--entity github:Owner/Repo` still matches.
+    let entity = q.entity.as_deref().map(str::to_lowercase);
+    let entity_ok = |s: &crate::model::SourceRow| match &entity {
+        None => true,
+        Some(e) => s.entities.iter().any(|have| have == e),
+    };
 
     let mut hits = Vec::new();
+
+    // Entity vocabulary listing (explicit-only): one row per entity id with
+    // its mention count, most-mentioned first — the cross-source value.
+    if q.kind == Some(QueryKind::Entities) {
+        let mut counts: std::collections::BTreeMap<&str, usize> =
+            std::collections::BTreeMap::new();
+        for s in &model.sources {
+            if !status_ok(source_status_str(s.status)) || !date_ok(s.date.as_deref()) {
+                continue;
+            }
+            for e in &s.entities {
+                *counts.entry(e.as_str()).or_default() += 1;
+            }
+        }
+        let mut rows: Vec<(&str, usize)> = counts
+            .into_iter()
+            .filter(|(e, _)| {
+                matches(&[e]) && entity.as_deref().map(|want| *e == want).unwrap_or(true)
+            })
+            .collect();
+        rows.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(b.0)));
+        for (e, n) in rows {
+            hits.push(Hit {
+                kind: "entity".into(),
+                status: "entity".into(),
+                line: format!("{e} ({n})"),
+                path: None,
+                id: Some(e.to_string()),
+            });
+        }
+        return hits;
+    }
 
     // The vocabulary listing is explicit-only (never in the all-kinds sweep):
     // one row per canonical tag over the status/date-filtered sources, count
@@ -139,7 +184,7 @@ pub fn run_query(model: &IndexModel, q: &Query) -> Vec<Hit> {
     if kind_ok(QueryKind::Sources) {
         for s in &model.sources {
             let status = source_status_str(s.status);
-            if !status_ok(status) || !date_ok(s.date.as_deref()) || !tag_ok(s) {
+            if !status_ok(status) || !date_ok(s.date.as_deref()) || !tag_ok(s) || !entity_ok(s) {
                 continue;
             }
             let title = s.title.as_deref().unwrap_or("(untitled)");
@@ -157,6 +202,9 @@ pub fn run_query(model: &IndexModel, q: &Query) -> Vec<Hit> {
             }
             if !s.tags_inferred.is_empty() {
                 line.push_str(&format!(" ~#{}", s.tags_inferred.join(" ~#")));
+            }
+            if !s.entities.is_empty() {
+                line.push_str(&format!(" @{}", s.entities.join(" @")));
             }
             if s.fail_count > 0 {
                 line.push_str(&format!(" fails={}", s.fail_count));
@@ -177,7 +225,7 @@ pub fn run_query(model: &IndexModel, q: &Query) -> Vec<Hit> {
     if kind_ok(QueryKind::Packs) {
         for p in &model.packs {
             // Packs/claims/runs carry no tags; a tag filter excludes them.
-            if tag.is_some() || !status_ok("pack") || !date_ok(p.date.as_deref()) {
+            if tag.is_some() || entity.is_some() || !status_ok("pack") || !date_ok(p.date.as_deref()) {
                 continue;
             }
             let cards_joined = p.card_titles.join(" | ");
@@ -208,7 +256,7 @@ pub fn run_query(model: &IndexModel, q: &Query) -> Vec<Hit> {
         for c in &model.claims {
             let status = claim_status_str(c.status);
             // Claims carry no date or tags; either filter excludes them.
-            if !status_ok(status) || q.date.is_some() || tag.is_some() {
+            if !status_ok(status) || q.date.is_some() || tag.is_some() || entity.is_some() {
                 continue;
             }
             let theme = c.theme.as_deref().unwrap_or("");
@@ -231,7 +279,7 @@ pub fn run_query(model: &IndexModel, q: &Query) -> Vec<Hit> {
 
     if kind_ok(QueryKind::Runs) {
         for r in &model.runs {
-            if tag.is_some() || !status_ok("run") || !date_ok(Some(&r.date)) {
+            if tag.is_some() || entity.is_some() || !status_ok("run") || !date_ok(Some(&r.date)) {
                 continue;
             }
             if !matches(&[&r.run_id, &r.date]) {
@@ -260,7 +308,7 @@ pub fn run_evidence_query(evidence: &EvidenceModel, q: &Query, limit: usize) -> 
     let mut scored: Vec<(f64, String, Hit)> = Vec::new();
 
     // Evidence rows carry no date or tags; either filter excludes them.
-    if q.date.is_some() || q.tag.is_some() {
+    if q.date.is_some() || q.tag.is_some() || q.entity.is_some() {
         return Vec::new();
     }
 

--- a/crates/ovp-index/src/query.rs
+++ b/crates/ovp-index/src/query.rs
@@ -111,7 +111,9 @@ pub fn run_query(model: &IndexModel, q: &Query) -> Vec<Hit> {
         let mut counts: std::collections::BTreeMap<&str, usize> =
             std::collections::BTreeMap::new();
         for s in &model.sources {
-            if !status_ok(source_status_str(s.status)) || !date_ok(s.date.as_deref()) {
+            // Cross-axis filters narrow the CONTRIBUTING sources (`--kind
+            // entities --tag agent` = entities of agent-tagged sources).
+            if !status_ok(source_status_str(s.status)) || !date_ok(s.date.as_deref()) || !tag_ok(s) {
                 continue;
             }
             for e in &s.entities {
@@ -145,7 +147,10 @@ pub fn run_query(model: &IndexModel, q: &Query) -> Vec<Hit> {
         let mut counts: std::collections::BTreeMap<&str, (usize, usize)> =
             std::collections::BTreeMap::new();
         for s in &model.sources {
-            if !status_ok(source_status_str(s.status)) || !date_ok(s.date.as_deref()) {
+            // `--kind tags --entity github:x/y` = tags of sources mentioning
+            // that entity; the `tag` filter narrows the OUTPUT rows below.
+            if !status_ok(source_status_str(s.status)) || !date_ok(s.date.as_deref()) || !entity_ok(s)
+            {
                 continue;
             }
             for t in &s.tags {

--- a/crates/ovp-index/tests/index_build.rs
+++ b/crates/ovp-index/tests/index_build.rs
@@ -889,6 +889,65 @@ fn tags_are_read_from_current_frontmatter_normalized_and_alias_resolved() {
 }
 
 #[test]
+fn url_entities_extract_dedup_across_sources_and_drive_the_filter() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    // Two sources mention the same repo (once via source_url, once in body)
+    // plus a paper; a third mentions only the paper. Extraction dedups per
+    // source; the entity index aggregates across sources.
+    place(
+        root,
+        "50-Inbox/01-Raw/2026-06/a.md",
+        "---\ntitle: A\nsource: https://github.com/AI4Finance-Foundation/FinGPT\n---\nsee arXiv:2504.19413\n",
+    );
+    place(
+        root,
+        "50-Inbox/01-Raw/2026-06/b.md",
+        "---\ntitle: B\nsource: https://e.x/b\n---\nrepo https://github.com/ai4finance-foundation/fingpt.git and https://arxiv.org/abs/2504.19413v2\n",
+    );
+    place(
+        root,
+        "50-Inbox/01-Raw/2026-06/c.md",
+        "---\ntitle: C\nsource: https://e.x/c\n---\njust a plain https://example.com/x link\n",
+    );
+
+    let model = build_index(root, "2026-06-09", None).unwrap();
+    let a = model.sources.iter().find(|s| s.title.as_deref() == Some("A")).unwrap();
+    assert_eq!(
+        a.entities,
+        vec!["arxiv:2504.19413", "github:ai4finance-foundation/fingpt"]
+    );
+    let c = model.sources.iter().find(|s| s.title.as_deref() == Some("C")).unwrap();
+    assert!(c.entities.is_empty(), "non-registry URLs are not entities");
+
+    // `--entity` restricts sources and excludes tagless kinds.
+    let hits = run_query(
+        &model,
+        &Query {
+            entity: Some("github:AI4Finance-Foundation/FinGPT".into()), // case-forgiving
+            ..Default::default()
+        },
+    );
+    assert_eq!(hits.len(), 2, "both A and B mention the repo: {hits:?}");
+    assert!(hits.iter().all(|h| h.kind == "source"));
+
+    // `--kind entities` = the aggregated index, most-mentioned first.
+    let vocab = run_query(
+        &model,
+        &Query {
+            kind: Some(QueryKind::Entities),
+            ..Default::default()
+        },
+    );
+    let lines: Vec<&str> = vocab.iter().map(|h| h.line.as_str()).collect();
+    assert_eq!(
+        lines,
+        vec!["arxiv:2504.19413 (2)", "github:ai4finance-foundation/fingpt (2)"]
+    );
+}
+
+#[test]
 fn inferred_tags_attach_only_to_untagged_sources_and_match_the_filter() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();

--- a/crates/ovp-mcp/src/lib.rs
+++ b/crates/ovp-mcp/src/lib.rs
@@ -148,15 +148,16 @@ fn handle_tools_list() -> Result<Value, RpcError> {
         "tools": [
             {
                 "name": "find",
-                "description": "Query the OVP index: sources, packs, claims, runs, tags. Filter by kind, status, date, tag, or free-text term.",
+                "description": "Query the OVP index: sources, packs, claims, runs, tags, entities. Filter by kind, status, date, tag, entity, or free-text term.",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
                         "term": { "type": "string", "description": "Free-text search term" },
-                        "kind": { "type": "string", "enum": ["sources", "packs", "claims", "runs", "tags"] },
+                        "kind": { "type": "string", "enum": ["sources", "packs", "claims", "runs", "tags", "entities"] },
                         "status": { "type": "string" },
                         "date": { "type": "string", "description": "Date prefix (YYYY or YYYY-MM or YYYY-MM-DD)" },
-                        "tag": { "type": "string", "description": "Canonical tag filter over sources (kind=tags lists the vocabulary)" }
+                        "tag": { "type": "string", "description": "Canonical tag filter over sources (kind=tags lists the vocabulary)" },
+                        "entity": { "type": "string", "description": "URL entity id filter over sources, e.g. github:owner/repo (kind=entities lists the index)" }
                     }
                 }
             },

--- a/crates/ovp-mcp/src/lib.rs
+++ b/crates/ovp-mcp/src/lib.rs
@@ -216,12 +216,14 @@ fn tool_find(state: &McpState, args: &Value) -> Result<Value, RpcError> {
             "claims" => Some(QueryKind::Claims),
             "runs" => Some(QueryKind::Runs),
             "tags" => Some(QueryKind::Tags),
+            "entities" => Some(QueryKind::Entities),
             _ => None,
         }),
         status: args.get("status").and_then(|v| v.as_str()).map(String::from),
         date: args.get("date").and_then(|v| v.as_str()).map(String::from),
         term: args.get("term").and_then(|v| v.as_str()).map(String::from),
         tag,
+        entity: args.get("entity").and_then(|v| v.as_str()).map(String::from),
     };
 
     let hits = run_query(&model, &query);
@@ -237,7 +239,7 @@ fn tool_search(state: &McpState, args: &Value) -> Result<Value, RpcError> {
         .ok_or_else(|| RpcError { code: -32000, message: "Index not available".into() })?;
 
     let term = args.get("query").and_then(|v| v.as_str()).map(String::from);
-    let query = Query { kind: None, status: None, date: None, term, tag: None };
+    let query = Query { kind: None, status: None, date: None, term, tag: None , entity: None };
     let hits = run_query(&model, &query);
     let text = serde_json::to_string_pretty(&hits).unwrap_or_else(|_| "[]".into());
 

--- a/crates/ovp-publish/src/lib.rs
+++ b/crates/ovp-publish/src/lib.rs
@@ -245,7 +245,7 @@ fn write_api_tree(
             if let Some(id) = e.get("id").and_then(|v| v.as_str())
                 && let Some(v) = bodies::entity_body(public, id)
             {
-                write_json(&api.join("entity").join(format!("{}.json", safe_component(id))), &v)?;
+                write_json(&api.join("entity").join(format!("{}.json", entity_filename(id))), &v)?;
                 files += 1;
             }
         }
@@ -410,6 +410,31 @@ fn safe_component(id: &str) -> String {
     }
 }
 
+/// Base64url (no padding) — a REVERSIBLE, collision-free, filesystem-safe
+/// filename for an entity id. `safe_component` maps both `:` and `/` to `_`,
+/// so `doi:10.x/a:b` and `doi:10.x/a/b` would collide; entity ids are ascii
+/// (URL-derived), and the SPA computes the same encoding to fetch the file.
+fn entity_filename(id: &str) -> String {
+    const T: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    let b = id.as_bytes();
+    let mut out = String::with_capacity(b.len().div_ceil(3) * 4);
+    for chunk in b.chunks(3) {
+        let n = chunk.len();
+        let triple = (u32::from(chunk[0]) << 16)
+            | (chunk.get(1).map_or(0, |&c| u32::from(c)) << 8)
+            | chunk.get(2).map_or(0, |&c| u32::from(c));
+        out.push(T[((triple >> 18) & 63) as usize] as char);
+        out.push(T[((triple >> 12) & 63) as usize] as char);
+        if n > 1 {
+            out.push(T[((triple >> 6) & 63) as usize] as char);
+        }
+        if n > 2 {
+            out.push(T[(triple & 63) as usize] as char);
+        }
+    }
+    out
+}
+
 fn write_json(path: &Path, value: &serde_json::Value) -> Result<(), String> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| format!("mkdir {}: {e}", parent.display()))?;
@@ -434,6 +459,20 @@ mod tests {
         CrystalStatus, DurableCitation, DurableRecord, FinalClass, ProvenanceClass, StrengthClass,
     };
     use ovp_index::{ClaimRow, ClaimStatus, PackRow, SourceRow, SourceStatus, Totals};
+
+    #[test]
+    fn entity_filename_is_collision_free_and_matches_base64url() {
+        // The two DOIs that collide under `safe_component` (`:`/`/` → `_`)
+        // get distinct base64url filenames.
+        assert_ne!(
+            entity_filename("doi:10.x/a:b"),
+            entity_filename("doi:10.x/a/b")
+        );
+        // Standard base64url(no-pad) — the exact string the SPA's
+        // `btoa(id).replace(+→-,/→_).strip(=)` produces.
+        assert_eq!(entity_filename("github:mem0ai/mem0"), "Z2l0aHViOm1lbTBhaS9tZW0w");
+        assert_eq!(entity_filename("arxiv:1"), "YXJ4aXY6MQ");
+    }
 
     fn record() -> DurableRecord {
         DurableRecord {

--- a/crates/ovp-publish/src/lib.rs
+++ b/crates/ovp-publish/src/lib.rs
@@ -167,7 +167,7 @@ fn write_api_tree(
     write_json(&api.join("themes.json"), &bodies::themes_body(records))?;
     write_json(&api.join("flow.json"), &bodies::flow_body(public))?;
     write_json(&api.join("settings.json"), &bodies::settings_public_body(Some(public)))?;
-    let empty = Query { kind: None, status: None, date: None, term: None, tag: None };
+    let empty = Query { kind: None, status: None, date: None, term: None, tag: None , entity: None };
     write_json(&api.join("search-index.json"), &bodies::find_body(public, &empty))?;
     files += 5;
 
@@ -229,6 +229,23 @@ fn write_api_tree(
             files += 1;
             if r.claim_id != r.claim_key && id_counts.get(r.claim_id.as_str()) == Some(&1) {
                 write_json(&api.join("claim").join(format!("{}.json", safe_component(&r.claim_id))), &v)?;
+                files += 1;
+            }
+        }
+    }
+
+    // Tier-0 URL entities: the index + one page per entity. Public content
+    // (URLs, unlike personal tags), so they ship. `safe_component` guards the
+    // filename against `/` in ids like `github:owner/repo`.
+    let entities = bodies::entities_body(public);
+    write_json(&api.join("entities.json"), &entities)?;
+    files += 1;
+    if let Some(list) = entities.get("entities").and_then(|v| v.as_array()) {
+        for e in list {
+            if let Some(id) = e.get("id").and_then(|v| v.as_str())
+                && let Some(v) = bodies::entity_body(public, id)
+            {
+                write_json(&api.join("entity").join(format!("{}.json", safe_component(id))), &v)?;
                 files += 1;
             }
         }
@@ -455,6 +472,7 @@ mod tests {
             last_reason: None,
             tags: Vec::new(),
             tags_inferred: Vec::new(),
+            entities: Vec::new(),
         }
     }
 

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -1207,7 +1207,9 @@ fn handle_entities_api(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
 
 /// `GET /api/entity/:id` — one entity's mentioning sources + citing claims.
 fn handle_entity_api(state: &AppState, url: &str) -> Response<std::io::Cursor<Vec<u8>>> {
-    let id = url_decode(url.strip_prefix("/api/entity/").unwrap_or(""));
+    // Strip any query string before the id so `?x=1` never lands in it.
+    let path = url.split('?').next().unwrap_or(url);
+    let id = url_decode(path.strip_prefix("/api/entity/").unwrap_or(""));
     if id.is_empty() {
         return json_response(400, r#"{"error":"missing entity id"}"#);
     }

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -635,6 +635,8 @@ fn dispatch(
         }
         (Method::Get, "/api/tags") => handle_tags_api(state),
         (Method::Post, "/api/tags/decision") => handle_tag_decision(state, body),
+        (Method::Get, "/api/entities") => handle_entities_api(state),
+        (Method::Get, p) if p.starts_with("/api/entity/") => handle_entity_api(state, url),
         (Method::Post, p) if p.starts_with("/api/source/") && p.ends_with("/tags") => {
             handle_source_tags_post(state, p, body)
         }
@@ -943,12 +945,14 @@ fn handle_find(state: &AppState, url: &str) -> Response<std::io::Cursor<Vec<u8>>
             "claims" => Some(QueryKind::Claims),
             "runs" => Some(QueryKind::Runs),
             "tags" => Some(QueryKind::Tags),
+            "entities" => Some(QueryKind::Entities),
             _ => None,
         }),
         status: params.get("status").cloned(),
         date: params.get("date").cloned(),
         term: params.get("term").cloned(),
         tag,
+        entity: params.get("entity").cloned(),
     };
 
     let body = bodies::find_body(&model, &query).to_string();
@@ -985,6 +989,7 @@ fn handle_search(state: &AppState, url: &str) -> Response<std::io::Cursor<Vec<u8
         date: None,
         term,
         tag: None,
+        entity: None,
     };
     let body = bodies::find_body(&model, &query).to_string();
     json_stamped(200, &body, Some(&model))
@@ -1189,6 +1194,29 @@ fn handle_graph(state: &AppState, url: &str) -> Response<std::io::Cursor<Vec<u8>
             let body = serde_json::json!({ "error": e.message });
             json_response(e.status, &body.to_string())
         }
+    }
+}
+
+/// `GET /api/entities` — the Tier-0 URL entity index (id/kind/url/count).
+fn handle_entities_api(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
+    let Some(model) = state.current_model() else {
+        return json_response(503, r#"{"error":"index not available"}"#);
+    };
+    json_stamped(200, &bodies::entities_body(&model).to_string(), Some(&model))
+}
+
+/// `GET /api/entity/:id` — one entity's mentioning sources + citing claims.
+fn handle_entity_api(state: &AppState, url: &str) -> Response<std::io::Cursor<Vec<u8>>> {
+    let id = url_decode(url.strip_prefix("/api/entity/").unwrap_or(""));
+    if id.is_empty() {
+        return json_response(400, r#"{"error":"missing entity id"}"#);
+    }
+    let Some(model) = state.current_model() else {
+        return json_response(503, r#"{"error":"index not available"}"#);
+    };
+    match bodies::entity_body(&model, &id) {
+        Some(v) => json_stamped(200, &v.to_string(), Some(&model)),
+        None => json_response(404, r#"{"error":"entity not found"}"#),
     }
 }
 
@@ -2241,6 +2269,7 @@ mod tests {
                 last_reason: None,
                 tags: Vec::new(),
                 tags_inferred: Vec::new(),
+                entities: Vec::new(),
             }],
             packs: vec![PackRow {
                 pack_dir: "40-Resources/Reader/good".into(),
@@ -2760,6 +2789,7 @@ mod tests {
             last_reason: None,
             tags: Vec::new(),
             tags_inferred: Vec::new(),
+            entities: Vec::new(),
         }
     }
 


### PR DESCRIPTION
## What

`docs/stage-tags-product.md` §5b. Machine-verifiable referents whose identity IS a registry URL, so extraction is deterministic string matching — no LLM, no network, ~100% precision. The author already did the linking by pasting the URL; the value is cross-source aggregation ("this repo appears in 13 things I've read").

- **`ovp-domain::url_entities`**: pure `extract(source_url, body)` over github (repo, with reserved-path + CDN-asset reject), arxiv (URL + inline `arXiv:`, version-collapsed), doi, npm/crates/pypi (scoped pkgs), hn. Case-insensitive host match. `url_for_id`/`kind_of_id` reconstruct the reverse index from the forward lists — **no sidecar file**.
- **index**: `SourceRow.entities` populated in the SAME per-source read as tags (zero extra I/O), lifecycle-move aware.
- **query**: `find --entity github:owner/repo` (source filter, case-forgiving) + `--kind entities` (index, most-mentioned first); same on `/api/find` + MCP (schema advertises both).
- **surfaces**: `/api/entities` + `/api/entity/:id` (mentioning sources + durable/caveated citing claims via pack join); SourceDetail entity chips (internal `/entity` link + external ↗); `/entities` index page + `/entity/:id` page + nav — **live AND static**. Publish **includes** entities (URLs are public content, unlike tags): `entities.json` + per-entity pages, filenames base64url-encoded (reversible, collision-free — `doi:…/a:b` vs `…/a/b` no longer collapse).

## Real-vault verification

1246 distinct entities from 1246 sources. Top: `mem0ai/mem0` (13 sources, 23 citing claims), `nousresearch/hermes-agent` (12), `langchain-ai/deepagents` (11), `openai/codex` (10). Index rebuild 2.3s. One CDN-path junk (`github:user-attachments/assets`) found and gated.

## Gates

84 Rust suites + SPA tsc/vitest/build green; clippy clean. codex review: GATE PASS (0 P1); 4 findings fixed (retired-claim filter, base64url publish filenames, MCP schema, host casing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Entities section for browsing and filtering extracted URL entities.
  * Added entity detail pages showing sources that mention an entity and related claims.
  * Added entity links and external URL shortcuts to source details.
  * Added entity filtering and entity-index queries to the command-line and search APIs.
  * Added support for GitHub, arXiv, DOI, npm, crates.io, PyPI, and Hacker News entities.
  * Added English and Simplified Chinese translations for the new interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->