### PR TITLE
feat(source): full-document source view + richer markdown rendering

### DIFF
--- a/console-ui/src/design/portal.css
+++ b/console-ui/src/design/portal.css
@@ -1006,6 +1006,66 @@ body {
 .md-block pre.md-frontmatter {
   color: var(--muted);
 }
+/* Collapsed provenance block (replaces the raw YAML wall). */
+.md-block details.md-frontmatter {
+  margin: 0 0 0.9rem;
+  border: 1px solid var(--border);
+  border-radius: var(--ovp-radius-input);
+  background: var(--surface-2);
+}
+.md-block details.md-frontmatter summary {
+  cursor: pointer;
+  padding: 0.35rem 0.7rem;
+  font-size: var(--ovp-text-xs);
+  color: var(--muted);
+  user-select: none;
+}
+.md-block details.md-frontmatter pre {
+  margin: 0;
+  border: 0;
+  border-top: 1px solid var(--border);
+  border-radius: 0;
+  color: var(--muted);
+  max-height: 16rem;
+  overflow-y: auto;
+}
+/* GFM tables */
+.md-block table {
+  border-collapse: collapse;
+  margin: 0 0 0.9rem;
+  font-size: var(--ovp-text-sm);
+  max-width: 100%;
+  display: block;
+  overflow-x: auto;
+}
+.md-block th,
+.md-block td {
+  border: 1px solid var(--border);
+  padding: 0.3rem 0.65rem;
+  vertical-align: top;
+}
+.md-block th {
+  background: var(--surface-2);
+  font-weight: 600;
+}
+/* Obsidian callouts: "> [!note] …" renders with a type label. */
+.md-block blockquote.md-callout {
+  border-left-color: var(--accent);
+}
+.md-block .md-callout-tag {
+  display: inline-block;
+  font-size: var(--ovp-text-xs);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--accent);
+  margin-bottom: 0.15rem;
+}
+.md-block mark {
+  background: var(--accent-soft);
+  color: inherit;
+  border-radius: 3px;
+  padding: 0 0.1em;
+}
 .md-block code {
   font-family: var(--ovp-font-mono);
   font-size: 0.9em;

--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -221,6 +221,7 @@ export const en = {
   'source.tabMemory': 'Memory',
   'source.tabMemoryCounts': '{cards} cards · {units} units',
   'source.tabSource': 'Source',
+  'source.frontmatter': 'Properties (frontmatter)',
   'source.cardsTitle': 'Cards',
   'source.cardsHint':
     'Readable distillations of this source — every statement traceable to a grounded unit below.',

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -211,6 +211,7 @@ export const zh: Record<keyof typeof en, string> = {
   'source.tabMemory': '记忆',
   'source.tabMemoryCounts': '{cards} 卡片 · {units} 单元',
   'source.tabSource': '原文',
+  'source.frontmatter': '属性（frontmatter）',
   'source.cardsTitle': '卡片',
   'source.cardsHint': '本源的可读提炼——每句话都可追溯到下方的接地单元。',
   'source.groundedUnits': '接地单元',

--- a/console-ui/src/lib/markdown.test.tsx
+++ b/console-ui/src/lib/markdown.test.tsx
@@ -4,7 +4,7 @@
  * is invalid markup with two competing navigations). */
 import { isValidElement, type ReactElement, type ReactNode } from 'react';
 import { describe, expect, it } from 'vitest';
-import { renderInline, type InlineMarker } from './markdown';
+import { parseMarkdown, renderInline, type InlineMarker } from './markdown';
 
 /** Mirror of the Ask page tokenizer (requires the literal brackets). */
 const CITE_RE = /\[\s*((?:claim|card|unit):[^\]\n]+?)\s*\]/g;
@@ -108,5 +108,83 @@ describe('renderInline marker hook', () => {
   it('renders unchanged when no marker is supplied', () => {
     const out = renderInline('plain [claim:c01] text', 'k');
     expect(text(out)).toBe('plain [claim:c01] text');
+  });
+});
+
+/** Clipping-body rendering (Source tab): badge links, escapes, wiki-links,
+ * highlights — the mini renderer must not leak raw syntax to the page. */
+describe('renderInline clipping syntax', () => {
+  it('renders a badge [![alt](img)](href) as ONE anchor, no dangling parens', () => {
+    const out = renderInline(
+      '[![CI](https://img.shields.io/ci.svg)](https://example.com/ci)',
+      'k',
+    );
+    const anchors = flatten(out).filter(
+      (n): n is ReactElement => isValidElement(n) && n.type === 'a',
+    );
+    expect(anchors).toHaveLength(1);
+    expect((anchors[0] as ReactElement<{ href: string }>).props.href).toBe(
+      'https://example.com/ci',
+    );
+    expect(text(out)).toBe('[image: CI]');
+  });
+
+  it('makes a bare image a clickable chip without remote loading', () => {
+    const out = renderInline('![alt](https://img.example/x.png)', 'k');
+    const anchors = flatten(out).filter(
+      (n): n is ReactElement => isValidElement(n) && n.type === 'a',
+    );
+    expect(anchors).toHaveLength(1);
+    expect(tags(out)).not.toContain('img');
+    expect(text(out)).toBe('[image: alt]');
+  });
+
+  it('unescapes clipper backslashes ("1\\. Codex")', () => {
+    const out = renderInline('1\\. Codex \\| a\\_b', 'k');
+    expect(text(out)).toBe('1. Codex | a_b');
+  });
+
+  it('renders wiki-links as their display text', () => {
+    expect(text(renderInline('see [[Ray Dalio]] here', 'k'))).toBe(
+      'see Ray Dalio here',
+    );
+    expect(text(renderInline('[[Note|Alias]]', 'k'))).toBe('Alias');
+  });
+
+  it('renders ==highlights== as mark', () => {
+    const out = renderInline('a ==key phrase== b', 'k');
+    expect(tags(out)).toContain('mark');
+    expect(text(out)).toBe('a key phrase b');
+  });
+});
+
+describe('parseMarkdown tables', () => {
+  it('parses a GFM table with alignment', () => {
+    const blocks = parseMarkdown(
+      ['| Name | Cost |', '| :--- | ---: |', '| a | 1 |', '| b | 2 |', '', 'after'].join('\n'),
+    );
+    const table = blocks.find((b) => b.kind === 'table');
+    expect(table).toBeDefined();
+    if (table?.kind !== 'table') return;
+    expect(table.header).toEqual(['Name', 'Cost']);
+    expect(table.aligns).toEqual(['left', 'right']);
+    expect(table.rows.map((r) => r.cells)).toEqual([
+      ['a', '1'],
+      ['b', '2'],
+    ]);
+    // The trailing paragraph is its own block, not absorbed into the table.
+    expect(blocks[blocks.length - 1]).toMatchObject({ kind: 'para' });
+  });
+
+  it('does not treat a pipe line without a separator as a table', () => {
+    const blocks = parseMarkdown('a | b\nno separator here\n');
+    expect(blocks.every((b) => b.kind !== 'table')).toBe(true);
+  });
+
+  it('keeps escaped pipes inside cells', () => {
+    const blocks = parseMarkdown('| a \\| b | c |\n| --- | --- |\n| d | e |\n');
+    const table = blocks[0];
+    if (table.kind !== 'table') throw new Error('expected table');
+    expect(table.header).toEqual(['a | b', 'c']);
   });
 });

--- a/console-ui/src/lib/markdown.tsx
+++ b/console-ui/src/lib/markdown.tsx
@@ -34,10 +34,62 @@ export type MdBlock =
       items: { line: number; text: string }[];
     }
   | { kind: 'hr'; line: number; end: number }
