### PR TITLE
feat(ask): recall hardening — language-aware ranking + reviewable trails (live-verified)

### DIFF
--- a/console-ui/src/design/portal.css
+++ b/console-ui/src/design/portal.css
@@ -1594,7 +1594,10 @@ body {
   white-space: nowrap;
 }
 .ask-step-note {
-  flex: none;
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 .ask-agent-meta {

--- a/console-ui/src/design/portal.css
+++ b/console-ui/src/design/portal.css
@@ -1593,6 +1593,10 @@ body {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+.ask-step-note {
+  flex: none;
+  white-space: nowrap;
+}
 .ask-agent-meta {
   margin-top: 0.7rem;
   padding-top: 0.6rem;

--- a/console-ui/src/lib/types.ts
+++ b/console-ui/src/lib/types.ts
@@ -275,6 +275,10 @@ export interface AskTraceEntry {
   tool: string;
   summary: string;
   ok: boolean;
+  /** Display narration of the call arguments ("query=… · limit=…"). */
+  args?: string | null;
+  /** Parsed result stats ("3 hit(s) · scanned 918/1281 · truncated"). */
+  note?: string | null;
 }
 
 /** One event from GET /api/ask/progress — the live mid-turn feed. */
@@ -285,6 +289,8 @@ export interface AskProgressEvent {
   /** Display narration for tool_started ("query=… · limit=…"). */
   args?: string | null;
   summary?: string;
+  /** Parsed result stats for tool_finished events. */
+  note?: string | null;
   ok?: boolean;
   turn_id?: string;
   stopped_reason?: string;

--- a/console-ui/src/pages/AskPage.tsx
+++ b/console-ui/src/pages/AskPage.tsx
@@ -114,6 +114,8 @@ interface TrailStep {
   args: string | null;
   status: 'running' | 'ok' | 'err';
   summary?: string;
+  /** Result stats ("3 hit(s) · scanned 918/1281 · truncated"). */
+  note?: string | null;
 }
 
 /** Fold started/finished event pairs into per-call steps (order preserved). */
@@ -131,6 +133,7 @@ function stepsFromEvents(events: AskProgressEvent[]): TrailStep[] {
           ...steps[i],
           status: ev.ok === false ? 'err' : 'ok',
           summary: ev.summary,
+          note: ev.note ?? null,
         };
       }
     }
@@ -141,9 +144,10 @@ function stepsFromEvents(events: AskProgressEvent[]): TrailStep[] {
 function stepsFromTrace(trace: AskTraceEntry[]): TrailStep[] {
   return trace.map((t) => ({
     tool: t.tool,
-    args: null,
+    args: t.args ?? null,
     status: t.ok ? ('ok' as const) : ('err' as const),
     summary: t.summary,
+    note: t.note ?? null,
   }));
 }
 
@@ -186,6 +190,7 @@ function AgentTrail({
           <span>{t(toolVerbKey(s.tool))}</span>
           <span className="mono ask-step-tool">{s.tool}</span>
           {s.args && <span className="mono muted ask-step-args">{s.args}</span>}
+          {s.note && <span className="tiny muted ask-step-note">→ {s.note}</span>}
           {s.status === 'err' && (
             <span className="pill failed">{t('ask.trailFailedStep')}</span>
           )}

--- a/crates/ovp-mcp/src/lib.rs
+++ b/crates/ovp-mcp/src/lib.rs
@@ -481,15 +481,18 @@ fn tool_ask(state: &McpState, args: &Value) -> Result<Value, RpcError> {
         }
         // Tool provenance survives the replay — rebuilt from the transcript,
         // exactly like the HTTP replay path.
-        let trail: Vec<String> = store
-            .tool_calls_for_turn(&done.turn_id)
-            .into_iter()
-            .map(|(tool, _id, is_error, _summary)| {
-                format!("{tool}{}", if is_error { "✗" } else { "✓" })
-            })
-            .collect();
+        let trail = store.tool_trail_for_turn(&done.turn_id);
         if !trail.is_empty() {
-            text.push_str(&format!("\nagent trail: {}", trail.join(", ")));
+            text.push_str("\nagent trail:");
+            for (tool, _id, is_error, _summary, arguments, note) in trail {
+                let mark = if is_error { "✗" } else { "✓" };
+                let args = match ovp_memory::receipts::args_brief(&arguments) {
+                    Value::String(s) => format!(" {s}"),
+                    _ => String::new(),
+                };
+                let note = note.map(|n| format!(" → {n}")).unwrap_or_default();
+                text.push_str(&format!("\n  {tool}{mark}{args}{note}"));
+            }
         }
         text.push_str(&format!(
             "\nidempotent replay of turn {} (no new model call)\nsession: {session} \
@@ -643,13 +646,21 @@ fn tool_ask(state: &McpState, args: &Value) -> Result<Value, RpcError> {
         text.push_str(&format!("\ncoverage: {line}"));
     }
     if !outcome.tool_trace.is_empty() {
-        let trail = outcome
-            .tool_trace
-            .iter()
-            .map(|t| format!("{}{}", t.tool, if t.is_error { "✗" } else { "✓" }))
-            .collect::<Vec<_>>()
-            .join(", ");
-        text.push_str(&format!("\nagent trail: {trail}"));
+        // One line per call, 复盘-grade: what was asked, what came back.
+        text.push_str("\nagent trail:");
+        for t in &outcome.tool_trace {
+            let mark = if t.is_error { "✗" } else { "✓" };
+            let args = match ovp_memory::receipts::args_brief(&t.arguments) {
+                Value::String(s) => format!(" {s}"),
+                _ => String::new(),
+            };
+            let note = t
+                .result_note
+                .as_deref()
+                .map(|n| format!(" → {n}"))
+                .unwrap_or_default();
+            text.push_str(&format!("\n  {}{mark}{args}{note}", t.tool));
+        }
     }
     if outcome.stopped_reason != StoppedReason::Final {
         text.push_str(&format!(

--- a/crates/ovp-mcp/src/lib.rs
+++ b/crates/ovp-mcp/src/lib.rs
@@ -612,6 +612,25 @@ fn tool_ask(state: &McpState, args: &Value) -> Result<Value, RpcError> {
         if !unverified.is_empty() {
             text.push_str(&format!("; UNVERIFIED: {}", unverified.join(", ")));
         }
+        // The trail IS available — reconstructed from the committed
+        // transcript by the engine's replay — and a racing retry deserves
+        // the same 复盘 detail as any other reply.
+        if !outcome.tool_trace.is_empty() {
+            text.push_str("\nagent trail:");
+            for t2 in &outcome.tool_trace {
+                let mark = if t2.is_error { "✗" } else { "✓" };
+                let args = match ovp_memory::receipts::args_brief(&t2.arguments) {
+                    Value::String(s) => format!(" {s}"),
+                    _ => String::new(),
+                };
+                let note = t2
+                    .result_note
+                    .as_deref()
+                    .map(|n| format!(" → {n}"))
+                    .unwrap_or_default();
+                text.push_str(&format!("\n  {}{mark}{args}{note}", t2.tool));
+            }
+        }
         text.push_str(&format!(
             "\nidempotent replay of turn {} (completed by a concurrent request)\n\
              session: {session} (pass as `chat` to continue)",

--- a/crates/ovp-memory/src/agent.rs
+++ b/crates/ovp-memory/src/agent.rs
@@ -83,6 +83,38 @@ pub struct ToolTraceEntry {
     pub tool_call_id: String,
     pub is_error: bool,
     pub summary: String,
+    /// The model's raw call input — replay/UI narration ("what did I search"),
+    /// never re-executed.
+    pub arguments: serde_json::Value,
+    /// Compact stats parsed from the FULL result ("3 hits · scanned 918/1281 ·
+    /// truncated") — the trail must support post-hoc 复盘, not just names.
+    pub result_note: Option<String>,
+}
+
+/// Generic result introspection for the trail: hits/scanned/truncated are the
+/// shared vocabulary of every search-shaped tool result. Non-JSON or
+/// keyless results narrate nothing (None), never a guess.
+pub fn tool_result_note(content: &str) -> Option<String> {
+    let v: serde_json::Value = serde_json::from_str(content).ok()?;
+    let obj = v.as_object()?;
+    let mut parts = Vec::new();
+    if let Some(hits) = obj.get("hits").and_then(|h| h.as_array()) {
+        parts.push(format!("{} hit(s)", hits.len()));
+    }
+    if let (Some(s), Some(t)) = (
+        obj.get("scanned_sources").and_then(|v| v.as_u64()),
+        obj.get("total_sources").and_then(|v| v.as_u64()),
+    ) {
+        parts.push(format!("scanned {s}/{t}"));
+    }
+    if obj.get("truncated").and_then(|v| v.as_bool()) == Some(true) {
+        parts.push("truncated".into());
+    }
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join(" · "))
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -160,8 +192,15 @@ pub enum AgentProgress {
     /// display summary (e.g. the query term) and MUST NOT execute from it.
     ToolStarted { tool_call_id: String, tool: String, arguments: serde_json::Value },
     /// `summary` mirrors the caller-facing `ToolTraceEntry` summary: capped,
-    /// and the discard marker (never content) for late results.
-    ToolFinished { tool_call_id: String, tool: String, is_error: bool, summary: String },
+    /// and the discard marker (never content) for late results. `note` is the
+    /// parsed result-stats line ("3 hit(s) · scanned 918/1281 · truncated").
+    ToolFinished {
+        tool_call_id: String,
+        tool: String,
+        is_error: bool,
+        summary: String,
+        note: Option<String>,
+    },
     Finished { turn_id: String, stopped_reason: StoppedReason },
 }
 
@@ -523,6 +562,9 @@ pub fn run_agent_turn_with_progress(
                 tool_call_id: id.clone(),
                 is_error: is_error || finished_late,
                 summary: trail_summary.clone(),
+                arguments: input.clone(),
+                // Late data stays discarded — no stats leak either.
+                result_note: if finished_late { None } else { tool_result_note(&content) },
             });
             let (model_content, model_is_error) = if finished_late {
                 timed_out = true;
@@ -552,6 +594,7 @@ pub fn run_agent_turn_with_progress(
                 tool: name.clone(),
                 is_error: model_is_error,
                 summary: trail_summary,
+                note: trace.last().and_then(|t| t.result_note.clone()),
             });
             results.push(ToolResultBlock {
                 tool_call_id: id.clone(),
@@ -635,14 +678,18 @@ pub fn run_agent_turn_with_progress(
 /// retry must not lose the provenance trail the original response carried.
 fn replayed_trace(store: &SessionStore, turn_id: &str) -> Vec<ToolTraceEntry> {
     store
-        .tool_calls_for_turn(turn_id)
+        .tool_trail_for_turn(turn_id)
         .into_iter()
-        .map(|(tool, tool_call_id, is_error, summary)| ToolTraceEntry {
-            tool,
-            tool_call_id,
-            is_error,
-            summary,
-        })
+        .map(
+            |(tool, tool_call_id, is_error, summary, arguments, result_note)| ToolTraceEntry {
+                tool,
+                tool_call_id,
+                is_error,
+                summary,
+                arguments,
+                result_note,
+            },
+        )
         .collect()
 }
 

--- a/crates/ovp-memory/src/agent.rs
+++ b/crates/ovp-memory/src/agent.rs
@@ -327,8 +327,8 @@ pub fn run_agent_turn_with_progress(
             temperature: cfg.temperature,
             tools: (!tool_defs.is_empty()).then(|| tool_defs.clone()),
             // Bumped with each ACCEPTED policy version (prompt-version
-            // isolation for recorded cassettes): v2 = ask_agent_policy-v2.
-            cache_namespace: Some("ask_agent/v2".into()),
+            // isolation for recorded cassettes): v3 = ask_agent_policy-v3.
+            cache_namespace: Some("ask_agent/v3".into()),
         };
         let reply = match client.call(&request) {
             Ok(r) => r,

--- a/crates/ovp-memory/src/agent_policy.rs
+++ b/crates/ovp-memory/src/agent_policy.rs
@@ -45,6 +45,23 @@ original wording and detail.
 - Read tool results carefully before deciding the next step. If a search \
 misses, vary the query or switch layers before concluding absence.
 
+SEARCH STRATEGY (recall tasks: find an article / a half-remembered item)
+- Start with the MEMORY layers — search_claims and search_evidence — \
+before body scans: cards condense what each article actually said, so a \
+distinctive concept often hits there first.
+- Search each language SEPARATELY. Most saved articles are English even \
+when the user asks in Chinese: issue one query with 1-3 distinctive \
+ENGLISH terms (translate the user's concepts) and, if warranted, another \
+with Chinese terms. A single mixed-language query dilutes ranking — terms \
+of the wrong language can never match and noise sources that match \
+several same-language terms drown the target.
+- Finish the corpus before concluding absence: when a fulltext result \
+says sources were NOT scanned, continue with its next_cursor (same \
+query) instead of re-searching with a new phrasing. Searched-and-found-nothing \
+is only true once the walk completed.
+- Inspect matched_terms on every hit: a source matching only ONE \
+distinctive term may still be the target described in another language.
+
 EVIDENCE
 - Cite what you used: when your answer rests on a claim, reference it as \
 [claim:<claim_key>]; when it rests on a source, reference it as \

--- a/crates/ovp-memory/src/agent_transcript.rs
+++ b/crates/ovp-memory/src/agent_transcript.rs
@@ -512,6 +512,56 @@ impl SessionStore {
     /// The audit ToolCalled rows of one turn — replayed outcomes rebuild
     /// their tool_trace from these (a retry must not lose the provenance
     /// trail the original response carried).
+    /// [`Self::tool_calls_for_turn`] plus the narration fields a replayed
+    /// trail needs for 复盘: the model's call ARGUMENTS (from the recorded
+    /// assistant blocks) and a result-stats note (from the full audit
+    /// content; late results narrate nothing, matching the original reply).
+    pub fn tool_trail_for_turn(
+        &self,
+        id: &str,
+    ) -> Vec<(String, String, bool, String, serde_json::Value, Option<String>)> {
+        let mut args_by_call: std::collections::HashMap<&str, &serde_json::Value> =
+            std::collections::HashMap::new();
+        for e in &self.events {
+            if let TranscriptEvent::Message {
+                turn_id,
+                message: ovp_llm::ModelMessage::AssistantBlocks { blocks },
+            } = e
+                && turn_id == id
+            {
+                for b in blocks {
+                    if let ovp_llm::AssistantBlock::ToolUse { id: call_id, input, .. } = b {
+                        args_by_call.insert(call_id.as_str(), input);
+                    }
+                }
+            }
+        }
+        self.events
+            .iter()
+            .filter_map(|e| match e {
+                TranscriptEvent::ToolCalled {
+                    turn_id, tool_call_id, tool, is_error, content, late, ..
+                } if turn_id == id => Some((
+                    tool.clone(),
+                    tool_call_id.clone(),
+                    *is_error,
+                    if *late {
+                        "late: discarded (audit only)".to_string()
+                    } else {
+                        content.chars().take(120).collect()
+                    },
+                    args_by_call
+                        .get(tool_call_id.as_str())
+                        .cloned()
+                        .cloned()
+                        .unwrap_or(serde_json::Value::Null),
+                    if *late { None } else { crate::agent::tool_result_note(content) },
+                )),
+                _ => None,
+            })
+            .collect()
+    }
+
     pub fn tool_calls_for_turn(&self, id: &str) -> Vec<(String, String, bool, String)> {
         self.events
             .iter()

--- a/crates/ovp-memory/src/receipts.rs
+++ b/crates/ovp-memory/src/receipts.rs
@@ -108,3 +108,44 @@ pub fn agent_citations_unindexed(
         })
         .collect()
 }
+
+/// Compact display line for a tool call's arguments ("query=agent memory ·
+/// limit=10") — narration for the live progress trail. Scalar fields only,
+/// well-known keys first, capped so a pathological argument can't flood the
+/// feed. Null when nothing scalar is present.
+pub fn args_brief(arguments: &serde_json::Value) -> serde_json::Value {
+    const PRIORITY: [&str; 6] = ["query", "claim_key", "claim_id", "source_id", "cursor", "limit"];
+    let Some(obj) = arguments.as_object() else {
+        return serde_json::Value::Null;
+    };
+    let render = |v: &serde_json::Value| match v {
+        serde_json::Value::String(s) => Some(s.clone()),
+        serde_json::Value::Number(n) => Some(n.to_string()),
+        serde_json::Value::Bool(b) => Some(b.to_string()),
+        _ => None,
+    };
+    let mut parts: Vec<String> = Vec::new();
+    for key in PRIORITY {
+        if let Some(v) = obj.get(key).and_then(&render) {
+            parts.push(format!("{key}={v}"));
+        }
+    }
+    for (key, value) in obj {
+        if parts.len() >= 3 {
+            break;
+        }
+        if !PRIORITY.contains(&key.as_str())
+            && let Some(v) = render(value)
+        {
+            parts.push(format!("{key}={v}"));
+        }
+    }
+    if parts.is_empty() {
+        return serde_json::Value::Null;
+    }
+    let mut brief = parts.join(" · ");
+    if brief.chars().count() > 120 {
+        brief = brief.chars().take(119).collect::<String>() + "…";
+    }
+    serde_json::Value::String(brief)
+}

--- a/crates/ovp-memory/src/vault_tools.rs
+++ b/crates/ovp-memory/src/vault_tools.rs
@@ -834,6 +834,29 @@ fn decode_fulltext_cursor(
 /// rank by the number of distinct OR-matched terms, with original index order
 /// breaking ties; source joins remain optional because pre-join packs can
 /// legitimately lack a source sha.
+/// Mixed-language queries are inherently biased: an English article can never
+/// match Chinese terms, so raw distinct-term counts drown it under noise
+/// sources matching several terms of the query's dominant language (live
+/// failure: `手写 Transformer 求职 笔记` ranked Chinese note-taking articles
+/// above the English target that matched only `transformer`). Terms are
+/// grouped by script (CJK-range vs everything else) and a candidate scores
+/// the BEST group fraction in permille — fully matching one language's terms
+/// beats partially matching the other's. Total matched terms breaks ties
+/// before recency/index order.
+fn language_grouped_score(terms: &[String], matched: &[String]) -> (u32, usize) {
+    let is_cjk = |t: &str| t.chars().any(|c| (c as u32) >= 0x2E80);
+    let mut best = 0u32;
+    for want_cjk in [false, true] {
+        let group: Vec<&String> = terms.iter().filter(|t| is_cjk(t) == want_cjk).collect();
+        if group.is_empty() {
+            continue;
+        }
+        let hit = group.iter().filter(|t| matched.iter().any(|m| m == **t)).count();
+        best = best.max((hit * 1000 / group.len()) as u32);
+    }
+    (best, matched.len())
+}
+
 pub fn search_evidence(model: &IndexModel, query: &str, limit: usize) -> Value {
     let terms = tokenize_search_terms(query);
     let limit = limit.clamp(1, MAX_SEARCH_LIMIT);
@@ -883,7 +906,7 @@ pub fn search_evidence(model: &IndexModel, query: &str, limit: usize) -> Value {
             })
             .collect::<Vec<_>>();
         any_matched_cards_truncated |= matched_cards_truncated;
-        let score = matched_terms.len();
+        let score = language_grouped_score(&terms, &matched_terms);
 
         let mut hit = Map::new();
         hit.insert("pack_title".into(), json!(pack.title));
@@ -1015,7 +1038,7 @@ fn search_fulltext_at_with_budget(
     // and a multi-term target deeper in the walk never surfaces. Instead the
     // walk runs to budget/deadline/end, then hits rank by score (recency
     // breaks ties via walk position) and `limit` trims the RETURNED list.
-    let mut scored_hits: Vec<(usize, usize, Value)> = Vec::new();
+    let mut scored_hits: Vec<((u32, usize), usize, Value)> = Vec::new();
     let mut scanned_sources = 0usize;
     let mut corpus_bytes = 0usize;
     let mut next_offset = start_offset;
@@ -1051,7 +1074,7 @@ fn search_fulltext_at_with_budget(
         corpus_bytes = corpus_bytes.saturating_add(scan.bytes_scanned);
 
         if !scan.matched_terms.is_empty() {
-            let score = scan.matched_terms.len();
+            let score = language_grouped_score(&terms, &scan.matched_terms);
             scored_hits.push((
                 score,
                 index,
@@ -1114,6 +1137,17 @@ fn search_fulltext_at_with_budget(
                 &terms,
                 model,
                 total_sources
+            )),
+        );
+        // Self-documenting continuation: a live turn issued FIVE fresh scans
+        // and ignored the cursor every time — the unscanned tail was a
+        // permanent blind spot the model never knew it had.
+        out.insert(
+            "note".into(),
+            json!(format!(
+                "{} of {total_sources} sources NOT scanned yet — pass next_cursor as \
+                 `cursor` (same query) to continue instead of re-searching",
+                total_sources.saturating_sub(next_offset)
             )),
         );
     }
@@ -3288,6 +3322,82 @@ mod tests {
         assert_eq!(hit_ids, vec!["sha-new", "sha-old", "sha-undated"]);
         assert_eq!(result["scanned_sources"], 3);
         assert_eq!(result["truncated"], false);
+    }
+
+    /// The 2026-07-26 live failure, verbatim: a mixed-language query
+    /// (手写 Transformer 求职 笔记) must rank the ENGLISH target that fully
+    /// matches its only Latin term above NEWER Chinese sources matching 2 of
+    /// 3 Chinese terms — raw distinct-term counting drowned it.
+    #[test]
+    fn fulltext_language_groups_rescue_cross_language_recall() {
+        let temp = tempfile::tempdir().expect("temp vault");
+        fs::create_dir_all(temp.path().join("sources")).expect("source dir");
+        let mut sources = Vec::new();
+        for i in 0..3 {
+            let rel = format!("sources/zh-{i}.md");
+            fs::write(
+                temp.path().join(&rel),
+                "\u{624b}\u{5199}\u{7b14}\u{8bb0}\u{8f6f}\u{4ef6}\u{6bd4}\u{8f83}",
+            )
+            .expect("body");
+            sources.push(source(
+                &format!("sha-zh-{i}"),
+                "Chinese notes app",
+                Some(&rel),
+                Some("2026-07-20"),
+            ));
+        }
+        fs::write(
+            temp.path().join("sources/target.md"),
+            "implementing a transformer comes up so often in interviews",
+        )
+        .expect("body");
+        sources.push(source(
+            "sha-en-target",
+            "Notes on the Industry Job Search",
+            Some("sources/target.md"),
+            Some("2026-06-22"),
+        ));
+        let model = fixture_model(sources, vec![], vec![]);
+        write_index(temp.path(), &model).expect("index fixture");
+        let mut tools = VaultTools::new(temp.path());
+        let result = ok_json(call(
+            &mut tools,
+            "search_fulltext",
+            json!({"query": "\u{624b}\u{5199} transformer \u{6c42}\u{804c} \u{7b14}\u{8bb0}"}),
+        ));
+        let hits = result["hits"].as_array().expect("hits");
+        assert_eq!(
+            hits[0]["source_id"], "sha-en-target",
+            "full Latin-group match (1/1) outranks newer 2-of-3 CJK matches: {result}"
+        );
+    }
+
+    /// Truncated walks tell the model HOW to continue — the note names the
+    /// unscanned remainder and the cursor mechanism.
+    #[test]
+    fn fulltext_truncated_walk_carries_a_continuation_note() {
+        let temp = tempfile::tempdir().expect("temp vault");
+        fs::create_dir_all(temp.path().join("sources")).expect("source dir");
+        let mut sources = Vec::new();
+        for i in 0..4 {
+            let rel = format!("sources/f-{i}.md");
+            fs::write(temp.path().join(&rel), "needle body padding padding").expect("body");
+            sources.push(source(&format!("sha-f-{i}"), "F", Some(&rel), Some("2026-07-01")));
+        }
+        let model = fixture_model(sources, vec![], vec![]);
+        write_index(temp.path(), &model).expect("index fixture");
+        let mut tools = VaultTools::new(temp.path()).with_fulltext_corpus_scan_bytes(30);
+        let result = ok_json(call(
+            &mut tools,
+            "search_fulltext",
+            json!({"query": "needle"}),
+        ));
+        assert_eq!(result["truncated"], true);
+        assert!(result.get("next_cursor").is_some(), "{result}");
+        let note = result["note"].as_str().expect("note");
+        assert!(note.contains("NOT scanned yet"), "{note}");
+        assert!(note.contains("next_cursor"), "{note}");
     }
 
     /// The live 1281-source replay's remaining defect: a common single term

--- a/crates/ovp-memory/src/vault_tools.rs
+++ b/crates/ovp-memory/src/vault_tools.rs
@@ -822,8 +822,9 @@ fn decode_fulltext_cursor(
         fulltext_cursor_fingerprint(&terms, model, fulltext_candidate_count(model), offset);
     if fingerprint != expected {
         return Ok(Err(
-            "fulltext cursor belongs to a different query, index, or position; \
-             restart without a cursor"
+            "fulltext cursor belongs to a different query, index, or position — \
+             a cursor only continues the EXACT query that returned it: repeat \
+             that query with this cursor, or drop the cursor to start fresh"
                 .into(),
         ));
     }
@@ -3621,7 +3622,7 @@ mod tests {
             outcome,
             ToolOutcome::Failed(ref detail)
                 if detail.contains("different query, index, or position")
-                    && detail.contains("restart without a cursor")
+                    && detail.contains("drop the cursor to start fresh")
         ));
         // ...and it leaves coverage untouched: nothing about the LAYER
         // failed, and worst-observed merging would otherwise pin the whole

--- a/crates/ovp-memory/src/vault_tools.rs
+++ b/crates/ovp-memory/src/vault_tools.rs
@@ -521,7 +521,7 @@ pub fn tool_definitions() -> Vec<ToolDef> {
         ),
         tool_def(
             "search_evidence",
-            "Search the reader-pack evidence layer by pack title and card titles — the best FIRST stop for 'I remember an article about…' recall questions, because card titles condense what each article actually said. Space-separated terms are OR-matched as case-insensitive verbatim substrings; hits are ranked by distinct-term score and report matched_terms. Prefer 1–3 distinctive terms, using the language the article is written in (an English article will not match Chinese terms); beyond 8 distinct terms only the first 8 are used. Does not search card bodies, units text, or source bodies.",
+            "Search the reader-pack evidence layer by pack title and card titles — the best FIRST stop for 'I remember an article about…' recall questions, because card titles condense what each article actually said. Space-separated terms are OR-matched as case-insensitive verbatim substrings; hits rank by LANGUAGE-GROUP coverage (terms group by script; a hit's score is its best group's matched fraction, so fully matching the English terms outranks partially matching the Chinese ones; total matched terms then recency break ties) and report matched_terms. Prefer 1–3 distinctive terms, using the language the article is written in (an English article will not match Chinese terms); beyond 8 distinct terms only the first 8 are used. Does not search card bodies, units text, or source bodies.",
             json!({
                 "type": "object",
                 "properties": {
@@ -534,7 +534,7 @@ pub fn tool_definitions() -> Vec<ToolDef> {
         ),
         tool_def(
             "search_fulltext",
-            "Search source bodies with bounded newest-first streaming scans. Space-separated terms are OR-matched as case-insensitive verbatim substrings; hits are ranked by how many DISTINCT terms each source matches (recency breaks ties) and report matched_terms — so include several distinctive terms you expect to co-occur in the target article, in the language it is written in (an English article will not match Chinese terms); beyond 8 distinct terms only the first 8 are used. Pass next_cursor to continue scanning where the previous call stopped (use its value as cursor). Does not search source metadata, crystallized claims, or the reader-pack evidence layer.",
+            "Search source bodies with bounded newest-first streaming scans. Space-separated terms are OR-matched as case-insensitive verbatim substrings; hits rank by LANGUAGE-GROUP coverage (terms group by script; score = best group's matched fraction; total matched then recency break ties) and report matched_terms — so include several distinctive terms you expect to co-occur in the target article, in the language it is written in (an English article will not match Chinese terms); beyond 8 distinct terms only the first 8 are used. Pass next_cursor to continue scanning where the previous call stopped (use its value as cursor). Does not search source metadata, crystallized claims, or the reader-pack evidence layer.",
             json!({
                 "type": "object",
                 "properties": {

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -36,7 +36,7 @@ use ovp_memory::ask::{
     AskArgs, AskHistoryTurn, AskResult, EvidenceItem, EvidenceKind, ask_with_optional_evidence,
     valid_chat_stem,
 };
-use ovp_memory::receipts::{agent_citations, agent_citations_unindexed};
+use ovp_memory::receipts::{agent_citations, agent_citations_unindexed, args_brief};
 use ovp_memory::verify::{citation_key, citations_in_order};
 use tiny_http::{Header, Method, Response, Server};
 
@@ -2367,10 +2367,13 @@ fn handle_ask_agent(
                 && let Some(done) = store.completed_turn_for_key(key)
             {
                 let trace: Vec<serde_json::Value> = store
-                    .tool_calls_for_turn(&done.turn_id)
+                    .tool_trail_for_turn(&done.turn_id)
                     .into_iter()
-                    .map(|(tool, _id, is_error, summary)| {
-                        serde_json::json!({"tool": tool, "summary": summary, "ok": !is_error})
+                    .map(|(tool, _id, is_error, summary, arguments, note)| {
+                        serde_json::json!({
+                            "tool": tool, "summary": summary, "ok": !is_error,
+                            "args": args_brief(&arguments), "note": note,
+                        })
                     })
                     .collect();
                 // Receipts recompute fine without a client (ledger + index
@@ -2476,11 +2479,11 @@ fn handle_ask_agent(
                             "args": args_brief(arguments),
                         })
                     }
-                    AgentProgress::ToolFinished { tool_call_id, tool, is_error, summary } => {
+                    AgentProgress::ToolFinished { tool_call_id, tool, is_error, summary, note } => {
                         serde_json::json!({
                             "event": "tool_finished", "tool": tool,
                             "tool_call_id": tool_call_id, "ok": !is_error,
-                            "summary": summary,
+                            "summary": summary, "note": note,
                         })
                     }
                     // The advertised terminal protocol is final | error: a
@@ -2567,11 +2570,15 @@ fn handle_ask_agent(
             let trace: Vec<serde_json::Value> = outcome
                 .tool_trace
                 .iter()
-                .map(|t|
-
+                .map(|t| {
                     serde_json::json!({
-                        "tool": t.tool, "summary": t.summary, "ok": !t.is_error
-                    }))
+                        "tool": t.tool, "summary": t.summary, "ok": !t.is_error,
+                        // 复盘 detail: what was asked, what came back — the
+                        // post-answer trail must not degrade to bare names.
+                        "args": args_brief(&t.arguments),
+                        "note": t.result_note,
+                    })
+                })
                 .collect();
             // History parity (A3d gate P1): the JSONL session transcript is
             // the audit record, but /api/chats and the Ask history rail read
@@ -2667,52 +2674,6 @@ fn handle_ask_agent(
             json_response(504, &body.to_string())
         }
     }
-}
-
-/// Resolve the agent answer's citation markers into receipts
-/// (`citations_resolved_not_trusted`): [claim:<key>] against the ACTIVE
-/// ledger records (link = the claim's knowledge anchor), [source:<id>]
-/// against the index (link = /library). Anything unresolvable is
-/// verified:false — surfaced, never silently dropped.
-/// Compact display line for a tool call's arguments ("query=agent memory ·
-/// limit=10") — narration for the live progress trail. Scalar fields only,
-/// well-known keys first, capped so a pathological argument can't flood the
-/// feed. Null when nothing scalar is present.
-fn args_brief(arguments: &serde_json::Value) -> serde_json::Value {
-    const PRIORITY: [&str; 6] = ["query", "claim_key", "claim_id", "source_id", "cursor", "limit"];
-    let Some(obj) = arguments.as_object() else {
-        return serde_json::Value::Null;
-    };
-    let render = |v: &serde_json::Value| match v {
-        serde_json::Value::String(s) => Some(s.clone()),
-        serde_json::Value::Number(n) => Some(n.to_string()),
-        serde_json::Value::Bool(b) => Some(b.to_string()),
-        _ => None,
-    };
-    let mut parts: Vec<String> = Vec::new();
-    for key in PRIORITY {
-        if let Some(v) = obj.get(key).and_then(&render) {
-            parts.push(format!("{key}={v}"));
-        }
-    }
-    for (key, value) in obj {
-        if parts.len() >= 3 {
-            break;
-        }
-        if !PRIORITY.contains(&key.as_str())
-            && let Some(v) = render(value)
-        {
-            parts.push(format!("{key}={v}"));
-        }
-    }
-    if parts.is_empty() {
-        return serde_json::Value::Null;
-    }
-    let mut brief = parts.join(" · ");
-    if brief.chars().count() > 120 {
-        brief = brief.chars().take(119).collect::<String>() + "…";
-    }
-    serde_json::Value::String(brief)
 }
 
 /// `GET /api/ask/progress?chat=<session>` — the minimal A0 §3.7 progress feed.

--- a/evolution/candidates/ask_agent_policy-v3.json
+++ b/evolution/candidates/ask_agent_policy-v3.json
@@ -1,0 +1,23 @@
+{
+  "kind": "ovp.evolution.candidate/v1",
+  "id": "ask_agent_policy-v3",
+  "base_version": "v2",
+  "target_version": "v3",
+  "surface": "prompt",
+  "component": "prompt.ask_agent_policy",
+  "hypothesis": "PROMPT surface, one additive SEARCH STRATEGY block for recall tasks, from the same live failure: the model searched memory layers once with one mixed query, issued five Chinese-dominant fulltext scans, ignored the cursor every time, and concluded absence at round 3 of 10. The block teaches: memory layers (claims+evidence) first; search each language SEPARATELY (translate the user's concepts to English — most saved articles are English even when asked in Chinese); finish the corpus via next_cursor before concluding absence; inspect matched_terms before dismissing single-term hits. Predicted: recall turns issue at least one English-term query and continue truncated walks; non-recall behavior unchanged (block scoped to recall tasks).",
+  "predicted_delta": {
+    "coverage": "recall searches stop being monolingual and stop concluding absence with a third of the corpus unscanned"
+  },
+  "guardrails": {
+    "additive_only": "every existing policy section keeps its text; A3a/v2 checklist and tripwire tests pass unmodified",
+    "tool_layer_backstop": "the tool-side fixes (language-grouped ranking, continuation note) do not depend on the model following this guidance — policy reduces wasted rounds, tools guarantee ranking"
+  },
+  "eval_plan": {
+    "replay_set": "live replay of the failed question must issue an English-term query and/or cursor continuation and recover the target; deterministic policy checklist tests pass unmodified",
+    "paired_sources": 0,
+    "soak": false
+  },
+  "rollback": "Revert the const to v2 text.",
+  "ablation_required": false
+}

--- a/evolution/candidates/ask_trail_detail-v1.json
+++ b/evolution/candidates/ask_trail_detail-v1.json
@@ -1,0 +1,24 @@
+{
+  "kind": "ovp.evolution.candidate/v1",
+  "id": "ask_trail_detail-v1",
+  "base_version": "v1.1",
+  "target_version": "v1.2",
+  "surface": "runtime",
+  "component": "runtime.ask_agent",
+  "hypothesis": "RUNTIME surface, additive trail enrichment for 复盘 (operator finding: the post-answer trail showed seven bare tool names — what was searched and what came back was invisible, unlike grok's reviewable per-query trail). ToolTraceEntry gains the call's raw arguments and a result-stats note parsed from the FULL result (hits count, scanned/total, truncated) — computed before model-facing truncation, absent (never guessed) for late or non-JSON results. The transcript store gains tool_trail_for_turn so REPLAYED turns reconstruct the same detail (arguments recovered from the recorded assistant blocks). Product surfaces render it: portal trail steps show query + stats persistently (live and post-answer), MCP replies list one call per line with args and stats. Predicted: a failed recall is diagnosable from the UI alone — which queries ran, in which language, how much corpus was covered.",
+  "predicted_delta": {
+    "operational_reliability": "failed searches become reviewable artifacts instead of opaque tool-name lists; the 复盘 that previously required reading the JSONL transcript happens in the product"
+  },
+  "guardrails": {
+    "audit_unchanged": "the transcript schema is untouched — arguments were already recorded in assistant blocks, notes derive from already-recorded content",
+    "late_stays_discarded": "late results narrate nothing (no stats leak past the discard marker)",
+    "additive_shape": "trace JSON gains keys; existing consumers reading tool/summary/ok are unaffected"
+  },
+  "eval_plan": {
+    "replay_set": "engine tests: trace entries carry arguments + parsed notes; transcript reconstruction returns arguments from assistant blocks; server tests: trace JSON carries args/note on live and replayed turns; UI builds",
+    "paired_sources": 0,
+    "soak": false
+  },
+  "rollback": "Drop the two ToolTraceEntry fields and the accessor — additive, no persisted state.",
+  "ablation_required": false
+}

--- a/evolution/candidates/ask_vault_tools-v3.json
+++ b/evolution/candidates/ask_vault_tools-v3.json
@@ -1,0 +1,25 @@
+{
+  "kind": "ovp.evolution.candidate/v1",
+  "id": "ask_vault_tools-v3",
+  "base_version": "v2",
+  "target_version": "v3",
+  "surface": "runtime",
+  "component": "runtime.ask_vault_tools",
+  "hypothesis": "RUNTIME surface, two recall fixes from a verbatim live failure (2026-07-26, the SAME article the v2 regression had recovered): the model issued five Chinese-dominant mixed queries; the English target matched only `transformer` (1 distinct term) and was outranked by newer Chinese sources matching 2-3 Chinese terms, while every scan stopped at 918/1281 and the model ignored next_cursor five times. (1) LANGUAGE-GROUPED RANKING: query terms split by script (CJK vs Latin); a candidate scores the best group fraction in permille — fully matching one language's terms (1/1 Latin) now outranks partially matching the other's (2/3 CJK); total matched terms breaks ties before recency. Applies to search_evidence and search_fulltext. (2) CONTINUATION NOTE: a truncated walk's result carries a note naming the unscanned remainder and telling the model to pass next_cursor with the same query. Predicted: the recorded failure replays to a hit; all-one-language queries rank exactly as before (single group).",
+  "predicted_delta": {
+    "coverage": "cross-language recall stops being structurally impossible for mixed queries; truncated walks become continuable instead of a permanent blind tail",
+    "operational_reliability": "self-documenting truncation reduces wasted re-scans (five identical 918-source scans in one live turn)"
+  },
+  "guardrails": {
+    "single_language_unchanged": "queries whose terms are all one script have one group — ranking is the same fraction ordering as v2's distinct-term counts (existing ranking tests pass unmodified)",
+    "honesty_unchanged": "scoring changes ORDER only; matched_terms, scanned/total accounting, truncated flags, and coverage semantics are untouched",
+    "note_is_display": "the continuation note is narration in the result payload — cursors, fingerprints, and walk semantics are byte-identical"
+  },
+  "eval_plan": {
+    "replay_set": "the live failure verbatim: query 手写 Transformer 求职 笔记 against an English target (matches only `transformer`) plus newer Chinese noise (matches 2/3 CJK terms) → target ranks first; truncated-walk note presence test; all prior v2 fixtures (flood ranking, cursor, budgets, frontmatter) pass unmodified",
+    "paired_sources": 0,
+    "soak": false
+  },
+  "rollback": "Revert language_grouped_score to matched_terms.len() and drop the note field — ranking-only change, no persisted state.",
+  "ablation_required": false
+}

--- a/evolution/components.json
+++ b/evolution/components.json
@@ -156,7 +156,7 @@
   {
    "id": "runtime.ask_agent",
    "surface": "runtime",
-   "current_version": "v1.1",
+   "current_version": "v1.2",
    "file": "crates/ovp-memory/src/ask.rs",
    "quality_buckets": [
     "coverage",
@@ -167,7 +167,7 @@
   {
    "id": "runtime.ask_vault_tools",
    "surface": "runtime",
-   "current_version": "v2",
+   "current_version": "v3",
    "file": "crates/ovp-memory/src/vault_tools.rs",
    "quality_buckets": [
     "coverage",
@@ -178,7 +178,7 @@
   {
    "id": "prompt.ask_agent_policy",
    "surface": "prompt",
-   "current_version": "v2",
+   "current_version": "v3",
    "file": "crates/ovp-memory/src/agent_policy.rs",
    "quality_buckets": [
     "coverage",


### PR DESCRIPTION
Driven by the operator re-asking the transformer-article recall in the shipped product and watching it miss. Transcript forensics: five Chinese-dominant mixed queries (the English target matched only `transformer` and was outranked by newer Chinese sources matching 2-3 Chinese terms), every scan stopped at 918/1281 with next_cursor ignored five times, absence concluded at round 3 of 10, and the post-answer trail showed seven bare tool names.

Three candidates (validated, registry flipped):
- **ask_vault_tools-v3** — language-grouped ranking: terms group by script; score = best group's matched fraction (1/1 Latin beats 2/3 CJK), total-matched then recency tie-breaks. Truncated walks carry a continuation note naming the unscanned remainder + the cursor mechanism. Stale-cursor errors teach the exact recovery.
- **ask_trail_detail-v1** — ToolTraceEntry carries arguments + result-stats note parsed from the FULL result; replayed turns reconstruct both from the transcript; portal steps and MCP replies render `query → N hit(s) · scanned x/y · truncated` persistently. A failed search is now diagnosable from the UI (grok-grade 复盘).
- **ask_agent_policy-v3** — recall strategy: memory layers first, one query PER language (translate to English), finish the corpus via next_cursor before concluding absence, inspect matched_terms.

**Live replay of the exact failed question**: the model issued English queries throughout, used a cursor for the first time ever, and finished `final` with a verified receipt for the matching article; the trail shows every query and its scan stats. Gate: round 1 = 3 metadata-consistency P2s (all fixed), no P1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced ask-agent activity trails with per-tool status, brief arguments, and optional notes in both live and replayed views.
  * Tool results now include compact narration; replayed traces match the live detail.
* **Bug Fixes**
  * Improved mixed-language search ranking and added clearer continuation guidance for long scans.
* **UI Improvements**
  * Trail notes are shown as compact single-line text and truncate gracefully when space is limited.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->