### PR TITLE
feat(ask): friendly citation titles + live process graph

### DIFF
--- a/console-ui/src/components/AskProcessGraph.test.ts
+++ b/console-ui/src/components/AskProcessGraph.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { buildProcessGraph } from './AskProcessGraph';
+
+describe('buildProcessGraph', () => {
+  it('replays a dense history trail (many sources + memory cards)', () => {
+    // Mirrors a real session tool_trace: fulltext + evidence hits, no live
+    // progress events — History must still build a non-empty graph.
+    const sources = Array.from({ length: 5 }, (_, i) => ({
+      kind: 'source',
+      id: `sha-${i}`,
+      label: `Source ${i}`,
+      source_id: `sha-${i}`,
+    }));
+    const cards = Array.from({ length: 3 }, (_, i) => ({
+      kind: 'card',
+      id: `card:sha-${i}:Card ${i}`,
+      label: `Card ${i}`,
+      source_id: `sha-${i}`,
+    }));
+    const { nodes, edges } = buildProcessGraph({
+      toolTrace: [
+        { tool: 'search_fulltext', summary: 'ok', ok: true, hits: sources },
+        { tool: 'search_evidence', summary: 'ok', ok: true, hits: cards },
+      ],
+    });
+    expect(nodes.filter((n) => n.kind === 'source')).toHaveLength(5);
+    expect(nodes.filter((n) => n.kind === 'card')).toHaveLength(3);
+    expect(edges.length).toBeGreaterThan(0);
+  });
+
+  it('accumulates claim/source/card hits and cites edges', () => {
+    const { nodes, edges } = buildProcessGraph({
+      events: [
+        {
+          event: 'tool_finished',
+          tool: 'search_claims',
+          hits: [
+            {
+              kind: 'claim',
+              id: 'ck-1',
+              label: 'Governed forgetting',
+              source_id: 'sha-a',
+            },
+          ],
+        },
+        {
+          event: 'tool_finished',
+          tool: 'search_sources',
+          hits: [
+            {
+              kind: 'source',
+              id: 'sha-a',
+              label: 'Agent Memory Systems',
+              source_id: 'sha-a',
+            },
+          ],
+        },
+      ],
+      citations: [
+        {
+          id: 'claim:ck-1',
+          kind: 'claim',
+          title: 'Governed forgetting',
+          snippet: null,
+          link_target: '/knowledge#ck-1',
+          verified: true,
+        },
+      ],
+    });
+
+    expect(nodes.some((n) => n.kind === 'claim' && n.cited)).toBe(true);
+    expect(nodes.some((n) => n.id === 'source:sha-a' && n.hit)).toBe(true);
+    expect(edges.some((e) => e.type === 'cites')).toBe(true);
+  });
+
+  it('builds from tool_trace alone (history replay)', () => {
+    const { nodes } = buildProcessGraph({
+      toolTrace: [
+        {
+          tool: 'search_evidence',
+          summary: 'ok',
+          ok: true,
+          hits: [
+            {
+              kind: 'card',
+              id: 'card:s1:Memory',
+              label: 'Memory as state',
+              source_id: 's1',
+            },
+          ],
+        },
+      ],
+    });
+    expect(nodes.some((n) => n.kind === 'card')).toBe(true);
+    expect(nodes.some((n) => n.id === 'source:s1')).toBe(true);
+  });
+});

