### PR TITLE
fix(desktop): async boot/set_vault_and_start — window stays responsive during startup

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -232,7 +232,9 @@ fn start_scheduler(state: &AppState, vault: &Path) {
         // spawn error (codex/bot review).
         match init {
             Ok(s) if !s.success() => {
-                eprintln!("ovp2-desktop: schedule init exited non-zero ({s}) — scheduler may not run")
+                eprintln!(
+                    "ovp2-desktop: schedule init exited non-zero ({s}) — scheduler may not run"
+                )
             }
             Err(e) => eprintln!("ovp2-desktop: schedule init failed to spawn: {e}"),
             _ => {}
@@ -264,10 +266,13 @@ fn valid_vault(vault: &str) -> bool {
 // Tauri commands (the small surface the splash calls).
 // ---------------------------------------------------------------------------
 
+// async: Tauri runs async commands OFF the main thread, so the 1-2s server
+// start (and any slow vault IO) can never beachball the window. The sync
+// form runs on the main thread and froze the UI for its whole duration.
 #[tauri::command]
-fn boot(app: AppHandle, state: State<AppState>) -> BootState {
+async fn boot(app: AppHandle, state: State<'_, AppState>) -> Result<BootState, String> {
     let cfg = load_config(&app);
-    match cfg.vault {
+    Ok(match cfg.vault {
         Some(vault) if valid_vault(&vault) => {
             let v = PathBuf::from(&vault);
             match ensure_server(&app, &state, &v) {
@@ -279,15 +284,24 @@ fn boot(app: AppHandle, state: State<AppState>) -> BootState {
             }
         }
         _ => BootState::NeedVault,
-    }
+    })
 }
 
 #[tauri::command]
-fn set_vault_and_start(app: AppHandle, state: State<AppState>, vault: String) -> Result<String, String> {
+async fn set_vault_and_start(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    vault: String,
+) -> Result<String, String> {
     if !valid_vault(&vault) {
         return Err("that folder is not a readable directory".into());
     }
-    save_config(&app, &AppConfig { vault: Some(vault.clone()) })?;
+    save_config(
+        &app,
+        &AppConfig {
+            vault: Some(vault.clone()),
+        },
+    )?;
     let v = PathBuf::from(&vault);
     let url = ensure_server(&app, &state, &v)?;
     start_scheduler(&state, &v);


### PR DESCRIPTION
Diagnosis session 2026-07-21 (operator-reported freeze on vault selection):

1. **White screen (new regression)**: yesterday's instrumentation build had its splash frontend assets broken at bundle time — the webview had literally nothing to render. Fixed by discarding the uncommitted instrumentation and rebuilding cleanly (splash `npm run build` → staged sidecar → `npm run tauri -- build`). No code change needed.
2. **Folder-dialog stall (original complaint)**: `sample` during a scripted reproduction pins the main thread inside `NSSavePanel _initBridgeAndStuff → ViewBridge NSCFRunLoopSemaphore wait → XPC to openAndSavePanelService` (~10s on this machine) — Apple's panel remote-service init, synchronous on the main thread by design, aggravated by ad-hoc signing (every rebuild = new cdhash = fresh syspolicyd/XProtect assessment, which is the disk IO observed). Not our code; Developer-ID + notarization (backlog G4) is the durable fix, and a pre-seeded config.json bypasses the picker entirely.
3. **This PR**: sync Tauri commands run on the macOS main thread — `boot`/`set_vault_and_start` froze the window for the whole server start on every launch. They are now async (runtime pool), so the splash stays responsive.

Verified: bundle rebuilt, app boots straight into the portal with the persisted vault (in-process server, theme-pages 15 pages served).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of desktop app startup and vault setup operations.
  * Invalid vault selections continue to return clear errors without proceeding.
  * Scheduler initialization failures now display more readable error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->