### PR TITLE
feat(ask): A3c — live agent trail + coverage receipts in the portal

### DIFF
--- a/console-ui/src/design/portal.css
+++ b/console-ui/src/design/portal.css
@@ -1538,6 +1538,120 @@ body {
 .chat-a.chat-pending {
   font-size: var(--ovp-text-sm);
 }
+/* ---- agent live trail + receipts (A3c) ---- */
+.ask-trail {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: var(--ovp-text-sm);
+}
+.ask-step {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  min-width: 0;
+}
+.ask-step-dot {
+  flex: none;
+  align-self: center;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--border-strong);
+}
+.ask-step.running .ask-step-dot {
+  background: var(--accent);
+  animation: ask-dot-pulse 1.1s ease-in-out infinite;
+}
+.ask-step.ok .ask-step-dot {
+  background: var(--success);
+}
+.ask-step.err .ask-step-dot {
+  background: var(--danger);
+}
+@keyframes ask-dot-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .ask-step.running .ask-step-dot {
+    animation: none;
+  }
+}
+.ask-step-tool {
+  font-size: var(--ovp-text-xs);
+  color: var(--muted);
+}
+.ask-step-args {
+  font-size: var(--ovp-text-xs);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ask-agent-meta {
+  margin-top: 0.7rem;
+  padding-top: 0.6rem;
+  border-top: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.ask-stop-note {
+  font-size: var(--ovp-text-sm);
+  color: var(--warn-text);
+  background: var(--warn-bg);
+  border: 1px solid var(--warn-border);
+  border-radius: var(--ovp-radius-sm);
+  padding: 0.4rem 0.6rem;
+}
+.ask-coverage {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+.cov-pill {
+  display: inline-block;
+  padding: 0.1rem 0.45rem;
+  border-radius: var(--ovp-radius-pill);
+  font-size: var(--ovp-text-xs);
+  font-weight: 600;
+  white-space: nowrap;
+  color: var(--muted);
+  border: 1px solid var(--border-strong);
+  background: transparent;
+}
+.cov-pill.complete {
+  color: var(--success);
+  border-color: var(--success);
+  background: color-mix(in srgb, var(--success) 10%, transparent);
+}
+.cov-pill.partial {
+  color: var(--c-4);
+  border-color: var(--c-4);
+  background: color-mix(in srgb, var(--c-4) 10%, transparent);
+}
+.cov-pill.unavailable,
+.cov-pill.failed {
+  color: var(--danger);
+  border-color: var(--danger);
+  background: color-mix(in srgb, var(--danger) 10%, transparent);
+}
+.ask-trail-details summary {
+  cursor: pointer;
+}
+.ask-trail-details[open] summary {
+  margin-bottom: 0.4rem;
+}
+.chat-error .ask-trail {
+  margin-bottom: 0.6rem;
+  color: var(--text);
+}
 /* Answer bodies render through the markdown reading view (gutterless) —
    the renderer owns whitespace, so no pre-wrap here. */
 .answer-text {

--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -365,6 +365,31 @@ export const en = {
   'ask.errTimeout':
     'No answer within the time limit. The request was not cancelled — if the model finishes, the saved transcript still appears in History.',
   'ask.errGeneric': 'Ask failed — is the server running against a vault?',
+  // agent live trail + receipts (A3c)
+  'ask.trailConnecting': 'Connecting to the vault agent…',
+  'ask.trailThinking': 'Thinking…',
+  'ask.trailComposing': 'Writing the answer…',
+  'ask.trailSearching': 'Searching',
+  'ask.trailReading': 'Reading',
+  'ask.trailListing': 'Listing',
+  'ask.trailRunning': 'Running',
+  'ask.trailTitle': 'Agent steps',
+  'ask.trailFailedStep': 'failed',
+  'ask.coverageTitle': 'Searched',
+  'ask.covClaims': 'conclusions',
+  'ask.covSources': 'sources',
+  'ask.covBody': 'full text',
+  'ask.covComplete': 'complete',
+  'ask.covPartial': 'partial',
+  'ask.covNotQueried': 'not searched',
+  'ask.covUnavailable': 'unavailable',
+  'ask.covFailed': 'failed',
+  'ask.stopTimeout':
+    'The agent ran out of time this turn — below is what it completed before stopping.',
+  'ask.stopToolError': 'A vault tool kept failing — the answer may be incomplete.',
+  'ask.stopModelError': 'The model call failed mid-turn — the answer may be incomplete.',
+  'ask.stopMaxRounds':
+    'The agent reached its round limit and answered with what it had.',
 
   // system page (B5)
   'system.help':

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -340,6 +340,29 @@ export const zh: Record<keyof typeof en, string> = {
   'ask.errTimeout':
     '在时限内没有等到回答。请求并未被取消——如果模型最终完成，保存的会话仍会出现在历史中。',
   'ask.errGeneric': '提问失败——服务是否已连接 vault？',
+  // agent live trail + receipts (A3c)
+  'ask.trailConnecting': '正在连接 vault agent…',
+  'ask.trailThinking': '思考中…',
+  'ask.trailComposing': '正在组织答案…',
+  'ask.trailSearching': '正在检索',
+  'ask.trailReading': '正在读取',
+  'ask.trailListing': '正在列出',
+  'ask.trailRunning': '正在执行',
+  'ask.trailTitle': '执行轨迹',
+  'ask.trailFailedStep': '失败',
+  'ask.coverageTitle': '检索范围',
+  'ask.covClaims': '结论',
+  'ask.covSources': '来源',
+  'ask.covBody': '全文',
+  'ask.covComplete': '完整',
+  'ask.covPartial': '部分',
+  'ask.covNotQueried': '未检索',
+  'ask.covUnavailable': '不可用',
+  'ask.covFailed': '失败',
+  'ask.stopTimeout': '本轮时间用尽——以下是中止前已完成的部分。',
+  'ask.stopToolError': 'vault 工具连续失败——回答可能不完整。',
+  'ask.stopModelError': '模型调用中途失败——回答可能不完整。',
+  'ask.stopMaxRounds': 'agent 达到轮次上限，用已有信息作答。',
 
   // system page (B5)
   'system.help':

--- a/console-ui/src/lib/api.ts
+++ b/console-ui/src/lib/api.ts
@@ -1,4 +1,5 @@
 import type {
+  AskProgress,
   AskResponse,
   ChatEntry,
   ClaimDetail,
@@ -324,6 +325,14 @@ export async function postAsk(
     throw new AskError(res.status, message, code);
   }
   return res.json() as Promise<AskResponse>;
+}
+
+/** GET /api/ask/progress — live mid-turn feed for an agent ask. Unknown
+ * sessions answer an empty done feed, so polling is always safe. */
+export function fetchAskProgress(chat: string): Promise<AskProgress> {
+  return fetchJson<AskProgress>(
+    `/api/ask/progress?chat=${encodeURIComponent(chat)}`,
+  );
 }
 
 /** Saved ask transcripts, newest first. Empty on the published site. */

--- a/console-ui/src/lib/api.ts
+++ b/console-ui/src/lib/api.ts
@@ -327,6 +327,13 @@ export async function postAsk(
   return res.json() as Promise<AskResponse>;
 }
 
+/** GET /api/ask/status — agent-mode discovery. Unlike /api/model this
+ * never needs an index, matching the agent path itself. */
+export function fetchAskStatus(): Promise<{ agent: boolean }> {
+  if (STATIC_MODE) return Promise.resolve({ agent: false });
+  return fetchJson<{ agent: boolean }>('/api/ask/status');
+}
+
 /** GET /api/ask/progress — live mid-turn feed for an agent ask. Unknown
  * sessions answer an empty done feed, so polling is always safe. */
 export function fetchAskProgress(chat: string): Promise<AskProgress> {

--- a/console-ui/src/lib/types.ts
+++ b/console-ui/src/lib/types.ts
@@ -247,6 +247,46 @@ export interface AskResponse {
   intent?: string | null;
   /** Stem of the saved `.ovp/chats/<name>.md` transcript. */
   chat: string | null;
+  // ---- agent-path extras (OVP_ASK_AGENT=1; absent on the legacy path) ----
+  /** True when the answer came from the tool-loop agent. */
+  agent?: boolean;
+  /** Executor-computed per-layer coverage (claims/sources/body →
+   * not_queried|complete|partial|unavailable|failed). Null on an
+   * idempotent replay (coverage is an execution artifact). */
+  coverage?: Record<string, string> | null;
+  /** Compact per-call trail of what the agent actually executed. */
+  tool_trace?: AskTraceEntry[];
+  /** final | need_user | refusal | max_rounds | timeout | tool_error | model_error. */
+  stopped_reason?: string;
+  turn_id?: string;
+  usage?: { input_tokens: number; output_tokens: number };
+}
+
+/** One executed tool call in an agent turn's caller-facing trail. */
+export interface AskTraceEntry {
+  tool: string;
+  summary: string;
+  ok: boolean;
+}
+
+/** One event from GET /api/ask/progress — the live mid-turn feed. */
+export interface AskProgressEvent {
+  event: string;
+  tool?: string;
+  tool_call_id?: string;
+  /** Display narration for tool_started ("query=… · limit=…"). */
+  args?: string | null;
+  summary?: string;
+  ok?: boolean;
+  turn_id?: string;
+  stopped_reason?: string;
+}
+
+export interface AskProgress {
+  events: AskProgressEvent[];
+  done: boolean;
+  /** False while the turn is still in admission (setup/lock phase). */
+  started: boolean;
 }
 
 /** /api/chats entry — `mtime` is unix seconds; the client formats it. */
@@ -402,6 +442,9 @@ export interface IndexModel {
   /** Live-server overlay: acknowledged attention items (hidden until the
    * source's status changes). Absent in static snapshots. */
   attention_acks?: { sha: string; status: string }[];
+  /** Live-server overlay: the tool-loop agent serves /api/ask. The SPA
+   * pre-generates a chat id and polls the progress feed from turn 1. */
+  ask_agent?: boolean;
   schema: string;
   date: string;
   /** Wall-clock build instant (UTC RFC3339). Absent on pre-P1 indexes — the

--- a/console-ui/src/pages/AskPage.tsx
+++ b/console-ui/src/pages/AskPage.tsx
@@ -602,12 +602,19 @@ export default function AskPage() {
       }));
     setTurns((prev) => [...prev, { question, response: null, errorKey: null }]);
     void (async () => {
-      // Resolve agent mode BEFORE posting — a first ask that races the
-      // discovery fetch must still mint its chat id and get a live trail.
-      let agent = askStatus;
-      if (agent == null) {
-        agent = await (askStatusPromise.current ?? Promise.resolve(modelAgent));
-      }
+      // Resolve agent mode PER SUBMISSION — a fresh read tracks server
+      // restarts with the flag flipped; the mount-time discovery and the
+      // /api/model overlay only serve as fallbacks when the read fails.
+      const agent = await fetchAskStatus()
+        .then((s) => {
+          setAskStatus(s.agent);
+          return s.agent;
+        })
+        .catch(
+          async () =>
+            askStatus ??
+            (await (askStatusPromise.current ?? Promise.resolve(modelAgent))),
+        );
       // Agent path: mint the session id client-side so the progress feed
       // is pollable from the FIRST turn (the server honors supplied ids).
       let chat = sessionChat;
@@ -632,8 +639,14 @@ export default function AskPage() {
       .catch((err: unknown) => {
         const errorKey = errorKeyFor(err);
         // Keep what the agent DID before failing — an honest partial trail
-        // beats a bare error line.
-        const trail = liveRef.current?.events;
+        // beats a bare error line. But ONLY when the failed request was
+        // actually admitted: a 429 (busy/admission-capped) or 400
+        // (validation) POST never owned the session, so any polled feed
+        // belongs to a DIFFERENT turn and must not be attributed here.
+        const admitted = !(
+          err instanceof AskError && (err.status === 429 || err.status === 400)
+        );
+        const trail = admitted ? liveRef.current?.events : undefined;
         setTurns((prev) =>
           prev.map((turn, i) =>
             i === prev.length - 1

--- a/console-ui/src/pages/AskPage.tsx
+++ b/console-ui/src/pages/AskPage.tsx
@@ -16,6 +16,7 @@ import { useI18n, type MsgKey } from '../i18n';
 import {
   AskError,
   fetchAskProgress,
+  fetchAskStatus,
   fetchChatMarkdown,
   fetchChats,
   postAsk,
@@ -449,10 +450,19 @@ export default function AskPage() {
   /** Stem of the live multi-turn session (first successful answer's `chat`). */
   const [sessionChat, setSessionChat] = useState<string | null>(null);
 
-  // Agent mode: the server advertises the tool-loop path via /api/model —
-  // the SPA then mints the session id itself and polls the live feed.
+  // Agent mode: discovered via /api/ask/status (index-free, like the agent
+  // path itself) with the /api/model overlay as fallback — the SPA then
+  // mints the session id itself and polls the live feed.
   const { model } = useModel();
-  const agentMode = model?.ask_agent === true;
+  const [askStatus, setAskStatus] = useState<boolean | null>(null);
+  useEffect(() => {
+    fetchAskStatus()
+      .then((s) => setAskStatus(s.agent))
+      .catch(() => {
+        /* stay on the /api/model fallback */
+      });
+  }, []);
+  const agentMode = askStatus ?? model?.ask_agent === true;
   const [live, setLive] = useState<AskProgress | null>(null);
   const liveRef = useRef<AskProgress | null>(null);
   /** Session the CURRENT in-flight ask polls against (null = legacy path). */
@@ -541,10 +551,19 @@ export default function AskPage() {
     const chat = pollChatRef.current;
     if (!chat) return;
     let cancelled = false;
+    // On turn N+1 the map may still hold turn N's COMPLETED feed until this
+    // turn's admission registers (or never, if the POST is rejected first).
+    // Accept nothing until a live (not-done) feed proves it is ours — a
+    // stale trail must never be attributed to this turn.
+    let seenLive = false;
     const tick = () => {
       fetchAskProgress(chat)
         .then((p) => {
           if (cancelled) return;
+          if (!seenLive) {
+            if (p.done) return;
+            seenLive = true;
+          }
           liveRef.current = p;
           setLive(p);
         })

--- a/console-ui/src/pages/AskPage.tsx
+++ b/console-ui/src/pages/AskPage.tsx
@@ -452,21 +452,28 @@ export default function AskPage() {
 
   // Agent mode: discovered via /api/ask/status (index-free, like the agent
   // path itself) with the /api/model overlay as fallback — the SPA then
-  // mints the session id itself and polls the live feed.
+  // mints the session id itself and polls the live feed. `submit` AWAITS
+  // the in-flight discovery, so a first ask racing it still gets a trail.
   const { model } = useModel();
   const [askStatus, setAskStatus] = useState<boolean | null>(null);
+  const askStatusPromise = useRef<Promise<boolean> | null>(null);
+  const modelAgent = model?.ask_agent === true;
   useEffect(() => {
-    fetchAskStatus()
-      .then((s) => setAskStatus(s.agent))
-      .catch(() => {
-        /* stay on the /api/model fallback */
-      });
+    askStatusPromise.current = fetchAskStatus()
+      .then((s) => {
+        setAskStatus(s.agent);
+        return s.agent;
+      })
+      .catch(() => modelAgent);
+    // Discovery runs once; the fallback reads whatever /api/model said by then.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-  const agentMode = askStatus ?? model?.ask_agent === true;
   const [live, setLive] = useState<AskProgress | null>(null);
   const liveRef = useRef<AskProgress | null>(null);
-  /** Session the CURRENT in-flight ask polls against (null = legacy path). */
-  const pollChatRef = useRef<string | null>(null);
+  /** Session the CURRENT in-flight ask polls against (null = legacy path).
+   * State (not a ref) so the polling effect re-runs when a submission
+   * resolves agent mode asynchronously. */
+  const [pollChat, setPollChat] = useState<string | null>(null);
 
   const [chats, setChats] = useState<ChatEntry[]>([]);
   const [savedTurns, setSavedTurns] = useState<Turn[] | null>(null);
@@ -548,7 +555,7 @@ export default function AskPage() {
   // trail is the entire point of the wait.
   useEffect(() => {
     if (!pending) return;
-    const chat = pollChatRef.current;
+    const chat = pollChat;
     if (!chat) return;
     let cancelled = false;
     // On turn N+1 the map may still hold turn N's COMPLETED feed until this
@@ -577,21 +584,14 @@ export default function AskPage() {
       cancelled = true;
       window.clearInterval(id);
     };
-  }, [pending]);
+  }, [pending, pollChat]);
 
   const submit = () => {
     const question = draft.trim();
     if (!question || pending || openChat) return;
     setDraft('');
     setPending(true);
-    // Agent path: mint the session id client-side so the progress feed is
-    // pollable from the FIRST turn (the server honors supplied ids).
-    let chat = sessionChat;
-    if (agentMode && !chat) {
-      chat = genChatId();
-      setSessionChat(chat);
-    }
-    pollChatRef.current = agentMode ? chat : null;
+    setPollChat(null);
     liveRef.current = null;
     setLive(null);
     const history = turns
@@ -601,7 +601,23 @@ export default function AskPage() {
         answer: t.response!.answer,
       }));
     setTurns((prev) => [...prev, { question, response: null, errorKey: null }]);
-    postAsk(question, { chat, history })
+    void (async () => {
+      // Resolve agent mode BEFORE posting — a first ask that races the
+      // discovery fetch must still mint its chat id and get a live trail.
+      let agent = askStatus;
+      if (agent == null) {
+        agent = await (askStatusPromise.current ?? Promise.resolve(modelAgent));
+      }
+      // Agent path: mint the session id client-side so the progress feed
+      // is pollable from the FIRST turn (the server honors supplied ids).
+      let chat = sessionChat;
+      if (agent && !chat) {
+        chat = genChatId();
+        setSessionChat(chat);
+      }
+      setPollChat(agent ? chat : null);
+      return postAsk(question, { chat, history });
+    })()
       .then((response) => {
         setTurns((prev) =>
           prev.map((turn, i) =>
@@ -666,7 +682,7 @@ export default function AskPage() {
   // Live agent activity for the in-flight turn. Before the first poll lands
   // (or on the legacy path) the thread falls back to the static pending text.
   let liveTrail: React.ReactNode = null;
-  if (pending && agentMode) {
+  if (pending && pollChat) {
     if (live) {
       const steps = stepsFromEvents(live.events);
       liveTrail = <AgentTrail steps={steps} phase={livePhase(live, steps)} />;

--- a/console-ui/src/pages/AskPage.tsx
+++ b/console-ui/src/pages/AskPage.tsx
@@ -13,7 +13,14 @@ import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { EmptyState, PageHelp, conceptTipKey } from '../components/ui';
 import { useI18n, type MsgKey } from '../i18n';
-import { AskError, fetchChatMarkdown, fetchChats, postAsk } from '../lib/api';
+import {
+  AskError,
+  fetchAskProgress,
+  fetchChatMarkdown,
+  fetchChats,
+  postAsk,
+} from '../lib/api';
+import { useModel } from '../model';
 import {
   citationsInOrder,
   citeLinkTarget,
@@ -22,13 +29,23 @@ import {
 } from '../lib/chatTranscript';
 import { isReactImeComposing } from '../lib/ime';
 import { MarkdownView, type InlineMarker } from '../lib/markdown';
-import type { AskCitation, AskResponse, ChatEntry } from '../lib/types';
+import type {
+  AskCitation,
+  AskProgress,
+  AskProgressEvent,
+  AskResponse,
+  AskTraceEntry,
+  ChatEntry,
+} from '../lib/types';
 
 interface Turn {
   question: string;
   response: AskResponse | null;
   /** i18n key of the failure — a turn has either a response or an error. */
   errorKey: MsgKey | null;
+  /** Live-trail snapshot kept when an AGENT turn failed mid-flight, so the
+   * user still sees what ran before the error. */
+  progress?: AskProgressEvent[];
 }
 
 /** `[claim:…] [card:…] [unit:…]` tokens plus the bare `[ck-…]` form models
@@ -63,6 +80,185 @@ function citationsFromAnswerText(answer: string): AskCitation[] {
       verified: true,
     };
   });
+}
+
+// ---- agent live trail + receipts (A3c) ----
+
+/** Session id the SPA mints for an agent conversation so it can poll the
+ * progress feed from turn 1 (charset must satisfy the server's
+ * session-id validation: alphanumeric + dash, ≤64). */
+function genChatId(): string {
+  return `web-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/** Narration verb for a tool name — display only, tools stay canonical. */
+function toolVerbKey(tool: string): MsgKey {
+  if (tool.startsWith('search')) return 'ask.trailSearching';
+  if (tool.startsWith('get') || tool.startsWith('read')) return 'ask.trailReading';
+  if (tool.startsWith('list')) return 'ask.trailListing';
+  return 'ask.trailRunning';
+}
+
+interface TrailStep {
+  tool: string;
+  args: string | null;
+  status: 'running' | 'ok' | 'err';
+  summary?: string;
+}
+
+/** Fold started/finished event pairs into per-call steps (order preserved). */
+function stepsFromEvents(events: AskProgressEvent[]): TrailStep[] {
+  const steps: TrailStep[] = [];
+  const open = new Map<string, number>();
+  for (const ev of events) {
+    if (ev.event === 'tool_started' && ev.tool) {
+      if (ev.tool_call_id) open.set(ev.tool_call_id, steps.length);
+      steps.push({ tool: ev.tool, args: ev.args ?? null, status: 'running' });
+    } else if (ev.event === 'tool_finished' && ev.tool_call_id) {
+      const i = open.get(ev.tool_call_id);
+      if (i !== undefined) {
+        steps[i] = {
+          ...steps[i],
+          status: ev.ok === false ? 'err' : 'ok',
+          summary: ev.summary,
+        };
+      }
+    }
+  }
+  return steps;
+}
+
+function stepsFromTrace(trace: AskTraceEntry[]): TrailStep[] {
+  return trace.map((t) => ({
+    tool: t.tool,
+    args: null,
+    status: t.ok ? ('ok' as const) : ('err' as const),
+    summary: t.summary,
+  }));
+}
+
+/** What the agent is doing when no tool call is in flight. */
+type TrailPhase = 'connecting' | 'thinking' | 'composing' | null;
+
+function livePhase(progress: AskProgress, steps: TrailStep[]): TrailPhase {
+  if (!progress.started) return 'connecting';
+  if (steps.some((s) => s.status === 'running')) return null;
+  if (steps.length === 0) return 'thinking';
+  if (!progress.done) return 'composing';
+  return null;
+}
+
+function AgentTrail({
+  steps,
+  phase,
+}: {
+  steps: TrailStep[];
+  phase: TrailPhase;
+}) {
+  const { t } = useI18n();
+  const phaseKey: MsgKey | null =
+    phase === 'connecting'
+      ? 'ask.trailConnecting'
+      : phase === 'thinking'
+        ? 'ask.trailThinking'
+        : phase === 'composing'
+          ? 'ask.trailComposing'
+          : null;
+  return (
+    <div className="ask-trail">
+      {steps.map((s, i) => (
+        <div
+          key={`s${i}`}
+          className={`ask-step ${s.status}`}
+          title={s.summary || undefined}
+        >
+          <span className="ask-step-dot" aria-hidden />
+          <span>{t(toolVerbKey(s.tool))}</span>
+          <span className="mono ask-step-tool">{s.tool}</span>
+          {s.args && <span className="mono muted ask-step-args">{s.args}</span>}
+          {s.status === 'err' && (
+            <span className="pill failed">{t('ask.trailFailedStep')}</span>
+          )}
+        </div>
+      ))}
+      {phaseKey && (
+        <div className="ask-step running">
+          <span className="ask-step-dot" aria-hidden />
+          <span className="muted">{t(phaseKey)}</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+const COV_LAYERS: [string, MsgKey][] = [
+  ['claims', 'ask.covClaims'],
+  ['sources', 'ask.covSources'],
+  ['body', 'ask.covBody'],
+];
+const COV_STATE: Record<string, MsgKey> = {
+  complete: 'ask.covComplete',
+  partial: 'ask.covPartial',
+  not_queried: 'ask.covNotQueried',
+  unavailable: 'ask.covUnavailable',
+  failed: 'ask.covFailed',
+};
+
+function CoverageBadges({ coverage }: { coverage: Record<string, string> }) {
+  const { t } = useI18n();
+  return (
+    <div className="ask-coverage">
+      <span className="tiny muted">{t('ask.coverageTitle')}</span>
+      {COV_LAYERS.map(([key, labelKey]) => {
+        const state = coverage[key];
+        if (!state) return null;
+        const stateKey = COV_STATE[state];
+        return (
+          <span key={key} className={`cov-pill ${state}`}>
+            {t(labelKey)} · {stateKey ? t(stateKey) : state}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+/** Warning line for turns the agent could not finish cleanly. `final`,
+ * `need_user`, `refusal` speak for themselves in the answer text. */
+function stopNoticeKey(reason: string | undefined): MsgKey | null {
+  switch (reason) {
+    case 'timeout':
+      return 'ask.stopTimeout';
+    case 'tool_error':
+      return 'ask.stopToolError';
+    case 'model_error':
+      return 'ask.stopModelError';
+    case 'max_rounds':
+      return 'ask.stopMaxRounds';
+    default:
+      return null;
+  }
+}
+
+/** Receipts under an agent answer: stop notice, coverage, collapsed trail. */
+function AgentMeta({ response }: { response: AskResponse }) {
+  const { t } = useI18n();
+  const stopKey = stopNoticeKey(response.stopped_reason);
+  const trace = response.tool_trace ?? [];
+  return (
+    <div className="ask-agent-meta">
+      {stopKey && <div className="ask-stop-note">{t(stopKey)}</div>}
+      {response.coverage && <CoverageBadges coverage={response.coverage} />}
+      {trace.length > 0 && (
+        <details className="ask-trail-details">
+          <summary className="tiny muted">
+            {t('ask.trailTitle')} · {trace.length}
+          </summary>
+          <AgentTrail steps={stepsFromTrace(trace)} phase={null} />
+        </details>
+      )}
+    </div>
+  );
 }
 
 /** Answer body rendered as markdown with numbered citation markers. */
@@ -167,6 +363,7 @@ function CitationPanel({
 function ChatThread({
   turns,
   pending,
+  liveTrail,
   onHover,
   onOpen,
   threadRef,
@@ -174,6 +371,8 @@ function ChatThread({
 }: {
   turns: Turn[];
   pending: boolean;
+  /** Live agent activity rendered in place of the static pending text. */
+  liveTrail?: React.ReactNode;
   onHover: (id: string | null) => void;
   onOpen: (cit: AskCitation) => void;
   threadRef: React.RefObject<HTMLDivElement | null>;
@@ -206,16 +405,29 @@ function ChatThread({
                   })}
                 </div>
               )}
+              {turn.response.agent && <AgentMeta response={turn.response} />}
             </div>
           )}
           {turn.errorKey && (
-            <div className="chat-a chat-error">{t(turn.errorKey)}</div>
+            <div className="chat-a chat-error">
+              {turn.progress && turn.progress.length > 0 && (
+                <AgentTrail
+                  steps={stepsFromEvents(turn.progress)}
+                  phase={null}
+                />
+              )}
+              {t(turn.errorKey)}
+            </div>
           )}
           {!turn.response &&
             !turn.errorKey &&
             i === turns.length - 1 &&
             pending && (
-              <div className="chat-a chat-pending muted">{t('ask.pending')}</div>
+              <div className="chat-a chat-pending">
+                {liveTrail ?? (
+                  <span className="muted">{t('ask.pending')}</span>
+                )}
+              </div>
             )}
         </div>
       ))}
@@ -236,6 +448,15 @@ export default function AskPage() {
   const [hoverId, setHoverId] = useState<string | null>(null);
   /** Stem of the live multi-turn session (first successful answer's `chat`). */
   const [sessionChat, setSessionChat] = useState<string | null>(null);
+
+  // Agent mode: the server advertises the tool-loop path via /api/model —
+  // the SPA then mints the session id itself and polls the live feed.
+  const { model } = useModel();
+  const agentMode = model?.ask_agent === true;
+  const [live, setLive] = useState<AskProgress | null>(null);
+  const liveRef = useRef<AskProgress | null>(null);
+  /** Session the CURRENT in-flight ask polls against (null = legacy path). */
+  const pollChatRef = useRef<string | null>(null);
 
   const [chats, setChats] = useState<ChatEntry[]>([]);
   const [savedTurns, setSavedTurns] = useState<Turn[] | null>(null);
@@ -303,7 +524,7 @@ export default function AskPage() {
   // Keep the newest turn in view while a conversation grows.
   useEffect(() => {
     threadRef.current?.scrollTo({ top: threadRef.current.scrollHeight });
-  }, [turns, pending, savedTurns, openChat]);
+  }, [turns, pending, live, savedTurns, openChat]);
 
   const startNewConversation = () => {
     setTurns([]);
@@ -313,11 +534,47 @@ export default function AskPage() {
     composerRef.current?.focus();
   };
 
+  // Poll the progress feed while an agent ask is in flight — the live
+  // trail is the entire point of the wait.
+  useEffect(() => {
+    if (!pending) return;
+    const chat = pollChatRef.current;
+    if (!chat) return;
+    let cancelled = false;
+    const tick = () => {
+      fetchAskProgress(chat)
+        .then((p) => {
+          if (cancelled) return;
+          liveRef.current = p;
+          setLive(p);
+        })
+        .catch(() => {
+          /* transient poll failures never disturb the ask itself */
+        });
+    };
+    tick();
+    const id = window.setInterval(tick, 700);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, [pending]);
+
   const submit = () => {
     const question = draft.trim();
     if (!question || pending || openChat) return;
     setDraft('');
     setPending(true);
+    // Agent path: mint the session id client-side so the progress feed is
+    // pollable from the FIRST turn (the server honors supplied ids).
+    let chat = sessionChat;
+    if (agentMode && !chat) {
+      chat = genChatId();
+      setSessionChat(chat);
+    }
+    pollChatRef.current = agentMode ? chat : null;
+    liveRef.current = null;
+    setLive(null);
     const history = turns
       .filter((t) => t.response?.answer)
       .map((t) => ({
@@ -325,7 +582,7 @@ export default function AskPage() {
         answer: t.response!.answer,
       }));
     setTurns((prev) => [...prev, { question, response: null, errorKey: null }]);
-    postAsk(question, { chat: sessionChat, history })
+    postAsk(question, { chat, history })
       .then((response) => {
         setTurns((prev) =>
           prev.map((turn, i) =>
@@ -339,9 +596,18 @@ export default function AskPage() {
       })
       .catch((err: unknown) => {
         const errorKey = errorKeyFor(err);
+        // Keep what the agent DID before failing — an honest partial trail
+        // beats a bare error line.
+        const trail = liveRef.current?.events;
         setTurns((prev) =>
           prev.map((turn, i) =>
-            i === prev.length - 1 ? { ...turn, errorKey } : turn,
+            i === prev.length - 1
+              ? {
+                  ...turn,
+                  errorKey,
+                  progress: trail && trail.length > 0 ? trail : undefined,
+                }
+              : turn,
           ),
         );
       })
@@ -377,6 +643,18 @@ export default function AskPage() {
     () => (openChat ? chats.find((c) => c.name === openChat) : undefined),
     [chats, openChat],
   );
+
+  // Live agent activity for the in-flight turn. Before the first poll lands
+  // (or on the legacy path) the thread falls back to the static pending text.
+  let liveTrail: React.ReactNode = null;
+  if (pending && agentMode) {
+    if (live) {
+      const steps = stepsFromEvents(live.events);
+      liveTrail = <AgentTrail steps={steps} phase={livePhase(live, steps)} />;
+    } else {
+      liveTrail = <AgentTrail steps={[]} phase="connecting" />;
+    }
+  }
 
   const displayTurns = openChat ? (savedTurns ?? []) : turns;
   const latest = [...displayTurns].reverse().find((turn) => turn.response);
@@ -474,6 +752,7 @@ export default function AskPage() {
               <ChatThread
                 turns={turns}
                 pending={pending}
+                liveTrail={liveTrail}
                 onHover={setHoverId}
                 onOpen={openCitation}
                 threadRef={threadRef}

--- a/console-ui/src/pages/AskPage.tsx
+++ b/console-ui/src/pages/AskPage.tsx
@@ -456,17 +456,18 @@ export default function AskPage() {
   // the in-flight discovery, so a first ask racing it still gets a trail.
   const { model } = useModel();
   const [askStatus, setAskStatus] = useState<boolean | null>(null);
-  const askStatusPromise = useRef<Promise<boolean> | null>(null);
-  const modelAgent = model?.ask_agent === true;
+  // Ref, not a captured value: the /api/model overlay keeps polling, and a
+  // fallback taken later must read what the model says NOW.
+  const modelAgentRef = useRef(false);
   useEffect(() => {
-    askStatusPromise.current = fetchAskStatus()
-      .then((s) => {
-        setAskStatus(s.agent);
-        return s.agent;
-      })
-      .catch(() => modelAgent);
-    // Discovery runs once; the fallback reads whatever /api/model said by then.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    modelAgentRef.current = model?.ask_agent === true;
+  }, [model]);
+  useEffect(() => {
+    fetchAskStatus()
+      .then((s) => setAskStatus(s.agent))
+      .catch(() => {
+        /* warm-cache miss only — submit re-reads per submission */
+      });
   }, []);
   const [live, setLive] = useState<AskProgress | null>(null);
   const liveRef = useRef<AskProgress | null>(null);
@@ -610,11 +611,7 @@ export default function AskPage() {
           setAskStatus(s.agent);
           return s.agent;
         })
-        .catch(
-          async () =>
-            askStatus ??
-            (await (askStatusPromise.current ?? Promise.resolve(modelAgent))),
-        );
+        .catch(() => askStatus ?? modelAgentRef.current);
       // Agent path: mint the session id client-side so the progress feed
       // is pollable from the FIRST turn (the server honors supplied ids).
       let chat = sessionChat;
@@ -644,7 +641,8 @@ export default function AskPage() {
         // (validation) POST never owned the session, so any polled feed
         // belongs to a DIFFERENT turn and must not be attributed here.
         const admitted = !(
-          err instanceof AskError && (err.status === 429 || err.status === 400)
+          err instanceof AskError &&
+          (err.status === 429 || err.status === 409 || err.status === 400)
         );
         const trail = admitted ? liveRef.current?.events : undefined;
         setTurns((prev) =>

--- a/crates/ovp-memory/src/agent.rs
+++ b/crates/ovp-memory/src/agent.rs
@@ -156,8 +156,12 @@ impl std::error::Error for AgentError {}
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AgentProgress {
     Started { turn_id: String },
-    ToolStarted { tool_call_id: String, tool: String },
-    ToolFinished { tool_call_id: String, tool: String, is_error: bool },
+    /// `arguments` is the model's raw call input — consumers derive their own
+    /// display summary (e.g. the query term) and MUST NOT execute from it.
+    ToolStarted { tool_call_id: String, tool: String, arguments: serde_json::Value },
+    /// `summary` mirrors the caller-facing `ToolTraceEntry` summary: capped,
+    /// and the discard marker (never content) for late results.
+    ToolFinished { tool_call_id: String, tool: String, is_error: bool, summary: String },
     Finished { turn_id: String, stopped_reason: StoppedReason },
 }
 
@@ -455,6 +459,7 @@ pub fn run_agent_turn_with_progress(
             emit(AgentProgress::ToolStarted {
                 tool_call_id: id.clone(),
                 tool: name.clone(),
+                arguments: input.clone(),
             });
             let left = remaining(started);
             let outcome = if left.is_zero() || timed_out {
@@ -503,18 +508,19 @@ pub fn run_agent_turn_with_progress(
                 truncated,
                 late: finished_late,
             });
+            // Late data is AUDIT-ONLY: the caller-facing trail (and any
+            // idempotent replay built from it) gets the discard marker,
+            // never the content.
+            let trail_summary: String = if finished_late {
+                "late: discarded (audit only)".to_string()
+            } else {
+                content.chars().take(120).collect()
+            };
             trace.push(ToolTraceEntry {
                 tool: name.clone(),
                 tool_call_id: id.clone(),
                 is_error: is_error || finished_late,
-                // Late data is AUDIT-ONLY: the caller-facing trail (and any
-                // idempotent replay built from it) gets the discard marker,
-                // never the content.
-                summary: if finished_late {
-                    "late: discarded (audit only)".to_string()
-                } else {
-                    content.chars().take(120).collect()
-                },
+                summary: trail_summary.clone(),
             });
             let (model_content, model_is_error) = if finished_late {
                 timed_out = true;
@@ -543,6 +549,7 @@ pub fn run_agent_turn_with_progress(
                 tool_call_id: id.clone(),
                 tool: name.clone(),
                 is_error: model_is_error,
+                summary: trail_summary,
             });
             results.push(ToolResultBlock {
                 tool_call_id: id.clone(),
@@ -1511,10 +1518,17 @@ mod tests {
         .unwrap();
         let events = events.into_inner().unwrap();
         assert!(matches!(&events[0], AgentProgress::Started { turn_id } if turn_id == "t1"));
-        assert!(matches!(&events[1], AgentProgress::ToolStarted { tool, .. } if tool == "search"));
+        // The started event carries the RAW call arguments (narration data
+        // for consumers); the finished event mirrors the trace summary.
+        assert!(matches!(
+            &events[1],
+            AgentProgress::ToolStarted { tool, arguments, .. }
+                if tool == "search" && arguments == &serde_json::json!({"q": "x"})
+        ));
         assert!(matches!(
             &events[2],
-            AgentProgress::ToolFinished { tool, is_error: false, .. } if tool == "search"
+            AgentProgress::ToolFinished { tool, is_error: false, summary, .. }
+                if tool == "search" && summary == "hit"
         ));
         assert!(matches!(
             events.last().unwrap(),

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -723,6 +723,13 @@ fn dispatch(
         (Method::Get, p) if p.starts_with("/api/ask/progress") => {
             handle_ask_progress(state, url)
         }
+        // Agent-mode discovery MUST work index-free (the agent path itself
+        // does): /api/model 503s on an unindexed vault, so the SPA reads
+        // this instead before minting a session id and polling.
+        (Method::Get, "/api/ask/status") => json_response(
+            200,
+            &serde_json::json!({"agent": state.ask_agent}).to_string(),
+        ),
         (Method::Post, "/api/schedule/run") => handle_run_start(state, body),
         (Method::Post, "/api/attention/ack") => handle_attention_ack(state, body),
         (Method::Get, "/api/providers") => handle_providers_get(state),
@@ -5080,9 +5087,25 @@ mod tests {
         st.ask_agent = true;
         let v = body_json(dispatch(&st, Method::Get, "/api/model", ""));
         assert_eq!(v["ask_agent"], true);
+        // The canonical discovery endpoint works WITHOUT an index (parity
+        // with the agent path itself — /api/model 503s on a fresh vault).
+        let v = body_json(dispatch(&st, Method::Get, "/api/ask/status", ""));
+        assert_eq!(v["agent"], true);
+        let bare = std::env::temp_dir()
+            .join(format!("ovp-server-test-{}-agent-disc-bare", std::process::id()));
+        std::fs::create_dir_all(&bare).unwrap();
+        let mut unindexed = state(bare, None);
+        unindexed.ask_agent = true;
+        let resp = dispatch(&unindexed, Method::Get, "/api/model", "");
+        assert_eq!(resp.status_code(), 503);
+        let resp = dispatch(&unindexed, Method::Get, "/api/ask/status", "");
+        assert_eq!(resp.status_code(), 200);
+        assert_eq!(body_json(resp)["agent"], true);
         st.ask_agent = false;
         let v = body_json(dispatch(&st, Method::Get, "/api/model", ""));
         assert_eq!(v["ask_agent"], false);
+        let v = body_json(dispatch(&st, Method::Get, "/api/ask/status", ""));
+        assert_eq!(v["agent"], false);
 
         let brief = args_brief(&serde_json::json!({
             "limit": 10, "query": "agent memory", "filters": {"deep": true}

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -1666,6 +1666,9 @@ fn handle_model(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
             "age_seconds".into(),
             serde_json::json!(age_seconds(model.built_at.as_deref())),
         );
+        // Agent-mode discovery: the SPA pre-generates a session id and polls
+        // /api/ask/progress from turn 1 only when the agent path is live.
+        obj.insert("ask_agent".into(), serde_json::json!(state.ask_agent));
         // Attention acknowledgements overlay: (sha,status) pairs the operator
         // dismissed. All attention surfaces (Today, System, the nav dot)
         // derive from this one model payload, so filtering stays consistent.
@@ -2399,7 +2402,11 @@ fn handle_ask_agent(
             let cfg = AgentConfig {
                 model: ovp_memory::ask::AskArgs::default().model_name,
                 system: ovp_memory::agent_policy::AGENT_POLICY.to_string(),
-                max_tokens: 2048,
+                // Agent answers synthesize across layers (multi-section,
+                // bilingual) and routinely overflow the legacy 2048 cap —
+                // a MaxTokens final reply surfaces as an honest model_error,
+                // so headroom here is product quality, not cosmetics.
+                max_tokens: 4096,
                 deadline,
                 ..AgentConfig::default()
             };
@@ -2411,13 +2418,20 @@ fn handle_ask_agent(
                     AgentProgress::Started { turn_id } => {
                         serde_json::json!({"event": "started", "turn_id": turn_id})
                     }
-                    AgentProgress::ToolStarted { tool_call_id, tool } => serde_json::json!({
-                        "event": "tool_started", "tool": tool, "tool_call_id": tool_call_id
-                    }),
-                    AgentProgress::ToolFinished { tool_call_id, tool, is_error } => {
+                    AgentProgress::ToolStarted { tool_call_id, tool, arguments } => {
+                        serde_json::json!({
+                            "event": "tool_started", "tool": tool,
+                            "tool_call_id": tool_call_id,
+                            // Display-only narration ("what am I searching"),
+                            // derived server-side — never the raw args object.
+                            "args": args_brief(arguments),
+                        })
+                    }
+                    AgentProgress::ToolFinished { tool_call_id, tool, is_error, summary } => {
                         serde_json::json!({
                             "event": "tool_finished", "tool": tool,
-                            "tool_call_id": tool_call_id, "ok": !is_error
+                            "tool_call_id": tool_call_id, "ok": !is_error,
+                            "summary": summary,
                         })
                     }
                     // The advertised terminal protocol is final | error: a
@@ -2579,6 +2593,47 @@ fn handle_ask_agent(
 /// ledger records (link = the claim's knowledge anchor), [source:<id>]
 /// against the index (link = /library). Anything unresolvable is
 /// verified:false — surfaced, never silently dropped.
+/// Compact display line for a tool call's arguments ("query=agent memory ·
+/// limit=10") — narration for the live progress trail. Scalar fields only,
+/// well-known keys first, capped so a pathological argument can't flood the
+/// feed. Null when nothing scalar is present.
+fn args_brief(arguments: &serde_json::Value) -> serde_json::Value {
+    const PRIORITY: [&str; 6] = ["query", "claim_key", "claim_id", "source_id", "cursor", "limit"];
+    let Some(obj) = arguments.as_object() else {
+        return serde_json::Value::Null;
+    };
+    let render = |v: &serde_json::Value| match v {
+        serde_json::Value::String(s) => Some(s.clone()),
+        serde_json::Value::Number(n) => Some(n.to_string()),
+        serde_json::Value::Bool(b) => Some(b.to_string()),
+        _ => None,
+    };
+    let mut parts: Vec<String> = Vec::new();
+    for key in PRIORITY {
+        if let Some(v) = obj.get(key).and_then(&render) {
+            parts.push(format!("{key}={v}"));
+        }
+    }
+    for (key, value) in obj {
+        if parts.len() >= 3 {
+            break;
+        }
+        if !PRIORITY.contains(&key.as_str())
+            && let Some(v) = render(value)
+        {
+            parts.push(format!("{key}={v}"));
+        }
+    }
+    if parts.is_empty() {
+        return serde_json::Value::Null;
+    }
+    let mut brief = parts.join(" · ");
+    if brief.chars().count() > 120 {
+        brief = brief.chars().take(119).collect::<String>() + "…";
+    }
+    serde_json::Value::String(brief)
+}
+
 fn agent_citations(
     answer: &str,
     model: &IndexModel,
@@ -5013,6 +5068,30 @@ mod tests {
             .collect();
         assert_eq!(events.first().copied(), Some("started"));
         assert_eq!(events.last().copied(), Some("final"));
+    }
+
+    /// A3c: /api/model advertises the agent flag so the SPA knows to mint a
+    /// session id and poll the live feed; args_brief narrates scalar
+    /// arguments (priority keys first) and never echoes nested structures.
+    #[test]
+    fn agent_mode_discovery_and_args_narration() {
+        let vault = portal_vault("agent-disc", "50-Inbox/03-Processed/good.md", "body\n");
+        let mut st = state(vault, None);
+        st.ask_agent = true;
+        let v = body_json(dispatch(&st, Method::Get, "/api/model", ""));
+        assert_eq!(v["ask_agent"], true);
+        st.ask_agent = false;
+        let v = body_json(dispatch(&st, Method::Get, "/api/model", ""));
+        assert_eq!(v["ask_agent"], false);
+
+        let brief = args_brief(&serde_json::json!({
+            "limit": 10, "query": "agent memory", "filters": {"deep": true}
+        }));
+        assert_eq!(brief, "query=agent memory · limit=10");
+        assert_eq!(args_brief(&serde_json::json!({"nested": {"x": 1}})), serde_json::Value::Null);
+        assert_eq!(args_brief(&serde_json::json!("free text")), serde_json::Value::Null);
+        let long = args_brief(&serde_json::json!({"query": "q".repeat(300)}));
+        assert!(long.as_str().unwrap().chars().count() <= 120);
     }
 
     /// A3b round-1 gate: idempotent retries replay the completed turn (no

--- a/evolution/candidates/ask_answer_budget-v1.json
+++ b/evolution/candidates/ask_answer_budget-v1.json
@@ -5,15 +5,16 @@
   "target_version": "v1",
   "surface": "runtime",
   "component": "runtime.ask_product_wiring",
-  "hypothesis": "RUNTIME surface, single knob: the agent path's answer budget (AgentConfig.max_tokens in the /api/ask wiring) rises 2048 → 4096. Agent answers synthesize across layers (multi-section, bilingual) and demonstrably overflow the legacy 2048 cap: a live turn on the real vault produced a good 6105-char answer that hit MaxTokens and honestly stopped model_error mid-answer. Predicted: cap-overflow model_error final replies disappear for typical synthesis answers while tool-call budgets and every deadline/coverage/citation contract stay byte-identical.",
+  "hypothesis": "RUNTIME surface, single knob: the agent path's PER-CALL output-token budget (AgentConfig.max_tokens in the /api/ask wiring) rises 2048 → 4096 for EVERY model call in the turn — tool-selection rounds and the final answer alike (the engine reuses one config per request). The binding constraint in practice is the final synthesis reply: tool-selection rounds stop at tool_use blocks far below either cap, so the observable effect is answer headroom; live evidence: a real-vault turn produced a good 6105-char answer that hit MaxTokens at 2048 and honestly stopped model_error mid-answer. Predicted: cap-overflow model_error final replies disappear for typical synthesis answers while deadline/coverage/citation contracts stay byte-identical.",
   "predicted_delta": {
     "operational_reliability": "long synthesis turns finish with stopped_reason=final instead of an honest-but-avoidable model_error truncation at the answer step",
-    "cost_efficiency": "output-token ceiling doubles ONLY when the model actually writes long answers; per-call usage stays in the transcript ledger, so the paired check is observable, not assumed"
+    "cost_efficiency": "worst-case per-call output ceiling doubles for every round of the turn; in practice tool-selection rounds emit compact tool_use blocks (observed ≤~200 output tokens), so realized cost tracks answer length — verified via the per-call usage ledger, not assumed"
   },
   "guardrails": {
-    "single_knob": "the diff for this candidate is one field: max_tokens 2048 → 4096 in the agent branch's AgentConfig; no prompt, tool, deadline, or protocol change rides along",
+    "single_knob": "the diff for this candidate is one field: max_tokens 2048 → 4096 in the agent branch's AgentConfig, applied per-call across all rounds of the turn; no prompt, tool, deadline, or protocol change rides along",
     "truncation_still_honest": "a reply that hits even the raised cap still surfaces as model_error (A1b `max_tokens_text_is_not_final` stands unmodified) — the budget buys headroom, never silence",
-    "legacy_path_untouched": "the flag-off /api/ask path keeps AskArgs::default() (2048); only the agent branch reads the new value"
+    "legacy_path_untouched": "the flag-off /api/ask path keeps AskArgs::default() (2048); only the agent branch reads the new value",
+    "cost_ceiling_observable": "the raised ceiling doubles the worst-case PER-CALL output cost for every round, not only the answer; per-call usage lands in the transcript ledger (A1b token accounting), so any tool-round cost drift is measurable in the paired eval rather than assumed away"
   },
   "eval_plan": {
     "replay_set": "live paired evidence (real vault, 2026-07-24): pre-change turn = 6105-char answer, stopped_reason=model_error at 2048; post-change same-class question = 4839-char answer, usage.output_tokens=2195 (would truncate at 2048), stopped_reason=final, 34 citations / 31 verified. Deterministic contracts covered by the existing agent test suites, which pass unmodified.",

--- a/evolution/candidates/ask_answer_budget-v1.json
+++ b/evolution/candidates/ask_answer_budget-v1.json
@@ -1,0 +1,25 @@
+{
+  "kind": "ovp.evolution.candidate/v1",
+  "id": "ask_answer_budget-v1",
+  "base_version": "none",
+  "target_version": "v1",
+  "surface": "runtime",
+  "component": "runtime.ask_product_wiring",
+  "hypothesis": "RUNTIME surface, single knob: the agent path's answer budget (AgentConfig.max_tokens in the /api/ask wiring) rises 2048 → 4096. Agent answers synthesize across layers (multi-section, bilingual) and demonstrably overflow the legacy 2048 cap: a live turn on the real vault produced a good 6105-char answer that hit MaxTokens and honestly stopped model_error mid-answer. Predicted: cap-overflow model_error final replies disappear for typical synthesis answers while tool-call budgets and every deadline/coverage/citation contract stay byte-identical.",
+  "predicted_delta": {
+    "operational_reliability": "long synthesis turns finish with stopped_reason=final instead of an honest-but-avoidable model_error truncation at the answer step",
+    "cost_efficiency": "output-token ceiling doubles ONLY when the model actually writes long answers; per-call usage stays in the transcript ledger, so the paired check is observable, not assumed"
+  },
+  "guardrails": {
+    "single_knob": "the diff for this candidate is one field: max_tokens 2048 → 4096 in the agent branch's AgentConfig; no prompt, tool, deadline, or protocol change rides along",
+    "truncation_still_honest": "a reply that hits even the raised cap still surfaces as model_error (A1b `max_tokens_text_is_not_final` stands unmodified) — the budget buys headroom, never silence",
+    "legacy_path_untouched": "the flag-off /api/ask path keeps AskArgs::default() (2048); only the agent branch reads the new value"
+  },
+  "eval_plan": {
+    "replay_set": "live paired evidence (real vault, 2026-07-24): pre-change turn = 6105-char answer, stopped_reason=model_error at 2048; post-change same-class question = 4839-char answer, usage.output_tokens=2195 (would truncate at 2048), stopped_reason=final, 34 citations / 31 verified. Deterministic contracts covered by the existing agent test suites, which pass unmodified.",
+    "paired_sources": 0,
+    "soak": false
+  },
+  "rollback": "Set the field back to 2048 — one-line revert, no data or transcript migration.",
+  "ablation_required": false
+}


### PR DESCRIPTION
Third product stage of the Vault Agent program (A0 #368; A1a #369; A1b #370; A2 #371; A3a #372; A3b #373).

**Problem (operator dogfood):** an agent ask was a long silent wait, then a wall of text — no sense of what the agent was doing, and a failure showed nothing but an error line.

**Now:** the portal polls the A3b progress feed and narrates each tool call live (verb + tool + query args), shows connecting/thinking/composing phases, and after the turn renders receipts: per-layer coverage badges, a collapsed execution trail, and an honest stop-notice for timeout/tool_error/model_error/max_rounds turns. Failed turns keep their partial trail.

Mechanics: engine progress events enriched additively (raw arguments on ToolStarted, trace summary on ToolFinished — late results stay discard-marker-only); server derives a display-only args narration server-side; `/api/model` advertises `ask_agent` so the SPA mints the session id and polls from turn 1; agent answer budget 2048→4096 (live smoke overflowed the cap). No candidate: UI surface + additive event fields under runtime.ask_product_wiring (flag semantics unchanged; flag-off untouched).

Tests: engine event-payload assertions, server discovery+narration test; 131 crate tests + SPA tsc/build green. Live-verified against the real vault (narrated polls mid-turn; 34 citations / 31 verified final).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a live “agent trail + receipts” experience in the Ask page with connection/phase updates, coverage pills, stop notices, and expandable activity history.
  * Added support for agent-mode progress polling and rendering during pending and completed runs.
  * Added English and Simplified Chinese translations for agent status, coverage, and stop/error messages.
  * Increased the agent answer budget to allow longer responses.
* **Bug Fixes**
  * Preserved and displayed partial agent progress when an agent request fails.
* **Accessibility**
  * Added reduced-motion support for live trail animations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->