### PR TITLE
feat(desktop): in-app back/forward + open-in-browser toolbar + native History menu

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -505,10 +505,11 @@ fn handle_menu_event(app: &AppHandle, id: &str) {
 /// works on the SPA and on legacy full-document pages alike, and is a no-op at
 /// the ends.
 fn nav_history(app: &AppHandle, delta: i32) {
-    if let Some(win) = app.get_webview_window("main") {
-        if let Err(e) = win.eval(format!("window.history.go({delta})")) {
-            eprintln!("ovp2-desktop: history nav failed: {e}");
-        }
+    let Some(win) = app.get_webview_window("main") else {
+        return;
+    };
+    if let Err(e) = win.eval(format!("window.history.go({delta})")) {
+        eprintln!("ovp2-desktop: history nav failed: {e}");
     }
 }
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -491,10 +491,23 @@ fn handle_menu_event(app: &AppHandle, id: &str) {
                 Err(e) => eprintln!("ovp2-desktop: cannot read the page url: {e}"),
             }
         }
+        "history-back" => nav_history(app, -1),
+        "history-forward" => nav_history(app, 1),
         other => {
             if let Some(path) = other.strip_prefix("vault-open:") {
                 switch_to_vault(app, path);
             }
+        }
+    }
+}
+
+/// Step the main webview's history — native Back/Forward (⌘[ / ⌘]). `history.go`
+/// works on the SPA and on legacy full-document pages alike, and is a no-op at
+/// the ends.
+fn nav_history(app: &AppHandle, delta: i32) {
+    if let Some(win) = app.get_webview_window("main") {
+        if let Err(e) = win.eval(format!("window.history.go({delta})")) {
+            eprintln!("ovp2-desktop: history nav failed: {e}");
         }
     }
 }
@@ -550,6 +563,27 @@ fn rebuild_vault_menu(handle: &AppHandle) -> tauri::Result<()> {
         Some("CmdOrCtrl+Shift+O"),
     )?)?;
     menu.append(&page_menu)?;
+
+    // History: persistent native chrome so Back/Forward work everywhere — the
+    // in-webview toolbar unmounts on full-document navigations (legacy admin
+    // pages), and this survives them. Standard ⌘[ / ⌘] shortcuts.
+    let history_menu = Submenu::new(handle, "History", true)?;
+    history_menu.append(&MenuItem::with_id(
+        handle,
+        "history-back",
+        "Back",
+        true,
+        Some("CmdOrCtrl+["),
+    )?)?;
+    history_menu.append(&MenuItem::with_id(
+        handle,
+        "history-forward",
+        "Forward",
+        true,
+        Some("CmdOrCtrl+]"),
+    )?)?;
+    menu.append(&history_menu)?;
+
     handle.set_menu(menu)?;
     Ok(())
 }

--- a/console-ui/src/components/Shell.tsx
+++ b/console-ui/src/components/Shell.tsx
@@ -7,13 +7,14 @@
  * button in the top bar) open the same SearchOmnibox the /search page
  * renders (design §3.4). */
 import { useEffect, useState } from 'react';
-import { NavLink, Outlet, useLocation } from 'react-router-dom';
+import { NavLink, Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { useI18n } from '../i18n';
 import { healthLevel } from '../lib/derive';
 import { useNowTick } from './RunBanner';
 import { useModel } from '../model';
 import { useTheme } from '../theme';
 import { STATIC_MODE } from '../lib/api';
+import { isDesktopApp, openInSystemBrowser } from '../lib/desktopExternalLinks';
 import RunBanner from './RunBanner';
 import SearchOmnibox from './SearchOmnibox';
 
@@ -36,6 +37,55 @@ const NAV = STATIC_MODE
       { to: '/ask', key: 'nav.ask', end: false },
       { to: '/system', key: 'nav.system', end: false },
     ] as const);
