### PR TITLE
feat(llm): A1a — tool-capable model protocol (ask_tool_protocol-v1)

### DIFF
--- a/crates/ovp-cli/src/commands/crystal_review_session.rs
+++ b/crates/ovp-cli/src/commands/crystal_review_session.rs
@@ -1398,6 +1398,8 @@ mod tests {
             text: r#"[{"claim_id":"c1r","strength":"supported","evidence_sufficient":true,"rationale":"both quotes state a scarce budget"}]"#.into(),
             stop_reason: ovp_llm::StopReason::EndTurn,
             usage: ovp_llm::Usage { input_tokens: 1, output_tokens: 1 },
+            blocks: None,
+            raw_stop_reason: None,
         };
         fs::write(
             dir.join(format!("{}.json", ovp_llm::request_key(&req))),

--- a/crates/ovp-cli/src/commands/crystal_synth.rs
+++ b/crates/ovp-cli/src/commands/crystal_synth.rs
@@ -779,6 +779,8 @@ mod tests {
                 input_tokens: 1,
                 output_tokens: 1,
             },
+            blocks: None,
+            raw_stop_reason: None,
         };
         std::fs::write(
             dir.join(format!("{key}.json")),

--- a/crates/ovp-cli/src/commands/crystal_synth_ab.rs
+++ b/crates/ovp-cli/src/commands/crystal_synth_ab.rs
@@ -483,6 +483,8 @@ mod tests {
                 input_tokens: 1,
                 output_tokens: 1,
             },
+            blocks: None,
+            raw_stop_reason: None,
         };
         std::fs::write(
             dir.join(format!("{}.json", request_key(req))),

--- a/crates/ovp-cli/src/commands/crystal_synth_llm.rs
+++ b/crates/ovp-cli/src/commands/crystal_synth_llm.rs
@@ -851,6 +851,8 @@ mod tests {
                 input_tokens: 1,
                 output_tokens: 1,
             },
+            blocks: None,
+            raw_stop_reason: None,
         };
         std::fs::write(
             dir.join(format!("{}.json", request_key(req))),

--- a/crates/ovp-cli/src/commands/crystal_theme_pages.rs
+++ b/crates/ovp-cli/src/commands/crystal_theme_pages.rs
@@ -427,6 +427,8 @@ mod tests {
                 input_tokens: 0,
                 output_tokens: 0,
             },
+            blocks: None,
+            raw_stop_reason: None,
         }
     }
 

--- a/crates/ovp-cli/tests/m31_e2e.rs
+++ b/crates/ovp-cli/tests/m31_e2e.rs
@@ -43,6 +43,8 @@ impl ModelClient for Canned {
             text: self.0.clone(),
             stop_reason: StopReason::EndTurn,
             usage: Usage { input_tokens: 1, output_tokens: 1 },
+            blocks: None,
+            raw_stop_reason: None,
         })
     }
 }

--- a/crates/ovp-daily/tests/daily_loop.rs
+++ b/crates/ovp-daily/tests/daily_loop.rs
@@ -24,6 +24,8 @@ impl ModelClient for Canned {
             text: self.0.clone(),
             stop_reason: StopReason::EndTurn,
             usage: Usage { input_tokens: 1, output_tokens: 1 },
+            blocks: None,
+            raw_stop_reason: None,
         })
     }
 }

--- a/crates/ovp-domain/src/crystal/select.rs
+++ b/crates/ovp-domain/src/crystal/select.rs
@@ -122,6 +122,7 @@ pub fn cluster_select_request(
         messages: vec![ModelMessage::User { content: user }],
         max_tokens: SELECT_MAX_TOKENS,
         temperature: None,
+        tools: None,
         cache_namespace: Some(CLUSTER_SELECT_PROMPT_ID.to_string()),
     }
 }

--- a/crates/ovp-domain/src/crystal/synth.rs
+++ b/crates/ovp-domain/src/crystal/synth.rs
@@ -399,6 +399,7 @@ fn synth_request_for_cases<'a>(
         messages: vec![ModelMessage::User { content: user }],
         max_tokens: SYNTH_MAX_TOKENS,
         temperature: None,
+        tools: None,
         cache_namespace: Some(CRYSTAL_SYNTH_PROMPT_ID.to_string()),
     }
 }
@@ -625,6 +626,7 @@ pub fn strength_request(candidate: &CrystalCandidate, catalog: &UnitsCatalog) ->
         messages: vec![ModelMessage::User { content: user }],
         max_tokens: STRENGTH_MAX_TOKENS,
         temperature: None,
+        tools: None,
         cache_namespace: Some(CRYSTAL_STRENGTH_PROMPT_ID.to_string()),
     }
 }

--- a/crates/ovp-domain/src/crystal/theme_pages.rs
+++ b/crates/ovp-domain/src/crystal/theme_pages.rs
@@ -152,6 +152,7 @@ pub fn theme_page_request(synth_theme: &str, claims: &[PageClaim]) -> ModelReque
         messages: vec![ModelMessage::User { content: user }],
         max_tokens: PAGE_MAX_TOKENS,
         temperature: None,
+        tools: None,
         cache_namespace: Some(THEME_PAGE_PROMPT_ID.to_string()),
     }
 }
@@ -203,6 +204,7 @@ pub fn theme_page_repair_request(
         messages: vec![ModelMessage::User { content: user }],
         max_tokens: PAGE_MAX_TOKENS,
         temperature: None,
+        tools: None,
         cache_namespace: Some(THEME_PAGE_PROMPT_ID.to_string()),
     }
 }

--- a/crates/ovp-domain/src/crystal/themes.rs
+++ b/crates/ovp-domain/src/crystal/themes.rs
@@ -307,6 +307,7 @@ pub fn theme_label_request(keywords: &[String], sample_titles: &[String]) -> Mod
         messages: vec![ModelMessage::User { content: user }],
         max_tokens: LABEL_MAX_TOKENS,
         temperature: None,
+        tools: None,
         cache_namespace: Some(THEME_LABEL_PROMPT_ID.to_string()),
     }
 }

--- a/crates/ovp-domain/src/model_reply.rs
+++ b/crates/ovp-domain/src/model_reply.rs
@@ -223,6 +223,7 @@ pub fn json_repair_request(broken_reply: &str) -> ModelRequest {
         }],
         max_tokens: 16384,
         temperature: None,
+        tools: None,
         cache_namespace: Some("json_repair/v1".to_string()),
     }
 }

--- a/crates/ovp-domain/src/reader/cards.rs
+++ b/crates/ovp-domain/src/reader/cards.rs
@@ -83,6 +83,7 @@ pub fn card_model_request(accepted_units: &[Unit]) -> ModelRequest {
         messages: vec![ModelMessage::User { content: user }],
         max_tokens: DEFAULT_MAX_TOKENS,
         temperature: None,
+        tools: None,
         cache_namespace: Some(CARD_PROMPT_ID.to_string()),
     }
 }
@@ -222,6 +223,8 @@ mod tests {
                 text: self.0.clone(),
                 stop_reason: StopReason::EndTurn,
                 usage: Usage { input_tokens: 1, output_tokens: 1 },
+                blocks: None,
+                raw_stop_reason: None,
             })
         }
     }
@@ -289,7 +292,8 @@ mod tests {
             let text = self.replies.get(self.i).or_else(|| self.replies.last()).cloned().unwrap_or_default();
             self.i += 1;
             Ok(ModelReply { model: "scripted".into(), text, stop_reason: StopReason::EndTurn,
-                usage: Usage { input_tokens: 1, output_tokens: 1 } })
+                usage: Usage { input_tokens: 1, output_tokens: 1 },
+                blocks: None, raw_stop_reason: None })
         }
     }
 

