### PR TITLE
feat(desktop): Obsidian-style vault management — switch, close, recents, auto-open

### DIFF
--- a/apps/desktop/index.html
+++ b/apps/desktop/index.html
@@ -20,6 +20,11 @@
         border: 2px solid #2a2e35; border-top-color: #38bdcc; animation: spin 0.8s linear infinite; display: inline-block; }
       @keyframes spin { to { transform: rotate(360deg); } }
       .hidden { display: none; }
+      #recent { margin-top: 18px; display: flex; flex-direction: column; gap: 8px; align-items: center; }
+      #recent button { margin-top: 0; background: #1a1f27; color: #e9e6e0; border: 1px solid #2a2e35;
+        font-weight: 500; max-width: 420px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+      #recent button:hover { border-color: #38bdcc88; }
+      #recent .path { color: #6b7178; font-size: 11px; margin-left: 8px; }
     </style>
   </head>
   <body>
@@ -29,6 +34,7 @@
         <div id="spinner" class="spinner"></div>
         <div id="msg" class="msg">Starting…</div>
         <div id="onboard" class="hidden">
+          <div id="recent"></div>
           <button id="pick">Choose your vault folder…</button>
           <div class="sub">Pick the Obsidian vault OVP2 should read and organize. You can change it later in Settings.</div>
         </div>

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -27,6 +27,35 @@ const SCHEDULER_INTERVAL: Duration = Duration::from_secs(600);
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 struct AppConfig {
     vault: Option<String>,
+    /// Obsidian-style recent-vault list, most-recent-first (additive: older
+    /// config files deserialize to empty). The current `vault` is always
+    /// also the head of this list after a successful open.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    known_vaults: Vec<String>,
+}
+
+/// Recent-list cap — enough for real multi-vault use, small enough for a menu.
+const MAX_KNOWN_VAULTS: usize = 10;
+
+/// The updated recent list after opening `vault`: moved/inserted at the head,
+/// deduped, capped. Pure — unit tested.
+fn remember_vault(known: &[String], vault: &str) -> Vec<String> {
+    let mut out = vec![vault.to_string()];
+    out.extend(known.iter().filter(|v| v.as_str() != vault).cloned());
+    out.truncate(MAX_KNOWN_VAULTS);
+    out
+}
+
+/// Menu label for a vault path: "<folder> — <parent dir>".
+fn vault_label(path: &str) -> String {
+    let p = Path::new(path);
+    let name = p.file_name().map(|n| n.to_string_lossy().to_string());
+    let parent = p.parent().map(|d| d.display().to_string());
+    match (name, parent) {
+        (Some(n), Some(d)) if !d.is_empty() => format!("{n} — {d}"),
+        (Some(n), _) => n,
+        _ => path.to_string(),
+    }
 }
 
 fn config_file(app: &AppHandle) -> Option<PathBuf> {
@@ -40,9 +69,20 @@ fn load_config(app: &AppHandle) -> AppConfig {
     // Env override wins (dev / CI): OVP2_VAULT points the app at a vault
     // without going through onboarding.
     match std::env::var("OVP2_VAULT") {
-        Ok(v) if !v.trim().is_empty() => return AppConfig { vault: Some(v) },
+        Ok(v) if !v.trim().is_empty() => {
+            // Env override carries no recent list of its own — keep the
+            // persisted one so the menu/splash still show it.
+            let mut cfg = read_config_file(app);
+            cfg.vault = Some(v);
+            return cfg;
+        }
         _ => {}
     }
+    read_config_file(app)
+}
+
+/// The persisted config.json, ignoring the OVP2_VAULT env override.
+fn read_config_file(app: &AppHandle) -> AppConfig {
     let Some(path) = config_file(app) else {
         return AppConfig::default();
     };
@@ -274,6 +314,20 @@ async fn boot(app: AppHandle, state: State<'_, AppState>) -> Result<BootState, S
     let cfg = load_config(&app);
     Ok(match cfg.vault {
         Some(vault) if valid_vault(&vault) => {
+            // A hand-seeded or env-provided vault may not be in the recent
+            // list yet — remember it (best-effort) so the Vault menu and the
+            // splash quick-pick know about it.
+            if !cfg.known_vaults.iter().any(|v| v == &vault) {
+                let cfg_file = read_config_file(&app);
+                let _ = save_config(
+                    &app,
+                    &AppConfig {
+                        vault: cfg_file.vault.clone().or_else(|| Some(vault.clone())),
+                        known_vaults: remember_vault(&cfg_file.known_vaults, &vault),
+                    },
+                );
+                refresh_vault_menu(&app);
+            }
             let v = PathBuf::from(&vault);
             match ensure_server(&app, &state, &v) {
                 Ok(url) => {
@@ -296,16 +350,146 @@ async fn set_vault_and_start(
     if !valid_vault(&vault) {
         return Err("that folder is not a readable directory".into());
     }
+    let prev = load_config(&app);
     save_config(
         &app,
         &AppConfig {
             vault: Some(vault.clone()),
+            known_vaults: remember_vault(&prev.known_vaults, &vault),
         },
     )?;
+    refresh_vault_menu(&app);
     let v = PathBuf::from(&vault);
     let url = ensure_server(&app, &state, &v)?;
     start_scheduler(&state, &v);
     Ok(url)
+}
+
+/// The recent-vault list for the splash quick-pick (existing dirs only) —
+/// one click straight into a vault, no NSOpenPanel involved.
+#[tauri::command]
+async fn known_vaults(app: AppHandle) -> Result<Vec<String>, String> {
+    Ok(load_config(&app)
+        .known_vaults
+        .into_iter()
+        .filter(|v| valid_vault(v))
+        .collect())
+}
+
+// ---------------------------------------------------------------------------
+// Vault menu — Obsidian-style switching. Every action is config + restart:
+// one mechanism, and the boot path (auto-open the persisted vault, else the
+// splash picker) does the rest. Restart also rebinds the scheduler and the
+// in-process server to the new vault with zero lifecycle juggling.
+// ---------------------------------------------------------------------------
+
+/// Persist `vault` as current (+ remember it) and relaunch. No-op when it is
+/// already the current vault or the directory is gone.
+fn switch_to_vault(app: &AppHandle, vault: &str) {
+    if !valid_vault(vault) {
+        eprintln!("ovp2-desktop: vault {vault} is not a readable directory — not switching");
+        return;
+    }
+    let prev = load_config(app);
+    if prev.vault.as_deref() == Some(vault) {
+        return;
+    }
+    let cfg = AppConfig {
+        vault: Some(vault.to_string()),
+        known_vaults: remember_vault(&prev.known_vaults, vault),
+    };
+    if let Err(e) = save_config(app, &cfg) {
+        eprintln!("ovp2-desktop: could not save vault config: {e}");
+        return;
+    }
+    app.restart();
+}
+
+fn handle_menu_event(app: &AppHandle, id: &str) {
+    match id {
+        "vault-close" => {
+            // Back to the splash picker (recent list keeps the old vault one
+            // click away).
+            let mut cfg = load_config(app);
+            cfg.vault = None;
+            if let Err(e) = save_config(app, &cfg) {
+                eprintln!("ovp2-desktop: could not save vault config: {e}");
+                return;
+            }
+            app.restart();
+        }
+        "vault-choose" => {
+            use tauri_plugin_dialog::DialogExt;
+            let handle = app.clone();
+            app.dialog().file().pick_folder(move |dir| {
+                let Some(dir) = dir else { return };
+                match dir.into_path() {
+                    Ok(p) => switch_to_vault(&handle, &p.to_string_lossy()),
+                    Err(e) => eprintln!("ovp2-desktop: folder pick failed: {e}"),
+                }
+            });
+        }
+        other => {
+            if let Some(path) = other.strip_prefix("vault-open:") {
+                switch_to_vault(app, path);
+            }
+        }
+    }
+}
+
+/// Build the "Vault" submenu appended to the standard menu bar: choose,
+/// recent vaults (current one checked), close. Rebuilt at launch AND after
+/// any config change (boot remembering a seeded vault, a splash pick), so
+/// the menu always reflects the live recent list.
+fn rebuild_vault_menu(handle: &AppHandle) -> tauri::Result<()> {
+    use tauri::menu::{CheckMenuItem, Menu, MenuItem, PredefinedMenuItem, Submenu};
+    let cfg = load_config(handle);
+
+    let menu = Menu::default(handle)?;
+    let vault_menu = Submenu::new(handle, "Vault", true)?;
+    vault_menu.append(&MenuItem::with_id(
+        handle,
+        "vault-choose",
+        "Choose Vault Folder…",
+        true,
+        None::<&str>,
+    )?)?;
+    if !cfg.known_vaults.is_empty() {
+        vault_menu.append(&PredefinedMenuItem::separator(handle)?)?;
+        for v in &cfg.known_vaults {
+            let checked = cfg.vault.as_deref() == Some(v.as_str());
+            vault_menu.append(&CheckMenuItem::with_id(
+                handle,
+                format!("vault-open:{v}"),
+                vault_label(v),
+                true,
+                checked,
+                None::<&str>,
+            )?)?;
+        }
+    }
+    vault_menu.append(&PredefinedMenuItem::separator(handle)?)?;
+    vault_menu.append(&MenuItem::with_id(
+        handle,
+        "vault-close",
+        "Close Vault",
+        cfg.vault.is_some(),
+        None::<&str>,
+    )?)?;
+    menu.append(&vault_menu)?;
+    handle.set_menu(menu)?;
+    Ok(())
+}
+
+/// Menu rebuild from any thread: hops to the main thread (menus are
+/// main-thread state on macOS).
+fn refresh_vault_menu(app: &AppHandle) {
+    let h = app.clone();
+    let _ = app.run_on_main_thread(move || {
+        if let Err(e) = rebuild_vault_menu(&h) {
+            eprintln!("ovp2-desktop: vault menu rebuild failed: {e}");
+        }
+    });
 }
 
 #[cfg(test)]
@@ -325,13 +509,45 @@ mod tests {
     fn app_config_json_round_trips() {
         let cfg = AppConfig {
             vault: Some("/Users/op/ovp-vault".into()),
+            known_vaults: vec!["/Users/op/ovp-vault".into(), "/Users/op/other".into()],
         };
         let s = serde_json::to_string(&cfg).unwrap();
         let back: AppConfig = serde_json::from_str(&s).unwrap();
         assert_eq!(back.vault.as_deref(), Some("/Users/op/ovp-vault"));
-        // A missing field tolerates older/empty config files.
+        assert_eq!(back.known_vaults.len(), 2);
+        // Missing fields tolerate older/empty config files (known_vaults is
+        // additive).
         let empty: AppConfig = serde_json::from_str("{}").unwrap();
         assert!(empty.vault.is_none());
+        assert!(empty.known_vaults.is_empty());
+        let old: AppConfig = serde_json::from_str(r#"{"vault":"/v"}"#).unwrap();
+        assert!(old.known_vaults.is_empty());
+    }
+
+    #[test]
+    fn remember_vault_moves_to_head_dedupes_and_caps() {
+        let known: Vec<String> = vec!["/a".into(), "/b".into(), "/c".into()];
+        assert_eq!(remember_vault(&known, "/b"), vec!["/b", "/a", "/c"]);
+        assert_eq!(
+            remember_vault(&known, "/new"),
+            vec!["/new", "/a", "/b", "/c"]
+        );
+        let many: Vec<String> = (0..MAX_KNOWN_VAULTS).map(|i| format!("/v{i}")).collect();
+        let out = remember_vault(&many, "/fresh");
+        assert_eq!(out.len(), MAX_KNOWN_VAULTS);
+        assert_eq!(out[0], "/fresh");
+        assert!(
+            !out.contains(&format!("/v{}", MAX_KNOWN_VAULTS - 1)),
+            "oldest dropped"
+        );
+    }
+
+    #[test]
+    fn vault_label_shows_folder_and_parent() {
+        assert_eq!(
+            vault_label("/Users/op/Documents/ovp-vault"),
+            "ovp-vault — /Users/op/Documents"
+        );
     }
 
     #[test]
@@ -345,7 +561,16 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .manage(AppState::default())
-        .invoke_handler(tauri::generate_handler![boot, set_vault_and_start])
+        .invoke_handler(tauri::generate_handler![
+            boot,
+            set_vault_and_start,
+            known_vaults
+        ])
+        .setup(|app| {
+            rebuild_vault_menu(app.handle())?;
+            Ok(())
+        })
+        .on_menu_event(|app, event| handle_menu_event(app, event.id().as_ref()))
         .run(tauri::generate_context!())
         .expect("error while running the OVP2 desktop app");
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -393,7 +393,10 @@ fn switch_to_vault(app: &AppHandle, vault: &str) {
         eprintln!("ovp2-desktop: vault {vault} is not a readable directory — not switching");
         return;
     }
-    let prev = load_config(app);
+    // The PERSISTED config is the truth here — under an OVP2_VAULT override
+    // load_config reports the env vault, which would both mis-skip a real
+    // switch and derive the saved state from a temporary value (bot review).
+    let prev = read_config_file(app);
     if prev.vault.as_deref() == Some(vault) {
         return;
     }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -314,15 +314,18 @@ async fn boot(app: AppHandle, state: State<'_, AppState>) -> Result<BootState, S
     let cfg = load_config(&app);
     Ok(match cfg.vault {
         Some(vault) if valid_vault(&vault) => {
-            // A hand-seeded or env-provided vault may not be in the recent
-            // list yet — remember it (best-effort) so the Vault menu and the
-            // splash quick-pick know about it.
-            if !cfg.known_vaults.iter().any(|v| v == &vault) {
+            // Keep the recents honest: the vault that just opened belongs at
+            // the HEAD of the list (MRU invariant), whether it is brand new
+            // (hand-seeded config) or merely not first. Only `known_vaults`
+            // is touched — the persisted `vault` stays as the FILE has it,
+            // so a temporary OVP2_VAULT override never turns into a
+            // persistent selection (codex P2s).
+            if cfg.known_vaults.first() != Some(&vault) {
                 let cfg_file = read_config_file(&app);
                 let _ = save_config(
                     &app,
                     &AppConfig {
-                        vault: cfg_file.vault.clone().or_else(|| Some(vault.clone())),
+                        vault: cfg_file.vault.clone(),
                         known_vaults: remember_vault(&cfg_file.known_vaults, &vault),
                     },
                 );

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -29,6 +29,41 @@ function showOnboard(text: string) {
   spinner.classList.add("hidden");
   onboard.classList.remove("hidden");
   msg.textContent = text;
+  void renderRecentVaults();
+}
+
+/** Obsidian-style quick pick: one click into a known vault — no folder
+ * dialog (and none of its slow panel-service spin-up) involved. */
+async function renderRecentVaults() {
+  const recent = document.getElementById("recent")!;
+  recent.innerHTML = "";
+  let vaults: string[] = [];
+  try {
+    vaults = (await invoke("known_vaults")) as string[];
+  } catch {
+    return; // older backend — just keep the picker button
+  }
+  for (const v of vaults) {
+    const name = v.split("/").filter(Boolean).pop() ?? v;
+    const b = document.createElement("button");
+    b.textContent = `Open ${name}`;
+    const path = document.createElement("span");
+    path.className = "path";
+    path.textContent = v;
+    b.appendChild(path);
+    b.addEventListener("click", () => void openVault(v));
+    recent.appendChild(b);
+  }
+}
+
+async function openVault(dir: string) {
+  showStarting("Setting up…");
+  try {
+    const url = (await invoke("set_vault_and_start", { vault: dir })) as string;
+    goto(url);
+  } catch (e) {
+    showOnboard(`Could not open that folder: ${e}`);
+  }
 }
 
 async function boot() {
@@ -46,14 +81,8 @@ pick.addEventListener("click", async () => {
   const dir = await open({ directory: true, multiple: false, title: "Choose your OVP2 vault" });
   if (!dir || typeof dir !== "string") return;
   pick.disabled = true;
-  showStarting("Setting up…");
-  try {
-    const url = (await invoke("set_vault_and_start", { vault: dir })) as string;
-    goto(url);
-  } catch (e) {
-    pick.disabled = false;
-    showOnboard(`Could not open that folder: ${e}`);
-  }
+  await openVault(dir);
+  pick.disabled = false;
 });
 
 boot();

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -44,7 +44,7 @@ async function renderRecentVaults() {
     return; // older backend — just keep the picker button
   }
   for (const v of vaults) {
-    const name = v.split("/").filter(Boolean).pop() ?? v;
+    const name = v.split(/[\\/]/).filter(Boolean).pop() ?? v;
     const b = document.createElement("button");
     b.textContent = `Open ${name}`;
     const path = document.createElement("span");


### PR DESCRIPTION
Operator ask: manage vaults like Obsidian — close the current vault, switch to another, and auto-open the default when one exists.

- **known_vaults** on AppConfig (additive serde): MRU list, deduped, capped at 10, maintained on every successful open (incl. hand-seeded configs remembered at boot; a temporary OVP2_VAULT override adds to recents but never persists as the selection).
- **Native Vault menu** (standard menu bar + `Vault`): Choose Vault Folder…, recents with the current vault check-marked, Close Vault. Every action = config + restart — one mechanism; the boot path rebinds the in-process server and scheduler to the new vault with zero lifecycle juggling. Menu rebuilds from AppHandle after config changes.
- **Splash quick-pick**: known vaults render as one-click Open buttons — entering a known vault never touches NSOpenPanel (whose remote-service spin-up was the stall diagnosed in #354).
- **Default auto-open**: the persisted vault (existing behavior, now with the full lifecycle around it).

Verified live on the rebuilt bundle: menu shows `Choose Vault Folder… / ovp-vault — /Users/chris/Documents ✓ / Close Vault`; recents persist in config.json; app boots straight into the portal. 5 unit tests (MRU/label/config round-trip). One codex round (2 P2) fixed.