### PR TITLE
feat(source-work): single worker election per vault

### DIFF
--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -225,6 +225,9 @@ export const en = {
   'workq.refresh': 'Refresh',
   'workq.counts': 'running {running} · queued {queued} · history {history}',
   'workq.polled': 'updated {time}',
+  'workq.workerHere': 'Queue worker is this portal (pid {pid}). Safe to open other windows — only one worker runs per vault.',
+  'workq.workerElsewhere':
+    'Queue worker is another process (pid {pid}); this portal (pid {here}) only enqueues. Jobs still run — no need to close either.',
   'workq.running': 'Running',
   'workq.queued': 'Queued',
   'workq.queuedEmpty': 'Nothing waiting — start Translate or Summary from a source page.',

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -215,6 +215,9 @@ export const zh: Record<keyof typeof en, string> = {
   'workq.refresh': '刷新',
   'workq.counts': '进行中 {running} · 排队 {queued} · 历史 {history}',
   'workq.polled': '更新于 {time}',
+  'workq.workerHere': '队列 worker 在本门户（pid {pid}）。可同时开多个窗口——同一 vault 只会有一个 worker。',
+  'workq.workerElsewhere':
+    '队列 worker 在另一进程（pid {pid}）；本门户（pid {here}）只负责入队。任务仍会执行，不必关掉任一方。',
   'workq.running': '进行中',
   'workq.queued': '排队中',
   'workq.queuedEmpty': '暂无排队 — 在资料页点「译为中文」或「深度摘要」即可入队。',

--- a/console-ui/src/lib/api.ts
+++ b/console-ui/src/lib/api.ts
@@ -369,11 +369,22 @@ export interface SourceWorkQueueItem {
   notify_sent: boolean;
 }
 
+export interface SourceWorkWorkerInfo {
+  /** This portal process is running the LLM worker. */
+  active_here: boolean;
+  /** PID holding the vault worker lock, if any. */
+  owner_pid?: number | null;
+  /** This portal's PID. */
+  this_pid?: number;
+}
+
 export interface SourceWorkQueueSnapshot {
   schema: string;
   items: SourceWorkQueueItem[];
   /** Terminal items the client should notify about (server marks sent). */
   notify: SourceWorkQueueItem[];
+  /** Cross-process worker election status. */
+  worker?: SourceWorkWorkerInfo;
 }
 
 export function fetchSourceWorkQueue(): Promise<SourceWorkQueueSnapshot> {

--- a/console-ui/src/lib/sourceWorkQueue.tsx
+++ b/console-ui/src/lib/sourceWorkQueue.tsx
@@ -16,11 +16,13 @@ import {
   fetchSourceWorkQueue,
   reorderSourceWorkQueue,
   type SourceWorkQueueItem,
+  type SourceWorkWorkerInfo,
 } from './api';
 import { ensureNotifyPermission, notifyWorkItemDone } from './notify';
 
 interface QueueCtx {
   items: SourceWorkQueueItem[];
+  worker: SourceWorkWorkerInfo | null;
   activeCount: number;
   refresh: () => void;
   enqueue: (opts: {
@@ -39,12 +41,14 @@ const Ctx = createContext<QueueCtx | null>(null);
 
 export function SourceWorkQueueProvider({ children }: { children: ReactNode }) {
   const [items, setItems] = useState<SourceWorkQueueItem[]>([]);
+  const [worker, setWorker] = useState<SourceWorkWorkerInfo | null>(null);
 
   const refresh = useCallback(() => {
     if (STATIC_MODE) return;
     fetchSourceWorkQueue()
       .then((snap) => {
         setItems(snap.items);
+        setWorker(snap.worker ?? null);
         for (const n of snap.notify) {
           notifyWorkItemDone(n);
         }
@@ -112,6 +116,7 @@ export function SourceWorkQueueProvider({ children }: { children: ReactNode }) {
   const value = useMemo(
     () => ({
       items,
+      worker,
       activeCount,
       refresh,
       enqueue,
@@ -119,7 +124,7 @@ export function SourceWorkQueueProvider({ children }: { children: ReactNode }) {
       cancel,
       remove,
     }),
-    [items, activeCount, refresh, enqueue, reorder, cancel, remove],
+    [items, worker, activeCount, refresh, enqueue, reorder, cancel, remove],
   );
 
   return <Ctx.Provider value={value}>{children}</Ctx.Provider>;

--- a/console-ui/src/pages/WorkQueuePage.tsx
+++ b/console-ui/src/pages/WorkQueuePage.tsx
@@ -83,7 +83,7 @@ function ItemRow({
 
 export default function WorkQueuePage() {
   const { t } = useI18n();
-  const { items, reorder, cancel, remove, refresh } = useSourceWorkQueue();
+  const { items, worker, reorder, cancel, remove, refresh } = useSourceWorkQueue();
   const [polledAt, setPolledAt] = useState(() => Date.now());
 
   const queued = items.filter((i) => i.status === 'queued');
@@ -127,6 +127,19 @@ export default function WorkQueuePage() {
           })}
         </span>
       </div>
+      {worker && !worker.active_here && (
+        <p className="tiny muted workq-worker-banner" role="status">
+          {t('workq.workerElsewhere', {
+            pid: worker.owner_pid ?? '—',
+            here: worker.this_pid ?? '—',
+          })}
+        </p>
+      )}
+      {worker?.active_here && (
+        <p className="tiny muted workq-worker-banner" role="status">
+          {t('workq.workerHere', { pid: worker.this_pid ?? '—' })}
+        </p>
+      )}
 
       {running.length > 0 && (
         <section className="workq-section">

--- a/crates/ovp-memory/Cargo.toml
+++ b/crates/ovp-memory/Cargo.toml
@@ -9,6 +9,7 @@ authors.workspace = true
 [dependencies]
 ovp-domain = { path = "../ovp-domain" }
 ovp-index = { path = "../ovp-index" }
+ovp-intake = { path = "../ovp-intake" }
 ovp-llm = { path = "../ovp-llm" }
 ovp-embed = { path = "../ovp-embed", optional = true }
 serde = { workspace = true }

--- a/crates/ovp-memory/src/source_work_queue.rs
+++ b/crates/ovp-memory/src/source_work_queue.rs
@@ -15,6 +15,10 @@ use serde::{Deserialize, Serialize};
 
 const QUEUE_SCHEMA: &str = "ovp.source-work-queue/v1";
 const QUEUE_REL: &str = ".ovp/source-work-queue.json";
+/// Cross-process exclusive lock for queue file mutations (enqueue/cancel/…).
+const QUEUE_WRITE_LOCK: &str = "source-work-queue.write.lock";
+/// Cross-process election: only one process runs the background worker.
+pub const WORKER_LOCK: &str = "source-work-worker.lock";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -297,6 +301,54 @@ impl SourceWorkQueue {
         self.wake.notify_one();
     }
 
+    /// Who currently holds [`WORKER_LOCK`] for this vault (if any).
+    pub fn worker_owner_pid(&self) -> Option<u32> {
+        read_lock_pid(&self.vault_root.join(".ovp").join(WORKER_LOCK))
+    }
+
+    /// True when `pid` is the live owner of the worker lock (or no lock and
+    /// we are about to take it — caller decides).
+    pub fn worker_owner_is_this_process(&self) -> bool {
+        match self.worker_owner_pid() {
+            Some(p) => p == std::process::id(),
+            None => false,
+        }
+    }
+
+    /// Brief exclusive lock around a disk-coordinated mutation. Retries a few
+    /// times if another portal is mid-write.
+    fn with_write_lock<R>(&self, f: impl FnOnce() -> Result<R, String>) -> Result<R, String> {
+        const ATTEMPTS: usize = 40;
+        for attempt in 0..ATTEMPTS {
+            match ovp_intake::RunLock::acquire_named(&self.vault_root, QUEUE_WRITE_LOCK) {
+                Ok(_lock) => return f(),
+                Err(_) if attempt + 1 < ATTEMPTS => {
+                    std::thread::sleep(std::time::Duration::from_millis(25));
+                }
+                Err(e) => {
+                    return Err(format!(
+                        "source-work queue busy (another portal is writing): {e}"
+                    ));
+                }
+            }
+        }
+        Err("source-work queue write lock timed out".into())
+    }
+
+    /// Force-replace in-memory state from the durable file (call under write lock).
+    fn reload_from_disk(&self, g: &mut QueueFile) {
+        if let Some(mut file) = load_file(&self.path) {
+            let _ = recover_interrupted(&self.vault_root, &mut file);
+            *g = file;
+            if let Ok(m) = std::fs::metadata(&self.path).and_then(|m| m.modified()) {
+                *self
+                    .disk_mtime
+                    .lock()
+                    .unwrap_or_else(|p| p.into_inner()) = Some(m);
+            }
+        }
+    }
+
     /// Block until something may need work, or timeout.
     pub fn wait_for_work(&self, timeout: std::time::Duration) {
         let guard = self.state.lock().unwrap_or_else(|p| p.into_inner());
@@ -307,11 +359,14 @@ impl SourceWorkQueue {
         if !req.translate && !req.summarize {
             return Err("at least one of translate/summarize required".into());
         }
-        let sha = req.sha256.trim();
+        let sha = req.sha256.trim().to_string();
         if sha.is_empty() || sha.len() > 128 {
             return Err("invalid sha256".into());
         }
+        let req = req;
+        self.with_write_lock(|| {
         let mut g = self.state.lock().unwrap_or_else(|p| p.into_inner());
+        self.reload_from_disk(&mut g);
         // Merge into existing *queued* item for same sha.
         if let Some(item) = g
             .items
@@ -373,11 +428,15 @@ impl SourceWorkQueue {
         drop(g);
         self.wake.notify_one();
         Ok(item)
+        })
     }
 
     /// Reorder: `ids` is the desired order of *queued* items (running is fixed first).
     pub fn reorder(&self, ids: &[String]) -> Result<QueueFile, String> {
+        let ids = ids.to_vec();
+        self.with_write_lock(|| {
         let mut g = self.state.lock().unwrap_or_else(|p| p.into_inner());
+        self.reload_from_disk(&mut g);
         let mut running: Vec<QueueItem> = Vec::new();
         let mut queued: Vec<QueueItem> = Vec::new();
         let mut rest: Vec<QueueItem> = Vec::new();
@@ -391,7 +450,7 @@ impl SourceWorkQueue {
         let mut by_id: std::collections::HashMap<String, QueueItem> =
             queued.into_iter().map(|i| (i.id.clone(), i)).collect();
         let mut new_queued = Vec::new();
-        for id in ids {
+        for id in &ids {
             if let Some(it) = by_id.remove(id) {
                 new_queued.push(it);
             }
@@ -407,10 +466,14 @@ impl SourceWorkQueue {
         g.items.extend(rest);
         self.persist_tracked(&g)?;
         Ok(g.clone())
+        })
     }
 
     pub fn cancel(&self, id: &str) -> Result<QueueItem, String> {
+        let id = id.to_string();
+        self.with_write_lock(|| {
         let mut g = self.state.lock().unwrap_or_else(|p| p.into_inner());
+        self.reload_from_disk(&mut g);
         let item = g
             .items
             .iter_mut()
@@ -438,10 +501,14 @@ impl SourceWorkQueue {
         let out = item.clone();
         self.persist_tracked(&g)?;
         Ok(out)
+        })
     }
 
     pub fn remove(&self, id: &str) -> Result<(), String> {
+        let id = id.to_string();
+        self.with_write_lock(|| {
         let mut g = self.state.lock().unwrap_or_else(|p| p.into_inner());
+        self.reload_from_disk(&mut g);
         let before = g.items.len();
         g.items.retain(|i| {
             // Never drop a running item mid-flight from the list; cancel first.
@@ -456,17 +523,21 @@ impl SourceWorkQueue {
         }
         self.persist_tracked(&g)?;
         Ok(())
+        })
     }
 
     /// Claim the next queued article for the worker (marks Running).
     pub fn claim_next(&self) -> Option<QueueItem> {
+        self.with_write_lock(|| {
         let mut g = self.state.lock().unwrap_or_else(|p| p.into_inner());
-        self.maybe_reload_from_disk(&mut g);
+        self.reload_from_disk(&mut g);
         self.recover_stale_running(&mut g);
         if g.items.iter().any(|i| i.status == ItemStatus::Running) {
-            return None; // one article at a time
+            return Ok(None); // one article at a time
         }
-        let item = g.items.iter_mut().find(|i| i.status == ItemStatus::Queued)?;
+        let Some(item) = g.items.iter_mut().find(|i| i.status == ItemStatus::Queued) else {
+            return Ok(None);
+        };
         item.status = ItemStatus::Running;
         item.started_at = Some(now_secs());
         if item.translate.wanted && item.translate.status == TaskStatus::Queued {
@@ -476,8 +547,11 @@ impl SourceWorkQueue {
             item.summarize.status = TaskStatus::Running;
         }
         let out = item.clone();
-        let _ = self.persist_tracked(&g);
-        Some(out)
+        self.persist_tracked(&g)?;
+        Ok(Some(out))
+        })
+        .ok()
+        .flatten()
     }
 
     pub fn finish_task(
@@ -486,7 +560,10 @@ impl SourceWorkQueue {
         kind: TaskKind,
         result: Result<(), String>,
     ) -> Result<QueueItem, String> {
+        let id = id.to_string();
+        self.with_write_lock(|| {
         let mut g = self.state.lock().unwrap_or_else(|p| p.into_inner());
+        self.reload_from_disk(&mut g);
         let item = g
             .items
             .iter_mut()
@@ -496,14 +573,14 @@ impl SourceWorkQueue {
             TaskKind::Translate => &mut item.translate,
             TaskKind::Summarize => &mut item.summarize,
         };
-        match result {
+        match &result {
             Ok(()) => {
                 task.status = TaskStatus::Done;
                 task.error = None;
             }
             Err(e) => {
                 task.status = TaskStatus::Failed;
-                task.error = Some(e);
+                task.error = Some(e.clone());
             }
         }
         // If cancelled mid-run, keep cancelled item status but record task results.
@@ -515,29 +592,34 @@ impl SourceWorkQueue {
         let out = item.clone();
         self.persist_tracked(&g)?;
         Ok(out)
+        })
     }
 
     /// Items that need a client notification (terminal + notify + !notify_sent).
     pub fn take_notify_batch(&self) -> Vec<QueueItem> {
-        let mut g = self.state.lock().unwrap_or_else(|p| p.into_inner());
-        let mut out = Vec::new();
-        for item in g.items.iter_mut() {
-            if item.notify
-                && !item.notify_sent
-                && matches!(
-                    item.status,
-                    ItemStatus::Done | ItemStatus::Failed | ItemStatus::Cancelled
-                )
-                && item_tasks_terminal(item)
-            {
-                item.notify_sent = true;
-                out.push(item.clone());
+        self.with_write_lock(|| {
+            let mut g = self.state.lock().unwrap_or_else(|p| p.into_inner());
+            self.reload_from_disk(&mut g);
+            let mut out = Vec::new();
+            for item in g.items.iter_mut() {
+                if item.notify
+                    && !item.notify_sent
+                    && matches!(
+                        item.status,
+                        ItemStatus::Done | ItemStatus::Failed | ItemStatus::Cancelled
+                    )
+                    && item_tasks_terminal(item)
+                {
+                    item.notify_sent = true;
+                    out.push(item.clone());
+                }
             }
-        }
-        if !out.is_empty() {
-            let _ = self.persist_tracked(&g);
-        }
-        out
+            if !out.is_empty() {
+                self.persist_tracked(&g)?;
+            }
+            Ok(out)
+        })
+        .unwrap_or_default()
     }
 
     pub fn mark_task_skipped_if_not_wanted(&self, id: &str) {
@@ -619,6 +701,27 @@ fn now_secs() -> u64 {
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs())
         .unwrap_or(0)
+}
+
+fn read_lock_pid(path: &Path) -> Option<u32> {
+    let raw = std::fs::read_to_string(path).ok()?;
+    let pid = raw.trim().parse::<u32>().ok().filter(|p| *p > 0)?;
+    // Only report if the process is still alive (unix kill -0).
+    #[cfg(unix)]
+    {
+        let alive = std::process::Command::new("kill")
+            .arg("-0")
+            .arg(pid.to_string())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if !alive {
+            return None;
+        }
+    }
+    Some(pid)
 }
 
 /// Recover items left mid-flight across process death. Returns how many

--- a/crates/ovp-server/src/lib.rs
+++ b/crates/ovp-server/src/lib.rs
@@ -323,6 +323,11 @@ struct AppState {
     /// Per-article translate/summarize queue (serial across sources; parallel
     /// tasks within one source). See `ovp_memory::source_work_queue`.
     source_work_queue: Arc<ovp_memory::source_work_queue::SourceWorkQueue>,
+    /// Held for process lifetime when THIS portal won the worker election.
+    /// Dropping the process releases the lock so another portal can take over.
+    _source_work_worker_lock: Option<ovp_intake::RunLock>,
+    /// True when this process runs the background source-work worker.
+    source_work_worker_here: bool,
 }
 
 /// State of the portal-triggered manual pipeline run.
@@ -583,6 +588,33 @@ pub fn run_server(config: ServeConfig) -> Result<(), String> {
     let vault_root = config.vault_root;
     let source_work_queue =
         Arc::new(ovp_memory::source_work_queue::SourceWorkQueue::open(&vault_root));
+    // Cross-process worker election: only ONE portal (desktop or CLI serve)
+    // runs the LLM worker for a given vault. Others still serve the API and
+    // can enqueue; jobs are claimed by the lock holder after disk reload.
+    let worker_lock = ovp_intake::RunLock::acquire_named(
+        &vault_root,
+        ovp_memory::source_work_queue::WORKER_LOCK,
+    );
+    let (worker_lock, worker_here) = match worker_lock {
+        Ok(lock) => {
+            eprintln!(
+                "source-work-queue: this process is the worker (pid {})",
+                std::process::id()
+            );
+            (Some(lock), true)
+        }
+        Err(e) => {
+            let owner = source_work_queue
+                .worker_owner_pid()
+                .map(|p| format!("pid {p}"))
+                .unwrap_or_else(|| "another process".into());
+            eprintln!(
+                "source-work-queue: worker already running ({owner}); \
+                 this portal will only enqueue/read — {e}"
+            );
+            (None, false)
+        }
+    };
     let state = Arc::new(AppState {
         vault_root,
         layout: VaultLayout::new(),
@@ -607,13 +639,15 @@ pub fn run_server(config: ServeConfig) -> Result<(), String> {
         ask_progress: Arc::new(std::sync::Mutex::new(HashMap::new())),
         chat_saves: Arc::new(std::sync::Mutex::new(())),
         source_work_queue,
+        _source_work_worker_lock: worker_lock,
+        source_work_worker_here: worker_here,
     });
 
     // Pre-load model
     state.refresh_model();
 
-    // Background worker: one article at a time; translate∥summarize inside.
-    {
+    // Background worker: only the elected process.
+    if worker_here {
         let worker_state = Arc::clone(&state);
         std::thread::Builder::new()
             .name("source-work-queue".into())
@@ -2599,12 +2633,18 @@ fn parse_force_flag(body: &str) -> bool {
 fn handle_source_work_queue_get(state: &AppState) -> Response<std::io::Cursor<Vec<u8>>> {
     let snap = state.source_work_queue.snapshot();
     let notify = state.source_work_queue.take_notify_batch();
+    let owner_pid = state.source_work_queue.worker_owner_pid();
     json_response(
         200,
         &serde_json::json!({
             "schema": snap.schema,
             "items": snap.items,
             "notify": notify,
+            "worker": {
+                "active_here": state.source_work_worker_here,
+                "owner_pid": owner_pid,
+                "this_pid": std::process::id(),
+            },
         })
         .to_string(),
     )
@@ -4551,6 +4591,8 @@ mod tests {
             ask_progress: Arc::new(std::sync::Mutex::new(HashMap::new())),
             chat_saves: Arc::new(std::sync::Mutex::new(())),
             source_work_queue,
+            _source_work_worker_lock: None,
+            source_work_worker_here: false,
         }
     }
 


### PR DESCRIPTION
## Summary
- **Worker election**: first portal (desktop or `ovp2 serve`) that opens a vault takes `.ovp/source-work-worker.lock` and runs the background LLM worker; others skip starting a second worker.
- **Write lock** on enqueue/cancel/reorder/claim/finish so two UIs cannot corrupt the durable queue.
- **UI**: Work Queue shows whether this portal is the worker or another process owns it — users need not remember “don’t open both”.

## Why
“Don’t open desktop and :8787 together” is not a product rule. Coordination must be automatic.

## Test plan
- [x] `cargo test -p ovp-memory open_ --lib`
- [x] `cargo check -p ovp-server -p ovp-cli`
- [ ] Start serve, then desktop: desktop log says worker already running; queue still advances
- [ ] Kill worker process: other process can reclaim lock on restart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added work-queue worker status indicators showing whether processing is active in the current portal or another process.
  - Displays relevant process IDs and operational guidance in English and Simplified Chinese.
  - Multiple portal processes can now safely share queue activity without starting duplicate workers.

- **Bug Fixes**
  - Improved queue consistency and reliability when multiple processes modify, claim, or complete work items concurrently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->