--- a/crates/ovp-domain/src/reader/pipeline.rs
+++ b/crates/ovp-domain/src/reader/pipeline.rs
@@ -196,6 +196,8 @@ mod tests {
                 text: self.0.clone(),
                 stop_reason: StopReason::EndTurn,
                 usage: Usage { input_tokens: 1, output_tokens: 1 },
+                blocks: None,
+                raw_stop_reason: None,
             })
         }
     }
@@ -286,6 +288,8 @@ mod tests {
                     text,
                     stop_reason: StopReason::EndTurn,
                     usage: Usage { input_tokens: 1, output_tokens: 1 },
+                    blocks: None,
+                    raw_stop_reason: None,
                 })
             }
         }
@@ -337,6 +341,8 @@ mod tests {
                     text,
                     stop_reason: StopReason::EndTurn,
                     usage: Usage { input_tokens: 1, output_tokens: 1 },
+                    blocks: None,
+                    raw_stop_reason: None,
                 })
             }
         }

--- a/crates/ovp-domain/src/referents/harness.rs
+++ b/crates/ovp-domain/src/referents/harness.rs
@@ -94,6 +94,8 @@ mod tests {
                 text: self.text.clone(),
                 stop_reason: StopReason::EndTurn,
                 usage: Usage { input_tokens: 1, output_tokens: 1 },
+                blocks: None,
+                raw_stop_reason: None,
             })
         }
     }

--- a/crates/ovp-domain/src/referents/prompt.rs
+++ b/crates/ovp-domain/src/referents/prompt.rs
@@ -58,6 +58,7 @@ pub fn referent_model_request(units: &[Unit], seeds: &[String]) -> ModelRequest 
         messages: vec![ModelMessage::User { content: user }],
         max_tokens: DEFAULT_MAX_TOKENS,
         temperature: None,
+        tools: None,
         cache_namespace: Some(REFERENT_PROMPT_ID.to_string()),
     }
 }

--- a/crates/ovp-domain/src/tags.rs
+++ b/crates/ovp-domain/src/tags.rs
@@ -503,6 +503,7 @@ pub fn tag_classify_request(
         messages: vec![ovp_llm::ModelMessage::User { content: user }],
         max_tokens: TAG_CLASSIFY_MAX_TOKENS,
         temperature: None,
+        tools: None,
         cache_namespace: Some(TAG_CLASSIFY_PROMPT_ID.to_string()),
     }
 }

--- a/crates/ovp-domain/src/transforms/llm_invoker.rs
+++ b/crates/ovp-domain/src/transforms/llm_invoker.rs
@@ -54,6 +54,7 @@ impl EffectfulTransform<DomainBody> for LLMInvoker {
             messages: vec![ModelMessage::User { content: prompt.user.clone() }],
             max_tokens: prompt.max_tokens,
             temperature: None,
+            tools: None,
             cache_namespace: Some(prompt.prompt_id.as_str().to_string()),
         };
 
@@ -144,6 +145,8 @@ mod tests {
             text: text.into(),
             stop_reason: stop,
             usage: Usage { input_tokens: 10, output_tokens: 20 },
+            blocks: None,
+            raw_stop_reason: None,
         }
     }
 
@@ -157,6 +160,7 @@ mod tests {
             messages: vec![ModelMessage::User { content: "user".into() }],
             max_tokens: 100,
             temperature: None,
+            tools: None,
             cache_namespace: None,
         };
         f.insert(&req, reply);

--- a/crates/ovp-domain/src/transforms/llm_invoker.rs
+++ b/crates/ovp-domain/src/transforms/llm_invoker.rs
@@ -103,6 +103,7 @@ fn call_error_to_filter_error(err: CallError) -> FilterError {
         ),
         CallError::Transport { detail } => ("transform.llm_invoker.transport", detail),
         CallError::Decode { detail } => ("transform.llm_invoker.decode", detail),
+        CallError::Protocol { detail } => ("transform.llm_invoker.protocol", detail),
         CallError::BudgetExhausted { detail } => ("transform.llm_invoker.budget_exhausted", detail),
         CallError::Unexpected { detail } => ("transform.llm_invoker.unexpected", detail),
     };

--- a/crates/ovp-domain/src/units/copy_probe.rs
+++ b/crates/ovp-domain/src/units/copy_probe.rs
@@ -109,6 +109,7 @@ pub fn run_copy_probe(
         messages: vec![ModelMessage::User { content: user }],
         max_tokens: 8192,
         temperature: None,
+        tools: None,
         cache_namespace: Some(COPY_PROBE_ID.to_string()),
     };
     let reply = client.call(&request)?;

--- a/crates/ovp-domain/src/units/critic.rs
+++ b/crates/ovp-domain/src/units/critic.rs
@@ -136,6 +136,7 @@ pub fn critic_model_request(source: &SourceDoc, base_units: &[Unit]) -> ModelReq
         messages: vec![ModelMessage::User { content: user }],
         max_tokens: DEFAULT_MAX_TOKENS,
         temperature: None,
+        tools: None,
         cache_namespace: Some(CRITIC_PROMPT_ID.to_string()),
     }
 }

--- a/crates/ovp-domain/src/units/harness.rs
+++ b/crates/ovp-domain/src/units/harness.rs
@@ -183,6 +183,8 @@ mod tests {
                 text: self.text.clone(),
                 stop_reason: StopReason::EndTurn,
                 usage: Usage { input_tokens: 1, output_tokens: 1 },
+                blocks: None,
+                raw_stop_reason: None,
             })
         }
     }
@@ -239,6 +241,8 @@ mod tests {
                 text,
                 stop_reason: StopReason::EndTurn,
                 usage: Usage { input_tokens: 1, output_tokens: 1 },
+                blocks: None,
+                raw_stop_reason: None,
             })
         }
     }

--- a/crates/ovp-domain/src/units/prompt.rs
+++ b/crates/ovp-domain/src/units/prompt.rs
@@ -54,6 +54,7 @@ pub fn unit_model_request(source: &SourceDoc) -> ModelRequest {
         messages: vec![ModelMessage::User { content: user }],
         max_tokens: DEFAULT_UNIT_MAX_TOKENS,
         temperature: None,
+        tools: None,
         cache_namespace: Some(UNIT_PROMPT_ID.to_string()),
     }
 }

--- a/crates/ovp-domain/tests/m14a_units.rs
+++ b/crates/ovp-domain/tests/m14a_units.rs
@@ -18,6 +18,8 @@ impl ModelClient for FakeModel {
             text: self.reply.clone(),
             stop_reason: StopReason::EndTurn,
             usage: Usage { input_tokens: 1, output_tokens: 1 },
+            blocks: None,
+            raw_stop_reason: None,
         })
     }
 }

