### PR TITLE
fix(portal): vault-relative image attachments render in source view

### DIFF
--- a/console-ui/src/lib/markdown.test.tsx
+++ b/console-ui/src/lib/markdown.test.tsx
@@ -6,7 +6,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 import {
   MarkdownView,
-  sourceImageResolver,
+  sourceImageCandidates,
   splitFrontmatter,
   trimAtMermaidErrorLine,
   type MarkdownViewProps,
@@ -57,37 +57,50 @@ describe('trimAtMermaidErrorLine (truncated-ingest healing)', () => {
   });
 });
 
-describe('sourceImageResolver (repo-relative README images)', () => {
-  const GH = sourceImageResolver('https://github.com/TencentCloud/TencentDB-Agent-Memory');
+describe('sourceImageCandidates (repo vs vault image chains)', () => {
+  const GH = sourceImageCandidates(
+    'https://github.com/TencentCloud/TencentDB-Agent-Memory',
+    '50-Inbox/03-Processed/2026-06/note.md',
+  );
 
-  it('maps repo-relative paths to raw.githubusercontent.com/HEAD', () => {
-    expect(GH?.('./assets/images/logo.png')).toBe(
+  it('GitHub notes try raw.githubusercontent.com/HEAD first, vault second', () => {
+    expect(GH('./assets/images/logo.png')).toEqual([
       'https://raw.githubusercontent.com/TencentCloud/TencentDB-Agent-Memory/HEAD/assets/images/logo.png',
-    );
-    expect(GH?.('docs/pic.png')).toBe(
-      'https://raw.githubusercontent.com/TencentCloud/TencentDB-Agent-Memory/HEAD/docs/pic.png',
-    );
+      '/api/file/assets/images/logo.png?note=50-Inbox%2F03-Processed%2F2026-06%2Fnote.md',
+    ]);
   });
 
   it('strips a .git suffix from the repo segment', () => {
-    const r = sourceImageResolver('https://github.com/o/r.git');
-    expect(r?.('./x.png')).toBe('https://raw.githubusercontent.com/o/r/HEAD/x.png');
+    const r = sourceImageCandidates('https://github.com/o/r.git');
+    expect(r('./x.png')[0]).toBe('https://raw.githubusercontent.com/o/r/HEAD/x.png');
   });
 
-  it('passes absolute/data srcs through untouched', () => {
-    expect(GH?.('https://img.shields.io/b.svg')).toBe('https://img.shields.io/b.svg');
-    expect(GH?.('data:image/png;base64,xx')).toBe('data:image/png;base64,xx');
+  it('passes absolute/data srcs through as a single candidate', () => {
+    expect(GH('https://img.shields.io/b.svg')).toEqual(['https://img.shields.io/b.svg']);
+    expect(GH('data:image/png;base64,xx')).toEqual(['data:image/png;base64,xx']);
   });
 
-  it('resolves non-GitHub pages by standard URL joining', () => {
-    const r = sourceImageResolver('https://example.com/blog/post');
-    expect(r?.('./img.png')).toBe('https://example.com/blog/img.png');
-    expect(r?.('/static/img.png')).toBe('https://example.com/static/img.png');
+  it('clippings try the vault attachment endpoint first, then URL-joined remote', () => {
+    const r = sourceImageCandidates(
+      'https://example.com/blog/post',
+      '50-Inbox/03-Processed/2026-05/note.md',
+    );
+    expect(r('50-Inbox/01-Raw/attachments/2026-05/img-1.png')).toEqual([
+      '/api/file/50-Inbox/01-Raw/attachments/2026-05/img-1.png?note=50-Inbox%2F03-Processed%2F2026-05%2Fnote.md',
+      'https://example.com/blog/50-Inbox/01-Raw/attachments/2026-05/img-1.png',
+    ]);
   });
 
-  it('returns undefined without a source URL (src untouched)', () => {
-    expect(sourceImageResolver(undefined)).toBeUndefined();
-    expect(sourceImageResolver('')).toBeUndefined();
+  it('percent-encodes path segments (Chinese dir names, spaces)', () => {
+    const r = sourceImageCandidates(undefined, undefined);
+    expect(r('50-Inbox/附件 图/img x.png')).toEqual([
+      `/api/file/50-Inbox/${encodeURIComponent('附件 图')}/${encodeURIComponent('img x.png')}`,
+    ]);
+  });
+
+  it('still yields the vault candidate without any source URL', () => {
+    expect(sourceImageCandidates()('a/b.png')).toEqual(['/api/file/a/b.png']);
+    expect(sourceImageCandidates('')('a/b.png')).toEqual(['/api/file/a/b.png']);
   });
 });
 

--- a/console-ui/src/lib/markdown.tsx
+++ b/console-ui/src/lib/markdown.tsx
@@ -231,7 +231,9 @@ interface MdCtxValue {
   gutter: boolean;
   register: (key: string, el: HTMLElement | null, ls: number, le: number) => void;
   cite?: CiteMarks;
-  resolveImageSrc?: (src: string) => string;
+  /** Relative image src → ordered candidates; the <img> error handler
+   * walks the list (see MdImg). */
+  imageSrcCandidates?: (src: string) => string[];
 }
 const MdCtx = createContext<MdCtxValue>({ gutter: true, register: () => {} });
 
@@ -268,6 +270,36 @@ function Row({
 }
 
 let mmdSeq = 0;
+
+/** <img> with a candidate walk: relative srcs get [primary, fallback] from
+ * ctx.imageSrcCandidates (e.g. GitHub → raw.githubusercontent first, vault
+ * attachments second; clippings the other way round). Each onError steps to
+ * the next candidate; when all fail (dead CDN link, missing attachment) the
+ * alt chip beats the browser's broken-image icon. */
+function MdImg({ raw, alt }: { raw: string; alt: string }) {
+  const ctx = useContext(MdCtx);
+  const [idx, setIdx] = useState(0);
+  const candidates =
+    raw && ctx.imageSrcCandidates ? ctx.imageSrcCandidates(raw) : [raw];
+  const src = candidates[idx];
+  if (STATIC_MODE || !src) {
+    // B2: the published static site never hot-loads remote imagery.
+    return (
+      <span className="md-img-placeholder">
+        [image{alt ? `: ${alt}` : ''}]
+      </span>
+    );
+  }
+  return (
+    <img
+      className="md-img"
+      src={src}
+      alt={alt}
+      loading="lazy"
+      onError={() => setIdx((i) => i + 1)}
+    />
+  );
+}
 
 /** Truncated READMEs (ingest cut mid-fence) leave an unclosed ```mermaid
  * block whose "code" runs to end-of-document — the trailing prose is not a
@@ -414,20 +446,11 @@ const components: Components = {
     );
   },
   img(props) {
-    const ctx = useContext(MdCtx);
     const p = props as unknown as { src?: unknown; alt?: unknown };
     const raw = typeof p.src === 'string' ? p.src : '';
-    const resolved = raw && ctx.resolveImageSrc ? ctx.resolveImageSrc(raw) : raw;
     const altText = typeof p.alt === 'string' ? p.alt : '';
-    if (STATIC_MODE || !resolved) {
-      // B2: the published static site never hot-loads remote imagery.
-      return (
-        <span className="md-img-placeholder">
-          [image{altText ? `: ${altText}` : ''}]
-        </span>
-      );
-    }
-    return <img className="md-img" src={resolved} alt={altText} loading="lazy" />;
+    // key: a changed src restarts the candidate walk from the top.
+    return <MdImg key={raw} raw={raw} alt={altText} />;
   },
   pre(props) {
     const p = props as unknown as AnyProps;
@@ -472,33 +495,49 @@ export interface MarkdownViewProps {
   frontmatterLabel?: string;
   /** Citation interactivity for Ask answers — see CiteMarks. */
   citeMarks?: CiteMarks;
-  /** Resolve relative image srcs (READMEs reference repo-relative paths) —
-   * SourceDetailPage rewrites them against the note's origin URL. */
-  resolveImageSrc?: (src: string) => string;
+  /** Relative image srcs → ordered candidates (READMEs reference
+   * repo-relative paths, clippings reference vault attachments) —
+   * SourceDetailPage builds the chain from the note's source URL + path. */
+  imageSrcCandidates?: (src: string) => string[];
 }
 
-/** Build the resolveImageSrc for a source note. Repo-relative paths
- * (`./assets/logo.png`, a README staple) must NOT resolve against the
- * portal origin (instant 404 broken-image); rewrite against the note's
- * source URL. GitHub repos map to raw.githubusercontent.com/<owner>/<repo>/
- * HEAD/<path> (github.com/... is the HTML view, not the bytes); everything
- * else resolves via standard URL joining. Absolute/data: srcs pass through.
- * Returns undefined when no usable base exists (src left untouched). */
-export function sourceImageResolver(
+/** Build the imageSrcCandidates chain for a source note. Relative image
+ * paths come in two shapes: GitHub READMEs point INTO THE REPO
+ * (`./assets/logo.png` → raw.githubusercontent.com/<owner>/<repo>/HEAD/…)
+ * while web clippings point INTO THE VAULT (`50-Inbox/01-Raw/attachments/
+ * …/img-x.png` → the server's /api/file/ endpoint, with the note's own
+ * directory as second base for note-relative refs). Neither is knowable
+ * from the path alone, so the chain tries the likely base first and MdImg
+ * walks the rest on onError. Absolute/data: srcs pass through as a
+ * single-candidate chain. */
+export function sourceImageCandidates(
   sourceUrl?: string,
-): ((src: string) => string) | undefined {
-  if (!sourceUrl) return undefined;
-  const gh = /^https?:\/\/github\.com\/([^/]+)\/([^/#?]+)/i.exec(sourceUrl);
-  const base = gh
+  noteRelPath?: string,
+): (src: string) => string[] {
+  const gh =
+    sourceUrl &&
+    /^https?:\/\/github\.com\/([^/]+)\/([^/#?]+)/i.exec(sourceUrl);
+  const remoteBase = gh
     ? `https://raw.githubusercontent.com/${gh[1]}/${gh[2].replace(/\.git$/, '')}/HEAD/`
     : sourceUrl;
   return (src) => {
-    if (!src || /^(?:https?:|data:|blob:|#)/i.test(src)) return src;
-    try {
-      return new URL(src, base).href;
-    } catch {
-      return src;
+    if (!src || /^(?:https?:|data:|blob:|#)/i.test(src)) return [src];
+    // Strip leading "./" segments: "./x" means "next to the note", and the
+    // server's plain-relative guard rejects CurDir components outright.
+    const vaultPath = src.replace(/^(\.\/)+/, '');
+    const vault =
+      `/api/file/${vaultPath.split('/').map(encodeURIComponent).join('/')}` +
+      (noteRelPath ? `?note=${encodeURIComponent(noteRelPath)}` : '');
+    let remote: string | null = null;
+    if (remoteBase) {
+      try {
+        remote = new URL(src, remoteBase).href;
+      } catch {
+        remote = null;
+      }
     }
+    const chain = gh ? [remote, vault] : [vault, remote];
+    return chain.filter((s): s is string => typeof s === 'string' && s !== '');
   };
 }
 
@@ -510,7 +549,7 @@ export function MarkdownView({
   gutter = true,
   frontmatterLabel = 'metadata',
   citeMarks,
-  resolveImageSrc,
+  imageSrcCandidates,
 }: MarkdownViewProps) {
   const fm = useMemo(() => splitFrontmatter(markdown), [markdown]);
   const rowsRef = useRef(new Map<string, { ls: number; le: number; el: HTMLElement }>());
@@ -540,9 +579,9 @@ export function MarkdownView({
       gutter,
       register,
       cite: citeMarks,
-      resolveImageSrc,
+      imageSrcCandidates,
     }),
-    [anchoredLines, highlightLine, gutter, register, citeMarks, resolveImageSrc],
+    [anchoredLines, highlightLine, gutter, register, citeMarks, imageSrcCandidates],
   );
 
   const rehypePlugins = useMemo(

--- a/console-ui/src/pages/SourceDetailPage.tsx
+++ b/console-ui/src/pages/SourceDetailPage.tsx
@@ -12,7 +12,7 @@ import { useI18n } from '../i18n';
 import { entityUrl, fetchSourceDetail, fetchTags, postSourceTags, STATIC_MODE } from '../lib/api';
 import { collectionOf } from '../lib/derive';
 import { isReactImeComposing } from '../lib/ime';
-import { MarkdownView, sourceImageResolver } from '../lib/markdown';
+import { MarkdownView, sourceImageCandidates } from '../lib/markdown';
 import type { ClaimRow, SourceDetail, SourceRow } from '../lib/types';
 
 type Tab = 'memory' | 'source';
@@ -205,14 +205,20 @@ export default function SourceDetailPage() {
     [detail],
   );
 
-  // READMEs reference repo-relative image paths (./assets/logo.png) — they
-  // must resolve against the note's source URL, not the portal origin.
+  // Notes reference image paths relative to the REPO (READMEs) or the
+  // VAULT (clipped attachments) — resolve through an ordered candidate
+  // chain built from the note's source URL + vault path; the <img> error
+  // handler walks it.
   // HOOKS RULE: this useMemo must stay ABOVE the status early-returns below
   // — a hook that only runs once `detail` is ready changes the hook count
   // between renders and React unmounts the whole app (the 2026-07-29
   // OpenChatCut white screen).
   const sourceUrl = detail?.source.url ?? undefined;
-  const resolveImageSrc = useMemo(() => sourceImageResolver(sourceUrl), [sourceUrl]);
+  const noteRelPath = detail?.source.rel_path ?? undefined;
+  const imageSrcCandidates = useMemo(
+    () => sourceImageCandidates(sourceUrl, noteRelPath),
+    [sourceUrl, noteRelPath],
+  );
 
   const jumpToLine = (line: number) => {
     setTab('source');
@@ -464,7 +470,7 @@ export default function SourceDetailPage() {
                     anchoredLines={anchoredLines}
                     highlightLine={highlightLine}
                     frontmatterLabel={t('source.frontmatter')}
-                    resolveImageSrc={resolveImageSrc}
+                    imageSrcCandidates={imageSrcCandidates}
                   />
                   {doc.truncated && (
                     <div className="doc-note tiny muted">

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -774,6 +774,7 @@ fn dispatch(
         (Method::Get, "/api/terrain") => handle_terrain(state),
         (Method::Get, p) if p.starts_with("/api/claim/") => handle_claim(state, url),
         (Method::Get, p) if p.starts_with("/api/source/") => handle_source_api(state, url),
+        (Method::Get, p) if p.starts_with("/api/file/") => handle_vault_file(state, url),
         (Method::Get, p) if p == "/api" || p.starts_with("/api/") => {
             json_response(404, r#"{"error":"unknown api route"}"#)
         }
@@ -3469,6 +3470,59 @@ fn resolve_static(state: &AppState, url_path: &str) -> Resolved {
     Resolved::NotFound
 }
 
+/// `GET /api/file/<vault-relative path>[?note=<rel>]` — serve an image
+/// attachment straight from the vault. Clipped articles reference
+/// vault-relative paths (`50-Inbox/01-Raw/attachments/2026-05/img-….png`)
+/// that can NEVER resolve against the note's source URL (2026-07-30: the
+/// Dynamic Workflows page showed a broken-image icon for every inline
+/// figure). `?note=` adds the note's own directory as a second resolution
+/// base (Obsidian-style note-relative references). Guards: plain-relative
+/// only, image extensions only, canonicalized path must stay under the
+/// canonicalized vault root (symlinks can't escape).
+fn handle_vault_file(state: &AppState, url: &str) -> Response<std::io::Cursor<Vec<u8>>> {
+    let not_found = || json_response(404, r#"{"error":"not found"}"#);
+    let path_part = url.split('?').next().unwrap_or(url);
+    let rel = url_decode(path_part.trim_start_matches("/api/file/"));
+    if !is_plain_relative(&rel) {
+        return not_found();
+    }
+    let mime = match rel.rsplit('.').next().unwrap_or("").to_lowercase().as_str() {
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "gif" => "image/gif",
+        "webp" => "image/webp",
+        "svg" => "image/svg+xml",
+        "avif" => "image/avif",
+        _ => return not_found(),
+    };
+    let mut candidates = vec![state.vault_root.join(&rel)];
+    // parse_query_string already url-decodes its values.
+    if let Some(note) = parse_query_string(url).get("note")
+        && is_plain_relative(note)
+        && let Some(parent) = std::path::Path::new(note).parent()
+    {
+        candidates.push(state.vault_root.join(parent).join(&rel));
+    }
+    let Ok(canon_vault) = state.vault_root.canonicalize() else {
+        return not_found();
+    };
+    for cand in candidates {
+        let Ok(canon) = cand.canonicalize() else {
+            continue;
+        };
+        if !canon.starts_with(&canon_vault) || !canon.is_file() {
+            continue;
+        }
+        if let Ok(bytes) = std::fs::read(&canon) {
+            let header = Header::from_bytes("Content-Type", mime.as_bytes()).unwrap();
+            return Response::from_data(bytes)
+                .with_header(header)
+                .with_status_code(200);
+        }
+    }
+    not_found()
+}
+
 /// True only for a plain relative path: every `Path::components()` entry is
 /// `Component::Normal` — no `ParentDir`, no `RootDir`, no Windows
 /// `Component::Prefix` (`C:\`, `\\server\share`). Backslashes and drive
@@ -4286,6 +4340,61 @@ mod tests {
         );
 
         let _ = std::fs::remove_dir_all(vault.parent().unwrap());
+    }
+
+    #[test]
+    fn vault_file_serves_attachments_and_refuses_traversal() {
+        let root = temp_root("vault-file");
+        let vault = root.join("vault");
+        // Vault-root-relative attachment (the Dynamic Workflows shape).
+        let att = vault.join("50-Inbox/01-Raw/attachments/2026-05");
+        std::fs::create_dir_all(&att).unwrap();
+        std::fs::write(att.join("img-1.png"), b"PNG-BYTES").unwrap();
+        // Note-relative attachment (Obsidian style: note dir + filename).
+        let note_dir = vault.join("50-Inbox/03-Processed/2026-05");
+        std::fs::create_dir_all(&note_dir).unwrap();
+        std::fs::write(note_dir.join("local.png"), b"LOCAL-PNG").unwrap();
+        std::fs::write(note_dir.join("secret.md"), "not an image").unwrap();
+        let st = state(vault.clone(), None);
+
+        // Root-relative hit.
+        let resp = dispatch(
+            &st,
+            Method::Get,
+            "/api/file/50-Inbox/01-Raw/attachments/2026-05/img-1.png",
+            "",
+        );
+        assert_eq!(resp.status_code(), 200);
+        assert_eq!(header_value(&resp, "Content-Type"), "image/png");
+
+        // Note-relative fallback via ?note=.
+        let resp = dispatch(
+            &st,
+            Method::Get,
+            "/api/file/local.png?note=50-Inbox/03-Processed/2026-05/n.md",
+            "",
+        );
+        assert_eq!(resp.status_code(), 200);
+
+        // Traversal, absolute paths, and non-image extensions are refused.
+        for bad in [
+            "/api/file/../secret.md",
+            "/api/file/50-Inbox/03-Processed/2026-05/secret.md",
+            "/api/file/%2e%2e/%2e%2e/etc/passwd.png",
+        ] {
+            assert_eq!(
+                dispatch(&st, Method::Get, bad, "").status_code(),
+                404,
+                "{bad} must 404"
+            );
+        }
+        // Missing file 404s.
+        assert_eq!(
+            dispatch(&st, Method::Get, "/api/file/nope.png", "").status_code(),
+            404
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]


### PR DESCRIPTION
Clipped articles (non-GitHub) reference vault attachment paths (`50-Inbox/01-Raw/attachments/…/img-x.png`) that can never resolve against the note's source URL — every inline figure rendered as a broken-image icon, making full articles look 'out of order / missing paragraphs'.

## Changes
- **ovp-server**: new `GET /api/file/<rel>[?note=<rel>]` serves image attachments from the vault. Guards: plain-relative only, image-extension allowlist (png/jpg/jpeg/gif/webp/svg/avif), canonicalized path must stay under the canonicalized vault root (symlinks can't escape). `?note=` adds the note's directory as a second resolution base (Obsidian-style note-relative refs).
- **markdown.tsx**: `MdImg` walks an ordered candidate chain on `onError`. GitHub notes: `raw.githubusercontent.com/<owner>/<repo>/HEAD/…` first, vault second. Clippings: vault first, then URL-joined remote. When every candidate fails (dead CDN link), the alt chip replaces the browser's broken-image icon. Replaces the single-URL `resolveImageSrc`/`sourceImageResolver` from #393.
- **SourceDetailPage**: passes `sourceImageCandidates(source.url, source.rel_path)` (memoized above early returns — hooks rule).

## Verification
- UI: 88/88 vitest, tsc clean. Server: 69/69 cargo test (new traversal/allowlist/note-fallback cases), clippy clean.
- Live on the real vault: `/api/file/50-Inbox/01-Raw/attachments/2026-05/img-198acd44.png` → 200 image/png (56 KB); `../../etc/passwd.png` and `.md` paths → 404.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved image loading in Markdown with automatic fallback options when an image source is unavailable.
  * Added support for serving vault image attachments through a secure file endpoint.
  * Added support for note-relative image paths, GitHub repository images, data URLs, and encoded file paths.

* **Bug Fixes**
  * Improved handling of missing, invalid, unsafe, and unsupported image files.
  * Prevented image path traversal outside the vault.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->