### PR TITLE
fix(portal): library row layout under many tags; feat(desktop): ⌘⇧O open page in browser

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -438,6 +438,31 @@ fn handle_menu_event(app: &AppHandle, id: &str) {
                 }
             });
         }
+        "page-open-browser" => {
+            let Some(win) = app.get_webview_window("main") else {
+                return;
+            };
+            match win.url() {
+                // Only the portal's http(s) pages make sense in a browser —
+                // the tauri:// splash does not.
+                Ok(url) if url.scheme() == "http" || url.scheme() == "https" => {
+                    #[cfg(target_os = "macos")]
+                    let opener = "open";
+                    #[cfg(target_os = "linux")]
+                    let opener = "xdg-open";
+                    #[cfg(target_os = "windows")]
+                    let opener = "explorer";
+                    if let Err(e) = std::process::Command::new(opener)
+                        .arg(url.to_string())
+                        .spawn()
+                    {
+                        eprintln!("ovp2-desktop: open in browser failed: {e}");
+                    }
+                }
+                Ok(url) => eprintln!("ovp2-desktop: not a browser-openable page: {url}"),
+                Err(e) => eprintln!("ovp2-desktop: cannot read the page url: {e}"),
+            }
+        }
         other => {
             if let Some(path) = other.strip_prefix("vault-open:") {
                 switch_to_vault(app, path);
@@ -486,6 +511,17 @@ fn rebuild_vault_menu(handle: &AppHandle) -> tauri::Result<()> {
         None::<&str>,
     )?)?;
     menu.append(&vault_menu)?;
+    // Page menu: browser hand-off for the current portal page (⌘⇧O) — the
+    // in-app webview and a real browser tab show the same loopback URL.
+    let page_menu = Submenu::new(handle, "Page", true)?;
+    page_menu.append(&MenuItem::with_id(
+        handle,
+        "page-open-browser",
+        "Open Page in Browser",
+        true,
+        Some("CmdOrCtrl+Shift+O"),
+    )?)?;
+    menu.append(&page_menu)?;
     handle.set_menu(menu)?;
     Ok(())
 }

--- a/console-ui/src/design/portal.css
+++ b/console-ui/src/design/portal.css
@@ -563,6 +563,18 @@ body {
 .row-list .row .meta {
   color: var(--muted);
   font-size: var(--ovp-text-xs);
+  /* A flex container that WRAPS ITS ITEMS (many tag chips flow onto extra
+     lines) while `nowrap` still keeps each text run — the date/collection —
+     unbroken. The width cap is what protects the title column: without it a
+     heavily-tagged row forces the meta to min-content width and crushes the
+     title to one word per line (2026-07-21 layout bug). */
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  align-items: baseline;
+  row-gap: 0.15rem;
+  max-width: 55%;
+  min-width: 0;
   white-space: nowrap;
   font-family: var(--ovp-font-mono);
 }


### PR DESCRIPTION
1. **Layout bug (operator screenshot 2026-07-21)**: rows whose sources carry many inferred tag chips crushed the title column to one word per line — `.row .meta` was `white-space: nowrap` with no width cap, so its min-content width won the flex negotiation. Now a wrapping flex container capped at 55% width: chips wrap onto extra lines, the date/collection text run stays unbroken, the title keeps its space. Verified the built rule serves live.
2. **Desktop**: Page menu with **Open Page in Browser (⌘⇧O)** — hands the current portal URL to the default browser (guarded to http(s); the tauri:// splash is not openable). Smoke-tested via the real menu on the rebuilt bundle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a menu option to open the current portal page in the system’s default web browser.
  - Added the keyboard shortcut `Cmd/Ctrl+Shift+O`.

- **Bug Fixes**
  - Improved portal row metadata layout so content wraps cleanly and remains readable in narrower views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->