### PR TITLE
feat(search): full-text source-body search in portal /api/search

### DIFF
--- a/crates/ovp-memory/src/vault_tools.rs
+++ b/crates/ovp-memory/src/vault_tools.rs
@@ -1004,6 +1004,33 @@ fn search_fulltext_at(
     )
 }
 
+/// Portal searches have no agent turn to protect — generous wall clock.
+const PORTAL_FULLTEXT_DEADLINE: Duration = Duration::from_secs(5);
+
+/// Portal `/api/search` entry point: the SAME bounded full-text body scan
+/// the agent `search_fulltext` tool runs (the portal's metadata query only
+/// matches title/url/path — body phrases found nothing). Whole corpus from
+/// the top, no cursor; the JSON shape is the tool's:
+/// `{ hits: [{source_id, title, open_ref, snippet, matched_terms}],
+///    scanned_sources, total_sources, truncated }`.
+pub fn portal_fulltext_search(
+    vault_root: &Path,
+    model: &IndexModel,
+    query: &str,
+    limit: usize,
+) -> Value {
+    search_fulltext_at_with_budget(
+        vault_root,
+        model,
+        query,
+        None,
+        limit,
+        Instant::now(),
+        PORTAL_FULLTEXT_DEADLINE,
+        MAX_FULLTEXT_CORPUS_SCAN_BYTES,
+    )
+}
+
 #[allow(clippy::too_many_arguments)]
 fn search_fulltext_at_with_budget(
     vault_root: &Path,

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -1135,11 +1135,66 @@ fn handle_search(state: &AppState, url: &str) -> Response<std::io::Cursor<Vec<u8
         kind: None,
         status: None,
         date: None,
-        term,
+        term: term.clone(),
         tag: None,
         entity: None,
     };
-    let body = bodies::find_body(&model, &query).to_string();
+    let mut hits = bodies::find_body(&model, &query)
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    // Full-text fallback over source BODIES: the metadata query above only
+    // matches title/url/path, so a remembered phrase from inside an article
+    // found nothing (operator report). Reuses the agent's bounded scanner
+    // (ranked + snippeted); metadata hits win on duplicates, additions
+    // capped at 20.
+    if let Some(term) = term.as_deref().map(str::trim).filter(|t| !t.is_empty()) {
+        let mut seen: std::collections::HashSet<String> = hits
+            .iter()
+            .filter_map(|h| {
+                h.get("id")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_string)
+            })
+            .collect();
+        let ft =
+            ovp_memory::vault_tools::portal_fulltext_search(&state.vault_root, &model, term, 20);
+        if let Some(body_hits) = ft.get("hits").and_then(serde_json::Value::as_array) {
+            for h in body_hits {
+                let Some(sha) = h.get("source_id").and_then(serde_json::Value::as_str) else {
+                    continue;
+                };
+                if !seen.insert(sha.to_string()) {
+                    continue;
+                }
+                let source = model.sources.iter().find(|s| s.sha256 == sha);
+                let title = h
+                    .get("title")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("(untitled)");
+                let snippet = h
+                    .get("snippet")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("");
+                let status = source
+                    .map(|s| ovp_index::query::source_status_str(s.status))
+                    .unwrap_or("source");
+                let line = if snippet.is_empty() {
+                    title.to_string()
+                } else {
+                    format!("{title} — “{snippet}”")
+                };
+                hits.push(serde_json::json!({
+                    "kind": "source",
+                    "status": status,
+                    "line": line,
+                    "path": source.and_then(|s| s.rel_path.clone()),
+                    "id": sha,
+                }));
+            }
+        }
+    }
+    let body = serde_json::Value::Array(hits).to_string();
     json_stamped(200, &body, Some(&model))
 }
 
@@ -4182,6 +4237,53 @@ mod tests {
         assert_eq!(std::fs::read_to_string(&ack_file).unwrap(), written);
         let v = body_json(dispatch(&st, Method::Get, "/api/model", ""));
         assert_eq!(v["attention_acks"].as_array().unwrap().len(), 1);
+
+        let _ = std::fs::remove_dir_all(vault.parent().unwrap());
+    }
+
+    #[test]
+    fn search_falls_back_to_fulltext_body_hits() {
+        // A phrase that lives ONLY in the article body — title/url/path
+        // don't contain it, so the metadata query alone returns nothing.
+        let vault = portal_vault(
+            "search-fulltext",
+            "50-Inbox/03-Processed/good.md",
+            "# Good Article\n\nLLMs compressed the internet into weights.\n",
+        );
+        let st = state(vault.clone(), None);
+
+        // Body-only phrase → one source hit carrying the snippet in `line`.
+        let v = body_json(dispatch(
+            &st,
+            Method::Get,
+            "/api/search?q=LLMs%20compressed%20the%20internet",
+            "",
+        ));
+        let hits = v.as_array().unwrap();
+        assert_eq!(hits.len(), 1, "expected exactly the body hit: {hits:?}");
+        assert_eq!(hits[0]["kind"], "source");
+        assert_eq!(hits[0]["id"], "aaaa1111");
+        assert_eq!(hits[0]["status"], "processed");
+        assert_eq!(
+            hits[0]["path"].as_str().unwrap(),
+            "50-Inbox/03-Processed/good.md"
+        );
+        let line = hits[0]["line"].as_str().unwrap();
+        assert!(line.contains("Good Article"), "line carries title: {line}");
+        assert!(
+            line.contains("compressed"),
+            "line carries the body snippet: {line}"
+        );
+
+        // A title phrase still hits via metadata and must NOT duplicate via
+        // the body scan (the body heading also contains it — dedupe by id).
+        let v = body_json(dispatch(&st, Method::Get, "/api/search?q=Good%20Article", ""));
+        let hits = v.as_array().unwrap();
+        assert_eq!(
+            hits.iter().filter(|h| h["id"] == "aaaa1111").count(),
+            1,
+            "metadata hit must not be re-added by fulltext: {hits:?}"
+        );
 
         let _ = std::fs::remove_dir_all(vault.parent().unwrap());
     }


### PR DESCRIPTION
## Problem

Portal Search / ⌘K omnibox only matched source **title/url/rel_path** (via `run_query`). A remembered phrase from inside an article body, e.g. "LLMs compressed the internet into weights", returned nothing.

## Fix

Reuse the agent's proven `search_fulltext` scanner (ranked by language-group coverage, snippeted, deadline + corpus-budget bounded) for the portal:

- `ovp-memory`: new `pub fn portal_fulltext_search(vault_root, model, query, limit)` — same scan, portal-sized 5s deadline, no cursor.
- `ovp-server` `handle_search`: metadata hits first, then full-text body hits appended (dedupe by sha, 20-hit cap). Body hits render as `{title} — "{snippet}"` and link to `/library/<sha>`. Zero UI changes needed (existing `FindHit` shape).

## Verification

- New server test `search_falls_back_to_fulltext_body_hits` (body-only phrase hit + no dedupe regression for title matches).
- `cargo test --workspace`: all green. `clippy --workspace --all-targets -D warnings`: clean.
- Live smoke against the real vault: `q=LLMs compressed the internet into weights` → top hit **Memory Is Purpose** with the exact sentence as snippet; ~1s per query.

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced search to include matches found within source content, in addition to metadata.
  * Search results now display relevant snippets and source paths.
  * Duplicate results are automatically removed when a source matches multiple search methods.

* **Bug Fixes**
  * Improved fallback behavior for body-only search phrases while preserving accurate title-based results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->