### PR TITLE
feat(portal): calendar day browser on Today

### DIFF
--- a/console-ui/src/components/DayCalendar.tsx
+++ b/console-ui/src/components/DayCalendar.tsx
@@ -1,0 +1,149 @@
+/** Month calendar for the Today page day-browser.
+ *
+ * Pure presentational: parent owns selected day + month cursor. Days with
+ * vault activity render a heat mark so past runs are scannable at a glance.
+ */
+import { useMemo } from 'react';
+import { useI18n } from '../i18n';
+import { isIsoDay, monthStart } from '../lib/derive';
+
+const WEEKDAYS_EN = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+const WEEKDAYS_ZH = ['一', '二', '三', '四', '五', '六', '日'];
+
+export interface DayCalendarProps {
+  /** Currently selected day (YYYY-MM-DD). */
+  selected: string;
+  /** Month being browsed (YYYY-MM-01 or any day in that month). */
+  monthCursor: string;
+  /** Heat 0–3 per ISO day. */
+  heat: Map<string, 0 | 1 | 2 | 3>;
+  /** Projection "today" — highlighted as the build day. */
+  projectionDay: string;
+  onSelect: (day: string) => void;
+  onMonthChange: (monthCursor: string) => void;
+}
+
+function daysInMonth(year: number, month0: number): number {
+  return new Date(Date.UTC(year, month0 + 1, 0)).getUTCDate();
+}
+
+/** Monday=0 … Sunday=6 for a UTC calendar day. */
+function mondayIndex(year: number, month0: number, day: number): number {
+  const dow = new Date(Date.UTC(year, month0, day)).getUTCDay(); // 0=Sun
+  return (dow + 6) % 7;
+}
+
+export default function DayCalendar({
+  selected,
+  monthCursor,
+  heat,
+  projectionDay,
+  onSelect,
+  onMonthChange,
+}: DayCalendarProps) {
+  const { t, lang } = useI18n();
+  const weekdays = lang === 'zh' ? WEEKDAYS_ZH : WEEKDAYS_EN;
+
+  const { year, month0, cells, label } = useMemo(() => {
+    const base = isIsoDay(monthCursor) ? monthCursor : monthStart(selected);
+    const y = Number(base.slice(0, 4));
+    const m0 = Number(base.slice(5, 7)) - 1;
+    const dim = daysInMonth(y, m0);
+    const lead = mondayIndex(y, m0, 1);
+    const cells: Array<{ day: string | null; n: number | null }> = [];
+    for (let i = 0; i < lead; i += 1) cells.push({ day: null, n: null });
+    for (let d = 1; d <= dim; d += 1) {
+      const dd = String(d).padStart(2, '0');
+      const mm = String(m0 + 1).padStart(2, '0');
+      cells.push({ day: `${y}-${mm}-${dd}`, n: d });
+    }
+    while (cells.length % 7 !== 0) cells.push({ day: null, n: null });
+    const label =
+      lang === 'zh'
+        ? `${y}年${m0 + 1}月`
+        : new Date(Date.UTC(y, m0, 1)).toLocaleString('en-US', {
+            month: 'long',
+            year: 'numeric',
+            timeZone: 'UTC',
+          });
+    return { year: y, month0: m0, cells, label };
+  }, [monthCursor, selected, lang]);
+
+  const goMonth = (delta: number) => {
+    const dt = new Date(Date.UTC(year, month0 + delta, 1));
+    const yy = dt.getUTCFullYear();
+    const mm = String(dt.getUTCMonth() + 1).padStart(2, '0');
+    onMonthChange(`${yy}-${mm}-01`);
+  };
+
+  return (
+    <div className="day-cal card">
+      <div className="day-cal-head">
+        <button
+          type="button"
+          className="day-cal-nav"
+          onClick={() => goMonth(-1)}
+          aria-label={t('today.calPrevMonth')}
+        >
+          ‹
+        </button>
+        <span className="day-cal-label">{label}</span>
+        <button
+          type="button"
+          className="day-cal-nav"
+          onClick={() => goMonth(1)}
+          aria-label={t('today.calNextMonth')}
+        >
+          ›
+        </button>
+      </div>
+      <div className="day-cal-weekdays">
+        {weekdays.map((w) => (
+          <span key={w} className="day-cal-wd">
+            {w}
+          </span>
+        ))}
+      </div>
+      <div className="day-cal-grid">
+        {cells.map((c, i) => {
+          if (!c.day || c.n == null) {
+            return <span key={`e${i}`} className="day-cal-cell empty" />;
+          }
+          const h = heat.get(c.day) ?? 0;
+          const cls = [
+            'day-cal-cell',
+            h > 0 ? `heat-${h}` : '',
+            c.day === selected ? 'selected' : '',
+            c.day === projectionDay ? 'is-today' : '',
+          ]
+            .filter(Boolean)
+            .join(' ');
+          return (
+            <button
+              key={c.day}
+              type="button"
+              className={cls}
+              onClick={() => onSelect(c.day!)}
+              title={c.day}
+            >
+              <span className="day-cal-n">{c.n}</span>
+              {h > 0 && <span className="day-cal-dot" aria-hidden />}
+            </button>
+          );
+        })}
+      </div>
+      <div className="day-cal-foot">
+        <button
+          type="button"
+          className="tiny day-cal-jump"
+          onClick={() => {
+            onMonthChange(monthStart(projectionDay));
+            onSelect(projectionDay);
+          }}
+        >
+          {t('today.calJumpToday')}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/console-ui/src/design/portal.css
+++ b/console-ui/src/design/portal.css
@@ -2125,3 +2125,140 @@ body {
   align-items: center;
   gap: 0.5rem;
 }
+
+/* ---------- Today day-browser + calendar ---------- */
+.today-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(240px, 280px);
+  gap: 1.25rem;
+  align-items: start;
+}
+@media (max-width: 900px) {
+  .today-layout {
+    grid-template-columns: 1fr;
+  }
+  .today-aside {
+    order: -1;
+  }
+}
+.today-aside {
+  position: sticky;
+  top: 0.75rem;
+}
+.day-cal {
+  padding: 0.75rem 0.85rem 0.65rem;
+}
+.day-cal-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.35rem;
+  margin-bottom: 0.55rem;
+}
+.day-cal-label {
+  font-weight: 600;
+  font-size: var(--ovp-text-sm);
+}
+.day-cal-nav {
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+  border-radius: var(--ovp-radius-sm);
+  width: 1.75rem;
+  height: 1.75rem;
+  cursor: pointer;
+  font: inherit;
+  color: var(--text);
+  line-height: 1;
+}
+.day-cal-nav:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.day-cal-weekdays,
+.day-cal-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 0.2rem;
+}
+.day-cal-wd {
+  text-align: center;
+  font-size: var(--ovp-text-xs);
+  color: var(--muted);
+  padding: 0.15rem 0;
+}
+.day-cal-cell {
+  position: relative;
+  border: 1px solid transparent;
+  background: transparent;
+  border-radius: var(--ovp-radius-sm);
+  min-height: 2rem;
+  padding: 0.2rem 0;
+  cursor: pointer;
+  font: inherit;
+  color: var(--text);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.1rem;
+}
+.day-cal-cell.empty {
+  cursor: default;
+  pointer-events: none;
+}
+.day-cal-cell:not(.empty):hover {
+  background: var(--accent-soft);
+  border-color: var(--border);
+}
+.day-cal-cell.selected {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  font-weight: 600;
+}
+.day-cal-cell.is-today .day-cal-n {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.day-cal-n {
+  font-size: var(--ovp-text-xs);
+  font-variant-numeric: tabular-nums;
+}
+.day-cal-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--accent);
+}
+.day-cal-cell.heat-1 .day-cal-dot {
+  opacity: 0.45;
+}
+.day-cal-cell.heat-2 .day-cal-dot {
+  opacity: 0.75;
+}
+.day-cal-cell.heat-3 .day-cal-dot {
+  opacity: 1;
+  width: 6px;
+  height: 6px;
+}
+.day-cal-foot {
+  margin-top: 0.55rem;
+  text-align: center;
+}
+.day-cal-jump,
+button.linkish {
+  border: 0;
+  background: transparent;
+  color: var(--accent);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+}
+.day-cal-jump:hover,
+button.linkish:hover {
+  text-decoration: underline;
+}
+.day-cal-legend {
+  margin: 0.45rem 0.15rem 0;
+  line-height: 1.4;
+}

