### PR TITLE
fix(ask): tolerant + legacy citation resolution on replay

### DIFF
--- a/console-ui/src/pages/AskPage.citations.test.ts
+++ b/console-ui/src/pages/AskPage.citations.test.ts
@@ -54,3 +54,77 @@ describe('citationsFromAnswerText with an index lookup', () => {
     expect(c.title).toMatch(/^source 6dc988d1d27/);
   });
 });
+
+describe('tolerant + legacy citation resolution', () => {
+  const REAL_SHA =
+    '979d7ea1381359b259a4d78a0b13a032f24272c77980b9539c3ec5d2cce4f9c1';
+  const legacy = {
+    sources: [
+      { sha256: REAL_SHA, title: 'Digital Human Production' },
+      {
+        sha256: 'ab'.repeat(32),
+        title: 'Working with evals (OpenAI API)',
+        rel_path:
+          '40-Resources/Reader/4b1d798e-2026-03-29_Working_with_evals_OpenAI_API________.md',
+      },
+    ],
+    claims: [],
+  };
+
+  it('resolves a model-mangled sha when the head is intact and unique', () => {
+    // The model elided the middle of the id (real: …b9539c3ec5d2cce4f9c1).
+    const mangled = '979d7ea1381359b259a4d78a0b13a032f24272c77980b9539c9c1';
+    const [c] = citationsFromAnswerText(
+      `see [source:${mangled}]`,
+      makeCitationTitleLookup(legacy),
+    );
+    expect(c.title).toBe('Digital Human Production');
+    expect(c.link_target).toBe(`/library/${REAL_SHA}`);
+  });
+
+  it('refuses to guess when the head prefix is ambiguous', () => {
+    const two = {
+      sources: [
+        { sha256: `${'a'.repeat(24)}${'0'.repeat(40)}`, title: 'One' },
+        { sha256: `${'a'.repeat(24)}${'1'.repeat(40)}`, title: 'Two' },
+      ],
+      claims: [],
+    };
+    const [c] = citationsFromAnswerText(
+      `see [source:${'a'.repeat(30)}]`,
+      makeCitationTitleLookup(two),
+    );
+    expect(c.title).toMatch(/^source aaaa/);
+    expect(c.link_target).toBeNull();
+  });
+
+  it('collapses doubled kind prefixes and resolves legacy card paths', () => {
+    const [c] = citationsFromAnswerText(
+      'per [card:card:40-Resources/Reader/4b1d798e-2026-03-29_Working_with_evals_OpenAI_API________:0]',
+      makeCitationTitleLookup(legacy),
+    );
+    expect(c.id).toBe(
+      'card:40-Resources/Reader/4b1d798e-2026-03-29_Working_with_evals_OpenAI_API________:0',
+    );
+    expect(c.title).toBe('Working with evals (OpenAI API)');
+    expect(c.link_target).toBe(`/library/${'ab'.repeat(32)}`);
+  });
+
+  it('humanizes legacy unit paths not present in the index', () => {
+    const [c] = citationsFromAnswerText(
+      'see [unit:unit:40-Resources/Reader/024fa72c-2026-04-01_Agentic_RAG_notes____:u-034-0e0d496f]',
+      makeCitationTitleLookup(legacy),
+    );
+    expect(c.title).toBe('Agentic RAG notes');
+    expect(c.link_target).toBeNull();
+  });
+
+  it('keeps degenerate ellipsis markers honest', () => {
+    const [c] = citationsFromAnswerText(
+      'see [card:card:...:0]',
+      makeCitationTitleLookup(legacy),
+    );
+    expect(c.title).toBe('card:...:0');
+    expect(c.link_target).toBeNull();
+  });
+});

--- a/console-ui/src/pages/AskPage.tsx
+++ b/console-ui/src/pages/AskPage.tsx
@@ -129,30 +129,99 @@ function shortSourceLabel(token: string): string {
   return short.length < token.length ? `source ${short}…` : `source ${token}`;
 }
 
