### PR TITLE
feat(server,memory): A3b — flag-gated agent path for POST /api/ask (ask_product_wiring-v1)

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -189,6 +189,8 @@ fn start_server(vault: PathBuf, viz_dir: PathBuf) -> Result<String, String> {
             ovp2_bin: resolve_ovp2_bin(),
             ask_timeout: None,
             max_concurrent_asks: None,
+            // Agent-path parity for the desktop lands with the A3d rollout.
+            ask_agent: false,
         };
         std::thread::spawn(move || {
             if let Err(e) = ovp_server::run_server(config) {

--- a/crates/ovp-cli/src/commands/serve.rs
+++ b/crates/ovp-cli/src/commands/serve.rs
@@ -51,6 +51,9 @@ pub fn run(args: ServeArgs) -> Result<(), CliError> {
         // (the same env the live client reads), the in-flight cap from
         // DEFAULT_MAX_CONCURRENT_ASKS.
         ask_timeout: None,
+        // A3b flag: OVP_ASK_AGENT=1 routes POST /api/ask through the agent
+        // loop (legacy single-shot stays the default until A3d).
+        ask_agent: std::env::var("OVP_ASK_AGENT").is_ok_and(|v| v == "1"),
         max_concurrent_asks: None,
     };
     run_server(config).map_err(CliError::Io)

--- a/crates/ovp-memory/src/agent.rs
+++ b/crates/ovp-memory/src/agent.rs
@@ -150,6 +150,17 @@ impl std::fmt::Display for AgentError {
 
 impl std::error::Error for AgentError {}
 
+/// Minimal progress feed (A0 §3.7: started → tool_started → tool_finished →
+/// final|error) — the A3b product wiring surfaces these through a polling
+/// slot; token streaming is A5.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AgentProgress {
+    Started { turn_id: String },
+    ToolStarted { tool_call_id: String, tool: String },
+    ToolFinished { tool_call_id: String, tool: String, is_error: bool },
+    Finished { turn_id: String, stopped_reason: StoppedReason },
+}
+
 /// Run one agent turn on `store`'s session. Mid-turn failures (model errors,
 /// timeouts, breakers) are NOT `Err` — they complete the turn with the
 /// matching `stopped_reason` so the audit trail is always whole. `Err` is
@@ -162,6 +173,26 @@ pub fn run_agent_turn(
     idempotency_key: Option<&str>,
     cfg: &AgentConfig,
 ) -> Result<AgentOutcome, AgentError> {
+    run_agent_turn_with_progress(client, tools, store, question, idempotency_key, cfg, None)
+}
+
+/// [`run_agent_turn`] with an optional progress sink. Additive so every
+/// existing caller/test stays byte-compatible; an idempotent replay emits
+/// NO progress (nothing executes).
+pub fn run_agent_turn_with_progress(
+    client: &mut dyn ModelClient,
+    tools: &mut dyn ToolExecutor,
+    store: &mut SessionStore,
+    question: &str,
+    idempotency_key: Option<&str>,
+    cfg: &AgentConfig,
+    progress: Option<&(dyn Fn(AgentProgress) + Sync)>,
+) -> Result<AgentOutcome, AgentError> {
+    let emit = |ev: AgentProgress| {
+        if let Some(sink) = progress {
+            sink(ev);
+        }
+    };
     // The whole-turn budget starts NOW — refresh, lock acquisition, and
     // compaction all spend from it (`deadline_authority` covers the turn,
     // not just the loop).
@@ -217,6 +248,7 @@ pub fn run_agent_turn(
     let remaining = |started: Instant| cfg.deadline.saturating_sub(started.elapsed());
 
     let turn_id = store.next_turn_id();
+    emit(AgentProgress::Started { turn_id: turn_id.clone() });
     let mut events: Vec<TranscriptEvent> = vec![TranscriptEvent::TurnStarted {
         turn_id: turn_id.clone(),
         question: question.to_string(),
@@ -420,6 +452,10 @@ pub fn run_agent_turn(
         let mut breaker_tripped = false;
         let mut timed_out = false;
         for (id, name, input) in &calls {
+            emit(AgentProgress::ToolStarted {
+                tool_call_id: id.clone(),
+                tool: name.clone(),
+            });
             let left = remaining(started);
             let outcome = if left.is_zero() || timed_out {
                 timed_out = true;
@@ -503,6 +539,11 @@ pub fn run_agent_turn(
                 }
                 (content, is_error)
             };
+            emit(AgentProgress::ToolFinished {
+                tool_call_id: id.clone(),
+                tool: name.clone(),
+                is_error: model_is_error,
+            });
             results.push(ToolResultBlock {
                 tool_call_id: id.clone(),
                 content: model_content,
@@ -538,6 +579,8 @@ pub fn run_agent_turn(
     store
         .commit_turn(events)
         .map_err(|e| AgentError::Store(e.to_string()))?;
+    // Emitted AFTER the commit: "final" must mean the turn is durable.
+    emit(AgentProgress::Finished { turn_id: turn_id.clone(), stopped_reason: stopped });
 
     Ok(AgentOutcome {
         turn_id,
@@ -1443,6 +1486,41 @@ mod tests {
             e,
             TranscriptEvent::TurnFinished { answer, .. } if answer == "foreign"
         )));
+    }
+
+    // A3b progress hook: events arrive in the A0 order and the sink is
+    // OPTIONAL (run_agent_turn delegates None — all older tests cover that).
+    #[test]
+    fn progress_events_follow_the_a0_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut client =
+            Scripted::new(vec![tool_reply(&[("c1", "search")]), text_reply("done")]);
+        let mut tools = MockTools::new(&[("search", Behavior::Ok("hit"))]);
+        let mut st = store(dir.path());
+        let events = std::sync::Mutex::new(Vec::new());
+        let sink = |ev: AgentProgress| events.lock().unwrap().push(ev);
+        let out = run_agent_turn_with_progress(
+            &mut client,
+            &mut tools,
+            &mut st,
+            "q?",
+            None,
+            &cfg(),
+            Some(&sink),
+        )
+        .unwrap();
+        let events = events.into_inner().unwrap();
+        assert!(matches!(&events[0], AgentProgress::Started { turn_id } if turn_id == "t1"));
+        assert!(matches!(&events[1], AgentProgress::ToolStarted { tool, .. } if tool == "search"));
+        assert!(matches!(
+            &events[2],
+            AgentProgress::ToolFinished { tool, is_error: false, .. } if tool == "search"
+        ));
+        assert!(matches!(
+            events.last().unwrap(),
+            AgentProgress::Finished { stopped_reason: StoppedReason::Final, .. }
+        ));
+        assert_eq!(out.stopped_reason, StoppedReason::Final);
     }
 
     // An empty/unstamped lock file is conservatively BUSY — a racing creator

--- a/crates/ovp-memory/src/vault_tools.rs
+++ b/crates/ovp-memory/src/vault_tools.rs
@@ -921,6 +921,10 @@ pub fn search_claims(
             }
             hit.insert("sources".into(), json!(record.source_cases));
             hit.insert(
+                "source_ids".into(),
+                json!(resolved_source_ids(model, &record.source_cases)),
+            );
+            hit.insert(
                 "provenance".into(),
                 json!({"score": record.provenance_score, "class": record.provenance_class}),
             );
@@ -954,6 +958,10 @@ pub fn search_claims(
             insert_option(&mut hit, "strength", row.strength.as_deref());
             insert_option(&mut hit, "theme", row.theme.as_deref());
             hit.insert("sources".into(), json!(row.sources));
+            hit.insert(
+                "source_ids".into(),
+                json!(resolved_source_ids(model, &row.sources)),
+            );
             hit.insert("status".into(), json!("caveated"));
             hits.push(Value::Object(hit));
         }
@@ -1323,6 +1331,23 @@ fn strength_name(strength: StrengthClass) -> String {
         .ok()
         .and_then(|value| value.as_str().map(str::to_string))
         .unwrap_or_else(|| "unknown".into())
+}
+
+/// Resolve case_ids to source shas via the packs join (pack_dir basename ==
+/// case_id). Misses are dropped — a citation path must never carry an id the
+/// index cannot open (A3a gate: caveated hits previously had NO followable
+/// source path at all).
+fn resolved_source_ids(model: &IndexModel, case_ids: &[String]) -> Vec<String> {
+    case_ids
+        .iter()
+        .filter_map(|case_id| {
+            model
+                .packs
+                .iter()
+                .find(|pack| pack.pack_dir.rsplit(['/', '\\']).next() == Some(case_id.as_str()))
+                .and_then(|pack| pack.source_sha256.clone())
+        })
+        .collect()
 }
 
 fn claim_source(model: &IndexModel, case_id: &str) -> Value {
@@ -1981,6 +2006,25 @@ mod tests {
             json!({"source_id": "sha-moved"}),
         ));
         assert_eq!(page["text"], "moved body");
+    }
+
+    /// A3b: search hits (durable AND caveated) carry resolved source_ids via
+    /// the packs join — the followable citation path the A3a gate found
+    /// missing for caveated claims.
+    #[test]
+    fn search_claims_hits_carry_resolved_source_ids() {
+        let fixture = Fixture::new();
+        let mut tools = fixture.tools();
+        let out = ok_json(call(
+            &mut tools,
+            "search_claims",
+            json!({"query": "Agent memory"}),
+        ));
+        let hits = out["hits"].as_array().unwrap();
+        let durable = hits.iter().find(|h| h["status"] == "durable").unwrap();
+        assert_eq!(durable["source_ids"][0], "sha-cjk", "case-a resolves via packs");
+        let caveated = hits.iter().find(|h| h["status"] == "caveated").unwrap();
+        assert_eq!(caveated["source_ids"][0], "sha-mal", "case-b resolves via packs");
     }
 
     #[test]

--- a/crates/ovp-memory/src/vault_tools.rs
+++ b/crates/ovp-memory/src/vault_tools.rs
@@ -171,6 +171,14 @@ impl VaultTools {
         }
     }
 
+    /// The index snapshot THIS executor's tools actually saw (lazily loaded,
+    /// cached). Citation verification must use the same snapshot — a rebuild
+    /// mid-turn would otherwise let the answer cite a source the verifier's
+    /// older view marks unverified.
+    pub fn index_snapshot(&mut self) -> Option<Arc<IndexModel>> {
+        self.cached_index().ok()
+    }
+
     /// Align the refusal budget with the driving runtime's per-result cap
     /// (leave ~2 KiB headroom under `AgentConfig.max_result_bytes`). Taken
     /// VERBATIM — silently raising a small caller cap would recreate the

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -2129,7 +2129,23 @@ fn handle_ask(
     // A3b (`ask_product_wiring-v1`): the FLAG-GATED agent path. The legacy
     // single-shot path below stays the byte-for-byte default until A3d.
     if state.ask_agent {
-        return handle_ask_agent(state, question, chat.as_deref(), slot, factory, model);
+        // Client retry key (A0 §3.7): a resend after a dropped response or
+        // 504 replays the completed turn instead of paying for a second one.
+        let idempotency_key = parsed
+            .get("idempotency_key")
+            .and_then(|k| k.as_str())
+            .map(str::trim)
+            .filter(|k| !k.is_empty() && k.len() <= 128)
+            .map(str::to_string);
+        return handle_ask_agent(
+            state,
+            question,
+            chat.as_deref(),
+            idempotency_key.as_deref(),
+            slot,
+            factory,
+            model,
+        );
     }
 
     // The slot was acquired at admission (before the body was even read —
@@ -2191,10 +2207,12 @@ fn handle_ask(
 /// audit authority (A1b). The agent deadline is derived UNDER the HTTP guard
 /// (`deadline_under_guard`): the loop's own timeout fires and the turn
 /// commits BEFORE the transport guard abandons the request.
+#[allow(clippy::too_many_arguments)]
 fn handle_ask_agent(
     state: &AppState,
     question: &str,
     chat: Option<&str>,
+    idempotency_key: Option<&str>,
     slot: AskSlot,
     factory: AskClientFactory,
     model: IndexModel,
@@ -2205,9 +2223,14 @@ fn handle_ask_agent(
     use ovp_memory::agent_transcript::{valid_session_id, SessionStore};
     use ovp_memory::vault_tools::VaultTools;
 
-    // Session id: the caller's (validated) or a generated timestamped one —
-    // returned in the response so the client can continue the session
-    // (`session_id_discipline`).
+    // Session id: the caller's (validated) or a generated one — returned in
+    // the response so the client can continue the session
+    // (`session_id_discipline`). A client that wants to POLL PROGRESS during
+    // its FIRST turn should supply its own fresh id (any [A-Za-z0-9_-]{1,64}
+    // string works; the store creates the session on first use) — the
+    // generated id is only knowable from the blocking response. The atomic
+    // counter makes same-millisecond generated ids collision-safe.
+    static SESSION_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
     let session = match chat {
         Some(c) if valid_session_id(c) => c.to_string(),
         Some(_) | None => {
@@ -2215,18 +2238,34 @@ fn handle_ask_agent(
                 .duration_since(std::time::UNIX_EPOCH)
                 .map(|d| d.as_millis())
                 .unwrap_or(0);
-            format!("agent-{now}")
+            let seq = SESSION_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            format!("agent-{now}-{seq}")
         }
     };
 
-    // Fresh progress feed for this turn (`progress_slot_bounded`).
-    {
+    // Fresh progress feed for this turn (`progress_slot_bounded`) — but NEVER
+    // clobber a live feed: a concurrent request on a busy session must not
+    // wipe the running turn's events (its own 409 exits without feed
+    // ownership).
+    let owns_feed = {
         let mut feeds = state.ask_progress.lock().unwrap();
-        feeds.insert(session.clone(), AskProgressFeed::default());
-    }
+        match feeds.get(&session) {
+            Some(feed) if !feed.done => false,
+            _ => {
+                feeds.insert(session.clone(), AskProgressFeed::default());
+                true
+            }
+        }
+    };
 
     // Deadline strictly under the HTTP guard so the turn always CONCLUDES
-    // (and commits its transcript) before the transport gives up.
+    // (and commits its transcript) before the transport gives up. KNOWN
+    // BOUND (ask_agent-v1 `deferred_to_model_surface`): a blocking live
+    // model call cannot be interrupted mid-flight — transport retries can in
+    // the worst case outlive this guard; the engine then discards the late
+    // reply, commits an honest timeout turn, and releases the slot/lock when
+    // the call returns. Propagating the remaining budget INTO the transport
+    // is the ask_tool_protocol-v2 (model surface) work.
     let guard = state.ask_timeout;
     let deadline = guard
         .saturating_sub(Duration::from_secs(15))
@@ -2238,6 +2277,7 @@ fn handle_ask_agent(
     let progress_session = session.clone();
     let question = question.to_string();
     let response_session = session.clone();
+    let request_key = idempotency_key.map(str::to_string);
 
     let (tx, rx) = mpsc::channel();
     std::thread::spawn(move || {
@@ -2277,6 +2317,9 @@ fn handle_ask_agent(
                         "stopped_reason": stopped_reason.as_str()
                     }),
                 };
+                if !owns_feed {
+                    return; // a rejected concurrent request never writes
+                }
                 let mut feeds = progress_map.lock().unwrap();
                 if let Some(feed) = feeds.get_mut(&progress_session) {
                     if feed.events.len() < MAX_PROGRESS_EVENTS {
@@ -2292,7 +2335,7 @@ fn handle_ask_agent(
                 &mut tools,
                 &mut store,
                 &question,
-                None,
+                request_key.as_deref(),
                 &cfg,
                 Some(&sink),
             )
@@ -2302,7 +2345,11 @@ fn handle_ask_agent(
             })?;
 
             let coverage = tools.coverage();
-            let citations = agent_citations(&outcome.answer, &model, &vault_root);
+            let records = ovp_api_projection::readers::load_active_records(
+                &vault_root,
+                &VaultLayout::new(),
+            );
+            let citations = agent_citations(&outcome.answer, &model, &records);
             let trace: Vec<serde_json::Value> = outcome
                 .tool_trace
                 .iter()
@@ -2327,8 +2374,10 @@ fn handle_ask_agent(
                 },
             }))
         })();
-        // Whatever happened, the feed must not stay live forever.
-        {
+        // Whatever happened, the OWNED feed must not stay live forever —
+        // a rejected concurrent request (no ownership) leaves the running
+        // turn's feed untouched.
+        if owns_feed {
             let mut feeds = progress_map.lock().unwrap();
             if let Some(feed) = feeds.get_mut(&progress_session) {
                 feed.done = true;
@@ -2379,9 +2428,8 @@ fn handle_ask_agent(
 fn agent_citations(
     answer: &str,
     model: &IndexModel,
-    vault_root: &std::path::Path,
+    records: &[ovp_domain::crystal::DurableRecord],
 ) -> Vec<serde_json::Value> {
-    let records = ovp_api_projection::readers::load_active_records(vault_root, &VaultLayout::new());
     citations_in_order(answer)
         .into_iter()
         .map(|key| {
@@ -2389,11 +2437,20 @@ fn agent_citations(
             match kind {
                 "claim" => {
                     let hit = records.iter().find(|r| r.claim_key == id);
+                    // Fail-closed anchor (same rule as the legacy citation
+                    // path): claim_ids can collide across runs, and a shared
+                    // anchor could open the WRONG claim — verified stays true
+                    // (the key resolved uniquely), the link is omitted.
+                    let link = hit.and_then(|r| {
+                        let same_id =
+                            records.iter().filter(|o| o.claim_id == r.claim_id).count();
+                        (same_id == 1).then(|| format!("/knowledge#{}", r.claim_id))
+                    });
                     serde_json::json!({
                         "id": key,
                         "kind": "claim",
                         "title": hit.map(|r| r.claim.chars().take(120).collect::<String>()),
-                        "link_target": hit.map(|r| format!("/knowledge#{}", r.claim_id)),
+                        "link_target": link,
                         "verified": hit.is_some(),
                     })
                 }
@@ -4760,6 +4817,78 @@ mod tests {
             .collect();
         assert_eq!(events.first().copied(), Some("started"));
         assert_eq!(events.last().copied(), Some("final"));
+    }
+
+    /// A3b round-1 gate: idempotent retries replay the completed turn (no
+    /// second paid call), generated session ids never collide, and ambiguous
+    /// legacy claim_ids get NO anchor link (fail-closed, legacy-path parity).
+    #[test]
+    fn agent_ask_idempotent_retry_and_collision_safe_ids() {
+        let vault = portal_vault("agent-idem", "50-Inbox/03-Processed/good.md", "body\n");
+        let mut st = state(vault, None);
+        st.ask_agent = true;
+        st.ask_client = Some(scripted_factory("first answer", Duration::from_millis(5)));
+        let resp = ask(
+            &st,
+            r#"{"question":"q","chat":"idem-s","idempotency_key":"key-1"}"#,
+        );
+        assert_eq!(resp.status_code(), 200);
+        let first: serde_json::Value =
+            serde_json::from_slice(resp.into_reader().get_ref()).unwrap();
+        // Retry with the same key: same turn, no second model call (the
+        // scripted factory would answer differently is irrelevant — the
+        // replay never invokes it; assert the SAME turn id + answer).
+        let resp = ask(
+            &st,
+            r#"{"question":"q","chat":"idem-s","idempotency_key":"key-1"}"#,
+        );
+        assert_eq!(resp.status_code(), 200);
+        let retry: serde_json::Value =
+            serde_json::from_slice(resp.into_reader().get_ref()).unwrap();
+        assert_eq!(retry["turn_id"], first["turn_id"]);
+        assert_eq!(retry["answer"], "first answer");
+
+        // Two chat-less asks get DISTINCT generated session ids.
+        let r1 = ask(&st, r#"{"question":"a"}"#);
+        let r2 = ask(&st, r#"{"question":"b"}"#);
+        let v1: serde_json::Value =
+            serde_json::from_slice(r1.into_reader().get_ref()).unwrap();
+        let v2: serde_json::Value =
+            serde_json::from_slice(r2.into_reader().get_ref()).unwrap();
+        assert_ne!(v1["chat"], v2["chat"], "generated ids must never collide");
+    }
+
+    /// A3b round-1 gate: the ambiguity rule on claim anchors, unit-level.
+    #[test]
+    fn agent_citations_fail_closed_on_ambiguous_claim_ids() {
+        use ovp_domain::crystal::{
+            CrystalStatus, DurableRecord, FinalClass, ProvenanceClass, StrengthClass,
+        };
+        let record = |key: &str, id: &str| DurableRecord {
+            claim_key: key.into(),
+            claim_id: id.into(),
+            claim: "text".into(),
+            theme: String::new(),
+            source_cases: vec![],
+            citations: vec![],
+            provenance_score: 1.0,
+            provenance_class: ProvenanceClass::Durable,
+            strength: StrengthClass::Supported,
+            strength_rationale: String::new(),
+            final_class: FinalClass::Durable,
+            run_id: "r".into(),
+            status: CrystalStatus::Active,
+        };
+        let records = vec![record("ck-a", "dup"), record("ck-b", "dup"), record("ck-c", "uniq")];
+        // A real (fixture-built) index: agent_citations only reads sources.
+        let vault = portal_vault("agent-ambig", "50-Inbox/03-Processed/good.md", "body\n");
+        let model = read_index(&vault).unwrap();
+        let cits = agent_citations("[claim:ck-a] [claim:ck-c]", &model, &records);
+        let a = &cits[0];
+        assert_eq!(a["verified"], true, "the key resolved uniquely");
+        assert!(a["link_target"].is_null(), "shared claim_id anchor must be omitted");
+        let c = &cits[1];
+        assert_eq!(c["link_target"], "/knowledge#uniq");
     }
 
     /// A3b: a busy session answers 409 without touching the model, and an

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -542,11 +542,15 @@ fn force_reload<T>(cache: &RwLock<Cached<T>>, path: &Path, data: Option<T>) {
 }
 
 
-/// One session's in-flight agent progress feed.
+/// One session's in-flight agent progress feed. `gen` ties the feed to the
+/// worker that ACQUIRED the session lock for this turn — cleanup and writes
+/// mutate the feed only while it still belongs to that worker (a newer turn
+/// on the same session replaces it with its own generation).
 #[derive(Default, Clone)]
 struct AskProgressFeed {
     events: Vec<serde_json::Value>,
     done: bool,
+    generation: u64,
 }
 
 pub fn run_server(config: ServeConfig) -> Result<(), String> {
@@ -2125,12 +2129,21 @@ fn handle_ask(
     if state.ask_agent {
         // Client retry key (A0 §3.7): a resend after a dropped response or
         // 504 replays the completed turn instead of paying for a second one.
+        // Replay lookup is SESSION-LOCAL, so a key without a stable session
+        // could never be found again — require `chat` alongside the key (a
+        // chatless retry would silently bill a second turn otherwise).
         let idempotency_key = parsed
             .get("idempotency_key")
             .and_then(|k| k.as_str())
             .map(str::trim)
             .filter(|k| !k.is_empty() && k.len() <= 128)
             .map(str::to_string);
+        if idempotency_key.is_some() && chat.is_none() {
+            return json_response(
+                400,
+                r#"{"error":"idempotency_key requires a stable `chat` session id","code":"idempotency_needs_chat"}"#,
+            );
+        }
         return handle_ask_agent(
             state,
             question,
@@ -2241,27 +2254,15 @@ fn handle_ask_agent(
         }
     };
 
-    // Fresh progress feed for this turn (`progress_slot_bounded`) — but NEVER
-    // clobber a live feed: a concurrent request on a busy session must not
-    // wipe the running turn's events (its own 409 exits without feed
-    // ownership).
-    let owns_feed = {
-        let mut feeds = state.ask_progress.lock().unwrap();
-        match feeds.get(&session) {
-            Some(feed) if !feed.done => false,
-            _ => {
-                // Bounded retention: completed feeds are ephemeral UI state —
-                // evict them once the map grows past the cap so a long-lived
-                // server cannot accumulate one entry per conversation.
-                const MAX_RETAINED_FEEDS: usize = 64;
-                if feeds.len() >= MAX_RETAINED_FEEDS {
-                    feeds.retain(|_, f| !f.done);
-                }
-                feeds.insert(session.clone(), AskProgressFeed::default());
-                true
-            }
-        }
-    };
+    // Feed ownership belongs to the worker that actually ACQUIRES the session
+    // lock: the engine emits `Started` only after lock+reload, so the sink
+    // creates the feed there — a concurrent request that loses the lock never
+    // emits and never touches the feed (its 409 carries no feed side effects).
+    // The generation token guards the worker's final cleanup against a NEWER
+    // turn having replaced the feed meanwhile.
+    static FEED_GENERATION: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+    let generation =
+        FEED_GENERATION.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
     // Deadline strictly under the HTTP guard so the turn always CONCLUDES
     // (and commits its transcript) before the transport gives up. KNOWN
@@ -2340,17 +2341,39 @@ fn handle_ask_agent(
                         })
                     }
                 };
-                if !owns_feed {
-                    return; // a rejected concurrent request never writes
-                }
                 let mut feeds = progress_map.lock().unwrap();
-                if let Some(feed) = feeds.get_mut(&progress_session) {
-                    if feed.events.len() < MAX_PROGRESS_EVENTS {
-                        feed.events.push(json);
+                if matches!(ev, AgentProgress::Started { .. }) {
+                    // We hold the session lock (Started fires after
+                    // acquisition) — any existing feed is a finished or
+                    // stale turn's; replace it with this turn's. Bounded
+                    // retention: evict completed feeds past the cap first.
+                    const MAX_RETAINED_FEEDS: usize = 64;
+                    if feeds.len() >= MAX_RETAINED_FEEDS {
+                        feeds.retain(|_, f| !f.done);
                     }
-                    if matches!(ev, AgentProgress::Finished { .. }) {
-                        feed.done = true;
+                    feeds.insert(
+                        progress_session.clone(),
+                        AskProgressFeed { events: vec![json], done: false, generation },
+                    );
+                    return;
+                }
+                let Some(feed) = feeds.get_mut(&progress_session) else {
+                    return;
+                };
+                if feed.generation != generation {
+                    return; // a newer turn owns this feed now
+                }
+                let terminal = matches!(ev, AgentProgress::Finished { .. });
+                // The terminal event ALWAYS lands — nonterminal events keep
+                // one slot reserved for it.
+                if terminal {
+                    if feed.events.len() >= MAX_PROGRESS_EVENTS {
+                        feed.events.pop();
                     }
+                    feed.events.push(json);
+                    feed.done = true;
+                } else if feed.events.len() < MAX_PROGRESS_EVENTS - 1 {
+                    feed.events.push(json);
                 }
             };
             let outcome = run_agent_turn_with_progress(
@@ -2405,12 +2428,15 @@ fn handle_ask_agent(
                 },
             }))
         })();
-        // Whatever happened, the OWNED feed must not stay live forever —
-        // a rejected concurrent request (no ownership) leaves the running
-        // turn's feed untouched.
-        if owns_feed {
+        // Whatever happened, OUR turn's feed must not stay live forever —
+        // guarded by the generation token so a newer turn's feed (same
+        // session) is never stomped, and a lock-losing worker (never
+        // Started) touches nothing.
+        {
             let mut feeds = progress_map.lock().unwrap();
-            if let Some(feed) = feeds.get_mut(&progress_session) {
+            if let Some(feed) = feeds.get_mut(&progress_session)
+                && feed.generation == generation
+            {
                 feed.done = true;
                 if result.is_err() {
                     feed.events.push(serde_json::json!({"event": "error"}));
@@ -4982,6 +5008,22 @@ mod tests {
             serde_json::from_slice(resp.into_reader().get_ref()).unwrap();
         assert_eq!(v["done"], true);
         assert_eq!(v["events"].as_array().unwrap().len(), 0);
+    }
+
+    /// A3b round-3 gate: an idempotency_key without a stable session is a
+    /// contract error (session-local replay could never find it — the retry
+    /// would silently bill a second turn).
+    #[test]
+    fn agent_ask_idempotency_requires_chat() {
+        let vault = portal_vault("agent-idemchat", "50-Inbox/03-Processed/good.md", "body\n");
+        let mut st = state(vault, None);
+        st.ask_agent = true;
+        st.ask_client = Some(scripted_factory("x", Duration::from_millis(5)));
+        let resp = ask(&st, r#"{"question":"q","idempotency_key":"k"}"#);
+        assert_eq!(resp.status_code(), 400);
+        let v: serde_json::Value =
+            serde_json::from_slice(resp.into_reader().get_ref()).unwrap();
+        assert_eq!(v["code"], "idempotency_needs_chat");
     }
 
     /// A3b round-2 gate: a fresh/unindexed vault still serves a zero-tool

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -2134,9 +2134,15 @@ fn handle_ask(
         // The agent's session-id rules are STRICTER than the legacy chat-stem
         // rules — a supplied-but-invalid id must fail loudly, not silently
         // land in a fresh generated session (which would break replay).
-        if let Some(raw) = parsed.get("chat").and_then(|c| c.as_str()).map(str::trim)
-            && !raw.is_empty()
-            && !ovp_memory::agent_transcript::valid_session_id(raw)
+        // ANY supplied non-null `chat` must be a valid session id — numbers,
+        // empty strings, and malformed ids all fail loudly (silently landing
+        // in a generated session would break continuation and replay).
+        if let Some(raw) = parsed.get("chat")
+            && !raw.is_null()
+            && !raw
+                .as_str()
+                .map(str::trim)
+                .is_some_and(ovp_memory::agent_transcript::valid_session_id)
         {
             return json_response(
                 400,
@@ -2275,7 +2281,9 @@ fn handle_ask_agent(
                 .map(|d| d.as_millis())
                 .unwrap_or(0);
             let seq = SESSION_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            format!("agent-{now}-{seq}")
+            // pid entropy: two server processes on one vault must not mint
+            // the same id in the same millisecond.
+            format!("agent-{now}-{}-{seq}", std::process::id())
         }
     };
 
@@ -2356,11 +2364,15 @@ fn handle_ask_agent(
                     Some(m) => agent_citations(&done.answer, &m, &records),
                     None => agent_citations_unindexed(&done.answer, &records),
                 };
+                // Coverage is an EXECUTION artifact the transcript does not
+                // persist — a replay reports null (unknown), never a
+                // fabricated all-not_queried that would misdescribe the
+                // original turn.
                 return Ok(serde_json::json!({
                     "agent": true,
                     "answer": done.answer,
                     "citations": citations,
-                    "coverage": ovp_memory::vault_tools::Coverage::default(),
+                    "coverage": serde_json::Value::Null,
                     "tool_trace": trace,
                     "chat": response_session,
                     "turn_id": done.turn_id,
@@ -2670,8 +2682,13 @@ fn handle_ask_progress(state: &AppState, url: &str) -> Response<std::io::Cursor<
         .unwrap_or_default();
     let feeds = state.ask_progress.lock().unwrap();
     let body = match feeds.get(&chat) {
-        Some(feed) => serde_json::json!({"events": feed.events, "done": feed.done}),
-        None => serde_json::json!({"events": [], "done": true}),
+        // `started` distinguishes a PENDING admission (setup/lock phase)
+        // from a running turn — a poller can show "connecting…" vs live
+        // tool activity.
+        Some(feed) => serde_json::json!({
+            "events": feed.events, "done": feed.done, "started": feed.started
+        }),
+        None => serde_json::json!({"events": [], "done": true, "started": false}),
     };
     json_response(200, &body.to_string())
 }

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -551,6 +551,10 @@ struct AskProgressFeed {
     events: Vec<serde_json::Value>,
     done: bool,
     generation: u64,
+    /// The engine's Started event arrived (the turn truly began). A PENDING
+    /// feed (started=false) is registered at admission so a poller during
+    /// client-build/lock-acquisition sees a live feed, not a stale done one.
+    started: bool,
 }
 
 pub fn run_server(config: ServeConfig) -> Result<(), String> {
@@ -2127,17 +2131,38 @@ fn handle_ask(
     // index check: a zero-tool capability turn must work on a fresh/unindexed
     // vault (tools report the missing index as honest unavailable coverage).
     if state.ask_agent {
+        // The agent's session-id rules are STRICTER than the legacy chat-stem
+        // rules — a supplied-but-invalid id must fail loudly, not silently
+        // land in a fresh generated session (which would break replay).
+        if let Some(raw) = parsed.get("chat").and_then(|c| c.as_str()).map(str::trim)
+            && !raw.is_empty()
+            && !ovp_memory::agent_transcript::valid_session_id(raw)
+        {
+            return json_response(
+                400,
+                r#"{"error":"invalid chat session id (want [A-Za-z0-9_-]{1,64})","code":"invalid_chat"}"#,
+            );
+        }
         // Client retry key (A0 §3.7): a resend after a dropped response or
         // 504 replays the completed turn instead of paying for a second one.
         // Replay lookup is SESSION-LOCAL, so a key without a stable session
         // could never be found again — require `chat` alongside the key (a
-        // chatless retry would silently bill a second turn otherwise).
-        let idempotency_key = parsed
-            .get("idempotency_key")
+        // chatless retry would silently bill a second turn otherwise). A
+        // PRESENT but malformed key is a loud 400: silently dropping it would
+        // strip the caller's replay protection.
+        let raw_key = parsed.get("idempotency_key");
+        let idempotency_key = raw_key
             .and_then(|k| k.as_str())
             .map(str::trim)
             .filter(|k| !k.is_empty() && k.len() <= 128)
             .map(str::to_string);
+        if raw_key.is_some() && !raw_key.is_some_and(|k| k.is_null()) && idempotency_key.is_none()
+        {
+            return json_response(
+                400,
+                r#"{"error":"idempotency_key must be a non-empty string of at most 128 chars","code":"invalid_idempotency_key"}"#,
+            );
+        }
         if idempotency_key.is_some() && chat.is_none() {
             return json_response(
                 400,
@@ -2263,6 +2288,25 @@ fn handle_ask_agent(
     static FEED_GENERATION: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
     let generation =
         FEED_GENERATION.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    // PENDING feed at admission: a poll during the pre-lock setup interval
+    // must see a live feed for this session (done:false), not a stale or
+    // missing one. Never touch a LIVE feed (a busy session's running turn
+    // owns it; our 409 exits without side effects — cleanup is
+    // generation-guarded).
+    {
+        let mut feeds = state.ask_progress.lock().unwrap();
+        let stale = feeds.get(&session).is_none_or(|f| f.done);
+        if stale {
+            const MAX_RETAINED_FEEDS: usize = 64;
+            if feeds.len() >= MAX_RETAINED_FEEDS {
+                feeds.retain(|_, f| !f.done);
+            }
+            feeds.insert(
+                session.clone(),
+                AskProgressFeed { events: vec![], done: false, generation, started: false },
+            );
+        }
+    }
 
     // Deadline strictly under the HTTP guard so the turn always CONCLUDES
     // (and commits its transcript) before the transport gives up. KNOWN
@@ -2287,9 +2331,48 @@ fn handle_ask_agent(
     std::thread::spawn(move || {
         let _slot = slot; // held for the WHOLE turn, freed on drop
         let result = (|| -> Result<serde_json::Value, String> {
-            let mut client = factory()?;
             let mut store = SessionStore::open(&sessions_dir, &progress_session)
                 .map_err(|e| e.to_string())?;
+            // Durable replay BEFORE building the model client: a keyed retry
+            // of a completed turn needs no provider access — it must succeed
+            // even after credentials were removed.
+            if let Some(key) = request_key.as_deref()
+                && let Some(done) = store.completed_turn_for_key(key)
+            {
+                let trace: Vec<serde_json::Value> = store
+                    .tool_calls_for_turn(&done.turn_id)
+                    .into_iter()
+                    .map(|(tool, _id, is_error, summary)| {
+                        serde_json::json!({"tool": tool, "summary": summary, "ok": !is_error})
+                    })
+                    .collect();
+                // Receipts recompute fine without a client (ledger + index
+                // reads only) — a replayed response keeps the full shape.
+                let records = ovp_api_projection::readers::load_active_records(
+                    &vault_root,
+                    &VaultLayout::new(),
+                );
+                let citations = match read_index(&vault_root).ok() {
+                    Some(m) => agent_citations(&done.answer, &m, &records),
+                    None => agent_citations_unindexed(&done.answer, &records),
+                };
+                return Ok(serde_json::json!({
+                    "agent": true,
+                    "answer": done.answer,
+                    "citations": citations,
+                    "coverage": ovp_memory::vault_tools::Coverage::default(),
+                    "tool_trace": trace,
+                    "chat": response_session,
+                    "turn_id": done.turn_id,
+                    "stopped_reason": done.stopped_reason,
+                    "idempotent_replay": true,
+                    "usage": {
+                        "input_tokens": done.input_tokens_total,
+                        "output_tokens": done.output_tokens_total,
+                    },
+                }));
+            }
+            let mut client = factory()?;
             // `coordinated cap`: the tools refuse anything the agent's
             // per-result budget would blind-truncate.
             // Deadline shares the ADMISSION clock with the HTTP guard: the
@@ -2344,16 +2427,18 @@ fn handle_ask_agent(
                 let mut feeds = progress_map.lock().unwrap();
                 if matches!(ev, AgentProgress::Started { .. }) {
                     // We hold the session lock (Started fires after
-                    // acquisition) — any existing feed is a finished or
-                    // stale turn's; replace it with this turn's. Bounded
-                    // retention: evict completed feeds past the cap first.
-                    const MAX_RETAINED_FEEDS: usize = 64;
-                    if feeds.len() >= MAX_RETAINED_FEEDS {
-                        feeds.retain(|_, f| !f.done);
-                    }
+                    // acquisition) — take over the feed: our own pending one,
+                    // another admission's pending one (it lost the lock), or
+                    // a finished turn's. A live STARTED feed cannot belong to
+                    // anyone else while we hold the lock.
                     feeds.insert(
                         progress_session.clone(),
-                        AskProgressFeed { events: vec![json], done: false, generation },
+                        AskProgressFeed {
+                            events: vec![json],
+                            done: false,
+                            generation,
+                            started: true,
+                        },
                     );
                     return;
                 }
@@ -5024,6 +5109,52 @@ mod tests {
         let v: serde_json::Value =
             serde_json::from_slice(resp.into_reader().get_ref()).unwrap();
         assert_eq!(v["code"], "idempotency_needs_chat");
+    }
+
+    /// A3b round-4 gate: a keyed replay succeeds WITHOUT provider access
+    /// (credentials removed after the first turn), and malformed inputs are
+    /// loud 400s (invalid chat id; invalid idempotency key).
+    #[test]
+    fn agent_ask_replay_without_provider_and_strict_validation() {
+        let vault = portal_vault("agent-replay", "50-Inbox/03-Processed/good.md", "body\n");
+        let mut st = state(vault, None);
+        st.ask_agent = true;
+        st.ask_client = Some(scripted_factory("paid answer", Duration::from_millis(5)));
+        let resp = ask(
+            &st,
+            r#"{"question":"q","chat":"replay-s","idempotency_key":"rk"}"#,
+        );
+        assert_eq!(resp.status_code(), 200);
+        // Credentials vanish: the factory now fails…
+        st.ask_client = Some(Arc::new(|| Err("no key".to_string())));
+        // …but the keyed retry replays the durable turn without a provider.
+        let resp = ask(
+            &st,
+            r#"{"question":"q","chat":"replay-s","idempotency_key":"rk"}"#,
+        );
+        assert_eq!(resp.status_code(), 200, "replay must not need the provider");
+        let v: serde_json::Value =
+            serde_json::from_slice(resp.into_reader().get_ref()).unwrap();
+        assert_eq!(v["answer"], "paid answer");
+        assert_eq!(v["idempotent_replay"], true);
+
+        // Strict validation: a supplied-but-invalid chat id is a loud 400
+        // (silently regenerating would break replay)…
+        let resp = ask(&st, r#"{"question":"q","chat":"has.dots"}"#);
+        assert_eq!(resp.status_code(), 400);
+        let v: serde_json::Value =
+            serde_json::from_slice(resp.into_reader().get_ref()).unwrap();
+        assert_eq!(v["code"], "invalid_chat");
+        // …and so is a present-but-malformed idempotency key.
+        let long_key = "k".repeat(200);
+        let body = format!(
+            r#"{{"question":"q","chat":"replay-s","idempotency_key":"{long_key}"}}"#
+        );
+        let resp = ask(&st, &body);
+        assert_eq!(resp.status_code(), 400);
+        let v: serde_json::Value =
+            serde_json::from_slice(resp.into_reader().get_ref()).unwrap();
+        assert_eq!(v["code"], "invalid_idempotency_key");
     }
 
     /// A3b round-2 gate: a fresh/unindexed vault still serves a zero-tool

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -2119,15 +2119,9 @@ fn handle_ask(
             r#"{"error":"llm not configured","code":"llm_not_configured"}"#,
         );
     };
-    let Some(model) = state.current_model() else {
-        return json_response(
-            503,
-            r#"{"error":"index not available","code":"index_unavailable"}"#,
-        );
-    };
-
-    // A3b (`ask_product_wiring-v1`): the FLAG-GATED agent path. The legacy
-    // single-shot path below stays the byte-for-byte default until A3d.
+    // A3b (`ask_product_wiring-v1`): the FLAG-GATED agent path — BEFORE the
+    // index check: a zero-tool capability turn must work on a fresh/unindexed
+    // vault (tools report the missing index as honest unavailable coverage).
     if state.ask_agent {
         // Client retry key (A0 §3.7): a resend after a dropped response or
         // 504 replays the completed turn instead of paying for a second one.
@@ -2144,9 +2138,14 @@ fn handle_ask(
             idempotency_key.as_deref(),
             slot,
             factory,
-            model,
         );
     }
+    let Some(model) = state.current_model() else {
+        return json_response(
+            503,
+            r#"{"error":"index not available","code":"index_unavailable"}"#,
+        );
+    };
 
     // The slot was acquired at admission (before the body was even read —
     // see serve_loop) and moves INTO the pipeline thread: even after the
@@ -2215,7 +2214,6 @@ fn handle_ask_agent(
     idempotency_key: Option<&str>,
     slot: AskSlot,
     factory: AskClientFactory,
-    model: IndexModel,
 ) -> Response<std::io::Cursor<Vec<u8>>> {
     use ovp_memory::agent::{
         run_agent_turn_with_progress, AgentConfig, AgentError, AgentProgress,
@@ -2252,6 +2250,13 @@ fn handle_ask_agent(
         match feeds.get(&session) {
             Some(feed) if !feed.done => false,
             _ => {
+                // Bounded retention: completed feeds are ephemeral UI state —
+                // evict them once the map grows past the cap so a long-lived
+                // server cannot accumulate one entry per conversation.
+                const MAX_RETAINED_FEEDS: usize = 64;
+                if feeds.len() >= MAX_RETAINED_FEEDS {
+                    feeds.retain(|_, f| !f.done);
+                }
                 feeds.insert(session.clone(), AskProgressFeed::default());
                 true
             }
@@ -2267,9 +2272,7 @@ fn handle_ask_agent(
     // the call returns. Propagating the remaining budget INTO the transport
     // is the ask_tool_protocol-v2 (model surface) work.
     let guard = state.ask_timeout;
-    let deadline = guard
-        .saturating_sub(Duration::from_secs(15))
-        .max(Duration::from_secs(30));
+    let admitted = std::time::Instant::now();
 
     let vault_root = state.vault_root.clone();
     let sessions_dir = vault_root.join(".ovp/ask-sessions");
@@ -2288,6 +2291,15 @@ fn handle_ask_agent(
                 .map_err(|e| e.to_string())?;
             // `coordinated cap`: the tools refuse anything the agent's
             // per-result budget would blind-truncate.
+            // Deadline shares the ADMISSION clock with the HTTP guard: the
+            // preprocessing above (client build, store open) already spent
+            // from it, so the loop's timeout still fires before the guard.
+            // No floor — a guard shorter than the margin yields a near-zero
+            // budget and an honest immediate timeout turn, never a 504
+            // before the commit.
+            let deadline = guard
+                .saturating_sub(Duration::from_secs(15))
+                .saturating_sub(admitted.elapsed());
             let cfg = AgentConfig {
                 model: ovp_memory::ask::AskArgs::default().model_name,
                 system: ovp_memory::agent_policy::AGENT_POLICY.to_string(),
@@ -2312,10 +2324,21 @@ fn handle_ask_agent(
                             "tool_call_id": tool_call_id, "ok": !is_error
                         })
                     }
-                    AgentProgress::Finished { turn_id, stopped_reason } => serde_json::json!({
-                        "event": "final", "turn_id": turn_id,
-                        "stopped_reason": stopped_reason.as_str()
-                    }),
+                    // The advertised terminal protocol is final | error: a
+                    // deliverable stop (final answer, refusal, best-effort
+                    // round cap) is `final`; runtime failures are `error` —
+                    // both carry stopped_reason for precise clients.
+                    AgentProgress::Finished { turn_id, stopped_reason } => {
+                        use ovp_memory::agent::StoppedReason as SR;
+                        let event = match stopped_reason {
+                            SR::Final | SR::NeedUser | SR::Refusal | SR::MaxRounds => "final",
+                            SR::Timeout | SR::ToolError | SR::ModelError => "error",
+                        };
+                        serde_json::json!({
+                            "event": event, "turn_id": turn_id,
+                            "stopped_reason": stopped_reason.as_str()
+                        })
+                    }
                 };
                 if !owns_feed {
                     return; // a rejected concurrent request never writes
@@ -2344,12 +2367,20 @@ fn handle_ask_agent(
                 AgentError::Store(d) => d,
             })?;
 
-            let coverage = tools.coverage();
             let records = ovp_api_projection::readers::load_active_records(
                 &vault_root,
                 &VaultLayout::new(),
             );
-            let citations = agent_citations(&outcome.answer, &model, &records);
+            // Verify against the SAME index snapshot the tools served from —
+            // a mid-turn rebuild must not let verification disagree with what
+            // the model actually saw. No snapshot (unindexed vault) → source
+            // citations resolve as unverified, honestly.
+            let snapshot = tools.index_snapshot();
+            let citations = match snapshot.as_deref() {
+                Some(m) => agent_citations(&outcome.answer, m, &records),
+                None => agent_citations_unindexed(&outcome.answer, &records),
+            };
+            let coverage = tools.coverage();
             let trace: Vec<serde_json::Value> = outcome
                 .tool_trace
                 .iter()
@@ -2471,6 +2502,43 @@ fn agent_citations(
                     "link_target": serde_json::Value::Null,
                     "verified": false,
                 }),
+            }
+        })
+        .collect()
+}
+
+/// [`agent_citations`] without an index snapshot (fresh/unindexed vault):
+/// claim receipts still resolve against the ledger; source references cannot
+/// be verified and honestly say so.
+fn agent_citations_unindexed(
+    answer: &str,
+    records: &[ovp_domain::crystal::DurableRecord],
+) -> Vec<serde_json::Value> {
+    citations_in_order(answer)
+        .into_iter()
+        .map(|key| {
+            let (kind, id) = key.split_once(':').unwrap_or(("", key.as_str()));
+            if kind == "claim" {
+                let hit = records.iter().find(|r| r.claim_key == id);
+                let link = hit.and_then(|r| {
+                    let same_id = records.iter().filter(|o| o.claim_id == r.claim_id).count();
+                    (same_id == 1).then(|| format!("/knowledge#{}", r.claim_id))
+                });
+                serde_json::json!({
+                    "id": key,
+                    "kind": "claim",
+                    "title": hit.map(|r| r.claim.chars().take(120).collect::<String>()),
+                    "link_target": link,
+                    "verified": hit.is_some(),
+                })
+            } else {
+                serde_json::json!({
+                    "id": key,
+                    "kind": kind,
+                    "title": serde_json::Value::Null,
+                    "link_target": serde_json::Value::Null,
+                    "verified": false,
+                })
             }
         })
         .collect()
@@ -4914,6 +4982,25 @@ mod tests {
             serde_json::from_slice(resp.into_reader().get_ref()).unwrap();
         assert_eq!(v["done"], true);
         assert_eq!(v["events"].as_array().unwrap().len(), 0);
+    }
+
+    /// A3b round-2 gate: a fresh/unindexed vault still serves a zero-tool
+    /// agent turn (no 503), with coverage reporting the missing layers.
+    #[test]
+    fn agent_ask_works_without_an_index() {
+        let vault = temp_root("agent-noindex");
+        let mut st = state(vault, None);
+        st.ask_agent = true;
+        st.ask_client = Some(scripted_factory(
+            "I can search sources and claims.",
+            Duration::from_millis(5),
+        ));
+        let resp = ask(&st, r#"{"question":"what can you do?"}"#);
+        assert_eq!(resp.status_code(), 200, "capability turns must not need an index");
+        let v: serde_json::Value =
+            serde_json::from_slice(resp.into_reader().get_ref()).unwrap();
+        assert_eq!(v["stopped_reason"], "final");
+        assert_eq!(v["coverage"]["sources"], "not_queried");
     }
 
     /// A3b: flag OFF keeps the legacy path — the response carries the legacy

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -122,6 +122,11 @@ pub struct ServeConfig {
     /// Override the in-flight ask cap (tests). `None` =
     /// [`DEFAULT_MAX_CONCURRENT_ASKS`].
     pub max_concurrent_asks: Option<usize>,
+    /// FLAG-GATED agent path for `POST /api/ask` (candidate
+    /// `ask_product_wiring-v1`): when true, ask runs the A1b tool loop with
+    /// the A2 vault tools and the A3a policy. Default false — the legacy
+    /// single-shot path stays the product default until A3d flips it.
+    pub ask_agent: bool,
 }
 
 /// Counting semaphore for in-flight asks — no queue, `try_acquire` only.
@@ -292,6 +297,13 @@ struct AppState {
     ovp2_bin: Option<PathBuf>,
     /// Serializes attention-ack read-modify-writes.
     acks_write_lock: std::sync::Mutex<()>,
+    /// Agent-path flag (see [`ServeConfig::ask_agent`]).
+    ask_agent: bool,
+    /// Per-session agent progress feeds (`progress_slot_bounded`): replaced at
+    /// each turn start, marked done at turn end, polled by
+    /// `GET /api/ask/progress`. In-memory only — progress is ephemeral UI
+    /// state; the transcript is the durable audit.
+    ask_progress: Arc<std::sync::Mutex<HashMap<String, AskProgressFeed>>>,
 }
 
 /// State of the portal-triggered manual pipeline run.
@@ -529,6 +541,14 @@ fn force_reload<T>(cache: &RwLock<Cached<T>>, path: &Path, data: Option<T>) {
     };
 }
 
+
+/// One session's in-flight agent progress feed.
+#[derive(Default, Clone)]
+struct AskProgressFeed {
+    events: Vec<serde_json::Value>,
+    done: bool,
+}
+
 pub fn run_server(config: ServeConfig) -> Result<(), String> {
     let bind = format!("{}:{}", config.host, config.port);
     let server = Server::http(&bind).map_err(|e| format!("failed to bind {bind}: {e}"))?;
@@ -553,6 +573,8 @@ pub fn run_server(config: ServeConfig) -> Result<(), String> {
         manual_run: Arc::new(std::sync::Mutex::new(ManualRun::default())),
         ovp2_bin: config.ovp2_bin,
         acks_write_lock: std::sync::Mutex::new(()),
+        ask_agent: config.ask_agent,
+        ask_progress: Arc::new(std::sync::Mutex::new(HashMap::new())),
     });
 
     // Pre-load model
@@ -690,6 +712,9 @@ fn dispatch(
         (Method::Get, "/api/publish/status") => handle_publish_status(state),
         (Method::Post, "/api/publish") => handle_publish_start(state),
         (Method::Get, "/api/schedule/run/status") => handle_run_status(state),
+        (Method::Get, p) if p.starts_with("/api/ask/progress") => {
+            handle_ask_progress(state, url)
+        }
         (Method::Post, "/api/schedule/run") => handle_run_start(state, body),
         (Method::Post, "/api/attention/ack") => handle_attention_ack(state, body),
         (Method::Get, "/api/providers") => handle_providers_get(state),
@@ -2101,6 +2126,12 @@ fn handle_ask(
         );
     };
 
+    // A3b (`ask_product_wiring-v1`): the FLAG-GATED agent path. The legacy
+    // single-shot path below stays the byte-for-byte default until A3d.
+    if state.ask_agent {
+        return handle_ask_agent(state, question, chat.as_deref(), slot, factory, model);
+    }
+
     // The slot was acquired at admission (before the body was even read —
     // see serve_loop) and moves INTO the pipeline thread: even after the
     // guard 504s below, the still-running provider call keeps its slot
@@ -2152,6 +2183,261 @@ fn handle_ask(
             json_response(504, &body.to_string())
         }
     }
+}
+
+/// The agent-path worker for /api/ask (candidate `ask_product_wiring-v1`).
+///
+/// Sessions live under `<vault>/.ovp/ask-sessions/`; the transcript is the
+/// audit authority (A1b). The agent deadline is derived UNDER the HTTP guard
+/// (`deadline_under_guard`): the loop's own timeout fires and the turn
+/// commits BEFORE the transport guard abandons the request.
+fn handle_ask_agent(
+    state: &AppState,
+    question: &str,
+    chat: Option<&str>,
+    slot: AskSlot,
+    factory: AskClientFactory,
+    model: IndexModel,
+) -> Response<std::io::Cursor<Vec<u8>>> {
+    use ovp_memory::agent::{
+        run_agent_turn_with_progress, AgentConfig, AgentError, AgentProgress,
+    };
+    use ovp_memory::agent_transcript::{valid_session_id, SessionStore};
+    use ovp_memory::vault_tools::VaultTools;
+
+    // Session id: the caller's (validated) or a generated timestamped one —
+    // returned in the response so the client can continue the session
+    // (`session_id_discipline`).
+    let session = match chat {
+        Some(c) if valid_session_id(c) => c.to_string(),
+        Some(_) | None => {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis())
+                .unwrap_or(0);
+            format!("agent-{now}")
+        }
+    };
+
+    // Fresh progress feed for this turn (`progress_slot_bounded`).
+    {
+        let mut feeds = state.ask_progress.lock().unwrap();
+        feeds.insert(session.clone(), AskProgressFeed::default());
+    }
+
+    // Deadline strictly under the HTTP guard so the turn always CONCLUDES
+    // (and commits its transcript) before the transport gives up.
+    let guard = state.ask_timeout;
+    let deadline = guard
+        .saturating_sub(Duration::from_secs(15))
+        .max(Duration::from_secs(30));
+
+    let vault_root = state.vault_root.clone();
+    let sessions_dir = vault_root.join(".ovp/ask-sessions");
+    let progress_map = Arc::clone(&state.ask_progress);
+    let progress_session = session.clone();
+    let question = question.to_string();
+    let response_session = session.clone();
+
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let _slot = slot; // held for the WHOLE turn, freed on drop
+        let result = (|| -> Result<serde_json::Value, String> {
+            let mut client = factory()?;
+            let mut store = SessionStore::open(&sessions_dir, &progress_session)
+                .map_err(|e| e.to_string())?;
+            // `coordinated cap`: the tools refuse anything the agent's
+            // per-result budget would blind-truncate.
+            let cfg = AgentConfig {
+                model: ovp_memory::ask::AskArgs::default().model_name,
+                system: ovp_memory::agent_policy::AGENT_POLICY.to_string(),
+                max_tokens: 2048,
+                deadline,
+                ..AgentConfig::default()
+            };
+            let mut tools = VaultTools::new(&vault_root)
+                .with_result_cap(cfg.max_result_bytes.saturating_sub(2 * 1024));
+            const MAX_PROGRESS_EVENTS: usize = 256;
+            let sink = |ev: AgentProgress| {
+                let json = match &ev {
+                    AgentProgress::Started { turn_id } => {
+                        serde_json::json!({"event": "started", "turn_id": turn_id})
+                    }
+                    AgentProgress::ToolStarted { tool_call_id, tool } => serde_json::json!({
+                        "event": "tool_started", "tool": tool, "tool_call_id": tool_call_id
+                    }),
+                    AgentProgress::ToolFinished { tool_call_id, tool, is_error } => {
+                        serde_json::json!({
+                            "event": "tool_finished", "tool": tool,
+                            "tool_call_id": tool_call_id, "ok": !is_error
+                        })
+                    }
+                    AgentProgress::Finished { turn_id, stopped_reason } => serde_json::json!({
+                        "event": "final", "turn_id": turn_id,
+                        "stopped_reason": stopped_reason.as_str()
+                    }),
+                };
+                let mut feeds = progress_map.lock().unwrap();
+                if let Some(feed) = feeds.get_mut(&progress_session) {
+                    if feed.events.len() < MAX_PROGRESS_EVENTS {
+                        feed.events.push(json);
+                    }
+                    if matches!(ev, AgentProgress::Finished { .. }) {
+                        feed.done = true;
+                    }
+                }
+            };
+            let outcome = run_agent_turn_with_progress(
+                client.as_mut(),
+                &mut tools,
+                &mut store,
+                &question,
+                None,
+                &cfg,
+                Some(&sink),
+            )
+            .map_err(|e| match e {
+                AgentError::SessionBusy => "session busy".to_string(),
+                AgentError::Store(d) => d,
+            })?;
+
+            let coverage = tools.coverage();
+            let citations = agent_citations(&outcome.answer, &model, &vault_root);
+            let trace: Vec<serde_json::Value> = outcome
+                .tool_trace
+                .iter()
+                .map(|t|
+
+                    serde_json::json!({
+                        "tool": t.tool, "summary": t.summary, "ok": !t.is_error
+                    }))
+                .collect();
+            Ok(serde_json::json!({
+                "agent": true,
+                "answer": outcome.answer,
+                "citations": citations,
+                "coverage": coverage,
+                "tool_trace": trace,
+                "chat": response_session,
+                "turn_id": outcome.turn_id,
+                "stopped_reason": outcome.stopped_reason.as_str(),
+                "usage": {
+                    "input_tokens": outcome.input_tokens_total,
+                    "output_tokens": outcome.output_tokens_total,
+                },
+            }))
+        })();
+        // Whatever happened, the feed must not stay live forever.
+        {
+            let mut feeds = progress_map.lock().unwrap();
+            if let Some(feed) = feeds.get_mut(&progress_session) {
+                feed.done = true;
+                if result.is_err() {
+                    feed.events.push(serde_json::json!({"event": "error"}));
+                }
+            }
+        }
+        let _ = tx.send(result);
+    });
+
+    match rx.recv_timeout(state.ask_timeout) {
+        Ok(Ok(payload)) => json_response(200, &payload.to_string()),
+        Ok(Err(e)) if e == LLM_NOT_CONFIGURED => json_response(
+            503,
+            r#"{"error":"llm not configured","code":"llm_not_configured"}"#,
+        ),
+        Ok(Err(e)) if e == "session busy" => json_response(
+            409,
+            r#"{"error":"a turn is already running on this session","code":"ask_session_busy"}"#,
+        ),
+        Ok(Err(e)) => {
+            let body = serde_json::json!({ "error": e });
+            json_response(502, &body.to_string())
+        }
+        Err(_) => {
+            // The agent deadline sits under this guard, so reaching here means
+            // something pathological — the honest message matches the legacy
+            // path (the turn is not cancelled; the transcript still commits).
+            let body = serde_json::json!({
+                "error": format!(
+                    "no answer within {}s; the turn was not cancelled and its \
+                     transcript will still commit",
+                    state.ask_timeout.as_secs()
+                ),
+                "code": "ask_timeout",
+            });
+            json_response(504, &body.to_string())
+        }
+    }
+}
+
+/// Resolve the agent answer's citation markers into receipts
+/// (`citations_resolved_not_trusted`): [claim:<key>] against the ACTIVE
+/// ledger records (link = the claim's knowledge anchor), [source:<id>]
+/// against the index (link = /library). Anything unresolvable is
+/// verified:false — surfaced, never silently dropped.
+fn agent_citations(
+    answer: &str,
+    model: &IndexModel,
+    vault_root: &std::path::Path,
+) -> Vec<serde_json::Value> {
+    let records = ovp_api_projection::readers::load_active_records(vault_root, &VaultLayout::new());
+    citations_in_order(answer)
+        .into_iter()
+        .map(|key| {
+            let (kind, id) = key.split_once(':').unwrap_or(("", key.as_str()));
+            match kind {
+                "claim" => {
+                    let hit = records.iter().find(|r| r.claim_key == id);
+                    serde_json::json!({
+                        "id": key,
+                        "kind": "claim",
+                        "title": hit.map(|r| r.claim.chars().take(120).collect::<String>()),
+                        "link_target": hit.map(|r| format!("/knowledge#{}", r.claim_id)),
+                        "verified": hit.is_some(),
+                    })
+                }
+                "source" => {
+                    let hit = model.sources.iter().find(|s| s.sha256 == id);
+                    serde_json::json!({
+                        "id": key,
+                        "kind": "source",
+                        "title": hit.and_then(|s| s.title.clone()),
+                        "link_target": hit.map(|s| format!("/library/{}", s.sha256)),
+                        "verified": hit.is_some(),
+                    })
+                }
+                _ => serde_json::json!({
+                    "id": key,
+                    "kind": kind,
+                    "title": serde_json::Value::Null,
+                    "link_target": serde_json::Value::Null,
+                    "verified": false,
+                }),
+            }
+        })
+        .collect()
+}
+
+/// `GET /api/ask/progress?chat=<session>` — the minimal A0 §3.7 progress feed.
+/// Unknown or finished sessions answer an EMPTY done feed (no 404 fishing on
+/// session ids).
+fn handle_ask_progress(state: &AppState, url: &str) -> Response<std::io::Cursor<Vec<u8>>> {
+    let chat = url
+        .split_once('?')
+        .map(|(_, q)| q)
+        .and_then(|q| {
+            q.split('&')
+                .find_map(|kv| kv.strip_prefix("chat="))
+                .map(str::to_string)
+        })
+        .unwrap_or_default();
+    let feeds = state.ask_progress.lock().unwrap();
+    let body = match feeds.get(&chat) {
+        Some(feed) => serde_json::json!({"events": feed.events, "done": feed.done}),
+        None => serde_json::json!({"events": [], "done": true}),
+    };
+    json_response(200, &body.to_string())
 }
 
 /// The worker side of /api/ask: build the client, run the pipeline (chat
@@ -2715,6 +3001,8 @@ mod tests {
             manual_run: Arc::new(std::sync::Mutex::new(ManualRun::default())),
             ovp2_bin: None,
             acks_write_lock: std::sync::Mutex::new(()),
+            ask_agent: false,
+            ask_progress: Arc::new(std::sync::Mutex::new(HashMap::new())),
         }
     }
 
@@ -4416,6 +4704,103 @@ mod tests {
     /// AND a second ask — the GET must answer well before the first ask
     /// completes, and the second ask must be refused (429) immediately
     /// instead of queueing behind the paid call.
+    /// A3b: the flag-gated agent path serves a full turn — response shape,
+    /// resolved citations, executor coverage, durable transcript, progress
+    /// feed. The scripted client answers with no tool calls (0-tool final).
+    #[test]
+    fn agent_ask_serves_a_full_turn_with_receipts() {
+        let vault = portal_vault("agent-turn", "50-Inbox/03-Processed/good.md", "body\n");
+        let mut st = state(vault.clone(), None);
+        st.ask_agent = true;
+        st.ask_client = Some(scripted_factory(
+            // One resolvable source ref (fixture sha) + one fabricated claim
+            // key: the server must verify the first and flag the second.
+            "answer [source:aaaa1111] and [claim:ck-fabricated]",
+            Duration::from_millis(10),
+        ));
+        let resp = ask(&st, r#"{"question":"what do we know?"}"#);
+        assert_eq!(resp.status_code(), 200);
+        let v: serde_json::Value =
+            serde_json::from_slice(resp.into_reader().get_ref()).unwrap();
+        assert_eq!(v["agent"], true);
+        assert_eq!(v["stopped_reason"], "final");
+        assert_eq!(v["turn_id"], "t1");
+        let chat = v["chat"].as_str().unwrap().to_string();
+        assert!(chat.starts_with("agent-"), "{chat}");
+        // 0-tool turn → every layer honestly not_queried, model never fills it.
+        assert_eq!(v["coverage"]["sources"], "not_queried");
+        assert_eq!(v["coverage"]["claims"], "not_queried");
+        assert_eq!(v["coverage"]["body"], "not_queried");
+        // Citations: resolved receipt vs flagged fabrication.
+        let cits = v["citations"].as_array().unwrap();
+        let src = cits.iter().find(|c| c["kind"] == "source").unwrap();
+        assert_eq!(src["verified"], true);
+        assert_eq!(src["link_target"], "/library/aaaa1111");
+        let claim = cits.iter().find(|c| c["kind"] == "claim").unwrap();
+        assert_eq!(claim["verified"], false);
+        // The transcript committed durably under .ovp/ask-sessions/.
+        let transcript = vault.join(format!(".ovp/ask-sessions/{chat}.jsonl"));
+        let body = std::fs::read_to_string(&transcript).unwrap();
+        assert!(body.contains("turn_finished"), "{body}");
+        // Progress feed: started + final, done.
+        let resp = dispatch(
+            &st,
+            Method::Get,
+            &format!("/api/ask/progress?chat={chat}"),
+            "",
+        );
+        let v: serde_json::Value =
+            serde_json::from_slice(resp.into_reader().get_ref()).unwrap();
+        assert_eq!(v["done"], true);
+        let events: Vec<&str> = v["events"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|e| e["event"].as_str().unwrap())
+            .collect();
+        assert_eq!(events.first().copied(), Some("started"));
+        assert_eq!(events.last().copied(), Some("final"));
+    }
+
+    /// A3b: a busy session answers 409 without touching the model, and an
+    /// unknown session's progress is an empty done feed (no 404 fishing).
+    #[test]
+    fn agent_ask_busy_session_and_unknown_progress() {
+        let vault = portal_vault("agent-busy", "50-Inbox/03-Processed/good.md", "body\n");
+        let mut st = state(vault.clone(), None);
+        st.ask_agent = true;
+        st.ask_client = Some(scripted_factory("unused", Duration::from_millis(5)));
+        // Hold the session lock like an in-flight turn would.
+        let store = ovp_memory::agent_transcript::SessionStore::open(
+            &vault.join(".ovp/ask-sessions"),
+            "held",
+        )
+        .unwrap();
+        let _lock = store.lock().unwrap();
+        let resp = ask(&st, r#"{"question":"q","chat":"held"}"#);
+        assert_eq!(resp.status_code(), 409);
+
+        let resp = dispatch(&st, Method::Get, "/api/ask/progress?chat=nope", "");
+        let v: serde_json::Value =
+            serde_json::from_slice(resp.into_reader().get_ref()).unwrap();
+        assert_eq!(v["done"], true);
+        assert_eq!(v["events"].as_array().unwrap().len(), 0);
+    }
+
+    /// A3b: flag OFF keeps the legacy path — the response carries the legacy
+    /// shape (no agent marker), proving the default is byte-compatible.
+    #[test]
+    fn agent_flag_off_serves_legacy_shape() {
+        let vault = portal_vault("agent-off", "50-Inbox/03-Processed/good.md", "body\n");
+        let mut st = state(vault, None);
+        st.ask_client = Some(scripted_factory("plain answer", Duration::from_millis(5)));
+        let resp = ask(&st, r#"{"question":"q"}"#);
+        assert_eq!(resp.status_code(), 200);
+        let v: serde_json::Value =
+            serde_json::from_slice(resp.into_reader().get_ref()).unwrap();
+        assert!(v.get("agent").is_none(), "legacy path must not carry the agent marker");
+    }
+
     #[test]
     fn ask_does_not_block_the_accept_loop() {
         use std::io::{Read, Write};

--- a/evolution/candidates/ask_product_wiring-v1.json
+++ b/evolution/candidates/ask_product_wiring-v1.json
@@ -1,0 +1,31 @@
+{
+  "kind": "ovp.evolution.candidate/v1",
+  "id": "ask_product_wiring-v1",
+  "base_version": "none",
+  "target_version": "v1",
+  "surface": "runtime",
+  "component": "runtime.ask_product_wiring",
+  "hypothesis": "RUNTIME surface: a FLAG-GATED agent path inside POST /api/ask (ServeConfig.ask_agent, default OFF — the legacy single-shot path stays the default byte-for-byte) that runs the A1b loop with the A2 VaultTools and the A3a policy over the EXISTING AskClientFactory, returning the A0 §3.7 response shape (answer, resolved citations, runtime coverage, compact tool_trace, chat/turn ids, stopped_reason) plus a minimal polling progress feed (started → tool_started/tool_finished → final|error) from an in-memory per-session slot. Predicted: flag-off behavior is unchanged (existing ask tests untouched); flag-on serves a full agent turn against a scripted client in tests, with citations resolved against the real ledger/index and coverage computed by the executor, never the model.",
+  "predicted_delta": {
+    "coverage": "the product ask can now search, drill, and read originals in one turn; the response carries honest per-layer coverage instead of a bag-of-evidence guess",
+    "crystal_provenance": "citations are RESOLVED receipts: [claim:<key>] verified against active ledger records (link to the claim anchor), [source:<id>] against the index (link to /library) — unresolvable references surface as verified:false, never silently dropped",
+    "operational_reliability": "the agent deadline is derived UNDER the HTTP guard (guard minus margin), so a turn always concludes and commits its transcript before the guard 504s; progress is observable mid-turn via the slot"
+  },
+  "guardrails": {
+    "flag_off_bytes_unchanged": "with ask_agent=false (default), POST /api/ask takes the legacy path — existing ask tests pass unmodified; the agent path is reachable only via the explicit flag",
+    "deadline_under_guard": "AgentConfig.deadline = ask HTTP guard minus a safety margin (never below a floor), so the loop's timeout fires and the turn commits BEFORE the transport guard abandons the request — no orphaned in-flight turn behind a 504",
+    "citations_resolved_not_trusted": "the answer's [claim:…]/[source:…] markers are parsed and resolved against the ledger/index by the SERVER; resolution status (verified) and link targets come from runtime lookups, never model output",
+    "coverage_from_executor": "the response coverage field is VaultTools::coverage() — the model cannot self-report exhaustiveness",
+    "progress_slot_bounded": "the per-session progress slot is in-memory, capped in event count, replaced at each turn start, and marked done at turn end; an unknown session polls to an empty done feed (no 404 fishing)",
+    "session_id_discipline": "the chat id must pass the store's session-id validation; absent ids get a generated timestamped id returned in the response — the client can continue the session with it",
+    "caveated_source_ids": "search_claims hits (durable AND caveated) now carry resolved source_ids via the packs join (case_id → source sha), closing the A3a gate finding that caveated citations had no followable path — the policy upgrade to cite them is a later prompt candidate",
+    "progress_hook_additive": "the engine gains run_agent_turn_with_progress (optional sink, emitting started/tool_started/tool_finished/final) — run_agent_turn delegates with None; all existing engine tests pass unchanged"
+  },
+  "eval_plan": {
+    "replay_set": "server tests with a scripted ModelClient factory: flag-on 0-tool turn → 200 with answer/stopped_reason=final/coverage/turn_id and a committed transcript; tool turn → trace + coverage reflect execution; citation resolution (real key verified:true + linked, fake key verified:false); progress feed sequence + done; unknown-session progress = empty done; flag-off = legacy (existing tests). ovp-memory tests: progress event ordering; source_ids enrichment on durable + caveated hits",
+    "paired_sources": 0,
+    "soak": false
+  },
+  "rollback": "Flip the flag off (default) — the legacy path never moved; the agent path additions are additive handlers + an engine hook with a None default.",
+  "ablation_required": false
+}

--- a/evolution/components.json
+++ b/evolution/components.json
@@ -185,6 +185,17 @@
         "crystal_provenance",
         "operational_reliability"
       ]
+    },
+    {
+      "id": "runtime.ask_product_wiring",
+      "surface": "runtime",
+      "current_version": "none",
+      "file": "crates/ovp-server/src/lib.rs",
+      "quality_buckets": [
+        "coverage",
+        "operational_reliability",
+        "crystal_provenance"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Fifth implementation Candidate of the Vault Agent program (`ovp2 evolve validate` ✓). RUNTIME surface.

**The wiring**: with `ServeConfig.ask_agent` (CLI: `OVP_ASK_AGENT=1`; desktop stays false until A3d), POST /api/ask runs the A1b loop + A2 VaultTools + A3a policy over the EXISTING AskClientFactory. Flag off (default) = legacy single-shot path byte-for-byte (test-pinned).

**Response** (A0 §3.7): answer; server-resolved citation receipts (claim keys vs active ledger → knowledge anchor; source ids vs index → /library; fabrications verified:false); executor-computed coverage; compact tool_trace; chat/turn ids; stopped_reason; usage. **Progress**: additive engine hook emits started/tool_started/tool_finished/final into a bounded per-session feed polled at GET /api/ask/progress. **Safety**: agent deadline derives UNDER the HTTP guard (turn always commits before a 504); busy session = 409 without touching the model.

Also closes the A3a gate finding: search_claims hits (durable + caveated) now carry resolved source_ids via the packs join.

Tests: full-turn shape/receipts/coverage/transcript/progress, 409 busy, unknown-progress, flag-off legacy, engine progress order, enrichment. Workspace tests + clippy clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an agent-powered `POST /api/ask` mode behind a configuration flag.
  - Added real-time per-session progress updates via `GET /api/ask/progress`, including ordered tool execution events.
  - Enhanced ask-agent responses with turn/session metadata, stopped reason, coverage, tool trace, usage, and improved citation verification.
  - Updated `search_claims` results to include resolved `source_ids` for both durable and caveated hits.
- **Compatibility**
  - Legacy ask behavior remains unchanged when agent mode is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->