### PR TITLE
fix(portal): harden mermaid recovery, image paths, /api/file, and fulltext

### DIFF
--- a/console-ui/src/lib/markdown.test.tsx
+++ b/console-ui/src/lib/markdown.test.tsx
@@ -80,14 +80,38 @@ describe('sourceImageCandidates (repo vs vault image chains)', () => {
     expect(GH('data:image/png;base64,xx')).toEqual(['data:image/png;base64,xx']);
   });
 
-  it('clippings try the vault attachment endpoint first, then URL-joined remote', () => {
+  it('upgrades protocol-relative URLs to https', () => {
+    expect(GH('//cdn.example.com/a.png')).toEqual(['https://cdn.example.com/a.png']);
+  });
+
+  it('strips Obsidian vault-root leading slash before /api/file', () => {
+    const r = sourceImageCandidates(
+      undefined,
+      '50-Inbox/03-Processed/2026-05/note.md',
+    );
+    expect(r('/50-Inbox/01-Raw/attachments/2026-05/img-1.png')).toEqual([
+      '/api/file/50-Inbox/01-Raw/attachments/2026-05/img-1.png?note=50-Inbox%2F03-Processed%2F2026-05%2Fnote.md',
+    ]);
+  });
+
+  it('clippings: vault attachments stay vault-only (no guaranteed-404 remote)', () => {
     const r = sourceImageCandidates(
       'https://example.com/blog/post',
       '50-Inbox/03-Processed/2026-05/note.md',
     );
     expect(r('50-Inbox/01-Raw/attachments/2026-05/img-1.png')).toEqual([
       '/api/file/50-Inbox/01-Raw/attachments/2026-05/img-1.png?note=50-Inbox%2F03-Processed%2F2026-05%2Fnote.md',
-      'https://example.com/blog/50-Inbox/01-Raw/attachments/2026-05/img-1.png',
+    ]);
+  });
+
+  it('clippings: site-relative images still try the remote hop', () => {
+    const r = sourceImageCandidates(
+      'https://example.com/blog/post/',
+      '50-Inbox/03-Processed/2026-05/note.md',
+    );
+    expect(r('images/fig.png')).toEqual([
+      '/api/file/images/fig.png?note=50-Inbox%2F03-Processed%2F2026-05%2Fnote.md',
+      'https://example.com/blog/post/images/fig.png',
     ]);
   });
 

--- a/console-ui/src/lib/markdown.tsx
+++ b/console-ui/src/lib/markdown.tsx
@@ -270,6 +270,26 @@ function Row({
 }
 
 let mmdSeq = 0;
+/** Last theme passed to mermaid.initialize — re-init only when it flips so
+ * concurrent diagrams don't race initialize() on every mount. */
+let mmdTheme: 'dark' | 'neutral' | null = null;
+
+async function ensureMermaid() {
+  const { default: mermaid } = await import('mermaid');
+  const dark =
+    typeof document !== 'undefined' &&
+    document.documentElement.dataset.theme === 'dark';
+  const theme: 'dark' | 'neutral' = dark ? 'dark' : 'neutral';
+  if (mmdTheme !== theme) {
+    mermaid.initialize({
+      startOnLoad: false,
+      securityLevel: 'strict',
+      theme,
+    });
+    mmdTheme = theme;
+  }
+  return mermaid;
+}
 
 /** <img> with a candidate walk: relative srcs get [primary, fallback] from
  * ctx.imageSrcCandidates (e.g. GitHub → raw.githubusercontent first, vault
@@ -316,22 +336,20 @@ export function trimAtMermaidErrorLine(code: string, err: unknown): string | nul
 }
 
 /** ```mermaid fence → SVG via the mermaid engine, loaded on demand so the
- * main bundle stays lean. Falls back to the raw code block on error. */
+ * main bundle stays lean. Falls back to the raw code block on error.
+ * The render host stays mounted (hidden on failure) so a later good `code`
+ * can write into `ref` — unmounting the host on fail left ref null forever. */
 function MermaidBlock({ code }: { code: string }) {
   const ref = useRef<HTMLDivElement>(null);
   const [failed, setFailed] = useState(false);
   useEffect(() => {
     let cancelled = false;
     const id = `ovp-mmd-${(mmdSeq += 1)}`;
+    setFailed(false);
+    if (ref.current) ref.current.innerHTML = '';
     void (async () => {
       try {
-        const { default: mermaid } = await import('mermaid');
-        const dark = document.documentElement.dataset.theme === 'dark';
-        mermaid.initialize({
-          startOnLoad: false,
-          securityLevel: 'strict',
-          theme: dark ? 'dark' : 'neutral',
-        });
+        const mermaid = await ensureMermaid();
         let src = code;
         try {
           await mermaid.parse(src);
@@ -347,6 +365,7 @@ function MermaidBlock({ code }: { code: string }) {
           // Documented trust boundary (module header): strict mode + own
           // vault. Never point this at untrusted markdown.
           ref.current.innerHTML = svg;
+          setFailed(false);
         }
       } catch {
         // mermaid.render/parse append their error graphic to document.body
@@ -355,21 +374,31 @@ function MermaidBlock({ code }: { code: string }) {
         for (const el of document.querySelectorAll(`#${id}, #d${id}`)) {
           el.remove();
         }
-        if (!cancelled) setFailed(true);
+        if (!cancelled) {
+          if (ref.current) ref.current.innerHTML = '';
+          setFailed(true);
+        }
       }
     })();
     return () => {
       cancelled = true;
     };
   }, [code]);
-  if (failed) {
-    return (
-      <pre>
-        <code>{code}</code>
-      </pre>
-    );
-  }
-  return <div className="md-mermaid" ref={ref} />;
+  return (
+    <>
+      {failed && (
+        <pre>
+          <code>{code}</code>
+        </pre>
+      )}
+      <div
+        className="md-mermaid"
+        ref={ref}
+        style={failed ? { display: 'none' } : undefined}
+        aria-hidden={failed || undefined}
+      />
+    </>
+  );
 }
 
 // ------------------------------------------------------------- components
@@ -501,6 +530,15 @@ export interface MarkdownViewProps {
   imageSrcCandidates?: (src: string) => string[];
 }
 
+/** Paths that live inside the vault (clipper attachments, PARA roots) —
+ * joining them onto a remote article URL always 404s, so skip that hop. */
+function looksLikeVaultPath(path: string): boolean {
+  return (
+    /^(?:\d{2}-|attachments\/|\.ovp\/)/i.test(path) ||
+    path.includes('/attachments/')
+  );
+}
+
 /** Build the imageSrcCandidates chain for a source note. Relative image
  * paths come in two shapes: GitHub READMEs point INTO THE REPO
  * (`./assets/logo.png` → raw.githubusercontent.com/<owner>/<repo>/HEAD/…)
@@ -521,17 +559,23 @@ export function sourceImageCandidates(
     ? `https://raw.githubusercontent.com/${gh[1]}/${gh[2].replace(/\.git$/, '')}/HEAD/`
     : sourceUrl;
   return (src) => {
-    if (!src || /^(?:https?:|data:|blob:|#)/i.test(src)) return [src];
-    // Strip leading "./" segments: "./x" means "next to the note", and the
-    // server's plain-relative guard rejects CurDir components outright.
-    const vaultPath = src.replace(/^(\.\/)+/, '');
+    if (!src) return [];
+    // Protocol-relative CDN URLs (`//cdn…/x.png`) are absolute, not vault.
+    if (src.startsWith('//')) return [`https:${src}`];
+    if (/^(?:https?:|data:|blob:|#)/i.test(src)) return [src];
+    // Strip "./" and a leading "/" (Obsidian vault-root absolute). The
+    // server's plain-relative guard rejects CurDir and RootDir outright.
+    const vaultPath = src.replace(/^(\.\/)+/, '').replace(/^\//, '');
+    if (!vaultPath) return [];
     const vault =
       `/api/file/${vaultPath.split('/').map(encodeURIComponent).join('/')}` +
       (noteRelPath ? `?note=${encodeURIComponent(noteRelPath)}` : '');
+    // Vault-shaped paths never resolve against a remote article URL.
+    // GitHub READMEs still try raw.githubusercontent.com first (repo assets).
     let remote: string | null = null;
-    if (remoteBase) {
+    if (remoteBase && (gh || !looksLikeVaultPath(vaultPath))) {
       try {
-        remote = new URL(src, remoteBase).href;
+        remote = new URL(vaultPath, remoteBase).href;
       } catch {
         remote = null;
       }

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -13,7 +13,7 @@
 // shared `ovp-api-projection` crate so the live server and the static publisher
 // can never drift. `graph` is re-exported under its old path so the many
 // `graph::…` call sites in this file are unchanged.
-use ovp_api_projection::{bodies, graph, readers};
+use ovp_api_projection::{bodies, graph, is_plain_relative, readers};
 
 mod ask_client;
 pub use ask_client::{
@@ -45,6 +45,14 @@ use tiny_http::{Header, Method, Response, Server};
 /// the response truncates with an explicit flag instead of shipping megabytes
 /// of JSON (same limit the v1 server-rendered page used).
 pub const MAX_SOURCE_DOC_BYTES: usize = 200 * 1024;
+
+/// Cap for a single image attachment served by `GET /api/file/…` — keeps a
+/// mis-labelled multi-hundred-MB blob from being read into memory.
+pub const MAX_VAULT_FILE_BYTES: u64 = 16 * 1024 * 1024;
+
+/// Skip the expensive full-text body scan when metadata already filled the
+/// result list (omnibox is satisfied; scanning 48 MiB for more hits is waste).
+const FULLTEXT_SKIP_WHEN_METADATA_HITS: usize = 10;
 
 /// Cap for POST request bodies (`/api/ask` questions are short; anything
 /// bigger is a mistake, not a question).
@@ -1148,8 +1156,12 @@ fn handle_search(state: &AppState, url: &str) -> Response<std::io::Cursor<Vec<u8
     // matches title/url/path, so a remembered phrase from inside an article
     // found nothing (operator report). Reuses the agent's bounded scanner
     // (ranked + snippeted); metadata hits win on duplicates, additions
-    // capped at 20.
-    if let Some(term) = term.as_deref().map(str::trim).filter(|t| !t.is_empty()) {
+    // capped at 20. Skipped for short/noisy ASCII terms and when metadata
+    // already filled the list (omnibox is satisfied without a 48 MiB scan).
+    if let Some(term) = term.as_deref().map(str::trim).filter(|t| !t.is_empty())
+        && fulltext_term_worth_scanning(term)
+        && hits.len() < FULLTEXT_SKIP_WHEN_METADATA_HITS
+    {
         let mut seen: std::collections::HashSet<String> = hits
             .iter()
             .filter_map(|h| {
@@ -3477,8 +3489,8 @@ fn resolve_static(state: &AppState, url_path: &str) -> Resolved {
 /// Dynamic Workflows page showed a broken-image icon for every inline
 /// figure). `?note=` adds the note's own directory as a second resolution
 /// base (Obsidian-style note-relative references). Guards: plain-relative
-/// only, image extensions only, canonicalized path must stay under the
-/// canonicalized vault root (symlinks can't escape).
+/// only, image extensions only, size ≤ `MAX_VAULT_FILE_BYTES`, canonicalized
+/// path must stay under the canonicalized vault root (symlinks can't escape).
 fn handle_vault_file(state: &AppState, url: &str) -> Response<std::io::Cursor<Vec<u8>>> {
     let not_found = || json_response(404, r#"{"error":"not found"}"#);
     let path_part = url.split('?').next().unwrap_or(url);
@@ -3513,29 +3525,37 @@ fn handle_vault_file(state: &AppState, url: &str) -> Response<std::io::Cursor<Ve
         if !canon.starts_with(&canon_vault) || !canon.is_file() {
             continue;
         }
+        let Ok(meta) = std::fs::metadata(&canon) else {
+            continue;
+        };
+        if meta.len() > MAX_VAULT_FILE_BYTES {
+            continue;
+        }
         if let Ok(bytes) = std::fs::read(&canon) {
-            let header = Header::from_bytes("Content-Type", mime.as_bytes()).unwrap();
             return Response::from_data(bytes)
-                .with_header(header)
+                .with_header(Header::from_bytes("Content-Type", mime.as_bytes()).unwrap())
+                .with_header(
+                    Header::from_bytes("Cache-Control", "private, max-age=3600").unwrap(),
+                )
+                .with_header(Header::from_bytes("X-Content-Type-Options", "nosniff").unwrap())
                 .with_status_code(200);
         }
     }
     not_found()
 }
 
-/// True only for a plain relative path: every `Path::components()` entry is
-/// `Component::Normal` — no `ParentDir`, no `RootDir`, no Windows
-/// `Component::Prefix` (`C:\`, `\\server\share`). Backslashes and drive
-/// colons are ALSO rejected as raw bytes: on Unix `C:\evil` parses as one
-/// Normal component, yet a Windows deployment would treat it as absolute
-/// and `Path::join` would silently replace the base directory.
-fn is_plain_relative(rel: &str) -> bool {
-    if rel.is_empty() || rel.contains('\\') || rel.contains(':') {
+/// True when a portal search term is worth the full-text body scan.
+/// Pure-ASCII 1–2 char queries (`AI`, `ab`) are too noisy/cheap for a
+/// corpus walk; 2+ char CJK (or other non-ASCII) and any 3+ char term pass.
+fn fulltext_term_worth_scanning(term: &str) -> bool {
+    let n = term.chars().count();
+    if n < 2 {
         return false;
     }
-    std::path::Path::new(rel)
-        .components()
-        .all(|c| matches!(c, std::path::Component::Normal(_)))
+    if n >= 3 {
+        return true;
+    }
+    !term.chars().all(|c| c.is_ascii_alphanumeric())
 }
 
 /// Read a root-relative asset from the SPA app build: the deployed
@@ -4339,7 +4359,26 @@ mod tests {
             "metadata hit must not be re-added by fulltext: {hits:?}"
         );
 
+        // Short pure-ASCII terms must NOT trigger a corpus scan (noise).
+        // Body-only "LL" is not in title/url/path → empty without fulltext.
+        let v = body_json(dispatch(&st, Method::Get, "/api/search?q=LL", ""));
+        assert!(
+            v.as_array().unwrap().is_empty(),
+            "2-char ASCII must skip fulltext: {v}"
+        );
+
         let _ = std::fs::remove_dir_all(vault.parent().unwrap());
+    }
+
+    #[test]
+    fn fulltext_term_gate_keeps_cjk_short_queries() {
+        assert!(fulltext_term_worth_scanning("记忆"));
+        assert!(fulltext_term_worth_scanning("LLM"));
+        assert!(fulltext_term_worth_scanning("compressed"));
+        assert!(!fulltext_term_worth_scanning(""));
+        assert!(!fulltext_term_worth_scanning("a"));
+        assert!(!fulltext_term_worth_scanning("AI"));
+        assert!(!fulltext_term_worth_scanning("ab"));
     }
 
     #[test]
@@ -4355,6 +4394,12 @@ mod tests {
         std::fs::create_dir_all(&note_dir).unwrap();
         std::fs::write(note_dir.join("local.png"), b"LOCAL-PNG").unwrap();
         std::fs::write(note_dir.join("secret.md"), "not an image").unwrap();
+        // Oversize image: present on disk but must not be loaded into memory.
+        {
+            let huge_path = att.join("huge.png");
+            let f = std::fs::File::create(&huge_path).unwrap();
+            f.set_len(MAX_VAULT_FILE_BYTES + 1).unwrap();
+        }
         let st = state(vault.clone(), None);
 
         // Root-relative hit.
@@ -4366,6 +4411,8 @@ mod tests {
         );
         assert_eq!(resp.status_code(), 200);
         assert_eq!(header_value(&resp, "Content-Type"), "image/png");
+        assert_eq!(header_value(&resp, "Cache-Control"), "private, max-age=3600");
+        assert_eq!(header_value(&resp, "X-Content-Type-Options"), "nosniff");
 
         // Note-relative fallback via ?note=.
         let resp = dispatch(
@@ -4391,6 +4438,17 @@ mod tests {
         // Missing file 404s.
         assert_eq!(
             dispatch(&st, Method::Get, "/api/file/nope.png", "").status_code(),
+            404
+        );
+        // Oversize image 404s (size guard before read).
+        assert_eq!(
+            dispatch(
+                &st,
+                Method::Get,
+                "/api/file/50-Inbox/01-Raw/attachments/2026-05/huge.png",
+                ""
+            )
+            .status_code(),
             404
         );
 


### PR DESCRIPTION
## Summary

Review follow-ups after the recent source-view / search work (#389–#395):

- **MermaidBlock**: keep the render host mounted (hidden on failure) so a later good `code` can recover; theme-aware mermaid init once-per-theme.
- **sourceImageCandidates**: upgrade `//…` to `https:`, strip Obsidian vault-root leading `/`, skip guaranteed-404 remote hops for vault-shaped attachment paths.
- **GET /api/file**: 16 MiB size guard, `Cache-Control: private, max-age=3600`, `X-Content-Type-Options: nosniff`, reuse `ovp_api_projection::is_plain_relative`.
- **Portal fulltext**: skip pure-ASCII 1–2 char noise; skip when metadata already has ≥10 hits. CJK 2-char queries still scan.

## Test plan

- [x] `vitest run src/lib/markdown.test.tsx` (25 passed)
- [x] `cargo test -p ovp-server --lib` (70 passed)
- [x] `cargo clippy -p ovp-server --all-targets -- -D warnings`
- [ ] Spot-check source detail: mermaid fence recovery, vault attachment images, clipping images without remote 404 flash
- [ ] Omnibox: short ASCII query does not hang on fulltext; body phrase still finds notes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mermaid diagrams now adapt to the selected theme.
  * Failed Mermaid diagrams display a readable code fallback instead of disappearing.
  * Image links handle protocol-relative and vault-relative paths more reliably.

* **Bug Fixes**
  * Oversized attachments are rejected safely.
  * Attachment responses now provide improved caching and content-type handling.
  * Search avoids unnecessary full-text scans for short, low-value queries.
  * Improved support for CJK search terms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->