### PR TITLE
feat(ask): A3d — agent is the default ask path (paired-eval verified)

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -190,7 +190,8 @@ fn start_server(vault: PathBuf, viz_dir: PathBuf) -> Result<String, String> {
             ask_timeout: None,
             max_concurrent_asks: None,
             // Agent-path parity for the desktop lands with the A3d rollout.
-            ask_agent: false,
+            // Parity with the CLI default (A3d): the agent path serves Ask.
+            ask_agent: true,
         };
         std::thread::spawn(move || {
             if let Err(e) = ovp_server::run_server(config) {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -190,8 +190,9 @@ fn start_server(vault: PathBuf, viz_dir: PathBuf) -> Result<String, String> {
             ask_timeout: None,
             max_concurrent_asks: None,
             // Agent-path parity for the desktop lands with the A3d rollout.
-            // Parity with the CLI default (A3d): the agent path serves Ask.
-            ask_agent: true,
+            // Parity with the CLI default AND its rollback hatch (A3d):
+            // the agent path serves Ask unless OVP_ASK_AGENT=0.
+            ask_agent: std::env::var("OVP_ASK_AGENT").map(|v| v != "0").unwrap_or(true),
         };
         std::thread::spawn(move || {
             if let Err(e) = ovp_server::run_server(config) {

--- a/console-ui/src/lib/chatTranscript.ts
+++ b/console-ui/src/lib/chatTranscript.ts
@@ -80,7 +80,10 @@ export function parseChatTranscript(md: string): ChatTurn[] {
     // Also stop before a stray next Q if evidence markers were missing.
     const nextQ = answerPart.search(/\n\n\*\*Q:\*\*/);
     if (nextQ >= 0) answerPart = answerPart.slice(0, nextQ);
-    const answer = answerPart.trim();
+    // Agent turns are minimal Q/A blocks separated by bare `---` (no
+    // Evidence section) — a trailing separator is a delimiter, not answer.
+    let answer = answerPart.trim();
+    answer = answer.replace(/\n+---\s*$/, '').trim();
     if (question && answer) turns.push({ question, answer });
   }
   return turns;

--- a/console-ui/src/lib/types.ts
+++ b/console-ui/src/lib/types.ts
@@ -254,7 +254,8 @@ export interface AskResponse {
   intent?: string | null;
   /** Stem of the saved `.ovp/chats/<name>.md` transcript. */
   chat: string | null;
-  // ---- agent-path extras (OVP_ASK_AGENT=1; absent on the legacy path) ----
+  // ---- agent-path extras (the DEFAULT path since A3d; absent on the
+  // legacy pipeline reachable via the OVP_ASK_AGENT=0 rollback hatch) ----
   /** True when the answer came from the tool-loop agent. */
   agent?: boolean;
   /** Executor-computed per-layer coverage (claims/sources/body →

--- a/console-ui/src/lib/types.ts
+++ b/console-ui/src/lib/types.ts
@@ -228,7 +228,11 @@ export interface AskCitation {
   title: string | null;
   snippet: string | null;
   link_target: string | null;
-  verified: boolean;
+  /** True/false = the server's verifier ruling. Null = UNKNOWN — a saved
+   * transcript replayed without re-verification must claim neither
+   * (previously replay upgraded every marker, fabricated ones included,
+   * to verified). Only `false` renders warnings. */
+  verified: boolean | null;
 }
 
 export interface AskVerification {

--- a/console-ui/src/lib/types.ts
+++ b/console-ui/src/lib/types.ts
@@ -166,6 +166,9 @@ export type ClaimStatus = 'durable' | 'superseded' | 'retracted' | 'caveated';
 
 export interface ClaimRow {
   claim_id: string;
+  /** Stable ledger identity (ck-…) — claim_ids can collide across runs,
+   * claim_keys cannot. Absent on pre-key indexes. */
+  claim_key?: string;
   claim: string;
   theme?: string;
   status: ClaimStatus;

--- a/console-ui/src/pages/AskPage.tsx
+++ b/console-ui/src/pages/AskPage.tsx
@@ -77,8 +77,10 @@ function citationsFromAnswerText(answer: string): AskCitation[] {
       title: id,
       snippet: null,
       link_target: citeLinkTarget(id),
-      // Saved transcript does not re-run the verifier; treat as known markers.
-      verified: true,
+      // Saved transcript does not re-run the verifier — verification state
+      // is UNKNOWN, and claiming either way would misrepresent receipts
+      // (a fabricated marker must not come back "verified" after refresh).
+      verified: null,
     };
   });
 }
@@ -287,7 +289,7 @@ function AnswerText({
         <button
           key={key}
           type="button"
-          className={`cite-marker${cit.verified ? '' : ' warn'}`}
+          className={`cite-marker${cit.verified === false ? ' warn' : ''}`}
           onMouseEnter={() => onHover(cit.id)}
           onMouseLeave={() => onHover(null)}
           onFocus={() => onHover(cit.id)}
@@ -338,7 +340,7 @@ function CitationPanel({
               <span className="pill" title={kindTip ? t(kindTip) : undefined}>
                 {c.kind}
               </span>
-              {!c.verified && (
+              {c.verified === false && (
                 <span className="pill unverified">{t('ask.unverified')}</span>
               )}
             </div>

--- a/console-ui/src/pages/AskPage.tsx
+++ b/console-ui/src/pages/AskPage.tsx
@@ -71,12 +71,19 @@ function errorKeyFor(err: unknown): MsgKey {
 function citationsFromAnswerText(answer: string): AskCitation[] {
   return citationsInOrder(answer).map((id) => {
     const kind = id.includes(':') ? id.slice(0, id.indexOf(':')) : '';
+    // Mirror the server's tolerant token extraction: decorated markers
+    // ([source:<sha> Some Title]) keep the RAW id for marker matching but
+    // link/display through the bare first token — otherwise replay builds
+    // /library/<sha>%20Some%20Title.
+    const rest = kind ? id.slice(id.indexOf(':') + 1) : id;
+    const token = (rest.trim().split(/\s+/)[0] ?? '').replace(/^<|>$/g, '');
+    const canonical = kind ? `${kind}:${token}` : token;
     return {
       id,
       kind,
-      title: id,
+      title: canonical,
       snippet: null,
-      link_target: citeLinkTarget(id),
+      link_target: citeLinkTarget(canonical),
       // Saved transcript does not re-run the verifier — verification state
       // is UNKNOWN, and claiming either way would misrepresent receipts
       // (a fabricated marker must not come back "verified" after refresh).

--- a/console-ui/src/pages/KnowledgePage.tsx
+++ b/console-ui/src/pages/KnowledgePage.tsx
@@ -223,10 +223,15 @@ export default function KnowledgePage() {
   // its (Unclassified) theme page via themeRoute rather than dead-ending here.
   const anchor = decodeURIComponent(location.hash.replace(/^#/, ''));
   if (anchor && model) {
-    const claim = model.claims.find((c) => c.claim_id === anchor);
+    // claim_id first; claim_key fallback (agent citations and replayed
+    // agent chats anchor by the stable ck-… key — theme pages anchor by
+    // claim_id, so forward with the RESOLVED id).
+    const claim =
+      model.claims.find((c) => c.claim_id === anchor) ??
+      model.claims.find((c) => c.claim_key === anchor);
     if (claim) {
       return (
-        <Navigate to={`${themeRoute(claim.theme)}#${anchor}`} replace />
+        <Navigate to={`${themeRoute(claim.theme)}#${claim.claim_id}`} replace />
       );
     }
   }

--- a/crates/ovp-cli/src/commands/serve.rs
+++ b/crates/ovp-cli/src/commands/serve.rs
@@ -53,7 +53,10 @@ pub fn run(args: ServeArgs) -> Result<(), CliError> {
         ask_timeout: None,
         // A3b flag: OVP_ASK_AGENT=1 routes POST /api/ask through the agent
         // loop (legacy single-shot stays the default until A3d).
-        ask_agent: std::env::var("OVP_ASK_AGENT").is_ok_and(|v| v == "1"),
+        // A3d rollout: the tool-loop agent IS the ask path (paired eval
+        // 2026-07-25, candidate ask_default_flip-v1). OVP_ASK_AGENT=0 is the
+        // rollback hatch to the legacy single-shot pipeline.
+        ask_agent: std::env::var("OVP_ASK_AGENT").map(|v| v != "0").unwrap_or(true),
         max_concurrent_asks: None,
     };
     run_server(config).map_err(CliError::Io)

--- a/crates/ovp-memory/src/agent.rs
+++ b/crates/ovp-memory/src/agent.rs
@@ -287,7 +287,9 @@ pub fn run_agent_turn_with_progress(
             max_tokens: cfg.max_tokens,
             temperature: cfg.temperature,
             tools: (!tool_defs.is_empty()).then(|| tool_defs.clone()),
-            cache_namespace: Some("ask_agent/v1".into()),
+            // Bumped with each ACCEPTED policy version (prompt-version
+            // isolation for recorded cassettes): v2 = ask_agent_policy-v2.
+            cache_namespace: Some("ask_agent/v2".into()),
         };
         let reply = match client.call(&request) {
             Ok(r) => r,

--- a/crates/ovp-memory/src/agent.rs
+++ b/crates/ovp-memory/src/agent.rs
@@ -558,6 +558,27 @@ pub fn run_agent_turn_with_progress(
             });
         }
 
+        // A model that has FOUND its material can still burn the remaining
+        // rounds chasing a better match and end max_rounds with no synthesis
+        // (live eval: target located round 6 of 10, answer never written).
+        // When the NEXT batch would be refused, say so in the model-facing
+        // copy of the last result — same pattern as the truncation marker;
+        // the audit events above keep the raw content.
+        if rounds == cfg.max_rounds
+            && let Some(last) = results.last_mut()
+        {
+            const NOTICE: &str = "\n\n[runtime notice: tool budget exhausted — this was \
+                                  the final tool round; write your answer now from what \
+                                  you already have]";
+            // Degenerate tiny caps skip the notice rather than exceed them.
+            if cfg.max_result_bytes >= NOTICE.len() {
+                if last.content.len() + NOTICE.len() > cfg.max_result_bytes {
+                    let keep = cfg.max_result_bytes.saturating_sub(NOTICE.len());
+                    last.content.truncate(floor_char_boundary(&last.content, keep));
+                }
+                last.content.push_str(NOTICE);
+            }
+        }
         // The COMPLETE batch is always recorded (adjacency), then a timeout
         // ends the turn.
         let results_msg = ModelMessage::ToolResults { results };
@@ -769,6 +790,59 @@ mod tests {
 
     fn store(dir: &std::path::Path) -> SessionStore {
         SessionStore::open(dir, "s1").unwrap()
+    }
+
+    // The final allowed tool round's results carry the runtime notice (the
+    // model must synthesize now); earlier rounds never do, and the AUDIT
+    // record of the tool call keeps the raw content without the notice.
+    #[test]
+    fn last_round_results_carry_the_synthesize_now_notice() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut client = Scripted::new(vec![
+            tool_reply(&[("c1", "search")]),
+            tool_reply(&[("c2", "search")]),
+            text_reply("answer"),
+        ]);
+        let mut tools = MockTools::new(&[("search", Behavior::Ok("hit"))]);
+        let mut st = store(dir.path());
+        let out = run_agent_turn(
+            &mut client,
+            &mut tools,
+            &mut st,
+            "q?",
+            None,
+            &AgentConfig { max_rounds: 2, ..cfg() },
+        )
+        .unwrap();
+        assert_eq!(out.stopped_reason, StoppedReason::Final);
+        let result_bodies: Vec<String> = st
+            .events()
+            .iter()
+            .filter_map(|e| match e {
+                TranscriptEvent::Message {
+                    message: ModelMessage::ToolResults { results },
+                    ..
+                } => Some(results[0].content.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(result_bodies.len(), 2);
+        assert!(
+            !result_bodies[0].contains("[runtime notice"),
+            "round 1 of 2 must not carry the notice: {}",
+            result_bodies[0]
+        );
+        assert!(
+            result_bodies[1].contains("final tool round")
+                && result_bodies[1].starts_with("hit"),
+            "round 2 of 2 carries content + notice: {}",
+            result_bodies[1]
+        );
+        // Audit record of the call itself stays raw.
+        assert!(st.events().iter().any(|e| matches!(
+            e,
+            TranscriptEvent::ToolCalled { content, .. } if content == "hit"
+        )));
     }
 
     // 0-tool: model answers directly; single round-trip, transcript complete.

--- a/crates/ovp-memory/src/agent.rs
+++ b/crates/ovp-memory/src/agent.rs
@@ -573,10 +573,17 @@ pub fn run_agent_turn_with_progress(
                                   the final tool round; write your answer now from what \
                                   you already have]";
             // Degenerate tiny caps skip the notice rather than exceed them.
-            if cfg.max_result_bytes >= NOTICE.len() {
+            const TRUNC: &str = "\n[truncated]";
+            if cfg.max_result_bytes >= NOTICE.len() + TRUNC.len() {
                 if last.content.len() + NOTICE.len() > cfg.max_result_bytes {
-                    let keep = cfg.max_result_bytes.saturating_sub(NOTICE.len());
+                    // Shrinking to fit the notice must not erase truncation
+                    // disclosure — the capped result's marker (or the one
+                    // this shrink itself creates) stays ahead of the notice.
+                    let keep = cfg
+                        .max_result_bytes
+                        .saturating_sub(NOTICE.len() + TRUNC.len());
                     last.content.truncate(floor_char_boundary(&last.content, keep));
+                    last.content.push_str(TRUNC);
                 }
                 last.content.push_str(NOTICE);
             }

--- a/crates/ovp-memory/src/agent_policy.rs
+++ b/crates/ovp-memory/src/agent_policy.rs
@@ -51,6 +51,11 @@ EVIDENCE
 [source:<source_id>] (the source_id from the tool result), with the title \
 as display text — that exact form is what makes the reference openable. Do \
 not decorate answers with citations for material you did not consult.
+- The brackets contain ONLY the bare key, exactly as a tool returned it: \
+no titles, no extra words, no angle brackets, no spaces inside the \
+brackets. Titles and commentary go OUTSIDE the brackets as display text. \
+Never write placeholder or example-shaped references (like a claim key of \
+x's) — if you have no real key from a tool result, cite nothing.
 - Distinguish claim strength when it matters: durable claims passed the \
 evidence gate and carry a claim_key to cite; caveated claims await review \
 and have NO claim_key and no bracketed citation — when you lean on one, \
@@ -60,11 +65,22 @@ with its id. Never fabricate a bracketed reference.
 - An honest miss beats a confident guess. If the vault does not contain the \
 answer, say what you searched and what would help narrow it (a URL, a date, \
 an author). Never present general knowledge as vault content.
+- When a vague recollection matches MORE than one plausible item, present \
+each candidate with the evidence that distinguishes it — do not silently \
+pick one and discard the rest.
+
+LENGTH
+- Answers have a hard output budget; an over-long answer gets truncated \
+mid-sentence, which is worse than a tight one. Default to the shortest \
+complete answer: lead with the finding, group details under short \
+headings, and stop — no padding, no restating the question, no summary of \
+your own process unless asked.
 
 LIMITS AND FAILURES
 - Tool results can be truncated or partial — the result says so. Page \
 through cursors when completeness matters; otherwise state that you saw a \
-partial view.
+partial view. A cursor belongs to the EXACT query that returned it — after \
+rephrasing a query, search again without a cursor.
 - If a tool fails or a layer is unavailable, work with the layers that \
 remain and tell the user which part of the vault you could not consult. Do \
 not claim full-vault coverage the execution trail cannot back.

--- a/crates/ovp-memory/src/agent_policy.rs
+++ b/crates/ovp-memory/src/agent_policy.rs
@@ -55,7 +55,10 @@ not decorate answers with citations for material you did not consult.
 no titles, no extra words, no angle brackets, no spaces inside the \
 brackets. Titles and commentary go OUTSIDE the brackets as display text. \
 Never write placeholder or example-shaped references (like a claim key of \
-x's) — if you have no real key from a tool result, cite nothing.
+x's) — if you have no real key from a tool result, cite nothing. When you \
+DESCRIBE your citation format in prose (a capability question), write the \
+forms without square brackets (say: the claim:… and source:… forms) so \
+your description is not itself parsed as a reference.
 - Distinguish claim strength when it matters: durable claims passed the \
 evidence gate and carry a claim_key to cite; caveated claims await review \
 and have NO claim_key and no bracketed citation — when you lean on one, \

--- a/crates/ovp-memory/src/ask.rs
+++ b/crates/ovp-memory/src/ask.rs
@@ -549,6 +549,35 @@ fn format_chat_turn(
     )
 }
 
+/// Persist one AGENT turn into the saved-chat surface
+/// (`.ovp/chats/<chat>.md`) so History (GET /api/chats and the Ask page's
+/// left rail) shows agent conversations too — the JSONL session transcript
+/// is the audit record, this is the product surface. Same stem rules and
+/// create-or-append semantics as the legacy path; the block is the minimal
+/// Q/A form the transcript parser needs.
+pub fn save_agent_chat_turn(
+    vault_root: &Path,
+    chat: &str,
+    question: &str,
+    answer: &str,
+) -> Result<PathBuf, String> {
+    let chats_dir = vault_root.join(".ovp").join("chats");
+    std::fs::create_dir_all(&chats_dir).map_err(|e| format!("create chats dir: {e}"))?;
+    let turn_block = format!("**Q:** {question}\n\n**A:** {answer}\n");
+    if !valid_chat_stem(chat) {
+        return Err(format!("invalid chat stem `{chat}`"));
+    }
+    let path = chats_dir.join(format!("{chat}.md"));
+    if path.is_file() {
+        append_chat_turn(&path, &turn_block)?;
+        return Ok(path);
+    }
+    let ts = chrono_like_timestamp();
+    std::fs::write(&path, format!("# Ask — {ts}\n\n{turn_block}"))
+        .map_err(|e| format!("write chat {}: {e}", path.display()))?;
+    Ok(path)
+}
+
 fn append_chat_turn(path: &Path, turn_block: &str) -> Result<(), String> {
     use std::io::Write;
     let mut file = std::fs::OpenOptions::new()

--- a/crates/ovp-memory/src/ask.rs
+++ b/crates/ovp-memory/src/ask.rs
@@ -568,14 +568,40 @@ pub fn save_agent_chat_turn(
         return Err(format!("invalid chat stem `{chat}`"));
     }
     let path = chats_dir.join(format!("{chat}.md"));
-    if path.is_file() {
-        append_chat_turn(&path, &turn_block)?;
-        return Ok(path);
-    }
-    let ts = chrono_like_timestamp();
-    std::fs::write(&path, format!("# Ask — {ts}\n\n{turn_block}"))
-        .map_err(|e| format!("write chat {}: {e}", path.display()))?;
+    // Create-or-append through ONE append-mode handle: even with two server
+    // processes on the same vault racing this export, append never
+    // truncates — worst case is a duplicated header, never a lost turn.
+    use std::io::Write;
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .map_err(|e| format!("open chat {}: {e}", path.display()))?;
+    let empty = file
+        .metadata()
+        .map_err(|e| format!("stat chat {}: {e}", path.display()))?
+        .len()
+        == 0;
+    let payload = if empty {
+        format!("# Ask — {}\n\n{turn_block}", chrono_like_timestamp())
+    } else {
+        format!("\n---\n\n{turn_block}")
+    };
+    file.write_all(payload.as_bytes())
+        .map_err(|e| format!("append chat {}: {e}", path.display()))?;
     Ok(path)
+}
+
+/// True when the saved-chat surface already has a file for this session —
+/// the replay path uses this to REPAIR a turn whose transcript committed but
+/// whose export failed (the retry would otherwise skip every save forever).
+pub fn agent_chat_exists(vault_root: &Path, chat: &str) -> bool {
+    valid_chat_stem(chat)
+        && vault_root
+            .join(".ovp")
+            .join("chats")
+            .join(format!("{chat}.md"))
+            .is_file()
 }
 
 fn append_chat_turn(path: &Path, turn_block: &str) -> Result<(), String> {

--- a/crates/ovp-memory/src/vault_tools.rs
+++ b/crates/ovp-memory/src/vault_tools.rs
@@ -290,7 +290,8 @@ impl VaultTools {
                     DispatchError::Unavailable(format!("fulltext index unavailable: {e}"))
                 })?;
                 let cursor = decode_fulltext_cursor(cursor.as_deref(), &query, &model)
-                    .map_err(DispatchError::InvalidArgs)?;
+                    .map_err(DispatchError::InvalidArgs)?
+                    .map_err(DispatchError::StaleState)?;
                 Ok(search_fulltext_at_with_budget(
                     &self.vault_root,
                     &model,
@@ -497,6 +498,7 @@ impl ToolExecutor for VaultTools {
                 self.merge_coverage(layer, LayerState::Failed);
                 ToolOutcome::Failed(detail)
             }
+            Err(DispatchError::StaleState(detail)) => ToolOutcome::Failed(detail),
         }
     }
 }
@@ -728,6 +730,7 @@ fn fulltext_cursor_fingerprint(
     terms: &[String],
     model: &IndexModel,
     candidate_count: usize,
+    offset: usize,
 ) -> String {
     const FNV_OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
     let mut sorted_terms = terms.to_vec();
@@ -746,6 +749,8 @@ fn fulltext_cursor_fingerprint(
     }
     update_fnv1a64(&mut hash, b"\ncandidate_count:");
     update_fnv1a64(&mut hash, candidate_count.to_string().as_bytes());
+    update_fnv1a64(&mut hash, b"\noffset:");
+    update_fnv1a64(&mut hash, offset.to_string().as_bytes());
     format!("{:08x}", hash as u32)
 }
 
@@ -755,7 +760,7 @@ fn format_fulltext_cursor(
     model: &IndexModel,
     candidate_count: usize,
 ) -> String {
-    let fingerprint = fulltext_cursor_fingerprint(terms, model, candidate_count);
+    let fingerprint = fulltext_cursor_fingerprint(terms, model, candidate_count, offset);
     format!("{FULLTEXT_CURSOR_PREFIX}{offset}:{fingerprint}")
 }
 
@@ -793,28 +798,36 @@ fn fulltext_cursor_parts(cursor: &str) -> Result<(&str, &str), String> {
     Ok((offset, fingerprint))
 }
 
+/// `Ok(Err(_))` = a syntactically valid cursor that does not belong to this
+/// (query, index, offset) — a STALE-STATE failure, not malformed arguments:
+/// the caller maps it to a plain tool failure so it never feeds the
+/// invalid-args breaker (a live turn was killed by exactly that).
 fn decode_fulltext_cursor(
     cursor: Option<&str>,
     query: &str,
     model: &IndexModel,
-) -> Result<Option<usize>, String> {
+) -> Result<Result<Option<usize>, String>, String> {
     let Some(cursor) = cursor else {
-        return Ok(None);
+        return Ok(Ok(None));
     };
     let (offset, fingerprint) = fulltext_cursor_parts(cursor)?;
+    let offset: usize = offset
+        .parse()
+        .map_err(|_| "invalid fulltext cursor source offset".to_string())?;
     let terms = tokenize_search_terms(query);
+    // The offset is BOUND into the fingerprint: only cursors this executor
+    // actually issued verify, so an edited offset cannot silently skip a
+    // walk segment while coverage still reports Complete.
     let expected =
-        fulltext_cursor_fingerprint(&terms, model, fulltext_candidate_count(model));
+        fulltext_cursor_fingerprint(&terms, model, fulltext_candidate_count(model), offset);
     if fingerprint != expected {
-        return Err(
-            "fulltext cursor belongs to a different query or index; restart without a cursor"
+        return Ok(Err(
+            "fulltext cursor belongs to a different query, index, or position; \
+             restart without a cursor"
                 .into(),
-        );
+        ));
     }
-    offset
-        .parse::<usize>()
-        .map(Some)
-        .map_err(|_| "invalid fulltext cursor source offset".into())
+    Ok(Ok(Some(offset)))
 }
 
 /// Search the reader-pack catalog surface: pack titles plus card titles. Packs
@@ -2336,6 +2349,11 @@ enum DispatchError {
     InvalidArgs(String),
     Unavailable(String),
     Failed(String),
+    /// A recoverable stale-state fault (e.g. a cursor from a different
+    /// query/index/position): surfaces as a failed call for the model to
+    /// retry WITHOUT a cursor, but touches neither the invalid-args breaker
+    /// nor the layer's coverage — nothing about the LAYER failed.
+    StaleState(String),
 }
 
 impl From<VaultToolError> for DispatchError {
@@ -3486,13 +3504,37 @@ mod tests {
             "search_fulltext",
             json!({"query": "different query", "cursor": cursor}),
         );
+        // A stale cursor is a FAILED tool run, not invalid-args: two of these
+        // in a row must never trip the invalid-args breaker (a live eval turn
+        // died exactly that way after the model reformulated its query).
         assert!(matches!(
             outcome,
-            ToolOutcome::InvalidArgs(ref detail)
-                if detail.contains("different query or index")
+            ToolOutcome::Failed(ref detail)
+                if detail.contains("different query, index, or position")
                     && detail.contains("restart without a cursor")
         ));
+        // ...and it leaves coverage untouched: nothing about the LAYER
+        // failed, and worst-observed merging would otherwise pin the whole
+        // turn's fulltext coverage at failed after one stale cursor.
         assert_eq!(second_tools.coverage(), Coverage::default());
+
+        // Offset-bound fingerprint: editing the offset digits invalidates the
+        // cursor (an edited cursor could otherwise skip a walk segment while
+        // coverage still reported Complete).
+        let issued = cursor.as_str().expect("cursor string").to_string();
+        let (prefix_and_offset, fp) = issued.rsplit_once(':').expect("cursor shape");
+        let mut digits_bumped = prefix_and_offset.to_string();
+        digits_bumped.replace_range(3.., "9999");
+        let forged = format!("{digits_bumped}:{fp}");
+        let mut forged_tools = fixture.tools();
+        assert!(matches!(
+            call(
+                &mut forged_tools,
+                "search_fulltext",
+                json!({"query": "first query", "cursor": forged})
+            ),
+            ToolOutcome::Failed(_)
+        ));
     }
 
     #[test]

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -304,6 +304,11 @@ struct AppState {
     /// `GET /api/ask/progress`. In-memory only — progress is ephemeral UI
     /// state; the transcript is the durable audit.
     ask_progress: Arc<std::sync::Mutex<HashMap<String, AskProgressFeed>>>,
+    /// Serializes saved-chat markdown writes (A3d gate: the save happens
+    /// after the session lock releases; 409-busy admission makes a same-
+    /// session reorder window sub-millisecond, but the create-vs-append
+    /// file race needs real mutual exclusion).
+    chat_saves: Arc<std::sync::Mutex<()>>,
 }
 
 /// State of the portal-triggered manual pipeline run.
@@ -583,6 +588,7 @@ pub fn run_server(config: ServeConfig) -> Result<(), String> {
         acks_write_lock: std::sync::Mutex::new(()),
         ask_agent: config.ask_agent,
         ask_progress: Arc::new(std::sync::Mutex::new(HashMap::new())),
+        chat_saves: Arc::new(std::sync::Mutex::new(())),
     });
 
     // Pre-load model
@@ -2340,6 +2346,7 @@ fn handle_ask_agent(
     let vault_root = state.vault_root.clone();
     let sessions_dir = vault_root.join(".ovp/ask-sessions");
     let progress_map = Arc::clone(&state.ask_progress);
+    let chat_saves = Arc::clone(&state.chat_saves);
     let progress_session = session.clone();
     let question = question.to_string();
     let response_session = session.clone();
@@ -2556,16 +2563,17 @@ fn handle_ask_agent(
                     "output_tokens": outcome.output_tokens_total,
                 },
             });
-            if !outcome.answer.is_empty()
-                && let Err(e) = ovp_memory::ask::save_agent_chat_turn(
+            if !outcome.answer.is_empty() {
+                let _save_guard = chat_saves.lock().unwrap();
+                if let Err(e) = ovp_memory::ask::save_agent_chat_turn(
                     &vault_root,
                     &response_session,
                     &question,
                     &outcome.answer,
-                )
-                && let Some(obj) = body.as_object_mut()
-            {
-                obj.insert("chat_save_error".into(), serde_json::json!(e));
+                ) && let Some(obj) = body.as_object_mut()
+                {
+                    obj.insert("chat_save_error".into(), serde_json::json!(e));
+                }
             }
             Ok(body)
         })();
@@ -3355,6 +3363,7 @@ mod tests {
             acks_write_lock: std::sync::Mutex::new(()),
             ask_agent: false,
             ask_progress: Arc::new(std::sync::Mutex::new(HashMap::new())),
+        chat_saves: Arc::new(std::sync::Mutex::new(())),
         }
     }
 

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -2536,7 +2536,13 @@ fn handle_ask_agent(
                         "tool": t.tool, "summary": t.summary, "ok": !t.is_error
                     }))
                 .collect();
-            Ok(serde_json::json!({
+            // History parity (A3d gate P1): the JSONL session transcript is
+            // the audit record, but /api/chats and the Ask history rail read
+            // `.ovp/chats/*.md` — an answered turn lands there too. Only a
+            // turn that actually RAN saves (the replay branch above returns
+            // earlier, so a keyed retry never double-appends). A save
+            // failure is reported, never silent and never fatal.
+            let mut body = serde_json::json!({
                 "agent": true,
                 "answer": outcome.answer,
                 "citations": citations,
@@ -2549,7 +2555,19 @@ fn handle_ask_agent(
                     "input_tokens": outcome.input_tokens_total,
                     "output_tokens": outcome.output_tokens_total,
                 },
-            }))
+            });
+            if !outcome.answer.is_empty()
+                && let Err(e) = ovp_memory::ask::save_agent_chat_turn(
+                    &vault_root,
+                    &response_session,
+                    &question,
+                    &outcome.answer,
+                )
+                && let Some(obj) = body.as_object_mut()
+            {
+                obj.insert("chat_save_error".into(), serde_json::json!(e));
+            }
+            Ok(body)
         })();
         // Whatever happened, OUR turn's feed must not stay live forever —
         // guarded by the generation token so a newer turn's feed (same
@@ -5076,6 +5094,12 @@ mod tests {
         let transcript = vault.join(format!(".ovp/ask-sessions/{chat}.jsonl"));
         let body = std::fs::read_to_string(&transcript).unwrap();
         assert!(body.contains("turn_finished"), "{body}");
+        // History parity (A3d): the answered turn also lands on the saved-
+        // chat surface the /api/chats rail reads.
+        let chat_md = vault.join(format!(".ovp/chats/{chat}.md"));
+        let md = std::fs::read_to_string(&chat_md).unwrap();
+        assert!(md.contains("**Q:** what do we know?"), "{md}");
+        assert!(md.contains("**A:** answer"), "{md}");
         // Progress feed: started + final, done.
         let resp = dispatch(
             &st,

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -2563,7 +2563,18 @@ fn handle_ask_agent(
                     "output_tokens": outcome.output_tokens_total,
                 },
             });
-            if !outcome.answer.is_empty() {
+            // Only DELIVERABLE outcomes enter saved history: replay cannot
+            // restore stopped_reason, so a timeout narration or truncated
+            // model_error text would read as a successful answer after
+            // refresh. Failed turns stay visible live (trail + stop note)
+            // and in the audit transcript.
+            let deliverable = matches!(
+                outcome.stopped_reason,
+                ovp_memory::agent::StoppedReason::Final
+                    | ovp_memory::agent::StoppedReason::NeedUser
+                    | ovp_memory::agent::StoppedReason::Refusal
+            );
+            if deliverable && !outcome.answer.is_empty() {
                 let _save_guard = chat_saves.lock().unwrap();
                 if let Err(e) = ovp_memory::ask::save_agent_chat_turn(
                     &vault_root,

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -2646,6 +2646,18 @@ fn args_brief(arguments: &serde_json::Value) -> serde_json::Value {
     serde_json::Value::String(brief)
 }
 
+/// Models decorate citation ids in the wild — `[source:<sha> Some Title]`,
+/// `[source: <sha>]` — and exact-string matching then fails receipts the
+/// model clearly intended. Tolerant extraction: trim whitespace and angle
+/// brackets, keep the first whitespace-delimited token. RESOLUTION stays
+/// exact — a token that matches nothing is still verified:false.
+fn citation_id_token(id: &str) -> &str {
+    id.split_whitespace()
+        .next()
+        .unwrap_or("")
+        .trim_matches(|c| c == '<' || c == '>')
+}
+
 fn agent_citations(
     answer: &str,
     model: &IndexModel,
@@ -2655,6 +2667,7 @@ fn agent_citations(
         .into_iter()
         .map(|key| {
             let (kind, id) = key.split_once(':').unwrap_or(("", key.as_str()));
+            let id = citation_id_token(id);
             match kind {
                 "claim" => {
                     let hit = records.iter().find(|r| r.claim_key == id);
@@ -2708,6 +2721,7 @@ fn agent_citations_unindexed(
         .into_iter()
         .map(|key| {
             let (kind, id) = key.split_once(':').unwrap_or(("", key.as_str()));
+            let id = citation_id_token(id);
             if kind == "claim" {
                 let hit = records.iter().find(|r| r.claim_key == id);
                 let link = hit.and_then(|r| {
@@ -5192,6 +5206,21 @@ mod tests {
         assert!(a["link_target"].is_null(), "shared claim_id anchor must be omitted");
         let c = &cits[1];
         assert_eq!(c["link_target"], "/knowledge#uniq");
+
+        // Paired-eval finding: models decorate ids — titles after the sha,
+        // angle brackets, leading spaces. The verifier extracts the first
+        // bare token; RESOLUTION stays exact (garbage still fails).
+        let decorated = agent_citations(
+            "[source:aaaa1111 Some Article Title | Site] [source: <aaaa1111>] \
+             [claim: <ck-c> trailing words] [claim:xxxx]",
+            &model,
+            &records,
+        );
+        assert_eq!(decorated[0]["verified"], true, "title-decorated sha resolves");
+        assert_eq!(decorated[0]["link_target"], "/library/aaaa1111");
+        assert_eq!(decorated[1]["verified"], true, "angle-bracketed sha resolves");
+        assert_eq!(decorated[2]["verified"], true, "decorated claim key resolves");
+        assert_eq!(decorated[3]["verified"], false, "placeholder still fails");
     }
 
     /// A3b: a busy session answers 409 without touching the model, and an

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -2381,11 +2381,31 @@ fn handle_ask_agent(
                     Some(m) => agent_citations(&done.answer, &m, &records),
                     None => agent_citations_unindexed(&done.answer, &records),
                 };
+                // Export REPAIR: a committed turn whose chat save failed
+                // would otherwise stay missing from History forever — every
+                // keyed retry returns here, before the live path's save. If
+                // the surface has no file at all for this session, save now
+                // (same deliverable-only rule as the live path).
+                let mut replay_save_error = None;
+                if matches!(done.stopped_reason.as_str(), "final" | "need_user" | "refusal")
+                    && !done.answer.is_empty()
+                    && !ovp_memory::ask::agent_chat_exists(&vault_root, &response_session)
+                {
+                    let _save_guard = chat_saves.lock().unwrap();
+                    if let Err(e) = ovp_memory::ask::save_agent_chat_turn(
+                        &vault_root,
+                        &response_session,
+                        &question,
+                        &done.answer,
+                    ) {
+                        replay_save_error = Some(e);
+                    }
+                }
                 // Coverage is an EXECUTION artifact the transcript does not
                 // persist — a replay reports null (unknown), never a
                 // fabricated all-not_queried that would misdescribe the
                 // original turn.
-                return Ok(serde_json::json!({
+                let mut body = serde_json::json!({
                     "agent": true,
                     "answer": done.answer,
                     "citations": citations,
@@ -2399,7 +2419,11 @@ fn handle_ask_agent(
                         "input_tokens": done.input_tokens_total,
                         "output_tokens": done.output_tokens_total,
                     },
-                }));
+                });
+                if let (Some(e), Some(obj)) = (replay_save_error, body.as_object_mut()) {
+                    obj.insert("chat_save_error".into(), serde_json::json!(e));
+                }
+                return Ok(body);
             }
             let mut client = factory()?;
             // `coordinated cap`: the tools refuse anything the agent's

--- a/evolution/candidates/ask_agent_policy-v2.json
+++ b/evolution/candidates/ask_agent_policy-v2.json
@@ -1,0 +1,26 @@
+{
+  "kind": "ovp.evolution.candidate/v1",
+  "id": "ask_agent_policy-v2",
+  "base_version": "v1",
+  "target_version": "v2",
+  "surface": "prompt",
+  "component": "prompt.ask_agent_policy",
+  "hypothesis": "PROMPT surface, driven by four live paired-eval failure modes (real vault, 2026-07-25): (1) the model wrote placeholder citations ([claim:xxxx]) on a meta question and decorated real ids with titles/angle brackets inside the brackets — receipts failed verification wholesale; (2) a 9k-char answer overran the output budget and stopped model_error; (3) a reused cursor after query reformulation burned rounds; (4) a vague recall with two plausible articles silently committed to one. Four additive policy blocks: bare-key-only citation form + never-placeholder, hard length discipline (lead with the finding, shortest complete answer), cursor-belongs-to-its-query, and present-all-candidates for ambiguous recall. Predicted: verified-citation rate on source-citing questions rises materially and cap-overflow model_error final replies disappear, with zero-call meta behavior unchanged.",
+  "predicted_delta": {
+    "crystal_provenance": "receipts survive verification because the model emits the exact resolvable form; placeholders vanish (fail-closed already caught them — now they are not produced)",
+    "coverage": "ambiguous recall presents every plausible candidate with distinguishing evidence instead of a silent best guess",
+    "operational_reliability": "answers fit the output budget; stale-cursor round burns stop"
+  },
+  "guardrails": {
+    "additive_blocks_only": "existing policy sections keep their text; the four fixes add sentences/blocks without weakening any A3a discipline (checklist tests keep passing unmodified)",
+    "zero_call_meta_unchanged": "capability questions still require zero tool calls (T5 discipline untouched)",
+    "fail_closed_stays": "the server verifier remains fail-closed regardless — policy reduces malformed citations, it is not the enforcement layer"
+  },
+  "eval_plan": {
+    "replay_set": "the four failing paired-eval questions replayed live post-change: q4-meta must emit no placeholder brackets; q8-cross-source must finish stopped_reason=final with a majority of citations verified; q1-recall must not burn rounds on stale cursors; recall-with-two-candidates presents both. Deterministic: agent_policy checklist + zero-quote tripwire tests pass unmodified.",
+    "paired_sources": 0,
+    "soak": false
+  },
+  "rollback": "Revert the const string to the v1 text — no state, no data migration.",
+  "ablation_required": false
+}

--- a/evolution/candidates/ask_default_flip-v1.json
+++ b/evolution/candidates/ask_default_flip-v1.json
@@ -1,0 +1,26 @@
+{
+  "kind": "ovp.evolution.candidate/v1",
+  "id": "ask_default_flip-v1",
+  "base_version": "v1.2",
+  "target_version": "v2",
+  "surface": "runtime",
+  "component": "runtime.ask_product_wiring",
+  "hypothesis": "RUNTIME surface, the A3d acceptance act: the tool-loop agent becomes the DEFAULT /api/ask path (CLI: OVP_ASK_AGENT=0 is the rollback hatch to the legacy pipeline; desktop: parity true). Evidence = the A3d paired eval (8 questions x agent/legacy, real 1281-source vault, two fix rounds): agent wins recall outright (found + verified receipts where legacy returned prose with zero receipts), wins durable-claims QA 33/34 vs 4/4 verified receipts, wins cross-source synthesis (6/7 verified, stopped final), matches find/explore classes, and ends with ZERO hard failures (the initial tool_error/model_error modes were diagnosed and fixed: stale-cursor breaker class, receipt tolerance, length policy, last-round notice). Keyword intent routing (intent.rs) is hereby retired from the production main path — reachable only through the opt-out hatch until the legacy path is removed.",
+  "predicted_delta": {
+    "coverage": "the default ask can search evidence cards and full bodies, read originals, and report per-layer coverage — the legacy path answers only from pre-retrieved context",
+    "crystal_provenance": "every default-path answer carries server-resolved receipts (verified against ledger/index), not model-claimed citations",
+    "operational_reliability": "live progress feed + honest partial trails on failure; deadline-authoritative turns always commit a transcript"
+  },
+  "guardrails": {
+    "rollback_hatch_stays": "OVP_ASK_AGENT=0 serves the byte-identical legacy path (its tests are untouched); the hatch stays until the legacy path's removal is its own reviewed change",
+    "registry_flip_recorded": "components.json flips runtime.ask_agent/runtime.ask_vault_tools/prompt.ask_agent_policy/runtime.ask_product_wiring to their delivered versions in the same commit as the default change",
+    "eval_preregistered": "the paired-eval verdict rule (agent >= legacy on verified receipts for the majority of classes, zero hard failures) was fixed before the run; the two fix rounds are recorded in the candidate chain (ask_receipt_tolerance-v1, ask_agent_policy-v2, ask_last_round_notice-v1)"
+  },
+  "eval_plan": {
+    "replay_set": "the 8-question paired eval artifacts (.run/a3d-eval/, local): round-1 scoreboard, per-question diagnosis, round-2/3 fix verification (q1 final 3/3 verified with both candidates presented; q8 final 6/7; q3 2/2). Deterministic: full agent test suites + flag-off legacy tests pass unmodified.",
+    "paired_sources": 0,
+    "soak": false
+  },
+  "rollback": "Set OVP_ASK_AGENT=0 (CLI) / ask_agent: false (desktop) — the legacy path never moved.",
+  "ablation_required": false
+}

--- a/evolution/candidates/ask_last_round_notice-v1.json
+++ b/evolution/candidates/ask_last_round_notice-v1.json
@@ -1,0 +1,25 @@
+{
+  "kind": "ovp.evolution.candidate/v1",
+  "id": "ask_last_round_notice-v1",
+  "base_version": "v1",
+  "target_version": "v1.1",
+  "surface": "runtime",
+  "component": "runtime.ask_agent",
+  "hypothesis": "RUNTIME surface, one additive engine behavior: when a tool batch consumes the FINAL allowed round (the next batch would be refused by max_rounds), the model-facing copy of that batch's last result gains a runtime notice — tool budget exhausted, write your answer now from what you have. Live evidence (paired eval, real vault): a recall turn located BOTH target articles by round 6 of 10 and still ended max_rounds with a 184-char process narration instead of an answer — the model had no way to know the budget was gone. Same mechanism as the existing [truncated] marker: model-facing copy only, the audit ToolCalled event keeps the raw content. Predicted: max_rounds terminations become synthesized answers; turns that finish early are byte-identical (no notice below the final round).",
+  "predicted_delta": {
+    "operational_reliability": "investigation turns that exhaust rounds deliver their findings instead of a mid-flight narration; stopped_reason max_rounds becomes rare and, when it happens, still carries a real answer",
+    "coverage": "found-but-unsynthesized results stop being lost at the round boundary"
+  },
+  "guardrails": {
+    "audit_unchanged": "TranscriptEvent::ToolCalled keeps the raw result content — the notice exists ONLY in the model-facing ToolResults copy, exactly like the truncation marker (test asserts both sides)",
+    "below_budget_byte_identical": "rounds before the final one carry no notice; a turn that never reaches the cap is unchanged (test asserts round 1 of 2 is clean)",
+    "cap_respected": "the notice participates in the max_result_bytes cap (content shrinks to make room); degenerate caps smaller than the notice skip it rather than exceed the cap"
+  },
+  "eval_plan": {
+    "replay_set": "engine test: max_rounds=2 scripted turn — round-1 results clean, round-2 results carry content + notice, audit raw; live replay of the q1 recall eval question must end with a synthesized candidates answer rather than a process narration",
+    "paired_sources": 0,
+    "soak": false
+  },
+  "rollback": "Delete the notice block — model-facing only, no persisted-state impact; old transcripts replay untouched (idempotent replay reads turn_finished, not result bytes).",
+  "ablation_required": false
+}

--- a/evolution/candidates/ask_receipt_tolerance-v1.json
+++ b/evolution/candidates/ask_receipt_tolerance-v1.json
@@ -1,0 +1,23 @@
+{
+  "kind": "ovp.evolution.candidate/v1",
+  "id": "ask_receipt_tolerance-v1",
+  "base_version": "v1",
+  "target_version": "v1.2",
+  "surface": "runtime",
+  "component": "runtime.ask_product_wiring",
+  "hypothesis": "RUNTIME surface, single verifier refinement: the server citation verifier extracts the first whitespace-delimited token (trimmed of angle brackets) from a citation's id segment before resolving. Live paired-eval evidence: models decorate ids in the wild — [source:<sha> Title | Site], [source: <sha>] — and exact-string matching failed 9/9 receipts on a cross-source answer whose shas were all real and resolvable. Resolution stays exact: the extracted token must still match a ledger claim_key or index sha256 verbatim, so fabricated keys and placeholders still verify false. Predicted: verified rate on source-citing answers rises to match the model's actual grounding; no false positives are introduced (garbage tokens resolve to nothing).",
+  "predicted_delta": {
+    "crystal_provenance": "receipts reflect actual grounding instead of penalizing citation formatting; fail-closed semantics (fabrication → verified:false, ambiguous claim anchors → no link) unchanged"
+  },
+  "guardrails": {
+    "exact_resolution_unchanged": "tolerance applies ONLY to token extraction; the resolved token must equal a claim_key / sha256 exactly — placeholder and fabricated ids still fail, covered by test",
+    "legacy_verifier_untouched": "the legacy ask path's verifier is not modified; this touches only the agent-path receipt builder"
+  },
+  "eval_plan": {
+    "replay_set": "server test: decorated forms ([source:<sha> Title], [source: <sha>], [claim: <key> words]) verify true with correct links; [claim:xxxx] stays false. Live: re-run of the failing paired-eval question must show most source receipts verified.",
+    "paired_sources": 0,
+    "soak": false
+  },
+  "rollback": "Remove the token-extraction helper — one function, no persisted state.",
+  "ablation_required": false
+}

--- a/evolution/components.json
+++ b/evolution/components.json
@@ -1,201 +1,201 @@
 {
-  "components": [
-    {
-      "id": "prompt.unit_extract",
-      "surface": "prompt",
-      "current_version": "v5",
-      "file": "crates/ovp-domain/prompts/unit_extraction.md",
-      "quality_buckets": [
-        "extraction_fidelity",
-        "coverage"
-      ],
-      "regression_fixtures": [
-        "fixtures/reader/m14a-coverage-set/"
-      ]
-    },
-    {
-      "id": "prompt.unit_critic",
-      "surface": "prompt",
-      "current_version": "v1",
-      "file": "crates/ovp-domain/prompts/unit_critic.md",
-      "quality_buckets": [
-        "extraction_fidelity"
-      ]
-    },
-    {
-      "id": "prompt.card_synth",
-      "surface": "prompt",
-      "current_version": "v3",
-      "file": "crates/ovp-domain/prompts/card_synthesis.md",
-      "quality_buckets": [
-        "card_quality",
-        "coverage"
-      ]
-    },
-    {
-      "id": "runtime.web_fetch",
-      "surface": "runtime",
-      "file": "crates/ovp-enrich/src/web_fetch.rs",
-      "quality_buckets": [
-        "operational_reliability"
-      ]
-    },
-    {
-      "id": "gate.crystal_lint",
-      "surface": "gate",
-      "file": "crates/ovp-cli/src/commands/crystal_lint.rs",
-      "quality_buckets": [
-        "crystal_provenance"
-      ]
-    },
-    {
-      "id": "prompt.crystal_synth",
-      "surface": "prompt",
-      "current_version": "v1",
-      "file": "crates/ovp-domain/prompts/crystal_synth.md",
-      "quality_buckets": [
-        "crystal_provenance",
-        "coverage"
-      ]
-    },
-    {
-      "id": "prompt.crystal_strength",
-      "surface": "prompt",
-      "current_version": "v1",
-      "file": "crates/ovp-domain/prompts/crystal_strength.md",
-      "quality_buckets": [
-        "crystal_provenance"
-      ]
-    },
-    {
-      "id": "prompt.cluster_select",
-      "surface": "prompt",
-      "current_version": "v1",
-      "file": "crates/ovp-domain/prompts/cluster_select.md",
-      "quality_buckets": [
-        "crystal_provenance",
-        "coverage"
-      ]
-    },
-    {
-      "id": "prompt.theme_label",
-      "surface": "prompt",
-      "current_version": "v1",
-      "file": "crates/ovp-domain/prompts/theme_label.md",
-      "quality_buckets": [
-        "card_quality"
-      ]
-    },
-    {
-      "id": "prompt.ask",
-      "surface": "prompt",
-      "current_version": "v3",
-      "file": "crates/ovp-memory/src/ask.rs",
-      "quality_buckets": [
-        "crystal_provenance",
-        "operational_reliability"
-      ]
-    },
-    {
-      "id": "prompt.theme_page",
-      "surface": "prompt",
-      "current_version": "v1",
-      "file": "crates/ovp-domain/prompts/theme_page.md",
-      "quality_buckets": [
-        "crystal_provenance",
-        "coverage"
-      ]
-    },
-    {
-      "id": "parser.json_repair",
-      "surface": "parser",
-      "file": "crates/ovp-domain/src/units/parser.rs",
-      "quality_buckets": [
-        "operational_reliability",
-        "extraction_fidelity"
-      ]
-    },
-    {
-      "id": "runtime.scheduler",
-      "surface": "runtime",
-      "current_version": "v1",
-      "file": "crates/ovp-scheduler/src/lib.rs",
-      "quality_buckets": [
-        "operational_reliability"
-      ]
-    },
-    {
-      "id": "parser.ask_verify",
-      "surface": "parser",
-      "current_version": "v1",
-      "file": "crates/ovp-memory/src/verify.rs",
-      "quality_buckets": [
-        "crystal_provenance",
-        "operational_reliability"
-      ]
-    },
-    {
-      "id": "runtime.claim_citation_keys",
-      "surface": "runtime",
-      "current_version": "v1",
-      "file": "crates/ovp-index/src/model.rs",
-      "quality_buckets": [
-        "crystal_provenance"
-      ]
-    },
-    {
-      "id": "model.ask_tool_protocol",
-      "surface": "model",
-      "current_version": "v1",
-      "file": "crates/ovp-llm/src/request.rs",
-      "quality_buckets": [
-        "operational_reliability",
-        "cost_efficiency"
-      ]
-    },
-    {
-      "id": "runtime.ask_agent",
-      "surface": "runtime",
-      "current_version": "none",
-      "file": "crates/ovp-memory/src/ask.rs",
-      "quality_buckets": [
-        "coverage",
-        "operational_reliability",
-        "crystal_provenance"
-      ]
-    },
-    {
-      "id": "runtime.ask_vault_tools",
-      "surface": "runtime",
-      "current_version": "none",
-      "file": "crates/ovp-memory/src/vault_tools.rs",
-      "quality_buckets": [
-        "coverage",
-        "operational_reliability",
-        "crystal_provenance"
-      ]
-    },
-    {
-      "id": "prompt.ask_agent_policy",
-      "surface": "prompt",
-      "current_version": "none",
-      "file": "crates/ovp-memory/src/agent_policy.rs",
-      "quality_buckets": [
-        "coverage",
-        "crystal_provenance",
-        "operational_reliability"
-      ]
-    },
-    {
-      "id": "runtime.ask_product_wiring",
-      "surface": "runtime",
-      "current_version": "none",
-      "file": "crates/ovp-server/src/lib.rs",
-      "quality_buckets": [
-        "coverage",
-        "operational_reliability",
-        "crystal_provenance"
-      ]
-    }
-  ]
+ "components": [
+  {
+   "id": "prompt.unit_extract",
+   "surface": "prompt",
+   "current_version": "v5",
+   "file": "crates/ovp-domain/prompts/unit_extraction.md",
+   "quality_buckets": [
+    "extraction_fidelity",
+    "coverage"
+   ],
+   "regression_fixtures": [
+    "fixtures/reader/m14a-coverage-set/"
+   ]
+  },
+  {
+   "id": "prompt.unit_critic",
+   "surface": "prompt",
+   "current_version": "v1",
+   "file": "crates/ovp-domain/prompts/unit_critic.md",
+   "quality_buckets": [
+    "extraction_fidelity"
+   ]
+  },
+  {
+   "id": "prompt.card_synth",
+   "surface": "prompt",
+   "current_version": "v3",
+   "file": "crates/ovp-domain/prompts/card_synthesis.md",
+   "quality_buckets": [
+    "card_quality",
+    "coverage"
+   ]
+  },
+  {
+   "id": "runtime.web_fetch",
+   "surface": "runtime",
+   "file": "crates/ovp-enrich/src/web_fetch.rs",
+   "quality_buckets": [
+    "operational_reliability"
+   ]
+  },
+  {
+   "id": "gate.crystal_lint",
+   "surface": "gate",
+   "file": "crates/ovp-cli/src/commands/crystal_lint.rs",
+   "quality_buckets": [
+    "crystal_provenance"
+   ]
+  },
+  {
+   "id": "prompt.crystal_synth",
+   "surface": "prompt",
+   "current_version": "v1",
+   "file": "crates/ovp-domain/prompts/crystal_synth.md",
+   "quality_buckets": [
+    "crystal_provenance",
+    "coverage"
+   ]
+  },
+  {
+   "id": "prompt.crystal_strength",
+   "surface": "prompt",
+   "current_version": "v1",
+   "file": "crates/ovp-domain/prompts/crystal_strength.md",
+   "quality_buckets": [
+    "crystal_provenance"
+   ]
+  },
+  {
+   "id": "prompt.cluster_select",
+   "surface": "prompt",
+   "current_version": "v1",
+   "file": "crates/ovp-domain/prompts/cluster_select.md",
+   "quality_buckets": [
+    "crystal_provenance",
+    "coverage"
+   ]
+  },
+  {
+   "id": "prompt.theme_label",
+   "surface": "prompt",
+   "current_version": "v1",
+   "file": "crates/ovp-domain/prompts/theme_label.md",
+   "quality_buckets": [
+    "card_quality"
+   ]
+  },
+  {
+   "id": "prompt.ask",
+   "surface": "prompt",
+   "current_version": "v3",
+   "file": "crates/ovp-memory/src/ask.rs",
+   "quality_buckets": [
+    "crystal_provenance",
+    "operational_reliability"
+   ]
+  },
+  {
+   "id": "prompt.theme_page",
+   "surface": "prompt",
+   "current_version": "v1",
+   "file": "crates/ovp-domain/prompts/theme_page.md",
+   "quality_buckets": [
+    "crystal_provenance",
+    "coverage"
+   ]
+  },
+  {
+   "id": "parser.json_repair",
+   "surface": "parser",
+   "file": "crates/ovp-domain/src/units/parser.rs",
+   "quality_buckets": [
+    "operational_reliability",
+    "extraction_fidelity"
+   ]
+  },
+  {
+   "id": "runtime.scheduler",
+   "surface": "runtime",
+   "current_version": "v1",
+   "file": "crates/ovp-scheduler/src/lib.rs",
+   "quality_buckets": [
+    "operational_reliability"
+   ]
+  },
+  {
+   "id": "parser.ask_verify",
+   "surface": "parser",
+   "current_version": "v1",
+   "file": "crates/ovp-memory/src/verify.rs",
+   "quality_buckets": [
+    "crystal_provenance",
+    "operational_reliability"
+   ]
+  },
+  {
+   "id": "runtime.claim_citation_keys",
+   "surface": "runtime",
+   "current_version": "v1",
+   "file": "crates/ovp-index/src/model.rs",
+   "quality_buckets": [
+    "crystal_provenance"
+   ]
+  },
+  {
+   "id": "model.ask_tool_protocol",
+   "surface": "model",
+   "current_version": "v1",
+   "file": "crates/ovp-llm/src/request.rs",
+   "quality_buckets": [
+    "operational_reliability",
+    "cost_efficiency"
+   ]
+  },
+  {
+   "id": "runtime.ask_agent",
+   "surface": "runtime",
+   "current_version": "v1.1",
+   "file": "crates/ovp-memory/src/ask.rs",
+   "quality_buckets": [
+    "coverage",
+    "operational_reliability",
+    "crystal_provenance"
+   ]
+  },
+  {
+   "id": "runtime.ask_vault_tools",
+   "surface": "runtime",
+   "current_version": "v2",
+   "file": "crates/ovp-memory/src/vault_tools.rs",
+   "quality_buckets": [
+    "coverage",
+    "operational_reliability",
+    "crystal_provenance"
+   ]
+  },
+  {
+   "id": "prompt.ask_agent_policy",
+   "surface": "prompt",
+   "current_version": "v2",
+   "file": "crates/ovp-memory/src/agent_policy.rs",
+   "quality_buckets": [
+    "coverage",
+    "crystal_provenance",
+    "operational_reliability"
+   ]
+  },
+  {
+   "id": "runtime.ask_product_wiring",
+   "surface": "runtime",
+   "current_version": "v1.2",
+   "file": "crates/ovp-server/src/lib.rs",
+   "quality_buckets": [
+    "coverage",
+    "operational_reliability",
+    "crystal_provenance"
+   ]
+  }
+ ]
 }

--- a/evolution/components.json
+++ b/evolution/components.json
@@ -189,7 +189,7 @@
   {
    "id": "runtime.ask_product_wiring",
    "surface": "runtime",
-   "current_version": "v1.2",
+   "current_version": "v2",
    "file": "crates/ovp-server/src/lib.rs",
    "quality_buckets": [
     "coverage",


### PR DESCRIPTION
The A3d rollout: after an 8-question paired eval (agent vs legacy, real 1281-source vault, pre-registered verdict rule) plus two fix rounds, the tool-loop agent becomes the DEFAULT /api/ask path.

**Eval summary** (verified receipts, agent vs legacy): recall 3/3 vs 0/0 (both candidate articles presented with distinguishing evidence); durable-claims QA 33/34 vs 4/4; cross-source synthesis 6/7 (final) vs 5/5; find/explore/meta comparable; zero hard failures after fixes. Eval artifacts in .run/a3d-eval/ (local).

**Eval-driven fixes** (candidates ask_receipt_tolerance-v1, ask_agent_policy-v2, ask_last_round_notice-v1): stale-cursor breaker class + offset-bound cursor fingerprints (also closes the deferred #375 gate-r2 finding), tolerant receipt token extraction (exact resolution unchanged), policy v2 (bare-key citations, never-placeholder, length discipline, cursor hygiene, multi-candidate recall), last-round runtime notice (found-but-unsynthesized turns now deliver).

**The flip** (candidate ask_default_flip-v1): CLI default on (OVP_ASK_AGENT=0 = rollback hatch), desktop parity, registry versions recorded, cassette namespace v2, intent.rs retired from the production main path.

**History parity** (5 gate rounds hardened it): answered agent turns land on the .ovp/chats surface (deliverable-only, append-never-truncate, replay repair); saved-chat replay claims UNKNOWN verification instead of upgrading fabricated receipts; transcript parser handles bare separators; claim_key anchors resolve on /knowledge.

MCP ask rewiring onto the shared agent loop = next PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ask now defaults to the agent-assisted workflow, with environment-based enablement behavior.
  * Agent chat turns are persisted under chats, including recovery for replayed requests.
* **Bug Fixes**
  * Knowledge claim navigation now forwards hashes using a resolved stable claim key.
  * Chat parsing and citation handling are more tolerant, and saved-chat citations no longer appear as fully verified.
  * Tool/search cursor handling now distinguishes stale vs invalid cursors and fails safely.
* **Improvements**
  * More consistent citation linking/formatting, including improved handling of ambiguous findings.
  * Agent responses are better finalized at the last tool round.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->