### PR TITLE
feat(viz): P3-VZ1 — evidence-closure trace in the knowledge graph

### DIFF
--- a/console-ui/src/components/KnowledgeGraph.tsx
+++ b/console-ui/src/components/KnowledgeGraph.tsx
@@ -21,12 +21,13 @@ import { polygonCentroid, polygonHull } from 'd3-polygon';
 import { useNavigate } from 'react-router-dom';
 import { useI18n } from '../i18n';
 import {
+  fetchClaim,
   fetchGlobalGraph,
   fetchSourceNeighborhood,
   fetchThemeGraph,
 } from '../lib/api';
-import { isMiscTheme, themeRoute } from '../lib/derive';
-import type { GraphNode, GraphResponse } from '../lib/types';
+import { closureNodeIds, isMiscTheme, themeRoute } from '../lib/derive';
+import type { ClaimDetail, GraphNode, GraphResponse } from '../lib/types';
 import { useModel } from '../model';
 import { EmptyState } from './ui';
 
@@ -190,6 +191,10 @@ export default function KnowledgeGraph({
   const [data, setData] = useState<GraphResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [selected, setSelected] = useState<GraphNode | null>(null);
+  /** Evidence closure of the SELECTED claim node (VZ1): its full citation
+   * detail, fetched on selection. `forId` guards against a stale response
+   * landing after the selection moved on. */
+  const [closure, setClosure] = useState<{ forId: string; detail: ClaimDetail } | null>(null);
   const [hoverId, setHoverId] = useState<string | null>(null);
   const [fullscreen, setFullscreen] = useState(false);
   const [mode, setMode] = useState<'2d' | '3d'>('2d');
@@ -294,6 +299,42 @@ export default function KnowledgeGraph({
     [data],
   );
 
+  // Fetch the selected claim's evidence closure. Silent on failure — the
+  // highlight then falls back to direct graph neighbors and the panel keeps
+  // its pre-VZ1 content.
+  useEffect(() => {
+    if (selected?.type !== 'claim') {
+      setClosure(null);
+      return;
+    }
+    const nodeId = selected.id;
+    const claimKey = nodeId.startsWith('claim:') ? nodeId.slice('claim:'.length) : nodeId;
+    let cancelled = false;
+    fetchClaim(claimKey)
+      .then((detail) => {
+        if (!cancelled) setClosure({ forId: nodeId, detail });
+      })
+      .catch(() => {
+        if (!cancelled) setClosure(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selected]);
+
+  /** Node ids inside the selected claim's evidence closure, or null when no
+   * claim is selected. Everything OUTSIDE the closure dims. */
+  const closureSet = useMemo(() => {
+    if (selected?.type !== 'claim') return null;
+    const detail = closure?.forId === selected.id ? closure.detail : null;
+    return closureNodeIds(
+      selected.id,
+      detail?.citations ?? null,
+      (id) => nodeById.has(id),
+      adjacency,
+    );
+  }, [selected, closure, nodeById, adjacency]);
+
   // Configure forces the moment the (lazy) graph instance mounts — a
   // data-effect would run while the graph is still suspended (ref null) and
   // never apply. Also fires when 2D/3D swaps to a fresh instance.
@@ -322,6 +363,12 @@ export default function KnowledgeGraph({
   useEffect(() => {
     fittedRef.current = false;
   }, [data, mode]);
+
+  /** ~15% alpha variant of a #rrggbb color (pass-through otherwise) — the
+   * out-of-closure fade for 3D nodes and 2D links, matching drawNode's
+   * globalAlpha dim. */
+  const faintColor = (c: string) =>
+    /^#[0-9a-f]{6}$/i.test(c) ? `${c}26` : c;
 
   const openNode = (n: GraphNode) => {
     if (n.type === 'source') {
@@ -412,10 +459,12 @@ export default function KnowledgeGraph({
     const isHover = hoverId === node.id;
     const isNeighbor =
       hoverId != null && (adjacency.get(hoverId)?.has(node.id) ?? false);
-    // Dim the rest to focus the hovered neighborhood. Safe now that hover only
-    // engages after the cursor settles (handleHover) — it no longer flips as
-    // the mouse sweeps across.
-    const dim = hoverId != null && !isHover && !isNeighbor;
+    // Dim the rest to focus the hovered neighborhood — or, when a claim is
+    // selected, everything OUTSIDE its evidence closure (VZ1: the claim +
+    // its cited sources stay lit; hover still punches through the dim).
+    const dim = closureSet
+      ? !closureSet.has(node.id) && !isHover
+      : hoverId != null && !isHover && !isNeighbor;
     const r = nodeRadius(node, isFocus);
     const x = node.x ?? 0;
     const y = node.y ?? 0;
@@ -526,9 +575,11 @@ export default function KnowledgeGraph({
 
   const onNodeClick = (node: FGNode) => {
     const n = nodeById.get(node.id) ?? node;
-    // Single click opens (matches the Terrain view's one-click-to-source). Only
-    // non-openable nodes (e.g. focus-tier units) fall back to select + zoom.
-    if (canOpen(n)) {
+    // Sources open on single click (matches the Terrain view). Claims now
+    // SELECT instead (VZ1): the click lights up the claim's evidence closure
+    // and the side panel lists its citations — navigation moved to the
+    // panel's Open button. Other non-openable nodes fall back to select+zoom.
+    if (n.type !== 'claim' && canOpen(n)) {
       openNode(n);
       return;
     }
@@ -540,10 +591,10 @@ export default function KnowledgeGraph({
     }
   };
 
-  // 3D: single click opens too; non-openable nodes select + fly the camera.
+  // 3D: same contract — sources open, claims select + closure + camera fly.
   const onNodeClick3D = (node: FGNode) => {
     const n = nodeById.get(node.id) ?? node;
-    if (canOpen(n)) {
+    if (n.type !== 'claim' && canOpen(n)) {
       openNode(n);
       return;
     }
@@ -637,19 +688,26 @@ export default function KnowledgeGraph({
                 onRenderFramePost={drawLabels}
                 nodePointerAreaPaint={paintPointerArea}
                 linkColor={(l: { source: FGNode; target: FGNode }) => {
-                  const active =
-                    hoverId != null &&
-                    ((l.source as FGNode).id === hoverId ||
-                      (l.target as FGNode).id === hoverId);
+                  const s = (l.source as FGNode).id;
+                  const t2 = (l.target as FGNode).id;
+                  if (closureSet) {
+                    // Closure edges (claim ↔ cited source) light up; every
+                    // other edge fades with its nodes.
+                    return closureSet.has(s) && closureSet.has(t2)
+                      ? tokens.linkHi
+                      : faintColor(tokens.link);
+                  }
+                  const active = hoverId != null && (s === hoverId || t2 === hoverId);
                   return active ? tokens.linkHi : tokens.link;
                 }}
-                linkWidth={(l: { source: FGNode; target: FGNode }) =>
-                  hoverId != null &&
-                  ((l.source as FGNode).id === hoverId ||
-                    (l.target as FGNode).id === hoverId)
-                    ? 1.5
-                    : 0.6
-                }
+                linkWidth={(l: { source: FGNode; target: FGNode }) => {
+                  const s = (l.source as FGNode).id;
+                  const t2 = (l.target as FGNode).id;
+                  if (closureSet) {
+                    return closureSet.has(s) && closureSet.has(t2) ? 1.5 : 0.4;
+                  }
+                  return hoverId != null && (s === hoverId || t2 === hoverId) ? 1.5 : 0.6;
+                }}
                 onNodeHover={handleHover}
                 onNodeClick={onNodeClick}
                 onBackgroundClick={() => setSelected(null)}
@@ -662,21 +720,28 @@ export default function KnowledgeGraph({
                 graphData={graphData}
                 backgroundColor="#0b0e15"
                 nodeRelSize={4}
-                nodeColor={(n: FGNode) =>
-                  n.id === hoverId ? tokens.linkHi : scopedFill(scope, n, tokens)
-                }
+                nodeColor={(n: FGNode) => {
+                  if (n.id === hoverId) return tokens.linkHi;
+                  const fill = scopedFill(scope, n, tokens);
+                  return closureSet && !closureSet.has(n.id) ? faintColor(fill) : fill;
+                }}
                 nodeVal={(n: FGNode) => 1.5 + 6 * (n.importance ?? 0)}
                 nodeLabel={(n: FGNode) => escapeHtml(n.label)}
                 nodeOpacity={1}
                 nodeResolution={12}
                 showNavInfo={false}
-                linkColor={(l: { source: FGNode; target: FGNode }) =>
-                  hoverId != null &&
-                  ((l.source as FGNode).id === hoverId ||
-                    (l.target as FGNode).id === hoverId)
+                linkColor={(l: { source: FGNode; target: FGNode }) => {
+                  const s = (l.source as FGNode).id;
+                  const t2 = (l.target as FGNode).id;
+                  if (closureSet) {
+                    return closureSet.has(s) && closureSet.has(t2)
+                      ? tokens.linkHi
+                      : '#2a2f3a';
+                  }
+                  return hoverId != null && (s === hoverId || t2 === hoverId)
                     ? tokens.linkHi
-                    : '#5a6270'
-                }
+                    : '#5a6270';
+                }}
                 linkOpacity={0.5}
                 linkWidth={0.6}
                 onNodeHover={handleHover}
@@ -771,6 +836,37 @@ export default function KnowledgeGraph({
               ) : (
                 <div className="tiny muted">
                   {selected.type === 'card' ? t('graph.cardHint') : t('graph.noPage')}
+                </div>
+              )}
+              {selected.type === 'claim' && closure?.forId === selected.id && (
+                <div className="graph-evidence">
+                  <div className="graph-evidence-title">
+                    {t('graph.evidenceTitle')}
+                  </div>
+                  {closure.detail.citations.map((c, i) => (
+                    <div className="graph-evidence-item" key={`${c.unit_id}-${i}`}>
+                      <div className="graph-evidence-quote">
+                        “{c.quote.length > 160 ? `${c.quote.slice(0, 160)}…` : c.quote}”
+                      </div>
+                      <div className="tiny muted">
+                        {c.unit_id}
+                        {c.resolved_line != null &&
+                          ` · ${t('graph.evidenceLine', { n: c.resolved_line })}`}
+                        {' · '}
+                        {c.source_sha256 && knownShas.has(c.source_sha256) ? (
+                          <button
+                            type="button"
+                            className="graph-evidence-src"
+                            onClick={() => navigate(`/library/${c.source_sha256}`)}
+                          >
+                            {c.source_title || c.case_id}
+                          </button>
+                        ) : (
+                          <span>{c.source_title || c.case_id}</span>
+                        )}
+                      </div>
+                    </div>
+                  ))}
                 </div>
               )}
             </div>

--- a/console-ui/src/components/KnowledgeGraph.tsx
+++ b/console-ui/src/components/KnowledgeGraph.tsx
@@ -50,6 +50,8 @@ export interface KnowledgeGraphProps {
 }
 
 const DEFAULT_HEIGHT = 360;
+/** Evidence-panel quote truncation (VZ1). */
+const MAX_QUOTE_LENGTH = 160;
 /** Base zoom at which a MAX-importance node reveals its label; leaves need to
  * be zoomed in further. Below this the graph reads as a labelled constellation
  * of only its most important nodes — the level-of-detail the old view lacked. */
@@ -365,11 +367,15 @@ export default function KnowledgeGraph({
   }, [data, mode]);
 
   /** ~15% alpha variant of a color — the out-of-closure fade for 3D nodes
-   * and 2D links, matching drawNode's globalAlpha dim. Handles both the
-   * #rrggbb form and the rgba(...) form the --graph-link tokens use
-   * (alpha replaced, not multiplied — the fade is the statement). */
+   * and 2D links, matching drawNode's globalAlpha dim. Handles #rgb/#rrggbb
+   * and the rgba(...) form the --graph-link tokens use (alpha replaced, not
+   * multiplied — the fade is the statement). */
   const faintColor = (c: string) => {
     if (/^#[0-9a-f]{6}$/i.test(c)) return `${c}26`;
+    if (/^#[0-9a-f]{3}$/i.test(c)) {
+      const [r, g, b] = c.slice(1);
+      return `#${r}${r}${g}${g}${b}${b}26`;
+    }
     const m = c.match(/^rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)/i);
     if (m) return `rgba(${m[1]}, ${m[2]}, ${m[3]}, 0.15)`;
     return c;
@@ -848,10 +854,10 @@ export default function KnowledgeGraph({
                   <div className="graph-evidence-title">
                     {t('graph.evidenceTitle')}
                   </div>
-                  {closure.detail.citations.map((c, i) => (
+                  {(closure.detail.citations ?? []).map((c, i) => (
                     <div className="graph-evidence-item" key={`${c.unit_id}-${i}`}>
                       <div className="graph-evidence-quote">
-                        “{c.quote.length > 160 ? `${c.quote.slice(0, 160)}…` : c.quote}”
+                        “{c.quote.length > MAX_QUOTE_LENGTH ? `${c.quote.slice(0, MAX_QUOTE_LENGTH)}…` : c.quote}”
                       </div>
                       <div className="tiny muted">
                         {c.unit_id}

--- a/console-ui/src/components/KnowledgeGraph.tsx
+++ b/console-ui/src/components/KnowledgeGraph.tsx
@@ -364,11 +364,16 @@ export default function KnowledgeGraph({
     fittedRef.current = false;
   }, [data, mode]);
 
-  /** ~15% alpha variant of a #rrggbb color (pass-through otherwise) — the
-   * out-of-closure fade for 3D nodes and 2D links, matching drawNode's
-   * globalAlpha dim. */
-  const faintColor = (c: string) =>
-    /^#[0-9a-f]{6}$/i.test(c) ? `${c}26` : c;
+  /** ~15% alpha variant of a color — the out-of-closure fade for 3D nodes
+   * and 2D links, matching drawNode's globalAlpha dim. Handles both the
+   * #rrggbb form and the rgba(...) form the --graph-link tokens use
+   * (alpha replaced, not multiplied — the fade is the statement). */
+  const faintColor = (c: string) => {
+    if (/^#[0-9a-f]{6}$/i.test(c)) return `${c}26`;
+    const m = c.match(/^rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)/i);
+    if (m) return `rgba(${m[1]}, ${m[2]}, ${m[3]}, 0.15)`;
+    return c;
+  };
 
   const openNode = (n: GraphNode) => {
     if (n.type === 'source') {

--- a/console-ui/src/design/portal.css
+++ b/console-ui/src/design/portal.css
@@ -1073,6 +1073,11 @@ body {
   bottom: 0.5rem;
   z-index: 2;
   max-width: min(320px, calc(100% - 1rem));
+  /* The whole card stays inside the graph viewport and scrolls as one —
+     an inner-only scroll would let a long evidence list push the claim
+     header + Open button above the embed's overflow:hidden clip (VZ1). */
+  max-height: calc(100% - 1rem);
+  overflow-y: auto;
   border: 1px solid var(--border);
   border-radius: var(--ovp-radius-md);
   background: var(--surface);
@@ -1728,8 +1733,6 @@ body {
   margin-top: 8px;
   border-top: 1px solid var(--border, #2a2f3a);
   padding-top: 6px;
-  max-height: 260px;
-  overflow-y: auto;
 }
 .graph-evidence-title {
   font-size: 11px;

--- a/console-ui/src/design/portal.css
+++ b/console-ui/src/design/portal.css
@@ -1722,3 +1722,38 @@ body {
   background: rgba(120, 180, 205, 0.2);
   color: #fff;
 }
+
+/* VZ1 — evidence-closure panel inside .graph-info */
+.graph-evidence {
+  margin-top: 8px;
+  border-top: 1px solid var(--border, #2a2f3a);
+  padding-top: 6px;
+  max-height: 260px;
+  overflow-y: auto;
+}
+.graph-evidence-title {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  opacity: 0.7;
+  margin-bottom: 4px;
+}
+.graph-evidence-item {
+  margin-bottom: 8px;
+}
+.graph-evidence-quote {
+  font-size: 12px;
+  line-height: 1.45;
+  font-style: italic;
+  opacity: 0.9;
+}
+.graph-evidence-src {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: var(--accent, #7aa2f7);
+  cursor: pointer;
+  text-decoration: underline;
+}

--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -231,6 +231,8 @@ export const en = {
   'graph.kindCard': 'card',
   'graph.openHint': 'Click for a summary, then Open.',
   'graph.open': 'Open',
+  'graph.evidenceTitle': 'Evidence chain',
+  'graph.evidenceLine': 'line {n}',
   'graph.no3d': '3D needs WebGL, which is unavailable in this browser.',
   'graph.controls3d': 'Drag to rotate · scroll to zoom · right-drag to pan',
   'graph.focusCommunity': 'Focus this community',

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -221,6 +221,8 @@ export const zh: Record<keyof typeof en, string> = {
   'graph.controls3d': '拖拽旋转 · 滚轮缩放 · 右键平移',
   'graph.focusCommunity': '聚焦这个社区',
   'graph.open': '打开',
+  'graph.evidenceTitle': '证据链路',
+  'graph.evidenceLine': '第 {n} 行',
   'graph.noPage': '旧源——该 vault 中没有对应的详情页。',
   'graph.cardHint': '这是本源的记忆——完整卡片在"记忆"标签页。',
 

--- a/console-ui/src/lib/derive.test.ts
+++ b/console-ui/src/lib/derive.test.ts
@@ -347,6 +347,19 @@ describe('closureNodeIds (VZ1 evidence closure)', () => {
     expect([...out].sort()).toEqual(['claim:ck-a', 'source:s1']);
   });
 
+  it('never presents related claims as evidence once citations are known', () => {
+    // Claim-perspective overview: NO source nodes exist, only `related`
+    // claim neighbors — with citations resolved, the closure must be the
+    // claim alone (codex P1), not its related claims.
+    const out = closureNodeIds(
+      'claim:ck-a',
+      [{ source_sha256: 's1' }],
+      (id) => id.startsWith('claim:'),
+      adjacency,
+    );
+    expect([...out]).toEqual(['claim:ck-a']);
+  });
+
   it('falls back to graph neighbors while citations are unavailable', () => {
     const out = closureNodeIds('claim:ck-a', null, () => true, adjacency);
     expect(out.has('source:s1')).toBe(true);

--- a/console-ui/src/lib/derive.test.ts
+++ b/console-ui/src/lib/derive.test.ts
@@ -2,6 +2,7 @@
  * Pure functions over the model + a passed-in wall clock — no DOM. */
 import { describe, expect, it } from 'vitest';
 import {
+  closureNodeIds,
   healthLevel,
   isRunningWithProgress,
   lastRunBanner,
@@ -328,5 +329,32 @@ describe('parsePageBody', () => {
         { kind: 'text', text: '，而不是附加功能。' },
       ],
     ]);
+  });
+});
+
+describe('closureNodeIds (VZ1 evidence closure)', () => {
+  const adjacency = new Map<string, Set<string>>([
+    ['claim:ck-a', new Set(['source:s1', 'claim:ck-b'])],
+  ]);
+
+  it('uses cited sources present in the graph, ignoring absent ones', () => {
+    const out = closureNodeIds(
+      'claim:ck-a',
+      [{ source_sha256: 's1' }, { source_sha256: 's-absent' }],
+      (id) => id === 'source:s1' || id === 'claim:ck-a',
+      adjacency,
+    );
+    expect([...out].sort()).toEqual(['claim:ck-a', 'source:s1']);
+  });
+
+  it('falls back to graph neighbors while citations are unavailable', () => {
+    const out = closureNodeIds('claim:ck-a', null, () => true, adjacency);
+    expect(out.has('source:s1')).toBe(true);
+    expect(out.has('claim:ck-b')).toBe(true);
+  });
+
+  it('always contains the claim itself, even with nothing else', () => {
+    const out = closureNodeIds('claim:ck-x', [], () => false, new Map());
+    expect([...out]).toEqual(['claim:ck-x']);
   });
 });

--- a/console-ui/src/lib/derive.ts
+++ b/console-ui/src/lib/derive.ts
@@ -586,3 +586,25 @@ export function ageParts(
     return { unknown: false, builtAt, seconds, unit: 'hour', value: Math.floor(seconds / HOUR) };
   return { unknown: false, builtAt, seconds, unit: 'day', value: Math.floor(seconds / DAY) };
 }
+
+/** VZ1 — the evidence-closure node set for a selected claim node: the claim
+ * itself plus its cited sources' graph nodes (`source:<sha256>`, filtered to
+ * nodes actually present). While the citation detail hasn't arrived (or the
+ * fetch failed), fall back to the claim's direct graph neighbors so the
+ * dim/highlight never waits on the network. Pure — vitest-covered. */
+export function closureNodeIds(
+  selectedId: string,
+  citations: { source_sha256: string }[] | null,
+  hasNode: (id: string) => boolean,
+  adjacency: Map<string, Set<string>>,
+): Set<string> {
+  const out = new Set<string>([selectedId]);
+  for (const c of citations ?? []) {
+    const id = `source:${c.source_sha256}`;
+    if (hasNode(id)) out.add(id);
+  }
+  if (out.size === 1) {
+    for (const n of adjacency.get(selectedId) ?? []) out.add(n);
+  }
+  return out;
+}

--- a/console-ui/src/lib/derive.ts
+++ b/console-ui/src/lib/derive.ts
@@ -589,9 +589,12 @@ export function ageParts(
 
 /** VZ1 — the evidence-closure node set for a selected claim node: the claim
  * itself plus its cited sources' graph nodes (`source:<sha256>`, filtered to
- * nodes actually present). While the citation detail hasn't arrived (or the
- * fetch failed), fall back to the claim's direct graph neighbors so the
- * dim/highlight never waits on the network. Pure — vitest-covered. */
+ * nodes actually present). ONLY while the citation detail hasn't arrived (or
+ * the fetch failed, `citations === null`) does it fall back to direct graph
+ * neighbors — once citations are known, neighbors must NOT stand in for
+ * evidence: in the claim-perspective overview the neighbors are merely
+ * `related` claims, and lighting them up would present relatedness as
+ * provenance. Pure — vitest-covered. */
 export function closureNodeIds(
   selectedId: string,
   citations: { source_sha256: string }[] | null,
@@ -599,12 +602,13 @@ export function closureNodeIds(
   adjacency: Map<string, Set<string>>,
 ): Set<string> {
   const out = new Set<string>([selectedId]);
-  for (const c of citations ?? []) {
+  if (citations === null) {
+    for (const n of adjacency.get(selectedId) ?? []) out.add(n);
+    return out;
+  }
+  for (const c of citations) {
     const id = `source:${c.source_sha256}`;
     if (hasNode(id)) out.add(id);
-  }
-  if (out.size === 1) {
-    for (const n of adjacency.get(selectedId) ?? []) out.add(n);
   }
   return out;
 }


### PR DESCRIPTION
The competitive-scan hero interaction (Marble's tap-to-trace, applied to OUR moat): clicking a claim node lights up its **evidence closure** — the claim plus the sources it cites — and dims everything else.

- Claims now select on click (2D + 3D); navigation moved to the panel's Open button. Sources keep one-click-open.
- Side panel gains the evidence chain: verbatim quote, unit id + resolved line, source link to /library/<sha> (sha-guarded).
- Closure = citations from /api/claim/<claim_key> (graph node ids carry the ledger key; works live and in the published static site). Neighbor fallback ONLY while the detail is loading/failed — once citations are known, related claims are never presented as provenance.
- Dim rendering: 2D canvas alpha + rgba-aware faint link colors, 3D faint node/link colors; hover punches through.

Verification: console-ui build + 42 vitest (closureNodeIds pure-helper coverage incl. the relatedness≠provenance case); one codex round (1P1+2P2) fixed.