+  | {
+      kind: 'table';
+      line: number;
+      end: number;
+      header: string[];
+      aligns: ('left' | 'center' | 'right' | null)[];
+      rows: { line: number; cells: string[] }[];
+    }
   | { kind: 'frontmatter'; line: number; end: number; text: string };
 
 const LIST_ITEM = /^\s{0,3}(?:([-*+])|(\d{1,9})[.)])\s+(.*)$/;
 const HR = /^ {0,3}(?:-{3,}|\*{3,}|_{3,})\s*$/;
+
+// --- GFM tables: header row + |---|---| separator, rows until a blank or
+// non-table line. Cells split on unescaped pipes.
+const TABLE_SEP = /^\s*\|?(?:\s*:?-{3,}:?\s*\|)+\s*:?-{3,}:?\s*\|?\s*$/;
+
+function splitTableRow(line: string): string[] {
+  const cells: string[] = [];
+  let cur = '';
+  for (let i = 0; i < line.length; i += 1) {
+    const ch = line[i];
+    if (ch === '\\' && line[i + 1] === '|') {
+      cur += '|';
+      i += 1;
+    } else if (ch === '|') {
+      cells.push(cur);
+      cur = '';
+    } else {
+      cur += ch;
+    }
+  }
+  cells.push(cur);
+  if (cells.length > 0 && cells[0].trim() === '') cells.shift();
+  if (cells.length > 0 && cells[cells.length - 1].trim() === '') cells.pop();
+  return cells.map((c) => c.trim());
+}
+
+function tableAligns(sep: string): ('left' | 'center' | 'right' | null)[] {
+  return splitTableRow(sep).map((cell) => {
+    const left = cell.startsWith(':');
+    const right = cell.endsWith(':');
+    if (left && right) return 'center';
+    if (right) return 'right';
+    if (left) return 'left';
+    return null;
+  });
+}
+
+/** A table starts here when this line holds a pipe and the NEXT line is the
+ * separator row (GFM requires both). */
+function tableStart(lines: string[], i: number): boolean {
+  return (
+    i + 1 < lines.length && lines[i].includes('|') && TABLE_SEP.test(lines[i + 1])
+  );
+}
 
 /** `## Title` → level 2. ATX only, requires the space (v1 parity). */
 function heading(line: string): { level: number; text: string } | null {
@@ -129,6 +181,20 @@ export function parseMarkdown(md: string): MdBlock[] {
       continue;
     }
 
+    if (tableStart(lines, i)) {
+      const header = splitTableRow(lines[i]);
+      const aligns = tableAligns(lines[i + 1]);
+      const rows: { line: number; cells: string[] }[] = [];
+      let j = i + 2;
+      while (j < lines.length && lines[j].trim() !== '' && lines[j].includes('|')) {
+        rows.push({ line: j + 1, cells: splitTableRow(lines[j]) });
+        j += 1;
+      }
+      blocks.push({ kind: 'table', line: lineNo, end: j, header, aligns, rows });
+      i = j;
+      continue;
+    }
+
     const li = LIST_ITEM.exec(line);
     if (li) {
       const ordered = li[2] !== undefined;
@@ -155,7 +221,8 @@ export function parseMarkdown(md: string): MdBlock[] {
       !heading(lines[j]) &&
       !lines[j].startsWith('>') &&
       !LIST_ITEM.test(lines[j]) &&
-      !HR.test(lines[j])
+      !HR.test(lines[j]) &&
+      !tableStart(lines, j)
     ) {
       body.push(lines[j]);
       j += 1;
@@ -179,8 +246,15 @@ export function safeLinkHref(url: string): string | null {
   return null;
 }
 
+// Token order matters: linked image (badge) before image before wikilink
+// before plain link — the longer bracket patterns must win.
 const INLINE =
-  /(!\[[^\]]*\]\([^)]*\))|(\[[^\]]+\]\([^)]*\))|(`[^`]+`)|(\*\*[^*]+\*\*)|(\*[^*\s][^*]*\*)/;
+  /(\[!\[[^\]]*\]\([^)]*\)\]\([^)]*\))|(!\[[^\]]*\]\([^)]*\))|(\[\[[^\]\n]+\]\])|(\[[^\]]+\]\([^)]*\))|(`[^`]+`)|(\*\*[^*]+\*\*)|(\*[^*\s][^*]*\*)|(==[^=\n]+==)/;
+
+/** Clippers escape markdown punctuation literally ("1\. Codex") — strip the
+ * backslash for the punctuation set CommonMark allows. Code spans never
+ * pass through here (they tokenize first), so `\` inside code survives. */
+const UNESCAPE = /\\([\\`*_[\]{}()#+.!|>~-])/g;
 
 /** Marker hook for the inline pass: plain-text runs are additionally split
  * on `pattern` (which MUST carry the `g` flag) and each match is handed to
@@ -210,8 +284,9 @@ export function renderInline(
   // a product failure. Trailing punctuation stays text; the href is the
   // matched URL verbatim (still only http/https — no scheme smuggling).
   const AUTOLINK = /https?:\/\/[^\s<>"'`\]}]+/g;
