### PR TITLE
fix(enrich,portal): full README bodies + repo-relative image resolution

### DIFF
--- a/console-ui/src/lib/markdown.test.tsx
+++ b/console-ui/src/lib/markdown.test.tsx
@@ -6,6 +6,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 import {
   MarkdownView,
+  sourceImageResolver,
   splitFrontmatter,
   trimAtMermaidErrorLine,
   type MarkdownViewProps,
@@ -53,6 +54,40 @@ describe('trimAtMermaidErrorLine (truncated-ingest healing)', () => {
     expect(
       trimAtMermaidErrorLine(TRUNCATED, new Error('Parse error on line 1: x')),
     ).toBeNull();
+  });
+});
+
+describe('sourceImageResolver (repo-relative README images)', () => {
+  const GH = sourceImageResolver('https://github.com/TencentCloud/TencentDB-Agent-Memory');
+
+  it('maps repo-relative paths to raw.githubusercontent.com/HEAD', () => {
+    expect(GH?.('./assets/images/logo.png')).toBe(
+      'https://raw.githubusercontent.com/TencentCloud/TencentDB-Agent-Memory/HEAD/assets/images/logo.png',
+    );
+    expect(GH?.('docs/pic.png')).toBe(
+      'https://raw.githubusercontent.com/TencentCloud/TencentDB-Agent-Memory/HEAD/docs/pic.png',
+    );
+  });
+
+  it('strips a .git suffix from the repo segment', () => {
+    const r = sourceImageResolver('https://github.com/o/r.git');
+    expect(r?.('./x.png')).toBe('https://raw.githubusercontent.com/o/r/HEAD/x.png');
+  });
+
+  it('passes absolute/data srcs through untouched', () => {
+    expect(GH?.('https://img.shields.io/b.svg')).toBe('https://img.shields.io/b.svg');
+    expect(GH?.('data:image/png;base64,xx')).toBe('data:image/png;base64,xx');
+  });
+
+  it('resolves non-GitHub pages by standard URL joining', () => {
+    const r = sourceImageResolver('https://example.com/blog/post');
+    expect(r?.('./img.png')).toBe('https://example.com/blog/img.png');
+    expect(r?.('/static/img.png')).toBe('https://example.com/static/img.png');
+  });
+
+  it('returns undefined without a source URL (src untouched)', () => {
+    expect(sourceImageResolver(undefined)).toBeUndefined();
+    expect(sourceImageResolver('')).toBeUndefined();
   });
 });
 

--- a/console-ui/src/lib/markdown.tsx
+++ b/console-ui/src/lib/markdown.tsx
@@ -477,6 +477,31 @@ export interface MarkdownViewProps {
   resolveImageSrc?: (src: string) => string;
 }
 
