### PR TITLE
feat(memory): A1b — ask-agent runtime engine (ask_agent-v1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ console-ui/dist-static/
 IMPLEMENTATION_PLAN.md
 # Competitive-research process docs — local only, never commit (operator directive)
 docs/design/ask-vault-agent-nowledge-review.md
+# Research process docs — local only, never commit (operator directive)
+docs/research/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2906,6 +2906,7 @@ dependencies = [
  "ovp-llm",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/ovp-memory/Cargo.toml
+++ b/crates/ovp-memory/Cargo.toml
@@ -13,5 +13,8 @@ ovp-llm = { path = "../ovp-llm" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
+[dev-dependencies]
+tempfile = { workspace = true }
+
 [features]
 default = []

--- a/crates/ovp-memory/src/agent.rs
+++ b/crates/ovp-memory/src/agent.rs
@@ -163,7 +163,11 @@ pub fn run_agent_turn(
     cfg: &AgentConfig,
 ) -> Result<AgentOutcome, AgentError> {
     // Idempotent replay BEFORE locking: a completed turn answers retries even
-    // while a different (new) turn holds the lock.
+    // while a different (new) turn holds the lock. Refresh the read-only view
+    // first — a long-lived store must see keys committed by other processes.
+    store
+        .refresh_readonly()
+        .map_err(|e| AgentError::Store(e.to_string()))?;
     if let Some(key) = idempotency_key
         && let Some(done) = store.completed_turn_for_key(key)
     {
@@ -265,11 +269,26 @@ pub fn run_agent_turn(
             round: rounds,
             input_tokens: reply.usage.input_tokens,
             output_tokens: reply.usage.output_tokens,
-            src: cfg.model.clone(),
+            // Attribute the spend to the model that actually replied — a
+            // client-side override can differ from cfg.model.
+            src: if reply.model.is_empty() { cfg.model.clone() } else { reply.model.clone() },
             scope: "turn".into(),
         });
         in_total += reply.usage.input_tokens;
         out_total += reply.usage.output_tokens;
+        // `deadline_authority` for the MODEL side too: the trait carries no
+        // per-call timeout (propagating remaining into the transport is the
+        // live-client integration's A1a-v2 concern), so a reply that lands
+        // after the deadline is LATE — audited, usage counted, never
+        // delivered as an answer or executed.
+        if remaining(started).is_zero() {
+            events.push(TranscriptEvent::ReplyDiscarded {
+                turn_id: turn_id.clone(),
+                round: rounds,
+                reason: "model reply arrived after the turn deadline".into(),
+            });
+            break 'turn StoppedReason::Timeout;
+        }
         if !reply.text.is_empty() {
             last_text = reply.text.clone();
         }
@@ -1080,13 +1099,20 @@ mod tests {
             run_agent_turn(&mut client, &mut tools, &mut st, "q?", None, &cfg()).unwrap();
         assert_eq!(out.input_tokens_total, 30); // 20 (tool round) + 10 (final)
         assert_eq!(out.output_tokens_total, 13); // 8 + 5
-        // And the transcript carries per-call events.
-        let model_events = st
+        // And the transcript carries per-call events, attributed to the model
+        // that actually replied (reply.model = "m"), scoped to the turn.
+        let usage_rows: Vec<_> = st
             .events()
             .iter()
-            .filter(|e| matches!(e, TranscriptEvent::ModelCalled { .. }))
-            .count();
-        assert_eq!(model_events, 2);
+            .filter_map(|e| match e {
+                TranscriptEvent::ModelCalled { src, scope, .. } => {
+                    Some((src.clone(), scope.clone()))
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(usage_rows.len(), 2);
+        assert!(usage_rows.iter().all(|(s, sc)| s == "m" && sc == "turn"));
     }
 
     // Model transport failure mid-turn: honest model_error, audited turn.
@@ -1238,6 +1264,63 @@ mod tests {
             })
             .collect();
         assert_eq!(shape, vec!["text", "tool", "text", "tool"], "provider order is protocol");
+    }
+
+    // A model reply that lands after the deadline is LATE: usage counted,
+    // discard audited, nothing delivered or executed.
+    #[test]
+    fn late_model_reply_is_discarded() {
+        struct SlowClient(Duration);
+        impl ModelClient for SlowClient {
+            fn call(&mut self, _r: &ModelRequest) -> Result<ModelReply, CallError> {
+                std::thread::sleep(self.0);
+                text_reply("too late")
+            }
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let mut client = SlowClient(Duration::from_millis(60));
+        let mut tools = MockTools::new(&[("search", Behavior::Ok("hit"))]);
+        let mut st = store(dir.path());
+        let mut c = cfg();
+        c.deadline = Duration::from_millis(25);
+        let out = run_agent_turn(&mut client, &mut tools, &mut st, "q?", None, &c).unwrap();
+        assert_eq!(out.stopped_reason, StoppedReason::Timeout);
+        assert!(out.answer.is_empty(), "a late reply is never delivered");
+        assert!(tools.calls.is_empty());
+        assert!(st.events().iter().any(|e| matches!(
+            e,
+            TranscriptEvent::ReplyDiscarded { reason, .. } if reason.contains("after the turn deadline")
+        )));
+        // The spend still happened and is accounted.
+        assert!(out.input_tokens_total > 0);
+    }
+
+    // A key completed by ANOTHER writer replays even while the session lock is
+    // held by someone else and our store was opened before the commit.
+    #[test]
+    fn stale_prelock_view_still_replays_completed_key() {
+        let dir = tempfile::tempdir().unwrap();
+        // Store A opened EARLY (stale view).
+        let mut stale = store(dir.path());
+        // Another store completes a turn with key K.
+        {
+            let mut client = Scripted::new(vec![text_reply("done elsewhere")]);
+            let mut tools = MockTools::new(&[]);
+            let mut other = store(dir.path());
+            run_agent_turn(&mut client, &mut tools, &mut other, "q?", Some("K"), &cfg())
+                .unwrap();
+        }
+        // A third party currently holds the lock.
+        let holder = store(dir.path());
+        let _held = holder.lock().unwrap();
+        // The stale store must REPLAY (refresh-before-lookup), not SessionBusy.
+        let mut client = Scripted::new(vec![text_reply("SHOULD NOT RUN")]);
+        let mut tools = MockTools::new(&[]);
+        let out = run_agent_turn(&mut client, &mut tools, &mut stale, "q?", Some("K"), &cfg())
+            .unwrap();
+        assert!(out.idempotent_replay);
+        assert_eq!(out.answer, "done elsewhere");
+        assert!(client.requests.is_empty());
     }
 
     // An empty/unstamped lock file is conservatively BUSY — a racing creator

--- a/crates/ovp-memory/src/agent.rs
+++ b/crates/ovp-memory/src/agent.rs
@@ -25,7 +25,7 @@ use ovp_llm::{
     ToolResultBlock,
 };
 
-use crate::agent_transcript::{SessionStore, StoreError, TranscriptEvent, TRANSCRIPT_SCHEMA};
+use crate::agent_transcript::{SessionStore, StoreError, TranscriptEvent};
 
 /// What a tool execution produced. `InvalidArgs` is distinguished because it
 /// feeds the circuit breaker; `Failed` is an execution error (fed back as
@@ -162,6 +162,10 @@ pub fn run_agent_turn(
     idempotency_key: Option<&str>,
     cfg: &AgentConfig,
 ) -> Result<AgentOutcome, AgentError> {
+    // The whole-turn budget starts NOW — refresh, lock acquisition, and
+    // compaction all spend from it (`deadline_authority` covers the turn,
+    // not just the loop).
+    let started = Instant::now();
     // Idempotent replay BEFORE locking: a completed turn answers retries even
     // while a different (new) turn holds the lock. Refresh the read-only view
     // first — a long-lived store must see keys committed by other processes.
@@ -210,12 +214,10 @@ pub fn run_agent_turn(
         });
     }
 
-    let started = Instant::now();
     let remaining = |started: Instant| cfg.deadline.saturating_sub(started.elapsed());
 
     let turn_id = store.next_turn_id();
     let mut events: Vec<TranscriptEvent> = vec![TranscriptEvent::TurnStarted {
-        schema: TRANSCRIPT_SCHEMA.to_string(),
         turn_id: turn_id.clone(),
         question: question.to_string(),
         idempotency_key: idempotency_key.map(str::to_string),
@@ -304,6 +306,29 @@ pub fn run_agent_turn(
             .unwrap_or_default();
 
         if calls.is_empty() {
+            // Fail closed on a CONTRADICTORY shape: tool_use blocks under a
+            // final stop reason (EndTurn/StopSequence). Treating it as Final
+            // would silently ignore the calls and deliver an incomplete
+            // answer as success.
+            let has_tool_blocks = reply
+                .blocks
+                .as_deref()
+                .unwrap_or_default()
+                .iter()
+                .any(|b| matches!(b, ovp_llm::ReplyBlock::ToolUse { .. }));
+            if has_tool_blocks
+                && matches!(reply.stop_reason, StopReason::EndTurn | StopReason::StopSequence)
+            {
+                events.push(TranscriptEvent::ReplyDiscarded {
+                    turn_id: turn_id.clone(),
+                    round: rounds,
+                    reason: format!(
+                        "contradictory reply: tool_use blocks under stop_reason {:?}",
+                        reply.stop_reason
+                    ),
+                });
+                break 'turn StoppedReason::ModelError;
+            }
             // No executable tools → the reply is the turn's terminal state.
             // Record the terminal assistant text as a Message event: later
             // turns project THIS turn and must see its answer, or multi-turn
@@ -445,7 +470,14 @@ pub fn run_agent_turn(
                 tool: name.clone(),
                 tool_call_id: id.clone(),
                 is_error: is_error || finished_late,
-                summary: content.chars().take(120).collect(),
+                // Late data is AUDIT-ONLY: the caller-facing trail (and any
+                // idempotent replay built from it) gets the discard marker,
+                // never the content.
+                summary: if finished_late {
+                    "late: discarded (audit only)".to_string()
+                } else {
+                    content.chars().take(120).collect()
+                },
             });
             let (model_content, model_is_error) = if finished_late {
                 timed_out = true;
@@ -813,10 +845,12 @@ mod tests {
             text_reply("never reached"),
         ]);
         let mut tools =
-            MockTools::new(&[("slow", Behavior::Slow(Duration::from_millis(80)))]);
+            MockTools::new(&[("slow", Behavior::Slow(Duration::from_millis(600)))]);
         let mut st = store(dir.path());
         let mut c = cfg();
-        c.deadline = Duration::from_millis(40);
+        // Generous margins: the clock starts at function entry, so lock/fs
+        // preprocessing must fit well inside the deadline under parallel load.
+        c.deadline = Duration::from_millis(300);
         let out = run_agent_turn(&mut client, &mut tools, &mut st, "q?", None, &c).unwrap();
         assert_eq!(out.stopped_reason, StoppedReason::Timeout);
         assert_eq!(client.requests.len(), 1, "no model call may START after the deadline");
@@ -999,23 +1033,16 @@ mod tests {
             let mut st = store(dir.path());
             run_agent_turn(&mut client, &mut tools, &mut st, "q?", None, &cfg()).unwrap();
         }
-        // Simulate a crash mid-turn: append turn events WITHOUT TurnFinished.
+        // Simulate a crash mid-turn: append turn events WITHOUT TurnFinished
+        // (raw lines in the on-disk wrapper shape: schema + session_id + event).
         let path = dir.path().join("s1.jsonl");
-        let torn = format!(
-            "{}\n{}\n",
-            serde_json::to_string(&TranscriptEvent::TurnStarted {
-                schema: TRANSCRIPT_SCHEMA.into(),
-                turn_id: "t2".into(),
-                question: "torn".into(),
-                idempotency_key: None,
-            })
-            .unwrap(),
-            serde_json::to_string(&TranscriptEvent::Message {
-                turn_id: "t2".into(),
-                message: ModelMessage::User { content: "torn".into() },
-            })
-            .unwrap()
-        );
+        let torn = concat!(
+            r#"{"schema":"ovp.ask_transcript/v1","session_id":"s1","event":"turn_started","turn_id":"t2","question":"torn"}"#,
+            "\n",
+            r#"{"schema":"ovp.ask_transcript/v1","session_id":"s1","event":"message","turn_id":"t2","message":{"role":"user","content":"torn"}}"#,
+            "\n"
+        )
+        .to_string();
         use std::io::Write as _;
         std::fs::OpenOptions::new()
             .append(true)
@@ -1144,12 +1171,12 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let mut client = Scripted::new(vec![tool_reply(&[("c1", "slow"), ("c2", "fast")])]);
         let mut tools = MockTools::new(&[
-            ("slow", Behavior::Slow(Duration::from_millis(80))),
+            ("slow", Behavior::Slow(Duration::from_millis(600))),
             ("fast", Behavior::Ok("quick")),
         ]);
         let mut st = store(dir.path());
         let mut c = cfg();
-        c.deadline = Duration::from_millis(40);
+        c.deadline = Duration::from_millis(300);
         let out = run_agent_turn(&mut client, &mut tools, &mut st, "q?", None, &c).unwrap();
         assert_eq!(out.stopped_reason, StoppedReason::Timeout);
         // Both calls answered — the skipped one as a timeout error.
@@ -1182,6 +1209,9 @@ mod tests {
             })
             .unwrap();
         assert_eq!(audit_raw, "slow done", "the late result survives in the audit");
+        // The caller-facing trail must NOT leak the late content.
+        assert!(out.tool_trace[0].summary.contains("discarded"));
+        assert!(!out.tool_trace[0].summary.contains("slow done"));
     }
 
     // MaxTokens without tools: a truncated answer must not present as Final.
@@ -1278,11 +1308,11 @@ mod tests {
             }
         }
         let dir = tempfile::tempdir().unwrap();
-        let mut client = SlowClient(Duration::from_millis(60));
+        let mut client = SlowClient(Duration::from_millis(600));
         let mut tools = MockTools::new(&[("search", Behavior::Ok("hit"))]);
         let mut st = store(dir.path());
         let mut c = cfg();
-        c.deadline = Duration::from_millis(25);
+        c.deadline = Duration::from_millis(300);
         let out = run_agent_turn(&mut client, &mut tools, &mut st, "q?", None, &c).unwrap();
         assert_eq!(out.stopped_reason, StoppedReason::Timeout);
         assert!(out.answer.is_empty(), "a late reply is never delivered");
@@ -1321,6 +1351,56 @@ mod tests {
         assert!(out.idempotent_replay);
         assert_eq!(out.answer, "done elsewhere");
         assert!(client.requests.is_empty());
+    }
+
+    // Every on-disk line carries schema + session_id (audit rows must stay
+    // versioned/correlatable when separated from the filename).
+    #[test]
+    fn every_line_carries_schema_and_session() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut client = Scripted::new(vec![text_reply("x")]);
+        let mut tools = MockTools::new(&[]);
+        let mut st = store(dir.path());
+        run_agent_turn(&mut client, &mut tools, &mut st, "q?", None, &cfg()).unwrap();
+        let body = std::fs::read_to_string(dir.path().join("s1.jsonl")).unwrap();
+        for line in body.lines() {
+            let v: serde_json::Value = serde_json::from_str(line).unwrap();
+            assert_eq!(v["schema"], "ovp.ask_transcript/v1", "{line}");
+            assert_eq!(v["session_id"], "s1", "{line}");
+        }
+    }
+
+    // Contradictory reply shape (tool_use blocks under a final stop) fails
+    // closed instead of silently dropping the calls.
+    #[test]
+    fn tool_blocks_under_final_stop_fail_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        let contradictory = Ok(ModelReply {
+            model: "m".into(),
+            text: "looks done".into(),
+            stop_reason: StopReason::EndTurn,
+            usage: Usage { input_tokens: 1, output_tokens: 1 },
+            blocks: Some(vec![
+                ReplyBlock::Text { text: "looks done".into() },
+                ReplyBlock::ToolUse {
+                    id: "c1".into(),
+                    name: "search".into(),
+                    input: serde_json::json!({}),
+                },
+            ]),
+            raw_stop_reason: None,
+        });
+        let mut client = Scripted::new(vec![contradictory]);
+        let mut tools = MockTools::new(&[("search", Behavior::Ok("hit"))]);
+        let mut st = store(dir.path());
+        let out =
+            run_agent_turn(&mut client, &mut tools, &mut st, "q?", None, &cfg()).unwrap();
+        assert_eq!(out.stopped_reason, StoppedReason::ModelError);
+        assert!(tools.calls.is_empty());
+        assert!(st.events().iter().any(|e| matches!(
+            e,
+            TranscriptEvent::ReplyDiscarded { reason, .. } if reason.contains("contradictory")
+        )));
     }
 
     // An empty/unstamped lock file is conservatively BUSY — a racing creator

--- a/crates/ovp-memory/src/agent.rs
+++ b/crates/ovp-memory/src/agent.rs
@@ -265,6 +265,8 @@ pub fn run_agent_turn(
             round: rounds,
             input_tokens: reply.usage.input_tokens,
             output_tokens: reply.usage.output_tokens,
+            src: cfg.model.clone(),
+            scope: "turn".into(),
         });
         in_total += reply.usage.input_tokens;
         out_total += reply.usage.output_tokens;
@@ -385,6 +387,11 @@ pub fn run_agent_turn(
                 // feeds back once and counts toward the breaker.
                 ToolOutcome::InvalidArgs(format!("unknown tool `{name}`"))
             };
+            // `deadline_authority` at the RESULT level too: a tool that
+            // overruns the remaining budget produced LATE data — audit it,
+            // but never feed it to the model as a success (A0 §5.2: late
+            // results are side-log material, not deliveries).
+            let finished_late = remaining(started).is_zero() && !timed_out;
             let (mut content, is_error, was_invalid_args) = match outcome {
                 ToolOutcome::Ok(body) => (body, false, false),
                 ToolOutcome::InvalidArgs(detail) => {
@@ -410,7 +417,7 @@ pub fn run_agent_turn(
                 turn_id: turn_id.clone(),
                 tool_call_id: id.clone(),
                 tool: name.clone(),
-                is_error,
+                is_error: is_error || finished_late,
                 result_bytes: raw_bytes,
                 content: content.clone(),
                 truncated,
@@ -418,14 +425,37 @@ pub fn run_agent_turn(
             trace.push(ToolTraceEntry {
                 tool: name.clone(),
                 tool_call_id: id.clone(),
-                is_error,
+                is_error: is_error || finished_late,
                 summary: content.chars().take(120).collect(),
             });
-            if truncated {
-                content.truncate(floor_char_boundary(&content, cfg.max_result_bytes));
-                content.push_str("\n[truncated]");
-            }
-            results.push(ToolResultBlock { tool_call_id: id.clone(), content, is_error });
+            let (model_content, model_is_error) = if finished_late {
+                timed_out = true;
+                (
+                    "tool result arrived after the turn deadline; discarded \
+                     (kept in the audit transcript only)"
+                        .to_string(),
+                    true,
+                )
+            } else {
+                if truncated {
+                    // The marker counts AGAINST the cap — the model-facing
+                    // copy must never exceed it.
+                    const MARKER: &str = "\n[truncated]";
+                    let keep = cfg.max_result_bytes.saturating_sub(MARKER.len());
+                    content.truncate(floor_char_boundary(&content, keep));
+                    content.push_str(MARKER);
+                    if content.len() > cfg.max_result_bytes {
+                        // Degenerate tiny caps: the marker alone overflows.
+                        content.truncate(floor_char_boundary(&content, cfg.max_result_bytes));
+                    }
+                }
+                (content, is_error)
+            };
+            results.push(ToolResultBlock {
+                tool_call_id: id.clone(),
+                content: model_content,
+                is_error: model_is_error,
+            });
         }
 
         // The COMPLETE batch is always recorded (adjacency), then a timeout
@@ -1108,9 +1138,24 @@ mod tests {
             })
             .expect("the batch must be recorded despite the timeout");
         assert_eq!(results_msg.len(), 2);
-        assert!(!results_msg[0].is_error);
+        // The slow tool FINISHED LATE: its data is discarded for the model
+        // (error result) but preserved raw in the audit row (A0: late results
+        // are side-log material, never deliveries).
+        assert!(results_msg[0].is_error, "late result must not be delivered as success");
+        assert!(results_msg[0].content.contains("after the turn deadline"));
         assert!(results_msg[1].is_error, "skipped call must be a timeout error result");
         assert!(results_msg[1].content.contains("deadline exhausted"));
+        let audit_raw = st
+            .events()
+            .iter()
+            .find_map(|e| match e {
+                TranscriptEvent::ToolCalled { tool, content, .. } if tool == "slow" => {
+                    Some(content.clone())
+                }
+                _ => None,
+            })
+            .unwrap();
+        assert_eq!(audit_raw, "slow done", "the late result survives in the audit");
     }
 
     // MaxTokens without tools: a truncated answer must not present as Final.

--- a/crates/ovp-memory/src/agent.rs
+++ b/crates/ovp-memory/src/agent.rs
@@ -179,10 +179,32 @@ pub fn run_agent_turn(
         });
     }
 
-    let _lock = store.lock().map_err(|e| match e {
+    let lock = store.lock().map_err(|e| match e {
         StoreError::SessionBusy { .. } => AgentError::SessionBusy,
         StoreError::Io(d) => AgentError::Store(d),
     })?;
+    // Under the lock: refresh state (a turn may have committed since `open`,
+    // which would stale our turn id + projection) and physically compact any
+    // crash-torn tail — the only place a rewrite cannot race an appender.
+    store
+        .reload_under_lock(&lock)
+        .map_err(|e| AgentError::Store(e.to_string()))?;
+    // Re-check idempotency against the FRESH view (the same key may have
+    // completed between the pre-lock check and lock acquisition).
+    if let Some(key) = idempotency_key
+        && let Some(done) = store.completed_turn_for_key(key)
+    {
+        return Ok(AgentOutcome {
+            turn_id: done.turn_id,
+            answer: done.answer,
+            stopped_reason: parse_stopped(&done.stopped_reason),
+            rounds: done.rounds,
+            tool_trace: Vec::new(),
+            input_tokens_total: done.input_tokens_total,
+            output_tokens_total: done.output_tokens_total,
+            idempotent_replay: true,
+        });
+    }
 
     let started = Instant::now();
     let remaining = |started: Instant| cfg.deadline.saturating_sub(started.elapsed());
@@ -258,6 +280,17 @@ pub fn run_agent_turn(
 
         if calls.is_empty() {
             // No executable tools → the reply is the turn's terminal state.
+            // Record the terminal assistant text as a Message event: later
+            // turns project THIS turn and must see its answer, or multi-turn
+            // continuity breaks and the audit is incomplete.
+            if !reply.text.is_empty() {
+                let final_msg = ModelMessage::Assistant { content: reply.text.clone() };
+                messages.push(final_msg.clone());
+                events.push(TranscriptEvent::Message {
+                    turn_id: turn_id.clone(),
+                    message: final_msg,
+                });
+            }
             break 'turn match reply.stop_reason {
                 StopReason::Refusal => StoppedReason::Refusal,
                 // `unknown_stop_not_final`: fail-closed.
@@ -265,9 +298,12 @@ pub fn run_agent_turn(
                 // ToolUse with zero executable calls cannot happen (the parse
                 // layer rejects truncated tool turns); treat defensively.
                 StopReason::ToolUse => StoppedReason::ModelError,
-                StopReason::EndTurn | StopReason::StopSequence | StopReason::MaxTokens => {
-                    StoppedReason::Final
-                }
+                // A MaxTokens text answer is TRUNCATED — surfacing it as a
+                // clean Final would present an incomplete answer as success
+                // (`is_final_success` is false for MaxTokens). The partial
+                // text still reaches the caller via `answer`.
+                StopReason::MaxTokens => StoppedReason::ModelError,
+                StopReason::EndTurn | StopReason::StopSequence => StoppedReason::Final,
             };
         }
 
@@ -280,61 +316,76 @@ pub fn run_agent_turn(
             }
         }
 
-        // Record the assistant tool turn in the conversation + transcript.
+        // `max_rounds_auxiliary`: refuse the batch BEFORE recording the
+        // assistant tool turn — a recorded tool_use with no results would
+        // make every later projection protocol-invalid.
+        if rounds + 1 > cfg.max_rounds {
+            break 'turn StoppedReason::MaxRounds;
+        }
+        rounds += 1;
+
+        // Record the assistant tool turn VERBATIM from the provider blocks —
+        // interleaved text/tool_use order is part of the protocol and of
+        // deterministic replay (concatenating text would reorder it).
         let assistant_msg = ModelMessage::AssistantBlocks {
-            blocks: {
-                let mut blocks: Vec<AssistantBlock> = Vec::new();
-                if !reply.text.is_empty() {
-                    blocks.push(AssistantBlock::Text { text: reply.text.clone() });
-                }
-                blocks.extend(calls.iter().map(|(id, name, input)| AssistantBlock::ToolUse {
-                    id: id.clone(),
-                    name: name.clone(),
-                    input: input.clone(),
-                }));
-                blocks
-            },
+            blocks: reply
+                .blocks
+                .as_deref()
+                .unwrap_or_default()
+                .iter()
+                .map(|b| match b {
+                    ovp_llm::ReplyBlock::Text { text } => {
+                        AssistantBlock::Text { text: text.clone() }
+                    }
+                    ovp_llm::ReplyBlock::ToolUse { id, name, input } => {
+                        AssistantBlock::ToolUse {
+                            id: id.clone(),
+                            name: name.clone(),
+                            input: input.clone(),
+                        }
+                    }
+                })
+                .collect(),
         };
         messages.push(assistant_msg.clone());
         events.push(TranscriptEvent::Message { turn_id: turn_id.clone(), message: assistant_msg });
 
-        // `max_rounds_auxiliary`: cap tool-execution batches.
-        rounds += 1;
-        if rounds > cfg.max_rounds {
-            break 'turn StoppedReason::MaxRounds;
-        }
-
-        // Execute ALL calls — failed ones become is_error results so the
-        // round is always fully answered (`all_results_fed_back`).
+        // Execute the calls — failed ones become is_error results so the
+        // round is always fully answered (`all_results_fed_back`). A mid-
+        // batch deadline exhaustion fills the REMAINING calls with timeout
+        // error results: the recorded assistant turn must always get its
+        // complete, adjacent result batch or the transcript would be
+        // protocol-invalid for every later projection.
         let mut results: Vec<ToolResultBlock> = Vec::new();
         let mut breaker_tripped = false;
         let mut timed_out = false;
         for (id, name, input) in &calls {
             let left = remaining(started);
-            if left.is_zero() {
+            let outcome = if left.is_zero() || timed_out {
                 timed_out = true;
-                break;
-            }
-            let outcome = if tool_defs.iter().any(|d| &d.name == name) {
+                ToolOutcome::Failed("skipped: turn deadline exhausted".into())
+            } else if tool_defs.iter().any(|d| &d.name == name) {
                 tools.execute(name, input, left)
             } else {
                 // A hallucinated tool name is an arguments-class failure: it
                 // feeds back once and counts toward the breaker.
                 ToolOutcome::InvalidArgs(format!("unknown tool `{name}`"))
             };
-            let (mut content, is_error) = match outcome {
-                ToolOutcome::Ok(body) => (body, false),
+            let (mut content, is_error, was_invalid_args) = match outcome {
+                ToolOutcome::Ok(body) => (body, false, false),
                 ToolOutcome::InvalidArgs(detail) => {
                     let n = invalid_streak.entry(name.clone()).or_insert(0);
                     *n += 1;
                     if *n >= cfg.invalid_args_breaker {
                         breaker_tripped = true;
                     }
-                    (format!("invalid arguments: {detail}"), true)
+                    (format!("invalid arguments: {detail}"), true, true)
                 }
-                ToolOutcome::Failed(detail) => (format!("tool failed: {detail}"), true),
+                ToolOutcome::Failed(detail) => (format!("tool failed: {detail}"), true, false),
             };
-            if !is_error {
+            // The breaker counts CONSECUTIVE invalid-args per tool: any other
+            // outcome — success OR an execution failure — resets the streak.
+            if !was_invalid_args {
                 invalid_streak.remove(name);
             }
             if content.len() > cfg.max_result_bytes {
@@ -357,13 +408,15 @@ pub fn run_agent_turn(
             results.push(ToolResultBlock { tool_call_id: id.clone(), content, is_error });
         }
 
-        if timed_out {
-            break 'turn StoppedReason::Timeout;
-        }
-
+        // The COMPLETE batch is always recorded (adjacency), then a timeout
+        // ends the turn.
         let results_msg = ModelMessage::ToolResults { results };
         messages.push(results_msg.clone());
         events.push(TranscriptEvent::Message { turn_id: turn_id.clone(), message: results_msg });
+
+        if timed_out {
+            break 'turn StoppedReason::Timeout;
+        }
 
         if breaker_tripped {
             break 'turn StoppedReason::ToolError;
@@ -487,6 +540,8 @@ mod tests {
         Fail,
         Slow(Duration),
         Big(usize),
+        /// Per-call scripted outcomes (last one repeats).
+        Script(Vec<ToolOutcome>),
     }
 
     struct MockTools {
@@ -532,6 +587,10 @@ mod tests {
                     ToolOutcome::Ok("slow done".into())
                 }
                 Some(Behavior::Big(n)) => ToolOutcome::Ok("x".repeat(*n)),
+                Some(Behavior::Script(seq)) => {
+                    let n = self.calls.iter().filter(|c| c == &name).count() - 1;
+                    seq.get(n.min(seq.len() - 1)).cloned().unwrap_or(ToolOutcome::Failed("empty script".into()))
+                }
                 None => ToolOutcome::Failed("unrouted".into()),
             }
         }
@@ -696,7 +755,25 @@ mod tests {
         c.max_rounds = 3;
         let out = run_agent_turn(&mut client, &mut tools, &mut st, "q?", None, &c).unwrap();
         assert_eq!(out.stopped_reason, StoppedReason::MaxRounds);
-        assert_eq!(out.rounds, 4, "stops when the cap is exceeded");
+        assert_eq!(out.rounds, 3, "the over-cap batch is refused BEFORE recording");
+        // The transcript must contain no unanswered tool_use: every recorded
+        // AssistantBlocks turn is followed by its ToolResults.
+        let msgs: Vec<_> = st
+            .events()
+            .iter()
+            .filter_map(|e| match e {
+                TranscriptEvent::Message { message, .. } => Some(message.clone()),
+                _ => None,
+            })
+            .collect();
+        for (i, m) in msgs.iter().enumerate() {
+            if matches!(m, ModelMessage::AssistantBlocks { .. }) {
+                assert!(
+                    matches!(msgs.get(i + 1), Some(ModelMessage::ToolResults { .. })),
+                    "tool turn at {i} lacks its adjacent results"
+                );
+            }
+        }
     }
 
     // Duplicate tool_use ids in ONE reply: nothing executes, fail-closed.
@@ -839,11 +916,24 @@ mod tests {
             .write_all(torn.as_bytes())
             .unwrap();
 
+        // A read-only open IGNORES the torn tail in memory but must NOT
+        // rewrite the file (it could race a concurrent appender).
         let st = store(dir.path());
-        assert_eq!(st.next_turn_id(), "t2", "torn turn compacted away");
+        assert_eq!(st.next_turn_id(), "t2", "torn turn ignored in memory");
+        assert!(
+            std::fs::read_to_string(&path).unwrap().contains("torn"),
+            "open() must not rewrite pre-lock"
+        );
+        // Running a turn (which compacts UNDER THE LOCK) purges the torn tail.
+        let mut client = Scripted::new(vec![text_reply("fresh")]);
+        let mut tools = MockTools::new(&[]);
+        let mut st = store(dir.path());
+        let out =
+            run_agent_turn(&mut client, &mut tools, &mut st, "again?", None, &cfg()).unwrap();
+        assert_eq!(out.turn_id, "t2");
         assert!(
             !std::fs::read_to_string(&path).unwrap().contains("torn"),
-            "compaction rewrote the file without the torn tail"
+            "locked compaction removed the torn tail"
         );
     }
 
@@ -924,5 +1014,150 @@ mod tests {
         assert_eq!(out.stopped_reason, StoppedReason::ModelError);
         let st2 = store(dir.path());
         assert_eq!(st2.next_turn_id(), "t2", "failed turn is still a complete audit record");
+    }
+
+    // Mid-batch deadline exhaustion: remaining calls get timeout is_error
+    // results; the batch stays COMPLETE and adjacent, then the turn times out.
+    #[test]
+    fn mid_batch_timeout_completes_the_result_batch() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut client = Scripted::new(vec![tool_reply(&[("c1", "slow"), ("c2", "fast")])]);
+        let mut tools = MockTools::new(&[
+            ("slow", Behavior::Slow(Duration::from_millis(80))),
+            ("fast", Behavior::Ok("quick")),
+        ]);
+        let mut st = store(dir.path());
+        let mut c = cfg();
+        c.deadline = Duration::from_millis(40);
+        let out = run_agent_turn(&mut client, &mut tools, &mut st, "q?", None, &c).unwrap();
+        assert_eq!(out.stopped_reason, StoppedReason::Timeout);
+        // Both calls answered — the skipped one as a timeout error.
+        let results_msg = st
+            .events()
+            .iter()
+            .find_map(|e| match e {
+                TranscriptEvent::Message { message: ModelMessage::ToolResults { results }, .. } => {
+                    Some(results.clone())
+                }
+                _ => None,
+            })
+            .expect("the batch must be recorded despite the timeout");
+        assert_eq!(results_msg.len(), 2);
+        assert!(!results_msg[0].is_error);
+        assert!(results_msg[1].is_error, "skipped call must be a timeout error result");
+        assert!(results_msg[1].content.contains("deadline exhausted"));
+    }
+
+    // MaxTokens without tools: a truncated answer must not present as Final.
+    #[test]
+    fn max_tokens_text_is_not_final() {
+        let dir = tempfile::tempdir().unwrap();
+        let truncated = Ok(ModelReply {
+            stop_reason: StopReason::MaxTokens,
+            ..text_reply("partial ans").unwrap()
+        });
+        let mut client = Scripted::new(vec![truncated]);
+        let mut tools = MockTools::new(&[]);
+        let mut st = store(dir.path());
+        let out =
+            run_agent_turn(&mut client, &mut tools, &mut st, "q?", None, &cfg()).unwrap();
+        assert_eq!(out.stopped_reason, StoppedReason::ModelError);
+        assert_eq!(out.answer, "partial ans", "the partial text still reaches the caller");
+    }
+
+    // The terminal assistant answer is recorded — later turns project it.
+    #[test]
+    fn terminal_answer_recorded_for_next_turn() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut client = Scripted::new(vec![text_reply("the answer")]);
+        let mut tools = MockTools::new(&[]);
+        let mut st = store(dir.path());
+        run_agent_turn(&mut client, &mut tools, &mut st, "q?", None, &cfg()).unwrap();
+        let proj = st.projection(1_000_000);
+        assert!(
+            proj.iter().any(|m| matches!(
+                m,
+                ModelMessage::Assistant { content } if content == "the answer"
+            )),
+            "multi-turn continuity requires the prior answer in the projection"
+        );
+    }
+
+    // Interleaved provider blocks survive verbatim into the recorded turn.
+    #[test]
+    fn assistant_block_order_preserved_verbatim() {
+        let dir = tempfile::tempdir().unwrap();
+        let interleaved = Ok(ModelReply {
+            model: "m".into(),
+            text: "a b".into(),
+            stop_reason: StopReason::ToolUse,
+            usage: Usage { input_tokens: 1, output_tokens: 1 },
+            blocks: Some(vec![
+                ReplyBlock::Text { text: "a".into() },
+                ReplyBlock::ToolUse {
+                    id: "c1".into(),
+                    name: "search".into(),
+                    input: serde_json::json!({}),
+                },
+                ReplyBlock::Text { text: "b".into() },
+                ReplyBlock::ToolUse {
+                    id: "c2".into(),
+                    name: "search".into(),
+                    input: serde_json::json!({}),
+                },
+            ]),
+            raw_stop_reason: None,
+        });
+        let mut client = Scripted::new(vec![interleaved, text_reply("done")]);
+        let mut tools = MockTools::new(&[("search", Behavior::Ok("hit"))]);
+        let mut st = store(dir.path());
+        run_agent_turn(&mut client, &mut tools, &mut st, "q?", None, &cfg()).unwrap();
+        let recorded = &client.requests[1].messages;
+        let blocks = recorded
+            .iter()
+            .find_map(|m| match m {
+                ModelMessage::AssistantBlocks { blocks } => Some(blocks.clone()),
+                _ => None,
+            })
+            .unwrap();
+        let shape: Vec<&str> = blocks
+            .iter()
+            .map(|b| match b {
+                AssistantBlock::Text { .. } => "text",
+                AssistantBlock::ToolUse { .. } => "tool",
+            })
+            .collect();
+        assert_eq!(shape, vec!["text", "tool", "text", "tool"], "provider order is protocol");
+    }
+
+    // An execution failure BETWEEN invalid-args failures resets the streak:
+    // the breaker fires only on CONSECUTIVE invalid-args.
+    #[test]
+    fn execution_failure_resets_invalid_args_streak() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut client = Scripted::new(vec![
+            tool_reply(&[("c1", "moody")]),
+            tool_reply(&[("c2", "moody")]),
+            tool_reply(&[("c3", "moody")]),
+            text_reply("survived"),
+        ]);
+        let mut tools = MockTools::new(&[(
+            "moody",
+            Behavior::Script(vec![
+                ToolOutcome::InvalidArgs("bad".into()),
+                ToolOutcome::Failed("boom".into()),
+                ToolOutcome::InvalidArgs("bad".into()),
+            ]),
+        )]);
+        let mut st = store(dir.path());
+        let mut c = cfg();
+        c.max_rounds = 10;
+        let out = run_agent_turn(&mut client, &mut tools, &mut st, "q?", None, &c).unwrap();
+        assert_eq!(
+            out.stopped_reason,
+            StoppedReason::Final,
+            "invalid → failed → invalid is NOT consecutive; the loop survives"
+        );
+        assert_eq!(out.answer, "survived");
     }
 }

--- a/crates/ovp-memory/src/agent.rs
+++ b/crates/ovp-memory/src/agent.rs
@@ -21,7 +21,7 @@
 use std::time::{Duration, Instant};
 
 use ovp_llm::{
-    AssistantBlock, CallError, ModelClient, ModelMessage, ModelRequest, StopReason, ToolDef,
+    AssistantBlock, ModelClient, ModelMessage, ModelRequest, StopReason, ToolDef,
     ToolResultBlock,
 };
 
@@ -168,11 +168,11 @@ pub fn run_agent_turn(
         && let Some(done) = store.completed_turn_for_key(key)
     {
         return Ok(AgentOutcome {
+            tool_trace: replayed_trace(store, &done.turn_id),
             turn_id: done.turn_id,
             answer: done.answer,
             stopped_reason: parse_stopped(&done.stopped_reason),
             rounds: done.rounds,
-            tool_trace: Vec::new(),
             input_tokens_total: done.input_tokens_total,
             output_tokens_total: done.output_tokens_total,
             idempotent_replay: true,
@@ -195,11 +195,11 @@ pub fn run_agent_turn(
         && let Some(done) = store.completed_turn_for_key(key)
     {
         return Ok(AgentOutcome {
+            tool_trace: replayed_trace(store, &done.turn_id),
             turn_id: done.turn_id,
             answer: done.answer,
             stopped_reason: parse_stopped(&done.stopped_reason),
             rounds: done.rounds,
-            tool_trace: Vec::new(),
             input_tokens_total: done.input_tokens_total,
             output_tokens_total: done.output_tokens_total,
             idempotent_replay: true,
@@ -250,11 +250,15 @@ pub fn run_agent_turn(
         let reply = match client.call(&request) {
             Ok(r) => r,
             // Mid-turn model failure ends the turn with an honest reason —
-            // the audit trail still gets its TurnFinished.
-            Err(CallError::Provider { .. } | CallError::Transport { .. }) => {
+            // audited (`ModelFailed`), and the trail still gets TurnFinished.
+            Err(e) => {
+                events.push(TranscriptEvent::ModelFailed {
+                    turn_id: turn_id.clone(),
+                    round: rounds,
+                    detail: e.to_string(),
+                });
                 break 'turn StoppedReason::ModelError;
             }
-            Err(_) => break 'turn StoppedReason::ModelError,
         };
         events.push(TranscriptEvent::ModelCalled {
             turn_id: turn_id.clone(),
@@ -312,6 +316,11 @@ pub fn run_agent_turn(
         {
             let mut seen = std::collections::BTreeSet::new();
             if calls.iter().any(|(id, _, _)| !seen.insert(id.clone())) {
+                events.push(TranscriptEvent::ReplyDiscarded {
+                    turn_id: turn_id.clone(),
+                    round: rounds,
+                    reason: "duplicate tool_use ids within one reply".into(),
+                });
                 break 'turn StoppedReason::ToolError;
             }
         }
@@ -320,6 +329,11 @@ pub fn run_agent_turn(
         // assistant tool turn — a recorded tool_use with no results would
         // make every later projection protocol-invalid.
         if rounds + 1 > cfg.max_rounds {
+            events.push(TranscriptEvent::ReplyDiscarded {
+                turn_id: turn_id.clone(),
+                round: rounds,
+                reason: format!("tool batch refused: max_rounds ({}) reached", cfg.max_rounds),
+            });
             break 'turn StoppedReason::MaxRounds;
         }
         rounds += 1;
@@ -388,16 +402,18 @@ pub fn run_agent_turn(
             if !was_invalid_args {
                 invalid_streak.remove(name);
             }
-            if content.len() > cfg.max_result_bytes {
-                content.truncate(floor_char_boundary(&content, cfg.max_result_bytes));
-                content.push_str("\n[truncated]");
-            }
+            // Audit keeps the FULL RAW result (the transcript is complete by
+            // contract); only the model-facing copy is capped.
+            let raw_bytes = content.len();
+            let truncated = raw_bytes > cfg.max_result_bytes;
             events.push(TranscriptEvent::ToolCalled {
                 turn_id: turn_id.clone(),
                 tool_call_id: id.clone(),
                 tool: name.clone(),
                 is_error,
-                result_bytes: content.len(),
+                result_bytes: raw_bytes,
+                content: content.clone(),
+                truncated,
             });
             trace.push(ToolTraceEntry {
                 tool: name.clone(),
@@ -405,6 +421,10 @@ pub fn run_agent_turn(
                 is_error,
                 summary: content.chars().take(120).collect(),
             });
+            if truncated {
+                content.truncate(floor_char_boundary(&content, cfg.max_result_bytes));
+                content.push_str("\n[truncated]");
+            }
             results.push(ToolResultBlock { tool_call_id: id.clone(), content, is_error });
         }
 
@@ -449,6 +469,21 @@ pub fn run_agent_turn(
     })
 }
 
+/// Rebuild a replayed outcome's tool trace from the turn's audit rows — a
+/// retry must not lose the provenance trail the original response carried.
+fn replayed_trace(store: &SessionStore, turn_id: &str) -> Vec<ToolTraceEntry> {
+    store
+        .tool_calls_for_turn(turn_id)
+        .into_iter()
+        .map(|(tool, tool_call_id, is_error, summary)| ToolTraceEntry {
+            tool,
+            tool_call_id,
+            is_error,
+            summary,
+        })
+        .collect()
+}
+
 fn parse_stopped(s: &str) -> StoppedReason {
     match s {
         "final" => StoppedReason::Final,
@@ -477,7 +512,7 @@ fn floor_char_boundary(s: &str, max: usize) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ovp_llm::{ModelReply, ReplyBlock, Usage};
+    use ovp_llm::{CallError, ModelReply, ReplyBlock, Usage};
     use std::collections::VecDeque;
 
     // ---- scripted model client: replies served in order ----
@@ -788,6 +823,12 @@ mod tests {
             run_agent_turn(&mut client, &mut tools, &mut st, "q?", None, &cfg()).unwrap();
         assert_eq!(out.stopped_reason, StoppedReason::ToolError);
         assert!(tools.calls.is_empty());
+        assert!(
+            st.events()
+                .iter()
+                .any(|e| matches!(e, TranscriptEvent::ReplyDiscarded { reason, .. } if reason.contains("duplicate"))),
+            "the discarded reply is audited"
+        );
     }
 
     // Refusal and unknown stop reasons: never final-success.
@@ -835,6 +876,20 @@ mod tests {
             }
             other => panic!("expected ToolResults, got {other:?}"),
         }
+        // The AUDIT row keeps the full raw result — only the model copy caps.
+        let audit = st
+            .events()
+            .iter()
+            .find_map(|e| match e {
+                TranscriptEvent::ToolCalled { content, truncated, result_bytes, .. } => {
+                    Some((content.len(), *truncated, *result_bytes))
+                }
+                _ => None,
+            })
+            .unwrap();
+        assert_eq!(audit.0, 100_000, "audit content is the raw result");
+        assert!(audit.1, "truncated flag marks the capped model copy");
+        assert_eq!(audit.2, 100_000);
     }
 
     // Concurrent same-session submit: the lock makes the second SessionBusy.
@@ -852,12 +907,14 @@ mod tests {
         assert!(client.requests.is_empty(), "busy session must run nothing");
     }
 
-    // Idempotency: same key replays the completed turn without running.
+    // Idempotency: same key replays the completed turn without running —
+    // INCLUDING its tool trace (a retry must not lose provenance).
     #[test]
     fn idempotent_retry_replays_without_running() {
         let dir = tempfile::tempdir().unwrap();
-        let mut client = Scripted::new(vec![text_reply("first")]);
-        let mut tools = MockTools::new(&[]);
+        let mut client =
+            Scripted::new(vec![tool_reply(&[("c1", "search")]), text_reply("first")]);
+        let mut tools = MockTools::new(&[("search", Behavior::Ok("hit"))]);
         let mut st = store(dir.path());
         let first =
             run_agent_turn(&mut client, &mut tools, &mut st, "q?", Some("k1"), &cfg())
@@ -872,6 +929,8 @@ mod tests {
         assert_eq!(replay.answer, "first");
         assert_eq!(replay.turn_id, first.turn_id);
         assert!(client2.requests.is_empty(), "retry must not produce a second turn");
+        assert_eq!(replay.tool_trace.len(), 1, "replay rebuilds the original trace");
+        assert_eq!(replay.tool_trace[0].tool, "search");
         // A DIFFERENT key runs normally.
         let mut client3 = Scripted::new(vec![text_reply("second")]);
         let out =
@@ -1014,6 +1073,12 @@ mod tests {
         assert_eq!(out.stopped_reason, StoppedReason::ModelError);
         let st2 = store(dir.path());
         assert_eq!(st2.next_turn_id(), "t2", "failed turn is still a complete audit record");
+        assert!(
+            st2.events()
+                .iter()
+                .any(|e| matches!(e, TranscriptEvent::ModelFailed { detail, .. } if detail.contains("conn reset"))),
+            "the failure reason is audited"
+        );
     }
 
     // Mid-batch deadline exhaustion: remaining calls get timeout is_error
@@ -1128,6 +1193,23 @@ mod tests {
             })
             .collect();
         assert_eq!(shape, vec!["text", "tool", "text", "tool"], "provider order is protocol");
+    }
+
+    // An empty/unstamped lock file is conservatively BUSY — a racing creator
+    // may sit between create_new and the pid write; stealing would let two
+    // turns run concurrently.
+    #[test]
+    fn unstamped_lock_is_busy_not_stale() {
+        let dir = tempfile::tempdir().unwrap();
+        let st = store(dir.path());
+        std::fs::write(dir.path().join("s1.lock"), "").unwrap();
+        match st.lock() {
+            Err(crate::agent_transcript::StoreError::SessionBusy { holder_pid }) => {
+                assert_eq!(holder_pid, 0)
+            }
+            Err(other) => panic!("expected SessionBusy, got {other:?}"),
+            Ok(_) => panic!("an unstamped lock must not be stolen"),
+        }
     }
 
     // An execution failure BETWEEN invalid-args failures resets the streak:

--- a/crates/ovp-memory/src/agent.rs
+++ b/crates/ovp-memory/src/agent.rs
@@ -465,6 +465,7 @@ pub fn run_agent_turn(
                 result_bytes: raw_bytes,
                 content: content.clone(),
                 truncated,
+                late: finished_late,
             });
             trace.push(ToolTraceEntry {
                 tool: name.clone(),
@@ -1177,7 +1178,7 @@ mod tests {
         let mut st = store(dir.path());
         let mut c = cfg();
         c.deadline = Duration::from_millis(300);
-        let out = run_agent_turn(&mut client, &mut tools, &mut st, "q?", None, &c).unwrap();
+        let out = run_agent_turn(&mut client, &mut tools, &mut st, "q?", Some("mk"), &c).unwrap();
         assert_eq!(out.stopped_reason, StoppedReason::Timeout);
         // Both calls answered — the skipped one as a timeout error.
         let results_msg = st
@@ -1212,6 +1213,14 @@ mod tests {
         // The caller-facing trail must NOT leak the late content.
         assert!(out.tool_trace[0].summary.contains("discarded"));
         assert!(!out.tool_trace[0].summary.contains("slow done"));
+        // …and neither must an idempotent REPLAY of the same turn.
+        let mut client2 = Scripted::new(vec![]);
+        let mut tools2 = MockTools::new(&[]);
+        let replay =
+            run_agent_turn(&mut client2, &mut tools2, &mut st, "q?", Some("mk"), &c).unwrap();
+        assert!(replay.idempotent_replay);
+        assert!(replay.tool_trace[0].summary.contains("discarded"));
+        assert!(!replay.tool_trace[0].summary.contains("slow done"));
     }
 
     // MaxTokens without tools: a truncated answer must not present as Final.
@@ -1400,6 +1409,39 @@ mod tests {
         assert!(st.events().iter().any(|e| matches!(
             e,
             TranscriptEvent::ReplyDiscarded { reason, .. } if reason.contains("contradictory")
+        )));
+    }
+
+    // A row from ANOTHER session (renamed/copied file) reads as torn — it
+    // must never join projection/replay/turn numbering.
+    #[test]
+    fn foreign_session_rows_read_as_torn() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let mut client = Scripted::new(vec![text_reply("mine")]);
+            let mut tools = MockTools::new(&[]);
+            let mut st = store(dir.path());
+            run_agent_turn(&mut client, &mut tools, &mut st, "q?", None, &cfg()).unwrap();
+        }
+        // Append a complete-looking turn stamped with a DIFFERENT session id.
+        use std::io::Write as _;
+        let foreign = concat!(
+            r#"{"schema":"ovp.ask_transcript/v1","session_id":"OTHER","event":"turn_started","turn_id":"t2","question":"foreign"}"#,
+            "\n",
+            r#"{"schema":"ovp.ask_transcript/v1","session_id":"OTHER","event":"turn_finished","turn_id":"t2","stopped_reason":"final","answer":"foreign","rounds":0,"input_tokens_total":0,"output_tokens_total":0}"#,
+            "\n"
+        );
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(dir.path().join("s1.jsonl"))
+            .unwrap()
+            .write_all(foreign.as_bytes())
+            .unwrap();
+        let st = store(dir.path());
+        assert_eq!(st.next_turn_id(), "t2", "foreign rows must not advance turn numbering");
+        assert!(st.events().iter().all(|e| !matches!(
+            e,
+            TranscriptEvent::TurnFinished { answer, .. } if answer == "foreign"
         )));
     }
 

--- a/crates/ovp-memory/src/agent.rs
+++ b/crates/ovp-memory/src/agent.rs
@@ -1,0 +1,928 @@
+//! Ask-agent runtime — the tool loop (candidate `ask_agent-v1`, surface:
+//! runtime). Model → tool_calls? → execute → observe → loop, over the A1a
+//! tool protocol, with the session transcript as the audit authority.
+//!
+//! NOT wired into any product path at this version (`no_product_wiring`):
+//! `POST /api/ask` and `ask.rs` are unchanged; only tests call this engine.
+//! Rollout (feature flag → paired eval → default switch) is A3d.
+//!
+//! Budget contracts (A0 §5.2, guardrails in the candidate spec):
+//! - the wall-clock **deadline is authoritative** — every model call and tool
+//!   execution gets only the REMAINING budget, and no call ever STARTS after
+//!   exhaustion (`deadline_authority`); `max_rounds` is auxiliary;
+//! - a tool's 2nd consecutive invalid-arguments failure stops the loop
+//!   (`invalid_args_breaker`) — the observed competitor failure mode is an
+//!   agent burning rounds re-sending the same malformed call;
+//! - every model call's token usage is recorded (`token_accounting`);
+//! - the deadline arrives as a caller-supplied parameter, which IS the
+//!   nested-propagation interface for a future MCP-embedded ask
+//!   (`nested_deadline_interface`).
+
+use std::time::{Duration, Instant};
+
+use ovp_llm::{
+    AssistantBlock, CallError, ModelClient, ModelMessage, ModelRequest, StopReason, ToolDef,
+    ToolResultBlock,
+};
+
+use crate::agent_transcript::{SessionStore, StoreError, TranscriptEvent, TRANSCRIPT_SCHEMA};
+
+/// What a tool execution produced. `InvalidArgs` is distinguished because it
+/// feeds the circuit breaker; `Failed` is an execution error (fed back as
+/// is_error, does not trip the breaker).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ToolOutcome {
+    Ok(String),
+    InvalidArgs(String),
+    Failed(String),
+}
+
+/// The executor the runtime drives. A2 supplies the real vault tools; tests
+/// use mocks. `remaining` is the turn's remaining budget — long-running tools must
+/// respect it (the runtime re-checks after every call regardless).
+pub trait ToolExecutor {
+    fn definitions(&self) -> Vec<ToolDef>;
+    fn execute(&mut self, name: &str, input: &serde_json::Value, remaining: Duration)
+        -> ToolOutcome;
+}
+
+/// Why the turn stopped. `NeedUser` is reserved for A3 policy (the runtime
+/// cannot distinguish "asking the user" from a final answer without it).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StoppedReason {
+    Final,
+    NeedUser,
+    MaxRounds,
+    Timeout,
+    ToolError,
+    Refusal,
+    /// Model-side failure (transport/decode/unknown stop). Unknown stop
+    /// reasons land here — `unknown_stop_not_final` (fail-closed).
+    ModelError,
+}
+
+impl StoppedReason {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            StoppedReason::Final => "final",
+            StoppedReason::NeedUser => "need_user",
+            StoppedReason::MaxRounds => "max_rounds",
+            StoppedReason::Timeout => "timeout",
+            StoppedReason::ToolError => "tool_error",
+            StoppedReason::Refusal => "refusal",
+            StoppedReason::ModelError => "model_error",
+        }
+    }
+}
+
+/// One tool execution in the answer's trail (compact — full payloads live in
+/// the transcript).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolTraceEntry {
+    pub tool: String,
+    pub tool_call_id: String,
+    pub is_error: bool,
+    pub summary: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentOutcome {
+    pub turn_id: String,
+    pub answer: String,
+    pub stopped_reason: StoppedReason,
+    pub rounds: usize,
+    pub tool_trace: Vec<ToolTraceEntry>,
+    pub input_tokens_total: u32,
+    pub output_tokens_total: u32,
+    /// True when this outcome was REPLAYED from a completed turn matching the
+    /// caller's idempotency key — nothing was executed.
+    pub idempotent_replay: bool,
+}
+
+pub struct AgentConfig {
+    pub model: String,
+    pub system: String,
+    pub max_tokens: u32,
+    pub temperature: Option<f32>,
+    /// Authoritative wall-clock budget for the whole turn.
+    pub deadline: Duration,
+    /// Auxiliary round cap (a round = one tool-execution batch).
+    pub max_rounds: usize,
+    /// Per-tool-result byte cap; longer results are truncated with a marker.
+    pub max_result_bytes: usize,
+    /// Consecutive invalid-arguments failures of ONE tool that stop the loop.
+    pub invalid_args_breaker: usize,
+    /// Char cap for the model-context projection of prior turns.
+    pub projection_max_chars: usize,
+}
+
+impl Default for AgentConfig {
+    fn default() -> Self {
+        Self {
+            model: String::new(),
+            system: String::new(),
+            max_tokens: 1024,
+            temperature: None,
+            deadline: Duration::from_secs(120),
+            max_rounds: 6,
+            max_result_bytes: 32 * 1024,
+            invalid_args_breaker: 2,
+            projection_max_chars: 60_000,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum AgentError {
+    /// Another turn is running on this session (or the store is locked).
+    SessionBusy,
+    Store(String),
+}
+
+impl std::fmt::Display for AgentError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AgentError::SessionBusy => write!(f, "session busy — a turn is already running"),
+            AgentError::Store(d) => write!(f, "agent store: {d}"),
+        }
+    }
+}
+
+impl std::error::Error for AgentError {}
+
+/// Run one agent turn on `store`'s session. Mid-turn failures (model errors,
+/// timeouts, breakers) are NOT `Err` — they complete the turn with the
+/// matching `stopped_reason` so the audit trail is always whole. `Err` is
+/// reserved for pre-turn conditions: a busy session or store IO.
+pub fn run_agent_turn(
+    client: &mut dyn ModelClient,
+    tools: &mut dyn ToolExecutor,
+    store: &mut SessionStore,
+    question: &str,
+    idempotency_key: Option<&str>,
+    cfg: &AgentConfig,
+) -> Result<AgentOutcome, AgentError> {
+    // Idempotent replay BEFORE locking: a completed turn answers retries even
+    // while a different (new) turn holds the lock.
+    if let Some(key) = idempotency_key
+        && let Some(done) = store.completed_turn_for_key(key)
+    {
+        return Ok(AgentOutcome {
+            turn_id: done.turn_id,
+            answer: done.answer,
+            stopped_reason: parse_stopped(&done.stopped_reason),
+            rounds: done.rounds,
+            tool_trace: Vec::new(),
+            input_tokens_total: done.input_tokens_total,
+            output_tokens_total: done.output_tokens_total,
+            idempotent_replay: true,
+        });
+    }
+
+    let _lock = store.lock().map_err(|e| match e {
+        StoreError::SessionBusy { .. } => AgentError::SessionBusy,
+        StoreError::Io(d) => AgentError::Store(d),
+    })?;
+
+    let started = Instant::now();
+    let remaining = |started: Instant| cfg.deadline.saturating_sub(started.elapsed());
+
+    let turn_id = store.next_turn_id();
+    let mut events: Vec<TranscriptEvent> = vec![TranscriptEvent::TurnStarted {
+        schema: TRANSCRIPT_SCHEMA.to_string(),
+        turn_id: turn_id.clone(),
+        question: question.to_string(),
+        idempotency_key: idempotency_key.map(str::to_string),
+    }];
+
+    // Conversation = capped projection of prior turns + this turn's messages.
+    let mut messages = store.projection(cfg.projection_max_chars);
+    let user_msg = ModelMessage::User { content: question.to_string() };
+    messages.push(user_msg.clone());
+    events.push(TranscriptEvent::Message { turn_id: turn_id.clone(), message: user_msg });
+
+    let tool_defs = tools.definitions();
+    let mut rounds = 0usize;
+    let mut in_total = 0u32;
+    let mut out_total = 0u32;
+    let mut trace: Vec<ToolTraceEntry> = Vec::new();
+    let mut last_text = String::new();
+    // Per-tool CONSECUTIVE invalid-args counter (`invalid_args_breaker`).
+    let mut invalid_streak: std::collections::BTreeMap<String, usize> =
+        std::collections::BTreeMap::new();
+
+    let stopped = 'turn: loop {
+        // `deadline_authority`: no model call STARTS after exhaustion.
+        if remaining(started).is_zero() {
+            break 'turn StoppedReason::Timeout;
+        }
+        let request = ModelRequest {
+            model: cfg.model.clone(),
+            system: (!cfg.system.is_empty()).then(|| cfg.system.clone()),
+            messages: messages.clone(),
+            max_tokens: cfg.max_tokens,
+            temperature: cfg.temperature,
+            tools: (!tool_defs.is_empty()).then(|| tool_defs.clone()),
+            cache_namespace: Some("ask_agent/v1".into()),
+        };
+        let reply = match client.call(&request) {
+            Ok(r) => r,
+            // Mid-turn model failure ends the turn with an honest reason —
+            // the audit trail still gets its TurnFinished.
+            Err(CallError::Provider { .. } | CallError::Transport { .. }) => {
+                break 'turn StoppedReason::ModelError;
+            }
+            Err(_) => break 'turn StoppedReason::ModelError,
+        };
+        events.push(TranscriptEvent::ModelCalled {
+            turn_id: turn_id.clone(),
+            round: rounds,
+            input_tokens: reply.usage.input_tokens,
+            output_tokens: reply.usage.output_tokens,
+        });
+        in_total += reply.usage.input_tokens;
+        out_total += reply.usage.output_tokens;
+        if !reply.text.is_empty() {
+            last_text = reply.text.clone();
+        }
+
+        let calls: Vec<(String, String, serde_json::Value)> = reply
+            .executable_tool_calls()
+            .map(|calls| {
+                calls
+                    .iter()
+                    .map(|c| (c.id.to_string(), c.name.to_string(), c.input.clone()))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        if calls.is_empty() {
+            // No executable tools → the reply is the turn's terminal state.
+            break 'turn match reply.stop_reason {
+                StopReason::Refusal => StoppedReason::Refusal,
+                // `unknown_stop_not_final`: fail-closed.
+                StopReason::Unknown => StoppedReason::ModelError,
+                // ToolUse with zero executable calls cannot happen (the parse
+                // layer rejects truncated tool turns); treat defensively.
+                StopReason::ToolUse => StoppedReason::ModelError,
+                StopReason::EndTurn | StopReason::StopSequence | StopReason::MaxTokens => {
+                    StoppedReason::Final
+                }
+            };
+        }
+
+        // `duplicate_ids_fail_closed`: a reply reusing a call id executes
+        // NOTHING (the A1a request validator would reject the follow-up).
+        {
+            let mut seen = std::collections::BTreeSet::new();
+            if calls.iter().any(|(id, _, _)| !seen.insert(id.clone())) {
+                break 'turn StoppedReason::ToolError;
+            }
+        }
+
+        // Record the assistant tool turn in the conversation + transcript.
+        let assistant_msg = ModelMessage::AssistantBlocks {
+            blocks: {
+                let mut blocks: Vec<AssistantBlock> = Vec::new();
+                if !reply.text.is_empty() {
+                    blocks.push(AssistantBlock::Text { text: reply.text.clone() });
+                }
+                blocks.extend(calls.iter().map(|(id, name, input)| AssistantBlock::ToolUse {
+                    id: id.clone(),
+                    name: name.clone(),
+                    input: input.clone(),
+                }));
+                blocks
+            },
+        };
+        messages.push(assistant_msg.clone());
+        events.push(TranscriptEvent::Message { turn_id: turn_id.clone(), message: assistant_msg });
+
+        // `max_rounds_auxiliary`: cap tool-execution batches.
+        rounds += 1;
+        if rounds > cfg.max_rounds {
+            break 'turn StoppedReason::MaxRounds;
+        }
+
+        // Execute ALL calls — failed ones become is_error results so the
+        // round is always fully answered (`all_results_fed_back`).
+        let mut results: Vec<ToolResultBlock> = Vec::new();
+        let mut breaker_tripped = false;
+        let mut timed_out = false;
+        for (id, name, input) in &calls {
+            let left = remaining(started);
+            if left.is_zero() {
+                timed_out = true;
+                break;
+            }
+            let outcome = if tool_defs.iter().any(|d| &d.name == name) {
+                tools.execute(name, input, left)
+            } else {
+                // A hallucinated tool name is an arguments-class failure: it
+                // feeds back once and counts toward the breaker.
+                ToolOutcome::InvalidArgs(format!("unknown tool `{name}`"))
+            };
+            let (mut content, is_error) = match outcome {
+                ToolOutcome::Ok(body) => (body, false),
+                ToolOutcome::InvalidArgs(detail) => {
+                    let n = invalid_streak.entry(name.clone()).or_insert(0);
+                    *n += 1;
+                    if *n >= cfg.invalid_args_breaker {
+                        breaker_tripped = true;
+                    }
+                    (format!("invalid arguments: {detail}"), true)
+                }
+                ToolOutcome::Failed(detail) => (format!("tool failed: {detail}"), true),
+            };
+            if !is_error {
+                invalid_streak.remove(name);
+            }
+            if content.len() > cfg.max_result_bytes {
+                content.truncate(floor_char_boundary(&content, cfg.max_result_bytes));
+                content.push_str("\n[truncated]");
+            }
+            events.push(TranscriptEvent::ToolCalled {
+                turn_id: turn_id.clone(),
+                tool_call_id: id.clone(),
+                tool: name.clone(),
+                is_error,
+                result_bytes: content.len(),
+            });
+            trace.push(ToolTraceEntry {
+                tool: name.clone(),
+                tool_call_id: id.clone(),
+                is_error,
+                summary: content.chars().take(120).collect(),
+            });
+            results.push(ToolResultBlock { tool_call_id: id.clone(), content, is_error });
+        }
+
+        if timed_out {
+            break 'turn StoppedReason::Timeout;
+        }
+
+        let results_msg = ModelMessage::ToolResults { results };
+        messages.push(results_msg.clone());
+        events.push(TranscriptEvent::Message { turn_id: turn_id.clone(), message: results_msg });
+
+        if breaker_tripped {
+            break 'turn StoppedReason::ToolError;
+        }
+        // Loop: the model observes the results and decides the next step.
+    };
+
+    let answer = last_text;
+    events.push(TranscriptEvent::TurnFinished {
+        turn_id: turn_id.clone(),
+        stopped_reason: stopped.as_str().to_string(),
+        answer: answer.clone(),
+        rounds,
+        input_tokens_total: in_total,
+        output_tokens_total: out_total,
+    });
+    store
+        .commit_turn(events)
+        .map_err(|e| AgentError::Store(e.to_string()))?;
+
+    Ok(AgentOutcome {
+        turn_id,
+        answer,
+        stopped_reason: stopped,
+        rounds,
+        tool_trace: trace,
+        input_tokens_total: in_total,
+        output_tokens_total: out_total,
+        idempotent_replay: false,
+    })
+}
+
+fn parse_stopped(s: &str) -> StoppedReason {
+    match s {
+        "final" => StoppedReason::Final,
+        "need_user" => StoppedReason::NeedUser,
+        "max_rounds" => StoppedReason::MaxRounds,
+        "timeout" => StoppedReason::Timeout,
+        "tool_error" => StoppedReason::ToolError,
+        "refusal" => StoppedReason::Refusal,
+        _ => StoppedReason::ModelError,
+    }
+}
+
+/// Largest byte index ≤ `max` that is a char boundary (stable-Rust version of
+/// `str::floor_char_boundary`) — result truncation must not split UTF-8.
+fn floor_char_boundary(s: &str, max: usize) -> usize {
+    if max >= s.len() {
+        return s.len();
+    }
+    let mut i = max;
+    while i > 0 && !s.is_char_boundary(i) {
+        i -= 1;
+    }
+    i
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ovp_llm::{ModelReply, ReplyBlock, Usage};
+    use std::collections::VecDeque;
+
+    // ---- scripted model client: replies served in order ----
+    struct Scripted {
+        replies: VecDeque<Result<ModelReply, CallError>>,
+        pub requests: Vec<ModelRequest>,
+    }
+
+    impl Scripted {
+        fn new(replies: Vec<Result<ModelReply, CallError>>) -> Self {
+            Self { replies: replies.into(), requests: Vec::new() }
+        }
+    }
+
+    impl ModelClient for Scripted {
+        fn call(&mut self, request: &ModelRequest) -> Result<ModelReply, CallError> {
+            self.requests.push(request.clone());
+            self.replies.pop_front().unwrap_or(Err(CallError::Unexpected {
+                detail: "script exhausted".into(),
+            }))
+        }
+    }
+
+    fn text_reply(text: &str) -> Result<ModelReply, CallError> {
+        Ok(ModelReply {
+            model: "m".into(),
+            text: text.into(),
+            stop_reason: StopReason::EndTurn,
+            usage: Usage { input_tokens: 10, output_tokens: 5 },
+            blocks: Some(vec![ReplyBlock::Text { text: text.into() }]),
+            raw_stop_reason: None,
+        })
+    }
+
+    fn tool_reply(calls: &[(&str, &str)]) -> Result<ModelReply, CallError> {
+        Ok(ModelReply {
+            model: "m".into(),
+            text: String::new(),
+            stop_reason: StopReason::ToolUse,
+            usage: Usage { input_tokens: 20, output_tokens: 8 },
+            blocks: Some(
+                calls
+                    .iter()
+                    .map(|(id, name)| ReplyBlock::ToolUse {
+                        id: (*id).into(),
+                        name: (*name).into(),
+                        input: serde_json::json!({"q": "x"}),
+                    })
+                    .collect(),
+            ),
+            raw_stop_reason: None,
+        })
+    }
+
+    // ---- mock tools ----
+    #[derive(Clone)]
+    enum Behavior {
+        Ok(&'static str),
+        InvalidArgs,
+        Fail,
+        Slow(Duration),
+        Big(usize),
+    }
+
+    struct MockTools {
+        behaviors: std::collections::BTreeMap<String, Behavior>,
+        pub calls: Vec<String>,
+    }
+
+    impl MockTools {
+        fn new(b: &[(&str, Behavior)]) -> Self {
+            Self {
+                behaviors: b.iter().map(|(n, x)| (n.to_string(), x.clone())).collect(),
+                calls: Vec::new(),
+            }
+        }
+    }
+
+    impl ToolExecutor for MockTools {
+        fn definitions(&self) -> Vec<ToolDef> {
+            self.behaviors
+                .keys()
+                .map(|name| ToolDef {
+                    name: name.clone(),
+                    version: "v1".into(),
+                    description: "test tool".into(),
+                    input_schema: serde_json::json!({"type": "object"}),
+                })
+                .collect()
+        }
+
+        fn execute(
+            &mut self,
+            name: &str,
+            _input: &serde_json::Value,
+            _remaining: Duration,
+        ) -> ToolOutcome {
+            self.calls.push(name.to_string());
+            match self.behaviors.get(name) {
+                Some(Behavior::Ok(s)) => ToolOutcome::Ok((*s).to_string()),
+                Some(Behavior::InvalidArgs) => ToolOutcome::InvalidArgs("bad".into()),
+                Some(Behavior::Fail) => ToolOutcome::Failed("boom".into()),
+                Some(Behavior::Slow(d)) => {
+                    std::thread::sleep(*d);
+                    ToolOutcome::Ok("slow done".into())
+                }
+                Some(Behavior::Big(n)) => ToolOutcome::Ok("x".repeat(*n)),
+                None => ToolOutcome::Failed("unrouted".into()),
+            }
+        }
+    }
+
+    fn cfg() -> AgentConfig {
+        AgentConfig { model: "m".into(), system: "sys".into(), ..AgentConfig::default() }
+    }
+
+    fn store(dir: &std::path::Path) -> SessionStore {
+        SessionStore::open(dir, "s1").unwrap()
+    }
+
+    // 0-tool: model answers directly; single round-trip, transcript complete.
+    #[test]
+    fn zero_tool_direct_answer() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut client = Scripted::new(vec![text_reply("direct")]);
+        let mut tools = MockTools::new(&[("search", Behavior::Ok("hit"))]);
+        let mut st = store(dir.path());
+        let out =
+            run_agent_turn(&mut client, &mut tools, &mut st, "q?", None, &cfg()).unwrap();
+        assert_eq!(out.answer, "direct");
+        assert_eq!(out.stopped_reason, StoppedReason::Final);
+        assert_eq!(out.rounds, 0);
+        assert!(tools.calls.is_empty());
+        assert_eq!(out.input_tokens_total, 10);
+        // Turn is durable: reopening sees one complete turn.
+        let st2 = store(dir.path());
+        assert_eq!(st2.next_turn_id(), "t2");
+    }
+
+    // 1-tool then answer: results fed back, second request carries them.
+    #[test]
+    fn one_tool_then_final() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut client =
+            Scripted::new(vec![tool_reply(&[("c1", "search")]), text_reply("answer")]);
+        let mut tools = MockTools::new(&[("search", Behavior::Ok("hit"))]);
+        let mut st = store(dir.path());
+        let out =
+            run_agent_turn(&mut client, &mut tools, &mut st, "q?", None, &cfg()).unwrap();
+        assert_eq!(out.answer, "answer");
+        assert_eq!(out.rounds, 1);
+        assert_eq!(tools.calls, vec!["search"]);
+        // `all_results_fed_back`: 2nd request ends with ToolResults for c1.
+        let second = &client.requests[1];
+        match second.messages.last().unwrap() {
+            ModelMessage::ToolResults { results } => {
+                assert_eq!(results.len(), 1);
+                assert_eq!(results[0].tool_call_id, "c1");
+                assert!(!results[0].is_error);
+            }
+            other => panic!("expected ToolResults, got {other:?}"),
+        }
+    }
+
+    // 2 tools in one round: both execute, both results fed back (one failed).
+    #[test]
+    fn two_tools_one_failed_all_results_fed_back() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut client = Scripted::new(vec![
+            tool_reply(&[("c1", "search"), ("c2", "broken")]),
+            text_reply("done"),
+        ]);
+        let mut tools =
+            MockTools::new(&[("search", Behavior::Ok("hit")), ("broken", Behavior::Fail)]);
+        let mut st = store(dir.path());
+        let out =
+            run_agent_turn(&mut client, &mut tools, &mut st, "q?", None, &cfg()).unwrap();
+        assert_eq!(out.stopped_reason, StoppedReason::Final);
+        let second = &client.requests[1];
+        match second.messages.last().unwrap() {
+            ModelMessage::ToolResults { results } => {
+                assert_eq!(results.len(), 2);
+                assert!(!results[0].is_error);
+                assert!(results[1].is_error, "failed execution must be is_error");
+            }
+            other => panic!("expected ToolResults, got {other:?}"),
+        }
+    }
+
+    // Unknown tool name: fed back once as invalid-args; second unknown trips
+    // the breaker (`invalid_args_breaker`).
+    #[test]
+    fn unknown_tool_feeds_back_then_breaker_stops() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut client = Scripted::new(vec![
+            tool_reply(&[("c1", "ghost")]),
+            tool_reply(&[("c2", "ghost")]),
+            text_reply("never reached"),
+        ]);
+        let mut tools = MockTools::new(&[("search", Behavior::Ok("hit"))]);
+        let mut st = store(dir.path());
+        let out =
+            run_agent_turn(&mut client, &mut tools, &mut st, "q?", None, &cfg()).unwrap();
+        assert_eq!(out.stopped_reason, StoppedReason::ToolError);
+        assert_eq!(out.rounds, 2);
+        assert!(tools.calls.is_empty(), "unknown tool must never reach the executor");
+        // The first unknown WAS fed back (2nd model call happened).
+        assert_eq!(client.requests.len(), 2);
+    }
+
+    // Consecutive invalid args on one tool trips the breaker; success resets.
+    #[test]
+    fn invalid_args_breaker_and_reset() {
+        let dir = tempfile::tempdir().unwrap();
+        // bad → ok → bad → bad = breaker (streak resets after ok).
+        let mut client = Scripted::new(vec![
+            tool_reply(&[("c1", "flaky")]),
+            tool_reply(&[("c2", "good")]),
+            tool_reply(&[("c3", "flaky")]),
+            tool_reply(&[("c4", "flaky")]),
+            text_reply("never"),
+        ]);
+        let mut tools = MockTools::new(&[
+            ("flaky", Behavior::InvalidArgs),
+            ("good", Behavior::Ok("fine")),
+        ]);
+        let mut st = store(dir.path());
+        let mut c = cfg();
+        c.max_rounds = 10;
+        let out = run_agent_turn(&mut client, &mut tools, &mut st, "q?", None, &c).unwrap();
+        // flaky: bad(streak1) → good resets NOTHING for flaky (different tool),
+        // so flaky's streak continues: bad(streak2) = breaker at round 3.
+        assert_eq!(out.stopped_reason, StoppedReason::ToolError);
+        assert_eq!(client.requests.len(), 3, "breaker fires on flaky's 2nd consecutive failure");
+    }
+
+    // Total timeout: a slow tool exhausts the deadline; no further model call.
+    #[test]
+    fn total_timeout_stops_loop() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut client = Scripted::new(vec![
+            tool_reply(&[("c1", "slow")]),
+            text_reply("never reached"),
+        ]);
+        let mut tools =
+            MockTools::new(&[("slow", Behavior::Slow(Duration::from_millis(80)))]);
+        let mut st = store(dir.path());
+        let mut c = cfg();
+        c.deadline = Duration::from_millis(40);
+        let out = run_agent_turn(&mut client, &mut tools, &mut st, "q?", None, &c).unwrap();
+        assert_eq!(out.stopped_reason, StoppedReason::Timeout);
+        assert_eq!(client.requests.len(), 1, "no model call may START after the deadline");
+        // The timed-out turn is still a complete audited turn.
+        let st2 = store(dir.path());
+        assert_eq!(st2.next_turn_id(), "t2");
+    }
+
+    // Max rounds: scripted infinite tool loop stops at the cap.
+    #[test]
+    fn max_rounds_auxiliary_cap() {
+        let dir = tempfile::tempdir().unwrap();
+        let replies: Vec<_> = (0..10)
+            .map(|i| tool_reply(&[(format!("c{i}").leak() as &str, "search")]))
+            .collect();
+        let mut client = Scripted::new(replies);
+        let mut tools = MockTools::new(&[("search", Behavior::Ok("hit"))]);
+        let mut st = store(dir.path());
+        let mut c = cfg();
+        c.max_rounds = 3;
+        let out = run_agent_turn(&mut client, &mut tools, &mut st, "q?", None, &c).unwrap();
+        assert_eq!(out.stopped_reason, StoppedReason::MaxRounds);
+        assert_eq!(out.rounds, 4, "stops when the cap is exceeded");
+    }
+
+    // Duplicate tool_use ids in ONE reply: nothing executes, fail-closed.
+    #[test]
+    fn duplicate_ids_fail_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut client =
+            Scripted::new(vec![tool_reply(&[("dup", "search"), ("dup", "search")])]);
+        let mut tools = MockTools::new(&[("search", Behavior::Ok("hit"))]);
+        let mut st = store(dir.path());
+        let out =
+            run_agent_turn(&mut client, &mut tools, &mut st, "q?", None, &cfg()).unwrap();
+        assert_eq!(out.stopped_reason, StoppedReason::ToolError);
+        assert!(tools.calls.is_empty());
+    }
+
+    // Refusal and unknown stop reasons: never final-success.
+    #[test]
+    fn refusal_and_unknown_stops() {
+        let dir = tempfile::tempdir().unwrap();
+        let refusal = Ok(ModelReply {
+            stop_reason: StopReason::Refusal,
+            ..text_reply("cannot").unwrap()
+        });
+        let mut client = Scripted::new(vec![refusal]);
+        let mut tools = MockTools::new(&[]);
+        let mut st = store(dir.path());
+        let out =
+            run_agent_turn(&mut client, &mut tools, &mut st, "q?", None, &cfg()).unwrap();
+        assert_eq!(out.stopped_reason, StoppedReason::Refusal);
+
+        let unknown = Ok(ModelReply {
+            stop_reason: StopReason::Unknown,
+            ..text_reply("???").unwrap()
+        });
+        let mut client = Scripted::new(vec![unknown]);
+        let mut st2 = SessionStore::open(dir.path(), "s2").unwrap();
+        let out =
+            run_agent_turn(&mut client, &mut tools, &mut st2, "q?", None, &cfg()).unwrap();
+        assert_eq!(out.stopped_reason, StoppedReason::ModelError, "unknown stop ≠ final");
+    }
+
+    // Oversized tool result is truncated at a char boundary with a marker.
+    #[test]
+    fn tool_result_truncated_to_cap() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut client =
+            Scripted::new(vec![tool_reply(&[("c1", "big")]), text_reply("ok")]);
+        let mut tools = MockTools::new(&[("big", Behavior::Big(100_000))]);
+        let mut st = store(dir.path());
+        let mut c = cfg();
+        c.max_result_bytes = 1000;
+        let out = run_agent_turn(&mut client, &mut tools, &mut st, "q?", None, &c).unwrap();
+        assert_eq!(out.stopped_reason, StoppedReason::Final);
+        match client.requests[1].messages.last().unwrap() {
+            ModelMessage::ToolResults { results } => {
+                assert!(results[0].content.len() < 1100);
+                assert!(results[0].content.ends_with("[truncated]"));
+            }
+            other => panic!("expected ToolResults, got {other:?}"),
+        }
+    }
+
+    // Concurrent same-session submit: the lock makes the second SessionBusy.
+    #[test]
+    fn concurrent_same_session_is_busy() {
+        let dir = tempfile::tempdir().unwrap();
+        let st = store(dir.path());
+        let _held = st.lock().unwrap();
+        let mut client = Scripted::new(vec![text_reply("x")]);
+        let mut tools = MockTools::new(&[]);
+        let mut st2 = store(dir.path());
+        let err = run_agent_turn(&mut client, &mut tools, &mut st2, "q?", None, &cfg())
+            .unwrap_err();
+        assert!(matches!(err, AgentError::SessionBusy));
+        assert!(client.requests.is_empty(), "busy session must run nothing");
+    }
+
+    // Idempotency: same key replays the completed turn without running.
+    #[test]
+    fn idempotent_retry_replays_without_running() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut client = Scripted::new(vec![text_reply("first")]);
+        let mut tools = MockTools::new(&[]);
+        let mut st = store(dir.path());
+        let first =
+            run_agent_turn(&mut client, &mut tools, &mut st, "q?", Some("k1"), &cfg())
+                .unwrap();
+        assert!(!first.idempotent_replay);
+
+        let mut client2 = Scripted::new(vec![text_reply("SHOULD NOT RUN")]);
+        let replay =
+            run_agent_turn(&mut client2, &mut tools, &mut st, "q?", Some("k1"), &cfg())
+                .unwrap();
+        assert!(replay.idempotent_replay);
+        assert_eq!(replay.answer, "first");
+        assert_eq!(replay.turn_id, first.turn_id);
+        assert!(client2.requests.is_empty(), "retry must not produce a second turn");
+        // A DIFFERENT key runs normally.
+        let mut client3 = Scripted::new(vec![text_reply("second")]);
+        let out =
+            run_agent_turn(&mut client3, &mut tools, &mut st, "q2?", Some("k2"), &cfg())
+                .unwrap();
+        assert!(!out.idempotent_replay);
+        assert_eq!(out.turn_id, "t2");
+    }
+
+    // Crash recovery: a torn tail (no TurnFinished) is compacted on open.
+    #[test]
+    fn crash_recovery_drops_torn_turn() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let mut client = Scripted::new(vec![text_reply("whole")]);
+            let mut tools = MockTools::new(&[]);
+            let mut st = store(dir.path());
+            run_agent_turn(&mut client, &mut tools, &mut st, "q?", None, &cfg()).unwrap();
+        }
+        // Simulate a crash mid-turn: append turn events WITHOUT TurnFinished.
+        let path = dir.path().join("s1.jsonl");
+        let torn = format!(
+            "{}\n{}\n",
+            serde_json::to_string(&TranscriptEvent::TurnStarted {
+                schema: TRANSCRIPT_SCHEMA.into(),
+                turn_id: "t2".into(),
+                question: "torn".into(),
+                idempotency_key: None,
+            })
+            .unwrap(),
+            serde_json::to_string(&TranscriptEvent::Message {
+                turn_id: "t2".into(),
+                message: ModelMessage::User { content: "torn".into() },
+            })
+            .unwrap()
+        );
+        use std::io::Write as _;
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap()
+            .write_all(torn.as_bytes())
+            .unwrap();
+
+        let st = store(dir.path());
+        assert_eq!(st.next_turn_id(), "t2", "torn turn compacted away");
+        assert!(
+            !std::fs::read_to_string(&path).unwrap().contains("torn"),
+            "compaction rewrote the file without the torn tail"
+        );
+    }
+
+    // Projection cap: oldest turns trimmed WHOLE; pairs never split.
+    #[test]
+    fn projection_trims_whole_turns_oldest_first() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut tools = MockTools::new(&[("search", Behavior::Ok("hit"))]);
+        let mut st = store(dir.path());
+        // Turn 1: tool turn (User + AssistantBlocks + ToolResults + final).
+        let mut client = Scripted::new(vec![
+            tool_reply(&[("c1", "search")]),
+            text_reply("one"),
+        ]);
+        run_agent_turn(&mut client, &mut tools, &mut st, "first?", None, &cfg()).unwrap();
+        // Turn 2: plain answer.
+        let mut client = Scripted::new(vec![text_reply("two")]);
+        run_agent_turn(&mut client, &mut tools, &mut st, "second?", None, &cfg()).unwrap();
+
+        // Unlimited: both turns present, pair intact.
+        let full = st.projection(1_000_000);
+        let has_tool_use = full.iter().any(|m| matches!(m, ModelMessage::AssistantBlocks { .. }));
+        let has_results = full.iter().any(|m| matches!(m, ModelMessage::ToolResults { .. }));
+        assert!(has_tool_use && has_results);
+
+        // Tight cap: turn 1 (the big tool turn) is dropped WHOLE — no orphan
+        // ToolResults without its AssistantBlocks.
+        let turn2_len: usize = st
+            .projection(1_000_000)
+            .iter()
+            .rev()
+            .take(2) // turn 2 = [User, (assistant text is not stored as Message? it is…)]
+            .map(|m| serde_json::to_string(m).unwrap().len())
+            .sum();
+        let capped = st.projection(turn2_len + 8);
+        assert!(!capped.is_empty(), "newest turn survives the cap");
+        let orphan_results = capped
+            .iter()
+            .any(|m| matches!(m, ModelMessage::ToolResults { .. }))
+            && !capped
+                .iter()
+                .any(|m| matches!(m, ModelMessage::AssistantBlocks { .. }));
+        assert!(!orphan_results, "a ToolResults must never appear without its assistant turn");
+    }
+
+    // Token accounting: usage summed across model calls.
+    #[test]
+    fn token_accounting_sums_all_calls() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut client =
+            Scripted::new(vec![tool_reply(&[("c1", "search")]), text_reply("done")]);
+        let mut tools = MockTools::new(&[("search", Behavior::Ok("hit"))]);
+        let mut st = store(dir.path());
+        let out =
+            run_agent_turn(&mut client, &mut tools, &mut st, "q?", None, &cfg()).unwrap();
+        assert_eq!(out.input_tokens_total, 30); // 20 (tool round) + 10 (final)
+        assert_eq!(out.output_tokens_total, 13); // 8 + 5
+        // And the transcript carries per-call events.
+        let model_events = st
+            .events()
+            .iter()
+            .filter(|e| matches!(e, TranscriptEvent::ModelCalled { .. }))
+            .count();
+        assert_eq!(model_events, 2);
+    }
+
+    // Model transport failure mid-turn: honest model_error, audited turn.
+    #[test]
+    fn model_failure_ends_turn_honestly() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut client = Scripted::new(vec![Err(CallError::Transport {
+            detail: "conn reset".into(),
+        })]);
+        let mut tools = MockTools::new(&[]);
+        let mut st = store(dir.path());
+        let out =
+            run_agent_turn(&mut client, &mut tools, &mut st, "q?", None, &cfg()).unwrap();
+        assert_eq!(out.stopped_reason, StoppedReason::ModelError);
+        let st2 = store(dir.path());
+        assert_eq!(st2.next_turn_id(), "t2", "failed turn is still a complete audit record");
+    }
+}

--- a/crates/ovp-memory/src/agent_transcript.rs
+++ b/crates/ovp-memory/src/agent_transcript.rs
@@ -53,14 +53,34 @@ pub enum TranscriptEvent {
         input_tokens: u32,
         output_tokens: u32,
     },
-    /// One tool execution's audit line (the result CONTENT lives in the
-    /// adjacent `Message`/`ToolResults` event; this row is the quick index).
+    /// One tool execution's audit line. `content` is the FULL RAW result —
+    /// the audit transcript is complete by contract; the adjacent
+    /// `ToolResults` message carries the CAPPED text the model actually saw
+    /// (that distinction is the audit-vs-projection split, A0 §3.5).
     ToolCalled {
         turn_id: String,
         tool_call_id: String,
         tool: String,
         is_error: bool,
+        /// Raw (pre-cap) result size in bytes.
         result_bytes: usize,
+        /// Full raw result content (audit-only; never projected).
+        content: String,
+        /// Whether the model-facing copy was truncated to the result cap.
+        truncated: bool,
+    },
+    /// A model call failed (audit-only; excluded from projection).
+    ModelFailed {
+        turn_id: String,
+        round: usize,
+        detail: String,
+    },
+    /// A model reply was rejected by the runtime without entering the
+    /// conversation (duplicate tool_use ids, over-cap round) — audit-only.
+    ReplyDiscarded {
+        turn_id: String,
+        round: usize,
+        reason: String,
     },
     TurnFinished {
         turn_id: String,
@@ -79,6 +99,8 @@ impl TranscriptEvent {
             | TranscriptEvent::Message { turn_id, .. }
             | TranscriptEvent::ModelCalled { turn_id, .. }
             | TranscriptEvent::ToolCalled { turn_id, .. }
+            | TranscriptEvent::ModelFailed { turn_id, .. }
+            | TranscriptEvent::ReplyDiscarded { turn_id, .. }
             | TranscriptEvent::TurnFinished { turn_id, .. } => turn_id,
         }
     }
@@ -262,14 +284,31 @@ impl SessionStore {
                 .open(&self.lock_path)
             {
                 Ok(mut f) => {
-                    let _ = write!(f, "{}", std::process::id());
+                    // The pid stamp must land: an unstamped lock reads as
+                    // invalid to other contenders (conservatively busy), and
+                    // holding one would wedge the session; on failure, release
+                    // and surface the IO error.
+                    if let Err(e) = write!(f, "{}", std::process::id()).and_then(|_| f.sync_data())
+                    {
+                        drop(f);
+                        let _ = fs::remove_file(&self.lock_path);
+                        return Err(StoreError::Io(format!("stamp lock: {e}")));
+                    }
                     return Ok(SessionLock { path: self.lock_path.clone() });
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
-                    let holder: u32 = fs::read_to_string(&self.lock_path)
+                    // Missing/empty/invalid owner data is CONSERVATIVELY BUSY:
+                    // a racing creator may sit between create_new and the pid
+                    // write, and stealing its lock would let two turns run
+                    // concurrently. (The crashed-unstamped case is a
+                    // microsecond window; doctor can clean a wedged lock.)
+                    let Some(holder) = fs::read_to_string(&self.lock_path)
                         .ok()
-                        .and_then(|s| s.trim().parse().ok())
-                        .unwrap_or(0);
+                        .and_then(|s| s.trim().parse::<u32>().ok())
+                        .filter(|pid| *pid != 0)
+                    else {
+                        return Err(StoreError::SessionBusy { holder_pid: 0 });
+                    };
                     // A live holder is BUSY — including our own pid: two
                     // stores in one process (desktop in-process server
                     // threads) must serialize too, and a same-pid leak is
@@ -424,6 +463,28 @@ impl SessionStore {
             .map_err(|e| StoreError::Io(format!("fsync: {e}")))?;
         self.events.extend(turn_events);
         Ok(())
+    }
+
+    /// The audit ToolCalled rows of one turn — replayed outcomes rebuild
+    /// their tool_trace from these (a retry must not lose the provenance
+    /// trail the original response carried).
+    pub fn tool_calls_for_turn(&self, id: &str) -> Vec<(String, String, bool, String)> {
+        self.events
+            .iter()
+            .filter_map(|e| match e {
+                TranscriptEvent::ToolCalled { turn_id, tool_call_id, tool, is_error, content, .. }
+                    if turn_id == id =>
+                {
+                    Some((
+                        tool.clone(),
+                        tool_call_id.clone(),
+                        *is_error,
+                        content.chars().take(120).collect(),
+                    ))
+                }
+                _ => None,
+            })
+            .collect()
     }
 
     /// All complete-turn events (read-only view; tests + future exporters).

--- a/crates/ovp-memory/src/agent_transcript.rs
+++ b/crates/ovp-memory/src/agent_transcript.rs
@@ -255,6 +255,14 @@ impl SessionStore {
         Ok(torn_tail)
     }
 
+    /// Read-only refresh (no rewrite): update the in-memory complete-turn
+    /// view. Used before pre-lock idempotency lookups on long-lived stores —
+    /// a key committed by ANOTHER process must replay even while a different
+    /// turn holds the lock.
+    pub fn refresh_readonly(&mut self) -> Result<(), StoreError> {
+        self.read_complete_events().map(|_| ())
+    }
+
     /// Under the session lock: re-read the file (the pre-lock view may be
     /// stale — another turn can have committed between `open` and `lock`) and
     /// physically COMPACT a crash-torn tail. Safe here and only here: the

--- a/crates/ovp-memory/src/agent_transcript.rs
+++ b/crates/ovp-memory/src/agent_transcript.rs
@@ -1,0 +1,399 @@
+//! Ask-agent session transcript store — the AUDIT AUTHORITY for agent turns
+//! (candidate `ask_agent-v1`, guardrail `transcript_authority`).
+//!
+//! One JSONL file per session under `<sessions_dir>/<session_id>.jsonl`,
+//! schema `ovp.ask_transcript/v1`. Design contracts (A0 §5.2):
+//!
+//! - **Turn atomicity** (`turn_atomicity_recovery`): a turn's events are
+//!   buffered in memory and committed as ONE append finalized by a
+//!   `turn_finished` event. On open, trailing events after the last
+//!   `turn_finished` are COMPACTED away — crash recovery always lands on the
+//!   last complete turn.
+//! - **Idempotency** (`idempotency`): `turn_started` records the caller's
+//!   `idempotency_key`; a completed turn with the same key replays its
+//!   outcome instead of running again.
+//! - **Session serialization** (`session_serialization`): a pid lock file
+//!   serializes same-session turns; stale (dead-pid) locks are reclaimed.
+//! - **Projection** (`transcript_authority`): the model context is REBUILT
+//!   from stored `message` events under a hard char cap that trims whole
+//!   turns oldest-first — a tool_use/tool_result pair can never be split
+//!   because a turn is the trim unit.
+
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use ovp_llm::ModelMessage;
+use serde::{Deserialize, Serialize};
+
+pub const TRANSCRIPT_SCHEMA: &str = "ovp.ask_transcript/v1";
+
+/// One transcript line. `schema` is stamped on every event so a reader never
+/// needs file-level framing to know what it is looking at.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub enum TranscriptEvent {
+    TurnStarted {
+        schema: String,
+        turn_id: String,
+        question: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        idempotency_key: Option<String>,
+    },
+    /// A conversation message appended during the turn, in order. The
+    /// projection for later turns is rebuilt from exactly these events.
+    Message {
+        turn_id: String,
+        message: ModelMessage,
+    },
+    /// One model call's cost (`token_accounting`).
+    ModelCalled {
+        turn_id: String,
+        round: usize,
+        input_tokens: u32,
+        output_tokens: u32,
+    },
+    /// One tool execution's audit line (the result CONTENT lives in the
+    /// adjacent `Message`/`ToolResults` event; this row is the quick index).
+    ToolCalled {
+        turn_id: String,
+        tool_call_id: String,
+        tool: String,
+        is_error: bool,
+        result_bytes: usize,
+    },
+    TurnFinished {
+        turn_id: String,
+        stopped_reason: String,
+        answer: String,
+        rounds: usize,
+        input_tokens_total: u32,
+        output_tokens_total: u32,
+    },
+}
+
+impl TranscriptEvent {
+    fn turn_id(&self) -> &str {
+        match self {
+            TranscriptEvent::TurnStarted { turn_id, .. }
+            | TranscriptEvent::Message { turn_id, .. }
+            | TranscriptEvent::ModelCalled { turn_id, .. }
+            | TranscriptEvent::ToolCalled { turn_id, .. }
+            | TranscriptEvent::TurnFinished { turn_id, .. } => turn_id,
+        }
+    }
+}
+
+/// A previously COMPLETED turn's outcome, replayable for idempotent retries.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CompletedTurn {
+    pub turn_id: String,
+    pub stopped_reason: String,
+    pub answer: String,
+    pub rounds: usize,
+    pub input_tokens_total: u32,
+    pub output_tokens_total: u32,
+}
+
+/// Session lock guard — pid file, removed on drop. Same primitive the daily
+/// heartbeat / RunLock use to reclaim stale locks (probe with `kill -0`;
+/// duplicated here because ovp-memory must not depend on ovp-daily).
+pub struct SessionLock {
+    path: PathBuf,
+}
+
+impl Drop for SessionLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+fn pid_alive(pid: u32) -> bool {
+    if pid == 0 {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        std::process::Command::new("kill")
+            .arg("-0")
+            .arg(pid.to_string())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|s| s.success())
+            // Conservative: if the probe can't run, assume alive so a real
+            // concurrent turn is never falsely stolen.
+            .unwrap_or(true)
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}
+
+/// Errors the store distinguishes because callers behave differently on them.
+#[derive(Debug)]
+pub enum StoreError {
+    /// Another live process (or turn) holds this session — retry later.
+    SessionBusy { holder_pid: u32 },
+    Io(String),
+}
+
+impl std::fmt::Display for StoreError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            StoreError::SessionBusy { holder_pid } => {
+                write!(f, "session busy (held by pid {holder_pid})")
+            }
+            StoreError::Io(detail) => write!(f, "transcript store: {detail}"),
+        }
+    }
+}
+
+impl std::error::Error for StoreError {}
+
+/// Store for ONE session's transcript. Opening compacts a crash-torn tail.
+pub struct SessionStore {
+    path: PathBuf,
+    lock_path: PathBuf,
+    /// Complete-turn events only (compaction dropped any torn tail).
+    events: Vec<TranscriptEvent>,
+}
+
+/// Session ids come from clients; confine them to one path segment.
+pub fn valid_session_id(id: &str) -> bool {
+    !id.is_empty()
+        && id.len() <= 64
+        && id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
+impl SessionStore {
+    /// Open (creating the dir if needed), COMPACTING any events after the
+    /// last `turn_finished` — the crash-recovery contract: a torn turn never
+    /// becomes visible state.
+    pub fn open(sessions_dir: &Path, session_id: &str) -> Result<Self, StoreError> {
+        if !valid_session_id(session_id) {
+            return Err(StoreError::Io(format!(
+                "invalid session id `{session_id}` (want [A-Za-z0-9_-]{{1,64}})"
+            )));
+        }
+        fs::create_dir_all(sessions_dir)
+            .map_err(|e| StoreError::Io(format!("create {}: {e}", sessions_dir.display())))?;
+        let path = sessions_dir.join(format!("{session_id}.jsonl"));
+        let lock_path = sessions_dir.join(format!("{session_id}.lock"));
+
+        let mut events: Vec<TranscriptEvent> = Vec::new();
+        let mut torn_tail = false;
+        if path.is_file() {
+            let body = fs::read_to_string(&path)
+                .map_err(|e| StoreError::Io(format!("read {}: {e}", path.display())))?;
+            let mut parsed: Vec<TranscriptEvent> = Vec::new();
+            for line in body.lines().filter(|l| !l.trim().is_empty()) {
+                match serde_json::from_str::<TranscriptEvent>(line) {
+                    Ok(ev) => parsed.push(ev),
+                    // A torn/corrupt line means everything from here on is
+                    // suspect; keep only what precedes it, then compact below.
+                    Err(_) => {
+                        torn_tail = true;
+                        break;
+                    }
+                }
+            }
+            let last_complete = parsed
+                .iter()
+                .rposition(|e| matches!(e, TranscriptEvent::TurnFinished { .. }))
+                .map(|i| i + 1)
+                .unwrap_or(0);
+            torn_tail = torn_tail || last_complete != parsed.len();
+            parsed.truncate(last_complete);
+            events = parsed;
+        }
+
+        let store = Self { path, lock_path, events };
+        if torn_tail {
+            store.rewrite()?;
+        }
+        Ok(store)
+    }
+
+    /// Atomic whole-file rewrite (tmp + rename) — used only by compaction.
+    fn rewrite(&self) -> Result<(), StoreError> {
+        let mut body = String::new();
+        for ev in &self.events {
+            body.push_str(
+                &serde_json::to_string(ev)
+                    .map_err(|e| StoreError::Io(format!("serialize event: {e}")))?,
+            );
+            body.push('\n');
+        }
+        let tmp = self.path.with_extension("jsonl.tmp");
+        fs::write(&tmp, body).map_err(|e| StoreError::Io(format!("write tmp: {e}")))?;
+        fs::rename(&tmp, &self.path)
+            .map_err(|e| StoreError::Io(format!("publish {}: {e}", self.path.display())))
+    }
+
+    /// Serialize this session: create the pid lock, reclaiming a stale one.
+    pub fn lock(&self) -> Result<SessionLock, StoreError> {
+        for attempt in 0..2 {
+            match fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&self.lock_path)
+            {
+                Ok(mut f) => {
+                    let _ = write!(f, "{}", std::process::id());
+                    return Ok(SessionLock { path: self.lock_path.clone() });
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                    let holder: u32 = fs::read_to_string(&self.lock_path)
+                        .ok()
+                        .and_then(|s| s.trim().parse().ok())
+                        .unwrap_or(0);
+                    // A live holder is BUSY — including our own pid: two
+                    // stores in one process (desktop in-process server
+                    // threads) must serialize too, and a same-pid leak is
+                    // practically impossible (panic unwinds run Drop; an
+                    // abort gets a fresh pid).
+                    if pid_alive(holder) {
+                        return Err(StoreError::SessionBusy { holder_pid: holder });
+                    }
+                    // Stale (dead pid / unreadable): reclaim once, retry create.
+                    if attempt == 0 {
+                        let _ = fs::remove_file(&self.lock_path);
+                        continue;
+                    }
+                    return Err(StoreError::SessionBusy { holder_pid: holder });
+                }
+                Err(e) => return Err(StoreError::Io(format!("lock: {e}"))),
+            }
+        }
+        unreachable!("loop returns on every path");
+    }
+
+    /// Next turn id: `t<N>` over COMPLETE turns (a torn turn was compacted
+    /// away, so its id is safely reused).
+    pub fn next_turn_id(&self) -> String {
+        let n = self
+            .events
+            .iter()
+            .filter(|e| matches!(e, TranscriptEvent::TurnFinished { .. }))
+            .count();
+        format!("t{}", n + 1)
+    }
+
+    /// The completed turn matching `idempotency_key`, if any — the idempotent
+    /// replay source.
+    pub fn completed_turn_for_key(&self, key: &str) -> Option<CompletedTurn> {
+        let turn_id = self.events.iter().find_map(|e| match e {
+            TranscriptEvent::TurnStarted { turn_id, idempotency_key: Some(k), .. } if k == key => {
+                Some(turn_id.clone())
+            }
+            _ => None,
+        })?;
+        self.completed_turn(&turn_id)
+    }
+
+    fn completed_turn(&self, id: &str) -> Option<CompletedTurn> {
+        self.events.iter().find_map(|e| match e {
+            TranscriptEvent::TurnFinished {
+                turn_id,
+                stopped_reason,
+                answer,
+                rounds,
+                input_tokens_total,
+                output_tokens_total,
+            } if turn_id == id => Some(CompletedTurn {
+                turn_id: turn_id.clone(),
+                stopped_reason: stopped_reason.clone(),
+                answer: answer.clone(),
+                rounds: *rounds,
+                input_tokens_total: *input_tokens_total,
+                output_tokens_total: *output_tokens_total,
+            }),
+            _ => None,
+        })
+    }
+
+    /// Model-context projection: all `Message` events of complete turns, then
+    /// trimmed to `max_chars` (serialized length) by dropping WHOLE turns
+    /// oldest-first. A turn is the trim unit, so tool_use/tool_result pairs
+    /// stay intact by construction and results are never orphaned.
+    pub fn projection(&self, max_chars: usize) -> Vec<ModelMessage> {
+        // Group message events by turn, in order.
+        let mut turns: Vec<(String, Vec<ModelMessage>)> = Vec::new();
+        for ev in &self.events {
+            if let TranscriptEvent::Message { turn_id, message } = ev {
+                match turns.last_mut() {
+                    Some((id, msgs)) if id == turn_id => msgs.push(message.clone()),
+                    _ => turns.push((turn_id.clone(), vec![message.clone()])),
+                }
+            }
+        }
+        let turn_len = |msgs: &[ModelMessage]| -> usize {
+            msgs.iter()
+                .map(|m| serde_json::to_string(m).map(|s| s.len()).unwrap_or(0))
+                .sum()
+        };
+        // Keep newest-first until the cap, then restore order.
+        let mut kept: Vec<usize> = Vec::new();
+        let mut used = 0usize;
+        for (i, (_, msgs)) in turns.iter().enumerate().rev() {
+            let len = turn_len(msgs);
+            if used + len > max_chars {
+                break;
+            }
+            used += len;
+            kept.push(i);
+        }
+        kept.reverse();
+        kept.into_iter()
+            .flat_map(|i| turns[i].1.clone())
+            .collect()
+    }
+
+    /// Commit a finished turn: ONE append of all its lines, fsynced. The last
+    /// line must be `TurnFinished` — enforced here so a partial commit can
+    /// never look complete to compaction.
+    pub fn commit_turn(&mut self, turn_events: Vec<TranscriptEvent>) -> Result<(), StoreError> {
+        let Some(TranscriptEvent::TurnFinished { .. }) = turn_events.last() else {
+            return Err(StoreError::Io(
+                "commit_turn: last event must be TurnFinished (atomicity contract)".into(),
+            ));
+        };
+        let first_turn = turn_events
+            .first()
+            .map(|e| e.turn_id().to_string())
+            .unwrap_or_default();
+        if turn_events.iter().any(|e| e.turn_id() != first_turn) {
+            return Err(StoreError::Io(
+                "commit_turn: events span multiple turn ids".into(),
+            ));
+        }
+        let mut body = String::new();
+        for ev in &turn_events {
+            body.push_str(
+                &serde_json::to_string(ev)
+                    .map_err(|e| StoreError::Io(format!("serialize event: {e}")))?,
+            );
+            body.push('\n');
+        }
+        let mut f = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)
+            .map_err(|e| StoreError::Io(format!("open {}: {e}", self.path.display())))?;
+        f.write_all(body.as_bytes())
+            .map_err(|e| StoreError::Io(format!("append: {e}")))?;
+        f.sync_data()
+            .map_err(|e| StoreError::Io(format!("fsync: {e}")))?;
+        self.events.extend(turn_events);
+        Ok(())
+    }
+
+    /// All complete-turn events (read-only view; tests + future exporters).
+    pub fn events(&self) -> &[TranscriptEvent] {
+        &self.events
+    }
+}

