### PR TITLE
fix(portal): cross-month 原文 resolution + bare-URL autolinking

### DIFF
--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -484,6 +484,7 @@ export const en = {
     'not configured — set an API key under LLM Provider above. Ask picks it up as soon as you save.',
   'system.askTimeout': 'ask timeout',
   'system.askTimeoutValue': '{secs}s per question · up to {cap} concurrent',
+  'system.uiBuild': 'UI build',
   'system.version': 'server version',
   'system.togglesNote':
     'Theme and language switch in the top bar (LIGHT/DARK · EN/中) — persisted per browser, on every page.',

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -452,6 +452,7 @@ export const zh: Record<keyof typeof en, string> = {
     '未配置——请在上方「LLM 提供商」中保存 API 密钥。保存后对话立即生效。',
   'system.askTimeout': '对话超时',
   'system.askTimeoutValue': '每问 {secs} 秒 · 并发上限 {cap}',
+  'system.uiBuild': '前端构建',
   'system.version': '服务端版本',
   'system.togglesNote':
     '主题与语言在顶栏切换（LIGHT/DARK · EN/中）——按浏览器持久化，每页可用。',

--- a/console-ui/src/lib/api.ts
+++ b/console-ui/src/lib/api.ts
@@ -1,6 +1,7 @@
 import type {
   AskProgress,
   AskResponse,
+  AskSessionTurn,
   ChatEntry,
   ClaimDetail,
   ClaimRow,
@@ -332,6 +333,15 @@ export async function postAsk(
 export function fetchAskStatus(): Promise<{ agent: boolean }> {
   if (STATIC_MODE) return Promise.resolve({ agent: false });
   return fetchJson<{ agent: boolean }>('/api/ask/status');
+}
+
+/** GET /api/ask/session/<chat> — completed turns with full trails from the
+ * audit transcript. Empty turns = a legacy markdown-only chat. */
+export function fetchAskSession(chat: string): Promise<{ turns: AskSessionTurn[] }> {
+  if (STATIC_MODE) return Promise.resolve({ turns: [] });
+  return fetchJson<{ turns: AskSessionTurn[] }>(
+    `/api/ask/session/${encodeURIComponent(chat)}`,
+  );
 }
 
 /** GET /api/ask/progress — live mid-turn feed for an agent ask. Unknown

--- a/console-ui/src/lib/markdown.tsx
+++ b/console-ui/src/lib/markdown.tsx
@@ -225,7 +225,7 @@ export function renderInline(
       // (https://en.wikipedia.org/wiki/Foo_(bar)).
       for (;;) {
         const last = url.slice(-1);
-        if (/[.,;:!?、。,;]/.test(last)) {
+        if (/[.,;:!?、。,;!?:]/.test(last)) {
           url = url.slice(0, -1);
           continue;
         }

--- a/console-ui/src/lib/markdown.tsx
+++ b/console-ui/src/lib/markdown.tsx
@@ -204,10 +204,40 @@ export function renderInline(
   const out: ReactNode[] = [];
   let rest = text;
   let k = 0;
+  // Bare http(s) URLs in prose become links too — models (and humans) write
+  // them without markdown syntax, and a dead-text GitHub URL in an answer is
+  // a product failure. Trailing punctuation stays text; the href is the
+  // matched URL verbatim (still only http/https — no scheme smuggling).
+  const AUTOLINK = /https?:\/\/[^\s<>"'`\])}]+/g;
+  const pushText = (chunk: string) => {
+    if (chunk === '') return;
+    let last = 0;
+    for (const m of chunk.matchAll(AUTOLINK)) {
+      const at = m.index ?? 0;
+      let url = m[0];
+      // Common trailing punctuation is sentence-ware, not URL.
+      while (/[.,;:!?、。,;)]$/.test(url)) url = url.slice(0, -1);
+      if (url.length === 0) continue;
+      if (at > last) out.push(chunk.slice(last, at));
+      out.push(
+        <a
+          key={`${keyPrefix}-al${k}`}
+          href={url}
+          target="_blank"
+          rel="noreferrer"
+        >
+          {url}
+        </a>,
+      );
+      k += 1;
+      last = at + url.length;
+    }
+    if (last < chunk.length) out.push(chunk.slice(last));
+  };
   const pushPlain = (chunk: string) => {
     if (chunk === '') return;
     if (!marker) {
-      out.push(chunk);
+      pushText(chunk);
       return;
     }
     let last = 0;
@@ -216,12 +246,12 @@ export function renderInline(
       const at = m.index ?? 0;
       const node = marker.render(m, `${keyPrefix}-mk${k}`);
       if (node == null) continue;
-      if (at > last) out.push(chunk.slice(last, at));
+      if (at > last) pushText(chunk.slice(last, at));
       out.push(node);
       k += 1;
       last = at + m[0].length;
     }
-    if (last < chunk.length) out.push(chunk.slice(last));
+    if (last < chunk.length) pushText(chunk.slice(last));
   };
   while (rest.length > 0) {
     const m = INLINE.exec(rest);

--- a/console-ui/src/lib/markdown.tsx
+++ b/console-ui/src/lib/markdown.tsx
@@ -200,6 +200,7 @@ export function renderInline(
   text: string,
   keyPrefix = 'i',
   marker?: InlineMarker,
+  autolink = true,
 ): ReactNode[] {
   const out: ReactNode[] = [];
   let rest = text;
@@ -208,15 +209,35 @@ export function renderInline(
   // them without markdown syntax, and a dead-text GitHub URL in an answer is
   // a product failure. Trailing punctuation stays text; the href is the
   // matched URL verbatim (still only http/https — no scheme smuggling).
-  const AUTOLINK = /https?:\/\/[^\s<>"'`\])}]+/g;
+  const AUTOLINK = /https?:\/\/[^\s<>"'`\]}]+/g;
   const pushText = (chunk: string) => {
     if (chunk === '') return;
+    if (!autolink) {
+      out.push(chunk);
+      return;
+    }
     let last = 0;
     for (const m of chunk.matchAll(AUTOLINK)) {
       const at = m.index ?? 0;
       let url = m[0];
-      // Common trailing punctuation is sentence-ware, not URL.
-      while (/[.,;:!?、。,;)]$/.test(url)) url = url.slice(0, -1);
+      // Common trailing punctuation is sentence-ware, not URL — but a
+      // closing paren stays when the URL contains its opening half
+      // (https://en.wikipedia.org/wiki/Foo_(bar)).
+      for (;;) {
+        const last = url.slice(-1);
+        if (/[.,;:!?、。,;]/.test(last)) {
+          url = url.slice(0, -1);
+          continue;
+        }
+        if (
+          last === ')' &&
+          (url.match(/\(/g)?.length ?? 0) < (url.match(/\)/g)?.length ?? 0)
+        ) {
+          url = url.slice(0, -1);
+          continue;
+        }
+        break;
+      }
       if (url.length === 0) continue;
       if (at > last) out.push(chunk.slice(last, at));
       out.push(
@@ -283,7 +304,7 @@ export function renderInline(
         // text and the <a> keeps single-navigation semantics.
         out.push(
           <a key={key} href={href} target="_blank" rel="noreferrer">
-            {renderInline(label, key)}
+            {renderInline(label, key, undefined, false)}
           </a>,
         );
       } else {

--- a/console-ui/src/lib/types.ts
+++ b/console-ui/src/lib/types.ts
@@ -296,6 +296,16 @@ export interface AskProgressEvent {
   stopped_reason?: string;
 }
 
+/** One completed turn from GET /api/ask/session/<chat> — the saved-chat
+ * bridge to the audit transcript (History replay with full trails). */
+export interface AskSessionTurn {
+  turn_id: string;
+  question: string;
+  answer: string;
+  stopped_reason: string;
+  tool_trace: AskTraceEntry[];
+}
+
 export interface AskProgress {
   events: AskProgressEvent[];
   done: boolean;
@@ -325,6 +335,14 @@ export interface AskLimits {
 
 /** Read-only server/vault configuration. Index-derived fields are null when
  * the vault has no index projection yet. */
+/** Server build identity — package version + git hash (+dirty) + build
+ * instant. The stale-build diagnosis surface. */
+export interface ServerVersion {
+  server: string;
+  git: string;
+  built: string;
+}
+
 export interface SettingsPayload {
   vault_root: string;
   schema_version: string | null;
@@ -347,7 +365,8 @@ export interface SettingsPayload {
   /** Run-liveness heartbeat block (OVP2 observability P0); null on a fresh
    * vault / pre-P0 index. Mirrors `model.ops.last_run`. */
   last_run: LastRunModel | null;
-  version: string;
+  /** Server build identity (was a bare package-version string pre-#379). */
+  version: ServerVersion;
 }
 
 export interface BlockedSource {

--- a/console-ui/src/pages/AskPage.tsx
+++ b/console-ui/src/pages/AskPage.tsx
@@ -16,6 +16,7 @@ import { useI18n, type MsgKey } from '../i18n';
 import {
   AskError,
   fetchAskProgress,
+  fetchAskSession,
   fetchAskStatus,
   fetchChatMarkdown,
   fetchChats,
@@ -518,9 +519,34 @@ export default function AskPage() {
     setHoverId(null);
     if (!openChat) return;
     let cancelled = false;
-    fetchChatMarkdown(openChat)
+    // Agent chats replay from the AUDIT transcript (full per-turn trails
+    // survive a reload — operator finding: History lost the 复盘 detail);
+    // legacy chats keep the markdown parse.
+    fetchAskSession(openChat)
+      .then((session) => {
+        if (cancelled || openChatRef.current !== openChat) return null;
+        if (session.turns.length === 0) return fetchChatMarkdown(openChat);
+        setSavedTurns(
+          session.turns.map((turn) => ({
+            question: turn.question,
+            errorKey: null,
+            response: {
+              answer: turn.answer,
+              citations: citationsFromAnswerText(turn.answer),
+              verified: null,
+              context_hits: 0,
+              chat: openChat,
+              agent: true,
+              stopped_reason: turn.stopped_reason,
+              turn_id: turn.turn_id,
+              tool_trace: turn.tool_trace,
+            },
+          })),
+        );
+        return null;
+      })
       .then((md) => {
-        if (cancelled || openChatRef.current !== openChat) return;
+        if (md == null || cancelled || openChatRef.current !== openChat) return;
         const parsed = parseChatTranscript(md);
         if (parsed.length === 0) {
           setSavedError(t('ask.chatParseEmpty'));

--- a/console-ui/src/pages/AskPage.tsx
+++ b/console-ui/src/pages/AskPage.tsx
@@ -523,6 +523,9 @@ export default function AskPage() {
     // survive a reload — operator finding: History lost the 复盘 detail);
     // legacy chats keep the markdown parse.
     fetchAskSession(openChat)
+      // An older server (no session endpoint) or a replay-read failure must
+      // not kill the page — markdown replay still works.
+      .catch(() => ({ turns: [] }))
       .then((session) => {
         if (cancelled || openChatRef.current !== openChat) return null;
         if (session.turns.length === 0) return fetchChatMarkdown(openChat);

--- a/console-ui/src/pages/SystemPage.tsx
+++ b/console-ui/src/pages/SystemPage.tsx
@@ -616,7 +616,13 @@ function SettingsSection({ refreshKey = 0 }: { refreshKey?: number }) {
             })}
           </dd>
           <dt>{t('system.version')}</dt>
-          <dd className="mono tiny">{settings.version}</dd>
+          <dd className="mono tiny">
+            {typeof settings.version === 'string'
+              ? settings.version
+              : `v${settings.version.server} · ${settings.version.git} · ${settings.version.built}`}
+          </dd>
+          <dt>{t('system.uiBuild')}</dt>
+          <dd className="mono tiny">{__OVP_UI_BUILD__}</dd>
         </dl>
       )}
       {/* The toggles themselves stay in the shell top bar (design §0.6:

--- a/console-ui/src/vite-env.d.ts
+++ b/console-ui/src/vite-env.d.ts
@@ -1,1 +1,4 @@
 /// <reference types="vite/client" />
+
+/** Injected at bundle time by vite.config.ts — git hash + build instant. */
+declare const __OVP_UI_BUILD__: string;

--- a/console-ui/vite.config.ts
+++ b/console-ui/vite.config.ts
@@ -1,7 +1,20 @@
 import { defineConfig } from 'vite';
 import { resolve } from 'path';
+import { execSync } from 'child_process';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
+
+// UI build identity (operator finding: stale builds were undiagnosable).
+function uiBuildStamp(): string {
+  let git = 'unknown';
+  try {
+    git = execSync('git rev-parse --short=9 HEAD').toString().trim();
+  } catch {
+    /* tarball builds */
+  }
+  const now = new Date().toISOString().replace(/\.\d+Z$/, 'Z');
+  return `${git} · ${now}`;
+}
 
 // Single-entry React SPA — the OVP2 portal (portal v2, B1). Served at the
 // site root: ovp-server serves dist/index.html for `/` and every client
@@ -12,6 +25,9 @@ import tailwindcss from '@tailwindcss/vite';
 // (e.g. '/blog/') so the SPA and its `<base>/api/*.json` fetches resolve under
 // a GitHub-Pages sub-path.
 export default defineConfig({
+  define: {
+    __OVP_UI_BUILD__: JSON.stringify(uiBuildStamp()),
+  },
   base: process.env.VITE_OVP_BASE ?? '/',
   plugins: [react(), tailwindcss()],
   build: {

--- a/crates/ovp-api-projection/src/readers.rs
+++ b/crates/ovp-api-projection/src/readers.rs
@@ -63,6 +63,7 @@ pub fn read_source_doc(
     vault_root: &Path,
     layout: &VaultLayout,
     rel_path: Option<&str>,
+    sha256: Option<&str>,
 ) -> (Option<String>, bool, Option<String>) {
     let Some(rel) = rel_path else {
         return (None, false, None);
@@ -73,7 +74,7 @@ pub fn read_source_doc(
     let recorded = vault_root.join(rel);
     let path = if recorded.is_file() {
         recorded
-    } else if let Some(moved) = lifecycle_moved_path(vault_root, layout, rel) {
+    } else if let Some(moved) = lifecycle_moved_path(vault_root, layout, rel, sha256) {
         moved
     } else {
         recorded
@@ -97,6 +98,11 @@ pub fn read_source_doc(
 /// Lifecycle-move fallback — delegates to the shared implementation in
 /// `ovp_domain::vault_layout` so every reader AND writer resolves the same
 /// candidate. Kept as a re-export shim for existing callers.
-pub fn lifecycle_moved_path(vault_root: &Path, layout: &VaultLayout, rel: &str) -> Option<PathBuf> {
-    ovp_domain::vault_layout::lifecycle_moved_path(vault_root, layout, rel)
+pub fn lifecycle_moved_path(
+    vault_root: &Path,
+    layout: &VaultLayout,
+    rel: &str,
+    expected_sha256: Option<&str>,
+) -> Option<PathBuf> {
+    ovp_domain::vault_layout::lifecycle_moved_path(vault_root, layout, rel, expected_sha256)
 }

--- a/crates/ovp-domain/src/vault_layout.rs
+++ b/crates/ovp-domain/src/vault_layout.rs
@@ -291,6 +291,19 @@ pub fn lifecycle_moved_path(
     let raw_prefix = format!("{}/", layout.inbox_raw_dir());
     let rest = rel.strip_prefix(&raw_prefix)?;
     let (month, file) = rest.split_once('/')?;
+    // Single plain components only: a multi-segment or dot-dot "file" (a
+    // poisoned rel_path) could join OUTSIDE the month bucket — the whole
+    // point of exact-basename isolation.
+    if file.is_empty()
+        || file.contains('/')
+        || file == "."
+        || file == ".."
+        || month.is_empty()
+        || month.contains('/')
+        || month.starts_with('.')
+    {
+        return None;
+    }
     let candidate = vault_root.join(layout.processed_dir(month)).join(file);
     if candidate.is_file() {
         return Some(candidate);

--- a/crates/ovp-domain/src/vault_layout.rs
+++ b/crates/ovp-domain/src/vault_layout.rs
@@ -286,7 +286,36 @@ pub fn lifecycle_moved_path(
     let rest = rel.strip_prefix(&raw_prefix)?;
     let (month, file) = rest.split_once('/')?;
     let candidate = vault_root.join(layout.processed_dir(month)).join(file);
-    candidate.is_file().then_some(candidate)
+    if candidate.is_file() {
+        return Some(candidate);
+    }
+    // Lifecycle archives by PROCESSED month, not capture month: a June
+    // capture processed in July lives under 03-Processed/2026-07/ while the
+    // index still records 01-Raw/2026-06/ (live bug: the portal's source
+    // detail showed no 原文 for exactly such rows). Cross-month probing is
+    // identity-safe for readers AND writers because it requires the
+    // recorded basename to embed its content-hash stem (`-<hex8>` before
+    // the extension, the normalized-source naming contract) and matches
+    // that EXACT basename: a colliding name would mean the same content
+    // hash, and safe_move's collision suffixes never match.
+    let stem = std::path::Path::new(file).file_stem()?.to_str()?;
+    let hash8 = stem.rsplit('-').next()?;
+    if hash8.len() != 8 || !hash8.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return None;
+    }
+    let entries = std::fs::read_dir(vault_root.join(layout.processed_root())).ok()?;
+    let mut months: Vec<std::path::PathBuf> = entries
+        .filter_map(|e| {
+            let e = e.ok()?;
+            e.file_type().ok()?.is_dir().then_some(e.path())
+        })
+        .collect();
+    months.sort();
+    months
+        .into_iter()
+        .rev() // newest bucket first — lifecycle moves land in recent months
+        .map(|dir| dir.join(file))
+        .find(|p| p.is_file())
 }
 
 /// Truncate to at most `max` characters on a char boundary (titles can be

--- a/crates/ovp-domain/src/vault_layout.rs
+++ b/crates/ovp-domain/src/vault_layout.rs
@@ -277,10 +277,16 @@ pub fn pack_case_id(pack_dir: &str) -> &str {
 /// subpath. When the recorded path misses and sits under the raw inbox dir,
 /// return the processed-dir candidate iff it exists. One implementation for
 /// every reader/writer (`rel` must already be traversal-checked).
+/// `expected_sha256`: when the caller knows WHICH source this path belongs
+/// to, cross-month candidates are accepted only if the basename's
+/// content-hash stem matches that sha's first 8 hex chars — a poisoned
+/// index row naming another source's file resolves to nothing (write
+/// safety: the tag endpoint mutates whatever this returns).
 pub fn lifecycle_moved_path(
     vault_root: &std::path::Path,
     layout: &VaultLayout,
     rel: &str,
+    expected_sha256: Option<&str>,
 ) -> Option<std::path::PathBuf> {
     let raw_prefix = format!("{}/", layout.inbox_raw_dir());
     let rest = rel.strip_prefix(&raw_prefix)?;
@@ -301,6 +307,11 @@ pub fn lifecycle_moved_path(
     let stem = std::path::Path::new(file).file_stem()?.to_str()?;
     let hash8 = stem.rsplit('-').next()?;
     if hash8.len() != 8 || !hash8.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return None;
+    }
+    if let Some(expected) = expected_sha256
+        && !expected.get(..8).is_some_and(|e| e.eq_ignore_ascii_case(hash8))
+    {
         return None;
     }
     let entries = std::fs::read_dir(vault_root.join(layout.processed_root())).ok()?;

--- a/crates/ovp-index/src/build.rs
+++ b/crates/ovp-index/src/build.rs
@@ -379,7 +379,12 @@ fn attach_tags(vault_root: &Path, rows: &mut [SourceRow]) -> Result<usize, Strin
         let path = if recorded.is_file() {
             recorded
         } else if let Some(moved) =
-            ovp_domain::vault_layout::lifecycle_moved_path(vault_root, &layout, rel)
+            ovp_domain::vault_layout::lifecycle_moved_path(
+                vault_root,
+                &layout,
+                rel,
+                Some(&row.sha256),
+            )
         {
             moved
         } else {

--- a/crates/ovp-mcp/src/lib.rs
+++ b/crates/ovp-mcp/src/lib.rs
@@ -1027,8 +1027,12 @@ fn handle_resources_read(state: &McpState, params: &Value) -> Result<Value, RpcE
                     code: -32602,
                     message: format!("No source with sha256 `{sha}`"),
                 })?;
-            let (doc, truncated, err) =
-                readers::read_source_doc(&state.vault_root, &state.layout, src.rel_path.as_deref());
+            let (doc, truncated, err) = readers::read_source_doc(
+                &state.vault_root,
+                &state.layout,
+                src.rel_path.as_deref(),
+                Some(&src.sha256),
+            );
             let json = serde_json::to_string(&serde_json::json!({
                 "uri": uri,
                 "source": src,

--- a/crates/ovp-memory/src/agent_transcript.rs
+++ b/crates/ovp-memory/src/agent_transcript.rs
@@ -516,6 +516,33 @@ impl SessionStore {
     /// trail needs for 复盘: the model's call ARGUMENTS (from the recorded
     /// assistant blocks) and a result-stats note (from the full audit
     /// content; late results narrate nothing, matching the original reply).
+    /// Every COMPLETED turn in transcript order — (turn_id, question,
+    /// answer, stopped_reason). The saved-chat surface uses this to marry
+    /// the product History with the audit trail's per-turn detail.
+    pub fn completed_turns(&self) -> Vec<(String, String, String, String)> {
+        let mut questions: std::collections::HashMap<&str, &str> =
+            std::collections::HashMap::new();
+        for e in &self.events {
+            if let TranscriptEvent::TurnStarted { turn_id, question, .. } = e {
+                questions.insert(turn_id.as_str(), question.as_str());
+            }
+        }
+        self.events
+            .iter()
+            .filter_map(|e| match e {
+                TranscriptEvent::TurnFinished { turn_id, answer, stopped_reason, .. } => {
+                    Some((
+                        turn_id.clone(),
+                        questions.get(turn_id.as_str()).copied().unwrap_or("").to_string(),
+                        answer.clone(),
+                        stopped_reason.clone(),
+                    ))
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
     pub fn tool_trail_for_turn(
         &self,
         id: &str,

--- a/crates/ovp-memory/src/agent_transcript.rs
+++ b/crates/ovp-memory/src/agent_transcript.rs
@@ -520,27 +520,28 @@ impl SessionStore {
     /// answer, stopped_reason). The saved-chat surface uses this to marry
     /// the product History with the audit trail's per-turn detail.
     pub fn completed_turns(&self) -> Vec<(String, String, String, String)> {
+        // One chronological pass: a finish pairs only with a start already
+        // SEEN — an orphaned finish never borrows a later turn's question.
         let mut questions: std::collections::HashMap<&str, &str> =
             std::collections::HashMap::new();
+        let mut out = Vec::new();
         for e in &self.events {
-            if let TranscriptEvent::TurnStarted { turn_id, question, .. } = e {
-                questions.insert(turn_id.as_str(), question.as_str());
-            }
-        }
-        self.events
-            .iter()
-            .filter_map(|e| match e {
+            match e {
+                TranscriptEvent::TurnStarted { turn_id, question, .. } => {
+                    questions.insert(turn_id.as_str(), question.as_str());
+                }
                 TranscriptEvent::TurnFinished { turn_id, answer, stopped_reason, .. } => {
-                    Some((
+                    out.push((
                         turn_id.clone(),
                         questions.get(turn_id.as_str()).copied().unwrap_or("").to_string(),
                         answer.clone(),
                         stopped_reason.clone(),
-                    ))
+                    ));
                 }
-                _ => None,
-            })
-            .collect()
+                _ => {}
+            }
+        }
+        out
     }
 
     pub fn tool_trail_for_turn(

--- a/crates/ovp-memory/src/vault_tools.rs
+++ b/crates/ovp-memory/src/vault_tools.rs
@@ -2121,48 +2121,6 @@ fn find_source<'a>(
         .ok_or_else(|| VaultToolError::Failed(format!("unknown source `{source_id}`")))
 }
 
-/// Read-only cross-month lifecycle fallback. The shared domain helper stays
-/// same-month-only because it also serves write paths; here the source index
-/// supplies the sha256 needed to prove that a basename belongs to this row.
-fn identity_verified_cross_month_path(
-    vault_root: &Path,
-    layout: &VaultLayout,
-    rel_path: &str,
-    sha256: &str,
-) -> Option<PathBuf> {
-    let raw_prefix = format!("{}/", layout.inbox_raw_dir());
-    let rest = rel_path.strip_prefix(&raw_prefix)?;
-    let (_, recorded_tail) = rest.split_once('/')?;
-    let basename = Path::new(recorded_tail).file_name()?.to_str()?;
-    let extension = Path::new(basename).extension()?.to_str()?;
-    if extension.is_empty() {
-        return None;
-    }
-    let stem = Path::new(basename).file_stem()?.to_str()?;
-    let sha8 = sha256.get(..8)?;
-    if !sha8.bytes().all(|byte| byte.is_ascii_hexdigit()) {
-        return None;
-    }
-    let expected_suffix = format!("-{}", sha8.to_ascii_lowercase());
-    if !stem.to_ascii_lowercase().ends_with(&expected_suffix) {
-        return None;
-    }
-
-    let processed_root = vault_root.join(layout.processed_root());
-    let mut month_dirs = std::fs::read_dir(processed_root)
-        .ok()?
-        .filter_map(|entry| {
-            let entry = entry.ok()?;
-            entry.file_type().ok()?.is_dir().then_some(entry.path())
-        })
-        .collect::<Vec<_>>();
-    month_dirs.sort();
-    month_dirs
-        .into_iter()
-        .rev()
-        .map(|month_dir| month_dir.join(basename))
-        .find(|candidate| candidate.is_file())
-}
 
 /// Resolve a source's on-disk file: index rel_path + the shared same-month
 /// lifecycle fallback, then an identity-verified read-only cross-month probe,
@@ -2189,17 +2147,30 @@ fn resolve_source_path(
         && let Some(moved) =
             ovp_domain::vault_layout::lifecycle_moved_path(vault_root, &layout, rel_path)
     {
-        joined = moved;
-    }
-    if !joined.is_file()
-        && let Some(moved) = identity_verified_cross_month_path(
-            vault_root,
-            &layout,
-            rel_path,
-            &source.sha256,
-        )
-    {
-        joined = moved;
+        // The shared fallback probes the SAME month permissively (the
+        // original contract) and other months by exact stem-carrying
+        // basename. The TOOLS layer holds cross-month candidates to a
+        // stricter bar: the stem must be THIS source's own sha8 — a
+        // poisoned index row whose recorded name embeds a different
+        // source's stem must not read another source's file.
+        let recorded_month = rel_path
+            .strip_prefix(&format!("{}/", layout.inbox_raw_dir()))
+            .and_then(|rest| rest.split_once('/'))
+            .map(|(month, _)| month);
+        let candidate_month = moved
+            .parent()
+            .and_then(|d| d.file_name())
+            .and_then(|n| n.to_str());
+        let same_month = recorded_month.is_some() && recorded_month == candidate_month;
+        let stem_is_own_sha = moved
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .and_then(|s| s.rsplit('-').next())
+            .zip(source.sha256.get(..8))
+            .is_some_and(|(stem, sha8)| stem.eq_ignore_ascii_case(sha8));
+        if same_month || stem_is_own_sha {
+            joined = moved;
+        }
     }
     let resolved = std::fs::canonicalize(&joined).map_err(|e| {
         VaultToolError::Failed(format!("reading source `{source_id}` at {rel_path}: {e}"))

--- a/crates/ovp-memory/src/vault_tools.rs
+++ b/crates/ovp-memory/src/vault_tools.rs
@@ -2144,33 +2144,16 @@ fn resolve_source_path(
     let layout = ovp_domain::vault_layout::VaultLayout::new();
     let mut joined = vault_root.join(rel_path);
     if !joined.is_file()
-        && let Some(moved) =
-            ovp_domain::vault_layout::lifecycle_moved_path(vault_root, &layout, rel_path)
+        && let Some(moved) = ovp_domain::vault_layout::lifecycle_moved_path(
+            vault_root,
+            &layout,
+            rel_path,
+            // Cross-month candidates must carry THIS source's own sha stem —
+            // a poisoned index row cannot read another source's file.
+            Some(&source.sha256),
+        )
     {
-        // The shared fallback probes the SAME month permissively (the
-        // original contract) and other months by exact stem-carrying
-        // basename. The TOOLS layer holds cross-month candidates to a
-        // stricter bar: the stem must be THIS source's own sha8 — a
-        // poisoned index row whose recorded name embeds a different
-        // source's stem must not read another source's file.
-        let recorded_month = rel_path
-            .strip_prefix(&format!("{}/", layout.inbox_raw_dir()))
-            .and_then(|rest| rest.split_once('/'))
-            .map(|(month, _)| month);
-        let candidate_month = moved
-            .parent()
-            .and_then(|d| d.file_name())
-            .and_then(|n| n.to_str());
-        let same_month = recorded_month.is_some() && recorded_month == candidate_month;
-        let stem_is_own_sha = moved
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .and_then(|s| s.rsplit('-').next())
-            .zip(source.sha256.get(..8))
-            .is_some_and(|(stem, sha8)| stem.eq_ignore_ascii_case(sha8));
-        if same_month || stem_is_own_sha {
-            joined = moved;
-        }
+        joined = moved;
     }
     let resolved = std::fs::canonicalize(&joined).map_err(|e| {
         VaultToolError::Failed(format!("reading source `{source_id}` at {rel_path}: {e}"))

--- a/crates/ovp-server/build.rs
+++ b/crates/ovp-server/build.rs
@@ -1,0 +1,35 @@
+//! Embed the git hash + build instant so every running surface can answer
+//! "which version am I?" (operator finding: undiagnosable stale builds).
+fn main() {
+    let git = std::process::Command::new("git")
+        .args(["rev-parse", "--short=9", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| "unknown".into());
+    let dirty = std::process::Command::new("git")
+        .args(["status", "--porcelain"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| !o.stdout.is_empty())
+        .unwrap_or(false);
+    println!(
+        "cargo:rustc-env=OVP_GIT_HASH={git}{}",
+        if dirty { "+dirty" } else { "" }
+    );
+    let built = std::process::Command::new("date")
+        .args(["-u", "+%Y-%m-%dT%H:%M:%SZ"])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| "unknown".into());
+    println!("cargo:rustc-env=OVP_BUILD_TIME={built}");
+    // Re-stamp on every commit / staging change; a dirty-tree edit that
+    // recompiles this crate re-runs the script anyway.
+    println!("cargo:rerun-if-changed=../../.git/HEAD");
+    println!("cargo:rerun-if-changed=../../.git/index");
+}

--- a/crates/ovp-server/build.rs
+++ b/crates/ovp-server/build.rs
@@ -28,8 +28,17 @@ fn main() {
         .map(|s| s.trim().to_string())
         .unwrap_or_else(|| "unknown".into());
     println!("cargo:rustc-env=OVP_BUILD_TIME={built}");
-    // Re-stamp on every commit / staging change; a dirty-tree edit that
-    // recompiles this crate re-runs the script anyway.
+    // rerun-if-changed REPLACES Cargo's default tracking — list the crate
+    // sources back in, plus the git state the stamp derives from (HEAD for
+    // branch switches, the RESOLVED branch ref for commits — commits move
+    // the ref, not HEAD — and the index for staged/dirty transitions).
+    println!("cargo:rerun-if-changed=src");
+    println!("cargo:rerun-if-changed=Cargo.toml");
     println!("cargo:rerun-if-changed=../../.git/HEAD");
     println!("cargo:rerun-if-changed=../../.git/index");
+    if let Ok(head) = std::fs::read_to_string("../../.git/HEAD")
+        && let Some(reference) = head.trim().strip_prefix("ref: ")
+    {
+        println!("cargo:rerun-if-changed=../../.git/{reference}");
+    }
 }

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -733,11 +733,20 @@ fn dispatch(
         }
         // Agent-mode discovery MUST work index-free (the agent path itself
         // does): /api/model 503s on an unindexed vault, so the SPA reads
-        // this instead before minting a session id and polling.
+        // this instead before minting a session id and polling. Carries the
+        // server's version identity — the first question when anything looks
+        // stale is "which build am I talking to?".
         (Method::Get, "/api/ask/status") => json_response(
             200,
-            &serde_json::json!({"agent": state.ask_agent}).to_string(),
+            &serde_json::json!({
+                "agent": state.ask_agent,
+                "version": server_version(),
+            })
+            .to_string(),
         ),
+        (Method::Get, p) if p.starts_with("/api/ask/session/") => {
+            handle_ask_session(state, p)
+        }
         (Method::Post, "/api/schedule/run") => handle_run_start(state, body),
         (Method::Post, "/api/attention/ack") => handle_attention_ack(state, body),
         (Method::Get, "/api/providers") => handle_providers_get(state),
@@ -977,9 +986,12 @@ fn handle_source_tags_post(
     let recorded = state.vault_root.join(&rel);
     let note_path = if recorded.is_file() {
         recorded
-    } else if let Some(moved) =
-        ovp_api_projection::readers::lifecycle_moved_path(&state.vault_root, &state.layout, &rel)
-    {
+    } else if let Some(moved) = ovp_api_projection::readers::lifecycle_moved_path(
+        &state.vault_root,
+        &state.layout,
+        &rel,
+        Some(sha),
+    ) {
         moved
     } else {
         // Recorded path gone and no lifecycle candidate: a stale row, not a
@@ -1903,6 +1915,7 @@ fn handle_source_api(state: &AppState, url: &str) -> Response<std::io::Cursor<Ve
                 &state.vault_root,
                 &state.layout,
                 source.rel_path.as_deref(),
+                Some(&source.sha256),
             );
             bodies::SourceDoc {
                 markdown,
@@ -1974,7 +1987,9 @@ fn handle_settings(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
         // stale "running"). Null on a fresh vault. The client derives age from
         // started_at/ended_at + now — the server ships no `minutes_since`.
         "last_run": state.current_last_run(),
-        "version": env!("CARGO_PKG_VERSION"),
+        // Build identity (operator finding: stale builds were undiagnosable):
+        // was a bare package version; now version+git+built.
+        "version": server_version(),
     });
     json_stamped(200, &body.to_string(), model.as_ref())
 }
@@ -2674,6 +2689,73 @@ fn handle_ask_agent(
             json_response(504, &body.to_string())
         }
     }
+}
+
+/// The server's build identity: package version + git hash (+dirty) + build
+/// instant, stamped by build.rs. Every surface that wonders "am I stale?"
+/// reads this — /api/ask/status (index-free) and /api/settings both carry it.
+fn server_version() -> serde_json::Value {
+    serde_json::json!({
+        "server": env!("CARGO_PKG_VERSION"),
+        "git": env!("OVP_GIT_HASH"),
+        "built": env!("OVP_BUILD_TIME"),
+    })
+}
+
+/// `GET /api/ask/session/<chat>` — the saved-chat surface's bridge to the
+/// AUDIT transcript: every completed turn with its question, answer, stop
+/// status, and per-call trail (args narration + result stats). History
+/// replay renders agent conversations from this instead of the minimal
+/// markdown, so the 复盘 detail survives a reload. Unknown/legacy chats
+/// answer empty turns (the UI falls back to markdown parsing).
+fn handle_ask_session(state: &AppState, path: &str) -> Response<std::io::Cursor<Vec<u8>>> {
+    // Session ids are [A-Za-z0-9_-] — nothing to percent-decode.
+    let chat = path.trim_start_matches("/api/ask/session/").to_string();
+    if !ovp_memory::agent_transcript::valid_session_id(&chat) {
+        return json_response(
+            400,
+            r#"{"error":"invalid chat session id","code":"invalid_chat"}"#,
+        );
+    }
+    let sessions_dir = state.vault_root.join(".ovp").join("ask-sessions");
+    // No session file = a legacy (markdown-only) chat — an empty reply, not
+    // an error, and nothing is created on disk for a read.
+    if !sessions_dir.join(format!("{chat}.jsonl")).is_file() {
+        return json_response(200, r#"{"turns":[]}"#);
+    }
+    let store = match ovp_memory::agent_transcript::SessionStore::open(&sessions_dir, &chat) {
+        Ok(s) => s,
+        Err(e) => {
+            return json_response(
+                500,
+                &format!(r#"{{"error":{}}}"#, json_str(&format!("session read: {e}"))),
+            );
+        }
+    };
+    let turns: Vec<serde_json::Value> = store
+        .completed_turns()
+        .into_iter()
+        .map(|(turn_id, question, answer, stopped_reason)| {
+            let trail: Vec<serde_json::Value> = store
+                .tool_trail_for_turn(&turn_id)
+                .into_iter()
+                .map(|(tool, _id, is_error, summary, arguments, note)| {
+                    serde_json::json!({
+                        "tool": tool, "ok": !is_error, "summary": summary,
+                        "args": args_brief(&arguments), "note": note,
+                    })
+                })
+                .collect();
+            serde_json::json!({
+                "turn_id": turn_id,
+                "question": question,
+                "answer": answer,
+                "stopped_reason": stopped_reason,
+                "tool_trace": trail,
+            })
+        })
+        .collect();
+    json_response(200, &serde_json::json!({"turns": turns}).to_string())
 }
 
 /// `GET /api/ask/progress?chat=<session>` — the minimal A0 §3.7 progress feed.
@@ -4123,7 +4205,9 @@ mod tests {
             v["ask_limits"]["max_concurrent"],
             DEFAULT_MAX_CONCURRENT_ASKS
         );
-        assert_eq!(v["version"], env!("CARGO_PKG_VERSION"));
+        assert_eq!(v["version"]["server"], env!("CARGO_PKG_VERSION"));
+        assert!(v["version"]["git"].is_string());
+        assert!(v["version"]["built"].is_string());
 
         // Factory alone is not enough — product surface needs a key in
         // providers.toml (or env). Seed the file the System page writes.


### PR DESCRIPTION
Operator dogfood found two live defects: (1) the source-detail 原文 panel still hit the cross-month lifecycle bug (#375's fix lived only in the agent tools) — the SHARED domain fallback now probes sibling processed-month buckets with identity-safe exact stem-carrying basename matching; the agent tools keep the stricter own-sha8 bar (poisoned index rows can't read another source's file). Verified live: the previously-empty article now serves 15k chars. (2) Bare http(s) URLs in rendered markdown autolink (target=_blank, http/https only) — model answers cite GitHub links without markdown syntax and they rendered as dead text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plain-text `http://` and `https://` URLs in markdown are now automatically rendered as clickable links.
  * Saved chat loading now prefers audit-backed session data when available.
  * System page now displays a structured server version and a new “UI build” row.
* **Bug Fixes**
  * Improved recovery of moved vault files across month boundaries with additional hash validation.
  * Strengthened source-file matching to reduce incorrect cross-source resolutions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->