-  const pushText = (chunk: string) => {
-    if (chunk === '') return;
+  const pushText = (raw: string) => {
+    if (raw === '') return;
+    const chunk = raw.replace(UNESCAPE, '$1');
     if (!autolink) {
       out.push(chunk);
       return;
@@ -286,14 +361,47 @@ export function renderInline(
     k += 1;
 
     if (m[1]) {
-      // Image → alt-text placeholder; no remote loading in B2.
-      const alt = /^!\[([^\]]*)\]/.exec(token)?.[1] ?? '';
+      // Linked image (badges: [![alt](src)](href)) — one anchor, the image
+      // stays an alt-text chip (no remote loading, B2), no dangling "(url)".
+      const parts = /^\[!\[([^\]]*)\]\(([^)]*)\)\]\(([^)]*)\)$/.exec(token);
+      const alt = parts?.[1] ?? '';
+      const href = safeLinkHref(parts?.[3] ?? '');
+      const chip = `[image${alt ? `: ${alt}` : ''}]`;
       out.push(
-        <span key={key} className="md-img-placeholder">
-          [image{alt ? `: ${alt}` : ''}]
-        </span>,
+        href ? (
+          <a key={key} href={href} target="_blank" rel="noreferrer">
+            <span className="md-img-placeholder">{chip}</span>
+          </a>
+        ) : (
+          <span key={key} className="md-img-placeholder">
+            {chip}
+          </span>
+        ),
       );
     } else if (m[2]) {
+      // Image → CLICKABLE alt-text chip; still no remote loading in B2.
+      const im = /^!\[([^\]]*)\]\(([^)]*)\)$/.exec(token);
+      const alt = im?.[1] ?? '';
+      const src = safeLinkHref(im?.[2] ?? '');
+      const chip = `[image${alt ? `: ${alt}` : ''}]`;
+      out.push(
+        src ? (
+          <a key={key} href={src} target="_blank" rel="noreferrer">
+            <span className="md-img-placeholder">{chip}</span>
+          </a>
+        ) : (
+          <span key={key} className="md-img-placeholder">
+            {chip}
+          </span>
+        ),
+      );
+    } else if (m[3]) {
+      // Obsidian wiki-link: [[Note]] / [[Note|Alias]] → plain text (the
+      // portal can't resolve vault-internal targets).
+      const body = token.slice(2, -2);
+      const pipe = body.indexOf('|');
+      out.push(pipe >= 0 ? body.slice(pipe + 1) : body);
+    } else if (m[4]) {
       const lm = /^\[([^\]]+)\]\(([^)]*)\)$/.exec(token);
       const label = lm?.[1] ?? token;
       const href = safeLinkHref(lm?.[2] ?? '');
