### PR TITLE
feat(themes,mcp): TP3 product surface + MP1-3 MCP hardening (stacked on #348)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2887,10 +2887,12 @@ dependencies = [
 name = "ovp-mcp"
 version = "2.0.1"
 dependencies = [
+ "ovp-api-projection",
  "ovp-domain",
  "ovp-index",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/console-ui/src/design/portal.css
+++ b/console-ui/src/design/portal.css
@@ -1273,6 +1273,31 @@ body {
 .claim-card .claim-meta a {
   font-weight: 500;
 }
+.topic-overview-caption {
+  margin-bottom: 1rem;
+}
+.topic-overview-section + .topic-overview-section {
+  margin-top: 1.25rem;
+}
+.topic-overview-section p {
+  color: var(--text-soft);
+  line-height: 1.65;
+}
+.topic-overview-section p:last-child {
+  margin-bottom: 0;
+}
+.topic-cite {
+  display: inline-block;
+  margin: 0 0.1em;
+  padding: 0.1rem 0.25rem;
+  border: 1px solid var(--border);
+  border-radius: var(--ovp-radius-pill);
+  background: var(--accent-soft);
+  font-family: var(--ovp-font-mono);
+  font-size: var(--ovp-text-xs);
+  line-height: 1.1;
+  vertical-align: baseline;
+}
 
 /* ---------- search omnibox: page + ⌘K overlay (B3) ---------- */
 .omni-open {

--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -285,6 +285,8 @@ export const en = {
     "Sources that didn't match any keyword bucket — automatic clustering is a planned improvement (M34).",
 
   // theme detail
+  'theme.topicOverview': 'Topic overview',
+  'theme.topicOverviewCaption': 'woven from {n} claims',
   'theme.counts': 'durable {durable} · caveated {caveated}',
   'theme.citedSources': 'Sources:',
   'theme.legacySource': 'Legacy source — no detail page in this vault.',

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -264,6 +264,8 @@ export const zh: Record<keyof typeof en, string> = {
     '未命中任何关键词分组的来源——自动聚类是计划中的改进（M34）。',
 
   // theme detail
+  'theme.topicOverview': '主题综述',
+  'theme.topicOverviewCaption': '由 {n} 条结晶主张编织',
   'theme.counts': '持久 {durable} · 存疑 {caveated}',
   'theme.citedSources': '来源：',
   'theme.legacySource': '旧源——该 vault 中没有对应的详情页。',

--- a/console-ui/src/lib/api.ts
+++ b/console-ui/src/lib/api.ts
@@ -10,6 +10,7 @@ import type {
   SettingsPayload,
   SourceDetail,
   ThemeCount,
+  ThemePagesResponse,
 } from './types';
 
 /** Static-publish mode: the SPA reads snapshotted `<base>/api/*.json` files
@@ -86,6 +87,16 @@ export function fetchClaim(id: string): Promise<ClaimDetail> {
 
 export function fetchFlow(): Promise<FlowData> {
   return fetchJson<FlowData>(STATIC_MODE ? `${API}/flow.json` : '/api/flow');
+}
+
+let themePagesCache: Promise<ThemePagesResponse> | null = null;
+export function fetchThemePages(): Promise<ThemePagesResponse> {
+  if (!themePagesCache) {
+    themePagesCache = fetchJson<ThemePagesResponse>(
+      STATIC_MODE ? `${API}/theme-pages.json` : '/api/theme-pages',
+    );
+  }
+  return themePagesCache;
 }
 
 export function fetchFind(term: string): Promise<FindHit[]> {

--- a/console-ui/src/lib/api.ts
+++ b/console-ui/src/lib/api.ts
@@ -100,6 +100,11 @@ export function fetchThemePages(): Promise<ThemePagesResponse> {
   }
   if (!themePagesCache) {
     themePagesCache = fetchJson<ThemePagesResponse>(`${API}/theme-pages.json`);
+    // A transiently failed fetch must not pin a rejected promise for the
+    // whole session — drop it so the next mount retries.
+    themePagesCache.catch(() => {
+      themePagesCache = null;
+    });
   }
   return themePagesCache;
 }

--- a/console-ui/src/lib/api.ts
+++ b/console-ui/src/lib/api.ts
@@ -91,10 +91,15 @@ export function fetchFlow(): Promise<FlowData> {
 
 let themePagesCache: Promise<ThemePagesResponse> | null = null;
 export function fetchThemePages(): Promise<ThemePagesResponse> {
+  // Cache only the STATIC snapshot (immutable for the session). The live
+  // server's projection changes when `crystal-theme-pages` reruns, and a
+  // transient failure or empty first response must not freeze the panel
+  // until a full reload.
+  if (!STATIC_MODE) {
+    return fetchJson<ThemePagesResponse>('/api/theme-pages');
+  }
   if (!themePagesCache) {
-    themePagesCache = fetchJson<ThemePagesResponse>(
-      STATIC_MODE ? `${API}/theme-pages.json` : '/api/theme-pages',
-    );
+    themePagesCache = fetchJson<ThemePagesResponse>(`${API}/theme-pages.json`);
   }
   return themePagesCache;
 }

--- a/console-ui/src/lib/derive.test.ts
+++ b/console-ui/src/lib/derive.test.ts
@@ -5,6 +5,7 @@ import {
   healthLevel,
   isRunningWithProgress,
   lastRunBanner,
+  parsePageBody,
   runActivity,
   STALE_AFTER_MS,
 } from './derive';
@@ -284,5 +285,48 @@ describe('runActivity (live per-source feed)', () => {
       status: 'running',
     });
     expect(runActivity(m).pct).toBeNull();
+  });
+});
+
+describe('parsePageBody', () => {
+  it('tokenizes a claim marker in the middle of a sentence', () => {
+    expect(parsePageBody('Memory is infrastructure [claim:ck-001] for agents.')).toEqual([
+      [
+        { kind: 'text', text: 'Memory is infrastructure ' },
+        { kind: 'cite', key: 'ck-001' },
+        { kind: 'text', text: ' for agents.' },
+      ],
+    ]);
+  });
+
+  it('tokenizes multiple markers and separates blank-line paragraphs', () => {
+    expect(
+      parsePageBody('First [claim:ck-001] and second [claim:ck-002].\n\nNext paragraph.'),
+    ).toEqual([
+      [
+        { kind: 'text', text: 'First ' },
+        { kind: 'cite', key: 'ck-001' },
+        { kind: 'text', text: ' and second ' },
+        { kind: 'cite', key: 'ck-002' },
+        { kind: 'text', text: '.' },
+      ],
+      [{ kind: 'text', text: 'Next paragraph.' }],
+    ]);
+  });
+
+  it('treats an unterminated claim bracket as text', () => {
+    expect(parsePageBody('Keep [claim:ck-001 as written.')).toEqual([
+      [{ kind: 'text', text: 'Keep [claim:ck-001 as written.' }],
+    ]);
+  });
+
+  it('preserves CJK text around claim markers', () => {
+    expect(parsePageBody('记忆是智能体的基础设施[claim:ck-中文]，而不是附加功能。')).toEqual([
+      [
+        { kind: 'text', text: '记忆是智能体的基础设施' },
+        { kind: 'cite', key: 'ck-中文' },
+        { kind: 'text', text: '，而不是附加功能。' },
+      ],
+    ]);
   });
 });

--- a/console-ui/src/lib/derive.ts
+++ b/console-ui/src/lib/derive.ts
@@ -515,11 +515,13 @@ export function parsePageBody(body: string): PageBodyToken[][] {
       const marker = /\[claim:([^\]]+)\]/g;
       let cursor = 0;
       for (const match of paragraph.matchAll(marker)) {
-        const index = match.index;
+        const index = match.index ?? 0;
         if (index > cursor) {
           tokens.push({ kind: 'text', text: paragraph.slice(cursor, index) });
         }
-        tokens.push({ kind: 'cite', key: match[1] });
+        // Same key semantics as the Rust extractor: `[claim: ck-b ]` is a
+        // valid citation, so the key must be trimmed before lookup.
+        tokens.push({ kind: 'cite', key: match[1].trim() });
         cursor = index + match[0].length;
       }
       if (cursor < paragraph.length) {

--- a/console-ui/src/lib/derive.ts
+++ b/console-ui/src/lib/derive.ts
@@ -499,6 +499,36 @@ export function sourcesByCase(model: IndexModel): Map<string, SourceRow> {
   return out;
 }
 
+export type PageBodyToken =
+  | { kind: 'text'; text: string }
+  | { kind: 'cite'; key: string };
+
+/** Blank-line paragraphs with inline `[claim:<key>]` references tokenized for
+ * the grounded topic-page renderer. Malformed/unterminated markers stay text. */
+export function parsePageBody(body: string): PageBodyToken[][] {
+  if (!body) return [];
+  return body
+    .split(/\r?\n(?:[ \t]*\r?\n)+/)
+    .filter((paragraph) => paragraph.length > 0)
+    .map((paragraph) => {
+      const tokens: PageBodyToken[] = [];
+      const marker = /\[claim:([^\]]+)\]/g;
+      let cursor = 0;
+      for (const match of paragraph.matchAll(marker)) {
+        const index = match.index;
+        if (index > cursor) {
+          tokens.push({ kind: 'text', text: paragraph.slice(cursor, index) });
+        }
+        tokens.push({ kind: 'cite', key: match[1] });
+        cursor = index + match[0].length;
+      }
+      if (cursor < paragraph.length) {
+        tokens.push({ kind: 'text', text: paragraph.slice(cursor) });
+      }
+      return tokens;
+    });
+}
+
 export function countBy<T, K>(items: T[], key: (item: T) => K): Map<K, number> {
   const counts = new Map<K, number>();
   for (const item of items) {

--- a/console-ui/src/lib/types.ts
+++ b/console-ui/src/lib/types.ts
@@ -79,6 +79,31 @@ export interface FlowData {
   flows: FlowLink[];
 }
 
+export interface ThemePageSection {
+  heading: string;
+  body: string;
+}
+
+export interface ThemePageData {
+  community_id: number;
+  label: string;
+  label_zh: string;
+  claim_count: number;
+  sections: ThemePageSection[];
+}
+
+export interface ThemePageClaimInfo {
+  claim_id: string;
+  claim: string;
+  strength?: string;
+  sources: string[];
+}
+
+export interface ThemePagesResponse {
+  pages: ThemePageData[];
+  claims: Record<string, ThemePageClaimInfo>;
+}
+
 /** /api/find and /api/search hit — a display line plus a kind-specific
  * stable id for entity links (source → sha256, pack → pack_dir,
  * claim → claim_id, run → run_id). */

--- a/console-ui/src/pages/ThemeDetailPage.tsx
+++ b/console-ui/src/pages/ThemeDetailPage.tsx
@@ -67,7 +67,18 @@ function TopicOverview({ theme }: { theme: string }) {
         }
       }
     }
-    return { sections, citationNumberByKey };
+    // claim_ids can collide across runs while claim_keys stay unique. The
+    // card anchors below are keyed by claim_id, so a chip pointing at a
+    // duplicated id could scroll to the wrong card — such chips render as
+    // plain (tooltip-only) markers instead of links.
+    const idCounts = new Map<string, number>();
+    for (const info of Object.values(themePages.claims)) {
+      idCounts.set(info.claim_id, (idCounts.get(info.claim_id) ?? 0) + 1);
+    }
+    const ambiguousIds = new Set(
+      [...idCounts.entries()].filter(([, n]) => n > 1).map(([id]) => id),
+    );
+    return { sections, citationNumberByKey, ambiguousIds };
   }, [page, themePages]);
 
   if (!page || !themePages || !overview) return null;
@@ -91,6 +102,17 @@ function TopicOverview({ theme }: { theme: string }) {
                 const claim = themePages.claims[token.key];
                 const number = overview.citationNumberByKey.get(token.key);
                 if (!claim || number == null) return null;
+                if (overview.ambiguousIds.has(claim.claim_id)) {
+                  return (
+                    <span
+                      className="topic-cite"
+                      key={`${token.key}-${tokenIndex}`}
+                      title={claim.claim}
+                    >
+                      [{number}]
+                    </span>
+                  );
+                }
                 return (
                   <Link
                     className="topic-cite"

--- a/console-ui/src/pages/ThemeDetailPage.tsx
+++ b/console-ui/src/pages/ThemeDetailPage.tsx
@@ -98,7 +98,9 @@ function TopicOverview({ theme }: { theme: string }) {
           {section.paragraphs.map((paragraph, paragraphIndex) => (
             <p key={paragraphIndex}>
               {paragraph.map((token, tokenIndex) => {
-                if (token.kind === 'text') return token.text;
+                if (token.kind === 'text') {
+                  return <span key={tokenIndex}>{token.text}</span>;
+                }
                 const claim = themePages.claims[token.key];
                 const number = overview.citationNumberByKey.get(token.key);
                 if (!claim || number == null) return null;

--- a/console-ui/src/pages/ThemeDetailPage.tsx
+++ b/console-ui/src/pages/ThemeDetailPage.tsx
@@ -11,9 +11,104 @@ import { Link, useLocation, useParams } from 'react-router-dom';
 import KnowledgeGraph from '../components/KnowledgeGraph';
 import { ClaimPill, EmptyState, ModelGate } from '../components/ui';
 import { useI18n } from '../i18n';
-import { isMiscTheme, sourcesByCase, themeClaims, themeFromRoute } from '../lib/derive';
-import type { ClaimRow, IndexModel, SourceRow } from '../lib/types';
+import { fetchThemePages } from '../lib/api';
+import {
+  isMiscTheme,
+  parsePageBody,
+  sourcesByCase,
+  themeClaims,
+  themeFromRoute,
+} from '../lib/derive';
+import type {
+  ClaimRow,
+  IndexModel,
+  SourceRow,
+  ThemePagesResponse,
+} from '../lib/types';
 import { useModel } from '../model';
+
+function TopicOverview({ theme }: { theme: string }) {
+  const { t } = useI18n();
+  const [themePages, setThemePages] = useState<ThemePagesResponse | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchThemePages().then(
+      (response) => {
+        if (!cancelled) setThemePages(response);
+      },
+      () => {
+        // Optional enhancement: fetch failures leave the original page intact.
+      },
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const page = themePages?.pages.find((candidate) => candidate.label === theme);
+  const overview = useMemo(() => {
+    if (!page || !themePages) return null;
+    const sections = page.sections.map((section) => ({
+      ...section,
+      paragraphs: parsePageBody(section.body),
+    }));
+    const citationNumberByKey = new Map<string, number>();
+    for (const section of sections) {
+      for (const paragraph of section.paragraphs) {
+        for (const token of paragraph) {
+          if (
+            token.kind === 'cite' &&
+            themePages.claims[token.key] &&
+            !citationNumberByKey.has(token.key)
+          ) {
+            citationNumberByKey.set(token.key, citationNumberByKey.size + 1);
+          }
+        }
+      }
+    }
+    return { sections, citationNumberByKey };
+  }, [page, themePages]);
+
+  if (!page || !themePages || !overview) return null;
+
+  return (
+    <div className="card topic-overview">
+      <h2>{t('theme.topicOverview')}</h2>
+      <div className="claim-meta topic-overview-caption">
+        {t('theme.topicOverviewCaption', { n: page.claim_count })}
+      </div>
+      {overview.sections.map((section, sectionIndex) => (
+        <section
+          className="topic-overview-section"
+          key={`${section.heading}-${sectionIndex}`}
+        >
+          <h3>{section.heading}</h3>
+          {section.paragraphs.map((paragraph, paragraphIndex) => (
+            <p key={paragraphIndex}>
+              {paragraph.map((token, tokenIndex) => {
+                if (token.kind === 'text') return token.text;
+                const claim = themePages.claims[token.key];
+                const number = overview.citationNumberByKey.get(token.key);
+                if (!claim || number == null) return null;
+                return (
+                  <Link
+                    className="topic-cite"
+                    key={`${token.key}-${tokenIndex}`}
+                    title={claim.claim}
+                    to={{ hash: `#${encodeURIComponent(claim.claim_id)}` }}
+                  >
+                    [{number}]
+                  </Link>
+                );
+              })}
+            </p>
+          ))}
+        </section>
+      ))}
+    </div>
+  );
+}
 
 function ClaimSources({
   claim,
@@ -192,6 +287,7 @@ export default function ThemeDetailPage() {
               {t('theme.unclassifiedNote')}
             </p>
           )}
+          <TopicOverview theme={theme} />
           <ThemeBody model={model} theme={theme} />
         </>
       )}

--- a/crates/ovp-api-projection/src/bodies.rs
+++ b/crates/ovp-api-projection/src/bodies.rs
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use ovp_domain::crystal::DurableRecord;
+use ovp_domain::crystal::theme_pages::ThemePagesFile;
 use ovp_domain::units::Unit;
 use ovp_index::{ClaimRow, ClaimStatus, EvidenceModel, IndexModel, PackRow, Query, SourceRow};
 use serde_json::{Value, json};
@@ -22,6 +23,50 @@ pub fn themes_body(records: &[DurableRecord]) -> Value {
         .map(|(theme, count)| json!({ "theme": theme, "count": count }))
         .collect();
     Value::Array(themes)
+}
+
+/// `/api/theme-pages` — the grounded topic pages plus a claim lookup for
+/// citation rendering (`[claim:<key>]` markers in section bodies resolve
+/// through `claims`). A page citing ANY claim key absent from `records` is
+/// dropped whole: the publisher feeds SCRUBBED public records, so a page
+/// touching a non-public claim never ships (a partial page would carry
+/// dangling citations); the live server feeds every active record, so
+/// nothing drops there.
+pub fn theme_pages_body(file: Option<&ThemePagesFile>, records: &[DurableRecord]) -> Value {
+    let by_key: HashMap<&str, &DurableRecord> =
+        records.iter().map(|r| (r.claim_key.as_str(), r)).collect();
+    let mut pages: Vec<Value> = Vec::new();
+    let mut claims = serde_json::Map::new();
+    for page in file.map(|f| f.pages.as_slice()).unwrap_or_default() {
+        let resolved: Option<Vec<&DurableRecord>> = page
+            .claim_keys
+            .iter()
+            .map(|k| by_key.get(k.as_str()).copied())
+            .collect();
+        let Some(resolved) = resolved else { continue };
+        for r in resolved {
+            claims.entry(r.claim_key.clone()).or_insert_with(|| {
+                json!({
+                    "claim_id": r.claim_id,
+                    "claim": r.claim,
+                    "strength": r.strength,
+                    "sources": r.source_cases,
+                })
+            });
+        }
+        pages.push(json!({
+            "community_id": page.community_id,
+            "label": page.label,
+            "label_zh": page.label_zh,
+            "claim_count": page.claim_keys.len(),
+            "sections": page
+                .sections
+                .iter()
+                .map(|s| json!({ "heading": s.heading, "body": s.body }))
+                .collect::<Vec<Value>>(),
+        }));
+    }
+    json!({ "pages": pages, "claims": claims })
 }
 
 /// `/api/flow` — the intake→reader→units→cards→crystal Sankey totals.

--- a/crates/ovp-cli/src/commands/mcp_guidance.rs
+++ b/crates/ovp-cli/src/commands/mcp_guidance.rs
@@ -1,0 +1,136 @@
+//! `mcp-guidance` — write the "when to consult the OVP vault" section into
+//! the vault's agent instruction files (CLAUDE.md + AGENTS.md), so agents
+//! actually reach for the MCP tools instead of grepping markdown (the
+//! openwiki pattern: the wiki is only consulted if the instruction files say
+//! so).
+//!
+//! Idempotent: the section lives between marker comments and is replaced in
+//! place on every run; content OUTSIDE the markers is never touched. A
+//! missing file is created with just the section.
+
+use std::path::{Path, PathBuf};
+
+use crate::CliError;
+
+pub struct McpGuidanceArgs {
+    pub vault_root: PathBuf,
+}
+
+const START: &str = "<!-- ovp-mcp:guidance:start -->";
+const END: &str = "<!-- ovp-mcp:guidance:end -->";
+
+/// The section body (between the markers). Kept as one literal so the whole
+/// contract is reviewable in one place.
+fn guidance_body() -> String {
+    "## OVP knowledge vault (MCP)\n\
+     \n\
+     This vault is indexed by OVP. Consult it BEFORE answering from memory\n\
+     when a question touches captured sources, synthesized knowledge, or\n\
+     what the operator has read. Launch: `ovp2 mcp --vault-root <this vault>`.\n\
+     \n\
+     - `search` / `find` — locate sources, reader packs, and durable claims\n\
+       (filter by kind/status/date/tag/entity).\n\
+     - `theme_page` — grounded topic overviews woven from durable claims;\n\
+       every sentence carries a `[claim:<key>]` citation. Call with no\n\
+       arguments to list topics.\n\
+     - `claim` — audit any `[claim:<key>]` citation: full evidence closure\n\
+       (claim → verbatim quote → line → source).\n\
+     - `status` / `doctor` — pipeline freshness and health.\n\
+     \n\
+     Stable references — safe to store in notes and answers:\n\
+     - `ovp://claim/<claim_key>` (claim_keys are deterministic and survive\n\
+       re-runs)\n\
+     - `ovp://source/<sha256>`\n\
+     \n\
+     Prefer citing claims over paraphrasing sources: a cited claim already\n\
+     passed the evidence gate; a paraphrase did not.\n"
+        .to_string()
+}
+
+/// Replace the marked section in `content`, or append it. Returns the new
+/// file content.
+fn splice(content: &str, body: &str) -> String {
+    let section = format!("{START}\n{body}{END}\n");
+    match (content.find(START), content.find(END)) {
+        (Some(s), Some(e)) if e >= s => {
+            let after = &content[e + END.len()..];
+            let after = after.strip_prefix('\n').unwrap_or(after);
+            format!("{}{section}{after}", &content[..s])
+        }
+        _ => {
+            // Append (or start) — keep exactly one blank line before the
+            // section when the file already has content.
+            if content.trim().is_empty() {
+                section
+            } else {
+                format!("{}\n\n{section}", content.trim_end())
+            }
+        }
+    }
+}
+
+fn update_file(path: &Path, body: &str) -> Result<bool, CliError> {
+    let old = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(e) => return Err(CliError::Io(format!("reading {}: {e}", path.display()))),
+    };
+    let new = splice(&old, body);
+    if new == old {
+        return Ok(false);
+    }
+    std::fs::write(path, &new)
+        .map_err(|e| CliError::Io(format!("writing {}: {e}", path.display())))?;
+    Ok(true)
+}
+
+pub fn run(args: McpGuidanceArgs) -> Result<(), CliError> {
+    let body = guidance_body();
+    for name in ["CLAUDE.md", "AGENTS.md"] {
+        let path = args.vault_root.join(name);
+        let changed = update_file(&path, &body)?;
+        println!(
+            "mcp-guidance: {} {}",
+            path.display(),
+            if changed { "updated" } else { "up to date" }
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn creates_updates_idempotently_and_preserves_surroundings() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_path_buf();
+
+        // Existing CLAUDE.md with operator content survives around the section.
+        std::fs::write(root.join("CLAUDE.md"), "# My vault rules\n\nkeep me\n").unwrap();
+        run(McpGuidanceArgs { vault_root: root.clone() }).unwrap();
+        let claude = std::fs::read_to_string(root.join("CLAUDE.md")).unwrap();
+        assert!(claude.starts_with("# My vault rules"), "{claude}");
+        assert!(claude.contains("keep me"));
+        assert!(claude.contains(START) && claude.contains(END));
+        assert!(claude.contains("ovp://claim/<claim_key>"));
+
+        // Missing AGENTS.md was created with just the section.
+        let agents = std::fs::read_to_string(root.join("AGENTS.md")).unwrap();
+        assert!(agents.starts_with(START), "{agents}");
+
+        // Re-run: no change (idempotent).
+        run(McpGuidanceArgs { vault_root: root.clone() }).unwrap();
+        assert_eq!(std::fs::read_to_string(root.join("CLAUDE.md")).unwrap(), claude);
+
+        // Content added AFTER the section survives an update; a stale body
+        // between the markers is replaced.
+        let edited = claude.replace("Prefer citing claims", "STALE TEXT") + "\n## Appended later\n";
+        std::fs::write(root.join("CLAUDE.md"), &edited).unwrap();
+        run(McpGuidanceArgs { vault_root: root.clone() }).unwrap();
+        let fresh = std::fs::read_to_string(root.join("CLAUDE.md")).unwrap();
+        assert!(!fresh.contains("STALE TEXT"));
+        assert!(fresh.contains("## Appended later"));
+    }
+}

--- a/crates/ovp-cli/src/commands/mcp_guidance.rs
+++ b/crates/ovp-cli/src/commands/mcp_guidance.rs
@@ -48,24 +48,36 @@ fn guidance_body() -> String {
 }
 
 /// Replace the marked section in `content`, or append it. Returns the new
-/// file content.
-fn splice(content: &str, body: &str) -> String {
+/// file content, or an error when the markers are unmatched/mis-ordered —
+/// appending a second block there would make the NEXT run pair the stray
+/// marker with the new one and delete the operator's content in between
+/// (codex review P2). Fail loud; the operator repairs the markers by hand.
+fn splice(content: &str, body: &str) -> Result<String, String> {
     let section = format!("{START}\n{body}{END}\n");
-    match (content.find(START), content.find(END)) {
-        (Some(s), Some(e)) if e >= s => {
+    let starts = content.matches(START).count();
+    let ends = content.matches(END).count();
+    match (starts, ends) {
+        (0, 0) => Ok(if content.trim().is_empty() {
+            section
+        } else {
+            // Keep exactly one blank line before the appended section.
+            format!("{}\n\n{section}", content.trim_end())
+        }),
+        (1, 1) => {
+            let s = content.find(START).expect("counted above");
+            let e = content.find(END).expect("counted above");
+            if e < s {
+                return Err(format!(
+                    "guidance markers are out of order ({END} before {START}) — fix the file manually"
+                ));
+            }
             let after = &content[e + END.len()..];
             let after = after.strip_prefix('\n').unwrap_or(after);
-            format!("{}{section}{after}", &content[..s])
+            Ok(format!("{}{section}{after}", &content[..s]))
         }
-        _ => {
-            // Append (or start) — keep exactly one blank line before the
-            // section when the file already has content.
-            if content.trim().is_empty() {
-                section
-            } else {
-                format!("{}\n\n{section}", content.trim_end())
-            }
-        }
+        _ => Err(format!(
+            "unmatched guidance markers ({starts}× start, {ends}× end) — fix the file manually"
+        )),
     }
 }
 
@@ -75,7 +87,8 @@ fn update_file(path: &Path, body: &str) -> Result<bool, CliError> {
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
         Err(e) => return Err(CliError::Io(format!("reading {}: {e}", path.display()))),
     };
-    let new = splice(&old, body);
+    let new = splice(&old, body)
+        .map_err(|e| CliError::Io(format!("mcp-guidance: {}: {e}", path.display())))?;
     if new == old {
         return Ok(false);
     }
@@ -109,7 +122,10 @@ mod tests {
 
         // Existing CLAUDE.md with operator content survives around the section.
         std::fs::write(root.join("CLAUDE.md"), "# My vault rules\n\nkeep me\n").unwrap();
-        run(McpGuidanceArgs { vault_root: root.clone() }).unwrap();
+        run(McpGuidanceArgs {
+            vault_root: root.clone(),
+        })
+        .unwrap();
         let claude = std::fs::read_to_string(root.join("CLAUDE.md")).unwrap();
         assert!(claude.starts_with("# My vault rules"), "{claude}");
         assert!(claude.contains("keep me"));
@@ -121,16 +137,43 @@ mod tests {
         assert!(agents.starts_with(START), "{agents}");
 
         // Re-run: no change (idempotent).
-        run(McpGuidanceArgs { vault_root: root.clone() }).unwrap();
-        assert_eq!(std::fs::read_to_string(root.join("CLAUDE.md")).unwrap(), claude);
+        run(McpGuidanceArgs {
+            vault_root: root.clone(),
+        })
+        .unwrap();
+        assert_eq!(
+            std::fs::read_to_string(root.join("CLAUDE.md")).unwrap(),
+            claude
+        );
 
         // Content added AFTER the section survives an update; a stale body
         // between the markers is replaced.
         let edited = claude.replace("Prefer citing claims", "STALE TEXT") + "\n## Appended later\n";
         std::fs::write(root.join("CLAUDE.md"), &edited).unwrap();
-        run(McpGuidanceArgs { vault_root: root.clone() }).unwrap();
+        run(McpGuidanceArgs {
+            vault_root: root.clone(),
+        })
+        .unwrap();
         let fresh = std::fs::read_to_string(root.join("CLAUDE.md")).unwrap();
         assert!(!fresh.contains("STALE TEXT"));
         assert!(fresh.contains("## Appended later"));
+    }
+
+    #[test]
+    fn unmatched_or_misordered_markers_fail_instead_of_eating_content() {
+        // A lone START must NOT trigger the append path: the next run would
+        // pair the stray START with the appended END and delete everything
+        // between them.
+        let lone_start = format!("# rules\n\n{START}\nuser content here\n");
+        let err = splice(&lone_start, "body\n").unwrap_err();
+        assert!(err.contains("unmatched"), "{err}");
+
+        let misordered = format!("{END}\nmiddle\n{START}\n");
+        let err = splice(&misordered, "body\n").unwrap_err();
+        assert!(err.contains("out of order"), "{err}");
+
+        let doubled = format!("{START}\na\n{END}\n{START}\nb\n{END}\n");
+        let err = splice(&doubled, "body\n").unwrap_err();
+        assert!(err.contains("unmatched") || err.contains("2"), "{err}");
     }
 }

--- a/crates/ovp-cli/src/commands/mod.rs
+++ b/crates/ovp-cli/src/commands/mod.rs
@@ -36,6 +36,7 @@ pub mod rag;
 pub mod read_source;
 pub mod review_run;
 pub mod mcp;
+pub mod mcp_guidance;
 pub mod run;
 pub mod run_cycle;
 pub mod schedule;

--- a/crates/ovp-cli/src/main.rs
+++ b/crates/ovp-cli/src/main.rs
@@ -443,10 +443,19 @@ enum Cmd {
         since_hours: Option<u64>,
     },
     /// PRODUCT — start the OVP MCP server (stdio JSON-RPC, synchronous).
-    /// Exposes OVP tools (find/search/status/doctor) and resources
-    /// (ovp://index, ovp://working-memory) to any MCP-compatible client.
+    /// Exposes OVP tools (find/search/claim/theme_page/status/doctor) and
+    /// resources (ovp://index, ovp://working-memory, ovp://claim/<key>,
+    /// ovp://source/<sha>) to any MCP-compatible client.
     /// Level 3+ integration surface — not a daily pipeline blocker.
     Mcp {
+        #[arg(long)]
+        vault_root: PathBuf,
+    },
+    /// PRODUCT — write the "when to consult the OVP vault" section into the
+    /// vault's CLAUDE.md and AGENTS.md (idempotent, marker-delimited; content
+    /// outside the markers is never touched), so MCP-capable agents actually
+    /// reach for the vault's tools.
+    McpGuidance {
         #[arg(long)]
         vault_root: PathBuf,
     },
@@ -1565,6 +1574,9 @@ fn main() -> ExitCode {
             since_hours,
         }),
         Cmd::Mcp { vault_root } => commands::mcp::run(commands::mcp::McpArgs { vault_root }),
+        Cmd::McpGuidance { vault_root } => {
+            commands::mcp_guidance::run(commands::mcp_guidance::McpGuidanceArgs { vault_root })
+        }
         Cmd::Serve {
             vault_root,
             port,

--- a/crates/ovp-mcp/Cargo.toml
+++ b/crates/ovp-mcp/Cargo.toml
@@ -9,5 +9,9 @@ authors.workspace = true
 [dependencies]
 ovp-index = { path = "../ovp-index" }
 ovp-domain = { path = "../ovp-domain" }
+ovp-api-projection = { path = "../ovp-api-projection" }
 serde.workspace = true
 serde_json.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/ovp-mcp/src/lib.rs
+++ b/crates/ovp-mcp/src/lib.rs
@@ -225,6 +225,7 @@ fn dispatch(state: &McpState, method: &str, params: &Value) -> Result<Value, Rpc
         "tools/list" => handle_tools_list(),
         "tools/call" => handle_tools_call(state, params),
         "resources/list" => handle_resources_list(),
+        "resources/templates/list" => handle_resources_templates_list(),
         "resources/read" => handle_resources_read(state, params),
         "notifications/initialized" | "notifications/cancelled" => Ok(Value::Null),
         _ => Err(RpcError {
@@ -350,35 +351,17 @@ fn tool_claim(state: &McpState, args: &Value) -> Result<Value, RpcError> {
     Ok(serde_json::json!({ "content": [{ "type": "text", "text": text }] }))
 }
 
-fn tool_theme_page(state: &McpState, args: &Value) -> Result<Value, RpcError> {
+/// One theme page + ONLY its claims from the lookup, so the closure travels
+/// with the narrative. `theme` accepts a label (exact), `t003`, `3`, or an
+/// `ovp://theme-page/<id>` URI — the payload behind both the `theme_page`
+/// tool and the `ovp://theme-page/<id>` resource.
+fn theme_page_payload(state: &McpState, theme: &str) -> Result<Value, RpcError> {
     let pages = state.load_theme_pages();
     let records = state.load_records();
     let body = bodies::theme_pages_body(pages.as_ref(), &records);
     let all = body["pages"].as_array().cloned().unwrap_or_default();
 
-    let theme = args
-        .get("theme")
-        .and_then(|v| v.as_str())
-        .map(str::trim)
-        .filter(|s| !s.is_empty());
-    let Some(theme) = theme else {
-        // No theme → the directory of available pages.
-        let listing: Vec<Value> = all
-            .iter()
-            .map(|p| {
-                serde_json::json!({
-                    "community_id": p["community_id"],
-                    "label": p["label"],
-                    "label_zh": p["label_zh"],
-                    "claim_count": p["claim_count"],
-                    "uri": format!("ovp://theme-page/{}", p["community_id"]),
-                })
-            })
-            .collect();
-        let text = serde_json::to_string_pretty(&listing).unwrap_or_else(|_| "[]".into());
-        return Ok(serde_json::json!({ "content": [{ "type": "text", "text": text }] }));
-    };
-
+    let theme = theme.strip_prefix("ovp://theme-page/").unwrap_or(theme);
     // `t003` / `3` → community id; anything else matches the label exactly.
     let by_id = theme.strip_prefix('t').unwrap_or(theme).parse::<i64>().ok();
     let page = all.iter().find(|p| {
@@ -393,8 +376,6 @@ fn tool_theme_page(state: &McpState, args: &Value) -> Result<Value, RpcError> {
             ),
         });
     };
-    // Ship the page plus ONLY its claims from the lookup, so the closure
-    // travels with the narrative.
     let keys: std::collections::BTreeSet<String> = page["sections"]
         .as_array()
         .into_iter()
@@ -409,7 +390,38 @@ fn tool_theme_page(state: &McpState, args: &Value) -> Result<Value, RpcError> {
         .into_iter()
         .filter(|(k, _)| keys.contains(k))
         .collect();
-    let out = serde_json::json!({ "page": page, "claims": claims });
+    Ok(serde_json::json!({ "page": page, "claims": claims }))
+}
+
+fn tool_theme_page(state: &McpState, args: &Value) -> Result<Value, RpcError> {
+    let theme = args
+        .get("theme")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    let Some(theme) = theme else {
+        // No theme → the directory of available pages.
+        let pages = state.load_theme_pages();
+        let records = state.load_records();
+        let body = bodies::theme_pages_body(pages.as_ref(), &records);
+        let listing: Vec<Value> = body["pages"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .map(|p| {
+                serde_json::json!({
+                    "community_id": p["community_id"],
+                    "label": p["label"],
+                    "label_zh": p["label_zh"],
+                    "claim_count": p["claim_count"],
+                    "uri": format!("ovp://theme-page/{}", p["community_id"]),
+                })
+            })
+            .collect();
+        let text = serde_json::to_string_pretty(&listing).unwrap_or_else(|_| "[]".into());
+        return Ok(serde_json::json!({ "content": [{ "type": "text", "text": text }] }));
+    };
+    let out = theme_page_payload(state, theme)?;
     let text = serde_json::to_string_pretty(&out).unwrap_or_else(|_| "{}".into());
     Ok(serde_json::json!({ "content": [{ "type": "text", "text": text }] }))
 }
@@ -556,16 +568,32 @@ fn handle_resources_list() -> Result<Value, RpcError> {
                 "description": "Today's working memory context package",
                 "mimeType": "text/markdown"
             },
+        ]
+    }))
+}
+
+/// Dynamic (parameterized) resources are advertised as RFC 6570 URI
+/// templates, not fake concrete entries — a client must never receive a
+/// listed URI that `resources/read` cannot dereference.
+fn handle_resources_templates_list() -> Result<Value, RpcError> {
+    Ok(serde_json::json!({
+        "resourceTemplates": [
             {
-                "uri": "ovp://claim/<claim_key>",
+                "uriTemplate": "ovp://claim/{claim_key}",
                 "name": "Durable claim (stable reference)",
                 "description": "One durable claim's full evidence closure — same payload as the `claim` tool. claim_keys (ck-…) are deterministic and survive re-runs, so these URIs are safe to store in notes and answers.",
                 "mimeType": "application/json"
             },
             {
-                "uri": "ovp://source/<sha256>",
+                "uriTemplate": "ovp://source/{sha256}",
                 "name": "Source document (stable reference)",
                 "description": "One captured source's metadata and markdown body, addressed by content sha256.",
+                "mimeType": "application/json"
+            },
+            {
+                "uriTemplate": "ovp://theme-page/{community_id}",
+                "name": "Grounded topic page",
+                "description": "One theme's topic page with its claims lookup — same payload as the `theme_page` tool. The `theme_page` tool called without arguments lists these URIs.",
                 "mimeType": "application/json"
             }
         ]
@@ -600,6 +628,13 @@ fn handle_resources_read(state: &McpState, params: &Value) -> Result<Value, RpcE
             let model = state.load_model();
             let json = serde_json::to_string(&claim_closure(record, model.as_ref()))
                 .unwrap_or_else(|_| "{}".into());
+            Ok(serde_json::json!({
+                "contents": [{ "uri": uri, "mimeType": "application/json", "text": json }]
+            }))
+        }
+        _ if uri.starts_with("ovp://theme-page/") => {
+            let payload = theme_page_payload(state, uri)?;
+            let json = serde_json::to_string(&payload).unwrap_or_else(|_| "{}".into());
             Ok(serde_json::json!({
                 "contents": [{ "uri": uri, "mimeType": "application/json", "text": json }]
             }))
@@ -777,6 +812,45 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.message.contains("No topic page"), "{}", err.message);
+    }
+
+    #[test]
+    fn theme_page_uris_from_the_listing_are_dereferenceable() {
+        // codex P2: every URI a tool emits must resolve via resources/read.
+        let (_tmp, state) = fixture_vault();
+        let v = call(&state, "theme_page", serde_json::json!({})).unwrap();
+        let listing: Value = serde_json::from_str(&text_of(&v)).unwrap();
+        let uri = listing[0]["uri"].as_str().unwrap().to_string();
+        assert_eq!(uri, "ovp://theme-page/0");
+        let read = dispatch(&state, "resources/read", &serde_json::json!({ "uri": uri })).unwrap();
+        let payload: Value =
+            serde_json::from_str(read["contents"][0]["text"].as_str().unwrap()).unwrap();
+        assert_eq!(payload["page"]["label"], "Agent memory");
+    }
+
+    #[test]
+    fn dynamic_uris_are_advertised_as_templates_not_fake_resources() {
+        let (_tmp, state) = fixture_vault();
+        let listed = dispatch(&state, "resources/list", &Value::Null).unwrap();
+        for r in listed["resources"].as_array().unwrap() {
+            let uri = r["uri"].as_str().unwrap();
+            assert!(
+                !uri.contains('<') && !uri.contains('{'),
+                "concrete resource list must not carry placeholders: {uri}"
+            );
+        }
+        let templates = dispatch(&state, "resources/templates/list", &Value::Null).unwrap();
+        let uris: Vec<&str> = templates["resourceTemplates"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|t| t["uriTemplate"].as_str().unwrap())
+            .collect();
+        assert!(uris.contains(&"ovp://claim/{claim_key}"), "{uris:?}");
+        assert!(
+            uris.contains(&"ovp://theme-page/{community_id}"),
+            "{uris:?}"
+        );
     }
 
     #[test]

--- a/crates/ovp-mcp/src/lib.rs
+++ b/crates/ovp-mcp/src/lib.rs
@@ -5,9 +5,12 @@
 use std::io::{self, BufRead, Write};
 use std::path::PathBuf;
 
+use ovp_api_projection::{bodies, readers};
 use ovp_domain::VaultLayout;
+use ovp_domain::crystal::DurableRecord;
+use ovp_domain::crystal::theme_pages::ThemePagesFile;
 use ovp_domain::tags::TagAliases;
-use ovp_index::{read_index, run_query, IndexModel, Query, QueryKind};
+use ovp_index::{IndexModel, Query, QueryKind, read_index, run_query};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -34,7 +37,7 @@ struct RpcResponse {
     error: Option<RpcError>,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 struct RpcError {
     code: i32,
     message: String,
@@ -42,19 +45,104 @@ struct RpcError {
 
 struct McpState {
     vault_root: PathBuf,
-    _layout: VaultLayout,
+    layout: VaultLayout,
 }
 
 impl McpState {
     fn load_model(&self) -> Option<IndexModel> {
         read_index(&self.vault_root).ok()
     }
+
+    /// ACTIVE durable records with display themes applied — the same fold the
+    /// live server uses (`readers::load_active_records`); corrupt state
+    /// degrades to empty (read tools answer, `ovp2 index` fails loud).
+    fn load_records(&self) -> Vec<DurableRecord> {
+        readers::load_active_records(&self.vault_root, &self.layout)
+    }
+
+    fn load_theme_pages(&self) -> Option<ThemePagesFile> {
+        let path = self
+            .vault_root
+            .join(self.layout.crystal_store_dir())
+            .join("theme_pages.json");
+        ThemePagesFile::load(&path).ok().flatten()
+    }
+}
+
+/// Resolve `key` (a `claim_key`, `claim_id`, or `ovp://claim/<key>` URI)
+/// against the active records. claim_key wins; claim_id is a convenience
+/// alias resolved only when unambiguous.
+fn find_record<'a>(records: &'a [DurableRecord], key: &str) -> Result<&'a DurableRecord, RpcError> {
+    let key = key.strip_prefix("ovp://claim/").unwrap_or(key);
+    if let Some(r) = records.iter().find(|r| r.claim_key == key) {
+        return Ok(r);
+    }
+    let by_id: Vec<&DurableRecord> = records.iter().filter(|r| r.claim_id == key).collect();
+    match by_id.as_slice() {
+        [one] => Ok(one),
+        [] => Err(RpcError {
+            code: -32602,
+            message: format!("No active claim with key or id `{key}`"),
+        }),
+        many => Err(RpcError {
+            code: -32602,
+            message: format!(
+                "claim_id `{key}` is ambiguous ({} records) — use the claim_key: {}",
+                many.len(),
+                many.iter()
+                    .map(|r| r.claim_key.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+        }),
+    }
+}
+
+/// The full evidence closure for one claim: text + gate verdicts + every
+/// citation resolved to its source row (title/sha) when the index knows it.
+/// This is the payload behind both the `claim` tool and `ovp://claim/<key>`.
+fn claim_closure(record: &DurableRecord, model: Option<&IndexModel>) -> Value {
+    // pack_dir basenames key claim↔source joins everywhere else too.
+    let source_of = |case_id: &str| -> Value {
+        let Some(m) = model else { return Value::Null };
+        let sha = m
+            .packs
+            .iter()
+            .find(|p| p.pack_dir.rsplit(['/', '\\']).next() == Some(case_id))
+            .and_then(|p| p.source_sha256.clone());
+        let Some(sha) = sha else { return Value::Null };
+        let Some(src) = m.sources.iter().find(|s| s.sha256 == sha) else {
+            return Value::Null;
+        };
+        serde_json::json!({
+            "sha256": src.sha256,
+            "title": src.title,
+            "url": src.url,
+            "uri": format!("ovp://source/{}", src.sha256),
+        })
+    };
+    serde_json::json!({
+        "uri": format!("ovp://claim/{}", record.claim_key),
+        "claim_key": record.claim_key,
+        "claim_id": record.claim_id,
+        "claim": record.claim,
+        "theme": record.theme,
+        "strength": record.strength,
+        "provenance_score": record.provenance_score,
+        "citations": record.citations.iter().map(|c| serde_json::json!({
+            "case_id": c.case_id,
+            "unit_id": c.unit_id,
+            "quote": c.quote,
+            "resolved_line": c.resolved_line,
+            "source": source_of(&c.case_id),
+        })).collect::<Vec<Value>>(),
+    })
 }
 
 pub fn run_mcp(config: McpConfig) -> Result<(), String> {
     let state = McpState {
         vault_root: config.vault_root,
-        _layout: VaultLayout::new(),
+        layout: VaultLayout::new(),
     };
 
     let stdin = io::stdin();
@@ -77,7 +165,10 @@ pub fn run_mcp(config: McpConfig) -> Result<(), String> {
                     jsonrpc: "2.0",
                     id: Value::Null,
                     result: None,
-                    error: Some(RpcError { code: -32700, message: format!("Parse error: {e}") }),
+                    error: Some(RpcError {
+                        code: -32700,
+                        message: format!("Parse error: {e}"),
+                    }),
                 };
                 write_response(&mut out, &resp);
                 continue;
@@ -89,7 +180,10 @@ pub fn run_mcp(config: McpConfig) -> Result<(), String> {
                 jsonrpc: "2.0",
                 id: req.id.unwrap_or(Value::Null),
                 result: None,
-                error: Some(RpcError { code: -32600, message: "Invalid jsonrpc version".into() }),
+                error: Some(RpcError {
+                    code: -32600,
+                    message: "Invalid jsonrpc version".into(),
+                }),
             };
             write_response(&mut out, &resp);
             continue;
@@ -99,8 +193,18 @@ pub fn run_mcp(config: McpConfig) -> Result<(), String> {
         let result = dispatch(&state, &req.method, &req.params);
 
         let resp = match result {
-            Ok(val) => RpcResponse { jsonrpc: "2.0", id, result: Some(val), error: None },
-            Err(e) => RpcResponse { jsonrpc: "2.0", id, result: None, error: Some(e) },
+            Ok(val) => RpcResponse {
+                jsonrpc: "2.0",
+                id,
+                result: Some(val),
+                error: None,
+            },
+            Err(e) => RpcResponse {
+                jsonrpc: "2.0",
+                id,
+                result: None,
+                error: Some(e),
+            },
         };
         write_response(&mut out, &resp);
     }
@@ -122,10 +226,11 @@ fn dispatch(state: &McpState, method: &str, params: &Value) -> Result<Value, Rpc
         "tools/call" => handle_tools_call(state, params),
         "resources/list" => handle_resources_list(),
         "resources/read" => handle_resources_read(state, params),
-        "notifications/initialized" | "notifications/cancelled" => {
-            Ok(Value::Null)
-        }
-        _ => Err(RpcError { code: -32601, message: format!("Method not found: {method}") }),
+        "notifications/initialized" | "notifications/cancelled" => Ok(Value::Null),
+        _ => Err(RpcError {
+            code: -32601,
+            message: format!("Method not found: {method}"),
+        }),
     }
 }
 
@@ -173,6 +278,27 @@ fn handle_tools_list() -> Result<Value, RpcError> {
                 }
             },
             {
+                "name": "claim",
+                "description": "Read one durable claim's FULL evidence closure: claim text, gate verdicts, and every citation resolved to its verbatim quote, line, and source (title/sha/url). Accepts a claim_key (ck-…), a claim_id, or an ovp://claim/<key> URI. This is how an answer's [claim:…] citation is audited.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "key": { "type": "string", "description": "claim_key (preferred, stable), claim_id, or ovp://claim/<key>" }
+                    },
+                    "required": ["key"]
+                }
+            },
+            {
+                "name": "theme_page",
+                "description": "Read one grounded topic page (wiki-style narrative woven from durable claims; every sentence carries a [claim:<key>] citation resolvable via the `claim` tool). Lists all pages when no theme is given.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "theme": { "type": "string", "description": "Theme label (exact) or community id (t000 / 0). Omit to list available pages." }
+                    }
+                }
+            },
+            {
                 "name": "doctor",
                 "description": "Run health checks over OVP vault state.",
                 "inputSchema": { "type": "object", "properties": {} }
@@ -188,20 +314,111 @@ fn handle_tools_list() -> Result<Value, RpcError> {
 
 fn handle_tools_call(state: &McpState, params: &Value) -> Result<Value, RpcError> {
     let name = params.get("name").and_then(|v| v.as_str()).unwrap_or("");
-    let arguments = params.get("arguments").cloned().unwrap_or(Value::Object(Default::default()));
+    let arguments = params
+        .get("arguments")
+        .cloned()
+        .unwrap_or(Value::Object(Default::default()));
 
     match name {
         "find" => tool_find(state, &arguments),
         "search" => tool_search(state, &arguments),
+        "claim" => tool_claim(state, &arguments),
+        "theme_page" => tool_theme_page(state, &arguments),
         "status" => tool_status(state),
         "doctor" => tool_doctor(state),
-        _ => Err(RpcError { code: -32602, message: format!("Unknown tool: {name}") }),
+        _ => Err(RpcError {
+            code: -32602,
+            message: format!("Unknown tool: {name}"),
+        }),
     }
 }
 
+fn tool_claim(state: &McpState, args: &Value) -> Result<Value, RpcError> {
+    let key = args
+        .get("key")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.trim().is_empty())
+        .ok_or_else(|| RpcError {
+            code: -32602,
+            message: "`key` is required".into(),
+        })?;
+    let records = state.load_records();
+    let record = find_record(&records, key.trim())?;
+    let model = state.load_model();
+    let text = serde_json::to_string_pretty(&claim_closure(record, model.as_ref()))
+        .unwrap_or_else(|_| "{}".into());
+    Ok(serde_json::json!({ "content": [{ "type": "text", "text": text }] }))
+}
+
+fn tool_theme_page(state: &McpState, args: &Value) -> Result<Value, RpcError> {
+    let pages = state.load_theme_pages();
+    let records = state.load_records();
+    let body = bodies::theme_pages_body(pages.as_ref(), &records);
+    let all = body["pages"].as_array().cloned().unwrap_or_default();
+
+    let theme = args
+        .get("theme")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    let Some(theme) = theme else {
+        // No theme → the directory of available pages.
+        let listing: Vec<Value> = all
+            .iter()
+            .map(|p| {
+                serde_json::json!({
+                    "community_id": p["community_id"],
+                    "label": p["label"],
+                    "label_zh": p["label_zh"],
+                    "claim_count": p["claim_count"],
+                    "uri": format!("ovp://theme-page/{}", p["community_id"]),
+                })
+            })
+            .collect();
+        let text = serde_json::to_string_pretty(&listing).unwrap_or_else(|_| "[]".into());
+        return Ok(serde_json::json!({ "content": [{ "type": "text", "text": text }] }));
+    };
+
+    // `t003` / `3` → community id; anything else matches the label exactly.
+    let by_id = theme.strip_prefix('t').unwrap_or(theme).parse::<i64>().ok();
+    let page = all.iter().find(|p| {
+        by_id.is_some_and(|id| p["community_id"].as_i64() == Some(id))
+            || p["label"].as_str() == Some(theme)
+    });
+    let Some(page) = page else {
+        return Err(RpcError {
+            code: -32602,
+            message: format!(
+                "No topic page for `{theme}` — call theme_page without arguments to list pages"
+            ),
+        });
+    };
+    // Ship the page plus ONLY its claims from the lookup, so the closure
+    // travels with the narrative.
+    let keys: std::collections::BTreeSet<String> = page["sections"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|s| s["body"].as_str())
+        .flat_map(ovp_domain::crystal::theme_pages::extract_claim_citations)
+        .collect();
+    let claims: serde_json::Map<String, Value> = body["claims"]
+        .as_object()
+        .cloned()
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|(k, _)| keys.contains(k))
+        .collect();
+    let out = serde_json::json!({ "page": page, "claims": claims });
+    let text = serde_json::to_string_pretty(&out).unwrap_or_else(|_| "{}".into());
+    Ok(serde_json::json!({ "content": [{ "type": "text", "text": text }] }))
+}
+
 fn tool_find(state: &McpState, args: &Value) -> Result<Value, RpcError> {
-    let model = state.load_model()
-        .ok_or_else(|| RpcError { code: -32000, message: "Index not available".into() })?;
+    let model = state.load_model().ok_or_else(|| RpcError {
+        code: -32000,
+        message: "Index not available".into(),
+    })?;
 
     // A queried alias resolves to its canonical tag, same as `ovp2 find`.
     // A broken alias table degrades to normalize-only here (a read tool
@@ -211,20 +428,29 @@ fn tool_find(state: &McpState, args: &Value) -> Result<Value, RpcError> {
         aliases.resolve_raw(raw).unwrap_or_else(|| raw.to_string())
     });
     let query = Query {
-        kind: args.get("kind").and_then(|v| v.as_str()).and_then(|k| match k {
-            "sources" => Some(QueryKind::Sources),
-            "packs" => Some(QueryKind::Packs),
-            "claims" => Some(QueryKind::Claims),
-            "runs" => Some(QueryKind::Runs),
-            "tags" => Some(QueryKind::Tags),
-            "entities" => Some(QueryKind::Entities),
-            _ => None,
-        }),
-        status: args.get("status").and_then(|v| v.as_str()).map(String::from),
+        kind: args
+            .get("kind")
+            .and_then(|v| v.as_str())
+            .and_then(|k| match k {
+                "sources" => Some(QueryKind::Sources),
+                "packs" => Some(QueryKind::Packs),
+                "claims" => Some(QueryKind::Claims),
+                "runs" => Some(QueryKind::Runs),
+                "tags" => Some(QueryKind::Tags),
+                "entities" => Some(QueryKind::Entities),
+                _ => None,
+            }),
+        status: args
+            .get("status")
+            .and_then(|v| v.as_str())
+            .map(String::from),
         date: args.get("date").and_then(|v| v.as_str()).map(String::from),
         term: args.get("term").and_then(|v| v.as_str()).map(String::from),
         tag,
-        entity: args.get("entity").and_then(|v| v.as_str()).map(String::from),
+        entity: args
+            .get("entity")
+            .and_then(|v| v.as_str())
+            .map(String::from),
     };
 
     let hits = run_query(&model, &query);
@@ -236,11 +462,20 @@ fn tool_find(state: &McpState, args: &Value) -> Result<Value, RpcError> {
 }
 
 fn tool_search(state: &McpState, args: &Value) -> Result<Value, RpcError> {
-    let model = state.load_model()
-        .ok_or_else(|| RpcError { code: -32000, message: "Index not available".into() })?;
+    let model = state.load_model().ok_or_else(|| RpcError {
+        code: -32000,
+        message: "Index not available".into(),
+    })?;
 
     let term = args.get("query").and_then(|v| v.as_str()).map(String::from);
-    let query = Query { kind: None, status: None, date: None, term, tag: None , entity: None };
+    let query = Query {
+        kind: None,
+        status: None,
+        date: None,
+        term,
+        tag: None,
+        entity: None,
+    };
     let hits = run_query(&model, &query);
     let text = serde_json::to_string_pretty(&hits).unwrap_or_else(|_| "[]".into());
 
@@ -250,8 +485,10 @@ fn tool_search(state: &McpState, args: &Value) -> Result<Value, RpcError> {
 }
 
 fn tool_status(state: &McpState) -> Result<Value, RpcError> {
-    let model = state.load_model()
-        .ok_or_else(|| RpcError { code: -32000, message: "Index not available".into() })?;
+    let model = state.load_model().ok_or_else(|| RpcError {
+        code: -32000,
+        message: "Index not available".into(),
+    })?;
 
     let text = format!(
         "OVP Status (index date: {})\n\
@@ -262,10 +499,14 @@ fn tool_status(state: &McpState) -> Result<Value, RpcError> {
          Queue depth: {}\n\
          Blocked sources: {}",
         model.date,
-        model.totals.sources, model.totals.queued, model.totals.processed,
-        model.totals.failed, model.totals.blocked,
+        model.totals.sources,
+        model.totals.queued,
+        model.totals.processed,
+        model.totals.failed,
+        model.totals.blocked,
         model.totals.packs,
-        model.totals.claims_durable, model.totals.claims_caveated,
+        model.totals.claims_durable,
+        model.totals.claims_caveated,
         model.totals.runs,
         model.ops.queue_depth,
         model.ops.blocked_sources.len(),
@@ -314,6 +555,18 @@ fn handle_resources_list() -> Result<Value, RpcError> {
                 "name": "Working Memory",
                 "description": "Today's working memory context package",
                 "mimeType": "text/markdown"
+            },
+            {
+                "uri": "ovp://claim/<claim_key>",
+                "name": "Durable claim (stable reference)",
+                "description": "One durable claim's full evidence closure — same payload as the `claim` tool. claim_keys (ck-…) are deterministic and survive re-runs, so these URIs are safe to store in notes and answers.",
+                "mimeType": "application/json"
+            },
+            {
+                "uri": "ovp://source/<sha256>",
+                "name": "Source document (stable reference)",
+                "description": "One captured source's metadata and markdown body, addressed by content sha256.",
+                "mimeType": "application/json"
             }
         ]
     }))
@@ -324,8 +577,10 @@ fn handle_resources_read(state: &McpState, params: &Value) -> Result<Value, RpcE
 
     match uri {
         "ovp://index" => {
-            let model = state.load_model()
-                .ok_or_else(|| RpcError { code: -32000, message: "Index not available".into() })?;
+            let model = state.load_model().ok_or_else(|| RpcError {
+                code: -32000,
+                message: "Index not available".into(),
+            })?;
             let json = serde_json::to_string(&model).unwrap_or_else(|_| "{}".into());
             Ok(serde_json::json!({
                 "contents": [{ "uri": uri, "mimeType": "application/json", "text": json }]
@@ -339,6 +594,202 @@ fn handle_resources_read(state: &McpState, params: &Value) -> Result<Value, RpcE
                 "contents": [{ "uri": uri, "mimeType": "text/markdown", "text": text }]
             }))
         }
-        _ => Err(RpcError { code: -32602, message: format!("Unknown resource: {uri}") }),
+        _ if uri.starts_with("ovp://claim/") => {
+            let records = state.load_records();
+            let record = find_record(&records, uri)?;
+            let model = state.load_model();
+            let json = serde_json::to_string(&claim_closure(record, model.as_ref()))
+                .unwrap_or_else(|_| "{}".into());
+            Ok(serde_json::json!({
+                "contents": [{ "uri": uri, "mimeType": "application/json", "text": json }]
+            }))
+        }
+        _ if uri.starts_with("ovp://source/") => {
+            let sha = uri.trim_start_matches("ovp://source/");
+            let model = state.load_model().ok_or_else(|| RpcError {
+                code: -32000,
+                message: "Index not available".into(),
+            })?;
+            let src = model
+                .sources
+                .iter()
+                .find(|s| s.sha256 == sha)
+                .ok_or_else(|| RpcError {
+                    code: -32602,
+                    message: format!("No source with sha256 `{sha}`"),
+                })?;
+            let (doc, truncated, err) =
+                readers::read_source_doc(&state.vault_root, &state.layout, src.rel_path.as_deref());
+            let json = serde_json::to_string(&serde_json::json!({
+                "uri": uri,
+                "source": src,
+                "markdown": doc,
+                "truncated": truncated,
+                "doc_error": err,
+            }))
+            .unwrap_or_else(|_| "{}".into());
+            Ok(serde_json::json!({
+                "contents": [{ "uri": uri, "mimeType": "application/json", "text": json }]
+            }))
+        }
+        _ => Err(RpcError {
+            code: -32602,
+            message: format!("Unknown resource: {uri}"),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ovp_domain::crystal::{
+        CrystalStatus, DurableCitation, FinalClass, ProvenanceClass, StoreEvent, StoreOp,
+        StrengthClass,
+    };
+
+    fn record(key: &str, id: &str, case: &str) -> DurableRecord {
+        DurableRecord {
+            claim_key: key.into(),
+            claim_id: id.into(),
+            claim: format!("claim text for {key}"),
+            theme: "Agent memory".into(),
+            source_cases: vec![case.into()],
+            citations: vec![DurableCitation {
+                case_id: case.into(),
+                unit_id: "u-1".into(),
+                quote: "verbatim quote".into(),
+                resolved_line: Some(12),
+            }],
+            provenance_score: 0.8,
+            provenance_class: ProvenanceClass::Durable,
+            strength: StrengthClass::Supported,
+            strength_rationale: "test".into(),
+            final_class: FinalClass::Durable,
+            run_id: "r1".into(),
+            status: CrystalStatus::Active,
+        }
+    }
+
+    /// A vault with a two-claim ledger and a one-page theme_pages.json.
+    fn fixture_vault() -> (tempfile::TempDir, McpState) {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_path_buf();
+        let layout = VaultLayout::new();
+        let store = root.join(layout.crystal_store_dir());
+        std::fs::create_dir_all(&store).unwrap();
+        let events = [
+            StoreEvent {
+                op: StoreOp::Write,
+                record: record("ck-aaa", "id-a", "case-1"),
+                supersedes: None,
+                reason: None,
+            },
+            StoreEvent {
+                op: StoreOp::Write,
+                record: record("ck-bbb", "id-b", "case-2"),
+                supersedes: None,
+                reason: None,
+            },
+        ];
+        let ledger: String = events
+            .iter()
+            .map(|e| serde_json::to_string(e).unwrap() + "\n")
+            .collect();
+        std::fs::write(store.join("ledger.jsonl"), ledger).unwrap();
+        std::fs::write(
+            store.join("theme_pages.json"),
+            serde_json::json!({
+                "schema": "ovp.theme_pages/v1",
+                "pages": [{
+                    "community_id": 0,
+                    "label": "Agent memory",
+                    "label_zh": "智能体记忆",
+                    "claim_keys": ["ck-aaa", "ck-bbb"],
+                    "sections": [{"heading": "H",
+                                   "body": "One [claim:ck-aaa]. Two [claim:ck-bbb]."}]
+                }]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let state = McpState {
+            vault_root: root,
+            layout,
+        };
+        (tmp, state)
+    }
+
+    fn call(state: &McpState, tool: &str, args: serde_json::Value) -> Result<Value, RpcError> {
+        dispatch(
+            state,
+            "tools/call",
+            &serde_json::json!({ "name": tool, "arguments": args }),
+        )
+    }
+
+    fn text_of(v: &Value) -> String {
+        v["content"][0]["text"].as_str().unwrap().to_string()
+    }
+
+    #[test]
+    fn claim_tool_returns_the_evidence_closure_by_key_id_or_uri() {
+        let (_tmp, state) = fixture_vault();
+        for key in ["ck-aaa", "id-a", "ovp://claim/ck-aaa"] {
+            let v = call(&state, "claim", serde_json::json!({ "key": key })).unwrap();
+            let closure: Value = serde_json::from_str(&text_of(&v)).unwrap();
+            assert_eq!(closure["claim_key"], "ck-aaa", "lookup by `{key}`");
+            assert_eq!(closure["uri"], "ovp://claim/ck-aaa");
+            assert_eq!(closure["citations"][0]["quote"], "verbatim quote");
+            assert_eq!(closure["citations"][0]["resolved_line"], 12);
+        }
+        let err = call(&state, "claim", serde_json::json!({ "key": "nope" })).unwrap_err();
+        assert!(err.message.contains("No active claim"), "{}", err.message);
+    }
+
+    #[test]
+    fn ambiguous_claim_id_lists_the_candidate_keys() {
+        let records = vec![record("ck-one", "dup", "c1"), record("ck-two", "dup", "c2")];
+        let err = find_record(&records, "dup").unwrap_err();
+        assert!(err.message.contains("ambiguous"), "{}", err.message);
+        assert!(err.message.contains("ck-one") && err.message.contains("ck-two"));
+    }
+
+    #[test]
+    fn theme_page_tool_lists_and_fetches_by_label_or_id() {
+        let (_tmp, state) = fixture_vault();
+        // Listing.
+        let v = call(&state, "theme_page", serde_json::json!({})).unwrap();
+        let listing: Value = serde_json::from_str(&text_of(&v)).unwrap();
+        assert_eq!(listing[0]["label"], "Agent memory");
+        assert_eq!(listing[0]["uri"], "ovp://theme-page/0");
+        // By label and by t000 — the page ships with its claims closure.
+        for theme in ["Agent memory", "t000", "0"] {
+            let v = call(&state, "theme_page", serde_json::json!({ "theme": theme })).unwrap();
+            let out: Value = serde_json::from_str(&text_of(&v)).unwrap();
+            assert_eq!(out["page"]["label"], "Agent memory", "lookup by `{theme}`");
+            assert_eq!(out["claims"]["ck-aaa"]["claim_id"], "id-a");
+            assert_eq!(out["claims"]["ck-bbb"]["claim_id"], "id-b");
+        }
+        let err = call(
+            &state,
+            "theme_page",
+            serde_json::json!({ "theme": "Ghost" }),
+        )
+        .unwrap_err();
+        assert!(err.message.contains("No topic page"), "{}", err.message);
+    }
+
+    #[test]
+    fn claim_resource_reads_by_stable_uri() {
+        let (_tmp, state) = fixture_vault();
+        let v = dispatch(
+            &state,
+            "resources/read",
+            &serde_json::json!({ "uri": "ovp://claim/ck-bbb" }),
+        )
+        .unwrap();
+        let text = v["contents"][0]["text"].as_str().unwrap();
+        let closure: Value = serde_json::from_str(text).unwrap();
+        assert_eq!(closure["claim_id"], "id-b");
     }
 }

--- a/crates/ovp-mcp/src/lib.rs
+++ b/crates/ovp-mcp/src/lib.rs
@@ -640,7 +640,7 @@ fn handle_resources_read(state: &McpState, params: &Value) -> Result<Value, RpcE
             }))
         }
         _ if uri.starts_with("ovp://source/") => {
-            let sha = uri.trim_start_matches("ovp://source/");
+            let sha = uri.strip_prefix("ovp://source/").unwrap_or(uri);
             let model = state.load_model().ok_or_else(|| RpcError {
                 code: -32000,
                 message: "Index not available".into(),

--- a/crates/ovp-publish/src/lib.rs
+++ b/crates/ovp-publish/src/lib.rs
@@ -126,10 +126,22 @@ pub fn publish(args: &PublishArgs) -> Result<PublishReport, String> {
         .join(layout.crystal_store_dir())
         .join("terrain.json");
 
+    // Grounded topic pages. Strict like the ledger: a corrupt projection must
+    // FAIL the publish, not silently deploy a site without its wiki layer. A
+    // genuinely missing file (never built) is fine — the body ships empty.
+    let theme_pages = ovp_domain::crystal::theme_pages::ThemePagesFile::load(
+        &args
+            .vault_root
+            .join(layout.crystal_store_dir())
+            .join("theme_pages.json"),
+    )
+    .map_err(|e| format!("publish: {e}"))?;
+
     let files = write_api_tree(
         &args.out_dir.join("api"),
         public,
         &records,
+        theme_pages.as_ref(),
         &terrain_src,
         args.published_at.as_deref(),
     )?;
@@ -154,6 +166,7 @@ fn write_api_tree(
     api: &Path,
     public: &IndexModel,
     records: &[ovp_domain::crystal::DurableRecord],
+    theme_pages: Option<&ovp_domain::crystal::theme_pages::ThemePagesFile>,
     terrain_src: &Path,
     published_at: Option<&str>,
 ) -> Result<usize, String> {
@@ -165,11 +178,17 @@ fn write_api_tree(
     // Top-level projections.
     write_json(&api.join("model.json"), &serde_json::to_value(public).unwrap_or_default())?;
     write_json(&api.join("themes.json"), &bodies::themes_body(records))?;
+    // Topic pages join against the SCRUBBED records: a page citing any
+    // non-public claim is dropped whole inside the body builder.
+    write_json(
+        &api.join("theme-pages.json"),
+        &bodies::theme_pages_body(theme_pages, records),
+    )?;
     write_json(&api.join("flow.json"), &bodies::flow_body(public))?;
     write_json(&api.join("settings.json"), &bodies::settings_public_body(Some(public)))?;
     let empty = Query { kind: None, status: None, date: None, term: None, tag: None , entity: None };
     write_json(&api.join("search-index.json"), &bodies::find_body(public, &empty))?;
-    files += 5;
+    files += 6;
 
     // Graph: the global overview + one keyed file of per-theme subgraphs (keyed
     // by label so the SPA looks up client-side, no slug-matching). Neighborhood
@@ -570,15 +589,51 @@ mod tests {
         let api = tmp.path().join("api");
         let pv = PublicView::from_model(&model());
         let recs = vec![record()];
+        let pages = ovp_domain::crystal::theme_pages::ThemePagesFile {
+            schema: ovp_domain::crystal::theme_pages::THEME_PAGES_SCHEMA.into(),
+            pages: vec![
+                ovp_domain::crystal::theme_pages::ThemePage {
+                    community_id: 0,
+                    label: "Theme A".into(),
+                    label_zh: "主题A".into(),
+                    claim_keys: vec!["ck-abc123".into()],
+                    sections: vec![ovp_domain::crystal::theme_pages::PageSection {
+                        heading: "H".into(),
+                        body: "Grounded [claim:ck-abc123].".into(),
+                    }],
+                },
+                // Cites a claim that does not survive redaction — the page
+                // must be dropped whole from the published body.
+                ovp_domain::crystal::theme_pages::ThemePage {
+                    community_id: 1,
+                    label: "Private".into(),
+                    label_zh: "私有".into(),
+                    claim_keys: vec!["ck-private".into()],
+                    sections: vec![ovp_domain::crystal::theme_pages::PageSection {
+                        heading: "P".into(),
+                        body: "Hidden [claim:ck-private].".into(),
+                    }],
+                },
+            ],
+        };
         let n = write_api_tree(
             &api,
             pv.model(),
             &recs,
+            Some(&pages),
             &tmp.path().join("no-terrain.json"),
             Some("2026-07-01T12:00:00Z"),
         )
         .unwrap();
         assert!(n >= 8, "expected the full tree, got {n} files");
+
+        // theme-pages.json: the public page ships with its claim lookup, the
+        // page citing a non-public claim is dropped whole.
+        let tp = read(&api.join("theme-pages.json"));
+        assert_eq!(tp["pages"].as_array().unwrap().len(), 1);
+        assert_eq!(tp["pages"][0]["label"], "Theme A");
+        assert_eq!(tp["claims"]["ck-abc123"]["claim_id"], "id-1");
+        assert!(tp["claims"].get("ck-private").is_none());
 
         // model.json: processed source only, durable claim only.
         let m = read(&api.join("model.json"));

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -649,6 +649,7 @@ fn dispatch(
         (Method::Get, "/api/flow") => handle_flow(state),
         (Method::Get, "/api/settings") => handle_settings(state),
         (Method::Get, "/api/themes") => handle_themes(state),
+        (Method::Get, "/api/theme-pages") => handle_theme_pages(state),
         (Method::Get, "/api/terrain") => handle_terrain(state),
         (Method::Get, p) if p.starts_with("/api/claim/") => handle_claim(state, url),
         (Method::Get, p) if p.starts_with("/api/source/") => handle_source_api(state, url),
@@ -1002,6 +1003,27 @@ fn handle_themes(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
     let model = state.current_model();
     let records = load_active_records(state);
     let body = bodies::themes_body(&records).to_string();
+    json_stamped(200, &body, model.as_ref())
+}
+
+/// `GET /api/theme-pages` — the grounded topic pages built by
+/// `ovp2 crystal-theme-pages`, joined against the live active records for the
+/// citation lookup. A missing/corrupt projection degrades to an empty body
+/// (the portal simply hides the wiki panel); corruption is logged, and
+/// `crystal-theme-pages` is where it fails loud.
+fn handle_theme_pages(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
+    let model = state.current_model();
+    let records = load_active_records(state);
+    let pages = match ovp_domain::crystal::theme_pages::ThemePagesFile::load(
+        &state.vault_root.join(".ovp/crystal/theme_pages.json"),
+    ) {
+        Ok(pages) => pages,
+        Err(e) => {
+            eprintln!("handle_theme_pages: ignoring theme_pages.json ({e})");
+            None
+        }
+    };
+    let body = bodies::theme_pages_body(pages.as_ref(), &records).to_string();
     json_stamped(200, &body, model.as_ref())
 }
 
@@ -2519,6 +2541,52 @@ mod tests {
         assert_eq!(resp.status_code(), 400);
         let resp = dispatch(&st, Method::Get, "/api/graph?scope=galaxy", "");
         assert_eq!(resp.status_code(), 400);
+
+        let _ = std::fs::remove_dir_all(vault.parent().unwrap());
+    }
+
+    #[test]
+    fn theme_pages_endpoint_serves_pages_with_claim_lookup_and_degrades() {
+        let vault = portal_vault("theme-pages-ep", "50-Inbox/03-Processed/good.md", "body\n");
+        write_ledger(&vault);
+        let store = vault.join(VaultLayout::new().crystal_store_dir());
+        std::fs::write(
+            store.join("theme_pages.json"),
+            serde_json::json!({
+                "schema": "ovp.theme_pages/v1",
+                "pages": [
+                    {"community_id": 0, "label": "Agent memory", "label_zh": "智能体记忆",
+                     "claim_keys": ["a"],
+                     "sections": [{"heading": "H", "body": "Grounded [claim:a]."}]},
+                    // Cites an unknown key — dropped whole from the body.
+                    {"community_id": 1, "label": "Ghost", "label_zh": "鬼",
+                     "claim_keys": ["nope"],
+                     "sections": [{"heading": "G", "body": "X [claim:nope]."}]}
+                ]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let st = state(vault.clone(), None);
+
+        let v = body_json(dispatch(&st, Method::Get, "/api/theme-pages", ""));
+        let pages = v["pages"].as_array().unwrap();
+        assert_eq!(pages.len(), 1, "ghost-claim page must drop: {v}");
+        assert_eq!(pages[0]["label"], "Agent memory");
+        assert_eq!(pages[0]["sections"][0]["body"], "Grounded [claim:a].");
+        assert_eq!(v["claims"]["a"]["claim_id"], "id-a");
+        assert_eq!(v["claims"]["a"]["sources"][0], "good");
+
+        // Missing projection → empty body, still 200 (portal hides the wiki).
+        std::fs::remove_file(store.join("theme_pages.json")).unwrap();
+        let v = body_json(dispatch(&st, Method::Get, "/api/theme-pages", ""));
+        assert_eq!(v["pages"].as_array().unwrap().len(), 0);
+        // Corrupt projection degrades the same way (logged, never a 500).
+        std::fs::write(store.join("theme_pages.json"), "not json").unwrap();
+        let resp = dispatch(&st, Method::Get, "/api/theme-pages", "");
+        assert_eq!(resp.status_code(), 200);
+        let v = body_json(resp);
+        assert_eq!(v["pages"].as_array().unwrap().len(), 0);
 
         let _ = std::fs::remove_dir_all(vault.parent().unwrap());
     }

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -1015,7 +1015,10 @@ fn handle_theme_pages(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
     let model = state.current_model();
     let records = load_active_records(state);
     let pages = match ovp_domain::crystal::theme_pages::ThemePagesFile::load(
-        &state.vault_root.join(".ovp/crystal/theme_pages.json"),
+        &state
+            .vault_root
+            .join(state.layout.crystal_store_dir())
+            .join("theme_pages.json"),
     ) {
         Ok(pages) => pages,
         Err(e) => {


### PR DESCRIPTION
Stacked on #348 (TP1). Retarget to main after it merges.

## TP3 — theme pages reach the product surfaces
- **Shared body builder** `theme_pages_body` (ovp-api-projection): joins the projection against durable records for the citation lookup; a page citing any claim key absent from the record set drops whole — one rule covers live (all active records, nothing drops) and publish (scrubbed public records, no dangling citations).
- **Server**: `GET /api/theme-pages`; missing/corrupt projection degrades to an empty body.
- **Publish**: `api/theme-pages.json` in the tree; corrupt projection fails the publish like a corrupt ledger.
- **Portal**: TopicOverview wiki panel on ThemeDetailPage — sections + numbered citation chips (first-appearance order) anchoring to the claim cards below; tooltip = claim text; collision-safe (duplicated claim_ids render tooltip-only chips); fetch failure renders nothing. Frontend implemented by codex subagent to spec, reviewed.

## MP1–MP3 — agent surface
- `claim` tool + `ovp://claim/{claim_key}`: full evidence closure (claim → quote → line → source) by stable key, claim_id alias when unambiguous.
- `theme_page` tool + `ovp://theme-page/{community_id}`: topic pages with their claims closure; no-arg lists the directory.
- `ovp://source/{sha256}`: source row + markdown via the shared traversal-safe reader.
- `resources/templates/list` (RFC 6570) for the dynamic URIs; every emitted URI is dereferenceable.
- `ovp2 mcp-guidance`: idempotent marker-delimited consult-the-vault section for vault CLAUDE.md/AGENTS.md (openwiki pattern).

## Verification
- ovp-mcp 6 tests, api-projection/publish/server suites green, console-ui build + 38 vitest.
- Live on the real vault: `/api/theme-pages` = 15 pages / 465-claim lookup (:7799); publish tree emits the same, filtered.
- One codex review round on this diff: 2 P1 + 3 P2, all fixed (key trim, collision-safe chips, live-mode cache, dereferenceable theme-page URIs, resource templates).