--- a/crates/ovp-memory/src/agent_transcript.rs
+++ b/crates/ovp-memory/src/agent_transcript.rs
@@ -85,6 +85,10 @@ pub enum TranscriptEvent {
         content: String,
         /// Whether the model-facing copy was truncated to the result cap.
         truncated: bool,
+        /// The result arrived after the turn deadline: audit-only data the
+        /// model/caller never saw — replays must show the marker, not this.
+        #[serde(default)]
+        late: bool,
     },
     /// A model call failed (audit-only; excluded from projection).
     ModelFailed {
@@ -244,9 +248,14 @@ impl SessionStore {
             let mut parsed: Vec<TranscriptEvent> = Vec::new();
             for line in body.lines().filter(|l| !l.trim().is_empty()) {
                 match serde_json::from_str::<TranscriptLine>(line) {
-                    // A schema we don't understand is treated like a torn
-                    // line: conservative, never misread as current-schema.
-                    Ok(l) if l.schema == TRANSCRIPT_SCHEMA => parsed.push(l.event),
+                    // A schema we don't understand OR a row from another
+                    // session (renamed/copied file) is treated like a torn
+                    // line: conservative — foreign events must never join the
+                    // projection, replay, or turn numbering, and compaction
+                    // must not relabel them.
+                    Ok(l) if l.schema == TRANSCRIPT_SCHEMA && l.session_id == self.session_id => {
+                        parsed.push(l.event)
+                    }
                     // A torn/corrupt/foreign line means everything from here
                     // on is suspect; keep only what precedes it.
                     _ => {
@@ -507,16 +516,21 @@ impl SessionStore {
         self.events
             .iter()
             .filter_map(|e| match e {
-                TranscriptEvent::ToolCalled { turn_id, tool_call_id, tool, is_error, content, .. }
-                    if turn_id == id =>
-                {
-                    Some((
-                        tool.clone(),
-                        tool_call_id.clone(),
-                        *is_error,
-                        content.chars().take(120).collect(),
-                    ))
-                }
+                TranscriptEvent::ToolCalled {
+                    turn_id, tool_call_id, tool, is_error, content, late, ..
+                } if turn_id == id => Some((
+                    tool.clone(),
+                    tool_call_id.clone(),
+                    *is_error,
+                    // Late data is audit-only: the replayed trail shows the
+                    // same marker the ORIGINAL response carried, never the
+                    // withheld content.
+                    if *late {
+                        "late: discarded (audit only)".to_string()
+                    } else {
+                        content.chars().take(120).collect()
+                    },
+                )),
                 _ => None,
             })
             .collect()

--- a/crates/ovp-memory/src/agent_transcript.rs
+++ b/crates/ovp-memory/src/agent_transcript.rs
@@ -170,9 +170,13 @@ pub fn valid_session_id(id: &str) -> bool {
 }
 
 impl SessionStore {
-    /// Open (creating the dir if needed), COMPACTING any events after the
-    /// last `turn_finished` — the crash-recovery contract: a torn turn never
-    /// becomes visible state.
+    /// Open (creating the dir if needed) and take a READ-ONLY view: events
+    /// after the last `turn_finished` are ignored IN MEMORY, but the file is
+    /// never rewritten here — a concurrent turn may be mid-append, and a
+    /// pre-lock rewrite would race it (rename to the compacted copy while the
+    /// active writer finishes against the old inode, losing its turn).
+    /// Physical compaction happens only under the session lock, in
+    /// [`Self::reload_under_lock`].
     pub fn open(sessions_dir: &Path, session_id: &str) -> Result<Self, StoreError> {
         if !valid_session_id(session_id) {
             return Err(StoreError::Io(format!(
@@ -183,18 +187,25 @@ impl SessionStore {
             .map_err(|e| StoreError::Io(format!("create {}: {e}", sessions_dir.display())))?;
         let path = sessions_dir.join(format!("{session_id}.jsonl"));
         let lock_path = sessions_dir.join(format!("{session_id}.lock"));
+        let mut store = Self { path, lock_path, events: Vec::new() };
+        store.read_complete_events()?;
+        Ok(store)
+    }
 
+    /// (Re)read the file into `self.events`, truncating to the last complete
+    /// turn IN MEMORY. Returns whether the file had a torn/extra tail.
+    fn read_complete_events(&mut self) -> Result<bool, StoreError> {
         let mut events: Vec<TranscriptEvent> = Vec::new();
         let mut torn_tail = false;
-        if path.is_file() {
-            let body = fs::read_to_string(&path)
-                .map_err(|e| StoreError::Io(format!("read {}: {e}", path.display())))?;
+        if self.path.is_file() {
+            let body = fs::read_to_string(&self.path)
+                .map_err(|e| StoreError::Io(format!("read {}: {e}", self.path.display())))?;
             let mut parsed: Vec<TranscriptEvent> = Vec::new();
             for line in body.lines().filter(|l| !l.trim().is_empty()) {
                 match serde_json::from_str::<TranscriptEvent>(line) {
                     Ok(ev) => parsed.push(ev),
                     // A torn/corrupt line means everything from here on is
-                    // suspect; keep only what precedes it, then compact below.
+                    // suspect; keep only what precedes it.
                     Err(_) => {
                         torn_tail = true;
                         break;
@@ -210,12 +221,20 @@ impl SessionStore {
             parsed.truncate(last_complete);
             events = parsed;
         }
+        self.events = events;
+        Ok(torn_tail)
+    }
 
-        let store = Self { path, lock_path, events };
-        if torn_tail {
-            store.rewrite()?;
+    /// Under the session lock: re-read the file (the pre-lock view may be
+    /// stale — another turn can have committed between `open` and `lock`) and
+    /// physically COMPACT a crash-torn tail. Safe here and only here: the
+    /// lock guarantees no concurrent appender.
+    pub fn reload_under_lock(&mut self, _lock: &SessionLock) -> Result<(), StoreError> {
+        let torn = self.read_complete_events()?;
+        if torn {
+            self.rewrite()?;
         }
-        Ok(store)
+        Ok(())
     }
 
     /// Atomic whole-file rewrite (tmp + rename) — used only by compaction.
@@ -259,10 +278,25 @@ impl SessionStore {
                     if pid_alive(holder) {
                         return Err(StoreError::SessionBusy { holder_pid: holder });
                     }
-                    // Stale (dead pid / unreadable): reclaim once, retry create.
+                    // Stale (dead pid / unreadable). Reclaim must be ATOMIC:
+                    // a naive remove-then-create lets contender B delete the
+                    // lock contender A just created after the same removal.
+                    // rename() arbitrates — exactly one mover wins; the loser
+                    // gets NotFound and treats the session as busy (someone
+                    // else is mid-reclaim).
                     if attempt == 0 {
-                        let _ = fs::remove_file(&self.lock_path);
-                        continue;
+                        let grave = self
+                            .lock_path
+                            .with_extension(format!("stale-{}", std::process::id()));
+                        match fs::rename(&self.lock_path, &grave) {
+                            Ok(()) => {
+                                let _ = fs::remove_file(&grave);
+                                continue; // we won the reclaim — retry create_new
+                            }
+                            Err(_) => {
+                                return Err(StoreError::SessionBusy { holder_pid: holder });
+                            }
+                        }
                     }
                     return Err(StoreError::SessionBusy { holder_pid: holder });
                 }

--- a/crates/ovp-memory/src/agent_transcript.rs
+++ b/crates/ovp-memory/src/agent_transcript.rs
@@ -28,13 +28,22 @@ use serde::{Deserialize, Serialize};
 
 pub const TRANSCRIPT_SCHEMA: &str = "ovp.ask_transcript/v1";
 
-/// One transcript line. `schema` is stamped on every event so a reader never
-/// needs file-level framing to know what it is looking at.
+/// The on-disk line shape: EVERY event row carries the schema version and its
+/// session id, so audit rows stay versioned and correlatable even when
+/// separated from their filename (turn ids restart per session).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+struct TranscriptLine {
+    schema: String,
+    session_id: String,
+    #[serde(flatten)]
+    event: TranscriptEvent,
+}
+
+/// One transcript event (the line wrapper above adds schema + session id).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "event", rename_all = "snake_case")]
 pub enum TranscriptEvent {
     TurnStarted {
-        schema: String,
         turn_id: String,
         question: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -186,6 +195,7 @@ impl std::error::Error for StoreError {}
 pub struct SessionStore {
     path: PathBuf,
     lock_path: PathBuf,
+    session_id: String,
     /// Complete-turn events only (compaction dropped any torn tail).
     events: Vec<TranscriptEvent>,
 }
@@ -217,7 +227,8 @@ impl SessionStore {
             .map_err(|e| StoreError::Io(format!("create {}: {e}", sessions_dir.display())))?;
         let path = sessions_dir.join(format!("{session_id}.jsonl"));
         let lock_path = sessions_dir.join(format!("{session_id}.lock"));
-        let mut store = Self { path, lock_path, events: Vec::new() };
+        let mut store =
+            Self { path, lock_path, session_id: session_id.to_string(), events: Vec::new() };
         store.read_complete_events()?;
         Ok(store)
     }
@@ -232,11 +243,13 @@ impl SessionStore {
                 .map_err(|e| StoreError::Io(format!("read {}: {e}", self.path.display())))?;
             let mut parsed: Vec<TranscriptEvent> = Vec::new();
             for line in body.lines().filter(|l| !l.trim().is_empty()) {
-                match serde_json::from_str::<TranscriptEvent>(line) {
-                    Ok(ev) => parsed.push(ev),
-                    // A torn/corrupt line means everything from here on is
-                    // suspect; keep only what precedes it.
-                    Err(_) => {
+                match serde_json::from_str::<TranscriptLine>(line) {
+                    // A schema we don't understand is treated like a torn
+                    // line: conservative, never misread as current-schema.
+                    Ok(l) if l.schema == TRANSCRIPT_SCHEMA => parsed.push(l.event),
+                    // A torn/corrupt/foreign line means everything from here
+                    // on is suspect; keep only what precedes it.
+                    _ => {
                         torn_tail = true;
                         break;
                     }
@@ -275,14 +288,21 @@ impl SessionStore {
         Ok(())
     }
 
+    /// One on-disk line for `ev`: schema + session id + the event fields.
+    fn line_json(&self, ev: &TranscriptEvent) -> Result<String, StoreError> {
+        serde_json::to_string(&TranscriptLine {
+            schema: TRANSCRIPT_SCHEMA.to_string(),
+            session_id: self.session_id.clone(),
+            event: ev.clone(),
+        })
+        .map_err(|e| StoreError::Io(format!("serialize event: {e}")))
+    }
+
     /// Atomic whole-file rewrite (tmp + rename) — used only by compaction.
     fn rewrite(&self) -> Result<(), StoreError> {
         let mut body = String::new();
         for ev in &self.events {
-            body.push_str(
-                &serde_json::to_string(ev)
-                    .map_err(|e| StoreError::Io(format!("serialize event: {e}")))?,
-            );
+            body.push_str(&self.line_json(ev)?);
             body.push('\n');
         }
         let tmp = self.path.with_extension("jsonl.tmp");
@@ -464,10 +484,7 @@ impl SessionStore {
         }
         let mut body = String::new();
         for ev in &turn_events {
-            body.push_str(
-                &serde_json::to_string(ev)
-                    .map_err(|e| StoreError::Io(format!("serialize event: {e}")))?,
-            );
+            body.push_str(&self.line_json(ev)?);
             body.push('\n');
         }
         let mut f = fs::OpenOptions::new()

--- a/crates/ovp-memory/src/agent_transcript.rs
+++ b/crates/ovp-memory/src/agent_transcript.rs
@@ -46,12 +46,20 @@ pub enum TranscriptEvent {
         turn_id: String,
         message: ModelMessage,
     },
-    /// One model call's cost (`token_accounting`).
+    /// One model call's cost (`token_accounting` — A0 §5.2 requires
+    /// {in, out, src, scope} so multi-client / nested-ask usage stays
+    /// attributable).
     ModelCalled {
         turn_id: String,
         round: usize,
         input_tokens: u32,
         output_tokens: u32,
+        /// Which model incurred the usage.
+        #[serde(default)]
+        src: String,
+        /// Budget scope — "turn" today; nested asks stamp their own.
+        #[serde(default)]
+        scope: String,
     },
     /// One tool execution's audit line. `content` is the FULL RAW result —
     /// the audit transcript is complete by contract; the adjacent
@@ -404,9 +412,11 @@ impl SessionStore {
                 }
             }
         }
+        // CHARS, not bytes: the budget is documented as characters, and CJK/
+        // emoji content would otherwise be charged 3-4x and dropped early.
         let turn_len = |msgs: &[ModelMessage]| -> usize {
             msgs.iter()
-                .map(|m| serde_json::to_string(m).map(|s| s.len()).unwrap_or(0))
+                .map(|m| serde_json::to_string(m).map(|s| s.chars().count()).unwrap_or(0))
                 .sum()
         };
         // Keep newest-first until the cap, then restore order.

--- a/crates/ovp-memory/src/lib.rs
+++ b/crates/ovp-memory/src/lib.rs
@@ -4,6 +4,8 @@
 //! Reads from the JSON index and Crystal store. **Never** writes to the Crystal
 //! ledger or drives projection — all outputs are derived, ephemeral views.
 
+pub mod agent;
+pub mod agent_transcript;
 pub mod ask;
 pub mod digest;
 pub mod intent;

--- a/evolution/candidates/ask_agent-v1.json
+++ b/evolution/candidates/ask_agent-v1.json
@@ -1,0 +1,35 @@
+{
+  "kind": "ovp.evolution.candidate/v1",
+  "id": "ask_agent-v1",
+  "base_version": "none",
+  "target_version": "v1",
+  "surface": "runtime",
+  "component": "runtime.ask_agent",
+  "hypothesis": "RUNTIME surface only: a deadline-authoritative agent loop (model -> tool_calls? -> execute -> observe -> loop) over the A1a tool protocol, with a server-side structured transcript (JSONL, turn-atomic, idempotent, session-serialized) as the audit authority and a capped projection as the model context, makes multi-round tool conversations safe to run and replay WITHOUT wiring into any product path yet (POST /api/ask unchanged; the engine is called only by tests at this version). Predicted: every A0 §5.2 gate scenario (0/1/2-tool, unknown tool, timeout, max-rounds, concurrent submit, crash recovery, idempotent retry, invalid-args breaker) passes deterministically with a scripted model client and mock tools.",
+  "predicted_delta": {
+    "operational_reliability": "no unbounded loops: wall-clock deadline is the authoritative budget (max_rounds auxiliary); invalid-args circuit breaker stops unproductive retry storms; token usage recorded per model call",
+    "crystal_provenance": "no change (read-only engine, no product wiring at this version)"
+  },
+  "guardrails": {
+    "deadline_authority": "the turn has ONE authoritative wall-clock deadline; every model call and every tool execution receives only the REMAINING budget; when remaining cannot safely cover the next call the loop STOPS with stopped_reason=timeout — no call ever STARTS after the deadline",
+    "max_rounds_auxiliary": "max_rounds (default 6) is a secondary guard; exceeding it stops with stopped_reason=max_rounds; it never substitutes for the wall-clock budget",
+    "transcript_authority": "the JSONL transcript (schema ovp.ask_transcript/v1, session/turn/call ids) is the audit authority; the model context is a PROJECTION rebuilt from it under a hard char cap that trims whole turns oldest-first and never splits a tool_use/tool_result pair or orphans results",
+    "turn_atomicity_recovery": "a turn's events are committed as one append finalized by turn_finished; on store open, trailing events after the last turn_finished are dropped (compacted) — crash recovery lands on the last complete turn",
+    "idempotency": "a submit carrying an idempotency_key matching a COMPLETED turn replays that turn's outcome without running anything; matching an in-flight turn (locked session) is SessionBusy — retries never produce two user turns",
+    "session_serialization": "same-session turns are serialized by a pid lock file (stale pid stolen); a concurrent submit gets SessionBusy, never interleaved transcript writes",
+    "all_results_fed_back": "every tool_use id from the assistant turn gets exactly one tool_result fed back (failed executions as is_error) — enforced downstream by A1a's validate_tool_protocol, so a partial round is a loud Protocol error, never a silent drop",
+    "invalid_args_breaker": "a tool's Nth (default 2nd) CONSECUTIVE invalid-arguments failure stops the loop with stopped_reason=tool_error; the first failure is fed back once as a structured is_error result; success resets the counter",
+    "duplicate_ids_fail_closed": "a model reply carrying duplicate tool_use ids within one turn executes NOTHING and stops with stopped_reason=tool_error (the A1a request validator would reject the follow-up anyway — fail at the source)",
+    "unknown_stop_not_final": "StopReason::Unknown never produces a final-success outcome (stopped_reason=model_error, fail-closed); Refusal maps to stopped_reason=refusal",
+    "token_accounting": "every model call's {input_tokens, output_tokens} is recorded in the transcript event and summed into the turn outcome",
+    "nested_deadline_interface": "the engine takes the deadline as a caller-supplied budget parameter — a future MCP-embedded ask propagates its own remaining budget through the same interface, no second mechanism",
+    "no_product_wiring": "POST /api/ask and the ask.rs product path are byte-unchanged at this version; the engine is exercised only by its tests (rollout is A3d) — registry current_version stays none until the default switch"
+  },
+  "eval_plan": {
+    "replay_set": "deterministic in-crate tests with a scripted ModelClient + mock ToolExecutor: 0/1/2-tool success; unknown tool name; duplicate tool call ids; total timeout via short deadline + slow tool; max rounds via scripted infinite tool loop; concurrent same-session submit; crash recovery from a partial turn; repeated idempotency_key; invalid-args breaker; projection cap trimming whole turns",
+    "paired_sources": 0,
+    "soak": false
+  },
+  "rollback": "The engine is a new module with no product callers; rollback = stop calling it (delete or leave dormant). Transcript files live under .ovp/ask-sessions/ and are additive — no existing state is touched.",
+  "ablation_required": false
+}

--- a/evolution/candidates/ask_agent-v1.json
+++ b/evolution/candidates/ask_agent-v1.json
@@ -11,7 +11,7 @@
     "crystal_provenance": "no change (read-only engine, no product wiring at this version)"
   },
   "guardrails": {
-    "deadline_authority": "the turn has ONE authoritative wall-clock deadline; every model call and every tool execution receives only the REMAINING budget; when remaining cannot safely cover the next call the loop STOPS with stopped_reason=timeout — no call ever STARTS after the deadline",
+    "deadline_authority": "the turn has ONE authoritative wall-clock deadline started at function entry (refresh/lock/compaction spend from it); every tool execution receives only the REMAINING budget; a model or tool result that ARRIVES after the deadline is audited but never delivered/executed; when remaining cannot safely cover the next call the loop STOPS with stopped_reason=timeout — no call ever STARTS after the deadline",
     "max_rounds_auxiliary": "max_rounds (default 6) is a secondary guard; exceeding it stops with stopped_reason=max_rounds; it never substitutes for the wall-clock budget",
     "transcript_authority": "the JSONL transcript (schema ovp.ask_transcript/v1, session/turn/call ids) is the audit authority; the model context is a PROJECTION rebuilt from it under a hard char cap that trims whole turns oldest-first and never splits a tool_use/tool_result pair or orphans results",
     "turn_atomicity_recovery": "a turn's events are committed as one append finalized by turn_finished; on store open, trailing events after the last turn_finished are dropped (compacted) — crash recovery lands on the last complete turn",
@@ -23,7 +23,8 @@
     "unknown_stop_not_final": "StopReason::Unknown never produces a final-success outcome (stopped_reason=model_error, fail-closed); Refusal maps to stopped_reason=refusal",
     "token_accounting": "every model call's {input_tokens, output_tokens} is recorded in the transcript event and summed into the turn outcome",
     "nested_deadline_interface": "the engine takes the deadline as a caller-supplied budget parameter — a future MCP-embedded ask propagates its own remaining budget through the same interface, no second mechanism",
-    "no_product_wiring": "POST /api/ask and the ask.rs product path are byte-unchanged at this version; the engine is exercised only by its tests (rollout is A3d) — registry current_version stays none until the default switch"
+    "no_product_wiring": "POST /api/ask and the ask.rs product path are byte-unchanged at this version; the engine is exercised only by its tests (rollout is A3d) — registry current_version stays none until the default switch",
+    "deferred_to_model_surface": "DELIBERATE DEFERRALS (need a ModelClient trait change = model surface, i.e. ask_tool_protocol-v2 at live-client integration): (1) propagating the remaining budget INTO a blocking model call so the transport itself is bounded — at this version no live client attaches (no_product_wiring) and late replies are rejected post-call; (2) attempt-level usage propagation through retry/escalation wrappers (only the final reply's usage is visible at the client boundary today)"
   },
   "eval_plan": {
     "replay_set": "deterministic in-crate tests with a scripted ModelClient + mock ToolExecutor: 0/1/2-tool success; unknown tool name; duplicate tool call ids; total timeout via short deadline + slow tool; max rounds via scripted infinite tool loop; concurrent same-session submit; crash recovery from a partial turn; repeated idempotency_key; invalid-args breaker; projection cap trimming whole turns",

--- a/evolution/components.json
+++ b/evolution/components.json
@@ -146,7 +146,7 @@
     {
       "id": "model.ask_tool_protocol",
       "surface": "model",
-      "current_version": "none",
+      "current_version": "v1",
       "file": "crates/ovp-llm/src/request.rs",
       "quality_buckets": [
         "operational_reliability",


### PR DESCRIPTION
Second implementation Candidate of the Vault Agent program (evolution/candidates/ask_agent-v1.json — `ovp2 evolve validate` ✓). RUNTIME surface only; NO product wiring (POST /api/ask byte-unchanged; rollout = A3d).

**Engine** (`ovp-memory`): `run_agent_turn` tool loop over the A1a protocol with (1) authoritative wall-clock deadline — no call starts after exhaustion, max_rounds auxiliary; (2) invalid-args circuit breaker (2nd consecutive per-tool failure stops the loop); (3) fail-closed handling of duplicate tool_use ids and unknown stop reasons; (4) all-results-fed-back (failed executions as is_error); (5) per-call token accounting; (6) deadline-as-parameter = nested propagation interface for a future MCP-embedded ask.

**Transcript** (`SessionStore`, `ovp.ask_transcript/v1` JSONL): audit authority with turn-atomic commits, compact-on-open crash recovery (lands on the last complete turn), idempotency-key replay (retries never double a turn), pid-file session serialization (live holder — including same-pid in-process threads — is busy; stale reclaimed), and a char-capped model-context projection that trims WHOLE turns oldest-first so tool_use/tool_result pairs never split.

**Tests**: 16 deterministic tests = the candidate's eval matrix (0/1/2-tool, unknown tool, breaker+reset, total timeout, max rounds, dup ids, refusal/unknown stops, truncation at char boundary, busy session, idempotent replay, crash recovery, projection cap, token accounting, model failure). Workspace tests + clippy -D warnings clean.

Rides along: registry `model.ask_tool_protocol` none→v1 (A1a live); gitignore `docs/research/` (operator directive: research process docs stay local).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an agent interaction engine with configurable time limits, round limits, tool execution, and usage tracking.
  * Added reliable session history with replay support, crash recovery, audit records, and safe context trimming.
  * Added safeguards for invalid tool requests, duplicate actions, timeouts, and incomplete responses.

* **Tests**
  * Added extensive coverage for tool handling, retries, concurrency, recovery, transcript integrity, and token accounting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->