### PR TITLE
fix(console): runs table cap + theme zh projection status

### DIFF
--- a/console-ui/src/design/portal.css
+++ b/console-ui/src/design/portal.css
@@ -436,6 +436,15 @@ body {
   white-space: nowrap;
 }
 
+.theme-zh-missing {
+  margin: 0 0 0.75rem;
+  border-left: 3px solid var(--accent, #4a90d9);
+  padding: 0.55rem 0.75rem;
+}
+.theme-zh-partial {
+  margin: 0 0 0.6rem;
+}
+
 /* ---------- toggles (theme + language): text buttons in a pill ---------- */
 .seg-toggle {
   display: inline-flex;

--- a/console-ui/src/i18n/en.ts
+++ b/console-ui/src/i18n/en.ts
@@ -463,6 +463,17 @@ export const en = {
   'theme.topicOverview': 'Topic overview',
   'theme.topicOverviewCaption': 'woven from {n} claims',
   'theme.counts': 'durable {durable} · caveated {caveated}',
+  'theme.contentLang': 'content {lang} · zh ready {zh}/{total}',
+  'theme.claimEnOnly': 'EN only',
+  'theme.claimZhMissingTip':
+    'No Chinese projection for this claim — ledger text is English authority.',
+  'theme.zhMissingBody':
+    'UI is Chinese, but claim translations are missing for all {n} claims on this theme. Theme labels may still localize; body text falls back to English.',
+  'theme.zhMissingHint':
+    'Generate rebuildable projections: `ovp2 source-work claims-zh --vault-root … --client live` and `ovp2 source-work memory-zh --vault-root … --theme-pages --client live`. Files land under `.ovp/crystal/claims_zh.json` / `theme_pages_zh.json` (ledger stays English).',
+  'theme.zhPartialOverview':
+    'Claim zh is partial; topic-overview sections are still English (no theme_pages_zh yet).',
+  'theme.switchToEn': 'Switch UI to EN',
   'theme.citedSources': 'Sources:',
   'theme.legacySource': 'Legacy source — no detail page in this vault.',
   'theme.strength': 'strength',
@@ -650,6 +661,12 @@ export const en = {
   'system.runs': 'Runs',
   'system.runsEmpty':
     'No runs recorded yet — run `ovp2 daily` against this vault.',
+  'system.runsShowingRecent':
+    'Showing the newest {shown} of {total} runs (reports are kept forever under .ovp/reports/).',
+  'system.runsShowingAll':
+    'Showing all {n} runs (reports are kept forever under .ovp/reports/).',
+  'system.runsExpand': 'Show {n} older run(s)…',
+  'system.runsCollapse': 'Show only the newest {n}',
   'system.runDate': 'date',
   'system.runOk': 'ok',
   'system.runFailed': 'failed',

--- a/console-ui/src/i18n/zh.ts
+++ b/console-ui/src/i18n/zh.ts
@@ -440,6 +440,17 @@ export const zh: Record<keyof typeof en, string> = {
   'theme.topicOverview': '主题综述',
   'theme.topicOverviewCaption': '由 {n} 条结晶主张编织',
   'theme.counts': '持久 {durable} · 存疑 {caveated}',
+  'theme.contentLang': '正文 {lang} · 中文就绪 {zh}/{total}',
+  'theme.claimEnOnly': '仅英文',
+  'theme.claimZhMissingTip':
+    '此主张尚无中文投影——账本正文以英文为权威。',
+  'theme.zhMissingBody':
+    '界面已是中文，但本主题 {n} 条主张都还没有中文投影。主题名可能已本地化，正文会回退到英文。',
+  'theme.zhMissingHint':
+    '生成可重建投影：`ovp2 source-work claims-zh --vault-root … --client live` 与 `ovp2 source-work memory-zh --vault-root … --theme-pages --client live`。文件写在 `.ovp/crystal/claims_zh.json` / `theme_pages_zh.json`（ledger 仍为英文权威）。',
+  'theme.zhPartialOverview':
+    '主张中文部分就绪；主题综述段落仍是英文（尚无 theme_pages_zh）。',
+  'theme.switchToEn': '切换界面到 EN',
   'theme.citedSources': '来源：',
   'theme.legacySource': '旧源——该 vault 中没有对应的详情页。',
   'theme.strength': '强度',
@@ -619,6 +630,10 @@ export const zh: Record<keyof typeof en, string> = {
     '机房页：定时自动化（定时在跑什么）、全部运行记录、需要你处理的源、管线管理视图、三层模型说明，以及服务端配置（只读）。',
   'system.runs': '运行记录',
   'system.runsEmpty': '还没有运行记录——对该 vault 运行 `ovp2 daily`。',
+  'system.runsShowingRecent': '显示最近 {shown} / 共 {total} 次（磁盘 .ovp/reports/ 仍全量保留）。',
+  'system.runsShowingAll': '显示全部 {n} 次运行（磁盘 .ovp/reports/ 全量保留）。',
+  'system.runsExpand': '展开更早的 {n} 次…',
+  'system.runsCollapse': '只显示最近 {n} 次',
   'system.runDate': '日期',
   'system.runOk': '成功',
   'system.runFailed': '失败',

--- a/console-ui/src/pages/SystemPage.tsx
+++ b/console-ui/src/pages/SystemPage.tsx
@@ -7,7 +7,7 @@
  * three-layer concept explainer, (e) read-only settings from /api/settings.
  * Internal vocabulary (pack/unit/ledger) is allowed HERE and only here
  * (design §6, BL-051 word layering). */
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import AttentionCard from '../components/AttentionCard';
 import AutomationPanel from '../components/AutomationPanel';
@@ -35,10 +35,17 @@ import { useModel } from '../model';
  * links: they are server-rendered pages outside the SPA router. */
 const ADMIN_PAGES = ['ops.html', 'audit.html', 'candidates.html'] as const;
 
+/** Default rows in System → Runs. Full history stays on disk / in the model;
+ * the table only expands on demand so the page does not grow without bound. */
+const RUNS_DEFAULT_SHOWN = 30;
+
 function RunsSection({ model }: { model: IndexModel }) {
   const { t } = useI18n();
-  // Newest first — model.runs is append-ordered.
-  const runs = [...model.runs].reverse();
+  const [showAll, setShowAll] = useState(false);
+  // Newest first — model.runs is append-ordered ascending by date/seq.
+  const runs = useMemo(() => [...model.runs].reverse(), [model.runs]);
+  const hidden = Math.max(0, runs.length - RUNS_DEFAULT_SHOWN);
+  const shown = showAll || hidden === 0 ? runs : runs.slice(0, RUNS_DEFAULT_SHOWN);
   return (
     <div className="section">
       <h2>{t('system.runs')}</h2>
@@ -47,36 +54,59 @@ function RunsSection({ model }: { model: IndexModel }) {
           <p>{t('system.runsEmpty')}</p>
         </EmptyState>
       ) : (
-        <table className="runs-table">
-          <thead>
-            <tr>
-              <th>{t('system.runDate')}</th>
-              <th className="num">{t('system.runOk')}</th>
-              <th className="num">{t('system.runFailed')}</th>
-              <th className="num">{t('system.runBlocked')}</th>
-              <th className="num">{t('system.runIngested')}</th>
-              <th>{t('system.runReport')}</th>
-            </tr>
-          </thead>
-          <tbody>
-            {runs.map((r) => (
-              <tr key={r.run_id}>
-                <td className="mono">{r.date}</td>
-                <td className="num">{r.succeeded}</td>
-                <td className={r.failed > 0 ? 'num warn' : 'num'}>
-                  {r.failed}
-                </td>
-                <td className={r.blocked > 0 ? 'num warn' : 'num'}>
-                  {r.blocked}
-                </td>
-                <td className="num">{r.ingested}</td>
-                {/* Filename as text (design §3.6): the report is a JSON file
-                    in the vault (.ovp/reports/), not an HTTP resource. */}
-                <td className="mono tiny">{r.report_file}</td>
+        <>
+          <p className="sm muted" style={{ marginBottom: '0.5rem' }}>
+            {showAll || hidden === 0
+              ? t('system.runsShowingAll', { n: runs.length })
+              : t('system.runsShowingRecent', {
+                  shown: shown.length,
+                  total: runs.length,
+                })}
+          </p>
+          <table className="runs-table">
+            <thead>
+              <tr>
+                <th>{t('system.runDate')}</th>
+                <th className="num">{t('system.runOk')}</th>
+                <th className="num">{t('system.runFailed')}</th>
+                <th className="num">{t('system.runBlocked')}</th>
+                <th className="num">{t('system.runIngested')}</th>
+                <th>{t('system.runReport')}</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {shown.map((r) => (
+                <tr key={`${r.run_id}-${r.report_file}`}>
+                  <td className="mono">{r.date}</td>
+                  <td className="num">{r.succeeded}</td>
+                  <td className={r.failed > 0 ? 'num warn' : 'num'}>
+                    {r.failed}
+                  </td>
+                  <td className={r.blocked > 0 ? 'num warn' : 'num'}>
+                    {r.blocked}
+                  </td>
+                  <td className="num">{r.ingested}</td>
+                  {/* Filename as text (design §3.6): the report is a JSON file
+                      in the vault (.ovp/reports/), not an HTTP resource. */}
+                  <td className="mono tiny">{r.report_file}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {hidden > 0 && (
+            <p style={{ marginTop: '0.5rem' }}>
+              <button
+                type="button"
+                className="linkish"
+                onClick={() => setShowAll((v) => !v)}
+              >
+                {showAll
+                  ? t('system.runsCollapse', { n: RUNS_DEFAULT_SHOWN })
+                  : t('system.runsExpand', { n: hidden })}
+              </button>
+            </p>
+          )}
+        </>
       )}
     </div>
   );

--- a/console-ui/src/pages/ThemeDetailPage.tsx
+++ b/console-ui/src/pages/ThemeDetailPage.tsx
@@ -183,16 +183,20 @@ function ClaimCard({
   claim,
   byCase,
   highlighted,
+  claimZh,
 }: {
   claim: ClaimRow;
   byCase: Map<string, SourceRow>;
   highlighted: boolean;
+  /** Optional zh from theme-pages / claims_zh projection (by claim_key). */
+  claimZh?: string | null;
 }) {
   const { t, lang } = useI18n();
-  // Content language follows UI lang: zh prefers claim_zh projection, falls
-  // back to English authority text when the projection is missing/stale.
-  const text =
-    lang === 'zh' && claim.claim_zh?.trim() ? claim.claim_zh : claim.claim;
+  // Content language follows UI lang (top-bar EN/中): zh prefers claim_zh
+  // projection, falls back to English authority when missing/stale.
+  const zh = (claimZh ?? claim.claim_zh ?? '').trim();
+  const hasZh = zh.length > 0;
+  const text = lang === 'zh' && hasZh ? zh : claim.claim;
   return (
     <div
       className={`card claim-card${highlighted ? ' claim-hit' : ''}`}
@@ -205,6 +209,11 @@ function ClaimCard({
         {claim.strength && (
           <span className="tiny muted">
             {t('theme.strength')} {claim.strength}
+          </span>
+        )}
+        {lang === 'zh' && !hasZh && (
+          <span className="tiny muted" title={t('theme.claimZhMissingTip')}>
+            {t('theme.claimEnOnly')}
           </span>
         )}
         {/* Scroll via onClick rather than a native `#id` href: under the
@@ -229,10 +238,50 @@ function ClaimCard({
 }
 
 function ThemeBody({ model, theme }: { model: IndexModel; theme: string }) {
-  const { t } = useI18n();
+  const { t, lang, setLang } = useI18n();
   const location = useLocation();
   const claims = useMemo(() => themeClaims(model.claims, theme), [model, theme]);
   const byCase = useMemo(() => sourcesByCase(model), [model]);
+  // theme-pages payload carries claim_zh keyed by claim_key when
+  // .ovp/crystal/claims_zh.json exists — reuse for cards (index model may not
+  // splice claim_zh on every claim row yet).
+  const [themePages, setThemePages] = useState<ThemePagesResponse | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    fetchThemePages().then(
+      (r) => {
+        if (!cancelled) setThemePages(r);
+      },
+      () => {
+        /* optional */
+      },
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  const zhByKey = useMemo(() => {
+    const m = new Map<string, string>();
+    if (!themePages?.claims) return m;
+    for (const [key, info] of Object.entries(themePages.claims)) {
+      const z = info.claim_zh?.trim();
+      if (z) m.set(key, z);
+    }
+    return m;
+  }, [themePages]);
+  const zhCount = useMemo(() => {
+    let n = 0;
+    for (const c of claims) {
+      const z =
+        (c.claim_key && zhByKey.get(c.claim_key)) ||
+        c.claim_zh?.trim() ||
+        '';
+      if (z) n += 1;
+    }
+    return n;
+  }, [claims, zhByKey]);
+  const pageMeta = themePages?.pages.find((p) => p.label === theme);
+  const hasSectionsZh = !!(pageMeta?.sections_zh && pageMeta.sections_zh.length > 0);
 
   // Anchor handling: #<claim_id> scrolls to + highlights the claim card
   // (same pattern as the source page's unit line anchors). Scroll fires
@@ -279,13 +328,46 @@ function ThemeBody({ model, theme }: { model: IndexModel; theme: string }) {
                 durable,
                 caveated: claims.length - durable,
               })}
+              {' · '}
+              {t('theme.contentLang', {
+                lang: lang === 'zh' ? '中文' : 'EN',
+                zh: zhCount,
+                total: claims.length,
+              })}
             </div>
+            {lang === 'zh' && zhCount === 0 && (
+              <div className="card theme-zh-missing sm">
+                <p style={{ margin: 0 }}>
+                  {t('theme.zhMissingBody', { n: claims.length })}
+                </p>
+                <p className="tiny muted" style={{ margin: '0.4rem 0 0' }}>
+                  {t('theme.zhMissingHint')}
+                </p>
+                <p style={{ margin: '0.5rem 0 0' }}>
+                  <button
+                    type="button"
+                    className="linkish tiny"
+                    onClick={() => setLang('en')}
+                  >
+                    {t('theme.switchToEn')}
+                  </button>
+                </p>
+              </div>
+            )}
+            {lang === 'zh' && zhCount > 0 && !hasSectionsZh && pageMeta && (
+              <p className="sm muted theme-zh-partial">
+                {t('theme.zhPartialOverview')}
+              </p>
+            )}
             {claims.map((c) => (
               <ClaimCard
                 key={c.claim_id}
                 claim={c}
                 byCase={byCase}
                 highlighted={anchor === c.claim_id}
+                claimZh={
+                  (c.claim_key && zhByKey.get(c.claim_key)) || c.claim_zh || null
+                }
               />
             ))}
           </>


### PR DESCRIPTION
## Summary

1. **System → Runs**: show newest 30 by default; expand/collapse for full history. Reports on disk remain unbounded.
2. **Theme page zh**: switching is top-bar **EN/中** (not a separate content toggle). This vault had **no** `.ovp/crystal/claims_zh.json` / `theme_pages_zh.json`, so claim bodies always fell back to English. UI now states `zh ready 0/N`, EN-only badges, and how to generate projections.

## Test plan

- [x] console-ui build
- [ ] System page: with >30 runs, collapse works
- [ ] Theme Agent Memory Systems + 中: banner explains missing claim zh; label may still show 智能体记忆系统

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Chinese localization status indicators for theme content, including missing and partial translation notices.
  * Added an option to switch the interface to English when Chinese content is unavailable.
  * Theme claim cards now display localized Chinese text with clear English fallback indicators.
  * System run history now shows recent runs first, with run counts and expand/collapse controls for older runs.
  * Added English and Simplified Chinese translations for the new interface messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->