### PR TITLE
feat(mcp): ask runs the shared vault agent (ask_mcp_rewire-v1)

### DIFF
--- a/crates/ovp-cli/src/commands/mcp.rs
+++ b/crates/ovp-cli/src/commands/mcp.rs
@@ -2,7 +2,7 @@
 
 use std::path::PathBuf;
 
-use ovp_server::{providers_ask_client_factory, LLM_NOT_CONFIGURED};
+use ovp_server::{providers_ask_client_factory_bounded, LLM_NOT_CONFIGURED};
 use ovp_mcp::{McpConfig, run_mcp};
 
 use crate::CliError;
@@ -14,7 +14,11 @@ pub struct McpArgs {
 pub fn run(args: McpArgs) -> Result<(), CliError> {
     // Same providers-aware factory as `serve` / desktop: re-reads
     // `.ovp/providers.toml` each ask; no set_var.
-    let ask_client = providers_ask_client_factory(args.vault_root.clone());
+    // Bounded posture for the synchronous stdio host: one slow provider
+    // call blocks EVERY MCP request, so the per-request timeout is clamped
+    // and transient retries are off (the agent loop reports an honest
+    // model_error instead of silently tripling the wait).
+    let ask_client = providers_ask_client_factory_bounded(args.vault_root.clone(), 45);
     // stdout is the JSON-RPC channel — operator-facing notes go to stderr.
     match &ask_client {
         None => eprintln!(

--- a/crates/ovp-llm/src/lib.rs
+++ b/crates/ovp-llm/src/lib.rs
@@ -33,5 +33,6 @@ pub use request::{
 pub use anthropic::AnthropicBlockingClient;
 #[cfg(feature = "anthropic")]
 pub use live::{
-    build_recording_live_client, resolve_api_key, LiveClientConfig, LLM_NOT_CONFIGURED,
+    build_recording_live_client, build_recording_live_client_bounded, resolve_api_key,
+    LiveClientConfig, LLM_NOT_CONFIGURED,
 };

--- a/crates/ovp-llm/src/live.rs
+++ b/crates/ovp-llm/src/live.rs
@@ -232,9 +232,15 @@ pub fn build_recording_live_client_bounded(
     Ok(Box::new(cached))
 }
 
-/// A user-configured timeout may SHORTEN the bound, never exceed it.
+/// A user-configured timeout may SHORTEN the bound, never exceed or disable
+/// it: `0` means "no timeout" to the underlying HTTP client, which would
+/// defeat the hard wall-clock guarantee — it falls back to the cap.
 pub fn clamp_timeout(configured: Option<u64>, cap_secs: u64) -> u64 {
-    configured.unwrap_or(cap_secs).min(cap_secs)
+    configured
+        .filter(|&t| t > 0)
+        .unwrap_or(cap_secs)
+        .min(cap_secs)
+        .max(1)
 }
 
 /// Resolve a non-empty API key from a lookup. Missing / blank → [`LLM_NOT_CONFIGURED`].
@@ -287,6 +293,14 @@ mod tests {
         assert_eq!(c.max_tokens, Some(24000));
         assert!(c.no_proxy);
         assert_eq!(c.timeout_secs, Some(300));
+    }
+
+    #[test]
+    fn clamp_timeout_never_disables_and_never_exceeds() {
+        assert_eq!(clamp_timeout(None, 45), 45, "no config → cap");
+        assert_eq!(clamp_timeout(Some(10), 45), 10, "shorter is honored");
+        assert_eq!(clamp_timeout(Some(300), 45), 45, "longer is clamped");
+        assert_eq!(clamp_timeout(Some(0), 45), 45, "0 = no-timeout → cap");
     }
 
     #[test]

--- a/crates/ovp-llm/src/live.rs
+++ b/crates/ovp-llm/src/live.rs
@@ -221,13 +221,11 @@ pub fn build_recording_live_client_bounded(
         live = live.with_timeout(secs);
     }
     let retrying = RetryingModelClient::new(live, max_retries, LIVE_RETRY_BACKOFF);
-    let escalated = bounded
-        .max_tokens
-        .unwrap_or(LIVE_BUDGET_BASE_DEFAULT)
-        .saturating_mul(LIVE_BUDGET_ESCALATION_FACTOR)
-        .min(LIVE_BUDGET_ESCALATION_CAP);
-    let escalating = BudgetEscalatingModelClient::new(retrying, escalated);
-    let cached = CachedModelClient::new(escalating, cache_dir, cache_namespace, CacheMode::Record)
+    // NO budget escalation here: it silently issues a SECOND provider
+    // request on BudgetExhausted, doubling the blocking window the whole
+    // builder exists to bound. A truncated reply surfaces as the agent
+    // loop's honest model_error instead.
+    let cached = CachedModelClient::new(retrying, cache_dir, cache_namespace, CacheMode::Record)
         .map_err(|e| format!("opening cache dir `{}`: {e}", cache_dir.display()))?;
     Ok(Box::new(cached))
 }

--- a/crates/ovp-llm/src/live.rs
+++ b/crates/ovp-llm/src/live.rs
@@ -190,7 +190,8 @@ pub fn build_recording_live_client(
 /// the per-request timeout is clamped to `timeout_cap_secs` (user config may
 /// lower it, never raise it) and transient-failure retries are capped at
 /// `max_retries` (0 = fail fast into the agent loop's honest ModelError).
-/// Everything else — budget escalation, cassette recording — is identical.
+/// Budget escalation is ALSO dropped (it issues a second provider request
+/// on BudgetExhausted); cassette recording is identical.
 pub fn build_recording_live_client_bounded(
     api_key: &str,
     cfg: &LiveClientConfig,

--- a/crates/ovp-llm/src/live.rs
+++ b/crates/ovp-llm/src/live.rs
@@ -32,7 +32,7 @@ pub const LLM_NOT_CONFIGURED: &str = "llm_not_configured";
 /// - `OVP_LLM_NO_PROXY` — boolean; bypass ambient `HTTP(S)_PROXY` for the live
 ///   HTTP client ONLY.
 /// - `OVP_LLM_TIMEOUT_SECS` — non-negative integer request timeout.
-#[derive(Debug, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct LiveClientConfig {
     pub base_url: Option<String>,
     pub model: Option<String>,
@@ -183,6 +183,58 @@ pub fn build_recording_live_client(
     let cached = CachedModelClient::new(escalating, cache_dir, cache_namespace, CacheMode::Record)
         .map_err(|e| format!("opening cache dir `{}`: {e}", cache_dir.display()))?;
     Ok(Box::new(cached))
+}
+
+/// [`build_recording_live_client`] with a HARD wall-clock posture for hosts
+/// that cannot tolerate long blocking calls (the synchronous MCP server):
+/// the per-request timeout is clamped to `timeout_cap_secs` (user config may
+/// lower it, never raise it) and transient-failure retries are capped at
+/// `max_retries` (0 = fail fast into the agent loop's honest ModelError).
+/// Everything else — budget escalation, cassette recording — is identical.
+pub fn build_recording_live_client_bounded(
+    api_key: &str,
+    cfg: &LiveClientConfig,
+    cache_dir: &Path,
+    cache_namespace: &str,
+    timeout_cap_secs: u64,
+    max_retries: u32,
+) -> Result<Box<dyn ModelClient>, String> {
+    let mut bounded = cfg.clone();
+    bounded.timeout_secs = Some(clamp_timeout(cfg.timeout_secs, timeout_cap_secs));
+    if api_key.trim().is_empty() {
+        return Err(LLM_NOT_CONFIGURED.into());
+    }
+    let mut live = AnthropicBlockingClient::new(api_key);
+    if let Some(url) = bounded.base_url.as_ref() {
+        live = live.with_base_url(url.clone());
+    }
+    if let Some(model) = bounded.model.as_ref() {
+        live = live.with_model_override(model.clone());
+    }
+    if let Some(mt) = bounded.max_tokens {
+        live = live.with_max_tokens(mt);
+    }
+    if bounded.no_proxy {
+        live = live.with_no_proxy();
+    }
+    if let Some(secs) = bounded.timeout_secs {
+        live = live.with_timeout(secs);
+    }
+    let retrying = RetryingModelClient::new(live, max_retries, LIVE_RETRY_BACKOFF);
+    let escalated = bounded
+        .max_tokens
+        .unwrap_or(LIVE_BUDGET_BASE_DEFAULT)
+        .saturating_mul(LIVE_BUDGET_ESCALATION_FACTOR)
+        .min(LIVE_BUDGET_ESCALATION_CAP);
+    let escalating = BudgetEscalatingModelClient::new(retrying, escalated);
+    let cached = CachedModelClient::new(escalating, cache_dir, cache_namespace, CacheMode::Record)
+        .map_err(|e| format!("opening cache dir `{}`: {e}", cache_dir.display()))?;
+    Ok(Box::new(cached))
+}
+
+/// A user-configured timeout may SHORTEN the bound, never exceed it.
+pub fn clamp_timeout(configured: Option<u64>, cap_secs: u64) -> u64 {
+    configured.unwrap_or(cap_secs).min(cap_secs)
 }
 
 /// Resolve a non-empty API key from a lookup. Missing / blank → [`LLM_NOT_CONFIGURED`].

--- a/crates/ovp-mcp/src/lib.rs
+++ b/crates/ovp-mcp/src/lib.rs
@@ -290,11 +290,12 @@ fn handle_tools_list() -> Result<Value, RpcError> {
             },
             {
                 "name": "ask",
-                "description": "Ask a question answered FROM THE VAULT'S EVIDENCE (active durable claims, cards, verbatim units). The answer carries inline citations and a deterministic report of how many citation IDs resolve against the supplied evidence (ID resolution — it does not prove every sentence is cited). Prefer this over answering from memory for anything the vault may cover; audit any [claim:…] citation with the `claim` tool.",
+                "description": "Ask the VAULT AGENT: a tool-loop agent that searches claims, sources, evidence cards, and full article bodies, reads originals when needed, and answers with server-VERIFIED receipts ([claim:…]/[source:…] resolved against the ledger/index — fabricated references are flagged, never trusted) plus honest per-layer coverage. Prefer this over answering from memory for anything the vault may cover; audit any [claim:…] citation with the `claim` tool. Pass the returned session id as `chat` to continue a conversation.",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
-                        "question": { "type": "string", "description": "The question to answer from vault evidence" }
+                        "question": { "type": "string", "description": "The question for the vault agent" },
+                        "chat": { "type": "string", "description": "Session id from a prior ask — continues that conversation" }
                     },
                     "required": ["question"]
                 }
@@ -356,7 +357,16 @@ fn handle_tools_call(state: &McpState, params: &Value) -> Result<Value, RpcError
     }
 }
 
+/// The MCP projection of the shared vault agent (A0: one tool registry, two
+/// projections). Runs the SAME loop/tools/policy as POST /api/ask; the reply
+/// is the answer plus server-verified receipts, per-layer coverage, and the
+/// session id for continuation. Deliverable turns also land on the saved-chat
+/// History surface, so portal and MCP conversations share one product record.
 fn tool_ask(state: &McpState, args: &Value) -> Result<Value, RpcError> {
+    use ovp_memory::agent::{run_agent_turn, AgentConfig, AgentError, StoppedReason};
+    use ovp_memory::agent_transcript::{valid_session_id, SessionStore};
+    use ovp_memory::vault_tools::VaultTools;
+
     let question = args
         .get("question")
         .and_then(|v| v.as_str())
@@ -376,39 +386,19 @@ fn tool_ask(state: &McpState, args: &Value) -> Result<Value, RpcError> {
                 .into(),
         });
     };
-    let mut model = state.load_model().ok_or_else(|| RpcError {
-        code: -32000,
-        message: "Index not available — run `ovp2 index` first".into(),
-    })?;
-    // This tool promises answers grounded in DURABLE claims — caveated,
-    // superseded, and retracted rows must not be retrievable here (codex
-    // P1; they also could not be audited by the active-record `claim` tool).
-    model
-        .claims
-        .retain(|c| c.status == ovp_index::ClaimStatus::Durable);
-    // Missing evidence.json = a fresh/claims-only vault (fine, noted);
-    // a CORRUPT sidecar is surfaced, never silently downgraded to
-    // claims-only while the report implies full evidence (codex P2).
-    // Existence is checked BEFORE the read so a read failure on a present
-    // file is always classified as corruption, not misfiled as missing.
-    let (evidence, degraded_note) = if !ovp_index::evidence::evidence_path(&state.vault_root)
-        .exists()
-    {
-        (
-            None,
-            Some("note: no evidence sidecar — answer drawn from claims only (no cards/units)"),
-        )
-    } else {
-        match ovp_index::read_evidence(&state.vault_root) {
-            Ok(e) => (Some(e), None),
-            Err(e) => {
-                return Err(RpcError {
-                    code: -32000,
-                    message: format!(
-                        "evidence sidecar unreadable ({e}) — rebuild with `ovp2 index` before asking"
-                    ),
-                });
-            }
+    // A supplied `chat` continues that session; anything else (including an
+    // invalid id) gets a fresh generated session — the reply always says
+    // which id to use next, so continuity is one copy-paste away.
+    let session = match args.get("chat").and_then(|v| v.as_str()).map(str::trim) {
+        Some(id) if valid_session_id(id) => id.to_string(),
+        _ => {
+            static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+            let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            let millis = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis())
+                .unwrap_or(0);
+            format!("mcp-{millis}-{}-{seq}", std::process::id())
         }
     };
     let mut client = factory().map_err(|e| {
@@ -426,49 +416,106 @@ fn tool_ask(state: &McpState, args: &Value) -> Result<Value, RpcError> {
             }
         }
     })?;
-    let ask_args = ovp_memory::ask::AskArgs {
-        question: question.to_string(),
-        verify_citations: true,
-        save_chat: false,
-        ..Default::default()
+    // Same knobs as the HTTP wiring (parity is the contract): the agent
+    // serves unindexed vaults too — tools report layer unavailability
+    // honestly instead of refusing the question up front.
+    let cfg = AgentConfig {
+        model: ovp_memory::ask::AskArgs::default().model_name,
+        system: ovp_memory::agent_policy::AGENT_POLICY.to_string(),
+        max_tokens: 4096,
+        max_rounds: 10,
+        deadline: std::time::Duration::from_secs(90),
+        ..AgentConfig::default()
     };
-    let result = ovp_memory::ask::ask_with_optional_evidence(
-        &model,
-        evidence.as_ref(),
-        client.as_mut(),
-        &ask_args,
-        &state.vault_root,
-    )
-    .map_err(|e| RpcError {
+    let mut tools = VaultTools::new(&state.vault_root)
+        .with_result_cap(cfg.max_result_bytes.saturating_sub(2 * 1024));
+    let sessions_dir = state.vault_root.join(".ovp").join("ask-sessions");
+    let mut store = SessionStore::open(&sessions_dir, &session).map_err(|e| RpcError {
         code: -32000,
-        message: format!("ask failed: {e}"),
+        message: format!("ask session store: {e}"),
     })?;
+    let outcome = run_agent_turn(client.as_mut(), &mut tools, &mut store, question, None, &cfg)
+        .map_err(|e| match e {
+            AgentError::SessionBusy => RpcError {
+                code: -32000,
+                message: format!(
+                    "session `{session}` has a turn in flight — retry shortly or start a new chat"
+                ),
+            },
+            AgentError::Store(d) => RpcError {
+                code: -32000,
+                message: format!("ask session store: {d}"),
+            },
+        })?;
 
-    // Answer first, then the deterministic verification report — the agent
-    // sees HOW grounded the answer is, not just the prose. The report checks
-    // that citation IDs resolve against the supplied evidence; it does NOT
-    // prove every sentence is cited (that gate exists only for theme pages).
-    let mut text = result.answer.trim().to_string();
-    if let Some(v) = &result.verification {
-        text.push_str(&format!(
-            "\n\n---\nverification (citation-ID resolution, not per-sentence): \
-             {} citation(s), {} resolved against supplied evidence",
-            v.cited, v.verified
-        ));
-        if !v.missing.is_empty() {
-            text.push_str(&format!("; UNRESOLVED: {}", v.missing.join(", ")));
-        }
-        if !v.warnings.is_empty() {
-            text.push_str(&format!("; warnings: {}", v.warnings.join(", ")));
-        }
-        text.push_str(
-            "\naudit any [claim:<key>] citation with the `claim` tool \
-             (accepts ck- claim keys, claim ids, and ovp://claim/ URIs)",
-        );
+    // Receipts verify against the SAME index snapshot the tools served from
+    // (or degrade honestly when the vault has no index).
+    let records = ovp_api_projection::readers::load_active_records(
+        &state.vault_root,
+        &ovp_domain::vault_layout::VaultLayout::new(),
+    );
+    let citations = match tools.index_snapshot().as_deref() {
+        Some(m) => ovp_memory::receipts::agent_citations(&outcome.answer, m, &records),
+        None => ovp_memory::receipts::agent_citations_unindexed(&outcome.answer, &records),
+    };
+    let coverage = tools.coverage();
+
+    let mut text = outcome.answer.trim().to_string();
+    text.push_str("\n\n---\n");
+    let verified = citations.iter().filter(|c| c["verified"] == true).count();
+    let unverified: Vec<&str> = citations
+        .iter()
+        .filter(|c| c["verified"] != true)
+        .filter_map(|c| c["id"].as_str())
+        .collect();
+    text.push_str(&format!(
+        "receipts: {} citation(s), {verified} verified against the vault",
+        citations.len()
+    ));
+    if !unverified.is_empty() {
+        text.push_str(&format!("; UNVERIFIED: {}", unverified.join(", ")));
     }
-    if let Some(note) = degraded_note {
-        text.push('\n');
-        text.push_str(note);
+    let cov = serde_json::to_value(coverage).unwrap_or_default();
+    if let Some(obj) = cov.as_object() {
+        let line = obj
+            .iter()
+            .map(|(k, v)| format!("{k}={}", v.as_str().unwrap_or("?")))
+            .collect::<Vec<_>>()
+            .join(" · ");
+        text.push_str(&format!("\ncoverage: {line}"));
+    }
+    if !outcome.tool_trace.is_empty() {
+        let trail = outcome
+            .tool_trace
+            .iter()
+            .map(|t| format!("{}{}", t.tool, if t.is_error { "✗" } else { "✓" }))
+            .collect::<Vec<_>>()
+            .join(", ");
+        text.push_str(&format!("\nagent trail: {trail}"));
+    }
+    if outcome.stopped_reason != StoppedReason::Final {
+        text.push_str(&format!(
+            "\nstopped: {} — the answer may be partial",
+            outcome.stopped_reason.as_str()
+        ));
+    }
+    text.push_str(&format!(
+        "\nsession: {session} (pass as `chat` to continue) — audit any [claim:<key>] \
+         citation with the `claim` tool"
+    ));
+
+    // History parity with the HTTP path: deliverable turns land on the
+    // saved-chat surface; a save failure is reported in-band, never silent.
+    let deliverable = matches!(
+        outcome.stopped_reason,
+        StoppedReason::Final | StoppedReason::NeedUser | StoppedReason::Refusal
+    );
+    if deliverable
+        && !outcome.answer.is_empty()
+        && let Err(e) =
+            ovp_memory::ask::save_agent_chat_turn(&state.vault_root, &session, question, &outcome.answer)
+    {
+        text.push_str(&format!("\nnote: chat history save failed: {e}"));
     }
     Ok(serde_json::json!({ "content": [{ "type": "text", "text": text }] }))
 }
@@ -1005,16 +1052,65 @@ mod tests {
         assert!(err.message.contains("ANTHROPIC_API_KEY"), "{}", err.message);
     }
 
+    /// A full agent turn through the MCP projection: 0-tool scripted reply
+    /// on an unindexed fixture vault — the reply carries the answer, honest
+    /// receipts (the fabricated key flagged UNVERIFIED), the session id for
+    /// continuation, and the deliverable turn lands on saved-chat History.
+    #[test]
+    fn ask_runs_a_full_agent_turn_with_receipts_and_history() {
+        struct Scripted;
+        impl ovp_llm::ModelClient for Scripted {
+            fn call(
+                &mut self,
+                request: &ovp_llm::ModelRequest,
+            ) -> Result<ovp_llm::ModelReply, ovp_llm::CallError> {
+                Ok(ovp_llm::ModelReply {
+                    model: request.model.clone(),
+                    text: "answer [claim:ck-fabricated]".into(),
+                    stop_reason: ovp_llm::StopReason::EndTurn,
+                    usage: ovp_llm::Usage { input_tokens: 1, output_tokens: 1 },
+                    blocks: None,
+                    raw_stop_reason: None,
+                })
+            }
+        }
+        let (tmp, mut state) = fixture_vault();
+        state.ask_client = Some(std::sync::Arc::new(|| {
+            Ok(Box::new(Scripted) as Box<dyn ovp_llm::ModelClient>)
+        }));
+        let v = call(
+            &state,
+            "ask",
+            serde_json::json!({ "question": "q?", "chat": "mcp-turn-test" }),
+        )
+        .unwrap();
+        let text = v["content"][0]["text"].as_str().unwrap();
+        assert!(text.starts_with("answer"), "{text}");
+        assert!(text.contains("UNVERIFIED: claim:ck-fabricated"), "{text}");
+        assert!(text.contains("session: mcp-turn-test"), "{text}");
+        assert!(text.contains("coverage:"), "{text}");
+        // Transcript (audit) + saved chat (History product surface).
+        assert!(
+            tmp.path().join(".ovp/ask-sessions/mcp-turn-test.jsonl").is_file()
+        );
+        let md = std::fs::read_to_string(
+            tmp.path().join(".ovp/chats/mcp-turn-test.md"),
+        )
+        .unwrap();
+        assert!(md.contains("**Q:** q?"), "{md}");
+    }
+
     #[test]
     fn ask_with_a_client_reaches_past_the_config_gate() {
         let (_tmp, mut state) = fixture_vault();
         // A configured factory moves the failure past "not configured" — the
-        // fixture vault has no index, so the next honest error is index
-        // availability (the full pipeline is covered in ovp-memory).
+        // agent path serves unindexed vaults, so the next honest failure is
+        // the client construction itself (the loop/tools/receipts pipeline
+        // is covered in ovp-memory/ovp-server).
         state.ask_client = Some(std::sync::Arc::new(|| Err("never built".into())));
         let err = call(&state, "ask", serde_json::json!({ "question": "q" })).unwrap_err();
         assert!(
-            err.message.contains("Index not available"),
+            err.message.contains("ask client configuration invalid: never built"),
             "{}",
             err.message
         );

--- a/crates/ovp-mcp/src/lib.rs
+++ b/crates/ovp-mcp/src/lib.rs
@@ -571,6 +571,32 @@ fn tool_ask(state: &McpState, args: &Value) -> Result<Value, RpcError> {
         Some(m) => ovp_memory::receipts::agent_citations(&outcome.answer, m, &records),
         None => ovp_memory::receipts::agent_citations_unindexed(&outcome.answer, &records),
     };
+    // A racing process completed this keyed turn between the preflight
+    // lookup and the engine's own replay check — nothing ran HERE, so this
+    // request's tools carry no coverage and no trail, and history was the
+    // racer's to save. Answer + receipts only, marked as a replay.
+    if outcome.idempotent_replay {
+        let verified = citations.iter().filter(|c| c["verified"] == true).count();
+        let unverified: Vec<&str> = citations
+            .iter()
+            .filter(|c| c["verified"] != true)
+            .filter_map(|c| c["id"].as_str())
+            .collect();
+        let mut text = outcome.answer.trim().to_string();
+        text.push_str(&format!(
+            "\n\n---\nreceipts: {} citation(s), {verified} verified against the vault",
+            citations.len()
+        ));
+        if !unverified.is_empty() {
+            text.push_str(&format!("; UNVERIFIED: {}", unverified.join(", ")));
+        }
+        text.push_str(&format!(
+            "\nidempotent replay of turn {} (completed by a concurrent request)\n\
+             session: {session} (pass as `chat` to continue)",
+            outcome.turn_id
+        ));
+        return Ok(serde_json::json!({ "content": [{ "type": "text", "text": text }] }));
+    }
     let coverage = tools.coverage();
 
     let mut text = outcome.answer.trim().to_string();

--- a/crates/ovp-mcp/src/lib.rs
+++ b/crates/ovp-mcp/src/lib.rs
@@ -295,7 +295,8 @@ fn handle_tools_list() -> Result<Value, RpcError> {
                     "type": "object",
                     "properties": {
                         "question": { "type": "string", "description": "The question for the vault agent" },
-                        "chat": { "type": "string", "description": "Session id from a prior ask — continues that conversation" }
+                        "chat": { "type": "string", "description": "Session id from a prior ask — continues that conversation. Retrying the SAME question on the same chat replays the completed turn (no second model call)." },
+                        "idempotency_key": { "type": "string", "description": "Optional stable retry key — a retry with the same key replays the completed turn instead of running a new one" }
                     },
                     "required": ["question"]
                 }
@@ -389,9 +390,14 @@ fn tool_ask(state: &McpState, args: &Value) -> Result<Value, RpcError> {
     // A supplied `chat` continues that session; anything else (including an
     // invalid id) gets a fresh generated session — the reply always says
     // which id to use next, so continuity is one copy-paste away.
-    let session = match args.get("chat").and_then(|v| v.as_str()).map(str::trim) {
-        Some(id) if valid_session_id(id) => id.to_string(),
-        _ => {
+    let supplied_chat = args
+        .get("chat")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|id| valid_session_id(id));
+    let session = match supplied_chat {
+        Some(id) => id.to_string(),
+        None => {
             static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
             let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             let millis = std::time::SystemTime::now()
@@ -401,6 +407,69 @@ fn tool_ask(state: &McpState, args: &Value) -> Result<Value, RpcError> {
             format!("mcp-{millis}-{}-{seq}", std::process::id())
         }
     };
+    // Idempotency: explicit key wins; a CONTINUED session derives one from
+    // (chat, question) so a host retry of a timed-out ask replays the
+    // completed turn instead of paying for (and double-appending) a second
+    // one. A fresh generated session cannot collide, so it needs no key.
+    let idem_key = args
+        .get("idempotency_key")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            supplied_chat.map(|chat| {
+                let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+                for byte in chat.bytes().chain([0u8]).chain(question.bytes()) {
+                    hash ^= u64::from(byte);
+                    hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+                }
+                format!("mcp-auto-{hash:016x}")
+            })
+        });
+    // Provider-free replay parity with the HTTP path: a keyed retry of a
+    // completed turn answers from the transcript BEFORE building a client.
+    let sessions_dir = state.vault_root.join(".ovp").join("ask-sessions");
+    let mut store = SessionStore::open(&sessions_dir, &session).map_err(|e| RpcError {
+        code: -32000,
+        message: format!("ask session store: {e}"),
+    })?;
+    if let Some(key) = idem_key.as_deref()
+        && let Some(done) = store.completed_turn_for_key(key)
+    {
+        let records = ovp_api_projection::readers::load_active_records(
+            &state.vault_root,
+            &ovp_domain::vault_layout::VaultLayout::new(),
+        );
+        let citations = match read_index(&state.vault_root).ok() {
+            Some(m) => ovp_memory::receipts::agent_citations(&done.answer, &m, &records),
+            None => ovp_memory::receipts::agent_citations_unindexed(&done.answer, &records),
+        };
+        let verified = citations.iter().filter(|c| c["verified"] == true).count();
+        let mut text = done.answer.trim().to_string();
+        text.push_str(&format!(
+            "\n\n---\nreceipts: {} citation(s), {verified} verified against the vault\n\
+             idempotent replay of turn {} (no new model call)\nsession: {session} \
+             (pass as `chat` to continue)",
+            citations.len(),
+            done.turn_id
+        ));
+        // History repair: a committed turn whose export failed must not stay
+        // missing forever (same rule as the HTTP replay path).
+        if matches!(done.stopped_reason.as_str(), "final" | "need_user" | "refusal")
+            && !done.answer.is_empty()
+            && !ovp_memory::ask::agent_chat_exists(&state.vault_root, &session)
+            && let Err(e) = ovp_memory::ask::save_agent_chat_turn(
+                &state.vault_root,
+                &session,
+                question,
+                &done.answer,
+            )
+        {
+            text.push_str(&format!("\nnote: chat history save failed: {e}"));
+        }
+        return Ok(serde_json::json!({ "content": [{ "type": "text", "text": text }] }));
+    }
     let mut client = factory().map_err(|e| {
         if e == "llm_not_configured" {
             RpcError {
@@ -429,12 +498,14 @@ fn tool_ask(state: &McpState, args: &Value) -> Result<Value, RpcError> {
     };
     let mut tools = VaultTools::new(&state.vault_root)
         .with_result_cap(cfg.max_result_bytes.saturating_sub(2 * 1024));
-    let sessions_dir = state.vault_root.join(".ovp").join("ask-sessions");
-    let mut store = SessionStore::open(&sessions_dir, &session).map_err(|e| RpcError {
-        code: -32000,
-        message: format!("ask session store: {e}"),
-    })?;
-    let outcome = run_agent_turn(client.as_mut(), &mut tools, &mut store, question, None, &cfg)
+    let outcome = run_agent_turn(
+        client.as_mut(),
+        &mut tools,
+        &mut store,
+        question,
+        idem_key.as_deref(),
+        &cfg,
+    )
         .map_err(|e| match e {
             AgentError::SessionBusy => RpcError {
                 code: -32000,
@@ -1098,6 +1169,50 @@ mod tests {
         )
         .unwrap();
         assert!(md.contains("**Q:** q?"), "{md}");
+    }
+
+    /// A host retry (same chat + same question) replays the completed turn:
+    /// one transcript turn, one History block, no second model call.
+    #[test]
+    fn ask_retry_on_same_chat_replays_without_a_second_turn() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        static CALLS: AtomicUsize = AtomicUsize::new(0);
+        struct Counting;
+        impl ovp_llm::ModelClient for Counting {
+            fn call(
+                &mut self,
+                request: &ovp_llm::ModelRequest,
+            ) -> Result<ovp_llm::ModelReply, ovp_llm::CallError> {
+                CALLS.fetch_add(1, Ordering::SeqCst);
+                Ok(ovp_llm::ModelReply {
+                    model: request.model.clone(),
+                    text: "stable answer".into(),
+                    stop_reason: ovp_llm::StopReason::EndTurn,
+                    usage: ovp_llm::Usage { input_tokens: 1, output_tokens: 1 },
+                    blocks: None,
+                    raw_stop_reason: None,
+                })
+            }
+        }
+        let (tmp, mut state) = fixture_vault();
+        state.ask_client = Some(std::sync::Arc::new(|| {
+            Ok(Box::new(Counting) as Box<dyn ovp_llm::ModelClient>)
+        }));
+        let args = serde_json::json!({ "question": "same q", "chat": "mcp-retry-test" });
+        let first = call(&state, "ask", args.clone()).unwrap();
+        assert!(first["content"][0]["text"].as_str().unwrap().starts_with("stable answer"));
+        let retry = call(&state, "ask", args).unwrap();
+        let text = retry["content"][0]["text"].as_str().unwrap();
+        assert!(text.contains("idempotent replay"), "{text}");
+        assert_eq!(CALLS.load(Ordering::SeqCst), 1, "no second paid model call");
+        let transcript = std::fs::read_to_string(
+            tmp.path().join(".ovp/ask-sessions/mcp-retry-test.jsonl"),
+        )
+        .unwrap();
+        assert_eq!(transcript.matches("turn_finished").count(), 1);
+        let md =
+            std::fs::read_to_string(tmp.path().join(".ovp/chats/mcp-retry-test.md")).unwrap();
+        assert_eq!(md.matches("**Q:** same q").count(), 1, "{md}");
     }
 
     #[test]

--- a/crates/ovp-mcp/src/lib.rs
+++ b/crates/ovp-mcp/src/lib.rs
@@ -377,16 +377,6 @@ fn tool_ask(state: &McpState, args: &Value) -> Result<Value, RpcError> {
             code: -32602,
             message: "`question` is required".into(),
         })?;
-    // Explicit configuration error, never a silent degrade: an agent must be
-    // able to tell "no LLM wired" from "the vault has no answer".
-    let Some(factory) = &state.ask_client else {
-        return Err(RpcError {
-            code: -32000,
-            message: "ask is not configured — run ovp2 built with `--features anthropic` \
-                      and set an API key via System → LLM Provider (or ANTHROPIC_API_KEY)"
-                .into(),
-        });
-    };
     // A supplied `chat` continues that session; anything else (including an
     // invalid id) gets a fresh generated session — the reply always says
     // which id to use next, so continuity is one copy-paste away.
@@ -411,12 +401,19 @@ fn tool_ask(state: &McpState, args: &Value) -> Result<Value, RpcError> {
     // (chat, question) so a host retry of a timed-out ask replays the
     // completed turn instead of paying for (and double-appending) a second
     // one. A fresh generated session cannot collide, so it needs no key.
-    let explicit_key = args
-        .get("idempotency_key")
-        .and_then(|v| v.as_str())
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(str::to_string);
+    let explicit_key = match args.get("idempotency_key") {
+        None | Some(Value::Null) => None,
+        Some(Value::String(s)) if !s.trim().is_empty() => Some(s.trim().to_string()),
+        // A malformed supplied key must fail LOUD (HTTP-path parity):
+        // dropping it would silently lose paid-call idempotency, or worse,
+        // fall back to the auto-derived key and replay a different turn.
+        Some(_) => {
+            return Err(RpcError {
+                code: -32602,
+                message: "`idempotency_key` must be a non-empty string".into(),
+            });
+        }
+    };
     // Same rule as the HTTP path: a key is only useful on a STABLE session
     // (replay lookup is session-local) — a key on a generated session could
     // never replay and would silently re-run a paid turn on retry.
@@ -512,6 +509,17 @@ fn tool_ask(state: &McpState, args: &Value) -> Result<Value, RpcError> {
         }
         return Ok(serde_json::json!({ "content": [{ "type": "text", "text": text }] }));
     }
+    // Explicit configuration error, never a silent degrade — checked AFTER
+    // the replay preflight, so a keyed retry of a completed turn answers
+    // provider-free even when no LLM is configured (HTTP-path parity).
+    let Some(factory) = &state.ask_client else {
+        return Err(RpcError {
+            code: -32000,
+            message: "ask is not configured — run ovp2 built with `--features anthropic` \
+                      and set an API key via System → LLM Provider (or ANTHROPIC_API_KEY)"
+                .into(),
+        });
+    };
     let mut client = factory().map_err(|e| {
         if e == "llm_not_configured" {
             RpcError {

--- a/crates/ovp-mcp/src/lib.rs
+++ b/crates/ovp-mcp/src/lib.rs
@@ -380,11 +380,20 @@ fn tool_ask(state: &McpState, args: &Value) -> Result<Value, RpcError> {
     // A supplied `chat` continues that session; anything else (including an
     // invalid id) gets a fresh generated session — the reply always says
     // which id to use next, so continuity is one copy-paste away.
-    let supplied_chat = args
-        .get("chat")
-        .and_then(|v| v.as_str())
-        .map(str::trim)
-        .filter(|id| valid_session_id(id));
+    let supplied_chat = match args.get("chat") {
+        None | Some(Value::Null) => None,
+        Some(Value::String(s)) if valid_session_id(s.trim()) => Some(s.trim()),
+        // A malformed supplied chat fails LOUD (HTTP parity): silently
+        // minting a fresh session would break the continuity (and the
+        // replay contract) the caller asked for.
+        Some(_) => {
+            return Err(RpcError {
+                code: -32602,
+                message: "`chat` must be a valid session id ([A-Za-z0-9_-], ≤64 chars)"
+                    .into(),
+            });
+        }
+    };
     let session = match supplied_chat {
         Some(id) => id.to_string(),
         None => {
@@ -403,14 +412,16 @@ fn tool_ask(state: &McpState, args: &Value) -> Result<Value, RpcError> {
     // one. A fresh generated session cannot collide, so it needs no key.
     let explicit_key = match args.get("idempotency_key") {
         None | Some(Value::Null) => None,
-        Some(Value::String(s)) if !s.trim().is_empty() => Some(s.trim().to_string()),
+        Some(Value::String(s)) if !s.trim().is_empty() && s.trim().len() <= 128 => {
+            Some(s.trim().to_string())
+        }
         // A malformed supplied key must fail LOUD (HTTP-path parity):
         // dropping it would silently lose paid-call idempotency, or worse,
         // fall back to the auto-derived key and replay a different turn.
         Some(_) => {
             return Err(RpcError {
                 code: -32602,
-                message: "`idempotency_key` must be a non-empty string".into(),
+                message: "`idempotency_key` must be a non-empty string of at most 128 chars".into(),
             });
         }
     };

--- a/crates/ovp-mcp/src/lib.rs
+++ b/crates/ovp-mcp/src/lib.rs
@@ -411,12 +411,24 @@ fn tool_ask(state: &McpState, args: &Value) -> Result<Value, RpcError> {
     // (chat, question) so a host retry of a timed-out ask replays the
     // completed turn instead of paying for (and double-appending) a second
     // one. A fresh generated session cannot collide, so it needs no key.
-    let idem_key = args
+    let explicit_key = args
         .get("idempotency_key")
         .and_then(|v| v.as_str())
         .map(str::trim)
         .filter(|s| !s.is_empty())
-        .map(str::to_string)
+        .map(str::to_string);
+    // Same rule as the HTTP path: a key is only useful on a STABLE session
+    // (replay lookup is session-local) — a key on a generated session could
+    // never replay and would silently re-run a paid turn on retry.
+    if explicit_key.is_some() && supplied_chat.is_none() {
+        return Err(RpcError {
+            code: -32602,
+            message: "`idempotency_key` requires a stable `chat` — a generated \
+                      session cannot replay a retried turn"
+                .into(),
+        });
+    }
+    let idem_key = explicit_key
         .or_else(|| {
             supplied_chat.map(|chat| {
                 let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
@@ -446,19 +458,49 @@ fn tool_ask(state: &McpState, args: &Value) -> Result<Value, RpcError> {
             None => ovp_memory::receipts::agent_citations_unindexed(&done.answer, &records),
         };
         let verified = citations.iter().filter(|c| c["verified"] == true).count();
+        let unverified: Vec<&str> = citations
+            .iter()
+            .filter(|c| c["verified"] != true)
+            .filter_map(|c| c["id"].as_str())
+            .collect();
         let mut text = done.answer.trim().to_string();
         text.push_str(&format!(
-            "\n\n---\nreceipts: {} citation(s), {verified} verified against the vault\n\
-             idempotent replay of turn {} (no new model call)\nsession: {session} \
+            "\n\n---\nreceipts: {} citation(s), {verified} verified against the vault",
+            citations.len()
+        ));
+        if !unverified.is_empty() {
+            text.push_str(&format!("; UNVERIFIED: {}", unverified.join(", ")));
+        }
+        // Tool provenance survives the replay — rebuilt from the transcript,
+        // exactly like the HTTP replay path.
+        let trail: Vec<String> = store
+            .tool_calls_for_turn(&done.turn_id)
+            .into_iter()
+            .map(|(tool, _id, is_error, _summary)| {
+                format!("{tool}{}", if is_error { "✗" } else { "✓" })
+            })
+            .collect();
+        if !trail.is_empty() {
+            text.push_str(&format!("\nagent trail: {}", trail.join(", ")));
+        }
+        text.push_str(&format!(
+            "\nidempotent replay of turn {} (no new model call)\nsession: {session} \
              (pass as `chat` to continue)",
-            citations.len(),
             done.turn_id
         ));
-        // History repair: a committed turn whose export failed must not stay
-        // missing forever (same rule as the HTTP replay path).
+        // History repair, PER TURN: the export may have failed after earlier
+        // turns landed, so file existence is not enough — repair when this
+        // turn's Q line is absent. (An identical question asked twice in one
+        // session skips the repair; the retry contract makes that turn a
+        // replay of the first anyway.)
+        let this_turn_missing = !ovp_memory::ask::agent_chat_contains_question(
+            &state.vault_root,
+            &session,
+            question,
+        );
         if matches!(done.stopped_reason.as_str(), "final" | "need_user" | "refusal")
             && !done.answer.is_empty()
-            && !ovp_memory::ask::agent_chat_exists(&state.vault_root, &session)
+            && this_turn_missing
             && let Err(e) = ovp_memory::ask::save_agent_chat_turn(
                 &state.vault_root,
                 &session,

--- a/crates/ovp-memory/src/ask.rs
+++ b/crates/ovp-memory/src/ask.rs
@@ -592,16 +592,19 @@ pub fn save_agent_chat_turn(
     Ok(path)
 }
 
-/// True when the saved-chat surface already has a file for this session —
-/// the replay path uses this to REPAIR a turn whose transcript committed but
-/// whose export failed (the retry would otherwise skip every save forever).
-pub fn agent_chat_exists(vault_root: &Path, chat: &str) -> bool {
-    valid_chat_stem(chat)
-        && vault_root
-            .join(".ovp")
-            .join("chats")
-            .join(format!("{chat}.md"))
-            .is_file()
+/// True when this session's saved chat already records a turn with exactly
+/// this question — the replay path uses this to REPAIR a turn whose
+/// transcript committed but whose export failed (checking the FILE alone
+/// would skip repairs forever once any earlier turn had exported).
+pub fn agent_chat_contains_question(vault_root: &Path, chat: &str, question: &str) -> bool {
+    if !valid_chat_stem(chat) {
+        return false;
+    }
+    let path = vault_root.join(".ovp").join("chats").join(format!("{chat}.md"));
+    match std::fs::read_to_string(&path) {
+        Ok(md) => md.contains(&format!("**Q:** {question}")),
+        Err(_) => false,
+    }
 }
 
 fn append_chat_turn(path: &Path, turn_block: &str) -> Result<(), String> {

--- a/crates/ovp-memory/src/ask.rs
+++ b/crates/ovp-memory/src/ask.rs
@@ -602,7 +602,11 @@ pub fn agent_chat_contains_question(vault_root: &Path, chat: &str, question: &st
     }
     let path = vault_root.join(".ovp").join("chats").join(format!("{chat}.md"));
     match std::fs::read_to_string(&path) {
-        Ok(md) => md.contains(&format!("**Q:** {question}")),
+        // Exact-block match, not a substring: `**Q:** foo` must not read as
+        // present because `**Q:** foo bar` was exported. The saved block is
+        // always `**Q:** <question>\n\n**A:** `, so matching through the
+        // answer marker pins the question's full extent.
+        Ok(md) => md.contains(&format!("**Q:** {question}\n\n**A:** ")),
         Err(_) => false,
     }
 }

--- a/crates/ovp-memory/src/lib.rs
+++ b/crates/ovp-memory/src/lib.rs
@@ -10,6 +10,7 @@ pub mod agent_transcript;
 pub mod ask;
 pub mod digest;
 pub mod intent;
+pub mod receipts;
 pub mod vault_tools;
 pub mod verify;
 pub mod working_memory;

--- a/crates/ovp-memory/src/receipts.rs
+++ b/crates/ovp-memory/src/receipts.rs
@@ -1,0 +1,110 @@
+//! Server-resolved citation RECEIPTS for agent answers — one implementation
+//! for every product projection of the agent loop (HTTP /api/ask, MCP ask).
+//! The verifier is fail-closed: fabricated references surface as
+//! verified:false, ambiguous claim_id anchors get NO link.
+
+use crate::verify::citations_in_order;
+use ovp_domain::crystal::DurableRecord;
+use ovp_index::IndexModel;
+
+/// Models decorate citation ids in the wild — `[source:<sha> Some Title]`,
+/// `[source: <sha>]` — and exact-string matching then fails receipts the
+/// model clearly intended. Tolerant extraction: trim whitespace and angle
+/// brackets, keep the first whitespace-delimited token. RESOLUTION stays
+/// exact — a token that matches nothing is still verified:false.
+pub fn citation_id_token(id: &str) -> &str {
+    id.split_whitespace()
+        .next()
+        .unwrap_or("")
+        .trim_matches(|c| c == '<' || c == '>')
+}
+
+pub fn agent_citations(
+    answer: &str,
+    model: &IndexModel,
+    records: &[DurableRecord],
+) -> Vec<serde_json::Value> {
+    citations_in_order(answer)
+        .into_iter()
+        .map(|key| {
+            let (kind, id) = key.split_once(':').unwrap_or(("", key.as_str()));
+            let id = citation_id_token(id);
+            match kind {
+                "claim" => {
+                    let hit = records.iter().find(|r| r.claim_key == id);
+                    // Fail-closed anchor (same rule as the legacy citation
+                    // path): claim_ids can collide across runs, and a shared
+                    // anchor could open the WRONG claim — verified stays true
+                    // (the key resolved uniquely), the link is omitted.
+                    let link = hit.and_then(|r| {
+                        let same_id =
+                            records.iter().filter(|o| o.claim_id == r.claim_id).count();
+                        (same_id == 1).then(|| format!("/knowledge#{}", r.claim_id))
+                    });
+                    serde_json::json!({
+                        "id": key,
+                        "kind": "claim",
+                        "title": hit.map(|r| r.claim.chars().take(120).collect::<String>()),
+                        "link_target": link,
+                        "verified": hit.is_some(),
+                    })
+                }
+                "source" => {
+                    let hit = model.sources.iter().find(|s| s.sha256 == id);
+                    serde_json::json!({
+                        "id": key,
+                        "kind": "source",
+                        "title": hit.and_then(|s| s.title.clone()),
+                        "link_target": hit.map(|s| format!("/library/{}", s.sha256)),
+                        "verified": hit.is_some(),
+                    })
+                }
+                _ => serde_json::json!({
+                    "id": key,
+                    "kind": kind,
+                    "title": serde_json::Value::Null,
+                    "link_target": serde_json::Value::Null,
+                    "verified": false,
+                }),
+            }
+        })
+        .collect()
+}
+
+/// [`agent_citations`] without an index snapshot (fresh/unindexed vault):
+/// claim receipts still resolve against the ledger; source references cannot
+/// be verified and honestly say so.
+pub fn agent_citations_unindexed(
+    answer: &str,
+    records: &[DurableRecord],
+) -> Vec<serde_json::Value> {
+    citations_in_order(answer)
+        .into_iter()
+        .map(|key| {
+            let (kind, id) = key.split_once(':').unwrap_or(("", key.as_str()));
+            let id = citation_id_token(id);
+            if kind == "claim" {
+                let hit = records.iter().find(|r| r.claim_key == id);
+                let link = hit.and_then(|r| {
+                    let same_id = records.iter().filter(|o| o.claim_id == r.claim_id).count();
+                    (same_id == 1).then(|| format!("/knowledge#{}", r.claim_id))
+                });
+                serde_json::json!({
+                    "id": key,
+                    "kind": "claim",
+                    "title": hit.map(|r| r.claim.chars().take(120).collect::<String>()),
+                    "link_target": link,
+                    "verified": hit.is_some(),
+                })
+            } else {
+                serde_json::json!({
+                    "id": key,
+                    "kind": kind,
+                    "title": serde_json::Value::Null,
+                    "link_target": serde_json::Value::Null,
+                    "verified": false,
+                })
+            }
+        })
+        .collect()
+}

--- a/crates/ovp-server/src/ask_client.rs
+++ b/crates/ovp-server/src/ask_client.rs
@@ -54,6 +54,53 @@ pub fn providers_ask_client_factory(vault_root: PathBuf) -> Option<AskClientFact
     }
 }
 
+/// [`providers_ask_client_factory`] with a HARD wall-clock posture for
+/// synchronous single-request hosts (the MCP stdio server): per-request
+/// timeout clamped to `timeout_cap_secs` and NO transient retries — a slow
+/// provider call bounds the host's blocking window to roughly one request,
+/// and failures surface as the agent loop's honest model_error instead of
+/// silently tripling the wait.
+pub fn providers_ask_client_factory_bounded(
+    vault_root: PathBuf,
+    timeout_cap_secs: u64,
+) -> Option<AskClientFactory> {
+    #[cfg(feature = "anthropic")]
+    {
+        use std::sync::Arc;
+        Some(Arc::new(move || {
+            build_ask_client_bounded(&vault_root, timeout_cap_secs)
+        }))
+    }
+    #[cfg(not(feature = "anthropic"))]
+    {
+        let _ = (vault_root, timeout_cap_secs);
+        None
+    }
+}
+
+#[cfg(feature = "anthropic")]
+fn build_ask_client_bounded(
+    vault_root: &Path,
+    timeout_cap_secs: u64,
+) -> Result<Box<dyn ovp_llm::ModelClient>, String> {
+    use ovp_domain::ARTICLE_PROMPT_ID;
+    use ovp_llm::{build_recording_live_client_bounded, resolve_api_key, LiveClientConfig};
+
+    let file = ovp_domain::providers::read_providers_file(vault_root)?;
+    let lookup = provider_lookup(&file);
+    let key = resolve_api_key(&lookup)?;
+    let cfg = LiveClientConfig::from_lookup(&lookup)?;
+    let cache_dir = vault_root.join(".ovp/cassettes/ask");
+    build_recording_live_client_bounded(
+        &key,
+        &cfg,
+        &cache_dir,
+        ARTICLE_PROMPT_ID,
+        timeout_cap_secs,
+        0,
+    )
+}
+
 /// Env-over-file lookup matching `apply_providers_env` semantics without
 /// mutating the process environment.
 #[cfg(feature = "anthropic")]

--- a/crates/ovp-server/src/ask_client.rs
+++ b/crates/ovp-server/src/ask_client.rs
@@ -57,7 +57,8 @@ pub fn providers_ask_client_factory(vault_root: PathBuf) -> Option<AskClientFact
 /// [`providers_ask_client_factory`] with a HARD wall-clock posture for
 /// synchronous single-request hosts (the MCP stdio server): per-request
 /// timeout clamped to `timeout_cap_secs` and NO transient retries — a slow
-/// provider call bounds the host's blocking window to roughly one request,
+/// provider call overruns the turn deadline by at most ONE request length
+/// (the deadline itself bounds the turn between calls),
 /// and failures surface as the agent loop's honest model_error instead of
 /// silently tripling the wait.
 pub fn providers_ask_client_factory_bounded(

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -16,7 +16,8 @@ use ovp_api_projection::{bodies, graph, readers};
 
 mod ask_client;
 pub use ask_client::{
-    api_key_configured, providers_ask_client_factory, LLM_NOT_CONFIGURED,
+    api_key_configured, providers_ask_client_factory, providers_ask_client_factory_bounded,
+    LLM_NOT_CONFIGURED,
 };
 
 use std::collections::{HashMap, HashSet};

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -2604,7 +2604,9 @@ fn handle_ask_agent(
                     | ovp_memory::agent::StoppedReason::NeedUser
                     | ovp_memory::agent::StoppedReason::Refusal
             );
-            if deliverable && !outcome.answer.is_empty() {
+            // An engine-level replay (a racing request completed this keyed
+            // turn mid-flight) ran nothing here — the racer owns the save.
+            if deliverable && !outcome.idempotent_replay && !outcome.answer.is_empty() {
                 let _save_guard = chat_saves.lock().unwrap();
                 if let Err(e) = ovp_memory::ask::save_agent_chat_turn(
                     &vault_root,

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -35,6 +35,7 @@ use ovp_memory::ask::{
     AskArgs, AskHistoryTurn, AskResult, EvidenceItem, EvidenceKind, ask_with_optional_evidence,
     valid_chat_stem,
 };
+use ovp_memory::receipts::{agent_citations, agent_citations_unindexed};
 use ovp_memory::verify::{citation_key, citations_in_order};
 use tiny_http::{Header, Method, Response, Server};
 
@@ -2705,108 +2706,6 @@ fn args_brief(arguments: &serde_json::Value) -> serde_json::Value {
         brief = brief.chars().take(119).collect::<String>() + "…";
     }
     serde_json::Value::String(brief)
-}
-
-/// Models decorate citation ids in the wild — `[source:<sha> Some Title]`,
-/// `[source: <sha>]` — and exact-string matching then fails receipts the
-/// model clearly intended. Tolerant extraction: trim whitespace and angle
-/// brackets, keep the first whitespace-delimited token. RESOLUTION stays
-/// exact — a token that matches nothing is still verified:false.
-fn citation_id_token(id: &str) -> &str {
-    id.split_whitespace()
-        .next()
-        .unwrap_or("")
-        .trim_matches(|c| c == '<' || c == '>')
-}
-
-fn agent_citations(
-    answer: &str,
-    model: &IndexModel,
-    records: &[ovp_domain::crystal::DurableRecord],
-) -> Vec<serde_json::Value> {
-    citations_in_order(answer)
-        .into_iter()
-        .map(|key| {
-            let (kind, id) = key.split_once(':').unwrap_or(("", key.as_str()));
-            let id = citation_id_token(id);
-            match kind {
-                "claim" => {
-                    let hit = records.iter().find(|r| r.claim_key == id);
-                    // Fail-closed anchor (same rule as the legacy citation
-                    // path): claim_ids can collide across runs, and a shared
-                    // anchor could open the WRONG claim — verified stays true
-                    // (the key resolved uniquely), the link is omitted.
-                    let link = hit.and_then(|r| {
-                        let same_id =
-                            records.iter().filter(|o| o.claim_id == r.claim_id).count();
-                        (same_id == 1).then(|| format!("/knowledge#{}", r.claim_id))
-                    });
-                    serde_json::json!({
-                        "id": key,
-                        "kind": "claim",
-                        "title": hit.map(|r| r.claim.chars().take(120).collect::<String>()),
-                        "link_target": link,
-                        "verified": hit.is_some(),
-                    })
-                }
-                "source" => {
-                    let hit = model.sources.iter().find(|s| s.sha256 == id);
-                    serde_json::json!({
-                        "id": key,
-                        "kind": "source",
-                        "title": hit.and_then(|s| s.title.clone()),
-                        "link_target": hit.map(|s| format!("/library/{}", s.sha256)),
-                        "verified": hit.is_some(),
-                    })
-                }
-                _ => serde_json::json!({
-                    "id": key,
-                    "kind": kind,
-                    "title": serde_json::Value::Null,
-                    "link_target": serde_json::Value::Null,
-                    "verified": false,
-                }),
-            }
-        })
-        .collect()
-}
-
-/// [`agent_citations`] without an index snapshot (fresh/unindexed vault):
-/// claim receipts still resolve against the ledger; source references cannot
-/// be verified and honestly say so.
-fn agent_citations_unindexed(
-    answer: &str,
-    records: &[ovp_domain::crystal::DurableRecord],
-) -> Vec<serde_json::Value> {
-    citations_in_order(answer)
-        .into_iter()
-        .map(|key| {
-            let (kind, id) = key.split_once(':').unwrap_or(("", key.as_str()));
-            let id = citation_id_token(id);
-            if kind == "claim" {
-                let hit = records.iter().find(|r| r.claim_key == id);
-                let link = hit.and_then(|r| {
-                    let same_id = records.iter().filter(|o| o.claim_id == r.claim_id).count();
-                    (same_id == 1).then(|| format!("/knowledge#{}", r.claim_id))
-                });
-                serde_json::json!({
-                    "id": key,
-                    "kind": "claim",
-                    "title": hit.map(|r| r.claim.chars().take(120).collect::<String>()),
-                    "link_target": link,
-                    "verified": hit.is_some(),
-                })
-            } else {
-                serde_json::json!({
-                    "id": key,
-                    "kind": kind,
-                    "title": serde_json::Value::Null,
-                    "link_target": serde_json::Value::Null,
-                    "verified": false,
-                })
-            }
-        })
-        .collect()
 }
 
 /// `GET /api/ask/progress?chat=<session>` — the minimal A0 §3.7 progress feed.

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -2391,7 +2391,11 @@ fn handle_ask_agent(
                 let mut replay_save_error = None;
                 if matches!(done.stopped_reason.as_str(), "final" | "need_user" | "refusal")
                     && !done.answer.is_empty()
-                    && !ovp_memory::ask::agent_chat_exists(&vault_root, &response_session)
+                    && !ovp_memory::ask::agent_chat_contains_question(
+                        &vault_root,
+                        &response_session,
+                        &question,
+                    )
                 {
                     let _save_guard = chat_saves.lock().unwrap();
                     if let Err(e) = ovp_memory::ask::save_agent_chat_turn(

--- a/evolution/candidates/ask_mcp_rewire-v1.json
+++ b/evolution/candidates/ask_mcp_rewire-v1.json
@@ -15,7 +15,9 @@
     "shared_resolver_single_impl": "ovp-memory::receipts is the ONE citation resolver — ovp-server delegates to it (its tests unchanged), MCP consumes it; no second implementation to drift",
     "parity_knobs": "AgentConfig knobs match the HTTP wiring (4096/10 rounds); the MCP deadline is fixed at 90s (no HTTP guard to derive from) and the turn commits before returning",
     "explicit_errors_stay": "no-client and client-construction failures keep their distinct, actionable messages (tests unchanged for the config gate)",
-    "history_shared_surface": "deliverable turns save to .ovp/chats under the same deliverable-only + append-only rules as the HTTP path"
+    "history_shared_surface": "deliverable turns save to .ovp/chats under the same deliverable-only + append-only rules as the HTTP path",
+    "bounded_blocking": "the MCP factory clamps the per-request provider timeout to 45s and disables transient retries — the synchronous stdio host's worst-case blocking window is roughly ONE request, never timeout×retries; failures surface as the loop's honest model_error",
+    "retry_idempotency": "an explicit idempotency_key or (auto-derived on a CONTINUED chat) key makes host retries replay the completed turn provider-free — one transcript turn, one History block, no second paid call; a fresh generated session cannot collide and needs no key"
   },
   "eval_plan": {
     "replay_set": "MCP tests: full scripted agent turn on an unindexed vault → answer + UNVERIFIED receipt flag + session id + coverage line + transcript AND History file on disk; config-gate errors unchanged. Live: one real `ask` through the MCP stdio binary against the real vault.",

--- a/evolution/candidates/ask_mcp_rewire-v1.json
+++ b/evolution/candidates/ask_mcp_rewire-v1.json
@@ -1,0 +1,27 @@
+{
+  "kind": "ovp.evolution.candidate/v1",
+  "id": "ask_mcp_rewire-v1",
+  "base_version": "v2",
+  "target_version": "v2.1",
+  "surface": "runtime",
+  "component": "runtime.ask_product_wiring",
+  "hypothesis": "RUNTIME surface, the A0 'one tool registry, two projections' completion: the MCP `ask` tool retires its legacy single-shot pipeline (durable-claims-filtered retrieval + evidence sidecar) and runs the SAME agent loop as POST /api/ask — VaultTools + AGENT_POLICY + session transcripts, identical knobs (max_tokens 4096, max_rounds 10, 90s deadline). The reply carries the answer plus server-verified receipts (the shared ovp-memory::receipts resolver, moved out of ovp-server so both projections use one fail-closed implementation), per-layer coverage, a compact trail, and the session id — an optional `chat` argument continues a conversation, and deliverable turns land on the SAME .ovp/chats History surface as the portal, so MCP and portal conversations share one product record. Predicted: MCP answers gain body/evidence/fulltext reach and verified receipts; an unindexed vault now answers honestly instead of refusing up front.",
+  "predicted_delta": {
+    "coverage": "MCP ask reaches every layer the portal agent reaches (claims, sources, evidence cards, full bodies) instead of pre-retrieved durable-claims context",
+    "crystal_provenance": "receipts are the SHARED fail-closed resolver — fabricated references surface as UNVERIFIED in the reply text, never trusted",
+    "operational_reliability": "session busy/store failures are explicit RpcErrors; the turn always commits its transcript; History save failures are reported in-band"
+  },
+  "guardrails": {
+    "shared_resolver_single_impl": "ovp-memory::receipts is the ONE citation resolver — ovp-server delegates to it (its tests unchanged), MCP consumes it; no second implementation to drift",
+    "parity_knobs": "AgentConfig knobs match the HTTP wiring (4096/10 rounds); the MCP deadline is fixed at 90s (no HTTP guard to derive from) and the turn commits before returning",
+    "explicit_errors_stay": "no-client and client-construction failures keep their distinct, actionable messages (tests unchanged for the config gate)",
+    "history_shared_surface": "deliverable turns save to .ovp/chats under the same deliverable-only + append-only rules as the HTTP path"
+  },
+  "eval_plan": {
+    "replay_set": "MCP tests: full scripted agent turn on an unindexed vault → answer + UNVERIFIED receipt flag + session id + coverage line + transcript AND History file on disk; config-gate errors unchanged. Live: one real `ask` through the MCP stdio binary against the real vault.",
+    "paired_sources": 0,
+    "soak": false
+  },
+  "rollback": "Revert tool_ask to the legacy pipeline call — the legacy ask machinery (ovp-memory::ask) is untouched and still serves the HTTP hatch.",
+  "ablation_required": false
+}


### PR DESCRIPTION
Completes the A0 'one tool registry, two projections' principle: MCP `ask` retires its legacy single-shot pipeline and runs the SAME agent loop/tools/policy as POST /api/ask.

- **Shared receipts resolver**: citation verification moved to `ovp-memory::receipts` — one fail-closed implementation for HTTP and MCP (fabrications flagged UNVERIFIED in-text).
- **Replies**: answer + verified receipts + per-layer coverage + compact trail + session id; `chat` continues a session; deliverable turns land on the SAME .ovp/chats History surface as the portal.
- **Bounded blocking (gate P1)**: the MCP client clamps per-request timeout to 45s, no transient retries, no budget escalation — the synchronous stdio host's worst blocking window is ~one request; `OVP_LLM_TIMEOUT_SECS=0` cannot disable the bound.
- **Retry idempotency (gate P1)**: explicit `idempotency_key` (requires stable `chat`) or auto-derived key on continued chats replays completed turns provider-free — one transcript turn, one History block, no second paid call; engine-level replay races skip save/coverage on both projections.

Live-verified via the stdio binary on the real vault (5/5 verified claim receipts). Gate: 5 rounds, P1s r1-r4 all fixed, r5 zero P1s (2 P2 taken, turn-ID markers declined with rationale).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - MCP `ask` now supports continuing chat sessions and idempotent, retry-safe requests without duplicating work.
  - Answers can include citation receipts with verification status, coverage details, and tool activity.
  - Chat transcripts are persisted and reused for continued sessions to improve continuity.
- **Bug Fixes**
  - Improved replay logic to avoid saving duplicate chat entries on idempotent retries.
  - Added bounded timeout behavior for MCP requests to prevent prolonged blocking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->