--- a/crates/ovp-llm/src/anthropic.rs
+++ b/crates/ovp-llm/src/anthropic.rs
@@ -276,6 +276,22 @@ pub fn parse_anthropic_reply(json_body: &str) -> Result<ModelReply, CallError> {
     let (stop_reason, raw_stop_reason) =
         map_stop_reason(v.get("stop_reason").and_then(|s| s.as_str()));
 
+    // `max_tokens_mid_tool`: a tool_use emitted under stop_reason=max_tokens
+    // may be TRUNCATED (partial input) — it must never execute, and it must
+    // never be cached as a successful reply either (errors are not persisted;
+    // an Ok here would poison the cassette). BudgetExhausted, not Protocol:
+    // this is no caller bug — a higher-budget retry (the caller's decision,
+    // e.g. BudgetEscalatingModelClient) is the recovery path.
+    if stop_reason == StopReason::MaxTokens
+        && blocks.iter().any(|b| matches!(b, ReplyBlock::ToolUse { .. }))
+    {
+        let detail = "tool_use_truncated_by_max_tokens: the reply stopped at the token \
+                      budget while emitting tool_use block(s); the calls may be incomplete \
+                      and must not execute. Retry with a larger max_tokens."
+            .to_string();
+        return Err(CallError::BudgetExhausted { detail });
+    }
+
     let input_tokens = v
         .pointer("/usage/input_tokens")
         .and_then(|n| n.as_u64())
@@ -774,23 +790,46 @@ mod tests {
         assert_eq!(reply.stop_reason, StopReason::MaxTokens);
     }
 
+    /// `max_tokens_mid_tool`: a truncated tool call must be an ERROR, not a
+    /// parseable success — an Ok reply would be cached as a valid cassette
+    /// entry and its raw blocks would stay accessible to naive consumers.
+    /// BudgetExhausted (not Protocol) so the existing higher-budget retry
+    /// machinery is the recovery path.
     #[test]
-    fn max_tokens_tool_use_is_parsed_but_never_executable() {
+    fn max_tokens_tool_use_is_rejected_as_budget_exhausted() {
         let json = r#"{
             "model":"m",
             "content":[
+                {"type":"text","text":"partial"},
                 {"type":"tool_use","id":"toolu_truncated","name":"vault_write","input":{"path":"note.md"}}
             ],
             "stop_reason":"max_tokens",
             "usage":{"input_tokens":1,"output_tokens":2}
         }"#;
-        let reply = parse_anthropic_reply(json).unwrap();
+        match parse_anthropic_reply(json) {
+            Err(CallError::BudgetExhausted { detail }) => {
+                assert!(detail.contains("tool_use_truncated_by_max_tokens"), "{detail}");
+            }
+            other => panic!("expected BudgetExhausted, got {other:?}"),
+        }
+    }
 
-        assert_eq!(reply.stop_reason, StopReason::MaxTokens);
-        assert!(matches!(
-            reply.blocks.as_deref(),
-            Some([ReplyBlock::ToolUse { id, .. }]) if id == "toolu_truncated"
-        ));
+    /// Defense in depth for replies that reach a consumer anyway (e.g. an old
+    /// cassette recorded before this rejection): the accessor still refuses.
+    #[test]
+    fn executable_tool_calls_refuses_max_tokens_replies() {
+        let reply = ModelReply {
+            model: "m".into(),
+            text: String::new(),
+            stop_reason: StopReason::MaxTokens,
+            usage: Usage { input_tokens: 1, output_tokens: 2 },
+            blocks: Some(vec![ReplyBlock::ToolUse {
+                id: "toolu_truncated".into(),
+                name: "vault_write".into(),
+                input: serde_json::json!({"path": "note.md"}),
+            }]),
+            raw_stop_reason: None,
+        };
         assert_eq!(reply.executable_tool_calls(), None);
         assert!(!reply.is_final_success());
     }

--- a/crates/ovp-llm/src/anthropic.rs
+++ b/crates/ovp-llm/src/anthropic.rs
@@ -19,10 +19,88 @@ use crate::request::{AssistantBlock, ModelMessage, ModelRequest};
 pub const DEFAULT_BASE_URL: &str = "https://api.anthropic.com/v1/messages";
 pub const ANTHROPIC_VERSION: &str = "2023-06-01";
 
+/// Enforce `tool_result_adjacency_all` BEFORE anything reaches the wire:
+/// every tool_use-bearing assistant turn must be immediately followed by a
+/// `ToolResults` turn answering exactly those ids (each exactly once — missing,
+/// duplicated, unknown, or delayed results are all violations), and
+/// `ToolResults` never appears without such a turn. Anthropic 4xxes these
+/// shapes; failing loudly here turns a silent invalid request into a caller
+/// bug with a precise message.
+fn validate_tool_protocol(messages: &[ModelMessage]) -> Result<(), CallError> {
+    let violation = |detail: String| CallError::Protocol { detail };
+    // ids emitted by the previous assistant turn, still awaiting results
+    let mut pending: Option<Vec<String>> = None;
+    for (i, m) in messages.iter().enumerate() {
+        match (pending.take(), m) {
+            (Some(ids), ModelMessage::ToolResults { results }) => {
+                let mut remaining = ids;
+                for r in results {
+                    match remaining.iter().position(|id| *id == r.tool_call_id) {
+                        Some(pos) => {
+                            remaining.remove(pos);
+                        }
+                        None => {
+                            return Err(violation(format!(
+                                "message {i}: tool_result for unknown or already-answered id `{}`",
+                                r.tool_call_id
+                            )));
+                        }
+                    }
+                }
+                if !remaining.is_empty() {
+                    return Err(violation(format!(
+                        "message {i}: missing tool_result(s) for id(s) {remaining:?}"
+                    )));
+                }
+            }
+            (Some(ids), _) => {
+                return Err(violation(format!(
+                    "message {i}: expected tool_results answering {ids:?} immediately \
+                     after the assistant tool_use turn"
+                )));
+            }
+            (None, ModelMessage::ToolResults { .. }) => {
+                return Err(violation(format!(
+                    "message {i}: tool_results without a preceding assistant tool_use turn"
+                )));
+            }
+            (None, _) => {}
+        }
+        if let ModelMessage::AssistantBlocks { blocks } = m {
+            let ids: Vec<String> = blocks
+                .iter()
+                .filter_map(|b| match b {
+                    AssistantBlock::ToolUse { id, .. } => Some(id.clone()),
+                    AssistantBlock::Text { .. } => None,
+                })
+                .collect();
+            for (n, id) in ids.iter().enumerate() {
+                if ids[..n].contains(id) {
+                    return Err(violation(format!(
+                        "message {i}: duplicate tool_use id `{id}` within one assistant turn"
+                    )));
+                }
+            }
+            if !ids.is_empty() {
+                pending = Some(ids);
+            }
+        }
+    }
+    if let Some(ids) = pending {
+        return Err(violation(format!(
+            "conversation ends with unanswered tool_use id(s) {ids:?}"
+        )));
+    }
+    Ok(())
+}
+
 /// Build the Anthropic Messages API request body from a provider-neutral
 /// `ModelRequest`. Pure — no I/O. `system` becomes a top-level field;
-/// messages map role-for-role.
-pub fn anthropic_request_body(req: &ModelRequest) -> serde_json::Value {
+/// messages map role-for-role. Errs with `CallError::Protocol` when the
+/// message sequence violates the tool-use contract (see
+/// [`validate_tool_protocol`]) — a caller bug, surfaced before the wire.
+pub fn anthropic_request_body(req: &ModelRequest) -> Result<serde_json::Value, CallError> {
+    validate_tool_protocol(&req.messages)?;
     let messages: Vec<serde_json::Value> = req
         .messages
         .iter()
@@ -94,7 +172,7 @@ pub fn anthropic_request_body(req: &ModelRequest) -> serde_json::Value {
                 .collect::<Vec<_>>()),
         );
     }
-    body
+    Ok(body)
 }
 
 /// Parse an Anthropic Messages API success response body into a