--- a/console-ui/src/components/AskProcessGraph.tsx
+++ b/console-ui/src/components/AskProcessGraph.tsx
@@ -1,0 +1,421 @@
+/** Live process graph for Ask — KMEM-style explainability during search.
+ *
+ * As the agent touches claims / sources / memory cards, nodes accumulate
+ * into a small force graph so the operator sees *what* entered the answer
+ * trail, not just a linear tool log. Seeded from progress-feed hits while
+ * a turn is in flight; after the answer lands, final citations are merged
+ * in (cited nodes get a stronger visual weight).
+ *
+ * Reuses react-force-graph-2d (already on the Knowledge graph) and the same
+ * DS community color tokens so the viz language stays one system.
+ */
+import { Suspense, lazy, useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useI18n } from '../i18n';
+import type {
+  AskCitation,
+  AskProgressEvent,
+  AskProgressHit,
+  AskTraceEntry,
+} from '../lib/types';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const ForceGraph2D = lazy(() => import('react-force-graph-2d')) as any;
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+export interface ProcessNode {
+  id: string;
+  kind: 'claim' | 'source' | 'card' | 'unit' | string;
+  label: string;
+  /** True when the final answer cites this entity. */
+  cited?: boolean;
+  /** True when a live tool result introduced this entity. */
+  hit?: boolean;
+  link_target?: string | null;
+  /** force-graph mutates these */
+  x?: number;
+  y?: number;
+  vx?: number;
+  vy?: number;
+}
+
+export interface ProcessEdge {
+  source: string;
+  target: string;
+  type: 'retrieved' | 'cites' | 'from';
+}
+
+export interface AskProcessGraphProps {
+  /** Live progress events (while a turn is in flight). */
+  events?: AskProgressEvent[];
+  /** Completed tool trail (post-answer / history replay). */
+  toolTrace?: AskTraceEntry[];
+  /** Final answer citations — mark cited nodes and fill gaps. */
+  citations?: AskCitation[];
+  height?: number;
+  /** Hover from the citations rail — highlight matching node. */
+  hoverId?: string | null;
+  onOpen?: (node: ProcessNode) => void;
+}
+
+function readToken(name: string, fallback: string): string {
+  if (typeof document === 'undefined') return fallback;
+  const v = getComputedStyle(document.documentElement)
+    .getPropertyValue(name)
+    .trim();
+  return v || fallback;
+}
+
+function kindFill(kind: string): string {
+  if (kind === 'source') return readToken('--c-1', '#3b82f6');
+  if (kind === 'claim') return readToken('--c-3', '#22c55e');
+  // card / unit / memory share the memory-layer color
+  return readToken('--c-2', '#a855f7');
+}
+
+function nodeKey(kind: string, id: string): string {
+  // Sources already use bare sha; claims use claim_key; cards carry a
+  // synthetic card:… id from the progress feed.
+  if (kind === 'source' && !id.startsWith('source:')) return `source:${id}`;
+  if (kind === 'claim' && !id.startsWith('claim:') && !id.startsWith('ck-')) {
+    return `claim:${id}`;
+  }
+  if (kind === 'claim' && id.startsWith('ck-')) return `claim:${id}`;
+  return id.includes(':') ? id : `${kind}:${id}`;
+}
+
+function linkFor(kind: string, id: string, sourceId?: string | null): string | null {
+  if (kind === 'source') {
+    const sha = id.replace(/^source:/, '');
+    return sha ? `/library/${encodeURIComponent(sha)}` : null;
+  }
+  if (kind === 'claim') {
+    const key = id.replace(/^claim:/, '');
+    return key ? `/knowledge#${encodeURIComponent(key)}` : null;
+  }
+  if ((kind === 'card' || kind === 'unit') && sourceId) {
+    return `/library/${encodeURIComponent(sourceId)}`;
+  }
+  return null;
+}
+
+function upsertNode(
+  map: Map<string, ProcessNode>,
+  partial: {
+    kind: string;
+    id: string;
+    label: string;
+    source_id?: string | null;
+    cited?: boolean;
+    hit?: boolean;
+  },
+) {
+  const key = nodeKey(partial.kind, partial.id);
+  const existing = map.get(key);
+  if (existing) {
+    if (partial.cited) existing.cited = true;
+    if (partial.hit) existing.hit = true;
+    // Prefer a human label over a bare id.
+    if (
+      partial.label &&
+      (!existing.label ||
+        existing.label === existing.id ||
+        existing.label.startsWith('source '))
+    ) {
+      existing.label = partial.label;
+    }
+    return;
+  }
+  map.set(key, {
+    id: key,
+    kind: partial.kind,
+    label: partial.label || key,
+    cited: partial.cited,
+    hit: partial.hit,
+    link_target: linkFor(partial.kind, partial.id, partial.source_id),
+  });
+}
+
+function addEdge(
+  edges: ProcessEdge[],
+  seen: Set<string>,
+  source: string,
+  target: string,
+  type: ProcessEdge['type'],
+) {
+  if (source === target) return;
+  const k = `${type}|${source}|${target}`;
+  if (seen.has(k)) return;
+  seen.add(k);
+  edges.push({ source, target, type });
+}
+
+/** Fold progress hits + tool_trace + citations into graph data. */
+export function buildProcessGraph(opts: {
+  events?: AskProgressEvent[];
+  toolTrace?: AskTraceEntry[];
+  citations?: AskCitation[];
+}): { nodes: ProcessNode[]; edges: ProcessEdge[] } {
+  const nodes = new Map<string, ProcessNode>();
+  const edges: ProcessEdge[] = [];
+  const edgeSeen = new Set<string>();
+
+  const ingestHit = (h: AskProgressHit) => {
+    upsertNode(nodes, {
+      kind: h.kind,
+      id: h.id,
+      label: h.label,
+      source_id: h.source_id,
+      hit: true,
+    });
+    if (h.source_id && h.kind !== 'source') {
+      const srcKey = nodeKey('source', h.source_id);
+      // Stub the source node if we only know its id — label filled later.
+      if (!nodes.has(srcKey)) {
+        upsertNode(nodes, {
+          kind: 'source',
+          id: h.source_id,
+          label: `source ${h.source_id.slice(0, 12)}…`,
+          source_id: h.source_id,
+          hit: true,
+        });
+      }
+      addEdge(
+        edges,
+        edgeSeen,
+        nodeKey(h.kind, h.id),
+        srcKey,
+        h.kind === 'claim' ? 'cites' : 'from',
+      );
+    }
+  };
+
+  for (const ev of opts.events ?? []) {
+    if (ev.event === 'tool_finished' && ev.hits) {
+      for (const h of ev.hits) ingestHit(h);
+    }
+  }
+  for (const t of opts.toolTrace ?? []) {
+    for (const h of t.hits ?? []) ingestHit(h);
+  }
+
+  for (const c of opts.citations ?? []) {
+    const kind = c.kind || (c.id.includes(':') ? c.id.split(':')[0] : 'claim');
+    const rawId = c.id.includes(':') ? c.id.slice(c.id.indexOf(':') + 1) : c.id;
+    const token = rawId.trim().split(/\s+/)[0]?.replace(/^<|>$/g, '') ?? rawId;
+    upsertNode(nodes, {
+      kind,
+      id: kind === 'source' || kind === 'claim' ? token : c.id,
+      label: c.title || c.id,
+      cited: true,
+      hit: true,
+    });
+  }
+
+  return { nodes: Array.from(nodes.values()), edges };
+}
+
+export default function AskProcessGraph({
+  events,
+  toolTrace,
+  citations,
+  height = 220,
+  hoverId,
+  onOpen,
+}: AskProcessGraphProps) {
+  const { t } = useI18n();
+  const navigate = useNavigate();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const fgRef = useRef<any>(null);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const [width, setWidth] = useState(0);
+
+  const data = useMemo(
+    () => buildProcessGraph({ events, toolTrace, citations }),
+    [events, toolTrace, citations],
+  );
+
+  // Fresh objects so force-graph can own physics without mutating our memo.
+  const graphData = useMemo(
+    () => ({
+      nodes: data.nodes.map((n) => ({ ...n })),
+      links: data.edges.map((e) => ({ ...e })),
+    }),
+    [data],
+  );
+
+  const hoverKey = useMemo(() => {
+    if (!hoverId) return null;
+    // Citations use stable ids like source:<sha> / claim:<key>.
+    return hoverId;
+  }, [hoverId]);
+
+  // Canvas wrapper is ALWAYS mounted (even with 0 nodes) so ResizeObserver
+  // can measure width. Previously we early-returned an empty state without
+  // the wrapper; the observer effect then bound to null on first paint and
+  // never re-ran when History async-loaded tool_trace — legend showed
+  // "53 sources · 33 memory" but ForceGraph stayed unmounted (width=0).
+  useEffect(() => {
+    const el = wrapRef.current;
+    if (!el) return;
+    const measure = () => {
+      const w = el.clientWidth;
+      setWidth((prev) => (prev === w ? prev : w));
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  // Nudge the camera when the graph first gains nodes or resizes.
+  useEffect(() => {
+    if (data.nodes.length === 0 || width <= 0) return;
+    const id = window.setTimeout(() => {
+      try {
+        fgRef.current?.zoomToFit?.(400, 28);
+      } catch {
+        /* force-graph not mounted yet */
+      }
+    }, 180);
+    return () => window.clearTimeout(id);
+  }, [data.nodes.length, width]);
+
+  const counts = data.nodes.reduce(
+    (acc, n) => {
+      acc[n.kind] = (acc[n.kind] ?? 0) + 1;
+      return acc;
+    },
+    {} as Record<string, number>,
+  );
+  const empty = data.nodes.length === 0;
+
+  return (
+    <div className={`ask-process${empty ? ' empty' : ''}`}>
+      {!empty && (
+        <div className="ask-process-legend tiny muted">
+          {counts.claim ? (
+            <span>
+              <i className="ask-process-swatch claim" />
+              {t('ask.processClaims', { n: counts.claim })}
+            </span>
+          ) : null}
+          {counts.source ? (
+            <span>
+              <i className="ask-process-swatch source" />
+              {t('ask.processSources', { n: counts.source })}
+            </span>
+          ) : null}
+          {(counts.card ?? 0) + (counts.unit ?? 0) > 0 ? (
+            <span>
+              <i className="ask-process-swatch card" />
+              {t('ask.processMemory', {
+                n: (counts.card ?? 0) + (counts.unit ?? 0),
+              })}
+            </span>
+          ) : null}
+        </div>
+      )}
+      <div className="ask-process-canvas" ref={wrapRef} style={{ height }}>
+        {empty ? (
+          <p className="tiny muted ask-process-empty-msg">{t('ask.processEmpty')}</p>
+        ) : width > 0 ? (
+          <Suspense
+            fallback={<div className="tiny muted">{t('common.loading')}</div>}
+          >
+            <ForceGraph2D
+              ref={fgRef}
+              graphData={graphData}
+              width={width}
+              height={height}
+              backgroundColor="transparent"
+              nodeId="id"
+              linkSource="source"
+              linkTarget="target"
+              cooldownTicks={80}
+              enableNodeDrag
+              enableZoomInteraction
+              enablePanInteraction
+              nodeRelSize={5}
+              linkColor={() =>
+                readToken('--graph-link', 'rgba(128,128,128,0.35)')
+              }
+              linkWidth={(l: ProcessEdge) => (l.type === 'cites' ? 1.6 : 1)}
+              linkDirectionalArrowLength={3}
+              linkDirectionalArrowRelPos={1}
+              nodeCanvasObject={(
+                node: ProcessNode,
+                ctx: CanvasRenderingContext2D,
+                globalScale: number,
+              ) => {
+                const r = node.cited ? 6.5 : node.hit ? 5.5 : 4.5;
+                const x = node.x ?? 0;
+                const y = node.y ?? 0;
+                const fill = kindFill(node.kind);
+                const isHover =
+                  hoverKey != null &&
+                  (node.id === hoverKey ||
+                    node.id.endsWith(hoverKey) ||
+                    hoverKey.endsWith(
+                      node.id.replace(/^(source|claim):/, ''),
+                    ));
+
+                ctx.beginPath();
+                ctx.arc(x, y, r, 0, 2 * Math.PI);
+                ctx.fillStyle = fill;
+                ctx.globalAlpha = isHover ? 1 : 0.92;
+                ctx.fill();
+                ctx.globalAlpha = 1;
+
+                if (node.cited || isHover) {
+                  ctx.strokeStyle = readToken('--accent', '#38bdf8');
+                  ctx.lineWidth = isHover ? 2 : 1.4;
+                  ctx.stroke();
+                }
+
+                // Dense graphs (50+ search hits): label cited hubs + hover;
+                // label more aggressively when the set is small.
+                const showLabel =
+                  globalScale > 1.2 ||
+                  node.cited ||
+                  isHover ||
+                  data.nodes.length <= 12;
+                if (showLabel) {
+                  const label =
+                    node.label.length > 28
+                      ? `${node.label.slice(0, 27)}…`
+                      : node.label;
+                  const fontSize = Math.max(9, 11 / Math.sqrt(globalScale));
+                  ctx.font = `${fontSize}px ${readToken('--ovp-font-sans', 'system-ui')}`;
+                  ctx.textAlign = 'center';
+                  ctx.textBaseline = 'top';
+                  ctx.fillStyle = readToken('--text', '#e5e7eb');
+                  ctx.globalAlpha = 0.9;
+                  ctx.fillText(label, x, y + r + 2);
+                  ctx.globalAlpha = 1;
+                }
+              }}
+              nodePointerAreaPaint={(
+                node: ProcessNode,
+                color: string,
+                ctx: CanvasRenderingContext2D,
+              ) => {
+                ctx.beginPath();
+                ctx.arc(node.x ?? 0, node.y ?? 0, 10, 0, 2 * Math.PI);
+                ctx.fillStyle = color;
+                ctx.fill();
+              }}
+              onNodeClick={(node: ProcessNode) => {
+                if (onOpen) {
+                  onOpen(node);
+                  return;
+                }
+                if (node.link_target) navigate(node.link_target);
+              }}
+            />
+          </Suspense>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/console-ui/src/design/portal.css
+++ b/console-ui/src/design/portal.css
@@ -1746,6 +1746,67 @@ body {
   opacity: 0.45;
   cursor: default;
 }
+/* right rail: process graph + citations */
+.ask-rail {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-width: 0;
+}
+.ask-process-card {
+  overflow: hidden;
+}
+.ask-process-help {
+  margin: 0 0 0.5rem;
+  line-height: 1.4;
+}
+.ask-process {
+  min-height: 4rem;
+}
+.ask-process.empty {
+  padding: 0.2rem 0 0;
+}
+.ask-process-empty-msg {
+  margin: 0;
+  padding: 1.25rem 0.75rem;
+  text-align: center;
+  line-height: 1.45;
+}
+.ask-process-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem 0.85rem;
+  margin-bottom: 0.35rem;
+  align-items: center;
+}
+.ask-process-legend > span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+.ask-process-swatch {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex: none;
+}
+.ask-process-swatch.claim {
+  background: var(--c-3);
+}
+.ask-process-swatch.source {
+  background: var(--c-1);
+}
+.ask-process-swatch.card {
+  background: var(--c-2);
+}
+.ask-process-canvas {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: var(--ovp-radius-md);
+  background: var(--graph-bg, var(--surface-2));
+  overflow: hidden;
+}
 /* citations panel (right rail) */
 .cite-entry {
   border: 1px solid var(--border);
@@ -1778,7 +1839,15 @@ body {
   font-weight: 600;
   line-height: 1.35;
   overflow-wrap: anywhere;
-  margin-bottom: 0.25rem;
+  margin-bottom: 0.15rem;
+}
+.cite-id {
+  margin-bottom: 0.3rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+  opacity: 0.75;
 }
 .cite-entry blockquote {
   margin: 0 0 0.35rem;

--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -341,6 +341,14 @@ export const en = {
   'ask.citationsTitle': 'Citations',
   'ask.citationsEmpty':
     'Citations for the latest answer land here — hover a [1] marker in the answer to highlight its evidence.',
+  'ask.processTitle': 'Process',
+  'ask.processHelp':
+    'Entities the agent touched while searching — claims, sources, and memory cards grow into the graph live.',
+  'ask.processEmpty':
+    'Nodes appear here as the agent searches claims, sources, and evidence.',
+  'ask.processClaims': '{n} claims',
+  'ask.processSources': '{n} sources',
+  'ask.processMemory': '{n} memory',
   'ask.unverified': 'unverified',
   'ask.openCitation': 'Open',
   'ask.noLink': 'No detail page in this vault.',

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -315,6 +315,13 @@ export const zh: Record<keyof typeof en, string> = {
   'ask.chatLoadError': '无法加载该会话——服务是否在运行？',
   'ask.chatParseEmpty': '该会话没有可解析的问答内容——文件可能损坏或为空。',
   'ask.citationsTitle': '引用',
+  'ask.processTitle': '过程图',
+  'ask.processHelp':
+    '检索过程中涉及的结论、来源与记忆卡片会实时汇入此图，便于解释答案从何而来。',
+  'ask.processEmpty': '开始检索后，这里会逐步出现涉及的结论、来源与记忆节点。',
+  'ask.processClaims': '{n} 条结论',
+  'ask.processSources': '{n} 个来源',
+  'ask.processMemory': '{n} 条记忆',
   'ask.citationsEmpty':
     '最新回答的引用会显示在这里——悬停回答中的 [1] 标记可高亮对应证据。',
   'ask.unverified': '未核实',

--- a/console-ui/src/lib/types.ts
+++ b/console-ui/src/lib/types.ts
@@ -270,6 +270,14 @@ export interface AskResponse {
   usage?: { input_tokens: number; output_tokens: number };
 }
 
+/** Compact involved-entity node from a tool result (process graph). */
+export interface AskProgressHit {
+  kind: string;
+  id: string;
+  label: string;
+  source_id?: string | null;
+}
+
 /** One executed tool call in an agent turn's caller-facing trail. */
 export interface AskTraceEntry {
   tool: string;
@@ -279,6 +287,8 @@ export interface AskTraceEntry {
   args?: string | null;
   /** Parsed result stats ("3 hit(s) · scanned 918/1281 · truncated"). */
   note?: string | null;
+  /** Involved entities for process visualization (claims/sources/cards). */
+  hits?: AskProgressHit[];
 }
 
 /** One event from GET /api/ask/progress — the live mid-turn feed. */
@@ -291,6 +301,8 @@ export interface AskProgressEvent {
   summary?: string;
   /** Parsed result stats for tool_finished events. */
   note?: string | null;
+  /** Involved entities painted into the live process graph. */
+  hits?: AskProgressHit[];
   ok?: boolean;
   turn_id?: string;
   stopped_reason?: string;

--- a/console-ui/src/pages/AskPage.tsx
+++ b/console-ui/src/pages/AskPage.tsx
@@ -11,6 +11,7 @@
  * handler leaves it alone while composing. */
 import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
+import AskProcessGraph from '../components/AskProcessGraph';
 import { EmptyState, PageHelp, conceptTipKey } from '../components/ui';
 import { useI18n, type MsgKey } from '../i18n';
 import {
@@ -68,6 +69,24 @@ function errorKeyFor(err: unknown): MsgKey {
   return 'ask.errGeneric';
 }
 
+/** Human title the model wrote after a bare id — `[source:<sha> Some Title]`. */
+function decoratedTitle(rest: string): string | null {
+  const parts = rest.trim().split(/\s+/);
+  if (parts.length < 2) return null;
+  const title = parts
+    .slice(1)
+    .join(' ')
+    .replace(/^[<>|]+|[<>|]+$/g, '')
+    .trim();
+  return title || null;
+}
+
+/** Short operator-facing fallback when only a hash is known. */
+function shortSourceLabel(token: string): string {
+  const short = token.slice(0, 12);
+  return short.length < token.length ? `source ${short}…` : `source ${token}`;
+}
+
 /** Build citation chips from answer text alone (saved-chat replay). */
 function citationsFromAnswerText(answer: string): AskCitation[] {
   return citationsInOrder(answer).map((id) => {
@@ -79,10 +98,13 @@ function citationsFromAnswerText(answer: string): AskCitation[] {
     const rest = kind ? id.slice(id.indexOf(':') + 1) : id;
     const token = (rest.trim().split(/\s+/)[0] ?? '').replace(/^<|>$/g, '');
     const canonical = kind ? `${kind}:${token}` : token;
+    const title =
+      decoratedTitle(rest) ??
+      (kind === 'source' ? shortSourceLabel(token) : canonical);
     return {
-      id,
+      id: canonical,
       kind,
-      title: canonical,
+      title,
       snippet: null,
       link_target: citeLinkTarget(canonical),
       // Saved transcript does not re-run the verifier — verification state
@@ -91,6 +113,16 @@ function citationsFromAnswerText(answer: string): AskCitation[] {
       verified: null,
     };
   });
+}
+
+/** Primary line for a citation panel entry — never a bare 64-char hash. */
+function citationTitle(c: AskCitation): string {
+  if (c.title && c.title.trim() && c.title !== c.id) return c.title;
+  if (c.kind === 'source' || c.id.startsWith('source:')) {
+    const token = c.id.includes(':') ? c.id.slice(c.id.indexOf(':') + 1) : c.id;
+    return shortSourceLabel(token.split(/\s+/)[0] ?? token);
+  }
+  return c.title ?? c.id;
 }
 
 // ---- agent live trail + receipts (A3c) ----
@@ -279,6 +311,17 @@ function AgentMeta({ response }: { response: AskResponse }) {
   );
 }
 
+/** Stable `kind:token` key for marker ↔ panel matching. Strips model
+ * decoration (`[source:<sha> Title]`) so the answer token and the receipt
+ * id always land on the same map entry. */
+function citationLookupKey(id: string): string {
+  const norm = normalizeCiteToken(id);
+  const kind = norm.includes(':') ? norm.slice(0, norm.indexOf(':')) : '';
+  const rest = kind ? norm.slice(norm.indexOf(':') + 1) : norm;
+  const token = (rest.trim().split(/\s+/)[0] ?? '').replace(/^<|>$/g, '');
+  return kind ? `${kind}:${token}` : token;
+}
+
 /** Answer body rendered as markdown with numbered citation markers. */
 function AnswerText({
   answer,
@@ -291,11 +334,11 @@ function AnswerText({
   onHover: (id: string | null) => void;
   onOpen: (cit: AskCitation) => void;
 }) {
-  const index = new Map(citations.map((c, i) => [c.id, i]));
+  const index = new Map(citations.map((c, i) => [citationLookupKey(c.id), i]));
   const marker: InlineMarker = {
     pattern: CITE_RE,
     render: (m, key) => {
-      const i = index.get(normalizeCiteToken(m[1]));
+      const i = index.get(citationLookupKey(m[1]));
       if (i === undefined) return null;
       const cit = citations[i];
       return (
@@ -308,7 +351,7 @@ function AnswerText({
           onFocus={() => onHover(cit.id)}
           onBlur={() => onHover(null)}
           onClick={() => onOpen(cit)}
-          title={cit.title ?? cit.id}
+          title={citationTitle(cit)}
         >
           [{i + 1}]
         </button>
@@ -343,10 +386,13 @@ function CitationPanel({
     <div>
       {citations.map((c, i) => {
         const kindTip = conceptTipKey(c.kind);
+        const hit =
+          hoverId != null &&
+          citationLookupKey(hoverId) === citationLookupKey(c.id);
         return (
           <div
             key={c.id}
-            className={`cite-entry${hoverId === c.id ? ' hover-hit' : ''}`}
+            className={`cite-entry${hit ? ' hover-hit' : ''}`}
           >
             <div className="cite-entry-top">
               <span className="cite-num mono">[{i + 1}]</span>
@@ -357,7 +403,12 @@ function CitationPanel({
                 <span className="pill unverified">{t('ask.unverified')}</span>
               )}
             </div>
-            <div className="cite-title">{c.title ?? c.id}</div>
+            <div className="cite-title">{citationTitle(c)}</div>
+            {c.id && citationTitle(c) !== c.id && (
+              <div className="cite-id mono tiny muted" title={c.id}>
+                {c.id}
+              </div>
+            )}
             {c.snippet && <blockquote>“{c.snippet}”</blockquote>}
             {c.link_target ? (
               <button
@@ -749,7 +800,21 @@ export default function AskPage() {
 
   const displayTurns = openChat ? (savedTurns ?? []) : turns;
   const latest = [...displayTurns].reverse().find((turn) => turn.response);
+  // Failed mid-flight turns keep a progress snapshot but no response —
+  // still surface their process graph in the rail.
+  const latestAny = [...displayTurns].reverse().find(
+    (turn) => turn.response || (turn.progress && turn.progress.length > 0),
+  );
   const citations = latest?.response?.citations ?? [];
+  // Live turn: only current progress events (never a prior turn's trail).
+  // Settled turn: tool_trace + citations (and error progress if any).
+  const processEvents = pending
+    ? live?.events
+    : latestAny?.progress;
+  const processTrace = pending
+    ? undefined
+    : latestAny?.response?.tool_trace;
+  const processCitations = pending ? [] : citations;
   const examples: MsgKey[] = ['ask.example1', 'ask.example2', 'ask.example3'];
   const viewingSaved = Boolean(openChat);
 
@@ -896,8 +961,19 @@ export default function AskPage() {
           )}
         </div>
 
-        {/* right rail: citations for the latest answer (live or saved) */}
-        <div>
+        {/* right rail: process graph + citations for the latest answer */}
+        <div className="ask-rail">
+          <div className="card ask-process-card">
+            <h3 style={{ marginBottom: '0.4rem' }}>{t('ask.processTitle')}</h3>
+            <p className="tiny muted ask-process-help">{t('ask.processHelp')}</p>
+            <AskProcessGraph
+              events={processEvents}
+              toolTrace={processTrace}
+              citations={processCitations}
+              hoverId={hoverId}
+              height={220}
+            />
+          </div>
           <div className="card">
             <h3 style={{ marginBottom: '0.6rem' }}>{t('ask.citationsTitle')}</h3>
             <CitationPanel

--- a/crates/ovp-mcp/src/lib.rs
+++ b/crates/ovp-mcp/src/lib.rs
@@ -484,7 +484,7 @@ fn tool_ask(state: &McpState, args: &Value) -> Result<Value, RpcError> {
         let trail = store.tool_trail_for_turn(&done.turn_id);
         if !trail.is_empty() {
             text.push_str("\nagent trail:");
-            for (tool, _id, is_error, _summary, arguments, note) in trail {
+            for (tool, _id, is_error, _summary, arguments, note, _hits) in trail {
                 let mark = if is_error { "✗" } else { "✓" };
                 let args = match ovp_memory::receipts::args_brief(&arguments) {
                     Value::String(s) => format!(" {s}"),

--- a/crates/ovp-memory/src/agent.rs
+++ b/crates/ovp-memory/src/agent.rs
@@ -89,6 +89,9 @@ pub struct ToolTraceEntry {
     /// Compact stats parsed from the FULL result ("3 hits · scanned 918/1281 ·
     /// truncated") — the trail must support post-hoc 复盘, not just names.
     pub result_note: Option<String>,
+    /// Involved entities from this call (process graph). Empty on errors /
+    /// late-discarded results.
+    pub hits: Vec<ProgressHit>,
 }
 
 /// Generic result introspection for the trail: hits/scanned/truncated are the
@@ -115,6 +118,130 @@ pub fn tool_result_note(content: &str) -> Option<String> {
     } else {
         Some(parts.join(" · "))
     }
+}
+
+/// One involved vault entity surfaced mid-turn for process visualization
+/// (KMEM live-preview pattern: memory / source / claim nodes the agent
+/// actually touched). Labels are operator-facing; ids are stable for
+/// graph node identity and deep links.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProgressHit {
+    pub kind: String,
+    pub id: String,
+    pub label: String,
+    pub source_id: Option<String>,
+}
+
+/// Compact involved-entity list from a tool result — drives the live ask
+/// process graph. Cap is intentional (UI graph stays scannable; full hits
+/// still reach the model via the tool result itself).
+const MAX_PROGRESS_HITS: usize = 12;
+
+pub fn tool_result_hits(content: &str) -> Vec<ProgressHit> {
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(content) else {
+        return Vec::new();
+    };
+    let Some(hits) = v.get("hits").and_then(|h| h.as_array()) else {
+        // Single-entity reads (get_claim / get_source / …) may return an
+        // object without a hits array — still surface them as one node.
+        return single_entity_hit(&v).into_iter().collect();
+    };
+    let mut out = Vec::new();
+    for hit in hits {
+        if out.len() >= MAX_PROGRESS_HITS {
+            break;
+        }
+        if let Some(n) = hit_to_progress(hit) {
+            out.push(n);
+        }
+    }
+    out
+}
+
+fn single_entity_hit(v: &serde_json::Value) -> Option<ProgressHit> {
+    hit_to_progress(v)
+}
+
+fn clip_label(s: &str, max: usize) -> String {
+    let t = s.trim();
+    if t.chars().count() <= max {
+        t.to_string()
+    } else {
+        t.chars().take(max.saturating_sub(1)).collect::<String>() + "…"
+    }
+}
+
+fn hit_to_progress(hit: &serde_json::Value) -> Option<ProgressHit> {
+    // Claims (search_claims / get_claim)
+    if let Some(key) = hit
+        .get("claim_key")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+    {
+        let claim = hit
+            .get("claim")
+            .and_then(|v| v.as_str())
+            .unwrap_or(key);
+        let source_id = hit
+            .get("source_ids")
+            .and_then(|v| v.as_array())
+            .and_then(|a| a.first())
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        return Some(ProgressHit {
+            kind: "claim".into(),
+            id: key.to_string(),
+            label: clip_label(claim, 80),
+            source_id,
+        });
+    }
+    // Sources (search_sources / fulltext / chunks)
+    if let Some(sid) = hit
+        .get("source_id")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+    {
+        // Evidence packs also carry source_id — prefer memory/card when a
+        // pack title or matched cards are present.
+        if let Some(pack) = hit.get("pack_title").and_then(|v| v.as_str()) {
+            let card = hit
+                .get("matched_cards")
+                .and_then(|v| v.as_array())
+                .and_then(|a| a.first())
+                .and_then(|v| v.as_str());
+            let label = card.unwrap_or(pack);
+            return Some(ProgressHit {
+                kind: "card".into(),
+                id: format!("card:{sid}:{}", clip_label(label, 40)),
+                label: clip_label(label, 80),
+                source_id: Some(sid.to_string()),
+            });
+        }
+        let title = hit
+            .get("title")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty() && *s != "(untitled)")
+            .or_else(|| hit.get("rel_path").and_then(|v| v.as_str()))
+            .unwrap_or(sid);
+        return Some(ProgressHit {
+            kind: "source".into(),
+            id: sid.to_string(),
+            label: clip_label(title, 80),
+            source_id: Some(sid.to_string()),
+        });
+    }
+    // Cards without source_id (rare)
+    if let Some(title) = hit.get("title").and_then(|v| v.as_str()) {
+        if hit.get("content").is_some() || hit.get("matched_cards").is_some() {
+            return Some(ProgressHit {
+                kind: "card".into(),
+                id: format!("card:{}", clip_label(title, 40)),
+                label: clip_label(title, 80),
+                source_id: None,
+            });
+        }
+    }
+    None
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -194,12 +321,14 @@ pub enum AgentProgress {
     /// `summary` mirrors the caller-facing `ToolTraceEntry` summary: capped,
     /// and the discard marker (never content) for late results. `note` is the
     /// parsed result-stats line ("3 hit(s) · scanned 918/1281 · truncated").
+    /// `hits` is a compact involved-entity list for process visualization.
     ToolFinished {
         tool_call_id: String,
         tool: String,
         is_error: bool,
         summary: String,
         note: Option<String>,
+        hits: Vec<ProgressHit>,
     },
     Finished { turn_id: String, stopped_reason: StoppedReason },
 }
@@ -557,15 +686,19 @@ pub fn run_agent_turn_with_progress(
             } else {
                 content.chars().take(120).collect()
             };
-            trace.push(ToolTraceEntry {
-                tool: name.clone(),
-                tool_call_id: id.clone(),
-                is_error: is_error || finished_late,
-                summary: trail_summary.clone(),
-                arguments: input.clone(),
-                // Late data stays discarded — no stats leak either.
-                result_note: if finished_late { None } else { tool_result_note(&content) },
-            });
+            // Stats from the full raw body (before model-facing truncation).
+            let result_note = if finished_late {
+                None
+            } else {
+                tool_result_note(&content)
+            };
+            // Process-viz hits from the raw body too (same hit set the model
+            // saw, minus late discards). Cap is enforced inside extraction.
+            let hits = if is_error || finished_late {
+                Vec::new()
+            } else {
+                tool_result_hits(&content)
+            };
             let (model_content, model_is_error) = if finished_late {
                 timed_out = true;
                 (
@@ -589,12 +722,22 @@ pub fn run_agent_turn_with_progress(
                 }
                 (content, is_error)
             };
+            trace.push(ToolTraceEntry {
+                tool: name.clone(),
+                tool_call_id: id.clone(),
+                is_error: is_error || finished_late,
+                summary: trail_summary.clone(),
+                arguments: input.clone(),
+                result_note: result_note.clone(),
+                hits: hits.clone(),
+            });
             emit(AgentProgress::ToolFinished {
                 tool_call_id: id.clone(),
                 tool: name.clone(),
                 is_error: model_is_error,
                 summary: trail_summary,
-                note: trace.last().and_then(|t| t.result_note.clone()),
+                note: result_note,
+                hits,
             });
             results.push(ToolResultBlock {
                 tool_call_id: id.clone(),
@@ -681,15 +824,32 @@ fn replayed_trace(store: &SessionStore, turn_id: &str) -> Vec<ToolTraceEntry> {
         .tool_trail_for_turn(turn_id)
         .into_iter()
         .map(
-            |(tool, tool_call_id, is_error, summary, arguments, result_note)| ToolTraceEntry {
-                tool,
-                tool_call_id,
-                is_error,
-                summary,
-                arguments,
-                result_note,
+            |(tool, tool_call_id, is_error, summary, arguments, result_note, hits)| {
+                ToolTraceEntry {
+                    tool,
+                    tool_call_id,
+                    is_error,
+                    summary,
+                    arguments,
+                    result_note,
+                    hits,
+                }
             },
         )
+        .collect()
+}
+
+/// Serialize process-viz hits for HTTP progress/tool_trace payloads.
+pub fn progress_hits_json(hits: &[ProgressHit]) -> Vec<serde_json::Value> {
+    hits.iter()
+        .map(|h| {
+            serde_json::json!({
+                "kind": h.kind,
+                "id": h.id,
+                "label": h.label,
+                "source_id": h.source_id,
+            })
+        })
         .collect()
 }
 
@@ -1665,6 +1825,31 @@ mod tests {
             AgentProgress::Finished { stopped_reason: StoppedReason::Final, .. }
         ));
         assert_eq!(out.stopped_reason, StoppedReason::Final);
+    }
+
+    #[test]
+    fn tool_result_hits_extract_claim_source_and_card() {
+        let claims = r#"{"hits":[{"claim_key":"ck-abc","claim":"Governed forgetting is necessary.","source_ids":["sha1"]}]}"#;
+        let h = tool_result_hits(claims);
+        assert_eq!(h.len(), 1);
+        assert_eq!(h[0].kind, "claim");
+        assert_eq!(h[0].id, "ck-abc");
+        assert!(h[0].label.contains("forgetting"));
+        assert_eq!(h[0].source_id.as_deref(), Some("sha1"));
+
+        let sources = r#"{"hits":[{"source_id":"deadbeef","title":"Agent Memory Systems"}]}"#;
+        let h = tool_result_hits(sources);
+        assert_eq!(h[0].kind, "source");
+        assert_eq!(h[0].label, "Agent Memory Systems");
+
+        let evidence = r#"{"hits":[{"pack_title":"Pack","matched_cards":["Memory as state"],"source_id":"s2"}]}"#;
+        let h = tool_result_hits(evidence);
+        assert_eq!(h[0].kind, "card");
+        assert_eq!(h[0].label, "Memory as state");
+        assert_eq!(h[0].source_id.as_deref(), Some("s2"));
+
+        assert!(tool_result_hits("not-json").is_empty());
+        assert!(tool_result_hits(r#"{"ok":true}"#).is_empty());
     }
 
     // An empty/unstamped lock file is conservatively BUSY — a racing creator

--- a/crates/ovp-memory/src/agent_transcript.rs
+++ b/crates/ovp-memory/src/agent_transcript.rs
@@ -547,7 +547,15 @@ impl SessionStore {
     pub fn tool_trail_for_turn(
         &self,
         id: &str,
-    ) -> Vec<(String, String, bool, String, serde_json::Value, Option<String>)> {
+    ) -> Vec<(
+        String,
+        String,
+        bool,
+        String,
+        serde_json::Value,
+        Option<String>,
+        Vec<crate::agent::ProgressHit>,
+    )> {
         let mut args_by_call: std::collections::HashMap<&str, &serde_json::Value> =
             std::collections::HashMap::new();
         for e in &self.events {
@@ -584,6 +592,14 @@ impl SessionStore {
                         .cloned()
                         .unwrap_or(serde_json::Value::Null),
                     if *late { None } else { crate::agent::tool_result_note(content) },
+                    // Rebuild process-viz hits from the durable audit body
+                    // so History/session replay keeps the same graph the
+                    // live turn painted.
+                    if *late || *is_error {
+                        Vec::new()
+                    } else {
+                        crate::agent::tool_result_hits(content)
+                    },
                 )),
                 _ => None,
             })

--- a/crates/ovp-memory/src/receipts.rs
+++ b/crates/ovp-memory/src/receipts.rs
@@ -19,6 +19,69 @@ pub fn citation_id_token(id: &str) -> &str {
         .trim_matches(|c| c == '<' || c == '>')
 }
 
+/// Human label the model wrote after a bare id — `[source:<sha> Some Title]`.
+/// Empty when the marker carried only the id (or angle brackets around it).
+fn decorated_citation_title(rest: &str) -> Option<String> {
+    let mut parts = rest.split_whitespace();
+    let _id = parts.next()?;
+    let title: String = parts.collect::<Vec<_>>().join(" ");
+    let title = title
+        .trim()
+        .trim_matches(|c| c == '<' || c == '>' || c == '|')
+        .trim();
+    if title.is_empty() {
+        None
+    } else {
+        Some(title.chars().take(120).collect())
+    }
+}
+
+/// Operator-facing source label: prefer a real title, then path basename,
+/// then a short host/url, never a raw 64-char sha as the primary line.
+pub fn source_display_title(source: &ovp_index::SourceRow) -> String {
+    if let Some(title) = source
+        .title
+        .as_deref()
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+    {
+        return title.chars().take(120).collect();
+    }
+    if let Some(path) = source.rel_path.as_deref() {
+        let base = path.rsplit(['/', '\\']).next().unwrap_or(path);
+        let base = base.trim();
+        if !base.is_empty() {
+            return base.chars().take(120).collect();
+        }
+    }
+    if let Some(url) = source.url.as_deref().map(str::trim).filter(|u| !u.is_empty()) {
+        // host/path fragment is more scannable than a full tracking URL.
+        let host = url
+            .trim_start_matches("https://")
+            .trim_start_matches("http://")
+            .split(['?', '#'])
+            .next()
+            .unwrap_or(url);
+        if !host.is_empty() {
+            return host.chars().take(120).collect();
+        }
+    }
+    // Last resort: short id — still better than dumping the full hash as the
+    // only visible text in the citations rail.
+    let short = source.sha256.chars().take(12).collect::<String>();
+    format!("source {short}…")
+}
+
+/// Canonical citation id for markers/UI matching (`source:<sha>`, not the
+/// decorated form). The raw answer key stays available via decorated titles.
+fn citation_stable_id(kind: &str, token: &str) -> String {
+    if kind.is_empty() {
+        token.to_string()
+    } else {
+        format!("{kind}:{token}")
+    }
+}
+
 pub fn agent_citations(
     answer: &str,
     model: &IndexModel,
@@ -27,8 +90,10 @@ pub fn agent_citations(
     citations_in_order(answer)
         .into_iter()
         .map(|key| {
-            let (kind, id) = key.split_once(':').unwrap_or(("", key.as_str()));
-            let id = citation_id_token(id);
+            let (kind, rest) = key.split_once(':').unwrap_or(("", key.as_str()));
+            let id = citation_id_token(rest);
+            let stable_id = citation_stable_id(kind, id);
+            let decorated = decorated_citation_title(rest);
             match kind {
                 "claim" => {
                     let hit = records.iter().find(|r| r.claim_key == id);
@@ -41,28 +106,38 @@ pub fn agent_citations(
                             records.iter().filter(|o| o.claim_id == r.claim_id).count();
                         (same_id == 1).then(|| format!("/knowledge#{}", r.claim_id))
                     });
+                    let title = hit
+                        .map(|r| r.claim.chars().take(120).collect::<String>())
+                        .or(decorated);
                     serde_json::json!({
-                        "id": key,
+                        "id": stable_id,
                         "kind": "claim",
-                        "title": hit.map(|r| r.claim.chars().take(120).collect::<String>()),
+                        "title": title,
                         "link_target": link,
                         "verified": hit.is_some(),
                     })
                 }
                 "source" => {
                     let hit = model.sources.iter().find(|s| s.sha256 == id);
+                    let title = hit
+                        .map(source_display_title)
+                        .or(decorated)
+                        .or_else(|| {
+                            let short = id.chars().take(12).collect::<String>();
+                            Some(format!("source {short}…"))
+                        });
                     serde_json::json!({
-                        "id": key,
+                        "id": stable_id,
                         "kind": "source",
-                        "title": hit.and_then(|s| s.title.clone()),
+                        "title": title,
                         "link_target": hit.map(|s| format!("/library/{}", s.sha256)),
                         "verified": hit.is_some(),
                     })
                 }
                 _ => serde_json::json!({
-                    "id": key,
+                    "id": stable_id,
                     "kind": kind,
-                    "title": serde_json::Value::Null,
+                    "title": decorated,
                     "link_target": serde_json::Value::Null,
                     "verified": false,
                 }),
@@ -73,7 +148,8 @@ pub fn agent_citations(
 
 /// [`agent_citations`] without an index snapshot (fresh/unindexed vault):
 /// claim receipts still resolve against the ledger; source references cannot
-/// be verified and honestly say so.
+/// be verified and honestly say so. Decorated marker titles still surface so
+/// the UI is not stuck showing only a hash.
 pub fn agent_citations_unindexed(
     answer: &str,
     records: &[DurableRecord],
@@ -81,26 +157,45 @@ pub fn agent_citations_unindexed(
     citations_in_order(answer)
         .into_iter()
         .map(|key| {
-            let (kind, id) = key.split_once(':').unwrap_or(("", key.as_str()));
-            let id = citation_id_token(id);
+            let (kind, rest) = key.split_once(':').unwrap_or(("", key.as_str()));
+            let id = citation_id_token(rest);
+            let stable_id = citation_stable_id(kind, id);
+            let decorated = decorated_citation_title(rest);
             if kind == "claim" {
                 let hit = records.iter().find(|r| r.claim_key == id);
                 let link = hit.and_then(|r| {
                     let same_id = records.iter().filter(|o| o.claim_id == r.claim_id).count();
                     (same_id == 1).then(|| format!("/knowledge#{}", r.claim_id))
                 });
+                let title = hit
+                    .map(|r| r.claim.chars().take(120).collect::<String>())
+                    .or(decorated);
                 serde_json::json!({
-                    "id": key,
+                    "id": stable_id,
                     "kind": "claim",
-                    "title": hit.map(|r| r.claim.chars().take(120).collect::<String>()),
+                    "title": title,
                     "link_target": link,
                     "verified": hit.is_some(),
                 })
+            } else if kind == "source" {
+                // No index → cannot verify or deep-link; still prefer any
+                // model-decorated title over dumping the raw sha.
+                let title = decorated.or_else(|| {
+                    let short = id.chars().take(12).collect::<String>();
+                    Some(format!("source {short}…"))
+                });
+                serde_json::json!({
+                    "id": stable_id,
+                    "kind": "source",
+                    "title": title,
+                    "link_target": serde_json::Value::Null,
+                    "verified": false,
+                })
             } else {
                 serde_json::json!({
-                    "id": key,
+                    "id": stable_id,
                     "kind": kind,
-                    "title": serde_json::Value::Null,
+                    "title": decorated,
                     "link_target": serde_json::Value::Null,
                     "verified": false,
                 })

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -2384,10 +2384,11 @@ fn handle_ask_agent(
                 let trace: Vec<serde_json::Value> = store
                     .tool_trail_for_turn(&done.turn_id)
                     .into_iter()
-                    .map(|(tool, _id, is_error, summary, arguments, note)| {
+                    .map(|(tool, _id, is_error, summary, arguments, note, hits)| {
                         serde_json::json!({
                             "tool": tool, "summary": summary, "ok": !is_error,
                             "args": args_brief(&arguments), "note": note,
+                            "hits": ovp_memory::agent::progress_hits_json(&hits),
                         })
                     })
                     .collect();
@@ -2494,11 +2495,21 @@ fn handle_ask_agent(
                             "args": args_brief(arguments),
                         })
                     }
-                    AgentProgress::ToolFinished { tool_call_id, tool, is_error, summary, note } => {
+                    AgentProgress::ToolFinished {
+                        tool_call_id,
+                        tool,
+                        is_error,
+                        summary,
+                        note,
+                        hits,
+                    } => {
+                        // Compact involved-entity nodes for the live process
+                        // graph (KMEM-style explainability during search).
                         serde_json::json!({
                             "event": "tool_finished", "tool": tool,
                             "tool_call_id": tool_call_id, "ok": !is_error,
                             "summary": summary, "note": note,
+                            "hits": ovp_memory::agent::progress_hits_json(hits),
                         })
                     }
                     // The advertised terminal protocol is final | error: a
@@ -2592,6 +2603,7 @@ fn handle_ask_agent(
                         // post-answer trail must not degrade to bare names.
                         "args": args_brief(&t.arguments),
                         "note": t.result_note,
+                        "hits": ovp_memory::agent::progress_hits_json(&t.hits),
                     })
                 })
                 .collect();
@@ -2739,10 +2751,11 @@ fn handle_ask_session(state: &AppState, path: &str) -> Response<std::io::Cursor<
             let trail: Vec<serde_json::Value> = store
                 .tool_trail_for_turn(&turn_id)
                 .into_iter()
-                .map(|(tool, _id, is_error, summary, arguments, note)| {
+                .map(|(tool, _id, is_error, summary, arguments, note, hits)| {
                     serde_json::json!({
                         "tool": tool, "ok": !is_error, "summary": summary,
                         "args": args_brief(&arguments), "note": note,
+                        "hits": ovp_memory::agent::progress_hits_json(&hits),
                     })
                 })
                 .collect();
@@ -5237,6 +5250,14 @@ mod tests {
         );
         assert_eq!(decorated[0]["verified"], true, "title-decorated sha resolves");
         assert_eq!(decorated[0]["link_target"], "/library/aaaa1111");
+        assert_eq!(decorated[0]["id"], "source:aaaa1111", "stable bare id for UI match");
+        // Prefer index title; when missing, fall back to the model decoration
+        // so the citations rail never shows only a raw hash.
+        let title0 = decorated[0]["title"].as_str().unwrap_or("");
+        assert!(
+            !title0.is_empty() && !title0.starts_with("source:aaaa"),
+            "operator-facing title, got {title0:?}"
+        );
         assert_eq!(decorated[1]["verified"], true, "angle-bracketed sha resolves");
         assert_eq!(decorated[2]["verified"], true, "decorated claim key resolves");
         assert_eq!(decorated[3]["verified"], false, "placeholder still fails");


### PR DESCRIPTION
## Summary
- **Citations rail**: resolve operator-facing titles (index title → path basename → URL host → model decoration → short id) so source citations no longer show only a 64-char hash.
- **Process graph**: emit compact tool-result hits on progress + tool_trace; render a KMEM-style live force graph of claims / sources / memory cards during Ask and when replaying History.
- **History empty-canvas fix**: keep the canvas wrapper mounted so ResizeObserver measures width after async session load (legend had “53 sources / 33 memory” but ForceGraph never mounted).

## Test plan
- [x] `cargo test -p ovp-memory --lib -- agent::`
- [x] `cargo test -p ovp-server --lib agent_citations`
- [x] `cd console-ui && npm test && npm run build`
- [x] Live session `web-ms2k9ey9-ggldak` returns 75 hits (53 sources + 33 cards) via `/api/ask/session`
- [ ] Open latest History on Ask — Process graph paints (not legend-only)
- [ ] Citation panel shows article titles with mono id secondary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a live process graph to Ask pages, visualizing claims, sources, and memory cards as they are discovered.
  * Added graph counters, legends, hover highlighting, zooming, panning, and node interactions.
  * Process graphs now remain available for replayed and failed turns when progress data exists.
  * Improved citation display with clearer titles, stable matching, and readable identifiers.
  * Added English and Simplified Chinese translations for process graph content.

* **Tests**
  * Added coverage for live, cited, and replayed process graph construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->