+/** Build the resolveImageSrc for a source note. Repo-relative paths
+ * (`./assets/logo.png`, a README staple) must NOT resolve against the
+ * portal origin (instant 404 broken-image); rewrite against the note's
+ * source URL. GitHub repos map to raw.githubusercontent.com/<owner>/<repo>/
+ * HEAD/<path> (github.com/... is the HTML view, not the bytes); everything
+ * else resolves via standard URL joining. Absolute/data: srcs pass through.
+ * Returns undefined when no usable base exists (src left untouched). */
+export function sourceImageResolver(
+  sourceUrl?: string,
+): ((src: string) => string) | undefined {
+  if (!sourceUrl) return undefined;
+  const gh = /^https?:\/\/github\.com\/([^/]+)\/([^/#?]+)/i.exec(sourceUrl);
+  const base = gh
+    ? `https://raw.githubusercontent.com/${gh[1]}/${gh[2].replace(/\.git$/, '')}/HEAD/`
+    : sourceUrl;
+  return (src) => {
+    if (!src || /^(?:https?:|data:|blob:|#)/i.test(src)) return src;
+    try {
+      return new URL(src, base).href;
+    } catch {
+      return src;
+    }
+  };
+}
+
 /** The ~720px-measure reading view with a line-number gutter. */
 export function MarkdownView({
   markdown,

--- a/console-ui/src/pages/SourceDetailPage.tsx
+++ b/console-ui/src/pages/SourceDetailPage.tsx
@@ -12,7 +12,7 @@ import { useI18n } from '../i18n';
 import { entityUrl, fetchSourceDetail, fetchTags, postSourceTags, STATIC_MODE } from '../lib/api';
 import { collectionOf } from '../lib/derive';
 import { isReactImeComposing } from '../lib/ime';
-import { MarkdownView } from '../lib/markdown';
+import { MarkdownView, sourceImageResolver } from '../lib/markdown';
 import type { ClaimRow, SourceDetail, SourceRow } from '../lib/types';
 
 type Tab = 'memory' | 'source';
@@ -231,6 +231,12 @@ export default function SourceDetailPage() {
 
   const { source, memory, citing_claims: citing, doc } = detail;
   const title = source.title ?? source.sha256;
+  // READMEs reference repo-relative image paths (./assets/logo.png) — they
+  // must resolve against the note's source URL, not the portal origin.
+  const resolveImageSrc = useMemo(
+    () => sourceImageResolver(source.url ?? undefined),
+    [source.url],
+  );
 
   return (
     <>
@@ -455,6 +461,7 @@ export default function SourceDetailPage() {
                     anchoredLines={anchoredLines}
                     highlightLine={highlightLine}
                     frontmatterLabel={t('source.frontmatter')}
+                    resolveImageSrc={resolveImageSrc}
                   />
                   {doc.truncated && (
                     <div className="doc-note tiny muted">

--- a/crates/ovp-cli/src/commands/daily.rs
+++ b/crates/ovp-cli/src/commands/daily.rs
@@ -23,7 +23,8 @@ use ovp_index::{
     build_evidence, build_index, build_index_with_progress, write_evidence, write_index,
 };
 use ovp_enrich::github::{
-    enrich_github_repos, parse_github_repo_url, FixtureGitHubFetch, GitHubFetch,
+    enrich_github_repos, find_truncated_github_notes, parse_github_repo_url, FixtureGitHubFetch,
+    GitHubFetch,
 };
 use ovp_enrich::web_fetch::{enrich_needs_content, FixtureWebFetch, WebFetch};
 use ovp_intake::{sweep_intake, sync_pinboard, FixturePinboardFetch, IntakeConfig, PinboardFetch};
@@ -287,7 +288,13 @@ fn run_inner(
     // Phase 2.6 — GitHub enrichment (optional).
     // Enriches needs-content sources whose URLs point to GitHub repos —
     // this run's freshly-flagged AND previously-flagged pending captures.
+    // Plus the self-healing backlog: notes written before the 100 KiB
+    // README cap still carry the legacy `*(README truncated)*` marker; the
+    // re-enrich rewrite drops the marker, so the repair list drains itself.
     if (args.github_fixture.is_some() || args.github_live) && !args.dry_run {
+        let repair = find_truncated_github_notes(&args.vault_root);
+        let repair_count = repair.len();
+        let mut seen_paths = std::collections::HashSet::new();
         let github_items: Vec<(String, String)> = sweep_needs_content
             .iter()
             .filter_map(|rec| {
@@ -300,6 +307,8 @@ fn run_inner(
                     .and_then(|u| parse_github_repo_url(u))
                     .map(|_| (from.clone(), url.clone().unwrap()))
             }))
+            .chain(repair)
+            .filter(|(rel, _)| seen_paths.insert(rel.clone()))
             .collect();
         if !github_items.is_empty() {
             let mut fetcher = build_github_fetcher(&args)?;
@@ -311,8 +320,8 @@ fn run_inner(
             let written = results.iter().filter(|r| r.written).count();
             let failed = results.iter().filter(|r| !r.written).count();
             sayln!(
-                "  github: {} repo URL(s), {} enriched, {} failed",
-                github_items.len(), written, failed,
+                "  github: {} repo URL(s) ({} truncated-note repairs), {} enriched, {} failed",
+                github_items.len(), repair_count, written, failed,
             );
             for r in &results {
                 if !r.written

--- a/crates/ovp-enrich/src/github.rs
+++ b/crates/ovp-enrich/src/github.rs
@@ -375,9 +375,14 @@ fn write_github_note(
 
     // README content. Floor the cut to a char boundary — READMEs are routinely
     // non-ASCII (CJK/emoji), so a raw byte slice would panic mid-character.
+    // Cap at 100 KiB: the old 8000 cut most READMEs in half (the portal Source
+    // view IS the reading surface — operator: "还是摘抄，没有渲染全文");
+    // the server serves up to 200 KiB and the fulltext scanner 2 MiB, so a
+    // 100 KiB note flows through every downstream budget whole.
     if let Some(readme) = &result.readme_content {
-        let truncated = if readme.len() > 8000 {
-            let mut end = 8000;
+        const MAX_README_BYTES: usize = 100 * 1024;
+        let truncated = if readme.len() > MAX_README_BYTES {
+            let mut end = MAX_README_BYTES;
             while end > 0 && !readme.is_char_boundary(end) {
                 end -= 1;
             }
@@ -386,13 +391,16 @@ fn write_github_note(
             readme.as_str()
         };
         body.push_str(truncated);
-        if readme.len() > 8000 {
+        if readme.len() > MAX_README_BYTES {
             // The cut can land INSIDE a fenced code block: an unclosed fence
             // then swallows the truncation marker (and any footer) into the
             // code — a ```mermaid fence so damaged renders as a parse error
             // wall instead of the diagram. Close the open fence first.
             body.push_str(&close_open_fence(truncated));
-            body.push_str("\n\n*(README truncated)*");
+            // SIZED marker: the repair scan targets the legacy unsized one
+            // exactly, so a genuinely >100 KiB README is NOT re-fetched on
+            // every daily run (the backlog drains instead of looping).
+            body.push_str("\n\n*(README truncated at 100 KiB)*");
         }
     }
     body.push('\n');
@@ -469,6 +477,70 @@ fn split_frontmatter(content: &str) -> (Option<&str>, &str) {
         }
         None => (None, content),
     }
+}
+
+/// Legacy truncation marker written by the pre-100-KiB-cap ingest
+/// (2026-07-30 and earlier). New truncations carry a SIZED marker so this
+/// repair scan self-drains instead of re-fetching >100 KiB READMEs forever.
+const LEGACY_TRUNCATION_MARKER: &str = "*(README truncated)*";
+
+/// Self-healing backlog for the pre-100-KiB-cap ingest: notes under
+/// 50-Inbox whose body still carries the legacy `*(README truncated)*`
+/// marker were written with an 8 KiB README stub (127 such notes in the
+/// operator vault). Returns `(rel_path, source URL)` for those pointing at
+/// GitHub repos so daily Phase 2.6 re-enriches them once — the rewrite
+/// drops the marker and the list drains itself.
+pub fn find_truncated_github_notes(vault_root: &std::path::Path) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    let mut stack = vec![vault_root.join("50-Inbox")];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            if path.extension().and_then(|e| e.to_str()) != Some("md") {
+                continue;
+            }
+            let Ok(content) = std::fs::read_to_string(&path) else {
+                continue;
+            };
+            if !content.contains(LEGACY_TRUNCATION_MARKER) {
+                continue;
+            }
+            let Some(url) = frontmatter_source_url(&content) else {
+                continue;
+            };
+            if parse_github_repo_url(&url).is_none() {
+                continue;
+            }
+            let Ok(rel) = path.strip_prefix(vault_root) else {
+                continue;
+            };
+            out.push((rel.to_string_lossy().to_string(), url));
+        }
+    }
+    out.sort();
+    out
+}
+
+/// `source:` URL from the YAML frontmatter block (quoted or bare).
+fn frontmatter_source_url(content: &str) -> Option<String> {
+    let content = content.strip_prefix("---\n")?;
+    let fm = content.split("\n---").next()?;
+    for line in fm.lines() {
+        if let Some(rest) = line.strip_prefix("source:") {
+            let v = rest.trim().trim_matches('"');
+            if !v.is_empty() {
+                return Some(v.to_string());
+            }
+        }
+    }
+    None
 }
 
 /// Scan markdown for an unclosed code fence; return the closing fence line
@@ -571,6 +643,47 @@ mod tests {
         assert_eq!(close_open_fence(nested), "\n```");
         // Opener length is respected: ```` needs at least 4 backticks.
         assert_eq!(close_open_fence("````\n```\n"), "\n````");
+    }
+
+    #[test]
+    fn find_truncated_github_notes_targets_legacy_marker_only() {
+        let tmp = tempfile::tempdir().unwrap();
+        let vault = tmp.path();
+        let dir = vault.join("50-Inbox/03-Processed/2026-07");
+        std::fs::create_dir_all(&dir).unwrap();
+        let fm = |url: &str| {
+            format!("---\ntitle: t\nsource: \"{url}\"\nsource_type: github_repo\n---\n\nbody\n")
+        };
+        // Hit: legacy marker + github source URL.
+        std::fs::write(
+            dir.join("a.md"),
+            format!("{}\n*(README truncated)*\n", fm("https://github.com/o/r")),
+        )
+        .unwrap();
+        // Skip: legacy marker but not a GitHub repo.
+        std::fs::write(
+            dir.join("b.md"),
+            format!("{}\n*(README truncated)*\n", fm("https://example.com/blog")),
+        )
+        .unwrap();
+        // Skip: github repo but NO marker (complete note).
+        std::fs::write(dir.join("c.md"), fm("https://github.com/o/r2")).unwrap();
+        // Skip: SIZED marker — genuinely >100 KiB README, must not be
+        // re-fetched every run (the backlog would never drain).
+        std::fs::write(
+            dir.join("d.md"),
+            format!("{}\n*(README truncated at 100 KiB)*\n", fm("https://github.com/o/r3")),
+        )
+        .unwrap();
+
+        let found = find_truncated_github_notes(vault);
+        assert_eq!(
+            found,
+            vec![(
+                "50-Inbox/03-Processed/2026-07/a.md".to_string(),
+                "https://github.com/o/r".to_string()
+            )]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problems (operator report on the TencentDB-Agent-Memory source page)

1. **Source md showed an excerpt, not the full README** — the GitHub enrich capped bodies at 8000 bytes (128 vault notes carry the marker; all verified written by THIS enrich — `source_type: github_repo` + the marker string's only code source is `ovp-enrich/github.rs` — never the gitingest line).
2. **Banner image broken** — READMEs reference repo-relative paths (`./assets/images/logo.png`) which 404 against the portal origin.

## Changes

- **Cap 8000 → 100 KiB** (server serves 200 KiB, fulltext scans 2 MiB — notes flow through every downstream budget whole). New truncations get a SIZED marker (`*(README truncated at 100 KiB)*`) so the repair scan self-drains.
- **`sourceImageResolver`** (markdown.tsx): repo-relative image srcs map to `raw.githubusercontent.com/<owner>/<repo>/HEAD/...` for GitHub sources, standard URL joining otherwise; absolute/data srcs untouched. Wired into SourceDetailPage. Verified live: the banner URL returns HTTP 200 image/png.
- **Repair pass** (daily Phase 2.6): `find_truncated_github_notes` scans 50-Inbox for the legacy marker → re-enrich once; rewrite drops the marker so the backlog drains itself. Operator approved ~127 reader re-runs (sha change → next daily treats them as new sources; old packs orphaned, `doctor` cleans).

## Verification

- New tests: `find_truncated_github_notes_targets_legacy_marker_only` (legacy-only targeting incl. sized-marker skip), 5 `sourceImageResolver` tests. UI 87/87, tsc clean, clippy `-D warnings` clean, ovp-enrich/ovp-cli suites green.
- Real-vault scan: 128/128 marker notes resolve to GitHub repo URLs → all covered by the next daily run.

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Relative images in source Markdown now load correctly from their original repository or source location.
  * GitHub README imports support automatic repair of notes truncated by earlier limits.
* **Improvements**
  * README content can now include up to 100 KiB while preserving valid Markdown formatting.
  * Truncation notices specify the applied size limit.
* **Bug Fixes**
  * Improved handling of repository image links and legacy truncated README notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->