### PR TITLE
feat(mcp,ask): MP1b — grounded ask over MCP + stable ck- citation keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2890,6 +2890,8 @@ dependencies = [
  "ovp-api-projection",
  "ovp-domain",
  "ovp-index",
+ "ovp-llm",
+ "ovp-memory",
  "serde",
  "serde_json",
  "tempfile",

--- a/console-ui/src/pages/AskPage.tsx
+++ b/console-ui/src/pages/AskPage.tsx
@@ -27,10 +27,17 @@ interface Turn {
   errorKey: MsgKey | null;
 }
 
-/** `[claim:…] [card:…] [unit:…]` tokens — mirrors the server tokenizer
- * (ovp-memory::verify), which is the source of truth for what counts as a
- * citation; anything this regex misses simply stays plain text. */
-const CITE_RE = /\[\s*((?:claim|card|unit):[^\]\n]+?)\s*\]/g;
+/** `[claim:…] [card:…] [unit:…]` tokens plus the bare `[ck-…]` form models
+ * shorten claim keys to — mirrors the server tokenizer (ovp-memory::verify),
+ * which is the source of truth for what counts as a citation; anything this
+ * regex misses simply stays plain text. */
+const CITE_RE = /\[\s*((?:claim|card|unit):[^\]\n]+?|ck-[^\]\s:]+)\s*\]/g;
+
+/** Same normalization as the server tokenizer: a bare ck- key is a claim
+ * citation, so both bracket forms resolve to the same returned citation id. */
+function normalizeCiteToken(token: string): string {
+  return token.startsWith('ck-') ? `claim:${token}` : token;
+}
 
 function errorKeyFor(err: unknown): MsgKey {
   if (err instanceof AskError) {
@@ -66,7 +73,7 @@ function AnswerText({
   const marker: InlineMarker = {
     pattern: CITE_RE,
     render: (m, key) => {
-      const i = index.get(m[1]);
+      const i = index.get(normalizeCiteToken(m[1]));
       if (i === undefined) return null; // not a returned citation — plain text
       const cit = citations[i];
       return (

--- a/crates/ovp-api-projection/src/graph.rs
+++ b/crates/ovp-api-projection/src/graph.rs
@@ -2267,6 +2267,7 @@ mod tests {
         let mut model = model_for_cases(&[("case1", "sha1", "Source One")]);
         model.claims.push(ovp_index::ClaimRow {
             claim_id: "cav-1".into(),
+            claim_key: None,
             claim: "caveated-only claim".into(),
             theme: Some("gamma".into()),
             status: ovp_index::ClaimStatus::Caveated,

--- a/crates/ovp-api-projection/src/redact.rs
+++ b/crates/ovp-api-projection/src/redact.rs
@@ -148,6 +148,7 @@ mod tests {
     fn claim(id: &str, status: ClaimStatus) -> ClaimRow {
         ClaimRow {
             claim_id: id.into(),
+            claim_key: None,
             claim: "c".into(),
             theme: Some("Th".into()),
             status,

--- a/crates/ovp-cli/src/commands/mcp.rs
+++ b/crates/ovp-cli/src/commands/mcp.rs
@@ -1,16 +1,56 @@
 //! `mcp` — start the OVP MCP stdio server.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-use ovp_mcp::{run_mcp, McpConfig};
+use ovp_mcp::{AskClientFactory, McpConfig, run_mcp};
 
 use crate::CliError;
+use crate::commands::client::{ClientKind, build_client};
 
 pub struct McpArgs {
     pub vault_root: PathBuf,
 }
 
 pub fn run(args: McpArgs) -> Result<(), CliError> {
-    let config = McpConfig { vault_root: args.vault_root };
+    let ask_client = ask_client_factory(&args.vault_root);
+    // stdout is the JSON-RPC channel — operator-facing notes go to stderr.
+    match &ask_client {
+        None => eprintln!(
+            "ovp-mcp: ask NOT CONFIGURED — the `ask` tool will answer with a \
+             configuration error. Build with `--features anthropic` and set \
+             ANTHROPIC_API_KEY to enable."
+        ),
+        // Same fail-loud-at-startup contract as `serve`: a present key with
+        // an invalid live setting must not surface as a generic error on the
+        // first ask.
+        Some(factory) => {
+            factory()
+                .map_err(|e| CliError::Io(format!("ask client configuration invalid: {e}")))?;
+        }
+    }
+    let config = McpConfig {
+        vault_root: args.vault_root,
+        ask_client,
+    };
     run_mcp(config).map_err(CliError::Io)
+}
+
+/// Same environment resolution as `serve`'s ask factory: live transport
+/// needs the `anthropic` build feature AND a non-empty ANTHROPIC_API_KEY;
+/// the client records into the shared ask cassette dir so repeated
+/// identical questions replay.
+fn ask_client_factory(vault_root: &Path) -> Option<AskClientFactory> {
+    if !cfg!(feature = "anthropic") {
+        return None;
+    }
+    let key_present = std::env::var("ANTHROPIC_API_KEY")
+        .map(|v| !v.trim().is_empty())
+        .unwrap_or(false);
+    if !key_present {
+        return None;
+    }
+    let cache_dir = vault_root.join(".ovp/cassettes/ask");
+    Some(std::sync::Arc::new(move || {
+        build_client(ClientKind::Live, &cache_dir).map_err(|e| e.to_string())
+    }))
 }

--- a/crates/ovp-console/src/render.rs
+++ b/crates/ovp-console/src/render.rs
@@ -381,6 +381,7 @@ mod tests {
             claims: vec![
                 ClaimRow {
                     claim_id: "c01".into(),
+                    claim_key: None,
                     claim: "Filesystem works as memory.".into(),
                     theme: Some("memory".into()),
                     status: ClaimStatus::Durable,
@@ -391,6 +392,7 @@ mod tests {
                 },
                 ClaimRow {
                     claim_id: "c02".into(),
+                    claim_key: None,
                     claim: "Context is the moat.".into(),
                     theme: None,
                     status: ClaimStatus::Caveated,

--- a/crates/ovp-index/src/build.rs
+++ b/crates/ovp-index/src/build.rs
@@ -840,6 +840,7 @@ fn build_claims(vault_root: &Path, layout: &VaultLayout) -> Result<Vec<ClaimRow>
         };
         claims.push(ClaimRow {
             claim_id: rec.claim_id.clone(),
+            claim_key: Some(rec.claim_key.clone()),
             claim: rec.claim.clone(),
             theme: (!rec.theme.is_empty()).then(|| rec.theme.clone()),
             status,
@@ -868,6 +869,8 @@ fn build_claims(vault_root: &Path, layout: &VaultLayout) -> Result<Vec<ClaimRow>
             };
             claims.push(ClaimRow {
                 claim_id: entry.claim_id,
+                // Review entries live outside the ledger and have no ck- key.
+                claim_key: None,
                 claim: entry.claim,
                 theme: (!entry.theme.is_empty()).then_some(entry.theme),
                 status: ClaimStatus::Caveated,

--- a/crates/ovp-index/src/model.rs
+++ b/crates/ovp-index/src/model.rs
@@ -102,6 +102,13 @@ pub enum ClaimStatus {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ClaimRow {
     pub claim_id: String,
+    /// The claim's STABLE ledger identity (`ck-…`, deterministic over claim
+    /// text + citation set). Additive: pre-existing indexes deserialize as
+    /// None; claim_ids can collide across runs, claim_keys cannot — surfaces
+    /// that need an unambiguous address (MCP ask citations, claim pages)
+    /// prefer this.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claim_key: Option<String>,
     pub claim: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub theme: Option<String>,

--- a/crates/ovp-mcp/Cargo.toml
+++ b/crates/ovp-mcp/Cargo.toml
@@ -10,6 +10,8 @@ authors.workspace = true
 ovp-index = { path = "../ovp-index" }
 ovp-domain = { path = "../ovp-domain" }
 ovp-api-projection = { path = "../ovp-api-projection" }
+ovp-memory = { path = "../ovp-memory" }
+ovp-llm = { path = "../ovp-llm" }
 serde.workspace = true
 serde_json.workspace = true
 

--- a/crates/ovp-mcp/src/lib.rs
+++ b/crates/ovp-mcp/src/lib.rs
@@ -14,8 +14,16 @@ use ovp_index::{IndexModel, Query, QueryKind, read_index, run_query};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+/// LLM client factory for the `ask` tool — same contract as the server's
+/// `ServeConfig::ask_client`: `None` means no live LLM is configured and
+/// `ask` answers with a clear configuration error instead of failing
+/// silently. The factory builds a fresh (cassette-recording) client per ask.
+pub type AskClientFactory =
+    std::sync::Arc<dyn Fn() -> Result<Box<dyn ovp_llm::ModelClient>, String> + Send + Sync>;
+
 pub struct McpConfig {
     pub vault_root: PathBuf,
+    pub ask_client: Option<AskClientFactory>,
 }
 
 #[derive(Deserialize)]
@@ -46,6 +54,7 @@ struct RpcError {
 struct McpState {
     vault_root: PathBuf,
     layout: VaultLayout,
+    ask_client: Option<AskClientFactory>,
 }
 
 impl McpState {
@@ -143,6 +152,7 @@ pub fn run_mcp(config: McpConfig) -> Result<(), String> {
     let state = McpState {
         vault_root: config.vault_root,
         layout: VaultLayout::new(),
+        ask_client: config.ask_client,
     };
 
     let stdin = io::stdin();
@@ -279,6 +289,17 @@ fn handle_tools_list() -> Result<Value, RpcError> {
                 }
             },
             {
+                "name": "ask",
+                "description": "Ask a question ANSWERED FROM THE VAULT'S EVIDENCE ONLY (durable claims, cards, verbatim units) — every statement cites its evidence and a deterministic verifier reports how many citations resolve. Prefer this over answering from memory for anything the vault may cover; audit any [claim:…] citation with the `claim` tool.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "question": { "type": "string", "description": "The question to answer from vault evidence" }
+                    },
+                    "required": ["question"]
+                }
+            },
+            {
                 "name": "claim",
                 "description": "Read one durable claim's FULL evidence closure: claim text, gate verdicts, and every citation resolved to its verbatim quote, line, and source (title/sha/url). Accepts a claim_key (ck-…), a claim_id, or an ovp://claim/<key> URI. This is how an answer's [claim:…] citation is audited.",
                 "inputSchema": {
@@ -323,6 +344,7 @@ fn handle_tools_call(state: &McpState, params: &Value) -> Result<Value, RpcError
     match name {
         "find" => tool_find(state, &arguments),
         "search" => tool_search(state, &arguments),
+        "ask" => tool_ask(state, &arguments),
         "claim" => tool_claim(state, &arguments),
         "theme_page" => tool_theme_page(state, &arguments),
         "status" => tool_status(state),
@@ -332,6 +354,75 @@ fn handle_tools_call(state: &McpState, params: &Value) -> Result<Value, RpcError
             message: format!("Unknown tool: {name}"),
         }),
     }
+}
+
+fn tool_ask(state: &McpState, args: &Value) -> Result<Value, RpcError> {
+    let question = args
+        .get("question")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| RpcError {
+            code: -32602,
+            message: "`question` is required".into(),
+        })?;
+    // Explicit configuration error, never a silent degrade: an agent must be
+    // able to tell "no LLM wired" from "the vault has no answer".
+    let Some(factory) = &state.ask_client else {
+        return Err(RpcError {
+            code: -32000,
+            message: "ask is not configured — run ovp2 built with `--features anthropic` \
+                      and set ANTHROPIC_API_KEY in the MCP server's environment"
+                .into(),
+        });
+    };
+    let model = state.load_model().ok_or_else(|| RpcError {
+        code: -32000,
+        message: "Index not available — run `ovp2 index` first".into(),
+    })?;
+    let evidence = ovp_index::read_evidence(&state.vault_root).ok();
+    let mut client = factory().map_err(|e| RpcError {
+        code: -32000,
+        message: format!("ask client configuration invalid: {e}"),
+    })?;
+    let ask_args = ovp_memory::ask::AskArgs {
+        question: question.to_string(),
+        verify_citations: true,
+        save_chat: false,
+        ..Default::default()
+    };
+    let result = ovp_memory::ask::ask_with_optional_evidence(
+        &model,
+        evidence.as_ref(),
+        client.as_mut(),
+        &ask_args,
+        &state.vault_root,
+    )
+    .map_err(|e| RpcError {
+        code: -32000,
+        message: format!("ask failed: {e}"),
+    })?;
+
+    // Answer first, then the deterministic verification report — the agent
+    // sees HOW grounded the answer is, not just the prose.
+    let mut text = result.answer.trim().to_string();
+    if let Some(v) = &result.verification {
+        text.push_str(&format!(
+            "\n\n---\nverification: {} citation(s), {} verified against supplied evidence",
+            v.cited, v.verified
+        ));
+        if !v.missing.is_empty() {
+            text.push_str(&format!("; UNRESOLVED: {}", v.missing.join(", ")));
+        }
+        if !v.warnings.is_empty() {
+            text.push_str(&format!("; warnings: {}", v.warnings.join(", ")));
+        }
+        text.push_str(
+            "\naudit any [claim:<id>] citation with the `claim` tool \
+             (accepts claim ids and ovp://claim/ keys)",
+        );
+    }
+    Ok(serde_json::json!({ "content": [{ "type": "text", "text": text }] }))
 }
 
 fn tool_claim(state: &McpState, args: &Value) -> Result<Value, RpcError> {
@@ -750,6 +841,7 @@ mod tests {
         let state = McpState {
             vault_root: root,
             layout,
+            ask_client: None,
         };
         (tmp, state)
     }
@@ -850,6 +942,33 @@ mod tests {
         assert!(
             uris.contains(&"ovp://theme-page/{community_id}"),
             "{uris:?}"
+        );
+    }
+
+    #[test]
+    fn ask_without_a_client_is_a_clear_configuration_error() {
+        let (_tmp, state) = fixture_vault();
+        let err = call(&state, "ask", serde_json::json!({ "question": "q" })).unwrap_err();
+        assert!(
+            err.message.contains("ask is not configured"),
+            "{}",
+            err.message
+        );
+        assert!(err.message.contains("ANTHROPIC_API_KEY"), "{}", err.message);
+    }
+
+    #[test]
+    fn ask_with_a_client_reaches_past_the_config_gate() {
+        let (_tmp, mut state) = fixture_vault();
+        // A configured factory moves the failure past "not configured" — the
+        // fixture vault has no index, so the next honest error is index
+        // availability (the full pipeline is covered in ovp-memory).
+        state.ask_client = Some(std::sync::Arc::new(|| Err("never built".into())));
+        let err = call(&state, "ask", serde_json::json!({ "question": "q" })).unwrap_err();
+        assert!(
+            err.message.contains("Index not available"),
+            "{}",
+            err.message
         );
     }
 

--- a/crates/ovp-mcp/src/lib.rs
+++ b/crates/ovp-mcp/src/lib.rs
@@ -389,22 +389,26 @@ fn tool_ask(state: &McpState, args: &Value) -> Result<Value, RpcError> {
     // Missing evidence.json = a fresh/claims-only vault (fine, noted);
     // a CORRUPT sidecar is surfaced, never silently downgraded to
     // claims-only while the report implies full evidence (codex P2).
-    let (evidence, degraded_note) = match ovp_index::read_evidence(&state.vault_root) {
-        Ok(e) => (Some(e), None),
-        Err(e) if !ovp_index::evidence::evidence_path(&state.vault_root).exists() => {
-            let _ = e;
-            (
-                None,
-                Some("note: no evidence sidecar — answer drawn from claims only (no cards/units)"),
-            )
-        }
-        Err(e) => {
-            return Err(RpcError {
-                code: -32000,
-                message: format!(
-                    "evidence sidecar unreadable ({e}) — rebuild with `ovp2 index` before asking"
-                ),
-            });
+    // Existence is checked BEFORE the read so a read failure on a present
+    // file is always classified as corruption, not misfiled as missing.
+    let (evidence, degraded_note) = if !ovp_index::evidence::evidence_path(&state.vault_root)
+        .exists()
+    {
+        (
+            None,
+            Some("note: no evidence sidecar — answer drawn from claims only (no cards/units)"),
+        )
+    } else {
+        match ovp_index::read_evidence(&state.vault_root) {
+            Ok(e) => (Some(e), None),
+            Err(e) => {
+                return Err(RpcError {
+                    code: -32000,
+                    message: format!(
+                        "evidence sidecar unreadable ({e}) — rebuild with `ovp2 index` before asking"
+                    ),
+                });
+            }
         }
     };
     let mut client = factory().map_err(|e| RpcError {

--- a/crates/ovp-mcp/src/lib.rs
+++ b/crates/ovp-mcp/src/lib.rs
@@ -290,7 +290,7 @@ fn handle_tools_list() -> Result<Value, RpcError> {
             },
             {
                 "name": "ask",
-                "description": "Ask a question ANSWERED FROM THE VAULT'S EVIDENCE ONLY (durable claims, cards, verbatim units) — every statement cites its evidence and a deterministic verifier reports how many citations resolve. Prefer this over answering from memory for anything the vault may cover; audit any [claim:…] citation with the `claim` tool.",
+                "description": "Ask a question answered FROM THE VAULT'S EVIDENCE (active durable claims, cards, verbatim units). The answer carries inline citations and a deterministic report of how many citation IDs resolve against the supplied evidence (ID resolution — it does not prove every sentence is cited). Prefer this over answering from memory for anything the vault may cover; audit any [claim:…] citation with the `claim` tool.",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
@@ -376,11 +376,37 @@ fn tool_ask(state: &McpState, args: &Value) -> Result<Value, RpcError> {
                 .into(),
         });
     };
-    let model = state.load_model().ok_or_else(|| RpcError {
+    let mut model = state.load_model().ok_or_else(|| RpcError {
         code: -32000,
         message: "Index not available — run `ovp2 index` first".into(),
     })?;
-    let evidence = ovp_index::read_evidence(&state.vault_root).ok();
+    // This tool promises answers grounded in DURABLE claims — caveated,
+    // superseded, and retracted rows must not be retrievable here (codex
+    // P1; they also could not be audited by the active-record `claim` tool).
+    model
+        .claims
+        .retain(|c| c.status == ovp_index::ClaimStatus::Durable);
+    // Missing evidence.json = a fresh/claims-only vault (fine, noted);
+    // a CORRUPT sidecar is surfaced, never silently downgraded to
+    // claims-only while the report implies full evidence (codex P2).
+    let (evidence, degraded_note) = match ovp_index::read_evidence(&state.vault_root) {
+        Ok(e) => (Some(e), None),
+        Err(e) if !state.vault_root.join(".ovp/evidence.json").exists() => {
+            let _ = e;
+            (
+                None,
+                Some("note: no evidence sidecar — answer drawn from claims only (no cards/units)"),
+            )
+        }
+        Err(e) => {
+            return Err(RpcError {
+                code: -32000,
+                message: format!(
+                    "evidence sidecar unreadable ({e}) — rebuild with `ovp2 index` before asking"
+                ),
+            });
+        }
+    };
     let mut client = factory().map_err(|e| RpcError {
         code: -32000,
         message: format!("ask client configuration invalid: {e}"),
@@ -404,11 +430,14 @@ fn tool_ask(state: &McpState, args: &Value) -> Result<Value, RpcError> {
     })?;
 
     // Answer first, then the deterministic verification report — the agent
-    // sees HOW grounded the answer is, not just the prose.
+    // sees HOW grounded the answer is, not just the prose. The report checks
+    // that citation IDs resolve against the supplied evidence; it does NOT
+    // prove every sentence is cited (that gate exists only for theme pages).
     let mut text = result.answer.trim().to_string();
     if let Some(v) = &result.verification {
         text.push_str(&format!(
-            "\n\n---\nverification: {} citation(s), {} verified against supplied evidence",
+            "\n\n---\nverification (citation-ID resolution, not per-sentence): \
+             {} citation(s), {} resolved against supplied evidence",
             v.cited, v.verified
         ));
         if !v.missing.is_empty() {
@@ -418,9 +447,13 @@ fn tool_ask(state: &McpState, args: &Value) -> Result<Value, RpcError> {
             text.push_str(&format!("; warnings: {}", v.warnings.join(", ")));
         }
         text.push_str(
-            "\naudit any [claim:<id>] citation with the `claim` tool \
-             (accepts claim ids and ovp://claim/ keys)",
+            "\naudit any [claim:<key>] citation with the `claim` tool \
+             (accepts ck- claim keys, claim ids, and ovp://claim/ URIs)",
         );
+    }
+    if let Some(note) = degraded_note {
+        text.push_str("\n");
+        text.push_str(note);
     }
     Ok(serde_json::json!({ "content": [{ "type": "text", "text": text }] }))
 }

--- a/crates/ovp-mcp/src/lib.rs
+++ b/crates/ovp-mcp/src/lib.rs
@@ -391,7 +391,7 @@ fn tool_ask(state: &McpState, args: &Value) -> Result<Value, RpcError> {
     // claims-only while the report implies full evidence (codex P2).
     let (evidence, degraded_note) = match ovp_index::read_evidence(&state.vault_root) {
         Ok(e) => (Some(e), None),
-        Err(e) if !state.vault_root.join(".ovp/evidence.json").exists() => {
+        Err(e) if !ovp_index::evidence::evidence_path(&state.vault_root).exists() => {
             let _ = e;
             (
                 None,

--- a/crates/ovp-memory/src/ask.rs
+++ b/crates/ovp-memory/src/ask.rs
@@ -15,7 +15,7 @@ use ovp_index::score::lexical_score;
 use ovp_llm::{ModelClient, ModelMessage, ModelRequest};
 use serde::{Deserialize, Serialize};
 
-use crate::verify::{verify_answer, VerificationReport};
+use crate::verify::{VerificationReport, verify_answer};
 
 pub struct AskArgs {
     pub question: String,
@@ -212,7 +212,13 @@ pub fn assemble_evidence(
             score,
             tier: 0,
             item: EvidenceItem {
-                id: claim.claim_id.clone(),
+                // The STABLE ledger key when the index carries it (claim_ids
+                // can collide across runs; an answer's [claim:…] citation
+                // must audit unambiguously), claim_id for older indexes.
+                id: claim
+                    .claim_key
+                    .clone()
+                    .unwrap_or_else(|| claim.claim_id.clone()),
                 kind: EvidenceKind::Claim,
                 title: format!("{status} claim{}", optional_theme_suffix(theme)),
                 body: format!(
@@ -449,13 +455,13 @@ fn write_unique_chat(dir: &Path, ts: &str, content: &str) -> Result<PathBuf, Str
 mod tests {
     use std::sync::{Arc, Mutex};
 
-    use ovp_index::evidence::{CardEvidenceRow, EvidenceModel, UnitEvidenceRow, EVIDENCE_SCHEMA};
+    use ovp_index::evidence::{CardEvidenceRow, EVIDENCE_SCHEMA, EvidenceModel, UnitEvidenceRow};
     use ovp_index::model::{
-        ClaimRow, ClaimStatus, IndexModel, OpsState, PackRow, Totals, INDEX_SCHEMA,
+        ClaimRow, ClaimStatus, INDEX_SCHEMA, IndexModel, OpsState, PackRow, Totals,
     };
     use ovp_llm::{CallError, ModelClient, ModelReply, ModelRequest, StopReason, Usage};
 
-    use crate::ask::{ask_with_evidence, assemble_evidence, AskArgs, EvidenceKind, EvidenceQuotas};
+    use crate::ask::{AskArgs, EvidenceKind, EvidenceQuotas, ask_with_evidence, assemble_evidence};
 
     struct CapturingClient {
         request: Arc<Mutex<Option<ModelRequest>>>,
@@ -497,13 +503,14 @@ mod tests {
             }],
             claims: vec![ClaimRow {
                 claim_id: "claim-memory-1".into(),
+                claim_key: None,
                 claim: "Agent memory should be treated as persistent state.".into(),
                 theme: Some("memory".into()),
                 status: ClaimStatus::Durable,
                 sources: vec!["40-Resources/Reader/memory".into()],
                 strength: Some("supported".into()),
                 run_id: Some("run-1".into()),
-                    lane: None,
+                lane: None,
             }],
             runs: vec![],
             ops: OpsState::default(),
@@ -564,20 +571,26 @@ mod tests {
 
         assert_eq!(result.context_hits, 3);
         assert_eq!(result.evidence.len(), 3);
-        assert!(result
-            .evidence
-            .iter()
-            .any(|item| item.kind == EvidenceKind::Claim && item.id == "claim-memory-1"));
-        assert!(result
-            .evidence
-            .iter()
-            .any(|item| item.kind == EvidenceKind::Card
-                && item.id == "card:40-Resources/Reader/memory:0"));
-        assert!(result
-            .evidence
-            .iter()
-            .any(|item| item.kind == EvidenceKind::Unit
-                && item.id == "unit:40-Resources/Reader/memory:u-001"));
+        assert!(
+            result
+                .evidence
+                .iter()
+                .any(|item| item.kind == EvidenceKind::Claim && item.id == "claim-memory-1")
+        );
+        assert!(
+            result
+                .evidence
+                .iter()
+                .any(|item| item.kind == EvidenceKind::Card
+                    && item.id == "card:40-Resources/Reader/memory:0")
+        );
+        assert!(
+            result
+                .evidence
+                .iter()
+                .any(|item| item.kind == EvidenceKind::Unit
+                    && item.id == "unit:40-Resources/Reader/memory:u-001")
+        );
         let request = captured.lock().unwrap().clone().unwrap();
         assert_eq!(request.cache_namespace.as_deref(), Some("ask/v2"));
         let user = match &request.messages[0] {
@@ -631,10 +644,8 @@ mod tests {
 
     #[test]
     fn saving_two_chats_in_the_same_second_creates_two_files() {
-        let vault = std::env::temp_dir().join(format!(
-            "ovp-memory-chat-collision-{}",
-            std::process::id()
-        ));
+        let vault =
+            std::env::temp_dir().join(format!("ovp-memory-chat-collision-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&vault);
         std::fs::create_dir_all(&vault).unwrap();
 
@@ -710,9 +721,11 @@ mod tests {
             },
         );
 
-        assert!(items
-            .iter()
-            .any(|item| item.kind == EvidenceKind::Card && item.body.contains("长期状态")));
+        assert!(
+            items
+                .iter()
+                .any(|item| item.kind == EvidenceKind::Card && item.body.contains("长期状态"))
+        );
         assert!(items.iter().any(|item| {
             item.kind == EvidenceKind::Unit
                 && item

--- a/crates/ovp-memory/src/ask.rs
+++ b/crates/ovp-memory/src/ask.rs
@@ -146,7 +146,9 @@ pub fn ask_with_optional_evidence(
         messages: vec![ModelMessage::User { content: user_msg }],
         max_tokens: args.max_tokens,
         temperature: Some(0.4),
-        cache_namespace: Some("ask/v2".into()),
+        // v3: stable ck- claim citation keys + verbatim-full-key prompt rule
+        // (evolution candidate ask_citation_keys-v3).
+        cache_namespace: Some("ask/v3".into()),
     };
 
     let reply = client.call(&request).map_err(|e| format!("ask LLM: {e}"))?;
@@ -594,7 +596,7 @@ mod tests {
                     && item.id == "unit:40-Resources/Reader/memory:u-001")
         );
         let request = captured.lock().unwrap().clone().unwrap();
-        assert_eq!(request.cache_namespace.as_deref(), Some("ask/v2"));
+        assert_eq!(request.cache_namespace.as_deref(), Some("ask/v3"));
         let user = match &request.messages[0] {
             ovp_llm::ModelMessage::User { content } => content,
             ovp_llm::ModelMessage::Assistant { .. } => panic!("expected user message"),

--- a/crates/ovp-memory/src/ask.rs
+++ b/crates/ovp-memory/src/ask.rs
@@ -129,7 +129,9 @@ pub fn ask_with_optional_evidence(
 
     let system = "You are a knowledge assistant for OVP (Obsidian Vault Pipeline). \
         Answer questions using ONLY the provided claim/card/unit evidence context. \
-        Cite evidence ids in square brackets. \
+        Cite evidence with the FULL bracketed key exactly as shown in the context \
+        (e.g. [claim:ck-1a2b3c4d], [card:…], [unit:…]) — never shorten or drop the \
+        kind prefix. \
         If evidence is insufficient, say what is missing. Do not invent citations."
         .to_string();
 

--- a/crates/ovp-memory/src/verify.rs
+++ b/crates/ovp-memory/src/verify.rs
@@ -55,7 +55,7 @@ fn extract_citations(answer: &str) -> Vec<String> {
         };
         let candidate = after_start[..end].trim();
         if is_citation_candidate(candidate) {
-            out.insert(candidate.to_string());
+            out.insert(normalize_candidate(candidate));
         }
         rest = &after_start[end + 1..];
     }
@@ -76,8 +76,11 @@ pub fn citations_in_order(answer: &str) -> Vec<String> {
             break;
         };
         let candidate = after_start[..end].trim();
-        if is_citation_candidate(candidate) && seen.insert(candidate.to_string()) {
-            out.push(candidate.to_string());
+        if is_citation_candidate(candidate) {
+            let normalized = normalize_candidate(candidate);
+            if seen.insert(normalized.clone()) {
+                out.push(normalized);
+            }
         }
         rest = &after_start[end + 1..];
     }
@@ -86,10 +89,23 @@ pub fn citations_in_order(answer: &str) -> Vec<String> {
 
 fn is_citation_candidate(candidate: &str) -> bool {
     !candidate.is_empty()
-        && matches!(
-            candidate.split_once(':').map(|(prefix, _)| prefix),
-            Some("unit" | "card" | "claim")
-        )
+        && (candidate.starts_with("ck-")
+            || matches!(
+                candidate.split_once(':').map(|(prefix, _)| prefix),
+                Some("unit" | "card" | "claim")
+            ))
+}
+
+/// Canonical citation key for a bracket candidate. Models reliably shorten
+/// `[claim:ck-…]` to `[ck-…]` — the `ck-` ledger prefix is reserved and
+/// unambiguous, so a bare key normalizes to its `claim:` form instead of
+/// being dropped as a non-citation. Everything else passes through.
+fn normalize_candidate(candidate: &str) -> String {
+    if candidate.starts_with("ck-") {
+        format!("claim:{candidate}")
+    } else {
+        candidate.to_string()
+    }
 }
 
 /// The `<kind>:<id>` key an answer must use to cite this evidence item.
@@ -232,6 +248,33 @@ mod tests {
         assert_eq!(
             crate::verify::citations_in_order(answer),
             vec!["claim:b".to_string(), "unit:a".to_string()],
+        );
+    }
+
+    #[test]
+    fn bare_ck_keys_normalize_to_claim_citations() {
+        // Models reliably shorten `[claim:ck-…]` to `[ck-…]`; the reserved
+        // ck- prefix is unambiguous, so both forms verify identically.
+        let evidence = vec![EvidenceItem {
+            id: "ck-793a2f557d2be6f9".into(),
+            kind: EvidenceKind::Claim,
+            title: "durable claim".into(),
+            body: "Claim: governed forgetting is necessary.".into(),
+            quote: None,
+            path: None,
+        }];
+        let report = verify_answer(
+            "Forgetting is governed [ck-793a2f557d2be6f9], twice [claim:ck-793a2f557d2be6f9].",
+            &evidence,
+        );
+        assert_eq!(report.cited, 1, "both forms collapse to one citation");
+        assert_eq!(report.verified, 1);
+        assert!(report.missing.is_empty());
+        assert_eq!(
+            crate::verify::citations_in_order(
+                "[ck-793a2f557d2be6f9] then [claim:ck-793a2f557d2be6f9]"
+            ),
+            vec!["claim:ck-793a2f557d2be6f9".to_string()],
         );
     }
 

--- a/crates/ovp-memory/src/working_memory.rs
+++ b/crates/ovp-memory/src/working_memory.rs
@@ -142,6 +142,7 @@ mod tests {
         let claims = (0..50)
             .map(|i| ClaimRow {
                 claim_id: format!("c{i}"),
+                claim_key: None,
                 claim: "代理记忆与上下文系统：文件系统即记忆，语义检索不足以独立支撑长期记忆。".into(),
                 theme: Some("记忆与上下文".into()),
                 status: ClaimStatus::Durable,

--- a/crates/ovp-publish/src/lib.rs
+++ b/crates/ovp-publish/src/lib.rs
@@ -555,6 +555,7 @@ mod tests {
             claims: vec![
                 ClaimRow {
                     claim_id: "id-1".into(),
+                    claim_key: Some("ck-abc123".into()),
                     claim: "A durable claim.".into(),
                     theme: Some("Theme A".into()),
                     status: ClaimStatus::Durable,
@@ -565,6 +566,7 @@ mod tests {
                 },
                 ClaimRow {
                     claim_id: "id-2".into(),
+                    claim_key: None,
                     claim: "caveated".into(),
                     theme: Some("Theme A".into()),
                     status: ClaimStatus::Caveated,

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -87,8 +87,7 @@ fn ask_guard(lookup: impl Fn(&str) -> Option<String>) -> Duration {
 /// Builds the LLM client for `POST /api/ask` on demand. Injected by the CLI,
 /// which owns the feature-gated live transport and the key check — the
 /// server itself stays transport-free. `None` = ask answers 503.
-pub type AskClientFactory =
-    Arc<dyn Fn() -> Result<Box<dyn ModelClient>, String> + Send + Sync>;
+pub type AskClientFactory = Arc<dyn Fn() -> Result<Box<dyn ModelClient>, String> + Send + Sync>;
 
 pub struct ServeConfig {
     pub vault_root: PathBuf,
@@ -228,8 +227,6 @@ fn markdown_basenames(dir: &Path) -> std::collections::HashSet<String> {
     walk(dir, &mut out);
     out
 }
-
-
 
 struct AppState {
     vault_root: PathBuf,
@@ -411,7 +408,9 @@ impl AppState {
     /// reloads the instant one appears.
     fn current_evidence(&self) -> Option<EvidenceModel> {
         let path = self.evidence_path();
-        freshen(&self.evidence, &path, || read_evidence(&self.vault_root).ok())
+        freshen(&self.evidence, &path, || {
+            read_evidence(&self.vault_root).ok()
+        })
     }
 
     /// Force-reload both caches from disk regardless of mtime. `/api/refresh`
@@ -670,8 +669,7 @@ fn handle_tags_api(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
         Some(m) => m,
         None => return json_response(503, r#"{"error":"index not available"}"#),
     };
-    let vocabulary =
-        ovp_domain::tags::TagVocabulary::load(&state.vault_root).unwrap_or_default();
+    let vocabulary = ovp_domain::tags::TagVocabulary::load(&state.vault_root).unwrap_or_default();
     let mut counts: std::collections::BTreeMap<&str, (usize, usize)> =
         std::collections::BTreeMap::new();
     // Seed from the vocabulary so zero-count community/llm entries still
@@ -758,11 +756,17 @@ fn handle_tag_decision(state: &AppState, body: &str) -> Response<std::io::Cursor
     };
     let action = parsed.get("action").and_then(|v| v.as_str()).unwrap_or("");
     let alias = parsed.get("alias").and_then(|v| v.as_str()).unwrap_or("");
-    let canonical = parsed.get("canonical").and_then(|v| v.as_str()).unwrap_or("");
+    let canonical = parsed
+        .get("canonical")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
     if alias.is_empty() || canonical.is_empty() {
         return json_response(400, r#"{"error":"alias and canonical are required"}"#);
     }
-    let _write = state.tags_write_lock.lock().unwrap_or_else(|p| p.into_inner());
+    let _write = state
+        .tags_write_lock
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let mut decisions = match ovp_domain::tags::TagDecisions::load(&state.vault_root) {
         Ok(d) => d,
         Err(e) => return json_response(500, &format!(r#"{{"error":{}}}"#, json_str(&e))),
@@ -839,7 +843,10 @@ fn handle_source_tags_post(
     if tags.is_empty() {
         return json_response(400, r#"{"error":"tags must be a non-empty string array"}"#);
     }
-    let _write = state.tags_write_lock.lock().unwrap_or_else(|p| p.into_inner());
+    let _write = state
+        .tags_write_lock
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let Some(model) = state.current_model() else {
         return json_response(503, r#"{"error":"index not available"}"#);
     };
@@ -873,7 +880,13 @@ fn handle_source_tags_post(
     let text = match std::fs::read_to_string(&note_path) {
         Ok(t) => t,
         Err(e) => {
-            return json_response(500, &format!(r#"{{"error":{}}}"#, json_str(&format!("reading {rel}: {e}"))));
+            return json_response(
+                500,
+                &format!(
+                    r#"{{"error":{}}}"#,
+                    json_str(&format!("reading {rel}: {e}"))
+                ),
+            );
         }
     };
     match ovp_domain::tags::add_tags_to_frontmatter(&text, &tags) {
@@ -881,7 +894,13 @@ fn handle_source_tags_post(
             // Atomic replace with a unique temp sibling: canonical USER data,
             // not rebuildable — a crash mid-write must never truncate the note.
             if let Err(e) = ovp_domain::tags::write_atomic(&note_path, &updated) {
-                return json_response(500, &format!(r#"{{"error":{}}}"#, json_str(&format!("writing {rel}: {e}"))));
+                return json_response(
+                    500,
+                    &format!(
+                        r#"{{"error":{}}}"#,
+                        json_str(&format!("writing {rel}: {e}"))
+                    ),
+                );
             }
             // Editing a QUEUED note changes its content hash → the rebuilt
             // index keys it under a NEW sha. Report the row now living at
@@ -896,7 +915,10 @@ fn handle_source_tags_post(
                         .unwrap_or_else(|| sha.to_string());
                     json_response(
                         200,
-                        &format!(r#"{{"ok":true,"changed":true,"sha":{}}}"#, json_str(&new_sha)),
+                        &format!(
+                            r#"{{"ok":true,"changed":true,"sha":{}}}"#,
+                            json_str(&new_sha)
+                        ),
                     )
                 }
                 Err(e) => json_response(500, &format!(r#"{{"error":{}}}"#, json_str(&e))),
@@ -1227,7 +1249,11 @@ fn handle_entities_api(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
     let Some(model) = state.current_model() else {
         return json_response(503, r#"{"error":"index not available"}"#);
     };
-    json_stamped(200, &bodies::entities_body(&model).to_string(), Some(&model))
+    json_stamped(
+        200,
+        &bodies::entities_body(&model).to_string(),
+        Some(&model),
+    )
 }
 
 /// `GET /api/entity/:id` — one entity's mentioning sources + citing claims.
@@ -1292,15 +1318,22 @@ fn handle_source_api(state: &AppState, url: &str) -> Response<std::io::Cursor<Ve
     // Read the doc via the shared reader (needs the source's rel_path). The
     // live server ships the full markdown; the publisher passes `None` for a
     // lite page. Missing sha → None doc → 404 from the builder below.
-    let doc = model.sources.iter().find(|s| s.sha256 == sha).map(|source| {
-        let (markdown, truncated, error) =
-            readers::read_source_doc(&state.vault_root, &state.layout, source.rel_path.as_deref());
-        bodies::SourceDoc {
-            markdown,
-            truncated,
-            error,
-        }
-    });
+    let doc = model
+        .sources
+        .iter()
+        .find(|s| s.sha256 == sha)
+        .map(|source| {
+            let (markdown, truncated, error) = readers::read_source_doc(
+                &state.vault_root,
+                &state.layout,
+                source.rel_path.as_deref(),
+            );
+            bodies::SourceDoc {
+                markdown,
+                truncated,
+                error,
+            }
+        });
 
     let evidence = state.current_evidence();
     match bodies::source_body(&model, evidence.as_ref(), &sha, doc) {
@@ -1454,7 +1487,10 @@ fn guard_json_same_origin(headers: &AskHeaders) -> Option<Response<std::io::Curs
     if let Some(origin) = headers.origin.as_deref()
         && !is_loopback_origin(origin)
     {
-        return Some(json_response(403, r#"{"error":"cross-origin write rejected"}"#));
+        return Some(json_response(
+            403,
+            r#"{"error":"cross-origin write rejected"}"#,
+        ));
     }
     None
 }
@@ -1593,7 +1629,7 @@ fn ask_response_json(model: &IndexModel, result: &AskResult) -> serde_json::Valu
                     "kind": kind_str(item.kind),
                     "title": item.title,
                     "snippet": citation_snippet(item),
-                    "link_target": citation_link(item, &pack_sha),
+                    "link_target": citation_link(item, &pack_sha, model),
                     "verified": verified,
                 }),
                 // Cited but never supplied as evidence — surfaced so the UI
@@ -1660,9 +1696,26 @@ fn citation_snippet(item: &EvidenceItem) -> String {
 
 /// Portal deep link for a citation (or None — the sha-guard: legacy packs
 /// without a source sha must not produce a dead `/library/...` link).
-fn citation_link(item: &EvidenceItem, pack_sha: &HashMap<&str, &str>) -> Option<String> {
+fn citation_link(
+    item: &EvidenceItem,
+    pack_sha: &HashMap<&str, &str>,
+    model: &IndexModel,
+) -> Option<String> {
     match item.kind {
-        EvidenceKind::Claim => Some(format!("/knowledge#{}", item.id)),
+        EvidenceKind::Claim => {
+            // Claim evidence ids are now the STABLE ck- ledger key, but the
+            // portal's claim-card anchors are keyed by claim_id — resolve the
+            // key back through the model so the link lands on the card
+            // instead of an unknown anchor (codex P1). Older indexes (no
+            // claim_key) pass the id through unchanged.
+            let anchor = model
+                .claims
+                .iter()
+                .find(|c| c.claim_key.as_deref() == Some(item.id.as_str()))
+                .map(|c| c.claim_id.as_str())
+                .unwrap_or(item.id.as_str());
+            Some(format!("/knowledge#{anchor}"))
+        }
         EvidenceKind::Card | EvidenceKind::Unit => {
             let pack_dir = item.path.as_deref()?.strip_suffix("/reader.md")?;
             let sha = pack_sha.get(pack_dir)?;
@@ -1841,12 +1894,13 @@ fn resolve_static(state: &AppState, url_path: &str) -> Resolved {
     }
 
     if is_client_route(relative)
-        && let Some(body) = read_app_file(state, "index.html") {
-            return Resolved::File {
-                body,
-                content_type: "text/html; charset=utf-8",
-            };
-        }
+        && let Some(body) = read_app_file(state, "index.html")
+    {
+        return Resolved::File {
+            body,
+            content_type: "text/html; charset=utf-8",
+        };
+    }
 
     Resolved::NotFound
 }
@@ -2031,7 +2085,9 @@ mod tests {
         assert!(!terrain_shape_ok(r#"{"schema":"ovp.crystal.terrain/v1"}"#)); // no points
         assert!(!terrain_shape_ok(r#"{"points":[]}"#)); // no schema
         assert!(!terrain_shape_ok(r#"{"schema":"other","points":[]}"#)); // wrong schema
-        assert!(!terrain_shape_ok(r#"{"schema":"ovp.crystal.terrain/v1","points":{}}"#)); // points not array
+        assert!(!terrain_shape_ok(
+            r#"{"schema":"ovp.crystal.terrain/v1","points":{}}"#
+        )); // points not array
         assert!(!terrain_shape_ok("{truncated")); // unparseable
     }
 
@@ -2057,15 +2113,12 @@ mod tests {
             ask_timeout: Duration::from_secs(60),
             ask_slots: AskSlots::new(DEFAULT_MAX_CONCURRENT_ASKS),
             live_queued: RwLock::new(LiveQueued::default()),
-        tags_write_lock: std::sync::Mutex::new(()),
+            tags_write_lock: std::sync::Mutex::new(()),
         }
     }
 
     /// Read a response header value (test helper).
-    fn header_value(
-        resp: &Response<std::io::Cursor<Vec<u8>>>,
-        name: &str,
-    ) -> String {
+    fn header_value(resp: &Response<std::io::Cursor<Vec<u8>>>, name: &str) -> String {
         resp.headers()
             .iter()
             .find(|h| h.field.as_str().as_str().eq_ignore_ascii_case(name))
@@ -2073,7 +2126,7 @@ mod tests {
             .unwrap_or_default()
     }
 
-        /// A ModelClient that replies with a fixed answer (or blocks) — the
+    /// A ModelClient that replies with a fixed answer (or blocks) — the
     /// /api/ask tests never touch a real transport.
     struct ScriptedClient {
         text: String,
@@ -2723,13 +2776,19 @@ mod tests {
         // P1 provenance: the instant, its producer, and a non-negative age.
         assert_eq!(v["built_at"], "2026-07-09T00:00:00Z");
         assert_eq!(v["run_id"], "daily-2026-07-09");
-        assert!(v["age_seconds"].as_i64().unwrap() >= 0, "age is present and non-negative");
+        assert!(
+            v["age_seconds"].as_i64().unwrap() >= 0,
+            "age is present and non-negative"
+        );
         assert_eq!(v["counts"]["sources"], 1);
         assert_eq!(v["counts"]["packs"], 1);
         assert!(v["counts"]["claims"].is_u64());
         assert_eq!(v["llm_configured"], false);
         assert_eq!(v["ask_limits"]["timeout_secs"], st.ask_timeout.as_secs());
-        assert_eq!(v["ask_limits"]["max_concurrent"], DEFAULT_MAX_CONCURRENT_ASKS);
+        assert_eq!(
+            v["ask_limits"]["max_concurrent"],
+            DEFAULT_MAX_CONCURRENT_ASKS
+        );
         assert_eq!(v["version"], env!("CARGO_PKG_VERSION"));
 
         // With an ask client the flag flips.
@@ -2823,7 +2882,10 @@ mod tests {
         st.live_queued.write().unwrap().computed_at = None;
 
         let v = body_json(dispatch(&st, Method::Get, "/api/settings", ""));
-        assert_eq!(v["queued_live"], 2, "live count ticked down as 01-Raw drained");
+        assert_eq!(
+            v["queued_live"], 2,
+            "live count ticked down as 01-Raw drained"
+        );
         assert_eq!(
             v["queued_at_build"], 4,
             "projection stays frozen — the whole point of the live overlay"
@@ -2832,7 +2894,10 @@ mod tests {
         // /api/model carries the same live overlay while totals.queued stays 4.
         let m = body_json(dispatch(&st, Method::Get, "/api/model", ""));
         assert_eq!(m["queued_live"], 2);
-        assert_eq!(m["totals"]["queued"], 4, "projection value untouched for other readers");
+        assert_eq!(
+            m["totals"]["queued"], 4,
+            "projection value untouched for other readers"
+        );
         assert_eq!(m["queued_at_build"], 4);
 
         let _ = std::fs::remove_dir_all(&root);
@@ -2901,12 +2966,18 @@ mod tests {
         }
         let mut baked = index_dated("2026-07-12");
         baked.sources = sources;
-        baked.totals = Totals { queued: 2, ..Default::default() };
+        baked.totals = Totals {
+            queued: 2,
+            ..Default::default()
+        };
         ovp_index::write_index(&vault, &baked).unwrap();
 
         let st = state(vault, None);
         let live = st.live_queued_count(st.current_model().as_ref());
-        assert_eq!(live, 2, "the 3 departed Processed rows must NOT be subtracted");
+        assert_eq!(
+            live, 2,
+            "the 3 departed Processed rows must NOT be subtracted"
+        );
     }
 
     #[test]
@@ -2922,7 +2993,11 @@ mod tests {
         for f in ["q0.md", "q1.md", "q2.md", "blocked.md", "dup.md", "proc.md"] {
             std::fs::write(raw.join(f), "body\n").unwrap();
         }
-        assert_eq!(markdown_basenames(&raw).len(), 6, "6 files physically present");
+        assert_eq!(
+            markdown_basenames(&raw).len(),
+            6,
+            "6 files physically present"
+        );
 
         // Projection mirroring what build_sources would classify for these
         // files: 3 Queued, 1 Blocked, 1 Duplicate — all rel_path under 01-Raw.
@@ -2941,12 +3016,18 @@ mod tests {
             .count();
         let mut baked = index_dated("2026-07-12");
         baked.sources = sources;
-        baked.totals = Totals { queued, ..Default::default() };
+        baked.totals = Totals {
+            queued,
+            ..Default::default()
+        };
         ovp_index::write_index(&vault, &baked).unwrap();
 
         let st = state(vault.clone(), None);
         let live = st.live_queued_count(st.current_model().as_ref());
-        assert_eq!(live, 3, "6 files − (blocked + dup + processed-in-raw) = 3 queued");
+        assert_eq!(
+            live, 3,
+            "6 files − (blocked + dup + processed-in-raw) = 3 queued"
+        );
         assert_eq!(
             live,
             st.current_model().unwrap().totals.queued,
@@ -2981,7 +3062,10 @@ mod tests {
             raw_source("h1", SourceStatus::Queued, "q1.md"),
             raw_source("hb", SourceStatus::Blocked, "blocked.md"),
         ];
-        baked.totals = Totals { queued: 2, ..Default::default() };
+        baked.totals = Totals {
+            queued: 2,
+            ..Default::default()
+        };
         ovp_index::write_index(&vault, &baked).unwrap();
         let st = state(vault.clone(), None);
 
@@ -3008,20 +3092,36 @@ mod tests {
 
     #[test]
     fn model_endpoint_carries_built_at_run_id_and_age() {
-        let vault = portal_vault("model-provenance", "50-Inbox/03-Processed/good.md", "body\n");
+        let vault = portal_vault(
+            "model-provenance",
+            "50-Inbox/03-Processed/good.md",
+            "body\n",
+        );
         let st = state(vault.clone(), None);
 
         let resp = dispatch(&st, Method::Get, "/api/model", "");
         assert_eq!(resp.status_code(), 200);
         // Provenance headers pair the body with the build that produced it.
-        assert_eq!(header_of(&resp, "X-OVP-Built-At").as_deref(), Some("2026-07-09T00:00:00Z"));
-        assert_eq!(header_of(&resp, "X-OVP-Run-Id").as_deref(), Some("daily-2026-07-09"));
-        assert!(header_of(&resp, "X-OVP-Age-Seconds").is_some(), "age header present");
+        assert_eq!(
+            header_of(&resp, "X-OVP-Built-At").as_deref(),
+            Some("2026-07-09T00:00:00Z")
+        );
+        assert_eq!(
+            header_of(&resp, "X-OVP-Run-Id").as_deref(),
+            Some("daily-2026-07-09")
+        );
+        assert!(
+            header_of(&resp, "X-OVP-Age-Seconds").is_some(),
+            "age header present"
+        );
 
         let v = body_json(resp);
         assert_eq!(v["built_at"], "2026-07-09T00:00:00Z");
         assert_eq!(v["run_id"], "daily-2026-07-09");
-        assert!(v["age_seconds"].as_i64().unwrap() >= 0, "server-computed age spliced in");
+        assert!(
+            v["age_seconds"].as_i64().unwrap() >= 0,
+            "server-computed age spliced in"
+        );
 
         let _ = std::fs::remove_dir_all(vault.parent().unwrap());
     }
@@ -3040,14 +3140,20 @@ mod tests {
         let resp = dispatch(&st, Method::Get, "/api/claim/a", "");
         assert_eq!(resp.status_code(), 200);
         // Response is paired with the projection it resolved against.
-        assert_eq!(header_of(&resp, "X-OVP-Built-At").as_deref(), Some("2026-07-09T00:00:00Z"));
+        assert_eq!(
+            header_of(&resp, "X-OVP-Built-At").as_deref(),
+            Some("2026-07-09T00:00:00Z")
+        );
         let v = body_json(resp);
         assert_eq!(v["claim_id"], "a");
         let cit = &v["citations"][0];
         assert_eq!(cit["case_id"], "good");
         // The fresh source's metadata resolved from the SAME-freshness index —
         // NOT a dangling citation (case `good` → sha aaaa1111 via the pack).
-        assert_eq!(cit["source_sha256"], "aaaa1111", "source sha resolved from the index");
+        assert_eq!(
+            cit["source_sha256"], "aaaa1111",
+            "source sha resolved from the index"
+        );
         assert_eq!(cit["source_title"], "Good Article", "source title resolved");
         assert_eq!(cit["source_url"], "https://example.com/good");
 
@@ -3069,11 +3175,17 @@ mod tests {
 
         let html = dispatch(&st, Method::Get, "/", "");
         let hv = header_value(&html, "Cache-Control");
-        assert!(hv.contains("no-cache"), "index.html must not be cached, got {hv:?}");
+        assert!(
+            hv.contains("no-cache"),
+            "index.html must not be cached, got {hv:?}"
+        );
 
         let js = dispatch(&st, Method::Get, "/assets/index-abc123.js", "");
         let jv = header_value(&js, "Cache-Control");
-        assert!(jv.contains("immutable"), "hashed asset should be immutable, got {jv:?}");
+        assert!(
+            jv.contains("immutable"),
+            "hashed asset should be immutable, got {jv:?}"
+        );
     }
 
     #[test]
@@ -3096,12 +3208,18 @@ mod tests {
         }
 
         // Non-API client routes still reach the SPA shell…
-        assert_eq!(dispatch(&st, Method::Get, "/library", "").status_code(), 200);
+        assert_eq!(
+            dispatch(&st, Method::Get, "/library", "").status_code(),
+            200
+        );
         // …exact API routes keep working even with a query string…
         let resp = dispatch(&st, Method::Get, "/api/refresh?x=1", "");
         assert_eq!(resp.status_code(), 200);
         // …and non-GET stays 405.
-        assert_eq!(dispatch(&st, Method::Post, "/api/model", "").status_code(), 405);
+        assert_eq!(
+            dispatch(&st, Method::Post, "/api/model", "").status_code(),
+            405
+        );
 
         let _ = std::fs::remove_dir_all(&root);
     }
@@ -3278,7 +3396,12 @@ mod tests {
 
         // Not JSON / wrong shape / blank question — all 400 with a JSON
         // error, and all checked BEFORE the llm-config 503.
-        for body in ["not json", "{}", r#"{"question":"   "}"#, r#"{"question":7}"#] {
+        for body in [
+            "not json",
+            "{}",
+            r#"{"question":"   "}"#,
+            r#"{"question":7}"#,
+        ] {
             let resp = ask(&st, body);
             assert_eq!(resp.status_code(), 400, "body {body}");
             let v = body_json(resp);
@@ -3290,10 +3413,7 @@ mod tests {
             r#"{{"question":"{}"}}"#,
             "x".repeat(MAX_POST_BODY_BYTES + 10)
         );
-        assert_eq!(
-            ask(&st, &huge).status_code(),
-            400
-        );
+        assert_eq!(ask(&st, &huge).status_code(), 400);
 
         let _ = std::fs::remove_dir_all(vault.parent().unwrap());
     }
@@ -3337,7 +3457,12 @@ mod tests {
 
         // The chat was saved like `ovp2 ask --save` and is listed + readable.
         let chat = v["chat"].as_str().expect("chat name").to_string();
-        assert!(vault.join(".ovp/chats").join(format!("{chat}.md")).is_file());
+        assert!(
+            vault
+                .join(".ovp/chats")
+                .join(format!("{chat}.md"))
+                .is_file()
+        );
 
         let list = body_json(dispatch(&st, Method::Get, "/api/chats", ""));
         let rows = list.as_array().unwrap();
@@ -3480,11 +3605,7 @@ mod tests {
         let state = Arc::new(st);
 
         let server = Arc::new(Server::http("127.0.0.1:0").expect("bind ephemeral port"));
-        let port = server
-            .server_addr()
-            .to_ip()
-            .expect("ip listener")
-            .port();
+        let port = server.server_addr().to_ip().expect("ip listener").port();
         {
             let server = Arc::clone(&server);
             let state = Arc::clone(&state);
@@ -3835,7 +3956,10 @@ mod tests {
         // /api/model overlays the live sidecar over the baked "running".
         let live = st.model_with_live_last_run().unwrap();
         let lr = live.ops.last_run.expect("live last_run present");
-        assert_eq!(lr.status, "completed", "must reflect the finalized sidecar, not baked 'running'");
+        assert_eq!(
+            lr.status, "completed",
+            "must reflect the finalized sidecar, not baked 'running'"
+        );
         assert_eq!(lr.processed, Some(8));
 
         // /api/settings reads the same live value.
@@ -3876,7 +4000,10 @@ mod tests {
         ovp_index::write_index(&vault, &baked).unwrap();
 
         let live = st.model_with_live_last_run().unwrap();
-        assert!(live.ops.last_run.is_none(), "no sidecar → live overlay is None, not the stale baked snapshot");
+        assert!(
+            live.ops.last_run.is_none(),
+            "no sidecar → live overlay is None, not the stale baked snapshot"
+        );
 
         let _ = std::fs::remove_dir_all(&root);
     }
@@ -3922,10 +4049,16 @@ mod tests {
         );
         assert_eq!(resp.status_code(), 200);
         assert!(vault.join(".ovp/tags/decisions.toml").exists());
-        assert!(!vault.join(".ovp/tags/aliases.toml").exists(), "operator file untouched");
+        assert!(
+            !vault.join(".ovp/tags/aliases.toml").exists(),
+            "operator file untouched"
+        );
         let v = body_json(dispatch(&st, Method::Get, "/api/tags", ""));
         assert_eq!(v["tags"][0]["tag"], "agent", "merge applied on rebuild");
-        assert!(v["proposals"].as_array().unwrap().is_empty(), "decided card retired");
+        assert!(
+            v["proposals"].as_array().unwrap().is_empty(),
+            "decided card retired"
+        );
 
         // POST reject: the card retires IMMEDIATELY (proposals.json is only
         // regenerated by tags-suggest, so /api/tags must filter decisions).
@@ -3942,7 +4075,10 @@ mod tests {
         );
         assert_eq!(resp.status_code(), 200);
         let v = body_json(dispatch(&st, Method::Get, "/api/tags", ""));
-        assert!(v["proposals"].as_array().unwrap().is_empty(), "rejected card retired");
+        assert!(
+            v["proposals"].as_array().unwrap().is_empty(),
+            "rejected card retired"
+        );
 
         // POST source tags: the one sanctioned frontmatter write. Editing a
         // QUEUED note changes its content hash — the response must carry the
@@ -3969,8 +4105,13 @@ mod tests {
             400
         );
         assert_eq!(
-            dispatch(&st, Method::Post, "/api/source/nope/tags", r#"{"tags":["x"]}"#)
-                .status_code(),
+            dispatch(
+                &st,
+                Method::Post,
+                "/api/source/nope/tags",
+                r#"{"tags":["x"]}"#
+            )
+            .status_code(),
             404
         );
 

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -2310,6 +2310,7 @@ mod tests {
             }],
             claims: vec![ClaimRow {
                 claim_id: "c01".into(),
+                claim_key: None,
                 claim: "Filesystem works as memory.".into(),
                 theme: Some("memory".into()),
                 status: ClaimStatus::Durable,

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -1707,13 +1707,21 @@ fn citation_link(
             // portal's claim-card anchors are keyed by claim_id — resolve the
             // key back through the model so the link lands on the card
             // instead of an unknown anchor (codex P1). Older indexes (no
-            // claim_key) pass the id through unchanged.
+            // claim_key) pass the id through unchanged. When the RESOLVED
+            // claim_id is shared by several rows the anchor is ambiguous and
+            // could open the wrong claim — no link then (round-3 P1; the
+            // citation stays visible and auditable, just unclickable — same
+            // degradation the theme-page chips use).
             let anchor = model
                 .claims
                 .iter()
                 .find(|c| c.claim_key.as_deref() == Some(item.id.as_str()))
                 .map(|c| c.claim_id.as_str())
                 .unwrap_or(item.id.as_str());
+            let occurrences = model.claims.iter().filter(|c| c.claim_id == anchor).count();
+            if occurrences > 1 {
+                return None;
+            }
             Some(format!("/knowledge#{anchor}"))
         }
         EvidenceKind::Card | EvidenceKind::Unit => {

--- a/evolution/candidates/ask_citation_keys-v3.json
+++ b/evolution/candidates/ask_citation_keys-v3.json
@@ -1,0 +1,21 @@
+{
+  "kind": "ovp.evolution.candidate/v1",
+  "id": "ask_citation_keys-v3",
+  "base_version": "v2",
+  "target_version": "v3",
+  "surface": "prompt",
+  "component": "prompt.ask",
+  "hypothesis": "Citing claims by their STABLE ledger key (ck-…, via ClaimRow.claim_key) instead of the collision-prone claim_id, plus a system-prompt rule demanding the full bracketed key verbatim and tokenizer normalization of the bare [ck-…] form models reliably produce, makes every claim citation in an ask answer unambiguously auditable (MCP `claim` tool, portal claim links) without losing verification recall. Predicted: citation-ID resolution rate on real-vault asks >= the v2 baseline (v2 live sample: claim ids resolved but card ids were shortened and lost; v3 live sample: 3/3 resolved), and zero ambiguous-claim audit dead-ends.",
+  "predicted_delta": {
+    "citation_auditability": "every [claim:…] citation resolves to exactly one ledger record via claim_key",
+    "verification_recall": ">= v2 (bare ck- forms normalize instead of dropping to 0 citations)"
+  },
+  "guardrails": {},
+  "eval_plan": {
+    "replay_set": "real-vault asks 2026-07-20 (.run/theme-pages-tp1/mcp-ask-*.log): v3 first live sample 3/3 citations resolved vs a v2 sample where the model's shortened forms left citations unresolved",
+    "paired_sources": 2,
+    "soak": false
+  },
+  "rollback": "Revert the ask/v3 namespace to ask/v2 and drop the claim_key preference in assemble_evidence (EvidenceItem.id falls back to claim_id); ClaimRow.claim_key is additive and can stay. Cassettes are namespaced, so v2 replies remain replayable.",
+  "ablation_required": false
+}

--- a/evolution/candidates/ask_citation_keys-v3.json
+++ b/evolution/candidates/ask_citation_keys-v3.json
@@ -5,7 +5,7 @@
   "target_version": "v3",
   "surface": "prompt",
   "component": "prompt.ask",
-  "hypothesis": "Citing claims by their STABLE ledger key (ck-…, via ClaimRow.claim_key) instead of the collision-prone claim_id, plus a system-prompt rule demanding the full bracketed key verbatim and tokenizer normalization of the bare [ck-…] form models reliably produce, makes every claim citation in an ask answer unambiguously auditable (MCP `claim` tool, portal claim links) without losing verification recall. Predicted: citation-ID resolution rate on real-vault asks >= the v2 baseline (v2 live sample: claim ids resolved but card ids were shortened and lost; v3 live sample: 3/3 resolved), and zero ambiguous-claim audit dead-ends.",
+  "hypothesis": "PROMPT surface only: adding the system-prompt rule 'cite the FULL bracketed key exactly as shown, never shorten or drop the kind prefix' raises citation-format compliance for the ck- claim keys the v3 evidence ids carry. Predicted: citation-ID resolution rate on real-vault asks >= the v2 baseline (v3 first live sample: 3/3 resolved vs a v2 sample where shortened forms left citations unresolved). Companion candidates cover the non-prompt surfaces: ask_verify_tokenizer-v1 (parser normalization of bare [ck-…]), claim_key_plumbing-v1 (index/runtime key routing).",
   "predicted_delta": {
     "citation_auditability": "every [claim:…] citation resolves to exactly one ledger record via claim_key",
     "verification_recall": ">= v2 (bare ck- forms normalize instead of dropping to 0 citations)"

--- a/evolution/candidates/ask_verify_tokenizer-v1.json
+++ b/evolution/candidates/ask_verify_tokenizer-v1.json
@@ -1,0 +1,20 @@
+{
+  "kind": "ovp.evolution.candidate/v1",
+  "id": "ask_verify_tokenizer-v1",
+  "base_version": "none",
+  "target_version": "v1",
+  "surface": "parser",
+  "component": "parser.ask_verify",
+  "hypothesis": "PARSER surface only: normalizing the bare [ck-…] bracket form (a reserved, unambiguous ledger prefix) to its claim: citation key in BOTH shared tokenizers (verify_answer + citations_in_order, mirrored in the AskPage regex) recovers citations models reliably shorten, instead of honestly-but-uselessly reporting 0 citations. Predicted: verification recall >= baseline with zero false citations (ck- cannot collide with prose brackets).",
+  "predicted_delta": {
+    "verification_recall": "bare-key answers report their true citation count instead of 0"
+  },
+  "guardrails": {},
+  "eval_plan": {
+    "replay_set": "real-vault ask 2026-07-20: identical question, pre-normalization sample reported 0 citations (no_citations warning), post 3/3 resolved",
+    "paired_sources": 2,
+    "soak": false
+  },
+  "rollback": "Revert normalize_candidate to a pass-through and drop the ck- arm in is_citation_candidate (plus the AskPage regex alternative); strict-prefix-only tokenizing returns.",
+  "ablation_required": false
+}

--- a/evolution/candidates/claim_key_plumbing-v1.json
+++ b/evolution/candidates/claim_key_plumbing-v1.json
@@ -1,0 +1,20 @@
+{
+  "kind": "ovp.evolution.candidate/v1",
+  "id": "claim_key_plumbing-v1",
+  "base_version": "none",
+  "target_version": "v1",
+  "surface": "runtime",
+  "component": "runtime.claim_citation_keys",
+  "hypothesis": "RUNTIME/INDEX surface only: carrying the ledger's deterministic claim_key on ClaimRow (additive) and preferring it as the claim evidence id makes every ask claim citation resolve to exactly one ledger record (claim_ids can collide across runs), with portal links resolving the key back to an unambiguous claim_id anchor and degrading to no-link when the anchor is shared. Predicted: zero ambiguous-claim audit dead-ends via the MCP claim tool, no wrong-card navigations from ask citations.",
+  "predicted_delta": {
+    "citation_auditability": "every [claim:…] citation resolves to exactly one ledger record via claim_key"
+  },
+  "guardrails": {},
+  "eval_plan": {
+    "replay_set": "real-vault index rebuild 2026-07-20 (465 durable claims all carrying claim_key) + MCP ask live samples in .run/theme-pages-tp1/",
+    "paired_sources": 2,
+    "soak": false
+  },
+  "rollback": "Drop the claim_key preference in assemble_evidence (id falls back to claim_id) and the citation_link key-resolution branch; ClaimRow.claim_key is additive and harmless to leave in place.",
+  "ablation_required": false
+}

--- a/evolution/components.json
+++ b/evolution/components.json
@@ -5,89 +5,143 @@
       "surface": "prompt",
       "current_version": "v5",
       "file": "crates/ovp-domain/prompts/unit_extraction.md",
-      "quality_buckets": ["extraction_fidelity", "coverage"],
-      "regression_fixtures": ["fixtures/reader/m14a-coverage-set/"]
+      "quality_buckets": [
+        "extraction_fidelity",
+        "coverage"
+      ],
+      "regression_fixtures": [
+        "fixtures/reader/m14a-coverage-set/"
+      ]
     },
     {
       "id": "prompt.unit_critic",
       "surface": "prompt",
       "current_version": "v1",
       "file": "crates/ovp-domain/prompts/unit_critic.md",
-      "quality_buckets": ["extraction_fidelity"]
+      "quality_buckets": [
+        "extraction_fidelity"
+      ]
     },
     {
       "id": "prompt.card_synth",
       "surface": "prompt",
       "current_version": "v3",
       "file": "crates/ovp-domain/prompts/card_synthesis.md",
-      "quality_buckets": ["card_quality", "coverage"]
+      "quality_buckets": [
+        "card_quality",
+        "coverage"
+      ]
     },
     {
       "id": "runtime.web_fetch",
       "surface": "runtime",
       "file": "crates/ovp-enrich/src/web_fetch.rs",
-      "quality_buckets": ["operational_reliability"]
+      "quality_buckets": [
+        "operational_reliability"
+      ]
     },
     {
       "id": "gate.crystal_lint",
       "surface": "gate",
       "file": "crates/ovp-cli/src/commands/crystal_lint.rs",
-      "quality_buckets": ["crystal_provenance"]
+      "quality_buckets": [
+        "crystal_provenance"
+      ]
     },
     {
       "id": "prompt.crystal_synth",
       "surface": "prompt",
       "current_version": "v1",
       "file": "crates/ovp-domain/prompts/crystal_synth.md",
-      "quality_buckets": ["crystal_provenance", "coverage"]
+      "quality_buckets": [
+        "crystal_provenance",
+        "coverage"
+      ]
     },
     {
       "id": "prompt.crystal_strength",
       "surface": "prompt",
       "current_version": "v1",
       "file": "crates/ovp-domain/prompts/crystal_strength.md",
-      "quality_buckets": ["crystal_provenance"]
+      "quality_buckets": [
+        "crystal_provenance"
+      ]
     },
     {
       "id": "prompt.cluster_select",
       "surface": "prompt",
       "current_version": "v1",
       "file": "crates/ovp-domain/prompts/cluster_select.md",
-      "quality_buckets": ["crystal_provenance", "coverage"]
+      "quality_buckets": [
+        "crystal_provenance",
+        "coverage"
+      ]
     },
     {
       "id": "prompt.theme_label",
       "surface": "prompt",
       "current_version": "v1",
       "file": "crates/ovp-domain/prompts/theme_label.md",
-      "quality_buckets": ["card_quality"]
+      "quality_buckets": [
+        "card_quality"
+      ]
     },
     {
       "id": "prompt.ask",
       "surface": "prompt",
       "current_version": "v3",
       "file": "crates/ovp-memory/src/ask.rs",
-      "quality_buckets": ["crystal_provenance", "operational_reliability"]
+      "quality_buckets": [
+        "crystal_provenance",
+        "operational_reliability"
+      ]
     },
     {
       "id": "prompt.theme_page",
       "surface": "prompt",
       "current_version": "v1",
       "file": "crates/ovp-domain/prompts/theme_page.md",
-      "quality_buckets": ["crystal_provenance", "coverage"]
+      "quality_buckets": [
+        "crystal_provenance",
+        "coverage"
+      ]
     },
     {
       "id": "parser.json_repair",
       "surface": "parser",
       "file": "crates/ovp-domain/src/units/parser.rs",
-      "quality_buckets": ["operational_reliability", "extraction_fidelity"]
+      "quality_buckets": [
+        "operational_reliability",
+        "extraction_fidelity"
+      ]
     },
     {
       "id": "runtime.scheduler",
       "surface": "runtime",
       "current_version": "v1",
       "file": "crates/ovp-scheduler/src/lib.rs",
-      "quality_buckets": ["operational_reliability"]
+      "quality_buckets": [
+        "operational_reliability"
+      ]
+    },
+    {
+      "id": "parser.ask_verify",
+      "surface": "parser",
+      "current_version": "v1",
+      "file": "crates/ovp-memory/src/verify.rs",
+      "quality_buckets": [
+        "crystal_provenance",
+        "operational_reliability"
+      ]
+    },
+    {
+      "id": "runtime.claim_citation_keys",
+      "surface": "runtime",
+      "current_version": "v1",
+      "file": "crates/ovp-index/src/model.rs",
+      "quality_buckets": [
+        "crystal_provenance"
+      ]
     }
   ]
 }

--- a/evolution/components.json
+++ b/evolution/components.json
@@ -63,6 +63,13 @@
       "quality_buckets": ["card_quality"]
     },
     {
+      "id": "prompt.ask",
+      "surface": "prompt",
+      "current_version": "v3",
+      "file": "crates/ovp-memory/src/ask.rs",
+      "quality_buckets": ["crystal_provenance", "operational_reliability"]
+    },
+    {
       "id": "prompt.theme_page",
       "surface": "prompt",
       "current_version": "v1",


### PR DESCRIPTION
Completes P1 (MCP hardening): the `ask` tool ships, and the citation layer it exposed gets hardened platform-wide.

## ask over MCP
- Same evidence pipeline as POST /api/ask (lexical retrieval over durable claims + cards + verbatim units), answer returned WITH its deterministic verification report (citation-ID resolution — described honestly, not oversold as per-sentence grounding) and the audit hint into the `claim` tool.
- Client injection mirrors serve's ask_client factory (anthropic feature + ANTHROPIC_API_KEY, shared ask cassettes, startup validation on stderr). Unconfigured → explicit error, so an agent can tell 'no LLM wired' from 'no answer in vault'. Retrieval filtered to ACTIVE DURABLE claims; corrupt evidence sidecar errors, missing one degrades with a note.

## Stable citation keys (3 governed surfaces, one candidate each)
- **runtime** `claim_key_plumbing-v1`: ClaimRow carries the ledger's deterministic ck- key (additive); ask claim evidence ids prefer it — claim_ids can collide across runs, keys cannot. Portal links resolve the key back to a claim_id anchor and degrade to no-link when the anchor is shared.
- **parser** `ask_verify_tokenizer-v1`: models reliably shorten [claim:ck-…] to [ck-…]; both shared tokenizers (and AskPage's regex) normalize the reserved ck- form instead of reporting 0 citations.
- **prompt** `ask_citation_keys-v3`: full-bracketed-key-verbatim rule; cassette namespace bumped ask/v2 → ask/v3.

## Verification
- Workspace 1047 tests green; console-ui build + 38 vitest.
- Real vault end-to-end over stdio JSON-RPC: first live sample under the old ids left citations unresolved; after the key plumbing + normalization, **3/3 citations resolved**, cited keys audit via `claim`/`ovp://claim/`.
- 3 codex rounds (2P1+2P2 → 1P1+3P2 → 1P1+1P2), all findings fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Ask tool for MCP integrations, returning answers with citation verification summaries.
  * Claim citations now use stable keys for more reliable evidence resolution and portal links.
  * Ask supports claims-only responses when optional evidence is unavailable.

* **Bug Fixes**
  * Improved recognition of citation formats, including bare claim keys.
  * Prevented incorrect links when citation targets are ambiguous.
  * Added clearer configuration errors when the Ask service is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->