### PR TITLE
chore: drop competitor references from ask process-graph comments

### DIFF
--- a/console-ui/src/components/AskProcessGraph.tsx
+++ b/console-ui/src/components/AskProcessGraph.tsx
@@ -1,4 +1,4 @@
-/** Live process graph for Ask — KMEM-style explainability during search.
+/** Live process graph for Ask.
  *
  * As the agent touches claims / sources / memory cards, nodes accumulate
  * into a small force graph so the operator sees *what* entered the answer

--- a/crates/ovp-memory/src/agent.rs
+++ b/crates/ovp-memory/src/agent.rs
@@ -121,9 +121,8 @@ pub fn tool_result_note(content: &str) -> Option<String> {
 }
 
 /// One involved vault entity surfaced mid-turn for process visualization
-/// (KMEM live-preview pattern: memory / source / claim nodes the agent
-/// actually touched). Labels are operator-facing; ids are stable for
-/// graph node identity and deep links.
+/// (memory / source / claim nodes the agent actually touched). Labels are
+/// operator-facing; ids are stable for graph node identity and deep links.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProgressHit {
     pub kind: String,

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -2504,7 +2504,7 @@ fn handle_ask_agent(
                         hits,
                     } => {
                         // Compact involved-entity nodes for the live process
-                        // graph (KMEM-style explainability during search).
+                        // graph during search.
                         serde_json::json!({
                             "event": "tool_finished", "tool": tool,
                             "tool_call_id": tool_call_id, "ok": !is_error,


### PR DESCRIPTION
## Summary
- Scrub competitor/product-comparison phrasing from ask process-graph comments shipped in #380.
- Comments now describe OVP behavior only.

## Test plan
- [x] Comment-only change; no behavior change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal comments and labels related to search progress and the live process graph.
  * Clarified operator-facing descriptions without changing functionality or runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->