@@ -369,7 +447,7 @@ mod live {
 
     impl ModelClient for AnthropicBlockingClient {
         fn call(&mut self, request: &ModelRequest) -> Result<ModelReply, CallError> {
-            let mut body = anthropic_request_body(request);
+            let mut body = anthropic_request_body(request)?;
             if let Some(model) = &self.model_override {
                 body["model"] = serde_json::json!(model);
             }
@@ -430,7 +508,7 @@ mod tests {
 
     #[test]
     fn request_body_shape() {
-        let body = anthropic_request_body(&req());
+        let body = anthropic_request_body(&req()).unwrap();
         assert_eq!(body["model"], "claude-sonnet-4-6");
         assert_eq!(body["max_tokens"], 1024);
         assert_eq!(body["system"], "you are terse");
@@ -444,7 +522,7 @@ mod tests {
     fn request_body_includes_temperature_when_set() {
         let mut r = req();
         r.temperature = Some(0.5);
-        let body = anthropic_request_body(&r);
+        let body = anthropic_request_body(&r).unwrap();
         assert_eq!(body["temperature"], 0.5);
     }
 
@@ -462,7 +540,7 @@ mod tests {
             }),
         }]);
 
-        let body = anthropic_request_body(&r);
+        let body = anthropic_request_body(&r).unwrap();
         assert_eq!(body["tools"][0]["name"], "vault_search");
         assert_eq!(body["tools"][0]["description"], "Search indexed vault content");
         assert_eq!(body["tools"][0]["input_schema"]["type"], "object");
@@ -470,6 +548,83 @@ mod tests {
             body["tools"][0].get("version").is_none(),
             "protocol version belongs to the request key, not the provider wire format"
         );
+    }
+
+    fn expect_protocol_violation(r: &ModelRequest, needle: &str) {
+        match anthropic_request_body(r) {
+            Err(CallError::Protocol { detail }) => {
+                assert!(detail.contains(needle), "detail `{detail}` missing `{needle}`");
+            }
+            other => panic!("expected Protocol violation containing `{needle}`, got {other:?}"),
+        }
+    }
+
+    fn tool_use(id: &str) -> AssistantBlock {
+        AssistantBlock::ToolUse {
+            id: id.into(),
+            name: "vault_search".into(),
+            input: json!({"query": "q"}),
+        }
+    }
+
+    fn result_for(id: &str) -> ToolResultBlock {
+        ToolResultBlock { tool_call_id: id.into(), content: "ok".into(), is_error: false }
+    }
+
+    /// `tool_result_adjacency_all`: every malformed continuation the runtime
+    /// could construct must fail loudly BEFORE the wire, not as a provider 4xx.
+    #[test]
+    fn tool_protocol_violations_fail_before_the_wire() {
+        // Missing one result of two.
+        let mut r = req();
+        r.messages = vec![
+            ModelMessage::AssistantBlocks { blocks: vec![tool_use("c1"), tool_use("c2")] },
+            ModelMessage::ToolResults { results: vec![result_for("c1")] },
+        ];
+        expect_protocol_violation(&r, "missing tool_result");
+
+        // Result for an id the assistant never emitted.
+        let mut r = req();
+        r.messages = vec![
+            ModelMessage::AssistantBlocks { blocks: vec![tool_use("c1")] },
+            ModelMessage::ToolResults { results: vec![result_for("ghost")] },
+        ];
+        expect_protocol_violation(&r, "unknown or already-answered");
+
+        // Duplicate result for the same id.
+        let mut r = req();
+        r.messages = vec![
+            ModelMessage::AssistantBlocks { blocks: vec![tool_use("c1")] },
+            ModelMessage::ToolResults { results: vec![result_for("c1"), result_for("c1")] },
+        ];
+        expect_protocol_violation(&r, "unknown or already-answered");
+
+        // Delayed results: an unrelated user turn slips in between.
+        let mut r = req();
+        r.messages = vec![
+            ModelMessage::AssistantBlocks { blocks: vec![tool_use("c1")] },
+            ModelMessage::User { content: "wait".into() },
+            ModelMessage::ToolResults { results: vec![result_for("c1")] },
+        ];
+        expect_protocol_violation(&r, "immediately");
+
+        // Results with no tool_use turn at all.
+        let mut r = req();
+        r.messages = vec![ModelMessage::ToolResults { results: vec![result_for("c1")] }];
+        expect_protocol_violation(&r, "without a preceding");
+
+        // Conversation ends with unanswered calls.
+        let mut r = req();
+        r.messages = vec![ModelMessage::AssistantBlocks { blocks: vec![tool_use("c1")] }];
+        expect_protocol_violation(&r, "ends with unanswered");
+
+        // Duplicate ids within one assistant turn.
+        let mut r = req();
+        r.messages = vec![
+            ModelMessage::AssistantBlocks { blocks: vec![tool_use("c1"), tool_use("c1")] },
+            ModelMessage::ToolResults { results: vec![result_for("c1")] },
+        ];
+        expect_protocol_violation(&r, "duplicate tool_use id");
     }
 
     #[test]
@@ -516,7 +671,7 @@ mod tests {
             },
         ];
 
-        let body = anthropic_request_body(&r);
+        let body = anthropic_request_body(&r).unwrap();
         assert_eq!(body["messages"][0]["role"], "assistant");
         assert_eq!(body["messages"][0]["content"].as_array().unwrap().len(), 3);
         assert_eq!(body["messages"][1]["role"], "user");

--- a/crates/ovp-llm/src/anthropic.rs
+++ b/crates/ovp-llm/src/anthropic.rs
@@ -13,8 +13,8 @@
 use serde_json::json;
 
 use crate::client::CallError;
-use crate::reply::{ModelReply, StopReason, Usage};
-use crate::request::{ModelMessage, ModelRequest};
+use crate::reply::{ModelReply, ReplyBlock, StopReason, Usage};
+use crate::request::{AssistantBlock, ModelMessage, ModelRequest};
 
 pub const DEFAULT_BASE_URL: &str = "https://api.anthropic.com/v1/messages";
 pub const ANTHROPIC_VERSION: &str = "2023-06-01";
@@ -31,6 +31,39 @@ pub fn anthropic_request_body(req: &ModelRequest) -> serde_json::Value {
             ModelMessage::Assistant { content } => {
                 json!({ "role": "assistant", "content": content })
             }
+            ModelMessage::AssistantBlocks { blocks } => {
+                let content: Vec<_> = blocks
+                    .iter()
+                    .map(|block| match block {
+                        AssistantBlock::Text { text } => {
+                            json!({ "type": "text", "text": text })
+                        }
+                        AssistantBlock::ToolUse { id, name, input } => json!({
+                            "type": "tool_use",
+                            "id": id,
+                            "name": name,
+                            "input": input,
+                        }),
+                    })
+                    .collect();
+                json!({ "role": "assistant", "content": content })
+            }
+            ModelMessage::ToolResults { results } => {
+                // This variant carries only results, so all tool_result blocks
+                // necessarily lead the user turn (`tool_result_adjacency_all`).
+                let content: Vec<_> = results
+                    .iter()
+                    .map(|result| {
+                        json!({
+                            "type": "tool_result",
+                            "tool_use_id": result.tool_call_id,
+                            "content": result.content,
+                            "is_error": result.is_error,
+                        })
+                    })
+                    .collect();
+                json!({ "role": "user", "content": content })
+            }
         })
         .collect();
 
@@ -45,6 +78,21 @@ pub fn anthropic_request_body(req: &ModelRequest) -> serde_json::Value {
     }
     if let Some(temp) = req.temperature {
         obj.insert("temperature".into(), json!(temp));
+    }
+    if let Some(tools) = &req.tools {
+        obj.insert(
+            "tools".into(),
+            json!(tools
+                .iter()
+                .map(|tool| {
+                    json!({
+                        "name": tool.name,
+                        "description": tool.description,
+                        "input_schema": tool.input_schema,
+                    })
+                })
+                .collect::<Vec<_>>()),
+        );
     }
     body
 }
