### PR TITLE
feat(publish,providers): P2 — publish.toml, portal publish button, providers.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2920,6 +2920,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
+ "toml 0.8.2",
 ]
 
 [[package]]
@@ -3005,6 +3006,7 @@ dependencies = [
  "ovp-intake",
  "ovp-llm",
  "ovp-memory",
+ "ovp-publish",
  "serde",
  "serde_json",
  "tiny_http",

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -121,17 +121,12 @@ fn resolve_viz_dir(app: &AppHandle) -> PathBuf {
 /// left unconfigured for now (POST /api/ask answers 503) — read/query/portal all
 /// work; live ask is wired in a later stage.
 fn start_server(vault: PathBuf, viz_dir: PathBuf) -> Result<String, String> {
-    // Providers config (.ovp/providers.toml) BEFORE any server/scheduler
-    // thread spawns — this is the desktop's replacement for shell-sourcing
-    // daily.env (which launchd/GUI launches cannot do). Env-set vars win.
-    match ovp_domain::providers::apply_providers_env(&vault) {
-        Ok(applied) if !applied.applied.is_empty() => eprintln!(
-            "ovp2-desktop: providers: {} var(s) from .ovp/providers.toml",
-            applied.applied.len()
-        ),
-        Ok(_) => {}
-        Err(e) => return Err(format!("providers.toml: {e}")),
-    }
+    // NOTE deliberately NO `providers::apply_providers_env` here: the Tauri
+    // runtime is multithreaded by the time any command handler runs, so the
+    // unsafe `set_var` contract cannot hold. The desktop process itself does
+    // not read provider env today (in-process ask stays unconfigured), and
+    // every scheduler job execs a fresh `ovp2` child whose own startup loads
+    // `.ovp/providers.toml` safely.
     // Retry a few times: free_port has a tiny TOCTOU window (another process
     // could grab the port between the probe and run_server binding it), so a
     // lost race just picks a new port rather than failing the launch.

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -121,6 +121,17 @@ fn resolve_viz_dir(app: &AppHandle) -> PathBuf {
 /// left unconfigured for now (POST /api/ask answers 503) — read/query/portal all
 /// work; live ask is wired in a later stage.
 fn start_server(vault: PathBuf, viz_dir: PathBuf) -> Result<String, String> {
+    // Providers config (.ovp/providers.toml) BEFORE any server/scheduler
+    // thread spawns — this is the desktop's replacement for shell-sourcing
+    // daily.env (which launchd/GUI launches cannot do). Env-set vars win.
+    match ovp_domain::providers::apply_providers_env(&vault) {
+        Ok(applied) if !applied.applied.is_empty() => eprintln!(
+            "ovp2-desktop: providers: {} var(s) from .ovp/providers.toml",
+            applied.applied.len()
+        ),
+        Ok(_) => {}
+        Err(e) => return Err(format!("providers.toml: {e}")),
+    }
     // Retry a few times: free_port has a tiny TOCTOU window (another process
     // could grab the port between the probe and run_server binding it), so a
     // lost race just picks a new port rather than failing the launch.

--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -379,6 +379,17 @@ export const en = {
     'DURABLE claims passed every evidence gate; CAVEATED claims carry a known weakness and wait for review — they are labeled, never hidden.',
   'system.conceptGate':
     'THE GATE is a mechanical check before anything is written to the crystal ledger: every citation must resolve to a real quoted unit, and claim strength is scored — human decisions go through it too, never around it.',
+  'system.publish': 'Publish',
+  'system.publishHelp':
+    'Snapshot the public-safe knowledge site and deploy it as configured in .ovp/publish.toml.',
+  'system.publishNotConfigured':
+    'Not configured — set `out` (and optionally `repo`/`branch`/`spa_dir`) in .ovp/publish.toml.',
+  'system.publishNow': 'Publish now',
+  'system.publishRunning': 'Publishing…',
+  'system.publishLastOk': 'Last publish: {files} files, {claims} durable claims',
+  'system.publishPushed': 'pushed',
+  'system.publishNoChange': 'no change to deploy',
+  'system.publishLastFailed': 'Last publish failed',
   'system.settings': 'Settings',
   'system.settingsReadonly':
     'Read-only in v1 — changes happen at the CLI, this panel shows what the server is running with.',

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -354,6 +354,16 @@ export const zh: Record<keyof typeof en, string> = {
     'durable（持久）主张通过了全部证据门；caveated（存疑）主张带有已知弱点、等待复核——只会被标注，不会被隐藏。',
   'system.conceptGate':
     '"门"（gate）是写入结晶账本前的机械校验：每条引用必须对应真实的引文单元，主张强度会被评分——人的裁决也要过门，从不绕过。',
+  'system.publish': '发布',
+  'system.publishHelp': '按 .ovp/publish.toml 的配置生成公开知识站点快照并部署。',
+  'system.publishNotConfigured':
+    '未配置——在 .ovp/publish.toml 里设置 `out`（可选 `repo`/`branch`/`spa_dir`）。',
+  'system.publishNow': '立即发布',
+  'system.publishRunning': '发布中…',
+  'system.publishLastOk': '上次发布：{files} 个文件，{claims} 条结晶主张',
+  'system.publishPushed': '已推送',
+  'system.publishNoChange': '无变更可部署',
+  'system.publishLastFailed': '上次发布失败',
   'system.settings': '设置',
   'system.settingsReadonly':
     'v1 只读——修改在 CLI 完成，这里展示服务端当前运行的配置。',

--- a/console-ui/src/lib/api.ts
+++ b/console-ui/src/lib/api.ts
@@ -137,6 +137,27 @@ export function fetchSettings(): Promise<SettingsPayload> {
   return fetchJson<SettingsPayload>(STATIC_MODE ? `${API}/settings.json` : '/api/settings');
 }
 
+/** Publish job status (live server only — the published site itself has no
+ * publish button). */
+export interface PublishStatus {
+  running: boolean;
+  configured: boolean;
+  last: Record<string, unknown> | null;
+}
+export function fetchPublishStatus(): Promise<PublishStatus> {
+  return fetchJson<PublishStatus>('/api/publish/status');
+}
+export async function startPublish(): Promise<void> {
+  const resp = await fetch('/api/publish', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+  });
+  if (!resp.ok && resp.status !== 202) {
+    const body = (await resp.json().catch(() => null)) as { error?: string } | null;
+    throw new Error(body?.error ?? `publish failed (${resp.status})`);
+  }
+}
+
 /** Three-layer source detail: meta + memory + citing claims + raw md. */
 export function fetchSourceDetail(sha: string): Promise<SourceDetail> {
   if (STATIC_MODE) return fetchJson<SourceDetail>(`${API}/source/${encodeURIComponent(sha)}.json`);

--- a/console-ui/src/pages/SystemPage.tsx
+++ b/console-ui/src/pages/SystemPage.tsx
@@ -13,7 +13,13 @@ import AttentionCard from '../components/AttentionCard';
 import { RunActivitySection } from '../components/RunActivity';
 import { AgeLabel, EmptyState, ModelGate, PageHelp } from '../components/ui';
 import { useI18n } from '../i18n';
-import { fetchSettings } from '../lib/api';
+import {
+  STATIC_MODE,
+  fetchPublishStatus,
+  fetchSettings,
+  startPublish,
+  type PublishStatus,
+} from '../lib/api';
 import { attentionSources } from '../lib/derive';
 import type { IndexModel, SettingsPayload } from '../lib/types';
 import { useModel } from '../model';
@@ -167,6 +173,108 @@ function ConceptsSection() {
   );
 }
 
+/** Publish card: one button running `.ovp/publish.toml`'s configured publish
+ * (build site + optional git deploy) via POST /api/publish, with a 2s status
+ * poll while it runs. Hidden entirely in static mode (a published site can't
+ * publish) and shows a configure hint when publish.toml is absent. */
+function PublishSection() {
+  const { t } = useI18n();
+  const [status, setStatus] = useState<PublishStatus | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (STATIC_MODE) return;
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const poll = () => {
+      fetchPublishStatus()
+        .then((s) => {
+          if (cancelled) return;
+          setStatus(s);
+          if (s.running) timer = setTimeout(poll, 2000);
+        })
+        .catch(() => {
+          // Silent: the card simply stays in its last state.
+        });
+    };
+    poll();
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, []);
+
+  if (STATIC_MODE) return null;
+
+  const onPublish = () => {
+    setError(null);
+    startPublish()
+      .then(() => {
+        setStatus((s) => (s ? { ...s, running: true } : s));
+        // Re-arm the poll loop.
+        const tick = () =>
+          fetchPublishStatus()
+            .then((s) => {
+              setStatus(s);
+              if (s.running) setTimeout(tick, 2000);
+            })
+            .catch(() => {});
+        setTimeout(tick, 1500);
+      })
+      .catch((e: Error) => setError(e.message));
+  };
+
+  const last = status?.last as
+    | {
+        ok?: boolean;
+        error?: string;
+        file_count?: number;
+        claims?: number;
+        deployed_to?: string;
+        pushed?: boolean;
+        finished_at?: string;
+      }
+    | null
+    | undefined;
+
+  return (
+    <div className="section">
+      <h2>{t('system.publish')}</h2>
+      {status && !status.configured ? (
+        <p className="sm muted">{t('system.publishNotConfigured')}</p>
+      ) : (
+        <>
+          <p className="sm muted">{t('system.publishHelp')}</p>
+          <button
+            type="button"
+            className="publish-btn"
+            disabled={!status || status.running}
+            onClick={onPublish}
+          >
+            {status?.running ? t('system.publishRunning') : t('system.publishNow')}
+          </button>
+          {error && <p className="sm warn">{error}</p>}
+          {last && (
+            <p className="sm">
+              {last.ok
+                ? t('system.publishLastOk', {
+                    files: last.file_count ?? 0,
+                    claims: last.claims ?? 0,
+                  }) +
+                  (last.deployed_to
+                    ? last.pushed
+                      ? ` · ${t('system.publishPushed')}`
+                      : ` · ${t('system.publishNoChange')}`
+                    : '')
+                : `${t('system.publishLastFailed')}: ${last.error ?? ''}`}
+            </p>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
 function SettingsSection() {
   const { t } = useI18n();
   const [settings, setSettings] = useState<SettingsPayload | null>(null);
@@ -293,6 +401,7 @@ export default function SystemPage() {
       </ModelGate>
       <SurfacesSection />
       <ConceptsSection />
+      <PublishSection />
       <SettingsSection />
     </>
   );

--- a/console-ui/src/pages/SystemPage.tsx
+++ b/console-ui/src/pages/SystemPage.tsx
@@ -182,6 +182,12 @@ function PublishSection() {
   const [status, setStatus] = useState<PublishStatus | null>(null);
   const [error, setError] = useState<string | null>(null);
 
+  // ONE lifecycle-managed poll loop: fetch once on mount, and keep polling
+  // while a run is in flight. Every timer lives inside this effect, so
+  // navigating away cancels everything (no detached setTimeout chain —
+  // review finding). `onPublish` never schedules its own timers; it just
+  // flips `running`, which re-arms this effect.
+  const running = status?.running ?? false;
   useEffect(() => {
     if (STATIC_MODE) return;
     let cancelled = false;
@@ -202,25 +208,14 @@ function PublishSection() {
       cancelled = true;
       if (timer) clearTimeout(timer);
     };
-  }, []);
+  }, [running]);
 
   if (STATIC_MODE) return null;
 
   const onPublish = () => {
     setError(null);
     startPublish()
-      .then(() => {
-        setStatus((s) => (s ? { ...s, running: true } : s));
-        // Re-arm the poll loop.
-        const tick = () =>
-          fetchPublishStatus()
-            .then((s) => {
-              setStatus(s);
-              if (s.running) setTimeout(tick, 2000);
-            })
-            .catch(() => {});
-        setTimeout(tick, 1500);
-      })
+      .then(() => setStatus((s) => (s ? { ...s, running: true } : s)))
       .catch((e: Error) => setError(e.message));
   };
 

--- a/crates/ovp-cli/src/commands/publish.rs
+++ b/crates/ovp-cli/src/commands/publish.rs
@@ -1,286 +1,72 @@
 //! `publish` — snapshot the public-safe API surface + SPA bundle into a static
 //! site and (optionally) push it to a public GitHub Pages repo.
 //!
-//! The published site is *just another projection* of the ledgers: rebuilt
-//! whole each run, content-hash-stable, so git computes a minimal diff. A
-//! `.ovp/publish.jsonl` ledger records each run's content hash so a no-op
-//! publish (nothing changed since last time) skips the push.
+//! Thin CLI shell: the whole run (config resolution over `.ovp/publish.toml`,
+//! out-dir guards, assembly, SPA copy, git deploy, publish ledger) lives in
+//! `ovp_publish::run` so the portal's `POST /api/publish` executes the exact
+//! same path.
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
-use ovp_domain::VaultLayout;
-use ovp_index::now_rfc3339;
-use ovp_intake::{append_jsonl, read_jsonl};
-use ovp_publish::{PublishArgs, publish};
-use serde::{Deserialize, Serialize};
+use ovp_publish::run::{RunOverrides, resolve_publish, run_publish};
 
 use crate::CliError;
 
 pub struct PublishCmd {
     pub vault_root: PathBuf,
-    pub out: PathBuf,
+    pub out: Option<PathBuf>,
     pub date: String,
     pub no_rebuild: bool,
     pub spa_dir: Option<PathBuf>,
     pub force: bool,
     pub repo: Option<String>,
-    pub branch: String,
-}
-
-/// One `.ovp/publish.jsonl` record.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct PublishRecord {
-    schema: String,
-    run_id: String,
-    published_at: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    index_run_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    index_built_at: Option<String>,
-    content_hash: String,
-    file_count: usize,
-    sources: usize,
-    claims: usize,
-    out_dir: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    deployed_to: Option<String>,
+    pub branch: Option<String>,
 }
 
 pub fn run(cmd: PublishCmd) -> Result<(), CliError> {
-    let layout = VaultLayout::new();
-    let ledger_path = cmd.vault_root.join(layout.publish_ledger());
-    // Propagate a CORRUPT publish ledger (a missing one is an empty first run) —
-    // silently forgetting the prior state would republish and re-corrupt it.
-    let last_hash = read_jsonl::<PublishRecord>(&ledger_path)
-        .map_err(CliError::Io)?
-        .pop()
-        .map(|r| r.content_hash);
-
-    // Assemble the site in a CLEAN directory: reusing --out would leave stale
-    // hashed SPA chunks / withdrawn files behind, which then deploy. Guard the
-    // recursive delete HARD — `--out .` / the vault / a parent must never be
-    // nuked by a typo.
-    // Reject `..` outright: a path like `<vault>/new/..` doesn't `exists()` yet,
-    // so it would skip every guard below, then `create_dir_all` resolves it back
-    // to the vault and the clean/copy would hit real data.
-    if cmd
-        .out
-        .components()
-        .any(|c| matches!(c, std::path::Component::ParentDir))
-    {
-        return Err(CliError::Io(format!(
-            "--out {} must not contain `..`",
-            cmd.out.display()
-        )));
-    }
-    let site_marker = cmd.out.join(".ovp-site");
-    if cmd.out.exists() {
-        let out_c = std::fs::canonicalize(&cmd.out)
-            .map_err(|e| CliError::Io(format!("resolve --out {}: {e}", cmd.out.display())))?;
-        let vault_c =
-            std::fs::canonicalize(&cmd.vault_root).unwrap_or_else(|_| cmd.vault_root.clone());
-        if out_c.parent().is_none() || vault_c == out_c || vault_c.starts_with(&out_c) {
-            return Err(CliError::Io(format!(
-                "refusing to publish into {} — it is the vault, an ancestor, or a filesystem root",
-                out_c.display()
-            )));
-        }
-        // Only clean an EMPTY dir or a prior publish site (our marker present);
-        // never blow away an arbitrary existing directory.
-        let is_prior_site = out_c.join(".ovp-site").is_file();
-        let is_empty = std::fs::read_dir(&out_c)
-            .map(|mut d| d.next().is_none())
-            .unwrap_or(false);
-        if !is_prior_site && !is_empty {
-            return Err(CliError::Io(format!(
-                "refusing to overwrite {} — not empty and not a prior publish output; remove it or choose an empty --out",
-                out_c.display()
-            )));
-        }
-        std::fs::remove_dir_all(&out_c)
-            .map_err(|e| CliError::Io(format!("clean {}: {e}", out_c.display())))?;
-    }
-
-    let published_at = now_rfc3339();
-    let report = publish(&PublishArgs {
-        vault_root: cmd.vault_root.clone(),
-        out_dir: cmd.out.clone(),
-        date: cmd.date.clone(),
+    let overrides = RunOverrides {
+        out: cmd.out,
+        repo: cmd.repo,
+        branch: cmd.branch,
+        spa_dir: cmd.spa_dir,
+        force: cmd.force,
         no_rebuild: cmd.no_rebuild,
-        published_at: Some(published_at.clone()),
-    })
+    };
+    let resolved = resolve_publish(&cmd.vault_root, &overrides).map_err(CliError::Io)?;
+    let summary = run_publish(
+        &cmd.vault_root,
+        &cmd.date,
+        &resolved,
+        overrides.force,
+        overrides.no_rebuild,
+    )
     .map_err(CliError::Io)?;
 
     println!(
         "publish: {} api file(s) → {} (sources={} durable={})",
-        report.file_count,
-        cmd.out.join("api").display(),
-        report.sources,
-        report.claims
+        summary.file_count,
+        std::path::Path::new(&summary.out_dir).join("api").display(),
+        summary.sources,
+        summary.claims
     );
-    // Informational only — the no-op decision is made by git over the COMPLETE
-    // assembled site (below), not this content hash, so an SPA/terrain-only
-    // change (or a newly-added --repo) still deploys.
-    if last_hash.as_deref() == Some(report.content_hash.as_str()) {
+    if summary.content_unchanged {
         println!("publish: durable content unchanged since last publish");
     }
-
-    // Marker so a re-publish knows this dir is a publish output it may clean.
-    std::fs::write(&site_marker, "ovp.publish/v1\n")
-        .map_err(|e| CliError::Io(format!("write {}: {e}", site_marker.display())))?;
-
-    // Copy the pre-built static SPA bundle over the site root (if given). The
-    // bundle already bakes its base path (VITE_OVP_BASE at build time) and its
-    // API base is relative to it — nothing to rewrite here.
-    if let Some(spa) = &cmd.spa_dir {
-        copy_dir(spa, &cmd.out).map_err(CliError::Io)?;
-        println!("publish: copied SPA bundle from {}", spa.display());
+    if summary.spa_copied {
+        println!("publish: copied SPA bundle");
     } else {
-        println!("publish: no --spa-dir given; wrote API JSON only (build the SPA with VITE_OVP_STATIC=1 and re-run with --spa-dir)");
-    }
-
-    // Optional deploy to a public repo. `deploy_git` diffs the WHOLE assembled
-    // site against the branch and no-ops the push when nothing changed — the
-    // real change-detection, covering API + SPA + terrain.
-    let deployed_to = if let Some(repo) = &cmd.repo {
-        let pushed = deploy_git(&cmd.out, repo, &cmd.branch, &report.content_hash, cmd.force)
-            .map_err(CliError::Io)?;
         println!(
-            "publish: {} {repo} ({})",
-            if pushed { "pushed to" } else { "no change to deploy for" },
-            cmd.branch
+            "publish: no SPA bundle configured; wrote API JSON only \
+             (build with VITE_OVP_STATIC=1 and set --spa-dir or `spa_dir` in .ovp/publish.toml)"
         );
-        Some(repo.clone())
-    } else {
-        None
-    };
-
-    // Record the run (append-only ledger, atomic append).
-    let record = PublishRecord {
-        schema: "ovp.publish/v1".into(),
-        run_id: format!("publish-{published_at}"),
-        published_at,
-        index_run_id: report.index_run_id.clone(),
-        index_built_at: report.index_built_at.clone(),
-        content_hash: report.content_hash.clone(),
-        file_count: report.file_count,
-        sources: report.sources,
-        claims: report.claims,
-        out_dir: cmd.out.display().to_string(),
-        deployed_to,
-    };
-    append_jsonl(&ledger_path, &record).map_err(CliError::Io)?;
-    Ok(())
-}
-
-/// Recursively copy `src` into `dst` (merging; `dst` is created if missing).
-fn copy_dir(src: &Path, dst: &Path) -> Result<(), String> {
-    std::fs::create_dir_all(dst).map_err(|e| format!("mkdir {}: {e}", dst.display()))?;
-    for entry in std::fs::read_dir(src).map_err(|e| format!("read {}: {e}", src.display()))? {
-        let entry = entry.map_err(|e| format!("read entry: {e}"))?;
-        let from = entry.path();
-        let to = dst.join(entry.file_name());
-        if from.is_dir() {
-            copy_dir(&from, &to)?;
-        } else {
-            std::fs::copy(&from, &to)
-                .map_err(|e| format!("copy {} → {}: {e}", from.display(), to.display()))?;
-        }
+    }
+    match (&summary.deployed_to, summary.pushed) {
+        (Some(repo), Some(true)) => println!("publish: pushed to {repo} ({})", resolved.branch),
+        (Some(repo), _) => println!(
+            "publish: no change to deploy for {repo} ({})",
+            resolved.branch
+        ),
+        (None, _) => {}
     }
     Ok(())
-}
-
-/// Deploy `site` to `<repo>#<branch>` via a temp clone: shallow-clone the
-/// branch (or start an orphan branch if it doesn't exist), replace its tracked
-/// content with `site`, commit, and push. Uses the ambient git credentials /
-/// token (e.g. sourced from `.ovp/daily.env` by the scheduler).
-fn deploy_git(
-    site: &Path,
-    repo: &str,
-    branch: &str,
-    hash: &str,
-    force: bool,
-) -> Result<bool, String> {
-    let work = site
-        .parent()
-        .unwrap_or_else(|| Path::new("."))
-        .join(".publish-deploy");
-    let _ = std::fs::remove_dir_all(&work);
-
-    let cloned = run_git(
-        Path::new("."),
-        &["clone", "--depth", "1", "--branch", branch, repo, &work.display().to_string()],
-    );
-    if cloned.is_err() {
-        // Branch (or repo history) doesn't exist yet — start it fresh.
-        run_git(Path::new("."), &["clone", "--depth", "1", repo, &work.display().to_string()])
-            .map_err(|e| format!("git clone {repo}: {e}"))?;
-        run_git(&work, &["checkout", "--orphan", branch])
-            .map_err(|e| format!("git checkout --orphan {branch}: {e}"))?;
-        run_git(&work, &["rm", "-rf", "--ignore-unmatch", "."]).ok();
-    }
-
-    // Replace tracked content with the freshly-built site (keep .git).
-    for entry in std::fs::read_dir(&work).map_err(|e| format!("read deploy dir: {e}"))? {
-        let p = entry.map_err(|e| format!("{e}"))?.path();
-        if p.file_name().and_then(|n| n.to_str()) == Some(".git") {
-            continue;
-        }
-        if p.is_dir() {
-            std::fs::remove_dir_all(&p).ok();
-        } else {
-            std::fs::remove_file(&p).ok();
-        }
-    }
-    copy_dir(site, &work)?;
-    // GitHub Pages: don't run the output through Jekyll.
-    std::fs::write(work.join(".nojekyll"), "").ok();
-
-    run_git(&work, &["add", "-A"]).map_err(|e| format!("git add: {e}"))?;
-    // No-op gate over the COMPLETE site, EXCLUDING the volatile-stamp files
-    // (published_at/built_at/run_id change every run). Without the excludes a
-    // scheduled publish would push every time even when nothing durable, SPA,
-    // or terrain changed; the deployed "as of" stamps then only advance when
-    // real content does — which is the correct semantics for a published site.
-    let msg = format!("publish {}", &hash[..12.min(hash.len())]);
-    let unchanged = run_git(
-        &work,
-        &[
-            "diff",
-            "--cached",
-            "--quiet",
-            "--",
-            ".",
-            ":(exclude)api/meta.json",
-            ":(exclude)api/model.json",
-            ":(exclude)api/settings.json",
-        ],
-    )
-    .is_ok();
-    if unchanged {
-        if !force {
-            return Ok(false);
-        }
-        run_git(&work, &["commit", "--allow-empty", "-m", &msg])
-            .map_err(|e| format!("git commit: {e}"))?;
-        run_git(&work, &["push", "origin", branch]).map_err(|e| format!("git push: {e}"))?;
-        return Ok(true);
-    }
-    run_git(&work, &["commit", "-m", &msg]).map_err(|e| format!("git commit: {e}"))?;
-    run_git(&work, &["push", "origin", branch]).map_err(|e| format!("git push: {e}"))?;
-    Ok(true)
-}
-
-/// Run a git command in `dir`; error carries stderr on non-zero exit.
-fn run_git(dir: &Path, args: &[&str]) -> Result<(), String> {
-    let out = std::process::Command::new("git")
-        .args(args)
-        .current_dir(dir)
-        .output()
-        .map_err(|e| format!("spawn git: {e}"))?;
-    if out.status.success() {
-        Ok(())
-    } else {
-        Err(String::from_utf8_lossy(&out.stderr).trim().to_string())
-    }
 }

--- a/crates/ovp-cli/src/main.rs
+++ b/crates/ovp-cli/src/main.rs
@@ -349,8 +349,9 @@ enum Cmd {
         #[arg(long)]
         vault_root: PathBuf,
         /// Output site directory (the API tree lands under `<out>/api/`).
+        /// Falls back to `out` in `.ovp/publish.toml`.
         #[arg(long)]
-        out: PathBuf,
+        out: Option<PathBuf>,
         #[arg(long)]
         date: Option<String>,
         /// Build the model in memory WITHOUT persisting index.json/evidence.json
@@ -359,18 +360,21 @@ enum Cmd {
         #[arg(long)]
         no_rebuild: bool,
         /// A pre-built static SPA bundle to copy into `<out>/` (from
-        /// `VITE_OVP_STATIC=1 npm run build`). Omit to snapshot API JSON only.
+        /// `VITE_OVP_STATIC=1 npm run build`). Falls back to `spa_dir` in
+        /// `.ovp/publish.toml`; absent in both → API JSON only.
         #[arg(long)]
         spa_dir: Option<PathBuf>,
         /// Publish even when the content hash is unchanged since the last run.
         #[arg(long)]
         force: bool,
         /// Public git repo URL to push the built site to (GitHub Pages).
+        /// Falls back to `repo` in `.ovp/publish.toml`.
         #[arg(long)]
         repo: Option<String>,
-        /// Branch on `--repo` to publish (default `gh-pages`).
-        #[arg(long, default_value = "gh-pages")]
-        branch: String,
+        /// Branch to publish (falls back to `branch` in `.ovp/publish.toml`,
+        /// then `gh-pages`).
+        #[arg(long)]
+        branch: Option<String>,
     },
     /// PRODUCT — Projection Lanes: view claims by routing lane (durable/review),
     /// or write durable claims as vault notes (`--write` / `--rebuild`).
@@ -1257,7 +1261,44 @@ enum EvolveAction {
     Diagnose,
 }
 
+/// Pre-parse peek at `--vault-root` so `.ovp/providers.toml` can seed the
+/// environment BEFORE any command logic reads it. A peek (not clap) because
+/// the vault path lives on ~40 different subcommand structs; failure mode of
+/// a miss is simply "providers.toml not loaded" — the environment still
+/// works exactly as before the file existed.
+fn peek_vault_root() -> Option<std::path::PathBuf> {
+    let mut args = std::env::args().skip(1);
+    while let Some(a) = args.next() {
+        if a == "--vault-root" {
+            return args.next().map(std::path::PathBuf::from);
+        }
+        if let Some(v) = a.strip_prefix("--vault-root=") {
+            return Some(std::path::PathBuf::from(v));
+        }
+    }
+    None
+}
+
 fn main() -> ExitCode {
+    // Providers config: applied before Cli::parse spawns nothing — set_var's
+    // single-threaded-startup contract holds. A broken file fails the run
+    // loud (a typo'd secrets file must not silently run unconfigured).
+    if let Some(vault_root) = peek_vault_root() {
+        match ovp_domain::providers::apply_providers_env(&vault_root) {
+            Ok(applied) if !applied.applied.is_empty() => {
+                eprintln!(
+                    "providers: {} var(s) from .ovp/providers.toml ({} already set in env)",
+                    applied.applied.len(),
+                    applied.already_set.len()
+                );
+            }
+            Ok(_) => {}
+            Err(e) => {
+                eprintln!("error: providers.toml: {e}");
+                return ExitCode::FAILURE;
+            }
+        }
+    }
     let cli = Cli::parse();
     let result = match cli.cmd {
         Cmd::Graph { manifest } => commands::graph::run(manifest),

--- a/crates/ovp-domain/src/lib.rs
+++ b/crates/ovp-domain/src/lib.rs
@@ -32,6 +32,7 @@ pub mod sources;
 /// Tag vocabulary layer: deterministic normalization + the operator-owned
 /// alias table. Canonicalization happens at projection build only; raw
 /// frontmatter tags are never rewritten.
+pub mod providers;
 pub mod tags;
 /// Tier-0 URL entities: machine-verifiable referents (github/arxiv/doi/npm/…)
 /// whose identity is a registry URL — deterministic extraction, no LLM.

--- a/crates/ovp-domain/src/providers.rs
+++ b/crates/ovp-domain/src/providers.rs
@@ -61,7 +61,12 @@ pub fn apply_providers_env(vault_root: &Path) -> Result<ProvidersApplied, String
     let file: ProvidersFile =
         toml::from_str(&raw).map_err(|e| format!("parsing {}: {e}", path.display()))?;
 
-    let mut out = ProvidersApplied::default();
+    // Two phases: validate + convert the ENTIRE table first, mutate second.
+    // A partial apply followed by an error would leave the process with an
+    // earlier entry exported; a corrected retry (long-lived desktop process)
+    // would then see it as "already set" and keep the stale value until
+    // restart (codex P2).
+    let mut pending: Vec<(String, String)> = Vec::with_capacity(file.env.len());
     for (name, value) in &file.env {
         if name.is_empty()
             || !name
@@ -91,15 +96,20 @@ pub fn apply_providers_env(vault_root: &Path) -> Result<ProvidersApplied, String
                 ));
             }
         };
-        if std::env::var_os(name).is_some() {
-            out.already_set.push(name.clone());
+        pending.push((name.clone(), text));
+    }
+
+    let mut out = ProvidersApplied::default();
+    for (name, text) in pending {
+        if std::env::var_os(&name).is_some() {
+            out.already_set.push(name);
             continue;
         }
         // SAFETY: single-threaded startup path (see the function contract);
         // set_var is only unsound with concurrent env readers on some
         // platforms, and both call sites run before any thread spawns.
-        unsafe { std::env::set_var(name, &text) };
-        out.applied.push(name.clone());
+        unsafe { std::env::set_var(&name, &text) };
+        out.applied.push(name);
     }
     Ok(out)
 }

--- a/crates/ovp-domain/src/providers.rs
+++ b/crates/ovp-domain/src/providers.rs
@@ -1,0 +1,160 @@
+//! `.ovp/providers.toml` — the vault's provider configuration file.
+//!
+//! Replaces shell-sourcing `daily.env` (which launchd cannot reliably do —
+//! the EPERM incident 2026-07) with a config file the APP reads itself. One
+//! flat `[env]` table of UPPERCASE variables; values act as DEFAULTS — a
+//! variable already present in the process environment always wins, so
+//! one-off `ANTHROPIC_API_KEY=… ovp2 …` overrides keep working and nothing
+//! in the existing env-reading code paths (LLM client, Pinboard, GitHub,
+//! embedding cache) had to change.
+//!
+//! ```toml
+//! [env]
+//! ANTHROPIC_API_KEY = "sk-…"
+//! ANTHROPIC_BASE_URL = "https://…/v1/messages"
+//! OVP_LLM_MODEL = "…"
+//! OVP_LLM_NO_PROXY = "1"
+//! GITHUB_TOKEN = "ghp_…"
+//! PINBOARD_TOKEN = "user:…"
+//! ```
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use serde::Deserialize;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ProvidersFile {
+    #[serde(default)]
+    env: BTreeMap<String, toml::Value>,
+}
+
+/// What `apply_providers_env` did, for the caller's (stderr) log line.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct ProvidersApplied {
+    /// Variables set from the file (they were absent from the environment).
+    pub applied: Vec<String>,
+    /// Variables skipped because the environment already had them.
+    pub already_set: Vec<String>,
+}
+
+/// Load `<vault>/.ovp/providers.toml` and export every `[env]` entry that is
+/// not already set in the process environment. Missing file → no-op;
+/// unparseable file, unknown top-level keys, lowercase names, or non-scalar
+/// values → `Err` (a typo'd secrets file must fail loud, not silently run
+/// unconfigured).
+///
+/// # Safety contract
+/// Mutates the PROCESS environment (`std::env::set_var`) — call once at
+/// startup before any threads exist. Both binaries do (CLI `main`, desktop
+/// boot).
+pub fn apply_providers_env(vault_root: &Path) -> Result<ProvidersApplied, String> {
+    let path = vault_root.join(".ovp/providers.toml");
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(ProvidersApplied::default());
+        }
+        Err(e) => return Err(format!("reading {}: {e}", path.display())),
+    };
+    let file: ProvidersFile =
+        toml::from_str(&raw).map_err(|e| format!("parsing {}: {e}", path.display()))?;
+
+    let mut out = ProvidersApplied::default();
+    for (name, value) in &file.env {
+        if name.is_empty()
+            || !name
+                .chars()
+                .all(|c| c.is_ascii_uppercase() || c == '_' || c.is_ascii_digit())
+        {
+            return Err(format!(
+                "{}: `{name}` is not an UPPER_SNAKE_CASE environment variable name",
+                path.display()
+            ));
+        }
+        let text = match value {
+            toml::Value::String(s) => s.clone(),
+            toml::Value::Integer(i) => i.to_string(),
+            toml::Value::Boolean(b) => {
+                if *b {
+                    "1".into()
+                } else {
+                    "0".into()
+                }
+            }
+            other => {
+                return Err(format!(
+                    "{}: `{name}` must be a string/integer/boolean, got {}",
+                    path.display(),
+                    other.type_str()
+                ));
+            }
+        };
+        if std::env::var_os(name).is_some() {
+            out.already_set.push(name.clone());
+            continue;
+        }
+        // SAFETY: single-threaded startup path (see the function contract);
+        // set_var is only unsound with concurrent env readers on some
+        // platforms, and both call sites run before any thread spawns.
+        unsafe { std::env::set_var(name, &text) };
+        out.applied.push(name.clone());
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_file_is_a_noop_and_env_wins_over_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(
+            apply_providers_env(tmp.path()).unwrap(),
+            ProvidersApplied::default()
+        );
+
+        std::fs::create_dir_all(tmp.path().join(".ovp")).unwrap();
+        std::fs::write(
+            tmp.path().join(".ovp/providers.toml"),
+            "[env]\nOVP_TEST_PROVIDERS_A = \"from-file\"\nOVP_TEST_PROVIDERS_B = 42\nOVP_TEST_PROVIDERS_C = true\n",
+        )
+        .unwrap();
+        // Pre-set one var: the file must NOT override it.
+        unsafe { std::env::set_var("OVP_TEST_PROVIDERS_A", "from-env") };
+        let applied = apply_providers_env(tmp.path()).unwrap();
+        assert_eq!(applied.already_set, vec!["OVP_TEST_PROVIDERS_A"]);
+        assert_eq!(
+            applied.applied,
+            vec!["OVP_TEST_PROVIDERS_B", "OVP_TEST_PROVIDERS_C"]
+        );
+        assert_eq!(std::env::var("OVP_TEST_PROVIDERS_A").unwrap(), "from-env");
+        assert_eq!(std::env::var("OVP_TEST_PROVIDERS_B").unwrap(), "42");
+        assert_eq!(std::env::var("OVP_TEST_PROVIDERS_C").unwrap(), "1");
+        for k in [
+            "OVP_TEST_PROVIDERS_A",
+            "OVP_TEST_PROVIDERS_B",
+            "OVP_TEST_PROVIDERS_C",
+        ] {
+            unsafe { std::env::remove_var(k) };
+        }
+    }
+
+    #[test]
+    fn corrupt_lowercase_and_nonscalar_fail_loud() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join(".ovp/providers.toml");
+        std::fs::create_dir_all(tmp.path().join(".ovp")).unwrap();
+        std::fs::write(&p, "not toml [").unwrap();
+        assert!(apply_providers_env(tmp.path()).is_err());
+        std::fs::write(&p, "[env]\nlowercase = \"x\"\n").unwrap();
+        assert!(apply_providers_env(tmp.path()).is_err());
+        std::fs::write(&p, "[env]\nOVP_X = [1, 2]\n").unwrap();
+        assert!(apply_providers_env(tmp.path()).is_err());
+        // Unknown top-level table — probably a misplaced section.
+        std::fs::write(&p, "[llm]\nkey = \"x\"\n").unwrap();
+        assert!(apply_providers_env(tmp.path()).is_err());
+    }
+}

--- a/crates/ovp-publish/Cargo.toml
+++ b/crates/ovp-publish/Cargo.toml
@@ -15,6 +15,7 @@ ovp-intake = { path = "../ovp-intake" }
 serde.workspace = true
 serde_json.workspace = true
 sha2 = { workspace = true }
+toml = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ovp-publish/src/lib.rs
+++ b/crates/ovp-publish/src/lib.rs
@@ -8,6 +8,8 @@
 //! diff. It reuses the SAME `ovp-api-projection` builders the live server uses
 //! (no drift) over a `PublicView` (durable claims + processed sources only).
 
+pub mod run;
+
 use std::path::{Path, PathBuf};
 
 use ovp_api_projection::{PublicView, bodies, graph, readers};

--- a/crates/ovp-publish/src/run.rs
+++ b/crates/ovp-publish/src/run.rs
@@ -1,0 +1,475 @@
+//! The full publish RUN — orchestration shared by `ovp2 publish` and the
+//! portal's `POST /api/publish`: config resolution (`.ovp/publish.toml` with
+//! CLI overrides), out-dir safety guards, site assembly, SPA copy, optional
+//! git deploy, and the append-only `.ovp/publish.jsonl` ledger. The CLI and
+//! server print/serialize the returned [`RunSummary`]; nothing here writes to
+//! stdout.
+
+use std::path::{Path, PathBuf};
+
+use ovp_domain::VaultLayout;
+use ovp_index::now_rfc3339;
+use ovp_intake::{append_jsonl, read_jsonl};
+use serde::{Deserialize, Serialize};
+
+use crate::{PublishArgs, publish};
+
+/// `.ovp/publish.toml` — persistent publish settings so the portal/desktop
+/// button and scheduled runs need no flags. Relative paths resolve against
+/// the vault root. Every field is optional; CLI flags override.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PublishConfig {
+    /// Site output directory.
+    pub out: Option<PathBuf>,
+    /// Git remote to deploy to (e.g. `git@github.com:me/site.git`).
+    pub repo: Option<String>,
+    /// Deploy branch (default `gh-pages`).
+    pub branch: Option<String>,
+    /// Pre-built `VITE_OVP_STATIC=1` SPA bundle to copy over the site root.
+    pub spa_dir: Option<PathBuf>,
+}
+
+/// Read `.ovp/publish.toml`. Missing → `Ok(None)` (flags-only operation);
+/// unparseable/unknown keys → `Err` (a typo'd config must not silently
+/// publish to the wrong place).
+pub fn load_publish_config(vault_root: &Path) -> Result<Option<PublishConfig>, String> {
+    let path = vault_root.join(".ovp/publish.toml");
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(format!("reading {}: {e}", path.display())),
+    };
+    let cfg: PublishConfig =
+        toml::from_str(&raw).map_err(|e| format!("parsing {}: {e}", path.display()))?;
+    Ok(Some(cfg))
+}
+
+/// Flag-level overrides for one run (all optional — config supplies the rest).
+#[derive(Debug, Clone, Default)]
+pub struct RunOverrides {
+    pub out: Option<PathBuf>,
+    pub repo: Option<String>,
+    pub branch: Option<String>,
+    pub spa_dir: Option<PathBuf>,
+    pub force: bool,
+    pub no_rebuild: bool,
+}
+
+/// Fully-resolved settings for one run (override > config > default).
+#[derive(Debug, Clone)]
+pub struct ResolvedPublish {
+    pub out: PathBuf,
+    pub repo: Option<String>,
+    pub branch: String,
+    pub spa_dir: Option<PathBuf>,
+}
+
+/// Merge overrides over `.ovp/publish.toml`. `out` is required from one of
+/// the two; relative config paths resolve against the vault root.
+pub fn resolve_publish(
+    vault_root: &Path,
+    overrides: &RunOverrides,
+) -> Result<ResolvedPublish, String> {
+    let cfg = load_publish_config(vault_root)?.unwrap_or_default();
+    let against_vault = |p: PathBuf| -> PathBuf {
+        if p.is_absolute() {
+            p
+        } else {
+            vault_root.join(p)
+        }
+    };
+    let out = overrides
+        .out
+        .clone()
+        .or_else(|| cfg.out.clone().map(against_vault))
+        .ok_or_else(|| {
+            format!(
+                "no output directory — pass --out or set `out` in {}",
+                vault_root.join(".ovp/publish.toml").display()
+            )
+        })?;
+    Ok(ResolvedPublish {
+        out,
+        repo: overrides.repo.clone().or(cfg.repo),
+        branch: overrides
+            .branch
+            .clone()
+            .or(cfg.branch)
+            .unwrap_or_else(|| "gh-pages".to_string()),
+        spa_dir: overrides
+            .spa_dir
+            .clone()
+            .or_else(|| cfg.spa_dir.map(against_vault)),
+    })
+}
+
+/// One `.ovp/publish.jsonl` record.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PublishRecord {
+    pub schema: String,
+    pub run_id: String,
+    pub published_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub index_run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub index_built_at: Option<String>,
+    pub content_hash: String,
+    pub file_count: usize,
+    pub sources: usize,
+    pub claims: usize,
+    pub out_dir: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deployed_to: Option<String>,
+}
+
+/// What one publish run did — the CLI prints it, `POST /api/publish` ships it
+/// as JSON.
+#[derive(Debug, Clone, Serialize)]
+pub struct RunSummary {
+    pub file_count: usize,
+    pub sources: usize,
+    pub claims: usize,
+    pub content_hash: String,
+    /// Durable content hash unchanged since the previous ledger record
+    /// (informational — the deploy no-op gate diffs the whole site).
+    pub content_unchanged: bool,
+    pub out_dir: String,
+    pub spa_copied: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deployed_to: Option<String>,
+    /// `Some(true)` pushed, `Some(false)` no-op deploy, `None` no repo.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pushed: Option<bool>,
+}
+
+/// Execute a full publish run with resolved settings + `date`.
+pub fn run_publish(
+    vault_root: &Path,
+    date: &str,
+    resolved: &ResolvedPublish,
+    force: bool,
+    no_rebuild: bool,
+) -> Result<RunSummary, String> {
+    let layout = VaultLayout::new();
+    let ledger_path = vault_root.join(layout.publish_ledger());
+    // Propagate a CORRUPT publish ledger (a missing one is an empty first
+    // run) — silently forgetting prior state would republish and re-corrupt.
+    let last_hash = read_jsonl::<PublishRecord>(&ledger_path)?
+        .pop()
+        .map(|r| r.content_hash);
+
+    guard_out_dir(vault_root, &resolved.out)?;
+
+    let published_at = now_rfc3339();
+    let report = publish(&PublishArgs {
+        vault_root: vault_root.to_path_buf(),
+        out_dir: resolved.out.clone(),
+        date: date.to_string(),
+        no_rebuild,
+        published_at: Some(published_at.clone()),
+    })?;
+
+    // Marker so a re-publish knows this dir is a publish output it may clean.
+    let site_marker = resolved.out.join(".ovp-site");
+    std::fs::write(&site_marker, "ovp.publish/v1\n")
+        .map_err(|e| format!("write {}: {e}", site_marker.display()))?;
+
+    // Copy the pre-built static SPA bundle over the site root (if given). The
+    // bundle bakes its base path at build time — nothing to rewrite here.
+    let spa_copied = if let Some(spa) = &resolved.spa_dir {
+        copy_dir(spa, &resolved.out)?;
+        true
+    } else {
+        false
+    };
+
+    // Optional deploy. `deploy_git` diffs the WHOLE assembled site against
+    // the branch and no-ops the push when nothing changed.
+    let (deployed_to, pushed) = if let Some(repo) = &resolved.repo {
+        let pushed = deploy_git(
+            &resolved.out,
+            repo,
+            &resolved.branch,
+            &report.content_hash,
+            force,
+        )?;
+        (Some(repo.clone()), Some(pushed))
+    } else {
+        (None, None)
+    };
+
+    let record = PublishRecord {
+        schema: "ovp.publish/v1".into(),
+        run_id: format!("publish-{published_at}"),
+        published_at,
+        index_run_id: report.index_run_id.clone(),
+        index_built_at: report.index_built_at.clone(),
+        content_hash: report.content_hash.clone(),
+        file_count: report.file_count,
+        sources: report.sources,
+        claims: report.claims,
+        out_dir: resolved.out.display().to_string(),
+        deployed_to: deployed_to.clone(),
+    };
+    append_jsonl(&ledger_path, &record)?;
+
+    Ok(RunSummary {
+        file_count: report.file_count,
+        sources: report.sources,
+        claims: report.claims,
+        content_unchanged: last_hash.as_deref() == Some(report.content_hash.as_str()),
+        content_hash: report.content_hash,
+        out_dir: resolved.out.display().to_string(),
+        spa_copied,
+        deployed_to,
+        pushed,
+    })
+}
+
+/// Out-dir safety: reject `..`, the vault, ancestors, filesystem roots, and
+/// non-empty dirs that are not a prior publish output; clean what remains.
+fn guard_out_dir(vault_root: &Path, out: &Path) -> Result<(), String> {
+    // Reject `..` outright: `<vault>/new/..` doesn't `exists()` yet, so it
+    // would skip every guard below, then `create_dir_all` resolves it back to
+    // the vault and the clean/copy would hit real data.
+    if out
+        .components()
+        .any(|c| matches!(c, std::path::Component::ParentDir))
+    {
+        return Err(format!("out dir {} must not contain `..`", out.display()));
+    }
+    if out.exists() {
+        let out_c = std::fs::canonicalize(out)
+            .map_err(|e| format!("resolve out dir {}: {e}", out.display()))?;
+        let vault_c =
+            std::fs::canonicalize(vault_root).unwrap_or_else(|_| vault_root.to_path_buf());
+        if out_c.parent().is_none() || vault_c == out_c || vault_c.starts_with(&out_c) {
+            return Err(format!(
+                "refusing to publish into {} — it is the vault, an ancestor, or a filesystem root",
+                out_c.display()
+            ));
+        }
+        // Only clean an EMPTY dir or a prior publish site (marker present);
+        // never blow away an arbitrary existing directory.
+        let is_prior_site = out_c.join(".ovp-site").is_file();
+        let is_empty = std::fs::read_dir(&out_c)
+            .map(|mut d| d.next().is_none())
+            .unwrap_or(false);
+        if !is_prior_site && !is_empty {
+            return Err(format!(
+                "refusing to overwrite {} — not empty and not a prior publish output; \
+                 remove it or choose an empty out dir",
+                out_c.display()
+            ));
+        }
+        std::fs::remove_dir_all(&out_c).map_err(|e| format!("clean {}: {e}", out_c.display()))?;
+    }
+    Ok(())
+}
+
+/// Recursively copy `src` into `dst` (merging; `dst` is created if missing).
+fn copy_dir(src: &Path, dst: &Path) -> Result<(), String> {
+    std::fs::create_dir_all(dst).map_err(|e| format!("mkdir {}: {e}", dst.display()))?;
+    for entry in std::fs::read_dir(src).map_err(|e| format!("read {}: {e}", src.display()))? {
+        let entry = entry.map_err(|e| format!("read entry: {e}"))?;
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        if from.is_dir() {
+            copy_dir(&from, &to)?;
+        } else {
+            std::fs::copy(&from, &to)
+                .map_err(|e| format!("copy {} → {}: {e}", from.display(), to.display()))?;
+        }
+    }
+    Ok(())
+}
+
+/// Deploy `site` to `<repo>#<branch>` via a temp clone: shallow-clone the
+/// branch (or start an orphan branch if it doesn't exist), replace its tracked
+/// content with `site`, commit, and push. Uses the ambient git credentials /
+/// token (e.g. sourced from `.ovp/daily.env` or providers.toml).
+fn deploy_git(
+    site: &Path,
+    repo: &str,
+    branch: &str,
+    hash: &str,
+    force: bool,
+) -> Result<bool, String> {
+    let work = site
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join(".publish-deploy");
+    let _ = std::fs::remove_dir_all(&work);
+
+    let cloned = run_git(
+        Path::new("."),
+        &[
+            "clone",
+            "--depth",
+            "1",
+            "--branch",
+            branch,
+            repo,
+            &work.display().to_string(),
+        ],
+    );
+    if cloned.is_err() {
+        // Branch (or repo history) doesn't exist yet — start it fresh.
+        run_git(
+            Path::new("."),
+            &["clone", "--depth", "1", repo, &work.display().to_string()],
+        )
+        .map_err(|e| format!("git clone {repo}: {e}"))?;
+        run_git(&work, &["checkout", "--orphan", branch])
+            .map_err(|e| format!("git checkout --orphan {branch}: {e}"))?;
+        run_git(&work, &["rm", "-rf", "--ignore-unmatch", "."]).ok();
+    }
+
+    // Replace tracked content with the freshly-built site (keep .git).
+    for entry in std::fs::read_dir(&work).map_err(|e| format!("read deploy dir: {e}"))? {
+        let p = entry.map_err(|e| format!("{e}"))?.path();
+        if p.file_name().and_then(|n| n.to_str()) == Some(".git") {
+            continue;
+        }
+        if p.is_dir() {
+            std::fs::remove_dir_all(&p).ok();
+        } else {
+            std::fs::remove_file(&p).ok();
+        }
+    }
+    copy_dir(site, &work)?;
+    // GitHub Pages: don't run the output through Jekyll.
+    std::fs::write(work.join(".nojekyll"), "").ok();
+
+    run_git(&work, &["add", "-A"]).map_err(|e| format!("git add: {e}"))?;
+    // No-op gate over the COMPLETE site, EXCLUDING the volatile-stamp files
+    // (published_at/built_at/run_id change every run) — the deployed "as of"
+    // stamps only advance when real content does.
+    let msg = format!("publish {}", &hash[..12.min(hash.len())]);
+    let unchanged = run_git(
+        &work,
+        &[
+            "diff",
+            "--cached",
+            "--quiet",
+            "--",
+            ".",
+            ":(exclude)api/meta.json",
+            ":(exclude)api/model.json",
+            ":(exclude)api/settings.json",
+        ],
+    )
+    .is_ok();
+    if unchanged {
+        if !force {
+            return Ok(false);
+        }
+        run_git(&work, &["commit", "--allow-empty", "-m", &msg])
+            .map_err(|e| format!("git commit: {e}"))?;
+        run_git(&work, &["push", "origin", branch]).map_err(|e| format!("git push: {e}"))?;
+        return Ok(true);
+    }
+    run_git(&work, &["commit", "-m", &msg]).map_err(|e| format!("git commit: {e}"))?;
+    run_git(&work, &["push", "origin", branch]).map_err(|e| format!("git push: {e}"))?;
+    Ok(true)
+}
+
+/// Run a git command in `dir`; error carries stderr on non-zero exit.
+fn run_git(dir: &Path, args: &[&str]) -> Result<(), String> {
+    let out = std::process::Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .map_err(|e| format!("spawn git: {e}"))?;
+    if out.status.success() {
+        Ok(())
+    } else {
+        Err(String::from_utf8_lossy(&out.stderr).trim().to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_missing_corrupt_and_unknown_keys() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        assert_eq!(load_publish_config(root).unwrap(), None);
+        std::fs::create_dir_all(root.join(".ovp")).unwrap();
+        std::fs::write(root.join(".ovp/publish.toml"), "not toml [").unwrap();
+        assert!(load_publish_config(root).is_err());
+        // Unknown keys fail loud — a typo must not silently mispublish.
+        std::fs::write(root.join(".ovp/publish.toml"), "outt = \"site\"\n").unwrap();
+        assert!(load_publish_config(root).is_err());
+        std::fs::write(
+            root.join(".ovp/publish.toml"),
+            "out = \"site\"\nrepo = \"git@github.com:me/site.git\"\n",
+        )
+        .unwrap();
+        let cfg = load_publish_config(root).unwrap().unwrap();
+        assert_eq!(cfg.out.as_deref(), Some(Path::new("site")));
+    }
+
+    #[test]
+    fn resolve_merges_overrides_over_config_and_requires_out() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        // No config, no override → clear error naming the config path.
+        let err = resolve_publish(root, &RunOverrides::default()).unwrap_err();
+        assert!(err.contains("publish.toml"), "{err}");
+
+        std::fs::create_dir_all(root.join(".ovp")).unwrap();
+        std::fs::write(
+            root.join(".ovp/publish.toml"),
+            "out = \"site\"\nrepo = \"git@github.com:me/site.git\"\nbranch = \"pages\"\nspa_dir = \"dist\"\n",
+        )
+        .unwrap();
+        let r = resolve_publish(root, &RunOverrides::default()).unwrap();
+        assert_eq!(
+            r.out,
+            root.join("site"),
+            "relative config paths resolve against the vault"
+        );
+        assert_eq!(r.branch, "pages");
+        assert_eq!(r.spa_dir.as_deref(), Some(root.join("dist").as_path()));
+
+        // Overrides win field-by-field; branch default applies only when
+        // neither side sets it.
+        let r = resolve_publish(
+            root,
+            &RunOverrides {
+                out: Some(PathBuf::from("/tmp/other")),
+                repo: Some("git@github.com:me/other.git".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(r.out, PathBuf::from("/tmp/other"));
+        assert_eq!(r.repo.as_deref(), Some("git@github.com:me/other.git"));
+        std::fs::write(root.join(".ovp/publish.toml"), "out = \"site\"\n").unwrap();
+        let r = resolve_publish(root, &RunOverrides::default()).unwrap();
+        assert_eq!(r.branch, "gh-pages");
+    }
+
+    #[test]
+    fn guard_rejects_dotdot_vault_and_nonempty_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let vault = tmp.path().join("vault");
+        std::fs::create_dir_all(&vault).unwrap();
+        assert!(guard_out_dir(&vault, &vault.join("x/..")).is_err());
+        assert!(guard_out_dir(&vault, &vault).is_err());
+        let nonempty = tmp.path().join("stuff");
+        std::fs::create_dir_all(&nonempty).unwrap();
+        std::fs::write(nonempty.join("keep.txt"), "x").unwrap();
+        assert!(guard_out_dir(&vault, &nonempty).is_err());
+        // A prior publish output (marker) is cleanable.
+        let site = tmp.path().join("site");
+        std::fs::create_dir_all(&site).unwrap();
+        std::fs::write(site.join(".ovp-site"), "ovp.publish/v1\n").unwrap();
+        guard_out_dir(&vault, &site).unwrap();
+        assert!(!site.exists(), "prior site dir is cleaned");
+    }
+}

--- a/crates/ovp-publish/src/run.rs
+++ b/crates/ovp-publish/src/run.rs
@@ -177,8 +177,20 @@ pub fn run_publish(
 
     // Copy the pre-built static SPA bundle over the site root (if given). The
     // bundle bakes its base path at build time — nothing to rewrite here.
+    // Guard: an out dir nested INSIDE the SPA dir would make this copy
+    // recurse into its own output forever (review finding).
     let spa_copied = if let Some(spa) = &resolved.spa_dir {
-        copy_dir(spa, &resolved.out)?;
+        let spa_c = std::fs::canonicalize(spa)
+            .map_err(|e| format!("resolve spa_dir {}: {e}", spa.display()))?;
+        let out_c = std::fs::canonicalize(&resolved.out).unwrap_or_else(|_| resolved.out.clone());
+        if out_c.starts_with(&spa_c) {
+            return Err(format!(
+                "out dir {} is inside spa_dir {} — the SPA copy would recurse into its own output",
+                out_c.display(),
+                spa_c.display()
+            ));
+        }
+        copy_dir(&spa_c, &resolved.out)?;
         true
     } else {
         false

--- a/crates/ovp-scheduler/src/lib.rs
+++ b/crates/ovp-scheduler/src/lib.rs
@@ -37,8 +37,15 @@ pub const VAULT_PLACEHOLDER: &str = "{vault}";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Cadence {
-    Daily { hour: u8, minute: u8 },
-    Weekly { weekday: Weekday, hour: u8, minute: u8 },
+    Daily {
+        hour: u8,
+        minute: u8,
+    },
+    Weekly {
+        weekday: Weekday,
+        hour: u8,
+        minute: u8,
+    },
 }
 
 fn parse_hm(s: &str) -> Result<(u8, u8), String> {
@@ -445,7 +452,14 @@ pub fn job_shell_command(
     job: &JobConfig,
 ) -> String {
     let mut cmd = String::new();
-    if let Some(env) = env_file {
+    // `.ovp/providers.toml` supersedes shell-sourcing: the child ovp2 process
+    // loads it itself at startup, so sourcing daily.env here would both
+    // OVERRIDE the file's values (env wins inside the child) and reintroduce
+    // the launchd EPERM failure mode the file exists to retire.
+    let providers_active = vault_root.join(".ovp/providers.toml").is_file();
+    if let Some(env) = env_file
+        && !providers_active
+    {
         let env = resolve_vault(&env.display().to_string(), vault_root);
         cmd.push_str(&format!("set -a; . {}; set +a; ", sh_quote(&env)));
     }
@@ -678,9 +692,10 @@ mod tests {
         let cry = reg.get("crystallize").unwrap();
         assert_eq!(cry.cadence, "weekly Sun 10:00");
         assert!(cry.argv.contains(&"--refresh".to_string()));
-        assert!(cry
-            .argv
-            .contains(&format!("{VAULT_PLACEHOLDER}/.ovp/work/crystal-synth")));
+        assert!(
+            cry.argv
+                .contains(&format!("{VAULT_PLACEHOLDER}/.ovp/work/crystal-synth"))
+        );
         assert_eq!(
             reg.env_file.as_deref(),
             Some(format!("{VAULT_PLACEHOLDER}/.ovp/daily.env").as_str())
@@ -777,6 +792,33 @@ mod tests {
              exec '/opt/homebrew/bin/ovp2' 'daily' '--vault-root' '/Users/op/ovp-vault' \
              --date \"$(date +%F)\""
         );
+    }
+
+    #[test]
+    fn shell_command_skips_env_sourcing_when_providers_toml_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let vault = tmp.path();
+        std::fs::create_dir_all(vault.join(".ovp")).unwrap();
+        std::fs::write(vault.join(".ovp/providers.toml"), "[env]\n").unwrap();
+        let j = JobConfig {
+            id: "daily".into(),
+            cadence: "daily 09:00".into(),
+            argv: vec!["daily".into()],
+            enabled: true,
+            description: String::new(),
+            stamp_date: false,
+        };
+        let cmd = job_shell_command(
+            Path::new("/bin/ovp2"),
+            Some(Path::new("{vault}/.ovp/daily.env")),
+            vault,
+            &j,
+        );
+        assert!(
+            !cmd.contains("daily.env"),
+            "providers.toml supersedes daily.env sourcing: {cmd}"
+        );
+        assert!(cmd.starts_with("exec "), "{cmd}");
     }
 
     #[test]

--- a/crates/ovp-server/Cargo.toml
+++ b/crates/ovp-server/Cargo.toml
@@ -13,6 +13,7 @@ ovp-domain = { path = "../ovp-domain" }
 ovp-intake = { path = "../ovp-intake" }
 ovp-memory = { path = "../ovp-memory" }
 ovp-llm = { path = "../ovp-llm" }
+ovp-publish = { path = "../ovp-publish" }
 serde.workspace = true
 serde_json.workspace = true
 chrono = { workspace = true }

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -1064,7 +1064,9 @@ fn handle_publish_start(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> 
         }
     };
     {
-        let mut job = state.publish_job.lock().expect("publish job lock");
+        // A poisoned lock (a prior panic while holding it) must not brick the
+        // endpoint for the server's lifetime — recover the inner state.
+        let mut job = state.publish_job.lock().unwrap_or_else(|e| e.into_inner());
         if job.running {
             return json_response(
                 409,
@@ -1077,7 +1079,20 @@ fn handle_publish_start(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> 
     let job = Arc::clone(&state.publish_job);
     std::thread::spawn(move || {
         let date = ovp_index::now_rfc3339()[..10].to_string();
-        let result = ovp_publish::run::run_publish(&vault_root, &date, &resolved, false, false);
+        // catch_unwind: a panic anywhere inside the publish must still clear
+        // `running` and surface as a failed outcome — otherwise the slot
+        // wedges at running=true until restart (review finding).
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            ovp_publish::run::run_publish(&vault_root, &date, &resolved, false, false)
+        }))
+        .unwrap_or_else(|panic| {
+            let msg = panic
+                .downcast_ref::<&str>()
+                .map(|s| (*s).to_string())
+                .or_else(|| panic.downcast_ref::<String>().cloned())
+                .unwrap_or_else(|| "publish panicked".to_string());
+            Err(format!("publish panicked: {msg}"))
+        });
         let outcome = match result {
             Ok(summary) => {
                 let mut v = serde_json::to_value(&summary).unwrap_or_default();
@@ -1093,7 +1108,7 @@ fn handle_publish_start(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> 
                 "finished_at": ovp_index::now_rfc3339(),
             }),
         };
-        let mut job = job.lock().expect("publish job lock");
+        let mut job = job.lock().unwrap_or_else(|e| e.into_inner());
         job.running = false;
         job.last = Some(outcome);
     });
@@ -1108,7 +1123,7 @@ fn handle_publish_status(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>>
         &ovp_publish::run::RunOverrides::default(),
     )
     .is_ok();
-    let job = state.publish_job.lock().expect("publish job lock");
+    let job = state.publish_job.lock().unwrap_or_else(|e| e.into_inner());
     let body = serde_json::json!({
         "running": job.running,
         "configured": configured,

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -265,6 +265,19 @@ struct AppState {
     /// load-modify-save + note frontmatter replace + projection rebuild) —
     /// two concurrent curation writes must never interleave.
     tags_write_lock: std::sync::Mutex<()>,
+    /// The one background publish job (`POST /api/publish` + status). One at
+    /// a time — the vault RunLock inside the run enforces cross-process
+    /// safety, this slot gives the portal an honest "already running".
+    publish_job: Arc<std::sync::Mutex<PublishJob>>,
+}
+
+/// State of the portal-triggered publish job.
+#[derive(Default)]
+struct PublishJob {
+    running: bool,
+    /// Last finished run: the RunSummary JSON on success, `{error}` on
+    /// failure, plus `finished_at`.
+    last: Option<serde_json::Value>,
 }
 
 /// TTL cache for the live 01-Raw backlog count. A recursive walk of ~200 files
@@ -504,6 +517,7 @@ pub fn run_server(config: ServeConfig) -> Result<(), String> {
         ),
         live_queued: RwLock::new(LiveQueued::default()),
         tags_write_lock: std::sync::Mutex::new(()),
+        publish_job: Arc::new(std::sync::Mutex::new(PublishJob::default())),
     });
 
     // Pre-load model
@@ -573,7 +587,9 @@ fn serve_loop(server: &Server, state: &Arc<AppState>) {
         // (the same slow-body failure mode /api/ask already avoids).
         if method == Method::Post {
             let p = path.split('?').next().unwrap_or(&path).to_string();
-            if p == "/api/tags/decision" || (p.starts_with("/api/source/") && p.ends_with("/tags"))
+            if p == "/api/tags/decision"
+                || p == "/api/publish"
+                || (p.starts_with("/api/source/") && p.ends_with("/tags"))
             {
                 let headers = AskHeaders::of(&request);
                 if let Some(resp) = guard_json_same_origin(&headers) {
@@ -633,6 +649,8 @@ fn dispatch(
             json_response(200, r#"{"ok":true}"#)
         }
         (Method::Get, "/api/tags") => handle_tags_api(state),
+        (Method::Get, "/api/publish/status") => handle_publish_status(state),
+        (Method::Post, "/api/publish") => handle_publish_start(state),
         (Method::Post, "/api/tags/decision") => handle_tag_decision(state, body),
         (Method::Get, "/api/entities") => handle_entities_api(state),
         (Method::Get, p) if p.starts_with("/api/entity/") => handle_entity_api(state, url),
@@ -1026,6 +1044,77 @@ fn handle_themes(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
     let records = load_active_records(state);
     let body = bodies::themes_body(&records).to_string();
     json_stamped(200, &body, model.as_ref())
+}
+
+/// `POST /api/publish` — kick off ONE background publish run using
+/// `.ovp/publish.toml` (the portal/desktop button never passes flags; an
+/// unconfigured vault gets a 400 naming the file). 202 on start, 409 while a
+/// prior run is still going; progress/result via `GET /api/publish/status`.
+/// Vault consistency is the RunLock's job inside the run — this slot only
+/// keeps the portal honest about concurrency.
+fn handle_publish_start(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
+    let resolved = match ovp_publish::run::resolve_publish(
+        &state.vault_root,
+        &ovp_publish::run::RunOverrides::default(),
+    ) {
+        Ok(r) => r,
+        Err(e) => {
+            let body = serde_json::json!({ "error": e, "code": "publish_not_configured" });
+            return json_response(400, &body.to_string());
+        }
+    };
+    {
+        let mut job = state.publish_job.lock().expect("publish job lock");
+        if job.running {
+            return json_response(
+                409,
+                r#"{"error":"publish already running","code":"publish_running"}"#,
+            );
+        }
+        job.running = true;
+    }
+    let vault_root = state.vault_root.clone();
+    let job = Arc::clone(&state.publish_job);
+    std::thread::spawn(move || {
+        let date = ovp_index::now_rfc3339()[..10].to_string();
+        let result = ovp_publish::run::run_publish(&vault_root, &date, &resolved, false, false);
+        let outcome = match result {
+            Ok(summary) => {
+                let mut v = serde_json::to_value(&summary).unwrap_or_default();
+                if let Some(obj) = v.as_object_mut() {
+                    obj.insert("ok".into(), serde_json::Value::Bool(true));
+                    obj.insert("finished_at".into(), ovp_index::now_rfc3339().into());
+                }
+                v
+            }
+            Err(e) => serde_json::json!({
+                "ok": false,
+                "error": e,
+                "finished_at": ovp_index::now_rfc3339(),
+            }),
+        };
+        let mut job = job.lock().expect("publish job lock");
+        job.running = false;
+        job.last = Some(outcome);
+    });
+    json_response(202, r#"{"started":true}"#)
+}
+
+/// `GET /api/publish/status` — `{running, configured, last}` for the portal's
+/// publish card.
+fn handle_publish_status(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
+    let configured = ovp_publish::run::resolve_publish(
+        &state.vault_root,
+        &ovp_publish::run::RunOverrides::default(),
+    )
+    .is_ok();
+    let job = state.publish_job.lock().expect("publish job lock");
+    let body = serde_json::json!({
+        "running": job.running,
+        "configured": configured,
+        "last": job.last,
+    });
+    json_response(200, &body.to_string())
 }
 
 /// `GET /api/theme-pages` — the grounded topic pages built by
@@ -2122,6 +2211,7 @@ mod tests {
             ask_slots: AskSlots::new(DEFAULT_MAX_CONCURRENT_ASKS),
             live_queued: RwLock::new(LiveQueued::default()),
             tags_write_lock: std::sync::Mutex::new(()),
+            publish_job: Arc::new(std::sync::Mutex::new(PublishJob::default())),
         }
     }
 
@@ -2606,6 +2696,56 @@ mod tests {
         assert_eq!(resp.status_code(), 400);
         let resp = dispatch(&st, Method::Get, "/api/graph?scope=galaxy", "");
         assert_eq!(resp.status_code(), 400);
+
+        let _ = std::fs::remove_dir_all(vault.parent().unwrap());
+    }
+
+    #[test]
+    fn publish_endpoints_report_config_state_and_run_in_background() {
+        let vault = portal_vault("publish-ep", "50-Inbox/03-Processed/good.md", "body\n");
+        let st = state(vault.clone(), None);
+
+        // Unconfigured: status says so, POST is a 400 naming the config file.
+        let v = body_json(dispatch(&st, Method::Get, "/api/publish/status", ""));
+        assert_eq!(v["configured"], false);
+        assert_eq!(v["running"], false);
+        let resp = dispatch(&st, Method::Post, "/api/publish", "");
+        assert_eq!(resp.status_code(), 400);
+        let v = body_json(resp);
+        assert_eq!(v["code"], "publish_not_configured");
+
+        // Configure via .ovp/publish.toml (relative out resolves against the
+        // vault) and run one background publish to completion.
+        std::fs::write(
+            vault.join(".ovp/publish.toml"),
+            "out = \"../publish-site\"\n",
+        )
+        .unwrap();
+        // `..` in the configured out is rejected by the run guard — use an
+        // absolute sibling path instead.
+        let site = vault.parent().unwrap().join("publish-site");
+        std::fs::write(
+            vault.join(".ovp/publish.toml"),
+            format!("out = \"{}\"\n", site.display()),
+        )
+        .unwrap();
+        let resp = dispatch(&st, Method::Post, "/api/publish", "");
+        assert_eq!(resp.status_code(), 202);
+        let deadline = std::time::Instant::now() + Duration::from_secs(60);
+        let last = loop {
+            let v = body_json(dispatch(&st, Method::Get, "/api/publish/status", ""));
+            if v["running"] == false && !v["last"].is_null() {
+                break v["last"].clone();
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "publish never finished"
+            );
+            std::thread::sleep(Duration::from_millis(100));
+        };
+        assert_eq!(last["ok"], true, "{last}");
+        assert!(site.join("api/model.json").is_file(), "site tree written");
+        assert!(last["pushed"].is_null(), "no repo configured → no deploy");
 
         let _ = std::fs::remove_dir_all(vault.parent().unwrap());
     }


### PR DESCRIPTION
Closes the P2 backlog (operator-approved follow-ups from #336 + the providers-config debt).

## PP1 — .ovp/publish.toml
Publish orchestration moved into `ovp_publish::run` (config resolution, out-dir guards, assembly, SPA copy, git deploy, ledger) — CLI and portal execute the same path. Config persists out/repo/branch/spa_dir; flags override; unknown keys fail loud; relative paths resolve against the vault.

## PP2 — portal/desktop publish entry
`POST /api/publish` runs ONE background publish from that config (400 naming the file when unconfigured, 409 while running, same-origin guarded) + `GET /api/publish/status`; System page publish card (button + poll + last-run summary, hidden in static mode). Desktop inherits it through the embedded portal.

## PP3 — REAL deploy verified live (first time ever)
Against the real vault and a fresh private repo (`fakechris/ovp-site`):
- run 1: **3321 API files + static SPA pushed to gh-pages** — config-driven, zero flags, GITHUB_TOKEN supplied by providers.toml in a clean env
- run 2: **no-op gate correctly skipped the push**
- `git ls-remote` + raw index.html on the branch verified

## PP4 — .ovp/providers.toml
Flat `[env]` defaults table applied at CLI startup (pre-parse --vault-root peek) before any thread spawns; env-set variables win. The desktop performs NO env mutation (Tauri is multithreaded before any handler; scheduler jobs exec fresh ovp2 children that self-load). `job_shell_command` skips daily.env sourcing when providers.toml exists — the legacy file can no longer override it or EPERM the child launch. Whole-table validate-then-apply.

## Verification
Workspace tests green (incl. new publish-endpoint background-job test, config/guard/scheduler tests); real-vault PP3 evidence above; one codex round (2P1+1P2) fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added publishing for the public knowledge site through the system page.
  * View publish configuration, progress, results, file counts, and deployment status.
  * Start publishing immediately and receive clear success, no-change, or failure feedback.
  * Added publish configuration through `publish.toml`, including optional site bundles and deployment settings.
  * Added provider environment configuration with validation and safe precedence handling.
* **Bug Fixes**
  * Prevented overlapping publish operations and improved publish error reporting.
  * Scheduler jobs now handle provider configuration consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->