### PR TITLE
feat(themes): P0 grounded topic pages (TP1) — crystal-theme-pages + sentence-level evidence gate

### DIFF
--- a/crates/ovp-cli/src/commands/crystal_theme_pages.rs
+++ b/crates/ovp-cli/src/commands/crystal_theme_pages.rs
@@ -54,6 +54,11 @@ pub(crate) struct PageBuildOutcome {
     pub(crate) built: usize,
     pub(crate) kept: usize,
     pub(crate) skipped_small: usize,
+    /// Themes whose draft AND bounded repair both failed the gate, with the
+    /// final defect list. Their old pages are NOT in `pages` — the caller
+    /// writes the partial projection (a missing page is honest; a stale one
+    /// citing retracted claims is not) and then fails loud.
+    pub(crate) failures: Vec<(i64, Vec<String>)>,
 }
 
 /// Group active durable records by majority theme community and synthesize a
@@ -80,11 +85,11 @@ pub(crate) fn build_pages(
         built: 0,
         kept: 0,
         skipped_small: 0,
+        failures: Vec::new(),
     };
     // Failed themes accumulate instead of aborting the loop: one run
     // invalidates EVERY ungrounded cassette entry, so the next live pass
-    // re-asks all of them at once (successes stay cached).
-    let mut failures: Vec<(i64, Vec<String>)> = Vec::new();
+    // re-asks them all at once (successes stay cached).
     for community in &themes.communities {
         let Some(mut group) = by_community.remove(&community.id) else {
             continue;
@@ -152,7 +157,7 @@ pub(crate) fn build_pages(
                 // replaying the same ungrounded page (no-op on replay).
                 client.invalidate(&req);
                 client.invalidate(&repair_req);
-                failures.push((
+                outcome.failures.push((
                     community.id,
                     defects.iter().map(|d| d.to_string()).collect(),
                 ));
@@ -168,19 +173,6 @@ pub(crate) fn build_pages(
             sections,
         });
         outcome.built += 1;
-    }
-    if !failures.is_empty() {
-        let mut msg = format!(
-            "crystal-theme-pages: {} theme(s) failed the page gate (nothing written; rerun re-asks them):",
-            failures.len()
-        );
-        for (id, defects) in &failures {
-            msg.push_str(&format!("\n  t{:03} ({} defect(s)):", id, defects.len()));
-            for d in defects {
-                msg.push_str(&format!("\n    {d}"));
-            }
-        }
-        return Err(CliError::Io(msg));
     }
     Ok(outcome)
 }
@@ -282,11 +274,29 @@ pub fn run(args: CrystalThemePagesArgs) -> Result<(), CliError> {
         args.refresh,
     )?;
 
+    // Write the projection BEFORE reporting gate failures: the passing pages
+    // land, and a failed theme's OLD page (which may cite claims that are no
+    // longer active) is dropped rather than left to masquerade as current
+    // (codex round-3 P2). A missing page is honest; a stale one is not.
     let file = ThemePagesFile {
         schema: THEME_PAGES_SCHEMA.to_string(),
         pages: outcome.pages,
     };
     write_pages_file(&store, &pages_path, &file)?;
+    if !outcome.failures.is_empty() {
+        let mut msg = format!(
+            "crystal-theme-pages: {} theme(s) failed the page gate \
+             (partial projection written without them; rerun re-asks them):",
+            outcome.failures.len()
+        );
+        for (id, defects) in &outcome.failures {
+            msg.push_str(&format!("\n  t{:03} ({} defect(s)):", id, defects.len()));
+            for d in defects {
+                msg.push_str(&format!("\n    {d}"));
+            }
+        }
+        return Err(CliError::Io(msg));
+    }
 
     println!(
         "crystal-theme-pages: {} page(s) ({} built, {} kept, {} theme(s) below --min-claims {}) → {}",
@@ -542,21 +552,24 @@ mod tests {
         r#"{"sections":[{"heading":"H","body":"No citation here.\n\nGhost handle [claim:c9]."}]}"#;
 
     #[test]
-    fn failed_repair_fails_the_gate_loudly() {
+    fn failed_repair_lands_in_failures_and_drops_the_page() {
         let themes = themes_fixture();
         let records = records_fixture();
         let mut client = FixtureModelClient::new();
         client.insert(&fixture_request(), reply(BAD_REPLY));
         // The repair attempt returns the SAME bad draft — still ungrounded.
         client.insert(&fixture_repair_request(BAD_REPLY), reply(BAD_REPLY));
-        let err = build_pages(&records, &themes, None, &mut client, 2, false).unwrap_err();
-        let msg = format!("{err:?}");
-        assert!(msg.contains("1 theme(s) failed the page gate"), "{msg}");
+        let out = build_pages(&records, &themes, None, &mut client, 2, false).unwrap();
+        assert!(out.pages.is_empty(), "failed theme must not produce a page");
+        assert_eq!(out.failures.len(), 1);
+        let (id, defects) = &out.failures[0];
+        assert_eq!(*id, 0);
+        let joined = defects.join("\n");
         assert!(
-            msg.contains("uncited sentence `No citation here.`"),
-            "{msg}"
+            joined.contains("uncited sentence `No citation here.`"),
+            "{joined}"
         );
-        assert!(msg.contains("unknown claim `c9`"), "{msg}");
+        assert!(joined.contains("unknown claim `c9`"), "{joined}");
     }
 
     #[test]

--- a/crates/ovp-cli/src/commands/crystal_theme_pages.rs
+++ b/crates/ovp-cli/src/commands/crystal_theme_pages.rs
@@ -21,8 +21,8 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 
 use ovp_domain::crystal::theme_pages::{
-    PageClaim, THEME_PAGES_SCHEMA, ThemePage, ThemePagesFile, parse_theme_page, theme_page_request,
-    uncited_keys, verify_page,
+    PageClaim, THEME_PAGES_SCHEMA, ThemePage, ThemePagesFile, parse_theme_page, resolve_handles,
+    theme_page_request, uncited_keys, verify_page,
 };
 use ovp_domain::crystal::themes::ThemesFile;
 use ovp_domain::crystal::{CrystalStatus, DurableRecord, StoreEvent, fold_ledger};
@@ -115,7 +115,11 @@ pub(crate) fn build_pages(
             })
             .collect();
         let req = theme_page_request(&community.synth_theme(), &claims);
-        let (sections, _repair) = call_and_parse(client, &req, "theme-page", parse_theme_page)?;
+        let (mut sections, _repair) = call_and_parse(client, &req, "theme-page", parse_theme_page)?;
+        // The model cites positional handles (c1, c2, …); the code owns the
+        // handle → claim_key substitution. Unresolved handles survive into
+        // the verifier and fail loud as UnknownClaim.
+        resolve_handles(&mut sections, &claim_keys);
 
         let known: BTreeSet<String> = claim_keys.iter().cloned().collect();
         let defects = verify_page(&sections, &known);
@@ -373,7 +377,7 @@ mod tests {
         client.insert(
             &fixture_request(),
             reply(
-                r#"{"sections":[{"heading":"Memory","body":"Persists [claim:ck-b], compounds [claim:ck-a]."}]}"#,
+                r#"{"sections":[{"heading":"Memory","body":"Persists [claim:c2], compounds [claim:c1]."}]}"#,
             ),
         );
 
@@ -385,6 +389,10 @@ mod tests {
         assert_eq!(page.label, "Agent memory");
         assert_eq!(page.claim_keys, vec!["ck-a", "ck-b"], "sorted claim keys");
         assert_eq!(page.sections.len(), 1);
+        assert_eq!(
+            page.sections[0].body, "Persists [claim:ck-b], compounds [claim:ck-a].",
+            "persisted pages carry real claim keys, not handles"
+        );
     }
 
     #[test]
@@ -432,7 +440,7 @@ mod tests {
         let mut client = FixtureModelClient::new();
         client.insert(
             &fixture_request(),
-            reply(r#"{"sections":[{"heading":"New","body":"New [claim:ck-b]."}]}"#),
+            reply(r#"{"sections":[{"heading":"New","body":"New [claim:c2]."}]}"#),
         );
         let out = build_pages(&records, &themes, Some(&existing), &mut client, 2, true).unwrap();
         assert_eq!((out.built, out.kept), (1, 0));
@@ -447,14 +455,14 @@ mod tests {
         client.insert(
             &fixture_request(),
             reply(
-                r#"{"sections":[{"heading":"H","body":"No citation here.\n\nGhost [claim:ck-ghost]."}]}"#,
+                r#"{"sections":[{"heading":"H","body":"No citation here.\n\nGhost handle [claim:c9]."}]}"#,
             ),
         );
         let err = build_pages(&records, &themes, None, &mut client, 2, false).unwrap_err();
         let msg = format!("{err:?}");
         assert!(msg.contains("failed the page gate"), "{msg}");
         assert!(msg.contains("no [claim:…] citation"), "{msg}");
-        assert!(msg.contains("ck-ghost"), "{msg}");
+        assert!(msg.contains("unknown claim `c9`"), "{msg}");
     }
 
     #[test]

--- a/crates/ovp-cli/src/commands/crystal_theme_pages.rs
+++ b/crates/ovp-cli/src/commands/crystal_theme_pages.rs
@@ -8,8 +8,9 @@
 //!       for `ClaimRow.theme`, keyed by community id — labels never vote)
 //!     → per community ≥ --min-claims: `theme_page/v1` synthesis over the
 //!       sorted claim set (request sees keywords + claims, NEVER labels)
-//!     → deterministic page gate: every paragraph cites ≥1 known
-//!       `[claim:<claim_key>]`, unknown keys fail loud
+//!     → deterministic page gate: every sentence cites ≥1 known
+//!       `[claim:<claim_key>]`, unknown keys fail loud; a failing draft
+//!       gets one bounded repair call before the theme counts as failed
 //!     → `.ovp/crystal/theme_pages.json` (rebuildable projection).
 //!
 //! Staleness: a page whose theme's active claim set is unchanged is kept
@@ -22,7 +23,7 @@ use std::path::PathBuf;
 
 use ovp_domain::crystal::theme_pages::{
     PageClaim, THEME_PAGES_SCHEMA, ThemePage, ThemePagesFile, parse_theme_page, resolve_handles,
-    theme_page_request, uncited_keys, verify_page,
+    theme_page_repair_request, theme_page_request, uncited_keys, verify_page,
 };
 use ovp_domain::crystal::themes::ThemesFile;
 use ovp_domain::crystal::{CrystalStatus, DurableRecord, StoreEvent, fold_ledger};
@@ -80,6 +81,10 @@ pub(crate) fn build_pages(
         kept: 0,
         skipped_small: 0,
     };
+    // Failed themes accumulate instead of aborting the loop: one run
+    // invalidates EVERY ungrounded cassette entry, so the next live pass
+    // re-asks all of them at once (successes stay cached).
+    let mut failures: Vec<(i64, Vec<String>)> = Vec::new();
     for community in &themes.communities {
         let Some(mut group) = by_community.remove(&community.id) else {
             continue;
@@ -90,13 +95,17 @@ pub(crate) fn build_pages(
         }
         group.sort_by(|a, b| a.claim_key.cmp(&b.claim_key));
         let claim_keys: Vec<String> = group.iter().map(|r| r.claim_key.clone()).collect();
+        let known: BTreeSet<String> = claim_keys.iter().cloned().collect();
 
         if !refresh
             && let Some(prev) = existing.and_then(|f| f.page(community.id))
             && prev.claim_keys == claim_keys
+            && verify_page(&prev.sections, &known).is_empty()
         {
-            // Unchanged claim set — keep the page, refresh only the
-            // presentation labels (they are never synthesis input).
+            // Unchanged claim set AND the retained page still passes the
+            // gate (a hand-edited or older-generator projection must not
+            // ride the fast path — codex review P2). Labels refresh; they
+            // are never synthesis input.
             outcome.pages.push(ThemePage {
                 label: community.label.clone(),
                 label_zh: community.label_zh.clone(),
@@ -115,25 +124,40 @@ pub(crate) fn build_pages(
             })
             .collect();
         let req = theme_page_request(&community.synth_theme(), &claims);
-        let (mut sections, _repair) = call_and_parse(client, &req, "theme-page", parse_theme_page)?;
+        let (draft, _repair) = call_and_parse(client, &req, "theme-page", parse_theme_page)?;
         // The model cites positional handles (c1, c2, …); the code owns the
         // handle → claim_key substitution. Unresolved handles survive into
         // the verifier and fail loud as UnknownClaim.
+        let mut sections = draft.clone();
         resolve_handles(&mut sections, &claim_keys);
 
-        let known: BTreeSet<String> = claim_keys.iter().cloned().collect();
-        let defects = verify_page(&sections, &known);
+        let mut defects = verify_page(&sections, &known);
         if !defects.is_empty() {
-            // Forget the exchange so a rerun re-asks the model instead of
-            // replaying the same ungrounded page forever (no-op on replay).
-            client.invalidate(&req);
+            // ONE bounded repair (M36 repair-workshop shape): the model gets
+            // its own draft + the defect list and must cite or delete each
+            // offending sentence. Small themes reliably need this — the
+            // model pads them with uncited synthesis glue.
             let listed: Vec<String> = defects.iter().map(|d| d.to_string()).collect();
-            return Err(CliError::Io(format!(
-                "crystal-theme-pages: t{:03} failed the page gate ({} defect(s)):\n  {}",
-                community.id,
-                listed.len(),
-                listed.join("\n  ")
-            )));
+            let repair_req =
+                theme_page_repair_request(&community.synth_theme(), &claims, &draft, &listed);
+            let (repaired, _log) =
+                call_and_parse(client, &repair_req, "theme-page-repair", parse_theme_page)?;
+            let mut repaired_resolved = repaired;
+            resolve_handles(&mut repaired_resolved, &claim_keys);
+            defects = verify_page(&repaired_resolved, &known);
+            if defects.is_empty() {
+                sections = repaired_resolved;
+            } else {
+                // Forget both exchanges so a rerun re-asks instead of
+                // replaying the same ungrounded page (no-op on replay).
+                client.invalidate(&req);
+                client.invalidate(&repair_req);
+                failures.push((
+                    community.id,
+                    defects.iter().map(|d| d.to_string()).collect(),
+                ));
+                continue;
+            }
         }
 
         outcome.pages.push(ThemePage {
@@ -145,7 +169,39 @@ pub(crate) fn build_pages(
         });
         outcome.built += 1;
     }
+    if !failures.is_empty() {
+        let mut msg = format!(
+            "crystal-theme-pages: {} theme(s) failed the page gate (nothing written; rerun re-asks them):",
+            failures.len()
+        );
+        for (id, defects) in &failures {
+            msg.push_str(&format!("\n  t{:03} ({} defect(s)):", id, defects.len()));
+            for d in defects {
+                msg.push_str(&format!("\n    {d}"));
+            }
+        }
+        return Err(CliError::Io(msg));
+    }
     Ok(outcome)
+}
+
+/// Atomically publish the projection (temp + rename) — readers must never see
+/// a torn file.
+fn write_pages_file(
+    store: &std::path::Path,
+    pages_path: &std::path::Path,
+    file: &ThemePagesFile,
+) -> Result<(), CliError> {
+    std::fs::create_dir_all(store)
+        .map_err(|e| CliError::Io(format!("creating {}: {e}", store.display())))?;
+    let body = serde_json::to_string_pretty(file)
+        .map_err(|e| CliError::Io(format!("serializing theme_pages.json: {e}")))?;
+    let tmp = pages_path.with_extension("json.tmp");
+    std::fs::write(&tmp, format!("{body}\n"))
+        .map_err(|e| CliError::Io(format!("writing {}: {e}", tmp.display())))?;
+    std::fs::rename(&tmp, pages_path)
+        .map_err(|e| CliError::Io(format!("publishing {}: {e}", pages_path.display())))?;
+    Ok(())
 }
 
 pub fn run(args: CrystalThemePagesArgs) -> Result<(), CliError> {
@@ -182,7 +238,21 @@ pub fn run(args: CrystalThemePagesArgs) -> Result<(), CliError> {
         .filter(|r| r.status == CrystalStatus::Active)
         .collect();
     if records.is_empty() {
-        println!("crystal-theme-pages: no active durable claims — nothing to page.");
+        // Publish an EMPTY projection rather than leaving a stale one behind:
+        // if every claim was later retracted/superseded, readers must not keep
+        // serving pages whose citations are no longer active (codex review P2).
+        write_pages_file(
+            &store,
+            &pages_path,
+            &ThemePagesFile {
+                schema: THEME_PAGES_SCHEMA.to_string(),
+                pages: Vec::new(),
+            },
+        )?;
+        println!(
+            "crystal-theme-pages: no active durable claims — wrote empty {}.",
+            pages_path.display()
+        );
         return Ok(());
     }
 
@@ -216,16 +286,7 @@ pub fn run(args: CrystalThemePagesArgs) -> Result<(), CliError> {
         schema: THEME_PAGES_SCHEMA.to_string(),
         pages: outcome.pages,
     };
-    std::fs::create_dir_all(&store)
-        .map_err(|e| CliError::Io(format!("creating {}: {e}", store.display())))?;
-    let body = serde_json::to_string_pretty(&file)
-        .map_err(|e| CliError::Io(format!("serializing theme_pages.json: {e}")))?;
-    // Publish atomically (temp + rename) — readers must never see a torn file.
-    let tmp = pages_path.with_extension("json.tmp");
-    std::fs::write(&tmp, format!("{body}\n"))
-        .map_err(|e| CliError::Io(format!("writing {}: {e}", tmp.display())))?;
-    std::fs::rename(&tmp, &pages_path)
-        .map_err(|e| CliError::Io(format!("publishing {}: {e}", pages_path.display())))?;
+    write_pages_file(&store, &pages_path, &file)?;
 
     println!(
         "crystal-theme-pages: {} page(s) ({} built, {} kept, {} theme(s) below --min-claims {}) → {}",
@@ -447,22 +508,103 @@ mod tests {
         assert_eq!(out.pages[0].sections[0].heading, "New");
     }
 
+    /// The repair request the command will issue for `bad_reply` below.
+    fn fixture_repair_request(bad_reply_json: &str) -> ovp_llm::ModelRequest {
+        let draft = parse_theme_page(bad_reply_json).unwrap();
+        let mut resolved = draft.clone();
+        resolve_handles(&mut resolved, &["ck-a".into(), "ck-b".into()]);
+        let known: BTreeSet<String> = ["ck-a".to_string(), "ck-b".to_string()].into();
+        let defects: Vec<String> = verify_page(&resolved, &known)
+            .iter()
+            .map(|d| d.to_string())
+            .collect();
+        let claims = [
+            PageClaim {
+                claim_key: "ck-a".into(),
+                claim: "Context compounds.".into(),
+                source_count: 2,
+            },
+            PageClaim {
+                claim_key: "ck-b".into(),
+                claim: "Memory persists.".into(),
+                source_count: 2,
+            },
+        ];
+        theme_page_repair_request(
+            &themes_fixture().communities[0].synth_theme(),
+            &claims,
+            &draft,
+            &defects,
+        )
+    }
+
+    const BAD_REPLY: &str =
+        r#"{"sections":[{"heading":"H","body":"No citation here.\n\nGhost handle [claim:c9]."}]}"#;
+
     #[test]
-    fn ungrounded_page_fails_the_gate_loudly() {
+    fn failed_repair_fails_the_gate_loudly() {
         let themes = themes_fixture();
         let records = records_fixture();
         let mut client = FixtureModelClient::new();
-        client.insert(
-            &fixture_request(),
-            reply(
-                r#"{"sections":[{"heading":"H","body":"No citation here.\n\nGhost handle [claim:c9]."}]}"#,
-            ),
-        );
+        client.insert(&fixture_request(), reply(BAD_REPLY));
+        // The repair attempt returns the SAME bad draft — still ungrounded.
+        client.insert(&fixture_repair_request(BAD_REPLY), reply(BAD_REPLY));
         let err = build_pages(&records, &themes, None, &mut client, 2, false).unwrap_err();
         let msg = format!("{err:?}");
-        assert!(msg.contains("failed the page gate"), "{msg}");
-        assert!(msg.contains("no [claim:…] citation"), "{msg}");
+        assert!(msg.contains("1 theme(s) failed the page gate"), "{msg}");
+        assert!(
+            msg.contains("uncited sentence `No citation here.`"),
+            "{msg}"
+        );
         assert!(msg.contains("unknown claim `c9`"), "{msg}");
+    }
+
+    #[test]
+    fn one_bounded_repair_can_save_a_failing_page() {
+        let themes = themes_fixture();
+        let records = records_fixture();
+        let mut client = FixtureModelClient::new();
+        client.insert(&fixture_request(), reply(BAD_REPLY));
+        client.insert(
+            &fixture_repair_request(BAD_REPLY),
+            reply(r#"{"sections":[{"heading":"H","body":"Now cited [claim:c1]."}]}"#),
+        );
+        let out = build_pages(&records, &themes, None, &mut client, 2, false).unwrap();
+        assert_eq!((out.built, out.kept), (1, 0));
+        assert_eq!(out.pages[0].sections[0].body, "Now cited [claim:ck-a].");
+    }
+
+    #[test]
+    fn keep_path_revalidates_and_regenerates_an_invalid_retained_page() {
+        let themes = themes_fixture();
+        let records = records_fixture();
+        // Same claim set, but the retained page violates the sentence gate
+        // (hand edit / older generator) — it must NOT ride the fast path.
+        let existing = ThemePagesFile {
+            schema: THEME_PAGES_SCHEMA.into(),
+            pages: vec![ThemePage {
+                community_id: 0,
+                label: "Agent memory".into(),
+                label_zh: "智能体记忆".into(),
+                claim_keys: vec!["ck-a".into(), "ck-b".into()],
+                sections: vec![ovp_domain::crystal::theme_pages::PageSection {
+                    heading: "H".into(),
+                    body: "Uncited sentence. Cited one [claim:ck-a].".into(),
+                }],
+            }],
+        };
+        let mut client = FixtureModelClient::new();
+        client.insert(
+            &fixture_request(),
+            reply(r#"{"sections":[{"heading":"Regen","body":"Fresh [claim:c1]."}]}"#),
+        );
+        let out = build_pages(&records, &themes, Some(&existing), &mut client, 2, false).unwrap();
+        assert_eq!(
+            (out.built, out.kept),
+            (1, 0),
+            "invalid page regenerated, not kept"
+        );
+        assert_eq!(out.pages[0].sections[0].heading, "Regen");
     }
 
     #[test]

--- a/crates/ovp-cli/src/commands/crystal_theme_pages.rs
+++ b/crates/ovp-cli/src/commands/crystal_theme_pages.rs
@@ -1,0 +1,473 @@
+//! `crystal-theme-pages` — weave each theme's ACTIVE durable claims into a
+//! grounded topic page (`.ovp/crystal/theme_pages.json`).
+//!
+//! Pipeline:
+//!
+//!   crystal ledger (fold → active durable records)
+//!     → group by majority theme community (the same vote `ovp-index` uses
+//!       for `ClaimRow.theme`, keyed by community id — labels never vote)
+//!     → per community ≥ --min-claims: `theme_page/v1` synthesis over the
+//!       sorted claim set (request sees keywords + claims, NEVER labels)
+//!     → deterministic page gate: every paragraph cites ≥1 known
+//!       `[claim:<claim_key>]`, unknown keys fail loud
+//!     → `.ovp/crystal/theme_pages.json` (rebuildable projection).
+//!
+//! Staleness: a page whose theme's active claim set is unchanged is kept
+//! verbatim (no LLM call); `--refresh` forces regeneration. Degradation
+//! contract: no `themes.json` or an empty ledger prints why and exits 0 —
+//! daily runs are never blocked.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
+
+use ovp_domain::crystal::theme_pages::{
+    PageClaim, THEME_PAGES_SCHEMA, ThemePage, ThemePagesFile, parse_theme_page, theme_page_request,
+    uncited_keys, verify_page,
+};
+use ovp_domain::crystal::themes::ThemesFile;
+use ovp_domain::crystal::{CrystalStatus, DurableRecord, StoreEvent, fold_ledger};
+use ovp_domain::vault_layout::VaultLayout;
+use ovp_intake::read_jsonl;
+use ovp_llm::ModelClient;
+
+use crate::CliError;
+use crate::commands::client::{ClientKind, build_client};
+use crate::commands::crystal_synth::call_and_parse;
+
+pub struct CrystalThemePagesArgs {
+    pub vault_root: PathBuf,
+    pub client_kind: ClientKind,
+    /// Cassette root for `theme_page/v1`. Default:
+    /// `<vault-root>/.ovp/cassettes/crystal` (shared with crystal-synth).
+    pub cache_dir: Option<PathBuf>,
+    /// Regenerate every page even when its claim set is unchanged.
+    pub refresh: bool,
+    /// Themes with fewer active durable claims get no page.
+    pub min_claims: usize,
+}
+
+/// What one build pass did, for the summary and for tests.
+#[derive(Debug)]
+pub(crate) struct PageBuildOutcome {
+    pub(crate) pages: Vec<ThemePage>,
+    pub(crate) built: usize,
+    pub(crate) kept: usize,
+    pub(crate) skipped_small: usize,
+}
+
+/// Group active durable records by majority theme community and synthesize a
+/// page per qualifying community. Pure over its inputs (the client carries
+/// the LLM); order is deterministic (communities in `themes.json` order,
+/// claims in sorted claim_key order).
+pub(crate) fn build_pages(
+    records: &[DurableRecord],
+    themes: &ThemesFile,
+    existing: Option<&ThemePagesFile>,
+    client: &mut dyn ModelClient,
+    min_claims: usize,
+    refresh: bool,
+) -> Result<PageBuildOutcome, CliError> {
+    let mut by_community: BTreeMap<i64, Vec<&DurableRecord>> = BTreeMap::new();
+    for r in records {
+        if let Some(id) = themes.majority_community(&r.source_cases) {
+            by_community.entry(id).or_default().push(r);
+        }
+    }
+
+    let mut outcome = PageBuildOutcome {
+        pages: Vec::new(),
+        built: 0,
+        kept: 0,
+        skipped_small: 0,
+    };
+    for community in &themes.communities {
+        let Some(mut group) = by_community.remove(&community.id) else {
+            continue;
+        };
+        if group.len() < min_claims {
+            outcome.skipped_small += 1;
+            continue;
+        }
+        group.sort_by(|a, b| a.claim_key.cmp(&b.claim_key));
+        let claim_keys: Vec<String> = group.iter().map(|r| r.claim_key.clone()).collect();
+
+        if !refresh
+            && let Some(prev) = existing.and_then(|f| f.page(community.id))
+            && prev.claim_keys == claim_keys
+        {
+            // Unchanged claim set — keep the page, refresh only the
+            // presentation labels (they are never synthesis input).
+            outcome.pages.push(ThemePage {
+                label: community.label.clone(),
+                label_zh: community.label_zh.clone(),
+                ..prev.clone()
+            });
+            outcome.kept += 1;
+            continue;
+        }
+
+        let claims: Vec<PageClaim> = group
+            .iter()
+            .map(|r| PageClaim {
+                claim_key: r.claim_key.clone(),
+                claim: r.claim.clone(),
+                source_count: r.source_cases.len(),
+            })
+            .collect();
+        let req = theme_page_request(&community.synth_theme(), &claims);
+        let (sections, _repair) = call_and_parse(client, &req, "theme-page", parse_theme_page)?;
+
+        let known: BTreeSet<String> = claim_keys.iter().cloned().collect();
+        let defects = verify_page(&sections, &known);
+        if !defects.is_empty() {
+            // Forget the exchange so a rerun re-asks the model instead of
+            // replaying the same ungrounded page forever (no-op on replay).
+            client.invalidate(&req);
+            let listed: Vec<String> = defects.iter().map(|d| d.to_string()).collect();
+            return Err(CliError::Io(format!(
+                "crystal-theme-pages: t{:03} failed the page gate ({} defect(s)):\n  {}",
+                community.id,
+                listed.len(),
+                listed.join("\n  ")
+            )));
+        }
+
+        outcome.pages.push(ThemePage {
+            community_id: community.id,
+            label: community.label.clone(),
+            label_zh: community.label_zh.clone(),
+            claim_keys,
+            sections,
+        });
+        outcome.built += 1;
+    }
+    Ok(outcome)
+}
+
+pub fn run(args: CrystalThemePagesArgs) -> Result<(), CliError> {
+    if args.min_claims == 0 {
+        return Err(CliError::Io(
+            "crystal-theme-pages: --min-claims must be ≥ 1".to_string(),
+        ));
+    }
+    let layout = VaultLayout::new();
+    let store = args.vault_root.join(layout.crystal_store_dir());
+    let pages_path = store.join("theme_pages.json");
+
+    let themes = match ThemesFile::load(&store.join("themes.json")) {
+        Ok(Some(themes)) => themes,
+        Ok(None) => {
+            println!(
+                "crystal-theme-pages: no themes.json under {} — run `ovp2 crystal-themes` first.",
+                store.display()
+            );
+            return Ok(());
+        }
+        Err(e) => return Err(CliError::Io(format!("crystal-theme-pages: {e}"))),
+    };
+
+    let ledger = store.join("ledger.jsonl");
+    let events: Vec<StoreEvent> = read_jsonl(&ledger).map_err(|e| {
+        CliError::Io(format!(
+            "crystal-theme-pages: ledger {}: {e}",
+            ledger.display()
+        ))
+    })?;
+    let records: Vec<DurableRecord> = fold_ledger(&events)
+        .into_iter()
+        .filter(|r| r.status == CrystalStatus::Active)
+        .collect();
+    if records.is_empty() {
+        println!("crystal-theme-pages: no active durable claims — nothing to page.");
+        return Ok(());
+    }
+
+    // A corrupt existing projection is about to be rebuilt anyway — warn and
+    // regenerate rather than refusing (`ovp2 index` is where corruption of
+    // read inputs fails loud).
+    let existing = match ThemePagesFile::load(&pages_path) {
+        Ok(existing) => existing,
+        Err(e) => {
+            eprintln!("warning: rebuilding corrupt theme_pages.json ({e})");
+            None
+        }
+    };
+
+    let cassette_dir = args
+        .cache_dir
+        .clone()
+        .unwrap_or_else(|| args.vault_root.join(".ovp/cassettes/crystal"));
+    let mut client = build_client(args.client_kind, &cassette_dir)?;
+
+    let outcome = build_pages(
+        &records,
+        &themes,
+        existing.as_ref(),
+        client.as_mut(),
+        args.min_claims,
+        args.refresh,
+    )?;
+
+    let file = ThemePagesFile {
+        schema: THEME_PAGES_SCHEMA.to_string(),
+        pages: outcome.pages,
+    };
+    std::fs::create_dir_all(&store)
+        .map_err(|e| CliError::Io(format!("creating {}: {e}", store.display())))?;
+    let body = serde_json::to_string_pretty(&file)
+        .map_err(|e| CliError::Io(format!("serializing theme_pages.json: {e}")))?;
+    // Publish atomically (temp + rename) — readers must never see a torn file.
+    let tmp = pages_path.with_extension("json.tmp");
+    std::fs::write(&tmp, format!("{body}\n"))
+        .map_err(|e| CliError::Io(format!("writing {}: {e}", tmp.display())))?;
+    std::fs::rename(&tmp, &pages_path)
+        .map_err(|e| CliError::Io(format!("publishing {}: {e}", pages_path.display())))?;
+
+    println!(
+        "crystal-theme-pages: {} page(s) ({} built, {} kept, {} theme(s) below --min-claims {}) → {}",
+        file.pages.len(),
+        outcome.built,
+        outcome.kept,
+        outcome.skipped_small,
+        args.min_claims,
+        pages_path.display()
+    );
+    for page in &file.pages {
+        let known: BTreeSet<String> = page.claim_keys.iter().cloned().collect();
+        let uncited = uncited_keys(&page.sections, &known);
+        println!(
+            "  t{:03}  {}  {} claim(s), {} section(s){}",
+            page.community_id,
+            page.label,
+            page.claim_keys.len(),
+            page.sections.len(),
+            if uncited.is_empty() {
+                String::new()
+            } else {
+                format!(", {} uncited", uncited.len())
+            }
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ovp_domain::crystal::themes::{THEMES_SCHEMA, ThemeCommunity, ThemeParams};
+    use ovp_domain::crystal::{DurableCitation, FinalClass, ProvenanceClass, StrengthClass};
+    use ovp_llm::{FixtureModelClient, ModelReply, StopReason, Usage};
+
+    fn themes_fixture() -> ThemesFile {
+        ThemesFile {
+            schema: THEMES_SCHEMA.into(),
+            model: "test-model".into(),
+            params: ThemeParams {
+                k: 10,
+                cosine_threshold: 0.5,
+                resolution: 1.5,
+                seed: 42,
+                text_prefix: "passage: ".into(),
+                head_chars: 1500,
+            },
+            generated_from: "abc".into(),
+            packs: BTreeMap::from([
+                ("case-a".to_string(), 0),
+                ("case-b".to_string(), 0),
+                ("case-c".to_string(), 1),
+            ]),
+            communities: vec![
+                ThemeCommunity {
+                    id: 0,
+                    label: "Agent memory".into(),
+                    label_zh: "智能体记忆".into(),
+                    keywords: vec!["memory".into()],
+                    size: 2,
+                },
+                ThemeCommunity {
+                    id: 1,
+                    label: "Quant markets".into(),
+                    label_zh: "量化市场".into(),
+                    keywords: vec!["quant".into()],
+                    size: 1,
+                },
+            ],
+            labels_provenance: Default::default(),
+        }
+    }
+
+    fn record(key: &str, claim: &str, cases: &[&str]) -> DurableRecord {
+        DurableRecord {
+            claim_key: key.into(),
+            claim_id: format!("id-{key}"),
+            claim: claim.into(),
+            theme: "t".into(),
+            source_cases: cases.iter().map(|s| s.to_string()).collect(),
+            citations: cases
+                .iter()
+                .map(|c| DurableCitation {
+                    case_id: c.to_string(),
+                    unit_id: "u-1".into(),
+                    quote: "q".into(),
+                    resolved_line: None,
+                })
+                .collect(),
+            provenance_score: 0.8,
+            provenance_class: ProvenanceClass::Durable,
+            strength: StrengthClass::Supported,
+            strength_rationale: "r".into(),
+            final_class: FinalClass::Durable,
+            run_id: "run-x".into(),
+            status: CrystalStatus::Active,
+        }
+    }
+
+    fn reply(text: &str) -> ModelReply {
+        ModelReply {
+            model: "test".into(),
+            text: text.to_string(),
+            stop_reason: StopReason::EndTurn,
+            usage: Usage {
+                input_tokens: 0,
+                output_tokens: 0,
+            },
+        }
+    }
+
+    /// The community-0 records used across tests (both cite theme-0 cases).
+    fn records_fixture() -> Vec<DurableRecord> {
+        vec![
+            record("ck-b", "Memory persists.", &["case-a", "case-b"]),
+            record("ck-a", "Context compounds.", &["case-a", "case-b"]),
+        ]
+    }
+
+    /// The request build_pages will issue for `records_fixture` (sorted by
+    /// claim_key: ck-a first).
+    fn fixture_request() -> ovp_llm::ModelRequest {
+        theme_page_request(
+            &themes_fixture().communities[0].synth_theme(),
+            &[
+                PageClaim {
+                    claim_key: "ck-a".into(),
+                    claim: "Context compounds.".into(),
+                    source_count: 2,
+                },
+                PageClaim {
+                    claim_key: "ck-b".into(),
+                    claim: "Memory persists.".into(),
+                    source_count: 2,
+                },
+            ],
+        )
+    }
+
+    #[test]
+    fn builds_a_page_per_qualifying_community_and_skips_small_ones() {
+        let themes = themes_fixture();
+        // Community 1 has a single claim → below min_claims 2 → skipped.
+        let mut records = records_fixture();
+        records.push(record("ck-c", "Quant claim.", &["case-c"]));
+
+        let mut client = FixtureModelClient::new();
+        client.insert(
+            &fixture_request(),
+            reply(
+                r#"{"sections":[{"heading":"Memory","body":"Persists [claim:ck-b], compounds [claim:ck-a]."}]}"#,
+            ),
+        );
+
+        let out = build_pages(&records, &themes, None, &mut client, 2, false).unwrap();
+        assert_eq!((out.built, out.kept, out.skipped_small), (1, 0, 1));
+        assert_eq!(out.pages.len(), 1);
+        let page = &out.pages[0];
+        assert_eq!(page.community_id, 0);
+        assert_eq!(page.label, "Agent memory");
+        assert_eq!(page.claim_keys, vec!["ck-a", "ck-b"], "sorted claim keys");
+        assert_eq!(page.sections.len(), 1);
+    }
+
+    #[test]
+    fn unchanged_claim_set_keeps_the_page_without_an_llm_call() {
+        let themes = themes_fixture();
+        let records = records_fixture();
+        let existing = ThemePagesFile {
+            schema: THEME_PAGES_SCHEMA.into(),
+            pages: vec![ThemePage {
+                community_id: 0,
+                label: "Old label".into(),
+                label_zh: "旧名".into(),
+                claim_keys: vec!["ck-a".into(), "ck-b".into()],
+                sections: vec![ovp_domain::crystal::theme_pages::PageSection {
+                    heading: "H".into(),
+                    body: "B [claim:ck-a].".into(),
+                }],
+            }],
+        };
+        // Empty fixture client: any LLM call would CacheMiss → error.
+        let mut client = FixtureModelClient::new();
+        let out = build_pages(&records, &themes, Some(&existing), &mut client, 2, false).unwrap();
+        assert_eq!((out.built, out.kept), (0, 1));
+        assert_eq!(out.pages[0].label, "Agent memory", "labels refresh on keep");
+        assert_eq!(out.pages[0].sections, existing.pages[0].sections);
+    }
+
+    #[test]
+    fn refresh_regenerates_even_when_unchanged() {
+        let themes = themes_fixture();
+        let records = records_fixture();
+        let existing = ThemePagesFile {
+            schema: THEME_PAGES_SCHEMA.into(),
+            pages: vec![ThemePage {
+                community_id: 0,
+                label: "Agent memory".into(),
+                label_zh: "智能体记忆".into(),
+                claim_keys: vec!["ck-a".into(), "ck-b".into()],
+                sections: vec![ovp_domain::crystal::theme_pages::PageSection {
+                    heading: "Old".into(),
+                    body: "Old [claim:ck-a].".into(),
+                }],
+            }],
+        };
+        let mut client = FixtureModelClient::new();
+        client.insert(
+            &fixture_request(),
+            reply(r#"{"sections":[{"heading":"New","body":"New [claim:ck-b]."}]}"#),
+        );
+        let out = build_pages(&records, &themes, Some(&existing), &mut client, 2, true).unwrap();
+        assert_eq!((out.built, out.kept), (1, 0));
+        assert_eq!(out.pages[0].sections[0].heading, "New");
+    }
+
+    #[test]
+    fn ungrounded_page_fails_the_gate_loudly() {
+        let themes = themes_fixture();
+        let records = records_fixture();
+        let mut client = FixtureModelClient::new();
+        client.insert(
+            &fixture_request(),
+            reply(
+                r#"{"sections":[{"heading":"H","body":"No citation here.\n\nGhost [claim:ck-ghost]."}]}"#,
+            ),
+        );
+        let err = build_pages(&records, &themes, None, &mut client, 2, false).unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(msg.contains("failed the page gate"), "{msg}");
+        assert!(msg.contains("no [claim:…] citation"), "{msg}");
+        assert!(msg.contains("ck-ghost"), "{msg}");
+    }
+
+    #[test]
+    fn claims_without_a_majority_community_are_not_paged() {
+        let themes = themes_fixture();
+        // Cites only unknown cases → majority_community None → no group.
+        let records = vec![
+            record("ck-x", "Orphan claim.", &["unknown-1", "unknown-2"]),
+            record("ck-y", "Another orphan.", &["unknown-3", "unknown-4"]),
+        ];
+        let mut client = FixtureModelClient::new();
+        let out = build_pages(&records, &themes, None, &mut client, 2, false).unwrap();
+        assert_eq!(out.pages.len(), 0);
+        assert_eq!((out.built, out.kept, out.skipped_small), (0, 0, 0));
+    }
+}

--- a/crates/ovp-cli/src/commands/crystal_theme_pages.rs
+++ b/crates/ovp-cli/src/commands/crystal_theme_pages.rs
@@ -128,8 +128,20 @@ pub(crate) fn build_pages(
                 source_count: r.source_cases.len(),
             })
             .collect();
+        // A call/parse failure on ONE theme must not abort the run before
+        // the safe partial write — the old page may cite claims that are no
+        // longer active, and exiting early would leave it serving (codex
+        // round-4 P1). Same failure path as a gate failure.
         let req = theme_page_request(&community.synth_theme(), &claims);
-        let (draft, _repair) = call_and_parse(client, &req, "theme-page", parse_theme_page)?;
+        let draft = match call_and_parse(client, &req, "theme-page", parse_theme_page) {
+            Ok((draft, _repair)) => draft,
+            Err(e) => {
+                outcome
+                    .failures
+                    .push((community.id, vec![format!("{e:?}")]));
+                continue;
+            }
+        };
         // The model cites positional handles (c1, c2, …); the code owns the
         // handle → claim_key substitution. Unresolved handles survive into
         // the verifier and fail loud as UnknownClaim.
@@ -145,8 +157,17 @@ pub(crate) fn build_pages(
             let listed: Vec<String> = defects.iter().map(|d| d.to_string()).collect();
             let repair_req =
                 theme_page_repair_request(&community.synth_theme(), &claims, &draft, &listed);
-            let (repaired, _log) =
-                call_and_parse(client, &repair_req, "theme-page-repair", parse_theme_page)?;
+            let repaired =
+                match call_and_parse(client, &repair_req, "theme-page-repair", parse_theme_page) {
+                    Ok((repaired, _log)) => repaired,
+                    Err(e) => {
+                        client.invalidate(&req);
+                        outcome
+                            .failures
+                            .push((community.id, vec![format!("{e:?}")]));
+                        continue;
+                    }
+                };
             let mut repaired_resolved = repaired;
             resolve_handles(&mut repaired_resolved, &claim_keys);
             defects = verify_page(&repaired_resolved, &known);

--- a/crates/ovp-cli/src/commands/mod.rs
+++ b/crates/ovp-cli/src/commands/mod.rs
@@ -11,6 +11,7 @@ pub mod crystal_synth;
 pub mod crystal_synth_ab;
 pub mod crystal_synth_llm;
 pub mod crystal_terrain;
+pub mod crystal_theme_pages;
 pub mod crystal_themes;
 pub mod tags_bootstrap;
 pub mod tags_suggest;

--- a/crates/ovp-cli/src/main.rs
+++ b/crates/ovp-cli/src/main.rs
@@ -671,9 +671,9 @@ enum Cmd {
     /// PRODUCT — weave each theme's ACTIVE durable claims into a grounded
     /// topic page (.ovp/crystal/theme_pages.json): claims grouped by majority
     /// community → theme_page/v1 narrative → deterministic page gate (every
-    /// paragraph cites a known [claim:<key>]). Rebuildable projection; pages
-    /// with an unchanged claim set are kept without an LLM call. Run
-    /// `crystal-themes` first.
+    /// sentence cites a known [claim:<key>]; failing drafts get one bounded
+    /// repair call). Rebuildable projection; pages with an unchanged claim
+    /// set are kept without an LLM call. Run `crystal-themes` first.
     CrystalThemePages {
         #[arg(long)]
         vault_root: PathBuf,

--- a/crates/ovp-cli/src/main.rs
+++ b/crates/ovp-cli/src/main.rs
@@ -668,6 +668,30 @@ enum Cmd {
         #[arg(long, default_value_t = 42)]
         seed: u64,
     },
+    /// PRODUCT — weave each theme's ACTIVE durable claims into a grounded
+    /// topic page (.ovp/crystal/theme_pages.json): claims grouped by majority
+    /// community → theme_page/v1 narrative → deterministic page gate (every
+    /// paragraph cites a known [claim:<key>]). Rebuildable projection; pages
+    /// with an unchanged claim set are kept without an LLM call. Run
+    /// `crystal-themes` first.
+    CrystalThemePages {
+        #[arg(long)]
+        vault_root: PathBuf,
+        /// `replay` (default) serves cassette replies; `live` calls the API
+        /// and records one theme_page/v1 exchange per stale theme.
+        #[arg(long, value_enum, default_value_t = ClientKindArg::Replay)]
+        client: ClientKindArg,
+        /// Cassette root for theme_page/v1. Default:
+        /// `<vault-root>/.ovp/cassettes/crystal`.
+        #[arg(long)]
+        cache_dir: Option<PathBuf>,
+        /// Regenerate every page even when its claim set is unchanged.
+        #[arg(long)]
+        refresh: bool,
+        /// Themes with fewer active durable claims get no page.
+        #[arg(long, default_value_t = ovp_domain::crystal::theme_pages::MIN_PAGE_CLAIMS)]
+        min_claims: usize,
+    },
     /// Cold-start tagging for vaults without a curated vocabulary: theme
     /// communities seed a closed vocabulary (.ovp/tags/vocabulary.toml) and a
     /// deterministic keyword floor; `--client live` adds batched LLM
@@ -1771,6 +1795,21 @@ fn main() -> ExitCode {
                 cosine_threshold,
                 resolution,
                 seed,
+            })
+        }
+        Cmd::CrystalThemePages { vault_root, client, cache_dir, refresh, min_claims } => {
+            use commands::client::ClientKind;
+            use commands::crystal_theme_pages::CrystalThemePagesArgs;
+            let client_kind = match client {
+                ClientKindArg::Replay => ClientKind::Replay,
+                ClientKindArg::Live => ClientKind::Live,
+            };
+            commands::crystal_theme_pages::run(CrystalThemePagesArgs {
+                vault_root,
+                client_kind,
+                cache_dir,
+                refresh,
+                min_claims,
             })
         }
         Cmd::TagsBootstrap {

--- a/crates/ovp-domain/prompts/theme_page.md
+++ b/crates/ovp-domain/prompts/theme_page.md
@@ -1,0 +1,38 @@
+# Theme page prompt — theme_page/v1
+
+You are writing ONE topic page for a personal knowledge base. You get a
+topic's distinguishing keywords and a list of DURABLE CLAIMS — statements
+that already passed an evidence gate (each is backed by verbatim quotes from
+multiple sources). The claims are the ONLY material you may use.
+
+Weave the claims into a short, readable wiki page: group related claims into
+sections, connect them into flowing prose, surface tensions between claims
+where they exist. Do NOT add outside knowledge, examples, or conclusions the
+claims do not support.
+
+Rules:
+
+1. **Every paragraph must cite its claims.** After each statement, cite the
+   claim(s) it comes from as `[claim:<key>]`, using the exact keys given in
+   the input (e.g. `[claim:ck-1a2b3c4d5e6f7a8b]`). A paragraph with no
+   citation will be rejected by a deterministic verifier.
+2. **Only the given claims.** Never invent a key; never cite anything else.
+   You do not have to use every claim — prefer a coherent page over full
+   coverage — but unused claims are reported, so drop one only when it truly
+   does not fit.
+3. **Structure.** 2–5 sections. Each section: a short heading and 1–3
+   paragraphs. No introduction restating the topic name; start with substance.
+4. **Language.** Write in the dominant language of the claims (English or
+   中文). Keep established technical terms (Claude Code, MCP, RAG …) in their
+   original form.
+5. **Tone.** Factual and compact — a reference page, not an essay. No
+   "this theme covers…" meta-prose.
+6. Output **only** JSON — no prose, no markdown fence:
+
+```json
+{"sections": [{"heading": "<heading>", "body": "<paragraphs separated by \n\n, citations inline>"}]}
+```
+
+## Topic
+
+(keywords + claims follow)

--- a/crates/ovp-domain/prompts/theme_page.md
+++ b/crates/ovp-domain/prompts/theme_page.md
@@ -12,16 +12,22 @@ claims do not support.
 
 Rules:
 
-1. **Every paragraph must cite its claims.** After each statement, cite the
+1. **Every sentence must cite its claims.** End each sentence with the
    claim(s) it comes from as `[claim:<handle>]`, copying the exact handle
-   from the input list (e.g. `[claim:c7]`). A paragraph with no citation
-   will be rejected by a deterministic verifier.
+   from the input list (e.g. `[claim:c7]`). A deterministic verifier rejects
+   any sentence with no citation — do not let one citation cover the
+   sentences around it. This includes summary and transition sentences: a
+   sentence that connects or generalizes over claims must cite every claim
+   it draws on (`… [claim:c2] [claim:c5]`). If a sentence cannot cite
+   anything, delete it.
 2. **Only the given claims.** Never invent a handle; never cite anything
    else. You do not have to use every claim — prefer a coherent page over
    full coverage — but unused claims are reported, so drop one only when it
    truly does not fit.
-3. **Structure.** 2–5 sections. Each section: a short heading and 1–3
-   paragraphs. No introduction restating the topic name; start with substance.
+3. **Structure.** 1–5 sections. Each section: a short heading and 1–3
+   paragraphs. A handful of claims fits one section — never pad structure
+   with prose the claims cannot support. No introduction restating the topic
+   name; start with substance.
 4. **Language.** Write in the dominant language of the claims (English or
    中文). Keep established technical terms (Claude Code, MCP, RAG …) in their
    original form.

--- a/crates/ovp-domain/prompts/theme_page.md
+++ b/crates/ovp-domain/prompts/theme_page.md
@@ -13,13 +13,13 @@ claims do not support.
 Rules:
 
 1. **Every paragraph must cite its claims.** After each statement, cite the
-   claim(s) it comes from as `[claim:<key>]`, using the exact keys given in
-   the input (e.g. `[claim:ck-1a2b3c4d5e6f7a8b]`). A paragraph with no
-   citation will be rejected by a deterministic verifier.
-2. **Only the given claims.** Never invent a key; never cite anything else.
-   You do not have to use every claim — prefer a coherent page over full
-   coverage — but unused claims are reported, so drop one only when it truly
-   does not fit.
+   claim(s) it comes from as `[claim:<handle>]`, copying the exact handle
+   from the input list (e.g. `[claim:c7]`). A paragraph with no citation
+   will be rejected by a deterministic verifier.
+2. **Only the given claims.** Never invent a handle; never cite anything
+   else. You do not have to use every claim — prefer a coherent page over
+   full coverage — but unused claims are reported, so drop one only when it
+   truly does not fit.
 3. **Structure.** 2–5 sections. Each section: a short heading and 1–3
    paragraphs. No introduction restating the topic name; start with substance.
 4. **Language.** Write in the dominant language of the claims (English or
@@ -30,7 +30,7 @@ Rules:
 6. Output **only** JSON — no prose, no markdown fence:
 
 ```json
-{"sections": [{"heading": "<heading>", "body": "<paragraphs separated by \n\n, citations inline>"}]}
+{"sections": [{"heading": "<heading>", "body": "<paragraphs separated by \n\n, [claim:cN] citations inline>"}]}
 ```
 
 ## Topic

--- a/crates/ovp-domain/src/crystal.rs
+++ b/crates/ovp-domain/src/crystal.rs
@@ -42,6 +42,7 @@ pub mod select;
 /// Semantic display themes: the `themes.json` projection schema + helpers
 /// (majority-label lookup, synthesis grouping, bilingual `theme_label/v1`
 /// model stage). Rebuildable projection; never baked into the ledger.
+pub mod theme_pages;
 pub mod themes;
 
 use crate::units::validator::deterministic_contains;

--- a/crates/ovp-domain/src/crystal/theme_pages.rs
+++ b/crates/ovp-domain/src/crystal/theme_pages.rs
@@ -464,8 +464,8 @@ fn sentences(paragraph: &str) -> Vec<String> {
 }
 
 /// Is the `.` at `dot` part of an abbreviation rather than a sentence end?
-/// True when the word before it is a single-letter dotted segment (`e.g.`,
-/// `i.e.`, `U.S.`) or a common non-terminal abbreviation.
+/// True only for the two high-confidence shapes: a dotted single-letter
+/// segment (`e.g.`, `i.e.`, `U.S.`) or a single-letter initial (`J. Smith`).
 fn is_abbreviation_dot(chars: &[char], dot: usize) -> bool {
     if chars[dot] != '.' {
         return false;
@@ -477,33 +477,13 @@ fn is_abbreviation_dot(chars: &[char], dot: usize) -> bool {
     if s > 0 && chars[s - 1] == '.' && dot - s <= 2 {
         return true; // dotted abbreviation segment: e.g. / i.e. / U.S.
     }
-    if dot - s == 1 && chars[s].is_alphabetic() {
-        return true; // single-letter initial: J. Smith
-    }
-    let word: String = chars[s..dot].iter().collect::<String>().to_lowercase();
-    matches!(
-        word.as_str(),
-        "etc"
-            | "vs"
-            | "cf"
-            | "al"
-            | "fig"
-            | "ca"
-            | "approx"
-            | "inc"
-            | "corp"
-            | "ltd"
-            | "et"
-            | "vol"
-            | "dr"
-            | "mr"
-            | "ms"
-            | "mrs"
-            | "prof"
-            | "jr"
-            | "sr"
-            | "st"
-    )
+    // Single-letter initial (J. Smith). NO word list beyond these two
+    // high-confidence shapes: every list entry ("Inc.", "etc.", …) is a
+    // laundering vector — `Acme Inc. A supported sentence [claim:x].` would
+    // merge and verify as one cited fragment (codex round-3 P1). A false
+    // SPLIT only costs a spurious defect that the bounded repair pass
+    // absorbs; a false MERGE breaks the grounding guarantee. Split wins.
+    dot - s == 1 && chars[s].is_alphabetic()
 }
 
 /// Split a fragment's leading run of `[claim:…]` citations (with surrounding
@@ -726,6 +706,24 @@ mod tests {
             vec![PageDefect::UncitedSentence {
                 section: 0,
                 snippet: "Unsupported claim.".into()
+            }]
+        );
+    }
+
+    #[test]
+    fn word_abbreviations_split_rather_than_launder() {
+        // Codex round-3 P1: `Inc.`-style tokens must not merge an uncited
+        // sentence into the cited one after it. The false-split cost lands
+        // on the repair pass, never on the grounding guarantee.
+        let sections = vec![PageSection {
+            heading: "H".into(),
+            body: "Acme Inc. A supported sentence [claim:ck-a].".into(),
+        }];
+        assert_eq!(
+            verify_page(&sections, &keys(&["ck-a"])),
+            vec![PageDefect::UncitedSentence {
+                section: 0,
+                snippet: "Acme Inc.".into()
             }]
         );
     }

--- a/crates/ovp-domain/src/crystal/theme_pages.rs
+++ b/crates/ovp-domain/src/crystal/theme_pages.rs
@@ -285,6 +285,10 @@ pub enum PageDefect {
     /// paragraph-level: one citation must not launder the uncited sentences
     /// around it into the grounded projection (codex review P1).
     UncitedSentence { section: usize, snippet: String },
+    /// A section whose body contains no semantic sentence at all (only
+    /// punctuation or bare citations) — a "grounded" page must contain
+    /// grounded prose, not citation confetti (codex review round-2 P2).
+    EmptySection { section: usize },
 }
 
 impl std::fmt::Display for PageDefect {
@@ -296,6 +300,9 @@ impl std::fmt::Display for PageDefect {
             }
             PageDefect::UncitedSentence { section, snippet } => {
                 write!(f, "section {section}: uncited sentence `{snippet}`")
+            }
+            PageDefect::EmptySection { section } => {
+                write!(f, "section {section}: no semantic sentences")
             }
         }
     }
@@ -336,8 +343,10 @@ pub fn verify_page(sections: &[PageSection], known_keys: &BTreeSet<String>) -> V
         return defects;
     }
     for (si, section) in sections.iter().enumerate() {
+        let mut semantic_sentences = 0usize;
         for para in paragraphs(&section.body) {
             for sentence in sentences(&para) {
+                semantic_sentences += 1;
                 if extract_claim_citations(&sentence).is_empty() {
                     defects.push(PageDefect::UncitedSentence {
                         section: si,
@@ -353,6 +362,9 @@ pub fn verify_page(sections: &[PageSection], known_keys: &BTreeSet<String>) -> V
                     });
                 }
             }
+        }
+        if semantic_sentences == 0 {
+            defects.push(PageDefect::EmptySection { section: si });
         }
     }
     defects
@@ -402,22 +414,16 @@ fn sentences(paragraph: &str) -> Vec<String> {
                 end += 1;
             }
         }
+        // A soft terminator splits whenever it is followed by whitespace (or
+        // ends the text) and is not an abbreviation dot. No uppercase
+        // heuristic: `Unsupported claim. however supported [claim:x].` must
+        // split too, or the trailing citation launders the first sentence
+        // (codex review round-2 P1). Abbreviation escapes carry the false-
+        // positive burden instead.
         let splits = if hard {
             true
         } else if soft {
-            if is_abbreviation_dot(&chars, i) {
-                false
-            } else if end >= chars.len() {
-                true
-            } else if chars[end].is_whitespace() {
-                let mut k = end;
-                while k < chars.len() && chars[k].is_whitespace() {
-                    k += 1;
-                }
-                k >= chars.len() || chars[k].is_uppercase() || is_cjk(chars[k]) || chars[k] == '['
-            } else {
-                false
-            }
+            !is_abbreviation_dot(&chars, i) && (end >= chars.len() || chars[end].is_whitespace())
         } else {
             false
         };
@@ -471,10 +477,32 @@ fn is_abbreviation_dot(chars: &[char], dot: usize) -> bool {
     if s > 0 && chars[s - 1] == '.' && dot - s <= 2 {
         return true; // dotted abbreviation segment: e.g. / i.e. / U.S.
     }
+    if dot - s == 1 && chars[s].is_alphabetic() {
+        return true; // single-letter initial: J. Smith
+    }
     let word: String = chars[s..dot].iter().collect::<String>().to_lowercase();
     matches!(
         word.as_str(),
-        "etc" | "vs" | "cf" | "al" | "fig" | "ca" | "approx"
+        "etc"
+            | "vs"
+            | "cf"
+            | "al"
+            | "fig"
+            | "ca"
+            | "approx"
+            | "inc"
+            | "corp"
+            | "ltd"
+            | "et"
+            | "vol"
+            | "dr"
+            | "mr"
+            | "ms"
+            | "mrs"
+            | "prof"
+            | "jr"
+            | "sr"
+            | "st"
     )
 }
 
@@ -682,6 +710,37 @@ mod tests {
                 section: 0,
                 snippet: "Unsupported claim.".into()
             }]
+        );
+    }
+
+    #[test]
+    fn lowercase_continuation_still_splits_and_fails_uncited() {
+        // Codex round-2 P1: sentence boundaries must not depend on the next
+        // sentence starting uppercase.
+        let sections = vec![PageSection {
+            heading: "H".into(),
+            body: "Unsupported claim. however supported [claim:ck-a].".into(),
+        }];
+        assert_eq!(
+            verify_page(&sections, &keys(&["ck-a"])),
+            vec![PageDefect::UncitedSentence {
+                section: 0,
+                snippet: "Unsupported claim.".into()
+            }]
+        );
+    }
+
+    #[test]
+    fn content_free_sections_are_rejected() {
+        // Codex round-2 P2: a section of citation confetti with no prose
+        // must not count as grounded content.
+        let sections = vec![PageSection {
+            heading: "H".into(),
+            body: "[claim:ck-a]".into(),
+        }];
+        assert_eq!(
+            verify_page(&sections, &keys(&["ck-a"])),
+            vec![PageDefect::EmptySection { section: 0 }]
         );
     }
 

--- a/crates/ovp-domain/src/crystal/theme_pages.rs
+++ b/crates/ovp-domain/src/crystal/theme_pages.rs
@@ -381,22 +381,23 @@ fn snippet_of(sentence: &str) -> String {
     }
 }
 
-/// CJK ranges relevant to sentence splitting (ideographs, kana, fullwidth,
-/// CJK punctuation) — used only to decide whether a `.` ends a sentence.
-fn is_cjk(c: char) -> bool {
-    matches!(c as u32, 0x3000..=0x9FFF | 0xF900..=0xFAFF | 0xFF00..=0xFFEF)
-}
-
-/// Split a paragraph into sentences for the citation gate. Deterministic and
-/// deliberately conservative:
+/// Split a paragraph into sentences for the citation gate.
 ///
-/// - `。！？` always end a sentence.
-/// - `.!?` end one only when followed (after closing quotes/brackets) by
-///   whitespace and then an uppercase letter, a CJK char, or end of text —
-///   so `e.g. something` and `v2.0 is` do not split.
+/// One rule, ZERO merge heuristics: a terminator (`.!?。！？`) ends a
+/// sentence whenever it is followed — after closing quotes/brackets — by
+/// whitespace, a `[claim:` citation, or end of text. Codex review rounds
+/// 2–4 demonstrated that every "don't split here" heuristic (uppercase
+/// look-ahead, abbreviation word lists, dotted segments like `U.S.`) is a
+/// laundering vector that merges an uncited sentence into a cited one. A
+/// false SPLIT costs one spurious defect that the bounded repair pass
+/// absorbs; a false MERGE breaks the grounding guarantee. Split wins,
+/// always. (`v2.0` still holds together — the dot is not followed by
+/// whitespace.)
+///
 /// - A fragment's LEADING `[claim:…]` cluster re-attaches to the previous
 ///   sentence (`Text. [claim:c1] Next…` cites "Text." with c1).
-/// - Fragments with no letters/digits/CJK (stray punctuation) are dropped.
+/// - Fragments with no alphanumeric content (stray punctuation, bare
+///   citations) are never semantic sentences.
 fn sentences(paragraph: &str) -> Vec<String> {
     let chars: Vec<char> = paragraph.chars().collect();
     let mut fragments: Vec<String> = Vec::new();
@@ -414,16 +415,10 @@ fn sentences(paragraph: &str) -> Vec<String> {
                 end += 1;
             }
         }
-        // A soft terminator splits whenever it is followed by whitespace (or
-        // ends the text) and is not an abbreviation dot. No uppercase
-        // heuristic: `Unsupported claim. however supported [claim:x].` must
-        // split too, or the trailing citation launders the first sentence
-        // (codex review round-2 P1). Abbreviation escapes carry the false-
-        // positive burden instead.
         let splits = if hard {
             true
         } else if soft {
-            !is_abbreviation_dot(&chars, i) && (end >= chars.len() || chars[end].is_whitespace())
+            end >= chars.len() || chars[end].is_whitespace() || chars[end] == '['
         } else {
             false
         };
@@ -449,7 +444,10 @@ fn sentences(paragraph: &str) -> Vec<String> {
             prev.push_str(&leading);
         }
         let rest = rest.trim();
-        if rest.chars().any(|c| c.is_alphanumeric() || is_cjk(c)) {
+        // `is_alphanumeric` covers CJK ideographs (Unicode Letter) while
+        // excluding CJK punctuation like `。` — a section of `。[claim:x]`
+        // confetti must not count as a semantic sentence (codex round-4 P2).
+        if rest.chars().any(char::is_alphanumeric) {
             out.push(rest.to_string());
         } else if !rest.is_empty()
             && let Some(prev) = out.last_mut()
@@ -461,29 +459,6 @@ fn sentences(paragraph: &str) -> Vec<String> {
         }
     }
     out
-}
-
-/// Is the `.` at `dot` part of an abbreviation rather than a sentence end?
-/// True only for the two high-confidence shapes: a dotted single-letter
-/// segment (`e.g.`, `i.e.`, `U.S.`) or a single-letter initial (`J. Smith`).
-fn is_abbreviation_dot(chars: &[char], dot: usize) -> bool {
-    if chars[dot] != '.' {
-        return false;
-    }
-    let mut s = dot;
-    while s > 0 && chars[s - 1].is_alphanumeric() {
-        s -= 1;
-    }
-    if s > 0 && chars[s - 1] == '.' && dot - s <= 2 {
-        return true; // dotted abbreviation segment: e.g. / i.e. / U.S.
-    }
-    // Single-letter initial (J. Smith). NO word list beyond these two
-    // high-confidence shapes: every list entry ("Inc.", "etc.", …) is a
-    // laundering vector — `Acme Inc. A supported sentence [claim:x].` would
-    // merge and verify as one cited fragment (codex round-3 P1). A false
-    // SPLIT only costs a spurious defect that the bounded repair pass
-    // absorbs; a false MERGE breaks the grounding guarantee. Split wins.
-    dot - s == 1 && chars[s].is_alphabetic()
 }
 
 /// Split a fragment's leading run of `[claim:…]` citations (with surrounding
@@ -743,19 +718,19 @@ mod tests {
     }
 
     #[test]
-    fn sentence_splitting_handles_trailing_citations_abbreviations_and_cjk() {
+    fn sentence_splitting_handles_trailing_citations_numbers_and_cjk() {
         // Citation AFTER the period attaches to the sentence it follows.
         let ok = vec![PageSection {
             heading: "H".into(),
             body: "Text. [claim:ck-a] Next sentence [claim:ck-b].".into(),
         }];
         assert!(verify_page(&ok, &keys(&["ck-a", "ck-b"])).is_empty());
-        // Abbreviations and version numbers do not split.
-        let abbrev = vec![PageSection {
+        // Version numbers hold together (dot not followed by whitespace).
+        let version = vec![PageSection {
             heading: "H".into(),
-            body: "Systems like e.g. Mem0 v2.0 persist state [claim:ck-a].".into(),
+            body: "Mem0 v2.0 persists state [claim:ck-a].".into(),
         }];
-        assert!(verify_page(&abbrev, &keys(&["ck-a"])).is_empty());
+        assert!(verify_page(&version, &keys(&["ck-a"])).is_empty());
         // CJK terminators split; the uncited CJK sentence fails.
         let cjk = vec![PageSection {
             heading: "H".into(),
@@ -767,6 +742,67 @@ mod tests {
                 section: 0,
                 snippet: "存储不是难点。".into()
             }]
+        );
+    }
+
+    #[test]
+    fn split_over_launder_has_no_abbreviation_escapes() {
+        // Codex rounds 3-4: every abbreviation escape was a laundering
+        // vector. `e.g.` now splits — the false positive is the accepted
+        // cost (the repair pass absorbs it), the merge would be a hole.
+        let eg = vec![PageSection {
+            heading: "H".into(),
+            body: "Systems like e.g. Mem0 persist state [claim:ck-a].".into(),
+        }];
+        assert_eq!(
+            verify_page(&eg, &keys(&["ck-a"])),
+            vec![PageDefect::UncitedSentence {
+                section: 0,
+                snippet: "Systems like e.g.".into()
+            }]
+        );
+        // The round-4 U.S. laundering example must produce a defect.
+        let us = vec![PageSection {
+            heading: "H".into(),
+            body: "Unsupported assertion about the U.S. Supported assertion [claim:ck-a].".into(),
+        }];
+        assert_eq!(
+            verify_page(&us, &keys(&["ck-a"])),
+            vec![PageDefect::UncitedSentence {
+                section: 0,
+                snippet: "Unsupported assertion about the U.S.".into()
+            }]
+        );
+    }
+
+    #[test]
+    fn citation_directly_after_period_still_splits() {
+        // Codex round-4 P1: `Supported fact.[claim:ck-a] Unsupported.` must
+        // not verify as one cited fragment.
+        let sections = vec![PageSection {
+            heading: "H".into(),
+            body: "Supported fact.[claim:ck-a] Unsupported follow-up.".into(),
+        }];
+        assert_eq!(
+            verify_page(&sections, &keys(&["ck-a"])),
+            vec![PageDefect::UncitedSentence {
+                section: 0,
+                snippet: "Unsupported follow-up.".into()
+            }]
+        );
+    }
+
+    #[test]
+    fn cjk_punctuation_confetti_is_not_semantic_content() {
+        // Codex round-4 P2: `。[claim:ck-a]` must be an EmptySection, not a
+        // "sentence".
+        let sections = vec![PageSection {
+            heading: "H".into(),
+            body: "。[claim:ck-a]".into(),
+        }];
+        assert_eq!(
+            verify_page(&sections, &keys(&["ck-a"])),
+            vec![PageDefect::EmptySection { section: 0 }]
         );
     }
 

--- a/crates/ovp-domain/src/crystal/theme_pages.rs
+++ b/crates/ovp-domain/src/crystal/theme_pages.rs
@@ -4,9 +4,10 @@
 //! majority theme community (the same vote `ovp-index` uses for
 //! `ClaimRow.theme`), asks the model to weave each group into a short wiki
 //! page (`theme_page/v1`), and gates the reply through a DETERMINISTIC
-//! verifier: every paragraph must cite at least one `[claim:<claim_key>]`
+//! verifier: every SENTENCE must cite at least one `[claim:<claim_key>]`
 //! and every cited key must be one of the claims supplied for that theme.
-//! A page that fails the verifier is never written.
+//! A failing draft gets ONE bounded repair call; a page that still fails
+//! the verifier is never written.
 //!
 //! `.ovp/crystal/theme_pages.json` is a REBUILDABLE projection: it is never
 //! baked into the crystal ledger, and pages are regenerated only when a
@@ -155,6 +156,57 @@ pub fn theme_page_request(synth_theme: &str, claims: &[PageClaim]) -> ModelReque
     }
 }
 
+/// Build the ONE bounded repair request for a draft that failed the page
+/// gate: the model gets its own previous JSON (still handle-cited), the
+/// verifier's defect list, and the claim list again — and must either cite
+/// or delete each offending sentence, never add content. Same cassette
+/// namespace as the synthesis stage; the request is deterministic given the
+/// draft + defects, so replay works. If the repaired draft still fails the
+/// gate, the command fails loud — there is no second repair (same bounded
+/// contract as the JSON-repair pass in `call_and_parse`).
+pub fn theme_page_repair_request(
+    synth_theme: &str,
+    claims: &[PageClaim],
+    previous_sections: &[PageSection],
+    defects: &[String],
+) -> ModelRequest {
+    let marker = "## Topic";
+    let (system, _) = THEME_PAGE_TEMPLATE
+        .split_once(marker)
+        .unwrap_or((THEME_PAGE_TEMPLATE, ""));
+    let mut user = format!("{marker}\n\nKeywords: {synth_theme}\n\nClaims:\n");
+    for (i, c) in claims.iter().enumerate() {
+        user.push_str(&format!(
+            "- [claim:{}] ({} source(s)) {}\n",
+            claim_handle(i),
+            c.source_count,
+            c.claim
+        ));
+    }
+    let draft = serde_json::json!({ "sections": previous_sections });
+    user.push_str("\n## Previous draft (failed the citation gate)\n\n");
+    user.push_str(&draft.to_string());
+    user.push_str("\n\n## Verifier defects\n\n");
+    for d in defects {
+        user.push_str(&format!("- {d}\n"));
+    }
+    user.push_str(
+        "\nRepair the draft: for each uncited sentence, either add the \
+         [claim:cN] citation(s) whose claims genuinely support it, or delete \
+         the sentence. Replace any unknown citation with a valid handle or \
+         remove it. Do NOT add new sentences, sections, or content. Output \
+         only the corrected JSON in the same format.",
+    );
+    ModelRequest {
+        model: PAGE_MODEL.to_string(),
+        system: Some(system.trim_end().to_string()),
+        messages: vec![ModelMessage::User { content: user }],
+        max_tokens: PAGE_MAX_TOKENS,
+        temperature: None,
+        cache_namespace: Some(THEME_PAGE_PROMPT_ID.to_string()),
+    }
+}
+
 /// Replace `[claim:cN]` handles with the real claim keys, in the same sorted
 /// claim order the request was built from. Unknown or out-of-range handles
 /// are left untouched — the verifier then reports them as `UnknownClaim`
@@ -229,8 +281,10 @@ pub enum PageDefect {
     NoSections,
     /// A cited key is not in this theme's claim set.
     UnknownClaim { section: usize, citation: String },
-    /// A paragraph carries no `[claim:…]` citation.
-    UncitedParagraph { section: usize, paragraph: usize },
+    /// A sentence carries no `[claim:…]` citation. Sentence-level, not
+    /// paragraph-level: one citation must not launder the uncited sentences
+    /// around it into the grounded projection (codex review P1).
+    UncitedSentence { section: usize, snippet: String },
 }
 
 impl std::fmt::Display for PageDefect {
@@ -240,11 +294,8 @@ impl std::fmt::Display for PageDefect {
             PageDefect::UnknownClaim { section, citation } => {
                 write!(f, "section {section}: cites unknown claim `{citation}`")
             }
-            PageDefect::UncitedParagraph { section, paragraph } => {
-                write!(
-                    f,
-                    "section {section} paragraph {paragraph}: no [claim:…] citation"
-                )
+            PageDefect::UncitedSentence { section, snippet } => {
+                write!(f, "section {section}: uncited sentence `{snippet}`")
             }
         }
     }
@@ -275,7 +326,9 @@ pub fn extract_claim_citations(text: &str) -> Vec<String> {
 
 /// Verify a synthesized page against the claim set it was given. Deterministic
 /// and total: returns EVERY defect (the command fails loud and reports all of
-/// them, so a rerun's repair pass has the full picture).
+/// them, so a rerun's repair pass has the full picture). Grounding is checked
+/// per SENTENCE — `Unsupported claim. Supported claim [claim:x].` must fail on
+/// the first sentence, not ride on the second's citation.
 pub fn verify_page(sections: &[PageSection], known_keys: &BTreeSet<String>) -> Vec<PageDefect> {
     let mut defects = Vec::new();
     if sections.is_empty() {
@@ -283,15 +336,16 @@ pub fn verify_page(sections: &[PageSection], known_keys: &BTreeSet<String>) -> V
         return defects;
     }
     for (si, section) in sections.iter().enumerate() {
-        for (pi, para) in paragraphs(&section.body).iter().enumerate() {
-            let cited = extract_claim_citations(para);
-            if cited.is_empty() {
-                defects.push(PageDefect::UncitedParagraph {
-                    section: si,
-                    paragraph: pi,
-                });
+        for para in paragraphs(&section.body) {
+            for sentence in sentences(&para) {
+                if extract_claim_citations(&sentence).is_empty() {
+                    defects.push(PageDefect::UncitedSentence {
+                        section: si,
+                        snippet: snippet_of(&sentence),
+                    });
+                }
             }
-            for key in cited {
+            for key in extract_claim_citations(&para) {
                 if !known_keys.contains(&key) {
                     defects.push(PageDefect::UnknownClaim {
                         section: si,
@@ -302,6 +356,147 @@ pub fn verify_page(sections: &[PageSection], known_keys: &BTreeSet<String>) -> V
         }
     }
     defects
+}
+
+/// First ~40 chars of a sentence, for actionable defect messages.
+fn snippet_of(sentence: &str) -> String {
+    let t = sentence.trim();
+    let cut: String = t.chars().take(40).collect();
+    if cut.chars().count() < t.chars().count() {
+        format!("{cut}…")
+    } else {
+        cut
+    }
+}
+
+/// CJK ranges relevant to sentence splitting (ideographs, kana, fullwidth,
+/// CJK punctuation) — used only to decide whether a `.` ends a sentence.
+fn is_cjk(c: char) -> bool {
+    matches!(c as u32, 0x3000..=0x9FFF | 0xF900..=0xFAFF | 0xFF00..=0xFFEF)
+}
+
+/// Split a paragraph into sentences for the citation gate. Deterministic and
+/// deliberately conservative:
+///
+/// - `。！？` always end a sentence.
+/// - `.!?` end one only when followed (after closing quotes/brackets) by
+///   whitespace and then an uppercase letter, a CJK char, or end of text —
+///   so `e.g. something` and `v2.0 is` do not split.
+/// - A fragment's LEADING `[claim:…]` cluster re-attaches to the previous
+///   sentence (`Text. [claim:c1] Next…` cites "Text." with c1).
+/// - Fragments with no letters/digits/CJK (stray punctuation) are dropped.
+fn sentences(paragraph: &str) -> Vec<String> {
+    let chars: Vec<char> = paragraph.chars().collect();
+    let mut fragments: Vec<String> = Vec::new();
+    let mut start = 0usize;
+    let mut i = 0usize;
+    while i < chars.len() {
+        let c = chars[i];
+        let hard = matches!(c, '。' | '！' | '？');
+        let soft = matches!(c, '.' | '!' | '?');
+        let mut end = i + 1;
+        if hard || soft {
+            // Closing quotes/brackets belong to the sentence they end.
+            while end < chars.len() && matches!(chars[end], '"' | '”' | '\'' | ')' | '）' | ']')
+            {
+                end += 1;
+            }
+        }
+        let splits = if hard {
+            true
+        } else if soft {
+            if is_abbreviation_dot(&chars, i) {
+                false
+            } else if end >= chars.len() {
+                true
+            } else if chars[end].is_whitespace() {
+                let mut k = end;
+                while k < chars.len() && chars[k].is_whitespace() {
+                    k += 1;
+                }
+                k >= chars.len() || chars[k].is_uppercase() || is_cjk(chars[k]) || chars[k] == '['
+            } else {
+                false
+            }
+        } else {
+            false
+        };
+        if splits {
+            fragments.push(chars[start..end].iter().collect());
+            start = end;
+            i = end;
+        } else {
+            i += 1;
+        }
+    }
+    if start < chars.len() {
+        fragments.push(chars[start..].iter().collect());
+    }
+
+    let mut out: Vec<String> = Vec::new();
+    for fragment in fragments {
+        let (leading, rest) = split_leading_citations(&fragment);
+        if !leading.is_empty()
+            && let Some(prev) = out.last_mut()
+        {
+            prev.push(' ');
+            prev.push_str(&leading);
+        }
+        let rest = rest.trim();
+        if rest.chars().any(|c| c.is_alphanumeric() || is_cjk(c)) {
+            out.push(rest.to_string());
+        } else if !rest.is_empty()
+            && let Some(prev) = out.last_mut()
+        {
+            // Citation-less punctuation tail (e.g. a stray `.`) — keep it
+            // attached rather than inventing an empty sentence.
+            prev.push(' ');
+            prev.push_str(rest);
+        }
+    }
+    out
+}
+
+/// Is the `.` at `dot` part of an abbreviation rather than a sentence end?
+/// True when the word before it is a single-letter dotted segment (`e.g.`,
+/// `i.e.`, `U.S.`) or a common non-terminal abbreviation.
+fn is_abbreviation_dot(chars: &[char], dot: usize) -> bool {
+    if chars[dot] != '.' {
+        return false;
+    }
+    let mut s = dot;
+    while s > 0 && chars[s - 1].is_alphanumeric() {
+        s -= 1;
+    }
+    if s > 0 && chars[s - 1] == '.' && dot - s <= 2 {
+        return true; // dotted abbreviation segment: e.g. / i.e. / U.S.
+    }
+    let word: String = chars[s..dot].iter().collect::<String>().to_lowercase();
+    matches!(
+        word.as_str(),
+        "etc" | "vs" | "cf" | "al" | "fig" | "ca" | "approx"
+    )
+}
+
+/// Split a fragment's leading run of `[claim:…]` citations (with surrounding
+/// whitespace) from the rest.
+fn split_leading_citations(fragment: &str) -> (String, String) {
+    let mut rest = fragment;
+    let mut leading = String::new();
+    loop {
+        let trimmed = rest.trim_start();
+        if let Some(after) = trimmed.strip_prefix("[claim:")
+            && let Some(end) = after.find(']')
+        {
+            if !leading.is_empty() {
+                leading.push(' ');
+            }
+            leading.push_str(&trimmed[..("[claim:".len() + end + 1)]);
+            rest = &after[end + 1..];
+        } else {
+            return (leading, rest.trim_start().to_string());
+        }
+    }
 }
 
 /// Claim keys the page never cites — reported as coverage, never a defect
@@ -457,9 +652,9 @@ mod tests {
         assert_eq!(
             defects,
             vec![
-                PageDefect::UncitedParagraph {
+                PageDefect::UncitedSentence {
                     section: 0,
-                    paragraph: 0
+                    snippet: "Uncited paragraph.".into()
                 },
                 PageDefect::UnknownClaim {
                     section: 0,
@@ -470,6 +665,51 @@ mod tests {
         assert_eq!(
             verify_page(&[], &keys(&["ck-a"])),
             vec![PageDefect::NoSections]
+        );
+    }
+
+    #[test]
+    fn one_citation_does_not_launder_the_uncited_sentence_beside_it() {
+        // The codex-review P1 example: paragraph-level checking would pass
+        // this; sentence-level must not.
+        let sections = vec![PageSection {
+            heading: "H".into(),
+            body: "Unsupported claim. Supported claim [claim:ck-a].".into(),
+        }];
+        assert_eq!(
+            verify_page(&sections, &keys(&["ck-a"])),
+            vec![PageDefect::UncitedSentence {
+                section: 0,
+                snippet: "Unsupported claim.".into()
+            }]
+        );
+    }
+
+    #[test]
+    fn sentence_splitting_handles_trailing_citations_abbreviations_and_cjk() {
+        // Citation AFTER the period attaches to the sentence it follows.
+        let ok = vec![PageSection {
+            heading: "H".into(),
+            body: "Text. [claim:ck-a] Next sentence [claim:ck-b].".into(),
+        }];
+        assert!(verify_page(&ok, &keys(&["ck-a", "ck-b"])).is_empty());
+        // Abbreviations and version numbers do not split.
+        let abbrev = vec![PageSection {
+            heading: "H".into(),
+            body: "Systems like e.g. Mem0 v2.0 persist state [claim:ck-a].".into(),
+        }];
+        assert!(verify_page(&abbrev, &keys(&["ck-a"])).is_empty());
+        // CJK terminators split; the uncited CJK sentence fails.
+        let cjk = vec![PageSection {
+            heading: "H".into(),
+            body: "记忆需要治理 [claim:ck-a]。存储不是难点。".into(),
+        }];
+        assert_eq!(
+            verify_page(&cjk, &keys(&["ck-a"])),
+            vec![PageDefect::UncitedSentence {
+                section: 0,
+                snippet: "存储不是难点。".into()
+            }]
         );
     }
 

--- a/crates/ovp-domain/src/crystal/theme_pages.rs
+++ b/crates/ovp-domain/src/crystal/theme_pages.rs
@@ -437,6 +437,13 @@ fn sentences(paragraph: &str) -> Vec<String> {
     let mut out: Vec<String> = Vec::new();
     for fragment in fragments {
         let (leading, rest) = split_leading_citations(&fragment);
+        // A leading citation with NO previous sentence (paragraph starts
+        // with `[claim:…]`) is deliberately dropped, so the following
+        // sentence fails as uncited. Attaching it forward would certify
+        // whatever prose the model chose to put after it — the same
+        // laundering shape the abbreviation escapes had. The false positive
+        // costs one bounded repair; the prompt says citations FOLLOW their
+        // statement.
         if !leading.is_empty()
             && let Some(prev) = out.last_mut()
         {
@@ -788,6 +795,26 @@ mod tests {
             vec![PageDefect::UncitedSentence {
                 section: 0,
                 snippet: "Unsupported follow-up.".into()
+            }]
+        );
+    }
+
+    #[test]
+    fn paragraph_leading_citation_does_not_certify_the_following_sentence() {
+        // gemini review suggested attaching a paragraph-leading citation to
+        // the sentence AFTER it. That is a laundering vector (the citation
+        // would certify arbitrary following prose), so the strict behavior
+        // is intentional: the citation drops, the sentence fails, the
+        // bounded repair pass rewrites it with a trailing citation.
+        let sections = vec![PageSection {
+            heading: "H".into(),
+            body: "[claim:ck-a] Prose the citation precedes.".into(),
+        }];
+        assert_eq!(
+            verify_page(&sections, &keys(&["ck-a"])),
+            vec![PageDefect::UncitedSentence {
+                section: 0,
+                snippet: "Prose the citation precedes.".into()
             }]
         );
     }

--- a/crates/ovp-domain/src/crystal/theme_pages.rs
+++ b/crates/ovp-domain/src/crystal/theme_pages.rs
@@ -1,0 +1,441 @@
+//! Grounded theme pages — the `theme_pages.json` PROJECTION over durable claims.
+//!
+//! `ovp2 crystal-theme-pages` groups the ACTIVE durable claims by their
+//! majority theme community (the same vote `ovp-index` uses for
+//! `ClaimRow.theme`), asks the model to weave each group into a short wiki
+//! page (`theme_page/v1`), and gates the reply through a DETERMINISTIC
+//! verifier: every paragraph must cite at least one `[claim:<claim_key>]`
+//! and every cited key must be one of the claims supplied for that theme.
+//! A page that fails the verifier is never written.
+//!
+//! `.ovp/crystal/theme_pages.json` is a REBUILDABLE projection: it is never
+//! baked into the crystal ledger, and pages are regenerated only when a
+//! theme's claim set changes (`ThemePage.claim_keys` is the staleness
+//! marker). Display labels are refreshed from `themes.json` at write time and
+//! never enter the synthesis request — a relabel must not move a cassette key
+//! (same contract as `ThemeCommunity::synth_theme`).
+
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use ovp_llm::{ModelMessage, ModelRequest};
+use serde::{Deserialize, Serialize};
+
+/// Schema marker for `theme_pages.json`.
+pub const THEME_PAGES_SCHEMA: &str = "ovp.theme_pages/v1";
+/// Cassette namespace + version marker for the page-synthesis stage.
+pub const THEME_PAGE_PROMPT_ID: &str = "theme_page/v1";
+/// Fewer durable claims than this and a theme gets no page — one claim is a
+/// claim card, not a topic page.
+pub const MIN_PAGE_CLAIMS: usize = 2;
+
+const THEME_PAGE_TEMPLATE: &str = include_str!("../../prompts/theme_page.md");
+const PAGE_MODEL: &str = "claude-sonnet-4-6";
+/// Pages weave dozens of claims into multi-section prose — far above the
+/// label stage's budget, still bounded.
+const PAGE_MAX_TOKENS: u32 = 4000;
+
+/// One claim as fed to the page synthesis: its durable ledger identity plus
+/// the text the narrative may use. `claim_key` (not `claim_id`) because the
+/// key is the unique, deterministic address every surface resolves
+/// (`claim/<key>.json` in the publish tree; claim_ids can collide across
+/// runs).
+#[derive(Debug, Clone, PartialEq)]
+pub struct PageClaim {
+    pub claim_key: String,
+    pub claim: String,
+    /// Distinct cited source cases — shown to the model so breadth is
+    /// visible ("supported by 4 sources"), never invented.
+    pub source_count: usize,
+}
+
+/// One rendered section of a theme page.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PageSection {
+    pub heading: String,
+    /// Paragraphs separated by blank lines; `[claim:<key>]` citations inline.
+    pub body: String,
+}
+
+/// One grounded topic page.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ThemePage {
+    /// Stable grouping identity: the `themes.json` community id.
+    pub community_id: i64,
+    /// Display-only, refreshed from `themes.json` on every write; never part
+    /// of the synthesis request.
+    pub label: String,
+    pub label_zh: String,
+    /// SORTED active-claim keys this page was woven from — the staleness
+    /// marker (same set ⇒ page is up to date) and the verifier's universe.
+    pub claim_keys: Vec<String>,
+    pub sections: Vec<PageSection>,
+}
+
+/// The whole projection file.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ThemePagesFile {
+    pub schema: String,
+    /// Pages sorted by `community_id`.
+    pub pages: Vec<ThemePage>,
+}
+
+impl ThemePagesFile {
+    /// Read `theme_pages.json`. Missing file → `Ok(None)` (pages are
+    /// optional); unparseable or wrong schema → `Err` (a corrupt projection
+    /// should be regenerated, not silently ignored).
+    pub fn load(path: &Path) -> Result<Option<ThemePagesFile>, String> {
+        if !path.exists() {
+            return Ok(None);
+        }
+        let raw = std::fs::read_to_string(path)
+            .map_err(|e| format!("reading {}: {e}", path.display()))?;
+        let file: ThemePagesFile = serde_json::from_str(&raw).map_err(|e| {
+            format!(
+                "parsing {}: {e} (regenerate with `ovp2 crystal-theme-pages --refresh`)",
+                path.display()
+            )
+        })?;
+        if file.schema != THEME_PAGES_SCHEMA {
+            return Err(format!(
+                "{}: unsupported schema `{}` (expected `{THEME_PAGES_SCHEMA}`)",
+                path.display(),
+                file.schema
+            ));
+        }
+        Ok(Some(file))
+    }
+
+    /// The page for a community, if any.
+    pub fn page(&self, community_id: i64) -> Option<&ThemePage> {
+        self.pages.iter().find(|p| p.community_id == community_id)
+    }
+}
+
+// ---- Synthesis request (`theme_page/v1`) ----
+
+/// Build the page-synthesis `ModelRequest` for one theme. `synth_theme` is
+/// the community's DETERMINISTIC keyword identity
+/// (`ThemeCommunity::synth_theme`) — never the display label, so a
+/// presentation relabel cannot move the cassette key or change a prompt
+/// byte. Claims are pre-sorted by the caller (sorted claim_key order) so the
+/// same claim set always builds the same request.
+pub fn theme_page_request(synth_theme: &str, claims: &[PageClaim]) -> ModelRequest {
+    let marker = "## Topic";
+    let (system, _) = THEME_PAGE_TEMPLATE
+        .split_once(marker)
+        .unwrap_or((THEME_PAGE_TEMPLATE, ""));
+    let mut user = format!("{marker}\n\nKeywords: {synth_theme}\n\nClaims:\n");
+    for c in claims {
+        user.push_str(&format!(
+            "- [claim:{}] ({} source(s)) {}\n",
+            c.claim_key, c.source_count, c.claim
+        ));
+    }
+    ModelRequest {
+        model: PAGE_MODEL.to_string(),
+        system: Some(system.trim_end().to_string()),
+        messages: vec![ModelMessage::User { content: user }],
+        max_tokens: PAGE_MAX_TOKENS,
+        temperature: None,
+        cache_namespace: Some(THEME_PAGE_PROMPT_ID.to_string()),
+    }
+}
+
+/// Parse a page reply: `{"sections": [{"heading": "...", "body": "..."}]}`.
+/// Structural checks only — grounding is the verifier's job.
+pub fn parse_theme_page(reply_text: &str) -> Result<Vec<PageSection>, String> {
+    let (value, _note) =
+        crate::model_reply::parse_reply_value(reply_text).map_err(|d| d.to_string())?;
+    let sections = value
+        .get("sections")
+        .and_then(|v| v.as_array())
+        .ok_or("missing `sections` array")?;
+    let mut out = Vec::with_capacity(sections.len());
+    for (i, s) in sections.iter().enumerate() {
+        let heading = s
+            .get("heading")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| format!("section {i}: missing `heading`"))?;
+        let body = s
+            .get("body")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| format!("section {i}: missing `body`"))?;
+        out.push(PageSection {
+            heading: heading.to_string(),
+            body: body.to_string(),
+        });
+    }
+    Ok(out)
+}
+
+// ---- Deterministic verifier (the page gate) ----
+
+/// One grounding defect found in a synthesized page.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PageDefect {
+    /// The model produced no sections at all.
+    NoSections,
+    /// A cited key is not in this theme's claim set.
+    UnknownClaim { section: usize, citation: String },
+    /// A paragraph carries no `[claim:…]` citation.
+    UncitedParagraph { section: usize, paragraph: usize },
+}
+
+impl std::fmt::Display for PageDefect {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PageDefect::NoSections => write!(f, "no sections"),
+            PageDefect::UnknownClaim { section, citation } => {
+                write!(f, "section {section}: cites unknown claim `{citation}`")
+            }
+            PageDefect::UncitedParagraph { section, paragraph } => {
+                write!(
+                    f,
+                    "section {section} paragraph {paragraph}: no [claim:…] citation"
+                )
+            }
+        }
+    }
+}
+
+/// Extract the `claim:<key>` citations from a body, in order of appearance
+/// (with duplicates — the verifier counts per-paragraph presence; callers
+/// wanting a set can collect one). Same `[…]` tokenizer semantics as
+/// `ovp-memory`'s answer verifier, restricted to the `claim:` kind — the two
+/// must not disagree on what counts as a citation.
+pub fn extract_claim_citations(text: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut rest = text;
+    while let Some(start) = rest.find('[') {
+        let after = &rest[start + 1..];
+        let Some(end) = after.find(']') else { break };
+        let candidate = after[..end].trim();
+        if let Some(key) = candidate.strip_prefix("claim:") {
+            let key = key.trim();
+            if !key.is_empty() {
+                out.push(key.to_string());
+            }
+        }
+        rest = &after[end + 1..];
+    }
+    out
+}
+
+/// Verify a synthesized page against the claim set it was given. Deterministic
+/// and total: returns EVERY defect (the command fails loud and reports all of
+/// them, so a rerun's repair pass has the full picture).
+pub fn verify_page(sections: &[PageSection], known_keys: &BTreeSet<String>) -> Vec<PageDefect> {
+    let mut defects = Vec::new();
+    if sections.is_empty() {
+        defects.push(PageDefect::NoSections);
+        return defects;
+    }
+    for (si, section) in sections.iter().enumerate() {
+        for (pi, para) in paragraphs(&section.body).iter().enumerate() {
+            let cited = extract_claim_citations(para);
+            if cited.is_empty() {
+                defects.push(PageDefect::UncitedParagraph {
+                    section: si,
+                    paragraph: pi,
+                });
+            }
+            for key in cited {
+                if !known_keys.contains(&key) {
+                    defects.push(PageDefect::UnknownClaim {
+                        section: si,
+                        citation: key,
+                    });
+                }
+            }
+        }
+    }
+    defects
+}
+
+/// Claim keys the page never cites — reported as coverage, never a defect
+/// (the prompt allows dropping claims that do not fit the narrative).
+pub fn uncited_keys(sections: &[PageSection], known_keys: &BTreeSet<String>) -> Vec<String> {
+    let cited: BTreeSet<String> = sections
+        .iter()
+        .flat_map(|s| extract_claim_citations(&s.body))
+        .collect();
+    known_keys
+        .iter()
+        .filter(|k| !cited.contains(*k))
+        .cloned()
+        .collect()
+}
+
+/// Split a body into paragraphs: blank-line separated runs of non-empty lines.
+fn paragraphs(body: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut current: Vec<&str> = Vec::new();
+    for line in body.lines() {
+        if line.trim().is_empty() {
+            if !current.is_empty() {
+                out.push(current.join("\n"));
+                current.clear();
+            }
+        } else {
+            current.push(line);
+        }
+    }
+    if !current.is_empty() {
+        out.push(current.join("\n"));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn keys(list: &[&str]) -> BTreeSet<String> {
+        list.iter().map(|s| s.to_string()).collect()
+    }
+
+    fn claims_fixture() -> Vec<PageClaim> {
+        vec![
+            PageClaim {
+                claim_key: "ck-aaaa111122223333".into(),
+                claim: "Agent memory persists across sessions.".into(),
+                source_count: 3,
+            },
+            PageClaim {
+                claim_key: "ck-bbbb444455556666".into(),
+                claim: "Retrieval quality beats graph rendering.".into(),
+                source_count: 2,
+            },
+        ]
+    }
+
+    #[test]
+    fn request_carries_keys_and_claims_and_namespace() {
+        let req = theme_page_request("memory · context · agent", &claims_fixture());
+        assert_eq!(req.cache_namespace.as_deref(), Some("theme_page/v1"));
+        assert!(req.system.as_deref().unwrap().contains("theme_page/v1"));
+        let ModelMessage::User { content } = &req.messages[0] else {
+            panic!()
+        };
+        assert!(content.contains("memory · context · agent"));
+        assert!(content.contains("[claim:ck-aaaa111122223333] (3 source(s))"));
+        assert!(content.contains("Retrieval quality beats graph rendering."));
+    }
+
+    #[test]
+    fn request_depends_on_keywords_never_display_labels() {
+        // The caller passes synth_theme (deterministic keywords). A display
+        // relabel changes nothing the request can see — same inputs, same
+        // request key.
+        let a = theme_page_request("memory · context", &claims_fixture());
+        let b = theme_page_request("memory · context", &claims_fixture());
+        assert_eq!(ovp_llm::request_key(&a), ovp_llm::request_key(&b));
+    }
+
+    #[test]
+    fn parse_theme_page_roundtrip_and_defects() {
+        let sections = parse_theme_page(
+            r#"{"sections":[{"heading":"Memory","body":"Persists [claim:ck-a]."}]}"#,
+        )
+        .unwrap();
+        assert_eq!(sections.len(), 1);
+        assert_eq!(sections[0].heading, "Memory");
+        assert!(parse_theme_page(r#"{"nope":1}"#).is_err());
+        assert!(parse_theme_page(r#"{"sections":[{"heading":"","body":"x"}]}"#).is_err());
+        assert!(parse_theme_page(r#"{"sections":[{"heading":"H"}]}"#).is_err());
+    }
+
+    #[test]
+    fn verifier_accepts_a_grounded_page() {
+        let sections = vec![PageSection {
+            heading: "Memory".into(),
+            body: "Agent memory persists [claim:ck-a].\n\n\
+                   Retrieval beats rendering [claim:ck-b], and both matter [claim:ck-a]."
+                .into(),
+        }];
+        assert!(verify_page(&sections, &keys(&["ck-a", "ck-b"])).is_empty());
+    }
+
+    #[test]
+    fn verifier_reports_every_defect() {
+        let sections = vec![PageSection {
+            heading: "H".into(),
+            body: "Uncited paragraph.\n\nCites a ghost [claim:ck-ghost].".into(),
+        }];
+        let defects = verify_page(&sections, &keys(&["ck-a"]));
+        assert_eq!(
+            defects,
+            vec![
+                PageDefect::UncitedParagraph {
+                    section: 0,
+                    paragraph: 0
+                },
+                PageDefect::UnknownClaim {
+                    section: 0,
+                    citation: "ck-ghost".into()
+                },
+            ]
+        );
+        assert_eq!(
+            verify_page(&[], &keys(&["ck-a"])),
+            vec![PageDefect::NoSections]
+        );
+    }
+
+    #[test]
+    fn citation_extraction_matches_the_answer_verifier_tokenizer() {
+        let text = "A [claim:ck-a], b [claim: ck-b ], skip [unit:u-1] and [see note], \
+                    unterminated [claim:ck-x";
+        assert_eq!(extract_claim_citations(text), vec!["ck-a", "ck-b"]);
+    }
+
+    #[test]
+    fn uncited_keys_reports_coverage_not_defects() {
+        let sections = vec![PageSection {
+            heading: "H".into(),
+            body: "Only a [claim:ck-a].".into(),
+        }];
+        assert_eq!(
+            uncited_keys(&sections, &keys(&["ck-a", "ck-b"])),
+            vec!["ck-b"]
+        );
+    }
+
+    #[test]
+    fn pages_file_load_missing_corrupt_and_schema() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("theme_pages.json");
+        assert_eq!(ThemePagesFile::load(&path).unwrap(), None);
+        std::fs::write(&path, "not json").unwrap();
+        assert!(ThemePagesFile::load(&path).is_err());
+        let mut good = ThemePagesFile {
+            schema: THEME_PAGES_SCHEMA.into(),
+            pages: vec![ThemePage {
+                community_id: 0,
+                label: "Agent memory".into(),
+                label_zh: "智能体记忆".into(),
+                claim_keys: vec!["ck-a".into(), "ck-b".into()],
+                sections: vec![PageSection {
+                    heading: "H".into(),
+                    body: "B [claim:ck-a].".into(),
+                }],
+            }],
+        };
+        std::fs::write(&path, serde_json::to_string(&good).unwrap()).unwrap();
+        let loaded = ThemePagesFile::load(&path).unwrap().unwrap();
+        assert_eq!(loaded, good);
+        assert!(loaded.page(0).is_some());
+        assert!(loaded.page(9).is_none());
+        good.schema = "ovp.theme_pages/v999".into();
+        std::fs::write(&path, serde_json::to_string(&good).unwrap()).unwrap();
+        assert!(
+            ThemePagesFile::load(&path).is_err(),
+            "wrong schema fails loud"
+        );
+    }
+}

--- a/crates/ovp-domain/src/crystal/theme_pages.rs
+++ b/crates/ovp-domain/src/crystal/theme_pages.rs
@@ -114,22 +114,35 @@ impl ThemePagesFile {
 
 // ---- Synthesis request (`theme_page/v1`) ----
 
+/// The positional citation handle the MODEL uses for claim `index` (0-based
+/// caller side, 1-based in the prompt): `c1`, `c2`, …. Real `claim_key`s are
+/// 16-hex strings the model cannot reliably copy dozens of times — the first
+/// live run on the real vault degraded into pattern-continued fake keys after
+/// ~4 sections (t003, 35 defects). Small handles are copyable; the code, not
+/// the model, owns the handle → claim_key substitution.
+pub fn claim_handle(index: usize) -> String {
+    format!("c{}", index + 1)
+}
+
 /// Build the page-synthesis `ModelRequest` for one theme. `synth_theme` is
 /// the community's DETERMINISTIC keyword identity
 /// (`ThemeCommunity::synth_theme`) — never the display label, so a
 /// presentation relabel cannot move the cassette key or change a prompt
 /// byte. Claims are pre-sorted by the caller (sorted claim_key order) so the
-/// same claim set always builds the same request.
+/// same claim set always builds the same request; the prompt shows each
+/// claim under its positional handle (`claim_handle`), never the raw key.
 pub fn theme_page_request(synth_theme: &str, claims: &[PageClaim]) -> ModelRequest {
     let marker = "## Topic";
     let (system, _) = THEME_PAGE_TEMPLATE
         .split_once(marker)
         .unwrap_or((THEME_PAGE_TEMPLATE, ""));
     let mut user = format!("{marker}\n\nKeywords: {synth_theme}\n\nClaims:\n");
-    for c in claims {
+    for (i, c) in claims.iter().enumerate() {
         user.push_str(&format!(
             "- [claim:{}] ({} source(s)) {}\n",
-            c.claim_key, c.source_count, c.claim
+            claim_handle(i),
+            c.source_count,
+            c.claim
         ));
     }
     ModelRequest {
@@ -139,6 +152,40 @@ pub fn theme_page_request(synth_theme: &str, claims: &[PageClaim]) -> ModelReque
         max_tokens: PAGE_MAX_TOKENS,
         temperature: None,
         cache_namespace: Some(THEME_PAGE_PROMPT_ID.to_string()),
+    }
+}
+
+/// Replace `[claim:cN]` handles with the real claim keys, in the same sorted
+/// claim order the request was built from. Unknown or out-of-range handles
+/// are left untouched — the verifier then reports them as `UnknownClaim`
+/// (fail loud, never silently drop a citation). Bodies that already carry a
+/// full `[claim:ck-…]` key pass through unchanged.
+pub fn resolve_handles(sections: &mut [PageSection], claim_keys: &[String]) {
+    for section in sections.iter_mut() {
+        let mut out = String::with_capacity(section.body.len());
+        let mut rest = section.body.as_str();
+        while let Some(start) = rest.find("[claim:") {
+            let (head, tail) = rest.split_at(start);
+            out.push_str(head);
+            let Some(end) = tail.find(']') else {
+                out.push_str(tail);
+                rest = "";
+                break;
+            };
+            let inner = tail["[claim:".len()..end].trim();
+            let resolved = inner
+                .strip_prefix('c')
+                .and_then(|n| n.parse::<usize>().ok())
+                .and_then(|n| n.checked_sub(1))
+                .and_then(|i| claim_keys.get(i));
+            match resolved {
+                Some(key) => out.push_str(&format!("[claim:{key}]")),
+                None => out.push_str(&tail[..=end]),
+            }
+            rest = &tail[end + 1..];
+        }
+        out.push_str(rest);
+        section.body = out;
     }
 }
 
@@ -315,7 +362,7 @@ mod tests {
     }
 
     #[test]
-    fn request_carries_keys_and_claims_and_namespace() {
+    fn request_carries_handles_and_claims_and_namespace() {
         let req = theme_page_request("memory · context · agent", &claims_fixture());
         assert_eq!(req.cache_namespace.as_deref(), Some("theme_page/v1"));
         assert!(req.system.as_deref().unwrap().contains("theme_page/v1"));
@@ -323,8 +370,47 @@ mod tests {
             panic!()
         };
         assert!(content.contains("memory · context · agent"));
-        assert!(content.contains("[claim:ck-aaaa111122223333] (3 source(s))"));
+        assert!(content.contains("[claim:c1] (3 source(s))"));
+        assert!(content.contains("[claim:c2] (2 source(s))"));
         assert!(content.contains("Retrieval quality beats graph rendering."));
+        assert!(
+            !content.contains("ck-aaaa111122223333"),
+            "raw keys never reach the model — handles only"
+        );
+    }
+
+    #[test]
+    fn resolve_handles_substitutes_and_leaves_the_unresolvable_loud() {
+        let keys_vec = vec!["ck-aaaa".to_string(), "ck-bbbb".to_string()];
+        let mut sections = vec![PageSection {
+            heading: "H".into(),
+            body: "First [claim:c1] and second [claim: c2 ].\n\n\
+                   Out of range [claim:c9], not a handle [claim:ck-aaaa], \
+                   garbage [claim:cx], unterminated [claim:c1"
+                .into(),
+        }];
+        resolve_handles(&mut sections, &keys_vec);
+        assert_eq!(
+            sections[0].body,
+            "First [claim:ck-aaaa] and second [claim:ck-bbbb].\n\n\
+             Out of range [claim:c9], not a handle [claim:ck-aaaa], \
+             garbage [claim:cx], unterminated [claim:c1"
+        );
+        // The survivors are exactly what the verifier then flags.
+        let defects = verify_page(&sections, &keys(&["ck-aaaa", "ck-bbbb"]));
+        assert_eq!(
+            defects,
+            vec![
+                PageDefect::UnknownClaim {
+                    section: 0,
+                    citation: "c9".into()
+                },
+                PageDefect::UnknownClaim {
+                    section: 0,
+                    citation: "cx".into()
+                },
+            ]
+        );
     }
 
     #[test]

--- a/crates/ovp-domain/src/crystal/themes.rs
+++ b/crates/ovp-domain/src/crystal/themes.rs
@@ -159,12 +159,13 @@ impl ThemesFile {
         self.community(id).map(|c| c.label.as_str())
     }
 
-    /// Majority community among `case_ids`, resolved to its display label
-    /// AFTER the vote. Votes are keyed by community ID — two distinct
-    /// communities that happen to share a display label must not pool
-    /// their votes (codex review P2). Ties → smallest community id.
-    /// `None` when no case maps to a community.
-    pub fn majority_label(&self, case_ids: &[String]) -> Option<String> {
+    /// Majority community ID among `case_ids`. Votes are keyed by community
+    /// ID — two distinct communities that happen to share a display label
+    /// must not pool their votes (codex review P2). Ties → smallest community
+    /// id. `None` when no case maps to a community. This is the STABLE
+    /// grouping identity (theme pages key on it); `majority_label` resolves
+    /// it to presentation only.
+    pub fn majority_community(&self, case_ids: &[String]) -> Option<i64> {
         let mut counts: BTreeMap<i64, usize> = BTreeMap::new();
         for case in case_ids {
             if let Some(&id) = self.packs.get(case)
@@ -176,7 +177,14 @@ impl ThemesFile {
         let (winner, _) = counts
             .into_iter()
             .max_by(|(ia, ca), (ib, cb)| ca.cmp(cb).then(ib.cmp(ia)))?;
-        self.community(winner).map(|c| c.label.clone())
+        self.community(winner).map(|c| c.id)
+    }
+
+    /// Majority community among `case_ids`, resolved to its display label
+    /// AFTER the vote (see `majority_community` for the vote semantics).
+    pub fn majority_label(&self, case_ids: &[String]) -> Option<String> {
+        let id = self.majority_community(case_ids)?;
+        self.community(id).map(|c| c.label.clone())
     }
 }
 

--- a/evolution/candidates/theme_page-v1.json
+++ b/evolution/candidates/theme_page-v1.json
@@ -1,0 +1,24 @@
+{
+  "kind": "ovp.evolution.candidate/v1",
+  "id": "theme_page-v1",
+  "base_version": "none",
+  "target_version": "v1",
+  "surface": "prompt",
+  "component": "prompt.theme_page",
+  "hypothesis": "Given one theme community's ACTIVE durable claims (sorted, addressed by positional c1..cN handles), one LLM call weaves them into a 2-5 section topic page in which EVERY sentence carries a [claim:<key>] citation that survives a deterministic sentence-level gate (unknown keys and uncited sentences fail loud; code, not the model, substitutes handles for real claim_keys). Predicted: >=90% of themes on the real vault pass the gate within two live passes, and the operator judges >=80% of sampled pages coherent-and-faithful vs reading the raw claim list.",
+  "predicted_delta": {
+    "grounded_synthesis_coverage": "cross-source topic narrative with per-sentence provenance, a surface no competitor's wiki mode has",
+    "cost": "<= 1 cached theme_page/v1 call per theme per claim-set change (unchanged themes replay/keep)"
+  },
+  "guardrails": {
+    "gate": "sentence-level citation verifier in ovp-domain::crystal::theme_pages (deterministic, total); pages failing the gate are never written",
+    "cassette_stability": "request depends on synth_theme keywords + sorted claims only, never display labels"
+  },
+  "eval_plan": {
+    "replay_set": "real-vault run 2026-07-20: 15 communities / 465 active durable claims; first pass exposed key-copying degradation (t003, 35 fake keys) which motivated the handle design",
+    "paired_sources": 15,
+    "soak": false
+  },
+  "rollback": "Delete .ovp/crystal/theme_pages.json and stop running crystal-theme-pages (no surface reads it yet in TP1); remove prompt.theme_page from evolution/components.json. The file is a rebuildable projection — no durable state carries page text.",
+  "ablation_required": false
+}

--- a/evolution/candidates/theme_page-v1.json
+++ b/evolution/candidates/theme_page-v1.json
@@ -5,15 +5,12 @@
   "target_version": "v1",
   "surface": "prompt",
   "component": "prompt.theme_page",
-  "hypothesis": "Given one theme community's ACTIVE durable claims (sorted, addressed by positional c1..cN handles), one LLM call weaves them into a 2-5 section topic page in which EVERY sentence carries a [claim:<key>] citation that survives a deterministic sentence-level gate (unknown keys and uncited sentences fail loud; code, not the model, substitutes handles for real claim_keys). Predicted: >=90% of themes on the real vault pass the gate within two live passes, and the operator judges >=80% of sampled pages coherent-and-faithful vs reading the raw claim list.",
+  "hypothesis": "Given one theme community's ACTIVE durable claims (sorted, addressed by positional c1..cN handles), one LLM call (plus at most one bounded repair call) weaves them into a 1-5 section topic page in which EVERY sentence carries a [claim:<key>] citation that survives a deterministic sentence-level gate (unknown keys, uncited sentences, and content-free sections fail loud; code, not the model, substitutes handles for real claim_keys; the request depends on synth_theme keywords + sorted claims only, never display labels, so relabels cannot move cassette keys). Predicted: >=90% of themes on the real vault pass the gate within two live passes, and the operator judges >=80% of sampled pages coherent-and-faithful vs reading the raw claim list.",
   "predicted_delta": {
     "grounded_synthesis_coverage": "cross-source topic narrative with per-sentence provenance, a surface no competitor's wiki mode has",
     "cost": "<= 1 cached theme_page/v1 call per theme per claim-set change (unchanged themes replay/keep)"
   },
-  "guardrails": {
-    "gate": "sentence-level citation verifier in ovp-domain::crystal::theme_pages (deterministic, total); pages failing the gate are never written",
-    "cassette_stability": "request depends on synth_theme keywords + sorted claims only, never display labels"
-  },
+  "guardrails": {},
   "eval_plan": {
     "replay_set": "real-vault run 2026-07-20: 15 communities / 465 active durable claims; first pass exposed key-copying degradation (t003, 35 fake keys) which motivated the handle design",
     "paired_sources": 15,

--- a/evolution/components.json
+++ b/evolution/components.json
@@ -63,6 +63,13 @@
       "quality_buckets": ["card_quality"]
     },
     {
+      "id": "prompt.theme_page",
+      "surface": "prompt",
+      "current_version": "v1",
+      "file": "crates/ovp-domain/prompts/theme_page.md",
+      "quality_buckets": ["crystal_provenance", "coverage"]
+    },
+    {
       "id": "parser.json_repair",
       "surface": "parser",
       "file": "crates/ovp-domain/src/units/parser.rs",


### PR DESCRIPTION
## What

`ovp2 crystal-theme-pages` — weave each theme community's ACTIVE durable claims into a wiki-style topic page, gated by a deterministic sentence-level verifier. Output: `.ovp/crystal/theme_pages.json` (rebuildable projection, never ledger state).

First stage (TP1) of the P0 'grounded topic pages' track from the 2026-07-20 competitive scan: every competitor ships wiki topic pages (WeKnora wiki mode, Nowledge Mem Library Wiki, openwiki, arkon); none can gate them on evidence. Assembling pages from already-gated durable claims keeps every sentence traceable to claim → unit → quote → line.

## Design

- **Projection, not ledger**: grouped by majority theme community (same vote as `ovp-index`), keyed on the sorted claim set; unchanged themes are kept without an LLM call (after revalidation), display relabels can never move a cassette key (`synth_theme` contract).
- **Handles, not keys**: the model cites `c1..cN` positional handles; code substitutes real `claim_key`s. First live run proved models cannot copy 16-hex keys dozens of times (t003 degraded into 34 pattern-continued fake keys).
- **Sentence-level gate, zero merge heuristics**: a terminator followed by whitespace/citation/EOL ends a sentence — 4 codex rounds showed every abbreviation/uppercase escape is a laundering vector. False splits cost one bounded repair call; false merges would break the guarantee.
- **One bounded repair** (M36 repair-workshop shape): failing drafts get their defect list back once — cite or delete, never add. Still failing → theme dropped from the projection (partial write; missing is honest, stale is not) + loud error.
- `theme_page/v1` registered in evolution governance (candidate spec + components.json).

## Verification

- 49 unit tests across ovp-domain/ovp-cli (525 total pass, 0 fail).
- Real vault (`~/Documents/ovp-vault`): **15/15 communities (465 active durable claims) pass the strictest gate**; 9 live iterations documented in `.run/theme-pages-tp1/` including the failure evidence that drove each design change.
- Local codex gate: 4 review rounds, findings 5 → 3 → 2 → 4(P1s all in one heuristic class, resolved by deleting the class); final design has no remaining suppression heuristics to attack.

## Next (separate PRs)

TP2 section-level incremental merge · TP3 server endpoint + ThemeDetailPage wiki view + publish tree

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new CLI subcommand to generate grounded crystal theme pages from ACTIVE durable claims.
  - Builds `theme_pages.json` deterministically by majority community, synthesizing 1–5 section pages with strict per-sentence citations.
  - Supports replay/live clients, optional caching, refresh mode, configurable minimum claim counts, and atomic updates; outputs summaries including per-page uncited counts.

- **Bug Fixes**
  - Missing/corrupt page files are safely rebuilt, active-record absence yields an empty projection, and invalid pages are handled without aborting the overall run (including bounded repair attempts).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->