### PR TITLE
fix(daily): stop last-run bricking on missing live features / pinboard blips

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -60,14 +60,10 @@ jobs:
       # `embed` (ONNX semantic themes) is OFF — its `ort` tree has no clean
       # x86_64-apple-darwin build (why dist dropped that target) and it bloats
       # the DMG. Themes stay a follow-up (lazy model download). Keeps both
-      # arches identical and small.
+      # arches identical and small. Uses scripts/build-desktop-sidecar.sh so
+      # local rebuilds can't silently ship a no-feature binary (2026-07-31).
       - name: Build ovp2 sidecar
-        run: |
-          cargo build --release -p ovp-cli --target ${{ matrix.target }} \
-            --features anthropic,pinboard-live,web-fetch-live,github-live
-          mkdir -p apps/desktop/src-tauri/binaries
-          cp "target/${{ matrix.target }}/release/ovp2" \
-             "apps/desktop/src-tauri/binaries/ovp2-${{ matrix.target }}"
+        run: bash scripts/build-desktop-sidecar.sh ${{ matrix.target }}
 
       - name: Build the portal (embedded by ovp-server)
         working-directory: console-ui

--- a/crates/ovp-cli/src/commands/daily.rs
+++ b/crates/ovp-cli/src/commands/daily.rs
@@ -161,7 +161,19 @@ fn run_inner(
     // PINBOARD_TOKEN with --pinboard-live, and `--pinboard-since auto`
     // before any watermark exists (the desktop scheduler enables both by
     // default; an explicit `pinboard-sync` invocation errors instead).
+    // Also: a product schedule that passes --pinboard-live against a binary
+    // built without the feature (local desktop rebuilds that forgot live
+    // flags) must WARN+skip, not brick the whole daily run.
     let pinboard_skip = if args.pinboard_live
+        && args.pinboard_fixture.is_none()
+        && !cfg!(feature = "pinboard-live")
+    {
+        Some(
+            "binary built without `--features pinboard-live` (rebuild the product \
+             ovp2 / desktop sidecar with live features)"
+                .to_string(),
+        )
+    } else if args.pinboard_live
         && args.pinboard_fixture.is_none()
         && std::env::var("PINBOARD_TOKEN").ok().filter(|t| !t.trim().is_empty()).is_none()
     {
@@ -201,22 +213,33 @@ fn run_inner(
             yes_all: false,
             ..Default::default()
         };
-        let outcome = sync_pinboard(&intake_cfg, fetch.as_mut(), args.dry_run, &opts)
-            .map_err(CliError::Io)?;
-        sayln!(
-            "  pinboard: {} fetched, {} new note(s), {} known ({})",
-            outcome.fetched, outcome.new_notes.len(), outcome.skipped_known, outcome.origin
-        );
-        if outcome.guard_would_abort {
-            sayln!(
-                "  WARNING: a REAL run would ABORT at the pinboard phase — {} new bookmark(s) \
-                 exceed the {}-note first-sync guard; pass --pinboard-since or --pinboard-max \
-                 (or run `ovp2 pinboard-sync --yes-all` once, deliberately)",
-                outcome.new_notes.len(),
-                ovp_intake::FIRST_SYNC_GUARD_MAX_NEW,
-            );
+        // Unattended daily: a transient Pinboard API outage (HTTP 5xx / network)
+        // must not brick the whole run — intake + reader still need to drain
+        // local captures. Explicit `ovp2 pinboard-sync` stays hard-fail.
+        match sync_pinboard(&intake_cfg, fetch.as_mut(), args.dry_run, &opts) {
+            Ok(outcome) => {
+                sayln!(
+                    "  pinboard: {} fetched, {} new note(s), {} known ({})",
+                    outcome.fetched,
+                    outcome.new_notes.len(),
+                    outcome.skipped_known,
+                    outcome.origin
+                );
+                if outcome.guard_would_abort {
+                    sayln!(
+                        "  WARNING: a REAL run would ABORT at the pinboard phase — {} new bookmark(s) \
+                         exceed the {}-note first-sync guard; pass --pinboard-since or --pinboard-max \
+                         (or run `ovp2 pinboard-sync --yes-all` once, deliberately)",
+                        outcome.new_notes.len(),
+                        ovp_intake::FIRST_SYNC_GUARD_MAX_NEW,
+                    );
+                }
+                report.pinboard = Some((&outcome).into());
+            }
+            Err(e) => {
+                sayln!("  pinboard: skipped (live capture failed: {e})");
+            }
         }
-        report.pinboard = Some((&outcome).into());
     }
 
     // Phase 2 — intake sweep (capture dirs → 01-Raw).
@@ -251,7 +274,20 @@ fn run_inner(
     // previously-flagged captures still pending) by fetching their URLs.
     // Successfully enriched files get enough body for plan_daily to pick them
     // up as reader candidates on the NEXT sweep.
-    if (args.web_fetch_fixture.is_some() || args.web_fetch_live) && !args.dry_run {
+    // Soft-skip when the schedule passes --web-fetch-live against a binary
+    // compiled without the feature (2026-07-31: desktop sidecar rebuilt
+    // without live flags → every last_run failed in ~1s and blocked reader
+    // processing of ready sources).
+    if args.web_fetch_live
+        && args.web_fetch_fixture.is_none()
+        && !cfg!(feature = "web-fetch-live")
+        && !args.dry_run
+    {
+        sayln!(
+            "  enrich: skipped (binary built without `--features web-fetch-live`; \
+             rebuild the product ovp2 / desktop sidecar with live features)"
+        );
+    } else if (args.web_fetch_fixture.is_some() || args.web_fetch_live) && !args.dry_run {
         let needs_content_items: Vec<(String, String)> = sweep_needs_content
             .iter()
             .filter_map(|rec| {
@@ -291,7 +327,17 @@ fn run_inner(
     // Plus the self-healing backlog: notes written before the 100 KiB
     // README cap still carry the legacy `*(README truncated)*` marker; the
     // re-enrich rewrite drops the marker, so the repair list drains itself.
-    if (args.github_fixture.is_some() || args.github_live) && !args.dry_run {
+    // Soft-skip on a no-feature binary (same desktop-sidecar footgun as 2.5).
+    if args.github_live
+        && args.github_fixture.is_none()
+        && !cfg!(feature = "github-live")
+        && !args.dry_run
+    {
+        sayln!(
+            "  github: skipped (binary built without `--features github-live`; \
+             rebuild the product ovp2 / desktop sidecar with live features)"
+        );
+    } else if (args.github_fixture.is_some() || args.github_live) && !args.dry_run {
         let repair = find_truncated_github_notes(&args.vault_root);
         let repair_count = repair.len();
         let mut seen_paths = std::collections::HashSet::new();

--- a/scripts/build-desktop-sidecar.sh
+++ b/scripts/build-desktop-sidecar.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Build the ovp2 CLI sidecar the desktop app's in-app scheduler execs.
+#
+# Product schedule.json always passes --web-fetch-live / --github-live /
+# --pinboard-live. A plain `cargo build -p ovp-cli` omits those features and
+# bricks every daily run the moment any needs-content item is pending
+# (2026-07-31 last-run regression). Mirror release-desktop.yml features.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+TRIPLE="${1:-$(rustc -vV | awk '/^host:/{print $2}')}"
+FEATURES="${OVP2_SIDECAR_FEATURES:-anthropic,pinboard-live,web-fetch-live,github-live}"
+OUT_DIR="apps/desktop/src-tauri/binaries"
+OUT="$OUT_DIR/ovp2-${TRIPLE}"
+
+echo "building ovp2 sidecar ($TRIPLE) features=$FEATURES"
+cargo build --release -p ovp-cli --target "$TRIPLE" --features "$FEATURES"
+mkdir -p "$OUT_DIR"
+cp "target/${TRIPLE}/release/ovp2" "$OUT"
+chmod +x "$OUT"
+echo "wrote $OUT ($(wc -c <"$OUT" | tr -d ' ') bytes)"
+
+# Optional: install into a running OVP2.app so the in-app scheduler picks it up
+# without a full DMG rebuild. Usage: INSTALL_APP=/Applications/OVP2.app ./scripts/build-desktop-sidecar.sh
+if [[ -n "${INSTALL_APP:-}" ]]; then
+  DEST="$INSTALL_APP/Contents/MacOS/ovp2"
+  if [[ ! -d "$INSTALL_APP/Contents/MacOS" ]]; then
+    echo "INSTALL_APP=$INSTALL_APP has no Contents/MacOS" >&2
+    exit 1
+  fi
+  cp "$OUT" "$DEST"
+  chmod +x "$DEST"
+  # ad-hoc re-sign so macOS will exec the replaced binary
+  if command -v codesign >/dev/null 2>&1; then
+    codesign --force --sign - "$DEST" 2>/dev/null || true
+  fi
+  echo "installed $DEST"
+fi


### PR DESCRIPTION
## Summary

Operator vault `last_run` was stuck on **failed** every day.

### Root cause
1. Desktop `ovp2` sidecar was rebuilt **without** `web-fetch-live` / `github-live` / `pinboard-live`.
2. `.ovp/schedule.json` always passes those flags.
3. With pending needs-content items, Phase 2.5 called `build_web_fetcher()` and hard-failed the whole run in ~1s — blocking reader processing of ready sources.
4. Separately, a Pinboard API HTTP 500 also hard-failed daily once features were restored.

### Fix
- Soft-skip pinboard / web-fetch / github when the binary lacks the feature (warn + continue).
- Soft-skip pinboard live capture on API/network errors (unattended loop stays green; `ovp2 pinboard-sync` remains hard-fail).
- `scripts/build-desktop-sidecar.sh` builds with product live features; optional `INSTALL_APP=/Applications/OVP2.app` install; release workflow uses the script.

### Live verify
Reinstalled sidecar with live features and ran daily on the operator vault:
- `status: completed`, 5 processed, 0 failed
- enrich 36/41, github 144/147, reader packs written

## Test plan
- [x] Live daily on operator vault completes
- [ ] (optional) Binary without live features + schedule flags: daily warns and continues instead of last_run=failed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Daily runs now continue when Pinboard synchronization fails, recording the issue as a skipped operation instead of stopping the entire run.
  - Runs now clearly indicate when Pinboard, web fetching, or GitHub enrichment is unavailable, rather than attempting unsupported integrations.

- **Improvements**
  - Desktop builds now use a consistent, streamlined process across supported architectures, improving sidecar installation and packaging reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->