@@ -81,13 +129,45 @@ pub fn parse_anthropic_reply(json_body: &str) -> Result<ModelReply, CallError> {
         .and_then(|c| c.as_array())
         .ok_or_else(|| CallError::Decode { detail: "missing `content` array".into() })?;
     let mut text = String::new();
+    let mut blocks = Vec::new();
+    let mut has_tool_use = false;
     for block in content {
-        if block.get("type").and_then(|t| t.as_str()) == Some("text")
-            && let Some(t) = block.get("text").and_then(|t| t.as_str()) {
-                text.push_str(t);
+        match block.get("type").and_then(|t| t.as_str()) {
+            Some("text") => {
+                if let Some(t) = block.get("text").and_then(|t| t.as_str()) {
+                    text.push_str(t);
+                    blocks.push(ReplyBlock::Text { text: t.to_string() });
+                }
             }
+            Some("tool_use") => {
+                let id = block
+                    .get("id")
+                    .and_then(|id| id.as_str())
+                    .ok_or_else(|| CallError::Decode {
+                        detail: "tool_use block missing string `id`".into(),
+                    })?
+                    .to_string();
+                let name = block
+                    .get("name")
+                    .and_then(|name| name.as_str())
+                    .ok_or_else(|| CallError::Decode {
+                        detail: "tool_use block missing string `name`".into(),
+                    })?
+                    .to_string();
+                let input =
+                    block
+                        .get("input")
+                        .cloned()
+                        .ok_or_else(|| CallError::Decode {
+                            detail: "tool_use block missing `input`".into(),
+                        })?;
+                has_tool_use = true;
+                blocks.push(ReplyBlock::ToolUse { id, name, input });
+            }
+            _ => {}
+        }
     }
-    if text.is_empty() {
+    if text.is_empty() && !has_tool_use {
         // Diagnose the common reasoning-model case: the provider returned only
         // `thinking` blocks (and no `text`), typically because it exhausted the
         // token budget while thinking. Make this loud + actionable rather than
@@ -115,7 +195,8 @@ pub fn parse_anthropic_reply(json_body: &str) -> Result<ModelReply, CallError> {
         return Err(CallError::Decode { detail });
     }
 
-    let stop_reason = map_stop_reason(v.get("stop_reason").and_then(|s| s.as_str()));
+    let (stop_reason, raw_stop_reason) =
+        map_stop_reason(v.get("stop_reason").and_then(|s| s.as_str()));
 
     let input_tokens = v
         .pointer("/usage/input_tokens")
@@ -131,15 +212,20 @@ pub fn parse_anthropic_reply(json_body: &str) -> Result<ModelReply, CallError> {
         text,
         stop_reason,
         usage: Usage { input_tokens, output_tokens },
+        blocks: Some(blocks),
+        raw_stop_reason,
     })
 }
 
-fn map_stop_reason(s: Option<&str>) -> StopReason {
+fn map_stop_reason(s: Option<&str>) -> (StopReason, Option<String>) {
     match s {
-        Some("end_turn") => StopReason::EndTurn,
-        Some("max_tokens") => StopReason::MaxTokens,
-        Some("stop_sequence") => StopReason::StopSequence,
-        _ => StopReason::Unknown,
+        Some("end_turn") => (StopReason::EndTurn, None),
+        Some("max_tokens") => (StopReason::MaxTokens, None),
+        Some("stop_sequence") => (StopReason::StopSequence, None),
+        Some("tool_use") => (StopReason::ToolUse, None),
+        Some("refusal") => (StopReason::Refusal, None),
+        Some(other) => (StopReason::Unknown, Some(other.to_string())),
+        None => (StopReason::Unknown, None),
     }
 }
 
@@ -328,6 +414,7 @@ mod live {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::request::{ToolDef, ToolResultBlock};
 
     fn req() -> ModelRequest {
         ModelRequest {
@@ -336,6 +423,7 @@ mod tests {
             messages: vec![ModelMessage::User { content: "hi".into() }],
             max_tokens: 1024,
             temperature: None,
+            tools: None,
             cache_namespace: None,
         }
     }
@@ -361,6 +449,87 @@ mod tests {
     }
 
     #[test]
+    fn request_body_uses_in_memory_tool_schema_and_description() {
+        let mut r = req();
+        r.tools = Some(vec![ToolDef {
+            name: "vault_search".into(),
+            version: "v1".into(),
+            description: "Search indexed vault content".into(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"]
+            }),
+        }]);
+
+        let body = anthropic_request_body(&r);
+        assert_eq!(body["tools"][0]["name"], "vault_search");
+        assert_eq!(body["tools"][0]["description"], "Search indexed vault content");
+        assert_eq!(body["tools"][0]["input_schema"]["type"], "object");
+        assert!(
+            body["tools"][0].get("version").is_none(),
+            "protocol version belongs to the request key, not the provider wire format"
+        );
+    }
+
+    #[test]
+    fn assistant_blocks_and_all_tool_results_map_to_adjacent_wire_turns() {
+        let mut r = req();
+        r.messages = vec![
+            ModelMessage::AssistantBlocks {
+                blocks: vec![
+                    AssistantBlock::ToolUse {
+                        id: "call-1".into(),
+                        name: "vault_search".into(),
+                        input: json!({"query": "one"}),
+                    },
+                    AssistantBlock::ToolUse {
+                        id: "call-2".into(),
+                        name: "vault_search".into(),
+                        input: json!({"query": "two"}),
+                    },
+                    AssistantBlock::ToolUse {
+                        id: "call-3".into(),
+                        name: "vault_search".into(),
+                        input: json!({"query": "three"}),
+                    },
+                ],
+            },
+            ModelMessage::ToolResults {
+                results: vec![
+                    ToolResultBlock {
+                        tool_call_id: "call-1".into(),
+                        content: "first".into(),
+                        is_error: false,
+                    },
+                    ToolResultBlock {
+                        tool_call_id: "call-2".into(),
+                        content: "failed".into(),
+                        is_error: true,
+                    },
+                    ToolResultBlock {
+                        tool_call_id: "call-3".into(),
+                        content: "third".into(),
+                        is_error: false,
+                    },
+                ],
+            },
+        ];
+
+        let body = anthropic_request_body(&r);
+        assert_eq!(body["messages"][0]["role"], "assistant");
+        assert_eq!(body["messages"][0]["content"].as_array().unwrap().len(), 3);
+        assert_eq!(body["messages"][1]["role"], "user");
+        let results = body["messages"][1]["content"].as_array().unwrap();
+        assert_eq!(results.len(), 3);
+        assert!(results.iter().all(|block| block["type"] == "tool_result"));
+        assert_eq!(results[0]["tool_use_id"], "call-1");
+        assert_eq!(results[1]["tool_use_id"], "call-2");
+        assert_eq!(results[1]["is_error"], true);
+        assert_eq!(results[2]["tool_use_id"], "call-3");
+    }
+
+    #[test]
     fn parse_success_reply() {
         let json = r#"{
             "model": "claude-sonnet-4-6",
@@ -377,10 +546,119 @@ mod tests {
     }
 
     #[test]
+    fn parse_tool_only_reply_is_success() {
+        let json = r#"{
+            "model": "claude-sonnet-4-6",
+            "content": [
+                {"type":"tool_use","id":"toolu_provider_01","name":"vault_search","input":{"query":"memory"}}
+            ],
+            "stop_reason": "tool_use",
+            "usage": {"input_tokens": 12, "output_tokens": 34}
+        }"#;
+        let reply = parse_anthropic_reply(json).unwrap();
+
+        assert_eq!(reply.text, "");
+        assert_eq!(reply.stop_reason, StopReason::ToolUse);
+        assert_eq!(
+            reply.blocks,
+            Some(vec![ReplyBlock::ToolUse {
+                id: "toolu_provider_01".into(),
+                name: "vault_search".into(),
+                input: json!({"query": "memory"}),
+            }])
+        );
+        let calls = reply.executable_tool_calls().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].id, "toolu_provider_01");
+    }
+
+    #[test]
+    fn parse_text_and_multiple_tool_uses_preserves_order_and_ids() {
+        let json = r#"{
+            "model": "claude-sonnet-4-6",
+            "content": [
+                {"type":"text","text":"I will check both. "},
+                {"type":"tool_use","id":"toolu_provider_A","name":"vault_search","input":{"query":"alpha"}},
+                {"type":"text","text":"Then compare. "},
+                {"type":"tool_use","id":"toolu_provider_B","name":"vault_search","input":{"query":"beta"}}
+            ],
+            "stop_reason": "tool_use",
+            "usage": {"input_tokens": 20, "output_tokens": 40}
+        }"#;
+        let reply = parse_anthropic_reply(json).unwrap();
+
+        assert_eq!(reply.text, "I will check both. Then compare. ");
+        assert_eq!(
+            reply.blocks,
+            Some(vec![
+                ReplyBlock::Text { text: "I will check both. ".into() },
+                ReplyBlock::ToolUse {
+                    id: "toolu_provider_A".into(),
+                    name: "vault_search".into(),
+                    input: json!({"query": "alpha"}),
+                },
+                ReplyBlock::Text { text: "Then compare. ".into() },
+                ReplyBlock::ToolUse {
+                    id: "toolu_provider_B".into(),
+                    name: "vault_search".into(),
+                    input: json!({"query": "beta"}),
+                },
+            ])
+        );
+        let calls = reply.executable_tool_calls().unwrap();
+        assert_eq!(
+            calls.iter().map(|call| call.id).collect::<Vec<_>>(),
+            vec!["toolu_provider_A", "toolu_provider_B"]
+        );
+    }
+
+    #[test]
     fn parse_max_tokens_stop_reason() {
         let json = r#"{"model":"m","content":[{"type":"text","text":"x"}],"stop_reason":"max_tokens","usage":{"input_tokens":1,"output_tokens":2}}"#;
         let reply = parse_anthropic_reply(json).unwrap();
         assert_eq!(reply.stop_reason, StopReason::MaxTokens);
+    }
+
+    #[test]
+    fn max_tokens_tool_use_is_parsed_but_never_executable() {
+        let json = r#"{
+            "model":"m",
+            "content":[
+                {"type":"tool_use","id":"toolu_truncated","name":"vault_write","input":{"path":"note.md"}}
+            ],
+            "stop_reason":"max_tokens",
+            "usage":{"input_tokens":1,"output_tokens":2}
+        }"#;
+        let reply = parse_anthropic_reply(json).unwrap();
+
+        assert_eq!(reply.stop_reason, StopReason::MaxTokens);
+        assert!(matches!(
+            reply.blocks.as_deref(),
+            Some([ReplyBlock::ToolUse { id, .. }]) if id == "toolu_truncated"
+        ));
+        assert_eq!(reply.executable_tool_calls(), None);
+        assert!(!reply.is_final_success());
+    }
+
+    #[test]
+    fn unknown_stop_reason_is_preserved_and_not_final_success() {
+        let json = r#"{"model":"m","content":[{"type":"text","text":"x"}],"stop_reason":"banana","usage":{"input_tokens":1,"output_tokens":2}}"#;
+        let reply = parse_anthropic_reply(json).unwrap();
+
+        assert_eq!(reply.stop_reason, StopReason::Unknown);
+        assert_eq!(reply.raw_stop_reason.as_deref(), Some("banana"));
+        assert!(!reply.is_final_success());
+        assert_eq!(reply.executable_tool_calls(), None);
+    }
+
+    #[test]
+    fn refusal_stop_reason_maps_without_becoming_success() {
+        let json = r#"{"model":"m","content":[{"type":"text","text":"I cannot do that."}],"stop_reason":"refusal","usage":{"input_tokens":1,"output_tokens":2}}"#;
+        let reply = parse_anthropic_reply(json).unwrap();
+
+        assert_eq!(reply.stop_reason, StopReason::Refusal);
+        assert_eq!(reply.raw_stop_reason, None);
+        assert!(!reply.is_final_success());
     }
 
     #[test]