--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -105,11 +105,15 @@ export const en = {
 
   // today page
   'today.title': 'Today',
+  'today.dayTitle': 'Day {day}',
   'today.help':
-    'Every day OVP2 captures your clippings and bookmarks, reads them into grounded memory, and crystallizes cross-source knowledge. This page shows what changed today.',
+    'Pick a day on the calendar to see captures, reads, reader packs, and crystal claims with a date-bearing run. The default is the projection build day; Attention is the live operator queue for that build.',
   'today.captured': 'Captured',
   'today.read': 'Read',
   'today.claims': 'Claims',
+  'today.dayClaims': 'Crystal',
+  'today.dayPacks': 'Packs',
+  'today.daySourcesDated': '{n} sources dated',
   'today.attention': 'Attention',
   'today.pinboard': 'pinboard',
   'today.unitsCards': '{units} units · {cards} cards',
@@ -125,17 +129,36 @@ export const en = {
   'today.claimsSample': 'From the crystal store',
   'today.claimsSampleNote':
     'A durable-first sample — the crystal ledger records no dates, so per-day attribution is not derivable yet.',
+  'today.crystalTitle': 'Crystal that day',
+  'today.crystalNote':
+    'Claims whose run id embeds this calendar day (for example a daily or full-crystal run). Claims without a date-bearing run id are omitted.',
+  'today.crystalEmpty': 'No date-linked claims for this day.',
   'today.claimSources': 'Sources',
   'today.strength': 'strength',
   'today.readToday': 'Read today',
-  'today.readEmpty': 'Nothing read yet today — the daily run has not produced new packs.',
-  'today.capturedEmpty': 'no capture runs today',
+  'today.readTitle': 'Read that day',
+  'today.readEmpty':
+    'Nothing processed on this day — no finished sources for its daily run(s).',
+  'today.packsTitle': 'Reader packs',
+  'today.packsEmpty': 'No reader packs dated this day.',
+  'today.sourcesDatedTitle': 'Sources dated this day',
+  'today.sourcesDatedEmpty': 'No sources carry this calendar date.',
+  'today.runsTitle': 'Pipeline runs',
+  'today.runLine': 'ok {ok} · fail {fail} · in {ingested} · blocked {blocked}',
+  'today.capturedEmpty': 'no intake that day',
   'today.timeline': 'Timeline',
   'today.timelineRead': 'read {n}',
   'today.timelineCaptured': 'captured {n}',
   'today.timelineAll': '→ System: all runs',
   'today.noRunsToday':
     'No runs recorded for today yet — stats show 0 until the daily run lands.',
+  'today.noActivityDay':
+    'No runs, packs, or date-linked claims recorded for this day in the current index.',
+  'today.calPrevMonth': 'Previous month',
+  'today.calNextMonth': 'Next month',
+  'today.calJumpToday': 'Jump to projection day',
+  'today.calLegend':
+    'Dots mark days with vault activity (runs, dated sources/packs, or date-linked claims).',
 
   // library page
   'library.title': 'Library',

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -97,11 +97,15 @@ export const zh: Record<keyof typeof en, string> = {
 
   // today page
   'today.title': '今天',
+  'today.dayTitle': '{day}',
   'today.help':
-    'OVP2 每天捕获你的剪藏与书签，读成有据记忆，并结晶跨源知识。本页展示今天的变化。',
+    '在日历上选一天，查看当天的捕获、阅读、阅读包，以及 run id 带日期的结晶主张。默认是投影构建日；「需要你」始终是当前构建的实时待办队列。',
   'today.captured': '进来',
   'today.read': '读完',
   'today.claims': '结晶',
+  'today.dayClaims': '结晶',
+  'today.dayPacks': '阅读包',
+  'today.daySourcesDated': '日期为当日的源 {n}',
   'today.attention': '待处理',
   'today.pinboard': '书签',
   'today.unitsCards': '{units} 单元 · {cards} 卡片',
@@ -117,16 +121,34 @@ export const zh: Record<keyof typeof en, string> = {
   'today.claimsSample': '来自结晶库',
   'today.claimsSampleNote':
     'durable 优先的样本——结晶账本尚未记录日期，暂无法按日归因。',
+  'today.crystalTitle': '当日结晶',
+  'today.crystalNote':
+    'run id 中带有该日历日的主张（例如 daily 或 full-crystal 运行）。无日期 run id 的主张不会出现在这里。',
+  'today.crystalEmpty': '这一天没有可按日关联的结晶主张。',
   'today.claimSources': '来源',
   'today.strength': '强度',
   'today.readToday': '今日读完',
-  'today.readEmpty': '今天还没有读完的内容——日常运行尚未产出新的阅读包。',
-  'today.capturedEmpty': '今天没有捕获运行',
+  'today.readTitle': '当日读完',
+  'today.readEmpty': '这一天没有处理完成的源——对应 daily 运行没有成功产出。',
+  'today.packsTitle': '阅读包',
+  'today.packsEmpty': '这一天没有标注日期的阅读包。',
+  'today.sourcesDatedTitle': '日期为当日的源',
+  'today.sourcesDatedEmpty': '没有源的日期字段落在这一天。',
+  'today.runsTitle': '管线运行',
+  'today.runLine': '成功 {ok} · 失败 {fail} · 入库 {ingested} · 阻塞 {blocked}',
+  'today.capturedEmpty': '这一天没有捕获',
   'today.timeline': '时间线',
   'today.timelineRead': '读完 {n}',
   'today.timelineCaptured': '进来 {n}',
   'today.timelineAll': '→ 系统：查看全部运行',
   'today.noRunsToday': '今天还没有运行记录——日常运行完成前统计为 0。',
+  'today.noActivityDay':
+    '当前索引中这一天没有运行、阅读包或可按日关联的结晶。',
+  'today.calPrevMonth': '上个月',
+  'today.calNextMonth': '下个月',
+  'today.calJumpToday': '回到投影日',
+  'today.calLegend':
+    '圆点表示该日有 vault 活动（运行、带日期的源/阅读包，或可按日关联的结晶）。',
 
   // library page
   'library.title': '资料',

--- a/console-ui/src/lib/derive.day.test.ts
+++ b/console-ui/src/lib/derive.day.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest';
+import {
+  activityDates,
+  claimActivityDate,
+  dayView,
+  packActivityDate,
+  shiftIsoDay,
+} from './derive';
+import type { IndexModel } from './types';
+
+function baseModel(overrides: Partial<IndexModel> = {}): IndexModel {
+  return {
+    schema: 'ovp.index/v2',
+    date: '2026-07-26',
+    totals: {
+      sources: 0,
+      queued: 0,
+      processed: 0,
+      failed: 0,
+      blocked: 0,
+      needs_content: 0,
+      unparseable: 0,
+      duplicates: 0,
+      packs: 0,
+      claims_durable: 0,
+      claims_caveated: 0,
+      runs: 0,
+    },
+    sources: [],
+    packs: [],
+    claims: [],
+    runs: [],
+    ops: { blocked_sources: [], queue_depth: 0 },
+    ...overrides,
+  };
+}
+
+describe('claimActivityDate / packActivityDate', () => {
+  it('parses daily and compact crystal run ids', () => {
+    expect(claimActivityDate({ claim_id: 'a', claim: 'x', status: 'durable', sources: [], run_id: 'daily-2026-07-26' })).toBe(
+      '2026-07-26',
+    );
+    expect(
+      claimActivityDate({
+        claim_id: 'b',
+        claim: 'y',
+        status: 'durable',
+        sources: [],
+        run_id: 'crystal-full-20260709',
+      }),
+    ).toBe('2026-07-09');
+    expect(
+      claimActivityDate({
+        claim_id: 'c',
+        claim: 'z',
+        status: 'durable',
+        sources: [],
+        run_id: 'run-8b0f5d4e',
+      }),
+    ).toBeNull();
+  });
+
+  it('pulls pack day from pack_dir when date field missing', () => {
+    expect(
+      packActivityDate({
+        pack_dir: '40-Resources/Reader/2026-06-15_Title-abc',
+        title: 'T',
+        units: 1,
+        cards: 1,
+        json_repaired: false,
+        card_titles: [],
+      }),
+    ).toBe('2026-06-15');
+  });
+});
+
+describe('dayView', () => {
+  it('aggregates runs, reads, packs, and date-linked claims for a day', () => {
+    const model = baseModel({
+      runs: [
+        {
+          run_id: 'daily-2026-07-26',
+          date: '2026-07-26',
+          report_file: 'r.json',
+          succeeded: 2,
+          failed: 0,
+          skipped: 0,
+          blocked: 0,
+          ingested: 1,
+          pinboard_new: 0,
+          lifecycle_warnings: 0,
+        },
+      ],
+      sources: [
+        {
+          sha256: 's1',
+          status: 'processed',
+          title: 'Read A',
+          date: '2026-07-26',
+          last_run_id: 'daily-2026-07-26',
+          pack_dir: '40-Resources/Reader/2026-07-26_A-s1',
+          fail_count: 0,
+        },
+        {
+          sha256: 's2',
+          status: 'processed',
+          title: 'Old',
+          date: '2026-07-01',
+          last_run_id: 'daily-2026-07-01',
+          fail_count: 0,
+        },
+      ],
+      packs: [
+        {
+          pack_dir: '40-Resources/Reader/2026-07-26_A-s1',
+          title: 'Pack A',
+          units: 10,
+          cards: 3,
+          json_repaired: false,
+          card_titles: [],
+          source_sha256: 's1',
+        },
+      ],
+      claims: [
+        {
+          claim_id: 'c1',
+          claim: 'A durable claim',
+          status: 'durable',
+          sources: [],
+          run_id: 'daily-2026-07-26',
+        },
+        {
+          claim_id: 'c2',
+          claim: 'Undated',
+          status: 'durable',
+          sources: [],
+          run_id: 'run-hash',
+        },
+      ],
+    });
+
+    const v = dayView(model, '2026-07-26');
+    expect(v.captured).toBe(1);
+    expect(v.read).toBe(2);
+    expect(v.sourcesRead).toHaveLength(1);
+    expect(v.packs).toHaveLength(1);
+    expect(v.claims).toHaveLength(1);
+    expect(v.claims[0].claim_id).toBe('c1');
+    expect(v.heat).toBeGreaterThan(0);
+
+    const dates = activityDates(model);
+    expect(dates.has('2026-07-26')).toBe(true);
+    expect(dates.has('2026-07-01')).toBe(true);
+  });
+});
+
+describe('shiftIsoDay', () => {
+  it('steps across month boundaries in UTC', () => {
+    expect(shiftIsoDay('2026-07-01', -1)).toBe('2026-06-30');
+    expect(shiftIsoDay('2026-02-28', 1)).toBe('2026-03-01');
+  });
+});

--- a/console-ui/src/lib/derive.ts
+++ b/console-ui/src/lib/derive.ts
@@ -317,6 +317,184 @@ export function timeline(model: IndexModel, days: number): TimelineDay[] {
     .slice(0, days);
 }
 
+// --------------------------------------------------------------- day browser
+
+const ISO_DAY = /^\d{4}-\d{2}-\d{2}$/;
+
+/** True when `s` is a calendar day `YYYY-MM-DD`. */
+export function isIsoDay(s: string | null | undefined): s is string {
+  return typeof s === 'string' && ISO_DAY.test(s);
+}
+
+/** Best pack activity day: explicit field, else first `YYYY-MM-DD` in pack_dir. */
+export function packActivityDate(pack: PackRow): string | null {
+  if (isIsoDay(pack.date)) return pack.date;
+  const m = pack.pack_dir.match(/(20\d{2}-\d{2}-\d{2})/);
+  return m?.[1] ?? null;
+}
+
+/**
+ * Best-effort day a claim was produced. The crystal ledger has no written-at;
+ * when `run_id` embeds a date (`daily-2026-07-26`, `crystal-full-20260709`)
+ * we surface it. Otherwise null — never invent.
+ */
+export function claimActivityDate(claim: ClaimRow): string | null {
+  const rid = claim.run_id ?? '';
+  const dashed = rid.match(/(20\d{2}-\d{2}-\d{2})/);
+  if (dashed) return dashed[1];
+  const compact = rid.match(/(20\d{6})/);
+  if (compact) {
+    const s = compact[1];
+    return `${s.slice(0, 4)}-${s.slice(4, 6)}-${s.slice(6, 8)}`;
+  }
+  return null;
+}
+
+/** All ISO days that have any known vault activity (for calendar dots). */
+export function activityDates(model: IndexModel): Set<string> {
+  const days = new Set<string>();
+  for (const r of model.runs) {
+    if (isIsoDay(r.date)) days.add(r.date);
+  }
+  for (const s of model.sources) {
+    if (isIsoDay(s.date)) days.add(s.date);
+  }
+  for (const p of model.packs) {
+    const d = packActivityDate(p);
+    if (d) days.add(d);
+  }
+  for (const c of model.claims) {
+    const d = claimActivityDate(c);
+    if (d) days.add(d);
+  }
+  if (isIsoDay(model.date)) days.add(model.date);
+  return days;
+}
+
+/** Shift an ISO day by `delta` calendar days (local arithmetic on Y-M-D). */
+export function shiftIsoDay(day: string, delta: number): string {
+  const [y, m, d] = day.split('-').map(Number);
+  const dt = new Date(Date.UTC(y, m - 1, d + delta));
+  const yy = dt.getUTCFullYear();
+  const mm = String(dt.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(dt.getUTCDate()).padStart(2, '0');
+  return `${yy}-${mm}-${dd}`;
+}
+
+/** First day of the month containing `day` (YYYY-MM-01). */
+export function monthStart(day: string): string {
+  return `${day.slice(0, 7)}-01`;
+}
+
+export interface DayView {
+  date: string;
+  /** True when `date === model.date` (the projection's build day). */
+  isProjectionDay: boolean;
+  runs: RunRow[];
+  captured: number;
+  capturedPinboard: number;
+  read: number;
+  readUnits: number;
+  readCards: number;
+  /** Sources whose recorded date is this day (clipping/publish date). */
+  sourcesDated: SourceRow[];
+  /** Sources processed by a run that ran on this day. */
+  sourcesRead: ReadSource[];
+  /** Reader packs whose activity date is this day. */
+  packs: PackRow[];
+  /** Claims with a date-bearing run_id for this day. */
+  claims: ClaimRow[];
+  claimsDurable: number;
+  claimsCaveated: number;
+  /** Intensity 0–3 for calendar heat (none / light / med / heavy). */
+  heat: 0 | 1 | 2 | 3;
+}
+
+function dayHeat(captured: number, read: number, claims: number): 0 | 1 | 2 | 3 {
+  const n = captured + read + claims;
+  if (n <= 0) return 0;
+  if (n < 5) return 1;
+  if (n < 20) return 2;
+  return 3;
+}
+
+/** Full multi-dimension view of one calendar day from the index projection. */
+export function dayView(model: IndexModel, date: string): DayView {
+  const day = isIsoDay(date) ? date : model.date;
+  const runs = model.runs.filter((r) => r.date === day);
+  const runIds = new Set(runs.map((r) => r.run_id));
+  const packByDir = new Map(model.packs.map((p) => [p.pack_dir, p]));
+
+  const sourcesDated = model.sources
+    .filter((s) => s.date === day)
+    .sort((a, b) => (a.title ?? '').localeCompare(b.title ?? ''));
+
+  const sourcesRead = model.sources
+    .filter(
+      (s) =>
+        s.status === 'processed' &&
+        s.last_run_id != null &&
+        runIds.has(s.last_run_id),
+    )
+    .map((source) => ({
+      source,
+      pack: source.pack_dir ? packByDir.get(source.pack_dir) : undefined,
+    }))
+    .sort((a, b) => (a.source.title ?? '').localeCompare(b.source.title ?? ''));
+
+  const packs = model.packs
+    .filter((p) => packActivityDate(p) === day)
+    .sort((a, b) => a.title.localeCompare(b.title));
+
+  const claims = model.claims
+    .filter((c) => claimActivityDate(c) === day)
+    .filter((c) => c.status === 'durable' || c.status === 'caveated')
+    .sort((a, b) => {
+      const ra = a.status === 'durable' ? 0 : 1;
+      const rb = b.status === 'durable' ? 0 : 1;
+      return ra - rb || a.claim.localeCompare(b.claim);
+    });
+
+  const captured = runs.reduce((n, r) => n + r.ingested, 0);
+  const capturedPinboard = runs.reduce((n, r) => n + r.pinboard_new, 0);
+  // Prefer run counters when present; fall back to source lists so a day
+  // with dated packs still shows activity without a run row.
+  const readFromRuns = runs.reduce((n, r) => n + r.succeeded, 0);
+  const read = readFromRuns > 0 ? readFromRuns : sourcesRead.length;
+
+  return {
+    date: day,
+    isProjectionDay: day === model.date,
+    runs,
+    captured,
+    capturedPinboard,
+    read,
+    readUnits: sourcesRead.reduce((n, s) => n + (s.pack?.units ?? 0), 0),
+    readCards: sourcesRead.reduce((n, s) => n + (s.pack?.cards ?? 0), 0),
+    sourcesDated,
+    sourcesRead,
+    packs,
+    claims,
+    claimsDurable: claims.filter((c) => c.status === 'durable').length,
+    claimsCaveated: claims.filter((c) => c.status === 'caveated').length,
+    heat: dayHeat(captured, read, claims.length),
+  };
+}
+
+/** Heat map for every day in a calendar month (`YYYY-MM`). */
+export function monthHeat(
+  model: IndexModel,
+  yearMonth: string,
+): Map<string, 0 | 1 | 2 | 3> {
+  const out = new Map<string, 0 | 1 | 2 | 3>();
+  const prefix = yearMonth.slice(0, 7);
+  for (const day of activityDates(model)) {
+    if (!day.startsWith(prefix)) continue;
+    out.set(day, dayView(model, day).heat);
+  }
+  return out;
+}
+
 // ------------------------------------------------------------------ library
 
 export type Collection = 'clippings' | 'pinboard' | 'capture';

--- a/console-ui/src/pages/TodayPage.tsx
+++ b/console-ui/src/pages/TodayPage.tsx
@@ -1,75 +1,182 @@
-/** Today `/` — answers US1/US6 (design §3.1): what came in, what was read,
- * what crystallized, what needs me. All numbers derive from /api/model for
- * model.date.
+/** Today `/` — day browser: calendar + multi-dimension view of a chosen day
+ * (captures, reads/packs, crystal claims with date-bearing runs, run rows).
  *
- * B1 deviation (documented): per-day claim attribution is not derivable
- * from ClaimRow (no date; run_id namespace differs from RunRow), so the
- * crystallized section renders as "Recent claims" — see lib/derive.ts. */
-import { useMemo } from 'react';
-import { Link } from 'react-router-dom';
+ * Default day is the projection's `model.date`. `?day=YYYY-MM-DD` selects a
+ * past day (bookmarkable). Attention stays on the projection day only —
+ * blocked/needs-content is a live operator queue, not a historical ledger.
+ */
+import { useMemo, useState } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
 import AttentionCard from '../components/AttentionCard';
-import { AgeLabel, ClaimPill, EmptyState, ModelGate, PageHelp } from '../components/ui';
+import DayCalendar from '../components/DayCalendar';
+import {
+  AgeLabel,
+  ClaimPill,
+  EmptyState,
+  ModelGate,
+  PageHelp,
+} from '../components/ui';
 import { useI18n } from '../i18n';
 import {
   attentionSources,
+  dayView,
+  isIsoDay,
   isMiscTheme,
-  readToday,
-  claimsSample,
-  timeline,
-  todayStats,
+  monthHeat,
+  monthStart,
+  type DayView,
 } from '../lib/derive';
-import type { TodayStats } from '../lib/derive';
-import type { IndexModel } from '../lib/types';
+import type { IndexModel, RunRow } from '../lib/types';
 import { useModel } from '../model';
 
-const RECENT_CLAIMS = 3;
-const TIMELINE_DAYS = 7;
+const LIST_CAP = 12;
 
-function Stats({ model, stats: s }: { model: IndexModel; stats: TodayStats }) {
+function DayStats({ view }: { view: DayView }) {
   const { t } = useI18n();
-  const { totals } = model;
   return (
     <div className="grid stats">
       <div className="card">
         <div className="metric-label">{t('today.captured')}</div>
-        <div className="metric-num">{s.captured}</div>
+        <div className="metric-num">{view.captured}</div>
         <div className="metric-sub">
-          {s.todayRuns.length === 0
+          {view.runs.length === 0 && view.captured === 0
             ? t('today.capturedEmpty')
-            : `${t('today.pinboard')} ${s.capturedPinboard}`}
+            : `${t('today.pinboard')} ${view.capturedPinboard}`}
         </div>
       </div>
       <div className="card">
         <div className="metric-label">{t('today.read')}</div>
-        <div className="metric-num">{s.read}</div>
+        <div className="metric-num">{view.read}</div>
         <div className="metric-sub">
-          {t('today.unitsCards', { units: s.readUnits, cards: s.readCards })}
+          {t('today.unitsCards', {
+            units: view.readUnits,
+            cards: view.readCards,
+          })}
         </div>
       </div>
       <div className="card">
-        <div className="metric-label">{t('today.claims')}</div>
-        <div className="metric-num">
-          {totals.claims_durable + totals.claims_caveated}
-        </div>
+        <div className="metric-label">{t('today.dayClaims')}</div>
+        <div className="metric-num">{view.claims.length}</div>
         <div className="metric-sub">
           {t('today.durableCaveated', {
-            durable: totals.claims_durable,
-            caveated: totals.claims_caveated,
+            durable: view.claimsDurable,
+            caveated: view.claimsCaveated,
           })}
         </div>
       </div>
       <div className="card">
-        <div className="metric-label">{t('today.attention')}</div>
-        <div className={s.attention > 0 ? 'metric-num warn' : 'metric-num'}>
-          {s.attention}
-        </div>
+        <div className="metric-label">{t('today.dayPacks')}</div>
+        <div className="metric-num">{view.packs.length}</div>
         <div className="metric-sub">
-          {t('today.blockedNeeds', {
-            blocked: totals.blocked,
-            needs: totals.needs_content,
-          })}
+          {t('today.daySourcesDated', { n: view.sourcesDated.length })}
         </div>
       </div>
+    </div>
+  );
+}
+
+function RunsThatDay({ runs }: { runs: RunRow[] }) {
+  const { t } = useI18n();
+  if (runs.length === 0) return null;
+  return (
+    <div className="section">
+      <h2>{t('today.runsTitle')}</h2>
+      <div className="row-list">
+        {runs.map((r, i) => (
+          <div className="row" key={`${r.run_id}-${i}`}>
+            <span className="mono">{r.run_id}</span>
+            <span className="meta">
+              {t('today.runLine', {
+                ok: r.succeeded,
+                fail: r.failed,
+                ingested: r.ingested,
+                blocked: r.blocked,
+              })}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SourceList({
+  title,
+  empty,
+  items,
+}: {
+  title: string;
+  empty: string;
+  items: { sha: string; title: string; meta?: string }[];
+}) {
+  const shown = items.slice(0, LIST_CAP);
+  const more = items.length - shown.length;
+  return (
+    <div className="section">
+      <h2>{title}</h2>
+      {items.length === 0 ? (
+        <EmptyState>
+          <p>{empty}</p>
+        </EmptyState>
+      ) : (
+        <div className="row-list">
+          {shown.map((it) => (
+            <div className="row" key={it.sha}>
+              <Link to={`/library/${it.sha}`}>{it.title}</Link>
+              {it.meta && <span className="meta">{it.meta}</span>}
+            </div>
+          ))}
+          {more > 0 && (
+            <p className="tiny muted">
+              +{more}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ClaimsThatDay({ view }: { view: DayView }) {
+  const { t } = useI18n();
+  const shown = view.claims.slice(0, LIST_CAP);
+  const more = view.claims.length - shown.length;
+  return (
+    <div className="section">
+      <h2>{t('today.crystalTitle')}</h2>
+      <p className="muted tiny">{t('today.crystalNote')}</p>
+      {view.claims.length === 0 ? (
+        <EmptyState>
+          <p>{t('today.crystalEmpty')}</p>
+        </EmptyState>
+      ) : (
+        <>
+          {shown.map((c) => (
+            <div className="card" key={c.claim_id}>
+              <div className="claim-top">
+                {(c.status === 'durable' || c.status === 'caveated') && (
+                  <ClaimPill status={c.status} />
+                )}
+                {c.strength && (
+                  <span className="claim-meta">
+                    {t('today.strength')}: {c.strength}
+                  </span>
+                )}
+                {c.run_id && (
+                  <span className="claim-meta mono tiny">{c.run_id}</span>
+                )}
+              </div>
+              <p className="claim-text">{c.claim}</p>
+              {c.theme && (
+                <div className="claim-meta">
+                  {isMiscTheme(c.theme) ? t('theme.unclassified') : c.theme}
+                </div>
+              )}
+            </div>
+          ))}
+          {more > 0 && <p className="tiny muted">+{more}</p>}
+        </>
+      )}
     </div>
   );
 }
@@ -88,125 +195,160 @@ function Attention({ model }: { model: IndexModel }) {
   );
 }
 
-function RecentClaims({ model }: { model: IndexModel }) {
+function DayBody({
+  model,
+  view,
+}: {
+  model: IndexModel;
+  view: DayView;
+}) {
   const { t } = useI18n();
-  const claims = claimsSample(model, RECENT_CLAIMS);
-  if (claims.length === 0) return null;
+  const readItems = view.sourcesRead.map(({ source, pack }) => ({
+    sha: source.sha256,
+    title: source.title ?? source.sha256,
+    meta: pack
+      ? t('today.unitsCards', { units: pack.units, cards: pack.cards })
+      : undefined,
+  }));
+  const datedItems = view.sourcesDated.map((s) => ({
+    sha: s.sha256,
+    title: s.title ?? s.sha256,
+    meta: s.status,
+  }));
+  const packItems = view.packs.map((p) => ({
+    sha: p.source_sha256 ?? p.pack_dir,
+    title: p.title,
+    meta: t('today.unitsCards', { units: p.units, cards: p.cards }),
+    href: p.source_sha256 ? `/library/${p.source_sha256}` : null,
+  }));
+
   return (
-    <div className="section">
-      <h2>{t('today.claimsSample')}</h2>
-      <p className="muted tiny">{t('today.claimsSampleNote')}</p>
-      {claims.map((c) => (
-        <div className="card" key={c.claim_id}>
-          <div className="claim-top">
-            {(c.status === 'durable' || c.status === 'caveated') && (
-              <ClaimPill status={c.status} />
-            )}
-            {c.strength && (
-              <span className="claim-meta">
-                {t('today.strength')}: {c.strength}
-              </span>
-            )}
+    <>
+      <DayStats view={view} />
+      {view.isProjectionDay && <Attention model={model} />}
+      <RunsThatDay runs={view.runs} />
+      <SourceList
+        title={t('today.readTitle')}
+        empty={t('today.readEmpty')}
+        items={readItems}
+      />
+      <div className="section">
+        <h2>{t('today.packsTitle')}</h2>
+        {packItems.length === 0 ? (
+          <EmptyState>
+            <p>{t('today.packsEmpty')}</p>
+          </EmptyState>
+        ) : (
+          <div className="row-list">
+            {packItems.slice(0, LIST_CAP).map((it) => (
+              <div className="row" key={it.sha}>
+                {it.href ? (
+                  <Link to={it.href}>{it.title}</Link>
+                ) : (
+                  <span>{it.title}</span>
+                )}
+                {it.meta && <span className="meta">{it.meta}</span>}
+              </div>
+            ))}
           </div>
-          <p className="claim-text">{c.claim}</p>
-          {c.theme && (
-            <div className="claim-meta">
-              {isMiscTheme(c.theme) ? t('theme.unclassified') : c.theme}
-            </div>
-          )}
-        </div>
-      ))}
-    </div>
-  );
-}
-
-function ReadToday({ model }: { model: IndexModel }) {
-  const { t } = useI18n();
-  const reads = readToday(model);
-  return (
-    <div className="section">
-      <h2>{t('today.readToday')}</h2>
-      {reads.length === 0 ? (
-        <EmptyState>
-          <p>{t('today.readEmpty')}</p>
-        </EmptyState>
-      ) : (
-        <div className="row-list">
-          {reads.map(({ source, pack }) => (
-            <div className="row" key={source.sha256}>
-              <Link to={`/library/${source.sha256}`}>
-                {source.title ?? source.sha256}
-              </Link>
-              {pack && (
-                <span className="meta">
-                  {t('today.unitsCards', {
-                    units: pack.units,
-                    cards: pack.cards,
-                  })}
-                </span>
-              )}
-            </div>
-          ))}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function Timeline({ model }: { model: IndexModel }) {
-  const { t } = useI18n();
-  const days = timeline(model, TIMELINE_DAYS);
-  if (days.length === 0) return null;
-  return (
-    <div className="foot">
-      {t('today.timeline')}:{' '}
-      {days.map((d) => (
-        <span key={d.date}>
-          <span className="mono">{d.date.slice(5)}</span>{' '}
-          {t('today.timelineRead', { n: d.read })}
-          {d.captured > 0 && (
-            <> · {t('today.timelineCaptured', { n: d.captured })}</>
-          )}
-          {' · '}
-        </span>
-      ))}
-      <Link to="/system">{t('today.timelineAll')}</Link>
-    </div>
+        )}
+      </div>
+      <SourceList
+        title={t('today.sourcesDatedTitle')}
+        empty={t('today.sourcesDatedEmpty')}
+        items={datedItems}
+      />
+      <ClaimsThatDay view={view} />
+    </>
   );
 }
 
 export default function TodayPage() {
   const { t } = useI18n();
   const { model, error, loading } = useModel();
-  // todayStats walks every run/pack row — compute once per model, not on
-  // every render and not once per consumer below.
-  const stats = useMemo(() => (model ? todayStats(model) : null), [model]);
+  const [params, setParams] = useSearchParams();
+  const paramDay = params.get('day');
+
+  // Month cursor for the calendar (independent of selection while browsing).
+  const [monthCursor, setMonthCursor] = useState<string | null>(null);
+
+  const selected = useMemo(() => {
+    if (!model) return null;
+    if (isIsoDay(paramDay)) return paramDay;
+    return model.date;
+  }, [model, paramDay]);
+
+  const view = useMemo(
+    () => (model && selected ? dayView(model, selected) : null),
+    [model, selected],
+  );
+
+  const heat = useMemo(() => {
+    if (!model || !selected) return new Map<string, 0 | 1 | 2 | 3>();
+    const cursor = monthCursor ?? monthStart(selected);
+    return monthHeat(model, cursor);
+  }, [model, selected, monthCursor]);
+
+  const setDay = (day: string) => {
+    const next = new URLSearchParams(params);
+    if (model && day === model.date) next.delete('day');
+    else next.set('day', day);
+    setParams(next, { replace: true });
+    setMonthCursor(monthStart(day));
+  };
+
   return (
     <ModelGate loading={loading} error={error}>
-      {model && stats && (
+      {model && selected && view && (
         <>
-          <h1 style={{ marginTop: '1rem' }}>{t('today.title')}</h1>
-          <p className="muted sm" style={{ marginTop: '-2px' }}>
-            <span className="mono">{model.date}</span>
-            {stats.dogfoodDay > 0 && (
-              <> · {t('common.day')} {stats.dogfoodDay}</>
-            )}
-            {' · '}
-            {/* P1: the build INSTANT + age, so three runs one day differ and a
-                stale count never reads like a fresh one. */}
-            <AgeLabel builtAt={model.built_at} />
-          </p>
-          <PageHelp>{t('today.help')}</PageHelp>
-          {stats.todayRuns.length === 0 && (
-            <p className="muted tiny" style={{ marginTop: '-0.5rem' }}>
-              {t('today.noRunsToday')}
-            </p>
-          )}
-          <Stats model={model} stats={stats} />
-          <Attention model={model} />
-          <RecentClaims model={model} />
-          <ReadToday model={model} />
-          <Timeline model={model} />
+          <div className="today-layout">
+            <div className="today-main">
+              <h1 style={{ marginTop: '1rem' }}>
+                {view.isProjectionDay
+                  ? t('today.title')
+                  : t('today.dayTitle', { day: selected })}
+              </h1>
+              <p className="muted sm" style={{ marginTop: '-2px' }}>
+                <span className="mono">{selected}</span>
+                {view.isProjectionDay && (
+                  <>
+                    {' · '}
+                    <AgeLabel builtAt={model.built_at} />
+                  </>
+                )}
+                {!view.isProjectionDay && (
+                  <>
+                    {' · '}
+                    <button
+                      type="button"
+                      className="tiny linkish"
+                      onClick={() => setDay(model.date)}
+                    >
+                      {t('today.calJumpToday')}
+                    </button>
+                  </>
+                )}
+              </p>
+              <PageHelp>{t('today.help')}</PageHelp>
+              {view.runs.length === 0 && view.heat === 0 && (
+                <p className="muted tiny" style={{ marginTop: '-0.5rem' }}>
+                  {t('today.noActivityDay')}
+                </p>
+              )}
+              <DayBody model={model} view={view} />
+            </div>
+            <aside className="today-aside">
+              <DayCalendar
+                selected={selected}
+                monthCursor={monthCursor ?? monthStart(selected)}
+                heat={heat}
+                projectionDay={model.date}
+                onSelect={setDay}
+                onMonthChange={setMonthCursor}
+              />
+              <p className="tiny muted day-cal-legend">{t('today.calLegend')}</p>
+            </aside>
+          </div>
         </>
       )}
     </ModelGate>


### PR DESCRIPTION
## Summary
- **Today** page gains a month calendar (activity heat dots) and a day browser.
- Selecting a day shows multi-dimension activity for that date: pipeline runs, sources read, reader packs, sources with that calendar date, and crystal claims whose `run_id` embeds the day.
- URL: `/?day=YYYY-MM-DD` (bookmarkable); default is the projection build day.
- Attention list only on the projection day (live operator queue).

## Notes
- Crystal “that day” is best-effort: only claims with a date-bearing run id are listed (ledger has no written-at yet).
- No competitor names or comparison language in code/docs.

## Test plan
- [x] `cd console-ui && npm test` (57)
- [x] `tsc --noEmit` + `npm run build`
- [x] Desktop app rebuild
- [ ] Open `/` → calendar on the right; click a past active day; stats/lists update
- [ ] `/?day=2026-07-13` loads that day; “Jump to projection day” returns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a calendar-based day browser to the Today page.
  * Browse previous and upcoming months, select any day, or jump back to today.
  * Calendar heat indicators highlight days with activity.
  * View daily captures, reads, sources, packs, claims, and pipeline runs.
  * Added day-specific URL selection and clearer empty states.
  * Added responsive two-column layout with localized English and Chinese labels.
* **Tests**
  * Added coverage for activity date detection, daily aggregation, calendar navigation, and activity heat levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->