### PR TITLE
feat(tags): T3 granularity — implications (specific ⇒ generic) roll-up + two-level facet

### DIFF
--- a/console-ui/src/design/portal.css
+++ b/console-ui/src/design/portal.css
@@ -728,6 +728,17 @@ body {
   border-style: dashed;
   opacity: 0.75;
 }
+/* Implied roll-up tags (`>#generic`): dotted + faint — a derived view. */
+.tag-chip.implied {
+  border-style: dotted;
+  opacity: 0.6;
+}
+/* Facet drill-down children: indented sub-list under an active generic. */
+.facet-children {
+  margin: 0.15rem 0 0.3rem 0.9rem;
+  padding-left: 0.5rem;
+  border-left: 1px solid var(--border);
+}
 /* Inline accept ✓ inside an inferred chip (SourceDetail). */
 .tag-chip-accept {
   border: 0;

--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -224,6 +224,13 @@ export const en = {
   'tags.reverseHint': 'Merge the other direction (make the second tag the alias)',
   'tags.showWeak': 'Show weaker candidates',
   'tags.hideWeak': 'Hide weaker candidates',
+  'tags.implyInbox': 'Implication proposals',
+  'tags.implyHelp':
+    'A specific tag that almost always co-occurs with a broader one, but not the reverse — accept to roll the specific up under the generic (searching/faceting the generic then finds it).',
+  'tags.forward': 'rolls up',
+  'tags.reverseProb': 'reverse',
+  'tags.implyHint': 'Roll the specific tag up under the generic',
+  'library.byTagChildren': 'more specific',
   'tags.accept': 'Accept',
   'tags.reject': 'Reject',
   'tags.vocabulary': 'Vocabulary',

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -214,6 +214,13 @@ export const zh: Record<keyof typeof en, string> = {
   'tags.reverseHint': '反方向合并（把第二个标签作为别名）',
   'tags.showWeak': '显示较弱候选',
   'tags.hideWeak': '隐藏较弱候选',
+  'tags.implyInbox': '蕴含提案',
+  'tags.implyHelp':
+    '一个具体标签几乎总是和某个更宽泛的标签同现,但反过来不成立——接受后把具体标签归入泛化标签(之后搜索/筛选泛化标签也能找到它)。',
+  'tags.forward': '归入',
+  'tags.reverseProb': '反向',
+  'tags.implyHint': '把具体标签归入泛化标签',
+  'library.byTagChildren': '更具体',
   'tags.accept': '接受',
   'tags.reject': '拒绝',
   'tags.vocabulary': '词表',

--- a/console-ui/src/lib/api.ts
+++ b/console-ui/src/lib/api.ts
@@ -629,7 +629,18 @@ export interface TagRow {
   tag: string;
   user: number;
   inferred: number;
+  implied?: number;
   origin?: 'user' | 'community' | 'llm' | null;
+}
+
+export interface ImplicationProposal {
+  specific: string;
+  specific_count: number;
+  generic: string;
+  generic_count: number;
+  forward: number;
+  reverse: number;
+  name_cosine?: number;
 }
 
 export interface TagProposal {
@@ -650,9 +661,12 @@ export interface TagsPayload {
   tags: TagRow[];
   banned: string[];
   proposals: TagProposal[];
+  implication_proposals?: ImplicationProposal[];
+  /** Accepted implication edges: specific → generics it rolls up to. */
+  implications?: Record<string, string[]>;
 }
 
-/** GET /api/tags — vocabulary counts + pending merge proposals. */
+/** GET /api/tags — vocabulary counts + pending merge/implication proposals. */
 export function fetchTags(): Promise<TagsPayload> {
   if (STATIC_MODE) {
     return Promise.resolve({ tags: [], banned: [], proposals: [] });
@@ -687,6 +701,15 @@ export async function postTagDecision(
   canonical: string,
 ): Promise<void> {
   await postJson('/api/tags/decision', { action, alias, canonical });
+}
+
+/** POST /api/tags/decision — accept/reject an implication `specific ⇒ generic`. */
+export async function postImplicationDecision(
+  action: 'accept_implication' | 'reject',
+  specific: string,
+  generic: string,
+): Promise<void> {
+  await postJson('/api/tags/decision', { action, specific, generic });
 }
 
 /** POST /api/source/:sha/tags — the one sanctioned frontmatter write

--- a/console-ui/src/lib/derive.ts
+++ b/console-ui/src/lib/derive.ts
@@ -865,7 +865,8 @@ export function filterSources(
       (filter.status === null || s.status === filter.status) &&
       (filter.tag === null ||
         (s.tags ?? []).includes(filter.tag) ||
-        (s.tags_inferred ?? []).includes(filter.tag)),
+        (s.tags_inferred ?? []).includes(filter.tag) ||
+        (s.tags_implied ?? []).includes(filter.tag)),
   );
 }
 
@@ -954,17 +955,15 @@ export function loadLibraryNavSnapshot(): LibraryNavSnapshot | null {
   }
 }
 
-/** Tag → source count over the whole library (operator + inferred — the
- * facet filters on both), count desc then name. */
+/** Tag → source count over the whole library (operator + inferred + implied
+ * roll-up — the facet filters on all three), count desc then name. */
 export function countTags(sources: SourceRow[]): [string, number][] {
   const counts = new Map<string, number>();
+  const bump = (t: string) => counts.set(t, (counts.get(t) ?? 0) + 1);
   for (const s of sources) {
-    for (const t of s.tags ?? []) {
-      counts.set(t, (counts.get(t) ?? 0) + 1);
-    }
-    for (const t of s.tags_inferred ?? []) {
-      counts.set(t, (counts.get(t) ?? 0) + 1);
-    }
+    for (const t of s.tags ?? []) bump(t);
+    for (const t of s.tags_inferred ?? []) bump(t);
+    for (const t of s.tags_implied ?? []) bump(t);
   }
   return [...counts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
 }

--- a/console-ui/src/lib/types.ts
+++ b/console-ui/src/lib/types.ts
@@ -174,6 +174,9 @@ export interface SourceRow {
   /** Machine-inferred backfill tags (tags-suggest kNN vote). Present only
    * while the source has no operator tags; rendered visibly weaker. */
   tags_inferred?: string[];
+  /** Generic tags rolled up from tags/tags_inferred via [implications]
+   * (`autogen` source ⇒ `agent`). Rendered as a weaker `>#` roll-up. */
+  tags_implied?: string[];
   /** Tier-0 URL entity ids this source mentions (`github:owner/repo`,
    * `arxiv:2504.19413`). Public content — present on the published model too. */
   entities?: string[];

--- a/console-ui/src/pages/LibraryPage.tsx
+++ b/console-ui/src/pages/LibraryPage.tsx
@@ -3,9 +3,9 @@
  * grouped rows, all state URL-parameterized: /library?c=&m=&status=.
  * Entering a source carries the active filter so detail can prev/next
  * within the same set. */
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
-import { STATIC_MODE } from '../lib/api';
+import { fetchTags, STATIC_MODE } from '../lib/api';
 import { AgeLabel, EmptyState, ModelGate, PageHelp, StatusPill } from '../components/ui';
 import { useI18n, type MsgKey } from '../i18n';
 import {
@@ -46,6 +46,24 @@ function LibraryBody({ model }: { model: IndexModel }) {
   // filter out every source under an invisible facet.
   const tagCounts = countTags(model.sources);
   const tag = tagCounts.length > 0 ? params.get('tag') : null;
+
+  // Implication edges (specific → generics) drive the two-level roll-up:
+  // an active generic tag expands to its specific children for drill-down.
+  // Live server only; the published site has no implications.
+  const [implications, setImplications] = useState<Record<string, string[]>>({});
+  useEffect(() => {
+    if (STATIC_MODE) return;
+    fetchTags()
+      .then((d) => setImplications(d.implications ?? {}))
+      .catch(() => setImplications({}));
+  }, []);
+  // Reverse: generic → its direct specific children (present in the vocab).
+  const childrenOf = (generic: string): string[] =>
+    Object.entries(implications)
+      .filter(([, generics]) => generics.includes(generic))
+      .map(([specific]) => specific)
+      .filter((s) => tagCounts.some(([t]) => t === s))
+      .sort();
 
   const setParam = (key: string, value: string | null) => {
     const next = new URLSearchParams(params);
@@ -175,18 +193,41 @@ function LibraryBody({ model }: { model: IndexModel }) {
           <div className="facet-group">
             <h3>{t('library.byTag')}</h3>
             <ul className="facet-list">
-              {tagFacet.map(([tg, n]) => (
-                <li key={tg}>
-                  <button
-                    type="button"
-                    className={tag === tg ? 'active' : ''}
-                    onClick={() => setParam('tag', tag === tg ? null : tg)}
-                  >
-                    <span>#{tg}</span>
-                    <span className="count">{n}</span>
-                  </button>
-                </li>
-              ))}
+              {tagFacet.map(([tg, n]) => {
+                const children = childrenOf(tg);
+                return (
+                  <li key={tg}>
+                    <button
+                      type="button"
+                      className={tag === tg ? 'active' : ''}
+                      onClick={() => setParam('tag', tag === tg ? null : tg)}
+                    >
+                      <span>
+                        #{tg}
+                        {children.length > 0 && <span className="muted"> ▾</span>}
+                      </span>
+                      <span className="count">{n}</span>
+                    </button>
+                    {/* Drill-down: when this generic is active, list its
+                        specific children so you can narrow the roll-up. */}
+                    {tag === tg && children.length > 0 && (
+                      <ul className="facet-list facet-children">
+                        {children.map((child) => (
+                          <li key={child}>
+                            <button
+                              type="button"
+                              className={tag === child ? 'active' : ''}
+                              onClick={() => setParam('tag', child)}
+                            >
+                              <span>#{child}</span>
+                            </button>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </li>
+                );
+              })}
             </ul>
             {hiddenTagCount > 0 && (
               <p className="muted sm">

--- a/console-ui/src/pages/SourceDetailPage.tsx
+++ b/console-ui/src/pages/SourceDetailPage.tsx
@@ -185,6 +185,16 @@ function SourceTags({
           )}
         </span>
       ))}
+      {(source.tags_implied ?? []).map((tg) => (
+        <Link
+          key={`>${tg}`}
+          className="tag-chip implied"
+          to={`/library?tag=${encodeURIComponent(tg)}`}
+          title="rolled up via implications"
+        >
+          &gt;#{tg}
+        </Link>
+      ))}
       {!STATIC_MODE && (
         <>
           <input
@@ -764,7 +774,10 @@ export default function SourceDetailPage() {
           </>
         )}
         {(!STATIC_MODE ||
-          (source.tags ?? []).length + (source.tags_inferred ?? []).length > 0) && (
+          (source.tags ?? []).length +
+            (source.tags_inferred ?? []).length +
+            (source.tags_implied ?? []).length >
+            0) && (
           <>
             <dt>{t('tags.title')}</dt>
             <SourceTags

--- a/console-ui/src/pages/TagsPage.tsx
+++ b/console-ui/src/pages/TagsPage.tsx
@@ -14,7 +14,14 @@
  *     decidable ones stay front and center. */
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { fetchTags, postTagDecision, type TagProposal, type TagsPayload } from '../lib/api';
+import {
+  fetchTags,
+  postImplicationDecision,
+  postTagDecision,
+  type ImplicationProposal,
+  type TagProposal,
+  type TagsPayload,
+} from '../lib/api';
 import { EmptyState, PageHelp } from '../components/ui';
 import { useI18n } from '../i18n';
 
@@ -50,6 +57,62 @@ export default function TagsPage() {
     } finally {
       setBusy(null);
     }
+  };
+
+  const decideImplication = async (
+    action: 'accept_implication' | 'reject',
+    specific: string,
+    generic: string,
+  ) => {
+    setBusy(`${specific}=>${generic}`);
+    setError(null);
+    try {
+      await postImplicationDecision(action, specific, generic);
+      await reload();
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const implProposals = data?.implication_proposals ?? [];
+
+  const implCard = (p: ImplicationProposal) => {
+    const key = `${p.specific}=>${p.generic}`;
+    return (
+      <div className="row" key={key}>
+        <span className="row-main">
+          <span className="mono">
+            #{p.specific} ({p.specific_count}) ⇒ #{p.generic} ({p.generic_count})
+          </span>
+          <span className="muted sm">
+            {p.name_cosine != null && `${t('tags.nameCos')} ${p.name_cosine.toFixed(2)} · `}
+            {t('tags.forward')} {p.forward.toFixed(2)} · {t('tags.reverseProb')}{' '}
+            {p.reverse.toFixed(2)}
+          </span>
+        </span>
+        <span className="meta">
+          <button
+            type="button"
+            className="tag-chip"
+            disabled={busy === key}
+            title={t('tags.implyHint')}
+            onClick={() => decideImplication('accept_implication', p.specific, p.generic)}
+          >
+            ✓ {t('tags.accept')}
+          </button>
+          <button
+            type="button"
+            className="tag-chip"
+            disabled={busy === key}
+            onClick={() => decideImplication('reject', p.specific, p.generic)}
+          >
+            ✕ {t('tags.reject')}
+          </button>
+        </span>
+      </div>
+    );
   };
 
   const proposals = data?.proposals ?? [];
@@ -138,6 +201,16 @@ export default function TagsPage() {
         </div>
       )}
 
+      {implProposals.length > 0 && (
+        <div className="section">
+          <h2>
+            {t('tags.implyInbox')} ({implProposals.length})
+          </h2>
+          <p className="muted sm">{t('tags.implyHelp')}</p>
+          <div className="row-list">{implProposals.map(implCard)}</div>
+        </div>
+      )}
+
       <div className="section">
         <h2>
           {t('tags.vocabulary')} ({data?.tags.length ?? 0})
@@ -166,6 +239,7 @@ export default function TagsPage() {
               <span className="meta">
                 {r.user}
                 {r.inferred > 0 ? ` + ~${r.inferred}` : ''}
+                {(r.implied ?? 0) > 0 ? ` + >${r.implied}` : ''}
               </span>
             </div>
           ))}

--- a/crates/ovp-api-projection/src/graph.rs
+++ b/crates/ovp-api-projection/src/graph.rs
@@ -1960,6 +1960,7 @@ mod tests {
                     last_reason: None,
                     tags: Vec::new(),
                     tags_inferred: Vec::new(),
+                    tags_implied: Vec::new(),
                     entities: Vec::new(),
                 })
                 .collect(),
@@ -2048,6 +2049,7 @@ mod tests {
             last_reason: None,
             tags: Vec::new(),
             tags_inferred: Vec::new(),
+            tags_implied: Vec::new(),
             entities: Vec::new(),
         });
         let resp = source_neighborhood(&records, Some(&model), None, "freshsha").unwrap();
@@ -2105,6 +2107,7 @@ mod tests {
             last_reason: None,
             tags: Vec::new(),
             tags_inferred: Vec::new(),
+            tags_implied: Vec::new(),
             entities: Vec::new(),
         });
         let evidence = evidence_for("fresh", "freshsha", 2);

--- a/crates/ovp-api-projection/src/redact.rs
+++ b/crates/ovp-api-projection/src/redact.rs
@@ -41,6 +41,7 @@ impl PublicView {
             // effect of the tag facet landing on the live portal.
             s.tags.clear();
             s.tags_inferred.clear();
+            s.tags_implied.clear();
             // `author` is KEPT, deliberately: it is the byline of an article
             // that is already public, and the `url` beside it names the same
             // person or org anyway. This scrubber works by deletion, so every
@@ -151,6 +152,7 @@ mod tests {
             last_reason: reason.map(String::from),
             tags: vec!["agent".into()],
             tags_inferred: vec!["rust".into()],
+            tags_implied: Vec::new(),
             entities: vec!["github:owner/repo".into()],
         }
     }

--- a/crates/ovp-cli/src/commands/crystal_terrain.rs
+++ b/crates/ovp-cli/src/commands/crystal_terrain.rs
@@ -574,6 +574,7 @@ mod tests {
             last_reason: None,
             tags: tags.iter().map(|t| t.to_string()).collect(),
             tags_inferred: inferred.iter().map(|t| t.to_string()).collect(),
+            tags_implied: Vec::new(),
             entities: Vec::new(),
         }
     }

--- a/crates/ovp-cli/src/commands/tags_suggest.rs
+++ b/crates/ovp-cli/src/commands/tags_suggest.rs
@@ -245,6 +245,110 @@ pub(crate) fn merge_proposals(
     (out, suppressed)
 }
 
+/// Schmitz subsumption thresholds (T3, docs §4): a specific tag implies a
+/// generic when almost every specific-source also carries the generic, but
+/// not vice versa (a hierarchy signal, not synonymy).
+const IMPLY_FORWARD: f64 = 0.7; // P(generic | specific) ≥
+const IMPLY_REVERSE: f64 = 0.3; // P(specific | generic) ≤
+const IMPLY_MIN_SPECIFIC: usize = 2; // ignore singleton specifics (noise)
+/// A real `specific ⇒ generic` also has RELATED NAMES (agentic-engineering /
+/// agent, creative-writing / writing, asr / voice). Pure co-occurrence with
+/// no name relation is base-rate noise — in an all-AI corpus every rare tag
+/// co-occurs with `ai`, but `business` is not a KIND of `ai`. Gate on the
+/// same name embeddings the merge candidates use.
+const IMPLY_NAME_COSINE: f64 = 0.35;
+
+/// One proposed `specific ⇒ generic` implication, evidence attached.
+#[derive(Debug, PartialEq, serde::Serialize)]
+pub(crate) struct ImplicationProposal {
+    pub(crate) specific: String,
+    pub(crate) specific_count: usize,
+    pub(crate) generic: String,
+    pub(crate) generic_count: usize,
+    /// P(generic | specific) — how reliably the specific rolls up.
+    pub(crate) forward: f64,
+    /// P(specific | generic) — low = the generic is genuinely broader.
+    pub(crate) reverse: f64,
+    /// Name-embedding cosine — the semantic-relatedness evidence; the list is
+    /// sorted by it so the true is-a-kind-of pairs float above base-rate
+    /// co-occurrence (`business ⇒ ai` sinks below `agentic-engineering ⇒ agent`).
+    pub(crate) name_cosine: f64,
+}
+
+/// Count the intersection of two ASCENDING source-index lists (the vocab
+/// pushes indices in source order, so they're pre-sorted).
+fn sorted_intersection(a: &[usize], b: &[usize]) -> usize {
+    let (mut i, mut j, mut n) = (0, 0, 0);
+    while i < a.len() && j < b.len() {
+        match a[i].cmp(&b[j]) {
+            std::cmp::Ordering::Less => i += 1,
+            std::cmp::Ordering::Greater => j += 1,
+            std::cmp::Ordering::Equal => {
+                n += 1;
+                i += 1;
+                j += 1;
+            }
+        }
+    }
+    n
+}
+
+/// Implication candidates over `tags` = (name, ascending source indices),
+/// gated by co-occurrence subsumption AND name-embedding relatedness
+/// (`name_vectors[i]` aligns with `tags[i]`). Pure, unit-tested. Proposes
+/// `specific ⇒ generic` when the specific is strictly rarer, forward ≥
+/// [`IMPLY_FORWARD`], reverse ≤ [`IMPLY_REVERSE`], names cosine ≥
+/// [`IMPLY_NAME_COSINE`].
+pub(crate) fn implication_proposals(
+    tags: &[(String, Vec<usize>)],
+    name_vectors: &[Vec<f32>],
+) -> Vec<ImplicationProposal> {
+    let mut out = Vec::new();
+    for i in 0..tags.len() {
+        let si = tags[i].1.len();
+        if si < IMPLY_MIN_SPECIFIC {
+            continue;
+        }
+        for (j, (jname, jsrcs)) in tags.iter().enumerate() {
+            let sj = jsrcs.len();
+            // specific (i) must be strictly rarer than the generic (j).
+            if *jname == tags[i].0 || si >= sj {
+                continue;
+            }
+            let both = sorted_intersection(&tags[i].1, jsrcs);
+            if both == 0 {
+                continue;
+            }
+            let forward = both as f64 / si as f64;
+            let reverse = both as f64 / sj as f64;
+            let name_cos = cosine(&name_vectors[i], &name_vectors[j]);
+            if forward >= IMPLY_FORWARD && reverse <= IMPLY_REVERSE && name_cos >= IMPLY_NAME_COSINE
+            {
+                out.push(ImplicationProposal {
+                    specific: tags[i].0.clone(),
+                    specific_count: si,
+                    generic: jname.clone(),
+                    generic_count: sj,
+                    forward: (forward * 1000.0).round() / 1000.0,
+                    reverse: (reverse * 1000.0).round() / 1000.0,
+                    name_cosine: (name_cos * 1000.0).round() / 1000.0,
+                });
+            }
+        }
+    }
+    // Strongest name relation first (base-rate co-occurrence sinks), then
+    // rarest specific, then name for determinism.
+    out.sort_by(|a, b| {
+        b.name_cosine
+            .partial_cmp(&a.name_cosine)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.specific_count.cmp(&b.specific_count))
+            .then_with(|| a.specific.cmp(&b.specific))
+            .then_with(|| a.generic.cmp(&b.generic))
+    });
+    out
+}
+
 pub fn run(args: TagsSuggestArgs) -> Result<(), CliError> {
     if !(-1.0..=1.0).contains(&args.merge_threshold) {
         return Err(CliError::Io(format!(
@@ -449,12 +553,36 @@ pub fn run(args: TagsSuggestArgs) -> Result<(), CliError> {
             })
         })
         .collect();
+    // Implication candidates (specific ⇒ generic) over the same source-index
+    // sets. Drop pairs already implied (operator + UI table) or UI-rejected.
+    let aliases = ovp_domain::tags::TagAliases::load(&args.vault_root).map_err(CliError::Io)?;
+    let mut implications = implication_proposals(&counts, &name_vectors);
+    implications.retain(|p| {
+        !decisions.is_ignored(&p.specific, &p.generic)
+            && !aliases.implied_generics(&p.specific).contains(&p.generic)
+    });
+    implications.truncate(MAX_MERGE_PROPOSALS);
+    let implications_json: Vec<serde_json::Value> = implications
+        .iter()
+        .map(|p| {
+            serde_json::json!({
+                "specific": p.specific,
+                "specific_count": p.specific_count,
+                "generic": p.generic,
+                "generic_count": p.generic_count,
+                "forward": p.forward,
+                "reverse": p.reverse,
+                "name_cosine": p.name_cosine,
+            })
+        })
+        .collect();
     let proposals_json = serde_json::json!({
         "schema": "ovp.tags-proposals/v1",
         "date": model.date,
         "merge_threshold": args.merge_threshold,
         "suppressed_co_occurrence": suppressed,
         "proposals": proposals_with_titles,
+        "implications": implications_json,
     });
     let json_path = args.vault_root.join(layout.tags_proposals_json_file());
     // Atomic write: the live portal polls this file — a truncated read (or a
@@ -506,6 +634,32 @@ pub fn run(args: TagsSuggestArgs) -> Result<(), CliError> {
     }
     report.push_str("```\n");
     report.push_str(&format!(
+        "\n## Implication candidates ({}) — `specific ⇒ generic` (specific rolls \
+         up under generic; accept in the /tags inbox or paste below)\n\n\
+         | name cos | forward | reverse | specific (count) | ⇒ generic (count) |\n\
+         |---|---|---|---|---|\n",
+        implications.len()
+    ));
+    for p in &implications {
+        report.push_str(&format!(
+            "| {:.2} | {:.2} | {:.2} | {} ({}) | {} ({}) |\n",
+            p.name_cosine, p.forward, p.reverse, p.specific, p.specific_count, p.generic, p.generic_count
+        ));
+    }
+    if !implications.is_empty() {
+        report.push_str("\n```toml\n[implications]\n");
+        // Group generics per specific for the paste-ready block.
+        let mut by_specific: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+        for p in &implications {
+            by_specific.entry(&p.specific).or_default().push(&p.generic);
+        }
+        for (s, generics) in by_specific {
+            let list: Vec<String> = generics.iter().map(|g| toml_basic_string(g)).collect();
+            report.push_str(&format!("{} = [{}]\n", toml_basic_string(s), list.join(", ")));
+        }
+        report.push_str("```\n");
+    }
+    report.push_str(&format!(
         "\n## Backfill\n\n{covered}/{} untagged sources received inferred tags \
          (`.ovp/tags/inferred.json`); they surface as `tags_inferred`, never as \
          operator tags. Regenerate anytime; delete the file to turn backfill off.\n",
@@ -519,8 +673,9 @@ pub fn run(args: TagsSuggestArgs) -> Result<(), CliError> {
     std::fs::write(&report_path, report)
         .map_err(|e| CliError::Io(format!("writing {}: {e}", report_path.display())))?;
     println!(
-        "  merges: {} candidate pair(s) → {}",
+        "  merges: {} candidate pair(s), {} implication(s) → {}",
         proposals.len(),
+        implications.len(),
         report_path.display()
     );
     println!("tags-suggest: done. Rebuild the index (`ovp2 index`) to surface inferred tags.");
@@ -604,6 +759,35 @@ mod tests {
         assert!(!name_evidence("ios", "ai", 0.94, 0.242));
         assert!(!name_evidence("git", "go", 0.93, 0.544));
         assert!(!name_evidence("tiptap", "nodejs", 0.94, 0.9));
+    }
+
+    #[test]
+    fn implication_proposals_fire_on_subsumption_only() {
+        // autogen (3 srcs) ⊂ agent (10 srcs): every autogen source is also
+        // agent (forward 1.0), but agent is much broader (reverse 0.3).
+        // rust (4 srcs) overlaps agent partially — NOT a subsumption.
+        let tags = vec![
+            ("agent".to_string(), (0..10).collect::<Vec<usize>>()),
+            ("autogen".to_string(), vec![0, 1, 2]),
+            ("rust".to_string(), vec![0, 1, 20, 21]),
+        ];
+        // Name vectors aligned with `tags`: agent≈autogen (related), rust ⟂.
+        let v = vec![vec![1.0, 0.0], vec![0.9, 0.44], vec![0.0, 1.0]];
+        let got = implication_proposals(&tags, &v);
+        assert_eq!(got.len(), 1, "{got:?}");
+        assert_eq!(got[0].specific, "autogen");
+        assert_eq!(got[0].generic, "agent");
+        assert_eq!(got[0].forward, 1.0);
+        assert!(got[0].reverse <= 0.3);
+        // Same subsumption but UNRELATED names (business ⟂ agent) → rejected.
+        let unrelated = vec![vec![1.0, 0.0], vec![0.0, 1.0], vec![0.0, 1.0]];
+        assert!(implication_proposals(&tags, &unrelated).is_empty());
+        // A singleton specific is ignored (noise floor).
+        let single = vec![
+            ("agent".to_string(), (0..10).collect::<Vec<usize>>()),
+            ("x".to_string(), vec![5]),
+        ];
+        assert!(implication_proposals(&single, &[vec![1.0], vec![1.0]]).is_empty());
     }
 
     #[test]

--- a/crates/ovp-console/src/render.rs
+++ b/crates/ovp-console/src/render.rs
@@ -355,6 +355,7 @@ mod tests {
                     last_reason: None,
                     tags: Vec::new(),
                     tags_inferred: Vec::new(),
+                    tags_implied: Vec::new(),
                     entities: Vec::new(),
                 },
                 SourceRow {
@@ -375,6 +376,7 @@ mod tests {
                     last_reason: Some("card synthesis did not parse".into()),
                     tags: Vec::new(),
                     tags_inferred: Vec::new(),
+                    tags_implied: Vec::new(),
                     entities: Vec::new(),
                 },
             ],

--- a/crates/ovp-domain/src/tags.rs
+++ b/crates/ovp-domain/src/tags.rs
@@ -334,7 +334,8 @@ impl TagAliases {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.map.is_empty()
+        // Implication-only configuration is still configuration (CodeRabbit).
+        self.map.is_empty() && self.implications.is_empty()
     }
 
     pub fn len(&self) -> usize {
@@ -758,6 +759,18 @@ impl TagDecisions {
         self.ignore.remove(&Self::pair(&s, &g));
         self.implications.entry(s).or_default().insert(g);
         Ok(())
+    }
+
+    /// Remove a recorded implication decision — the rollback for an accept
+    /// that turned out to be a no-op after absorb (mirrors `remove_alias`).
+    pub fn remove_implication(&mut self, specific: &str, generic: &str) -> bool {
+        match (normalize_tag(specific), normalize_tag(generic)) {
+            (Some(s), Some(g)) => self
+                .implications
+                .get_mut(&s)
+                .is_some_and(|set| set.remove(&g)),
+            _ => false,
+        }
     }
 
     pub fn parse(text: &str) -> Result<Self, String> {
@@ -1243,6 +1256,26 @@ mod tests {
         // Merged into TagAliases via load (no operator file needed).
         let merged = TagAliases::load(dir.path()).unwrap();
         assert!(merged.implied_generics("autogen").contains("agent"));
+        // Rollback helper: the just-accepted edge is removable (CodeRabbit's
+        // no-op-accept 409 path in the server uses it).
+        assert!(d.remove_implication("autogen", "agent"));
+        assert!(!d.remove_implication("autogen", "agent"), "already gone");
+    }
+
+    /// `is_empty` must see implication-only configuration (CodeRabbit): a
+    /// parsed `[implications]` table with no alias entries is NOT empty.
+    #[test]
+    fn implication_only_config_is_not_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".ovp/tags")).unwrap();
+        std::fs::write(
+            dir.path().join(".ovp/tags/aliases.toml"),
+            "[implications]\n\"autogen\" = [\"agent\"]\n",
+        )
+        .unwrap();
+        let merged = TagAliases::load(dir.path()).unwrap();
+        assert!(!merged.is_empty());
+        assert_eq!(merged.len(), 0, "no alias map entries though");
     }
 
     #[test]

--- a/crates/ovp-domain/src/tags.rs
+++ b/crates/ovp-domain/src/tags.rs
@@ -87,6 +87,10 @@ pub fn normalize_tag(raw: &str) -> Option<String> {
 pub struct TagAliases {
     map: BTreeMap<String, String>,
     drop: std::collections::BTreeSet<String>,
+    /// Danbooru-style implications: a SPECIFIC tag → the GENERIC tags it rolls
+    /// up to (`autogen` ⇒ `agent`). Direct edges only; the closure is
+    /// computed on demand. Both sides normalized + alias-resolved.
+    implications: BTreeMap<String, std::collections::BTreeSet<String>>,
 }
 
 impl TagAliases {
@@ -104,6 +108,9 @@ impl TagAliases {
             aliases: BTreeMap<String, String>,
             #[serde(default)]
             drop: Vec<String>,
+            /// `"specific" = ["generic", …]`.
+            #[serde(default)]
+            implications: BTreeMap<String, Vec<String>>,
         }
         let file: File =
             toml::from_str(text).map_err(|e| format!("tag aliases: invalid TOML: {e}"))?;
@@ -164,7 +171,71 @@ impl TagAliases {
                 ));
             }
         }
-        Ok(Self { map, drop })
+        // Implications: normalize + alias-resolve both sides, reject dead
+        // config (self-loop, dropped/boilerplate target).
+        let resolve = |t: &str| -> Option<String> {
+            let n = normalize_tag(t)?;
+            Some(map.get(&n).cloned().unwrap_or(n))
+        };
+        let mut implications: BTreeMap<String, std::collections::BTreeSet<String>> = BTreeMap::new();
+        for (specific, generics) in &file.implications {
+            let s = resolve(specific).ok_or_else(|| {
+                format!("tag implications: {specific:?} normalizes to nothing")
+            })?;
+            for generic in generics {
+                let g = resolve(generic).ok_or_else(|| {
+                    format!("tag implications: {generic:?} (for {specific:?}) normalizes to nothing")
+                })?;
+                if s == g {
+                    return Err(format!("tag implications: {specific:?} implies itself"));
+                }
+                if drop.contains(&g) || BOILERPLATE_TAGS.contains(&g.as_str()) {
+                    return Err(format!(
+                        "tag implications: {specific:?} ⇒ {g:?} targets a dropped/boilerplate tag"
+                    ));
+                }
+                implications.entry(s.clone()).or_default().insert(g);
+            }
+        }
+        Ok(Self {
+            map,
+            drop,
+            implications,
+        })
+    }
+
+    /// All generics `tag` transitively rolls up to (`autogen` → {agent, ai}),
+    /// excluding `tag`. Cycle-safe.
+    pub fn implied_generics(&self, tag: &str) -> std::collections::BTreeSet<String> {
+        let mut out = std::collections::BTreeSet::new();
+        let mut stack: Vec<String> = self
+            .implications
+            .get(tag)
+            .map(|s| s.iter().cloned().collect())
+            .unwrap_or_default();
+        while let Some(g) = stack.pop() {
+            if out.insert(g.clone())
+                && let Some(next) = self.implications.get(&g)
+            {
+                stack.extend(next.iter().cloned());
+            }
+        }
+        out
+    }
+
+    /// All specifics that transitively imply `generic` — the facet children +
+    /// query-expansion set. O(keys²) but keys is a small curated set.
+    pub fn specifics_of(&self, generic: &str) -> std::collections::BTreeSet<String> {
+        self.implications
+            .keys()
+            .filter(|s| self.implied_generics(s).contains(generic))
+            .cloned()
+            .collect()
+    }
+
+    /// Direct implication edges (specific → generics) for surfaces.
+    pub fn implications(&self) -> &BTreeMap<String, std::collections::BTreeSet<String>> {
+        &self.implications
     }
 
     /// Load the table from `<vault_root>/.ovp/tags/aliases.toml`, then merge
@@ -211,6 +282,21 @@ impl TagAliases {
                 continue;
             }
             self.map.insert(a.clone(), c);
+        }
+        // Merge UI-accepted implications: alias-resolve both sides, skip dead
+        // config (self-loop, dropped/boilerplate target), then add the edge.
+        for (specific, generics) in &decisions.implications {
+            let s = self.resolve(specific).to_string();
+            for generic in generics {
+                let g = self.resolve(generic).to_string();
+                if s == g
+                    || self.drop.contains(&g)
+                    || BOILERPLATE_TAGS.contains(&g.as_str())
+                {
+                    continue;
+                }
+                self.implications.entry(s.clone()).or_default().insert(g);
+            }
         }
     }
 
@@ -580,6 +666,8 @@ pub struct TagDecisions {
     pub aliases: BTreeMap<String, String>,
     /// Rejected pairs, stored as sorted (a, b) name tuples.
     pub ignore: std::collections::BTreeSet<(String, String)>,
+    /// Accepted implications: specific → generics it rolls up to.
+    pub implications: BTreeMap<String, std::collections::BTreeSet<String>>,
 }
 
 impl TagDecisions {
@@ -630,11 +718,25 @@ impl TagDecisions {
         }
     }
 
-    /// Record a rejected pair (the proposal never resurfaces).
+    /// Record a rejected pair (the proposal never resurfaces). Covers both
+    /// merge proposals and implication proposals (a rejected `specific⇒generic`
+    /// is stored as the same order-insensitive ignored pair).
     pub fn reject(&mut self, a: &str, b: &str) -> Result<(), String> {
         let a = normalize_tag(a).ok_or("tag normalizes to nothing")?;
         let b = normalize_tag(b).ok_or("tag normalizes to nothing")?;
         self.ignore.insert(Self::pair(&a, &b));
+        Ok(())
+    }
+
+    /// Record an accepted implication `specific ⇒ generic`.
+    pub fn accept_implication(&mut self, specific: &str, generic: &str) -> Result<(), String> {
+        let s = normalize_tag(specific).ok_or("specific normalizes to nothing")?;
+        let g = normalize_tag(generic).ok_or("generic normalizes to nothing")?;
+        if s == g {
+            return Err("a tag cannot imply itself".into());
+        }
+        self.ignore.remove(&Self::pair(&s, &g));
+        self.implications.entry(s).or_default().insert(g);
         Ok(())
     }
 
@@ -647,6 +749,8 @@ impl TagDecisions {
             aliases: BTreeMap<String, String>,
             #[serde(default)]
             ignore: Vec<(String, String)>,
+            #[serde(default)]
+            implications: BTreeMap<String, Vec<String>>,
         }
         let file: File =
             toml::from_str(text).map_err(|e| format!("tag decisions: invalid TOML: {e}"))?;
@@ -664,6 +768,12 @@ impl TagDecisions {
         for (a, b) in &file.ignore {
             out.reject(a, b)
                 .map_err(|e| format!("tag decisions: ignore ({a:?}, {b:?}): {e}"))?;
+        }
+        for (s, generics) in &file.implications {
+            for g in generics {
+                out.accept_implication(s, g)
+                    .map_err(|e| format!("tag decisions: implication {s:?} ⇒ {g:?}: {e}"))?;
+            }
         }
         Ok(out)
     }
@@ -708,6 +818,13 @@ impl TagDecisions {
                 toml_basic_string(a),
                 toml_basic_string(c)
             ));
+        }
+        if !self.implications.is_empty() {
+            body.push_str("\n[implications]\n");
+            for (s, generics) in &self.implications {
+                let list: Vec<String> = generics.iter().map(|g| toml_basic_string(g)).collect();
+                body.push_str(&format!("{} = [{}]\n", toml_basic_string(s), list.join(", ")));
+            }
         }
         write_atomic(&path, &body)?;
         Ok(path.display().to_string())
@@ -1051,6 +1168,40 @@ mod tests {
         assert!(parse_tag_classify(r#"{"sources":[{"id":0,"tags":[]}]}"#, 2).is_err());
         assert!(parse_tag_classify(r#"{"sources":[{"id":5,"tags":[]}]}"#, 1).is_err());
         assert!(parse_tag_classify(r#"{"new_tags":[]}"#, 0).is_err());
+    }
+
+    #[test]
+    fn implications_transitive_closure_and_reverse() {
+        // autogen ⇒ agent ⇒ ai (two edges); ai-agents is an alias of agent.
+        let t = TagAliases::parse(
+            "[aliases]\n\"ai-agents\" = \"agent\"\n\
+             [implications]\n\"autogen\" = [\"ai-agents\"]\n\"agent\" = [\"ai\"]\n",
+        )
+        .unwrap();
+        // autogen rolls up to agent (alias-resolved) AND ai (transitive).
+        assert_eq!(
+            t.implied_generics("autogen"),
+            ["agent", "ai"].iter().map(|s| s.to_string()).collect()
+        );
+        // reverse: everything that implies ai = autogen + agent.
+        assert_eq!(
+            t.specifics_of("ai"),
+            ["agent", "autogen"].iter().map(|s| s.to_string()).collect()
+        );
+        assert!(TagAliases::parse("[implications]\n\"x\" = [\"x\"]\n").is_err());
+    }
+
+    #[test]
+    fn ui_implications_persist_and_merge_and_roll_up() {
+        let mut d = TagDecisions::default();
+        d.accept_implication("Autogen", "agent").unwrap();
+        assert!(d.accept_implication("x", "x").is_err());
+        let dir = tempfile::tempdir().unwrap();
+        d.save(dir.path()).unwrap();
+        assert_eq!(TagDecisions::load(dir.path()).unwrap(), d);
+        // Merged into TagAliases via load (no operator file needed).
+        let merged = TagAliases::load(dir.path()).unwrap();
+        assert!(merged.implied_generics("autogen").contains("agent"));
     }
 
     #[test]

--- a/crates/ovp-domain/src/tags.rs
+++ b/crates/ovp-domain/src/tags.rs
@@ -205,7 +205,7 @@ impl TagAliases {
     }
 
     /// All generics `tag` transitively rolls up to (`autogen` → {agent, ai}),
-    /// excluding `tag`. Cycle-safe.
+    /// excluding `tag` itself even if a cycle (`a⇒b⇒a`) leads back to it.
     pub fn implied_generics(&self, tag: &str) -> std::collections::BTreeSet<String> {
         let mut out = std::collections::BTreeSet::new();
         let mut stack: Vec<String> = self
@@ -214,6 +214,9 @@ impl TagAliases {
             .map(|s| s.iter().cloned().collect())
             .unwrap_or_default();
         while let Some(g) = stack.pop() {
+            if g == tag {
+                continue; // a cycle back to the start is not a self-implication
+            }
             if out.insert(g.clone())
                 && let Some(next) = self.implications.get(&g)
             {
@@ -282,6 +285,23 @@ impl TagAliases {
                 continue;
             }
             self.map.insert(a.clone(), c);
+        }
+        // Re-canonicalize the OPERATOR implication edges through the now-merged
+        // alias map: a UI merge on an endpoint (`ai-agents → agent`) must move
+        // the edge (`autogen ⇒ ai-agents` → `autogen ⇒ agent`), not leave it
+        // pointing at the obsolete name that source tags no longer carry.
+        let old = std::mem::take(&mut self.implications);
+        for (s, generics) in old {
+            let s2 = self.resolve(&s).to_string();
+            for g in generics {
+                let g2 = self.resolve(&g).to_string();
+                if s2 != g2
+                    && !self.drop.contains(&g2)
+                    && !BOILERPLATE_TAGS.contains(&g2.as_str())
+                {
+                    self.implications.entry(s2.clone()).or_default().insert(g2);
+                }
+            }
         }
         // Merge UI-accepted implications: alias-resolve both sides, skip dead
         // config (self-loop, dropped/boilerplate target), then add the edge.
@@ -1189,6 +1209,27 @@ mod tests {
             ["agent", "autogen"].iter().map(|s| s.to_string()).collect()
         );
         assert!(TagAliases::parse("[implications]\n\"x\" = [\"x\"]\n").is_err());
+
+        // A cycle (a⇒b⇒a) must not make a its own implied-generic/child.
+        let cyc = TagAliases::parse("[implications]\n\"a\" = [\"b\"]\n\"b\" = [\"a\"]\n").unwrap();
+        assert_eq!(cyc.implied_generics("a"), ["b"].iter().map(|s| s.to_string()).collect());
+        assert!(!cyc.specifics_of("a").contains("a"));
+
+        // A UI merge on an implication endpoint re-canonicalizes the edge:
+        // operator `autogen ⇒ ai-agents`, then UI accepts `ai-agents → agent`.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".ovp/tags")).unwrap();
+        std::fs::write(
+            dir.path().join(".ovp/tags/aliases.toml"),
+            "[implications]\n\"autogen\" = [\"ai-agents\"]\n",
+        )
+        .unwrap();
+        let mut d = TagDecisions::default();
+        d.accept("ai-agents", "agent").unwrap();
+        d.save(dir.path()).unwrap();
+        let merged = TagAliases::load(dir.path()).unwrap();
+        assert!(merged.implied_generics("autogen").contains("agent"));
+        assert!(!merged.implied_generics("autogen").contains("ai-agents"));
     }
 
     #[test]

--- a/crates/ovp-index/src/build.rs
+++ b/crates/ovp-index/src/build.rs
@@ -482,6 +482,16 @@ fn attach_tags(vault_root: &Path, rows: &mut [SourceRow]) -> Result<usize, Strin
         } else if row.content_date.is_none() {
             row.content_date = first_iso_day_in(rel);
         }
+        // Roll-up: the generics every own/inferred tag implies (transitive),
+        // minus any already present. Separate field so operator tags stay pure.
+        let mut implied: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+        for t in row.tags.iter().chain(row.tags_inferred.iter()) {
+            implied.extend(aliases.implied_generics(t));
+        }
+        for t in row.tags.iter().chain(row.tags_inferred.iter()) {
+            implied.remove(t);
+        }
+        row.tags_implied = implied.into_iter().collect();
         // Tier-0 URL entities from the SAME per-source read (no extra I/O):
         // the reverse index (entity → sources) is derived on demand from
         // these forward lists, so nothing else is persisted.

--- a/crates/ovp-index/src/model.rs
+++ b/crates/ovp-index/src/model.rs
@@ -113,6 +113,12 @@ pub struct SourceRow {
     /// surfaces render them visibly weaker (`~#tag`, dashed chips).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tags_inferred: Vec<String>,
+    /// Generic tags this source rolls up to via `[implications]` (`autogen`
+    /// source ⇒ `agent`). Derived from `tags`/`tags_inferred` at build, kept
+    /// separate so operator tags stay pure; searching/faceting a generic
+    /// matches these, surfaces render them as a weaker roll-up (`>#tag`).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags_implied: Vec<String>,
     /// Tier-0 URL entity ids this source mentions (`github:owner/repo`,
     /// `arxiv:2504.19413`, …), extracted deterministically from the note's
     /// URL + body. Forward list for the SourceDetail chips + `find --entity`;
@@ -143,6 +149,7 @@ impl SourceRow {
             last_reason: None,
             tags: Vec::new(),
             tags_inferred: Vec::new(),
+            tags_implied: Vec::new(),
             entities: Vec::new(),
         }
     }

--- a/crates/ovp-index/src/query.rs
+++ b/crates/ovp-index/src/query.rs
@@ -87,12 +87,16 @@ pub fn run_query(model: &IndexModel, q: &Query) -> Vec<Hit> {
             None => return Vec::new(),
         },
     };
-    // Operator tags and inferred backfill are both matchable — the filter's
-    // job is recall; the row display keeps the provenance visible (`~#x`).
+    // Operator tags, inferred backfill, AND implied roll-ups are all
+    // matchable — a `--tag agent` filter finds `autogen` sources that roll up
+    // to it. Recall is the filter's job; the row display keeps provenance
+    // visible (`~#` inferred, `>#` implied).
     let tag_ok = |s: &crate::model::SourceRow| match &tag {
         None => true,
         Some(t) => {
-            s.tags.iter().any(|have| have == t) || s.tags_inferred.iter().any(|have| have == t)
+            s.tags.iter().any(|have| have == t)
+                || s.tags_inferred.iter().any(|have| have == t)
+                || s.tags_implied.iter().any(|have| have == t)
         }
     };
     // Entity ids are already lowercase from extraction; lowercase the query
@@ -143,8 +147,8 @@ pub fn run_query(model: &IndexModel, q: &Query) -> Vec<Hit> {
     // one row per canonical tag over the status/date-filtered sources, count
     // descending. `term` narrows by substring; a `--tag` filter is exact.
     if q.kind == Some(QueryKind::Tags) {
-        // (operator count, inferred count) per canonical tag.
-        let mut counts: std::collections::BTreeMap<&str, (usize, usize)> =
+        // (operator, inferred, implied roll-up) counts per canonical tag.
+        let mut counts: std::collections::BTreeMap<&str, (usize, usize, usize)> =
             std::collections::BTreeMap::new();
         for s in &model.sources {
             // `--kind tags --entity github:x/y` = tags of sources mentioning
@@ -159,26 +163,31 @@ pub fn run_query(model: &IndexModel, q: &Query) -> Vec<Hit> {
             for t in &s.tags_inferred {
                 counts.entry(t.as_str()).or_default().1 += 1;
             }
+            for t in &s.tags_implied {
+                counts.entry(t.as_str()).or_default().2 += 1;
+            }
         }
-        let mut rows: Vec<(&str, (usize, usize))> = counts
+        let mut rows: Vec<(&str, (usize, usize, usize))> = counts
             .into_iter()
             .filter(|(t, _)| matches(&[t]) && tag.as_deref().map(|want| *t == want).unwrap_or(true))
             .collect();
         rows.sort_by(|a, b| {
-            (b.1.0 + b.1.1)
-                .cmp(&(a.1.0 + a.1.1))
+            (b.1.0 + b.1.1 + b.1.2)
+                .cmp(&(a.1.0 + a.1.1 + a.1.2))
                 .then_with(|| a.0.cmp(b.0))
         });
-        for (t, (user, inferred)) in rows {
-            let line = if inferred > 0 {
-                format!("{t} ({user}, ~{inferred})")
-            } else {
-                format!("{t} ({user})")
-            };
+        for (t, (user, inferred, implied)) in rows {
+            let mut extra = String::new();
+            if inferred > 0 {
+                extra.push_str(&format!(", ~{inferred}"));
+            }
+            if implied > 0 {
+                extra.push_str(&format!(", >{implied}"));
+            }
             hits.push(Hit {
                 kind: "tag".into(),
                 status: "tag".into(),
-                line,
+                line: format!("{t} ({user}{extra})"),
                 path: None,
                 id: Some(t.to_string()),
             });
@@ -215,6 +224,9 @@ pub fn run_query(model: &IndexModel, q: &Query) -> Vec<Hit> {
             }
             if !s.tags_inferred.is_empty() {
                 line.push_str(&format!(" ~#{}", s.tags_inferred.join(" ~#")));
+            }
+            if !s.tags_implied.is_empty() {
+                line.push_str(&format!(" >#{}", s.tags_implied.join(" >#")));
             }
             if !s.entities.is_empty() {
                 line.push_str(&format!(" @{}", s.entities.join(" @")));

--- a/crates/ovp-index/tests/index_build.rs
+++ b/crates/ovp-index/tests/index_build.rs
@@ -889,6 +889,61 @@ fn tags_are_read_from_current_frontmatter_normalized_and_alias_resolved() {
 }
 
 #[test]
+fn implications_roll_up_generics_and_expand_the_filter() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    place(
+        root,
+        "50-Inbox/01-Raw/2026-06/a.md",
+        "---\ntitle: Autogen Piece\nsource: https://e.x/a\ntags:\n  - autogen\n---\nbody\n",
+    );
+    place(
+        root,
+        "50-Inbox/01-Raw/2026-06/b.md",
+        "---\ntitle: Plain Agent\nsource: https://e.x/b\ntags:\n  - agent\n---\nbody\n",
+    );
+    // autogen ⇒ agent ⇒ ai.
+    place(
+        root,
+        ".ovp/tags/aliases.toml",
+        "[implications]\n\"autogen\" = [\"agent\"]\n\"agent\" = [\"ai\"]\n",
+    );
+
+    let model = build_index(root, "2026-06-09", None).unwrap();
+    let a = model.sources.iter().find(|s| s.title.as_deref() == Some("Autogen Piece")).unwrap();
+    assert_eq!(a.tags, vec!["autogen"]);
+    // Rolls up transitively, own tag excluded.
+    assert_eq!(a.tags_implied, vec!["agent", "ai"]);
+
+    // `--tag agent` finds the autogen source (roll-up) AND the plain one.
+    let hits = run_query(
+        &model,
+        &Query {
+            tag: Some("agent".into()),
+            ..Default::default()
+        },
+    );
+    assert_eq!(hits.len(), 2, "{hits:?}");
+    // The roll-up source marks the implied tag `>#`.
+    assert!(
+        hits.iter().any(|h| h.line.contains("#autogen") && h.line.contains(">#agent")),
+        "{hits:?}"
+    );
+
+    // Vocabulary shows the roll-up count: agent = 1 direct + 1 implied.
+    let vocab = run_query(
+        &model,
+        &Query {
+            kind: Some(QueryKind::Tags),
+            ..Default::default()
+        },
+    );
+    let agent = vocab.iter().find(|h| h.id.as_deref() == Some("agent")).unwrap();
+    assert_eq!(agent.line, "agent (1, >1)");
+}
+
+#[test]
 fn url_entities_extract_dedup_across_sources_and_drive_the_filter() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();

--- a/crates/ovp-memory/src/vault_tools.rs
+++ b/crates/ovp-memory/src/vault_tools.rs
@@ -2892,6 +2892,7 @@ mod tests {
             last_reason: None,
             tags: vec!["agent-memory".into()],
             tags_inferred: vec!["retrieval".into()],
+            tags_implied: vec![],
             entities: vec![],
         }
     }

--- a/crates/ovp-publish/src/lib.rs
+++ b/crates/ovp-publish/src/lib.rs
@@ -567,6 +567,7 @@ mod tests {
             last_reason: None,
             tags: Vec::new(),
             tags_inferred: Vec::new(),
+            tags_implied: Vec::new(),
             entities: Vec::new(),
         }
     }

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -889,8 +889,9 @@ fn handle_tags_api(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
         Some(m) => m,
         None => return json_response(503, r#"{"error":"index not available"}"#),
     };
-    let vocabulary = ovp_domain::tags::TagVocabulary::load(&state.vault_root).unwrap_or_default();
-    let mut counts: std::collections::BTreeMap<&str, (usize, usize)> =
+    let vocabulary =
+        ovp_domain::tags::TagVocabulary::load(&state.vault_root).unwrap_or_default();
+    let mut counts: std::collections::BTreeMap<&str, (usize, usize, usize)> =
         std::collections::BTreeMap::new();
     // Seed from the vocabulary so zero-count community/llm entries still
     // appear (browser completeness + Source Detail autocomplete).
@@ -903,6 +904,9 @@ fn handle_tags_api(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
         }
         for t in &s.tags_inferred {
             counts.entry(t.as_str()).or_default().1 += 1;
+        }
+        for t in &s.tags_implied {
+            counts.entry(t.as_str()).or_default().2 += 1;
         }
     }
     let origins: std::collections::BTreeMap<&str, &str> = vocabulary
@@ -920,11 +924,12 @@ fn handle_tags_api(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
         .collect();
     let tags: Vec<serde_json::Value> = counts
         .iter()
-        .map(|(tag, (user, inferred))| {
+        .map(|(tag, (user, inferred, implied))| {
             serde_json::json!({
                 "tag": tag,
                 "user": user,
                 "inferred": inferred,
+                "implied": implied,
                 "origin": origins.get(tag),
             })
         })
@@ -955,11 +960,44 @@ fn handle_tags_api(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
             && !decisions.is_ignored(alias, canonical)
     })
     .collect();
+    // Implication proposals awaiting a decision: drop ones already implied
+    // (operator + UI table) or UI-rejected — same immediate-retire rule.
+    let impl_proposals: Vec<serde_json::Value> = std::fs::read_to_string(
+        state
+            .vault_root
+            .join(state.layout.tags_proposals_json_file()),
+    )
+    .ok()
+    .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
+    .and_then(|v| v.get("implications").cloned())
+    .and_then(|v| v.as_array().cloned())
+    .unwrap_or_default()
+    .into_iter()
+    .filter(|p| {
+        let specific = p.get("specific").and_then(|v| v.as_str()).unwrap_or("");
+        let generic = p.get("generic").and_then(|v| v.as_str()).unwrap_or("");
+        !specific.is_empty()
+            && !aliases.implied_generics(specific).contains(generic)
+            && !decisions.is_ignored(specific, generic)
+    })
+    .collect();
+    // The accepted implication edges (specific → generics) for the two-level
+    // facet rollup.
+    let implications = serde_json::to_value(
+        aliases
+            .implications()
+            .iter()
+            .map(|(s, generics)| (s.clone(), generics.iter().cloned().collect::<Vec<_>>()))
+            .collect::<std::collections::BTreeMap<_, _>>(),
+    )
+    .unwrap_or_default();
     let banned: Vec<&str> = vocabulary.banned().collect();
     let body = serde_json::json!({
         "tags": tags,
         "banned": banned,
         "proposals": proposals,
+        "implication_proposals": impl_proposals,
+        "implications": implications,
     })
     .to_string();
     json_stamped(200, &body, Some(&model))
@@ -975,13 +1013,20 @@ fn handle_tag_decision(state: &AppState, body: &str) -> Response<std::io::Cursor
         Err(_) => return json_response(400, r#"{"error":"invalid JSON body"}"#),
     };
     let action = parsed.get("action").and_then(|v| v.as_str()).unwrap_or("");
-    let alias = parsed.get("alias").and_then(|v| v.as_str()).unwrap_or("");
+    // Merge decisions carry alias/canonical; implication decisions carry
+    // specific/generic. `reject` accepts either pair.
+    let alias = parsed
+        .get("alias")
+        .or_else(|| parsed.get("specific"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
     let canonical = parsed
         .get("canonical")
+        .or_else(|| parsed.get("generic"))
         .and_then(|v| v.as_str())
         .unwrap_or("");
     if alias.is_empty() || canonical.is_empty() {
-        return json_response(400, r#"{"error":"alias and canonical are required"}"#);
+        return json_response(400, r#"{"error":"both tags of the pair are required"}"#);
     }
     let _write = state
         .tags_write_lock
@@ -993,8 +1038,14 @@ fn handle_tag_decision(state: &AppState, body: &str) -> Response<std::io::Cursor
     };
     let result = match action {
         "accept" => decisions.accept(alias, canonical),
+        "accept_implication" => decisions.accept_implication(alias, canonical),
         "reject" => decisions.reject(alias, canonical),
-        _ => return json_response(400, r#"{"error":"action must be accept or reject"}"#),
+        _ => {
+            return json_response(
+                400,
+                r#"{"error":"action must be accept, accept_implication, or reject"}"#,
+            );
+        }
     };
     if let Err(e) = result {
         return json_response(400, &format!(r#"{{"error":{}}}"#, json_str(&e)));
@@ -4997,6 +5048,7 @@ mod tests {
                 last_reason: None,
                 tags: Vec::new(),
                 tags_inferred: Vec::new(),
+                tags_implied: Vec::new(),
                 entities: Vec::new(),
             }],
             packs: vec![PackRow {
@@ -6013,6 +6065,7 @@ mod tests {
             last_reason: None,
             tags: Vec::new(),
             tags_inferred: Vec::new(),
+            tags_implied: Vec::new(),
             entities: Vec::new(),
         }
     }

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -1077,6 +1077,35 @@ fn handle_tag_decision(state: &AppState, body: &str) -> Response<std::io::Cursor
             );
         }
     }
+    // Same class for implication accepts: absorb can silently discard the
+    // edge (self-loop after alias resolution, or the generic is dropped /
+    // boilerplate) — detect the no-op, roll the decision back, and 409
+    // instead of a false success that leaves the proposal card stuck
+    // (CodeRabbit on PR #347).
+    if action == "accept_implication" {
+        let ns = ovp_domain::tags::normalize_tag(alias).unwrap_or_default();
+        let ng = ovp_domain::tags::normalize_tag(canonical).unwrap_or_default();
+        let merged = ovp_domain::tags::TagAliases::load(&state.vault_root).unwrap_or_default();
+        let s = merged.resolve(&ns).to_string();
+        let g = merged.resolve(&ng).to_string();
+        let effective =
+            !ns.is_empty() && !ng.is_empty() && merged.implied_generics(&s).contains(&g);
+        if !effective {
+            let mut d = ovp_domain::tags::TagDecisions::load(&state.vault_root).unwrap_or_default();
+            d.remove_implication(alias, canonical);
+            let _ = d.save(&state.vault_root);
+            return json_response(
+                409,
+                &format!(
+                    r#"{{"error":{}}}"#,
+                    json_str(&format!(
+                        "implication #{alias} ⇒ #{canonical} cannot take effect (self-loop after \
+                         alias resolution, or the generic is dropped/boilerplate)"
+                    ))
+                ),
+            );
+        }
+    }
     match rebuild_index_now(state) {
         Ok(_) => json_response(200, r#"{"ok":true,"changed":true}"#),
         Err(e) => json_response(500, &format!(r#"{{"error":{}}}"#, json_str(&e))),


### PR DESCRIPTION
## What

`docs/stage-tags-product.md` §4 — the generic-tag drill-down fix (operator pain: "点 #ai 出 164 篇等于没过滤"). Danbooru-style implications let a specific tag roll up under a broader one, so `#agent` covers its specifics AND you can narrow into them.

- **domain**: `[implications]` in aliases.toml + decisions.toml (`specific → [generics]`), transitive closure (`implied_generics`/`specifics_of`, cycle-safe), merged in `TagAliases::load` (operator edges re-canonicalized through UI alias merges); `TagDecisions.accept_implication` (UI-owned, operator file untouched).
- **tags-suggest**: Schmitz subsumption proposals — `specific ⇒ generic` when P(generic|specific) ≥ 0.7, P(specific|generic) ≤ 0.3, specific strictly rarer, **AND name-embedding cosine ≥ 0.35** (kills base-rate co-occurrence: in an all-AI corpus every rare tag co-occurs with `ai`, but `business` is not a KIND of `ai`). Sorted by name cosine so is-a-kind-of pairs float above base-rate noise.
- **index**: `SourceRow.tags_implied` = transitive generics rolled up from tags/tags_inferred (separate field — operator tags stay pure).
- **query/find**: `--tag agent` matches rolled-up specifics; vocabulary count shows the roll-up (`agent (1, >1)`); source line marks implied `>#`.
- **surfaces**: `/api/tags` exposes implications + implication_proposals; TagsPage implication inbox (accept ⇒ decisions.toml, reject remembered); Library facet **two-level** (active generic expands to its specific children); SourceDetail dotted `>#` roll-up chips. Publish clears them (personal taxonomy).

## Real-vault verification

87 raw implication candidates → **42 after the name gate**, sorted top: `tool-ai⇒tool` (0.91), `creative-writing⇒writing` (0.80), `agentic-engineering⇒agent` (0.77), `multi-agent⇒agent` (0.77); base-rate `⇒ai` sinks to the bottom for the operator to reject. `/api/tags` serves 42 proposals; two-level facet + rollup search verified.

## Gates

84 Rust suites + SPA tsc/vitest/build green; clippy clean. codex review: GATE PASS (0 P1); 2 P2s fixed (re-canonicalize operator implications after UI merges, cycle-safe closure).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tag implication support across search, filtering, facets, and source details.
  * Added nested tag drill-down in the Library view.
  * Added an implication curation inbox with accept and reject actions.
  * Added implication candidate suggestions and improved tag count visibility.
  * Added support for transitive tag relationships and implication-aware filtering.

* **Style**
  * Added visual styling and localized labels for implied tags and nested facets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->