### PR TITLE
fix(portal,desktop): blank WebView — CORS on static + HEAD

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -212,14 +212,41 @@ fn start_server(vault: PathBuf, viz_dir: PathBuf) -> Result<String, String> {
     // could grab the port between the probe and run_server binding it), so a
     // lost race just picks a new port rather than failing the launch.
     let mut last_err = "failed to start the portal server".to_string();
-    for _ in 0..3 {
+    // Local diagnostic (desktop launches swallow stderr when opened via Finder).
+    let diag = |msg: &str| {
+        let line = format!(
+            "{} {}\n",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0),
+            msg
+        );
+        let _ = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(vault.join(".ovp/desktop-portal.log"))
+            .and_then(|mut f| {
+                use std::io::Write;
+                f.write_all(line.as_bytes())
+            });
+        eprintln!("ovp2-desktop: {msg}");
+    };
+    diag(&format!(
+        "start_server vault={} viz={}",
+        vault.display(),
+        viz_dir.display()
+    ));
+    for attempt in 0..3 {
         let port = match free_port() {
             Ok(p) => p,
             Err(e) => {
                 last_err = e;
+                diag(&format!("free_port failed: {last_err}"));
                 continue;
             }
         };
+        diag(&format!("attempt {attempt} port {port}"));
         let ask_client = ovp_server::providers_ask_client_factory(vault.clone());
         let config = ovp_server::ServeConfig {
             vault_root: vault.clone(),
@@ -243,10 +270,18 @@ fn start_server(vault: PathBuf, viz_dir: PathBuf) -> Result<String, String> {
             }
         });
         match wait_until_http(port) {
-            Ok(()) => return Ok(format!("http://127.0.0.1:{port}/")),
-            Err(e) => last_err = e,
+            Ok(()) => {
+                let url = format!("http://127.0.0.1:{port}/");
+                diag(&format!("portal up at {url}"));
+                return Ok(url);
+            }
+            Err(e) => {
+                last_err = e;
+                diag(&format!("wait_until_http failed: {last_err}"));
+            }
         }
     }
+    diag(&format!("start_server giving up: {last_err}"));
     Err(last_err)
 }
 

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -798,6 +798,20 @@ fn dispatch(
             json_response(404, r#"{"error":"unknown api route"}"#)
         }
         (Method::Get, _) => serve_static(state, url),
+        // HEAD for static assets — some WebViews probe modules with HEAD
+        // before GET; answering 405 can leave the portal blank.
+        (Method::Head, path) if !path.starts_with("/api/") => {
+            let resp = serve_static(state, url);
+            // tiny_http doesn't strip body on HEAD; drop payload so clients
+            // that only read headers stay happy.
+            let headers: Vec<_> = resp.headers().to_vec();
+            let status = resp.status_code();
+            let mut out = Response::from_data(Vec::<u8>::new()).with_status_code(status);
+            for h in headers {
+                out.add_header(h);
+            }
+            out
+        }
         _ => text_response(405, "Method Not Allowed"),
     }
 }
@@ -3642,9 +3656,14 @@ fn serve_static(state: &AppState, url_path: &str) -> Response<std::io::Cursor<Ve
             } else {
                 "public, max-age=31536000, immutable"
             };
+            // Vite emits `crossorigin` on module scripts / stylesheets. In the
+            // desktop WKWebView that forces CORS mode even for same-origin
+            // loads — without ACAO the JS never executes and the portal is a
+            // blank white page (Chrome is more lenient; 2026-07-31 repro).
             Response::from_data(body)
                 .with_header(Header::from_bytes("Content-Type", content_type).unwrap())
                 .with_header(Header::from_bytes("Cache-Control", cache_control).unwrap())
+                .with_header(Header::from_bytes("Access-Control-Allow-Origin", "*").unwrap())
                 .with_status_code(200)
         }
         Resolved::BadRequest => text_response(400, "Bad Request"),


### PR DESCRIPTION
## Summary
Desktop OVP2 window was blank while the same portal URL in Chrome showed full Today data (1374 sources). Root cause: Vite `crossorigin` on JS/CSS + WKWebView CORS mode without ACAO headers; also HEAD on assets returned 405.

## Fix
- Static responses include `Access-Control-Allow-Origin: *`
- HEAD supported for static routes
- Desktop start_server writes `.ovp/desktop-portal.log` for boot diagnosis

## Test
- Chrome headless dump shows Today / Library / metrics
- GET /api/model 200 (~4MB)
- New OVP2.app rebuild + deep ad-hoc sign boots portal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of `HEAD` requests for static resources, returning accurate status and headers without a response body.
  * Added cross-origin access support for static file responses.

* **Diagnostics**
  * Added startup, port-selection, readiness, and failure details to the desktop portal log and error output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->