@@ -310,15 +418,19 @@ export function renderInline(
       } else {
         out.push(label);
       }
-    } else if (m[3]) {
+    } else if (m[5]) {
       out.push(<code key={key}>{token.slice(1, -1)}</code>);
-    } else if (m[4]) {
+    } else if (m[6]) {
       out.push(
         <strong key={key}>{renderInline(token.slice(2, -2), key, marker)}</strong>,
       );
-    } else {
+    } else if (m[7]) {
       out.push(
         <em key={key}>{renderInline(token.slice(1, -1), key, marker)}</em>,
+      );
+    } else {
+      out.push(
+        <mark key={key}>{renderInline(token.slice(2, -2), key, marker)}</mark>,
       );
     }
     rest = rest.slice(m.index + token.length);
@@ -328,7 +440,12 @@ export function renderInline(
 
 // ---------------------------------------------------------------- renderer
 
-function blockBody(block: MdBlock, key: string, marker?: InlineMarker): ReactNode {
+function blockBody(
+  block: MdBlock,
+  key: string,
+  marker?: InlineMarker,
+  frontmatterLabel = 'metadata',
+): ReactNode {
   switch (block.kind) {
     case 'heading': {
       const inner = renderInline(block.text, key, marker);
@@ -354,16 +471,50 @@ function blockBody(block: MdBlock, key: string, marker?: InlineMarker): ReactNod
           <code>{block.text}</code>
         </pre>
       );
-    case 'quote':
+    case 'quote': {
+      // Obsidian callout: "> [!note] Title" — lift the marker into a small
+      // type label instead of leaking the bracket syntax into the text.
+      const cm = /^\[!(\w+)\][+-]?\s*(.*)$/.exec(block.lines[0] ?? '');
+      const lines = cm ? [cm[2], ...block.lines.slice(1)] : block.lines;
       return (
-        <blockquote>
-          {block.lines.map((l, n) => (
+        <blockquote
+          className={cm ? 'md-callout' : undefined}
+          data-callout={cm ? cm[1].toLowerCase() : undefined}
+        >
+          {cm && <span className="md-callout-tag">{cm[1].toLowerCase()}</span>}
+          {lines.map((l, n) => (
             <span key={`${key}-q${n}`}>
               {n > 0 && <br />}
               {renderInline(l, `${key}-q${n}`, marker)}
             </span>
           ))}
         </blockquote>
+      );
+    }
+    case 'table':
+      return (
+        <table>
+          <thead>
+            <tr>
+              {block.header.map((cell, n) => (
+                <th key={`${key}-h${n}`} style={{ textAlign: block.aligns[n] ?? undefined }}>
+                  {renderInline(cell, `${key}-h${n}`, marker)}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {block.rows.map((row, r) => (
+              <tr key={`${key}-r${r}`}>
+                {row.cells.map((cell, n) => (
+                  <td key={`${key}-r${r}c${n}`} style={{ textAlign: block.aligns[n] ?? undefined }}>
+                    {renderInline(cell, `${key}-r${r}c${n}`, marker)}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
       );
     case 'list': {
       const items = block.items.map((it, n) => (
@@ -376,10 +527,16 @@ function blockBody(block: MdBlock, key: string, marker?: InlineMarker): ReactNod
     case 'hr':
       return <hr />;
     case 'frontmatter':
+      // Collapsed by default — clipping frontmatter is provenance metadata,
+      // not prose; a wall of YAML above every article read as broken
+      // rendering to the operator.
       return (
-        <pre className="md-frontmatter">
-          <code>{block.text}</code>
-        </pre>
+        <details className="md-frontmatter">
+          <summary>{frontmatterLabel}</summary>
+          <pre>
+            <code>{block.text}</code>
+          </pre>
+        </details>
       );
   }
 }
@@ -395,6 +552,8 @@ export interface MarkdownViewProps {
   gutter?: boolean;
   /** Inline marker hook — see InlineMarker (Ask citation markers). */
   marker?: InlineMarker;
+  /** Summary label for the collapsed frontmatter block (localized). */
+  frontmatterLabel?: string;
 }
 
 /** The ~720px-measure reading view with a line-number gutter. Blocks whose
@@ -406,6 +565,7 @@ export function MarkdownView({
   highlightLine,
   gutter = true,
   marker,
+  frontmatterLabel,
 }: MarkdownViewProps) {
   // Parsing walks the whole document — memoize per markdown string so
   // unrelated re-renders (highlight changes, anchor sets) don't re-parse.
@@ -449,7 +609,9 @@ export function MarkdownView({
             {gutter && (
               <span className="gut">{anchor != null ? `L${anchor}` : ''}</span>
             )}
-            <div className="md-block">{blockBody(b, `b${b.line}`, marker)}</div>
+            <div className="md-block">
+              {blockBody(b, `b${b.line}`, marker, frontmatterLabel)}
+            </div>
           </div>
         );
       })}

--- a/console-ui/src/pages/SourceDetailPage.tsx
+++ b/console-ui/src/pages/SourceDetailPage.tsx
@@ -177,15 +177,16 @@ export default function SourceDetailPage() {
   // Bumped after a tag write so the detail (and its rebuilt tags) reloads.
   const [version, setVersion] = useState(0);
   const { detail, status } = useSourceDetail(sha, version);
-  // Tab is URL-parameterized (?tab=source) — shareable deep links, same
-  // rule as the Library facets (design §5).
+  // Tab is URL-parameterized (?tab=memory) — shareable deep links, same
+  // rule as the Library facets (design §5). Default is the full SOURCE
+  // rendering (operator finding: the memory tab alone reads as excerpts).
   const [searchParams, setSearchParams] = useSearchParams();
-  const tab: Tab = searchParams.get('tab') === 'source' ? 'source' : 'memory';
+  const tab: Tab = searchParams.get('tab') === 'memory' ? 'memory' : 'source';
   const setTab = (next: Tab) => {
     setSearchParams(
       (prev) => {
         const p = new URLSearchParams(prev);
-        if (next === 'source') p.set('tab', 'source');
+        if (next === 'memory') p.set('tab', 'memory');
         else p.delete('tab');
         return p;
       },
@@ -363,6 +364,13 @@ export default function SourceDetailPage() {
           <div className="tab-row">
             <button
               type="button"
+              className={tab === 'source' ? 'active' : ''}
+              onClick={() => setTab('source')}
+            >
+              {t('source.tabSource')} <span className="mono muted tiny">md</span>
+            </button>
+            <button
+              type="button"
               className={tab === 'memory' ? 'active' : ''}
               onClick={() => setTab('memory')}
             >
@@ -375,13 +383,6 @@ export default function SourceDetailPage() {
                 })}
                 )
               </span>
-            </button>
-            <button
-              type="button"
-              className={tab === 'source' ? 'active' : ''}
-              onClick={() => setTab('source')}
-            >
-              {t('source.tabSource')} <span className="mono muted tiny">md</span>
             </button>
           </div>
 
@@ -453,6 +454,7 @@ export default function SourceDetailPage() {
                     markdown={doc.markdown}
                     anchoredLines={anchoredLines}
                     highlightLine={highlightLine}
+                    frontmatterLabel={t('source.frontmatter')}
                   />
                   {doc.truncated && (
                     <div className="doc-note tiny muted">


### PR DESCRIPTION
Operator findings on `/library/<sha>`:

1. **"The view only has excerpts"** — the page defaulted to the Memory tab (cards + grounded-unit quotes). Now defaults to the full rendered source document; Memory stays one click away (`?tab=memory`, deep links unchanged).
2. **"Rendering looks wrong"** — extended the dependency-free mini renderer for real clipping bodies:
   - GFM tables → real `<table>` with column alignment
   - `[![badge](img)](href)` → one clean anchor (was: alt-text chip + dangling `(url)` text)
   - images → clickable alt-text chips (B2 no-remote-loading preserved)
   - `[[wiki-links]]` → display text, `> [!callout]` → labeled quote, `==highlight==` → `<mark>`
   - CommonMark backslash unescape (clipper output like `## 1\. Codex` rendered the backslash literally)
   - frontmatter → collapsed `<details>` (localized label) instead of a YAML wall

80/80 console-ui tests green (8 new renderer tests), tsc clean.