### PR TITLE
fix(server,portal): manual run-now --id arg bug + undefined .publish-btn

### DIFF
--- a/console-ui/src/design/portal.css
+++ b/console-ui/src/design/portal.css
@@ -1682,6 +1682,36 @@ body {
   padding: 0.15rem 0;
 }
 
+/* Primary action button — Run today's job / Publish / Retry (used across the
+   System page and RunBanner). Was undefined, so these rendered as bare native
+   buttons; this is the DS filled-accent button. */
+.publish-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin: 0.2rem 0 0.4rem;
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-input);
+  background: var(--accent);
+  color: var(--on-accent);
+  font: inherit;
+  font-size: var(--ovp-text-sm);
+  font-weight: 600;
+  line-height: 1.2;
+  cursor: pointer;
+  transition: background var(--dur-fast) var(--ease),
+    border-color var(--dur-fast) var(--ease);
+}
+.publish-btn:hover:not(:disabled) {
+  background: var(--accent-strong);
+  border-color: var(--accent-strong);
+}
+.publish-btn:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
 /* runs table: quiet 1px rules, numbers right-aligned */
 .runs-table {
   width: 100%;

--- a/crates/ovp-cli/src/main.rs
+++ b/crates/ovp-cli/src/main.rs
@@ -2347,3 +2347,63 @@ fn days_to_ymd(mut days: i64) -> (i32, u32, u32) {
 fn is_leap(y: i32) -> bool {
     (y % 4 == 0 && y % 100 != 0) || (y % 400 == 0)
 }
+
+#[cfg(test)]
+mod arg_contract_tests {
+    use super::*;
+    use clap::Parser;
+
+    // The `Cli` enum is huge; clap's generated parser recurses deep enough to
+    // overflow the test harness's default 2 MB stack in an unoptimized build.
+    // Run each parse on a roomy stack (the release binary is fine).
+    fn on_big_stack<F: FnOnce() + Send + 'static>(f: F) {
+        std::thread::Builder::new()
+            .stack_size(32 * 1024 * 1024)
+            .spawn(f)
+            .unwrap()
+            .join()
+            .unwrap();
+    }
+
+    /// The EXACT argv the manual-run endpoint spawns (ovp-server
+    /// `handle_run_start`). `<ID>` is a POSITIONAL arg on `schedule run-now`,
+    /// so a `--id` flag is rejected. This guards that server↔CLI contract —
+    /// the endpoint returns 202 before the child parses, so only a test like
+    /// this catches an argv drift (the child failing at runtime otherwise).
+    #[test]
+    fn schedule_run_now_server_argv_parses() {
+        on_big_stack(|| {
+            let cli = Cli::try_parse_from([
+                "ovp2", "schedule", "run-now", "--vault-root", "/tmp/vault", "daily",
+                "--unless-ran-within-secs", "120",
+            ])
+            .expect("server's run-now argv must parse");
+            match cli.cmd {
+                Cmd::Schedule {
+                    action:
+                        ScheduleAction::RunNow {
+                            id,
+                            unless_ran_within_secs,
+                            vault_root,
+                        },
+                } => {
+                    assert_eq!(id, "daily");
+                    assert_eq!(unless_ran_within_secs, Some(120));
+                    assert_eq!(vault_root, PathBuf::from("/tmp/vault"));
+                }
+                _ => panic!("unexpected parse for run-now argv"),
+            }
+        });
+    }
+
+    /// The old bug: passing `--id` (flag) must FAIL, since id is positional.
+    #[test]
+    fn schedule_run_now_rejects_id_flag() {
+        on_big_stack(|| {
+            let parsed = Cli::try_parse_from([
+                "ovp2", "schedule", "run-now", "--vault-root", "/tmp/vault", "--id", "daily",
+            ]);
+            assert!(parsed.is_err(), "--id flag must be rejected (id is positional)");
+        });
+    }
+}

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -1238,7 +1238,9 @@ fn handle_run_start(state: &AppState, body: &str) -> Response<std::io::Cursor<Ve
             "run-now",
             "--vault-root",
             &vault_root.display().to_string(),
-            "--id",
+            // `<ID>` is a POSITIONAL arg on `schedule run-now`, not a `--id`
+            // flag — passing `--id` makes clap reject it. Keep this in sync with
+            // the CLI definition (see the run_now_args parse test in ovp-cli).
             &job_id,
             // Atomic with the dispatch lock in the child: skip when the job
             // (auto tick or another trigger) already ran moments ago — closes


### PR DESCRIPTION
Operator hit two real defects trying to trigger a daily run from the UI.

## 1. Manual run always failed ("Manual run failed: tip: to pass '--id' as a value…")

`handle_run_start` (ovp-server) spawned `ovp2 schedule run-now --vault-root X --id <job> --unless-ran-within-secs 120`, but the CLI defines `<ID>` as a **positional** arg (`id: String`, no `#[arg(long)]`) — clap rejects the unknown `--id` flag. Every portal/desktop "Run today's job now" click failed at the child. The endpoint returns 202 **before** the child parses, so the 202/409-only endpoint tests never caught it.

Fix: pass the id positionally. Verified the corrected argv parses on the real release binary (it reaches the scheduler lock, not a clap usage error). Added `ovp-cli` arg-contract tests: the exact server argv parses to `id="daily"`, and a `--id` flag is rejected — run on a 32 MB stack because the giant `Cli` enum overflows the 2 MB test-harness stack in debug.

## 2. "That doesn't look like a button" — `.publish-btn` had no CSS

The primary action button (Run today's job / Publish / Retry — System page + RunBanner) used `className="publish-btn"`, which was **defined in no stylesheet**, so it rendered as a bare native button. Defined it as the DS filled-accent button (accent fill, `--on-accent` text, `--radius-input`, hover `--accent-strong`, disabled state) using the Lumen DS tokens.

Audited every `className` in `console-ui` against defined selectors: `.publish-btn` was the only real gap; the rest ride companion classes (`.card`/`.warn`, `.muted`/`.tiny`) or are variables.

## Verification

- `cargo test -p ovp-cli arg_contract` → 2 passed.
- Release binary parses the corrected argv (reaches lock check).
- `.publish-btn` styled rule served live on 7777; `/api/model` 200.
- Note: a real daily run was already in progress during testing (desktop app scheduler), so the manual endpoint correctly reports overlap — the protection works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reusable primary action button style with hover and disabled states.

* **Bug Fixes**
  * Fixed manual schedule runs so their job identifier is passed correctly.
  * Added validation to ensure schedule run-now command arguments are accepted and rejected appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->