--- a/crates/ovp-llm/src/client.rs
+++ b/crates/ovp-llm/src/client.rs
@@ -20,6 +20,10 @@ pub enum CallError {
     Transport { detail: String },
     /// Response failed to parse into the wire `ModelReply` shape.
     Decode { detail: String },
+    /// The request violates the tool-use protocol (`tool_result_adjacency_all`):
+    /// e.g. a tool_use turn not answered by exactly its results. Caller bug —
+    /// failing loudly here beats a provider 4xx on an invalid request.
+    Protocol { detail: String },
     /// A reasoning/thinking model spent its whole `max_tokens` budget on a
     /// thinking block and emitted NO text block (`stop_reason=max_tokens`). NOT
     /// transient — retrying with the SAME budget won't help — but recoverable by
@@ -36,6 +40,7 @@ impl std::fmt::Display for CallError {
             CallError::Provider { code, detail } => write!(f, "provider error {code}: {detail}"),
             CallError::Transport { detail } => write!(f, "transport: {detail}"),
             CallError::Decode { detail } => write!(f, "decode: {detail}"),
+            CallError::Protocol { detail } => write!(f, "tool protocol violation: {detail}"),
             CallError::BudgetExhausted { detail } => write!(f, "budget exhausted: {detail}"),
             CallError::Unexpected { detail } => write!(f, "unexpected: {detail}"),
         }
@@ -95,8 +100,11 @@ pub fn is_transient(err: &CallError) -> bool {
                 c.contains("rate_limit") || c.contains("overloaded") || c.contains("unavailable")
             }
         }
+        // Protocol violations are caller bugs — retrying resends the same
+        // invalid message sequence.
         CallError::CacheMiss { .. }
         | CallError::Decode { .. }
+        | CallError::Protocol { .. }
         | CallError::BudgetExhausted { .. }
         | CallError::Unexpected { .. } => false,
     }

--- a/crates/ovp-llm/src/client.rs
+++ b/crates/ovp-llm/src/client.rs
@@ -211,6 +211,8 @@ mod retry_tests {
                 text: "ok".into(),
                 stop_reason: StopReason::EndTurn,
                 usage: Usage { input_tokens: 1, output_tokens: 1 },
+                blocks: None,
+                raw_stop_reason: None,
             }
         }
     }
@@ -233,6 +235,7 @@ mod retry_tests {
             messages: vec![],
             max_tokens: 16,
             temperature: None,
+            tools: None,
             cache_namespace: None,
         }
     }

