### PR TITLE
fix(mermaid): heal truncated-README fences breaking diagram render

### DIFF
--- a/console-ui/src/lib/markdown.test.tsx
+++ b/console-ui/src/lib/markdown.test.tsx
@@ -7,6 +7,7 @@ import { describe, expect, it } from 'vitest';
 import {
   MarkdownView,
   splitFrontmatter,
+  trimAtMermaidErrorLine,
   type MarkdownViewProps,
 } from './markdown';
 
@@ -14,6 +15,46 @@ const render = (md: string, extra?: Partial<MarkdownViewProps>) =>
   renderToStaticMarkup(<MarkdownView markdown={md} gutter={false} {...extra} />);
 
 const CITE_RE = /\[\s*((?:claim|card|unit):[^\]\n]+?)\s*\]/g;
+
+describe('trimAtMermaidErrorLine (truncated-ingest healing)', () => {
+  // The 2026-07-13 TencentDB-Agent-Memory note: README cut at 8000 bytes
+  // mid-```mermaid block; the unclosed fence swallowed "*(README
+  // truncated)*" into the code and mermaid failed with "Syntax error".
+  const TRUNCATED =
+    'graph LR\n' +
+    '  Log["Verbose Logs"] --> FS[("External FS")]\n' +
+    '  style Log fill:#f1f5f9\n' +
+    '\n' +
+    '*(README truncated)*';
+
+  it('cuts the garbage tail at the parse-error line', () => {
+    const err = new Error(
+      'Parse error on line 5:\n*(README truncated)*\n———^\nExpecting ...',
+    );
+    expect(trimAtMermaidErrorLine(TRUNCATED, err)).toBe(
+      'graph LR\n' +
+        '  Log["Verbose Logs"] --> FS[("External FS")]\n' +
+        '  style Log fill:#f1f5f9\n',
+    );
+  });
+
+  it('accepts lexical-error wording too', () => {
+    const cut = trimAtMermaidErrorLine(
+      TRUNCATED,
+      new Error('Lexical error on line 3.'),
+    );
+    expect(cut).toBe('graph LR\n  Log["Verbose Logs"] --> FS[("External FS")]');
+  });
+
+  it('returns null when the error has no usable line number', () => {
+    expect(trimAtMermaidErrorLine(TRUNCATED, new Error('boom'))).toBeNull();
+    expect(trimAtMermaidErrorLine(TRUNCATED, 'nope')).toBeNull();
+    // Line 1 failures leave nothing renderable — no retry.
+    expect(
+      trimAtMermaidErrorLine(TRUNCATED, new Error('Parse error on line 1: x')),
+    ).toBeNull();
+  });
+});
 
 describe('mature-engine coverage', () => {
   it('renders a GFM table as a real table', () => {

--- a/console-ui/src/lib/markdown.tsx
+++ b/console-ui/src/lib/markdown.tsx
@@ -269,6 +269,20 @@ function Row({
 
 let mmdSeq = 0;
 
+/** Truncated READMEs (ingest cut mid-fence) leave an unclosed ```mermaid
+ * block whose "code" runs to end-of-document — the trailing prose is not a
+ * diagram and mermaid fails with "Parse error on line N". Everything before
+ * N parsed fine, so cut the tail and retry once. Returns null when the
+ * error carries no usable line number. Exported for tests. */
+export function trimAtMermaidErrorLine(code: string, err: unknown): string | null {
+  const m = /line (\d+)/i.exec(String((err as Error)?.message ?? err));
+  if (!m) return null;
+  const lineNo = Number(m[1]);
+  if (!Number.isFinite(lineNo) || lineNo < 2) return null;
+  const cut = code.split('\n').slice(0, lineNo - 1).join('\n');
+  return cut.trim() ? cut : null;
+}
+
 /** ```mermaid fence → SVG via the mermaid engine, loaded on demand so the
  * main bundle stays lean. Falls back to the raw code block on error. */
 function MermaidBlock({ code }: { code: string }) {
@@ -276,6 +290,7 @@ function MermaidBlock({ code }: { code: string }) {
   const [failed, setFailed] = useState(false);
   useEffect(() => {
     let cancelled = false;
+    const id = `ovp-mmd-${(mmdSeq += 1)}`;
     void (async () => {
       try {
         const { default: mermaid } = await import('mermaid');
@@ -285,13 +300,29 @@ function MermaidBlock({ code }: { code: string }) {
           securityLevel: 'strict',
           theme: dark ? 'dark' : 'neutral',
         });
-        const { svg } = await mermaid.render(`ovp-mmd-${(mmdSeq += 1)}`, code);
+        let src = code;
+        try {
+          await mermaid.parse(src);
+        } catch (e) {
+          // Heal truncated-ingest tails (see trimAtMermaidErrorLine).
+          const cut = trimAtMermaidErrorLine(src, e);
+          if (cut == null) throw e;
+          src = cut;
+          await mermaid.parse(src);
+        }
+        const { svg } = await mermaid.render(id, src);
         if (!cancelled && ref.current) {
           // Documented trust boundary (module header): strict mode + own
           // vault. Never point this at untrusted markdown.
           ref.current.innerHTML = svg;
         }
       } catch {
+        // mermaid.render/parse append their error graphic to document.body
+        // under the render id — remove it or the "Syntax error" wall
+        // lingers on the page next to our raw-code fallback.
+        for (const el of document.querySelectorAll(`#${id}, #d${id}`)) {
+          el.remove();
+        }
         if (!cancelled) setFailed(true);
       }
     })();

--- a/crates/ovp-enrich/src/github.rs
+++ b/crates/ovp-enrich/src/github.rs
@@ -387,6 +387,11 @@ fn write_github_note(
         };
         body.push_str(truncated);
         if readme.len() > 8000 {
+            // The cut can land INSIDE a fenced code block: an unclosed fence
+            // then swallows the truncation marker (and any footer) into the
+            // code — a ```mermaid fence so damaged renders as a parse error
+            // wall instead of the diagram. Close the open fence first.
+            body.push_str(&close_open_fence(truncated));
             body.push_str("\n\n*(README truncated)*");
         }
     }
@@ -466,6 +471,37 @@ fn split_frontmatter(content: &str) -> (Option<&str>, &str) {
     }
 }
 
+/// Scan markdown for an unclosed code fence; return the closing fence line
+/// ("\n```"/"\n~~~", matching the opener's char + length) or "" when every
+/// fence is closed. CommonMark rules: opener = ≥3 backticks/tildes + info;
+/// closer = same char, ≥ opener length, empty info string (a fence-looking
+/// line WITH an info string inside a block is content, not a closer).
+fn close_open_fence(md: &str) -> String {
+    let mut open: Option<(char, usize)> = None;
+    for line in md.lines() {
+        let t = line.trim_start();
+        let (ch, len) = if t.starts_with("```") {
+            ('`', t.chars().take_while(|c| *c == '`').count())
+        } else if t.starts_with("~~~") {
+            ('~', t.chars().take_while(|c| *c == '~').count())
+        } else {
+            continue;
+        };
+        let after = &t[len..];
+        match open {
+            None => open = Some((ch, len)),
+            Some((och, olen)) if ch == och && len >= olen && after.trim().is_empty() => {
+                open = None;
+            }
+            _ => {}
+        }
+    }
+    match open {
+        Some((ch, len)) => format!("\n{}", ch.to_string().repeat(len)),
+        None => String::new(),
+    }
+}
+
 fn chrono_now_iso() -> String {
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -517,6 +553,25 @@ struct FixturePayload {
 mod tests {
     use super::*;
     use std::fs;
+
+    #[test]
+    fn close_open_fence_closes_unclosed_backtick_fence() {
+        // The 2026-07-13 TencentDB-Agent-Memory note: README cut at 8000
+        // bytes landed mid-```mermaid block; the marker line got swallowed
+        // into the code and mermaid failed with "Syntax error in text".
+        let md = "# T\n\n```mermaid\ngraph LR\n  A --> B\n  style A fill:#fff\n";
+        assert_eq!(close_open_fence(md), "\n```");
+        // Already-closed fences stay untouched.
+        let closed = "```mermaid\ngraph LR\n```\ntail\n";
+        assert_eq!(close_open_fence(closed), "");
+        // Tilde fences close with tildes; a longer closer still matches.
+        assert_eq!(close_open_fence("~~~js\nlet a = 1;\n"), "\n~~~");
+        // An info-string line inside a fence is CONTENT, not a closer.
+        let nested = "```\nplain\n```rust\nstill content per CommonMark\n";
+        assert_eq!(close_open_fence(nested), "\n```");
+        // Opener length is respected: ```` needs at least 4 backticks.
+        assert_eq!(close_open_fence("````\n```\n"), "\n````");
+    }
 
     #[test]
     fn parse_github_repo_url_valid() {


### PR DESCRIPTION
## Problem

TencentCloud/TencentDB-Agent-Memory note: mermaid diagram fails with "Syntax error in text". Root cause: the GitHub README was cut at the 8000-byte ingest cap **mid-```mermaid fence**; the unclosed fence runs to end-of-note, so the diagram's "code" includes the `*(README truncated)*` marker line, and mermaid parses prose.

## Fix (two layers)

1. **Ingest** (`ovp-enrich/src/github.rs`): when truncating, close any still-open code fence before appending the marker — new `close_open_fence` follows CommonMark open/close rules (fence char, opener length, empty info string).
2. **Renderer** (`MermaidBlock`): heals existing notes — on mermaid parse failure, cut the code at the error's reported line number and retry once; also remove mermaid's error graphic that `render`/`parse` append to `document.body` (the "Syntax error in text / mermaid version" wall) so the raw-code fallback stands alone.

## Verification

- Rust: `close_open_fence` unit tests (backtick/tilde, opener length, info-string-not-a-closer).
- UI: `trimAtMermaidErrorLine` tests (parse/lexical error wording, no-line → null); full suite 82/82, tsc clean, clippy clean.

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Mermaid diagram rendering when truncated content contains parsing errors.
  * Failed Mermaid diagrams now fall back cleanly to displaying the original code.
  * Truncated README content now preserves Markdown code fence formatting.
  * Improved cleanup of temporary Mermaid rendering elements after failures.

* **Tests**
  * Added coverage for Mermaid error recovery and Markdown fence handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->