### PR TITLE
feat(desktop): open external article links in the system browser

### DIFF
--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -8,6 +8,7 @@
   },
   "permissions": [
     "core:default",
-    "dialog:default"
+    "dialog:default",
+    "allow-open-external"
   ]
 }

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -3,6 +3,9 @@
   "identifier": "default",
   "description": "OVP2 desktop: boot the in-process portal and pick a vault.",
   "windows": ["main"],
+  "remote": {
+    "urls": ["http://127.0.0.1:*", "http://localhost:*"]
+  },
   "permissions": [
     "core:default",
     "dialog:default"

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -1,14 +1,11 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "OVP2 desktop: boot the in-process portal and pick a vault.",
+  "description": "Local splash: pick a vault and boot the in-process portal. LOCAL content only — no remote origin gets these.",
   "windows": ["main"],
-  "remote": {
-    "urls": ["http://127.0.0.1:*", "http://localhost:*"]
-  },
   "permissions": [
     "core:default",
     "dialog:default",
-    "allow-open-external"
+    "allow-local-commands"
   ]
 }

--- a/apps/desktop/src-tauri/capabilities/portal.json
+++ b/apps/desktop/src-tauri/capabilities/portal.json
@@ -3,6 +3,7 @@
   "identifier": "portal",
   "description": "The loopback portal (http://127.0.0.1:<port>) is a REMOTE origin. Grant it ONLY open_external — no core/dialog/window APIs — so a redirect to another localhost service can't reach more than opening a browser URL.",
   "windows": ["main"],
+  "local": false,
   "remote": {
     "urls": ["http://127.0.0.1:*", "http://localhost:*"]
   },

--- a/apps/desktop/src-tauri/capabilities/portal.json
+++ b/apps/desktop/src-tauri/capabilities/portal.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../gen/schemas/remote-schema.json",
+  "identifier": "portal",
+  "description": "The loopback portal (http://127.0.0.1:<port>) is a REMOTE origin. Grant it ONLY open_external — no core/dialog/window APIs — so a redirect to another localhost service can't reach more than opening a browser URL.",
+  "windows": ["main"],
+  "remote": {
+    "urls": ["http://127.0.0.1:*", "http://localhost:*"]
+  },
+  "permissions": [
+    "allow-open-external"
+  ]
+}

--- a/apps/desktop/src-tauri/permissions/local-commands.toml
+++ b/apps/desktop/src-tauri/permissions/local-commands.toml
@@ -1,0 +1,8 @@
+# Defining ANY app-command ACL puts Tauri into allowlist mode for EVERY custom
+# command, so the splash's startup commands must be explicitly allowed too or
+# the app can't boot. These run only from the LOCAL splash page (see the
+# local `default` capability — no remote origin gets them).
+[[permission]]
+identifier = "allow-local-commands"
+description = "Splash/startup commands: pick a vault, boot the in-process portal, list recents."
+commands.allow = ["boot", "set_vault_and_start", "known_vaults"]

--- a/apps/desktop/src-tauri/permissions/open-external.toml
+++ b/apps/desktop/src-tauri/permissions/open-external.toml
@@ -1,0 +1,8 @@
+# Authorizes the loopback portal (a REMOTE origin to Tauri, served from
+# http://127.0.0.1:<port>) to invoke the app's `open_external` command. Custom
+# commands are allowed by default for LOCAL webviews, but a remote origin needs
+# an explicit ACL permission listed in its capability.
+[[permission]]
+identifier = "allow-open-external"
+description = "Allow opening external http(s) URLs in the system browser (portal article + citation links)."
+commands.allow = ["open_external"]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -398,10 +398,15 @@ fn open_external(url: String) -> Result<(), String> {
     let opener = "xdg-open";
     #[cfg(target_os = "windows")]
     let opener = "explorer";
-    std::process::Command::new(opener)
+    let mut child = std::process::Command::new(opener)
         .arg(&url)
         .spawn()
         .map_err(|e| format!("open failed: {e}"))?;
+    // Reap the short-lived opener: Rust doesn't wait on Child drop, so without
+    // this every link click would leave a zombie until the app exits.
+    std::thread::spawn(move || {
+        let _ = child.wait();
+    });
     Ok(())
 }
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -382,6 +382,29 @@ async fn known_vaults(app: AppHandle) -> Result<Vec<String>, String> {
         .collect())
 }
 