--- a/crates/ovp-llm/src/key.rs
+++ b/crates/ovp-llm/src/key.rs
@@ -24,7 +24,8 @@ fn hex_lower(bytes: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::request::ModelMessage;
+    use crate::request::{ModelMessage, ToolDef};
+    use serde_json::json;
 
     fn req() -> ModelRequest {
         ModelRequest {
@@ -33,6 +34,7 @@ mod tests {
             messages: vec![ModelMessage::User { content: "hi".into() }],
             max_tokens: 100,
             temperature: None,
+            tools: None,
             cache_namespace: None,
         }
     }
@@ -66,5 +68,41 @@ mod tests {
         let k = request_key(&req());
         assert_eq!(k.len(), 64);
         assert!(k.chars().all(|c| c.is_ascii_hexdigit() && (c.is_ascii_digit() || c.is_ascii_lowercase())));
+    }
+
+    #[test]
+    fn tool_less_key_matches_pre_protocol_request_json() {
+        assert_eq!(
+            request_key(&req()),
+            "5c9b43757b8975b8b1cc2f52ebf02d981c4665278eb24e71a2bc97efc8f2e558"
+        );
+    }
+
+    #[test]
+    fn tool_key_uses_only_name_and_version() {
+        let mut baseline = req();
+        baseline.tools = Some(vec![ToolDef {
+            name: "vault_search".into(),
+            version: "v1".into(),
+            description: "Search the vault".into(),
+            input_schema: json!({"type": "object", "properties": {"query": {"type": "string"}}}),
+        }]);
+
+        let mut docs_changed = baseline.clone();
+        let tool = docs_changed.tools.as_mut().unwrap().first_mut().unwrap();
+        tool.description = "Search every indexed vault document".into();
+        tool.input_schema = json!({
+            "type": "object",
+            "properties": {"query": {"type": "string", "description": "Search text"}}
+        });
+        assert_eq!(request_key(&baseline), request_key(&docs_changed));
+
+        let mut name_changed = baseline.clone();
+        name_changed.tools.as_mut().unwrap()[0].name = "vault_lookup".into();
+        assert_ne!(request_key(&baseline), request_key(&name_changed));
+
+        let mut version_changed = baseline.clone();
+        version_changed.tools.as_mut().unwrap()[0].version = "v2".into();
+        assert_ne!(request_key(&baseline), request_key(&version_changed));
     }
 }

--- a/crates/ovp-llm/src/lib.rs
+++ b/crates/ovp-llm/src/lib.rs
@@ -24,8 +24,10 @@ pub use client::{
 };
 pub use fixture::FixtureModelClient;
 pub use key::request_key;
-pub use reply::{ModelReply, StopReason, Usage};
-pub use request::{ModelMessage, ModelRequest};
+pub use reply::{ExecutableToolCall, ModelReply, ReplyBlock, StopReason, Usage};
+pub use request::{
+    AssistantBlock, ModelMessage, ModelRequest, ToolDef, ToolResultBlock,
+};
 
 #[cfg(feature = "anthropic")]
 pub use anthropic::AnthropicBlockingClient;

--- a/crates/ovp-llm/src/reply.rs
+++ b/crates/ovp-llm/src/reply.rs
@@ -13,9 +13,11 @@ pub struct ModelReply {
     /// cassette replies, where `text` remains the compatibility surface.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub blocks: Option<Vec<ReplyBlock>>,
-    /// Verbatim provider stop reason when it is not recognized. This
-    /// diagnostic is deliberately not part of persisted cassette JSON.
-    #[serde(default, skip)]
+    /// Verbatim provider stop reason when it is not recognized. PERSISTED in
+    /// cassette JSON (absent on legacy files → None): replay must reproduce
+    /// live behavior, so an unknown stop's diagnostic string survives the
+    /// disk round-trip instead of silently becoming None on replay.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub raw_stop_reason: Option<String>,
 }
 
@@ -108,5 +110,29 @@ mod tests {
         assert_eq!(reply.blocks, None);
         assert_eq!(reply.raw_stop_reason, None);
         assert!(!reply.is_final_success());
+    }
+
+    /// Cassette replay must reproduce LIVE behavior: an unknown provider stop
+    /// reason's verbatim string survives the disk round-trip (it would
+    /// otherwise be Some(raw) live but None on replay — divergent runs).
+    #[test]
+    fn unknown_raw_stop_reason_survives_cassette_round_trip() {
+        let reply = ModelReply {
+            model: "m".into(),
+            text: "done".into(),
+            stop_reason: StopReason::Unknown,
+            usage: Usage { input_tokens: 1, output_tokens: 2 },
+            blocks: None,
+            raw_stop_reason: Some("banana".into()),
+        };
+        let json = serde_json::to_string(&reply).unwrap();
+        assert!(json.contains("\"raw_stop_reason\":\"banana\""), "{json}");
+        let replayed: ModelReply = serde_json::from_str(&json).unwrap();
+        assert_eq!(replayed.raw_stop_reason.as_deref(), Some("banana"));
+
+        // And when there is nothing to preserve, the field stays absent —
+        // legacy cassette bytes (and keys derived from reply JSON) unchanged.
+        let plain = ModelReply { raw_stop_reason: None, ..reply };
+        assert!(!serde_json::to_string(&plain).unwrap().contains("raw_stop_reason"));
     }
 }

