### PR TITLE
fix(portal): white screen on source detail — hook after early return

### DIFF
--- a/console-ui/src/components/ErrorBoundary.tsx
+++ b/console-ui/src/components/ErrorBoundary.tsx
@@ -1,0 +1,47 @@
+/** Error boundary around page content: a render crash must not unmount the
+ * whole SPA into a dead white screen (2026-07-29: a hook placed after the
+ * loading early-return fired only on the loading→ready transition and took
+ * the entire app down). The nav chrome survives, the message is readable,
+ * and Shell keys this boundary by pathname so route changes reset it. */
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+interface Props {
+  title: string;
+  hint: string;
+  children: ReactNode;
+}
+
+interface State {
+  error: Error | null;
+}
+
+export default class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('portal page crash:', error, info.componentStack);
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div className="card warn" style={{ marginTop: '1rem' }}>
+          <p className="sm">
+            <strong>{this.props.title}</strong>
+          </p>
+          <p className="tiny muted mono">
+            {String(this.state.error.message ?? this.state.error)}
+          </p>
+          <p className="tiny muted" style={{ marginBottom: 0 }}>
+            {this.props.hint}
+          </p>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/console-ui/src/components/Shell.tsx
+++ b/console-ui/src/components/Shell.tsx
@@ -15,6 +15,7 @@ import { useModel } from '../model';
 import { useTheme } from '../theme';
 import { STATIC_MODE } from '../lib/api';
 import { isDesktopApp, openInSystemBrowser } from '../lib/desktopExternalLinks';
+import ErrorBoundary from './ErrorBoundary';
 import RunBanner from './RunBanner';
 import SearchOmnibox from './SearchOmnibox';
 
@@ -228,7 +229,14 @@ export default function Shell() {
             </nav>
           </div>
           <div className="shell-body">
-            <Outlet />
+            {/* key=pathname: navigating after a crash resets the boundary. */}
+            <ErrorBoundary
+              key={location.pathname}
+              title={t('error.pageTitle')}
+              hint={t('error.pageHint')}
+            >
+              <Outlet />
+            </ErrorBoundary>
           </div>
         </div>
       </div>

--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -218,6 +218,9 @@ export const en = {
   'source.notFound': 'No source with this id in the index.',
   'source.backToLibrary': 'Library',
   'source.loadError': 'Could not load the source detail — is the server running?',
+  'error.pageTitle': 'Something went wrong rendering this page.',
+  'error.pageHint':
+    'Use the navigation above to keep browsing — reopening the page retries.',
   'source.tabMemory': 'Memory',
   'source.tabMemoryCounts': '{cards} cards · {units} units',
   'source.tabSource': 'Source',

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -208,6 +208,8 @@ export const zh: Record<keyof typeof en, string> = {
   'source.notFound': '索引中没有这个 id 对应的源。',
   'source.backToLibrary': '资料',
   'source.loadError': '无法加载资料详情——服务是否在运行？',
+  'error.pageTitle': '这一页渲染出错了。',
+  'error.pageHint': '可以用上方导航继续浏览；重新打开这一页会重试。',
   'source.tabMemory': '记忆',
   'source.tabMemoryCounts': '{cards} 卡片 · {units} 单元',
   'source.tabSource': '原文',

--- a/console-ui/src/pages/SourceDetailPage.tsx
+++ b/console-ui/src/pages/SourceDetailPage.tsx
@@ -205,6 +205,15 @@ export default function SourceDetailPage() {
     [detail],
   );
 
+  // READMEs reference repo-relative image paths (./assets/logo.png) — they
+  // must resolve against the note's source URL, not the portal origin.
+  // HOOKS RULE: this useMemo must stay ABOVE the status early-returns below
+  // — a hook that only runs once `detail` is ready changes the hook count
+  // between renders and React unmounts the whole app (the 2026-07-29
+  // OpenChatCut white screen).
+  const sourceUrl = detail?.source.url ?? undefined;
+  const resolveImageSrc = useMemo(() => sourceImageResolver(sourceUrl), [sourceUrl]);
+
   const jumpToLine = (line: number) => {
     setTab('source');
     setHighlightLine(line);
@@ -231,12 +240,6 @@ export default function SourceDetailPage() {
 
   const { source, memory, citing_claims: citing, doc } = detail;
   const title = source.title ?? source.sha256;
-  // READMEs reference repo-relative image paths (./assets/logo.png) — they
-  // must resolve against the note's source URL, not the portal origin.
-  const resolveImageSrc = useMemo(
-    () => sourceImageResolver(source.url ?? undefined),
-    [source.url],
-  );
 
   return (
     <>


### PR DESCRIPTION
## Problem

Clicking any Library entry (reported: 0xsline/OpenChatCut) white-screened the whole app. Root cause: PR #393's `resolveImageSrc` useMemo was placed BELOW SourceDetailPage's loading/error/notFound early returns. First render (loading) skips it; when data arrives the hook appears mid-lifecycle → React throws "Rendered more hooks than during the previous render" → with no error boundary the entire SPA unmounts into a dead white page. SSR/tests never caught it because `renderToStaticMarkup` renders once with complete props — no loading→ready transition.

## Fix

- Hook moved above the gates (stable hook count), with a comment documenting the rule at the site.
- New `ErrorBoundary` around the Shell `<Outlet/>`, keyed by pathname so navigating recovers: a page crash now shows a readable error panel with nav chrome alive, instead of white-screening the app. en/zh strings included.

## Verification

UI 87/87, tsc clean. Hook-order audit of the page confirms all hooks now precede the early returns.

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a safeguard that prevents page-rendering errors from crashing the entire application.
  * Displays a helpful error message while allowing continued navigation and retrying by reopening the page.
  * Improved error handling on source detail pages, including loading, error, and not-found states.
  * Added English and Simplified Chinese translations for the new error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->