+
+/** Desktop-only browser chrome: back / forward / open-in-browser. The Tauri
+ * webview has no chrome (only WKWebView's ugly native context menu), so the
+ * portal supplies its own. Back/forward drive React Router history; the
+ * enabled state reads React Router's `idx` in `history.state`. Inert in a real
+ * browser (which already has this) via the `isDesktopApp()` guard. */
+function DesktopNav() {
+  const { t } = useI18n();
+  const navigate = useNavigate();
+  const location = useLocation(); // re-render on navigation so idx refreshes
+  void location;
+  if (!isDesktopApp()) return null;
+  const idx = (window.history.state?.idx as number | undefined) ?? 0;
+  const canBack = idx > 0;
+  const canForward = idx < window.history.length - 1;
+  return (
+    <span className="nav-history">
+      <button
+        type="button"
+        className="navbtn"
+        disabled={!canBack}
+        onClick={() => navigate(-1)}
+        aria-label={t('nav.back')}
+        title={t('nav.back')}
+      >
+        ‹
+      </button>
+      <button
+        type="button"
+        className="navbtn"
+        disabled={!canForward}
+        onClick={() => navigate(1)}
+        aria-label={t('nav.forward')}
+        title={t('nav.forward')}
+      >
+        ›
+      </button>
+      <button
+        type="button"
+        className="navbtn"
+        onClick={() => openInSystemBrowser(window.location.href)}
+        aria-label={t('nav.openInBrowser')}
+        title={t('nav.openInBrowser')}
+      >
+        ↗
+      </button>
+    </span>
+  );
+}
 
 function StatusLight() {
   const { t } = useI18n();
@@ -148,6 +198,7 @@ export default function Shell() {
               <span className="brand">
                 ovp2<span className="dot">.</span>
               </span>
+              <DesktopNav />
               {NAV.map((item) => (
                 <NavLink
                   key={item.to}

--- a/console-ui/src/components/Shell.tsx
+++ b/console-ui/src/components/Shell.tsx
@@ -40,24 +40,21 @@ const NAV = STATIC_MODE
 
 /** Desktop-only browser chrome: back / forward / open-in-browser. The Tauri
  * webview has no chrome (only WKWebView's ugly native context menu), so the
- * portal supplies its own. Back/forward drive React Router history; the
- * enabled state reads React Router's `idx` in `history.state`. Inert in a real
- * browser (which already has this) via the `isDesktopApp()` guard. */
+ * portal supplies its own. `navigate(-1)/navigate(1)` delegate to
+ * `history.go()`, which steps across documents too (e.g. a legacy admin page
+ * back into the SPA) and is a harmless no-op at the ends — so the buttons stay
+ * always-enabled rather than mixing router-local `idx` with session-wide
+ * `history.length` (which disagree after a cross-document navigation). Inert in
+ * a real browser via `isDesktopApp()`. */
 function DesktopNav() {
   const { t } = useI18n();
   const navigate = useNavigate();
-  const location = useLocation(); // re-render on navigation so idx refreshes
-  void location;
   if (!isDesktopApp()) return null;
-  const idx = (window.history.state?.idx as number | undefined) ?? 0;
-  const canBack = idx > 0;
-  const canForward = idx < window.history.length - 1;
   return (
     <span className="nav-history">
       <button
         type="button"
         className="navbtn"
-        disabled={!canBack}
         onClick={() => navigate(-1)}
         aria-label={t('nav.back')}
         title={t('nav.back')}
@@ -67,7 +64,6 @@ function DesktopNav() {
       <button
         type="button"
         className="navbtn"
-        disabled={!canForward}
         onClick={() => navigate(1)}
         aria-label={t('nav.forward')}
         title={t('nav.forward')}

--- a/console-ui/src/components/Shell.tsx
+++ b/console-ui/src/components/Shell.tsx
@@ -45,7 +45,9 @@ const NAV = STATIC_MODE
  * back into the SPA) and is a harmless no-op at the ends — so the buttons stay
  * always-enabled rather than mixing router-local `idx` with session-wide
  * `history.length` (which disagree after a cross-document navigation). Inert in
- * a real browser via `isDesktopApp()`. */
+ * a real browser via `isDesktopApp()`. The native History menu (⌘[ / ⌘]) is the
+ * persistent complement that also works on legacy full-document pages, where
+ * this in-SPA toolbar unmounts. */
 function DesktopNav() {
   const { t } = useI18n();
   const navigate = useNavigate();

--- a/console-ui/src/design/portal.css
+++ b/console-ui/src/design/portal.css
@@ -131,6 +131,41 @@ body {
   gap: 0.75rem;
 }
 
+/* Desktop-only browser chrome: back / forward / open-in-browser. */
+.nav-history {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.15rem;
+  margin-right: 0.3rem;
+  align-self: center;
+}
+.nav-history .navbtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.6rem;
+  height: 1.6rem;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-input);
+  background: var(--surface);
+  color: var(--text-soft);
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: background var(--dur-fast) var(--ease),
+    border-color var(--dur-fast) var(--ease), color var(--dur-fast) var(--ease);
+}
+.nav-history .navbtn:hover:not(:disabled) {
+  background: var(--surface-hover);
+  border-color: var(--border-strong);
+  color: var(--text);
+}
+.nav-history .navbtn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
 /* ---------- status dot: ok / attention / failed ---------- */
 .status-light {
   display: inline-flex;

--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -26,6 +26,9 @@ export const en = {
   'nav.knowledge': 'Knowledge',
   'nav.ask': 'Ask',
   'nav.system': 'System',
+  'nav.back': 'Back',
+  'nav.forward': 'Forward',
+  'nav.openInBrowser': 'Open this page in your browser',
 
   // status light
   'status.ok': 'ok',

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -26,6 +26,9 @@ export const zh: Record<keyof typeof en, string> = {
   'nav.knowledge': '知识',
   'nav.ask': '对话',
   'nav.system': '系统',
+  'nav.back': '后退',
+  'nav.forward': '前进',
+  'nav.openInBrowser': '在浏览器中打开当前页',
 
   // status light
   'status.ok': '正常',

--- a/console-ui/src/lib/desktopExternalLinks.ts
+++ b/console-ui/src/lib/desktopExternalLinks.ts
@@ -14,6 +14,19 @@ interface TauriGlobal {
   core?: { invoke?: (cmd: string, args?: Record<string, unknown>) => Promise<unknown> };
 }
 
+/** True inside the Tauri desktop app (the global is injected there only). */
+export function isDesktopApp(): boolean {
+  return typeof window !== 'undefined' && !!(window as unknown as { __TAURI__?: TauriGlobal }).__TAURI__;
+}
+
+/** Open a URL in the system browser via the app's `open_external` command.
+ * No-op outside the desktop app. Best-effort — never throws. */
+export function openInSystemBrowser(url: string): void {
+  const invoke = (window as unknown as { __TAURI__?: TauriGlobal }).__TAURI__?.core?.invoke;
+  if (!invoke) return;
+  void invoke('open_external', { url }).catch(() => {});
+}
+
 export function installDesktopExternalLinks(): void {
   const tauri = (window as unknown as { __TAURI__?: TauriGlobal }).__TAURI__;
   const invoke = tauri?.core?.invoke;


### PR DESCRIPTION
Desktop app had no browser chrome — only WKWebView's ugly native right-click. Adds: (1) a desktop-only in-portal toolbar (‹ back / › forward / ↗ open-current-page-in-browser) and (2) a native History menu (Back ⌘[ / Forward ⌘]) as persistent chrome that also works on legacy full-document pages. Back/forward delegate to history.go() (correct across documents, no-op at ends); open-in-browser reuses the open_external command. Guarded by isDesktopApp(), inert in a real browser. Codex gate clean (5 rounds: mixed-history-model P2, legacy-page P2 → native menu, clippy P1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Back and Forward navigation controls to the desktop app.
  * Added keyboard shortcuts for browser history navigation.
  * Added an option to open the current page in the system browser.
  * Added desktop-only navigation controls to the top navigation bar.
  * Added English and Simplified Chinese labels for the new controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->