--- a/crates/ovp-llm/src/reply.rs
+++ b/crates/ovp-llm/src/reply.rs
@@ -9,6 +9,45 @@ pub struct ModelReply {
     pub text: String,
     pub stop_reason: StopReason,
     pub usage: Usage,
+    /// Provider content blocks in their original order. Absent in legacy
+    /// cassette replies, where `text` remains the compatibility surface.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blocks: Option<Vec<ReplyBlock>>,
+    /// Verbatim provider stop reason when it is not recognized. This
+    /// diagnostic is deliberately not part of persisted cassette JSON.
+    #[serde(default, skip)]
+    pub raw_stop_reason: Option<String>,
+}
+
+impl ModelReply {
+    /// Return provider-issued tool calls only when the turn explicitly stopped
+    /// for tool use. In particular, `MaxTokens` makes every included call
+    /// non-executable (`max_tokens_mid_tool`); raising the budget and retrying
+    /// is the caller's decision.
+    pub fn executable_tool_calls(&self) -> Option<Vec<ExecutableToolCall<'_>>> {
+        if self.stop_reason != StopReason::ToolUse {
+            return None;
+        }
+
+        let calls: Vec<_> = self
+            .blocks
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .filter_map(|block| match block {
+                ReplyBlock::ToolUse { id, name, input } => {
+                    Some(ExecutableToolCall { id, name, input })
+                }
+                ReplyBlock::Text { .. } => None,
+            })
+            .collect();
+        (!calls.is_empty()).then_some(calls)
+    }
+
+    /// Whether this reply represents a completed successful answer.
+    pub fn is_final_success(&self) -> bool {
+        self.stop_reason.is_final_success()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -17,11 +56,57 @@ pub enum StopReason {
     EndTurn,
     MaxTokens,
     StopSequence,
+    ToolUse,
+    Refusal,
     Unknown,
+}
+
+impl StopReason {
+    /// Unknown, truncated, refused, and tool-intermediate turns are never final
+    /// successes. This keeps future provider stop strings fail-closed.
+    pub fn is_final_success(&self) -> bool {
+        matches!(self, Self::EndTurn | Self::StopSequence)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ReplyBlock {
+    Text {
+        text: String,
+    },
+    ToolUse {
+        id: String,
+        name: String,
+        input: serde_json::Value,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ExecutableToolCall<'a> {
+    pub id: &'a str,
+    pub name: &'a str,
+    pub input: &'a serde_json::Value,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Usage {
     pub input_tokens: u32,
     pub output_tokens: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_cassette_reply_without_protocol_fields_still_deserializes() {
+        let raw = r#"{"model":"m","text":"done","stop_reason":"unknown","usage":{"input_tokens":1,"output_tokens":2}}"#;
+        let reply: ModelReply = serde_json::from_str(raw).unwrap();
+
+        assert_eq!(reply.stop_reason, StopReason::Unknown);
+        assert_eq!(reply.blocks, None);
+        assert_eq!(reply.raw_stop_reason, None);
+        assert!(!reply.is_final_success());
+    }
 }

--- a/crates/ovp-llm/src/request.rs
+++ b/crates/ovp-llm/src/request.rs
@@ -13,6 +13,10 @@ pub struct ModelRequest {
     pub messages: Vec<ModelMessage>,
     pub max_tokens: u32,
     pub temperature: Option<f32>,
+    /// Provider-neutral tool definitions. This field is absent from legacy
+    /// request JSON when no tools are supplied, preserving cassette keys.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<ToolDef>>,
     /// Per-request cache namespace hint (e.g. `article_interpret/v1`).
     /// A deliberate, provider-neutral hint at the request boundary so one
     /// `CachedModelClient` can file article vs. paper cassettes under the
@@ -36,4 +40,73 @@ impl ModelRequest {
 pub enum ModelMessage {
     User { content: String },
     Assistant { content: String },
+    AssistantBlocks {
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        blocks: Vec<AssistantBlock>,
+    },
+    /// A complete tool-result turn. Since this variant cannot carry trailing
+    /// text, every result maps to the front of the next Anthropic user message
+    /// (`tool_result_adjacency_all`).
+    ToolResults {
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        results: Vec<ToolResultBlock>,
+    },
+}
+
+/// Provider-neutral tool definition.
+///
+/// Only `(name, version)` enters `ModelRequest` serialization and therefore
+/// `request_key`. Provider-facing documentation and schemas remain available
+/// in memory for wire mapping without invalidating cassettes when edited.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ToolDef {
+    pub name: String,
+    pub version: String,
+    #[serde(skip)]
+    pub description: String,
+    #[serde(skip)]
+    pub input_schema: serde_json::Value,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AssistantBlock {
+    Text {
+        text: String,
+    },
+    ToolUse {
+        id: String,
+        name: String,
+        input: serde_json::Value,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolResultBlock {
+    pub tool_call_id: String,
+    pub content: String,
+    pub is_error: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tool_less_request_serialization_is_byte_identical_to_legacy_json() {
+        let request = ModelRequest {
+            model: "test".into(),
+            system: None,
+            messages: vec![ModelMessage::User { content: "hi".into() }],
+            max_tokens: 100,
+            temperature: None,
+            tools: None,
+            cache_namespace: None,
+        };
+
+        assert_eq!(
+            serde_json::to_string(&request).unwrap(),
+            r#"{"model":"test","system":null,"messages":[{"role":"user","content":"hi"}],"max_tokens":100,"temperature":null}"#
+        );
+    }
 }

--- a/crates/ovp-llm/tests/clients.rs
+++ b/crates/ovp-llm/tests/clients.rs
@@ -16,6 +16,7 @@ fn req(text: &str) -> ModelRequest {
         messages: vec![ModelMessage::User { content: text.into() }],
         max_tokens: 100,
         temperature: None,
+        tools: None,
         cache_namespace: None,
     }
 }
@@ -26,6 +27,8 @@ fn reply(text: &str) -> ModelReply {
         text: text.into(),
         stop_reason: StopReason::EndTurn,
         usage: Usage { input_tokens: 5, output_tokens: 10 },
+        blocks: None,
+        raw_stop_reason: None,
     }
 }
 

--- a/crates/ovp-memory/src/ask.rs
+++ b/crates/ovp-memory/src/ask.rs
@@ -260,6 +260,7 @@ pub fn ask_with_optional_evidence(
         messages,
         max_tokens: args.max_tokens,
         temperature: Some(temperature),
+        tools: None,
         // v4: intent-routed assistant (find / qa / explore / meta).
         cache_namespace: Some("ask/v4".into()),
     };
@@ -518,15 +519,15 @@ fn save_or_append_chat(
 
     let turn_block = format_chat_turn(question, answer, evidence, verification, context_hits);
 
-    if let Some(stem) = chat.map(str::trim).filter(|s| !s.is_empty()) {
-        if valid_chat_stem(stem) {
-            let path = chats_dir.join(format!("{stem}.md"));
-            if path.is_file() {
-                append_chat_turn(&path, &turn_block)?;
-                return Ok(path);
-            }
+    // Invalid name or missing file → fall through to a new session file.
+    if let Some(stem) = chat.map(str::trim).filter(|s| !s.is_empty())
+        && valid_chat_stem(stem)
+    {
+        let path = chats_dir.join(format!("{stem}.md"));
+        if path.is_file() {
+            append_chat_turn(&path, &turn_block)?;
+            return Ok(path);
         }
-        // Invalid name or missing file → fall through to a new session file.
     }
 
     let ts = chrono_like_timestamp();
@@ -859,6 +860,8 @@ mod tests {
                     input_tokens: 1,
                     output_tokens: 1,
                 },
+                blocks: None,
+                raw_stop_reason: None,
             })
         }
     }
@@ -975,7 +978,9 @@ mod tests {
         assert_eq!(request.cache_namespace.as_deref(), Some("ask/v4"));
         let user = match &request.messages[0] {
             ovp_llm::ModelMessage::User { content } => content,
-            ovp_llm::ModelMessage::Assistant { .. } => panic!("expected user message"),
+            ovp_llm::ModelMessage::Assistant { .. }
+            | ovp_llm::ModelMessage::AssistantBlocks { .. }
+            | ovp_llm::ModelMessage::ToolResults { .. } => panic!("expected user message"),
         };
 
         assert!(user.contains("[claim:claim-memory-1]"), "{user}");

--- a/crates/ovp-memory/src/digest.rs
+++ b/crates/ovp-memory/src/digest.rs
@@ -145,6 +145,7 @@ pub fn render_llm_digest(
         messages: vec![ModelMessage::User { content: prompt }],
         max_tokens,
         temperature: Some(0.3),
+        tools: None,
         cache_namespace: Some("digest/v1".into()),
     };
 

--- a/crates/ovp-memory/src/intent.rs
+++ b/crates/ovp-memory/src/intent.rs
@@ -63,7 +63,7 @@ pub fn classify_intent(question: &str, history: &[AskHistoryTurn]) -> AskIntent 
 
     // If the prior user turns were clearly "find that article" and this turn
     // is a short clarification, keep hunting.
-    if history.len() >= 1
+    if !history.is_empty()
         && q.chars().count() < 40
         && prior_was_find(history)
         && !looks_like_meta(&lower)

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -2748,6 +2748,8 @@ mod tests {
                     input_tokens: 1,
                     output_tokens: 1,
                 },
+                blocks: None,
+                raw_stop_reason: None,
             })
         }
     }


### PR DESCRIPTION
First implementation Candidate of the A0-signed Vault Agent program (evolution/candidates/ask_tool_protocol-v1.json — `ovp2 evolve validate` ✓). MODEL surface only: no runtime loop, ask stays single-shot.

**What**: provider-neutral tool protocol in ovp-llm — ModelRequest.tools + ToolDef (serialized form ONLY (name,version); description/schema serde-skipped so schema edits never invalidate cassettes), AssistantBlocks/ToolResults message variants (ordered blocks, provider-issued ids verbatim, all-results-lead-next-user-turn), ModelReply blocks + ToolUse/Refusal stop reasons, executable_tool_calls() (calls executable ONLY on stop==tool_use; MaxTokens-truncated calls never execute), is_final_success() fail-closed on Unknown. Anthropic wire mapping both directions; tool-only reply = success; thinking-budget diagnosis preserved.

**Cassette safety (the trap)**: request_key = SHA-256 of serde JSON, so every new field is default+skip_serializing_if; a hardcoded pre-change key test proves a tool-less request's key is byte-identical (hash independently recomputed during review). Key policy tests: schema/description edits keep the key; tool name/version changes rotate it.

**Out-of-crate changes**: mechanical `tools: None`/`blocks: None`/`raw_stop_reason: None` threading at construction sites (zero behavior) + two latent ovp-memory clippy debts surfaced by recompilation (let-chain collapse, len>=1→!is_empty).

**Process**: developed by codex agent against the candidate spec (Coase check: spec was fully written, acceptance decidable); reviewed and verified here — workspace tests green, workspace clippy -D warnings clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for structured tool definitions, tool calls, and tool results in model conversations.
  - Model replies can now include ordered text/tool blocks and preserve raw provider stop-reason details.
  - Improved detection of final-success responses (including tool-related cases).

- **Bug Fixes**
  - Fixed handling of tool-only responses and improved compatibility with existing saved request/replay data.
  - Tool protocol violations are now detected and surfaced as non-retryable errors.

- **Tests**
  - Expanded coverage for tool serialization, structured reply parsing, stop-reason preservation, and legacy compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->