-/** Resolves a citation id to a human title from the loaded index — the
- * replay/recovery paths build citations from answer text alone (no server
- * receipts), so without this the right rail degrades to truncated hashes. */
-export type CitationTitleLookup = (kind: string, token: string) => string | null;
+/** Resolves a citation id from the loaded index — the replay/recovery
+ * paths build citations from answer text alone (no server receipts), so
+ * without this the right rail degrades to truncated hashes. */
+export interface CitationResolution {
+  title?: string | null;
+  link?: string | null;
+}
+export type CitationTitleLookup = (
+  kind: string,
+  token: string,
+) => CitationResolution | null;
+
+/** Models sometimes elide long ids ("…b9539c3ec5d2cce4f9c1" written as
+ * "…b9539c9c1"). When the head is intact (>=24 hex chars) and exactly one
+ * index sha shares it, resolution is safe: 96 bits of intact prefix make a
+ * wrong match practically impossible, and no match just falls back. */
+const SHA_HEAD = 24;
+
+/** Legacy card/unit markers carry a vault path + trailing suffix
+ * (":0", ":u-034-…"). The path part identifies the source note. */
+function legacyPathBody(token: string): string {
+  const i = token.lastIndexOf(':');
+  return i > 0 ? token.slice(0, i) : token;
+}
+
+/** Reader notes sanitize titles into filenames ("4b1d798e-2026-03-29_
+ * Working_with_evals___") — undo that for a readable fallback title. */
+function humanizeLegacyPath(path: string): string | null {
+  const base = path.split('/').pop() ?? path;
+  const text = base
+    .replace(/^[0-9a-f]{8}-/i, '')
+    .replace(/^\d{4}-\d{2}-\d{2}_/, '')
+    .replace(/_+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return text.length >= 3 && !/^[.\s]+$/.test(text) ? text : null;
+}
 
 export function makeCitationTitleLookup(
-  model: { sources: { sha256: string; title?: string }[]; claims: { claim_key?: string; claim: string }[] } | null,
+  model: {
+    sources: { sha256: string; title?: string; rel_path?: string }[];
+    claims: { claim_key?: string; claim: string }[];
+  } | null,
 ): CitationTitleLookup {
-  const sources = new Map(
-    (model?.sources ?? [])
-      .filter((s) => s.title && s.title.trim())
-      .map((s) => [s.sha256, s.title as string]),
+  const rows = model?.sources ?? [];
+  const bySha = new Map(rows.map((s) => [s.sha256, s]));
+  const byPath = new Map(
+    rows
+      .filter((s) => s.rel_path)
+      .map((s) => [(s.rel_path as string).replace(/\.md$/, ''), s]),
   );
   const claims = new Map(
     (model?.claims ?? [])
       .filter((c) => c.claim_key)
       .map((c) => [c.claim_key as string, c.claim]),
   );
-  return (kind, token) =>
-    kind === 'source'
-      ? sources.get(token) ?? null
-      : kind === 'claim'
-        ? claims.get(token) ?? null
+  const sourceRow = (token: string) => {
+    const exact = bySha.get(token);
+    if (exact) return exact;
+    if (!/^[0-9a-f]{24,}$/i.test(token)) return undefined;
+    const head = token.slice(0, SHA_HEAD);
+    const cands = rows.filter(
+      (s) => s.sha256.startsWith(token) || s.sha256.startsWith(head),
+    );
+    return cands.length === 1 ? cands[0] : undefined;
+  };
+  return (kind, rawToken) => {
+    // Legacy answers doubled the kind: "card:card:<path>:0".
+    const token =
+      (kind === 'card' || kind === 'unit') && rawToken.startsWith(`${kind}:`)
+        ? rawToken.slice(kind.length + 1)
+        : rawToken;
+    if (kind === 'source') {
+      const hit = sourceRow(token);
+      return hit
+        ? { title: hit.title || null, link: `/library/${hit.sha256}` }
         : null;
+    }
+    if (kind === 'claim') {
+      const text = claims.get(token);
+      return text ? { title: text } : null;
+    }
+    if (kind === 'card' || kind === 'unit') {
+      const body = legacyPathBody(token);
+      const hit = byPath.get(body);
+      if (hit) {
+        return { title: hit.title || null, link: `/library/${hit.sha256}` };
+      }
+      const human = humanizeLegacyPath(body);
+      return human ? { title: human } : null;
+    }
+    return null;
+  };
 }
 
 /** Build citation chips from answer text alone (saved-chat replay). */
@@ -167,20 +236,36 @@ export function citationsFromAnswerText(
     // link/display through the bare first token — otherwise replay builds
     // /library/<sha>%20Some%20Title.
     const rest = kind ? id.slice(id.indexOf(':') + 1) : id;
-    const token = (rest.trim().split(/\s+/)[0] ?? '').replace(/^<|>$/g, '');
+    let token = (rest.trim().split(/\s+/)[0] ?? '').replace(/^<|>$/g, '');
+    // Legacy answers doubled the kind ("card:card:<path>:0") — collapse so
+    // stored ids and lookups see the clean form.
+    if (kind && token.startsWith(`${kind}:`)) {
+      token = token.slice(kind.length + 1);
+    }
     const canonical = kind ? `${kind}:${token}` : token;
+    const isLegacy = kind === 'card' || kind === 'unit';
+    const res = lookup?.(kind, token);
     // Canonical index title first (the vault's own display title), then any
-    // title the model decorated into the marker, then the hash fallback.
+    // title the model decorated into the marker, then humanized legacy
+    // paths, then the hash fallback.
     const title =
-      lookup?.(kind, token) ??
+      res?.title ??
       decoratedTitle(rest) ??
-      (kind === 'source' ? shortSourceLabel(token) : canonical);
+      (kind === 'source'
+        ? shortSourceLabel(token)
+        : isLegacy
+          ? humanizeLegacyPath(legacyPathBody(token)) ?? canonical
+          : canonical);
     return {
       id: canonical,
       kind,
       title,
       snippet: null,
-      link_target: citeLinkTarget(canonical),
+      // Sources link fail-closed once the index was consulted: an unknown
+      // (stale/mangled) id must not produce a /library link that 404s.
+      link_target:
+        res?.link ??
+        (kind === 'source' && lookup ? null : citeLinkTarget(canonical)),
       // Saved transcript does not re-run the verifier — verification state
       // is UNKNOWN, and claiming either way would misrepresent receipts
       // (a fabricated marker must not come back "verified" after refresh).
@@ -198,10 +283,13 @@ function citationTitle(c: AskCitation, lookup?: CitationTitleLookup): string {
   const token = (c.id.includes(':') ? c.id.slice(c.id.indexOf(':') + 1) : c.id)
     .split(/\s+/)[0] ?? c.id;
   const fromIndex = lookup?.(kind, token);
-  if (fromIndex) return fromIndex;
+  if (fromIndex?.title) return fromIndex.title;
   if (c.title && c.title.trim() && c.title !== c.id) return c.title;
   if (kind === 'source') {
     return shortSourceLabel(token);
+  }
+  if (kind === 'card' || kind === 'unit') {
+    return humanizeLegacyPath(legacyPathBody(token)) ?? c.title ?? c.id;
   }
   return c.title ?? c.id;
 }


### PR DESCRIPTION
Follow-up to #387 — operator found two remaining citation-rail gaps on `/ask/chat/web-ms5oakt4-vvpf41`:

1. **Model-mangled source ids**: the model elided the middle of a 64-char sha (`…b9539c3ec5d2cce4f9c1` written as `…b9539c9c1`). Now resolved by unique 24-hex-char head match (96 intact bits, ambiguous heads refuse to guess).
2. **Legacy card/unit citations** from pre-agent chats: doubled kind prefix (`card:card:…`) collapsed; the embedded vault path resolves to the indexed source for a real title + working Open link, or humanizes the sanitized filename (`4b1d798e-2026-03-29_Working_with_evals___` → "Working with evals"). Degenerate `...:0` markers stay honest.
3. Unknown source ids no longer produce `/library/<garbage>` links that 404 — fail-closed once the index was consulted, matching the server receipts philosophy.

Verified against the real vault index: the mangled sha resolves to its true title/link; legacy reader paths (not index-covered) degrade to readable humanized titles. 72/72 console-ui tests green (5 new), tsc clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved citation resolution for replayed and recovered answers.
  * Legacy citation formats now resolve to the correct titles and links when possible.
  * Ambiguous or invalid citations no longer link to guessed destinations.
  * Normalized legacy citation markers and improved readable fallback titles for older paths.
  * Enhanced citation tooltips and panel titles with more accurate source names.

* **Tests**
  * Added coverage for legacy, ambiguous, malformed, and unresolved citation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->