### PR TITLE
chore: Cargo.lock for source-work worker lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2905,6 +2905,7 @@ dependencies = [
  "ovp-domain",
  "ovp-embed",
  "ovp-index",
+ "ovp-intake",
  "ovp-llm",
  "serde",
  "serde_json",


### PR DESCRIPTION
Follow-up to #404: lockfile records ovp-memory → ovp-intake.