+/// Open an external URL in the system browser. A WKWebView can't pop a browser
+/// itself — `target="_blank"` and external navigations are silently dropped —
+/// so the portal's external links (a source's original article URL, citations)
+/// call this instead. http/https ONLY: never hand an arbitrary scheme to the
+/// shell, and `.arg(&url)` passes the url as one argument (no shell parsing).
+#[tauri::command]
+fn open_external(url: String) -> Result<(), String> {
+    if !(url.starts_with("http://") || url.starts_with("https://")) {
+        return Err(format!("refusing to open non-http(s) url: {url}"));
+    }
+    #[cfg(target_os = "macos")]
+    let opener = "open";
+    #[cfg(target_os = "linux")]
+    let opener = "xdg-open";
+    #[cfg(target_os = "windows")]
+    let opener = "explorer";
+    std::process::Command::new(opener)
+        .arg(&url)
+        .spawn()
+        .map_err(|e| format!("open failed: {e}"))?;
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Vault menu — Obsidian-style switching. Every action is config + restart:
 // one mechanism, and the boot path (auto-open the persisted vault, else the
@@ -544,7 +567,8 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             boot,
             set_vault_and_start,
-            known_vaults
+            known_vaults,
+            open_external
         ])
         .setup(|app| {
             rebuild_vault_menu(app.handle())?;

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -10,6 +10,7 @@
     "frontendDist": "../dist"
   },
   "app": {
+    "withGlobalTauri": true,
     "windows": [
       {
         "label": "main",

--- a/console-ui/src/lib/desktopExternalLinks.ts
+++ b/console-ui/src/lib/desktopExternalLinks.ts
@@ -25,6 +25,17 @@ export function installDesktopExternalLinks(): void {
     });
   };
 
+  // External = an http(s) URL whose parsed ORIGIN differs from the portal's.
+  // A string-prefix check is wrong: port 1234 is a prefix of 12345.
+  const isExternalHttp = (raw: string): boolean => {
+    try {
+      const u = new URL(raw, location.href);
+      return (u.protocol === 'http:' || u.protocol === 'https:') && u.origin !== location.origin;
+    } catch {
+      return false;
+    }
+  };
+
   // Capture phase so we decide before React Router's root listener — but we
   // only act on EXTERNAL links, leaving internal navigation to the router.
   document.addEventListener(
@@ -35,7 +46,7 @@ export function installDesktopExternalLinks(): void {
       const anchor = el?.closest?.('a[href]') as HTMLAnchorElement | null;
       if (!anchor) return;
       const href = anchor.href; // absolute, browser-resolved
-      if (/^https?:\/\//i.test(href) && !href.startsWith(location.origin)) {
+      if (isExternalHttp(href)) {
         e.preventDefault();
         openExternal(href);
       }
@@ -49,7 +60,7 @@ export function installDesktopExternalLinks(): void {
   const nativeOpen = window.open.bind(window);
   window.open = ((url?: string | URL, ...rest: unknown[]) => {
     const str = typeof url === 'string' ? url : url?.toString() ?? '';
-    if (/^https?:\/\//i.test(str) && !str.startsWith(location.origin)) {
+    if (isExternalHttp(str)) {
       openExternal(str);
       return null;
     }

--- a/console-ui/src/lib/desktopExternalLinks.ts
+++ b/console-ui/src/lib/desktopExternalLinks.ts
@@ -1,0 +1,58 @@
+/** Desktop-app external-link bridge.
+ *
+ * The portal is shared: in a normal browser, `<a target="_blank">` and
+ * `window.open` open external article URLs fine. Inside the Tauri desktop app
+ * the WKWebView silently DROPS those — no browser pops, no in-app browser — so
+ * a source's original article, citations, etc. can't be opened. Route external
+ * http(s) links through the app's `open_external` command (system browser).
+ *
+ * Feature-detected on `window.__TAURI__`, so this is a no-op in the browser
+ * (native `target="_blank"` keeps working there). Same-origin links (React
+ * Router `<Link>`, internal `/library/...`) are left untouched. */
+
+interface TauriGlobal {
+  core?: { invoke?: (cmd: string, args?: Record<string, unknown>) => Promise<unknown> };
+}
+
+export function installDesktopExternalLinks(): void {
+  const tauri = (window as unknown as { __TAURI__?: TauriGlobal }).__TAURI__;
+  const invoke = tauri?.core?.invoke;
+  if (!invoke) return; // plain browser — nothing to bridge
+
+  const openExternal = (url: string) => {
+    void invoke('open_external', { url }).catch(() => {
+      /* best-effort; a failed open must not throw into the click handler */
+    });
+  };
+
+  // Capture phase so we decide before React Router's root listener — but we
+  // only act on EXTERNAL links, leaving internal navigation to the router.
+  document.addEventListener(
+    'click',
+    (e) => {
+      if (e.defaultPrevented || e.button !== 0) return;
+      const el = e.target as HTMLElement | null;
+      const anchor = el?.closest?.('a[href]') as HTMLAnchorElement | null;
+      if (!anchor) return;
+      const href = anchor.href; // absolute, browser-resolved
+      if (/^https?:\/\//i.test(href) && !href.startsWith(location.origin)) {
+        e.preventDefault();
+        openExternal(href);
+      }
+    },
+    true,
+  );
+
+  // Some surfaces (e.g. the terrain) call window.open directly. Route external
+  // targets to the system browser; leave internal ones to the default (the app
+  // navigates in-window).
+  const nativeOpen = window.open.bind(window);
+  window.open = ((url?: string | URL, ...rest: unknown[]) => {
+    const str = typeof url === 'string' ? url : url?.toString() ?? '';
+    if (/^https?:\/\//i.test(str) && !str.startsWith(location.origin)) {
+      openExternal(str);
+      return null;
+    }
+    return (nativeOpen as (u?: string | URL, ...a: unknown[]) => Window | null)(url, ...rest);
+  }) as typeof window.open;
+}

--- a/console-ui/src/main.tsx
+++ b/console-ui/src/main.tsx
@@ -4,9 +4,14 @@ import { BrowserRouter, HashRouter } from 'react-router-dom';
 import App from './App';
 import { I18nProvider } from './i18n';
 import { STATIC_MODE } from './lib/api';
+import { installDesktopExternalLinks } from './lib/desktopExternalLinks';
 import './design/colors_and_type.css';
 import './design/portal.css';
 import './styles/index.css';
+
+// In the Tauri desktop app, open external article links in the system browser
+// (WKWebView drops target="_blank"). No-op in a normal browser.
+installDesktopExternalLinks();
 
 // Published static site → HashRouter: deep links like `/#/knowledge` work on
 // any static host (GitHub Pages, object storage) with zero rewrite rules. The


### PR DESCRIPTION
In the Tauri desktop app, a WKWebView silently drops `target="_blank"` and external navigations, so a source's original article URL (Library / source detail) and citation links couldn't be opened — no browser popped, and there's no in-app browser. Adds an `open_external` Tauri command (http/https only; url passed as one arg, no shell parsing) + a feature-detected frontend shim that routes external `<a>` clicks and `window.open(external)` through it. Guarded by `window.__TAURI__` (via `withGlobalTauri`), so it's inert in the plain browser portal; same-origin links stay with React Router. Frontend build + `cargo check -p ovp2-desktop` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * External HTTP and HTTPS links now open in the system’s default browser when using the desktop app.
  * Internal links and non-web links continue to open within the app.
  * External links opened through browser pop-ups are handled consistently.

* **Bug Fixes**
  * Invalid external URLs are rejected safely without disrupting the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->